### PR TITLE
refactor(i18n): give subx date_parse.c's parameter list, and measure I18n::Base

### DIFF
--- a/packages/i18n/src/backend/base.file-loading.trails.test.ts
+++ b/packages/i18n/src/backend/base.file-loading.trails.test.ts
@@ -6,7 +6,7 @@
 import { readFile } from "node:fs/promises";
 import { beforeEach, describe, expect, it } from "vitest";
 import { Simple } from "./simple.js";
-import { config, reloadBang, resetConfig } from "../i18n.js";
+import { config, eagerLoadBang, reloadBang, resetConfig } from "../i18n.js";
 import { resetClassConfig } from "../config.js";
 import { InvalidLocaleData, UnknownFileType } from "../exceptions.js";
 import { preloadTranslationFiles, registerFileReader, registerLocaleModule } from "./base.js";
@@ -100,6 +100,34 @@ describe("I18n::Backend::Base file loading", () => {
     body = "en:\n  foo:\n    bar: qux\n";
     await reloadBang();
     expect(backend.initialized()).toBe(true);
+    expect(backend.translate("en", "foo.bar")).toBe("qux");
+  });
+
+  it("reads I18n.load_path once per reload, and not again on eagerLoadBang", async () => {
+    let reads = 0;
+    registerFileReader(() => {
+      reads += 1;
+      return Promise.resolve("en:\n  foo:\n    bar: baz\n");
+    });
+    await config().setLoadPath(["mutable.yml"]);
+    reads = 0;
+
+    await eagerLoadBang();
+    expect(reads).toBe(0);
+
+    await reloadBang();
+    expect(reads).toBe(1);
+  });
+
+  it("serves the mutated file on an eagerLoadBang that follows a reloadBang", async () => {
+    let body = "en:\n  foo:\n    bar: baz\n";
+    registerFileReader(() => Promise.resolve(body));
+    await config().setLoadPath(["mutable.yml"]);
+    expect(backend.translate("en", "foo.bar")).toBe("baz");
+
+    body = "en:\n  foo:\n    bar: qux\n";
+    await reloadBang();
+    await eagerLoadBang();
     expect(backend.translate("en", "foo.bar")).toBe("qux");
   });
 

--- a/packages/i18n/src/date.ts
+++ b/packages/i18n/src/date.ts
@@ -724,16 +724,31 @@ function s3e(
  * replaces the text it matched with a space, so a later one reads only what no
  * earlier one took. That leftover is what `parse_frag` is anchored to.
  *
- * Ruby edits the one String they all share (`f_aset2`); a JS string is
- * immutable, so the edited string is answered instead, as `parse_day` below
- * already does. Ruby's `subx` also runs the match and dispatches to the
- * sub-parser's `_cb`; most of the ported sub-parsers inlined their `_cb`, so
- * they hold their own match and this takes it — story
- * `i18n-date-subx-cb-decomposition` extracts those `_cb`s and gives `subx`
- * `date_parse.c:319`'s full parameter list.
+ * Ruby edits the one String they all share (`f_aset2`) and answers whether it
+ * matched; a JS string is immutable, so the edited string is answered instead,
+ * and `null` stands for C's `0`.
+ *
+ * `SUBS(s, p, c)` (`date_parse.c:340-343`) is `subx(s, asp_string(), p, hash,
+ * c)`, so every sub-parser below is that one line over its pattern and its
+ * `_cb`.
  */
-function subx(str: string, m: RegExpExecArray): string {
-  return str.slice(0, m.index) + " " + str.slice(m.index + m[0].length);
+function subx(
+  str: string,
+  rep: string,
+  pat: RegExp,
+  hash: DateParts,
+  cb: (m: RegExpExecArray, hash: DateParts) => number,
+): string | null {
+  const m = pat.exec(str);
+
+  if (m === null) return null;
+
+  const be = m.index;
+  const en = m.index + m[0].length;
+  const rest = str.slice(0, be) + rep + str.slice(en);
+  cb(m, hash);
+
+  return rest;
 }
 
 /**
@@ -751,11 +766,9 @@ function parseDayCb(m: RegExpExecArray, hash: DateParts): number {
  * not a date field the rest of the sub-parsers should see, so it comes out of
  * the string — but it is one Ruby records, as `:wday`.
  */
-function parseDay(str: string, hash: DateParts): string {
-  const m = new RegExp(`\\b(${ABBR_DAYS})[^-/\\d\\s]*`, "i").exec(str);
-  if (m === null) return str;
-  parseDayCb(m, hash);
-  return subx(str, m);
+function parseDay(str: string, hash: DateParts): string | null {
+  const pat = new RegExp(`\\b(${ABBR_DAYS})[^-/\\d\\s]*`, "i");
+  return subx(str, " ", pat, hash, parseDayCb);
 }
 
 /**
@@ -831,7 +844,7 @@ function parseTimeCb(m: RegExpExecArray, hash: DateParts): number {
  * (`(?-i:…)`); the groups it guards are character classes that already span
  * both cases, so the ported pattern is the same language without the flag.
  */
-function parseTime(str: string, hash: DateParts): string {
+function parseTime(str: string, hash: DateParts): string | null {
   const patSource =
     "(" +
     NUMBER +
@@ -864,11 +877,7 @@ function parseTime(str: string, hash: DateParts): string {
     ")" +
     ")?";
 
-  const m = new RegExp(patSource, "i").exec(str);
-  if (m === null) return str;
-  const rest = subx(str, m);
-  parseTimeCb(m, hash);
-  return rest;
+  return subx(str, " ", new RegExp(patSource, "i"), hash, parseTimeCb);
 }
 
 /**
@@ -897,7 +906,7 @@ function parseEuCb(m: RegExpExecArray, hash: DateParts): number {
 
 /** @internal `date_parse.c` `parse_eu` (`date_parse.c:869-916`): `2nd July 2008`, `2 Jul 2008`, `3 Feb`. */
 function parseEu(str: string, hash: DateParts): string | null {
-  const m = new RegExp(
+  const pat = new RegExp(
     `('?${NUMBER}+)[^-\\d\\s]*` +
       "\\s*" +
       `(${ABBR_MONTHS})[^-\\d\\s']*` +
@@ -912,10 +921,9 @@ function parseEu(str: string, hash: DateParts): string | null {
       "('?-?\\d+(?:(?:st|nd|rd|th)\\b)?)" +
       ")?",
     "i",
-  ).exec(str);
-  if (m === null) return null;
-  parseEuCb(m, hash);
-  return subx(str, m);
+  );
+
+  return subx(str, " ", pat, hash, parseEuCb);
 }
 
 /**
@@ -944,7 +952,7 @@ function parseUsCb(m: RegExpExecArray, hash: DateParts): number {
  * here because neither the era nor the year can begin with a space or a comma.
  */
 function parseUs(str: string, hash: DateParts): string | null {
-  const m = new RegExp(
+  const pat = new RegExp(
     `\\b(${ABBR_MONTHS})[^-\\d\\s']*` +
       "\\s*" +
       "('?\\d+)[^-\\d\\s']*" +
@@ -956,27 +964,33 @@ function parseUs(str: string, hash: DateParts): string | null {
       "('?-?\\d+)" +
       ")?",
     "i",
-  ).exec(str);
-  if (m === null) return null;
-  parseUsCb(m, hash);
-  return subx(str, m);
+  );
+
+  return subx(str, " ", pat, hash, parseUsCb);
+}
+
+/** @internal `date_parse.c` `parse_iso_cb` (`date_parse.c:997-1013`). */
+function parseIsoCb(m: RegExpExecArray, hash: DateParts): number {
+  const y = m[1];
+  const mon = m[2];
+  const d = m[3];
+
+  s3e(hash, y, mon, d, false);
+  return 1;
 }
 
 /** @internal `date_parse.c` `parse_iso`: `2008-07-02`, and the unpadded `2008-7-2`. */
 function parseIso(str: string, hash: DateParts): string | null {
-  const m = /([-+]?\d+)-(\d+)-(-?\d+)/.exec(str);
-  if (m === null) return null;
-  s3e(hash, m[1], m[2], m[3], false);
-  return subx(str, m);
+  const pat = /([-+]?\d+)-(\d+)-(-?\d+)/;
+
+  return subx(str, " ", pat, hash, parseIsoCb);
 }
 
 /**
- * @internal `date_parse.c` `parse_iso21` (`date_parse.c:1035-1070`): the
- * commercial week date, `"2001-W05-6"` and the yearless `"-W061"`.
+ * @internal `date_parse.c` `parse_iso21_cb` (`date_parse.c:1035-1051`): the
+ * commercial week date's year, week and day.
  */
-function parseIso21(str: string, hash: DateParts): string | null {
-  const m = /\b(\d{2}|\d{4})?-?w(\d{2})(?:-?(\d))?\b/i.exec(str);
-  if (m === null) return null;
+function parseIso21Cb(m: RegExpExecArray, hash: DateParts): number {
   const y = m[1];
   const w = m[2];
   const d = m[3];
@@ -985,45 +999,83 @@ function parseIso21(str: string, hash: DateParts): string | null {
   hash.cweek = Number(w);
   if (d !== undefined) hash.cwday = Number(d);
 
-  return subx(str, m);
+  return 1;
 }
 
-/** @internal `date_parse.c` `parse_iso22` (`date_parse.c:1073-1099`): `"-W-6"`, a commercial day alone. */
+/**
+ * @internal `date_parse.c` `parse_iso21` (`date_parse.c:1053-1071`): the
+ * commercial week date, `"2001-W05-6"` and the yearless `"-W061"`.
+ */
+function parseIso21(str: string, hash: DateParts): string | null {
+  const pat = /\b(\d{2}|\d{4})?-?w(\d{2})(?:-?(\d))?\b/i;
+
+  return subx(str, " ", pat, hash, parseIso21Cb);
+}
+
+/** @internal `date_parse.c` `parse_iso22_cb` (`date_parse.c:1073-1081`). */
+function parseIso22Cb(m: RegExpExecArray, hash: DateParts): number {
+  const d = m[1];
+
+  hash.cwday = Number(d);
+  return 1;
+}
+
+/** @internal `date_parse.c` `parse_iso22` (`date_parse.c:1083-1101`): `"-W-6"`, a commercial day alone. */
 function parseIso22(str: string, hash: DateParts): string | null {
-  const m = /-w-(\d)\b/i.exec(str);
-  if (m === null) return null;
-  hash.cwday = Number(m[1]);
-  return subx(str, m);
+  const pat = /-w-(\d)\b/i;
+
+  return subx(str, " ", pat, hash, parseIso22Cb);
 }
 
-/** @internal `date_parse.c` `parse_iso23` (`date_parse.c:1103-1134`): `"--02-03"`, and `"---03"`. */
-function parseIso23(str: string, hash: DateParts): string | null {
-  const m = /--(\d{2})?-(\d{2})\b/.exec(str);
-  if (m === null) return null;
+/** @internal `date_parse.c` `parse_iso23_cb` (`date_parse.c:1103-1116`). */
+function parseIso23Cb(m: RegExpExecArray, hash: DateParts): number {
   const mon = m[1];
   const d = m[2];
 
   if (mon !== undefined) hash.mon = Number(mon);
   hash.mday = Number(d);
 
-  return subx(str, m);
+  return 1;
 }
 
-/** @internal `date_parse.c` `parse_iso24` (`date_parse.c:1138-1169`): the unseparated `"--0203"`. */
-function parseIso24(str: string, hash: DateParts): string | null {
-  const m = /--(\d{2})(\d{2})?\b/.exec(str);
-  if (m === null) return null;
+/** @internal `date_parse.c` `parse_iso23` (`date_parse.c:1118-1136`): `"--02-03"`, and `"---03"`. */
+function parseIso23(str: string, hash: DateParts): string | null {
+  const pat = /--(\d{2})?-(\d{2})\b/;
+
+  return subx(str, " ", pat, hash, parseIso23Cb);
+}
+
+/** @internal `date_parse.c` `parse_iso24_cb` (`date_parse.c:1138-1151`). */
+function parseIso24Cb(m: RegExpExecArray, hash: DateParts): number {
   const mon = m[1];
   const d = m[2];
 
   hash.mon = Number(mon);
   if (d !== undefined) hash.mday = Number(d);
 
-  return subx(str, m);
+  return 1;
+}
+
+/** @internal `date_parse.c` `parse_iso24` (`date_parse.c:1153-1171`): the unseparated `"--0203"`. */
+function parseIso24(str: string, hash: DateParts): string | null {
+  const pat = /--(\d{2})(\d{2})?\b/;
+
+  return subx(str, " ", pat, hash, parseIso24Cb);
+}
+
+/** @internal `date_parse.c` `parse_iso25_cb` (`date_parse.c:1173-1185`). */
+function parseIso25Cb(m: RegExpExecArray, hash: DateParts): number {
+  const y = m[1];
+  const d = m[2];
+
+  hash.year = Number(y);
+  hash.yday = Number(d);
+
+  return 1;
 }
 
 /**
- * @internal `date_parse.c` `parse_iso25` (`date_parse.c:1173-1219`): the ordinal
+ * @internal `date_parse.c` `parse_iso25` (`date_parse.c:1187-1221`): the ordinal
  * date `"2001-034"`. `pat0` declines the run that is a second fraction
  * (`"1.2001-034"`), which `parse_ddd` reads instead.
  */
@@ -1032,23 +1084,27 @@ function parseIso25(str: string, hash: DateParts): string | null {
   const pat = /\b(\d{2}|\d{4})-(\d{3})\b/;
 
   if (pat0.exec(str) !== null) return null;
-  const m = pat.exec(str);
-  if (m === null) return null;
-  hash.year = Number(m[1]);
-  hash.yday = Number(m[2]);
-  return subx(str, m);
+
+  return subx(str, " ", pat, hash, parseIso25Cb);
 }
 
-/** @internal `date_parse.c` `parse_iso26` (`date_parse.c:1223-1265`): the yearless ordinal date `"-034"`. */
+/** @internal `date_parse.c` `parse_iso26_cb` (`date_parse.c:1223-1231`). */
+function parseIso26Cb(m: RegExpExecArray, hash: DateParts): number {
+  const d = m[1];
+
+  hash.yday = Number(d);
+
+  return 1;
+}
+
+/** @internal `date_parse.c` `parse_iso26` (`date_parse.c:1233-1267`): the yearless ordinal date `"-034"`. */
 function parseIso26(str: string, hash: DateParts): string | null {
   const pat0 = /\d-\d{3}\b/;
   const pat = /\b-(\d{3})\b/;
 
   if (pat0.exec(str) !== null) return null;
-  const m = pat.exec(str);
-  if (m === null) return null;
-  hash.yday = Number(m[1]);
-  return subx(str, m);
+
+  return subx(str, " ", pat, hash, parseIso26Cb);
 }
 
 /**
@@ -1104,13 +1160,8 @@ function gengo(c: string): number {
   return e;
 }
 
-/**
- * @internal `date_parse.c` `parse_jis` (`date_parse.c:1309-1346`): the JIS X
- * 0301 date, `"H13.02.03"` — Heisei 13, which is 2001.
- */
-function parseJis(str: string, hash: DateParts): string | null {
-  const m = new RegExp(`\\b([${JISX0301_ERA_INITIALS}])(\\d+)\\.(\\d+)\\.(\\d+)`, "i").exec(str);
-  if (m === null) return null;
+/** @internal `date_parse.c` `parse_jis_cb` (`date_parse.c:1309-1327`). */
+function parseJisCb(m: RegExpExecArray, hash: DateParts): number {
   const e = m[1];
   const y = m[2];
   const mon = m[3];
@@ -1122,35 +1173,55 @@ function parseJis(str: string, hash: DateParts): string | null {
   hash.mon = Number(mon);
   hash.mday = Number(d);
 
-  return subx(str, m);
+  return 1;
 }
 
-/** @internal `date_parse.c` `parse_vms11` (`date_parse.c:1349-1388`): `"3-FEB-2001"`. */
-function parseVms11(str: string, hash: DateParts): string | null {
-  const m = new RegExp(`('?-?${NUMBER}+)-(${ABBR_MONTHS})[^-/.]*-('?-?\\d+)`, "i").exec(str);
-  if (m === null) return null;
+/**
+ * @internal `date_parse.c` `parse_jis` (`date_parse.c:1329-1347`): the JIS X
+ * 0301 date, `"H13.02.03"` — Heisei 13, which is 2001.
+ */
+function parseJis(str: string, hash: DateParts): string | null {
+  const pat = new RegExp(`\\b([${JISX0301_ERA_INITIALS}])(\\d+)\\.(\\d+)\\.(\\d+)`, "i");
+
+  return subx(str, " ", pat, hash, parseJisCb);
+}
+
+/** @internal `date_parse.c` `parse_vms11_cb` (`date_parse.c:1349-1367`). */
+function parseVms11Cb(m: RegExpExecArray, hash: DateParts): number {
   const d = m[1];
-  let mon = m[2];
+  let mon: string | number = m[2];
   const y = m[3];
 
-  mon = String(monNum(mon));
+  mon = monNum(mon);
 
-  s3e(hash, y, mon, d, false);
-  return subx(str, m);
+  s3e(hash, y, String(mon), d, false);
+  return 1;
 }
 
-/** @internal `date_parse.c` `parse_vms12` (`date_parse.c:1391-1431`): `"FEB-3-2001"`, and `"FEB-3"`. */
-function parseVms12(str: string, hash: DateParts): string | null {
-  const m = new RegExp(`\\b(${ABBR_MONTHS})[^-/.]*-('?-?\\d+)(?:-('?-?\\d+))?`, "i").exec(str);
-  if (m === null) return null;
-  let mon = m[1];
+/** @internal `date_parse.c` `parse_vms11` (`date_parse.c:1369-1389`): `"3-FEB-2001"`. */
+function parseVms11(str: string, hash: DateParts): string | null {
+  const pat = new RegExp(`('?-?${NUMBER}+)-(${ABBR_MONTHS})[^-/.]*-('?-?\\d+)`, "i");
+
+  return subx(str, " ", pat, hash, parseVms11Cb);
+}
+
+/** @internal `date_parse.c` `parse_vms12_cb` (`date_parse.c:1391-1409`). */
+function parseVms12Cb(m: RegExpExecArray, hash: DateParts): number {
+  let mon: string | number = m[1];
   const d = m[2];
   const y = m[3];
 
-  mon = String(monNum(mon));
+  mon = monNum(mon);
 
-  s3e(hash, y ?? null, mon, d, false);
-  return subx(str, m);
+  s3e(hash, y ?? null, String(mon), d, false);
+  return 1;
+}
+
+/** @internal `date_parse.c` `parse_vms12` (`date_parse.c:1411-1431`): `"FEB-3-2001"`, and `"FEB-3"`. */
+function parseVms12(str: string, hash: DateParts): string | null {
+  const pat = new RegExp(`\\b(${ABBR_MONTHS})[^-/.]*-('?-?\\d+)(?:-('?-?\\d+))?`, "i");
+
+  return subx(str, " ", pat, hash, parseVms12Cb);
 }
 
 /** @internal `date_parse.c` `parse_vms` (`date_parse.c:1433-1444`): the VMS date, either way round. */
@@ -1158,48 +1229,87 @@ function parseVms(str: string, hash: DateParts): string | null {
   return parseVms11(str, hash) ?? parseVms12(str, hash);
 }
 
+/** @internal `date_parse.c` `parse_sla_cb` (`date_parse.c:1446-1462`). */
+function parseSlaCb(m: RegExpExecArray, hash: DateParts): number {
+  const y = m[1];
+  const mon = m[2];
+  const d = m[3];
+
+  s3e(hash, y, mon, d ?? null, false);
+  return 1;
+}
+
 /** @internal `date_parse.c` `parse_sla`: `2012/12/13`, `01/01/2012`, `2008/07`. */
 function parseSla(str: string, hash: DateParts): string | null {
-  const m = /([-+]?\d+)\/\s*(\d+)(?:\D\s*(-?\d+))?/.exec(str);
-  if (m === null) return null;
-  s3e(hash, m[1], m[2], m[3] ?? null, false);
-  return subx(str, m);
+  const pat = /([-+]?\d+)\/\s*(\d+)(?:\D\s*(-?\d+))?/;
+
+  return subx(str, " ", pat, hash, parseSlaCb);
+}
+
+/** @internal `date_parse.c` `parse_dot_cb` (`date_parse.c:1554-1570`). */
+function parseDotCb(m: RegExpExecArray, hash: DateParts): number {
+  const y = m[1];
+  const mon = m[2];
+  const d = m[3];
+
+  s3e(hash, y, mon, d, false);
+  return 1;
 }
 
 /** @internal `date_parse.c` `parse_dot`: `2012.12.13`, `01.01.2012`. */
 function parseDot(str: string, hash: DateParts): string | null {
-  const m = /([-+]?\d+)\.\s*(\d+)\.\s*(-?\d+)/.exec(str);
-  if (m === null) return null;
-  s3e(hash, m[1], m[2], m[3], false);
-  return subx(str, m);
+  const pat = /([-+]?\d+)\.\s*(\d+)\.\s*(-?\d+)/;
+
+  return subx(str, " ", pat, hash, parseDotCb);
 }
 
-/** @internal `date_parse.c` `parse_year` (`date_parse.c:1662-1688`): the year alone, `"'01"`. */
+/** @internal `date_parse.c` `parse_year_cb` (`date_parse.c:1662-1670`). */
+function parseYearCb(m: RegExpExecArray, hash: DateParts): number {
+  const y = m[1];
+
+  hash.year = Number(y);
+  return 1;
+}
+
+/** @internal `date_parse.c` `parse_year` (`date_parse.c:1672-1690`): the year alone, `"'01"`. */
 function parseYear(str: string, hash: DateParts): string | null {
-  const m = /'(\d+)\b/.exec(str);
-  if (m === null) return null;
-  hash.year = Number(m[1]);
-  return subx(str, m);
+  const pat = /'(\d+)\b/;
+
+  return subx(str, " ", pat, hash, parseYearCb);
 }
 
-/** @internal `date_parse.c` `parse_mon` (`date_parse.c:1692-1718`): the month alone, `"Feb"`. */
+/** @internal `date_parse.c` `parse_mon_cb` (`date_parse.c:1692-1700`). */
+function parseMonCb(m: RegExpExecArray, hash: DateParts): number {
+  const mon = m[1];
+
+  hash.mon = monNum(mon);
+  return 1;
+}
+
+/** @internal `date_parse.c` `parse_mon` (`date_parse.c:1702-1720`): the month alone, `"Feb"`. */
 function parseMon(str: string, hash: DateParts): string | null {
-  const m = new RegExp(`\\b(${ABBR_MONTHS})\\S*`, "i").exec(str);
-  if (m === null) return null;
-  hash.mon = monNum(m[1]);
-  return subx(str, m);
+  const pat = new RegExp(`\\b(${ABBR_MONTHS})\\S*`, "i");
+
+  return subx(str, " ", pat, hash, parseMonCb);
+}
+
+/** @internal `date_parse.c` `parse_mday_cb` (`date_parse.c:1722-1730`). */
+function parseMdayCb(m: RegExpExecArray, hash: DateParts): number {
+  const d = m[1];
+
+  hash.mday = Number(d);
+  return 1;
 }
 
 /**
- * @internal `date_parse.c` `parse_mday` (`date_parse.c:1722-1748`): the day of
+ * @internal `date_parse.c` `parse_mday` (`date_parse.c:1732-1750`): the day of
  * the month alone, `"3rd"`. It sits directly above `parse_ddd`, so an ordinal
  * suffix is what tells the two apart.
  */
 function parseMday(str: string, hash: DateParts): string | null {
-  const m = new RegExp(`(${NUMBER}+)(st|nd|rd|th)\\b`, "i").exec(str);
-  if (m === null) return null;
-  hash.mday = Number(m[1]);
-  return subx(str, m);
+  const pat = new RegExp(`(${NUMBER}+)(st|nd|rd|th)\\b`, "i");
+
+  return subx(str, " ", pat, hash, parseMdayCb);
 }
 
 /** @internal `date_parse.c` `n2i`: the `w` digits of `s` from `f`, as a number. */
@@ -1382,7 +1492,7 @@ function parseDddCb(m: RegExpExecArray, hash: DateParts): number {
  * itself, plus the time and zone that can follow it.
  */
 function parseDdd(str: string, hash: DateParts): string | null {
-  const m = new RegExp(
+  const pat = new RegExp(
     `([-+]?)(${NUMBER}{2,14})` +
       "(?:" +
       "\\s*" +
@@ -1401,14 +1511,19 @@ function parseDdd(str: string, hash: DateParts): string | null {
       ")" +
       ")?",
     "i",
-  ).exec(str);
-  if (m === null) return null;
-  parseDddCb(m, hash);
-  return subx(str, m);
+  );
+
+  return subx(str, " ", pat, hash, parseDddCb);
+}
+
+/** @internal `date_parse.c` `parse_bc_cb` (`date_parse.c:2003-2008`). */
+function parseBcCb(_m: RegExpExecArray, hash: DateParts): number {
+  hash._bc = true;
+  return 1;
 }
 
 /**
- * @internal `date_parse.c` `parse_bc` (`date_parse.c:2003-2019`): the era
+ * @internal `date_parse.c` `parse_bc` (`date_parse.c:2010-2019`): the era
  * suffix. It runs after whichever date sub-parser matched and only records
  * `:_bc`; the tail of `date__parse` is what negates the year. It is a `SUBS`
  * like every sub-parser above, and `parse_frag` runs on what it leaves — so
@@ -1416,10 +1531,9 @@ function parseDdd(str: string, hash: DateParts): string | null {
  * the anchored pattern reads the `5`.
  */
 function parseBc(str: string, hash: DateParts): string | null {
-  const m = /\b(bc\b|bce\b|b\.c\.|b\.c\.e\.)/i.exec(str);
-  if (m === null) return null;
-  hash._bc = true;
-  return subx(str, m);
+  const pat = /\b(bc\b|bce\b|b\.c\.|b\.c\.e\.)/i;
+
+  return subx(str, " ", pat, hash, parseBcCb);
 }
 
 /**
@@ -1452,10 +1566,9 @@ function parseFragCb(m: RegExpExecArray, hash: DateParts): number {
  * own `subx` answers is what no one reads — Ruby's caller drops it too.
  */
 function parseFrag(str: string, hash: DateParts): string | null {
-  const m = /^\s*(\d{1,2})\s*$/.exec(str);
-  if (m === null) return null;
-  parseFragCb(m, hash);
-  return subx(str, m);
+  const pat = /^\s*(\d{1,2})\s*$/;
+
+  return subx(str, " ", pat, hash, parseFragCb);
 }
 
 /**
@@ -1647,8 +1760,8 @@ export class Date {
    */
   static _parse(str: string, comp = true): DateParts {
     const hash: DateParts = {};
-    str = parseDay(str, hash);
-    str = parseTime(str, hash);
+    str = parseDay(str, hash) ?? str;
+    str = parseTime(str, hash) ?? str;
     let rest: string | null = null;
     if (/[a-z]/i.test(str) && /\d/.test(str)) {
       rest = parseEu(str, hash) ?? parseUs(str, hash);

--- a/packages/i18n/src/date.ts
+++ b/packages/i18n/src/date.ts
@@ -876,7 +876,6 @@ function parseTime(str: string, hash: DateParts): string | null {
     "[A-Za-z]+(?:\\sdst)?\\b" +
     ")" +
     ")?";
-
   return subx(str, " ", new RegExp(patSource, "i"), hash, parseTimeCb);
 }
 
@@ -922,7 +921,6 @@ function parseEu(str: string, hash: DateParts): string | null {
       ")?",
     "i",
   );
-
   return subx(str, " ", pat, hash, parseEuCb);
 }
 
@@ -965,7 +963,6 @@ function parseUs(str: string, hash: DateParts): string | null {
       ")?",
     "i",
   );
-
   return subx(str, " ", pat, hash, parseUsCb);
 }
 
@@ -979,10 +976,9 @@ function parseIsoCb(m: RegExpExecArray, hash: DateParts): number {
   return 1;
 }
 
-/** @internal `date_parse.c` `parse_iso`: `2008-07-02`, and the unpadded `2008-7-2`. */
+/** @internal `date_parse.c` `parse_iso` (`date_parse.c:1015-1033`): `2008-07-02`, and the unpadded `2008-7-2`. */
 function parseIso(str: string, hash: DateParts): string | null {
   const pat = /([-+]?\d+)-(\d+)-(-?\d+)/;
-
   return subx(str, " ", pat, hash, parseIsoCb);
 }
 
@@ -1008,14 +1004,12 @@ function parseIso21Cb(m: RegExpExecArray, hash: DateParts): number {
  */
 function parseIso21(str: string, hash: DateParts): string | null {
   const pat = /\b(\d{2}|\d{4})?-?w(\d{2})(?:-?(\d))?\b/i;
-
   return subx(str, " ", pat, hash, parseIso21Cb);
 }
 
 /** @internal `date_parse.c` `parse_iso22_cb` (`date_parse.c:1073-1081`). */
 function parseIso22Cb(m: RegExpExecArray, hash: DateParts): number {
   const d = m[1];
-
   hash.cwday = Number(d);
   return 1;
 }
@@ -1023,7 +1017,6 @@ function parseIso22Cb(m: RegExpExecArray, hash: DateParts): number {
 /** @internal `date_parse.c` `parse_iso22` (`date_parse.c:1083-1101`): `"-W-6"`, a commercial day alone. */
 function parseIso22(str: string, hash: DateParts): string | null {
   const pat = /-w-(\d)\b/i;
-
   return subx(str, " ", pat, hash, parseIso22Cb);
 }
 
@@ -1041,7 +1034,6 @@ function parseIso23Cb(m: RegExpExecArray, hash: DateParts): number {
 /** @internal `date_parse.c` `parse_iso23` (`date_parse.c:1118-1136`): `"--02-03"`, and `"---03"`. */
 function parseIso23(str: string, hash: DateParts): string | null {
   const pat = /--(\d{2})?-(\d{2})\b/;
-
   return subx(str, " ", pat, hash, parseIso23Cb);
 }
 
@@ -1059,7 +1051,6 @@ function parseIso24Cb(m: RegExpExecArray, hash: DateParts): number {
 /** @internal `date_parse.c` `parse_iso24` (`date_parse.c:1153-1171`): the unseparated `"--0203"`. */
 function parseIso24(str: string, hash: DateParts): string | null {
   const pat = /--(\d{2})(\d{2})?\b/;
-
   return subx(str, " ", pat, hash, parseIso24Cb);
 }
 
@@ -1084,14 +1075,12 @@ function parseIso25(str: string, hash: DateParts): string | null {
   const pat = /\b(\d{2}|\d{4})-(\d{3})\b/;
 
   if (pat0.exec(str) !== null) return null;
-
   return subx(str, " ", pat, hash, parseIso25Cb);
 }
 
 /** @internal `date_parse.c` `parse_iso26_cb` (`date_parse.c:1223-1231`). */
 function parseIso26Cb(m: RegExpExecArray, hash: DateParts): number {
   const d = m[1];
-
   hash.yday = Number(d);
 
   return 1;
@@ -1103,7 +1092,6 @@ function parseIso26(str: string, hash: DateParts): string | null {
   const pat = /\b-(\d{3})\b/;
 
   if (pat0.exec(str) !== null) return null;
-
   return subx(str, " ", pat, hash, parseIso26Cb);
 }
 
@@ -1182,7 +1170,6 @@ function parseJisCb(m: RegExpExecArray, hash: DateParts): number {
  */
 function parseJis(str: string, hash: DateParts): string | null {
   const pat = new RegExp(`\\b([${JISX0301_ERA_INITIALS}])(\\d+)\\.(\\d+)\\.(\\d+)`, "i");
-
   return subx(str, " ", pat, hash, parseJisCb);
 }
 
@@ -1201,7 +1188,6 @@ function parseVms11Cb(m: RegExpExecArray, hash: DateParts): number {
 /** @internal `date_parse.c` `parse_vms11` (`date_parse.c:1369-1389`): `"3-FEB-2001"`. */
 function parseVms11(str: string, hash: DateParts): string | null {
   const pat = new RegExp(`('?-?${NUMBER}+)-(${ABBR_MONTHS})[^-/.]*-('?-?\\d+)`, "i");
-
   return subx(str, " ", pat, hash, parseVms11Cb);
 }
 
@@ -1220,7 +1206,6 @@ function parseVms12Cb(m: RegExpExecArray, hash: DateParts): number {
 /** @internal `date_parse.c` `parse_vms12` (`date_parse.c:1411-1431`): `"FEB-3-2001"`, and `"FEB-3"`. */
 function parseVms12(str: string, hash: DateParts): string | null {
   const pat = new RegExp(`\\b(${ABBR_MONTHS})[^-/.]*-('?-?\\d+)(?:-('?-?\\d+))?`, "i");
-
   return subx(str, " ", pat, hash, parseVms12Cb);
 }
 
@@ -1239,10 +1224,9 @@ function parseSlaCb(m: RegExpExecArray, hash: DateParts): number {
   return 1;
 }
 
-/** @internal `date_parse.c` `parse_sla`: `2012/12/13`, `01/01/2012`, `2008/07`. */
+/** @internal `date_parse.c` `parse_sla` (`date_parse.c:1464-1483`): `2012/12/13`, `01/01/2012`, `2008/07`. */
 function parseSla(str: string, hash: DateParts): string | null {
   const pat = /([-+]?\d+)\/\s*(\d+)(?:\D\s*(-?\d+))?/;
-
   return subx(str, " ", pat, hash, parseSlaCb);
 }
 
@@ -1256,17 +1240,15 @@ function parseDotCb(m: RegExpExecArray, hash: DateParts): number {
   return 1;
 }
 
-/** @internal `date_parse.c` `parse_dot`: `2012.12.13`, `01.01.2012`. */
+/** @internal `date_parse.c` `parse_dot` (`date_parse.c:1572-1591`): `2012.12.13`, `01.01.2012`. */
 function parseDot(str: string, hash: DateParts): string | null {
   const pat = /([-+]?\d+)\.\s*(\d+)\.\s*(-?\d+)/;
-
   return subx(str, " ", pat, hash, parseDotCb);
 }
 
 /** @internal `date_parse.c` `parse_year_cb` (`date_parse.c:1662-1670`). */
 function parseYearCb(m: RegExpExecArray, hash: DateParts): number {
   const y = m[1];
-
   hash.year = Number(y);
   return 1;
 }
@@ -1274,14 +1256,12 @@ function parseYearCb(m: RegExpExecArray, hash: DateParts): number {
 /** @internal `date_parse.c` `parse_year` (`date_parse.c:1672-1690`): the year alone, `"'01"`. */
 function parseYear(str: string, hash: DateParts): string | null {
   const pat = /'(\d+)\b/;
-
   return subx(str, " ", pat, hash, parseYearCb);
 }
 
 /** @internal `date_parse.c` `parse_mon_cb` (`date_parse.c:1692-1700`). */
 function parseMonCb(m: RegExpExecArray, hash: DateParts): number {
   const mon = m[1];
-
   hash.mon = monNum(mon);
   return 1;
 }
@@ -1289,14 +1269,12 @@ function parseMonCb(m: RegExpExecArray, hash: DateParts): number {
 /** @internal `date_parse.c` `parse_mon` (`date_parse.c:1702-1720`): the month alone, `"Feb"`. */
 function parseMon(str: string, hash: DateParts): string | null {
   const pat = new RegExp(`\\b(${ABBR_MONTHS})\\S*`, "i");
-
   return subx(str, " ", pat, hash, parseMonCb);
 }
 
 /** @internal `date_parse.c` `parse_mday_cb` (`date_parse.c:1722-1730`). */
 function parseMdayCb(m: RegExpExecArray, hash: DateParts): number {
   const d = m[1];
-
   hash.mday = Number(d);
   return 1;
 }
@@ -1308,7 +1286,6 @@ function parseMdayCb(m: RegExpExecArray, hash: DateParts): number {
  */
 function parseMday(str: string, hash: DateParts): string | null {
   const pat = new RegExp(`(${NUMBER}+)(st|nd|rd|th)\\b`, "i");
-
   return subx(str, " ", pat, hash, parseMdayCb);
 }
 
@@ -1512,12 +1489,11 @@ function parseDdd(str: string, hash: DateParts): string | null {
       ")?",
     "i",
   );
-
   return subx(str, " ", pat, hash, parseDddCb);
 }
 
 /** @internal `date_parse.c` `parse_bc_cb` (`date_parse.c:2003-2008`). */
-function parseBcCb(_m: RegExpExecArray, hash: DateParts): number {
+function parseBcCb(m: RegExpExecArray, hash: DateParts): number {
   hash._bc = true;
   return 1;
 }
@@ -1532,7 +1508,6 @@ function parseBcCb(_m: RegExpExecArray, hash: DateParts): number {
  */
 function parseBc(str: string, hash: DateParts): string | null {
   const pat = /\b(bc\b|bce\b|b\.c\.|b\.c\.e\.)/i;
-
   return subx(str, " ", pat, hash, parseBcCb);
 }
 
@@ -1567,7 +1542,6 @@ function parseFragCb(m: RegExpExecArray, hash: DateParts): number {
  */
 function parseFrag(str: string, hash: DateParts): string | null {
   const pat = /^\s*(\d{1,2})\s*$/;
-
   return subx(str, " ", pat, hash, parseFragCb);
 }
 

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -18,7 +18,6 @@ import type { Base } from "./backend/base.js";
 import { Config } from "./config.js";
 import { ArgumentError, Disabled, InvalidLocale, MissingTranslation } from "./exceptions.js";
 import type { TranslateOptions } from "./backend/base.js";
-import { reloadTranslationFiles } from "./backend/base.js";
 import { throwException, catchException } from "./throw-catch.js";
 
 /** Ruby models locales as Symbols; the JS analogue is a plain string. */
@@ -198,13 +197,14 @@ export async function reloadBang(): Promise<void> {
  * Rails production environment. Backends can implement whatever strategy
  * is useful.
  *
- * The re-read of `I18n.load_path` precedes it for the reason given on
- * `reload!` above: `eager_load!` reaches `init_translations` /
- * `load_translations` (simple.rb:64, base.rb:14) straight away, so it does the
- * same async init the boot preload does rather than depending on one.
+ * Async because `Backend::Base#eager_load!` is: it runs under
+ * `Backend::Base#reload!`'s re-read (base.rb:101-103), which is a Promise here.
+ * The bytes it initializes from are the ones already in memory — from the boot
+ * preload, or from that `reload!` — so `eager_load!` reads nothing of its own,
+ * as the gem's does not either: `Simple#eager_load!` reaches `init_translations`
+ * (simple.rb:64), which loads only while the backend is uninitialized.
  */
 export async function eagerLoadBang(): Promise<void> {
-  await reloadTranslationFiles();
   await config().backend.eagerLoadBang();
 }
 

--- a/packages/i18n/src/locale/fallbacks.test.ts
+++ b/packages/i18n/src/locale/fallbacks.test.ts
@@ -2,8 +2,8 @@
  * Mirrors: i18n/test/locale/fallbacks_test.rb
  *
  * `#inspect` renders `self.class.name`, which in the gem carries Ruby's module
- * nesting (`I18n::Locale::Fallbacks`); TypeScript has no nesting to render, so
- * the constructor name is the whole name.
+ * nesting (`I18n::Locale::Fallbacks`); the class declares that name over
+ * `Function.name`, so `this.constructor.name` renders the gem's string.
  */
 
 import { beforeEach, describe, expect, it } from "vitest";
@@ -210,7 +210,7 @@ describe("I18nFallbacksHashCompatibilityTest", () => {
 
   it("#inspect", () => {
     expect(fallbacks.inspect()).toBe(
-      `#<Fallbacks @map={:"de-AT"=>[:"de-DE"]} @defaults=[:"en-US", :en]>`,
+      `#<I18n::Locale::Fallbacks @map={:"de-AT"=>[:"de-DE"]} @defaults=[:"en-US", :en]>`,
     );
   });
 });

--- a/packages/i18n/src/locale/fallbacks.ts
+++ b/packages/i18n/src/locale/fallbacks.ts
@@ -57,6 +57,15 @@ function inspectLocales(locales: Locale[]): string {
 }
 
 export class Fallbacks extends Map<Locale, Locale[]> {
+  /**
+   * Ruby's `Class#name` carries the module nesting the class was defined in, so
+   * `self.class.name` renders `I18n::Locale::Fallbacks` rather than the bare
+   * constant. A TS class has no nesting to read, so it declares the Ruby name
+   * over `Function.name` — `this.constructor.name` is then the same string
+   * Ruby's is, and any sibling ported class carries its own the same way.
+   */
+  static override name = "I18n::Locale::Fallbacks";
+
   private mapStore: Record<Locale, Locale[]> = {};
   private defaultsStore: Locale[] = [];
 

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -305,6 +305,19 @@ DEPENDENCY_PATTERNS = {
   },
 }
 
+# Packages whose umbrella file (`<libPath>.rb`) defines real methods rather than
+# only requires, autoloads and module-level config, and so must be walked in
+# full instead of harvested for singleton config alone.
+#
+# `vendor/i18n/lib/i18n.rb` is where `I18n::Base` — the gem's whole public
+# facade — is actually defined: 19 `def`s plus 3 aliases. The config-only scan
+# sees only the aliases, so the ported facade is measured against a denominator
+# of 3. Rails' umbrella files stay on the config-only path: `active_record.rb`
+# and its siblings are autoload manifests whose only method bodies are
+# `def self.` boot helpers no trails file ports, and walking them attributes
+# those to the umbrella module's junk-drawer entity file as false-missing.
+UMBRELLA_FULL_SCAN_PACKAGES = %w[i18n].to_set
+
 # ---- AST walker ----
 
 class ApiExtractor
@@ -389,8 +402,11 @@ class ApiExtractor
   # against those statics instead of leaking into the umbrella module's
   # entity-file bucket (the junk-drawer `deprecator.rb`). Must run AFTER the
   # package's own files so the `<Module>::Base` class already exists in `@classes`.
-  def scan_umbrella_file(filepath, package_root)
-    @scanning_umbrella = true
+  #
+  # `full:` walks the umbrella exactly as any other file instead, for the
+  # packages in UMBRELLA_FULL_SCAN_PACKAGES whose umbrella defines real methods.
+  def scan_umbrella_file(filepath, package_root, full: false)
+    @scanning_umbrella = !full
     process_file(filepath, package_root)
   ensure
     @scanning_umbrella = false
@@ -2490,7 +2506,11 @@ def run
     # config and attribute it to `<Module>::Base`. Done last so that Base class
     # already exists. See ApiExtractor#scan_umbrella_file.
     umbrella_file = "#{pkg_dir.sub(%r{/\z}, '')}.rb"
-    extractor.scan_umbrella_file(umbrella_file, pkg_dir) if File.file?(umbrella_file)
+    if File.file?(umbrella_file)
+      extractor.scan_umbrella_file(
+        umbrella_file, pkg_dir, full: UMBRELLA_FULL_SCAN_PACKAGES.include?(pkg_name)
+      )
+    end
 
     # Drop define_method entries a literal `def` in the same bucket supersedes.
     extractor.dedupe_define_methods!

--- a/scripts/api-compare/extract-ruby-api.test.ts
+++ b/scripts/api-compare/extract-ruby-api.test.ts
@@ -689,7 +689,11 @@ describe("Ruby extractor umbrella module-config scanning", () => {
   // Lay out a package libPath with a `base.rb` and a sibling umbrella file
   // one level above it, scan the package then the umbrella, and return the
   // ActiveRecord::Base / ActiveRecord entries.
-  function scanWithUmbrella(baseSrc: string, umbrellaSrc: string): Record<string, ClassEntry> {
+  function scanWithUmbrella(
+    baseSrc: string,
+    umbrellaSrc: string,
+    full = false,
+  ): Record<string, ClassEntry> {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "umbrella-rb-"));
     try {
       const libPath = path.join(root, "active_record");
@@ -701,7 +705,7 @@ describe("Ruby extractor umbrella module-config scanning", () => {
         require "json"
         ex = ApiExtractor.new
         ex.process_file(File.join(${JSON.stringify(libPath)}, "base.rb"), ${JSON.stringify(libPath)})
-        ex.scan_umbrella_file(File.join(${JSON.stringify(root)}, "active_record.rb"), ${JSON.stringify(libPath)})
+        ex.scan_umbrella_file(File.join(${JSON.stringify(root)}, "active_record.rb"), ${JSON.stringify(libPath)}, full: ${full})
         out = {}
         (ex.classes.merge(ex.modules)).each do |fqn, info|
           out[fqn] = { classMethods: info[:classMethods], instanceMethods: info[:instanceMethods], file: info[:file] }
@@ -717,7 +721,7 @@ describe("Ruby extractor umbrella module-config scanning", () => {
 
   interface ClassEntry {
     classMethods: { name: string; umbrellaConfig?: boolean }[];
-    instanceMethods: { name: string }[];
+    instanceMethods: { name: string; visibility: string }[];
     file: string;
   }
 
@@ -814,6 +818,60 @@ describe("Ruby extractor umbrella module-config scanning", () => {
     const mod = out["ActiveSupport"];
     const names = mod ? [...mod.classMethods, ...mod.instanceMethods].map((m) => m.name) : [];
     expect(names).not.toContain("error_reporter");
+  });
+
+  // `vendor/i18n/lib/i18n.rb` is not an autoload manifest: it is where
+  // `I18n::Base`, the gem's whole public facade, is defined. The config-only
+  // scan above sees only its three aliases, so the ported facade is measured
+  // against a denominator of 3. UMBRELLA_FULL_SCAN_PACKAGES opts such a package
+  // into a full walk.
+  it("extracts the method definitions of an umbrella file scanned in full", () => {
+    const out = scanWithUmbrella(
+      BASE_SRC,
+      `
+      module ActiveRecord
+        module Facade
+          def translate(key, **options); end
+          alias :t :translate
+
+          private
+
+          def translate_key(key); end
+        end
+
+        def self.reserve_key(key); end
+
+        extend Facade
+      end
+    `,
+      true,
+    );
+    const facade = out["ActiveRecord::Facade"];
+    expect(facade.instanceMethods.map((m) => m.name)).toEqual(["translate", "t", "translate_key"]);
+    expect(facade.instanceMethods.map((m) => m.visibility)).toEqual([
+      "public",
+      "public",
+      "private",
+    ]);
+    expect(facade.file).toBe("../active_record.rb");
+    expect(out["ActiveRecord"].classMethods.map((m) => m.name)).toContain("reserve_key");
+  });
+
+  it("keeps a config-only umbrella scan free of those definitions", () => {
+    const out = scanWithUmbrella(
+      BASE_SRC,
+      `
+      module ActiveRecord
+        module Facade
+          def translate(key, **options); end
+        end
+
+        def self.reserve_key(key); end
+      end
+    `,
+    );
+    expect(out["ActiveRecord::Facade"].instanceMethods).toEqual([]);
+    expect(out["ActiveRecord"].classMethods).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Four RFC 0074 stories, all in `packages/i18n` plus the Ruby extractor.

## `subx` gets `date_parse.c`'s parameter list

`subx` (date-3.4.1 `ext/date/date_parse.c:318-337`) is
`subx(str, rep, pat, hash, cb)`: it runs the match itself, splices `rep` over
it, and dispatches to the sub-parser's `_cb`. `SUBS(s, p, c)`
(`date_parse.c:340-343`) is that one line, and every sub-parser is one `SUBS`
over its pattern and its `_cb`.

The port had the splice half only — `subx(str, m)` — because most sub-parsers
inlined their `_cb`. Each of those is now extracted under its Rails name
(`parseIsoCb`, `parseIso21Cb`…`parseIso26Cb`, `parseJisCb`, `parseVms11Cb`,
`parseVms12Cb`, `parseSlaCb`, `parseDotCb`, `parseYearCb`, `parseMonCb`,
`parseMdayCb`, `parseBcCb`), and every sub-parser body — including `parseTime`,
`parseEu`, `parseUs`, `parseDdd`, `parseFrag`, which already had theirs — is its
`SUBS` line. `s3e` stays `s3e(hash, y, m, d, bc)` (`date_parse.c:80-81`), called
from the `_cb`s that call it in C.

`subx` answers the edited string (or `null` for C's `0`) because a JS string is
immutable; `parseTime` moves from `string` to `string | null` with it, and
`Date._parse` reads `parseTime(str, hash) ?? str` — C's "0 means `str` is
untouched". No behavior change: `date.trails.test.ts` is green unedited.

## `I18n.eager_load!` no longer re-reads `I18n.load_path`

`I18n.eager_load!` (i18n.rb:92-94) is `config.backend.eager_load!` and nothing
else. The port called `reloadTranslationFiles()` first, so an eager load re-read
bytes the gem does not: `Simple#eager_load!` reaches `init_translations`
(simple.rb:64), which loads only while the backend is uninitialized. The bytes
are already in memory from the boot preload or from `Backend::Base#reload!`'s
re-read, so the call was redundant as well as divergent. Two trails cases cover
it — an `eagerLoadBang` that reads nothing while a `reloadBang` reads once, and
an eager load after a mutated file and a reload serving the new content.

## `Fallbacks#inspect` renders the namespaced name

`inspect` renders `self.class.name` (fallbacks.rb:86-88), which in Ruby carries
the module nesting. The class declares that name over `Function.name`
(`static override name = "I18n::Locale::Fallbacks"`), so `this.constructor.name`
renders the gem's string and the ported `"#inspect"` case asserts
`fallbacks_test.rb:182` verbatim. The mechanism is a declared name, not a
literal in the method, so a sibling ported class carries its own the same way.

## The i18n umbrella file is extracted in full

`scan_umbrella_file` harvests only module-level singleton config and attributes
it to `<Module>::Base`. That is right for Rails, where `lib/active_record.rb` is
an autoload manifest whose only bodies are `def self.` boot helpers no trails
file ports. `vendor/i18n/lib/i18n.rb` is different: it is where `I18n::Base` —
the gem's whole public facade — is defined, so the config-only scan saw its
three aliases and nothing else.

`UMBRELLA_FULL_SCAN_PACKAGES` opts a package into a full walk; i18n is its only
member, and Rails' umbrellas keep the existing path (covered by a new
"keeps a config-only umbrella scan free of those definitions" case alongside the
four that already pin the redirect).

Numbers, against a pre-change `API_COMPARE_FORCE=1 pnpm api:compare`:

- `../i18n.rb → i18n.ts`: **0/3 (0%) → 25/25 (100%)**. 22 of those are
  `I18n::Base`'s 19 `def`s and 3 aliases, the figure the story predicted; the
  other 3 are `I18n.new_double_nested_cache` / `reserve_key` /
  `reserved_keys_pattern` (i18n.rb:38, 44, 48), real `def self.` API the story's
  list did not enumerate. All 25 are already ported, so the facade stories that
  follow now have a denominator that contains them.
- i18n: 217/217 (100%) → **239/239 (100%)**; arity 142 → 160.
- No other package's totals move (diff of the two runs' summary lines is those
  two rows and the overall line).

## Gates

`pnpm api:calls` OK (14 baselined), `pnpm api:calls:wide` OK (2215 baselined),
`pnpm api:extra --package i18n` reports 0 novel names, `pnpm lint`,
`pnpm typecheck`, `pnpm vitest run packages/i18n/src` (578) and
`scripts/api-compare` (972) green, `pnpm test:compare` unchanged.

Rebased onto #6088/#6089/#6093. `parse_day` gained its `:wday` `_cb` in #6089
while still calling the old two-argument `subx`; it is converged onto the same
`SUBS` line here (`date_parse.c:607`), so `Date._parse` reads
`parseDay(str, hash) ?? str` for the same reason it reads it for `parseTime`.

Closes-story: i18n-date-subx-cb-decomposition
Closes-story: i18n-eager-load-extra-read
Closes-story: i18n-inspect-namespaced-class-name
Closes-story: i18n-umbrella-file-method-extraction
