### PR TITLE
feat(i18n): port the seven date__parse sub-parsers Date._parse omitted

### DIFF
--- a/packages/i18n/src/date.trails.test.ts
+++ b/packages/i18n/src/date.trails.test.ts
@@ -101,6 +101,58 @@ describe("Date", () => {
     expect(() => RubyDate.parse("10:30")).toThrow("invalid date");
   });
 
+  it("reads the one-fragment strings parse_year, parse_mon and parse_mday take", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2008-08-04T12:00:00Z"));
+    try {
+      const mday = RubyDate.parse("3rd");
+      expect([mday.year, mday.mon, mday.day]).toEqual([2008, 8, 3]);
+      const mon = RubyDate.parse("Feb");
+      expect([mon.year, mon.mon, mon.day]).toEqual([2008, 2, 1]);
+    } finally {
+      vi.useRealTimers();
+    }
+    const year = RubyDate.parse("'01");
+    expect([year.year, year.mon, year.day]).toEqual([2001, 1, 1]);
+  });
+
+  it("reads the VMS date either way round, as parse_vms does", () => {
+    for (const str of ["3-FEB-2001", "FEB-3-2001"]) {
+      const date = RubyDate.parse(str);
+      expect([str, date.year, date.mon, date.day]).toEqual([str, 2001, 2, 3]);
+    }
+  });
+
+  it("reads a JIS X 0301 date, as parse_jis does", () => {
+    const heisei = RubyDate.parse("H13.02.03");
+    expect([heisei.year, heisei.mon, heisei.day]).toEqual([2001, 2, 3]);
+    const meiji = RubyDate.parse("M6.5.4");
+    expect([meiji.year, meiji.mon, meiji.day]).toEqual([1873, 5, 4]);
+  });
+
+  it("reads the ISO spellings parse_iso does not take, as parse_iso2 does", () => {
+    const ordinal = RubyDate.parse("2001-034");
+    expect([ordinal.year, ordinal.mon, ordinal.day]).toEqual([2001, 2, 3]);
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2008-08-04T12:00:00Z"));
+    try {
+      for (const str of ["--0203", "--02-03"]) {
+        const date = RubyDate.parse(str);
+        expect([str, date.year, date.mon, date.day]).toEqual([str, 2008, 2, 3]);
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+    expect(RubyDate._parse("2001-W05-6")).toEqual({ cwyear: 2001, cweek: 5, cwday: 6 });
+  });
+
+  it("negates the year of a BC date, as parse_bc does", () => {
+    expect(RubyDate.parse("4004-01-02 BC").year).toBe(-4003);
+    expect(RubyDate.parse("feb 3 4004 b.c.e.").year).toBe(-4003);
+    expect(RubyDate.parse("70-1-2 BC").year).toBe(-69);
+    expect(() => RubyDate.parse("4004 BC")).toThrow("invalid date");
+  });
+
   it("leaves a signed year uncompleted, as date_parse.c does", () => {
     expect(RubyDate.parse("-08-07-02").year).toBe(-8);
     expect(RubyDate.parse("+08-07-02").year).toBe(8);

--- a/packages/i18n/src/date.trails.test.ts
+++ b/packages/i18n/src/date.trails.test.ts
@@ -123,6 +123,18 @@ describe("Date", () => {
     }
   });
 
+  it("reads an apostrophized VMS year as the year, as s3e does", () => {
+    for (const str of ["'01-FEB-3", "3-FEB-'01"]) {
+      const date = RubyDate.parse(str);
+      expect([str, date.year, date.mon, date.day]).toEqual([str, 2001, 2, 3]);
+    }
+  });
+
+  it("reads the era parse_eu and parse_us match, not only the trailing one", () => {
+    expect(RubyDate.parse("july 4 1776 b.c.").year).toBe(-1775);
+    expect(RubyDate.parse("1 jan 2008 ad").year).toBe(2008);
+  });
+
   it("reads a JIS X 0301 date, as parse_jis does", () => {
     const heisei = RubyDate.parse("H13.02.03");
     expect([heisei.year, heisei.mon, heisei.day]).toEqual([2001, 2, 3]);

--- a/packages/i18n/src/date.ts
+++ b/packages/i18n/src/date.ts
@@ -202,11 +202,12 @@ function monNum(str: string): number {
  *
  * A signed year is never completable (`date_parse.c:172-181`, `:250-251`), so
  * `"-08-07-02"` is year -8 rather than 1992.
+ *
+ * Each token is read from its first sign or digit (`date_parse.c:167-169`,
+ * `:204-206`, `:226-228`), so the apostrophe `parse_vms` captures is skipped —
+ * and, being outside the digit span, does not count towards the width either.
  */
 function s3e(y: string | null, m: string, d: string | null): DateParts {
-  // `date_parse.c:167-169`, `:204-206`, `:226-228`: each token is read from its
-  // first sign or digit, so the apostrophe `parse_vms` captures is skipped —
-  // and, being outside the digit span, does not count towards the width either.
   if (y !== null) y = y.replace(/^'/, "");
   if (d !== null) d = d.replace(/^'/, "");
   if (y === null && d !== null && d.length > 2) {
@@ -947,8 +948,11 @@ export class Date {
    * and only ever turns false, so an absent one is `comp`, and the year is
    * completed only within `0..99` (`date_parse.c:2267-2287`).
    *
-   * @missingRailsCall `date_zone_to_diff` (`date_parse.c:416-559`) is not
-   * ported, so the `:offset` a `:zone` also sets is missing
+   * @missingRailsCall `parse_frag` (`date_parse.c:2021-2052`) is not ported:
+   * its pattern is anchored to the whole string, so it reads the leftover
+   * Ruby's `subx` leaves behind, which the ported sub-parsers do not produce.
+   * Neither is `date_zone_to_diff` (`date_parse.c:416-559`), so the `:offset`
+   * a `:zone` also sets is missing
    * from both of its call sites — the tail of `date__parse` itself
    * (`date_parse.c:2290-2294`) and the bracketed zone of `parse_ddd_cb`
    * (`date_parse.c:1934-1960`). It reads a zone-name table `::Date` has no use

--- a/packages/i18n/src/date.ts
+++ b/packages/i18n/src/date.ts
@@ -164,12 +164,16 @@ interface DateParts {
   mon?: number;
   mday?: number;
   yday?: number;
+  cwyear?: number;
+  cweek?: number;
+  cwday?: number;
   hour?: number;
   min?: number;
   sec?: number;
   secFraction?: number;
   zone?: string;
   _comp?: boolean;
+  _bc?: boolean;
 }
 
 /**
@@ -200,6 +204,11 @@ function monNum(str: string): number {
  * `"-08-07-02"` is year -8 rather than 1992.
  */
 function s3e(y: string | null, m: string, d: string | null): DateParts {
+  // `date_parse.c:167-169`, `:204-206`, `:226-228`: each token is read from its
+  // first sign or digit, so the apostrophe `parse_vms` captures is skipped —
+  // and, being outside the digit span, does not count towards the width either.
+  if (y !== null) y = y.replace(/^'/, "");
+  if (d !== null) d = d.replace(/^'/, "");
   if (y === null && d !== null && d.length > 2) {
     y = d;
     d = null;
@@ -363,6 +372,184 @@ function parseIso(str: string): DateParts | null {
   return m ? s3e(m[1], m[2], m[3]) : null;
 }
 
+/**
+ * @internal `date_parse.c` `parse_iso21` (`date_parse.c:1035-1070`): the
+ * commercial week date, `"2001-W05-6"` and the yearless `"-W061"`.
+ */
+function parseIso21(str: string): DateParts | null {
+  const m = /\b(\d{2}|\d{4})?-?w(\d{2})(?:-?(\d))?\b/i.exec(str);
+  if (m === null) return null;
+  const hash: DateParts = {};
+  const y = m[1];
+  const w = m[2];
+  const d = m[3];
+
+  if (y !== undefined) hash.cwyear = Number(y);
+  hash.cweek = Number(w);
+  if (d !== undefined) hash.cwday = Number(d);
+
+  return hash;
+}
+
+/** @internal `date_parse.c` `parse_iso22` (`date_parse.c:1073-1099`): `"-W-6"`, a commercial day alone. */
+function parseIso22(str: string): DateParts | null {
+  const m = /-w-(\d)\b/i.exec(str);
+  return m ? { cwday: Number(m[1]) } : null;
+}
+
+/** @internal `date_parse.c` `parse_iso23` (`date_parse.c:1103-1134`): `"--02-03"`, and `"---03"`. */
+function parseIso23(str: string): DateParts | null {
+  const m = /--(\d{2})?-(\d{2})\b/.exec(str);
+  if (m === null) return null;
+  const hash: DateParts = {};
+  const mon = m[1];
+  const d = m[2];
+
+  if (mon !== undefined) hash.mon = Number(mon);
+  hash.mday = Number(d);
+
+  return hash;
+}
+
+/** @internal `date_parse.c` `parse_iso24` (`date_parse.c:1138-1169`): the unseparated `"--0203"`. */
+function parseIso24(str: string): DateParts | null {
+  const m = /--(\d{2})(\d{2})?\b/.exec(str);
+  if (m === null) return null;
+  const hash: DateParts = {};
+  const mon = m[1];
+  const d = m[2];
+
+  hash.mon = Number(mon);
+  if (d !== undefined) hash.mday = Number(d);
+
+  return hash;
+}
+
+/**
+ * @internal `date_parse.c` `parse_iso25` (`date_parse.c:1173-1219`): the ordinal
+ * date `"2001-034"`. `pat0` declines the run that is a second fraction
+ * (`"1.2001-034"`), which `parse_ddd` reads instead.
+ */
+function parseIso25(str: string): DateParts | null {
+  const pat0 = /[,.](\d{2}|\d{4})-\d{3}\b/;
+  const pat = /\b(\d{2}|\d{4})-(\d{3})\b/;
+
+  if (pat0.exec(str) !== null) return null;
+  const m = pat.exec(str);
+  return m ? { year: Number(m[1]), yday: Number(m[2]) } : null;
+}
+
+/** @internal `date_parse.c` `parse_iso26` (`date_parse.c:1223-1265`): the yearless ordinal date `"-034"`. */
+function parseIso26(str: string): DateParts | null {
+  const pat0 = /\d-\d{3}\b/;
+  const pat = /\b-(\d{3})\b/;
+
+  if (pat0.exec(str) !== null) return null;
+  const m = pat.exec(str);
+  return m ? { yday: Number(m[1]) } : null;
+}
+
+/**
+ * @internal `date_parse.c` `parse_iso2` (`date_parse.c:1269-1287`): the ISO
+ * spellings `parse_iso` does not take.
+ */
+function parseIso2(str: string): DateParts | null {
+  return (
+    parseIso21(str) ??
+    parseIso22(str) ??
+    parseIso23(str) ??
+    parseIso24(str) ??
+    parseIso25(str) ??
+    parseIso26(str)
+  );
+}
+
+/**
+ * @internal `date_parse.c` `JISX0301_ERA_INITIALS` (`date_parse.c:1290`): the
+ * initials of the Japanese eras `parse_jis` takes.
+ */
+const JISX0301_ERA_INITIALS = "mtshr";
+
+/** @internal `date_parse.c` `gengo` (`date_parse.c:1293-1307`): the year an era counts from. */
+function gengo(c: string): number {
+  let e: number;
+
+  switch (c) {
+    case "M":
+    case "m":
+      e = 1867;
+      break;
+    case "T":
+    case "t":
+      e = 1911;
+      break;
+    case "S":
+    case "s":
+      e = 1925;
+      break;
+    case "H":
+    case "h":
+      e = 1988;
+      break;
+    case "R":
+    case "r":
+      e = 2018;
+      break;
+    default:
+      e = 0;
+      break;
+  }
+  return e;
+}
+
+/**
+ * @internal `date_parse.c` `parse_jis` (`date_parse.c:1309-1346`): the JIS X
+ * 0301 date, `"H13.02.03"` — Heisei 13, which is 2001.
+ */
+function parseJis(str: string): DateParts | null {
+  const m = new RegExp(`\\b([${JISX0301_ERA_INITIALS}])(\\d+)\\.(\\d+)\\.(\\d+)`, "i").exec(str);
+  if (m === null) return null;
+  const e = m[1];
+  const y = m[2];
+  const mon = m[3];
+  const d = m[4];
+
+  const ep = gengo(e[0]);
+
+  return { year: Number(y) + ep, mon: Number(mon), mday: Number(d) };
+}
+
+/** @internal `date_parse.c` `parse_vms11` (`date_parse.c:1349-1388`): `"3-FEB-2001"`. */
+function parseVms11(str: string): DateParts | null {
+  const m = new RegExp(`('?-?${NUMBER}+)-(${ABBR_MONTHS})[^-/.]*-('?-?\\d+)`, "i").exec(str);
+  if (m === null) return null;
+  const d = m[1];
+  let mon = m[2];
+  const y = m[3];
+
+  mon = String(monNum(mon));
+
+  return s3e(y, mon, d);
+}
+
+/** @internal `date_parse.c` `parse_vms12` (`date_parse.c:1391-1431`): `"FEB-3-2001"`, and `"FEB-3"`. */
+function parseVms12(str: string): DateParts | null {
+  const m = new RegExp(`\\b(${ABBR_MONTHS})[^-/.]*-('?-?\\d+)(?:-('?-?\\d+))?`, "i").exec(str);
+  if (m === null) return null;
+  let mon = m[1];
+  const d = m[2];
+  const y = m[3];
+
+  mon = String(monNum(mon));
+
+  return s3e(y ?? null, mon, d);
+}
+
+/** @internal `date_parse.c` `parse_vms` (`date_parse.c:1433-1444`): the VMS date, either way round. */
+function parseVms(str: string): DateParts | null {
+  return parseVms11(str) ?? parseVms12(str);
+}
+
 /** @internal `date_parse.c` `parse_sla`: `2012/12/13`, `01/01/2012`, `2008/07`. */
 function parseSla(str: string): DateParts | null {
   const m = /([-+]?\d+)\/\s*(\d+)(?:\D\s*(-?\d+))?/.exec(str);
@@ -373,6 +560,28 @@ function parseSla(str: string): DateParts | null {
 function parseDot(str: string): DateParts | null {
   const m = /([-+]?\d+)\.\s*(\d+)\.\s*(-?\d+)/.exec(str);
   return m ? s3e(m[1], m[2], m[3]) : null;
+}
+
+/** @internal `date_parse.c` `parse_year` (`date_parse.c:1662-1688`): the year alone, `"'01"`. */
+function parseYear(str: string): DateParts | null {
+  const m = /'(\d+)\b/.exec(str);
+  return m ? { year: Number(m[1]) } : null;
+}
+
+/** @internal `date_parse.c` `parse_mon` (`date_parse.c:1692-1718`): the month alone, `"Feb"`. */
+function parseMon(str: string): DateParts | null {
+  const m = new RegExp(`\\b(${ABBR_MONTHS})\\S*`, "i").exec(str);
+  return m ? { mon: monNum(m[1]) } : null;
+}
+
+/**
+ * @internal `date_parse.c` `parse_mday` (`date_parse.c:1722-1748`): the day of
+ * the month alone, `"3rd"`. It sits directly above `parse_ddd`, so an ordinal
+ * suffix is what tells the two apart.
+ */
+function parseMday(str: string): DateParts | null {
+  const m = new RegExp(`(${NUMBER}+)(st|nd|rd|th)\\b`, "i").exec(str);
+  return m ? { mday: Number(m[1]) } : null;
 }
 
 /** @internal `date_parse.c` `n2i`: the `w` digits of `s` from `f`, as a number. */
@@ -569,6 +778,18 @@ function parseDdd(str: string): DateParts | null {
 }
 
 /**
+ * @internal `date_parse.c` `parse_bc` (`date_parse.c:2003-2019`): the era
+ * suffix. It runs after whichever date sub-parser matched and only records
+ * `:_bc`; the tail of `date__parse` is what negates the year.
+ */
+function parseBc(str: string, hash: DateParts): number {
+  const m = /\b(bc\b|bce\b|b\.c\.|b\.c\.e\.)/i.exec(str);
+  if (m === null) return 0;
+  hash._bc = true;
+  return 1;
+}
+
+/**
  * @internal `date_core.c` `rt_complete_frags` (`date_core.c:3878-4036`), which
  * decides what kind of date the fields name — the entry of its table with the
  * most of them present wins, ties going to the earliest — and then fills the
@@ -726,10 +947,8 @@ export class Date {
    * and only ever turns false, so an absent one is `comp`, and the year is
    * completed only within `0..99` (`date_parse.c:2267-2287`).
    *
-   * @missingRailsCall `parse_jis`, `parse_vms`, `parse_iso2`, `parse_year`,
-   * `parse_mon`, `parse_mday` and `parse_bc` are not ported: they read a
-   * calendar Rails never round-trips. Neither is `date_zone_to_diff`
-   * (`date_parse.c:416-559`), so the `:offset` a `:zone` also sets is missing
+   * @missingRailsCall `date_zone_to_diff` (`date_parse.c:416-559`) is not
+   * ported, so the `:offset` a `:zone` also sets is missing
    * from both of its call sites — the tail of `date__parse` itself
    * (`date_parse.c:2290-2294`) and the bracketed zone of `parse_ddd_cb`
    * (`date_parse.c:1934-1960`). It reads a zone-name table `::Date` has no use
@@ -743,11 +962,32 @@ export class Date {
     if (/[a-z]/i.test(str)) {
       parts = parseEu(str) ?? parseUs(str);
     }
-    parts ??= parseIso(str) ?? parseSla(str) ?? parseDot(str) ?? parseDdd(str);
+    parts ??=
+      parseIso(str) ??
+      parseJis(str) ??
+      parseVms(str) ??
+      parseSla(str) ??
+      parseDot(str) ??
+      parseIso2(str) ??
+      parseYear(str) ??
+      parseMon(str) ??
+      parseMday(str) ??
+      parseDdd(str);
     if (parts === null && Object.keys(hash).length === 0) return null;
     parts = Object.assign(hash, parts);
-    if (comp && parts._comp !== false && parts.year !== undefined) {
-      if (parts.year >= 0 && parts.year <= 99) parts.year = compYear69(parts.year);
+    parseBc(str, parts);
+    if (parts._bc) {
+      if (parts.cwyear !== undefined) parts.cwyear = -parts.cwyear + 1;
+      if (parts.year !== undefined) parts.year = -parts.year + 1;
+    }
+    delete parts._bc;
+    if (comp && parts._comp !== false) {
+      if (parts.cwyear !== undefined && parts.cwyear >= 0 && parts.cwyear <= 99) {
+        parts.cwyear = compYear69(parts.cwyear);
+      }
+      if (parts.year !== undefined && parts.year >= 0 && parts.year <= 99) {
+        parts.year = compYear69(parts.year);
+      }
     }
     delete parts._comp;
     return parts;

--- a/packages/i18n/src/date.ts
+++ b/packages/i18n/src/date.ts
@@ -192,43 +192,160 @@ function monNum(str: string): number {
   return ABBR_MONTH_NAMES.findIndex((m) => m.toLowerCase() === str.slice(0, 3).toLowerCase()) + 1;
 }
 
+/** @internal `date_parse.c` `issign` (`date_parse.c:63`). */
+function issign(c: string): boolean {
+  return c === "-" || c === "+";
+}
+
+/** @internal `date_parse.c` `isdigit`, the C library's. */
+function isdigit(c: string): boolean {
+  return c >= "0" && c <= "9";
+}
+
+/** @internal `date_parse.c` `digit_span` (`date_parse.c:71-78`): the run of digits at `s`. */
+function digitSpan(str: string, s: number, e: number): number {
+  let i = 0;
+  while (s + i < e && isdigit(str[s + i])) i++;
+  return i;
+}
+
 /**
- * @internal `date_parse.c` `s3e`, which decides which of a match's numeric
- * tokens is the year: a token of more than two digits is one, a shorter one is
- * a month or a day. That is why `"01/01/2012".to_date` is 1 Jan 2012 while
- * `"12/13/2012".to_date` raises
- * (activesupport/lib/active_support/core_ext/string/conversions.rb:38-41), and
- * why `"07/08"` names no year at all.
+ * @internal `date_parse.c` `s3e` (`date_parse.c:80-253`), which decides which of
+ * a match's tokens is the year: a token of more than two characters is one, and
+ * so is a token an apostrophe marks (`:99-157`). That is why
+ * `"01/01/2012".to_date` is 1 Jan 2012 while `"12/13/2012".to_date` raises
+ * (activesupport/lib/active_support/core_ext/string/conversions.rb:38-41), why
+ * `"07/08"` names no year at all, and why `"'01-FEB-3"` is 3 February 2001
+ * where `"3-FEB-2001"` is the same date the other way round.
  *
- * A signed year is never completable (`date_parse.c:172-181`, `:250-251`), so
+ * Each of the three is then read from its first sign or digit (`:159-192`,
+ * `:197-221`, `:223-247`), so the apostrophe never reaches the number. A signed
+ * year, and one of more than two digits, is not completable (`:167-181`), so
  * `"-08-07-02"` is year -8 rather than 1992.
  *
- * Each token is read from its first sign or digit (`date_parse.c:167-169`,
- * `:204-206`, `:226-228`), so the apostrophe `parse_vms` captures is skipped —
- * and, being outside the digit span, does not count towards the width either.
+ * `bc` is the era `parse_eu` and `parse_us` read out of the string itself
+ * (`:194-195`), and sets the same `:_bc` `parse_bc` does.
+ *
+ * Ruby's `m` is a Ruby object that `f_to_s` makes a String (`:86-87`); the
+ * ported callers pass the String directly.
  */
-function s3e(y: string | null, m: string, d: string | null): DateParts {
-  if (y !== null) y = y.replace(/^'/, "");
-  if (d !== null) d = d.replace(/^'/, "");
-  if (y === null && d !== null && d.length > 2) {
-    y = d;
-    d = null;
+function s3e(y: string | null, m: string | null, d: string | null, bc: boolean): DateParts {
+  const hash: DateParts = {};
+  let c: boolean | null = null;
+
+  if (y !== null && m !== null && d === null) {
+    const oy = y;
+    const om = m;
+    const od = d;
+
+    y = od;
+    m = oy;
+    d = om;
   }
-  if (y !== null && d === null) {
-    if (y.replace(/^[-+]/, "").length > 2) return { year: Number(y), mon: Number(m), _comp: false };
-    if (m.length > 2) return { year: Number(m), mon: Number(y), _comp: false };
-    return { mon: Number(y), mday: Number(m) };
+
+  if (y === null) {
+    if (d !== null && d.length > 2) {
+      y = d;
+      d = null;
+    }
+    if (d !== null && d.length > 0 && d[0] === "'") {
+      y = d;
+      d = null;
+    }
   }
-  if (y === null) return { mon: Number(m), mday: Number(d) };
-  if (y.replace(/^[-+]/, "").length < 3 && d !== null && d.length > 2) {
-    [y, d] = [d, y];
+
+  if (y !== null) {
+    let s = 0;
+    let ep = y.length;
+    const end = y.length;
+
+    while (s < ep && !issign(y[s]) && !isdigit(y[s])) s++;
+    if (s < ep) {
+      const bp = s;
+      if (issign(y[s])) s++;
+      const l = digitSpan(y, s, ep);
+      ep = s + l;
+      if (ep < end) {
+        const od = y.slice(bp, ep);
+
+        y = d;
+        d = od;
+      }
+    }
   }
-  return {
-    year: Number(y),
-    mon: Number(m),
-    mday: Number(d),
-    _comp: /^\d{1,2}$/.test(y),
-  };
+
+  if (m !== null) {
+    if (m[0] === "'" || m.length > 2) {
+      const oy = y;
+      const om = m;
+      const od = d;
+
+      y = om;
+      m = od;
+      d = oy;
+    }
+  }
+
+  if (d !== null) {
+    if (d[0] === "'" || d.length > 2) {
+      const oy = y;
+      const od = d;
+
+      y = od;
+      d = oy;
+    }
+  }
+
+  if (y !== null) {
+    let s = 0;
+    let ep = y.length;
+    let sign = false;
+
+    while (s < ep && !issign(y[s]) && !isdigit(y[s])) s++;
+    if (s < ep) {
+      const bp = s;
+      if (issign(y[s])) {
+        s++;
+        sign = true;
+      }
+      if (sign) c = false;
+      const l = digitSpan(y, s, ep);
+      ep = s + l;
+      if (l > 2) c = false;
+      hash.year = Number(y.slice(bp, ep));
+    }
+  }
+
+  if (bc) hash._bc = true;
+
+  if (m !== null) {
+    let s = 0;
+    let ep = m.length;
+
+    while (s < ep && !isdigit(m[s])) s++;
+    if (s < ep) {
+      const bp = s;
+      const l = digitSpan(m, s, ep);
+      ep = s + l;
+      hash.mon = Number(m.slice(bp, ep));
+    }
+  }
+
+  if (d !== null) {
+    let s = 0;
+    let ep = d.length;
+
+    while (s < ep && !isdigit(d[s])) s++;
+    if (s < ep) {
+      const bp = s;
+      const l = digitSpan(d, s, ep);
+      ep = s + l;
+      hash.mday = Number(d.slice(bp, ep));
+    }
+  }
+
+  if (c !== null) hash._comp = c;
+  return hash;
 }
 
 /** @internal `date_parse.c` `parse_day`: a leading day name is not a date field. */
@@ -349,28 +466,109 @@ function parseTime(str: string, hash: DateParts): string {
   return rest;
 }
 
-/** @internal `date_parse.c` `parse_eu`: `2nd July 2008`, `2 Jul 2008`, `3 Feb`. */
-function parseEu(str: string): DateParts | null {
-  const m = new RegExp(
-    `'?(\\d+)[^-\\d\\s]*[-,.\\s]*(${ABBR_MONTHS})[^-\\d\\s]*(?:[,.\\s]+'?([-+]?\\d+)|[-,.\\s]*'?(\\d+))?`,
-    "i",
-  ).exec(str);
-  return m ? s3e(m[3] ?? m[4] ?? null, String(monNum(m[2])), m[1]) : null;
+/**
+ * @internal `date_parse.c` `BEGIN_ERA` / `END_ERA` (`date_parse.c:736-737`): the
+ * era spelling `parse_eu` and `parse_us` take is a word of its own, and `"b.c."`
+ * ends in the dot that would otherwise end the word.
+ */
+const BEGIN_ERA = "\\b";
+const END_ERA = "(?!(?<!\\.)[a-z])";
+
+/**
+ * @internal `date_parse.c` `parse_eu_cb` (`date_parse.c:836-868`): the day, the
+ * month, the era and the year, in the order `parse_eu` matches them.
+ */
+function parseEuCb(m: RegExpExecArray, hash: DateParts): number {
+  const d = m[1];
+  let mon: string | number = m[2];
+  const b = m[3];
+  const y = m[4];
+
+  mon = monNum(mon);
+
+  Object.assign(
+    hash,
+    s3e(y ?? null, String(mon), d, b !== undefined && (b[0] === "B" || b[0] === "b")),
+  );
+  return 1;
 }
 
-/** @internal `date_parse.c` `parse_us`: `Jul 2 2008`, `July 2nd, 2008`, `Feb 2008`. */
-function parseUs(str: string): DateParts | null {
+/** @internal `date_parse.c` `parse_eu` (`date_parse.c:869-916`): `2nd July 2008`, `2 Jul 2008`, `3 Feb`. */
+function parseEu(str: string): DateParts | null {
   const m = new RegExp(
-    `\\b(${ABBR_MONTHS})[^-\\d\\s]*[-,.\\s]+'?(\\d+)[^-\\d\\s]*(?:[,.\\s]+'?([-+]?\\d+)|[-,.\\s]*'?(\\d+))?`,
+    `('?${NUMBER}+)[^-\\d\\s]*` +
+      "\\s*" +
+      `(${ABBR_MONTHS})[^-\\d\\s']*` +
+      "(?:" +
+      "\\s*" +
+      "(?:" +
+      BEGIN_ERA +
+      "(c(?:e|\\.e\\.)|b(?:ce|\\.c\\.e\\.)|a(?:d|\\.d\\.)|b(?:c|\\.c\\.))" +
+      END_ERA +
+      ")?" +
+      "\\s*" +
+      "('?-?\\d+(?:(?:st|nd|rd|th)\\b)?)" +
+      ")?",
     "i",
   ).exec(str);
-  return m ? s3e(m[3] ?? m[4] ?? null, String(monNum(m[1])), m[2]) : null;
+  if (m === null) return null;
+  const hash: DateParts = {};
+  parseEuCb(m, hash);
+  return hash;
+}
+
+/**
+ * @internal `date_parse.c` `parse_us_cb` (`date_parse.c:917-950`): the same four
+ * tokens, with the month first.
+ */
+function parseUsCb(m: RegExpExecArray, hash: DateParts): number {
+  let mon: string | number = m[1];
+  const d = m[2];
+
+  const b = m[3];
+  const y = m[4];
+
+  mon = monNum(mon);
+
+  Object.assign(
+    hash,
+    s3e(y ?? null, String(mon), d, b !== undefined && (b[0] === "B" || b[0] === "b")),
+  );
+  return 1;
+}
+
+/**
+ * @internal `date_parse.c` `parse_us` (`date_parse.c:951-996`): `Jul 2 2008`,
+ * `July 2nd, 2008`, `Feb 2008`.
+ *
+ * Ruby writes the two runs before the year possessively (`\s*+,?\s*+`); JS has
+ * no possessive quantifier, and the greedy spelling matches the same language
+ * here because neither the era nor the year can begin with a space or a comma.
+ */
+function parseUs(str: string): DateParts | null {
+  const m = new RegExp(
+    `\\b(${ABBR_MONTHS})[^-\\d\\s']*` +
+      "\\s*" +
+      "('?\\d+)[^-\\d\\s']*" +
+      "(?:" +
+      "\\s*,?" +
+      "\\s*" +
+      "(c(?:e|\\.e\\.)|b(?:ce|\\.c\\.e\\.)|a(?:d|\\.d\\.)|b(?:c|\\.c\\.))?" +
+      "\\s*" +
+      "('?-?\\d+)" +
+      ")?",
+    "i",
+  ).exec(str);
+  if (m === null) return null;
+  const hash: DateParts = {};
+  parseUsCb(m, hash);
+  return hash;
 }
 
 /** @internal `date_parse.c` `parse_iso`: `2008-07-02`, and the unpadded `2008-7-2`. */
 function parseIso(str: string): DateParts | null {
   const m = /([-+]?\d+)-(\d+)-(-?\d+)/.exec(str);
-  return m ? s3e(m[1], m[2], m[3]) : null;
+  return m ? s3e(m[1], m[2], m[3], false) : null;
 }
 
 /**
@@ -530,7 +728,7 @@ function parseVms11(str: string): DateParts | null {
 
   mon = String(monNum(mon));
 
-  return s3e(y, mon, d);
+  return s3e(y, mon, d, false);
 }
 
 /** @internal `date_parse.c` `parse_vms12` (`date_parse.c:1391-1431`): `"FEB-3-2001"`, and `"FEB-3"`. */
@@ -543,7 +741,7 @@ function parseVms12(str: string): DateParts | null {
 
   mon = String(monNum(mon));
 
-  return s3e(y ?? null, mon, d);
+  return s3e(y ?? null, mon, d, false);
 }
 
 /** @internal `date_parse.c` `parse_vms` (`date_parse.c:1433-1444`): the VMS date, either way round. */
@@ -554,13 +752,13 @@ function parseVms(str: string): DateParts | null {
 /** @internal `date_parse.c` `parse_sla`: `2012/12/13`, `01/01/2012`, `2008/07`. */
 function parseSla(str: string): DateParts | null {
   const m = /([-+]?\d+)\/\s*(\d+)(?:\D\s*(-?\d+))?/.exec(str);
-  return m ? s3e(m[1], m[2], m[3] ?? null) : null;
+  return m ? s3e(m[1], m[2], m[3] ?? null, false) : null;
 }
 
 /** @internal `date_parse.c` `parse_dot`: `2012.12.13`, `01.01.2012`. */
 function parseDot(str: string): DateParts | null {
   const m = /([-+]?\d+)\.\s*(\d+)\.\s*(-?\d+)/.exec(str);
-  return m ? s3e(m[1], m[2], m[3]) : null;
+  return m ? s3e(m[1], m[2], m[3], false) : null;
 }
 
 /** @internal `date_parse.c` `parse_year` (`date_parse.c:1662-1688`): the year alone, `"'01"`. */


### PR DESCRIPTION
Ports the seven `date__parse` sub-parsers `Date._parse` still omitted, in
Ruby's own order (`date-3.4.1/ext/date/date_parse.c:2179-2265`):

- `parse_jis` (`date_parse.c:1309-1346`) with `gengo` — `"H13.02.03"`.
- `parse_vms11` / `parse_vms12` / `parse_vms` (`:1349-1444`) —
  `"3-FEB-2001"`, `"FEB-3-2001"`.
- `parse_iso21`…`parse_iso26` / `parse_iso2` (`:1035-1287`) —
  `"2001-W05-6"`, `"-W061"`, `"2001-034"`, `"--0203"`.
- `parse_year` / `parse_mon` / `parse_mday` (`:1662-1748`) — the
  one-fragment `"'01"`, `"Feb"`, `"3rd"`, each tried before `parse_ddd`.
- `parse_bc` (`:2003-2019`) plus the `del_hash("_bc")` arm of `date__parse`
  (`:2251-2264`) that negates `:year` / `:cwyear`.

The `_comp` arm at `:2266-2286` gains its `:cwyear` half alongside the
`:year` one it already had, and `DateParts` carries `cwyear` / `cweek` /
`cwday` / `_bc`. `s3e` now skips the apostrophe `parse_vms` captures, as C
does by scanning to the first sign or digit (`:167-169`, `:204-206`,
`:226-228`).

Verified field-for-field against `ruby -rdate` over a 57-string battery
(every spelling already in `date.trails.test.ts` plus the new ones): the
only differences left are the two pre-existing ones — `:wday`, which this
shim does not carry, and `:sec_fraction`, which Ruby answers as a Rational.

`rt_complete_frags` still carries only `:time` / `:ordinal` / `:civil`, so
`"2001-W05-6"` is asserted through `Date._parse` rather than `Date.parse`;
the commercial entry of that table is not in this story's scope.


The `@missingRailsCall` on `Date._parse` loses the sub-parser clause and now
names `parse_frag` (`date_parse.c:2021-2052`) alongside `date_zone_to_diff`:
it is the last unported call in the chain, and its pattern is anchored to the
whole string, so it needs the `subx` removal Ruby gives its sub-parsers.
Filed as `0074-i18n-parity/i18n-date-parse-frag-and-subx-removal`.

## Review round 1 — `s3e`, `parse_eu`, `parse_us`

The reviewer was right that stripping the apostrophe in `s3e` is not what C
does. Rather than patch the one swap, `s3e` is now the 3.4.1 function
(`date_parse.c:80-253`): all four token swaps (`:89-97`, `:99-108`, `:110-129`,
`:131-145`, `:147-157` — an apostrophized or over-wide token routes to the year
instead of being rewritten in place), each field read from its first sign or
digit (`:159-247`), the `bc` parameter (`:194-195`), and `:_comp` set only when
false (`:249-250`), with `digit_span` and `issign` alongside it.

That exposed why it mattered: the ported `parse_eu` / `parse_us` patterns were
not 3.4.1's — they allowed `[-,.\s]*` between the day and the month, so they
swallowed `"3-FEB-2001"` and `"FEB-3-2001"` whole and `parse_vms` was
unreachable dead code. Both now carry their 3.4.1 patterns
(`:869-916`, `:951-996`) and their era group, through `parse_eu_cb` /
`parse_us_cb` (`:836-868`, `:917-950`), so `"july 4 1776 b.c."` gets its era
from the sub-parser that matched it, as Ruby does.

Re-verified against `ruby -rdate` on a 115-string battery: 114 agree exactly.
The one that does not is `"11pm 5"` — `parse_frag`, receipted and filed.

**Over the 500-LOC ceiling** at ~590: the story itself is ~300, and the `s3e` /
`parse_eu` / `parse_us` convergence above is the rest. Splitting it out would
have left `parse_vms` unreachable in this PR and the review finding unfixed.

Closes-story: i18n-date-parse-remaining-sub-parsers
