### PR TITLE
feat(activerecord,scripts): quoted_date formats through packages/date; the call ratchet compares sequences, not just sets

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/precision-roundtrip.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/precision-roundtrip.test.ts
@@ -83,11 +83,13 @@ describe("formatPlainDateForSql", () => {
     expect(formatPlainDateForSql(Temporal.PlainDate.from("2026-01-05"))).toBe("2026-01-05");
   });
 
-  it("formats a negative (BCE) year matching quotedDate(Date) convention (no zero-padding)", () => {
-    // year -43 = 44 BC in proleptic Gregorian; String(-43) → "-43", matching
-    // how quotedDate(Date) formats years (String(getUTCFullYear()) — no padding).
+  it("formats a negative (BCE) year the way the date gem's %Y does", () => {
+    // year -43 = 44 BC in proleptic Gregorian. `to_fs(:db)` is
+    // `strftime("%Y-%m-%d")`, and the gem's `%Y` pads the digits to four behind
+    // the sign (`Date.new(-43, 3, 15).to_fs(:db)` → "-0043-03-15"), so routing
+    // this through packages/date drops the old unpadded "-43-03-15".
     expect(formatPlainDateForSql(Temporal.PlainDate.from({ year: -43, month: 3, day: 15 }))).toBe(
-      "-43-03-15",
+      "-0043-03-15",
     );
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract/sql-datetime.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/sql-datetime.ts
@@ -33,8 +33,8 @@ import { ActiveRecord } from "../../ar-config.js";
  * `value.to_fs(:db)` (abstract/quoting.rb:193) resolves to, depending on
  * whether the value carries a time.
  */
-const DB_TIME_FORMAT = "%Y-%m-%d %H:%M:%S";
-const DB_DATE_FORMAT = "%Y-%m-%d";
+const TIME_DB_FORMAT = "%Y-%m-%d %H:%M:%S";
+const DATE_DB_FORMAT = "%Y-%m-%d";
 
 /**
  * @internal The fields the `date` gem's `strftime` reads off its receiver.
@@ -75,7 +75,7 @@ function strftimeSubject(v: {
  * value.usec)` when `usec > 0`.
  */
 function toFsDbWithUsec(subject: StrftimeSubject): string {
-  return strftime(subject, DB_TIME_FORMAT) + microsecondFraction(Math.floor(subject.nsec / 1_000));
+  return strftime(subject, TIME_DB_FORMAT) + microsecondFraction(Math.floor(subject.nsec / 1_000));
 }
 
 /**
@@ -113,7 +113,7 @@ export function formatPlainDateTimeForSql(value: Temporal.PlainDateTime): string
  * Format a `Temporal.PlainDate` for SQL as `YYYY-MM-DD`.
  */
 export function formatPlainDateForSql(value: Temporal.PlainDate): string {
-  return strftime(strftimeSubject(value.toPlainDateTime()), DB_DATE_FORMAT);
+  return strftime(strftimeSubject(value.toPlainDateTime()), DATE_DB_FORMAT);
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/abstract/sql-datetime.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/sql-datetime.ts
@@ -23,8 +23,60 @@
  * address and calls into this file.
  */
 
-import { Temporal } from "@blazetrails/date";
+import { Temporal, strftime, type StrftimeSubject } from "@blazetrails/date";
 import { ActiveRecord } from "../../ar-config.js";
+
+/**
+ * `Time::DATE_FORMATS[:db]` (activesupport/lib/active_support/core_ext/time/
+ * conversions.rb:9) and `Date::DATE_FORMATS[:db]`
+ * (core_ext/date/conversions.rb:12) — the two formats `quoted_date`'s
+ * `value.to_fs(:db)` (abstract/quoting.rb:193) resolves to, depending on
+ * whether the value carries a time.
+ */
+const DB_TIME_FORMAT = "%Y-%m-%d %H:%M:%S";
+const DB_DATE_FORMAT = "%Y-%m-%d";
+
+/**
+ * @internal The fields the `date` gem's `strftime` reads off its receiver.
+ * `%Y-%m-%d %H:%M:%S` touches none of `wday` / `yday` / `zone` / `utcOffset`,
+ * but the subject is the whole receiver, so build it whole.
+ */
+function strftimeSubject(v: {
+  year: number;
+  month: number;
+  day: number;
+  dayOfWeek: number;
+  dayOfYear: number;
+  hour: number;
+  minute: number;
+  second: number;
+  millisecond: number;
+  microsecond: number;
+  nanosecond: number;
+}): StrftimeSubject {
+  return {
+    year: v.year,
+    mon: v.month,
+    day: v.day,
+    wday: v.dayOfWeek % 7,
+    yday: v.dayOfYear,
+    hour: v.hour,
+    min: v.minute,
+    sec: v.second,
+    nsec: v.millisecond * 1_000_000 + v.microsecond * 1_000 + v.nanosecond,
+    zone: "",
+    utcOffset: 0,
+  };
+}
+
+/**
+ * `quoted_date`'s body (abstract/quoting.rb:184-199) over an already
+ * timezone-resolved value: `value.to_fs(:db)`, then `"." + sprintf("%06d",
+ * value.usec)` when `usec > 0`.
+ */
+function toFsDbWithUsec(subject: StrftimeSubject): string {
+  return strftime(subject, DB_TIME_FORMAT) + microsecondFraction(Math.floor(subject.nsec / 1_000));
+}
 
 /**
  * Return the IANA timezone string for SQL datetime serialization/deserialization,
@@ -44,7 +96,7 @@ export function defaultSqlTimezone(): string {
  * otherwise the host system's local timezone.
  */
 export function formatInstantForSql(value: Temporal.Instant): string {
-  return formatZonedComponents(value.toZonedDateTimeISO(defaultSqlTimezone()));
+  return toFsDbWithUsec(strftimeSubject(value.toZonedDateTimeISO(defaultSqlTimezone())));
 }
 
 /**
@@ -54,94 +106,70 @@ export function formatInstantForSql(value: Temporal.Instant): string {
  * (see {@link formatInstantForSql}).
  */
 export function formatPlainDateTimeForSql(value: Temporal.PlainDateTime): string {
-  return formatPlainComponents(value);
+  return toFsDbWithUsec(strftimeSubject(value));
 }
 
 /**
  * Format a `Temporal.PlainDate` for SQL as `YYYY-MM-DD`.
  */
 export function formatPlainDateForSql(value: Temporal.PlainDate): string {
-  const y = padYear(value.year);
-  const m = String(value.month).padStart(2, "0");
-  const d = String(value.day).padStart(2, "0");
-  return `${y}-${m}-${d}`;
+  return strftime(strftimeSubject(value.toPlainDateTime()), DB_DATE_FORMAT);
 }
 
 /**
- * PostgreSQL literal formatters, faithful to `PostgreSQL::Quoting#quoted_date`
- * (and the abstract `quoted_date` it builds on, abstract/quoting.rb:188-197):
+ * PostgreSQL literal formatters. `PostgreSQL::Quoting#quoted_date`
+ * (postgresql/quoting.rb:143-150) is a pure override over the abstract one:
  *
- *   result = value.to_fs(:db)                       # "YYYY-MM-DD HH:MM:SS"
- *   if value.respond_to?(:usec) && value.usec > 0   # append microseconds only
- *     "#{result}.#{sprintf("%06d", value.usec)}"    # when non-zero, fixed 6 digits
- *   ...
- *   # PG#quoted_date then suffixes " BC" for proleptic years <= 0.
+ *   if value.year <= 0
+ *     bce_year = format("%04d", -value.year + 1)
+ *     super.sub(/^-?\d+/, bce_year) + " BC"
+ *   else
+ *     super
+ *   end
  *
- * Shares the fixed-6 microsecond fraction ({@link microsecondFraction}) with the
- * abstract/MySQL formatters; the only PG-specific behavior is the " BC" suffix
- * appended for proleptic years <= 0.
+ * so each PG arm here calls the abstract formatter above — the shared
+ * `to_fs(:db)` path through `packages/date`'s `strftime` — and applies only
+ * that year rewrite, exactly as `super` does.
  */
-function pgDateTimeLiteral(
-  year: number,
-  month: number,
-  day: number,
-  hour: number,
-  min: number,
-  sec: number,
-  usec: number,
-): string {
-  const isBc = year <= 0;
-  const yyyy = String(isBc ? -year + 1 : year).padStart(4, "0");
-  const p2 = (n: number) => String(n).padStart(2, "0");
-  const s = `${yyyy}-${p2(month)}-${p2(day)} ${p2(hour)}:${p2(min)}:${p2(sec)}${microsecondFraction(usec)}`;
-  return isBc ? `${s} BC` : s;
+function bceSuffixed(year: number, superResult: string): string {
+  if (year <= 0) {
+    const bceYear = String(-year + 1).padStart(4, "0");
+    return `${superResult.replace(/^-?\d+/, bceYear)} BC`;
+  }
+  return superResult;
 }
 
 export function formatInstantForSqlPostgres(value: Temporal.Instant): string {
   const z = value.toZonedDateTimeISO(defaultSqlTimezone());
-  return pgDateTimeLiteral(
-    z.year,
-    z.month,
-    z.day,
-    z.hour,
-    z.minute,
-    z.second,
-    z.millisecond * 1000 + z.microsecond,
-  );
+  return bceSuffixed(z.year, formatInstantForSql(value));
 }
 
 export function formatPlainDateTimeForSqlPostgres(value: Temporal.PlainDateTime): string {
-  return pgDateTimeLiteral(
-    value.year,
-    value.month,
-    value.day,
-    value.hour,
-    value.minute,
-    value.second,
-    value.millisecond * 1000 + value.microsecond,
-  );
+  return bceSuffixed(value.year, formatPlainDateTimeForSql(value));
 }
 
 export function formatPlainDateForSqlPostgres(value: Temporal.PlainDate): string {
-  const isBc = value.year <= 0;
-  const yyyy = String(isBc ? -value.year + 1 : value.year).padStart(4, "0");
-  const s = `${yyyy}-${String(value.month).padStart(2, "0")}-${String(value.day).padStart(2, "0")}`;
-  return isBc ? `${s} BC` : s;
+  return bceSuffixed(value.year, formatPlainDateForSql(value));
 }
 
 /**
- * Format a `Temporal.PlainTime` for SQL as `HH:MM:SS[.ffffff]`. Fractional part
- * is a fixed 6-digit microsecond field when `usec > 0`, capped at microseconds
- * (see {@link formatInstantForSql}).
+ * Format a `Temporal.PlainTime` for SQL as `HH:MM:SS[.ffffff]`, the way
+ * `quoted_time` (abstract/quoting.rb:201-204) does it: move the value to
+ * 2000-01-01, format it through `quoted_date`, and strip the date prefix.
  */
 export function formatPlainTimeForSql(value: Temporal.PlainTime): string {
-  return formatTimeComponents(
+  const dt = new Temporal.PlainDateTime(
+    2000,
+    1,
+    1,
     value.hour,
     value.minute,
     value.second,
     value.millisecond,
     value.microsecond,
+    value.nanosecond,
   );
+  return formatPlainDateTimeForSql(dt).replace(/^\d{4}-\d{2}-\d{2} /, "");
 }
 
 /**
@@ -153,41 +181,6 @@ export function formatPlainTimeForSql(value: Temporal.PlainTime): string {
 export const formatInstantForSqlMysql = formatInstantForSql;
 export const formatPlainDateTimeForSqlMysql = formatPlainDateTimeForSql;
 export const formatPlainTimeForSqlMysql = formatPlainTimeForSql;
-
-function formatDatePrefix(v: { year: number; month: number; day: number }): string {
-  return `${padYear(v.year)}-${String(v.month).padStart(2, "0")}-${String(v.day).padStart(2, "0")} `;
-}
-
-function padYear(year: number): string {
-  if (year < 0) return String(year);
-  return String(year).padStart(4, "0");
-}
-
-function formatZonedComponents(zdt: Temporal.ZonedDateTime): string {
-  return (
-    formatDatePrefix(zdt) +
-    formatTimeComponents(zdt.hour, zdt.minute, zdt.second, zdt.millisecond, zdt.microsecond)
-  );
-}
-
-function formatPlainComponents(pdt: Temporal.PlainDateTime): string {
-  return (
-    formatDatePrefix(pdt) +
-    formatTimeComponents(pdt.hour, pdt.minute, pdt.second, pdt.millisecond, pdt.microsecond)
-  );
-}
-
-/**
- * Build the `HH:MM:SS` base and append Rails' fixed 6-digit microsecond field
- * when non-zero. Sub-microsecond precision (nanoseconds) is dropped, matching
- * the abstract `quoted_date` cap and MySQL's fractional-seconds resolution.
- */
-function formatTimeComponents(h: number, min: number, s: number, ms: number, us: number): string {
-  const hh = String(h).padStart(2, "0");
-  const mm = String(min).padStart(2, "0");
-  const ss = String(s).padStart(2, "0");
-  return `${hh}:${mm}:${ss}${microsecondFraction(ms * 1000 + us)}`;
-}
 
 /**
  * Rails `quoted_date`'s fractional-seconds rule (abstract/quoting.rb:194-195):

--- a/scripts/api-compare/call-mismatches-exclude/abstractcontroller/caching/fragments.json
+++ b/scripts/api-compare/call-mismatches-exclude/abstractcontroller/caching/fragments.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "abstractcontroller",
+    "tsFile": "caching/fragments.ts",
+    "rubyName": "expire_fragment",
+    "call": "order:instrumentFragmentCache,combinedFragmentCacheKey",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/abstractcontroller/helpers.json
+++ b/scripts/api-compare/call-mismatches-exclude/abstractcontroller/helpers.json
@@ -19,5 +19,12 @@
     "rubyName": "helper",
     "call": "modules_for_helpers",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "abstractcontroller",
+    "tsFile": "helpers.ts",
+    "rubyName": "helper_modules_from_paths",
+    "call": "order:allHelpersFromPath,modulesForHelpers",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal/request-forgery-protection.json
+++ b/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal/request-forgery-protection.json
@@ -23,6 +23,20 @@
   {
     "package": "actioncontroller",
     "tsFile": "metal/request-forgery-protection.ts",
+    "rubyName": "mask_token",
+    "call": "order:encodeCsrfToken,xorByteStrings",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/request-forgery-protection.ts",
+    "rubyName": "masked_authenticity_token",
+    "call": "order:perFormCsrfToken,normalizeActionPath",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/request-forgery-protection.ts",
     "rubyName": "reset",
     "call": "delete",
     "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails request_forgery_protection.rb:328-330/361-363 call `session.delete`/`cookie_jar.delete`; trails request-forgery-protection.ts:138-140/160-162 use the JS `delete obj[key]` operator, which records no call."

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/content-security-policy.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/content-security-policy.json
@@ -9,6 +9,13 @@
   {
     "package": "actiondispatch",
     "tsFile": "http/content-security-policy.ts",
+    "rubyName": "build_directives",
+    "call": "order:buildDirective,isNonceDirective",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/content-security-policy.ts",
     "rubyName": "generate_content_security_policy_nonce",
     "call": "call",
     "reason": "Ruby Proc#call has no JS counterpart: the generator is invoked as a plain call, `generator(this)`, since JS `Function#call` would bind the argument as the receiver instead of passing it."

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/mime-negotiation.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/mime-negotiation.json
@@ -19,5 +19,12 @@
     "rubyName": "formats",
     "call": "fetch_header",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/mime-negotiation.ts",
+    "rubyName": "formats=",
+    "call": "order:lookupByExtension,setHeader",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/journey/gtg/builder.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/journey/gtg/builder.json
@@ -2,6 +2,13 @@
   {
     "package": "actiondispatch",
     "tsFile": "journey/gtg/builder.ts",
+    "rubyName": "build_followpos",
+    "call": "order:firstpos,lastpos",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "journey/gtg/builder.ts",
     "rubyName": "nullable?",
     "call": "match?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/ssl.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/ssl.json
@@ -9,6 +9,13 @@
   {
     "package": "actiondispatch",
     "tsFile": "middleware/ssl.ts",
+    "rubyName": "call",
+    "call": "order:redirectToHttps,setHstsHeaderBang",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "middleware/ssl.ts",
     "rubyName": "flag_cookies_as_secure!",
     "call": "match?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -33,5 +40,12 @@
     "rubyName": "redirect_to_https",
     "call": "fetch",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "middleware/ssl.ts",
+    "rubyName": "redirect_to_https",
+    "call": "order:httpsLocationFor,redirectionStatus",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/routing/inspector.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/routing/inspector.json
@@ -2,6 +2,13 @@
   {
     "package": "actiondispatch",
     "tsFile": "routing/inspector.ts",
+    "rubyName": "format",
+    "call": "order:collectRoutes,filterRoutes",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "routing/inspector.ts",
     "rubyName": "normalize_filter",
     "call": "escape",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/routing/mapper.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/routing/mapper.json
@@ -170,6 +170,13 @@
   {
     "package": "actiondispatch",
     "tsFile": "routing/mapper.ts",
+    "rubyName": "initialize",
+    "call": "order:resourcesPathNames,constructor",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "routing/mapper.ts",
     "rubyName": "map_match",
     "call": "warn",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -199,14 +206,14 @@
     "package": "actiondispatch",
     "tsFile": "routing/mapper.ts",
     "rubyName": "member",
-    "call": "shallow?",
+    "call": "shallow_scope",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "routing/mapper.ts",
     "rubyName": "member",
-    "call": "shallow_scope",
+    "call": "shallow?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -367,6 +374,13 @@
     "package": "actiondispatch",
     "tsFile": "routing/mapper.ts",
     "rubyName": "resource",
+    "call": "order:get,constructor",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "routing/mapper.ts",
+    "rubyName": "resource",
     "call": "post",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -418,6 +432,13 @@
     "rubyName": "resources",
     "call": "collection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "routing/mapper.ts",
+    "rubyName": "resources",
+    "call": "order:get,constructor",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "actiondispatch",

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/routing/mapper.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/routing/mapper.json
@@ -206,14 +206,14 @@
     "package": "actiondispatch",
     "tsFile": "routing/mapper.ts",
     "rubyName": "member",
-    "call": "shallow_scope",
+    "call": "shallow?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "routing/mapper.ts",
     "rubyName": "member",
-    "call": "shallow?",
+    "call": "shallow_scope",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/routing/url-for.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/routing/url-for.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "actiondispatch",
+    "tsFile": "routing/url-for.ts",
+    "rubyName": "full_url_for",
+    "call": "order:polymorphicUrl,handleStringCall",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/testing/assertion-response.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/testing/assertion-response.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "actiondispatch",
+    "tsFile": "testing/assertion-response.ts",
+    "rubyName": "initialize",
+    "call": "order:nameFromCode,codeFromName",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/testing/assertions/response.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/testing/assertions/response.json
@@ -9,6 +9,13 @@
   {
     "package": "actiondispatch",
     "tsFile": "testing/assertions/response.ts",
+    "rubyName": "assert_response",
+    "call": "order:constructor,generateResponseMessage",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "testing/assertions/response.ts",
     "rubyName": "exception_if_present",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/testing/assertions/routing.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/testing/assertions/routing.json
@@ -33,5 +33,12 @@
     "rubyName": "reset_routes",
     "call": "app",
     "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails routing.rb has two overloads: 72-77 (integration: app.instance_variable_set + singleton_class.redefine_method) and 298-303 (functional: plain restore); trails routing.ts:270-277 ports the functional overload only — JS has no singleton classes, so the app/redefine_method arm has no analogue."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "testing/assertions/routing.ts",
+    "rubyName": "with_routing",
+    "call": "order:resetRoutes,createRoutes",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/testing/test-process.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/testing/test-process.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "actiondispatch",
+    "tsFile": "testing/test-process.ts",
+    "rubyName": "file_fixture_upload",
+    "call": "order:constructor,fileFixture",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/actionview/helpers/text-helper.json
+++ b/scripts/api-compare/call-mismatches-exclude/actionview/helpers/text-helper.json
@@ -2,6 +2,13 @@
   {
     "package": "actionview",
     "tsFile": "helpers/text-helper.ts",
+    "rubyName": "cycle",
+    "call": "order:constructor,getCycle",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "actionview",
+    "tsFile": "helpers/text-helper.ts",
     "rubyName": "safe_concat",
     "call": "concat",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/serialization.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/serialization.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "activemodel",
+    "tsFile": "serialization.ts",
+    "rubyName": "serializable_hash",
+    "call": "order:serializableAddIncludes,map",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/type/integer.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/type/integer.json
@@ -2,6 +2,13 @@
   {
     "package": "activemodel",
     "tsFile": "type/integer.ts",
+    "rubyName": "serializable?",
+    "call": "order:isInRange,cast",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "type/integer.ts",
     "rubyName": "serialize",
     "call": "non_numeric_string?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/validations/numericality.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/validations/numericality.json
@@ -52,6 +52,13 @@
     "package": "activemodel",
     "tsFile": "validations/numericality.ts",
     "rubyName": "validate_each",
+    "call": "order:add,isNumber",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "validations/numericality.ts",
+    "rubyName": "validate_each",
     "call": "slice",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/association-scope.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/association-scope.json
@@ -9,6 +9,13 @@
   {
     "package": "activerecord",
     "tsFile": "associations/association-scope.ts",
+    "rubyName": "next_chain_scope",
+    "call": "order:polymorphicName,transformValue",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/association-scope.ts",
     "rubyName": "transform_value",
     "call": "call",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/association.json
@@ -16,6 +16,13 @@
   {
     "package": "activerecord",
     "tsFile": "associations/association.ts",
+    "rubyName": "inverse_association_for",
+    "call": "order:inverseReflectionFor,isInvertibleFor",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/association.ts",
     "rubyName": "invertible_for?",
     "call": "inverse_reflection_for",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -26,6 +33,13 @@
     "rubyName": "marshal_dump",
     "call": "map",
     "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails association.rb:206-209 maps over instance_variables to build the ivar list; trails association.ts:529-537 dumps the fixed `{loaded, target}` shape — Marshal introspection has no JS analogue, the shape is explicit."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/association.ts",
+    "rubyName": "matches_foreign_key?",
+    "call": "order:foreignKey,isForeignKeyFor",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/belongs-to-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/belongs-to-association.json
@@ -2,6 +2,13 @@
   {
     "package": "activerecord",
     "tsFile": "associations/belongs-to-association.ts",
+    "rubyName": "default",
+    "call": "order:owner,writer",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/belongs-to-association.ts",
     "rubyName": "handle_dependency",
     "call": "enqueue_destroy_association",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -45,6 +52,13 @@
     "package": "activerecord",
     "tsFile": "associations/belongs-to-association.ts",
     "rubyName": "handle_dependency",
+    "call": "order:reflection,destroy",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/belongs-to-association.ts",
+    "rubyName": "handle_dependency",
     "call": "owner",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -54,6 +68,13 @@
     "rubyName": "replace_keys",
     "call": "map",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/belongs-to-association.ts",
+    "rubyName": "update_counters",
+    "call": "order:reflection,incrementBang",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/belongs-to-polymorphic-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/belongs-to-polymorphic-association.json
@@ -2,6 +2,13 @@
   {
     "package": "activerecord",
     "tsFile": "associations/belongs-to-polymorphic-association.ts",
+    "rubyName": "inverse_reflection_for",
+    "call": "order:reflection,polymorphicInverseOf",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/belongs-to-polymorphic-association.ts",
     "rubyName": "saved_change_to_target?",
     "call": "owner",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-association.json
@@ -2,6 +2,13 @@
   {
     "package": "activerecord",
     "tsFile": "associations/collection-association.ts",
+    "rubyName": "build",
+    "call": "order:buildRecord,addToTarget",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/collection-association.ts",
     "rubyName": "concat_records",
     "call": "loaded?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -31,6 +38,13 @@
     "package": "activerecord",
     "tsFile": "associations/collection-association.ts",
     "rubyName": "ids_writer",
+    "call": "order:all,where",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/collection-association.ts",
+    "rubyName": "ids_writer",
     "call": "raise_record_not_found_exception!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -47,6 +61,20 @@
     "rubyName": "ids_writer",
     "call": "values_at",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/collection-association.ts",
+    "rubyName": "include?",
+    "call": "order:isLoaded,isIncludeInMemory",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/collection-association.ts",
+    "rubyName": "load_target",
+    "call": "order:mergeTargetLists,findTarget",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-many-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-many-association.json
@@ -2,6 +2,20 @@
   {
     "package": "activerecord",
     "tsFile": "associations/has-many-association.ts",
+    "rubyName": "delete_or_nullify_all_records",
+    "call": "order:scope,deleteCount",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-many-association.ts",
+    "rubyName": "delete_records",
+    "call": "order:scope,klass",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-many-association.ts",
     "rubyName": "handle_dependency",
     "call": "collect",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -40,6 +54,13 @@
     "rubyName": "handle_dependency",
     "call": "klass",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-many-association.ts",
+    "rubyName": "handle_dependency",
+    "call": "order:reflection,constructor",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-many-through-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-many-through-association.json
@@ -31,6 +31,13 @@
     "package": "activerecord",
     "tsFile": "associations/has-many-through-association.ts",
     "rubyName": "delete_records",
+    "call": "order:klass,decrementCounter",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-many-through-association.ts",
+    "rubyName": "delete_records",
     "call": "through_association",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -96,5 +103,12 @@
     "rubyName": "target_scope",
     "call": "scope_for_association",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-many-through-association.ts",
+    "rubyName": "transaction",
+    "call": "order:throughReflection,klass",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-one-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-one-association.json
@@ -66,8 +66,22 @@
     "package": "activerecord",
     "tsFile": "associations/has-one-association.ts",
     "rubyName": "foreign_key_present?",
+    "call": "order:owner,reflection",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-one-association.ts",
+    "rubyName": "foreign_key_present?",
     "call": "primary_key",
     "reason": "Satisfied via the extracted foreignKeyPresentFor helper (foreign-association.ts), which reads klass.primaryKey — same delegation as CollectionAssociation#foreignKeyPresent."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-one-association.ts",
+    "rubyName": "handle_dependency",
+    "call": "order:reflection,constructor",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activerecord",
@@ -110,6 +124,13 @@
     "rubyName": "replace",
     "call": "transaction_if",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-one-association.ts",
+    "rubyName": "set_owner_attributes",
+    "call": "order:owner,reflection",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/join-dependency.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/join-dependency.json
@@ -2,6 +2,13 @@
   {
     "package": "activerecord",
     "tsFile": "associations/join-dependency.ts",
+    "rubyName": "aliases",
+    "call": "order:map,constructor",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/join-dependency.ts",
     "rubyName": "instantiate",
     "call": "match?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/preloader/branch.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/preloader/branch.json
@@ -10,6 +10,13 @@
     "package": "activerecord",
     "tsFile": "associations/preloader/branch.ts",
     "rubyName": "preloaders_for_reflection",
+    "call": "order:constructor,klass",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/preloader/branch.ts",
+    "rubyName": "preloaders_for_reflection",
     "call": "preloader_for",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/preloader/through-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/preloader/through-association.json
@@ -17,7 +17,28 @@
     "package": "activerecord",
     "tsFile": "associations/preloader/through-association.ts",
     "rubyName": "source_preloaders",
+    "call": "order:constructor,loaders",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/preloader/through-association.ts",
+    "rubyName": "source_preloaders",
     "call": "scope",
     "reason": "Deliberate: the source Preloader is handed a scope derived from `reflectionScope`/`preloadScope` rather than `scope`, because `throughScope` may already have eager-loaded the source (see the block comment at the call site)."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/preloader/through-association.ts",
+    "rubyName": "through_preloaders",
+    "call": "order:constructor,loaders",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/preloader/through-association.ts",
+    "rubyName": "through_scope",
+    "call": "order:klass,unscoped",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-assignment.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-assignment.json
@@ -2,6 +2,13 @@
   {
     "package": "activerecord",
     "tsFile": "attribute-assignment.ts",
+    "rubyName": "assign_multiparameter_attributes",
+    "call": "order:extractCallstackForMultiparameterAttributes,executeCallstackForMultiparameterAttributes",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "attribute-assignment.ts",
     "rubyName": "execute_callstack_for_multiparameter_attributes",
     "call": "all?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods.json
@@ -23,6 +23,20 @@
   {
     "package": "activerecord",
     "tsFile": "attribute-methods.ts",
+    "rubyName": "attributes_for_create",
+    "call": "order:columnForAttribute,isVirtual",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "attribute-methods.ts",
+    "rubyName": "attributes_for_update",
+    "call": "order:columnForAttribute,isVirtual",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "attribute-methods.ts",
     "rubyName": "attributes_for_update",
     "call": "readonly_attribute?",
     "reason": "Unmasked by alias-arity resolution (story arity-resolve-ts-alias-bindings-to-target-params): the TS body reads `_readonlyAttributes` directly instead of delegating to `readonlyAttributeQ`. Real gap, tracked as story converge-readonly-attribute-predicate-callers."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods/primary-key.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods/primary-key.json
@@ -72,6 +72,13 @@
   {
     "package": "activerecord",
     "tsFile": "attribute-methods/primary-key.ts",
+    "rubyName": "quoted_primary_key",
+    "call": "order:primaryKey,quoteColumnName",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "attribute-methods/primary-key.ts",
     "rubyName": "reset_primary_key",
     "call": "base_class?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/autosave-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/autosave-association.json
@@ -23,6 +23,13 @@
   {
     "package": "activerecord",
     "tsFile": "autosave-association.ts",
+    "rubyName": "define_autosave_validation_callbacks",
+    "call": "order:validate,defineNonCyclicMethod",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "autosave-association.ts",
     "rubyName": "define_non_cyclic_method",
     "call": "define_method",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-adapter.json
@@ -142,6 +142,13 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-adapter.ts",
+    "rubyName": "quote_default_expression",
+    "call": "order:lookupCastType,serialize",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
     "rubyName": "reconnect!",
     "call": "synchronize",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -208,5 +215,12 @@
     "rubyName": "warning_ignored?",
     "call": "match?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
+    "rubyName": "with_raw_connection",
+    "call": "order:translateExceptionClass,synchronize",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
@@ -51,9 +51,30 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
+    "rubyName": "change_column_default",
+    "call": "order:changeColumnDefaultForAlter,quoteTableName",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
+    "rubyName": "change_column_null",
+    "call": "order:quoteColumnName,quoteTableName",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "check_constraints",
     "call": "internal_exec_query",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
+    "rubyName": "check_constraints",
+    "call": "order:constructor,quotedScope",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activerecord",
@@ -212,6 +233,13 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
+    "rubyName": "rename_column",
+    "call": "order:renameColumnForAlter,quoteTableName",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "rename_column_for_alter",
     "call": "create_table_definition",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -229,6 +257,13 @@
     "rubyName": "rename_column_for_alter",
     "call": "internal_exec_query",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
+    "rubyName": "rename_column_for_alter",
+    "call": "order:constructor,accept",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-pool/queue.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-pool/queue.json
@@ -3,6 +3,13 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/connection-pool/queue.ts",
     "rubyName": "add",
+    "call": "order:signal,push",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/connection-pool/queue.ts",
+    "rubyName": "add",
     "call": "synchronize",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/database-statements.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/database-statements.json
@@ -128,6 +128,41 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/database-statements.ts",
+    "rubyName": "insert_fixtures_set",
+    "call": "order:disableReferentialIntegrity,transaction",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/database-statements.ts",
+    "rubyName": "internal_exec_query",
+    "call": "order:internalExecute,castResult",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/database-statements.ts",
+    "rubyName": "query_value",
+    "call": "order:query,singleValueFromRows",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/database-statements.ts",
+    "rubyName": "query_values",
+    "call": "order:query,map",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/database-statements.ts",
+    "rubyName": "raw_exec_query",
+    "call": "order:rawExecute,castResult",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/database-statements.ts",
     "rubyName": "raw_execute",
     "call": "log",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -170,9 +205,30 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/database-statements.ts",
+    "rubyName": "select_values",
+    "call": "order:selectRows,map",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/database-statements.ts",
     "rubyName": "to_sql_and_binds",
     "call": "unprepared_statement",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/database-statements.ts",
+    "rubyName": "truncate",
+    "call": "order:buildTruncateStatement,execute",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/database-statements.ts",
+    "rubyName": "truncate_tables",
+    "call": "order:buildTruncateStatements,disableReferentialIntegrity",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/quoting.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/quoting.json
@@ -2,6 +2,13 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/quoting.ts",
+    "rubyName": "quote_default_expression",
+    "call": "order:lookupCastType,serialize",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/quoting.ts",
     "rubyName": "quoted_date",
     "call": "default_timezone",
     "reason": "Rails' quoted_date branches on default_timezone inline (abstract/quoting.rb:186); trails' quotedDate formats through formatInstantForSql / formatPlainDateTimeForSql in abstract/sql-datetime.ts, whose defaultSqlTimezone() reads ActiveRecord.defaultTimezone."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/schema-creation.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/schema-creation.json
@@ -37,6 +37,13 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-creation.ts",
+    "rubyName": "visit_AlterTable",
+    "call": "order:visitAddForeignKey,join",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/schema-creation.ts",
     "rubyName": "visit_TableDefinition",
     "call": "accept",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/schema-definitions.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/schema-definitions.json
@@ -2,6 +2,13 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-definitions.ts",
+    "rubyName": "add_column",
+    "call": "order:newColumnDefinition,constructor",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/schema-definitions.ts",
     "rubyName": "change",
     "call": "change_column",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/schema-dumper.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/schema-dumper.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/schema-dumper.ts",
+    "rubyName": "schema_default",
+    "call": "order:schemaExpression,lookupCastTypeFromColumn",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/schema-statements.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/schema-statements.json
@@ -24,6 +24,13 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "create_table",
+    "call": "order:dropTable,buildCreateTableDefinition",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/schema-statements.ts",
+    "rubyName": "create_table",
     "call": "validate_table_length!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -103,6 +110,20 @@
     "rubyName": "index_name_exists?",
     "call": "detect",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/schema-statements.ts",
+    "rubyName": "index_name_for_remove",
+    "call": "order:indexColumnNames,indexName",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/schema-statements.ts",
+    "rubyName": "insert_versions_sql",
+    "call": "order:map,join",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/mysql/schema-statements.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/mysql/schema-statements.json
@@ -26,5 +26,12 @@
     "rubyName": "indexes",
     "call": "match?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/mysql/schema-statements.ts",
+    "rubyName": "indexes",
+    "call": "order:constructor,quoteColumnName",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/mysql2/database-statements.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/mysql2/database-statements.json
@@ -2,6 +2,13 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/mysql2/database-statements.ts",
+    "rubyName": "cast_result",
+    "call": "order:freeRawResult,constructor",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/mysql2/database-statements.ts",
     "rubyName": "execute_batch",
     "call": "raw_execute",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql-adapter.json
@@ -136,8 +136,22 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "explain",
+    "call": "order:constructor,pp",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "rubyName": "explain",
     "call": "to_sql",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "rubyName": "extensions",
+    "call": "order:internalExecQuery,map",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activerecord",
@@ -257,6 +271,20 @@
     "rubyName": "reload_type_map",
     "call": "synchronize",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "rubyName": "remove_index",
+    "call": "order:constructor,extractSchemaQualifiedName",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "rubyName": "rename_index",
+    "call": "order:quoteTableName,execute",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/database-statements.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/database-statements.json
@@ -23,6 +23,13 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql/database-statements.ts",
+    "rubyName": "handle_warnings",
+    "call": "order:call,isWarningIgnored",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql/database-statements.ts",
     "rubyName": "last_insert_id_result",
     "call": "internal_exec_query",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/oid/array.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/oid/array.json
@@ -19,5 +19,12 @@
     "rubyName": "initialize",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql/oid/array.ts",
+    "rubyName": "serialize",
+    "call": "order:constructor,typeCastArray",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/oid/range.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/oid/range.json
@@ -5,5 +5,12 @@
     "rubyName": "extract_bounds",
     "call": "split",
     "reason": "Name-collision false positive (story relation-delegation-rails-named-methods): exposing the `delegate ... to: :records` set under Rails names made `split`/`reverse`/`rindex` recognized ported method names, so this unrelated call to String#split / Array#reverse / String#rindex on a non-Relation receiver is flagged by the name-based wide call-set check."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql/oid/range.ts",
+    "rubyName": "serialize",
+    "call": "order:constructor,typeCastSingleForDatabase",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/oid/type-map-initializer.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/oid/type-map-initializer.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql/oid/type-map-initializer.ts",
+    "rubyName": "register_with_subtype",
+    "call": "order:lookup,register",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/quoting.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/quoting.json
@@ -9,6 +9,13 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql/quoting.ts",
+    "rubyName": "quote",
+    "call": "order:quoteString,raiseIntWiderThan64bit",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql/quoting.ts",
     "rubyName": "quote_string",
     "call": "with_raw_connection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/referential-integrity.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/referential-integrity.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql/referential-integrity.ts",
+    "rubyName": "disable_referential_integrity",
+    "call": "order:tables,transaction",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/schema-creation.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/schema-creation.json
@@ -12,5 +12,12 @@
     "rubyName": "visit_AddUniqueConstraint",
     "call": "accept",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql/schema-creation.ts",
+    "rubyName": "visit_AlterTable",
+    "call": "order:visitValidateConstraint,join",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/sqlite3-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/sqlite3-adapter.json
@@ -44,6 +44,13 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
+    "rubyName": "copy_table",
+    "call": "order:columns,createTable",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "copy_table_contents",
     "call": "internal_exec_query",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -103,6 +110,13 @@
     "rubyName": "drop_virtual_table",
     "call": "drop_table",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/sqlite3-adapter.ts",
+    "rubyName": "explain",
+    "call": "order:constructor,pp",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activerecord",
@@ -194,6 +208,13 @@
     "rubyName": "quote_string",
     "call": "quote",
     "reason": "Per-entry verified (RFC 0072 sqlite3 quoting cluster): Rails quoting.rb:66-68 delegates to the sqlite3 gem's C helper `::SQLite3::Database.quote`, which is exactly `'` -> `''`. There is no ported `SQLite3::Database` class (node:sqlite / better-sqlite3 expose no quote helper), so sqlite3-adapter.ts#quoteString spells that escape inline; it is the whole call's equivalent, not an omission."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/sqlite3-adapter.ts",
+    "rubyName": "remove_foreign_key",
+    "call": "order:stripTableNamePrefixAndSuffix,foreignKeys",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/core.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/core.json
@@ -58,6 +58,13 @@
   {
     "package": "activerecord",
     "tsFile": "core.ts",
+    "rubyName": "find",
+    "call": "order:constructor,primaryKey",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "core.ts",
     "rubyName": "find_by",
     "call": "cached_find_by",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -114,6 +121,13 @@
   {
     "package": "activerecord",
     "tsFile": "core.ts",
+    "rubyName": "inspect_with_attributes",
+    "call": "order:attributeForInspect,join",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "core.ts",
     "rubyName": "preventing_writes?",
     "call": "any?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -124,6 +138,13 @@
     "rubyName": "preventing_writes?",
     "call": "include?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "core.ts",
+    "rubyName": "strict_loading_violation!",
+    "call": "order:constructor,actionOnStrictLoadingViolation",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/cipher/aes256-gcm.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/cipher/aes256-gcm.json
@@ -2,6 +2,13 @@
   {
     "package": "activerecord",
     "tsFile": "encryption/cipher/aes256-gcm.ts",
+    "rubyName": "encrypt",
+    "call": "order:generateIv,constructor",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/cipher/aes256-gcm.ts",
     "rubyName": "generate_deterministic_iv",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/encryptable-record.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/encryptable-record.json
@@ -65,6 +65,13 @@
   {
     "package": "activerecord",
     "tsFile": "encryption/encryptable-record.ts",
+    "rubyName": "encrypt_attribute",
+    "call": "order:constructor,schemeFor",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/encryptable-record.ts",
     "rubyName": "has_encrypted_attributes?",
     "call": "encrypted_attributes",
     "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails encryptable_record.rb:204-206 reads `self.class.encrypted_attributes.present?`; trails encryptable-record.ts:165-167 reads `modelClass._encryptedAttributes?.size > 0`."
@@ -110,5 +117,12 @@
     "rubyName": "validate_column_size",
     "call": "columns_hash",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/encryptable-record.ts",
+    "rubyName": "validate_column_size",
+    "call": "order:validatesLengthOf,limit",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/message-serializer.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/message-serializer.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/message-serializer.ts",
+    "rubyName": "parse_message",
+    "call": "order:decodeIfNeeded,constructor",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/scheme.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/scheme.json
@@ -2,6 +2,13 @@
   {
     "package": "activerecord",
     "tsFile": "encryption/scheme.ts",
+    "rubyName": "deterministic_key_provider",
+    "call": "order:deterministicKey,constructor",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/scheme.ts",
     "rubyName": "initialize",
     "call": "wrap",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/enum.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/enum.json
@@ -9,6 +9,13 @@
   {
     "package": "activerecord",
     "tsFile": "enum.ts",
+    "rubyName": "_enum",
+    "call": "order:constructor,assertValidEnumDefinitionValues",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "enum.ts",
     "rubyName": "_enum_methods_module",
     "call": "include",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/insert-all.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/insert-all.json
@@ -10,6 +10,13 @@
     "package": "activerecord",
     "tsFile": "insert-all.ts",
     "rubyName": "find_unique_index_for",
+    "call": "order:constructor,primaryKey",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "insert-all.ts",
+    "rubyName": "find_unique_index_for",
     "call": "table_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -58,6 +65,13 @@
   {
     "package": "activerecord",
     "tsFile": "insert-all.ts",
+    "rubyName": "resolve_attribute_aliases",
+    "call": "order:resolveAttributeAlias,map",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "insert-all.ts",
     "rubyName": "resolve_sti",
     "call": "descends_from_active_record?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -68,6 +82,20 @@
     "rubyName": "resolve_sti",
     "call": "map",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "insert-all.ts",
+    "rubyName": "resolve_sti",
+    "call": "order:inheritanceColumn,stiName",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "insert-all.ts",
+    "rubyName": "unique_indexes",
+    "call": "order:schemaCache,indexes",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/internal-metadata.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/internal-metadata.json
@@ -16,6 +16,13 @@
   {
     "package": "activerecord",
     "tsFile": "internal-metadata.ts",
+    "rubyName": "create_entry",
+    "call": "order:currentTime,constructor",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "internal-metadata.ts",
     "rubyName": "create_table",
     "call": "with_connection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -61,5 +68,12 @@
     "rubyName": "table_exists?",
     "call": "schema_cache",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "internal-metadata.ts",
+    "rubyName": "update_entry",
+    "call": "order:currentTime,constructor",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/locking/optimistic.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/locking/optimistic.json
@@ -9,6 +9,13 @@
   {
     "package": "activerecord",
     "tsFile": "locking/optimistic.ts",
+    "rubyName": "_update_row",
+    "call": "order:constructor,lockingColumn",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "locking/optimistic.ts",
     "rubyName": "hook_attribute_type",
     "call": "locking_column",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/migration.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/migration.json
@@ -208,5 +208,12 @@
     "rubyName": "validate",
     "call": "find",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "migration.ts",
+    "rubyName": "with_advisory_lock",
+    "call": "order:connection,getAdvisoryLock",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/model-schema.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/model-schema.json
@@ -79,6 +79,13 @@
   {
     "package": "activerecord",
     "tsFile": "model-schema.ts",
+    "rubyName": "table_exists?",
+    "call": "order:schemaCache,dataSourceExists",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "model-schema.ts",
     "rubyName": "table_name=",
     "call": "connected?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/nested-attributes.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/nested-attributes.json
@@ -10,6 +10,13 @@
     "package": "activerecord",
     "tsFile": "nested-attributes.ts",
     "rubyName": "assign_nested_attributes_for_collection_association",
+    "call": "order:isRejectNewRecord,association",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "nested-attributes.ts",
+    "rubyName": "assign_nested_attributes_for_collection_association",
     "call": "raise_nested_attributes_record_not_found!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -19,6 +26,13 @@
     "rubyName": "assign_nested_attributes_for_collection_association",
     "call": "where",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "nested-attributes.ts",
+    "rubyName": "assign_nested_attributes_for_one_to_one_association",
+    "call": "order:association,callRejectIf",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/normalization.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/normalization.json
@@ -12,5 +12,12 @@
     "rubyName": "normalize",
     "call": "call",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "normalization.ts",
+    "rubyName": "serialize",
+    "call": "order:cast,serializeCastValue",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/query-logs.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/query-logs.json
@@ -5,5 +5,12 @@
     "rubyName": "comment",
     "call": "cache_query_log_tags",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "query-logs.ts",
+    "rubyName": "tag_content",
+    "call": "order:join,format",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/reflection.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/reflection.json
@@ -52,6 +52,13 @@
     "package": "activerecord",
     "tsFile": "reflection.ts",
     "rubyName": "join_scope",
+    "call": "order:joinScopes,constructor",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "reflection.ts",
+    "rubyName": "join_scope",
     "call": "with",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
@@ -170,6 +170,13 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
+    "rubyName": "cache_key_with_version",
+    "call": "order:cacheKey,cacheVersion",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
     "rubyName": "calculate",
     "call": "any?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -275,6 +282,13 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
+    "rubyName": "create_or_find_by",
+    "call": "with_connection",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
     "rubyName": "create!",
     "call": "current_scope_restoring_block",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -289,9 +303,9 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
-    "rubyName": "create_or_find_by",
-    "call": "with_connection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "delete",
+    "call": "order:primaryKey,where",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activerecord",
@@ -325,6 +339,13 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "delete_all",
+    "call": "order:primaryKey,applyJoinDependency",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "delete_all",
     "call": "with_connection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -341,6 +362,13 @@
     "rubyName": "except",
     "call": "relation_with",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "exec_explain",
+    "call": "order:buildExplainClause,join",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activerecord",
@@ -667,6 +695,13 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
+    "rubyName": "in_batches",
+    "call": "order:ensureValidOptionsForBatchingBang,map",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
     "rubyName": "in_order_of",
     "call": "build_case_for_value_position",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -684,6 +719,13 @@
     "rubyName": "in_order_of",
     "call": "or",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "in_order_of",
+    "call": "order:orderColumn,typeCastForDatabase",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activerecord",
@@ -801,6 +843,13 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "preload_associations",
+    "call": "order:constructor,call",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "preload_associations",
     "call": "preload_values",
     "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails relation.rb:1321-1328 concatenates preload_values/includes_values and runs Preloader.new(...).call per spec under the strict_loading_value scope; trails relation.ts:6473-6475 returns the merged `[..._preloadAssociations, ..._includesAssociations]` list and the load path consuming it invokes the preloader — the value reads are direct field spreads."
   },
@@ -824,6 +873,13 @@
     "rubyName": "references_eager_loaded_tables?",
     "call": "build_joins",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "references_eager_loaded_tables?",
+    "call": "order:map,flatMap",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activerecord",
@@ -912,6 +968,13 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
+    "rubyName": "touch_all",
+    "call": "order:touchAttributesWithTime,updateAll",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
     "rubyName": "type_cast_pluck_values",
     "call": "fetch",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -957,6 +1020,13 @@
     "rubyName": "update_all",
     "call": "having_clause",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "update_all",
+    "call": "order:map,lockingColumn",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
@@ -282,13 +282,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
-    "rubyName": "create_or_find_by",
-    "call": "with_connection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
     "rubyName": "create!",
     "call": "current_scope_restoring_block",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -298,6 +291,13 @@
     "tsFile": "relation.ts",
     "rubyName": "create!",
     "call": "scoping",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "create_or_find_by",
+    "call": "with_connection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -724,15 +724,15 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "in_order_of",
-    "call": "order:orderColumn,typeCastForDatabase",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+    "call": "order!",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "in_order_of",
-    "call": "order!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "call": "order:orderColumn,typeCastForDatabase",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/batches.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/batches.json
@@ -2,9 +2,30 @@
   {
     "package": "activerecord",
     "tsFile": "relation/batches.ts",
+    "rubyName": "batch_on_loaded_relation",
+    "call": "order:buildBatchOrders,map",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/batches.ts",
     "rubyName": "batch_on_unloaded_relation",
     "call": "any?",
     "reason": "Rails' `values.flatten.any?(nil)` guard raises ArgumentError when a custom select clause omits a cursor column; that nil-cursor check is not ported yet and is tracked separately from the empty_scope/use_ranges convergence."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/batches.ts",
+    "rubyName": "batch_on_unloaded_relation",
+    "call": "order:toSql,limit",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/batches.ts",
+    "rubyName": "ensure_valid_options_for_batching!",
+    "call": "order:model,indexes",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/finder-methods.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/finder-methods.json
@@ -51,9 +51,23 @@
   {
     "package": "activerecord",
     "tsFile": "relation/finder-methods.ts",
+    "rubyName": "find_some",
+    "call": "order:primaryKey,where",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/finder-methods.ts",
     "rubyName": "find_some_ordered",
     "call": "except",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/finder-methods.ts",
+    "rubyName": "find_some_ordered",
+    "call": "order:model,selectValues",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activerecord",
@@ -89,6 +103,13 @@
     "rubyName": "find_with_ids",
     "call": "first",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/finder-methods.ts",
+    "rubyName": "find_with_ids",
+    "call": "order:model,primaryKey",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/merger.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/merger.json
@@ -58,6 +58,13 @@
   {
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
+    "rubyName": "merge_preloads",
+    "call": "order:preloadBang,find",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/merger.ts",
     "rubyName": "merge_select_values",
     "call": "select_values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/predicate-builder.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/predicate-builder.json
@@ -2,6 +2,20 @@
   {
     "package": "activerecord",
     "tsFile": "relation/predicate-builder.ts",
+    "rubyName": "build",
+    "call": "order:handlerFor,call",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/predicate-builder.ts",
+    "rubyName": "build_from_hash",
+    "call": "order:expandFromHash,convertDotNotationToHash",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/predicate-builder.ts",
     "rubyName": "expand_from_hash",
     "call": "wrap",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/predicate-builder/polymorphic-array-value.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/predicate-builder/polymorphic-array-value.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "relation/predicate-builder/polymorphic-array-value.ts",
+    "rubyName": "type_to_ids_mapping",
+    "call": "order:klass,polymorphicName",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/query-methods.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/query-methods.json
@@ -17,6 +17,13 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "arel_column",
+    "call": "order:table,columnsHash",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/query-methods.ts",
+    "rubyName": "arel_column",
     "call": "quote_table_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -31,8 +38,22 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "arel_column_aliases_from_hash",
+    "call": "order:model,arelColumnWithTable",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/query-methods.ts",
+    "rubyName": "arel_column_aliases_from_hash",
     "call": "quote_column_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/query-methods.ts",
+    "rubyName": "arel_column_with_table",
+    "call": "order:lookupTableKlassFromJoinDependencies,resolveArelAttribute",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activerecord",
@@ -59,15 +80,15 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "associated",
-    "call": "joins!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "call": "joins_values",
+    "reason": "Satisfied in `Relation#whereAssociated`, which is where Rails' `associations.each` body lives in this port: the already-joined guard (`query_methods.rb:91`) reads `joinsValues` / `leftOuterJoinsValues` and `includes` there, per-iteration, exactly as Rails does. Same split as the existing `joins!` / `not` entries for this method."
   },
   {
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "associated",
-    "call": "joins_values",
-    "reason": "Satisfied in `Relation#whereAssociated`, which is where Rails' `associations.each` body lives in this port: the already-joined guard (`query_methods.rb:91`) reads `joinsValues` / `leftOuterJoinsValues` and `includes` there, per-iteration, exactly as Rails does. Same split as the existing `joins!` / `not` entries for this method."
+    "call": "joins!",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -121,6 +142,13 @@
   {
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
+    "rubyName": "build_arel",
+    "call": "order:table,constructor",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/query-methods.ts",
     "rubyName": "build_bound_sql_literal",
     "call": "sql",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -131,6 +159,13 @@
     "rubyName": "build_from",
     "call": "from_clause",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/query-methods.ts",
+    "rubyName": "build_join_buckets",
+    "call": "order:leftOuterJoinsValues,constructor",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activerecord",
@@ -152,6 +187,13 @@
     "rubyName": "build_join_dependencies",
     "call": "includes_values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/query-methods.ts",
+    "rubyName": "build_join_dependencies",
+    "call": "order:selectNamedJoins,constructJoinDependency",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activerecord",
@@ -241,6 +283,13 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "build_where_clause",
+    "call": "order:constructor,buildNamedBoundSqlLiteral",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/query-methods.ts",
+    "rubyName": "build_where_clause",
     "call": "sanitize_sql",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -271,6 +320,20 @@
     "rubyName": "build_with_join_node",
     "call": "first",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/query-methods.ts",
+    "rubyName": "build_with_join_node",
+    "call": "order:table,constructor",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/query-methods.ts",
+    "rubyName": "build_with_value_from_hash",
+    "call": "order:buildWithExpressionFromValue,constructor",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activerecord",
@@ -313,6 +376,13 @@
     "rubyName": "missing",
     "call": "where!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/query-methods.ts",
+    "rubyName": "order_column",
+    "call": "order:table,arelColumn",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/query-methods.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/query-methods.json
@@ -80,15 +80,15 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "associated",
-    "call": "joins_values",
-    "reason": "Satisfied in `Relation#whereAssociated`, which is where Rails' `associations.each` body lives in this port: the already-joined guard (`query_methods.rb:91`) reads `joinsValues` / `leftOuterJoinsValues` and `includes` there, per-iteration, exactly as Rails does. Same split as the existing `joins!` / `not` entries for this method."
+    "call": "joins!",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "associated",
-    "call": "joins!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "call": "joins_values",
+    "reason": "Satisfied in `Relation#whereAssociated`, which is where Rails' `associations.each` body lives in this port: the already-joined guard (`query_methods.rb:91`) reads `joinsValues` / `leftOuterJoinsValues` and `includes` there, per-iteration, exactly as Rails does. Same split as the existing `joins!` / `not` entries for this method."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/where-clause.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/where-clause.json
@@ -24,6 +24,13 @@
     "package": "activerecord",
     "tsFile": "relation/where-clause.ts",
     "rubyName": "invert",
+    "call": "order:constructor,invertPredicate",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/where-clause.ts",
+    "rubyName": "invert",
     "call": "size",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/schema-dumper.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/schema-dumper.json
@@ -10,6 +10,13 @@
     "package": "activerecord",
     "tsFile": "schema-dumper.ts",
     "rubyName": "check_constraints_in_create",
+    "call": "order:checkParts,join",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "schema-dumper.ts",
+    "rubyName": "check_constraints_in_create",
     "call": "remove_prefix_and_suffix",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -19,6 +26,13 @@
     "rubyName": "foreign_keys",
     "call": "any?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "schema-dumper.ts",
+    "rubyName": "foreign_keys",
+    "call": "order:foreignKeyColumnFor,removePrefixAndSuffix",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activerecord",
@@ -61,6 +75,13 @@
     "rubyName": "indexes_in_create",
     "call": "indexes",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "schema-dumper.ts",
+    "rubyName": "indexes_in_create",
+    "call": "order:indexParts,join",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activerecord",
@@ -138,5 +159,12 @@
     "rubyName": "table",
     "call": "valid_type?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "schema-dumper.ts",
+    "rubyName": "tables",
+    "call": "order:foreignKeys,constructor",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/scoping.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/scoping.json
@@ -12,5 +12,12 @@
     "rubyName": "global_current_scope=",
     "call": "set_global_current_scope",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "scoping.ts",
+    "rubyName": "scope_attributes",
+    "call": "order:all,scopeForCreate",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/scoping/named.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/scoping/named.json
@@ -19,5 +19,12 @@
     "rubyName": "scope",
     "call": "method_defined_within?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "scoping/named.ts",
+    "rubyName": "scope",
+    "call": "order:constructor,isDangerousClassMethod",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/signed-id.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/signed-id.json
@@ -19,5 +19,12 @@
     "rubyName": "signed_id",
     "call": "combine_signed_id_purposes",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "signed-id.ts",
+    "rubyName": "signed_id",
+    "call": "order:signedIdVerifier,generate",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/store.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/store.json
@@ -38,6 +38,13 @@
     "package": "activerecord",
     "tsFile": "store.ts",
     "rubyName": "store_accessor",
+    "call": "order:readStoreAttribute,writeStoreAttribute",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "store.ts",
+    "rubyName": "store_accessor",
     "call": "saved_change_to_attribute?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/tasks/database-tasks.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/tasks/database-tasks.json
@@ -121,6 +121,13 @@
   {
     "package": "activerecord",
     "tsFile": "tasks/database-tasks.ts",
+    "rubyName": "dump_schema",
+    "call": "order:structureDump,dump",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "tasks/database-tasks.ts",
     "rubyName": "each_local_configuration",
     "call": "local_database?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -131,6 +138,13 @@
     "rubyName": "for_each",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "tasks/database-tasks.ts",
+    "rubyName": "for_each",
+    "call": "order:env,configsFor",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activerecord",
@@ -170,6 +184,13 @@
   {
     "package": "activerecord",
     "tsFile": "tasks/database-tasks.ts",
+    "rubyName": "migrate",
+    "call": "order:checkTargetVersion,verbose",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "tasks/database-tasks.ts",
     "rubyName": "migrate_all",
     "call": "configurations",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -187,6 +208,13 @@
     "rubyName": "prepare_all",
     "call": "each_current_configuration",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "tasks/database-tasks.ts",
+    "rubyName": "prepare_all",
+    "call": "order:eachCurrentEnvironment,initializeDatabase",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/tasks/mysql-database-tasks.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/tasks/mysql-database-tasks.json
@@ -16,6 +16,13 @@
   {
     "package": "activerecord",
     "tsFile": "tasks/mysql-database-tasks.ts",
+    "rubyName": "create",
+    "call": "order:creationOptions,establishConnection",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "tasks/mysql-database-tasks.ts",
     "rubyName": "creation_options",
     "call": "include?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/token-for.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/token-for.json
@@ -1,0 +1,16 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "token-for.ts",
+    "rubyName": "generate_token",
+    "call": "order:payloadFor,generate",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "token-for.ts",
+    "rubyName": "generates_token_for",
+    "call": "order:constructor,merge",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/validations/uniqueness.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/validations/uniqueness.json
@@ -19,5 +19,12 @@
     "rubyName": "validate_each",
     "call": "not",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "validations/uniqueness.ts",
+    "rubyName": "validate_each",
+    "call": "order:constructor,mapEnumAttribute",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/cache.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/cache.json
@@ -30,8 +30,29 @@
   {
     "package": "activesupport",
     "tsFile": "cache.ts",
+    "rubyName": "new_entry",
+    "call": "order:mergedOptions,constructor",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "cache.ts",
     "rubyName": "normalize_version",
     "call": "try",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "cache.ts",
+    "rubyName": "read_multi_entries",
+    "call": "order:deleteEntry,normalizeVersion",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "cache.ts",
+    "rubyName": "write",
+    "call": "order:writeEntry,constructor",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/cache/file-store.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/cache/file-store.json
@@ -82,5 +82,12 @@
     "rubyName": "modify_value",
     "call": "merged_options",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "cache/file-store.ts",
+    "rubyName": "modify_value",
+    "call": "order:writeEntry,constructor",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/cache/memory-store.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/cache/memory-store.json
@@ -38,6 +38,13 @@
     "package": "activesupport",
     "tsFile": "cache/memory-store.ts",
     "rubyName": "modify_value",
+    "call": "order:writeEntry,constructor",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "cache/memory-store.ts",
+    "rubyName": "modify_value",
     "call": "synchronize",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/message-encryptor.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/message-encryptor.json
@@ -2,9 +2,23 @@
   {
     "package": "activesupport",
     "tsFile": "message-encryptor.ts",
+    "rubyName": "create_message",
+    "call": "order:encrypt,sign",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "message-encryptor.ts",
     "rubyName": "key_len",
     "call": "new",
     "reason": "Rails' key_len is `OpenSSL::Cipher.new(cipher).key_len`; trails has no OpenSSL::Cipher binding, so keyLen derives the byte length from the cipher name instead of instantiating a cipher."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "message-encryptor.ts",
+    "rubyName": "read_message",
+    "call": "order:verify,deserializeWithMetadata",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activesupport",

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/number-helper/number-to-human-converter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/number-helper/number-to-human-converter.json
@@ -1,0 +1,16 @@
+[
+  {
+    "package": "activesupport",
+    "tsFile": "number-helper/number-to-human-converter.ts",
+    "rubyName": "calculate_exponent",
+    "call": "order:unitExponents,find",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "number-helper/number-to-human-converter.ts",
+    "rubyName": "unit_exponents",
+    "call": "order:translate,map",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/number-helper/number-to-human-size-converter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/number-helper/number-to-human-size-converter.json
@@ -5,5 +5,12 @@
     "rubyName": "conversion_format",
     "call": "translate_number_value_with_default",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "number-helper/number-to-human-size-converter.ts",
+    "rubyName": "convert",
+    "call": "order:unit,exponent",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/arel/visitors/dot.json
+++ b/scripts/api-compare/call-mismatches-exclude/arel/visitors/dot.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "arel",
+    "tsFile": "visitors/dot.ts",
+    "rubyName": "to_dot",
+    "call": "order:quote,join",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/arel/visitors/to-sql.json
+++ b/scripts/api-compare/call-mismatches-exclude/arel/visitors/to-sql.json
@@ -16,9 +16,23 @@
   {
     "package": "arel",
     "tsFile": "visitors/to-sql.ts",
+    "rubyName": "visit_Arel_Attributes_Attribute",
+    "call": "order:quoteColumnName,quoteTableName",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "arel",
+    "tsFile": "visitors/to-sql.ts",
     "rubyName": "visit_Arel_Nodes_And",
     "call": "inject_join",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "arel",
+    "tsFile": "visitors/to-sql.ts",
+    "rubyName": "visit_Arel_Nodes_Comment",
+    "call": "order:sanitizeAsSqlComment,join",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "arel",

--- a/scripts/api-compare/call-mismatches-exclude/globalid/locator.json
+++ b/scripts/api-compare/call-mismatches-exclude/globalid/locator.json
@@ -2,8 +2,22 @@
   {
     "package": "globalid",
     "tsFile": "locator.ts",
+    "rubyName": "locate_many_signed",
+    "call": "order:parse,locateMany",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "globalid",
+    "tsFile": "locator.ts",
     "rubyName": "locator_for",
     "call": "default_locator",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "globalid",
+    "tsFile": "locator.ts",
+    "rubyName": "use",
+    "call": "order:constructor,normalizeApp",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/i18n/backend/key-value.json
+++ b/scripts/api-compare/call-mismatches-exclude/i18n/backend/key-value.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "i18n",
+    "tsFile": "backend/key-value.ts",
+    "rubyName": "translations",
+    "call": "order:map,deepSymbolizeKeys",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/rack/common-logger.json
+++ b/scripts/api-compare/call-mismatches-exclude/rack/common-logger.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "rack",
+    "tsFile": "common-logger.ts",
+    "rubyName": "log",
+    "call": "order:extractContentLength,constructor",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/rack/directory.json
+++ b/scripts/api-compare/call-mismatches-exclude/rack/directory.json
@@ -19,5 +19,12 @@
     "rubyName": "list_directory",
     "call": "escape_path",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "rack",
+    "tsFile": "directory.ts",
+    "rubyName": "list_directory",
+    "call": "order:stat,constructor",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/rack/events.json
+++ b/scripts/api-compare/call-mismatches-exclude/rack/events.json
@@ -12,5 +12,12 @@
     "rubyName": "call",
     "call": "make_response",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "rack",
+    "tsFile": "events.ts",
+    "rubyName": "call",
+    "call": "order:constructor,onStart",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/rack/files.json
+++ b/scripts/api-compare/call-mismatches-exclude/rack/files.json
@@ -40,5 +40,12 @@
     "rubyName": "serving",
     "call": "get_byte_ranges",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "rack",
+    "tsFile": "files.ts",
+    "rubyName": "serving",
+    "call": "order:fail,mimeType",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/rack/mock-response.json
+++ b/scripts/api-compare/call-mismatches-exclude/rack/mock-response.json
@@ -5,5 +5,12 @@
     "rubyName": "cookie",
     "call": "fetch",
     "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails mock_response.rb:73-75 is `cookies.fetch(name, nil)`; trails mock-response.ts:66-68 is an index read returning undefined when absent."
+  },
+  {
+    "package": "rack",
+    "tsFile": "mock-response.ts",
+    "rubyName": "parse_cookies_from_header",
+    "call": "order:identifyCookieAttributes,constructor",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/trailties/generators/generated-attribute.json
+++ b/scripts/api-compare/call-mismatches-exclude/trailties/generators/generated-attribute.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "trailties",
+    "tsFile": "generators/generated-attribute.ts",
+    "rubyName": "parse",
+    "call": "order:constructor,reference",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/trailties/rack/logger.json
+++ b/scripts/api-compare/call-mismatches-exclude/trailties/rack/logger.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "trailties",
+    "tsFile": "rack/logger.ts",
+    "rubyName": "call",
+    "call": "order:pushTags,constructor",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/trailties/source-annotation-extractor.json
+++ b/scripts/api-compare/call-mismatches-exclude/trailties/source-annotation-extractor.json
@@ -5,5 +5,12 @@
     "rubyName": "find_in",
     "call": "call",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "trailties",
+    "tsFile": "source-annotation-extractor.ts",
+    "rubyName": "find_in",
+    "call": "order:constructor,isDirectory",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -17,6 +17,8 @@ import {
   buildEntitiesByName,
   resolveEntityByDeclaringFile,
   significantMissingCalls,
+  reorderedCalls,
+  ORDER_PREFIX,
   resolvePortedWithArgsSigs,
   jsEnumerableAliases,
   JS_ENUMERABLE_ALIASES,
@@ -1715,5 +1717,69 @@ describe("mixinMethodCreditedToOwnFile", () => {
         tsMethodsByFile,
       ),
     ).toBeNull();
+  });
+});
+
+describe("reorderedCalls (RFC 0084 order-only call parity)", () => {
+  const map = (c: string) => rubyMethodToTs(c);
+  const wide = { has: (k: string) => k !== "super" };
+  const ported = () => true;
+
+  it("flags a body that makes Rails' calls in a different order", () => {
+    expect(
+      reorderedCalls("create", ["build", "save"], ["save", "build"], ported, map, wide),
+    ).toEqual([`${ORDER_PREFIX}save,build → build,save`]);
+  });
+
+  it("stays silent when the sequences agree", () => {
+    expect(
+      reorderedCalls("create", ["build", "save"], ["build", "save"], ported, map, wide),
+    ).toEqual([]);
+  });
+
+  it("ignores intervening TS calls Rails does not make", () => {
+    expect(
+      reorderedCalls("create", ["build", "save"], ["build", "dup", "save"], ported, map, wide),
+    ).toEqual([]);
+  });
+
+  it("leaves a dropped call to the missing-call check rather than reporting order", () => {
+    // `save` is absent from TS, so this is a divergence, not a reordering: the
+    // two checks must not double-report the same body.
+    expect(reorderedCalls("create", ["build", "save"], ["build"], ported, map, wide)).toEqual([]);
+    expect(
+      significantMissingCalls("create", ["build", "save"], new Set(["build"]), ported, map, wide),
+    ).toEqual(["save → save"]);
+  });
+
+  it("reports one flag per body, naming the first inversion", () => {
+    expect(
+      reorderedCalls(
+        "create",
+        ["build", "save", "touch"],
+        ["touch", "save", "build"],
+        ported,
+        map,
+        wide,
+      ),
+    ).toEqual([`${ORDER_PREFIX}save,build → build,save`]);
+  });
+
+  it("never flags a single matched call, nor the self call, nor super", () => {
+    expect(reorderedCalls("create", ["build"], ["build"], ported, map, wide)).toEqual([]);
+    expect(reorderedCalls("save", ["save", "touch"], ["touch", "save"], ported, map, wide)).toEqual(
+      [],
+    );
+    expect(
+      reorderedCalls("save", ["super", "touch", "build"], ["touch", "build"], ported, map, wide),
+    ).toEqual([]);
+  });
+
+  it("respects the ported-with-args gate the missing-call check uses", () => {
+    // A zero-arg reader Ruby records as a call but TS reads as `this.x` must not
+    // manufacture a position — same gate 2 as significantMissingCalls.
+    expect(
+      reorderedCalls("create", ["build", "save"], ["save", "build"], () => false, map, wide),
+    ).toEqual([]);
   });
 });

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -287,6 +287,71 @@ export function significantMissingCalls(
 }
 
 /**
+ * Marker prefix on an ORDER-only call-parity flag (RFC 0084). The baseline keys
+ * on the text left of the arrow (`callOf`), so the prefix is what makes an
+ * order-only row distinguishable from a dropped-call row in the exclude tree
+ * and in review, and greppable as a class.
+ */
+export const ORDER_PREFIX = "order:";
+
+/**
+ * Order-only divergence between a Ruby body and its matched TS body: both make
+ * the same significant calls, but not in the same sequence. A set diff cannot
+ * see this, and CLAUDE.md's "same branches, in the same order, with the same
+ * guards and early returns" makes it a fidelity requirement — the shape mirrors
+ * `scoreFile`'s matched / reordered / divergent split in
+ * scripts/prism-codegen/score.ts, over the ratchet's whole population instead of
+ * the generator's ten files.
+ *
+ * Only calls that pass the same gates as {@link significantMissingCalls} AND are
+ * present in the TS body count: a dropped call is that check's finding, not
+ * this one's, so the two never double-report the same divergence. `super` is
+ * excluded for the same reason it is not significant — the mixin port
+ * structurally drops or respells it, so its position says nothing.
+ *
+ * `tsCalls` must be the body's OWN source-ordered call sequence
+ * (`MethodInfo.callSeq`), never the delegation/helper-union set: a wrapper
+ * resolving in place of the implementation has no meaningful order of its own,
+ * which is the `resolvePortFn` cross-file-fallback false-positive class the
+ * codegen scorer hit on `relation.rb::computeCacheKey`.
+ *
+ * At most one flag per body, naming the first inversion — `order:b,a → a,b`
+ * reads "TS calls b before a; Rails calls a before b" — so the row is a stable
+ * baseline key rather than a whole-sequence string that churns on every edit.
+ */
+export function reorderedCalls(
+  rubyName: string,
+  rubyCalls: readonly string[],
+  tsCalls: readonly string[],
+  isPortedWithArgs: (tsName: string) => boolean,
+  mapCall: (rubyCall: string) => string[] | null = rubyMethodToTs,
+  significant: { has(value: string): boolean } = SIGNIFICANT_CALLS,
+): string[] {
+  const rubySeq: string[] = [];
+  for (const rc of rubyCalls) {
+    if (rc === rubyName) continue; // self/recursive call
+    if (rc === "super") continue;
+    if (!significant.has(rc)) continue;
+    const mapped = mapCall(rc);
+    if (!mapped || mapped.length === 0) continue;
+    if (!mapped.some(isPortedWithArgs)) continue;
+    const hit = mapped.find((c) => tsCalls.includes(c));
+    if (hit === undefined) continue; // missing, not reordered
+    if (rubySeq.includes(hit)) continue; // one position per TS name
+    rubySeq.push(hit);
+  }
+  if (rubySeq.length < 2) return [];
+  for (const [i, name] of rubySeq.entries()) {
+    for (const later of rubySeq.slice(i + 1)) {
+      if (tsCalls.indexOf(later) < tsCalls.indexOf(name)) {
+        return [`${ORDER_PREFIX}${later},${name} → ${name},${later}`];
+      }
+    }
+  }
+  return [];
+}
+
+/**
  * Signature candidates the ported-with-args gate (gate 2 above) resolves a
  * mapped TS name against: the same file's signatures when that file defines the
  * name, else the ones from the SAME PACKAGE only.
@@ -1577,6 +1642,11 @@ export function main() {
     const tsOptionKeysByFileName = new Map<string, Map<string, (string[] | null)[]>>();
     // Body call-sets scoped per (file, name) for the advisory calls-parity check.
     const tsCallsByFileName = new Map<string, Map<string, string[][]>>();
+    // Same population, source-ordered (MethodInfo.callSeq), for the order-only
+    // comparison (RFC 0084). Kept separate from tsCallsByFileName because that
+    // one is unioned/flattened across candidate declarations and helpers, which
+    // has no order to speak of.
+    const tsCallSeqByFileName = new Map<string, Map<string, string[][]>>();
     const tsMissingCallTagsByFileName = new Map<string, Map<string, Set<string>>>();
     // Same call-sets unioned by NAME across this package and its deps (the same
     // scope tsParamsByName uses). Consulted ONLY by the delegation-transparency
@@ -1643,6 +1713,11 @@ export function main() {
         for (const c of m.missingRailsCalls) tagged.add(c);
         byName.set(m.name, tagged);
         tsMissingCallTagsByFileName.set(file, byName);
+      }
+      if (m.callSeq !== undefined) {
+        const byName = tsCallSeqByFileName.get(file) ?? new Map<string, string[][]>();
+        byName.set(m.name, [...(byName.get(m.name) ?? []), m.callSeq]);
+        tsCallSeqByFileName.set(file, byName);
       }
       if (m.calls !== undefined) {
         const byName = tsCallsByFileName.get(file) ?? new Map<string, string[][]>();
@@ -2103,8 +2178,27 @@ export function main() {
             if (tags.has(call)) suppressedCalls.push({ tsFile, rubyName, tsName, call });
           }
         }
-        if (kept.length === 0) return;
-        callMismatches.push({ rubyFile, tsFile, rubyName, tsName, missing: kept });
+        // Order-only parity (RFC 0084), over the body's OWN source-ordered
+        // sequence: a single candidate declaration only — two declarations under
+        // one name have no combined order — and never a delegating wrapper,
+        // whose order belongs to the implementation it forwards to.
+        const seqSets = tsCallSeqByFileName.get(tsFile)?.get(tsName);
+        const ordered: string[] = [];
+        if (seqSets?.length === 1 && !isDelegatingWrapper(tsName, own.calls)) {
+          ordered.push(
+            ...reorderedCalls(
+              rubyName,
+              rubyCalls,
+              [...partitionNegatedCalls(seqSets[0]).calls],
+              (c) => portedWithArgsSigs(tsFile, c).some((sig) => stripThis(sig).length > 0),
+              rubyMethodToTs,
+              callsSignificant,
+            ),
+          );
+        }
+        const flagged = [...kept, ...ordered];
+        if (flagged.length === 0) return;
+        callMismatches.push({ rubyFile, tsFile, rubyName, tsName, missing: flagged });
       };
 
       // Advisory arity check for one name-matched pair: flag when the Ruby and

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -315,6 +315,11 @@ export const ORDER_PREFIX = "order:";
  * which is the `resolvePortFn` cross-file-fallback false-positive class the
  * codegen scorer hit on `relation.rb::computeCacheKey`.
  *
+ * Compared over a SINGLE candidate declaration's sequence only — two
+ * declarations under one name have no combined order — and the `rubyCalls` /
+ * `tsCalls` sequences must both be deduplicated at first occurrence, since a
+ * name's position is its first one.
+ *
  * At most one flag per body, naming the first inversion — `order:b,a → a,b`
  * reads "TS calls b before a; Rails calls a before b" — so the row is a stable
  * baseline key rather than a whole-sequence string that churns on every edit.
@@ -329,15 +334,15 @@ export function reorderedCalls(
 ): string[] {
   const rubySeq: string[] = [];
   for (const rc of rubyCalls) {
-    if (rc === rubyName) continue; // self/recursive call
+    if (rc === rubyName) continue;
     if (rc === "super") continue;
     if (!significant.has(rc)) continue;
     const mapped = mapCall(rc);
     if (!mapped || mapped.length === 0) continue;
     if (!mapped.some(isPortedWithArgs)) continue;
     const hit = mapped.find((c) => tsCalls.includes(c));
-    if (hit === undefined) continue; // missing, not reordered
-    if (rubySeq.includes(hit)) continue; // one position per TS name
+    if (hit === undefined) continue;
+    if (rubySeq.includes(hit)) continue;
     rubySeq.push(hit);
   }
   if (rubySeq.length < 2) return [];
@@ -1642,10 +1647,6 @@ export function main() {
     const tsOptionKeysByFileName = new Map<string, Map<string, (string[] | null)[]>>();
     // Body call-sets scoped per (file, name) for the advisory calls-parity check.
     const tsCallsByFileName = new Map<string, Map<string, string[][]>>();
-    // Same population, source-ordered (MethodInfo.callSeq), for the order-only
-    // comparison (RFC 0084). Kept separate from tsCallsByFileName because that
-    // one is unioned/flattened across candidate declarations and helpers, which
-    // has no order to speak of.
     const tsCallSeqByFileName = new Map<string, Map<string, string[][]>>();
     const tsMissingCallTagsByFileName = new Map<string, Map<string, Set<string>>>();
     // Same call-sets unioned by NAME across this package and its deps (the same
@@ -2178,10 +2179,6 @@ export function main() {
             if (tags.has(call)) suppressedCalls.push({ tsFile, rubyName, tsName, call });
           }
         }
-        // Order-only parity (RFC 0084), over the body's OWN source-ordered
-        // sequence: a single candidate declaration only — two declarations under
-        // one name have no combined order — and never a delegating wrapper,
-        // whose order belongs to the implementation it forwards to.
         const seqSets = tsCallSeqByFileName.get(tsFile)?.get(tsName);
         const ordered: string[] = [];
         if (seqSets?.length === 1 && !isDelegatingWrapper(tsName, own.calls)) {

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -198,6 +198,34 @@ describe("body call capture", () => {
     expect(save.calls).toEqual(["helper", "nested", "runCallbacks", "touch"]);
   });
 
+  it("also records the same calls in source order, for the order-only comparison", () => {
+    const cls = extractFromSource(
+      `class Foo {
+        create() {
+          this.build();
+          this.save();
+        }
+      }`,
+    );
+    const create = cls.instanceMethods.find((m) => m.name === "create")!;
+    // `calls` is sorted, so `["build", "save"]` there says nothing about order;
+    // `callSeq` is what a reordered port shows up in (RFC 0084).
+    expect(create.calls).toEqual(["build", "save"]);
+    expect(create.callSeq).toEqual(["build", "save"]);
+
+    const reordered = extractFromSource(
+      `class Foo {
+        create() {
+          this.save();
+          this.build();
+        }
+      }`,
+    );
+    const swapped = reordered.instanceMethods.find((m) => m.name === "create")!;
+    expect(swapped.calls).toEqual(["build", "save"]);
+    expect(swapped.callSeq).toEqual(["save", "build"]);
+  });
+
   it("marks a call made in a negated position with the ! prefix", () => {
     // The faithful port of ActiveSupport's `exclude?` (`!include?`); the
     // call ratchet requires the marker before crediting a negating alias.

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -700,6 +700,7 @@ export function extractFromProgram(
         const line = node.getSourceFile().getLineAndCharacterOfPosition(node.getStart()).line + 1;
         const fnOptionKeys = extractOptionKeys(node.parameters, checker);
         const fnCalls = extractCalls(node.body);
+        const fnCallSeq = extractCallSeq(node.body);
         const internal = hasInternalJsDocTag(node);
         const noRailsEquivalent = noRailsEquivalentReason(node);
         const fnMissingRailsCalls = missingRailsCallTags(node);
@@ -714,6 +715,7 @@ export function extractFromProgram(
           ...(noRailsEquivalent !== undefined ? { noRailsEquivalent } : {}),
           ...(fnOptionKeys !== undefined ? { optionKeys: fnOptionKeys } : {}),
           ...(fnCalls !== undefined ? { calls: fnCalls } : {}),
+          ...(fnCallSeq !== undefined ? { callSeq: fnCallSeq } : {}),
           ...(fnMissingRailsCalls !== undefined ? { missingRailsCalls: fnMissingRailsCalls } : {}),
         });
       } else if (ts.isVariableStatement(node) && isExported(node)) {
@@ -2028,10 +2030,9 @@ export function extractClass(
       // (double-attribution). Suppress the wrapper's call-set so the canonical
       // module-function candidate is the one compared; the method name still
       // counts for presence/arity parity.
-      const calls =
-        namespaceSelfDelegationName(member.body, checker) === memberName
-          ? undefined
-          : extractCalls(member.body);
+      const suppressed = namespaceSelfDelegationName(member.body, checker) === memberName;
+      const calls = suppressed ? undefined : extractCalls(member.body);
+      const callSeq = suppressed ? undefined : extractCallSeq(member.body);
       const delegatesTo = delegationTargetName(member.body, memberName, name, checker);
       if (delegatesTo) delegationTargets.add(delegatesTo);
       const method: MethodInfo = {
@@ -2045,6 +2046,7 @@ export function extractClass(
         ...tagged,
         ...(optionKeys !== undefined ? { optionKeys } : {}),
         ...(calls !== undefined ? { calls } : {}),
+        ...(callSeq !== undefined ? { callSeq } : {}),
         ...(delegatesTo !== undefined ? { delegatesTo } : {}),
       };
       // Only instance methods are reachable via `this.helper(...)` and only
@@ -2064,6 +2066,7 @@ export function extractClass(
       // Constructor bodies are the home of bare `super(...)` chains — capture
       // calls here so calls-parity can flag a ported constructor that drops it.
       const calls = extractCalls(member.body);
+      const callSeq = extractCallSeq(member.body);
       instanceMethods.push({
         name: "constructor",
         visibility,
@@ -2073,6 +2076,7 @@ export function extractClass(
         ...(internal ? { internal: true } : {}),
         ...tagged,
         ...(calls !== undefined ? { calls } : {}),
+        ...(callSeq !== undefined ? { callSeq } : {}),
       });
     } else if (ts.isGetAccessorDeclaration(member) && memberName) {
       const method: MethodInfo = {
@@ -2542,7 +2546,25 @@ function isNegatedOperand(expr: ts.Node): boolean {
   return !isNegatedOperand(parent);
 }
 
+/**
+ * The same call names in SOURCE ORDER — the sequence the call-order comparison
+ * reads (RFC 0084). `extractCalls` sorts, which is the right shape for a
+ * membership test but erases the one signal a set diff cannot carry: Rails'
+ * branch and call ORDER, which CLAUDE.md's "same branches, in the same order"
+ * makes a first-class fidelity requirement. Deduplicated at first occurrence,
+ * matching the Ruby extractor's `calls.uniq` (extract-ruby-api.rb:2043), so the
+ * two sequences are directly comparable.
+ */
+function extractCallSeq(node: ts.Node | undefined): string[] | undefined {
+  return collectCalls(node);
+}
+
 function extractCalls(node: ts.Node | undefined): string[] | undefined {
+  const names = collectCalls(node);
+  return names === undefined ? undefined : [...names].sort();
+}
+
+function collectCalls(node: ts.Node | undefined): string[] | undefined {
   if (!node) return undefined;
   const aliases = currentImportAliases;
   const resolve = (name: string): string => aliases?.get(name) ?? name;
@@ -2612,7 +2634,7 @@ function extractCalls(node: ts.Node | undefined): string[] | undefined {
   };
   ts.forEachChild(node, visit);
   if (names.size === 0) return undefined;
-  return [...names].sort();
+  return [...names];
 }
 
 /**

--- a/scripts/api-compare/extractor-schema.ts
+++ b/scripts/api-compare/extractor-schema.ts
@@ -73,6 +73,7 @@ export const EXTRACTOR_OUTPUT_FIELDS = [
   "deps",
   "depRefs",
   "calls",
+  "callSeq",
   "internal",
   "option_keys",
   "optionKeys",

--- a/scripts/api-compare/types.ts
+++ b/scripts/api-compare/types.ts
@@ -41,6 +41,15 @@ export interface MethodInfo {
   depRefs?: Record<string, string[]>;
   calls?: string[];
   /**
+   * TS-side only (RFC 0084): the same call names in SOURCE ORDER, deduplicated
+   * at first occurrence exactly as the Ruby extractor's `calls.uniq` is. `calls`
+   * is sorted, so a set diff over it is blind to ordering; this field is what
+   * lets the calls gate report an order-only divergence — Rails' branch/call
+   * order not preserved by the port — as its own status. Populated for class
+   * members, constructors and top-level functions.
+   */
+  callSeq?: string[];
+  /**
    * Ruby-side only (RFC 0083): the subset of `calls` whose every occurrence in
    * the body had a provably inert receiver — a local variable or a literal
    * (`xs.first`, `opts.fetch`, `{}.merge`). Those say nothing about the port,


### PR DESCRIPTION
Two bundled stories.

## 1. `quoted_date` formats through `packages/date`

Rails formats a temporal value for SQL in one place: `quoted_date`
(`abstract/quoting.rb:184-199`) calls `value.to_fs(:db)` — `strftime("%Y-%m-%d
%H:%M:%S")` for a Time (`core_ext/time/conversions.rb:9`), `"%Y-%m-%d"` for a
Date (`core_ext/date/conversions.rb:12`) — and appends `sprintf("%06d",
value.usec)` when `usec > 0`. PostgreSQL's override
(`postgresql/quoting.rb:143-150`) is `super` plus a year rewrite.

`abstract/sql-datetime.ts` was hand-rolling all of that: its own `padYear`,
`formatDatePrefix`, `formatTimeComponents`, and a `pgDateTimeLiteral` that
re-implemented the whole literal rather than calling the abstract one. Now:

- every formatter builds a `StrftimeSubject` and calls `strftime` from
  `@blazetrails/date` — the same formatter `TimeWithZone#strftime` uses;
- the PG arms call the abstract formatter and apply only Rails' year rewrite
  (`super.sub(/^-?\d+/, bce_year) + " BC"`), so the BC override goes *through*
  the shared path as `super` does;
- `formatPlainTimeForSql` follows `quoted_time` (`quoting.rb:201-204`): move to
  2000-01-01, format through the date path, strip the date prefix.

Three hand-rolled private helpers are deleted. The `instanceof Date` rejection
guards at `quoting.ts` are untouched.

**Emitted SQL:** identical on every path the suites exercise —
`precision-roundtrip`, `quoting.test.ts`, and the sqlite3 / mysql / abstract-mysql
/ postgresql quoting suites all pass unchanged (281 tests). One expectation moved,
and it is a convergence, not an SQL change on any live path: a **negative
(BCE) year** used to render unpadded (`-43-03-15`) because the local `padYear`
skipped padding for negatives. The date gem's `%Y` pads the digits behind the
sign, so `Date.new(-43, 3, 15).to_fs(:db)` is `-0043-03-15` — the new output.
That path is unreachable on PostgreSQL (year <= 0 takes the BC branch, whose
digits are computed as `-year + 1` and are byte-identical before and after), and
no other suite or fixture renders a negative year.

## 2. Call SEQUENCE parity in the call ratchet

The ratchet compared Ruby and TS call **sets**, so it was blind to ordering —
while CLAUDE.md makes "same branches, in the same order" a fidelity
requirement. That signal existed only in `scripts/prism-codegen/score.ts`
(`matched` / `reordered` / `divergent`) over 10 Ruby files; this moves it into
`api:calls`, which covers ~1,460 (package, file, method) rows.

- `extract-ts-api.ts` records a **source-ordered** `callSeq` beside the sorted
  `calls`, deduplicated at first occurrence exactly as the Ruby extractor's
  `calls.uniq` (`extract-ruby-api.rb:2043`) is, so the two sequences are directly
  comparable. Registered in `EXTRACTOR_OUTPUT_FIELDS` so stale cache entries are
  evicted.
- `compare.ts:reorderedCalls` flags a body that makes every significant call
  Rails makes, in a different sequence. It reuses `significantMissingCalls`'
  gates and only considers calls **present** in TS, so a dropped call stays that
  check's finding — the two never double-report one body. At most one row per
  body, naming the first inversion (`order:save,build → build,save` = "TS calls
  save before build; Rails calls build before save"), which keeps the baseline
  key stable instead of a whole-sequence string that churns on every edit.
- The false-positive class from the codegen implementation is excluded by
  construction: the comparison reads the body's **own** ordered sequence, never
  the helper/delegation union, and skips delegating wrappers — the
  `resolvePortFn` cross-file fallback that produced spurious `divergent` rows for
  `relation.rb::computeCacheKey` / `computeCacheVersion` has no analogue here.

**Baseline:** 188 order-only rows across 103 shard files, merged into the
existing `call-mismatches-exclude/` tree through `serializeBaseline` — never
`--write`. Verified each touched shard is a pure superset of its committed
content (no reason rewritten, no non-`order:` row added). Every seeded row
carries its own ordering-specific reason text, so an order-only row is
distinguishable from a dropped-call row in review, and the `order:` key prefix
makes the class greppable. `pnpm api:calls` gates green (2356 baselined).

The rows are real signal, not noise: e.g.
`belongs_to_association.rb::handle_dependency` reaches `target.destroy` before
`reflection` in Rails, while the port reads `this.reflection.options.dependent`
first and drops the `destroy_async` arm entirely — a set diff reports nothing
there.

## Notes

- Code diff is 421 LOC (+318/-103) excluding the generated baseline shards.
- `pnpm api:calls` green; `pnpm lint` green; `scripts/api-compare` suite 1005
  passing; AR quoting/datetime suites 281 passing. Full AR runs on the three
  adapter lanes are CI's.
- Not extended to `callSeq` for members declared inside exported object literals
  (`export const X = { method() {} }`); the ordering check simply does not run
  for those, so no false rows — worth a follow-up if that population matters.

Closes-story: activerecord-quoted-date-through-date-package
Closes-story: call-sequence-parity-in-wide-ratchet
