### PR TITLE
fix(website): drop top-level await from the service-worker yaml import

### DIFF
--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -33,6 +33,7 @@
     "typedoc-plugin-markdown": "^4.11.0",
     "vite": "^6.0.0",
     "vitepress": "^1.6.4",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "yaml": "^2.8.3"
   }
 }

--- a/packages/website/src/stubs/yaml-stub.ts
+++ b/packages/website/src/stubs/yaml-stub.ts
@@ -1,7 +1,2 @@
-// `@blazetrails/activesupport/yaml` resolves the optional `yaml` package with a
-// top-level `await import(...)` so a missing install fails at the call site
-// rather than at link time — incompatible with Rollup's IIFE format, which the
-// service-worker bundle needs for `importScripts("/sql-wasm.js")`. In the
-// browser bundle `yaml` is always present (it is bundled), so a static
-// re-export is equivalent and drops the top-level await.
+// `@blazetrails/activesupport/yaml` uses top-level await — incompatible with Rollup IIFE format.
 export { parse, stringify } from "yaml";

--- a/packages/website/src/stubs/yaml-stub.ts
+++ b/packages/website/src/stubs/yaml-stub.ts
@@ -1,0 +1,7 @@
+// `@blazetrails/activesupport/yaml` resolves the optional `yaml` package with a
+// top-level `await import(...)` so a missing install fails at the call site
+// rather than at link time — incompatible with Rollup's IIFE format, which the
+// service-worker bundle needs for `importScripts("/sql-wasm.js")`. In the
+// browser bundle `yaml` is always present (it is bundled), so a static
+// re-export is equivalent and drops the top-level await.
+export { parse, stringify } from "yaml";

--- a/packages/website/vite.sw.config.ts
+++ b/packages/website/vite.sw.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
       // sqlite drivers (@blazetrails/activerecord/sqlite/<name>) are handled by
       // the generic activerecord subpath alias below — the src/sqlite/ dir
       // matches the specifier, so no special case is needed.
+      pkgAlias("@blazetrails/activesupport/yaml", "src/stubs/yaml-stub.ts"),
       {
         find: /^@blazetrails\/activesupport\/(.+)$/,
         replacement: path.resolve(__dirname, "../activesupport/src/$1.ts"),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -386,6 +386,9 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@25.3.5)(jiti@2.6.1)(jsdom@29.0.1)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
+      yaml:
+        specifier: ^2.8.3
+        version: 2.8.3
 
   scripts/guides-typecheck:
     dependencies:


### PR DESCRIPTION
The `Website` job fails on `main` @f6b381cd: `Build SvelteKit` aborts with

> Module format "iife" does not support top-level await.
> file: packages/activesupport/src/yaml.ts

#6078 resolves the optional `yaml` package with a top-level `await import(...)`
so a missing install fails at the call site instead of at link time. The sandbox
service worker is built as IIFE because it needs `importScripts("/sql-wasm.js")`,
and Rollup cannot emit top-level await in that format.

Fix stays entirely on the website side — `activesupport/src/yaml.ts` keeps its
shape. `vite.sw.config.ts` now aliases `@blazetrails/activesupport/yaml` to a
static re-export of the `yaml` package, which is always bundled in the browser
build, so the optional-miss handling is moot there and the top-level await goes
away. This mirrors the existing `nokogiri-stub.ts` alias, added for the same
IIFE/top-level-await reason.

Verified locally: `build:sw`, `vite build`, and `vitest run scripts/` all pass.

Closes-story: red-f6b381cd
