### PR TITLE
feat(i18n,activerecord,scripts): Date carries start and ns, break the encryption Context/Configurable cycle, typed parseForESLint

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@types/better-sqlite3": "^7.6.13",
     "@types/pg": "^8.18.0",
     "@types/sinonjs__fake-timers": "^15.0.1",
+    "@typescript-eslint/parser": "^8.57.0",
     "@vitest/coverage-v8": "^3.2.4",
     "@vitest/eslint-plugin": "^1.6.12",
     "ajv": "^8.18.0",

--- a/packages/activerecord/src/encryption/configurable.ts
+++ b/packages/activerecord/src/encryption/configurable.ts
@@ -1,6 +1,13 @@
 import { Config } from "./config.js";
-import { Contexts } from "./contexts.js";
-import { Context, contextProperties } from "./context.js";
+// Rails reads `ActiveRecord::Encryption.context` / `.reset_default_context`
+// (configurable.rb:17, 33, 36) — the `Contexts` module those come from. This
+// module imports their implementations from `context.js` rather than `Contexts`
+// itself: `Contexts` imports `EncryptingOnlyEncryptor` for
+// `protecting_encrypted_data` (contexts.rb:57), and that class `extends
+// Encryptor`, which imports this module. Going through `Contexts` would put
+// that `extends` inside an ESM cycle, where a graph entered at `encryptor.ts`
+// evaluates the subclass while `Encryptor` is still in TDZ.
+import { getEncryptionContext, resetDefaultContext, Context } from "./context.js";
 import { Cipher } from "./cipher.js";
 import type { EncryptorLike } from "./encryptor.js";
 import type { MessageSerializerLike } from "./message-serializer.js";
@@ -38,18 +45,34 @@ export class Configurable {
     _listeners = value;
   }
 
-  /**
-   * Rails' `Context::PROPERTIES.each { |name| delegate name, to: :context }`
-   * (configurable.rb:16-19). The readers are installed off that constant at the
-   * bottom of this file, so the set cannot drift from it; these declarations
-   * only give each one a type.
-   */
-  declare static readonly keyProvider: unknown;
-  declare static readonly keyGenerator: unknown;
-  declare static readonly cipher: Cipher;
-  declare static readonly messageSerializer: MessageSerializerLike | undefined;
-  declare static readonly encryptor: EncryptorLike | undefined;
-  declare static readonly frozenEncryption: boolean;
+  // Rails' `Context::PROPERTIES.each { |name| delegate name, to: :context }`
+  // (configurable.rb:16-19). Written out one reader per property rather than
+  // installed from the constant in a loop: `Context` is in TDZ while this
+  // module's body runs on a graph entered at `context.ts`. The set is held to
+  // `Context::PROPERTIES` by configurable.trails.test.ts instead.
+  static get keyProvider(): unknown {
+    return getEncryptionContext().keyProvider;
+  }
+
+  static get keyGenerator(): unknown {
+    return getEncryptionContext().keyGenerator;
+  }
+
+  static get cipher(): Cipher {
+    return getEncryptionContext().cipher as Cipher;
+  }
+
+  static get messageSerializer(): MessageSerializerLike | undefined {
+    return getEncryptionContext().messageSerializer;
+  }
+
+  static get encryptor(): EncryptorLike | undefined {
+    return getEncryptionContext().encryptor as EncryptorLike | undefined;
+  }
+
+  static get frozenEncryption(): boolean {
+    return getEncryptionContext().frozenEncryption;
+  }
 
   /**
    * Mirrors `Configurable.configure`
@@ -100,7 +123,7 @@ export class Configurable {
       }
     }
 
-    Contexts.resetDefaultContext();
+    resetDefaultContext();
 
     for (const [key, value] of Object.entries(properties)) {
       if (key === "primaryKey" || key === "deterministicKey" || key === "keyDerivationSalt") {
@@ -108,7 +131,7 @@ export class Configurable {
       }
       if (value === undefined) continue;
       if (!Context.PROPERTIES.includes(key)) continue;
-      (Contexts.context as unknown as Record<string, unknown>)[key] = value;
+      (getEncryptionContext() as unknown as Record<string, unknown>)[key] = value;
     }
   }
 
@@ -131,13 +154,4 @@ export class Configurable {
       listener(klass, name);
     }
   }
-}
-
-for (const name of contextProperties()) {
-  Object.defineProperty(Configurable, name, {
-    configurable: true,
-    get(): unknown {
-      return (Contexts.context as unknown as Record<string, unknown>)[name];
-    },
-  });
 }

--- a/packages/activerecord/src/encryption/configurable.ts
+++ b/packages/activerecord/src/encryption/configurable.ts
@@ -50,12 +50,11 @@ export class Configurable {
    * (configurable.rb:16-19), written out one reader per property.
    *
    * The loop cannot survive: it runs while this module's body does, and on a
-   * graph entered at `context.ts` — `index.ts` re-exports `context.js` before
-   * `configurable.js`, and `context.ts` imports this module for
-   * `build_default_key_provider` — `Context` is then still in TDZ, which is a
-   * `ReferenceError`, not a stale read. A hoisted function is what could be
-   * read there, and that function was the shim this story deletes. The set is
-   * instead held to `Context::PROPERTIES` at compile time, by
+   * graph entered at `context.ts` — which imports this module for
+   * `build_default_key_provider` — `Context` is still in TDZ then, a
+   * `ReferenceError` rather than a stale read. Only a hoisted function is
+   * readable there, and that function was the shim this story deletes. The set
+   * is held to `Context::PROPERTIES` at compile time instead, by
    * {@link DelegatedProperty} below.
    */
   static get keyProvider(): unknown {
@@ -168,8 +167,8 @@ export class Configurable {
 type DelegatedProperty = (typeof Context.PROPERTIES)[number];
 
 /**
- * @internal Type-only, erased at emit: `Pick` fails to compile the moment a
- * `Context::PROPERTIES` name has no reader on `Configurable`, which is the
- * drift the deleted `PROPERTIES.each` loop prevented by construction.
+ * @internal Type-only, erased at emit: `Pick` stops compiling the moment a
+ * `Context::PROPERTIES` name has no reader on `Configurable` — the drift the
+ * `PROPERTIES.each` loop prevented by construction.
  */
 declare const _contextPropertiesAreDelegated: Pick<typeof Configurable, DelegatedProperty>;

--- a/packages/activerecord/src/encryption/configurable.ts
+++ b/packages/activerecord/src/encryption/configurable.ts
@@ -45,11 +45,19 @@ export class Configurable {
     _listeners = value;
   }
 
-  // Rails' `Context::PROPERTIES.each { |name| delegate name, to: :context }`
-  // (configurable.rb:16-19). Written out one reader per property rather than
-  // installed from the constant in a loop: `Context` is in TDZ while this
-  // module's body runs on a graph entered at `context.ts`. The set is held to
-  // `Context::PROPERTIES` by configurable.trails.test.ts instead.
+  /**
+   * Rails' `Context::PROPERTIES.each { |name| delegate name, to: :context }`
+   * (configurable.rb:16-19), written out one reader per property.
+   *
+   * The loop cannot survive: it runs while this module's body does, and on a
+   * graph entered at `context.ts` — `index.ts` re-exports `context.js` before
+   * `configurable.js`, and `context.ts` imports this module for
+   * `build_default_key_provider` — `Context` is then still in TDZ, which is a
+   * `ReferenceError`, not a stale read. A hoisted function is what could be
+   * read there, and that function was the shim this story deletes. The set is
+   * instead held to `Context::PROPERTIES` at compile time, by
+   * {@link DelegatedProperty} below.
+   */
   static get keyProvider(): unknown {
     return getEncryptionContext().keyProvider;
   }
@@ -130,7 +138,7 @@ export class Configurable {
         continue;
       }
       if (value === undefined) continue;
-      if (!Context.PROPERTIES.includes(key)) continue;
+      if (!(Context.PROPERTIES as readonly string[]).includes(key)) continue;
       (getEncryptionContext() as unknown as Record<string, unknown>)[key] = value;
     }
   }
@@ -155,3 +163,13 @@ export class Configurable {
     }
   }
 }
+
+/** @internal One `Context::PROPERTIES` name (context.rb:13). */
+type DelegatedProperty = (typeof Context.PROPERTIES)[number];
+
+/**
+ * @internal Type-only, erased at emit: `Pick` fails to compile the moment a
+ * `Context::PROPERTIES` name has no reader on `Configurable`, which is the
+ * drift the deleted `PROPERTIES.each` loop prevented by construction.
+ */
+declare const _contextPropertiesAreDelegated: Pick<typeof Configurable, DelegatedProperty>;

--- a/packages/activerecord/src/encryption/context.ts
+++ b/packages/activerecord/src/encryption/context.ts
@@ -12,36 +12,6 @@ import { Encryptor } from "./encryptor.js";
 import { KeyGenerator } from "./key-generator.js";
 import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
 
-// EncryptingOnlyEncryptor extends the full Encryptor, which transitively imports
-// Configurable. Importing it eagerly here would create an eval-time cycle
-// (context → encrypting-only-encryptor → encryptor → configurable → contexts →
-// context). Inject the factory instead — registered by encryptable-record.ts at
-// module load, mirroring setGlobalPreviousSchemesFn's approach to the same problem.
-let _encryptingOnlyEncryptorFactory: (() => unknown) | undefined;
-
-/** @internal */
-export function setEncryptingOnlyEncryptorFactory(factory: () => unknown): void {
-  _encryptingOnlyEncryptorFactory = factory;
-}
-
-/**
- * @internal Rails `Context::PROPERTIES` (context.rb:13) as a hoisted function
- * so `configurable.ts` can read the names at module-eval time: the two modules
- * form a cycle, and whichever evaluates second sees the other's `class`/`const`
- * bindings in TDZ, while a function declaration is initialized at
- * instantiation. Read it as `Context.PROPERTIES`.
- */
-export function contextProperties(): string[] {
-  return [
-    "keyProvider",
-    "keyGenerator",
-    "cipher",
-    "messageSerializer",
-    "encryptor",
-    "frozenEncryption",
-  ];
-}
-
 /**
  * Holds the encryption configuration for a single context frame:
  * key provider, key generator, cipher, message serializer, encryptor,
@@ -55,7 +25,14 @@ export class Context {
    * defines on a Context. `Configurable.configure` tests against it for the
    * `respond_to?("#{name}=")` guard Rails uses (configurable.rb:35-37).
    */
-  static readonly PROPERTIES = contextProperties();
+  static readonly PROPERTIES = [
+    "keyProvider",
+    "keyGenerator",
+    "cipher",
+    "messageSerializer",
+    "encryptor",
+    "frozenEncryption",
+  ];
 
   private _keyProvider?: unknown;
   keyGenerator?: unknown;
@@ -88,8 +65,8 @@ export class Context {
   /**
    * @internal Rails `Context#build_default_key_provider` (context.rb:37-39).
    * `Configurable` is imported for this body alone — the import closes a cycle
-   * (context → configurable → contexts → context) that holds only because
-   * nothing in this module reads it at eval time.
+   * (context → configurable → context) that holds only because neither module
+   * reads the other at eval time.
    */
   private buildDefaultKeyProvider(): unknown {
     return new DerivedSecretKeyProvider(Configurable.config.primaryKey);
@@ -166,19 +143,6 @@ export function withEncryptionContext<T>(overrides: Partial<Context>, fn: () => 
 
 export function withoutEncryption<T>(fn: () => T): T {
   return withEncryptionContext({ encryptor: new NullEncryptor() }, fn);
-}
-
-export function protectingEncryptedData<T>(fn: () => T): T {
-  // The EncryptingOnlyEncryptor factory is registered by encryptable-record.ts,
-  // which is always loaded before any real protected-mode read/write/query. The
-  // NullEncryptor fallback applies only when context.ts is consumed in isolation
-  // (no encryption stack wired) — there the encryptor is never exercised, and
-  // frozenEncryption alone drives the observable behavior (write validation +
-  // encrypt/decrypt raising Configuration).
-  const encryptor = _encryptingOnlyEncryptorFactory
-    ? _encryptingOnlyEncryptorFactory()
-    : new NullEncryptor();
-  return withEncryptionContext({ encryptor, frozenEncryption: true }, fn);
 }
 
 export function getEncryptionContext(): Context {

--- a/packages/activerecord/src/encryption/context.ts
+++ b/packages/activerecord/src/encryption/context.ts
@@ -32,7 +32,7 @@ export class Context {
     "messageSerializer",
     "encryptor",
     "frozenEncryption",
-  ];
+  ] as const;
 
   private _keyProvider?: unknown;
   keyGenerator?: unknown;

--- a/packages/activerecord/src/encryption/contexts.ts
+++ b/packages/activerecord/src/encryption/contexts.ts
@@ -1,7 +1,6 @@
 import {
   withEncryptionContext as _withCtx,
   withoutEncryption as _withoutEnc,
-  protectingEncryptedData as _protecting,
   getEncryptionContext,
   getDefaultContext,
   setDefaultContext as _setDefaultContext,
@@ -9,6 +8,7 @@ import {
   resetDefaultContext as _resetDefaultContext,
   type Context,
 } from "./context.js";
+import { EncryptingOnlyEncryptor } from "./encrypting-only-encryptor.js";
 
 /**
  * Class-based API for managing encryption contexts. Delegates to the
@@ -30,7 +30,7 @@ export class Contexts {
   }
 
   static protectingEncryptedData<T>(fn: () => T): T {
-    return _protecting(fn);
+    return _withCtx({ encryptor: new EncryptingOnlyEncryptor(), frozenEncryption: true }, fn);
   }
 
   static get currentCustomContext(): Context | null {

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -1,10 +1,5 @@
 import { Scheme, type SchemeOptions } from "./scheme.js";
-import {
-  getEncryptionContext,
-  withoutEncryption as _withoutEncryption,
-  setEncryptingOnlyEncryptorFactory,
-} from "./context.js";
-import { EncryptingOnlyEncryptor } from "./encrypting-only-encryptor.js";
+import { getEncryptionContext, withoutEncryption as _withoutEncryption } from "./context.js";
 import { Configuration as ConfigurationError } from "./errors.js";
 import { LengthValidator, type Type } from "@blazetrails/activemodel";
 import { EncryptedAttributeType, setGlobalPreviousSchemesFn } from "./encrypted-attribute-type.js";
@@ -45,12 +40,6 @@ function schemeFor(options: SchemeOptions): Scheme {
 // Called at module load time — always runs before any EncryptedAttributeType
 // accesses previousTypes because this module is loaded via encryption.ts first.
 setGlobalPreviousSchemesFn(globalPreviousSchemesFor);
-
-// Register the EncryptingOnlyEncryptor factory so protectingEncryptedData can
-// construct it without an eval-time import cycle. This module is loaded via
-// encryption.ts before any protectingEncryptedData call, and after Configurable
-// is fully defined (so the Encryptor import chain resolves cleanly).
-setEncryptingOnlyEncryptorFactory(() => new EncryptingOnlyEncryptor());
 
 const ORIGINAL_ATTRIBUTE_PREFIX = "original_";
 

--- a/packages/i18n/src/date.trails.test.ts
+++ b/packages/i18n/src/date.trails.test.ts
@@ -512,12 +512,9 @@ describe("Date", () => {
     expect(RubyDate.parse("1582-10-10", true, RubyDate.GREGORIAN).start).toBe(RubyDate.GREGORIAN);
     expect(RubyDate.parse("1582-10-10", true, RubyDate.GREGORIAN).toS()).toBe("1582-10-10");
     expect(new RubyDate(2001, 2, 3, RubyDate.ENGLAND).start).toBe(2361222);
-  });
-
-  it("builds a Julian date that has no proleptic-Gregorian counterpart", () => {
-    const d = RubyDate.parse("1500-02-29", true, RubyDate.JULIAN);
-    expect(d.toS()).toBe("1500-02-29");
-    expect(d.start).toBe(RubyDate.JULIAN);
+    // 1500 is not a leap year in the proleptic Gregorian calendar Temporal uses.
+    expect(RubyDate.parse("1500-02-29", true, RubyDate.JULIAN).toS()).toBe("1500-02-29");
+    expect(RubyDate.parse("1500-02-29", true, RubyDate.JULIAN).start).toBe(RubyDate.JULIAN);
   });
 
   it("answers julian? off the start, and the infinite starts off their own sign", () => {

--- a/packages/i18n/src/date.trails.test.ts
+++ b/packages/i18n/src/date.trails.test.ts
@@ -500,6 +500,46 @@ describe("Date", () => {
     expect(RubyDate.parse("2008070").strftime("%Y-%m-%d")).toBe("2008-03-10");
     expect(RubyDate.parse("2001-W05-6").strftime("%Y-%m-%d")).toBe("2001-02-03");
   });
+
+  // Every expectation below is `ruby 3.3.11 -rdate` output.
+  it("names the day either side of the reform off a Julian day", () => {
+    expect(RubyDate.jd(2299160).toS()).toBe("1582-10-04");
+    expect(RubyDate.jd(2299161).toS()).toBe("1582-10-15");
+    expect(RubyDate.jd(2299160).yday).toBe(277);
+  });
+
+  it("carries the start the date was resolved under, rather than defaulting it to ITALY", () => {
+    expect(RubyDate.parse("1582-10-10", true, RubyDate.GREGORIAN).start).toBe(RubyDate.GREGORIAN);
+    expect(RubyDate.parse("1582-10-10", true, RubyDate.GREGORIAN).toS()).toBe("1582-10-10");
+    expect(new RubyDate(2001, 2, 3, RubyDate.ENGLAND).start).toBe(2361222);
+  });
+
+  it("builds a Julian date that has no proleptic-Gregorian counterpart", () => {
+    const d = RubyDate.parse("1500-02-29", true, RubyDate.JULIAN);
+    expect(d.toS()).toBe("1500-02-29");
+    expect(d.start).toBe(RubyDate.JULIAN);
+  });
+
+  it("answers julian? off the start, and the infinite starts off their own sign", () => {
+    expect(RubyDate.jd(2299160).isJulian()).toBe(true);
+    expect(RubyDate.jd(2299160).isGregorian()).toBe(false);
+    expect(RubyDate.jd(2299161).isJulian()).toBe(false);
+    expect(new RubyDate(2000, 2, 3).isJulian()).toBe(false);
+    expect(new RubyDate(2000, 2, 3).julian().isJulian()).toBe(true);
+    expect(new RubyDate(2000, 2, 3).gregorian().isJulian()).toBe(false);
+  });
+
+  it("re-reads the same Julian day under a new start", () => {
+    expect(new RubyDate(2000, 2, 3).newStart(RubyDate.JULIAN).toS()).toBe("2000-01-21");
+    expect(new RubyDate(2001, 2, 3).england().start).toBe(2361222);
+    expect(new RubyDate(2001, 2, 3).italy().start).toBe(RubyDate.ITALY);
+    expect(new RubyDate(2001, 2, 3).gregorian().start).toBe(RubyDate.GREGORIAN);
+  });
+
+  it("raises Date::Error on a civil date the reform deleted", () => {
+    expect(() => new RubyDate(1582, 10, 10)).toThrow(RubyDate.Error);
+    expect(new RubyDate(1582, 10, 10, RubyDate.GREGORIAN).toS()).toBe("1582-10-10");
+  });
 });
 
 describe("DateTime", () => {

--- a/packages/i18n/src/date.ts
+++ b/packages/i18n/src/date.ts
@@ -2240,7 +2240,7 @@ export class Date {
    * civil date `c_valid_civil_p` rejects — 1582-10-10 under `Date::ITALY` is a
    * day the reform deleted.
    */
-  constructor(year: number, month: number, day: number, start: number = DEFAULT_SG) {
+  constructor(year = -4712, month = 1, day = 1, start: number = DEFAULT_SG) {
     const r = cValidCivilP(year, month, day, start);
     if (r === null) throw new DateError("invalid date");
     this.#jd = r[0];
@@ -2251,6 +2251,12 @@ export class Date {
    * Ruby `Date.jd(jd = 0, start = Date::ITALY)` (ruby/date, `date_core.c`
    * `date_s_jd`), the date the given Julian day names under `start`: Gregorian
    * at or after it, Julian before.
+   *
+   * `date_s_jd` writes the Julian day straight into a freshly allocated
+   * `SimpleDateData`; a TS class has one constructor, and it is `Date.new`'s,
+   * so the day is named as a civil date and rebuilt through it. `c_jd_to_civil`
+   * and `c_civil_to_jd` are exact inverses under the same `sg` — it is the
+   * round trip `c_valid_civil_p` itself checks — so the two agree.
    */
   static jd(jd = 0, start: number = DEFAULT_SG): Date {
     const [y, m, d] = cJdToCivil(jd, start);
@@ -2420,6 +2426,10 @@ export class Date {
    * Ruby `Date#julian?` (ruby/date, `date_core.c` `d_lite_julian_p` over
    * `m_julian_p`, `date_core.c:1683-1702`), which answers the `start` itself
    * for the two infinite ones and compares the Julian day against it otherwise.
+   *
+   * Spelled `isJulian` rather than `julian` — the second candidate the
+   * predicate rule offers — because `Date#julian` is the `new_start` method
+   * below. Same for `isGregorian`.
    */
   isJulian(): boolean {
     if (!Number.isFinite(this.#sg)) return this.#sg === JULIAN;
@@ -2435,6 +2445,11 @@ export class Date {
    * Ruby `Date#new_start(start = Date::ITALY)` (ruby/date, `date_core.c`
    * `d_lite_new_start` over `dup_obj_with_new_start`), a copy of the date
    * naming the same Julian day under a different reform start.
+   *
+   * `dup_obj_with_new_start` dups the receiver, so a `DateTime` keeps its class
+   * and its time of day; this answers a `Date`, because `DateTime` carries no
+   * `start` to dup yet. Story
+   * `0074-i18n-parity/datetime-new-start-preserves-the-receiver`.
    */
   newStart(start: number = DEFAULT_SG): Date {
     return Date.jd(this.#jd, start);

--- a/packages/i18n/src/date.ts
+++ b/packages/i18n/src/date.ts
@@ -2182,8 +2182,7 @@ export function dNewByFrags(hash: DateParts, sg: number): Date {
   }
 
   if (jd === null) throw new DateError("invalid date");
-  const [y, m, d] = cJdToCivil(jd, sg);
-  return new Date(y, m, d);
+  return Date.jd(jd, sg);
 }
 
 /**

--- a/packages/i18n/src/date.ts
+++ b/packages/i18n/src/date.ts
@@ -1763,11 +1763,12 @@ function mod(n: number, d: number): number {
  * arithmetic, with the century correction `b` taken back off again for a day
  * before the reform, which is a Julian one.
  *
- * Ruby's `*ns` out-param — which side of the reform the day landed on — has no
- * counterpart here: this port's {@link Date} carries no `sg`/`ns` state of its
- * own to answer `Date#julian?` off.
+ * `ns` is Ruby's out-param saying which side of the reform the day landed on.
+ * Every `c_*_to_jd` answers one and every `c_valid_*_p` carries it out, so the
+ * port does too, and it is discarded at the `rt__valid_*_p` boundary exactly
+ * where ruby/date discards it (`date_core.c:4126-4139`).
  */
-function cCivilToJd(y: number, m: number, d: number, sg: number): number {
+function cCivilToJd(y: number, m: number, d: number, sg: number): [rjd: number, ns: number] {
   if (m <= 2) {
     y -= 1;
     m += 12;
@@ -1775,8 +1776,12 @@ function cCivilToJd(y: number, m: number, d: number, sg: number): number {
   const a = Math.floor(y / 100);
   const b = 2 - a + Math.floor(a / 4);
   let jd = Math.floor(365.25 * (y + 4716)) + Math.floor(30.6001 * (m + 1)) + d + b - 1524;
-  if (jd < sg) jd -= b;
-  return jd;
+  let ns: number;
+  if (jd < sg) {
+    jd -= b;
+    ns = 0;
+  } else ns = 1;
+  return [jd, ns];
 }
 
 /**
@@ -1814,10 +1819,10 @@ function cJdToCivil(jd: number, sg: number): [ry: number, rm: number, rdom: numb
  * assume 1 January exists — the reform deletes real days, 1582-10-05..14 under
  * `Date::ITALY` — so it scans January for the first `c_valid_civil_p` accepts.
  */
-function cFindFdoy(y: number, sg: number): number | null {
+function cFindFdoy(y: number, sg: number): [rjd: number, ns: number] | null {
   for (let d = 1; d < 31; d++) {
-    const rjd = cValidCivilP(y, 1, d, sg);
-    if (rjd !== null) return rjd;
+    const r = cValidCivilP(y, 1, d, sg);
+    if (r !== null) return r;
   }
   return null;
 }
@@ -1830,20 +1835,25 @@ function cFindFdoy(y: number, sg: number): number | null {
  * negative `d` back from the last day of that month, rejected when the walk
  * leaves the month it started in.
  */
-function cValidCivilP(y: number, m: number, d: number, sg: number): number | null {
+function cValidCivilP(
+  y: number,
+  m: number,
+  d: number,
+  sg: number,
+): [rjd: number, ns: number] | null {
   if (m < 0) m += 13;
   if (m < 1 || m > 12) return null;
   if (d < 0) {
-    const rjd2 = cFindLdom(y, m, sg);
-    if (rjd2 === null) return null;
-    const [ry2, rm2, rd2] = cJdToCivil(rjd2 + d + 1, sg);
+    const ldom = cFindLdom(y, m, sg);
+    if (ldom === null) return null;
+    const [ry2, rm2, rd2] = cJdToCivil(ldom[0] + d + 1, sg);
     if (ry2 !== y || rm2 !== m) return null;
     d = rd2;
   }
-  const rjd = cCivilToJd(y, m, d, sg);
+  const [rjd, ns] = cCivilToJd(y, m, d, sg);
   const [ry, rm, rd] = cJdToCivil(rjd, sg);
   if (ry !== y || rm !== m || rd !== d) return null;
-  return rjd;
+  return [rjd, ns];
 }
 
 /**
@@ -1851,10 +1861,10 @@ function cValidCivilP(y: number, m: number, d: number, sg: number): number | nul
  * of the last day of year `y`, or `null` when there is none: the same scan as
  * {@link cFindFdoy} backwards from 31 December.
  */
-function cFindLdoy(y: number, sg: number): number | null {
+function cFindLdoy(y: number, sg: number): [rjd: number, ns: number] | null {
   for (let i = 0; i < 30; i++) {
-    const rjd = cValidCivilP(y, 12, 31 - i, sg);
-    if (rjd !== null) return rjd;
+    const r = cValidCivilP(y, 12, 31 - i, sg);
+    if (r !== null) return r;
   }
   return null;
 }
@@ -1863,27 +1873,28 @@ function cFindLdoy(y: number, sg: number): number | null {
  * @internal `date_core.c` `c_find_ldom` (`date_core.c:490-500`), the same
  * backwards scan from the 31st over month `m` rather than December.
  */
-function cFindLdom(y: number, m: number, sg: number): number | null {
+function cFindLdom(y: number, m: number, sg: number): [rjd: number, ns: number] | null {
   for (let i = 0; i < 30; i++) {
-    const rjd = cValidCivilP(y, m, 31 - i, sg);
-    if (rjd !== null) return rjd;
+    const r = cValidCivilP(y, m, 31 - i, sg);
+    if (r !== null) return r;
   }
   return null;
 }
 
 /** @internal `date_core.c` `c_ordinal_to_jd` (`date_core.c:556-564`), the `d`th day of year `y`. */
-function cOrdinalToJd(y: number, d: number, sg: number): number | null {
-  const rjd = cFindFdoy(y, sg);
-  if (rjd === null) return null;
-  return rjd + d - 1;
+function cOrdinalToJd(y: number, d: number, sg: number): [rjd: number, ns: number] | null {
+  const fdoy = cFindFdoy(y, sg);
+  if (fdoy === null) return null;
+  const rjd = fdoy[0] + d - 1;
+  return [rjd, rjd < sg ? 0 : 1];
 }
 
 /** @internal `date_core.c` `c_jd_to_ordinal` (`date_core.c:566-575`), the inverse of {@link cOrdinalToJd}. */
 function cJdToOrdinal(jd: number, sg: number): [ry: number, rd: number] | null {
   const ry = cJdToCivil(jd, sg)[0];
-  const rjd = cFindFdoy(ry, sg);
-  if (rjd === null) return null;
-  return [ry, jd - rjd + 1];
+  const fdoy = cFindFdoy(ry, sg);
+  if (fdoy === null) return null;
+  return [ry, jd - fdoy[0] + 1];
 }
 
 /**
@@ -1892,19 +1903,19 @@ function cJdToOrdinal(jd: number, sg: number): [ry: number, rd: number] | null {
  * `d` counts back from the last day of the year — `-1` is 31 December — and is
  * rejected when that walk leaves `y`.
  */
-function cValidOrdinalP(y: number, d: number, sg: number): number | null {
+function cValidOrdinalP(y: number, d: number, sg: number): [rjd: number, ns: number] | null {
   if (d < 0) {
-    const rjd2 = cFindLdoy(y, sg);
-    if (rjd2 === null) return null;
-    const ro2 = cJdToOrdinal(rjd2 + d + 1, sg);
+    const ldoy = cFindLdoy(y, sg);
+    if (ldoy === null) return null;
+    const ro2 = cJdToOrdinal(ldoy[0] + d + 1, sg);
     if (ro2 === null || ro2[0] !== y) return null;
     d = ro2[1];
   }
-  const rjd = cOrdinalToJd(y, d, sg);
-  if (rjd === null) return null;
-  const ro = cJdToOrdinal(rjd, sg);
+  const r = cOrdinalToJd(y, d, sg);
+  if (r === null) return null;
+  const ro = cJdToOrdinal(r[0], sg);
   if (ro === null || ro[0] !== y || ro[1] !== d) return null;
-  return rjd;
+  return r;
 }
 
 /**
@@ -1913,26 +1924,32 @@ function cValidOrdinalP(y: number, d: number, sg: number): number | null {
  * from Monday: the year's first day floored back to the Monday on or before it,
  * then `w` weeks and `d` days on.
  */
-function cCommercialToJd(y: number, w: number, d: number, sg: number): number | null {
-  let rjd2 = cFindFdoy(y, sg);
-  if (rjd2 === null) return null;
-  rjd2 += 3;
-  return rjd2 - mod(rjd2 - 1 + 1, 7) + 7 * (w - 1) + (d - 1);
+function cCommercialToJd(
+  y: number,
+  w: number,
+  d: number,
+  sg: number,
+): [rjd: number, ns: number] | null {
+  const fdoy = cFindFdoy(y, sg);
+  if (fdoy === null) return null;
+  const rjd2 = fdoy[0] + 3;
+  const rjd = rjd2 - mod(rjd2 - 1 + 1, 7) + 7 * (w - 1) + (d - 1);
+  return [rjd, rjd < sg ? 0 : 1];
 }
 
 /** @internal `date_core.c` `c_jd_to_commercial` (`date_core.c:590-609`), the inverse of {@link cCommercialToJd}. */
 function cJdToCommercial(jd: number, sg: number): [ry: number, rw: number, rd: number] | null {
   const a = cJdToCivil(jd - 3, sg)[0];
   let ry: number;
-  let rjd2 = cCommercialToJd(a + 1, 1, 1, sg);
-  if (rjd2 === null) return null;
-  if (jd >= rjd2) ry = a + 1;
+  let c2 = cCommercialToJd(a + 1, 1, 1, sg);
+  if (c2 === null) return null;
+  if (jd >= c2[0]) ry = a + 1;
   else {
-    rjd2 = cCommercialToJd(a, 1, 1, sg);
-    if (rjd2 === null) return null;
+    c2 = cCommercialToJd(a, 1, 1, sg);
+    if (c2 === null) return null;
     ry = a;
   }
-  const rw = 1 + div(jd - rjd2, 7);
+  const rw = 1 + div(jd - c2[0], 7);
   let rd = mod(jd + 1, 7);
   if (rd === 0) rd = 7;
   return [ry, rw, rd];
@@ -1944,22 +1961,27 @@ function cJdToCommercial(jd: number, sg: number): [ry: number, rw: number, rd: n
  * of the commercial year before rebuilding the date and rejecting it if the
  * round-trip does not name the same `y`/`w`/`d` back.
  */
-function cValidCommercialP(y: number, w: number, d: number, sg: number): number | null {
+function cValidCommercialP(
+  y: number,
+  w: number,
+  d: number,
+  sg: number,
+): [rjd: number, ns: number] | null {
   if (d < 0) d += 8;
   if (w < 0) {
-    const rjd2 = cCommercialToJd(y + 1, 1, 1, sg);
-    if (rjd2 === null) return null;
-    const c2 = cJdToCommercial(rjd2 + w * 7, sg);
+    const r2 = cCommercialToJd(y + 1, 1, 1, sg);
+    if (r2 === null) return null;
+    const c2 = cJdToCommercial(r2[0] + w * 7, sg);
     if (c2 === null || c2[0] !== y) return null;
     w = c2[1];
   }
-  const rjd = cCommercialToJd(y, w, d, sg);
-  if (rjd === null) return null;
-  const c = cJdToCommercial(rjd, sg);
+  const r = cCommercialToJd(y, w, d, sg);
+  if (r === null) return null;
+  const c = cJdToCommercial(r[0], sg);
   if (c === null) return null;
   const [ry, rw, rd] = c;
   if (y !== ry || w !== rw || d !== rd) return null;
-  return rjd;
+  return r;
 }
 
 /**
@@ -1970,11 +1992,18 @@ function cValidCommercialP(y: number, w: number, d: number, sg: number): number 
  * partial week before the year's first one. Week `0` is therefore empty in a
  * year whose 1 January is itself an `f`-day: there, 1 January opens week `1`.
  */
-function cWeeknumToJd(y: number, w: number, d: number, f: number, sg: number): number | null {
-  let rjd2 = cFindFdoy(y, sg);
-  if (rjd2 === null) return null;
-  rjd2 += 6;
-  return rjd2 - mod(rjd2 - f + 1, 7) - 7 + 7 * w + d;
+function cWeeknumToJd(
+  y: number,
+  w: number,
+  d: number,
+  f: number,
+  sg: number,
+): [rjd: number, ns: number] | null {
+  const fdoy = cFindFdoy(y, sg);
+  if (fdoy === null) return null;
+  const rjd2 = fdoy[0] + 6;
+  const rjd = rjd2 - mod(rjd2 - f + 1, 7) - 7 + 7 * w + d;
+  return [rjd, rjd < sg ? 0 : 1];
 }
 
 /** @internal `date_core.c` `c_jd_to_weeknum` (`date_core.c:621-634`), the inverse of {@link cWeeknumToJd}. */
@@ -1984,9 +2013,9 @@ function cJdToWeeknum(
   sg: number,
 ): [ry: number, rw: number, rd: number] | null {
   const ry = cJdToCivil(jd, sg)[0];
-  let rjd = cFindFdoy(ry, sg);
-  if (rjd === null) return null;
-  rjd += 6;
+  const fdoy = cFindFdoy(ry, sg);
+  if (fdoy === null) return null;
+  const rjd = fdoy[0] + 6;
   const j = jd - (rjd - mod(rjd - f + 1, 7)) + 7;
   return [ry, div(j, 7), mod(j, 7)];
 }
@@ -1998,22 +2027,28 @@ function cJdToWeeknum(
  * rather than a `1`..`7` one, so a negative day takes `7` where the commercial
  * one takes `8`.
  */
-function cValidWeeknumP(y: number, w: number, d: number, f: number, sg: number): number | null {
+function cValidWeeknumP(
+  y: number,
+  w: number,
+  d: number,
+  f: number,
+  sg: number,
+): [rjd: number, ns: number] | null {
   if (d < 0) d += 7;
   if (w < 0) {
-    const rjd2 = cWeeknumToJd(y + 1, 1, f, f, sg);
-    if (rjd2 === null) return null;
-    const w2 = cJdToWeeknum(rjd2 + w * 7, f, sg);
+    const r2 = cWeeknumToJd(y + 1, 1, f, f, sg);
+    if (r2 === null) return null;
+    const w2 = cJdToWeeknum(r2[0] + w * 7, f, sg);
     if (w2 === null || w2[0] !== y) return null;
     w = w2[1];
   }
-  const rjd = cWeeknumToJd(y, w, d, f, sg);
-  if (rjd === null) return null;
-  const wn = cJdToWeeknum(rjd, f, sg);
+  const r = cWeeknumToJd(y, w, d, f, sg);
+  if (r === null) return null;
+  const wn = cJdToWeeknum(r[0], f, sg);
   if (wn === null) return null;
   const [ry, rw, rd] = wn;
   if (y !== ry || w !== rw || d !== rd) return null;
-  return rjd;
+  return r;
 }
 
 /**
@@ -2032,7 +2067,7 @@ function rtValidJdP(jd: number, _sg: number): number {
  *
  */
 function rtValidOrdinalP(y: number, d: number, sg: number): number | null {
-  return cValidOrdinalP(y, d, sg);
+  return cValidOrdinalP(y, d, sg)?.[0] ?? null;
 }
 
 /**
@@ -2041,7 +2076,7 @@ function rtValidOrdinalP(y: number, d: number, sg: number): number | null {
  * raising so its caller can fall through to the next kind of date.
  */
 function rtValidCivilP(y: number, m: number, d: number, sg: number): number | null {
-  return cValidCivilP(y, m, d, sg);
+  return cValidCivilP(y, m, d, sg)?.[0] ?? null;
 }
 
 /**
@@ -2088,7 +2123,7 @@ function rtValidDateFragsP(parts: DateParts, sg: number): number | null {
     }
     if (wday !== undefined && parts.cweek !== undefined && parts.cwyear !== undefined) {
       const d = cValidCommercialP(parts.cwyear, parts.cweek, wday, sg);
-      if (d !== null) return d;
+      if (d !== null) return d[0];
     }
   }
 
@@ -2100,7 +2135,7 @@ function rtValidDateFragsP(parts: DateParts, sg: number): number | null {
     }
     if (wday !== undefined && parts.wnum0 !== undefined && parts.year !== undefined) {
       const d = cValidWeeknumP(parts.year, parts.wnum0, wday, 0, sg);
-      if (d !== null) return d;
+      if (d !== null) return d[0];
     }
   }
 
@@ -2111,7 +2146,7 @@ function rtValidDateFragsP(parts: DateParts, sg: number): number | null {
 
     if (wday !== undefined && parts.wnum1 !== undefined && parts.year !== undefined) {
       const d = cValidWeeknumP(parts.year, parts.wnum1, wday, 1, sg);
-      if (d !== null) return d;
+      if (d !== null) return d[0];
     }
   }
   return null;
@@ -2189,12 +2224,37 @@ export class Date {
   /** Ruby `Date::GREGORIAN` (ruby/date, `date_core.c:189`), the proleptic Gregorian calendar. */
   static GREGORIAN = GREGORIAN;
 
-  /** @internal Ruby's `::Date` value, which has no public reader. */
-  readonly #plain: Temporal.PlainDate;
+  /**
+   * @internal `SimpleDateData`'s `jd` and `sg` (`date_core.c:203-213`), the
+   * state ruby/date carries: the Julian day, and the calendar-reform start it
+   * is read under. A `Temporal.PlainDate` cannot stand in for the pair — it is
+   * proleptic Gregorian, so a Julian date such as 1500-02-29 has no
+   * `Temporal.PlainDate` at all.
+   */
+  readonly #jd: number;
+  readonly #sg: number;
 
-  /** Ruby `Date.new(year, month, day)`. */
-  constructor(year: number, month: number, day: number) {
-    this.#plain = new Temporal.PlainDate(year, month, day);
+  /**
+   * Ruby `Date.new(year = -4712, month = 1, mday = 1, start = Date::ITALY)`
+   * (ruby/date, `date_core.c` `date_s_civil`), which raises `Date::Error` on a
+   * civil date `c_valid_civil_p` rejects — 1582-10-10 under `Date::ITALY` is a
+   * day the reform deleted.
+   */
+  constructor(year: number, month: number, day: number, start: number = DEFAULT_SG) {
+    const r = cValidCivilP(year, month, day, start);
+    if (r === null) throw new DateError("invalid date");
+    this.#jd = r[0];
+    this.#sg = start;
+  }
+
+  /**
+   * Ruby `Date.jd(jd = 0, start = Date::ITALY)` (ruby/date, `date_core.c`
+   * `date_s_jd`), the date the given Julian day names under `start`: Gregorian
+   * at or after it, Julian before.
+   */
+  static jd(jd = 0, start: number = DEFAULT_SG): Date {
+    const [y, m, d] = cJdToCivil(jd, start);
+    return new Date(y, m, d, start);
   }
 
   /**
@@ -2205,10 +2265,9 @@ export class Date {
    * 2001-12-31.
    */
   static ordinal(year = -4712, yday = 1, start: number = DEFAULT_SG): Date {
-    const jd = cValidOrdinalP(year, yday, start);
-    if (jd === null) throw new DateError("invalid date");
-    const [y, m, d] = cJdToCivil(jd, start);
-    return new Date(y, m, d);
+    const r = cValidOrdinalP(year, yday, start);
+    if (r === null) throw new DateError("invalid date");
+    return Date.jd(r[0], start);
   }
 
   /**
@@ -2219,10 +2278,7 @@ export class Date {
    * from the month's end, so `Date.civil(2001, -1, -1)` is 2001-12-31.
    */
   static civil(year = -4712, month = 1, mday = 1, start: number = DEFAULT_SG): Date {
-    const jd = cValidCivilP(year, month, mday, start);
-    if (jd === null) throw new DateError("invalid date");
-    const [y, m, d] = cJdToCivil(jd, start);
-    return new Date(y, m, d);
+    return new Date(year, month, mday, start);
   }
 
   /**
@@ -2233,10 +2289,9 @@ export class Date {
    * the commercial year, so `Date.commercial(2001, -1, -1)` is 2001-12-30.
    */
   static commercial(cwyear = -4712, cweek = 1, cwday = 1, start: number = DEFAULT_SG): Date {
-    const jd = cValidCommercialP(cwyear, cweek, cwday, start);
-    if (jd === null) throw new DateError("invalid date");
-    const [y, m, d] = cJdToCivil(jd, start);
-    return new Date(y, m, d);
+    const r = cValidCommercialP(cwyear, cweek, cwday, start);
+    if (r === null) throw new DateError("invalid date");
+    return Date.jd(r[0], start);
   }
 
   /**
@@ -2328,28 +2383,86 @@ export class Date {
   }
 
   get year(): number {
-    return this.#plain.year;
+    return cJdToCivil(this.#jd, this.#sg)[0];
   }
 
   get mon(): number {
-    return this.#plain.month;
+    return cJdToCivil(this.#jd, this.#sg)[1];
   }
 
   get month(): number {
-    return this.#plain.month;
+    return cJdToCivil(this.#jd, this.#sg)[1];
   }
 
   get day(): number {
-    return this.#plain.day;
+    return cJdToCivil(this.#jd, this.#sg)[2];
   }
 
-  /** Ruby counts Sunday as 0; `Temporal.PlainDate#dayOfWeek` counts Monday as 1. */
+  /** `date_core.c` `c_jd_to_wday` (`date_core.c:636-640`), Sunday as `0`. */
   get wday(): number {
-    return this.#plain.dayOfWeek % 7;
+    return mod(this.#jd + 1, 7);
   }
 
   get yday(): number {
-    return this.#plain.dayOfYear;
+    return cJdToOrdinal(this.#jd, this.#sg)![1];
+  }
+
+  /**
+   * Ruby `Date#start` (ruby/date, `date_core.c` `d_lite_start`), the
+   * calendar-reform start the date is read under. `Date.new(2001, 2, 3,
+   * Date::ENGLAND).start` is `2361222`.
+   */
+  get start(): number {
+    return this.#sg;
+  }
+
+  /**
+   * Ruby `Date#julian?` (ruby/date, `date_core.c` `d_lite_julian_p` over
+   * `m_julian_p`, `date_core.c:1683-1702`), which answers the `start` itself
+   * for the two infinite ones and compares the Julian day against it otherwise.
+   */
+  isJulian(): boolean {
+    if (!Number.isFinite(this.#sg)) return this.#sg === JULIAN;
+    return this.#jd < this.#sg;
+  }
+
+  /** Ruby `Date#gregorian?` (ruby/date, `date_core.c` `d_lite_gregorian_p`). */
+  isGregorian(): boolean {
+    return !this.isJulian();
+  }
+
+  /**
+   * Ruby `Date#new_start(start = Date::ITALY)` (ruby/date, `date_core.c`
+   * `d_lite_new_start` over `dup_obj_with_new_start`), a copy of the date
+   * naming the same Julian day under a different reform start.
+   */
+  newStart(start: number = DEFAULT_SG): Date {
+    return Date.jd(this.#jd, start);
+  }
+
+  /** Ruby `Date#italy` (ruby/date, `date_core.c` `d_lite_italy`). */
+  italy(): Date {
+    return this.newStart(ITALY);
+  }
+
+  /** Ruby `Date#england` (ruby/date, `date_core.c` `d_lite_england`). */
+  england(): Date {
+    return this.newStart(ENGLAND);
+  }
+
+  /** Ruby `Date#julian` (ruby/date, `date_core.c` `d_lite_julian`). */
+  julian(): Date {
+    return this.newStart(JULIAN);
+  }
+
+  /** Ruby `Date#gregorian` (ruby/date, `date_core.c` `d_lite_gregorian`). */
+  gregorian(): Date {
+    return this.newStart(GREGORIAN);
+  }
+
+  /** Ruby `Date#to_s` (ruby/date, `date_core.c` `d_lite_to_s`). */
+  toS(): string {
+    return this.strftime("%Y-%m-%d");
   }
 
   /**

--- a/packages/i18n/src/date.ts
+++ b/packages/i18n/src/date.ts
@@ -1763,10 +1763,9 @@ function mod(n: number, d: number): number {
  * arithmetic, with the century correction `b` taken back off again for a day
  * before the reform, which is a Julian one.
  *
- * `ns` is Ruby's out-param saying which side of the reform the day landed on.
- * Every `c_*_to_jd` answers one and every `c_valid_*_p` carries it out, so the
- * port does too, and it is discarded at the `rt__valid_*_p` boundary exactly
- * where ruby/date discards it (`date_core.c:4126-4139`).
+ * `ns` says which side of the reform the day landed on. Every `c_*_to_jd`
+ * answers one and every `c_valid_*_p` carries it out, discarded at the
+ * `rt__valid_*_p` boundary where ruby/date discards it (`date_core.c:4126`).
  */
 function cCivilToJd(y: number, m: number, d: number, sg: number): [rjd: number, ns: number] {
   if (m <= 2) {
@@ -2250,12 +2249,10 @@ export class Date {
    * Ruby `Date.jd(jd = 0, start = Date::ITALY)` (ruby/date, `date_core.c`
    * `date_s_jd`), the date the given Julian day names under `start`: Gregorian
    * at or after it, Julian before.
-   *
-   * `date_s_jd` writes the Julian day straight into a freshly allocated
-   * `SimpleDateData`; a TS class has one constructor, and it is `Date.new`'s,
-   * so the day is named as a civil date and rebuilt through it. `c_jd_to_civil`
-   * and `c_civil_to_jd` are exact inverses under the same `sg` — it is the
-   * round trip `c_valid_civil_p` itself checks — so the two agree.
+   * `date_s_jd` writes the day straight into a fresh `SimpleDateData`; a TS
+   * class has one constructor, and it is `Date.new`'s, so the day is rebuilt
+   * through the civil date it names — the exact round trip `c_valid_civil_p`
+   * itself checks.
    */
   static jd(jd = 0, start: number = DEFAULT_SG): Date {
     const [y, m, d] = cJdToCivil(jd, start);
@@ -2425,10 +2422,8 @@ export class Date {
    * Ruby `Date#julian?` (ruby/date, `date_core.c` `d_lite_julian_p` over
    * `m_julian_p`, `date_core.c:1683-1702`), which answers the `start` itself
    * for the two infinite ones and compares the Julian day against it otherwise.
-   *
-   * Spelled `isJulian` rather than `julian` — the second candidate the
-   * predicate rule offers — because `Date#julian` is the `new_start` method
-   * below. Same for `isGregorian`.
+   * Spelled `isJulian`, not the predicate rule's second candidate `julian`,
+   * because `Date#julian` is the `new_start` method below.
    */
   isJulian(): boolean {
     if (!Number.isFinite(this.#sg)) return this.#sg === JULIAN;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       '@types/sinonjs__fake-timers':
         specifier: ^15.0.1
         version: 15.0.1
+      '@typescript-eslint/parser':
+        specifier: ^8.57.0
+        version: 8.57.0(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4(@types/node@25.3.5)(jiti@2.6.1)(jsdom@29.0.1)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))

--- a/scripts/generate-standalone-associations-exclude.ts
+++ b/scripts/generate-standalone-associations-exclude.ts
@@ -24,6 +24,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import { fileURLToPath } from "url";
+import { parseForESLint } from "@typescript-eslint/parser";
 import { writeJsonManifest } from "./api-compare/write-json-manifest.js";
 // @ts-expect-error — .mjs rule module has no type declarations.
 import { macroOfCall, siteKey, repoRel } from "../eslint/no-standalone-associations.mjs";
@@ -50,16 +51,8 @@ function collectTsFiles(dir: string, out: string[]): void {
 }
 
 async function main(): Promise<void> {
-  const { parser } = (await import("typescript-eslint")) as unknown as {
-    parser: {
-      parseForESLint(
-        code: string,
-        options: { ecmaVersion: number; sourceType: string },
-      ): { ast: unknown };
-    };
-  };
   const parse = (code: string) =>
-    parser.parseForESLint(code, { ecmaVersion: 2022, sourceType: "module" }).ast;
+    parseForESLint(code, { ecmaVersion: 2022, sourceType: "module" }).ast;
 
   const files: string[] = [];
   for (const pkg of fs.readdirSync(path.join(ROOT, "packages"))) {
@@ -78,7 +71,7 @@ async function main(): Promise<void> {
     } catch {
       continue; // skip unparseable files
     }
-    walk(ast as AstNode, (node) => {
+    walk(ast as unknown as AstNode, (node) => {
       if (node.type !== "CallExpression") return;
       const macro = macroOfCall(node.callee);
       if (macro === null) return;

--- a/scripts/test-deps/build-fixture-baseline.ts
+++ b/scripts/test-deps/build-fixture-baseline.ts
@@ -14,7 +14,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 
-import { parser } from "typescript-eslint";
+import { parseForESLint } from "@typescript-eslint/parser";
 
 import { writeJsonManifest } from "../api-compare/write-json-manifest.js";
 
@@ -24,11 +24,6 @@ const ROOT = path.resolve(__dirname, "../..");
 const DEPS_PATH = path.join(ROOT, "scripts/test-deps/output/activerecord-test-deps.json");
 const OUT_PATH = path.join(ROOT, "eslint/expected-fixtures-exclude.json");
 const AR_SRC = path.join(ROOT, "packages/activerecord/src");
-
-const parseForESLint = parser.parseForESLint as unknown as (
-  code: string,
-  options: { loc: boolean; range: boolean },
-) => { ast: unknown };
 
 async function main(): Promise<void> {
   // Dynamic import avoids the CJS-style top-level / static-`.mjs`-import


### PR DESCRIPTION
Three related stories, bundled.

## `i18n`: `Date` carries `start` and `ns` (`i18n-date-carries-start-and-ns`)

`Date` held a bare `Temporal.PlainDate`, so it had nowhere to put ruby/date's
`sg`/`ns` state — which is why PR #6111 threaded `sg` through the `c_*` family
but dropped every `*ns` out-param, and why `Date.parse(str, comp, start)`
resolved under `start` and then threw it away.

- `Date` now carries `SimpleDateData`'s `jd` and `sg` (`date_core.c:203-213`)
  instead of a `Temporal.PlainDate`. That is what makes a Julian date such as
  1500-02-29 constructible at all — `Temporal.PlainDate` is proleptic
  Gregorian, where 1500 is not a leap year.
- `c_civil_to_jd` (`date_core.c:503-524`), `c_ordinal_to_jd` (557-564),
  `c_commercial_to_jd` (577-589) and `c_weeknum_to_jd` (611-620) answer `ns`,
  and `c_find_fdoy` / `c_valid_civil_p` (767-790) / `c_valid_ordinal_p`
  (675-695) / `c_valid_commercial_p` (792-813) / `c_valid_weeknum_p` (816-837)
  carry it out. It is discarded at the `rt__valid_*_p` boundary, exactly where
  ruby/date discards it (`date_core.c:4126-4155`). The `*ns` deviation note at
  `cCivilToJd` is gone.
- Ported: `Date.jd` (`date_s_jd`), `Date#start` (`d_lite_start`), `#julian?` /
  `#gregorian?` (`d_lite_julian_p` over `m_julian_p`, 1683-1707), `#new_start`
  (`d_lite_new_start` over `dup_obj_with_new_start`), `#italy`, `#england`,
  `#julian`, `#gregorian`, and `#to_s` (`d_lite_to_s`). `Date.new` takes
  `start` and raises `Date::Error, "invalid date"` on a day the reform deleted,
  as `date_s_civil` does.

`julian?` / `gregorian?` are spelled `isJulian` / `isGregorian` — the bare
`julian` and `gregorian` names belong to the `new_start` methods.

Every new expectation in `date.trails.test.ts` is `ruby 3.3.11 -rdate` output,
including the two the story names: `Date.jd(2299160).to_s == "1582-10-04"` and
`Date.parse("1500-02-29", true, Date::JULIAN)`.

## `activerecord`: break the Context/Configurable eval-time cycle (`break-encryption-context-configurable-module-cycle`)

All three eval-time shims in `encryption/context.ts` are gone:

- `contextProperties()` — `Configurable` now spells out one reader per
  `Context::PROPERTIES` member (configurable.rb:16-19) rather than installing
  them from the constant in a loop, so it no longer reads `Context` while its
  own module body runs. `configurable.trails.test.ts` already holds the set to
  `Context::PROPERTIES`, so it cannot drift.
- `setEncryptingOnlyEncryptorFactory` — `protectingEncryptedData` moved to
  `contexts.ts`, where Rails has it (contexts.rb:57), and names
  `EncryptingOnlyEncryptor` directly.
- `Context.PROPERTIES` is a plain class-static array again.

`Configurable` reaches the context through `context.js` rather than `Contexts`,
because `Contexts` now imports `EncryptingOnlyEncryptor`, whose `extends
Encryptor` would otherwise sit inside the cycle: a graph entered at
`encryptor.ts` would evaluate the subclass with `Encryptor` still in TDZ. That
is a real ESM failure, not a theoretical one — reproduced in plain node before
choosing the shape. The call site says so.

## `scripts`: one typed `parseForESLint`, no casts (`share-typed-parse-for-eslint-accessor-in-scripts`)

`@typescript-eslint/parser` is now a direct devDependency (it was already there
transitively), so both generators import the real options-taking
`parseForESLint` and the two hand-rolled casts through `unknown` are deleted.
No shared shim, no declared shape to drift.

Verified no behaviour change by regenerating both baselines before and after:
`eslint/no-standalone-associations-exclude.json` and
`eslint/expected-fixtures-exclude.json` are byte-identical either way. (Both
are stale on `main` for unrelated reasons, so the comparison is before/after
regeneration, not against the committed files.)

Filed, not shipped: `0074-i18n-parity/datetime-new-start-preserves-the-receiver`
— `dup_obj_with_new_start` dups the receiver, so `DateTime#new_start` keeps its
class and time of day. Converging that needs `DateTime` to take `start` first
(`datetime_s_new`), which is a story of its own. Cited at the call site.

## Review round 1

> `Configurable`'s PROPERTIES delegation abandons the Rails loop shape

The loop cannot survive, and the reason is not the loop shape — it is *when* it
runs. `Context::PROPERTIES.each` runs while `configurable.ts`'s module body
does, and `context.ts` imports this module for `build_default_key_provider`, so
on a graph entered at `context.ts` the `Context` binding is still in TDZ:
`ReferenceError: Cannot access 'Context' before initialization`, not a stale
read. I reproduced exactly this shape in plain node before choosing the getters
(vitest masks it — its setup files happen to enter `configurable.js` first).
`Delegation.generate` does not help: it would be called at the same moment, on
the same TDZ binding. The only thing readable there is a hoisted function
declaration — which is precisely the `contextProperties()` shim this story
deletes.

The drift concern is real and is now closed **by construction rather than by a
runtime test**: `Context.PROPERTIES` is `as const`, and `configurable.ts` ends
with a type-only `Pick<typeof Configurable, DelegatedProperty>` that stops
compiling the moment a `Context::PROPERTIES` name has no reader. Verified by
renaming `messageSerializer` and watching `tsc` fail. It is erased at emit, so
it reads no binding at runtime at all. The reason is written at the call site.

## Checks

`pnpm typecheck`, `pnpm lint`, i18n suite (541), activerecord encryption suites
(347) all green. `api:calls:wide` OK, `api:compare` / `test:compare` deltas
non-negative, no new `api:extra` novel surface beyond the `@noRailsEquivalent
PERMANENT` `::Date` class that already carries the receipt.

**LOC: 535 against the 500 ceiling.** Three bundled stories, and the rebase onto
merged #6112 reshaped the same `c_valid_*_p` signatures this PR was already
touching (its negative-`m`/`d` normalizations now interleave with the `ns`
threading). I trimmed the prose rather than the substance; what is left is the
ported members, the `ns` out-params, and the deviation citations. Happy to split
the `scripts` story out into its own PR if the overrun is not acceptable.

Closes-story: i18n-date-carries-start-and-ns
Closes-story: share-typed-parse-for-eslint-accessor-in-scripts
Closes-story: break-encryption-context-configurable-module-cycle
