### PR TITLE
fix(activerecord): pin every writing pool in fixture setup, port PG integer_like_primary_key_type, delete collection sync writers

### DIFF
--- a/packages/activerecord/src/associations/builder/collection-association.ts
+++ b/packages/activerecord/src/associations/builder/collection-association.ts
@@ -153,39 +153,15 @@ export class CollectionAssociation extends Association {
     }
   }
 
-  static override defineWriters(mixin: object, name: string): void {
-    if (!mixin || typeof mixin !== "object") return;
-    // Skip `super.defineWriters` for the main name: the base installs a setter
-    // calling the association's `writer`, which for collections is now
-    // awaitable (it persists inline on a persisted owner). A JS property
-    // setter cannot `await`, so route to `syncWrite` — in-memory replace on
-    // an unpersisted owner, `CollectionPersistedAssignmentError` on a
-    // persisted one, whose message names the awaitable replacement
-    // (`await owner.#{name}.replace([...])`). RFC 0068.
-    const nameDescriptor = Object.getOwnPropertyDescriptor(mixin, name);
-    if (!nameDescriptor || nameDescriptor.configurable) {
-      Object.defineProperty(mixin, name, {
-        get: nameDescriptor?.get,
-        set(this: AssociationInstanceHost, records: unknown) {
-          (this.association(name) as any).syncWrite(records);
-        },
-        configurable: true,
-      });
-    }
-    const idsName = `${singularize(name)}Ids`;
-    const existing = Object.getOwnPropertyDescriptor(mixin, idsName);
-    if (existing && !existing.configurable) return;
-    Object.defineProperty(mixin, idsName, {
-      get: existing?.get,
-      // The ids setter throws on BOTH owner arms (`CollectionIdsAssignmentError`):
-      // Rails' `ids_writer` resolves the ids with a query even for a new record,
-      // so there is no arm a sync setter can serve. Returning the promise here
-      // instead made a bad id an unhandled rejection and raced an immediate
-      // `save()`. RFC 0068.
-      set(this: AssociationInstanceHost, ids: unknown) {
-        (this.association(name) as any).syncIdsWrite(ids);
-      },
-      configurable: true,
-    });
-  }
+  // Rails' `Builder::CollectionAssociation.define_writers`
+  // (builder/collection_association.rb:67-74) calls `super` — which defines
+  // `#{name}=` — and adds `#{name.singularize}_ids=`. Both of Rails' writers
+  // do DB I/O at assignment time: `writer` runs `replace`'s diffed
+  // deletes+inserts in a transaction (collection_association.rb:46-48, :242),
+  // and `ids_writer` resolves the ids with a query first
+  // (collection_association.rb:61-83). A JS property setter cannot `await`, so
+  // neither is expressible as one. The awaitable ports carry the Rails names
+  // on the association itself — `association(name).writer` / `replace` /
+  // `idsWriter` — and are the only collection-mutation surface (RFC 0087 §1).
+  static override defineWriters(_mixin: object, _name: string): void {}
 }

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -175,17 +175,15 @@ export class CollectionAssociation extends Association {
   }
 
   /**
-   * The `#{singular}Ids=` analogue of {@link syncWrite} — and, unlike it,
-   * a throw on BOTH owner arms.
+   * The `#{singular}Ids` analogue of {@link syncWrite}, reached from
+   * mass assignment (`new Author({ postIds })`, `assignAttributes`) — and,
+   * unlike it, a throw on BOTH owner arms.
    *
    * `syncWrite`'s unpersisted arm is faithful because Rails does no I/O for a
    * new-record owner either. `ids_writer` has no such arm: it resolves the ids
    * to records with a query before replacing
    * (collection_association.rb:61-83), so the new-record path is DB I/O too.
-   * The sync setter used to return that promise for it to discard, which made
-   * a bad id (`raiseNotFoundAll`) an unhandled rejection instead of a
-   * catchable throw and let an immediate `save()` read the target before the
-   * in-flight replace landed. Awaitable surfaces exist for both arms —
+   * Awaitable surfaces exist for both arms —
    * `await owner.update({ itemIds: [...] })` (persistence.ts routes collection
    * keys through `idsWriter`) and `await owner.association(name).idsWriter()`
    * — so this throws loudly and names them. RFC 0068.

--- a/packages/activerecord/src/associations/collection-awaitable-writers.trails.test.ts
+++ b/packages/activerecord/src/associations/collection-awaitable-writers.trails.test.ts
@@ -1,27 +1,24 @@
 /**
- * Trails-only: the native `=` collection setter (`owner.items = [...]`, the
- * `#{singular}Ids=` setter, and the mass-assignment hasMany/HABTM arm)
- * deviates from Rails on a *persisted* owner. Rails'
- * `CollectionAssociation#writer` → `replace`
- * (vendor/rails/activerecord/lib/active_record/associations/collection_association.rb:46-48,
- * :242) diffs against the loaded target and runs the deletes + inserts inline
- * in a transaction (`replace_records`) — synchronous DB I/O JS cannot do from
- * a property setter. Rather than silently deferring the writes to the owner's
- * next `save()` (where a deferred delete can race an interim insert), the
- * setter THROWS and names the awaitable Rails-named replacement
- * (`await owner.items.replace([...])`). On an *unpersisted* owner Rails does
- * no I/O either, so the in-memory replace is faithful and kept. There is no
- * Rails test for this deviation.
+ * Trails-only: collection associations have NO native `=` writers. Rails
+ * generates `#{name}=` and `#{name.singularize}_ids=`
+ * (vendor/rails/activerecord/lib/active_record/associations/builder/collection_association.rb:67-74),
+ * but both do DB I/O at assignment time — `writer` → `replace` diffs the
+ * loaded target and runs the deletes + inserts in a transaction
+ * (collection_association.rb:46-48, :242), and `ids_writer` resolves the ids
+ * with a query first (:61-83). A JS property setter cannot `await` either, so
+ * RFC 0087 §1 deletes them: the awaitable ports on the association —
+ * `writer` / `replace` / `idsWriter` — are the only collection-mutation
+ * surface. There is no Rails test for this deviation.
  *
- * The `#{singular}Ids=` setter goes further and throws on BOTH owner arms
- * (`CollectionIdsAssignmentError`): `ids_writer` resolves the ids to records
- * with a query before replacing (collection_association.rb:61-83), so even the
- * new-record arm is DB I/O. The awaitable surfaces are
- * `await owner.update({ itemIds: [...] })` and
- * `await owner.association(name).idsWriter([...])`.
+ * Mass assignment still reaches the collection keys (Rails' `assign_attributes`
+ * → `public_send("#{k}=")`), and is retired separately by RFC 0087's
+ * `retire-sync-association-mass-assignment-arms`. Until then it keeps RFC
+ * 0068's split: in-memory on an unpersisted owner for the record key, and a
+ * throw on both arms for the ids key, whose resolving query has no in-memory
+ * arm at all.
  */
 import { describe, it, expect, beforeAll } from "vitest";
-import { registerModel, AssociationTypeMismatch, RecordNotFound } from "../index.js";
+import { registerModel, RecordNotFound } from "../index.js";
 import { CollectionIdsAssignmentError, CollectionPersistedAssignmentError } from "./errors.js";
 import { Author } from "../test-helpers/models/author.js";
 import { Post } from "../test-helpers/models/post.js";
@@ -30,8 +27,6 @@ import { Category } from "../test-helpers/models/category.js";
 import { fixtures } from "../test-fixtures.js";
 
 interface CollectionOwner {
-  posts?: unknown;
-  postIds?: unknown;
   assignAttributes(attrs: Record<string, unknown>): void;
 }
 
@@ -53,7 +48,14 @@ const writerOf =
       .association("posts")
       .writer(records);
 
-describe("CollectionPersistedSetterThrows", () => {
+const idsWriterOf =
+  (owner: Author) =>
+  (ids: unknown[]): Promise<void> =>
+    (owner as unknown as { association(n: string): { idsWriter(i: unknown[]): Promise<void> } })
+      .association("posts")
+      .idsWriter(ids);
+
+describe("CollectionAwaitableWriters", () => {
   fixtures(["authors", "posts", "comments"]);
 
   beforeAll(() => {
@@ -63,56 +65,27 @@ describe("CollectionPersistedSetterThrows", () => {
     registerModel(Category);
   });
 
-  it("native = setter throws on a persisted owner", async () => {
-    const author = (await Author.create({ name: "Bill" })) as unknown as CollectionOwner;
+  it("no native = setter is generated for the collection", async () => {
+    const author = await Author.create({ name: "Bill" });
     const post = await Post.create({ title: "t", body: "b" });
+    // The reader survives; only the writer half of the property is gone.
     expect(() => {
-      author.posts = [post];
-    }).toThrow(CollectionPersistedAssignmentError);
-    // The message names the awaitable Rails-named replacement.
-    expect(() => {
-      author.posts = [post];
-    }).toThrow(/await owner\.posts\.replace\(\[\.\.\.\]\)/);
+      (author as unknown as { posts: unknown }).posts = [post];
+    }).toThrow(TypeError);
+    expect(postsOf(author)).toBeDefined();
   });
 
-  it("native = setter raises the type mismatch before the persisted-owner throw", async () => {
-    // Rails' `replace` raises `AssociationTypeMismatch` for every element as
-    // its first statement (collection_association.rb:242), before any other
-    // work — the sync guard is preserved ahead of the persisted-owner throw.
-    const author = (await Author.create({ name: "Bill" })) as unknown as CollectionOwner;
+  it("no native ids= setter is generated for the collection", async () => {
+    const author = await Author.create({ name: "Bill" });
     expect(() => {
-      author.posts = [1];
-    }).toThrow(AssociationTypeMismatch);
-  });
-
-  it("ids= setter throws on a persisted owner", async () => {
-    const author = (await Author.create({ name: "Bill" })) as unknown as CollectionOwner;
-    const post = await Post.create({ title: "t", body: "b" });
-    expect(() => {
-      author.postIds = [post.id];
-    }).toThrow(CollectionIdsAssignmentError);
-    // The message names the awaitable replacements.
-    expect(() => {
-      author.postIds = [post.id];
-    }).toThrow(/await owner\.update\(\{ postIds: \[\.\.\.\] \}\)/);
-  });
-
-  it("ids= setter throws on an unpersisted owner too", () => {
-    // Unlike the record writer, whose unpersisted arm is pure in-memory work,
-    // `ids_writer` queries to resolve the ids even for a new record. Returning
-    // that promise from the sync setter made a bad id an unhandled rejection
-    // and let an immediate `save()` race the in-flight replace, so this arm
-    // throws rather than floating a promise.
-    const author = new Author({ name: "Bill" });
-    expect(() => {
-      (author as unknown as CollectionOwner).postIds = [1];
-    }).toThrow(CollectionIdsAssignmentError);
+      (author as unknown as { postIds: unknown }).postIds = [1];
+    }).toThrow(TypeError);
+    expect(await (author as unknown as { postIds: Promise<unknown> }).postIds).toBeDefined();
   });
 
   it("ids= mass-assignment throws on both owner arms", async () => {
-    // Mass-assignment shares the setter, so it raises through
-    // `_assign_attributes`' rescue — the deviation is the `cause`, as in the
-    // record-writer case below.
+    // Mass-assignment raises through `_assign_attributes`' rescue, so the
+    // deviation is the `cause`, as in the record-writer case below.
     const post = await Post.create({ title: "t", body: "b" });
     const causeOf = (owner: Author): unknown => {
       try {
@@ -130,8 +103,6 @@ describe("CollectionPersistedSetterThrows", () => {
   });
 
   it("a bad id is a catchable rejection on the awaitable ids surface", async () => {
-    // The hazard this replaces: through the setter, an id that doesn't resolve
-    // surfaced as an unhandled rejection. Through `update` it is catchable.
     const author = await Author.create({ name: "Bill" });
     await expect(author.update({ postIds: [0] })).rejects.toThrow(RecordNotFound);
   });
@@ -153,9 +124,6 @@ describe("CollectionPersistedSetterThrows", () => {
   it("mass-assignment throws on a persisted owner", async () => {
     const author = (await Author.create({ name: "Bill" })) as unknown as CollectionOwner;
     const post = await Post.create({ title: "t", body: "b" });
-    // Mass-assignment wraps a failing setter in `AttributeAssignmentError`
-    // (Rails' `_assign_attributes` rescue), so the deviation surfaces as the
-    // `cause`.
     let raised: unknown;
     try {
       author.assignAttributes({ posts: [post] });
@@ -167,13 +135,13 @@ describe("CollectionPersistedSetterThrows", () => {
     );
   });
 
-  it("keeps in-memory assignment on an unpersisted owner", async () => {
+  it("keeps in-memory mass-assignment on an unpersisted owner", async () => {
     // Rails defers here too (`replace_records` without a save — the FK isn't
-    // known yet), so the sync setter is faithful and autosave persists at the
+    // known yet), so the in-memory arm is faithful and autosave persists at the
     // owner's first `save()`.
     const author = new Author({ name: "Bill" });
     const post = new Post({ title: "t", body: "b" });
-    (author as unknown as CollectionOwner).posts = [post];
+    (author as unknown as CollectionOwner).assignAttributes({ posts: [post] });
 
     expect(targetOf(author).length).toBe(1);
     await author.save();
@@ -221,5 +189,15 @@ describe("CollectionPersistedSetterThrows", () => {
     await author.reload();
     const titles = (await postsOf(author).toArray()).map((p) => p.title);
     expect(titles).toEqual(["b"]);
+  });
+
+  it("the awaitable idsWriter replaces on a persisted owner", async () => {
+    const author = await Author.create({ name: "Bill" });
+    const first = await Post.create({ title: "a", body: "a" });
+    const second = await Post.create({ title: "b", body: "b" });
+
+    await idsWriterOf(author)([first.id, second.id]);
+    await author.reload();
+    expect(await postsOf(author).count()).toBe(2);
   });
 });

--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -7,14 +7,7 @@
 
 import { describe, it, expect } from "vitest";
 import { throwAbort } from "@blazetrails/activesupport";
-import {
-  Base,
-  association,
-  registerModel,
-  RecordInvalid,
-  RecordNotFound,
-  CollectionPersistedAssignmentError,
-} from "../index.js";
+import { Base, association, registerModel, RecordInvalid, RecordNotFound } from "../index.js";
 import { fixtures } from "../test-fixtures.js";
 // Opt this file into the canonical-model autoload index (Zeitwerk analog):
 // `Comment`, `Tagging`, `Tag`, and `Owner` — association targets with no
@@ -375,10 +368,11 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
   });
 
   it("writer `author.posts = [...]` still flows through Association#writer", async () => {
-    // R.2 only swapped the reader; the writer still routes through
-    // `this.association(name).writer(value)` — but as of RFC 0068 that writer
-    // is awaitable (it persists the replacement inline for a persisted owner),
-    // so the non-awaitable `=` setter throws rather than deferring the writes.
+    // R.2 only swapped the reader; the writer routes through
+    // `this.association(name).writer(value)` — awaitable since RFC 0068 (it
+    // persists the replacement inline for a persisted owner), so RFC 0087 §1
+    // deleted the `=` setter that could not await it. `author.posts` is a
+    // getter-only property now and the awaitable `replace` is the writer.
     const author = await authorWithPosts();
     const replacement = await Post.create({
       title: "z",
@@ -387,7 +381,7 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
     });
     expect(() => {
       (author as any).posts = [replacement];
-    }).toThrow(CollectionPersistedAssignmentError);
+    }).toThrow(TypeError);
     await association<Post>(author, "posts").replace([replacement]);
     // The proxy returned by the reader reflects the new target.
     const reader = (author as any).posts;

--- a/packages/activerecord/src/associations/errors.ts
+++ b/packages/activerecord/src/associations/errors.ts
@@ -432,9 +432,11 @@ export class HasOnePersistedAssignmentError extends ActiveRecordError {
 }
 
 /**
- * Thrown when a collection association (`has_many` / HABTM) is assigned with
- * the native `=` setter — `owner.items = [...]`, `owner.itemIds = [...]`, or a
- * mass-assignment key — on a *persisted* owner. The collection analogue of
+ * Thrown when a collection association (`has_many` / HABTM) is assigned by
+ * mass assignment — `owner.assignAttributes({ items: [...] })`, `new Owner({
+ * items: [...] })` — on a *persisted* owner. (RFC 0087 §1 removed the native
+ * `=` setter that also raised this; the mass-assignment arm is retired by that
+ * RFC's `retire-sync-association-mass-assignment-arms`.) The collection analogue of
  * {@link HasOnePersistedAssignmentError}, and a deliberate trails-only
  * deviation with no Rails counterpart: Rails'
  * `CollectionAssociation#replace` diffs against the loaded target and runs the
@@ -450,7 +452,7 @@ export class CollectionPersistedAssignmentError extends ActiveRecordError {
 
   constructor(association: string) {
     super(
-      `Cannot assign collection association \`${association}\` with \`=\` on a ` +
+      `Cannot assign collection association \`${association}\` by mass assignment on a ` +
         `persisted record: Rails replaces the collection at assignment time, ` +
         `which requires \`await\` in JS. Use \`await owner.${association}.replace([...])\` ` +
         `(or \`.concat(...)\` / \`.destroy(...)\`).`,
@@ -461,30 +463,31 @@ export class CollectionPersistedAssignmentError extends ActiveRecordError {
 }
 
 /**
- * Thrown when a collection association's ids are assigned with the native
- * `#{singular}Ids=` setter — `owner.itemIds = [...]` or the matching
- * mass-assignment key — on *either* owner arm.
+ * Thrown when a collection association's ids are assigned by mass assignment —
+ * `owner.assignAttributes({ itemIds: [...] })`, `new Owner({ itemIds: [...] })`
+ * — on *either* owner arm.
  *
  * The ids writer is stricter than {@link CollectionPersistedAssignmentError}'s
  * record writer, which only throws for a persisted owner: Rails' `ids_writer`
  * (collection_association.rb:61-83) *resolves the ids to records with a query*
  * before it replaces, so even the new-record arm — where the replace itself is
- * pure in-memory work — needs I/O the sync setter cannot await. Returning that
- * promise from the setter made a bad id (`raise_record_not_found_exception!`)
- * surface as an unhandled rejection rather than a catchable throw, and let an
- * immediate `save()` race the in-flight resolution. See RFC
+ * pure in-memory work — needs I/O mass assignment cannot await. Returning that
+ * promise for the caller to discard made a bad id
+ * (`raise_record_not_found_exception!`) surface as an unhandled rejection
+ * rather than a catchable throw, and let an immediate `save()` race the
+ * in-flight resolution. See RFC
  * 0068-awaitable-has-one-setter ("Why 'loud' beats 'deferred'").
  */
 export class CollectionIdsAssignmentError extends ActiveRecordError {
   readonly association: string;
 
   constructor(association: string) {
-    // The setter that raised, derived here rather than passed in so the
-    // message can never name a key that differs from the installed writer
-    // (builder/collection-association.ts singularizes the same way).
+    // The key that raised, derived here rather than passed in so the message
+    // can never name a key that differs from the one mass assignment matched
+    // (attribute-assignment.ts singularizes the same way).
     const idsName = `${singularize(association)}Ids`;
     super(
-      `Cannot assign collection association \`${association}\` ids with \`=\`: ` +
+      `Cannot assign collection association \`${association}\` ids by mass assignment: ` +
         `Rails resolves the ids with a query and replaces the collection at ` +
         `assignment time, which requires \`await\` in JS. Use ` +
         `\`await owner.update({ ${idsName}: [...] })\` (or ` +

--- a/packages/activerecord/src/associations/has-many-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-through-associations.test.ts
@@ -748,7 +748,9 @@ describe("HasManyThroughAssociationsTest", () => {
     const post = new Post({ title: "Hello", body: "world" });
     const person = new Person({ first_name: "Sean" });
 
-    (post as any).people = [person];
+    // Rails: `post.people = [person]`. RFC 0087 §1 removed the sync `=`
+    // setter; `writer` is the awaitable port of the same Rails writer.
+    await (post as any).association("people").writer([person]);
     await post.save();
 
     expect(post.id).toBeTruthy();

--- a/packages/activerecord/src/associations/required.test.ts
+++ b/packages/activerecord/src/associations/required.test.ts
@@ -248,7 +248,9 @@ describe("RequiredAssociationsTest", () => {
     registerModel("Child", Child);
 
     const parent = new Parent();
-    (parent as any).children = [new Child()];
+    // Rails: `parent.children = [Child.new]` — the awaitable writer since
+    // RFC 0087 §1 removed the sync `=` setter.
+    await (parent as any).association("children").writer([new Child()]);
     expect(await parent.save()).toBe(false);
     expect(parent.errors.fullMessages).toEqual(["Children is invalid"]);
   });

--- a/packages/activerecord/src/attribute-assignment.ts
+++ b/packages/activerecord/src/attribute-assignment.ts
@@ -14,6 +14,7 @@ import {
   extractMultiparameterCallstack,
   executeMultiparameterAssignment,
 } from "./multiparameter-attribute-assignment.js";
+import { singularize } from "@blazetrails/activesupport";
 
 interface AttributeAssignmentHost {
   writeAttribute(key: string, value: unknown): void;
@@ -161,18 +162,39 @@ export function assignAssociationIfMatch(
   const ctor = host.constructor as
     | { _associations?: Array<{ name: string; type: string }> }
     | undefined;
-  const assoc = ctor?._associations?.find((a) => a.name === key);
+  let assoc = ctor?._associations?.find((a) => a.name === key);
+  // `#{singular}Ids` is a second mass-assignment key onto the same collection
+  // association — Rails generates `#{name.singularize}_ids=`
+  // (builder/collection_association.rb:67-74) and `assign_attributes` reaches
+  // it through `public_send`. trails has no such property setter (it would
+  // have to await `ids_writer`'s resolving query — RFC 0087 §1), so the key is
+  // matched here and dispatched to the association below.
+  let idsKey = false;
+  if (!assoc) {
+    assoc = ctor?._associations?.find(
+      (a) =>
+        (a.type === "hasMany" || a.type === "hasAndBelongsToMany") &&
+        `${singularize(a.name)}Ids` === key,
+    );
+    idsKey = assoc !== undefined;
+  }
   if (!assoc) return false;
   if (typeof host.association !== "function") return false;
-  const proxy = host.association(key) as
+  const proxy = host.association(assoc.name) as
     | {
         replace?: (v: unknown[]) => void;
         writer?: (v: unknown) => void;
         syncWrite?: (v: unknown) => void;
+        syncIdsWrite?: (v: unknown[]) => never;
       }
     | null
     | undefined;
   if (!proxy) return false;
+  if (idsKey) {
+    if (typeof proxy.syncIdsWrite !== "function") return false;
+    proxy.syncIdsWrite(value as unknown[]);
+    return true;
+  }
   if (assoc.type === "hasMany" || assoc.type === "hasAndBelongsToMany") {
     // Mass-assignment can't await, so it shares the native `=` setter's
     // `syncWrite` dispatch: in-memory replace on an unpersisted owner, and a

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -686,7 +686,7 @@ interface _PendingAssociationAttr {
  * collection associations? A `*Ids` key naming no collection association
  * (a genuine column, say) is left on the attribute path.
  */
-function _isCollectionIdsWriter(
+function _isCollectionIdsKey(
   ctor: typeof Base | undefined,
   defs: _AssociationDefLike[],
   key: string,
@@ -728,7 +728,7 @@ function _extractAssociationAttrs(
   for (const k of Object.keys(attrs)) {
     if (defs.find((a) => a.name === k)) {
       (assocs ??= []).push({ name: k, value: attrs[k] });
-    } else if (_isCollectionIdsWriter(ctor, defs, k)) {
+    } else if (_isCollectionIdsKey(ctor, defs, k)) {
       (assocs ??= []).push({ name: k, value: attrs[k] });
     }
   }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -686,18 +686,13 @@ interface _PendingAssociationAttr {
  * collection associations? A `*Ids` key naming no collection association
  * (a genuine column, say) is left on the attribute path.
  */
-function _isCollectionIdsKey(
-  ctor: typeof Base | undefined,
-  defs: _AssociationDefLike[],
-  key: string,
-): boolean {
+function _isCollectionIdsKey(defs: _AssociationDefLike[], key: string): boolean {
   if (!key.endsWith("Ids")) return false;
-  const named = defs.some(
+  return defs.some(
     (a) =>
       (a.type === "hasMany" || a.type === "hasAndBelongsToMany") &&
       `${_singularize(a.name)}Ids` === key,
   );
-  return named;
 }
 
 /**
@@ -728,7 +723,7 @@ function _extractAssociationAttrs(
   for (const k of Object.keys(attrs)) {
     if (defs.find((a) => a.name === k)) {
       (assocs ??= []).push({ name: k, value: attrs[k] });
-    } else if (_isCollectionIdsKey(ctor, defs, k)) {
+    } else if (_isCollectionIdsKey(defs, k)) {
       (assocs ??= []).push({ name: k, value: attrs[k] });
     }
   }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -670,24 +670,21 @@ interface _AssociationDefLike {
 }
 
 /**
- * A constructor-form assignment held back until after `super()`. `viaSetter`
- * entries name a generated writer (`postIds`) rather than an association, so
- * they must be dispatched through that setter — `assignAssociationIfMatch`
- * matches on association name and would drop the value.
+ * A constructor-form assignment held back until after `super()` —
+ * `assignAssociationIfMatch` reaches `this.association(...)`, whose cache
+ * field is not initialized until `super()` returns.
  * @internal
  */
 interface _PendingAssociationAttr {
   name: string;
   value: unknown;
-  viaSetter?: boolean;
 }
 
 /**
  * @internal
- * Is `key` the generated `#{singular}Ids` writer of one of `defs`' collection
- * associations? Requires a live setter on the prototype as well as the name
- * match, so that a `*Ids` key which would NOT dispatch an association writer
- * inside `super()` (a genuine column, say) is left on the attribute path.
+ * Is `key` the `#{singular}Ids` mass-assignment key of one of `defs`'
+ * collection associations? A `*Ids` key naming no collection association
+ * (a genuine column, say) is left on the attribute path.
  */
 function _isCollectionIdsWriter(
   ctor: typeof Base | undefined,
@@ -700,14 +697,7 @@ function _isCollectionIdsWriter(
       (a.type === "hasMany" || a.type === "hasAndBelongsToMany") &&
       `${_singularize(a.name)}Ids` === key,
   );
-  if (!named) return false;
-  let proto: object | null = (ctor as unknown as { prototype?: object })?.prototype ?? null;
-  while (proto) {
-    const descriptor = Object.getOwnPropertyDescriptor(proto, key);
-    if (descriptor) return typeof descriptor.set === "function";
-    proto = Object.getPrototypeOf(proto) as object | null;
-  }
-  return false;
+  return named;
 }
 
 /**
@@ -717,9 +707,9 @@ function _isCollectionIdsWriter(
  * when no key matches a declared association so the hot path allocates
  * nothing.
  *
- * A generated `#{singular}Ids` key (`new Author({postIds: [...]})`) is deferred
- * too: its setter reaches `this.association(name)`, whose cache field is not
- * initialized until after `super()` returns.
+ * A `#{singular}Ids` key (`new Author({postIds: [...]})`) is deferred too:
+ * `assignAssociationIfMatch` reaches `this.association(name)`, whose cache
+ * field is not initialized until after `super()` returns.
  */
 function _extractAssociationAttrs(
   ctor: typeof Base | undefined,
@@ -739,7 +729,7 @@ function _extractAssociationAttrs(
     if (defs.find((a) => a.name === k)) {
       (assocs ??= []).push({ name: k, value: attrs[k] });
     } else if (_isCollectionIdsWriter(ctor, defs, k)) {
-      (assocs ??= []).push({ name: k, value: attrs[k], viaSetter: true });
+      (assocs ??= []).push({ name: k, value: attrs[k] });
     }
   }
   if (!assocs) return null;
@@ -853,11 +843,7 @@ function _reinstateConstructorDirtiness(
 
 /** @internal */
 function _dispatchAssociationAttrs(record: Base, assocs: _PendingAssociationAttr[]): void {
-  for (const { name, value, viaSetter } of assocs) {
-    if (viaSetter) {
-      (record as unknown as Record<string, unknown>)[name] = value;
-      continue;
-    }
+  for (const { name, value } of assocs) {
     _AttributeAssignment.assignAssociationIfMatch(
       record as unknown as { constructor?: unknown; association?: (name: string) => unknown },
       name,

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -971,8 +971,10 @@ export class ConnectionPool implements ReapablePool {
         const drain = (conn as unknown as { whenClosed?: () => Promise<void> }).whenClosed?.();
         if (drain) draining.push(drain);
       }
-      this._pinnedConnections.clear();
-      this._fixturePin = null;
+      // Pins deliberately survive: `disconnect` (connection_pool.rb:454-465)
+      // clears `@connections`, `@leases` and `@available` but leaves
+      // `@pinned_connection` alone, so a disconnected-but-pinned pool still
+      // unpins cleanly at fixture teardown.
       if (this._connections) this._connections.length = 0;
       this._available?.rejectAll(
         new ConnectionNotEstablished("Connection pool has been disconnected"),
@@ -1036,8 +1038,9 @@ export class ConnectionPool implements ReapablePool {
       const drain = (conn as unknown as { whenClosed?: () => Promise<void> }).whenClosed?.();
       if (drain) draining.push(drain);
     }
-    this._pinnedConnections.clear();
-    this._fixturePin = null;
+    // As in `_disconnect`: `discard!` (connection_pool.rb:484-492) nils
+    // `@connections`/`@available`/`@leases` only — `@pinned_connection` is
+    // cleared in `initialize` and `unpin_connection!` and nowhere else.
     this._connections = null;
     this._available?.rejectAll(new ConnectionNotEstablished("Connection pool has been discarded"));
     this._available?.clear();

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -971,10 +971,11 @@ export class ConnectionPool implements ReapablePool {
         const drain = (conn as unknown as { whenClosed?: () => Promise<void> }).whenClosed?.();
         if (drain) draining.push(drain);
       }
-      // Pins deliberately survive: `disconnect` (connection_pool.rb:454-465)
-      // clears `@connections`, `@leases` and `@available` but leaves
-      // `@pinned_connection` alone, so a disconnected-but-pinned pool still
-      // unpins cleanly at fixture teardown.
+      // No pin clearing here: `disconnect` (connection_pool.rb:454-465) clears
+      // `@connections`, `@leases` and `@available` only. Rails clears
+      // `@pinned_connection` in `initialize` (:267) and `unpin_connection!`
+      // (:347) and nowhere else, so a pool disconnected mid-test still unpins
+      // cleanly at fixture teardown.
       if (this._connections) this._connections.length = 0;
       this._available?.rejectAll(
         new ConnectionNotEstablished("Connection pool has been disconnected"),
@@ -1039,8 +1040,7 @@ export class ConnectionPool implements ReapablePool {
       if (drain) draining.push(drain);
     }
     // As in `_disconnect`: `discard!` (connection_pool.rb:484-492) nils
-    // `@connections`/`@available`/`@leases` only — `@pinned_connection` is
-    // cleared in `initialize` and `unpin_connection!` and nowhere else.
+    // `@connections`/`@available`/`@leases` only, never the pin.
     this._connections = null;
     this._available?.rejectAll(new ConnectionNotEstablished("Connection pool has been discarded"));
     this._available?.clear();

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
@@ -285,9 +285,9 @@ export class TableDefinition extends AbstractTableDefinition {
     options: ColumnOptions,
   ): ColumnType {
     if (type === "bigint" || options.limit === 8) {
-      return "bigserial" as ColumnType;
+      return "bigserial";
     } else {
-      return "serial" as ColumnType;
+      return "serial";
     }
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
@@ -275,6 +275,22 @@ export class TableDefinition extends AbstractTableDefinition {
     return fallback;
   }
 
+  /**
+   * @internal
+   * Mirrors: PostgreSQL::TableDefinition#integer_like_primary_key_type
+   * (postgresql/schema_definitions.rb:293-299)
+   */
+  protected override integerLikePrimaryKeyType(
+    type: ColumnType,
+    options: ColumnOptions,
+  ): ColumnType {
+    if (type === "bigint" || options.limit === 8) {
+      return "bigserial" as ColumnType;
+    } else {
+      return "serial" as ColumnType;
+    }
+  }
+
   /** @internal */
   protected override validColumnDefinitionOptions(): string[] {
     return [
@@ -850,13 +866,5 @@ function aliasedTypes(name: any, fallback: any): never {
   // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb:289 cluster=pg-long-tail
   throw new NotImplementedError(
     "ActiveRecord::ConnectionAdapters::PostgreSQL::TableDefinition#aliased_types is not implemented",
-  );
-}
-
-/** @internal */
-function integerLikePrimaryKeyType(type: any, options: any): never {
-  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb:293 cluster=pg-long-tail
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::PostgreSQL::TableDefinition#integer_like_primary_key_type is not implemented",
   );
 }

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -512,6 +512,7 @@ describe("ConnectionHandlingTest", () => {
     // Snapshot it so test ordering can't pin the wrong registry.
     const priorCurrent = (DatabaseConfigurations as any).current;
     const priorConfigs = Base.configurations();
+    class InMemoryModel extends Base {}
     try {
       const inMemory = new DatabaseConfigurations([
         new HashConfig(env, "primary", {
@@ -523,12 +524,18 @@ describe("ConnectionHandlingTest", () => {
       // Rails' registry is one class variable, so the config goes on Base
       // even though the connection is established on the subclass.
       Base.configurations(inMemory);
-      class InMemoryModel extends Base {}
 
       await InMemoryModel.establishConnection();
       expect(InMemoryModel.connectionPool().dbConfig.database).toBe("db/common.sqlite3");
       expect(await InMemoryModel.adapterClass()).toBe(await Base.adapterClass());
     } finally {
+      // The pool is never connected here (only its dbConfig is read), but it
+      // stays in the handler's writing list, and `setup_transactional_fixtures`
+      // pins EVERY writing pool with an eager `verify!`
+      // (connection_pool.rb:335) — which would try to open `db/common.sqlite3`
+      // for real in a later test. Drop it, as the sibling establishConnection
+      // tests in this file do.
+      InMemoryModel.removeConnection();
       Base.configurations(priorConfigs);
       (DatabaseConfigurations as any).current = priorCurrent;
     }

--- a/packages/activerecord/src/primary-keys.test.ts
+++ b/packages/activerecord/src/primary-keys.test.ts
@@ -458,9 +458,7 @@ describe("PrimaryKeyWithAutoIncrementTest", () => {
 
   it("primary key with integer", async () => {
     // Rails: id: :integer → SERIAL on PG; INTEGER on MySQL/SQLite.
-    // Our adapter does not map integer id to SERIAL on PG (integerLikePrimaryKeyType
-    // not overridden); use "serial" directly so the column auto-increments on PG.
-    const type = adapterType === "postgres" ? "serial" : "integer";
+    const type = "integer";
     await (Base.connection as any).createTable("auto_increments", {
       id: { type },
       force: true,
@@ -470,7 +468,7 @@ describe("PrimaryKeyWithAutoIncrementTest", () => {
 
   it("primary key with bigint", async () => {
     // Rails: id: :bigint → BIGSERIAL on PG; BIGINT AUTO_INCREMENT on MySQL.
-    const type = adapterType === "postgres" ? "bigserial" : "bigint";
+    const type = "bigint";
     await (Base.connection as any).createTable("auto_increments", {
       id: { type },
       force: true,

--- a/packages/activerecord/src/test-fixtures.ts
+++ b/packages/activerecord/src/test-fixtures.ts
@@ -35,7 +35,6 @@ import { registerModel } from "./associations.js";
 import {
   withTransactionalFixtures,
   type WithTransactionalFixturesOptions,
-  pinFixtureConnectionPool,
 } from "./test-fixtures/with-transactional-fixtures.js";
 import {
   leaseFixtureConnection,
@@ -517,7 +516,6 @@ function useFixtures(
         registerModel(model);
       }
       const adapter = await leaseFixtureConnectionFor(model, fixtureConnection);
-      await pinFixtureConnectionPool(adapter);
       setAdapters.set(key, adapter);
       let group = groups.get(adapter);
       if (group === undefined) {

--- a/packages/activerecord/src/test-fixtures/with-transactional-fixtures.ts
+++ b/packages/activerecord/src/test-fixtures/with-transactional-fixtures.ts
@@ -132,42 +132,6 @@ let fixtureConnectionPools: ConnectionPool[] | null = null;
 let fixtureScopeDepth = 0;
 
 /**
- * Pin the pool a fixture set is about to seed through, if the running test has
- * not pinned it already.
- *
- * Rails needs no such call. It pins every writing pool in
- * `setup_transactional_fixtures` itself (`test_fixtures.rb:175-180`), and
- * discovers later ones from the `!connection.active_record` subscriber
- * (`:182-200`) — which trails now installs below. What is still missing is the
- * literal setup line: pinning `connectionPoolList("writing")` wholesale breaks
- * `base_test.rb`'s `connection in utc time`, where a mid-test
- * `establishConnection` disconnects the pinned pool and teardown then unpins a
- * pool with no pin. Rails survives that because `disconnect!`/`discard!` leave
- * `@pinned_connection` alone — it is cleared only in `initialize`
- * (`connection_pool.rb:267`) and `unpin_connection!` (`:347`) — where
- * `ConnectionPool#_disconnect`/`#_discard` null `_fixturePin`
- * (`connection-pool.ts:975`, `:1040`). Until that diverges back, seeding is the
- * discovery point for pools established before setup.
- *
- * A no-op outside a transactional test, and for an adapter with no pool of its
- * own (the raw-adapter cluster suites seed through the connection the wrapper
- * already opened a transaction on).
- *
- * @noRailsEquivalent CONVERGEABLE — see above; blocked on the `_fixturePin`
- * divergence in `ConnectionPool#_disconnect`/`#_discard`, tracked by RFC 0064
- * `pin-writing-pool-list-in-setup-transactional-fixtures`.
- */
-export async function pinFixtureConnectionPool(
-  adapter: TransactionalFixturesAdapter,
-): Promise<void> {
-  if (fixtureConnectionPools === null) return;
-  const pool = pooledAdapterPool(adapter);
-  if (pool === null || fixtureConnectionPools.includes(pool)) return;
-  fixtureConnectionPools.push(pool);
-  await pinConnectionPool(pool);
-}
-
-/**
  * The pools whose `pinConnectionBang` actually resolved, and therefore the only
  * ones teardown may unpin. Rails needs no such split: its push and its
  * pin/lease are one synchronous step (`test_fixtures.rb:176-180`, `:192-196`),
@@ -349,9 +313,22 @@ export function withTransactionalFixtures(
       // thread that owns the pin. Without this, vitest beforeEach/afterEach
       // can resolve to different AsyncLocalStorage contexts and the unpin
       // won't find the pin set in beforeEach.
-      if (fixtureConnectionPools === null) fixtureConnectionPools = [];
+      if (fixtureConnectionPools === null) {
+        // test_fixtures.rb:175-180 — "Begin transactions for connections
+        // already established":
+        //   @fixture_connection_pools = Base.connection_handler.connection_pool_list(:writing)
+        //   @fixture_connection_pools.each { |p| p.pin_connection!(lock_threads); p.lease_connection }
+        // The wrapped adapter's own pool is appended when it is a sidecar pool
+        // outside the handler's writing list (createPooledTestAdapter), which
+        // Rails has no analogue for — there the test connection *is* the
+        // writing pool.
+        fixtureConnectionPools = Base.connectionHandler.connectionPoolList("writing");
+        if (!fixtureConnectionPools.includes(pool)) fixtureConnectionPools.push(pool);
+        for (const p of fixtureConnectionPools) {
+          await pinConnectionPool(p);
+        }
+      }
       fixtureScopeDepth++;
-      await pinFixtureConnectionPool(adapter);
     } else {
       // Non-pooled path — preserved verbatim. Mirrors Rails
       // ConnectionPool#pin_connection! body.


### PR DESCRIPTION
Three RFC stories, 409 LOC.

## 1. Pin the writing pool list in `setup_transactional_fixtures` (RFC 0064)

Rails pins **every** writing pool as the first step of
`setup_transactional_fixtures` (`test_fixtures.rb:175-180`). trails pinned only
the wrapped adapter's own pool and discovered the rest lazily from `fixtures()`'
seeding loop, via `pinFixtureConnectionPool` (`@noRailsEquivalent CONVERGEABLE`).

The literal port has been attempted twice and failed both times on `base_test.rb`'s
`connection in utc time` — `There isn't a pinned connection`. Root cause, and what
this PR fixes first: `ConnectionPool#_disconnect` and `#_discard` nulled
`_fixturePin` (and cleared `_pinnedConnections`). Rails clears `@pinned_connection`
in exactly two places — `initialize` (`connection_pool.rb:267`) and
`unpin_connection!` (`:347`); `disconnect!` (`:475`) and `discard!` (`:484`) touch
`@connections` / `@leases` / `@available` only. So a pool displaced mid-test by
`establishConnection` and disconnected still unpins cleanly at teardown. With that
converged, `withTransactionalFixtures` pins
`Base.connectionHandler.connectionPoolList("writing")` in setup as Rails does, and
`pinFixtureConnectionPool` plus its receipt are deleted.

One trails-side addition, called out at the site: the wrapped adapter's pool is
appended when it is a sidecar pool outside the handler's writing list
(`createPooledTestAdapter`) — Rails has no analogue, its test connection *is* the
writing pool.

Green: `connection in utc time`, `test-fixtures.test.ts`' secondary-pool
regression, and the multi-`fixtures()` suites (`base`, `autosave-association`,
`attribute-methods`, `associations`, `transactions`, `persistence`, `fixtures`).

## 2. `PostgreSQL::TableDefinition#integer_like_primary_key_type` (RFC 0072)

The story proposed teaching `api:compare` to credit an inherited method to the
ancestor's file. That would have been the wrong fix here: PG **genuinely
overrides** this method (`postgresql/schema_definitions.rb:293-299` → `:bigserial`
/ `:serial`), and the story's own guard says the credit "must not credit a method
the subclass genuinely needs to override and does not." trails had a dead `@nie`
stub and inherited the abstract identity instead.

So this ports it for real. No comparator change; `connection_adapters/postgresql/schema_definitions.rb`
reports 0 missing and the **data layer reaches 7816/7816**.

`id: :integer` / `id: :bigint` now map to SERIAL / BIGSERIAL on PG as in Rails,
which the two trails-only `primary-keys.test.ts` cases had been working around by
naming the serial type directly; their conditionals are gone.

## 3. Delete the collection sync writers (RFC 0087 §1)

The generated `#{name}=` and `#{name}Ids=` property setters are removed. Both of
Rails' writers do DB I/O at assignment time — `writer` → `replace` runs the diffed
deletes+inserts in a transaction, `ids_writer` resolves the ids with a query first
(`collection_association.rb:46-48`, `:61-83`, `:242`) — so neither is expressible
as a JS property setter. `association(name).writer` / `replace` / `idsWriter` are
the collection-mutation surface.

Call sites migrated: `has-many-through-associations.test.ts` "both parent ids set
when saving new" and `required.test.ts` "validates has_many children…" now use
`association(name).writer([...])`. Test names unchanged.
`collection-persisted-setter-throws.trails.test.ts` → `collection-awaitable-writers.trails.test.ts`
(trails-only file; its subject changed) and gained coverage that neither setter
exists and that `idsWriter` replaces.

**Scoped down from the AC, deliberately.** The AC asks for
`CollectionIdsAssignmentError` to be dropped, but the RFC's own rollout retires the
mass-assignment arms in a later step (`retire-sync-association-mass-assignment-arms`),
and those arms are the error's remaining caller: `new Author({ postIds })` /
`assignAttributes({ postIds })` still need a throw naming the awaitable form.
Deleting it now would have turned that into an unknown-attribute error. So the
error and `syncIdsWrite` stay, and the mass-assignment path — which used to reach
them *through* the deleted prototype setter — now matches the `#{singular}Ids` key
directly in `assignAssociationIfMatch` (the single dispatch point shared by the
constructor, `assignAttributes` and `update`). `syncWrite` stays for the same
reason. Both go with the mass-assignment story.

## A leaked pool the upfront pin exposed (PG + MariaDB CI)

Pinning *every* writing pool turned a latent test leak into a hard failure, on
both adapter lanes. `connection-handling.test.ts`'s "autoConnect honors an
in-memory DatabaseConfigurations registry" established a pool on a throwaway
`InMemoryModel` with `database: "db/common.sqlite3"` and restored
`Base.configurations` in its `finally` — but never removed the pool. Nothing
connected it, so it sat inert in the handler's writing list.

`setup_transactional_fixtures` then pins every writing pool, and Rails'
`pin_connection!` **eagerly verifies** the connection
(`connection_pool.rb:335`, `@pinned_connection.verify!`). So the next test to
pin tried to open `db/common.sqlite3` for real:

- PG: `NoDatabaseError: We could not find your database: db/common.sqlite3`
- MariaDB: `ER_DBACCESS_DENIED_ERROR` (payload shows
  `_connectionDescriptor: { name: "InMemoryModel" }`)

Fixed at the source — the test now calls `InMemoryModel.removeConnection()` in
its `finally`, as the sibling `establishConnection` tests in that same file
already do (`BackfillModel`, `CapturedConfigModel`). Not worked around in
`withTransactionalFixtures`: Rails verifies eagerly too, so a bogus pool in the
handler would break Rails identically — the leak is the bug.

Reproduced and verified on an isolated local stack: the MySQL lane fails on
`HEAD~1` and passes with the fix; the PG suites around the pin path and the
SERIAL change are green. `base_test.rb`'s `connection in local time` fails
identically on `origin/main` under PG (host-timezone dependent) and is not from
this diff.

## Gates

- `pnpm api:compare` — activerecord 6148/6148, **data layer 7816/7816**, overall
  13069/17775 (unchanged).
- `pnpm api:calls` OK (14 baselined) · `pnpm api:calls:wide` OK — no new rows, no
  reseed.
- `pnpm api:extra --package activerecord` — no new surface.
- `pnpm lint` clean · `pnpm build` clean · `pnpm test:compare` no name changes.

Closes-story: pin-writing-pool-list-in-setup-transactional-fixtures
Closes-story: credit-inherited-methods-to-the-ancestor-that-defines-them
Closes-story: delete-collection-sync-writers

