### PR TITLE
feat(activesupport): port MessageEncryptors

### DIFF
--- a/packages/activesupport/src/message-encryptors.test.ts
+++ b/packages/activesupport/src/message-encryptors.test.ts
@@ -1,11 +1,73 @@
-import { describe, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
+import { InvalidMessage, MessageEncryptor } from "./message-encryptor.js";
+import { MessageEncryptors } from "./message-encryptors.js";
+import type { SecretGenerator } from "./messages/rotation-coordinator.js";
+
+/** Rails' `"".ljust(secret_length, salt)`. */
+const SECRET_GENERATOR: SecretGenerator = (salt, { secretLength }) =>
+  salt.repeat(secretLength as number).slice(0, secretLength as number);
 
 describe("MessageEncryptorsTest", () => {
-  it.skip("can override secret generator");
+  const makeCoordinator = (): MessageEncryptors => new MessageEncryptors(SECRET_GENERATOR);
 
-  it.skip("supports arbitrary secret generator kwargs");
+  const roundtrip = (
+    message: string,
+    encryptor: MessageEncryptor,
+    decryptor: MessageEncryptor = encryptor,
+  ): unknown => {
+    try {
+      return decryptor.decryptAndVerify(encryptor.encryptAndSign(message));
+    } catch (error) {
+      if (error instanceof InvalidMessage) return null;
+      throw error;
+    }
+  };
 
-  it.skip("supports arbitrary secret generator kwargs when using #rotate block");
+  const kwargSecretGenerator = (): SecretGenerator =>
+    Object.assign(
+      (_salt: string, { secretLength, foo, bar }: Record<string, unknown>) =>
+        (foo as string)[bar as number].repeat(secretLength as number),
+      { parameters: ["foo", "bar"] as const },
+    );
 
-  it.skip("supports separate secrets for encryption and signing");
+  let coordinator: MessageEncryptors;
+
+  beforeEach(() => {
+    coordinator = makeCoordinator().rotateDefaults();
+  });
+
+  it("can override secret generator", () => {
+    const secretGenerator: SecretGenerator = (salt, { secretLength }) =>
+      salt[0].repeat(secretLength as number);
+    const other = makeCoordinator().rotate({ secretGenerator });
+
+    expect(roundtrip("message", other.get("salt"))).toEqual("message");
+    expect(roundtrip("message", coordinator.get("salt"), other.get("salt"))).toBeNull();
+  });
+
+  it("supports arbitrary secret generator kwargs", () => {
+    const other = new MessageEncryptors(kwargSecretGenerator());
+    other.rotate({ foo: "foo", bar: 0 });
+
+    expect(roundtrip("message", other.get("salt"))).toEqual("message");
+  });
+
+  it("supports arbitrary secret generator kwargs when using #rotate block", () => {
+    const other = new MessageEncryptors(kwargSecretGenerator());
+    other.rotate(() => ({ foo: "foo", bar: 0 }));
+
+    expect(roundtrip("message", other.get("salt"))).toEqual("message");
+  });
+
+  it("supports separate secrets for encryption and signing", () => {
+    const secretGenerator: SecretGenerator = (salt, options) => [
+      SECRET_GENERATOR(salt, options),
+      "signing secret",
+    ];
+    const other = new MessageEncryptors(secretGenerator);
+    other.rotateDefaults();
+
+    expect(roundtrip("message", other.get("salt"))).toEqual("message");
+    expect(roundtrip("message", coordinator.get("salt"), other.get("salt"))).toBeNull();
+  });
 });

--- a/packages/activesupport/src/message-encryptors.trails.test.ts
+++ b/packages/activesupport/src/message-encryptors.trails.test.ts
@@ -1,0 +1,28 @@
+import { describe } from "vitest";
+
+import { InvalidMessage, MessageEncryptor } from "./message-encryptor.js";
+import { MessageEncryptors } from "./message-encryptors.js";
+import { rotationCoordinatorTests } from "./messages/rotation-coordinator-tests.js";
+
+/**
+ * Rails' `MessageEncryptorsTest` does `include RotationCoordinatorTests`; the
+ * shared module's tests are not part of `message_encryptors_test.rb` itself, so
+ * they run from here rather than from `message-encryptors.test.ts`.
+ */
+describe("MessageEncryptorsTest", () => {
+  rotationCoordinatorTests<MessageEncryptor>({
+    makeCoordinator: () =>
+      new MessageEncryptors((salt, { secretLength }) =>
+        salt.repeat(secretLength as number).slice(0, secretLength as number),
+      ),
+
+    roundtrip(message, encryptor, decryptor = encryptor) {
+      try {
+        return decryptor.decryptAndVerify(encryptor.encryptAndSign(message));
+      } catch (error) {
+        if (error instanceof InvalidMessage) return null;
+        throw error;
+      }
+    },
+  });
+});

--- a/packages/activesupport/src/message-encryptors.ts
+++ b/packages/activesupport/src/message-encryptors.ts
@@ -1,0 +1,13 @@
+import { MessageEncryptor } from "./message-encryptor.js";
+import { RotationCoordinator, type BuildOptions } from "./messages/rotation-coordinator.js";
+
+export class MessageEncryptors extends RotationCoordinator<MessageEncryptor> {
+  /** @internal */
+  protected build(salt: string, options: BuildOptions): MessageEncryptor {
+    const { secretGenerator, secretGeneratorOptions, ...rest } = options;
+    const secretLength = MessageEncryptor.keyLen(rest.cipher as string | undefined);
+    const secret = secretGenerator(salt, { secretLength, ...secretGeneratorOptions });
+    const secrets = (Array.isArray(secret) ? secret : [secret]) as (string | Buffer)[];
+    return new MessageEncryptor(secrets[0], secrets[1], rest);
+  }
+}

--- a/packages/activesupport/src/messages/rotation-coordinator.trails.test.ts
+++ b/packages/activesupport/src/messages/rotation-coordinator.trails.test.ts
@@ -6,9 +6,8 @@ import { RotationCoordinator, type BuildOptions } from "./rotation-coordinator.j
 
 /**
  * `RotationCoordinator` is abstract and Rails covers it only through
- * `MessageVerifiers` / `MessageEncryptors`, neither of which is ported yet.
- * This stands in for `MessageVerifiers` so the base class and the shared
- * `RotationCoordinatorTests` module are exercised until it lands.
+ * `MessageVerifiers` / `MessageEncryptors`. This stands in for them so the
+ * base class itself is exercised directly.
  */
 class VerifierCoordinator extends RotationCoordinator<MessageVerifier> {
   protected build(salt: string, options: BuildOptions): MessageVerifier {


### PR DESCRIPTION
Ports `ActiveSupport::MessageEncryptors`
(`activesupport/lib/active_support/message_encryptors.rb:137`) — the
`Messages::RotationCoordinator` subclass whose private `build` derives the
secret length from the cipher (`MessageEncryptor.key_len(*options[:cipher])`),
calls the secret generator with `secret_length:` plus the generator's own
options, and splats `Array(secret)` into `MessageEncryptor.new` so a generator
returning `[secret, sign_secret]` yields separate encryption and signing
secrets.

Tests: the four bodyless placeholders in `message-encryptors.test.ts` are
replaced with the ported bodies from
`activesupport/test/message_encryptors_test.rb` (`test:compare`
`message_encryptors_test.rb` 0/4 → 4/4). Rails' file also does
`include RotationCoordinatorTests`; since those tests belong to the shared
module rather than to this file, they run from
`message-encryptors.trails.test.ts` (20 tests, all passing) and the now-stale
"neither of which is ported yet" comment in
`messages/rotation-coordinator.trails.test.ts` is updated.

`pnpm typecheck`, `pnpm lint`, `pnpm api:extra --package activesupport` (no new
extra surface), `pnpm api:calls`, and `pnpm api:calls:wide` all pass.

Closes-story: port-activesupport-message-encryptors
