### PR TITLE
feat(activerecord,ci): seed Context defaults, drop TokenDefinition stubs, declare MySQL mixin surface, retire PG pg getter, lift gate prose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,161 +97,21 @@ jobs:
             base="${{ github.event.before }}"
             head="${{ github.sha }}"
           fi
-          # First push to a branch has a zero-SHA base; force-push may
-          # rewrite history out from under us. In either case we can't
-          # reliably compute a diff — fall back to running the full matrix.
-          # activerecord_affected gates the three AR test jobs (sqlite,
-          # postgres, mariadb). True when changes touch activerecord, its
-          # runtime deps (arel/activemodel/activesupport/globalid), or any
-          # cross-cutting file (lockfile, root tsconfig, vitest config,
-          # shared scripts, this workflow). Push to main / schedule /
-          # workflow_dispatch always force true. Pattern mirrors the
-          # AR-touching set in scripts/parity/run.ts.
-          # Cross-cutting paths force every per-package gate true. Anything
-          # here affects all packages: workspace topology, root tooling
-          # config, shared scripts, this workflow, composite actions.
-          # The blanket `scripts/` below also sweeps up subtrees that are NOT
-          # cross-cutting; INFRA_CARVEOUT_RE strips them back out — keep the
-          # two in sync. Every carved subtree must still be named in the gate
-          # of whichever job runs its tests, or a change confined to it runs
-          # nothing; scripts/ci-suite-coverage.test.ts enforces that pairing.
+          # Gate rationale: scripts/ci-suite-coverage.test.ts ("Gate reference").
           INFRA_RE='^(pnpm-lock\.yaml$|pnpm-workspace\.yaml$|package\.json$|tsconfig[^/]*\.json$|vitest[^/]*\.config\.ts$|scripts/|\.github/workflows/ci\.yml$|\.github/actions/)'
           INFRA_CARVEOUT_RE='^scripts/((tasks|ci|guides-typecheck|rails-find|sync-stats|phase-g-hunt|fixtures-inventory|test-deps|__fixtures__|api-compare|test-compare|fixtures-compare|schema-compare|parity)/|(build-rails-privates-manifest|build-rails-file-structure-manifest|rails-file-structure-mixins|strip-asany|ci-suite-coverage|deprecated-manifest-diff|mixin-declaration-drift|mysql-grant-namespaces|stale-story-references)(\.test)?\.ts$)'
-          # AR workspace deps: arel/activemodel/activesupport/globalid/
-          # did-you-mean (per packages/activerecord/package.json). Also
-          # consumes @blazetrails/trails-tsc at runtime via the tsc-wrapper
-          # CLI + type-virtualization modules (see packages/activerecord/src/
-          # tsc-wrapper, schema-columns-dump.test.ts), so trails-tsc changes
-          # can fail AR vitest suites — include it in the gate.
-          # activerecord-cli E2E suites run in the three AR DB jobs (its tests
-          # exercise the CLI against real DBs), so cli source changes must also
-          # flip activerecord_affected.
           AR_PKGS_RE='^packages/(activerecord|activerecord-cli|arel|activemodel|activesupport|globalid|did-you-mean|trails-tsc)/'
-          # db_adapter_affected gates nothing on its own: it is the opt-in that
-          # runs the PG/MariaDB suites while a PR is still a draft, so a false
-          # negative costs a later signal, never coverage. `abstract/` and
-          # sql-classification.ts are in scope because that substrate breaks
-          # one backend without naming it (the latter carries the PG cursor
-          # statements in its read-only allowlist).
           DB_ADAPTER_RE='^(packages/activerecord/src/(adapters/(postgresql|abstract-mysql-adapter)|connection-adapters/(postgresql|mysql|mysql2|abstract-mysql-adapter|abstract/|abstract-adapter\.ts|column\.ts|adapter-args\.ts|sql-classification\.ts|pool))|packages/arel/src/visitors/(postgres|mysql)|packages/activerecord-cli/src/__e2e__/(postgres|mysql))'
-          # actionpack_affected gates actionpack-tests. True for actionpack +
-          # its runtime deps (actionview/activemodel/activesupport/rack/did-you-mean).
           AP_PKGS_RE='^packages/(actionpack|actionview|activemodel|activesupport|rack|did-you-mean)/'
-          # actionview_affected gates the actionview step of leaf-tests.
-          # ActionView's only
-          # workspace dependency is activesupport (see actionview/package.json).
           AV_PKGS_RE='^packages/(actionview|activesupport)/'
-          # trailties_affected gates trailties-tests. Trailties consumes
-          # actionpack/actionview/activerecord/rack/activesupport, so any of
-          # their workspace upstreams also flips this on.
           TRAILTIES_PKGS_RE='^packages/(trailties|actionpack|actionview|activerecord|arel|activemodel|activesupport|globalid|rack|did-you-mean|trails-tsc)/'
-          # trails_tsc_affected gates the virtualized DX type tests, the
-          # blocking trails-tsc-tests job, and trails-tsc-coverage.
-          # Workspace consumers of @blazetrails/trails-tsc today: activerecord
-          # (tsc-wrapper + type-virtualization) and scripts/guides-typecheck;
-          # AR consumption is the reason trails-tsc is also in AR_PKGS_RE.
           TRAILS_TSC_PKGS_RE='^packages/trails-tsc/'
-          # tse_compiler_affected gates the tse-compiler step of leaf-tests.
-          # The package has
-          # no workspace dependencies today (no activesupport import), so
-          # the gate matches the package path only.
           TSE_COMPILER_PKGS_RE='^packages/tse-compiler/'
-          # rack_affected gates the rack step of leaf-tests (split out of
-          # unit-tests so a rack-only PR doesn't drag in
-          # arel/activemodel/activesupport tests). Rack's only workspace
-          # dependency is activesupport.
           RACK_PKGS_RE='^packages/(rack|activesupport)/'
-          # unit_tests_affected gates the bundled vitest run for the small
-          # leaf packages (arel/activemodel/activesupport/i18n) and the
-          # scripts/guides-typecheck self-test. Rack is excluded here — it
-          # runs in the leaf-tests job.
-          # scripts/tasks/ and scripts/guides-typecheck/ also ride on this gate
-          # since they're bundled into the same vitest invocation as the leaf
-          # packages (ci.yml:604) — and both are carved out of the infra sweep
-          # (INFRA_CARVEOUT_RE), so this clause is what keeps their self-tests
-          # running on a subtree-only change.
-          # scripts/parity/ rides on it too: the query-runner integration tests
-          # spawn dump.ts/ar_dump.ts against the fixtures, so a change to either
-          # the runners or the fixtures has to re-run them. (Their other input,
-          # packages/activerecord/, is deliberately NOT on this gate — pulling
-          # every AR PR into the leaf-package suites costs more than it catches;
-          # the label-gated query-parity-trails job covers that direction.)
-          # NO packages/activerecord/ path feeds this gate. The two suites here
-          # that import AR — scripts/test-deps/ and scripts/parity/query/node/ —
-          # are re-run by sqlite-tests (activerecord_affected) instead; see the
-          # comment there.
-          # The compare tooling's suites run in that same invocation and are
-          # ALL in INFRA_CARVEOUT_RE, so without naming them here a change
-          # confined to one of them would run none of its own tests.
-          # schema-compare/ is deliberately absent — its suite parses the real
-          # vendored schema.rb, so it runs in rails-comparison (COMPARISON_RE).
-          # eslint/ rides on it because the custom rules' own RuleTester suites
-          # are in the same invocation: without this clause a PR that only
-          # touches a rule or its test would skip the only job that runs them.
-          # eslint.config.mjs is named separately (it is not under eslint/):
-          # eslint/rails-private-jsdoc.config.test.mjs is a drift guard between
-          # it and eslint/rails-private-jsdoc.config.mjs, so an isolated change
-          # to the root config must still run the guard.
-          # scripts/ci/check-control-bytes.sh is named for the same reason:
-          # eslint/no-raw-control-bytes.drift.test.mjs is a drift guard between
-          # its byte set and the ESLint rule's, and scripts/ci/ is carved out
-          # of the infra sweep (INFRA_CARVEOUT_RE).
           UNIT_TESTS_PKGS_RE='^(packages/(arel|activemodel|activesupport|i18n)/|eslint/|scripts/(tasks|guides-typecheck|parity|api-compare|test-compare|fixtures-compare|test-deps|rails-find|sync-stats|prism-codegen)/|scripts/ci/check-control-bytes\.sh$|scripts/(strip-asany|rails-file-structure-mixins|ci-suite-coverage|deprecated-manifest-diff|mixin-declaration-drift|mysql-grant-namespaces|stale-story-references|non-transactional-row-writes)(\.test)?\.ts$|scripts/db-init/mysql/01-rails-user\.sql$|packages/activerecord-cli/src/__e2e__/|eslint\.config\.mjs$|vendor/(sources\.ts|sources\.lock\.json|sources\.test\.ts|fetch\.ts)$)'
-          # guides_affected gates the Guides Code Type Check job, which
-          # compiles fenced TS blocks in packages/website/docs/guides/**.
-          # Today guides only import @blazetrails/activerecord,
-          # @blazetrails/activemodel, and @blazetrails/activesupport — plus
-          # AR's transitive type deps. Confirmed via:
-          #   grep -rhE "from ['\"]@blazetrails/[a-z-]+" packages/website/docs/guides
-          # scripts/guides-typecheck/ is the job's own implementation and is
-          # carved out of the infra sweep (INFRA_CARVEOUT_RE), so it must be
-          # named here or a checker-only change would stop running the checker.
           GUIDES_PKGS_RE='^(packages/(activerecord|activemodel|activesupport|arel|globalid|did-you-mean|trails-tsc)/|packages/website/docs/guides/|scripts/guides-typecheck/)'
           GUIDES_EXCL_RE='(/src/test-helpers(/|\.ts$)|/test-fixtures?(/|\.ts$)|/__fixtures__/|/__snapshots__/|\.test\.ts$)'
-          # website_affected gates the Website build (SvelteKit + typedoc +
-          # VitePress). Scoped narrowly to packages/website/ — package-source
-          # changes alone don't trigger it. To run the site build on a PR
-          # that touches package sources, apply the `website` label (or the
-          # `release` label, which always runs it). The job is also
-          # exercised post-merge by push-to-main.
           WEBSITE_PKGS_RE='^packages/website/'
-          # comparison_affected gates the Rails API/Test Comparison job. That
-          # job is only meaningful when Rails-port package source, the compare
-          # tooling (scripts/{api,test,fixtures,schema}-compare/ and the Rails
-          # manifest builders), or the vendored
-          # upstream Ruby sources changed — plus cross-cutting infra (INFRA_RE)
-          # below. A scripts/tasks-only, website-only, or other tooling-only
-          # change can't move any comparison output, so it skips.
-          # packages/website/ is EXCLUDED: it's the SvelteKit docs site, never
-          # one of apiComparePackages() (vendor/sources.ts), so the comparison
-          # never scans it — set_gate's exclusion argument drops it before
-          # the COMPARISON_RE `^packages/` clause is applied.
-          # NOTE: scripts/api-compare/conventions.ts regenerates
-          # docs/ruby-ts-conventions.md (checked by api:conventions --check in
-          # the job); the scripts/api-compare/ clause keeps that drift check
-          # gated on. As with the package gates, infra_files (which carves out
-          # the single-consumer scripts/ subtrees) feeds the INFRA_RE half of
-          # the OR.
-          # docs/ruby-ts-conventions.md is ALSO matched directly: it's the
-          # generated artifact the conventions check guards, and the docs_only
-          # logic above (`:234`) deliberately keeps a hand-edit of it
-          # non-docs-only so the drift check still runs. Mirror that here — a
-          # PR that edits ONLY that file matches neither INFRA_RE nor the
-          # package/vendor clauses, so without this it would skip the very
-          # check the docs_only exception was built to preserve.
-          # eslint/rails-deprecated-methods.json is matched directly for the
-          # same reason as ruby-ts-conventions.md: it is the generated artifact
-          # the `--check-deprecated` step guards, and `eslint/` appears in
-          # neither INFRA_RE nor the package/vendor clauses. Without this, the
-          # one change shape the guard exists to catch — a commit that ONLY
-          # drops manifest entries — would skip rails-comparison entirely and
-          # never run the recompute.
-          # schema-compare/ (the Schema comparison step, ci.yml:1272) and the
-          # two Rails manifest builders + their shared mixin resolver (the
-          # privates/file-structure steps, ci.yml:1279/1293) are named
-          # explicitly: all are carved out of the infra sweep
-          # (INFRA_CARVEOUT_RE), so this clause is the only thing that still
-          # runs rails-comparison on a change confined to them.
           COMPARISON_RE='^(packages/|scripts/((api|test|fixtures|schema)-compare/|prism-codegen/|(build-rails-privates-manifest|build-rails-file-structure-manifest|rails-file-structure-mixins|deprecated-manifest-diff)\.ts$)|vendor/|docs/ruby-ts-conventions\.md$|eslint/rails-deprecated-methods\.json$)'
           force_all_affected() {
             echo "activerecord_affected=true" >> "$GITHUB_OUTPUT"
@@ -272,11 +132,6 @@ jobs:
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
             echo "prettier_files=__ALL__" >> "$GITHUB_OUTPUT"
             force_all_affected
-          # Triple-dot: diff against the merge-base of $base and $head, not
-          # against the current tip of the base branch. Using `$base $head`
-          # would also include every commit merged to main since this branch
-          # diverged, inflating the changed-files list with unrelated paths
-          # and triggering gates that shouldn't fire.
           elif ! files=$(git diff --name-only "$base"..."$head" 2>/dev/null); then
             echo "git diff failed (base may be unreachable after force-push) — running full matrix"
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
@@ -285,14 +140,6 @@ jobs:
           else
             echo "Changed files:"
             echo "$files"
-            # Prettier file list for the Prettier job. A change to Prettier's
-            # config or its version pin reformats the whole tree, so fall back
-            # to `__ALL__` (check everything) in that case — there is no other
-            # full-tree check to catch the resulting drift. Otherwise emit the
-            # changed files, excluding deletions (--diff-filter=ACMR keeps
-            # added/copied/modified/renamed) since Prettier can't format a path
-            # that no longer exists. If that diff somehow fails, fall back to
-            # `__ALL__` rather than silently skipping the check.
             if echo "$files" | grep -qE '^(\.prettierrc\.json|\.prettierignore|package\.json)$'; then
               echo "prettier_files=__ALL__" >> "$GITHUB_OUTPUT"
             elif pfiles=$(git diff --name-only --diff-filter=ACMR "$base"..."$head" 2>/dev/null); then
@@ -304,18 +151,6 @@ jobs:
             else
               echo "prettier_files=__ALL__" >> "$GITHUB_OUTPUT"
             fi
-            # docs_only: any line NOT under `docs/`, `examples/`, and not the
-            # top-level `README.md` flips the switch. README is markdown-only
-            # and only ever runs through prettier; `examples/` are standalone
-            # apps not built, type-checked, or tested by any CI job (the root
-            # `tsc --build` doesn't reference them and they have no `test`
-            # script) — so neither needs the full matrix.
-            #
-            # Exception: docs/ruby-ts-conventions.md is GENERATED from
-            # conventions.ts and guarded by `api:conventions --check` in the
-            # rails-comparison job. Treat a change to it as non-docs-only so a
-            # hand-edit (ignoring the file's do-not-edit banner) still runs the
-            # drift check instead of short-circuiting to a green docs-only run.
             if [ -z "$files" ]; then
               echo "docs_only=false" >> "$GITHUB_OUTPUT"
             elif echo "$files" | grep -qvE '^docs/|^examples/|^README\.md$|^CLAUDE\.md$'; then
@@ -325,9 +160,6 @@ jobs:
             else
               echo "docs_only=true" >> "$GITHUB_OUTPUT"
             fi
-            # On push to main / schedule / workflow_dispatch force every
-            # package gate true. Downstream jobs still honor docs_only, so a
-            # docs-only push to main still short-circuits the matrix.
             case "${{ github.event_name }}" in
               push|schedule|workflow_dispatch)
                 force_all_affected
@@ -347,13 +179,6 @@ jobs:
                   echo "website_affected=false"      >> "$GITHUB_OUTPUT"
                   echo "comparison_affected=false"   >> "$GITHUB_OUTPUT"
                 else
-                  # Drop the single-consumer scripts/ subtrees (see
-                  # INFRA_CARVEOUT_RE above) from the infra sweep so a change
-                  # confined to them doesn't trip INFRA_RE's blanket `scripts/`
-                  # and force every package gate true (the whole Rails matrix).
-                  # Per-package gates below still see the full $files list, so
-                  # each carved subtree still flips its own consuming job's gate
-                  # via that gate's regex.
                   infra_files=$(echo "$files" | grep -vE "$INFRA_CARVEOUT_RE" || true)
                   set_gate() {
                     local name="$1" re="$2" excl="${3:-}" gate_files="$files"
@@ -380,10 +205,6 @@ jobs:
                 ;;
             esac
           fi
-          # Website label opt-in. The Website job otherwise gates only on
-          # packages/website/ paths, so PRs that need a site preview (or
-          # release PRs that must build the production site) can apply the
-          # `website` or `release` label to force the job on.
           case "${{ github.event_name }}" in
             pull_request)
               if echo "$PR_LABELS" | jq -e 'any(.[]; .name == "website" or .name == "release")' >/dev/null; then
@@ -396,12 +217,6 @@ jobs:
               echo "website_label=false" >> "$GITHUB_OUTPUT"
               ;;
           esac
-          # Per-adapter parity gates. Each suite is expensive (~15-20 CI
-          # minutes across 7 jobs), so plain PRs skip all parity. Run on:
-          #   - push to main / schedule / workflow_dispatch → all adapters
-          #   - PRs carrying a per-adapter label → only that adapter
-          # `any(.[]; ...)` guards against the `.[].name == "..."` bug where
-          # jq -e bases exit status on the last element of a stream.
           case "${{ github.event_name }}" in
             schedule|workflow_dispatch)
               echo "parity_sqlite=true"   >> "$GITHUB_OUTPUT"

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -4566,20 +4566,6 @@ export class Base extends Model {
   generateTokenFor(purpose: string): string {
     return _generateTokenFor(this, purpose);
   }
-
-  /** @internal */
-  declare fullPurpose: () => string;
-  /** @internal */
-  declare messageVerifier: () => unknown;
-  /** @internal */
-  declare payloadFor: (model: Base) => unknown[];
-  /** @internal */
-  declare generateToken: (model: Base) => string;
-  /** @internal */
-  declare resolveToken: (
-    token: string,
-    finder: (id: unknown) => Promise<Base | null>,
-  ) => Promise<Base | null>;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -72,14 +72,15 @@ import {
   CreateIndexDefinition,
   IndexDefinition,
 } from "./abstract/schema-definitions.js";
-import type { ColumnOptions, RemoveForeignKeyOptions } from "./abstract/schema-definitions.js";
+import type {
+  AddIndexOptions,
+  ColumnOptions,
+  RemoveForeignKeyOptions,
+} from "./abstract/schema-definitions.js";
 import {
   TableDefinition as MysqlTableDefinition,
   Table as MysqlTable,
 } from "./mysql/schema-definitions.js";
-import type { AddIndexOptions } from "./abstract/schema-definitions.js";
-
-type CreateTableArgs = Parameters<MysqlSchemaStatements["createTable"]>;
 import {
   dataSourceSql as mysqlDataSourceSql,
   extractForeignKeyAction as mysqlExtractForeignKeyAction,
@@ -169,6 +170,8 @@ const ER_CLIENT_INTERACTION_TIMEOUT = 4031;
 
 // eslint-disable-next-line no-control-regex
 const QUOTE_STRING_RE = /['\\\x00\n\r\x1a]/g;
+type CreateTableArgs = Parameters<MysqlSchemaStatements["createTable"]>;
+
 const QUOTE_STRING_MAP: Record<string, string> = {
   "'": "\\'",
   "\\": "\\\\",

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -2077,13 +2077,13 @@ export class StatementPool extends ConnectionStatementPool<MysqlPreparedStatemen
   }
 }
 
+/* eslint-disable @typescript-eslint/no-unsafe-declaration-merging */
 /**
  * The `MySQL::SchemaStatements` surface `include()` installs below
  * (abstract_mysql_adapter.rb:19). Declaration-merged so callers see the mixin's
  * signatures instead of falling through to `AbstractAdapter`'s; kept in step
  * with the mixin by `scripts/mixin-declaration-drift.ts`. @internal
  */
-// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface AbstractMysqlAdapter {
   updateTableDefinition(tableName: string, base?: unknown): MysqlTable;
 
@@ -2115,6 +2115,7 @@ export interface AbstractMysqlAdapter {
   /** @internal */
   validPrimaryKeyOptions(): string[];
 }
+/* eslint-enable @typescript-eslint/no-unsafe-declaration-merging */
 
 // Rails: `include MySQL::SchemaStatements` (abstract_mysql_adapter.rb:19).
 include(AbstractMysqlAdapter, MysqlSchemaStatements);

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -73,7 +73,13 @@ import {
   IndexDefinition,
 } from "./abstract/schema-definitions.js";
 import type { ColumnOptions, RemoveForeignKeyOptions } from "./abstract/schema-definitions.js";
-import { TableDefinition as MysqlTableDefinition } from "./mysql/schema-definitions.js";
+import {
+  TableDefinition as MysqlTableDefinition,
+  Table as MysqlTable,
+} from "./mysql/schema-definitions.js";
+import type { AddIndexOptions } from "./abstract/schema-definitions.js";
+
+type CreateTableArgs = Parameters<MysqlSchemaStatements["createTable"]>;
 import {
   dataSourceSql as mysqlDataSourceSql,
   extractForeignKeyAction as mysqlExtractForeignKeyAction,
@@ -172,6 +178,7 @@ const QUOTE_STRING_MAP: Record<string, string> = {
   "\x1a": "\\Z",
 };
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class AbstractMysqlAdapter extends AbstractAdapter {
   /**
    * Return Column objects for a table. Mirrors Rails'
@@ -2065,6 +2072,45 @@ export class StatementPool extends ConnectionStatementPool<MysqlPreparedStatemen
   nextKey(): string {
     return `a${++this._counter}`;
   }
+}
+
+/**
+ * The `MySQL::SchemaStatements` surface `include()` installs below
+ * (abstract_mysql_adapter.rb:19). Declaration-merged so callers see the mixin's
+ * signatures instead of falling through to `AbstractAdapter`'s; kept in step
+ * with the mixin by `scripts/mixin-declaration-drift.ts`. @internal
+ */
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface AbstractMysqlAdapter {
+  updateTableDefinition(tableName: string, base?: unknown): MysqlTable;
+
+  addIndex(
+    tableName: string,
+    columnName: string | string[],
+    options?: AddIndexOptions,
+  ): Promise<void>;
+
+  createTable(
+    name: string,
+    optionsOrFn?: CreateTableArgs[1],
+    fn?: CreateTableArgs[2],
+  ): Promise<void>;
+
+  removeColumn(
+    tableName: string,
+    columnName: string,
+    type?: string,
+    options?: { ifExists?: boolean },
+  ): Promise<void>;
+
+  dropTable(
+    ...args:
+      | [string, ...string[]]
+      | [string, ...string[], { ifExists?: boolean; force?: "cascade"; temporary?: boolean }]
+  ): Promise<void>;
+
+  /** @internal */
+  validPrimaryKeyOptions(): string[];
 }
 
 // Rails: `include MySQL::SchemaStatements` (abstract_mysql_adapter.rb:19).

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -100,12 +100,16 @@ function toS(value: unknown): string {
  * PostgreSQL's `SchemaStatements` is only ever mixed into `PostgreSQLAdapter`
  * (`include()` at the bottom of the adapter module), so its bodies call plain
  * `this` methods the way Rails' module does. This merged interface gives those
- * calls the PG adapter's type. @internal
+ * calls the PG adapter's type.
+ *
+ * The `Omit`ted names already reach `this` from `AbstractSchemaStatements` with
+ * a signature TypeScript will not let a narrower PG one merge over — a method
+ * declared on a base class wins over a merged-interface property. The bodies use
+ * the abstract signature for them, which is why `resetPkSequenceBang` casts
+ * `getDatabaseVersion`'s `number | Version` (PG returns `server_version_num`)
+ * back to `number`. The three restated below are the reverse case: own members
+ * TypeScript does accept, narrowed from the generic adapter's. @internal
  */
-// drift-ok: the omitted names already come from `AbstractSchemaStatements` with
-// a signature TS will not let a narrower PG one merge over (a method declared on
-// a base class wins over a merged-interface property). The bodies below use the
-// abstract signature for them, so nothing is lost.
 export interface SchemaStatements extends Omit<
   PgSchemaAdapter,
   | "execute"
@@ -118,8 +122,6 @@ export interface SchemaStatements extends Omit<
   | "logger"
   | "nativeDatabaseTypes"
 > {
-  // Declared as own members rather than inherited: `AbstractSchemaStatements`
-  // types each of these for the generic adapter, and PG narrows them.
   readonly typeMap: HashLookupTypeMap;
   readonly logger: { warn?(message: string): void } | null;
   nativeDatabaseTypes(): Record<string, string | { name?: string; limit?: number }>;
@@ -1894,8 +1896,6 @@ export class SchemaStatements extends AbstractSchemaStatements {
     );
     let minvalue: unknown = null;
     if (maxPk == null) {
-      // PG's own `getDatabaseVersion` returns `server_version_num`; the abstract
-      // adapter types the return as `number | Version` for MySQL's sake.
       const dbVersion = (await this.getDatabaseVersion()) as number;
       minvalue =
         dbVersion >= 100000

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -71,7 +71,6 @@ interface PgSchemaAdapter {
     actionSql(action: string, dependency: string): string;
     accept(o: unknown): string;
   };
-  readonly typeMap: HashLookupTypeMap;
   readonly visitor: Visitors.ToSql;
   loadAdditionalTypes(oids?: number[]): Promise<void>;
   lookupCastTypeFromColumn(column: {
@@ -107,8 +106,9 @@ function toS(value: unknown): string {
  * declared on a base class wins over a merged-interface property. The bodies use
  * the abstract signature for them, which is why `resetPkSequenceBang` casts
  * `getDatabaseVersion`'s `number | Version` (PG returns `server_version_num`)
- * back to `number`. The three restated below are the reverse case: own members
- * TypeScript does accept, narrowed from the generic adapter's. @internal
+ * back to `number`, and `columns` casts the base's `unknown` `typeMap` accessor.
+ * The two restated below are the reverse case: own members TypeScript does
+ * accept, narrowed from the generic adapter's. @internal
  */
 export interface SchemaStatements extends Omit<
   PgSchemaAdapter,
@@ -122,7 +122,6 @@ export interface SchemaStatements extends Omit<
   | "logger"
   | "nativeDatabaseTypes"
 > {
-  readonly typeMap: HashLookupTypeMap;
   readonly logger: { warn?(message: string): void } | null;
   nativeDatabaseTypes(): Record<string, string | { name?: string; limit?: number }>;
 }
@@ -666,17 +665,18 @@ export class SchemaStatements extends AbstractSchemaStatements {
     // Mirrors Rails' load_additional_types batch call: gather all OIDs not
     // yet in the map and load them in a single pg_type query before building
     // Column objects. This avoids N concurrent queries for wide tables.
+    const typeMap = this.typeMap as HashLookupTypeMap;
     const missingOids = [
-      ...new Set(rows.map((r) => Number(r.oid)).filter((oid) => !this.typeMap.has(oid))),
+      ...new Set(rows.map((r) => Number(r.oid)).filter((oid) => !typeMap.has(oid))),
     ];
     if (missingOids.length > 0) {
       await this.loadAdditionalTypes(missingOids);
       // Mirrors Rails' get_oid_type fallback: register any OIDs still absent
       // after the pg_type query so repeated columns() calls don't re-query.
       for (const oid of missingOids) {
-        if (!this.typeMap.has(oid)) {
+        if (!typeMap.has(oid)) {
           console.warn(`unknown OID ${oid}: unrecognized column type, treating as generic value.`);
-          this.typeMap.registerType(oid, new ValueType());
+          typeMap.registerType(oid, new ValueType());
         }
       }
     }

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -95,10 +95,38 @@ function toS(value: unknown): string {
   return value == null ? "" : String(value);
 }
 
+/* eslint-disable @typescript-eslint/no-unsafe-declaration-merging */
+/**
+ * PostgreSQL's `SchemaStatements` is only ever mixed into `PostgreSQLAdapter`
+ * (`include()` at the bottom of the adapter module), so its bodies call plain
+ * `this` methods the way Rails' module does. This merged interface gives those
+ * calls the PG adapter's type. @internal
+ */
+// drift-ok: the omitted names already come from `AbstractSchemaStatements` with
+// a signature TS will not let a narrower PG one merge over (a method declared on
+// a base class wins over a merged-interface property). The bodies below use the
+// abstract signature for them, so nothing is lost.
+export interface SchemaStatements extends Omit<
+  PgSchemaAdapter,
+  | "execute"
+  | "internalExecute"
+  | "getDatabaseVersion"
+  | "lookupCastTypeFromColumn"
+  | "schemaCreation"
+  | "quotedScope"
+  | "typeMap"
+  | "logger"
+  | "nativeDatabaseTypes"
+> {
+  // Declared as own members rather than inherited: `AbstractSchemaStatements`
+  // types each of these for the generic adapter, and PG narrows them.
+  readonly typeMap: HashLookupTypeMap;
+  readonly logger: { warn?(message: string): void } | null;
+  nativeDatabaseTypes(): Record<string, string | { name?: string; limit?: number }>;
+}
+
 export class SchemaStatements extends AbstractSchemaStatements {
-  private get pg(): PgSchemaAdapter {
-    return this as unknown as PgSchemaAdapter;
-  }
+  /* eslint-enable @typescript-eslint/no-unsafe-declaration-merging */
 
   /** Mirrors: PostgreSQL::SchemaStatements#update_table_definition */
   override updateTableDefinition(tableName: string, base?: unknown): PgTable {
@@ -126,9 +154,9 @@ export class SchemaStatements extends AbstractSchemaStatements {
   // ---------------------------------------------------------------------------
 
   async indexes(tableName: string): Promise<IndexDefinition[]> {
-    const scope = this.pg.quotedScope(tableName);
+    const scope = this.quotedScope(tableName);
 
-    const result = await this.pg.query(
+    const result = await this.query(
       `SELECT distinct i.relname, d.indisunique, d.indkey, pg_get_indexdef(d.indexrelid), t.oid,
                       pg_catalog.obj_description(i.oid, 'pg_class') AS comment, d.indisvalid
        FROM pg_class t
@@ -215,9 +243,9 @@ export class SchemaStatements extends AbstractSchemaStatements {
   }
 
   async indexNameExists(tableName: string, indexName: string): Promise<boolean> {
-    const table = this.pg.quotedScope(tableName);
-    const index = this.pg.quotedScope(indexName);
-    const count = await this.pg.queryValue(
+    const table = this.quotedScope(tableName);
+    const index = this.quotedScope(indexName);
+    const count = await this.queryValue(
       `
       SELECT COUNT(*)
       FROM pg_class t
@@ -247,7 +275,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
   // Mirrors Rails #tables (data_source_sql type: "BASE TABLE" → relkind
   // IN ('r','p')). pg_tables would omit partitioned tables (relkind 'p').
   async tables(): Promise<string[]> {
-    const rows = await this.pg.schemaQuery(this.pg.dataSourceSql(null, { type: "BASE TABLE" }));
+    const rows = await this.schemaQuery(this.dataSourceSql(null, { type: "BASE TABLE" }));
     return rows.map((r) => r.relname as string);
   }
 
@@ -260,7 +288,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
    * directly catches both.
    */
   async views(): Promise<string[]> {
-    const rows = await this.pg.schemaQuery(
+    const rows = await this.schemaQuery(
       `SELECT c.relname FROM pg_class c
          LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
          WHERE n.nspname = ANY(current_schemas(false))
@@ -293,11 +321,11 @@ export class SchemaStatements extends AbstractSchemaStatements {
     // Rails' table_exists?(nil) / "" returns false; a null/empty name has no
     // identifier to parse, so short-circuit before extractSchemaQualifiedName.
     if (!name) return false;
-    const [schema, table] = this.pg.extractSchemaQualifiedName(name);
+    const [schema, table] = this.extractSchemaQualifiedName(name);
     if (schema) {
       // $1=schema, $2=table, $3..=relkinds
       const relPlaceholders = relkinds.map((_, i) => `$${i + 3}`).join(", ");
-      const rows = await this.pg.schemaQuery(
+      const rows = await this.schemaQuery(
         `SELECT 1 AS one FROM pg_class c
            LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
            WHERE n.nspname = $1 AND c.relname = $2
@@ -313,7 +341,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
     // compared against `relname = '"widgets"'` in pg_class, which
     // never matches (the catalog stores names unquoted).
     const relPlaceholders = relkinds.map((_, i) => `$${i + 2}`).join(", ");
-    const rows = await this.pg.schemaQuery(
+    const rows = await this.schemaQuery(
       `SELECT 1 AS one FROM pg_class c
          LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
          WHERE n.nspname = ANY(current_schemas(false))
@@ -325,9 +353,9 @@ export class SchemaStatements extends AbstractSchemaStatements {
   }
 
   override async tableComment(tableName: string): Promise<string | null> {
-    const scope = this.pg.quotedScope(tableName, { type: "BASE TABLE" });
+    const scope = this.quotedScope(tableName, { type: "BASE TABLE" });
     if (!scope.name) return null;
-    const comment = await this.pg.queryValue(
+    const comment = await this.queryValue(
       `
       SELECT pg_catalog.obj_description(c.oid, 'pg_class')
       FROM pg_catalog.pg_class c
@@ -342,8 +370,8 @@ export class SchemaStatements extends AbstractSchemaStatements {
   }
 
   async tablePartitionDefinition(tableName: string): Promise<string | null> {
-    const scope = this.pg.quotedScope(tableName, { type: "BASE TABLE" });
-    const def = await this.pg.queryValue(
+    const scope = this.quotedScope(tableName, { type: "BASE TABLE" });
+    const def = await this.queryValue(
       `SELECT pg_catalog.pg_get_partkeydef(c.oid)
        FROM pg_catalog.pg_class c
        LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
@@ -356,8 +384,8 @@ export class SchemaStatements extends AbstractSchemaStatements {
   }
 
   async inheritedTableNames(tableName: string): Promise<string[]> {
-    const scope = this.pg.quotedScope(tableName, { type: "BASE TABLE" });
-    const names = await this.pg.queryValues(
+    const scope = this.quotedScope(tableName, { type: "BASE TABLE" });
+    const names = await this.queryValues(
       `SELECT parent.relname
        FROM pg_catalog.pg_inherits i
        JOIN pg_catalog.pg_class child ON i.inhrelid = child.oid
@@ -373,7 +401,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
 
   override async tableOptions(tableName: string): Promise<Record<string, unknown>> {
     // supportsNativePartitioning() reads databaseVersion; ensure it's populated.
-    await this.pg.getDatabaseVersion();
+    await this.getDatabaseVersion();
     const options: Record<string, unknown> = {};
     const comment = await this.tableComment(tableName);
     if (comment !== null) options.comment = comment;
@@ -381,7 +409,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
     if (inherited.length > 0) {
       options.options = `INHERITS (${inherited.join(", ")})`;
     }
-    if (!options.options && this.pg.supportsNativePartitioning()) {
+    if (!options.options && this.supportsNativePartitioning()) {
       const partDef = await this.tablePartitionDefinition(tableName);
       if (partDef) options.options = `PARTITION BY ${partDef}`;
     }
@@ -402,13 +430,13 @@ export class SchemaStatements extends AbstractSchemaStatements {
       attgenerated: string | null;
     }[]
   > {
-    const identityCol = this.pg.supportsIdentityColumns()
+    const identityCol = this.supportsIdentityColumns()
       ? "attidentity"
-      : `${this.pg.quote("")}::varchar`;
-    const generatedCol = this.pg.supportsVirtualColumns()
+      : `${this.quote("")}::varchar`;
+    const generatedCol = this.supportsVirtualColumns()
       ? "attgenerated"
-      : `${this.pg.quote("")}::varchar`;
-    const rows = await this.pg.schemaQuery(
+      : `${this.quote("")}::varchar`;
+    const rows = await this.schemaQuery(
       `SELECT a.attname, format_type(a.atttypid, a.atttypmod),
               pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid, a.atttypmod,
               c.collname, col_description(a.attrelid, a.attnum) AS comment,
@@ -418,7 +446,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
          LEFT JOIN pg_attrdef d ON a.attrelid = d.adrelid AND a.attnum = d.adnum
          LEFT JOIN pg_type t ON a.atttypid = t.oid
          LEFT JOIN pg_collation c ON a.attcollation = c.oid AND a.attcollation <> t.typcollation
-        WHERE a.attrelid = ${this.pg.quote(this.pg.quoteTableName(tableName))}::regclass
+        WHERE a.attrelid = ${this.quote(this.quoteTableName(tableName))}::regclass
           AND a.attnum > 0 AND NOT a.attisdropped
         ORDER BY a.attnum`,
     );
@@ -441,7 +469,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
   // ---------------------------------------------------------------------------
 
   async schemaNames(): Promise<string[]> {
-    const names = await this.pg.queryValues(
+    const names = await this.queryValues(
       `SELECT nspname
          FROM pg_namespace
         WHERE nspname !~ '^pg_.*'
@@ -474,15 +502,15 @@ export class SchemaStatements extends AbstractSchemaStatements {
   }
 
   async schemaExists(name: string): Promise<boolean> {
-    const count = await this.pg.queryValue(
-      `SELECT COUNT(*) FROM pg_namespace WHERE nspname = ${this.pg.quote(name)}`,
+    const count = await this.queryValue(
+      `SELECT COUNT(*) FROM pg_namespace WHERE nspname = ${this.quote(name)}`,
       "SCHEMA",
     );
     return Number(count) > 0;
   }
 
   async currentSchema(): Promise<string> {
-    return (await this.pg.queryValue("SELECT current_schema", "SCHEMA")) as string;
+    return (await this.queryValue("SELECT current_schema", "SCHEMA")) as string;
   }
 
   // ---------------------------------------------------------------------------
@@ -521,11 +549,11 @@ export class SchemaStatements extends AbstractSchemaStatements {
       }
     }
 
-    await this.execute(`CREATE DATABASE ${this.pg.quoteTableName(name)}${optionString}`);
+    await this.execute(`CREATE DATABASE ${this.quoteTableName(name)}${optionString}`);
   }
 
   async dropDatabase(name: string): Promise<void> {
-    await this.execute(`DROP DATABASE IF EXISTS ${this.pg.quoteTableName(name)}`);
+    await this.execute(`DROP DATABASE IF EXISTS ${this.quoteTableName(name)}`);
   }
 
   async recreateDatabase(name: string, options: CreateDatabaseOptions = {}): Promise<void> {
@@ -534,25 +562,25 @@ export class SchemaStatements extends AbstractSchemaStatements {
   }
 
   async currentDatabase(): Promise<string> {
-    return (await this.pg.queryValue("SELECT current_database()", "SCHEMA")) as string;
+    return (await this.queryValue("SELECT current_database()", "SCHEMA")) as string;
   }
 
   async encoding(): Promise<string> {
-    return (await this.pg.queryValue(
+    return (await this.queryValue(
       "SELECT pg_encoding_to_char(encoding) FROM pg_database WHERE datname = current_database()",
       "SCHEMA",
     )) as string;
   }
 
   async collation(): Promise<string> {
-    return (await this.pg.queryValue(
+    return (await this.queryValue(
       "SELECT datcollate FROM pg_database WHERE datname = current_database()",
       "SCHEMA",
     )) as string;
   }
 
   async ctype(): Promise<string> {
-    return (await this.pg.queryValue(
+    return (await this.queryValue(
       "SELECT datctype FROM pg_database WHERE datname = current_database()",
       "SCHEMA",
     )) as string;
@@ -563,27 +591,24 @@ export class SchemaStatements extends AbstractSchemaStatements {
   // ---------------------------------------------------------------------------
 
   async schemaSearchPath(): Promise<string> {
-    if (this.pg._schemaSearchPathMemo == null) {
-      this.pg._schemaSearchPathMemo = (await this.pg.queryValue(
-        "SHOW search_path",
-        "SCHEMA",
-      )) as string;
+    if (this._schemaSearchPathMemo == null) {
+      this._schemaSearchPathMemo = (await this.queryValue("SHOW search_path", "SCHEMA")) as string;
     }
-    return this.pg._schemaSearchPathMemo;
+    return this._schemaSearchPathMemo;
   }
 
   async setSchemaSearchPath(searchPath: string | null): Promise<void> {
     if (!searchPath) return;
-    await this.pg.internalExecute(`SET search_path TO ${searchPath}`);
-    this.pg._schemaSearchPathMemo = searchPath;
+    await this.internalExecute(`SET search_path TO ${searchPath}`);
+    this._schemaSearchPathMemo = searchPath;
   }
 
   async clientMinMessages(): Promise<string> {
-    return (await this.pg.queryValue("SHOW client_min_messages", "SCHEMA")) as string;
+    return (await this.queryValue("SHOW client_min_messages", "SCHEMA")) as string;
   }
 
   async setClientMinMessages(level: string): Promise<void> {
-    await this.pg.internalExecute(`SET client_min_messages TO '${level}'`, "SCHEMA");
+    await this.internalExecute(`SET client_min_messages TO '${level}'`, "SCHEMA");
   }
 
   private quoteSchemaName(name: string): string {
@@ -595,7 +620,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
   // ---------------------------------------------------------------------------
 
   override async columns(tableName: string): Promise<Column[]> {
-    const [schema, table] = this.pg.extractSchemaQualifiedName(tableName);
+    const [schema, table] = this.extractSchemaQualifiedName(tableName);
 
     let tableCondition: string;
     const binds: unknown[] = [];
@@ -608,7 +633,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
       tableCondition = `t.oid = to_regclass($1)`;
     }
 
-    const rows = await this.pg.schemaQuery(
+    const rows = await this.schemaQuery(
       `SELECT a.attname AS name,
               pg_catalog.format_type(a.atttypid, a.atttypmod) AS type,
               pg_get_expr(d.adbin, d.adrelid) AS "default",
@@ -640,16 +665,16 @@ export class SchemaStatements extends AbstractSchemaStatements {
     // yet in the map and load them in a single pg_type query before building
     // Column objects. This avoids N concurrent queries for wide tables.
     const missingOids = [
-      ...new Set(rows.map((r) => Number(r.oid)).filter((oid) => !this.pg.typeMap.has(oid))),
+      ...new Set(rows.map((r) => Number(r.oid)).filter((oid) => !this.typeMap.has(oid))),
     ];
     if (missingOids.length > 0) {
-      await this.pg.loadAdditionalTypes(missingOids);
+      await this.loadAdditionalTypes(missingOids);
       // Mirrors Rails' get_oid_type fallback: register any OIDs still absent
       // after the pg_type query so repeated columns() calls don't re-query.
       for (const oid of missingOids) {
-        if (!this.pg.typeMap.has(oid)) {
+        if (!this.typeMap.has(oid)) {
           console.warn(`unknown OID ${oid}: unrecognized column type, treating as generic value.`);
-          this.pg.typeMap.registerType(oid, new ValueType());
+          this.typeMap.registerType(oid, new ValueType());
         }
       }
     }
@@ -675,7 +700,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
         r.identity,
         r.attgenerated,
       ];
-      columns.push(await this.pg.newColumnFromField(tableName, field, rows));
+      columns.push(await this.newColumnFromField(tableName, field, rows));
     }
     return columns;
   }
@@ -688,7 +713,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
         throw new TypeError("columnNumbers must contain only safe integers");
       return n;
     });
-    const rows = await this.pg.query(
+    const rows = await this.query(
       `SELECT a.attnum, a.attname
        FROM pg_attribute a
        WHERE a.attrelid = ${tableOid}
@@ -704,7 +729,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
     orders?: (string | Nodes.Node)[],
   ): string {
     const base = Array.isArray(columns) ? columns.join(", ") : columns;
-    const visitor = this.pg.visitor;
+    const visitor = this.visitor;
     // Mirrors Rails two-pass compact_blank: filter blanks before AND after stripping
     // so an order that becomes empty after stripping (e.g. bare "DESC") doesn't
     // consume an alias index slot and shift subsequent aliases.
@@ -768,7 +793,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
         break;
       default: {
         const { precision, scale } = options;
-        const native = this.pg.nativeDatabaseTypes()[type];
+        const native = this.nativeDatabaseTypes()[type];
         const baseName = native
           ? typeof native === "string"
             ? native
@@ -813,11 +838,11 @@ export class SchemaStatements extends AbstractSchemaStatements {
     name: string,
     options: Record<string, unknown> = {},
   ): AbstractTableDefinition {
-    return this.pg.createTableDefinition(name, options);
+    return this.createTableDefinition(name, options);
   }
 
   override createAlterTable(name: string): AlterTable {
-    return this.pg.createAlterTable(name);
+    return this.createAlterTable(name);
   }
 
   override async changeColumn(
@@ -832,9 +857,9 @@ export class SchemaStatements extends AbstractSchemaStatements {
     // running the procs. The visitor (visit_ChangeColumnDefinition) emits the
     // combined "ALTER COLUMN ... TYPE ..., ALTER COLUMN ... SET DEFAULT ..."
     // string; the only proc Rails appends here is the :comment change.
-    this.pg.clearCacheBang();
+    this.clearCacheBang();
     const changeColDef = this.buildChangeColumnDefinition(tableName, columnName, type, options);
-    const clause = await this.pg.schemaCreation.accept(changeColDef);
+    const clause = await this.schemaCreation.accept(changeColDef);
     // Route DDL through the public `execute` (not the raw `exec`) so the
     // dirties_query_cache wrapper clears the query cache on schema changes.
     await this.execute(`ALTER TABLE ${this.quoteTableName(tableName)} ${clause}`);
@@ -859,7 +884,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
     // cache, defer to the abstract implementation (which builds an AlterTable
     // and accepts it through schema_creation), then propagate :comment via
     // change_column_comment.
-    this.pg.clearCacheBang();
+    this.clearCacheBang();
     await super.addColumn(tableName, columnName, type, options);
     if ("comment" in options) {
       await this.changeColumnComment(tableName, columnName, options.comment ?? null);
@@ -873,7 +898,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
   ): Promise<void> {
     // Mirrors PostgreSQL::SchemaStatements#rename_column: clear the statement
     // cache, rename, then fix up index names that embed the column name.
-    this.pg.clearCacheBang();
+    this.clearCacheBang();
     await this.schemaCache.clearDataSourceCacheBang(tableName);
     await this.execute(
       `ALTER TABLE ${this.quoteTableName(tableName)} RENAME COLUMN ${this.quoteColumnName(columnName)} TO ${this.quoteColumnName(newColumnName)}`,
@@ -884,7 +909,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
   override async renameIndex(tableName: string, oldName: string, newName: string): Promise<void> {
     this.validateIndexLengthBang(tableName, newName);
 
-    const [schema] = this.pg.extractSchemaQualifiedName(tableName);
+    const [schema] = this.extractSchemaQualifiedName(tableName);
     await this.schemaCache.clearDataSourceCacheBang(tableName);
     await this.execute(
       `ALTER INDEX ${schema ? `${this.quoteTableName(schema)}.` : ""}${this.quoteColumnName(oldName)} RENAME TO ${this.quoteTableName(newName)}`,
@@ -951,7 +976,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
     // Mirrors PostgreSQL::SchemaStatements#change_column_null: validate the
     // boolean argument and clear the statement cache before issuing DDL.
     this.validateChangeColumnNullArgumentBang(nullable);
-    this.pg.clearCacheBang();
+    this.clearCacheBang();
     const quotedTable = this.quoteTableName(tableName);
     const quotedCol = this.quoteColumnName(columnName);
     if (!nullable && defaultValue != null) {
@@ -978,10 +1003,10 @@ export class SchemaStatements extends AbstractSchemaStatements {
     // Mirrors PostgreSQL::SchemaStatements#change_column_comment: clear the
     // statement cache and unwrap the {from:, to:} change hash before issuing
     // the COMMENT ON statement.
-    this.pg.clearCacheBang();
+    this.clearCacheBang();
     const comment = this.extractNewCommentValue(commentOrChanges) as string | null;
     await this.execute(
-      `COMMENT ON COLUMN ${this.quoteTableName(tableName)}.${this.quoteColumnName(columnName)} IS ${this.pg.quote(comment)}`,
+      `COMMENT ON COLUMN ${this.quoteTableName(tableName)}.${this.quoteColumnName(columnName)} IS ${this.quote(comment)}`,
     );
   }
 
@@ -990,10 +1015,10 @@ export class SchemaStatements extends AbstractSchemaStatements {
     commentOrChanges: string | null | { from?: string | null; to?: string | null },
   ): Promise<void> {
     // Mirrors PostgreSQL::SchemaStatements#change_table_comment.
-    this.pg.clearCacheBang();
+    this.clearCacheBang();
     const comment = this.extractNewCommentValue(commentOrChanges) as string | null;
     await this.execute(
-      `COMMENT ON TABLE ${this.quoteTableName(tableName)} IS ${this.pg.quote(comment)}`,
+      `COMMENT ON TABLE ${this.quoteTableName(tableName)} IS ${this.quote(comment)}`,
     );
   }
 
@@ -1003,9 +1028,9 @@ export class SchemaStatements extends AbstractSchemaStatements {
 
   /** @internal */
   async validateConstraint(tableName: string, constraintName: string): Promise<void> {
-    const at = this.pg.createAlterTable(tableName) as PgAlterTable;
+    const at = this.createAlterTable(tableName) as PgAlterTable;
     at.validateConstraint(constraintName);
-    await this.execute(await this.pg.schemaCreation.accept(at));
+    await this.execute(await this.schemaCreation.accept(at));
   }
 
   async validateCheckConstraint(
@@ -1028,7 +1053,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
   }
 
   override foreignKeyColumnFor(tableName: string, columnName = "id"): string {
-    const [, table] = this.pg.extractSchemaQualifiedName(tableName);
+    const [, table] = this.extractSchemaQualifiedName(tableName);
     return `${singularize(table)}_${columnName}`;
   }
 
@@ -1071,8 +1096,8 @@ export class SchemaStatements extends AbstractSchemaStatements {
   }
 
   override async foreignKeys(tableName: string): Promise<ForeignKeyDefinition[]> {
-    const scope = this.pg.quotedScope(tableName);
-    const fkInfo = await this.pg.internalExecQuery(
+    const scope = this.quotedScope(tableName);
+    const fkInfo = await this.internalExecQuery(
       `
       SELECT t2.oid::regclass::text AS to_table, a1.attname AS column, a2.attname AS primary_key,
              c.conname AS name, c.confupdtype AS on_update, c.confdeltype AS on_delete,
@@ -1085,7 +1110,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
       JOIN pg_attribute a2 ON a2.attnum = c.confkey[1] AND a2.attrelid = t2.oid
       JOIN pg_namespace t3 ON c.connamespace = t3.oid
       WHERE c.contype = 'f'
-        AND t1.relname = ${scope.name!}
+        AND t1.relname = ${scope.name}
         AND t3.nspname = ${scope.schema}
       ORDER BY c.conname
     `,
@@ -1159,23 +1184,23 @@ export class SchemaStatements extends AbstractSchemaStatements {
       toTable,
       options as Record<string, unknown>,
     );
-    const at = this.pg.createAlterTable(fromTable);
+    const at = this.createAlterTable(fromTable);
     // Route through AlterTable#addForeignKey -> TableDefinition#newForeignKeyDefinition
     // (now converged): it applies table_name_prefix/suffix and re-runs
     // foreign_key_options idempotently (column/name already filled above).
     at.addForeignKey(toTable, fkOptions as Partial<AddForeignKeyOptions>);
-    await this.execute(await this.pg.schemaCreation.accept(at));
+    await this.execute(await this.schemaCreation.accept(at));
   }
 
   override async checkConstraints(tableName: string): Promise<CheckConstraintDefinition[]> {
-    const scope = this.pg.quotedScope(tableName);
-    const checkInfo = await this.pg.internalExecQuery(
+    const scope = this.quotedScope(tableName);
+    const checkInfo = await this.internalExecQuery(
       `SELECT conname, pg_get_constraintdef(c.oid, true) AS constraintdef, c.convalidated AS valid
        FROM pg_constraint c
        JOIN pg_class t ON c.conrelid = t.oid
        JOIN pg_namespace n ON n.oid = c.connamespace
        WHERE c.contype = 'c'
-         AND t.relname = ${scope.name!}
+         AND t.relname = ${scope.name}
          AND n.nspname = ${scope.schema}`,
       "SCHEMA",
       [],
@@ -1211,9 +1236,9 @@ export class SchemaStatements extends AbstractSchemaStatements {
     options: ExclusionConstraintOptions = {},
   ): Promise<void> {
     const opts = this.exclusionConstraintOptions(tableName, expression, options);
-    const at = this.pg.createAlterTable(tableName) as PgAlterTable;
+    const at = this.createAlterTable(tableName) as PgAlterTable;
     at.addExclusionConstraint(expression, opts);
-    await this.execute(await this.pg.schemaCreation.accept(at));
+    await this.execute(await this.schemaCreation.accept(at));
   }
 
   async removeExclusionConstraint(
@@ -1236,8 +1261,8 @@ export class SchemaStatements extends AbstractSchemaStatements {
   }
 
   async exclusionConstraints(tableName: string): Promise<ExclusionConstraintDefinition[]> {
-    const scope = this.pg.quotedScope(tableName);
-    const exclusionInfo = await this.pg.internalExecQuery(
+    const scope = this.quotedScope(tableName);
+    const exclusionInfo = await this.internalExecQuery(
       `
       SELECT conname, pg_get_constraintdef(c.oid) AS constraintdef, c.condeferrable, c.condeferred
       FROM pg_constraint c
@@ -1295,8 +1320,8 @@ export class SchemaStatements extends AbstractSchemaStatements {
     options: Record<string, unknown> = {},
   ): Promise<ExclusionConstraintDefinition | undefined> {
     const name = this.exclusionConstraintName(tableName, options);
-    const scope = this.pg.quotedScope(tableName);
-    const rows = await this.pg.schemaQuery(
+    const scope = this.quotedScope(tableName);
+    const rows = await this.schemaQuery(
       `SELECT conname, pg_get_constraintdef(c.oid) AS constraintdef FROM pg_constraint c
        JOIN pg_class t ON c.conrelid = t.oid JOIN pg_namespace n ON n.oid = c.connamespace
        WHERE c.contype = 'x' AND c.conname = $1 AND t.relname = ${scope.name} AND n.nspname = ${scope.schema}`,
@@ -1349,9 +1374,9 @@ export class SchemaStatements extends AbstractSchemaStatements {
     options: UniqueConstraintOptions = {},
   ): Promise<void> {
     const opts = this.uniqueConstraintOptions(tableName, columnName, options);
-    const at = this.pg.createAlterTable(tableName) as PgAlterTable;
+    const at = this.createAlterTable(tableName) as PgAlterTable;
     at.addUniqueConstraint(columnName as string | string[], opts);
-    await this.execute(await this.pg.schemaCreation.accept(at));
+    await this.execute(await this.schemaCreation.accept(at));
   }
 
   async removeUniqueConstraint(
@@ -1378,8 +1403,8 @@ export class SchemaStatements extends AbstractSchemaStatements {
   }
 
   async uniqueConstraints(tableName: string): Promise<UniqueConstraintDefinition[]> {
-    const scope = this.pg.quotedScope(tableName);
-    const uniqueInfo = await this.pg.internalExecQuery(
+    const scope = this.quotedScope(tableName);
+    const uniqueInfo = await this.internalExecQuery(
       `
       SELECT c.conname, c.conrelid, c.conkey, c.condeferrable, c.condeferred,
              pg_get_constraintdef(c.oid) AS constraintdef
@@ -1484,7 +1509,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
       GROUP BY type.OID, n.nspname, type.typname
     `;
     const currentSchema = await this.currentSchema();
-    const rows = (await this.pg.schemaQuery(query)) as Array<{
+    const rows = (await this.schemaQuery(query)) as Array<{
       name: string;
       schema: string;
       value: string[];
@@ -1502,23 +1527,23 @@ export class SchemaStatements extends AbstractSchemaStatements {
     values: string[],
     _options?: Record<string, unknown>,
   ): Promise<void> {
-    const [schema, enumName] = this.pg.extractSchemaQualifiedName(name);
+    const [schema, enumName] = this.extractSchemaQualifiedName(name);
     const qualifiedName = schema
-      ? `${this.pg.quoteColumnName(schema)}.${this.pg.quoteColumnName(enumName)}`
-      : this.pg.quoteColumnName(enumName);
-    const valueList = values.map((v) => this.pg.quoteLiteral(v)).join(", ");
+      ? `${this.quoteColumnName(schema)}.${this.quoteColumnName(enumName)}`
+      : this.quoteColumnName(enumName);
+    const valueList = values.map((v) => this.quoteLiteral(v)).join(", ");
     // Mirrors Rails create_enum: guard with IF NOT EXISTS so re-running a
     // Schema.define under a different search_path is idempotent. The schema
     // scope defaults to the search path (current_schemas) when unqualified.
-    const schemaScope = schema ? this.pg.quoteLiteral(schema) : "ANY (current_schemas(false))";
-    await this.pg.exec(`
+    const schemaScope = schema ? this.quoteLiteral(schema) : "ANY (current_schemas(false))";
+    await this.exec(`
       DO $$
       BEGIN
           IF NOT EXISTS (
             SELECT 1
             FROM pg_type t
             JOIN pg_namespace n ON t.typnamespace = n.oid
-            WHERE t.typname = ${this.pg.quoteLiteral(enumName)}
+            WHERE t.typname = ${this.quoteLiteral(enumName)}
               AND n.nspname = ${schemaScope}
           ) THEN
               CREATE TYPE ${qualifiedName} AS ENUM (${valueList});
@@ -1526,39 +1551,39 @@ export class SchemaStatements extends AbstractSchemaStatements {
       END
       $$;
     `);
-    await this.pg.reloadTypeMap();
+    await this.reloadTypeMap();
   }
 
   async dropEnum(name: string, options: { ifExists?: boolean } = {}): Promise<void> {
-    const [schema, enumName] = this.pg.extractSchemaQualifiedName(name);
+    const [schema, enumName] = this.extractSchemaQualifiedName(name);
     const qualifiedName = schema
-      ? `${this.pg.quoteColumnName(schema)}.${this.pg.quoteColumnName(enumName)}`
-      : this.pg.quoteColumnName(enumName);
+      ? `${this.quoteColumnName(schema)}.${this.quoteColumnName(enumName)}`
+      : this.quoteColumnName(enumName);
     const ifExists = options.ifExists ? " IF EXISTS" : "";
-    await this.pg.exec(`DROP TYPE${ifExists} ${qualifiedName}`);
+    await this.exec(`DROP TYPE${ifExists} ${qualifiedName}`);
     // Mirrors Rails drop_enum: `internal_exec_query(query).tap { reload_type_map }`
     // (postgresql_adapter.rb:571-576). reloadTypeMap also drops the
     // prepared-statement name map so a cached plan referencing the dropped
     // type's OID is never re-executed ("cache lookup failed for type <oid>").
-    await this.pg.reloadTypeMap();
+    await this.reloadTypeMap();
   }
 
   async renameEnum(name: string, newNameOrOptions: string | { to: string }): Promise<void> {
     const newName = typeof newNameOrOptions === "string" ? newNameOrOptions : newNameOrOptions.to;
-    const [newSchema] = this.pg.extractSchemaQualifiedName(newName);
+    const [newSchema] = this.extractSchemaQualifiedName(newName);
     if (newSchema) {
       throw new Error(
         "PostgreSQLAdapter#renameEnum does not support changing enum schema; pass an unqualified type name.",
       );
     }
-    const [schema, enumName] = this.pg.extractSchemaQualifiedName(name);
+    const [schema, enumName] = this.extractSchemaQualifiedName(name);
     const qualifiedName = schema
-      ? `${this.pg.quoteColumnName(schema)}.${this.pg.quoteColumnName(enumName)}`
-      : this.pg.quoteColumnName(enumName);
-    await this.pg.exec(`ALTER TYPE ${qualifiedName} RENAME TO ${this.pg.quoteColumnName(newName)}`);
+      ? `${this.quoteColumnName(schema)}.${this.quoteColumnName(enumName)}`
+      : this.quoteColumnName(enumName);
+    await this.exec(`ALTER TYPE ${qualifiedName} RENAME TO ${this.quoteColumnName(newName)}`);
     // Mirrors Rails rename_enum: `exec_query(...).tap { reload_type_map }`
     // (postgresql_adapter.rb:584).
-    await this.pg.reloadTypeMap();
+    await this.reloadTypeMap();
   }
 
   async addEnumValue(
@@ -1566,39 +1591,39 @@ export class SchemaStatements extends AbstractSchemaStatements {
     value: string,
     options: { before?: string; after?: string; ifNotExists?: boolean } = {},
   ): Promise<void> {
-    const [schema, enumName] = this.pg.extractSchemaQualifiedName(name);
+    const [schema, enumName] = this.extractSchemaQualifiedName(name);
     const qualifiedName = schema
-      ? `${this.pg.quoteColumnName(schema)}.${this.pg.quoteColumnName(enumName)}`
-      : this.pg.quoteColumnName(enumName);
+      ? `${this.quoteColumnName(schema)}.${this.quoteColumnName(enumName)}`
+      : this.quoteColumnName(enumName);
     const ifNotExists = options.ifNotExists ? " IF NOT EXISTS" : "";
     if (options.before && options.after) {
       throw new Error("Cannot specify both `before` and `after` for addEnumValue");
     }
     let position = "";
     if (options.before) {
-      position = ` BEFORE ${this.pg.quoteLiteral(options.before)}`;
+      position = ` BEFORE ${this.quoteLiteral(options.before)}`;
     } else if (options.after) {
-      position = ` AFTER ${this.pg.quoteLiteral(options.after)}`;
+      position = ` AFTER ${this.quoteLiteral(options.after)}`;
     }
-    await this.pg.exec(
-      `ALTER TYPE ${qualifiedName} ADD VALUE${ifNotExists} ${this.pg.quoteLiteral(value)}${position}`,
+    await this.exec(
+      `ALTER TYPE ${qualifiedName} ADD VALUE${ifNotExists} ${this.quoteLiteral(value)}${position}`,
     );
     // Mirrors Rails add_enum_value: `exec_query(...).tap { reload_type_map }`
     // (postgresql_adapter.rb:602).
-    await this.pg.reloadTypeMap();
+    await this.reloadTypeMap();
   }
 
   async renameEnumValue(name: string, options: { from: string; to: string }): Promise<void> {
-    const [schema, enumName] = this.pg.extractSchemaQualifiedName(name);
+    const [schema, enumName] = this.extractSchemaQualifiedName(name);
     const qualifiedName = schema
-      ? `${this.pg.quoteColumnName(schema)}.${this.pg.quoteColumnName(enumName)}`
-      : this.pg.quoteColumnName(enumName);
-    await this.pg.exec(
-      `ALTER TYPE ${qualifiedName} RENAME VALUE ${this.pg.quoteLiteral(options.from)} TO ${this.pg.quoteLiteral(options.to)}`,
+      ? `${this.quoteColumnName(schema)}.${this.quoteColumnName(enumName)}`
+      : this.quoteColumnName(enumName);
+    await this.exec(
+      `ALTER TYPE ${qualifiedName} RENAME VALUE ${this.quoteLiteral(options.from)} TO ${this.quoteLiteral(options.to)}`,
     );
     // Mirrors Rails rename_enum_value: `exec_query(...).tap { reload_type_map }`
     // (postgresql_adapter.rb:614-616).
-    await this.pg.reloadTypeMap();
+    await this.reloadTypeMap();
   }
 
   // ---------------------------------------------------------------------------
@@ -1609,10 +1634,10 @@ export class SchemaStatements extends AbstractSchemaStatements {
     name: string,
     options: { subtype: string; subtypeDiff?: string },
   ): Promise<void> {
-    const [schema, rangeName] = this.pg.extractSchemaQualifiedName(name);
+    const [schema, rangeName] = this.extractSchemaQualifiedName(name);
     const qualifiedName = schema
-      ? `${this.pg.quoteColumnName(schema)}.${this.pg.quoteColumnName(rangeName)}`
-      : this.pg.quoteColumnName(rangeName);
+      ? `${this.quoteColumnName(schema)}.${this.quoteColumnName(rangeName)}`
+      : this.quoteColumnName(rangeName);
     const quoteQualifiedIdentifier = (identifier: string, param: string) => {
       if (/[\s()]/.test(identifier)) {
         throw new Error(
@@ -1626,16 +1651,14 @@ export class SchemaStatements extends AbstractSchemaStatements {
           `PostgreSQLAdapter#createRange: ${param} must have 1 or 2 dot-separated parts, got ${parts.length}: "${identifier}".`,
         );
       }
-      const [s, t] = this.pg.extractSchemaQualifiedName(identifier);
-      return s
-        ? `${this.pg.quoteColumnName(s)}.${this.pg.quoteColumnName(t)}`
-        : this.pg.quoteColumnName(t);
+      const [s, t] = this.extractSchemaQualifiedName(identifier);
+      return s ? `${this.quoteColumnName(s)}.${this.quoteColumnName(t)}` : this.quoteColumnName(t);
     };
     const parts = [`SUBTYPE = ${quoteQualifiedIdentifier(options.subtype, "subtype")}`];
     if (options.subtypeDiff) {
       parts.push(`SUBTYPE_DIFF = ${quoteQualifiedIdentifier(options.subtypeDiff, "subtypeDiff")}`);
     }
-    await this.pg.exec(`CREATE TYPE ${qualifiedName} AS RANGE (${parts.join(", ")})`);
+    await this.exec(`CREATE TYPE ${qualifiedName} AS RANGE (${parts.join(", ")})`);
     // createRange/dropRange are deliberate, permanent trails surface, not
     // unfinished porting: Rails supports PG range *column* types first-class but
     // ships no range-type DDL helper because Ruby has a core `Range` to lean on,
@@ -1651,18 +1674,18 @@ export class SchemaStatements extends AbstractSchemaStatements {
     // built against a prior incarnation of the type (drop + recreate reassigns
     // the OID) is re-prepared instead of raising
     // "cache lookup failed for type <oid>".
-    await this.pg.reloadTypeMap();
+    await this.reloadTypeMap();
   }
 
   async dropRange(name: string, options: { ifExists?: boolean } = {}): Promise<void> {
-    const [schema, rangeName] = this.pg.extractSchemaQualifiedName(name);
+    const [schema, rangeName] = this.extractSchemaQualifiedName(name);
     const qualifiedName = schema
-      ? `${this.pg.quoteColumnName(schema)}.${this.pg.quoteColumnName(rangeName)}`
-      : this.pg.quoteColumnName(rangeName);
+      ? `${this.quoteColumnName(schema)}.${this.quoteColumnName(rangeName)}`
+      : this.quoteColumnName(rangeName);
     const ifExists = options.ifExists ? " IF EXISTS" : "";
-    await this.pg.exec(`DROP TYPE${ifExists} ${qualifiedName}`);
+    await this.exec(`DROP TYPE${ifExists} ${qualifiedName}`);
     // See createRange: mirror Rails' type-DDL `reload_type_map` pattern.
-    await this.pg.reloadTypeMap();
+    await this.reloadTypeMap();
   }
 
   // ---------------------------------------------------------------------------
@@ -1670,7 +1693,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
   // ---------------------------------------------------------------------------
 
   override async primaryKey(tableName: string): Promise<string | string[] | null> {
-    const [schema, table] = this.pg.extractSchemaQualifiedName(tableName);
+    const [schema, table] = this.extractSchemaQualifiedName(tableName);
 
     let tableCondition: string;
     const binds: unknown[] = [];
@@ -1691,7 +1714,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
     // non-deterministic order pg_attribute happens to yield rows.
     // `array_position(i.indkey, a.attnum)` gives each column's
     // 1-based position inside the index definition.
-    const rows = await this.pg.schemaQuery(
+    const rows = await this.schemaQuery(
       `SELECT a.attname
        FROM pg_index i
        JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
@@ -1709,7 +1732,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
   }
 
   async primaryKeys(tableName: string): Promise<string[]> {
-    const names = await this.pg.queryValues(
+    const names = await this.queryValues(
       `SELECT a.attname
        FROM (
          SELECT indrelid, indkey, generate_subscripts(indkey, 1) idx
@@ -1730,12 +1753,12 @@ export class SchemaStatements extends AbstractSchemaStatements {
     // Rails wraps the whole of `pk_and_sequence_for` in a bare `rescue nil`, so
     // ANY error — not just an unknown table — yields nil.
     try {
-      const quotedTable = this.pg.quote(this.pg.quoteTableName(tableName));
+      const quotedTable = this.quote(this.quoteTableName(tableName));
 
       // First try looking for a sequence with a dependency on the
       // given table's primary key.
       let result = (
-        await this.pg.query(
+        await this.query(
           `SELECT attr.attname, nsp.nspname, seq.relname
            FROM pg_class      seq,
                 pg_attribute  attr,
@@ -1758,7 +1781,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
 
       if (result == null || result.length === 0) {
         result = (
-          await this.pg.query(
+          await this.query(
             `SELECT attr.attname, nsp.nspname,
                CASE
                  WHEN pg_get_expr(def.adbin, def.adrelid) !~* 'nextval' THEN NULL
@@ -1791,8 +1814,8 @@ export class SchemaStatements extends AbstractSchemaStatements {
   }
 
   async serialSequence(tableName: string, column: string): Promise<string | null> {
-    return ((await this.pg.queryValue(
-      `SELECT pg_get_serial_sequence(${this.pg.quote(tableName)}, ${this.pg.quote(column)})`,
+    return ((await this.queryValue(
+      `SELECT pg_get_serial_sequence(${this.quote(tableName)}, ${this.quote(column)})`,
       "SCHEMA",
     )) ?? null) as string | null;
   }
@@ -1813,8 +1836,8 @@ export class SchemaStatements extends AbstractSchemaStatements {
 
   /** @internal */
   sequenceNameFromParts(tableName: string, columnName: string, suffix: string): string {
-    const maxIdentifierLength = this.pg.maxIdentifierLength();
-    const [, unqualifiedTable] = this.pg.extractSchemaQualifiedName(tableName);
+    const maxIdentifierLength = this.maxIdentifierLength();
+    const [, unqualifiedTable] = this.extractSchemaQualifiedName(tableName);
     let overLength =
       unqualifiedTable.length + columnName.length + suffix.length + 2 - maxIdentifierLength;
     let col = columnName;
@@ -1840,10 +1863,10 @@ export class SchemaStatements extends AbstractSchemaStatements {
     const [pk, seq] = result ?? [null, null];
     if (!pk) return;
     if (seq) {
-      const quotedSequence = this.pg.quoteTableName(seq.toString());
-      await this.queryValue(`SELECT setval(${this.pg.quote(quotedSequence)}, ${value})`, "SCHEMA");
+      const quotedSequence = this.quoteTableName(seq.toString());
+      await this.queryValue(`SELECT setval(${this.quote(quotedSequence)}, ${value})`, "SCHEMA");
     } else {
-      this.pg.logger?.warn?.(`${tableName} has primary key ${pk} with no default sequence.`);
+      this.logger?.warn?.(`${tableName} has primary key ${pk} with no default sequence.`);
     }
   }
 
@@ -1859,23 +1882,25 @@ export class SchemaStatements extends AbstractSchemaStatements {
     }
 
     if (pk && !sequence) {
-      this.pg.logger?.warn?.(`${tableName} has primary key ${pk} with no default sequence.`);
+      this.logger?.warn?.(`${tableName} has primary key ${pk} with no default sequence.`);
     }
 
     if (!pk || !sequence) return;
 
-    const quotedSequence = this.pg.quoteTableName(sequence);
+    const quotedSequence = this.quoteTableName(sequence);
     const maxPk = await this.queryValue(
-      `SELECT MAX(${this.pg.quoteColumnName(pk)}) FROM ${this.pg.quoteTableName(tableName)}`,
+      `SELECT MAX(${this.quoteColumnName(pk)}) FROM ${this.quoteTableName(tableName)}`,
       "SCHEMA",
     );
     let minvalue: unknown = null;
     if (maxPk == null) {
-      const dbVersion = await this.pg.getDatabaseVersion();
+      // PG's own `getDatabaseVersion` returns `server_version_num`; the abstract
+      // adapter types the return as `number | Version` for MySQL's sake.
+      const dbVersion = (await this.getDatabaseVersion()) as number;
       minvalue =
         dbVersion >= 100000
           ? await this.queryValue(
-              `SELECT seqmin FROM pg_sequence WHERE seqrelid = ${this.pg.quote(quotedSequence)}::regclass`,
+              `SELECT seqmin FROM pg_sequence WHERE seqrelid = ${this.quote(quotedSequence)}::regclass`,
               "SCHEMA",
             )
           : await this.queryValue(`SELECT min_value FROM ${quotedSequence}`, "SCHEMA");
@@ -1884,7 +1909,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
     // Ruby's `max_pk ? true : false` is a nil check — 0 is truthy in Ruby, so a
     // table whose max primary key is 0 must still emit `true`.
     await this.queryValue(
-      `SELECT setval(${this.pg.quote(quotedSequence)}, ${maxPk ?? minvalue}, ${maxPk == null ? "false" : "true"})`,
+      `SELECT setval(${this.quote(quotedSequence)}, ${maxPk ?? minvalue}, ${maxPk == null ? "false" : "true"})`,
       "SCHEMA",
     );
   }

--- a/packages/activerecord/src/encryption/context.ts
+++ b/packages/activerecord/src/encryption/context.ts
@@ -4,10 +4,12 @@
  * Mirrors: ActiveRecord::Encryption::Contexts
  */
 
-import type { MessageSerializerLike } from "./message-serializer.js";
+import { MessageSerializer, type MessageSerializerLike } from "./message-serializer.js";
 import { NullEncryptor } from "./null-encryptor.js";
 import { Configurable } from "./configurable.js";
 import { Cipher } from "./cipher.js";
+import { Encryptor } from "./encryptor.js";
+import { KeyGenerator } from "./key-generator.js";
 import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
 
 // EncryptingOnlyEncryptor extends the full Encryptor, which transitively imports
@@ -74,18 +76,13 @@ export class Context {
     this._keyProvider = value;
   }
 
-  /**
-   * @internal Rails `Context#set_defaults` (context.rb:29-35) also seeds
-   * `key_generator`, `encryptor` and `message_serializer`. Each of those
-   * modules imports `Configurable`, and this module is evaluated while
-   * building the default context, so constructing them here would close an
-   * eval-time cycle. Story
-   * `0072-api-compare-parity-burndown/converge-context-set-defaults-remaining-three`
-   * carries the convergence.
-   */
+  /** @internal */
   private setDefaults(): void {
     this.frozenEncryption = false;
+    this.keyGenerator = new KeyGenerator();
     this.cipher = new Cipher();
+    this.encryptor = new Encryptor();
+    this.messageSerializer = new MessageSerializer();
   }
 
   /**
@@ -105,11 +102,17 @@ const contextStack: Context[] = [];
  * (contexts.rb:18). A real Context, not a bare object, because Context is where
  * the default key provider is memoized (context.rb:25-27) — that memo is Rails'
  * only key-provider cache, and `reset_default_context` is its only invalidation.
+ *
+ * Built on first read rather than at module eval: `set_defaults` constructs a
+ * KeyGenerator/Encryptor (context.rb:29-35), and both transitively import this
+ * module. Ruby's autoload resolves that at the point of use; ESM would evaluate
+ * whichever module was entered first and hit the other's class binding in its
+ * TDZ, so the construction has to happen after both module bodies have run.
  */
-let _defaultContext: Context = new Context();
+let _defaultContext: Context | undefined;
 
 export function getDefaultContext(): Context {
-  return _defaultContext;
+  return (_defaultContext ??= new Context());
 }
 
 /** @internal */
@@ -122,7 +125,7 @@ export function resetDefaultContext(): void {
 }
 
 function currentContext(): Context {
-  return contextStack.length > 0 ? contextStack[contextStack.length - 1] : _defaultContext;
+  return contextStack.length > 0 ? contextStack[contextStack.length - 1] : getDefaultContext();
 }
 
 export function withEncryptionContext<T>(overrides: Partial<Context>, fn: () => T): T {

--- a/packages/activerecord/src/encryption/encryptor.ts
+++ b/packages/activerecord/src/encryption/encryptor.ts
@@ -6,7 +6,7 @@
 
 import { Message } from "./message.js";
 import type { Properties } from "./properties.js";
-import { MessageSerializer, type MessageSerializerLike } from "./message-serializer.js";
+import type { MessageSerializerLike } from "./message-serializer.js";
 import { getEncryptionContext } from "./context.js";
 import { Configurable } from "./configurable.js";
 import { Base, Configuration, Decryption, Encoding, ForbiddenClass } from "./errors.js";
@@ -45,7 +45,6 @@ export interface KeyProviderLike {
 export class Encryptor {
   private _compress: boolean;
   private _compressor: Compressor;
-  private _serializer = new MessageSerializer();
 
   constructor(options?: { compress?: boolean; compressor?: Compressor }) {
     this._compress = options?.compress ?? true;
@@ -188,7 +187,7 @@ export class Encryptor {
 
   /** @internal */
   private serializer(): MessageSerializerLike {
-    return getEncryptionContext().messageSerializer ?? this._serializer;
+    return getEncryptionContext().messageSerializer as MessageSerializerLike;
   }
 
   /** @internal */

--- a/packages/activerecord/src/encryption/scheme.test.ts
+++ b/packages/activerecord/src/encryption/scheme.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Scheme } from "./scheme.js";
+import { Encryptor } from "./encryptor.js";
 import { Configuration } from "./errors.js";
 import { Configurable } from "./configurable.js";
 import { Contexts } from "./contexts.js";
@@ -189,7 +190,7 @@ describe("ActiveRecord::Encryption::SchemeTest", () => {
     let ran = false;
     scheme.withContext(() => {
       ran = true;
-      expect(getEncryptionContext().encryptor).toBeUndefined();
+      expect(getEncryptionContext().encryptor).toBeInstanceOf(Encryptor);
     });
     expect(ran).toBe(true);
   });
@@ -207,7 +208,7 @@ describe("ActiveRecord::Encryption::SchemeTest", () => {
       encryptorInContext = getEncryptionContext().encryptor;
     });
     expect(encryptorInContext).toBe(customEncryptor);
-    expect(getEncryptionContext().encryptor).toBeUndefined();
+    expect(getEncryptionContext().encryptor).toBeInstanceOf(Encryptor);
   });
 
   it("isCompatibleWith returns true when deterministic flags match", () => {

--- a/scripts/ci-suite-coverage.test.ts
+++ b/scripts/ci-suite-coverage.test.ts
@@ -134,6 +134,246 @@ function gateRegex(yml: string, name: string): RegExp {
 }
 
 /**
+ * Gate reference for the `changes` job's `- id: filter` step.
+ *
+ * The rationale for every `*_RE` in that step lives here rather than beside it:
+ * the step is a single inline `run:` script under a hard GitHub Actions size
+ * limit, crossing it fails the WHOLE workflow at startup — zero jobs, no checks
+ * reported, no run created — and a comment costs exactly as many bytes as code.
+ * This file already executes that gate block verbatim (see `gateRunner`), so it
+ * is where the prose stays honest.
+ *
+ * Each entry is headed by the shell variable or line it documents.
+ *
+ *
+ *  base/head fallback + INFRA_RE
+ *  First push to a branch has a zero-SHA base; force-push may
+ *  rewrite history out from under us. In either case we can't
+ *  reliably compute a diff — fall back to running the full matrix.
+ *  activerecord_affected gates the three AR test jobs (sqlite,
+ *  postgres, mariadb). True when changes touch activerecord, its
+ *  runtime deps (arel/activemodel/activesupport/globalid), or any
+ *  cross-cutting file (lockfile, root tsconfig, vitest config,
+ *  shared scripts, this workflow). Push to main / schedule /
+ *  workflow_dispatch always force true. Pattern mirrors the
+ *  AR-touching set in scripts/parity/run.ts.
+ *  Cross-cutting paths force every per-package gate true. Anything
+ *  here affects all packages: workspace topology, root tooling
+ *  config, shared scripts, this workflow, composite actions.
+ *  The blanket `scripts/` below also sweeps up subtrees that are NOT
+ *  cross-cutting; INFRA_CARVEOUT_RE strips them back out — keep the
+ *  two in sync. Every carved subtree must still be named in the gate
+ *  of whichever job runs its tests, or a change confined to it runs
+ *  nothing; scripts/ci-suite-coverage.test.ts enforces that pairing.
+ *
+ *  AR_PKGS_RE
+ *  AR workspace deps: arel/activemodel/activesupport/globalid/
+ *  did-you-mean (per packages/activerecord/package.json). Also
+ *  consumes @blazetrails/trails-tsc at runtime via the tsc-wrapper
+ *  CLI + type-virtualization modules (see packages/activerecord/src/
+ *  tsc-wrapper, schema-columns-dump.test.ts), so trails-tsc changes
+ *  can fail AR vitest suites — include it in the gate.
+ *  activerecord-cli E2E suites run in the three AR DB jobs (its tests
+ *  exercise the CLI against real DBs), so cli source changes must also
+ *  flip activerecord_affected.
+ *
+ *  DB_ADAPTER_RE
+ *  db_adapter_affected gates nothing on its own: it is the opt-in that
+ *  runs the PG/MariaDB suites while a PR is still a draft, so a false
+ *  negative costs a later signal, never coverage. `abstract/` and
+ *  sql-classification.ts are in scope because that substrate breaks
+ *  one backend without naming it (the latter carries the PG cursor
+ *  statements in its read-only allowlist).
+ *
+ *  AP_PKGS_RE
+ *  actionpack_affected gates actionpack-tests. True for actionpack +
+ *  its runtime deps (actionview/activemodel/activesupport/rack/did-you-mean).
+ *
+ *  AV_PKGS_RE
+ *  actionview_affected gates the actionview step of leaf-tests.
+ *  ActionView's only
+ *  workspace dependency is activesupport (see actionview/package.json).
+ *
+ *  TRAILTIES_PKGS_RE
+ *  trailties_affected gates trailties-tests. Trailties consumes
+ *  actionpack/actionview/activerecord/rack/activesupport, so any of
+ *  their workspace upstreams also flips this on.
+ *
+ *  TRAILS_TSC_PKGS_RE
+ *  trails_tsc_affected gates the virtualized DX type tests, the
+ *  blocking trails-tsc-tests job, and trails-tsc-coverage.
+ *  Workspace consumers of @blazetrails/trails-tsc today: activerecord
+ *  (tsc-wrapper + type-virtualization) and scripts/guides-typecheck;
+ *  AR consumption is the reason trails-tsc is also in AR_PKGS_RE.
+ *
+ *  TSE_COMPILER_PKGS_RE
+ *  tse_compiler_affected gates the tse-compiler step of leaf-tests.
+ *  The package has
+ *  no workspace dependencies today (no activesupport import), so
+ *  the gate matches the package path only.
+ *
+ *  RACK_PKGS_RE
+ *  rack_affected gates the rack step of leaf-tests (split out of
+ *  unit-tests so a rack-only PR doesn't drag in
+ *  arel/activemodel/activesupport tests). Rack's only workspace
+ *  dependency is activesupport.
+ *
+ *  UNIT_TESTS_PKGS_RE
+ *  unit_tests_affected gates the bundled vitest run for the small
+ *  leaf packages (arel/activemodel/activesupport/i18n) and the
+ *  scripts/guides-typecheck self-test. Rack is excluded here — it
+ *  runs in the leaf-tests job.
+ *  scripts/tasks/ and scripts/guides-typecheck/ also ride on this gate
+ *  since they're bundled into the same vitest invocation as the leaf
+ *  packages (ci.yml:604) — and both are carved out of the infra sweep
+ *  (INFRA_CARVEOUT_RE), so this clause is what keeps their self-tests
+ *  running on a subtree-only change.
+ *  scripts/parity/ rides on it too: the query-runner integration tests
+ *  spawn dump.ts/ar_dump.ts against the fixtures, so a change to either
+ *  the runners or the fixtures has to re-run them. (Their other input,
+ *  packages/activerecord/, is deliberately NOT on this gate — pulling
+ *  every AR PR into the leaf-package suites costs more than it catches;
+ *  the label-gated query-parity-trails job covers that direction.)
+ *  NO packages/activerecord/ path feeds this gate. The two suites here
+ *  that import AR — scripts/test-deps/ and scripts/parity/query/node/ —
+ *  are re-run by sqlite-tests (activerecord_affected) instead; see the
+ *  comment there.
+ *  The compare tooling's suites run in that same invocation and are
+ *  ALL in INFRA_CARVEOUT_RE, so without naming them here a change
+ *  confined to one of them would run none of its own tests.
+ *  schema-compare/ is deliberately absent — its suite parses the real
+ *  vendored schema.rb, so it runs in rails-comparison (COMPARISON_RE).
+ *  eslint/ rides on it because the custom rules' own RuleTester suites
+ *  are in the same invocation: without this clause a PR that only
+ *  touches a rule or its test would skip the only job that runs them.
+ *  eslint.config.mjs is named separately (it is not under eslint/):
+ *  eslint/rails-private-jsdoc.config.test.mjs is a drift guard between
+ *  it and eslint/rails-private-jsdoc.config.mjs, so an isolated change
+ *  to the root config must still run the guard.
+ *  scripts/ci/check-control-bytes.sh is named for the same reason:
+ *  eslint/no-raw-control-bytes.drift.test.mjs is a drift guard between
+ *  its byte set and the ESLint rule's, and scripts/ci/ is carved out
+ *  of the infra sweep (INFRA_CARVEOUT_RE).
+ *
+ *  GUIDES_PKGS_RE
+ *  guides_affected gates the Guides Code Type Check job, which
+ *  compiles fenced TS blocks in packages/website/docs/guides/**.
+ *  Today guides only import @blazetrails/activerecord,
+ *  @blazetrails/activemodel, and @blazetrails/activesupport — plus
+ *  AR's transitive type deps. Confirmed via:
+ *  grep -rhE "from ['\"]@blazetrails/[a-z-]+" packages/website/docs/guides
+ *  scripts/guides-typecheck/ is the job's own implementation and is
+ *  carved out of the infra sweep (INFRA_CARVEOUT_RE), so it must be
+ *  named here or a checker-only change would stop running the checker.
+ *
+ *  WEBSITE_PKGS_RE
+ *  website_affected gates the Website build (SvelteKit + typedoc +
+ *  VitePress). Scoped narrowly to packages/website/ — package-source
+ *  changes alone don't trigger it. To run the site build on a PR
+ *  that touches package sources, apply the `website` label (or the
+ *  `release` label, which always runs it). The job is also
+ *  exercised post-merge by push-to-main.
+ *
+ *  COMPARISON_RE
+ *  comparison_affected gates the Rails API/Test Comparison job. That
+ *  job is only meaningful when Rails-port package source, the compare
+ *  tooling (scripts/{api,test,fixtures,schema}-compare/ and the Rails
+ *  manifest builders), or the vendored
+ *  upstream Ruby sources changed — plus cross-cutting infra (INFRA_RE)
+ *  below. A scripts/tasks-only, website-only, or other tooling-only
+ *  change can't move any comparison output, so it skips.
+ *  packages/website/ is EXCLUDED: it's the SvelteKit docs site, never
+ *  one of apiComparePackages() (vendor/sources.ts), so the comparison
+ *  never scans it — set_gate's exclusion argument drops it before
+ *  the COMPARISON_RE `^packages/` clause is applied.
+ *  NOTE: scripts/api-compare/conventions.ts regenerates
+ *  docs/ruby-ts-conventions.md (checked by api:conventions --check in
+ *  the job); the scripts/api-compare/ clause keeps that drift check
+ *  gated on. As with the package gates, infra_files (which carves out
+ *  the single-consumer scripts/ subtrees) feeds the INFRA_RE half of
+ *  the OR.
+ *  docs/ruby-ts-conventions.md is ALSO matched directly: it's the
+ *  generated artifact the conventions check guards, and the docs_only
+ *  logic above (`:234`) deliberately keeps a hand-edit of it
+ *  non-docs-only so the drift check still runs. Mirror that here — a
+ *  PR that edits ONLY that file matches neither INFRA_RE nor the
+ *  package/vendor clauses, so without this it would skip the very
+ *  check the docs_only exception was built to preserve.
+ *  eslint/rails-deprecated-methods.json is matched directly for the
+ *  same reason as ruby-ts-conventions.md: it is the generated artifact
+ *  the `--check-deprecated` step guards, and `eslint/` appears in
+ *  neither INFRA_RE nor the package/vendor clauses. Without this, the
+ *  one change shape the guard exists to catch — a commit that ONLY
+ *  drops manifest entries — would skip rails-comparison entirely and
+ *  never run the recompute.
+ *  schema-compare/ (the Schema comparison step, ci.yml:1272) and the
+ *  two Rails manifest builders + their shared mixin resolver (the
+ *  privates/file-structure steps, ci.yml:1279/1293) are named
+ *  explicitly: all are carved out of the infra sweep
+ *  (INFRA_CARVEOUT_RE), so this clause is the only thing that still
+ *  runs rails-comparison on a change confined to them.
+ *
+ *  elif ! files
+ *  Triple-dot: diff against the merge-base of $base and $head, not
+ *  against the current tip of the base branch. Using `$base $head`
+ *  would also include every commit merged to main since this branch
+ *  diverged, inflating the changed-files list with unrelated paths
+ *  and triggering gates that shouldn't fire.
+ *
+ *  if echo "$files" | grep -qE '^(\.prettierrc\.json|\.prettierignore|package\.json)$'; then
+ *  Prettier file list for the Prettier job. A change to Prettier's
+ *  config or its version pin reformats the whole tree, so fall back
+ *  to `__ALL__` (check everything) in that case — there is no other
+ *  full-tree check to catch the resulting drift. Otherwise emit the
+ *  changed files, excluding deletions (--diff-filter=ACMR keeps
+ *  added/copied/modified/renamed) since Prettier can't format a path
+ *  that no longer exists. If that diff somehow fails, fall back to
+ *  `__ALL__` rather than silently skipping the check.
+ *
+ *  if [ -z "$files" ]; then
+ *  docs_only: any line NOT under `docs/`, `examples/`, and not the
+ *  top-level `README.md` flips the switch. README is markdown-only
+ *  and only ever runs through prettier; `examples/` are standalone
+ *  apps not built, type-checked, or tested by any CI job (the root
+ *  `tsc --build` doesn't reference them and they have no `test`
+ *  script) — so neither needs the full matrix.
+ *
+ *  Exception: docs/ruby-ts-conventions.md is GENERATED from
+ *  conventions.ts and guarded by `api:conventions --check` in the
+ *  rails-comparison job. Treat a change to it as non-docs-only so a
+ *  hand-edit (ignoring the file's do-not-edit banner) still runs the
+ *  drift check instead of short-circuiting to a green docs-only run.
+ *
+ *  case "${{ github.event_name }}" in
+ *  On push to main / schedule / workflow_dispatch force every
+ *  package gate true. Downstream jobs still honor docs_only, so a
+ *  docs-only push to main still short-circuits the matrix.
+ *
+ *  infra_files
+ *  Drop the single-consumer scripts/ subtrees (see
+ *  INFRA_CARVEOUT_RE above) from the infra sweep so a change
+ *  confined to them doesn't trip INFRA_RE's blanket `scripts/`
+ *  and force every package gate true (the whole Rails matrix).
+ *  Per-package gates below still see the full $files list, so
+ *  each carved subtree still flips its own consuming job's gate
+ *  via that gate's regex.
+ *
+ *  case "${{ github.event_name }}" in
+ *  Website label opt-in. The Website job otherwise gates only on
+ *  packages/website/ paths, so PRs that need a site preview (or
+ *  release PRs that must build the production site) can apply the
+ *  `website` or `release` label to force the job on.
+ *
+ *  case "${{ github.event_name }}" in
+ *  Per-adapter parity gates. Each suite is expensive (~15-20 CI
+ *  minutes across 7 jobs), so plain PRs skip all parity. Run on:
+ *  - push to main / schedule / workflow_dispatch → all adapters
+ *  - PRs carrying a per-adapter label → only that adapter
+ *  `any(.[]; ...)` guards against the `.[].name == "..."` bug where
+ *  jq -e bases exit status on the last element of a stream.
+ */
+
+/**
  * Runs the `changes` job's own gate block — the `*_RE` definitions plus the
  * `infra_files`/`set_gate` region lifted verbatim out of ci.yml — over a
  * changed-file list, under the same `set -euo pipefail` the job uses. Modelling

--- a/scripts/mixin-declaration-drift.test.ts
+++ b/scripts/mixin-declaration-drift.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import * as fs from "fs/promises";
 import { BetterSQLite3Adapter } from "../packages/activerecord/src/connection-adapters/better-sqlite3-adapter.js";
 import { PostgreSQLAdapter } from "../packages/activerecord/src/connection-adapters/postgresql-adapter.js";
+import { AbstractMysqlAdapter } from "../packages/activerecord/src/connection-adapters/abstract-mysql-adapter.js";
 import {
   findDrift,
   findUninstalled,
@@ -40,6 +41,14 @@ const PAIRS = [
     adapterFile: `${ADAPTERS}postgresql-adapter.ts`,
     adapterInterface: "PostgreSQLAdapter",
     witness: PostgreSQLAdapter,
+  },
+  {
+    label: "AbstractMysqlAdapter / MySQL::SchemaStatements",
+    mixinFile: `${ADAPTERS}mysql/schema-statements.ts`,
+    mixinClass: "MysqlSchemaStatements",
+    adapterFile: `${ADAPTERS}abstract-mysql-adapter.ts`,
+    adapterInterface: "AbstractMysqlAdapter",
+    witness: AbstractMysqlAdapter,
   },
 ] as const;
 


### PR DESCRIPTION
Bundle of five stories.

## 1. `Context#setDefaults` seeds all five properties (`context.rb:29-35`)

`setDefaults` seeded only `frozenEncryption`; `keyGenerator`, `cipher`,
`encryptor` and `messageSerializer` stayed `undefined`. All five are now
seeded, and `Encryptor#serializer` drops the `?? this._serializer` fallback that
existed only to cover the gap (`encryptor.rb:131-133` reads the context
serializer unconditionally).

The blocker was the eval-time module cycle: those classes import `Configurable`
→ `contexts.ts` → `context.ts`, which built a `Context` at module scope. The
default context is now built on first read (`getDefaultContext`) instead of at
module eval, so the construction happens after both module bodies have run —
Ruby gets the same effect from autoload. No other lazy machinery was added.

`scheme.test.ts` had two assertions asserting the missing default
(`expect(getEncryptionContext().encryptor).toBeUndefined()`); they now assert
the default `Encryptor`. No test names changed.

## 2. Drop the `TokenDefinition` stubs from `Base`

The five `declare`d instance methods (`fullPurpose`, `messageVerifier`,
`payloadFor`, `generateToken`, `resolveToken`) belong to the
`TokenFor::TokenDefinition` Struct (`token_for.rb:14-36`), not to
`ActiveRecord::Base`, and `token-for.ts`'s `TokenDefinition` already implements
all five. `generateTokenFor` (`token_for.rb:119`) remains the only `TokenFor`
instance method on `Base`. `TokenDefinition` is unchanged.

`pnpm api:compare` — activerecord 6147/6148 (100%); `pnpm api:extra --package
activerecord` lists no name I added or moved, for `base.ts` or `token-for.ts`.

## 3. Declare the MySQL `SchemaStatements` mixin surface

`include(AbstractMysqlAdapter, MysqlSchemaStatements)`
(`abstract_mysql_adapter.rb:19`) had no declaration-merged
`export interface AbstractMysqlAdapter`, so every caller fell back to
`AbstractAdapter`'s signature. Added one covering the mixin's six public
methods, plus the third `PAIRS` entry in `scripts/mixin-declaration-drift.test.ts`
— both drift checks pass for it (11 tests green). `schemaCreation` is not in the
interface: the adapter class declares that getter itself, so it is not the
mixin's to restate.

## 4. Drop `PostgreSQLSchemaStatements`' self-returning `pg` getter

`private get pg()` is gone and its 148 `this.pg.x(...)` call sites read
`this.x(...)`, the way Rails' `PostgreSQL::SchemaStatements` calls `self`. The
class gets its own merged interface over `PgSchemaAdapter`. Nine names are
`Omit`ted from it — they already come from `AbstractSchemaStatements` with a
signature TypeScript will not let a narrower PG one merge over (a method on a
base class wins over a merged-interface property); the bodies use the abstract
signature, so nothing is lost, and the reason is at the call site. No new
narrowing getter replaces `pg`.

## 5. Shrink the changes-job filter script

All gate prose moved out of the size-limited inline `run:` into a "Gate
reference" block in `scripts/ci-suite-coverage.test.ts`, which already executes
that gate block verbatim. One pointer line stays in `ci.yml`.

**Rendered `run:` size: 19,779 B → 8,360 B** (measured with the story's
`yaml.safe_load` one-liner). Gate behaviour is unchanged — `gateRunner` lifts
only `*_RE=` definitions and the `infra_files`…`set_gate comparison_affected`
region, neither of which contained code; all 14 `ci-suite-coverage` tests pass.

## Checks

`pnpm typecheck`, `pnpm lint`, `pnpm api:compare` (activerecord 100%),
`pnpm api:calls` (OK, 14 baselined), `pnpm api:calls:wide` (OK), `pnpm
api:extra --package activerecord` (no new novel names), `pnpm test:compare`
(15172/22510, unchanged). Suites run locally: `encryption/` (350 passed),
`token-for*.test.ts`, `mysql/schema-statements.test.ts`,
`mixin-declaration-drift.test.ts`, `ci-suite-coverage.test.ts`. PG/MySQL lanes
are CI's.

## Size

861 LOC, over the 500 ceiling. 723 of it is two mechanical sweeps the stories
specify: 296 from the 148 `this.pg.` → `this.` rewrites, and 427 from relocating
187 comment lines out of `ci.yml`. The hand-written change is ~140 LOC.

Closes-story: converge-context-set-defaults-remaining-three
Closes-story: drop-token-definition-stubs-from-base
Closes-story: shrink-changes-job-filter-script-headroom
Closes-story: declare-the-mysql-schema-statements-mixin-surface
Closes-story: drop-postgresql-schema-statements-pg-self-getter
