### PR TITLE
refactor(activerecord): retire the synchronous association mass-assignment arms

### DIFF
--- a/packages/activerecord/src/associations/collection-awaitable-writers.trails.test.ts
+++ b/packages/activerecord/src/associations/collection-awaitable-writers.trails.test.ts
@@ -92,9 +92,10 @@ describe("CollectionAwaitableWriters", () => {
     const post = await Post.create({ title: "t", body: "b" });
     const assignOn = (owner: Author): void =>
       (owner as unknown as CollectionOwner).assignAttributes({ postIds: [post.id] });
+    const persisted = await Author.create({ name: "Bill" });
 
     expect(() => assignOn(new Author({ name: "Bill" }))).toThrow(/unknown attribute `postIds`/);
-    expect(() => assignOn(new Author({ name: "Bill" }))).toThrow(/unknown attribute `postIds`/);
+    expect(() => assignOn(persisted)).toThrow(/unknown attribute `postIds`/);
   });
 
   it("a bad id is a catchable rejection on the awaitable ids surface", async () => {

--- a/packages/activerecord/src/associations/collection-awaitable-writers.trails.test.ts
+++ b/packages/activerecord/src/associations/collection-awaitable-writers.trails.test.ts
@@ -19,7 +19,7 @@
  */
 import { describe, it, expect, beforeAll } from "vitest";
 import { registerModel, RecordNotFound } from "../index.js";
-import { CollectionIdsAssignmentError, CollectionPersistedAssignmentError } from "./errors.js";
+import { CollectionIdsAssignmentError } from "./errors.js";
 import { Author } from "../test-helpers/models/author.js";
 import { Post } from "../test-helpers/models/post.js";
 import { Comment } from "../test-helpers/models/comment.js";
@@ -83,23 +83,18 @@ describe("CollectionAwaitableWriters", () => {
     expect(await (author as unknown as { postIds: Promise<unknown> }).postIds).toBeDefined();
   });
 
-  it("ids= mass-assignment throws on both owner arms", async () => {
-    // Mass-assignment raises through `_assign_attributes`' rescue, so the
-    // deviation is the `cause`, as in the record-writer case below.
+  it("ids= mass-assignment reaches no association writer on either owner arm", async () => {
+    // RFC 0087: `assign_attributes` no longer routes `#{singular}Ids` into a
+    // synchronous writer. Rails' generated `post_ids=`
+    // (builder/collection_association.rb:67-74) resolves the ids with a query,
+    // which trails cannot await here, so with no writer for the key
+    // ActiveModel's `attribute_writer_missing` answers on both arms.
     const post = await Post.create({ title: "t", body: "b" });
-    const causeOf = (owner: Author): unknown => {
-      try {
-        (owner as unknown as CollectionOwner).assignAttributes({ postIds: [post.id] });
-      } catch (e) {
-        return (e as { cause?: unknown }).cause;
-      }
-      return undefined;
-    };
+    const assignOn = (owner: Author): void =>
+      (owner as unknown as CollectionOwner).assignAttributes({ postIds: [post.id] });
 
-    expect(causeOf(new Author({ name: "Bill" }))).toBeInstanceOf(CollectionIdsAssignmentError);
-    expect(causeOf(await Author.create({ name: "Bill" }))).toBeInstanceOf(
-      CollectionIdsAssignmentError,
-    );
+    expect(() => assignOn(new Author({ name: "Bill" }))).toThrow(/unknown attribute `postIds`/);
+    expect(() => assignOn(new Author({ name: "Bill" }))).toThrow(/unknown attribute `postIds`/);
   });
 
   it("a bad id is a catchable rejection on the awaitable ids surface", async () => {
@@ -121,27 +116,18 @@ describe("CollectionAwaitableWriters", () => {
     expect((await postsOf(author).toArray()).map((p) => p.title)).toEqual(["b"]);
   });
 
-  it("mass-assignment throws on a persisted owner", async () => {
+  it("mass-assignment reaches no association writer on a persisted owner", async () => {
     const author = (await Author.create({ name: "Bill" })) as unknown as CollectionOwner;
     const post = await Post.create({ title: "t", body: "b" });
-    let raised: unknown;
-    try {
-      author.assignAttributes({ posts: [post] });
-    } catch (e) {
-      raised = e;
-    }
-    expect((raised as { cause?: unknown })?.cause).toBeInstanceOf(
-      CollectionPersistedAssignmentError,
-    );
+    expect(() => author.assignAttributes({ posts: [post] })).toThrow(/unknown attribute `posts`/);
   });
 
-  it("keeps in-memory mass-assignment on an unpersisted owner", async () => {
+  it("keeps in-memory assignment on construction", async () => {
     // Rails defers here too (`replace_records` without a save — the FK isn't
-    // known yet), so the in-memory arm is faithful and autosave persists at the
-    // owner's first `save()`.
-    const author = new Author({ name: "Bill" });
+    // known yet), so the constructor's in-memory arm is faithful and autosave
+    // persists at the owner's first `save()`.
     const post = new Post({ title: "t", body: "b" });
-    (author as unknown as CollectionOwner).assignAttributes({ posts: [post] });
+    const author = new Author({ name: "Bill", posts: [post] });
 
     expect(targetOf(author).length).toBe(1);
     await author.save();

--- a/packages/activerecord/src/associations/constructor-form-and-hmt-insert.test.ts
+++ b/packages/activerecord/src/associations/constructor-form-and-hmt-insert.test.ts
@@ -36,27 +36,32 @@ describe("constructor-form association writer", () => {
     expect(target[1]).toBe(p2);
   });
 
-  it("dispatches via assignAttributes (manual-call path, non-multiparameter)", () => {
-    const author = new Author();
+  it("dispatches alongside plain attributes in the same constructor bag", () => {
     const p1 = new Post({ title: "a" });
-    author.assignAttributes({ name: "Acme", posts: [p1] });
+    const author = new Author({ name: "Acme", posts: [p1] });
     expect((author as any).readAttribute("name")).toBe("Acme");
     expect((author as any).association("posts").target).toEqual([p1]);
   });
 
-  it("dispatches via assignAttributes (multiparameter branch)", () => {
-    const author = new Author();
+  it("dispatches alongside a multiparameter key in the same constructor bag", () => {
     const p1 = new Post({ title: "a" });
-    // Mix in a multiparameter key so assignAttributes takes the
-    // hasMultiparameterKeys branch — association routing must still happen.
-    author.assignAttributes({
-      posts: [p1],
-      // Force the multiparameter branch via a parenthesized key —
-      // value content is irrelevant; we only care that `posts` still
-      // routes through assignAssociationIfMatch in this branch.
-      "name(1)": "x",
-    });
+    // Mix in a parenthesized key so construction takes the multiparameter
+    // branch — the association must still be dispatched in that branch. The
+    // value content is irrelevant.
+    const author = new Author({ posts: [p1], "name(1)": "x" });
     expect((author as any).association("posts").target).toEqual([p1]);
+  });
+
+  it("no longer routes an association key reached through assignAttributes", () => {
+    // RFC 0087: mass assignment onto an existing record has no unpersisted-owner
+    // guarantee, so it no longer reaches a synchronous association writer. With
+    // no writer for the key, ActiveModel's `attribute_writer_missing`
+    // (attribute_assignment.rb:67-75) is what answers. Callers use `#update`,
+    // which awaits the real writer.
+    const author = new Author();
+    expect(() => author.assignAttributes({ posts: [new Post({ title: "a" })] })).toThrow(
+      /unknown attribute `posts`/,
+    );
   });
 
   it("dispatches single record to hasOne association on construction", () => {

--- a/packages/activerecord/src/associations/has-one-persisted-setter-throws.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-persisted-setter-throws.trails.test.ts
@@ -9,8 +9,11 @@
  * writes to the owner's next `save()` (the order-undefined two-row race
  * RFC 0068 exists to kill), the assignment THROWS and names the awaitable
  * replacement (`await owner.set#{Name}(x)`). On an *unpersisted* owner Rails
- * does no I/O either, so the in-memory replace is faithful and kept. There is
- * no Rails test for this deviation.
+ * does no I/O either, so the in-memory replace is faithful and kept — but only
+ * on the *constructor* arm, whose owner is unpersisted by definition. RFC 0087
+ * retired the mass-assignment routing, so a has_one key reaching
+ * `assign_attributes` now falls to ActiveModel's `attribute_writer_missing`.
+ * There is no Rails test for this deviation.
  */
 import { describe, it, expect, beforeAll } from "vitest";
 import { registerModel, AssociationTypeMismatch } from "../index.js";
@@ -21,6 +24,7 @@ import { Member } from "../test-helpers/models/member.js";
 import { Membership } from "../test-helpers/models/membership.js";
 import { Club } from "../test-helpers/models/club.js";
 import { fixtures } from "../test-fixtures.js";
+import { assertQueriesCount } from "../testing/query-assertions.js";
 
 interface HasOneOwner {
   account?: unknown;
@@ -91,14 +95,18 @@ describe("HasOnePersistedSetterThrows", () => {
     }
   });
 
-  it("mass-assignment (assignAttributes) throws on a persisted owner", async () => {
+  it("mass-assignment (assignAttributes) reaches no association writer", async () => {
+    // RFC 0087: `assign_attributes` no longer routes a has_one key into the
+    // synchronous writer. Rails would `public_send("account=")` and persist the
+    // displacement inline (has_one_association.rb:59-84); trails cannot await
+    // there, so with no writer for the key ActiveModel's
+    // `attribute_writer_missing` (attribute_assignment.rb:67-75) answers, and
+    // callers use `#update` or `setAccount` instead.
     const firm = (await Firm.create({ name: "GlobalMegaCorp" })) as unknown as HasOneOwner;
     const account = await Account.create({ credit_limit: 1000 });
-    // `assignAttributes` wraps a setter throw in AttributeAssignmentError
-    // (longstanding trails behavior), whose message carries the inner one.
     expect(() => {
       firm.assignAttributes({ account });
-    }).toThrow(/await owner\.setAccount\(x\)/);
+    }).toThrow(/unknown attribute `account`/);
   });
 
   it("update awaits the has_one writer on a persisted owner", async () => {
@@ -123,21 +131,31 @@ describe("HasOnePersistedSetterThrows", () => {
     ).toThrow(HasOnePersistedAssignmentError);
   });
 
-  it("has_one_through mass-assignment throws on a persisted owner", async () => {
+  it("has_one_through mass-assignment reaches no association writer", async () => {
     const member = (await Member.create({ name: "Groucho" })) as unknown as HasOneOwner;
     const club = await Club.create({ name: "Moustache" });
     expect(() => {
       member.assignAttributes({ club });
-    }).toThrow(/await owner\.setClub\(x\)/);
+    }).toThrow(/unknown attribute `club`/);
   });
 
-  it("mass-assignment does the in-memory replace on an unpersisted owner", async () => {
-    const firm = new Firm({ name: "GlobalMegaCorp" });
+  it("construction issues no query for the association assignment", async () => {
+    // The synchronous constructor arm is only faithful because it does no I/O:
+    // `find_target?` (association.rb:320-322) has both disjuncts false for a
+    // has_one on a new owner, so Rails loads nothing either.
     const account = new Account({ credit_limit: 1000 });
-    const owner = firm as unknown as HasOneOwner;
-    expect(() => {
-      owner.assignAttributes({ account });
-    }).not.toThrow();
+    await assertQueriesCount(0, false, async () => {
+      new Firm({ name: "GlobalMegaCorp", account });
+    });
+  });
+
+  it("construction does the in-memory replace on an unpersisted owner", async () => {
+    // The constructor arm stays synchronous: its owner is unpersisted by
+    // definition, so `save &&= owner.persisted?` (has_one_association.rb:66) and
+    // `remove_target!`'s gate (:108) make the write in-memory in Rails too, and
+    // autosave persists it at the owner's first `save`.
+    const account = new Account({ credit_limit: 1000 });
+    const firm = new Firm({ name: "GlobalMegaCorp", account });
     await firm.save();
     expect((account as unknown as { firm_id: number }).firm_id).toBe(Number(firm.id));
   });

--- a/packages/activerecord/src/attribute-assignment.ts
+++ b/packages/activerecord/src/attribute-assignment.ts
@@ -14,7 +14,6 @@ import {
   extractMultiparameterCallstack,
   executeMultiparameterAssignment,
 } from "./multiparameter-attribute-assignment.js";
-import { singularize } from "@blazetrails/activesupport";
 
 interface AttributeAssignmentHost {
   writeAttribute(key: string, value: unknown): void;
@@ -22,8 +21,6 @@ interface AttributeAssignmentHost {
   // a key through its writer, or route a writer-less key to
   // `attribute_writer_missing` (→ UnknownAttributeError). Inherited from `Model`.
   _assignAttribute(key: string, value: unknown): void;
-  constructor: unknown;
-  association?: (name: string) => unknown;
 }
 
 /**
@@ -40,14 +37,6 @@ export function _assignAttributes(
   for (const [k, v] of Object.entries(attributes)) {
     if (k.includes("(")) {
       (multiParameterAttributes ??= Object.create(null))[k] = v;
-    } else if (
-      assignAssociationIfMatch(
-        this as { constructor?: unknown; association?: (name: string) => unknown },
-        k,
-        v,
-      )
-    ) {
-      // Routed to association proxy writer (constructor-form collection / singular).
     } else if (v !== null && typeof v === "object" && !Array.isArray(v)) {
       (nestedParameterAttributes ??= Object.create(null))[k] = v;
     } else {
@@ -140,92 +129,6 @@ export function typeCastAttributeValue(multiparameterName: string, value: string
 export function findParameterPosition(multiparameterName: string): number {
   const match = multiparameterName.match(/\((\d+)/);
   return match ? parseInt(match[1], 10) : 0;
-}
-
-/**
- * @internal
- * Shared dispatch for constructor-form / assignAttributes association
- * writers. When `key` matches a declared association on `host.constructor`,
- * route `value` to the proxy's `replace`/`writer` rather than
- * `writeAttribute`. Mirrors Rails' `_assign_attribute` routing through
- * `public_send("#{k}=")` into association writer methods.
- *
- * Single source of truth used by `persistence.ts#assignAttributes`,
- * `attribute-assignment.ts#_assignAttributes`, and the constructor
- * dispatch in `base.ts`.
- */
-export function assignAssociationIfMatch(
-  host: { constructor?: unknown; association?: (name: string) => unknown },
-  key: string,
-  value: unknown,
-): boolean {
-  const ctor = host.constructor as
-    | { _associations?: Array<{ name: string; type: string }> }
-    | undefined;
-  let assoc = ctor?._associations?.find((a) => a.name === key);
-  // `#{singular}Ids` is a second mass-assignment key onto the same collection
-  // association — Rails generates `#{name.singularize}_ids=`
-  // (builder/collection_association.rb:67-74) and `assign_attributes` reaches
-  // it through `public_send`. trails has no such property setter (it would
-  // have to await `ids_writer`'s resolving query — RFC 0087 §1), so the key is
-  // matched here and dispatched to the association below.
-  let idsKey = false;
-  if (!assoc) {
-    assoc = ctor?._associations?.find(
-      (a) =>
-        (a.type === "hasMany" || a.type === "hasAndBelongsToMany") &&
-        `${singularize(a.name)}Ids` === key,
-    );
-    idsKey = assoc !== undefined;
-  }
-  if (!assoc) return false;
-  if (typeof host.association !== "function") return false;
-  const proxy = host.association(assoc.name) as
-    | {
-        replace?: (v: unknown[]) => void;
-        writer?: (v: unknown) => void;
-        syncWrite?: (v: unknown) => void;
-        syncIdsWrite?: (v: unknown[]) => never;
-      }
-    | null
-    | undefined;
-  if (!proxy) return false;
-  if (idsKey) {
-    if (typeof proxy.syncIdsWrite !== "function") return false;
-    proxy.syncIdsWrite(value as unknown[]);
-    return true;
-  }
-  if (assoc.type === "hasMany" || assoc.type === "hasAndBelongsToMany") {
-    // Mass-assignment can't await, so it shares the native `=` setter's
-    // `syncWrite` dispatch: in-memory replace on an unpersisted owner, and a
-    // throw (`CollectionPersistedAssignmentError`) on a persisted one — Rails
-    // replaces the collection inline at assignment, which needs `await` in JS.
-    // Callers use `await owner.#{name}.replace([...])` instead (RFC 0068).
-    //
-    // Rails fidelity: pass the value through unchanged. The writer path does
-    // not Array.wrap — Rails' replace calls `.each` on the argument and raises
-    // on nil / scalars. Coercing here would silently accept inputs the regular
-    // writer rejects.
-    if (typeof proxy.syncWrite !== "function") return false;
-    proxy.syncWrite(value as unknown[]);
-    return true;
-  }
-  if (assoc.type === "hasOne") {
-    // Mass-assignment can't await, so it shares the native `=` setter's
-    // `syncWrite` dispatch: in-memory replace on an unpersisted owner, and a
-    // throw (`HasOnePersistedAssignmentError`) on a persisted one — Rails
-    // persists a has_one displacement inline at assignment, which needs `await`
-    // in JS. Callers use `await owner.set#{Name}(x)` instead (RFC 0068).
-    if (typeof proxy.syncWrite !== "function") return false;
-    proxy.syncWrite(value);
-    return true;
-  }
-  if (assoc.type === "belongsTo") {
-    if (typeof proxy.writer !== "function") return false;
-    proxy.writer(value);
-    return true;
-  }
-  return false;
 }
 
 export const InstanceMethods = {

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -837,15 +837,60 @@ function _reinstateConstructorDirtiness(
   record._dirty.reinstateNewRecordChanges(record._attributes);
 }
 
-/** @internal */
+/**
+ * The constructor's association arm. Rails reaches these writers through
+ * `assign_attributes` → `public_send("#{k}=", v)`
+ * (activemodel/lib/active_model/attribute_assignment.rb:67-75); trails cannot,
+ * because a has_one / collection writer is awaitable (RFC 0087) and `new` is
+ * not. It stays synchronous here and only here, because a constructor's owner
+ * is unpersisted by definition and Rails does no I/O for one either:
+ * `save &&= owner.persisted?` (has_one_association.rb:66), `remove_target!`'s
+ * `owner.persisted?` gate (:108) and `find_target?` (association.rb:320-322)
+ * are all false, so the write is in-memory in Rails too and autosave persists
+ * it at the owner's first `save`. Mass assignment onto an *existing* record has
+ * no such guarantee and no longer routes here — it goes through `#update`,
+ * which awaits the real writer.
+ *
+ * @internal
+ */
 function _dispatchAssociationAttrs(record: Base, assocs: _PendingAssociationAttr[]): void {
+  const defs = (record.constructor as { _associations?: _AssociationDefLike[] })._associations;
   for (const { name, value } of assocs) {
-    _AttributeAssignment.assignAssociationIfMatch(
-      record as unknown as { constructor?: unknown; association?: (name: string) => unknown },
-      name,
-      value,
-    );
+    let assoc = defs?.find((a) => a.name === name);
+    let idsKey = false;
+    if (!assoc) {
+      assoc = defs?.find(
+        (a) =>
+          (a.type === "hasMany" || a.type === "hasAndBelongsToMany") &&
+          `${_singularize(a.name)}Ids` === name,
+      );
+      idsKey = assoc !== undefined;
+    }
+    if (!assoc) continue;
+    const proxy = (
+      record as unknown as { association(n: string): _ConstructorAssociationWriter | null }
+    ).association(assoc.name);
+    if (!proxy) continue;
+    if (idsKey) {
+      proxy.syncIdsWrite?.(value as unknown[]);
+    } else if (assoc.type === "hasMany" || assoc.type === "hasAndBelongsToMany") {
+      // Rails fidelity: pass the value through unchanged. `replace` calls
+      // `.each` on the argument and raises on nil / scalars, so an `Array.wrap`
+      // here would silently accept inputs the writer rejects.
+      proxy.syncWrite?.(value as unknown[]);
+    } else if (assoc.type === "hasOne") {
+      proxy.syncWrite?.(value);
+    } else if (assoc.type === "belongsTo") {
+      proxy.writer?.(value);
+    }
   }
+}
+
+/** @internal The writers {@link _dispatchAssociationAttrs} reaches on an association. */
+interface _ConstructorAssociationWriter {
+  writer?: (v: unknown) => void;
+  syncWrite?: (v: unknown) => void;
+  syncIdsWrite?: (v: unknown[]) => void;
 }
 
 // Build the Arel value node for one write-path column (INSERT VALUES / UPDATE

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -672,7 +672,7 @@ interface _AssociationDefLike {
 
 /**
  * A constructor-form assignment held back until after `super()` —
- * `assignAssociationIfMatch` reaches `this.association(...)`, whose cache
+ * `_dispatchAssociationAttrs` reaches `this.association(...)`, whose cache
  * field is not initialized until `super()` returns.
  * @internal
  */
@@ -704,7 +704,7 @@ function _isCollectionIdsKey(defs: _AssociationDefLike[], key: string): boolean 
  * nothing.
  *
  * A `#{singular}Ids` key (`new Author({postIds: [...]})`) is deferred too:
- * `assignAssociationIfMatch` reaches `this.association(name)`, whose cache
+ * `_dispatchAssociationAttrs` reaches `this.association(name)`, whose cache
  * field is not initialized until after `super()` returns.
  */
 function _extractAssociationAttrs(

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -679,17 +679,23 @@ interface _AssociationDefLike {
 interface _PendingAssociationAttr {
   name: string;
   value: unknown;
+  /** The association `name` resolved to, and whether `name` was its `#{singular}Ids` key. */
+  assoc: _AssociationDefLike;
+  idsKey: boolean;
 }
 
 /**
  * @internal
- * Is `key` the `#{singular}Ids` mass-assignment key of one of `defs`'
- * collection associations? A `*Ids` key naming no collection association
- * (a genuine column, say) is left on the attribute path.
+ * The collection association whose `#{singular}Ids` mass-assignment key is
+ * `key`, if any. A `*Ids` key naming no collection association (a genuine
+ * column, say) is left on the attribute path.
  */
-function _isCollectionIdsKey(defs: _AssociationDefLike[], key: string): boolean {
-  if (!key.endsWith("Ids")) return false;
-  return defs.some(
+function _collectionIdsKeyOwner(
+  defs: _AssociationDefLike[],
+  key: string,
+): _AssociationDefLike | undefined {
+  if (!key.endsWith("Ids")) return undefined;
+  return defs.find(
     (a) =>
       (a.type === "hasMany" || a.type === "hasAndBelongsToMany") &&
       `${_singularize(a.name)}Ids` === key,
@@ -722,10 +728,14 @@ function _extractAssociationAttrs(
   // copy entries. Avoids per-construction overhead for the hot path.
   let assocs: _PendingAssociationAttr[] | null = null;
   for (const k of Object.keys(attrs)) {
-    if (defs.find((a) => a.name === k)) {
-      (assocs ??= []).push({ name: k, value: attrs[k] });
-    } else if (_isCollectionIdsKey(defs, k)) {
-      (assocs ??= []).push({ name: k, value: attrs[k] });
+    const named = defs.find((a) => a.name === k);
+    if (named) {
+      (assocs ??= []).push({ name: k, value: attrs[k], assoc: named, idsKey: false });
+      continue;
+    }
+    const idsOwner = _collectionIdsKeyOwner(defs, k);
+    if (idsOwner) {
+      (assocs ??= []).push({ name: k, value: attrs[k], assoc: idsOwner, idsKey: true });
     }
   }
   if (!assocs) return null;
@@ -854,19 +864,7 @@ function _reinstateConstructorDirtiness(
  * @internal
  */
 function _dispatchAssociationAttrs(record: Base, assocs: _PendingAssociationAttr[]): void {
-  const defs = (record.constructor as { _associations?: _AssociationDefLike[] })._associations;
-  for (const { name, value } of assocs) {
-    let assoc = defs?.find((a) => a.name === name);
-    let idsKey = false;
-    if (!assoc) {
-      assoc = defs?.find(
-        (a) =>
-          (a.type === "hasMany" || a.type === "hasAndBelongsToMany") &&
-          `${_singularize(a.name)}Ids` === name,
-      );
-      idsKey = assoc !== undefined;
-    }
-    if (!assoc) continue;
+  for (const { value, assoc, idsKey } of assocs) {
     const proxy = (
       record as unknown as { association(n: string): _ConstructorAssociationWriter | null }
     ).association(assoc.name);

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -30,7 +30,6 @@ import {
   extractMultiparameterCallstack,
   executeMultiparameterAssignment,
 } from "./multiparameter-attribute-assignment.js";
-import { assignAssociationIfMatch } from "./attribute-assignment.js";
 import { threadedConnectionFor } from "./connection-handling.js";
 import {
   getStiBase,
@@ -1093,17 +1092,6 @@ export function _reapplyNestedAttrSetters(
  */
 function _assignAttribute(self: AttributeIO, key: string, value: unknown): void {
   try {
-    if (
-      assignAssociationIfMatch(
-        self as { constructor?: unknown; association?: (name: string) => unknown },
-        key,
-        value,
-      )
-    ) {
-      // Routed to the association proxy writer (constructor-form collection /
-      // singular) — Rails reaches these through `public_send("#{k}=")` too.
-      return;
-    }
     const setter = findPrototypeSetter(self, key);
     if (setter) {
       setter.call(self, value);


### PR DESCRIPTION
RFC 0087 §3. With the synchronous association writers retired by the earlier
stories in this epic, the mass-assignment routing arms that fed them go too,
and each entry point takes the shape its own signature allows.

**What changed**

- `attribute-assignment.ts#_assignAttributes` loses its association branch and
  is now an exact mirror of `attribute_assignment.rb:6-22` — multiparameter
  key, Hash value, else `_assign_attribute`.
- `persistence.ts#_assignAttribute` (the live `assign_attributes` path) loses
  the same branch. With no writer for a has_one / collection / `#{singular}Ids`
  key, ActiveModel's `attribute_writer_missing`
  (`attribute_assignment.rb:67-75`) answers, as it does in Rails for any
  writer-less key.
- The shared `assignAssociationIfMatch` helper — a trails invention with no
  Rails counterpart, previously called from three sites — is deleted. Its one
  surviving caller, the constructor, keeps the dispatch inline in
  `_dispatchAssociationAttrs` in `base.ts`.

**What did not change, and why**

`#update` / `#update!` already await the association write inline
(`assignUpdateAttribute` routes collections through `idsWriter` / `writer` and
has_one through `writer`), which is where Rails' `assign_attributes` does it.
`create` needs no change either: Rails' `create` is `new(attributes); save`, so
it reaches the constructor arm.

The constructor arm stays synchronous. A constructor's owner is unpersisted by
definition, so `save &&= owner.persisted?` (`has_one_association.rb:66`),
`remove_target!`'s `owner.persisted?` gate (`:108`) and `find_target?`
(`association.rb:320-322`, both disjuncts false for has_one / has_many on a new
owner) are all false — the write is in-memory in Rails too, and autosave
persists it at the owner's first `save`. A new test pins that
`new Firm({ account })` issues no query.

**Tests**

The trails-only tests that pinned the retired arms (`assignAttributes` throwing
`HasOnePersistedAssignmentError` / `CollectionPersistedAssignmentError` /
`CollectionIdsAssignmentError`) now pin the `attribute_writer_missing` outcome,
and their unpersisted-owner in-memory cases move to the constructor form they
now describe. The direct `syncWrite` coverage is untouched — that surface is
retired by `grep-gate-sync-association-writers-to-zero`.

**Gates**

`pnpm api:compare` unchanged (13108/17794). `pnpm test:compare` unchanged
(15211/22648, 4007 extra) — delta zero. `pnpm api:calls` clean, no new baseline
rows. `pnpm api:extra --package activerecord`: `attribute-assignment.ts` drops
from 1 novel to 0; `base.ts` unchanged at 6. `pnpm lint` clean. 292 LOC.

**Not in this PR**

The two `packages/date` stories bundled with this one are blocked, not skipped.
Both depend on #6153 (split (a): seat `Date` on `Temporal.PlainDate`), which is
still open — `date-temporal-default-return-and-ruby-opt-in`'s entire premise is
that (a) has landed, and `datetime-new-offset-arg-is-not-val2off`'s exact
target lines (the `DateTime` constructor JSDoc and signature) are rewritten
inside #6153's diff. Both are `pnpm tasks block`ed with that reason rather than
stacked on an unmerged branch.

Closes-story: retire-sync-association-mass-assignment-arms
