### PR TITLE
feat(activerecord,ci): schema_creation allocates per call, PG tasks read db_config, extra-surface gates run in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1298,19 +1298,11 @@ jobs:
       - name: API comparison (privates)
         run: pnpm exec tsx scripts/api-compare/compare.ts --privates
       - name: Extra-surface tag gates
-        # RFC 0072. extra-surface.ts implements three hard gates — a STALE
-        # `@noRailsEquivalent` (tag on a name that no longer flags), a reason
-        # stating neither PERMANENT nor CONVERGEABLE, and a refused file-level
-        # tag (Rails counterpart exists, or a name in the file scores `moved`) —
-        # and exits non-zero on any of them. Until this step, nothing in CI
-        # invoked it, so all three were a lint you had to remember to run: a PR
-        # could delete a Rails method, leave behind the tag that excused its TS
-        # counterpart, and go green. Rides this job because the gates read the
-        # api-compare manifests the API comparison step above already wrote —
-        # no extra build.
-        #
-        # No --exclude-glob here: an exclusion disarms the stale gate (see
-        # main()), which is the gate with the most to say.
+        # RFC 0072. Fails on a STALE `@noRailsEquivalent` (tag on a name that no
+        # longer flags), a reason stating neither PERMANENT nor CONVERGEABLE, or
+        # a refused file-level tag. Rides this job because the gates read the
+        # api-compare manifests the step above already wrote. No --exclude-glob:
+        # an exclusion disarms the stale gate (see extra-surface.ts `main()`).
         run: pnpm exec tsx scripts/api-compare/extra-surface.ts
       - name: Arity excludes gate
         # Fails on a malformed or STALE entry in

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1297,6 +1297,21 @@ jobs:
         run: pnpm exec tsx scripts/api-compare/extract-ts-api.ts && pnpm exec tsx scripts/api-compare/compare.ts
       - name: API comparison (privates)
         run: pnpm exec tsx scripts/api-compare/compare.ts --privates
+      - name: Extra-surface tag gates
+        # RFC 0072. extra-surface.ts implements three hard gates — a STALE
+        # `@noRailsEquivalent` (tag on a name that no longer flags), a reason
+        # stating neither PERMANENT nor CONVERGEABLE, and a refused file-level
+        # tag (Rails counterpart exists, or a name in the file scores `moved`) —
+        # and exits non-zero on any of them. Until this step, nothing in CI
+        # invoked it, so all three were a lint you had to remember to run: a PR
+        # could delete a Rails method, leave behind the tag that excused its TS
+        # counterpart, and go green. Rides this job because the gates read the
+        # api-compare manifests the API comparison step above already wrote —
+        # no extra build.
+        #
+        # No --exclude-glob here: an exclusion disarms the stale gate (see
+        # main()), which is the gate with the most to say.
+        run: pnpm exec tsx scripts/api-compare/extra-surface.ts
       - name: Arity excludes gate
         # Fails on a malformed or STALE entry in
         # scripts/api-compare/arity-exclude.json (the reasoned suppression file

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -36,11 +36,9 @@ type CreateTableOptions = Extract<CreateTableArgs[1], { options?: string }>;
  * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements (partial)
  */
 export class MysqlSchemaStatements extends BaseSchemaStatements {
-  private _mysqlSchemaCreation?: MysqlSchemaCreation;
+  /** Mirrors: MySQL::SchemaStatements#schema_creation */
   override get schemaCreation(): MysqlSchemaCreation {
-    return (this._mysqlSchemaCreation ??= new MysqlSchemaCreation(
-      this as unknown as VisitorHostAdapter,
-    ));
+    return new MysqlSchemaCreation(this as unknown as VisitorHostAdapter);
   }
 
   /** Mirrors: MySQL::SchemaStatements#update_table_definition */

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -211,8 +211,9 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     return "sqlite";
   }
 
+  /** Mirrors: SQLite3::SchemaStatements#schema_creation */
   get schemaCreation(): SQLite3SchemaCreation {
-    return (this._sqlite3SchemaCreation ??= new SQLite3SchemaCreation("sqlite", this));
+    return new SQLite3SchemaCreation("sqlite", this);
   }
 
   /** @internal */
@@ -305,7 +306,6 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   }
 
   private _inTransaction = false;
-  private _sqlite3SchemaCreation?: SQLite3SchemaCreation;
   private _readonly: boolean;
   private _strict: boolean;
   /** @internal Rails' `@last_affected_rows`; read by the affected_rows port. */

--- a/packages/activerecord/src/support/stubbed-ddl-methods.test.ts
+++ b/packages/activerecord/src/support/stubbed-ddl-methods.test.ts
@@ -49,7 +49,6 @@ const NON_EMITTING: ReadonlyMap<string, string> = new Map([
   ["_statementPool", "prepared-statement slot clearCacheBang resets, not a DDL emitter"],
   ["_schemaCache", "memoized backing slot of the schemaCache read"],
   ["_poolSchemaReflection", "pool reflection the schemaCache read binds to"],
-  ["_sqlite3SchemaCreation", "memoized backing slot of the schemaCreation renderer"],
   ["quoteColumnName", "renderer input — quotes a name into DDL the renderer is already building"],
   ["quoteTableName", "renderer input — quotes a table name into DDL, emits nothing itself"],
   ["quoteDefaultExpression", "renderer input — renders a column default, emits nothing itself"],

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import { PostgreSQLDatabaseTasks, normalizeSchemaSearchPath } from "./postgresql-database-tasks.js";
 import { DatabaseTasks } from "./database-tasks.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
+import { UrlConfig } from "../database-configurations/url-config.js";
 import { DatabaseAlreadyExists } from "../errors.js";
 
 function config(overrides: Record<string, unknown> = {}): HashConfig {
@@ -176,6 +177,50 @@ describe("PostgreSQLDatabaseTasks", () => {
 
     expect(establishCalls).toHaveLength(1);
     expect(establishCalls[0]).toMatchObject({ database: "postgres", schemaSearchPath: "public" });
+  });
+
+  it("test_creates_database_with_url_only_configuration", async () => {
+    // UrlConfig resolves the URL into configuration_hash (url_config.rb:35-42),
+    // so the task reads db_config.database like every other config shape.
+    const establishCalls: Array<Record<string, unknown> | undefined> = [];
+    const createDatabase = vi.fn(async () => {});
+    const tasks = new PostgreSQLDatabaseTasks(
+      new UrlConfig("development", "primary", "postgres://someone:secret@localhost:5433/url_db"),
+    );
+    vi.spyOn(
+      tasks as unknown as { connection(): Promise<unknown> },
+      "connection",
+    ).mockResolvedValue({ createDatabase });
+    vi.spyOn(
+      tasks as unknown as { establishConnection(c?: Record<string, unknown>): Promise<void> },
+      "establishConnection",
+    ).mockImplementation(async (c?: Record<string, unknown>) => {
+      establishCalls.push(c);
+    });
+
+    await tasks.create();
+
+    expect(createDatabase).toHaveBeenCalledWith(
+      "url_db",
+      expect.objectContaining({ host: "localhost", port: 5433, encoding: "utf8" }),
+    );
+    expect(establishCalls[0]).toMatchObject({ database: "postgres", schemaSearchPath: "public" });
+  });
+
+  it("test_psql_env_reads_the_configuration_hash_for_a_url_config", () => {
+    const tasks = new PostgreSQLDatabaseTasks(
+      new UrlConfig(
+        "development",
+        "primary",
+        "postgres://someone:secret@localhost:5433/url_db?sslmode=require",
+      ),
+    );
+    const env = (tasks as unknown as { psqlEnv(): Record<string, string> }).psqlEnv();
+    expect(env.PGHOST).toBe("localhost");
+    expect(env.PGPORT).toBe("5433");
+    expect(env.PGUSER).toBe("someone");
+    expect(env.PGPASSWORD).toBe("secret");
+    expect(env.PGSSLMODE).toBe("require");
   });
 
   describe("structureDump schema filtering", () => {

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.test.ts
@@ -179,9 +179,7 @@ describe("PostgreSQLDatabaseTasks", () => {
     expect(establishCalls[0]).toMatchObject({ database: "postgres", schemaSearchPath: "public" });
   });
 
-  it("test_creates_database_with_url_only_configuration", async () => {
-    // UrlConfig resolves the URL into configuration_hash (url_config.rb:35-42),
-    // so the task reads db_config.database like every other config shape.
+  it("create names db_config.database on a url-only configuration", async () => {
     const establishCalls: Array<Record<string, unknown> | undefined> = [];
     const createDatabase = vi.fn(async () => {});
     const tasks = new PostgreSQLDatabaseTasks(
@@ -207,7 +205,7 @@ describe("PostgreSQLDatabaseTasks", () => {
     expect(establishCalls[0]).toMatchObject({ database: "postgres", schemaSearchPath: "public" });
   });
 
-  it("test_psql_env_reads_the_configuration_hash_for_a_url_config", () => {
+  it("psqlEnv reads the configuration hash on a url-only configuration", () => {
     const tasks = new PostgreSQLDatabaseTasks(
       new UrlConfig(
         "development",

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.ts
@@ -47,8 +47,6 @@ export class PostgreSQLDatabaseTasks {
       await this.establishConnection(this.publicSchemaConfig());
     }
     const conn = await this.connection();
-    // Rails names `db_config.database` unguarded (postgresql_database_tasks.rb:22);
-    // a config with no database lets the adapter raise, as it does in Ruby.
     await conn.createDatabase(this.dbConfig.database as string, {
       ...this.configurationHash,
       encoding: this.encoding(),
@@ -230,22 +228,14 @@ export class PostgreSQLDatabaseTasks {
       ...((globalThis as { process?: { env?: NodeJS.ProcessEnv } }).process?.env ?? {}),
     };
     const c = this.configurationHash;
-    const host = this.dbConfig.host;
-    const port = c.port;
-    const password = c.password;
-    const username = c.username;
-    if (host) env.PGHOST = String(host);
-    if (port !== undefined) env.PGPORT = String(port);
-    if (password !== undefined) env.PGPASSWORD = String(password);
-    if (username !== undefined) env.PGUSER = String(username);
-    const sslmode = c.sslmode;
-    const sslcert = c.sslcert;
-    const sslkey = c.sslkey;
-    const sslrootcert = c.sslrootcert;
-    if (sslmode !== undefined) env.PGSSLMODE = String(sslmode);
-    if (sslcert !== undefined) env.PGSSLCERT = String(sslcert);
-    if (sslkey !== undefined) env.PGSSLKEY = String(sslkey);
-    if (sslrootcert !== undefined) env.PGSSLROOTCERT = String(sslrootcert);
+    if (this.dbConfig.host) env.PGHOST = String(this.dbConfig.host);
+    if (c.port != null) env.PGPORT = String(c.port);
+    if (c.password != null) env.PGPASSWORD = String(c.password);
+    if (c.username != null) env.PGUSER = String(c.username);
+    if (c.sslmode != null) env.PGSSLMODE = String(c.sslmode);
+    if (c.sslcert != null) env.PGSSLCERT = String(c.sslcert);
+    if (c.sslkey != null) env.PGSSLKEY = String(c.sslkey);
+    if (c.sslrootcert != null) env.PGSSLROOTCERT = String(c.sslrootcert);
     return env;
   }
 

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.ts
@@ -29,43 +29,9 @@ const SQL_COMMENT_BEGIN = "--";
 
 type ConfigHash = Record<string, unknown>;
 
-interface UrlParts {
-  host?: string;
-  port?: string;
-  username?: string;
-  password?: string;
-  database?: string;
-  sslmode?: string;
-  sslcert?: string;
-  sslkey?: string;
-  sslrootcert?: string;
-}
-
-function parseDbUrl(url: string | undefined): UrlParts {
-  if (!url) return {};
-  try {
-    const parsed = new URL(url);
-    const database = decodeURIComponent(parsed.pathname.replace(/^\/+/, ""));
-    return {
-      host: parsed.hostname || undefined,
-      port: parsed.port || undefined,
-      username: parsed.username ? decodeURIComponent(parsed.username) : undefined,
-      password: parsed.password ? decodeURIComponent(parsed.password) : undefined,
-      database: database || undefined,
-      sslmode: parsed.searchParams.get("sslmode") ?? undefined,
-      sslcert: parsed.searchParams.get("sslcert") ?? undefined,
-      sslkey: parsed.searchParams.get("sslkey") ?? undefined,
-      sslrootcert: parsed.searchParams.get("sslrootcert") ?? undefined,
-    };
-  } catch {
-    return {};
-  }
-}
-
 export class PostgreSQLDatabaseTasks {
   private readonly dbConfig: DatabaseConfig;
   private readonly configurationHash: ConfigHash;
-  private readonly urlParts: UrlParts;
 
   static usingDatabaseConfigurations(): boolean {
     return true;
@@ -74,7 +40,6 @@ export class PostgreSQLDatabaseTasks {
   constructor(dbConfig: DatabaseConfig) {
     this.dbConfig = dbConfig;
     this.configurationHash = { ...dbConfig.configuration };
-    this.urlParts = parseDbUrl(this.configurationHash.url as string | undefined);
   }
 
   async create(connectionAlreadyEstablished = false): Promise<void> {
@@ -82,7 +47,9 @@ export class PostgreSQLDatabaseTasks {
       await this.establishConnection(this.publicSchemaConfig());
     }
     const conn = await this.connection();
-    await conn.createDatabase(this.requireDatabaseName(), {
+    // Rails names `db_config.database` unguarded (postgresql_database_tasks.rb:22);
+    // a config with no database lets the adapter raise, as it does in Ruby.
+    await conn.createDatabase(this.dbConfig.database as string, {
       ...this.configurationHash,
       encoding: this.encoding(),
     });
@@ -92,7 +59,7 @@ export class PostgreSQLDatabaseTasks {
   async drop(): Promise<void> {
     await this.establishConnection(this.publicSchemaConfig());
     const conn = await this.connection();
-    await conn.dropDatabase(this.requireDatabaseName());
+    await conn.dropDatabase(this.dbConfig.database as string);
   }
 
   async charset(): Promise<string> {
@@ -117,7 +84,7 @@ export class PostgreSQLDatabaseTasks {
       "--no-owner",
       "--file",
       filename,
-      `--dbname=${this.requireDatabaseName()}`,
+      `--dbname=${this.dbConfig.database}`,
     ];
     if (extraFlags) {
       args.push(...(Array.isArray(extraFlags) ? extraFlags : [extraFlags]));
@@ -187,7 +154,7 @@ export class PostgreSQLDatabaseTasks {
       nullDevice,
       "--file",
       filename,
-      `--dbname=${this.requireDatabaseName()}`,
+      `--dbname=${this.dbConfig.database}`,
     ];
     if (extraFlags) {
       args.push(...(Array.isArray(extraFlags) ? extraFlags : [extraFlags]));
@@ -209,7 +176,7 @@ export class PostgreSQLDatabaseTasks {
       : new PostgreSQLAdapter({
           host: (c.host as string) ?? "localhost",
           port: coercePort(c.port, 5432),
-          database: this.requireDatabaseName(),
+          database: this.dbConfig.database,
           user: c.username as string | undefined,
           password: c.password as string | undefined,
         });
@@ -263,18 +230,18 @@ export class PostgreSQLDatabaseTasks {
       ...((globalThis as { process?: { env?: NodeJS.ProcessEnv } }).process?.env ?? {}),
     };
     const c = this.configurationHash;
-    const host = this.dbConfig.host ?? this.urlParts.host;
-    const port = c.port ?? this.urlParts.port;
-    const password = c.password ?? this.urlParts.password;
-    const username = c.username ?? this.urlParts.username;
+    const host = this.dbConfig.host;
+    const port = c.port;
+    const password = c.password;
+    const username = c.username;
     if (host) env.PGHOST = String(host);
     if (port !== undefined) env.PGPORT = String(port);
     if (password !== undefined) env.PGPASSWORD = String(password);
     if (username !== undefined) env.PGUSER = String(username);
-    const sslmode = c.sslmode ?? this.urlParts.sslmode;
-    const sslcert = c.sslcert ?? this.urlParts.sslcert;
-    const sslkey = c.sslkey ?? this.urlParts.sslkey;
-    const sslrootcert = c.sslrootcert ?? this.urlParts.sslrootcert;
+    const sslmode = c.sslmode;
+    const sslcert = c.sslcert;
+    const sslkey = c.sslkey;
+    const sslrootcert = c.sslrootcert;
     if (sslmode !== undefined) env.PGSSLMODE = String(sslmode);
     if (sslcert !== undefined) env.PGSSLCERT = String(sslcert);
     if (sslkey !== undefined) env.PGSSLKEY = String(sslkey);
@@ -319,12 +286,6 @@ export class PostgreSQLDatabaseTasks {
     }
   }
 
-  private requireDatabaseName(): string {
-    const name = this.dbConfig.database ?? this.urlParts.database;
-    if (!name) throw new Error("PostgreSQL configuration missing 'database'");
-    return name;
-  }
-
   /** @internal */
   private async establishConnection(configHash?: Record<string, unknown>): Promise<void> {
     await Base.establishConnection(
@@ -334,18 +295,7 @@ export class PostgreSQLDatabaseTasks {
 
   /** @internal */
   private publicSchemaConfig(): ConfigHash {
-    const c = this.configurationHash;
-    if (c.url) {
-      // Modify the URL to target the postgres system DB and strip `database`
-      // from the spread. buildAdapterArg uses the URL path when `database` is
-      // undefined; if `database` remains in the hash it discards the URL and
-      // builds a host-less config instead.
-      const parsed = new URL(String(c.url));
-      parsed.pathname = "/postgres";
-      const { database: _db, ...rest } = c;
-      return { ...rest, url: parsed.toString(), schemaSearchPath: "public" };
-    }
-    return { ...c, database: "postgres", schemaSearchPath: "public" };
+    return { ...this.configurationHash, database: "postgres", schemaSearchPath: "public" };
   }
 }
 


### PR DESCRIPTION
Bundle of three RFC 0051/0072 stories. A fourth, `extra-surface-has-one-through-persist-classify`, was already satisfied on `main` and is marked done against #5940 rather than shipped here (see below).

## `schema_creation` allocates per call

Rails allocates a fresh `SchemaCreation` on every read:

- `mysql/schema_statements.rb:138-140` — `MySQL::SchemaCreation.new(self)`
- `sqlite3/schema_statements.rb:126-128` — `SQLite3::SchemaCreation.new(self)`

trails memoized both behind `_mysqlSchemaCreation` / `_sqlite3SchemaCreation`. A
cached `SchemaCreation` captures the adapter it was built with, so it outlives
changes Rails would pick up on the next call. Both memo fields are gone; the
getters now return `new …SchemaCreation(this)`.

The sibling arms were checked as the story asked: the abstract
(`abstract/schema_statements.rb:1551`) and PG (`postgresql/schema_statements.rb:953`)
ports already allocate per call — no change needed there.

`stubbed-ddl-methods.test.ts` loses its `_sqlite3SchemaCreation` exemption row;
that guard fails on stale entries, so the row had to go with the field.

## `PostgreSQLDatabaseTasks` reads `db_config` / `configuration_hash`

Rails names `db_config.database` and `configuration_hash[...]` directly
(`postgresql_database_tasks.rb:22,27,47,60,73,102-104`) because
`DatabaseConfigurations` has already resolved the URL into the configuration hash
— `UrlConfig#initialize` merges `build_url_hash` in (`url_config.rb:35-42`).

trails' `UrlConfig` **already does that merge** (`url-config.ts:21-23`, via
`ConnectionUrlResolver#toHash`, which also folds query params such as `sslmode`
into the hash), so this story is pure deletion in the task:

- `parseDbUrl`, the `UrlParts` interface, the `urlParts` field and
  `requireDatabaseName` are deleted.
- All nine former `requireDatabaseName()` / `urlParts.*` call sites (create,
  drop, the `pg_dump`/`psql` `--dbname=`, `truncateAll`, `psqlEnv`) read
  `dbConfig.database` / `configurationHash[...]`.
- `publicSchemaConfig` collapses to the single
  `{ ...configurationHash, database: "postgres", schemaSearchPath: "public" }`
  of `postgresql_database_tasks.rb:102-104`; the URL-rewriting arm existed only
  because the URL had never been resolved into the hash.
- The bespoke `Error("PostgreSQL configuration missing 'database'")` is gone —
  Rails passes `nil` through and lets the adapter raise.

`psqlEnv` also loses its four `?? this.urlParts.*` fallbacks and its
pass-through locals, converging on the direct chain of
`postgresql_database_tasks.rb:105-114`. The guards are `!= null` rather than
`!== undefined`, matching Ruby's `if configuration_hash[:port]` truthiness.

Two new tests drive the task from a `url:`-only config
(`postgres://someone:secret@localhost:5433/url_db?sslmode=require`): one asserts
`createDatabase` is called with `"url_db"` and the resolved host/port, one that
`psqlEnv` picks `PGHOST`/`PGPORT`/`PGUSER`/`PGPASSWORD`/`PGSSLMODE` out of the
configuration hash. They carry prose names, not `test_*` ones: Rails'
`postgresql_rake_test.rb` is not in the vendored tree and neither case has a
Rails counterpart to name after, so a `test_*` name would be a false match for
`test:compare`. They run on the PG lane (`ARCONN=postgresql`), which is where CI
exercises this file.

The two `as string` casts on `dbConfig.database` are typing only, not behaviour:
`DatabaseConfig#database` is `string | undefined` and the adapter's
`createDatabase`/`dropDatabase` are typed `string`. Rails passes the value
unguarded and lets the adapter raise; the cast preserves exactly that, and
widening the two adapter signatures is out of this story's scope.

`api:extra` for `tasks/postgresql-database-tasks.ts`: **4 novel → 1** (the
remaining one is the pre-existing `normalizeSchemaSearchPath`).

## Extra-surface tag gates now run in CI

`grep -rn "api:extra\|extra-surface" .github/` returned nothing: all three gates
`extra-surface.ts` implements — `gateStale`, `gateUnclassified`,
`gateFileTagRejections` — were advisory, enforced only when someone remembered to
run the script. A PR could delete a Rails method, leave behind the
`@noRailsEquivalent` that excused its TS counterpart, and go green.

The new **Extra-surface tag gates** step rides the existing
`Rails API/Test Comparison` job, immediately after `API comparison`. That job
already runs `pnpm build` and writes the api-compare manifests the gates read, so
the added wall-clock cost is one `tsx` invocation over two JSON files — no extra
build. No `--exclude-glob` is passed, so the stale gate stays armed (per the
reasoning in `main()`: an exclusion can hide a tag but never invent one).

**Gate demonstrated, not assumed.** Adding a deliberately stale
`@noRailsEquivalent PERMANENT` to `DatabaseTasks.registerTask` (a name that does
not flag) and rebuilding:

```
$ pnpm exec tsx scripts/api-compare/extra-surface.ts; echo $?
extra-surface: 1 STALE @noRailsEquivalent tag(s) on methods that no longer flag …
  - activerecord  tasks/database-tasks.ts  registerTask
1
```

The probe was reverted; the gate is green on this branch.

## `extra-surface-has-one-through-persist-classify` — already done on `main`

The story's premise no longer holds:

- `persistThroughRecord` does not exist anywhere in the tree.
- `persistReplace` carries a `@noRailsEquivalent PERMANENT` tag whose reason is
  the ratifiable class — Rails does this DB work inline in the *synchronous*
  `create_through_record`, reached from `replace` / `build_#{name}` /
  `create_#{name}`, which in JS cannot `await`; the in-memory half **is** ported
  under the Rails name (`createThroughRecord`).

`pnpm api:extra --package activerecord --novel-only` reports **no** entry for
`associations/has-one-through-association.ts` — 0 novel. `git log -S` traces both
to #5940. Marked done against that PR rather than re-litigated here.

## Verification

- `pnpm build`, `pnpm api:compare`, `pnpm typecheck` clean.
- `pnpm api:calls`: `OK (2172 baselined, 1976 unreviewed)` — no new rows, none deleted.
- `pnpm exec tsx scripts/api-compare/extra-surface.ts`: exit 0.
- `pnpm vitest run` on `stubbed-ddl-methods`, `abstract-mysql-adapter`,
  `mysql/schema-creation`, `sqlite-adapter`: 145 passed.
- The PG task tests need a live PG; they run on the CI PG lane.

Closes-story: mysql-schema-creation-memoizes-where-rails-allocates
Closes-story: extra-surface-has-one-through-persist-classify
Closes-story: pg-database-tasks-reads-db-config-not-a-hand-parsed-url
Closes-story: run-extra-surface-gates-in-ci
