### PR TITLE
test(activerecord): converge schema-information dump tests to dumpSchemaInformation

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -689,6 +689,11 @@ export interface AbstractAdapter {
   explain?(arel: unknown, binds?: unknown[], options?: ExplainOption[]): Promise<string>;
 
   /**
+   * Mirrors: ActiveRecord::ConnectionAdapters::SchemaStatements#dump_schema_information
+   */
+  dumpSchemaInformation?(): Promise<string | null>;
+
+  /**
    * Mirrors: ActiveRecord::ConnectionAdapters::SchemaStatements#create_table_definition
    *
    * @internal

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -376,28 +376,37 @@ describe("SchemaDumperTest", () => {
   });
 
   it("dump schema information with empty versions", async () => {
-    const { SchemaDumper: TopLevelDumper } = await import("./schema-dumper.js");
-    const { SchemaMigration } = await import("./schema-migration.js");
-    const adapter = Base.connection;
-    const sm = new SchemaMigration(adapter);
-    await sm.createTable();
-    await sm.deleteAllVersions();
-    const result = await TopLevelDumper.dumpWithVersion(adapter);
-    expect(result).toContain("Schema version: 0");
+    const schemaMigration = Base.connectionPool().schemaMigration;
+    await schemaMigration.createTable();
+    await schemaMigration.deleteAllVersions();
+    // Rails' `dump_schema_information` returns nil for an empty
+    // `schema_migrations`; minitest's `assert_no_match` passes on nil, so
+    // normalize before matching rather than asserting on the null.
+    const schemaInfo = (await Base.connection.dumpSchemaInformation!()) ?? "";
+    expect(schemaInfo).not.toMatch(/INSERT INTO/);
   });
 
   it("dump schema information outputs lexically reverse ordered versions regardless of database order", async () => {
-    const { SchemaDumper: TopLevelDumper } = await import("./schema-dumper.js");
-    const { SchemaMigration } = await import("./schema-migration.js");
-    const adapter = Base.connection;
-    const sm = new SchemaMigration(adapter);
-    await sm.createTable();
-    await sm.deleteAllVersions();
-    await sm.recordVersion("20240301000000");
-    await sm.recordVersion("20240101000000");
-    await sm.recordVersion("20240201000000");
-    const result = await TopLevelDumper.dumpWithVersion(adapter);
-    expect(result).toContain("Schema version: 20240301000000");
+    const schemaMigration = Base.connectionPool().schemaMigration;
+    await schemaMigration.createTable();
+    await schemaMigration.deleteAllVersions();
+    const versions = ["20100101010101", "20100201010101", "20100301010101"];
+    for (const v of [...versions].sort(() => Math.random() - 0.5)) {
+      await schemaMigration.createVersion(v);
+    }
+
+    try {
+      const schemaInfo = await Base.connection.dumpSchemaInformation!();
+      const expected = [
+        `INSERT INTO ${Base.connection.quoteTableName("schema_migrations")} (version) VALUES`,
+        "('20100301010101'),",
+        "('20100201010101'),",
+        "('20100101010101');",
+      ].join("\n");
+      expect(schemaInfo).toEqual(expected);
+    } finally {
+      await schemaMigration.deleteAllVersions();
+    }
   });
 
   it("schema dump include migration version", async () => {


### PR DESCRIPTION
`Active Record PostgreSQL Tests (2)` went red on main @eb32c962 with a single
failure: `SchemaDumperTest > dump schema information with empty versions`
timed out at 5000ms.

## Root cause

The two `dump schema information …` cases drove
`SchemaDumper.dumpWithVersion(adapter)`, which enumerates **every** table in the
database and dumps its full schema. Against the canonical PG schema that is
seconds of reflection per call — the first case tipped over vitest's 5s default.

That full dump is also a divergence: Rails asserts on
`ActiveRecord::Base.lease_connection.dump_schema_information`
(`activerecord/test/cases/schema_dumper_test.rb:21-42`), which reads
`schema_migrations` and nothing else.

## Change

- Port both cases to `dumpSchemaInformation`:
  - empty case asserts no `INSERT INTO` (Rails `assert_no_match`; our
    `dumpSchemaInformation` returns `null` for no versions, matching
    `schema_statements.rb:1355-1358`, so it is normalized before matching —
    minitest's `assert_no_match` passes on `nil`);
  - ordering case shuffles the three versions before inserting, asserts the exact
    reverse-ordered `INSERT INTO … VALUES` string, and clears versions in a
    `finally` mirroring Rails' `ensure`.
- Declare `dumpSchemaInformation?()` on the `AbstractAdapter` interface. It is
  mixed in from `SchemaStatements` (`schema_statements.rb:1355`) but was missing
  from the declaration block that lists the other mixin-provided members.

Runtime for the two cases: >5000ms (timeout) → 113ms.

Closes-story: red-eb32c962
