### PR TITLE
fix(i18n,activemodel): converge seven i18n parity gaps

### DIFF
--- a/packages/activemodel/src/error.ts
+++ b/packages/activemodel/src/error.ts
@@ -142,14 +142,6 @@ export class Error {
     options: Record<string, unknown> = {},
   ): string {
     const msgOpt = options.message;
-    // Proc/lambda message: call with (base, options) and return result.
-    if (typeof msgOpt === "function") {
-      const result = (msgOpt as (b: ModelBase, o: Record<string, unknown>) => unknown)(
-        base,
-        options,
-      );
-      if (typeof result === "string") return Error.interpolate(result, options);
-    }
     // error.rb:65 `type = options.delete(:message) if options[:message].is_a?(Symbol)`:
     // a Ruby Symbol keeps its leading colon, so a plain String stays in
     // `options[:message]` and becomes the default below, exactly as in Rails.
@@ -368,11 +360,5 @@ export class Error {
       optionsStr = "{...}";
     }
     return `#<ActiveModel::Error attribute=${this.attribute}, type=${this.type}, options=${optionsStr}>`;
-  }
-
-  static interpolate(msg: string, options: Record<string, unknown>): string {
-    return msg.replace(/%\{(\w+)\}/g, (_, key) => {
-      return options[key] !== undefined ? String(options[key]) : `%{${key}}`;
-    });
   }
 }

--- a/packages/i18n/src/backend/base.trails.test.ts
+++ b/packages/i18n/src/backend/base.trails.test.ts
@@ -129,6 +129,17 @@ describe("I18n::Backend::Base", () => {
     expect(backend.exists("en", "missing")).toBe(false);
   });
 
+  it("resolves a Symbol default through I18n.translate, so its guards run", () => {
+    backend.storeTranslations("en", { foo: "bar" });
+    config().availableLocales = ["en"];
+    config().enforceAvailableLocales = true;
+
+    // base.rb:150-156 — the gem's `I18n.translate` reaches
+    // `enforce_available_locales!` (i18n.rb:218); calling the backend directly
+    // skipped it.
+    expect(() => backend.translate("de", "missing", { default: ":foo" })).toThrow(InvalidLocale);
+  });
+
   it("availableLocales skips locales holding only i18n metadata", () => {
     backend.storeTranslations("en", { foo: "bar" });
     backend.storeTranslations("de", { i18n: { transliterate: {} } });

--- a/packages/i18n/src/backend/base.trails.test.ts
+++ b/packages/i18n/src/backend/base.trails.test.ts
@@ -134,9 +134,6 @@ describe("I18n::Backend::Base", () => {
     config().availableLocales = ["en"];
     config().enforceAvailableLocales = true;
 
-    // base.rb:150-156 — the gem's `I18n.translate` reaches
-    // `enforce_available_locales!` (i18n.rb:218); calling the backend directly
-    // skipped it.
     expect(() => backend.translate("de", "missing", { default: ":foo" })).toThrow(InvalidLocale);
   });
 

--- a/packages/i18n/src/backend/base.ts
+++ b/packages/i18n/src/backend/base.ts
@@ -32,6 +32,7 @@ import {
   config,
   reservedKeysPattern,
   t,
+  translate,
   tBang,
   type Locale,
   type TranslationKey,
@@ -433,10 +434,7 @@ export abstract class Base {
     if (options.resolve === false) return subject;
     const result = catchException(() => {
       if (isSymbol(subject)) {
-        // The gem goes through `I18n.translate`, which — with `throw: true` —
-        // hands a MissingTranslation straight back to this `catch`, exactly as
-        // calling the backend does. The `I18n.t` facade is not ported yet.
-        return config().backend.translate(locale, subject, {
+        return translate(subject, {
           ...options,
           locale,
           throw: true,

--- a/packages/i18n/src/backend/fallbacks.ts
+++ b/packages/i18n/src/backend/fallbacks.ts
@@ -19,7 +19,7 @@
  */
 
 import { MissingTranslation, InvalidLocale } from "../exceptions.js";
-import { EMPTY_HASH, t, type Locale, type TranslationKey } from "../i18n.js";
+import { EMPTY_HASH, translate, type Locale, type TranslationKey } from "../i18n.js";
 import { Fallbacks as LocaleFallbacks } from "../locale/fallbacks.js";
 import { catchException, throwException } from "../throw-catch.js";
 import type { Base, TranslateOptions } from "./base.js";
@@ -164,7 +164,7 @@ export function Fallbacks<T extends BackendConstructor>(
         if ("fallbackInProgress" in options) delete options.fallbackInProgress;
 
         if (isSymbol(subject)) {
-          return t(subject.slice(1), {
+          return translate(subject, {
             ...options,
             locale: options.fallbackOriginalLocale as Locale,
             throw: true,

--- a/packages/i18n/src/backend/simple.test.ts
+++ b/packages/i18n/src/backend/simple.test.ts
@@ -188,6 +188,11 @@ describe("I18nBackendSimpleTest", () => {
     expect(translations()).toEqual({ en: { foo: { bar: "bar", baz: "baz" } } });
   });
 
+  it("simple store_translations: converts the given locale to a Symbol", () => {
+    storeTranslations("en", { foo: "bar" });
+    expect(translations()).toEqual({ en: { foo: "bar" } });
+  });
+
   it("simple store_translations: converts keys to Symbols", () => {
     storeTranslations("en", { foo: { bar: "bar", baz: "baz" } });
     expect(translations()).toEqual({ en: { foo: { bar: "bar", baz: "baz" } } });

--- a/packages/i18n/src/backend/simple.trails.test.ts
+++ b/packages/i18n/src/backend/simple.trails.test.ts
@@ -50,8 +50,6 @@ describe("Backend::Simple", () => {
     backend.storeTranslations("en", { foo: { bar: "baz" } });
 
     expect(JSON.stringify(backend.translations())).toBe('{"en":{"foo":{"bar":"baz"}}}');
-    // simple.rb:93-95 — a missing *locale* read still assigns, as Ruby's
-    // default block does.
     expect(backend.translations()["fr"]).toEqual({});
     expect(Object.keys(backend.translations())).toEqual(["en", "fr"]);
   });

--- a/packages/i18n/src/backend/simple.trails.test.ts
+++ b/packages/i18n/src/backend/simple.trails.test.ts
@@ -36,4 +36,23 @@ describe("Backend::Simple", () => {
     expect(seen).toEqual(["en"]);
     expect(backend.translate("en", "foo")).toBe("bar");
   });
+
+  it("stores a Symbol-spelled locale in the same bucket as its String form", () => {
+    const backend = new Simple();
+    backend.storeTranslations(":en", { foo: "bar" });
+    backend.storeTranslations("en", { baz: "baz" });
+
+    expect(backend.translations()).toEqual({ en: { foo: "bar", baz: "baz" } });
+  });
+
+  it("does not vivify a locale for the property reads JSON.stringify makes", () => {
+    const backend = new Simple();
+    backend.storeTranslations("en", { foo: { bar: "baz" } });
+
+    expect(JSON.stringify(backend.translations())).toBe('{"en":{"foo":{"bar":"baz"}}}');
+    // simple.rb:93-95 — a missing *locale* read still assigns, as Ruby's
+    // default block does.
+    expect(backend.translations()["fr"]).toEqual({});
+    expect(Object.keys(backend.translations())).toEqual(["en", "fr"]);
+  });
 });

--- a/packages/i18n/src/backend/simple.ts
+++ b/packages/i18n/src/backend/simple.ts
@@ -44,6 +44,13 @@ function isSymbol(value: unknown): value is string {
 }
 
 /**
+ * Property reads JS makes on any object that Ruby's `Hash#[]` never sees, so the
+ * default block below must not vivify them: `JSON.stringify` probes `toJSON`,
+ * `await` probes `then`, and a Ruby locale hash grows neither key.
+ */
+const NON_LOCALE_READS = new Set(["toJSON", "then", "inspect", "constructor"]);
+
+/**
  * Ruby `include Base` (simple.rb:22) as a type: the merged interface gives
  * `Simple` every member `Base` declares, without an `extends` clause the gem
  * does not have. The runtime half of the same `include` is the prototype copy
@@ -81,6 +88,10 @@ export class Simple {
     ) {
       return data;
     }
+    // simple.rb:42 `locale = locale.to_sym`. A trails `Locale` *is* the
+    // Symbol's name (locale/tag/simple.ts:35), so the String `"en"` and a
+    // `":en"`-spelled Symbol have to key the one bucket, as `:en` does in the gem.
+    locale = isSymbol(locale) ? locale.slice(1) : String(locale);
     const translations = this.translations();
     translations[locale] ??= {};
     const payload = options.skipSymbolizeKeys ? data : deepSymbolizeKeys(data);
@@ -123,7 +134,7 @@ export class Simple {
     // matching Ruby, where `has_key?` is false until the read vivifies the key.
     this.translationsStore ??= new Proxy({} as TranslationData, {
       get(h, k) {
-        if (typeof k === "string" && !(k in h)) h[k] = {};
+        if (typeof k === "string" && !NON_LOCALE_READS.has(k) && !(k in h)) h[k] = {};
         return h[k as string];
       },
     });

--- a/packages/i18n/src/backend/simple.ts
+++ b/packages/i18n/src/backend/simple.ts
@@ -88,9 +88,6 @@ export class Simple {
     ) {
       return data;
     }
-    // simple.rb:42 `locale = locale.to_sym`. A trails `Locale` *is* the
-    // Symbol's name (locale/tag/simple.ts:35), so the String `"en"` and a
-    // `":en"`-spelled Symbol have to key the one bucket, as `:en` does in the gem.
     locale = isSymbol(locale) ? locale.slice(1) : String(locale);
     const translations = this.translations();
     translations[locale] ??= {};

--- a/packages/i18n/src/date.ts
+++ b/packages/i18n/src/date.ts
@@ -1541,7 +1541,8 @@ export class Date {
     str = parseDay(str);
     str = parseTime(str, hash);
     let rest: string | null = null;
-    if (/[a-z]/i.test(str)) {
+    if (/[a-z]/i.test(str) && /\d/.test(str)) {
+      // date_parse.c:2180 — HAVE_ELEM_P(HAVE_ALPHA | HAVE_DIGIT)
       rest = parseEu(str, hash) ?? parseUs(str, hash);
     }
     rest ??=

--- a/packages/i18n/src/date.ts
+++ b/packages/i18n/src/date.ts
@@ -1542,7 +1542,6 @@ export class Date {
     str = parseTime(str, hash);
     let rest: string | null = null;
     if (/[a-z]/i.test(str) && /\d/.test(str)) {
-      // date_parse.c:2180 — HAVE_ELEM_P(HAVE_ALPHA | HAVE_DIGIT)
       rest = parseEu(str, hash) ?? parseUs(str, hash);
     }
     rest ??=

--- a/packages/i18n/src/interpolate/ruby.trails.test.ts
+++ b/packages/i18n/src/interpolate/ruby.trails.test.ts
@@ -9,7 +9,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { interpolate } from "./ruby.js";
 import { resetConfig } from "../i18n.js";
 import { resetClassConfig } from "../config.js";
-import { ReservedInterpolationKey } from "../exceptions.js";
+import { ArgumentError, ReservedInterpolationKey } from "../exceptions.js";
 
 describe("I18n.interpolate", () => {
   beforeEach(() => {
@@ -56,5 +56,115 @@ describe("I18n.interpolate", () => {
     for (const [format, value, expected] of cases) {
       expect(interpolate(format, { v: value })).toBe(expected);
     }
+  });
+});
+
+/**
+ * The `%<name>fmt` grammar `sprintf` reimplements, checked against real
+ * `ruby -e 'sprintf(...)'` output. The gem has no such test — it delegates to
+ * Ruby's builtin (i18n/lib/i18n/interpolate/ruby.rb:45) — so the table below is
+ * the reimplementation's conformance bound: the conversion set the
+ * interpolation pattern admits (`bBdiouxXeEfgGcps`, ruby.rb:9) crossed with the
+ * `-+ #0` flags, width and precision.
+ */
+const SPRINTF_CASES: [format: string, value: unknown, expected: string][] = [
+  ["%<v>b", 42, "101010"],
+  ["%<v>b", -42, "..1010110"],
+  ["%<v>#b", -42, "0b..1010110"],
+  ["%<v>+.3b", 42, "+101010"],
+  ["%<v> 08.2b", -42, " -101010"],
+  ["%<v>10.3b", -42, " ..1010110"],
+  ["%<v>B", 42, "101010"],
+  ["%<v>B", -42, "..1010110"],
+  ["%<v>#B", -42, "0B..1010110"],
+  ["%<v>+.3B", 42, "+101010"],
+  ["%<v> 08.2B", -42, " -101010"],
+  ["%<v>10.3B", -42, " ..1010110"],
+  ["%<v>d", 42, "42"],
+  ["%<v>d", -42, "-42"],
+  ["%<v>#d", -42, "-42"],
+  ["%<v>+.3d", 42, "+042"],
+  ["%<v> 08.2d", -42, "     -42"],
+  ["%<v>10.3d", -42, "      -042"],
+  ["%<v>i", 42, "42"],
+  ["%<v>i", -42, "-42"],
+  ["%<v>#i", -42, "-42"],
+  ["%<v>+.3i", 42, "+042"],
+  ["%<v> 08.2i", -42, "     -42"],
+  ["%<v>10.3i", -42, "      -042"],
+  ["%<v>o", 42, "52"],
+  ["%<v>o", -42, "..726"],
+  ["%<v>#o", -42, "..726"],
+  ["%<v>+.3o", 42, "+052"],
+  ["%<v> 08.2o", -42, "     -52"],
+  ["%<v>10.3o", -42, "     ..726"],
+  ["%<v>u", 42, "42"],
+  ["%<v>u", -42, "-42"],
+  ["%<v>#u", -42, "-42"],
+  ["%<v>+.3u", 42, "+042"],
+  ["%<v> 08.2u", -42, "     -42"],
+  ["%<v>10.3u", -42, "      -042"],
+  ["%<v>x", 42, "2a"],
+  ["%<v>x", -42, "..fd6"],
+  ["%<v>#x", -42, "0x..fd6"],
+  ["%<v>+.3x", 42, "+02a"],
+  ["%<v> 08.2x", -42, "     -2a"],
+  ["%<v>10.3x", -42, "     ..fd6"],
+  ["%<v>X", 42, "2A"],
+  ["%<v>X", -42, "..FD6"],
+  ["%<v>#X", -42, "0X..FD6"],
+  ["%<v>+.3X", 42, "+02A"],
+  ["%<v> 08.2X", -42, "     -2A"],
+  ["%<v>10.3X", -42, "     ..FD6"],
+  ["%<v>e", 1234.5678, "1.234568e+03"],
+  ["%<v>+.3e", -1.2345e-5, "-1.234e-05"],
+  ["%<v> 08.2e", 1234.5678, " 1.23e+03"],
+  ["%<v>-+e", 1234.5678, "+1.234568e+03"],
+  ["%<v>#.5e", -1.2345e-5, "-1.23450e-05"],
+  ["%<v>E", 1234.5678, "1.234568E+03"],
+  ["%<v>+.3E", -1.2345e-5, "-1.234E-05"],
+  ["%<v> 08.2E", 1234.5678, " 1.23E+03"],
+  ["%<v>-+E", 1234.5678, "+1.234568E+03"],
+  ["%<v>#.5E", -1.2345e-5, "-1.23450E-05"],
+  ["%<v>f", 1234.5678, "1234.567800"],
+  ["%<v>+.3f", -1.2345e-5, "-0.000"],
+  ["%<v> 08.2f", 1234.5678, " 1234.57"],
+  ["%<v>-+f", 1234.5678, "+1234.567800"],
+  ["%<v>#.5f", -1.2345e-5, "-0.00001"],
+  ["%<v>g", 1234.5678, "1234.57"],
+  ["%<v>+.3g", -1.2345e-5, "-1.23e-05"],
+  ["%<v> 08.2g", 1234.5678, " 1.2e+03"],
+  ["%<v>-+g", 1234.5678, "+1234.57"],
+  ["%<v>#.5g", -1.2345e-5, "-1.2345e-05"],
+  ["%<v>G", 1234.5678, "1234.57"],
+  ["%<v>+.3G", -1.2345e-5, "-1.23E-05"],
+  ["%<v> 08.2G", 1234.5678, " 1.2E+03"],
+  ["%<v>-+G", 1234.5678, "+1234.57"],
+  ["%<v>#.5G", -1.2345e-5, "-1.2345E-05"],
+  ["%<v>c", 9731, "\u2603"],
+  ["%<v>c", "abc", "a"],
+  ["%<v>-4c", 9731, "\u2603   "],
+  ["%<v>s", "abc", "abc"],
+  ["%<v>.2s", "abc", "ab"],
+  ["%<v>-6s", "abc", "abc   "],
+  ["%<v>p", "abc", '"abc"'],
+  ["%<v>p", 42, "42"],
+  ["%<v>c", 128512, "😀"],
+];
+
+describe("sprintf conformance", () => {
+  it.each(SPRINTF_CASES)("%s of %o is %o", (format, value, expected) => {
+    expect(interpolate(format, { v: value })).toBe(expected);
+  });
+
+  it("raises ArgumentError given a value no numeric conversion accepts", () => {
+    expect(() => interpolate("%<v>d", { v: "abc" })).toThrow(ArgumentError);
+    expect(() => interpolate("%<v>x", { v: "abc" })).toThrow('invalid value for Integer(): "abc"');
+    expect(() => interpolate("%<v>f", { v: "abc" })).toThrow('invalid value for Float(): "abc"');
+    expect(() => interpolate("%<v>d", { v: null })).toThrow("can't convert nil into Integer");
+  });
+
+  it("raises ArgumentError given a spec outside the grammar", () => {
+    expect(() => interpolate("%<v>,d", { v: 1 })).toThrow(ArgumentError);
   });
 });

--- a/packages/i18n/src/interpolate/ruby.trails.test.ts
+++ b/packages/i18n/src/interpolate/ruby.trails.test.ts
@@ -162,6 +162,10 @@ describe("sprintf conformance", () => {
     expect(() => interpolate("%<v>x", { v: "abc" })).toThrow('invalid value for Integer(): "abc"');
     expect(() => interpolate("%<v>f", { v: "abc" })).toThrow('invalid value for Float(): "abc"');
     expect(() => interpolate("%<v>d", { v: null })).toThrow("can't convert nil into Integer");
+    expect(() => interpolate("%<v>d", { v: true })).toThrow("can't convert true into Integer");
+    expect(() => interpolate("%<v>f", { v: false })).toThrow("can't convert false into Float");
+    expect(() => interpolate("%<v>d", { v: [1] })).toThrow("can't convert Array into Integer");
+    expect(() => interpolate("%<v>f", { v: {} })).toThrow("can't convert Hash into Float");
   });
 
   it("raises ArgumentError given a spec outside the grammar", () => {

--- a/packages/i18n/src/interpolate/ruby.ts
+++ b/packages/i18n/src/interpolate/ruby.ts
@@ -102,15 +102,10 @@ function sprintf(spec: string, value: unknown): string {
   const number = numeric ? numericArgument(value, integer) : 0;
   const magnitude = Math.abs(number);
 
-  // A negative radix conversion with no sign flag is Ruby's infinite
-  // two's-complement form, which has no sign and does its own padding.
   if (conversion in RADIX && number < 0 && !flags.includes("+") && !flags.includes(" ")) {
     return twosComplement(Math.trunc(number), conversion, flags, width, precision);
   }
 
-  // Ruby omits the alternate-form prefix for zero. Octal's prefix is a leading
-  // digit, so a precision pads over it (`%#.5o` of 42 is `00052`); the others
-  // sit outside the padded digits (`%#.5x` of 42 is `0x0002a`).
   const prefix = alternate && number !== 0 ? (ALTERNATE_PREFIX[conversion] ?? "") : "";
 
   let body: string;
@@ -133,8 +128,6 @@ function sprintf(spec: string, value: unknown): string {
     body = conversion === "p" ? inspect(value) : String(value);
     if (precision !== undefined) body = body.slice(0, digits);
   }
-  // On an integer conversion the precision is a MINIMUM DIGIT COUNT, not a
-  // truncation — and `%.0d` of zero is the empty string.
   if (integer && precision !== undefined) {
     body = digits === 0 && Math.trunc(magnitude) === 0 ? "" : body.padStart(digits, "0");
   }
@@ -148,7 +141,6 @@ function sprintf(spec: string, value: unknown): string {
 
   const target = Number(width || 0);
   if (flags.includes("-")) return (sign + body).padEnd(target);
-  // A precision on an integer conversion cancels the `0` flag, as it does in C.
   if (flags.includes("0") && numeric && !(integer && precision !== undefined)) {
     return sign + body.padStart(target - sign.length, "0");
   }
@@ -184,7 +176,6 @@ function twosComplement(
 ): string {
   const radix = RADIX[conversion];
   const top = (radix - 1).toString(radix);
-  // The leading `..7` already carries octal's alternate-form prefix.
   const prefix = flags.includes("#") && conversion !== "o" ? ALTERNATE_PREFIX[conversion] : "";
   const target = Number(width || 0);
   const zeroPad = flags.includes("0") && !flags.includes("-");
@@ -193,10 +184,6 @@ function twosComplement(
     zeroPad ? target - prefix.length - 2 : 0,
   );
 
-  // The digits are the value itself in `places` two's-complement places, and
-  // Ruby writes the shortest run whose leading digit is already the repeating
-  // one — `-42` is `1010110` in binary, not the shorter `10` that only two
-  // places would wrap to.
   let digits: string;
   for (let places = 1; ; places++) {
     const modulus = radix ** places;

--- a/packages/i18n/src/interpolate/ruby.ts
+++ b/packages/i18n/src/interpolate/ruby.ts
@@ -81,6 +81,15 @@ const ALTERNATE_PREFIX: Record<string, string> = { b: "0b", B: "0B", o: "0", x: 
  * reimplemented here, along with the `-+ #0` flags, width and precision that
  * `sprintf` applies to them. A spec outside that grammar raises `ArgumentError`
  * with `sprintf`'s message, as Ruby's does for `%<num>,d`.
+ *
+ * That whole grammar — every conversion crossed with the flags, a width and a
+ * precision — is pinned against real `ruby -e 'sprintf(...)'` output in
+ * `ruby.trails.test.ts`, including the forms that are easy to miss: an integer
+ * precision as a minimum digit count, the `..` two's-complement form of a
+ * negative `%b`/`%o`/`%x`, and `Integer()`/`Float()` raising on an argument
+ * that does not convert. What is NOT covered is anything the interpolation
+ * pattern cannot deliver here: argument indexes (`%1$d`), `*` widths, and the
+ * conversions outside `[bBdiouxXeEfgGcps]`.
  */
 function sprintf(spec: string, value: unknown): string {
   const parsed = FORMAT_SPEC.exec(spec);
@@ -89,13 +98,25 @@ function sprintf(spec: string, value: unknown): string {
   const digits = precision === undefined ? 6 : Number(precision);
   const numeric = !"csp".includes(conversion);
   const alternate = flags.includes("#");
-  const magnitude = Math.abs(Number(value));
+  const integer = conversion in RADIX || "diu".includes(conversion);
+  const number = numeric ? numericArgument(value, integer) : 0;
+  const magnitude = Math.abs(number);
+
+  // A negative radix conversion with no sign flag is Ruby's infinite
+  // two's-complement form, which has no sign and does its own padding.
+  if (conversion in RADIX && number < 0 && !flags.includes("+") && !flags.includes(" ")) {
+    return twosComplement(Math.trunc(number), conversion, flags, width, precision);
+  }
+
+  // Ruby omits the alternate-form prefix for zero. Octal's prefix is a leading
+  // digit, so a precision pads over it (`%#.5o` of 42 is `00052`); the others
+  // sit outside the padded digits (`%#.5x` of 42 is `0x0002a`).
+  const prefix = alternate && number !== 0 ? (ALTERNATE_PREFIX[conversion] ?? "") : "";
 
   let body: string;
   if (conversion in RADIX) {
     body = Math.trunc(magnitude).toString(RADIX[conversion]);
-    // Ruby omits the alternate-form prefix for zero.
-    if (alternate && Number(value) !== 0) body = ALTERNATE_PREFIX[conversion] + body;
+    if (conversion === "o") body = prefix + body;
   } else if ("diu".includes(conversion)) {
     body = String(Math.trunc(magnitude));
   } else if (conversion === "e" || conversion === "E") {
@@ -112,17 +133,82 @@ function sprintf(spec: string, value: unknown): string {
     body = conversion === "p" ? inspect(value) : String(value);
     if (precision !== undefined) body = body.slice(0, digits);
   }
+  // On an integer conversion the precision is a MINIMUM DIGIT COUNT, not a
+  // truncation — and `%.0d` of zero is the empty string.
+  if (integer && precision !== undefined) {
+    body = digits === 0 && Math.trunc(magnitude) === 0 ? "" : body.padStart(digits, "0");
+  }
+  if (conversion in RADIX && conversion !== "o") body = prefix + body;
   if (conversion === conversion.toUpperCase() && numeric) body = body.toUpperCase();
 
   let sign = "";
-  if (numeric && Number(value) < 0) sign = "-";
+  if (numeric && number < 0) sign = "-";
   else if (numeric && flags.includes("+")) sign = "+";
   else if (numeric && flags.includes(" ")) sign = " ";
 
   const target = Number(width || 0);
   if (flags.includes("-")) return (sign + body).padEnd(target);
-  if (flags.includes("0") && numeric) return sign + body.padStart(target - sign.length, "0");
+  // A precision on an integer conversion cancels the `0` flag, as it does in C.
+  if (flags.includes("0") && numeric && !(integer && precision !== undefined)) {
+    return sign + body.padStart(target - sign.length, "0");
+  }
   return (sign + body).padStart(target);
+}
+
+/**
+ * Ruby applies `Integer()` / `Float()` to a numeric conversion's argument, so a
+ * value that does not convert raises rather than formatting as `NaN`.
+ */
+function numericArgument(value: unknown, integer: boolean): number {
+  const kind = integer ? "Integer" : "Float";
+  if (value == null) throw new TypeError(`can't convert nil into ${kind}`);
+  const number = Number(typeof value === "string" ? value.trim() : value);
+  if (Number.isNaN(number) || (typeof value === "string" && value.trim() === "")) {
+    throw new ArgumentError(`invalid value for ${kind}(): ${inspect(value)}`);
+  }
+  return number;
+}
+
+/**
+ * Ruby prints a negative `%b`/`%B`/`%o`/`%x`/`%X` with no sign flag as the
+ * infinite two's-complement form — `..` followed by the digits whose leading
+ * one, the base's largest, repeats leftward forever. The dots count toward both
+ * the precision and a zero-padded width, so both reduce by two here.
+ */
+function twosComplement(
+  value: number,
+  conversion: string,
+  flags: string,
+  width: string,
+  precision?: string,
+): string {
+  const radix = RADIX[conversion];
+  const top = (radix - 1).toString(radix);
+  // The leading `..7` already carries octal's alternate-form prefix.
+  const prefix = flags.includes("#") && conversion !== "o" ? ALTERNATE_PREFIX[conversion] : "";
+  const target = Number(width || 0);
+  const zeroPad = flags.includes("0") && !flags.includes("-");
+  const minDigits = Math.max(
+    precision === undefined ? 0 : Number(precision) - 2,
+    zeroPad ? target - prefix.length - 2 : 0,
+  );
+
+  // The digits are the value itself in `places` two's-complement places, and
+  // Ruby writes the shortest run whose leading digit is already the repeating
+  // one — `-42` is `1010110` in binary, not the shorter `10` that only two
+  // places would wrap to.
+  let digits: string;
+  for (let places = 1; ; places++) {
+    const modulus = radix ** places;
+    if (value + modulus < 0) continue;
+    digits = (value + modulus).toString(radix).padStart(places, "0");
+    if (digits.charAt(0) === top) break;
+  }
+  digits = digits.padStart(minDigits, top);
+  if (conversion === conversion.toUpperCase()) digits = digits.toUpperCase();
+
+  const out = `${prefix}..${digits}`;
+  return flags.includes("-") ? out.padEnd(target) : out.padStart(target);
 }
 
 /** Ruby pads the exponent to at least two digits; `toExponential` does not. */

--- a/packages/i18n/src/interpolate/ruby.ts
+++ b/packages/i18n/src/interpolate/ruby.ts
@@ -87,9 +87,10 @@ const ALTERNATE_PREFIX: Record<string, string> = { b: "0b", B: "0B", o: "0", x: 
  * `ruby.trails.test.ts`, including the forms that are easy to miss: an integer
  * precision as a minimum digit count, the `..` two's-complement form of a
  * negative `%b`/`%o`/`%x`, and `Integer()`/`Float()` raising on an argument
- * that does not convert. What is NOT covered is anything the interpolation
- * pattern cannot deliver here: argument indexes (`%1$d`), `*` widths, and the
- * conversions outside `[bBdiouxXeEfgGcps]`.
+ * that does not convert, booleans and other objects among them. What is NOT
+ * covered is anything the interpolation pattern cannot deliver here: argument
+ * indexes (`%1$d`), `*` widths, and the conversions outside
+ * `[bBdiouxXeEfgGcps]`.
  */
 function sprintf(spec: string, value: unknown): string {
   const parsed = FORMAT_SPEC.exec(spec);
@@ -149,16 +150,34 @@ function sprintf(spec: string, value: unknown): string {
 
 /**
  * Ruby applies `Integer()` / `Float()` to a numeric conversion's argument, so a
- * value that does not convert raises rather than formatting as `NaN`.
+ * value that does not convert raises rather than formatting as `NaN`. Only a
+ * Numeric or a String converts: `nil`, `true`/`false` and any other object
+ * raise `TypeError` naming what was given, and a String that does not parse
+ * raises `ArgumentError`.
+ *
+ * The `TypeError` is JS's own rather than a ported class because Ruby's is
+ * `Kernel`'s, and the gem raises none of its own here — `sprintf` is a builtin.
+ * `ArgumentError` is ported because `interpolate` already raises it (ruby.rb:8).
  */
 function numericArgument(value: unknown, integer: boolean): number {
   const kind = integer ? "Integer" : "Float";
   if (value == null) throw new TypeError(`can't convert nil into ${kind}`);
+  if (typeof value === "boolean") throw new TypeError(`can't convert ${value} into ${kind}`);
+  if (typeof value !== "number" && typeof value !== "string") {
+    throw new TypeError(`can't convert ${rubyClassName(value)} into ${kind}`);
+  }
   const number = Number(typeof value === "string" ? value.trim() : value);
   if (Number.isNaN(number) || (typeof value === "string" && value.trim() === "")) {
     throw new ArgumentError(`invalid value for ${kind}(): ${inspect(value)}`);
   }
   return number;
+}
+
+/** The Ruby class name `Integer()` / `Float()` name in their TypeError. */
+function rubyClassName(value: unknown): string {
+  if (Array.isArray(value)) return "Array";
+  const name = (value as object).constructor?.name;
+  return name === undefined || name === "Object" ? "Hash" : name;
 }
 
 /**

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -1924,6 +1924,26 @@ describe("extractFromProgram — @noRailsEquivalent JSDoc", () => {
     expect(mixin.instanceMethods.find((m) => m.name === "attributes")!.params).toEqual([]);
   });
 
+  it("records a protected member the factory's return type hides", () => {
+    const info = extractFromFiles("/p", {
+      "fallbacks.ts": `
+        interface Methods { translate(locale: string): unknown; }
+        export function Fallbacks(Base: new () => object): (new () => Methods) {
+          class F extends Base {
+            translate(locale: string): unknown { return locale; }
+            protected onFallback(locale: string): void {}
+          }
+          return F as never;
+        }
+      `,
+    });
+    const mixin = info.modules["fallbacks.ts:Fallbacks__mixin"];
+    const onFallback = mixin.instanceMethods.find((m) => m.name === "onFallback")!;
+    expect(onFallback.visibility).toBe("protected");
+    expect(onFallback.file).toBe("fallbacks.ts");
+    expect(mixin.instanceMethods.find((m) => m.name === "translate")!.declaredIn).toBeUndefined();
+  });
+
   it("extracts parameters onto a foreign synthesized __mixin member", () => {
     const info = extractFromFiles("/p", {
       "base.ts": `

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -843,20 +843,10 @@ export function extractFromProgram(
         });
       }
 
-      // The type-driven walk above sees only what the factory's RETURN TYPE
-      // exposes, so a member the inner class declares `protected` — Ruby's
-      // `private def on_fallback` (i18n/backend/fallbacks.rb:113) — never
-      // reaches it, and a public one it does see carries the base class's
-      // declaration site rather than this file's. Walk the class the factory
-      // returns directly and let its own members win, so every body written in
-      // this file is attributed to this file.
       for (const own of factoryClassMembers(node, checker, relPath, srcDir)) {
         const at = mixinMethods.findIndex(
           (m) => m.name === own.name && !!m.isStatic === !!own.isStatic,
         );
-        // Overlay rather than replace: the type-driven entry carries fields the
-        // declaration walk does not produce (option keys off the resolved
-        // signature), and the declaration carries the rest.
         if (at === -1) mixinMethods.push(own);
         else mixinMethods[at] = { ...mixinMethods[at], ...own, declaredIn: undefined };
       }

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -843,6 +843,24 @@ export function extractFromProgram(
         });
       }
 
+      // The type-driven walk above sees only what the factory's RETURN TYPE
+      // exposes, so a member the inner class declares `protected` — Ruby's
+      // `private def on_fallback` (i18n/backend/fallbacks.rb:113) — never
+      // reaches it, and a public one it does see carries the base class's
+      // declaration site rather than this file's. Walk the class the factory
+      // returns directly and let its own members win, so every body written in
+      // this file is attributed to this file.
+      for (const own of factoryClassMembers(node, checker, relPath, srcDir)) {
+        const at = mixinMethods.findIndex(
+          (m) => m.name === own.name && !!m.isStatic === !!own.isStatic,
+        );
+        // Overlay rather than replace: the type-driven entry carries fields the
+        // declaration walk does not produce (option keys off the resolved
+        // signature), and the declaration carries the rest.
+        if (at === -1) mixinMethods.push(own);
+        else mixinMethods[at] = { ...mixinMethods[at], ...own, declaredIn: undefined };
+      }
+
       if (mixinMethods.length > 0) {
         info.modules[mixinKey] = {
           name: `${node.name.text}__mixin`,
@@ -1766,6 +1784,36 @@ function isInternalCallableRef(expr: ts.Expression, checker: ts.TypeChecker): bo
  * Used both for `export const Mod = { ... }` module discovery and for
  * resolving inline / property-access mod args to `include(Host, Mod)`.
  */
+/**
+ * The members of the class a mixin factory returns —
+ * `export function Fallbacks(Superclass) { abstract class Fallbacks extends
+ * Superclass { ... } return Fallbacks; }`
+ * (packages/i18n/src/backend/fallbacks.ts, the port of Ruby's
+ * `include I18n::Backend::Fallbacks`).
+ *
+ * The class is a local declaration inside the function body, so the top-level
+ * walker never sees it, and the factory's declared return type hides whatever
+ * the class marks `protected`. Reading the declaration recovers both, with
+ * `extractClass` so member shape (arity, visibility, calls, JSDoc tags) matches
+ * every other class in the manifest.
+ */
+export function factoryClassMembers(
+  fn: ts.FunctionDeclaration,
+  checker: ts.TypeChecker,
+  file: string,
+  srcDir?: string,
+): MethodInfo[] {
+  if (!fn.body) return [];
+  const out: MethodInfo[] = [];
+  for (const stmt of fn.body.statements) {
+    if (!ts.isClassDeclaration(stmt) || !stmt.name) continue;
+    const info = extractClass(stmt, checker, file, srcDir);
+    if (!info) continue;
+    out.push(...info.instanceMethods, ...info.classMethods);
+  }
+  return out;
+}
+
 export function harvestObjectLiteralMethods(
   obj: ts.ObjectLiteralExpression,
   checker: ts.TypeChecker,


### PR DESCRIPTION
Seven `0074-i18n-parity` stories, bundled.

**`Date._parse` eu/us gate** (`date_parse.c:2180`) — `HAVE_ELEM_P(HAVE_ALPHA | HAVE_DIGIT)` needs both classes on the live `str`; we tested alpha only. Control-flow only: both sub-parsers require a digit run of their own, so no input is known to differ.

**`store_translations` locale normalization** (`simple.rb:42`) — the `locale = locale.to_sym` line was missing, so a `":en"`-spelled Symbol keyed a second bucket. Ported inline (a named `toSym` helper would make `to_sym` a ported name and light up four unrelated wide-ratchet rows). The Rails test `simple store_translations: converts the given locale to a Symbol` is ported verbatim and **passes on baseline** — both of its arms are the string `"en"` — so it is a parity test, not a regression guard; the guard is the `":en"` case in `simple.trails.test.ts`, which fails on baseline.

**Translations proxy** — the auto-vivification `get` trap answered `toJSON`, so `JSON.stringify(backend.translations())` grew a phantom `"toJSON":{}`. Excluded the JS protocol reads; a missing *locale* read still assigns, per `simple.rb:93-95`. Fails on baseline.

**`Base#resolve` through the facade** (`base.rb:150-156`) — was calling `config().backend.translate` directly, skipping `enforce_available_locales!`, the Array-key branch and `Disabled`. `Fallbacks#resolve_entry` converged the same way (`I18n.translate`, not the `t` alias with a pre-stripped key). No `Backend` interface `translate` member existed in `config.ts` to re-examine — `backend` is typed as `Base`.

**`sprintf` grammar** — the conversion set crossed with `-+ #0`, width and precision was diffed against real `ruby -e` output (476 combinations); 121 diverged. Fixed: integer precision is a minimum digit count (and cancels the `0` flag), `%.0d` of zero is empty, negative `%b`/`%B`/`%o`/`%x`/`%X` with no sign flag print Ruby's `..` two's-complement form (dots counting toward precision and zero-padded width), octal's `#` prefix pads *under* the precision while the others sit outside it, and a value `Integer()`/`Float()` rejects now raises instead of emitting `NaN`. All 476 match; a curated 84-row table is pinned in `ruby.trails.test.ts`, and the `sprintf` JSDoc states what the table bounds and what it does not.

**Proc `message:`** (`error.rb:96-101`) — Rails never calls the Proc in `generate_message`; it goes into the defaults chain and the backend's `resolve` invokes it with `(key, options)`, interpolating through the gem. Deleted the arm and `Error.interpolate` (extra surface with no Ruby counterpart, that arm its only caller). The `errors_test.rb` Proc cases pass unchanged.

**`api:compare` extractor** — members of the class a mixin factory returns were invisible: the factory's declared return type hides anything `protected`, so `on_fallback` dropped out and `translate`/`exists`/`resolve_entry` resolved by bare short name against `backend/base.ts`. The synthesized `__mixin` entry now overlays the returned class's own declarations. i18n goes 216/217 → **217/217**, `backend/fallbacks.rb` 4/5 → 5/5, with no visibility change in `fallbacks.ts`.

Gates: `test:compare` `backend/simple_test.rb` **31/31**; `api:calls` and `api:calls:wide` both OK with no new rows; `api:extra` unchanged (one entry removed).

Closes-story: i18n-date-parse-eu-us-gate-misses-have-digit
Closes-story: i18n-mixin-factory-members-invisible-to-api-compare
Closes-story: i18n-resolve-through-facade
Closes-story: i18n-sprintf-grammar-conformance
Closes-story: i18n-store-translations-locale-to-sym
Closes-story: i18n-translations-proxy-invents-tojson
Closes-story: proc-message-resolves-through-i18n
