### PR TITLE
feat(activerecord): converge Version state and full_version_string, drop the redundant per-file truncate-all

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter-version.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter-version.trails.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { Version } from "./abstract-adapter.js";
+
+// Rails has no test of its own for `AbstractAdapter::Version`'s state
+// (abstract_adapter.rb:243-259); these pin the shape its callers depend on.
+describe("AbstractAdapter::Version", () => {
+  it("stringifies the parsed parts, not the string it was built from", () => {
+    expect(new Version("8.0.31-log").toString()).toBe("8.0.31");
+    expect(new Version("10.6.5-MariaDB").toString()).toBe("10.6.5");
+    expect(new Version("5.7.22").toString()).toBe("5.7.22");
+  });
+
+  it("carries the full version string its caller passed", () => {
+    const version = new Version("8.0.31", "8.0.31-log");
+    expect(version.fullVersionString).toBe("8.0.31-log");
+    expect(version.toString()).toBe("8.0.31");
+  });
+
+  it("has no full version string when the caller passed none", () => {
+    expect(new Version("3.45.0").fullVersionString).toBeNull();
+  });
+
+  it("compares by parsed part, longer version winning a tie", () => {
+    expect(new Version("8.0.31").compare("8.0.4")).toBe(1);
+    expect(new Version("5.7.22").compare("5.7.22")).toBe(0);
+    expect(new Version("10.2").compare("10.2.1")).toBe(-1);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -154,12 +154,7 @@ export function adapterNameFromConfig(configAdapter: string | undefined): Adapte
  * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter::Version
  */
 export class Version {
-  /**
-   * Rails' `@version` (abstract_adapter.rb:249), the parsed parts — not the
-   * string it was built from. Ruby's `String#to_i` reads the leading integer
-   * and answers `0` for a part that has none, which is what keeps a banner
-   * like `"8.0.31-log"` parsing as `[8, 0, 31]`.
-   */
+  /** Rails' `@version` (abstract_adapter.rb:249). */
   private _version: number[];
 
   /** Rails: `attr_reader :full_version_string` (abstract_adapter.rb:246). */

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -154,16 +154,24 @@ export function adapterNameFromConfig(configAdapter: string | undefined): Adapte
  * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter::Version
  */
 export class Version {
-  private _version: string;
-  private _parts: number[];
+  /**
+   * Rails' `@version` (abstract_adapter.rb:249), the parsed parts — not the
+   * string it was built from. Ruby's `String#to_i` reads the leading integer
+   * and answers `0` for a part that has none, which is what keeps a banner
+   * like `"8.0.31-log"` parsing as `[8, 0, 31]`.
+   */
+  private _version: number[];
 
-  constructor(version: string) {
-    this._version = version;
-    this._parts = version.split(".").map(Number);
+  /** Rails: `attr_reader :full_version_string` (abstract_adapter.rb:246). */
+  readonly fullVersionString: string | null;
+
+  constructor(versionString: string, fullVersionString: string | null = null) {
+    this._version = versionString.split(".").map((part) => parseInt(part, 10) || 0);
+    this.fullVersionString = fullVersionString;
   }
 
   toString(): string {
-    return this._version;
+    return this._version.join(".");
   }
 
   /**
@@ -175,12 +183,12 @@ export class Version {
    * spell them `compare(...) >= 0` / `compare(...) < 0`.
    */
   compare(versionString: string): number {
-    const other = versionString.split(".").map(Number);
-    for (let i = 0; i < Math.min(this._parts.length, other.length); i++) {
-      if (this._parts[i] > other[i]) return 1;
-      if (this._parts[i] < other[i]) return -1;
+    const other = versionString.split(".").map((part) => parseInt(part, 10) || 0);
+    for (let i = 0; i < Math.min(this._version.length, other.length); i++) {
+      if (this._version[i] > other[i]) return 1;
+      if (this._version[i] < other[i]) return -1;
     }
-    return this._parts.length === other.length ? 0 : this._parts.length > other.length ? 1 : -1;
+    return this._version.length === other.length ? 0 : this._version.length > other.length ? 1 : -1;
   }
 }
 

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1734,7 +1734,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     // (e.g. Mysql2Adapter#getFullVersion populates it while fetching); re-check
     // to avoid double-parsing the version string in those subclasses.
     if (this._databaseVersion) return this._databaseVersion;
-    const version = new Version(this.versionString(fullVersion));
+    const version = new Version(this.versionString(fullVersion), fullVersion);
     this._databaseVersion = version;
     return version;
   }

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1753,19 +1753,20 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     const ver = row?.v ?? "0.0.0";
     this._fullVersionString = ver;
     this._mariadb = /mariadb/i.test(ver);
-    this._databaseVersion = new Version(this.versionString(ver));
+    this._databaseVersion = new Version(this.versionString(ver), ver);
     return ver;
   }
 
   /**
-   * Return the full raw version string, lazily fetching it if needed.
-   * Mirrors Rails' full_version → database_version.full_version_string,
-   * which always returns the real server version without a separate warm-up.
+   * Mirrors: Mysql2Adapter#full_version (mysql2_adapter.rb:164-166) —
+   * `database_version.full_version_string`. Rails' reader is sync because
+   * `database_version` is memoized by `configure_connection`; here the fetch is
+   * awaited, and the banner comes off the `Version` rather than a second field.
    * @internal
    */
   async fullVersion(): Promise<string> {
-    if (!this._fullVersionString) await this.getFullVersion();
-    return this._fullVersionString ?? "0.0.0";
+    const databaseVersion = await this.getDatabaseVersion();
+    return databaseVersion.fullVersionString ?? "0.0.0";
   }
 
   /** @internal */

--- a/packages/activerecord/src/support/connection.ts
+++ b/packages/activerecord/src/support/connection.ts
@@ -14,8 +14,7 @@
  *
  * On top of Rails' three methods it wires the resolved configurations into
  * `DatabaseTasks`, so the per-worker boot can purge this database through the
- * real Rails-mirrored path (`DatabaseTasks.purge` / `truncateTables`) before
- * the schema load. Rails has no equivalent because its suite loads `schema.rb`
+ * real Rails-mirrored path (`DatabaseTasks.purge`) before the schema load. Rails has no equivalent because its suite loads `schema.rb`
  * directly from `cases/helper.rb` against a database it never re-loads.
  *
  * As in `config.example.yml`, `ENV` only feeds connection *sub-settings*

--- a/packages/activerecord/src/support/drop-all-tables.test.ts
+++ b/packages/activerecord/src/support/drop-all-tables.test.ts
@@ -249,4 +249,16 @@ describe("purge-only pre-snapshot path", () => {
   it("rejects a purge that runs after the boot-laid snapshot", async () => {
     await expect(purgeToCanonicalTables(adapter)).rejects.toThrow(/after recordBootLaidTables/);
   });
+
+  // Kept last: this one runs a real purge, which drops the adapter-specific
+  // tables until the next test file's boot re-lays them.
+  it("clears the rows of a canonical table, so the boot needs no truncate ahead of it", async () => {
+    const { dropAllTablesModule } = await freshModules();
+    await adapter.executeMutation(`INSERT INTO articles (id) VALUES (4243)`);
+    expect(((await adapter.execute(`SELECT id FROM articles`)) as unknown[]).length).toBe(1);
+
+    await dropAllTablesModule.purgeToCanonicalTables(adapter);
+
+    expect(((await adapter.execute(`SELECT id FROM articles`)) as unknown[]).length).toBe(0);
+  });
 });

--- a/packages/activerecord/src/test-setup-dy.ts
+++ b/packages/activerecord/src/test-setup-dy.ts
@@ -13,8 +13,9 @@
  * What Rails has no counterpart for is the step *before* the load: this
  * database is not freshly created, so it has to be emptied first. Which form
  * that takes is the driver gate (RFC 0002 §Design):
- *   - already laid by this run (`canonicalSchemaUpToDate`) → TRUNCATE, skipping
- *     the canonical DDL only. All three lanes reach it: globalSetup stamps what
+ *   - already laid by this run (`canonicalSchemaUpToDate`) → purge back to the
+ *     canonical tables, skipping the canonical DDL only. All three lanes reach
+ *     it: globalSetup stamps what
  *     it lays (a PG slot cloned from the stamped template, the sqlite template
  *     file each worker clones, each MySQL slot DB), and this arm re-stamps, so
  *     a worker recycled onto a database an earlier worker used takes it too.
@@ -48,9 +49,15 @@ const { canonicalSchemaUpToDate, stampCanonicalSchema } =
 const { recordBootOutcome } = await import("./support/boot-outcome.js");
 
 if (await canonicalSchemaUpToDate(await Base.leaseConnection())) {
-  if (getEnv("SKIP_TEST_DATABASE_TRUNCATE") === undefined) {
-    await DatabaseTasks.truncateTables(envConfig);
-  }
+  // No `DatabaseTasks.truncateTables` here: the purge below already clears the
+  // rows. `purgeToCanonicalTables` truncates every *non-empty* canonical table
+  // (`support/drop-all-tables.ts`'s `truncateNonEmpty`) and **drops** everything
+  // else — the adapter-specific tables the arm below re-lays, the bookkeeping
+  // tables, bespoke tables a test made. A truncate-all ahead of it emptied the
+  // same tables a second time, over a second connection the task handler opens
+  // per call, and on MySQL that is ~250 DDL-grade `TRUNCATE`s per test file
+  // (measured 1.0-1.3 s) for a database the next two statements empty anyway.
+  //
   // Only the canonical arm is skipped here — those tables are already laid, and
   // now empty. The adapter-specific arm is re-run as on the full path: its
   // tables are `force: true` throughout, and a worker recycled onto a database

--- a/packages/activerecord/src/test-setup-dy.ts
+++ b/packages/activerecord/src/test-setup-dy.ts
@@ -49,14 +49,9 @@ const { canonicalSchemaUpToDate, stampCanonicalSchema } =
 const { recordBootOutcome } = await import("./support/boot-outcome.js");
 
 if (await canonicalSchemaUpToDate(await Base.leaseConnection())) {
-  // No `DatabaseTasks.truncateTables` here: the purge below already clears the
-  // rows. `purgeToCanonicalTables` truncates every *non-empty* canonical table
-  // (`support/drop-all-tables.ts`'s `truncateNonEmpty`) and **drops** everything
-  // else — the adapter-specific tables the arm below re-lays, the bookkeeping
-  // tables, bespoke tables a test made. A truncate-all ahead of it emptied the
-  // same tables a second time, over a second connection the task handler opens
-  // per call, and on MySQL that is ~250 DDL-grade `TRUNCATE`s per test file
-  // (measured 1.0-1.3 s) for a database the next two statements empty anyway.
+  // No truncate ahead of the purge: `purgeToCanonicalTables` already truncates
+  // every non-empty canonical table and drops everything else, so a
+  // `DatabaseTasks.truncateTables` here emptied the same tables a second time.
   //
   // Only the canonical arm is skipped here — those tables are already laid, and
   // now empty. The adapter-specific arm is re-run as on the full path: its


### PR DESCRIPTION
Bundle of four claimed stories. Two shipped here; one was already done on `main`; one is blocked on an unmerged sibling PR.

## `Version` stores the parsed parts and carries `full_version_string`

`AbstractAdapter::Version` (`abstract_adapter.rb:243-259`) parses the version
string into `@version` and answers *that* from `to_s`. trails retained the raw
string and echoed it back, so `new Version("8.0.31-log").toString()` was
`"8.0.31-log"` where Rails answers `"8.0.31"`, and there was nowhere
Rails-shaped for the raw server banner to live.

- `@version` is the parsed `number[]`; the retained string field is gone and
  `toString()` is `this._version.join(".")` (`abstract_adapter.rb:257-259`).
- Parts parse with Ruby `String#to_i` semantics (leading integer, `0` when
  there is none) rather than `Number`, which is what keeps `"8.0.31-log"`
  reading as `[8, 0, 31]` instead of `[8, 0, NaN]`. `compare` uses the same
  parsing, matching `<=>`'s own `split(".").map(&:to_i)`.
- Second constructor parameter `fullVersionString` with its reader
  (`abstract_adapter.rb:246-250`). `AbstractMysqlAdapter#get_database_version`
  (`abstract_mysql_adapter.rb:85-90`) and `Mysql2Adapter`'s banner fetch pass
  it, and `Mysql2Adapter#full_version` (`mysql2_adapter.rb:164-166`) now reads
  `database_version.full_version_string` as Rails does rather than a second
  cached field.

## The AR bootstrap's per-file truncate-all is redundant, not merely expensive

`test-setup-dy.ts` runs once per test *file*. Its fast path called
`DatabaseTasks.truncateTables(envConfig)` and then, two statements later,
`purgeToCanonicalTables(conn)` — which already truncates every **non-empty**
canonical table (`support/drop-all-tables.ts`'s `truncateNonEmpty`) and
**drops** everything else: the adapter-specific tables the next line re-lays,
the bookkeeping tables, any bespoke table a test made. So the truncate-all
emptied the same tables a second time, over a connection the task handler opens
per call, and on MySQL that is ~250 DDL-grade `TRUNCATE`s per test file.

Rails truncates nothing between files: the schema is laid once
(`test/cases/test_case.rb:298-300`) and isolation is transactional fixtures
(`test_fixtures.rb:113-144`). Removing the call is a strict subtraction — the
end state after the purge is identical — so no test file needed an explicit
opt-in.

Measured on the sqlite lane, instrumented `test-setup-dy.ts`, 7 AR test files
at `TRAILS_TEST_FORKS=2`, steady state:

| phase               | before      | after      |
| ------------------- | ----------- | ---------- |
| truncate            | 32-56 ms    | not run    |
| fast-path boot total| 73-132 ms   | 47-72 ms   |

`DatabaseTasks.reconstructFromSchema` and its `SKIP_TEST_DATABASE_TRUNCATE`
opt-out are untouched — the change is only in how the test bootstrap invokes
the truncate, per that story's third acceptance criterion.

`drop-all-tables.test.ts` gains the invariant the removal rests on: a real
`purgeToCanonicalTables` clears the rows of a canonical table.

## Two stories not shipped here

- **`generate-schema-file-once-per-run`** — already done on `main`. The
  bootstrap stopped calling `generateSchemaFile` in #5678, which routed the
  per-worker canonical schema through `loadCanonicalSchema`; nothing in
  `packages/` or `scripts/` calls it outside its own tests. Marked done
  against #5678.
- **`i18n-date-valid-ordinal-civil-negative-fields`** — blocked. Its converged
  shape (`rtValidOrdinalP` / `rtValidCivilP`, their "not carried" notes, and
  `cFindFdoy` to extend) exists only on the unmerged #6104; `main` still has a
  single inlined `rtValidDateFragsP` with no `valid_*_p` helpers, and building
  it here would either duplicate #6104 or stack on it. Blocked with that
  reason; re-ready once #6104 merges.

Closes-story: converge-version-state-and-full-version-string
Closes-story: stop-per-file-truncate-all
