### PR TITLE
fix(activesupport): resolve the optional yaml package without a link-time edge

### DIFF
--- a/packages/activesupport/src/yaml.ts
+++ b/packages/activesupport/src/yaml.ts
@@ -1,1 +1,23 @@
-export { parse, stringify } from "yaml";
+// `yaml` is an optionalDependency of this package. Rails has no counterpart to
+// this file at all: Psych is stdlib, so `require "yaml"` at the top of
+// `active_record/coders/yaml_column.rb` (yaml_column.rb:3) cannot fail, and
+// `active_record.rb:31` requires it unconditionally. In trails `yaml` is an npm
+// package a consumer may omit, and a static `export … from "yaml"` here is an
+// eager ESM link-time edge — it makes every module that merely *names* the YAML
+// coders unimportable, taking the whole `@blazetrails/activerecord` and
+// `@blazetrails/actionview` root imports down with it. Resolving the package
+// once, here, and keeping the miss local moves the failure to the call site,
+// which is where Ruby would raise from `YAML.dump` too.
+const yaml = await import("yaml").catch(() => {
+  const missing = (): never => {
+    // Ruby's counterpart is the core `LoadError` that `require "yaml"` would
+    // raise; there is no Rails error class to port here.
+    // eslint-disable-next-line blazetrails/rails-error-parity
+    throw new Error(
+      "The `yaml` package is required to read or write YAML. Install it with `npm install yaml`.",
+    );
+  };
+  return { parse: missing, stringify: missing } as unknown as typeof import("yaml");
+});
+
+export const { parse, stringify } = yaml;

--- a/scripts/test-deps/yaml-optional-dependency.test.ts
+++ b/scripts/test-deps/yaml-optional-dependency.test.ts
@@ -1,20 +1,23 @@
 // Guard: `yaml` is an optional dependency of `@blazetrails/activesupport`, so
-// nothing reachable from that package's `index.ts` may import it.
+// nothing reachable from a package's `index.ts` may statically import it.
 //
 // Rails has no counterpart to this — Psych is stdlib, `require "yaml"` never
-// fails, and `active_support.rb` can name YAML freely. In trails `yaml` is an
-// npm package a consumer may legitimately omit, and ESM static imports are
-// eager: one `export … from "./yaml.js"` in `index.ts` would turn every
-// `import "@blazetrails/activesupport"` into a hard `ERR_MODULE_NOT_FOUND`.
-// The YAML surface is reachable only through the `./yaml` and
-// `./configuration-file` subpath exports, and this test pins that.
+// fails, and `active_record.rb:31` / `coders/yaml_column.rb:3` require it
+// unconditionally. In trails `yaml` is an npm package a consumer may
+// legitimately omit, and ESM static imports are eager: one
+// `export … from "yaml"` on a path reachable from `index.ts` turns every
+// `import "@blazetrails/<pkg>"` into a hard `ERR_MODULE_NOT_FOUND`.
 //
-// Measured blast radius with `yaml` uninstalled (see the PR that added this
-// file): the root imports of `@blazetrails/activesupport` and
-// `@blazetrails/activemodel` resolve; the root imports of
-// `@blazetrails/activerecord` (via `base.ts` → `coders/yaml-column.ts`) and
-// `@blazetrails/actionview` (via `helpers/index.ts` → `debug-helper.ts`) do
-// not. Those two edges are debt to converge, not a settled shape.
+// Measured blast radius before this guard covered them: the root imports of
+// `@blazetrails/activesupport` and `@blazetrails/activemodel` resolved, but the
+// root imports of `@blazetrails/activerecord` (via `base.ts` →
+// `coders/yaml-column.ts`) and `@blazetrails/actionview` (via
+// `helpers/index.ts` → `debug-helper.ts`) did not. Both reach
+// `@blazetrails/activesupport/yaml`, which is why that specifier is followed
+// into `activesupport/src/yaml.ts` rather than treated as an offender: that
+// module resolves `yaml` dynamically, so naming the YAML coders costs nothing
+// at load time and the miss surfaces where Ruby would raise it, from the
+// dump/load call.
 import { readFile, readdir } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -24,8 +27,13 @@ const PACKAGES = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../
 
 const IMPORT_RE = /(?:^|\n)\s*(?:import|export)\s+([\s\S]*?)\s*from\s*["']([^"']+)["']/g;
 
-/** Specifiers whose resolution needs the optional `yaml` package installed. */
-const YAML_SPECIFIERS = new Set(["yaml", "@blazetrails/activesupport/yaml"]);
+/** The optional package itself — a static import of it is the load-time hazard. */
+const YAML_PACKAGE = "yaml";
+
+/** Cross-package specifier followed as a graph edge into its source file. */
+const CROSS_PACKAGE_EDGES = new Map([
+  ["@blazetrails/activesupport/yaml", { pkg: "activesupport", file: "yaml.ts" }],
+]);
 
 async function tsFiles(dir: string, root = dir): Promise<string[]> {
   const out: string[] = [];
@@ -40,42 +48,54 @@ async function tsFiles(dir: string, root = dir): Promise<string[]> {
   return out;
 }
 
+type Node = { pkg: string; file: string };
+
+const key = (node: Node): string => `${node.pkg}/src/${node.file}`;
+
 /**
- * Files reachable from `<pkg>/src/index.ts` over value-import edges that import
- * `yaml`. `import type` is erased by tsc and carries no load-time edge.
+ * Files reachable from `<pkg>/src/index.ts` over value-import edges that
+ * statically import `yaml`. `import type` is erased by tsc and carries no
+ * load-time edge.
  */
 async function yamlImportersReachableFromIndex(pkg: string): Promise<string[]> {
-  const src = path.join(PACKAGES, pkg, "src");
-  const files = await tsFiles(src);
-  const known = new Set(files);
-  const graph = new Map<string, string[]>();
-  const importsYaml = new Set<string>();
-  for (const file of files) {
-    const source = await readFile(path.join(src, file), "utf8");
-    const targets = new Set<string>();
-    for (const [, clause, specifier] of source.matchAll(IMPORT_RE)) {
-      if (/^\s*type\b/.test(clause)) continue;
-      if (YAML_SPECIFIERS.has(specifier)) importsYaml.add(file);
-      if (!specifier.startsWith(".")) continue;
-      const target = path
-        .normalize(path.join(path.dirname(file), specifier))
-        .replace(/\.js$/, ".ts");
-      if (known.has(target)) targets.add(target);
+  const known = new Map<string, Set<string>>();
+  const filesOf = async (name: string): Promise<Set<string>> => {
+    let files = known.get(name);
+    if (!files) {
+      files = new Set(await tsFiles(path.join(PACKAGES, name, "src")));
+      known.set(name, files);
     }
-    graph.set(file, [...targets]);
-  }
+    return files;
+  };
 
   const seen = new Set<string>();
   const offenders: string[] = [];
-  const stack = ["index.ts"];
+  const stack: Node[] = [{ pkg, file: "index.ts" }];
   while (stack.length > 0) {
-    const file = stack.pop()!;
-    if (seen.has(file)) continue;
-    seen.add(file);
-    if (importsYaml.has(file)) offenders.push(file);
-    stack.push(...(graph.get(file) ?? []));
+    const node = stack.pop()!;
+    if (seen.has(key(node))) continue;
+    seen.add(key(node));
+
+    const source = await readFile(path.join(PACKAGES, node.pkg, "src", node.file), "utf8");
+    for (const [, clause, specifier] of source.matchAll(IMPORT_RE)) {
+      if (/^\s*type\b/.test(clause)) continue;
+      if (specifier === YAML_PACKAGE) {
+        offenders.push(key(node));
+        continue;
+      }
+      const crossPackage = CROSS_PACKAGE_EDGES.get(specifier);
+      if (crossPackage) {
+        stack.push(crossPackage);
+        continue;
+      }
+      if (!specifier.startsWith(".")) continue;
+      const file = path
+        .normalize(path.join(path.dirname(node.file), specifier))
+        .replace(/\.js$/, ".ts");
+      if ((await filesOf(node.pkg)).has(file)) stack.push({ pkg: node.pkg, file });
+    }
   }
-  return offenders.sort();
+  return [...new Set(offenders)].sort();
 }
 
 describe("yaml optional dependency", () => {
@@ -85,5 +105,13 @@ describe("yaml optional dependency", () => {
 
   it("is not reachable from the activemodel root import", async () => {
     expect(await yamlImportersReachableFromIndex("activemodel")).toEqual([]);
+  });
+
+  it("is not reachable from the activerecord root import", async () => {
+    expect(await yamlImportersReachableFromIndex("activerecord")).toEqual([]);
+  });
+
+  it("is not reachable from the actionview root import", async () => {
+    expect(await yamlImportersReachableFromIndex("actionview")).toEqual([]);
   });
 });


### PR DESCRIPTION
## What

`yaml` is an `optionalDependency` of `@blazetrails/activesupport` (#6077). With it uninstalled, the **root imports of `@blazetrails/activerecord` and `@blazetrails/actionview` died** with `ERR_MODULE_NOT_FOUND: Cannot find package 'yaml'` — `base.ts` names `Coders::YAMLColumn` and `helpers/index.ts` re-exports `debug`, and ESM static imports are eager.

Rails has no such hazard: Psych is stdlib, so `require "yaml"` at `activerecord/lib/active_record.rb:31` and `activerecord/lib/active_record/coders/yaml_column.rb:3` cannot fail, and `actionview/lib/action_view/helpers.rb:20` requires `debug_helper` freely.

The single eager edge is `packages/activesupport/src/yaml.ts` — a file with no Rails counterpart at all. It now resolves `yaml` once via a caught dynamic import, so the miss surfaces at the dump/load call (where Ruby would raise) instead of at link time. `parse` / `stringify` keep their names, their types and their synchronous behaviour when `yaml` is installed; no wrapper indirection, and nothing changes in `YAMLColumn` or `debug`.

## Verified

Built `dist` and hid `node_modules/yaml` + `packages/activesupport/node_modules/yaml`:

```
OK   @blazetrails/actionview
OK   @blazetrails/activerecord
OK   @blazetrails/activesupport
call throws: The `yaml` package is required to read or write YAML. Install it with `npm install yaml`.
```

`scripts/test-deps/yaml-optional-dependency.test.ts` now covers the `activerecord` and `actionview` roots too; it follows `@blazetrails/activesupport/yaml` as a graph edge into the module that does the resolving rather than treating that specifier as the hazard, so the offender is a *static* import of the bare `yaml` package. Reverting `yaml.ts` reds both new cases (and only those).

Closes-story: yaml-optional-eager-edges-in-activerecord-and-actionview
