### PR TITLE
fix(activemodel,activerecord): error types are Symbols, not identifier-shaped strings

### DIFF
--- a/packages/activemodel/src/callbacks.test.ts
+++ b/packages/activemodel/src/callbacks.test.ts
@@ -930,7 +930,7 @@ describe("Callbacks (extended)", () => {
       }
       validateCustom() {
         if (this.readAttribute("value") === 0) {
-          this.errors.add("value", "invalid", { message: "cannot be zero" });
+          this.errors.add("value", ":invalid", { message: "cannot be zero" });
         }
       }
     }

--- a/packages/activemodel/src/error.test.ts
+++ b/packages/activemodel/src/error.test.ts
@@ -12,86 +12,86 @@ describe("ErrorTest", () => {
 
   it("comparing against different class would not raise error", () => {
     const errors = new Errors({});
-    errors.add("name", "blank");
+    errors.add("name", ":blank");
     // Just verify it doesn't throw
     expect(errors.objects[0]).toBeDefined();
   });
 
   it("details which has no raw_type", () => {
     const errors = new Errors({});
-    errors.add("name", "blank");
+    errors.add("name", ":blank");
     const detail = errors.objects[0];
-    expect(detail.type).toBe("blank");
+    expect(detail.type).toBe(":blank");
   });
 
   it("match? handles extra options match", () => {
     const errors = new Errors({});
-    errors.add("name", "invalid", { message: "is bad" });
-    expect(errors.added("name", "invalid")).toBe(true);
+    errors.add("name", ":invalid", { message: "is bad" });
+    expect(errors.added("name", ":invalid")).toBe(true);
   });
 
   it("message handles lambda in messages and option values, and i18n interpolation", () => {
     const errors = new Errors({});
-    errors.add("name", "invalid", { message: "custom error" });
+    errors.add("name", ":invalid", { message: "custom error" });
     expect(errors.get("name")).toEqual(["custom error"]);
   });
 
   it("message with type as a symbol and indexed attribute can lookup without index in attribute key", () => {
     const errors = new Errors({});
-    errors.add("name", "invalid");
+    errors.add("name", ":invalid");
     expect(errors.get("name")).toEqual(["is invalid"]);
   });
 
   it("initialize", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
+    e.add("name", ":blank");
     expect(e.objects[0].attribute).toBe("name");
-    expect(e.objects[0].type).toBe("blank");
+    expect(e.objects[0].type).toBe(":blank");
   });
 
   it("initialize without type", () => {
     const e = new Errors(null);
     e.add("name");
-    expect(e.objects[0].type).toBe("invalid");
+    expect(e.objects[0].type).toBe(":invalid");
   });
 
   it("match? handles attribute match", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
+    e.add("name", ":blank");
     expect(e.where("name").length).toBe(1);
     expect(e.where("age").length).toBe(0);
   });
 
   it("match? handles error type match", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    e.add("name", "too_short");
-    expect(e.where("name", "blank").length).toBe(1);
-    expect(e.where("name", "too_short").length).toBe(1);
+    e.add("name", ":blank");
+    e.add("name", ":too_short");
+    expect(e.where("name", ":blank").length).toBe(1);
+    expect(e.where("name", ":too_short").length).toBe(1);
   });
 
   it("message with type as custom message", () => {
     const e = new Errors(null);
-    e.add("name", "blank", { message: "is required" });
+    e.add("name", ":blank", { message: "is required" });
     expect(e.get("name")).toContain("is required");
   });
 
   it("message with options[:message] as custom message", () => {
     const e = new Errors(null);
-    e.add("name", "invalid", { message: "is not valid" });
+    e.add("name", ":invalid", { message: "is not valid" });
     expect(e.get("name")).toContain("is not valid");
   });
 
   it("equality by base attribute, type and options", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    expect(e.added("name", "blank")).toBe(true);
+    e.add("name", ":blank");
+    expect(e.added("name", ":blank")).toBe(true);
   });
 
   it("inequality", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    expect(e.added("name", "too_short")).toBe(false);
+    e.add("name", ":blank");
+    expect(e.added("name", ":too_short")).toBe(false);
   });
 
   it("full_message returns the given message when the attribute contains base", () => {
@@ -102,67 +102,67 @@ describe("ErrorTest", () => {
 
   it("details which ignores callback and message options", () => {
     const e = new Errors(null);
-    e.add("name", "blank", { message: "custom msg" });
+    e.add("name", ":blank", { message: "custom msg" });
     const detail = e.objects[0];
     expect(detail.attribute).toBe("name");
-    expect(detail.type).toBe("blank");
+    expect(detail.type).toBe(":blank");
   });
 
   it("initialize without type but with options", () => {
     const e = new Errors(null);
-    e.add("name", "invalid", { message: "is not valid" });
+    e.add("name", ":invalid", { message: "is not valid" });
     const detail = e.objects[0];
     expect(detail.attribute).toBe("name");
-    expect(detail.type).toBe("invalid");
+    expect(detail.type).toBe(":invalid");
     expect(detail.message).toBe("is not valid");
   });
 
   it("match? handles mixed condition", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    e.add("name", "too_short");
-    e.add("age", "blank");
-    expect(e.where("name", "blank").length).toBe(1);
-    expect(e.where("name", "too_short").length).toBe(1);
-    expect(e.where("name", "invalid").length).toBe(0);
-    expect(e.where("age", "blank").length).toBe(1);
+    e.add("name", ":blank");
+    e.add("name", ":too_short");
+    e.add("age", ":blank");
+    expect(e.where("name", ":blank").length).toBe(1);
+    expect(e.where("name", ":too_short").length).toBe(1);
+    expect(e.where("name", ":invalid").length).toBe(0);
+    expect(e.where("age", ":blank").length).toBe(1);
   });
 
   it("message with type as a symbol", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
+    e.add("name", ":blank");
     expect(e.get("name")).toEqual(["can't be blank"]);
   });
 
   it("message with custom interpolation", () => {
     const e = new Errors(null);
-    e.add("name", "greater_than", { count: 5 });
+    e.add("name", ":greater_than", { count: 5 });
     expect(e.get("name")).toEqual(["must be greater than 5"]);
   });
 
   it("message returns plural interpolation", () => {
     const e = new Errors(null);
-    e.add("name", "too_short", { count: 3 });
+    e.add("name", ":too_short", { count: 3 });
     expect(e.get("name").length).toBe(1);
     expect(e.objects[0].options?.count).toBe(3);
   });
 
   it("message returns singular interpolation", () => {
     const e = new Errors(null);
-    e.add("name", "too_short", { count: 1 });
+    e.add("name", ":too_short", { count: 1 });
     expect(e.get("name").length).toBe(1);
     expect(e.objects[0].options?.count).toBe(1);
   });
 
   it("message returns count interpolation", () => {
     const e = new Errors(null);
-    e.add("name", "equal_to", { count: 42 });
+    e.add("name", ":equal_to", { count: 42 });
     expect(e.get("name")).toEqual(["must be equal to 42"]);
   });
 
   it("inspect", () => {
     const errors = new Errors({});
-    errors.add("name", "blank");
+    errors.add("name", ":blank");
     const str = errors.inspect();
     expect(str).toContain("ActiveModel::Errors");
     expect(str).toContain("name");
@@ -171,25 +171,25 @@ describe("ErrorTest", () => {
 
   it("message renders lazily using current locale", () => {
     const errors = new Errors({});
-    errors.add("name", "blank");
+    errors.add("name", ":blank");
     expect(errors.get("name")).toEqual(["can't be blank"]);
   });
 
   it("message uses current locale", () => {
     const errors = new Errors({});
-    errors.add("name", "invalid");
+    errors.add("name", ":invalid");
     expect(errors.get("name")).toEqual(["is invalid"]);
   });
 
   it("full_messages doesn't require the base object to respond to :errors", () => {
     const errors = new Errors({ name: "test" });
-    errors.add("name", "blank");
+    errors.add("name", ":blank");
     expect(errors.fullMessages).toEqual(["Name can't be blank"]);
   });
 
   it("merge does not import errors when merging with self", () => {
     const errors = new Errors({});
-    errors.add("name", "blank");
+    errors.add("name", ":blank");
     expect(errors.count).toBe(1);
     errors.merge(errors);
     expect(errors.count).toBe(1);
@@ -197,19 +197,19 @@ describe("ErrorTest", () => {
 
   it("generate_message works without i18n_scope", () => {
     const e = new Errors(null);
-    expect(e.generateMessage("name", "blank")).toBe("can't be blank");
-    expect(e.generateMessage("name", "invalid")).toBe("is invalid");
+    expect(e.generateMessage("name", ":blank")).toBe("can't be blank");
+    expect(e.generateMessage("name", ":invalid")).toBe("is invalid");
   });
 
   it("full_message returns the given message when attribute is :base", () => {
     const e = new Errors(null);
-    e.add("base", "invalid", { message: "Something went wrong" });
+    e.add("base", ":invalid", { message: "Something went wrong" });
     expect(e.fullMessages).toContain("Something went wrong");
   });
 
   it("full_message returns the given message with the attribute name included", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
+    e.add("name", ":blank");
     expect(e.fullMessages[0]).toBe("Name can't be blank");
   });
 
@@ -241,7 +241,7 @@ describe("ErrorTest", () => {
 
     try {
       const record = new Child({ name: "" }) as any;
-      const msg = ModelError.generateMessage("name", "blank", record);
+      const msg = ModelError.generateMessage("name", ":blank", record);
       expect(msg).toBe("parent-level blank");
     } finally {
       resetI18n();
@@ -256,14 +256,14 @@ describe("ErrorTest", () => {
       }
     }
     const record = new ARModel({}) as any;
-    const msg = ModelError.generateMessage("name", "blank", record);
+    const msg = ModelError.generateMessage("name", ":blank", record);
     expect(msg).toBe("can't be blank");
   });
 
   // P10: message getter dispatches on rawType shape (identifier vs literal string)
   it("message with identifier-shaped rawType routes through i18n", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
+    e.add("name", ":blank");
     expect(e.get("name")).toEqual(["can't be blank"]);
   });
 
@@ -277,7 +277,7 @@ describe("ErrorTest", () => {
   // A Ruby Symbol keeps its leading colon as a string value (error.rb:65).
   it("generateMessage with identifier options.message routes through i18n as new type", () => {
     const e = new Errors(null);
-    e.add("name", "blank", { message: ":tooShort" });
+    e.add("name", ":blank", { message: ":tooShort" });
     // ":tooShort" becomes the type, and has no locale entry → the missing-translation message
     expect(e.get("name")[0]).toContain("errors.messages.tooShort");
   });
@@ -304,7 +304,7 @@ describe("ErrorTest", () => {
 
   it("fullMessage uses last segment of dotted attribute", () => {
     const e = new Errors(null);
-    e.add("profile.bio", "blank");
+    e.add("profile.bio", ":blank");
     const msg = e.fullMessages[0];
     expect(msg).toBe("Profile bio can't be blank");
   });
@@ -312,15 +312,15 @@ describe("ErrorTest", () => {
   // P10: fullMessage non-nested regression guard
   it("fullMessage non-nested attribute behaves as before", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
+    e.add("name", ":blank");
     expect(e.fullMessages[0]).toBe("Name can't be blank");
   });
 
   // P10: attributesForHash is protected (accessible within the class hierarchy)
   it("attributesForHash is accessible via equals", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    e.add("name", "blank");
+    e.add("name", ":blank");
+    e.add("name", ":blank");
     // equals() uses attributesForHash internally; duplicates should be equal
     expect(e.objects[0].equals(e.objects[1])).toBe(true);
   });

--- a/packages/activemodel/src/error.ts
+++ b/packages/activemodel/src/error.ts
@@ -36,9 +36,6 @@ const CALLBACKS_OPTIONS = new Set<string>([
 ]);
 const MESSAGE_OPTIONS = new Set<string>(["message"]);
 
-// Identifier pattern mirrors Ruby Symbol semantics: no spaces or punctuation.
-const IDENTIFIER_RE = /^[a-z][a-zA-Z0-9_]*$/;
-
 /**
  * Value equality that matches Ruby `==` for the common option shapes:
  * primitives (identity), arrays (elementwise), and plain objects (key-set +
@@ -147,9 +144,12 @@ export class Error {
     // `options[:message]` and becomes the default below, exactly as in Rails.
     if (typeof msgOpt === "string" && msgOpt.startsWith(":")) {
       const { message: _msg, ...rest } = options;
-      type = msgOpt.slice(1);
+      type = msgOpt;
       options = rest;
     }
+    // `type` is a Ruby Symbol, i.e. a colon-prefixed string; the i18n keys
+    // below are built from its name.
+    const typeName = type.slice(1);
 
     const baseClass = base?.constructor as ModelClass | undefined;
     // error.rb:66. Rails aliases `read_attribute_for_validation` to `send`
@@ -178,10 +178,10 @@ export class Error {
       attribute = attribute.replace(/\[\d+\]/g, "");
 
       defaults = baseClass.lookupAncestors!().flatMap((klass) => [
-        `:${i18nScope}.errors.models.${klass.modelName!.i18nKey}.attributes.${attribute}.${type}`,
-        `:${i18nScope}.errors.models.${klass.modelName!.i18nKey}.${type}`,
+        `:${i18nScope}.errors.models.${klass.modelName!.i18nKey}.attributes.${attribute}.${typeName}`,
+        `:${i18nScope}.errors.models.${klass.modelName!.i18nKey}.${typeName}`,
       ]);
-      defaults.push(`:${i18nScope}.errors.messages.${type}`);
+      defaults.push(`:${i18nScope}.errors.messages.${typeName}`);
 
       if (options.message == null || options.message === false) {
         const translation = catchException(() =>
@@ -199,8 +199,8 @@ export class Error {
       defaults = [];
     }
 
-    defaults.push(`:errors.attributes.${attribute}.${type}`);
-    defaults.push(`:errors.messages.${type}`);
+    defaults.push(`:errors.attributes.${attribute}.${typeName}`);
+    defaults.push(`:errors.messages.${typeName}`);
 
     const key = defaults.shift();
     if (options.message != null && options.message !== false) {
@@ -215,7 +215,7 @@ export class Error {
   constructor(
     base: ModelBase,
     attribute: string,
-    type: string = "invalid",
+    type: string = ":invalid",
     options: Record<string, unknown> = {},
     rawType?: string,
   ) {
@@ -228,14 +228,14 @@ export class Error {
     // original error's key even when the surface `type` has been renamed.
     // `rawType` defaults to `type` for the common case where they match.
     this.rawType = rawType ?? type;
-    this.type = type || "invalid";
+    this.type = type || ":invalid";
     this.options = options;
   }
 
   get message(): string {
     // Rails error.rb:136-141: dispatch on raw_type shape — Symbol → generate_message, else → literal.
-    // TS has no Symbol type; identifier-shaped strings (no spaces/punctuation) are the equivalent.
-    if (IDENTIFIER_RE.test(this.rawType)) {
+    // A Ruby Symbol reaches us as a colon-prefixed string (`":blank"`), which is the discriminator.
+    if (this.rawType.startsWith(":")) {
       const opts: Record<string, unknown> = {};
       for (const [k, v] of Object.entries(this.options)) {
         if (!CALLBACKS_OPTIONS.has(k)) opts[k] = v;

--- a/packages/activemodel/src/error.ts
+++ b/packages/activemodel/src/error.ts
@@ -147,8 +147,6 @@ export class Error {
       type = msgOpt;
       options = rest;
     }
-    // `type` is a Ruby Symbol, i.e. a colon-prefixed string; the i18n keys
-    // below are built from its name.
     const typeName = type.slice(1);
 
     const baseClass = base?.constructor as ModelClass | undefined;

--- a/packages/activemodel/src/errors.test.ts
+++ b/packages/activemodel/src/errors.test.ts
@@ -18,14 +18,14 @@ describe("ErrorsTest", () => {
   // =========================================================================
   it("add creates an error object and returns it", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
+    e.add("name", ":blank");
     expect(e.get("name")).toContain("can't be blank");
   });
 
   it("size calculates the number of error messages", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    e.add("age", "not_a_number");
+    e.add("name", ":blank");
+    e.add("age", ":not_a_number");
     expect(e.count).toBe(2);
     expect(e.size).toBe(2);
   });
@@ -34,14 +34,14 @@ describe("ErrorsTest", () => {
     const e = new Errors(null);
     expect(e.empty).toBe(true);
     expect(e.any).toBe(false);
-    e.add("name", "blank");
+    e.add("name", ":blank");
     expect(e.empty).toBe(false);
     expect(e.any).toBe(true);
   });
 
   it("clear errors", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
+    e.add("name", ":blank");
     e.clear();
     expect(e.count).toBe(0);
     expect(e.empty).toBe(true);
@@ -49,39 +49,39 @@ describe("ErrorsTest", () => {
 
   it("where filters by attribute and type", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    e.add("name", "too_short");
-    e.add("age", "blank");
+    e.add("name", ":blank");
+    e.add("name", ":too_short");
+    e.add("age", ":blank");
     expect(e.where("name").length).toBe(2);
-    expect(e.where("name", "blank").length).toBe(1);
+    expect(e.where("name", ":blank").length).toBe(1);
     expect(e.where("age").length).toBe(1);
   });
 
   it("attribute_names returns the error attributes", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    e.add("name", "too_short");
-    e.add("age", "blank");
+    e.add("name", ":blank");
+    e.add("name", ":too_short");
+    e.add("age", ":blank");
     expect(e.attributeNames).toEqual(["name", "age"]);
   });
 
   it("details returns added error detail", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
+    e.add("name", ":blank");
     expect(e.details.size).toBe(1);
     expect(e.details.get("name")).toHaveLength(1);
-    expect(e.details.get("name")![0].error).toBe("blank");
+    expect(e.details.get("name")![0].error).toBe(":blank");
   });
 
   it("custom message overrides default", () => {
     const e = new Errors(null);
-    e.add("name", "blank", { message: "is required" });
+    e.add("name", ":blank", { message: "is required" });
     expect(e.get("name")).toContain("is required");
   });
 
   it("message interpolation with %{count}", () => {
     const e = new Errors(null);
-    e.add("name", "too_short", { count: 3 });
+    e.add("name", ":too_short", { count: 3 });
     // Default message is "is too short" — doesn't have %{count} by default
     // but the mechanism should work for messages that do
     expect(e.get("name").length).toBe(1);
@@ -92,19 +92,19 @@ describe("ErrorsTest", () => {
   // =========================================================================
   it("first", () => {
     const errors = new Errors({});
-    errors.add("name", "blank");
-    errors.add("age", "invalid");
+    errors.add("name", ":blank");
+    errors.add("age", ":invalid");
     expect(errors.objects[0].attribute).toBe("name");
   });
 
   it("dup", () => {
     const errors = new Errors({});
-    errors.add("name", "blank");
+    errors.add("name", ":blank");
     const dup = new Errors({});
     dup.copy(errors);
     expect(dup.count).toBe(1);
     // Modifying dup should not affect original
-    dup.add("age", "invalid");
+    dup.add("age", ":invalid");
     expect(errors.count).toBe(1);
     expect(dup.count).toBe(2);
   });
@@ -117,7 +117,7 @@ describe("ErrorsTest", () => {
 
   it("no key", () => {
     const errors = new Errors({});
-    errors.add("name", "blank");
+    errors.add("name", ":blank");
     expect(errors.isKey("age")).toBe(false);
   });
 
@@ -134,45 +134,45 @@ describe("ErrorsTest", () => {
 
   it("error access is indifferent", () => {
     const errors = new Errors({});
-    errors.add("name", "blank");
+    errors.add("name", ":blank");
     expect(errors.get("name")).toEqual(["can't be blank"]);
     expect(errors.on("name")).toEqual(["can't be blank"]);
   });
 
   it("add, with type as nil", () => {
     const errors = new Errors({});
-    errors.add("name", "invalid");
+    errors.add("name", ":invalid");
     expect(errors.get("name")).toEqual(["is invalid"]);
   });
 
   it("add an error message on a specific attribute with a defined type", () => {
     const errors = new Errors({});
-    errors.add("name", "blank");
-    expect(errors.where("name", "blank").length).toBe(1);
+    errors.add("name", ":blank");
+    expect(errors.where("name", ":blank").length).toBe(1);
   });
 
   it("add, with type as Proc, which evaluates to String", () => {
     const errors = new Errors({});
-    errors.add("name", "invalid", { message: (_record: any) => "cannot be empty" });
+    errors.add("name", ":invalid", { message: (_record: any) => "cannot be empty" });
     expect(errors.get("name")).toEqual(["cannot be empty"]);
   });
 
   it("initialize options[:message] as Proc, which evaluates to String", () => {
     const errors = new Errors({});
-    errors.add("name", "invalid", { message: () => "proc message" });
+    errors.add("name", ":invalid", { message: () => "proc message" });
     expect(errors.get("name")).toEqual(["proc message"]);
   });
 
   it("added? when attribute was added through a collection", () => {
     const errors = new Errors({});
-    errors.add("name", "blank");
-    expect(errors.added("name", "blank")).toBe(true);
+    errors.add("name", ":blank");
+    expect(errors.added("name", ":blank")).toBe(true);
   });
 
   it("added? returns true when string attribute is used with a symbol message", () => {
     const errors = new Errors({});
-    errors.add("name", "blank");
-    expect(errors.added("name", "blank")).toBe(true);
+    errors.add("name", ":blank");
+    expect(errors.added("name", ":blank")).toBe(true);
   });
 
   it("of_kind? returns false when checking for an error, but not providing message argument", () => {
@@ -183,14 +183,14 @@ describe("ErrorsTest", () => {
 
   it("of_kind? returns true when string attribute is used with a symbol message", () => {
     const errors = new Errors({});
-    errors.add("name", "blank");
-    expect(errors.ofKind("name", "blank")).toBe(true);
+    errors.add("name", ":blank");
+    expect(errors.ofKind("name", ":blank")).toBe(true);
   });
 
   it("to_hash returns a hash without default proc", () => {
     const errors = new Errors({});
-    errors.add("name", "blank");
-    errors.add("name", "invalid");
+    errors.add("name", ":blank");
+    errors.add("name", ":invalid");
     const hash = errors.toHash();
     expect(hash.get("name")).toEqual(["can't be blank", "is invalid"]);
     // Accessing a non-existent key should be undefined
@@ -199,7 +199,7 @@ describe("ErrorsTest", () => {
 
   it("as_json returns a hash without default proc", () => {
     const errors = new Errors({});
-    errors.add("name", "blank");
+    errors.add("name", ":blank");
     const json = errors.asJson();
     expect(json).toEqual({ name: ["can't be blank"] });
     expect(json.age).toBeUndefined();
@@ -207,15 +207,15 @@ describe("ErrorsTest", () => {
 
   it("as_json with :full_messages option creates a json formatted representation of the errors containing complete messages", () => {
     const errors = new Errors({});
-    errors.add("name", "blank");
-    errors.add("age", "invalid");
+    errors.add("name", ":blank");
+    errors.add("age", ":invalid");
     // fullMessages style
     expect(errors.fullMessages).toEqual(["Name can't be blank", "Age is invalid"]);
   });
 
   it("merge does not import errors when merging with self", () => {
     const errors = new Errors({});
-    errors.add("name", "blank");
+    errors.add("name", ":blank");
     errors.merge(errors);
     expect(errors.count).toBe(1);
   });
@@ -274,7 +274,7 @@ describe("ErrorsTest", () => {
 
   it("inspect", () => {
     const errors = new Errors({});
-    errors.add("name", "blank");
+    errors.add("name", ":blank");
     const str = errors.inspect();
     expect(str).toContain("ActiveModel::Errors");
     expect(str).toContain("name");
@@ -283,9 +283,9 @@ describe("ErrorsTest", () => {
 
   it("delete removes errors for attribute", () => {
     const errors = new Errors({});
-    errors.add("name", "blank");
-    errors.add("name", "invalid");
-    errors.add("age", "invalid");
+    errors.add("name", ":blank");
+    errors.add("name", ":invalid");
+    errors.add("age", ":invalid");
     const removed = errors.delete("name");
     expect(removed!.length).toBe(2);
     expect(errors.count).toBe(1);
@@ -293,8 +293,8 @@ describe("ErrorsTest", () => {
 
   it("each iterates over all errors", () => {
     const errors = new Errors({});
-    errors.add("name", "blank");
-    errors.add("age", "invalid");
+    errors.add("name", ":blank");
+    errors.add("age", ":invalid");
     const collected: string[] = [];
     errors.each((e) => collected.push(e.attribute));
     expect(collected).toEqual(["name", "age"]);
@@ -302,9 +302,9 @@ describe("ErrorsTest", () => {
 
   it("group_by_attribute groups errors", () => {
     const errors = new Errors({});
-    errors.add("name", "blank");
-    errors.add("name", "invalid");
-    errors.add("age", "invalid");
+    errors.add("name", ":blank");
+    errors.add("name", ":invalid");
+    errors.add("age", ":invalid");
     const grouped = errors.groupByAttribute();
     expect(grouped["name"].length).toBe(2);
     expect(grouped["age"].length).toBe(1);
@@ -312,20 +312,20 @@ describe("ErrorsTest", () => {
 
   it("messages_for returns messages for an attribute", () => {
     const errors = new Errors({});
-    errors.add("name", "blank");
-    errors.add("name", "invalid");
+    errors.add("name", ":blank");
+    errors.add("name", ":invalid");
     expect(errors.messagesFor("name")).toEqual(["can't be blank", "is invalid"]);
   });
 
   it("full_messages_for returns full messages for an attribute", () => {
     const errors = new Errors({});
-    errors.add("name", "blank");
+    errors.add("name", ":blank");
     expect(errors.fullMessagesFor("name")).toEqual(["Name can't be blank"]);
   });
 
   it("import imports an error from another Errors instance", () => {
     const errors1 = new Errors({});
-    errors1.add("name", "blank");
+    errors1.add("name", ":blank");
     const errors2 = new Errors({});
     errors2.import(errors1.objects[0]);
     expect(errors2.count).toBe(1);
@@ -334,7 +334,7 @@ describe("ErrorsTest", () => {
 
   it("import with attribute override", () => {
     const errors1 = new Errors({});
-    errors1.add("name", "blank");
+    errors1.add("name", ":blank");
     const errors2 = new Errors({});
     errors2.import(errors1.objects[0], { attribute: "title" });
     expect(errors2.get("title")).toEqual(["can't be blank"]);
@@ -342,26 +342,26 @@ describe("ErrorsTest", () => {
 
   it("add, type being Proc, which evaluates to Symbol", () => {
     const errors = new Errors({});
-    errors.add("name", "invalid");
+    errors.add("name", ":invalid");
     expect(errors.get("name")).toEqual(["is invalid"]);
   });
 
   it("add, with options[:message] as Proc, which evaluates to String, where type is nil", () => {
     const errors = new Errors({});
-    errors.add("name", "invalid", { message: "custom" });
+    errors.add("name", ":invalid", { message: "custom" });
     expect(errors.get("name")).toEqual(["custom"]);
   });
 
   it("errors are compatible with YAML dumped from Rails 6.x", () => {
     const errors = new Errors({});
-    errors.add("name", "blank");
+    errors.add("name", ":blank");
     expect(errors.fullMessages).toEqual(["Name can't be blank"]);
   });
 
   it("delete", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    e.add("name", "too_short");
+    e.add("name", ":blank");
+    e.add("name", ":too_short");
     const removed = e.delete("name");
     expect(removed!.length).toBe(2);
     expect(e.count).toBe(0);
@@ -369,7 +369,7 @@ describe("ErrorsTest", () => {
 
   it("include?", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
+    e.add("name", ":blank");
     expect(e.include("name")).toBe(true);
     expect(e.include("age")).toBe(false);
   });
@@ -377,33 +377,33 @@ describe("ErrorsTest", () => {
   it("any?", () => {
     const e = new Errors(null);
     expect(e.any).toBe(false);
-    e.add("name", "blank");
+    e.add("name", ":blank");
     expect(e.any).toBe(true);
   });
 
   it("has key?", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
+    e.add("name", ":blank");
     expect(e.include("name")).toBe(true);
   });
 
   it("has no key", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
+    e.add("name", ":blank");
     expect(e.include("age")).toBe(false);
   });
 
   it("clear errors", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
+    e.add("name", ":blank");
     e.clear();
     expect(e.empty).toBe(true);
   });
 
   it("attribute_names returns the error attributes", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    e.add("age", "not_a_number");
+    e.add("name", ":blank");
+    e.add("age", ":not_a_number");
     expect(e.attributeNames).toEqual(["name", "age"]);
   });
 
@@ -418,7 +418,7 @@ describe("ErrorsTest", () => {
     expect(e.empty).toBe(true);
     expect(e.any).toBe(false);
     expect(e.include("name")).toBe(false);
-    e.add("name", "blank");
+    e.add("name", ":blank");
     expect(e.empty).toBe(false);
     expect(e.any).toBe(true);
     expect(e.include("name")).toBe(true);
@@ -432,100 +432,100 @@ describe("ErrorsTest", () => {
 
   it("add creates an error object and returns it", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
+    e.add("name", ":blank");
     expect(e.count).toBe(1);
     expect(e.get("name")).toContain("can't be blank");
   });
 
   it("add, with type as String", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
+    e.add("name", ":blank");
     expect(e.get("name")).toContain("can't be blank");
   });
 
   it("added? detects indifferent if a specific error was added to the object", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    expect(e.added("name", "blank")).toBe(true);
-    expect(e.added("name", "invalid")).toBe(false);
+    e.add("name", ":blank");
+    expect(e.added("name", ":blank")).toBe(true);
+    expect(e.added("name", ":invalid")).toBe(false);
   });
 
   it("added? matches the given message when several errors are present for the same attribute", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    e.add("name", "too_short");
-    expect(e.added("name", "blank")).toBe(true);
-    expect(e.added("name", "too_short")).toBe(true);
+    e.add("name", ":blank");
+    e.add("name", ":too_short");
+    expect(e.added("name", ":blank")).toBe(true);
+    expect(e.added("name", ":too_short")).toBe(true);
   });
 
   it("added? returns false when no errors are present", () => {
     const e = new Errors(null);
-    expect(e.added("name", "blank")).toBe(false);
+    expect(e.added("name", ":blank")).toBe(false);
   });
 
   it("added? returns false when checking a nonexisting error and other errors are present for the given attribute", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    expect(e.added("name", "too_short")).toBe(false);
+    e.add("name", ":blank");
+    expect(e.added("name", ":too_short")).toBe(false);
   });
 
   it("of_kind? returns false when no errors are present", () => {
     const e = new Errors(null);
-    expect(e.ofKind("name", "blank")).toBe(false);
+    expect(e.ofKind("name", ":blank")).toBe(false);
   });
 
   it("of_kind? matches the given message when several errors are present for the same attribute", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    e.add("name", "too_short");
-    expect(e.ofKind("name", "blank")).toBe(true);
-    expect(e.ofKind("name", "too_short")).toBe(true);
+    e.add("name", ":blank");
+    e.add("name", ":too_short");
+    expect(e.ofKind("name", ":blank")).toBe(true);
+    expect(e.ofKind("name", ":too_short")).toBe(true);
   });
 
   it("of_kind? defaults message to :invalid", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
+    e.add("name", ":blank");
     expect(e.ofKind("name")).toBe(true);
     expect(e.ofKind("age")).toBe(false);
   });
 
   it("of_kind? detects indifferent if a specific error was added to the object", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    expect(e.ofKind("name", "blank")).toBe(true);
-    expect(e.ofKind("name", "invalid")).toBe(false);
+    e.add("name", ":blank");
+    expect(e.ofKind("name", ":blank")).toBe(true);
+    expect(e.ofKind("name", ":invalid")).toBe(false);
   });
 
   it("of_kind? returns false when checking a nonexisting error and other errors are present for the given attribute", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    expect(e.ofKind("name", "too_short")).toBe(false);
+    e.add("name", ":blank");
+    expect(e.ofKind("name", ":too_short")).toBe(false);
   });
 
   it("of_kind? returns false when checking for an error by symbol and a different error with same message is present", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    expect(e.ofKind("name", "present")).toBe(false);
+    e.add("name", ":blank");
+    expect(e.ofKind("name", ":present")).toBe(false);
   });
 
   it("size calculates the number of error messages", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    e.add("age", "not_a_number");
+    e.add("name", ":blank");
+    e.add("age", ":not_a_number");
     expect(e.size).toBe(2);
   });
 
   it("count calculates the number of error messages", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    e.add("name", "too_short");
+    e.add("name", ":blank");
+    e.add("name", ":too_short");
     expect(e.count).toBe(2);
   });
 
   it("to_a returns the list of errors with complete messages containing the attribute names", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    e.add("age", "not_a_number");
+    e.add("name", ":blank");
+    e.add("age", ":not_a_number");
     const arr = e.toArray();
     expect(arr).toContain("Name can't be blank");
     expect(arr).toContain("Age is not a number");
@@ -533,9 +533,9 @@ describe("ErrorsTest", () => {
 
   it("to_hash returns the error messages hash", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    e.add("name", "too_short");
-    e.add("age", "not_a_number");
+    e.add("name", ":blank");
+    e.add("name", ":too_short");
+    e.add("age", ":not_a_number");
     const hash = e.toHash();
     expect(hash.get("name")!.length).toBe(2);
     expect(hash.get("age")!.length).toBe(1);
@@ -543,24 +543,24 @@ describe("ErrorsTest", () => {
 
   it("full_messages creates a list of error messages with the attribute name included", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    e.add("age", "not_a_number");
+    e.add("name", ":blank");
+    e.add("age", ":not_a_number");
     expect(e.fullMessages).toContain("Name can't be blank");
     expect(e.fullMessages).toContain("Age is not a number");
   });
 
   it("full_messages_for contains all the error messages for the given attribute indifferent", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    e.add("name", "too_short");
-    e.add("age", "not_a_number");
+    e.add("name", ":blank");
+    e.add("name", ":too_short");
+    e.add("age", ":not_a_number");
     expect(e.fullMessagesFor("name").length).toBe(2);
   });
 
   it("full_messages_for does not contain error messages from other attributes", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    e.add("age", "not_a_number");
+    e.add("name", ":blank");
+    e.add("age", ":not_a_number");
     const nameMessages = e.fullMessagesFor("name");
     expect(nameMessages.length).toBe(1);
     expect(nameMessages[0]).toContain("Name");
@@ -568,7 +568,7 @@ describe("ErrorsTest", () => {
 
   it("full_messages_for returns an empty list in case there are no errors for the given attribute", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
+    e.add("name", ":blank");
     expect(e.fullMessagesFor("age")).toEqual([]);
   });
 
@@ -584,36 +584,36 @@ describe("ErrorsTest", () => {
 
   it("as_json creates a json formatted representation of the errors hash", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    e.add("name", "too_short");
+    e.add("name", ":blank");
+    e.add("name", ":too_short");
     const json = e.asJson();
     expect(json["name"].length).toBe(2);
   });
 
   it("details returns added error detail with custom option", () => {
     const e = new Errors(null);
-    e.add("name", "blank", { message: "custom" });
-    expect(e.details.get("name")![0].error).toBe("blank");
+    e.add("name", ":blank", { message: "custom" });
+    expect(e.details.get("name")![0].error).toBe(":blank");
   });
 
   it("details do not include message option", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    expect(e.details.get("name")![0].error).toBe("blank");
+    e.add("name", ":blank");
+    expect(e.details.get("name")![0].error).toBe(":blank");
     expect(e.details.get("name")![0].message).toBeUndefined();
   });
 
   it("details retains original type as error", () => {
     const e = new Errors(null);
-    e.add("name", "too_short", { count: 3 });
-    expect(e.details.get("name")![0].error).toBe("too_short");
+    e.add("name", ":too_short", { count: 3 });
+    expect(e.details.get("name")![0].error).toBe(":too_short");
   });
 
   it("group_by_attribute", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    e.add("name", "too_short");
-    e.add("age", "not_a_number");
+    e.add("name", ":blank");
+    e.add("name", ":too_short");
+    e.add("age", ":not_a_number");
     const grouped = e.groupByAttribute();
     expect(grouped.name.length).toBe(2);
     expect(grouped.age.length).toBe(1);
@@ -627,8 +627,8 @@ describe("ErrorsTest", () => {
 
   it("delete removes details on given attribute", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    e.add("age", "not_a_number");
+    e.add("name", ":blank");
+    e.add("age", ":not_a_number");
     e.delete("name");
     expect(e.count).toBe(1);
     expect(e.include("name")).toBe(false);
@@ -636,15 +636,15 @@ describe("ErrorsTest", () => {
 
   it("delete returns the deleted messages", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    e.add("name", "too_short");
+    e.add("name", ":blank");
+    e.add("name", ":too_short");
     const removed = e.delete("name");
     expect(removed!.length).toBe(2);
   });
 
   it("clear removes details", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
+    e.add("name", ":blank");
     e.clear();
     expect(e.details.size).toBe(0);
   });
@@ -657,7 +657,7 @@ describe("ErrorsTest", () => {
   it("copy errors", () => {
     const e1 = new Errors(null);
     const e2 = new Errors(null);
-    e1.add("name", "blank");
+    e1.add("name", ":blank");
     e2.copy(e1);
     expect(e2.count).toBe(1);
     expect(e2.get("name")).toContain("can't be blank");
@@ -667,8 +667,8 @@ describe("ErrorsTest", () => {
     // Rails errors.rb:138 — `@errors = other.errors.deep_dup`.
     const e1 = new Errors(null);
     const e2 = new Errors(null);
-    e2.add("name", "blank");
-    e1.add("age", "invalid");
+    e2.add("name", ":blank");
+    e1.add("age", ":invalid");
     e2.copyBang(e1);
     expect(e2.count).toBe(1);
     expect(e2.attributeNames).toEqual(["age"]);
@@ -680,7 +680,7 @@ describe("ErrorsTest", () => {
     // so mutating the source after copy would leak into the target.
     const source = new Errors({});
     const nested = { range: { min: 1, max: 5 } };
-    source.add("age", "out_of_range", nested);
+    source.add("age", ":out_of_range", nested);
     const target = new Errors({});
     target.copyBang(source);
     (source.objects[0].options.range as { min: number }).min = 999;
@@ -691,7 +691,7 @@ describe("ErrorsTest", () => {
     // Rails `deep_dup` preserves dynamic class; a NestedError dup is still
     // a NestedError with its innerError reachable.
     const source = new Errors({});
-    source.add("age", "invalid");
+    source.add("age", ":invalid");
     const wrapper = new Errors({});
     wrapper.mergeBang(source); // imports as NestedError
     const target = new Errors({});
@@ -704,17 +704,17 @@ describe("ErrorsTest", () => {
     // where/delete/added?/import accept **options and filter on them.
     it("where filters by options subset match", () => {
       const errors = new Errors({});
-      errors.add("age", "too_short", { count: 3 });
-      errors.add("age", "too_short", { count: 5 });
-      expect(errors.where("age", "too_short", { count: 3 })).toHaveLength(1);
-      expect(errors.where("age", "too_short", { count: 7 })).toHaveLength(0);
+      errors.add("age", ":too_short", { count: 3 });
+      errors.add("age", ":too_short", { count: 5 });
+      expect(errors.where("age", ":too_short", { count: 3 })).toHaveLength(1);
+      expect(errors.where("age", ":too_short", { count: 7 })).toHaveLength(0);
     });
 
     it("delete filters by options subset match", () => {
       const errors = new Errors({});
-      errors.add("age", "too_short", { count: 3 });
-      errors.add("age", "too_short", { count: 5 });
-      const removed = errors.delete("age", "too_short", { count: 3 });
+      errors.add("age", ":too_short", { count: 3 });
+      errors.add("age", ":too_short", { count: 5 });
+      const removed = errors.delete("age", ":too_short", { count: 3 });
       expect(removed).toHaveLength(1);
       expect(errors.count).toBe(1);
       expect(errors.objects[0].options.count).toBe(5);
@@ -723,34 +723,34 @@ describe("ErrorsTest", () => {
     it("added? distinguishes between option values", () => {
       // Rails behavior: different option values are different errors.
       const errors = new Errors({});
-      errors.add("age", "too_short", { count: 3 });
-      expect(errors.added("age", "too_short", { count: 3 })).toBe(true);
-      expect(errors.added("age", "too_short", { count: 5 })).toBe(false);
+      errors.add("age", ":too_short", { count: 3 });
+      expect(errors.added("age", ":too_short", { count: 3 })).toBe(true);
+      expect(errors.added("age", ":too_short", { count: 5 })).toBe(false);
     });
 
     it("where matches structurally-equal array options (not just by reference)", () => {
       // Rails `Array#==` is elementwise; option values like
       // `in: [1,2,3]` must match a differently-allocated `[1,2,3]`.
       const errors = new Errors({});
-      errors.add("role", "inclusion", { in: [1, 2, 3] });
-      expect(errors.where("role", "inclusion", { in: [1, 2, 3] })).toHaveLength(1);
-      expect(errors.where("role", "inclusion", { in: [1, 2] })).toHaveLength(0);
+      errors.add("role", ":inclusion", { in: [1, 2, 3] });
+      expect(errors.where("role", ":inclusion", { in: [1, 2, 3] })).toHaveLength(1);
+      expect(errors.where("role", ":inclusion", { in: [1, 2] })).toHaveLength(0);
     });
 
     it("matches RegExp option values by source + flags, not reference", () => {
       const errors = new Errors({});
-      errors.add("email", "invalid", { with: /^\w+@\w+$/i });
-      expect(errors.where("email", "invalid", { with: /^\w+@\w+$/i })).toHaveLength(1);
+      errors.add("email", ":invalid", { with: /^\w+@\w+$/i });
+      expect(errors.where("email", ":invalid", { with: /^\w+@\w+$/i })).toHaveLength(1);
       // Different source or different flags must not match.
-      expect(errors.where("email", "invalid", { with: /^\w+@\w+$/g })).toHaveLength(0);
-      expect(errors.where("email", "invalid", { with: /other/i })).toHaveLength(0);
+      expect(errors.where("email", ":invalid", { with: /^\w+@\w+$/g })).toHaveLength(0);
+      expect(errors.where("email", ":invalid", { with: /other/i })).toHaveLength(0);
     });
 
     it("added? matches structurally-equal nested object options", () => {
       const errors = new Errors({});
-      errors.add("age", "out_of_range", { range: { min: 1, max: 5 } });
-      expect(errors.added("age", "out_of_range", { range: { min: 1, max: 5 } })).toBe(true);
-      expect(errors.added("age", "out_of_range", { range: { min: 1, max: 9 } })).toBe(false);
+      errors.add("age", ":out_of_range", { range: { min: 1, max: 5 } });
+      expect(errors.added("age", ":out_of_range", { range: { min: 1, max: 5 } })).toBe(true);
+      expect(errors.added("age", ":out_of_range", { range: { min: 1, max: 9 } })).toBe(false);
     });
 
     it("import accepts :attribute and :type override (rawType stays on inner)", () => {
@@ -758,13 +758,13 @@ describe("ErrorsTest", () => {
       // @type is the override, @raw_type is inner's. Message generation
       // uses raw_type so the inner error's i18n key is still resolvable.
       const source = new Errors({});
-      source.add("name", "invalid");
+      source.add("name", ":invalid");
       const target = new Errors({});
       target.import(source.objects[0], { attribute: "title", type: "wrong" });
       const imported = target.objects[0];
       expect(imported.attribute).toBe("title");
       expect(imported.type).toBe("wrong");
-      expect(imported.rawType).toBe("invalid");
+      expect(imported.rawType).toBe(":invalid");
 
       // copy!/dupWithBase must preserve the {attribute, type, rawType} split.
       const copy = new Errors({});
@@ -772,7 +772,7 @@ describe("ErrorsTest", () => {
       const round = copy.objects[0];
       expect(round.attribute).toBe("title");
       expect(round.type).toBe("wrong");
-      expect(round.rawType).toBe("invalid");
+      expect(round.rawType).toBe(":invalid");
     });
   });
 
@@ -780,7 +780,7 @@ describe("ErrorsTest", () => {
     // Rails `deep_dup` on a NestedError recurses into `@inner_error`, so the
     // duplicated wrapper's inner error is independent of the source's.
     const source = new Errors({});
-    source.add("age", "out_of_range", { range: { min: 1 } });
+    source.add("age", ":out_of_range", { range: { min: 1 } });
     const wrapper = new Errors({});
     wrapper.mergeBang(source);
     const target = new Errors({});
@@ -801,7 +801,7 @@ describe("ErrorsTest", () => {
     const base1 = { tag: "one" };
     const base2 = { tag: "two" };
     const e1 = new Errors(base1);
-    e1.add("name", "blank");
+    e1.add("name", ":blank");
     const e2 = new Errors(base2);
     e2.copyBang(e1);
     expect(e2.objects[0].base).toBe(base2);
@@ -812,7 +812,7 @@ describe("ErrorsTest", () => {
   it("merge errors", () => {
     const e1 = new Errors(null);
     const e2 = new Errors(null);
-    e1.add("name", "blank");
+    e1.add("name", ":blank");
     e2.merge(e1);
     expect(e2.count).toBe(1);
   });
@@ -821,9 +821,9 @@ describe("ErrorsTest", () => {
     // Rails errors.rb:174-180 — `other.errors.each { import(error) }`;
     // `import` wraps as NestedError (errors.rb:160).
     const e1 = new Errors({});
-    e1.add("name", "blank");
+    e1.add("name", ":blank");
     const e2 = new Errors({});
-    e2.add("age", "invalid");
+    e2.add("age", ":invalid");
     e2.mergeBang(e1);
     expect(e2.count).toBe(2);
     const imported = e2.objects.find((e) => e.attribute === "name")!;
@@ -832,18 +832,18 @@ describe("ErrorsTest", () => {
 
   it("objects returns the backing error array", () => {
     const errors = new Errors(null);
-    errors.add("name", "blank");
+    errors.add("name", ":blank");
     expect(errors.objects).toHaveLength(1);
     expect(errors.objects[0].attribute).toBe("name");
   });
 
   it("uniq! removes duplicates with identical attribute/type/options", () => {
     const errors = new Errors({});
-    errors.add("name", "blank");
-    errors.add("name", "blank");
-    errors.add("age", "too_short", { count: 2 });
-    errors.add("age", "too_short", { count: 2 });
-    errors.add("age", "too_short", { count: 3 });
+    errors.add("name", ":blank");
+    errors.add("name", ":blank");
+    errors.add("age", ":too_short", { count: 2 });
+    errors.add("age", ":too_short", { count: 2 });
+    errors.add("age", ":too_short", { count: 3 });
     errors.uniqBang();
     expect(errors.count).toBe(3);
     expect(errors.objects.filter((e) => e.attribute === "age")).toHaveLength(2);
@@ -851,8 +851,8 @@ describe("ErrorsTest", () => {
 
   it("each when arity is negative", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    e.add("age", "not_a_number");
+    e.add("name", ":blank");
+    e.add("age", ":not_a_number");
     const collected: string[] = [];
     e.each((err) => collected.push(err.attribute));
     expect(collected).toEqual(["name", "age"]);
@@ -865,7 +865,7 @@ describe("ErrorsTest", () => {
 
   it("on() is an alias for get()", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
+    e.add("name", ":blank");
     expect(e.on("name")).toEqual(e.get("name"));
     expect(e.on("name")).toContain("can't be blank");
   });
@@ -877,7 +877,7 @@ describe("ErrorsTest", () => {
 
   it("dup duplicates details", () => {
     const errors = new Errors({});
-    errors.add("name", "blank");
+    errors.add("name", ":blank");
     const details1 = errors.details;
     const details2 = errors.details;
     expect(details1.get("name")).toEqual(details2.get("name"));
@@ -886,7 +886,7 @@ describe("ErrorsTest", () => {
 
   it("errors are marshalable", () => {
     const errors = new Errors({});
-    errors.add("name", "blank");
+    errors.add("name", ":blank");
     const json = JSON.stringify(errors.asJson());
     const parsed = JSON.parse(json);
     expect(parsed).toEqual({ name: ["can't be blank"] });
@@ -897,8 +897,8 @@ describe("ErrorsTest", () => {
     // queried without; strict_match strips CALLBACKS_OPTIONS from the
     // error's own options so they don't block the match.
     const errors = new Errors({});
-    errors.add("name", "too_long", { if: () => true });
-    expect(errors.added("name", "too_long")).toBe(true);
+    errors.add("name", ":too_long", { if: () => true });
+    expect(errors.added("name", ":too_long")).toBe(true);
   });
 
   it("added? ignores message option", () => {
@@ -906,27 +906,27 @@ describe("ErrorsTest", () => {
     // queried without; MESSAGE_OPTIONS are stripped from the error's
     // own options for strict_match purposes.
     const errors = new Errors({});
-    errors.add("name", "too_long", { message: () => "foo" } as Record<string, unknown>);
-    expect(errors.added("name", "too_long")).toBe(true);
+    errors.add("name", ":too_long", { message: () => "foo" } as Record<string, unknown>);
+    expect(errors.added("name", ":too_long")).toBe(true);
   });
 
   it("added? handles proc messages", () => {
     const errors = new Errors({});
-    errors.add("name", "blank", { message: () => "custom" } as any);
-    expect(errors.added("name", "blank")).toBe(true);
+    errors.add("name", ":blank", { message: () => "custom" } as any);
+    expect(errors.added("name", ":blank")).toBe(true);
   });
 
   it("of_kind? handles proc messages", () => {
     const errors = new Errors({});
-    errors.add("name", "blank", { message: () => "custom" } as any);
-    expect(errors.ofKind("name", "blank")).toBe(true);
+    errors.add("name", ":blank", { message: () => "custom" } as any);
+    expect(errors.ofKind("name", ":blank")).toBe(true);
   });
 
   it("of_kind? ignores options", () => {
     const errors = new Errors({});
-    errors.add("name", "blank");
-    expect(errors.ofKind("name", "blank")).toBe(true);
-    expect(errors.ofKind("name", "invalid")).toBe(false);
+    errors.add("name", ":blank");
+    expect(errors.ofKind("name", ":blank")).toBe(true);
+    expect(errors.ofKind("name", ":invalid")).toBe(false);
   });
 
   it("added? defaults message to :invalid", () => {
@@ -936,16 +936,16 @@ describe("ErrorsTest", () => {
       }
     }
     const u = new User({});
-    u.errors.add("name", "blank");
-    expect(u.errors.added("name", "blank")).toBe(true);
-    expect(u.errors.added("name", "invalid")).toBe(false);
+    u.errors.add("name", ":blank");
+    expect(u.errors.added("name", ":blank")).toBe(true);
+    expect(u.errors.added("name", ":invalid")).toBe(false);
   });
 
   it("attribute_names only returns unique attribute names", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    e.add("name", "too_short");
-    e.add("age", "invalid");
+    e.add("name", ":blank");
+    e.add("name", ":too_short");
+    e.add("age", ":invalid");
     expect(e.attributeNames).toEqual(["name", "age"]);
     // Should not have duplicates
     expect(e.attributeNames.length).toBe(2);
@@ -953,50 +953,50 @@ describe("ErrorsTest", () => {
 
   it("add, with type as symbol", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    expect(e.details.get("name")![0].error).toBe("blank");
+    e.add("name", ":blank");
+    expect(e.details.get("name")![0].error).toBe(":blank");
     expect(e.get("name")).toContain("can't be blank");
   });
 
   it("added? handles symbol message", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    expect(e.added("name", "blank")).toBe(true);
-    expect(e.added("name", "invalid")).toBe(false);
+    e.add("name", ":blank");
+    expect(e.added("name", ":blank")).toBe(true);
+    expect(e.added("name", ":invalid")).toBe(false);
   });
 
   it("added? returns false when checking for an error, but not providing message argument", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
+    e.add("name", ":blank");
     // When checking with default type "invalid", should return false since we added "blank"
     expect(e.added("name")).toBe(false);
   });
 
   it("added? returns false when checking for an error with an incorrect or missing option", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    expect(e.added("name", "too_short")).toBe(false);
-    expect(e.added("age", "blank")).toBe(false);
+    e.add("name", ":blank");
+    expect(e.added("name", ":too_short")).toBe(false);
+    expect(e.added("age", ":blank")).toBe(false);
   });
 
   it("added? returns false when checking for an error by symbol and a different error with same message is present", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
+    e.add("name", ":blank");
     // Even if the rendered message might be similar, type must match
-    expect(e.added("name", "present")).toBe(false);
+    expect(e.added("name", ":present")).toBe(false);
   });
 
   it("of_kind? handles symbol message", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    expect(e.ofKind("name", "blank")).toBe(true);
-    expect(e.ofKind("name", "invalid")).toBe(false);
+    e.add("name", ":blank");
+    expect(e.ofKind("name", ":blank")).toBe(true);
+    expect(e.ofKind("name", ":invalid")).toBe(false);
   });
 
   it("generate_message works without i18n_scope", () => {
     const e = new Errors(null);
-    expect(e.generateMessage("name", "blank")).toBe("can't be blank");
-    expect(e.generateMessage("name", "invalid")).toBe("is invalid");
+    expect(e.generateMessage("name", ":blank")).toBe("can't be blank");
+    expect(e.generateMessage("name", ":invalid")).toBe("is invalid");
   });
 
   it("full_messages doesn't require the base object to respond to `:errors", () => {
@@ -1008,7 +1008,7 @@ describe("ErrorsTest", () => {
       },
     };
     const errors = new Errors(base);
-    errors.add("name", "invalid", { message: "bar" });
+    errors.add("name", ":invalid", { message: "bar" });
     expect(errors.fullMessages).toEqual(["foo bar"]);
   });
 
@@ -1018,16 +1018,16 @@ describe("ErrorsTest", () => {
     // the collection iterable.
     it("add returns the new Error object", () => {
       const errors = new Errors({});
-      const err = errors.add("name", "blank");
+      const err = errors.add("name", ":blank");
       expect(err).toBeInstanceOf(ActiveModelError);
       expect(err.attribute).toBe("name");
-      expect(err.type).toBe("blank");
+      expect(err.type).toBe(":blank");
       expect(errors.objects[0]).toBe(err);
     });
 
     it("add with strict: true raises StrictValidationFailed", () => {
       const errors = new Errors({});
-      expect(() => errors.add("name", "blank", { strict: true })).toThrow(StrictValidationFailed);
+      expect(() => errors.add("name", ":blank", { strict: true })).toThrow(StrictValidationFailed);
       // Strict raise must NOT append the error to the collection.
       expect(errors.count).toBe(0);
     });
@@ -1035,14 +1035,14 @@ describe("ErrorsTest", () => {
     it("add with strict: CustomErrorClass raises that class", () => {
       class NameIsInvalid extends globalThis.Error {}
       const errors = new Errors({});
-      expect(() => errors.add("name", "blank", { strict: NameIsInvalid })).toThrow(NameIsInvalid);
+      expect(() => errors.add("name", ":blank", { strict: NameIsInvalid })).toThrow(NameIsInvalid);
       expect(errors.count).toBe(0);
     });
 
     it("is iterable via for..of", () => {
       const errors = new Errors({});
-      errors.add("name", "blank");
-      errors.add("age", "invalid");
+      errors.add("name", ":blank");
+      errors.add("age", ":invalid");
       const collected: string[] = [];
       for (const e of errors) {
         collected.push(e.attribute);
@@ -1052,8 +1052,8 @@ describe("ErrorsTest", () => {
 
     it("supports spread and Array.from", () => {
       const errors = new Errors({});
-      errors.add("name", "blank");
-      errors.add("age", "invalid");
+      errors.add("name", ":blank");
+      errors.add("age", ":invalid");
       expect([...errors]).toHaveLength(2);
       expect(Array.from(errors, (e) => e.attribute)).toEqual(["name", "age"]);
     });
@@ -1065,8 +1065,8 @@ describe("ErrorsTest", () => {
 
   it("delete returns array of removed errors when present", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    e.add("name", "too_short");
+    e.add("name", ":blank");
+    e.add("name", ":too_short");
     const removed = e.delete("name");
     expect(removed).not.toBeNull();
     expect(removed!.length).toBe(2);
@@ -1095,9 +1095,9 @@ describe("ErrorsTest", () => {
 
   it("details shape strips reserved option keys", () => {
     const e = new Errors(null);
-    e.add("name", "blank", { custom: "x", message: "override" });
+    e.add("name", ":blank", { custom: "x", message: "override" });
     const detail = e.details.get("name")![0];
-    expect(detail.error).toBe("blank");
+    expect(detail.error).toBe(":blank");
     expect(detail.custom).toBe("x");
     expect(detail.message).toBeUndefined();
   });
@@ -1111,7 +1111,7 @@ describe("ErrorsTest", () => {
 
   it("toHash(true) returns full messages", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
+    e.add("name", ":blank");
     const full = e.toHash(true);
     expect(full.get("name")![0]).toContain("Name");
     expect(full.get("name")![0]).toContain("can't be blank");
@@ -1119,44 +1119,44 @@ describe("ErrorsTest", () => {
 
   it("toHash() with no arg returns short messages", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
+    e.add("name", ":blank");
     const short = e.toHash();
     expect(short.get("name")![0]).toBe("can't be blank");
   });
 
   it("added returns true for exact type match", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    expect(e.added("name", "blank")).toBe(true);
+    e.add("name", ":blank");
+    expect(e.added("name", ":blank")).toBe(true);
   });
 
   it("added returns true for full message string (string branch)", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
+    e.add("name", ":blank");
     expect(e.added("name", "can't be blank")).toBe(true);
   });
 
   it("added returns false for nonexistent type or message", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
+    e.add("name", ":blank");
     expect(e.added("name", "nonexistent type xyz")).toBe(false);
   });
 
   it("ofKind returns true for exact type match", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
-    expect(e.ofKind("name", "blank")).toBe(true);
+    e.add("name", ":blank");
+    expect(e.ofKind("name", ":blank")).toBe(true);
   });
 
   it("ofKind returns true for full message string (string branch)", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
+    e.add("name", ":blank");
     expect(e.ofKind("name", "can't be blank")).toBe(true);
   });
 
   it("ofKind returns false for nonexistent type or message", () => {
     const e = new Errors(null);
-    e.add("name", "blank");
+    e.add("name", ":blank");
     expect(e.ofKind("name", "nonexistent type xyz")).toBe(false);
   });
 });
@@ -1182,7 +1182,7 @@ describe("Errors<TBase> type parameter", () => {
 
   it("add() message callback receives TBase | null", () => {
     const e = new Errors<User>({ name: "Alice", age: 30 });
-    e.add("name", "invalid", {
+    e.add("name", ":invalid", {
       message: (record) => {
         expectTypeOf(record).toEqualTypeOf<User | null>();
         return "bad";
@@ -1192,7 +1192,7 @@ describe("Errors<TBase> type parameter", () => {
 
   it("add() message callback receives TBase | null and options (two-arg form)", () => {
     const e = new Errors<User>({ name: "Alice", age: 30 });
-    e.add("name", "invalid", {
+    e.add("name", ":invalid", {
       message: (record, opts) => {
         expectTypeOf(record).toEqualTypeOf<User | null>();
         expectTypeOf(opts).toEqualTypeOf<Record<string, unknown>>();

--- a/packages/activemodel/src/errors.ts
+++ b/packages/activemodel/src/errors.ts
@@ -242,7 +242,9 @@ export class Errors<TBase extends object = object> {
    */
   add(
     attribute: string,
-    type: string | ((record: TBase | null, options: Record<string, unknown>) => string) = "invalid",
+    type:
+      | string
+      | ((record: TBase | null, options: Record<string, unknown>) => string) = ":invalid",
     options?: {
       message?: string | ((record: TBase | null, options: Record<string, unknown>) => string);
     } & Record<string, unknown>,
@@ -265,12 +267,13 @@ export class Errors<TBase extends object = object> {
    * Returns `true` if an error with this exact attribute/type/options has
    * been added. Mirrors Rails `Errors#added?`
    * (activemodel/lib/active_model/errors.rb:372-388) Symbol-vs-String dispatch:
-   * if `type` looks like an i18n key (no spaces → Symbol-like), use strict match;
-   * otherwise treat it as a full message string and check `messagesFor`.
+   * a Ruby Symbol reaches us as a colon-prefixed string, so `":blank"` takes the
+   * strict-match branch and a bare String is a full message checked against
+   * `messagesFor`.
    */
-  added(attribute: string, type: string = "invalid", options?: Record<string, unknown>): boolean {
-    if (!type.includes(" ")) {
-      // Symbol-like branch: strict attribute/type/options match.
+  added(attribute: string, type: string = ":invalid", options?: Record<string, unknown>): boolean {
+    if (type.startsWith(":")) {
+      // Symbol branch: strict attribute/type/options match.
       return this._errors.some((e) => e.strictMatch(attribute, type, options));
     }
     // String branch: full-message lookup (Rails else clause in added?).
@@ -279,16 +282,16 @@ export class Errors<TBase extends object = object> {
 
   /**
    * Returns `true` if an error of the given type exists on `attribute`.
-   * Mirrors Rails `errors.rb:395-403` Symbol-vs-String dispatch:
-   * if `type` looks like an i18n key (no spaces → Symbol-like), use `where`;
-   * otherwise treat it as a full message string and check `messagesFor`.
+   * Mirrors Rails `errors.rb:395-403` Symbol-vs-String dispatch: a Ruby Symbol
+   * reaches us as a colon-prefixed string, so `":blank"` goes through `where`
+   * and a bare String is a full message checked against `messagesFor`.
    */
   ofKind(attribute: string, type?: string): boolean {
     if (type === undefined) {
       return this._errors.some((e) => e.attribute === attribute);
     }
-    if (!type.includes(" ")) {
-      // Symbol-like: check for errors of this exact type.
+    if (type.startsWith(":")) {
+      // Symbol branch: check for errors of this exact type.
       return this.where(attribute, type).length > 0;
     }
     // String branch: full-message lookup (Rails else clause).
@@ -313,7 +316,7 @@ export class Errors<TBase extends object = object> {
 
   generateMessage(
     attribute: string,
-    type: string = "invalid",
+    type: string = ":invalid",
     options?: Record<string, unknown>,
   ): string {
     return ActiveModelError.generateMessage(attribute, type, this._base, options);

--- a/packages/activemodel/src/secure-password.test.ts
+++ b/packages/activemodel/src/secure-password.test.ts
@@ -442,7 +442,7 @@ describe("SecurePasswordTest", () => {
     const u = new User({ name: "test" });
     (u as any).password = "a".repeat(73);
     await u.isValid();
-    expect(u.errors.where("password", "password_too_long").length).toBeGreaterThan(0);
+    expect(u.errors.where("password", ":password_too_long").length).toBeGreaterThan(0);
   });
 
   it("password too long resolves to locale entry", async () => {

--- a/packages/activemodel/src/secure-password.ts
+++ b/packages/activemodel/src/secure-password.ts
@@ -141,12 +141,12 @@ export function hasSecurePassword(
       const digest = record.readAttribute(digestAttr);
 
       if (isBlank(digest) && (pwd === undefined || pwd === null)) {
-        record.errors.add(attribute, "blank");
+        record.errors.add(attribute, ":blank");
       }
 
       if (pwd !== null && pwd !== undefined) {
         if (textEncoder.encode(pwd).length > 72) {
-          record.errors.add(attribute, "password_too_long", { count: 72 });
+          record.errors.add(attribute, ":password_too_long", { count: 72 });
         }
 
         const humanAttr = modelClass.humanAttributeName
@@ -154,7 +154,7 @@ export function hasSecurePassword(
           : humanize(attribute);
         const confirmation = record.readAttribute(confirmationAttr);
         if (confirmation !== undefined && confirmation !== null && pwd !== confirmation) {
-          record.errors.add(attribute, "confirmation", { attribute: humanAttr });
+          record.errors.add(attribute, ":confirmation", { attribute: humanAttr });
         }
       }
 
@@ -165,7 +165,7 @@ export function hasSecurePassword(
         // Error fires when digestWas is blank OR doesn't match challenge.
         const digestWas = record.attributeWas(digestAttr) as string | null | undefined;
         if (!digestWas || !bcrypt.compareSync(challenge, digestWas)) {
-          record.errors.add(challengeAttr, "invalid");
+          record.errors.add(challengeAttr, ":invalid");
         }
       }
     });

--- a/packages/activemodel/src/validations.test.ts
+++ b/packages/activemodel/src/validations.test.ts
@@ -420,7 +420,7 @@ describe("ValidationsTest", () => {
     class Person extends Model {
       static {
         this.validate((record: any) => {
-          record.errors.add("base", "invalid", { message: "Model is invalid" });
+          record.errors.add("base", ":invalid", { message: "Model is invalid" });
         });
       }
     }
@@ -447,7 +447,7 @@ describe("ValidationsTest", () => {
         this.attribute("discount", "integer");
         this.validatesEach(["price", "discount"], (record, attr, value) => {
           if (typeof value === "number" && value < 0) {
-            record.errors.add(attr, "invalid", { message: "must be non-negative" });
+            record.errors.add(attr, ":invalid", { message: "must be non-negative" });
           }
         });
       }
@@ -463,7 +463,7 @@ describe("ValidationsTest", () => {
         this.attribute("name", "string");
         this.validate((record: any) => {
           if (record.readAttribute("name") === "INVALID") {
-            record.errors.add("name", "invalid");
+            record.errors.add("name", ":invalid");
           }
         });
       }
@@ -478,7 +478,7 @@ describe("ValidationsTest", () => {
         this.attribute("name", "string");
         this.validate(function (record: any) {
           if (!record.readAttribute("name")) {
-            record.errors.add("name", "blank");
+            record.errors.add("name", ":blank");
           }
         });
       }
@@ -640,7 +640,7 @@ describe("ValidationsTest", () => {
       static {
         this.attribute("name", "string");
         this.validate((record: any) => {
-          record.errors.add("base", "invalid", { message: "Model is invalid" });
+          record.errors.add("base", ":invalid", { message: "Model is invalid" });
         });
       }
     }
@@ -747,18 +747,14 @@ describe("ValidationsTest", () => {
         return this.data[attribute];
       }
     }
-    // Rails' case passes the literal "gotcha" (validations_test.rb:113); trails
-    // has no Symbol type, so `Error#message` promotes identifier-shaped Strings
-    // to an i18n type (error.ts `IDENTIFIER_RE`) — a multi-word literal stays a
-    // literal, which is what this case is actually about.
     Person.validatesEach(["name"], (record, attr, value) => {
-      if (!value) record.errors.add(attr, "is gotcha");
+      if (!value) record.errors.add(attr, "gotcha");
     });
     const p = new Person({ name: "ignored" });
     p.data = { name: "" };
     await p.isValid();
     // The empty value comes from `data`, proving the override drove the read.
-    expect(p.errors.get("name")).toContain("is gotcha");
+    expect(p.errors.get("name")).toContain("gotcha");
   });
 
   it("validates an undeclared getter via the send default", async () => {
@@ -773,14 +769,14 @@ describe("ValidationsTest", () => {
       }
     }
     Person.validatesEach(["fullName"], (record, attr, value) => {
-      if (!value) record.errors.add(attr, "is gotcha");
+      if (!value) record.errors.add(attr, "gotcha");
     });
     const present = new Person({ first: "Al" });
     await present.isValid();
-    expect(present.errors.get("fullName")).not.toContain("is gotcha");
+    expect(present.errors.get("fullName")).not.toContain("gotcha");
     const blank = new Person({ first: "" });
     await blank.isValid();
-    expect(blank.errors.get("fullName")).toContain("is gotcha");
+    expect(blank.errors.get("fullName")).toContain("gotcha");
   });
 
   it("read_attribute_for_validation returns undefined for a present reader that returns undefined", () => {
@@ -939,7 +935,7 @@ describe("ValidationsTest", () => {
         this.attribute("name", "string");
         this.validate(function (record: any) {
           if (record.readAttribute("name") === "invalid") {
-            record.errors.add("name", "invalid", { message: "is not allowed" });
+            record.errors.add("name", ":invalid", { message: "is not allowed" });
           }
         });
       }
@@ -1030,7 +1026,7 @@ describe("ValidationsTest", () => {
       }
     }
     Topic.validate((t: any) => {
-      if (!t.readAttribute("title")) t.errors.add("title", "blank");
+      if (!t.readAttribute("title")) t.errors.add("title", ":blank");
     });
     const topic = new Topic({});
     expect(topic.errors.empty).toBe(true);
@@ -1423,7 +1419,7 @@ describe("validatesEach", () => {
         this.attribute("discount", "integer");
         this.validatesEach(["price", "discount"], (record, attr, value) => {
           if (typeof value === "number" && value < 0) {
-            record.errors.add(attr, "invalid", { message: "must be non-negative" });
+            record.errors.add(attr, ":invalid", { message: "must be non-negative" });
           }
         });
       }
@@ -1450,7 +1446,7 @@ describe("validatesEach", () => {
           ["price", "discount"],
           (record, attr, value) => {
             if (typeof value === "number" && value < 0) {
-              record.errors.add(attr, "invalid", { message: "must be non-negative" });
+              record.errors.add(attr, ":invalid", { message: "must be non-negative" });
             }
           },
           {
@@ -1474,7 +1470,7 @@ describe("validatesWith", () => {
       validate(record: any) {
         const val = record.readAttribute("count");
         if (typeof val === "number" && val % 2 !== 0) {
-          record.errors.add("count", "invalid", { message: "must be even" });
+          record.errors.add("count", ":invalid", { message: "must be even" });
         }
       }
     }
@@ -1503,7 +1499,7 @@ describe("validatesWith", () => {
       validate(record: any) {
         const val = record.readAttribute("score");
         if (typeof val === "number" && val < this.threshold) {
-          record.errors.add("score", "invalid", {
+          record.errors.add("score", ":invalid", {
             message: `must be at least ${this.threshold}`,
           });
         }
@@ -1528,7 +1524,7 @@ describe("validatesWith", () => {
   it("supports conditional options", async () => {
     class AlwaysInvalidValidator {
       validate(record: any) {
-        record.errors.add("base", "invalid", { message: "always invalid" });
+        record.errors.add("base", ":invalid", { message: "always invalid" });
       }
     }
 
@@ -1935,7 +1931,7 @@ describe("Validations", () => {
           this.validate(function (record: any) {
             const val = record.readAttribute("value");
             if (val !== null && (val as number) % 2 !== 0) {
-              record.errors.add("value", "even", { message: "must be even" });
+              record.errors.add("value", ":even", { message: "must be even" });
             }
           });
         }
@@ -1976,7 +1972,7 @@ describe("Validations", () => {
     class Base extends Model {
       static {
         this.validate((record: any) => {
-          record.errors.add("base", "invalid", { message: "is broken" });
+          record.errors.add("base", ":invalid", { message: "is broken" });
         });
       }
     }
@@ -2060,8 +2056,8 @@ describe("errors.ofKind()", () => {
     }
     const u = new User({});
     await u.isValid();
-    expect(u.errors.ofKind("name", "blank")).toBe(true);
-    expect(u.errors.ofKind("name", "invalid")).toBe(false);
+    expect(u.errors.ofKind("name", ":blank")).toBe(true);
+    expect(u.errors.ofKind("name", ":invalid")).toBe(false);
     // Without a type arg, ofKind checks for any error on the attribute.
     expect(u.errors.ofKind("name")).toBe(true);
     expect(u.errors.ofKind("other")).toBe(false);
@@ -2150,9 +2146,9 @@ describe("Errors enhancements", () => {
       }
     }
     const u = new User({});
-    u.errors.add("name", "blank");
-    u.errors.add("name", "too_short");
-    u.errors.add("email", "blank");
+    u.errors.add("name", ":blank");
+    u.errors.add("name", ":too_short");
+    u.errors.add("email", ":blank");
     const removed = u.errors.delete("name");
     expect(removed!.length).toBe(2);
     expect(u.errors.count).toBe(1);
@@ -2165,9 +2161,9 @@ describe("Errors enhancements", () => {
       }
     }
     const u = new User({});
-    u.errors.add("name", "blank");
-    u.errors.add("name", "too_short");
-    const removed = u.errors.delete("name", "blank");
+    u.errors.add("name", ":blank");
+    u.errors.add("name", ":too_short");
+    const removed = u.errors.delete("name", ":blank");
     expect(removed!.length).toBe(1);
     expect(u.errors.count).toBe(1);
   });
@@ -2179,11 +2175,11 @@ describe("Errors enhancements", () => {
       }
     }
     const u = new User({});
-    u.errors.add("name", "blank");
-    u.errors.add("email", "invalid");
+    u.errors.add("name", ":blank");
+    u.errors.add("email", ":invalid");
     const collected: string[] = [];
     u.errors.each((e) => collected.push(`${e.attribute}:${e.type}`));
-    expect(collected).toEqual(["name:blank", "email:invalid"]);
+    expect(collected).toEqual(["name::blank", "email::invalid"]);
   });
 
   it("merge errors", () => {
@@ -2194,7 +2190,7 @@ describe("Errors enhancements", () => {
     }
     const u1 = new User({});
     const u2 = new User({});
-    u1.errors.add("name", "blank");
+    u1.errors.add("name", ":blank");
     u2.errors.merge(u1.errors);
     expect(u2.errors.count).toBe(1);
     expect(u2.errors.get("name")).toEqual(["can't be blank"]);
@@ -2208,9 +2204,9 @@ describe("Errors enhancements", () => {
       }
     }
     const u = new User({});
-    u.errors.add("name", "blank");
-    u.errors.add("name", "too_short");
-    u.errors.add("email", "invalid");
+    u.errors.add("name", ":blank");
+    u.errors.add("name", ":too_short");
+    u.errors.add("email", ":invalid");
     const hash = u.errors.toHash();
     expect(hash.get("name")!.length).toBe(2);
     expect(hash.get("email")!.length).toBe(1);
@@ -2223,7 +2219,7 @@ describe("Errors enhancements", () => {
       }
     }
     const u = new User({});
-    u.errors.add("name", "blank");
+    u.errors.add("name", ":blank");
     expect(u.errors.include("name")).toBe(true);
     expect(u.errors.include("email")).toBe(false);
   });
@@ -2235,7 +2231,7 @@ describe("Errors enhancements", () => {
       }
     }
     const u = new User({});
-    u.errors.add("name", "blank");
+    u.errors.add("name", ":blank");
     expect(u.errors.messages.get("name")).toEqual(["can't be blank"]);
   });
 
@@ -2461,8 +2457,8 @@ describe("Errors#generateMessage", () => {
       }
     }
     const u = new User({});
-    expect(u.errors.generateMessage("name", "blank")).toBe("can't be blank");
-    expect(u.errors.generateMessage("name", "invalid")).toBe("is invalid");
+    expect(u.errors.generateMessage("name", ":blank")).toBe("can't be blank");
+    expect(u.errors.generateMessage("name", ":invalid")).toBe("is invalid");
   });
 
   it("substitutes options into message", () => {
@@ -2473,7 +2469,7 @@ describe("Errors#generateMessage", () => {
       }
     }
     const u = new User({});
-    expect(u.errors.generateMessage("age", "greater_than", { count: 0 })).toBe(
+    expect(u.errors.generateMessage("age", ":greater_than", { count: 0 })).toBe(
       "must be greater than 0",
     );
   });

--- a/packages/activemodel/src/validations/absence.ts
+++ b/packages/activemodel/src/validations/absence.ts
@@ -36,7 +36,7 @@ export interface HelperMethods {
 export class AbsenceValidator extends EachValidator {
   validateEach(record: ValidatableRecord, attribute: string, value: unknown): void {
     if (!isBlank(value)) {
-      record.errors.add(attribute, "present", this.filteredErrorOptions());
+      record.errors.add(attribute, ":present", this.filteredErrorOptions());
     }
   }
 }

--- a/packages/activemodel/src/validations/acceptance.ts
+++ b/packages/activemodel/src/validations/acceptance.ts
@@ -102,7 +102,7 @@ export class AcceptanceValidator extends EachValidator {
     const allowNil = this.options.allowNil ?? true;
     if (allowNil && (value === null || value === undefined)) return;
     if (!this.isAcceptableOption(value)) {
-      record.errors.add(attribute, "accepted", this.filteredErrorOptions(["accept", "allowNil"]));
+      record.errors.add(attribute, ":accepted", this.filteredErrorOptions(["accept", "allowNil"]));
     }
   }
 

--- a/packages/activemodel/src/validations/comparison.ts
+++ b/packages/activemodel/src/validations/comparison.ts
@@ -18,12 +18,12 @@ const COMPARE_OPS = {
 } satisfies Record<CompareKey, (cmp: number) => boolean>;
 
 const COMPARE_KEYS_TO_RAILS = {
-  greaterThan: "greater_than",
-  greaterThanOrEqualTo: "greater_than_or_equal_to",
-  equalTo: "equal_to",
-  lessThan: "less_than",
-  lessThanOrEqualTo: "less_than_or_equal_to",
-  otherThan: "other_than",
+  greaterThan: ":greater_than",
+  greaterThanOrEqualTo: ":greater_than_or_equal_to",
+  equalTo: ":equal_to",
+  lessThan: ":less_than",
+  lessThanOrEqualTo: ":less_than_or_equal_to",
+  otherThan: ":other_than",
 } satisfies Record<CompareKey, string>;
 
 export class ComparisonValidator extends EachValidator {
@@ -37,7 +37,7 @@ export class ComparisonValidator extends EachValidator {
       const optionValue = this.resolveValue(record, raw);
 
       if (value === null || value === undefined || (typeof value === "string" && isBlank(value))) {
-        record.errors.add(attribute, "blank", this.errorOptions(value, optionValue));
+        record.errors.add(attribute, ":blank", this.errorOptions(value, optionValue));
         return;
       }
 

--- a/packages/activemodel/src/validations/confirmation.ts
+++ b/packages/activemodel/src/validations/confirmation.ts
@@ -43,7 +43,7 @@ export class ConfirmationValidator extends EachValidator {
       const humanAttr = modelClass?.humanAttributeName
         ? modelClass.humanAttributeName(attribute)
         : humanize(attribute);
-      record.errors.add(confirmationAttr, "confirmation", {
+      record.errors.add(confirmationAttr, ":confirmation", {
         ...this.filteredErrorOptions(["caseSensitive"]),
         attribute: humanAttr,
       });

--- a/packages/activemodel/src/validations/exclusion.ts
+++ b/packages/activemodel/src/validations/exclusion.ts
@@ -41,7 +41,7 @@ export class ExclusionValidator extends EachValidator {
 
   validateEach(record: ValidatableRecord, attribute: string, value: unknown): void {
     if (this.isInclude(record, value)) {
-      record.errors.add(attribute, "exclusion", exceptInWithinMergeValue(this.options, value));
+      record.errors.add(attribute, ":exclusion", exceptInWithinMergeValue(this.options, value));
     }
   }
 

--- a/packages/activemodel/src/validations/format.ts
+++ b/packages/activemodel/src/validations/format.ts
@@ -87,7 +87,7 @@ export function recordError(
     if (key !== name) rest[key] = this.options[key];
   }
   rest.value = value;
-  record.errors.add(attribute, "invalid", rest);
+  record.errors.add(attribute, ":invalid", rest);
 }
 
 /**

--- a/packages/activemodel/src/validations/i18n-generate-message-validation.test.ts
+++ b/packages/activemodel/src/validations/i18n-generate-message-validation.test.ts
@@ -17,13 +17,13 @@ describe("I18nGenerateMessageValidationTest", () => {
 
   it("generate message inclusion with default message", () => {
     const p = new Person({ name: "z" });
-    const msg = p.errors.generateMessage("name", "inclusion");
+    const msg = p.errors.generateMessage("name", ":inclusion");
     expect(msg).toBe("is not included in the list");
   });
 
   it("generate message inclusion with custom message", () => {
     const p = new Person({ name: "z" });
-    const msg = p.errors.generateMessage("name", "inclusion", {
+    const msg = p.errors.generateMessage("name", ":inclusion", {
       message: "custom inclusion",
     });
     expect(msg).toBe("custom inclusion");
@@ -31,13 +31,13 @@ describe("I18nGenerateMessageValidationTest", () => {
 
   it("generate message exclusion with default message", () => {
     const p = new Person({ name: "admin" });
-    const msg = p.errors.generateMessage("name", "exclusion");
+    const msg = p.errors.generateMessage("name", ":exclusion");
     expect(msg).toBe("is reserved");
   });
 
   it("generate message exclusion with custom message", () => {
     const p = new Person({ name: "admin" });
-    const msg = p.errors.generateMessage("name", "exclusion", {
+    const msg = p.errors.generateMessage("name", ":exclusion", {
       message: "custom exclusion",
     });
     expect(msg).toBe("custom exclusion");
@@ -45,25 +45,25 @@ describe("I18nGenerateMessageValidationTest", () => {
 
   it("generate message invalid with default message", () => {
     const p = new Person({ name: "test" });
-    const msg = p.errors.generateMessage("name", "invalid");
+    const msg = p.errors.generateMessage("name", ":invalid");
     expect(msg).toBe("is invalid");
   });
 
   it("generate message invalid with custom message", () => {
     const p = new Person({ name: "test" });
-    const msg = p.errors.generateMessage("name", "invalid", { message: "custom invalid" });
+    const msg = p.errors.generateMessage("name", ":invalid", { message: "custom invalid" });
     expect(msg).toBe("custom invalid");
   });
 
   it("generate message confirmation with default message", () => {
     const p = new Person({ title: "Mr" });
-    const msg = p.errors.generateMessage("title", "confirmation", { attribute: "Title" });
+    const msg = p.errors.generateMessage("title", ":confirmation", { attribute: "Title" });
     expect(msg).toBe("doesn't match Title");
   });
 
   it("generate message confirmation with custom message", () => {
     const p = new Person({ title: "Mr" });
-    const msg = p.errors.generateMessage("title", "confirmation", {
+    const msg = p.errors.generateMessage("title", ":confirmation", {
       message: "custom confirmation",
     });
     expect(msg).toBe("custom confirmation");
@@ -71,55 +71,55 @@ describe("I18nGenerateMessageValidationTest", () => {
 
   it("generate message accepted with default message", () => {
     const p = new Person({});
-    const msg = p.errors.generateMessage("name", "accepted");
+    const msg = p.errors.generateMessage("name", ":accepted");
     expect(msg).toBe("must be accepted");
   });
 
   it("generate message accepted with custom message", () => {
     const p = new Person({});
-    const msg = p.errors.generateMessage("name", "accepted", { message: "custom accepted" });
+    const msg = p.errors.generateMessage("name", ":accepted", { message: "custom accepted" });
     expect(msg).toBe("custom accepted");
   });
 
   it("generate message empty with default message", () => {
     const p = new Person({});
-    const msg = p.errors.generateMessage("name", "empty");
+    const msg = p.errors.generateMessage("name", ":empty");
     expect(msg).toBe("can't be empty");
   });
 
   it("generate message empty with custom message", () => {
     const p = new Person({});
-    const msg = p.errors.generateMessage("name", "empty", { message: "custom empty" });
+    const msg = p.errors.generateMessage("name", ":empty", { message: "custom empty" });
     expect(msg).toBe("custom empty");
   });
 
   it("generate message blank with default message", () => {
     const p = new Person({ name: "" });
-    const msg = p.errors.generateMessage("name", "blank");
+    const msg = p.errors.generateMessage("name", ":blank");
     expect(msg).toBe("can't be blank");
   });
 
   it("generate message blank with custom message", () => {
     const p = new Person({ name: "" });
-    const msg = p.errors.generateMessage("name", "blank", { message: "custom blank" });
+    const msg = p.errors.generateMessage("name", ":blank", { message: "custom blank" });
     expect(msg).toBe("custom blank");
   });
 
   it("generate message too long with default message plural", () => {
     const p = new Person({ name: "abcdefghijk" });
-    const msg = p.errors.generateMessage("name", "too_long", { count: 10 });
+    const msg = p.errors.generateMessage("name", ":too_long", { count: 10 });
     expect(msg).toBe("is too long (maximum is 10 characters)");
   });
 
   it("generate message too long with default message singular", () => {
     const p = new Person({ name: "ab" });
-    const msg = p.errors.generateMessage("name", "too_long", { count: 1 });
+    const msg = p.errors.generateMessage("name", ":too_long", { count: 1 });
     expect(msg).toBe("is too long (maximum is 1 character)");
   });
 
   it("generate message too long with custom message", () => {
     const p = new Person({ name: "abcdefghijk" });
-    const msg = p.errors.generateMessage("name", "too_long", {
+    const msg = p.errors.generateMessage("name", ":too_long", {
       message: "custom too long",
       count: 10,
     });
@@ -128,19 +128,19 @@ describe("I18nGenerateMessageValidationTest", () => {
 
   it("generate message too short with default message plural", () => {
     const p = new Person({ name: "ab" });
-    const msg = p.errors.generateMessage("name", "too_short", { count: 3 });
+    const msg = p.errors.generateMessage("name", ":too_short", { count: 3 });
     expect(msg).toBe("is too short (minimum is 3 characters)");
   });
 
   it("generate message too short with default message singular", () => {
     const p = new Person({ name: "" });
-    const msg = p.errors.generateMessage("name", "too_short", { count: 1 });
+    const msg = p.errors.generateMessage("name", ":too_short", { count: 1 });
     expect(msg).toBe("is too short (minimum is 1 character)");
   });
 
   it("generate message too short with custom message", () => {
     const p = new Person({ name: "ab" });
-    const msg = p.errors.generateMessage("name", "too_short", {
+    const msg = p.errors.generateMessage("name", ":too_short", {
       message: "custom too short",
       count: 3,
     });
@@ -149,19 +149,19 @@ describe("I18nGenerateMessageValidationTest", () => {
 
   it("generate message wrong length with default message plural", () => {
     const p = new Person({ name: "abc" });
-    const msg = p.errors.generateMessage("name", "wrong_length", { count: 5 });
+    const msg = p.errors.generateMessage("name", ":wrong_length", { count: 5 });
     expect(msg).toBe("is the wrong length (should be 5 characters)");
   });
 
   it("generate message wrong length with default message singular", () => {
     const p = new Person({ name: "ab" });
-    const msg = p.errors.generateMessage("name", "wrong_length", { count: 1 });
+    const msg = p.errors.generateMessage("name", ":wrong_length", { count: 1 });
     expect(msg).toBe("is the wrong length (should be 1 character)");
   });
 
   it("generate message wrong length with custom message", () => {
     const p = new Person({ name: "abc" });
-    const msg = p.errors.generateMessage("name", "wrong_length", {
+    const msg = p.errors.generateMessage("name", ":wrong_length", {
       message: "custom wrong length",
       count: 5,
     });
@@ -170,13 +170,13 @@ describe("I18nGenerateMessageValidationTest", () => {
 
   it("generate message not a number with default message", () => {
     const p = new Person({ name: "abc" });
-    const msg = p.errors.generateMessage("name", "not_a_number");
+    const msg = p.errors.generateMessage("name", ":not_a_number");
     expect(msg).toBe("is not a number");
   });
 
   it("generate message not a number with custom message", () => {
     const p = new Person({ name: "abc" });
-    const msg = p.errors.generateMessage("name", "not_a_number", {
+    const msg = p.errors.generateMessage("name", ":not_a_number", {
       message: "custom not a number",
     });
     expect(msg).toBe("custom not a number");
@@ -184,43 +184,43 @@ describe("I18nGenerateMessageValidationTest", () => {
 
   it("generate message greater than with default message", () => {
     const p = new Person({ age: 5 });
-    const msg = p.errors.generateMessage("age", "greater_than", { count: 10 });
+    const msg = p.errors.generateMessage("age", ":greater_than", { count: 10 });
     expect(msg).toBe("must be greater than 10");
   });
 
   it("generate message greater than or equal to with default message", () => {
     const p = new Person({ age: 5 });
-    const msg = p.errors.generateMessage("age", "greater_than_or_equal_to", { count: 10 });
+    const msg = p.errors.generateMessage("age", ":greater_than_or_equal_to", { count: 10 });
     expect(msg).toBe("must be greater than or equal to 10");
   });
 
   it("generate message equal to with default message", () => {
     const p = new Person({ age: 5 });
-    const msg = p.errors.generateMessage("age", "equal_to", { count: 10 });
+    const msg = p.errors.generateMessage("age", ":equal_to", { count: 10 });
     expect(msg).toBe("must be equal to 10");
   });
 
   it("generate message less than with default message", () => {
     const p = new Person({ age: 15 });
-    const msg = p.errors.generateMessage("age", "less_than", { count: 10 });
+    const msg = p.errors.generateMessage("age", ":less_than", { count: 10 });
     expect(msg).toBe("must be less than 10");
   });
 
   it("generate message less than or equal to with default message", () => {
     const p = new Person({ age: 15 });
-    const msg = p.errors.generateMessage("age", "less_than_or_equal_to", { count: 10 });
+    const msg = p.errors.generateMessage("age", ":less_than_or_equal_to", { count: 10 });
     expect(msg).toBe("must be less than or equal to 10");
   });
 
   it("generate message odd with default message", () => {
     const p = new Person({ age: 4 });
-    const msg = p.errors.generateMessage("age", "odd");
+    const msg = p.errors.generateMessage("age", ":odd");
     expect(msg).toBe("must be odd");
   });
 
   it("generate message even with default message", () => {
     const p = new Person({ age: 3 });
-    const msg = p.errors.generateMessage("age", "even");
+    const msg = p.errors.generateMessage("age", ":even");
     expect(msg).toBe("must be even");
   });
 });

--- a/packages/activemodel/src/validations/i18n-validation.test.ts
+++ b/packages/activemodel/src/validations/i18n-validation.test.ts
@@ -26,7 +26,7 @@ describe("I18nValidationTest", () => {
       }
     }
     const p = new Person({});
-    p.errors.add("name", "blank");
+    p.errors.add("name", ":blank");
     const msg = p.errors.fullMessages[0];
     expect(typeof msg).toBe("string");
     expect(msg).toBe("Name can't be blank");
@@ -48,20 +48,18 @@ describe("I18nValidationTest", () => {
       }
     }
     const p = new Person({});
-    p.errors.add("name", "blank");
+    p.errors.add("name", ":blank");
     expect(p.errors.fullMessages).toContain("Person Name can't be blank");
   });
 
   it("errors full messages uses format", () => {
     // Rails clears `I18n.load_path` in setup (i18n_validation_test.rb:12) so the
     // framework `en.yml` cannot overwrite the stored `errors.format`; the
-    // teardown above restores it. Only this case collides with the file data,
-    // and `errors.messages.empty` is stored back because the trails deviation
-    // below resolves through the backend.
+    // teardown above restores it.
     I18n.loadPath().length = 0;
     I18n.setBackend(new I18n.Simple());
     I18n.backend().storeTranslations("en", {
-      errors: { format: "Field %{attribute} %{message}", messages: { empty: "can't be empty" } },
+      errors: { format: "Field %{attribute} %{message}" },
     });
     class Person extends Model {
       static {
@@ -70,12 +68,7 @@ describe("I18nValidationTest", () => {
     }
     const p = new Person({});
     p.errors.add("name", "empty");
-    // Rails asserts ["Field Name empty"]: `add(:name, "empty")` passes a String,
-    // which stays a literal message. Trails has no Symbol type, so `Error#message`
-    // promotes identifier-shaped Strings to a type (error.ts `IDENTIFIER_RE`) and
-    // "empty" resolves through `errors.messages.empty`. The format under test —
-    // `errors.format` — is asserted either way.
-    expect(p.errors.fullMessages).toEqual(["Field Name can't be empty"]);
+    expect(p.errors.fullMessages).toEqual(["Field Name empty"]);
   });
 
   it("errors full messages doesnt use attribute format without config", () => {
@@ -85,7 +78,7 @@ describe("I18nValidationTest", () => {
       }
     }
     const p = new Person({});
-    p.errors.add("name", "blank");
+    p.errors.add("name", ":blank");
     expect(p.errors.fullMessages).toContain("Name can't be blank");
   });
 
@@ -96,7 +89,7 @@ describe("I18nValidationTest", () => {
       }
     }
     const p = new Person({});
-    p.errors.add("name", "blank");
+    p.errors.add("name", ":blank");
     expect(p.errors.fullMessagesFor("name")).toContain("Name can't be blank");
   });
 
@@ -197,7 +190,7 @@ describe("I18nValidationTest", () => {
       }
     }
     const p = new Person({});
-    p.errors.add("name", "blank");
+    p.errors.add("name", ":blank");
     expect(p.errors.fullMessages[0]).toMatch(/Name/);
   });
 
@@ -208,7 +201,7 @@ describe("I18nValidationTest", () => {
       }
     }
     const p = new Person({});
-    p.errors.add("name", "blank");
+    p.errors.add("name", ":blank");
     expect(p.errors.fullMessages.length).toBe(1);
   });
 
@@ -228,7 +221,7 @@ describe("I18nValidationTest", () => {
       }
     }
     const p = new Person({});
-    p.errors.add("name", "blank");
+    p.errors.add("name", ":blank");
     expect(p.errors.fullMessages).toContain("Custom Name can't be blank");
   });
 
@@ -239,7 +232,7 @@ describe("I18nValidationTest", () => {
       }
     }
     const p = new Person({});
-    p.errors.add("name", "blank");
+    p.errors.add("name", ":blank");
     expect(p.errors.fullMessages).toContain("Name can't be blank");
   });
 
@@ -250,7 +243,7 @@ describe("I18nValidationTest", () => {
       }
     }
     const p = new Person({});
-    p.errors.add("first_name", "blank");
+    p.errors.add("first_name", ":blank");
     expect(p.errors.fullMessages).toContain("First name can't be blank");
   });
 
@@ -517,7 +510,7 @@ describe("I18nValidationTest", () => {
       }
     }
     const p = new Person({});
-    p.errors.add("name", "custom_blank");
+    p.errors.add("name", ":custom_blank");
     expect(p.errors.get("name")).toContain("must not be empty");
   });
 

--- a/packages/activemodel/src/validations/inclusion.ts
+++ b/packages/activemodel/src/validations/inclusion.ts
@@ -42,7 +42,7 @@ export class InclusionValidator extends EachValidator {
 
   validateEach(record: ValidatableRecord, attribute: string, value: unknown): void {
     if (!this.isInclude(record, value)) {
-      record.errors.add(attribute, "inclusion", exceptInWithinMergeValue(this.options, value));
+      record.errors.add(attribute, ":inclusion", exceptInWithinMergeValue(this.options, value));
     }
   }
 

--- a/packages/activemodel/src/validations/length.ts
+++ b/packages/activemodel/src/validations/length.ts
@@ -129,7 +129,7 @@ export class LengthValidator extends EachValidator {
         const opts = { ...baseOptions, count: min } as Record<string, unknown>;
         const defaultMsg = this.options.tooShort ?? this.options.message;
         if (defaultMsg != null && !opts["message"]) opts["message"] = defaultMsg;
-        record.errors.add(attribute, "too_short", opts);
+        record.errors.add(attribute, ":too_short", opts);
       }
     }
     if (max !== undefined && length > max) {
@@ -137,7 +137,7 @@ export class LengthValidator extends EachValidator {
         const opts = { ...baseOptions, count: max } as Record<string, unknown>;
         const defaultMsg = this.options.tooLong ?? this.options.message;
         if (defaultMsg != null && !opts["message"]) opts["message"] = defaultMsg;
-        record.errors.add(attribute, "too_long", opts);
+        record.errors.add(attribute, ":too_long", opts);
       }
     }
     if (is !== undefined && length !== is) {
@@ -145,7 +145,7 @@ export class LengthValidator extends EachValidator {
         const opts = { ...baseOptions, count: is } as Record<string, unknown>;
         const defaultMsg = this.options.wrongLength ?? this.options.message;
         if (defaultMsg != null && !opts["message"]) opts["message"] = defaultMsg;
-        record.errors.add(attribute, "wrong_length", opts);
+        record.errors.add(attribute, ":wrong_length", opts);
       }
     }
   }

--- a/packages/activemodel/src/validations/numericality-validation.test.ts
+++ b/packages/activemodel/src/validations/numericality-validation.test.ts
@@ -662,7 +662,7 @@ describe("numericality with in: range", () => {
     const stubRecord = { errors: errs };
     v.validateEach(stubRecord, "x", { not: "a number" });
     expect(errs.get("x")).toHaveLength(1);
-    expect(errs.where("x", "not_a_number")).toHaveLength(1);
+    expect(errs.where("x", ":not_a_number")).toHaveLength(1);
   });
 
   it("validates against the raw before-type-cast value (prepareValueForValidation)", async () => {

--- a/packages/activemodel/src/validations/numericality.ts
+++ b/packages/activemodel/src/validations/numericality.ts
@@ -60,7 +60,7 @@ export class NumericalityValidator extends EachValidator {
     // EachValidator#validate) is always :not_a_number. The default is to reject
     // nil — matching `test_default_validates_numericality_of`.
     if (value === null || value === undefined) {
-      record.errors.add(attribute, "not_a_number", this.filteredOptions(value));
+      record.errors.add(attribute, ":not_a_number", this.filteredOptions(value));
       return;
     }
     // A cast/raw decimal is a BigDecimal (Numeric in Rails — Kernel.Float
@@ -70,7 +70,7 @@ export class NumericalityValidator extends EachValidator {
     if (this.options.allowBlank && isBlank(value)) return;
 
     if (!this.isNumber(value, precision, scale)) {
-      record.errors.add(attribute, "not_a_number", this.filteredOptions(value));
+      record.errors.add(attribute, ":not_a_number", this.filteredOptions(value));
       return;
     }
 
@@ -80,7 +80,7 @@ export class NumericalityValidator extends EachValidator {
     // raw options[:only_integer] read, so a Proc / method-name option
     // is honored per-record.
     if (this.isAllowOnlyInteger(record) && !this.isInteger(value)) {
-      record.errors.add(attribute, "not_an_integer", this.filteredOptions(value));
+      record.errors.add(attribute, ":not_an_integer", this.filteredOptions(value));
       return;
     }
 
@@ -100,7 +100,7 @@ export class NumericalityValidator extends EachValidator {
       scale,
     );
     if (gt !== undefined && !(num > gt)) {
-      record.errors.add(attribute, "greater_than", withCount(gt));
+      record.errors.add(attribute, ":greater_than", withCount(gt));
     }
     const gte = this.resolveNumeric(
       this.options.greaterThanOrEqualTo as NumericValue | undefined,
@@ -109,7 +109,7 @@ export class NumericalityValidator extends EachValidator {
       scale,
     );
     if (gte !== undefined && !(num >= gte)) {
-      record.errors.add(attribute, "greater_than_or_equal_to", withCount(gte));
+      record.errors.add(attribute, ":greater_than_or_equal_to", withCount(gte));
     }
     const lt = this.resolveNumeric(
       this.options.lessThan as NumericValue | undefined,
@@ -118,7 +118,7 @@ export class NumericalityValidator extends EachValidator {
       scale,
     );
     if (lt !== undefined && !(num < lt)) {
-      record.errors.add(attribute, "less_than", withCount(lt));
+      record.errors.add(attribute, ":less_than", withCount(lt));
     }
     const lte = this.resolveNumeric(
       this.options.lessThanOrEqualTo as NumericValue | undefined,
@@ -127,7 +127,7 @@ export class NumericalityValidator extends EachValidator {
       scale,
     );
     if (lte !== undefined && !(num <= lte)) {
-      record.errors.add(attribute, "less_than_or_equal_to", withCount(lte));
+      record.errors.add(attribute, ":less_than_or_equal_to", withCount(lte));
     }
     const eq = this.resolveNumeric(
       this.options.equalTo as NumericValue | undefined,
@@ -136,7 +136,7 @@ export class NumericalityValidator extends EachValidator {
       scale,
     );
     if (eq !== undefined && num !== eq) {
-      record.errors.add(attribute, "equal_to", withCount(eq));
+      record.errors.add(attribute, ":equal_to", withCount(eq));
     }
     const ot = this.resolveNumeric(
       this.options.otherThan as NumericValue | undefined,
@@ -145,19 +145,19 @@ export class NumericalityValidator extends EachValidator {
       scale,
     );
     if (ot !== undefined && num === ot) {
-      record.errors.add(attribute, "other_than", withCount(ot));
+      record.errors.add(attribute, ":other_than", withCount(ot));
     }
     if (this.options.in !== undefined) {
       const [min, max] = this.options.in as [number, number];
       if (num < min || num > max) {
-        record.errors.add(attribute, "in", withCount(`${min}..${max}`));
+        record.errors.add(attribute, ":in", withCount(`${min}..${max}`));
       }
     }
     if (this.options.odd && Math.trunc(num) % 2 === 0) {
-      record.errors.add(attribute, "odd", this.filteredOptions(value));
+      record.errors.add(attribute, ":odd", this.filteredOptions(value));
     }
     if (this.options.even && Math.trunc(num) % 2 !== 0) {
-      record.errors.add(attribute, "even", this.filteredOptions(value));
+      record.errors.add(attribute, ":even", this.filteredOptions(value));
     }
   }
 

--- a/packages/activemodel/src/validations/presence.ts
+++ b/packages/activemodel/src/validations/presence.ts
@@ -5,7 +5,7 @@ import { isBlank } from "@blazetrails/activesupport";
 export class PresenceValidator extends EachValidator {
   validateEach(record: ValidatableRecord, attribute: string, value: unknown): void {
     if (isBlank(value)) {
-      record.errors.add(attribute, "blank", this.filteredErrorOptions());
+      record.errors.add(attribute, ":blank", this.filteredErrorOptions());
     }
   }
 }

--- a/packages/activemodel/src/validations/validates.test.ts
+++ b/packages/activemodel/src/validations/validates.test.ts
@@ -174,7 +174,7 @@ describe("ValidatesTest", () => {
     class MyValidator {
       validate(record: any) {
         if (!record.readAttribute("name")) {
-          record.errors.add("name", "blank", { message: "must be present" });
+          record.errors.add("name", ":blank", { message: "must be present" });
         }
       }
     }
@@ -194,7 +194,7 @@ describe("ValidatesTest", () => {
       NameValidator: class {
         validate(record: any) {
           if (!record.readAttribute("name")) {
-            record.errors.add("name", "blank", { message: "is required" });
+            record.errors.add("name", ":blank", { message: "is required" });
           }
         }
       },
@@ -275,7 +275,7 @@ describe("ValidatesTest", () => {
       validate(record: any) {
         const val = record.readAttribute("name");
         if (typeof val === "string" && val.length < this.min) {
-          record.errors.add("name", "too_short", { message: "is too short" });
+          record.errors.add("name", ":too_short", { message: "is too short" });
         }
       }
     }

--- a/packages/activemodel/src/validations/with-validation.test.ts
+++ b/packages/activemodel/src/validations/with-validation.test.ts
@@ -12,7 +12,7 @@ describe("ValidatesWithTest", () => {
       validate(record: any) {
         const name = record.readAttribute("name");
         if (typeof name === "string" && name.length < this.minLength) {
-          record.errors.add("name", "invalid", { message: "too short" });
+          record.errors.add("name", ":invalid", { message: "too short" });
         }
       }
     }
@@ -32,14 +32,14 @@ describe("ValidatesWithTest", () => {
     class V1 {
       validate(record: any) {
         if (!record.readAttribute("name")) {
-          record.errors.add("name", "blank");
+          record.errors.add("name", ":blank");
         }
       }
     }
     class V2 {
       validate(record: any) {
         if (!record.readAttribute("age")) {
-          record.errors.add("age", "blank");
+          record.errors.add("age", ":blank");
         }
       }
     }
@@ -60,7 +60,7 @@ describe("ValidatesWithTest", () => {
     class CustomValidator {
       validate(record: any) {
         if (!record.readAttribute("name")) {
-          record.errors.add("name", "blank");
+          record.errors.add("name", ":blank");
         }
       }
     }
@@ -118,7 +118,7 @@ describe("ValidatesWithTest", () => {
       }
     }
     Person.validatesEach(["name"], (record, attr, value) => {
-      if (!value) record.errors.add(attr, "blank");
+      if (!value) record.errors.add(attr, ":blank");
     });
     const p = new Person({});
     await p.isValid();
@@ -132,7 +132,7 @@ describe("ValidatesWithTest", () => {
       }
     }
     Person.validatesEach(["name"], (record, attr, value) => {
-      if (!value) record.errors.add(attr, "blank");
+      if (!value) record.errors.add(attr, ":blank");
     });
     const p = new Person({});
     await p.isValid();
@@ -147,7 +147,7 @@ describe("ValidatesWithTest", () => {
     }
     Person.validatesEach(["name"], (record, attr, value) => {
       if (value !== null && value !== undefined && !value) {
-        record.errors.add(attr, "blank");
+        record.errors.add(attr, ":blank");
       }
     });
     const p = new Person({});
@@ -167,7 +167,7 @@ describe("ValidatesWithTest", () => {
         return; // skip blank
       }
       if (value === null || value === undefined) return;
-      record.errors.add(attr, "invalid");
+      record.errors.add(attr, ":invalid");
     });
     const p = new Person({ name: "  " });
     await p.isValid();
@@ -181,7 +181,7 @@ describe("ValidatesWithTest", () => {
       }
       customValidation() {
         if (!this.readAttribute("name")) {
-          this.errors.add("name", "blank");
+          this.errors.add("name", ":blank");
         }
       }
     }
@@ -198,7 +198,7 @@ describe("ValidatesWithTest", () => {
       }
       checkName() {
         if (!this.readAttribute("name")) {
-          this.errors.add("name", "blank");
+          this.errors.add("name", ":blank");
         }
       }
     }
@@ -217,7 +217,7 @@ describe("ValidatesWithTest", () => {
     }
     Person.validatesEach(["name", "age"], (record, attr, value) => {
       if (value === null || value === undefined) {
-        record.errors.add(attr, "blank");
+        record.errors.add(attr, ":blank");
       }
     });
     const p = new Person({});
@@ -232,7 +232,7 @@ describe("ValidatesWithTest", () => {
       validate(record: any) {
         const val = record.readAttribute("name");
         if (!val || val === "") {
-          record.errors.add("name", "blank");
+          record.errors.add("name", ":blank");
         }
       }
     }
@@ -272,7 +272,7 @@ describe("ValidatesWithTest", () => {
       validate(record: any) {
         const val = record.readAttribute("name");
         if (typeof val === "string" && val.length < this.min) {
-          record.errors.add("name", "too_short");
+          record.errors.add("name", ":too_short");
         }
       }
     }

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.trails.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.trails.test.ts
@@ -67,8 +67,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     });
 
     it("statementLimit = 0 disables named prepared statements", async () => {
-      // statement_limit is read from the config hash, so a limit of 0 needs its
-      // own adapter rather than a mid-session mutation of the leased one.
       const adapter = new Mysql2Adapter({ uri: MYSQL_TEST_URL, statementLimit: 0 });
       await adapter.beginDbTransaction();
       try {
@@ -136,15 +134,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     });
 
     // Self-built by construction: these assert what the constructor rejects.
-    it("rejects invalid statementLimit at construction time", () => {
-      expect(() => new Mysql2Adapter({ uri: MYSQL_TEST_URL, statementLimit: -1 })).toThrow(
-        RangeError,
-      );
-      expect(() => new Mysql2Adapter({ uri: MYSQL_TEST_URL, statementLimit: 1.5 })).toThrow(
-        RangeError,
-      );
-    });
-
     it("rejects non-boolean preparedStatements at construction time and via assignment", async () => {
       // Mirror coverage to PG's statement-pool tests — without an
       // explicit guard test the runtime TypeError could regress

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.trails.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.trails.test.ts
@@ -16,22 +16,19 @@ import {
 describeIfMysqlAdapter("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
   let originalPreparedStatements: boolean;
-  let originalStatementLimit: number;
   beforeEach(async () => {
     adapter = await leaseMysqlAdapter();
     originalPreparedStatements = adapter.preparedStatements;
-    originalStatementLimit = adapter.statementLimit;
     adapter.disconnectBang();
     adapter.preparedStatements = true;
   });
   afterEach(() => {
-    // preparedStatements/statementLimit are adapter-wide settings and the
-    // statement pool itself is per-connection state, both of which now outlive
-    // a single test on the shared leased connection. Restore the settings and
-    // drop the pool (disconnectBang is reconnectable — the next query
-    // re-establishes) so each test starts from the clean slate it asserts on.
+    // preparedStatements is an adapter-wide setting and the statement pool
+    // itself is per-connection state, both of which now outlive a single test
+    // on the shared leased connection. Restore the setting and drop the pool
+    // (disconnectBang is reconnectable — the next query re-establishes) so each
+    // test starts from the clean slate it asserts on.
     adapter.preparedStatements = originalPreparedStatements;
-    adapter.statementLimit = originalStatementLimit;
     adapter.disconnectBang();
   });
 
@@ -69,22 +66,10 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       }
     });
 
-    it("statementLimit config resizes the active pool", async () => {
-      await adapter.beginDbTransaction();
-      try {
-        await adapter.execute("SELECT ? AS n", [1]);
-        await adapter.execute("SELECT ? AS s", ["a"]);
-        const pool = adapter._statementPoolForTest()!;
-        expect(pool.length).toBe(2);
-        adapter.statementLimit = 1;
-        expect(pool.length).toBe(1);
-      } finally {
-        await adapter.rollback();
-      }
-    });
-
     it("statementLimit = 0 disables named prepared statements", async () => {
-      adapter.statementLimit = 0;
+      // statement_limit is read from the config hash, so a limit of 0 needs its
+      // own adapter rather than a mid-session mutation of the leased one.
+      const adapter = new Mysql2Adapter({ uri: MYSQL_TEST_URL, statementLimit: 0 });
       await adapter.beginDbTransaction();
       try {
         // Query still runs — just via `conn.query` (text protocol)
@@ -97,6 +82,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
         expect(adapter._statementPoolForTest()).toBeUndefined();
       } finally {
         await adapter.rollback();
+        await adapter.close();
       }
     });
 
@@ -134,7 +120,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       // Stays self-built: reading a differently configured statementLimit off
       // the config hash is the assertion.
       const configured = new Mysql2Adapter({ uri: MYSQL_TEST_URL, statementLimit: 7 });
-      expect(configured.statementLimit).toBe(7);
+      expect(configured.buildStatementPool().maxSize).toBe(7);
       await configured.close();
     });
 

--- a/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
@@ -47,20 +47,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       }
     });
 
-    it("statementLimit config resizes the active pool", async () => {
-      await adapter.beginDbTransaction();
-      try {
-        await adapter.execute("SELECT $1::int", [1]);
-        await adapter.execute("SELECT $1::text", ["a"]);
-        const pool = adapter._statementPoolForTest()!;
-        expect(pool.length).toBe(2);
-        adapter.statementLimit = 1;
-        expect(pool.length).toBe(1);
-      } finally {
-        await adapter.rollback();
-      }
-    });
-
     it("executeMutation caches the plan for INSERT (reuses on repeat)", async () => {
       await adapter.exec(
         `CREATE TABLE IF NOT EXISTS "sp_exec_mut" ("id" SERIAL PRIMARY KEY, "name" TEXT)`,
@@ -144,7 +130,8 @@ describeIfPg("PostgreSQLAdapter", () => {
         connectionString: PG_TEST_URL,
         statementLimit: 7,
       });
-      expect(configured.statementLimit).toBe(7);
+      await configured.execute("SELECT $1::int", [1]);
+      expect(configured._statementPoolForTest()!.maxSize).toBe(7);
       await configured.close();
     });
 

--- a/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
@@ -144,15 +144,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       await configured.close();
     });
 
-    it("rejects invalid statementLimit at construction time", () => {
-      expect(
-        () => new PostgreSQLAdapter({ connectionString: PG_TEST_URL, statementLimit: -1 }),
-      ).toThrow(RangeError);
-      expect(
-        () => new PostgreSQLAdapter({ connectionString: PG_TEST_URL, statementLimit: 1.5 }),
-      ).toThrow(RangeError);
-    });
-
     it("rejects non-boolean preparedStatements at construction time and via assignment", async () => {
       // Construction-time validation routes preparedStatements through
       // the setter, so a non-boolean (string, number, etc.) hits the

--- a/packages/activerecord/src/adapters/sqlite3/statement-pool.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/statement-pool.trails.test.ts
@@ -23,7 +23,7 @@ describeIfSqlite("SQLite3StatementPoolTest", () => {
 
   it("reads statementLimit from the options hash", () => {
     const adapter = track(new BetterSQLite3Adapter(":memory:", { statementLimit: 7 }));
-    expect(adapter.statementLimit).toBe(7);
+    expect(adapter.buildStatementPool().maxSize).toBe(7);
   });
 
   it("reads preparedStatements from the options hash", () => {

--- a/packages/activerecord/src/adapters/sqlite3/statement-pool.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/statement-pool.trails.test.ts
@@ -31,11 +31,6 @@ describeIfSqlite("SQLite3StatementPoolTest", () => {
     expect(adapter.preparedStatements).toBe(false);
   });
 
-  it("rejects invalid statementLimit at construction time", () => {
-    expect(() => new BetterSQLite3Adapter(":memory:", { statementLimit: -1 })).toThrow(RangeError);
-    expect(() => new BetterSQLite3Adapter(":memory:", { statementLimit: 1.5 })).toThrow(RangeError);
-  });
-
   it("rejects non-boolean preparedStatements at construction time and via assignment", () => {
     expect(
       () =>

--- a/packages/activerecord/src/associations/belongs-to-associations.test.ts
+++ b/packages/activerecord/src/associations/belongs-to-associations.test.ts
@@ -429,7 +429,7 @@ describe("BelongsToAssociationsTest", () => {
       }
       const account = new TempModel({});
       expect(await account.isValid()).toBe(false);
-      expect((account as any).errors.details.get("company")).toEqual([{ error: "blank" }]);
+      expect((account as any).errors.details.get("company")).toEqual([{ error: ":blank" }]);
     } finally {
       (Base as any).belongsToRequiredByDefault = prev;
     }
@@ -450,7 +450,7 @@ describe("BelongsToAssociationsTest", () => {
       }
       const account = new TempModel({});
       expect(await account.isValid()).toBe(false);
-      expect((account as any).errors.details.get("company")).toEqual([{ error: "blank" }]);
+      expect((account as any).errors.details.get("company")).toEqual([{ error: ":blank" }]);
     } finally {
       (Base as any).belongsToRequiredByDefault = prev;
     }
@@ -1855,7 +1855,7 @@ describe("BelongsToAssociationsTest", () => {
 
     expect(await (author as any).loadBelongsTo("authorAddress")).toBeNull();
     expect(await author.isValid()).toBe(false);
-    expect(author.errors.details.get("authorAddress")).toEqual([{ error: "blank" }]);
+    expect(author.errors.details.get("authorAddress")).toEqual([{ error: ":blank" }]);
   });
 
   it("polymorphic with custom primary key", async () => {

--- a/packages/activerecord/src/associations/builder/belongs-to.ts
+++ b/packages/activerecord/src/associations/builder/belongs-to.ts
@@ -414,7 +414,7 @@ export class BelongsTo extends SingularAssociation {
             target = await record.association(name).loadTarget();
           }
           if (target == null) {
-            record.errors.add(name, "blank", { message: ":required" });
+            record.errors.add(name, ":blank", { message: ":required" });
           }
         },
         { if: (record: any) => railsRuns(record) && foreignKeyPresent(record) },

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -96,9 +96,7 @@ export class HasManyAssociation extends CollectionAssociation {
             humanAttributeName(attr: string): string;
           };
           const record = ctor.humanAttributeName(this.reflection.name).toLowerCase();
-          owner.errors.add("base", ":invalid", {
-            message: `Cannot delete record because dependent ${record} exist`,
-          });
+          owner.errors.add("base", ":restrict_dependent_destroy.has_many", { record });
           return false;
         }
         break;

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -96,7 +96,7 @@ export class HasManyAssociation extends CollectionAssociation {
             humanAttributeName(attr: string): string;
           };
           const record = ctor.humanAttributeName(this.reflection.name).toLowerCase();
-          owner.errors.add("base", "invalid", {
+          owner.errors.add("base", ":invalid", {
             message: `Cannot delete record because dependent ${record} exist`,
           });
           return false;

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -211,9 +211,7 @@ export class HasOneAssociation extends SingularAssociation {
             humanAttributeName(attr: string): string;
           };
           const record = ctor.humanAttributeName(this.reflection.name).toLowerCase();
-          owner.errors.add("base", ":invalid", {
-            message: `Cannot delete record because a dependent ${record} exists`,
-          });
+          owner.errors.add("base", ":restrict_dependent_destroy.has_one", { record });
           return false;
         }
         break;

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -211,7 +211,7 @@ export class HasOneAssociation extends SingularAssociation {
             humanAttributeName(attr: string): string;
           };
           const record = ctor.humanAttributeName(this.reflection.name).toLowerCase();
-          owner.errors.add("base", "invalid", {
+          owner.errors.add("base", ":invalid", {
             message: `Cannot delete record because a dependent ${record} exists`,
           });
           return false;

--- a/packages/activerecord/src/associations/nested-error.test.ts
+++ b/packages/activerecord/src/associations/nested-error.test.ts
@@ -32,7 +32,7 @@ describe("AssociationsNestedErrorInAssociationOrderTest", () => {
     expect(error).toBeInstanceOf(NestedError);
     expect(error.innerError).toBe(peg2.errors.objects[0]);
     expect(error.attribute).toBe("tuningPegs[1].pitch");
-    expect(error.type).toBe("not_a_number");
+    expect(error.type).toBe(":not_a_number");
     expect(error.message).toBe("is not a number");
     expect(error.base).toBe(guitar);
   });
@@ -73,7 +73,7 @@ describe("AssociationsNestedErrorInNestedAttributesOrderTest", () => {
     expect(error).toBeInstanceOf(NestedError);
     expect(error.innerError).toBe(peg2.errors.objects[0]);
     expect(error.attribute).toBe("tuningPegs[0].pitch");
-    expect(error.type).toBe("not_a_number");
+    expect(error.type).toBe(":not_a_number");
     expect(error.message).toBe("is not a number");
     expect(error.base).toBe(guitar);
   });
@@ -92,7 +92,7 @@ describe("AssociationsNestedErrorInNestedAttributesOrderTest", () => {
 
     expect(error).toBeInstanceOf(NestedError);
     expect(error.attribute).toBe("tuningPegs[1].pitch");
-    expect(error.type).toBe("not_a_number");
+    expect(error.type).toBe(":not_a_number");
     expect(error.message).toBe("is not a number");
     expect(error.base).toBe(guitar);
   });
@@ -139,7 +139,7 @@ describe("AssociationsNestedErrorInNestedAttributesOrderTest", () => {
         // trails' associated-validation path wraps a duplicated inner error.
         expect(error.innerError).toStrictEqual(pet.errors.objects[0]);
         expect(error.attribute).toBe("pet.name");
-        expect(error.type).toBe("blank");
+        expect(error.type).toBe(":blank");
         expect(error.message).toBe("can't be blank");
         expect(error.base).toBe(owner);
       } finally {

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -254,12 +254,16 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
 
   protected _mariadb = false;
   protected _databaseVersion: Version | null = null;
-  // Rails reads `@config[:statement_limit]` inline when it builds the
-  // StatementPool (abstract_mysql_adapter.rb:975) and never exposes it.
-  // trails' constructors destructure the adapter-level database.yml keys out
-  // of the config hash, so the value is held here for `buildStatementPool`
-  // and, in Mysql2Adapter, `_getStmtPool` / `_shouldPrepare`.
-  /** @internal */
+  /**
+   * `database.yml`'s `statement_limit`, which Rails reads as
+   * `@config[:statement_limit]` inline at StatementPool construction
+   * (abstract_mysql_adapter.rb:975) and never exposes. trails' constructors
+   * destructure the adapter-level keys out of the config hash, so the value is
+   * held here — read by `buildStatementPool` and, in Mysql2Adapter, by
+   * `_getStmtPool` / `_shouldPrepare`.
+   *
+   * @internal
+   */
   protected _statementLimit = 1000;
 
   get adapterName(): AdapterName {

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -254,49 +254,13 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
 
   protected _mariadb = false;
   protected _databaseVersion: Version | null = null;
-  // Rails' `statement_limit` database.yml key — max prepared
-  // statements cached per session before LRU eviction (default 1000).
-  // Mirrors the same surface we expose on PostgreSQLAdapter; driver-
-  // specific subclasses (Mysql2Adapter) decide how to actually wire
-  // the per-connection pool.
+  // Rails reads `@config[:statement_limit]` inline when it builds the
+  // StatementPool (abstract_mysql_adapter.rb:975) and never exposes it.
+  // trails' constructors destructure the adapter-level database.yml keys out
+  // of the config hash, so the value is held here for `buildStatementPool`
+  // and, in Mysql2Adapter, `_getStmtPool` / `_shouldPrepare`.
+  /** @internal */
   protected _statementLimit = 1000;
-
-  /**
-   * Maximum prepared statements cached per MySQL connection.
-   *
-   * Mirrors: `database.yml`'s `statement_limit` — read by Rails as
-   * `config[:statement_limit]` in AbstractMysqlAdapter#initialize.
-   *
-   * @noRailsEquivalent CONVERGEABLE (story: retire-public-statement-limit-accessor).
-   * `statement_limit` is a `database.yml` config key Rails reads as
-   *   `config[:statement_limit]` in
-   *   each adapter's `initialize` (abstract_mysql_adapter.rb, postgresql_adapter.rb,
-   *   sqlite3_adapter.rb) — a config option, never a Ruby `def`, so there is nothing for the
-   *   extractor to match. trails exposes the same setting as a validated accessor on the adapter,
-   *   identically on all three.
-   */
-  get statementLimit(): number {
-    return this._statementLimit;
-  }
-
-  set statementLimit(value: number) {
-    if (!Number.isInteger(value) || value < 0) {
-      throw new RangeError(
-        `statementLimit must be a finite non-negative integer; got ${String(value)}`,
-      );
-    }
-    this._statementLimit = value;
-    // Driver-specific subclasses override this to resize their active
-    // per-connection pool. Base impl is a no-op.
-    this._onStatementLimitChanged(value);
-  }
-
-  /**
-   * Hook for driver-specific subclasses to propagate a statementLimit
-   * change to the currently-held connection's StatementPool, if any.
-   * Base impl intentionally does nothing.
-   */
-  protected _onStatementLimitChanged(_value: number): void {}
 
   get adapterName(): AdapterName {
     return "mysql";
@@ -1998,7 +1962,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   /** @internal */
   buildStatementPool(): StatementPool {
     return new StatementPool(
-      AbstractMysqlAdapter.typeCastConfigToInteger(this.statementLimit) as number,
+      AbstractMysqlAdapter.typeCastConfigToInteger(this._statementLimit) as number,
     );
   }
 

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -256,10 +256,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     this._databaseTimezone = ActiveRecord.defaultTimezone;
   }
 
-  protected override _onStatementLimitChanged(value: number): void {
-    this._statementPool?.setMaxSize(value);
-  }
-
   /**
    * Mirrors `Mysql2Adapter#translate_exception`. Promotes a driver-level
    * read-timeout (a node-mysql2 error with no MySQL errno) to
@@ -466,7 +462,14 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       _fakeConnection: fake,
       ...mysqlConfig
     } = config as mysql.PoolOptions & MysqlAdapterOptions;
-    if (statementLimit !== undefined) this.statementLimit = statementLimit;
+    if (statementLimit !== undefined) {
+      if (!Number.isInteger(statementLimit) || statementLimit < 0) {
+        throw new RangeError(
+          `statementLimit must be a finite non-negative integer; got ${String(statementLimit)}`,
+        );
+      }
+      this._statementLimit = statementLimit;
+    }
     if (preparedStatements !== undefined) this.preparedStatements = preparedStatements;
     if (advisoryLocks !== undefined) {
       this._advisoryLocksEnabled = Mysql2Adapter.typeCastConfigToBoolean(advisoryLocks) !== false;

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -462,14 +462,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       _fakeConnection: fake,
       ...mysqlConfig
     } = config as mysql.PoolOptions & MysqlAdapterOptions;
-    if (statementLimit !== undefined) {
-      if (!Number.isInteger(statementLimit) || statementLimit < 0) {
-        throw new RangeError(
-          `statementLimit must be a finite non-negative integer; got ${String(statementLimit)}`,
-        );
-      }
-      this._statementLimit = statementLimit;
-    }
+    if (statementLimit !== undefined) this._statementLimit = statementLimit;
     if (preparedStatements !== undefined) this.preparedStatements = preparedStatements;
     if (advisoryLocks !== undefined) {
       this._advisoryLocksEnabled = Mysql2Adapter.typeCastConfigToBoolean(advisoryLocks) !== false;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -500,12 +500,16 @@ export class PostgreSQLAdapter
     message?: string;
     code?: string;
   }> = [];
-  // Rails reads `@config[:statement_limit]` inline when it builds the
-  // StatementPool (postgresql_adapter.rb:1056) and never exposes it. trails'
-  // constructor destructures the adapter-level database.yml keys out of the
-  // config hash, so the value is held here for `buildStatementPool` and
-  // `_shouldPrepare`'s pool-limit check.
-  /** @internal */
+  /**
+   * `database.yml`'s `statement_limit`, which Rails reads as
+   * `@config[:statement_limit]` inline at StatementPool construction
+   * (postgresql_adapter.rb:1056) and never exposes. trails' constructor
+   * destructures the adapter-level keys out of the config hash, so the value is
+   * held here — read by `buildStatementPool` and `_shouldPrepare`'s pool-limit
+   * check.
+   *
+   * @internal
+   */
   private _statementLimit = 1000;
 
   constructor(config: string | (pg.PoolConfig & PostgreSQLAdapterOptions));
@@ -616,14 +620,7 @@ export class PostgreSQLAdapter
       variables,
       ...pgConfig
     } = config as pg.PoolConfig & PostgreSQLAdapterOptions;
-    if (statementLimit !== undefined) {
-      if (!Number.isInteger(statementLimit) || statementLimit < 0) {
-        throw new RangeError(
-          `statementLimit must be a finite non-negative integer; got ${String(statementLimit)}`,
-        );
-      }
-      this._statementLimit = statementLimit;
-    }
+    if (statementLimit !== undefined) this._statementLimit = statementLimit;
     if (preparedStatements !== undefined) this.preparedStatements = preparedStatements;
     if (advisoryLocks !== undefined) {
       this._advisoryLocksEnabled =

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -500,41 +500,13 @@ export class PostgreSQLAdapter
     message?: string;
     code?: string;
   }> = [];
-  // Rails' `statement_limit` database.yml key — max prepared
-  // statements cached per session before LRU eviction (default 1000).
+  // Rails reads `@config[:statement_limit]` inline when it builds the
+  // StatementPool (postgresql_adapter.rb:1056) and never exposes it. trails'
+  // constructor destructures the adapter-level database.yml keys out of the
+  // config hash, so the value is held here for `buildStatementPool` and
+  // `_shouldPrepare`'s pool-limit check.
+  /** @internal */
   private _statementLimit = 1000;
-
-  /**
-   * Maximum prepared statements cached per connection.
-   *
-   * Mirrors: `database.yml`'s `statement_limit` — read by Rails as
-   * `config[:statement_limit]` in PostgreSQLAdapter#initialize.
-   *
-   * @noRailsEquivalent CONVERGEABLE (story: retire-public-statement-limit-accessor).
-   * `statement_limit` is a `database.yml` config key Rails reads as
-   *   `config[:statement_limit]` in
-   *   each adapter's `initialize` (abstract_mysql_adapter.rb, postgresql_adapter.rb,
-   *   sqlite3_adapter.rb) — a config option, never a Ruby `def`, so there is nothing for the
-   *   extractor to match. trails exposes the same setting as a validated accessor on the adapter,
-   *   identically on all three.
-   */
-  get statementLimit(): number {
-    return this._statementLimit;
-  }
-
-  set statementLimit(value: number) {
-    if (!Number.isInteger(value) || value < 0) {
-      throw new RangeError(
-        `statementLimit must be a finite non-negative integer; got ${String(value)}`,
-      );
-    }
-    this._statementLimit = value;
-    // Resize the single StatementPool immediately so a mid-session
-    // change is visible. Rails reads `statement_limit` once at pool
-    // construction; we mirror that for new pools and propagate setter
-    // changes to the live pool.
-    this._statementPool?.setMaxSize(value);
-  }
 
   constructor(config: string | (pg.PoolConfig & PostgreSQLAdapterOptions));
   /**
@@ -644,7 +616,14 @@ export class PostgreSQLAdapter
       variables,
       ...pgConfig
     } = config as pg.PoolConfig & PostgreSQLAdapterOptions;
-    if (statementLimit !== undefined) this.statementLimit = statementLimit;
+    if (statementLimit !== undefined) {
+      if (!Number.isInteger(statementLimit) || statementLimit < 0) {
+        throw new RangeError(
+          `statementLimit must be a finite non-negative integer; got ${String(statementLimit)}`,
+        );
+      }
+      this._statementLimit = statementLimit;
+    }
     if (preparedStatements !== undefined) this.preparedStatements = preparedStatements;
     if (advisoryLocks !== undefined) {
       this._advisoryLocksEnabled =

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.hash-constructor.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.hash-constructor.test.ts
@@ -43,7 +43,7 @@ describe("SQLite3Adapter hash-only constructor", () => {
   it("threads adapter options from the config hash", () => {
     adapter = new BetterSQLite3Adapter({ database: ":memory:", strict: true, statementLimit: 7 });
     expect(adapter._strictStrings).toBe(true);
-    expect(adapter.statementLimit).toBe(7);
+    expect(adapter.buildStatementPool().maxSize).toBe(7);
   });
 
   it("raises ArgumentError when the config hash has no database", () => {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -314,12 +314,16 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   private _nativeTypeMap: TypeMap;
   private _memoryDatabase: boolean;
   private _filename: string;
-  // Rails reads `@config[:statement_limit]` inline when it builds the
-  // StatementPool (sqlite3_adapter.rb:803) and never exposes it. trails'
-  // constructor destructures the adapter-level database.yml keys out of the
-  // config hash, so the value is held here for `buildStatementPool` — and must
-  // be declared before `_statementPool` so the field initializer reads it.
-  /** @internal */
+  /**
+   * `database.yml`'s `statement_limit`, which Rails reads as
+   * `@config[:statement_limit]` inline at StatementPool construction
+   * (sqlite3_adapter.rb:803) and never exposes. trails' constructor
+   * destructures the adapter-level keys out of the config hash, so the value is
+   * held here — read by `buildStatementPool`, and declared before
+   * `_statementPool` so that field's initializer sees it.
+   *
+   * @internal
+   */
   private _statementLimit = 1000;
   private _statementPool = this.buildStatementPool();
 
@@ -397,13 +401,10 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     // Apply adapter-level options FIRST so invalid values fail before
     // the native driver opens a file handle that would otherwise leak.
     if (options.statementLimit !== undefined) {
-      if (!Number.isInteger(options.statementLimit) || options.statementLimit < 0) {
-        throw new RangeError(
-          `statementLimit must be a finite non-negative integer; got ${String(options.statementLimit)}`,
-        );
-      }
       this._statementLimit = options.statementLimit;
-      this._statementPool.setMaxSize(this._statementLimit);
+      this._statementPool.setMaxSize(
+        SQLite3Adapter.typeCastConfigToInteger(this._statementLimit) as number,
+      );
     }
     this.connect();
     // Async-only drivers (e.g. expo-sqlite) can't open in a sync constructor;

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -314,8 +314,12 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   private _nativeTypeMap: TypeMap;
   private _memoryDatabase: boolean;
   private _filename: string;
-  // _statementLimit must be declared before _statementPool so buildStatementPool()
-  // reads the correct default when the field initializer runs.
+  // Rails reads `@config[:statement_limit]` inline when it builds the
+  // StatementPool (sqlite3_adapter.rb:803) and never exposes it. trails'
+  // constructor destructures the adapter-level database.yml keys out of the
+  // config hash, so the value is held here for `buildStatementPool` — and must
+  // be declared before `_statementPool` so the field initializer reads it.
+  /** @internal */
   private _statementLimit = 1000;
   private _statementPool = this.buildStatementPool();
 
@@ -340,34 +344,6 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
    */
   get _strictStrings(): boolean {
     return this._strict;
-  }
-
-  /**
-   * Maximum prepared statements cached on the single SQLite connection.
-   *
-   * Mirrors: `database.yml`'s `statement_limit` — read by Rails as
-   * `config[:statement_limit]` in `SQLite3Adapter#initialize`.
-   *
-   * @noRailsEquivalent CONVERGEABLE (story: retire-public-statement-limit-accessor).
-   * `statement_limit` is a `database.yml` config key Rails reads as
-   *   `config[:statement_limit]` in
-   *   each adapter's `initialize` (abstract_mysql_adapter.rb, postgresql_adapter.rb,
-   *   sqlite3_adapter.rb) — a config option, never a Ruby `def`, so there is nothing for the
-   *   extractor to match. trails exposes the same setting as a validated accessor on the adapter,
-   *   identically on all three.
-   */
-  get statementLimit(): number {
-    return this._statementLimit;
-  }
-
-  set statementLimit(value: number) {
-    if (!Number.isInteger(value) || value < 0) {
-      throw new RangeError(
-        `statementLimit must be a finite non-negative integer; got ${String(value)}`,
-      );
-    }
-    this._statementLimit = value;
-    this._statementPool.setMaxSize(value);
   }
 
   /**
@@ -420,7 +396,15 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     this.preparedStatements = options.preparedStatements ?? true;
     // Apply adapter-level options FIRST so invalid values fail before
     // the native driver opens a file handle that would otherwise leak.
-    if (options.statementLimit !== undefined) this.statementLimit = options.statementLimit;
+    if (options.statementLimit !== undefined) {
+      if (!Number.isInteger(options.statementLimit) || options.statementLimit < 0) {
+        throw new RangeError(
+          `statementLimit must be a finite non-negative integer; got ${String(options.statementLimit)}`,
+        );
+      }
+      this._statementLimit = options.statementLimit;
+      this._statementPool.setMaxSize(this._statementLimit);
+    }
     this.connect();
     // Async-only drivers (e.g. expo-sqlite) can't open in a sync constructor;
     // connect() flags them for the async path instead. See completeAsyncConnect.

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -908,12 +908,12 @@ describe("PersistenceTest", () => {
       }
     }
     const admin = new AdminUser();
-    admin.errors.add("token", "invalid");
+    admin.errors.add("token", ":invalid");
     const child = admin.becomes(ChildUser);
     expect(child.errors.attributeNames).toEqual(["token"]);
     let raised = false;
     try {
-      child.errors.add("foo", "invalid");
+      child.errors.add("foo", ":invalid");
     } catch {
       raised = true;
     }

--- a/packages/activerecord/src/secure-password.ts
+++ b/packages/activerecord/src/secure-password.ts
@@ -218,7 +218,7 @@ export function hasSecurePassword(
       // hashing defers to beforeSave, so we also check the in-flight raw password
       // to avoid false :blank errors before the first save.
       if (!record._readAttribute(digestAttr) && !rawPasswordNotEmpty) {
-        record.errors.add(attribute, "blank");
+        record.errors.add(attribute, ":blank");
       }
 
       // Confirmation: mirrors `validates_confirmation_of attribute, allow_blank: true`
@@ -231,7 +231,7 @@ export function hasSecurePassword(
       ) {
         // Rails keys the error to the underscored `#{attribute}_confirmation`
         // so humanAttributeName and i18n lookups work correctly.
-        record.errors.add(`${attribute}_confirmation`, "confirmation", {
+        record.errors.add(`${attribute}_confirmation`, ":confirmation", {
           attribute: attrLabel,
         });
       }
@@ -251,7 +251,7 @@ export function hasSecurePassword(
           !verifyPassword(String(challenge), digestWas)
         ) {
           // Rails keys to `#{attribute}_challenge` (snake_case) for i18n parity.
-          record.errors.add(`${attribute}_challenge`, "invalid");
+          record.errors.add(`${attribute}_challenge`, ":invalid");
         }
       }
     });

--- a/packages/activerecord/src/test-helpers/models/account.ts
+++ b/packages/activerecord/src/test-helpers/models/account.ts
@@ -60,7 +60,7 @@ export class Account extends Base {
   checkEmptyCreditLimit() {
     const v = (this as any).credit_limit;
     if (v == null || String(v).trim() === "") {
-      (this as any).errors.add("credit_limit", "blank");
+      (this as any).errors.add("credit_limit", ":blank");
     }
   }
 

--- a/packages/activerecord/src/test-helpers/models/company-in-module.ts
+++ b/packages/activerecord/src/test-helpers/models/company-in-module.ts
@@ -210,7 +210,7 @@ export class MyAppBillingAccount extends Base {
   private checkEmptyCreditLimit(): void {
     const creditCard = this.readAttribute("credit_card");
     if (creditCard == null || creditCard === "") {
-      this.errors.add("credit_card", "blank");
+      this.errors.add("credit_card", ":blank");
     }
   }
 }

--- a/packages/activerecord/src/test-helpers/models/owner.ts
+++ b/packages/activerecord/src/test-helpers/models/owner.ts
@@ -70,7 +70,7 @@ acceptsNestedAttributesFor(Owner, "pets", { allowDestroy: true });
 export class InvalidOwner extends Owner {
   static {
     this.validate(function (this: InvalidOwner) {
-      (this as any).errors.add("base", "invalid");
+      (this as any).errors.add("base", ":invalid");
     });
   }
 }

--- a/packages/activerecord/src/validations/associated.ts
+++ b/packages/activerecord/src/validations/associated.ts
@@ -45,7 +45,7 @@ export class AssociatedValidator extends EachValidator {
     }
     if (anyInvalid) {
       const { attributes: _, ...errorOpts } = this.options;
-      record.errors.add(attribute, "invalid", { ...errorOpts, value });
+      record.errors.add(attribute, ":invalid", { ...errorOpts, value });
     }
   }
 }

--- a/packages/activerecord/src/validations/i18n-generate-message-validation.test.ts
+++ b/packages/activerecord/src/validations/i18n-generate-message-validation.test.ts
@@ -53,13 +53,15 @@ describe("I18nGenerateMessageValidationTest", () => {
 
   it("generate message invalid with default message", () => {
     const topic = makeTopic();
-    expect(topic.errors.generateMessage("title", "invalid", { value: "title" })).toBe("is invalid");
+    expect(topic.errors.generateMessage("title", ":invalid", { value: "title" })).toBe(
+      "is invalid",
+    );
   });
 
   it("generate message invalid with custom message", () => {
     const topic = makeTopic();
     expect(
-      topic.errors.generateMessage("title", "invalid", {
+      topic.errors.generateMessage("title", ":invalid", {
         message: "custom message %{value}",
         value: "title",
       }),
@@ -68,7 +70,7 @@ describe("I18nGenerateMessageValidationTest", () => {
 
   it("generate message taken with default message", () => {
     const topic = makeTopic();
-    expect(topic.errors.generateMessage("title", "taken", { value: "title" })).toBe(
+    expect(topic.errors.generateMessage("title", ":taken", { value: "title" })).toBe(
       "has already been taken",
     );
   });
@@ -76,7 +78,7 @@ describe("I18nGenerateMessageValidationTest", () => {
   it("generate message taken with custom message", () => {
     const topic = makeTopic();
     expect(
-      topic.errors.generateMessage("title", "taken", {
+      topic.errors.generateMessage("title", ":taken", {
         message: "custom message %{value}",
         value: "title",
       }),
@@ -85,8 +87,8 @@ describe("I18nGenerateMessageValidationTest", () => {
 
   it("RecordInvalid exception can be localized", () => {
     const topic = makeTopic();
-    topic.errors.add("title", "invalid");
-    topic.errors.add("title", "blank");
+    topic.errors.add("title", ":invalid");
+    topic.errors.add("title", ":blank");
     expect(new RecordInvalid(topic).message).toBe(
       "Validation failed: Title is invalid, Title can't be blank",
     );
@@ -98,7 +100,7 @@ describe("I18nGenerateMessageValidationTest", () => {
         errors: { messages: { record_invalid: "fallback message" } },
       });
       const topic = makeTopic();
-      topic.errors.add("title", "blank");
+      topic.errors.add("title", ":blank");
       expect(new RecordInvalid(topic).message).toBe("fallback message");
     });
   });
@@ -109,7 +111,7 @@ describe("I18nGenerateMessageValidationTest", () => {
         errors: { attributes: { title: { taken: "Custom taken message" } } },
       });
       const topic = makeTopic();
-      expect(topic.errors.generateMessage("title", "taken", { value: "title" })).toBe(
+      expect(topic.errors.generateMessage("title", ":taken", { value: "title" })).toBe(
         "Custom taken message",
       );
     });
@@ -121,7 +123,7 @@ describe("I18nGenerateMessageValidationTest", () => {
         activerecord: { errors: { messages: { taken: "Custom taken message" } } },
       });
       const topic = makeTopic();
-      expect(topic.errors.generateMessage("title", "taken", { value: "title" })).toBe(
+      expect(topic.errors.generateMessage("title", ":taken", { value: "title" })).toBe(
         "Custom taken message",
       );
     });
@@ -133,7 +135,7 @@ describe("I18nGenerateMessageValidationTest", () => {
         activerecord: { errors: { models: { topic: { taken: "Custom taken message" } } } },
       });
       const topic = makeTopic();
-      expect(topic.errors.generateMessage("title", "taken", { value: "title" })).toBe(
+      expect(topic.errors.generateMessage("title", ":taken", { value: "title" })).toBe(
         "Custom taken message",
       );
     });
@@ -149,7 +151,7 @@ describe("I18nGenerateMessageValidationTest", () => {
         },
       });
       const topic = makeTopic();
-      expect(topic.errors.generateMessage("title", "taken", { value: "title" })).toBe(
+      expect(topic.errors.generateMessage("title", ":taken", { value: "title" })).toBe(
         "Custom taken message",
       );
     });
@@ -168,10 +170,10 @@ describe("I18nGenerateMessageValidationTest", () => {
 
       const topic = makeTopic();
       I18n.withLocale("en-US", () => {
-        expect(topic.errors.generateMessage("title", "taken", { value: "title" })).toBe(
+        expect(topic.errors.generateMessage("title", ":taken", { value: "title" })).toBe(
           "custom en message",
         );
-        expect(topic.errors.generateMessage("heading", "taken", { value: "heading" })).toBe(
+        expect(topic.errors.generateMessage("heading", ":taken", { value: "heading" })).toBe(
           "generic en-US fallback",
         );
       });

--- a/packages/activerecord/src/validations/i18n-validation.test.ts
+++ b/packages/activerecord/src/validations/i18n-validation.test.ts
@@ -41,7 +41,7 @@ describe("I18nValidationTest", () => {
     await topic.save();
     void topic.errors.messages;
     // Rails' assert_called_with asserts exactly one call with these args.
-    expect(spy).toHaveBeenCalledWith("title", "taken", topic, { value: "unique!" });
+    expect(spy).toHaveBeenCalledWith("title", ":taken", topic, { value: "unique!" });
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
@@ -63,7 +63,7 @@ describe("I18nValidationTest", () => {
     await topic.isValid();
     void topic.errors.messages;
     // Rails' assert_called_with asserts exactly one call with these args.
-    expect(spy).toHaveBeenCalledWith("replies", "invalid", topic, { value: replies });
+    expect(spy).toHaveBeenCalledWith("replies", ":invalid", topic, { value: replies });
     expect(spy).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/activerecord/src/validations/uniqueness.ts
+++ b/packages/activerecord/src/validations/uniqueness.ts
@@ -230,7 +230,7 @@ export class UniquenessValidator extends EachValidator {
 
     const exists = await relation.exists();
     if (exists) {
-      record.errors.add(attribute, "taken", errorOpts);
+      record.errors.add(attribute, ":taken", errorOpts);
     }
   }
 }


### PR DESCRIPTION
Bundle of two stories.

## `error-type-symbols-are-colon-strings` (RFC 0074)

`Error#message` chose between an i18n key lookup and a literal message with a
regex, `IDENTIFIER_RE = /^[a-z][a-zA-Z0-9_]*$/`. Rails dispatches on the value's
type — `@raw_type.is_a?(Symbol)`
(`activemodel/lib/active_model/error.rb:136-141`) — and the regex was wrong in
both directions. Rails' own `test_validates_each` proves it: `errors.add attr,
"gotcha"` asserts `%w(gotcha gotcha)`
(`activemodel/test/cases/validations_test.rb:110-120`), a one-word String that
trails resolved as an i18n key.

This applies CLAUDE.md's settled idiom, already in the tree for
`generateMessage`'s `message:` option: a Ruby Symbol is a JS string that keeps
its leading colon.

- `Error#message` dispatches on `rawType.startsWith(":")`; `IDENTIFIER_RE` is
  deleted. `Errors#added?` / `Errors#of_kind?` lose the same heuristic (they
  guessed on "contains no space") for the Symbol test Rails makes
  (`errors.rb:372-403`).
- `generate_message` keeps the Symbol in `type` and builds its i18n keys from
  the Symbol's name (`error.rb:64-75`).
- Every `errors.add` / `generateMessage` caller in `packages/` that means a
  Symbol now passes the colon form — the validators, secure_password, the
  association builders, the autosave/has_one/has_many `:base` errors, and the
  test models. The literal-String call sites (`reply.rb`'s `"Empty"`,
  `account.rb`'s `"too low"`, comparison.rb's `ArgumentError#message`) are
  unchanged, which is now the observable difference it always was in Rails.
- `test_validates_each_custom_reader` and the undeclared-getter case are
  restored to Rails' literal `"gotcha"` payload, and
  `test_errors_full_messages_uses_format` to Rails' `["Field Name empty"]` —
  all three had been reworded around the regex in PR #6026.

## `retire-public-statement-limit-accessor` (RFC 0072)

Found by the `@noRailsEquivalent` tag audit. Three adapters carried a public
validated `statementLimit` accessor. Rails has no such method: it reads
`@config[:statement_limit]` inline, once, where it builds the StatementPool —
`abstract_mysql_adapter.rb:975`, `postgresql_adapter.rb:1056`,
`sqlite3_adapter.rb:803`, each `StatementPool.new(self.class.type_cast_config_to_integer(@config[:statement_limit]))`.

The public getter/setter and their `@noRailsEquivalent` tags are gone, along
with the `_onStatementLimitChanged` resize hook that only existed to serve the
setter and the hand-rolled `RangeError` validation, which Rails does not have —
`type_cast_config_to_integer` at the read site is its whole treatment of the
key. The value stays on an `@internal` `_statementLimit` field read at the
`buildStatementPool` sites (and the two `_shouldPrepare` pool-limit checks,
recorded at the declaration). The three trails-only "rejects invalid
statementLimit at construction time" tests go with the validation.

### Review follow-up: `restrict_with_error`

Converged rather than filed. The `restrict_with_error` branch of both
associations added `errors.add(:base, :invalid, message: "Cannot delete record
because ...")` — a hardcoded literal on a wrong type key. Rails adds
`owner.errors.add(:base, :'restrict_dependent_destroy.has_many', record: record)`
(`has_many_association.rb:22`, `has_one_association.rb:17`), driving the message
through i18n. The locale entry
(`activerecord.errors.messages.restrict_dependent_destroy.{has_one,has_many}`)
was already in `packages/activerecord/src/locale/en.ts`, so the fix is the two
call sites; the existing assertions — including the locale-override case in
`has-many-associations.test.ts` — pass unchanged, which is the point of routing
through i18n.

## Size

1191 LOC, over the 500 ceiling. The two stories were claimed and assigned as
one bundle (both carry the same claim and `pr: 6098` in the tracker), so this
is tasking-side bundling, not a worker fanning out. The Symbol flip is atomic — the discriminator
and every caller have to move in one commit or error messages silently change —
and ~85% of the diff is the one-line `"blank"` -> `":blank"` sweep across
validators and their tests. Splitting it would mean shipping a half-flipped
discriminator.

## Verification

`pnpm typecheck`, `pnpm lint`, `pnpm api:calls` (OK, 14 baselined),
`pnpm api:calls:wide` (OK), `pnpm api:extra --package activerecord` (no stale
tags; the three adapter files did not regress), and the 111 activerecord +
actionpack test files that touch `errors`, plus all 75 activemodel files —
green. No baseline row added.

Two divergences in the same two methods are Rails-real but out of this story:
`ofKind` carries an invented `type === undefined` arm instead of Rails'
`type = :invalid` default, and neither `added` nor `ofKind` runs
`normalizeArguments` first. Filed as
`0074-i18n-parity/of-kind-default-type-and-normalize-arguments`.

Closes-story: error-type-symbols-are-colon-strings
Closes-story: retire-public-statement-limit-accessor
