### PR TITLE
feat(date,activerecord): d_simple_new_internal skips the second civil validation; port PG transaction_status

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.transaction-status.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.transaction-status.trails.test.ts
@@ -1,0 +1,72 @@
+/**
+ * `PostgreSQLAdapter#transactionStatus` — the port of ruby-pg's
+ * `PG::Connection#transaction_status` (libpq `PQtransactionStatus`), which
+ * Rails reads in `retryable_query_error?` (postgresql_adapter.rb:850) and
+ * `cancel_any_running_query` (postgresql/database_statements.rb:127).
+ *
+ * Trails-only: ruby-pg gets the value from libpq, so there is no Rails test to
+ * mirror — the transitions are the driver-level invariant the two ported call
+ * sites stand on. RFC 0085.
+ */
+import { expect, it } from "vitest";
+import { Deadlocked } from "../errors.js";
+import { describeIfPg, PG_TEST_URL } from "../support/describe-if-pg.js";
+import { PostgreSQLAdapter } from "./postgresql-adapter.js";
+
+// Same numbering as libpq's PGTransactionStatusType.
+const PQTRANS_IDLE = 0;
+const PQTRANS_INTRANS = 2;
+const PQTRANS_INERROR = 3;
+const PQTRANS_UNKNOWN = 4;
+
+function transactionStatus(adapter: PostgreSQLAdapter): number {
+  return (adapter as unknown as { transactionStatus: number }).transactionStatus;
+}
+
+describeIfPg("PostgreSQLAdapter transaction_status", () => {
+  it("is unknown before a connection is opened", async () => {
+    const adapter = new PostgreSQLAdapter({ connectionString: PG_TEST_URL });
+    try {
+      expect(transactionStatus(adapter)).toBe(PQTRANS_UNKNOWN);
+    } finally {
+      await adapter.disconnectBang();
+    }
+  });
+
+  it("moves idle → in transaction → in failed transaction", async () => {
+    const adapter = new PostgreSQLAdapter({ connectionString: PG_TEST_URL });
+    try {
+      await adapter.execute("SELECT 1");
+      expect(transactionStatus(adapter)).toBe(PQTRANS_IDLE);
+
+      await adapter.beginDbTransaction();
+      expect(transactionStatus(adapter)).toBe(PQTRANS_INTRANS);
+
+      await expect(adapter.execute("SELECT * FROM no_such_table_here")).rejects.toThrow();
+      expect(transactionStatus(adapter)).toBe(PQTRANS_INERROR);
+
+      await adapter.rollbackDbTransaction();
+      expect(transactionStatus(adapter)).toBe(PQTRANS_IDLE);
+    } finally {
+      await adapter.disconnectBang();
+    }
+  });
+
+  it("retryable_query_error? is false inside a broken transaction", async () => {
+    const adapter = new PostgreSQLAdapter({ connectionString: PG_TEST_URL });
+    try {
+      await adapter.execute("SELECT 1");
+      expect(adapter.isRetryableQueryError(new Deadlocked("deadlock detected"))).toBe(true);
+
+      await adapter.beginDbTransaction();
+      await expect(adapter.execute("SELECT * FROM no_such_table_here")).rejects.toThrow();
+      expect(transactionStatus(adapter)).toBe(PQTRANS_INERROR);
+      expect(adapter.isRetryableQueryError(new Deadlocked("deadlock detected"))).toBe(false);
+
+      await adapter.rollbackDbTransaction();
+      expect(adapter.isRetryableQueryError(new Deadlocked("deadlock detected"))).toBe(true);
+    } finally {
+      await adapter.disconnectBang();
+    }
+  });
+});

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -112,8 +112,10 @@ const PQTRANS_ACTIVE = 1;
 const PQTRANS_INTRANS = 2;
 const PQTRANS_INERROR = 3;
 const PQTRANS_UNKNOWN = 4;
-// Mirrors: PostgreSQL::DatabaseStatements::IDLE_TRANSACTION_STATUSES
-// (postgresql/database_statements.rb:124)
+/**
+ * Mirrors: `PostgreSQL::DatabaseStatements::IDLE_TRANSACTION_STATUSES`
+ * (postgresql/database_statements.rb:124).
+ */
 const IDLE_TRANSACTION_STATUSES = [PQTRANS_IDLE, PQTRANS_INTRANS, PQTRANS_INERROR];
 import {
   READ_QUERY,
@@ -450,20 +452,26 @@ export class PostgreSQLAdapter
   // "in TX?" check at call sites that mirror the prior shape.
   private _client: pg.Client | null = null;
   private _inTransaction = false;
-  // The status byte of the last ReadyForQuery message on `_rawConnection`
-  // ('I' idle / 'T' in transaction / 'E' failed transaction), which is what
-  // libpq derives `PQtransactionStatus` from. See `transactionStatus`.
+  /**
+   * The status byte of the last ReadyForQuery message on `_rawConnection`
+   * ('I' idle / 'T' in transaction / 'E' failed transaction), which is what
+   * libpq derives `PQtransactionStatus` from. See `transactionStatus`.
+   */
   private _readyForQueryStatus = "I";
-  // Whether the command on the wire has produced its terminating message
-  // (CommandComplete / ErrorResponse) but not yet its ReadyForQuery. libpq has
-  // no such window — PQgetResult returns only once the whole cycle is drained —
-  // but node-pg settles the query promise on the terminating message, so
-  // without this the caller can read the status back in that gap and see a
-  // command that is over reported as PQTRANS_ACTIVE.
+  /**
+   * Whether the command on the wire has produced its terminating message
+   * (CommandComplete / ErrorResponse) but not yet its ReadyForQuery. libpq has
+   * no such window — `PQgetResult` returns only once the whole cycle is drained
+   * — but node-pg settles the query promise on the terminating message, so
+   * without this the caller can read the status back in that gap and see a
+   * command that is over reported as PQTRANS_ACTIVE.
+   */
   private _commandSettled = true;
-  // The TransactionManager lock token of the chain that issued the query
-  // `transactionStatus` reports as PQTRANS_ACTIVE — see
-  // `_cancelAnyRunningQuery`.
+  /**
+   * The TransactionManager lock token of the chain that issued the query
+   * `transactionStatus` reports as PQTRANS_ACTIVE — see
+   * `_cancelAnyRunningQuery`.
+   */
   private _queryInFlightOwner: symbol | null = null;
   private _databaseVersion: number | null = null;
   private _typeMap: HashLookupTypeMap | null = null;
@@ -2278,7 +2286,9 @@ export class PostgreSQLAdapter
   /**
    * Record the ReadyForQuery status byte libpq keeps on the PGconn. Attached
    * once per pg.Client lifecycle alongside the notice listener, for the same
-   * reason: `resetBang` re-runs configure on the same client.
+   * reason: `resetBang` re-runs configure on the same client. An ErrorResponse
+   * aborts the open transaction, which the ReadyForQuery that follows spells
+   * 'E'; recording it on both keeps them consistent across the settle window.
    *
    * @internal
    */
@@ -2295,9 +2305,6 @@ export class PostgreSQLAdapter
       this._commandSettled = true;
     });
     connection.on("errorMessage", () => {
-      // The backend aborts the open transaction on any error; the
-      // ReadyForQuery that follows spells it 'E'. Recording it here as well
-      // keeps the two consistent across the settle window above.
       if (this._readyForQueryStatus === "T") this._readyForQueryStatus = "E";
       this._commandSettled = true;
     });

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -101,6 +101,20 @@ const TEMPORAL_OIDS = new Set([1082, 1083, 1114, 1184, 1266]);
 const OID_INTERVAL = 1186;
 const OID_INTERVAL_ARRAY = 1187;
 const OID_MONEY = 790;
+/**
+ * ruby-pg's `PG::PQTRANS_*` (libpq `PGTransactionStatusType`), which
+ * `PG::Connection#transaction_status` answers. Rails reads it in
+ * `retryable_query_error?` (postgresql_adapter.rb:850) and in
+ * `cancel_any_running_query` (postgresql/database_statements.rb:127).
+ */
+const PQTRANS_IDLE = 0;
+const PQTRANS_ACTIVE = 1;
+const PQTRANS_INTRANS = 2;
+const PQTRANS_INERROR = 3;
+const PQTRANS_UNKNOWN = 4;
+// Mirrors: PostgreSQL::DatabaseStatements::IDLE_TRANSACTION_STATUSES
+// (postgresql/database_statements.rb:124)
+const IDLE_TRANSACTION_STATUSES = [PQTRANS_IDLE, PQTRANS_INTRANS, PQTRANS_INERROR];
 import {
   READ_QUERY,
   buildTruncateStatements as pgBuildTruncateStatements,
@@ -436,9 +450,20 @@ export class PostgreSQLAdapter
   // "in TX?" check at call sites that mirror the prior shape.
   private _client: pg.Client | null = null;
   private _inTransaction = false;
-  private _queryInFlight = false;
+  // The status byte of the last ReadyForQuery message on `_rawConnection`
+  // ('I' idle / 'T' in transaction / 'E' failed transaction), which is what
+  // libpq derives `PQtransactionStatus` from. See `transactionStatus`.
+  private _readyForQueryStatus = "I";
+  // Whether the command on the wire has produced its terminating message
+  // (CommandComplete / ErrorResponse) but not yet its ReadyForQuery. libpq has
+  // no such window — PQgetResult returns only once the whole cycle is drained —
+  // but node-pg settles the query promise on the terminating message, so
+  // without this the caller can read the status back in that gap and see a
+  // command that is over reported as PQTRANS_ACTIVE.
+  private _commandSettled = true;
   // The TransactionManager lock token of the chain that issued the query
-  // `_queryInFlight` refers to — see `_cancelAnyRunningQuery`.
+  // `transactionStatus` reports as PQTRANS_ACTIVE — see
+  // `_cancelAnyRunningQuery`.
   private _queryInFlightOwner: symbol | null = null;
   private _databaseVersion: number | null = null;
   private _typeMap: HashLookupTypeMap | null = null;
@@ -1372,6 +1397,7 @@ export class PostgreSQLAdapter
         // reset (node-pg's EventEmitter, unlike libpq's
         // set_notice_receiver, doesn't replace).
         this._attachNoticeListener(newClient);
+        this._attachReadyForQueryListener(newClient);
         this._rawConnection = newClient;
         client = newClient;
       }
@@ -1545,20 +1571,21 @@ export class PostgreSQLAdapter
     });
     this._maintenanceTail = prev.then(() => gate);
     await prev.catch(() => {});
-    // DEVIATION (converging, RFC 0085): both fields are inventions.
-    // `_queryInFlight` stands in for `@raw_connection.transaction_status`,
-    // `_queryInFlightOwner` for the lock trails releases early — Rails'
-    // `cancel_any_running_query` (postgresql/database_statements.rb:127) needs
-    // neither. Scheduled for deletion; do not build on them. Claimed after the
-    // tail await so the marker names the query actually on the wire rather than
-    // one still queued (#5660) — a placement no test can pin down while these
-    // stand (RFC 0061 pg-in-flight-marker-regression-coverage, wontfix).
-    this._queryInFlight = true;
+    // DEVIATION (converging, RFC 0085): `_queryInFlightOwner` is an invention —
+    // it stands in for the lock trails releases early, which Rails'
+    // `cancel_any_running_query` (postgresql/database_statements.rb:127) does
+    // not need. Scheduled for deletion; do not build on it. Claimed after the
+    // tail await so it names the query actually on the wire rather than one
+    // still queued (#5660).
     this._queryInFlightOwner = this._transactionManager.currentLockToken;
+    // node-pg emits parsed backend messages only, so the send side of the
+    // cycle has no event to listen for: the outstanding-query half of
+    // `transactionStatus` is opened here, where the query goes on the wire,
+    // and closed by the terminating message.
+    this._commandSettled = false;
     try {
       return await fn();
     } finally {
-      this._queryInFlight = false;
       this._queryInFlightOwner = null;
       release();
     }
@@ -2220,6 +2247,62 @@ export class PostgreSQLAdapter
     await this.internalExecute("ROLLBACK AND CHAIN", "TRANSACTION");
   }
 
+  /**
+   * Mirrors: `PG::Connection#transaction_status` (ruby-pg / libpq
+   * `PQtransactionStatus`), which Rails reads in `retryable_query_error?`
+   * (postgresql_adapter.rb:850) and `cancel_any_running_query`
+   * (postgresql/database_statements.rb:127).
+   *
+   * libpq derives it from the status byte of the last ReadyForQuery message
+   * plus whether a query is outstanding; node-pg exposes both — pg-protocol
+   * parses the byte into `ReadyForQueryMessage.status` and `pg.Client` flips
+   * `readyForQuery` false for exactly the span a query is on the wire, which is
+   * the PQTRANS_ACTIVE that has no byte of its own.
+   *
+   * @internal
+   */
+  get transactionStatus(): number {
+    const client = this._rawConnection as (pg.Client & { readyForQuery?: boolean }) | null;
+    if (client == null) return PQTRANS_UNKNOWN;
+    if (client.readyForQuery !== true && !this._commandSettled) return PQTRANS_ACTIVE;
+    switch (this._readyForQueryStatus) {
+      case "T":
+        return PQTRANS_INTRANS;
+      case "E":
+        return PQTRANS_INERROR;
+      default:
+        return PQTRANS_IDLE;
+    }
+  }
+
+  /**
+   * Record the ReadyForQuery status byte libpq keeps on the PGconn. Attached
+   * once per pg.Client lifecycle alongside the notice listener, for the same
+   * reason: `resetBang` re-runs configure on the same client.
+   *
+   * @internal
+   */
+  private _attachReadyForQueryListener(client: pg.Client): void {
+    this._readyForQueryStatus = "I";
+    this._commandSettled = true;
+    const connection = (client as pg.Client & { connection?: pg.Connection }).connection;
+    if (connection == null) return;
+    connection.on("readyForQuery", (message: { status?: string }) => {
+      if (typeof message?.status === "string") this._readyForQueryStatus = message.status;
+      this._commandSettled = true;
+    });
+    connection.on("commandComplete", () => {
+      this._commandSettled = true;
+    });
+    connection.on("errorMessage", () => {
+      // The backend aborts the open transaction on any error; the
+      // ReadyForQuery that follows spells it 'E'. Recording it here as well
+      // keeps the two consistent across the settle window above.
+      if (this._readyForQueryStatus === "T") this._readyForQueryStatus = "E";
+      this._commandSettled = true;
+    });
+  }
+
   // Mirrors: PostgreSQL::DatabaseStatements#cancel_any_running_query (database_statements.rb private)
   // Sends a CancelRequest to abort any in-flight query on the transaction connection
   // before issuing ROLLBACK / ROLLBACK AND CHAIN, so the rollback isn't blocked
@@ -2254,7 +2337,10 @@ export class PostgreSQLAdapter
       cancel(processID: number, secretKey: number): void;
     };
     const txClient = this._client as PgClientWithPid | null;
-    if (!this._queryInFlight || txClient?.processID == null) return;
+    if (this._rawConnection == null || IDLE_TRANSACTION_STATUSES.includes(this.transactionStatus)) {
+      return;
+    }
+    if (txClient?.processID == null) return;
     const owner = this._transactionManager.currentLockToken;
     if (owner === null || owner !== this._queryInFlightOwner) return;
     try {
@@ -4432,14 +4518,9 @@ export class PostgreSQLAdapter
    * @internal
    */
   isRetryableQueryError(exception: unknown): boolean {
-    // Rails additionally guards on `@raw_connection.transaction_status !=
-    // PG::PQTRANS_INERROR`, omitted here for want of a `transaction_status`
-    // port; the abstract predicate (Deadlocked | LockWaitTimeout) is still the
-    // authoritative gate. Not a hard limit of the driver, as previously noted
-    // here: pg-protocol parses the ReadyForQuery status byte into
-    // `ReadyForQueryMessage.status` ('I' / 'T' / 'E'), emitted on
-    // `client.connection`. Porting it is RFC 0085.
-    return super.isRetryableQueryError(exception);
+    // We cannot retry anything if we're inside a broken transaction; we need to at
+    // least raise until the innermost savepoint is rolled back
+    return this.transactionStatus !== PQTRANS_INERROR && super.isRetryableQueryError(exception);
   }
 
   /**

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -2174,7 +2174,7 @@ export function dNewByFrags(hash: DateParts): Date {
   }
 
   if (jd === null) throw new DateError("invalid date");
-  return new Date(jd.year, jd.month, jd.day);
+  return new Date(jd);
 }
 
 /**
@@ -2199,9 +2199,10 @@ function of2str(of: number): string {
  * `60` back to `59` — and the `:offset` `date_zone_to_diff` left in the frags.
  *
  * Ruby then moves the day and day-fraction to UTC (`jd_local_to_utc` /
- * `df_local_to_utc`, `date_core.c:8311-8313`) and converts back on every read.
- * The {@link DateTime} constructor does both conversions, so the local civil
- * date and time of day are handed to it as they are.
+ * `df_local_to_utc`, `date_core.c:8311-8313`) and converts back on every read,
+ * and hands the converted pair to `d_complex_new_internal` — so the conversion
+ * happens here, at the C's own call site, and the constructor's UTC overload
+ * takes the result as it is.
  *
  * The `:offset` bound (`date_core.c:8297-8306`) is ported as written — strictly
  * outside `±DAY_IN_SECONDS` is ignored rather than raised on. It is unreachable
@@ -2252,7 +2253,8 @@ export function dtNewByFrags(hash: DateParts): DateTime {
   let of = t == null ? 0 : t instanceof Rational ? t.numerator / t.denominator : t;
   if (of < -DAY_IN_SECONDS || of > DAY_IN_SECONDS) of = 0;
 
-  return new DateTime(jd.year, jd.month, jd.day, rh, rmin, rs, of);
+  const df = timeToDf(rh, rmin, rs);
+  return new DateTime(jdLocalToUtc(jd, df, of), dfLocalToUtc(df, of), of);
 }
 
 /**
@@ -2307,7 +2309,26 @@ export class Date {
    * `date_core.c` `date_s_civil`), which raises `Date::Error` on a civil date
    * `c_valid_civil_p` rejects.
    */
-  constructor(year = -4712, month = 1, day = 1) {
+  constructor(year?: number, month?: number, day?: number);
+  /**
+   * @internal `date_core.c` `d_simple_new_internal` (`date_core.c:1057-1078`),
+   * which writes an already-resolved day straight into a fresh
+   * `SimpleDateData` under `HAVE_JD` and validates nothing — every caller
+   * (`d_new_by_frags`, `date_s_jd`, `date_s_ordinal`, `date_s_commercial`)
+   * has already established the date is buildable.
+   *
+   * It is a static C function the module-level `d_new_by_frags` calls; TS has
+   * no member visibility between "the class body" and "exported", so a
+   * `static #` seam would be unreachable from the module-level ports and a
+   * `WeakMap` seam would be machinery ruby/date has no counterpart for. This
+   * overload is the smallest seam that reaches `#date`.
+   */
+  constructor(rjd: Temporal.PlainDate);
+  constructor(year: number | Temporal.PlainDate = -4712, month = 1, day = 1) {
+    if (year instanceof Temporal.PlainDate) {
+      this.#date = year;
+      return;
+    }
     const r = cValidCivilP(year, month, day);
     if (r === null) throw new DateError("invalid date");
     this.#date = r;
@@ -2321,8 +2342,7 @@ export class Date {
    * so the conversion happens at the call.
    */
   static jd(jd = 0): Date {
-    const d = jdToPlainDate(jd);
-    return new Date(d.year, d.month, d.day);
+    return new Date(jdToPlainDate(jd));
   }
 
   /**
@@ -2334,7 +2354,7 @@ export class Date {
   static ordinal(year = -4712, yday = 1): Date {
     const r = cValidOrdinalP(year, yday);
     if (r === null) throw new DateError("invalid date");
-    return new Date(r.year, r.month, r.day);
+    return new Date(r);
   }
 
   /**
@@ -2358,7 +2378,7 @@ export class Date {
   static commercial(cwyear = -4712, cweek = 1, cwday = 1): Date {
     const r = cValidCommercialP(cwyear, cweek, cwday);
     if (r === null) throw new DateError("invalid date");
-    return new Date(r.year, r.month, r.day);
+    return new Date(r);
   }
 
   /**
@@ -2577,11 +2597,37 @@ export class DateTime extends Date {
     year: number,
     month: number,
     day: number,
+    hour?: number,
+    minute?: number,
+    second?: number,
+    offset?: number,
+  );
+  /**
+   * @internal `date_core.c` `d_complex_new_internal` (`date_core.c:3055-3071`),
+   * the seam `dt_new_by_frags` (`date_core.c:8239-8322`) ends at, under
+   * `HAVE_JD | HAVE_DF`: the day and day-fraction it has already converted to
+   * UTC (`date_core.c:8311-8313`) and the offset are written straight into a
+   * fresh `ComplexDateData`, with neither a civil triple nor a time of day to
+   * validate. The arguments are `d_complex_new_internal`'s own `rjd`, `df` and
+   * `of`. Same TS shortcoming as {@link Date}'s counterpart overload.
+   */
+  constructor(rjd: Temporal.PlainDate, df: number, of: number);
+  constructor(
+    year: number | Temporal.PlainDate,
+    month = 1,
+    day = 1,
     hour = 0,
     minute = 0,
     second = 0,
     offset = 0,
   ) {
+    if (year instanceof Temporal.PlainDate) {
+      super(jdUtcToLocal(year, month, day));
+      this.#date = year;
+      this.#df = month;
+      this.#of = day;
+      return;
+    }
     super(year, month, day);
     const rjd = cValidCivilP(year, month, day);
     if (rjd === null) throw new DateError("invalid date");

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -2311,7 +2311,7 @@ export class Date {
    */
   constructor(year?: number, month?: number, day?: number);
   /**
-   * @internal `date_core.c` `d_simple_new_internal` (`date_core.c:1057-1078`),
+   * @internal `date_core.c` `d_simple_new_internal` (`date_core.c:3036-3050`),
    * which writes an already-resolved day straight into a fresh
    * `SimpleDateData` under `HAVE_JD` and validates nothing — every caller
    * (`d_new_by_frags`, `date_s_jd`, `date_s_ordinal`, `date_s_commercial`)


### PR DESCRIPTION
Two convergence stories from one bundle. The third,
`check-pending-has-no-file-update-checker-watcher`, is **blocked** and not in
this PR: Rails' `CheckPending` is built around
`ActiveSupport::FileUpdateChecker`, which has no trails port
(`packages/activesupport/src` holds only a skipped
`evented-file-update-checker.test.ts`), and its watcher block calls
`Migration.check_pending_migrations`, which is still a no-op stub in trails
(`migration.ts:1521`). Both have to land before `call` can take Rails' shape.
Blocker recorded on the story.

## `d_simple_new_internal` skips the second civil validation

ruby/date's `d_new_by_frags` ends at
`d_simple_new_internal(cDate, nth, rjd, sg, 0, 0, 0, HAVE_JD)`
(`date_core.c:4282-4304`) — the day is written straight into a fresh
`SimpleDateData` with no validation, because `rt__valid_date_frags_p` has
already established the date is buildable. `dt_new_by_frags`
(`date_core.c:8239-8322`) does the same through `d_complex_new_internal`.

The ports ended at `new Date(jd.year, jd.month, jd.day)`, re-running
`cValidCivilP` — and so `Temporal.PlainDate.from(..., { overflow: "reject" })` —
over a `PlainDate` that is valid by construction. Same shape in `Date.jd`,
`Date.ordinal` and `Date.commercial`.

Rebased onto #6154, which reseated `DateTime` on a UTC `jd`/`df` pair. That
moved the seam closer to the C: the internal overload is
`constructor(rjd: Temporal.PlainDate, df: number, of: number)` — the arguments
`d_complex_new_internal` itself takes under `HAVE_JD | HAVE_DF` — and the
`jd_local_to_utc` / `df_local_to_utc` conversions live in `dtNewByFrags`, where
the C performs them (`date_core.c:8311-8313`), rather than inside the
constructor. `Date`'s seam is the same idea one argument wide.

The seam is a second constructor overload taking the resolved
`Temporal.PlainDate`. It is the smallest thing that reaches `#date` from a
module-level function: TS has no visibility between "the class body" and
"exported", so a `static #` seam is unreachable from `dNewByFrags` /
`dtNewByFrags` (module-level, as they are in the C), and a `WeakMap` seam is
machinery ruby/date has no counterpart for. Justified at the call site, on both
overloads. Public typing is unchanged — `pnpm api:extra --package date` is 0
novel — and the `Date::Error` arms still raise from `dNewByFrags` for an
invalid frag set.

## PG `transaction_status`

The old comment claiming node-pg does not expose the transaction status byte
was wrong: pg-protocol parses ReadyForQuery into `ReadyForQueryMessage.status`
('I' / 'T' / 'E') and `pg.Client` emits it on `client.connection`. So:

- `transactionStatus` answers the `PG::PQTRANS_*` value, from the last status
  byte plus outstanding-query tracking (PQTRANS_ACTIVE has no byte of its own).
  node-pg emits parsed *backend* messages only, so the send side of the cycle is
  opened in `_serializePinnedQuery`, where the query goes on the wire, and
  closed by the terminating message. The `_commandSettled` window matters:
  node-pg settles the query promise on CommandComplete/ErrorResponse, one
  packet before ReadyForQuery, where libpq's `PQgetResult` drains the whole
  cycle — without it a finished command reads back as PQTRANS_ACTIVE (this was
  observably flaky before it was added).
- `isRetryableQueryError` restores Rails' `!= PG::PQTRANS_INERROR` guard
  (`postgresql_adapter.rb:850`), comment and all.
- `_cancelAnyRunningQuery` gates on `IDLE_TRANSACTION_STATUSES`
  (`postgresql/database_statements.rb:124-127`) instead of the invented
  `_queryInFlight`, which is deleted. `_queryInFlightOwner` stays until the
  lock-leak story lands, with its deviation note narrowed to it.

New trails test covers idle → in-transaction → failed-transaction against a
live PG, plus the INERROR retry gate. `pnpm api:calls` clean;
`api:extra` unchanged; full PG lanes for `adapters/postgresql/`,
`connection-adapters/` and `transactions.test.ts` green locally.

Closes-story: d-new-by-frags-skips-the-second-civil-validation
Closes-story: pg-transaction-status-port

