### PR TITLE
fix(activesupport): converge fetch semantics in JSONGemEncoder#encode, baseline the two encoder call gaps

### DIFF
--- a/packages/activesupport/src/json/encoding.ts
+++ b/packages/activesupport/src/json/encoding.ts
@@ -51,7 +51,16 @@ export class JSONGemEncoder {
   encode(value: unknown): string {
     let json = this.stringify(this.jsonify(value));
 
-    if (this.options.escapeHtmlEntities ?? Encoding.escapeHtmlEntitiesInJson) {
+    // Ruby's `@options.fetch(:escape_html_entities, ...)` (encoding.rb:63)
+    // returns the *stored* value whenever the key is present — including a
+    // stored nil, which `??` would replace with the default — so the presence
+    // check is an `in` guard, and the branch follows Ruby truthiness (nil and
+    // false only).
+    const escapeHtmlEntities =
+      "escapeHtmlEntities" in this.options
+        ? this.options.escapeHtmlEntities
+        : Encoding.escapeHtmlEntitiesInJson;
+    if (escapeHtmlEntities != null && escapeHtmlEntities !== false) {
       json = json.replaceAll(">", "\\u003e");
       json = json.replaceAll("<", "\\u003c");
       json = json.replaceAll("&", "\\u0026");

--- a/packages/activesupport/src/json/encoding.ts
+++ b/packages/activesupport/src/json/encoding.ts
@@ -47,15 +47,16 @@ export class JSONGemEncoder {
    * that traversal, so gating it on a non-empty options hash would skip the
    * `asJson` calls — and the raises they exist to surface, e.g. `Type#asJson` —
    * for the common no-options encode.
+   *
+   * Deviation: Ruby's `@options.fetch(:escape_html_entities, ...)`
+   * (encoding.rb:63) returns the *stored* value whenever the key is present —
+   * including a stored nil, which `??` would replace with the default — and JS
+   * has no `Hash#fetch`, so the presence check is an `in` guard and the branch
+   * follows Ruby truthiness (nil and false only).
    */
   encode(value: unknown): string {
     let json = this.stringify(this.jsonify(value));
 
-    // Ruby's `@options.fetch(:escape_html_entities, ...)` (encoding.rb:63)
-    // returns the *stored* value whenever the key is present — including a
-    // stored nil, which `??` would replace with the default — so the presence
-    // check is an `in` guard, and the branch follows Ruby truthiness (nil and
-    // false only).
     const escapeHtmlEntities =
       "escapeHtmlEntities" in this.options
         ? this.options.escapeHtmlEntities

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/json/encoding.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/json/encoding.json
@@ -1,0 +1,16 @@
+[
+  {
+    "package": "activesupport",
+    "tsFile": "json/encoding.ts",
+    "rubyName": "encode",
+    "call": "fetch",
+    "reason": "Ruby Hash#fetch has no JS call analogue; encode reproduces its stored-value-wins semantics with an `in` guard rather than `??`."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "json/encoding.ts",
+    "rubyName": "stringify",
+    "call": "generate",
+    "reason": "::JSON.generate is the Ruby JSON gem entry point; JSON.stringify is its only JS analogue and already implements quirks_mode with no nesting limit."
+  }
+]


### PR DESCRIPTION
`Rails API/Test Comparison` has been red on `main` since 2f77ead7 (#6134), at
the **Call-mismatches ratchet** step:

```
+ activesupport  json/encoding.ts  encode      fetch
+ activesupport  json/encoding.ts  stringify   generate
```

`encode` selected the escape flag with `??`, which substitutes the default for a
stored `null`, where Ruby's
`@options.fetch(:escape_html_entities, Encoding.escape_html_entities_in_json)`
(`activesupport/lib/active_support/json/encoding.rb:63`) returns the *stored*
value whenever the key is present. Ported as an `in` guard plus Ruby truthiness
(`nil`/`false` only).

Ruby `Hash#fetch` and `::JSON.generate` have no same-named JS analogue, so each
row gets a reasoned baseline entry in
`scripts/api-compare/call-mismatches-exclude/activesupport/json/encoding.json`.

`pnpm api:calls` is green: `OK (2174 baselined, ...)`. `packages/activesupport/src/json/` tests pass.

Closes-story: red-2f77ead7
