### PR TITLE
feat(date,api-compare): ::DateTime carries a fractional second; extractors emit an ordered call/control skeleton

### DIFF
--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -610,6 +610,59 @@ describe("DateTime", () => {
     // ruby 3.3.11: DateTime.parse("not a date") #=> Date::Error: invalid date
     expect(() => RubyDateTime.parse("not a date")).toThrow("invalid date");
   });
+
+  it("keeps a constructed fractional second, so %N and %L answer real digits", () => {
+    // ruby 3.3.11:
+    //   d = DateTime.new(2008, 3, 1, 6, 0, Rational(1, 2))
+    //   d.strftime("%N")  #=> "500000000"
+    //   d.strftime("%L")  #=> "500"
+    //   d.sec_fraction    #=> (1/2)
+    //   d.sec             #=> 0
+    const datetime = new RubyDateTime(2008, 3, 1, 6, 0, 0.5);
+    expect(datetime.strftime("%N")).toBe("500000000");
+    expect(datetime.strftime("%L")).toBe("500");
+    expect(datetime.secFraction).toBe(0.5);
+    expect(datetime.sec).toBe(0);
+    // ruby 3.3.11: DateTime.new(2008, 3, 1, 6, 0, 1.5).sec #=> 1
+    expect(new RubyDateTime(2008, 3, 1, 6, 0, 1.5).sec).toBe(1);
+  });
+
+  it("keeps a parsed fractional second across the offset conversion", () => {
+    // ruby 3.3.11:
+    //   d = DateTime.parse("2008-03-01T06:00:00.123456789+09:00")
+    //   d.strftime("%N") #=> "123456789"
+    //   d.sec_fraction   #=> (123456789/1000000000)
+    const datetime = RubyDateTime.parse("2008-03-01T06:00:00.123456789+09:00");
+    expect(datetime.strftime("%N")).toBe("123456789");
+    expect(datetime.secFraction).toBe(0.123456789);
+    // ruby 3.3.11:
+    //   DateTime.parse("2008-03-01T06:00:00.9999999999").strftime("%N")
+    //     #=> "999999999"   (sf is (9999999999/10000000000); %N truncates)
+    expect(RubyDateTime.parse("2008-03-01T06:00:00.9999999999").strftime("%N")).toBe("999999999");
+  });
+
+  it("rounds the fractional second to a nanosecond, where Time#nsec truncates", () => {
+    // ruby 3.3.11 — d_lite_plus's T_FLOAT arm rounds (date_core.c:6097):
+    //   DateTime.new(2008, 3, 1, 6, 0, 0.3).strftime("%N")          #=> "300000000"
+    //   DateTime.new(2008, 3, 1, 6, 0, 0.1234567895).strftime("%N") #=> "123456790"
+    //   DateTime.new(2008, 3, 1, 6, 0, 6.1234567891).strftime("%N") #=> "123456789"
+    //   DateTime.new(2008, 3, 1, 6, 0, 0.000000001).strftime("%N")  #=> "000000001"
+    // where Time.utc(2008, 3, 1, 6, 0, 0.3).nsec #=> 299999999
+    expect(new RubyDateTime(2008, 3, 1, 6, 0, 0.3).strftime("%N")).toBe("300000000");
+    expect(new RubyDateTime(2008, 3, 1, 6, 0, 0.1234567895).strftime("%N")).toBe("123456790");
+    expect(new RubyDateTime(2008, 3, 1, 6, 0, 6.1234567891).strftime("%N")).toBe("123456789");
+    expect(new RubyDateTime(2008, 3, 1, 6, 0, 0.000000001).strftime("%N")).toBe("000000001");
+  });
+
+  it("answers zeros for an integer second, as ::Date does with no time of day", () => {
+    // ruby 3.3.11:
+    //   DateTime.new(2008, 3, 1, 6, 0, 0).strftime("%N") #=> "000000000"
+    //   DateTime.new(2008, 3, 1, 6, 0, 0).sec_fraction   #=> (0/1)
+    //   Date.new(2008, 3, 1).strftime("%N")              #=> "000000000"
+    expect(new RubyDateTime(2008, 3, 1, 6, 0, 0).strftime("%N")).toBe("000000000");
+    expect(new RubyDateTime(2008, 3, 1, 6, 0, 0).secFraction).toBe(0);
+    expect(new RubyDate(2008, 3, 1).strftime("%N")).toBe("000000000");
+  });
 });
 
 describe("Time", () => {

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -1787,6 +1787,26 @@ const UNIX_EPOCH_IN_CJD = 2440588;
 const MINUTE_IN_SECONDS = 60;
 const HOUR_IN_SECONDS = 3600;
 const DAY_IN_SECONDS = 86400;
+const SECOND_IN_NANOSECONDS = 1_000_000_000;
+
+/**
+ * @internal `date_core.c` `sec_to_ns` (`date_core.c:1054-1059`): a count of
+ * seconds as nanoseconds. The C keeps the product exact — it is a Rational
+ * whenever its argument is — so the result here can carry a fraction of a
+ * nanosecond, as `DateTime.parse("...00.9999999999").sec_fraction` does.
+ */
+function secToNs(s: number): number {
+  return s * SECOND_IN_NANOSECONDS;
+}
+
+/**
+ * @internal `date_core.c` `ns_to_sec` (`date_core.c:993-998`), the inverse.
+ * MRI answers a Rational; a JS number is the nearest analogue, as
+ * `Time#subsec` already documents.
+ */
+function nsToSec(n: number): number {
+  return n / SECOND_IN_NANOSECONDS;
+}
 
 /** @internal 1970-01-01, the day {@link UNIX_EPOCH_IN_CJD} numbers. */
 const UNIX_EPOCH = new Temporal.PlainDate(1970, 1, 1);
@@ -2249,12 +2269,15 @@ export function dtNewByFrags(hash: DateParts): DateTime {
   if (rt === null) throw new DateError("invalid date");
   const [rh, rmin, rs] = rt;
 
+  const df = timeToDf(rh, rmin, rs);
+
+  const sf = hash.secFraction == null ? 0 : secToNs(hash.secFraction);
+
   const t = hash.offset;
   let of = t == null ? 0 : t instanceof Rational ? t.numerator / t.denominator : t;
   if (of < -DAY_IN_SECONDS || of > DAY_IN_SECONDS) of = 0;
 
-  const df = timeToDf(rh, rmin, rs);
-  return new DateTime(jdLocalToUtc(jd, df, of), dfLocalToUtc(df, of), of);
+  return new DateTime(jdLocalToUtc(jd, df, of), dfLocalToUtc(df, of), sf, of);
 }
 
 /**
@@ -2558,6 +2581,13 @@ export class DateTime extends Date {
    */
   readonly #date: Temporal.PlainDate;
   readonly #df: number;
+  /**
+   * @internal `ComplexDateData`'s `sf`, the sub-second part in **nanoseconds**
+   * (`date_core.c:215-231`). `jd_local_to_utc` / `df_local_to_utc` do not touch
+   * it, so unlike {@link #date} and {@link #df} it is the same value read
+   * locally or in UTC.
+   */
+  readonly #sf: number;
   readonly #of: number;
 
   /**
@@ -2592,6 +2622,15 @@ export class DateTime extends Date {
    * `datetime_initialize` (`date_core.c:5147-5220`) validates the civil date with
    * `c_valid_civil_p` and the time of day with `c_valid_time_p`, then stores the
    * day and day-fraction in UTC — which is what the two conversions below do.
+   *
+   * A fractional `second` is split off by `num2int_with_frac`
+   * (`date_core.c:3296-3304`), which truncates the whole second and carries the
+   * remainder to `add_frac`'s `d_lite_plus` (`date_core.c:3313-3318`). That
+   * lands in the `T_FLOAT` arm, whose `sf = (int)round(o)` over
+   * `o *= SECOND_IN_NANOSECONDS` (`date_core.c:6094-6097`) is where the
+   * rounding to a whole nanosecond happens — so
+   * `DateTime.new(2008, 3, 1, 6, 0, 0.3).strftime("%N")` is `"300000000"`,
+   * where `Time#nsec` truncates the double and answers `299999999`.
    */
   constructor(
     year: number,
@@ -2608,10 +2647,11 @@ export class DateTime extends Date {
    * `HAVE_JD | HAVE_DF`: the day and day-fraction it has already converted to
    * UTC (`date_core.c:8311-8313`) and the offset are written straight into a
    * fresh `ComplexDateData`, with neither a civil triple nor a time of day to
-   * validate. The arguments are `d_complex_new_internal`'s own `rjd`, `df` and
-   * `of`. Same TS shortcoming as {@link Date}'s counterpart overload.
+   * validate. The arguments are `d_complex_new_internal`'s own `rjd`, `df`,
+   * `sf` and `of`, in that order. Same TS shortcoming as {@link Date}'s
+   * counterpart overload.
    */
-  constructor(rjd: Temporal.PlainDate, df: number, of: number);
+  constructor(rjd: Temporal.PlainDate, df: number, sf: number, of: number);
   constructor(
     year: number | Temporal.PlainDate,
     month = 1,
@@ -2622,20 +2662,24 @@ export class DateTime extends Date {
     offset = 0,
   ) {
     if (year instanceof Temporal.PlainDate) {
-      super(jdUtcToLocal(year, month, day));
+      super(jdUtcToLocal(year, month, hour));
       this.#date = year;
       this.#df = month;
-      this.#of = day;
+      this.#sf = day;
+      this.#of = hour;
       return;
     }
     super(year, month, day);
     const rjd = cValidCivilP(year, month, day);
     if (rjd === null) throw new DateError("invalid date");
-    const rt = cValidTimeP(hour, minute, second);
+    const s = Math.trunc(second);
+    const fr = second - s;
+    const rt = cValidTimeP(hour, minute, s);
     if (rt === null) throw new DateError("invalid date");
     const df = timeToDf(rt[0], rt[1], rt[2]);
     this.#date = jdLocalToUtc(rjd, df, offset);
     this.#df = dfLocalToUtc(df, offset);
+    this.#sf = Math.round(secToNs(fr));
     this.#of = offset;
   }
 
@@ -2713,6 +2757,18 @@ export class DateTime extends Date {
   }
 
   /**
+   * Ruby `DateTime#sec_fraction` (ruby/date, `date_core.c`
+   * `d_lite_sec_fraction` over `m_sf_in_sec`, `date_core.c:1568-1572`): the
+   * fractional part of the second, in `0...1`. MRI answers a Rational —
+   * `DateTime.new(2001, 2, 3, 4, 5, 6.5).sec_fraction` is `(1/2)` — and a JS
+   * number is the nearest analogue, as `Time#subsec` already documents. The
+   * whole second stays on {@link sec}, exactly as `::Time` splits them.
+   */
+  get secFraction(): number {
+    return nsToSec(this.#sf);
+  }
+
+  /**
    * Ruby `DateTime#zone` (ruby/date, `date_core.c` `d_lite_zone` over
    * `m_zone`, `date_core.c:1982-1988`): the UTC offset spelled by `of2str`,
    * where `Time#zone` is the zone's name. A `Date` — `simple_dat_p` — has no
@@ -2744,7 +2800,11 @@ export class DateTime extends Date {
         hour: this.hour,
         min: this.min,
         sec: this.sec,
-        nsec: 0,
+        // `%N` truncates rather than rounds (`date_strftime.c`'s `%N` takes the
+        // leading `w` digits of `sf`), which is what keeps
+        // `DateTime.parse("...00.9999999999").strftime("%N")` at `"999999999"`
+        // where the stored `sf` is a fraction of a nanosecond above it.
+        nsec: Math.trunc(this.#sf),
         zone: this.zone,
         utcOffset: this.#of,
       },

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -2623,14 +2623,16 @@ export class DateTime extends Date {
    * `c_valid_civil_p` and the time of day with `c_valid_time_p`, then stores the
    * day and day-fraction in UTC — which is what the two conversions below do.
    *
-   * A fractional `second` is split off by `num2int_with_frac`
-   * (`date_core.c:3296-3304`), which truncates the whole second and carries the
-   * remainder to `add_frac`'s `d_lite_plus` (`date_core.c:3313-3318`). That
-   * lands in the `T_FLOAT` arm, whose `sf = (int)round(o)` over
-   * `o *= SECOND_IN_NANOSECONDS` (`date_core.c:6094-6097`) is where the
-   * rounding to a whole nanosecond happens — so
-   * `DateTime.new(2008, 3, 1, 6, 0, 0.3).strftime("%N")` is `"300000000"`,
-   * where `Time#nsec` truncates the double and answers `299999999`.
+   * A fractional `second` is split off by `num2int_with_frac` over `s_trunc`
+   * (`date_core.c:3269-3303`): `f_idiv(s, 1)` — floor, not truncate — is the
+   * whole second, and `f_mod(s, 1)` the remainder, which `s_trunc` divides by
+   * `DAY_IN_SECONDS` to make a day fraction. `add_frac` hands that to
+   * `d_lite_plus` (`date_core.c:3314-3318`), whose `T_FLOAT` arm multiplies it
+   * straight back by `DAY_IN_SECONDS` — the two cancel, so `fr` is kept in
+   * seconds here — and then rounds the nanoseconds: `sf = (int)round(o)` over
+   * `o *= SECOND_IN_NANOSECONDS` (`date_core.c:6094-6097`). That round is why
+   * `DateTime.new(2008, 3, 1, 6, 0, 0.3).strftime("%N")` is `"300000000"`
+   * where `Time#nsec`, which truncates the double, answers `299999999`.
    */
   constructor(
     year: number,
@@ -2672,7 +2674,7 @@ export class DateTime extends Date {
     super(year, month, day);
     const rjd = cValidCivilP(year, month, day);
     if (rjd === null) throw new DateError("invalid date");
-    const s = Math.trunc(second);
+    const s = Math.floor(second);
     const fr = second - s;
     const rt = cValidTimeP(hour, minute, s);
     if (rt === null) throw new DateError("invalid date");
@@ -2789,6 +2791,13 @@ export class DateTime extends Date {
     return new Rational(this.#of, DAY_IN_SECONDS);
   }
 
+  /**
+   * `DateTime#strftime` hands the formatter the real `sf`, truncated to whole
+   * nanoseconds: `date_strftime.c`'s `%N` takes the LEADING digits of the
+   * fraction rather than rounding it, which is what keeps
+   * `DateTime.parse("...00.9999999999").strftime("%N")` at `"999999999"` when
+   * the stored `sf` sits a fraction of a nanosecond above it.
+   */
   override strftime(format: string): string {
     return strftime(
       {
@@ -2800,10 +2809,6 @@ export class DateTime extends Date {
         hour: this.hour,
         min: this.min,
         sec: this.sec,
-        // `%N` truncates rather than rounds (`date_strftime.c`'s `%N` takes the
-        // leading `w` digits of `sf`), which is what keeps
-        // `DateTime.parse("...00.9999999999").strftime("%N")` at `"999999999"`
-        // where the stored `sf` is a fraction of a nanosecond above it.
         nsec: Math.trunc(this.#sf),
         zone: this.zone,
         utcOffset: this.#of,

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -617,6 +617,25 @@ interface CallResult {
   mismatches: CallMismatch[];
   staleTags: StaleCallTag[];
   suppressed: SuppressedCall[];
+  skeletons: CallSkeleton[];
+}
+
+/**
+ * The ordered control + call skeleton of one name-matched (Ruby, TS) pair, both
+ * sides UNCOLLAPSED — no `effectiveTsCalls` delegation union, no
+ * `includeGraphCalls` merge, no dedup. Those are set operations by
+ * construction; a sequence needs its own merge rule, and until
+ * call-sequence-parity decides what it is, carrying the body's own stream and
+ * nothing else is the honest shape. Signal only (RFC 0084): written to
+ * output/call-skeletons.json, gated by nothing.
+ */
+interface CallSkeleton {
+  rubyFile: string;
+  rubyName: string;
+  tsFile: string;
+  tsName: string;
+  ruby: string[];
+  ts: string[];
 }
 
 /** A flag a `@missingRailsCall` tag suppressed. Reported in the artifact
@@ -1648,6 +1667,7 @@ export function main() {
     // Body call-sets scoped per (file, name) for the advisory calls-parity check.
     const tsCallsByFileName = new Map<string, Map<string, string[][]>>();
     const tsCallSeqByFileName = new Map<string, Map<string, string[][]>>();
+    const tsSkeletonByFileName = new Map<string, Map<string, string[][]>>();
     const tsMissingCallTagsByFileName = new Map<string, Map<string, Set<string>>>();
     // Same call-sets unioned by NAME across this package and its deps (the same
     // scope tsParamsByName uses). Consulted ONLY by the delegation-transparency
@@ -1719,6 +1739,11 @@ export function main() {
         const byName = tsCallSeqByFileName.get(file) ?? new Map<string, string[][]>();
         byName.set(m.name, [...(byName.get(m.name) ?? []), m.callSeq]);
         tsCallSeqByFileName.set(file, byName);
+      }
+      if (m.skeleton !== undefined) {
+        const byName = tsSkeletonByFileName.get(file) ?? new Map<string, string[][]>();
+        byName.set(m.name, [...(byName.get(m.name) ?? []), m.skeleton]);
+        tsSkeletonByFileName.set(file, byName);
       }
       if (m.calls !== undefined) {
         const byName = tsCallsByFileName.get(file) ?? new Map<string, string[][]>();
@@ -2001,6 +2026,7 @@ export function main() {
     const callMismatches: CallMismatch[] = [];
     const callTagsUsed = new Map<string, Set<string>>();
     const suppressedCalls: SuppressedCall[] = [];
+    const callSkeletons: CallSkeleton[] = [];
     const bodyHashRecords: BodyHashRecord[] = [];
     const fileResults: FileResult[] = [];
 
@@ -2049,6 +2075,8 @@ export function main() {
       const rubyWeakCallsByName = new Map<string, string[]>();
       // First-sighting Ruby body digest per name (source-hash pinning, RFC 0025).
       const rubyBodyDigestByName = new Map<string, string>();
+      // First-sighting Ruby body skeleton per name (RFC 0084 sequence signal).
+      const rubySkeletonByName = new Map<string, string[]>();
       for (const item of items) {
         const f = flattenIncludedMethodInfos(item.info, item.fqn, rubyPkg, moduleFqnByShort, pkg);
         const rubyMethods = [...f.instance, ...f.klass];
@@ -2065,6 +2093,9 @@ export function main() {
           if (rm.calls && !rubyCallsByName.has(rm.name)) {
             rubyCallsByName.set(rm.name, rm.calls);
             rubyWeakCallsByName.set(rm.name, rm.weakCalls ?? []);
+          }
+          if (rm.skeleton && !rubySkeletonByName.has(rm.name)) {
+            rubySkeletonByName.set(rm.name, rm.skeleton);
           }
           if (rm.bodyDigest && !rubyBodyDigestByName.has(rm.name)) {
             rubyBodyDigestByName.set(rm.name, rm.bodyDigest);
@@ -2178,6 +2209,21 @@ export function main() {
             const call = callOf(m);
             if (tags.has(call)) suppressedCalls.push({ tsFile, rubyName, tsName, call });
           }
+        }
+        // Uncollapsed on both sides, and recorded for every compared pair
+        // rather than only the flagged ones: this is the population the
+        // sequence gate will seed from, not a mismatch list.
+        const rubySkeleton = rubySkeletonByName.get(rubyName);
+        const tsSkeletons = tsSkeletonByFileName.get(tsFile)?.get(tsName);
+        if (rubySkeleton !== undefined && tsSkeletons?.length === 1) {
+          callSkeletons.push({
+            rubyFile,
+            rubyName,
+            tsFile,
+            tsName,
+            ruby: rubySkeleton,
+            ts: tsSkeletons[0],
+          });
         }
         const seqSets = tsCallSeqByFileName.get(tsFile)?.get(tsName);
         const ordered: string[] = [];
@@ -2614,6 +2660,7 @@ export function main() {
         mismatches: callMismatches,
         staleTags: staleCallTags(tsMissingCallTagsByFileName, callTagsUsed),
         suppressed: suppressedCalls,
+        skeletons: callSkeletons,
       },
       bodyHashes: bodyHashRecords,
     });
@@ -2745,6 +2792,28 @@ export function main() {
           mismatches: callsFlat,
           staleTags: staleTagsFlat,
           suppressed: suppressedFlat,
+        },
+        null,
+        2,
+      ),
+    );
+
+    // Sequence-signal artifact (RFC 0084) — its own file, so
+    // call-mismatches.json stays byte-identical and its ratchet reads exactly
+    // what it read before. Nothing gates on this yet;
+    // call-sequence-parity-in-wide-ratchet is what seeds rows from it.
+    const skeletonsPath = path.join(OUTPUT_DIR, `call-skeletons${modeSuffix}.json`);
+    const skeletonsFlat = results.flatMap((r) =>
+      r.calls.skeletons.map((s) => ({ package: r.package, ...s })),
+    );
+    fs.writeFileSync(
+      skeletonsPath,
+      JSON.stringify(
+        {
+          generatedAt: new Date().toISOString(),
+          note: "Advisory, ungated. Ordered control + call skeleton per name-matched pair, both sides uncollapsed: if/loop/try/throw, new:Ctor, ref:<name>, in source order with duplicates.",
+          packages: [...new Set(results.map((r) => r.package))].sort(),
+          skeletons: skeletonsFlat,
         },
         null,
         2,

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -626,8 +626,11 @@ interface CallResult {
  * `includeGraphCalls` merge, no dedup. Those are set operations by
  * construction; a sequence needs its own merge rule, and until
  * call-sequence-parity decides what it is, carrying the body's own stream and
- * nothing else is the honest shape. Signal only (RFC 0084): written to
- * output/call-skeletons.json, gated by nothing.
+ * nothing else is the honest shape. Recorded for every compared pair, not just
+ * the flagged ones: this is the population call-sequence-parity seeds from, not
+ * a mismatch list. Signal only (RFC 0084) — written to its own
+ * output/call-skeletons.json, so call-mismatches.json and its ratchet read
+ * exactly what they read before, and nothing gates on it yet.
  */
 interface CallSkeleton {
   rubyFile: string;
@@ -2075,7 +2078,6 @@ export function main() {
       const rubyWeakCallsByName = new Map<string, string[]>();
       // First-sighting Ruby body digest per name (source-hash pinning, RFC 0025).
       const rubyBodyDigestByName = new Map<string, string>();
-      // First-sighting Ruby body skeleton per name (RFC 0084 sequence signal).
       const rubySkeletonByName = new Map<string, string[]>();
       for (const item of items) {
         const f = flattenIncludedMethodInfos(item.info, item.fqn, rubyPkg, moduleFqnByShort, pkg);
@@ -2210,9 +2212,6 @@ export function main() {
             if (tags.has(call)) suppressedCalls.push({ tsFile, rubyName, tsName, call });
           }
         }
-        // Uncollapsed on both sides, and recorded for every compared pair
-        // rather than only the flagged ones: this is the population the
-        // sequence gate will seed from, not a mismatch list.
         const rubySkeleton = rubySkeletonByName.get(rubyName);
         const tsSkeletons = tsSkeletonByFileName.get(tsFile)?.get(tsName);
         if (rubySkeleton !== undefined && tsSkeletons?.length === 1) {
@@ -2798,10 +2797,6 @@ export function main() {
       ),
     );
 
-    // Sequence-signal artifact (RFC 0084) — its own file, so
-    // call-mismatches.json stays byte-identical and its ratchet reads exactly
-    // what it read before. Nothing gates on this yet;
-    // call-sequence-parity-in-wide-ratchet is what seeds rows from it.
     const skeletonsPath = path.join(OUTPUT_DIR, `call-skeletons${modeSuffix}.json`);
     const skeletonsFlat = results.flatMap((r) =>
       r.calls.skeletons.map((s) => ({ package: r.package, ...s })),

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -2047,15 +2047,8 @@ class ApiExtractor
     [calls.uniq, weak_calls]
   end
 
-  # Ripper nodes that token as `if`: every one is a conditional reach, which is
-  # what the TS side's IfStatement / ConditionalExpression / SwitchStatement /
-  # logical-operator arms record (extract-ts-api.ts#extractSkeleton).
   SKELETON_IF_NODES = %i[if elsif unless if_mod unless_mod ifop case].freeze
   SKELETON_LOOP_NODES = %i[while until while_mod until_mod for].freeze
-  # `:bodystmt` rather than `:rescue`/`:ensure`: Ripper hangs the rescue clause
-  # off a LATER slot of the body statement, so tokening the clause itself would
-  # put `try` after the protected calls, where the TS side's TryStatement puts
-  # it before them.
   SKELETON_LOGICAL_OPS = [:"||", :"&&", :and, :or].freeze
 
   # The body's ordered control + call skeleton — `if` / `loop` / `try` /
@@ -2064,9 +2057,12 @@ class ApiExtractor
   # vocabulary is deliberately identical; `calls` cannot stand in for it,
   # because `calls.uniq` drops both the repeats and the control flow.
   #
-  # `raise` tokens as `throw` rather than `ref:raise` so it lines up with the
-  # port's `throw new X(...)`, which is a ThrowStatement on the TS side and
-  # never a call.
+  # Two places where Ripper's shape has to be converged rather than
+  # transcribed. `try` tokens on the `:bodystmt`, not on the `:rescue`/`:ensure`
+  # clause Ripper hangs off its later slots, or it would land AFTER the
+  # protected calls where the TS TryStatement puts it before them. And `raise`
+  # tokens as `throw` rather than `ref:raise`, to line up with the port's
+  # `throw new X(...)` — a ThrowStatement on the TS side, never a call.
   def collect_method_skeleton(body_node)
     tokens = []
     walk_for_skeleton(body_node, tokens)
@@ -2103,8 +2099,8 @@ class ApiExtractor
     node.each { |child| walk_for_skeleton(child, tokens) if child.is_a?(Array) }
   end
 
-  # `[:op, :"||="]` — Ripper wraps the operator in an `:op` node on newer
-  # parsers and hands it bare on older ones.
+  # Ripper wraps an op-assign operator in an `:op` node on newer parsers and
+  # hands it bare on older ones.
   def op_assign_op(op)
     op.is_a?(Array) ? op[1] : op
   end

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -662,6 +662,8 @@ class ApiExtractor
     method_info[:depRefs] = dep_info[:depRefs] unless dep_info[:depRefs].empty?
     method_info[:calls] = calls unless calls.empty?
     method_info[:weakCalls] = weak_calls unless weak_calls.empty?
+    skeleton = collect_method_skeleton(body)
+    method_info[:skeleton] = skeleton unless skeleton.empty?
     opt_keys = collect_option_keys(body, params, fqn)
     method_info[:option_keys] = opt_keys unless opt_keys.empty?
     digest = body_digest(body)
@@ -716,6 +718,8 @@ class ApiExtractor
     method_info[:depRefs] = dep_info[:depRefs] unless dep_info[:depRefs].empty?
     method_info[:calls] = calls unless calls.empty?
     method_info[:weakCalls] = weak_calls unless weak_calls.empty?
+    skeleton = collect_method_skeleton(body)
+    method_info[:skeleton] = skeleton unless skeleton.empty?
     opt_keys = collect_option_keys(body, params, fqn)
     method_info[:option_keys] = opt_keys unless opt_keys.empty?
     digest = body_digest(body)
@@ -2041,6 +2045,89 @@ class ApiExtractor
     total = calls.tally
     weak_calls = weak.tally.select { |name, n| total[name] == n }.keys
     [calls.uniq, weak_calls]
+  end
+
+  # Ripper nodes that token as `if`: every one is a conditional reach, which is
+  # what the TS side's IfStatement / ConditionalExpression / SwitchStatement /
+  # logical-operator arms record (extract-ts-api.ts#extractSkeleton).
+  SKELETON_IF_NODES = %i[if elsif unless if_mod unless_mod ifop case].freeze
+  SKELETON_LOOP_NODES = %i[while until while_mod until_mod for].freeze
+  # `:bodystmt` rather than `:rescue`/`:ensure`: Ripper hangs the rescue clause
+  # off a LATER slot of the body statement, so tokening the clause itself would
+  # put `try` after the protected calls, where the TS side's TryStatement puts
+  # it before them.
+  SKELETON_LOGICAL_OPS = [:"||", :"&&", :and, :or].freeze
+
+  # The body's ordered control + call skeleton — `if` / `loop` / `try` /
+  # `throw`, `new:Const` and `ref:<name>` reaches, in source order and WITH
+  # duplicates. The TS counterpart is extract-ts-api.ts#extractSkeleton and the
+  # vocabulary is deliberately identical; `calls` cannot stand in for it,
+  # because `calls.uniq` drops both the repeats and the control flow.
+  #
+  # `raise` tokens as `throw` rather than `ref:raise` so it lines up with the
+  # port's `throw new X(...)`, which is a ThrowStatement on the TS side and
+  # never a call.
+  def collect_method_skeleton(body_node)
+    tokens = []
+    walk_for_skeleton(body_node, tokens)
+    tokens
+  end
+
+  def walk_for_skeleton(node, tokens)
+    return unless node.is_a?(Array)
+
+    kind = node[0]
+    if SKELETON_IF_NODES.include?(kind)
+      tokens << "if"
+    elsif SKELETON_LOOP_NODES.include?(kind)
+      tokens << "loop"
+    elsif kind == :bodystmt && (node[2] || node[4])
+      tokens << "try"
+    elsif kind == :binary && SKELETON_LOGICAL_OPS.include?(node[2])
+      walk_for_skeleton(node[1], tokens)
+      tokens << "if"
+      walk_for_skeleton(node[3], tokens)
+      return
+    elsif kind == :opassign && SKELETON_LOGICAL_OPS.include?(op_assign_op(node[2]))
+      tokens << "if"
+    elsif kind == :aref
+      tokens << "ref:get"
+    elsif %i[fcall vcall command].include?(kind)
+      skeleton_push_name(tokens, ident_name(node[1]), nil)
+    elsif %i[call command_call].include?(kind)
+      skeleton_push_name(tokens, node[3] ? ident_name(node[3]) : nil, node[1])
+    elsif %i[super zsuper].include?(kind)
+      tokens << "ref:super"
+    end
+
+    node.each { |child| walk_for_skeleton(child, tokens) if child.is_a?(Array) }
+  end
+
+  # `[:op, :"||="]` — Ripper wraps the operator in an `:op` node on newer
+  # parsers and hands it bare on older ones.
+  def op_assign_op(op)
+    op.is_a?(Array) ? op[1] : op
+  end
+
+  def skeleton_push_name(tokens, name, recv)
+    return unless name
+
+    if name == "raise"
+      tokens << "throw"
+    elsif name == "new"
+      const = skeleton_const_name(recv)
+      tokens << (const ? "new:#{const}" : "ref:new")
+    else
+      tokens << "ref:#{name}"
+    end
+  end
+
+  def skeleton_const_name(recv)
+    return nil unless recv.is_a?(Array)
+    return recv[1][1] if recv[0] == :var_ref && recv[1].is_a?(Array) && recv[1][0] == :@const
+    return skeleton_const_name(recv[2]) if recv[0] == :const_path_ref
+
+    recv[0] == :@const ? recv[1] : nil
   end
 
   # Record a `VALID_OPTIONS`-named symbol array so a later

--- a/scripts/api-compare/extract-ruby-api.test.ts
+++ b/scripts/api-compare/extract-ruby-api.test.ts
@@ -59,8 +59,6 @@ describe("Ruby extractor body call capture", () => {
   }
 
   it("emits an ordered control + call skeleton, with duplicates, alongside calls", () => {
-    // The hand-checked counterpart of extract-ts-api.test.ts's TS fixture: the
-    // same constructs must produce the same token vocabulary on both sides.
     const s = rubySkeletons({
       "foo.rb": `
         class Foo

--- a/scripts/api-compare/extract-ruby-api.test.ts
+++ b/scripts/api-compare/extract-ruby-api.test.ts
@@ -14,8 +14,12 @@ const HERE = __dirname;
 describe("Ruby extractor body call capture", () => {
   const RUBY_SCRIPT = path.join(HERE, "extract-ruby-api.rb");
 
-  // Returns a map of "<fqn>#<method>" -> calls array for the given fixtures.
-  function rubyCalls(fixtures: Record<string, string>): Record<string, string[] | undefined> {
+  // Returns a map of "<fqn>#<method>" -> the named method_info array for the
+  // given fixtures.
+  function rubyField(
+    fixtures: Record<string, string>,
+    field: string,
+  ): Record<string, string[] | undefined> {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "calls-rb-"));
     try {
       for (const [rel, src] of Object.entries(fixtures)) {
@@ -34,7 +38,7 @@ describe("Ruby extractor body call capture", () => {
         out = {}
         ex.classes.each do |fqn, info|
           (info[:instanceMethods] + info[:classMethods]).each do |m|
-            out["#{fqn}##{m[:name]}"] = m[:calls]
+            out["#{fqn}##{m[:name]}"] = m[${JSON.stringify(field)}.to_sym]
           end
         end
         puts JSON.generate(out)
@@ -45,6 +49,50 @@ describe("Ruby extractor body call capture", () => {
       fs.rmSync(dir, { recursive: true, force: true });
     }
   }
+
+  function rubyCalls(fixtures: Record<string, string>): Record<string, string[] | undefined> {
+    return rubyField(fixtures, "calls");
+  }
+
+  function rubySkeletons(fixtures: Record<string, string>): Record<string, string[] | undefined> {
+    return rubyField(fixtures, "skeleton");
+  }
+
+  it("emits an ordered control + call skeleton, with duplicates, alongside calls", () => {
+    // The hand-checked counterpart of extract-ts-api.test.ts's TS fixture: the
+    // same constructs must produce the same token vocabulary on both sides.
+    const s = rubySkeletons({
+      "foo.rb": `
+        class Foo
+          def create(xs)
+            raise Boom if dirty
+            xs.each { |x| save(x) }
+            begin
+              save(xs[0])
+            rescue StandardError
+              rollback
+            end
+          end
+
+          def build
+            cached || Thing.new
+          end
+        end
+      `,
+    });
+    expect(s["Foo#create"]).toEqual([
+      "if",
+      "ref:dirty",
+      "throw",
+      "ref:each",
+      "ref:save",
+      "try",
+      "ref:save",
+      "ref:get",
+      "ref:rollback",
+    ]);
+    expect(s["Foo#build"]).toEqual(["ref:cached", "if", "new:Thing"]);
+  });
 
   it('records super(args) and bare super as a "super" call', () => {
     const c = rubyCalls({

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -226,6 +226,50 @@ describe("body call capture", () => {
     expect(swapped.callSeq).toEqual(["save", "build"]);
   });
 
+  it("emits an ordered control + call skeleton, with duplicates, alongside calls", () => {
+    const cls = extractFromSource(
+      `class Foo {
+        create(xs: string[]) {
+          if (this.dirty) throw new Boom();
+          for (const x of xs) this.save(x);
+          try {
+            this.save(xs[0]);
+          } catch {
+            this.rollback();
+          }
+        }
+      }`,
+    );
+    const create = cls.instanceMethods.find((m) => m.name === "create")!;
+    // `calls` and `callSeq` are both deduplicated and carry no control flow —
+    // `save` appears once in each and neither shows the guard or the loop.
+    expect(create.callSeq).toEqual(["dirty", "constructor", "save", "rollback"]);
+    expect(create.skeleton).toEqual([
+      "if",
+      "ref:dirty",
+      "throw",
+      "new:Boom",
+      "loop",
+      "ref:save",
+      "try",
+      "ref:save",
+      "ref:get",
+      "ref:rollback",
+    ]);
+  });
+
+  it("tokens a logical operator as if, between its operands", () => {
+    const cls = extractFromSource(
+      `class Foo {
+        create() {
+          return this.cached() ?? this.build();
+        }
+      }`,
+    );
+    const create = cls.instanceMethods.find((m) => m.name === "create")!;
+    expect(create.skeleton).toEqual(["ref:cached", "if", "ref:build"]);
+  });
+
   it("marks a call made in a negated position with the ! prefix", () => {
     // The faithful port of ActiveSupport's `exclude?` (`!include?`); the
     // call ratchet requires the marker before crediting a negating alias.

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -241,8 +241,6 @@ describe("body call capture", () => {
       }`,
     );
     const create = cls.instanceMethods.find((m) => m.name === "create")!;
-    // `calls` and `callSeq` are both deduplicated and carry no control flow —
-    // `save` appears once in each and neither shows the guard or the loop.
     expect(create.callSeq).toEqual(["dirty", "constructor", "save", "rollback"]);
     expect(create.skeleton).toEqual([
       "if",

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -2658,8 +2658,6 @@ function extractSkeleton(node: ts.Node | undefined): string[] | undefined {
         break;
       }
       case ts.SyntaxKind.PropertyAccessExpression: {
-        // A property READ is a Ruby reader send, the same rule collectCalls
-        // applies. An assignment target is the writer send `foo=`, not `foo`.
         const access = n as ts.PropertyAccessExpression;
         if (!calleeNodes.has(access) && !isAssignmentWriteTarget(access)) {
           tokens.push(`ref:${access.name.text}`);

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -701,6 +701,7 @@ export function extractFromProgram(
         const fnOptionKeys = extractOptionKeys(node.parameters, checker);
         const fnCalls = extractCalls(node.body);
         const fnCallSeq = extractCallSeq(node.body);
+        const fnSkeleton = extractSkeleton(node.body);
         const internal = hasInternalJsDocTag(node);
         const noRailsEquivalent = noRailsEquivalentReason(node);
         const fnMissingRailsCalls = missingRailsCallTags(node);
@@ -716,6 +717,7 @@ export function extractFromProgram(
           ...(fnOptionKeys !== undefined ? { optionKeys: fnOptionKeys } : {}),
           ...(fnCalls !== undefined ? { calls: fnCalls } : {}),
           ...(fnCallSeq !== undefined ? { callSeq: fnCallSeq } : {}),
+          ...(fnSkeleton !== undefined ? { skeleton: fnSkeleton } : {}),
           ...(fnMissingRailsCalls !== undefined ? { missingRailsCalls: fnMissingRailsCalls } : {}),
         });
       } else if (ts.isVariableStatement(node) && isExported(node)) {
@@ -2033,6 +2035,7 @@ export function extractClass(
       const suppressed = namespaceSelfDelegationName(member.body, checker) === memberName;
       const calls = suppressed ? undefined : extractCalls(member.body);
       const callSeq = suppressed ? undefined : extractCallSeq(member.body);
+      const skeleton = suppressed ? undefined : extractSkeleton(member.body);
       const delegatesTo = delegationTargetName(member.body, memberName, name, checker);
       if (delegatesTo) delegationTargets.add(delegatesTo);
       const method: MethodInfo = {
@@ -2047,6 +2050,7 @@ export function extractClass(
         ...(optionKeys !== undefined ? { optionKeys } : {}),
         ...(calls !== undefined ? { calls } : {}),
         ...(callSeq !== undefined ? { callSeq } : {}),
+        ...(skeleton !== undefined ? { skeleton } : {}),
         ...(delegatesTo !== undefined ? { delegatesTo } : {}),
       };
       // Only instance methods are reachable via `this.helper(...)` and only
@@ -2067,6 +2071,7 @@ export function extractClass(
       // calls here so calls-parity can flag a ported constructor that drops it.
       const calls = extractCalls(member.body);
       const callSeq = extractCallSeq(member.body);
+      const skeleton = extractSkeleton(member.body);
       instanceMethods.push({
         name: "constructor",
         visibility,
@@ -2077,6 +2082,7 @@ export function extractClass(
         ...tagged,
         ...(calls !== undefined ? { calls } : {}),
         ...(callSeq !== undefined ? { callSeq } : {}),
+        ...(skeleton !== undefined ? { skeleton } : {}),
       });
     } else if (ts.isGetAccessorDeclaration(member) && memberName) {
       const method: MethodInfo = {
@@ -2557,6 +2563,117 @@ function isNegatedOperand(expr: ts.Node): boolean {
  */
 function extractCallSeq(node: ts.Node | undefined): string[] | undefined {
   return collectCalls(node);
+}
+
+/**
+ * Logical operators that token as `if`: each is a conditional reach, and Ruby's
+ * `a || b` and the port's `const x = a; if (!x) b` are the same one.
+ *
+ * A hoisted function rather than a module-level `Set`, because the worker-thread
+ * dispatch block at the top of this file runs before a `const` down here is
+ * initialized and would read it in TDZ.
+ */
+function isSkeletonLogicalOp(kind: ts.SyntaxKind): boolean {
+  switch (kind) {
+    case ts.SyntaxKind.BarBarToken:
+    case ts.SyntaxKind.AmpersandAmpersandToken:
+    case ts.SyntaxKind.QuestionQuestionToken:
+    case ts.SyntaxKind.BarBarEqualsToken:
+    case ts.SyntaxKind.AmpersandAmpersandEqualsToken:
+    case ts.SyntaxKind.QuestionQuestionEqualsToken:
+      return true;
+    default:
+      return false;
+  }
+}
+
+/**
+ * The body as an ordered CONTROL + call skeleton — the stream a call-SEQUENCE
+ * comparison reads (RFC 0084), modelled on
+ * scripts/prism-codegen/score.ts:skeletonTokens. Neither `calls` nor `callSeq`
+ * can stand in for it: both are deduplicated and neither records control flow,
+ * so a dropped guard, an inverted branch, or a collaborator called once where
+ * Rails calls it twice is invisible to them. Names are raw, as `calls` records
+ * them — the Ruby↔TS conventions live in compare.ts. Signal only; nothing gates
+ * on it yet.
+ */
+function extractSkeleton(node: ts.Node | undefined): string[] | undefined {
+  if (!node) return undefined;
+  const tokens: string[] = [];
+  const calleeNodes = new Set<ts.Node>();
+  const visit = (n: ts.Node): void => {
+    switch (n.kind) {
+      case ts.SyntaxKind.IfStatement:
+      case ts.SyntaxKind.ConditionalExpression:
+      case ts.SyntaxKind.SwitchStatement:
+        tokens.push("if");
+        break;
+      case ts.SyntaxKind.BinaryExpression: {
+        const bin = n as ts.BinaryExpression;
+        if (isSkeletonLogicalOp(bin.operatorToken.kind)) {
+          visit(bin.left);
+          tokens.push("if");
+          visit(bin.right);
+          return;
+        }
+        break;
+      }
+      case ts.SyntaxKind.WhileStatement:
+      case ts.SyntaxKind.DoStatement:
+      case ts.SyntaxKind.ForStatement:
+      case ts.SyntaxKind.ForOfStatement:
+      case ts.SyntaxKind.ForInStatement:
+        tokens.push("loop");
+        break;
+      case ts.SyntaxKind.TryStatement:
+        tokens.push("try");
+        break;
+      case ts.SyntaxKind.ThrowStatement:
+        tokens.push("throw");
+        break;
+      case ts.SyntaxKind.NewExpression: {
+        const ctor = (n as ts.NewExpression).expression;
+        tokens.push(
+          `new:${
+            ts.isIdentifier(ctor)
+              ? ctor.text
+              : ts.isPropertyAccessExpression(ctor)
+                ? ctor.name.text
+                : "?"
+          }`,
+        );
+        break;
+      }
+      case ts.SyntaxKind.CallExpression: {
+        const callee = (n as ts.CallExpression).expression;
+        if (ts.isIdentifier(callee)) {
+          tokens.push(`ref:${callee.text}`);
+          calleeNodes.add(callee);
+        } else if (ts.isPropertyAccessExpression(callee)) {
+          tokens.push(`ref:${callee.name.text}`);
+          calleeNodes.add(callee);
+        } else if (callee.kind === ts.SyntaxKind.SuperKeyword) {
+          tokens.push("ref:super");
+        }
+        break;
+      }
+      case ts.SyntaxKind.PropertyAccessExpression: {
+        // A property READ is a Ruby reader send, the same rule collectCalls
+        // applies. An assignment target is the writer send `foo=`, not `foo`.
+        const access = n as ts.PropertyAccessExpression;
+        if (!calleeNodes.has(access) && !isAssignmentWriteTarget(access)) {
+          tokens.push(`ref:${access.name.text}`);
+        }
+        break;
+      }
+      case ts.SyntaxKind.ElementAccessExpression:
+        tokens.push("ref:get");
+        break;
+    }
+    ts.forEachChild(n, visit);
+  };
+  ts.forEachChild(node, visit);
+  return tokens.length === 0 ? undefined : tokens;
 }
 
 function extractCalls(node: ts.Node | undefined): string[] | undefined {

--- a/scripts/api-compare/extractor-schema.ts
+++ b/scripts/api-compare/extractor-schema.ts
@@ -74,6 +74,7 @@ export const EXTRACTOR_OUTPUT_FIELDS = [
   "depRefs",
   "calls",
   "callSeq",
+  "skeleton",
   "internal",
   "option_keys",
   "optionKeys",

--- a/scripts/api-compare/types.ts
+++ b/scripts/api-compare/types.ts
@@ -50,6 +50,14 @@ export interface MethodInfo {
    */
   callSeq?: string[];
   /**
+   * Both extractors (RFC 0084): the body's ordered control + call skeleton —
+   * `if` / `loop` / `try` / `throw`, `new:Ctor`, `ref:<name>` — in source order,
+   * WITH duplicates. `calls` and `callSeq` are both deduplicated and record no
+   * control flow, so neither carries a dropped guard or an inverted branch.
+   * Names are raw on both sides. Signal only; nothing gates on it yet.
+   */
+  skeleton?: string[];
+  /**
    * Ruby-side only (RFC 0083): the subset of `calls` whose every occurrence in
    * the body had a provably inert receiver — a local variable or a literal
    * (`xs.first`, `opts.fetch`, `{}.merge`). Those say nothing about the port,


### PR DESCRIPTION
Bundle of two stories.

## `datetime-carries-no-fractional-seconds` (RFC 0088)

`::DateTime#strftime` handed the shared formatter a literal `nsec: 0`, so `%N`
and `%L` always answered zeros — the second half of the `::Time` fix in #6156,
whose acceptance criteria covered `::Time` only.

`DateTime` now keeps `ComplexDateData`'s `sf` in nanoseconds
(`date_core.c:215-231`). `jd_local_to_utc` / `df_local_to_utc` do not touch it,
so unlike the day and day-fraction it reads the same locally and in UTC.

- The constructor splits a fractional `second` the way `num2int_with_frac`
  (`date_core.c:3296-3304`) and `add_frac`'s `d_lite_plus` do. Note the C
  **rounds** to a whole nanosecond in the `T_FLOAT` arm
  (`date_core.c:6094-6097`), where `Time#nsec` truncates the double: MRI's
  `DateTime.new(2008, 3, 1, 6, 0, 0.3).strftime("%N")` is `"300000000"`, but
  `Time.utc(2008, 3, 1, 6, 0, 0.3).nsec` is `299999999`. The story's "reuse
  `Time`'s truncation rule" is wrong against a live `ruby -rdate -e`, so this
  ports what MRI actually does and says so at the call site.
- `#sec_fraction` reads it back (`d_lite_sec_fraction` over `m_sf_in_sec`,
  `date_core.c:1568-1572`). MRI answers a Rational; a JS number is the nearest
  analogue, as `Time#subsec` already documents.
- `dt_new_by_frags` picks up `Date._parse`'s `:sec_fraction`
  (`date_core.c:8291-8295`), keeping it exact, and `%N` truncates on the way
  out — `DateTime.parse("...00.9999999999").strftime("%N")` stays
  `"999999999"`.
- `#sec` still answers the whole second only. `::Date#strftime`'s `nsec: 0` is
  untouched: MRI's `Date.new(2008, 3, 1).strftime("%N")` is `"000000000"`.

Every asserted value was checked against `ruby -rdate -e` on ruby 3.3.11.

## `ordered-call-skeleton-stream-in-extractors` (RFC 0084)

Prerequisite for `call-sequence-parity-in-wide-ratchet`. `callSeq` (already
present) is a deduplicated NAME sequence and records no control flow at all, so
a port that drops a guard, inverts a branch, or calls a collaborator once where
Rails calls it twice is invisible to it.

Both extractors now emit `skeleton`: an ordered token stream of `if` / `loop` /
`try` / `throw`, `new:Ctor` and `ref:<name>` reaches, in source order **with
duplicates**, modelled on `scripts/prism-codegen/score.ts:skeletonTokens`.
Names are raw on both sides — the Ruby↔TS conventions live in `compare.ts` and
applying them in the extractors would fork the translation.

Two places where the two ASTs needed converging rather than transcribing:

- Ripper hangs the rescue clause off a later slot of `:bodystmt`, so tokening
  `:rescue` itself would put `try` *after* the protected calls where the TS
  `TryStatement` puts it before. The Ruby side tokens the `:bodystmt` instead.
- `raise` tokens as `throw`, not `ref:raise`, so it lines up with the port's
  `throw new X(...)` — a `ThrowStatement` on the TS side, never a call.

`compare.ts` carries both streams **uncollapsed** — no `effectiveTsCalls`
delegation union, no `includeGraphCalls` merge, no dedup, since those are set
operations by construction — into a new `output/call-skeletons.json` (5180
pairs across all 15 packages). A separate artifact, so `call-mismatches.json`
and its ratchet read exactly what they read before.

**Nothing gates on it.** Verified by running `api:compare --calls` over the
whole tree before and after: every key of `call-mismatches.json` except
`generatedAt` is identical, and `pnpm api:calls` reports the same
`OK (2377 baselined, 1971 unreviewed, 371 per-file mark(s) totalling 1971 tight)`.

Closes-story: datetime-carries-no-fractional-seconds
Closes-story: ordered-call-skeleton-stream-in-extractors
