### PR TITLE
fix(scripts): mark sync-stats as ESM so tsx stops CJS-transforming dist

### DIFF
--- a/scripts/sync-stats/module-format.test.ts
+++ b/scripts/sync-stats/module-format.test.ts
@@ -1,0 +1,26 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// The nightly stats sync runs `pnpm tsx scripts/sync-stats/sync.ts`. tsx picks
+// the module format from the nearest package.json, and the repo root declares
+// no "type" — so without a local marker sync.ts loads as CommonJS and tsx
+// transforms the whole workspace `dist/` graph it imports to CJS as well. That
+// graph reaches `@blazetrails/activesupport`'s `dist/yaml.js`, whose top-level
+// await cannot be represented in CJS, and esbuild aborts the run with
+// "Top-level await is currently not supported with the \"cjs\" output format".
+// The crash is invisible to typecheck and to vitest (both ESM), so this is the
+// only thing standing between a deleted marker and a silently dead cron.
+const dir = fileURLToPath(new URL(".", import.meta.url));
+
+describe("sync-stats module format", () => {
+  it("declares ESM so tsx does not CJS-transform the workspace dist graph", async () => {
+    const pkg: unknown = JSON.parse(await readFile(`${dir}package.json`, "utf8"));
+    expect((pkg as { type?: string }).type).toBe("module");
+  });
+
+  it("still imports a workspace package, so the ESM marker is load-bearing", async () => {
+    const source = await readFile(`${dir}sync.ts`, "utf8");
+    expect(source).toMatch(/from "@blazetrails\//);
+  });
+});

--- a/scripts/sync-stats/module-format.test.ts
+++ b/scripts/sync-stats/module-format.test.ts
@@ -2,15 +2,8 @@ import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
-// The nightly stats sync runs `pnpm tsx scripts/sync-stats/sync.ts`. tsx picks
-// the module format from the nearest package.json, and the repo root declares
-// no "type" — so without a local marker sync.ts loads as CommonJS and tsx
-// transforms the whole workspace `dist/` graph it imports to CJS as well. That
-// graph reaches `@blazetrails/activesupport`'s `dist/yaml.js`, whose top-level
-// await cannot be represented in CJS, and esbuild aborts the run with
-// "Top-level await is currently not supported with the \"cjs\" output format".
-// The crash is invisible to typecheck and to vitest (both ESM), so this is the
-// only thing standing between a deleted marker and a silently dead cron.
+// Rationale for the marker this guards: scripts/sync-stats/package.json's
+// "description". typecheck and vitest are both ESM, so nothing else notices.
 const dir = fileURLToPath(new URL(".", import.meta.url));
 
 describe("sync-stats module format", () => {

--- a/scripts/sync-stats/package.json
+++ b/scripts/sync-stats/package.json
@@ -1,0 +1,5 @@
+{
+  "private": true,
+  "type": "module",
+  "description": "Marks the stats-sync scripts as ESM. The repo root has no \"type\", so without this tsx loads sync.ts as CommonJS and transforms every workspace dist/ file it pulls in to CJS too — which fails on the top-level await in @blazetrails/activesupport's dist/yaml.js. Enforced by module-format.test.ts."
+}


### PR DESCRIPTION
## Problem

The nightly stats sync (host crontab → `scripts/sync-stats/cron-wrapper.sh`) failed on its 2026-08-05 run:

```
/…/packages/activesupport/dist/yaml.js:11:13: ERROR: Top-level await is currently not supported with the "cjs" output format
```

`pnpm stats:sync` runs `pnpm tsx scripts/sync-stats/sync.ts`. tsx picks the module format from the nearest `package.json`; the repo root declares no `"type"`, so `sync.ts` loaded as **CommonJS** and tsx transformed the whole workspace `dist/` graph it imports to CJS along with it. That graph reaches `@blazetrails/activesupport`'s `dist/yaml.js`, which resolves the optional `yaml` package with a top-level `await import` (added in #6078) — esbuild cannot represent top-level await in a CJS output and aborts the run. `stats.db` has been receiving nothing since.

Reproduced locally with `pnpm stats:sync --latest`; the same error, same line.

## Fix

`scripts/sync-stats/package.json` with `"type": "module"` — the marker `scripts/parity` and `scripts/guides-typecheck` already carry for exactly this reason (both import workspace packages and both are ESM). It is deliberately *not* registered in `pnpm-workspace.yaml`: resolution already works through root hoisting, and registering it would make the cron host's next run depend on a fresh `pnpm install`.

With the marker in place `pnpm stats:sync --latest` gets past the transform and syncs normally (PR data, files, commits, comments/reviews, requested reviewers, linked issues…).

## Guard

`module-format.test.ts` asserts the directory still declares `"type": "module"` and that `sync.ts` still imports a `@blazetrails/*` package (so the marker stays load-bearing rather than quietly vacuous). This is the only guard available: the crash is invisible to `tsc` and to vitest, both of which load ESM, so nothing else in CI would notice the marker being removed.

No change to the cron schedule or to the wrapper's alerting.

Closes-story: stats-sync-20260805
