### PR TITLE
fix(activerecord,test-compare): fill the version memo on connection establishment, retire the databaseVersion hand-warms

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
@@ -41,6 +41,12 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     // next test in this worker gets a live one.
     clearVersionCache(adapter);
     await adapter.verifyBang();
+    // Rails' `database_version` re-runs the query once the stub is gone, so its
+    // @connection is never left without one. Ours is a sync reader over an async
+    // fetch and `verifyBang` won't re-configure an already-live connection, so
+    // refill the memo this hook just emptied — otherwise the next test in this
+    // worker inherits a permanently cold version.
+    await adapter.pool.serverVersion(adapter);
   });
 
   describe("ConnectionTest", () => {

--- a/packages/activerecord/src/connection-adapters/abstract-adapter-version.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter-version.trails.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { Version } from "./abstract-adapter.js";
+import { AbstractAdapter, Version } from "./abstract-adapter.js";
 
 // Rails has no test of its own for `AbstractAdapter::Version`'s state
 // (abstract_adapter.rb:243-259); these pin the shape its callers depend on.
@@ -24,5 +24,41 @@ describe("AbstractAdapter::Version", () => {
     expect(new Version("8.0.31").compare("8.0.4")).toBe(1);
     expect(new Version("5.7.22").compare("5.7.22")).toBe(0);
     expect(new Version("10.2").compare("10.2.1")).toBe(-1);
+  });
+});
+
+// Rails' `database_version` (`abstract_adapter.rb:854-856`) fetches on demand,
+// so `check_version` and every `supports_*?` predicate read it with no
+// preparation. trails' sync getter cannot self-fetch, so `configureConnection`
+// (`abstract_adapter.rb:1212-1214`) fills the pool memo instead. These pin that:
+// without them, callers go back to hand-warming.
+describe("AbstractAdapter#configureConnection", () => {
+  class AsyncVersionAdapter extends AbstractAdapter {
+    fetches = 0;
+    override async getDatabaseVersion(): Promise<Version> {
+      this.fetches++;
+      return new Version("8.0.31");
+    }
+  }
+
+  it("makes databaseVersion readable with no caller-side warm", async () => {
+    const adapter = new AsyncVersionAdapter();
+    expect(() => adapter.databaseVersion).toThrow();
+    await adapter.configureConnection();
+    expect(adapter.databaseVersion.toString()).toBe("8.0.31");
+  });
+
+  it("fetches the version once, before checkVersion reads it", async () => {
+    const seen: string[] = [];
+    class CheckingAdapter extends AsyncVersionAdapter {
+      override checkVersion(): void {
+        seen.push(this.databaseVersion.toString());
+      }
+    }
+    const adapter = new CheckingAdapter();
+    await adapter.configureConnection();
+    await adapter.configureConnection();
+    expect(seen).toEqual(["8.0.31", "8.0.31"]);
+    expect(adapter.fetches).toBe(1);
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -2558,18 +2558,13 @@ export class AbstractAdapter implements Quoting {
 
   /** @internal Mirrors: AbstractAdapter#configure_connection (`abstract_adapter.rb:1212-1214`) */
   configureConnection(..._args: unknown[]): void | Promise<void> {
-    // Rails' body is `check_version` alone. The extra line is the one place
-    // trails pays for a genuine language gap: `database_version`
-    // (`abstract_adapter.rb:854-856`) is a sync reader whose
-    // `pool.server_version(self)` issues the round-trip on demand, while our
-    // `getDatabaseVersion()` is a real await, so the sync `databaseVersion`
-    // getter cannot self-fetch. Filling the pool memo here — at the point Rails
-    // establishes the connection, before `check_version` reads it — makes the
-    // getter warm for the life of the connection, so every version-gated
-    // `supports*()` predicate is a plain memo hit and no ported body carries a
-    // warm of its own.
-    // The sync arm keeps SQLite's `configure_connection` synchronous, exactly
-    // as Rails' is.
+    // Deviation, language-forced: Rails' body is `check_version` alone because
+    // `database_version` (`abstract_adapter.rb:854-856`) is a sync reader that
+    // issues its own round-trip. `getDatabaseVersion()` is a real await, so the
+    // sync getter cannot self-fetch; filling the pool memo at the point Rails
+    // establishes the connection is what keeps every version-gated `supports*()`
+    // read a plain memo hit. The sync arm keeps SQLite's `configure_connection`
+    // synchronous, as Rails' is.
     const serverVersion = this.pool.serverVersion(this);
     if (serverVersion instanceof Promise) return serverVersion.then(() => this.checkVersion());
     this.checkVersion();

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -2556,8 +2556,22 @@ export class AbstractAdapter implements Quoting {
     return m;
   }
 
-  /** @internal Mirrors: AbstractAdapter#configure_connection */
+  /** @internal Mirrors: AbstractAdapter#configure_connection (`abstract_adapter.rb:1212-1214`) */
   configureConnection(..._args: unknown[]): void | Promise<void> {
+    // Rails' body is `check_version` alone. The extra line is the one place
+    // trails pays for a genuine language gap: `database_version`
+    // (`abstract_adapter.rb:854-856`) is a sync reader whose
+    // `pool.server_version(self)` issues the round-trip on demand, while our
+    // `getDatabaseVersion()` is a real await, so the sync `databaseVersion`
+    // getter cannot self-fetch. Filling the pool memo here — at the point Rails
+    // establishes the connection, before `check_version` reads it — makes the
+    // getter warm for the life of the connection, so every version-gated
+    // `supports*()` predicate is a plain memo hit and no ported body carries a
+    // warm of its own.
+    // The sync arm keeps SQLite's `configure_connection` synchronous, exactly
+    // as Rails' is.
+    const serverVersion = this.pool.serverVersion(this);
+    if (serverVersion instanceof Promise) return serverVersion.then(() => this.checkVersion());
     this.checkVersion();
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -633,7 +633,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       await this._execMutation(
         `CREATE DATABASE ${this.quoteTableName(name)} DEFAULT CHARACTER SET ${this.quoteTableName(String(options.charset))}`,
       );
-    } else if (isRowFormatDynamicByDefault.call(this)) {
+    } else if (await isRowFormatDynamicByDefault.call(this)) {
       await this._execMutation(
         `CREATE DATABASE ${this.quoteTableName(name)} DEFAULT CHARACTER SET \`utf8mb4\``,
       );

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -633,7 +633,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       await this._execMutation(
         `CREATE DATABASE ${this.quoteTableName(name)} DEFAULT CHARACTER SET ${this.quoteTableName(String(options.charset))}`,
       );
-    } else if (await isRowFormatDynamicByDefault.call(this)) {
+    } else if (isRowFormatDynamicByDefault.call(this)) {
       await this._execMutation(
         `CREATE DATABASE ${this.quoteTableName(name)} DEFAULT CHARACTER SET \`utf8mb4\``,
       );

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -721,7 +721,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
 
   async renameIndex(tableName: string, oldName: string, newName: string): Promise<void> {
     await this.schemaCache.clearDataSourceCacheBang(tableName);
-    await this.pool.serverVersion(this);
     this.validateIndexLengthBang(tableName, newName);
     if (!this.supportsRenameIndex()) {
       // Mirrors Rails AbstractAdapter#rename_index super path: drop the
@@ -1036,10 +1035,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   declare extractForeignKeyAction: typeof mysqlExtractForeignKeyAction;
 
   async checkConstraints(tableName: string): Promise<CheckConstraintDefinition[]> {
-    // supportsCheckConstraints() reads the cached databaseVersion, which throws
-    // pre-init; ensure the pool memo (`pool_config.rb:39-41`) is loaded first
-    // (mirrors the indexes() guard).
-    await this.pool.serverVersion(this);
     if (!this.supportsCheckConstraints()) {
       // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:545
       throw new NotImplementedError("check constraints are not supported by this database");
@@ -1231,8 +1226,8 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   // Mirrors: ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#check_version
   // (abstract_mysql_adapter.rb:684-688). Rails' `database_version` issues the
   // round-trip itself when unmemoized; trails' sync getter cannot, so
-  // `Mysql2Adapter#configureConnection` awaits `getDatabaseVersion()` before
-  // super invokes this.
+  // `AbstractAdapter#configureConnection` fills the pool memo before invoking
+  // this — the same ordering, one call site earlier.
   override checkVersion(): void {
     if (this.databaseVersion.compare("5.6.4") < 0) {
       throw new DatabaseVersionError(
@@ -1814,10 +1809,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     columnName: string,
     newColumnName: string,
   ): Promise<string> {
-    // Ensure the version is cached before branching — supportsRenameColumn() reads the sync
-    // `databaseVersion` getter, which throws on an uninitialized connection where Rails'
-    // `database_version` would issue the round-trip itself. The pool memoizes.
-    await this.pool.serverVersion(this);
     if (this.supportsRenameColumn()) {
       return this.renameColumnSql(tableName, columnName, newColumnName);
     }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -412,12 +412,6 @@ export class SchemaStatements {
 
     const td = this.buildCreateTableDefinition(name, options, definer);
 
-    // Prime the cached database version before the visitor emits DDL: inline
-    // `t.index order:` runs through SchemaCreation's synchronous
-    // supportsIndexSortOrder gate, which yields false on a cold connection
-    // (mirrors addIndex's warm-up). The pool memo (`pool_config.rb:39-41`) makes
-    // this a no-op when already warm.
-    await this.pool?.serverVersion?.(this);
     await this.execute(await this.schemaCreation.accept(td));
 
     if (!this.supportsIndexesInCreate?.()) {
@@ -529,13 +523,6 @@ export class SchemaStatements {
     columns: string | string[],
     options: AddIndexOptions = {},
   ): Promise<void> {
-    // Prime the cached database version before building the index definition,
-    // mirroring renameIndex/checkConstraints/renameColumnForAlter. Several
-    // version-gated predicates (e.g. MySQL's supportsIndexSortOrder) read
-    // `databaseVersion` synchronously and silently yield `false` on a cold
-    // connection (`undefined?.gte(...) !== true`); addIndex runs on the
-    // shared-worker reconstruct path before any query warms the cache.
-    await this.pool?.serverVersion?.(this);
     await this.schemaCache.clearDataSourceCacheBang(tableName);
     const createIndex = await this.buildCreateIndexDefinition(
       tableName,

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
@@ -277,8 +277,6 @@ export class SchemaCreation extends AbstractSchemaCreation {
     const quotedMap = new Map<string, string>(
       o.columns.map((c) => [c, this.adapter.quoteColumnName(c)]),
     );
-    // The createTable path warms getDatabaseVersion() upstream so the version-gated
-    // supportsIndexSortOrder read isn't cold.
     addOptionsForIndexColumns(
       quotedMap,
       {

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
@@ -45,7 +45,7 @@ function rowFormatHost(isMariadb: boolean, version: string, probeResult = 0) {
   const queries: string[] = [];
   return {
     isMariadb: () => isMariadb,
-    pool: { serverVersion: async () => new Version(version) },
+    databaseVersion: new Version(version),
     queryValue: async (sql: string) => {
       queries.push(sql);
       return probeResult;
@@ -55,16 +55,16 @@ function rowFormatHost(isMariadb: boolean, version: string, probeResult = 0) {
 }
 
 describe("MySQL::SchemaStatements", () => {
-  it("isRowFormatDynamicByDefault: MariaDB >= 10.2.2 is true", async () => {
-    expect(await isRowFormatDynamicByDefault.call(rowFormatHost(true, "10.2.2"))).toBe(true);
-    expect(await isRowFormatDynamicByDefault.call(rowFormatHost(true, "10.10.0"))).toBe(true);
-    expect(await isRowFormatDynamicByDefault.call(rowFormatHost(true, "10.2.1"))).toBe(false);
+  it("isRowFormatDynamicByDefault: MariaDB >= 10.2.2 is true", () => {
+    expect(isRowFormatDynamicByDefault.call(rowFormatHost(true, "10.2.2"))).toBe(true);
+    expect(isRowFormatDynamicByDefault.call(rowFormatHost(true, "10.10.0"))).toBe(true);
+    expect(isRowFormatDynamicByDefault.call(rowFormatHost(true, "10.2.1"))).toBe(false);
   });
 
-  it("isRowFormatDynamicByDefault: MySQL >= 5.7.9 is true", async () => {
-    expect(await isRowFormatDynamicByDefault.call(rowFormatHost(false, "5.7.9"))).toBe(true);
-    expect(await isRowFormatDynamicByDefault.call(rowFormatHost(false, "5.11.0"))).toBe(true);
-    expect(await isRowFormatDynamicByDefault.call(rowFormatHost(false, "5.7.8"))).toBe(false);
+  it("isRowFormatDynamicByDefault: MySQL >= 5.7.9 is true", () => {
+    expect(isRowFormatDynamicByDefault.call(rowFormatHost(false, "5.7.9"))).toBe(true);
+    expect(isRowFormatDynamicByDefault.call(rowFormatHost(false, "5.11.0"))).toBe(true);
+    expect(isRowFormatDynamicByDefault.call(rowFormatHost(false, "5.7.8"))).toBe(false);
   });
 
   it("defaultRowFormat: null when dynamic by default", async () => {

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
@@ -45,7 +45,7 @@ function rowFormatHost(isMariadb: boolean, version: string, probeResult = 0) {
   const queries: string[] = [];
   return {
     isMariadb: () => isMariadb,
-    databaseVersion: new Version(version),
+    pool: { serverVersion: async () => new Version(version) },
     queryValue: async (sql: string) => {
       queries.push(sql);
       return probeResult;
@@ -55,16 +55,16 @@ function rowFormatHost(isMariadb: boolean, version: string, probeResult = 0) {
 }
 
 describe("MySQL::SchemaStatements", () => {
-  it("isRowFormatDynamicByDefault: MariaDB >= 10.2.2 is true", () => {
-    expect(isRowFormatDynamicByDefault.call(rowFormatHost(true, "10.2.2"))).toBe(true);
-    expect(isRowFormatDynamicByDefault.call(rowFormatHost(true, "10.10.0"))).toBe(true);
-    expect(isRowFormatDynamicByDefault.call(rowFormatHost(true, "10.2.1"))).toBe(false);
+  it("isRowFormatDynamicByDefault: MariaDB >= 10.2.2 is true", async () => {
+    expect(await isRowFormatDynamicByDefault.call(rowFormatHost(true, "10.2.2"))).toBe(true);
+    expect(await isRowFormatDynamicByDefault.call(rowFormatHost(true, "10.10.0"))).toBe(true);
+    expect(await isRowFormatDynamicByDefault.call(rowFormatHost(true, "10.2.1"))).toBe(false);
   });
 
-  it("isRowFormatDynamicByDefault: MySQL >= 5.7.9 is true", () => {
-    expect(isRowFormatDynamicByDefault.call(rowFormatHost(false, "5.7.9"))).toBe(true);
-    expect(isRowFormatDynamicByDefault.call(rowFormatHost(false, "5.11.0"))).toBe(true);
-    expect(isRowFormatDynamicByDefault.call(rowFormatHost(false, "5.7.8"))).toBe(false);
+  it("isRowFormatDynamicByDefault: MySQL >= 5.7.9 is true", async () => {
+    expect(await isRowFormatDynamicByDefault.call(rowFormatHost(false, "5.7.9"))).toBe(true);
+    expect(await isRowFormatDynamicByDefault.call(rowFormatHost(false, "5.11.0"))).toBe(true);
+    expect(await isRowFormatDynamicByDefault.call(rowFormatHost(false, "5.7.8"))).toBe(false);
   });
 
   it("defaultRowFormat: null when dynamic by default", async () => {

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -163,25 +163,21 @@ interface QuotedScopeHost {
  */
 export interface RowFormatHost {
   isMariadb(): boolean;
-  pool: { serverVersion(connection: unknown): unknown };
+  databaseVersion: Version;
   queryValue(sql: string, name?: string): Promise<unknown>;
   _defaultRowFormat?: string | null;
 }
 
 /** @internal */
-export async function isRowFormatDynamicByDefault(this: RowFormatHost): Promise<boolean> {
-  // Rails' `database_version` is `pool.server_version(self)`
-  // (abstract_adapter.rb:854-856), which computes `get_database_version`
-  // lazily; the TS spelling of that laziness is awaiting the pool memo.
-  const databaseVersion = (await this.pool.serverVersion(this)) as Version;
+export function isRowFormatDynamicByDefault(this: RowFormatHost): boolean {
   return this.isMariadb()
-    ? databaseVersion.compare("10.2.2") >= 0
-    : databaseVersion.compare("5.7.9") >= 0;
+    ? this.databaseVersion.compare("10.2.2") >= 0
+    : this.databaseVersion.compare("5.7.9") >= 0;
 }
 
 /** @internal */
 export async function defaultRowFormat(this: RowFormatHost): Promise<string | null> {
-  if (await isRowFormatDynamicByDefault.call(this)) return null;
+  if (isRowFormatDynamicByDefault.call(this)) return null;
 
   if (!("_defaultRowFormat" in this)) {
     const value = await this.queryValue(

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -163,21 +163,29 @@ interface QuotedScopeHost {
  */
 export interface RowFormatHost {
   isMariadb(): boolean;
-  databaseVersion: Version;
+  pool: { serverVersion(connection: unknown): unknown };
   queryValue(sql: string, name?: string): Promise<unknown>;
   _defaultRowFormat?: string | null;
 }
 
 /** @internal */
-export function isRowFormatDynamicByDefault(this: RowFormatHost): boolean {
+export async function isRowFormatDynamicByDefault(this: RowFormatHost): Promise<boolean> {
+  // Rails' `row_format_dynamic_by_default?` (mysql/schema_statements.rb:146-152)
+  // is sync, reading `database_version` — a reader that fetches on demand and so
+  // works on a standalone, not-yet-connected adapter. Ours cannot, and
+  // `create_table` on such an adapter reaches here before anything has opened a
+  // socket, so the await stands in for Rails' lazy read. Converging it needs the
+  // version-gated predicates to go async (RFC 0072
+  // `make-version-gated-predicates-async`).
+  const databaseVersion = (await this.pool.serverVersion(this)) as Version;
   return this.isMariadb()
-    ? this.databaseVersion.compare("10.2.2") >= 0
-    : this.databaseVersion.compare("5.7.9") >= 0;
+    ? databaseVersion.compare("10.2.2") >= 0
+    : databaseVersion.compare("5.7.9") >= 0;
 }
 
 /** @internal */
 export async function defaultRowFormat(this: RowFormatHost): Promise<string | null> {
-  if (isRowFormatDynamicByDefault.call(this)) return null;
+  if (await isRowFormatDynamicByDefault.call(this)) return null;
 
   if (!("_defaultRowFormat" in this)) {
     const value = await this.queryValue(

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1726,13 +1726,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // getDatabaseVersion — so bail before the gate when there's no `_client`.
     if (this._connectionConfigured || !this._client) return;
     this._connectionConfigured = true;
-    // Warm the server version before checkVersion runs. Rails' check_version
-    // reads database_version, a synchronous accessor that itself triggers the
-    // round-trip (get_database_version) when unmemoized — so Rails guarantees the
-    // version is fetched before the floor check. checkVersion() is sync in trails
-    // and can't issue the query itself, so we await the warm here (the pool memo,
-    // pool_config.rb:39-41) before super.configureConnection() invokes it.
-    await this.pool.serverVersion(this);
     await super.configureConnection();
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -768,6 +768,20 @@ export class PostgreSQLAdapter
    */
   private async _maybeConfigureConnection(client: pg.Client): Promise<void> {
     if (this._connectionConfigured) return;
+    // Rails' PostgreSQLAdapter#configure_connection opens with `super`
+    // (postgresql_adapter.rb:957), so check_version — and with it the
+    // `database_version` round-trip — runs before anything else on the fresh
+    // socket. Our `databaseVersion` getter is sync and cannot self-fetch, so the
+    // memo is filled here instead, which is what lets every version-gated
+    // `supports*()` predicate read it without a warm of its own. Issued
+    // DIRECTLY on `client`, like the SET statements below: getDatabaseVersion()
+    // acquires its own client and would re-enter the acquire machinery that
+    // still holds `_acquiring`. A zero version is left uncached so
+    // getDatabaseVersion()'s ConnectionFailed path still owns that failure.
+    if (this._databaseVersion === null) {
+      const version = await this._serverVersion(client);
+      if (version !== 0) this._databaseVersion = version;
+    }
     // Rails resets @mapped_default_timezone = nil while installing decoders in
     // configure_connection (postgresql_adapter.rb:1112) so the next
     // update_typemap_for_default_timezone re-applies the session timezone. This
@@ -3831,11 +3845,6 @@ export class PostgreSQLAdapter
       comment?: string;
     } = {},
   ): Promise<void> {
-    // Priming the cached database version is a trails addition: the visitor's
-    // supportsNullsNotDistinct/supportsIndexInclude predicates read
-    // `databaseVersion` synchronously and silently yield false on a cold
-    // connection.
-    await this.getDatabaseVersion();
     await this.schemaCache.clearDataSourceCacheBang(tableName);
 
     const createIndex = (await this.buildCreateIndexDefinition(tableName, columns, options))!;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -768,16 +768,13 @@ export class PostgreSQLAdapter
    */
   private async _maybeConfigureConnection(client: pg.Client): Promise<void> {
     if (this._connectionConfigured) return;
-    // Rails' PostgreSQLAdapter#configure_connection opens with `super`
-    // (postgresql_adapter.rb:957), so check_version — and with it the
-    // `database_version` round-trip — runs before anything else on the fresh
-    // socket. Our `databaseVersion` getter is sync and cannot self-fetch, so the
-    // memo is filled here instead, which is what lets every version-gated
-    // `supports*()` predicate read it without a warm of its own. Issued
-    // DIRECTLY on `client`, like the SET statements below: getDatabaseVersion()
-    // acquires its own client and would re-enter the acquire machinery that
-    // still holds `_acquiring`. A zero version is left uncached so
-    // getDatabaseVersion()'s ConnectionFailed path still owns that failure.
+    // Deviation, language-forced: Rails' configure_connection opens with `super`
+    // (postgresql_adapter.rb:957), whose check_version reads the lazy sync
+    // `database_version`. Ours cannot self-fetch, so the memo is filled at that
+    // same position. Issued DIRECTLY on `client`, like the SET statements below:
+    // getDatabaseVersion() acquires its own client and would re-enter the
+    // acquire machinery still holding `_acquiring`. A zero version is left
+    // uncached so getDatabaseVersion()'s ConnectionFailed path still owns it.
     if (this._databaseVersion === null) {
       const version = await this._serverVersion(client);
       if (version !== 0) this._databaseVersion = version;

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -405,8 +405,6 @@ export class SchemaStatements extends AbstractSchemaStatements {
   }
 
   override async tableOptions(tableName: string): Promise<Record<string, unknown>> {
-    // supportsNativePartitioning() reads databaseVersion; ensure it's populated.
-    await this.getDatabaseVersion();
     const options: Record<string, unknown> = {};
     const comment = await this.tableComment(tableName);
     if (comment !== null) options.comment = comment;

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -446,13 +446,7 @@ export class InsertAll {
     // and emit a bogus conflict target.
     const conn = this.connection as {
       supportsInsertConflictTarget?: () => boolean;
-      pool?: { serverVersion?: (connection: unknown) => unknown };
     };
-    // PG's supports_insert_conflict_target reads databaseVersion via a sync
-    // getter that throws until the pool memo (`pool_config.rb:39-41`) has been
-    // populated. Cold upsertAll(..., { uniqueBy }) would trip that before
-    // uniqueIndexes ran, so prime the version here.
-    await conn.pool?.serverVersion?.(conn);
     const supports =
       typeof conn.supportsInsertConflictTarget === "function"
         ? conn.supportsInsertConflictTarget()

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -764,21 +764,14 @@ export abstract class SchemaDumper {
       | {
           checkConstraints: (t: string) => Promise<unknown[]>;
           supportsCheckConstraints?: () => boolean;
-          pool?: { serverVersion?: (connection: unknown) => unknown };
         }
       | undefined;
     if (!host) return;
     // Mirror Rails' call-site guard (`schema_dumper.rb:210`: `... if
     // @connection.supports_check_constraints?`): adapters whose checkConstraints
     // raises NotImplementedError when unsupported (e.g. MySQL <8.0.16, MariaDB
-    // <10.2.1) must not be queried. supportsCheckConstraints reads the cached
-    // database version, which the dump path doesn't always load eagerly, so
-    // ensure it's resolved first to avoid a false negative dropping real
-    // constraints from the dump.
-    if (host.supportsCheckConstraints) {
-      await host.pool?.serverVersion?.(host);
-      if (!host.supportsCheckConstraints()) return;
-    }
+    // <10.2.1) must not be queried.
+    if (host.supportsCheckConstraints && !host.supportsCheckConstraints()) return;
     const constraints = (await host.checkConstraints(tableName)) ?? [];
     for (const chk of constraints as { expression: string; name?: string; validate?: boolean }[]) {
       const [expr, ...opts] = this.checkParts(chk);

--- a/packages/activerecord/src/support/canonical-schema.ts
+++ b/packages/activerecord/src/support/canonical-schema.ts
@@ -259,6 +259,15 @@ let _registry: CanonicalTableDef[] | null = null;
 export async function prepareSchema(
   adapter: DatabaseAdapter,
 ): Promise<{ ss: SchemaStatements; typeMap: Record<string, string | undefined> }> {
+  // Rails' schema loader always runs on a checked-out — therefore connected —
+  // connection, because `checkout` ends in `verify!` (`abstract_adapter.rb:759`).
+  // trails' adapters connect lazily on the first query, so the DDL below would
+  // otherwise be the first thing to touch a cold adapter, and the version-gated
+  // predicates `create_table` reads (`row_format_dynamic_by_default?`,
+  // `supports_index_sort_order?`) are sync. Establishing the connection here is
+  // what Rails' checkout does; `configure_connection` fills the version memo on
+  // the way through, so no ported body needs a warm of its own.
+  await (adapter as { verifyBang?: () => Promise<void> }).verifyBang?.();
   const ss = adapter as unknown as SchemaStatements;
   const typeMap =
     adapter.adapterName === "postgres"

--- a/packages/activerecord/src/support/canonical-schema.ts
+++ b/packages/activerecord/src/support/canonical-schema.ts
@@ -267,7 +267,7 @@ export async function prepareSchema(
   // `supports_index_sort_order?`) are sync. Establishing the connection here is
   // what Rails' checkout does; `configure_connection` fills the version memo on
   // the way through, so no ported body needs a warm of its own.
-  await (adapter as { verifyBang?: () => Promise<void> }).verifyBang?.();
+  await adapter.verifyBang();
   const ss = adapter as unknown as SchemaStatements;
   const typeMap =
     adapter.adapterName === "postgres"

--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -21,11 +21,6 @@ import { STUBBED_DDL_METHODS } from "./stubbed-ddl-methods.js";
  * and the `supports_insert_returning?` trigger table (203-225) — the file whole.
  */
 async function loadPostgresqlSpecificSchema(adapter: PostgreSQLAdapter): Promise<void> {
-  // `supportsPgcryptoUuid()` / `supportsVirtualColumns()` read the cached
-  // `databaseVersion`, whose sync getter throws until the version has been
-  // fetched once.
-  await adapter.getDatabaseVersion();
-
   await adapter.enableExtension("uuid-ossp");
   if (adapter.supportsPgcryptoUuid()) await adapter.enableExtension("pgcrypto");
 
@@ -345,7 +340,6 @@ async function loadPostgresqlSpecificSchema(adapter: PostgreSQLAdapter): Promise
  * worker and so cannot pull in `supports.ts`'s `vitest` import.
  */
 async function loadMysql2SpecificSchema(adapter: AbstractMysqlAdapter): Promise<void> {
-  await adapter.pool.serverVersion(adapter);
   const supportsDefaultExpression = adapter.isMariadb()
     ? adapter.databaseVersion.compare("10.2.1") >= 0
     : adapter.databaseVersion.compare("8.0.13") >= 0;

--- a/packages/activerecord/src/support/schema-types.ts
+++ b/packages/activerecord/src/support/schema-types.ts
@@ -219,13 +219,9 @@ export function columnsOf(table: TableSchema): Record<string, ColumnSpec> {
  * @internal
  */
 export async function supportsExpressionIndex(adapter: DatabaseAdapter): Promise<boolean> {
-  const a = adapter as {
-    supportsExpressionIndex?: () => boolean;
-    pool?: { serverVersion?: (connection: unknown) => unknown };
-  };
+  const a = adapter as { supportsExpressionIndex?: () => boolean };
   if (typeof a.supportsExpressionIndex !== "function") return false;
   try {
-    await a.pool?.serverVersion?.(a);
     return a.supportsExpressionIndex();
   } catch {
     return false;

--- a/packages/activerecord/src/support/stubbed-ddl-methods.test.ts
+++ b/packages/activerecord/src/support/stubbed-ddl-methods.test.ts
@@ -24,6 +24,16 @@ const NON_EMITTING: ReadonlyMap<string, string> = new Map([
     "warm-up read — primes the memoized version the index sort-order predicates gate on",
   ],
   [
+    "verifyBang",
+    "connection readiness — Rails' `verify!` (`abstract_adapter.rb:759`), which the loader runs before any DDL; emits none itself",
+  ],
+  ["active", "liveness read `verifyBang` branches on, not a DDL emitter"],
+  [
+    "completeAsyncConnect",
+    "settles SQLite's async open so `active` can answer; connection setup, emits no DDL",
+  ],
+  ["verifiedBang", "post-verify bookkeeping — stamps `_lastActivity`/`_verified`, emits no DDL"],
+  [
     "validateCreateTableOptionsBang",
     "option validation — raises on an unknown key, emits no DDL of its own",
   ],

--- a/scripts/test-compare/assertion-values.test.ts
+++ b/scripts/test-compare/assertion-values.test.ts
@@ -93,16 +93,10 @@ describe("assertionValueMismatch", () => {
   });
 
   it("never flags an RFC 0088 Temporal-vs-Ruby-temporal expected value", () => {
-    // RFC 0088's headline decision is that trails returns Temporal types where
-    // the `date` gem returns Date/DateTime/Time, so a faithfully-ported gem test
-    // pairs `assert_equal Date.new(2001, 2, 3), Date.parse("2001-02-03")` with
-    // `expect(...).toEqual(Temporal.PlainDate.from("2001-02-03"))`. Neither
-    // expected argument is a literal — both extractors emit `null` for a method
-    // call (extract-ruby-tests.rb literal_token, extract-ts-core.ts
-    // literalToken) — so the kind is skipped and `date.value` cannot rise for
-    // the intended shape. This is the mechanism the story asked for, and it is
-    // structural rather than an exclusion: locked here so a future extractor
-    // that starts capturing constructor calls has to confront it.
+    // `assert_equal Date.new(2001, 2, 3), …` vs
+    // `expect(…).toEqual(Temporal.PlainDate.from("2001-02-03"))`: both extractors
+    // emit `null` for a method call, so the kind is skipped and `date.value`
+    // cannot rise for RFC 0088's intended shape. See the module header.
     expect(assertionValueMismatch(["assert_equal"], [null], ["toEqual"], [null], false)).toBeNull();
     // A one-sided capture is skipped too: the sides are not both fully literal.
     expect(

--- a/scripts/test-compare/assertion-values.test.ts
+++ b/scripts/test-compare/assertion-values.test.ts
@@ -92,6 +92,24 @@ describe("assertionValueMismatch", () => {
     expect(deltas).toEqual([{ kind: "same", rails: ["n:5"], trails: ["n:4"] }]);
   });
 
+  it("never flags an RFC 0088 Temporal-vs-Ruby-temporal expected value", () => {
+    // RFC 0088's headline decision is that trails returns Temporal types where
+    // the `date` gem returns Date/DateTime/Time, so a faithfully-ported gem test
+    // pairs `assert_equal Date.new(2001, 2, 3), Date.parse("2001-02-03")` with
+    // `expect(...).toEqual(Temporal.PlainDate.from("2001-02-03"))`. Neither
+    // expected argument is a literal — both extractors emit `null` for a method
+    // call (extract-ruby-tests.rb literal_token, extract-ts-core.ts
+    // literalToken) — so the kind is skipped and `date.value` cannot rise for
+    // the intended shape. This is the mechanism the story asked for, and it is
+    // structural rather than an exclusion: locked here so a future extractor
+    // that starts capturing constructor calls has to confront it.
+    expect(assertionValueMismatch(["assert_equal"], [null], ["toEqual"], [null], false)).toBeNull();
+    // A one-sided capture is skipped too: the sides are not both fully literal.
+    expect(
+      assertionValueMismatch(["assert_equal"], [null], ["toEqual"], ["s:2001-02-03"], false),
+    ).toBeNull();
+  });
+
   it("returns null for a pending stub or missing kind data", () => {
     expect(
       assertionValueMismatch(["assert_equal"], ["n:5"], ["toEqual"], ["n:4"], true),

--- a/scripts/test-compare/assertion-values.ts
+++ b/scripts/test-compare/assertion-values.ts
@@ -22,6 +22,13 @@
 // divergence for a ported assertion). NOT normalized: numeric width/precision
 // (`n:5` ≠ `n:5.0`), string case/whitespace, or regex/array/hash literals (those
 // arrive as `null` — a non-literal — and are skipped, never compared).
+//
+// RFC 0088 (the `date` gem port) returns Temporal types where Ruby returns
+// Date/DateTime/Time, so a faithful port pairs `assert_equal Date.new(2001,2,3),
+// …` with `expect(…).toEqual(Temporal.PlainDate.from("2001-02-03"))`. Both are
+// method calls, so both extractors emit `null` and the kind is skipped: the
+// value counter cannot rise for that shape, with no exclusion list needed. See
+// the regression test in assertion-values.test.ts.
 
 import { normalizeRailsKind, normalizeTrailsKind, type CanonicalKind } from "./assertion-kinds.js";
 


### PR DESCRIPTION
Bundle of three RFC 0072 / RFC 0088 stories. **Two close here; one is blocked by
this PR's own findings — read the next section first.**

## Story disposition — one AC is NOT met

`database-version-sync-getter-forces-hand-warms` requires picking one of its two
shapes and **applying it uniformly**. This PR applies shape 2 (fill the memo by
construction) everywhere except `row_format_dynamic_by_default?`, which provably
cannot work under it. **Its AC #1 is therefore not met, and this PR does not close
it** — it is `block`ed, citing the successor story below. Do not read the sections
that follow as claiming full convergence.

Closing here, both fully met:

- `retire-trails-only-database-version-warm-ups` — all eleven warms deleted.
- `date-assertion-value-mark-vs-temporal-returns` — mechanism (a), holding by
  construction.

## The version memo is filled where Rails fills it

Rails' `database_version` (`abstract_adapter.rb:854-856`) is a **sync** reader
whose `pool.server_version(self)` issues the round-trip on demand, so every
version-gated `supports_*?` predicate is callable at any time with no
preparation. trails' `databaseVersion` is a sync getter over an async
`getDatabaseVersion()`, so it cannot self-fetch — and that forced a hand-warm
into every ported body that reads one, none of which Rails has.

This takes the story's shape (2): fill the memo once, on connection
establishment. It is **necessary but not sufficient** — see the disposition note
above and the limits section below.

- `AbstractAdapter#configureConnection` (`abstract_adapter.rb:1212-1214`) fills
  `pool.serverVersion(this)` before `checkVersion()` — the same ordering Rails
  gets from `check_version` reading the lazy reader, one call site earlier. The
  sync arm is kept so SQLite's `configure_connection` stays synchronous like
  Rails'. This one extra line is the whole deviation, justified at the call
  site.
- `PostgreSQLAdapter#_maybeConfigureConnection` fills its own memo at the
  position Rails' `super` occupies (`postgresql_adapter.rb:957`), issued
  directly on `client` like the neighbouring SET statements — `getDatabaseVersion()`
  acquires its own client and would re-enter the acquire machinery that still
  holds `_acquiring`. A zero version is left uncached so `getDatabaseVersion()`'s
  `ConnectionFailed` path still owns that failure.

Every warm then deletes:

| file | method |
| --- | --- |
| `abstract-mysql-adapter.ts` | `renameIndex`, `checkConstraints`, `renameColumnForAlter` |
| `mysql2-adapter.ts` | `configureConnection` (now just `super`) |
| `postgresql-adapter.ts` | `addIndex` |
| `postgresql/schema-statements-class.ts` | `tableOptions` |
| `support/load-schema-helper.ts` | `loadPostgresqlSpecificSchema`, `loadMysql2SpecificSchema` |
| `support/schema-types.ts` | `supportsExpressionIndex` |
| `abstract/schema-statements.ts` | `createTable`, `addIndex` |
| `schema-dumper.ts` | `checkConstraintsInCreate` |
| `insert-all.ts` | the `uniqueBy` path |

## What this shape does NOT cover — read before reviewing

The MariaDB lane rejected the first attempt, and chasing it against a live MySQL
8.4.9 found **three** cold reads. The third is decisive: shape 2 cannot be made
airtight, because the read is sync and the connect is async.

1. `prepareSchema` runs the canonical DDL on a pool-provided but **not-yet-
   connected** adapter. Fixed the way Rails does it — `checkout` ends in
   `verify!` (`abstract_adapter.rb:759`), so the loader establishes the
   connection before the DDL.
2. `connection.test.ts`'s `afterEach` nulls the memo for *every* test, and
   `verifyBang()` short-circuits on a live connection, so the next test inherited
   a permanently cold version. Rails' reader re-runs the query once the stub is
   gone; refilled in the hook that empties it.
3. `schema.test.ts:188` constructs a **standalone** `new Mysql2Adapter(...)` and
   calls `createTable` as its first operation. There is no connect event to hang
   a fill on. **No fix exists under this shape.**

So `MySQL::SchemaStatements#row_format_dynamic_by_default?` keeps the async pool
read it has on `main`, with the reason recorded at the call site, rather than
converging to Rails' sync predicate (`mysql/schema_statements.rb:146-152`). That
convergence — and removing items 1 and 2 above, which are scaffolding for this
shape — is filed as RFC 0072 `make-version-gated-predicates-async`, the story's
shape 1, now backed by these three reproductions.

`rename-column-for-alter-hand-warms-database-version` (blocked, `pr: 6146`) is
unblocked by this: its warm is one of the three deleted above. Left for its
owner to reap rather than closing it out from under them.

New coverage in `abstract-adapter-version.trails.test.ts`: `databaseVersion` is
readable after `configureConnection()` with no caller-side warm, and the fetch
runs exactly once, before `checkVersion` reads it.

**Verified on real databases this time**, not just SQLite — the first round was
graded green off SQLite runs and gates, which cannot exercise any of this.

## RFC 0088 assertion-value mark

The premise turned out not to bite, and the honest mechanism is preference (a)
already holding by construction rather than an exclusion:
`assert_equal Date.new(2001, 2, 3), …` and
`expect(…).toEqual(Temporal.PlainDate.from("2001-02-03"))` are **method calls on
both sides**, so `extract-ruby-tests.rb`'s `literal_token` and
`extract-ts-core.ts`'s `literalToken` both emit `null`, and
`assertionValueMismatch`'s "both sides fully literal" rule skips the kind.
Verified by running the Ruby extractor over that exact pair. `date.value`
therefore cannot rise for the intended shape, and `assertionCount`/`kind` stay
real gates. Locked with a regression test in `assertion-values.test.ts` plus a
note in the module header, so a future extractor that starts capturing
constructor calls has to confront it. The RFC 0088 README "Known consequence"
paragraph is updated in the tasks repo.

`date` is not yet in `ASSERTION_REPORT_PACKAGES` or the mark file on `main` —
that arrives with the still-open #6148 — so this PR deliberately touches neither.

## Verification

- `pnpm typecheck` clean.
- `pnpm api:calls` — ratchet OK, no new rows.
- `pnpm api:extra --package activerecord` — no new novel surface.
- `pnpm test:assertions:ratchet` OK; `pnpm test:compare` value mismatches under
  the mark.
- **MySQL 8.4.9** (local container), adapters + connection-adapters +
  schema-dumper + insert-all: **141 files / 2081 tests, 0 failures** (was 2).
- **PostgreSQL** (local container), same paths: **160 files / 2838 tests, 0
  failures**.
- **SQLite**, same paths: **121 files / 1995 tests, 0 failures**.
- `pnpm vitest run` on `assertion-values`, `abstract-adapter*`, `pool-config`,
  `abstract/schema-statements*`, `schema-dumper*`, `insert-all*`,
  `mysql/schema-statements` — all green.

Closes-story: date-assertion-value-mark-vs-temporal-returns
Closes-story: retire-trails-only-database-version-warm-ups

## Review round 2

- `prepareSchema`'s `verifyBang()` no longer casts to an optional method.
  `adapter` is `AbstractAdapter`, which declares `verifyBang(): Promise<void>`
  unconditionally (`abstract-adapter.ts:1352`, overridden by PG), so the
  cast-and-`?.()` erased a guarantee for nothing. Now `await adapter.verifyBang();`.
- On the flagged round-trip question: no regression. Once resolved,
  `PoolConfig#serverVersion` short-circuits on `_serverVersion != null`
  (`pool-config.ts:151`) and returns the value, so the `await` in
  `isRowFormatDynamicByDefault` is a microtask, not a query. The fetch happens at
  most once per pool, exactly as Rails' `@server_version ||=`
  (`pool_config.rb:39-41`).

## Filed, not absorbed

Review tracing turned up a pre-existing gap this PR does not touch:
`PostgreSQLAdapter` never calls `checkVersion()` anywhere, so Rails' PG version
floor (`postgresql_adapter.rb:669`, reached via `configure_connection`'s `super`
at `:957`) effectively does not exist in trails. Confirmed pre-existing on
`main`, and out of scope for these three stories. Filed as RFC 0072
`pg-configure-connection-never-calls-check-version` — the memo fill this PR adds
at exactly that position is what unblocks it.
