### PR TITLE
feat(i18n,activerecord): %Y pads the year, one scheme_for, singular find_target is a pure query

### DIFF
--- a/packages/activerecord/src/associations/association-scope.test.ts
+++ b/packages/activerecord/src/associations/association-scope.test.ts
@@ -2,7 +2,7 @@ import type { AssociationProxy } from "./collection-proxy.js";
 import { describe, it, expect } from "vitest";
 import { Base, registerModel, registerSubclass } from "../index.js";
 import { Associations } from "../associations.js";
-import { association as associationInstance } from "./instance-methods.js";
+import { loadSingularTarget } from "../test-helpers/load-singular-target.js";
 import { findTarget } from "./has-many-association.js";
 import { AssociationScope, ReflectionProxy } from "./association-scope.js";
 import { fixtures } from "../test-fixtures.js";
@@ -17,19 +17,6 @@ import { Member } from "../test-helpers/models/member.js";
 import { Membership, CurrentMembership } from "../test-helpers/models/membership.js";
 import { Club } from "../test-helpers/models/club.js";
 import { MemberDetail } from "../test-helpers/models/member-detail.js";
-
-/**
- * Rails' entry point for reading a singular association is
- * `record.association(name).load_target` (association.rb:190) — the cached
- * read and the staleness guard live there, and `find_target`
- * (singular_association.rb:47-55) is a pure query underneath it.
- */
-async function loadSingularTarget(record: Base, name: string): Promise<Base | null> {
-  // `async` so `check_validity!`, which Rails runs in `Association#initialize`
-  // (association.rb:41-45) and trails runs when the holder is built, surfaces
-  // as a rejection like every other load failure.
-  return associationInstance.call(record, name).loadTarget() as Promise<Base | null>;
-}
 
 describe("AssociationScope", () => {
   fixtures([]);

--- a/packages/activerecord/src/associations/association-scope.test.ts
+++ b/packages/activerecord/src/associations/association-scope.test.ts
@@ -2,7 +2,7 @@ import type { AssociationProxy } from "./collection-proxy.js";
 import { describe, it, expect } from "vitest";
 import { Base, registerModel, registerSubclass } from "../index.js";
 import { Associations } from "../associations.js";
-import { findTarget as findSingularTarget } from "./singular-association.js";
+import { association as associationInstance } from "./instance-methods.js";
 import { findTarget } from "./has-many-association.js";
 import { AssociationScope, ReflectionProxy } from "./association-scope.js";
 import { fixtures } from "../test-fixtures.js";
@@ -17,6 +17,19 @@ import { Member } from "../test-helpers/models/member.js";
 import { Membership, CurrentMembership } from "../test-helpers/models/membership.js";
 import { Club } from "../test-helpers/models/club.js";
 import { MemberDetail } from "../test-helpers/models/member-detail.js";
+
+/**
+ * Rails' entry point for reading a singular association is
+ * `record.association(name).load_target` (association.rb:190) — the cached
+ * read and the staleness guard live there, and `find_target`
+ * (singular_association.rb:47-55) is a pure query underneath it.
+ */
+async function loadSingularTarget(record: Base, name: string): Promise<Base | null> {
+  // `async` so `check_validity!`, which Rails runs in `Association#initialize`
+  // (association.rb:41-45) and trails runs when the holder is built, surfaces
+  // as a rejection like every other load failure.
+  return associationInstance.call(record, name).loadTarget() as Promise<Base | null>;
+}
 
 describe("AssociationScope", () => {
   fixtures([]);
@@ -722,11 +735,7 @@ describe("AssociationScope", () => {
     const membership = await Membership.create({ member_id: member.id });
     const memberDetail = await MemberDetail.create({ member_id: member.id });
 
-    const loaded = (await findSingularTarget(memberDetail, "membership", {
-      className: "Membership",
-      through: "member",
-      source: "membership",
-    })) as Membership | null;
+    const loaded = (await loadSingularTarget(memberDetail, "membership")) as Membership | null;
     expect(loaded).not.toBeNull();
     expect(loaded!.id).toBe(membership.id);
   });
@@ -766,11 +775,7 @@ describe("AssociationScope", () => {
     const club = await Club.create({ name: "Great club" });
     await CurrentMembership.create({ member_id: member.id, club_id: club.id });
 
-    const loaded = (await findSingularTarget(member, "club", {
-      className: "Club",
-      through: "currentMembership",
-      source: "club",
-    })) as Club | null;
+    const loaded = (await loadSingularTarget(member, "club")) as Club | null;
     expect(loaded).not.toBeNull();
     expect(loaded!.name).toBe("Great club");
   });

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -1,6 +1,6 @@
 import type { Base } from "../base.js";
 import type { AssociationDefinition, AssociationOptions } from "../associations.js";
-import { findTarget as findSingularTarget } from "./singular-association.js";
+import { association } from "./instance-methods.js";
 import { HasManyAssociation, findTarget as findHasManyTarget } from "./has-many-association.js";
 import {
   HasManyThroughCantAssociateThroughHasOneOrManyReflection,
@@ -1161,10 +1161,10 @@ export async function findTarget(
       throughRecords = await findHasManyTarget(record, throughAssoc.name, throughAssoc.options);
     }
   } else if (throughAssoc.type === "hasOne") {
-    const one = await findSingularTarget(record, throughAssoc.name, throughAssoc.options);
+    const one = (await association.call(record, throughAssoc.name).loadTarget()) as Base | null;
     throughRecords = one ? [one] : [];
   } else if (throughAssoc.type === "belongsTo") {
-    const one = await findSingularTarget(record, throughAssoc.name, throughAssoc.options);
+    const one = (await association.call(record, throughAssoc.name).loadTarget()) as Base | null;
     throughRecords = one ? [one] : [];
   } else {
     throughRecords = [];

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -1,6 +1,6 @@
 import type { Base } from "../base.js";
 import type { AssociationDefinition, AssociationOptions } from "../associations.js";
-import { findTarget as findSingularTarget } from "./singular-association.js";
+import { association } from "./instance-methods.js";
 import { findTarget as findHasManyTarget } from "./has-many-association.js";
 import { camelize, underscore } from "@blazetrails/activesupport";
 import { resolveAssocClass, _hmtNotFound } from "../associations.js";
@@ -743,9 +743,9 @@ export async function findTarget(
 
   let throughRecord: Base | null;
   if (throughAssoc.type === "hasOne") {
-    throughRecord = await findSingularTarget(record, throughAssoc.name, throughAssoc.options);
+    throughRecord = (await association.call(record, throughAssoc.name).loadTarget()) as Base | null;
   } else if (throughAssoc.type === "belongsTo") {
-    throughRecord = await findSingularTarget(record, throughAssoc.name, throughAssoc.options);
+    throughRecord = (await association.call(record, throughAssoc.name).loadTarget()) as Base | null;
   } else if (throughAssoc.type === "hasMany") {
     const throughRecords = await findHasManyTarget(record, throughAssoc.name, throughAssoc.options);
     throughRecord = throughRecords[0] ?? null;
@@ -762,9 +762,9 @@ export async function findTarget(
 
   if (sourceAssoc) {
     if (sourceAssoc.type === "belongsTo") {
-      return findSingularTarget(throughRecord, sourceName, sourceAssoc.options);
+      return (await association.call(throughRecord, sourceName).loadTarget()) as Base | null;
     } else if (sourceAssoc.type === "hasOne") {
-      return findSingularTarget(throughRecord, sourceName, sourceAssoc.options);
+      return (await association.call(throughRecord, sourceName).loadTarget()) as Base | null;
     }
   }
 

--- a/packages/activerecord/src/associations/instance-methods.ts
+++ b/packages/activerecord/src/associations/instance-methods.ts
@@ -7,7 +7,6 @@
  */
 
 import type { Base } from "../base.js";
-import { findTarget } from "./singular-association.js";
 import { Association as AssociationInstance } from "./association.js";
 import { BelongsToAssociation } from "./belongs-to-association.js";
 import { BelongsToPolymorphicAssociation } from "./belongs-to-polymorphic-association.js";
@@ -161,13 +160,14 @@ export function association(this: Base, name: string): AssociationInstance {
  * `BelongsToAssociation` which are the belongs_to-specific preload paths.
  */
 export async function loadBelongsTo(this: Base, name: string): Promise<Base | null> {
-  const assocDef = assertSingularAssociation.call(this, name, "belongsTo");
+  assertSingularAssociation.call(this, name, "belongsTo");
+  // Rails' equivalent of this entry point is `record.association(name)
+  // .load_target`: the cache read, the staleness guard and the writeback all
+  // live in `load_target` (association.rb:190), and `find_target` is a pure
+  // query underneath it.
   const result = await bypassStrictLoading.call(this, () =>
-    findTarget(this, name, (assocDef.options ?? {}) as any),
+    association.call(this, name).loadTarget(),
   );
-  // Loader writeback: this is the tail of this function's own query, not a
-  // caller replacing the target. See Association#_setTargetFromLoader.
-  association.call(this, name)._setTargetFromLoader(result as any);
   return result as Base | null;
 }
 
@@ -179,13 +179,11 @@ export async function loadBelongsTo(this: Base, name: string): Promise<Base | nu
  * Mirrors Rails' `HasOneAssociation` preload path.
  */
 export async function loadHasOne(this: Base, name: string): Promise<Base | null> {
-  const assocDef = assertSingularAssociation.call(this, name, "hasOne");
+  assertSingularAssociation.call(this, name, "hasOne");
+  // See `loadBelongsTo`: `association(name).load_target` is Rails' entry point.
   const result = await bypassStrictLoading.call(this, () =>
-    findTarget(this, name, (assocDef.options ?? {}) as any),
+    association.call(this, name).loadTarget(),
   );
-  // Loader writeback: this is the tail of this function's own query, not a
-  // caller replacing the target. See Association#_setTargetFromLoader.
-  association.call(this, name)._setTargetFromLoader(result as any);
   return result as Base | null;
 }
 

--- a/packages/activerecord/src/associations/instance-methods.ts
+++ b/packages/activerecord/src/associations/instance-methods.ts
@@ -156,15 +156,14 @@ export function association(this: Base, name: string): AssociationInstance {
  * preloaded value if present; otherwise runs a query. Not a forced
  * reload — use `record.reload()` for that.
  *
- * Mirrors Rails' `ActiveRecord::Associations::Preloader::Branch` /
- * `BelongsToAssociation` which are the belongs_to-specific preload paths.
+ * Rails spells this entry point `record.association(name).load_target`, and
+ * that is what it delegates to: the cache read, the staleness guard and the
+ * writeback all live in `load_target` (association.rb:190), with
+ * `SingularAssociation#find_target` (singular_association.rb:47-55) the pure
+ * query underneath.
  */
 export async function loadBelongsTo(this: Base, name: string): Promise<Base | null> {
   assertSingularAssociation.call(this, name, "belongsTo");
-  // Rails' equivalent of this entry point is `record.association(name)
-  // .load_target`: the cache read, the staleness guard and the writeback all
-  // live in `load_target` (association.rb:190), and `find_target` is a pure
-  // query underneath it.
   const result = await bypassStrictLoading.call(this, () =>
     association.call(this, name).loadTarget(),
   );
@@ -176,11 +175,11 @@ export async function loadBelongsTo(this: Base, name: string): Promise<Base | nu
  * preloaded value if present; otherwise runs a query. Not a forced
  * reload — use `record.reload()` for that.
  *
- * Mirrors Rails' `HasOneAssociation` preload path.
+ * Reaches the target through `association(name).load_target` for the reasons
+ * given on `loadBelongsTo`.
  */
 export async function loadHasOne(this: Base, name: string): Promise<Base | null> {
   assertSingularAssociation.call(this, name, "hasOne");
-  // See `loadBelongsTo`: `association(name).load_target` is Rails' entry point.
   const result = await bypassStrictLoading.call(this, () =>
     association.call(this, name).loadTarget(),
   );

--- a/packages/activerecord/src/associations/inverse-associations.test.ts
+++ b/packages/activerecord/src/associations/inverse-associations.test.ts
@@ -2,7 +2,7 @@
  * Mirrors Rails activerecord/test/cases/associations/inverse_associations_test.rb
  */
 import { describe, it, expect, beforeAll } from "vitest";
-import { findTarget } from "./singular-association.js";
+import { association as associationInstance } from "./instance-methods.js";
 import {
   Base,
   association,
@@ -40,6 +40,19 @@ import { SpecialContract } from "../test-helpers/models/contract.js";
 import { Book } from "../test-helpers/models/book.js";
 import { Subscription } from "../test-helpers/models/subscription.js";
 import { Subscriber } from "../test-helpers/models/subscriber.js";
+
+/**
+ * Rails' entry point for reading a singular association is
+ * `record.association(name).load_target` (association.rb:190) — the cached
+ * read and the staleness guard live there, and `find_target`
+ * (singular_association.rb:47-55) is a pure query underneath it.
+ */
+async function loadSingularTarget(record: Base, name: string): Promise<Base | null> {
+  // `async` so `check_validity!`, which Rails runs in `Association#initialize`
+  // (association.rb:41-45) and trails runs when the holder is built, surfaces
+  // as a rejection like every other load failure.
+  return associationInstance.call(record, name).loadTarget() as Promise<Base | null>;
+}
 
 /**
  * Rails' `with_has_many_inversing(model = ActiveRecord::Base)` toggles
@@ -260,7 +273,7 @@ describe("AutomaticInverseFindingTests", () => {
     const comment = (await Comment.first())!;
     const rating = await Rating.createBang({ comment_id: (comment as any).id });
 
-    const ratingComment = (await findTarget(rating, "comment", { inverseOf: "ratings" })) as any;
+    const ratingComment = (await loadSingularTarget(rating, "comment")) as any;
     expect(ratingComment.id).toBe((comment as any).id);
 
     ratingComment.body = "Fennec foxes are the smallest of the foxes.";
@@ -270,7 +283,7 @@ describe("AutomaticInverseFindingTests", () => {
   it("has many and belongs to automatic inverse shares objects on comment", async () => {
     const rating = await Rating.createBang({});
     const comment = (await Comment.first())!;
-    await findTarget(rating, "comment", { inverseOf: "ratings" });
+    await loadSingularTarget(rating, "comment");
     (rating as any).comment = comment;
 
     expect((rating as any).comment).toBe(comment);
@@ -407,7 +420,7 @@ describe("InverseHasOneTests", () => {
 
   it("parent instance should be shared with child on find", async () => {
     const human = humans("gordon");
-    const face = (await findTarget(human, "face", { inverseOf: "human" }))!;
+    const face = (await loadSingularTarget(human, "face"))!;
     expect((face as any).human.name).toBe(human.name);
     (human as any).name = "Bongo";
     expect((face as any).human.name).toBe((human as any).name);
@@ -492,17 +505,14 @@ describe("InverseHasOneTests", () => {
 
   it("trying to use inverses that dont exist should raise an error", async () => {
     const human = (await Human.first())!;
-    await expect(
-      findTarget(human, "confusedFace", { className: "Face", inverseOf: "cnffusedHuman" }),
-    ).rejects.toThrow(InverseOfAssociationNotFoundError);
+    await expect(loadSingularTarget(human, "confusedFace")).rejects.toThrow(
+      InverseOfAssociationNotFoundError,
+    );
   });
 
   it("trying to use inverses that dont exist should have suggestions for fix", async () => {
     const human = (await Human.first())!;
-    const err = await findTarget(human, "confusedFace", {
-      className: "Face",
-      inverseOf: "cnffusedHuman",
-    }).catch((e) => e);
+    const err = await loadSingularTarget(human, "confusedFace").catch((e) => e);
     expect(err).toBeInstanceOf(InverseOfAssociationNotFoundError);
     expect(err.detailedMessage()).toMatch(/Did you mean\?/);
     expect(err.corrections[0]).toBe("confusedHuman");
@@ -837,9 +847,9 @@ describe("InverseHasManyTests", () => {
     const post1 = (await Post.first())!;
     const post2 = (await Post.all().order("id").offset(1).first())!;
     const comment = (await findHasManyTarget(post1, "comments", { inverseOf: "post" }))[0] as any;
-    expect(await findTarget(comment, "post", { inverseOf: "comments" })).toBe(post1);
+    expect(await loadSingularTarget(comment, "post")).toBe(post1);
     await comment.updateBang({ post_id: (post2 as any).id });
-    const reloaded = (await findTarget(comment, "post", { inverseOf: "comments" })) as any;
+    const reloaded = (await loadSingularTarget(comment, "post")) as any;
     expect(reloaded.id).toBe((post2 as any).id);
   });
 
@@ -882,7 +892,7 @@ describe("InverseBelongsToTests", () => {
 
   it("child instance should be shared with parent on find", async () => {
     const face = faces("trusting");
-    const human = (await findTarget(face, "human", { inverseOf: "face" }))!;
+    const human = (await loadSingularTarget(face, "human"))!;
     expect((human as any).face.description).toBe((face as any).description);
     (face as any).description = "gormless";
     expect((human as any).face.description).toBe((face as any).description);
@@ -934,7 +944,7 @@ describe("InverseBelongsToTests", () => {
 
   it("should not try to set inverse instances when the inverse is a has many", async () => {
     const interest = interests("trainspotting");
-    const human = (await findTarget(interest, "human", { inverseOf: "interests" }))!;
+    const human = (await loadSingularTarget(interest, "human"))!;
     // Rails: human.interests.detect { |_iz| _iz.id == interest.id } — block-find
     // over the CollectionProxy (Enumerable#detect loads the target), not the AR
     // PK finder.
@@ -950,7 +960,7 @@ describe("InverseBelongsToTests", () => {
   it("with has many inversing should try to set inverse instances when the inverse is a has many", async () => {
     await withHasManyInversing(Human, async () => {
       const interest = interests("trainspotting");
-      const human = (await findTarget(interest, "human", { inverseOf: "interests" })) as any;
+      const human = (await loadSingularTarget(interest, "human")) as any;
       const cached = human._associationCache("interests")?.target as any[];
       const iz = cached.find((i: any) => i.id === (interest as any).id);
       expect(iz).toBeDefined();
@@ -975,11 +985,7 @@ describe("InverseBelongsToTests", () => {
   it("with has many inversing does not trigger association callbacks on set when the inverse is a has many", async () => {
     await withHasManyInversing(Interest, async () => {
       const interest = interests("trainspotting");
-      const human = (await findTarget(interest, "humanWithCallbacks", {
-        className: "Human",
-        foreignKey: "human_id",
-        inverseOf: "interestsWithCallbacks",
-      })) as any;
+      const human = (await loadSingularTarget(interest, "humanWithCallbacks")) as any;
       expect(human.addCallbackCalled).toBe(false);
     });
   });
@@ -1017,23 +1023,23 @@ describe("InverseBelongsToTests", () => {
 
   it("unscope does not set inverse when incorrect", async () => {
     const interest = interests("trainspotting");
-    const human = (await findTarget(interest, "human", { inverseOf: "interests" }))!;
+    const human = (await loadSingularTarget(interest, "human"))!;
     const createdHuman = await Human.create({ name: "wrong human" });
     const foundInterest = await (createdHuman as any).interests
       .or((human as any).interests)
       .detect((thisInterest: any) => (interest as any).id === thisInterest.id);
-    const foundHuman = await findTarget(foundInterest, "human", { inverseOf: "interests" });
+    const foundHuman = await loadSingularTarget(foundInterest, "human");
     expect((foundHuman as any).id).toBe((human as any).id);
   });
 
   it("or does not set inverse when incorrect", async () => {
     const interest = interests("trainspotting");
-    const human = (await findTarget(interest, "human", { inverseOf: "interests" }))!;
+    const human = (await loadSingularTarget(interest, "human"))!;
     const createdHuman = await Human.create({ name: "wrong human" });
     const foundInterest = await (createdHuman as any).interests
       .unscope("where")
       .detect((thisInterest: any) => (interest as any).id === thisInterest.id);
-    const foundHuman = await findTarget(foundInterest, "human", { inverseOf: "interests" });
+    const foundHuman = await loadSingularTarget(foundInterest, "human");
     expect((foundHuman as any).id).toBe((human as any).id);
   });
 
@@ -1051,17 +1057,14 @@ describe("InverseBelongsToTests", () => {
 
   it("trying to use inverses that dont exist should raise an error", async () => {
     const face = (await Face.first())!;
-    await expect(
-      findTarget(face, "confusedHuman", { className: "Human", inverseOf: "cnffusedFace" }),
-    ).rejects.toThrow(InverseOfAssociationNotFoundError);
+    await expect(loadSingularTarget(face, "confusedHuman")).rejects.toThrow(
+      InverseOfAssociationNotFoundError,
+    );
   });
 
   it("trying to use inverses that dont exist should have suggestions for fix", async () => {
     const face = (await Face.first())!;
-    const err = await findTarget(face, "confusedHuman", {
-      className: "Human",
-      inverseOf: "cnffusedFace",
-    }).catch((e) => e);
+    const err = await loadSingularTarget(face, "confusedHuman").catch((e) => e);
     expect(err).toBeInstanceOf(InverseOfAssociationNotFoundError);
     expect(err.detailedMessage()).toMatch(/Did you mean\?/);
     expect(err.corrections[0]).toBe("confusedFace");
@@ -1086,10 +1089,7 @@ describe("InversePolymorphicBelongsToTests", () => {
 
   it("child instance should be shared with parent on find", async () => {
     const face = faces("confused");
-    const human = (await findTarget(face, "polymorphicHuman", {
-      polymorphic: true,
-      inverseOf: "polymorphicFace",
-    })) as any;
+    const human = (await loadSingularTarget(face, "polymorphicHuman")) as any;
     expect(human.polymorphicFace.description).toBe((face as any).description);
     (face as any).description = "gormless";
     expect(human.polymorphicFace.description).toBe((face as any).description);
@@ -1099,10 +1099,7 @@ describe("InversePolymorphicBelongsToTests", () => {
 
   it("eager loaded child instance should be shared with parent on find", async () => {
     let face = (await Face.where({ description: "confused" }).includes("human"))[0] as any;
-    let human = (await findTarget(face, "polymorphicHuman", {
-      polymorphic: true,
-      inverseOf: "polymorphicFace",
-    })) as any;
+    let human = (await loadSingularTarget(face, "polymorphicHuman")) as any;
     expect(human.polymorphicFace.description).toBe(face.description);
     face.description = "gormless";
     expect(human.polymorphicFace.description).toBe(face.description);
@@ -1112,10 +1109,7 @@ describe("InversePolymorphicBelongsToTests", () => {
     face = (
       await Face.where({ description: "confused" }).includes("human").order("humans.id")
     )[0] as any;
-    human = (await findTarget(face, "polymorphicHuman", {
-      polymorphic: true,
-      inverseOf: "polymorphicFace",
-    })) as any;
+    human = (await loadSingularTarget(face, "polymorphicHuman")) as any;
     expect(human.polymorphicFace.description).toBe(face.description);
     face.description = "gormless";
     expect(human.polymorphicFace.description).toBe(face.description);
@@ -1194,10 +1188,7 @@ describe("InversePolymorphicBelongsToTests", () => {
 
   it("should not try to set inverse instances when the inverse is a has many", async () => {
     const interest = interests("llama_wrangling");
-    const human = (await findTarget(interest, "polymorphicHuman", {
-      polymorphic: true,
-      inverseOf: "polymorphicInterests",
-    })) as any;
+    const human = (await loadSingularTarget(interest, "polymorphicHuman")) as any;
     // Rails: human.polymorphic_interests.detect { |_iz| _iz.id == interest.id }
     const iz = await human.polymorphicInterests.detect((i: any) => i.id === (interest as any).id);
     expect(iz).toBeDefined();
@@ -1211,10 +1202,7 @@ describe("InversePolymorphicBelongsToTests", () => {
   it("with has many inversing should try to set inverse instances when the inverse is a has many", async () => {
     await withHasManyInversing(Human, async () => {
       const interest = interests("llama_wrangling");
-      const human = (await findTarget(interest, "polymorphicHuman", {
-        polymorphic: true,
-        inverseOf: "polymorphicInterests",
-      })) as any;
+      const human = (await loadSingularTarget(interest, "polymorphicHuman")) as any;
       const cached = human._associationCache("polymorphicInterests")?.target as any[];
       const iz = cached.find((i: any) => i.id === (interest as any).id);
       expect(iz).toBeDefined();
@@ -1236,10 +1224,7 @@ describe("InversePolymorphicBelongsToTests", () => {
 
   it("trying to access inverses that dont exist shouldnt raise an error", async () => {
     const face = (await Face.first())!;
-    await findTarget(face, "puzzledPolymorphicHuman", {
-      polymorphic: true,
-      inverseOf: "puzzledPolymorphicFace",
-    });
+    await loadSingularTarget(face, "puzzledPolymorphicHuman");
   });
 
   it("trying to set polymorphic inverses that dont exist at all should raise an error", async () => {
@@ -1274,8 +1259,8 @@ describe("InverseMultipleHasManyInversesForSameModel", () => {
 
   it("that we can load associations that have the same reciprocal name from different models", async () => {
     const interest = (await Interest.first())!;
-    await findTarget(interest, "zine", { inverseOf: "interests" });
-    await findTarget(interest, "human", { inverseOf: "interests" });
+    await loadSingularTarget(interest, "zine");
+    await loadSingularTarget(interest, "human");
   });
 
   it("that we can create associations that have the same reciprocal name from different models", async () => {
@@ -1310,10 +1295,7 @@ describe("InverseBelongsToTests", () => {
       const main = await BrokenBranch.create({});
       const feature = await association(main, "branches").create({});
       const topic = association(feature, "branches").build({});
-      const err = await findTarget(topic, "branch", {
-        className: "BrokenBranch",
-        inverseOf: "branch",
-      }).catch((e) => e);
+      const err = await loadSingularTarget(topic, "branch").catch((e) => e);
       expect(err).toBeInstanceOf(InverseOfAssociationRecursiveError);
       expect((err as Error).message).toBe(
         "Inverse association branch (:branch in BrokenBranch) is recursive.",

--- a/packages/activerecord/src/associations/inverse-associations.test.ts
+++ b/packages/activerecord/src/associations/inverse-associations.test.ts
@@ -2,7 +2,7 @@
  * Mirrors Rails activerecord/test/cases/associations/inverse_associations_test.rb
  */
 import { describe, it, expect, beforeAll } from "vitest";
-import { association as associationInstance } from "./instance-methods.js";
+import { loadSingularTarget } from "../test-helpers/load-singular-target.js";
 import {
   Base,
   association,
@@ -40,19 +40,6 @@ import { SpecialContract } from "../test-helpers/models/contract.js";
 import { Book } from "../test-helpers/models/book.js";
 import { Subscription } from "../test-helpers/models/subscription.js";
 import { Subscriber } from "../test-helpers/models/subscriber.js";
-
-/**
- * Rails' entry point for reading a singular association is
- * `record.association(name).load_target` (association.rb:190) — the cached
- * read and the staleness guard live there, and `find_target`
- * (singular_association.rb:47-55) is a pure query underneath it.
- */
-async function loadSingularTarget(record: Base, name: string): Promise<Base | null> {
-  // `async` so `check_validity!`, which Rails runs in `Association#initialize`
-  // (association.rb:41-45) and trails runs when the holder is built, surfaces
-  // as a rejection like every other load failure.
-  return associationInstance.call(record, name).loadTarget() as Promise<Base | null>;
-}
 
 /**
  * Rails' `with_has_many_inversing(model = ActiveRecord::Base)` toggles

--- a/packages/activerecord/src/associations/singular-association.ts
+++ b/packages/activerecord/src/associations/singular-association.ts
@@ -8,7 +8,6 @@ import {
   _ownerChainReflection,
   _routeThroughViaAssociationScope,
   _loadSingularViaStatementCache,
-  _loadedSingularTarget,
   _resolveInverseName,
   _scopeForAssociation,
   _skipSingularStatementCache,
@@ -341,51 +340,6 @@ function scopeForCreate(assoc: SingularAssociation): Record<string, unknown> {
 }
 
 /**
- * belongs_to's cached-target read. Unlike has_one it validates `inverse_of`
- * even on a cached hit, and honors `stale_target?` so a reassigned foreign key
- * re-queries.
- *
- * Rails has no counterpart: it caches the target on the association instance,
- * so `find_target` is only ever reached on a miss.
- *
- * @internal
- */
-function _belongsToCachedHit(
-  record: Base,
-  assocName: string,
-  options: AssociationOptions,
-): { hit: boolean; value: Base | null } {
-  const loaded = _loadedSingularTarget(record, assocName);
-  if (!loaded) return { hit: false, value: null };
-  const cached = loaded.value;
-
-  // Validate inverseOf before the null check: an invalid name must throw even
-  // when the cached value is null (e.g. the preloader stored null for a missing
-  // row), consistent with the cache-miss path.
-  if (options.inverseOf && !options.polymorphic) {
-    const targetModel =
-      (cached?.constructor as typeof Base | undefined) ??
-      resolveAssocClass(record, assocName, options.className ?? camelize(assocName));
-    validateInverseOf(targetModel, assocName, options.inverseOf);
-  }
-  if (!cached) return { hit: true, value: null };
-
-  // `_cacheSingularTarget` routes singular inverse writes through
-  // `inversedFrom` (→ `replace_keys` → `loadedBang`), so the holder's
-  // `isStaleTarget()` snapshot is authoritative.
-  const holder = record._associationInstances.get(assocName) as
-    | { isStaleTarget?: () => boolean }
-    | undefined;
-  if (typeof holder?.isStaleTarget === "function" && holder.isStaleTarget()) {
-    return { hit: false, value: null };
-  }
-
-  const inverseName = _resolveInverseName(record.constructor as typeof Base, assocName, options);
-  if (inverseName) _wireInverseAssociation(record, cached, inverseName);
-  return { hit: true, value: cached };
-}
-
-/**
  * has_one's polymorphic `:as` key guard: a composite FK is always rejected, and
  * a composite owner PK collapses to "id" when present (matching Rails'
  * `join_id_for`); otherwise it is rejected too.
@@ -434,10 +388,9 @@ function _validateHasOnePolymorphicKeys(
  * the `find_target?` predicate (`belongs_to_association.rb:124-126`), never
  * `find_target`, which is why there is no belongs_to override here either.
  *
- * The macro-conditional steps are the ones Rails has no counterpart for: the
- * cached-target read (trails caches on the owner, Rails on the association
- * instance) and the has_one `:through` routing. They are named helpers rather
- * than inline branches so this body keeps the shape of Rails'.
+ * The one macro-conditional step Rails has no counterpart for is the has_one
+ * `:through` routing. It is a named helper rather than an inline branch so this
+ * body keeps the shape of Rails'.
  *
  * @internal
  */
@@ -459,13 +412,12 @@ export async function findTarget(
   // (mirrored in the `Association` constructor via
   // `validateReflectionValidity`), so a recursive/missing `inverse_of` has
   // already surfaced by now — no load-path recursion shim is needed.
-  if (isBelongsTo) {
-    const cached = _belongsToCachedHit(record, assocName, options);
-    if (cached.hit) return cached.value;
-  } else {
-    const loaded = _loadedSingularTarget(record, assocName);
-    if (loaded) return loaded.value;
-  }
+  //
+  // No cached-target read here: `find_target` (singular_association.rb:47-55)
+  // is a pure query. The cache is consulted one level up, in
+  // `Association#loadTarget` → `doFindTarget`, mirroring
+  // `load_target`'s `(@stale_state && stale_target?) || find_target?` guard
+  // (association.rb:190); every caller reaches this body through it.
 
   // Rails `Association#find_target`'s first statement. Gated by `find_target?`:
   // a new-record owner without the key present never reaches `find_target` and

--- a/packages/activerecord/src/associations/singular-association.ts
+++ b/packages/activerecord/src/associations/singular-association.ts
@@ -388,6 +388,13 @@ function _validateHasOnePolymorphicKeys(
  * the `find_target?` predicate (`belongs_to_association.rb:124-126`), never
  * `find_target`, which is why there is no belongs_to override here either.
  *
+ * It reads no cache: `find_target` is a pure query, and the cached read lives
+ * one level up in `Association#loadTarget` → `doFindTarget`, mirroring
+ * `load_target`'s `(@stale_state && stale_target?) || find_target?` guard
+ * (`association.rb:190`). `reflection.check_validity!` has likewise already run
+ * in `Association#initialize` (`association.rb:41-45`), so a recursive or
+ * missing `inverse_of` has surfaced before this body.
+ *
  * The one macro-conditional step Rails has no counterpart for is the has_one
  * `:through` routing. It is a named helper rather than an inline branch so this
  * body keeps the shape of Rails'.
@@ -407,17 +414,6 @@ export async function findTarget(
   if (options.through) {
     validateThroughReflection(ctor, assocName);
   }
-
-  // Rails runs `reflection.check_validity!` in `Association#initialize`
-  // (mirrored in the `Association` constructor via
-  // `validateReflectionValidity`), so a recursive/missing `inverse_of` has
-  // already surfaced by now — no load-path recursion shim is needed.
-  //
-  // No cached-target read here: `find_target` (singular_association.rb:47-55)
-  // is a pure query. The cache is consulted one level up, in
-  // `Association#loadTarget` → `doFindTarget`, mirroring
-  // `load_target`'s `(@stale_state && stale_target?) || find_target?` guard
-  // (association.rb:190); every caller reaches this body through it.
 
   // Rails `Association#find_target`'s first statement. Gated by `find_target?`:
   // a new-record owner without the key present never reaches `find_target` and

--- a/packages/activerecord/src/delegate.ts
+++ b/packages/activerecord/src/delegate.ts
@@ -1,7 +1,7 @@
 import type { Base } from "./base.js";
-import { findTarget } from "./associations/singular-association.js";
 import type { AssociationDefinition } from "./associations.js";
 import { upcaseFirst } from "@blazetrails/activesupport";
+import { association } from "./associations/instance-methods.js";
 
 /**
  * Delegate methods to an association.
@@ -37,10 +37,11 @@ export function delegate(
         }
 
         let target: Base | null = null;
-        if (assocDef.type === "belongsTo") {
-          target = await findTarget(this, assocName, assocDef.options);
-        } else if (assocDef.type === "hasOne") {
-          target = await findTarget(this, assocName, assocDef.options);
+        if (assocDef.type === "belongsTo" || assocDef.type === "hasOne") {
+          // Rails' `delegate ... to: :association` reads the association the
+          // ordinary way; `association(name).load_target` (association.rb:190)
+          // is that path, cache read and staleness guard included.
+          target = (await association.call(this, assocName).loadTarget()) as Base | null;
         }
 
         if (!target) return null;

--- a/packages/activerecord/src/delegate.ts
+++ b/packages/activerecord/src/delegate.ts
@@ -38,9 +38,6 @@ export function delegate(
 
         let target: Base | null = null;
         if (assocDef.type === "belongsTo" || assocDef.type === "hasOne") {
-          // Rails' `delegate ... to: :association` reads the association the
-          // ordinary way; `association(name).load_target` (association.rb:190)
-          // is that path, cache read and staleness guard included.
           target = (await association.call(this, assocName).loadTarget()) as Base | null;
         }
 

--- a/packages/activerecord/src/encrypted-attribute-sti.trails.test.ts
+++ b/packages/activerecord/src/encrypted-attribute-sti.trails.test.ts
@@ -40,8 +40,8 @@ const encryptedAttributesOf = (klass: typeof Company) =>
 describe("STI subclass encrypts", () => {
   fixtures([]);
 
-  // Encryption must be configured before any declaration runs — buildScheme has
-  // no lazy fallback.
+  // Encryption must be configured before any declaration runs — `scheme_for`
+  // has no lazy fallback.
   const snapshot = snapshotEncryptionConfig();
   beforeAll(() => configureEncryption());
   afterAll(() => restoreEncryptionConfig(snapshot));

--- a/packages/activerecord/src/encryption-hooks.ts
+++ b/packages/activerecord/src/encryption-hooks.ts
@@ -24,14 +24,6 @@ export interface EncryptionHooks {
    */
   requireOriginalColumnsAfterReflection?(klass: any, columnNames: string[]): void;
 
-  /**
-   * Build a Scheme from `Base.encrypts` options, adapting the legacy
-   * `{ encrypt, decrypt }` shim and supplying a defaultEncryptor fallback.
-   * Optional: only registered once the encryption namespace is loaded; callers
-   * fall back to `schemeFor` when it's absent.
-   */
-  buildScheme?(options: any): any;
-
   encryptedAttribute(record: any, name: string): boolean;
 
   ciphertextFor(record: any, name: string): unknown;

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -21,114 +21,26 @@
 
 import { registerEncryptionHooks } from "./encryption-hooks.js";
 import { Scheme, type SchemeOptions } from "./encryption/scheme.js";
-import type { EncryptorLike } from "./encryption/encryptor.js";
+import type { EncryptorOptionLike } from "./encryption/encryptor.js";
 import { Aes256Gcm as AesGcmCipher } from "./encryption/cipher/aes256-gcm.js";
 export { Cipher } from "./encryption/cipher.js";
-import {
-  EncryptableRecord,
-  encryptedTypeOf,
-  globalPreviousSchemesFor,
-} from "./encryption/encryptable-record.js";
+import { EncryptableRecord, encryptedTypeOf } from "./encryption/encryptable-record.js";
 import { Configurable } from "./encryption/configurable.js";
 import { Contexts } from "./encryption/contexts.js";
 import { getEncryptionContext, type Context } from "./encryption/context.js";
 import type { Config } from "./encryption/config.js";
 
 /**
- * The simple encryptor surface `Base.encrypts({ encryptor })` accepts.
- * If the encryptor implements `isEncrypted(text)` it will be consulted
- * directly; otherwise the shim probes by calling `decrypt(text)` and
- * treats a non-throwing decrypt as encrypted (see
- * `LegacyEncryptorShim.isEncrypted`). Custom encryptors whose `decrypt`
- * accepts plaintext without throwing should also implement
- * `isEncrypted(text)` to avoid misclassification.
+ * The simple encryptor surface `Base.encrypts({ encryptor })` accepts — the
+ * same shape `Scheme`'s `encryptor:` option takes, adapted to the full contract
+ * by `LegacyEncryptorShim` where that option is read.
  *
  * @noRailsEquivalent CONVERGEABLE (story:
  * converge-encryption-simple-encryptor-onto-encryptor-like). Rails has one
  * encryptor contract, `Encryption::Encryptor`, which trails ports as a class
- * plus the `EncryptorLike` shape; this narrow surface and its shim exist only
- * for older call sites.
+ * plus the `EncryptorLike` shape; this alias exists only for older call sites.
  */
-export interface Encryptor {
-  encrypt(value: string): string;
-  decrypt(ciphertext: string): string;
-  isEncrypted?(text: string): boolean;
-  isBinary?(): boolean;
-}
-
-const ENCRYPTED_PREFIX = "AR_ENC:";
-
-export const defaultEncryptor: Encryptor = {
-  encrypt(value: string): string {
-    return ENCRYPTED_PREFIX + Buffer.from(value, "utf-8").toString("base64");
-  },
-  decrypt(ciphertext: string): string {
-    if (!ciphertext.startsWith(ENCRYPTED_PREFIX)) {
-      throw new Error("Not an encrypted value");
-    }
-    return Buffer.from(ciphertext.slice(ENCRYPTED_PREFIX.length), "base64").toString("utf-8");
-  },
-  isEncrypted(text: string): boolean {
-    return typeof text === "string" && text.startsWith(ENCRYPTED_PREFIX);
-  },
-};
-
-/**
- * Adapts the simple `{ encrypt, decrypt }` pair accepted by `Base.encrypts`
- * to the wider `EncryptorLike` surface that `Scheme.encryptor` expects.
- * Options are intentionally ignored — the legacy path has no key provider
- * or deterministic mode.
- *
- * `isEncrypted()` is what `supportUnencryptedData` consults to distinguish
- * ciphertext from plaintext on read. Returning the wrong answer is
- * critical in both directions: false positive and the shim decrypts
- * plaintext (may corrupt it); false negative and it skips decryption
- * for real ciphertext (returns garbage to the caller). Resolution order:
- *
- *   1. Delegate to `inner.isEncrypted(text)` if the user supplied one —
- *      this is the only reliable answer for custom encryptors.
- *   2. Otherwise, try `inner.decrypt(text)` and treat a throw as
- *      "not encrypted". Matches Rails' own
- *      `ActiveRecord::Encryption::Encryptor#encrypted?`, which does
- *      `serializer.load(encrypted_text); true; rescue; false`.
- *
- * Two caveats with the fallback path:
- *
- * - A custom encryptor whose `decrypt` is permissive (doesn't throw
- *   on plaintext) MUST supply `isEncrypted()` to avoid misclassification.
- * - When `supportUnencryptedData` is enabled, the scheme consults
- *   `isEncrypted()` before decrypting, so the fallback path runs
- *   `decrypt` once for the probe and once for real — roughly 2x the
- *   CPU. Rails avoids this by probing with `serializer.load` (cheap
- *   parse, no cipher), but the simple `{ encrypt, decrypt }` surface
- *   has no equivalent cheap probe. Supplying `isEncrypted()` eliminates
- *   the double work; consider doing so in perf-sensitive paths.
- */
-class LegacyEncryptorShim implements EncryptorLike {
-  constructor(private readonly inner: Encryptor) {}
-
-  encrypt(clearText: string, _options?: Record<string, unknown>): string {
-    return this.inner.encrypt(clearText);
-  }
-
-  decrypt(encryptedText: string, _options?: Record<string, unknown>): string {
-    return this.inner.decrypt(encryptedText);
-  }
-
-  isEncrypted(text: string): boolean {
-    if (this.inner.isEncrypted) return this.inner.isEncrypted(text);
-    try {
-      this.inner.decrypt(text);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  isBinary(): boolean {
-    return this.inner.isBinary?.() ?? false;
-  }
-}
+export type Encryptor = EncryptorOptionLike;
 
 /**
  * The options bag `Base.encrypts` accepts. Mirrors Rails' kwargs:
@@ -141,48 +53,6 @@ export interface EncryptsOptions extends Omit<SchemeOptions, "encryptor"> {
   encryptor?: Encryptor;
 }
 
-/**
- * `Base.encrypts`' variant of `EncryptableRecord#scheme_for`, carrying the
- * legacy `{ encrypt, decrypt }` shim and the defaultEncryptor fallback. It owes
- * `scheme_for`'s one-shot `previous_schemes` assignment
- * (encryptable_record.rb:70-76): globals first, then the declared ones.
- */
-function buildScheme(options: EncryptsOptions): Scheme {
-  const { encryptor, previousSchemes: localPrevious = [], ...schemeOptions } = options;
-
-  const hasSchemeOptions =
-    schemeOptions.key !== undefined ||
-    schemeOptions.keyProvider !== undefined ||
-    schemeOptions.deterministic !== undefined ||
-    schemeOptions.downcase !== undefined ||
-    schemeOptions.ignoreCase !== undefined ||
-    localPrevious.length > 0 ||
-    schemeOptions.compress !== undefined ||
-    schemeOptions.compressor !== undefined ||
-    schemeOptions.supportUnencryptedData !== undefined;
-
-  // Switch to the real Scheme whenever any encryption key material is configured.
-  // If config is incomplete (e.g. only keyDerivationSalt set, no primaryKey),
-  // Scheme._defaultKeyProvider() returns undefined and Encryptor raises
-  // "No encryption key provided" at serialize/deserialize time — still more
-  // informative than silently storing AR_ENC:base64 data.
-  const config = Configurable.config;
-  const hasConfiguredKeys =
-    config.hasPrimaryKey() !== undefined ||
-    config.hasDeterministicKey() !== undefined ||
-    config.hasKeyDerivationSalt() !== undefined;
-
-  const coreOpts: SchemeOptions = encryptor
-    ? { ...schemeOptions, encryptor: new LegacyEncryptorShim(encryptor) }
-    : hasSchemeOptions || hasConfiguredKeys
-      ? schemeOptions
-      : { encryptor: new LegacyEncryptorShim(defaultEncryptor) };
-
-  const scheme = new Scheme(coreOpts);
-  scheme.previousSchemes = [...globalPreviousSchemesFor(scheme), ...localPrevious];
-  return scheme;
-}
-
 interface PendingEncryption {
   name: string;
   scheme: Scheme;
@@ -192,9 +62,10 @@ interface PendingEncryption {
  * Declare one or more attributes as encrypted on a model class.
  *
  * Routes each attribute through the shared `EncryptableRecord.encryptAttribute`
- * (single declaration path, mirroring Rails' single `encrypts`), passing a
- * scheme built by `buildScheme` so the legacy `{ encrypt, decrypt }` shim and
- * defaultEncryptor fallback are preserved on the primary path.
+ * (single declaration path, mirroring Rails' single `encrypts`), which builds
+ * its scheme with `scheme_for` (encryptable_record.rb:69-76) — the one scheme
+ * constructor, as in Rails. A legacy `{ encrypt, decrypt }` encryptor rides the
+ * `encryptor:` option and is adapted where `Scheme` reads it.
  *
  * The actual type wrapping is deferred (Rails' `decorate_attributes` /
  * PendingDecorator) — `encryptAttribute` pushes the durable decorator once at
@@ -213,13 +84,8 @@ export function encrypts(klass: any, ...args: Array<string | EncryptsOptions>): 
     }
   }
 
-  // Drop the legacy `encryptor` field so the remaining shape is assignable to
-  // SchemeOptions — the scheme is already built, so `encryptAttribute` only
-  // reads `options.ignoreCase` from here.
-  const { encryptor: _encryptor, ...schemeOptions } = options;
-
   for (const name of names) {
-    EncryptableRecord.encryptAttribute(klass, name, schemeOptions, () => buildScheme(options));
+    EncryptableRecord.encryptAttribute(klass, name, options);
   }
 }
 
@@ -392,7 +258,6 @@ registerEncryptionHooks({
   applyPendingEncryptions,
   requireOriginalColumnsAfterReflection: (klass: any, columnNames: string[]) =>
     EncryptableRecord.requireOriginalColumnsAfterReflection(klass, columnNames),
-  buildScheme,
   encryptedAttribute: (record: any, name: string) =>
     EncryptableRecord.encryptedAttribute(record, name),
   ciphertextFor: (record: any, name: string) => EncryptableRecord.ciphertextFor(record, name),

--- a/packages/activerecord/src/encryption/contexts.test.ts
+++ b/packages/activerecord/src/encryption/contexts.test.ts
@@ -44,8 +44,8 @@ describe("ActiveRecord::Encryption::ContextsTest", () => {
     // encryption test (uniqueness-validations.test.ts) hand-rolls models for
     // the same reason. They are also defined after configureEncryption so
     // encrypts() builds the scheme against the configured key material
-    // (otherwise buildScheme falls back to the legacy AR_ENC placeholder
-    // encryptor).
+    // (otherwise the Encryptor raises "No encryption key provided" on the first
+    // serialize).
     EncryptedPost = class EncryptedPost extends Base {
       static {
         this._tableName = "posts";

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -164,21 +164,13 @@ export class EncryptableRecord {
    * (via encryption.ts#encrypts) and direct callers route through here, mirroring
    * Rails' single `encrypt_attribute`.
    *
-   * `buildScheme` lets `Base.encrypts` supply encryption.ts#buildScheme (which
-   * adapts the legacy `{ encrypt, decrypt }` shim and supplies a defaultEncryptor
-   * fallback) in place of `schemeFor`, which direct callers get by omitting it.
-   * It is a function, not a scheme, because Rails calls `scheme_for` inside the
-   * `decorate_attributes` block (encryptable_record.rb:85-88) — see
-   * `PendingEncryption`.
+   * The scheme is built by `schemeFor` — Rails' one `scheme_for` — inside the
+   * `PendingEncryption` getter, because Rails calls `scheme_for` inside the
+   * `decorate_attributes` block (encryptable_record.rb:85-88).
    *
    * @internal
    */
-  static encryptAttribute(
-    modelClass: any,
-    name: string,
-    options: SchemeOptions = {},
-    buildScheme?: () => Scheme,
-  ): void {
+  static encryptAttribute(modelClass: any, name: string, options: SchemeOptions = {}): void {
     // Own-property guard mirrors Rails' `class_attribute` semantics — a subclass
     // encrypting a new attribute must not mutate the parent's (or a sibling's) Set.
     if (!Object.prototype.hasOwnProperty.call(modelClass, "_encryptedAttributes")) {
@@ -190,7 +182,7 @@ export class EncryptableRecord {
     const pending: PendingEncryption = {
       name,
       get scheme(): Scheme {
-        return buildScheme ? buildScheme() : schemeFor(options);
+        return schemeFor(options);
       },
     };
 
@@ -401,20 +393,9 @@ export class EncryptableRecord {
 
     // Declare original_<name> with a default scheme, mirroring Rails' bare
     // `encrypts original_attribute_name` (encryptable_record.rb:105 — no kwargs).
-    // Build it through the shared buildScheme so the legacy encryptor shim +
-    // defaultEncryptor fallback apply exactly as they do for the primary
-    // attribute (a bare schemeFor({}) would raise "No encryption key provided"
-    // when no keys are configured). Falls back to schemeFor when the encryption
-    // namespace isn't loaded (pure-direct unit tests, which never serialize).
     // encryptAttribute's durable branch buffers this in _pendingEncryptions so
     // the original column rides the same replay-safe machinery as its source.
-    const buildOriginalScheme = encryptionHooks.buildScheme;
-    this.encryptAttribute(
-      modelClass,
-      originalName,
-      {},
-      buildOriginalScheme && (() => buildOriginalScheme({}) as Scheme),
-    );
+    this.encryptAttribute(modelClass, originalName, {});
     this.overrideAccessorsToPreserveOriginal(modelClass, name, originalName);
   }
 

--- a/packages/activerecord/src/encryption/encryptor.ts
+++ b/packages/activerecord/src/encryption/encryptor.ts
@@ -35,6 +35,78 @@ export interface EncryptorLike {
   isBinary(): boolean;
 }
 
+/**
+ * The shape `Scheme`'s `encryptor:` option accepts: the full contract above, or
+ * the simple `{ encrypt, decrypt }` pair `Base.encrypts` has always taken, whose
+ * two optional members `LegacyEncryptorShim` fills in.
+ *
+ * @noRailsEquivalent CONVERGEABLE (story:
+ * converge-encryption-simple-encryptor-onto-encryptor-like). Rails' `encryptor:`
+ * takes one contract, `Encryption::Encryptor`.
+ */
+export type EncryptorOptionLike = Omit<EncryptorLike, "isEncrypted" | "isBinary"> &
+  Partial<Pick<EncryptorLike, "isEncrypted" | "isBinary">>;
+
+/**
+ * Adapts a simple `{ encrypt, decrypt }` pair — the surface `Base.encrypts`'
+ * `encryptor:` option has always accepted — to the wider `EncryptorLike` the
+ * scheme expects. Applied by `Scheme`'s constructor where the `encryptor:`
+ * option is read, so there is exactly one scheme constructor
+ * (`EncryptableRecord#scheme_for`, encryptable_record.rb:69-76) as in Rails.
+ *
+ * Both calls forward their options untouched: a duck that declares no second
+ * parameter simply ignores it, so wrapping a fuller encryptor is transparent.
+ * What the shim adds is the two optional members of the contract:
+ *
+ * - `isEncrypted()` is what `supportUnencryptedData` consults to distinguish
+ *   ciphertext from plaintext on read. Returning the wrong answer is critical
+ *   in both directions: a false positive decrypts plaintext (may corrupt it),
+ *   a false negative skips decryption for real ciphertext. It delegates when
+ *   the inner encryptor supplies one — the only reliable answer — and
+ *   otherwise probes with `decrypt`, treating a throw as "not encrypted",
+ *   matching Rails' `Encryptor#encrypted?`, which does
+ *   `serializer.load(encrypted_text); true; rescue; false`.
+ * - `isBinary()` defaults to false.
+ *
+ * A custom encryptor whose `decrypt` is permissive (doesn't throw on
+ * plaintext) MUST supply `isEncrypted()` to avoid misclassification. With
+ * `supportUnencryptedData` on, the probe path also runs `decrypt` twice —
+ * once for the probe, once for real. Rails avoids that by probing with
+ * `serializer.load` (cheap parse, no cipher); the simple pair has no
+ * equivalent cheap probe, so supplying `isEncrypted()` is worthwhile in
+ * perf-sensitive paths.
+ *
+ * @noRailsEquivalent CONVERGEABLE (story:
+ * converge-encryption-simple-encryptor-onto-encryptor-like). Rails has one
+ * encryptor contract and no adapter; this exists only for the older
+ * `{ encrypt, decrypt }` call sites.
+ */
+export class LegacyEncryptorShim implements EncryptorLike {
+  constructor(private readonly inner: EncryptorOptionLike) {}
+
+  encrypt(clearText: string, options?: Record<string, unknown>): string {
+    return this.inner.encrypt(clearText, options);
+  }
+
+  decrypt(encryptedText: string, options?: Record<string, unknown>): string {
+    return this.inner.decrypt(encryptedText, options);
+  }
+
+  isEncrypted(text: string): boolean {
+    if (this.inner.isEncrypted) return this.inner.isEncrypted(text);
+    try {
+      this.inner.decrypt(text);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  isBinary(): boolean {
+    return this.inner.isBinary?.() ?? false;
+  }
+}
+
 export interface KeyProviderLike {
   encryptionKey(): { secret: string; publicTags?: Record<string, unknown> | Properties };
   decryptionKeys(

--- a/packages/activerecord/src/encryption/index.ts
+++ b/packages/activerecord/src/encryption/index.ts
@@ -50,7 +50,6 @@ export {
   encrypts,
   applyPendingEncryptions,
   isEncryptedAttribute,
-  defaultEncryptor,
   keyLength,
   ivLength,
   eagerLoadBang,

--- a/packages/activerecord/src/encryption/scheme.ts
+++ b/packages/activerecord/src/encryption/scheme.ts
@@ -57,9 +57,6 @@ export class Scheme {
     this.previousSchemes = options.previousSchemes ?? [];
 
     if (options.encryptor) {
-      // The option also accepts the simple `{ encrypt, decrypt }` pair
-      // `Base.encrypts` takes; fill in the two members it may omit here, where
-      // the option is read, rather than in a second scheme builder.
       const encryptor = options.encryptor;
       this._encryptor =
         typeof encryptor.isEncrypted === "function" && typeof encryptor.isBinary === "function"

--- a/packages/activerecord/src/encryption/scheme.ts
+++ b/packages/activerecord/src/encryption/scheme.ts
@@ -4,7 +4,12 @@
  * Mirrors: ActiveRecord::Encryption::Scheme
  */
 
-import { Encryptor, type EncryptorLike } from "./encryptor.js";
+import {
+  Encryptor,
+  LegacyEncryptorShim,
+  type EncryptorLike,
+  type EncryptorOptionLike,
+} from "./encryptor.js";
 import { Configuration } from "./errors.js";
 import { getSharedConfig, type Compressor } from "./config.js";
 import type { MessageSerializerLike } from "./message-serializer.js";
@@ -23,7 +28,7 @@ export interface SchemeOptions {
   previousSchemes?: Scheme[];
   compress?: boolean;
   compressor?: Compressor;
-  encryptor?: EncryptorLike;
+  encryptor?: EncryptorOptionLike;
   messageSerializer?: MessageSerializerLike;
 }
 
@@ -52,7 +57,14 @@ export class Scheme {
     this.previousSchemes = options.previousSchemes ?? [];
 
     if (options.encryptor) {
-      this._encryptor = options.encryptor;
+      // The option also accepts the simple `{ encrypt, decrypt }` pair
+      // `Base.encrypts` takes; fill in the two members it may omit here, where
+      // the option is read, rather than in a second scheme builder.
+      const encryptor = options.encryptor;
+      this._encryptor =
+        typeof encryptor.isEncrypted === "function" && typeof encryptor.isBinary === "function"
+          ? (encryptor as EncryptorLike)
+          : new LegacyEncryptorShim(encryptor);
     } else {
       this._encryptor = new Encryptor({
         compress: options.compress,

--- a/packages/activerecord/src/strict-loading.test.ts
+++ b/packages/activerecord/src/strict-loading.test.ts
@@ -4,7 +4,7 @@
  * Targets: vendor/rails/activerecord/test/cases/strict_loading_test.rb
  */
 import { describe, it, expect, beforeAll } from "vitest";
-import { association as associationInstance } from "./associations/instance-methods.js";
+import { loadSingularTarget } from "./test-helpers/load-singular-target.js";
 import { Notifications } from "@blazetrails/activesupport";
 import { ActiveRecord, Base, StrictLoadingViolationError, registerModel } from "./index.js";
 import { association } from "./associations.js";
@@ -22,19 +22,6 @@ import { Treasure } from "./test-helpers/models/treasure.js";
 import { StrictZine } from "./test-helpers/models/strict-zine.js";
 import { Zine } from "./test-helpers/models/zine.js";
 import { Interest } from "./test-helpers/models/interest.js";
-
-/**
- * Rails' entry point for reading a singular association is
- * `record.association(name).load_target` (association.rb:190) — the cached
- * read and the staleness guard live there, and `find_target`
- * (singular_association.rb:47-55) is a pure query underneath it.
- */
-async function loadSingularTarget(record: Base, name: string): Promise<Base | null> {
-  // `async` so `check_validity!`, which Rails runs in `Association#initialize`
-  // (association.rb:41-45) and trails runs when the holder is built, surfaces
-  // as a rejection like every other load failure.
-  return associationInstance.call(record, name).loadTarget() as Promise<Base | null>;
-}
 
 // Simulate an eager-preload by seeding the real association holder (RFC 0022:
 // `record.association(name).target` is the source of truth) the same way the

--- a/packages/activerecord/src/strict-loading.test.ts
+++ b/packages/activerecord/src/strict-loading.test.ts
@@ -4,7 +4,7 @@
  * Targets: vendor/rails/activerecord/test/cases/strict_loading_test.rb
  */
 import { describe, it, expect, beforeAll } from "vitest";
-import { findTarget } from "./associations/singular-association.js";
+import { association as associationInstance } from "./associations/instance-methods.js";
 import { Notifications } from "@blazetrails/activesupport";
 import { ActiveRecord, Base, StrictLoadingViolationError, registerModel } from "./index.js";
 import { association } from "./associations.js";
@@ -22,6 +22,19 @@ import { Treasure } from "./test-helpers/models/treasure.js";
 import { StrictZine } from "./test-helpers/models/strict-zine.js";
 import { Zine } from "./test-helpers/models/zine.js";
 import { Interest } from "./test-helpers/models/interest.js";
+
+/**
+ * Rails' entry point for reading a singular association is
+ * `record.association(name).load_target` (association.rb:190) — the cached
+ * read and the staleness guard live there, and `find_target`
+ * (singular_association.rb:47-55) is a pure query underneath it.
+ */
+async function loadSingularTarget(record: Base, name: string): Promise<Base | null> {
+  // `async` so `check_validity!`, which Rails runs in `Association#initialize`
+  // (association.rb:41-45) and trails runs when the holder is built, surfaces
+  // as a rejection like every other load failure.
+  return associationInstance.call(record, name).loadTarget() as Promise<Base | null>;
+}
 
 // Simulate an eager-preload by seeding the real association holder (RFC 0022:
 // `record.association(name).target` is the source of truth) the same way the
@@ -360,12 +373,12 @@ describe("StrictLoadingTest", () => {
 
       const preloaded = (await Developer.all().includes("ship").first())!;
       expect(preloaded.isStrictLoading()).toBe(true);
-      const loaded = await findTarget(preloaded, "ship", { className: "Ship" });
+      const loaded = await loadSingularTarget(preloaded, "ship");
       expect(loaded?.id).toBe(ship.id);
 
       await preloaded.reload();
 
-      const reloaded = await findTarget(preloaded, "ship", { className: "Ship" });
+      const reloaded = await loadSingularTarget(preloaded, "ship");
       expect(reloaded?.id).toBe(ship.id);
     });
   });
@@ -428,9 +441,7 @@ describe("StrictLoadingTest", () => {
     await expect(association(loaded!, "contracts").toArray()).rejects.toThrow(
       StrictLoadingViolationError,
     );
-    await expect(findTarget(loaded!, "ship", { className: "Ship" })).rejects.toThrow(
-      StrictLoadingViolationError,
-    );
+    await expect(loadSingularTarget(loaded!, "ship")).rejects.toThrow(StrictLoadingViolationError);
   });
 
   // Rails: test_strict_loading_with_has_one_through_does_not_prevent_creation_of_association
@@ -562,13 +573,9 @@ describe("StrictLoadingTest", () => {
     const developer = await Developer.first();
     await developer!.updateColumn("mentor_id", mentor.id);
 
-    await expect(
-      findTarget(developer!, "strictLoadingMentor", {
-        className: "Mentor",
-        foreignKey: "mentor_id",
-        strictLoading: true,
-      }),
-    ).rejects.toThrow(StrictLoadingViolationError);
+    await expect(loadSingularTarget(developer!, "strictLoadingMentor")).rejects.toThrow(
+      StrictLoadingViolationError,
+    );
   });
 
   // Rails: test_raises_on_lazy_loading_a_belongs_to_relation_if_strict_loading_by_default
@@ -578,7 +585,7 @@ describe("StrictLoadingTest", () => {
       const developer = await Developer.first();
       await developer!.updateColumn("mentor_id", mentor.id);
 
-      await expect(findTarget(developer!, "mentor", { className: "Mentor" })).rejects.toThrow(
+      await expect(loadSingularTarget(developer!, "mentor")).rejects.toThrow(
         StrictLoadingViolationError,
       );
     });
@@ -591,11 +598,7 @@ describe("StrictLoadingTest", () => {
       const developer = await Developer.first();
       await developer!.updateColumn("mentor_id", mentor.id);
 
-      const loaded = await findTarget(developer!, "strictLoadingOffMentor", {
-        className: "Mentor",
-        foreignKey: "mentor_id",
-        strictLoading: false,
-      });
+      const loaded = await loadSingularTarget(developer!, "strictLoadingOffMentor");
       expect(loaded?.id).toBe(mentor.id);
     });
   });
@@ -608,11 +611,7 @@ describe("StrictLoadingTest", () => {
 
     const developer = (await Developer.all().includes("strictLoadingMentor").first())!;
 
-    const loaded = await findTarget(developer, "strictLoadingMentor", {
-      className: "Mentor",
-      foreignKey: "mentor_id",
-      strictLoading: true,
-    });
+    const loaded = await loadSingularTarget(developer, "strictLoadingMentor");
     expect(loaded?.id).toBe(mentor.id);
   });
 
@@ -624,7 +623,7 @@ describe("StrictLoadingTest", () => {
       await first!.updateColumn("mentor_id", mentor.id);
 
       const developer = (await Developer.all().includes("mentor").first())!;
-      const loaded = await findTarget(developer, "mentor", { className: "Mentor" });
+      const loaded = await loadSingularTarget(developer, "mentor");
       expect(loaded?.id).toBe(mentor.id);
     });
   });
@@ -635,12 +634,9 @@ describe("StrictLoadingTest", () => {
     const ship = await Ship.first();
     await ship!.updateColumn("developer_id", developer!.id);
 
-    await expect(
-      findTarget(developer!, "strictLoadingShip", {
-        className: "Ship",
-        strictLoading: true,
-      }),
-    ).rejects.toThrow(StrictLoadingViolationError);
+    await expect(loadSingularTarget(developer!, "strictLoadingShip")).rejects.toThrow(
+      StrictLoadingViolationError,
+    );
   });
 
   // Rails: test_raises_on_lazy_loading_a_has_one_relation_if_strict_loading_by_default
@@ -650,7 +646,7 @@ describe("StrictLoadingTest", () => {
       const ship = await Ship.first();
       await ship!.updateColumn("developer_id", developer!.id);
 
-      await expect(findTarget(developer!, "ship", { className: "Ship" })).rejects.toThrow(
+      await expect(loadSingularTarget(developer!, "ship")).rejects.toThrow(
         StrictLoadingViolationError,
       );
     });
@@ -662,10 +658,7 @@ describe("StrictLoadingTest", () => {
     await ship!.updateColumn("developer_id", developers("david").id);
 
     const developer = (await Developer.all().includes("strictLoadingShip").first())!;
-    const loaded = await findTarget(developer, "strictLoadingShip", {
-      className: "Ship",
-      strictLoading: true,
-    });
+    const loaded = await loadSingularTarget(developer, "strictLoadingShip");
     expect(loaded).not.toBeNull();
   });
 
@@ -676,7 +669,7 @@ describe("StrictLoadingTest", () => {
       await ship!.updateColumn("developer_id", developers("david").id);
 
       const developer = (await Developer.all().includes("ship").first())!;
-      const loaded = await findTarget(developer, "ship", { className: "Ship" });
+      const loaded = await loadSingularTarget(developer, "ship");
       expect(loaded).not.toBeNull();
     });
   });
@@ -827,7 +820,7 @@ describe("StrictLoadingTest", () => {
     treasure.strictLoadingBang();
     expect(treasure.isStrictLoading()).toBe(true);
 
-    await expect(findTarget(treasure, "looter", { polymorphic: true })).rejects.toThrow(
+    await expect(loadSingularTarget(treasure, "looter")).rejects.toThrow(
       "`Treasure` is marked for strict_loading. " +
         "The polymorphic association named `:looter` cannot be lazily loaded.",
     );
@@ -848,7 +841,7 @@ describe("StrictLoadingTest", () => {
       logged = event.payload.reflection.strictLoadingViolationMessage(event.payload.owner);
     });
     try {
-      await findTarget(treasure, "looter", { polymorphic: true });
+      await loadSingularTarget(treasure, "looter");
       expect(logged).toBe(
         "`Treasure` is marked for strict_loading. " +
           "The polymorphic association named `:looter` cannot be lazily loaded.",

--- a/packages/activerecord/src/strict-loading.trails.test.ts
+++ b/packages/activerecord/src/strict-loading.trails.test.ts
@@ -8,7 +8,8 @@
  * convention file tracks Rails 1:1.
  */
 import { describe, it, expect } from "vitest";
-import { findTarget } from "./associations/singular-association.js";
+import { association as associationInstance } from "./associations/instance-methods.js";
+import type { Base } from "./base.js";
 import { StrictLoadingViolationError, registerModel } from "./index.js";
 import { findTarget as findHasManyTarget } from "./associations/has-many-association.js";
 import { fixtures } from "./test-fixtures.js";
@@ -16,6 +17,19 @@ import { Developer, AuditLog } from "./test-helpers/models/developer.js";
 import { Ship } from "./test-helpers/models/ship.js";
 import { Project } from "./test-helpers/models/project.js";
 import { Firm } from "./test-helpers/models/company.js";
+
+/**
+ * Rails' entry point for reading a singular association is
+ * `record.association(name).load_target` (association.rb:190) — the cached
+ * read and the staleness guard live there, and `find_target`
+ * (singular_association.rb:47-55) is a pure query underneath it.
+ */
+async function loadSingularTarget(record: Base, name: string): Promise<Base | null> {
+  // `async` so `check_validity!`, which Rails runs in `Association#initialize`
+  // (association.rb:41-45) and trails runs when the holder is built, surfaces
+  // as a rejection like every other load failure.
+  return associationInstance.call(record, name).loadTarget() as Promise<Base | null>;
+}
 
 interface ReflectionHost {
   _reflectOnAssociation(name: string): { options: Record<string, unknown> };
@@ -69,13 +83,13 @@ describe("StrictLoadingNewRecordFindTargetTest", () => {
   it("does not raise on lazy loading a has_one on a new strict-loading owner without the foreign key", async () => {
     const developer = new Developer({ name: "New Dev" });
     developer.strictLoadingBang();
-    await expect(findTarget(developer, "ship", optionsFor("ship"))).resolves.toBeNull();
+    await expect(loadSingularTarget(developer, "ship")).resolves.toBeNull();
   });
 
   it("does not raise on lazy loading a belongs_to on a new strict-loading owner without the foreign key", async () => {
     const developer = new Developer({ name: "New Dev" });
     developer.strictLoadingBang();
-    await expect(findTarget(developer, "firm", optionsFor("firm"))).resolves.toBeNull();
+    await expect(loadSingularTarget(developer, "firm")).resolves.toBeNull();
   });
 
   it("does not raise on lazy loading a habtm on a new strict-loading owner without the foreign key", async () => {
@@ -92,14 +106,14 @@ describe("StrictLoadingNewRecordFindTargetTest", () => {
     developer.firm_id = null as unknown as number;
     developer.strictLoadingBang();
     expect(developer.isNewRecord()).toBe(false);
-    await expect(findTarget(developer, "firm", optionsFor("firm"))).resolves.toBeNull();
+    await expect(loadSingularTarget(developer, "firm")).resolves.toBeNull();
   });
 
   it("raises on lazy loading a belongs_to on a new strict-loading owner with the foreign key present", async () => {
     const developer = new Developer({ name: "New Dev", firm_id: 1 });
     developer.strictLoadingBang();
     expect(developer.isNewRecord()).toBe(true);
-    await expect(findTarget(developer, "firm", optionsFor("firm"))).rejects.toThrow(
+    await expect(loadSingularTarget(developer, "firm")).rejects.toThrow(
       StrictLoadingViolationError,
     );
   });

--- a/packages/activerecord/src/strict-loading.trails.test.ts
+++ b/packages/activerecord/src/strict-loading.trails.test.ts
@@ -8,8 +8,7 @@
  * convention file tracks Rails 1:1.
  */
 import { describe, it, expect } from "vitest";
-import { association as associationInstance } from "./associations/instance-methods.js";
-import type { Base } from "./base.js";
+import { loadSingularTarget } from "./test-helpers/load-singular-target.js";
 import { StrictLoadingViolationError, registerModel } from "./index.js";
 import { findTarget as findHasManyTarget } from "./associations/has-many-association.js";
 import { fixtures } from "./test-fixtures.js";
@@ -17,19 +16,6 @@ import { Developer, AuditLog } from "./test-helpers/models/developer.js";
 import { Ship } from "./test-helpers/models/ship.js";
 import { Project } from "./test-helpers/models/project.js";
 import { Firm } from "./test-helpers/models/company.js";
-
-/**
- * Rails' entry point for reading a singular association is
- * `record.association(name).load_target` (association.rb:190) — the cached
- * read and the staleness guard live there, and `find_target`
- * (singular_association.rb:47-55) is a pure query underneath it.
- */
-async function loadSingularTarget(record: Base, name: string): Promise<Base | null> {
-  // `async` so `check_validity!`, which Rails runs in `Association#initialize`
-  // (association.rb:41-45) and trails runs when the holder is built, surfaces
-  // as a rejection like every other load failure.
-  return associationInstance.call(record, name).loadTarget() as Promise<Base | null>;
-}
 
 interface ReflectionHost {
   _reflectOnAssociation(name: string): { options: Record<string, unknown> };

--- a/packages/activerecord/src/test-helpers/load-singular-target.ts
+++ b/packages/activerecord/src/test-helpers/load-singular-target.ts
@@ -1,0 +1,21 @@
+import type { Base } from "../base.js";
+import { association } from "../associations/instance-methods.js";
+
+/**
+ * Reads a belongs_to / has_one target the way Rails' own tests do —
+ * `record.association(name).load_target` (`association.rb:190`), which holds
+ * the cache read and the staleness guard, with
+ * `SingularAssociation#find_target` (`singular_association.rb:47-55`) the pure
+ * query underneath.
+ *
+ * `async` so `check_validity!` — run when the holder is built, as in
+ * `Association#initialize` (`association.rb:41-45`) — surfaces as a rejection
+ * like every other load failure.
+ *
+ * Test-only sugar for the `load_target` call Rails' tests spell inline: the
+ * TypeScript reader answers `Base | Base[] | null`, and every singular call
+ * site would otherwise repeat the same narrowing cast.
+ */
+export async function loadSingularTarget(record: Base, name: string): Promise<Base | null> {
+  return association.call(record, name).loadTarget() as Promise<Base | null>;
+}

--- a/packages/activerecord/src/test-helpers/models/bulb.ts
+++ b/packages/activerecord/src/test-helpers/models/bulb.ts
@@ -4,7 +4,7 @@ import type { Car } from "./car.js";
 // vendor/rails/activerecord/test/models/bulb.rb
 import { Base } from "../../base.js";
 import { association } from "../../associations.js";
-import { findTarget } from "../../associations/singular-association.js";
+import { association as associationInstance } from "../../associations/instance-methods.js";
 
 export class Bulb extends Base {
   declare car: Car | null;
@@ -36,7 +36,7 @@ export class Bulb extends Base {
     });
     this.afterCreate(async (record: Bulb) => {
       record.countAfterCreate = await Bulb.unscoped(async () => {
-        const car = await findTarget(record, "car", {});
+        const car = (await associationInstance.call(record, "car").loadTarget()) as Car | null;
         return car ? await association(car, "bulbs").count() : undefined;
       });
     });

--- a/packages/i18n/src/date.trails.test.ts
+++ b/packages/i18n/src/date.trails.test.ts
@@ -508,6 +508,16 @@ describe("Date", () => {
     expect(RubyDate.jd(2299160).yday).toBe(277);
   });
 
+  it("pads the year to four digits the way date_strftime's %Y does", () => {
+    expect(new RubyDate(1, 1, 1).toS()).toBe("0001-01-01");
+    expect(new RubyDate(99, 12, 31).toS()).toBe("0099-12-31");
+    expect(new RubyDate(999, 6, 15).toS()).toBe("0999-06-15");
+    expect(new RubyDate(-1, 1, 1).toS()).toBe("-0001-01-01");
+    expect(new RubyDate(-12345, 1, 1).toS()).toBe("-12345-01-01");
+    expect(new RubyDate(12345, 1, 1).toS()).toBe("12345-01-01");
+    expect(new RubyDate(1, 1, 1).strftime("%F")).toBe("0001-01-01");
+  });
+
   it("carries the start the date was resolved under, rather than defaulting it to ITALY", () => {
     expect(RubyDate.parse("1582-10-10", true, RubyDate.GREGORIAN).start).toBe(RubyDate.GREGORIAN);
     expect(RubyDate.parse("1582-10-10", true, RubyDate.GREGORIAN).toS()).toBe("1582-10-10");

--- a/packages/i18n/src/date.ts
+++ b/packages/i18n/src/date.ts
@@ -57,6 +57,17 @@ function pad2(n: number): string {
 }
 
 /**
+ * @internal `date_strftime.c`'s `%Y` arm: `FMT('0', 0 <= y ? 4 : 5, "ld", y)`
+ * (ruby/date, `date_strftime.c:236-247`), so a non-negative year pads to four
+ * digits and a negative one pads to five columns counting the sign — `-0001`,
+ * not `-1`. `Date#to_s` is `strftimev("%Y-%m-%d")` (`date_core.c:6967-6970`),
+ * which is why a pre-1000 date renders as `0001-01-01`.
+ */
+function padYear(year: number): string {
+  return year < 0 ? `-${String(-year).padStart(4, "0")}` : String(year).padStart(4, "0");
+}
+
+/**
  * @internal The fields the one C `strftime(3)` behind both `Date#strftime` and
  * `Time#strftime` reads off its receiver. It is not the public surface of
  * either class — `Date` deliberately answers no `hour`/`sec` — so each caller
@@ -101,13 +112,13 @@ export interface StrftimeSubject {
  */
 export function strftime(subject: StrftimeSubject, format: string): string {
   const tokens: Record<string, () => string> = {
-    Y: () => String(subject.year),
+    Y: () => padYear(subject.year),
     y: () => pad2(subject.year % 100),
     m: () => pad2(subject.mon),
     d: () => pad2(subject.day),
     e: () => String(subject.day).padStart(2, " "),
     j: () => String(subject.yday).padStart(3, "0"),
-    F: () => `${subject.year}-${pad2(subject.mon)}-${pad2(subject.day)}`,
+    F: () => `${padYear(subject.year)}-${pad2(subject.mon)}-${pad2(subject.day)}`,
     A: () => DAY_NAMES[subject.wday],
     a: () => ABBR_DAY_NAMES[subject.wday],
     B: () => MONTH_NAMES[subject.mon - 1],


### PR DESCRIPTION
Three convergence stories.

### `Date#to_s` pads the year (RFC 0074)

`date_strftime.c`'s `%Y` arm is `FMT('0', 0 <= y ? 4 : 5, "ld", y)`
(vendor/date, `date_strftime.c:236-247`), and `Date#to_s` is
`strftimev("%Y-%m-%d")` (`date_core.c:6967-6970`). trails emitted the bare
number, so every pre-1000 date rendered as `1-01-01` where Ruby answers
`0001-01-01`. `%F` is `STRFTIME("%Y-%m-%d")` (`date_strftime.c:231-233`) and
picks up the same padding. Expectations verified against `ruby 3.3.11 -rdate`:

```
Date.new(1,1,1).to_s      => "0001-01-01"
Date.new(-1,1,1).to_s     => "-0001-01-01"
Date.new(-12345,1,1).to_s => "-12345-01-01"
```

### One `scheme_for` (RFC 0072)

Rails has exactly one scheme constructor, `EncryptableRecord#scheme_for`
(`encryptable_record.rb:69-76`). `encryption.ts#buildScheme`, the
`encryptionHooks.buildScheme` indirection and `encryptAttribute`'s
scheme-builder parameter are gone; `encryptAttribute` is back to Rails'
`encrypt_attribute(name, **options)` shape.

- `LegacyEncryptorShim` moved next to `EncryptorLike` and is applied where
  `Scheme` reads the `encryptor:` option, so a `{ encrypt, decrypt }` pair is
  normalized once, at the option, rather than in a second builder. Both calls
  forward their options, so wrapping is transparent; the shim only fills in the
  contract's two optional members.
- The `defaultEncryptor` AR_ENC placeholder fallback turned out to have no
  remaining dependents once the second builder went, so it is deleted rather
  than filed — Rails raises "No encryption key provided" from `Encryptor`
  there, which is the intended behaviour, and the whole encryption suite is
  green without it.

### Singular `find_target` is a pure query (RFC 0072)

`SingularAssociation#find_target` (`singular_association.rb:47-55`) reads no
cache; the read lives one level up in `load_target`'s
`(@stale_state && stale_target?) || find_target?` guard (`association.rb:190`).

- `_belongsToCachedHit` and the has_one `_loadedSingularTarget` early return are
  gone from the engine loader.
- Every direct caller — `loadBelongsTo` / `loadHasOne`, `delegate.ts`, the
  singular through loaders, `Bulb`'s callback and the test call sites — now goes
  through `association(name).loadTarget()`, which is Rails' own entry point.
- Staleness is decided only in `loadTarget`, whose existing trails relaxation
  (and its reason) stays documented at that one site.
- The cached-hit `inverse_of` validation is dropped in favour of
  `check_validity!` time (`reflection.ts#checkValidityOfInverseBang`), where
  Rails validates it. The two `trying to use inverses that dont exist` tests
  now see the raise from holder construction — no test renamed.

### Verification

- `pnpm typecheck`, `pnpm lint` clean.
- associations + preloader + strict-loading + delegate: 96 files, 2202 tests
  passed. Full encryption suite (37 files, 358 tests) passed. i18n date/time
  suites passed.
- `pnpm api:calls:wide` OK, no new baseline rows. `pnpm api:extra --package
  activerecord` reports only the pre-existing `encryption/config.ts
  getSharedConfig` row (file untouched here).

Size note: 640 LOC counted (242 insertions, 398 deletions), above the 500
ceiling. The three bundled stories were scoped at ~90/160/250, and the
singular-loader story's acceptance criteria require converting every direct
call site. The change is net -156 lines of code.

Closes-story: date-to-s-does-not-zero-pad-the-year
Closes-story: collapse-buildscheme-into-scheme-for
Closes-story: converge-singular-cached-target-read
