### PR TITLE
refactor(i18n): key normalizeKey's memo on key itself, not a cacheKey copy

### DIFF
--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -363,8 +363,7 @@ function normalizeKey(key: unknown, separator: string): TranslationKey[] {
     bySeparator = new Map();
     normalizedKeyCache.set(separator, bySeparator);
   }
-  const cacheKey = key;
-  let normalized = bySeparator.get(cacheKey);
+  let normalized = bySeparator.get(key);
   if (normalized === undefined) {
     if (Array.isArray(key)) {
       normalized = key.flatMap((k) => normalizeKey(k, separator));
@@ -381,7 +380,7 @@ function normalizeKey(key: unknown, separator: string): TranslationKey[] {
         return k;
       });
     }
-    bySeparator.set(cacheKey, normalized);
+    bySeparator.set(key, normalized);
   }
   return normalized;
 }


### PR DESCRIPTION
The JS-`Symbol` arm was already removed from `normalizeKey` by #6038, but the
local it forced — `const cacheKey = key` — outlived it. Rails writes the memo
against the one `key` binding (`vendor/i18n/lib/i18n.rb:442`):

```ruby
@@normalized_key_cache[separator][key] ||= ...
```

So this collapses `cacheKey` back into `key` for both the read and the write.
No behavior change (the copy was never reassigned); i18n suite green, 395
passing.

Closes-story: normalize-key-drops-js-symbol-arm
