### PR TITLE
feat(i18n): measure backend/chain.rb (drop stale whole-file deferral)

### DIFF
--- a/packages/i18n/src/backend/chain.ts
+++ b/packages/i18n/src/backend/chain.ts
@@ -103,7 +103,7 @@ export class Chain {
   }
 
   availableLocales(): Locale[] {
-    return [...new Set(this.backends.flatMap((backend) => backend.availableLocales()))];
+    return [...new Set(this.backends.map((backend) => backend.availableLocales()).flat())];
   }
 
   translate(

--- a/scripts/api-compare/unported-files.test.ts
+++ b/scripts/api-compare/unported-files.test.ts
@@ -52,6 +52,7 @@ describe("isSourceUnported package scoping", () => {
       "../i18n.rb",
       "backend.rb",
       "backend/base.rb",
+      "backend/chain.rb",
       "backend/fallbacks.rb",
       "backend/flatten.rb",
       "backend/key_value.rb",

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -1139,11 +1139,6 @@ export const UNPORTED_FILES: UnportedFile[] = [
   },
   // --- i18n: optional backend mixins composed on top of Simple ---
   {
-    pattern: "backend/chain.rb",
-    package: "i18n",
-    reason: "Pre-1.0: optional backend mixin — composes several backends behind one lookup.",
-  },
-  {
     pattern: "backend/cache.rb",
     testFile: "backend/cache_test.rb",
     package: "i18n",


### PR DESCRIPTION
`backend/chain.rb` was still listed in `unported-files.ts` as a pre-1.0 deferral ("optional backend mixin"), but `packages/i18n/src/backend/chain.ts` has mirrored it method for method for some time, with `chain.test.ts` porting its suite. So nothing in `Chain` was measured — the same stale-deferral bug #6063 fixed for `key_value.rb` and `flatten.rb`.

Removing the entry (and adding `backend/chain.rb` to the `inScope` set in the enrollment test) takes i18n from `177/184 methods | files 15/15` to **`212/217 | files 16/16`**, inheritance 7/7, arity 138/138.

The one gap the newly-measured file reports is `load_rb` — `Chain::Implementation` does `include Base` (chain.rb:21), so it inherits the same permanent deviation `base.rb`, `key_value.rb` and `simple.rb` already carry, justified at its call site in `base.ts` (`@noRailsEquivalent PERMANENT`, base.rb:254). Nothing new to port.

The wide call ratchet did surface one real divergence in the newly-measured body: `available_locales` (chain.rb:54) is `backends.map { |b| b.available_locales }.flatten.uniq`, collapsed in the port into a single `flatMap`. Restored to `map(...).flat()` so the Rails calls are visible.

Closes-story: i18n-defer-backend-chain-stale