### PR TITLE
fix(ci): declare @blazetrails/date in guides-typecheck workspace deps

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -426,6 +426,9 @@ importers:
       '@blazetrails/arel':
         specifier: workspace:*
         version: link:../../packages/arel
+      '@blazetrails/date':
+        specifier: workspace:*
+        version: link:../../packages/date
       '@blazetrails/did-you-mean':
         specifier: workspace:*
         version: link:../../packages/did-you-mean

--- a/scripts/guides-typecheck/package.json
+++ b/scripts/guides-typecheck/package.json
@@ -10,6 +10,7 @@
     "@blazetrails/activerecord-cli": "workspace:*",
     "@blazetrails/activesupport": "workspace:*",
     "@blazetrails/arel": "workspace:*",
+    "@blazetrails/date": "workspace:*",
     "@blazetrails/rack": "workspace:*",
     "@blazetrails/actionpack": "workspace:*",
     "@blazetrails/actionview": "workspace:*",


### PR DESCRIPTION
Guides Code Type Check went red on main @6a7f1152: `validatePackageCoverage` in `scripts/guides-typecheck/check.ts` requires every non-website `@blazetrails/*` package to be declared as a workspace dep, and the new `packages/date` (added in #6139) was not. Same fix shape as #5976 did for i18n.

`pnpm guides:typecheck` now passes: 17 blocks from 5 guides, all clean.

Closes-story: red-6a7f1152