### PR TITLE
feat(activerecord,scripts): MySQL banner off the handshake, has_one loses its property setter, token renames derive their regex

### DIFF
--- a/packages/activerecord/src/associations/builder/has-one.ts
+++ b/packages/activerecord/src/associations/builder/has-one.ts
@@ -95,9 +95,11 @@ export class HasOne extends SingularAssociation {
     // `rubyMethodToTs` offers `set#{Name}` as a candidate for `name=`
     // (scripts/api-compare/conventions.ts).
     //
-    // Generated here — beside the `=` setter below, unconditionally (including
-    // polymorphic has_one) — rather than in `defineConstructors`, which Rails
-    // skips for polymorphic; the writer must exist wherever `=` does. A thin
+    // Generated unconditionally (including polymorphic has_one) rather than in
+    // `defineConstructors`, which Rails skips for polymorphic; the writer must
+    // exist for every has_one. It is the ONLY writer: RFC 0087 §1 removed the
+    // generated `#{name}=` property setter, so assigning the property now fails
+    // as a plain JS write to a getter-only accessor. A thin
     // delegation to the association-level `writer`, whose has_one /
     // has_one_through overrides run the Rails-faithful immediate replace/persist
     // and whose returned promise rejects (`RecordNotSaved`) at the call site.
@@ -114,29 +116,6 @@ export class HasOne extends SingularAssociation {
         configurable: true,
       });
     }
-    const existing = Object.getOwnPropertyDescriptor(mixin, name);
-    if (existing && !existing.configurable) return;
-    Object.defineProperty(mixin, name, {
-      get: existing?.get,
-      // The synchronous path, supported alongside `set${cap}` — Rails defines
-      // `#{name}=`, so this stays. It is fully faithful on the branch where
-      // Rails does no I/O either: an *unpersisted* owner, where Rails'
-      // assignment is in-memory too, so `syncWrite` sets the FK/inverse and
-      // lets autosave persist at the owner's first `save()`.
-      //
-      // On a *persisted* owner Rails persists the displacement inline, which
-      // needs `await` — unreachable from a JS property setter. `syncWrite`
-      // therefore throws `HasOnePersistedAssignmentError`, a deliberate
-      // DEVIATION (Rails raises nothing there): the alternative is accepting
-      // the assignment and silently skipping the write, so the throw is a guard
-      // against data loss, not a deprecation. Persisted-owner callers use
-      // `await owner.set#{Name}(value)` (the `set${cap}` port above) or
-      // `await record.association(name).writer(value)` (RFC 0068).
-      set(this: { association(n: string): { syncWrite(v: unknown): void } }, value: unknown) {
-        this.association(name).syncWrite(value);
-      },
-      configurable: true,
-    });
   }
 
   static override validDependentOptions(): string[] {

--- a/packages/activerecord/src/associations/errors.ts
+++ b/packages/activerecord/src/associations/errors.ts
@@ -405,8 +405,11 @@ export class NestedAttributesDisplacementError extends ActiveRecordError {
 }
 
 /**
- * Thrown when a `has_one` association is assigned with the native `=` setter
- * (or a mass-assignment key) on a *persisted* owner. This is a deliberate
+ * Thrown when a `has_one` association is assigned by mass assignment —
+ * `owner.assignAttributes({ account: x })`, `new Owner({ account: x })` — on a
+ * *persisted* owner. (RFC 0087 §1 removed the native `=` setter that also
+ * raised this; the mass-assignment arm is retired by that RFC's
+ * `retire-sync-association-mass-assignment-arms`.) This is a deliberate
  * trails-only deviation with no Rails counterpart: Rails'
  * `HasOneAssociation#replace` persists the displacement + new record inline at
  * assignment, which is synchronous DB I/O JS cannot do from a property setter.
@@ -421,7 +424,7 @@ export class HasOnePersistedAssignmentError extends ActiveRecordError {
   constructor(association: string) {
     const cap = association.charAt(0).toUpperCase() + association.slice(1);
     super(
-      `Cannot assign has_one association \`${association}\` with \`=\` on a ` +
+      `Cannot assign has_one association \`${association}\` by mass assignment on a ` +
         `persisted record: Rails persists the replacement at assignment time, ` +
         `which requires \`await\` in JS. Use \`await owner.set${cap}(x)\` (or ` +
         `\`await owner.association("${association}").writer(x)\`).`,

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -26,8 +26,11 @@ export class HasOneAssociation extends SingularAssociation {
   }
 
   /**
-   * Writer for the JS property setter (`owner.account = x`, builder/has-one.ts
-   * `defineWriters`) and mass-assignment, neither of which can `await`.
+   * Writer for mass-assignment (`new Firm({ account })`,
+   * `firm.assignAttributes({ account })`), which cannot `await`. RFC 0087 §1
+   * removed the `owner.account = x` property setter that was its other caller;
+   * the mass-assignment arm itself goes in that RFC's
+   * `retire-sync-association-mass-assignment-arms`, and this method with it.
    *
    * - **Unpersisted owner:** in-memory `replace` (FK + inverse set), exactly as
    *   Rails' `replace` does no I/O for a new-record owner (`save &&=
@@ -41,10 +44,10 @@ export class HasOneAssociation extends SingularAssociation {
    *   0068-awaitable-has-one-setter ("Why 'loud' beats 'deferred'") for the
    *   ergonomic-tradeoff decision to deviate loudly from Rails' legal syntax.
    *
-   * `protected`: the generated `#{name}=` property setter (builder/has-one.ts
-   * `defineWriters`) is the sole caller, and it reaches the association through
-   * a structural handle rather than the class type. The Rails-named surface is
-   * `writer` / `set#{Name}`.
+   * `protected`: its callers (`attribute-assignment.ts`'s hasOne arm, and the
+   * through-inverse wiring in collection-proxy.ts / has-many-through-association.ts)
+   * reach the association through a structural handle rather than the class
+   * type. The Rails-named surface is `writer` / `set#{Name}`.
    *
    * @internal
    */
@@ -73,8 +76,7 @@ export class HasOneAssociation extends SingularAssociation {
    * a *saved* owner: the displaced record is nullified/deleted/destroyed and
    * the new record saved immediately. Returns a Promise so callers can `await`
    * the writes — the only floating-promise-free way to reach the immediate path
-   * from JS (the sync property setter cannot await, so it uses `syncWrite`
-   * instead). For a *new* owner the foreign key isn't known yet, so persistence
+   * from JS (mass-assignment cannot await, so it uses `syncWrite` instead). For a *new* owner the foreign key isn't known yet, so persistence
    * defers to the owner's next save (`autosaveHasOne`).
    */
   override writer(record: Base | null): void | Promise<void> {

--- a/packages/activerecord/src/associations/has-one-persisted-setter-throws.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-persisted-setter-throws.trails.test.ts
@@ -1,11 +1,13 @@
 /**
- * Trails-only: the native `=` has_one setter (and the mass-assignment hasOne
- * arm) deviates from Rails on a *persisted* owner. Rails' `HasOneAssociation#replace`
+ * Trails-only: the mass-assignment hasOne arm deviates from Rails on a
+ * *persisted* owner. (RFC 0087 §1 removed the native `=` property setter that
+ * shared the deviation; `set#{Name}` is the writer now.)
+ * Rails' `HasOneAssociation#replace`
  * (vendor/rails/activerecord/lib/active_record/associations/has_one_association.rb:59-84)
  * persists the displacement + new record inline at assignment — synchronous DB
  * I/O JS cannot do from a property setter. Rather than silently deferring the
  * writes to the owner's next `save()` (the order-undefined two-row race
- * RFC 0068 exists to kill), the setter THROWS and names the awaitable
+ * RFC 0068 exists to kill), the assignment THROWS and names the awaitable
  * replacement (`await owner.set#{Name}(x)`). On an *unpersisted* owner Rails
  * does no I/O either, so the in-memory replace is faithful and kept. There is
  * no Rails test for this deviation.
@@ -40,30 +42,47 @@ describe("HasOnePersistedSetterThrows", () => {
     registerModel(Club);
   });
 
-  it("native = setter throws on a persisted owner", async () => {
+  it("set#{Name} persists the replacement on a persisted owner", async () => {
+    // The awaitable writer the deviation names: it reaches
+    // `HasOneAssociation#writer` → Rails' inline replace/persist.
+    const firm = (await Firm.create({ name: "GlobalMegaCorp" })) as unknown as HasOneOwner;
+    const account = await Account.create({ credit_limit: 1000 });
+    await firm.setAccount(account);
+    expect((account as unknown as { firm_id: number }).firm_id).toBe(
+      Number((firm as unknown as { id: unknown }).id),
+    );
+  });
+
+  it("assigning the property is a plain JS write to a getter-only accessor", async () => {
+    // RFC 0087 §1: no `#{name}=` setter is generated, so the write fails as an
+    // ordinary strict-mode assignment rather than routing anywhere.
     const firm = (await Firm.create({ name: "GlobalMegaCorp" })) as unknown as HasOneOwner;
     const account = await Account.create({ credit_limit: 1000 });
     expect(() => {
       firm.account = account;
-    }).toThrow(HasOnePersistedAssignmentError);
+    }).toThrow(TypeError);
   });
 
-  it("native = setter raises the type mismatch before the persisted-owner throw", async () => {
+  it("mass-assignment raises the type mismatch before the persisted-owner throw", async () => {
     // Rails' `replace` raises `AssociationTypeMismatch` as its first line
     // (has_one_association.rb:59-60), before any other work — the sync guard is
     // preserved ahead of the persisted-owner deviation.
     const firm = (await Firm.create({ name: "GlobalMegaCorp" })) as unknown as HasOneOwner;
-    expect(() => {
-      firm.account = 1;
-    }).toThrow(AssociationTypeMismatch);
+    expect(() =>
+      (firm as unknown as { association(n: string): { syncWrite(v: unknown): void } })
+        .association("account")
+        .syncWrite(1),
+    ).toThrow(AssociationTypeMismatch);
   });
 
   it("throw message names the association and the awaitable replacement", async () => {
     const firm = (await Firm.create({ name: "GlobalMegaCorp" })) as unknown as HasOneOwner;
     const account = await Account.create({ credit_limit: 1000 });
     try {
-      firm.account = account;
-      expect.unreachable("expected the persisted setter to throw");
+      (firm as unknown as { association(n: string): { syncWrite(v: unknown): void } })
+        .association("account")
+        .syncWrite(account);
+      expect.unreachable("expected the persisted assignment to throw");
     } catch (e) {
       expect(e).toBeInstanceOf(HasOnePersistedAssignmentError);
       expect((e as Error).message).toContain("`account`");
@@ -82,18 +101,26 @@ describe("HasOnePersistedSetterThrows", () => {
     }).toThrow(/await owner\.setAccount\(x\)/);
   });
 
-  it("update throws on a persisted owner with a hasOne key", async () => {
+  it("update awaits the has_one writer on a persisted owner", async () => {
+    // `#update` is async, so — unlike mass assignment — it reaches Rails'
+    // inline replace/persist (has_one_association.rb:59-84) instead of the
+    // deviation's throw.
     const firm = (await Firm.create({ name: "GlobalMegaCorp" })) as unknown as HasOneOwner;
     const account = await Account.create({ credit_limit: 1000 });
-    await expect(firm.update({ account })).rejects.toThrow(/await owner\.setAccount\(x\)/);
+    await firm.update({ account });
+    expect((account as unknown as { firm_id: number }).firm_id).toBe(
+      Number((firm as unknown as { id: unknown }).id),
+    );
   });
 
-  it("has_one_through native = setter throws on a persisted owner", async () => {
+  it("has_one_through mass-assignment throws HasOnePersistedAssignmentError on a persisted owner", async () => {
     const member = (await Member.create({ name: "Groucho" })) as unknown as HasOneOwner;
     const club = await Club.create({ name: "Moustache" });
-    expect(() => {
-      member.club = club;
-    }).toThrow(HasOnePersistedAssignmentError);
+    expect(() =>
+      (member as unknown as { association(n: string): { syncWrite(v: unknown): void } })
+        .association("club")
+        .syncWrite(club),
+    ).toThrow(HasOnePersistedAssignmentError);
   });
 
   it("has_one_through mass-assignment throws on a persisted owner", async () => {
@@ -104,12 +131,12 @@ describe("HasOnePersistedSetterThrows", () => {
     }).toThrow(/await owner\.setClub\(x\)/);
   });
 
-  it("native = setter does the in-memory replace on an unpersisted owner", async () => {
+  it("mass-assignment does the in-memory replace on an unpersisted owner", async () => {
     const firm = new Firm({ name: "GlobalMegaCorp" });
     const account = new Account({ credit_limit: 1000 });
     const owner = firm as unknown as HasOneOwner;
     expect(() => {
-      owner.account = account;
+      owner.assignAttributes({ account });
     }).not.toThrow();
     await firm.save();
     expect((account as unknown as { firm_id: number }).firm_id).toBe(Number(firm.id));

--- a/packages/activerecord/src/associations/required.test.ts
+++ b/packages/activerecord/src/associations/required.test.ts
@@ -178,7 +178,7 @@ describe("RequiredAssociationsTest", () => {
     expect(await record.save()).toBe(false);
     expect(record.errors.fullMessages).toEqual(["Child must exist"]);
 
-    (record as any).child = new Child();
+    await (record as any).setChild(new Child());
     expect(await record.save()).toBe(true);
   });
 

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1727,7 +1727,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    * `getDatabaseVersion()` only after a subclass has wired this.
    * @internal
    */
-  async getFullVersion(): Promise<string> {
+  async getFullVersion(): Promise<string | null> {
     throw new Error(`${this.constructor.name} must implement getFullVersion()`);
   }
 

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.base-connection-field.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.base-connection-field.trails.test.ts
@@ -18,12 +18,14 @@ describe("Mysql2Adapter base _connection field", () => {
 
   function stubNewClient(): { end: ReturnType<typeof vi.fn> } {
     const end = vi.fn(() => Promise.resolve());
-    // The connect-once configure warms the server version (getFullVersion issues
-    // SELECT VERSION() before checkVersion); hand it a row so the warm resolves.
+    // The connect-once configure warms the server version (getFullVersion reads
+    // the driver's handshake banner before checkVersion); hand it one so the
+    // warm resolves.
     const fakeConn = {
       end,
       ping: () => Promise.resolve(),
-      query: () => Promise.resolve([[{ v: "8.0.28" }]]),
+      _handshakePacket: { serverVersion: "8.0.28" },
+      query: () => Promise.resolve([[]]),
     };
     vi.spyOn(Mysql2Adapter, "newClient").mockResolvedValue(fakeConn as never);
     return { end };

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.base-connection-field.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.base-connection-field.trails.test.ts
@@ -24,7 +24,7 @@ describe("Mysql2Adapter base _connection field", () => {
     const fakeConn = {
       end,
       ping: () => Promise.resolve(),
-      _handshakePacket: { serverVersion: "8.0.28" },
+      connection: { _handshakePacket: { serverVersion: "8.0.28" } },
       query: () => Promise.resolve([[]]),
     };
     vi.spyOn(Mysql2Adapter, "newClient").mockResolvedValue(fakeConn as never);

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.configure-on-connect.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.configure-on-connect.trails.test.ts
@@ -23,9 +23,10 @@ describe("Mysql2Adapter configure-on-fresh-connect", () => {
     const fakeConn = {
       end: () => Promise.resolve(),
       // getFullVersion() (run by the connect-once configure to warm the version
-      // before checkVersion) issues SELECT VERSION(); hand it a row so the warm
-      // resolves offline.
-      query: () => Promise.resolve([[{ v: version }]]),
+      // before checkVersion) reads the driver's handshake banner; hand it one
+      // so the warm resolves offline.
+      _handshakePacket: { serverVersion: version },
+      query: () => Promise.resolve([[]]),
     };
     vi.spyOn(Mysql2Adapter, "newClient").mockResolvedValue(fakeConn as never);
   }

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.configure-on-connect.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.configure-on-connect.trails.test.ts
@@ -25,7 +25,7 @@ describe("Mysql2Adapter configure-on-fresh-connect", () => {
       // getFullVersion() (run by the connect-once configure to warm the version
       // before checkVersion) reads the driver's handshake banner; hand it one
       // so the warm resolves offline.
-      _handshakePacket: { serverVersion: version },
+      connection: { _handshakePacket: { serverVersion: version } },
       query: () => Promise.resolve([[]]),
     };
     vi.spyOn(Mysql2Adapter, "newClient").mockResolvedValue(fakeConn as never);

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.connected-vs-active.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.connected-vs-active.trails.test.ts
@@ -16,7 +16,11 @@ describe("Mysql2Adapter connected? vs active?", () => {
   function stubNewClient(ping: () => Promise<void>): void {
     const fakeConn = {
       end: () => Promise.resolve(),
-      query: () => Promise.resolve([[{ v: "8.0.28" }]]),
+      // The connect-once configure warms the server version off the driver's
+      // handshake banner (getFullVersion) before checkVersion; hand it one so
+      // the warm resolves offline.
+      connection: { _handshakePacket: { serverVersion: "8.0.28" } },
+      query: () => Promise.resolve([[]]),
       ping,
     };
     vi.spyOn(Mysql2Adapter, "newClient").mockResolvedValue(fakeConn as never);

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1744,15 +1744,16 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * node-mysql2 keeps the parsed handshake on `_handshakePacket`
    * (mysql2/lib/base/connection.js:135, `serverVersion` per
    * lib/packets/handshake.js:62), which is the same string the Ruby driver's
-   * `server_info[:version]` reports. A missing banner is passed through, so it
-   * reaches `versionString` and raises there as Rails' nil does.
+   * `server_info[:version]` reports. An absent banner is Ruby's nil: it is
+   * passed through so it reaches `versionString` and raises there, where Rails'
+   * nil does.
    * @internal
    */
-  async getFullVersion(): Promise<string> {
+  override async getFullVersion(): Promise<string | null> {
     const conn = (await this.anyRawConnection()) as unknown as {
       _handshakePacket?: { serverVersion?: string };
-    };
-    return conn?._handshakePacket?.serverVersion as string;
+    } | null;
+    return conn?._handshakePacket?.serverVersion ?? null;
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1739,15 +1739,20 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   /**
    * Mirrors: Mysql2Adapter#get_full_version (mysql2_adapter.rb:168-170). No
    * memo and no side effects: `database_version` is the only memo in the Rails
-   * chain. Rails reads `any_raw_connection.server_info[:version]`; node-mysql2
-   * exposes no `server_info`, so the banner comes from `SELECT VERSION()` —
-   * the same string the server reports there.
+   * chain. Like Rails' `any_raw_connection.server_info[:version]`, the banner
+   * is read off the connection's handshake state rather than queried —
+   * node-mysql2 keeps the parsed handshake on `_handshakePacket`
+   * (mysql2/lib/base/connection.js:135, `serverVersion` per
+   * lib/packets/handshake.js:62), which is the same string the Ruby driver's
+   * `server_info[:version]` reports. A missing banner is passed through, so it
+   * reaches `versionString` and raises there as Rails' nil does.
    * @internal
    */
   async getFullVersion(): Promise<string> {
-    const conn = await this.getConn();
-    const [[row]] = (await conn.query("SELECT VERSION() AS v")) as [Array<{ v: string }>, unknown];
-    return row?.v ?? "0.0.0";
+    const conn = (await this.anyRawConnection()) as unknown as {
+      _handshakePacket?: { serverVersion?: string };
+    };
+    return conn?._handshakePacket?.serverVersion as string;
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1743,17 +1743,21 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * is read off the connection's handshake state rather than queried —
    * node-mysql2 keeps the parsed handshake on `_handshakePacket`
    * (mysql2/lib/base/connection.js:135, `serverVersion` per
-   * lib/packets/handshake.js:62), which is the same string the Ruby driver's
+   * lib/packets/handshake.js:62) of the core connection, which the promise
+   * wrapper we hold delegates to as `.connection`
+   * (mysql2/lib/promise/connection.js:12). It carries the same string the Ruby
+   * driver's
    * `server_info[:version]` reports. An absent banner is Ruby's nil: it is
    * passed through so it reaches `versionString` and raises there, where Rails'
    * nil does.
    * @internal
    */
   override async getFullVersion(): Promise<string | null> {
-    const conn = (await this.anyRawConnection()) as unknown as {
-      _handshakePacket?: { serverVersion?: string };
-    } | null;
-    return conn?._handshakePacket?.serverVersion ?? null;
+    type Handshake = { _handshakePacket?: { serverVersion?: string } };
+    const conn = (await this.anyRawConnection()) as unknown as
+      | (Handshake & { connection?: Handshake })
+      | null;
+    return (conn?.connection ?? conn)?._handshakePacket?.serverVersion ?? null;
   }
 
   /** @internal */

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -685,6 +685,18 @@ function assignUpdateAttribute(self: any, key: string, value: unknown): Promise<
   }
   const collectionWrite = collectionWriterPromise(self, key, value);
   if (collectionWrite) return collectionWrite;
+  // The awaitable has_one writer, for the same reason as `#{name}_attributes=`
+  // above: Rails' `#{name}=` removes the displaced record and saves the new one
+  // inline (has_one_association.rb:59-84), and RFC 0087 §1 removed the property
+  // setter that used to catch this key on the prototype walk below. `#update` is
+  // async, so it awaits what the property setter could not.
+  const hasOne = (
+    self.constructor?._associations as { name: string; type: string }[] | undefined
+  )?.find((a) => a.type === "hasOne" && a.name === key);
+  if (hasOne) {
+    const result: unknown = self.association(key).writer(value);
+    return result instanceof Promise ? result : undefined;
+  }
   // Dispatch through prototype setter for generated writers (e.g. *Ids writers
   // from CollectionAssociation builder). Mirrors Rails' public_send("#{key}=").
   // *Ids writers are async (they query the DB to resolve records); return the

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -685,15 +685,12 @@ function assignUpdateAttribute(self: any, key: string, value: unknown): Promise<
   }
   const collectionWrite = collectionWriterPromise(self, key, value);
   if (collectionWrite) return collectionWrite;
-  // The awaitable has_one writer, for the same reason as `#{name}_attributes=`
-  // above: Rails' `#{name}=` removes the displaced record and saves the new one
-  // inline (has_one_association.rb:59-84), and RFC 0087 §1 removed the property
-  // setter that used to catch this key on the prototype walk below. `#update` is
-  // async, so it awaits what the property setter could not.
-  const hasOne = (
+  // Rails' `#{name}=` removes the displaced record and saves the new one inline
+  // (has_one_association.rb:59-84); `#update` is async, so it awaits that writer.
+  const isHasOne = (
     self.constructor?._associations as { name: string; type: string }[] | undefined
-  )?.find((a) => a.type === "hasOne" && a.name === key);
-  if (hasOne) {
+  )?.some((a) => a.type === "hasOne" && a.name === key);
+  if (isHasOne) {
     const result: unknown = self.association(key).writer(value);
     return result instanceof Promise ? result : undefined;
   }

--- a/scripts/api-compare/conventions.test.ts
+++ b/scripts/api-compare/conventions.test.ts
@@ -18,6 +18,7 @@ import {
   isRubyOnlyClass,
   isScopedSkip,
   ALREADY_PREDICATE_PREFIXES,
+  TOKEN_RENAMES,
   explainConventions,
 } from "./conventions.js";
 
@@ -114,6 +115,20 @@ describe("snakeToCamel", () => {
     expect(snakeToCamel("superb_thing")).toBe("superbThing");
     // `erb` must keep winning the alternation over the shorter `rb`.
     expect(snakeToCamel("compile_erb")).toBe("compileTse");
+  });
+
+  it("honors every TOKEN_RENAMES entry", () => {
+    // The `rb: js` entry was dead code on main until #6043 — the table and the
+    // substitution's alternation were two sources of truth and drifted. The
+    // pattern is derived from the table now; this asserts every key is reachable
+    // so a future entry cannot go unhonored while the generated conventions doc
+    // advertises it as live.
+    for (const [tok, renamed] of Object.entries(TOKEN_RENAMES)) {
+      expect(snakeToCamel(tok)).toBe(renamed);
+      expect(snakeToCamel(`load_${tok}`)).toBe(
+        `load${renamed[0].toUpperCase()}${renamed.slice(1)}`,
+      );
+    }
   });
 });
 

--- a/scripts/api-compare/conventions.ts
+++ b/scripts/api-compare/conventions.ts
@@ -22,7 +22,7 @@ import * as path from "path";
  * `visit_Arel_Nodes_X`. File paths get the equivalent substitution
  * separately in `rubyFileToTs` below.
  */
-const TOKEN_RENAMES: Record<string, string> = {
+export const TOKEN_RENAMES: Record<string, string> = {
   erb: "tse",
   // A Ruby source file is a TypeScript one: I18n::Backend::Base#load_rb
   // (i18n/lib/i18n/backend/base.rb:254) loads a translation file written in
@@ -33,11 +33,24 @@ const TOKEN_RENAMES: Record<string, string> = {
   Erb: "Tse",
 };
 
+/**
+ * Alternation built from `TOKEN_RENAMES` itself, so an entry added to the table
+ * can never be dead code — the regex used to restate the token list and the two
+ * drifted (the `rb` entry sat unreachable on main until #6043 widened the
+ * literal). Longest key first so a longer token beats a shorter one that
+ * suffixes it (`erb` must win over `rb`), and keys are escaped so a future entry
+ * containing a metacharacter cannot corrupt the pattern.
+ */
+const TOKEN_RENAME_PATTERN = new RegExp(
+  `(^|_)(${Object.keys(TOKEN_RENAMES)
+    .sort((a, b) => b.length - a.length || (a < b ? -1 : 1))
+    .map((tok) => tok.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+    .join("|")})(?=_|$|[A-Z])`,
+  "g",
+);
+
 function applyTokenRenames(snake: string): string {
-  return snake.replace(
-    /(^|_)(erb|ERB|Erb|rb)(?=_|$|[A-Z])/g,
-    (_m, pre, tok: string) => pre + TOKEN_RENAMES[tok],
-  );
+  return snake.replace(TOKEN_RENAME_PATTERN, (_m, pre, tok: string) => pre + TOKEN_RENAMES[tok]);
 }
 
 export function snakeToCamel(name: string): string {


### PR DESCRIPTION
Four stories, three of them investigations that end in a finding rather than machinery.

## `Mysql2Adapter#getFullVersion` reads the handshake banner (no query)

Rails is `any_raw_connection.server_info[:version]` — a read off the driver's
connection handshake, not a round-trip
(`mysql2_adapter.rb:168-170`). node-mysql2 **does** expose it: the parsed
handshake is kept on the connection as `_handshakePacket`
(`mysql2/lib/base/connection.js:135`), whose `serverVersion` is read off the
packet at `lib/packets/handshake.js:62`. So the `SELECT VERSION()` round-trip at
connect time is gone, access routes through `anyRawConnection` like Rails, and
the invented `?? "0.0.0"` fallback — which turned a missing banner into a
silently ancient server failing every `supports_*` floor — is dropped, so a
missing banner reaches `versionString` and raises there as Rails' nil does.

The two offline mysql2 tests now hand their fake connection a
`_handshakePacket` instead of a `SELECT VERSION()` row.

## `applyTokenRenames` derives its pattern from `TOKEN_RENAMES`

The table and the regex were two sources of truth for one rule and had drifted
once already (`rb: "js"` was dead code on main until #6043 widened the literal,
while the generated conventions doc advertised it as live). The alternation is
now built from `Object.keys(TOKEN_RENAMES)`, longest-key-first so `erb` still
beats `rb`, with keys regex-escaped. Boundaries are unchanged. A new test
iterates the table and asserts every key is reachable — the guard that would
have caught the drift. `pnpm api:conventions` regenerates with no diff and
api:compare totals are unchanged.

## has_one `#{name}=` property setter deleted (RFC 0087 §1)

Call sites were migrated by `migrate-has-one-assignments-to-awaitable-writer`,
so the `Object.defineProperty(mixin, name, ...)` writer arm in
`HasOneBuilder#defineWriters` is gone. `set#{Name}` is the only writer;
assigning the property is now a plain strict-mode write to a getter-only
accessor.

Two consequences handled:

- `#update` used to catch the has_one key on its prototype-setter walk. It now
  routes the key through the association's awaitable `writer`, alongside the
  `#{name}Attributes=` and `#{singular}Ids` cases already there — which is a
  convergence, not a workaround: `#update` is async, so it reaches Rails' inline
  replace/persist (`has_one_association.rb:59-84`) instead of the deviation's
  throw.
- `syncWrite` and `HasOnePersistedAssignmentError` are **not** deleted here.
  Their sole remaining caller is the mass-assignment arm in
  `attribute-assignment.ts`, which `retire-sync-association-mass-assignment-arms`
  removes — exactly the sequencing the shipped collection sibling
  (`delete-collection-sync-writers`) used, and which that story's own design
  assumes. Their docs and the error message now say mass assignment rather than
  `=`, and the trails-only test file covers `set#{Name}` and the surviving
  mass-assignment arm.

## `@noRailsEquivalent` is file-scoped — guidance, no code

`allowKeyOf` (`scripts/api-compare/extra-surface.ts:403`) keys a tag as
`package tsFile name`, so a `base.ts` mixin echo (`declare static X: typeof
Module.X`) is NOT covered by a tag written in the home file. A rename forces the
`base.ts` edit via `tsc`; a tag does not, and the home-file story closes
believing the name is done. Recorded in the RFC 0072 README with the six echoes
and their home files.

## File-level tag on import-less files — finding, no machinery

One import-less file carries more than one tag: `packages/i18n/src/throw-catch.ts`
(3). It still cannot use a file-level form, for a reason unrelated to imports —
`fileTagVerdict` refuses a blanket over a file with `moved` names, and
`extra-surface` scores `value` and `constructor` as moved there. A
`@fileoverview`-marked spelling was prototyped and reverted: with the sole
candidate refused on other grounds it would be machinery for a hypothetical,
which the story explicitly forbids. Finding recorded on the story.

## Not in this PR

`pg-schema-statements-abstract-signature-divergences` is released, not shipped.
Its acceptance is "converge the abstract/PG signature divergences" across the
~18-name list its context enumerates; that does not fit under this PR's LOC
ceiling and does not belong bolted onto four unrelated stories.

Closes-story: file-level-tag-unavailable-to-import-less-files
Closes-story: mysql2-get-full-version-queries-instead-of-reading-server-info
Closes-story: note-no-rails-equivalent-tag-is-file-scoped-for-mixin-echoes
Closes-story: token-renames-table-and-regex-drift
Closes-story: delete-has-one-sync-property-setter
