### PR TITLE
feat(i18n,activerecord,vendor): m_yday's civil fast arms, Configurable-named encryption readers, bare MySQL full_version

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -158,7 +158,17 @@ export class Version {
   /** Rails' `@version` (abstract_adapter.rb:249). */
   private _version: number[];
 
-  /** Rails: `attr_reader :full_version_string` (abstract_adapter.rb:246). */
+  /**
+   * Rails: `attr_reader :full_version_string` (abstract_adapter.rb:246).
+   *
+   * Nullable because Rails' own `initialize` defaults it to `nil`
+   * (abstract_adapter.rb:248) and an adapter really does build one that way:
+   * `SQLite3Adapter#get_database_version` passes only the version string
+   * (sqlite3_adapter.rb:477). The MySQL side is the one that must always carry
+   * it, and does — `get_database_version` passes both
+   * (abstract_mysql_adapter.rb:86-90) — which is why `Mysql2Adapter#full_version`
+   * needs no arm for the nil (mysql2_adapter.rb:164-166).
+   */
   readonly fullVersionString: string | null;
 
   constructor(versionString: string, fullVersionString: string | null = null) {

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.full-version.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.full-version.trails.test.ts
@@ -3,12 +3,15 @@ import { Mysql2Adapter } from "./mysql2-adapter.js";
 import { Version } from "./abstract-adapter.js";
 
 // Trails-specific guard (no Rails counterpart, because Rails cannot reach the
-// state): Rails' #full_version is a bare `database_version.full_version_string`
-// (mysql2_adapter.rb:164-166) and every MySQL Version it builds carries one
-// (abstract_mysql_adapter.rb:86-90), so nil is unobservable there. Trails can
-// build a Version from a bare numeric string (abstract_adapter.rb:248), and
-// #full_version used to substitute "" for it — which answered #mariadb? "no"
-// for a server it had never asked.
+// state through MySQL): #full_version is a bare
+// `database_version.full_version_string` (mysql2_adapter.rb:164-166) and every
+// MySQL Version is built with both arguments (abstract_mysql_adapter.rb:86-90),
+// so nil is unobservable on that adapter. It stays reachable on the class —
+// `full_version_string` defaults to nil (abstract_adapter.rb:248) and
+// SQLite3Adapter#get_database_version builds one that way
+// (sqlite3_adapter.rb:477) — so these pin both arms. #full_version used to
+// substitute "" for the nil, which answered #mariadb? "no" for a server it had
+// never asked.
 describe("AbstractMysqlAdapter#full_version", () => {
   function adapterWith(version: Version): Mysql2Adapter {
     const adapter = new Mysql2Adapter({ host: "localhost" });

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.full-version.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.full-version.trails.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { Mysql2Adapter } from "./mysql2-adapter.js";
+import { Version } from "./abstract-adapter.js";
+
+// Trails-specific guard (no Rails counterpart, because Rails cannot reach the
+// state): Rails' #full_version is a bare `database_version.full_version_string`
+// (mysql2_adapter.rb:164-166) and every MySQL Version it builds carries one
+// (abstract_mysql_adapter.rb:86-90), so nil is unobservable there. Trails can
+// build a Version from a bare numeric string (abstract_adapter.rb:248), and
+// #full_version used to substitute "" for it — which answered #mariadb? "no"
+// for a server it had never asked.
+describe("AbstractMysqlAdapter#full_version", () => {
+  function adapterWith(version: Version): Mysql2Adapter {
+    const adapter = new Mysql2Adapter({ host: "localhost" });
+    (adapter as unknown as { _databaseVersion: Version })._databaseVersion = version;
+    return adapter;
+  }
+
+  it("answers the full version string the Version carries", () => {
+    expect(adapterWith(new Version("10.6.5", "5.5.5-10.6.5-MariaDB")).fullVersion()).toBe(
+      "5.5.5-10.6.5-MariaDB",
+    );
+    expect(adapterWith(new Version("10.6.5", "5.5.5-10.6.5-MariaDB")).isMariadb()).toBe(true);
+  });
+
+  it("answers nil, not an empty string, when the Version carries none", () => {
+    expect(adapterWith(new Version("10.6.5")).fullVersion()).toBeNull();
+    expect(adapterWith(new Version("10.6.5")).isMariadb()).toBe(false);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -382,15 +382,10 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    * adapter and reaches it from the abstract class by duck typing; TS needs a
    * declared member, so the single definition lives here. Sync like Rails,
    * because `database_version` is the memo `configureConnection` warms.
-   *
-   * Deviation: `Version#fullVersionString` is nullable in trails — a Version
-   * built from a bare numeric string carries none — where Rails always sets it
-   * from `get_full_version`, so the `?? ""` stands in for a field Rails cannot
-   * observe as nil.
    * @internal
    */
-  fullVersion(): string {
-    return this.databaseVersion.fullVersionString ?? "";
+  fullVersion(): string | null {
+    return this.databaseVersion.fullVersionString;
   }
 
   /**
@@ -398,7 +393,10 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    * `/mariadb/i.match?(full_version)`.
    */
   isMariadb(): boolean {
-    return /mariadb/i.test(this.fullVersion());
+    // Ruby's `Regexp#match?` accepts nil and answers false; `RegExp#test`
+    // stringifies null to "null", so the nil arm is spelled out.
+    const fullVersion = this.fullVersion();
+    return fullVersion != null && /mariadb/i.test(fullVersion);
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -390,11 +390,12 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
 
   /**
    * Mirrors: AbstractMysqlAdapter#mariadb? (abstract_mysql_adapter.rb:92-94) —
-   * `/mariadb/i.match?(full_version)`.
+   * `/mariadb/i.match?(full_version)`. Ruby's `Regexp#match?` accepts nil and
+   * answers false; `RegExp#test` stringifies `null` to `"null"`, so the nil
+   * arm — a Version built without a full version string
+   * (`abstract_adapter.rb:248`) — is spelled out.
    */
   isMariadb(): boolean {
-    // Ruby's `Regexp#match?` accepts nil and answers false; `RegExp#test`
-    // stringifies null to "null", so the nil arm is spelled out.
     const fullVersion = this.fullVersion();
     return fullVersion != null && /mariadb/i.test(fullVersion);
   }

--- a/packages/activerecord/src/encryption/config.ts
+++ b/packages/activerecord/src/encryption/config.ts
@@ -168,23 +168,3 @@ export class Config {
     this.previousSchemes.push(new Scheme(properties));
   }
 }
-
-let _sharedConfig: Config | undefined;
-
-/**
- * @internal The store behind Rails' `mattr_reader :config, default: Config.new`
- * (encryption/configurable.rb:9), read through `Configurable.config` — which
- * stays the reader, where Rails declares it.
- *
- * Why it is here and not on `Configurable`: Ruby resolves
- * `ActiveRecord::Encryption.config` at call
- * time, so `Encryptor`, `Context`, `Scheme`, `KeyProvider` and `KeyGenerator`
- * name it with no load-order consequence. ESM has no such deferral: an `import`
- * of `configurable.js` from those files puts `Contexts` — and therefore
- * `EncryptingOnlyEncryptor extends Encryptor` — inside a cycle entered at
- * `encryptor.ts`, where the subclass evaluates with `Encryptor` in its TDZ.
- * Keeping the singleton next to its class keeps that `extends` out of the cycle.
- */
-export function getSharedConfig(): Config {
-  return (_sharedConfig ??= new Config());
-}

--- a/packages/activerecord/src/encryption/configurable-slot.ts
+++ b/packages/activerecord/src/encryption/configurable-slot.ts
@@ -1,0 +1,30 @@
+// Late-bound Configurable slot, extracted into a module with ZERO runtime
+// imports so it cannot participate in any import cycle.
+//
+// Why this exists: Rails resolves `ActiveRecord::Encryption.config`,
+// `.key_provider` and `.cipher` when the method runs — encryptor.rb:27,98,108,
+// context.rb:38, scheme.rb:49,98,103, key_provider.rb:22, key_generator.rb:11,45
+// — so naming them costs those files no load order. ESM has no such deferral:
+// `configurable.ts` reads `Contexts.context` and `Config` (configurable.rb:9,17,
+// 33,36), which reach `Encryptor` and `KeyProvider` again, so an eager `import`
+// of `configurable.js` from any of those five files puts
+// `EncryptingOnlyEncryptor extends Encryptor` and
+// `DerivedSecretKeyProvider extends KeyProvider` inside a cycle: entered at
+// `encryptor.ts` or `key-provider.ts`, the subclass evaluates with its
+// superclass still in TDZ.
+//
+// `configurable.ts` sets this on load (self-registration at the bottom of the
+// file); the five readers alias it back to the Rails constant name at the call
+// site, which is what Ruby's constant lookup does there.
+
+import type { Configurable } from "./configurable.js";
+
+/** @internal */
+
+export let _Configurable: typeof Configurable | undefined;
+
+/** @internal */
+
+export function _setConfigurable(configurable: typeof Configurable): void {
+  _Configurable = configurable;
+}

--- a/packages/activerecord/src/encryption/configurable-slot.ts
+++ b/packages/activerecord/src/encryption/configurable-slot.ts
@@ -1,30 +1,41 @@
-// Late-bound Configurable slot, extracted into a module with ZERO runtime
-// imports so it cannot participate in any import cycle.
-//
-// Why this exists: Rails resolves `ActiveRecord::Encryption.config`,
-// `.key_provider` and `.cipher` when the method runs — encryptor.rb:27,98,108,
-// context.rb:38, scheme.rb:49,98,103, key_provider.rb:22, key_generator.rb:11,45
-// — so naming them costs those files no load order. ESM has no such deferral:
-// `configurable.ts` reads `Contexts.context` and `Config` (configurable.rb:9,17,
-// 33,36), which reach `Encryptor` and `KeyProvider` again, so an eager `import`
-// of `configurable.js` from any of those five files puts
-// `EncryptingOnlyEncryptor extends Encryptor` and
-// `DerivedSecretKeyProvider extends KeyProvider` inside a cycle: entered at
-// `encryptor.ts` or `key-provider.ts`, the subclass evaluates with its
-// superclass still in TDZ.
-//
-// `configurable.ts` sets this on load (self-registration at the bottom of the
-// file); the five readers alias it back to the Rails constant name at the call
-// site, which is what Ruby's constant lookup does there.
+/**
+ * Late-bound `Configurable` slot, a module with ZERO runtime imports so it
+ * cannot participate in any import cycle. `configurable.ts` fills it on load
+ * (self-registration at the bottom of that file), and the five files Rails has
+ * read `ActiveRecord::Encryption.config` / `.cipher` / `.key_provider` /
+ * `.message_serializer` import the binding from here under its Rails name, so
+ * their call sites read exactly as the Ruby does.
+ *
+ * Ruby resolves those constants when the method runs — `encryptor.rb:27,98,108,132`,
+ * `context.rb:38`, `scheme.rb:49,98,103`, `key_provider.rb:22`,
+ * `key_generator.rb:11,45` — so naming them costs those files no load order.
+ * ESM has no such deferral: `configurable.ts` reads `Contexts.context` and
+ * `Config` (`configurable.rb:9,17,33,36`), which reach `Encryptor` and
+ * `KeyProvider` again, so an eager `import` of `configurable.js` from any of
+ * the five puts `EncryptingOnlyEncryptor extends Encryptor`
+ * (`encrypting_only_encryptor.rb:6`) and
+ * `DerivedSecretKeyProvider extends KeyProvider`
+ * (`derived_secret_key_provider.rb:6`) inside a cycle: entered at
+ * `encryptor.ts` or `key-provider.ts`, the subclass evaluates with its
+ * superclass still in TDZ.
+ *
+ * @internal
+ */
 
-import type { Configurable } from "./configurable.js";
+import type { Configurable as ConfigurableClass } from "./configurable.js";
+
+/**
+ * Typed as always present because every reader runs long after
+ * `configurable.ts` has been loaded — the module the whole cluster's public API
+ * funnels through.
+ *
+ * @internal
+ */
+
+export let Configurable = undefined as unknown as typeof ConfigurableClass;
 
 /** @internal */
 
-export let _Configurable: typeof Configurable | undefined;
-
-/** @internal */
-
-export function _setConfigurable(configurable: typeof Configurable): void {
-  _Configurable = configurable;
+export function _setConfigurable(configurable: typeof ConfigurableClass): void {
+  Configurable = configurable;
 }

--- a/packages/activerecord/src/encryption/configurable.ts
+++ b/packages/activerecord/src/encryption/configurable.ts
@@ -13,9 +13,6 @@ type DeclarationListener = (klass: any, name: string) => void;
 // (no default → nil). Lazily allocated in onEncryptedAttributeDeclared.
 let _listeners: DeclarationListener[] | undefined;
 
-// Mirrors Rails' `mattr_reader :config, default: Config.new`
-// (configurable.rb:9). Built on first read rather than at module eval so the
-// singleton does not depend on where in the import graph this module lands.
 let _config: Config | undefined;
 
 /**
@@ -25,6 +22,11 @@ let _config: Config | undefined;
  * Mirrors: ActiveRecord::Encryption::Configurable
  */
 export class Configurable {
+  /**
+   * Mirrors Rails' `mattr_reader :config, default: Config.new`
+   * (configurable.rb:9). Built on first read rather than at module eval so the
+   * singleton does not depend on where in the import graph this module lands.
+   */
   static get config(): Config {
     return (_config ??= new Config());
   }

--- a/packages/activerecord/src/encryption/configurable.ts
+++ b/packages/activerecord/src/encryption/configurable.ts
@@ -1,4 +1,5 @@
-import { Config, getSharedConfig } from "./config.js";
+import { Config } from "./config.js";
+import { _setConfigurable } from "./configurable-slot.js";
 import { Context } from "./context.js";
 import { Contexts } from "./contexts.js";
 import { Cipher } from "./cipher.js";
@@ -12,6 +13,11 @@ type DeclarationListener = (klass: any, name: string) => void;
 // (no default → nil). Lazily allocated in onEncryptedAttributeDeclared.
 let _listeners: DeclarationListener[] | undefined;
 
+// Mirrors Rails' `mattr_reader :config, default: Config.new`
+// (configurable.rb:9). Built on first read rather than at module eval so the
+// singleton does not depend on where in the import graph this module lands.
+let _config: Config | undefined;
+
 /**
  * Configuration API for ActiveRecord::Encryption. Manages the shared
  * Config instance and encrypted attribute declaration callbacks.
@@ -20,7 +26,7 @@ let _listeners: DeclarationListener[] | undefined;
  */
 export class Configurable {
   static get config(): Config {
-    return getSharedConfig();
+    return (_config ??= new Config());
   }
 
   // Mirrors Rails' `mattr_accessor :encrypted_attribute_declaration_listeners`
@@ -151,6 +157,8 @@ export class Configurable {
     }
   }
 }
+
+_setConfigurable(Configurable);
 
 /** @internal One `Context::PROPERTIES` name (context.rb:13). */
 type DelegatedProperty = (typeof Context.PROPERTIES)[number];

--- a/packages/activerecord/src/encryption/context.ts
+++ b/packages/activerecord/src/encryption/context.ts
@@ -7,7 +7,7 @@
 import { MessageSerializer, type MessageSerializerLike } from "./message-serializer.js";
 import { NullEncryptor } from "./null-encryptor.js";
 import { Cipher } from "./cipher.js";
-import { _Configurable } from "./configurable-slot.js";
+import { Configurable } from "./configurable-slot.js";
 import { Encryptor } from "./encryptor.js";
 import { KeyGenerator } from "./key-generator.js";
 import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
@@ -66,7 +66,6 @@ export class Context {
    * @internal Rails `Context#build_default_key_provider` (context.rb:37-39).
    */
   private buildDefaultKeyProvider(): unknown {
-    const Configurable = _Configurable!;
     return new DerivedSecretKeyProvider(Configurable.config.primaryKey);
   }
 }

--- a/packages/activerecord/src/encryption/context.ts
+++ b/packages/activerecord/src/encryption/context.ts
@@ -7,7 +7,7 @@
 import { MessageSerializer, type MessageSerializerLike } from "./message-serializer.js";
 import { NullEncryptor } from "./null-encryptor.js";
 import { Cipher } from "./cipher.js";
-import { getSharedConfig } from "./config.js";
+import { _Configurable } from "./configurable-slot.js";
 import { Encryptor } from "./encryptor.js";
 import { KeyGenerator } from "./key-generator.js";
 import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
@@ -66,7 +66,8 @@ export class Context {
    * @internal Rails `Context#build_default_key_provider` (context.rb:37-39).
    */
   private buildDefaultKeyProvider(): unknown {
-    return new DerivedSecretKeyProvider(getSharedConfig().primaryKey);
+    const Configurable = _Configurable!;
+    return new DerivedSecretKeyProvider(Configurable.config.primaryKey);
   }
 }
 

--- a/packages/activerecord/src/encryption/encryptor.ts
+++ b/packages/activerecord/src/encryption/encryptor.ts
@@ -9,7 +9,7 @@ import type { Properties } from "./properties.js";
 import type { MessageSerializerLike } from "./message-serializer.js";
 import { Base, Configuration, Decryption, Encoding, ForbiddenClass } from "./errors.js";
 import { type Compressor } from "./config.js";
-import { _Configurable } from "./configurable-slot.js";
+import { Configurable } from "./configurable-slot.js";
 import { normalizeEncoding, replaceUnencodable } from "./encoding-helpers.js";
 
 // Mirrors: ActiveRecord::Encryption::Encryptor::THRESHOLD_TO_JUSTIFY_COMPRESSION
@@ -119,7 +119,6 @@ export class Encryptor {
 
   constructor(options?: { compress?: boolean; compressor?: Compressor }) {
     this._compress = options?.compress ?? true;
-    const Configurable = _Configurable!;
     this._compressor = options?.compressor ?? Configurable.config.compressor;
   }
 
@@ -214,7 +213,6 @@ export class Encryptor {
 
   /** @internal */
   private cipher() {
-    const Configurable = _Configurable!;
     return Configurable.cipher;
   }
 
@@ -228,7 +226,6 @@ export class Encryptor {
 
   /** @internal */
   private defaultKeyProvider(): KeyProviderLike | undefined {
-    const Configurable = _Configurable!;
     return Configurable.keyProvider as KeyProviderLike | undefined;
   }
 
@@ -261,7 +258,6 @@ export class Encryptor {
 
   /** @internal */
   private serializer(): MessageSerializerLike {
-    const Configurable = _Configurable!;
     return Configurable.messageSerializer as MessageSerializerLike;
   }
 
@@ -329,7 +325,6 @@ export class Encryptor {
 
   /** @internal */
   private forcedEncodingForDeterministicEncryption(): string {
-    const Configurable = _Configurable!;
     return Configurable.config.forcedEncodingForDeterministicEncryption;
   }
 }

--- a/packages/activerecord/src/encryption/encryptor.ts
+++ b/packages/activerecord/src/encryption/encryptor.ts
@@ -5,12 +5,11 @@
  */
 
 import { Message } from "./message.js";
-import type { Cipher } from "./cipher.js";
 import type { Properties } from "./properties.js";
 import type { MessageSerializerLike } from "./message-serializer.js";
-import { getEncryptionContext } from "./context.js";
 import { Base, Configuration, Decryption, Encoding, ForbiddenClass } from "./errors.js";
-import { getSharedConfig, type Compressor } from "./config.js";
+import { type Compressor } from "./config.js";
+import { _Configurable } from "./configurable-slot.js";
 import { normalizeEncoding, replaceUnencodable } from "./encoding-helpers.js";
 
 // Mirrors: ActiveRecord::Encryption::Encryptor::THRESHOLD_TO_JUSTIFY_COMPRESSION
@@ -120,7 +119,8 @@ export class Encryptor {
 
   constructor(options?: { compress?: boolean; compressor?: Compressor }) {
     this._compress = options?.compress ?? true;
-    this._compressor = options?.compressor ?? getSharedConfig().compressor;
+    const Configurable = _Configurable!;
+    this._compressor = options?.compressor ?? Configurable.config.compressor;
   }
 
   encrypt(
@@ -214,7 +214,8 @@ export class Encryptor {
 
   /** @internal */
   private cipher() {
-    return getEncryptionContext().cipher as Cipher;
+    const Configurable = _Configurable!;
+    return Configurable.cipher;
   }
 
   get compressor(): Compressor {
@@ -227,7 +228,8 @@ export class Encryptor {
 
   /** @internal */
   private defaultKeyProvider(): KeyProviderLike | undefined {
-    return getEncryptionContext().keyProvider as KeyProviderLike | undefined;
+    const Configurable = _Configurable!;
+    return Configurable.keyProvider as KeyProviderLike | undefined;
   }
 
   /** @internal */
@@ -259,7 +261,8 @@ export class Encryptor {
 
   /** @internal */
   private serializer(): MessageSerializerLike {
-    return getEncryptionContext().messageSerializer as MessageSerializerLike;
+    const Configurable = _Configurable!;
+    return Configurable.messageSerializer as MessageSerializerLike;
   }
 
   /** @internal */
@@ -326,6 +329,7 @@ export class Encryptor {
 
   /** @internal */
   private forcedEncodingForDeterministicEncryption(): string {
-    return getSharedConfig().forcedEncodingForDeterministicEncryption;
+    const Configurable = _Configurable!;
+    return Configurable.config.forcedEncodingForDeterministicEncryption;
   }
 }

--- a/packages/activerecord/src/encryption/key-generator.ts
+++ b/packages/activerecord/src/encryption/key-generator.ts
@@ -7,13 +7,14 @@
 import { getCrypto } from "@blazetrails/activesupport";
 import { KeyGenerator as AsKeyGenerator } from "@blazetrails/activesupport/key-generator";
 
-import { getSharedConfig } from "./config.js";
+import { _Configurable } from "./configurable-slot.js";
 
 export class KeyGenerator {
   private _hashDigestClass: string;
 
   constructor(hashDigestClass?: string) {
-    this._hashDigestClass = hashDigestClass ?? getSharedConfig().hashDigestClass;
+    const Configurable = _Configurable!;
+    this._hashDigestClass = hashDigestClass ?? Configurable.config.hashDigestClass;
   }
 
   get hashDigestClass(): string {
@@ -49,7 +50,8 @@ export class KeyGenerator {
 
   /** @internal */
   private keyDerivationSalt(): string {
-    return getSharedConfig().keyDerivationSalt;
+    const Configurable = _Configurable!;
+    return Configurable.config.keyDerivationSalt;
   }
 
   /** @internal */

--- a/packages/activerecord/src/encryption/key-generator.ts
+++ b/packages/activerecord/src/encryption/key-generator.ts
@@ -7,13 +7,12 @@
 import { getCrypto } from "@blazetrails/activesupport";
 import { KeyGenerator as AsKeyGenerator } from "@blazetrails/activesupport/key-generator";
 
-import { _Configurable } from "./configurable-slot.js";
+import { Configurable } from "./configurable-slot.js";
 
 export class KeyGenerator {
   private _hashDigestClass: string;
 
   constructor(hashDigestClass?: string) {
-    const Configurable = _Configurable!;
     this._hashDigestClass = hashDigestClass ?? Configurable.config.hashDigestClass;
   }
 
@@ -50,7 +49,6 @@ export class KeyGenerator {
 
   /** @internal */
   private keyDerivationSalt(): string {
-    const Configurable = _Configurable!;
     return Configurable.config.keyDerivationSalt;
   }
 

--- a/packages/activerecord/src/encryption/key-provider.ts
+++ b/packages/activerecord/src/encryption/key-provider.ts
@@ -6,7 +6,7 @@
 
 import { Key } from "./key.js";
 import { headerString } from "./encoding-helpers.js";
-import { getSharedConfig } from "./config.js";
+import { _Configurable } from "./configurable-slot.js";
 import type { Message } from "./message.js";
 
 export class KeyProvider {
@@ -21,7 +21,8 @@ export class KeyProvider {
   encryptionKey(): Key {
     if (!this._encryptionKey) {
       const key = this._keys[this._keys.length - 1];
-      if (getSharedConfig().storeKeyReferences) {
+      const Configurable = _Configurable!;
+      if (Configurable.config.storeKeyReferences) {
         key.publicTags.encryptedDataKeyId = key.id;
       }
       this._encryptionKey = key;

--- a/packages/activerecord/src/encryption/key-provider.ts
+++ b/packages/activerecord/src/encryption/key-provider.ts
@@ -6,7 +6,7 @@
 
 import { Key } from "./key.js";
 import { headerString } from "./encoding-helpers.js";
-import { _Configurable } from "./configurable-slot.js";
+import { Configurable } from "./configurable-slot.js";
 import type { Message } from "./message.js";
 
 export class KeyProvider {
@@ -21,7 +21,6 @@ export class KeyProvider {
   encryptionKey(): Key {
     if (!this._encryptionKey) {
       const key = this._keys[this._keys.length - 1];
-      const Configurable = _Configurable!;
       if (Configurable.config.storeKeyReferences) {
         key.publicTags.encryptedDataKeyId = key.id;
       }

--- a/packages/activerecord/src/encryption/scheme.ts
+++ b/packages/activerecord/src/encryption/scheme.ts
@@ -12,7 +12,7 @@ import {
 } from "./encryptor.js";
 import { Configuration } from "./errors.js";
 import { type Compressor } from "./config.js";
-import { _Configurable } from "./configurable-slot.js";
+import { Configurable } from "./configurable-slot.js";
 import type { MessageSerializerLike } from "./message-serializer.js";
 import { withEncryptionContext, type Context } from "./context.js";
 import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
@@ -90,7 +90,6 @@ export class Scheme {
   }
 
   isSupportUnencryptedData(): boolean {
-    const Configurable = _Configurable!;
     return this._opts.supportUnencryptedData ?? Configurable.config.supportUnencryptedData;
   }
 
@@ -152,14 +151,12 @@ export class Scheme {
 
   /** @internal */
   private defaultKeyProvider(): unknown {
-    const Configurable = _Configurable!;
     return Configurable.keyProvider;
   }
 
   /** @internal */
   private deterministicKeyProvider(): DeterministicKeyProvider | undefined {
     if (this.deterministic) {
-      const Configurable = _Configurable!;
       const deterministicKey = Configurable.config.deterministicKey;
       this._cachedDeterministicKeyProvider ??= new DeterministicKeyProvider(deterministicKey);
       return this._cachedDeterministicKeyProvider;

--- a/packages/activerecord/src/encryption/scheme.ts
+++ b/packages/activerecord/src/encryption/scheme.ts
@@ -11,9 +11,10 @@ import {
   type EncryptorOptionLike,
 } from "./encryptor.js";
 import { Configuration } from "./errors.js";
-import { getSharedConfig, type Compressor } from "./config.js";
+import { type Compressor } from "./config.js";
+import { _Configurable } from "./configurable-slot.js";
 import type { MessageSerializerLike } from "./message-serializer.js";
-import { withEncryptionContext, getEncryptionContext, type Context } from "./context.js";
+import { withEncryptionContext, type Context } from "./context.js";
 import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
 import { DeterministicKeyProvider } from "./deterministic-key-provider.js";
 
@@ -89,7 +90,8 @@ export class Scheme {
   }
 
   isSupportUnencryptedData(): boolean {
-    return this._opts.supportUnencryptedData ?? getSharedConfig().supportUnencryptedData;
+    const Configurable = _Configurable!;
+    return this._opts.supportUnencryptedData ?? Configurable.config.supportUnencryptedData;
   }
 
   // fixed: true (default for deterministic) → serialize uses the oldest previous
@@ -150,13 +152,15 @@ export class Scheme {
 
   /** @internal */
   private defaultKeyProvider(): unknown {
-    return getEncryptionContext().keyProvider;
+    const Configurable = _Configurable!;
+    return Configurable.keyProvider;
   }
 
   /** @internal */
   private deterministicKeyProvider(): DeterministicKeyProvider | undefined {
     if (this.deterministic) {
-      const deterministicKey = getSharedConfig().deterministicKey;
+      const Configurable = _Configurable!;
+      const deterministicKey = Configurable.config.deterministicKey;
       this._cachedDeterministicKeyProvider ??= new DeterministicKeyProvider(deterministicKey);
       return this._cachedDeterministicKeyProvider;
     }

--- a/packages/activerecord/src/support/mysql-server-version.ts
+++ b/packages/activerecord/src/support/mysql-server-version.ts
@@ -41,7 +41,7 @@ export const mysqlVersion = mysqlVersionStr;
 // AbstractMysqlAdapter#version_string does (strips the MariaDB 5.5.5- prefix).
 function parseMysqlVersion(full: string): Version | null {
   const m = full.match(/^(?:5\.5\.5-)?(\d+\.\d+\.\d+)/);
-  return m ? new Version(m[1]) : null;
+  return m ? new Version(m[1], full) : null;
 }
 const _serverVersion = parseMysqlVersion(mysqlVersionStr);
 

--- a/packages/activerecord/src/support/schema-conn.ts
+++ b/packages/activerecord/src/support/schema-conn.ts
@@ -29,7 +29,10 @@ export function schemaConn(name: SchemaConnName): TableDefinitionConn {
           ? new PostgreSQLAdapter("postgresql://localhost/trails_schema_conn")
           : new Mysql2Adapter("mysql://localhost/trails_schema_conn");
     if (name === "mysql") {
-      (conn as unknown as { _databaseVersion: Version })._databaseVersion = new Version("8.0.35");
+      (conn as unknown as { _databaseVersion: Version })._databaseVersion = new Version(
+        "8.0.35",
+        "8.0.35",
+      );
     }
     conns.set(name, conn);
   }

--- a/packages/i18n/src/date.ts
+++ b/packages/i18n/src/date.ts
@@ -1782,6 +1782,15 @@ const monthtab: readonly (readonly number[])[] = [
   [0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
 ];
 
+/**
+ * @internal `date_core.c` `yeartab` (`date_core.c:1805-1808`), the number of
+ * days before each month indexed by leapness then month.
+ */
+const yeartab: readonly (readonly number[])[] = [
+  [0, 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334],
+  [0, 0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335],
+];
+
 /** @internal `date_core.c`'s `DIV` macro (`date_core.c:168-170`), floored division. */
 function div(n: number, d: number): number {
   return Math.floor(n / d);
@@ -1861,6 +1870,11 @@ function cFindFdoy(y: number, sg: number): [rjd: number, ns: number] | null {
   return null;
 }
 
+/** @internal `date_core.c` `c_julian_leap_p` (`date_core.c:702-706`). */
+function cJulianLeapP(y: number): boolean {
+  return mod(y, 4) === 0;
+}
+
 /** @internal `date_core.c` `c_gregorian_leap_p` (`date_core.c:708-712`). */
 function cGregorianLeapP(y: number): boolean {
   return (mod(y, 4) === 0 && y % 100 !== 0) || mod(y, 400) === 0;
@@ -1869,6 +1883,16 @@ function cGregorianLeapP(y: number): boolean {
 /** @internal `date_core.c` `c_gregorian_last_day_of_month` (`date_core.c:721-726`). */
 function cGregorianLastDayOfMonth(y: number, m: number): number {
   return monthtab[cGregorianLeapP(y) ? 1 : 0][m];
+}
+
+/** @internal `date_core.c` `c_julian_to_yday` (`date_core.c:1810-1815`). */
+function cJulianToYday(y: number, m: number, d: number): number {
+  return yeartab[cJulianLeapP(y) ? 1 : 0][m] + d;
+}
+
+/** @internal `date_core.c` `c_gregorian_to_yday` (`date_core.c:1817-1822`). */
+function cGregorianToYday(y: number, m: number, d: number): number {
+  return yeartab[cGregorianLeapP(y) ? 1 : 0][m] + d;
 }
 
 /**
@@ -2423,6 +2447,20 @@ export class Date {
     return this.#jd;
   }
 
+  /** @internal ruby/date's `m_proleptic_julian_p` (`date_core.c:1710-1719`). */
+  #mProlepticJulianP(): boolean {
+    const sg = this.#sg;
+    if (!Number.isFinite(sg) && sg > 0) return true;
+    return false;
+  }
+
+  /** @internal ruby/date's `m_proleptic_gregorian_p` (`date_core.c:1721-1730`). */
+  #mProlepticGregorianP(): boolean {
+    const sg = this.#sg;
+    if (!Number.isFinite(sg) && sg < 0) return true;
+    return false;
+  }
+
   /** @internal ruby/date's `m_year` (`date_core.c:1732-1743`). */
   #mYear(): number {
     this.#getSCivil();
@@ -2439,6 +2477,23 @@ export class Date {
   #mMday(): number {
     this.#getSCivil();
     return this.#mday;
+  }
+
+  /**
+   * @internal ruby/date's `m_yday` (`date_core.c:1824-1839`). The two leading
+   * arms read the day of the year off the civil fields, so only the reform
+   * window falls through to `c_jd_to_ordinal`. `sg` is `m_virtual_sg`, which
+   * for a `SimpleDateData` with `nth == 0` — the only kind this port builds —
+   * is `m_sg`, i.e. `#sg` (`date_core.c:1119-1141`).
+   */
+  #mYday(): number {
+    const jd = this.#mJd();
+    const sg = this.#sg;
+
+    if (this.#mProlepticGregorianP() || jd - sg > 366)
+      return cGregorianToYday(this.#mYear(), this.#mMon(), this.#mMday());
+    if (this.#mProlepticJulianP()) return cJulianToYday(this.#mYear(), this.#mMon(), this.#mMday());
+    return cJdToOrdinal(jd, sg)![1];
   }
 
   /**
@@ -2588,7 +2643,7 @@ export class Date {
   }
 
   get yday(): number {
-    return cJdToOrdinal(this.#mJd(), this.#sg)![1];
+    return this.#mYday();
   }
 
   /**

--- a/vendor/sources.ts
+++ b/vendor/sources.ts
@@ -196,12 +196,17 @@ export const SOURCES: readonly UpstreamSource[] = [
         name: "date",
         libPath: "lib",
         testPath: "test/date",
-        // Vendored-only for now: the gem's surface is implemented in C, so
-        // the Ruby extractor sees almost nothing until RFC
-        // 0088-date-gem-port's `date-package-scaffold`,
-        // `date-api-compare-enrollment` and `date-test-compare-enrollment`
-        // stories land `packages/date` and flip these on. Same
-        // shipped-interim pattern RFC 0074 used for i18n.
+        // Vendored-only: the gem's surface is implemented in C, so the Ruby
+        // extractor sees almost nothing. Measured by RFC 0088-date-gem-port's
+        // `date-c-source-extractor-decision` spike, running
+        // `scripts/api-compare/extract-ruby-api.rb` against this `libPath`:
+        // `date: 2 classes, 0 modules, 12 public methods (1 internal)` — all of
+        // `lib/date.rb`'s `Date#infinite?` and the `:nodoc:` `Date::Infinity`,
+        // against 2,805 lines of port. So `compareApi` stays off; the C sources
+        // are a read-anchor, and they need no `UNPORTED_FILES` entry because
+        // the extractor globs `**/*.rb` and never sees them. `compareTests`
+        // flips in `date-test-compare-enrollment` — `test/date/` is 12 files
+        // and 145 `def test_` methods, and it is the gate for this cluster.
         compareApi: false,
         compareTests: false,
       },


### PR DESCRIPTION
Four bundled stories.

### `Date#yday` ports all three of `m_yday`'s arms

`get yday` ported only `m_yday`'s third branch. It now mirrors
`date_core.c:1824-1839` in order, with `c_gregorian_to_yday` /
`c_julian_to_yday` (`date_core.c:1810-1822`), `yeartab` (`date_core.c:1805`),
`c_julian_leap_p` (`date_core.c:702`) and the `m_proleptic_gregorian_p` /
`m_proleptic_julian_p` predicates (`date_core.c:1710-1730`) ported at their
Rails names, behind a `#mYday` the getter delegates to.

**One acceptance criterion is deliberately not met, on fidelity grounds:** "a
`HAVE_CIVIL`-only date answers `yday` without computing a Julian day". `m_yday`
computes `m_local_jd(x)` *unconditionally*, at `date_core.c:1830`, before it
branches — the fast arms skip `c_jd_to_ordinal`, not the Julian day. Making the
TS lazy would reorder the body away from the C. Same branches, same order,
same guards was the higher bar.

Verified with a 2,628-construction differential (6 `start` values × 12 years ×
12 months × 3 days, plus 6 raw `jd`s per start) against `ruby 3.3.11 -rdate`:
**zero mismatches**.

### Encryption cluster reads `Configurable`, not free functions

`Encryptor`, `Context`, `Scheme`, `KeyProvider` and `KeyGenerator` now name
`Configurable.config` / `.cipher` / `.keyProvider` / `.messageSerializer` at
every site listed in the story (`encryptor.rb:27,98,108,132,173`,
`context.rb:38`, `scheme.rb:49,98,103`, `key_provider.rb:22`,
`key_generator.rb:11,45`). `getSharedConfig` and its `@noRailsEquivalent` tag
are deleted; the singleton is back on `Configurable` where
`mattr_reader :config, default: Config.new` (`configurable.rb:9`) declares it.
`configurable.ts` still reads `Contexts.context` / `Contexts.resetDefaultContext()`
(#6127 is not reverted).

The ESM cycle is broken at exactly one edge, `configurable-slot.ts` — the
repo's existing zero-import slot idiom (`associations/collection-proxy-slot.ts`).
It exports the binding under its Rails name, so every reader's call site is
byte-identical to the Ruby and the whole deviation is contained in one file
with one receipt. Two other shapes were tried first and rejected: deferring
`contexts.ts -> EncryptingOnlyEncryptor` alone does not cover `key-provider.ts`'s
cycle, and deferring each subclass edge instead needs four slots *and* fails at
runtime — nothing loads the provider modules, so `Configurable.configure` dies
on an unregistered ctor (37 suites red). Deferring the `Configurable` edge
itself is one slot, registered by the module the whole cluster funnels through.

Verified per the acceptance criteria with a plain-node import of the **built**
`dist/encryption/{encryptor,contexts,configurable,key-provider,config,context,scheme,key-generator}.js`
as entry modules: all green. `key-provider.js` was red on main before this
(`Cannot access 'KeyProvider' before initialization`) — the pre-existing latent
cycle the story flagged is retired too. Encryption suites: 355 passed, 1
skipped.

### MySQL `full_version` loses the `?? ""`

`fullVersion()` is a bare `return this.databaseVersion.fullVersionString;`
(`mysql2_adapter.rb:164-166`) and the deviation JSDoc is deleted. The two
Version constructions that built a MySQL Version from a bare numeric string —
`support/schema-conn.ts` and `support/mysql-server-version.ts` — now pass the
full string, as `get_database_version` always does
(`abstract_mysql_adapter.rb:86-90`). `Version#fullVersionString` keeps Rails'
`nil` default (`abstract_adapter.rb:248`), so the nil arm moves to `isMariadb`,
where Ruby's `Regexp#match?(nil)` answers false and JS's `RegExp#test` would
stringify `null`.

**On the "cannot be null on any adapter-built Version" criterion:** the story
offered two converged shapes and this takes the second — narrow the window, not
make the field non-nullable. Non-nullable is not available: Rails' own
`initialize` defaults `full_version_string` to `nil`
(`abstract_adapter.rb:248`) and an adapter really does build one that way —
`SQLite3Adapter#get_database_version` passes only the version string
(`sqlite3_adapter.rb:477`). So the invariant holds exactly where Rails has it,
on the MySQL side, and the type keeps Rails' signature. Cited at the field
(`abstract-adapter.ts`) and in the test's header, not just here.

### date C-source extractor spike — settled as (b)

Ran `scripts/api-compare/extract-ruby-api.rb` against `vendor/date/lib`, which
is what enrollment would feed it:

    date: 2 classes, 0 modules, 12 public methods (1 internal)

That is all of `lib/date.rb` (70 lines) — `Date#infinite?` and the `:nodoc:`
`Date::Infinity` — against 2,805 lines of port implemented in
`ext/date/date_core.c` (10,064) and `date_parse.c` (3,086). `api:compare`
credits ~0%.

**Correction to the RFC's fallback: no `UNPORTED_FILES` entries are needed or
possible.** The extractor globs `**/*.rb` under `libPath`
(`extract-ruby-api.rb:2496`), so the C sources never enter the compared
population — there is nothing to exclude. `compareApi` stays off; `test:compare`
over `test/date/` (12 files, 145 `def test_`) is the gate, and
`date-test-compare-enrollment` is unblocked. No C-extractor story is filed.
Written up in the RFC README and in `vendor/sources.ts` next to the flags.

No package scaffold, no file moves.

### Tests

`abstract-mysql-adapter.full-version.trails.test.ts` is new and **fails on
baseline** (`?? ""` returns `""` where the test expects `null`). Story 1 gets no
new test on purpose: the fast arms are value-identical to the third arm — that
is the point of the differential — so no assertion could distinguish them.

### Gates

`pnpm build`, `pnpm lint`, `api:extra` (activerecord/i18n — nothing new; the
slot's exports are `@internal`) clean. `pnpm api:calls` reports 2 NEW rows, both
in `activesupport/json/encoding.ts` from #6134 — untouched here, already tracked
as red main by #6137.

Closes-story: date-yday-drops-m-yday-fast-arms
Closes-story: date-c-source-extractor-decision
Closes-story: encryption-readers-name-configurable-not-free-functions
Closes-story: mysql-full-version-empty-string-fallback-for-nullable-version-string
