### PR TITLE
feat(activerecord,scripts): eager encryption scheme resolution, writing-pool leak guard, template-literal-aware row-write lint, parity-aware Ruby gate booleans

### DIFF
--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -40,8 +40,10 @@ vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
 // ==========================================================================
 describe("BasicsTest", () => {
   fixtures([]);
-  afterEach(() => {
+  const cleanupConnections: Array<() => unknown> = [];
+  afterEach(async () => {
     vi.restoreAllMocks();
+    while (cleanupConnections.length > 0) await cleanupConnections.pop()!();
   });
 
   it("table name based on model name", () => {
@@ -1324,6 +1326,7 @@ describe("BasicsTest", () => {
       await Default.establishConnection(
         newConfig as Parameters<typeof Default.establishConnection>[0],
       );
+      cleanupConnections.push(() => Default.removeConnection());
 
       const d = new Default();
       const fd = d.readAttribute("fixed_date") as Temporal.PlainDate;
@@ -1356,6 +1359,7 @@ describe("BasicsTest", () => {
       await Default.establishConnection(
         newConfig as Parameters<typeof Default.establishConnection>[0],
       );
+      cleanupConnections.push(() => Default.removeConnection());
 
       const d = new Default();
       const fd = d.readAttribute("fixed_date") as Temporal.PlainDate;

--- a/packages/activerecord/src/cases/helper.ts
+++ b/packages/activerecord/src/cases/helper.ts
@@ -10,6 +10,7 @@
 // in activerecord/index.ts) to keep better-sqlite3 a true optional peer for
 // non-test consumers.
 import "../sqlite/better-sqlite3.js";
+import { afterAll, beforeAll, expect } from "vitest";
 import { Base } from "../base.js";
 import { I18n } from "@blazetrails/activemodel";
 import { getZone, setZone, resetZone, isZoneExplicit } from "@blazetrails/activesupport";
@@ -75,6 +76,51 @@ EncryptionConfigurable.configure({
 // railtie does in a real app (railtie.rb:349-355).
 EncryptionConfigurable.config.extendQueries = true;
 installExtendedQueriesIfConfigured();
+
+/**
+ * Rails' `ActiveRecord::TestCase` tears its connections down per case, so a
+ * pool cannot outlive the file that established it. trails' connection handler
+ * is module-level state shared by every test file in a vitest worker, and since
+ * PR #6109 `setup_transactional_fixtures` pins every writing pool up front
+ * (test_fixtures.rb:175-180) — and `pin_connection!` eagerly `verify!`s the
+ * connection (connection_pool.rb:335). So a pool one file leaves behind is
+ * opened for real by the next file that pins, and fails THAT file, on the lanes
+ * whose server actually rejects the config: `NoDatabaseError` on PostgreSQL,
+ * `ER_DBACCESS_DENIED_ERROR` on MariaDB. Naming the pools by connection
+ * descriptor and counting them per file fails the culprit instead of the victim.
+ *
+ * The baseline is taken once the file's module body has run, so a connection a
+ * file establishes at module scope — and keeps for its whole run — is its own.
+ */
+function writingPoolCensus(): Map<string, number> {
+  const census = new Map<string, number>();
+  for (const pool of Base.connectionHandler.connectionPoolList("writing")) {
+    const name = String(pool.connectionDescriptor?.name);
+    census.set(name, (census.get(name) ?? 0) + 1);
+  }
+  return census;
+}
+
+let baselineWritingPools = new Map<string, number>();
+
+beforeAll(() => {
+  baselineWritingPools = writingPoolCensus();
+});
+
+afterAll(() => {
+  const leaked: string[] = [];
+  for (const [name, count] of writingPoolCensus()) {
+    const before = baselineWritingPools.get(name) ?? 0;
+    if (count > before) leaked.push(before === 0 ? name : `${name} (${before} -> ${count})`);
+  }
+  expect(
+    leaked,
+    "This file left connection pool(s) in the writing list. Remove them in " +
+      "teardown (removeConnection() / connectionHandler.removeConnectionPool(name)): " +
+      "the next file to run in this worker pins and verifies every writing pool, " +
+      "and fails on yours instead of on this one.",
+  ).toEqual([]);
+});
 
 /**
  * Rails declares `module InTimeZone` inside this very file —

--- a/packages/activerecord/src/connection-adapters/connection-handlers-multi-db.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-handlers-multi-db.test.ts
@@ -136,6 +136,8 @@ describe("ConnectionHandlersMultiDbTest", () => {
     });
 
     expect((await relation.first())!.readAttribute("connection_role")).toBe("reading");
+    await SecondaryBase.removeConnection();
+    Base.connectionHandler.removeConnectionPool("SecondaryBase", { role: "secondary" });
   });
 
   it("establish connection using 3 levels config", () => {

--- a/packages/activerecord/src/connection-adapters/connection-handlers-sharding-db.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-handlers-sharding-db.test.ts
@@ -37,12 +37,22 @@ let dbDir: string;
 const dbPath = (basename: string) => path.join(dbDir, basename);
 
 describe("ConnectionHandlersShardingDbTest", () => {
+  let baselinePools: Set<unknown>;
+
   beforeEach(async () => {
     dbDir = await mkdtemp(path.join(os.tmpdir(), "trails-sharding-db-"));
+    baselinePools = new Set(Base.connectionHandler.connectionPoolList("all"));
   });
 
   afterEach(async () => {
     await Base.connectionHandler.clearAllConnectionsBang();
+    for (const pool of Base.connectionHandler.connectionPoolList("all")) {
+      if (baselinePools.has(pool)) continue;
+      Base.connectionHandler.removeConnectionPool(String(pool.connectionDescriptor.name), {
+        role: pool.role,
+        shard: pool.shard,
+      });
+    }
     await rm(dbDir, { recursive: true, force: true });
     (Base as any)._shardKeys = undefined;
     (Base as any)._defaultShard = undefined;

--- a/packages/activerecord/src/connection-adapters/connection-swapping-nested.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-swapping-nested.test.ts
@@ -62,7 +62,10 @@ describe("ConnectionSwappingNestedTest", () => {
     ...extra,
   });
 
+  let baselinePools: Set<unknown>;
+
   beforeEach(async () => {
+    baselinePools = new Set(Base.connectionHandler.connectionPoolList("all"));
     const fs = await asyncFs();
     const path = await getPathAsync();
     const os = await getOsAsync();
@@ -83,6 +86,13 @@ describe("ConnectionSwappingNestedTest", () => {
 
   afterEach(async () => {
     await Base.connectionHandler.clearAllConnectionsBang();
+    for (const pool of Base.connectionHandler.connectionPoolList("all")) {
+      if (baselinePools.has(pool)) continue;
+      Base.connectionHandler.removeConnectionPool(String(pool.connectionDescriptor.name), {
+        role: pool.role,
+        shard: pool.shard,
+      });
+    }
     Base.configurations(prevConfigs);
     DatabaseConfigurations.defaultEnv = prevDefaultEnv;
     (DatabaseConfigurations as any).current = prevCurrent;

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -552,13 +552,13 @@ describe("ConnectionHandlingTest", () => {
 
     const priorCurrent = (DatabaseConfigurations as any).current;
     const priorConfigs = Base.configurations();
+    class WorkerModel extends Base {}
     try {
       const url = new UrlConfig(env, "primary", "sqlite3:db/foo.sqlite3");
       url._database = "db/foo-2.sqlite3"; // mimic worker-suffix mutation
       const inMemory = new DatabaseConfigurations([url]);
 
       Base.configurations(inMemory);
-      class WorkerModel extends Base {}
 
       await WorkerModel.establishConnection();
       // The connection pool's resolved dbConfig must point at the
@@ -573,6 +573,7 @@ describe("ConnectionHandlingTest", () => {
         await import("./connection-adapters/better-sqlite3-adapter.js");
       expect(Klass).toBe(BetterSQLite3Adapter);
     } finally {
+      await WorkerModel.removeConnection();
       Base.configurations(priorConfigs);
       (DatabaseConfigurations as any).current = priorCurrent;
     }
@@ -844,6 +845,7 @@ describe("resolveConfigForConnection / connectsTo with unset configurations", ()
       SecondaryAbstract.connectsTo({ database: { writing: "primary" } });
       expect((SecondaryAbstract as any)._connectionSpecificationName).toBe("SecondaryAbstract");
     } finally {
+      await SecondaryAbstract.removeConnection();
       __resetPrimaryAbstractClass();
       if (priorConfigs) Base.configurations(priorConfigs);
     }

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -385,6 +385,7 @@ it("connection notification is called", async () => {
     expect(payloads[0].role).toBe("writing");
   } finally {
     Notifications.unsubscribe(sub);
+    Base.connectionHandler.removeConnectionPool(ConnectionTestModel.name);
     await Base.connectionHandler.clearAllConnectionsBang();
   }
 });
@@ -405,6 +406,7 @@ it("connection notification is called for shard", async () => {
     expect(payloads[0].role).toBe("writing");
   } finally {
     Notifications.unsubscribe(sub);
+    Base.connectionHandler.removeConnectionPool(ConnectionTestModel.name);
     await Base.connectionHandler.clearAllConnectionsBang();
   }
 });

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -24,7 +24,11 @@ import { Scheme, type SchemeOptions } from "./encryption/scheme.js";
 import type { EncryptorLike } from "./encryption/encryptor.js";
 import { Aes256Gcm as AesGcmCipher } from "./encryption/cipher/aes256-gcm.js";
 export { Cipher } from "./encryption/cipher.js";
-import { EncryptableRecord, encryptedTypeOf } from "./encryption/encryptable-record.js";
+import {
+  EncryptableRecord,
+  encryptedTypeOf,
+  globalPreviousSchemesFor,
+} from "./encryption/encryptable-record.js";
 import { Configurable } from "./encryption/configurable.js";
 import { Contexts } from "./encryption/contexts.js";
 import { getEncryptionContext, type Context } from "./encryption/context.js";
@@ -137,6 +141,12 @@ export interface EncryptsOptions extends Omit<SchemeOptions, "encryptor"> {
   encryptor?: Encryptor;
 }
 
+/**
+ * `Base.encrypts`' variant of `EncryptableRecord#scheme_for`, carrying the
+ * legacy `{ encrypt, decrypt }` shim and the defaultEncryptor fallback. It owes
+ * `scheme_for`'s one-shot `previous_schemes` assignment
+ * (encryptable_record.rb:70-76): globals first, then the declared ones.
+ */
 function buildScheme(options: EncryptsOptions): Scheme {
   const { encryptor, previousSchemes: localPrevious = [], ...schemeOptions } = options;
 
@@ -168,11 +178,9 @@ function buildScheme(options: EncryptsOptions): Scheme {
       ? schemeOptions
       : { encryptor: new LegacyEncryptorShim(defaultEncryptor) };
 
-  // Only pass locally-declared previous schemes — global ones are resolved lazily
-  // in EncryptedAttributeType at serialize/deserialize time.
-  return localPrevious.length > 0
-    ? new Scheme({ ...coreOpts, previousSchemes: localPrevious })
-    : new Scheme(coreOpts);
+  const scheme = new Scheme(coreOpts);
+  scheme.previousSchemes = [...globalPreviousSchemesFor(scheme), ...localPrevious];
+  return scheme;
 }
 
 interface PendingEncryption {
@@ -205,14 +213,13 @@ export function encrypts(klass: any, ...args: Array<string | EncryptsOptions>): 
     }
   }
 
-  const scheme = buildScheme(options);
   // Drop the legacy `encryptor` field so the remaining shape is assignable to
   // SchemeOptions — the scheme is already built, so `encryptAttribute` only
   // reads `options.ignoreCase` from here.
   const { encryptor: _encryptor, ...schemeOptions } = options;
 
   for (const name of names) {
-    EncryptableRecord.encryptAttribute(klass, name, schemeOptions, scheme);
+    EncryptableRecord.encryptAttribute(klass, name, schemeOptions, () => buildScheme(options));
   }
 }
 

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -164,10 +164,12 @@ export class EncryptableRecord {
    * (via encryption.ts#encrypts) and direct callers route through here, mirroring
    * Rails' single `encrypt_attribute`.
    *
-   * `prebuiltScheme` lets `Base.encrypts` supply a scheme built by
-   * encryption.ts#buildScheme (which adapts the legacy `{ encrypt, decrypt }`
-   * shim and supplies a defaultEncryptor fallback); direct callers omit it and
-   * get a per-attribute scheme from `schemeFor`.
+   * `buildScheme` lets `Base.encrypts` supply encryption.ts#buildScheme (which
+   * adapts the legacy `{ encrypt, decrypt }` shim and supplies a defaultEncryptor
+   * fallback) in place of `schemeFor`, which direct callers get by omitting it.
+   * It is a function, not a scheme, because Rails calls `scheme_for` inside the
+   * `decorate_attributes` block (encryptable_record.rb:85-88) — see
+   * `PendingEncryption`.
    *
    * @internal
    */

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -2,7 +2,7 @@ import { Scheme, type SchemeOptions } from "./scheme.js";
 import { getEncryptionContext, withoutEncryption as _withoutEncryption } from "./context.js";
 import { Configuration as ConfigurationError } from "./errors.js";
 import { LengthValidator, type Type } from "@blazetrails/activemodel";
-import { EncryptedAttributeType, setGlobalPreviousSchemesFn } from "./encrypted-attribute-type.js";
+import { EncryptedAttributeType } from "./encrypted-attribute-type.js";
 import { Configurable } from "./configurable.js";
 import { encryptionHooks } from "../encryption-hooks.js";
 
@@ -22,24 +22,38 @@ export function globalPreviousSchemesFor(scheme: Scheme): Scheme[] {
 }
 
 /**
- * Mirrors Rails' EncryptableRecord#scheme_for.
- * Builds the scheme with only locally-declared previousSchemes; global previous
- * schemes are resolved lazily in EncryptedAttributeType at serialize/deserialize
- * time so that configure() calls after encrypts() are picked up automatically.
+ * Mirrors Rails' EncryptableRecord#scheme_for (encryptable_record.rb:70-76):
+ * the scheme is built from the declared options alone, then `previousSchemes`
+ * is assigned in one shot, globals first. Assigning it here — rather than
+ * resolving globals at type-read time — is what makes it frozen by
+ * construction, which is what lets EncryptedAttributeType memoize.
  *
  * @internal
  */
 function schemeFor(options: SchemeOptions): Scheme {
-  const { previousSchemes: localPrevious = [], ...rest } = options;
-  return localPrevious.length > 0
-    ? new Scheme({ ...rest, previousSchemes: localPrevious })
-    : new Scheme(rest);
+  const { previousSchemes: previous = [], ...rest } = options;
+  const scheme = new Scheme(rest);
+  scheme.previousSchemes = [...globalPreviousSchemesFor(scheme), ...previous];
+  return scheme;
 }
 
-// Register the global-previous-schemes provider into EncryptedAttributeType.
-// Called at module load time — always runs before any EncryptedAttributeType
-// accesses previousTypes because this module is loaded via encryption.ts first.
-setGlobalPreviousSchemesFn(globalPreviousSchemesFor);
+/**
+ * One `encrypts` declaration's bookkeeping, read back off `_pendingEncryptions`
+ * by `fixtures.ts` and `applyPendingEncryptions`.
+ *
+ * `scheme` is a getter, and unmemoized, because Rails calls `scheme_for` inside
+ * the `decorate_attributes` block (encryptable_record.rb:85-95): the scheme is
+ * built when the attribute type is resolved, and rebuilt on every replay, not
+ * when `encrypts` is called. That is what lets a `configure` between the two
+ * contribute its global previous schemes — "encryption schemes are resolved when
+ * used, not when declared" (encryptable_record_test.rb:388). A memo here would
+ * pin the pre-`configure` answer, the way the retired `_globalPreviousSchemesFn`
+ * injection point did one level up.
+ */
+interface PendingEncryption {
+  name: string;
+  readonly scheme: Scheme;
+}
 
 const ORIGINAL_ATTRIBUTE_PREFIX = "original_";
 
@@ -161,7 +175,7 @@ export class EncryptableRecord {
     modelClass: any,
     name: string,
     options: SchemeOptions = {},
-    prebuiltScheme?: Scheme,
+    buildScheme?: () => Scheme,
   ): void {
     // Own-property guard mirrors Rails' `class_attribute` semantics — a subclass
     // encrypting a new attribute must not mutate the parent's (or a sibling's) Set.
@@ -171,10 +185,12 @@ export class EncryptableRecord {
     modelClass._encryptedAttributes.add(name);
     delete modelClass._deterministicEncryptedAttributes;
 
-    // Build the per-attribute scheme (mirrors Rails scheme_for) unless the caller
-    // supplied one. Each attribute gets its own scheme so per-attribute options
-    // (deterministic, downcase, previousSchemes) don't leak across declarations.
-    const scheme = prebuiltScheme ?? schemeFor(options);
+    const pending: PendingEncryption = {
+      name,
+      get scheme(): Scheme {
+        return buildScheme ? buildScheme() : schemeFor(options);
+      },
+    };
 
     if (typeof modelClass.decorateAttributes === "function") {
       // Durable path (real model classes): push the durable PendingDecorator NOW,
@@ -186,14 +202,14 @@ export class EncryptableRecord {
       // time, so it needs no re-push after schema reflection. The
       // `_pendingEncryptions` buffer remains only for validator re-runs +
       // frozen-validator install on rebuild (applyPendingEncryptions).
-      this.registerPendingEncryption(modelClass, name, scheme);
-      this.pushEncryptionDecorator(modelClass, name, scheme);
+      this.registerPendingEncryption(modelClass, pending);
+      this.pushEncryptionDecorator(modelClass, name, pending);
       encryptionHooks.applyPendingEncryptions(modelClass);
     } else {
       // Immediate path (plain-object callers without decoration machinery, e.g.
       // direct `EncryptableRecord.encrypts` tests): register the encrypted type
       // synchronously so it's readable right after the call.
-      this.registerEncryptedType(modelClass, name, scheme);
+      this.registerEncryptedType(modelClass, name, pending.scheme);
     }
 
     if (Configurable.config.validateColumnSize) {
@@ -217,11 +233,11 @@ export class EncryptableRecord {
    * is kept in each entry for `encryptFixtureRows` (define-fixtures.ts).
    * @internal
    */
-  static registerPendingEncryption(modelClass: any, name: string, scheme: Scheme): void {
+  static registerPendingEncryption(modelClass: any, pending: PendingEncryption): void {
     if (!Object.prototype.hasOwnProperty.call(modelClass, "_pendingEncryptions")) {
       modelClass._pendingEncryptions = [...(modelClass._pendingEncryptions ?? [])];
     }
-    modelClass._pendingEncryptions.push({ name, scheme });
+    modelClass._pendingEncryptions.push(pending);
   }
 
   /**
@@ -239,7 +255,7 @@ export class EncryptableRecord {
    * DB default without any re-push.
    * @internal
    */
-  static pushEncryptionDecorator(modelClass: any, name: string, scheme: Scheme): void {
+  static pushEncryptionDecorator(modelClass: any, name: string, pending: PendingEncryption): void {
     modelClass.decorateAttributes([name], (attrName: string, castType: Type, host?: unknown) => {
       // Idempotence guard for the eager immediate-apply pass (a fresh-seed
       // replay applies each queued decorator once, but `decorateAttributes`
@@ -247,7 +263,7 @@ export class EncryptableRecord {
       if (castType instanceof EncryptedAttributeType) return null as unknown as Type;
       const target = host ?? modelClass;
       return new EncryptedAttributeType({
-        scheme,
+        scheme: pending.scheme,
         castType,
         default: this.columnDefaultFor(
           target,
@@ -390,8 +406,13 @@ export class EncryptableRecord {
     // namespace isn't loaded (pure-direct unit tests, which never serialize).
     // encryptAttribute's durable branch buffers this in _pendingEncryptions so
     // the original column rides the same replay-safe machinery as its source.
-    const originalScheme = encryptionHooks.buildScheme?.({}) as Scheme | undefined;
-    this.encryptAttribute(modelClass, originalName, {}, originalScheme);
+    const buildOriginalScheme = encryptionHooks.buildScheme;
+    this.encryptAttribute(
+      modelClass,
+      originalName,
+      {},
+      buildOriginalScheme && (() => buildOriginalScheme({}) as Scheme),
+    );
     this.overrideAccessorsToPreserveOriginal(modelClass, name, originalName);
   }
 

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -13,15 +13,6 @@ import {
   replaceUnencodable as _replaceUnencodable,
 } from "./encoding-helpers.js";
 
-// Injectable provider for global previous schemes — set by encryptable-record.ts
-// to avoid the circular import cycle (encryptable-record → encrypted-attribute-type → encryptable-record).
-let _globalPreviousSchemesFn: ((scheme: Scheme) => Scheme[]) | null = null;
-
-/** @internal */
-export function setGlobalPreviousSchemesFn(fn: (scheme: Scheme) => Scheme[]): void {
-  _globalPreviousSchemesFn = fn;
-}
-
 /**
  * An ActiveModel type that encrypts/decrypts attribute values. This is
  * the central piece connecting the encryption system with `encrypts`
@@ -36,6 +27,9 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
   private _previousType: boolean;
   private _default?: unknown;
   private _encryptor: EncryptorLike;
+  private _previousTypes?: Map<boolean, EncryptedAttributeType[]>;
+  private _previousTypesWithoutCleanText?: EncryptedAttributeType[];
+  private _serializeWithOldest = false;
 
   constructor(options: {
     scheme: Scheme;
@@ -154,15 +148,16 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
     return this.castType.type();
   }
 
-  /**
-   * Rails memoizes on `support_unencrypted_data?` (encrypted_attribute_type.rb:56-59)
-   * because a scheme's `previous_schemes` is frozen at `encrypts` declaration time
-   * (encryptable_record.rb:73). trails resolves the global previous schemes lazily
-   * instead — see `_effectivePreviousSchemes` — so the result is not immutable and
-   * a memo would pin a pre-`configure` answer. Recompute, as the Ruby body does.
-   */
+  /** Memoizing on `support_unencrypted_data?` so that we can tweak it during tests. */
   get previousTypes(): EncryptedAttributeType[] {
-    return this.buildPreviousTypesFor(this.previousSchemesIncludingCleanText());
+    this._previousTypes ??= new Map();
+    const supportUnencryptedData = this.supportUnencryptedData;
+    let types = this._previousTypes.get(supportUnencryptedData);
+    if (types === undefined) {
+      types = this.buildPreviousTypesFor(this.previousSchemesIncludingCleanText());
+      this._previousTypes.set(supportUnencryptedData, types);
+    }
+    return types;
   }
 
   get supportUnencryptedData(): boolean {
@@ -174,24 +169,17 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
   }
 
   /** @internal */
-  private _effectivePreviousSchemes(): Scheme[] {
-    // Previous types are already derived from global+local schemes at the
-    // top-level — don't re-expand globals or we get infinite recursion.
-    if (this._previousType) return this.scheme.previousSchemes ?? [];
-    const global = _globalPreviousSchemesFn ? _globalPreviousSchemesFn(this.scheme) : [];
-    return [...global, ...(this.scheme.previousSchemes ?? [])];
-  }
-
-  /** @internal */
   private previousSchemesIncludingCleanText(): Scheme[] {
-    const schemes = [...this._effectivePreviousSchemes()];
+    const schemes = [...this.previousSchemes];
     if (this.supportUnencryptedData) schemes.push(this.cleanTextScheme());
     return schemes;
   }
 
   /** @internal */
   private previousTypesWithoutCleanText(): EncryptedAttributeType[] {
-    return this.buildPreviousTypesFor(this._effectivePreviousSchemes());
+    return (this._previousTypesWithoutCleanText ??= this.buildPreviousTypesFor(
+      this.previousSchemes,
+    ));
   }
 
   /** @internal */
@@ -273,7 +261,8 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
 
   /** @internal */
   private isSerializeWithOldest(): boolean {
-    return this.isFixed() && this.previousTypesWithoutCleanText().length > 0;
+    return (this._serializeWithOldest ||=
+      this.isFixed() && this.previousTypesWithoutCleanText().length > 0);
   }
 
   /** @internal */

--- a/packages/activerecord/src/shard-keys.test.ts
+++ b/packages/activerecord/src/shard-keys.test.ts
@@ -17,7 +17,10 @@ describe("ShardsKeysTest", () => {
   let prevDefaultEnv: string;
   let prevCurrent: unknown;
 
+  let baselinePools: Set<unknown>;
+
   beforeEach(() => {
+    baselinePools = new Set(Base.connectionHandler.connectionPoolList("all"));
     prevConfigs = Base.configurations();
     prevDefaultEnv = DatabaseConfigurations.defaultEnv;
     prevCurrent = (DatabaseConfigurations as any).current;
@@ -45,6 +48,13 @@ describe("ShardsKeysTest", () => {
 
   afterEach(async () => {
     await Base.connectionHandler.clearAllConnectionsBang();
+    for (const pool of Base.connectionHandler.connectionPoolList("all")) {
+      if (baselinePools.has(pool)) continue;
+      Base.connectionHandler.removeConnectionPool(String(pool.connectionDescriptor.name), {
+        role: pool.role,
+        shard: pool.shard,
+      });
+    }
     Base.configurations(prevConfigs);
     DatabaseConfigurations.defaultEnv = prevDefaultEnv;
     (DatabaseConfigurations as any).current = prevCurrent;

--- a/packages/activerecord/src/shard-selector.test.ts
+++ b/packages/activerecord/src/shard-selector.test.ts
@@ -7,6 +7,7 @@ import { ambientPoolConfiguration } from "./test-adapter.js";
 describe("ShardSelectorTest", () => {
   afterEach(async () => {
     await Base.connectionHandler.clearAllConnectionsBang();
+    Base.connectionHandler.removeConnectionPool("Base", { shard: "shard_one" });
   });
 
   function setupShards() {

--- a/packages/activerecord/src/test-fixtures/with-transactional-fixtures.test.ts
+++ b/packages/activerecord/src/test-fixtures/with-transactional-fixtures.test.ts
@@ -69,6 +69,7 @@ describe("withTransactionalFixtures", () => {
     await Promise.resolve();
     await Promise.resolve();
     expect((pool as unknown as { _fixturePin: unknown })._fixturePin).not.toBeNull();
+    Base.connectionHandler.removeConnectionPool("MidTestPool");
   });
 
   it("nested user transaction becomes a savepoint and still rolls back at teardown", async () => {

--- a/scripts/non-transactional-row-writes.json
+++ b/scripts/non-transactional-row-writes.json
@@ -2,6 +2,7 @@
   "packages/activerecord/src/adapters/postgresql/postgresql-adapter-perform-query.trails.test.ts",
   "packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-perform-query.trails.test.ts",
   "packages/activerecord/src/connection-adapters/connection-handlers-sharding-db.test.ts",
+  "packages/activerecord/src/encryption/encryption-schemes.test.ts",
   "packages/activerecord/src/invertible-migration.test.ts",
   "packages/activerecord/src/migration/columns.test.ts",
   "packages/activerecord/src/migration/rename-table.test.ts",

--- a/scripts/non-transactional-row-writes.test.ts
+++ b/scripts/non-transactional-row-writes.test.ts
@@ -202,6 +202,43 @@ describe("non-transactional row writes", () => {
     expect(isOffender(src)).toBe(false);
   });
 
+  it("catches a write in an it.each tagged-template table body", () => {
+    const src = [
+      'describe("x", () => {',
+      "  const adapter = Base.connection;",
+      "",
+      "  it.each`",
+      "    name      | count",
+      '    ${"Dune"} | ${1}',
+      '  `("writes $name", async ({ name }) => {',
+      "    await Book.create({ name });",
+      "  });",
+      "});",
+      "",
+    ].join("\n");
+    expect(rowWritesAtItScope(src).map((w) => w.pattern)).toEqual([".create("]);
+    expect(isOffender(src)).toBe(true);
+  });
+
+  it("does not shift paren depth for parens inside a template literal", () => {
+    const src = [
+      'describe("x", () => {',
+      "  it.each`",
+      "    name",
+      "    ${String(1)} )))",
+      '  `("reads $name", async () => {',
+      "    expect(await Book.count()).toBe(0);",
+      "  });",
+      "",
+      '  it("writes", async () => {',
+      '    await Book.create({ name: "Dune" });',
+      "  });",
+      "});",
+      "",
+    ].join("\n");
+    expect(rowWritesAtItScope(src).map((w) => w.line)).toEqual([10]);
+  });
+
   it("does not grow past the seeded ratchet", async () => {
     const offenders = await findOffenders(path.join(REPO_ROOT, TEST_ROOT));
     const relative = offenders.map((file) => path.relative(REPO_ROOT, file));

--- a/scripts/non-transactional-row-writes.ts
+++ b/scripts/non-transactional-row-writes.ts
@@ -50,6 +50,14 @@
  * connection implicitly, naming no accessor. No file in this tree has that
  * shape — the canonical-schema files all ride `fixtures()` — and closing it
  * needs receiver-level knowledge the textual scan does not have.
+ *
+ * The seed grew by one once `stripCommentsAndStrings` became a scanner. The
+ * regex chain it replaced ran one pass per quote kind, so a quote of one kind
+ * inside a literal of another paired with the next one anywhere in the file and
+ * deleted everything between — the apostrophe in a template's `` `Couldn't find
+ * a match` `` swallowed the rest of `encryption-schemes.test.ts`, taking its
+ * unmatched parens with it and desynchronising the depth below. That file was
+ * always an offender; it was hidden, not clean.
  */
 
 import { readdir, readFile } from "node:fs/promises";
@@ -82,19 +90,86 @@ export const WRITE_PATTERNS = [".create(", ".insert", ".update(", "INSERT INTO",
 /**
  * Strip block comments, line comments, and string literals so a commented-out
  * `.create(` — or a `fixtures(` named in prose — doesn't change the verdict.
- * Template literals are emptied rather than dropped so an interpolated
- * `INSERT INTO` inside raw SQL still counts as the write it is; the literal is
- * replaced by its own contents minus the backticks.
+ * Newlines survive every strip, so a reported line number still names the line
+ * it was read from.
+ *
+ * A template literal keeps its raw text — an interpolated `INSERT INTO` inside
+ * raw SQL still counts as the write it is — but its parentheses are blanked,
+ * because raw text is not code and a `(` in an `it.each` table cell would
+ * otherwise desynchronise the paren depth {@link rowWritesAtItScope} tracks
+ * scope with. Its `${…}` interpolations ARE code and are left alone. The
+ * delimiting backticks survive for the outermost literal, which is what lets
+ * `rowWritesAtItScope` see where a tagged-template table ends; a literal nested
+ * inside an interpolation is blanked so the two cannot be confused.
  */
 export function stripCommentsAndStrings(src: string): string {
-  return src
-    .replace(/\/\*[\s\S]*?\*\//g, "")
-    .replace(/\/\/.*$/gm, "")
-    .replace(/'(?:\\.|[^'\\])*'/g, "''")
-    .replace(/"(?:\\.|[^"\\])*"/g, '""');
+  const stack: { kind: "template" | "interp"; braces: number }[] = [];
+  const inRawText = (): boolean => stack[stack.length - 1]?.kind === "template";
+  const nested = (): boolean => stack.some((frame) => frame.kind === "template");
+  let out = "";
+
+  for (let i = 0; i < src.length; i++) {
+    const ch = src[i];
+
+    if (inRawText()) {
+      if (ch === "\\") {
+        out += src[i + 1] === "\n" ? " \n" : "  ";
+        i++;
+      } else if (ch === "`") {
+        stack.pop();
+        out += nested() ? " " : "`";
+      } else if (ch === "$" && src[i + 1] === "{") {
+        stack.push({ kind: "interp", braces: 0 });
+        out += "  ";
+        i++;
+      } else {
+        out += ch === "(" || ch === ")" ? " " : ch;
+      }
+      continue;
+    }
+
+    if (ch === "/" && src[i + 1] === "*") {
+      const end = src.indexOf("*/", i + 2);
+      const body = end === -1 ? src.slice(i) : src.slice(i, end + 2);
+      out += body.replace(/[^\n]/g, " ");
+      i += body.length - 1;
+      continue;
+    }
+    if (ch === "/" && src[i + 1] === "/") {
+      const end = src.indexOf("\n", i);
+      const body = end === -1 ? src.slice(i) : src.slice(i, end);
+      out += " ".repeat(body.length);
+      i += body.length - 1;
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      let j = i + 1;
+      while (j < src.length && src[j] !== ch) j += src[j] === "\\" ? 2 : 1;
+      out += ch + ch;
+      i = j;
+      continue;
+    }
+    if (ch === "`") {
+      out += nested() ? " " : "`";
+      stack.push({ kind: "template", braces: 0 });
+      continue;
+    }
+    if (ch === "{" && stack.length > 0) stack[stack.length - 1].braces++;
+    if (ch === "}" && stack[stack.length - 1]?.kind === "interp") {
+      const frame = stack[stack.length - 1];
+      if (frame.braces === 0) {
+        stack.pop();
+        out += " ";
+        continue;
+      }
+      frame.braces--;
+    }
+    out += ch;
+  }
+  return out;
 }
 
-const IT_CALL = /(?:^|[^.\w])(?:it|test)((?:\.\w+)*)\s*\(/g;
+const IT_CALL = /(?:^|[^.\w])(?:it|test)((?:\.\w+)*)\s*[(`]/g;
 
 export interface RowWrite {
   line: number;
@@ -116,12 +191,9 @@ export interface RowWrite {
  * The table form `it.each([...])("name", fn)` puts the body in a SECOND call,
  * so the `it.each(` paren closes before the body starts. That paren is tracked
  * separately and, when it closes, the scope push is deferred to the `(` that
- * opens the body call.
- *
- * Known gap: the tagged-template table form (`` it.each`…`("name", fn) ``) is
- * not recognized — template literals survive `stripCommentsAndStrings`, so the
- * parens inside a table cell would be read as code. No file in this tree uses
- * it.
+ * opens the body call. The tagged-template table form
+ * (`` it.each`…`("name", fn) ``) is the same shape with a template in place of
+ * the array, so the same deferral runs off the template's closing backtick.
  */
 export function rowWritesAtItScope(src: string): RowWrite[] {
   const stripped = stripCommentsAndStrings(src);
@@ -130,6 +202,8 @@ export function rowWritesAtItScope(src: string): RowWrite[] {
   const eachParens: number[] = [];
   let bodyCallPending = false;
   let parenDepth = 0;
+  let inTemplate = false;
+  let taggedTemplate = false;
 
   const lines = stripped.split("\n");
   for (let i = 0; i < lines.length; i++) {
@@ -137,14 +211,29 @@ export function rowWritesAtItScope(src: string): RowWrite[] {
 
     const itColumns = new Set<number>();
     const eachColumns = new Set<number>();
+    const tagColumns = new Set<number>();
     IT_CALL.lastIndex = 0;
     for (let m = IT_CALL.exec(line); m !== null; m = IT_CALL.exec(line)) {
       const column = m.index + m[0].length - 1;
-      (m[1].split(".").includes("each") ? eachColumns : itColumns).add(column);
+      if (line[column] === "`") tagColumns.add(column);
+      else (m[1].split(".").includes("each") ? eachColumns : itColumns).add(column);
     }
 
     for (let c = 0; c < line.length; c++) {
       const ch = line[c];
+      if (ch === "`") {
+        if (inTemplate) {
+          inTemplate = false;
+          if (taggedTemplate) {
+            taggedTemplate = false;
+            bodyCallPending = true;
+            continue;
+          }
+        } else {
+          inTemplate = true;
+          taggedTemplate = tagColumns.has(c);
+        }
+      }
       if (ch === "(") {
         parenDepth++;
         if (eachColumns.has(c)) eachParens.push(parenDepth);

--- a/scripts/test-compare/extract-ruby-gates.test.ts
+++ b/scripts/test-compare/extract-ruby-gates.test.ts
@@ -296,6 +296,29 @@ describe("Ruby extractor gate detection", () => {
     expect(g["unless compound"]).toEqual({ guards: ["no_insert_returning"], source: ["class"] });
   });
 
+  it("reads a boolean nested under a negation in run space", () => {
+    const g = rubyGates({
+      "cases/bar_test.rb": `
+        def test_not_pg_and_feature; end if !(current_adapter?(:PostgreSQLAdapter) && supports_insert_returning?)
+        def test_unless_not_pg_or_feature; end unless !(current_adapter?(:PostgreSQLAdapter) || supports_insert_returning?)
+      `,
+    });
+    // `if !(A && feature)` runs on `!A || !feature` — a disjunction, even though
+    // the only operator in the source text is `&&`. Reading the token alone made
+    // it a pure conjunction and emitted the exclusion `ALL - postgresql`, which
+    // is wrong: the test also runs on PostgreSQL without the feature.
+    expect(g["not pg and feature"]).toEqual({
+      features: ["insert_returning"],
+      source: ["class"],
+    });
+    // `unless !(A || feature)` runs on `A || feature` — the same union, reached
+    // from the other path.
+    expect(g["unless not pg or feature"]).toEqual({
+      guards: ["no_insert_returning"],
+      source: ["class"],
+    });
+  });
+
   it("intersects a positive adapter with a negated adapter in a pure conjunction", () => {
     const g = rubyGates({
       "cases/bar_test.rb": `

--- a/scripts/test-compare/extract-ruby-tests.rb
+++ b/scripts/test-compare/extract-ruby-tests.rb
@@ -607,7 +607,7 @@ class TestExtractor
   # whether the body runs when the condition is true (`if` → true, `unless` → false).
   def gate_from_run_condition(cond, positive)
     acc = { adapter_syms: [], neg_adapter_syms: [], features: [], neg_features: [], guards: [],
-            has_or: false, has_and: false }
+            or_true: false, or_false: false }
     scan_run_condition(cond, acc)
 
     # A NEGATED feature predicate only decomposes when the RUN condition is a pure
@@ -617,11 +617,15 @@ class TestExtractor
     # Elsewhere the run-on set isn't that intersection, so the polarity-blind
     # lumping stays.
     #
-    # `has_or` is textual, so it only answers that question on the run-when-true
-    # path. On the `unless` path the run condition is the NEGATION of the source
-    # condition, and De Morgan turns its `&&` into a disjunction (`unless A && B`
-    # runs on `!A || B`) that `has_or` never sees — hence `has_and`.
-    run_has_or = positive ? acc[:has_or] : (acc[:has_and] || acc[:has_or])
+    # `scan_run_condition` records each boolean in RUN space at its own negation
+    # parity: `or_true` is "the source condition is a disjunction", `or_false`
+    # is "its negation is" — which is what the `unless` path runs on (`unless
+    # A && B` runs on `!A || B`). The `unless` path keeps `or_true` in the union
+    # as well: `unless A || B` runs on the conjunction `!A && !B`, but treating
+    # it as a disjunction only withholds a decomposition, and holding the two
+    # paths' outcomes fixed for un-negated shapes is what keeps this change to
+    # the negated-boolean shapes it is about.
+    run_has_or = positive ? acc[:or_true] : (acc[:or_false] || acc[:or_true])
     split = !run_has_or
     # Feature polarity is read against the RUN condition: on the `unless` path a
     # textually-negated predicate is the one the test RUNS on (`skip if
@@ -666,8 +670,8 @@ class TestExtractor
     # negated-adapter branch below uses.
     mixed = !adapters.empty? &&
             (!acc[:guards].empty? ||
-             (any_feature && (acc[:has_or] || !positive)) ||
-             (acc[:has_or] && !neg_adapters.empty?))
+             (any_feature && (acc[:or_true] || !positive)) ||
+             (acc[:or_true] && !neg_adapters.empty?))
     if !adapters.empty? && !mixed
       gate[:adapters] = positive ? adapters : (ALL_ADAPTERS - adapters)
     end
@@ -677,7 +681,7 @@ class TestExtractor
     # runs on every adapter that supports the feature, minus SQLite. We can only
     # emit it on the run-when-true (`if`) path; under `unless` the negation turns
     # the conjunction into a disjunction that isn't expressible as one adapter set.
-    if positive && !neg_adapters.empty? && !acc[:has_or]
+    if positive && !neg_adapters.empty? && !run_has_or
       base = gate[:adapters] || ALL_ADAPTERS
       gate[:adapters] = base - neg_adapters
     end
@@ -707,13 +711,27 @@ class TestExtractor
       scan_run_condition(node[2], acc, !negated)
       return
     end
-    # `||`/`or` anywhere makes the run-on adapter set a disjunction; record it so
-    # a negated-adapter exclusion isn't unsoundly emitted from a compound.
-    acc[:has_or] = true if node[0] == :binary && (node[2] == :"||" || node[2] == :or)
-    # `&&`/`and` becomes a disjunction once the condition is negated, which is
-    # exactly what the `unless` path runs on; recorded so the polarity split can
-    # tell a pure run-condition conjunction from `!(A && B)`.
-    acc[:has_and] = true if node[0] == :binary && (node[2] == :"&&" || node[2] == :and)
+    # A disjunction makes the run-on adapter set a union; record it so a
+    # negated-adapter exclusion isn't unsoundly emitted from a compound. Which
+    # operator a node contributes is read in RUN space, not source space: an
+    # enclosing `!` De Morgans it, so `!(A && B)` is a disjunction and
+    # `!(A || B)` is a conjunction. `negated` is the same parity the adapter and
+    # feature predicates below already read, so a boolean nested under a `!` is
+    # no longer counted as the operator its token spells.
+    if node[0] == :binary
+      or_op = node[2] == :"||" || node[2] == :or
+      and_op = node[2] == :"&&" || node[2] == :and
+      if or_op || and_op
+        # The operator this node presents when the SOURCE condition is true.
+        eff_or = negated ? and_op : or_op
+        # ...and when it is false, which is what the `unless` path runs on.
+        if eff_or
+          acc[:or_true] = true
+        else
+          acc[:or_false] = true
+        end
+      end
+    end
     name = call_ident_name(node)
     if name
       # Once a predicate is identified, stop: recursing into its own receiver/args


### PR DESCRIPTION
feat(activerecord,scripts): eager encryption scheme resolution, writing-pool leak guard, template-literal-aware row-write lint, parity-aware Ruby gate booleans

Four bundled stories.

## Assign global previous schemes at scheme_for time, restoring Rails' memos

`encrypted-attribute-type.ts` carried a module-level `_globalPreviousSchemesFn`,
injected by `encryptable-record.ts` and read at type-read time — a trails
invention with no Rails counterpart, and the reason PR #6116 had to DELETE the
three memos `encrypted_attribute_type.rb` has.

Rails assigns `scheme.previous_schemes` in one shot inside `scheme_for`
(encryptable_record.rb:70-76), which is what makes it frozen by construction.
`schemeFor` (and `buildScheme`, its legacy-shim variant) now does the same, and
the injection point, `_effectivePreviousSchemes`, and the deviation JSDoc are
gone; `previousSchemesIncludingCleanText` / `previousTypesWithoutCleanText` read
the plain `previousSchemes` delegate as `:66-71` do. The three memos are back
with Rails' keys: `@previous_types` hashed on `support_unencrypted_data?`, plus
the two `||=`.

The cycle the injection dodged disappears with it — `encrypted-attribute-type`
no longer reaches back into `encryptable-record` at all.

One further deviation had to converge for "encryption schemes are resolved when
used, not when declared" (encryptable_record_test.rb:388) to stay green: Rails
runs `scheme_for` INSIDE the `decorate_attributes` block, so the scheme is built
when the attribute type is resolved (and rebuilt on replay), not at `encrypts`
time. trails built it at declaration. The pending-encryption entry now carries
the scheme as a getter, so a `configure` between `encrypts` and the first type
resolution contributes its global previous schemes exactly as in Rails.

## Guard against leaked writing pools in test teardown

Since #6109 pinned every writing pool up front, `pin_connection!`'s eager
`verify!` (connection_pool.rb:335) turns any pool a file leaves in the handler
into a hard cross-file failure — on the NEXT file, and only on the lanes whose
server rejects the config.

`cases/helper.ts` (the `helper.rb` port) now takes a per-file census of
`connectionPoolList("writing")` and fails the file that grew it, naming the
leaked pool's connection descriptor. Proven by reverting
`InMemoryModel.removeConnection()`: the file reds and names `InMemoryModel`.

The audit it surfaced fixed nine files — `base.test.ts`,
`connection-handling.test.ts`, `connection-pool.test.ts`, `shard-selector`,
`shard-keys`, `connection-handlers-multi-db`, `connection-handlers-sharding-db`,
`connection-swapping-nested`, `with-transactional-fixtures`. Most were
`clearAllConnections!` teardowns, which disconnect the pools but leave them in
the handler. All 217 top-level `activerecord/src/*.test.ts` files pass with the
guard armed.

## Row-write lint sees `it.each` tagged-template tables

`stripCommentsAndStrings` is a scanner now, not a regex chain: template literals
keep their raw text (so an interpolated `INSERT INTO` still counts) with their
parens blanked, `${…}` interpolations stay code, and every strip preserves
newlines. `IT_CALL` matches the tagged form and defers the scope push to the `(`
after the closing backtick, the same deferral the `it.each(` table form uses. The
remaining-gap note is gone from the JSDoc.

The ratchet reseeds by one (rebased onto #6125's shared-connection scoping,
which retired the other three), rationale recorded in the module doc: the regex
chain ran one pass per quote kind, so the apostrophe in a template's
`` `Couldn't find a match` `` paired with the next one further down and deleted
everything between, taking unmatched parens with it. `encryption-schemes.test.ts`
was always an offender — it was hidden, not clean.

## Ruby gate extractor's booleans are parity-aware

`has_or` / `has_and` were set from the operator token alone, ignoring the
`negated` parity the same walk already tracks, so `if !(A && B)` — which runs on
`!A || B` — was read as a pure conjunction and emitted an unsound adapter
exclusion. They are replaced by `or_true` / `or_false`, recorded in run space at
each node's own parity, converging on `gateFromGuardExpr`'s run-condition
reading (gates.ts:186-215).

Verified latent as the story predicted: the per-gate diff of
`output/rails-tests.json` across the whole vendored suite moved 0 of 22,903
tests (1,916 gated, unchanged). All existing pins pass unchanged; two new pins
cover both negated-boolean shapes.

## Not in this PR

`datetime-new-start-preserves-the-receiver` is not implemented here. It was
blocked on PR #6123 (`Date#new_start`, `Date`'s `start`/`jd` state) when this
branch was cut; #6123 has since merged, so the story is back in the ready queue
(`status: ready`, unclaimed) for its own PR rather than being folded into this
one at the LOC ceiling.

Closes-story: guard-against-leaked-writing-pools-in-test-teardown
Closes-story: row-write-lint-misses-tagged-template-each
Closes-story: ruby-gate-extractor-boolean-flags-are-negation-blind
Closes-story: converge-global-previous-schemes-to-eager-scheme-assignment
