### PR TITLE
feat(activerecord,test-compare): derive MySQL mariadb?/full version, fix unless-path gate polarity, record row-count debt policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,9 +287,12 @@ catches a class of drift a reviewer would otherwise spend a cycle on.
 
    **New mismatch?** The right fix is almost always to make the TS body call
    what Rails calls. Baselining is the fallback, and it costs a reviewed
-   one-line `reason` — never leave the seeded placeholder (RFC 0083 ratchets the
-   count of unreviewed reasons; leaving placeholders reds the gate for whoever
-   comes next). A single justified omission can also carry a `@missingRailsCall`
+   one-line `reason` for the row **you** add — never leave the seeded
+   placeholder there. But the debt metric for this baseline is the **row
+   count**, not the unreviewed-reason count: rows converge by deletion, and
+   inherited seed strings in rows your PR did not add are not yours to
+   wordsmith and are not grounds to block a PR (RFC 0084; see
+   [CONTRIBUTING.md](CONTRIBUTING.md#row-count-is-the-debt-metric-the-unreviewed-count-is-not)). A single justified omission can also carry a `@missingRailsCall`
    JSDoc tag at the call site instead.
 
    **Converged something?** The wide baseline is **only-shrink**: fixing a real

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,6 +139,38 @@ to carry a real reason (writing one is still the rule, enforced by whoever
 reviews the baseline diff). `pnpm api:calls:wide:unreviewed` prints the count
 and the mark.
 
+#### Row count is the debt metric; the unreviewed count is not
+
+Decision (RFC 0084): the debt this campaign burns down is the wide baseline's
+**row count**. The unreviewed-reason count is a review-hygiene signal, not a
+debt metric, and is not tracked as one.
+
+The evidence is the two series side by side. Rows went 6,845 (2026-07-17) →
+2,218 (2026-08-03) → 2,195 today, because rows converge by **deletion** — the
+port starts making the call Rails makes and the row goes stale. Over the same
+window the unreviewed count barely moved: 2,028 of 2,218 rows (91%) still
+carried the verbatim RFC 0047 seed weeks after seeding, and it is 2,005 of
+2,195 now. Per-row reason wordsmithing is not happening at any rate that
+matters, and reviewer cycles spent demanding it buy no convergence — the row
+they would have justified is one a later PR deletes outright.
+
+So, concretely:
+
+- **Do not block a PR on seeded reasons in rows it did not add.** Inherited
+  seed strings are not that PR's debt.
+- **Do write a real reason for a row you add.** That rule stands (CLAUDE.md's
+  pre-PR checklist) — it is what makes the baseline diff reviewable — and
+  `@missingRailsCall` at the call site remains the alternative. Rows an author
+  chooses to justify keep their reviewed reason; nothing about the reviewed
+  path is withdrawn.
+- **Report progress in rows retired**, not reasons written.
+
+Nothing mechanical is loosened. The only-shrink row ratchet, the per-file
+unreviewed high-water marks, the stale-tag arm, the reseed-drift arm and the
+sharding are all untouched — every one of them has a paid-for incident behind
+it (#4020, #5869), and the unreviewed marks in particular still stop the count
+from _growing_. What changes is what we ask reviewers to spend cycles on.
+
 Decision (this story): the wide lint is deliberately **kept out of
 `pnpm api:compare`** and documented here instead. Folding it in would make the
 common narrow run pay for the wide-artifact regeneration on every invocation,

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -379,13 +379,23 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   }
 
   /**
+   * Mirrors: Mysql2Adapter#full_version (mysql2_adapter.rb:164-166) —
+   * `database_version.full_version_string`. Rails defines this per concrete
+   * adapter and reaches it from the abstract class by duck typing; TS needs a
+   * declared member, so the single definition lives here. Sync like Rails,
+   * because `database_version` is the memo `configureConnection` warms.
+   * @internal
+   */
+  fullVersion(): string {
+    return this._databaseVersion?.fullVersionString ?? "";
+  }
+
+  /**
    * Mirrors: AbstractMysqlAdapter#mariadb? (abstract_mysql_adapter.rb:92-94) —
-   * `/mariadb/i.match?(full_version)`. Rails' `full_version` reads
-   * `database_version.full_version_string`, memoized by `configure_connection`;
-   * we read the same memo synchronously off `_databaseVersion`.
+   * `/mariadb/i.match?(full_version)`.
    */
   isMariadb(): boolean {
-    return /mariadb/i.test(this._databaseVersion?.fullVersionString ?? "");
+    return /mariadb/i.test(this.fullVersion());
   }
 
   /**
@@ -1725,12 +1735,11 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   }
 
   /**
-   * Parse the server version from the full version string and return it.
-   * Caches the result in `_databaseVersion` so the sync `databaseVersion` getter
-   * works after this method has been awaited once.
-   *
-   * Mirrors: AbstractMysqlAdapter#get_database_version — calls get_full_version,
-   * strips MariaDB prefix via version_string, returns Version.
+   * Mirrors: AbstractMysqlAdapter#get_database_version
+   * (abstract_mysql_adapter.rb:86-90). The leading memo guard stands in for
+   * Rails' `AbstractAdapter#database_version` (`pool.server_version(self)`),
+   * which trails' pool does not cache — without it every `databaseVersion` read
+   * would re-query. It also backs the sync `databaseVersion` getter.
    */
   override async getDatabaseVersion(): Promise<Version> {
     if (this._databaseVersion) return this._databaseVersion;

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -252,7 +252,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       : super.removeForeignKey(fromTable, toTableOrOptions, opts);
   }
 
-  protected _mariadb = false;
   protected _databaseVersion: Version | null = null;
   /**
    * `database.yml`'s `statement_limit`, which Rails reads as
@@ -379,8 +378,14 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return this.quoteTableName(`${table}.${attr}`);
   }
 
+  /**
+   * Mirrors: AbstractMysqlAdapter#mariadb? (abstract_mysql_adapter.rb:92-94) —
+   * `/mariadb/i.match?(full_version)`. Rails' `full_version` reads
+   * `database_version.full_version_string`, memoized by `configure_connection`;
+   * we read the same memo synchronously off `_databaseVersion`.
+   */
   isMariadb(): boolean {
-    return this._mariadb;
+    return /mariadb/i.test(this._databaseVersion?.fullVersionString ?? "");
   }
 
   /**
@@ -410,14 +415,14 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   supportsIndexSortOrder(): boolean {
     // Rails: `mariadb? ? database_version >= "10.8.1" : database_version >= "8.0.1"`
     // (abstract_mysql_adapter.rb#supports_index_sort_order?).
-    if (this._mariadb) return (this._databaseVersion?.compare("10.8.1") ?? -1) >= 0;
+    if (this.isMariadb()) return (this._databaseVersion?.compare("10.8.1") ?? -1) >= 0;
     return (this._databaseVersion?.compare("8.0.1") ?? -1) >= 0;
   }
 
   supportsExpressionIndex(): boolean {
     // Mirror Rails `!mariadb? && database_version >= "8.0.13"`
     // (abstract_mysql_adapter.rb:104) — MariaDB is excluded.
-    if (this._mariadb) return false;
+    if (this.isMariadb()) return false;
     return (this._databaseVersion?.compare("8.0.13") ?? -1) >= 0;
   }
 
@@ -442,7 +447,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   }
 
   supportsCheckConstraints(): boolean {
-    if (this._mariadb) {
+    if (this.isMariadb()) {
       // Rails' two-branch MariaDB floor (abstract_mysql_adapter.rb:128-132):
       // 10.3.10+, or a pre-10.3 series from 10.2.22 — 10.3.0..10.3.9 is
       // excluded, which a single `>= 10.2.22` would wrongly admit.
@@ -469,12 +474,12 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   }
 
   supportsOptimizerHints(): boolean {
-    if (this._mariadb) return false;
+    if (this.isMariadb()) return false;
     return (this._databaseVersion?.compare("5.7.7") ?? -1) >= 0;
   }
 
   supportsCommonTableExpressions(): boolean {
-    if (this._mariadb) return (this._databaseVersion?.compare("10.2.1") ?? -1) >= 0;
+    if (this.isMariadb()) return (this._databaseVersion?.compare("10.2.1") ?? -1) >= 0;
     return (this._databaseVersion?.compare("8.0") ?? -1) >= 0;
   }
 
@@ -491,7 +496,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   }
 
   supportsInsertReturning(): boolean {
-    if (this._mariadb) return (this._databaseVersion?.compare("10.5.0") ?? -1) >= 0;
+    if (this.isMariadb()) return (this._databaseVersion?.compare("10.5.0") ?? -1) >= 0;
     return false;
   }
 
@@ -522,7 +527,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     // Mirror Rails `!mariadb? && database_version >= "5.7.8"`
     // (mysql2_adapter.rb:70 / trilogy_adapter.rb:95) — MariaDB JSON is a
     // LONGTEXT alias, so Rails reports it unsupported.
-    if (this._mariadb) return false;
+    if (this.isMariadb()) return false;
     return (this._databaseVersion?.compare("5.7.8") ?? -1) >= 0;
   }
 
@@ -1045,7 +1050,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
         AND cc.constraint_schema = ${scope.schema}`;
     // MariaDB lacks the schema+name uniqueness MySQL's JOIN relies on, so it
     // additionally filters cc.table_name (mirrors Rails).
-    if (this._mariadb) sql += ` AND cc.table_name = ${scope.name}`;
+    if (this.isMariadb()) sql += ` AND cc.table_name = ${scope.name}`;
 
     const rows = await this.schemaQuery(sql);
 
@@ -1056,7 +1061,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
         expression = expression.slice(1, -1);
       }
       expression = this.stripWhitespaceCharacters(expression);
-      if (!this._mariadb) {
+      if (!this.isMariadb()) {
         // MySQL returns check constraints expression in an already escaped form.
         // This leads to duplicate escaping later (e.g. when the expression is
         // used in the SchemaDumper).
@@ -1412,7 +1417,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::DatabaseStatements#analyze_without_explain?
    */
   protected analyzeWithoutExplain(): boolean {
-    return this._mariadb && (this._databaseVersion?.compare("10.1.0") ?? -1) >= 0;
+    return this.isMariadb() && (this._databaseVersion?.compare("10.1.0") ?? -1) >= 0;
   }
 
   /**
@@ -1692,19 +1697,19 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
 
   /** @internal */
   supportsInsertRawAliasSyntax(): boolean {
-    if (this._mariadb) return false;
+    if (this.isMariadb()) return false;
     return (this._databaseVersion?.compare("8.0.19") ?? -1) >= 0;
   }
 
   /** @internal */
   supportsRenameIndex(): boolean {
-    if (this._mariadb) return (this._databaseVersion?.compare("10.5.2") ?? -1) >= 0;
+    if (this.isMariadb()) return (this._databaseVersion?.compare("10.5.2") ?? -1) >= 0;
     return (this._databaseVersion?.compare("5.7.6") ?? -1) >= 0;
   }
 
   /** @internal */
   supportsRenameColumn(): boolean {
-    if (this._mariadb) return (this._databaseVersion?.compare("10.5.2") ?? -1) >= 0;
+    if (this.isMariadb()) return (this._databaseVersion?.compare("10.5.2") ?? -1) >= 0;
     return (this._databaseVersion?.compare("8.0.3") ?? -1) >= 0;
   }
 
@@ -1729,12 +1734,9 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    */
   override async getDatabaseVersion(): Promise<Version> {
     if (this._databaseVersion) return this._databaseVersion;
-    const fullVersion = await this.getFullVersion();
-    // getFullVersion() may have set _databaseVersion as a side effect
-    // (e.g. Mysql2Adapter#getFullVersion populates it while fetching); re-check
-    // to avoid double-parsing the version string in those subclasses.
-    if (this._databaseVersion) return this._databaseVersion;
-    const version = new Version(this.versionString(fullVersion), fullVersion);
+    const fullVersionString = await this.getFullVersion();
+    const versionString = this.versionString(fullVersionString);
+    const version = new Version(versionString, fullVersionString);
     this._databaseVersion = version;
     return version;
   }

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -16,11 +16,7 @@ import { isRubyTruthy } from "../ruby-truthy.js";
 import { TypeMap } from "../type/type-map.js";
 import * as Type from "../type.js";
 import { UnsignedInteger } from "../type/unsigned-integer.js";
-import {
-  AbstractAdapter,
-  Version,
-  RAW_CONNECTION_DEPRECATION_MESSAGE,
-} from "./abstract-adapter.js";
+import { AbstractAdapter, RAW_CONNECTION_DEPRECATION_MESSAGE } from "./abstract-adapter.js";
 import { deprecator } from "../deprecator.js";
 import { captureUnwrappedExecute, dirtiesQueryCache } from "./abstract/query-cache.js";
 import {
@@ -351,7 +347,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     super.clearCacheBang();
     this._statementPool?.clear();
   }
-  private _fullVersionString: string | null = null;
   private _database: string | undefined;
 
   /**
@@ -1742,19 +1737,15 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   }
 
   /**
-   * Fetch the raw version string from the server (e.g. "8.0.28").
-   * Populates _databaseVersion and _mariadb as a side effect.
+   * Mirrors: Mysql2Adapter#get_full_version (mysql2_adapter.rb:168-170) —
+   * `any_raw_connection.server_info[:version]`. No memo: `database_version` is
+   * the only memo in the Rails chain.
    * @internal
    */
   async getFullVersion(): Promise<string> {
-    if (this._fullVersionString) return this._fullVersionString;
     const conn = await this.getConn();
     const [[row]] = (await conn.query("SELECT VERSION() AS v")) as [Array<{ v: string }>, unknown];
-    const ver = row?.v ?? "0.0.0";
-    this._fullVersionString = ver;
-    this._mariadb = /mariadb/i.test(ver);
-    this._databaseVersion = new Version(this.versionString(ver), ver);
-    return ver;
+    return row?.v ?? "0.0.0";
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1737,27 +1737,17 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   }
 
   /**
-   * Mirrors: Mysql2Adapter#get_full_version (mysql2_adapter.rb:168-170) —
-   * `any_raw_connection.server_info[:version]`. No memo: `database_version` is
-   * the only memo in the Rails chain.
+   * Mirrors: Mysql2Adapter#get_full_version (mysql2_adapter.rb:168-170). No
+   * memo and no side effects: `database_version` is the only memo in the Rails
+   * chain. Rails reads `any_raw_connection.server_info[:version]`; node-mysql2
+   * exposes no `server_info`, so the banner comes from `SELECT VERSION()` —
+   * the same string the server reports there.
    * @internal
    */
   async getFullVersion(): Promise<string> {
     const conn = await this.getConn();
     const [[row]] = (await conn.query("SELECT VERSION() AS v")) as [Array<{ v: string }>, unknown];
     return row?.v ?? "0.0.0";
-  }
-
-  /**
-   * Mirrors: Mysql2Adapter#full_version (mysql2_adapter.rb:164-166) —
-   * `database_version.full_version_string`. Rails' reader is sync because
-   * `database_version` is memoized by `configure_connection`; here the fetch is
-   * awaited, and the banner comes off the `Version` rather than a second field.
-   * @internal
-   */
-  async fullVersion(): Promise<string> {
-    const databaseVersion = await this.getDatabaseVersion();
-    return databaseVersion.fullVersionString ?? "0.0.0";
   }
 
   /** @internal */

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
@@ -151,7 +151,7 @@
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "mariadb?",
     "call": "match?",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails abstract_mysql_adapter.rb:92-94 runs `/mariadb/i.match?(full_version)` live; trails isMariadb (abstract-mysql-adapter.ts:422-424) returns the `_mariadb` flag computed once at connect by the same regex (mysql2-adapter.ts:1864)."
+    "reason": "Per-entry verified: Rails abstract_mysql_adapter.rb:92-94 runs `/mariadb/i.match?(full_version)`; trails isMariadb runs the same regex over the same `fullVersion()` reader, spelled `RegExp#test` because TS has no `Regexp#match?`."
   },
   {
     "package": "activerecord",

--- a/scripts/test-compare/extract-ruby-gates.test.ts
+++ b/scripts/test-compare/extract-ruby-gates.test.ts
@@ -256,6 +256,35 @@ describe("Ruby extractor gate detection", () => {
     expect(g["send only"]).toEqual({ features: ["rename_index"], source: ["body-skip"] });
   });
 
+  it("reads feature polarity against the run condition on the skip-if path", () => {
+    const g = rubyGates({
+      // `skip if !supports_x?` runs on `supports_x?`. The run condition is the
+      // NEGATION of the source condition, so the textually-negated predicate is
+      // the one the test runs on — a plain feature gate, not a `no_` guard.
+      // `has_or` is textual and never sees that inversion, hence `has_and`.
+      "cases/bar_test.rb": `
+        class BarTest < ActiveRecord::TestCase
+          def test_skip_if_not_feature
+            skip "x" if !supports_insert_returning?
+          end
+          def test_unless_not_feature
+            skip "x" unless !supports_insert_returning?
+          end
+        end
+      `,
+    });
+    expect(g["skip if not feature"]).toEqual({
+      features: ["insert_returning"],
+      source: ["body-skip"],
+    });
+    // `skip unless !feature` runs on `!supports_x?`, so the same predicate
+    // inverts the other way — into the `no_` guard.
+    expect(g["unless not feature"]).toEqual({
+      guards: ["no_insert_returning"],
+      source: ["body-skip"],
+    });
+  });
+
   it("does not emit an adapter exclusion under `unless` (negation → disjunction)", () => {
     const g = rubyGates({
       // `unless feature && !sqlite` runs when `!feature || sqlite` — a disjunction

--- a/scripts/test-compare/extract-ruby-tests.rb
+++ b/scripts/test-compare/extract-ruby-tests.rb
@@ -607,18 +607,29 @@ class TestExtractor
   # whether the body runs when the condition is true (`if` → true, `unless` → false).
   def gate_from_run_condition(cond, positive)
     acc = { adapter_syms: [], neg_adapter_syms: [], features: [], neg_features: [], guards: [],
-            has_or: false }
+            has_or: false, has_and: false }
     scan_run_condition(cond, acc)
 
-    # A NEGATED feature predicate only decomposes on the run-when-true path of a
-    # pure conjunction (`if current_adapter?(:X) && !supports_y?`): there the test
-    # runs on `X ∩ ¬y`, which a surviving adapter set plus a `no_y` guard states
-    # exactly — while lumping `y` into `:features` would claim the OPPOSITE
-    # capability alongside that adapter set. Elsewhere the run-on set isn't that
-    # intersection, so the polarity-blind lumping stays.
-    split = positive && !acc[:has_or]
-    features = split ? acc[:features] : acc[:features] + acc[:neg_features]
-    inverted_features = split ? acc[:neg_features] : []
+    # A NEGATED feature predicate only decomposes when the RUN condition is a pure
+    # conjunction: there the test runs on an intersection, which a surviving
+    # adapter set plus a `no_y` guard states exactly — while lumping `y` into
+    # `:features` would claim the OPPOSITE capability alongside that adapter set.
+    # Elsewhere the run-on set isn't that intersection, so the polarity-blind
+    # lumping stays.
+    #
+    # `has_or` is textual, so it only answers that question on the run-when-true
+    # path. On the `unless` path the run condition is the NEGATION of the source
+    # condition, and De Morgan turns its `&&` into a disjunction (`unless A && B`
+    # runs on `!A || B`) that `has_or` never sees — hence `has_and`.
+    run_has_or = positive ? acc[:has_or] : (acc[:has_and] || acc[:has_or])
+    split = !run_has_or
+    # Feature polarity is read against the RUN condition: on the `unless` path a
+    # textually-negated predicate is the one the test RUNS on (`skip if
+    # !supports_x?` runs on `supports_x?`), so the two buckets swap.
+    run_features = positive ? acc[:features] : acc[:neg_features]
+    run_neg_features = positive ? acc[:neg_features] : acc[:features]
+    features = split ? run_features : acc[:features] + acc[:neg_features]
+    inverted_features = split ? run_neg_features : []
     any_feature = !features.empty? || !inverted_features.empty?
 
     adapters = acc[:adapter_syms].map { |s| ADAPTER_SYMBOL_MAP[s] }.compact.uniq
@@ -671,7 +682,7 @@ class TestExtractor
       gate[:adapters] = base - neg_adapters
     end
     unless features.empty?
-      if positive
+      if positive || split
         gate[:features] = features.uniq
       else
         gate[:guards] = (gate[:guards] || []) + features.map { |f| "no_#{f}" }
@@ -699,6 +710,10 @@ class TestExtractor
     # `||`/`or` anywhere makes the run-on adapter set a disjunction; record it so
     # a negated-adapter exclusion isn't unsoundly emitted from a compound.
     acc[:has_or] = true if node[0] == :binary && (node[2] == :"||" || node[2] == :or)
+    # `&&`/`and` becomes a disjunction once the condition is negated, which is
+    # exactly what the `unless` path runs on; recorded so the polarity split can
+    # tell a pure run-condition conjunction from `!(A && B)`.
+    acc[:has_and] = true if node[0] == :binary && (node[2] == :"&&" || node[2] == :and)
     name = call_ident_name(node)
     if name
       # Once a predicate is identified, stop: recursing into its own receiver/args


### PR DESCRIPTION
Bundle of four RFC stories. Three ship here; the fourth is blocked (below).

## 1. `row-count-is-debt-not-seeded-reasons` (RFC 0084) — docs

Records the policy decision: the wide baseline's **row count** is the debt
metric; the unreviewed-reason count is not tracked as debt.

The evidence is the two series side by side. Rows: 6,845 (2026-07-17) → 2,218
(2026-08-03) → 2,195 today, because rows converge by **deletion** — the port
starts making the call and the row goes stale. Unreviewed over the same window:
2,028/2,218 (91%) → 2,005/2,195 (91%), flat. The reason a reviewer would demand
is one a later PR removes outright.

Written into RFC 0084's README (tasks repo, `48d57ef8b`), `CONTRIBUTING.md`
(new subsection under the wide-ratchet section) and `CLAUDE.md` (pre-PR
checklist step 2).

Explicitly preserved: an author still writes a real reason for a row **they**
add; `@missingRailsCall` stays the per-site alternative; reviewed reasons stay
fully supported. What changes is that inherited seed strings in rows a PR did
not add are not that PR's debt and are not grounds to block it.

**No mechanical loosening.** The only-shrink row ratchet, the per-file
unreviewed high-water marks, the stale-tag arm, the reseed-drift arm and the
sharding are byte-for-byte untouched — no code under `scripts/api-compare/` is
in this diff.

## 2. `ruby-gate-extractor-unless-path-inverts-feature-polarity` (RFC 0064)

`gate_from_run_condition` split feature polarity only when
`positive && !acc[:has_or]`, so on the `unless` path it inverted its whole
feature list textually: `skip if !supports_x?` emitted `guards: [no_x]` where
the truth — and what `gates.ts` emits — is `features: [x]`.

`has_or` is textual, and `unless A && B` runs on `!A || B`, a disjunction it
never sees. So the fix adds `has_and` and reads the run condition through it:

```ruby
run_has_or = positive ? acc[:has_or] : (acc[:has_and] || acc[:has_or])
split = !run_has_or
run_features     = positive ? acc[:features] : acc[:neg_features]
run_neg_features = positive ? acc[:neg_features] : acc[:features]
```

On the `unless` path the two buckets swap, because a textually-negated
predicate is the one the test RUNS on. Emission then keys off `positive || split`.

The `if`-path and disjunctive behaviour #5683 established is unchanged: the
positive branch still reads `acc[:has_or]` alone.

**Verification.** Diffed the per-gate JSON (`output/rails-tests.json`) before
and after, not just the summary count: **1,929 gated tests before, 1,929 after,
0 moved.** All 20 existing pins in `extract-ruby-gates.test.ts` still pass
unchanged — including `reads a supports_X? predicate reached through send`,
whose `foreign_key_test.rb:96` shape has `has_and`, so it stays unsplit and
resolves to a guards-only (non-comparable) gate exactly as before. One new pin
covers both polarities of the converged shape.

This is latent, not live — as the story says, no Rails test hits it today.

## 3. `retire-mysql-full-version-and-mariadb-memo-fields` (RFC 0072)

Rails' MySQL version state is derived; `database_version` is the only memo in
the chain. trails carried two extra cached fields.

- `getFullVersion` is now the bare fetch, per `mysql2_adapter.rb:168-170` — no
  `_fullVersionString` memo, no `_databaseVersion` side effect, no `_mariadb`
  side effect. The field is deleted. (Rails reads
  `any_raw_connection.server_info[:version]`; node-mysql2 exposes no
  `server_info`, so the banner still comes from `SELECT VERSION()` — cited at
  the call site.)
- `isMariadb()` is now a literal port of `abstract_mysql_adapter.rb:92-94`:
  `/mariadb/i` against **`this.fullVersion()`**, not against a field. That
  restores the `mariadb? → full_version` delegation Rails has. `_mariadb` is
  deleted; its ~14 read sites call the predicate.
- `fullVersion()` collapses to **one** definition, ported from
  `mysql2_adapter.rb:164-166` (`database_version.full_version_string`) and
  **sync like Rails**, replacing the async duplicate on `Mysql2Adapter` (which
  had no callers). Rails defines it per concrete adapter and reaches it from
  the abstract class by duck typing; TS needs a declared member, so the single
  definition sits on `AbstractMysqlAdapter` — cited at the call site.
- `getDatabaseVersion` loses the invented double-memo re-check and reads like
  `abstract_mysql_adapter.rb:86-90` with the Rails locals (`fullVersionString`,
  `versionString`). The one remaining leading memo guard is cited as the
  stand-in for `AbstractAdapter#database_version`'s `pool.server_version(self)`,
  which trails' pool does not cache.

The `mariadb?` / `match?` wide-baseline row stays (TS has no `Regexp#match?`;
`RegExp#test` is the spelling), but its **reason was factually invalidated by
this change** — it described the deleted `_mariadb` flag — so it is rewritten to
describe what the body now does. That is the sanctioned case for touching a
reason, not wordsmithing under the policy in §1.

Note on sync-ness: the predicate stays **sync**, which is Rails' own chain —
`mariadb?` → `full_version` → `database_version.full_version_string`, where
`database_version` is the memo `configure_connection` warms. Making it async
would have cascaded through every sync `supports_*` method for no fidelity
gain. Ordering is unchanged: both deleted fields were previously populated
inside `getFullVersion`, which `getDatabaseVersion` awaits before any reader runs.

`pnpm api:extra --package activerecord` adds no novel surface (`isMariadb`
already existed).

## 4. `port-base-association-find-target-body` (RFC 0072) — **blocked, not in this PR**

The story estimates ~250 LOC for a body port. It is not one. The Rails base
`find_target` machinery does not exist in trails:

- `skip_statement_cache?` (`association.rb:391`) has **no TS counterpart at all**.
- The subclass `findTarget` overrides do not call a shared base body. Each
  delegates to a standalone functional loader — `singular-association.ts:444`,
  `has-many-association.ts:514`, `has-one-through-association.ts:732`, plus
  `has-many-through-association.ts` — ~3,300 LOC across four files that never
  builds `scope` or a statement cache at all.
- `super.findTarget()` at `has-many-through-association.ts:51` resolves to
  `HasManyAssociation`'s override, not the base.

Porting `association.rb:248-270` into the base and routing subclasses through
it means replacing that whole loader architecture. Porting the base body
*without* rerouting the subclasses would add unreachable surface and fail the
story's own second criterion, so that is not a partial worth shipping.

Blocked via `pnpm tasks block` with a suggested re-cut as an epic: (1) add
`skipStatementCache?`, (2) converge one loader at a time onto
`scope` / `associationScopeCache` / `getBindValues`, (3) collapse into the base.

## Gates

- Size: 120 insertions, 45 deletions (excl. `.md`) — well under ceiling.
- `pnpm api:calls` — OK (14 baselined).
- `pnpm api:calls:wide` — OK (2195 baselined, 2005 unreviewed, 373 marks, tight).
  One reason rewritten (above); no rows added, no reseed.
- `pnpm api:extra --package activerecord` — no novel names added.
- `pnpm api:compare` — activerecord 6147/6148 (100%), files 277/277; no delta.
- `pnpm typecheck` clean; `pnpm test:compare --gates` per-gate JSON diff empty.

MySQL/MariaDB lanes are CI-only from here — that arm is on CI.

Closes-story: row-count-is-debt-not-seeded-reasons
Closes-story: ruby-gate-extractor-unless-path-inverts-feature-polarity
Closes-story: retire-mysql-full-version-and-mariadb-memo-fields
