### PR TITLE
fix(api-compare): inheritance-check I18n::Backend::KeyValue

### DIFF
--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -652,8 +652,6 @@ describe("primaryClassesPerFile", () => {
   });
 
   it("keeps a ruby-only class out of the inheritance selection", () => {
-    // key_value.rb declares `I18n::JSON` (:8) and `I18n::Backend::KeyValue`
-    // (:68). The two-segment shim used to win, leaving KeyValue unchecked.
     const { inheritance } = primaryClassesPerFile({
       "I18n::JSON": cls("backend/key_value.rb"),
       "I18n::Backend::KeyValue": cls("backend/key_value.rb"),
@@ -663,8 +661,6 @@ describe("primaryClassesPerFile", () => {
   });
 
   it("keeps the ruby-only class as the folding parent", () => {
-    // Folding is lexical: promoting KeyValue here would make SubtreeProxy a
-    // nested class of the file's parent and drop its methods.
     const { folding } = primaryClassesPerFile({
       "I18n::JSON": cls("backend/key_value.rb"),
       "I18n::Backend::KeyValue": cls("backend/key_value.rb"),

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   nameMatches,
   superclassesMatch,
+  primaryClassesPerFile,
   resolveTsClassForRuby,
   methodInMode,
   tsShouldIncludeInIndex,
@@ -628,6 +629,56 @@ describe("nameMatches", () => {
       expect(nameMatches("Foo", "FooBar")).toBe(false);
       expect(nameMatches("Foo", "BarFoo")).toBe(false);
     });
+  });
+});
+
+describe("primaryClassesPerFile", () => {
+  const cls = (file: string): ClassInfo => ({
+    name: "x",
+    file,
+    includes: [],
+    extends: [],
+    instanceMethods: [],
+    classMethods: [],
+  });
+
+  it("picks the shortest fqn in the file for both selections", () => {
+    const { folding, inheritance } = primaryClassesPerFile({
+      "A::B": cls("a.rb"),
+      "A::B::C": cls("a.rb"),
+    });
+    expect(folding.get("a.rb")).toBe("A::B");
+    expect(inheritance.get("a.rb")).toBe("A::B");
+  });
+
+  it("keeps a ruby-only class out of the inheritance selection", () => {
+    // key_value.rb declares `I18n::JSON` (:8) and `I18n::Backend::KeyValue`
+    // (:68). The two-segment shim used to win, leaving KeyValue unchecked.
+    const { inheritance } = primaryClassesPerFile({
+      "I18n::JSON": cls("backend/key_value.rb"),
+      "I18n::Backend::KeyValue": cls("backend/key_value.rb"),
+      "I18n::Backend::KeyValue::SubtreeProxy": cls("backend/key_value.rb"),
+    });
+    expect(inheritance.get("backend/key_value.rb")).toBe("I18n::Backend::KeyValue");
+  });
+
+  it("keeps the ruby-only class as the folding parent", () => {
+    // Folding is lexical: promoting KeyValue here would make SubtreeProxy a
+    // nested class of the file's parent and drop its methods.
+    const { folding } = primaryClassesPerFile({
+      "I18n::JSON": cls("backend/key_value.rb"),
+      "I18n::Backend::KeyValue": cls("backend/key_value.rb"),
+      "I18n::Backend::KeyValue::SubtreeProxy": cls("backend/key_value.rb"),
+    });
+    expect(folding.get("backend/key_value.rb")).toBe("I18n::JSON");
+  });
+
+  it("ignores classes with no file", () => {
+    const { folding, inheritance } = primaryClassesPerFile({
+      "A::B": { ...cls(""), file: undefined },
+    });
+    expect(folding.size).toBe(0);
+    expect(inheritance.size).toBe(0);
   });
 });
 

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -932,6 +932,45 @@ export function resolveTsClassForRuby(
   return resolved;
 }
 
+/**
+ * The two per-file "which class is this file about?" selections, both by
+ * shortest fqn but over different populations:
+ *
+ *   - `folding`: every class. Used to skip nested classes that share a file
+ *     with a shorter-named parent — `Preloader::Association::LoaderQuery` in
+ *     preloader/association.rb is an implementation detail whose methods
+ *     shouldn't inflate the parent's count. This is a purely lexical
+ *     question, so a RUBY_ONLY_CLASSES entry still counts as a parent here.
+ *   - `inheritance`: RUBY_ONLY_CLASSES excluded. A shim we deliberately do
+ *     not port must not become the one class a file contributes to the
+ *     inheritance check, or the real class in the file is never checked at
+ *     all — `I18n::JSON` (key_value.rb:8, two segments) otherwise wins over
+ *     `I18n::Backend::KeyValue` (:68, three) and key_value.rb contributes
+ *     nothing.
+ *
+ * Kept as two maps rather than one: reusing the inheritance selection for
+ * folding would promote `KeyValue` to lexical parent and swallow
+ * `KeyValue::SubtreeProxy` (key_value.rb:154), which has its own TS class
+ * and its own measured methods.
+ */
+export function primaryClassesPerFile(classes: Record<string, ClassInfo>): {
+  folding: Map<string, string>;
+  inheritance: Map<string, string>;
+} {
+  const folding = new Map<string, string>();
+  const inheritance = new Map<string, string>();
+  const shorter = (fqn: string, existing: string | undefined) =>
+    !existing || fqn.split("::").length < existing.split("::").length;
+
+  for (const [fqn, cls] of Object.entries(classes)) {
+    if (!cls.file) continue;
+    if (shorter(fqn, folding.get(cls.file))) folding.set(cls.file, fqn);
+    if (isRubyOnlyClass(fqn)) continue;
+    if (shorter(fqn, inheritance.get(cls.file))) inheritance.set(cls.file, fqn);
+  }
+  return { folding, inheritance };
+}
+
 export function superclassesMatch(
   rubySuper: string | null,
   tsChain: string[],
@@ -1707,18 +1746,8 @@ export function main() {
     // Collect all Ruby classes and modules with their methods
     const allRuby: RubyEntity[] = [];
 
-    // Skip nested classes that share a file with a shorter-named parent.
-    // e.g., Preloader::Association::LoaderQuery in preloader/association.rb
-    // is an implementation detail — its methods shouldn't inflate the parent's count.
-    const primaryClassPerFile = new Map<string, string>();
-    for (const [fqn, info] of Object.entries(rubyPkg.classes)) {
-      const cls = info as unknown as ClassInfo;
-      if (!cls.file) continue;
-      const existing = primaryClassPerFile.get(cls.file);
-      if (!existing || fqn.split("::").length < existing.split("::").length) {
-        primaryClassPerFile.set(cls.file, fqn);
-      }
-    }
+    const { folding: primaryClassPerFile, inheritance: inheritanceClassPerFile } =
+      primaryClassesPerFile(rubyPkg.classes as unknown as Record<string, ClassInfo>);
 
     for (const [fqn, info] of Object.entries(rubyPkg.classes)) {
       const cls = info as unknown as ClassInfo;
@@ -2348,8 +2377,7 @@ export function main() {
 
       for (const { fqn, info } of allRuby) {
         if (!info.file || isSourceUnported(info.file, pkg)) continue;
-        if (primaryClassPerFile.get(info.file) !== fqn) continue;
-        if (isRubyOnlyClass(fqn)) continue;
+        if (inheritanceClassPerFile.get(info.file) !== fqn) continue;
         // `allRuby` mixes classes and modules; modules don't carry superclass.
         if (!(fqn in rubyPkg.classes)) continue;
 


### PR DESCRIPTION
`primaryClassPerFile` (`scripts/api-compare/compare.ts`) picks the **shortest
fqn** in a Ruby file. `vendor/i18n/lib/i18n/backend/key_value.rb` declares
`I18n::JSON` (`:8`, two segments) and `I18n::Backend::KeyValue` (`:68`, three),
so `I18n::JSON` won — and since PR #6063 entered it in `RUBY_ONLY_CLASSES` and
made the inheritance loop skip it, key_value.rb contributed **no** inheritance
check at all.

Fix: split the per-file selection into two maps (`primaryClassesPerFile`, now a
small exported helper so it can be unit-tested).

- `folding` — every class, unchanged. Skipping nested classes that share a file
  with a shorter-named parent is a purely *lexical* question, so a
  `RUBY_ONLY_CLASSES` entry still counts as a parent here. This is what keeps
  `I18n::Backend::KeyValue::SubtreeProxy` (`key_value.rb:154`) measured: if
  `KeyValue` were promoted to lexical parent, `SubtreeProxy`'s methods would be
  folded away.
- `inheritance` — `RUBY_ONLY_CLASSES` excluded, so `I18n::Backend::KeyValue` is
  the class key_value.rb's inheritance check actually looks at.

## On the story's second converged-shape item

The story predicted `KeyValue` would report a super-mismatch because "trails
writes `include Base, Flatten` as `class KeyValue extends Base`". It does not:
`packages/i18n/src/backend/key-value.ts` uses declaration merging
(`export interface KeyValue extends Base {}`) plus a prototype copy, so the
extractor records `superclass: undefined` — matching Ruby's `class KeyValue`,
which also has no superclass (`key_value.rb:68`; `include Base, Flatten` is on
the nested `Implementation` module at `:70`). `superclassesMatch(null, [], …)`
already returns `true`, and the check passes as-is. Teaching
`superclassesMatch` about Ruby `include` → TS `extends` would be an unexercised
feature here, so it is not in this PR.

## Result

- i18n inheritance **7/7 → 8/8 (100%)**, with `I18n::Backend::KeyValue` now
  among the checked and matching.
- i18n methods unchanged at **212/217**; `backend/key_value.rb` unchanged at
  **39/40** — `SubtreeProxy`'s methods stay measured.
- No other package moves (`I18n::JSON` is the only `RUBY_ONLY_CLASSES` entry).

Closes-story: i18n-key-value-inheritance-never-checked
