### PR TITLE
fix(i18n): answer the tzdata abbreviation from Time#zone

### DIFF
--- a/packages/i18n/src/time.trails.test.ts
+++ b/packages/i18n/src/time.trails.test.ts
@@ -100,8 +100,6 @@ describe("Time", () => {
       inZone("Australia/Adelaide");
       expect(new Time(2008, 1, 1, 6, 0, 0).zone).toBe("ACDT");
       expect(new Time(2008, 7, 1, 6, 0, 0).zone).toBe("ACST");
-      // Dublin's summer time is its *standard* time in tzdata, so an
-      // is-it-DST flag would answer these two backwards.
       inZone("Europe/Dublin");
       expect(new Time(2008, 1, 1, 6, 0, 0).zone).toBe("GMT");
       expect(new Time(2008, 7, 1, 6, 0, 0).zone).toBe("IST");

--- a/packages/i18n/src/time.trails.test.ts
+++ b/packages/i18n/src/time.trails.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { Temporal } from "@js-temporal/polyfill";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { ArgumentError } from "./date.js";
 import { Time } from "./time.js";
 
@@ -79,5 +79,39 @@ describe("Time", () => {
     );
     expect(time.utcOffset).toBe(Number(local.offsetNanoseconds) / 1_000_000_000);
     expect(time.strftime("%z")).toBe(local.offset.replace(":", ""));
+  });
+
+  describe("in a local zone `Intl` has no abbreviation for", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    function inZone(timeZoneId: string): void {
+      vi.spyOn(Temporal.Now, "timeZoneId").mockReturnValue(timeZoneId);
+    }
+
+    it("Time#zone answers the tzdata abbreviation, not Intl's short name", () => {
+      inZone("Asia/Kolkata");
+      expect(new Time(2008, 3, 1, 6, 0, 0).zone).toBe("IST");
+      expect(new Time(2008, 3, 1, 6, 0, 0).strftime("%z %Z")).toBe("+0530 IST");
+    });
+
+    it("Time#zone answers the standard or the summer abbreviation by offset", () => {
+      inZone("Australia/Adelaide");
+      expect(new Time(2008, 1, 1, 6, 0, 0).zone).toBe("ACDT");
+      expect(new Time(2008, 7, 1, 6, 0, 0).zone).toBe("ACST");
+      // Dublin's summer time is its *standard* time in tzdata, so an
+      // is-it-DST flag would answer these two backwards.
+      inZone("Europe/Dublin");
+      expect(new Time(2008, 1, 1, 6, 0, 0).zone).toBe("GMT");
+      expect(new Time(2008, 7, 1, 6, 0, 0).zone).toBe("IST");
+    });
+
+    it("Time#zone spells an untabulated zone's abbreviation as tzdata does", () => {
+      inZone("Asia/Dubai");
+      expect(new Time(2008, 3, 1, 6, 0, 0).zone).toBe("+04");
+      inZone("Asia/Kathmandu");
+      expect(new Time(2008, 3, 1, 6, 0, 0).zone).toBe("+0545");
+    });
   });
 });

--- a/packages/i18n/src/time.ts
+++ b/packages/i18n/src/time.ts
@@ -221,7 +221,7 @@ export class Time {
   }
 
   /**
-   * `Time#zone` is the zone's abbreviation — `"UTC"` for a `Time.utc`, `"PDT"`
+   * `Time#zone` is the zone's tzdata abbreviation — `"UTC"` for a `Time.utc`, `"PDT"`
    * for a local summer time — not an offset, which is what `::DateTime#zone`
    * answers instead. A time built from an offset rather than a zone has no
    * abbreviation to answer and Ruby returns `nil`, which `%Z` prints as "".

--- a/packages/i18n/src/time.ts
+++ b/packages/i18n/src/time.ts
@@ -66,6 +66,82 @@ function pad2(n: number): string {
 }
 
 /**
+ * The tzdata abbreviations MRI's `Time#zone` answers, for the zones `Intl`
+ * cannot supply them for: an `en-US` `timeZoneName: "short"` is an
+ * abbreviation only where English has one (`"EST"`, `"PDT"`, `"HST"`) and a
+ * `"GMT+5:30"` string everywhere else, where MRI answers `"IST"`.
+ *
+ * Each entry is the zone's standard abbreviation, then its summer one where
+ * the zone has a second — picked by offset rather than by a DST flag, so
+ * `Europe/Dublin`'s negative DST (standard `"IST"` in summer, `"GMT"` in
+ * winter) falls out the same way as every other zone's. Zones whose tzdata
+ * abbreviation is the numeric `"+04"` form need no entry: `tzdataAbbreviation`
+ * spells those from the offset.
+ */
+const ZONE_ABBREVIATIONS: Record<string, readonly [string] | readonly [string, string]> = {
+  "Africa/Cairo": ["EET", "EEST"],
+  "Africa/Harare": ["CAT"],
+  "Africa/Johannesburg": ["SAST"],
+  "Africa/Lagos": ["WAT"],
+  "Africa/Nairobi": ["EAT"],
+  "America/St_Johns": ["NST", "NDT"],
+  "Asia/Hong_Kong": ["HKT"],
+  "Asia/Jakarta": ["WIB"],
+  "Asia/Jayapura": ["WIT"],
+  "Asia/Jerusalem": ["IST", "IDT"],
+  "Asia/Karachi": ["PKT"],
+  "Asia/Kolkata": ["IST"],
+  "Asia/Makassar": ["WITA"],
+  "Asia/Manila": ["PST"],
+  "Asia/Seoul": ["KST"],
+  "Asia/Shanghai": ["CST"],
+  "Asia/Taipei": ["CST"],
+  "Asia/Tokyo": ["JST"],
+  "Asia/Yangon": ["MMT"],
+  "Australia/Adelaide": ["ACST", "ACDT"],
+  "Australia/Brisbane": ["AEST"],
+  "Australia/Darwin": ["ACST"],
+  "Australia/Perth": ["AWST"],
+  "Australia/Sydney": ["AEST", "AEDT"],
+  "Europe/Athens": ["EET", "EEST"],
+  "Europe/Berlin": ["CET", "CEST"],
+  "Europe/Dublin": ["GMT", "IST"],
+  "Europe/Lisbon": ["WET", "WEST"],
+  "Europe/London": ["GMT", "BST"],
+  "Europe/Moscow": ["MSK"],
+  "Europe/Paris": ["CET", "CEST"],
+  "Pacific/Auckland": ["NZST", "NZDT"],
+  "Pacific/Guam": ["ChST"],
+};
+
+/**
+ * The abbreviation tzdata gives `zoned`'s zone at `zoned`'s instant, which is
+ * what MRI's `Time#zone` and `%Z` answer. Zones outside `ZONE_ABBREVIATIONS`
+ * either have an English abbreviation `Intl` knows (`"EST"`) or carry tzdata's
+ * numeric abbreviation, which is the offset spelled `"+04"` / `"+0545"` —
+ * neither of them `Intl`'s `"GMT+4"`.
+ */
+function tzdataAbbreviation(zoned: Temporal.ZonedDateTime): string {
+  const abbreviations = ZONE_ABBREVIATIONS[zoned.timeZoneId];
+  if (abbreviations !== undefined) {
+    if (abbreviations.length === 1) return abbreviations[0];
+    const january = Number(zoned.with({ month: 1, day: 1 }).offsetNanoseconds);
+    const july = Number(zoned.with({ month: 7, day: 1 }).offsetNanoseconds);
+    return Number(zoned.offsetNanoseconds) > Math.min(january, july)
+      ? abbreviations[1]
+      : abbreviations[0];
+  }
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: zoned.timeZoneId,
+    timeZoneName: "short",
+  }).formatToParts(new globalThis.Date(zoned.epochMilliseconds));
+  const short = parts.find((part) => part.type === "timeZoneName")!.value;
+  if (short === "GMT" || !short.startsWith("GMT")) return short;
+  const offset = zoned.offset;
+  return offset.endsWith(":00") ? offset.slice(0, 3) : offset.replace(":", "");
+}
+
+/**
  * @noRailsEquivalent PERMANENT — Ruby core `::Time`. Rails never defines the
  * class, only reopens it in `core_ext/time/*.rb`, so there is no Rails
  * counterpart for a port to converge on. trails carries only the members a
@@ -152,13 +228,7 @@ export class Time {
    */
   get zone(): string | null {
     if (this.#timeZoneId == null) return null;
-    const parts = new Intl.DateTimeFormat("en-US", {
-      timeZone: this.#timeZoneId,
-      timeZoneName: "short",
-    }).formatToParts(
-      new globalThis.Date(this.#plain.toZonedDateTime(this.#timeZoneId).epochMilliseconds),
-    );
-    return parts.find((part) => part.type === "timeZoneName")!.value;
+    return tzdataAbbreviation(this.#plain.toZonedDateTime(this.#timeZoneId));
   }
 
   /** Ruby `Time#utc_offset`, the receiver's offset from UTC in seconds. */


### PR DESCRIPTION
`Time#zone` read the abbreviation off `Intl.DateTimeFormat(..., { timeZoneName: "short" })`, which is an abbreviation only for the zones English has one for. `Asia/Kolkata` answered `"GMT+5:30"` where MRI answers `"IST"`, and `Australia/Adelaide` answered `"GMT+10:30"` where MRI answers `"ACDT"`. That reaches a caller through `%Z` on a local-zone `Time`, and `I18n::Backend::Base#localize` (i18n/lib/i18n/backend/base.rb:91-92) uses the receiver's `strftime` result verbatim, so the wrong abbreviation printed straight into a localized string.

`zone` now answers the tzdata abbreviation:

- a `ZONE_ABBREVIATIONS` table on the i18n side (`packages/i18n` cannot import `packages/activesupport`, so it cannot borrow `values/time-zone.ts`) covers the zones with a non-numeric tzdata abbreviation that `Intl` spells `GMT+X`;
- an entry carries its standard abbreviation and, where the zone has one, its summer abbreviation, picked **by offset** rather than by a DST flag — so `Europe/Dublin`'s negative DST (`GMT` in winter, standard `IST` in summer) falls out the same way as every other zone's;
- zones outside the table keep `Intl`'s value where it is a real abbreviation (`EST`, `PDT`, `GMT`), and otherwise get tzdata's numeric abbreviation spelled from the offset — `Asia/Dubai` is `"+04"` and `Asia/Kathmandu` is `"+0545"`, both of which MRI answers and neither of which is `Intl`'s `"GMT+4"`.

`Time.utc(...).zone` is still `"UTC"`, an offset-built time is still `null`, and the localization tests are unchanged.

Closes-story: i18n-time-zone-abbreviation
