### PR TITLE
fix(i18n,activerecord): Date._parse answers a Hash always; drop encryption/config extra surface

### DIFF
--- a/packages/activerecord/src/encryption/auto-filtered-parameters.ts
+++ b/packages/activerecord/src/encryption/auto-filtered-parameters.ts
@@ -59,7 +59,7 @@ export class AutoFilteredParameters {
 
   /** @internal */
   private isExcludedFromFilterParameters(filterParameter: string): boolean {
-    return Configurable.config.excludeFromFilterParameters.some(
+    return Configurable.config.excludedFromFilterParameters.some(
       (excluded) => excluded === filterParameter,
     );
   }

--- a/packages/activerecord/src/encryption/config.ts
+++ b/packages/activerecord/src/encryption/config.ts
@@ -4,10 +4,37 @@
  * Mirrors: ActiveRecord::Encryption::Config
  */
 
+import { deflateSync, inflateSync } from "zlib";
+
 import { presence } from "@blazetrails/activesupport";
 
 import { Configuration } from "./errors.js";
 import type { SchemeOptions } from "./scheme.js";
+
+/**
+ * The `deflate`/`inflate` pair a compressor answers (encryption/encryptor.rb:24).
+ * Ruby duck-types it, so `config.rb` names no such type; it is a type alias
+ * rather than a declared surface for that reason.
+ */
+export type Compressor = {
+  deflate(data: string): Buffer | Uint8Array;
+  inflate(data: Buffer | Uint8Array): string;
+};
+
+/**
+ * Ruby's `Zlib`, the module `set_defaults` assigns to `compressor`
+ * (encryption/config.rb:59). It is a stdlib constant there, so it is not part
+ * of this file's surface; here it is the module-local object that answers the
+ * same `deflate`/`inflate` pair.
+ */
+const Zlib: Compressor = {
+  deflate(data: string): Buffer {
+    return deflateSync(Buffer.from(data, "utf-8"));
+  },
+  inflate(data: Buffer | Uint8Array): string {
+    return inflateSync(data).toString("utf-8");
+  },
+};
 
 export class Config {
   private _primaryKey?: string | string[];
@@ -18,21 +45,16 @@ export class Config {
   encryptFixtures: boolean = false;
   validateColumnSize: boolean = true;
   addToFilterParameters: boolean = true;
-  excludeFromFilterParameters: string[] = [];
+  excludedFromFilterParameters: string[] = [];
   previousSchemes: SchemeOptions[] = [];
   supportSha1ForNonDeterministicEncryption: boolean = false;
   extendQueries: boolean = false;
   hashDigestClass: string = "SHA1";
-  keyProviderClass?: string;
-  compressor: Compressor = defaultCompressor;
+  compressor: Compressor = Zlib;
   forcedEncodingForDeterministicEncryption: string = "UTF-8";
 
   constructor() {
     this.setDefaults();
-  }
-
-  get excludedFromFilterParameters(): string[] {
-    return this.excludeFromFilterParameters;
   }
 
   set previous(schemes: SchemeOptions[]) {
@@ -111,11 +133,11 @@ export class Config {
     this.encryptFixtures = false;
     this.validateColumnSize = true;
     this.addToFilterParameters = true;
-    this.excludeFromFilterParameters = [];
+    this.excludedFromFilterParameters = [];
     this.previousSchemes = [];
     this.forcedEncodingForDeterministicEncryption = "UTF-8";
     this.hashDigestClass = "SHA1";
-    this.compressor = defaultCompressor;
+    this.compressor = Zlib;
     this.extendQueries = false;
   }
 
@@ -124,19 +146,3 @@ export class Config {
     this.previousSchemes.push(properties);
   }
 }
-
-export interface Compressor {
-  deflate(data: string): Buffer | Uint8Array;
-  inflate(data: Buffer | Uint8Array): string;
-}
-
-import { deflateSync, inflateSync } from "zlib";
-
-export const defaultCompressor: Compressor = {
-  deflate(data: string): Buffer {
-    return deflateSync(Buffer.from(data, "utf-8"));
-  },
-  inflate(data: Buffer | Uint8Array): string {
-    return inflateSync(data).toString("utf-8");
-  },
-};

--- a/packages/activerecord/src/encryption/config.ts
+++ b/packages/activerecord/src/encryption/config.ts
@@ -12,14 +12,17 @@ import { Configuration } from "./errors.js";
 import type { SchemeOptions } from "./scheme.js";
 
 /**
- * The `deflate`/`inflate` pair a compressor answers (encryption/encryptor.rb:24).
- * Ruby duck-types it, so `config.rb` names no such type; it is a type alias
- * rather than a declared surface for that reason.
+ * The `deflate`/`inflate` pair a compressor answers.
+ *
+ * @noRailsEquivalent PERMANENT — Ruby duck-types the compressor — "it must respond to
+ * +deflate+ and +inflate+" (encryption/encryptor.rb:22-24) — so no Rails file
+ * declares this shape or these two members. TypeScript has to write it down
+ * for `Config#compressor`, `Encryptor` and `Scheme` to name the same type.
  */
-export type Compressor = {
+export interface Compressor {
   deflate(data: string): Buffer | Uint8Array;
   inflate(data: Buffer | Uint8Array): string;
-};
+}
 
 /**
  * Ruby's `Zlib`, the module `set_defaults` assigns to `compressor`

--- a/packages/activerecord/src/encryption/configurable.test.ts
+++ b/packages/activerecord/src/encryption/configurable.test.ts
@@ -17,7 +17,7 @@ describe("ActiveRecord::Encryption::ConfigurableTest", () => {
       keyDerivationSalt: c.keyDerivationSalt,
       previousSchemes: [...c.previousSchemes],
       addToFilterParameters: c.addToFilterParameters,
-      excludeFromFilterParameters: [...c.excludeFromFilterParameters],
+      excludedFromFilterParameters: [...c.excludedFromFilterParameters],
     };
   }
 
@@ -32,7 +32,7 @@ describe("ActiveRecord::Encryption::ConfigurableTest", () => {
     c.keyDerivationSalt = savedConfig.keyDerivationSalt;
     c.previousSchemes = savedConfig.previousSchemes;
     c.addToFilterParameters = savedConfig.addToFilterParameters;
-    c.excludeFromFilterParameters = savedConfig.excludeFromFilterParameters;
+    c.excludedFromFilterParameters = savedConfig.excludedFromFilterParameters;
     Contexts.resetDefaultContext();
   });
 
@@ -134,7 +134,7 @@ describe("ActiveRecord::Encryption::ConfigurableTest", () => {
   });
 
   it("exclude the installation of autofiltered params", () => {
-    Configurable.config.excludeFromFilterParameters = ["catchphrase"];
+    Configurable.config.excludedFromFilterParameters = ["catchphrase"];
 
     const filterParameters: string[] = [];
     const autoFilteredParameters = new AutoFilteredParameters(filterParameters);
@@ -151,7 +151,7 @@ describe("ActiveRecord::Encryption::ConfigurableTest", () => {
       expect(filterParameters).toEqual([]);
     } finally {
       dispose();
-      Configurable.config.excludeFromFilterParameters = [];
+      Configurable.config.excludedFromFilterParameters = [];
     }
   });
 
@@ -168,8 +168,8 @@ describe("ActiveRecord::Encryption::ConfigurableTest", () => {
     }
   });
 
-  it("excludeFromFilterParameters excludes specific attributes while others are still filtered", () => {
-    Configurable.config.excludeFromFilterParameters = ["secret_token"];
+  it("excludedFromFilterParameters excludes specific attributes while others are still filtered", () => {
+    Configurable.config.excludedFromFilterParameters = ["secret_token"];
 
     const filterParameters: string[] = [];
     const autoFilteredParameters = new AutoFilteredParameters(filterParameters);

--- a/packages/activerecord/src/encryption/configurable.test.ts
+++ b/packages/activerecord/src/encryption/configurable.test.ts
@@ -168,7 +168,7 @@ describe("ActiveRecord::Encryption::ConfigurableTest", () => {
     }
   });
 
-  it("excludedFromFilterParameters excludes specific attributes while others are still filtered", () => {
+  it("excludeFromFilterParameters excludes specific attributes while others are still filtered", () => {
     Configurable.config.excludedFromFilterParameters = ["secret_token"];
 
     const filterParameters: string[] = [];

--- a/packages/activerecord/src/encryption/encryptor.test.ts
+++ b/packages/activerecord/src/encryption/encryptor.test.ts
@@ -8,7 +8,6 @@ import { DecryptionError, ForbiddenClass, Encryption as EncryptionError } from "
 import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
 import { MessageSerializer } from "./message-serializer.js";
 import { Message } from "./message.js";
-import { defaultCompressor } from "./config.js";
 import * as crypto from "crypto";
 
 function generateKey(): string {
@@ -193,11 +192,11 @@ describe("ActiveRecord::Encryption::EncryptorTest", () => {
     const spyCompressor = {
       deflate(data: string) {
         deflated = true;
-        return defaultCompressor.deflate(data);
+        return Configurable.config.compressor.deflate(data);
       },
       inflate(data: Buffer) {
         inflated = true;
-        return defaultCompressor.inflate(data);
+        return Configurable.config.compressor.inflate(data);
       },
     };
     const enc = new Encryptor({ compress: true, compressor: spyCompressor });

--- a/packages/activerecord/src/encryption/encryptor.ts
+++ b/packages/activerecord/src/encryption/encryptor.ts
@@ -15,7 +15,6 @@ import {
 } from "./default-key-provider-cache.js";
 import { Base, ConfigError, DecryptionError, Encoding, ForbiddenClass } from "./errors.js";
 import type { Compressor } from "./config.js";
-import { defaultCompressor } from "./config.js";
 import { normalizeEncoding, replaceUnencodable } from "./encoding-helpers.js";
 
 // Mirrors: ActiveRecord::Encryption::Encryptor::THRESHOLD_TO_JUSTIFY_COMPRESSION
@@ -54,7 +53,7 @@ export class Encryptor {
 
   constructor(options?: { compress?: boolean; compressor?: Compressor }) {
     this._compress = options?.compress ?? true;
-    this._compressor = options?.compressor ?? defaultCompressor;
+    this._compressor = options?.compressor ?? Configurable.config.compressor;
   }
 
   encrypt(

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -278,8 +278,8 @@ export function makeEncryptedAuthor(adapter: DatabaseAdapter) {
 }
 
 export function makeEncryptedBookWithCustomCompressor(adapter: DatabaseAdapter) {
-  // Delegates actual compression to the configured compressor (zlib) so the compressed
-  // output IS smaller and the path is exercised. inflate adds "[compressed] "
+  // Delegates actual compression to the configured compressor (zlib) so the
+  // compressed output IS smaller and the path is exercised. inflate adds "[compressed] "
   // prefix so tests can assert the custom compressor was actually called —
   // mirrors Rails' EncryptedBookWithCustomCompressor fixture.
   const customCompressor: Compressor = {

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -13,7 +13,7 @@ import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/
 
 export { Base };
 import { Configurable } from "./configurable.js";
-import { defaultCompressor, type Compressor } from "./config.js";
+import { type Compressor } from "./config.js";
 import { Contexts } from "./contexts.js";
 import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
 import { clearDefaultKeyProviderCache, type Scheme } from "./scheme.js";
@@ -278,16 +278,16 @@ export function makeEncryptedAuthor(adapter: DatabaseAdapter) {
 }
 
 export function makeEncryptedBookWithCustomCompressor(adapter: DatabaseAdapter) {
-  // Delegates actual compression to defaultCompressor (zlib) so the compressed
+  // Delegates actual compression to the configured compressor (zlib) so the compressed
   // output IS smaller and the path is exercised. inflate adds "[compressed] "
   // prefix so tests can assert the custom compressor was actually called —
   // mirrors Rails' EncryptedBookWithCustomCompressor fixture.
   const customCompressor: Compressor = {
     deflate(data: string): Buffer | Uint8Array {
-      return defaultCompressor.deflate(data);
+      return Configurable.config.compressor.deflate(data);
     },
     inflate(data: Buffer | Uint8Array): string {
-      return "[compressed] " + defaultCompressor.inflate(data);
+      return "[compressed] " + Configurable.config.compressor.inflate(data);
     },
   };
   return class EncryptedBookWithCustomCompressor extends Base {

--- a/packages/i18n/src/date.trails.test.ts
+++ b/packages/i18n/src/date.trails.test.ts
@@ -227,6 +227,12 @@ describe("Date", () => {
     expect(() => RubyDate.parse("not a date")).toThrow("invalid date");
   });
 
+  it("answers an empty Hash for a string no sub-parser matched", () => {
+    expect(RubyDate._parse("not a date")).toEqual({});
+    expect(RubyDate._parse("1 BCE")).toEqual({});
+    expect(() => RubyDate.parse("1 BCE")).toThrow("invalid date");
+  });
+
   it("raises Date::Error, which subclasses ArgumentError as it does in Ruby", () => {
     expect(() => RubyDate.parse("not a date")).toThrow(RubyDate.Error);
     expect(() => RubyDate.parse("2008-02-30")).toThrow(RubyDate.Error);

--- a/packages/i18n/src/date.ts
+++ b/packages/i18n/src/date.ts
@@ -1500,7 +1500,6 @@ export class Date {
    */
   static parse(str: string, comp = true): Date {
     const parts = Date._parse(str, comp);
-    if (!parts) throw new DateError("invalid date");
     completeFrags(parts);
     let d: Temporal.PlainDate | null = null;
     try {
@@ -1522,8 +1521,12 @@ export class Date {
    * `date__parse`), which runs its sub-parsers in a fixed order and stops at
    * the first that matches: the alphabetic pair first, then the numeric ones.
    * Ruby answers a Hash of whatever fields it found, which is why a fragment
-   * such as `"Feb 3rd"` comes back without a `:year`; `null` is the Hash no
-   * sub-parser filled at all.
+   * such as `"Feb 3rd"` comes back without a `:year`, and a string no
+   * sub-parser matched at all comes back as the empty Hash `date__parse`
+   * built up front (`date_parse.c:2166-2294`) rather than as a distinguished
+   * value: `Date._parse("not a date")` is `{}`. `Date.parse` raises on it the
+   * way `rt__valid_date_frags_p` (`date_core.c:4185-4220`) does, by finding no
+   * buildable combination of fields.
    *
    * Ruby's sub-parsers all `set_hash` into the one Hash it built up front, so a
    * later one overwrites what `parse_time` put there, and each `subx`es the text
@@ -1533,7 +1536,7 @@ export class Date {
    * (`date_parse.c:2172`) and only ever turns false, so an absent one is `comp`,
    * and the year is completed only within `0..99` (`date_parse.c:2267-2287`).
    */
-  static _parse(str: string, comp = true): DateParts | null {
+  static _parse(str: string, comp = true): DateParts {
     const hash: DateParts = {};
     str = parseDay(str);
     str = parseTime(str, hash);
@@ -1552,7 +1555,6 @@ export class Date {
       parseMon(str, hash) ??
       parseMday(str, hash) ??
       parseDdd(str, hash);
-    if (rest === null && Object.keys(hash).length === 0) return null;
     if (rest !== null) str = rest;
     if (/[a-z]/i.test(str)) str = parseBc(str, hash) ?? str;
     if (/\d/.test(str)) parseFrag(str, hash);


### PR DESCRIPTION
Two of the three bundled stories; the third was already on `main`.

## `Date._parse` answers a Hash always (RFC 0074)

`date__parse` (date-3.4.1/ext/date/date_parse.c:2166-2294) builds one Hash up
front and always answers it, so `Date._parse("not a date")` and
`Date._parse("1 BCE")` are `{}`. trails answered `null` when no sub-parser
filled anything, and `Date.parse` read that as its invalid-date signal.

The `null` return and the check in front of `completeFrags` are gone;
`Date.parse` decides on the fields present the way `rt__valid_date_frags_p`
(date_core.c:4185-4220) does, and still raises `Date::Error("invalid date")`
for both strings.

## `encryption/config.ts` extra surface (RFC 0072)

`pnpm api:extra --package activerecord` reported five novel names in this file;
it now reports none.

- `excludeFromFilterParameters` (the invented writable field) and the read-only
  `excludedFromFilterParameters` getter over it collapse into the single
  Rails-named writable field (config.rb:9-12, :53). Callers updated.
- `defaultCompressor` becomes the module-local `Zlib` object that
  `set_defaults` assigns (config.rb:59), and `Encryptor` defaults its
  compressor from `ActiveRecord::Encryption.config.compressor` as
  encryptor.rb:27 does rather than from a second exported constant. The
  duck-typed `Compressor` shape stays an exported `interface`, carrying a
  `@noRailsEquivalent PERMANENT` tag: Rails states the contract in prose —
  "it must respond to +deflate+ and +inflate+" (encryptor.rb:22-24) — and
  declares no such type, so the tag is the tracked, sanctioned receipt.
- `keyProviderClass` has no counterpart in `config.rb` (Rails resolves the key
  provider through `Config#key_provider` / the scheme) and had no callers; it is
  deleted.

## Already done: `sqlite3-add-column-reimplements-super`

PR #6082 had already landed both acceptance criteria on `main`: SQLite3
`addColumn` keeps only the `isInvalidAlterTableType` branch and delegates the
rest to `super` (sqlite3_adapter.rb:338-347), and the `add_column` arm of
`test_add_column_with_invalid_options` is ported and ungated. Marked done
against #6082 rather than re-shipped here.

## Verification

- `packages/i18n/src/` (25 files, 486 tests), `packages/activerecord/src/encryption/`
  (341 tests), `migration/invalid-options.test.ts` — green.
- `pnpm api:compare`: `encryption/config.rb` stays 100%. `pnpm api:calls` and
  `pnpm api:calls:wide` ratchets OK. `pnpm api:extra --package activerecord`
  exits 0 with `encryption/config.ts` no longer listed (was 5 novel), and the
  permanence-claim tally reads 0 unclassified.

Closes-story: i18n-date-parse-answers-a-hash-never-null
Closes-story: sqlite3-add-column-reimplements-super
Closes-story: remove-encryption-config-extra-surface
