### PR TITLE
fix(activerecord): extract _skipValidateOptions in buildCreateTableDefinition

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
@@ -246,3 +246,26 @@ describe("IndexDefinition concise options", () => {
     expect(index.lengths).toBe(10);
   });
 });
+
+describe("TableDefinition#create_column_definition", () => {
+  const td = () =>
+    new TableDefinition("articles", { adapter: schemaConn("sqlite"), adapterName: "sqlite" });
+
+  it("raises on a column option outside valid_column_definition_options", () => {
+    expect(() => td().column("title", "string", { preccision: true } as never)).toThrow(
+      "Unknown key: :preccision. Valid keys are: :limit, :precision, :scale, :default, :null, :collation, :comment, :primaryKey, :ifExists, :ifNotExists",
+    );
+  });
+
+  it("skips the check when _skipValidateOptions is set", () => {
+    expect(() =>
+      td().column("title", "string", { preccision: true, _skipValidateOptions: true } as never),
+    ).not.toThrow();
+  });
+
+  it("excepts _usesLegacyReferenceIndexName from the checked keys", () => {
+    expect(() =>
+      td().column("title", "string", { _usesLegacyReferenceIndexName: true } as never),
+    ).not.toThrow();
+  });
+});

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1,6 +1,6 @@
 import type { SchemaQuoter } from "./assert-schema-adapter.js";
 import type { Column } from "../column.js";
-import { singularize, pluralize, getCrypto } from "@blazetrails/activesupport";
+import { singularize, pluralize, getCrypto, assertValidKeys } from "@blazetrails/activesupport";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { SchemaDumper } from "../../schema-dumper.js";
 import {
@@ -516,6 +516,8 @@ export interface ColumnOptions {
   type?: ColumnType;
   as?: string;
   stored?: boolean;
+  _usesLegacyReferenceIndexName?: boolean;
+  _skipValidateOptions?: boolean;
 }
 
 /**
@@ -1139,6 +1141,11 @@ export class TableDefinition {
     type: ColumnType,
     options: ColumnOptions,
   ): ColumnDefinition {
+    if (!options._skipValidateOptions) {
+      const { _usesLegacyReferenceIndexName: _u, _skipValidateOptions: _s, ...rest } = options;
+      assertValidKeys(rest, this.validColumnDefinitionOptions());
+    }
+
     return new ColumnDefinition(name, type, options);
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -805,6 +805,39 @@ describe("buildCreateTableDefinition routing", () => {
     expect(td.options).toBe("ENGINE=InnoDB");
   });
 
+  it("extracts _skipValidateOptions into the table definition options", () => {
+    const createTableDefinition = vi.fn(
+      (name: string, options: Record<string, unknown>) => new TableDefinition(name, options as any),
+    );
+    const ss = makeStatements({ createTableDefinition });
+
+    const td = ss.buildCreateTableDefinition("users", {
+      id: "integer",
+      _skipValidateOptions: true,
+    });
+
+    expect(createTableDefinition.mock.calls[0]?.[1]).toMatchObject({ _skipValidateOptions: true });
+    // Rails' `extract!` deletes what it returns, so the second extraction never
+    // sees the key (schema_statements.rb:334-335).
+    expect(pkColumn(td)?.options).not.toHaveProperty("_skipValidateOptions");
+  });
+
+  it("carries autoIncrement to the primary key only where valid_primary_key_options lists it", () => {
+    const abstract = makeStatements();
+    const mysql = makeStatements({
+      validPrimaryKeyOptions: () => ["limit", "unsigned", "autoIncrement"],
+    });
+
+    expect(
+      pkColumn(abstract.buildCreateTableDefinition("users", { id: "integer", autoIncrement: true }))
+        ?.options,
+    ).not.toHaveProperty("autoIncrement");
+    expect(
+      pkColumn(mysql.buildCreateTableDefinition("users", { id: "integer", autoIncrement: true }))
+        ?.options,
+    ).toMatchObject({ autoIncrement: true });
+  });
+
   it("expands the hash form of id onto the primary key column", () => {
     const ss = makeStatements();
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -10,6 +10,7 @@ import {
   TableDefinition,
   type ColumnType,
 } from "./schema-definitions.js";
+import { TableDefinition as MysqlTableDefinition } from "../mysql/schema-definitions.js";
 import { AbstractAdapter } from "../abstract-adapter.js";
 import { NATIVE_DATABASE_TYPES_BY_ADAPTER } from "./native-database-types.js";
 import { NotImplementedError } from "../../errors.js";
@@ -824,6 +825,8 @@ describe("buildCreateTableDefinition routing", () => {
     const abstract = makeStatements();
     const mysql = makeStatements({
       validPrimaryKeyOptions: () => ["limit", "unsigned", "autoIncrement"],
+      createTableDefinition: (name: string, options: Record<string, unknown>) =>
+        new MysqlTableDefinition(name, options as any),
     });
 
     expect(

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -817,8 +817,6 @@ describe("buildCreateTableDefinition routing", () => {
     });
 
     expect(createTableDefinition.mock.calls[0]?.[1]).toMatchObject({ _skipValidateOptions: true });
-    // Rails' `extract!` deletes what it returns, so the second extraction never
-    // sees the key (schema_statements.rb:334-335).
     expect(pkColumn(td)?.options).not.toHaveProperty("_skipValidateOptions");
   });
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1491,13 +1491,21 @@ export class SchemaStatements {
     fn?: (td: TableDefinition) => void,
   ): TableDefinition {
     const { id = true, primaryKey, force: _force, ...rest } = options;
+    // Rails uses `options.extract!`, which *deletes* what it returns — so
+    // `_skipValidateOptions` only ever reaches the first extraction.
     const tdOptions: Record<string, unknown> = {};
-    for (const key of this.validTableDefinitionOptions()) {
-      if (rest[key] !== undefined) tdOptions[key] = rest[key];
+    for (const key of [...this.validTableDefinitionOptions(), "_skipValidateOptions"]) {
+      if (key in rest) {
+        tdOptions[key] = rest[key];
+        delete rest[key];
+      }
     }
     const pkOptions: Record<string, unknown> = {};
-    for (const key of this.validPrimaryKeyOptions()) {
-      if (rest[key] !== undefined) pkOptions[key] = rest[key];
+    for (const key of [...this.validPrimaryKeyOptions(), "_skipValidateOptions"]) {
+      if (key in rest) {
+        pkOptions[key] = rest[key];
+        delete rest[key];
+      }
     }
 
     const ctdOptions = {

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-creation.test.ts
@@ -1,10 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { SchemaCreation } from "./schema-creation.js";
-import {
-  ForeignKeyDefinition,
-  TableDefinition,
-  CreateIndexDefinition,
-} from "../abstract/schema-definitions.js";
+import { ForeignKeyDefinition, CreateIndexDefinition } from "../abstract/schema-definitions.js";
+import { TableDefinition } from "./schema-definitions.js";
 import { schemaConn } from "../../support/schema-conn.js";
 
 describe("SQLite3::SchemaCreation", () => {


### PR DESCRIPTION
## `build_create_table_definition` option splitting

`build_create_table_definition` (schema_statements.rb:334-335) splits the
options hash with
`options.extract!(*valid_table_definition_options, :_skip_validate_options)`
and `options.extract!(*valid_primary_key_options, :_skip_validate_options)`.

trails read only the two adapter option lists and never extracted
`_skipValidateOptions`. (The `"autoIncrement"` hardcode named in the story was
already deleted by #6065; MySQL supplies it through
`MysqlSchemaStatements#validPrimaryKeyOptions`, mysql/schema_statements.rb:168-170.)

Both splits now include `_skipValidateOptions`, and — matching Ruby's mutating
`extract!` — the first split deletes it, so only the table definition receives
it. The extractions also key on presence rather than a non-`undefined` value,
as `extract!` does.

## `create_column_definition` key validation

That flag had no consumer: Rails' `TableDefinition#create_column_definition`
(schema_definitions.rb:593-599) does

```ruby
unless options[:_skip_validate_options]
  options.except(:_uses_legacy_reference_index_name, :_skip_validate_options).assert_valid_keys(valid_column_definition_options)
end
```

and trails skipped the guard entirely — which left
`validColumnDefinitionOptions` dead code at all four sites that define it
(abstract/schema-definitions.ts:1123, sqlite3:63, mysql:261, postgresql:279)
and silently swallowed unknown column options where Rails raises
`ArgumentError`. The guard is now ported.

It surfaced one real defect: the SQLite3 `SchemaCreation` test built a base
`TableDefinition` while passing `as`/`stored`. Rails uses
`SQLite3::TableDefinition` there, whose `valid_column_definition_options` adds
`:as, :type, :stored` (sqlite3/schema_definitions.rb:33) — so the test now does
too.

## Filed, not fixed here

- `sqlite3-add-column-reimplements-super` — SQLite3 `add_column` reimplements
  the `ALTER TABLE` string instead of falling through to `super`
  (sqlite3_adapter.rb:338-347), so the new guard cannot fire on that path. This
  is why the `add_column` arm of `test_add_column_with_invalid_options` stays
  unported: it would pass on MySQL/PostgreSQL and fail on SQLite, and Rails
  applies no adapter gate to it.
- `valid-column-definition-options-duplicated-on-table-definition` — the base
  `TableDefinition` inlines `ColumnDefinition::OPTION_NAMES` instead of
  delegating to `@conn.valid_column_definition_options`
  (schema_definitions.rb:589-591). Delegating means widening `SchemaQuoter`,
  which is out of scope here.

Closes-story: build-create-table-definition-hardcodes-auto-increment
