### PR TITLE
feat(date,activesupport,arel): TimeWithZone#strftime delegates to the date gem's formatter

### DIFF
--- a/packages/activemodel/package.json
+++ b/packages/activemodel/package.json
@@ -28,6 +28,7 @@
   "license": "MIT",
   "dependencies": {
     "@blazetrails/activesupport": "workspace:*",
+    "@blazetrails/date": "workspace:*",
     "@blazetrails/i18n": "workspace:*",
     "bcryptjs": "^3.0.3"
   }

--- a/packages/activemodel/src/attribute-mutation-tracker.ts
+++ b/packages/activemodel/src/attribute-mutation-tracker.ts
@@ -1,4 +1,4 @@
-import { Temporal } from "@blazetrails/activesupport/temporal";
+import { Temporal } from "@blazetrails/date";
 import { AttributeSet } from "./attribute-set.js";
 
 /** @internal */

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -1,4 +1,4 @@
-import { Temporal } from "@blazetrails/activesupport/temporal";
+import { Temporal } from "@blazetrails/date";
 import { NoMethodError, RuntimeError } from "./attribute-assignment.js";
 
 /** Minimum shape required of a record object passed to serialization helpers. */

--- a/packages/activemodel/src/type/date-time.test.ts
+++ b/packages/activemodel/src/type/date-time.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Temporal } from "@blazetrails/activesupport/temporal";
+import { Temporal } from "@blazetrails/date";
 import { instant, plainDateTime } from "@blazetrails/activesupport/testing/temporal-helpers";
 import { TimeZone, setZoneDefault } from "@blazetrails/activesupport";
 import { Types } from "../index.js";

--- a/packages/activemodel/src/type/date-time.trails.test.ts
+++ b/packages/activemodel/src/type/date-time.trails.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Temporal } from "@blazetrails/activesupport/temporal";
+import { Temporal } from "@blazetrails/date";
 import { Types } from "../index.js";
 
 // Fallback-parser coverage for shapes `Date._parse` accepts that no Rails test

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -1,4 +1,4 @@
-import { Temporal } from "@blazetrails/activesupport/temporal";
+import { Temporal } from "@blazetrails/date";
 import {
   DateInfinity,
   DateNegativeInfinity,

--- a/packages/activemodel/src/type/date.test.ts
+++ b/packages/activemodel/src/type/date.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Temporal } from "@blazetrails/activesupport/temporal";
+import { Temporal } from "@blazetrails/date";
 import { plainDate } from "@blazetrails/activesupport/testing/temporal-helpers";
 import { Types } from "../index.js";
 

--- a/packages/activemodel/src/type/date.ts
+++ b/packages/activemodel/src/type/date.ts
@@ -1,4 +1,4 @@
-import { Temporal } from "@blazetrails/activesupport/temporal";
+import { Temporal } from "@blazetrails/date";
 import { AcceptsMultiparameterTime, isHash } from "./helpers/accepts-multiparameter-time.js";
 import { looseDateParse } from "./helpers/loose-date-parse.js";
 import {

--- a/packages/activemodel/src/type/helpers/accepts-multiparameter-time-defaults.test.ts
+++ b/packages/activemodel/src/type/helpers/accepts-multiparameter-time-defaults.test.ts
@@ -18,7 +18,7 @@ describe("AcceptsMultiparameterTime defaults", () => {
     const result = wrapper.cast({ "1": 2025, "2": 7, "3": 4, "4": 15 });
     expect(result).not.toBeNull();
     // The Instant's UTC hour should be 15 (timezone is UTC in test env)
-    const instant = result as import("@blazetrails/activesupport/temporal").Temporal.Instant;
+    const instant = result as import("@blazetrails/date").Temporal.Instant;
     expect(instant.toZonedDateTimeISO("UTC").hour).toBe(15);
   });
 
@@ -28,7 +28,7 @@ describe("AcceptsMultiparameterTime defaults", () => {
     // hour is empty string — should be treated as missing and filled with 0
     const result = wrapper.cast({ "1": 2025, "2": 7, "3": 4, "4": "" });
     expect(result).not.toBeNull();
-    const instant = result as import("@blazetrails/activesupport/temporal").Temporal.Instant;
+    const instant = result as import("@blazetrails/date").Temporal.Instant;
     expect(instant.toZonedDateTimeISO("UTC").hour).toBe(0);
   });
 

--- a/packages/activemodel/src/type/helpers/accepts-multiparameter-time.ts
+++ b/packages/activemodel/src/type/helpers/accepts-multiparameter-time.ts
@@ -1,4 +1,4 @@
-import { Temporal } from "@blazetrails/activesupport/temporal";
+import { Temporal } from "@blazetrails/date";
 import { ArgumentError } from "../../attribute-assignment.js";
 import { Type } from "../value.js";
 

--- a/packages/activemodel/src/type/helpers/loose-date-parse.ts
+++ b/packages/activemodel/src/type/helpers/loose-date-parse.ts
@@ -1,4 +1,4 @@
-import { Temporal } from "@blazetrails/activesupport/temporal";
+import { Temporal } from "@blazetrails/date";
 
 export interface LooseDateParts {
   year?: number;

--- a/packages/activemodel/src/type/helpers/time-value.test.ts
+++ b/packages/activemodel/src/type/helpers/time-value.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Temporal } from "@blazetrails/activesupport/temporal";
+import { Temporal } from "@blazetrails/date";
 import { applySecondsPrecision, fastStringToTime, newTime } from "./time-value.js";
 
 // Mirrors ActiveModel::Type::Helpers::TimeValue#apply_seconds_precision

--- a/packages/activemodel/src/type/helpers/time-value.ts
+++ b/packages/activemodel/src/type/helpers/time-value.ts
@@ -3,7 +3,7 @@
  *
  * Mirrors: ActiveModel::Type::Helpers::TimeValue
  */
-import { Temporal } from "@blazetrails/activesupport/temporal";
+import { Temporal } from "@blazetrails/date";
 import { isUtc } from "./timezone.js";
 
 export interface TimezoneAware {

--- a/packages/activemodel/src/type/time.test.ts
+++ b/packages/activemodel/src/type/time.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Temporal } from "@blazetrails/activesupport/temporal";
+import { Temporal } from "@blazetrails/date";
 import { plainTime } from "@blazetrails/activesupport/testing/temporal-helpers";
 import { Types } from "../index.js";
 

--- a/packages/activemodel/src/type/time.ts
+++ b/packages/activemodel/src/type/time.ts
@@ -1,4 +1,4 @@
-import { Temporal } from "@blazetrails/activesupport/temporal";
+import { Temporal } from "@blazetrails/date";
 import { looseDateParse } from "./helpers/loose-date-parse.js";
 import { AcceptsMultiparameterTime, isHash } from "./helpers/accepts-multiparameter-time.js";
 import { ValueType } from "./value.js";

--- a/packages/activemodel/src/validations/comparison.ts
+++ b/packages/activemodel/src/validations/comparison.ts
@@ -1,4 +1,4 @@
-import { Temporal } from "@blazetrails/activesupport/temporal";
+import { Temporal } from "@blazetrails/date";
 import { ArgumentError } from "../attribute-assignment.js";
 import { EachValidator } from "../validator.js";
 import type { ValidatableRecord } from "../validator.js";

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -10,6 +10,7 @@ import { Duration } from "./duration.js";
 import { currentTime } from "./time-travel.js";
 import { getZone } from "./time-zone-config.js";
 import { Temporal, instantFrom } from "./temporal.js";
+import { strftime } from "@blazetrails/date";
 import { Encoding } from "./json/encoding.js";
 
 /**
@@ -39,23 +40,6 @@ export interface AdvanceOptions {
   seconds?: number;
 }
 
-const DAY_NAMES = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
-
-const MONTH_NAMES = [
-  "January",
-  "February",
-  "March",
-  "April",
-  "May",
-  "June",
-  "July",
-  "August",
-  "September",
-  "October",
-  "November",
-  "December",
-];
-
 const SHORT_MONTH_NAMES = [
   "Jan",
   "Feb",
@@ -75,10 +59,6 @@ const SHORT_DAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
 function pad2(n: number): string {
   return String(n).padStart(2, "0");
-}
-
-function pad3(n: number): string {
-  return String(n).padStart(3, "0");
 }
 
 function daysInMonth(year: number, month: number): number {
@@ -392,54 +372,30 @@ export class TimeWithZone {
   }
 
   /**
-   * Format using strftime-style format string.
+   * Rails' `TimeWithZone` defines no `strftime` of its own — `method_missing`
+   * sends it on to the underlying `Time` (`time_with_zone.rb:557-566`), so the
+   * one implementation both reach is the `date` gem's C formatter, ported at
+   * `packages/date/src/date.ts`. `%z` comes off `formattedOffset` rather than
+   * the zone name, as `Time#strftime`'s does off `utc_offset`.
    */
   strftime(format: string): string {
     const l = this._local();
-    const tokens: Record<string, () => string> = {
-      Y: () => String(l.year),
-      C: () => String(Math.floor(l.year / 100)),
-      y: () => pad2(l.year % 100),
-      m: () => pad2(l.month),
-      d: () => pad2(l.day),
-      e: () => String(l.day).padStart(2, " "),
-      j: () => String(this.yday).padStart(3, "0"),
-      H: () => pad2(l.hour),
-      k: () => String(l.hour).padStart(2, " "),
-      I: () => pad2(l.hour === 0 ? 12 : l.hour > 12 ? l.hour - 12 : l.hour),
-      l: () => String(l.hour === 0 ? 12 : l.hour > 12 ? l.hour - 12 : l.hour).padStart(2, " "),
-      P: () => (l.hour < 12 ? "am" : "pm"),
-      p: () => (l.hour < 12 ? "AM" : "PM"),
-      M: () => pad2(l.minute),
-      S: () => pad2(l.second),
-      L: () => pad3(l.millisecond),
-      N: () => String(l.millisecond * 1_000_000).padStart(9, "0"),
-      z: () => this.formattedOffset(false),
-      Z: () => this.zone,
-      ":z": () => this.formattedOffset(true),
-      A: () => DAY_NAMES[this.wday],
-      a: () => SHORT_DAY_NAMES[this.wday],
-      u: () => String(this.wday === 0 ? 7 : this.wday),
-      w: () => String(this.wday),
-      B: () => MONTH_NAMES[l.month - 1],
-      b: () => SHORT_MONTH_NAMES[l.month - 1],
-      h: () => SHORT_MONTH_NAMES[l.month - 1],
-      s: () => String(this.toI()),
-      n: () => "\n",
-      t: () => "\t",
-      "%": () => "%",
-    };
-
-    return format.replace(/%(-?)(:?[A-Za-z%])/g, (_match, flag, spec) => {
-      const fn = tokens[spec];
-      if (!fn) return _match;
-      let result = fn();
-      if (flag === "-") {
-        // Remove leading zeros/spaces
-        result = result.replace(/^[0 ]+/, "") || "0";
-      }
-      return result;
-    });
+    return strftime(
+      {
+        year: l.year,
+        mon: l.month,
+        day: l.day,
+        wday: this.wday,
+        yday: this.yday,
+        hour: l.hour,
+        min: l.minute,
+        sec: l.second,
+        nsec: l.millisecond * 1_000_000,
+        zone: this.zone,
+        zoneOffset: this.formattedOffset(false),
+      },
+      format,
+    );
   }
 
   /**

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -394,7 +394,7 @@ export class TimeWithZone {
         hour: l.hour,
         min: l.minute,
         sec: l.second,
-        nsec: l.millisecond * 1_000_000,
+        nsec: this.nsec,
         zone: "",
         utcOffset: this.utcOffset,
       },

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -372,13 +372,17 @@ export class TimeWithZone {
   }
 
   /**
-   * Rails' `TimeWithZone` defines no `strftime` of its own — `method_missing`
-   * sends it on to the underlying `Time` (`time_with_zone.rb:557-566`), so the
-   * one implementation both reach is the `date` gem's C formatter, ported at
-   * `packages/date/src/date.ts`. `%z` comes off `formattedOffset` rather than
-   * the zone name, as `Time#strftime`'s does off `utc_offset`.
+   * Replaces `%Z` directive with +zone before passing to `Time#strftime`,
+   * so that zone information is correct.
+   *
+   * `getlocal(utc_offset)` answers a `::Time` at the receiver's offset, whose
+   * `strftime` is the `date` gem's C formatter — ported at
+   * `packages/date/src/date.ts`. That `::Time` was built from an offset rather
+   * than a zone, so its own `zone` is `nil` and any `%Z` the gsub left behind
+   * prints empty, as in Ruby.
    */
   strftime(format: string): string {
+    format = format.replace(/((?:^|[^%])(?:%%)*)%Z/g, `$1${this.zone}`);
     const l = this._local();
     return strftime(
       {
@@ -391,8 +395,8 @@ export class TimeWithZone {
         min: l.minute,
         sec: l.second,
         nsec: l.millisecond * 1_000_000,
-        zone: this.zone,
-        zoneOffset: this.formattedOffset(false),
+        zone: "",
+        utcOffset: this.utcOffset,
       },
       format,
     );

--- a/packages/activesupport/src/time-zone.test.ts
+++ b/packages/activesupport/src/time-zone.test.ts
@@ -642,8 +642,11 @@ describe("TimeZoneTest", () => {
   });
 
   it("z format strings", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
-    expect(zone.formattedOffset()).toMatch(/^[+-]\d{2}:\d{2}$/);
+    const zone = TimeZone.find("Tokyo");
+    const twz = zone.now();
+    expect(twz.strftime("%z")).toBe("+0900");
+    expect(twz.strftime("%:z")).toBe("+09:00");
+    expect(twz.strftime("%::z")).toBe("+09:00:00");
   });
 
   it("formatted offset zero", () => {

--- a/packages/arel/package.json
+++ b/packages/arel/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "@blazetrails/activemodel": "workspace:*",
-    "@blazetrails/activesupport": "workspace:*"
+    "@blazetrails/activesupport": "workspace:*",
+    "@blazetrails/date": "workspace:*"
   },
   "files": [
     "dist"

--- a/packages/arel/src/attributes/attribute.test.ts
+++ b/packages/arel/src/attributes/attribute.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Temporal } from "@blazetrails/activesupport/temporal";
+import { Temporal } from "@blazetrails/date";
 import { testConnection } from "../test-helpers/connection.js";
 import { Table, star, Nodes, Visitors } from "../index.js";
 

--- a/packages/arel/src/insert-manager.test.ts
+++ b/packages/arel/src/insert-manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Temporal } from "@blazetrails/activesupport/temporal";
+import { Temporal } from "@blazetrails/date";
 import { Table, sql, InsertManager, Nodes } from "./index.js";
 import { fakeRecordEngine } from "./test-helpers/connection.js";
 

--- a/packages/arel/src/nodes/binary.ts
+++ b/packages/arel/src/nodes/binary.ts
@@ -1,5 +1,5 @@
 import type { Attribute as ModelAttribute } from "@blazetrails/activemodel";
-import type { Temporal } from "@blazetrails/activesupport/temporal";
+import type { Temporal } from "@blazetrails/date";
 import { Node, NodeVisitor } from "./node.js";
 import { NodeExpression } from "./node-expression.js";
 import { SqlLiteral } from "./sql-literal.js";

--- a/packages/arel/src/test-helpers/connection.ts
+++ b/packages/arel/src/test-helpers/connection.ts
@@ -2,7 +2,7 @@ import type { ArelConnection } from "../visitors/connection.js";
 import type { ArelEngine } from "../nodes/node.js";
 import { ToSql } from "../visitors/to-sql.js";
 import { defaultQuoter, mysqlDefaultQuoter, postgresqlDefaultQuoter } from "./default-quoter.js";
-import { Temporal } from "@blazetrails/activesupport/temporal";
+import { Temporal } from "@blazetrails/date";
 
 /**
  * Explicit connections for Arel visitor construction in tests.

--- a/packages/arel/src/test-helpers/default-quoter.ts
+++ b/packages/arel/src/test-helpers/default-quoter.ts
@@ -1,6 +1,6 @@
 import type { ArelConnection } from "../visitors/connection.js";
 import { quoteSchemaQualifiedName } from "../visitors/split-schema-qualified-name.js";
-import { Temporal } from "@blazetrails/activesupport/temporal";
+import { Temporal } from "@blazetrails/date";
 
 // Standalone comment sanitize for these test hosts: strips block-comment
 // delimiters (leaving `--` alone, like Rails' abstract sanitize). Real

--- a/packages/arel/src/visitors/dot.test.ts
+++ b/packages/arel/src/visitors/dot.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { Attribute as ModelAttribute, ValueType } from "@blazetrails/activemodel";
-import { Temporal } from "@blazetrails/activesupport/temporal";
+import { Temporal } from "@blazetrails/date";
 import {
   Table,
   star,

--- a/packages/arel/src/visitors/postgres.test.ts
+++ b/packages/arel/src/visitors/postgres.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { testConnection, postgresqlTestConnection } from "../test-helpers/connection.js";
 import { Table, star, SelectManager, Nodes, Visitors } from "../index.js";
-import { Temporal } from "@blazetrails/activesupport/temporal";
+import { Temporal } from "@blazetrails/date";
 
 describe("PostgresTest", () => {
   const users = new Table("users");

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Temporal } from "@blazetrails/activesupport/temporal";
+import { Temporal } from "@blazetrails/date";
 import {
   Table,
   star,

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -463,6 +463,22 @@ describe("Date", () => {
     expect(date.strftime("%a %A")).toBe("Wed Wednesday");
   });
 
+  it("formats the strftime directives the conformance mixins use", () => {
+    const date = RubyDate.parse("2008-07-02");
+    expect(date.strftime("%C")).toBe("20");
+    expect(date.strftime("%u %w")).toBe("3 3");
+    expect(date.strftime("%I %k %l")).toBe("12  0 12");
+    expect(date.strftime("%L %N")).toBe("000 000000000");
+    expect(date.strftime("%:z")).toBe("+00:00");
+    expect(date.strftime("%n%t")).toBe("\n\t");
+  });
+
+  it("computes %s from the receiver's own fields, as date_strftime does", () => {
+    expect(RubyDate.parse("2008-07-02").strftime("%s")).toBe("1214956800");
+    expect(RubyDate.parse("1969-12-31").strftime("%s")).toBe("-86400");
+    expect(new RubyDateTime(2008, 7, 2, 6, 30, 15).strftime("%s")).toBe("1214980215");
+  });
+
   it("strips the padding for the %-d flag and leaves unknown directives alone", () => {
     const date = RubyDate.parse("2008-07-02");
     expect(date.strftime("%-m/%-d")).toBe("7/2");

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -88,8 +88,31 @@ export interface StrftimeSubject {
   hour: number;
   min: number;
   sec: number;
+  nsec: number;
   zone: string;
   zoneOffset: string;
+}
+
+/**
+ * @internal `%s`'s value — `date_strftime.c` computes it from the receiver's
+ * own fields rather than reading a `to_i` off it, which is what lets `::Date`
+ * (midnight, UTC) answer `%s` at all. The offset comes back off `zoneOffset`
+ * because that is the only spelling of it the subject carries.
+ */
+function epochSeconds(subject: StrftimeSubject): number {
+  const utc = new Temporal.PlainDateTime(
+    subject.year,
+    subject.mon,
+    subject.day,
+    subject.hour,
+    subject.min,
+    subject.sec,
+  ).toZonedDateTime("UTC");
+  const offset = /^([+-])(\d{2})(\d{2})$/.exec(subject.zoneOffset);
+  const offsetSeconds = offset
+    ? (offset[1] === "-" ? -1 : 1) * (Number(offset[2]) * 3600 + Number(offset[3]) * 60)
+    : 0;
+  return Math.floor(utc.epochMilliseconds / 1000) - offsetSeconds;
 }
 
 /**
@@ -112,8 +135,10 @@ export interface StrftimeSubject {
  * local zone and answers its real offset and abbreviation.
  */
 export function strftime(subject: StrftimeSubject, format: string): string {
+  const hour12 = subject.hour % 12 === 0 ? 12 : subject.hour % 12;
   const tokens: Record<string, () => string> = {
     Y: () => padYear(subject.year),
+    C: () => pad2(Math.floor(subject.year / 100)),
     y: () => pad2(subject.year % 100),
     m: () => pad2(subject.mon),
     d: () => pad2(subject.day),
@@ -125,18 +150,29 @@ export function strftime(subject: StrftimeSubject, format: string): string {
     B: () => MONTH_NAMES[subject.mon - 1],
     b: () => ABBR_MONTH_NAMES[subject.mon - 1],
     h: () => ABBR_MONTH_NAMES[subject.mon - 1],
+    u: () => String(subject.wday === 0 ? 7 : subject.wday),
+    w: () => String(subject.wday),
     H: () => pad2(subject.hour),
+    k: () => String(subject.hour).padStart(2, " "),
+    I: () => pad2(hour12),
+    l: () => String(hour12).padStart(2, " "),
     M: () => pad2(subject.min),
     S: () => pad2(subject.sec),
+    L: () => String(Math.floor(subject.nsec / 1_000_000)).padStart(3, "0"),
+    N: () => String(subject.nsec).padStart(9, "0"),
+    s: () => String(epochSeconds(subject)),
     p: () => (subject.hour < 12 ? "AM" : "PM"),
     P: () => (subject.hour < 12 ? "am" : "pm"),
     x: () => `${pad2(subject.mon)}/${pad2(subject.day)}/${pad2(subject.year % 100)}`,
     z: () => subject.zoneOffset,
+    ":z": () => `${subject.zoneOffset.slice(0, 3)}:${subject.zoneOffset.slice(3)}`,
     Z: () => subject.zone,
+    n: () => "\n",
+    t: () => "\t",
     "%": () => "%",
   };
 
-  return format.replace(/%(-?)([A-Za-z%])/g, (match, flag, spec) => {
+  return format.replace(/%(-?)(:?[A-Za-z%])/g, (match, flag, spec) => {
     const fn = tokens[spec];
     if (!fn) return match;
     let result = fn();
@@ -2727,6 +2763,7 @@ export class Date {
         hour: 0,
         min: 0,
         sec: 0,
+        nsec: 0,
         zone: "+00:00",
         zoneOffset: "+0000",
       },
@@ -2808,6 +2845,7 @@ export class DateTime extends Date {
         hour: this.hour,
         min: this.min,
         sec: this.sec,
+        nsec: 0,
         zone: this.zone,
         zoneOffset: "+0000",
       },

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -111,20 +111,27 @@ function epochSeconds(subject: StrftimeSubject): number {
 }
 
 /**
- * @internal The three spellings `date_strftime.c`'s `%z` arm gives the offset,
+ * @internal The four spellings `date_strftime.c`'s `%z` arm gives the offset,
  * picked by how many colons preceded the directive: none is `"+0900"`, one is
- * `"+09:00"` and two is `"+09:00:00"`. All three come off the one offset in
- * seconds, which is why the subject carries a number rather than a string —
- * `%::z` is the only directive that can show a sub-minute offset.
+ * `"+09:00"`, two is `"+09:00:00"`, and three is the shortest form that loses
+ * nothing — MRI shows the minute and second only when they are nonzero, so
+ * `+09:00:00` is `"+09"` while `+05:30` stays `"+05:30"`. All four come off the
+ * one offset in seconds, which is why the subject carries a number rather than
+ * a string: `%::z` and `%:::z` are the only spellings that can show a
+ * sub-minute offset.
  */
 function formatOffset(utcOffset: number, colons: number): string {
   const sign = utcOffset < 0 ? "-" : "+";
   const abs = Math.abs(utcOffset);
   const hour = pad2(Math.floor(abs / 3600));
   const min = pad2(Math.floor(abs / 60) % 60);
+  const sec = pad2(abs % 60);
   if (colons === 0) return `${sign}${hour}${min}`;
   if (colons === 1) return `${sign}${hour}:${min}`;
-  return `${sign}${hour}:${min}:${pad2(abs % 60)}`;
+  if (colons === 2) return `${sign}${hour}:${min}:${sec}`;
+  if (abs % 60 !== 0) return `${sign}${hour}:${min}:${sec}`;
+  if (Math.floor(abs / 60) % 60 !== 0) return `${sign}${hour}:${min}`;
+  return `${sign}${hour}`;
 }
 
 /**
@@ -179,13 +186,14 @@ export function strftime(subject: StrftimeSubject, format: string): string {
     z: () => formatOffset(subject.utcOffset, 0),
     ":z": () => formatOffset(subject.utcOffset, 1),
     "::z": () => formatOffset(subject.utcOffset, 2),
+    ":::z": () => formatOffset(subject.utcOffset, 3),
     Z: () => subject.zone,
     n: () => "\n",
     t: () => "\t",
     "%": () => "%",
   };
 
-  return format.replace(/%(-?)(:{0,2}[A-Za-z%])/g, (match, flag, spec) => {
+  return format.replace(/%(-?)(:{0,3}[A-Za-z%])/g, (match, flag, spec) => {
     const fn = tokens[spec];
     if (!fn) return match;
     let result = fn();

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -90,14 +90,13 @@ export interface StrftimeSubject {
   sec: number;
   nsec: number;
   zone: string;
-  zoneOffset: string;
+  utcOffset: number;
 }
 
 /**
  * @internal `%s`'s value — `date_strftime.c` computes it from the receiver's
  * own fields rather than reading a `to_i` off it, which is what lets `::Date`
- * (midnight, UTC) answer `%s` at all. The offset comes back off `zoneOffset`
- * because that is the only spelling of it the subject carries.
+ * (midnight, UTC) answer `%s` at all.
  */
 function epochSeconds(subject: StrftimeSubject): number {
   const utc = new Temporal.PlainDateTime(
@@ -108,11 +107,24 @@ function epochSeconds(subject: StrftimeSubject): number {
     subject.min,
     subject.sec,
   ).toZonedDateTime("UTC");
-  const offset = /^([+-])(\d{2})(\d{2})$/.exec(subject.zoneOffset);
-  const offsetSeconds = offset
-    ? (offset[1] === "-" ? -1 : 1) * (Number(offset[2]) * 3600 + Number(offset[3]) * 60)
-    : 0;
-  return Math.floor(utc.epochMilliseconds / 1000) - offsetSeconds;
+  return Math.floor(utc.epochMilliseconds / 1000) - subject.utcOffset;
+}
+
+/**
+ * @internal The three spellings `date_strftime.c`'s `%z` arm gives the offset,
+ * picked by how many colons preceded the directive: none is `"+0900"`, one is
+ * `"+09:00"` and two is `"+09:00:00"`. All three come off the one offset in
+ * seconds, which is why the subject carries a number rather than a string —
+ * `%::z` is the only directive that can show a sub-minute offset.
+ */
+function formatOffset(utcOffset: number, colons: number): string {
+  const sign = utcOffset < 0 ? "-" : "+";
+  const abs = Math.abs(utcOffset);
+  const hour = pad2(Math.floor(abs / 3600));
+  const min = pad2(Math.floor(abs / 60) % 60);
+  if (colons === 0) return `${sign}${hour}${min}`;
+  if (colons === 1) return `${sign}${hour}:${min}`;
+  return `${sign}${hour}:${min}:${pad2(abs % 60)}`;
 }
 
 /**
@@ -164,15 +176,16 @@ export function strftime(subject: StrftimeSubject, format: string): string {
     p: () => (subject.hour < 12 ? "AM" : "PM"),
     P: () => (subject.hour < 12 ? "am" : "pm"),
     x: () => `${pad2(subject.mon)}/${pad2(subject.day)}/${pad2(subject.year % 100)}`,
-    z: () => subject.zoneOffset,
-    ":z": () => `${subject.zoneOffset.slice(0, 3)}:${subject.zoneOffset.slice(3)}`,
+    z: () => formatOffset(subject.utcOffset, 0),
+    ":z": () => formatOffset(subject.utcOffset, 1),
+    "::z": () => formatOffset(subject.utcOffset, 2),
     Z: () => subject.zone,
     n: () => "\n",
     t: () => "\t",
     "%": () => "%",
   };
 
-  return format.replace(/%(-?)(:?[A-Za-z%])/g, (match, flag, spec) => {
+  return format.replace(/%(-?)(:{0,2}[A-Za-z%])/g, (match, flag, spec) => {
     const fn = tokens[spec];
     if (!fn) return match;
     let result = fn();
@@ -2765,7 +2778,7 @@ export class Date {
         sec: 0,
         nsec: 0,
         zone: "+00:00",
-        zoneOffset: "+0000",
+        utcOffset: 0,
       },
       format,
     );
@@ -2847,7 +2860,7 @@ export class DateTime extends Date {
         sec: this.sec,
         nsec: 0,
         zone: this.zone,
-        zoneOffset: "+0000",
+        utcOffset: 0,
       },
       format,
     );

--- a/packages/date/src/time.trails.test.ts
+++ b/packages/date/src/time.trails.test.ts
@@ -37,6 +37,16 @@ describe("Time", () => {
     expect(new Time(2008, 3, 1, 6, 0, 0, "+09").strftime("%z")).toBe("+0900");
   });
 
+  it("spells the offset four ways, one per leading colon", () => {
+    const at = (offset: number) =>
+      new Time(2008, 3, 1, 6, 0, 0, offset).strftime("%z|%:z|%::z|%:::z");
+    expect(at(32400)).toBe("+0900|+09:00|+09:00:00|+09");
+    expect(at(19800)).toBe("+0530|+05:30|+05:30:00|+05:30");
+    expect(at(30)).toBe("+0000|+00:00|+00:00:30|+00:00:30");
+    expect(at(-1800)).toBe("-0030|-00:30|-00:30:00|-00:30");
+    expect(at(0)).toBe("+0000|+00:00|+00:00:00|+00");
+  });
+
   it("Time.new takes a military zone letter", () => {
     expect(new Time(2008, 3, 1, 6, 0, 0, "K").utcOffset).toBe(10 * 3600);
     expect(new Time(2008, 3, 1, 6, 0, 0, "Y").utcOffset).toBe(-12 * 3600);

--- a/packages/date/src/time.ts
+++ b/packages/date/src/time.ts
@@ -61,10 +61,6 @@ function utcOffsetArgument(zone: string | number): "UTC" | number {
   throw new ArgumentError('"+HH:MM", "-HH:MM", "UTC" or "A".."I","K".."Z" expected for utc_offset');
 }
 
-function pad2(n: number): string {
-  return String(n).padStart(2, "0");
-}
-
 /**
  * The tzdata abbreviations MRI's `Time#zone` answers, for the zones `Intl`
  * cannot supply them for: an `en-US` `timeZoneName: "short"` is an
@@ -266,9 +262,6 @@ export class Time {
   }
 
   strftime(format: string): string {
-    // `%z` is `±HHMM` — neither `Time#zone` nor `Temporal`'s extended `±HH:MM`.
-    const minutes = Math.floor(Math.abs(this.utcOffset) / 60);
-    const zoneOffset = `${this.utcOffset < 0 ? "-" : "+"}${pad2(Math.floor(minutes / 60))}${pad2(minutes % 60)}`;
     return strftime(
       {
         year: this.year,
@@ -281,7 +274,7 @@ export class Time {
         sec: this.sec,
         nsec: 0,
         zone: this.zone ?? "",
-        zoneOffset,
+        utcOffset: this.utcOffset,
       },
       format,
     );

--- a/packages/date/src/time.ts
+++ b/packages/date/src/time.ts
@@ -279,6 +279,7 @@ export class Time {
         hour: this.hour,
         min: this.min,
         sec: this.sec,
+        nsec: 0,
         zone: this.zone ?? "",
         zoneOffset,
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,6 +169,9 @@ importers:
       '@blazetrails/activesupport':
         specifier: workspace:*
         version: link:../activesupport
+      '@blazetrails/date':
+        specifier: workspace:*
+        version: link:../date
       '@blazetrails/i18n':
         specifier: workspace:*
         version: link:../i18n
@@ -258,6 +261,9 @@ importers:
       '@blazetrails/activesupport':
         specifier: workspace:*
         version: link:../activesupport
+      '@blazetrails/date':
+        specifier: workspace:*
+        version: link:../date
 
   packages/date:
     dependencies:


### PR DESCRIPTION
Bundle of two RFC 0088 stories.

## 1. `TimeWithZone#strftime` delegates to `packages/date`

Rails' `TimeWithZone#strftime` (`time_with_zone.rb:223-227`) is two lines: it
gsubs unescaped `%Z` to `zone`, then delegates to
`getlocal(utc_offset).strftime(format)` — the `date` gem's C formatter. Trails
had a second, hand-rolled token table in `time-with-zone.ts`. It is deleted; the
method is now that gsub plus a call into `@blazetrails/date`. Because the
delegate is a `::Time` built from an offset rather than a zone, its own `zone`
is `nil`, so the subject passes `zone: ""` and any `%%Z` the gsub left behind
prints empty, as in Ruby. The
now-unused `pad3`, `DAY_NAMES` and `MONTH_NAMES` are deleted too (`pad2` and the
`SHORT_*` arrays are still used by `toString`/`rfc822`).

### Directive diff (AS table vs. the gem table), all ported into the gem table

| Directive | Was only in AS | Now |
| --- | --- | --- |
| `%C` | century | `pad2(floor(year / 100))` — `date_strftime.c`'s `%C` is `"%02d"`, so the AS unpadded form is corrected |
| `%k` `%I` `%l` | blank-padded hour, 12-hour zero/blank-padded | ported |
| `%L` `%N` | milliseconds / nanoseconds | ported; `StrftimeSubject` gains `nsec` (`Date`/`DateTime`/`Time` pass `0`, they carry no sub-second) |
| `%u` `%w` | ISO weekday, weekday | ported |
| `%s` | epoch seconds | ported. `date_strftime.c` computes it from the receiver's own fields rather than reading `to_i`, which is what lets `::Date` answer it — so `epochSeconds()` does the same, taking the offset off `zoneOffset` |
| `%n` `%t` | newline, tab | ported |
| `%:z` | colon offset | ported, **with `%::z` and `%:::z`** — `test_z_format_strings` (`time_zone_test.rb:755-761`) asserts the first three. The directive regex is `/%(-?)(:{0,3}[A-Za-z%])/` |

Nothing was dropped. `%F`, `%x` and `%e` were gem-only and stay. `%Y` now goes
through `padYear` (`date_strftime.c:236-247`), so a pre-1000 year pads to four
columns instead of the AS table's bare `String(year)` — a fix, not a regression.

`StrftimeSubject` now carries the offset as `utcOffset`, a number of seconds —
the shape Ruby's `tmx` carries it in, and what lets all four `%z` spellings be
formatted from one value. `%::z` and `%:::z` are the only spellings that can
show a sub-minute offset, which is why the seconds must survive to the formatter;
`Time#strftime` no longer pre-formats a `±HHMM` string on the way in. `%Z`
answers the zone abbreviation via the gsub above.

`%:::z` is MRI's shortest form — minute and second shown only when nonzero, so
`+09:00:00` prints `"+09"` but `+05:30` stays `"+05:30"`. All four spellings are
pinned against a live `ruby` in `time.trails.test.ts`:

```
32400: +0900|+09:00|+09:00:00|+09        30: +0000|+00:00|+00:00:30|+00:00:30
19800: +0530|+05:30|+05:30:00|+05:30   -1800: -0030|-00:30|-00:30:00|-00:30
```

**Audit of the other two `strftime` references:** neither is a third
implementation. `values/time-zone.ts:429` is a *parser* (a `strptime` analogue,
prose mention only); `activerecord/src/migration.ts:1374` is a comment quoting
the Rails source. No change needed.

`time-with-zone.test.ts` passes **unmodified**. `TimeZoneTest#z format strings`
was a hollowed-out stub asserting only `formattedOffset()` against a regex; it
is converged onto the Rails body (name unchanged). AS + date + AM + arel:
7742 passing.

## 2. Route `Temporal` imports in activemodel + arel onto `@blazetrails/date`

Purely mechanical: every `@blazetrails/activesupport/temporal` import in
`packages/activemodel` (15 files) and `packages/arel` (8 files) becomes
`@blazetrails/date`; both `package.json`s declare the dep. All were plain
`Temporal` imports — nothing pulled `instantFrom`, so no shim was needed.

No behavior change, no type change. `activesupport/src/temporal.ts` stays as the
re-export for the not-yet-converged packages (activerecord, actionpack), and
because it re-exports the *same* module instance, `instanceof` identity is
unchanged — the AR quoting guards (`quoting.ts:155-158`) see the same
`Temporal.PlainDate` they did before. AM, arel and AS suites pass (7663 tests).

Closes-story: converge-time-with-zone-strftime-onto-date-package
Closes-story: route-temporal-imports-activemodel-arel
