### PR TITLE
fix(activerecord): extract only validPrimaryKeyOptions in buildCreateTableDefinition

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1496,7 +1496,7 @@ export class SchemaStatements {
       if (rest[key] !== undefined) tdOptions[key] = rest[key];
     }
     const pkOptions: Record<string, unknown> = {};
-    for (const key of [...this.validPrimaryKeyOptions(), "autoIncrement"]) {
+    for (const key of this.validPrimaryKeyOptions()) {
       if (rest[key] !== undefined) pkOptions[key] = rest[key];
     }
 


### PR DESCRIPTION
`buildCreateTableDefinition` extracted `[...validPrimaryKeyOptions(), "autoIncrement"]`. Rails extracts exactly `valid_primary_key_options` (`activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:333-335`, list at `:1588-1590` — `[:limit, :default, :precision]`); an `auto_increment:` table-level option would not survive `assert_valid_keys` there.

The extraction is now `this.validPrimaryKeyOptions()` with nothing appended.

MySQL keeps `unsigned` / `autoIncrement` through Rails' own extension point — `MySQL::SchemaStatements#valid_primary_key_options` is `super + [:unsigned, :auto_increment]` (`mysql/schema_statements.rb:168-170`). This PR originally carried that override too; a sibling PR landed it on `main` first, so after the rebase the diff is just the abstract one-liner.

Sweep: the only `createTable` caller passing a table-level `autoIncrement:` is the MySQL-lane `auto-increment.test.ts`, still served by the MySQL override. On other adapters such an option already failed `validateCreateTableOptionsBang`, which never included the appended key.

Closes-story: build-create-table-definition-appends-auto-increment-to-pk-options
