### PR TITLE
feat(date,activerecord): packages/date owns date.ts and time.ts, pool.serverVersion is the version memo

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
@@ -24,7 +24,10 @@ import mysql from "mysql2/promise";
 // version is already cached) and after (their stubbed one must not outlive the
 // test). Rails' @connection is likewise long-lived; its stubs re-run the query.
 function clearVersionCache(adapter: Mysql2Adapter): void {
-  (adapter as unknown as { _databaseVersion: unknown })._databaseVersion = null;
+  // The memo is the pool's (`pool_config.rb:39-41`); nil resets it, exactly as
+  // Rails' `@server_version ||=` refetches after `server_version = nil`.
+  (adapter.pool as unknown as { poolConfig: { serverVersion: unknown } }).poolConfig.serverVersion =
+    null;
 }
 
 describeIfMysqlAdapter("Mysql2Adapter", () => {

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
@@ -24,8 +24,6 @@ import mysql from "mysql2/promise";
 // version is already cached) and after (their stubbed one must not outlive the
 // test). Rails' @connection is likewise long-lived; its stubs re-run the query.
 function clearVersionCache(adapter: Mysql2Adapter): void {
-  // The memo is the pool's (`pool_config.rb:39-41`); nil resets it, exactly as
-  // Rails' `@server_version ||=` refetches after `server_version = nil`.
   (adapter.pool as unknown as { poolConfig: { serverVersion: unknown } }).poolConfig.serverVersion =
     null;
 }

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -2201,10 +2201,12 @@ export class AbstractAdapter implements Quoting {
     return new Version("0.0.0");
   }
 
-  // Rails' `database_version` is a sync accessor (`pool.server_version(self)`
-  // caches the result). Overrides may narrow to `Version` or `number`.
+  // Mirrors: AbstractAdapter#database_version (`abstract_adapter.rb:854-856`)
+  // — `pool.server_version(self)`, the pool-level memo that makes every
+  // adapter's `get_database_version` a pure fetch run at most once. Overrides
+  // may narrow to `Version` or `number`.
   get databaseVersion(): Version | number {
-    const v = this.getDatabaseVersion();
+    const v = this.pool.serverVersion(this) as Version | number | Promise<Version | number>;
     if (v instanceof Promise) {
       throw new Error(
         "databaseVersion is only available synchronously after getDatabaseVersion() has resolved; await getDatabaseVersion() first",

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.full-version.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.full-version.trails.test.ts
@@ -15,7 +15,6 @@ import { Version } from "./abstract-adapter.js";
 describe("AbstractMysqlAdapter#full_version", () => {
   function adapterWith(version: Version): Mysql2Adapter {
     const adapter = new Mysql2Adapter({ host: "localhost" });
-    // The version memo lives on the pool; seed the fetch it caches.
     (adapter as unknown as { getDatabaseVersion: () => Version }).getDatabaseVersion = () =>
       version;
     return adapter;

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.full-version.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.full-version.trails.test.ts
@@ -15,7 +15,9 @@ import { Version } from "./abstract-adapter.js";
 describe("AbstractMysqlAdapter#full_version", () => {
   function adapterWith(version: Version): Mysql2Adapter {
     const adapter = new Mysql2Adapter({ host: "localhost" });
-    (adapter as unknown as { _databaseVersion: Version })._databaseVersion = version;
+    // The version memo lives on the pool; seed the fetch it caches.
+    (adapter as unknown as { getDatabaseVersion: () => Version }).getDatabaseVersion = () =>
+      version;
     return adapter;
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
@@ -78,6 +78,9 @@ describe("AbstractMysqlAdapter#renameColumnForAlter fallback", () => {
     const { AbstractMysqlAdapter } = await import("./abstract-mysql-adapter.js");
     const adapter = Object.create(AbstractMysqlAdapter.prototype);
     adapter.supportsRenameColumn = () => supportsRename;
+    // Object.create skips the constructor that plants Rails' NullPool
+    // (abstract_adapter.rb:153); the version warm reads it.
+    adapter.pool = new NullPool();
     adapter.getDatabaseVersion = async () => {};
     adapter.quoteColumnName = (s: string) => `\`${s}\``;
     adapter.columnDefinitions = async (_: string) => [
@@ -807,8 +810,13 @@ describe("AbstractMysqlAdapter#checkVersion", () => {
     const adapter = Object.create(AbstractMysqlAdapter.prototype) as InstanceType<
       typeof AbstractMysqlAdapter
     >;
-    (adapter as unknown as { _databaseVersion: InstanceType<typeof Version> })._databaseVersion =
-      new Version("5.6.3");
+    const { NullPool } = await import("./abstract/connection-pool.js");
+    adapter.pool = new NullPool();
+    // A sync stub stands in for the awaited warm: `checkVersion` reads the
+    // pool memo synchronously (`abstract_adapter.rb:854-856`).
+    (
+      adapter as unknown as { getDatabaseVersion: () => InstanceType<typeof Version> }
+    ).getDatabaseVersion = () => new Version("5.6.3");
     expect(() => adapter.checkVersion()).toThrow(DatabaseVersionError);
     expect(() => adapter.checkVersion()).toThrow(
       "Your version of MySQL (5.6.3) is too old. Active Record supports MySQL >= 5.6.4.",
@@ -821,8 +829,13 @@ describe("AbstractMysqlAdapter#checkVersion", () => {
     const adapter = Object.create(AbstractMysqlAdapter.prototype) as InstanceType<
       typeof AbstractMysqlAdapter
     >;
-    (adapter as unknown as { _databaseVersion: InstanceType<typeof Version> })._databaseVersion =
-      new Version("5.6.4");
+    const { NullPool } = await import("./abstract/connection-pool.js");
+    adapter.pool = new NullPool();
+    // A sync stub stands in for the awaited warm: `checkVersion` reads the
+    // pool memo synchronously (`abstract_adapter.rb:854-856`).
+    (
+      adapter as unknown as { getDatabaseVersion: () => InstanceType<typeof Version> }
+    ).getDatabaseVersion = () => new Version("5.6.4");
     expect(() => adapter.checkVersion()).not.toThrow();
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
@@ -78,8 +78,6 @@ describe("AbstractMysqlAdapter#renameColumnForAlter fallback", () => {
     const { AbstractMysqlAdapter } = await import("./abstract-mysql-adapter.js");
     const adapter = Object.create(AbstractMysqlAdapter.prototype);
     adapter.supportsRenameColumn = () => supportsRename;
-    // Object.create skips the constructor that plants Rails' NullPool
-    // (abstract_adapter.rb:153); the version warm reads it.
     adapter.pool = new NullPool();
     adapter.getDatabaseVersion = async () => {};
     adapter.quoteColumnName = (s: string) => `\`${s}\``;
@@ -812,8 +810,6 @@ describe("AbstractMysqlAdapter#checkVersion", () => {
     >;
     const { NullPool } = await import("./abstract/connection-pool.js");
     adapter.pool = new NullPool();
-    // A sync stub stands in for the awaited warm: `checkVersion` reads the
-    // pool memo synchronously (`abstract_adapter.rb:854-856`).
     (
       adapter as unknown as { getDatabaseVersion: () => InstanceType<typeof Version> }
     ).getDatabaseVersion = () => new Version("5.6.3");
@@ -831,8 +827,6 @@ describe("AbstractMysqlAdapter#checkVersion", () => {
     >;
     const { NullPool } = await import("./abstract/connection-pool.js");
     adapter.pool = new NullPool();
-    // A sync stub stands in for the awaited warm: `checkVersion` reads the
-    // pool memo synchronously (`abstract_adapter.rb:854-856`).
     (
       adapter as unknown as { getDatabaseVersion: () => InstanceType<typeof Version> }
     ).getDatabaseVersion = () => new Version("5.6.4");

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -263,7 +263,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       : super.removeForeignKey(fromTable, toTableOrOptions, opts);
   }
 
-  protected _databaseVersion: Version | null = null;
   /**
    * `database.yml`'s `statement_limit`, which Rails reads as
    * `@config[:statement_limit]` inline at StatementPool construction
@@ -401,18 +400,14 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   }
 
   /**
-   * Sync accessor for the cached database version. Mirrors the PostgreSQLAdapter
-   * pattern: throws a clear error when called before `getDatabaseVersion()` has
-   * been awaited. Overrides AbstractAdapter#databaseVersion which throws whenever
-   * it sees a Promise return from getDatabaseVersion().
+   * Rails has no MySQL override — `AbstractAdapter#database_version` already
+   * answers a `Version` there. TS cannot redeclare an inherited getter's type
+   * without a body, so this narrows the base `Version | number` to the `Version`
+   * every MySQL version gate reads; the value and the pool memo behind it are
+   * the base getter's.
    */
   override get databaseVersion(): Version {
-    if (!this._databaseVersion) {
-      throw new Error(
-        "databaseVersion is not available yet — await getDatabaseVersion() after connecting",
-      );
-    }
-    return this._databaseVersion;
+    return super.databaseVersion as Version;
   }
 
   supportsBulkAlter(): boolean {
@@ -726,7 +721,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
 
   async renameIndex(tableName: string, oldName: string, newName: string): Promise<void> {
     await this.schemaCache.clearDataSourceCacheBang(tableName);
-    await this.getDatabaseVersion();
+    await this.pool.serverVersion(this);
     this.validateIndexLengthBang(tableName, newName);
     if (!this.supportsRenameIndex()) {
       // Mirrors Rails AbstractAdapter#rename_index super path: drop the
@@ -1042,8 +1037,9 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
 
   async checkConstraints(tableName: string): Promise<CheckConstraintDefinition[]> {
     // supportsCheckConstraints() reads the cached databaseVersion, which throws
-    // pre-init; ensure it is loaded first (mirrors the indexes() guard).
-    await this.getDatabaseVersion();
+    // pre-init; ensure the pool memo (`pool_config.rb:39-41`) is loaded first
+    // (mirrors the indexes() guard).
+    await this.pool.serverVersion(this);
     if (!this.supportsCheckConstraints()) {
       // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:545
       throw new NotImplementedError("check constraints are not supported by this database");
@@ -1733,18 +1729,14 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
 
   /**
    * Mirrors: AbstractMysqlAdapter#get_database_version
-   * (abstract_mysql_adapter.rb:86-90). The leading memo guard stands in for
-   * Rails' `AbstractAdapter#database_version` (`pool.server_version(self)`),
-   * which trails' pool does not cache — without it every `databaseVersion` read
-   * would re-query. It also backs the sync `databaseVersion` getter.
+   * (abstract_mysql_adapter.rb:86-90) — a pure derivation. The memo lives on
+   * the pool (`pool_config.rb:39-41`), reached through
+   * `AbstractAdapter#databaseVersion`.
    */
   override async getDatabaseVersion(): Promise<Version> {
-    if (this._databaseVersion) return this._databaseVersion;
     const fullVersionString = await this.getFullVersion();
     const versionString = this.versionString(fullVersionString);
-    const version = new Version(versionString, fullVersionString);
-    this._databaseVersion = version;
-    return version;
+    return new Version(versionString, fullVersionString);
   }
 
   /** @internal */
@@ -1824,8 +1816,8 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   ): Promise<string> {
     // Ensure the version is cached before branching — supportsRenameColumn() reads the sync
     // `databaseVersion` getter, which throws on an uninitialized connection where Rails'
-    // `database_version` would issue the round-trip itself. getDatabaseVersion() memoizes.
-    await this.getDatabaseVersion();
+    // `database_version` would issue the round-trip itself. The pool memoizes.
+    await this.pool.serverVersion(this);
     if (this.supportsRenameColumn()) {
       return `RENAME COLUMN ${this.quoteColumnName(columnName)} TO ${this.quoteColumnName(newColumnName)}`;
     }

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -126,8 +126,13 @@ export class NullPool implements AbstractPool {
   serverVersion(connection: DatabaseAdapter): unknown {
     if (this._serverVersion != null) return this._serverVersion;
     const version = connection.getDatabaseVersion?.();
+    // Only the resolved value is memoized, never the in-flight promise: the
+    // fetch opens the connection, whose `configureConnection`
+    // (`abstract_adapter.rb:1212`) reads back through here, and handing that
+    // nested call the promise it is itself inside would deadlock. Ruby's
+    // `synchronize` is a re-entrant Monitor, so it recomputes there too.
     if (version instanceof Promise) {
-      return (this._serverVersion = version.then((v) => (this._serverVersion = v)));
+      return version.then((v) => (this._serverVersion = v));
     }
     return (this._serverVersion = version);
   }

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -115,15 +115,21 @@ export class NullPool implements AbstractPool {
   static readonly NULL_CONFIG = NULL_CONFIG;
 
   private _serverVersion: unknown = null;
-  private _serverVersionCached = false;
   private _schemaReflection: SchemaReflection | null = null;
 
+  /**
+   * Mirrors: ConnectionPool::NullPool#server_version
+   * (`abstract/connection_pool.rb:30-32`) — the same `@server_version ||=`
+   * memo the real pool keeps on its PoolConfig. The promise arm is the trails
+   * async shape documented on `PoolConfig#serverVersion`.
+   */
   serverVersion(connection: DatabaseAdapter): unknown {
-    if (!this._serverVersionCached) {
-      this._serverVersion = connection.getDatabaseVersion?.();
-      this._serverVersionCached = true;
+    if (this._serverVersion != null) return this._serverVersion;
+    const version = connection.getDatabaseVersion?.();
+    if (version instanceof Promise) {
+      return (this._serverVersion = version.then((v) => (this._serverVersion = v)));
     }
-    return this._serverVersion;
+    return (this._serverVersion = version);
   }
 
   get schemaReflection(): SchemaReflection {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -415,8 +415,9 @@ export class SchemaStatements {
     // Prime the cached database version before the visitor emits DDL: inline
     // `t.index order:` runs through SchemaCreation's synchronous
     // supportsIndexSortOrder gate, which yields false on a cold connection
-    // (mirrors addIndex's warm-up). Memoized → no-op when already warm.
-    await this.getDatabaseVersion?.();
+    // (mirrors addIndex's warm-up). The pool memo (`pool_config.rb:39-41`) makes
+    // this a no-op when already warm.
+    await this.pool?.serverVersion?.(this);
     await this.execute(await this.schemaCreation.accept(td));
 
     if (!this.supportsIndexesInCreate?.()) {
@@ -534,7 +535,7 @@ export class SchemaStatements {
     // `databaseVersion` synchronously and silently yield `false` on a cold
     // connection (`undefined?.gte(...) !== true`); addIndex runs on the
     // shared-worker reconstruct path before any query warms the cache.
-    await this.getDatabaseVersion?.();
+    await this.pool?.serverVersion?.(this);
     await this.schemaCache.clearDataSourceCacheBang(tableName);
     const createIndex = await this.buildCreateIndexDefinition(
       tableName,

--- a/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
@@ -58,7 +58,7 @@ export function isWriteQuery(sql: string): boolean {
 
 export interface BuildExplainClauseHost {
   isMariadb?(): boolean;
-  getDatabaseVersion?(): Version;
+  databaseVersion?: Version;
 }
 
 /**
@@ -93,7 +93,8 @@ interface AutoIncrementColumnHost {
 export function isAnalyzeWithoutExplain(this: BuildExplainClauseHost | void): boolean {
   const host = this as BuildExplainClauseHost | null;
   if (!host?.isMariadb?.()) return false;
-  return (host.getDatabaseVersion?.().compare("10.1.0") ?? -1) >= 0;
+  // Rails: `database_version >= "10.1.0"` (mysql/database_statements.rb:50).
+  return (host.databaseVersion?.compare("10.1.0") ?? -1) >= 0;
 }
 
 /** @internal */

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
@@ -45,7 +45,7 @@ function rowFormatHost(isMariadb: boolean, version: string, probeResult = 0) {
   const queries: string[] = [];
   return {
     isMariadb: () => isMariadb,
-    getDatabaseVersion: async () => new Version(version),
+    pool: { serverVersion: async () => new Version(version) },
     queryValue: async (sql: string) => {
       queries.push(sql);
       return probeResult;

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -163,17 +163,17 @@ interface QuotedScopeHost {
  */
 export interface RowFormatHost {
   isMariadb(): boolean;
-  getDatabaseVersion(): Promise<Version>;
+  pool: { serverVersion(connection: unknown): unknown };
   queryValue(sql: string, name?: string): Promise<unknown>;
   _defaultRowFormat?: string | null;
 }
 
 /** @internal */
 export async function isRowFormatDynamicByDefault(this: RowFormatHost): Promise<boolean> {
-  // Rails' `database_version` is `pool.server_version(self)`, which computes
-  // `get_database_version` lazily; the TS spelling of that laziness is awaiting
-  // `getDatabaseVersion()`, whose result the adapter memoizes.
-  const databaseVersion = await this.getDatabaseVersion();
+  // Rails' `database_version` is `pool.server_version(self)`
+  // (abstract_adapter.rb:854-856), which computes `get_database_version`
+  // lazily; the TS spelling of that laziness is awaiting the pool memo.
+  const databaseVersion = (await this.pool.serverVersion(this)) as Version;
   return this.isMariadb()
     ? databaseVersion.compare("10.2.2") >= 0
     : databaseVersion.compare("5.7.9") >= 0;

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1730,9 +1730,9 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // reads database_version, a synchronous accessor that itself triggers the
     // round-trip (get_database_version) when unmemoized — so Rails guarantees the
     // version is fetched before the floor check. checkVersion() is sync in trails
-    // and can't issue the query itself, so we await the warm here (getDatabaseVersion
-    // memoizes into _databaseVersion) before super.configureConnection() invokes it.
-    await this.getDatabaseVersion();
+    // and can't issue the query itself, so we await the warm here (the pool memo,
+    // pool_config.rb:39-41) before super.configureConnection() invokes it.
+    await this.pool.serverVersion(this);
     await super.configureConnection();
   }
 

--- a/packages/activerecord/src/connection-adapters/pool-config.ts
+++ b/packages/activerecord/src/connection-adapters/pool-config.ts
@@ -146,14 +146,17 @@ export class PoolConfig {
   get serverVersion(): (connection: DatabaseAdapter) => unknown {
     if (!this._serverVersionFn) {
       this._serverVersionFn = (connection: DatabaseAdapter) => {
+        // trails-only: `getDatabaseVersion` is a real await on every adapter
+        // whose version comes off the wire, where Rails' is sync.
         if (this._serverVersion != null) return this._serverVersion;
         const version = connection.getDatabaseVersion?.();
-        // trails-only: `getDatabaseVersion` is a real await on every adapter
-        // whose version comes off the wire, where Rails' is sync. Holding the
-        // in-flight promise keeps the fetch once-only, and replacing it with
-        // the resolved value keeps the sync `databaseVersion` read honest.
+        // Only the resolved value is memoized, never the in-flight promise: the
+        // fetch opens the connection, whose `configureConnection`
+        // (`abstract_adapter.rb:1212`) reads back through here, and handing that
+        // nested call the promise it is itself inside would deadlock. Ruby's
+        // `synchronize` is a re-entrant Monitor, so it recomputes there too.
         if (version instanceof Promise) {
-          return (this._serverVersion = version.then((v) => (this._serverVersion = v)));
+          return version.then((v) => (this._serverVersion = v));
         }
         return (this._serverVersion = version);
       };

--- a/packages/activerecord/src/connection-adapters/pool-config.ts
+++ b/packages/activerecord/src/connection-adapters/pool-config.ts
@@ -28,8 +28,7 @@ export class PoolConfig {
   private _pool: ConnectionPool | null = null;
   private _connectionDescriptor!: ConnectionDescriptor;
   private _schemaReflection: SchemaReflection | null = null;
-  private _serverVersion: unknown;
-  private _serverVersionCached = false;
+  private _serverVersion: unknown = null;
   private _serverVersionFn: ((connection: DatabaseAdapter) => unknown) | null = null;
 
   constructor(
@@ -133,14 +132,30 @@ export class PoolConfig {
     this._schemaReflection = value;
   }
 
+  /**
+   * Mirrors: ActiveRecord::ConnectionAdapters::PoolConfig#server_version
+   * (`pool_config.rb:39-41`) — `@server_version || synchronize { @server_version
+   * ||= connection.get_database_version }`. This is the single cache every
+   * adapter's `get_database_version` is fetched through; the adapters
+   * themselves stay pure.
+   *
+   * Ruby has both `server_version(connection)` and `attr_writer
+   * :server_version` (`pool_config.rb:9`); TS cannot carry a method and a
+   * setter under one name, so the reader is a getter returning the callable.
+   */
   get serverVersion(): (connection: DatabaseAdapter) => unknown {
     if (!this._serverVersionFn) {
       this._serverVersionFn = (connection: DatabaseAdapter) => {
-        if (!this._serverVersionCached) {
-          this._serverVersion = connection.getDatabaseVersion?.();
-          this._serverVersionCached = true;
+        if (this._serverVersion != null) return this._serverVersion;
+        const version = connection.getDatabaseVersion?.();
+        // trails-only: `getDatabaseVersion` is a real await on every adapter
+        // whose version comes off the wire, where Rails' is sync. Holding the
+        // in-flight promise keeps the fetch once-only, and replacing it with
+        // the resolved value keeps the sync `databaseVersion` read honest.
+        if (version instanceof Promise) {
+          return (this._serverVersion = version.then((v) => (this._serverVersion = v)));
         }
-        return this._serverVersion;
+        return (this._serverVersion = version);
       };
     }
     return this._serverVersionFn;
@@ -148,8 +163,6 @@ export class PoolConfig {
 
   set serverVersion(value: unknown) {
     this._serverVersion = value;
-    this._serverVersionCached = true;
-    this._serverVersionFn = null;
   }
 
   get pool(): ConnectionPool {

--- a/packages/activerecord/src/connection-adapters/pool-server-version.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/pool-server-version.trails.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { Mysql2Adapter } from "./mysql2-adapter.js";
+import { NullPool } from "./abstract/connection-pool.js";
+import type { AbstractAdapter } from "./abstract-adapter.js";
 import { Version } from "./abstract-adapter.js";
 
 // Trails-only: Rails' `PoolConfig#server_version` (`pool_config.rb:39-41`) and
@@ -55,4 +57,29 @@ describe("ConnectionPool#server_version", () => {
     expect(adapter.databaseVersion).toBeInstanceOf(Version);
     expect(adapter.supportsExpressionIndex()).toBe(true);
   });
+
+  // The fetch opens the connection, and `connect()` runs `configureConnection`
+  // (`abstract_adapter.rb:1212`), whose `checkVersion` reads the version back
+  // through the pool. Rails' `synchronize` is a re-entrant Monitor, so that
+  // nested call recomputes against a still-nil `@server_version`; a memo that
+  // held the in-flight promise would hand the nested call the promise it is
+  // itself inside, and neither would ever settle.
+  it("re-entrant read from inside the fetch resolves rather than awaiting itself", async () => {
+    const pool = new NullPool();
+    const connected = Promise.resolve();
+    let fetches = 0;
+    const connection = {
+      async getDatabaseVersion(): Promise<Version> {
+        fetches += 1;
+        // The nested read lands after the fetch has yielded, exactly as
+        // `configureConnection` does behind the connect the fetch awaits.
+        await connected;
+        if (fetches === 1) await pool.serverVersion(this as unknown as AbstractAdapter);
+        return new Version("8.0.35");
+      },
+    } as unknown as AbstractAdapter;
+
+    expect(String(await pool.serverVersion(connection))).toBe("8.0.35");
+    expect(fetches).toBe(2);
+  }, 5000);
 });

--- a/packages/activerecord/src/connection-adapters/pool-server-version.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/pool-server-version.trails.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { Mysql2Adapter } from "./mysql2-adapter.js";
+import { Version } from "./abstract-adapter.js";
+
+// Trails-only: Rails' `PoolConfig#server_version` (`pool_config.rb:39-41`) and
+// `AbstractAdapter#database_version` (`abstract_adapter.rb:854-856`) are
+// exercised through every version-gated predicate in the Rails suite, which
+// needs a live server. These pin the memo itself, because trails'
+// `getDatabaseVersion` is async where Rails' is sync — the pool holds the
+// in-flight promise and then the resolved value, which is what keeps the sync
+// `databaseVersion` read honest.
+describe("ConnectionPool#server_version", () => {
+  function adapterFetching(versions: string[]): Mysql2Adapter {
+    const adapter = new Mysql2Adapter({ host: "localhost" });
+    let calls = 0;
+    (adapter as unknown as { getFullVersion: () => Promise<string> }).getFullVersion = async () =>
+      versions[Math.min(calls++, versions.length - 1)];
+    return adapter;
+  }
+
+  it("fetches get_database_version once and answers the memo after", async () => {
+    const adapter = adapterFetching(["8.0.35", "5.7.9"]);
+
+    expect(String(await adapter.pool.serverVersion(adapter))).toBe("8.0.35");
+    expect(String(await adapter.pool.serverVersion(adapter))).toBe("8.0.35");
+    expect(adapter.databaseVersion.fullVersionString).toBe("8.0.35");
+  });
+
+  it("get_database_version itself is a pure derivation, not a memo", async () => {
+    const adapter = adapterFetching(["8.0.35", "5.7.9"]);
+
+    expect(String(await adapter.getDatabaseVersion())).toBe("8.0.35");
+    expect(String(await adapter.getDatabaseVersion())).toBe("5.7.9");
+  });
+
+  it("re-fetches after the memo is cleared, as `@server_version ||=` does", async () => {
+    const adapter = adapterFetching(["8.0.35", "5.7.9"]);
+    await adapter.pool.serverVersion(adapter);
+
+    (adapter.pool as unknown as { _serverVersion: unknown })._serverVersion = null;
+
+    expect(String(await adapter.pool.serverVersion(adapter))).toBe("5.7.9");
+  });
+
+  it("databaseVersion raises before the memo is warm, since the fetch is async", () => {
+    const adapter = adapterFetching(["8.0.35"]);
+
+    expect(() => adapter.databaseVersion).toThrow(/only available synchronously/);
+  });
+
+  it("answers a Version, so MySQL's version gates read it", async () => {
+    const adapter = adapterFetching(["8.0.35"]);
+    await adapter.pool.serverVersion(adapter);
+
+    expect(adapter.databaseVersion).toBeInstanceOf(Version);
+    expect(adapter.supportsExpressionIndex()).toBe(true);
+  });
+});

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -446,16 +446,13 @@ export class InsertAll {
     // and emit a bogus conflict target.
     const conn = this.connection as {
       supportsInsertConflictTarget?: () => boolean;
-      getDatabaseVersion?: () => Promise<unknown>;
+      pool?: { serverVersion?: (connection: unknown) => unknown };
     };
     // PG's supports_insert_conflict_target reads databaseVersion via a sync
-    // getter that throws until getDatabaseVersion() has populated the cache.
-    // Cold upsertAll(..., { uniqueBy }) would trip that before uniqueIndexes
-    // ran, so prime the version here when the adapter advertises the async
-    // initializer (mirroring how AbstractAdapter#prepareCoercedClass uses it).
-    if (typeof conn.getDatabaseVersion === "function") {
-      await conn.getDatabaseVersion();
-    }
+    // getter that throws until the pool memo (`pool_config.rb:39-41`) has been
+    // populated. Cold upsertAll(..., { uniqueBy }) would trip that before
+    // uniqueIndexes ran, so prime the version here.
+    await conn.pool?.serverVersion?.(conn);
     const supports =
       typeof conn.supportsInsertConflictTarget === "function"
         ? conn.supportsInsertConflictTarget()

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -764,7 +764,7 @@ export abstract class SchemaDumper {
       | {
           checkConstraints: (t: string) => Promise<unknown[]>;
           supportsCheckConstraints?: () => boolean;
-          getDatabaseVersion?: () => Promise<unknown>;
+          pool?: { serverVersion?: (connection: unknown) => unknown };
         }
       | undefined;
     if (!host) return;
@@ -776,7 +776,7 @@ export abstract class SchemaDumper {
     // ensure it's resolved first to avoid a false negative dropping real
     // constraints from the dump.
     if (host.supportsCheckConstraints) {
-      await host.getDatabaseVersion?.();
+      await host.pool?.serverVersion?.(host);
       if (!host.supportsCheckConstraints()) return;
     }
     const constraints = (await host.checkConstraints(tableName)) ?? [];

--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -345,7 +345,7 @@ async function loadPostgresqlSpecificSchema(adapter: PostgreSQLAdapter): Promise
  * worker and so cannot pull in `supports.ts`'s `vitest` import.
  */
 async function loadMysql2SpecificSchema(adapter: AbstractMysqlAdapter): Promise<void> {
-  await adapter.getDatabaseVersion();
+  await adapter.pool.serverVersion(adapter);
   const supportsDefaultExpression = adapter.isMariadb()
     ? adapter.databaseVersion.compare("10.2.1") >= 0
     : adapter.databaseVersion.compare("8.0.13") >= 0;

--- a/packages/activerecord/src/support/schema-conn.ts
+++ b/packages/activerecord/src/support/schema-conn.ts
@@ -29,10 +29,11 @@ export function schemaConn(name: SchemaConnName): TableDefinitionConn {
           ? new PostgreSQLAdapter("postgresql://localhost/trails_schema_conn")
           : new Mysql2Adapter("mysql://localhost/trails_schema_conn");
     if (name === "mysql") {
-      (conn as unknown as { _databaseVersion: Version })._databaseVersion = new Version(
-        "8.0.35",
-        "8.0.35",
-      );
+      // The version memo lives on the pool (`pool_config.rb:39-41`) and is
+      // filled from the connection's `get_database_version`; a connection that
+      // is never opened cannot answer one, so seed that fetch directly.
+      const version = new Version("8.0.35", "8.0.35");
+      (conn as unknown as { getDatabaseVersion: () => Version }).getDatabaseVersion = () => version;
     }
     conns.set(name, conn);
   }

--- a/packages/activerecord/src/support/schema-conn.ts
+++ b/packages/activerecord/src/support/schema-conn.ts
@@ -29,9 +29,8 @@ export function schemaConn(name: SchemaConnName): TableDefinitionConn {
           ? new PostgreSQLAdapter("postgresql://localhost/trails_schema_conn")
           : new Mysql2Adapter("mysql://localhost/trails_schema_conn");
     if (name === "mysql") {
-      // The version memo lives on the pool (`pool_config.rb:39-41`) and is
-      // filled from the connection's `get_database_version`; a connection that
-      // is never opened cannot answer one, so seed that fetch directly.
+      // A connection that is never opened cannot answer `get_database_version`,
+      // so seed the fetch the pool memo (`pool_config.rb:39-41`) caches.
       const version = new Version("8.0.35", "8.0.35");
       (conn as unknown as { getDatabaseVersion: () => Version }).getDatabaseVersion = () => version;
     }

--- a/packages/activerecord/src/support/schema-types.ts
+++ b/packages/activerecord/src/support/schema-types.ts
@@ -212,8 +212,8 @@ export function columnsOf(table: TableSchema): Record<string, ColumnSpec> {
 /**
  * Whether the adapter supports expression indexes. The getter reads
  * `databaseVersion` synchronously (SQLite ≥ 3.9, MySQL ≥ 8.0.13, never MariaDB),
- * which throws before the version cache is populated — so prime it via the
- * async `getDatabaseVersion()` first. A missing/throwing getter is treated as
+ * which throws before the version cache is populated — so prime the pool memo
+ * (`pool_config.rb:39-41`) first. A missing/throwing getter is treated as
  * unsupported, so we skip the expression index rather than emit invalid DDL.
  *
  * @internal
@@ -221,11 +221,11 @@ export function columnsOf(table: TableSchema): Record<string, ColumnSpec> {
 export async function supportsExpressionIndex(adapter: DatabaseAdapter): Promise<boolean> {
   const a = adapter as {
     supportsExpressionIndex?: () => boolean;
-    getDatabaseVersion?: () => Promise<unknown>;
+    pool?: { serverVersion?: (connection: unknown) => unknown };
   };
   if (typeof a.supportsExpressionIndex !== "function") return false;
   try {
-    if (typeof a.getDatabaseVersion === "function") await a.getDatabaseVersion();
+    await a.pool?.serverVersion?.(a);
     return a.supportsExpressionIndex();
   } catch {
     return false;

--- a/packages/activerecord/src/support/stubbed-ddl-methods.test.ts
+++ b/packages/activerecord/src/support/stubbed-ddl-methods.test.ts
@@ -45,7 +45,6 @@ const NON_EMITTING: ReadonlyMap<string, string> = new Map([
     "definition factory — a stub returns no CreateIndexDefinition and dies at once",
   ],
   ["databaseVersion", "version read behind the index sort-order predicates"],
-  ["_databaseVersion", "memoized backing slot of the databaseVersion read"],
   ["_statementPool", "prepared-statement slot clearCacheBang resets, not a DDL emitter"],
   ["_schemaCache", "memoized backing slot of the schemaCache read"],
   ["_poolSchemaReflection", "pool reflection the schemaCache read binds to"],

--- a/packages/activesupport/src/i18n.test.ts
+++ b/packages/activesupport/src/i18n.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { I18n } from "./i18n.js";
 import { toSentence } from "./array-utils.js";
 import { TimeZone } from "./values/time-zone.js";
-import { Date as RubyDate } from "@blazetrails/i18n/date";
+import { Date as RubyDate } from "@blazetrails/date";
 import type { TimeWithZone } from "./time-with-zone.js";
 
 // Rails' activesupport/test/abstract_unit.rb:35 turns the check off for the

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -3,7 +3,7 @@
  * These cover the members `I18n::Backend::Base#localize` duck-types.
  */
 
-import { Temporal } from "@blazetrails/date";
+import { Temporal } from "@js-temporal/polyfill";
 import { describe, it, expect, vi } from "vitest";
 import {
   ArgumentError,

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -10,16 +10,17 @@
  * date. `I18n::Backend::Base#localize` is exactly such a method: it asks for
  * `strftime`, `wday` and `mon`, and picks `date.formats` over `time.formats` by
  * the *absence* of `sec` (i18n/lib/i18n/backend/base.rb:105-115, ported at
- * `./backend/base.ts:245-271`). These wrappers are that duck type, and `Date`'s
+ * `packages/i18n/src/backend/base.ts:245-271`). These wrappers are that duck type, and `Date`'s
  * lack of `sec`/`hour` is the distinction Ruby gets from `Date` not being a
  * `Time`.
  *
- * This lives in `packages/i18n` rather than `packages/activesupport` because
- * `packages/i18n` is a dependency of `packages/activesupport`, and both
- * packages' localization tests drive the same objects.
+ * This lives in `packages/date` rather than `packages/i18n` or
+ * `packages/activesupport` because it is Ruby's stdlib `date`, not i18n: the
+ * gem ships no date implementation, and `packages/date` is a dependency of
+ * both.
  */
 
-import { Temporal } from "@blazetrails/date";
+import { Temporal } from "@js-temporal/polyfill";
 
 const DAY_NAMES = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
 const ABBR_DAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];

--- a/packages/date/src/index.ts
+++ b/packages/date/src/index.ts
@@ -10,3 +10,14 @@
  * `AbstractAdapter#quote` into its `can't quote` TypeError.
  */
 export { Temporal } from "@js-temporal/polyfill";
+export {
+  ArgumentError,
+  Date,
+  DateTime,
+  Rational,
+  dNewByFrags,
+  strftime,
+  type DateParts,
+  type StrftimeSubject,
+} from "./date.js";
+export { Time } from "./time.js";

--- a/packages/date/src/time.trails.test.ts
+++ b/packages/date/src/time.trails.test.ts
@@ -5,7 +5,7 @@
  * and `%z`/`%Z` answer the receiver's zone rather than a constant.
  */
 
-import { Temporal } from "@blazetrails/date";
+import { Temporal } from "@js-temporal/polyfill";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ArgumentError } from "./date.js";
 import { Time } from "./time.js";

--- a/packages/date/src/time.ts
+++ b/packages/date/src/time.ts
@@ -3,11 +3,11 @@
  * `./date.ts`. It answers `hour`/`min`/`sec` where `::Date` does not, which is
  * what routes `I18n::Backend::Base#localize` to `time.formats` rather than
  * `date.formats` (i18n/lib/i18n/backend/base.rb:105-115, ported at
- * `./backend/base.ts:245-271`), and `%Z` answers the zone's abbreviation
+ * `packages/i18n/src/backend/base.ts:245-271`), and `%Z` answers the zone's abbreviation
  * (`"UTC"` for a `Time.utc`) rather than `::Date`'s offset spelling.
  */
 
-import { Temporal } from "@blazetrails/date";
+import { Temporal } from "@js-temporal/polyfill";
 import { ArgumentError, strftime } from "./date.js";
 
 /**

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -9,14 +9,6 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
-    },
-    "./date": {
-      "types": "./dist/date.d.ts",
-      "default": "./dist/date.js"
-    },
-    "./time": {
-      "types": "./dist/time.d.ts",
-      "default": "./dist/time.js"
     }
   },
   "scripts": {

--- a/packages/i18n/src/backend/fallbacks.test.ts
+++ b/packages/i18n/src/backend/fallbacks.test.ts
@@ -21,8 +21,8 @@ import { config, exists, l, resetConfig, setLocale, t, type Locale } from "../i1
 import { resetClassConfig } from "../config.js";
 import { MissingTranslationData } from "../exceptions.js";
 import { Fallbacks as LocaleFallbacks } from "../locale/fallbacks.js";
-import { Date } from "../date.js";
-import { Time } from "../time.js";
+import { Date } from "@blazetrails/date";
+import { Time } from "@blazetrails/date";
 import type { TranslationData } from "../utils.js";
 
 class Backend extends Fallbacks(Simple) {}

--- a/packages/i18n/src/backend/localization.test.ts
+++ b/packages/i18n/src/backend/localization.test.ts
@@ -11,8 +11,8 @@ import { Simple } from "./simple.js";
 import { config, l, resetConfig } from "../i18n.js";
 import { resetClassConfig } from "../config.js";
 import { ArgumentError, MissingTranslationData, inspect } from "../exceptions.js";
-import { Date as RubyDate, DateTime as RubyDateTime } from "../date.js";
-import { Time as RubyTime } from "../time.js";
+import { Date as RubyDate, DateTime as RubyDateTime } from "@blazetrails/date";
+import { Time as RubyTime } from "@blazetrails/date";
 
 function setupDateTranslations(): void {
   config().backend.storeTranslations("de", {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -238,8 +238,6 @@ const alias = {
   "@blazetrails/trails-tsc": path.resolve(__dirname, "packages/trails-tsc/src/index.ts"),
   "@blazetrails/date": path.resolve(__dirname, "packages/date/src/index.ts"),
   "@blazetrails/did-you-mean": path.resolve(__dirname, "packages/did-you-mean/src/index.ts"),
-  "@blazetrails/i18n/date": path.resolve(__dirname, "packages/i18n/src/date.ts"),
-  "@blazetrails/i18n/time": path.resolve(__dirname, "packages/i18n/src/time.ts"),
   "@blazetrails/i18n": path.resolve(__dirname, "packages/i18n/src/index.ts"),
   "@blazetrails/nokogiri": path.resolve(__dirname, "packages/nokogiri/src/index.ts"),
 };


### PR DESCRIPTION
Two related stories.

## 1. `packages/i18n/src/{date,time}.ts` → `packages/date/src/`

A **mechanical move, no behavior change** (CLAUDE.md single-mechanical-rename
exception). These files are Ruby's stdlib `date`, not i18n: `vendor/i18n` ships
no date implementation, and `I18n::Backend::Base#localize` duck-types its
argument on `strftime`/`wday`/`mon`/`hour`/`sec`
(`i18n/lib/i18n/backend/base.rb:105-115`), so it never names the class.

- `date.ts`, `time.ts` and both `.trails.test.ts` files moved; `Temporal` now
  comes straight from the polyfill the package already owns.
- `./date` and `./time` subpath exports dropped from `packages/i18n/package.json`
  and from the vitest aliases; the classes are re-exported from
  `@blazetrails/date`.
- The three consumers (`activesupport/src/i18n.test.ts`, i18n's
  `backend/fallbacks.test.ts` and `backend/localization.test.ts`) import from
  `@blazetrails/date`.
- No method body edited, no test renamed.

## 2. `pool.serverVersion` is the version memo

Rails keeps the version cache on the pool and leaves `get_database_version`
pure:

- `PoolConfig#server_version` / `NullPool#server_version`
  (`pool_config.rb:39-41`, `abstract/connection_pool.rb:30-32`) are the
  `@server_version ||=` memo. The trails versions had a separate
  `_serverVersionCached` flag, which diverged from Rails (writing nil no longer
  refetched); they are now the `||=` shape, and a promise result is replaced by
  its resolved value so the sync read stays honest.
- `AbstractAdapter#databaseVersion` reads `this.pool.serverVersion(this)`
  (`abstract_adapter.rb:854-856`).
- `AbstractMysqlAdapter#getDatabaseVersion` is now the pure three-line
  derivation of `abstract_mysql_adapter.rb:86-90` — no leading memo guard, no
  field assignment — and `_databaseVersion` is gone from that adapter. Its
  `databaseVersion` override is a TS type narrowing only (`super.databaseVersion
  as Version`), because an inherited getter's type cannot be redeclared without
  a body.
- The trails-only version warm-ups (`addIndex`, `createTable`, `renameIndex`,
  `renameColumnForAlter`, `checkConstraints`, `configureConnection`, the schema
  dumper and `insertAll`) now await the pool memo rather than re-deriving.
  `isRowFormatDynamicByDefault` and `isAnalyzeWithoutExplain` read
  `database_version` as Rails does.

PG and SQLite still carry the same pushed-down memo (plus, on PG, an
`_hasOptimizerHints` warm that has no Rails counterpart); converging them is a
bigger diff in adapters this PR does not otherwise touch, so it is filed as
`0072-api-compare-parity-burndown/retire-pg-sqlite-get-database-version-memo-guards`.

Closes-story: move-date-time-to-date-package
Closes-story: port-pool-server-version-retire-get-database-version-memo-guard
