### PR TITLE
feat(scripts,activerecord): model-level receivers in the row-write ratchet, orphan reopened-file buckets, encryption support_unencrypted_data gate

### DIFF
--- a/packages/activemodel/src/validations.ts
+++ b/packages/activemodel/src/validations.ts
@@ -370,15 +370,6 @@ export interface ReadAttributeForValidationHost {
 }
 
 /**
- * Rails: ActiveModel::Validations extends Translation (validations.rb:43),
- * so the singleton accessor surfaces on Validations directly. Mirror that
- * here so callers can read/write via `Validations.raiseOnMissingTranslations(...)`.
- */
-export function raiseOnMissingTranslations(value?: boolean): boolean {
-  return translationRaise(value);
-}
-
-/**
  * Normalize the `validates_each` argument list, splitting attribute
  * names from the trailing options hash and stamping the merged
  * options with `attributes:`. Mirrors Rails
@@ -396,6 +387,15 @@ export function _mergeAttributes(attrNames: unknown[]): Record<string, unknown> 
   const flat = attrNames.flat(Infinity).map((n) => String(n));
   options.attributes = flat;
   return options;
+}
+
+/**
+ * Rails: ActiveModel::Validations extends Translation (validations.rb:43),
+ * so the singleton accessor surfaces on Validations directly. Mirror that
+ * here so callers can read/write via `Validations.raiseOnMissingTranslations(...)`.
+ */
+export function raiseOnMissingTranslations(value?: boolean): boolean {
+  return translationRaise(value);
 }
 
 /**

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.test.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.test.ts
@@ -8,6 +8,8 @@ import {
 } from "./test-helpers.js";
 import { EncryptedAttributeType } from "./encrypted-attribute-type.js";
 import { Scheme } from "./scheme.js";
+import { Configurable } from "./configurable.js";
+import { Decryption } from "./errors.js";
 
 describe("EncryptedAttributeType#databaseTypeToText — serialized+binary cast type", () => {
   let savedConfig: ReturnType<typeof snapshotEncryptionConfig>;
@@ -129,5 +131,56 @@ describe("EncryptedAttributeType — delegations to scheme", () => {
 
     expect(result).toBe("value");
     expect(spy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("EncryptedAttributeType#supportUnencryptedData — global config conjunct", () => {
+  // encrypted_attribute_type.rb:61-63 —
+  //   config.support_unencrypted_data && scheme.support_unencrypted_data? && !previous_type?
+  // The global config is not merely the scheme's fallback (scheme.rb:48-50): it
+  // AND-gates an explicit per-attribute opt-in too.
+  let savedConfig: ReturnType<typeof snapshotEncryptionConfig>;
+
+  beforeEach(() => {
+    savedConfig = snapshotEncryptionConfig();
+    configureEncryption({ supportUnencryptedData: false });
+  });
+
+  afterEach(() => {
+    restoreEncryptionConfig(savedConfig);
+  });
+
+  it("an attribute-level opt-in does not survive a global opt-out", () => {
+    const scheme = new Scheme({ supportUnencryptedData: true });
+    expect(scheme.isSupportUnencryptedData()).toBe(true);
+    expect(new EncryptedAttributeType({ scheme }).supportUnencryptedData).toBe(false);
+  });
+
+  it("re-raises a Decryption error instead of returning the ciphertext as clear text", () => {
+    const type = new EncryptedAttributeType({
+      scheme: new Scheme({ supportUnencryptedData: true }),
+    });
+
+    expect(() => type.deserialize("not a valid ciphertext")).toThrow(Decryption);
+  });
+
+  it("is true when both the global config and the scheme allow it", () => {
+    Configurable.config.supportUnencryptedData = true;
+    const type = new EncryptedAttributeType({
+      scheme: new Scheme({ supportUnencryptedData: true }),
+    });
+
+    expect(type.supportUnencryptedData).toBe(true);
+    expect(type.deserialize("not a valid ciphertext")).toBe("not a valid ciphertext");
+  });
+
+  it("is false for a previous type even when everything else allows it", () => {
+    Configurable.config.supportUnencryptedData = true;
+    const type = new EncryptedAttributeType({
+      scheme: new Scheme({ supportUnencryptedData: true }),
+      previousType: true,
+    });
+
+    expect(type.supportUnencryptedData).toBe(false);
   });
 });

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -161,11 +161,11 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
   }
 
   get supportUnencryptedData(): boolean {
-    if (this._previousType) return false;
-    // Mirrors Rails' EncryptedAttributeType#support_unencrypted_data? which delegates
-    // directly to scheme.support_unencrypted_data?. The scheme already handles the
-    // per-attribute override vs global config fallback — no extra AND-gate needed here.
-    return this.scheme.isSupportUnencryptedData();
+    return (
+      Configurable.config.supportUnencryptedData &&
+      this.scheme.isSupportUnencryptedData() &&
+      !this._previousType
+    );
   }
 
   /** @internal */

--- a/scripts/api-compare/conventions.ts
+++ b/scripts/api-compare/conventions.ts
@@ -101,6 +101,23 @@ export const RUBY_FILE_TS_OVERRIDES: Record<string, string> = {
   // `interpolate_hash` are measured against `backend/cache.ts` and, since
   // cache.rb is unported, drop out of accounting entirely.
   "i18n:interpolate/ruby.rb": "interpolate/ruby.ts",
+  // `encryption.rb` defines `module Cipher` (encryption.rb:22, `autoload`
+  // aside) before `encryption/cipher.rb` reopens it with the whole class-method
+  // surface, so all six land in the `encryption.rb` bucket and read as missing.
+  "activerecord:encryption/cipher.rb": "encryption/cipher.ts",
+  // `GlobalID` is first defined by `fixture_set.rb`'s reopening, so the class's
+  // entire surface — every method in `global_id.rb` itself — buckets there.
+  "globalid:global_id.rb": "global-id.ts",
+  // `validations.rb` opens `Validations::ClassMethods` first, so `validates`,
+  // `validates!` and their two private helpers bucket under it. trails carries
+  // all four on `Model` (model.ts), the class `Validations` is mixed into.
+  "activemodel:validations/validates.rb": "model.ts",
+  // Likewise `HelperMethods`, whose first definition Rails puts in
+  // `validations/absence.rb`; trails' `_mergeAttributes` lives in validations.ts.
+  "activemodel:validations/helper_methods.rb": "validations.ts",
+  // `ARTest` is defined by `config.rb` first; `connection.rb` reopens it for the
+  // three connection helpers, which trails ports to `support/connection.ts`.
+  "activerecord-test-support:connection.rb": "connection.ts",
 };
 
 /** The explicit TS mapping for `rubyFile` in `pkg`, or undefined when unmapped. */

--- a/scripts/non-transactional-row-writes.test.ts
+++ b/scripts/non-transactional-row-writes.test.ts
@@ -7,6 +7,7 @@ import {
   hasTransactionalWiring,
   isOffender,
   loadRatchet,
+  NON_MODEL_RECEIVERS,
   RATCHET_PATH,
   reachesSharedConnection,
   rowWritesAtItScope,
@@ -237,6 +238,55 @@ describe("non-transactional row writes", () => {
       "",
     ].join("\n");
     expect(rowWritesAtItScope(src).map((w) => w.line)).toEqual([10]);
+  });
+
+  it("catches a model-level write that names no shared-connection accessor", () => {
+    const src = `describe("x", () => {
+  it("writes", async () => {
+    await Book.create({ name: "Dune" });
+  });
+});
+`;
+    expect(reachesSharedConnection(src)).toBe(false);
+    expect(rowWritesAtItScope(src).map((w) => w.receiver)).toEqual(["Book"]);
+    expect(isOffender(src)).toBe(true);
+  });
+
+  it.each([...NON_MODEL_RECEIVERS])("clears a %s.create( false positive", (receiver) => {
+    const src = `describe("x", () => {
+  it("does not write", () => {
+    ${receiver}.create({ name: "Dune" });
+  });
+});
+`;
+    expect(isOffender(src)).toBe(false);
+  });
+
+  it("clears a model bound to an adapter the file owns", () => {
+    const src = `describe("x", () => {
+  let adapter: Mysql2Adapter;
+  beforeEach(async () => {
+    adapter = await leaseMysqlAdapter();
+    EnumTest.adapter = adapter;
+  });
+
+  it("writes", async () => {
+    await EnumTest.create({ enum_column: "text" });
+  });
+});
+`;
+    expect(isOffender(src)).toBe(false);
+  });
+
+  it("clears a lowercase receiver whose update writes no row", () => {
+    const src = `describe("x", () => {
+  it("encrypts", () => {
+    cipher.update(clearText);
+  });
+});
+`;
+    expect(rowWritesAtItScope(src).map((w) => w.receiver)).toEqual(["cipher"]);
+    expect(isOffender(src)).toBe(false);
   });
 
   it("does not grow past the seeded ratchet", async () => {

--- a/scripts/non-transactional-row-writes.ts
+++ b/scripts/non-transactional-row-writes.ts
@@ -46,10 +46,13 @@
  *   GCM cipher's `.update(...)`. None of those files touch the shared
  *   connection either.
  *
- * Known gap: a model-level write (`Book.create(...)`) that reaches the shared
- * connection implicitly, naming no accessor. No file in this tree has that
- * shape — the canonical-schema files all ride `fixtures()` — and closing it
- * needs receiver-level knowledge the textual scan does not have.
+ * A model-level write (`Book.create(...)`) reaches the shared connection without
+ * naming any accessor, so clause (c) also counts a write whose receiver is a
+ * model class — a capitalised identifier that is not one of the
+ * {@link NON_MODEL_RECEIVERS} the textual `WRITE_PATTERNS` also match. A file
+ * that binds its models to an adapter it owns (`EnumTest.adapter = adapter`,
+ * {@link EXPLICIT_ADAPTER_BINDING}) is writing over that adapter, not the shared
+ * connection, which is what keeps the `adapters/*` cluster retired.
  *
  * The seed grew by one once `stripCommentsAndStrings` became a scanner. The
  * regex chain it replaced ran one pass per quote kind, so a quote of one kind
@@ -174,6 +177,31 @@ const IT_CALL = /(?:^|[^.\w])(?:it|test)((?:\.\w+)*)\s*[(`]/g;
 export interface RowWrite {
   line: number;
   pattern: string;
+  /** The identifier the call was made on — `""` for `INSERT INTO` and for a
+   *  call with no receiver at all (`create(...)`, `(await x).insert`). */
+  receiver: string;
+}
+
+/**
+ * Capitalised receivers `WRITE_PATTERNS` matches that are not model classes and
+ * so write no row: the false positives the module header enumerates.
+ */
+export const NON_MODEL_RECEIVERS = new Set([
+  "AliasTracker",
+  "DatabaseTasks",
+  "Object",
+  "SchemaDumper",
+]);
+
+/**
+ * A model bound to an adapter the file owns (`EnumTest.adapter = adapter`).
+ * Writes on it land in that adapter's database, not the shared per-worker one.
+ */
+export const EXPLICIT_ADAPTER_BINDING = /\.adapter\s*=[^=]/;
+
+/** Whether a write's receiver is a model class rather than a known false positive. */
+export function isModelReceiver(receiver: string): boolean {
+  return /^[A-Z]/.test(receiver) && !NON_MODEL_RECEIVERS.has(receiver);
 }
 
 /**
@@ -195,6 +223,19 @@ export interface RowWrite {
  * (`` it.each`…`("name", fn) ``) is the same shape with a template in place of
  * the array, so the same deferral runs off the template's closing backtick.
  */
+/**
+ * The identifier a `.`-prefixed write was called on, read backwards from the
+ * dot. A pattern that is not a method call (`INSERT INTO`) has no receiver, and
+ * neither does a dotted call whose left-hand side is an expression rather than
+ * an identifier (`(await adapter).insert`).
+ */
+function receiverAt(line: string, index: number, pattern: string): string {
+  if (!pattern.startsWith(".")) return "";
+  let start = index;
+  while (start > 0 && /[\w$]/.test(line[start - 1])) start--;
+  return line.slice(start, index);
+}
+
 export function rowWritesAtItScope(src: string): RowWrite[] {
   const stripped = stripCommentsAndStrings(src);
   const writes: RowWrite[] = [];
@@ -253,7 +294,9 @@ export function rowWritesAtItScope(src: string): RowWrite[] {
       if (bodyCallPending && ch.trim() !== "") bodyCallPending = false;
       if (itParens.length === 0) continue;
       for (const pattern of WRITE_PATTERNS) {
-        if (line.startsWith(pattern, c)) writes.push({ line: i + 1, pattern });
+        if (line.startsWith(pattern, c)) {
+          writes.push({ line: i + 1, pattern, receiver: receiverAt(line, c, pattern) });
+        }
       }
     }
   }
@@ -284,10 +327,21 @@ export function reachesSharedConnection(src: string): boolean {
   return SHARED_CONNECTION_ACCESSORS.some((accessor) => stripped.includes(accessor));
 }
 
+/**
+ * Whether a write reaches the shared connection through a model class instead of
+ * a named accessor. A file that binds an adapter of its own to its models is
+ * writing over that adapter, so its model writes do not count.
+ */
+export function writesThroughModel(src: string, writes: RowWrite[]): boolean {
+  if (EXPLICIT_ADAPTER_BINDING.test(stripCommentsAndStrings(src))) return false;
+  return writes.some((write) => isModelReceiver(write.receiver));
+}
+
 export function isOffender(src: string): boolean {
   if (hasTransactionalWiring(src)) return false;
-  if (!reachesSharedConnection(src)) return false;
-  return rowWritesAtItScope(src).length > 0;
+  const writes = rowWritesAtItScope(src);
+  if (writes.length === 0) return false;
+  return reachesSharedConnection(src) || writesThroughModel(src, writes);
 }
 
 async function collectTestFiles(dir: string, out: string[]): Promise<void> {


### PR DESCRIPTION
Three bundled stories.

## 1. Row-write ratchet: model-level writes (`row-write-ratchet-misses-implicit-model-level-writes`)

PR #6125 scoped the non-transactional row-write ratchet to files that name a
`SHARED_CONNECTION_ACCESSORS` member, and documented the gap that opened: a
model-level write (`Book.create(...)`) reaches the shared connection implicitly,
naming no accessor.

`rowWritesAtItScope` now records each write's **receiver**, and clause (c) also
counts a write whose receiver is a model class — a capitalised identifier that is
not one of the documented `NON_MODEL_RECEIVERS` (`Object`, `SchemaDumper`,
`AliasTracker`, `DatabaseTasks`, the textual false positives the module header
already enumerated). A file that binds its models to an adapter it owns
(`EnumTest.adapter = adapter`, `EXPLICIT_ADAPTER_BINDING`) is writing over that
adapter, which is what keeps the `adapters/*` throwaway cluster retired — the
three files with PascalCase model writes today (`case-sensitivity`, `mysql-enum`,
`unsigned-type`) all assign `.adapter` explicitly. A lowercase receiver
(a GCM cipher's `.update(...)`) is excluded by construction.

The "Known gap" paragraph is deleted, replaced by the rule that closes it.

**Verdicts are unchanged on the whole corpus**: all 9 rows in
`scripts/non-transactional-row-writes.json` and every file the accessor rule
removed keep their current verdict (the `does not grow past the seeded ratchet`
case passes with an empty `added`/`stale`). New per-case tests cover the model
write, each non-model receiver, the owned-adapter binding, and the cipher.

## 2. Orphan reopened-file buckets (`api-compare-orphan-reopened-file-buckets`)

api:compare buckets an entity's whole method set under the file that defined its
FIRST method, so every method a later reopening adds is measured against the
DEFINING file's TS counterpart and reports missing forever. This PR takes the
**non-activesupport slice** — five files, mapped through
`RUBY_FILE_TS_OVERRIDES`:

| Ruby file | TS counterpart | methods |
| --- | --- | --- |
| `activerecord:encryption/cipher.rb` | `encryption/cipher.ts` | 6 |
| `globalid:global_id.rb` | `global-id.ts` | 22 |
| `activemodel:validations/validates.rb` | `model.ts` | 4 |
| `activemodel:validations/helper_methods.rb` | `validations.ts` | 1 |
| `activerecord-test-support:connection.rb` | `connection.ts` | 3 |

**Ported-method deltas — these are measurement fixes, not new porting work:**

| package | before | after |
| --- | --- | --- |
| activerecord | 6148/6148, files 277 | 6148/6148, files 278 |
| activerecord-test-support | 32/32 | 35/35 |
| activemodel | 716/716, files 63 | 716/716, files 65 |
| globalid | 63/63 (100%) | **76/80 (95%)** |
| Overall | 13076/17775, files 802 | 13092/17795, files 807 |

globalid's drop to 95% is the point of the exercise: moving `GlobalID`'s own
surface out of the `fixture_set.rb` bucket surfaced four members that were
invisible before — `deconstruct_keys`, `as_json` (ported under the JS name
`toJSON`), `default_locator`, `parse_encoded_gid`. Matched methods went **up**
(63 → 76); the four are pre-existing gaps, now measured, and are filed as
`globalid-missing-members-surfaced-by-bucket-split`.

`pnpm api:calls:wide` is green (no new mismatch, no stale row) — the newly split
buckets introduced no wide call-mismatch entry, so no baseline row was added.
`pnpm lint --fix` reordered `validations.ts` to the Rails source order the new
`helper_methods.rb` bucket asserts.

The remaining orphans are registered as their own stories rather than fanned out
here:

- `api-compare-orphan-buckets-activesupport-calculations` — the
  `core_ext/{time,date,date_time}/calculations.rb` cluster (129 methods).
- `api-compare-orphan-buckets-activesupport-core-ext-tail` — ~60 remaining
  activesupport core_ext files, plus the `version.rb` orphans. Note for whoever
  takes it: `isSourceUnported` matches by substring, and `"version.rb"` is a
  substring of `"gem_version.rb"`, which is a real entity home — a naive
  `UNPORTED_FILES` pattern silently drops that bucket.

## 3. `support_unencrypted_data?` global-config conjunct (`converge-encrypted-attribute-type-support-unencrypted-data-gate`)

`vendor/rails/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb:61-63`:

```ruby
def support_unencrypted_data?
  ActiveRecord::Encryption.config.support_unencrypted_data && scheme.support_unencrypted_data? && !previous_type?
end
```

trails dropped the first conjunct, with a call-site comment claiming the scheme
already handled it. It does not: `Scheme#support_unencrypted_data?`
(`scheme.rb:48-50`) falls back to the global config only when the attribute set
nothing, so `encrypts :name, support_unencrypted_data: true` under a global
`false` answered **true** in trails and **false** in Rails — a fail-open
divergence that appends a clean-text scheme Rails would not append and swallows a
`Decryption` error Rails re-raises.

Ported verbatim, config conjunct first and `previous_type?` last. The comment is
gone. Four tests pin it, including the deserialize path re-raising `Decryption`
rather than returning the ciphertext; the two divergent-case tests fail on the
pre-change body.

Closes-story: row-write-ratchet-misses-implicit-model-level-writes
Closes-story: api-compare-orphan-reopened-file-buckets
Closes-story: converge-encrypted-attribute-type-support-unencrypted-data-gate
