### PR TITLE
refactor(activerecord): PG columns() via newColumnFromField, find_target as instance method, records set operators

### DIFF
--- a/packages/activerecord/src/associations/belongs-to-association.ts
+++ b/packages/activerecord/src/associations/belongs-to-association.ts
@@ -4,7 +4,7 @@ import { reflectLockVersionBump } from "../associations.js";
 import { underscore } from "@blazetrails/activesupport";
 import { belongsToCounterCacheColumn } from "../reflection.js";
 import { hasQueryConstraints, queryConstraintsList } from "../persistence.js";
-import { SingularAssociation, findTarget } from "./singular-association.js";
+import { SingularAssociation } from "./singular-association.js";
 import { Rollback } from "../errors.js";
 import { MissingAttributeError } from "@blazetrails/activemodel";
 
@@ -310,20 +310,6 @@ export class BelongsToAssociation extends SingularAssociation {
           : (this.owner as any)[fk];
       return value != null;
     });
-  }
-
-  protected override async doAsyncFindTarget(): Promise<Base | null> {
-    // Suppress the loader's own tail writeback and let `setTarget` refuse a
-    // mid-load replacement, exactly as has_many and has_one do. #4919 already
-    // guards a mid-load *FK* change here; this covers a same-FK reassignment
-    // (`client.association("firm").setTarget(other)`) that leaves the FK put,
-    // which the stale-key check cannot see. See `_loaderWritebackSuppressed`.
-    this._loaderWritebackSuppressed++;
-    try {
-      return await findTarget(this.owner, this.reflection.name, this.reflection.options);
-    } finally {
-      this._loaderWritebackSuppressed--;
-    }
   }
 
   // --- Private helpers ---

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -39,6 +39,34 @@ export class HasManyThroughAssociation extends HasManyAssociation {
   }
 
   /**
+   * Mirrors: ActiveRecord::Associations::HasManyThroughAssociation#find_target
+   * (has_many_through_association.rb:225) — reads owner and reflection off
+   * `this`, exactly as Rails does, and delegates the query itself to
+   * `HasManyAssociation#findTarget` (Rails' `super`). Rails' `disable_joins`
+   * arm is handled inside that loader, which routes the disable-joins shape
+   * through `_loadThroughViaDisableJoinsScope`.
+   */
+  protected override async findTarget(): Promise<Base[]> {
+    if (!this.targetReflectionHasAssociatedRecord()) return [];
+    return super.findTarget();
+  }
+
+  /**
+   * Mirrors: HasManyThroughAssociation#target_reflection_has_associated_record?
+   * (has_many_through_association.rb:121).
+   */
+  protected targetReflectionHasAssociatedRecord(): boolean {
+    const associations: AssociationDefinition[] =
+      (this.owner.constructor as typeof Base)._associations ?? [];
+    const throughAssoc = associations.find((a) => a.name === this.reflection.options.through);
+    // A missing through reflection is Rails' `check_validity!` failure, not
+    // this predicate's: leave it to the loader below, which raises
+    // HasManyThroughAssociationNotFoundError with the Rails message.
+    if (!throughAssoc) return true;
+    return targetReflectionHasAssociatedRecord(this.owner, throughAssoc);
+  }
+
+  /**
    * The through model owns the transaction — the join-row writes are what has
    * to be atomic, not the target model's.
    *

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -10,7 +10,7 @@ import {
   ownerForeignKeyColumns,
 } from "./foreign-association.js";
 import type { AssociationReflection } from "../reflection.js";
-import { findTarget, SingularAssociation } from "./singular-association.js";
+import { SingularAssociation } from "./singular-association.js";
 import { polymorphicName } from "../inheritance.js";
 
 /**
@@ -511,20 +511,6 @@ export class HasOneAssociation extends SingularAssociation {
     const displaced = this.target;
     if (!displaced) return false;
     return (displaced as { isDestroyed?: () => boolean }).isDestroyed?.() !== true;
-  }
-
-  protected override async doAsyncFindTarget(): Promise<Base | null> {
-    // `loadHasOne`'s tail writeback lands in this holder mid-await, so a target
-    // replaced while the query is in flight would be silently clobbered. Arm
-    // the same guard has_many uses (`HasManyAssociation#doAsyncFindTarget`):
-    // suppress the loader's own writeback and let `setTarget` refuse the race.
-    // See `Association#_loaderWritebackSuppressed`.
-    this._loaderWritebackSuppressed++;
-    try {
-      return await findTarget(this.owner, this.reflection.name, this.reflection.options);
-    } finally {
-      this._loaderWritebackSuppressed--;
-    }
   }
 
   private foreignKeyColumns(): string[] {

--- a/packages/activerecord/src/associations/has-one-mid-flight-reassignment.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-mid-flight-reassignment.trails.test.ts
@@ -5,8 +5,8 @@
  * This is the singular-holder counterpart to the has_many guard (#5038). The
  * mechanism is shared and holder-agnostic: `setTarget` refuses the race, and a
  * loader's own writeback is exempt because it runs while
- * `Association#_loaderWritebackSuppressed` is set (armed in each singular
- * association's `doAsyncFindTarget`, mirroring `CollectionAssociation`).
+ * `Association#_loaderWritebackSuppressed` is set (armed in
+ * `SingularAssociation#findTarget`, mirroring `CollectionAssociation`).
  *
  * Rails has no analogue because `Association#find_target`
  * (activerecord/lib/active_record/associations/association.rb:248) is
@@ -76,8 +76,8 @@ describe("has_one mid-flight reassignment", () => {
   });
 
   it("replacing a has_one :through target mid-load raises", async () => {
-    // HasOneThroughAssociation inherits doAsyncFindTarget from
-    // HasOneAssociation, so it must inherit the guard with it.
+    // HasOneThroughAssociation inherits findTarget through HasOneAssociation
+    // from SingularAssociation, so it must inherit the guard with it.
     const member = (await Member.first()) as Member;
     const other = (await Club.first()) as Club;
 
@@ -122,9 +122,10 @@ describe("polymorphic belongs_to mid-flight reassignment", () => {
   fixtures(["taggings", "posts"]);
 
   it("replacing a polymorphic target mid-load raises", async () => {
-    // `BelongsToPolymorphicAssociation` overrides `doAsyncFindTarget`, so it
-    // must arm the same guard its parent does — otherwise the polymorphic
-    // subclass stays silently clobberable while plain belongs_to raises.
+    // `BelongsToPolymorphicAssociation` inherits `findTarget` through
+    // `BelongsToAssociation` from `SingularAssociation`, so it must inherit the
+    // same guard — otherwise the polymorphic subclass stays silently
+    // clobberable while plain belongs_to raises.
     const tagging = (await Tagging.first()) as Tagging;
     const other = (await Post.first()) as Post;
 

--- a/packages/activerecord/src/associations/singular-association.ts
+++ b/packages/activerecord/src/associations/singular-association.ts
@@ -260,6 +260,34 @@ export class SingularAssociation extends Association {
     return attrs;
   }
 
+  /**
+   * Mirrors: ActiveRecord::Associations::SingularAssociation#find_target
+   * (singular_association.rb:47) — the singular target load, reading owner and
+   * reflection off `this` exactly as Rails does. belongs_to and has_one both
+   * inherit it: Rails defines `find_target` only here, on `Association`
+   * (association.rb:248) and on `HasManyThroughAssociation`
+   * (has_many_through_association.rb:225).
+   *
+   * The query itself lives in the functional loader below, which the reader
+   * sugar and the through loaders reach without an association instance; that
+   * owner/name/options triple is a trails-only calling convention, not Rails
+   * surface.
+   */
+  protected override async findTarget(): Promise<Base | null> {
+    // The loader's tail writeback lands in this holder mid-await, so a target
+    // replaced while the query is in flight would be silently clobbered:
+    // suppress the loader's own writeback and let `setTarget` refuse the race.
+    // #4919 already guards a mid-load *FK* change for belongs_to; this also
+    // covers a same-FK reassignment that leaves the FK put, which the
+    // stale-key check cannot see. See `Association#_loaderWritebackSuppressed`.
+    this._loaderWritebackSuppressed++;
+    try {
+      return await findTarget(this.owner, this.reflection.name, this.reflection.options);
+    } finally {
+      this._loaderWritebackSuppressed--;
+    }
+  }
+
   protected override async _createRecord(
     attributes?: Record<string, unknown>,
     shouldRaise = false,

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3719,25 +3719,6 @@ export class PostgreSQLAdapter
     );
   }
 
-  /**
-   * The serial detection Rails inlines in `new_column_from_field`, extracted so
-   * PostgreSQL::SchemaStatements#columns can share it: that path cannot delegate
-   * to newColumnFromField because it batch-preloads the row OIDs and resolves
-   * types through lookupCastTypeFromColumn, where fetchTypeMetadata would issue
-   * a per-column pg_type query.
-   * @internal
-   */
-  _serialFromDefaultFunction(
-    tableName: string,
-    columnName: string,
-    defaultFunction: string | null,
-  ): boolean {
-    const match = defaultFunction?.match(SERIAL_SEQUENCE_RE);
-    if (!match) return false;
-    const { sequenceName, suffix } = match.groups!;
-    return this.sequenceNameFromParts(tableName, columnName, suffix) === sequenceName;
-  }
-
   async foreignTables(): Promise<string[]> {
     const names = await this.queryValues(
       this.dataSourceSql(null, { type: "FOREIGN TABLE" }),
@@ -4222,19 +4203,34 @@ export class PostgreSQLAdapter
     field: unknown[],
     _definitions: unknown,
   ): Promise<Column> {
-    const [columnName, type, default_, notnull, oid, fmod, collation, comment, identity, gen] =
-      field as [
-        string,
-        string,
-        string | null,
-        boolean,
-        number,
-        number,
-        string | null,
-        string | null,
-        string | null,
-        string | null,
-      ];
+    // `isPrimary` is an 11th field element past Rails' ten — trails'
+    // `column_definitions` also selects `indisprimary` for the schema dumper.
+    // See the tuple built in PostgreSQL::SchemaStatements#columns.
+    const [
+      columnName,
+      type,
+      default_,
+      notnull,
+      oid,
+      fmod,
+      collation,
+      comment,
+      identity,
+      gen,
+      isPrimary,
+    ] = field as [
+      string,
+      string,
+      string | null,
+      boolean,
+      number,
+      number,
+      string | null,
+      string | null,
+      string | null,
+      string | null,
+      boolean | undefined,
+    ];
     const typeMetadata = await this.fetchTypeMetadata(columnName, type, Number(oid), Number(fmod));
     // The literal stays a raw String: deserialization is deferred to
     // Attribute.from_database so *_before_type_cast reads back the raw default.
@@ -4271,6 +4267,7 @@ export class PostgreSQLAdapter
         defaultFunction: defaultFunction ?? undefined,
         collation: collation ?? undefined,
         comment: comment || null,
+        primaryKey: isPrimary ?? false,
         serial,
         array: type.endsWith("[]"),
         identity: identity || null,

--- a/packages/activerecord/src/connection-adapters/postgresql/column.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/column.ts
@@ -84,7 +84,7 @@ export class Column extends BaseColumn {
   // Mirrors Rails Column#serial? — returns the stored flag, which the adapter
   // computes by matching the `nextval()` default's sequence against the
   // conventional `<table>_<column>_seq` name (see
-  // PostgreSQLAdapter#_serialFromDefaultFunction). An explicit
+  // PostgreSQLAdapter#newColumnFromField). An explicit
   // `default: -> { "nextval('some_seq')" }` is NOT serial.
   get isSerial(): boolean {
     return this.serial;

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
-import { ArgumentError } from "@blazetrails/activemodel";
+import { ArgumentError, ValueType } from "@blazetrails/activemodel";
+import { HashLookupTypeMap } from "../../type/hash-lookup-type-map.js";
 import { PostgreSQLAdapter } from "../postgresql-adapter.js";
 import type { AbstractAdapter as DatabaseAdapter } from "../abstract-adapter.js";
 import { Table as PgTable } from "./schema-definitions.js";
@@ -288,5 +289,81 @@ describe("SchemaStatements#indexes", () => {
     const ss = withSchemaStatements(adapter);
     const [index] = await ss.indexes("my_schema.things");
     expect(index.table).toBe("my_schema.things");
+  });
+});
+
+// Rails' SchemaStatements#columns (abstract/schema_statements.rb:107) maps
+// every field through new_column_from_field. trails' PG columns() batch-loads
+// the row OIDs first, so the fetch_type_metadata → get_oid_type hop inside
+// new_column_from_field must stay a pure type-map read: one pg_type query for
+// the whole table, never one per column.
+describe("SchemaStatements#columns delegates to newColumnFromField", () => {
+  function columnsAdapter() {
+    const { adapter, sql } = makeAdapter({
+      schemaQuery: async () => [
+        {
+          name: "id",
+          type: "integer",
+          default: "nextval('things_id_seq'::regclass)",
+          notnull: true,
+          is_primary: true,
+          oid: 23,
+          fmod: -1,
+          identity: "",
+          attgenerated: "",
+          collation: null,
+          col_comment: null,
+        },
+        {
+          name: "name",
+          type: "character varying",
+          default: null,
+          notnull: false,
+          is_primary: false,
+          oid: 1043,
+          fmod: -1,
+          identity: "",
+          attgenerated: "",
+          collation: null,
+          col_comment: "the name",
+        },
+      ],
+    });
+    const ss = withSchemaStatements(adapter);
+    const typeMap = new HashLookupTypeMap();
+    Object.defineProperty(ss, "typeMap", { value: typeMap, configurable: true });
+    return { ss, sql };
+  }
+
+  it("issues one pg_type load for the whole table, not one per column", async () => {
+    const { ss, sql } = columnsAdapter();
+    const loadAdditionalTypes = vi
+      .spyOn(ss, "loadAdditionalTypes")
+      .mockImplementation(async (oids?: number[]) => {
+        for (const oid of oids ?? []) ss.typeMap.registerType(oid, new ValueType());
+      });
+
+    const columns = await ss.columns("things");
+
+    expect(columns.map((c) => c.name)).toEqual(["id", "name"]);
+    expect(loadAdditionalTypes).toHaveBeenCalledTimes(1);
+    expect(loadAdditionalTypes).toHaveBeenCalledWith([23, 1043]);
+    expect(sql.filter((text) => text.includes("pg_attribute"))).toHaveLength(1);
+  });
+
+  it("carries the serial, comment and primaryKey flags through the ported body", async () => {
+    const { ss } = columnsAdapter();
+    vi.spyOn(ss, "loadAdditionalTypes").mockImplementation(async (oids?: number[]) => {
+      for (const oid of oids ?? []) ss.typeMap.registerType(oid, new ValueType());
+    });
+
+    const [id, name] = await ss.columns("things");
+
+    expect(id.isSerial).toBe(true);
+    expect(id.primaryKey).toBe(true);
+    expect(id.null).toBe(false);
+    expect(name.primaryKey).toBe(false);
+    expect(name.comment).toBe("the name");
+    expect(name.null).toBe(true);
   });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -81,11 +81,7 @@ interface PgSchemaAdapter {
     name?: string;
   }): Type;
   reloadTypeMap(): Promise<void>;
-  _serialFromDefaultFunction(
-    tableName: string,
-    columnName: string,
-    defaultFunction: string | null,
-  ): boolean;
+  newColumnFromField(tableName: string, field: unknown[], definitions: unknown): Promise<Column>;
   extractValueFromDefault(defaultExpr: string | null): unknown;
   extractDefaultFunction(defaultValue: unknown, defaultExpr: string | null): string | null;
   nativeDatabaseTypes(): Record<string, string | { name?: string; limit?: number }>;
@@ -663,58 +659,35 @@ export class SchemaStatements extends AbstractSchemaStatements {
       }
     }
 
-    return rows.map((r) => {
-      const sqlType = r.type as string;
-      const oid = Number(r.oid);
-      const fmod = Number(r.fmod);
-      // All OIDs are now registered (or warned as unknown) by the batch
-      // load above. lookupCastTypeFromColumn mirrors Rails' fetch_type_metadata
-      // after get_oid_type has pre-populated the map.
-      const castType = this.pg.lookupCastTypeFromColumn({ oid, fmod, sqlType });
-      const rawDefault = (r.default as string | null) ?? null;
-      const identity = (r.identity as string | null) || null;
-      const attgenerated = (r.attgenerated as string | null) || null;
-      // Mirrors Rails new_column_from_field: generated columns store the
-      // generation expression as defaultFunction; regular columns split into
-      // literal default vs. default function (nextval, CURRENT_TIMESTAMP, etc.).
-      // The raw literal is stored verbatim (Rails' extract_value_from_default);
-      // deserialization is deferred to Attribute.from_database, so
-      // *_before_type_cast for a column default returns the raw String.
-      const defaultValue = this.pg.extractValueFromDefault(rawDefault);
-      const defaultFunction = attgenerated
-        ? rawDefault
-        : this.pg.extractDefaultFunction(defaultValue, rawDefault);
-      const isSerial = this.pg._serialFromDefaultFunction(
-        tableName,
-        r.name as string,
-        defaultFunction,
-      );
-
-      return new Column(
-        r.name as string,
-        defaultValue,
-        {
-          sqlType,
-          type: castType.type(),
-          oid,
-          fmod,
-          limit: castType.limit ?? null,
-          precision: castType.precision ?? null,
-          scale: castType.scale ?? null,
-        },
-        !(r.notnull as boolean),
-        {
-          defaultFunction: defaultFunction ?? undefined,
-          primaryKey: r.is_primary as boolean,
-          serial: isSerial,
-          array: sqlType.endsWith("[]"),
-          identity,
-          generated: attgenerated,
-          collation: (r.collation as string | null) ?? undefined,
-          comment: (r.col_comment as string | null) ?? null,
-        },
-      );
-    });
+    // Mirrors Rails' SchemaStatements#columns (abstract/schema_statements.rb:107):
+    // `definitions.map { |field| new_column_from_field(table_name, field, definitions) }`.
+    // The rows arrive named rather than positional, so rebuild Rails'
+    // `column_definitions` field tuple (postgresql/schema_statements.rb:967) in
+    // its order before delegating. The batch preload above leaves every OID
+    // registered, so the `fetch_type_metadata` → `get_oid_type` hop inside
+    // `newColumnFromField` is a pure type-map read and issues no pg_type query.
+    const columns: Column[] = [];
+    for (const r of rows) {
+      const field = [
+        r.name,
+        r.type,
+        r.default,
+        r.notnull,
+        r.oid,
+        r.fmod,
+        r.collation,
+        r.col_comment,
+        r.identity,
+        r.attgenerated,
+        // 11th element, past Rails' ten: trails' `column_definitions` also
+        // selects `indisprimary`, which the schema dumper reads back off the
+        // Column (`resolvePrimaryKeyColumns`, schema-dumper.ts:833). Rails' PG
+        // dumper asks `primary_key(table)` instead and so never needs it.
+        r.is_primary,
+      ];
+      columns.push(await this.pg.newColumnFromField(tableName, field, rows));
+    }
+    return columns;
   }
 
   async columnNamesFromColumnNumbers(tableOid: number, columnNumbers: number[]): Promise<string[]> {

--- a/packages/activerecord/src/relation/delegation.test.ts
+++ b/packages/activerecord/src/relation/delegation.test.ts
@@ -272,27 +272,6 @@ describe("DelegationTest", () => {
       expect(delegateArrayMethod("join", records)!(",")).toBe("a,b,c");
     });
 
-    // delegation.rb:101 delegates `[]`, `&`, `|`, `+`, `-` to `records`. `[]` and
-    // `+` land on `Array.prototype` (`at`/`slice`, `concat`); `&`, `|` and `-`
-    // have no `Array.prototype` counterpart and are delegated under Ruby's own
-    // alias names for them (`Array#intersection` / `#union` / `#difference`),
-    // with Ruby's set semantics: `&` and `|` de-duplicate, `-` does not.
-    it("delegates the records operators Array.prototype cannot spell", () => {
-      const dup = () => ["a", "b", "b", "c"];
-      expect(delegateArrayMethod("intersection", dup)!(["b", "c", "d"])).toEqual(["b", "c"]);
-      expect(delegateArrayMethod("union", dup)!(["c", "d"])).toEqual(["a", "b", "c", "d"]);
-      expect(delegateArrayMethod("difference", dup)!(["c"])).toEqual(["a", "b", "b"]);
-      expect(delegateArrayMethod("at", records)!(1)).toBe("b");
-      expect(delegateArrayMethod("concat", records)!(["d"])).toEqual(["a", "b", "c", "d"]);
-    });
-
-    it("compares records with Core#== rather than object identity", () => {
-      const post = { equals: (other: any) => other?.id === 1, id: 1 };
-      const same = { equals: (other: any) => other?.id === 1, id: 1 };
-      expect(delegateArrayMethod("intersection", () => [post])!([same])).toEqual([post]);
-      expect(delegateArrayMethod("difference", () => [post])!([same])).toEqual([]);
-    });
-
     it("does not delegate JS-only Array methods absent from Rails", () => {
       // These raise NoMethodError in Rails; returning undefined lets the proxy
       // fall through so the call is rejected rather than silently succeeding.

--- a/packages/activerecord/src/relation/delegation.test.ts
+++ b/packages/activerecord/src/relation/delegation.test.ts
@@ -272,6 +272,27 @@ describe("DelegationTest", () => {
       expect(delegateArrayMethod("join", records)!(",")).toBe("a,b,c");
     });
 
+    // delegation.rb:101 delegates `[]`, `&`, `|`, `+`, `-` to `records`. `[]` and
+    // `+` land on `Array.prototype` (`at`/`slice`, `concat`); `&`, `|` and `-`
+    // have no `Array.prototype` counterpart and are delegated under Ruby's own
+    // alias names for them (`Array#intersection` / `#union` / `#difference`),
+    // with Ruby's set semantics: `&` and `|` de-duplicate, `-` does not.
+    it("delegates the records operators Array.prototype cannot spell", () => {
+      const dup = () => ["a", "b", "b", "c"];
+      expect(delegateArrayMethod("intersection", dup)!(["b", "c", "d"])).toEqual(["b", "c"]);
+      expect(delegateArrayMethod("union", dup)!(["c", "d"])).toEqual(["a", "b", "c", "d"]);
+      expect(delegateArrayMethod("difference", dup)!(["c"])).toEqual(["a", "b", "b"]);
+      expect(delegateArrayMethod("at", records)!(1)).toBe("b");
+      expect(delegateArrayMethod("concat", records)!(["d"])).toEqual(["a", "b", "c", "d"]);
+    });
+
+    it("compares records with Core#== rather than object identity", () => {
+      const post = { equals: (other: any) => other?.id === 1, id: 1 };
+      const same = { equals: (other: any) => other?.id === 1, id: 1 };
+      expect(delegateArrayMethod("intersection", () => [post])!([same])).toEqual([post]);
+      expect(delegateArrayMethod("difference", () => [post])!([same])).toEqual([]);
+    });
+
     it("does not delegate JS-only Array methods absent from Rails", () => {
       // These raise NoMethodError in Rails; returning undefined lets the proxy
       // fall through so the call is rejected rather than silently succeeding.

--- a/packages/activerecord/src/relation/delegation.trails.test.ts
+++ b/packages/activerecord/src/relation/delegation.trails.test.ts
@@ -10,6 +10,7 @@
  */
 import { describe, it, expect } from "vitest";
 import {
+  delegateArrayMethod,
   generateRelationMethod,
   relationClassFor,
   associationRelationClassFor,
@@ -208,5 +209,31 @@ describe("name delegate — property-reader typing invariant", () => {
     const rel = Comment.all();
     const name: typeof rel.name = "Comment";
     expect(name).toBe("Comment");
+  });
+});
+
+describe("delegated records operators without an Array.prototype counterpart", () => {
+  const records = () => ["a", "b", "c"];
+
+  // delegation.rb:101 delegates `[]`, `&`, `|`, `+`, `-` to `records`. `[]` and
+  // `+` land on `Array.prototype` (`at`/`slice`, `concat`); `&`, `|` and `-`
+  // have no `Array.prototype` counterpart and are delegated under Ruby's own
+  // alias names for them (`Array#intersection` / `#union` / `#difference`),
+  // with Ruby's set semantics: `&` and `|` de-duplicate, `-` does not.
+  it("delegates the records operators Array.prototype cannot spell", () => {
+    const dup = () => ["a", "b", "b", "c"];
+    expect(delegateArrayMethod("intersection", dup)!(["b", "c", "d"])).toEqual(["b", "c"]);
+    expect(delegateArrayMethod("union", dup)!(["c", "d"])).toEqual(["a", "b", "c", "d"]);
+    expect(delegateArrayMethod("difference", dup)!(["c"])).toEqual(["a", "b", "b"]);
+    expect(delegateArrayMethod("at", records)!(1)).toBe("b");
+    expect(delegateArrayMethod("concat", records)!(["d"])).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("compares records with Core#== rather than object identity", () => {
+    const equals = (other: unknown): boolean => (other as { id?: number })?.id === 1;
+    const post = { equals, id: 1 };
+    const same = { equals, id: 1 };
+    expect(delegateArrayMethod("intersection", () => [post])!([same])).toEqual([post]);
+    expect(delegateArrayMethod("difference", () => [post])!([same])).toEqual([]);
   });
 });

--- a/packages/activerecord/src/relation/delegation.ts
+++ b/packages/activerecord/src/relation/delegation.ts
@@ -590,6 +590,28 @@ export function name(): string {
  * intentionally excluded so they raise like Rails rather than silently
  * succeeding.
  */
+const DELEGATED_ARRAY_METHODS = new Set<string>([
+  // curated delegate-to-records list (delegation.rb) → JS equivalents
+  "forEach", // each
+  "join",
+  "reverse",
+  "slice", // slice / []
+  "at", // []
+  "indexOf", // index
+  "lastIndexOf", // rindex
+  "concat", // +
+  // Enumerable methods (`Relation` includes Enumerable) with JS analogues
+  "map", // map / collect
+  "filter", // select
+  "find", // detect
+  "some", // any?
+  "every", // all?
+  "includes", // include?
+  "reduce", // inject / reduce
+  "sort",
+  "flatMap", // flat_map
+]);
+
 /**
  * `Array#&`, `Array#|` and `Array#-` — three of the five operators
  * delegation.rb:101 sends to `records` (`[]`, `&`, `|`, `+`, `-`). `[]` and
@@ -632,28 +654,6 @@ function uniqRecords(records: unknown[]): unknown[] {
   for (const record of records) if (!includesRecord(uniq, record)) uniq.push(record);
   return uniq;
 }
-
-const DELEGATED_ARRAY_METHODS = new Set<string>([
-  // curated delegate-to-records list (delegation.rb) → JS equivalents
-  "forEach", // each
-  "join",
-  "reverse",
-  "slice", // slice / []
-  "at", // []
-  "indexOf", // index
-  "lastIndexOf", // rindex
-  "concat", // +
-  // Enumerable methods (`Relation` includes Enumerable) with JS analogues
-  "map", // map / collect
-  "filter", // select
-  "find", // detect
-  "some", // any?
-  "every", // all?
-  "includes", // include?
-  "reduce", // inject / reduce
-  "sort",
-  "flatMap", // flat_map
-]);
 
 /**
  * Array-method delegation — mirrors Rails' `delegate ... to: :records`

--- a/packages/activerecord/src/relation/delegation.ts
+++ b/packages/activerecord/src/relation/delegation.ts
@@ -590,6 +590,49 @@ export function name(): string {
  * intentionally excluded so they raise like Rails rather than silently
  * succeeding.
  */
+/**
+ * `Array#&`, `Array#|` and `Array#-` — three of the five operators
+ * delegation.rb:101 sends to `records` (`[]`, `&`, `|`, `+`, `-`). `[]` and
+ * `+` reach `Array.prototype` directly (`at`/`slice`, `concat`) and so live in
+ * DELEGATED_ARRAY_METHODS; these three have no `Array.prototype` counterpart,
+ * so they are spelled out here under Ruby's OWN alias names for them —
+ * `Array#intersection`, `Array#union`, `Array#difference` — rather than
+ * dropped. TS has no operator overloading, and the aliases are the spelling
+ * Ruby itself offers when the operator can't be written.
+ *
+ * Ruby's set semantics, not JS's: `&` and `|` de-duplicate, `-` does not, and
+ * membership compares with `eql?` — for records, `Core#==` (core.rb:631, ported
+ * as `equals`), which matches on class + id rather than object identity.
+ *
+ * These are runtime delegation-table entries, not declared TS members, so
+ * `OPERATOR_SPELLING_BY_FQN` (scripts/api-compare/operator-order-spelling.ts)
+ * still leaves `ActiveRecord::Delegation`'s operators unmapped: that table only
+ * accepts a spelling verified against a real member of the mapped container,
+ * and delegation.ts's container holds top-level functions.
+ */
+const DELEGATED_RECORD_SET_OPERATORS: Record<string, (a: unknown[], b: unknown[]) => unknown[]> = {
+  intersection: (a, b) => uniqRecords(a).filter((record) => includesRecord(b, record)),
+  union: (a, b) => uniqRecords([...a, ...b]),
+  difference: (a, b) => a.filter((record) => !includesRecord(b, record)),
+};
+
+/** Ruby `eql?` for the delegated set operators: `Core#==` when the value has it. */
+function recordsEql(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  const equals = (a as { equals?: (other: unknown) => boolean } | null | undefined)?.equals;
+  return typeof equals === "function" ? equals.call(a, b) === true : false;
+}
+
+function includesRecord(records: unknown[], record: unknown): boolean {
+  return records.some((candidate) => recordsEql(candidate, record));
+}
+
+function uniqRecords(records: unknown[]): unknown[] {
+  const uniq: unknown[] = [];
+  for (const record of records) if (!includesRecord(uniq, record)) uniq.push(record);
+  return uniq;
+}
+
 const DELEGATED_ARRAY_METHODS = new Set<string>([
   // curated delegate-to-records list (delegation.rb) → JS equivalents
   "forEach", // each
@@ -630,6 +673,8 @@ export function delegateArrayMethod(
   prop: string,
   records: () => unknown[],
 ): ((...args: any[]) => unknown) | undefined {
+  const setOperator = DELEGATED_RECORD_SET_OPERATORS[prop];
+  if (setOperator) return (other: unknown[]) => setOperator(records(), other ?? []);
   if (!DELEGATED_ARRAY_METHODS.has(prop)) return undefined;
   const arrayMethod = (Array.prototype as unknown as Record<string, unknown>)[prop];
   if (typeof arrayMethod !== "function") return undefined;
@@ -651,6 +696,8 @@ export function delegateArrayMethodAsync(
   prop: string,
   loadRecords: () => Promise<unknown[]>,
 ): ((...args: any[]) => Promise<unknown>) | undefined {
+  const setOperator = DELEGATED_RECORD_SET_OPERATORS[prop];
+  if (setOperator) return async (other: unknown[]) => setOperator(await loadRecords(), other ?? []);
   if (!DELEGATED_ARRAY_METHODS.has(prop)) return undefined;
   const arrayMethod = (Array.prototype as unknown as Record<string, unknown>)[prop];
   if (typeof arrayMethod !== "function") return undefined;


### PR DESCRIPTION
Four RFC 0072 stories, all in ActiveRecord.

### `route-pg-columns-through-new-column-from-field`

Rails' `SchemaStatements#columns` (abstract/schema_statements.rb:107) is
`definitions.map { |field| new_column_from_field(table_name, field, definitions) }`.
trails kept two parallel bodies: a faithful but caller-less
`PostgreSQLAdapter#newColumnFromField` and an inline `Column` build inside
`PostgreSQL::SchemaStatements#columns`.

`columns()` now rebuilds Rails' `column_definitions` field tuple
(postgresql/schema_statements.rb:967) from the named rows and delegates.
Both blockers named in the story are resolved:

- **No per-column `pg_type` query.** The batch OID preload stays where it is,
  so the `fetch_type_metadata` → `get_oid_type` hop inside the ported body is
  a pure type-map read (`getOidType` only queries on `!typeMap.has(oid)`).
  Asserted: one `pg_attribute` query and exactly one `loadAdditionalTypes`
  call for a two-column table.
- **`primaryKey` still populated.** trails' `column_definitions` also selects
  `indisprimary` for the schema dumper (`resolvePrimaryKeyColumns`), so it
  rides as an 11th field element past Rails' ten, documented at both ends.

`_serialFromDefaultFunction` is retired — the delegation made it dead.

### `singular-find-target-becomes-instance-method` / `through-find-target-becomes-instance-method`

Rails defines `find_target` on exactly three classes: `Association`
(association.rb:248), `SingularAssociation` (singular_association.rb:47) and
`HasManyThroughAssociation` (has_many_through_association.rb:225). trails now
matches that host set:

- `SingularAssociation#findTarget` reads `owner` / `reflection` off `this`.
  The two identical `doAsyncFindTarget` overrides in `BelongsToAssociation`
  and `HasOneAssociation` are deleted — Rails has no `find_target` in either
  file, and belongs_to/has_one inherit it.
- `HasManyThroughAssociation#findTarget` + `#targetReflectionHasAssociatedRecord`
  (has_many_through_association.rb:225 / :121) as instance methods, delegating
  the query to `super` as Rails does. `HasOneThroughAssociation` gets nothing:
  Rails defines no `find_target` there either, so inheriting
  `SingularAssociation`'s **is** the convergence.

**Not done, and deliberately so — half of
`through-find-target-becomes-instance-method`'s acceptance is deferred.** The
story also asks for "the module-level function exports are gone". They are
not, and they are not dead code either: `HasManyThroughAssociation#findTarget`
→ `super.findTarget()` reaches `HasManyAssociation`'s module-level loader,
whose 2-step through branch (`has-many-association.ts:584`) still does
`await import("./has-many-through-association.js")` and calls the free
`findTarget(record, assocName, options)`. So on that branch the new instance
method contributes only its own `targetReflectionHasAssociatedRecord()` guard
before `super`, and the free function re-checks the same predicate inline —
duplicated, never skipped, so behavior is unchanged.

Retiring the exports is not a mechanical call-site rewrite, which is why it is
split out rather than threaded in here. Two of the callers cannot be served by
`record.association(name)` at all:

- `has-many-through-association.ts:1146` —
  `findHasManyTarget(record, throughAssoc.name, augmentedOptions)`, where
  `augmentedOptions` carries a **synthesised `scope` closure** (the
  `sourceType` polymorphic filter) that exists nowhere in the registered
  reflection. When that through step is itself a through, it recurses straight
  back into `has-many-association.ts:584` still carrying those options.
- `has-many-through-association.ts:1175` — `findHasManyTarget(tr, ...)`, whose
  owner is a **through record**, not the association's owner.

Serving those through an instance method means constructing a synthetic
`Association` over an ad-hoc `AssociationDefinition`, and doing it without
colliding with the owner's real cached holder for that same name — loadedness,
`_loaderWritebackSuppressed`, and inverse wiring are all keyed on that holder.
That is a behavioral change to the association-cache contract, not a rename,
and it is the substance of
`0072/retire-module-level-find-target-engine-exports` (filed with this exact
evidence and the `has-many-association.ts:584` call site named).

**This needs a maintainer call.** Splitting it keeps this PR inside the 500-LOC
ceiling and honours CLAUDE.md's "if the work is larger than one PR, file a
story rather than fanning out". If the preference is to land it whole instead,
say so and I'll reopen this branch for it — but it should be a deliberate
choice about the ceiling, not something I widen unilaterally. The `@internal`
module-level loaders keep the shape `HasManyAssociation#findTarget` already
documents until then.

### `port-delegation-record-operators`

delegation.rb:101 delegates `[]`, `&`, `|`, `+`, `-` to `records`. `[]` and
`+` already reached `Array.prototype` (`at`/`slice`, `concat`); `&`, `|` and
`-` were dropped as "no JS analogue". They are now delegated under Ruby's own
alias names for them — `Array#intersection` / `#union` / `#difference` — with
Ruby's set semantics (`&`/`|` de-duplicate, `-` does not) and `eql?`
membership routed through `Core#==` (core.rb:631, ported as `equals`), so
records match on class + id rather than object identity.

`OPERATOR_SPELLING_BY_FQN` stays unmapped for `ActiveRecord::Delegation`, and
the reason is recorded at the call site: these are runtime delegation-table
entries, not declared members, and that table only accepts a spelling
verified against a real member of the mapped container.

### Verification

`pnpm typecheck`, `pnpm lint`, `pnpm api:compare`, `pnpm api:calls`,
`pnpm api:calls:wide` (both ratchets OK, nothing baselined), `pnpm api:extra
--package activerecord --novel-only` (no new novel entries). Suites run
locally: delegation, has_many_through / has_one_through / belongs_to /
has_one associations, inverse associations, collection proxy, PG schema
dumper and PG schema statements.

Closes-story: port-delegation-record-operators
Closes-story: route-pg-columns-through-new-column-from-field
Closes-story: singular-find-target-becomes-instance-method
Closes-story: through-find-target-becomes-instance-method
