### PR TITLE
feat(i18n): register Active Model's and Active Record's en locales on I18n.load_path

### DIFF
--- a/packages/activemodel/src/i18n.ts
+++ b/packages/activemodel/src/i18n.ts
@@ -3,12 +3,9 @@
  * `activemodel/lib/active_model.rb`, which appends Active Model's own `en`
  * locale to `I18n.load_path`.
  *
- * The load path is not used for it. `Simple#initTranslations` reads the path
- * through the `FileReader` a host registers, and that read is async
- * (`backend/simple.ts:116`), while these translations have to be in the backend
- * by the time this module finishes importing — nothing awaits an import for a
- * side effect. So the locale is a module and is stored directly, the shape
- * `activesupport/src/i18n.ts` already uses.
+ * The locale is one module rather than an `en.yml`, so it is registered with
+ * `registerLocaleModule` before its path is appended — the shape
+ * `activesupport/src/i18n.ts` settled on, and for the reasons its header gives.
  *
  * Importing `@blazetrails/activesupport`'s `I18n` (rather than
  * `@blazetrails/i18n` directly) mirrors `require "active_support/i18n"`: it
@@ -18,6 +15,8 @@
 import { I18n } from "@blazetrails/activesupport";
 import { en } from "./locale/en.js";
 
-I18n.backend().storeTranslations("en", en);
+const enPath = new URL("./locale/en.js", import.meta.url).pathname;
+I18n.registerLocaleModule(enPath, { en });
+I18n.loadPath().push(enPath);
 
 export { I18n };

--- a/packages/activemodel/src/locale/en.ts
+++ b/packages/activemodel/src/locale/en.ts
@@ -3,8 +3,8 @@
  *
  * Rails appends this file to `I18n.load_path` from the `on_load(:i18n)` hook at
  * the bottom of `activemodel/lib/active_model.rb`. The data lives here as a
- * module instead, and `i18n.ts` stores it into the backend directly — see the
- * header there for why the load path can't carry it.
+ * module instead, which `i18n.ts` registers before appending its path to
+ * `I18n.load_path`.
  */
 
 import type { TranslationData } from "@blazetrails/i18n";

--- a/packages/activemodel/src/test-helpers/i18n.ts
+++ b/packages/activemodel/src/test-helpers/i18n.ts
@@ -2,20 +2,10 @@
  * Rails test cases isolate translations with `I18n.backend = I18n::Backend::Simple.new`
  * and let `load_path` re-supply each framework's `en.yml` lazily (see
  * `reset_i18n_load_path` in activemodel/test/cases/validations/i18n_validation_test.rb).
- * Trails' framework locales are modules rather than load-path entries
- * (`activemodel/src/i18n.ts`), so re-storing them here stands in for that
- * re-read.
  */
 import { I18n } from "../i18n.js";
-import { en } from "../locale/en.js";
 
-/** A fresh backend carrying the framework locales, as Rails' load path supplies them. */
+/** A fresh backend; Rails' load path re-supplies the framework locales. */
 export function resetI18n(): void {
-  resetI18nEmpty();
-  I18n.backend().storeTranslations("en", en);
-}
-
-/** A fresh backend with no framework locales — Rails' `I18n.load_path.clear`. */
-export function resetI18nEmpty(): void {
   I18n.setBackend(new I18n.Simple());
 }

--- a/packages/activemodel/src/validations/i18n-validation.test.ts
+++ b/packages/activemodel/src/validations/i18n-validation.test.ts
@@ -50,11 +50,10 @@ describe("I18nValidationTest", () => {
   });
 
   it("errors full messages uses format", () => {
-    // Rails clears `I18n.load_path` in setup (i18n_validation_test.rb:12), so a
-    // stored `errors.format` is not overwritten by the framework `en.yml` the
-    // backend loads lazily. Only this case collides with the file data, so the
-    // clear is local to it; `errors.messages.empty` is stored back because the
-    // trails deviation below resolves the message through the backend.
+    // Rails clears `I18n.load_path` in setup (i18n_validation_test.rb:12) so the
+    // framework `en.yml` cannot overwrite the stored `errors.format`. Only this
+    // case collides with the file data, and `errors.messages.empty` is stored
+    // back because the trails deviation below resolves through the backend.
     const oldLoadPath = [...I18n.loadPath()];
     I18n.loadPath().length = 0;
     I18n.setBackend(new I18n.Simple());

--- a/packages/activemodel/src/validations/i18n-validation.test.ts
+++ b/packages/activemodel/src/validations/i18n-validation.test.ts
@@ -8,11 +8,14 @@ describe("I18nValidationTest", () => {
   // Rails' setup/teardown pair
   // (activemodel/test/cases/validations/i18n_validation_test.rb:11-28).
   const originalI18nCustomizeFullMessage = ModelError.i18nCustomizeFullMessage;
+  let oldLoadPath: string[];
   beforeEach(() => {
+    oldLoadPath = [...I18n.loadPath()];
     resetI18n();
     ModelError.i18nCustomizeFullMessage = true;
   });
   afterEach(() => {
+    I18n.loadPath().splice(0, I18n.loadPath().length, ...oldLoadPath);
     ModelError.i18nCustomizeFullMessage = originalI18nCustomizeFullMessage;
   });
 
@@ -51,10 +54,10 @@ describe("I18nValidationTest", () => {
 
   it("errors full messages uses format", () => {
     // Rails clears `I18n.load_path` in setup (i18n_validation_test.rb:12) so the
-    // framework `en.yml` cannot overwrite the stored `errors.format`. Only this
-    // case collides with the file data, and `errors.messages.empty` is stored
-    // back because the trails deviation below resolves through the backend.
-    const oldLoadPath = [...I18n.loadPath()];
+    // framework `en.yml` cannot overwrite the stored `errors.format`; the
+    // teardown above restores it. Only this case collides with the file data,
+    // and `errors.messages.empty` is stored back because the trails deviation
+    // below resolves through the backend.
     I18n.loadPath().length = 0;
     I18n.setBackend(new I18n.Simple());
     I18n.backend().storeTranslations("en", {
@@ -73,7 +76,6 @@ describe("I18nValidationTest", () => {
     // "empty" resolves through `errors.messages.empty`. The format under test —
     // `errors.format` — is asserted either way.
     expect(p.errors.fullMessages).toEqual(["Field Name can't be empty"]);
-    I18n.loadPath().splice(0, I18n.loadPath().length, ...oldLoadPath);
   });
 
   it("errors full messages doesnt use attribute format without config", () => {

--- a/packages/activemodel/src/validations/i18n-validation.test.ts
+++ b/packages/activemodel/src/validations/i18n-validation.test.ts
@@ -50,7 +50,17 @@ describe("I18nValidationTest", () => {
   });
 
   it("errors full messages uses format", () => {
-    I18n.backend().storeTranslations("en", { errors: { format: "Field %{attribute} %{message}" } });
+    // Rails clears `I18n.load_path` in setup (i18n_validation_test.rb:12), so a
+    // stored `errors.format` is not overwritten by the framework `en.yml` the
+    // backend loads lazily. Only this case collides with the file data, so the
+    // clear is local to it; `errors.messages.empty` is stored back because the
+    // trails deviation below resolves the message through the backend.
+    const oldLoadPath = [...I18n.loadPath()];
+    I18n.loadPath().length = 0;
+    I18n.setBackend(new I18n.Simple());
+    I18n.backend().storeTranslations("en", {
+      errors: { format: "Field %{attribute} %{message}", messages: { empty: "can't be empty" } },
+    });
     class Person extends Model {
       static {
         this.attribute("name", "string");
@@ -64,6 +74,7 @@ describe("I18nValidationTest", () => {
     // "empty" resolves through `errors.messages.empty`. The format under test —
     // `errors.format` — is asserted either way.
     expect(p.errors.fullMessages).toEqual(["Field Name can't be empty"]);
+    I18n.loadPath().splice(0, I18n.loadPath().length, ...oldLoadPath);
   });
 
   it("errors full messages doesnt use attribute format without config", () => {

--- a/packages/activerecord/src/i18n.trails.test.ts
+++ b/packages/activerecord/src/i18n.trails.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { I18n } from "@blazetrails/activemodel";
+import "./i18n.js";
+
+describe("ActiveRecordI18nLoadPathTest", () => {
+  it("re-reads Active Model's and Active Record's locales after reload!", async () => {
+    I18n.setBackend(new I18n.Simple());
+    expect(I18n.t("errors.messages.blank")).toBe("can't be blank");
+    expect(I18n.t("errors.messages.taken")).toBe("has already been taken");
+
+    await I18n.reloadBang();
+
+    expect(I18n.t("errors.messages.blank")).toBe("can't be blank");
+    expect(I18n.t("errors.messages.taken")).toBe("has already been taken");
+  });
+});

--- a/packages/activerecord/src/i18n.ts
+++ b/packages/activerecord/src/i18n.ts
@@ -6,11 +6,12 @@
  * The hook lives in a file of its own — rather than in `index.ts`, which is
  * where the rest of `active_record.rb` lands — because `base.ts` has to import
  * it for its side effect: a model file that never loads the package index still
- * has to be able to translate its error messages. Why the load path does not
- * carry the data: see the header in `activemodel/src/i18n.ts`.
+ * has to be able to translate its error messages.
  */
 
 import { I18n } from "@blazetrails/activemodel";
 import { en } from "./locale/en.js";
 
-I18n.backend().storeTranslations("en", en);
+const enPath = new URL("./locale/en.js", import.meta.url).pathname;
+I18n.registerLocaleModule(enPath, { en });
+I18n.loadPath().push(enPath);

--- a/packages/activerecord/src/locale/en.ts
+++ b/packages/activerecord/src/locale/en.ts
@@ -3,8 +3,8 @@
  *
  * Rails appends this file to `I18n.load_path` from the `on_load(:i18n)` hook at
  * the bottom of `activerecord/lib/active_record.rb`. The data lives here as a
- * module instead, and `i18n.ts` stores it into the backend directly — see the
- * header in `activemodel/src/i18n.ts` for why the load path can't carry it.
+ * module instead, which `i18n.ts` registers before appending its path to
+ * `I18n.load_path`.
  */
 
 import type { TranslationData } from "@blazetrails/i18n";

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -640,7 +640,7 @@ export class Relation<T extends Base> {
     // of those columns before re-adding them.
     const newClause = rel.buildWhereClause(conditions) as WhereClause;
     rel._whereClause = rel._whereClause.except(...newClause.extractAttributes());
-    rel._whereClause.predicates.push(...newClause.predicates);
+    rel._whereClause = rel._whereClause.plus(newClause);
     return rel;
   }
 
@@ -846,7 +846,7 @@ export class Relation<T extends Base> {
         // in place (`IN` → `NOT IN`, `Grouping(Or)` → `NOT (...)`), while a flat
         // multi-predicate single tuple ANDs then negates → `NOT (c1 = ? AND
         // c2 = ?)` — the same shape as inverting the hash-key `where.not`.
-        rel._whereClause.predicates.push(...new WhereClause(nodes).invert().predicates);
+        rel._whereClause = rel._whereClause.plus(new WhereClause(nodes).invert());
       }
       return rel;
     }
@@ -860,7 +860,7 @@ export class Relation<T extends Base> {
         throw argumentError("Relation#whereNot: unsupported argument (empty array)");
       }
       const clause = rel.buildWhereClause(conditions) as WhereClause;
-      rel._whereClause.predicates.push(...clause.invert().predicates);
+      rel._whereClause = rel._whereClause.plus(clause.invert());
       return rel;
     }
     // Mirrors Rails WhereChain#not → `build_where_clause(opts).invert`
@@ -871,7 +871,7 @@ export class Relation<T extends Base> {
     // assembled clause: 1 predicate → node.invert() (`!=`, `IS NOT NULL`,
     // `NOT IN`, ...), 2+ predicates → NOT(p1 AND p2 AND ...).
     const clause = rel.buildWhereClause(conditions) as WhereClause;
-    rel._whereClause.predicates.push(...clause.invert().predicates);
+    rel._whereClause = rel._whereClause.plus(clause.invert());
     return rel;
   }
 

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -940,7 +940,7 @@ export function buildWhereClause(
 function whereBang(this: QueryMethodsHost, opts: any, ...rest: unknown[]): any {
   if (opts == null) return this;
   const clause = buildWhereClause.call(this, opts, rest);
-  this._whereClause.predicates.push(...clause.predicates);
+  this._whereClause = this._whereClause.plus(clause);
   return this;
 }
 

--- a/packages/activerecord/src/relation/where-clause.test.ts
+++ b/packages/activerecord/src/relation/where-clause.test.ts
@@ -16,17 +16,6 @@ function bindParam(value: unknown): Nodes.BindParam {
   return new Nodes.BindParam(value);
 }
 
-function concat(a: WhereClause, b: WhereClause): WhereClause {
-  return new WhereClause([...a.predicates, ...b.predicates]);
-}
-
-function eql(a: WhereClause, b: WhereClause): boolean {
-  return (
-    a.predicates.length === b.predicates.length &&
-    a.predicates.every((p, i) => p.eql(b.predicates[i]))
-  );
-}
-
 describe("ActiveRecord::Relation", () => {
   // `to_sql` compiles through `Table.engine`'s connection (arel/nodes/node.rb:148-153),
   // so these Arel assertions need a connection, as Rails' do via helper.rb.
@@ -40,21 +29,21 @@ describe("ActiveRecord::Relation", () => {
         t.get("id").eq(bindParam(1)),
         t.get("name").eq(bindParam("Sean")),
       ]);
-      expect(eql(concat(firstClause, secondClause), combined)).toBe(true);
+      expect(firstClause.plus(secondClause).equals(combined)).toBe(true);
     });
 
     it("+ is associative, but not commutative", () => {
       const a = new WhereClause([new Nodes.SqlLiteral("a")]);
       const b = new WhereClause([new Nodes.SqlLiteral("b")]);
       const c = new WhereClause([new Nodes.SqlLiteral("c")]);
-      expect(eql(concat(a, concat(b, c)), concat(concat(a, b), c))).toBe(true);
-      expect(eql(concat(a, b), concat(b, a))).toBe(false);
+      expect(a.plus(b.plus(c)).equals(a.plus(b).plus(c))).toBe(true);
+      expect(a.plus(b).equals(b.plus(a))).toBe(false);
     });
 
     it("an empty where clause is the identity value for +", () => {
       const t = table();
       const clause = new WhereClause([t.get("id").eq(bindParam(1))]);
-      expect(eql(concat(clause, WhereClause.empty()), clause)).toBe(true);
+      expect(clause.plus(WhereClause.empty()).equals(clause)).toBe(true);
     });
 
     it("merge combines two where clauses", () => {
@@ -62,7 +51,7 @@ describe("ActiveRecord::Relation", () => {
       const a = new WhereClause([t.get("id").eq(1)]);
       const b = new WhereClause([t.get("name").eq("Sean")]);
       const expected = new WhereClause([t.get("id").eq(1), t.get("name").eq("Sean")]);
-      expect(eql(a.merge(b), expected)).toBe(true);
+      expect(a.merge(b).equals(expected)).toBe(true);
     });
 
     it("merge keeps the right side, when two equality clauses reference the same column", () => {
@@ -70,7 +59,7 @@ describe("ActiveRecord::Relation", () => {
       const a = new WhereClause([t.get("id").eq(1), t.get("name").eq("Sean")]);
       const b = new WhereClause([t.get("name").eq("Jim")]);
       const expected = new WhereClause([t.get("id").eq(1), t.get("name").eq("Jim")]);
-      expect(eql(a.merge(b), expected)).toBe(true);
+      expect(a.merge(b).equals(expected)).toBe(true);
     });
 
     it("merge removes bind parameters matching overlapping equality clauses", () => {
@@ -84,7 +73,7 @@ describe("ActiveRecord::Relation", () => {
         t.get("id").eq(bindParam(1)),
         t.get("name").eq(bindParam("Jim")),
       ]);
-      expect(eql(a.merge(b), expected)).toBe(true);
+      expect(a.merge(b).equals(expected)).toBe(true);
     });
 
     it("merge allows for columns with the same name from different tables", () => {
@@ -96,7 +85,7 @@ describe("ActiveRecord::Relation", () => {
         t2.get("id").eq(bindParam(2)),
         t.get("id").eq(bindParam(3)),
       ]);
-      expect(eql(a.merge(b), expected)).toBe(true);
+      expect(a.merge(b).equals(expected)).toBe(true);
     });
 
     it("a clause knows if it is empty", () => {
@@ -141,7 +130,7 @@ describe("ActiveRecord::Relation", () => {
           ]),
         ),
       ]);
-      expect(eql(original.invert(), expected)).toBe(true);
+      expect(original.invert().equals(expected)).toBe(true);
     });
 
     it("except removes binary predicates referencing a given column", () => {
@@ -152,7 +141,7 @@ describe("ActiveRecord::Relation", () => {
         t.get("age").gteq(bindParam(30)),
       ]);
       const expected = new WhereClause([t.get("age").gteq(bindParam(30))]);
-      expect(eql(whereClause.except("id", "name"), expected)).toBe(true);
+      expect(whereClause.except("id", "name").equals(expected)).toBe(true);
     });
 
     it("except jumps over unhandled binds (like with OR) correctly", () => {
@@ -170,14 +159,14 @@ describe("ActiveRecord::Relation", () => {
         wcs[6].or(wcs[7]),
         wcs[8],
         wcs[9],
-      ].reduce((acc, c) => concat(acc, c), wcs[0]);
+      ].reduce((acc, c) => acc.plus(c), wcs[0]);
       // wcs[0] + wcs[2].or(wcs[3]) + wcs[5] + wcs[6].or(wcs[7]) + wcs[9]
       const expected = [wcs[2].or(wcs[3]), wcs[5], wcs[6].or(wcs[7]), wcs[9]].reduce(
-        (acc, c) => concat(acc, c),
+        (acc, c) => acc.plus(c),
         wcs[0],
       );
       const actual = wc.except("id1", "id2", "id4", "id7", "id8");
-      expect(eql(actual, expected)).toBe(true);
+      expect(actual.equals(expected)).toBe(true);
     });
 
     it("ast groups its predicates with AND", () => {
@@ -241,7 +230,7 @@ describe("ActiveRecord::Relation", () => {
       const orClause = new WhereClause([t.get("name").eq(bindParam("Sean"))]).or(
         new WhereClause([t.get("hair_color").eq(bindParam("black"))]),
       );
-      expect(eql(a.or(b), concat(common, orClause))).toBe(true);
+      expect(a.or(b).equals(common.plus(orClause))).toBe(true);
     });
 
     it("or can detect identical or as being a common condition", () => {
@@ -249,12 +238,12 @@ describe("ActiveRecord::Relation", () => {
       const commonOr = new WhereClause([t.get("name").eq(bindParam("Sean"))]).or(
         new WhereClause([t.get("hair_color").eq(bindParam("black"))]),
       );
-      const a = concat(commonOr, new WhereClause([t.get("id").eq(bindParam(1))]));
-      const b = concat(commonOr, new WhereClause([t.get("foo").eq(bindParam("bar"))]));
+      const a = commonOr.plus(new WhereClause([t.get("id").eq(bindParam(1))]));
+      const b = commonOr.plus(new WhereClause([t.get("foo").eq(bindParam("bar"))]));
       const newOr = new WhereClause([t.get("id").eq(bindParam(1))]).or(
         new WhereClause([t.get("foo").eq(bindParam("bar"))]),
       );
-      expect(eql(a.or(b), concat(commonOr, newOr))).toBe(true);
+      expect(a.or(b).equals(commonOr.plus(newOr))).toBe(true);
     });
 
     it("or will use only common conditions if one side only has common conditions", () => {
@@ -263,12 +252,11 @@ describe("ActiveRecord::Relation", () => {
         t.get("id").eq(bindParam(1)),
         new Nodes.SqlLiteral("foo = bar"),
       ]);
-      const commonWithExtra = concat(
-        onlyCommon,
+      const commonWithExtra = onlyCommon.plus(
         new WhereClause([t.get("extra").eq(bindParam("pluto"))]),
       );
-      expect(eql(onlyCommon.or(commonWithExtra), onlyCommon)).toBe(true);
-      expect(eql(commonWithExtra.or(onlyCommon), onlyCommon)).toBe(true);
+      expect(onlyCommon.or(commonWithExtra).equals(onlyCommon)).toBe(true);
+      expect(commonWithExtra.or(onlyCommon).equals(onlyCommon)).toBe(true);
     });
 
     it("supports hash equality", () => {
@@ -277,8 +265,8 @@ describe("ActiveRecord::Relation", () => {
       const a1 = new WhereClause([new Nodes.SqlLiteral("a")]);
       const a2 = new WhereClause([new Nodes.SqlLiteral("a")]);
       const b = new WhereClause([new Nodes.SqlLiteral("b")]);
-      expect(eql(a1, a2)).toBe(true);
-      expect(eql(a1, b)).toBe(false);
+      expect(a1.equals(a2)).toBe(true);
+      expect(a1.equals(b)).toBe(false);
     });
   });
 });

--- a/packages/activerecord/src/relation/where-clause.ts
+++ b/packages/activerecord/src/relation/where-clause.ts
@@ -43,6 +43,16 @@ export class WhereClause {
     return this.predicates.length > 0;
   }
 
+  /** Mirrors: where_clause.rb:14 `def +(other)` — Ruby `Array#+`, a plain concatenation. */
+  plus(other: WhereClause): WhereClause {
+    return new WhereClause([...this.predicates, ...other.predicates]);
+  }
+
+  /** Mirrors: where_clause.rb:18 `def -(other)` — Ruby `Array#-`. */
+  minus(other: WhereClause): WhereClause {
+    return new WhereClause(subtractNodes(this.predicates, other.predicates));
+  }
+
   merge(other: WhereClause): WhereClause {
     // Rails: remove predicates from self that conflict with other's attributes,
     // then union with other's predicates (other wins on conflict)
@@ -50,9 +60,12 @@ export class WhereClause {
     return new WhereClause(unionNodes(filtered, other.predicates));
   }
 
-  // Rails WhereClause#| — array union of predicates (dedups identical
-  // predicates, keeps distinct ones). Used by Relation#and! which ANDs both
-  // clauses' conditions together rather than letting one win on conflict.
+  /**
+   * Mirrors: where_clause.rb:22 `def |(other)` — Ruby `Array#|`, which dedups
+   * identical predicates and keeps distinct ones. Named `union` after the Ruby
+   * operator's name (`Array#|` is "union"), the spelling
+   * `operator-order-spelling.ts` pins for this class.
+   */
   union(other: WhereClause): WhereClause {
     return new WhereClause(unionNodes(this.predicates, other.predicates));
   }
@@ -78,36 +91,41 @@ export class WhereClause {
   }
 
   or(other: WhereClause): WhereClause {
-    const selfPreds = this.predicates;
-    const otherPreds = other.predicates;
+    const leftClause = this.minus(other);
+    const common = this.minus(leftClause);
+    const rightClause = other.minus(common);
 
-    const leftOnly = subtractNodes(selfPreds, otherPreds);
-    const common = subtractNodes(selfPreds, leftOnly);
-    const rightOnly = subtractNodes(otherPreds, common);
+    if (leftClause.isEmpty() || rightClause.isEmpty()) {
+      return common;
+    } else {
+      let left: Nodes.Node = leftClause.ast;
+      if (left instanceof Nodes.Grouping && left.expr instanceof Nodes.Node) left = left.expr;
 
-    if (leftOnly.length === 0 || rightOnly.length === 0) {
-      return new WhereClause([...common]);
+      let right: Nodes.Node = rightClause.ast;
+      if (right instanceof Nodes.Grouping && right.expr instanceof Nodes.Node) right = right.expr;
+
+      const orClause =
+        left instanceof Nodes.Or
+          ? new Nodes.Or([...left.children, right])
+          : new Nodes.Or([left, right]);
+
+      common.predicates.push(new Nodes.Grouping(orClause));
+      return common;
     }
-
-    let leftAst: Nodes.Node = leftOnly.length === 1 ? leftOnly[0] : new Nodes.And(leftOnly);
-    if (leftAst instanceof Nodes.Grouping && leftAst.expr instanceof Nodes.Node)
-      leftAst = leftAst.expr;
-
-    let rightAst: Nodes.Node = rightOnly.length === 1 ? rightOnly[0] : new Nodes.And(rightOnly);
-    if (rightAst instanceof Nodes.Grouping && rightAst.expr instanceof Nodes.Node)
-      rightAst = rightAst.expr;
-
-    const orNode =
-      leftAst instanceof Nodes.Or
-        ? new Nodes.Or([...leftAst.children, rightAst])
-        : new Nodes.Or([leftAst, rightAst]);
-
-    return new WhereClause([...common, new Nodes.Grouping(orNode)]);
   }
 
   get ast(): Nodes.Node {
     const wrapped = this.predicatesWithWrappedSqlLiterals();
     return wrapped.length === 1 ? wrapped[0] : new Nodes.And(wrapped);
+  }
+
+  /** Mirrors: where_clause.rb:75 `def ==(other)`, aliased `eql?`. */
+  equals(other: unknown): boolean {
+    return (
+      other instanceof WhereClause &&
+      this.predicates.length === other.predicates.length &&
+      this.predicates.every((predicate, i) => predicate.eql(other.predicates[i]))
+    );
   }
 
   isContradiction(): boolean {

--- a/packages/activerecord/src/relation/where-clause.ts
+++ b/packages/activerecord/src/relation/where-clause.ts
@@ -53,13 +53,6 @@ export class WhereClause {
     return new WhereClause(subtractNodes(this.predicates, other.predicates));
   }
 
-  merge(other: WhereClause): WhereClause {
-    // Rails: remove predicates from self that conflict with other's attributes,
-    // then union with other's predicates (other wins on conflict)
-    const filtered = this.exceptPredicates(other.extractAttributes());
-    return new WhereClause(unionNodes(filtered, other.predicates));
-  }
-
   /**
    * Mirrors: where_clause.rb:22 `def |(other)` — Ruby `Array#|`, which dedups
    * identical predicates and keeps distinct ones. Named `union` after the Ruby
@@ -68,6 +61,13 @@ export class WhereClause {
    */
   union(other: WhereClause): WhereClause {
     return new WhereClause(unionNodes(this.predicates, other.predicates));
+  }
+
+  merge(other: WhereClause): WhereClause {
+    // Rails: remove predicates from self that conflict with other's attributes,
+    // then union with other's predicates (other wins on conflict)
+    const filtered = this.exceptPredicates(other.extractAttributes());
+    return new WhereClause(unionNodes(filtered, other.predicates));
   }
 
   invert(): WhereClause {

--- a/packages/activerecord/src/test-helpers/i18n.ts
+++ b/packages/activerecord/src/test-helpers/i18n.ts
@@ -1,21 +1,11 @@
 /**
- * Active Record's arm of the same load-path stand-in Active Model's
- * `test-helpers/i18n.ts` documents: a fresh backend plus the `en.yml` data
- * Rails' `I18n.load_path` would re-read.
+ * Active Record's arm of `activemodel/src/test-helpers/i18n.ts`: a fresh
+ * backend, with `I18n.load_path` re-supplying the framework locales.
  */
 import { I18n } from "@blazetrails/activemodel";
-import { en as activemodelEn } from "@blazetrails/activemodel/locale/en";
-import { en } from "../locale/en.js";
+import "../i18n.js";
 
-/**
- * A fresh backend carrying the framework locales, as Rails' load path supplies
- * them. `backend` is the `I18n.backend = ...` half of the stand-in: Rails test
- * cases that need a mixin over `Simple` declare their own backend class and
- * assign an instance of it (activerecord/test/cases/validations/
- * i18n_generate_message_validation_test.rb:14).
- */
-export function resetI18n(backend: I18n.Base = new I18n.Simple()): void {
-  I18n.setBackend(backend);
-  I18n.backend().storeTranslations("en", activemodelEn);
-  I18n.backend().storeTranslations("en", en);
+/** A fresh backend; Rails' load path re-supplies the framework locales. */
+export function resetI18n(): void {
+  I18n.setBackend(new I18n.Simple());
 }

--- a/packages/activerecord/src/validations/i18n-generate-message-validation.test.ts
+++ b/packages/activerecord/src/validations/i18n-generate-message-validation.test.ts
@@ -3,7 +3,7 @@ import { Base } from "../index.js";
 import { I18n } from "@blazetrails/activemodel";
 import { RecordInvalid } from "../validations.js";
 import { fixtures } from "../test-fixtures.js";
-import { resetI18n } from "../test-helpers/i18n.js";
+import "../i18n.js";
 
 vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
 fixtures({});
@@ -18,22 +18,23 @@ describe("I18nGenerateMessageValidationTest", () => {
   /**
    * Mirrors: activerecord/test/cases/validations/i18n_generate_message_validation_test.rb:17-25
    * — snapshots the load path and backend, clears/replaces both, yields, and
-   * restores both in `ensure`. Trails' framework locales are modules rather
-   * than load-path entries, so a fresh backend is the whole of
-   * `I18n.load_path.clear` plus `I18n.backend = Backend.new`.
+   * restores both in `ensure`.
    */
   function resetI18nLoadPath(fn: () => void): void {
+    const oldLoadPath = [...I18n.loadPath()];
     const oldBackend = I18n.backend();
+    I18n.loadPath().length = 0;
     I18n.setBackend(new Backend());
     try {
       fn();
     } finally {
+      I18n.loadPath().splice(0, I18n.loadPath().length, ...oldLoadPath);
       I18n.setBackend(oldBackend);
     }
   }
 
   beforeEach(() => {
-    resetI18n(new Backend());
+    I18n.setBackend(new Backend());
   });
   afterAll(() => {
     vi.unstubAllEnvs();

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -186,6 +186,12 @@ const MIRROR_CANDIDATE_OVERRIDES: Record<string, string[]> = {
   to_ary: ["toArray"],
   "==": ["equals"],
   "<=>": ["compare"],
+  // `WhereClause#+` / `#-` / `#|` (relation/where_clause.rb:14, :18, :22) —
+  // named `plus` / `minus` / `union`, the spellings OPERATOR_SPELLING_BY_FQN
+  // pins for that class.
+  "+": ["plus"],
+  "-": ["minus"],
+  "|": ["union"],
   initialize_copy: ["clone", "dup"],
   initialize_dup: ["dup"],
   initialize_clone: ["clone"],

--- a/scripts/api-compare/operator-order-spelling.ts
+++ b/scripts/api-compare/operator-order-spelling.ts
@@ -79,6 +79,16 @@ export const OPERATOR_SPELLING_BY_FQN: Record<string, Record<string, string[]>> 
   "ActiveRecord::Reflection::MacroReflection": { "==": ["equals"] },
   // relation/from_clause.rb:21 `def ==(other)` → relation/from-clause.ts `equals`.
   "ActiveRecord::Relation::FromClause": { "==": ["equals"] },
+  // relation/where_clause.rb:14 `def +(other)` / :18 `def -(other)` / :22
+  // `def |(other)` / :75 `def ==(other)` → relation/where-clause.ts `plus` /
+  // `minus` / `union` / `equals`. `|` keeps the `union` spelling the class
+  // already used for Ruby `Array#|`.
+  "ActiveRecord::Relation::WhereClause": {
+    "+": ["plus"],
+    "-": ["minus"],
+    "|": ["union"],
+    "==": ["equals"],
+  },
   // connection_adapters/mysql/type_metadata.rb:18 `def ==(other)` →
   // connection-adapters/mysql/type-metadata.ts `equals`.
   "ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata": { "==": ["equals"] },


### PR DESCRIPTION
Bundle of two stories.

## 1. Register Active Model's / Active Record's `en` on `I18n.load_path`

Sibling arms of #6017. Both packages stored their locale straight into the
backend, so `I18n.reloadBang()` dropped it permanently. Rails appends the
locale from the `ActiveSupport.on_load(:i18n)` hook at the bottom of
`active_model.rb` / `active_record.rb`, and `Simple#init_translations`
(`i18n/lib/i18n/backend/simple.rb:83-86`) reads the path back on first use and
after every `I18n.reload!`.

- `activemodel/src/i18n.ts`, `activerecord/src/i18n.ts` — `registerLocaleModule`
  then `I18n.loadPath().push(...)`, the shape `activesupport/src/i18n.ts` settled
  on in #6017. The header paragraphs excusing the direct `storeTranslations` are
  gone (also from the two `locale/en.ts` headers).
- `activerecord/src/test-helpers/i18n.ts` — the invented `backend` parameter and
  the two `storeTranslations` calls are gone; `resetI18n()` is now Rails' single
  `I18n.backend = I18n::Backend::Simple.new`. Same for the Active Model helper
  (its `resetI18nEmpty` collapsed into `resetI18n` and was deleted).
- `i18n-generate-message-validation.test.ts` — `resetI18nLoadPath` now snapshots,
  clears and restores the load path as well as the backend, per
  `activerecord/test/cases/validations/i18n_generate_message_validation_test.rb:17-25`,
  and `beforeEach` is Rails' bare `I18n.backend = Backend.new` (:14).
- `i18n.trails.test.ts` — covers the acceptance criterion that `reloadBang()`
  re-reads both locales instead of dropping them.

One Active Model case (`errors full messages uses format`) now clears the load
path locally: with the framework `en.yml` on the path, the lazily-loaded
`errors.format` would overwrite the format the test stores. Rails clears the
load path for the whole file in setup (`i18n_validation_test.rb:12`); trails
only needs it for the one colliding case, because the other cases resolve their
messages through the file data.

## 2. `WhereClause` `+` `-` `|` `==`

`where_clause.rb:14, :18, :22, :75` had no TS members.

- `plus` / `minus` ported; `|` maps onto the existing `union` (Ruby `Array#|` is
  "union" — this converges the previously-unmapped member into the operator slot
  rather than adding a fifth); `==` → `equals`, the settled spelling.
- `or` (`:35-58`) rewritten on `minus` / `isEmpty` / `ast`, matching the Ruby
  line for line instead of hand-rolling the same arithmetic over raw arrays.
- `where-clause.test.ts` — the hand-rolled `concat` / `eql` helpers (exactly what
  the story predicted) are replaced by `plus` / `equals`.
- `operator-order-spelling.ts` — the four `(fqn, operator) → spelling` entries,
  cited at both ends; manifest build stays green.
- Callers converged onto the new members: `where!` (`query_methods.rb:1044`
  `self.where_clause += build_where_clause(opts, rest)`), `rewhere`
  (`:1068`) and the three `where.not` arms (`:52`
  `@scope.where_clause += where_clause.invert`) hand-rolled the concatenation
  by pushing into `predicates` in place; they now use `plus`, as Rails' `+=`
  does.
- `extra-surface.ts` — `+` / `-` / `|` join `==` / `<=>` in
  `MIRROR_CANDIDATE_OVERRIDES` so the operator ports are matched, not counted as
  novel surface (`api:extra` for `where-clause.ts`: 0 novel).

Gates: `api:calls` OK (14 baselined), `api:calls:wide` OK, `api:extra` no new
novel surface, `api:compare` unchanged, no new baseline rows.

Closes-story: am-ar-i18n-register-en-on-load-path
Closes-story: where-clause-operator-methods-unported
