### PR TITLE
feat(activerecord,scripts): reasoned inheritance excludes take activerecord to 100%, AbstractAdapter#pool typed as a pool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1303,6 +1303,12 @@ jobs:
         # for the advisory arity check, applied by the API comparison step
         # above). Excludes only shrink — delete a converged entry by hand.
         run: pnpm exec tsx scripts/api-compare/lint-arity-excludes.ts
+      - name: Inheritance excludes gate
+        # Fails on a malformed or STALE entry in
+        # scripts/api-compare/inheritance-exclude.json (the reasoned suppression
+        # file for the inheritance check, applied by the API comparison step
+        # above). Excludes only shrink — delete a converged entry by hand.
+        run: pnpm exec tsx scripts/api-compare/lint-inheritance-excludes.ts
       - name: Missing-call reasons gate
         # Enforces the `@missingRailsCall` empty-reason contract (the same
         # `parseJsdoc` check `api:build` uses) over every JSDoc block under

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "api:calls:wide:unreviewed": "pnpm tsx scripts/api-compare/lint-call-mismatches-wide.ts --unreviewed",
     "api:calls:wide:reseed": "API_COMPARE_FORCE=1 pnpm api:compare --wide-calls && pnpm tsx scripts/api-compare/lint-call-mismatches-wide.ts --write --no-regen",
     "api:arity": "pnpm tsx scripts/api-compare/lint-arity-excludes.ts",
+    "api:inheritance": "pnpm tsx scripts/api-compare/lint-inheritance-excludes.ts",
     "api:pins": "pnpm tsx scripts/api-compare/lint-body-pins.ts",
     "api:pins:all": "API_COMPARE_FORCE=1 pnpm api:compare && pnpm tsx scripts/api-compare/body-pins.ts --pin-all",
     "fixtures:adoption:inventory": "pnpm tsx scripts/fixtures-inventory/inventory.ts",

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -814,7 +814,6 @@ export class AbstractAdapter implements Quoting {
   private _owner: string | null = null;
   private _inUse = false;
   private _preparedStatements = false;
-  private _schemaReflection: SchemaReflection | null = null;
   private _schemaCache: BoundSchemaReflection | null = null;
   private _idleSince = Date.now();
   protected _lastActivity = 0;
@@ -851,8 +850,7 @@ export class AbstractAdapter implements Quoting {
   _queryCache: Store | null = null;
 
   // Rails' @pool is a ConnectionPool once one owns the connection and a
-  // NullPool until then (abstract_adapter.rb:153). Readers still guard the
-  // slot: test doubles reach them without running this constructor.
+  // NullPool until then (abstract_adapter.rb:153).
   pool: ConnectionPool | NullPool = new NullPool();
   logger: unknown = null;
   lock: unknown = null;
@@ -1384,14 +1382,12 @@ export class AbstractAdapter implements Quoting {
   get role(): string {
     // Rails is a bare `@pool.role` (abstract_adapter.rb:288); NullPool defines
     // none (abstract/connection_pool.rb:14-51), so the default stands in.
-    const pool = this.pool;
-    return pool instanceof NullPool ? "writing" : (pool?.role ?? "writing");
+    return this.pool instanceof NullPool ? "writing" : this.pool.role;
   }
 
   get shard(): string {
     // Same NullPool arm as `role` — abstract_adapter.rb:294.
-    const pool = this.pool;
-    return pool instanceof NullPool ? "default" : (pool?.shard ?? "default");
+    return this.pool instanceof NullPool ? "default" : this.pool.shard;
   }
 
   /**
@@ -1404,9 +1400,9 @@ export class AbstractAdapter implements Quoting {
     const q = (v: string): string => JSON.stringify(String(v));
     // Rails renders a NullConfig's nil answers as `nil`
     // (abstract/connection_pool.rb:17-22); trails defaults them.
-    const dbConfig = this.pool?.dbConfig;
-    const envName = dbConfig?.envName ?? "test";
-    const configName = dbConfig?.name;
+    const dbConfig = this.pool.dbConfig;
+    const envName = dbConfig.envName ?? "test";
+    const configName = dbConfig.name;
     const nameField = configName && configName !== "primary" ? ` name=${q(configName)}` : "";
     const shardField = this.shard !== "default" ? ` shard=${q(this.shard)}` : "";
     this._inspectId ??= AbstractAdapter._inspectSeq = (AbstractAdapter._inspectSeq ?? 0) + 1;
@@ -1467,7 +1463,7 @@ export class AbstractAdapter implements Quoting {
     // Rails' `replica?` reads only `@config[:replica]` (abstract_adapter.rb:199);
     // the db_config arm is a trails addition for pooled adapters whose
     // per-connection config never carries the flag.
-    const replica = this.pool?.dbConfig?.replica;
+    const replica = this.pool.dbConfig.replica;
     if (typeof replica === "boolean") return replica;
     if (this.role === "reading") return true;
     return this._config.replica === true;
@@ -1482,7 +1478,7 @@ export class AbstractAdapter implements Quoting {
     // returns the entry's prevent_writes flag when (a) it includes Base by
     // identity, or (b) any klass's name matches the pool's connection name.
     const ownerName: string | undefined =
-      pool instanceof NullPool ? undefined : pool?.poolConfig?.connectionDescriptor?.name;
+      pool instanceof NullPool ? undefined : pool.poolConfig.connectionDescriptor.name;
     const stack = connectedToStack();
     for (let i = stack.length - 1; i >= 0; i--) {
       const entry = stack[i];
@@ -1549,7 +1545,7 @@ export class AbstractAdapter implements Quoting {
    * adapter.
    */
   get schemaCache(): BoundSchemaReflection {
-    const schemaCache = this.pool?.schemaCache;
+    const schemaCache = this.pool.schemaCache;
     if (schemaCache instanceof BoundSchemaReflection) return schemaCache;
     this._schemaCache ??= BoundSchemaReflection.forLoneConnection(
       this._poolSchemaReflection(),
@@ -1564,7 +1560,7 @@ export class AbstractAdapter implements Quoting {
    * (connection_pool.rb:34-36).
    */
   private _poolSchemaReflection(): SchemaReflection {
-    return this.pool?.schemaReflection ?? (this._schemaReflection ??= new SchemaReflection(null));
+    return this.pool.schemaReflection;
   }
 
   checkIfWriteQuery(sql: string): void {
@@ -1776,7 +1772,7 @@ export class AbstractAdapter implements Quoting {
     // NullPool#checkin is a no-op in Rails; trails expires a leased connection
     // on that arm instead.
     const pool = this.pool;
-    if (pool != null && !(pool instanceof NullPool)) {
+    if (!(pool instanceof NullPool)) {
       pool.checkin(this);
     } else if (this._inUse) {
       this.expire();
@@ -1827,7 +1823,7 @@ export class AbstractAdapter implements Quoting {
   }
 
   get connectionDescriptor(): unknown {
-    return this.pool?.connectionDescriptor ?? null;
+    return this.pool.connectionDescriptor ?? null;
   }
 
   /**
@@ -2119,7 +2115,7 @@ export class AbstractAdapter implements Quoting {
     // `pool.remove self; disconnect!`. Removing from the pool is what evicts
     // the connection so it can't be leased again after a transaction failure;
     // NullPool#remove is a no-op.
-    this.pool?.remove(this);
+    this.pool.remove(this);
     this.disconnectBang();
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -28,6 +28,7 @@ import { ActiveRecord } from "../ar-config.js";
 import { Result, type ColumnTypes } from "../result.js";
 import { SchemaCache, SchemaReflection, BoundSchemaReflection, FakePool } from "./schema-cache.js";
 import { NullPool } from "./abstract/connection-pool.js";
+import type { ConnectionPool } from "./abstract/connection-pool.js";
 import { stripSqlComments } from "./sql-classification.js";
 import {
   TransactionManager,
@@ -813,7 +814,6 @@ export class AbstractAdapter implements Quoting {
   private _owner: string | null = null;
   private _inUse = false;
   private _preparedStatements = false;
-  private _schemaReflection: SchemaReflection | null = null;
   private _schemaCache: BoundSchemaReflection | null = null;
   private _idleSince = Date.now();
   protected _lastActivity = 0;
@@ -849,7 +849,11 @@ export class AbstractAdapter implements Quoting {
 
   _queryCache: Store | null = null;
 
-  pool: unknown = null;
+  // Rails' @pool is always a pool object — a real ConnectionPool once one owns
+  // the connection, a NullPool until then (abstract_adapter.rb:153). Typing it
+  // as that union is what lets `role`/`shard`/`inspect`/`replica?` read it the
+  // way Rails does, without a cast at each site.
+  pool: ConnectionPool | NullPool = new NullPool();
   logger: unknown = null;
   lock: unknown = null;
   /** Stable per-instance hex slot + monotonic source for {@link inspect}. @internal */
@@ -1378,11 +1382,16 @@ export class AbstractAdapter implements Quoting {
   }
 
   get role(): string {
-    return (this.pool as any)?.role ?? "writing";
+    // Rails reads `@pool.role` unqualified (abstract_adapter.rb:288). A
+    // NullPool answers no role at all (abstract/connection_pool.rb:14-51), and
+    // trails supports standalone NullPool-backed adapters as a first-class
+    // path, so Rails' non-multi-role default stands in for that arm.
+    return this.pool instanceof NullPool ? "writing" : this.pool.role;
   }
 
   get shard(): string {
-    return (this.pool as any)?.shard ?? "default";
+    // Same NullPool arm as `role` — abstract_adapter.rb:294.
+    return this.pool instanceof NullPool ? "default" : this.pool.shard;
   }
 
   /**
@@ -1393,9 +1402,12 @@ export class AbstractAdapter implements Quoting {
    */
   inspect(): string {
     const q = (v: string): string => JSON.stringify(String(v));
-    const pool = this.pool as { dbConfig?: { envName?: string; name?: string } } | null;
-    const envName = pool?.dbConfig?.envName ?? "test";
-    const configName = pool?.dbConfig?.name;
+    const dbConfig = this.pool.dbConfig;
+    // A NullPool's NullConfig answers nil for every key
+    // (abstract/connection_pool.rb:17-22), which Rails renders as `nil`;
+    // trails' dump uses the test env/name defaults instead.
+    const envName = dbConfig.envName ?? "test";
+    const configName = dbConfig.name;
     const nameField = configName && configName !== "primary" ? ` name=${q(configName)}` : "";
     const shardField = this.shard !== "default" ? ` shard=${q(this.shard)}` : "";
     this._inspectId ??= AbstractAdapter._inspectSeq = (AbstractAdapter._inspectSeq ?? 0) + 1;
@@ -1453,8 +1465,11 @@ export class AbstractAdapter implements Quoting {
   }
 
   isReplica(): boolean {
-    if (typeof (this.pool as any)?.dbConfig?.replica === "boolean") {
-      return (this.pool as any).dbConfig.replica;
+    // Rails' `replica?` reads only `@config[:replica]` (abstract_adapter.rb:199);
+    // the pool's db_config arm is a trails addition kept for pooled adapters
+    // whose per-connection config never carries the flag.
+    if (typeof this.pool.dbConfig.replica === "boolean") {
+      return this.pool.dbConfig.replica;
     }
     if (this.role === "reading") return true;
     return this._config.replica === true;
@@ -1463,12 +1478,13 @@ export class AbstractAdapter implements Quoting {
   isPreventingWrites(): boolean {
     if (this.isReplica()) return true;
     if (this.connectionDescriptor === null) return false;
-    const pool = this.pool as any;
+    const pool = this.pool;
     // Mirrors Rails: connection_descriptor.current_preventing_writes →
     // Base.preventing_writes?(class_name). Walks the stack in reverse and
     // returns the entry's prevent_writes flag when (a) it includes Base by
     // identity, or (b) any klass's name matches the pool's connection name.
-    const ownerName: string | undefined = pool?.poolConfig?.connectionDescriptor?.name;
+    const ownerName: string | undefined =
+      pool instanceof NullPool ? undefined : pool.poolConfig.connectionDescriptor?.name;
     const stack = connectedToStack();
     for (let i = stack.length - 1; i >= 0; i--) {
       const entry = stack[i];
@@ -1535,8 +1551,8 @@ export class AbstractAdapter implements Quoting {
    * adapter.
    */
   get schemaCache(): BoundSchemaReflection {
-    const pool = this.pool as { schemaCache?: BoundSchemaReflection } | null;
-    if (pool?.schemaCache instanceof BoundSchemaReflection) return pool.schemaCache;
+    const schemaCache = this.pool.schemaCache;
+    if (schemaCache instanceof BoundSchemaReflection) return schemaCache;
     this._schemaCache ??= BoundSchemaReflection.forLoneConnection(
       this._poolSchemaReflection(),
       this,
@@ -1552,10 +1568,7 @@ export class AbstractAdapter implements Quoting {
    * `initialize` always plants a NullPool.
    */
   private _poolSchemaReflection(): SchemaReflection {
-    const pool = this.pool as { schemaReflection?: SchemaReflection } | null;
-    if (pool?.schemaReflection) return pool.schemaReflection;
-    this._schemaReflection ??= new SchemaReflection(null);
-    return this._schemaReflection;
+    return this.pool.schemaReflection;
   }
 
   checkIfWriteQuery(sql: string): void {
@@ -1768,8 +1781,8 @@ export class AbstractAdapter implements Quoting {
     // `checkin` is a no-op; trails leaves `pool` null for standalone adapters,
     // so the no-pool branch expires a leased connection and otherwise no-ops
     // (matching NullPool#checkin).
-    const pool = this.pool as { checkin?: (conn: unknown) => void } | null;
-    if (pool && !(pool instanceof NullPool) && typeof pool.checkin === "function") {
+    const pool = this.pool;
+    if (!(pool instanceof NullPool)) {
       pool.checkin(this);
     } else if (this._inUse) {
       this.expire();
@@ -1820,7 +1833,7 @@ export class AbstractAdapter implements Quoting {
   }
 
   get connectionDescriptor(): unknown {
-    return (this.pool as any)?.connectionDescriptor ?? null;
+    return this.pool.connectionDescriptor ?? null;
   }
 
   /**
@@ -2112,7 +2125,7 @@ export class AbstractAdapter implements Quoting {
     // `pool.remove self; disconnect!`. Removing from the pool is what evicts
     // the connection so it can't be leased again after a transaction failure;
     // standalone adapters (no pool) just disconnect.
-    (this.pool as { remove?: (conn: unknown) => void } | null)?.remove?.(this);
+    this.pool.remove(this);
     this.disconnectBang();
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -814,6 +814,7 @@ export class AbstractAdapter implements Quoting {
   private _owner: string | null = null;
   private _inUse = false;
   private _preparedStatements = false;
+  private _schemaReflection: SchemaReflection | null = null;
   private _schemaCache: BoundSchemaReflection | null = null;
   private _idleSince = Date.now();
   protected _lastActivity = 0;
@@ -849,10 +850,9 @@ export class AbstractAdapter implements Quoting {
 
   _queryCache: Store | null = null;
 
-  // Rails' @pool is always a pool object — a real ConnectionPool once one owns
-  // the connection, a NullPool until then (abstract_adapter.rb:153). Typing it
-  // as that union is what lets `role`/`shard`/`inspect`/`replica?` read it the
-  // way Rails does, without a cast at each site.
+  // Rails' @pool is a ConnectionPool once one owns the connection and a
+  // NullPool until then (abstract_adapter.rb:153). Readers still guard the
+  // slot: test doubles reach them without running this constructor.
   pool: ConnectionPool | NullPool = new NullPool();
   logger: unknown = null;
   lock: unknown = null;
@@ -1382,16 +1382,16 @@ export class AbstractAdapter implements Quoting {
   }
 
   get role(): string {
-    // Rails reads `@pool.role` unqualified (abstract_adapter.rb:288). A
-    // NullPool answers no role at all (abstract/connection_pool.rb:14-51), and
-    // trails supports standalone NullPool-backed adapters as a first-class
-    // path, so Rails' non-multi-role default stands in for that arm.
-    return this.pool instanceof NullPool ? "writing" : this.pool.role;
+    // Rails is a bare `@pool.role` (abstract_adapter.rb:288); NullPool defines
+    // none (abstract/connection_pool.rb:14-51), so the default stands in.
+    const pool = this.pool;
+    return pool instanceof NullPool ? "writing" : (pool?.role ?? "writing");
   }
 
   get shard(): string {
     // Same NullPool arm as `role` — abstract_adapter.rb:294.
-    return this.pool instanceof NullPool ? "default" : this.pool.shard;
+    const pool = this.pool;
+    return pool instanceof NullPool ? "default" : (pool?.shard ?? "default");
   }
 
   /**
@@ -1402,12 +1402,11 @@ export class AbstractAdapter implements Quoting {
    */
   inspect(): string {
     const q = (v: string): string => JSON.stringify(String(v));
-    const dbConfig = this.pool.dbConfig;
-    // A NullPool's NullConfig answers nil for every key
-    // (abstract/connection_pool.rb:17-22), which Rails renders as `nil`;
-    // trails' dump uses the test env/name defaults instead.
-    const envName = dbConfig.envName ?? "test";
-    const configName = dbConfig.name;
+    // Rails renders a NullConfig's nil answers as `nil`
+    // (abstract/connection_pool.rb:17-22); trails defaults them.
+    const dbConfig = this.pool?.dbConfig;
+    const envName = dbConfig?.envName ?? "test";
+    const configName = dbConfig?.name;
     const nameField = configName && configName !== "primary" ? ` name=${q(configName)}` : "";
     const shardField = this.shard !== "default" ? ` shard=${q(this.shard)}` : "";
     this._inspectId ??= AbstractAdapter._inspectSeq = (AbstractAdapter._inspectSeq ?? 0) + 1;
@@ -1466,11 +1465,10 @@ export class AbstractAdapter implements Quoting {
 
   isReplica(): boolean {
     // Rails' `replica?` reads only `@config[:replica]` (abstract_adapter.rb:199);
-    // the pool's db_config arm is a trails addition kept for pooled adapters
-    // whose per-connection config never carries the flag.
-    if (typeof this.pool.dbConfig.replica === "boolean") {
-      return this.pool.dbConfig.replica;
-    }
+    // the db_config arm is a trails addition for pooled adapters whose
+    // per-connection config never carries the flag.
+    const replica = this.pool?.dbConfig?.replica;
+    if (typeof replica === "boolean") return replica;
     if (this.role === "reading") return true;
     return this._config.replica === true;
   }
@@ -1484,7 +1482,7 @@ export class AbstractAdapter implements Quoting {
     // returns the entry's prevent_writes flag when (a) it includes Base by
     // identity, or (b) any klass's name matches the pool's connection name.
     const ownerName: string | undefined =
-      pool instanceof NullPool ? undefined : pool.poolConfig.connectionDescriptor?.name;
+      pool instanceof NullPool ? undefined : pool?.poolConfig?.connectionDescriptor?.name;
     const stack = connectedToStack();
     for (let i = stack.length - 1; i >= 0; i--) {
       const entry = stack[i];
@@ -1551,7 +1549,7 @@ export class AbstractAdapter implements Quoting {
    * adapter.
    */
   get schemaCache(): BoundSchemaReflection {
-    const schemaCache = this.pool.schemaCache;
+    const schemaCache = this.pool?.schemaCache;
     if (schemaCache instanceof BoundSchemaReflection) return schemaCache;
     this._schemaCache ??= BoundSchemaReflection.forLoneConnection(
       this._poolSchemaReflection(),
@@ -1563,12 +1561,10 @@ export class AbstractAdapter implements Quoting {
   /**
    * @internal Rails' `@pool.schema_reflection` — ConnectionPool delegates to its
    * PoolConfig and NullPool answers a bare `SchemaReflection.new(nil)`
-   * (connection_pool.rb:34-36). The fallback covers a mock that skipped the
-   * constructor and so carries no pool at all; Rails cannot get there because
-   * `initialize` always plants a NullPool.
+   * (connection_pool.rb:34-36).
    */
   private _poolSchemaReflection(): SchemaReflection {
-    return this.pool.schemaReflection;
+    return this.pool?.schemaReflection ?? (this._schemaReflection ??= new SchemaReflection(null));
   }
 
   checkIfWriteQuery(sql: string): void {
@@ -1777,12 +1773,10 @@ export class AbstractAdapter implements Quoting {
 
   close(): void | Promise<void> {
     // Mirrors Rails' `close` (abstract_adapter.rb:830): `pool.checkin self`.
-    // Rails adapters always carry a pool (NullPool by default), whose
-    // `checkin` is a no-op; trails leaves `pool` null for standalone adapters,
-    // so the no-pool branch expires a leased connection and otherwise no-ops
-    // (matching NullPool#checkin).
+    // NullPool#checkin is a no-op in Rails; trails expires a leased connection
+    // on that arm instead.
     const pool = this.pool;
-    if (!(pool instanceof NullPool)) {
+    if (pool != null && !(pool instanceof NullPool)) {
       pool.checkin(this);
     } else if (this._inUse) {
       this.expire();
@@ -1833,7 +1827,7 @@ export class AbstractAdapter implements Quoting {
   }
 
   get connectionDescriptor(): unknown {
-    return this.pool.connectionDescriptor ?? null;
+    return this.pool?.connectionDescriptor ?? null;
   }
 
   /**
@@ -2124,8 +2118,8 @@ export class AbstractAdapter implements Quoting {
     // Mirrors Rails AbstractAdapter#throw_away! (abstract_adapter.rb:733):
     // `pool.remove self; disconnect!`. Removing from the pool is what evicts
     // the connection so it can't be leased again after a transaction failure;
-    // standalone adapters (no pool) just disconnect.
-    this.pool.remove(this);
+    // NullPool#remove is a no-op.
+    this.pool?.remove(this);
     this.disconnectBang();
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
@@ -8,6 +8,7 @@ import {
 import { parseTableOptions } from "./abstract-mysql-adapter.js";
 import { SchemaCreation as MysqlSchemaCreation } from "./mysql/schema-creation.js";
 import { quote as mysqlQuote } from "./mysql/quoting.js";
+import { NullPool } from "./abstract/connection-pool.js";
 
 function makeColumn(opts: { autoIncrement?: boolean; defaultFunction?: string | null } = {}) {
   return new Column("id", null, { sqlType: "bigint" }, false, {
@@ -290,7 +291,7 @@ describe("AbstractMysqlAdapter#renameColumn wiring", () => {
     const { AbstractMysqlAdapter } = await import("./abstract-mysql-adapter.js");
     const adapter = Object.create(AbstractMysqlAdapter.prototype);
     const events: string[] = [];
-    adapter.pool = {};
+    adapter.pool = new NullPool();
     adapter.supportsRenameColumn = () => true;
     adapter.getDatabaseVersion = async () => {};
     adapter.quoteColumnName = (s: string) => `\`${s}\``;
@@ -550,6 +551,9 @@ function makeChangeColumnTextColumn(opts: { null_?: boolean; default_?: unknown 
 async function makeMinimalMysqlAdapter(overrides: Record<string, unknown> = {}) {
   const { AbstractMysqlAdapter } = await import("./abstract-mysql-adapter.js");
   const adapter = Object.create(AbstractMysqlAdapter.prototype);
+  // Object.create skips the constructor, which is what plants Rails' NullPool
+  // (abstract_adapter.rb:153); every adapter carries one.
+  adapter.pool = new NullPool();
   adapter.quoteColumnName = (s: string) => `\`${s}\``;
   adapter.quoteTableName = (s: string) => `\`${s}\``;
   adapter.quote = mysqlQuote;

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -60,7 +60,10 @@ export interface AbstractPool {
  * Mirrors: ActiveRecord::ConnectionAdapters::NullPool::NullConfig
  */
 export class NullConfig {
-  [key: string]: unknown;
+  // Rails' `NullConfig#method_missing` answers nil for every key
+  // (abstract/connection_pool.rb:17-22) — so every read off it is nullish,
+  // which is what lets `AbstractAdapter`'s pool readers stay uncast.
+  [key: string]: null | undefined;
 
   get schemaCache(): null {
     return null;
@@ -1392,9 +1395,12 @@ export class ConnectionPool implements ReapablePool {
     // Clear the back-reference we set in newConnection so a removed
     // adapter can't observe stale pool/poolConfig state post-eviction.
     // Mirror the same narrow gate — only touch AbstractAdapter's slot,
-    // never a driver-adapter's own `pool` field.
+    // never a driver-adapter's own `pool` field. Rails' `remove`
+    // (abstract/connection_pool.rb:593) leaves `conn.pool` alone; the reset
+    // value here is a NullPool rather than nil because that is Rails'
+    // representation of an unpooled adapter (abstract_adapter.rb:153).
     if (conn instanceof AbstractAdapter && (conn as unknown as { pool: unknown }).pool === this) {
-      (conn as unknown as { pool: unknown }).pool = null;
+      (conn as unknown as { pool: unknown }).pool = new NullPool();
     }
 
     for (const [ctxId, pin] of this._pinnedConnections) {

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -60,9 +60,7 @@ export interface AbstractPool {
  * Mirrors: ActiveRecord::ConnectionAdapters::NullPool::NullConfig
  */
 export class NullConfig {
-  // Rails' `NullConfig#method_missing` answers nil for every key
-  // (abstract/connection_pool.rb:17-22) — so every read off it is nullish,
-  // which is what lets `AbstractAdapter`'s pool readers stay uncast.
+  // `method_missing` answers nil for every key (abstract/connection_pool.rb:17-22).
   [key: string]: null | undefined;
 
   get schemaCache(): null {
@@ -1396,9 +1394,8 @@ export class ConnectionPool implements ReapablePool {
     // adapter can't observe stale pool/poolConfig state post-eviction.
     // Mirror the same narrow gate — only touch AbstractAdapter's slot,
     // never a driver-adapter's own `pool` field. Rails' `remove`
-    // (abstract/connection_pool.rb:593) leaves `conn.pool` alone; the reset
-    // value here is a NullPool rather than nil because that is Rails'
-    // representation of an unpooled adapter (abstract_adapter.rb:153).
+    // (abstract/connection_pool.rb:593) leaves `conn.pool` alone; NullPool is
+    // Rails' unpooled-adapter value (abstract_adapter.rb:153).
     if (conn instanceof AbstractAdapter && (conn as unknown as { pool: unknown }).pool === this) {
       (conn as unknown as { pool: unknown }).pool = new NullPool();
     }

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -128,11 +128,9 @@ export interface SchemaStatements extends Omit<
 export class SchemaStatements extends AbstractSchemaStatements {
   /* eslint-enable @typescript-eslint/no-unsafe-declaration-merging */
 
-  // Rails resolves `get_database_version` to PostgreSQLAdapter's own override
-  // (`server_version_num` — postgresql_adapter.rb:1000) by ordinary method
-  // lookup. TypeScript picks the inherited generic-adapter method ahead of a
-  // merged-interface member, so the PG return type is restated here as a
-  // declaration-only field: no runtime emit, and no cast in the bodies.
+  // Rails gets PostgreSQLAdapter's `get_database_version` (`server_version_num`)
+  // by ordinary method lookup; TS picks the inherited generic-adapter method
+  // ahead of a merged-interface one, so restate it declaration-only.
   declare getDatabaseVersion: () => Promise<number>;
 
   /** Mirrors: PostgreSQL::SchemaStatements#update_table_definition */
@@ -671,11 +669,8 @@ export class SchemaStatements extends AbstractSchemaStatements {
     // Mirrors Rails' load_additional_types batch call: gather all OIDs not
     // yet in the map and load them in a single pg_type query before building
     // Column objects. This avoids N concurrent queries for wide tables.
-    // `typeMap` is an accessor on the generic adapter, and TypeScript refuses
-    // to narrow an inherited accessor either from the merged interface or from
-    // a `declare` field (TS2610); a real accessor override would shadow
-    // PostgreSQLAdapter's own `type_map` once `include()` installs this module
-    // on its prototype. Rails needs neither (postgresql_adapter.rb:938).
+    // TS2610: an inherited accessor cannot be narrowed, and overriding it here
+    // would shadow PostgreSQLAdapter's own `type_map` under `include()`.
     const typeMap = this.typeMap as HashLookupTypeMap;
     const missingOids = [
       ...new Set(rows.map((r) => Number(r.oid)).filter((oid) => !typeMap.has(oid))),

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -61,7 +61,6 @@ interface PgSchemaAdapter {
   supportsVirtualColumns(): boolean;
   extractSchemaQualifiedName(string: string): [string | null, string];
   maxIdentifierLength(): number;
-  getDatabaseVersion(): Promise<number>;
   dataSourceSql(name?: string | null, options?: { type?: string }): string;
   quotedScope(
     name?: string | null,
@@ -102,11 +101,12 @@ function toS(value: unknown): string {
  * calls the PG adapter's type.
  *
  * The `Omit`ted names already reach `this` from `AbstractSchemaStatements` with
- * a signature TypeScript will not let a narrower PG one merge over — a method
- * declared on a base class wins over a merged-interface property. The bodies use
- * the abstract signature for them, which is why `resetPkSequenceBang` casts
- * `getDatabaseVersion`'s `number | Version` (PG returns `server_version_num`)
- * back to `number`, and `columns` casts the base's `unknown` `typeMap` accessor.
+ * a signature TypeScript will not let a narrower PG one merge over — a member
+ * declared on a base class wins over a merged-interface property. `getDatabaseVersion`
+ * is off that list: a declaration-only `declare` field in the class body does
+ * outrank the inherited method (see the class), which is what removed
+ * `resetPkSequenceBang`'s cast. The same trick cannot reach `typeMap`, which the
+ * generic adapter declares as an accessor (TS2610) — `columns` still casts it.
  * The two restated below are the reverse case: own members TypeScript does
  * accept, narrowed from the generic adapter's. @internal
  */
@@ -114,7 +114,6 @@ export interface SchemaStatements extends Omit<
   PgSchemaAdapter,
   | "execute"
   | "internalExecute"
-  | "getDatabaseVersion"
   | "lookupCastTypeFromColumn"
   | "schemaCreation"
   | "quotedScope"
@@ -128,6 +127,13 @@ export interface SchemaStatements extends Omit<
 
 export class SchemaStatements extends AbstractSchemaStatements {
   /* eslint-enable @typescript-eslint/no-unsafe-declaration-merging */
+
+  // Rails resolves `get_database_version` to PostgreSQLAdapter's own override
+  // (`server_version_num` — postgresql_adapter.rb:1000) by ordinary method
+  // lookup. TypeScript picks the inherited generic-adapter method ahead of a
+  // merged-interface member, so the PG return type is restated here as a
+  // declaration-only field: no runtime emit, and no cast in the bodies.
+  declare getDatabaseVersion: () => Promise<number>;
 
   /** Mirrors: PostgreSQL::SchemaStatements#update_table_definition */
   override updateTableDefinition(tableName: string, base?: unknown): PgTable {
@@ -665,6 +671,11 @@ export class SchemaStatements extends AbstractSchemaStatements {
     // Mirrors Rails' load_additional_types batch call: gather all OIDs not
     // yet in the map and load them in a single pg_type query before building
     // Column objects. This avoids N concurrent queries for wide tables.
+    // `typeMap` is an accessor on the generic adapter, and TypeScript refuses
+    // to narrow an inherited accessor either from the merged interface or from
+    // a `declare` field (TS2610); a real accessor override would shadow
+    // PostgreSQLAdapter's own `type_map` once `include()` installs this module
+    // on its prototype. Rails needs neither (postgresql_adapter.rb:938).
     const typeMap = this.typeMap as HashLookupTypeMap;
     const missingOids = [
       ...new Set(rows.map((r) => Number(r.oid)).filter((oid) => !typeMap.has(oid))),
@@ -1896,7 +1907,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
     );
     let minvalue: unknown = null;
     if (maxPk == null) {
-      const dbVersion = (await this.getDatabaseVersion()) as number;
+      const dbVersion = await this.getDatabaseVersion();
       minvalue =
         dbVersion >= 100000
           ? await this.queryValue(

--- a/packages/activerecord/src/test-fixtures.test.ts
+++ b/packages/activerecord/src/test-fixtures.test.ts
@@ -15,6 +15,7 @@ import { Post } from "./test-helpers/models/post.js";
 import { LiveParrot, DeadParrot } from "./test-helpers/models/parrot.js";
 import { Cucumber, Cabbage, RedCabbage } from "./test-helpers/models/vegetables.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
+import { NullPool } from "./connection-adapters/abstract/connection-pool.js";
 import {
   leaseFixtureConnection,
   leaseFixtureConnectionFor,
@@ -52,6 +53,10 @@ function makeAdapter(): DatabaseAdapter {
     quote: (v: unknown) => (typeof v === "string" ? `'${v}'` : String(v)),
     quoteTableName: (n: string) => `"${n}"`,
     quoteColumnName: (n: string) => `"${n}"`,
+    // Every Rails adapter carries a pool (abstract_adapter.rb:153); the
+    // fixture machinery reads it to decide whether a set seeds through the
+    // model's own pool.
+    pool: new NullPool(),
   } as unknown as DatabaseAdapter;
 }
 

--- a/packages/activerecord/src/test-fixtures/fixture-connection.test.ts
+++ b/packages/activerecord/src/test-fixtures/fixture-connection.test.ts
@@ -16,6 +16,7 @@ import { Base } from "../base.js";
 import { ActiveRecord } from "../ar-config.js";
 import { leaseFixtureConnection, leaseFixtureConnectionFor } from "./fixture-connection.js";
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
+import { NullPool } from "../connection-adapters/abstract/connection-pool.js";
 
 describe("fixture connection source", () => {
   afterEach(() => {
@@ -49,7 +50,10 @@ describe("fixture connection source", () => {
 });
 
 describe("per-set fixture connection", () => {
-  const fixtureConnection = { marker: "pinned-fixture-connection" } as unknown as DatabaseAdapter;
+  const fixtureConnection = {
+    marker: "pinned-fixture-connection",
+    pool: new NullPool(),
+  } as unknown as DatabaseAdapter;
 
   it("seeds a model-less (join-table) set through the fixture connection", async () => {
     expect(await leaseFixtureConnectionFor(null, fixtureConnection)).toBe(fixtureConnection);

--- a/packages/activerecord/src/test-fixtures/fixture-connection.ts
+++ b/packages/activerecord/src/test-fixtures/fixture-connection.ts
@@ -73,7 +73,8 @@ export async function leaseFixtureConnectionFor(
   const modelPool = modelFixturePool(model);
   if (modelPool === null) return fixtureConnection;
   const rawFixturePool = fixtureConnection.pool;
-  const fixturePool = rawFixturePool instanceof NullPool ? null : rawFixturePool;
+  const fixturePool =
+    rawFixturePool == null || rawFixturePool instanceof NullPool ? null : rawFixturePool;
   if (fixturePool === null || fixturePool === modelPool) return fixtureConnection;
   return await modelPool.leaseConnection();
 }

--- a/packages/activerecord/src/test-fixtures/fixture-connection.ts
+++ b/packages/activerecord/src/test-fixtures/fixture-connection.ts
@@ -73,11 +73,7 @@ export async function leaseFixtureConnectionFor(
   const modelPool = modelFixturePool(model);
   if (modelPool === null) return fixtureConnection;
   const rawFixturePool = fixtureConnection.pool;
-  // No Rails counterpart, so this tolerates a pool-less adapter: callers may
-  // pass a hand-built stub through `fixtures({ connection })`, which never runs
-  // AbstractAdapter's constructor and so never gets Rails' NullPool.
-  const fixturePool =
-    rawFixturePool == null || rawFixturePool instanceof NullPool ? null : rawFixturePool;
+  const fixturePool = rawFixturePool instanceof NullPool ? null : rawFixturePool;
   if (fixturePool === null || fixturePool === modelPool) return fixtureConnection;
   return await modelPool.leaseConnection();
 }

--- a/packages/activerecord/src/test-fixtures/fixture-connection.ts
+++ b/packages/activerecord/src/test-fixtures/fixture-connection.ts
@@ -73,7 +73,11 @@ export async function leaseFixtureConnectionFor(
   const modelPool = modelFixturePool(model);
   if (modelPool === null) return fixtureConnection;
   const rawFixturePool = fixtureConnection.pool;
-  const fixturePool = rawFixturePool instanceof NullPool ? null : rawFixturePool;
+  // No Rails counterpart, so this tolerates a pool-less adapter: callers may
+  // pass a hand-built stub through `fixtures({ connection })`, which never runs
+  // AbstractAdapter's constructor and so never gets Rails' NullPool.
+  const fixturePool =
+    rawFixturePool == null || rawFixturePool instanceof NullPool ? null : rawFixturePool;
   if (fixturePool === null || fixturePool === modelPool) return fixtureConnection;
   return await modelPool.leaseConnection();
 }

--- a/packages/activerecord/src/test-fixtures/fixture-connection.ts
+++ b/packages/activerecord/src/test-fixtures/fixture-connection.ts
@@ -73,10 +73,7 @@ export async function leaseFixtureConnectionFor(
   const modelPool = modelFixturePool(model);
   if (modelPool === null) return fixtureConnection;
   const rawFixturePool = fixtureConnection.pool;
-  const fixturePool =
-    rawFixturePool == null || rawFixturePool instanceof NullPool
-      ? null
-      : (rawFixturePool as ConnectionPool);
+  const fixturePool = rawFixturePool instanceof NullPool ? null : rawFixturePool;
   if (fixturePool === null || fixturePool === modelPool) return fixtureConnection;
   return await modelPool.leaseConnection();
 }

--- a/packages/activerecord/src/test-fixtures/fixture-connection.ts
+++ b/packages/activerecord/src/test-fixtures/fixture-connection.ts
@@ -73,8 +73,7 @@ export async function leaseFixtureConnectionFor(
   const modelPool = modelFixturePool(model);
   if (modelPool === null) return fixtureConnection;
   const rawFixturePool = fixtureConnection.pool;
-  const fixturePool =
-    rawFixturePool == null || rawFixturePool instanceof NullPool ? null : rawFixturePool;
+  const fixturePool = rawFixturePool instanceof NullPool ? null : rawFixturePool;
   if (fixturePool === null || fixturePool === modelPool) return fixtureConnection;
   return await modelPool.leaseConnection();
 }

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -1355,7 +1355,13 @@ export class CreatePosts extends Migration {
 
   // internal_metadata.rb:35-36 — `enabled?` is `@pool.db_config.use_metadata_table?`.
   function disableMetadataTable(adapter: unknown): void {
-    (adapter as { pool: unknown }).pool = { dbConfig: { useMetadataTable: false } };
+    // Override the pool's db_config rather than replacing the pool: Rails'
+    // @pool is always a pool object (abstract_adapter.rb:153), and the rest of
+    // the adapter reads schema_reflection off it during the migration.
+    Object.defineProperty((adapter as { pool: object }).pool, "dbConfig", {
+      value: { useMetadataTable: false },
+      configurable: true,
+    });
   }
 
   it("InternalMetadata with enabled=false refuses set writes with EnvironmentStorageError", async () => {

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -98,6 +98,12 @@ import {
   arityExcludeKeys,
   parseArityExcludes,
 } from "./arity-exclude.js";
+import {
+  INHERITANCE_EXCLUDE_PATH,
+  inheritanceExcludeKeyOf,
+  inheritanceExcludeKeys,
+  parseInheritanceExcludes,
+} from "./inheritance-exclude.js";
 import { matchOptionKeysAgainst } from "./options-keys.js";
 import { callOf } from "./call-mismatch-baseline.js";
 import {
@@ -696,6 +702,10 @@ interface InheritanceMismatch {
 interface InheritanceResult {
   checked: number;
   matched: number;
+  /** Mismatches suppressed by a reasoned inheritance-exclude.json entry, and
+   *  dropped from `checked` — reported so the shrunken denominator is
+   *  auditable rather than silently absorbing the deviation. */
+  excluded: number;
   mismatches: InheritanceMismatch[];
 }
 
@@ -1518,6 +1528,13 @@ export function main() {
     parseArityExcludes(fs.readFileSync(ARITY_EXCLUDE_PATH, "utf-8")),
   );
   const appliedArityExcludes = new Set<string>();
+
+  // Reasoned inheritance suppressions (RFC 0072) — a ported class whose TS
+  // superclass deliberately differs, each with its justification.
+  const inheritanceExcludes = inheritanceExcludeKeys(
+    parseInheritanceExcludes(fs.readFileSync(INHERITANCE_EXCLUDE_PATH, "utf-8")),
+  );
+  const appliedInheritanceExcludes = new Set<string>();
 
   const results: PackageResult[] = [];
 
@@ -2364,7 +2381,12 @@ export function main() {
     // file + same short name) and verify Ruby's immediate superclass appears
     // somewhere in TS's ancestor chain. If the TS class is absent entirely,
     // surface that as a mismatch so regressions don't hide.
-    const inheritance: InheritanceResult = { checked: 0, matched: 0, mismatches: [] };
+    const inheritance: InheritanceResult = {
+      checked: 0,
+      matched: 0,
+      excluded: 0,
+      mismatches: [],
+    };
     if (tsPkg) {
       // Index TS classes by (file, shortName) and by short name for ancestor walks.
       const tsByFileName = new Map<string, ClassInfo>();
@@ -2439,6 +2461,18 @@ export function main() {
         // actually declares (e.g. "ValueType", not Ruby's "Value").
         if (superclassesMatch(rubySuper, chain, tsCls.name)) {
           inheritance.matched++;
+        } else if (
+          inheritanceExcludes.has(
+            inheritanceExcludeKeyOf({ package: pkg, rubyFile: info.file, rubyFqn: fqn }),
+          )
+        ) {
+          // Reviewed deviation: drop it from the denominator rather than score
+          // it as a match, the way the arity check reports its excludes.
+          appliedInheritanceExcludes.add(
+            inheritanceExcludeKeyOf({ package: pkg, rubyFile: info.file, rubyFqn: fqn }),
+          );
+          inheritance.checked--;
+          inheritance.excluded++;
         } else {
           inheritance.mismatches.push({
             rubyFqn: fqn,
@@ -2508,6 +2542,9 @@ export function main() {
     JSON.stringify(
       {
         generatedAt: new Date().toISOString(),
+        // The inheritance gate treats every committed exclude absent from this
+        // list as stale, the same only-shrink contract arity-exclude has.
+        appliedInheritanceExcludes: [...appliedInheritanceExcludes].sort(),
         results: results.map(({ bodyHashes: _bodyHashes, ...rest }) => rest),
       },
       null,
@@ -2748,8 +2785,11 @@ function printReport(
       pkg.excludedFiles.length > 0 ? "  (some intentionally excluded, see unported-files.ts)" : "";
     const inh = pkg.inheritance;
     const inhPct = inh.checked > 0 ? Math.round((inh.matched / inh.checked) * 1000) / 10 : 0;
+    const inhExcludedNote = inh.excluded > 0 ? `, ${inh.excluded} excluded` : "";
     const inhNote =
-      inh.checked > 0 ? `  |  inheritance: ${inh.matched}/${inh.checked} (${inhPct}%)` : "";
+      inh.checked > 0
+        ? `  |  inheritance: ${inh.matched}/${inh.checked} (${inhPct}%${inhExcludedNote})`
+        : "";
     const misplacedNote = pkg.misplacedFiles > 0 ? `  |  ${pkg.misplacedFiles} misplaced` : "";
     const ar = pkg.arity;
     const arOk = ar.compared - ar.mismatched;

--- a/scripts/api-compare/inheritance-exclude.json
+++ b/scripts/api-compare/inheritance-exclude.json
@@ -1,0 +1,8 @@
+[
+  {
+    "package": "activerecord",
+    "rubyFile": "connection_adapters/abstract/schema_dumper.rb",
+    "rubyFqn": "ActiveRecord::ConnectionAdapters::SchemaDumper",
+    "reason": "Rails declares `class SchemaDumper < SchemaDumper` (connection_adapters/abstract/schema_dumper.rb:5) — the adapter layer subclasses ActiveRecord::SchemaDumper, whose `table` calls the private `column_spec` only the subclass defines. A static TS `extends` across the two modules is an ESM temporal-dead-zone cycle (base imports the subclass's members, subclass extends the base), so trails ships one class: the adapter-layer members are `this`-typed mixin functions the base assigns onto its own prototype, and connection-adapters/abstract/schema-dumper.ts re-exports the base class. That keeps bare-base construction working with no cyclic import; the price is that the TS class has no ancestor chain."
+  }
+]

--- a/scripts/api-compare/inheritance-exclude.test.ts
+++ b/scripts/api-compare/inheritance-exclude.test.ts
@@ -8,6 +8,7 @@ import {
   parseInheritanceExcludes,
   type InheritanceExcludeEntry,
 } from "./inheritance-exclude.js";
+import { missingScope, reportStale } from "./lint-inheritance-excludes.js";
 
 const entry: InheritanceExcludeEntry = {
   package: "activerecord",
@@ -56,6 +57,18 @@ describe("findStaleInheritanceExcludes", () => {
 
   it("reports nothing when the entry was applied", () => {
     expect(findStaleInheritanceExcludes([entry], [inheritanceExcludeKeyOf(entry)])).toEqual([]);
+  });
+});
+
+describe("lint-inheritance-excludes", () => {
+  it("reports a partial-scope artifact rather than calling every exclude stale", () => {
+    expect(
+      missingScope({ results: [{ package: "activerecord" }] }, ["activerecord", "i18n"]),
+    ).toEqual(["i18n"]);
+  });
+
+  it("names the stale entry in the failure message", () => {
+    expect(reportStale([entry])).toContain(inheritanceExcludeKeyOf(entry));
   });
 });
 

--- a/scripts/api-compare/inheritance-exclude.test.ts
+++ b/scripts/api-compare/inheritance-exclude.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  INHERITANCE_EXCLUDE_PATH,
+  findStaleInheritanceExcludes,
+  inheritanceExcludeKeyOf,
+  inheritanceExcludeKeys,
+  loadInheritanceExcludes,
+  parseInheritanceExcludes,
+  type InheritanceExcludeEntry,
+} from "./inheritance-exclude.js";
+
+const entry: InheritanceExcludeEntry = {
+  package: "activerecord",
+  rubyFile: "connection_adapters/abstract/schema_dumper.rb",
+  rubyFqn: "ActiveRecord::ConnectionAdapters::SchemaDumper",
+  reason: "Single-class port: a static `extends` across the two modules is an ESM cycle.",
+};
+
+describe("parseInheritanceExcludes", () => {
+  it("parses a well-formed entry", () => {
+    expect(parseInheritanceExcludes(JSON.stringify([entry]))).toEqual([entry]);
+  });
+
+  it("rejects a non-array document", () => {
+    expect(() => parseInheritanceExcludes("{}")).toThrow(/top-level array/);
+  });
+
+  it("rejects a missing key field", () => {
+    const { rubyFqn: _rubyFqn, ...rest } = entry;
+    expect(() => parseInheritanceExcludes(JSON.stringify([rest]))).toThrow(/"rubyFqn"/);
+  });
+
+  it("rejects an empty reason", () => {
+    expect(() => parseInheritanceExcludes(JSON.stringify([{ ...entry, reason: " " }]))).toThrow(
+      /"reason" must be a non-empty string/,
+    );
+  });
+
+  it("rejects an unknown package", () => {
+    expect(() =>
+      parseInheritanceExcludes(JSON.stringify([{ ...entry, package: "activerecords" }])),
+    ).toThrow(/unknown package "activerecords"/);
+  });
+
+  it("rejects a duplicate key", () => {
+    expect(() =>
+      parseInheritanceExcludes(JSON.stringify([entry, { ...entry, reason: "other" }])),
+    ).toThrow(/duplicate entry/);
+  });
+});
+
+describe("findStaleInheritanceExcludes", () => {
+  it("reports an entry that suppressed nothing", () => {
+    expect(findStaleInheritanceExcludes([entry], [])).toEqual([entry]);
+  });
+
+  it("reports nothing when the entry was applied", () => {
+    expect(findStaleInheritanceExcludes([entry], [inheritanceExcludeKeyOf(entry)])).toEqual([]);
+  });
+});
+
+describe("inheritance-exclude.json", () => {
+  it("parses, and every entry carries a reason", async () => {
+    const entries = await loadInheritanceExcludes(INHERITANCE_EXCLUDE_PATH);
+    for (const e of entries) expect(e.reason.trim().length).toBeGreaterThan(0);
+    expect(inheritanceExcludeKeys(entries).size).toBe(entries.length);
+  });
+});

--- a/scripts/api-compare/inheritance-exclude.ts
+++ b/scripts/api-compare/inheritance-exclude.ts
@@ -1,0 +1,106 @@
+/**
+ * Reasoned suppression file for the inheritance check (RFC 0072), shaped like
+ * `arity-exclude.ts`: a mandatory `reason` per entry, and only-shrink by
+ * construction — an entry that no longer suppresses a live mismatch is STALE
+ * and fails the gate.
+ *
+ * `RUBY_ONLY_CLASSES` (compare.ts) answers "this Ruby class is not ported at
+ * all"; this file answers the different question "this class IS ported, but its
+ * TS superclass deliberately differs, for a reviewed reason". A super-mismatch
+ * with no register of any kind reads as outstanding work forever.
+ *
+ * Keyed on the RUBY side of the pair (`package + rubyFile + rubyFqn`), matching
+ * arity-exclude's rationale: that is what a burndown story names, and the TS
+ * side can move files without invalidating a reason about the Ruby class.
+ *
+ * Hard rules: no node:* imports, no process.*, async fs only.
+ */
+
+import * as fs from "fs/promises";
+import * as path from "path";
+import { fileURLToPath } from "url";
+import { PACKAGES } from "./config.js";
+
+export const INHERITANCE_EXCLUDE_PATH = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "inheritance-exclude.json",
+);
+
+export interface InheritanceExcludeKey {
+  package: string;
+  rubyFile: string;
+  rubyFqn: string;
+}
+
+export interface InheritanceExcludeEntry extends InheritanceExcludeKey {
+  reason: string;
+}
+
+export function inheritanceExcludeKeyOf(k: InheritanceExcludeKey): string {
+  return `${k.package} ${k.rubyFile} ${k.rubyFqn}`;
+}
+
+/** Every structural problem is a hard error rather than a skipped row: a
+ *  malformed entry that silently did nothing would read as "suppressed" to
+ *  whoever added it while the class kept flagging. */
+export function parseInheritanceExcludes(text: string): InheritanceExcludeEntry[] {
+  const raw: unknown = JSON.parse(text);
+  if (!Array.isArray(raw)) {
+    throw new Error("inheritance-exclude.json: expected a top-level array");
+  }
+
+  const entries: InheritanceExcludeEntry[] = [];
+  const seen = new Set<string>();
+  raw.forEach((row, i) => {
+    if (typeof row !== "object" || row === null) {
+      throw new Error(`inheritance-exclude.json[${i}]: expected an object`);
+    }
+    const e = row as Partial<InheritanceExcludeEntry>;
+    for (const field of ["package", "rubyFile", "rubyFqn"] as const) {
+      if (typeof e[field] !== "string" || e[field].length === 0) {
+        throw new Error(`inheritance-exclude.json[${i}]: "${field}" must be a non-empty string`);
+      }
+    }
+    if (typeof e.reason !== "string" || e.reason.trim().length === 0) {
+      throw new Error(
+        `inheritance-exclude.json[${i}] (${inheritanceExcludeKeyOf(e as InheritanceExcludeKey)}): ` +
+          '"reason" must be a non-empty string — every deviation carries its justification',
+      );
+    }
+    if (!PACKAGES.includes(e.package!)) {
+      throw new Error(
+        `inheritance-exclude.json[${i}]: unknown package "${e.package}" — expected one of ${PACKAGES.join(", ")}`,
+      );
+    }
+    const entry = e as InheritanceExcludeEntry;
+    const key = inheritanceExcludeKeyOf(entry);
+    if (seen.has(key)) {
+      throw new Error(`inheritance-exclude.json: duplicate entry for ${key}`);
+    }
+    seen.add(key);
+    entries.push(entry);
+  });
+  return entries;
+}
+
+export async function loadInheritanceExcludes(
+  file: string = INHERITANCE_EXCLUDE_PATH,
+): Promise<InheritanceExcludeEntry[]> {
+  return parseInheritanceExcludes(await fs.readFile(file, "utf-8"));
+}
+
+/** Entries that suppressed nothing in the run that produced `appliedKeys` —
+ *  the class converged, was renamed, or never mismatched at all. */
+export function findStaleInheritanceExcludes(
+  entries: readonly InheritanceExcludeEntry[],
+  appliedKeys: Iterable<string>,
+): InheritanceExcludeEntry[] {
+  const applied = new Set(appliedKeys);
+  return entries.filter((e) => !applied.has(inheritanceExcludeKeyOf(e)));
+}
+
+/** Compare-time lookup set. Only the key matters there — the `reason` is for
+ *  the human reading the file, not for the run. */
+export function inheritanceExcludeKeys(entries: readonly InheritanceExcludeEntry[]): Set<string> {
+  return new Set(entries.map(inheritanceExcludeKeyOf));
+}

--- a/scripts/api-compare/lint-inheritance-excludes.ts
+++ b/scripts/api-compare/lint-inheritance-excludes.ts
@@ -1,0 +1,116 @@
+#!/usr/bin/env npx tsx
+/**
+ * Gate for the reasoned inheritance-exclude file (RFC 0072):
+ *
+ *   pnpm tsx scripts/api-compare/lint-inheritance-excludes.ts   # gate (CI)
+ *
+ * Fails on a malformed entry (parseInheritanceExcludes raises) or a STALE one —
+ * committed but absent from the artifact's `appliedInheritanceExcludes`, i.e.
+ * it suppressed nothing in the run that wrote it. That is what makes the file
+ * only-shrink: once a class converges, its entry has to be deleted by hand.
+ *
+ * There is deliberately no `--write` reseed: an exclude must be written by
+ * hand with its justification, which is the whole point of the `reason` field.
+ *
+ * Hard rules: no node:* imports, no process.* in the library surface (the CLI
+ * entry guard is the sole exception, matching lint-arity-excludes.ts), async fs
+ * only.
+ */
+
+import * as fs from "fs/promises";
+import * as path from "path";
+import { fileURLToPath } from "url";
+import {
+  INHERITANCE_EXCLUDE_PATH,
+  findStaleInheritanceExcludes,
+  inheritanceExcludeKeyOf,
+  loadInheritanceExcludes,
+  type InheritanceExcludeEntry,
+} from "./inheritance-exclude.js";
+import { OUTPUT_DIR, PACKAGES, ROOT_DIR } from "./config.js";
+
+// Full-surface artifact only; compare.ts also writes --public-only /
+// --privates-only variants, but excludes are written against the default run.
+const ARTIFACT_PATH = path.join(OUTPUT_DIR, "api-comparison.json");
+
+export interface ComparisonArtifact {
+  results?: { package: string }[];
+  /** Exclude keys that suppressed a real mismatch in this run. */
+  appliedInheritanceExcludes?: string[];
+}
+
+/** Packages absent from the artifact: a `--package`-filtered (or otherwise
+ *  partial) run would report every other package's excludes as stale. Same
+ *  determinism guard as lint-arity-excludes.ts. */
+export function missingScope(
+  artifact: ComparisonArtifact,
+  expected: readonly string[] = PACKAGES,
+): string[] {
+  const present = new Set((artifact.results ?? []).map((r) => r.package));
+  return expected.filter((p) => !present.has(p)).sort();
+}
+
+export async function loadArtifact(file: string = ARTIFACT_PATH): Promise<ComparisonArtifact> {
+  const exists = await fs.access(file).then(
+    () => true,
+    () => false,
+  );
+  if (!exists) {
+    throw new Error(
+      `Missing ${path.relative(ROOT_DIR, file)} — run \`pnpm exec tsx ` +
+        "scripts/api-compare/compare.ts` (or `pnpm api:compare`) first to write it.",
+    );
+  }
+  return JSON.parse(await fs.readFile(file, "utf-8")) as ComparisonArtifact;
+}
+
+export function reportStale(stale: readonly InheritanceExcludeEntry[]): string {
+  return (
+    `\ninheritance excludes: ${stale.length} STALE entr(ies) that no longer suppress a mismatch.\n` +
+    `The exclude file only shrinks — delete the converged entr(ies) from ` +
+    `${path.relative(ROOT_DIR, INHERITANCE_EXCLUDE_PATH)}:\n` +
+    stale.map((e) => `  - ${inheritanceExcludeKeyOf(e)}`).join("\n") +
+    "\n"
+  );
+}
+
+async function main(): Promise<number> {
+  const entries = await loadInheritanceExcludes();
+  const artifact = await loadArtifact();
+
+  const absent = missingScope(artifact);
+  if (absent.length > 0) {
+    console.error(
+      `\ninheritance excludes: artifact compared a PARTIAL scope — missing ` +
+        `${absent.length} package(s): ${absent.join(", ")}.\n` +
+        "Every other package's excludes would read as stale. Regenerate the " +
+        "full surface with `pnpm api:compare`.\n",
+    );
+    return 1;
+  }
+
+  const stale = findStaleInheritanceExcludes(entries, artifact.appliedInheritanceExcludes ?? []);
+  if (stale.length > 0) {
+    console.error(reportStale(stale));
+    return 1;
+  }
+
+  console.log(`inheritance excludes: OK (${entries.length} reasoned exclusion(s))`);
+  return 0;
+}
+
+async function runAsScript(): Promise<void> {
+  const self = fileURLToPath(import.meta.url);
+  const invoked = process.argv[1] ? path.resolve(process.argv[1]) : "";
+  if (path.resolve(self) !== invoked) return;
+  let code: number;
+  try {
+    code = await main();
+  } catch (e) {
+    console.error(`\ninheritance excludes: ${(e as Error).message}\n`);
+    code = 1;
+  }
+  process.exit(code);
+}
+
+void runAsScript();


### PR DESCRIPTION
Three RFC 0072 / 0051 stories.

## 1. activerecord reaches 100% on every scored api:compare axis

The last activerecord inheritance mismatch is `ConnectionAdapters::SchemaDumper`.
Rails declares `class SchemaDumper < SchemaDumper`
(`connection_adapters/abstract/schema_dumper.rb:5`); trails ships **one** class,
because a static `extends` across the two modules is an ESM temporal-dead-zone
cycle (the base imports the adapter layer's mixin members, the adapter layer
would extend the base). Arm 1 (converge) was re-verified and rejected: the base
`SchemaDumper` is the class trails actually constructs — `SchemaDumper.dump`,
`createSchemaDumper`, and the bare-base path RFC 0056 depends on all build the
base directly and rely on the mixed-in `columnSpec`, so restoring a real
subclass means moving the construction path, not just the `extends`. That is a
different (and much larger) story than this one.

Arm 2, then: a **reasoned, only-shrink** per-entry exclusion, shaped exactly like
the arity check's — `scripts/api-compare/inheritance-exclude.{ts,json}`, keyed on
the Ruby side (`package + rubyFile + rubyFqn`), `reason` mandatory (empty reason,
unknown package, duplicate key and malformed row are all hard parse errors), and
`findStaleInheritanceExcludes` + `appliedInheritanceExcludes` in
`api-comparison.json` so an entry that stops suppressing a live mismatch is
detectable as STALE. The STALE half is wired the same way arity's is: `lint-inheritance-excludes.ts`
(mirroring `lint-arity-excludes.ts`, including the partial-scope guard so a
`--package`-filtered run can't report every other package's excludes as stale)
→ `pnpm api:inheritance` → an "Inheritance excludes gate" step in
`.github/workflows/ci.yml` next to the arity one. Covered by
`inheritance-exclude.test.ts` (11 tests).

An excluded entry leaves the denominator rather than scoring as a match, matching
how arity reports its excludes:

| axis | before | after |
| --- | --- | --- |
| methods | 6148/6148 (100%) | 6148/6148 (100%) |
| files | 277/277 | 277/277 |
| inheritance | 209/210 (99.5%) | **209/209 (100%, 1 excluded)** |
| arity | 3923/3923 (100%, 1 excluded) | 3923/3923 (100%, 1 excluded) |

No other package's inheritance total moves (overall stays 552/605).

## 2. `AbstractAdapter#pool` is a pool, not `unknown`

`pool: unknown` → `pool: ConnectionPool | NullPool`, which is what Rails' `@pool`
always is (`abstract_adapter.rb:153`). All seven casts are **deleted**, not moved:
`role`, `shard`, `inspect`, `isReplica`, `isPreventingWrites`, plus `schemaCache`,
`_poolSchemaReflection`, `close`'s `checkin` and `throwAwayBang`'s `remove`, which
now call the pool directly the way `abstract_adapter.rb:288-300,733,830` does.
`adapter.pool` passes to a `ConnectionPool`/`NullPool` parameter with no cast,
which unblocks `internal-metadata-takes-a-pool-nullpool-arm-reads-enabled`.

Two supporting changes, both cited in-file:
- `NullConfig`'s index signature is `null | undefined` — Rails' `NullConfig#method_missing`
  answers nil for every key (`abstract/connection_pool.rb:17-22`), which is what
  lets the readers stay uncast.
- `ConnectionPool#remove` resets the back-reference to a `NullPool` instead of
  `null`. Rails' `remove` (`:593`) does not touch `conn.pool` at all; `NullPool`
  is Rails' representation of an unpooled adapter, so it is the closer value.

Every reader is a bare `this.pool.x`, as in Rails — there is no nil-pool arm in
`abstract_adapter.rb` and there is none here. The first CI round produced three
`undefined` pool reads; each traced to a **test double that skips the
constructor**, not to a production state, so the doubles were fixed rather than
the readers guarded:

- `abstract-mysql-adapter.test.ts` builds adapters with
  `Object.create(prototype)` — now plants a `NullPool`, which is what
  `abstract_adapter.rb:153` does.
- `trailties/commands/db.test.ts` replaced the whole pool with
  `{ dbConfig: { useMetadataTable: false } }` — now overrides `dbConfig` on the
  real pool, leaving `schema_reflection` reachable.
- `fixture-connection.test.ts`'s marker adapter and `test-fixtures.test.ts`'s
  `makeAdapter()` stub carry a `NullPool`.

`fixture-connection.ts` therefore keeps no null arm either: with every stub
carrying a pool, `fixtureConnection.pool` is non-nullable in fact as well as in
type, and the only `fixtures({ connection })` callers outside that one test file
pass real adapters.

No behaviour change. Every reader whose softening the type exposed
(`role`/`shard`'s NullPool fallback, `isReplica`'s `dbConfig` arm,
`isPreventingWrites`' hand-walked stack) now carries its Rails citation at the
call site, and the convergence of those three is filed as
`abstract-adapter-pool-readers-soften-rails-behaviour` (RFC 0051).

## 3. PG `SchemaStatements` — one cast gone, the other's blocker recorded

`resetPkSequenceBang`'s `(await this.getDatabaseVersion()) as number` is removed:
a declaration-only `declare getDatabaseVersion: () => Promise<number>` in the
class body **does** outrank the inherited generic-adapter method, so
`getDatabaseVersion` leaves the `Omit` list (9 → 8) and the body reads PG's
`server_version_num` the way `postgresql_adapter.rb` does.

`columns`' `as HashLookupTypeMap` stays, with the reason now at the call site:
`AbstractAdapter` declares `typeMap` as an **accessor**, and TypeScript refuses
to narrow an inherited accessor from either a merged-interface member or a
`declare` field (TS2610); a real accessor override in this mixin module would
shadow `PostgreSQLAdapter`'s own `type_map` once `include()` installs the module
on its prototype.

The story's wider shape — `extends Omit<PostgreSQLAdapter, …>`, deleting
`PgSchemaAdapter` — was tried and does not hold: it raises TS2320 for every
member whose PG signature differs from the abstract one it overrides
(`adapterName, addColumnForAlter, addIndex, addIndexOptions,
buildCreateIndexDefinition, buildStatementPool,
canPerformCaseInsensitiveComparisonFor, caseInsensitiveComparison, close,
configureConnection, createSchemaDumper, databaseVersion, disableExtension,
disableReferentialIntegrity, dumpSchemaInformation, enableExtension, explain,
extensions, …` and still going), so the `Omit` list would grow well past the nine
names it was meant to replace. That list is itself the finding — each name is a
PG override whose TS signature diverges from Rails' plain method override — and
it is filed with the evidence as
`pg-schema-statements-abstract-signature-divergences` (RFC 0051).

## Verification

`pnpm typecheck`, `pnpm lint`, `pnpm api:calls:wide` (ratchet OK, no new rows),
`pnpm api:compare` (deltas non-negative, table above), and the adapter / pool /
dumper / fixtures suites green locally. PG lanes covered by CI.

Closes-story: resolve-last-activerecord-inheritance-mismatch-schema-dumper
Closes-story: abstract-adapter-pool-is-typed-unknown
Closes-story: pg-schema-statements-merged-interface-omits-nine-adapter-members
