### PR TITLE
feat(activerecord): pin mid-test pools via notification, retire MySQL visit_TableDefinition, TokenFor on Base

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -138,6 +138,10 @@ import {
   setTokenDefinitions as _setTokenDefinitions,
   generatedTokenVerifier as _generatedTokenVerifier,
   setGeneratedTokenVerifier as _setGeneratedTokenVerifier,
+  generatesTokenFor as _generatesTokenFor,
+  generateTokenFor as _generateTokenFor,
+  findByTokenFor as _findByTokenFor,
+  findByTokenForBang as _findByTokenForBang,
 } from "./token-for.js";
 import type { TokenDefinition as _TokenDefinition } from "./token-for.js";
 import type { MessageVerifier as _MessageVerifier } from "@blazetrails/activesupport/message-verifier";
@@ -2112,6 +2116,15 @@ export class Base extends Model {
 
   /** Mirrors: ActiveRecord::SecureToken::ClassMethods#generate_unique_secure_token (secure_token.rb:57). */
   static generateUniqueSecureToken = _generateUniqueSecureToken;
+
+  /** Mirrors: ActiveRecord::TokenFor::ClassMethods#generates_token_for (token_for.rb:100). */
+  static generatesTokenFor = _generatesTokenFor;
+
+  /** Mirrors: ActiveRecord::TokenFor::ClassMethods#find_by_token_for (token_for.rb:104). */
+  static findByTokenFor = _findByTokenFor;
+
+  /** Mirrors: ActiveRecord::TokenFor::ClassMethods#find_by_token_for! (token_for.rb:108). */
+  static findByTokenForBang = _findByTokenForBang;
 
   // The fallback coder used by `serialize` when no explicit coder is given
   // (`coder ||= default_column_serializer`). Subclasses inherit via JS
@@ -4585,16 +4598,13 @@ export class Base extends Model {
     return defs.has(resolveAliasNameIn(this as never, defs, String(name)));
   }
 
-  // --- TokenFor instance methods (token-for.ts, wired at runtime via generatesTokenFor) ---
-  // Rails' TokenFor module is included in Base; these are its instance methods,
-  // installed on the prototype lazily by generatesTokenFor (so they're only
-  // declared here for api:compare credit). The TokenFor *class* accessors
-  // (token_definitions / generated_token_verifier) are real static getters above
-  // — token-for.ts only imports MessageVerifier, the same node:crypto-backed
-  // dependency base.ts already pulls in via signed-id.ts; crypto stays out of the
-  // public barrel because index.ts routes generatesTokenFor to a subpath (BC-3),
-  // not because base.ts avoids the import.
-  declare generateTokenFor: (purpose: string) => string;
+  /**
+   * Mirrors: ActiveRecord::TokenFor#generate_token_for (token_for.rb:118).
+   */
+  generateTokenFor(purpose: string): string {
+    return _generateTokenFor(this, purpose);
+  }
+
   /** @internal */
   declare fullPurpose: () => string;
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
@@ -217,46 +217,6 @@ export class SchemaCreation extends AbstractSchemaCreation {
     return this.adapter.supportsCheckConstraints();
   }
 
-  /**
-   * MySQL CREATE TABLE generator. Mirrors Rails'
-   * `abstract/schema_creation.rb#visit_TableDefinition`, routing every
-   * column through {@link SchemaCreation#visitColumnDefinition} so
-   * `addColumnOptions` (this subclass) handles `AUTO_INCREMENT`,
-   * `ON UPDATE`, charset/collation, etc. consistently with addColumn.
-   *
-   * @internal
-   */
-  protected override async visitTableDefinition(o: TableDefinition): Promise<string> {
-    let sql = `CREATE${this.tableModifierInCreate(o)} TABLE`;
-    if (o.ifNotExists) sql += " IF NOT EXISTS";
-    sql += ` ${this.adapter.quoteTableName(o.tableName)}`;
-
-    // Mirrors the abstract visitor's sequential map-to-thunks shape.
-    const statements: string[] = [];
-    for (const visit of o.columns.map((c) => () => this.visitColumnDefinition(c))) {
-      statements.push(await visit());
-    }
-    const primaryKeys = o.primaryKeys();
-    if (primaryKeys) statements.push(this.visitPrimaryKeyDefinition(primaryKeys));
-    if (this.supportsIndexesInCreate()) {
-      for (const [columnName, options] of o.indexes) {
-        statements.push(await this.indexInCreate(o.tableName, columnName, options));
-      }
-    }
-    if (this.useForeignKeys()) {
-      for (const fk of o.foreignKeys) statements.push(this.visitForeignKeyDefinition(fk));
-    }
-    if (this.supportsCheckConstraints()) {
-      for (const chk of o.checkConstraints)
-        statements.push(this.visitCheckConstraintDefinition(chk));
-    }
-
-    if (statements.length > 0) sql += ` (${statements.join(", ")})`;
-    sql = this.addTableOptionsBang(sql, o);
-    if (o.as) sql += ` AS ${o.as}`;
-    return sql;
-  }
-
   /** @internal */
   override accept(
     o:

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -32,6 +32,7 @@ describe("ConnectionHandlingTest", () => {
       "establish_connection with a url stores a UrlConfig with discrete fields",
       "remove_connection removes the pool",
       "remove_connection returns undefined when no pool exists",
+      "establishConnection backfills the adapter on an adapter-less HashConfig",
     ],
   });
 

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -24,8 +24,12 @@ import * as nodeOs from "node:os";
 import * as nodePath from "node:path";
 
 describe("ConnectionHandlingTest", () => {
-  // The opted-out cases assert the pool releases its connection, which
-  // transactional fixtures defeat by pinning one for the wrapping transaction.
+  // The opted-out cases either assert the pool releases its connection, or
+  // establish one against a config that is never meant to be dialled
+  // (`db/foo.sqlite3`, an in-memory registry entry). Transactional fixtures
+  // defeat both: setup pins a connection for the wrapping transaction, and the
+  // `!connection.active_record` subscriber pins any pool established mid-test,
+  // whose `verifyBang` then really connects.
   fixtures(["posts"], {
     usesTransaction: [
       "common APIs don't permanently hold a connection when permanent checkout is deprecated or disallowed",
@@ -33,6 +37,8 @@ describe("ConnectionHandlingTest", () => {
       "remove_connection removes the pool",
       "remove_connection returns undefined when no pool exists",
       "establishConnection backfills the adapter on an adapter-less HashConfig",
+      "autoConnect honors an in-memory DatabaseConfigurations registry",
+      "autoConnect reconnects via mutated configuration.database for UrlConfig",
     ],
   });
 

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -286,7 +286,8 @@ export { ColumnNotSerializableError } from "./attribute-methods/serialization.js
 // Encryption is server-only. Import `@blazetrails/activerecord/encryption` BEFORE
 // calling Base.encrypts() — omitting it throws at declaration time.
 // Boot-time installer: `@blazetrails/activerecord/encryption/install.js`.
-// generatesTokenFor requires node:crypto — use subpath: @blazetrails/activerecord/generates-token-for
+// generatesTokenFor / findByTokenFor / findByTokenForBang are class methods on
+// Base (base.rb:328 `include TokenFor`); generateTokenFor is an instance method.
 export { delegatedType, getDelegatedTypeConfig } from "./delegated-type.js";
 export { DatabaseConfig } from "./database-configurations/database-config.js";
 export type { DatabaseConfigOptions } from "./database-configurations/database-config.js";

--- a/packages/activerecord/src/secure-password.ts
+++ b/packages/activerecord/src/secure-password.ts
@@ -1,7 +1,6 @@
 import { getCrypto, camelize, humanize, isBlank, pbkdf2Async } from "@blazetrails/activesupport";
 import { ArgumentError } from "@blazetrails/activemodel";
 import type { Base } from "./base.js";
-import { generatesTokenFor } from "./token-for.js";
 
 /**
  * Secure password support using PBKDF2 (Web Crypto API).
@@ -271,7 +270,7 @@ export function hasSecurePassword(
     // When the password (and therefore the digest) changes, the hash changes
     // too — existing tokens are automatically invalidated, matching Rails'
     // BCrypt::Password#version approach.
-    generatesTokenFor(modelClass, purpose, {
+    modelClass.generatesTokenFor(purpose, {
       expiresIn: FIFTEEN_MINUTES,
       generator: (record: Base) => {
         const digest = record._readAttribute(digestAttr);

--- a/packages/activerecord/src/test-fixtures.ts
+++ b/packages/activerecord/src/test-fixtures.ts
@@ -35,6 +35,7 @@ import { registerModel } from "./associations.js";
 import {
   withTransactionalFixtures,
   type WithTransactionalFixturesOptions,
+  pinFixtureConnectionPool,
 } from "./test-fixtures/with-transactional-fixtures.js";
 import {
   leaseFixtureConnection,
@@ -516,6 +517,7 @@ function useFixtures(
         registerModel(model);
       }
       const adapter = await leaseFixtureConnectionFor(model, fixtureConnection);
+      await pinFixtureConnectionPool(adapter);
       setAdapters.set(key, adapter);
       let group = groups.get(adapter);
       if (group === undefined) {

--- a/packages/activerecord/src/test-fixtures.ts
+++ b/packages/activerecord/src/test-fixtures.ts
@@ -34,7 +34,6 @@ import { Base } from "./base.js";
 import { registerModel } from "./associations.js";
 import {
   withTransactionalFixtures,
-  pinFixtureConnectionPool,
   type WithTransactionalFixturesOptions,
 } from "./test-fixtures/with-transactional-fixtures.js";
 import {
@@ -517,7 +516,6 @@ function useFixtures(
         registerModel(model);
       }
       const adapter = await leaseFixtureConnectionFor(model, fixtureConnection);
-      await pinFixtureConnectionPool(adapter);
       setAdapters.set(key, adapter);
       let group = groups.get(adapter);
       if (group === undefined) {

--- a/packages/activerecord/src/test-fixtures/with-transactional-fixtures.test.ts
+++ b/packages/activerecord/src/test-fixtures/with-transactional-fixtures.test.ts
@@ -57,6 +57,20 @@ describe("withTransactionalFixtures", () => {
     expect(rows).toHaveLength(0);
   });
 
+  it("pins a connection pool established inside the test body", async () => {
+    // Rails pins mid-test pools from its "!connection.active_record" subscriber
+    // (test_fixtures.rb:183-200); the notification is emitted by
+    // ConnectionHandler#establish_connection (connection_handler.rb:149).
+    const pool = Base.connectionHandler.establishConnection(
+      { adapter: "sqlite3", database: ":memory:" },
+      { owner: "MidTestPool" },
+    );
+    // The subscriber's pin/lease is async, so let its microtasks settle.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect((pool as unknown as { _fixturePin: unknown })._fixturePin).not.toBeNull();
+  });
+
   it("nested user transaction becomes a savepoint and still rolls back at teardown", async () => {
     const tm = ((await primaryAdapter()) as unknown as TmHandle).transactionManager;
     await tm.beginTransaction({});

--- a/packages/activerecord/src/test-fixtures/with-transactional-fixtures.ts
+++ b/packages/activerecord/src/test-fixtures/with-transactional-fixtures.ts
@@ -5,6 +5,8 @@
  * module for size only; see the header of `../test-fixtures.ts`.
  */
 import { beforeEach, afterEach, type TaskContext } from "vitest";
+import { Notifications, type NotificationSubscriber } from "@blazetrails/activesupport";
+import { Base } from "../base.js";
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
 import type { ConnectionPool } from "../connection-adapters/abstract/connection-pool.js";
 import { NullPool } from "../connection-adapters/abstract/connection-pool.js";
@@ -130,38 +132,34 @@ let fixtureConnectionPools: ConnectionPool[] | null = null;
 let fixtureScopeDepth = 0;
 
 /**
- * Pin the pool a fixture set is about to seed through, if the running test has
- * not pinned it already.
- *
- * Rails discovers these the same way, from the `!connection.active_record`
- * subscriber `setup_transactional_fixtures` installs
- * (`test_fixtures.rb:183-200`): a pool that shows up after setup is pinned,
- * leased and appended to `@fixture_connection_pools`. trails has no such
- * notification, but `fixtures()` seeds each set through its own model's pool
- * (`leaseFixtureConnectionFor`), so the seeding site is the discovery point —
- * without this, a set on the arunit2 secondary commits its rows and only
- * teardown's per-set DELETE removes them.
- *
- * A no-op outside a transactional test, and for an adapter with no pool of its
- * own (the raw-adapter cluster suites seed through the connection the wrapper
- * already opened a transaction on).
- *
- * @noRailsEquivalent CONVERGEABLE — Rails' counterpart is the anonymous
- * `ActiveSupport::Notifications.subscribe("!connection.active_record")` block in
- * `setup_transactional_fixtures` (test_fixtures.rb:183-200); trails has no such
- * notification to subscribe to yet. Retired by RFC 0064
- * `pin-fixture-pools-via-connection-notification`, which emits it from
- * `ConnectionPool#newConnection` and deletes this function.
+ * The pools whose `pinConnectionBang` actually resolved, and therefore the only
+ * ones teardown may unpin. Rails needs no such split: its push and its
+ * pin/lease are one synchronous step (`test_fixtures.rb:176-180`, `:192-196`),
+ * so membership in `@fixture_connection_pools` is proof of a pin. The
+ * subscriber's are two events, and `unpinConnectionBang` raises on a pool that
+ * was never pinned (`connection-pool.ts:726`).
  */
-export async function pinFixtureConnectionPool(
-  adapter: TransactionalFixturesAdapter,
-): Promise<void> {
-  if (fixtureConnectionPools === null) return;
-  const pool = pooledAdapterPool(adapter);
-  if (pool === null || fixtureConnectionPools.includes(pool)) return;
+let pinnedPools: ConnectionPool[] = [];
+
+/** Rails' `@connection_subscriber` (`test_fixtures.rb:183`). */
+let connectionSubscriber: NotificationSubscriber | null = null;
+
+/**
+ * In-flight pins queued by the `!connection.active_record` subscriber. Settled
+ * in teardown so a rejected pin fails the test instead of surfacing as an
+ * unhandled rejection.
+ */
+let pendingPins: Promise<void>[] = [];
+
+/**
+ * Pin, lease and register `pool` unless the running test already has it.
+ * Mirrors the body Rails runs from both `setup_transactional_fixtures` sites
+ * (`test_fixtures.rb:177-180` and `:192-196`).
+ */
+async function pinConnectionPool(pool: ConnectionPool): Promise<void> {
   await pool.pinConnectionBang({ fixture: true });
+  pinnedPools.push(pool);
   await pool.leaseConnection();
-  fixtureConnectionPools.push(pool);
 }
 
 /**
@@ -279,11 +277,6 @@ export function withTransactionalFixtures(
   // Tracks whether we opened an outer transaction for the current test.
   // Tests in usesTransaction run without a wrapping transaction (Rails parity:
   // test_fixtures.rb:108-110 run_in_transaction? returns false for these).
-  // Known gap vs Rails: Rails also subscribes to "!connection.active_record"
-  // to pin connection pools opened mid-test (test_fixtures.rb:183-200). We
-  // only pin the pools that exist at beforeEach time; pools opened during the
-  // test body are not pinned. Closing this gap requires adding a notification
-  // hook to ConnectionPool#newConnection (production code change).
   let _txnOpenedForTest = false;
 
   beforeEach(async (ctx: TaskContext) => {
@@ -322,23 +315,84 @@ export function withTransactionalFixtures(
       // won't find the pin set in beforeEach.
       if (fixtureConnectionPools === null) fixtureConnectionPools = [];
       fixtureScopeDepth++;
-      await pinFixtureConnectionPool(adapter);
+      // Mirrors test_fixtures.rb:175-180:
+      //   @fixture_connection_pools = ActiveRecord::Base.connection_handler
+      //     .connection_pool_list(:writing)
+      //   @fixture_connection_pools.each { |pool| pool.pin_connection!(...); pool.lease_connection }
+      // Every writing pool, not just this adapter's: a fixture set on the
+      // arunit2 secondary seeds through its own model's pool, and an unpinned
+      // one commits its rows. This is what retired `pinFixtureConnectionPool`,
+      // which pinned the same pools later, from the seeding site.
+      const writingPools = [pool, ...Base.connectionHandler.connectionPoolList("writing")];
+      for (const p of writingPools) {
+        if (fixtureConnectionPools.includes(p)) continue;
+        fixtureConnectionPools.push(p);
+        await pinConnectionPool(p);
+      }
     } else {
       // Non-pooled path — preserved verbatim. Mirrors Rails
       // ConnectionPool#pin_connection! body.
       await tm(adapter).beginTransaction({ joinable: false, _lazy: false });
     }
+
+    // When connections are established in the future, begin a transaction too.
+    // Mirrors test_fixtures.rb:182-200 — Rails' anonymous subscriber block on
+    // "!connection.active_record", emitted by ConnectionHandler#establishConnection
+    // (connection_handler.rb:149).
+    connectionSubscriber = Notifications.subscribe("!connection.active_record", (event) => {
+      const payload = event.payload as { connection_name?: string; shard?: string };
+      const connectionName = "connection_name" in payload ? payload.connection_name : undefined;
+      const shard = "shard" in payload ? payload.shard : undefined;
+
+      if (connectionName != null) {
+        const newPool = Base.connectionHandler.retrieveConnectionPool(connectionName, { shard });
+        if (newPool) {
+          if (fixtureConnectionPools !== null && !fixtureConnectionPools.includes(newPool)) {
+            // The pin/lease pair is async where Rails' is not
+            // (test_fixtures.rb:193-194), and the subscriber body must stay
+            // synchronous because Notifications does not await its listeners.
+            // The push stays synchronous so a second notification for the same
+            // pool is deduplicated by the `includes` guard above, the way
+            // Rails' fully-synchronous block is; the promise settles in
+            // teardown.
+            fixtureConnectionPools.push(newPool);
+            pendingPins.push(pinConnectionPool(newPool));
+          }
+        }
+      }
+    });
   });
 
   afterEach(async () => {
-    if (!_txnOpenedForTest) return;
+    // Mirrors test_fixtures.rb:203.
+    if (connectionSubscriber) {
+      Notifications.unsubscribe(connectionSubscriber);
+      connectionSubscriber = null;
+    }
+    // `allSettled`, not `all`: every pin has to settle before `pinnedPools` is
+    // final, and one rejection must not skip the unpin of the pools that did
+    // pin. The failure is re-raised at the end of teardown so the rest of it
+    // still runs — Rails raises straight out of the subscriber body, but its
+    // pin is synchronous, so there is nothing left half-done to clean up.
+    const pins = pendingPins;
+    pendingPins = [];
+    const pinResults = await Promise.allSettled(pins);
+    if (!_txnOpenedForTest) {
+      const failed = pinResults.find((r) => r.status === "rejected");
+      if (failed) throw failed.reason;
+      return;
+    }
     const adapter = getAdapter();
     if (fixtureConnectionPools !== null && pooledAdapterPool(adapter) !== null) {
       // Mirrors Rails test_fixtures.rb:206-211 teardown:
       //   @fixture_connection_pools.map(&:unpin_connection!)
       //   @fixture_connection_pools.clear
       if (--fixtureScopeDepth === 0) {
-        for (const pool of fixtureConnectionPools) {
+        // Driven by `pinnedPools`, not by the registered list: a pool whose pin
+        // rejected is registered but not pinned.
+        const pools = pinnedPools;
+        pinnedPools = [];
+        for (const pool of pools) {
           await pool.unpinConnectionBang();
         }
         fixtureConnectionPools = null;
@@ -348,5 +402,7 @@ export function withTransactionalFixtures(
       while (t.openTransactions > 0) await t.rollbackTransaction();
     }
     if (invalidateSchemaCache) await reReflectTouchedTables(adapter);
+    const failed = pinResults.find((r) => r.status === "rejected");
+    if (failed) throw failed.reason;
   });
 }

--- a/packages/activerecord/src/test-fixtures/with-transactional-fixtures.ts
+++ b/packages/activerecord/src/test-fixtures/with-transactional-fixtures.ts
@@ -132,6 +132,42 @@ let fixtureConnectionPools: ConnectionPool[] | null = null;
 let fixtureScopeDepth = 0;
 
 /**
+ * Pin the pool a fixture set is about to seed through, if the running test has
+ * not pinned it already.
+ *
+ * Rails needs no such call. It pins every writing pool in
+ * `setup_transactional_fixtures` itself (`test_fixtures.rb:175-180`), and
+ * discovers later ones from the `!connection.active_record` subscriber
+ * (`:182-200`) — which trails now installs below. What is still missing is the
+ * literal setup line: pinning `connectionPoolList("writing")` wholesale breaks
+ * `base_test.rb`'s `connection in utc time`, where a mid-test
+ * `establishConnection` disconnects the pinned pool and teardown then unpins a
+ * pool with no pin. Rails survives that because `disconnect!`/`discard!` leave
+ * `@pinned_connection` alone — it is cleared only in `initialize`
+ * (`connection_pool.rb:267`) and `unpin_connection!` (`:347`) — where
+ * `ConnectionPool#_disconnect`/`#_discard` null `_fixturePin`
+ * (`connection-pool.ts:975`, `:1040`). Until that diverges back, seeding is the
+ * discovery point for pools established before setup.
+ *
+ * A no-op outside a transactional test, and for an adapter with no pool of its
+ * own (the raw-adapter cluster suites seed through the connection the wrapper
+ * already opened a transaction on).
+ *
+ * @noRailsEquivalent CONVERGEABLE — see above; blocked on the `_fixturePin`
+ * divergence in `ConnectionPool#_disconnect`/`#_discard`, tracked by RFC 0064
+ * `pin-writing-pool-list-in-setup-transactional-fixtures`.
+ */
+export async function pinFixtureConnectionPool(
+  adapter: TransactionalFixturesAdapter,
+): Promise<void> {
+  if (fixtureConnectionPools === null) return;
+  const pool = pooledAdapterPool(adapter);
+  if (pool === null || fixtureConnectionPools.includes(pool)) return;
+  fixtureConnectionPools.push(pool);
+  await pinConnectionPool(pool);
+}
+
+/**
  * The pools whose `pinConnectionBang` actually resolved, and therefore the only
  * ones teardown may unpin. Rails needs no such split: its push and its
  * pin/lease are one synchronous step (`test_fixtures.rb:176-180`, `:192-196`),
@@ -315,20 +351,7 @@ export function withTransactionalFixtures(
       // won't find the pin set in beforeEach.
       if (fixtureConnectionPools === null) fixtureConnectionPools = [];
       fixtureScopeDepth++;
-      // Mirrors test_fixtures.rb:175-180:
-      //   @fixture_connection_pools = ActiveRecord::Base.connection_handler
-      //     .connection_pool_list(:writing)
-      //   @fixture_connection_pools.each { |pool| pool.pin_connection!(...); pool.lease_connection }
-      // Every writing pool, not just this adapter's: a fixture set on the
-      // arunit2 secondary seeds through its own model's pool, and an unpinned
-      // one commits its rows. This is what retired `pinFixtureConnectionPool`,
-      // which pinned the same pools later, from the seeding site.
-      const writingPools = [pool, ...Base.connectionHandler.connectionPoolList("writing")];
-      for (const p of writingPools) {
-        if (fixtureConnectionPools.includes(p)) continue;
-        fixtureConnectionPools.push(p);
-        await pinConnectionPool(p);
-      }
+      await pinFixtureConnectionPool(adapter);
     } else {
       // Non-pooled path — preserved verbatim. Mirrors Rails
       // ConnectionPool#pin_connection! body.

--- a/packages/activerecord/src/test-helpers/models/cpk.ts
+++ b/packages/activerecord/src/test-helpers/models/cpk.ts
@@ -3,7 +3,6 @@ import { throwAbort } from "@blazetrails/activesupport";
 // vendor/rails/activerecord/test/models/cpk/
 import { Base } from "../../base.js";
 import { acceptsNestedAttributesFor } from "../../nested-attributes.js";
-import { generatesTokenFor } from "../../token-for.js";
 
 // cpk/author.rb
 export class CpkAuthor extends Base {
@@ -61,7 +60,7 @@ export class CpkBook extends Base {
 }
 
 acceptsNestedAttributesFor(CpkBook, "chapters");
-generatesTokenFor(CpkBook, "test");
+CpkBook.generatesTokenFor("test");
 
 export class CpkBestSeller extends CpkBook {
   declare loadBelongsTo: ((name: "order") => Promise<CpkOrder | null>) &

--- a/packages/activerecord/src/token-for.test.ts
+++ b/packages/activerecord/src/token-for.test.ts
@@ -10,7 +10,7 @@ import { Room } from "./test-helpers/models/room.js";
 import { CpkBook } from "./test-helpers/models/cpk.js";
 import { InvalidSignature } from "@blazetrails/activesupport/message-verifier";
 import { travel, travelBack } from "@blazetrails/activesupport";
-import { generatesTokenFor, setTokenForSecret } from "./token-for.js";
+import { setTokenForSecret } from "./token-for.js";
 import { fixtures } from "./test-fixtures.js";
 // Zeitwerk analog: Cpk::Book's counter-cached/association targets (Cpk::Order)
 // are resolved by name, as Rails resolves them from the autoloaded models tree.
@@ -19,13 +19,13 @@ import "./support/canonical-model-index.js";
 // Rails: class User < ::User { generates_token_for :lookup; … }
 class TokenUser extends User {
   static {
-    generatesTokenFor(this, "lookup");
-    generatesTokenFor(this, "password_reset", {
+    this.generatesTokenFor("lookup");
+    this.generatesTokenFor("password_reset", {
       expiresIn: 15 * 60,
       // first 10 characters of the BCrypt salt — Rails: password_digest.to_s[-(31 + 22), 10]
       generator: (r: any) => String(r.password_digest ?? "").slice(-(31 + 22), -(31 + 22) + 10),
     });
-    generatesTokenFor(this, "snapshot", {
+    this.generatesTokenFor("snapshot", {
       generator: (r: any) => ({ updated_at: r.updated_at }),
     });
   }
@@ -56,8 +56,8 @@ describe("TokenForTest", () => {
     user = new TokenUser();
     (user as any).password_digest = `$2a$4$${"x".repeat(22)}${"y".repeat(31)}`;
     await user.save();
-    lookupToken = (user as any).generateTokenFor("lookup");
-    passwordResetToken = (user as any).generateTokenFor("password_reset");
+    lookupToken = user.generateTokenFor("lookup");
+    passwordResetToken = user.generateTokenFor("password_reset");
   });
 
   afterEach(async () => {
@@ -68,91 +68,85 @@ describe("TokenForTest", () => {
   });
 
   it("finds record by token", async () => {
-    expect((await (TokenUser as any).findByTokenFor("lookup", lookupToken)).id).toBe(user.id);
-    expect((await (TokenUser as any).findByTokenForBang("lookup", lookupToken)).id).toBe(user.id);
+    expect((await TokenUser.findByTokenFor("lookup", lookupToken))!.id).toBe(user.id);
+    expect((await TokenUser.findByTokenForBang("lookup", lookupToken)).id).toBe(user.id);
   });
 
   it("returns nil when record is not found", async () => {
     await user.destroy();
-    expect(await (TokenUser as any).findByTokenFor("lookup", lookupToken)).toBeNull();
+    expect(await TokenUser.findByTokenFor("lookup", lookupToken)).toBeNull();
   });
 
   it("raises on bang when record is not found", async () => {
     await user.destroy();
-    await expect((TokenUser as any).findByTokenForBang("lookup", lookupToken)).rejects.toThrow(
+    await expect(TokenUser.findByTokenForBang("lookup", lookupToken)).rejects.toThrow(
       RecordNotFound,
     );
   });
 
   it("raises when token definition does not exist", async () => {
-    await expect((TokenUser as any).findByTokenFor("bad", lookupToken)).rejects.toThrow();
+    await expect(TokenUser.findByTokenFor("bad", lookupToken)).rejects.toThrow();
   });
 
   it("does not find record when token is invalid", async () => {
-    expect(await (TokenUser as any).findByTokenFor("lookup", "bad")).toBeNull();
-    await expect((TokenUser as any).findByTokenForBang("lookup", "bad")).rejects.toThrow(
+    expect(await TokenUser.findByTokenFor("lookup", "bad")).toBeNull();
+    await expect(TokenUser.findByTokenForBang("lookup", "bad")).rejects.toThrow(InvalidSignature);
+  });
+
+  it("does not find record when token is for a different purpose", async () => {
+    expect(await TokenUser.findByTokenFor("password_reset", lookupToken)).toBeNull();
+    await expect(TokenUser.findByTokenForBang("password_reset", lookupToken)).rejects.toThrow(
       InvalidSignature,
     );
   });
 
-  it("does not find record when token is for a different purpose", async () => {
-    expect(await (TokenUser as any).findByTokenFor("password_reset", lookupToken)).toBeNull();
-    await expect(
-      (TokenUser as any).findByTokenForBang("password_reset", lookupToken),
-    ).rejects.toThrow(InvalidSignature);
-  });
-
   it("finds record when token has not expired and embedded data has not changed", async () => {
-    expect((await (TokenUser as any).findByTokenFor("password_reset", passwordResetToken)).id).toBe(
+    expect((await TokenUser.findByTokenFor("password_reset", passwordResetToken))!.id).toBe(
       user.id,
     );
   });
 
   it("does not find record when token has expired", async () => {
     travel(DAY);
-    expect(
-      await (TokenUser as any).findByTokenFor("password_reset", passwordResetToken),
-    ).toBeNull();
+    expect(await TokenUser.findByTokenFor("password_reset", passwordResetToken)).toBeNull();
     await expect(
-      (TokenUser as any).findByTokenForBang("password_reset", passwordResetToken),
+      TokenUser.findByTokenForBang("password_reset", passwordResetToken),
     ).rejects.toThrow(InvalidSignature);
   });
 
   it("tokens do not expire by default", async () => {
     travel(1000 * 365 * DAY);
-    expect((await (TokenUser as any).findByTokenFor("lookup", lookupToken)).id).toBe(user.id);
+    expect((await TokenUser.findByTokenFor("lookup", lookupToken))!.id).toBe(user.id);
   });
 
   it("does not find record when expires_in is different", async () => {
-    generatesTokenFor(TokenUser, "lookup", { expiresIn: 365 * DAY });
+    TokenUser.generatesTokenFor("lookup", { expiresIn: 365 * DAY });
 
     try {
-      expect(await (TokenUser as any).findByTokenFor("lookup", lookupToken)).toBeNull();
-      const newLookupToken = (user as any).generateTokenFor("lookup");
-      expect((await (TokenUser as any).findByTokenFor("lookup", newLookupToken)).id).toBe(user.id);
+      expect(await TokenUser.findByTokenFor("lookup", lookupToken)).toBeNull();
+      const newLookupToken = user.generateTokenFor("lookup");
+      expect((await TokenUser.findByTokenFor("lookup", newLookupToken))!.id).toBe(user.id);
     } finally {
-      generatesTokenFor(TokenUser, "lookup");
+      TokenUser.generatesTokenFor("lookup");
     }
   });
 
   it("does not find record when embedded data is different", async () => {
     (user as any).password_digest = "new password";
     await user.save();
-    expect(
-      await (TokenUser as any).findByTokenFor("password_reset", passwordResetToken),
-    ).toBeNull();
+    expect(await TokenUser.findByTokenFor("password_reset", passwordResetToken)).toBeNull();
     await expect(
-      (TokenUser as any).findByTokenForBang("password_reset", passwordResetToken),
+      TokenUser.findByTokenForBang("password_reset", passwordResetToken),
     ).rejects.toThrow(InvalidSignature);
   });
 
   it("supports JSON-serializable embedded data", async () => {
-    const snapshotToken = (user as any).generateTokenFor("snapshot");
-    expect((await (TokenUser as any).findByTokenFor("snapshot", snapshotToken)).id).toBe(user.id);
+    const snapshotToken = user.generateTokenFor("snapshot");
+    expect((await TokenUser.findByTokenFor("snapshot", snapshotToken))!.id).toBe(user.id);
     // Rails: @user.touch(time: @user.updated_at.advance(seconds: 1))
     const advanced = new Date(new Date(String((user as any).updated_at)).getTime() + 1000);
     await (user as any).touch({ time: advanced });
-    expect(await (TokenUser as any).findByTokenFor("snapshot", snapshotToken)).toBeNull();
+    expect(await TokenUser.findByTokenFor("snapshot", snapshotToken)).toBeNull();
   });
 
   it("finds record through relation", async () => {
@@ -164,26 +158,24 @@ describe("TokenForTest", () => {
 
   it("finds record through subclass", async () => {
     class Subclass extends TokenUser {}
-    const subclassedUser = await (Subclass as any).findByTokenFor("lookup", lookupToken);
+    const subclassedUser = await Subclass.findByTokenFor("lookup", lookupToken);
 
     expect(subclassedUser).toBeInstanceOf(Subclass);
-    expect(subclassedUser.id).toBe(user.id);
+    expect(subclassedUser!.id).toBe(user.id);
   });
 
   it("subclasses can redefine tokens", async () => {
     class Subclass extends TokenUser {
       static {
-        generatesTokenFor(this, "lookup");
+        this.generatesTokenFor("lookup");
       }
     }
     const subclassedUser = await Subclass.find(user.id);
     const subclassedLookupToken = (subclassedUser as any).generateTokenFor("lookup");
 
-    expect((await (Subclass as any).findByTokenFor("lookup", subclassedLookupToken)).id).toBe(
-      user.id,
-    );
-    expect(await (Subclass as any).findByTokenFor("lookup", lookupToken)).toBeNull();
-    expect(await (TokenUser as any).findByTokenFor("lookup", subclassedLookupToken)).toBeNull();
+    expect((await Subclass.findByTokenFor("lookup", subclassedLookupToken))!.id).toBe(user.id);
+    expect(await Subclass.findByTokenFor("lookup", lookupToken)).toBeNull();
+    expect(await TokenUser.findByTokenFor("lookup", subclassedLookupToken)).toBeNull();
   });
 
   it("finds record with a custom primary key", async () => {
@@ -193,29 +185,27 @@ describe("TokenForTest", () => {
     const customPkUser = await CustomPk.find((user as any).auth_token);
     const customPkLookupToken = (customPkUser as any).generateTokenFor("lookup");
 
-    expect((await (CustomPk as any).findByTokenFor("lookup", customPkLookupToken)).id).toBe(
+    expect((await CustomPk.findByTokenFor("lookup", customPkLookupToken))!.id).toBe(
       (customPkUser as any).id,
     );
-    expect(await (CustomPk as any).findByTokenFor("lookup", lookupToken)).toBeNull();
+    expect(await CustomPk.findByTokenFor("lookup", lookupToken)).toBeNull();
   });
 
   it("finds record with a composite primary key", async () => {
     // Rails: Cpk::Book.create!(id: [1, 3], shop_id: 2) — composite PK [author_id, id].
     const book = await CpkBook.create({ id: [1, 3], shop_id: 2 });
-    const token = (book as any).generateTokenFor("test");
+    const token = book.generateTokenFor("test");
 
-    expect((await (CpkBook as any).findByTokenFor("test", token)).id).toEqual((book as any).id);
+    expect((await CpkBook.findByTokenFor("test", token))!.id).toEqual((book as any).id);
   });
 
   it("raises when no primary key has been declared", async () => {
     class NoPk extends Matey {
       static {
-        generatesTokenFor(this, "parley");
+        this.generatesTokenFor("parley");
       }
     }
 
-    await expect(
-      (NoPk as any).findByTokenFor("parley", "this token will not be checked"),
-    ).rejects.toThrow();
+    await expect(NoPk.findByTokenFor("parley", "this token will not be checked")).rejects.toThrow();
   });
 });

--- a/packages/activerecord/src/token-for.trails.test.ts
+++ b/packages/activerecord/src/token-for.trails.test.ts
@@ -7,12 +7,12 @@
  */
 import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
 import { User } from "./test-helpers/models/user.js";
-import { generatesTokenFor, setTokenForSecret } from "./token-for.js";
+import { setTokenForSecret } from "./token-for.js";
 import { fixtures } from "./test-fixtures.js";
 
 class TokenUser extends User {
   static {
-    generatesTokenFor(this, "lookup");
+    this.generatesTokenFor("lookup");
   }
 }
 

--- a/packages/activerecord/src/token-for.ts
+++ b/packages/activerecord/src/token-for.ts
@@ -294,49 +294,15 @@ export function setGeneratedTokenVerifier(
  * Mirrors: ActiveRecord::TokenFor::ClassMethods#generates_token_for
  */
 export function generatesTokenFor(
-  modelClass: typeof Base,
+  this: typeof Base,
   purpose: string,
   options: {
     expiresIn?: number;
     generator?: (record: any) => unknown;
   } = {},
 ): void {
-  const def = new TokenDefinition(modelClass, purpose, options.expiresIn, options.generator);
-  setTokenDefinitions(modelClass, tokenDefinitions(modelClass).merge({ [purpose]: def }));
-
-  if (!(modelClass.prototype as any).generateTokenFor) {
-    Object.defineProperty(modelClass.prototype, "generateTokenFor", {
-      value: function (this: Base, purposeName: string): string {
-        return generateTokenFor(this, purposeName);
-      },
-      writable: true,
-      configurable: true,
-    });
-  }
-
-  if (!(modelClass as any).findByTokenFor) {
-    Object.defineProperty(modelClass, "findByTokenFor", {
-      value: async function (
-        this: typeof Base,
-        purposeName: string,
-        token: string,
-      ): Promise<Base | null> {
-        return findByTokenFor(this, purposeName, token);
-      },
-      writable: true,
-      configurable: true,
-    });
-  }
-
-  if (!(modelClass as any).findByTokenForBang) {
-    Object.defineProperty(modelClass, "findByTokenForBang", {
-      value: async function (this: typeof Base, purposeName: string, token: string): Promise<Base> {
-        return findByTokenForBang(this, purposeName, token);
-      },
-      writable: true,
-      configurable: true,
-    });
-  }
+  const def = new TokenDefinition(this, purpose, options.expiresIn, options.generator);
+  setTokenDefinitions(this, tokenDefinitions(this).merge({ [purpose]: def }));
 }
 
 /**
@@ -356,11 +322,11 @@ export function generateTokenFor(record: Base, purpose: string): string {
  * Mirrors: ActiveRecord::TokenFor::ClassMethods#find_by_token_for
  */
 export async function findByTokenFor(
-  modelClass: typeof Base,
+  this: typeof Base,
   purpose: string,
   token: string,
 ): Promise<Base | null> {
-  return modelClass.all().findByTokenFor(purpose, token);
+  return this.all().findByTokenFor(purpose, token);
 }
 
 /**
@@ -369,9 +335,9 @@ export async function findByTokenFor(
  * Mirrors: ActiveRecord::TokenFor::ClassMethods#find_by_token_for!
  */
 export async function findByTokenForBang(
-  modelClass: typeof Base,
+  this: typeof Base,
   purpose: string,
   token: string,
 ): Promise<Base> {
-  return modelClass.all().findByTokenForBang(purpose, token);
+  return this.all().findByTokenForBang(purpose, token);
 }


### PR DESCRIPTION
Three bundled stories. The fourth, `stop-per-file-truncate-all`, was released
back to the queue — see the bottom of this description.

## pin-fixture-pools-via-connection-notification (RFC 0064)

**Rebased onto #6103, which landed overlapping work.** That PR added
`pinFixtureConnectionPool` with a `@noRailsEquivalent CONVERGEABLE` receipt
naming this very story as its retirement. `setup_transactional_fixtures` has two
halves; this PR lands one of them and the receipt is narrowed to the other.

**Landed — the subscriber (`test_fixtures.rb:182-200`).**
`withTransactionalFixtures` now subscribes to `!connection.active_record` and
pins/leases/appends any pool established mid-test, unsubscribing in teardown
(`:203`). The notification already existed on
`ConnectionHandler#establishConnection`, mirroring `connection_handler.rb:149`.
New cover: "pins a connection pool established inside the test body", verified
red on baseline.

Two deviations, justified at the call site. `pinConnectionBang`/`leaseConnection`
are async where Rails' are not and `Notifications` does not await subscribers, so
the pin/lease is queued from the synchronous subscriber body; teardown
`allSettled`s the queue and re-raises after cleanup. And because registration and
pin-success are two events here where Rails' are one, `pinnedPools` tracks what
actually pinned — `unpinConnectionBang` raises on an unpinned pool
(`connection-pool.ts:739`), which would otherwise shadow the real failure and
abort the teardown loop.

**Not landed — the setup line (`test_fixtures.rb:175-180`), and why.** Rails'
first step is to pin `connection_pool_list(:writing)` wholesale.
`pinFixtureConnectionPool` therefore survives, still pinning those pools lazily
from the seeding site, with its receipt rewritten to record the blocker rather
than restate the gap.

I tried the literal port and hit exactly what #6103 documents hitting:
`base_test.rb`'s `connection in utc time` fails with `There isn't a pinned
connection`. Root cause found this round — Rails clears `@pinned_connection` in
only two places, `initialize` (`connection_pool.rb:267`) and `unpin_connection!`
(`:347`); `disconnect!`/`discard!` deliberately leave it alone, so a
disconnected-but-pinned pool still unpins cleanly. trails'
`ConnectionPool#_disconnect` (`connection-pool.ts:975`) and `#_discard`
(`:1040`) both null `_fixturePin`, so the mid-test `establishConnection` in that
test orphans the pin. Converging that is a production-pool change well outside
this PR, so it is filed with the reproduction and the cite as RFC 0064
`pin-writing-pool-list-in-setup-transactional-fixtures`.

`#6103`'s secondary-pool regression test and `connection in utc time` are both
green here.

## retire-mysql-visit-table-definition-override (RFC 0051)

Rails' `MySQL::SchemaCreation`
(`connection_adapters/mysql/schema_creation.rb`) does not override
`visit_TableDefinition`; CREATE TABLE assembly stays in the abstract visitor
(`abstract/schema_creation.rb:44-75`) and MySQL behaviour is reached through
`visit_ColumnDefinition`/`add_column_options!`, `index_in_create` (`:98-101`),
`add_table_options!` and the `supports*` flags — all of which we already
override.

The trails override is deleted. Since #6095 converged the inline-index branch
the two bodies were line-for-line identical except for two things the abstract
one gets right: the `tableConstraintStatements(o)` push the override silently
dropped (the exclusion/unique-constraint slot,
`abstract/schema_creation.rb:64-71`), and `AS ${this.toSql(o.as)}` instead of a
bare `o.as` (`:73`). 39 lines out.

`connection-adapters/mysql/schema-creation.test.ts` — including "inlines indexes
when supportsIndexesInCreate (MySQL)" — stays green, no test names touched.

## token-for-classmethods-onto-base (RFC 0072)

`base.rb:328` does `include TokenFor`, so `generates_token_for` is a class method
on every `ActiveRecord::Base` subclass. We had it behind the
`@blazetrails/activerecord/generates-token-for` subpath on a "requires
node:crypto" premise that #6100 already disproved for `SecureToken`: `token-for.ts`
has no static `node:crypto` import, its only crypto reach is `MessageVerifier`
(which resolves through `getCrypto()` lazily), and `base.ts` has imported
`token-for.js` all along for the `tokenDefinitions` / `generatedTokenVerifier`
class accessors.

So, matching the `SecureToken` wiring landed in #6100:

- `generatesTokenFor`, `findByTokenFor`, `findByTokenForBang` become
  `this: typeof Base` functions (the settled mixin idiom, same as
  `secure-token.ts:35`) assigned as statics on `Base` immediately after the
  `SecureToken` members, `base.rb:328`'s position.
- `generateTokenFor` becomes a real instance method delegating to the ported
  free function, the way `signedId` already does (`base.ts:4374`); the block of
  `declare` stubs standing in for it is gone.
- `generatesTokenFor`'s three lazy `Object.defineProperty` installs are deleted.
  With the members on `Base` their `if (!modelClass.findByTokenFor)` guards were
  dead, and Rails' `generates_token_for` (`token_for.rb:100`) is a one-line
  merge and nothing else.
- The `index.ts:289` subpath comment is replaced. The
  `generates-token-for` subpath keeps re-exporting these names, but this is a
  **signature break, not a compatibility shim**: the three `ClassMethods`
  members now take `this` as the model class, so
  `generatesTokenFor(Model, purpose)` no longer type-checks and would misbind
  `purpose` if forced through. That is the point of the story — Rails reaches
  them as class methods (`base.rb:328`), never as free functions — so the
  subpath's header documents the new calling convention rather than preserving
  the old one.

Call sites move to the Rails spelling (`User.generatesTokenFor(:purpose)` /
`User.findByTokenFor(...)`), which also lets a pile of `(X as any)` casts in
`token-for.test.ts` go away. No test names changed.

## Not in this PR: stop-per-file-truncate-all

Released back to the queue (`pnpm tasks release`), not closed. Two reasons:

1. Its context is written against code that has since moved. `test-setup-dy.ts`
   no longer calls `DatabaseTasks.reconstructFromSchema` at all — the fast path
   is inlined, and the `SKIP_TEST_DATABASE_TRUNCATE` guard the story proposes
   adopting is *already* wrapped around the `truncateTables` call. The remaining
   per-file cost on that arm is dominated by `purgeToCanonicalTables` +
   `loadAdapterSpecificSchema`, which the story does not scope. It needs
   re-derivation against current `main` before it is worth building.
2. Its acceptance criteria require before/after instrumented numbers and a green
   full AR suite on all three lanes across repeated co-scheduled runs. Row
   leakage between files is exactly the failure mode the guard hides, so
   shipping it unverified inside a bundle is the wrong trade — and the full
   suite is not something to run locally.

## Gates

- Size: 126 insertions / 145 deletions.
- `pnpm api:calls` — OK (14 baselined). `pnpm api:calls:wide` — OK.
- `pnpm api:extra --package activerecord` — no new novel names in
  `token-for.ts`, `mysql/schema-creation.ts`, or
  `test-fixtures/with-transactional-fixtures.ts`.
- `pnpm api:compare` — no regression (data layer 7729/7816).
- `pnpm lint`, `pnpm typecheck` clean.
- Local: `test-fixtures/`, `token-for*`, `secure-password`, `base`, and
  `mysql/schema-creation` suites — 265 passed / 3 skipped.

Closes-story: pin-fixture-pools-via-connection-notification
Closes-story: retire-mysql-visit-table-definition-override
Closes-story: token-for-classmethods-onto-base
