### PR TITLE
feat(i18n): carry rt_complete_frags' wday entry and the commercial wday fallback

### DIFF
--- a/docs/infrastructure/mixin-attribution-triage.md
+++ b/docs/infrastructure/mixin-attribution-triage.md
@@ -1,0 +1,78 @@
+# Mixin parity-gap triage (RFC 0072)
+
+Triage of the data-layer parity gaps that became visible when PR #5334 taught
+`resolveModuleName` to resolve partially-qualified `include`/`extend` names
+(`include PostgreSQL::Quoting` inside `module ActiveRecord::ConnectionAdapters`).
+Because `resolveModuleName` also feeds `flattenIncludedMethodInfos`, that
+expanded the Rails-side **expected** surface, and the story
+`triage-newly-visible-mixin-parity-gaps` was filed to split the newly-visible
+gaps into "really unported" / "mis-attributed" / "out of scope" before anyone
+sized porting work.
+
+Measured on 2026-08-04 from `scripts/api-compare/output/` after a full
+`pnpm build` + `pnpm api:compare`:
+
+```
+Data layer: 7729/7816 methods (98.9%)  |  files: 409/409
+```
+
+so the data layer carries **87** missing methods, not the 258/93 the story
+quoted — the intervening year of porting absorbed the rest.
+
+## The finding
+
+**85 of the 87 are already ported, in the TS file that mirrors the mixin's own
+Ruby file.** They are reported missing only because the flattening re-expects
+every mixed-in method in each _host_ file as well:
+`PostgreSQL::Quoting#escape_bytea` is expected in both
+`connection_adapters/postgresql/quoting.rb` (where trails ports it, as
+`connection-adapters/postgresql/quoting.ts`, and where it matches) and again in
+`connection_adapters/postgresql_adapter.rb` (where trails does not repeat it,
+because Rails does not either). The host copy is a duplicate expectation, so
+the same method is counted twice in the denominator and once in the numerator.
+
+That is a comparator-attribution defect, not a porting gap, and it is why the
+old data-layer 100% and the current 98.9% are both artifacts. Crediting the 85
+puts the data layer at **7814/7816 (99.97%)** — the known floor asked for by the
+story's last acceptance criterion.
+
+## Groups
+
+Every group below is `<count> | <ruby file> | <host> | <mixin that defines it>`.
+"ported at" is the TS file the method is actually implemented in.
+
+| n   | host file                                              | mixin                                 | verdict                                                                                                       |
+| --- | ------------------------------------------------------ | ------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| 18  | `base.rb`                                              | `Encryption::EncryptableRecord`       | mis-attributed — `encryption/encryptable-record.ts` (of 19; the 19th is below)                                |
+| 5   | `base.rb`                                              | `Delegation::DelegateCache`           | mis-attributed — `relation/delegation.ts`                                                                     |
+| 3   | `base.rb`                                              | `Aggregations::ClassMethods`          | mis-attributed — `aggregations.ts`                                                                            |
+| 1   | `base.rb`                                              | `Encryption::EncryptableRecord`       | **unported** — `encrypted_attributes?`                                                                        |
+| 8   | `connection_adapters/postgresql_adapter.rb`            | `PostgreSQL::Quoting`                 | mis-attributed — `postgresql/quoting.ts`                                                                      |
+| 4   | `connection_adapters/postgresql_adapter.rb`            | `PostgreSQL::DatabaseStatements`      | mis-attributed — `postgresql/database-statements.ts`                                                          |
+| 1   | `connection_adapters/postgresql_adapter.rb`            | `PostgreSQL::Quoting` (`infinity?`)   | mis-attributed — `postgresql/quoting.ts`                                                                      |
+| 8   | `connection_adapters/abstract_mysql_adapter.rb`        | `MySQL::SchemaStatements`             | mis-attributed — `mysql/schema-statements.ts`                                                                 |
+| 2   | `connection_adapters/abstract_mysql_adapter.rb`        | `MySQL::DatabaseStatements`           | mis-attributed — `mysql/database-statements.ts`                                                               |
+| 1   | `connection_adapters/mysql2_adapter.rb`                | `Mysql2::DatabaseStatements`          | mis-attributed — `mysql2/database-statements.ts`                                                              |
+| 1   | `connection_adapters/mysql2_adapter.rb`                | `Mysql2::DatabaseStatements`          | **name divergence** — `multi_statements_enabled?` is `multiStatementsEnabled`, not `isMultiStatementsEnabled` |
+| 4   | `connection_adapters/sqlite3_adapter.rb`               | `SQLite3::SchemaStatements`           | mis-attributed — `sqlite3/schema-statements.ts`                                                               |
+| 1   | `connection_adapters/postgresql/schema_definitions.rb` | own (`TableDefinition`)               | mis-attributed — `abstract/schema-definitions.ts` (inherited)                                                 |
+| 3   | `type/{date,date_time,time}.rb` (AR)                   | `Type::Internal::Timezone`            | mis-attributed — `type/internal/timezone.ts`                                                                  |
+| 8   | `type/{date,date_time,time}.rb` (AM)                   | `Type::Helpers::{Timezone,TimeValue}` | mis-attributed — `type/helpers/*.ts`                                                                          |
+| 19  | `type/{decimal,float,integer}.rb` (AM)                 | `Type::Helpers::Numeric`              | mis-attributed — `type/helpers/numeric.ts`                                                                    |
+
+Totals: **85 mis-attributed, 1 genuinely unported, 1 name divergence.** Nothing
+in the data layer falls into "out of scope per `unported-files.ts`" — the
+out-of-scope hosts were already excluded before the flattening ran.
+
+## What was filed
+
+- `credit-mixin-methods-ported-in-their-own-file` (RFC 0072) — the comparator
+  fix: a flattened mixin method already matched in the file mirroring the
+  mixin's own Ruby file must not be re-expected in each host.
+- `port-encryptable-record-encrypted-attributes-predicate` (RFC 0072) — the one
+  genuinely unported method.
+- `rename-multi-statements-enabled-to-conventions-predicate` (RFC 0072) — the
+  `is`-prefix predicate rename.
+
+No exclusion-file rows were added: 85 duplicate expectations are a defect in the
+expected surface, and baselining them would ratify it.

--- a/packages/i18n/src/date.trails.test.ts
+++ b/packages/i18n/src/date.trails.test.ts
@@ -213,6 +213,8 @@ describe("Date", () => {
         expect([str, `${date.year}-08-0${date.day}`]).toEqual([str, expected]);
       }
       expect(() => RubyDate.parse("wed 2008")).toThrow("invalid date");
+      expect(() => RubyDate.parse("wed 10:00:00")).toThrow("invalid date");
+      expect(() => RubyDate.parse("sunday 10:00:00")).toThrow("invalid date");
     } finally {
       vi.useRealTimers();
     }

--- a/packages/i18n/src/date.trails.test.ts
+++ b/packages/i18n/src/date.trails.test.ts
@@ -198,6 +198,35 @@ describe("Date", () => {
     expect([long.year, long.mon, long.day]).toEqual([2020, 12, 28]);
   });
 
+  it("resolves a day of the week against today, as rt_complete_frags' wday entry does", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-04T12:00:00Z"));
+    try {
+      for (const [str, expected] of [
+        ["sunday", "2026-08-02"],
+        ["monday", "2026-08-03"],
+        ["wednesday", "2026-08-05"],
+        ["sat", "2026-08-08"],
+        ["wed 10:00", "2026-08-05"],
+      ] as const) {
+        const date = RubyDate.parse(str);
+        expect([str, `${date.year}-08-0${date.day}`]).toEqual([str, expected]);
+      }
+      expect(() => RubyDate.parse("wed 2008")).toThrow("invalid date");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("falls back to wday in the commercial arm, as rt__valid_date_frags_p does", () => {
+    const sun = RubyDate.parse("2001-W05 sun");
+    expect([sun.year, sun.mon, sun.day]).toEqual([2001, 2, 4]);
+    const wed = RubyDate.parse("2001-W05 wed");
+    expect([wed.year, wed.mon, wed.day]).toEqual([2001, 1, 31]);
+    const cwday = RubyDate.parse("2001-W05-6 sun");
+    expect([cwday.year, cwday.mon, cwday.day]).toEqual([2001, 2, 3]);
+  });
+
   it("negates the year of a BC date, as parse_bc does", () => {
     expect(RubyDate.parse("4004-01-02 BC").year).toBe(-4003);
     expect(RubyDate.parse("feb 3 4004 b.c.e.").year).toBe(-4003);

--- a/packages/i18n/src/date.ts
+++ b/packages/i18n/src/date.ts
@@ -165,6 +165,7 @@ const ABBR_DAYS = "sun|mon|tue|wed|thu|fri|sat";
  * answers `{... :offset => nil}` there.
  */
 interface DateParts {
+  jd?: number;
   year?: number;
   mon?: number;
   mday?: number;
@@ -185,9 +186,10 @@ interface DateParts {
 
 /**
  * @internal The date and time elements of `rt_complete_frags`' table
- * (`date_core.c:3878-3892`) this shim carries.
+ * (`date_core.c:3884-3968`) this shim carries.
  */
 type DateFrag =
+  | "jd"
   | "year"
   | "mon"
   | "mday"
@@ -195,6 +197,7 @@ type DateFrag =
   | "cwyear"
   | "cweek"
   | "cwday"
+  | "wday"
   | "hour"
   | "min"
   | "sec";
@@ -1468,23 +1471,27 @@ function parseFrag(str: string, hash: DateParts): string | null {
  * `activesupport/test/core_ext/string_ext_test.rb:775` — and `"102".to_date` is
  * this year's 102nd day.
  *
- * Only the `:time`, `:ordinal`, `:civil` and `:commercial` entries of that
- * table are carried: the rest are the Julian-day, `:wday` and week-numbered
- * dates, whose fields (`:jd`, `:wday`, `:wnum0`, `:wnum1`) no sub-parser
- * ported here can produce. `:time` names no date, so it has no completion
- * branch in Ruby either, and the string goes on to raise.
+ * The three `:wnum0`/`:wnum1` entries of that table are not carried: no
+ * sub-parser ported here sets `:wnum0` or `:wnum1`, and their completion
+ * branches read a week number off `Date.today` that Ruby's `::Date` has no
+ * reader for. `:time` names no date, so it has no completion branch here
+ * either — Ruby's only fills a `:jd` for `DateTime` — and the string goes on
+ * to raise.
  */
 function completeFrags(parts: DateParts): void {
-  const tab: [string, DateFrag[]][] = [
+  const tab: [string | null, DateFrag[]][] = [
     ["time", ["hour", "min", "sec"]],
+    [null, ["jd"]],
     ["ordinal", ["year", "yday", "hour", "min", "sec"]],
     ["civil", ["year", "mon", "mday", "hour", "min", "sec"]],
     ["commercial", ["cwyear", "cweek", "cwday", "hour", "min", "sec"]],
+    ["wday", ["wday", "hour", "min", "sec"]],
+    [null, ["cwyear", "cweek", "wday", "hour", "min", "sec"]],
   ];
 
   let g: boolean;
   let e = 0;
-  let k = "";
+  let k: string | null = null;
   let a: DateFrag[] = [];
   {
     let eno = 0;
@@ -1509,7 +1516,7 @@ function completeFrags(parts: DateParts): void {
     }
   }
 
-  if (g && a.length - e) {
+  if (g && k !== null && a.length - e) {
     const d = Temporal.Now.plainDateISO();
     const today: Partial<Record<DateFrag, number>> = {
       year: d.year,
@@ -1538,8 +1545,38 @@ function completeFrags(parts: DateParts): void {
       }
       parts.cweek ??= 1;
       parts.cwday ??= 1;
+    } else if (k === "wday") {
+      parts.jd = jdOf(d.subtract({ days: d.dayOfWeek % 7 }).add({ days: parts.wday as number }));
     }
   }
+}
+
+/**
+ * @internal `date_core.c`'s `UNIX_EPOCH_IN_CJD` (`date_core.c:192`), the
+ * chronological Julian day number of 1970-01-01, which is the anchor
+ * `date__parse` itself converts a `Time` to a `:jd` on (`date_core.c:3864`).
+ */
+const UNIX_EPOCH_IN_CJD = 2440588;
+
+/** @internal 1970-01-01, the day {@link UNIX_EPOCH_IN_CJD} numbers. */
+const UNIX_EPOCH = new Temporal.PlainDate(1970, 1, 1);
+
+/**
+ * @internal Ruby `Date#jd` (`date_core.c` `d_lite_jd`, `date_core.c:5249`), the
+ * reader `rt_complete_frags`' `:wday` branch takes its `:jd` off. `Temporal` has
+ * no Julian day, so the number is the day count from the Unix epoch Ruby
+ * anchors its own `Time`-to-`:jd` conversion on.
+ */
+function jdOf(d: Temporal.PlainDate): number {
+  return UNIX_EPOCH_IN_CJD + d.since(UNIX_EPOCH).days;
+}
+
+/**
+ * @internal Ruby `Date.jd(jd)` (`date_core.c` `date_s_jd`,
+ * `date_core.c:3358`), the inverse of {@link jdOf}.
+ */
+function jdToCivil(jd: number): Temporal.PlainDate {
+  return UNIX_EPOCH.add({ days: jd - UNIX_EPOCH_IN_CJD });
 }
 
 /**
@@ -1594,29 +1631,44 @@ export class Date {
    * civil one, and the commercial date — a `:cwyear`, a `:cweek` and a
    * `:cwday`, which is what `"2001-W05-6"` names — after both. A string that
    * named only a time of day answers none of them and raises. The
-   * out-of-range week Ruby rejects in `c_valid_commercial_p` is rejected here
-   * by round-tripping the built date's own week date.
+   * out-of-range week or day Ruby rejects in `c_valid_commercial_p`
+   * (`date_core.c:792-810`) is rejected here by round-tripping the built date's
+   * own week date. That arm reads `:cwday` and falls back to a `:wday` whose
+   * `0` it maps to `7`, which is how `"2001-W05 sun"` names the Sunday of that
+   * ISO week. A `:jd` — which `rt_complete_frags` writes for a string that
+   * named only a day of the week — answers before all of them.
    */
   static parse(str: string, comp = true): Date {
     const parts = Date._parse(str, comp);
     completeFrags(parts);
     let d: Temporal.PlainDate | null = null;
     try {
-      if (parts.yday !== undefined && parts.year !== undefined && parts.yday >= 1) {
+      if (parts.jd !== undefined) {
+        d = jdToCivil(parts.jd);
+      } else if (parts.yday !== undefined && parts.year !== undefined && parts.yday >= 1) {
         d = new Temporal.PlainDate(parts.year, 1, 1).add({ days: parts.yday - 1 });
         if (d.year !== parts.year) d = null;
       } else if (parts.mon !== undefined && parts.mday !== undefined) {
         d = new Temporal.PlainDate(parts.year as number, parts.mon, parts.mday);
-      } else if (
-        parts.cwday !== undefined &&
-        parts.cweek !== undefined &&
-        parts.cwyear !== undefined
-      ) {
-        const jan4 = new Temporal.PlainDate(parts.cwyear, 1, 4);
-        d = jan4
-          .subtract({ days: jan4.dayOfWeek - 1 })
-          .add({ days: (parts.cweek - 1) * 7 + (parts.cwday - 1) });
-        if (d.yearOfWeek !== parts.cwyear || d.weekOfYear !== parts.cweek) d = null;
+      } else {
+        let cwday = parts.cwday;
+        if (cwday === undefined) {
+          cwday = parts.wday;
+          if (cwday !== undefined) if (cwday === 0) cwday = 7;
+        }
+        if (cwday !== undefined && parts.cweek !== undefined && parts.cwyear !== undefined) {
+          const jan4 = new Temporal.PlainDate(parts.cwyear, 1, 4);
+          d = jan4
+            .subtract({ days: jan4.dayOfWeek - 1 })
+            .add({ days: (parts.cweek - 1) * 7 + (cwday - 1) });
+          if (
+            d.yearOfWeek !== parts.cwyear ||
+            d.weekOfYear !== parts.cweek ||
+            d.dayOfWeek !== cwday
+          ) {
+            d = null;
+          }
+        }
       }
     } catch {
       d = null;


### PR DESCRIPTION
Bundle of three RFC stories.

**`i18n-date-complete-frags-wday-element`** — `completeFrags` carries the `:wday` entry of `rt_complete_frags`' table and the `[cwyear, cweek, wday]` entry that outranks the commercial one (date-3.4.1 `ext/date/date_core.c:3878-4095`). A string that names only a day of the week now completes to the `:jd` of that day in the current week (`jd = today.jd - today.wday + wday`, `date_core.c:4056-4060`), and `Date.parse` answers it from the `:jd` arm `rt__valid_date_frags_p` tries first (`date_core.c:4186-4196`). `Date.parse("wednesday")`, `"sunday"`, `"sat"` and `"wed 10:00"` agree with ruby 3.3.11 / date 3.4.1; `"wed 2008"` still raises `Date::Error "invalid date"`, because the civil entry still wins there.

The three `:wnum0`/`:wnum1` entries stay uncarried — no ported sub-parser sets those fields, and their completion branches read a week number off `Date.today` that `::Date` has no reader for. That is documented at `completeFrags`.

**`i18n-date-valid-commercial-day-check-and-wday-fallback`** — the commercial arm reads `:cwday` and falls back to a `:wday` whose `0` it maps to `7` (`date_core.c:4223-4239`), so `"2001-W05 sun"` is 2001-02-04 and `"2001-W05-6 sun"` stays 2001-02-03; and it rejects a day that does not round-trip, which `c_valid_commercial_p` checks alongside the week and the year (`date_core.c:806-808`).

Both new tests were verified to fail on the baseline.

**`triage-newly-visible-mixin-parity-gaps`** — docs only, `docs/infrastructure/mixin-attribution-triage.md`. Measured after a full build: the data layer is at 7729/7816 (98.9%), 87 gaps rather than the 258/93 the story quoted. **85 of the 87 are the same method expected twice** — once in the file mirroring the mixin's own Ruby file, where trails ports it and matches, and again in every host that includes it. Crediting them puts the floor at 7814/7816 (99.97%). Exactly one method is genuinely unported (`encrypted_attributes?`) and one is a name divergence (`multiStatementsEnabled` vs the conventions' `isMultiStatementsEnabled`). No exclusion rows were added; three follow-up stories were filed under RFC 0072 instead.

`route-order-args-through-sanitize-order-arguments` was claimed with the bundle and found already implemented in `main` — `order`/`reorder` route through `checkIfMethodHasArgumentsBang`, whose `orderArgs` block calls `sanitizeOrderArguments` + `flattenedOrderArgs` (relation.ts:1003, :1126, :5533; landed by #5937). Marked done against that PR, nothing in this diff.

Closes-story: i18n-date-complete-frags-wday-element
Closes-story: i18n-date-valid-commercial-day-check-and-wday-fallback
Closes-story: triage-newly-visible-mixin-parity-gaps