### PR TITLE
feat(api-compare): measure i18n key_value.rb and flatten.rb

### DIFF
--- a/docs/ruby-ts-conventions.md
+++ b/docs/ruby-ts-conventions.md
@@ -127,7 +127,7 @@ their methods nor their place in the inheritance chain. Each one only papers
 over a gap in the Ruby standard library that JavaScript does not have:
 
 - `I18n::JSON`
-  - i18n/lib/i18n/backend/key*value.rb:7-22 defines `I18n::JSON` at load time as whichever JSON library is installed — `Oj` wrapped in `encode`/`decode` when the gem is present, else `JSON = ActiveSupport::JSON`. It is a library-selection shim, not behavior: JavaScript has `JSON` in the language, and its `stringify`/`parse` \_are* that `encode`/`decode`, which is what `KeyValue` calls directly (packages/i18n/src/backend/key-value.ts). Mirroring it would mean adding a trails class whose whole body forwards to a global the language already provides.
+  - `i18n/lib/i18n/backend/key_value.rb:7-22` defines `I18n::JSON` at load time as whichever JSON library is installed — `:11`/`:14` wrap `Oj` in `encode`/`decode` when the gem is present, and `:19`-`:21` falls back to `JSON = ActiveSupport::JSON`. It is a library-selection shim, not behavior: JavaScript has `JSON` in the language, and its `stringify`/`parse` are that `encode`/`decode`, which is what `KeyValue` calls directly (`packages/i18n/src/backend/key-value.ts`). Mirroring it would mean adding a trails class whose whole body forwards to a global the language already provides.
 
 ## Arity overrides
 

--- a/docs/ruby-ts-conventions.md
+++ b/docs/ruby-ts-conventions.md
@@ -120,6 +120,15 @@ a genuine gap:
 - `module ARTest` opens in config.rb and is reopened in connection.rb, so the Ruby extractor records one ARTest entity filed under config.rb and every ARTest method buckets there. Two populations end up in that bucket, neither of which is a gap. (1) `connection_name` / `test_configuration_hashes` / `connect` (connection.rb) and `expand_config` (config.rb) ARE ported — all four in packages/activerecord/src/support/connection.ts, next to the CONNECTIONS entries they name and expand. They miss only because the bucket's expected TS file is config.ts; export status is not why — in the default full-surface run the TS extractor records file-local functions too, so the non-exported `expandConfig` (connection.ts:269) is as visible to api:compare as the three exported ones, and exporting it would not match it. (Under --public-only the two sides drop it symmetrically: Ruby's `expand_config` is itself private, under config.rb's `private` at :13, so neither side offers it.) Moving it into config.ts is the only thing that would match it, and that is what cannot happen: it is typed on `NamedConnection` and `ARUNIT_ENTRY_NAMES`, both declared in connection.ts, which already imports from config.ts — so the move would CREATE an import cycle, and dragging those declarations along would relocate the `connections:` vocabulary out of the file mirroring connection.rb. (2) `config` / `config_file` / `read_config` are the memoized read of test/config.yml; trails ships no config.yml — the `connections:` hash is expressed directly as the CONNECTIONS table in connection.ts and the sub-setting readers in config.ts — so there is no file to locate, copy from config.example.yml, or parse. Scoped to config.rb, the only Ruby file in the tree that defines these names.
   - `config`, `config_file`, `read_config`, `expand_config`, `connection_name`, `test_configuration_hashes`, `connect` (only in: `config.rb`)
 
+## Ruby-only classes
+
+api:compare expects no TS counterpart for these Ruby classes at all — neither
+their methods nor their place in the inheritance chain. Each one only papers
+over a gap in the Ruby standard library that JavaScript does not have:
+
+- `I18n::JSON`
+  - i18n/lib/i18n/backend/key*value.rb:7-22 defines `I18n::JSON` at load time as whichever JSON library is installed — `Oj` wrapped in `encode`/`decode` when the gem is present, else `JSON = ActiveSupport::JSON`. It is a library-selection shim, not behavior: JavaScript has `JSON` in the language, and its `stringify`/`parse` \_are* that `encode`/`decode`, which is what `KeyValue` calls directly (packages/i18n/src/backend/key-value.ts). Mirroring it would mean adding a trails class whose whole body forwards to a global the language already provides.
+
 ## Arity overrides
 
 The advisory arity check (arity.ts) suppresses these Ruby methods — their

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -85,6 +85,7 @@ import { SpellChecker } from "../../packages/did-you-mean/src/spell-checker.js";
 import {
   hasRubyFileTsOverride,
   isArityOverridden,
+  isRubyOnlyClass,
   isScopedSkip,
   rubyFileToTs,
   rubyMethodToTs,
@@ -1228,6 +1229,7 @@ export function dedupeRubyMethodInto(
   rubyFile?: string,
 ): void {
   if (rubyMethodToTs(rm.name) === null) return;
+  if (isRubyOnlyClass(itemFqn)) return;
   if (rubyFile !== undefined && isScopedSkip(rm.name, rubyFile)) return;
   const key = rm.name;
   if (!seen.has(key)) {
@@ -2347,6 +2349,9 @@ export function main() {
       for (const { fqn, info } of allRuby) {
         if (!info.file || isSourceUnported(info.file, pkg)) continue;
         if (primaryClassPerFile.get(info.file) !== fqn) continue;
+        // A Ruby-only class has no TS class to inherit anything: mirroring it
+        // is not a gap the port can close (see RUBY_ONLY_CLASSES).
+        if (isRubyOnlyClass(fqn)) continue;
         // `allRuby` mixes classes and modules; modules don't carry superclass.
         if (!(fqn in rubyPkg.classes)) continue;
 

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -2349,8 +2349,6 @@ export function main() {
       for (const { fqn, info } of allRuby) {
         if (!info.file || isSourceUnported(info.file, pkg)) continue;
         if (primaryClassPerFile.get(info.file) !== fqn) continue;
-        // A Ruby-only class has no TS class to inherit anything: mirroring it
-        // is not a gap the port can close (see RUBY_ONLY_CLASSES).
         if (isRubyOnlyClass(fqn)) continue;
         // `allRuby` mixes classes and modules; modules don't carry superclass.
         if (!(fqn in rubyPkg.classes)) continue;

--- a/scripts/api-compare/conventions.test.ts
+++ b/scripts/api-compare/conventions.test.ts
@@ -12,7 +12,9 @@ import {
   SKIP_GROUPS,
   ARITY_OVERRIDE_GROUPS,
   isArityOverridden,
+  RUBY_ONLY_CLASSES,
   SCOPED_SKIP_GROUPS,
+  isRubyOnlyClass,
   isScopedSkip,
   ALREADY_PREDICATE_PREFIXES,
   explainConventions,
@@ -280,6 +282,20 @@ describe("SKIP_GROUPS", () => {
     for (const name of SKIP) {
       expect(rubyMethodToTs(name)).toBeNull();
     }
+  });
+});
+
+describe("RUBY_ONLY_CLASSES", () => {
+  it("requires a fully-qualified name and a non-empty reason per entry", () => {
+    for (const c of RUBY_ONLY_CLASSES) {
+      expect(c.fqn).toContain("::");
+      expect(c.reason.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it("recognises only the listed classes", () => {
+    for (const c of RUBY_ONLY_CLASSES) expect(isRubyOnlyClass(c.fqn)).toBe(true);
+    expect(isRubyOnlyClass("I18n::Backend::KeyValue")).toBe(false);
   });
 });
 

--- a/scripts/api-compare/conventions.ts
+++ b/scripts/api-compare/conventions.ts
@@ -465,6 +465,44 @@ export function isScopedSkip(rubyName: string, rubyFile: string): boolean {
 }
 
 /**
+ * A Ruby class that exists only to paper over a gap in the Ruby standard
+ * library that JavaScript has no gap in — so there is no TS class to mirror
+ * and no TS method to name. Unlike {@link SKIP_GROUPS}, this is class-level:
+ * both the method comparison and the inheritance check consult it, so the
+ * class is neither expected as a superclass host nor scored for its members.
+ *
+ * This is deliberately narrow. A class trails simply has not ported yet is a
+ * gap and belongs in `unported-files.ts` (whole file) or stays reported.
+ */
+export interface RubyOnlyClass {
+  fqn: string;
+  reason: string;
+}
+
+export const RUBY_ONLY_CLASSES: RubyOnlyClass[] = [
+  {
+    fqn: "I18n::JSON",
+    reason:
+      "i18n/lib/i18n/backend/key_value.rb:7-22 defines `I18n::JSON` at load " +
+      "time as whichever JSON library is installed — `Oj` wrapped in " +
+      "`encode`/`decode` when the gem is present, else `JSON = " +
+      "ActiveSupport::JSON`. It is a library-selection shim, not behavior: " +
+      "JavaScript has `JSON` in the language, and its `stringify`/`parse` " +
+      "*are* that `encode`/`decode`, which is what `KeyValue` calls directly " +
+      "(packages/i18n/src/backend/key-value.ts). Mirroring it would mean " +
+      "adding a trails class whose whole body forwards to a global the " +
+      "language already provides.",
+  },
+];
+
+const RUBY_ONLY_CLASS_FQNS = new Set(RUBY_ONLY_CLASSES.map((c) => c.fqn));
+
+/** True when `fqn` names a {@link RUBY_ONLY_CLASSES} entry. */
+export function isRubyOnlyClass(fqn: string): boolean {
+  return RUBY_ONLY_CLASS_FQNS.has(fqn);
+}
+
+/**
  * A group of Ruby method names whose arity is *intentionally* allowed to diverge
  * from the TS port. Like {@link SkipGroup} but scoped: `rubyFiles` restricts the
  * override to the Ruby source files (path relative to the package lib root, as
@@ -818,6 +856,10 @@ export function explainConventions(): string {
     return `- ${g.reason}\n  - ${names}`;
   }).join("\n");
 
+  const rubyOnlyClassSections = RUBY_ONLY_CLASSES.map(
+    (c) => `- \`${c.fqn}\`\n  - ${c.reason}`,
+  ).join("\n");
+
   const arityOverrideSections = ARITY_OVERRIDE_GROUPS.map((g) => {
     const names = g.names.map((n) => `\`${n}\``).join(", ");
     return `- ${g.reason}\n  - ${names}`;
@@ -918,6 +960,14 @@ have a real TS surface elsewhere, so the skip is file-scoped to avoid silencing
 a genuine gap:
 
 ${scopedSkipSections}
+
+## Ruby-only classes
+
+api:compare expects no TS counterpart for these Ruby classes at all — neither
+their methods nor their place in the inheritance chain. Each one only papers
+over a gap in the Ruby standard library that JavaScript does not have:
+
+${rubyOnlyClassSections}
 
 ## Arity overrides
 

--- a/scripts/api-compare/conventions.ts
+++ b/scripts/api-compare/conventions.ts
@@ -483,15 +483,15 @@ export const RUBY_ONLY_CLASSES: RubyOnlyClass[] = [
   {
     fqn: "I18n::JSON",
     reason:
-      "i18n/lib/i18n/backend/key_value.rb:7-22 defines `I18n::JSON` at load " +
-      "time as whichever JSON library is installed — `Oj` wrapped in " +
-      "`encode`/`decode` when the gem is present, else `JSON = " +
-      "ActiveSupport::JSON`. It is a library-selection shim, not behavior: " +
-      "JavaScript has `JSON` in the language, and its `stringify`/`parse` " +
-      "*are* that `encode`/`decode`, which is what `KeyValue` calls directly " +
-      "(packages/i18n/src/backend/key-value.ts). Mirroring it would mean " +
-      "adding a trails class whose whole body forwards to a global the " +
-      "language already provides.",
+      "`i18n/lib/i18n/backend/key_value.rb:7-22` defines `I18n::JSON` at load " +
+      "time as whichever JSON library is installed — `:11`/`:14` wrap `Oj` in " +
+      "`encode`/`decode` when the gem is present, and `:19`-`:21` falls back " +
+      "to `JSON = ActiveSupport::JSON`. It is a library-selection shim, not " +
+      "behavior: JavaScript has `JSON` in the language, and its " +
+      "`stringify`/`parse` are that `encode`/`decode`, which is what " +
+      "`KeyValue` calls directly (`packages/i18n/src/backend/key-value.ts`). " +
+      "Mirroring it would mean adding a trails class whose whole body " +
+      "forwards to a global the language already provides.",
   },
 ];
 

--- a/scripts/api-compare/unported-files.test.ts
+++ b/scripts/api-compare/unported-files.test.ts
@@ -60,8 +60,6 @@ describe("isSourceUnported package scoping", () => {
       "config.rb",
       "exceptions.rb",
       "interpolate/ruby.rb",
-      // `locale.rb` is nothing but `autoload`s, so api:compare's file count
-      // never reaches it — but `locale.ts` is its port, so it is accounted for.
       "locale.rb",
       "locale/fallbacks.rb",
       "locale/tag.rb",

--- a/scripts/api-compare/unported-files.test.ts
+++ b/scripts/api-compare/unported-files.test.ts
@@ -52,12 +52,21 @@ describe("isSourceUnported package scoping", () => {
       "../i18n.rb",
       "backend.rb",
       "backend/base.rb",
+      "backend/fallbacks.rb",
       "backend/flatten.rb",
+      "backend/key_value.rb",
       "backend/simple.rb",
       "backend/transliterator.rb",
       "config.rb",
       "exceptions.rb",
       "interpolate/ruby.rb",
+      // `locale.rb` is nothing but `autoload`s, so api:compare's file count
+      // never reaches it — but `locale.ts` is its port, so it is accounted for.
+      "locale.rb",
+      "locale/fallbacks.rb",
+      "locale/tag.rb",
+      "locale/tag/parents.rb",
+      "locale/tag/simple.rb",
       "utils.rb",
     ]);
     const unaccounted = ["../i18n.rb", ...files].filter(

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -1144,11 +1144,6 @@ export const UNPORTED_FILES: UnportedFile[] = [
     reason: "Pre-1.0: optional backend mixin — composes several backends behind one lookup.",
   },
   {
-    pattern: "backend/key_value.rb",
-    package: "i18n",
-    reason: "Pre-1.0: optional backend over a key-value store, keyed by Ruby-marshalled subtrees.",
-  },
-  {
     pattern: "backend/cache.rb",
     package: "i18n",
     reason: "Pre-1.0: optional backend mixin — caches lookups through ActiveSupport::Cache.",
@@ -1162,14 +1157,6 @@ export const UNPORTED_FILES: UnportedFile[] = [
     pattern: "backend/cascade.rb",
     package: "i18n",
     reason: "Pre-1.0: optional backend mixin — cascading key lookup (`foo.bar.baz` → `foo.baz`).",
-  },
-  {
-    pattern: "backend/flatten.rb",
-    package: "i18n",
-    reason:
-      "Pre-1.0: optional backend mixin — key-flattening helpers used only by the " +
-      "deferred `key_value.rb`, `cache_file.rb` and `memoize.rb` backends; " +
-      "`Simple` does not include it.",
   },
   {
     pattern: "backend/interpolation_compiler.rb",


### PR DESCRIPTION
## What

`backend/key_value.rb` and `backend/flatten.rb` are ported
(`packages/i18n/src/backend/key-value.ts`, `.../flatten.ts`) but were still
deferred whole-file in `unported-files.ts`, so nothing inside them was
measured. (The story's context says PR #6060 already removed them; #6060 is
open and is about `test:compare` exclusions, so this PR does the removal.)

i18n `api:compare`, before → after:

```
130/136 methods (95.6%) | files: 13/13 | inheritance: 6/6 | arity:  76/76
177/184 methods (96.2%) | files: 15/15 | inheritance: 6/6 | arity: 114/114
```

## `I18n::JSON`

Removing the deferral surfaces three gaps: `I18n::JSON.encode` / `.decode`,
and `I18n::Backend::KeyValue#load_rb`. It also reports `I18n::JSON` as
`ts-class-missing` — it is the shortest-FQN class in `key_value.rb`, so it,
not `KeyValue`, is that file's inheritance-checked primary.

`vendor/i18n/lib/i18n/backend/key_value.rb:7-22` defines `I18n::JSON` at load
time as whichever JSON library is installed: `Oj` wrapped in `encode`/`decode`
when the gem is present, otherwise `JSON = ActiveSupport::JSON`. It is
library selection, not behavior — JavaScript has `JSON` in the language, and
its `stringify` / `parse` *are* that `encode` / `decode`, which is what
`KeyValue` already calls directly (`key-value.ts:10-11` documents this).

A `SCOPED_SKIP_GROUPS` row cannot close this: it silences method names, and
the inheritance check never consults it. So this adds a class-level register,
`RUBY_ONLY_CLASSES` (`conventions.ts`), consulted by **both** the method
comparison (`dedupeRubyMethodInto`) and the inheritance loop, with `I18n::JSON`
as its one entry and the `key_value.rb:7-22` citation as its reason. It is
deliberately narrow — a class trails simply has not ported yet is a gap and
belongs in `unported-files.ts` or stays reported. The generated
`docs/ruby-ts-conventions.md` gains a matching section.

`KeyValue#load_rb` is left reported: it is the same `Backend::Base#load_rb`
gap already visible on `base.rb` and `simple.rb` and justified at its call
site (`backend/base.ts:597-604`, `loadJs`), now surfacing on a third includer.
Not new debt, and not this story's to close.

## Also

`unported-files.test.ts`'s "accounts for every file in the vendored i18n lib
tree" invariant was already red on `main` — its hand-written `inScope` set had
drifted from what `api:compare` measures, missing `backend/fallbacks.rb`,
`locale/fallbacks.rb` and the `locale/tag` tree. Synced, plus `locale.rb`
(all `autoload`s, so the file count never reaches it, but `locale.ts` is its
port) and `backend/key_value.rb`.

Gates: `api:calls` OK, `api:calls:wide` OK, `test:compare` unchanged.

Closes-story: i18n-key-value-residual-api-gaps

Considered and rejected: also skipping ruby-only classes in `primaryClassPerFile`
selection, so `KeyValue` (not `I18n::JSON`) becomes key_value.rb's
inheritance primary. It makes the numbers worse — `SubtreeProxy` then reads as
a nested class under a shorter-named parent and its methods drop out
(177/184 → 176/183), and `KeyValue` reports a super-mismatch because Ruby
`include Base` vs TS `extends Base` is not something `superclassesMatch`
models. Left alone.
