### PR TITLE
chore(activesupport): take yaml as an optional npm dependency

### DIFF
--- a/packages/activesupport/package.json
+++ b/packages/activesupport/package.json
@@ -88,7 +88,9 @@
   "dependencies": {
     "@blazetrails/i18n": "workspace:*",
     "@js-temporal/polyfill": "^0.5.1",
-    "tinyglobby": "^0.2.16",
+    "tinyglobby": "^0.2.16"
+  },
+  "optionalDependencies": {
     "yaml": "^2.8.3"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,13 +238,14 @@ importers:
       tinyglobby:
         specifier: ^0.2.16
         version: 0.2.16
-      yaml:
-        specifier: ^2.8.3
-        version: 2.8.3
     devDependencies:
       '@blazetrails/nokogiri':
         specifier: workspace:*
         version: link:../nokogiri
+    optionalDependencies:
+      yaml:
+        specifier: ^2.8.3
+        version: 2.8.3
 
   packages/arel:
     dependencies:

--- a/scripts/test-deps/yaml-optional-dependency.test.ts
+++ b/scripts/test-deps/yaml-optional-dependency.test.ts
@@ -1,0 +1,89 @@
+// Guard: `yaml` is an optional dependency of `@blazetrails/activesupport`, so
+// nothing reachable from that package's `index.ts` may import it.
+//
+// Rails has no counterpart to this — Psych is stdlib, `require "yaml"` never
+// fails, and `active_support.rb` can name YAML freely. In trails `yaml` is an
+// npm package a consumer may legitimately omit, and ESM static imports are
+// eager: one `export … from "./yaml.js"` in `index.ts` would turn every
+// `import "@blazetrails/activesupport"` into a hard `ERR_MODULE_NOT_FOUND`.
+// The YAML surface is reachable only through the `./yaml` and
+// `./configuration-file` subpath exports, and this test pins that.
+//
+// Measured blast radius with `yaml` uninstalled (see the PR that added this
+// file): the root imports of `@blazetrails/activesupport` and
+// `@blazetrails/activemodel` resolve; the root imports of
+// `@blazetrails/activerecord` (via `base.ts` → `coders/yaml-column.ts`) and
+// `@blazetrails/actionview` (via `helpers/index.ts` → `debug-helper.ts`) do
+// not. Those two edges are debt to converge, not a settled shape.
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+
+const PACKAGES = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../packages");
+
+const IMPORT_RE = /(?:^|\n)\s*(?:import|export)\s+([\s\S]*?)\s*from\s*["']([^"']+)["']/g;
+
+/** Specifiers whose resolution needs the optional `yaml` package installed. */
+const YAML_SPECIFIERS = new Set(["yaml", "@blazetrails/activesupport/yaml"]);
+
+async function tsFiles(dir: string, root = dir): Promise<string[]> {
+  const out: string[] = [];
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...(await tsFiles(full, root)));
+    } else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
+      out.push(path.relative(root, full));
+    }
+  }
+  return out;
+}
+
+/**
+ * Files reachable from `<pkg>/src/index.ts` over value-import edges that import
+ * `yaml`. `import type` is erased by tsc and carries no load-time edge.
+ */
+async function yamlImportersReachableFromIndex(pkg: string): Promise<string[]> {
+  const src = path.join(PACKAGES, pkg, "src");
+  const files = await tsFiles(src);
+  const known = new Set(files);
+  const graph = new Map<string, string[]>();
+  const importsYaml = new Set<string>();
+  for (const file of files) {
+    const source = await readFile(path.join(src, file), "utf8");
+    const targets = new Set<string>();
+    for (const [, clause, specifier] of source.matchAll(IMPORT_RE)) {
+      if (/^\s*type\b/.test(clause)) continue;
+      if (YAML_SPECIFIERS.has(specifier)) importsYaml.add(file);
+      if (!specifier.startsWith(".")) continue;
+      const target = path
+        .normalize(path.join(path.dirname(file), specifier))
+        .replace(/\.js$/, ".ts");
+      if (known.has(target)) targets.add(target);
+    }
+    graph.set(file, [...targets]);
+  }
+
+  const seen = new Set<string>();
+  const offenders: string[] = [];
+  const stack = ["index.ts"];
+  while (stack.length > 0) {
+    const file = stack.pop()!;
+    if (seen.has(file)) continue;
+    seen.add(file);
+    if (importsYaml.has(file)) offenders.push(file);
+    stack.push(...(graph.get(file) ?? []));
+  }
+  return offenders.sort();
+}
+
+describe("yaml optional dependency", () => {
+  it("is not reachable from the activesupport root import", async () => {
+    expect(await yamlImportersReachableFromIndex("activesupport")).toEqual([]);
+  });
+
+  it("is not reachable from the activemodel root import", async () => {
+    expect(await yamlImportersReachableFromIndex("activemodel")).toEqual([]);
+  });
+});


### PR DESCRIPTION
`yaml` was a hard runtime dependency of `packages/activesupport`, so every
consumer of `@blazetrails/activesupport` installed it whether or not it ever
parsed YAML. Nothing in trails' boot path reads a `.yml` file and the framework
locales are TS modules (`packages/activesupport/src/locale/en.ts`), so it should
be optional.

Rails has no counterpart to this decision — Psych is stdlib, `require "yaml"`
never fails, and there is no missing-dependency arm to port. This is a packaging
change only: no ported body moves, and behaviour with `yaml` installed is
byte-identical.

## Shape

The story's preferred shape, taken as-is: move `yaml` from `dependencies` to
`optionalDependencies` at the same range (`^2.8.3`) and leave the static imports
alone. pnpm installs optional dependencies by default, so the workspace, CI and
every existing test keep working unchanged. `configuration-file.ts`,
`coders/yaml-column.ts`, the activemodel yaml codec and `debug-helper.ts` keep
their current imports and tests. No lazy `createRequire` helper, no wrapper, no
new public name — the resolver's `ERR_MODULE_NOT_FOUND` was judged acceptable
for a consumer who deliberately omits an optional dependency.

## Measured blast radius

Probed by building `dist`, removing both `yaml` symlinks (root and
`packages/activesupport/node_modules`) and `import()`ing each entry point:

| entry point | `yaml` absent |
| --- | --- |
| `@blazetrails/activesupport` | resolves |
| `@blazetrails/activemodel` | resolves |
| `@blazetrails/activerecord` | **`ERR_MODULE_NOT_FOUND`** |
| `@blazetrails/actionview` | **`ERR_MODULE_NOT_FOUND`** |
| `@blazetrails/activesupport/yaml` | fails (expected) |
| `@blazetrails/activesupport/configuration-file` | fails (expected) |
| `activerecord/coders/yaml-column.js` | fails (expected) |
| `activemodel/attribute-set/codecs/yaml.js` | fails (expected) |
| `actionview/helpers/debug-helper.js` | fails (expected) |

The story's context predicted that none of the four YAML modules was reachable
from its package's `index.ts`. **Two are**, and this is the one place the PR
diverges from the story's stated expectation:

- `packages/activerecord/src/base.ts:336` imports `YAMLColumn` for value
  (as does `attribute-methods/serialization.ts:12`), so `base.ts` → the whole
  `activerecord` root import needs `yaml`.
- `packages/actionview/src/helpers/index.ts:7` re-exports `debug` from
  `debug-helper.ts`, so the `actionview` root import needs it too.

Rails has no such hazard — both files are autoloaded, so naming the constant
costs nothing until it is referenced; ESM evaluates the import eagerly. Removing
those two load-time edges is real work with its own fidelity questions
(`base.ts`'s registration idiom vs. `import type`), well outside a packaging
change, so it is filed as
`0074-i18n-parity/yaml-optional-eager-edges-in-activerecord-and-actionview`
with the `file:line`s above rather than smuggled in here.

## Guard

`scripts/test-deps/yaml-optional-dependency.test.ts` walks each package's
source value-import graph from `index.ts` and asserts nothing reachable imports
`yaml` or `@blazetrails/activesupport/yaml`. It covers only the two roots that
are actually clean — asserting the activerecord/actionview edges *exist* would
ratify them. Verified to fail on a real edge: pointed at `activerecord` it
reports `coders/yaml-column.ts`.

No baseline row, allowlist entry or skip is added. No ported method body is
touched, so the call-parity ratchets and `api:extra` are unaffected.

Closes-story: yaml-is-an-optional-npm-dependency
