### PR TITLE
feat(i18n): parse_day's :wday, a Rational offset, and cacheDumpFilename tests

### DIFF
--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -218,17 +218,12 @@ describe("DatabaseTasksRegisterTask", () => {
 describe("DatabaseTasksDumpSchemaCacheTest", () => {
   fixtures([]);
 
-  let originalSchema: string | undefined;
   let originalDbDir: string;
 
   beforeEach(() => {
-    originalSchema = process.env.SCHEMA;
     originalDbDir = DatabaseTasks.dbDir;
-    delete process.env.SCHEMA;
   });
   afterEach(() => {
-    if (originalSchema === undefined) delete process.env.SCHEMA;
-    else process.env.SCHEMA = originalSchema;
     DatabaseTasks.dbDir = originalDbDir;
   });
 
@@ -257,25 +252,43 @@ describe("DatabaseTasksDumpSchemaCacheTest", () => {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
   });
+  // Rails asserts `schema_cache.yml`; trails' HashConfig#defaultSchemaCachePath
+  // writes `.json` because dumpSchemaCache produces JSON, not YAML.
   it("cache dump default filename", () => {
-    expect(DatabaseTasks.dumpSchemaFilename()).toBe("db/schema.ts");
+    const config = new HashConfig("development", "primary", {});
+
+    DatabaseTasks.dbDir = "db";
+    expect(DatabaseTasks.cacheDumpFilename(config)).toBe("db/schema_cache.json");
   });
   it("cache dump default filename with custom db dir", () => {
-    DatabaseTasks.dbDir = "custom_db";
-    expect(DatabaseTasks.dumpSchemaFilename()).toBe("custom_db/schema.ts");
+    const config = new HashConfig("development", "primary", {});
+
+    DatabaseTasks.dbDir = "my_db";
+    expect(DatabaseTasks.cacheDumpFilename(config)).toBe("my_db/schema_cache.json");
   });
   it("cache dump alternate filename", () => {
-    process.env.SCHEMA = "alt_schema.rb";
-    expect(DatabaseTasks.dumpSchemaFilename()).toBe("alt_schema.rb");
+    const config = new HashConfig("development", "alternate", {});
+
+    DatabaseTasks.dbDir = "db";
+    expect(DatabaseTasks.cacheDumpFilename(config)).toBe("db/alternate_schema_cache.json");
   });
   it("cache dump filename with path from db config", () => {
-    const config = new HashConfig("development", "alternate", {});
-    expect(DatabaseTasks.dumpSchemaFilename(config)).toBe("db/alternate_schema.ts");
+    const config = new HashConfig("development", "primary", {
+      schemaCachePath: "tmp/something.yml",
+    });
+
+    DatabaseTasks.dbDir = "db";
+    expect(DatabaseTasks.cacheDumpFilename(config)).toBe("tmp/something.yml");
   });
   it("cache dump filename with path from the argument has precedence", () => {
-    process.env.SCHEMA = "override.rb";
-    const config = new HashConfig("development", "primary", {});
-    expect(DatabaseTasks.dumpSchemaFilename(config)).toBe("override.rb");
+    const config = new HashConfig("development", "primary", {
+      schemaCachePath: "tmp/something.yml",
+    });
+
+    DatabaseTasks.dbDir = "db";
+    expect(DatabaseTasks.cacheDumpFilename(config, { schemaCachePath: "tmp/another.yml" })).toBe(
+      "tmp/another.yml",
+    );
   });
 });
 

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -252,8 +252,6 @@ describe("DatabaseTasksDumpSchemaCacheTest", () => {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
   });
-  // Rails asserts `schema_cache.yml`; trails' HashConfig#defaultSchemaCachePath
-  // writes `.json` because dumpSchemaCache produces JSON, not YAML.
   it("cache dump default filename", () => {
     const config = new HashConfig("development", "primary", {});
 

--- a/packages/i18n/src/date.trails.test.ts
+++ b/packages/i18n/src/date.trails.test.ts
@@ -5,7 +5,7 @@
 
 import { Temporal } from "@js-temporal/polyfill";
 import { describe, it, expect, vi } from "vitest";
-import { ArgumentError, Date as RubyDate, DateTime as RubyDateTime } from "./date.js";
+import { ArgumentError, Date as RubyDate, DateTime as RubyDateTime, Rational } from "./date.js";
 import { Time as RubyTime } from "./time.js";
 
 describe("Date", () => {
@@ -190,6 +190,30 @@ describe("Date", () => {
     expect(RubyDate.parse("080702").year).toBe(2008);
     expect(RubyDate.parse("690702").year).toBe(1969);
     expect(RubyDate.parse("080702", false).year).toBe(8);
+  });
+
+  it("sets :wday from the day name it strips, as parse_day_cb does", () => {
+    expect(RubyDate._parse("Wed, 2 Jul 2008")).toEqual({ wday: 3, year: 2008, mon: 7, mday: 2 });
+    expect(RubyDate._parse("Wednesday, July 2, 2008")).toEqual({
+      wday: 3,
+      year: 2008,
+      mon: 7,
+      mday: 2,
+    });
+    expect(RubyDate._parse("sat 2008-07-02")).toEqual({ wday: 6, year: 2008, mon: 7, mday: 2 });
+    expect(RubyDate._parse("Wed")).toEqual({ wday: 3 });
+  });
+
+  it("answers a Rational offset for a fraction past two places, as date_zone_to_diff does", () => {
+    for (const [zone, s] of [
+      ["+9.5555", "171999/5"],
+      ["-9.5555", "-171999/5"],
+      ["+9.12345678", "102638889/3125"],
+    ] as const) {
+      const offset = RubyDate._parse(`2008-07-02 10:30:00 ${zone}`)?.offset;
+      expect(offset).toBeInstanceOf(Rational);
+      expect(String(offset)).toBe(s);
+    }
   });
 
   it("answers the offset a zone names, as date_zone_to_diff does", () => {

--- a/packages/i18n/src/date.ts
+++ b/packages/i18n/src/date.ts
@@ -390,7 +390,7 @@ function iGcd(x: number, y: number): number {
     x = y;
     y = t;
   }
-  return x === 0 ? 1 : x;
+  return x;
 }
 
 /**

--- a/packages/i18n/src/date.ts
+++ b/packages/i18n/src/date.ts
@@ -172,12 +172,13 @@ interface DateParts {
   cwyear?: number;
   cweek?: number;
   cwday?: number;
+  wday?: number;
   hour?: number;
   min?: number;
   sec?: number;
   secFraction?: number;
   zone?: string;
-  offset?: number | null;
+  offset?: number | Rational | null;
   _comp?: boolean;
   _bc?: boolean;
 }
@@ -196,6 +197,11 @@ function compYear69(y: number): number {
 /** @internal `date_parse.c` `mon_num`: an abbreviation, or the head of a full name. */
 function monNum(str: string): number {
   return ABBR_MONTH_NAMES.findIndex((m) => m.toLowerCase() === str.slice(0, 3).toLowerCase()) + 1;
+}
+
+/** @internal `date_parse.c` `day_num` (`date_parse.c:561-571`): the `ABBR_DAYS` index of a day name. */
+function dayNum(str: string): number {
+  return ABBR_DAY_NAMES.findIndex((d) => d.toLowerCase() === str.slice(0, 3).toLowerCase());
 }
 
 /** @internal `date_parse.c` `issign` (`date_parse.c:63`). */
@@ -375,6 +381,56 @@ function shrinkSpace(s: string, l: number): string {
   return d;
 }
 
+/** @internal `rational.c` `i_gcd`, the greatest common divisor a Rational reduces by. */
+function iGcd(x: number, y: number): number {
+  if (x < 0) x = -x;
+  if (y < 0) y = -y;
+  while (y !== 0) {
+    const t = x % y;
+    x = y;
+    y = t;
+  }
+  return x === 0 ? 1 : x;
+}
+
+/**
+ * Ruby's `Rational` (`rational.c`), as much of it as `date_zone_to_diff`'s
+ * fractional-hour offset needs: `rb_rational_new` canonicalizes to lowest terms
+ * (`rational.c` `nurat_s_canonicalize_internal`), `+` adds an Integer
+ * (`rational.c` `nurat_add`), and `numerator`/`denominator` read the parts back
+ * out. A Rational never becomes an Integer on its own in Ruby — the caller asks
+ * whether the denominator is one and takes the numerator itself.
+ *
+ * @noRailsEquivalent PERMANENT — Ruby core, like the `::Date` below it. Rails
+ * defines no Rational; it inherits Ruby's, and `Date._parse` answers one for a
+ * fractional-hour `:offset`, so trails needs the value type to answer the same.
+ */
+export class Rational {
+  /** `rational.c` `nurat_numerator` (`Rational#numerator`).
+   * @noRailsEquivalent PERMANENT — Ruby core, part of the Rational above. */
+  readonly numerator: number;
+
+  /** `rational.c` `nurat_denominator` (`Rational#denominator`).
+   * @noRailsEquivalent PERMANENT — Ruby core, part of the Rational above. */
+  readonly denominator: number;
+
+  constructor(num: number, den: number) {
+    const g = iGcd(num, den);
+    this.numerator = num / g;
+    this.denominator = den / g;
+  }
+
+  /** `rational.c` `nurat_add` (`Rational#+`), for the Integer addend this port needs. */
+  add(other: number): Rational {
+    return new Rational(this.numerator + other * this.denominator, this.denominator);
+  }
+
+  /** `rational.c` `nurat_to_s` (`Rational#to_s`). */
+  toString(): string {
+    return `${this.numerator}/${this.denominator}`;
+  }
+}
+
 /**
  * @internal `date_parse.c` `date_zone_to_diff` (`date_parse.c:415-559`): the
  * `:offset` in seconds a `:zone` names. A trailing `standard`, `daylight` or
@@ -387,12 +443,12 @@ function shrinkSpace(s: string, l: number): string {
  * (`date_parse.c:514-517`) and its round-half-to-even on the eighth
  * (`date_parse.c:519-522`), where the comparison character is `'5' + !(sec & 1)`.
  *
- * Ruby answers a Rational for a fractional-hour offset of more than two
- * decimal places (`date_parse.c:522-528`); TypeScript has no Rational, so the
- * division is a `number` there.
+ * A fractional-hour offset of more than two decimal places is a `Rational`
+ * (`date_parse.c:523-528`), and only an integer once its denominator reduces to
+ * one — `+9.5555` is `(171999/5)` where `+9.555` is `34398`.
  */
-function dateZoneToDiff(str: string): number | null {
-  let offset: number | null = null;
+function dateZoneToDiff(str: string): number | Rational | null {
+  let offset: number | Rational | null = null;
   let l = str.length;
   let s = str;
 
@@ -492,7 +548,8 @@ function dateZoneToDiff(str: string): number | null {
             offset = sec + hour * 3600;
           } else {
             const denom = 10 ** (n - 2);
-            offset = sec / denom + hour * 3600;
+            const rat = new Rational(sec, denom).add(hour * 3600);
+            offset = rat.denominator === 1 ? rat.numerator : rat;
           }
           return offset;
         } else if (l > 2) {
@@ -669,9 +726,26 @@ function subx(str: string, m: RegExpExecArray): string {
   return str.slice(0, m.index) + " " + str.slice(m.index + m[0].length);
 }
 
-/** @internal `date_parse.c` `parse_day`: a leading day name is not a date field. */
-function parseDay(str: string): string {
-  return str.replace(new RegExp(`\\b(${ABBR_DAYS})[^-\\d\\s]*`, "i"), " ");
+/**
+ * @internal `date_parse.c` `parse_day_cb` (`date_parse.c:583-592`): the day name
+ * a date string carries is a field of its own, even though `Date.parse` never
+ * reads it back.
+ */
+function parseDayCb(m: RegExpExecArray, hash: DateParts): number {
+  hash.wday = dayNum(m[1]);
+  return 1;
+}
+
+/**
+ * @internal `date_parse.c` `parse_day` (`date_parse.c:594-604`): a day name is
+ * not a date field the rest of the sub-parsers should see, so it comes out of
+ * the string — but it is one Ruby records, as `:wday`.
+ */
+function parseDay(str: string, hash: DateParts): string {
+  const m = new RegExp(`\\b(${ABBR_DAYS})[^-\\d\\s]*`, "i").exec(str);
+  if (m === null) return str;
+  parseDayCb(m, hash);
+  return subx(str, m);
 }
 
 /**
@@ -1535,7 +1609,7 @@ export class Date {
    */
   static _parse(str: string, comp = true): DateParts | null {
     const hash: DateParts = {};
-    str = parseDay(str);
+    str = parseDay(str, hash);
     str = parseTime(str, hash);
     let rest: string | null = null;
     if (/[a-z]/i.test(str)) {

--- a/packages/i18n/src/date.ts
+++ b/packages/i18n/src/date.ts
@@ -742,7 +742,7 @@ function parseDayCb(m: RegExpExecArray, hash: DateParts): number {
  * the string — but it is one Ruby records, as `:wday`.
  */
 function parseDay(str: string, hash: DateParts): string {
-  const m = new RegExp(`\\b(${ABBR_DAYS})[^-\\d\\s]*`, "i").exec(str);
+  const m = new RegExp(`\\b(${ABBR_DAYS})[^-/\\d\\s]*`, "i").exec(str);
   if (m === null) return str;
   parseDayCb(m, hash);
   return subx(str, m);


### PR DESCRIPTION
Three bundled stories.

**`parse_day` sets `:wday`** — `parseDay` stripped the day name and dropped the
field Ruby records (`date-3.4.1/ext/date/date_parse.c:583-592`,
`parse_day_cb`). It now takes the hash, as the other sub-parsers do, and sets
`:wday` through a ported `day_num` (`:561-571`). Verified against
`ruby -rdate` 3.3.11: `Date._parse("Wed, 2 Jul 2008")` is
`{wday: 3, year: 2008, mon: 7, mday: 2}`, and `Date._parse("Wed")` is
`{wday: 3}`.

**`date_zone_to_diff` answers a Rational** — the fractional-hour branch built a
float where Ruby builds a Rational for a fraction past two decimal places
(`date_parse.c:523-528`), so `+9.5555` was `34399.8` rather than `(171999/5)`.
`Rational` is a minimal port of the `rational.c` surface that branch needs —
canonicalize, `+` with an Integer, `numerator`/`denominator`, `to_s`. The
integer-reducing cases are unchanged: `+9.555` → `34398`, `+9.5` → `34200`, as
`rb_rational_den(offset) == INT2FIX(1)` makes Ruby do. The
"TypeScript has no Rational" note in `dateZoneToDiff`'s JSDoc is gone.

**`DumpSchemaCache` tests call `cacheDumpFilename`** — all five called
`dumpSchemaFilename`, whose `schema.rb`-shaped answer happened to satisfy the
assertions; Rails' counterparts all call `cache_dump_filename`
(`vendor/rails/activerecord/test/cases/tasks/database_tasks_test.rb:315-359`).
The alternate case now drives off the `HashConfig` name rather than
`ENV["SCHEMA"]`, and the precedence case passes the explicit
`{ schemaCachePath }` argument. Paths assert `.json`, the extension
`HashConfig#defaultSchemaCachePath` already produces (trails dumps JSON, not
YAML) — test names unchanged, `test:compare` stays 77/77.

Gates: `api:calls` OK (14 baselined), `api:calls:wide` OK, `api:extra --package i18n`
0 novel in `date.ts` (`Rational` and its two readers carry
`@noRailsEquivalent PERMANENT` — Ruby core, like the `::Date` below them),
lint and typecheck clean.

Closes-story: i18n-date-parse-day-sets-wday
Closes-story: i18n-date-zone-to-diff-rational-offset
Closes-story: converge-dump-schema-cache-tests-onto-cache-dump-filename


---

**Review round 1** — the one finding (`parse_day`'s char class dropped the `/`
Ruby excludes, `date_parse.c:598`) is converged rather than deferred: it is one
character on the exact line this story rewrote. Re-verified against
`ruby -rdate` on eight day-name-then-slash strings (`sun/7/2`, `sunday/2008`,
`sun/2008/7/2`, `sat//7/2`, `fri/x/2008-1-2`, …) plus the original 18-string
battery — every field still matches the interpreter exactly.
