### PR TITLE
feat(i18n): port UnsupportedMethod, give Time a public local-zone constructor

### DIFF
--- a/packages/i18n/src/backend/base.ts
+++ b/packages/i18n/src/backend/base.ts
@@ -604,10 +604,8 @@ export abstract class Base {
   /**
    * Loads a plain JavaScript translations file. Evaluating the file must yield
    * translation data with locales as toplevel keys — the gem `eval`s Ruby
-   * source for that hash, and a JS module's exports are the same hash.
-   *
-   * @noRailsEquivalent PERMANENT — the JS analogue of the gem's `load_rb`
-   * (base.rb:254-257) — there is no Ruby source to `eval` here.
+   * source for that hash (`load_rb`, base.rb:254-257), and a JS module's
+   * exports are the same hash.
    */
   protected loadJs(filename: string): [unknown, boolean] {
     const translations = readLocaleModule(filename);

--- a/packages/i18n/src/backend/transliterator.test.ts
+++ b/packages/i18n/src/backend/transliterator.test.ts
@@ -1,8 +1,8 @@
 /**
  * Mirrors: i18n/test/backend/transliterator_test.rb
  *
- * `default transliterator raises errors for invalid UTF-8` stays measured as
- * missing rather than faked: it feeds `"a\x92b"`, a String whose bytes are not
+ * `default transliterator raises errors for invalid UTF-8` is excluded in
+ * `scripts/api-compare/unported-files.ts` rather than faked: it feeds `"a\x92b"`, a String whose bytes are not
  * valid UTF-8, and relies on Ruby's regexp engine raising
  * `ArgumentError: invalid byte sequence` (transliterator.rb:96). A JS string is
  * a sequence of UTF-16 code units with no invalid-byte state to reach, so there

--- a/packages/i18n/src/date.ts
+++ b/packages/i18n/src/date.ts
@@ -77,6 +77,7 @@ export interface StrftimeSubject {
   min: number;
   sec: number;
   zone: string;
+  zoneOffset: string;
 }
 
 /**
@@ -94,8 +95,9 @@ export interface StrftimeSubject {
  *
  * Only the directives the i18n format strings and the conformance mixins use
  * are recognised; Ruby leaves an unknown directive in place, and so does this.
- * `%z` is fixed at `+0000` because trails models only the UTC these classes are
- * built in; `%Z` varies, so it comes off the subject.
+ * `%z` and `%Z` both come off the subject: `::Date` has no zone of its own and
+ * answers UTC, while a `::Time` built through the public constructor is in the
+ * local zone and answers its real offset and abbreviation.
  */
 export function strftime(subject: StrftimeSubject, format: string): string {
   const tokens: Record<string, () => string> = {
@@ -117,7 +119,7 @@ export function strftime(subject: StrftimeSubject, format: string): string {
     p: () => (subject.hour < 12 ? "AM" : "PM"),
     P: () => (subject.hour < 12 ? "am" : "pm"),
     x: () => `${pad2(subject.mon)}/${pad2(subject.day)}/${pad2(subject.year % 100)}`,
-    z: () => "+0000",
+    z: () => subject.zoneOffset,
     Z: () => subject.zone,
     "%": () => "%",
   };
@@ -211,6 +213,7 @@ export class Date {
         min: 0,
         sec: 0,
         zone: "+00:00",
+        zoneOffset: "+0000",
       },
       format,
     );
@@ -265,6 +268,7 @@ export class DateTime extends Date {
         min: this.min,
         sec: this.sec,
         zone: this.zone,
+        zoneOffset: "+0000",
       },
       format,
     );

--- a/packages/i18n/src/exceptions.trails.test.ts
+++ b/packages/i18n/src/exceptions.trails.test.ts
@@ -12,6 +12,7 @@ import {
   MissingTranslationData,
   ReservedInterpolationKey,
   UnknownFileType,
+  UnsupportedMethod,
   inspect,
 } from "./exceptions.js";
 import { resetClassConfig } from "./config.js";
@@ -42,6 +43,7 @@ describe("exceptions", () => {
       new MissingInterpolationArgument(":bar", { baz: "baz" }, "%{bar}"),
       new ReservedInterpolationKey(":scope", "%{scope}"),
       new UnknownFileType("xml", "en.xml"),
+      new UnsupportedMethod("available_locales", Simple, "Chain#available_locales"),
     ];
     for (const e of errors) expect(e).toBeInstanceOf(ArgumentError);
   });
@@ -71,6 +73,16 @@ describe("exceptions", () => {
     expect(exception.type).toBe("xml");
     expect(exception.message).toBe(
       "can not load translations from en.xml, the file type xml is not known",
+    );
+  });
+
+  it("UnsupportedMethod stores method, backendKlass and msg", () => {
+    const exception = new UnsupportedMethod("available_locales", Simple, "Please implement it.");
+    expect(exception.method).toBe("available_locales");
+    expect(exception.backendKlass).toBe(Simple);
+    expect(exception.msg).toBe("Please implement it.");
+    expect(exception.message).toBe(
+      "Simple does not support the #available_locales method. Please implement it.",
     );
   });
 

--- a/packages/i18n/src/exceptions.ts
+++ b/packages/i18n/src/exceptions.ts
@@ -306,6 +306,29 @@ export class UnknownFileType extends ArgumentError {
 }
 
 /**
+ * Mirrors: I18n::UnsupportedMethod (i18n/lib/i18n/exceptions.rb:122-130).
+ *
+ * `backend_klass` is interpolated into the message, which for a Ruby Class is
+ * `Class#to_s` — its name. A JS class is a function, whose default string
+ * conversion is its whole source text, so the name is taken off `.name`.
+ */
+type BackendKlass = (abstract new (...args: never[]) => unknown) & { name: string };
+
+export class UnsupportedMethod extends ArgumentError {
+  readonly method: string;
+  readonly backendKlass: BackendKlass;
+  readonly msg: string;
+
+  constructor(method: string, backendKlass: BackendKlass, msg: string) {
+    super(`${backendKlass.name} does not support the #${method} method. ${msg}`);
+    this.name = "UnsupportedMethod";
+    this.method = method;
+    this.backendKlass = backendKlass;
+    this.msg = msg;
+  }
+}
+
+/**
  * Mirrors: I18n::ExceptionHandler. Returns the message for a missing
  * translation and re-raises anything else.
  */

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -12,6 +12,7 @@ export {
   MissingTranslationData,
   ReservedInterpolationKey,
   UnknownFileType,
+  UnsupportedMethod,
 } from "./exceptions.js";
 export type { MissingTranslationOptions } from "./exceptions.js";
 export {

--- a/packages/i18n/src/time.trails.test.ts
+++ b/packages/i18n/src/time.trails.test.ts
@@ -7,6 +7,7 @@
 
 import { Temporal } from "@js-temporal/polyfill";
 import { describe, expect, it } from "vitest";
+import { ArgumentError } from "./date.js";
 import { Time } from "./time.js";
 
 describe("Time", () => {
@@ -16,20 +17,23 @@ describe("Time", () => {
     expect(time.strftime("%Y-%m-%d %H:%M:%S %z %Z")).toBe("2008-03-01 06:00:00 +0000 UTC");
   });
 
-  it("Time.new builds a time in the named zone", () => {
-    const time = new Time(2008, 3, 1, 6, 0, 0, "America/New_York");
+  it("Time.new builds a time at the given offset", () => {
+    const time = new Time(2008, 3, 1, 6, 0, 0, "-05:00");
     expect(time.hour).toBe(6);
     expect(time.utcOffset).toBe(-5 * 3600);
-    expect(time.strftime("%Y-%m-%d %H:%M:%S %z %Z")).toBe("2008-03-01 06:00:00 -0500 EST");
+    // MRI answers no abbreviation for an offset-built time, so `%Z` is empty.
+    expect(time.zone).toBeNull();
+    expect(time.strftime("%Y-%m-%d %H:%M:%S %z %Z")).toBe("2008-03-01 06:00:00 -0500 ");
   });
 
-  it("Time.new accepts Ruby's offset spelling for the zone", () => {
-    const time = new Time(2008, 3, 1, 6, 0, 0, "+09:00");
-    expect(time.utcOffset).toBe(9 * 3600);
-    // Ruby answers no abbreviation for an offset-built time, and prints the
-    // offset for `%Z`.
-    expect(time.zone).toBeNull();
-    expect(time.strftime("%z %Z")).toBe("+0900 +09:00");
+  it("Time.new takes a military zone letter", () => {
+    expect(new Time(2008, 3, 1, 6, 0, 0, "K").utcOffset).toBe(10 * 3600);
+    expect(new Time(2008, 3, 1, 6, 0, 0, "Y").utcOffset).toBe(-12 * 3600);
+    expect(new Time(2008, 3, 1, 6, 0, 0, "Z").utcOffset).toBe(0);
+  });
+
+  it("Time.new rejects a zone name", () => {
+    expect(() => new Time(2008, 3, 1, 6, 0, 0, "America/New_York")).toThrow(ArgumentError);
   });
 
   it("Time.new defaults to the local zone", () => {

--- a/packages/i18n/src/time.trails.test.ts
+++ b/packages/i18n/src/time.trails.test.ts
@@ -23,6 +23,15 @@ describe("Time", () => {
     expect(time.strftime("%Y-%m-%d %H:%M:%S %z %Z")).toBe("2008-03-01 06:00:00 -0500 EST");
   });
 
+  it("Time.new accepts Ruby's offset spelling for the zone", () => {
+    const time = new Time(2008, 3, 1, 6, 0, 0, "+09:00");
+    expect(time.utcOffset).toBe(9 * 3600);
+    // Ruby answers no abbreviation for an offset-built time, and prints the
+    // offset for `%Z`.
+    expect(time.zone).toBeNull();
+    expect(time.strftime("%z %Z")).toBe("+0900 +09:00");
+  });
+
   it("Time.new defaults to the local zone", () => {
     const time = new Time(2008, 3, 1, 6, 0, 0);
     const local = new Temporal.PlainDateTime(2008, 3, 1, 6, 0, 0).toZonedDateTime(

--- a/packages/i18n/src/time.trails.test.ts
+++ b/packages/i18n/src/time.trails.test.ts
@@ -40,7 +40,9 @@ describe("Time", () => {
   it("Time.new takes a military zone letter", () => {
     expect(new Time(2008, 3, 1, 6, 0, 0, "K").utcOffset).toBe(10 * 3600);
     expect(new Time(2008, 3, 1, 6, 0, 0, "Y").utcOffset).toBe(-12 * 3600);
-    expect(new Time(2008, 3, 1, 6, 0, 0, "Z").utcOffset).toBe(0);
+    expect(new Time(2008, 3, 1, 6, 0, 0, "K").strftime("%z %Z")).toBe("+1000 ");
+    // MRI treats `"Z"` as UTC itself, so it keeps a zone where an offset does not.
+    expect(new Time(2008, 3, 1, 6, 0, 0, "Z").strftime("%z %Z")).toBe("+0000 UTC");
   });
 
   it("Time.new rejects a zone name", () => {

--- a/packages/i18n/src/time.trails.test.ts
+++ b/packages/i18n/src/time.trails.test.ts
@@ -1,0 +1,34 @@
+/**
+ * trails-only coverage for `./time.ts`, the `::Time` duck type. The gem has no
+ * test of its own for Ruby core `::Time`, so these assert the two constructors
+ * against MRI's documented behaviour: `Time.utc` is UTC, `Time.new` is local,
+ * and `%z`/`%Z` answer the receiver's zone rather than a constant.
+ */
+
+import { Temporal } from "@js-temporal/polyfill";
+import { describe, expect, it } from "vitest";
+import { Time } from "./time.js";
+
+describe("Time", () => {
+  it("Time.utc builds a UTC time", () => {
+    const time = Time.utc(2008, 3, 1, 6, 0, 0);
+    expect(time.zone).toBe("UTC");
+    expect(time.strftime("%Y-%m-%d %H:%M:%S %z %Z")).toBe("2008-03-01 06:00:00 +0000 UTC");
+  });
+
+  it("Time.new builds a time in the named zone", () => {
+    const time = new Time(2008, 3, 1, 6, 0, 0, "America/New_York");
+    expect(time.hour).toBe(6);
+    expect(time.utcOffset).toBe(-5 * 3600);
+    expect(time.strftime("%Y-%m-%d %H:%M:%S %z %Z")).toBe("2008-03-01 06:00:00 -0500 EST");
+  });
+
+  it("Time.new defaults to the local zone", () => {
+    const time = new Time(2008, 3, 1, 6, 0, 0);
+    const local = new Temporal.PlainDateTime(2008, 3, 1, 6, 0, 0).toZonedDateTime(
+      Temporal.Now.timeZoneId(),
+    );
+    expect(time.utcOffset).toBe(Number(local.offsetNanoseconds) / 1_000_000_000);
+    expect(time.strftime("%z")).toBe(local.offset.replace(":", ""));
+  });
+});

--- a/packages/i18n/src/time.trails.test.ts
+++ b/packages/i18n/src/time.trails.test.ts
@@ -26,6 +26,17 @@ describe("Time", () => {
     expect(time.strftime("%Y-%m-%d %H:%M:%S %z %Z")).toBe("2008-03-01 06:00:00 -0500 ");
   });
 
+  it("Time.new takes an offset in seconds, as Rails passes", () => {
+    expect(new Time(2008, 3, 1, 6, 0, 0, 3600).utcOffset).toBe(3600);
+    expect(new Time(2008, 3, 1, 6, 0, 0, 0).strftime("%z %Z")).toBe("+0000 ");
+    expect(new Time(2008, 3, 1, 6, 0, 0, -19800).strftime("%z")).toBe("-0530");
+  });
+
+  it("Time.new takes the compact and hour-only offset spellings", () => {
+    expect(new Time(2008, 3, 1, 6, 0, 0, "+0930").strftime("%z")).toBe("+0930");
+    expect(new Time(2008, 3, 1, 6, 0, 0, "+09").strftime("%z")).toBe("+0900");
+  });
+
   it("Time.new takes a military zone letter", () => {
     expect(new Time(2008, 3, 1, 6, 0, 0, "K").utcOffset).toBe(10 * 3600);
     expect(new Time(2008, 3, 1, 6, 0, 0, "Y").utcOffset).toBe(-12 * 3600);

--- a/packages/i18n/src/time.ts
+++ b/packages/i18n/src/time.ts
@@ -8,7 +8,26 @@
  */
 
 import { Temporal } from "@js-temporal/polyfill";
-import { strftime } from "./date.js";
+import { ArgumentError, strftime } from "./date.js";
+
+/**
+ * The `utc_offset` argument MRI's `Time.new` accepts, resolved to something
+ * `Temporal` takes: `"UTC"`, an offset, or one of the military zone letters
+ * (`A`..`I` = +1..+9, `K`..`M` = +10..+12, `N`..`Y` = -1..-12, `Z` = UTC).
+ * Anything else raises, with MRI's message — an IANA name like
+ * `"America/New_York"` is not a `Time.new` zone, it is what a `TimeZone`
+ * object wraps.
+ */
+function utcOffsetArgument(zone: string): string {
+  if (zone === "UTC" || /^[+-]\d{2}:\d{2}(:\d{2})?$/.test(zone)) return zone;
+  if (/^[A-IK-Z]$/.test(zone)) {
+    const code = zone.charCodeAt(0);
+    const hours = zone === "Z" ? 0 : code <= 73 ? code - 64 : code <= 77 ? code - 65 : 77 - code;
+    const sign = hours < 0 ? "-" : "+";
+    return `${sign}${String(Math.abs(hours)).padStart(2, "0")}:00`;
+  }
+  throw new ArgumentError('"+HH:MM", "-HH:MM", "UTC" or "A".."I","K".."Z" expected for utc_offset');
+}
 
 /**
  * @noRailsEquivalent PERMANENT — Ruby core `::Time`. Rails never defines the
@@ -28,10 +47,9 @@ export class Time {
 
   /**
    * Ruby `Time.new(year, month, day, hour = 0, min = 0, sec = 0, zone = nil)`,
-   * which builds a time in the *local* zone unless `zone` names another one.
-   * `Time.utc` is the UTC entry point, as in Ruby. `zone` takes the spellings
-   * Ruby's does — an offset (`"+09:00"`) or a zone name — because `Temporal`
-   * resolves both.
+   * which builds a time in the *local* zone unless `zone` gives an offset.
+   * `Time.utc` is the UTC entry point, as in Ruby, and `zone` takes only the
+   * spellings MRI's `utc_offset` argument takes — see `utcOffsetArgument`.
    */
   constructor(
     year: number,
@@ -43,7 +61,9 @@ export class Time {
     zone: string | null = null,
   ) {
     this.#plain = new Temporal.PlainDateTime(year, month, day, hour, min, sec);
-    this.#zoned = this.#plain.toZonedDateTime(zone ?? Temporal.Now.timeZoneId());
+    this.#zoned = this.#plain.toZonedDateTime(
+      zone == null ? Temporal.Now.timeZoneId() : utcOffsetArgument(zone),
+    );
   }
 
   get year(): number {
@@ -87,7 +107,7 @@ export class Time {
    * `Time#zone` is the zone's abbreviation — `"UTC"` for a `Time.utc`, `"PDT"`
    * for a local summer time — not an offset, which is what `::DateTime#zone`
    * answers instead. A time built from an offset rather than a zone has no
-   * abbreviation to answer and Ruby returns `nil`; `%Z` then prints the offset.
+   * abbreviation to answer and Ruby returns `nil`, which `%Z` prints as "".
    */
   get zone(): string | null {
     if (/^[+-]\d{2}:?\d{2}$/.test(this.#zoned.timeZoneId)) return null;
@@ -114,7 +134,7 @@ export class Time {
         hour: this.hour,
         min: this.min,
         sec: this.sec,
-        zone: this.zone ?? this.#zoned.offset,
+        zone: this.zone ?? "",
         zoneOffset: this.#zoned.offset.replace(":", ""),
       },
       format,

--- a/packages/i18n/src/time.ts
+++ b/packages/i18n/src/time.ts
@@ -12,21 +12,44 @@ import { ArgumentError, strftime } from "./date.js";
 
 /**
  * The `utc_offset` argument MRI's `Time.new` accepts, resolved to something
- * `Temporal` takes: `"UTC"`, an offset, or one of the military zone letters
- * (`A`..`I` = +1..+9, `K`..`M` = +10..+12, `N`..`Y` = -1..-12, `Z` = UTC).
- * Anything else raises, with MRI's message — an IANA name like
+ * `Temporal` takes: `"UTC"`, an offset — `"+09"`, `"+0900"`, `"+09:00"` or a
+ * number of seconds east of UTC, which is the form Rails passes
+ * (`activesupport/lib/active_support/core_ext/string/conversions.rb:28`,
+ * `core_ext/time/calculations.rb:172-175`) — or one of the military zone
+ * letters (`A`..`I` = +1..+9, `K`..`M` = +10..+12, `N`..`Y` = -1..-12,
+ * `Z` = UTC). Anything else raises with MRI's message; an IANA name like
  * `"America/New_York"` is not a `Time.new` zone, it is what a `TimeZone`
  * object wraps.
+ *
+ * MRI also takes a sub-minute offset. `Temporal` has no way to express one —
+ * an offset time zone is minute-precision — so that one spelling raises here
+ * where MRI accepts it. Rails never builds one: its offsets come from zone
+ * tables and `Date._parse`, both of which are whole minutes.
  */
-function utcOffsetArgument(zone: string): string {
-  if (zone === "UTC" || /^[+-]\d{2}:\d{2}(:\d{2})?$/.test(zone)) return zone;
+function utcOffsetArgument(zone: string | number): string {
+  if (typeof zone === "number") {
+    if (zone % 60 !== 0) throw new ArgumentError("utc_offset out of range");
+    const sign = zone < 0 ? "-" : "+";
+    const minutes = Math.abs(zone) / 60;
+    return `${sign}${pad2(Math.floor(minutes / 60))}:${pad2(minutes % 60)}`;
+  }
+  if (zone === "UTC") return zone;
+  if (/^[+-]\d{2}(:?\d{2})?$/.test(zone)) return zone;
+  if (/^[+-]\d{2}:\d{2}:\d{2}$/.test(zone)) {
+    if (!zone.endsWith(":00")) throw new ArgumentError("utc_offset out of range");
+    return zone.slice(0, 6);
+  }
   if (/^[A-IK-Z]$/.test(zone)) {
     const code = zone.charCodeAt(0);
     const hours = zone === "Z" ? 0 : code <= 73 ? code - 64 : code <= 77 ? code - 65 : 77 - code;
     const sign = hours < 0 ? "-" : "+";
-    return `${sign}${String(Math.abs(hours)).padStart(2, "0")}:00`;
+    return `${sign}${pad2(Math.abs(hours))}:00`;
   }
   throw new ArgumentError('"+HH:MM", "-HH:MM", "UTC" or "A".."I","K".."Z" expected for utc_offset');
+}
+
+function pad2(n: number): string {
+  return String(n).padStart(2, "0");
 }
 
 /**
@@ -48,7 +71,7 @@ export class Time {
   /**
    * Ruby `Time.new(year, month, day, hour = 0, min = 0, sec = 0, zone = nil)`,
    * which builds a time in the *local* zone unless `zone` gives an offset.
-   * `Time.utc` is the UTC entry point, as in Ruby, and `zone` takes only the
+   * `Time.utc` is the UTC entry point, as in Ruby, and `zone` takes the
    * spellings MRI's `utc_offset` argument takes — see `utcOffsetArgument`.
    */
   constructor(
@@ -58,7 +81,7 @@ export class Time {
     hour = 0,
     min = 0,
     sec = 0,
-    zone: string | null = null,
+    zone: string | number | null = null,
   ) {
     this.#plain = new Temporal.PlainDateTime(year, month, day, hour, min, sec);
     this.#zoned = this.#plain.toZonedDateTime(
@@ -124,6 +147,9 @@ export class Time {
   }
 
   strftime(format: string): string {
+    // `%z` is `±HHMM` — neither `Time#zone` nor `Temporal`'s extended `±HH:MM`.
+    const minutes = Math.abs(this.utcOffset) / 60;
+    const zoneOffset = `${this.utcOffset < 0 ? "-" : "+"}${pad2(Math.floor(minutes / 60))}${pad2(minutes % 60)}`;
     return strftime(
       {
         year: this.year,
@@ -135,7 +161,7 @@ export class Time {
         min: this.min,
         sec: this.sec,
         zone: this.zone ?? "",
-        zoneOffset: this.#zoned.offset.replace(":", ""),
+        zoneOffset,
       },
       format,
     );

--- a/packages/i18n/src/time.ts
+++ b/packages/i18n/src/time.ts
@@ -29,9 +29,9 @@ export class Time {
   /**
    * Ruby `Time.new(year, month, day, hour = 0, min = 0, sec = 0, zone = nil)`,
    * which builds a time in the *local* zone unless `zone` names another one.
-   * `Time.utc` is the UTC entry point, as in Ruby. Ruby's `zone` argument also
-   * accepts an offset spelling (`"+09:00"`); here it is the IANA identifier
-   * `Temporal` resolves.
+   * `Time.utc` is the UTC entry point, as in Ruby. `zone` takes the spellings
+   * Ruby's does — an offset (`"+09:00"`) or a zone name — because `Temporal`
+   * resolves both.
    */
   constructor(
     year: number,
@@ -86,9 +86,11 @@ export class Time {
   /**
    * `Time#zone` is the zone's abbreviation — `"UTC"` for a `Time.utc`, `"PDT"`
    * for a local summer time — not an offset, which is what `::DateTime#zone`
-   * answers instead.
+   * answers instead. A time built from an offset rather than a zone has no
+   * abbreviation to answer and Ruby returns `nil`; `%Z` then prints the offset.
    */
-  get zone(): string {
+  get zone(): string | null {
+    if (/^[+-]\d{2}:?\d{2}$/.test(this.#zoned.timeZoneId)) return null;
     const parts = new Intl.DateTimeFormat("en-US", {
       timeZone: this.#zoned.timeZoneId,
       timeZoneName: "short",
@@ -112,7 +114,7 @@ export class Time {
         hour: this.hour,
         min: this.min,
         sec: this.sec,
-        zone: this.zone,
+        zone: this.zone ?? this.#zoned.offset,
         zoneOffset: this.#zoned.offset.replace(":", ""),
       },
       format,

--- a/packages/i18n/src/time.ts
+++ b/packages/i18n/src/time.ts
@@ -3,8 +3,8 @@
  * `./date.ts`. It answers `hour`/`min`/`sec` where `::Date` does not, which is
  * what routes `I18n::Backend::Base#localize` to `time.formats` rather than
  * `date.formats` (i18n/lib/i18n/backend/base.rb:105-115, ported at
- * `./backend/base.ts:245-271`), and `%Z` answers `"UTC"` rather than `::Date`'s
- * offset spelling.
+ * `./backend/base.ts:245-271`), and `%Z` answers the zone's abbreviation
+ * (`"UTC"` for a `Time.utc`) rather than `::Date`'s offset spelling.
  */
 
 import { Temporal } from "@js-temporal/polyfill";
@@ -18,26 +18,32 @@ import { strftime } from "./date.js";
  */
 export class Time {
   readonly #plain: Temporal.PlainDateTime;
+  /** @internal The receiver's zone — Ruby's `Time#zone`/`#utc_offset` source. */
+  readonly #zoned: Temporal.ZonedDateTime;
 
   /** Ruby `Time.utc(year, month, day, hour = 0, min = 0, sec = 0)`. */
   static utc(year: number, month: number, day: number, hour = 0, min = 0, sec = 0): Time {
-    return new Time(year, month, day, hour, min, sec);
+    return new Time(year, month, day, hour, min, sec, "UTC");
   }
 
   /**
-   * Private because Ruby's `Time.new` builds a *local* time, and trails models
-   * only the UTC one `Time.utc` returns — a public constructor here would read
-   * as `Time.new` and quietly mean something else.
+   * Ruby `Time.new(year, month, day, hour = 0, min = 0, sec = 0, zone = nil)`,
+   * which builds a time in the *local* zone unless `zone` names another one.
+   * `Time.utc` is the UTC entry point, as in Ruby. Ruby's `zone` argument also
+   * accepts an offset spelling (`"+09:00"`); here it is the IANA identifier
+   * `Temporal` resolves.
    */
-  private constructor(
+  constructor(
     year: number,
     month: number,
     day: number,
-    hour: number,
-    min: number,
-    sec: number,
+    hour = 0,
+    min = 0,
+    sec = 0,
+    zone: string | null = null,
   ) {
     this.#plain = new Temporal.PlainDateTime(year, month, day, hour, min, sec);
+    this.#zoned = this.#plain.toZonedDateTime(zone ?? Temporal.Now.timeZoneId());
   }
 
   get year(): number {
@@ -77,9 +83,22 @@ export class Time {
     return this.#plain.dayOfYear;
   }
 
-  /** `Time.utc(...).strftime('%Z')` is `"UTC"`, not an offset. */
+  /**
+   * `Time#zone` is the zone's abbreviation — `"UTC"` for a `Time.utc`, `"PDT"`
+   * for a local summer time — not an offset, which is what `::DateTime#zone`
+   * answers instead.
+   */
   get zone(): string {
-    return "UTC";
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone: this.#zoned.timeZoneId,
+      timeZoneName: "short",
+    }).formatToParts(new globalThis.Date(this.#zoned.epochMilliseconds));
+    return parts.find((part) => part.type === "timeZoneName")!.value;
+  }
+
+  /** Ruby `Time#utc_offset`, the receiver's offset from UTC in seconds. */
+  get utcOffset(): number {
+    return Number(this.#zoned.offsetNanoseconds) / 1_000_000_000;
   }
 
   strftime(format: string): string {
@@ -94,6 +113,7 @@ export class Time {
         min: this.min,
         sec: this.sec,
         zone: this.zone,
+        zoneOffset: this.#zoned.offset.replace(":", ""),
       },
       format,
     );

--- a/packages/i18n/src/time.ts
+++ b/packages/i18n/src/time.ts
@@ -16,8 +16,8 @@ import { ArgumentError, strftime } from "./date.js";
  * number of seconds east of UTC, which is the form Rails passes
  * (`activesupport/lib/active_support/core_ext/string/conversions.rb:28`,
  * `core_ext/time/calculations.rb:172-175`) — or one of the military zone
- * letters (`A`..`I` = +1..+9, `K`..`M` = +10..+12, `N`..`Y` = -1..-12,
- * `Z` = UTC). Anything else raises with MRI's message; an IANA name like
+ * letters (`A`..`I` = +1..+9, `K`..`M` = +10..+12, `N`..`Y` = -1..-12, and
+ * `Z`, which MRI treats as UTC itself rather than as a zero offset). Anything else raises with MRI's message; an IANA name like
  * `"America/New_York"` is not a `Time.new` zone, it is what a `TimeZone`
  * object wraps.
  *
@@ -33,15 +33,17 @@ function utcOffsetArgument(zone: string | number): string {
     const minutes = Math.abs(zone) / 60;
     return `${sign}${pad2(Math.floor(minutes / 60))}:${pad2(minutes % 60)}`;
   }
-  if (zone === "UTC") return zone;
+  // `"Z"` is the military letter for UTC, and MRI treats it as `Time.utc`
+  // does — `zone` answers `"UTC"`, not `nil` as an offset-built time does.
+  if (zone === "UTC" || zone === "Z") return "UTC";
   if (/^[+-]\d{2}(:?\d{2})?$/.test(zone)) return zone;
   if (/^[+-]\d{2}:\d{2}:\d{2}$/.test(zone)) {
     if (!zone.endsWith(":00")) throw new ArgumentError("utc_offset out of range");
     return zone.slice(0, 6);
   }
-  if (/^[A-IK-Z]$/.test(zone)) {
+  if (/^[A-IK-Y]$/.test(zone)) {
     const code = zone.charCodeAt(0);
-    const hours = zone === "Z" ? 0 : code <= 73 ? code - 64 : code <= 77 ? code - 65 : 77 - code;
+    const hours = code <= 73 ? code - 64 : code <= 77 ? code - 65 : 77 - code;
     const sign = hours < 0 ? "-" : "+";
     return `${sign}${pad2(Math.abs(hours))}:00`;
   }

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -2182,6 +2182,22 @@ function extractInterface(
             const resolved = checker.getTypeAtLocation(type);
             for (const prop of resolved.getProperties()) {
               const propName = prop.getName();
+              // `getProperties()` returns protected and private members too.
+              // The copy synthesized below carries no modifier of its own, so
+              // its visibility and `internal` flag have to come off the
+              // declaration it resolves to, as the `__mixin` case above does —
+              // hardcoding "public" here counts a protected member as this
+              // file's public surface, which Ruby's `include` does not do
+              // either, and leaves it demanding a `@noRailsEquivalent` reason
+              // its own declaration is too private to be asked for.
+              const propDecl = prop.declarations?.[0];
+              const propFlags = propDecl !== undefined ? ts.getCombinedModifierFlags(propDecl) : 0;
+              const propVisibility =
+                propFlags & ts.ModifierFlags.Private
+                  ? "private"
+                  : propFlags & ts.ModifierFlags.Protected
+                    ? "protected"
+                    : "public";
               // Keep _-prefixed properties — Rails has public methods like _reflect_on_association
               const propType = checker.getTypeOfSymbolAtLocation(prop, type);
               const signatures = propType.getCallSignatures();
@@ -2193,10 +2209,14 @@ function extractInterface(
                 const noRailsEquivalent = noRailsEquivalentOfSymbol(prop, checker);
                 instanceMethods.push({
                   name: propName,
-                  visibility: "public",
+                  visibility: propVisibility,
                   params: [],
                   line: 0,
                   file,
+                  ...(propVisibility !== "public" ||
+                  (propDecl !== undefined && hasInternalJsDocTag(propDecl))
+                    ? { internal: true }
+                    : {}),
                   ...(noRailsEquivalent !== undefined ? { noRailsEquivalent } : {}),
                 });
               }

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -2182,14 +2182,6 @@ function extractInterface(
             const resolved = checker.getTypeAtLocation(type);
             for (const prop of resolved.getProperties()) {
               const propName = prop.getName();
-              // `getProperties()` returns protected and private members too.
-              // The copy synthesized below carries no modifier of its own, so
-              // its visibility and `internal` flag have to come off the
-              // declaration it resolves to, as the `__mixin` case above does —
-              // hardcoding "public" here counts a protected member as this
-              // file's public surface, which Ruby's `include` does not do
-              // either, and leaves it demanding a `@noRailsEquivalent` reason
-              // its own declaration is too private to be asked for.
               const propDecl = prop.declarations?.[0];
               const propFlags = propDecl !== undefined ? ts.getCombinedModifierFlags(propDecl) : 0;
               const propVisibility =
@@ -2205,7 +2197,10 @@ function extractInterface(
                 // Unlike the `__mixin` and inherited-interface-property cases
                 // elsewhere, these entries carry no `declaredIn`, so
                 // `collectTsFileNames` counts them as THIS file's surface —
-                // they need the resolved declaration's tag to be justifiable.
+                // they need the resolved declaration's tag, visibility and
+                // `@internal` flag to be scored the way that declaration is.
+                // `getProperties()` returns protected and private members, and
+                // the copy pushed below carries no modifier of its own.
                 const noRailsEquivalent = noRailsEquivalentOfSymbol(prop, checker);
                 instanceMethods.push({
                   name: propName,

--- a/scripts/api-compare/unported-files.test.ts
+++ b/scripts/api-compare/unported-files.test.ts
@@ -52,6 +52,7 @@ describe("isSourceUnported package scoping", () => {
       "../i18n.rb",
       "backend.rb",
       "backend/base.rb",
+      "backend/fallbacks.rb",
       "backend/flatten.rb",
       "backend/key_value.rb",
       "backend/simple.rb",
@@ -59,6 +60,11 @@ describe("isSourceUnported package scoping", () => {
       "config.rb",
       "exceptions.rb",
       "interpolate/ruby.rb",
+      "locale.rb",
+      "locale/fallbacks.rb",
+      "locale/tag.rb",
+      "locale/tag/parents.rb",
+      "locale/tag/simple.rb",
       "utils.rb",
     ]);
     const unaccounted = ["../i18n.rb", ...files].filter(

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -1301,6 +1301,15 @@ export const UNPORTED_FILES: UnportedFile[] = [
       "storage of this shape nor Fibers, so there is nothing to assert.",
   },
   {
+    testFile: "backend/transliterator_test.rb",
+    tests: ["default transliterator raises errors for invalid UTF-8"],
+    reason:
+      'Feeds `"a\\x92b"`, whose bytes are not valid UTF-8, and relies on Ruby\'s regexp ' +
+      "engine raising `ArgumentError: invalid byte sequence` (transliterator.rb:96). A JS " +
+      "string is UTF-16 code units with no invalid-byte state to reach, so no input makes " +
+      "the ported `transliterate` raise.",
+  },
+  {
     pattern: "tests/",
     package: "i18n",
     reason:


### PR DESCRIPTION
Four RFC 0074 i18n-parity stories.

**`I18n::UnsupportedMethod`** (`exceptions.rb:122-130`) — ported with the gem's
reader names (`method`, `backendKlass`, `msg`), parameter order and message
string. `backend_klass` is interpolated through Ruby's `Class#to_s`; a JS class
stringifies to its source, so the name comes off `.name`. `api:compare` now
reports `exceptions.rb 19/19`.

**`Time.new`** — the constructor is public and means what Ruby's means: local
zone, with the optional 7th `zone` argument Ruby also takes. `Time.utc` stays
the UTC entry point (unchanged behaviour, localization tests untouched), and
`%z` now answers the receiver's real offset instead of a hardcoded `+0000` —
`strftime`'s subject carries `zoneOffset` alongside `zone`.

**transliterator invalid UTF-8** — a JS string is UTF-16 code units and has no
invalid-byte state to reach, so the case is excluded in `unported-files.ts`
with that reason rather than faked with an invented lone-surrogate guard.
`test:compare` shows `backend/transliterator_test.rb 12/12`.

**stale `@noRailsEquivalent` on `loadJs`** — converged rather than moved. The
tag was stale because `Base#loadJs` is `protected`, while the extractor's
`interface Simple extends Base` synthesis pushed the resolved property as
`visibility: "public"` with no `internal` flag, so a protected member counted
as `simple.ts`'s public surface and demanded a reason its own declaration was
too private to be asked for. The synthesis now carries the resolved
declaration's visibility and `@internal` flag, as the `__mixin` path already
does; the tag is deleted and i18n's novel count goes 18 → 17 (no package's
novel count rises; activerecord's *moved* total drops 1430 → 1392).

Drive-by: the i18n enrollment-invariant test in `unported-files.test.ts` was
red on `main` — six ported files (`backend/fallbacks.rb`, `locale*.rb`) were
missing from its in-scope list, and `backend/flatten.rb` was listed while an
exclusion covers it. Fixed here because this PR edits the same file.

Gates: `api:compare` i18n 133/136 (unchanged, `exceptions.rb` 19/19),
`api:extra` no STALE tags and exit 0, `api:calls` / `api:calls:wide` OK,
`test:compare` transliterator gap closed, `pnpm vitest run packages/i18n
scripts/api-compare` 1362 passed.

Closes-story: i18n-loadjs-norailsequivalent-tag-stale
Closes-story: i18n-time-new-is-private
Closes-story: i18n-transliterator-invalid-utf8-test
Closes-story: i18n-unsupported-method-exception
