### PR TITLE
fix(api-compare): bucket the three activesupport calculations.rb reopenings on time-ext.ts

### DIFF
--- a/scripts/api-compare/call-mismatches-exclude/activesupport/time-ext.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/time-ext.json
@@ -1,0 +1,177 @@
+[
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "advance",
+    "call": "change",
+    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#advance: it computes the result inline instead of delegating to `change` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "advance",
+    "call": "to_date",
+    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#advance: it computes the result inline instead of delegating to `to_date` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "ago",
+    "call": "in_time_zone",
+    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#ago: it computes the result inline instead of delegating to `in_time_zone` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "ago",
+    "call": "since",
+    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#ago: it computes the result inline instead of delegating to `since` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "beginning_of_day",
+    "call": "change",
+    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#beginning_of_day: it computes the result inline instead of delegating to `change` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "beginning_of_day",
+    "call": "in_time_zone",
+    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#beginning_of_day: it computes the result inline instead of delegating to `in_time_zone` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "beginning_of_hour",
+    "call": "change",
+    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#beginning_of_hour: it computes the result inline instead of delegating to `change` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "beginning_of_minute",
+    "call": "change",
+    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#beginning_of_minute: it computes the result inline instead of delegating to `change` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "days_in_year",
+    "call": "days_in_month",
+    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#days_in_year: it computes the result inline instead of delegating to `days_in_month` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "end_of_day",
+    "call": "change",
+    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#end_of_day: it computes the result inline instead of delegating to `change` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "end_of_day",
+    "call": "in_time_zone",
+    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#end_of_day: it computes the result inline instead of delegating to `in_time_zone` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "end_of_hour",
+    "call": "change",
+    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#end_of_hour: it computes the result inline instead of delegating to `change` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "end_of_minute",
+    "call": "change",
+    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#end_of_minute: it computes the result inline instead of delegating to `change` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "middle_of_day",
+    "call": "change",
+    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#middle_of_day: it computes the result inline instead of delegating to `change` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "middle_of_day",
+    "call": "in_time_zone",
+    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#middle_of_day: it computes the result inline instead of delegating to `in_time_zone` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "next_day",
+    "call": "advance",
+    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#next_day: it computes the result inline instead of delegating to `advance` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "next_month",
+    "call": "advance",
+    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#next_month: it computes the result inline instead of delegating to `advance` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "next_year",
+    "call": "advance",
+    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#next_year: it computes the result inline instead of delegating to `advance` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "prev_day",
+    "call": "advance",
+    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#prev_day: it computes the result inline instead of delegating to `advance` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "prev_month",
+    "call": "advance",
+    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#prev_month: it computes the result inline instead of delegating to `advance` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "prev_year",
+    "call": "advance",
+    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#prev_year: it computes the result inline instead of delegating to `advance` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "seconds_since_midnight",
+    "call": "change",
+    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#seconds_since_midnight: it computes the result inline instead of delegating to `change` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "seconds_until_end_of_day",
+    "call": "end_of_day",
+    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#seconds_until_end_of_day: it computes the result inline instead of delegating to `end_of_day` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "since",
+    "call": "in_time_zone",
+    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#since: it computes the result inline instead of delegating to `in_time_zone` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "since",
+    "call": "warn",
+    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#since: it computes the result inline instead of delegating to `warn` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
+  }
+]

--- a/scripts/api-compare/conventions.test.ts
+++ b/scripts/api-compare/conventions.test.ts
@@ -329,6 +329,21 @@ describe("RUBY_FILE_TS_OVERRIDES", () => {
     expect(rubyFileToTs("../i18n.rb", "i18n")).toBe("i18n.ts");
     expect(rubyFileToTs("interpolate/ruby.rb", "i18n")).toBe("interpolate/ruby.ts");
   });
+
+  it("maps all three activesupport calculations.rb reopenings onto time-ext.ts", () => {
+    // `Time`, `Date` and `DateTime` are each first reopened elsewhere
+    // (object/blank.rb:186, date/acts_like.rb:5, date_time/acts_like.rb:6), so
+    // without these the 129 methods the calculations.rb files add are measured
+    // against files that define none of them.
+    expect(rubyFileToTs("core_ext/time/calculations.rb", "activesupport")).toBe("time-ext.ts");
+    expect(rubyFileToTs("core_ext/date/calculations.rb", "activesupport")).toBe("time-ext.ts");
+    expect(rubyFileToTs("core_ext/date_time/calculations.rb", "activesupport")).toBe("time-ext.ts");
+  });
+
+  it("leaves the acts_like.rb reopenings on the default kebab-case rule", () => {
+    expect(hasRubyFileTsOverride("core_ext/date/acts_like.rb", "activesupport")).toBe(false);
+    expect(hasRubyFileTsOverride("core_ext/date_time/acts_like.rb", "activesupport")).toBe(false);
+  });
 });
 
 describe("SKIP_GROUPS", () => {

--- a/scripts/api-compare/conventions.ts
+++ b/scripts/api-compare/conventions.ts
@@ -146,6 +146,18 @@ export const RUBY_FILE_TS_OVERRIDES: Record<string, string> = {
   // `ARTest` is defined by `config.rb` first; `connection.rb` reopens it for the
   // three connection helpers, which trails ports to `support/connection.ts`.
   "activerecord-test-support:connection.rb": "connection.ts",
+  // `Time`, `Date` and `DateTime` are each first reopened by a different
+  // core_ext file — `object/blank.rb:186`, `date/acts_like.rb:5` and
+  // `date_time/acts_like.rb:6` — so the three `calculations.rb` reopenings
+  // (`time/calculations.rb:11`, `date/calculations.rb:10`,
+  // `date_time/calculations.rb:5`) contribute 129 methods to buckets named
+  // after files that define none of them. trails ports all three onto the one
+  // `time-ext.ts` (its three test files — `core-ext/{time,date,date-time}-ext.test.ts`
+  // — all import from it), the same one-TS-file-for-several-reopenings shape as
+  // `inflector.ts` above.
+  "activesupport:core_ext/time/calculations.rb": "time-ext.ts",
+  "activesupport:core_ext/date/calculations.rb": "time-ext.ts",
+  "activesupport:core_ext/date_time/calculations.rb": "time-ext.ts",
 };
 
 /** The explicit TS mapping for `rubyFile` in `pkg`, or undefined when unmapped. */


### PR DESCRIPTION
Measurement fix, not new porting work. No `packages/**` source changes.

## The orphan buckets

The extractor stamps one `file` on a Ruby entity — where its first method is
defined — so every later reopening's methods are measured against *that* file's
TS counterpart. `Time`, `Date` and `DateTime` are each first reopened by a
different core_ext file:

| entity | first reopened at | calculations.rb reopening | methods |
| --- | --- | --- | --- |
| `Time` | `core_ext/object/blank.rb:186` | `core_ext/time/calculations.rb:11` | 57 |
| `DateTime` | `core_ext/date_time/acts_like.rb:6` | `core_ext/date_time/calculations.rb:5` | 38 |
| `Date` | `core_ext/date/acts_like.rb:5` | `core_ext/date/calculations.rb:10` | 34 |

129 methods measured against `core-ext/object/blank.ts` /
`core-ext/date/acts-like.ts` / `core-ext/date-time/acts-like.ts`, none of which
define any of them — so they read as missing forever, and any future port of
`calculations.rb` would still read as missing.

## The fix

Three `RUBY_FILE_TS_OVERRIDES` entries in `scripts/api-compare/conventions.ts`,
all pointing at `packages/activesupport/src/time-ext.ts` — the single module
trails ports the three reopenings to, and the one all three of
`core-ext/{time,date,date-time}-ext.test.ts` import from. Same
one-TS-file-for-several-reopenings shape as the existing `inflector.ts` pair.

`splitOverriddenFileBuckets` (compare.ts:1272) then gives each file its own
bucket instead of leaking into the defining file's.

## Deltas (measurement fixes, not new ports)

`pnpm api:compare`:

| | before | after |
| --- | --- | --- |
| activesupport methods | 875/2328 (37.6%) | **918/2333 (39.3%)** |
| activesupport files | 94/176 | **97/179** |
| activesupport arity | 621/641 | 663/683 (20 mismatches either way) |
| overall | 13108/17794 (73.7%) | **13151/17799 (73.9%)** |
| overall files | 808/1050 | **811/1053** |

+43 methods, +3 files. Per-file rows the split creates:

```
core_ext/time/calculations.rb        time-ext.ts   21   30   51  41%
core_ext/date_time/calculations.rb   time-ext.ts   12   25   37  32%
core_ext/date/calculations.rb        time-ext.ts   10   21   31  32%
core_ext/object/blank.rb             …blank.ts      2  111  113   2%   (was 2/162)
core_ext/date/acts_like.rb           …acts-like.ts  0   75   75   0%   (was 0/103)
core_ext/date_time/acts_like.rb      …acts-like.ts  0   18   18   0%   (was 0/55)
```

`pnpm api:extra --package activesupport`: novel 373 and moved 491 both
unchanged; the no-Rails-counterpart slice drops **488 → 430** as `time-ext.ts`
(5 novel, 53 moved) stops being scored against an empty allowed set. No new
public surface.

`pnpm test:compare`: unchanged (15211/22648, 778/1073 files).

## Call ratchet

The newly-matched pairs surface 25 pre-existing call-set divergences, baselined
in `call-mismatches-exclude/activesupport/time-ext.json` with a real per-row
reason (no seeded default): `time-ext.ts` is a free-function module over JS
`Date` that computes each result inline, where Rails' `calculations.rb`
decomposes through `change` (boundary readers), `advance` (navigation readers),
`since` (`ago`), `days_in_month` (`days_in_year`) and `end_of_day`
(`seconds_until_end_of_day`). Surfaced, not introduced — this PR touches no
`packages/**` source. `pnpm api:calls` green.

Convergence is filed as
`0072-api-compare-parity-burndown/stories/activesupport-core-ext-calculations-delegation`,
with the Rails `file:line` for each delegation.

## Gates

`pnpm api:calls`, `api:arity`, `api:inheritance`, `api:pins`, `api:reasons`,
`api:detached` all green; `pnpm vitest run scripts/api-compare/` 1005 passed.

Closes-story: api-compare-orphan-buckets-activesupport-calculations
