### PR TITLE
feat(activerecord): port AttributeMethods#[] and #[]= as get/set

### DIFF
--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -9,12 +9,14 @@ export type { ModelWithErrors } from "./validations.js";
 export { Validator, EachValidator, BlockValidator, shouldValidate } from "./validator.js";
 export {
   MissingAttributeError,
+  missingAttribute,
   AttributeMethodPattern,
   resolveAliasName,
   resolveAliasNameIn,
   AttrNames,
   defineDirtyAttributeMethods,
 } from "./attribute-methods.js";
+export type { InstanceHost } from "./attribute-methods.js";
 export { ForbiddenAttributesError } from "./forbidden-attributes-protection.js";
 export {
   assignAttributes,

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1668,7 +1668,7 @@ export class Model {
 
   // -- Attribute access --
 
-  readAttribute(name: string): unknown {
+  readAttribute(name: string, block?: (name: string) => unknown): unknown {
     // Rails resolves alias_attribute names in `read_attribute`
     // (attribute_aliases[name] || name, read.rb:31-34); `_read_attribute`
     // skips it. Resolved against the loaded attribute set so the trails
@@ -1678,7 +1678,7 @@ export class Model {
       return null;
     }
     this._accessedFields.add(resolved);
-    return this._attributes.fetchValue(resolved) ?? null;
+    return this._attributes.fetchValue(resolved, block) ?? null;
   }
 
   /**

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1674,10 +1674,7 @@ export class Model {
     // skips it. Resolved against the loaded attribute set so the trails
     // camelCase-key bridge cannot displace a name the record already owns.
     const resolved = resolveAliasNameIn(this.constructor as typeof Model, this._attributes, name);
-    if (!this._attributes.has(resolved)) {
-      return null;
-    }
-    this._accessedFields.add(resolved);
+    if (this._attributes.has(resolved)) this._accessedFields.add(resolved);
     return this._attributes.fetchValue(resolved, block) ?? null;
   }
 

--- a/packages/activerecord/src/attribute-methods.test.ts
+++ b/packages/activerecord/src/attribute-methods.test.ts
@@ -884,6 +884,8 @@ describe("AttributeMethodsTest", () => {
     const topic = new Topic({ title: "a" });
     Object.defineProperty(topic, "title", { get: () => "b" });
     expect(topic.readAttribute("title")).toBe("a");
+    // Mirrors: assert_equal "a", topic[:title]
+    expect((topic as any).get("title")).toBe("a");
   });
 
   it("non-attribute read and write", async () => {
@@ -1010,7 +1012,14 @@ describe("AttributeMethodsTest", () => {
       }
     }
     const t = Topic.new({ title: "read-test" }) as any;
-    expect(t.readAttribute("title")).toBe("read-test");
+    const superReadAttribute = t.readAttribute.bind(t);
+    t.readAttribute = (attrName: string, block?: (name: string) => unknown) =>
+      String(superReadAttribute(attrName, block)).toUpperCase();
+
+    expect(t.readAttribute("title")).toBe("READ-TEST");
+    // Mirrors: assert_equal "STOP CHANGING THE TOPIC", topic["title"] — `[]`
+    // dispatches read_attribute, so the override reaches bracket reads too.
+    expect(t.get("title")).toBe("READ-TEST");
   });
 
   it("attribute_method?", async () => {

--- a/packages/activerecord/src/attribute-methods.test.ts
+++ b/packages/activerecord/src/attribute-methods.test.ts
@@ -309,24 +309,15 @@ describe("AttributeMethodsTest", () => {
     await Post.create({ title: "sel_test" });
     const result = await Post.select("title").first();
     // Mirrors: computer[:developer] → assert_raises MissingAttributeError.
-    // Rails `[]` reads via `_read_attribute(attr) { |n| missing_attribute(n) }`;
-    // The generated per-attribute getter supplies the same raising block.
     // `legacy_comments_count` is a real canonical `posts` column that wasn't in
     // the SELECT, so reading it raises.
-    expect(() => (result as any).legacy_comments_count).toThrow(
-      "missing attribute 'legacy_comments_count'",
-    );
-    // Same read through `[]` itself (attribute_methods.rb:415).
     expect(() => (result as any).get("legacy_comments_count")).toThrow(
       "missing attribute 'legacy_comments_count'",
     );
     // Mirrors: assert_nothing_raised { computer[:extendedWarranty] }
-    // (block-less `read_attribute` never raises; a selected column reads back).
-    expect(result?.readAttribute("title")).toBe("sel_test");
     expect((result as any).get("title")).toBe("sel_test");
     // Mirrors: assert_nothing_raised { computer[:no_column_exists] } — an unknown
-    // name returns nil even through the raising getter/`[]` block.
-    expect(result?.readAttribute("no_column_exists")).toBeNull();
+    // name returns nil even through `[]`'s raising block.
     expect((result as any).get("no_column_exists")).toBeNull();
   });
   it("user-defined time attribute predicate", async () => {
@@ -809,20 +800,27 @@ describe("AttributeMethodsTest", () => {
   it("write_attribute", async () => {
     const Topic = makeTopic();
     const t = new Topic({});
-    t.writeAttribute("title", "Written");
-    expect(t.readAttribute("title")).toBe("Written");
+    t.writeAttribute("title", "Still another topic");
+    expect(t.title).toBe("Still another topic");
 
-    // Mirrors: topic[:title] = "Still another topic: part 2"
-    t.set("title", "Written: part 2");
-    expect(t.title).toBe("Written: part 2");
+    t.set("title", "Still another topic: part 2");
+    expect(t.title).toBe("Still another topic: part 2");
+
+    t.writeAttribute("title", "Still another topic: part 3");
+    expect(t.title).toBe("Still another topic: part 3");
+
+    t.set("title", "Still another topic: part 4");
+    expect(t.title).toBe("Still another topic: part 4");
   });
 
   it("read_attribute", async () => {
     const Topic = makeTopic();
-    const t = new Topic({ title: "Read" });
-    expect(t.readAttribute("title")).toBe("Read");
-    // Mirrors: assert_equal "Don't change the topic", topic["title"]
-    expect(t.get("title")).toBe("Read");
+    const t = new Topic({ title: "Don't change the topic" });
+    expect(t.readAttribute("title")).toBe("Don't change the topic");
+    expect(t.get("title")).toBe("Don't change the topic");
+
+    expect(t.readAttribute("title")).toBe("Don't change the topic");
+    expect(t.get("title")).toBe("Don't change the topic");
   });
 
   it("read_attribute when false", async () => {
@@ -883,8 +881,6 @@ describe("AttributeMethodsTest", () => {
     const Topic = makeTopic();
     const topic = new Topic({ title: "a" });
     Object.defineProperty(topic, "title", { get: () => "b" });
-    expect(topic.readAttribute("title")).toBe("a");
-    // Mirrors: assert_equal "a", topic[:title]
     expect((topic as any).get("title")).toBe("a");
   });
 
@@ -1011,15 +1007,17 @@ describe("AttributeMethodsTest", () => {
         this.attribute("title", "string");
       }
     }
-    const t = Topic.new({ title: "read-test" }) as any;
+    const t = Topic.new({ title: "Stop changing the topic" }) as any;
     const superReadAttribute = t.readAttribute.bind(t);
     t.readAttribute = (attrName: string, block?: (name: string) => unknown) =>
       String(superReadAttribute(attrName, block)).toUpperCase();
 
-    expect(t.readAttribute("title")).toBe("READ-TEST");
-    // Mirrors: assert_equal "STOP CHANGING THE TOPIC", topic["title"] — `[]`
-    // dispatches read_attribute, so the override reaches bracket reads too.
-    expect(t.get("title")).toBe("READ-TEST");
+    // `[]` dispatches read_attribute, so the override reaches bracket reads too.
+    expect(t.readAttribute("title")).toBe("STOP CHANGING THE TOPIC");
+    expect(t.get("title")).toBe("STOP CHANGING THE TOPIC");
+
+    expect(t.readAttribute("title")).toBe("STOP CHANGING THE TOPIC");
+    expect(t.get("title")).toBe("STOP CHANGING THE TOPIC");
   });
 
   it("attribute_method?", async () => {

--- a/packages/activerecord/src/attribute-methods.test.ts
+++ b/packages/activerecord/src/attribute-methods.test.ts
@@ -310,19 +310,24 @@ describe("AttributeMethodsTest", () => {
     const result = await Post.select("title").first();
     // Mirrors: computer[:developer] → assert_raises MissingAttributeError.
     // Rails `[]` reads via `_read_attribute(attr) { |n| missing_attribute(n) }`;
-    // trails has no `[]` operator, so its equivalent is the generated
-    // per-attribute getter, which supplies the same raising block.
+    // The generated per-attribute getter supplies the same raising block.
     // `legacy_comments_count` is a real canonical `posts` column that wasn't in
     // the SELECT, so reading it raises.
     expect(() => (result as any).legacy_comments_count).toThrow(
       "missing attribute 'legacy_comments_count'",
     );
+    // Same read through `[]` itself (attribute_methods.rb:415).
+    expect(() => (result as any).get("legacy_comments_count")).toThrow(
+      "missing attribute 'legacy_comments_count'",
+    );
     // Mirrors: assert_nothing_raised { computer[:extendedWarranty] }
     // (block-less `read_attribute` never raises; a selected column reads back).
     expect(result?.readAttribute("title")).toBe("sel_test");
+    expect((result as any).get("title")).toBe("sel_test");
     // Mirrors: assert_nothing_raised { computer[:no_column_exists] } — an unknown
     // name returns nil even through the raising getter/`[]` block.
     expect(result?.readAttribute("no_column_exists")).toBeNull();
+    expect((result as any).get("no_column_exists")).toBeNull();
   });
   it("user-defined time attribute predicate", async () => {
     const { Post } = makeModel();
@@ -806,12 +811,18 @@ describe("AttributeMethodsTest", () => {
     const t = new Topic({});
     t.writeAttribute("title", "Written");
     expect(t.readAttribute("title")).toBe("Written");
+
+    // Mirrors: topic[:title] = "Still another topic: part 2"
+    t.set("title", "Written: part 2");
+    expect(t.title).toBe("Written: part 2");
   });
 
   it("read_attribute", async () => {
     const Topic = makeTopic();
     const t = new Topic({ title: "Read" });
     expect(t.readAttribute("title")).toBe("Read");
+    // Mirrors: assert_equal "Don't change the topic", topic["title"]
+    expect(t.get("title")).toBe("Read");
   });
 
   it("read_attribute when false", async () => {
@@ -1321,6 +1332,9 @@ describe("AttributeMethodsTest", () => {
     expect(t.readAttribute("title")).toBe("known");
     // Mirrors: topic[:no_column_exists] = "Hello!" → assert_raises MissingAttributeError
     expect(() => t.writeAttribute("no_column_exists", "Hello!")).toThrow(
+      "can't write unknown attribute `no_column_exists`",
+    );
+    expect(() => t.set("no_column_exists", "Hello!")).toThrow(
       "can't write unknown attribute `no_column_exists`",
     );
   });

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -4,7 +4,12 @@
  * Mirrors: ActiveRecord::AttributeMethods
  */
 import { isBlank } from "@blazetrails/activesupport";
-import { MissingAttributeError, resolveAliasNameIn } from "@blazetrails/activemodel";
+import {
+  MissingAttributeError,
+  missingAttribute,
+  resolveAliasNameIn,
+  type InstanceHost as AttributeMethodsInstanceHost,
+} from "@blazetrails/activemodel";
 import { formatForInspect as _formatForInspect } from "./attribute-inspection.js";
 import {
   attributeForInspect as _attrForInspect,
@@ -62,8 +67,10 @@ interface InstanceMethodHost {
   };
   _primaryKey?: string | string[];
   id?: unknown;
+  readAttribute(name: string, block?: (name: string) => unknown): unknown;
+  writeAttribute(name: string, value: unknown): void;
   /** @internal */
-  _readAttribute(name: string): unknown;
+  _readAttribute(name: string, block?: (name: string) => unknown): unknown;
   _writeAttribute(name: string, value: unknown): void;
 }
 
@@ -697,8 +704,40 @@ export function attributeForInspect(this: InstanceMethodHost, attr: string): str
 }
 
 /** Mirrors: ActiveRecord::AttributeMethods#read_attribute (read.rb:31-34) */
-export function readAttribute(this: InstanceMethodHost, name: string): unknown {
-  return this._readAttribute(recordAliasName(this, name));
+export function readAttribute(
+  this: InstanceMethodHost,
+  name: string,
+  block?: (name: string) => unknown,
+): unknown {
+  return this._readAttribute(recordAliasName(this, name), block);
+}
+
+/**
+ * Mirrors: ActiveRecord::AttributeMethods#[] (attribute_methods.rb:415-417)
+ *
+ *   def [](attr_name)
+ *     read_attribute(attr_name) { |n| missing_attribute(n, caller) }
+ *   end
+ */
+export function get(this: InstanceMethodHost, attrName: string): unknown {
+  // `read_attribute` here is AR's (read.rb:31-34) — the `readAttribute` above.
+  // Base's own `readAttribute` is still ActiveModel's, which short-circuits an
+  // unselected column to nil before the block can run, so calling the AR port
+  // directly is what preserves the missing_attribute raise.
+  return readAttribute.call(this, attrName, (n) =>
+    missingAttribute.call(this as unknown as AttributeMethodsInstanceHost, n),
+  );
+}
+
+/**
+ * Mirrors: ActiveRecord::AttributeMethods#[]= (attribute_methods.rb:428-430)
+ *
+ *   def []=(attr_name, value)
+ *     write_attribute(attr_name, value)
+ *   end
+ */
+export function set(this: InstanceMethodHost, attrName: string, value: unknown): void {
+  this.writeAttribute(attrName, value);
 }
 
 /** Mirrors: ActiveRecord::AttributeMethods#write_attribute (write.rb:31-34) */

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -720,11 +720,7 @@ export function readAttribute(
  *   end
  */
 export function get(this: InstanceMethodHost, attrName: string): unknown {
-  // `read_attribute` here is AR's (read.rb:31-34) — the `readAttribute` above.
-  // Base's own `readAttribute` is still ActiveModel's, which short-circuits an
-  // unselected column to nil before the block can run, so calling the AR port
-  // directly is what preserves the missing_attribute raise.
-  return readAttribute.call(this, attrName, (n) =>
+  return this.readAttribute(attrName, (n) =>
     missingAttribute.call(this as unknown as AttributeMethodsInstanceHost, n),
   );
 }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -203,6 +203,8 @@ import {
   attributeNamesForPartialInserts as _attributeNamesForPartialInserts,
   idBeforeTypeCast as _idBeforeTypeCast,
   isSavedChanges as _isSavedChanges,
+  get as _get,
+  set as _set,
 } from "./attribute-methods.js";
 import { normalizedAttributes as _normalizedAttributes } from "./normalization.js";
 import {
@@ -4115,7 +4117,11 @@ export class Base extends Model {
   declare accessedFields: () => string[];
   declare queryAttribute: (name: string) => boolean;
   declare _queryAttribute: (name: string) => boolean;
-  declare readAttribute: (name: string) => unknown;
+  declare readAttribute: (name: string, block?: (name: string) => unknown) => unknown;
+  /** Mirrors: ActiveRecord::AttributeMethods#[] (attribute_methods.rb:415) */
+  declare get: (attrName: string) => unknown;
+  /** Mirrors: ActiveRecord::AttributeMethods#[]= (attribute_methods.rb:428) */
+  declare set: (attrName: string, value: unknown) => void;
   /** @internal */
   declare _readAttribute: (name: string) => unknown;
   declare _writeAttribute: (name: string, value: unknown) => void;
@@ -4894,6 +4900,8 @@ include(Base, {
   attributePresent: _attributePresent,
   accessedFields: _accessedFields,
   queryAttribute: _queryAttribute,
+  get: _get,
+  set: _set,
   _queryAttribute: _queryAttributeFn,
   _readAttribute: _readAttributeFn,
   _writeAttribute: ReadonlyAttributes._writeAttribute,

--- a/scripts/api-compare/operator-order-spelling.test.ts
+++ b/scripts/api-compare/operator-order-spelling.test.ts
@@ -41,6 +41,9 @@ describe("operatorSpelling", () => {
     expect(operatorSpelling(pool, "[]")).toEqual(["get"]);
     expect(operatorSpelling(pool, "[]=")).toEqual(["set"]);
     expect(operatorSpelling("ActiveRecord::Result", "[]")).toEqual(["at"]);
+    const attributeMethods = "ActiveRecord::AttributeMethods";
+    expect(operatorSpelling(attributeMethods, "[]")).toEqual(["get"]);
+    expect(operatorSpelling(attributeMethods, "[]=")).toEqual(["set"]);
   });
 
   it("resolves every Arel::Math operator to its named mixin spelling", () => {
@@ -57,8 +60,6 @@ describe("operatorSpelling", () => {
   });
 
   it("leaves module operators with no TS counterpart unmapped", () => {
-    expect(operatorSpelling("ActiveRecord::AttributeMethods", "[]")).toBeUndefined();
-    expect(operatorSpelling("ActiveRecord::AttributeMethods", "[]=")).toBeUndefined();
     expect(operatorSpelling("ActiveRecord::Delegation", "[]")).toBeUndefined();
     expect(operatorSpelling("ActiveRecord::Delegation", "+")).toBeUndefined();
     expect(operatorSpelling("ActiveSupport::CompareWithRange", "===")).toBeUndefined();

--- a/scripts/api-compare/operator-order-spelling.ts
+++ b/scripts/api-compare/operator-order-spelling.ts
@@ -108,6 +108,9 @@ export const OPERATOR_SPELLING_BY_FQN: Record<string, Record<string, string[]>> 
   // connection_adapters/postgresql/utils.rb:30 `def ==(o)` →
   // connection-adapters/postgresql/utils.ts `Name#equals`.
   "ActiveRecord::ConnectionAdapters::PostgreSQL::Name": { "==": ["equals"] },
+  // attribute_methods.rb:415 `def [](attr_name)` / :428 `def []=(attr_name, value)`
+  // → attribute-methods.ts `get` / `set`.
+  "ActiveRecord::AttributeMethods": { "[]": ["get"], "[]=": ["set"] },
   // connection_adapters/statement_pool.rb:23 `def [](key)` / :31 `def []=(sql, stmt)`
   // → connection-adapters/statement-pool.ts `get` / `set`.
   "ActiveRecord::ConnectionAdapters::StatementPool": { "[]": ["get"], "[]=": ["set"] },


### PR DESCRIPTION
Ports `ActiveRecord::AttributeMethods#[]` (attribute_methods.rb:415-417) and
`#[]=` (attribute_methods.rb:428-430) to `packages/activerecord/src/attribute-methods.ts`
as `get` / `set` — the established spelling pair for `[]` / `[]=` in
`OPERATOR_SPELLING_BY_FQN`.

- `get` mirrors `read_attribute(attr_name) { |n| missing_attribute(n, caller) }`,
  raising `MissingAttributeError` for a known-but-unselected column via the
  already-ported `missingAttribute` helper (activemodel attribute_methods.rb:552)
  instead of re-inlining the raise the generated accessors carry.
- `readAttribute` gains the `&block` parameter Rails' `read_attribute`
  (read.rb:31-34) has, and `Model#readAttribute` forwards it to
  `fetchValue(name, block)` so the block can fire.
- Both are wired onto `Base` alongside the other AttributeMethods instance
  methods (`include(Base, { ... })`).
- Pins `ActiveRecord::AttributeMethods` `[]` / `[]=` in
  `OPERATOR_SPELLING_BY_FQN` with the `file:line` comment the table uses.

Tests converge the existing Rails-named cases (`read_attribute`,
`write_attribute`, the two missing-attribute cases) onto the bracket accessors
the Ruby tests actually use. `pnpm api:compare`, `api:calls`, `api:calls:wide`
and `api:extra` are all green.

Closes-story: port-attribute-methods-bracket-accessors
