### PR TITLE
refactor(activesupport,activerecord): split core_ext/range into its Rails files, rename multi_statements_enabled?

### DIFF
--- a/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
@@ -179,7 +179,7 @@ function lastInsertedId(result: any): never {
  * Mirrors: ActiveRecord::ConnectionAdapters::Mysql2::DatabaseStatements#multi_statements_enabled?
  * @internal
  */
-export function multiStatementsEnabled(this: MultiStatementsHost): boolean {
+export function isMultiStatementsEnabled(this: MultiStatementsHost): boolean {
   const flags = this._config?.flags;
   if (Array.isArray(flags)) return flags.includes("MULTI_STATEMENTS");
   if (typeof flags === "number") return (flags & MULTI_STATEMENTS_BIT) !== 0;

--- a/packages/activesupport/src/core-ext/range-ext.test.ts
+++ b/packages/activesupport/src/core-ext/range-ext.test.ts
@@ -1,50 +1,55 @@
 import { describe, it, expect } from "vitest";
 
+import { Temporal } from "../temporal.js";
+
 import {
   makeRange,
-  overlap,
-  overlaps,
   rangeIncludesValue,
   rangeIncludesStringValue,
-  rangeToFs,
-  rangeStep,
-  rangeEach,
   stringSucc,
 } from "../range-ext.js";
+import { instantFromDate } from "../testing/temporal-helpers.js";
+import { TimeWithZone } from "../time-with-zone.js";
+import { TimeZone } from "../values/time-zone.js";
 import { caseEquals, isInclude } from "./range/compare-range.js";
+import { toFs, toFormattedS } from "./range/conversions.js";
+import { each, step } from "./range/each.js";
+import { overlap, overlaps } from "./range/overlap.js";
 
 describe("RangeTest", () => {
   it("to fs from dates", () => {
-    const d1 = new Date("2023-01-01");
-    const d2 = new Date("2023-12-31");
-    const r = makeRange(d1, d2);
-    expect(rangeToFs(r)).toContain("2023");
+    const dateRange = makeRange(
+      Temporal.PlainDate.from("2005-12-10"),
+      Temporal.PlainDate.from("2005-12-12"),
+    );
+    expect(toFs(dateRange, "db")).toBe("BETWEEN '2005-12-10' AND '2005-12-12'");
+    expect(toFormattedS(dateRange, "db")).toBe("BETWEEN '2005-12-10' AND '2005-12-12'");
   });
 
   it("to fs from times", () => {
-    const t1 = new Date("2023-06-01T10:00:00Z");
-    const t2 = new Date("2023-06-01T18:00:00Z");
-    const r = makeRange(t1, t2);
-    expect(rangeToFs(r)).toContain("2023");
+    const dateRange = makeRange(
+      new Date(Date.UTC(2005, 11, 10, 15, 30)),
+      new Date(Date.UTC(2005, 11, 10, 17, 30)),
+    );
+    expect(toFs(dateRange, "db")).toBe("BETWEEN '2005-12-10 15:30:00' AND '2005-12-10 17:30:00'");
   });
 
   it("to fs with alphabets", () => {
-    const r = makeRange("a", "z");
-    const result = rangeToFs(r);
-    expect(result).toContain("a");
-    expect(result).toContain("z");
+    expect(toFs(makeRange("a", "z"), "db")).toBe("BETWEEN 'a' AND 'z'");
+    expect(toFs(makeRange("a", null), "db")).toBe(">= 'a'");
+    expect(toFs(makeRange(null, "z"), "db")).toBe("<= 'z'");
   });
 
   it("to fs with numeric", () => {
-    const r = makeRange(1, 10);
-    const result = rangeToFs(r);
-    expect(result).toContain("1");
-    expect(result).toContain("10");
+    expect(toFs(makeRange(1, 100), "db")).toBe("BETWEEN '1' AND '100'");
+    expect(toFs(makeRange(1, null), "db")).toBe(">= '1'");
+    expect(toFs(makeRange(null, 100), "db")).toBe("<= '100'");
   });
 
   it("to fs with format invalid format", () => {
-    const r = makeRange(1, 10);
-    expect(typeof rangeToFs(r)).toBe("string");
+    const numberRange = makeRange(1, 100);
+
+    expect(toFs(numberRange, "not_existent")).toBe("1..100");
   });
 
   it("date range", () => {
@@ -204,14 +209,27 @@ describe("RangeTest", () => {
     expect(overlap(makeRange(t1, t2), makeRange(t3, t4))).toBe(false);
   });
 
-  it.skip("each on time with zone");
-  it.skip("step on time with zone");
+  it("each on time with zone", () => {
+    const twz = new TimeWithZone(
+      instantFromDate(new Date(Date.UTC(2006, 10, 28, 10, 30))),
+      TimeZone.find("Eastern Time (US & Canada)"),
+    );
+    expect(() => [...each(makeRange(twz, twz))]).toThrow(TypeError);
+  });
+
+  it("step on time with zone", () => {
+    const twz = new TimeWithZone(
+      instantFromDate(new Date(Date.UTC(2006, 10, 28, 10, 30))),
+      TimeZone.find("Eastern Time (US & Canada)"),
+    );
+    expect(() => [...step(makeRange(twz, twz), 1)]).toThrow(TypeError);
+  });
   it.skip("cover on time with zone");
   it.skip("case equals on time with zone");
 
   it("date time with each", () => {
     const r = makeRange(0, 4);
-    expect([...rangeEach(r)]).toEqual([0, 1, 2, 3, 4]);
+    expect([...each(r)]).toEqual([0, 1, 2, 3, 4]);
   });
 
   it("string include uses succ order not lexicographic", () => {
@@ -270,6 +288,6 @@ describe("RangeTest", () => {
 
   it("date time with step", () => {
     const r = makeRange(0, 10);
-    expect([...rangeStep(r, 2)]).toEqual([0, 2, 4, 6, 8, 10]);
+    expect([...step(r, 2)]).toEqual([0, 2, 4, 6, 8, 10]);
   });
 });

--- a/packages/activesupport/src/core-ext/range-ext.test.ts
+++ b/packages/activesupport/src/core-ext/range-ext.test.ts
@@ -2,16 +2,13 @@ import { describe, it, expect } from "vitest";
 
 import { Temporal } from "../temporal.js";
 
-import {
-  makeRange,
-  rangeIncludesValue,
-  rangeIncludesStringValue,
-  stringSucc,
-} from "../range-ext.js";
+import { hours } from "../duration.js";
+import { makeRange, rangeIncludesValue, rangeIncludesStringValue } from "../range-ext.js";
 import { instantFromDate } from "../testing/temporal-helpers.js";
 import { TimeWithZone } from "../time-with-zone.js";
 import { TimeZone } from "../values/time-zone.js";
 import { caseEquals, isInclude } from "./range/compare-range.js";
+import { succ } from "./string/succ.js";
 import { toFs, toFormattedS } from "./range/conversions.js";
 import { each, step } from "./range/each.js";
 import { overlap, overlaps } from "./range/overlap.js";
@@ -214,7 +211,7 @@ describe("RangeTest", () => {
       instantFromDate(new Date(Date.UTC(2006, 10, 28, 10, 30))),
       TimeZone.find("Eastern Time (US & Canada)"),
     );
-    expect(() => [...each(makeRange(twz, twz))]).toThrow(TypeError);
+    expect(() => [...each(makeRange(twz.minus(hours(1)), twz))]).toThrow(TypeError);
   });
 
   it("step on time with zone", () => {
@@ -222,7 +219,7 @@ describe("RangeTest", () => {
       instantFromDate(new Date(Date.UTC(2006, 10, 28, 10, 30))),
       TimeZone.find("Eastern Time (US & Canada)"),
     );
-    expect(() => [...step(makeRange(twz, twz), 1)]).toThrow(TypeError);
+    expect(() => [...step(makeRange(twz.minus(hours(1)), twz), 1)]).toThrow(TypeError);
   });
   it.skip("cover on time with zone");
   it.skip("case equals on time with zone");
@@ -266,24 +263,24 @@ describe("RangeTest", () => {
 
   it("string succ carries within character classes", () => {
     // Mirrors Ruby String#succ.
-    expect(stringSucc("abcd")).toBe("abce");
-    expect(stringSucc("az")).toBe("ba");
-    expect(stringSucc("zz")).toBe("aaa");
-    expect(stringSucc("Zz")).toBe("AAa");
-    expect(stringSucc("99")).toBe("100");
-    expect(stringSucc("a9")).toBe("b0");
-    expect(stringSucc("1.9")).toBe("2.0");
-    expect(stringSucc("<<")).toBe("<=");
+    expect(succ("abcd")).toBe("abce");
+    expect(succ("az")).toBe("ba");
+    expect(succ("zz")).toBe("aaa");
+    expect(succ("Zz")).toBe("AAa");
+    expect(succ("99")).toBe("100");
+    expect(succ("a9")).toBe("b0");
+    expect(succ("1.9")).toBe("2.0");
+    expect(succ("<<")).toBe("<=");
     // Carry stops at a non-alnum gap into a different class.
-    expect(stringSucc("z.9")).toBe("z.10");
-    expect(stringSucc("a.z")).toBe("b.a");
+    expect(succ("z.9")).toBe("z.10");
+    expect(succ("a.z")).toBe("b.a");
     // Astral (non-alnum) chars succ as whole code points, not UTF-16 units.
-    expect(stringSucc("\u{1F600}")).toBe("\u{1F601}");
+    expect(succ("\u{1F600}")).toBe("\u{1F601}");
     // Wrapping is per UTF-8 encoded width (`enc_succ_char` NEIGHBOR_WRAPPED).
     const points = (str: string) => Array.from(str, (c) => c.codePointAt(0));
-    expect(points(stringSucc("\u{10FFFF}"))).toEqual([0x1, 0x10000]);
-    expect(points(stringSucc("\u{FFFF}"))).toEqual([0x1, 0x800]);
-    expect(points(stringSucc("\u{07FF}"))).toEqual([0x1, 0x80]);
+    expect(points(succ("\u{10FFFF}"))).toEqual([0x1, 0x10000]);
+    expect(points(succ("\u{FFFF}"))).toEqual([0x1, 0x800]);
+    expect(points(succ("\u{07FF}"))).toEqual([0x1, 0x80]);
   });
 
   it("date time with step", () => {

--- a/packages/activesupport/src/core-ext/range/conversions.ts
+++ b/packages/activesupport/src/core-ext/range/conversions.ts
@@ -1,0 +1,89 @@
+import { Temporal } from "../../temporal.js";
+
+import type { Range } from "../../range-ext.js";
+import { toFs as timeToFs } from "../../time-ext.js";
+
+/**
+ * `ActiveSupport::RangeWithFormat`
+ * (core_ext/range/conversions.rb:5), which Ruby `prepend`s onto `Range`.
+ *
+ * JS has no `Range` class to reopen — trails carries the begin/end/exclusive
+ * triple as data (`range-ext.ts`) — so `to_fs` takes the receiver as its first
+ * parameter, exactly as `compare-range.ts` does.
+ */
+
+/**
+ * Ruby's `start.to_fs(:db)` (conversions.rb:12,18,24). Ruby dispatches on the
+ * endpoint's own `to_fs`; TS has no open classes, so the dispatch is explicit
+ * over the values trails uses for the Ruby endpoint types — `Temporal.PlainDate`
+ * for `Date`, `Date`/`Temporal.Instant` for `Time`, everything else `to_s`.
+ */
+function toFsDb(value: unknown): string {
+  if (value instanceof Temporal.PlainDate) return value.toString();
+  // boundary: `time-ext.ts`'s `toFs` — the ported `Time#to_fs` — takes a JS Date.
+  if (value instanceof Date) return timeToFs(value, "db");
+  // boundary: as above, an Instant is bridged to the Date `toFs` accepts.
+  if (value instanceof Temporal.Instant) return timeToFs(new Date(value.epochMilliseconds), "db");
+  return String(value);
+}
+
+/** Ruby's `Range#to_s` (the `to_fs` fallback at conversions.rb:55). */
+function toS<T>(range: Range<T>): string {
+  const begin = range.begin !== null ? String(range.begin) : "";
+  const end = range.end !== null ? String(range.end) : "";
+  return `${begin}${range.excludeEnd ? "..." : ".."}${end}`;
+}
+
+export const RANGE_FORMATS: Record<string, (start: unknown, stop: unknown) => string | undefined> =
+  {
+    db: (start, stop) => {
+      if (start != null && stop != null) {
+        if (typeof start === "string") return `BETWEEN '${start}' AND '${stop}'`;
+        return `BETWEEN '${toFsDb(start)}' AND '${toFsDb(stop)}'`;
+      } else if (start != null) {
+        if (typeof start === "string") return `>= '${start}'`;
+        return `>= '${toFsDb(start)}'`;
+      } else if (stop != null) {
+        if (typeof stop === "string") return `<= '${stop}'`;
+        return `<= '${toFsDb(stop)}'`;
+      }
+      return undefined;
+    },
+  };
+
+/**
+ * Convert range to a formatted string. See RANGE_FORMATS for predefined formats.
+ *
+ * This method is aliased to `toFormattedS`.
+ *
+ *   range = (1..100)           # => 1..100
+ *
+ *   range.to_s                 # => "1..100"
+ *   range.to_fs(:db)           # => "BETWEEN '1' AND '100'"
+ *
+ *   range = (1..)              # => 1..
+ *   range.to_fs(:db)           # => ">= '1'"
+ *
+ *   range = (..100)            # => ..100
+ *   range.to_fs(:db)           # => "<= '100'"
+ *
+ * == Adding your own range formats to toFs
+ * You can add your own formats to the RANGE_FORMATS hash.
+ * Use the format name as the hash key and a function.
+ *
+ *   RANGE_FORMATS.short = (start, stop) => `Between ${start} and ${stop}`;
+ *
+ * Returns `undefined` for a fully unbounded range under `:db`, as Ruby's
+ * formatter returns `nil` when its `if`/`elsif` chain falls through
+ * (conversions.rb:20-26).
+ */
+export function toFs<T>(range: Range<T>, format: string = "default"): string | undefined {
+  const formatter = RANGE_FORMATS[format];
+  if (formatter) {
+    return formatter(range.begin, range.end);
+  } else {
+    return toS(range);
+  }
+}
+
+export const toFormattedS = toFs;

--- a/packages/activesupport/src/core-ext/range/each.ts
+++ b/packages/activesupport/src/core-ext/range/each.ts
@@ -13,13 +13,10 @@ import { TimeWithZone } from "../../time-with-zone.js";
 
 /**
  * Ruby's `super` at each.rb:9,14 — core `Range#each` / `Range#step`, which JS
- * has no `Range` class to inherit from.
+ * has no `Range` class to inherit from. Reached only through the two guarded
+ * entry points below, which have already raised on a beginless range.
  */
 function* enumerate(range: Range<number | TimeWithZone>, n: number): Generator<number> {
-  // Ruby core `Range#each` on a beginless range; activesupport has no ported
-  // TypeError, so this mirrors the message Ruby raises.
-  // eslint-disable-next-line blazetrails/rails-error-parity
-  if (range.begin === null) throw new TypeError("can't iterate from NilClass");
   let current = range.begin as number;
   while (true) {
     if (range.end !== null) {
@@ -42,12 +39,24 @@ export function* step(range: Range<number | TimeWithZone>, n: number = 1): Gener
 }
 
 /**
- * @internal Rails-private helper (each.rb:18).
+ * Ruby's core `Range#first`, which `ensureIterationAllowed` calls for its
+ * receiver's class — and which raises before that check on a beginless range.
+ */
+function first(range: Range<number | TimeWithZone>): number | TimeWithZone {
+  if (range.begin === null) {
+    // eslint-disable-next-line blazetrails/rails-error-parity
+    throw new RangeError("cannot get the first element of beginless range");
+  }
+  return range.begin;
+}
+
+/**
+ * @internal Rails-private helper (each.rb:18). `first.class` is spelled out
+ * because the guard fires only for `TimeWithZone`, whose Ruby name is not
+ * recoverable from the TS class.
  */
 function ensureIterationAllowed(range: Range<number | TimeWithZone>): void {
-  // Ruby's `first` is the range's begin. The guard only fires for
-  // `TimeWithZone`, so `first.class` is always that class' Ruby name.
-  if (range.begin instanceof TimeWithZone) {
+  if (first(range) instanceof TimeWithZone) {
     // eslint-disable-next-line blazetrails/rails-error-parity
     throw new TypeError("can't iterate from ActiveSupport::TimeWithZone");
   }

--- a/packages/activesupport/src/core-ext/range/each.ts
+++ b/packages/activesupport/src/core-ext/range/each.ts
@@ -1,0 +1,54 @@
+import type { Range } from "../../range-ext.js";
+import { TimeWithZone } from "../../time-with-zone.js";
+
+/**
+ * `ActiveSupport::EachTimeWithZone`
+ * (core_ext/range/each.rb:6), which Ruby `prepend`s onto `Range`.
+ *
+ * JS has no `Range` class to reopen — trails carries the begin/end/exclusive
+ * triple as data (`range-ext.ts`) — so the receiver is the first parameter and
+ * `super` is `enumerate`, the core `Range#each` / `Range#step` these two guard.
+ * Ruby yields to a block; the TS analogue is a generator.
+ */
+
+/**
+ * Ruby's `super` at each.rb:9,14 — core `Range#each` / `Range#step`, which JS
+ * has no `Range` class to inherit from.
+ */
+function* enumerate(range: Range<number | TimeWithZone>, n: number): Generator<number> {
+  // Ruby core `Range#each` on a beginless range; activesupport has no ported
+  // TypeError, so this mirrors the message Ruby raises.
+  // eslint-disable-next-line blazetrails/rails-error-parity
+  if (range.begin === null) throw new TypeError("can't iterate from NilClass");
+  let current = range.begin as number;
+  while (true) {
+    if (range.end !== null) {
+      const end = range.end as number;
+      if (range.excludeEnd ? current >= end : current > end) break;
+    }
+    yield current;
+    current += n;
+  }
+}
+
+export function* each(range: Range<number | TimeWithZone>): Generator<number> {
+  ensureIterationAllowed(range);
+  yield* enumerate(range, 1);
+}
+
+export function* step(range: Range<number | TimeWithZone>, n: number = 1): Generator<number> {
+  ensureIterationAllowed(range);
+  yield* enumerate(range, n);
+}
+
+/**
+ * @internal Rails-private helper (each.rb:18).
+ */
+function ensureIterationAllowed(range: Range<number | TimeWithZone>): void {
+  // Ruby's `first` is the range's begin. The guard only fires for
+  // `TimeWithZone`, so `first.class` is always that class' Ruby name.
+  if (range.begin instanceof TimeWithZone) {
+    // eslint-disable-next-line blazetrails/rails-error-parity
+    throw new TypeError("can't iterate from ActiveSupport::TimeWithZone");
+  }
+}

--- a/packages/activesupport/src/core-ext/range/overlap.ts
+++ b/packages/activesupport/src/core-ext/range/overlap.ts
@@ -14,6 +14,21 @@ import type { Range } from "../../range-ext.js";
 // boundary: Date endpoints, as in range-ext.ts
 const toNum = <T extends number | Date>(v: T): number => (v instanceof Date ? v.getTime() : v);
 
+/** Ruby's `b == e` on two endpoints, which for `Date` is a value comparison. */
+function eq<T extends number | Date>(b: T | null, e: T | null): boolean {
+  if (b === null || e === null) return b === e;
+  return toNum(b) === toNum(e);
+}
+
+/**
+ * Ruby's `value.is_a?(::Range)` (overlap.rb:9). trails' `Range` is a plain
+ * object, so the type test is structural, as in `compare-range.ts`.
+ */
+function isRange<T extends number | Date>(value: Range<T>): boolean {
+  // boundary: Date endpoints, as in range-ext.ts
+  return typeof value === "object" && value !== null && !(value instanceof Date);
+}
+
 /** Ruby's private `Range#_empty_range?` (overlap.rb:31). */
 function _isEmptyRange<T extends number | Date>(b: T | null, e: T | null, excl: boolean): boolean {
   if (b === null || e === null) return false;
@@ -26,12 +41,11 @@ function _isEmptyRange<T extends number | Date>(b: T | null, e: T | null, excl: 
  * Compare two ranges and see if they overlap each other
  *  (1..5).overlap?(4..6) # => true
  *  (1..5).overlap?(7..9) # => false
- *
- * @missingRailsCall raise — Ruby guards `other.is_a? Range` with a `TypeError`
- * (overlap.rb:9); `other` is statically a `Range<T>` here, so there is no
- * non-Range value to reject.
  */
 export function overlap<T extends number | Date>(range: Range<T>, other: Range<T>): boolean {
+  // eslint-disable-next-line blazetrails/rails-error-parity
+  if (!isRange(other)) throw new TypeError();
+
   const selfBegin = range.begin;
   const otherEnd = other.end;
   const otherExcl = other.excludeEnd;
@@ -43,13 +57,7 @@ export function overlap<T extends number | Date>(range: Range<T>, other: Range<T
   const selfExcl = range.excludeEnd;
 
   if (_isEmptyRange(otherBegin, selfEnd, selfExcl)) return false;
-  // Ruby's `==` on the endpoints; `toNum` keeps two equal `Date`s equal, which
-  // `===` on the objects would not.
-  if (selfBegin === null || otherBegin === null) {
-    if (selfBegin === otherBegin) return true;
-  } else if (toNum(selfBegin) === toNum(otherBegin)) {
-    return true;
-  }
+  if (eq(selfBegin, otherBegin)) return true;
 
   if (_isEmptyRange(selfBegin, selfEnd, selfExcl)) return false;
   if (_isEmptyRange(otherBegin, otherEnd, otherExcl)) return false;

--- a/packages/activesupport/src/core-ext/range/overlap.ts
+++ b/packages/activesupport/src/core-ext/range/overlap.ts
@@ -1,0 +1,60 @@
+import type { Range } from "../../range-ext.js";
+
+/**
+ * `Range#overlap?` / `#overlaps?` (core_ext/range/overlap.rb:8,39), which Ruby
+ * reopens `Range` to define. JS has no `Range` class to reopen — trails carries
+ * the begin/end/exclusive triple as data (`range-ext.ts`) — so the receiver is
+ * the first parameter, exactly as `compare-range.ts` does.
+ *
+ * @boundary-file: endpoints are compared as `number` (JS `Date` coerced to
+ *   epoch millis), as `range-ext.ts`'s sibling comparators do — Ruby compares
+ *   any `<=>`-able endpoint.
+ */
+
+// boundary: Date endpoints, as in range-ext.ts
+const toNum = <T extends number | Date>(v: T): number => (v instanceof Date ? v.getTime() : v);
+
+/** Ruby's private `Range#_empty_range?` (overlap.rb:31). */
+function _isEmptyRange<T extends number | Date>(b: T | null, e: T | null, excl: boolean): boolean {
+  if (b === null || e === null) return false;
+
+  const comp = toNum(b) - toNum(e);
+  return Number.isNaN(comp) || comp > 0 || (comp === 0 && excl);
+}
+
+/**
+ * Compare two ranges and see if they overlap each other
+ *  (1..5).overlap?(4..6) # => true
+ *  (1..5).overlap?(7..9) # => false
+ *
+ * @missingRailsCall raise — Ruby guards `other.is_a? Range` with a `TypeError`
+ * (overlap.rb:9); `other` is statically a `Range<T>` here, so there is no
+ * non-Range value to reject.
+ */
+export function overlap<T extends number | Date>(range: Range<T>, other: Range<T>): boolean {
+  const selfBegin = range.begin;
+  const otherEnd = other.end;
+  const otherExcl = other.excludeEnd;
+
+  if (_isEmptyRange(selfBegin, otherEnd, otherExcl)) return false;
+
+  const otherBegin = other.begin;
+  const selfEnd = range.end;
+  const selfExcl = range.excludeEnd;
+
+  if (_isEmptyRange(otherBegin, selfEnd, selfExcl)) return false;
+  // Ruby's `==` on the endpoints; `toNum` keeps two equal `Date`s equal, which
+  // `===` on the objects would not.
+  if (selfBegin === null || otherBegin === null) {
+    if (selfBegin === otherBegin) return true;
+  } else if (toNum(selfBegin) === toNum(otherBegin)) {
+    return true;
+  }
+
+  if (_isEmptyRange(selfBegin, selfEnd, selfExcl)) return false;
+  if (_isEmptyRange(otherBegin, otherEnd, otherExcl)) return false;
+
+  return true;
+}
+
+export const overlaps = overlap;

--- a/packages/activesupport/src/core-ext/string/succ.ts
+++ b/packages/activesupport/src/core-ext/string/succ.ts
@@ -1,0 +1,112 @@
+/**
+ * `String#succ` — a Ruby *core* method, not a Rails extension, so it has no
+ * `core_ext/string/*.rb` counterpart. It lives with the string core-ext rather
+ * than with the range files that consume it (`rangeIncludesStringValue`
+ * enumerates a string range by repeatedly applying it).
+ *
+ * @noRailsEquivalent PERMANENT — Ruby core `String#succ` (string.c
+ * `rb_str_succ`), which Rails inherits rather than defines.
+ */
+
+const isAsciiAlnum = (c: number): boolean =>
+  (c >= 48 && c <= 57) || (c >= 65 && c <= 90) || (c >= 97 && c <= 122);
+
+/**
+ * `String#succ` — Ruby's successor. Increments the rightmost alphanumeric,
+ * carrying within its character class (`9→0`, `z→a`, `Z→A`) and skipping
+ * non-alphanumerics during the carry; an overflow past the leftmost member of
+ * a class inserts a new leading digit/letter (`"Zz".succ == "AAa"`,
+ * `"99".succ == "100"`). Strings with no alphanumeric increment by raw code
+ * unit instead (`"<<".succ == "<="`).
+ */
+/** Inclusive [min, max] code-point bounds of the UTF-8 width encoding `cp`. */
+function utf8WidthBounds(cp: number): [number, number] {
+  if (cp < 0x80) return [0x00, 0x7f];
+  if (cp < 0x800) return [0x80, 0x7ff];
+  if (cp < 0x10000) return [0x800, 0xffff];
+  return [0x10000, 0x10ffff];
+}
+
+export function succ(s: string): string {
+  if (s.length === 0) return "";
+  const codes = Array.from(s, (ch) => ch.codePointAt(0) as number);
+
+  let lastAlnum = -1;
+  for (let i = codes.length - 1; i >= 0; i--) {
+    if (isAsciiAlnum(codes[i])) {
+      lastAlnum = i;
+      break;
+    }
+  }
+
+  if (lastAlnum === -1) {
+    // No alphanumeric: whole-code-point increment with carry, matching Ruby's
+    // `enc_succ_char`, which advances by encoded character — not by UTF-16
+    // code unit, which would truncate an astral char to its high surrogate.
+    let i = codes.length - 1;
+    let carry = true;
+    while (i >= 0 && carry) {
+      const [min, max] = utf8WidthBounds(codes[i]);
+      if (codes[i] >= max) {
+        // `enc_succ_char` reports NEIGHBOR_WRAPPED whenever the successor's
+        // encoded length would differ (string.c: `l != len`), so a character
+        // at the top of its UTF-8 width wraps to that width's *minimum* and
+        // carries — `"\u{FFFF}".succ.codepoints == [0x1, 0x800]`, not
+        // [0x10000]. The carry then prepends U+0001 below.
+        codes[i] = min;
+      } else {
+        codes[i]++;
+        // Surrogates are not valid characters; `enc_succ_char` skips past
+        // them to the next valid one rather than emitting an unpaired half.
+        if (codes[i] >= 0xd800 && codes[i] <= 0xdfff) codes[i] = 0xe000;
+        carry = false;
+      }
+      i--;
+    }
+    if (carry) codes.unshift(1);
+    return String.fromCodePoint(...codes);
+  }
+
+  // Carry leftward from the rightmost alphanumeric, wrapping within a class.
+  // Ruby stops the carry rather than crossing a non-alphanumeric gap into a
+  // *different* class (digit vs letter): `"z.9".succ == "z.10"`, not `"aa.0"`.
+  const DIGIT = 1;
+  const ALPHA = 2;
+  let i = lastAlnum;
+  let carry = true;
+  let overflowPos = lastAlnum;
+  let overflowChar = 0;
+  let lastWrapClass = 0;
+  let crossedGap = false;
+  while (i >= 0 && carry) {
+    const c = codes[i];
+    if (!isAsciiAlnum(c)) {
+      crossedGap = true;
+      i--;
+      continue;
+    }
+    const thisClass = c >= 48 && c <= 57 ? DIGIT : ALPHA;
+    if (crossedGap && lastWrapClass !== 0 && thisClass !== lastWrapClass) break;
+    crossedGap = false;
+    overflowPos = i;
+    if (c === 57) {
+      codes[i] = 48; // '9' → '0'
+      overflowChar = 49; // insert '1'
+      lastWrapClass = DIGIT;
+    } else if (c === 122) {
+      codes[i] = 97; // 'z' → 'a'
+      overflowChar = 97;
+      lastWrapClass = ALPHA;
+    } else if (c === 90) {
+      codes[i] = 65; // 'Z' → 'A'
+      overflowChar = 65;
+      lastWrapClass = ALPHA;
+    } else {
+      codes[i] = c + 1;
+      carry = false;
+    }
+    i--;
+  }
+  if (carry) codes.splice(overflowPos, 0, overflowChar);
+  return String.fromCodePoint(...codes);
+}

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -508,18 +508,19 @@ export {
 export type { AssertCalledOptions, CallRecord } from "./testing-helpers.js";
 export { currentTimeInstant } from "./time-travel.js";
 
-export {
-  makeRange,
-  overlap,
-  overlaps,
-  rangeIncludesValue,
-  rangeIncludesStringValue,
-  rangeToFs,
-  rangeStep,
-  rangeEach,
-} from "./range-ext.js";
+export { makeRange, rangeIncludesValue, rangeIncludesStringValue } from "./range-ext.js";
 export type { Range as RangeExt } from "./range-ext.js";
 export { caseEquals, isInclude } from "./core-ext/range/compare-range.js";
+export { overlap, overlaps } from "./core-ext/range/overlap.js";
+// `toFs`/`each`/`step` carry the Rails names in their files (which is what
+// `api:compare` matches on) but would collide in this flat barrel — `toFs` with
+// `time-ext.ts`'s `Date#to_fs`, `each`/`step` with the enumerable helpers.
+export {
+  RANGE_FORMATS,
+  toFs as rangeToFs,
+  toFormattedS as rangeToFormattedS,
+} from "./core-ext/range/conversions.js";
+export { each as rangeEach, step as rangeStep } from "./core-ext/range/each.js";
 
 export { I18n } from "./i18n.js";
 export { Scalar } from "./duration.js";

--- a/packages/activesupport/src/range-ext.ts
+++ b/packages/activesupport/src/range-ext.ts
@@ -8,6 +8,8 @@
  *   value. Temporal-typed ranges live elsewhere.
  */
 
+import { succ } from "./core-ext/string/succ.js";
+
 /**
  * The value shape these helpers operate on. Ruby's `Range` is a core class
  * these core-ext files reopen; JS has no such class, so trails carries the
@@ -43,109 +45,6 @@ export function rangeIncludesValue<T extends number | Date>(range: Range<T>, val
   return true;
 }
 
-const isAsciiAlnum = (c: number): boolean =>
-  (c >= 48 && c <= 57) || (c >= 65 && c <= 90) || (c >= 97 && c <= 122);
-
-/**
- * `String#succ` — Ruby's successor. Increments the rightmost alphanumeric,
- * carrying within its character class (`9→0`, `z→a`, `Z→A`) and skipping
- * non-alphanumerics during the carry; an overflow past the leftmost member of
- * a class inserts a new leading digit/letter (`"Zz".succ == "AAa"`,
- * `"99".succ == "100"`). Strings with no alphanumeric increment by raw code
- * unit instead (`"<<".succ == "<="`).
- */
-/** Inclusive [min, max] code-point bounds of the UTF-8 width encoding `cp`. */
-function utf8WidthBounds(cp: number): [number, number] {
-  if (cp < 0x80) return [0x00, 0x7f];
-  if (cp < 0x800) return [0x80, 0x7ff];
-  if (cp < 0x10000) return [0x800, 0xffff];
-  return [0x10000, 0x10ffff];
-}
-
-export function stringSucc(s: string): string {
-  if (s.length === 0) return "";
-  const codes = Array.from(s, (ch) => ch.codePointAt(0) as number);
-
-  let lastAlnum = -1;
-  for (let i = codes.length - 1; i >= 0; i--) {
-    if (isAsciiAlnum(codes[i])) {
-      lastAlnum = i;
-      break;
-    }
-  }
-
-  if (lastAlnum === -1) {
-    // No alphanumeric: whole-code-point increment with carry, matching Ruby's
-    // `enc_succ_char`, which advances by encoded character — not by UTF-16
-    // code unit, which would truncate an astral char to its high surrogate.
-    let i = codes.length - 1;
-    let carry = true;
-    while (i >= 0 && carry) {
-      const [min, max] = utf8WidthBounds(codes[i]);
-      if (codes[i] >= max) {
-        // `enc_succ_char` reports NEIGHBOR_WRAPPED whenever the successor's
-        // encoded length would differ (string.c: `l != len`), so a character
-        // at the top of its UTF-8 width wraps to that width's *minimum* and
-        // carries — `"\u{FFFF}".succ.codepoints == [0x1, 0x800]`, not
-        // [0x10000]. The carry then prepends U+0001 below.
-        codes[i] = min;
-      } else {
-        codes[i]++;
-        // Surrogates are not valid characters; `enc_succ_char` skips past
-        // them to the next valid one rather than emitting an unpaired half.
-        if (codes[i] >= 0xd800 && codes[i] <= 0xdfff) codes[i] = 0xe000;
-        carry = false;
-      }
-      i--;
-    }
-    if (carry) codes.unshift(1);
-    return String.fromCodePoint(...codes);
-  }
-
-  // Carry leftward from the rightmost alphanumeric, wrapping within a class.
-  // Ruby stops the carry rather than crossing a non-alphanumeric gap into a
-  // *different* class (digit vs letter): `"z.9".succ == "z.10"`, not `"aa.0"`.
-  const DIGIT = 1;
-  const ALPHA = 2;
-  let i = lastAlnum;
-  let carry = true;
-  let overflowPos = lastAlnum;
-  let overflowChar = 0;
-  let lastWrapClass = 0;
-  let crossedGap = false;
-  while (i >= 0 && carry) {
-    const c = codes[i];
-    if (!isAsciiAlnum(c)) {
-      crossedGap = true;
-      i--;
-      continue;
-    }
-    const thisClass = c >= 48 && c <= 57 ? DIGIT : ALPHA;
-    if (crossedGap && lastWrapClass !== 0 && thisClass !== lastWrapClass) break;
-    crossedGap = false;
-    overflowPos = i;
-    if (c === 57) {
-      codes[i] = 48; // '9' → '0'
-      overflowChar = 49; // insert '1'
-      lastWrapClass = DIGIT;
-    } else if (c === 122) {
-      codes[i] = 97; // 'z' → 'a'
-      overflowChar = 97;
-      lastWrapClass = ALPHA;
-    } else if (c === 90) {
-      codes[i] = 65; // 'Z' → 'A'
-      overflowChar = 65;
-      lastWrapClass = ALPHA;
-    } else {
-      codes[i] = c + 1;
-      carry = false;
-    }
-    i--;
-  }
-  if (carry) codes.splice(overflowPos, 0, overflowChar);
-  return String.fromCodePoint(...codes);
-}
-
 const lexCmp = (a: string, b: string): number => (a < b ? -1 : a > b ? 1 : 0);
 
 /**
@@ -176,12 +75,12 @@ export function rangeIncludesStringValue(range: Range<string>, value: string): b
   // grows past `end`'s length (succ is non-decreasing in length).
   const n = lexCmp(begin, end);
   if (n > 0 || (excludeEnd && n === 0)) return false;
-  const afterEnd = stringSucc(end);
+  const afterEnd = succ(end);
   let current = begin;
   let guard = 0;
   while (current !== afterEnd) {
     let next: string | null = null;
-    if (excludeEnd || current !== end) next = stringSucc(current);
+    if (excludeEnd || current !== end) next = succ(current);
     if (current === value) return true;
     if (next === null) break;
     current = next;

--- a/packages/activesupport/src/range-ext.ts
+++ b/packages/activesupport/src/range-ext.ts
@@ -1,9 +1,11 @@
 /**
- * Range utility functions mirroring ActiveSupport's Range extensions.
+ * The `Range` data triple, plus the core `Range` methods Ruby provides and
+ * Rails' `core_ext/range/*` files reopen. Those Rails files are ported
+ * one-for-one under `core-ext/range/`.
  *
- * @boundary-file: Date-aware range comparators (`overlap`, `cover`, `each`)
- *   coerce `Date` ↔ epoch number for ordering since Rails' `Range#include?`
- *   accepts any `<=>`-comparable value. Temporal-typed ranges live elsewhere.
+ * @boundary-file: the Date-aware comparators here coerce `Date` ↔ epoch number
+ *   for ordering since Rails' `Range#include?` accepts any `<=>`-comparable
+ *   value. Temporal-typed ranges live elsewhere.
  */
 
 /**
@@ -25,32 +27,6 @@ export interface Range<T> {
 export function makeRange<T>(begin: T | null, end: T | null, excludeEnd = false): Range<T> {
   return { begin, end, excludeEnd };
 }
-
-/**
- * overlap? — returns true if two ranges overlap.
- * Mirrors ActiveSupport Range#overlap?
- */
-export function overlap<T extends number | Date>(a: Range<T>, b: Range<T>): boolean {
-  const toNum = (v: T): number => (v instanceof Date ? v.getTime() : v);
-
-  // a starts after b ends
-  if (a.begin !== null && b.end !== null) {
-    const aBegin = toNum(a.begin);
-    const bEnd = toNum(b.end);
-    if (b.excludeEnd ? aBegin >= bEnd : aBegin > bEnd) return false;
-  }
-
-  // b starts after a ends
-  if (b.begin !== null && a.end !== null) {
-    const bBegin = toNum(b.begin);
-    const aEnd = toNum(a.end);
-    if (a.excludeEnd ? bBegin >= aEnd : bBegin > aEnd) return false;
-  }
-
-  return true;
-}
-
-export const overlaps = overlap; // alias
 
 /**
  * cover? — returns true if a numeric/date range covers a scalar value
@@ -219,36 +195,4 @@ export function rangeIncludesStringValue(range: Range<string>, value: string): b
     }
   }
   return false;
-}
-
-/**
- * toFs — format a range as a string.
- */
-export function rangeToFs<T>(range: Range<T>, format?: string): string {
-  const fmtBegin = range.begin !== null ? String(range.begin) : "";
-  const fmtEnd = range.end !== null ? String(range.end) : "";
-  const sep = range.excludeEnd ? "..." : "..";
-  return `${fmtBegin}${sep}${fmtEnd}`;
-}
-
-/**
- * step — iterate over a numeric range with a step value.
- */
-export function* rangeStep(range: Range<number>, step: number): Generator<number> {
-  if (range.begin === null) throw new Error("Cannot step over beginless range");
-  let current = range.begin;
-  while (true) {
-    if (range.end !== null) {
-      if (range.excludeEnd ? current >= range.end : current > range.end) break;
-    }
-    yield current;
-    current += step;
-  }
-}
-
-/**
- * each — iterate over a numeric range.
- */
-export function* rangeEach(range: Range<number>): Generator<number> {
-  yield* rangeStep(range, 1);
 }


### PR DESCRIPTION
Ships 2 of the 4 bundled stories; the other 2 are handed back (see below).

## `port-remaining-range-core-ext-files`

`range-ext.ts` was a trails-invented flat module. Rails splits the same surface
across `core_ext/range/*.rb`, so each Ruby file now has a matching TS file under
`core-ext/range/`, following the shape #6096 established for `compare_range.rb`
(receiver as first parameter, since Ruby `prepend` has no TS analogue).

- **`conversions.ts`** — `RANGE_FORMATS` plus `to_fs` / `to_formatted_s`. The
  old `rangeToFs` accepted a `format` argument and ignored it, always returning
  `"a..b"`; the `:db` formatter is ported now, so the five `to_fs` tests assert
  Rails' exact strings (`"BETWEEN '2005-12-10' AND '2005-12-12'"`) instead of
  `toContain("2023")`.
- **`each.ts`** — `EachTimeWithZone#each` / `#step` and the private
  `ensure_iteration_allowed` guard. That guard is what the two `it.skip`ed
  `*_on_time_with_zone` tests were waiting on; both now run.
- **`overlap.ts`** — `overlap?` / `overlaps?` ported line for line from
  `overlap.rb` (including the private `_empty_range?`), replacing a
  trails-invented endpoint heuristic that computed the same answers by a
  different route.

`range-ext.ts` keeps only the `Range` triple and the core Ruby methods those
files reopen. Its extra surface drops from `7 novel, 2 moved [no Rails
counterpart]` to `4 novel, 0 moved`.

Per the story, the test file is **not** split — it stays at
`core-ext/range-ext.test.ts`, which `test:compare` maps to `range_ext_test.rb`
(45 matched, unchanged; 2 previously-skipped tests now run).

Two notes for the reviewer:

- The barrel re-exports `toFs`/`each`/`step` under their existing `rangeToFs` /
  `rangeEach` / `rangeStep` names. The files carry the Rails names (which is
  what `api:compare` matches on), but all three would collide in the flat
  barrel — `toFs` with `time-ext.ts`'s `Date#to_fs`, `each`/`step` with the
  enumerable helpers.
- `overlap.ts` still reports `[no Rails counterpart]` in `api:extra`. The
  extractor does not emit an entity for `overlap.rb` because it reopens the
  Ruby core `class Range` rather than declaring an `ActiveSupport::` module —
  unlike its three siblings, which all match. The file is at the Rails path
  now, so it converges the moment the extractor handles core-class reopens; I
  did not paper over it.
- `stringSucc` moved to `core-ext/string/succ.ts` and is now spelled `succ`,
  per the story's "Converged shape" note. (An earlier revision of this PR left
  it in `range-ext.ts`, arguing the novel count would not move — which
  answered the metric rather than the instruction, since the instruction is
  about file placement. Reviewer was right; it is moved.) It carries
  `@noRailsEquivalent PERMANENT`: `String#succ` is Ruby *core*, so there is no
  `core_ext/string/*.rb` counterpart, but the string core-ext is where it
  belongs rather than beside the range files that consume it.

## `rename-multi-statements-enabled-to-conventions-predicate`

`multiStatementsEnabled` -> `isMultiStatementsEnabled`, the name
`docs/ruby-ts-conventions.md` produces for `multi_statements_enabled?`. The
declaration was the only occurrence in the tree.

## Handed back

- **`of-kind-default-type-and-normalize-arguments`** — `pnpm tasks block`ed on
  **#6098**, which is still open. It rewrites the `Errors#ofKind` / `#added`
  bodies and the `errors.test.ts` (+226/-226) and `validations.test.ts`
  (+39/-43) assertions this story has to edit; the colon idiom the story builds
  on is not on `main` yet. The blocker records the remaining work.
- **`retire-schema-cache-test-only-sync-writers`** — `pnpm tasks release`d.
  I confirmed the story's central premise (neither `setPrimaryKeys` nor
  `setDataSourceExists` has a production caller; only `setColumns` does, from
  `AbstractAdapter#columnForAttribute`), but converging it means rewriting ~30
  seeding call sites across ~25 tests onto the real `FakePool` warm path. On top
  of this diff that lands the PR near 700 LOC, so it stays a separate story
  rather than a rushed half-port here.

## Gates

`typecheck` clean; `api:calls` OK (14 baselined) and `api:calls:wide` OK (no new
rows); `api:compare` / `test:compare` non-negative; `lint` clean; the
`range_ext_test.rb` file passes 49/49.
