### PR TITLE
refactor(activerecord,trailties): stamp the migration environment once per run, derive InternalMetadata#enabled? from the pool's db_config

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -449,11 +449,9 @@ export class ConnectionPool implements ReapablePool {
       const pool = this;
       this._adapterProxy = new Proxy({} as DatabaseAdapter, {
         get(_target, prop) {
-          // `pool` is a data property on every real adapter, not a method, so
-          // answer the pool itself rather than a `withConnection` dispatcher.
-          // Rails' pool-owned collaborators read the config off it —
-          // `InternalMetadata#enabled?` is `@pool.db_config.use_metadata_table?`
-          // (internal_metadata.rb:35-36).
+          // A data property on every real adapter, not a method: answering a
+          // `withConnection` dispatcher here would hand callers a function
+          // where `abstract_adapter.rb:153`'s `@pool` is expected.
           if (prop === "pool") return pool;
           if (prop === "adapterName")
             return (

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -449,6 +449,12 @@ export class ConnectionPool implements ReapablePool {
       const pool = this;
       this._adapterProxy = new Proxy({} as DatabaseAdapter, {
         get(_target, prop) {
+          // `pool` is a data property on every real adapter, not a method, so
+          // answer the pool itself rather than a `withConnection` dispatcher.
+          // Rails' pool-owned collaborators read the config off it —
+          // `InternalMetadata#enabled?` is `@pool.db_config.use_metadata_table?`
+          // (internal_metadata.rb:35-36).
+          if (prop === "pool") return pool;
           if (prop === "adapterName")
             return (
               (pool.activeConnection ?? pool.connections[0])?.adapterName ??

--- a/packages/activerecord/src/internal-metadata.ts
+++ b/packages/activerecord/src/internal-metadata.ts
@@ -95,11 +95,17 @@ export class InternalMetadata {
    * Mirrors ActiveRecord::InternalMetadata#enabled?
    * (`internal_metadata.rb:35-36`) — `@pool.db_config.use_metadata_table?`.
    *
-   * trails threads an adapter rather than a pool, so the db_config is reached
-   * through `adapter.pool`. A bare adapter carries a NullPool, whose config
-   * answers nil for every key (Rails' `NullConfig#method_missing`), which is
-   * why an absent flag reads as enabled — the same default
-   * `DatabaseConfig#useMetadataTable` applies.
+   * trails threads an adapter rather than a pool, so the config is reached
+   * through `adapter.pool`.
+   *
+   * Deviation: a `NullPool` answers `NULL_CONFIG`, whose every key is undefined
+   * (Rails' `NullConfig#method_missing` returns nil), so Rails would read that
+   * arm as disabled. Rails never gets there — its `InternalMetadata` is always
+   * built from a real pool — while trails builds one over bare, NullPool-backed
+   * adapters throughout the test suite and the trailties `db` commands, so the
+   * absent flag has to keep `DatabaseConfig#useMetadataTable`'s default. It
+   * converges once those call sites hold a pool
+   * (`migration-context-collaborators-need-a-pool`).
    */
   get enabled(): boolean {
     const pool = this._connection.pool as { dbConfig?: { useMetadataTable?: boolean } } | null;

--- a/packages/activerecord/src/internal-metadata.ts
+++ b/packages/activerecord/src/internal-metadata.ts
@@ -86,22 +86,24 @@ export class InternalMetadata {
     return `${base.tableNamePrefix}${base.internalMetadataTableName}${base.tableNameSuffix}`;
   }
 
-  private _enabled: boolean;
-
-  constructor(adapter: DatabaseAdapter, options: { enabled?: boolean } = {}) {
+  constructor(adapter: DatabaseAdapter) {
     this._connection = adapter;
     this.arelTable = new Table(this.tableName);
-    this._enabled = options.enabled ?? true;
   }
 
   /**
-   * Whether metadata storage is enabled for this configuration.
+   * Mirrors ActiveRecord::InternalMetadata#enabled?
+   * (`internal_metadata.rb:35-36`) — `@pool.db_config.use_metadata_table?`.
    *
-   * Mirrors ActiveRecord::InternalMetadata#enabled? — false only when the
-   * db_config opts out via `use_metadata_table: false`. Defaults to true.
+   * trails threads an adapter rather than a pool, so the db_config is reached
+   * through `adapter.pool`. A bare adapter carries a NullPool, whose config
+   * answers nil for every key (Rails' `NullConfig#method_missing`), which is
+   * why an absent flag reads as enabled — the same default
+   * `DatabaseConfig#useMetadataTable` applies.
    */
   get enabled(): boolean {
-    return this._enabled;
+    const pool = this._connection.pool as { dbConfig?: { useMetadataTable?: boolean } } | null;
+    return pool?.dbConfig?.useMetadataTable !== false;
   }
 
   // Rails: create_table(table_name, id: false) { |t| t.string :key, **...; t.string
@@ -110,7 +112,7 @@ export class InternalMetadata {
   // resulting table matches the DDL this used to hand-build — but the column
   // types and quoting now come from the adapter instead of an adapterName branch.
   async createTable(): Promise<void> {
-    if (!this._enabled) return;
+    if (!this.enabled) return;
     if (await this._connection.tableExists(this.tableName)) return;
     await this._connection.createTable(this.tableName, { id: false }, (t) => {
       t.string("key", this._connection.internalStringOptionsForPrimaryKey());
@@ -126,7 +128,7 @@ export class InternalMetadata {
    * returns when `enabled?` is false.
    */
   async createTableAndSetFlags(environment: string, schemaSha1?: string): Promise<void> {
-    if (!this._enabled) return;
+    if (!this.enabled) return;
     await this.createTable();
     await this.updateOrCreateEntry(this._connection, "environment", environment);
     if (schemaSha1 !== undefined) {
@@ -139,7 +141,7 @@ export class InternalMetadata {
     // when metadata is disabled. Prevents a disabled instance from
     // reaching over and dropping ar_internal_metadata that another
     // config or adapter is actively using.
-    if (!this._enabled) return;
+    if (!this.enabled) return;
     // Rails: drop_table table_name, if_exists: true (internal_metadata.rb:100-104).
     await this._connection.dropTable(this.tableName, { ifExists: true });
   }
@@ -148,7 +150,7 @@ export class InternalMetadata {
     // When metadata is disabled, treat every key as unset without
     // probing ar_internal_metadata — callers shouldn't observe stale
     // rows from a previous run that had the flag enabled.
-    if (!this._enabled) return null;
+    if (!this.enabled) return null;
     const entry = await this.selectEntry(this._connection, key);
     if (!entry) return null;
     const value = entry[this.valueKey];
@@ -157,7 +159,7 @@ export class InternalMetadata {
   }
 
   async set(key: string, value: string): Promise<void> {
-    if (!this._enabled) {
+    if (!this.enabled) {
       // Rails' `environment:set` raises EnvironmentStorageError when
       // internal_metadata is disabled; surface the same error here so
       // callers that attempt to write through a disabled instance fail
@@ -189,7 +191,7 @@ export class InternalMetadata {
     // dropTable(): a disabled instance treats the store as empty — don't
     // run a DELETE that would either mutate a supposedly-invisible store
     // or throw against a missing table.
-    if (!this._enabled) return;
+    if (!this.enabled) return;
     const dm = new DeleteManager();
     dm.from(this.arelTable);
     await this._connection.execute(this._connection.toSql(dm));
@@ -199,7 +201,7 @@ export class InternalMetadata {
     // Symmetric with get() / tableExists(): a disabled instance reports
     // an empty store, without probing ar_internal_metadata (which may
     // not exist, or may carry stale rows from a prior enabled run).
-    if (!this._enabled) return 0;
+    if (!this.enabled) return 0;
     const sm = new SelectManager(this.arelTable);
     sm.project(new Nodes.NamedFunction("COUNT", [star]).as("cnt"));
     const rows = await this._connection.execute(this._connection.toSql(sm));
@@ -218,7 +220,7 @@ export class InternalMetadata {
     // When disabled, report the table as absent so callers don't
     // accidentally trust it. The physical table may still exist on disk
     // from a previous run; the flag is what drives semantic visibility.
-    if (!this._enabled) return false;
+    if (!this.enabled) return false;
     try {
       const sm = new SelectManager(this.arelTable);
       sm.project(new Nodes.Quoted(1));

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -1121,22 +1121,39 @@ describe("MigrationTest", () => {
     const adapter = Base.connection;
     const { InternalMetadata } = await import("./internal-metadata.js");
 
-    const im = new InternalMetadata(adapter, { enabled: false });
+    // Rails swaps `use_metadata_table: false` into the pool's db_config
+    // configuration_hash (migration_test.rb:728-730) and lets `enabled?`
+    // read it back off `@pool.db_config` (internal_metadata.rb:35-36).
+    const im = new InternalMetadata(adapter);
+    await im.dropTable();
+
+    const { _setConfigurationHash } = await import("./database-configurations/database-config.js");
+    type Cfg = import("./database-configurations/database-config.js").DatabaseConfig;
+    const dbConfig = (adapter.pool as { dbConfig: Cfg }).dbConfig;
+    const originalConfig = dbConfig.configuration;
+    _setConfigurationHash(dbConfig, { ...originalConfig, useMetadataTable: false });
+
     expect(im.enabled).toBe(false);
+    expect(await im.tableExists()).toBe(false);
 
     const proxy: MigrationProxy = {
       version: "1",
       name: "TestMigration",
       migration: () => anonymousMigration("TestMigration", "1"),
     };
-    const migrator = new Migrator(adapter, [proxy], { internalMetadataEnabled: false });
-    await migrator.up();
+    const migrator = new Migrator(adapter, [proxy]);
+    try {
+      await migrator.up();
 
-    // im.get() short-circuits to null when disabled, so use a catalog query to
-    // verify the table was physically not created (catalog tables always exist,
-    // so this doesn't trigger the test-adapter's auto-schema).
-    const rows = await adapter.execute(internalMetadataExistsSql(adapterType));
-    expect(Number(rows[0]?.cnt ?? 0)).toBe(0);
+      // im.get() short-circuits to null when disabled, so use a catalog query to
+      // verify the table was physically not created (catalog tables always exist,
+      // so this doesn't trigger the test-adapter's auto-schema).
+      const rows = await adapter.execute(internalMetadataExistsSql(adapterType));
+      expect(Number(rows[0]?.cnt ?? 0)).toBe(0);
+    } finally {
+      _setConfigurationHash(dbConfig, originalConfig);
+      await im.createTable();
+    }
   });
 
   it("inserting a new entry into internal metadata", async () => {

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -1121,9 +1121,8 @@ describe("MigrationTest", () => {
     const adapter = Base.connection;
     const { InternalMetadata } = await import("./internal-metadata.js");
 
-    // Rails swaps `use_metadata_table: false` into the pool's db_config
-    // configuration_hash (migration_test.rb:728-730) and lets `enabled?`
-    // read it back off `@pool.db_config` (internal_metadata.rb:35-36).
+    // migration_test.rb:727-730 — drop the table, then swap
+    // `use_metadata_table: false` into the pool's db_config configuration_hash.
     const im = new InternalMetadata(adapter);
     await im.dropTable();
 

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1808,7 +1808,6 @@ export class MigrationContext {
     return new Migrator(this.connection, migrations, {
       direction,
       targetVersion,
-      internalMetadataEnabled: this._internalMetadata?.enabled,
     });
   }
 
@@ -1851,7 +1850,6 @@ export class MigrationContext {
     return new Migrator(this.connection, this.migrations, {
       direction: "up",
       targetVersion: null,
-      internalMetadataEnabled: this._internalMetadata?.enabled,
     });
   }
 
@@ -2062,12 +2060,6 @@ export class MigrationContext {
  */
 type MigratorOptions = {
   environment?: string;
-  /**
-   * Set to false when the db_config opts out of metadata storage
-   * (Rails' `use_metadata_table: false`). environment stamping is a
-   * no-op / raises in `environment:set` when this is false.
-   */
-  internalMetadataEnabled?: boolean;
   direction?: "up" | "down";
   targetVersion?: number | string | null;
 };
@@ -2098,9 +2090,7 @@ export class Migrator {
     this._targetVersion = options.targetVersion ?? null;
     this._adapter = adapter;
     this._schemaMigration = new SchemaMigration(adapter);
-    this._internalMetadata = new InternalMetadata(adapter, {
-      enabled: options.internalMetadataEnabled ?? true,
-    });
+    this._internalMetadata = new InternalMetadata(adapter);
     this._environment =
       options.environment ??
       getEnv("TRAILS_ENV") ??
@@ -2781,9 +2771,6 @@ export class Migrator {
       await this._ddlTransaction(loaded, async () => {
         await loaded.migrate(direction);
         await this.recordVersionStateAfterMigrating(proxy.version, direction);
-        if (direction === "up" && this._internalMetadata.enabled) {
-          await this._internalMetadata.set("environment", this._recordedEnvironment());
-        }
       });
     } catch (e) {
       // Mirrors: ActiveRecord::Migrator#execute_migration_in_transaction rescue block

--- a/packages/activerecord/src/migrator.trails.test.ts
+++ b/packages/activerecord/src/migrator.trails.test.ts
@@ -74,6 +74,27 @@ describe("Migrator trails extensions", () => {
     expect(env).toBe(envName(adapter));
   });
 
+  it("stamps the environment once per run, not once per migration", async () => {
+    // Rails stamps it in `record_environment` before the migration loop
+    // (migration.rb:1508-1512); `execute_migration_in_transaction`
+    // (:1528-1537) writes no metadata at all.
+    const migrator = new Migrator(
+      adapter,
+      [makeMigration("1", "M1"), makeMigration("2", "M2"), makeMigration("3", "M3")],
+      { environment: "test" },
+    );
+    const set = vi.spyOn(InternalMetadata.prototype, "set");
+    let environmentWrites: number;
+    try {
+      await migrator.up();
+    } finally {
+      environmentWrites = set.mock.calls.filter(([key]) => key === "environment").length;
+      set.mockRestore();
+    }
+    expect(environmentWrites).toBe(1);
+    expect(await new InternalMetadata(adapter).get("environment")).toBe(envName(adapter));
+  });
+
   it("executeMigrationInTransaction skips migrations already in migrated", async () => {
     const calls: Array<[string, number]> = [];
     const proxy = makeMigration(

--- a/packages/activerecord/src/migrator.trails.test.ts
+++ b/packages/activerecord/src/migrator.trails.test.ts
@@ -75,9 +75,7 @@ describe("Migrator trails extensions", () => {
   });
 
   it("stamps the environment once per run, not once per migration", async () => {
-    // Rails stamps it in `record_environment` before the migration loop
-    // (migration.rb:1508-1512); `execute_migration_in_transaction`
-    // (:1528-1537) writes no metadata at all.
+    // migration.rb:1508-1512 stamps before the loop; :1528-1537 writes nothing.
     const migrator = new Migrator(
       adapter,
       [makeMigration("1", "M1"), makeMigration("2", "M2"), makeMigration("3", "M3")],

--- a/packages/activerecord/src/schema.ts
+++ b/packages/activerecord/src/schema.ts
@@ -6,19 +6,6 @@ import { InternalMetadata } from "./internal-metadata.js";
 import { DatabaseConfigurations } from "./database-configurations.js";
 
 /**
- * Look up an optional pool property without exposing the concrete
- * ConnectionPool type (pool is accessed via `(adapter as any).pool`
- * throughout the schema/migration stack; mirror that here).
- */
-function adapterPool(adapter: DatabaseAdapter):
-  | {
-      dbConfig?: { useMetadataTable?: boolean };
-    }
-  | undefined {
-  return (adapter as unknown as { pool?: { dbConfig?: { useMetadataTable?: boolean } } }).pool;
-}
-
-/**
  * Info hash accepted by `Schema.define`. Mirrors the Ruby
  * positional-hash arg used by Rails' `Schema.define(info = {}, &block)`.
  */
@@ -97,14 +84,6 @@ export class Schema extends Current {
       // migrations between.
       await schema.connection.assumeMigratedUptoVersion(info.version);
     }
-    // Honour the use_metadata_table / useMetadataTable opt-out so
-    // schema loading doesn't create / stamp ar_internal_metadata when
-    // the db_config has it disabled. Rails routes this through
-    // `connection_pool.internal_metadata` which respects
-    // db_config.use_metadata_table; we read it off pool.dbConfig here
-    // (the rest of the migration stack uses the same shape — see
-    // migration.ts:1440).
-    const enabled = adapterPool(adapter)?.dbConfig?.useMetadataTable !== false;
     // Environment fallback chain: explicit info.environment → TRAILS_ENV
     // → NODE_ENV (one-release fallback) → DatabaseConfigurations.defaultEnv
     // (defaults to "development" but can be overridden by the app, e.g. via
@@ -116,7 +95,7 @@ export class Schema extends Current {
       getEnv("TRAILS_ENV") ??
       getEnv("NODE_ENV") ??
       DatabaseConfigurations.defaultEnv;
-    const internalMetadata = new InternalMetadata(adapter, { enabled });
+    const internalMetadata = new InternalMetadata(adapter);
     await internalMetadata.createTableAndSetFlags(environment);
   }
 

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -1593,16 +1593,14 @@ export async function checkCurrentProtectedEnvironmentBang(
 ): Promise<void> {
   const { NoDatabaseError } = await import("../errors.js");
   const { EnvironmentMismatchError } = await import("../migration.js");
-  // Rails reads the context straight off the pool (`database_tasks.rb:635-636`
-  // — `with_temporary_pool { |pool| pool.migration_context }`) and puts the
-  // `NoDatabaseError` rescue inside the block (`:648-649`). Neither shape is
-  // reachable yet: `ConnectionPool#migrationContext` builds its collaborators
-  // over the pool's adapter proxy, whose `get` trap routes every member through
-  // `withConnection`, so the synchronous `toSql` a SchemaMigration /
-  // InternalMetadata query needs comes back as a Promise and the query is handed
-  // a Promise instead of SQL; and `withTemporaryConnection` leases eagerly, so
-  // `NoDatabaseError` can surface from the lease rather than from inside the
-  // block. Both are the adapter-vs-pool gap, tracked separately.
+  // Deviation: Rails uses `with_temporary_pool { |pool| pool.migration_context }`
+  // and rescues inside the block (`database_tasks.rb:635-636`, `:648-649`).
+  // `ConnectionPool#migrationContext` builds its collaborators over the pool's
+  // adapter proxy, which routes the synchronous `toSql` those queries need
+  // through `withConnection` and hands them a Promise instead of SQL; and
+  // `withTemporaryConnection` leases eagerly, so `NoDatabaseError` can surface
+  // from the lease. Both converge in
+  // `check-current-protected-environment-pool-migration-context-blocked-on-adapter-proxy`.
   try {
     await DatabaseTasks.withTemporaryConnection(dbConfig, async (adapter) => {
       const migrationContext = await DatabaseTasks._migrationContextFor(adapter, dbConfig);

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -361,7 +361,7 @@ export class DatabaseTasks {
     })(
       paths == null ? [] : Array.isArray(paths) ? paths : [paths],
       new SchemaMigration(adapter),
-      new InternalMetadata(adapter, { enabled: dbConfig.useMetadataTable }),
+      new InternalMetadata(adapter),
     );
   }
 
@@ -372,7 +372,6 @@ export class DatabaseTasks {
     const { Migrator } = await import("../migration.js");
     return new Migrator(adapter, this._migrationsFor(dbConfig), {
       environment: dbConfig.envName,
-      internalMetadataEnabled: dbConfig.useMetadataTable,
     });
   }
 
@@ -1594,14 +1593,26 @@ export async function checkCurrentProtectedEnvironmentBang(
 ): Promise<void> {
   const { NoDatabaseError } = await import("../errors.js");
   const { EnvironmentMismatchError } = await import("../migration.js");
+  // Rails reads the context straight off the pool (`database_tasks.rb:635-636`
+  // — `with_temporary_pool { |pool| pool.migration_context }`) and puts the
+  // `NoDatabaseError` rescue inside the block (`:648-649`). Neither shape is
+  // reachable yet: `ConnectionPool#migrationContext` builds its collaborators
+  // over the pool's adapter proxy, whose `get` trap routes every member through
+  // `withConnection`, so the synchronous `toSql` a SchemaMigration /
+  // InternalMetadata query needs comes back as a Promise and the query is handed
+  // a Promise instead of SQL; and `withTemporaryConnection` leases eagerly, so
+  // `NoDatabaseError` can surface from the lease rather than from inside the
+  // block. Both are the adapter-vs-pool gap, tracked separately.
   try {
     await DatabaseTasks.withTemporaryConnection(dbConfig, async (adapter) => {
-      const context = await DatabaseTasks._migrationContextFor(adapter, dbConfig);
-      const current = context.currentEnvironment;
-      const stored = await context.lastStoredEnvironment();
-      if (stored && (await context.protectedEnvironment())) {
-        throw new ProtectedEnvironmentError(stored);
+      const migrationContext = await DatabaseTasks._migrationContextFor(adapter, dbConfig);
+      const current = migrationContext.currentEnvironment;
+      const stored = await migrationContext.lastStoredEnvironment();
+
+      if (await migrationContext.protectedEnvironment()) {
+        throw new ProtectedEnvironmentError(stored!);
       }
+
       if (stored && stored !== current) {
         throw new EnvironmentMismatchError(current, stored);
       }

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -1353,6 +1353,15 @@ export class CreatePosts extends Migration {
     }
   });
 
+  /**
+   * Give a bare adapter a pool whose db_config opts out of metadata storage.
+   * `InternalMetadata#enabled?` is `@pool.db_config.use_metadata_table?`
+   * (internal_metadata.rb:35-36), so this is how Rails turns it off.
+   */
+  function disableMetadataTable(adapter: unknown): void {
+    (adapter as { pool: unknown }).pool = { dbConfig: { useMetadataTable: false } };
+  }
+
   it("InternalMetadata with enabled=false refuses set writes with EnvironmentStorageError", async () => {
     const { EnvironmentStorageError, InternalMetadata } = await import("@blazetrails/activerecord");
     const { BetterSQLite3Adapter } =
@@ -1361,7 +1370,8 @@ export class CreatePosts extends Migration {
     const dbFile = path.join(tmpDir, "disabled.sqlite3");
     const adapter = new BetterSQLite3Adapter(dbFile);
     try {
-      const disabledMeta = new InternalMetadata(adapter, { enabled: false });
+      disableMetadataTable(adapter);
+      const disabledMeta = new InternalMetadata(adapter);
       expect(disabledMeta.enabled).toBe(false);
 
       // createTable + createTableAndSetFlags silently no-op (Rails'
@@ -1406,9 +1416,8 @@ export class CreatePosts extends Migration {
             })("CreateWidgets", "20260101000000"),
         },
       ];
-      const migrator = new Migrator(adapter, migrations, {
-        internalMetadataEnabled: false,
-      });
+      disableMetadataTable(adapter);
+      const migrator = new Migrator(adapter, migrations);
 
       // Migrate should succeed and NOT throw EnvironmentStorageError
       // despite the stamping call site being hit.
@@ -1426,7 +1435,7 @@ export class CreatePosts extends Migration {
       const context = new MigrationContext(
         [],
         new SchemaMigration(adapter),
-        new InternalMetadata(adapter, { enabled: false }),
+        new InternalMetadata(adapter),
       );
       expect(await context.lastStoredEnvironment()).toBeNull();
     } finally {
@@ -1444,15 +1453,16 @@ export class CreatePosts extends Migration {
     try {
       // Seed a real metadata table + environment value with a separate
       // enabled=true instance.
-      const enabledMeta = new InternalMetadata(adapter, { enabled: true });
+      const enabledMeta = new InternalMetadata(adapter);
       await enabledMeta.createTable();
       await enabledMeta.set("environment", "production");
+      disableMetadataTable(adapter);
 
       // Disabled context should still report null (no stale read).
       const context = new MigrationContext(
         [],
         new SchemaMigration(adapter),
-        new InternalMetadata(adapter, { enabled: false }),
+        new InternalMetadata(adapter),
       );
       expect(await context.lastStoredEnvironment()).toBeNull();
       expect(await context.protectedEnvironment()).toBe(false);

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -1353,11 +1353,7 @@ export class CreatePosts extends Migration {
     }
   });
 
-  /**
-   * Give a bare adapter a pool whose db_config opts out of metadata storage.
-   * `InternalMetadata#enabled?` is `@pool.db_config.use_metadata_table?`
-   * (internal_metadata.rb:35-36), so this is how Rails turns it off.
-   */
+  // internal_metadata.rb:35-36 — `enabled?` is `@pool.db_config.use_metadata_table?`.
   function disableMetadataTable(adapter: unknown): void {
     (adapter as { pool: unknown }).pool = { dbConfig: { useMetadataTable: false } };
   }

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -375,17 +375,11 @@ interface RunOptions {
 function createMigrator(
   adapter: DatabaseAdapter,
   migrations: Awaited<ReturnType<typeof discoverMigrations>>,
-  raw?: RawConfig,
 ): Migrator {
   const envName = resolveEnv();
   return new Migrator(adapter, migrations, {
     environment: envName,
-    internalMetadataEnabled: metadataTableEnabled(raw),
   });
-}
-
-function metadataTableEnabled(raw?: RawConfig): boolean {
-  return raw == null || (raw as { useMetadataTable?: boolean }).useMetadataTable !== false;
 }
 
 async function runMigrate(
@@ -400,7 +394,7 @@ async function runMigrate(
     return;
   }
 
-  const migrator = createMigrator(adapter, migrations, raw);
+  const migrator = createMigrator(adapter, migrations);
   await migrator.migrate(targetVersion ?? null);
 
   const pending = await migrator.pendingMigrations();
@@ -600,7 +594,6 @@ async function withMigrationTasksForDb(
   if (opts?.afterPending) {
     const migrator = new Migrator(ctx.adapter, migrations, {
       environment: ctx.config.envName,
-      internalMetadataEnabled: ctx.config.useMetadataTable,
     });
     opts.afterPending((await migrator.pendingMigrations()).length);
   }
@@ -659,7 +652,6 @@ async function runMigrateAll(targetVersion: string | null): Promise<void> {
           const migrations = migrationsFor.get(name) ?? [];
           const migrator = new Migrator(await pool.leaseConnection(), migrations, {
             environment: hashConfig.envName,
-            internalMetadataEnabled: hashConfig.useMetadataTable,
           });
           const pending = await migrator.pendingMigrations();
           if (pending.length === 0) console.log(`${prefix}All migrations are up to date.`);
@@ -744,7 +736,7 @@ export function dbCommand(): Command {
     .option("--database <name>", "Target a specific named database")
     .action(async (opts: DatabaseOpts) => {
       await forEachDatabase(opts, async ({ adapter, prefix, raw: dbRaw }) => {
-        const migrator = createMigrator(adapter, [], dbRaw);
+        const migrator = createMigrator(adapter, []);
         const version = await migrator.currentVersionReadOnly();
         console.log(`${prefix}Current version: ${version}`);
       });
@@ -757,9 +749,7 @@ export function dbCommand(): Command {
     .action(async (opts: DatabaseOpts) => {
       await forEachDatabase(opts, async ({ adapter, raw, prefix }) => {
         const envName = resolveEnv();
-        const internalMetadata = new InternalMetadata(adapter, {
-          enabled: metadataTableEnabled(raw),
-        });
+        const internalMetadata = new InternalMetadata(adapter);
         if (!internalMetadata.enabled) {
           const { EnvironmentStorageError } = await import("@blazetrails/activerecord");
           throw new EnvironmentStorageError();
@@ -801,7 +791,7 @@ export function dbCommand(): Command {
         const mDirs = await migrationsDirsForConfig(name, raw);
         const migrations = await discoverMigrationsFromDirs(mDirs);
         if (migrations.length === 0) return;
-        const migrator = createMigrator(adapter, migrations, raw);
+        const migrator = createMigrator(adapter, migrations);
         // Use the read-only pending check so running this in a
         // production-health-check context (e.g. before deploying) doesn't
         // silently create schema_migrations / ar_internal_metadata.
@@ -1011,7 +1001,7 @@ export function dbCommand(): Command {
           return;
         }
 
-        const migrator = createMigrator(adapter, migrations, raw);
+        const migrator = createMigrator(adapter, migrations);
         const statuses = await migrator.migrationsStatus();
 
         console.log("");

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -735,7 +735,7 @@ export function dbCommand(): Command {
     .description("Print the current schema version")
     .option("--database <name>", "Target a specific named database")
     .action(async (opts: DatabaseOpts) => {
-      await forEachDatabase(opts, async ({ adapter, prefix, raw: dbRaw }) => {
+      await forEachDatabase(opts, async ({ adapter, prefix }) => {
         const migrator = createMigrator(adapter, []);
         const version = await migrator.currentVersionReadOnly();
         console.log(`${prefix}Current version: ${version}`);
@@ -747,7 +747,7 @@ export function dbCommand(): Command {
     .description("Stamp the schema with the current environment name")
     .option("--database <name>", "Target a specific named database")
     .action(async (opts: DatabaseOpts) => {
-      await forEachDatabase(opts, async ({ adapter, raw, prefix }) => {
+      await forEachDatabase(opts, async ({ adapter, prefix }) => {
         const envName = resolveEnv();
         const internalMetadata = new InternalMetadata(adapter);
         if (!internalMetadata.enabled) {


### PR DESCRIPTION
Two convergences in the migration/metadata stack.

## `_runMigration` no longer duplicates `record_environment`

`Migrator#_runMigration` stamped `ar_internal_metadata[:environment]` inside the
DDL transaction of **every executed migration**. Rails'
`execute_migration_in_transaction`
(`activerecord/lib/active_record/migration.rb:1528-1537`) does only
`migration.migrate(@direction)` + `record_version_state_after_migrating`; the
environment is stamped once per run by `record_environment` (`:1508-1512`),
before the migration loop, which trails already calls from both
`runWithoutLock` and `migrateWithoutLock`. An N-migration run was issuing N
redundant `ar_internal_metadata` writes.

New coverage in `migrator.trails.test.ts` asserts the write happens once for a
three-migration run.

## `InternalMetadata#enabled?` derives from the pool's db_config

Rails' `InternalMetadata#enabled?`
(`activerecord/lib/active_record/internal_metadata.rb:35-36`) is
`@pool.db_config.use_metadata_table?`. trails only honoured the flag when a
caller passed `{ enabled: dbConfig.useMetadataTable }` by hand, so every
construction site that forgot it silently ignored `useMetadataTable: false`.

The getter now reads it off `adapter.pool.dbConfig`, and the option is gone —
along with `Migrator`'s `internalMetadataEnabled` option, `schema.ts`'s
`adapterPool` helper, and the hand-threaded flag in `DatabaseTasks` and the
trailties `db` command. `ConnectionPool`'s adapter proxy now answers `pool`
with the pool itself instead of a `withConnection` dispatcher (`pool` is a data
property on every real adapter, not a method), so `pool.internalMetadata`
honours the flag too.

One arm stays divergent and is cited at the getter: a `NullPool` answers
`NULL_CONFIG`, whose every key is undefined (Rails' `NullConfig#method_missing`
returns nil), so Rails would read that as disabled. Rails never gets there — its
`InternalMetadata` is always built from a real pool — while trails builds one
over bare, NullPool-backed adapters throughout the test suite and the trailties
`db` commands. It converges once those call sites hold a pool
(`migration-context-collaborators-need-a-pool`).

`migration.test.ts`'s "internal metadata not used when not enabled" now mirrors
Rails' `migration_test.rb:726-744` — it swaps `use_metadata_table: false` into
the pool's db_config configuration hash and lets `enabled?` read it back.

## Scoped out of this PR

`check-current-protected-environment-uses-pool-migration-context` also asks for
`checkCurrentProtectedEnvironmentBang` to use `withTemporaryPool` +
`pool.migrationContext` (`tasks/database_tasks.rb:635-637`). That half is
blocked and filed as
`0051-migration-schema-statements-fidelity/check-current-protected-environment-pool-migration-context-blocked-on-adapter-proxy`:
`ConnectionPool#migrationContext` builds its collaborators over
`_getAdapterProxy()`, whose `get` trap routes every member through
`withConnection`, so `InternalMetadata#tableExists`' synchronous
`this._connection.toSql(sm)` comes back as a Promise and the query receives a
Promise instead of SQL. Measured on this branch: switching the check reds 11
tests with `NoEnvironmentInSchemaError`. The `NoDatabaseError` rescue placement
(`:648-649`) is blocked by the same eager-lease gap and rides along.

The other four stories in the bundle
(`retire-module-level-find-target-engine-exports`,
`migration-proxy-version-string-forces-call-site-coercion`,
`migration-context-collaborators-need-a-pool`,
`check-pending-has-no-file-update-checker-watcher`) were released back to the
queue — each is a deep change on its own and the four together are well past
the LOC ceiling for a single reviewable PR.

## Gates

`pnpm typecheck`, `pnpm lint`, `pnpm api:calls` (OK, 14 baselined),
`pnpm api:calls:wide` (OK), `pnpm api:extra --package activerecord
--novel-only` (no new novel entries — this PR only removes surface).
Suites: `packages/activerecord/src/tasks`, `connection-adapters`,
`migration.test.ts`, `migrator.test.ts`, `migrator.trails.test.ts`,
`internal-metadata.trails.test.ts`, `migration-context.trails.test.ts`,
`packages/trailties/src` — all green.

Closes-story: runmigration-duplicates-record-environment-per-migration
Closes-story: check-current-protected-environment-uses-pool-migration-context
