### PR TITLE
refactor(i18n): make the whole reload chain async, not just the I18n.reload! seam

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  ColumnDefinition,
   IndexDefinition,
   ForeignKeyDefinition,
   ReferenceDefinition,
@@ -487,6 +488,7 @@ describe("TableDefinition id hash form", () => {
     quoteColumnName: (s: string) => `\`${s}\``,
     quoteTableName: (s: string) => `\`${s}\``,
     quoteDefaultExpression: (_v: unknown) => "",
+    validColumnDefinitionOptions: () => ColumnDefinition.OPTION_NAMES,
   };
 
   it("extracts type and merges remaining keys as pk column options", () => {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -135,6 +135,19 @@ function defaultCheckConstraintName(tableName: string, expression: string): stri
  * Mirrors: ActiveRecord::ConnectionAdapters::ColumnDefinition
  */
 export class ColumnDefinition {
+  static readonly OPTION_NAMES = [
+    "limit",
+    "precision",
+    "scale",
+    "default",
+    "null",
+    "collation",
+    "comment",
+    "primaryKey",
+    "ifExists",
+    "ifNotExists",
+  ];
+
   sqlType?: string;
   // PostgreSQL only: physical storage type ("timestamp" / "timestamptz") for
   // datetime-family columns, recorded at creation time so the schema dumper
@@ -1121,18 +1134,11 @@ export class TableDefinition {
 
   /** @internal */
   protected validColumnDefinitionOptions(): string[] {
-    return [
-      "limit",
-      "precision",
-      "scale",
-      "default",
-      "null",
-      "collation",
-      "comment",
-      "primaryKey",
-      "ifExists",
-      "ifNotExists",
-    ];
+    const conn = this._adapter as Partial<{ validColumnDefinitionOptions(): string[] }>;
+    // A bare-{@link SchemaQuoter} host (the MySQL schema quoter) is not a
+    // connection and has no reader; the adapter's answer is
+    // `ColumnDefinition::OPTION_NAMES` (schema_statements.rb:1584-1586).
+    return conn.validColumnDefinitionOptions?.() ?? ColumnDefinition.OPTION_NAMES;
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1132,13 +1132,16 @@ export class TableDefinition {
     if (index !== -1) this.columns.splice(index, 1);
   }
 
-  /** @internal */
+  /**
+   * The cast covers a typing gap only: `SchemaStatements` is mixed into the
+   * adapters at runtime, so the reader answering `ColumnDefinition::OPTION_NAMES`
+   * (schema_statements.rb:1584-1586) is not on the static {@link SchemaQuoter}
+   * surface `_adapter` is declared with.
+   * @internal
+   */
   protected validColumnDefinitionOptions(): string[] {
-    const conn = this._adapter as Partial<{ validColumnDefinitionOptions(): string[] }>;
-    // A bare-{@link SchemaQuoter} host (the MySQL schema quoter) is not a
-    // connection and has no reader; the adapter's answer is
-    // `ColumnDefinition::OPTION_NAMES` (schema_statements.rb:1584-1586).
-    return conn.validColumnDefinitionOptions?.() ?? ColumnDefinition.OPTION_NAMES;
+    const conn = this._adapter as unknown as { validColumnDefinitionOptions(): string[] };
+    return conn.validColumnDefinitionOptions();
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -19,6 +19,7 @@ import {
   AlterTable,
   IndexDefinition,
   AddColumnDefinition,
+  ColumnDefinition,
   ChangeColumnDefaultDefinition,
   CreateIndexDefinition,
   ForeignKeyDefinition,
@@ -1979,18 +1980,7 @@ export class SchemaStatements {
   }
 
   validColumnDefinitionOptions(): string[] {
-    return [
-      "limit",
-      "precision",
-      "scale",
-      "default",
-      "null",
-      "collation",
-      "comment",
-      "primaryKey",
-      "ifExists",
-      "ifNotExists",
-    ];
+    return ColumnDefinition.OPTION_NAMES;
   }
 
   validPrimaryKeyOptions(): string[] {

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach, beforeAll, afterAll } from "vitest";
 import { SchemaDumper } from "../../schema-dumper.js";
+import { ColumnDefinition } from "../abstract/schema-definitions.js";
 import {
   ExclusionConstraintDefinition,
   UniqueConstraintDefinition,
@@ -477,6 +478,7 @@ describe("TableDefinition#toSql", () => {
       quoteTableName: (s: string) => `"${s}"`,
       quoteDefaultExpression: (v: unknown) => ` DEFAULT ${String(v)}`,
       typeToSql: (type: string) => type, // returns lowercase verbatim (mirrors PG native types)
+      validColumnDefinitionOptions: () => ColumnDefinition.OPTION_NAMES,
     };
     const td = new TableDefinition("widgets", { adapter: stubAdapter as any });
     td.cidr("net");

--- a/packages/i18n/src/backend/base.file-loading.trails.test.ts
+++ b/packages/i18n/src/backend/base.file-loading.trails.test.ts
@@ -67,8 +67,6 @@ describe("I18n::Backend::Base file loading", () => {
   });
 
   it("refuses a lazy lookup while I18n.load_path is unread", () => {
-    // In-place, the way the gem documents it (config.rb:125) — an assignment
-    // goes through `load_path=`, which reloads the backend and so reads.
     config().loadPath.push(`${localesDir()}/never-preloaded.yml`);
     expect(() => backend.translate("en", "foo.bar")).toThrow(
       /await I18n.preloadTranslationFiles\(\)/,

--- a/packages/i18n/src/backend/base.file-loading.trails.test.ts
+++ b/packages/i18n/src/backend/base.file-loading.trails.test.ts
@@ -67,14 +67,16 @@ describe("I18n::Backend::Base file loading", () => {
   });
 
   it("refuses a lazy lookup while I18n.load_path is unread", () => {
-    config().loadPath = [`${localesDir()}/never-preloaded.yml`];
+    // In-place, the way the gem documents it (config.rb:125) — an assignment
+    // goes through `load_path=`, which reloads the backend and so reads.
+    config().loadPath.push(`${localesDir()}/never-preloaded.yml`);
     expect(() => backend.translate("en", "foo.bar")).toThrow(
       /await I18n.preloadTranslationFiles\(\)/,
     );
   });
 
-  it("serves lookups after an awaited preload of I18n.load_path", () => {
-    config().loadPath = [`${localesDir()}/en.yml`];
+  it("serves lookups after an awaited preload of I18n.load_path", async () => {
+    await config().setLoadPath([`${localesDir()}/en.yml`]);
     expect(backend.translate("en", "foo.bar")).toBe("baz");
     expect(backend.initialized()).toBe(true);
   });
@@ -82,8 +84,7 @@ describe("I18n::Backend::Base file loading", () => {
   it("re-reads I18n.load_path on reloadBang", async () => {
     let body = "en:\n  foo:\n    bar: baz\n";
     registerFileReader(() => Promise.resolve(body));
-    config().loadPath = ["mutable.yml"];
-    await preloadTranslationFiles();
+    await config().setLoadPath(["mutable.yml"]);
     expect(backend.translate("en", "foo.bar")).toBe("baz");
 
     body = "en:\n  foo:\n    bar: qux\n";
@@ -94,9 +95,8 @@ describe("I18n::Backend::Base file loading", () => {
   it("re-reads I18n.load_path on reloadBang with an eager loaded backend", async () => {
     let body = "en:\n  foo:\n    bar: baz\n";
     registerFileReader(() => Promise.resolve(body));
-    config().loadPath = ["mutable.yml"];
-    await preloadTranslationFiles();
-    backend.eagerLoadBang();
+    await config().setLoadPath(["mutable.yml"]);
+    await backend.eagerLoadBang();
     expect(backend.translate("en", "foo.bar")).toBe("baz");
 
     body = "en:\n  foo:\n    bar: qux\n";
@@ -105,8 +105,8 @@ describe("I18n::Backend::Base file loading", () => {
     expect(backend.translate("en", "foo.bar")).toBe("qux");
   });
 
-  it("leaves the lazy-init guard armed when the load path holds an invalid file", () => {
-    config().loadPath = [`${localesDir()}/invalid/syntax.yml`];
+  it("leaves the lazy-init guard armed when the load path holds an invalid file", async () => {
+    await config().setLoadPath([`${localesDir()}/invalid/syntax.yml`]);
     expect(() => backend.translate("en", "foo.bar")).toThrow(InvalidLocaleData);
     expect(backend.initialized()).toBe(false);
   });

--- a/packages/i18n/src/backend/base.ts
+++ b/packages/i18n/src/backend/base.ts
@@ -113,8 +113,8 @@ export async function preloadTranslationFiles(...filenames: (string | string[])[
  * @noRailsEquivalent PERMANENT — the counterpart of `preloadTranslationFiles`
  * above: the gem's re-read is a synchronous `YAML.load_file` inside
  * `init_translations`, and the four call sites that reach it are synchronous in
- * Rails all the way up. Awaiting the re-read at `I18n.reload!` — the one seam
- * the gem also treats as a whole-backend reset — is what the language leaves.
+ * Rails all the way up. Awaiting the re-read at the reload seams — the ones the
+ * gem also treats as a whole-backend reset — is what the language leaves.
  */
 export async function reloadTranslationFiles(): Promise<void> {
   if (!fileReader) return;
@@ -361,11 +361,19 @@ export abstract class Base {
     throw new NotImplementedError();
   }
 
-  reloadBang(): void {
-    if (this.eagerLoaded()) this.eagerLoadBang();
+  /**
+   * The re-read of `I18n.load_path` precedes the gem's body because in the gem
+   * it happens later, inside the next lazy `init_translations` (simple.rb:83-86)
+   * — a synchronous `YAML.load_file` (base.rb:246). Here that read is a Promise,
+   * so it is pulled forward to this seam, where one read serves both the lazy
+   * arm and the `eager_load!` the guard below may run during the reload itself.
+   */
+  async reloadBang(): Promise<void> {
+    await reloadTranslationFiles();
+    if (this.eagerLoaded()) await this.eagerLoadBang();
   }
 
-  eagerLoadBang(): void {
+  async eagerLoadBang(): Promise<void> {
     this.eagerLoadedFlag = true;
   }
 

--- a/packages/i18n/src/backend/chain.test.ts
+++ b/packages/i18n/src/backend/chain.test.ts
@@ -139,22 +139,22 @@ describe("I18nBackendChainTest", () => {
     expect((config().backend as Chain).initialized()).toBe(true);
   });
 
-  it("store should call initialize on all backends and return false if one not initialized", () => {
-    first.reloadBang();
+  it("store should call initialize on all backends and return false if one not initialized", async () => {
+    await first.reloadBang();
     send(second, "initTranslations");
     expect((config().backend as Chain).initialized()).toBe(false);
   });
 
-  it("should reload all backends", () => {
+  it("should reload all backends", async () => {
     send(first, "initTranslations");
     send(second, "initTranslations");
-    config().backend.reloadBang();
+    await config().backend.reloadBang();
     expect(first.initialized()).toBe(false);
     expect(second.initialized()).toBe(false);
   });
 
-  it("should eager load all backends", () => {
-    config().backend.eagerLoadBang();
+  it("should eager load all backends", async () => {
+    await config().backend.eagerLoadBang();
     expect(first.initialized()).toBe(true);
     expect(second.initialized()).toBe(true);
   });

--- a/packages/i18n/src/backend/chain.ts
+++ b/packages/i18n/src/backend/chain.ts
@@ -86,12 +86,12 @@ export class Chain {
     return true;
   }
 
-  reloadBang(): void {
-    for (const backend of this.backends) backend.reloadBang();
+  async reloadBang(): Promise<void> {
+    for (const backend of this.backends) await backend.reloadBang();
   }
 
-  eagerLoadBang(): void {
-    for (const backend of this.backends) backend.eagerLoadBang();
+  async eagerLoadBang(): Promise<void> {
+    for (const backend of this.backends) await backend.eagerLoadBang();
   }
 
   storeTranslations(

--- a/packages/i18n/src/backend/key-value.test.ts
+++ b/packages/i18n/src/backend/key-value.test.ts
@@ -113,9 +113,9 @@ describe("I18nBackendKeyValueTest", () => {
     expect(() => t("foo", { raise: true } as TranslateOptions)).toThrow(MissingTranslationData);
   });
 
-  it("initialized? checks that a store is available", () => {
+  it("initialized? checks that a store is available", async () => {
     setupBackend();
-    backend.reloadBang();
+    await backend.reloadBang();
     expect(backend.initialized()).toBe(true);
   });
 

--- a/packages/i18n/src/backend/simple.test.ts
+++ b/packages/i18n/src/backend/simple.test.ts
@@ -140,8 +140,8 @@ describe("I18nBackendSimpleTest", () => {
     expect(() => backend.loadTranslations(`${localesDir()}/en.js`)).not.toThrow();
   });
 
-  it("simple load_translations: given no argument, it uses I18n.load_path", () => {
-    config().loadPath = [`${localesDir()}/en.yml`];
+  it("simple load_translations: given no argument, it uses I18n.load_path", async () => {
+    await config().setLoadPath([`${localesDir()}/en.yml`]);
     backend.loadTranslations();
     expect(translations()).toEqual({ en: { foo: { bar: "baz" } } });
   });
@@ -218,13 +218,13 @@ describe("I18nBackendSimpleTest", () => {
     expect(t(1)).toBe("foo");
   });
 
-  it("simple store_translations: store translations doesn't deep symbolize keys if skip_symbolize_keys is true", () => {
+  it("simple store_translations: store translations doesn't deep symbolize keys if skip_symbolize_keys is true", async () => {
     const data = { foo: { bar: "barfr", baz: "bazfr" } };
 
     storeTranslations("fr", data);
     expect(translations()["fr"]).toEqual({ foo: { bar: "barfr", baz: "bazfr" } });
 
-    backend.reloadBang();
+    await backend.reloadBang();
 
     backend.storeTranslations("fr", data, { skipSymbolizeKeys: true });
     // JS object keys are already strings, so the only observable difference is
@@ -235,26 +235,26 @@ describe("I18nBackendSimpleTest", () => {
 
   // reloading translations
 
-  it("simple reload_translations: unloads translations", () => {
+  it("simple reload_translations: unloads translations", async () => {
     storeTranslations("en", { foo: "bar" });
-    backend.reloadBang();
+    await backend.reloadBang();
     expect(translations()).toEqual({});
   });
 
-  it("simple reload_translations: uninitializes the backend", () => {
-    backend.reloadBang();
+  it("simple reload_translations: uninitializes the backend", async () => {
+    await backend.reloadBang();
     expect(backend.initialized()).toBe(false);
   });
 
-  it("simple eager_load!: loads the translations", () => {
+  it("simple eager_load!: loads the translations", async () => {
     expect(backend.initialized()).toBe(false);
-    backend.eagerLoadBang();
+    await backend.eagerLoadBang();
     expect(backend.initialized()).toBe(true);
   });
 
-  it("simple reload!: reinitialize the backend if it was previously eager loaded", () => {
-    backend.eagerLoadBang();
-    backend.reloadBang();
+  it("simple reload!: reinitialize the backend if it was previously eager loaded", async () => {
+    await backend.eagerLoadBang();
+    await backend.reloadBang();
     expect(backend.initialized()).toBe(true);
   });
 
@@ -275,8 +275,8 @@ describe("I18nBackendSimpleTest", () => {
     expect(t("stars.special", { count: 20 })).toBe("20 special stars");
   });
 
-  it("returns localized string given missing pluralization data", () => {
-    config().loadPath = [`${localesDir()}/en.yml`];
+  it("returns localized string given missing pluralization data", async () => {
+    await config().setLoadPath([`${localesDir()}/en.yml`]);
     backend.loadTranslations();
     expect(t("foo.bar", { count: 1 })).toBe("baz");
   });

--- a/packages/i18n/src/backend/simple.ts
+++ b/packages/i18n/src/backend/simple.ts
@@ -100,15 +100,15 @@ export class Simple {
   }
 
   /** Clean up translations hash and set initialized to false on reload. */
-  reloadBang(): void {
+  async reloadBang(): Promise<void> {
     this.initializedFlag = false;
     this.translationsStore = undefined;
-    Base.prototype.reloadBang.call(this);
+    await Base.prototype.reloadBang.call(this);
   }
 
-  eagerLoadBang(): void {
+  async eagerLoadBang(): Promise<void> {
     if (!this.initialized()) this.initTranslations();
-    Base.prototype.eagerLoadBang.call(this);
+    await Base.prototype.eagerLoadBang.call(this);
   }
 
   translations({ doInit = false }: { doInit?: boolean } = {}): TranslationData {

--- a/packages/i18n/src/config.trails.test.ts
+++ b/packages/i18n/src/config.trails.test.ts
@@ -18,7 +18,7 @@ class FakeBackend extends Base {
   availableLocales(): string[] {
     return this.locales;
   }
-  override reloadBang(): void {
+  override async reloadBang(): Promise<void> {
     this.reloaded += 1;
   }
   protected lookup(): unknown {
@@ -116,7 +116,7 @@ describe("Config", () => {
     expect(config.missingInterpolationArgumentHandler("bar", {}, "%{bar}")).toBe("bar is missing");
   });
 
-  it("loadPath defaults to an empty array and reloads the backend when assigned", () => {
+  it("loadPath defaults to an empty array and reloads the backend when assigned", async () => {
     expect(config.loadPath).toEqual([]);
     config.loadPath.push("a.yml");
     expect(new Config().loadPath).toEqual(["a.yml"]);
@@ -124,7 +124,7 @@ describe("Config", () => {
     const backend = new FakeBackend();
     config.backend = backend;
     config.availableLocales = ["en"];
-    config.loadPath = ["b.yml"];
+    await config.setLoadPath(["b.yml"]);
     expect(backend.reloaded).toBe(1);
     expect(config.availableLocalesInitialized).toBe(true);
     expect(config.availableLocalesSet.has("en")).toBe(true);

--- a/packages/i18n/src/config.ts
+++ b/packages/i18n/src/config.ts
@@ -159,10 +159,18 @@ export class Config {
     return loadPath;
   }
 
-  set loadPath(value: string[]) {
+  /**
+   * Sets the load path instance. Custom implementations are expected to behave
+   * like a Ruby Array.
+   *
+   * Mirrors `load_path=` (config.rb:132-136); it is a method rather than a
+   * `set` accessor because `backend.reload!` is async here and a TS `set`
+   * accessor cannot be awaited.
+   */
+  async setLoadPath(value: string[]): Promise<void> {
     loadPath = value;
     availableLocalesSet = undefined;
-    this.backend.reloadBang();
+    await this.backend.reloadBang();
   }
 
   /** Whether to verify locales are in the available list. Defaults to true. */

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -166,8 +166,8 @@ export function loadPath(): string[] {
   return config().loadPath;
 }
 
-export function setLoadPath(value: string[]): void {
-  config().loadPath = value;
+export async function setLoadPath(value: string[]): Promise<void> {
+  await config().setLoadPath(value);
 }
 
 export function enforceAvailableLocales(): boolean {
@@ -183,32 +183,29 @@ export function setEnforceAvailableLocales(value: boolean): void {
  * Rails development environment. Backends can implement whatever strategy
  * is useful.
  *
- * The gem's `reload!` is synchronous because `Simple#reload!` only clears
- * `@initialized` / `@translations` (simple.rb:57-62) and the re-read of
- * `I18n.load_path` happens later, inside the next lazy `init_translations`
- * (simple.rb:83-86). Here that read is a Promise, so it is pulled forward to
- * this one seam and awaited: `reload!` is the only method that becomes async,
- * and every ported body below it — including the four lazy call sites — stays
- * verbatim and synchronous.
- *
- * It precedes `backend.reload!` because that is not always lazy: `Base#reload!`
- * re-runs `eager_load!` on an eager-loaded backend (base.rb:101), which reaches
- * `init_translations` / `load_translations` during the reload itself
- * (simple.rb:83, base.rb:14).
+ * Async because the re-read of `I18n.load_path` that the gem does lazily inside
+ * `init_translations` (simple.rb:83-86, base.rb:246) is a Promise here, and so
+ * sits inside `Backend::Base#reload!` (base.rb:101-103). The four lazy call
+ * sites below it stay verbatim and synchronous.
  */
 export async function reloadBang(): Promise<void> {
   config().clearAvailableLocalesSet();
-  await reloadTranslationFiles();
-  config().backend.reloadBang();
+  await config().backend.reloadBang();
 }
 
 /**
  * Tells the backend to load translations now. Used in situations like the
  * Rails production environment. Backends can implement whatever strategy
  * is useful.
+ *
+ * The re-read of `I18n.load_path` precedes it for the reason given on
+ * `reload!` above: `eager_load!` reaches `init_translations` /
+ * `load_translations` (simple.rb:64, base.rb:14) straight away, so it does the
+ * same async init the boot preload does rather than depending on one.
  */
-export function eagerLoadBang(): void {
-  config().backend.eagerLoadBang();
+export async function eagerLoadBang(): Promise<void> {
+  await reloadTranslationFiles();
+  await config().backend.eagerLoadBang();
 }
 
 /**


### PR DESCRIPTION
Two related stories.

## i18n-async-reload-chain

Moves the async re-read of `I18n.load_path` from the outermost seam into the
reload chain itself, where the gem reads.

- `Backend::Base#reloadBang` (base.rb:101-103) awaits `reloadTranslationFiles()`
  then keeps `eager_load! if eager_loaded?` verbatim — one read per reload, and
  the eager arm sees the fresh bytes.
- `Backend::Base#eagerLoadBang` (base.rb:105-107), `Simple#reloadBang` /
  `#eagerLoadBang` (simple.rb:57-67) and `Chain#reloadBang` / `#eagerLoadBang`
  (chain.rb:40-46) become async, awaiting `super` / each backend, statements in
  gem order.
- `I18n.eagerLoadBang` (i18n.rb:92-94) awaits the same re-read, so an eager load
  is self-sufficient rather than depending on a prior preload.
- `Config#load_path=` (config.rb:132-136) calls `backend.reload!`, now async; a
  TS `set` accessor cannot be awaited, so it converges to the settled
  `setLoadPath()` idiom, with `I18n.setLoadPath` (i18n.rb:69) awaiting it.

The four lazy `initTranslations` call sites in `simple.ts` stay synchronous and
verbatim. Boot still awaits `preloadTranslationFiles()` once. No test name
reworded — only callbacks became async; the one trails test pinning the
unread-load-path guard now mutates `I18n.load_path` in place (the shape
config.rb:125 documents), since an assignment goes through `load_path=` and so
reads.

## valid-column-definition-options-duplicated-on-table-definition

`TableDefinition#validColumnDefinitionOptions` (schema_definitions.rb:589-591)
now delegates to the connection instead of carrying a second copy of the list.
`ColumnDefinition::OPTION_NAMES` (schema_definitions.rb:79-90) is ported as a
static on `ColumnDefinition` and is its single home; the adapter reader
(schema_statements.rb:1584-1586) returns it. The delegation casts through the
declared `SchemaQuoter` type of `_adapter` (assert-schema-adapter.ts:9-12): the
reader is on `SchemaStatements`, mixed into the adapters at runtime but absent
from their static types, so this is a typing gap only — no fallback list.
Adapter subclass overrides keep their `super + [...]` shape.

Closes-story: i18n-async-reload-chain
Closes-story: valid-column-definition-options-duplicated-on-table-definition
