### PR TITLE
feat(i18n): accept MRI's sub-minute utc_offset in Time.new

### DIFF
--- a/packages/i18n/src/time.trails.test.ts
+++ b/packages/i18n/src/time.trails.test.ts
@@ -52,11 +52,20 @@ describe("Time", () => {
     expect(new Time(2008, 3, 1, 6, 0, 0, -32430).utcOffset).toBe(-32430);
     expect(new Time(2008, 3, 1, 6, 0, 0, "+09:00:30").strftime("%z")).toBe("+0900");
     expect(new Time(2008, 3, 1, 6, 0, 0, -32430).strftime("%z")).toBe("-0900");
+    expect(new Time(2008, 3, 1, 6, 0, 0, 32430.5).utcOffset).toBe(32430.5);
   });
 
   it("Time.new rejects an out-of-range offset", () => {
     expect(() => new Time(2008, 3, 1, 6, 0, 0, 86400)).toThrow(ArgumentError);
+    expect(() => new Time(2008, 3, 1, 6, 0, 0, -86400)).toThrow(ArgumentError);
+    expect(new Time(2008, 3, 1, 6, 0, 0, 86399).utcOffset).toBe(86399);
     expect(() => new Time(2008, 3, 1, 6, 0, 0, "+24:00:00")).toThrow(ArgumentError);
+  });
+
+  it("Time.new rejects a minute past 59 as a malformed offset", () => {
+    expect(() => new Time(2008, 3, 1, 6, 0, 0, "+00:60:00")).toThrow(/expected for utc_offset/);
+    expect(() => new Time(2008, 3, 1, 6, 0, 0, "+006000")).toThrow(/expected for utc_offset/);
+    expect(new Time(2008, 3, 1, 6, 0, 0, "+00:00:99").utcOffset).toBe(99);
   });
 
   it("Time.new rejects a zone name", () => {

--- a/packages/i18n/src/time.trails.test.ts
+++ b/packages/i18n/src/time.trails.test.ts
@@ -47,9 +47,9 @@ describe("Time", () => {
 
   it("Time.new takes a sub-minute offset, as MRI does", () => {
     expect(new Time(2008, 3, 1, 6, 0, 0, "+09:00:30").utcOffset).toBe(32430);
+    expect(new Time(2008, 3, 1, 6, 0, 0, "+090030").utcOffset).toBe(32430);
     expect(new Time(2008, 3, 1, 6, 0, 0, 32430).utcOffset).toBe(32430);
     expect(new Time(2008, 3, 1, 6, 0, 0, -32430).utcOffset).toBe(-32430);
-    // `%z` is `±HHMM`, so MRI drops the seconds there.
     expect(new Time(2008, 3, 1, 6, 0, 0, "+09:00:30").strftime("%z")).toBe("+0900");
     expect(new Time(2008, 3, 1, 6, 0, 0, -32430).strftime("%z")).toBe("-0900");
   });

--- a/packages/i18n/src/time.trails.test.ts
+++ b/packages/i18n/src/time.trails.test.ts
@@ -45,6 +45,20 @@ describe("Time", () => {
     expect(new Time(2008, 3, 1, 6, 0, 0, "Z").strftime("%z %Z")).toBe("+0000 UTC");
   });
 
+  it("Time.new takes a sub-minute offset, as MRI does", () => {
+    expect(new Time(2008, 3, 1, 6, 0, 0, "+09:00:30").utcOffset).toBe(32430);
+    expect(new Time(2008, 3, 1, 6, 0, 0, 32430).utcOffset).toBe(32430);
+    expect(new Time(2008, 3, 1, 6, 0, 0, -32430).utcOffset).toBe(-32430);
+    // `%z` is `±HHMM`, so MRI drops the seconds there.
+    expect(new Time(2008, 3, 1, 6, 0, 0, "+09:00:30").strftime("%z")).toBe("+0900");
+    expect(new Time(2008, 3, 1, 6, 0, 0, -32430).strftime("%z")).toBe("-0900");
+  });
+
+  it("Time.new rejects an out-of-range offset", () => {
+    expect(() => new Time(2008, 3, 1, 6, 0, 0, 86400)).toThrow(ArgumentError);
+    expect(() => new Time(2008, 3, 1, 6, 0, 0, "+24:00:00")).toThrow(ArgumentError);
+  });
+
   it("Time.new rejects a zone name", () => {
     expect(() => new Time(2008, 3, 1, 6, 0, 0, "America/New_York")).toThrow(ArgumentError);
   });

--- a/packages/i18n/src/time.ts
+++ b/packages/i18n/src/time.ts
@@ -11,21 +11,20 @@ import { Temporal } from "@js-temporal/polyfill";
 import { ArgumentError, strftime } from "./date.js";
 
 /**
- * The `utc_offset` argument MRI's `Time.new` accepts, resolved to something
- * `Temporal` takes: `"UTC"`, an offset — `"+09"`, `"+0900"`, `"+09:00"` or a
- * number of seconds east of UTC, which is the form Rails passes
+ * The `utc_offset` argument MRI's `Time.new` accepts: `"UTC"`, an offset —
+ * `"+09"`, `"+0900"`, `"+09:00"`, `"+09:00:30"` or a number of seconds east of
+ * UTC, which is the form Rails passes
  * (`activesupport/lib/active_support/core_ext/string/conversions.rb:28`,
  * `core_ext/time/calculations.rb:172-175`) — or one of the military zone
  * letters (`A`..`I` = +1..+9, `K`..`M` = +10..+12, `N`..`Y` = -1..-12, and
- * `Z`, which MRI treats as UTC itself rather than as a zero offset). Anything else raises with MRI's message; an IANA name like
- * `"America/New_York"` is not a `Time.new` zone, it is what a `TimeZone`
- * object wraps.
+ * `Z`, which MRI treats as UTC itself rather than as a zero offset). Anything
+ * else raises with MRI's message; an IANA name like `"America/New_York"` is
+ * not a `Time.new` zone, it is what a `TimeZone` object wraps.
  *
  * The answer is `"UTC"` — the one zone `Time.new` names — or the offset in
- * seconds east of UTC, which is how the receiver carries it. MRI takes a
- * sub-minute offset (`"+09:00:30"` is `32430`), so the offset is a number
- * trails owns rather than a `Temporal` offset time zone, which is
- * minute-precision.
+ * seconds east of UTC, which is how the receiver carries it: a number trails
+ * owns, so that MRI's sub-minute offsets are representable where a `Temporal`
+ * offset time zone (minute-precision) cannot hold them.
  */
 function utcOffsetArgument(zone: string | number): "UTC" | number {
   if (typeof zone === "number") {

--- a/packages/i18n/src/time.ts
+++ b/packages/i18n/src/time.ts
@@ -21,31 +21,33 @@ import { ArgumentError, strftime } from "./date.js";
  * `"America/New_York"` is not a `Time.new` zone, it is what a `TimeZone`
  * object wraps.
  *
- * MRI also takes a sub-minute offset. `Temporal` has no way to express one —
- * an offset time zone is minute-precision — so that one spelling raises here
- * where MRI accepts it. Rails never builds one: its offsets come from zone
- * tables and `Date._parse`, both of which are whole minutes.
+ * The answer is `"UTC"` — the one zone `Time.new` names — or the offset in
+ * seconds east of UTC, which is how the receiver carries it. MRI takes a
+ * sub-minute offset (`"+09:00:30"` is `32430`), so the offset is a number
+ * trails owns rather than a `Temporal` offset time zone, which is
+ * minute-precision.
  */
-function utcOffsetArgument(zone: string | number): string {
+function utcOffsetArgument(zone: string | number): "UTC" | number {
   if (typeof zone === "number") {
-    if (zone % 60 !== 0) throw new ArgumentError("utc_offset out of range");
-    const sign = zone < 0 ? "-" : "+";
-    const minutes = Math.abs(zone) / 60;
-    return `${sign}${pad2(Math.floor(minutes / 60))}:${pad2(minutes % 60)}`;
+    if (!Number.isInteger(zone) || Math.abs(zone) >= 86400) {
+      throw new ArgumentError("utc_offset out of range");
+    }
+    return zone;
   }
   // `"Z"` is the military letter for UTC, and MRI treats it as `Time.utc`
   // does — `zone` answers `"UTC"`, not `nil` as an offset-built time does.
   if (zone === "UTC" || zone === "Z") return "UTC";
-  if (/^[+-]\d{2}(:?\d{2})?$/.test(zone)) return zone;
-  if (/^[+-]\d{2}:\d{2}:\d{2}$/.test(zone)) {
-    if (!zone.endsWith(":00")) throw new ArgumentError("utc_offset out of range");
-    return zone.slice(0, 6);
+  const offset = /^([+-])(\d{2})(?::?(\d{2})(?::?(\d{2}))?)?$/.exec(zone);
+  if (offset) {
+    const [, sign, hour, min = "00", sec = "00"] = offset;
+    const seconds = Number(hour) * 3600 + Number(min) * 60 + Number(sec);
+    if (seconds >= 86400) throw new ArgumentError("utc_offset out of range");
+    return sign === "-" ? -seconds : seconds;
   }
   if (/^[A-IK-Y]$/.test(zone)) {
     const code = zone.charCodeAt(0);
     const hours = code <= 73 ? code - 64 : code <= 77 ? code - 65 : 77 - code;
-    const sign = hours < 0 ? "-" : "+";
-    return `${sign}${pad2(Math.abs(hours))}:00`;
+    return hours * 3600;
   }
   throw new ArgumentError('"+HH:MM", "-HH:MM", "UTC" or "A".."I","K".."Z" expected for utc_offset');
 }
@@ -62,8 +64,10 @@ function pad2(n: number): string {
  */
 export class Time {
   readonly #plain: Temporal.PlainDateTime;
-  /** @internal The receiver's zone — Ruby's `Time#zone`/`#utc_offset` source. */
-  readonly #zoned: Temporal.ZonedDateTime;
+  /** @internal The receiver's zone, or `null` when it was built from an offset. */
+  readonly #timeZoneId: string | null;
+  /** @internal Seconds east of UTC — Ruby's `Time#utc_offset`. */
+  readonly #utcOffset: number;
 
   /** Ruby `Time.utc(year, month, day, hour = 0, min = 0, sec = 0)`. */
   static utc(year: number, month: number, day: number, hour = 0, min = 0, sec = 0): Time {
@@ -86,9 +90,12 @@ export class Time {
     zone: string | number | null = null,
   ) {
     this.#plain = new Temporal.PlainDateTime(year, month, day, hour, min, sec);
-    this.#zoned = this.#plain.toZonedDateTime(
-      zone == null ? Temporal.Now.timeZoneId() : utcOffsetArgument(zone),
-    );
+    const utcOffset = zone == null ? Temporal.Now.timeZoneId() : utcOffsetArgument(zone);
+    this.#timeZoneId = typeof utcOffset === "number" ? null : utcOffset;
+    this.#utcOffset =
+      typeof utcOffset === "number"
+        ? utcOffset
+        : Number(this.#plain.toZonedDateTime(utcOffset).offsetNanoseconds) / 1_000_000_000;
   }
 
   get year(): number {
@@ -135,22 +142,25 @@ export class Time {
    * abbreviation to answer and Ruby returns `nil`, which `%Z` prints as "".
    */
   get zone(): string | null {
-    if (/^[+-]\d{2}:?\d{2}$/.test(this.#zoned.timeZoneId)) return null;
+    if (this.#timeZoneId == null) return null;
     const parts = new Intl.DateTimeFormat("en-US", {
-      timeZone: this.#zoned.timeZoneId,
+      timeZone: this.#timeZoneId,
       timeZoneName: "short",
-    }).formatToParts(new globalThis.Date(this.#zoned.epochMilliseconds));
+    }).formatToParts(
+      new globalThis.Date(this.#plain.toZonedDateTime(this.#timeZoneId).epochMilliseconds),
+    );
     return parts.find((part) => part.type === "timeZoneName")!.value;
   }
 
   /** Ruby `Time#utc_offset`, the receiver's offset from UTC in seconds. */
   get utcOffset(): number {
-    return Number(this.#zoned.offsetNanoseconds) / 1_000_000_000;
+    return this.#utcOffset;
   }
 
   strftime(format: string): string {
     // `%z` is `±HHMM` — neither `Time#zone` nor `Temporal`'s extended `±HH:MM`.
-    const minutes = Math.abs(this.utcOffset) / 60;
+    // MRI truncates a sub-minute offset there; `utc_offset` keeps the seconds.
+    const minutes = Math.floor(Math.abs(this.utcOffset) / 60);
     const zoneOffset = `${this.utcOffset < 0 ? "-" : "+"}${pad2(Math.floor(minutes / 60))}${pad2(minutes % 60)}`;
     return strftime(
       {

--- a/packages/i18n/src/time.ts
+++ b/packages/i18n/src/time.ts
@@ -37,9 +37,11 @@ function utcOffsetArgument(zone: string | number): "UTC" | number {
   // `"Z"` is the military letter for UTC, and MRI treats it as `Time.utc`
   // does — `zone` answers `"UTC"`, not `nil` as an offset-built time does.
   if (zone === "UTC" || zone === "Z") return "UTC";
-  const offset = /^([+-])(\d{2})(?::?(\d{2})(?::?(\d{2}))?)?$/.exec(zone);
+  const offset = /^([+-])(\d{2})(?::(\d{2})(?::(\d{2}))?|(\d{2})(\d{2})?)?$/.exec(zone);
   if (offset) {
-    const [, sign, hour, min = "00", sec = "00"] = offset;
+    const [, sign, hour, colonMin, colonSec, compactMin, compactSec] = offset;
+    const min = colonMin ?? compactMin ?? "00";
+    const sec = colonSec ?? compactSec ?? "00";
     const seconds = Number(hour) * 3600 + Number(min) * 60 + Number(sec);
     if (seconds >= 86400) throw new ArgumentError("utc_offset out of range");
     return sign === "-" ? -seconds : seconds;
@@ -159,7 +161,6 @@ export class Time {
 
   strftime(format: string): string {
     // `%z` is `±HHMM` — neither `Time#zone` nor `Temporal`'s extended `±HH:MM`.
-    // MRI truncates a sub-minute offset there; `utc_offset` keeps the seconds.
     const minutes = Math.floor(Math.abs(this.utcOffset) / 60);
     const zoneOffset = `${this.utcOffset < 0 ? "-" : "+"}${pad2(Math.floor(minutes / 60))}${pad2(minutes % 60)}`;
     return strftime(

--- a/packages/i18n/src/time.ts
+++ b/packages/i18n/src/time.ts
@@ -25,10 +25,16 @@ import { ArgumentError, strftime } from "./date.js";
  * seconds east of UTC, which is how the receiver carries it: a number trails
  * owns, so that MRI's sub-minute offsets are representable where a `Temporal`
  * offset time zone (minute-precision) cannot hold them.
+ *
+ * MRI rejects a minute past 59 as a malformed spelling — `"+00:60:00"` gets the
+ * `expected for utc_offset` message, not `"utc_offset out of range"` — while a
+ * second past 59 it takes (`"+00:00:99"` is `99`), bounded only by the total
+ * `86400`. A numeric offset needs no whole-second bound either: MRI takes a
+ * `Float`/`Rational` and answers it back from `utc_offset`.
  */
 function utcOffsetArgument(zone: string | number): "UTC" | number {
   if (typeof zone === "number") {
-    if (!Number.isInteger(zone) || Math.abs(zone) >= 86400) {
+    if (!Number.isFinite(zone) || Math.abs(zone) >= 86400) {
       throw new ArgumentError("utc_offset out of range");
     }
     return zone;
@@ -41,9 +47,11 @@ function utcOffsetArgument(zone: string | number): "UTC" | number {
     const [, sign, hour, colonMin, colonSec, compactMin, compactSec] = offset;
     const min = colonMin ?? compactMin ?? "00";
     const sec = colonSec ?? compactSec ?? "00";
-    const seconds = Number(hour) * 3600 + Number(min) * 60 + Number(sec);
-    if (seconds >= 86400) throw new ArgumentError("utc_offset out of range");
-    return sign === "-" ? -seconds : seconds;
+    if (Number(min) < 60) {
+      const seconds = Number(hour) * 3600 + Number(min) * 60 + Number(sec);
+      if (seconds >= 86400) throw new ArgumentError("utc_offset out of range");
+      return sign === "-" ? -seconds : seconds;
+    }
   }
   if (/^[A-IK-Y]$/.test(zone)) {
     const code = zone.charCodeAt(0);


### PR DESCRIPTION
`Time` carried its zone as a `Temporal.ZonedDateTime`, and a Temporal offset
time zone is minute-precision — so `utcOffsetArgument` raised
`ArgumentError` for a sub-minute `utc_offset` that MRI accepts
(`Time.new(2008, 3, 1, 6, 0, 0, "+09:00:30").utc_offset # => 32430`).

The receiver now keeps the `PlainDateTime` plus the offset in seconds
(`#utcOffset`) and the zone id only when it was built from a named zone
(`#timeZoneId`, `null` for an offset-built time — which is what `Time#zone`
answers `nil` for). `utcOffsetArgument` answers `"UTC"` or a second count
instead of a Temporal zone id, so every offset MRI accepts is representable
and the sub-minute raise is gone; the MRI "utc_offset out of range" message
stays for the spellings MRI itself rejects (|offset| >= 86400, non-integer
seconds). `%z` stays `±HHMM` and truncates the seconds, as MRI does;
`utc_offset` answers the full count.

Rails anchor: the only callers reaching core `Time.new` with an offset are
`activesupport/lib/active_support/core_ext/string/conversions.rb:28-35` and
`core_ext/time/calculations.rb:172-175`, both whole minutes — unchanged here.

Closes-story: i18n-time-subminute-utc-offset


**Review round 1:** `utcOffsetArgument` now rejects a minute past 59 as a malformed spelling (MRI gives the `expected for utc_offset` message there, not `out of range`), keeps taking a second past 59 (`"+00:00:99"` is `99`, bounded only by the `86400` total), and takes a fractional numeric offset as MRI takes a `Float`/`Rational`. All three are covered.
