### PR TITLE
feat(i18n): carry rt_complete_frags' commercial entry so Date.parse builds a week date

### DIFF
--- a/packages/i18n/src/backend/base.file-loading.trails.test.ts
+++ b/packages/i18n/src/backend/base.file-loading.trails.test.ts
@@ -8,8 +8,8 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { Simple } from "./simple.js";
 import { config, reloadBang, resetConfig } from "../i18n.js";
 import { resetClassConfig } from "../config.js";
-import { InvalidLocaleData } from "../exceptions.js";
-import { preloadTranslationFiles, registerFileReader } from "./base.js";
+import { InvalidLocaleData, UnknownFileType } from "../exceptions.js";
+import { preloadTranslationFiles, registerFileReader, registerLocaleModule } from "./base.js";
 import { parseYaml } from "../yaml.js";
 
 function localesDir(): string {
@@ -107,6 +107,43 @@ describe("I18n::Backend::Base file loading", () => {
     await config().setLoadPath([`${localesDir()}/invalid/syntax.yml`]);
     expect(() => backend.translate("en", "foo.bar")).toThrow(InvalidLocaleData);
     expect(backend.initialized()).toBe(false);
+  });
+
+  // `registerLocaleModule` / `loadJs` stand in for the gem's `load_rb`
+  // (base.rb:254-256, dispatched by `load_file`'s extension arms at :240-247).
+  // Every test here names its own `bundled/*` entry: the registry is a module
+  // singleton with no reset, so a shared name would leak into its siblings.
+  describe("the locale-module registry", () => {
+    it("serves a registered module without reaching import()", () => {
+      registerLocaleModule("bundled/registered.js", { en: { bundled: { greeting: "hi" } } });
+      config().loadPath = ["bundled/registered.js"];
+      expect(backend.translate("en", "bundled.greeting")).toBe("hi");
+    });
+
+    it("refuses a module the load path names but nothing registered", () => {
+      config().loadPath = ["bundled/unregistered.js"];
+      expect(() => backend.translate("en", "bundled.greeting")).toThrow(
+        /register it with I18n.registerLocaleModule\(\)/,
+      );
+      expect(() => backend.translate("en", "bundled.greeting")).not.toThrow(UnknownFileType);
+    });
+
+    it("raises InvalidLocaleData given a module whose export is not a hash", () => {
+      registerLocaleModule("bundled/non-hash.js", "en:\n  bundled:\n    greeting: hi\n");
+      expect(() => backend.loadTranslations("bundled/non-hash.js")).toThrow(InvalidLocaleData);
+      expect(() => backend.loadTranslations("bundled/non-hash.js")).toThrow(
+        "expects it to return a hash, but does not",
+      );
+    });
+
+    it("loads a module the host imported off disk under its emitted .js name", async () => {
+      const { en } = (await import("../test-data/locales/en.js")) as {
+        en: Record<string, unknown>;
+      };
+      registerLocaleModule(`${localesDir()}/en.js`, { en });
+      config().loadPath = [`${localesDir()}/en.js`];
+      expect(backend.translate("en", "fuh.bah")).toBe("bas");
+    });
   });
 
   describe("the YAML subset", () => {

--- a/packages/i18n/src/backend/base.file-loading.trails.test.ts
+++ b/packages/i18n/src/backend/base.file-loading.trails.test.ts
@@ -116,12 +116,12 @@ describe("I18n::Backend::Base file loading", () => {
   describe("the locale-module registry", () => {
     it("serves a registered module without reaching import()", () => {
       registerLocaleModule("bundled/registered.js", { en: { bundled: { greeting: "hi" } } });
-      config().loadPath = ["bundled/registered.js"];
+      config().loadPath.push("bundled/registered.js");
       expect(backend.translate("en", "bundled.greeting")).toBe("hi");
     });
 
     it("refuses a module the load path names but nothing registered", () => {
-      config().loadPath = ["bundled/unregistered.js"];
+      config().loadPath.push("bundled/unregistered.js");
       expect(() => backend.translate("en", "bundled.greeting")).toThrow(
         /register it with I18n.registerLocaleModule\(\)/,
       );
@@ -141,7 +141,7 @@ describe("I18n::Backend::Base file loading", () => {
         en: Record<string, unknown>;
       };
       registerLocaleModule(`${localesDir()}/en.js`, { en });
-      config().loadPath = [`${localesDir()}/en.js`];
+      config().loadPath.push(`${localesDir()}/en.js`);
       expect(backend.translate("en", "fuh.bah")).toBe("bas");
     });
   });

--- a/packages/i18n/src/date.trails.test.ts
+++ b/packages/i18n/src/date.trails.test.ts
@@ -191,6 +191,13 @@ describe("Date", () => {
     }
   });
 
+  it("rejects a week outside the year, as c_valid_commercial_p does", () => {
+    expect(() => RubyDate.parse("2001-W54-1")).toThrow("invalid date");
+    expect(() => RubyDate.parse("2001-W00-1")).toThrow("invalid date");
+    const long = RubyDate.parse("2020-W53-1");
+    expect([long.year, long.mon, long.day]).toEqual([2020, 12, 28]);
+  });
+
   it("negates the year of a BC date, as parse_bc does", () => {
     expect(RubyDate.parse("4004-01-02 BC").year).toBe(-4003);
     expect(RubyDate.parse("feb 3 4004 b.c.e.").year).toBe(-4003);

--- a/packages/i18n/src/date.trails.test.ts
+++ b/packages/i18n/src/date.trails.test.ts
@@ -174,6 +174,23 @@ describe("Date", () => {
     expect(RubyDate._parse("2001-W05-6")).toEqual({ cwyear: 2001, cweek: 5, cwday: 6 });
   });
 
+  it("builds a week date from the commercial entry of rt_complete_frags' table", () => {
+    const full = RubyDate.parse("2001-W05-6");
+    expect([full.year, full.mon, full.day]).toEqual([2001, 2, 3]);
+    const comp = RubyDate.parse("01-W05-6");
+    expect([comp.year, comp.mon, comp.day]).toEqual([2001, 2, 3]);
+    const week = RubyDate.parse("2001-W05");
+    expect([week.year, week.mon, week.day]).toEqual([2001, 1, 29]);
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2008-08-04T12:00:00Z"));
+    try {
+      const today = RubyDate.parse("-W061");
+      expect([today.year, today.mon, today.day]).toEqual([2008, 2, 4]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("negates the year of a BC date, as parse_bc does", () => {
     expect(RubyDate.parse("4004-01-02 BC").year).toBe(-4003);
     expect(RubyDate.parse("feb 3 4004 b.c.e.").year).toBe(-4003);

--- a/packages/i18n/src/date.ts
+++ b/packages/i18n/src/date.ts
@@ -186,7 +186,17 @@ interface DateParts {
  * @internal The date and time elements of `rt_complete_frags`' table
  * (`date_core.c:3878-3892`) this shim carries.
  */
-type DateFrag = "year" | "mon" | "mday" | "yday" | "hour" | "min" | "sec";
+type DateFrag =
+  | "year"
+  | "mon"
+  | "mday"
+  | "yday"
+  | "cwyear"
+  | "cweek"
+  | "cwday"
+  | "hour"
+  | "min"
+  | "sec";
 
 /** @internal `date_parse.c` `comp_year69`: `69` is 1969, `68` is 2068. */
 function compYear69(y: number): number {
@@ -1384,16 +1394,18 @@ function parseFrag(str: string, hash: DateParts): string | null {
  * `activesupport/test/core_ext/string_ext_test.rb:775` — and `"102".to_date` is
  * this year's 102nd day.
  *
- * Only the `:time`, `:ordinal` and `:civil` entries of that table are carried:
- * the rest are the Julian-day, commercial and week-numbered dates, none of
- * which any sub-parser ported here can produce. `:time` names no date, so it
- * has no completion branch in Ruby either, and the string goes on to raise.
+ * Only the `:time`, `:ordinal`, `:civil` and `:commercial` entries of that
+ * table are carried: the rest are the Julian-day, `:wday` and week-numbered
+ * dates, whose fields (`:jd`, `:wday`, `:wnum0`, `:wnum1`) no sub-parser
+ * ported here can produce. `:time` names no date, so it has no completion
+ * branch in Ruby either, and the string goes on to raise.
  */
 function completeFrags(parts: DateParts): void {
   const tab: [string, DateFrag[]][] = [
     ["time", ["hour", "min", "sec"]],
     ["ordinal", ["year", "yday", "hour", "min", "sec"]],
     ["civil", ["year", "mon", "mday", "hour", "min", "sec"]],
+    ["commercial", ["cwyear", "cweek", "cwday", "hour", "min", "sec"]],
   ];
 
   let g: boolean;
@@ -1430,6 +1442,9 @@ function completeFrags(parts: DateParts): void {
       mon: d.month,
       mday: d.day,
       yday: d.dayOfYear,
+      cwyear: d.yearOfWeek ?? undefined,
+      cweek: d.weekOfYear ?? undefined,
+      cwday: d.dayOfWeek,
     };
 
     if (k === "ordinal") {
@@ -1442,6 +1457,13 @@ function completeFrags(parts: DateParts): void {
       }
       parts.mon ??= 1;
       parts.mday ??= 1;
+    } else if (k === "commercial") {
+      for (const el of a) {
+        if (parts[el] !== undefined) break;
+        parts[el] = today[el];
+      }
+      parts.cweek ??= 1;
+      parts.cwday ??= 1;
     }
   }
 }
@@ -1495,8 +1517,11 @@ export class Date {
    *
    * `rt__valid_date_frags_p` (`date_core.c:4185-4220`) tries the ordinal date
    * — a `:year` and a `:yday`, which is what `"2008070"` names — before the
-   * civil one, and a string that named only a time of day answers neither and
-   * raises.
+   * civil one, and the commercial date — a `:cwyear`, a `:cweek` and a
+   * `:cwday`, which is what `"2001-W05-6"` names — after both. A string that
+   * named only a time of day answers none of them and raises. The
+   * out-of-range week Ruby rejects in `c_valid_commercial_p` is rejected here
+   * by round-tripping the built date's own week date.
    */
   static parse(str: string, comp = true): Date {
     const parts = Date._parse(str, comp);
@@ -1508,6 +1533,16 @@ export class Date {
         if (d.year !== parts.year) d = null;
       } else if (parts.mon !== undefined && parts.mday !== undefined) {
         d = new Temporal.PlainDate(parts.year as number, parts.mon, parts.mday);
+      } else if (
+        parts.cwday !== undefined &&
+        parts.cweek !== undefined &&
+        parts.cwyear !== undefined
+      ) {
+        const jan4 = new Temporal.PlainDate(parts.cwyear, 1, 4);
+        d = jan4
+          .subtract({ days: jan4.dayOfWeek - 1 })
+          .add({ days: (parts.cweek - 1) * 7 + (parts.cwday - 1) });
+        if (d.yearOfWeek !== parts.cwyear || d.weekOfYear !== parts.cweek) d = null;
       }
     } catch {
       d = null;


### PR DESCRIPTION
Three bundled stories.

## 1. `rt_complete_frags`' commercial entry (`i18n-date-complete-frags-commercial-entry`)

`completeFrags` carried three of the seven entries in `rt_complete_frags`' table
(date-3.4.1 `ext/date/date_core.c:3888-3949`), and its JSDoc said the rest were
unreachable. `parse_iso21` / `parse_iso22` (`date_parse.c:1035-1099`, PR #6075)
made that stale: `Date._parse("2001-W05-6")` answers `{cwyear:, cweek:, cwday:}`
and `Date.parse` raised on it.

- `["commercial", ["cwyear", "cweek", "cwday", "hour", "min", "sec"]]` joins the
  table in its `date_core.c` position, with the completion branch
  `rt_complete_frags` gives it (`date_core.c:4034-4054`): the fields above the
  highest named come from today's commercial date, the ones below are `1`.
- `Date.parse` builds it where `rt__valid_date_frags_p` does
  (`date_core.c:4185-4240`). **Deviation from the story text**, which said
  "after the ordinal arm, before the civil one": the vendored source puts the
  commercial arm *after* the civil one (jd → ordinal → civil → commercial →
  wnum), so the port follows the source. Behaviourally the two orders are
  indistinguishable — `completeFrags` only ever fills one family's fields.
- The out-of-range week `c_valid_commercial_p` rejects is rejected here by
  round-tripping the built date's own `yearOfWeek` / `weekOfYear`.
- The `:jd`, `:wday`, `:wnum0` and `:wnum1` entries stay out — no ported
  sub-parser answers their fields — and the JSDoc now says that instead of the
  old claim.

Checked against the interpreter: `"2001-W05-6"` → 2001-02-03, `"01-W05-6"` →
2001-02-03, `"2001-W05"` → 2001-01-29, `"-W061"` at a faked 2008-08-04 →
2008-02-04.

## 2. Locale-module registry seam tests (`i18n-locale-module-seam-tests`)

Four trails-only tests in `base.file-loading.trails.test.ts` (nothing in
`simple.test.ts` touched, no new public surface): a module registered under a
bundler-style `bundled/registered.js` that could not resolve on disk serving a
lookup; the unregistered contrast raising the directed
`registerLocaleModule()` error and *not* `UnknownFileType` (base.ts:135-138) —
the pair is what proves the registry short-circuits `import()`; a non-hash
export raising `InvalidLocaleData` (the post-dispatch check at
`vendor/i18n/lib/i18n/backend/base.rb:240-252`); and the on-disk
`test-data/locales/en.ts` fixture imported by the host and registered under its
emitted `en.js` name.

Two acceptance bullets are answered differently from how they were written,
because the merged shape does not support them literally:
`preloadTranslationFiles()` reads through the registered **file reader** and
never dispatches on `.js`, so a `bundled/*` path handed to it would hit the fs
and reject. The seam these tests drive is the one that actually exists — lazy
`init_translations` over `I18n.load_path` → `load_file` → `loadJs` → registry.
Likewise the "development path" is the host importing the module and
registering it; a real `import()` inside the package is exactly what
`registerLocaleModule`'s `@noRailsEquivalent` says the language forces out.
Isolation is by unique per-test `bundled/*` names — the registry is a module
singleton with no reset, and adding one would be new public surface.

## 3. Slot-1 purge-path measurement (`measure-slot-1-purge-path-timing-on-pg-and-mysql`)

No code change. CI wall clock could not be the source: GitHub run retention on
`main` only reaches 2026-07-31T19:00Z and #5710 merged at 2026-07-31T15:39Z, so
no pre-flip run survives. Measured locally instead, isolated PG 17 / MySQL 8
compose project, `TRAILS_TEST_FORKS=3` (slot 1 claimed), fixed 24-file set
(`associations/*.test.ts`, sorted, first 24), 3 alternating reps per arm.
`after` = main; `before` = the pre-#5710 gate (`ownsSlotDatabase()` →
`slotNumber(read) > 1`), all runs green.

| lane  | before (median) | after (median) | delta      |
| ----- | --------------- | -------------- | ---------- |
| PG    | 64.96 s         | 64.84 s        | −0.1 s     |
| MySQL | 77.87 s         | 79.86 s        | **+2.0 s** |

**PG: the win is inside noise** — the arms interleave run to run (before
63.45/64.96/66.34, after 63.60/64.84/65.42).

**MySQL: a small regression, not noise.** All three `after` reps
(78.67/79.86/80.46) are slower than all three `before` reps
(75.76/77.87/78.45), and vitest's own `setup` total moves the same way
(71.5 → 73.1 s). ~2.5% of the job for one worker in three: the MySQL purge
(drop + create database) looks slightly *more* expensive than dropping the
tables in place for slot 1.

Per the story's last bullet the follow-up is filed rather than reverted here —
n=3 at forks=3 on one file set is too thin to revert a merged flip on, and the
PG half is not a regression: `0028-ci-cost-optimization/remeasure-slot-1-purge-flip-on-mysql`
(larger n, CI's fork count, and a lane-gated fix rather than a wholesale revert
if it holds).

## Gates

Rebased onto `main` after #6085/#6086/#6087 landed in `packages/i18n`; the
three `config().loadPath = [...]` assignments became `push()` because `main`
dropped the setter in favour of the async `setLoadPath()` (config.ts:157-174),
which is the idiom already used at `base.file-loading.trails.test.ts:70`.

`pnpm api:extra --package i18n` — `date.ts` 0 novel, no new names anywhere.
`pnpm api:calls` OK (14 baselined, unchanged). `pnpm test:compare` Overall
unmoved from `main`. `pnpm lint` and `pnpm build` clean; CI green.

Closes-story: i18n-date-complete-frags-commercial-entry
Closes-story: i18n-locale-module-seam-tests
Closes-story: measure-slot-1-purge-path-timing-on-pg-and-mysql
