### PR TITLE
feat(activemodel,activerecord): ModelName#human options, Version#compare, TableDefinition @conn typing, SHA1 encryption writer

### DIFF
--- a/packages/activemodel/src/error.ts
+++ b/packages/activemodel/src/error.ts
@@ -14,7 +14,7 @@ interface ValidatableBase {
 interface ModelClass {
   name?: string;
   i18nScope?: string;
-  modelName?: { i18nKey?: string; human?: string };
+  modelName?: { i18nKey?: string; human?: () => string };
   humanAttributeName?: (attr: string, options?: { default?: string; base?: ModelBase }) => string;
   lookupAncestors?: () => ModelClass[];
 }
@@ -163,7 +163,7 @@ export class Error {
         : undefined;
 
     options = {
-      model: baseClass?.modelName?.human,
+      model: baseClass?.modelName?.human?.(),
       attribute: baseClass?.humanAttributeName
         ? baseClass.humanAttributeName(attribute, { base })
         : humanize(attribute),

--- a/packages/activemodel/src/lint.test.ts
+++ b/packages/activemodel/src/lint.test.ts
@@ -76,7 +76,7 @@ describe("Lint::Tests", () => {
   });
 
   describe("testModelNaming", () => {
-    const goodName = { human: "Foo", singular: "foo", plural: "foos" };
+    const goodName = { human: () => "Foo", singular: "foo", plural: "foos" };
 
     it("passes when instance.modelName === constructor.modelName", () => {
       const fixture = { modelName: goodName, constructor: { modelName: goodName } };

--- a/packages/activemodel/src/lint.ts
+++ b/packages/activemodel/src/lint.ts
@@ -130,15 +130,15 @@ export namespace Tests {
   }
 
   type ModelNamingHost = {
-    modelName: { human: string; singular: string; plural: string };
-    constructor: { modelName?: { human: string; singular: string; plural: string } };
+    modelName: { human: () => string; singular: string; plural: string };
+    constructor: { modelName?: { human: () => string; singular: string; plural: string } };
   };
   export function testModelNaming(model: ModelNamingHost): void {
     const classModelName = model.constructor.modelName;
     if (!classModelName) {
       throw new MinitestAssertion("model.constructor.modelName must be defined");
     }
-    if (typeof classModelName.human !== "string") {
+    if (typeof classModelName.human() !== "string") {
       throw new MinitestAssertion("modelName.human must return a string");
     }
     if (typeof classModelName.singular !== "string") {

--- a/packages/activemodel/src/naming.test.ts
+++ b/packages/activemodel/src/naming.test.ts
@@ -57,7 +57,7 @@ describe("NamingTest", () => {
 
   it("human", () => {
     const name = new ModelName("Post");
-    expect(name.human).toBe("Post");
+    expect(name.human()).toBe("Post");
   });
 
   it("uncountable", () => {
@@ -190,7 +190,7 @@ describe("NamingWithNamespacedModelInSharedNamespaceTest", () => {
   });
 
   it("human", () => {
-    expect(new ModelName("Post", opts).human).toBe("Post");
+    expect(new ModelName("Post", opts).human()).toBe("Post");
   });
 
   it("route key", () => {
@@ -225,7 +225,7 @@ describe("NamingWithSuppliedModelNameTest", () => {
   });
   it("human", () => {
     const name = new ModelName("Article");
-    expect(name.human).toBe("Article");
+    expect(name.human()).toBe("Article");
   });
   it("route key", () => {
     const name = new ModelName("Article");
@@ -272,7 +272,7 @@ describe("NamingUsingRelativeModelNameTest", () => {
     expect(new ModelName("Post", opts).collection).toBe("blog/posts");
   });
   it("human", () => {
-    expect(new ModelName("Post", opts).human).toBe("Post");
+    expect(new ModelName("Post", opts).human()).toBe("Post");
   });
   it("route key", () => {
     expect(new ModelName("Post", opts).routeKey).toBe("posts");
@@ -295,7 +295,7 @@ describe("NamingWithNamespacedModelInIsolatedNamespaceTest", () => {
     expect(new ModelName("Post", opts).singular).toBe("blog_post");
   });
   it("human", () => {
-    expect(new ModelName("Post", opts).human).toBe("Post");
+    expect(new ModelName("Post", opts).human()).toBe("Post");
   });
   it("plural", () => {
     expect(new ModelName("Post", opts).plural).toBe("blog_posts");

--- a/packages/activemodel/src/naming.ts
+++ b/packages/activemodel/src/naming.ts
@@ -63,6 +63,7 @@ export namespace Naming {
   }
 }
 import { I18n } from "./i18n.js";
+import type { TranslateOptions } from "@blazetrails/i18n";
 
 /** @internal Mirrors ActiveModel::Name::MISSING_TRANSLATION */
 const MISSING_TRANSLATION = -(2 ** 60);
@@ -329,7 +330,7 @@ export class ModelName {
     this.singularRouteKey = singularize(this.routeKey);
   }
 
-  get human(): string {
+  human(options: TranslateOptions = {}): string {
     if (!this._klass) return this._humanFallback;
 
     const i18nKeys = this.i18nKeys();
@@ -338,11 +339,13 @@ export class ModelName {
 
     const [key, ...defaults] = i18nKeys as unknown[];
     const defaultChain: unknown[] = defaults.map((k) => `:${k as string}`);
+    if (options.default != null && options.default !== false) defaultChain.push(options.default);
     defaultChain.push(MISSING_TRANSLATION);
 
     let translation = I18n.translate(key as string, {
       scope: i18nScope,
       count: 1,
+      ...options,
       default: defaultChain,
     });
     if (translation === MISSING_TRANSLATION) translation = this._humanFallback;

--- a/packages/activemodel/src/translation.test.ts
+++ b/packages/activemodel/src/translation.test.ts
@@ -148,6 +148,23 @@ describe("ActiveModelI18nTests", () => {
     expect(opts).toEqual({});
   });
 
+  it("translated model with default value when missing translation", () => {
+    class Person extends Model {}
+    expect(Person.modelName.human({ default: "dude" })).toBe("dude");
+  });
+
+  it("translated model with default key when missing both translations", () => {
+    class Person extends Model {}
+    expect(Person.modelName.human({ default: ":this_key_does_not_exist" })).toBe("Person");
+  });
+
+  it("human does not modify options", () => {
+    class Person extends Model {}
+    const options = { default: "person model" };
+    Person.modelName.human(options);
+    expect(options).toEqual({ default: "person model" });
+  });
+
   it("raise on missing translations", () => {
     // humanAttributeName always returns a default, never raises
     expect(Model.humanAttributeName("missing_field")).toBe("Missing field");

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-explain.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-explain.test.ts
@@ -40,9 +40,11 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     let expectedClause: string;
     beforeAll(() => {
       const ver = adapter.databaseVersion;
-      const supportsAnalyze = isMariaDb && ver.gte("10.1.0");
+      const supportsAnalyze = isMariaDb && ver.compare("10.1.0") >= 0;
       // `version <= "10.0"` expressed as `Version("10.0") >= version`.
-      const supportsExplainAnalyze = isMariaDb ? new Version("10.0").gte(ver) : ver.gte("6.0");
+      const supportsExplainAnalyze = isMariaDb
+        ? new Version("10.0").compare(String(ver)) >= 0
+        : ver.compare("6.0") >= 0;
       explainOpt = supportsAnalyze || supportsExplainAnalyze ? "analyze" : "extended";
       expectedClause = supportsAnalyze
         ? "ANALYZE"
@@ -145,7 +147,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     it("buildExplainClause combines string flag and format hash space-separated", () => {
       const clause = adapter.buildExplainClause(["analyze", { format: "json" }]);
       // MariaDB >= 10.1 drops the EXPLAIN prefix for ANALYZE (analyze_without_explain?).
-      const analyzeWithoutExplain = isMariaDb && adapter.databaseVersion.gte("10.1.0");
+      const analyzeWithoutExplain = isMariaDb && adapter.databaseVersion.compare("10.1.0") >= 0;
       expect(clause).toBe(
         analyzeWithoutExplain ? "ANALYZE FORMAT=JSON for:" : "EXPLAIN ANALYZE FORMAT=JSON for:",
       );

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/table-options.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/table-options.test.ts
@@ -18,7 +18,9 @@ import {
 // Probed at module load so the conditional can sit on it.skipIf instead of
 // inside the test body (which the lint rule forbids).
 const skipNoTableOptions =
-  isMariaDb || mysqlVersion === "" || new Version(mysqlVersion.replace(/-.*$/, "")).gte("5.7.22");
+  isMariaDb ||
+  mysqlVersion === "" ||
+  new Version(mysqlVersion.replace(/-.*$/, "")).compare("5.7.22") >= 0;
 
 const dumpTable = (adapter: Mysql2Adapter, tableName: string) =>
   SchemaDumper.dumpTableSchema(adapter as unknown as SchemaSource, tableName);

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -167,34 +167,20 @@ export class Version {
   }
 
   /**
-   * Rails' Version `include Comparable` and defines only `<=>`; `>=` / `<`
-   * come from Comparable itself, so there is no `def gte` to mirror
-   * (abstract_adapter.rb:243-259). `gte`/`lt` are the TS spelling of those two
-   * Comparable operators — the only ones any caller uses — over the same
-   * dotted-part comparison `<=>` performs.
-   *
-   * @noRailsEquivalent CONVERGEABLE (story: port-version-compare-and-retire-gte-lt).
-   * Rails' `AbstractAdapter::Version` does `include Comparable` and defines only
-   *   `<=>`
-   *   (abstract_adapter.rb:243-259); `>=` and `<` come from Comparable, so there is no `def gte` for
-   *   the extractor to match. `gte`/`lt` are the TS spelling of those two Comparable operators over
-   *   the same dotted-part comparison `<=>` performs. Justified at the declaration. The non-Rails
-   *   part-readers on the same class (`major`/`minor`/`patch`) were deleted rather than allowlisted —
-   *   they had no callers.
+   * Mirrors Rails' `<=>` (abstract_adapter.rb:252-254): `@version <=>
+   * version_string.split(".").map(&:to_i)`. Ruby's `Array#<=>` compares
+   * element by element and falls back to length, which is what the loop and
+   * the trailing length comparison spell out here. Rails' `>=` / `<` come
+   * from `include Comparable`; TS has no operator overloading, so call sites
+   * spell them `compare(...) >= 0` / `compare(...) < 0`.
    */
-  gte(other: Version | string): boolean {
-    const otherVersion = typeof other === "string" ? new Version(other) : other;
-    for (let i = 0; i < Math.max(this._parts.length, otherVersion._parts.length); i++) {
-      const a = this._parts[i] ?? 0;
-      const b = otherVersion._parts[i] ?? 0;
-      if (a > b) return true;
-      if (a < b) return false;
+  compare(versionString: string): number {
+    const other = versionString.split(".").map(Number);
+    for (let i = 0; i < Math.min(this._parts.length, other.length); i++) {
+      if (this._parts[i] > other[i]) return 1;
+      if (this._parts[i] < other[i]) return -1;
     }
-    return true;
-  }
-
-  lt(other: Version | string): boolean {
-    return !this.gte(other);
+    return this._parts.length === other.length ? 0 : this._parts.length > other.length ? 1 : -1;
   }
 }
 
@@ -399,6 +385,15 @@ export interface AbstractAdapter {
     options?: Omit<ForeignKeyLookupOptions, "toTable">,
   ): Promise<boolean>;
   addForeignKey(fromTable: string, toTable: string, options?: AddForeignKeyOptions): Promise<void>;
+  /**
+   * Mirrors: ActiveRecord::ConnectionAdapters::SchemaStatements#foreign_key_options
+   * @internal
+   */
+  foreignKeyOptions(
+    fromTable: string,
+    toTable: string,
+    options?: Record<string, unknown>,
+  ): Record<string, unknown>;
   isUseForeignKeys(): boolean;
   removeForeignKey(
     fromTable: string,
@@ -427,6 +422,15 @@ export interface AbstractAdapter {
     options?: { name?: string; validate?: boolean; ifNotExists?: boolean; [key: string]: unknown },
   ): Promise<void>;
   checkConstraints(tableName: string): Promise<CheckConstraintDefinition[]>;
+  /**
+   * Mirrors: ActiveRecord::ConnectionAdapters::SchemaStatements#check_constraint_options
+   * @internal
+   */
+  checkConstraintOptions(
+    tableName: string,
+    expression: string,
+    options?: Record<string, unknown>,
+  ): Record<string, unknown>;
   checkConstraintExists(
     tableName: string,
     options: { name?: string; expression?: string },
@@ -442,6 +446,11 @@ export interface AbstractAdapter {
     options?: { name?: string; ifExists?: boolean },
   ): Promise<void>;
   removeConstraint(tableName: string, constraintName: string): Promise<void>;
+  /**
+   * Mirrors: ActiveRecord::ConnectionAdapters::SchemaStatements#valid_column_definition_options
+   * @internal
+   */
+  validColumnDefinitionOptions(): string[];
   updateTableDefinition(tableName: string, base?: unknown): Table;
   assumeMigratedUptoVersion(version: number | string): Promise<void>;
   createJoinTable(

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -442,15 +442,15 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   supportsIndexSortOrder(): boolean {
     // Rails: `mariadb? ? database_version >= "10.8.1" : database_version >= "8.0.1"`
     // (abstract_mysql_adapter.rb#supports_index_sort_order?).
-    if (this._mariadb) return this._databaseVersion?.gte("10.8.1") === true;
-    return this._databaseVersion?.gte("8.0.1") === true;
+    if (this._mariadb) return (this._databaseVersion?.compare("10.8.1") ?? -1) >= 0;
+    return (this._databaseVersion?.compare("8.0.1") ?? -1) >= 0;
   }
 
   supportsExpressionIndex(): boolean {
     // Mirror Rails `!mariadb? && database_version >= "8.0.13"`
     // (abstract_mysql_adapter.rb:104) — MariaDB is excluded.
     if (this._mariadb) return false;
-    return this._databaseVersion?.gte("8.0.13") === true;
+    return (this._databaseVersion?.compare("8.0.13") ?? -1) >= 0;
   }
 
   supportsTransactionIsolation(): boolean {
@@ -480,9 +480,12 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       // excluded, which a single `>= 10.2.22` would wrongly admit.
       const version = this._databaseVersion;
       if (!version) return false;
-      return version.gte("10.3.10") || (version.lt("10.3") && version.gte("10.2.22"));
+      return (
+        version.compare("10.3.10") >= 0 ||
+        (version.compare("10.3") < 0 && version.compare("10.2.22") >= 0)
+      );
     }
-    return this._databaseVersion?.gte("8.0.16") === true;
+    return (this._databaseVersion?.compare("8.0.16") ?? -1) >= 0;
   }
 
   supportsViews(): boolean {
@@ -499,12 +502,12 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
 
   supportsOptimizerHints(): boolean {
     if (this._mariadb) return false;
-    return this._databaseVersion?.gte("5.7.7") === true;
+    return (this._databaseVersion?.compare("5.7.7") ?? -1) >= 0;
   }
 
   supportsCommonTableExpressions(): boolean {
-    if (this._mariadb) return this._databaseVersion?.gte("10.2.1") === true;
-    return this._databaseVersion?.gte("8.0") === true;
+    if (this._mariadb) return (this._databaseVersion?.compare("10.2.1") ?? -1) >= 0;
+    return (this._databaseVersion?.compare("8.0") ?? -1) >= 0;
   }
 
   supportsAdvisoryLocks(): boolean {
@@ -520,7 +523,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   }
 
   supportsInsertReturning(): boolean {
-    if (this._mariadb) return this._databaseVersion?.gte("10.5.0") === true;
+    if (this._mariadb) return (this._databaseVersion?.compare("10.5.0") ?? -1) >= 0;
     return false;
   }
 
@@ -552,7 +555,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     // (mysql2_adapter.rb:70 / trilogy_adapter.rb:95) — MariaDB JSON is a
     // LONGTEXT alias, so Rails reports it unsupported.
     if (this._mariadb) return false;
-    return this._databaseVersion?.gte("5.7.8") === true;
+    return (this._databaseVersion?.compare("5.7.8") ?? -1) >= 0;
   }
 
   supportsComments(): boolean {
@@ -1255,7 +1258,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   // rather than raise a false positive — a query-issuing sync port isn't possible.
   override checkVersion(): void {
     const version = this._databaseVersion;
-    if (version && version.lt("5.6.4")) {
+    if (version && version.compare("5.6.4") < 0) {
       throw new DatabaseVersionError(
         `Your version of MySQL (${version}) is too old. Active Record supports MySQL >= 5.6.4.`,
       );
@@ -1441,7 +1444,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::DatabaseStatements#analyze_without_explain?
    */
   protected analyzeWithoutExplain(): boolean {
-    return this._mariadb && this._databaseVersion?.gte("10.1.0") === true;
+    return this._mariadb && (this._databaseVersion?.compare("10.1.0") ?? -1) >= 0;
   }
 
   /**
@@ -1722,19 +1725,19 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   /** @internal */
   supportsInsertRawAliasSyntax(): boolean {
     if (this._mariadb) return false;
-    return this._databaseVersion?.gte("8.0.19") === true;
+    return (this._databaseVersion?.compare("8.0.19") ?? -1) >= 0;
   }
 
   /** @internal */
   supportsRenameIndex(): boolean {
-    if (this._mariadb) return this._databaseVersion?.gte("10.5.2") === true;
-    return this._databaseVersion?.gte("5.7.6") === true;
+    if (this._mariadb) return (this._databaseVersion?.compare("10.5.2") ?? -1) >= 0;
+    return (this._databaseVersion?.compare("5.7.6") ?? -1) >= 0;
   }
 
   /** @internal */
   supportsRenameColumn(): boolean {
-    if (this._mariadb) return this._databaseVersion?.gte("10.5.2") === true;
-    return this._databaseVersion?.gte("8.0.3") === true;
+    if (this._mariadb) return (this._databaseVersion?.compare("10.5.2") ?? -1) >= 0;
+    return (this._databaseVersion?.compare("8.0.3") ?? -1) >= 0;
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from "vitest";
 import {
-  ColumnDefinition,
   IndexDefinition,
   ForeignKeyDefinition,
   ReferenceDefinition,
@@ -484,12 +483,7 @@ describe("Table#aliasedTypes", () => {
 });
 
 describe("TableDefinition id hash form", () => {
-  const mysqlAdapter = {
-    quoteColumnName: (s: string) => `\`${s}\``,
-    quoteTableName: (s: string) => `\`${s}\``,
-    quoteDefaultExpression: (_v: unknown) => "",
-    validColumnDefinitionOptions: () => ColumnDefinition.OPTION_NAMES,
-  };
+  const mysqlAdapter = schemaConn("mysql");
 
   it("extracts type and merges remaining keys as pk column options", () => {
     const td = new TableDefinition("t", { adapterName: "mysql", adapter: mysqlAdapter });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1197,14 +1197,14 @@ export class TableDefinition {
     return this;
   }
 
+  /**
+   * Mirrors: ActiveRecord::ConnectionAdapters::TableDefinition#new_foreign_key_definition
+   * (schema_definitions.rb:575-581).
+   */
   newForeignKeyDefinition(
     toTable: string,
     options: Partial<AddForeignKeyOptions> = {},
   ): ForeignKeyDefinition {
-    // Mirrors Rails' TableDefinition#new_foreign_key_definition
-    // (schema_definitions.rb:575-581): apply table_name_prefix/suffix to
-    // to_table, then delegate the column/name defaults to
-    // `@conn.foreign_key_options`.
     const prefix = this._adapter.tableNamePrefix ?? globalTableNamePrefix();
     const suffix = this._adapter.tableNameSuffix ?? globalTableNameSuffix();
     const prefixedToTable = `${prefix}${toTable}${suffix}`;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1,6 +1,6 @@
 import type { SchemaQuoter } from "./assert-schema-adapter.js";
 import type { Column } from "../column.js";
-import { singularize, pluralize, getCrypto, assertValidKeys } from "@blazetrails/activesupport";
+import { singularize, pluralize, assertValidKeys } from "@blazetrails/activesupport";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { SchemaDumper } from "../../schema-dumper.js";
 import {
@@ -88,10 +88,8 @@ export type ReferentialAction = "cascade" | "nullify" | "restrict";
 /**
  * The adapter surface {@link TableDefinition.newForeignKeyDefinition} reads
  * beyond {@link SchemaQuoter}: the table_name_prefix/suffix (Rails reads these
- * off `ActiveRecord::Base`) and the converged `foreign_key_options` that fills
- * the default column and SHA256 `fk_rails_<hex>` name. All optional — a
- * bare-{@link SchemaQuoter} host (the MySQL schema quoter) exposes none and
- * falls back locally.
+ * off `ActiveRecord::Base`) and `foreign_key_options` that fills the default
+ * column and SHA256 `fk_rails_<hex>` name.
  * @internal
  */
 export interface ForeignKeyOptionsAdapter {
@@ -120,16 +118,19 @@ export interface CheckConstraintOptionsAdapter {
 }
 
 /**
- * Mirrors Rails' check_constraint_name default. Used only as the fallback for a
- * bare quoter that carries no `checkConstraintOptions`.
- *
+ * The `@conn` surface `TableDefinition` reads (schema_definitions.rb:575-591:
+ * `foreign_key_options`, `check_constraint_options`,
+ * `valid_column_definition_options`), plus the quoting subset schema emission
+ * needs. In Rails `@conn` is the adapter itself, with `SchemaStatements` mixed
+ * in, so every one of these is always there.
  * @internal
  */
-function defaultCheckConstraintName(tableName: string, expression: string): string {
-  const identifier = `${tableName}_${expression}_chk`;
-  const hex = getCrypto().createHash("sha256").update(identifier).digest("hex").slice(0, 10);
-  return `chk_rails_${hex}`;
-}
+export type TableDefinitionConn = SchemaQuoter &
+  ForeignKeyOptionsAdapter &
+  CheckConstraintOptionsAdapter & {
+    /** @internal */
+    validColumnDefinitionOptions(): string[];
+  };
 
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::ColumnDefinition
@@ -1003,13 +1004,13 @@ export class TableDefinition {
   readonly comment?: string;
   private _primaryKeys?: PrimaryKeyDefinition;
   private _adapterName: "sqlite" | "postgres" | "mysql";
-  protected _adapter: SchemaQuoter;
+  protected _adapter: TableDefinitionConn;
 
   constructor(
     tableName: string,
     tdOptions: {
       adapterName?: "sqlite" | "postgres" | "mysql";
-      adapter: SchemaQuoter;
+      adapter: TableDefinitionConn;
       temporary?: boolean;
       ifNotExists?: boolean;
       as?: string;
@@ -1137,16 +1138,9 @@ export class TableDefinition {
     if (index !== -1) this.columns.splice(index, 1);
   }
 
-  /**
-   * The cast covers a typing gap only: `SchemaStatements` is mixed into the
-   * adapters at runtime, so the reader answering `ColumnDefinition::OPTION_NAMES`
-   * (schema_statements.rb:1584-1586) is not on the static {@link SchemaQuoter}
-   * surface `_adapter` is declared with.
-   * @internal
-   */
+  /** @internal */
   protected validColumnDefinitionOptions(): string[] {
-    const conn = this._adapter as unknown as { validColumnDefinitionOptions(): string[] };
-    return conn.validColumnDefinitionOptions();
+    return this._adapter.validColumnDefinitionOptions();
   }
 
   /** @internal */
@@ -1207,14 +1201,14 @@ export class TableDefinition {
     toTable: string,
     options: Partial<AddForeignKeyOptions> = {},
   ): ForeignKeyDefinition {
-    // Mirrors Rails' TableDefinition#new_foreign_key_definition: apply
-    // table_name_prefix/suffix to to_table, then route the column/name defaults
-    // through the adapter's foreign_key_options (SHA256 `fk_rails_<hex>` name).
-    const adapter = this._adapter as Partial<ForeignKeyOptionsAdapter>;
-    const prefix = adapter.tableNamePrefix ?? globalTableNamePrefix();
-    const suffix = adapter.tableNameSuffix ?? globalTableNameSuffix();
+    // Mirrors Rails' TableDefinition#new_foreign_key_definition
+    // (schema_definitions.rb:575-581): apply table_name_prefix/suffix to
+    // to_table, then delegate the column/name defaults to
+    // `@conn.foreign_key_options`.
+    const prefix = this._adapter.tableNamePrefix ?? globalTableNamePrefix();
+    const suffix = this._adapter.tableNameSuffix ?? globalTableNameSuffix();
     const prefixedToTable = `${prefix}${toTable}${suffix}`;
-    const opts = this._foreignKeyOptions(prefixedToTable, options);
+    const opts = this._adapter.foreignKeyOptions(this.tableName, prefixedToTable, { ...options });
     return new ForeignKeyDefinition(
       this.tableName,
       prefixedToTable,
@@ -1232,65 +1226,18 @@ export class TableDefinition {
     );
   }
 
-  /**
-   * Delegate to the adapter's `foreignKeyOptions` (which fills the default
-   * column and SHA256 `fk_rails_<hex>` name) when available. A
-   * bare-{@link SchemaQuoter} host (the MySQL schema quoter) lacks it, so fall
-   * back to the same derivation as SchemaStatements#foreignKeyOptions /
-   * foreignKeyName.
-   * @internal
-   */
-  private _foreignKeyOptions(
-    toTable: string,
-    options: Partial<AddForeignKeyOptions>,
-  ): Record<string, unknown> {
-    const adapter = this._adapter as Partial<ForeignKeyOptionsAdapter>;
-    if (typeof adapter.foreignKeyOptions === "function") {
-      return adapter.foreignKeyOptions(this.tableName, toTable, { ...options });
-    }
-    const result: Record<string, unknown> = { ...options };
-    // Mirror foreign_key_column_for: strip table_name_prefix/suffix (and the
-    // trails schema-qualifier) before singularizing, so a prefixed to_table
-    // still yields the bare `<singular>_<pk>` default column.
-    const columnFor = (pk: string): string => {
-      const prefix = adapter.tableNamePrefix ?? globalTableNamePrefix();
-      const suffix = adapter.tableNameSuffix ?? globalTableNameSuffix();
-      let base = toTable.replace(/^.*\./, "");
-      if (prefix || suffix) {
-        const stripped = base.match(new RegExp(`^${prefix}(.+)${suffix}$`));
-        if (stripped) base = stripped[1];
-      }
-      return `${singularize(base)}_${pk}`;
-    };
-    if (!result.column) {
-      // Mirror foreign_key_options: a composite primary_key array maps each PK
-      // column to its own foreign-key column; the scalar branch always derives
-      // from the literal "id" (schema_statements.rb:1246-1267).
-      result.column = Array.isArray(result.primaryKey)
-        ? (result.primaryKey as string[]).map((pk) => columnFor(pk))
-        : columnFor("id");
-    }
-    if (!result.name) {
-      const cols = Array.isArray(result.column) ? result.column : [result.column];
-      const identifier = `${this.tableName}_${cols.join("_and_")}_fk`;
-      const hex = getCrypto().createHash("sha256").update(identifier).digest("hex").slice(0, 10);
-      result.name = `fk_rails_${hex}`;
-    }
-    assertCompositeForeignKeyArity(toTable, result.column, result.primaryKey);
-    return result;
-  }
-
   newCheckConstraintDefinition(
     expression: string,
     options: { name?: string; validate?: boolean } = {},
   ): CheckConstraintDefinition {
-    const conn = this._adapter as Partial<CheckConstraintOptionsAdapter>;
-    const resolved = (conn.checkConstraintOptions?.(this.tableName, expression, options) ??
-      options) as { name?: string; validate?: boolean };
+    const resolved = this._adapter.checkConstraintOptions(this.tableName, expression, options) as {
+      name?: string;
+      validate?: boolean;
+    };
     return new CheckConstraintDefinition(
       this.tableName,
       expression,
-      resolved.name ?? defaultCheckConstraintName(this.tableName, expression),
+      resolved.name as string,
       resolved.validate ?? true,
     );
   }

--- a/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
@@ -93,7 +93,7 @@ interface AutoIncrementColumnHost {
 export function isAnalyzeWithoutExplain(this: BuildExplainClauseHost | void): boolean {
   const host = this as BuildExplainClauseHost | null;
   if (!host?.isMariadb?.()) return false;
-  return host.getDatabaseVersion?.().gte("10.1.0") === true;
+  return (host.getDatabaseVersion?.().compare("10.1.0") ?? -1) >= 0;
 }
 
 /** @internal */

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
@@ -12,6 +12,7 @@ import type {
   ColumnType,
   AddColumnDefinition,
   AddIndexOptions,
+  TableDefinitionConn,
 } from "../abstract/schema-definitions.js";
 import {
   assertSafeMysqlIdentifier,
@@ -21,7 +22,6 @@ import {
   IndexDefinition,
   TableDefinition,
 } from "../abstract/schema-definitions.js";
-import type { SchemaQuoter } from "../abstract/assert-schema-adapter.js";
 import {
   addOptionsForIndexColumns,
   integerToSql,
@@ -52,7 +52,7 @@ type MysqlTableDef = TableDefinition & { charset?: string; collation?: string };
 /** @internal Adapter surface consulted by the visitor's support flags and MariaDB branches.
  * Rails' `SchemaCreation#initialize(conn)` always receives the live adapter, so the quoting
  * half is required and dispatches polymorphically. */
-export interface VisitorHostAdapter extends SchemaQuoter {
+export interface VisitorHostAdapter extends TableDefinitionConn {
   supportsCheckConstraints(): boolean;
   supportsForeignKeys(): boolean;
   supportsIndexesInCreate(): boolean;

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -176,7 +176,9 @@ export async function isRowFormatDynamicByDefault(this: RowFormatHost): Promise<
   // `get_database_version` lazily; the TS spelling of that laziness is awaiting
   // `getDatabaseVersion()`, whose result the adapter memoizes.
   const databaseVersion = await this.getDatabaseVersion();
-  return this.isMariadb() ? databaseVersion.gte("10.2.2") : databaseVersion.gte("5.7.9");
+  return this.isMariadb()
+    ? databaseVersion.compare("10.2.2") >= 0
+    : databaseVersion.compare("5.7.9") >= 0;
 }
 
 /** @internal */

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
@@ -23,7 +23,7 @@ import type {
   ColumnType,
   SchemaStatementsLike,
 } from "../abstract/schema-definitions.js";
-import type { SchemaQuoter } from "../abstract/assert-schema-adapter.js";
+import type { TableDefinitionConn } from "../abstract/schema-definitions.js";
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace PostgreSQL {
@@ -206,7 +206,7 @@ export class TableDefinition extends AbstractTableDefinition {
       temporary?: boolean;
       ifNotExists?: boolean;
       as?: string;
-      adapter: SchemaQuoter;
+      adapter: TableDefinitionConn;
     },
   ) {
     super(tableName, { ...options, adapterName: "postgres" });

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1252,7 +1252,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   }
 
   supportsExpressionIndex(): boolean {
-    return this.databaseVersion.gte("3.9.0");
+    return this.databaseVersion.compare("3.9.0") >= 0;
   }
 
   override supportsForeignKeys(): boolean {
@@ -1276,11 +1276,11 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   }
 
   override supportsCommonTableExpressions(): boolean {
-    return this.databaseVersion.gte("3.8.3");
+    return this.databaseVersion.compare("3.8.3") >= 0;
   }
 
   supportsInsertReturning(): boolean {
-    return this.databaseVersion.gte("3.35.0");
+    return this.databaseVersion.compare("3.35.0") >= 0;
   }
 
   /** Mirrors: SQLite3::DatabaseStatements#returning_column_values — the full
@@ -1316,7 +1316,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   }
 
   supportsInsertOnConflict(): boolean {
-    return this.databaseVersion.gte("3.24.0");
+    return this.databaseVersion.compare("3.24.0") >= 0;
   }
 
   override supportsInsertOnDuplicateSkip(): boolean {
@@ -1336,7 +1336,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   }
 
   override supportsVirtualColumns(): boolean {
-    return this.databaseVersion.gte("3.31.0");
+    return this.databaseVersion.compare("3.31.0") >= 0;
   }
 
   override supportsIndexSortOrder(): boolean {
@@ -1476,7 +1476,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   }
 
   override checkVersion(): void {
-    if (this.databaseVersion.lt("3.8.0")) {
+    if (this.databaseVersion.compare("3.8.0") < 0) {
       throw new Error(
         `Your version of SQLite (${this.databaseVersion}) is too old. Active Record supports SQLite >= 3.8.`,
       );

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-definitions.ts
@@ -9,12 +9,12 @@ import {
   ColumnDefinition,
 } from "../abstract/schema-definitions.js";
 import type { ColumnOptions, ColumnType } from "../abstract/schema-definitions.js";
-import type { SchemaQuoter } from "../abstract/assert-schema-adapter.js";
+import type { TableDefinitionConn } from "../abstract/schema-definitions.js";
 
 export class TableDefinition extends AbstractTableDefinition {
   constructor(
     tableName: string,
-    options: { id?: boolean | "uuid"; adapter: SchemaQuoter; [key: string]: unknown },
+    options: { id?: boolean | "uuid"; adapter: TableDefinitionConn; [key: string]: unknown },
   ) {
     super(tableName, { ...options, adapterName: "sqlite" });
   }

--- a/packages/activerecord/src/encryption/config.ts
+++ b/packages/activerecord/src/encryption/config.ts
@@ -9,6 +9,8 @@ import { deflateSync, inflateSync } from "zlib";
 import { presence } from "@blazetrails/activesupport";
 
 import { Configuration } from "./errors.js";
+import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
+import { KeyGenerator } from "./key-generator.js";
 import type { SchemeOptions } from "./scheme.js";
 
 /**
@@ -50,7 +52,6 @@ export class Config {
   addToFilterParameters: boolean = true;
   excludedFromFilterParameters: string[] = [];
   previousSchemes: SchemeOptions[] = [];
-  supportSha1ForNonDeterministicEncryption: boolean = false;
   extendQueries: boolean = false;
   hashDigestClass: string = "SHA1";
   compressor: Compressor = Zlib;
@@ -63,6 +64,24 @@ export class Config {
   set previous(schemes: SchemeOptions[]) {
     for (const props of schemes) {
       this.addPreviousScheme(props);
+    }
+  }
+
+  /**
+   * Rails `support_sha1_for_non_deterministic_encryption=`
+   * (encryption/config.rb:28-33) is a writer with behavior and no reader: a
+   * truthy value with a primary key configured installs a previous scheme
+   * whose key provider derives from a SHA1 key generator. A TS `set` accessor
+   * would do, but the trails idiom for a Ruby `x=` that is not stored state is
+   * a `setX` method, and this one takes no reader alongside it.
+   */
+  setSupportSha1ForNonDeterministicEncryption(value: boolean): void {
+    if (value && this.hasPrimaryKey()) {
+      const sha1KeyGenerator = new KeyGenerator("SHA1");
+      const sha1KeyProvider = new DerivedSecretKeyProvider(this.primaryKey, {
+        keyGenerator: sha1KeyGenerator,
+      });
+      this.addPreviousScheme({ keyProvider: sha1KeyProvider });
     }
   }
 

--- a/packages/activerecord/src/encryption/configurable.test.ts
+++ b/packages/activerecord/src/encryption/configurable.test.ts
@@ -23,6 +23,8 @@ describe("ActiveRecord::Encryption::ConfigurableTest", () => {
 
   beforeEach(() => {
     savedConfig = snapshotConfig();
+    // EncryptionTestCase#setup — helper.rb:141.
+    Configurable.config.previousSchemes.length = 0;
   });
 
   afterEach(() => {
@@ -66,9 +68,7 @@ describe("ActiveRecord::Encryption::ConfigurableTest", () => {
     expect(config.primaryKey).toBe("the primary key");
     expect(config.deterministicKey).toBe("the deterministic key");
     expect(config.keyDerivationSalt).toBe("the salt");
-    expect(config.previousSchemes[config.previousSchemes.length - 1]).toMatchObject({
-      keyProvider: previousKeyProvider,
-    });
+    expect(config.previousSchemes[0]).toMatchObject({ keyProvider: previousKeyProvider });
   });
 
   it("can add listeners that will get invoked when declaring encrypted attributes", () => {

--- a/packages/activerecord/src/encryption/configurable.ts
+++ b/packages/activerecord/src/encryption/configurable.ts
@@ -68,10 +68,6 @@ export class Configurable {
         continue;
       }
       if (value === undefined) continue;
-      // Rails' `configure` does `config.public_send("#{name}=", value)`
-      // (configurable.rb:24-26), which reaches writers that are behavior
-      // rather than stored state — `support_sha1_for_non_deterministic_encryption=`
-      // (config.rb:28). Those are spelled `setX` here.
       const writer = `set${key[0].toUpperCase()}${key.slice(1)}`;
       if (typeof (config as unknown as Record<string, unknown>)[writer] === "function") {
         (config as unknown as Record<string, (v: unknown) => void>)[writer](value);

--- a/packages/activerecord/src/encryption/configurable.ts
+++ b/packages/activerecord/src/encryption/configurable.ts
@@ -63,7 +63,12 @@ export class Configurable {
     if (options.keyDerivationSalt !== undefined)
       config.keyDerivationSalt = options.keyDerivationSalt;
 
-    for (const [key, value] of Object.entries(options)) {
+    const properties: Record<string, unknown> = { ...options };
+    // Set the default for this property here instead of in +Config#set_defaults+ as this needs
+    // to happen *after* the keys have been set.
+    properties.supportSha1ForNonDeterministicEncryption ??= true;
+
+    for (const [key, value] of Object.entries(properties)) {
       if (key === "primaryKey" || key === "deterministicKey" || key === "keyDerivationSalt") {
         continue;
       }

--- a/packages/activerecord/src/encryption/configurable.ts
+++ b/packages/activerecord/src/encryption/configurable.ts
@@ -68,6 +68,15 @@ export class Configurable {
         continue;
       }
       if (value === undefined) continue;
+      // Rails' `configure` does `config.public_send("#{name}=", value)`
+      // (configurable.rb:24-26), which reaches writers that are behavior
+      // rather than stored state — `support_sha1_for_non_deterministic_encryption=`
+      // (config.rb:28). Those are spelled `setX` here.
+      const writer = `set${key[0].toUpperCase()}${key.slice(1)}`;
+      if (typeof (config as unknown as Record<string, unknown>)[writer] === "function") {
+        (config as unknown as Record<string, (v: unknown) => void>)[writer](value);
+        continue;
+      }
       if (key in config) {
         (config as any)[key] = value;
       }

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -336,9 +336,8 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
   });
 
   it("encryption schemes are resolved when used, not when declared", async () => {
-    // Declare the model BEFORE configuring supportSha1ForNonDeterministicEncryption.
-    // Global previous schemes must be resolved lazily (at previousTypes access time),
-    // not eagerly at encrypts() call time — mirrors Rails' lazy previous_schemes behavior.
+    // Declares the model BEFORE configure, as the Rails test does: the scheme
+    // must resolve at previousTypes access time, not at encrypts() call time.
     const adp = await freshAdapter();
     const Post = class extends Base {
       static {
@@ -358,7 +357,6 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     });
 
     const type = Post.typeForAttribute("title");
-    // One lazy-resolved global previous scheme (the SHA1 key provider).
     expect(type.previousTypes).toHaveLength(1);
   });
 

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -350,8 +350,12 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     } as any;
     Post.encrypts("title");
 
-    configureEncryption({ primaryKey: "the primary key", keyDerivationSalt: "the salt" });
-    Configurable.config.supportSha1ForNonDeterministicEncryption = true;
+    Configurable.configure({
+      primaryKey: "the primary key",
+      deterministicKey: "the deterministic key",
+      keyDerivationSalt: "the salt",
+      supportSha1ForNonDeterministicEncryption: true,
+    });
 
     const type = Post.typeForAttribute("title");
     // One lazy-resolved global previous scheme (the SHA1 key provider).
@@ -625,8 +629,8 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
       primaryKey: "the primary key",
       deterministicKey: "the deterministic key",
       keyDerivationSalt: "the salt",
+      supportSha1ForNonDeterministicEncryption: true,
     });
-    Configurable.config.supportSha1ForNonDeterministicEncryption = true;
 
     const { KeyGenerator } = await import("./key-generator.js");
     const { DerivedSecretKeyProvider } = await import("./derived-secret-key-provider.js");

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -9,45 +9,7 @@ import { Configuration as ConfigurationError } from "./errors.js";
 import { LengthValidator, type Type } from "@blazetrails/activemodel";
 import { EncryptedAttributeType, setGlobalPreviousSchemesFn } from "./encrypted-attribute-type.js";
 import { Configurable } from "./configurable.js";
-import { KeyGenerator } from "./key-generator.js";
-import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
 import { encryptionHooks } from "../encryption-hooks.js";
-
-// Memoized SHA1 key provider: PBKDF2 is expensive (65536 iterations), so
-// reuse the same provider as long as primaryKey and keyDerivationSalt haven't
-// changed. Cleared by the onConfigure hook below so config rotation invalidates it.
-let _sha1ProviderCache:
-  | {
-      primaryKey: string | string[];
-      keyDerivationSalt: string | undefined;
-      provider: DerivedSecretKeyProvider;
-    }
-  | undefined;
-
-// Clear the SHA1 provider cache whenever configure() is called so the new
-// primary key / key derivation salt is picked up on the next encrypt call.
-Configurable.onConfigure(() => {
-  _sha1ProviderCache = undefined;
-});
-
-function getSha1KeyProvider(
-  primaryKey: string | string[],
-  keyDerivationSalt: string | undefined,
-): DerivedSecretKeyProvider {
-  const cacheKey = JSON.stringify(primaryKey);
-  if (
-    _sha1ProviderCache &&
-    JSON.stringify(_sha1ProviderCache.primaryKey) === cacheKey &&
-    _sha1ProviderCache.keyDerivationSalt === keyDerivationSalt
-  ) {
-    return _sha1ProviderCache.provider;
-  }
-  const provider = new DerivedSecretKeyProvider(primaryKey, {
-    keyGenerator: new KeyGenerator("SHA1"),
-  });
-  _sha1ProviderCache = { primaryKey, keyDerivationSalt, provider };
-  return provider;
-}
 
 /**
  * Mirrors Rails' EncryptableRecord#global_previous_schemes_for.
@@ -61,15 +23,6 @@ function getSha1KeyProvider(
 export function globalPreviousSchemesFor(scheme: Scheme): Scheme[] {
   const config = Configurable.config;
   const allSchemeOptions: SchemeOptions[] = [...config.previousSchemes];
-
-  // Mirrors Rails' support_sha1_for_non_deterministic_encryption= setter:
-  // builds the SHA1 DerivedSecretKeyProvider lazily here (not in Config) to
-  // avoid a config → key-generator → configurable → config circular import.
-  if (config.supportSha1ForNonDeterministicEncryption && config.hasPrimaryKey()) {
-    allSchemeOptions.push({
-      keyProvider: getSha1KeyProvider(config.primaryKey, config.hasKeyDerivationSalt()),
-    });
-  }
 
   return allSchemeOptions
     .map((opts) => new Scheme(opts))

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -94,6 +94,9 @@ export function configureEncryption(
   // Mirrors Rails' encryption test helper which unconditionally prepends EncryptedFixtures:
   // `class ActiveRecord::Fixture; prepend ActiveRecord::Encryption::EncryptedFixtures; end`
   Configurable.config.encryptFixtures = overrides.encryptFixtures ?? true;
+  // helper.rb:141 — `ActiveRecord::Encryption.config.previous_schemes.clear` in
+  // EncryptionTestCase#setup, which runs after the boot-time `configure`.
+  Configurable.config.previousSchemes.length = 0;
 }
 
 export const AUTHOR_NAME_LIMIT = 100;

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -43,7 +43,6 @@ interface ConfigSnapshot {
   encryptFixtures: boolean;
   previousSchemes: typeof Configurable.config.previousSchemes;
   forcedEncodingForDeterministicEncryption: string;
-  supportSha1ForNonDeterministicEncryption: boolean;
 }
 
 export function snapshotEncryptionConfig(): ConfigSnapshot {
@@ -56,7 +55,6 @@ export function snapshotEncryptionConfig(): ConfigSnapshot {
     encryptFixtures: c.encryptFixtures,
     previousSchemes: [...c.previousSchemes],
     forcedEncodingForDeterministicEncryption: c.forcedEncodingForDeterministicEncryption,
-    supportSha1ForNonDeterministicEncryption: c.supportSha1ForNonDeterministicEncryption,
   };
 }
 
@@ -69,7 +67,6 @@ export function restoreEncryptionConfig(snapshot: ConfigSnapshot): void {
   c.encryptFixtures = snapshot.encryptFixtures;
   c.previousSchemes = snapshot.previousSchemes;
   c.forcedEncodingForDeterministicEncryption = snapshot.forcedEncodingForDeterministicEncryption;
-  c.supportSha1ForNonDeterministicEncryption = snapshot.supportSha1ForNonDeterministicEncryption;
   Contexts.resetDefaultContext();
   // Eagerly clear so the previous test's key material doesn't linger in
   // memory after config reset — the lazy clear on next keyProvider access

--- a/packages/activerecord/src/i18n.test.ts
+++ b/packages/activerecord/src/i18n.test.ts
@@ -78,7 +78,7 @@ describe("ActiveRecordI18nTests", () => {
       activerecord: { models: { topic: "topic model" } },
     });
 
-    expect(Topic.modelName.human).toBe("topic model");
+    expect(Topic.modelName.human()).toBe("topic model");
   });
 
   it("translated model names with sti", () => {
@@ -93,7 +93,7 @@ describe("ActiveRecordI18nTests", () => {
       activerecord: { models: { reply: "reply model" } },
     });
 
-    expect(Reply.modelName.human).toBe("reply model");
+    expect(Reply.modelName.human()).toBe("reply model");
   });
 
   it("translated model names with sti fallback", () => {
@@ -108,6 +108,6 @@ describe("ActiveRecordI18nTests", () => {
       activerecord: { models: { topic: "topic model" } },
     });
 
-    expect(Reply.modelName.human).toBe("topic model");
+    expect(Reply.modelName.human()).toBe("topic model");
   });
 });

--- a/packages/activerecord/src/migration/columns.test.ts
+++ b/packages/activerecord/src/migration/columns.test.ts
@@ -15,7 +15,7 @@ import { assertQueriesCount } from "../testing/query-assertions.js";
 import { adapterSupports } from "../support/supports.js";
 
 const mariaDbRejectsUniqueColumnDrop =
-  adapterType === "mysql" && isMariaDb && serverVersion?.gte("10.2.8") === true;
+  adapterType === "mysql" && isMariaDb && (serverVersion?.compare("10.2.8") ?? -1) >= 0;
 
 const indexesSurvivingColumnDrop =
   adapterType === "postgres" ? [] : ["index_test_models_on_hat_style_and_hat_size"];

--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -347,8 +347,8 @@ async function loadPostgresqlSpecificSchema(adapter: PostgreSQLAdapter): Promise
 async function loadMysql2SpecificSchema(adapter: AbstractMysqlAdapter): Promise<void> {
   await adapter.getDatabaseVersion();
   const supportsDefaultExpression = adapter.isMariadb()
-    ? adapter.databaseVersion.gte("10.2.1")
-    : adapter.databaseVersion.gte("8.0.13");
+    ? adapter.databaseVersion.compare("10.2.1") >= 0
+    : adapter.databaseVersion.compare("8.0.13") >= 0;
 
   await adapter.createTable("datetime_defaults", { force: true }, (t) => {
     t.datetime("modified_datetime", { precision: null, default: () => "CURRENT_TIMESTAMP" });

--- a/packages/activerecord/src/support/mysql-server-version.ts
+++ b/packages/activerecord/src/support/mysql-server-version.ts
@@ -53,7 +53,7 @@ export const serverVersion = _serverVersion;
  * never MariaDB. Lets adapter tests gate on hint support the way the Rails
  * suite wraps `OptimizerHintsTest` in `if supports_optimizer_hints?`.
  */
-export const supportsOptimizerHints = !mariaDb && _serverVersion?.gte("5.7.7") === true;
+export const supportsOptimizerHints = !mariaDb && (_serverVersion?.compare("5.7.7") ?? -1) >= 0;
 
 /**
  * Mirrors `supports_default_expression?` (adapter_helper.rb:23) for MySQL: an
@@ -62,8 +62,8 @@ export const supportsOptimizerHints = !mariaDb && _serverVersion?.gte("5.7.7") =
  * exactly as Rails' mysql2_specific_schema.rb does.
  */
 export const supportsDefaultExpression = mariaDb
-  ? _serverVersion?.gte("10.2.1") === true
-  : _serverVersion?.gte("8.0.13") === true;
+  ? (_serverVersion?.compare("10.2.1") ?? -1) >= 0
+  : (_serverVersion?.compare("8.0.13") ?? -1) >= 0;
 
 /**
  * Mirrors AbstractMysqlAdapter#supports_expression_index?
@@ -72,7 +72,7 @@ export const supportsDefaultExpression = mariaDb
  * the answer into a static adapterType table — the mysql lane may be MySQL 8
  * (true) or the MariaDB CI stand-in (false).
  */
-export const supportsExpressionIndex = !mariaDb && _serverVersion?.gte("8.0.13") === true;
+export const supportsExpressionIndex = !mariaDb && (_serverVersion?.compare("8.0.13") ?? -1) >= 0;
 
 /**
  * Mirrors AbstractMysqlAdapter#supports_rename_index?
@@ -82,23 +82,24 @@ export const supportsExpressionIndex = !mariaDb && _serverVersion?.gte("8.0.13")
  * without hiding the supported MySQL path behind a blanket adapter skip.
  */
 export const supportsRenameIndex = mariaDb
-  ? _serverVersion?.gte("10.5.2") === true
-  : _serverVersion?.gte("5.7.6") === true;
+  ? (_serverVersion?.compare("10.5.2") ?? -1) >= 0
+  : (_serverVersion?.compare("5.7.6") ?? -1) >= 0;
 
 /** Mirrors Mysql2Adapter#supports_json? (mysql2_adapter.rb:70): MySQL ≥ 5.7.8; never MariaDB. */
-export const supportsJson = !mariaDb && _serverVersion?.gte("5.7.8") === true;
+export const supportsJson = !mariaDb && (_serverVersion?.compare("5.7.8") ?? -1) >= 0;
 
 /**
  * Mirrors AbstractMysqlAdapter#supports_insert_returning?
  * (abstract_mysql_adapter.rb:173): MariaDB ≥ 10.5.0 only; never MySQL.
  */
-export const supportsInsertReturning = mariaDb && _serverVersion?.gte("10.5.0") === true;
+export const supportsInsertReturning = mariaDb && (_serverVersion?.compare("10.5.0") ?? -1) >= 0;
 
 /**
  * Mirrors `supports_text_column_with_default?` (adapter_helper.rb:42) for the
  * MySQL family: MariaDB ≥ 10.2.1 only.
  */
-export const supportsTextColumnWithDefault = mariaDb && _serverVersion?.gte("10.2.1") === true;
+export const supportsTextColumnWithDefault =
+  mariaDb && (_serverVersion?.compare("10.2.1") ?? -1) >= 0;
 
 /**
  * Mirrors `supports_non_unique_constraint_name?` (adapter_helper.rb:33) for the
@@ -111,8 +112,8 @@ export const supportsNonUniqueConstraintName = mariaDb;
  * MySQL family: MariaDB ≥ 10.3.13, MySQL ≥ 8.0.19.
  */
 export const supportsSqlStandardDropConstraint = mariaDb
-  ? _serverVersion?.gte("10.3.13") === true
-  : _serverVersion?.gte("8.0.19") === true;
+  ? (_serverVersion?.compare("10.3.13") ?? -1) >= 0
+  : (_serverVersion?.compare("8.0.19") ?? -1) >= 0;
 
 /**
  * Mirrors AbstractMysqlAdapter#supports_check_constraints?
@@ -120,6 +121,6 @@ export const supportsSqlStandardDropConstraint = mariaDb
  * pre-10.3 series from 10.2.22 (10.3.0–10.3.9 is excluded).
  */
 export const supportsCheckConstraints = mariaDb
-  ? _serverVersion?.gte("10.3.10") === true ||
-    (_serverVersion?.lt("10.3") === true && _serverVersion?.gte("10.2.22") === true)
-  : _serverVersion?.gte("8.0.16") === true;
+  ? (_serverVersion?.compare("10.3.10") ?? -1) >= 0 ||
+    ((_serverVersion?.compare("10.3") ?? 0) < 0 && (_serverVersion?.compare("10.2.22") ?? -1) >= 0)
+  : (_serverVersion?.compare("8.0.16") ?? -1) >= 0;

--- a/packages/activerecord/src/support/schema-conn.ts
+++ b/packages/activerecord/src/support/schema-conn.ts
@@ -2,11 +2,11 @@ import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adap
 import { PostgreSQLAdapter } from "../connection-adapters/postgresql-adapter.js";
 import { Mysql2Adapter } from "../connection-adapters/mysql2-adapter.js";
 import { Version } from "../connection-adapters/abstract-adapter.js";
-import type { SchemaQuoter } from "../connection-adapters/abstract/assert-schema-adapter.js";
+import type { TableDefinitionConn } from "../connection-adapters/abstract/schema-definitions.js";
 
 export type SchemaConnName = "sqlite" | "postgres" | "mysql";
 
-const conns = new Map<SchemaConnName, SchemaQuoter>();
+const conns = new Map<SchemaConnName, TableDefinitionConn>();
 
 /**
  * The `conn` argument for DDL-rendering unit tests. Rails' `SchemaCreation.new`
@@ -19,7 +19,7 @@ const conns = new Map<SchemaConnName, SchemaQuoter>();
  * read the cached version, which is cold on a connection that was never opened, so
  * that adapter is seeded with a modern server version.
  */
-export function schemaConn(name: SchemaConnName): SchemaQuoter {
+export function schemaConn(name: SchemaConnName): TableDefinitionConn {
   let conn = conns.get(name);
   if (!conn) {
     conn =

--- a/packages/activerecord/src/support/supports-live-adapter.trails.test.ts
+++ b/packages/activerecord/src/support/supports-live-adapter.trails.test.ts
@@ -14,7 +14,7 @@ type LiveConnection = {
 } & Record<string, unknown>;
 
 function mysqlAtLeast(connection: LiveConnection, version: string): boolean {
-  return (connection.databaseVersion as Version).gte(version);
+  return (connection.databaseVersion as Version).compare(version) >= 0;
 }
 
 function adapterHelperSupport(feature: string, connection: LiveConnection): boolean | undefined {

--- a/scripts/api-compare/operator-order-spelling.ts
+++ b/scripts/api-compare/operator-order-spelling.ts
@@ -69,6 +69,10 @@ export const OPERATOR_SPELLING_BY_FQN: Record<string, Record<string, string[]>> 
   // and `compare`. `===` / `=~` share that line but have no TS member, so they
   // stay unmapped.
   "ActiveModel::Name": { "==": ["equals"], "<=>": ["compare"] },
+  // abstract_adapter.rb:252 `def <=>(version_string)` → abstract-adapter.ts
+  // `compare`. `Version` does `include Comparable`, so `>=` / `<` are derived
+  // and have no TS member of their own.
+  "ActiveRecord::ConnectionAdapters::AbstractAdapter::Version": { "<=>": ["compare"] },
   // core.rb:631 `def ==(comparison_object)` / :665 `def <=>(other_object)` →
   // core.ts `equals` / `compare`. The aliased `eql?` (:637) has no TS member.
   "ActiveRecord::Core": { "==": ["equals"], "<=>": ["compare"] },


### PR DESCRIPTION
Four bundled stories.

**`ModelName#human` takes options** (naming.rb:197-207). It was a getter, so
`count:`, `locale:`, interpolation values and a `default:` that joins the
lookup chain were unreachable. It is now `human(options = {})`, threading
`options` into `I18n.translate` after `defaults << options[:default]` and
before the `MISSING_TRANSLATION` sentinel. Call sites (`Error#full_message`
path, lint, tests) updated. translation_test.rb's
`test_translated_model_with_default_value_when_missing_translation`,
`..._with_default_key_when_missing_both_translations` and
`test_human_does_not_modify_options` ported.

**`TableDefinition#_adapter` carries the `@conn` surface.** It was typed
`SchemaQuoter`, which forced `as unknown as` casts in
`validColumnDefinitionOptions`, `_foreignKeyOptions` and
`newCheckConstraintDefinition`. `_adapter` is now `TableDefinitionConn`
(quoting subset + `foreignKeyOptions` / `checkConstraintOptions` /
`validColumnDefinitionOptions`, all declared on the `AbstractAdapter`
interface merge where `SchemaStatements` mixes them in), the casts are gone,
and `new_foreign_key_definition` / `new_check_constraint_definition` delegate
unconditionally the way schema_definitions.rb:575-586 does — the local
column/name derivations they fell back to are deleted.

**`Config#support_sha1_for_non_deterministic_encryption=` is behavior, not
state** (config.rb:28-33). The stored boolean field is replaced by
`setSupportSha1ForNonDeterministicEncryption`, which under `has_primary_key?`
builds a SHA1 `KeyGenerator` + `DerivedSecretKeyProvider` and
`add_previous_scheme`s it. No reader (Rails has none), and `setDefaults`
does not assign it. The lazy rebuild that lived in `EncryptableRecord` (with
its provider cache) is gone. `Configurable.configure` now reaches `setX`
writers, mirroring Ruby's `public_send("#{key}=", value)`, so the Rails tests'
`support_sha1_for_non_deterministic_encryption: true` configure option lands.
`configure` also applies that property's default (configurable.rb:26-27), set
after the keys. Enabling it first reds five suites, because our per-test setup
never ported EncryptionTestCase#setup's `config.previous_schemes.clear`
(helper.rb:141) — that clear is now in `configureEncryption` and in
`configurable.test.ts`'s `beforeEach`, and
`.configure configures initial config properties` asserts
`previous_schemes.first` the way configurable_test.rb:26 does instead of the
last element.

**`Version#compare` replaces `gte`/`lt`** (abstract_adapter.rb:243-259). Rails
`include Comparable` and defines only `<=>`; the `@noRailsEquivalent` tag on
`gte` is retired along with both members, all ~50 call sites moved to
`compare(...) >= 0` / `< 0`, and `<=>` → `compare` is registered for
`ActiveRecord::ConnectionAdapters::AbstractAdapter::Version` in
`operator-order-spelling.ts`.

Gates: typecheck, lint, `api:calls` / `api:calls:wide` OK, `api:extra` shows
`abstract-adapter.ts` down to 2 novel with no stale tags, `test:compare`
activemodel `translation_test.rb` up to 26 matched.

Closes-story: model-name-human-takes-options
Closes-story: table-definition-adapter-type-forces-casts
Closes-story: converge-encryption-config-sha1-writer-to-a-behavioral-setter
Closes-story: port-version-compare-and-retire-gte-lt
