### PR TITLE
feat(tasks): variadic story-status verbs + release

### DIFF
--- a/scripts/tasks/cli.test.ts
+++ b/scripts/tasks/cli.test.ts
@@ -40,6 +40,7 @@ import {
   checkPrNotOpen,
   claimState,
   claimBatch,
+  findStoryFile,
   prLocDelta,
   uncheckedCheckboxes,
   commitAndPush,
@@ -762,6 +763,21 @@ describe("claimState (idempotent re-claim discriminator)", () => {
       `---\nstatus: claimed\nclaim: "2026-01-01T00:00:00Z"\nassignee: "alice"\n---\n` +
       `assignee: "dean"\n`;
     expect(claimState(fm, "dean")).toBe("taken");
+  });
+});
+
+describe("findStoryFile (lenient id resolution)", () => {
+  it("resolves a known id to its file path", () => {
+    const idx = index([story({ id: "a", file_path: "rfcs/0005-gaps/stories/a.md" })]);
+    expect(findStoryFile(idx, "a")).toMatch(/rfcs\/0005-gaps\/stories\/a\.md$/);
+  });
+
+  // The per-id-resilient verbs (`done`, `in-progress`) must be able to report an
+  // unknown id and keep going: resolving it strictly would exit the process and
+  // abort the whole bundle, leaving the known ids unmarked behind a merged PR.
+  it("returns null for an unknown id instead of exiting", () => {
+    const idx = index([story({ id: "a" })]);
+    expect(findStoryFile(idx, "nope")).toBeNull();
   });
 });
 

--- a/scripts/tasks/cli.test.ts
+++ b/scripts/tasks/cli.test.ts
@@ -39,6 +39,7 @@ import {
   checkCheckboxesDone,
   checkPrNotOpen,
   claimState,
+  claimBatch,
   prLocDelta,
   uncheckedCheckboxes,
   commitAndPush,
@@ -83,6 +84,10 @@ import {
   isDepResolved,
   statusEdits,
   statusOf,
+  prOf,
+  trackingSkip,
+  releaseError,
+  RELEASE_EDITS,
   statusTransitionError,
   STORY_STATUSES,
   stringFlag,
@@ -760,6 +765,123 @@ describe("claimState (idempotent re-claim discriminator)", () => {
   });
 });
 
+describe("claimBatch (multi-id claim partitioning)", () => {
+  const unclaimed = `---\nstatus: ready\nclaim: null\nassignee: null\n---\n`;
+  const mine = `---\nstatus: claimed\nclaim: "2026-01-01T00:00:00Z"\nassignee: "dean"\n---\n`;
+  const theirs = `---\nstatus: claimed\nclaim: "2026-01-01T00:00:00Z"\nassignee: "alice"\n---\n`;
+
+  it("partitions a whole batch of unclaimed stories as available", () => {
+    const batch = claimBatch(
+      [
+        { id: "a", text: unclaimed },
+        { id: "b", text: unclaimed },
+        { id: "c", text: unclaimed },
+      ],
+      "dean",
+    );
+    expect(batch).toEqual({ available: ["a", "b", "c"], owned: [], taken: [] });
+  });
+
+  // Atomicity: the caller refuses the ENTIRE batch when `taken` is non-empty, so
+  // a bundle that loses the race on one story never leaves the others claimed
+  // with no worker behind them (invisible to `ready` AND to the merge sweep).
+  it("reports the taken ids so one lost race refuses the whole batch", () => {
+    const batch = claimBatch(
+      [
+        { id: "a", text: unclaimed },
+        { id: "b", text: theirs },
+        { id: "c", text: unclaimed },
+      ],
+      "dean",
+    );
+    expect(batch.taken).toEqual(["b"]);
+    expect(batch.available).toEqual(["a", "c"]);
+  });
+
+  it("separates ids this assignee already holds (idempotent re-claim)", () => {
+    const batch = claimBatch(
+      [
+        { id: "a", text: mine },
+        { id: "b", text: unclaimed },
+      ],
+      "dean",
+    );
+    expect(batch).toEqual({ available: ["b"], owned: ["a"], taken: [] });
+  });
+});
+
+describe("trackingSkip (per-id resilience for done / in-progress)", () => {
+  it("skips an id already marked done for this exact PR", () => {
+    expect(trackingSkip(`---\nstatus: done\npr: 42\n---\n`, "done", 42)).toBe(true);
+  });
+
+  it("re-marks an id recorded against a different PR", () => {
+    expect(trackingSkip(`---\nstatus: done\npr: 41\n---\n`, "done", 42)).toBe(false);
+  });
+
+  it("marks an id that is still in-progress", () => {
+    expect(trackingSkip(`---\nstatus: in-progress\npr: 42\n---\n`, "done", 42)).toBe(false);
+  });
+
+  it("marks an id with no pr recorded", () => {
+    expect(trackingSkip(`---\nstatus: claimed\npr: null\n---\n`, "done", 42)).toBe(false);
+  });
+});
+
+describe("prOf", () => {
+  it("reads a numeric pr from frontmatter", () => {
+    expect(prOf(`---\nstatus: done\npr: 6062\n---\n`)).toBe(6062);
+  });
+
+  it("returns null for an unset pr", () => {
+    expect(prOf(`---\nstatus: ready\npr: null\n---\n`)).toBeNull();
+  });
+
+  it("ignores a `pr:` line in the Markdown body", () => {
+    expect(prOf(`---\nstatus: ready\n---\npr: 99 in the prose\n`)).toBeNull();
+  });
+});
+
+describe("releaseError (claimed → ready inverse of claim)", () => {
+  it("allows releasing a claimed story", () => {
+    expect(releaseError("claimed")).toBeNull();
+  });
+
+  it("treats an already-ready story as a clean no-op", () => {
+    expect(releaseError("ready")).toBeNull();
+  });
+
+  it("refuses a story with work behind it", () => {
+    expect(releaseError("in-progress")).toMatch(/only a claimed story can be released/);
+    expect(releaseError("done")).toMatch(/only a claimed story can be released/);
+  });
+
+  it("refuses an unreadable status", () => {
+    expect(releaseError(null)).toBe("cannot read current status");
+  });
+});
+
+describe("release round-trips a claim", () => {
+  it("returns a claimed story to the unclaimed ready shape", () => {
+    const dir = mkdtempSync(join(tmpdir(), "tasks-test-"));
+    const file = join(dir, "s.md");
+    writeFileSync(file, `---\nstatus: ready\nclaim: null\nassignee: null\n---\nbody\n`);
+    editFrontmatter(file, {
+      status: "claimed",
+      claim: `"2026-01-01T00:00:00Z"`,
+      assignee: `"dean"`,
+    });
+    expect(claimState(readFileSync(file, "utf8"), "alice")).toBe("taken");
+
+    editFrontmatter(file, RELEASE_EDITS);
+    const out = readFileSync(file, "utf8");
+    expect(statusOf(out)).toBe("ready");
+    // Any non-null claim reads as taken, so both keys must clear or the readied
+    // story would be unclaimable by the next agent.
+    expect(claimState(out, "alice")).toBe("available");
+  });
+});
+
 describe("statusOf", () => {
   it("reads the status scalar from frontmatter", () => {
     expect(statusOf(`---\nstatus: draft\npriority: 30\n---\nbody\n`)).toBe("draft");
@@ -1265,6 +1387,32 @@ describe("commitAndPush (git mutation flow)", () => {
       "diff-tree",
       "push",
     ]);
+  });
+
+  // A variadic verb (`claim a b c`) mutates N story files in ONE commit under
+  // ONE lock — the whole point of the multi-id verbs, since the tasks lock
+  // serializes every agent on the machine, not just the caller.
+  it("stages every file of a multi-id mutation in one add, one commit, one push", () => {
+    const { seen } = setup();
+    const added: string[][] = [];
+    execFileSyncMock.mockImplementation((_file, args) => {
+      const label = args && args.length >= 3 ? args[2] : "";
+      if (label === "symbolic-ref") return "main" as never;
+      seen.push(label);
+      if (label === "add") added.push((args ?? []).slice(3));
+      if (label === "diff-tree") return "story.md" as never;
+      return "" as never;
+    });
+    commitAndPush({
+      message: "claim: a, b, c",
+      fileToStage: ["/t/a.md", "/t/b.md", "/t/c.md"],
+      mutator: () => {},
+      raceMessage: "shouldn't be reached",
+      raceExitCode: 3,
+    });
+    expect(added).toEqual([["/t/a.md", "/t/b.md", "/t/c.md"]]);
+    expect(seen.filter((l) => l === "commit").length).toBe(1);
+    expect(seen.filter((l) => l === "push").length).toBe(1);
   });
 
   // Regression: a concurrent `reset --hard` in the shared canonical checkout

--- a/scripts/tasks/cli.ts
+++ b/scripts/tasks/cli.ts
@@ -1347,15 +1347,19 @@ export interface StoryTarget {
   file: string;
 }
 
-// Resolve ids to story files. `"all"` (claim, release, and every single-id verb)
-// aborts the whole command on an unknown id — an atomic verb must write nothing
-// when part of its input is bogus. `"each"` (done, in-progress) drops the
-// unknown ids and proceeds with the rest, so one bad id in a bundle doesn't
-// strand the others behind a merged PR; it still exits 1 when nothing resolves.
+// Resolve ids to story files, ignoring repeats (a duplicated id would otherwise
+// stage and report the same story twice). `"all"` (claim, release, and every
+// single-id verb) aborts the whole command on an unknown id — an atomic verb
+// must write nothing when part of its input is bogus. `"each"` (done,
+// in-progress) drops the unknown ids and proceeds with the rest, so one bad id
+// in a bundle doesn't strand the others behind a merged PR; it still exits 1
+// when nothing resolves, restoring the generated index files loadIndex() may
+// have dirtied (as storyFilePath does on its own not-found exit).
 function storyTargets(index: Index, ids: string[], mode: "all" | "each"): StoryTarget[] {
-  if (mode === "all") return ids.map((id) => ({ id, file: storyFilePath(index, id) }));
+  const unique = [...new Set(ids)];
+  if (mode === "all") return unique.map((id) => ({ id, file: storyFilePath(index, id) }));
   const targets: StoryTarget[] = [];
-  for (const id of ids) {
+  for (const id of unique) {
     const entry = index.stories.find((s) => s.id === id);
     if (!entry) {
       console.error(`error: story "${id}" not found in index — skipping`);
@@ -1364,10 +1368,8 @@ function storyTargets(index: Index, ids: string[], mode: "all" | "each"): StoryT
     targets.push({ id, file: join(TASKS_DIR, entry.file_path) });
   }
   if (targets.length === 0) {
-    // loadIndex() may have rebuilt and so dirtied the generated index files;
-    // restore them before this error exit (matches storyFilePath).
     restoreGeneratedFiles(TASKS_DIR);
-    console.error(`error: no known stories among: ${ids.join(", ")}`);
+    console.error(`error: no known stories among: ${unique.join(", ")}`);
     process.exit(1);
   }
   return targets;
@@ -1457,13 +1459,16 @@ export function claimBatch(
 // post-pull state before ANY write, and a single taken id refuses the lot.
 function claim(ids: string[], assignee: string): void {
   const list = ids.join(", ");
+  let held: string[] = [];
   flip(ids, `claim: ${list}`, `lost claim race on ${list} — pick another story`, 3, (targets) => {
+    held = targets.map((t) => t.id);
     const batch = claimBatch(
       targets.map((t) => ({ id: t.id, text: readFileSync(t.file, "utf8") })),
       assignee,
     );
     if (batch.taken.length > 0) {
-      console.error(`error: ${batch.taken.join(", ")} is already claimed`);
+      const verb = batch.taken.length > 1 ? "are" : "is";
+      console.error(`error: ${batch.taken.join(", ")} ${verb} already claimed`);
       throw new MutatorEarlyExit(2);
     }
     const available = targets.filter((t) => batch.available.includes(t.id));
@@ -1479,7 +1484,7 @@ function claim(ids: string[], assignee: string): void {
       // push never landed and the claim is still null or held by someone else.)
       // This runs inside commitAndPush's lock; throw the early-exit sentinel
       // (not process.exit, which would skip the lock's `finally` and leak it).
-      for (const id of ids) console.log(`claimed ${id} as ${assignee}`);
+      for (const id of held) console.log(`claimed ${id} as ${assignee}`);
       throw new MutatorEarlyExit(0);
     }
     const now = new Date().toISOString().replace(/\.\d+Z$/, "Z");
@@ -1492,7 +1497,7 @@ function claim(ids: string[], assignee: string): void {
     }
     return available.map((s) => s.file);
   });
-  for (const id of ids) console.log(`claimed ${id} as ${assignee}`);
+  for (const id of held) console.log(`claimed ${id} as ${assignee}`);
 }
 
 const RETRY_MSG = (id: string) => `failed to update ${id} after retry — pull manually and retry`;
@@ -1506,36 +1511,41 @@ export function trackingSkip(fileText: string, status: StoryStatus, pr: number):
   return statusOf(fileText) === status && prOf(fileText) === pr;
 }
 
-// Shared body of `in-progress` and `done`: both stamp status + pr on each id
-// independently (best-effort), reporting one outcome line per story.
+// Shared body of `in-progress` and `done`. Both are best-effort per id: each
+// story is stamped independently and reported on its own line, so an id already
+// carrying this exact status+pr is skipped rather than aborting the rest — a
+// half-marked bundle behind a merged PR is the failure this exists to prevent.
+// Outcomes are recorded (and reset) inside the mutator, which commitAndPush may
+// re-run after a lost race, and printed once it has landed.
 function markTracking(ids: string[], status: "in-progress" | "done", pr: number): void {
   const list = ids.join(", ");
+  let outcomes: { id: string; skipped: boolean }[] = [];
   flip(
     ids,
     `${status}: ${list} #${pr}`,
     RETRY_MSG(list),
     4,
     (targets) => {
+      outcomes = [];
       const written: string[] = [];
       for (const { id, file } of targets) {
-        if (trackingSkip(readFileSync(file, "utf8"), status, pr)) {
-          console.log(`${id} already ${status} #${pr} — skipping`);
-          continue;
-        }
+        const skipped = trackingSkip(readFileSync(file, "utf8"), status, pr);
+        outcomes.push({ id, skipped });
+        if (skipped) continue;
         editFrontmatter(file, { status, pr: String(pr) });
         written.push(file);
       }
       if (written.length === 0) {
-        // Every id was already in the target state; there is nothing to commit
-        // and `git commit` would error "nothing to commit". Bail cleanly (the
-        // sentinel, not process.exit, so commitAndPush releases its lock).
+        for (const o of outcomes) console.log(`${o.id} already ${status} #${pr}`);
         throw new MutatorEarlyExit(0);
       }
       return written;
     },
     "each",
   );
-  for (const id of ids) console.log(`marked ${id} ${status} #${pr}`);
+  for (const o of outcomes) {
+    console.log(o.skipped ? `${o.id} already ${status} #${pr}` : `marked ${o.id} ${status} #${pr}`);
+  }
 }
 
 function inProgress(ids: string[], pr: number): void {
@@ -1552,8 +1562,10 @@ function done(ids: string[], pr: number): void {
 // `STATUS_TRANSITIONS.claimed` is empty, so `status-set` refuses it.
 function release(ids: string[]): void {
   const list = ids.join(", ");
+  let outcomes: { id: string; from: string | null }[] = [];
   flip(ids, `release: ${list}`, RETRY_MSG(list), 4, (targets) => {
     const states = targets.map((t) => ({ ...t, from: statusOf(readFileSync(t.file, "utf8")) }));
+    outcomes = states.map((s) => ({ id: s.id, from: s.from }));
     const illegal = states.filter((s) => releaseError(s.from) !== null);
     if (illegal.length > 0) {
       for (const s of illegal) console.error(`error: ${releaseError(s.from)} for ${s.id}`);
@@ -1567,7 +1579,9 @@ function release(ids: string[]): void {
     for (const s of claimed) editFrontmatter(s.file, RELEASE_EDITS);
     return claimed.map((s) => s.file);
   });
-  for (const id of ids) console.log(`released ${id}`);
+  for (const o of outcomes) {
+    console.log(o.from === "claimed" ? `released ${o.id}` : `${o.id} already ready`);
+  }
 }
 
 // Pure guard for `release`, unit-testable without a git repo. Returns null when
@@ -3404,8 +3418,6 @@ function main(): void {
         checkCheckboxesDone(splitFrontmatter(storyFilePath(index, id)).body, flags.force === true);
       }
       done(ids, pr);
-      // One PR carries the whole bundle, so the estimate it is measured against
-      // is the sum of the stories marked done by this call.
       const estLoc = ids.reduce<number | null>((sum, id) => {
         const est = index.stories.find((s) => s.id === id)?.est_loc ?? null;
         return est === null ? sum : (sum ?? 0) + est;

--- a/scripts/tasks/cli.ts
+++ b/scripts/tasks/cli.ts
@@ -700,9 +700,17 @@ function assertCleanWorktree(cwd: string | undefined): void {
   process.exit(1);
 }
 
-function storyFilePath(index: Index, id: string): string {
+// Path of a story file, or null when the id is unknown. The lenient half of
+// storyFilePath, for the callers that must keep going past an unresolvable id
+// (the `each` verbs) instead of exiting.
+export function findStoryFile(index: Index, id: string): string | null {
   const entry = index.stories.find((s) => s.id === id);
-  if (!entry) {
+  return entry ? join(TASKS_DIR, entry.file_path) : null;
+}
+
+function storyFilePath(index: Index, id: string): string {
+  const file = findStoryFile(index, id);
+  if (file === null) {
     // loadIndex() (run by the caller before this) may have rebuilt and so
     // dirtied the generated index files; restore them before this error exit so
     // the tasks checkout isn't left dirty (matches rfcFilePath).
@@ -710,7 +718,7 @@ function storyFilePath(index: Index, id: string): string {
     console.error(`error: story "${id}" not found in index`);
     process.exit(1);
   }
-  return join(TASKS_DIR, entry.file_path);
+  return file;
 }
 
 // Canonical frontmatter key order, mirrors buildStoryContent. Used by
@@ -1347,8 +1355,7 @@ export interface StoryTarget {
   file: string;
 }
 
-// Resolve ids to story files, ignoring repeats (a duplicated id would otherwise
-// stage and report the same story twice). `"all"` (claim, release, and every
+// Resolve ids to story files, ignoring repeats. `"all"` (claim, release, and every
 // single-id verb) aborts the whole command on an unknown id — an atomic verb
 // must write nothing when part of its input is bogus. `"each"` (done,
 // in-progress) drops the unknown ids and proceeds with the rest, so one bad id
@@ -1360,12 +1367,12 @@ function storyTargets(index: Index, ids: string[], mode: "all" | "each"): StoryT
   if (mode === "all") return unique.map((id) => ({ id, file: storyFilePath(index, id) }));
   const targets: StoryTarget[] = [];
   for (const id of unique) {
-    const entry = index.stories.find((s) => s.id === id);
-    if (!entry) {
+    const file = findStoryFile(index, id);
+    if (file === null) {
       console.error(`error: story "${id}" not found in index — skipping`);
       continue;
     }
-    targets.push({ id, file: join(TASKS_DIR, entry.file_path) });
+    targets.push({ id, file });
   }
   if (targets.length === 0) {
     restoreGeneratedFiles(TASKS_DIR);
@@ -3389,33 +3396,37 @@ function main(): void {
       );
       break;
     case "claim": {
-      const ids = pos;
+      const ids = [...new Set(pos)];
       const assignee = stringFlag(flags, "assignee");
       if (ids.length === 0) usage();
       claim(ids, assignee ?? ids[0]);
       break;
     }
     case "release": {
-      const ids = pos;
+      const ids = [...new Set(pos)];
       if (ids.length === 0) usage();
       release(ids);
       break;
     }
     case "in-progress": {
-      const ids = pos;
+      const ids = [...new Set(pos)];
       const pr = numberFlag(flags, "pr");
       if (ids.length === 0 || pr === null) usage();
       inProgress(ids, pr);
       break;
     }
     case "done": {
-      const ids = pos;
+      const ids = [...new Set(pos)];
       const pr = numberFlag(flags, "pr");
       if (ids.length === 0 || pr === null) usage();
       if (!flags.force) checkPrNotOpen(pr);
       const index = loadIndex();
+      // Unknown ids are reported and skipped by the `each` resolution inside
+      // done(); resolving them strictly here would abort the whole bundle.
       for (const id of ids) {
-        checkCheckboxesDone(splitFrontmatter(storyFilePath(index, id)).body, flags.force === true);
+        const file = findStoryFile(index, id);
+        if (file === null) continue;
+        checkCheckboxesDone(splitFrontmatter(file).body, flags.force === true);
       }
       done(ids, pr);
       const estLoc = ids.reduce<number | null>((sum, id) => {

--- a/scripts/tasks/cli.ts
+++ b/scripts/tasks/cli.ts
@@ -1074,7 +1074,9 @@ export function extractMarkdownlintViolations(stderr: string): string[] {
 // retry) only after two consecutive lost races.
 export function commitAndPush(opts: {
   message: string;
-  fileToStage: string;
+  // One path, or several when a variadic verb (`claim a b c`) mutates N story
+  // files in the single commit this call produces.
+  fileToStage: string | string[];
   mutator: () => void;
   raceMessage: string;
   raceExitCode: number;
@@ -1221,7 +1223,12 @@ export function commitAndPush(opts: {
         // ends up with two dirs for one RFC. When it repaired anything the
         // mutation's own path may have moved, so stage everything.
         const reconciled = reconcileDuplicateRfcDirs(cwd);
-        git(["add", reconciled ? "-A" : opts.fileToStage], { cwd });
+        const toStage = reconciled
+          ? ["-A"]
+          : Array.isArray(opts.fileToStage)
+            ? opts.fileToStage
+            : [opts.fileToStage];
+        git(["add", ...toStage], { cwd });
         // RFCS_NO_AUTOPUSH: the tasks repo's .husky/post-commit hook otherwise
         // pushes `main` after this commit, racing the explicit push below (and,
         // back when the CLI still hard-reset the checkout on reads, occasionally
@@ -1332,24 +1339,62 @@ export function commitAndPush(opts: {
   if (earlyExit) process.exit(earlyExit.code);
 }
 
+// A story id paired with the file the index resolved it to. The variadic
+// status verbs carry the id alongside the path so per-id outcome lines can name
+// the story without a second index lookup.
+export interface StoryTarget {
+  id: string;
+  file: string;
+}
+
+// Resolve ids to story files. `"all"` (claim, release, and every single-id verb)
+// aborts the whole command on an unknown id — an atomic verb must write nothing
+// when part of its input is bogus. `"each"` (done, in-progress) drops the
+// unknown ids and proceeds with the rest, so one bad id in a bundle doesn't
+// strand the others behind a merged PR; it still exits 1 when nothing resolves.
+function storyTargets(index: Index, ids: string[], mode: "all" | "each"): StoryTarget[] {
+  if (mode === "all") return ids.map((id) => ({ id, file: storyFilePath(index, id) }));
+  const targets: StoryTarget[] = [];
+  for (const id of ids) {
+    const entry = index.stories.find((s) => s.id === id);
+    if (!entry) {
+      console.error(`error: story "${id}" not found in index — skipping`);
+      continue;
+    }
+    targets.push({ id, file: join(TASKS_DIR, entry.file_path) });
+  }
+  if (targets.length === 0) {
+    // loadIndex() may have rebuilt and so dirtied the generated index files;
+    // restore them before this error exit (matches storyFilePath).
+    restoreGeneratedFiles(TASKS_DIR);
+    console.error(`error: no known stories among: ${ids.join(", ")}`);
+    process.exit(1);
+  }
+  return targets;
+}
+
 // All mutations enter via `flip`. The order — `inGitTasks()` then
 // `loadIndex()` — matters: if `$TASKS_DIR` is missing or not a git repo,
 // the friendly error from `inGitTasks` fires before `loadIndex` would try
 // to `execFileSync` the tasks-side build script in a non-repo directory.
-// `mutate` receives the resolved file path so command implementations
-// don't repeat the lookup.
+// `mutate` receives the resolved targets so command implementations don't
+// repeat the lookup. It sees ALL of them at once (not one call per id) so an
+// atomic verb can validate the whole batch against the post-pull state before
+// writing anything, and returns the files it actually wrote — only those get
+// their `updated` stamped, so a skipped id contributes no diff.
 function flip(
-  id: string,
+  ids: string[],
   message: string,
   raceMessage: string,
   raceExitCode: number,
-  mutate: (file: string) => void,
+  mutate: (targets: StoryTarget[]) => string[] | void,
+  mode: "all" | "each" = "all",
 ): void {
   inGitTasks();
-  const file = storyFilePath(loadIndex(), id);
+  const targets = storyTargets(loadIndex(), ids, mode);
   commitAndPush({
     message,
-    fileToStage: file,
+    fileToStage: targets.map((t) => t.file),
     raceMessage,
     raceExitCode,
     // Per-worktree checkout: HEAD:main pushes the mutation regardless of
@@ -1358,8 +1403,8 @@ function flip(
     // stale content to origin/main.
     pushRefspec: TASKS_DIR_IS_SYMLINK ? "HEAD:main" : "main",
     mutator: () => {
-      mutate(file);
-      editFrontmatter(file, { updated: today() });
+      const written = mutate(targets) ?? targets.map((t) => t.file);
+      for (const file of written) editFrontmatter(file, { updated: today() });
     },
   });
 }
@@ -1387,11 +1432,42 @@ export function claimState(fileText: string, assignee: string): "available" | "o
   return held === assignee ? "owned" : "taken";
 }
 
-function claim(id: string, assignee: string): void {
-  flip(id, `claim: ${id}`, `lost claim race on ${id} — pick another story`, 3, (file) => {
-    const fm = readFileSync(file, "utf8");
-    const state = claimState(fm, assignee);
-    if (state === "owned") {
+// Partitions a whole `claim` batch by claimState, so the atomicity decision is
+// made once over all ids before any write. Pure (no I/O) and exported so the
+// partial-failure rule — one taken id refuses the entire batch — is unit-
+// testable without a git repo.
+export function claimBatch(
+  texts: { id: string; text: string }[],
+  assignee: string,
+): { available: string[]; owned: string[]; taken: string[] } {
+  const available: string[] = [];
+  const owned: string[] = [];
+  const taken: string[] = [];
+  for (const { id, text } of texts) {
+    const state = claimState(text, assignee);
+    (state === "available" ? available : state === "owned" ? owned : taken).push(id);
+  }
+  return { available, owned, taken };
+}
+
+// `claim` is all-or-nothing across its ids: a bundle worker that claims 3 of 5
+// stories and then aborts leaves the other 2 `claimed` with nobody behind them
+// — invisible to `ready` (not ready) and to the merge sweep (no PR), i.e.
+// silently dropped from the backlog. So the whole batch is validated against the
+// post-pull state before ANY write, and a single taken id refuses the lot.
+function claim(ids: string[], assignee: string): void {
+  const list = ids.join(", ");
+  flip(ids, `claim: ${list}`, `lost claim race on ${list} — pick another story`, 3, (targets) => {
+    const batch = claimBatch(
+      targets.map((t) => ({ id: t.id, text: readFileSync(t.file, "utf8") })),
+      assignee,
+    );
+    if (batch.taken.length > 0) {
+      console.error(`error: ${batch.taken.join(", ")} is already claimed`);
+      throw new MutatorEarlyExit(2);
+    }
+    const available = targets.filter((t) => batch.available.includes(t.id));
+    if (available.length === 0) {
       // Idempotent re-claim. `claim` is run more than once for the same story
       // across separate invocations — e.g. a prior `claim` pushed the claim to
       // main but then errored client-side (commitAndPush exits 1 on a non-race
@@ -1403,42 +1479,123 @@ function claim(id: string, assignee: string): void {
       // push never landed and the claim is still null or held by someone else.)
       // This runs inside commitAndPush's lock; throw the early-exit sentinel
       // (not process.exit, which would skip the lock's `finally` and leak it).
-      console.log(`claimed ${id} as ${assignee}`);
+      for (const id of ids) console.log(`claimed ${id} as ${assignee}`);
       throw new MutatorEarlyExit(0);
     }
-    if (state === "taken") {
-      console.error(`error: ${id} is already claimed`);
-      throw new MutatorEarlyExit(2);
-    }
     const now = new Date().toISOString().replace(/\.\d+Z$/, "Z");
-    editFrontmatter(file, {
-      status: "claimed",
-      claim: JSON.stringify(now),
-      assignee: JSON.stringify(assignee),
-    });
+    for (const s of available) {
+      editFrontmatter(s.file, {
+        status: "claimed",
+        claim: JSON.stringify(now),
+        assignee: JSON.stringify(assignee),
+      });
+    }
+    return available.map((s) => s.file);
   });
-  console.log(`claimed ${id} as ${assignee}`);
+  for (const id of ids) console.log(`claimed ${id} as ${assignee}`);
 }
 
 const RETRY_MSG = (id: string) => `failed to update ${id} after retry — pull manually and retry`;
 
-function inProgress(id: string, pr: number): void {
-  flip(id, `in-progress: ${id} #${pr}`, RETRY_MSG(id), 4, (file) =>
-    editFrontmatter(file, { status: "in-progress", pr: String(pr) }),
-  );
-  console.log(`marked ${id} in-progress #${pr}`);
+// Decides, per id, whether a `done`/`in-progress` flip has anything to write.
+// Pure so the per-id resilience branch is unit-testable without a git repo:
+// re-marking a story that already carries this exact status+pr is a skip, not a
+// failure — a bundle whose PR merged mid-way must be completable by re-running
+// the same command, and one already-done id must not abort the rest.
+export function trackingSkip(fileText: string, status: StoryStatus, pr: number): boolean {
+  return statusOf(fileText) === status && prOf(fileText) === pr;
 }
 
-function done(id: string, pr: number): void {
-  flip(id, `done: ${id} #${pr}`, RETRY_MSG(id), 4, (file) =>
-    editFrontmatter(file, { status: "done", pr: String(pr) }),
+// Shared body of `in-progress` and `done`: both stamp status + pr on each id
+// independently (best-effort), reporting one outcome line per story.
+function markTracking(ids: string[], status: "in-progress" | "done", pr: number): void {
+  const list = ids.join(", ");
+  flip(
+    ids,
+    `${status}: ${list} #${pr}`,
+    RETRY_MSG(list),
+    4,
+    (targets) => {
+      const written: string[] = [];
+      for (const { id, file } of targets) {
+        if (trackingSkip(readFileSync(file, "utf8"), status, pr)) {
+          console.log(`${id} already ${status} #${pr} — skipping`);
+          continue;
+        }
+        editFrontmatter(file, { status, pr: String(pr) });
+        written.push(file);
+      }
+      if (written.length === 0) {
+        // Every id was already in the target state; there is nothing to commit
+        // and `git commit` would error "nothing to commit". Bail cleanly (the
+        // sentinel, not process.exit, so commitAndPush releases its lock).
+        throw new MutatorEarlyExit(0);
+      }
+      return written;
+    },
+    "each",
   );
-  console.log(`marked ${id} done #${pr}`);
+  for (const id of ids) console.log(`marked ${id} ${status} #${pr}`);
 }
+
+function inProgress(ids: string[], pr: number): void {
+  markTracking(ids, "in-progress", pr);
+}
+
+function done(ids: string[], pr: number): void {
+  markTracking(ids, "done", pr);
+}
+
+// The inverse of `claim`: hand claimed stories back to the ready queue. Without
+// it, recovering a stranded claim (a worker that died between claims, or lost
+// the race partway through a bundle) meant hand-editing frontmatter —
+// `STATUS_TRANSITIONS.claimed` is empty, so `status-set` refuses it.
+function release(ids: string[]): void {
+  const list = ids.join(", ");
+  flip(ids, `release: ${list}`, RETRY_MSG(list), 4, (targets) => {
+    const states = targets.map((t) => ({ ...t, from: statusOf(readFileSync(t.file, "utf8")) }));
+    const illegal = states.filter((s) => releaseError(s.from) !== null);
+    if (illegal.length > 0) {
+      for (const s of illegal) console.error(`error: ${releaseError(s.from)} for ${s.id}`);
+      throw new MutatorEarlyExit(2);
+    }
+    const claimed = states.filter((s) => s.from === "claimed");
+    if (claimed.length === 0) {
+      for (const s of states) console.log(`${s.id} already ready`);
+      throw new MutatorEarlyExit(0);
+    }
+    for (const s of claimed) editFrontmatter(s.file, RELEASE_EDITS);
+    return claimed.map((s) => s.file);
+  });
+  for (const id of ids) console.log(`released ${id}`);
+}
+
+// Pure guard for `release`, unit-testable without a git repo. Returns null when
+// the id is releasable — `claimed` (the real move) or `ready` (already there,
+// handled by the caller as a clean no-op) — else a rejection reason. An
+// in-progress/done story has a PR behind it, so releasing it would orphan work.
+export function releaseError(from: string | null): string | null {
+  if (from === null) return `cannot read current status`;
+  if (from === "claimed" || from === "ready") return null;
+  return `only a claimed story can be released (status ${from})`;
+}
+
+// Frontmatter edits `release` stamps: back to the ready queue with the claim
+// cleared. `claimState` reads any non-null `claim` as taken, so both keys must
+// go or the readied story would be unclaimable. `pr` is untouched — a claimed
+// story has none.
+export const RELEASE_EDITS: Record<string, string> = {
+  status: "ready",
+  claim: "null",
+  assignee: "null",
+};
 
 function block(id: string, reason: string): void {
-  flip(id, `block: ${id} — ${reason}`, RETRY_MSG(id), 4, (file) =>
-    editFrontmatter(file, { status: "blocked", "blocked-by": JSON.stringify(reason) }),
+  flip([id], `block: ${id} — ${reason}`, RETRY_MSG(id), 4, (targets) =>
+    editFrontmatter(targets[0].file, {
+      status: "blocked",
+      "blocked-by": JSON.stringify(reason),
+    }),
   );
   console.log(`blocked ${id}: ${reason}`);
 }
@@ -1477,7 +1634,8 @@ export function closeEdits(reason: string): Record<string, string> {
 // mutator (post-`git pull`) so a story a concurrent agent just closed (or
 // completed) is never clobbered.
 function close(id: string, reason: string): void {
-  flip(id, `close: ${id} — ${reason}`, RETRY_MSG(id), 4, (file) => {
+  flip([id], `close: ${id} — ${reason}`, RETRY_MSG(id), 4, (targets) => {
+    const file = targets[0].file;
     const from = statusOf(readFileSync(file, "utf8"));
     if (from === "closed") {
       // A concurrent agent already closed it; the pull brought that back.
@@ -1517,7 +1675,8 @@ function setPriority(id: string, priority: number | null): void {
     return;
   }
   const message = priority === null ? `priority clear: ${id}` : `priority ${priority}: ${id}`;
-  flip(id, message, RETRY_MSG(id), 4, (file) => {
+  flip([id], message, RETRY_MSG(id), 4, (targets) => {
+    const file = targets[0].file;
     if (priority === null) removeFrontmatterKey(file, "priority");
     else editFrontmatter(file, { priority: String(priority) });
   });
@@ -1571,6 +1730,20 @@ export function statusOf(fileText: string): string | null {
     return null;
   }
   return typeof fm.status === "string" ? fm.status : null;
+}
+
+// Reads the `pr:` scalar from a story file's frontmatter (null when unset or
+// non-numeric), with the same YAML semantics as statusOf. Used by the
+// done/in-progress skip check to tell "already marked for THIS pr" (a re-run of
+// the same command) from "marked for a different pr" (a real update).
+export function prOf(fileText: string): number | null {
+  let fm: Record<string, unknown>;
+  try {
+    fm = (parseYaml(frontmatterBlock(fileText)) ?? {}) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+  return typeof fm.pr === "number" ? fm.pr : null;
 }
 
 // Pure transition check, unit-testable without a git repo. Returns null when the
@@ -1637,7 +1810,8 @@ function setStatus(id: string, target: StoryStatus): void {
     console.error(`error: ${preError} for ${id}`);
     process.exit(2);
   }
-  flip(id, `status ${target}: ${id}`, RETRY_MSG(id), 4, (file) => {
+  flip([id], `status ${target}: ${id}`, RETRY_MSG(id), 4, (targets) => {
+    const file = targets[0].file;
     const fresh = statusOf(readFileSync(file, "utf8"));
     if (fresh === target) {
       // Concurrent agent already landed this exact move; the pull brought it
@@ -1952,7 +2126,9 @@ function setDeps(id: string, kind: "deps" | "deps-rfc", csv: string): void {
   }
 
   const cmd = kind === "deps" ? "set-deps" : "set-deps-rfc";
-  flip(id, `${cmd}: ${id}`, RETRY_MSG(id), 4, (file) => setFrontmatterList(file, kind, items));
+  flip([id], `${cmd}: ${id}`, RETRY_MSG(id), 4, (targets) =>
+    setFrontmatterList(targets[0].file, kind, items),
+  );
   console.log(`set ${id} ${kind} = [${items.join(", ")}]`);
 }
 
@@ -3199,30 +3375,42 @@ function main(): void {
       );
       break;
     case "claim": {
-      const id = pos[0];
+      const ids = pos;
       const assignee = stringFlag(flags, "assignee");
-      if (!id) usage();
-      claim(id, assignee ?? id);
+      if (ids.length === 0) usage();
+      claim(ids, assignee ?? ids[0]);
+      break;
+    }
+    case "release": {
+      const ids = pos;
+      if (ids.length === 0) usage();
+      release(ids);
       break;
     }
     case "in-progress": {
-      const id = pos[0];
+      const ids = pos;
       const pr = numberFlag(flags, "pr");
-      if (!id || pr === null) usage();
-      inProgress(id, pr);
+      if (ids.length === 0 || pr === null) usage();
+      inProgress(ids, pr);
       break;
     }
     case "done": {
-      const id = pos[0];
+      const ids = pos;
       const pr = numberFlag(flags, "pr");
-      if (!id || pr === null) usage();
+      if (ids.length === 0 || pr === null) usage();
       if (!flags.force) checkPrNotOpen(pr);
       const index = loadIndex();
-      const file = storyFilePath(index, id);
-      checkCheckboxesDone(splitFrontmatter(file).body, flags.force === true);
-      done(id, pr);
-      const entry = index.stories.find((s) => s.id === id);
-      const delta = prLocDelta(pr, entry?.est_loc ?? null);
+      for (const id of ids) {
+        checkCheckboxesDone(splitFrontmatter(storyFilePath(index, id)).body, flags.force === true);
+      }
+      done(ids, pr);
+      // One PR carries the whole bundle, so the estimate it is measured against
+      // is the sum of the stories marked done by this call.
+      const estLoc = ids.reduce<number | null>((sum, id) => {
+        const est = index.stories.find((s) => s.id === id)?.est_loc ?? null;
+        return est === null ? sum : (sum ?? 0) + est;
+      }, null);
+      const delta = prLocDelta(pr, estLoc);
       if (delta) console.log(delta);
       break;
     }
@@ -3386,9 +3574,10 @@ function usage(): never {
   show <id>
   status
 
-  claim <id> [--assignee <name>]
-  in-progress <id> --pr <N>
-  done <id> --pr <N> [--force]
+  claim <id...> [--assignee <name>]            (all-or-nothing across ids: one commit, one lock)
+  release <id...>                              (claimed → ready, clearing the claim; the inverse of claim)
+  in-progress <id...> --pr <N>
+  done <id...> --pr <N> [--force]
   block <id> --reason "<text>"
   close <id> --reason "<text>"                 (terminally close a non-done story: superseded/abandoned/won't-do)
   refine <id> [--pr <N>] [--dir <tasks worktree>] [--force]


### PR DESCRIPTION
Makes the story-status verbs variadic so a bundle worker mutates N stories in
**one commit under one acquisition of the global tasks lock**, and adds the
missing inverse of `claim`.

```
pnpm tasks claim <id...> [--assignee <name>]
pnpm tasks release <id...>
pnpm tasks in-progress <id...> --pr <N>
pnpm tasks done <id...> --pr <N>
```

- `commitAndPush`'s `fileToStage` takes a list; `flip` resolves all ids up front
  and hands the whole batch to its mutator, stamping `updated` only on the files
  the mutator actually wrote (a skipped id contributes no diff).
- **`claim` is atomic.** `claimBatch` partitions the batch by `claimState`
  against the post-pull state before any write, so one lost race refuses the lot
  — no more stories left `claimed` with no worker behind them, invisible to both
  `ready` and the merge sweep (the `i18n-backend-key-value` failure). Exit codes
  are unchanged: 3 for a lost push race, 2 for an id held by someone else.
- **`done` / `in-progress` are per-id best-effort.** An unknown id, or one
  already carrying this exact status+pr, is reported and skipped without
  aborting the rest; `done` measures the PR against the summed `est-loc`.
- **`release <id...>`** moves `claimed → ready`, clearing `claim` + `assignee`
  (any non-null claim reads as taken, so both must go), and is a clean no-op on
  a story that is already `ready`. Recovering a stranded claim previously meant
  hand-editing frontmatter — `STATUS_TRANSITIONS.claimed` is empty, so
  `status-set` refuses it.

Single-id behaviour, messages and exit codes are unchanged; all 323 existing
`cli.test.ts` tests pass untouched. New tests cover multi-file staging in one
add/commit/push, `claim` partial-failure atomicity, `done` per-id skipping, and
a `release` round-trip of a claim.

Follow-on (not in this PR): simplify `buildBundlePrompt` in btwhooks to a single
`claim` / `done` call and delete the "release any you already claimed"
paragraph.

Closes-story: multi-id-story-status-verbs
