### PR TITLE
feat(i18n,activerecord): Date takes date_initialize's guess_style arm, Configurable reads the context through Contexts

### DIFF
--- a/packages/activerecord/src/encryption/config.ts
+++ b/packages/activerecord/src/encryption/config.ts
@@ -168,3 +168,23 @@ export class Config {
     this.previousSchemes.push(new Scheme(properties));
   }
 }
+
+/**
+ * Backing store for Rails' `mattr_reader :config, default: Config.new`
+ * (encryption/configurable.rb:9), read through {@link Configurable.config}.
+ *
+ * @noRailsEquivalent Ruby resolves `ActiveRecord::Encryption.config` at call
+ * time, so `Encryptor` and `Context` can name it without any load-order
+ * consequence. ESM has no such deferral: an `import` of `configurable.js` from
+ * those two files puts `Contexts` — and therefore
+ * `EncryptingOnlyEncryptor extends Encryptor` — inside a cycle entered at
+ * `encryptor.ts`, where the subclass evaluates with `Encryptor` in its TDZ.
+ * Holding the singleton next to its class keeps the reader on `Configurable`
+ * where Rails declares it, and keeps the `extends` out of the cycle.
+ */
+let _sharedConfig: Config | undefined;
+
+/** @internal Backs `Configurable.config`; see {@link _sharedConfig}. */
+export function getSharedConfig(): Config {
+  return (_sharedConfig ??= new Config());
+}

--- a/packages/activerecord/src/encryption/config.ts
+++ b/packages/activerecord/src/encryption/config.ts
@@ -169,22 +169,21 @@ export class Config {
   }
 }
 
-/**
- * Backing store for Rails' `mattr_reader :config, default: Config.new`
- * (encryption/configurable.rb:9), read through {@link Configurable.config}.
- *
- * @noRailsEquivalent Ruby resolves `ActiveRecord::Encryption.config` at call
- * time, so `Encryptor` and `Context` can name it without any load-order
- * consequence. ESM has no such deferral: an `import` of `configurable.js` from
- * those two files puts `Contexts` — and therefore
- * `EncryptingOnlyEncryptor extends Encryptor` — inside a cycle entered at
- * `encryptor.ts`, where the subclass evaluates with `Encryptor` in its TDZ.
- * Holding the singleton next to its class keeps the reader on `Configurable`
- * where Rails declares it, and keeps the `extends` out of the cycle.
- */
 let _sharedConfig: Config | undefined;
 
-/** @internal Backs `Configurable.config`; see {@link _sharedConfig}. */
+/**
+ * @internal The store behind Rails' `mattr_reader :config, default: Config.new`
+ * (encryption/configurable.rb:9), read through `Configurable.config` — which
+ * stays the reader, where Rails declares it.
+ *
+ * @noRailsEquivalent Ruby resolves `ActiveRecord::Encryption.config` at call
+ * time, so `Encryptor`, `Context`, `Scheme`, `KeyProvider` and `KeyGenerator`
+ * name it with no load-order consequence. ESM has no such deferral: an `import`
+ * of `configurable.js` from those files puts `Contexts` — and therefore
+ * `EncryptingOnlyEncryptor extends Encryptor` — inside a cycle entered at
+ * `encryptor.ts`, where the subclass evaluates with `Encryptor` in its TDZ.
+ * Keeping the singleton next to its class keeps that `extends` out of the cycle.
+ */
 export function getSharedConfig(): Config {
   return (_sharedConfig ??= new Config());
 }

--- a/packages/activerecord/src/encryption/configurable.ts
+++ b/packages/activerecord/src/encryption/configurable.ts
@@ -1,13 +1,6 @@
-import { Config } from "./config.js";
-// Rails reads `ActiveRecord::Encryption.context` / `.reset_default_context`
-// (configurable.rb:17, 33, 36) — the `Contexts` module those come from. This
-// module imports their implementations from `context.js` rather than `Contexts`
-// itself: `Contexts` imports `EncryptingOnlyEncryptor` for
-// `protecting_encrypted_data` (contexts.rb:57), and that class `extends
-// Encryptor`, which imports this module. Going through `Contexts` would put
-// that `extends` inside an ESM cycle, where a graph entered at `encryptor.ts`
-// evaluates the subclass while `Encryptor` is still in TDZ.
-import { getEncryptionContext, resetDefaultContext, Context } from "./context.js";
+import { Config, getSharedConfig } from "./config.js";
+import { Context } from "./context.js";
+import { Contexts } from "./contexts.js";
 import { Cipher } from "./cipher.js";
 import type { EncryptorLike } from "./encryptor.js";
 import type { MessageSerializerLike } from "./message-serializer.js";
@@ -15,7 +8,6 @@ import type { SchemeOptions } from "./scheme.js";
 
 type DeclarationListener = (klass: any, name: string) => void;
 
-let _sharedConfig: Config | null = null;
 // Mirrors Rails' `mattr_accessor :encrypted_attribute_declaration_listeners`
 // (no default → nil). Lazily allocated in onEncryptedAttributeDeclared.
 let _listeners: DeclarationListener[] | undefined;
@@ -28,10 +20,7 @@ let _listeners: DeclarationListener[] | undefined;
  */
 export class Configurable {
   static get config(): Config {
-    if (!_sharedConfig) {
-      _sharedConfig = new Config();
-    }
-    return _sharedConfig;
+    return getSharedConfig();
   }
 
   // Mirrors Rails' `mattr_accessor :encrypted_attribute_declaration_listeners`
@@ -58,27 +47,27 @@ export class Configurable {
    * {@link DelegatedProperty} below.
    */
   static get keyProvider(): unknown {
-    return getEncryptionContext().keyProvider;
+    return Contexts.context.keyProvider;
   }
 
   static get keyGenerator(): unknown {
-    return getEncryptionContext().keyGenerator;
+    return Contexts.context.keyGenerator;
   }
 
   static get cipher(): Cipher {
-    return getEncryptionContext().cipher as Cipher;
+    return Contexts.context.cipher as Cipher;
   }
 
   static get messageSerializer(): MessageSerializerLike | undefined {
-    return getEncryptionContext().messageSerializer;
+    return Contexts.context.messageSerializer;
   }
 
   static get encryptor(): EncryptorLike | undefined {
-    return getEncryptionContext().encryptor as EncryptorLike | undefined;
+    return Contexts.context.encryptor as EncryptorLike | undefined;
   }
 
   static get frozenEncryption(): boolean {
-    return getEncryptionContext().frozenEncryption;
+    return Contexts.context.frozenEncryption;
   }
 
   /**
@@ -130,7 +119,7 @@ export class Configurable {
       }
     }
 
-    resetDefaultContext();
+    Contexts.resetDefaultContext();
 
     for (const [key, value] of Object.entries(properties)) {
       if (key === "primaryKey" || key === "deterministicKey" || key === "keyDerivationSalt") {
@@ -138,7 +127,7 @@ export class Configurable {
       }
       if (value === undefined) continue;
       if (!(Context.PROPERTIES as readonly string[]).includes(key)) continue;
-      (getEncryptionContext() as unknown as Record<string, unknown>)[key] = value;
+      (Contexts.context as unknown as Record<string, unknown>)[key] = value;
     }
   }
 

--- a/packages/activerecord/src/encryption/context.ts
+++ b/packages/activerecord/src/encryption/context.ts
@@ -6,8 +6,8 @@
 
 import { MessageSerializer, type MessageSerializerLike } from "./message-serializer.js";
 import { NullEncryptor } from "./null-encryptor.js";
-import { Configurable } from "./configurable.js";
 import { Cipher } from "./cipher.js";
+import { getSharedConfig } from "./config.js";
 import { Encryptor } from "./encryptor.js";
 import { KeyGenerator } from "./key-generator.js";
 import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
@@ -64,12 +64,9 @@ export class Context {
 
   /**
    * @internal Rails `Context#build_default_key_provider` (context.rb:37-39).
-   * `Configurable` is imported for this body alone — the import closes a cycle
-   * (context → configurable → context) that holds only because neither module
-   * reads the other at eval time.
    */
   private buildDefaultKeyProvider(): unknown {
-    return new DerivedSecretKeyProvider(Configurable.config.primaryKey);
+    return new DerivedSecretKeyProvider(getSharedConfig().primaryKey);
   }
 }
 

--- a/packages/activerecord/src/encryption/encryptor.ts
+++ b/packages/activerecord/src/encryption/encryptor.ts
@@ -5,12 +5,12 @@
  */
 
 import { Message } from "./message.js";
+import type { Cipher } from "./cipher.js";
 import type { Properties } from "./properties.js";
 import type { MessageSerializerLike } from "./message-serializer.js";
 import { getEncryptionContext } from "./context.js";
-import { Configurable } from "./configurable.js";
 import { Base, Configuration, Decryption, Encoding, ForbiddenClass } from "./errors.js";
-import type { Compressor } from "./config.js";
+import { getSharedConfig, type Compressor } from "./config.js";
 import { normalizeEncoding, replaceUnencodable } from "./encoding-helpers.js";
 
 // Mirrors: ActiveRecord::Encryption::Encryptor::THRESHOLD_TO_JUSTIFY_COMPRESSION
@@ -48,7 +48,7 @@ export class Encryptor {
 
   constructor(options?: { compress?: boolean; compressor?: Compressor }) {
     this._compress = options?.compress ?? true;
-    this._compressor = options?.compressor ?? Configurable.config.compressor;
+    this._compressor = options?.compressor ?? getSharedConfig().compressor;
   }
 
   encrypt(
@@ -142,7 +142,7 @@ export class Encryptor {
 
   /** @internal */
   private cipher() {
-    return Configurable.cipher;
+    return getEncryptionContext().cipher as Cipher;
   }
 
   get compressor(): Compressor {
@@ -155,7 +155,7 @@ export class Encryptor {
 
   /** @internal */
   private defaultKeyProvider(): KeyProviderLike | undefined {
-    return Configurable.keyProvider as KeyProviderLike | undefined;
+    return getEncryptionContext().keyProvider as KeyProviderLike | undefined;
   }
 
   /** @internal */
@@ -254,6 +254,6 @@ export class Encryptor {
 
   /** @internal */
   private forcedEncodingForDeterministicEncryption(): string {
-    return Configurable.config.forcedEncodingForDeterministicEncryption;
+    return getSharedConfig().forcedEncodingForDeterministicEncryption;
   }
 }

--- a/packages/activerecord/src/encryption/key-generator.ts
+++ b/packages/activerecord/src/encryption/key-generator.ts
@@ -6,13 +6,14 @@
 
 import { getCrypto } from "@blazetrails/activesupport";
 import { KeyGenerator as AsKeyGenerator } from "@blazetrails/activesupport/key-generator";
-import { Configurable } from "./configurable.js";
+
+import { getSharedConfig } from "./config.js";
 
 export class KeyGenerator {
   private _hashDigestClass: string;
 
   constructor(hashDigestClass?: string) {
-    this._hashDigestClass = hashDigestClass ?? Configurable.config.hashDigestClass;
+    this._hashDigestClass = hashDigestClass ?? getSharedConfig().hashDigestClass;
   }
 
   get hashDigestClass(): string {
@@ -48,7 +49,7 @@ export class KeyGenerator {
 
   /** @internal */
   private keyDerivationSalt(): string {
-    return Configurable.config.keyDerivationSalt;
+    return getSharedConfig().keyDerivationSalt;
   }
 
   /** @internal */

--- a/packages/activerecord/src/encryption/key-provider.ts
+++ b/packages/activerecord/src/encryption/key-provider.ts
@@ -6,7 +6,7 @@
 
 import { Key } from "./key.js";
 import { headerString } from "./encoding-helpers.js";
-import { Configurable } from "./configurable.js";
+import { getSharedConfig } from "./config.js";
 import type { Message } from "./message.js";
 
 export class KeyProvider {
@@ -21,7 +21,7 @@ export class KeyProvider {
   encryptionKey(): Key {
     if (!this._encryptionKey) {
       const key = this._keys[this._keys.length - 1];
-      if (Configurable.config.storeKeyReferences) {
+      if (getSharedConfig().storeKeyReferences) {
         key.publicTags.encryptedDataKeyId = key.id;
       }
       this._encryptionKey = key;

--- a/packages/activerecord/src/encryption/scheme.ts
+++ b/packages/activerecord/src/encryption/scheme.ts
@@ -6,10 +6,9 @@
 
 import { Encryptor, type EncryptorLike } from "./encryptor.js";
 import { Configuration } from "./errors.js";
-import type { Compressor } from "./config.js";
+import { getSharedConfig, type Compressor } from "./config.js";
 import type { MessageSerializerLike } from "./message-serializer.js";
-import { Configurable } from "./configurable.js";
-import { withEncryptionContext, type Context } from "./context.js";
+import { withEncryptionContext, getEncryptionContext, type Context } from "./context.js";
 import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
 import { DeterministicKeyProvider } from "./deterministic-key-provider.js";
 
@@ -81,7 +80,7 @@ export class Scheme {
   }
 
   isSupportUnencryptedData(): boolean {
-    return this._opts.supportUnencryptedData ?? Configurable.config.supportUnencryptedData;
+    return this._opts.supportUnencryptedData ?? getSharedConfig().supportUnencryptedData;
   }
 
   // fixed: true (default for deterministic) → serialize uses the oldest previous
@@ -142,13 +141,13 @@ export class Scheme {
 
   /** @internal */
   private defaultKeyProvider(): unknown {
-    return Configurable.keyProvider;
+    return getEncryptionContext().keyProvider;
   }
 
   /** @internal */
   private deterministicKeyProvider(): DeterministicKeyProvider | undefined {
     if (this.deterministic) {
-      const deterministicKey = Configurable.config.deterministicKey;
+      const deterministicKey = getSharedConfig().deterministicKey;
       this._cachedDeterministicKeyProvider ??= new DeterministicKeyProvider(deterministicKey);
       return this._cachedDeterministicKeyProvider;
     }

--- a/packages/i18n/src/date.trails.test.ts
+++ b/packages/i18n/src/date.trails.test.ts
@@ -537,6 +537,46 @@ describe("Date", () => {
     expect(() => new RubyDate(1582, 10, 10)).toThrow(RubyDate.Error);
     expect(new RubyDate(1582, 10, 10, RubyDate.GREGORIAN).toS()).toBe("1582-10-10");
   });
+  // `date_initialize` branches on `guess_style` (date_core.c:3533) before it
+  // validates: outside REFORM_BEGIN_YEAR..REFORM_END_YEAR, or under an infinite
+  // `start`, it takes the `valid_gregorian_p` arm (date_core.c:3533-3542)
+  // instead of `valid_civil_p`. Every expectation below is `ruby 3.3.11 -rdate`.
+  it("takes date_initialize's guess_style arms either side of the reform years", () => {
+    const cases: Array<[number, number, number, number, [number, number, number] | "E"]> = [
+      // y < REFORM_BEGIN_YEAR — positive style, still the valid_civil_p arm.
+      [1581, 12, 31, RubyDate.ITALY, [1581, 12, 31]],
+      [1500, 2, 29, RubyDate.ITALY, [1500, 2, 29]],
+      [1500, 2, 29, RubyDate.GREGORIAN, "E"],
+      // inside the reform window — the valid_civil_p arm, deleted days and all.
+      [1582, 10, 10, RubyDate.ITALY, "E"],
+      [1582, 10, 15, RubyDate.ITALY, [1582, 10, 15]],
+      [1752, 9, 3, RubyDate.ENGLAND, "E"],
+      [1930, 12, 31, RubyDate.ITALY, [1930, 12, 31]],
+      // y > REFORM_END_YEAR — negative style, the valid_gregorian_p arm.
+      [1931, 1, 1, RubyDate.ITALY, [1931, 1, 1]],
+      [1900, 2, 29, RubyDate.ITALY, "E"],
+      [2000, 2, 29, RubyDate.ITALY, [2000, 2, 29]],
+      [2001, 2, 29, RubyDate.ITALY, "E"],
+      [2001, -1, -1, RubyDate.ITALY, [2001, 12, 31]],
+      [2001, 13, 1, RubyDate.ITALY, "E"],
+      // an infinite start — non-zero style whatever the year.
+      [2001, 1, 1, RubyDate.JULIAN, [2001, 1, 1]],
+      [1, 1, 1, RubyDate.JULIAN, [1, 1, 1]],
+      [1, 1, 1, RubyDate.GREGORIAN, [1, 1, 1]],
+      [-4712, 1, 1, RubyDate.GREGORIAN, [-4712, 1, 1]],
+    ];
+    for (const [year, month, day, start, expected] of cases) {
+      const got = (() => {
+        try {
+          const date = new RubyDate(year, month, day, start);
+          return [date.year, date.mon, date.day];
+        } catch {
+          return "E";
+        }
+      })();
+      expect([year, month, day, start, got]).toEqual([year, month, day, start, expected]);
+    }
+  });
 });
 
 describe("DateTime", () => {

--- a/packages/i18n/src/date.trails.test.ts
+++ b/packages/i18n/src/date.trails.test.ts
@@ -558,12 +558,14 @@ describe("Date", () => {
     expect(civilOrError(1582, 10, 15, RubyDate.ITALY)).toEqual([1582, 10, 15]);
     expect(civilOrError(1752, 9, 3, RubyDate.ENGLAND)).toBe("E");
     expect(civilOrError(1930, 12, 31, RubyDate.ITALY)).toEqual([1930, 12, 31]);
+    expect(civilOrError(1900, 2, 29, RubyDate.ITALY)).toBe("E");
   });
 
   it("takes date_initialize's valid_gregorian_p arm past REFORM_END_YEAR", () => {
     expect(civilOrError(1931, 1, 1, RubyDate.ITALY)).toEqual([1931, 1, 1]);
-    expect(civilOrError(1900, 2, 29, RubyDate.ITALY)).toBe("E");
     expect(civilOrError(2000, 2, 29, RubyDate.ITALY)).toEqual([2000, 2, 29]);
+    expect(civilOrError(2100, 2, 29, RubyDate.ITALY)).toBe("E");
+    expect(civilOrError(2100, 2, 28, RubyDate.ITALY)).toEqual([2100, 2, 28]);
     expect(civilOrError(2001, 2, 29, RubyDate.ITALY)).toBe("E");
     expect(civilOrError(2001, -1, -1, RubyDate.ITALY)).toEqual([2001, 12, 31]);
     expect(civilOrError(2001, 13, 1, RubyDate.ITALY)).toBe("E");

--- a/packages/i18n/src/date.trails.test.ts
+++ b/packages/i18n/src/date.trails.test.ts
@@ -537,45 +537,44 @@ describe("Date", () => {
     expect(() => new RubyDate(1582, 10, 10)).toThrow(RubyDate.Error);
     expect(new RubyDate(1582, 10, 10, RubyDate.GREGORIAN).toS()).toBe("1582-10-10");
   });
-  // `date_initialize` branches on `guess_style` (date_core.c:3533) before it
-  // validates: outside REFORM_BEGIN_YEAR..REFORM_END_YEAR, or under an infinite
-  // `start`, it takes the `valid_gregorian_p` arm (date_core.c:3533-3542)
-  // instead of `valid_civil_p`. Every expectation below is `ruby 3.3.11 -rdate`.
-  it("takes date_initialize's guess_style arms either side of the reform years", () => {
-    const cases: Array<[number, number, number, number, [number, number, number] | "E"]> = [
-      // y < REFORM_BEGIN_YEAR — positive style, still the valid_civil_p arm.
-      [1581, 12, 31, RubyDate.ITALY, [1581, 12, 31]],
-      [1500, 2, 29, RubyDate.ITALY, [1500, 2, 29]],
-      [1500, 2, 29, RubyDate.GREGORIAN, "E"],
-      // inside the reform window — the valid_civil_p arm, deleted days and all.
-      [1582, 10, 10, RubyDate.ITALY, "E"],
-      [1582, 10, 15, RubyDate.ITALY, [1582, 10, 15]],
-      [1752, 9, 3, RubyDate.ENGLAND, "E"],
-      [1930, 12, 31, RubyDate.ITALY, [1930, 12, 31]],
-      // y > REFORM_END_YEAR — negative style, the valid_gregorian_p arm.
-      [1931, 1, 1, RubyDate.ITALY, [1931, 1, 1]],
-      [1900, 2, 29, RubyDate.ITALY, "E"],
-      [2000, 2, 29, RubyDate.ITALY, [2000, 2, 29]],
-      [2001, 2, 29, RubyDate.ITALY, "E"],
-      [2001, -1, -1, RubyDate.ITALY, [2001, 12, 31]],
-      [2001, 13, 1, RubyDate.ITALY, "E"],
-      // an infinite start — non-zero style whatever the year.
-      [2001, 1, 1, RubyDate.JULIAN, [2001, 1, 1]],
-      [1, 1, 1, RubyDate.JULIAN, [1, 1, 1]],
-      [1, 1, 1, RubyDate.GREGORIAN, [1, 1, 1]],
-      [-4712, 1, 1, RubyDate.GREGORIAN, [-4712, 1, 1]],
-    ];
-    for (const [year, month, day, start, expected] of cases) {
-      const got = (() => {
-        try {
-          const date = new RubyDate(year, month, day, start);
-          return [date.year, date.mon, date.day];
-        } catch {
-          return "E";
-        }
-      })();
-      expect([year, month, day, start, got]).toEqual([year, month, day, start, expected]);
+  const civilOrError = (
+    year: number,
+    month: number,
+    day: number,
+    start: number,
+  ): [number, number, number] | "E" => {
+    try {
+      const date = new RubyDate(year, month, day, start);
+      return [date.year, date.mon, date.day];
+    } catch {
+      return "E";
     }
+  };
+
+  it("takes date_initialize's valid_civil_p arm at or before REFORM_END_YEAR", () => {
+    expect(civilOrError(1581, 12, 31, RubyDate.ITALY)).toEqual([1581, 12, 31]);
+    expect(civilOrError(1500, 2, 29, RubyDate.ITALY)).toEqual([1500, 2, 29]);
+    expect(civilOrError(1582, 10, 10, RubyDate.ITALY)).toBe("E");
+    expect(civilOrError(1582, 10, 15, RubyDate.ITALY)).toEqual([1582, 10, 15]);
+    expect(civilOrError(1752, 9, 3, RubyDate.ENGLAND)).toBe("E");
+    expect(civilOrError(1930, 12, 31, RubyDate.ITALY)).toEqual([1930, 12, 31]);
+  });
+
+  it("takes date_initialize's valid_gregorian_p arm past REFORM_END_YEAR", () => {
+    expect(civilOrError(1931, 1, 1, RubyDate.ITALY)).toEqual([1931, 1, 1]);
+    expect(civilOrError(1900, 2, 29, RubyDate.ITALY)).toBe("E");
+    expect(civilOrError(2000, 2, 29, RubyDate.ITALY)).toEqual([2000, 2, 29]);
+    expect(civilOrError(2001, 2, 29, RubyDate.ITALY)).toBe("E");
+    expect(civilOrError(2001, -1, -1, RubyDate.ITALY)).toEqual([2001, 12, 31]);
+    expect(civilOrError(2001, 13, 1, RubyDate.ITALY)).toBe("E");
+  });
+
+  it("takes date_initialize's guess_style arm under an infinite start", () => {
+    expect(civilOrError(2001, 1, 1, RubyDate.JULIAN)).toEqual([2001, 1, 1]);
+    expect(civilOrError(1, 1, 1, RubyDate.JULIAN)).toEqual([1, 1, 1]);
+    expect(civilOrError(1, 1, 1, RubyDate.GREGORIAN)).toEqual([1, 1, 1]);
+    expect(civilOrError(1500, 2, 29, RubyDate.GREGORIAN)).toBe("E");
+    expect(civilOrError(-4712, 1, 1, RubyDate.GREGORIAN)).toEqual([-4712, 1, 1]);
   });
 });
 

--- a/packages/i18n/src/date.ts
+++ b/packages/i18n/src/date.ts
@@ -1747,6 +1747,21 @@ const GREGORIAN = -Infinity;
 /** @internal `date_core.c`'s `DEFAULT_SG` (`date_core.c:190`). */
 const DEFAULT_SG = ITALY;
 
+/** @internal `date_core.c:207`, the first year the calendar reform can touch. */
+const REFORM_BEGIN_YEAR = 1582;
+
+/** @internal `date_core.c:208`, the last year the calendar reform can touch. */
+const REFORM_END_YEAR = 1930;
+
+/**
+ * @internal `date_core.c` `monthtab` (`date_core.c:697-700`), the last day of
+ * each month indexed by leapness then month, with a `0` in slot zero.
+ */
+const monthtab: readonly (readonly number[])[] = [
+  [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
+  [0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
+];
+
 /** @internal `date_core.c`'s `DIV` macro (`date_core.c:168-170`), floored division. */
 function div(n: number, d: number): number {
   return Math.floor(n / d);
@@ -1824,6 +1839,61 @@ function cFindFdoy(y: number, sg: number): [rjd: number, ns: number] | null {
     if (r !== null) return r;
   }
   return null;
+}
+
+/** @internal `date_core.c` `c_gregorian_leap_p` (`date_core.c:708-712`). */
+function cGregorianLeapP(y: number): boolean {
+  return (mod(y, 4) === 0 && y % 100 !== 0) || mod(y, 400) === 0;
+}
+
+/** @internal `date_core.c` `c_gregorian_last_day_of_month` (`date_core.c:721-726`). */
+function cGregorianLastDayOfMonth(y: number, m: number): number {
+  return monthtab[cGregorianLeapP(y) ? 1 : 0][m];
+}
+
+/**
+ * @internal `date_core.c` `c_valid_gregorian_p` (`date_core.c:747-763`), the
+ * table lookup {@link cValidCivilP}'s round trip stands in for once the
+ * calendar reform is known not to bite. A negative `m` counts back from a
+ * thirteenth month and a negative `d` from the month's last day, as there.
+ */
+function cValidGregorianP(y: number, m: number, d: number): [rm: number, rd: number] | null {
+  if (m < 0) m += 13;
+  if (m < 1 || m > 12) return null;
+  const last = cGregorianLastDayOfMonth(y, m);
+  if (d < 0) d = last + d + 1;
+  if (d < 1 || d > last) return null;
+  return [m, d];
+}
+
+/**
+ * @internal `date_core.c` `valid_gregorian_p` (`date_core.c:2229-2236`).
+ * `decode_year` splits a bignum year into an `nth` cycle count and a fixnum
+ * remainder; the port carries no `nth`, so the year passes straight through.
+ */
+function validGregorianP(y: number, m: number, d: number): [rm: number, rd: number] | null {
+  return cValidGregorianP(y, m, d);
+}
+
+/**
+ * @internal `date_core.c` `guess_style` (`date_core.c:1413-1432`), which
+ * answers a non-zero style — `-/+oo` — whenever the calendar reform cannot
+ * possibly bite: an infinite `sg`, a year too large for a fixnum, or a year
+ * outside `REFORM_BEGIN_YEAR .. REFORM_END_YEAR`. Ruby's fixnum bound is a JS
+ * safe integer here.
+ */
+function guessStyle(y: number, sg: number): number {
+  let style = 0;
+
+  if (!Number.isFinite(sg)) style = sg;
+  else if (!Number.isSafeInteger(y)) style = y > 0 ? GREGORIAN : JULIAN;
+  else {
+    const iy = y;
+
+    if (iy < REFORM_BEGIN_YEAR) style = JULIAN;
+    else if (iy > REFORM_END_YEAR) style = GREGORIAN;
+  }
+  return style;
 }
 
 /**
@@ -2237,11 +2307,25 @@ export class Date {
    * (ruby/date, `date_core.c` `date_s_civil`), which raises `Date::Error` on a
    * civil date `c_valid_civil_p` rejects — 1582-10-10 under `Date::ITALY` is a
    * day the reform deleted.
+   *
+   * `date_initialize` branches on `guess_style` first (`date_core.c:3533`): on a
+   * negative style the reform cannot bite, so it validates with
+   * `valid_gregorian_p` and stores `HAVE_CIVIL` alone — no Julian day is
+   * computed at all (`date_core.c:3533-3542`). `SimpleDateData`'s `flags`
+   * (`date_core.c:173-183`) is what lets it defer that; the port carries `jd`
+   * and `sg` in place of the flags word, so the Julian day is computed here
+   * either way and only the validation differs.
    */
   constructor(year = -4712, month = 1, day = 1, start: number = DEFAULT_SG) {
-    const r = cValidCivilP(year, month, day, start);
-    if (r === null) throw new DateError("invalid date");
-    this.#jd = r[0];
+    if (guessStyle(year, start) < 0) {
+      const r = validGregorianP(year, month, day);
+      if (r === null) throw new DateError("invalid date");
+      this.#jd = cCivilToJd(year, r[0], r[1], start)[0];
+    } else {
+      const r = cValidCivilP(year, month, day, start);
+      if (r === null) throw new DateError("invalid date");
+      this.#jd = r[0];
+    }
     this.#sg = start;
   }
 

--- a/packages/i18n/src/date.ts
+++ b/packages/i18n/src/date.ts
@@ -1880,7 +1880,8 @@ function validGregorianP(y: number, m: number, d: number): [rm: number, rd: numb
  * answers a non-zero style — `-/+oo` — whenever the calendar reform cannot
  * possibly bite: an infinite `sg`, a year too large for a fixnum, or a year
  * outside `REFORM_BEGIN_YEAR .. REFORM_END_YEAR`. Ruby's fixnum bound is a JS
- * safe integer here.
+ * safe integer here, and its `positive_inf`/`negative_inf` are the two
+ * infinities `JULIAN` and `GREGORIAN` already name (`date_core.c:188-189`).
  */
 function guessStyle(y: number, sg: number): number {
   let style = 0;
@@ -1888,10 +1889,8 @@ function guessStyle(y: number, sg: number): number {
   if (!Number.isFinite(sg)) style = sg;
   else if (!Number.isSafeInteger(y)) style = y > 0 ? GREGORIAN : JULIAN;
   else {
-    const iy = y;
-
-    if (iy < REFORM_BEGIN_YEAR) style = JULIAN;
-    else if (iy > REFORM_END_YEAR) style = GREGORIAN;
+    if (y < REFORM_BEGIN_YEAR) style = JULIAN;
+    else if (y > REFORM_END_YEAR) style = GREGORIAN;
   }
   return style;
 }


### PR DESCRIPTION
Two convergence stories from a three-story bundle. The third is blocked; see below.

## `Date`'s constructor takes `date_initialize`'s `guess_style` arm

`date_initialize` branches on `guess_style` (`date_core.c:1413-1432`) before it
validates anything. On a negative style — an infinite `sg`, a year too large for
a fixnum, or a year outside `REFORM_BEGIN_YEAR .. REFORM_END_YEAR`
(`date_core.c:207-208`) — the reform cannot bite, so it validates with
`valid_gregorian_p` (`date_core.c:3533-3542`) rather than `valid_civil_p`
(`date_core.c:3543-3554`). The port ran every construction through
`c_valid_civil_p`.

Ports `guess_style`, `valid_gregorian_p` (`date_core.c:2229-2236`),
`c_valid_gregorian_p` (`:747-763`), `c_gregorian_last_day_of_month` (`:721-726`),
`c_gregorian_leap_p` (`:708-712`) and `monthtab` (`:697-700`).

On the deferred-Julian-day question the story raised: ruby/date stores
`HAVE_CIVIL` alone on that arm and computes no Julian day, which
`SimpleDateData`'s `flags` word (`date_core.c:173-183`) is what makes possible.
The port carries `jd`/`sg` in place of the flags, so the arm collapses to
computing the Julian day either way and only the validation differs — noted at
the constructor.

Checked against `ruby 3.3.11 -rdate` over 4536 constructions (18 years × 7
months × 9 days × 4 starts, spanning 1581/1582/1583 and 1929/1930/1931 and both
infinite starts): zero mismatches. A representative slice of that matrix is now
a test.

## `Configurable` reads the context through `Contexts`

Rails' `Configurable` reads `ActiveRecord::Encryption.context` and
`.reset_default_context` (`configurable.rb:17, 33, 36`); trails' analogue of
that module is `Contexts`. #6123 had to import the free functions from
`context.js` instead, because going through `Contexts` puts
`EncryptingOnlyEncryptor extends Encryptor` (`encrypting_only_encryptor.rb:6`)
inside an ESM cycle entered at `encryptor.ts`, where the subclass evaluates with
`Encryptor` in its TDZ.

The cycle is broken at its source. The shared `Config` singleton behind Rails'
`mattr_reader :config, default: Config.new` (`configurable.rb:9`) now lives next
to its class in `config.ts`, and the five files that read
`ActiveRecord::Encryption.config` / `.cipher` / `.key_provider` from a method
body — `encryptor.rb:27,98,108,173`, `context.rb:38`, `scheme.rb`,
`key_provider.rb`, `key_generator.rb` — reach them without importing
`Configurable`. `Configurable.config` stays the reader, where Rails declares it.
The cycle note is deleted, not reworded.

Pre-existing, not a regression: `key-provider.js` used as a plain-node *entry
module* still hits a TDZ on `DerivedSecretKeyProvider extends KeyProvider`,
because `config.rb`'s own SHA1 provider (`config.rb:81`) makes
`config.ts -> derived-secret-key-provider.ts -> key-provider.ts` a real cycle.
That cycle is on `main` too, one hop longer
(`key-provider -> configurable -> config -> ...`); no code path enters there.

Verified the way the story asks — not under vitest, whose setup files enter
`configurable.js` first and mask the TDZ, but a plain `node` import of the built
`dist/encryption/encryptor.js`, plus every other module in the cluster as an
entry point.

## Not in this PR: `internal-metadata-takes-a-pool-nullpool-arm-reads-enabled`

Blocked, with the finding recorded on the story. Doing the conversion on this
branch showed two prerequisites the story does not own:

- `AbstractAdapter#pool` is declared `pool: unknown`
  (`connection-adapters/abstract-adapter.ts:852`), so all ~30
  `new InternalMetadata(adapter)` sites need either an `as ConnectionPool` cast
  or a pool-typing change of its own.
- Once `enabled` is the faithful `@pool.db_config.use_metadata_table?`
  (`internal_metadata.rb:35-36`) with no softening, every NullPool-backed site —
  `migrator.trails.test.ts`, `migration.test.ts`,
  `support/canonical-schema-stamp.ts`, `schema.ts`'s `Schema.define`,
  `tasks/database-tasks.ts`, trailties' `db.ts` — reads `NULL_CONFIG`
  (`connection-pool.ts:62,155`) and silently disables metadata storage
  suite-wide, exactly as the story's own context predicts.

It is now `blocked` with `migration-context-collaborators-need-a-pool` as its
dependency, so it gets rescheduled after the prerequisite rather than being
converged half-way here.

Closes-story: date-initialize-guess-style-fast-path
Closes-story: configurable-reads-the-context-through-contexts
