### PR TITLE
feat(activerecord,activesupport): fullVersion moves to Mysql2Adapter, SecureCompareRotator ported, check-constraint cases filled in

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.full-version.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.full-version.trails.test.ts
@@ -12,9 +12,6 @@ import { Version } from "./abstract-adapter.js";
 // (sqlite3_adapter.rb:477) — so these pin both arms. #full_version used to
 // substitute "" for the nil, which answered #mariadb? "no" for a server it had
 // never asked.
-// The file keeps its abstract-mysql-adapter name so it stays on the default
-// vitest project: `mysql2-*.test.ts` routes to the server-backed mysql2 lane,
-// and these two cases construct the adapter without ever connecting.
 describe("Mysql2Adapter#full_version", () => {
   function adapterWith(version: Version): Mysql2Adapter {
     const adapter = new Mysql2Adapter({ host: "localhost" });

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.full-version.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.full-version.trails.test.ts
@@ -12,7 +12,10 @@ import { Version } from "./abstract-adapter.js";
 // (sqlite3_adapter.rb:477) — so these pin both arms. #full_version used to
 // substitute "" for the nil, which answered #mariadb? "no" for a server it had
 // never asked.
-describe("AbstractMysqlAdapter#full_version", () => {
+// The file keeps its abstract-mysql-adapter name so it stays on the default
+// vitest project: `mysql2-*.test.ts` routes to the server-backed mysql2 lane,
+// and these two cases construct the adapter without ever connecting.
+describe("Mysql2Adapter#full_version", () => {
   function adapterWith(version: Version): Mysql2Adapter {
     const adapter = new Mysql2Adapter({ host: "localhost" });
     (adapter as unknown as { _databaseVersion: Version })._databaseVersion = version;

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -377,15 +377,15 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   }
 
   /**
-   * Mirrors: Mysql2Adapter#full_version (mysql2_adapter.rb:164-166) —
-   * `database_version.full_version_string`. Rails defines this per concrete
-   * adapter and reaches it from the abstract class by duck typing; TS needs a
-   * declared member, so the single definition lives here. Sync like Rails,
-   * because `database_version` is the memo `configureConnection` warms.
+   * Rails reaches `full_version` from here (abstract_mysql_adapter.rb:93) by
+   * duck typing — it is defined only on the concrete adapters
+   * (mysql2_adapter.rb:164-166). TS needs a declared member for that call, so
+   * the declaration stays and concrete adapters override it with the real
+   * body, the same split `getFullVersion` uses.
    * @internal
    */
   fullVersion(): string | null {
-    return this.databaseVersion.fullVersionString;
+    throw new Error(`${this.constructor.name} must implement fullVersion()`);
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -370,9 +370,6 @@ export class SchemaCreation {
   }
 
   protected visitCheckConstraintDefinition(o: CheckConstraintDefinition): string {
-    if (!o.validate && this.adapterName !== "postgres") {
-      throw new Error("Check constraint validate: false is only supported on PostgreSQL");
-    }
     return `CONSTRAINT ${this.adapter.quoteColumnName(o.name)} CHECK (${o.expression})`;
   }
 

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1737,6 +1737,16 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   }
 
   /**
+   * Mirrors: Mysql2Adapter#full_version (mysql2_adapter.rb:164-166). Sync like
+   * Rails, because `database_version` is the memo `configureConnection` warms.
+   *
+   * @internal
+   */
+  override fullVersion(): string | null {
+    return this.databaseVersion.fullVersionString;
+  }
+
+  /**
    * Mirrors: Mysql2Adapter#get_full_version (mysql2_adapter.rb:168-170). No
    * memo and no side effects: `database_version` is the only memo in the Rails
    * chain. Like Rails' `any_raw_connection.server_info[:version]`, the banner

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2212,12 +2212,8 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     expression: string,
     options: { name?: string; validate?: boolean } = {},
   ): Promise<void> {
-    if (options.validate === false) {
-      throw new Error("validate: false is only supported on PostgreSQL");
-    }
-    const { name } = options;
     await this.alterTable(tableName, undefined, undefined, undefined, (definition) => {
-      definition.checkConstraint(expression, { name });
+      definition.checkConstraint(expression, options);
     });
   }
 

--- a/packages/activerecord/src/migration/check-constraint.test.ts
+++ b/packages/activerecord/src/migration/check-constraint.test.ts
@@ -1,9 +1,18 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { ArgumentError } from "@blazetrails/activemodel";
+import { Base } from "../base.js";
+import { StatementInvalid } from "../errors.js";
 import type { CheckConstraintDefinition } from "../connection-adapters/abstract/schema-definitions.js";
+import type { ValidateConstraintStatements } from "../connection-adapters/abstract/schema-statements.js";
 import { ambientConnection } from "../support/rocket-tables.js";
-import { describeIfSupports } from "../support/supports.js";
+import { adapterSupports, describeIfSupports, itIfSupports } from "../support/supports.js";
 import { adapterType } from "../test-adapter.js";
+
+class Trade extends Base {
+  static {
+    this._tableName = "trades";
+  }
+}
 
 async function assertNothingRaised(block: () => Promise<unknown>): Promise<void> {
   await block();
@@ -30,11 +39,217 @@ describe("Migration", () => {
         t.integer("price");
         t.integer("quantity");
       });
+
+      await connection.createTable("purchases", { force: true }, (t) => {
+        t.integer("price");
+        t.integer("quantity");
+      });
+
+      // Rails' setup also creates a `constraint_test` table on the MySQL lanes
+      // for `test_check_constraints` (check_constraint_test.rb:27-31), which is
+      // not ported yet.
+      Trade.resetColumnInformation();
     });
 
     afterEach(async () => {
       const connection = await ambientConnection();
-      await connection.dropTable("trades", { ifExists: true });
+      await connection.dropTable("trades", "purchases", { ifExists: true });
+      Trade.resetColumnInformation();
+    });
+
+    it("add check constraint", async () => {
+      const connection = await ambientConnection();
+      await connection.addCheckConstraint("trades", "quantity > 0");
+
+      const checkConstraints = await connection.checkConstraints("trades");
+      expect(checkConstraints.length).toBe(1);
+
+      const constraint = checkConstraints[0];
+      expect(constraint.tableName).toBe("trades");
+      expect(constraint.name).toBe("chk_rails_2189e9f96c");
+
+      // eslint-disable-next-line vitest/no-conditional-in-test -- mirrors Rails' inline `if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)` (check_constraint_test.rb:112-116)
+      if (adapterType === "mysql") {
+        expect(constraint.expression).toBe("`quantity` > 0");
+      } else {
+        expect(constraint.expression).toBe("quantity > 0");
+      }
+    });
+
+    it("add check constraint with if not exists options", async () => {
+      const connection = await ambientConnection();
+      await connection.addCheckConstraint("trades", "quantity > 0");
+
+      await assertNothingRaised(() =>
+        connection.addCheckConstraint("trades", "quantity > 0", { ifNotExists: true }),
+      );
+    });
+
+    itIfSupports(
+      "non_unique_constraint_name",
+      "add constraint with same name to different table",
+      async () => {
+        const connection = await ambientConnection();
+        await connection.addCheckConstraint("trades", "quantity > 0", {
+          name: "greater_than_zero",
+        });
+        await connection.addCheckConstraint("purchases", "quantity > 0", {
+          name: "greater_than_zero",
+        });
+
+        const tradesCheckConstraints = await connection.checkConstraints("trades");
+        expect(tradesCheckConstraints.length).toBe(1);
+        const tradeConstraint = tradesCheckConstraints[0];
+        expect(tradeConstraint.tableName).toBe("trades");
+        expect(tradeConstraint.name).toBe("greater_than_zero");
+
+        const purchasesCheckConstraints = await connection.checkConstraints("purchases");
+        expect(purchasesCheckConstraints.length).toBe(1);
+        const purchaseConstraint = purchasesCheckConstraints[0];
+        expect(purchaseConstraint.tableName).toBe("purchases");
+        expect(purchaseConstraint.name).toBe("greater_than_zero");
+      },
+    );
+
+    it("add check constraint with non existent table raises", async () => {
+      const connection = await ambientConnection();
+      let e: Error | undefined;
+      await expect(
+        connection
+          .addCheckConstraint("refunds", "quantity > 0", { name: "quantity_check" })
+          .catch((error: Error) => {
+            e = error;
+            throw error;
+          }),
+      ).rejects.toThrow(StatementInvalid);
+      expect(e?.message).toMatch(/refunds/);
+    });
+
+    it("added check constraint ensures valid values", async () => {
+      const connection = await ambientConnection();
+      await connection.addCheckConstraint("trades", "quantity > 0", { name: "quantity_check" });
+
+      await expect(Trade.create({ quantity: -1 })).rejects.toThrow(StatementInvalid);
+    });
+
+    itIfSupports("validate_constraints", "not valid check constraint", async () => {
+      const connection = await ambientConnection();
+      await Trade.create({ quantity: -1 });
+
+      await connection.addCheckConstraint("trades", "quantity > 0", {
+        name: "quantity_check",
+        validate: false,
+      });
+
+      await expect(Trade.create({ quantity: -1 })).rejects.toThrow(StatementInvalid);
+    });
+
+    itIfSupports("validate_constraints", "validate check constraint by name", async () => {
+      const connection = await ambientConnection();
+      await connection.addCheckConstraint("trades", "quantity > 0", {
+        name: "quantity_check",
+        validate: false,
+      });
+      expect((await connection.checkConstraints("trades"))[0].isValidate).toBe(false);
+
+      await (connection as unknown as ValidateConstraintStatements).validateCheckConstraint(
+        "trades",
+        { name: "quantity_check" },
+      );
+      expect((await connection.checkConstraints("trades"))[0].isValidate).toBe(true);
+    });
+
+    itIfSupports("validate_constraints", "validated check constraint exists", async () => {
+      const connection = await ambientConnection();
+      await connection.addCheckConstraint("trades", "quantity > 0", {
+        name: "quantity_check",
+        validate: false,
+      });
+      expect(
+        await connection.checkConstraintExists("trades", {
+          name: "quantity_check",
+          validate: true,
+        }),
+      ).toBe(false);
+
+      await (connection as unknown as ValidateConstraintStatements).validateCheckConstraint(
+        "trades",
+        { name: "quantity_check" },
+      );
+      expect(
+        await connection.checkConstraintExists("trades", {
+          name: "quantity_check",
+          validate: true,
+        }),
+      ).toBe(true);
+    });
+
+    itIfSupports(
+      "validate_constraints",
+      "validate non existing check constraint raises",
+      async () => {
+        const connection = await ambientConnection();
+        await expect(
+          (connection as unknown as ValidateConstraintStatements).validateCheckConstraint(
+            "trades",
+            {
+              name: "quantity_check",
+            },
+          ),
+        ).rejects.toThrow(ArgumentError);
+      },
+    );
+
+    // Check constraint should still be created, but should not be invalid
+    it.skipIf(adapterSupports("validate_constraints"))("add invalid check constraint", async () => {
+      const connection = await ambientConnection();
+      await connection.addCheckConstraint("trades", "quantity > 0", {
+        name: "quantity_check",
+        validate: false,
+      });
+
+      const checkConstraints = await connection.checkConstraints("trades");
+      expect(checkConstraints.length).toBe(1);
+
+      const cc = checkConstraints[0];
+      expect(cc.isValidate).toBe(true);
+    });
+
+    it("check constraint exists", async () => {
+      const connection = await ambientConnection();
+      await connection.addCheckConstraint("trades", "quantity > 0", { name: "quantity_check" });
+
+      expect(await connection.checkConstraintExists("trades", { name: "quantity_check" })).toBe(
+        true,
+      );
+      expect(await connection.checkConstraintExists("non_trades", { name: "quantity_check" })).toBe(
+        false,
+      );
+      expect(await connection.checkConstraintExists("trades", { name: "other_check" })).toBe(false);
+    });
+
+    it("check constraint exists ensures required options", async () => {
+      const connection = await ambientConnection();
+      await connection.addCheckConstraint("trades", "quantity > 0", { name: "quantity_check" });
+      let error: Error | undefined;
+      await expect(
+        connection
+          .checkConstraintExists("trades", { something: true } as { name?: string })
+          .catch((e: Error) => {
+            error = e;
+            throw e;
+          }),
+      ).rejects.toThrow(ArgumentError);
+      expect(error?.message).toBe("At least one of :name or :expression must be supplied");
+    });
+
+    itIfSupports("sql_standard_drop_constraint", "remove constraint", async () => {
+      const connection = await ambientConnection();
+      await connection.addCheckConstraint("trades", "quantity > 0", { name: "quantity_check" });
+
+      expect((await connection.checkConstraints("trades")).length).toBe(1);
+      await connection.removeConstraint("trades", "quantity_check");
+      expect((await connection.checkConstraints("trades")).length).toBe(0);
     });
 
     it("remove check constraint", async () => {
@@ -86,6 +301,28 @@ describe("Migration", () => {
       await expect(
         connection.removeCheckConstraint("trades", { name: "nonexistent" }),
       ).rejects.toThrow(ArgumentError);
+    });
+
+    it("add constraint from change table with options", async () => {
+      const connection = await ambientConnection();
+      await connection.changeTable("trades", async (t) => {
+        await t.checkConstraint("price > 0", { name: "price_check" });
+      });
+
+      const constraint = (await connection.checkConstraints("trades"))[0];
+      expect(constraint.tableName).toBe("trades");
+      expect(constraint.name).toBe("price_check");
+    });
+
+    it("remove constraint from change table with options", async () => {
+      const connection = await ambientConnection();
+      await connection.addCheckConstraint("trades", "price > 0", { name: "price_check" });
+
+      await connection.changeTable("trades", async (t) => {
+        await t.removeCheckConstraint("price > 0", { name: "price_check" });
+      });
+
+      expect((await connection.checkConstraints("trades")).length).toBe(0);
     });
   });
 });

--- a/packages/activerecord/src/migration/check-constraint.test.ts
+++ b/packages/activerecord/src/migration/check-constraint.test.ts
@@ -5,6 +5,7 @@ import { StatementInvalid } from "../errors.js";
 import type { CheckConstraintDefinition } from "../connection-adapters/abstract/schema-definitions.js";
 import type { ValidateConstraintStatements } from "../connection-adapters/abstract/schema-statements.js";
 import { ambientConnection } from "../support/rocket-tables.js";
+import { useTransactionalTests } from "../test-fixtures/use-transactional-tests.js";
 import { adapterSupports, describeIfSupports, itIfSupports } from "../support/supports.js";
 import { adapterType } from "../test-adapter.js";
 
@@ -33,6 +34,14 @@ function assertEmpty(collection: CheckConstraintDefinition[]): void {
 
 describe("Migration", () => {
   describeIfSupports("check_constraints", "CheckConstraintTest", () => {
+    useTransactionalTests({
+      usesTransaction: [
+        "add check constraint with non existent table raises",
+        "added check constraint ensures valid values",
+        "not valid check constraint",
+      ],
+    });
+
     beforeEach(async () => {
       const connection = await ambientConnection();
       await connection.createTable("trades", { force: true }, (t) => {

--- a/packages/activerecord/src/migration/check-constraint.test.ts
+++ b/packages/activerecord/src/migration/check-constraint.test.ts
@@ -45,9 +45,6 @@ describe("Migration", () => {
         t.integer("quantity");
       });
 
-      // Rails' setup also creates a `constraint_test` table on the MySQL lanes
-      // for `test_check_constraints` (check_constraint_test.rb:27-31), which is
-      // not ported yet.
       Trade.resetColumnInformation();
     });
 

--- a/packages/activesupport/package.json
+++ b/packages/activesupport/package.json
@@ -30,6 +30,10 @@
       "types": "./dist/digest.d.ts",
       "default": "./dist/digest.js"
     },
+    "./secure-compare-rotator": {
+      "types": "./dist/secure-compare-rotator.d.ts",
+      "default": "./dist/secure-compare-rotator.js"
+    },
     "./security-utils": {
       "types": "./dist/security-utils.d.ts",
       "default": "./dist/security-utils.js"

--- a/packages/activesupport/src/secure-compare-rotator.test.ts
+++ b/packages/activesupport/src/secure-compare-rotator.test.ts
@@ -1,13 +1,63 @@
-import { describe, it } from "vitest";
+import { describe, it, expect } from "vitest";
+import { SecureCompareRotator, InvalidMatch } from "./secure-compare-rotator.js";
 
 describe("SecureCompareRotatorTest", () => {
-  it.skip("#secure_compare! works correctly after rotation");
+  it("#secure_compare! works correctly after rotation", () => {
+    const wrapper = new SecureCompareRotator("old_secret");
+    wrapper.rotate("new_secret");
 
-  it.skip("#secure_compare! works correctly after multiple rotation");
+    expect(wrapper.secureCompareBang("new_secret")).toEqual(true);
+  });
 
-  it.skip("#secure_compare! fails correctly when credential is not part of the rotation");
+  it("#secure_compare! works correctly after multiple rotation", () => {
+    const wrapper = new SecureCompareRotator("old_secret");
+    wrapper.rotate("new_secret");
+    wrapper.rotate("another_secret");
+    wrapper.rotate("and_another_one");
 
-  it.skip("#secure_compare! calls the on_rotation proc");
+    expect(wrapper.secureCompareBang("and_another_one")).toEqual(true);
+  });
 
-  it.skip("#secure_compare! calls the on_rotation proc that given in constructor");
+  it("#secure_compare! fails correctly when credential is not part of the rotation", () => {
+    const wrapper = new SecureCompareRotator("old_secret");
+    wrapper.rotate("new_secret");
+
+    expect(() => wrapper.secureCompareBang("different_secret")).toThrow(InvalidMatch);
+  });
+
+  it("#secure_compare! calls the on_rotation proc", () => {
+    const wrapper = new SecureCompareRotator("old_secret");
+    wrapper.rotate("new_secret");
+    wrapper.rotate("another_secret");
+    wrapper.rotate("and_another_one");
+
+    let witness: boolean | null = null;
+
+    expect(witness).toBeNull();
+    expect(
+      wrapper.secureCompareBang("and_another_one", {
+        onRotation: () => {
+          witness = true;
+        },
+      }),
+    ).toEqual(true);
+    expect(witness).toEqual(true);
+  });
+
+  it("#secure_compare! calls the on_rotation proc that given in constructor", () => {
+    let witness: boolean | null = null;
+
+    const wrapper = new SecureCompareRotator("old_secret", {
+      onRotation: () => {
+        witness = true;
+      },
+    });
+    wrapper.rotate("new_secret");
+    wrapper.rotate("another_secret");
+    wrapper.rotate("and_another_one");
+
+    expect(witness).toBeNull();
+    expect(wrapper.secureCompareBang("and_another_one")).toEqual(true);
+    expect(witness).toEqual(true);
+  });
 });

--- a/packages/activesupport/src/secure-compare-rotator.ts
+++ b/packages/activesupport/src/secure-compare-rotator.ts
@@ -17,6 +17,9 @@ export class InvalidMatch extends Error {}
  * One real use case example would be to rotate a basic auth credentials.
  *
  * Mirrors: ActiveSupport::SecureCompareRotator (secure_compare_rotator.rb:32-56).
+ * Ruby's `include SecurityUtils` (:33) makes `secure_compare` an instance
+ * method; trails' SecurityUtils is a statics-only class, so the calls go
+ * through it by name.
  */
 export class SecureCompareRotator {
   private value: string;

--- a/packages/activesupport/src/secure-compare-rotator.ts
+++ b/packages/activesupport/src/secure-compare-rotator.ts
@@ -1,0 +1,53 @@
+import { SecurityUtils } from "./security-utils.js";
+
+export class InvalidMatch extends Error {}
+
+/**
+ * = Secure Compare Rotator
+ *
+ * The SecureCompareRotator is a wrapper around SecurityUtils.secureCompare
+ * and allows you to rotate a previously defined value to a new one.
+ *
+ * It can be used as follow:
+ *
+ *   const rotator = new SecureCompareRotator("new_production_value");
+ *   rotator.rotate("previous_production_value");
+ *   rotator.secureCompareBang("previous_production_value");
+ *
+ * One real use case example would be to rotate a basic auth credentials.
+ *
+ * Mirrors: ActiveSupport::SecureCompareRotator (secure_compare_rotator.rb:32-56).
+ */
+export class SecureCompareRotator {
+  private value: string;
+  private rotateValues: string[];
+  private onRotation: (() => void) | null;
+
+  constructor(value: string, { onRotation = null }: { onRotation?: (() => void) | null } = {}) {
+    this.value = value;
+    this.rotateValues = [];
+    this.onRotation = onRotation;
+  }
+
+  rotate(previousValue: string): void {
+    this.rotateValues.push(previousValue);
+  }
+
+  secureCompareBang(
+    otherValue: string,
+    options: { onRotation?: (() => void) | null } = {},
+  ): boolean {
+    // Ruby's `on_rotation: @on_rotation` default only applies when the kwarg is
+    // absent, so an explicitly-passed nil must not fall back to the memo.
+    const onRotation = "onRotation" in options ? options.onRotation : this.onRotation;
+
+    if (SecurityUtils.secureCompare(this.value, otherValue)) {
+      return true;
+    } else if (this.rotateValues.some((value) => SecurityUtils.secureCompare(value, otherValue))) {
+      onRotation?.();
+      return true;
+    } else {
+      throw new InvalidMatch();
+    }
+  }
+}

--- a/packages/activesupport/src/secure-compare-rotator.ts
+++ b/packages/activesupport/src/secure-compare-rotator.ts
@@ -1,6 +1,11 @@
 import { SecurityUtils } from "./security-utils.js";
 
-export class InvalidMatch extends Error {}
+export class InvalidMatch extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = "InvalidMatch";
+  }
+}
 
 /**
  * = Secure Compare Rotator


### PR DESCRIPTION
Bundle of three stories.

### 1. `fullVersion` moves to `Mysql2Adapter`

Rails defines `full_version` only on the concrete adapter
(`mysql2_adapter.rb:164-166`) and reaches it from `AbstractMysqlAdapter#mariadb?`
(`abstract_mysql_adapter.rb:93`) by duck typing. The real body now lives on
`Mysql2Adapter`, at that position in the file; the abstract member is a
declaration-only stub that throws, which is the same split `getFullVersion`
already uses (PR #6143).

### 2. `ActiveSupport::SecureCompareRotator` ported

`packages/activesupport/src/secure-compare-rotator.ts`, from
`activesupport/lib/active_support/secure_compare_rotator.rb`. The vendored Rails
version does *not* include `Messages::Rotator` (the story context predates that
change) — it defines `initialize` / `rotate` / `secure_compare!` itself over
`SecurityUtils.secure_compare`, so the port does the same. `api:compare` reports
the file at 3/3. The five bodyless `it.skip` placeholders are replaced with the
ported tests, names verbatim from `secure_compare_rotator_test.rb`.

Because `SecurityUtils` is a subpath-only export (adapter pattern), the rotator
gets its own `./secure-compare-rotator` subpath rather than an index export.

### 3. 13 more `check_constraint_test.rb` cases

`migration/check_constraint_test.rb` goes from 7/25 to 20/25 matched in
`pnpm test:compare`, 0 gate mismatches. Added: the `add_check_constraint`
family, the `check_constraint_exists?` pair, the `validate_*` group (gated
`validate_constraints`) and its non-PG `else` arm, `remove_constraint` (gated
`sql_standard_drop_constraint`), the same-name-different-table case (gated
`non_unique_constraint_name`), and the two `change_table` cases. Setup grows the
`purchases` table and a `Trade` model, mirroring Rails' `setup`. Both arms of
every `current_adapter?(:Mysql2Adapter, :TrilogyAdapter)` branch are ported.

The remaining five cases (`test_check_constraints`, the PG schema-scoped case,
and the two `SchemaDumpingHelper` cases) need setup this file does not have —
filed as `port-final-check-constraint-test-cases` with the `file:line` details.

**Convergence:** `test_add_invalid_check_constraint` asserts a `validate: false`
constraint is still *created* on non-PostgreSQL adapters. trails raised
`"validate: false is only supported on PostgreSQL"` from two invented guards —
`SQLite3Adapter#addCheckConstraint` and
`SchemaCreation#visitCheckConstraintDefinition`. Rails has neither
(`sqlite3/schema_statements.rb:107-111` forwards `**options` verbatim;
`schema_creation.rb:125-127` is a bare interpolation), so both are removed.

Closes-story: mysql-full-version-belongs-on-mysql2-adapter
Closes-story: port-activesupport-secure-compare-rotator
Closes-story: port-remaining-check-constraint-test-cases
