### PR TITLE
feat(vendor,i18n,activerecord,activesupport): vendor ruby/date, SimpleDateData flags, MySQL schemaCreation on the mixin, MessagePack metadata matrix

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -46,9 +46,9 @@ import {
 } from "../errors.js";
 import { sql as arelSql, Nodes, Visitors } from "@blazetrails/arel";
 import { StatementPool as ConnectionStatementPool } from "./statement-pool.js";
-import {
+import type {
   SchemaCreation as MysqlSchemaCreation,
-  type MysqlAddColumnOptions,
+  MysqlAddColumnOptions,
 } from "./mysql/schema-creation.js";
 import {
   quote as mysqlQuote,
@@ -278,19 +278,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
 
   get adapterName(): AdapterName {
     return "mysql";
-  }
-
-  private _mysqlSchemaCreation?: MysqlSchemaCreation;
-  /**
-   * MySQL-specific SchemaCreation so that DDL methods mixed in from
-   * SchemaStatements (e.g. `addColumn`) emit `CHARACTER SET` / `COLLATE`
-   * clauses. Overrides the abstract SchemaStatements getter which would
-   * otherwise create a bare `abstract/schema-creation` instance lacking
-   * MySQL-specific column-option handling.
-   * @internal
-   */
-  get schemaCreation(): MysqlSchemaCreation {
-    return (this._mysqlSchemaCreation ??= new MysqlSchemaCreation(this));
   }
 
   // Rails maps MySQL::SchemaStatements#table_alias_length (256, not the
@@ -2096,6 +2083,15 @@ export class StatementPool extends ConnectionStatementPool<MysqlPreparedStatemen
  * with the mixin by `scripts/mixin-declaration-drift.ts`. @internal
  */
 export interface AbstractMysqlAdapter {
+  /**
+   * MySQL-specific SchemaCreation so that DDL methods mixed in from
+   * SchemaStatements (e.g. `addColumn`) emit `CHARACTER SET` / `COLLATE`
+   * clauses. Rails declares it on `MySQL::SchemaStatements`
+   * (mysql/schema_statements.rb:139), not on the adapter, so it arrives here
+   * through `include(AbstractMysqlAdapter, MysqlSchemaStatements)`.
+   */
+  readonly schemaCreation: MysqlSchemaCreation;
+
   updateTableDefinition(tableName: string, base?: unknown): MysqlTable;
 
   addIndex(

--- a/packages/activesupport/src/cache/coder.test.ts
+++ b/packages/activesupport/src/cache/coder.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { coder } from "./coder.js";
+import { Temporal } from "../temporal.js";
 
 // Fidelity guarantees of the trails Marshal-equivalent serializer: the cases
 // where plain JSON would lose or mangle a value. These are not Rails tests —
@@ -14,6 +15,13 @@ describe("cache coder fidelity", () => {
     const result = roundtrip(date) as Date;
     expect(result).toBeInstanceOf(Date);
     expect(result.getTime()).toBe(date.getTime());
+  });
+
+  it("preserves Temporal.Instant instances", () => {
+    const instant = Temporal.Instant.from("2004-01-01T00:00:00Z");
+    const result = roundtrip(instant) as Temporal.Instant;
+    expect(result).toBeInstanceOf(Temporal.Instant);
+    expect(result.equals(instant)).toBe(true);
   });
 
   it("preserves undefined distinct from null", () => {

--- a/packages/activesupport/src/cache/coder.ts
+++ b/packages/activesupport/src/cache/coder.ts
@@ -29,6 +29,7 @@
 // needs escaping (see ARRAY_ESCAPE below).
 // entry.ts imports `coder` from here; `LazyEntry` extends `Entry` lazily (see
 // lazyEntryClass) so this cyclic import is never dereferenced at module-eval.
+import { Temporal } from "../temporal.js";
 import { Entry } from "./entry.js";
 import { DeserializationError } from "./deserialization-error.js";
 
@@ -36,6 +37,7 @@ const PREFIX = "~#";
 const UNDEF = "~#u";
 const BIGINT = "~#b";
 const DATE = "~#d";
+const INSTANT = "~#i";
 const NUMBER = "~#n";
 const ARRAY_ESCAPE = "~#a";
 
@@ -61,6 +63,10 @@ function encode(value: unknown): unknown {
   // boundary: cache values are arbitrary JS objects; a real JS Date must be
   // preserved with full fidelity, so we tag it explicitly here.
   if (value instanceof Date) return [DATE, value.getTime()];
+
+  // boundary: Ruby Marshal round-trips a Time, and `Temporal.Instant` is the
+  // trails analogue, so it is tagged for the same reason a JS Date is.
+  if (value instanceof Temporal.Instant) return [INSTANT, value.toString()];
 
   if (Array.isArray(value)) {
     const encoded = value.map(encode);
@@ -90,6 +96,8 @@ function decode(node: unknown): unknown {
         case DATE:
           // boundary: restoring the JS Date tagged on the way out.
           return new Date(node[1] as number);
+        case INSTANT:
+          return Temporal.Instant.from(node[1] as string);
         case NUMBER: {
           const v = node[1] as string;
           return v === "NaN" ? NaN : v === "Infinity" ? Infinity : -Infinity;
@@ -111,7 +119,7 @@ function decode(node: unknown): unknown {
 /**
  * The trails Marshal-equivalent cache serializer. Mirrors the `dump`/`load`
  * surface of Rails' `Cache::Coder` while preserving JS type fidelity (Date,
- * undefined, bigint, NaN/±Infinity) that plain JSON would lose.
+ * `Temporal.Instant`, undefined, bigint, NaN/±Infinity) that plain JSON would lose.
  *
  * @internal
  */

--- a/packages/activesupport/src/messages/message-metadata-tests.ts
+++ b/packages/activesupport/src/messages/message-metadata-tests.ts
@@ -34,19 +34,44 @@ export function freezeTime(
 }
 
 /**
- * Rails' `DATA`. Rails' second and third entries also carry a
- * `Time.local(2004)`, which survives its `:message_pack` and `Marshal` arms as
- * a Time and its `JSON` arms only because Ruby's `Time#<=>` coerces a String
- * operand through `to_datetime <=> other`
- * (core_ext/time/calculations.rb:329-343). trails' `:marshal` format is backed
- * by `cache/coder.ts`, which flattens a `Temporal.Instant` to `{}`, so the
- * temporal entries stay out until that roundtrips (follow-up story
- * `metadata-data-set-carries-a-time`).
+ * Ruby's `Time#<=>` coerces a non-Time operand through `to_datetime <=> other`
+ * (activesupport/lib/active_support/core_ext/time/calculations.rb:329-343), so
+ * `Time.local(2004) == "2004-01-01 00:00:00 -0500"` is true and Rails'
+ * `assert_equal data, ...` holds over {@link DATA} even under the serializers
+ * that decode the time back as a string. JS equality has no such coercion, so
+ * the two spellings `ActiveSupport::JSON` can render an instant in —
+ * `xmlschema` and the `use_standard_json_time_format = false` slash format
+ * (json.ts `temporalAsJson`) — are compared the same way here.
  */
+expect.addEqualityTesters([
+  function (a: unknown, b: unknown): boolean | undefined {
+    const [instant, other] =
+      a instanceof Temporal.Instant
+        ? [a, b]
+        : b instanceof Temporal.Instant
+          ? [b, a]
+          : [null, null];
+    if (instant === null || typeof other !== "string") return undefined;
+    const slash = other.match(/^(\d+)\/(\d\d)\/(\d\d) (\d\d:\d\d:\d\d) ([+-]\d\d)(\d\d)$/);
+    const iso = slash
+      ? `${slash[1]}-${slash[2]}-${slash[3]}T${slash[4]}${slash[5]}:${slash[6]}`
+      : other;
+    try {
+      return Temporal.Instant.from(iso).equals(instant);
+    } catch {
+      return false;
+    }
+  },
+]);
+
+/** Rails' `Time.local(2004)`. */
+const A_TIME = Temporal.Instant.from("2004-01-01T00:00:00Z");
+
+/** Rails' `DATA`. */
 const DATA: readonly unknown[] = [
   "a string",
-  { a_number: 123, an_object: { key: "value" } },
-  ["a string", 123, { key: "value" }],
+  { a_number: 123, a_time: A_TIME, an_object: { key: "value" } },
+  ["a string", 123, A_TIME, { key: "value" }],
 ];
 
 const CustomSerializer: MessageSerializer = {

--- a/packages/activesupport/src/messages/message-metadata-tests.ts
+++ b/packages/activesupport/src/messages/message-metadata-tests.ts
@@ -35,10 +35,13 @@ export function freezeTime(
 
 /**
  * Rails' `DATA`. Rails' second and third entries also carry a
- * `Time.local(2004)`; a temporal value does not survive the `:json`
- * serializer as a temporal (it decodes back as a string), and the
- * `:message_pack` serializer that would preserve it is excluded — see
- * {@link SERIALIZERS}.
+ * `Time.local(2004)`, which survives its `:message_pack` and `Marshal` arms as
+ * a Time and its `JSON` arms only because Ruby's `Time#<=>` coerces a String
+ * operand through `to_datetime <=> other`
+ * (core_ext/time/calculations.rb:329-343). trails' `:marshal` format is backed
+ * by `cache/coder.ts`, which flattens a `Temporal.Instant` to `{}`, so the
+ * temporal entries stay out until that roundtrips (follow-up story
+ * `metadata-data-set-carries-a-time`).
  */
 const DATA: readonly unknown[] = [
   "a string",
@@ -57,12 +60,16 @@ const CustomSerializer: MessageSerializer = {
 };
 
 /**
- * Rails' `SERIALIZERS`. `ActiveSupport::MessagePack` is excluded pending its
- * temporal packer (follow-up story). Rails lists `JSON` and
- * `ActiveSupport::JSON` separately; trails' `:json` serializer is
- * `ActiveSupport::JSON`, so those two entries collapse into one.
+ * Rails' `SERIALIZERS`. Rails lists `JSON` and `ActiveSupport::JSON`
+ * separately; trails' `:json` serializer is `ActiveSupport::JSON`, so those
+ * two entries collapse into one.
  */
-const SERIALIZERS: readonly (Format | MessageSerializer)[] = ["marshal", "json", CustomSerializer];
+const SERIALIZERS: readonly (Format | MessageSerializer)[] = [
+  "marshal",
+  "json",
+  "message_pack",
+  CustomSerializer,
+];
 
 export function eachScenario<T>(
   makeCodec: (serializer: Format | MessageSerializer) => T,

--- a/packages/i18n/src/date.ts
+++ b/packages/i18n/src/date.ts
@@ -1732,6 +1732,15 @@ function jdOf(d: Temporal.PlainDate): number {
   return UNIX_EPOCH_IN_CJD + d.since(UNIX_EPOCH).days;
 }
 
+/**
+ * @internal `date_core.c:173-175`, two of the `flags` bits a `SimpleDateData`
+ * carries: which of the Julian day and the civil date have been computed.
+ * `HAVE_DF` and `HAVE_TIME` are `ComplexDateData`'s and have no bearer here
+ * yet.
+ */
+const HAVE_JD = 1 << 0;
+const HAVE_CIVIL = 1 << 2;
+
 /** @internal `date_core.c:186`, the Julian day of 1582-10-15. */
 const ITALY = 2299161;
 
@@ -1836,7 +1845,7 @@ function cJdToCivil(jd: number, sg: number): [ry: number, rm: number, rdom: numb
 function cFindFdoy(y: number, sg: number): [rjd: number, ns: number] | null {
   for (let d = 1; d < 31; d++) {
     const r = cValidCivilP(y, 1, d, sg);
-    if (r !== null) return r;
+    if (r !== null) return [r[2], r[3]];
   }
   return null;
 }
@@ -1908,7 +1917,7 @@ function cValidCivilP(
   m: number,
   d: number,
   sg: number,
-): [rjd: number, ns: number] | null {
+): [rm: number, rd: number, rjd: number, ns: number] | null {
   if (m < 0) m += 13;
   if (m < 1 || m > 12) return null;
   if (d < 0) {
@@ -1921,7 +1930,7 @@ function cValidCivilP(
   const [rjd, ns] = cCivilToJd(y, m, d, sg);
   const [ry, rm, rd] = cJdToCivil(rjd, sg);
   if (ry !== y || rm !== m || rd !== d) return null;
-  return [rjd, ns];
+  return [rm, rd, rjd, ns];
 }
 
 /**
@@ -1932,7 +1941,7 @@ function cValidCivilP(
 function cFindLdoy(y: number, sg: number): [rjd: number, ns: number] | null {
   for (let i = 0; i < 30; i++) {
     const r = cValidCivilP(y, 12, 31 - i, sg);
-    if (r !== null) return r;
+    if (r !== null) return [r[2], r[3]];
   }
   return null;
 }
@@ -1944,7 +1953,7 @@ function cFindLdoy(y: number, sg: number): [rjd: number, ns: number] | null {
 function cFindLdom(y: number, m: number, sg: number): [rjd: number, ns: number] | null {
   for (let i = 0; i < 30; i++) {
     const r = cValidCivilP(y, m, 31 - i, sg);
-    if (r !== null) return r;
+    if (r !== null) return [r[2], r[3]];
   }
   return null;
 }
@@ -2144,7 +2153,7 @@ function rtValidOrdinalP(y: number, d: number, sg: number): number | null {
  * raising so its caller can fall through to the next kind of date.
  */
 function rtValidCivilP(y: number, m: number, d: number, sg: number): number | null {
-  return cValidCivilP(y, m, d, sg)?.[0] ?? null;
+  return cValidCivilP(y, m, d, sg)?.[2] ?? null;
 }
 
 /**
@@ -2292,14 +2301,26 @@ export class Date {
   static GREGORIAN = GREGORIAN;
 
   /**
-   * @internal `SimpleDateData`'s `jd` and `sg` (`date_core.c:203-213`), the
-   * state ruby/date carries: the Julian day, and the calendar-reform start it
-   * is read under. A `Temporal.PlainDate` cannot stand in for the pair — it is
-   * proleptic Gregorian, so a Julian date such as 1500-02-29 has no
+   * @internal `SimpleDateData`'s fields (`date_core.c:203-213`), the state
+   * ruby/date carries: the Julian day, the civil date, the calendar-reform
+   * start both are read under, and the `flags` word saying which of the two
+   * representations has actually been computed (`HAVE_JD` / `HAVE_CIVIL`,
+   * `date_core.c:173-183`). Neither is authoritative on its own: a
+   * `Temporal.PlainDate` cannot stand in for the civil triple either, because
+   * it is proleptic Gregorian and a Julian date such as 1500-02-29 has no
    * `Temporal.PlainDate` at all.
+   *
+   * `#year`/`#mon`/`#mday` are meaningful only under `HAVE_CIVIL` and `#jd`
+   * only under `HAVE_JD`; `#getSCivil` and `#getSJd` fill the missing
+   * one in on first read, as `get_s_civil` / `get_s_jd` do
+   * (`date_core.c:1168-1206`).
    */
-  readonly #jd: number;
-  readonly #sg: number;
+  #jd = 0;
+  #year = 0;
+  #mon = 0;
+  #mday = 0;
+  #sg = 0;
+  #flags = 0;
 
   /**
    * Ruby `Date.new(year = -4712, month = 1, mday = 1, start = Date::ITALY)`
@@ -2309,37 +2330,80 @@ export class Date {
    *
    * `date_initialize` branches on `guess_style` first (`date_core.c:3533`): on a
    * negative style the reform cannot bite, so it validates with
-   * `valid_gregorian_p` and stores `HAVE_CIVIL` alone — no Julian day is
-   * computed at all (`date_core.c:3533-3542`). `SimpleDateData`'s `flags`
-   * (`date_core.c:173-183`) is what lets it defer that; the port carries `jd`
-   * and `sg` in place of the flags word, so the Julian day is computed here
-   * either way and only the validation differs.
+   * `valid_gregorian_p` and stores `HAVE_CIVIL` alone, computing no Julian day
+   * (`date_core.c:3533-3542`).
    */
   constructor(year = -4712, month = 1, day = 1, start: number = DEFAULT_SG) {
     if (guessStyle(year, start) < 0) {
       const r = validGregorianP(year, month, day);
       if (r === null) throw new DateError("invalid date");
-      this.#jd = cCivilToJd(year, r[0], r[1], start)[0];
+      this.#setToSimple(0, start, year, r[0], r[1], HAVE_CIVIL);
     } else {
       const r = cValidCivilP(year, month, day, start);
       if (r === null) throw new DateError("invalid date");
-      this.#jd = r[0];
+      this.#setToSimple(r[2], start, year, r[0], r[1], HAVE_JD | HAVE_CIVIL);
     }
-    this.#sg = start;
   }
 
   /**
    * Ruby `Date.jd(jd = 0, start = Date::ITALY)` (ruby/date, `date_core.c`
    * `date_s_jd`), the date the given Julian day names under `start`: Gregorian
-   * at or after it, Julian before.
-   * `date_s_jd` writes the day straight into a fresh `SimpleDateData`; a TS
-   * class has one constructor, and it is `Date.new`'s, so the day is rebuilt
-   * through the civil date it names — the exact round trip `c_valid_civil_p`
-   * itself checks.
+   * at or after it, Julian before. `date_s_jd` writes the day straight into a
+   * fresh `SimpleDateData` under `HAVE_JD` alone
+   * (`date_core.c:3286-3296`), leaving the civil date to `get_s_civil`.
    */
   static jd(jd = 0, start: number = DEFAULT_SG): Date {
-    const [y, m, d] = cJdToCivil(jd, start);
-    return new Date(y, m, d, start);
+    // `d_simple_new_internal` allocates the object and writes its fields;
+    // private fields are only installed by a constructor call in JS, so the
+    // allocation runs through `Date.new`'s default date and is overwritten.
+    const date = new Date(undefined, undefined, undefined, start);
+    date.#setToSimple(jd, start, 0, 0, 0, HAVE_JD);
+    return date;
+  }
+
+  /**
+   * @internal ruby/date's `set_to_simple` (`date_core.c:339-348`), which writes
+   * a `SimpleDateData`'s fields and the `flags` saying which of them the write
+   * made meaningful.
+   */
+  #setToSimple(
+    jd: number,
+    sg: number,
+    year: number,
+    mon: number,
+    mday: number,
+    flags: number,
+  ): void {
+    this.#jd = jd;
+    this.#sg = sg;
+    this.#year = year;
+    this.#mon = mon;
+    this.#mday = mday;
+    this.#flags = flags;
+  }
+
+  /**
+   * @internal ruby/date's `get_s_jd` (`date_core.c:1168-1186`), which computes
+   * the Julian day from the civil date on first read and records `HAVE_JD`.
+   */
+  #getSJd(): number {
+    if (!(this.#flags & HAVE_JD)) {
+      this.#jd = cCivilToJd(this.#year, this.#mon, this.#mday, this.#sg)[0];
+      this.#flags |= HAVE_JD;
+    }
+    return this.#jd;
+  }
+
+  /**
+   * @internal ruby/date's `get_s_civil` (`date_core.c:1188-1206`), the mirror
+   * image: the civil date from the Julian day, recording `HAVE_CIVIL`.
+   */
+  #getSCivil(): [number, number, number] {
+    if (!(this.#flags & HAVE_CIVIL)) {
+      [this.#year, this.#mon, this.#mday] = cJdToCivil(this.#jd, this.#sg);
+      this.#flags |= HAVE_CIVIL;
+    }
+    return [this.#year, this.#mon, this.#mday];
   }
 
   /**
@@ -2468,28 +2532,28 @@ export class Date {
   }
 
   get year(): number {
-    return cJdToCivil(this.#jd, this.#sg)[0];
+    return this.#getSCivil()[0];
   }
 
   get mon(): number {
-    return cJdToCivil(this.#jd, this.#sg)[1];
+    return this.#getSCivil()[1];
   }
 
   get month(): number {
-    return cJdToCivil(this.#jd, this.#sg)[1];
+    return this.#getSCivil()[1];
   }
 
   get day(): number {
-    return cJdToCivil(this.#jd, this.#sg)[2];
+    return this.#getSCivil()[2];
   }
 
   /** `date_core.c` `c_jd_to_wday` (`date_core.c:636-640`), Sunday as `0`. */
   get wday(): number {
-    return mod(this.#jd + 1, 7);
+    return mod(this.#getSJd() + 1, 7);
   }
 
   get yday(): number {
-    return cJdToOrdinal(this.#jd, this.#sg)![1];
+    return cJdToOrdinal(this.#getSJd(), this.#sg)![1];
   }
 
   /**
@@ -2510,7 +2574,7 @@ export class Date {
    */
   isJulian(): boolean {
     if (!Number.isFinite(this.#sg)) return this.#sg === JULIAN;
-    return this.#jd < this.#sg;
+    return this.#getSJd() < this.#sg;
   }
 
   /** Ruby `Date#gregorian?` (ruby/date, `date_core.c` `d_lite_gregorian_p`). */
@@ -2529,7 +2593,7 @@ export class Date {
    * `0074-i18n-parity/datetime-new-start-preserves-the-receiver`.
    */
   newStart(start: number = DEFAULT_SG): Date {
-    return Date.jd(this.#jd, start);
+    return Date.jd(this.#getSJd(), start);
   }
 
   /** Ruby `Date#italy` (ruby/date, `date_core.c` `d_lite_italy`). */

--- a/packages/i18n/src/date.ts
+++ b/packages/i18n/src/date.ts
@@ -2349,13 +2349,15 @@ export class Date {
    * Ruby `Date.jd(jd = 0, start = Date::ITALY)` (ruby/date, `date_core.c`
    * `date_s_jd`), the date the given Julian day names under `start`: Gregorian
    * at or after it, Julian before. `date_s_jd` writes the day straight into a
-   * fresh `SimpleDateData` under `HAVE_JD` alone
-   * (`date_core.c:3286-3296`), leaving the civil date to `get_s_civil`.
+   * fresh `SimpleDateData` under `HAVE_JD` alone (`date_core.c:3377-3387`),
+   * leaving the civil date to `get_s_civil`.
+   *
+   * `d_simple_new_internal` allocates the object and writes its fields in one
+   * step; a JS private field is only installed by a constructor call, so the
+   * allocation runs through `Date.new`'s default date and is then written
+   * over.
    */
   static jd(jd = 0, start: number = DEFAULT_SG): Date {
-    // `d_simple_new_internal` allocates the object and writes its fields;
-    // private fields are only installed by a constructor call in JS, so the
-    // allocation runs through `Date.new`'s default date and is overwritten.
     const date = new Date(undefined, undefined, undefined, start);
     date.#setToSimple(jd, start, 0, 0, 0, HAVE_JD);
     return date;
@@ -2386,24 +2388,46 @@ export class Date {
    * @internal ruby/date's `get_s_jd` (`date_core.c:1168-1186`), which computes
    * the Julian day from the civil date on first read and records `HAVE_JD`.
    */
-  #getSJd(): number {
+  #getSJd(): void {
     if (!(this.#flags & HAVE_JD)) {
       this.#jd = cCivilToJd(this.#year, this.#mon, this.#mday, this.#sg)[0];
       this.#flags |= HAVE_JD;
     }
-    return this.#jd;
   }
 
   /**
    * @internal ruby/date's `get_s_civil` (`date_core.c:1188-1206`), the mirror
    * image: the civil date from the Julian day, recording `HAVE_CIVIL`.
    */
-  #getSCivil(): [number, number, number] {
+  #getSCivil(): void {
     if (!(this.#flags & HAVE_CIVIL)) {
       [this.#year, this.#mon, this.#mday] = cJdToCivil(this.#jd, this.#sg);
       this.#flags |= HAVE_CIVIL;
     }
-    return [this.#year, this.#mon, this.#mday];
+  }
+
+  /** @internal ruby/date's `m_jd` (`date_core.c:1459-1470`). */
+  #mJd(): number {
+    this.#getSJd();
+    return this.#jd;
+  }
+
+  /** @internal ruby/date's `m_year` (`date_core.c:1732-1743`). */
+  #mYear(): number {
+    this.#getSCivil();
+    return this.#year;
+  }
+
+  /** @internal ruby/date's `m_mon` (`date_core.c:1763-1782`). */
+  #mMon(): number {
+    this.#getSCivil();
+    return this.#mon;
+  }
+
+  /** @internal ruby/date's `m_mday` (`date_core.c:1784-1800`). */
+  #mMday(): number {
+    this.#getSCivil();
+    return this.#mday;
   }
 
   /**
@@ -2532,28 +2556,28 @@ export class Date {
   }
 
   get year(): number {
-    return this.#getSCivil()[0];
+    return this.#mYear();
   }
 
   get mon(): number {
-    return this.#getSCivil()[1];
+    return this.#mMon();
   }
 
   get month(): number {
-    return this.#getSCivil()[1];
+    return this.#mMon();
   }
 
   get day(): number {
-    return this.#getSCivil()[2];
+    return this.#mMday();
   }
 
   /** `date_core.c` `c_jd_to_wday` (`date_core.c:636-640`), Sunday as `0`. */
   get wday(): number {
-    return mod(this.#getSJd() + 1, 7);
+    return mod(this.#mJd() + 1, 7);
   }
 
   get yday(): number {
-    return cJdToOrdinal(this.#getSJd(), this.#sg)![1];
+    return cJdToOrdinal(this.#mJd(), this.#sg)![1];
   }
 
   /**
@@ -2574,7 +2598,7 @@ export class Date {
    */
   isJulian(): boolean {
     if (!Number.isFinite(this.#sg)) return this.#sg === JULIAN;
-    return this.#getSJd() < this.#sg;
+    return this.#mJd() < this.#sg;
   }
 
   /** Ruby `Date#gregorian?` (ruby/date, `date_core.c` `d_lite_gregorian_p`). */
@@ -2593,7 +2617,7 @@ export class Date {
    * `0074-i18n-parity/datetime-new-start-preserves-the-receiver`.
    */
   newStart(start: number = DEFAULT_SG): Date {
-    return Date.jd(this.#getSJd(), start);
+    return Date.jd(this.#mJd(), start);
   }
 
   /** Ruby `Date#italy` (ruby/date, `date_core.c` `d_lite_italy`). */

--- a/scripts/mixin-declaration-drift.test.ts
+++ b/scripts/mixin-declaration-drift.test.ts
@@ -103,6 +103,39 @@ describe("mixin declaration drift", () => {
     expect(requiredInterfaceMethodNames("adapter.ts", source, "Adapter")).toEqual(["addIndex"]);
   });
 
+  it("compares a mixin getter against the interface property that restates it", () => {
+    const mixinSource = [
+      "export class Mixin {",
+      "  get schemaCreation(): SchemaCreation {",
+      "    return new SchemaCreation(this);",
+      "  }",
+      "}",
+    ].join("\n");
+    const interfaceSource = [
+      "export interface Adapter {",
+      "  readonly schemaCreation: SchemaCreation;",
+      "}",
+    ].join("\n");
+    const mixin = mixinSignatures("mixin.ts", mixinSource, "Mixin");
+    const declared = interfaceSignatures("adapter.ts", interfaceSource, "Adapter");
+    expect(mixin).toEqual([{ name: "schemaCreation", signature: ": SchemaCreation" }]);
+    expect(findDrift(mixin, declared)).toEqual([]);
+    expect(requiredInterfaceMethodNames("adapter.ts", interfaceSource, "Adapter")).toEqual([
+      "schemaCreation",
+    ]);
+  });
+
+  it("reports a getter the interface restates with a stale type", () => {
+    const mixinSource = "export class Mixin {\n  get schemaCreation(): SchemaCreation {}\n}";
+    const interfaceSource = "export interface Adapter {\n  readonly schemaCreation: unknown;\n}";
+    expect(
+      findDrift(
+        mixinSignatures("mixin.ts", mixinSource, "Mixin"),
+        interfaceSignatures("adapter.ts", interfaceSource, "Adapter"),
+      ),
+    ).toEqual([{ name: "schemaCreation", mixin: ": SchemaCreation", declared: ": unknown" }]);
+  });
+
   it("reports a mixin signature the interface no longer matches", () => {
     const mixin: SignatureEntry[] = [{ name: "addIndex", signature: "(name: string): void" }];
     const stale: SignatureEntry[] = [{ name: "addIndex", signature: "(name: number): void" }];

--- a/scripts/mixin-declaration-drift.ts
+++ b/scripts/mixin-declaration-drift.ts
@@ -79,8 +79,19 @@ function signatureOf(node: ts.SignatureDeclarationBase): string {
 /** Stands in for a parameter type TypeScript infers rather than spells. */
 const WILDCARD = "*";
 
-function isPublicInstanceMethod(member: ts.ClassElement): member is ts.MethodDeclaration {
-  if (!ts.isMethodDeclaration(member)) return false;
+/**
+ * A getter's signature, spelled the way an interface has to restate it: a
+ * property type. `get schemaCreation(): T` on the mixin is `readonly
+ * schemaCreation: T` on the interface, so both sides normalize to `: T`.
+ */
+function propertySignatureOf(node: ts.GetAccessorDeclaration | ts.PropertySignature): string {
+  return `: ${typeText(node.type) ?? ""}`;
+}
+
+function isPublicInstanceMember(
+  member: ts.ClassElement,
+): member is ts.MethodDeclaration | ts.GetAccessorDeclaration {
+  if (!ts.isMethodDeclaration(member) && !ts.isGetAccessorDeclaration(member)) return false;
   const modifiers = ts.getModifiers(member) ?? [];
   return !modifiers.some(
     (m) =>
@@ -90,7 +101,7 @@ function isPublicInstanceMethod(member: ts.ClassElement): member is ts.MethodDec
   );
 }
 
-/** Public instance-method signatures of `className` in `source`. */
+/** Public instance method and getter signatures of `className` in `source`. */
 export function mixinSignatures(
   fileName: string,
   source: string,
@@ -100,10 +111,15 @@ export function mixinSignatures(
   for (const statement of parse(fileName, source).statements) {
     if (!ts.isClassDeclaration(statement) || statement.name?.text !== className) continue;
     for (const member of statement.members) {
-      if (!isPublicInstanceMethod(member)) continue;
+      if (!isPublicInstanceMember(member)) continue;
       const name = member.name.getText();
       if (name.startsWith("#")) continue;
-      entries.push({ name, signature: signatureOf(member) });
+      entries.push({
+        name,
+        signature: ts.isGetAccessorDeclaration(member)
+          ? propertySignatureOf(member)
+          : signatureOf(member),
+      });
     }
   }
   return entries;
@@ -122,7 +138,7 @@ function isWaived(source: string, member: ts.TypeElement): boolean {
   );
 }
 
-/** Method-member signatures of `interface <interfaceName>` in `source`. */
+/** Method- and property-member signatures of `interface <interfaceName>` in `source`. */
 export function interfaceSignatures(
   fileName: string,
   source: string,
@@ -132,8 +148,12 @@ export function interfaceSignatures(
   for (const statement of parse(fileName, source).statements) {
     if (!ts.isInterfaceDeclaration(statement) || statement.name.text !== interfaceName) continue;
     for (const member of statement.members) {
-      if (!ts.isMethodSignature(member) || isWaived(source, member)) continue;
-      entries.push({ name: member.name.getText(), signature: signatureOf(member) });
+      if (isWaived(source, member)) continue;
+      if (ts.isMethodSignature(member)) {
+        entries.push({ name: member.name.getText(), signature: signatureOf(member) });
+      } else if (ts.isPropertySignature(member)) {
+        entries.push({ name: member.name.getText(), signature: propertySignatureOf(member) });
+      }
     }
   }
   return entries;
@@ -154,9 +174,8 @@ export function requiredInterfaceMethodNames(
   for (const statement of parse(fileName, source).statements) {
     if (!ts.isInterfaceDeclaration(statement) || statement.name.text !== interfaceName) continue;
     for (const member of statement.members) {
-      if (!ts.isMethodSignature(member) || member.questionToken || isWaived(source, member)) {
-        continue;
-      }
+      if (!ts.isMethodSignature(member) && !ts.isPropertySignature(member)) continue;
+      if (member.questionToken || isWaived(source, member)) continue;
       names.push(member.name.getText());
     }
   }

--- a/vendor/sources.lock.json
+++ b/vendor/sources.lock.json
@@ -1,5 +1,9 @@
 {
   "sources": {
+    "date": {
+      "ref": "v3.4.1",
+      "sha": "a3295ad262773a80ad61526beb500b29e770b817"
+    },
     "did_you_mean": {
       "ref": "v1.6.3",
       "sha": "f7703add765054b6e63ef581818a0c307fdd4abf"

--- a/vendor/sources.ts
+++ b/vendor/sources.ts
@@ -188,20 +188,20 @@ export const SOURCES: readonly UpstreamSource[] = [
     },
     packages: [
       {
-        // TS-side workspace dir is `packages/corelib/src`; the date port
-        // (packages/i18n/src/date.ts today) cites
+        // The date port (packages/i18n/src/date.ts today) cites
         // `ext/date/date_core.c` / `ext/date/date_parse.c` by line
         // throughout, so the C sources have to be readable in-tree.
         // `libPath: "lib"` covers `lib/date.rb` — the Ruby-visible surface
         // api-compare would extract once it is enrolled.
-        name: "corelib",
+        name: "date",
         libPath: "lib",
         testPath: "test/date",
         // Vendored-only for now: the gem's surface is implemented in C, so
-        // the Ruby extractor sees almost nothing until the enrollment
-        // stories of RFC 0088-corelib-package wire up `packages/corelib`
-        // and flip these on. Same shipped-interim pattern RFC 0074 used
-        // for i18n.
+        // the Ruby extractor sees almost nothing until RFC
+        // 0088-date-gem-port's `date-package-scaffold`,
+        // `date-api-compare-enrollment` and `date-test-compare-enrollment`
+        // stories land `packages/date` and flip these on. Same
+        // shipped-interim pattern RFC 0074 used for i18n.
         compareApi: false,
         compareTests: false,
       },

--- a/vendor/sources.ts
+++ b/vendor/sources.ts
@@ -180,6 +180,34 @@ export const SOURCES: readonly UpstreamSource[] = [
     ],
   },
   {
+    name: "date",
+    origin: {
+      type: "git",
+      url: "https://github.com/ruby/date.git",
+      ref: "v3.4.1",
+    },
+    packages: [
+      {
+        // TS-side workspace dir is `packages/corelib/src`; the date port
+        // (packages/i18n/src/date.ts today) cites
+        // `ext/date/date_core.c` / `ext/date/date_parse.c` by line
+        // throughout, so the C sources have to be readable in-tree.
+        // `libPath: "lib"` covers `lib/date.rb` — the Ruby-visible surface
+        // api-compare would extract once it is enrolled.
+        name: "corelib",
+        libPath: "lib",
+        testPath: "test/date",
+        // Vendored-only for now: the gem's surface is implemented in C, so
+        // the Ruby extractor sees almost nothing until the enrollment
+        // stories of RFC 0088-corelib-package wire up `packages/corelib`
+        // and flip these on. Same shipped-interim pattern RFC 0074 used
+        // for i18n.
+        compareApi: false,
+        compareTests: false,
+      },
+    ],
+  },
+  {
     name: "i18n",
     origin: {
       type: "git",


### PR DESCRIPTION
Four related stories.

**vendor-ruby-date-gem** — `vendor/sources.ts` gains a `date` source
(`https://github.com/ruby/date.git` @ `v3.4.1`) with one package
`{ name: "date", libPath: "lib", testPath: "test/date" }`, `compareApi` /
`compareTests` false until RFC 0088-date-gem-port's `date-package-scaffold`,
`date-api-compare-enrollment` and `date-test-compare-enrollment` stories flip
them (the shipped-interim pattern RFC 0074 used for i18n). `pnpm vendor:fetch` populates
`vendor/date/` with `lib/date.rb`, `ext/date/date_parse.c`,
`ext/date/date_core.c` and `test/date/`, so the JSDoc citations throughout
`packages/i18n/src/date.ts` now point at a file in the tree.

**date-state-lacks-simple-date-data-flags** — `Date` now carries
`SimpleDateData`'s shape: `jd`, the civil triple, `sg`, and a `flags` word with
`HAVE_JD` / `HAVE_CIVIL` (`date_core.c:173-183`). `date_initialize`'s
negative-style arm stores `HAVE_CIVIL` alone and computes no Julian day
(`date_core.c:3533-3542`); `Date.jd` stores the day under `HAVE_JD` alone
(`date_core.c:3377-3387`) rather than rebuilding it through civil; `#getSJd` /
`#getSCivil` fill the missing representation in on first read
(`date_core.c:1168-1206`). `cValidCivilP` regains `c_valid_civil_p`'s `rm`/`rd`
outputs (`date_core.c:767-789`), which the `HAVE_JD | HAVE_CIVIL` write needs.

Values verified unchanged: a 4668-construction differential against
`ruby 3.3.11 -rdate` (18 years x 7 months x 9 days x 4 starts, spanning
1581/1582/1583 and 1929/1930/1931 and both infinite starts, plus a `Date.jd`
sweep across the reform) is at zero value mismatches.

**mysql-schema-creation-declared-on-adapter-not-the-mixin** —
`AbstractMysqlAdapter`'s duplicate `schemaCreation` getter and its
`_mysqlSchemaCreation` memo are gone; `MysqlSchemaStatements` is the only
definition, as Rails has it at `mysql/schema_statements.rb:139`. The merged
`export interface AbstractMysqlAdapter` declares it, and
`scripts/mixin-declaration-drift.ts` learned to compare a mixin getter against
the interface property that restates it, so all six MySQL mixin members are
drift-checked.

**activesupport-metadata-message-pack-serializer-matrix** — the shared
`Messages::Metadata` cases now run over the MessagePack serializer alongside
marshal, json and the custom one, exercising `TIMESTAMP_SERIALIZERS`' raw
`Temporal.Instant` expiry path. `DATA` also carries Rails'
`Time.local(2004)` in its second and third entries, which took two things:
`cache/coder.ts` — the trails Marshal-equivalent backing the `:marshal`
format — now tags a `Temporal.Instant` the way it already tags a JS `Date`,
since Ruby Marshal round-trips a `Time`; and the JSON-family arms compare the
way Rails' `assert_equal` does, where `Time#<=>` coerces a String operand
through `to_datetime <=> other`
(`core_ext/time/calculations.rb:329-343`) — that coercion is what makes Rails'
own JSON arms pass, and it is stated at the comparison rather than worked
around by dropping the value. That closes
`0072-api-compare-parity-burndown/metadata-data-set-carries-a-time`, filed
earlier in this PR's life when only the deferral looked reachable.

Closes-story: vendor-ruby-date-gem
Closes-story: date-state-lacks-simple-date-data-flags
Closes-story: mysql-schema-creation-declared-on-adapter-not-the-mixin
Closes-story: activesupport-metadata-message-pack-serializer-matrix
Closes-story: metadata-data-set-carries-a-time

