### PR TITLE
feat(date,test-compare): enroll the ruby/date gem test suite in test:compare

### DIFF
--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -2311,11 +2311,13 @@ class DateError extends ArgumentError {
 }
 
 /**
- * @noRailsEquivalent PERMANENT — Ruby stdlib `::Date`. Rails never defines the
- * class, only reopens it, so there is no Rails counterpart for a port to
- * converge on; JS has no stdlib equivalent either (`Temporal.PlainDate` answers
- * `dayOfWeek`/`month`, not `wday`/`mon`, and has no `strftime`). trails carries
- * only the members a caller duck-types.
+ * @noRailsEquivalent PERMANENT — the `ruby/date` gem's `::Date`. Rails never
+ * defines the class, only reopens it. The gem does have a counterpart now that
+ * it is vendored, but it is C — `vendor/date/ext/date/date_core.c` — and
+ * `extract-ruby-api.rb` parses Ruby, so `api:compare` cannot credit it
+ * (RFC 0088 `date-c-source-extractor-decision`: `lib/date.rb` credits 12
+ * methods, none of them these). The gem's `test/date/` suite is the fidelity
+ * measure instead; see `vendor/sources.ts`'s `date` entry.
  */
 export class Date {
   /**
@@ -2736,8 +2738,11 @@ export class Date {
 }
 
 /**
- * @noRailsEquivalent PERMANENT — Ruby stdlib `::DateTime`, a `::Date` that also
- * answers `hour`, `min` and `sec`. Those are what route a `localize` lookup to
+ * @noRailsEquivalent PERMANENT — the `ruby/date` gem's `::DateTime`, a `::Date`
+ * that also answers `hour`, `min` and `sec`. Defined in C
+ * (`vendor/date/ext/date/date_core.c`), so it is outside `api:compare`'s
+ * population for the same reason as `Date` above. Those readers are what route
+ * a `localize` lookup to
  * `time.formats` (i18n/lib/i18n/backend/base.rb:105-115), while `%Z` keeps
  * `::Date`'s offset spelling rather than `::Time`'s `"UTC"`.
  */

--- a/scripts/api-compare/unported-files.test.ts
+++ b/scripts/api-compare/unported-files.test.ts
@@ -4,7 +4,12 @@ import { join, relative } from "node:path";
 import { describe, it, expect } from "vitest";
 
 import { resolvePath } from "../../vendor/sources.js";
-import { isSourceUnported, isTestFileUnported, UNPORTED_FILES } from "./unported-files.js";
+import {
+  isSourceUnported,
+  isTestCaseUnported,
+  isTestFileUnported,
+  UNPORTED_FILES,
+} from "./unported-files.js";
 
 async function walkRb(dir: string): Promise<string[]> {
   const out: string[] = [];
@@ -106,6 +111,16 @@ describe("UNPORTED_FILES schema", () => {
         ).toBeTruthy();
       }
     }
+  });
+
+  it("names per-test entries the way the extractor emits them, without the test_ prefix", () => {
+    // Regression: extract-ruby-tests.rb strips the `def test_` prefix, so
+    // `test_marshal14` reaches isTestCaseUnported as `marshal14`. A
+    // `test_`-prefixed entry matches nothing and the exclusion is a silent
+    // no-op — the test stays in the compared population with no error anywhere.
+    expect(isTestCaseUnported("test_switch_hitter.rb", "marshal14", "TestSH")).toBe(true);
+    expect(isTestCaseUnported("test_switch_hitter.rb", "test_marshal14", "TestSH")).toBe(false);
+    expect(isTestCaseUnported("test_switch_hitter.rb", "strftime", "TestSH")).toBe(false);
   });
 
   it("scopes the globalid railtie_test.rb exclusion so activemodel's is still counted", () => {

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -1321,6 +1321,32 @@ export const UNPORTED_FILES: UnportedFile[] = [
       "conformance mixins excluded above — a file that sits beside the " +
       "directory the pattern above reaches.",
   },
+  {
+    testFile: "test_date_ractor.rb",
+    package: "date",
+    reason:
+      "Ractor is Ruby's actor-based parallelism primitive — the file exercises " +
+      "`Ractor.make_shareable`/`Ractor.new` round-tripping of a Date across " +
+      "isolated interpreter states. JS is single-threaded and has no analogue, " +
+      "same reason `promise.rb` is excluded above.",
+  },
+  {
+    testFile: "test_date_marshal.rb",
+    package: "date",
+    reason:
+      "Ruby's Marshal binary object format — `Marshal.dump`/`Marshal.load` of a " +
+      "Date, including the frozen-string and instance-variable round trip. " +
+      "Not applicable: JS has no Marshal, and the wire format is Ruby-only.",
+  },
+  {
+    testFile: "test_switch_hitter.rb",
+    tests: ["test_marshal14", "test_marshal16", "test_marshal18", "test_marshal192"],
+    reason:
+      "The four Marshal cases inside TestSH load Marshal payloads emitted by " +
+      "Ruby 1.4/1.6/1.8/1.9.2 to check the dumped Date representation stays " +
+      "loadable. Ruby-only wire format, same as test_date_marshal.rb above; the " +
+      "rest of the file stays counted.",
+  },
 ];
 
 export function isSourceUnported(file: string, pkg?: string): boolean {

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -1340,7 +1340,11 @@ export const UNPORTED_FILES: UnportedFile[] = [
   },
   {
     testFile: "test_switch_hitter.rb",
-    tests: ["test_marshal14", "test_marshal16", "test_marshal18", "test_marshal192"],
+    className: "TestSH",
+    // `tests` matches the extracted description, which is the `def test_` name
+    // with its `test_` prefix stripped — `test_marshal14` extracts as
+    // `marshal14`. A `test_`-prefixed entry here is a silent no-op.
+    tests: ["marshal14", "marshal16", "marshal18", "marshal192"],
     reason:
       "The four Marshal cases inside TestSH load Marshal payloads emitted by " +
       "Ruby 1.4/1.6/1.8/1.9.2 to check the dumped Date representation stays " +

--- a/scripts/test-compare/assertion-mismatch-mark.json
+++ b/scripts/test-compare/assertion-mismatch-mark.json
@@ -40,6 +40,11 @@
       "kind": 0,
       "value": 0
     },
+    "date": {
+      "assertionCount": 0,
+      "kind": 0,
+      "value": 0
+    },
     "did-you-mean": {
       "assertionCount": 0,
       "kind": 0,

--- a/scripts/test-compare/extract-ts-tests.ts
+++ b/scripts/test-compare/extract-ts-tests.ts
@@ -22,6 +22,7 @@ function getPackageTestFiles(): Record<string, string[]> {
     "globalid",
     "did-you-mean",
     "i18n",
+    "date",
   ];
   const packageAliases: Record<string, string> = {};
   const result: Record<string, string[]> = {};

--- a/scripts/test-compare/test-compare.ts
+++ b/scripts/test-compare/test-compare.ts
@@ -67,8 +67,8 @@ import { buildHistogram, diffHistograms, type KindDelta } from "./assertion-kind
 import { assertionValueMismatch, type ValueDelta } from "./assertion-values.js";
 import { isTestCaseUnported, isTestFileUnported } from "../api-compare/unported-files.js";
 import { PATH_SEGMENT_ALIASES } from "../api-compare/conventions.js";
-import { PACKAGES } from "../api-compare/config.js";
 import { SpellChecker } from "../../packages/did-you-mean/src/spell-checker.js";
+import { testPathsManifest } from "../../vendor/sources.js";
 
 const SCRIPT_DIR = __dirname;
 const OUTPUT_DIR = path.join(SCRIPT_DIR, "output");
@@ -427,11 +427,16 @@ function main() {
     process.exit(1);
   }
 
-  if (filterPkg && !PACKAGES.includes(filterPkg)) {
-    const suggestions = new SpellChecker({ dictionary: PACKAGES }).correct(filterPkg);
+  // The dictionary is the TEST-compared population, not the api-compared one:
+  // `date` is enrolled in test:compare and deliberately not in api:compare, so
+  // gating on PACKAGES would reject `--package date` for a package this script
+  // does report on.
+  const comparedPackages = Object.keys(testPathsManifest()).sort();
+  if (filterPkg && !comparedPackages.includes(filterPkg)) {
+    const suggestions = new SpellChecker({ dictionary: comparedPackages }).correct(filterPkg);
     const hint = suggestions.length ? ` Did you mean: ${suggestions.join(", ")}?` : "";
     console.error(`--package: unknown package "${filterPkg}".${hint}`);
-    console.error(`Available: ${PACKAGES.join(", ")}`);
+    console.error(`Available: ${comparedPackages.join(", ")}`);
     process.exit(1);
   }
 

--- a/scripts/test-compare/test-compare.ts
+++ b/scripts/test-compare/test-compare.ts
@@ -1257,6 +1257,7 @@ function extractRelativeTsPath(fullPath: string, pkg: string): string {
     globalid: "packages/globalid/src/",
     "did-you-mean": "packages/did-you-mean/src/",
     i18n: "packages/i18n/src/",
+    date: "packages/date/src/",
   };
 
   const prefix = pkgDirs[pkg];

--- a/vendor/sources.test.ts
+++ b/vendor/sources.test.ts
@@ -61,6 +61,23 @@ describe("vendor/sources.ts", () => {
     ]);
   });
 
+  it("declares the date source, enrolled in test-compare only", () => {
+    // api-compare stays off deliberately: the gem's surface is C
+    // (ext/date/date_core.c), so extract-ruby-api.rb credits only the 12
+    // methods in lib/date.rb. RFC 0088 `date-c-source-extractor-decision`.
+    const date = SOURCES.find((s) => s.name === "date");
+    expect(date).toBeDefined();
+    expect(date!.origin).toEqual({
+      type: "git",
+      url: "https://github.com/ruby/date.git",
+      ref: "v3.4.1",
+    });
+    expect(apiComparePackages()).not.toContain("date");
+    expect(Object.keys(libPathsManifest())).not.toContain("date");
+    expect(Object.keys(testPathsManifest())).toContain("date");
+    expect(resolvePath("date", "test").endsWith("vendor/date/test/date")).toBe(true);
+  });
+
   it("declares the i18n source, enrolled in both api-compare and test-compare", () => {
     const i18n = SOURCES.find((s) => s.name === "i18n");
     expect(i18n).toBeDefined();
@@ -224,6 +241,7 @@ describe("vendor/sources.ts", () => {
         "activerecord",
         "activesupport",
         "arel",
+        "date",
         "did-you-mean",
         "globalid",
         "i18n",

--- a/vendor/sources.ts
+++ b/vendor/sources.ts
@@ -204,11 +204,21 @@ export const SOURCES: readonly UpstreamSource[] = [
         // `lib/date.rb`'s `Date#infinite?` and the `:nodoc:` `Date::Infinity`,
         // against 2,805 lines of port. So `compareApi` stays off; the C sources
         // are a read-anchor, and they need no `UNPORTED_FILES` entry because
-        // the extractor globs `**/*.rb` and never sees them. `compareTests`
-        // flips in `date-test-compare-enrollment` — `test/date/` is 12 files
-        // and 145 `def test_` methods, and it is the gate for this cluster.
+        // the extractor globs `**/*.rb` and never sees them.
         compareApi: false,
-        compareTests: false,
+        // `test/date/` is the gate for this cluster — 12 files, 145 `def test_`
+        // methods — and it is the only fidelity measure the date port has:
+        // per RFC 0088 the gem's test suite is the measure, not a
+        // method-by-method mirror of Ruby's internal representation.
+        //
+        // Assertion-value mismatches against these tests are EXPECTED and
+        // BENIGN, not drift. RFC 0088 returns `Temporal` types by default where
+        // Ruby returns `Date`/`DateTime`/`Time`, so a ported test whose Ruby
+        // form asserts `assert_equal Date.new(2001,2,3), Date.parse("…")`
+        // compares a `Temporal.PlainDate` on our side. `test:compare` matches on
+        // test *names*, so the test still counts. Do not "converge" a
+        // Temporal return back to a Ruby-shaped one to silence a value
+        // mismatch — that reverses the RFC's headline decision.
       },
     ],
   },


### PR DESCRIPTION
Gives the date cluster a stopping condition. RFC 0074's date port ran to 32
stories / 24 merged PRs with no gate that could ever go green, because both its
test files use the `.trails.test.ts` suffix — TS-only extras, outside the
compared population by construction.

## `compareTests: true` — all four registrations

`test:compare` enrollment is four registrations, not one, and the fourth has no
local gate that runs by default (`pnpm test:compare` passes without it while
CI's `Rails API/Test Comparison` job hard-fails on an unmarked package):

1. `vendor/sources.ts` — drop `compareTests: false`, plus the exact-key-list
   expectation in `vendor/sources.test.ts` (two of them).
2. `scripts/test-compare/extract-ts-tests.ts` — `getPackageTestFiles()`.
3. `scripts/test-compare/test-compare.ts` — `pkgDirs`, else TS paths degrade to
   bare basenames.
4. `scripts/test-compare/assertion-mismatch-mark.json` — seeded at 0/0/0, the
   honest number with 0 tests matched. The reseed also wanted to ratchet
   `activerecord` down 1987→1977 from a sibling's convergence; reverted, only the
   `date` row is mine.

**Baseline: `date — 0/138 tests (0%) | 0/10 files | 0 misplaced`**, recorded in
the RFC README so the burndown has a starting point.

## Deferred suites — excluded, not deleted

`UNPORTED_FILES` entries with real reasons: `test_date_ractor.rb` (Ractor is
Ruby's actor parallelism; JS is single-threaded, same grounds as `promise.rb`),
`test_date_marshal.rb` (Ruby Marshal wire format), and per-test entries for
`test_switch_hitter.rb`'s `test_marshal14/16/18/192` — the other 18 tests in that
file stay counted. Those per-test entries are spelled `marshal14` … `marshal192`:
`extract-ruby-tests.rb` strips the `def test_` prefix, so a `test_`-prefixed
entry matches nothing and the exclusion is a **silent** no-op — it cost this PR
one round (142 → 138) and now has a regression test in
`unported-files.test.ts`.

## `compareApi` stays off — the spike's answer, not a deferral

`date-c-source-extractor-decision` (#6138) measured it: `extract-ruby-api.rb`
against `vendor/date/lib` credits `2 classes, 12 public methods` — all of
`lib/date.rb`'s 70 lines — against a 2,805-line port whose surface lives in
`ext/date/date_core.c` (10,064 lines) and `date_parse.c` (3,086). Flipping it
buys 12 methods and costs a package-sized extra-surface report. No
`UNPORTED_FILES` `pattern` entries are needed either: the extractor globs
`**/*.rb`, so the C sources never enter the compared population.

Triage done rather than assumed: `pnpm api:extra --package date` reports nothing
(the package isn't in `PACKAGES`), and the pre-existing `@noRailsEquivalent` tags
on `Date` / `DateTime` were re-checked against the now-vendored gem. Their stated
reason — "Rails never defines the class, so there is no counterpart to converge
on" — is stale: the gem *does* define them, in C. Rewritten to say so and to cite
where the fidelity measure actually lives. The `Rational`, `Time` and
`strftime`-shim tags remain accurate and are untouched.

## Assertion-value mismatches are expected and benign

Recorded at the enrollment site and in the RFC README. RFC 0088 returns
`Temporal` where Ruby returns `Date`/`DateTime`/`Time`, so a faithfully-ported
test asserting `assert_equal Date.new(2001,2,3), Date.parse("…")` compares a
`Temporal.PlainDate` here. `test:compare` matches on test *names*, so the test
still counts — the value-shape difference is the RFC's headline decision, not
drift, and must not be "converged" back.

That has a consequence the first porting story will hit: `nextMark` takes
`Math.min` (`assertion-ratchet.ts:126`), so `date.value` can never be raised from
its honest 0 by `--write`. Filed as
`date-assertion-value-mark-vs-temporal-returns` rather than pre-inflating the
seed with debt that does not exist yet.

## Two silent defects fixed in the second commit

Both were found by verifying the enrollment rather than trusting it:

- the per-test exclusion spelling above (142 → 138, `test_switch_hitter.rb`
  22 → 18);
- `--package date` was rejected outright, because the validation dictionary was
  api-compare's `PACKAGES` — which deliberately excludes `date`. It is now
  `testPathsManifest()`, the population this script actually reports on. Any
  future test-compare-only source would have hit the same wall.

## Gates

- `pnpm test:compare` — date enrolled at 0/138; overall matched unchanged at
  15193, total 22648 (−4, the newly-effective per-test exclusions). No other
  package moved.
- `pnpm test:assertions:ratchet` — OK.
- `pnpm api:compare` — 13105/17794 (73.6%), unchanged (date is not api-compared).
- `pnpm api:calls` — OK (2172 baselined, 1976 unreviewed); no rows added.
- `pnpm api:extra --package date` — empty, as expected.
- `pnpm lint --fix`, `pnpm vitest run vendor/sources.test.ts scripts/test-compare/ scripts/api-compare/unported-files.test.ts` — 201 passed.

Closes-story: date-api-compare-enrollment
Closes-story: date-test-compare-enrollment
