### PR TITLE
feat(date,api-compare): DateTime.new guards a non-final fraction; %N/%L take a width prefix; block iteration folds onto loop

### DIFF
--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -730,6 +730,14 @@ describe("DateTime", () => {
     expect(datetime.strftime("%3N")).toBe("999");
     expect(datetime.strftime("%9N")).toBe("999999999");
     expect(datetime.strftime("%12N")).toBe("999999999900");
+    //   d.strftime("%15N") #=> "999999999900000"
+    //   d.strftime("%20N") #=> "99999999990000000000"
+    expect(datetime.strftime("%15N")).toBe("999999999900000");
+    expect(datetime.strftime("%20N")).toBe("99999999990000000000");
+    // ruby 3.3.11:
+    //   DateTime.new(2008, 3, 1, 6, 0, Rational(1, 2)).strftime("%20N")
+    //     #=> "50000000000000000000"
+    expect(new RubyDateTime(2008, 3, 1, 6, 0, 0.5).strftime("%20N")).toBe("50000000000000000000");
   });
 
   it("answers zeros at every width for a ::Date, which has no time of day", () => {

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -663,6 +663,84 @@ describe("DateTime", () => {
     expect(new RubyDateTime(2008, 3, 1, 6, 0, 0).secFraction).toBe(0);
     expect(new RubyDate(2008, 3, 1).strftime("%N")).toBe("000000000");
   });
+
+  it("raises Date::Error on a fraction in any but the last argument supplied", () => {
+    // ruby 3.3.11 — num2int_with_frac's `argc > n` (date_core.c:3296-3304):
+    //   DateTime.new(2008, 3, 1, 6, 0.5, 0) #=> Date::Error: invalid fraction
+    //   DateTime.new(2008, 3, 1, 6.5, 0)    #=> Date::Error: invalid fraction
+    //   DateTime.new(2008, 3, 1.5, 0)       #=> Date::Error: invalid fraction
+    expect(() => new RubyDateTime(2008, 3, 1, 6, 0.5, 0)).toThrow("invalid fraction");
+    expect(() => new RubyDateTime(2008, 3, 1, 6.5, 0)).toThrow("invalid fraction");
+    expect(() => new RubyDateTime(2008, 3, 1, 6.5, 0, 0)).toThrow("invalid fraction");
+    expect(() => new RubyDateTime(2008, 3, 1.5, 0)).toThrow("invalid fraction");
+    expect(() => new RubyDateTime(2008, 3, 1.5, 6)).toThrow("invalid fraction");
+    // The second's bound is `positive_inf`, so a later argument never makes its
+    // fraction illegal:
+    //   DateTime.new(2008, 3, 1, 6, 0, 0.5, 3600).sec_fraction #=> (1/2)
+    expect(new RubyDateTime(2008, 3, 1, 6, 0, 0.5, 3600).secFraction).toBe(0.5);
+  });
+
+  it("carries the fraction of a legal non-final argument through add_frac", () => {
+    // ruby 3.3.11:
+    //   DateTime.new(2008, 3, 1, 6, 0.5).to_s   #=> "2008-03-01T06:00:30+00:00"
+    //   DateTime.new(2008, 3, 1, 6, 0.5).sec_fraction #=> (0/1)
+    //   DateTime.new(2008, 3, 1, 6, 0.25).to_s  #=> "2008-03-01T06:00:15+00:00"
+    //   DateTime.new(2008, 3, 1, 6.5).to_s      #=> "2008-03-01T06:30:00+00:00"
+    //   DateTime.new(2008, 3, 1, 23.75).to_s    #=> "2008-03-01T23:45:00+00:00"
+    //   DateTime.new(2008, 3, 1.5).to_s         #=> "2008-03-01T12:00:00+00:00"
+    const halfMinute = new RubyDateTime(2008, 3, 1, 6, 0.5);
+    expect(halfMinute.strftime("%H:%M:%S")).toBe("06:00:30");
+    expect(halfMinute.secFraction).toBe(0);
+    expect(new RubyDateTime(2008, 3, 1, 6, 0.25).strftime("%H:%M:%S")).toBe("06:00:15");
+    expect(new RubyDateTime(2008, 3, 1, 6.5).strftime("%H:%M:%S")).toBe("06:30:00");
+    expect(new RubyDateTime(2008, 3, 1, 23.75).strftime("%H:%M:%S")).toBe("23:45:00");
+    expect(new RubyDateTime(2008, 3, 1.5).strftime("%F %H:%M:%S")).toBe("2008-03-01 12:00:00");
+  });
+
+  it("takes the leading digits of the fraction at the width %N and %L are given", () => {
+    // ruby 3.3.11 — date_strftime.c:275-315 reads the width off the directive:
+    //   d = DateTime.new(2008, 3, 1, 6, 0, Rational(1, 2))
+    //   d.strftime("%1N")  #=> "5"
+    //   d.strftime("%3N")  #=> "500"
+    //   d.strftime("%6N")  #=> "500000"
+    //   d.strftime("%9N")  #=> "500000000"
+    //   d.strftime("%12N") #=> "500000000000"
+    //   d.strftime("%3L")  #=> "500"
+    //   d.strftime("%12L") #=> "500000000000"
+    const datetime = new RubyDateTime(2008, 3, 1, 6, 0, 0.5);
+    expect(datetime.strftime("%1N")).toBe("5");
+    expect(datetime.strftime("%3N")).toBe("500");
+    expect(datetime.strftime("%6N")).toBe("500000");
+    expect(datetime.strftime("%9N")).toBe("500000000");
+    expect(datetime.strftime("%12N")).toBe("500000000000");
+    expect(datetime.strftime("%3L")).toBe("500");
+    expect(datetime.strftime("%12L")).toBe("500000000000");
+    // Bare %N and %L keep their nine and three digits.
+    // ruby 3.3.11: d.strftime("%N %L") #=> "500000000 500"
+    expect(datetime.strftime("%N %L")).toBe("500000000 500");
+  });
+
+  it("truncates rather than rounds, so a sub-nanosecond tail survives a wide %N", () => {
+    // ruby 3.3.11:
+    //   d = DateTime.parse("2008-03-01T06:00:00.9999999999")
+    //   d.strftime("%3N")  #=> "999"
+    //   d.strftime("%9N")  #=> "999999999"
+    //   d.strftime("%12N") #=> "999999999900"
+    const datetime = RubyDateTime.parse("2008-03-01T06:00:00.9999999999");
+    expect(datetime.strftime("%3N")).toBe("999");
+    expect(datetime.strftime("%9N")).toBe("999999999");
+    expect(datetime.strftime("%12N")).toBe("999999999900");
+  });
+
+  it("answers zeros at every width for a ::Date, which has no time of day", () => {
+    // ruby 3.3.11:
+    //   Date.new(2008, 3, 1).strftime("%3N")  #=> "000"
+    //   Date.new(2008, 3, 1).strftime("%12N") #=> "000000000000"
+    //   Date.new(2008, 3, 1).strftime("%12L") #=> "000000000000"
+    expect(new RubyDate(2008, 3, 1).strftime("%3N")).toBe("000");
+    expect(new RubyDate(2008, 3, 1).strftime("%12N")).toBe("000000000000");
+    expect(new RubyDate(2008, 3, 1).strftime("%12L")).toBe("000000000000");
+  });
 });
 
 describe("Time", () => {

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -135,6 +135,29 @@ function formatOffset(utcOffset: number, colons: number): string {
 }
 
 /**
+ * @internal `date_strftime.c`'s shared `%L`/`%N` arm
+ * (`date_strftime.c:275-315`): the directive's own width prefix, defaulting to
+ * `3` for `%L` and `9` for `%N`, scales `tmx_sec_fraction` by `10**precision`
+ * and integer-divides — so the answer is the LEADING `precision` digits of the
+ * fraction, truncated rather than rounded, zero-padded on the left when the
+ * fraction is small and on the right when the width outruns it.
+ *
+ * The subject carries the fraction as nanoseconds where MRI carries a Rational,
+ * so the first nine digits come off the whole nanoseconds as digits — the
+ * scale-and-floor the C does would drop `299999999` to `299999998` through a
+ * double — and only a width past nine reaches for the sub-nanosecond tail
+ * `DateTime.parse("...00.9999999999")` keeps.
+ */
+function subsecDigits(nsec: number, precision: number): string {
+  if (precision <= 9) {
+    return String(Math.floor(nsec)).padStart(9, "0").slice(0, precision);
+  }
+  const extra = precision - 9;
+  if (extra > 15) return subsecDigits(nsec, 24).padEnd(precision, "0");
+  return String(Math.floor(nsec * 10 ** extra)).padStart(precision, "0");
+}
+
+/**
  * @internal Ruby routes `Date#strftime` and `Time#strftime` through the same C
  * formatter, so trails has one implementation rather than a copy per class.
  *
@@ -155,7 +178,7 @@ function formatOffset(utcOffset: number, colons: number): string {
  */
 export function strftime(subject: StrftimeSubject, format: string): string {
   const hour12 = subject.hour % 12 === 0 ? 12 : subject.hour % 12;
-  const tokens: Record<string, () => string> = {
+  const tokens: Record<string, (precision: number) => string> = {
     Y: () => padYear(subject.year),
     C: () => pad2(Math.floor(subject.year / 100)),
     y: () => pad2(subject.year % 100),
@@ -177,8 +200,8 @@ export function strftime(subject: StrftimeSubject, format: string): string {
     l: () => String(hour12).padStart(2, " "),
     M: () => pad2(subject.min),
     S: () => pad2(subject.sec),
-    L: () => String(Math.floor(subject.nsec / 1_000_000)).padStart(3, "0"),
-    N: () => String(subject.nsec).padStart(9, "0"),
+    L: (precision) => subsecDigits(subject.nsec, precision <= 0 ? 3 : precision),
+    N: (precision) => subsecDigits(subject.nsec, precision <= 0 ? 9 : precision),
     s: () => String(epochSeconds(subject)),
     p: () => (subject.hour < 12 ? "AM" : "PM"),
     P: () => (subject.hour < 12 ? "am" : "pm"),
@@ -193,10 +216,14 @@ export function strftime(subject: StrftimeSubject, format: string): string {
     "%": () => "%",
   };
 
-  return format.replace(/%(-?)(:{0,3}[A-Za-z%])/g, (match, flag, spec) => {
+  // `date_strftime.c` reads a width prefix ahead of EVERY directive
+  // (`date_strftime.c:160-230`); only the `%L`/`%N` arm is honoured here, so a
+  // width on any other directive keeps falling through verbatim as before.
+  return format.replace(/%(-?)(\d*)(:{0,3}[A-Za-z%])/g, (match, flag, width, spec) => {
     const fn = tokens[spec];
     if (!fn) return match;
-    let result = fn();
+    if (width !== "" && spec !== "L" && spec !== "N") return match;
+    let result = fn(width === "" ? -1 : Number(width));
     if (flag === "-") result = result.replace(/^[0 ]+/, "") || "0";
     return result;
   });
@@ -1952,6 +1979,37 @@ function cValidTimeP(
 }
 
 /**
+ * @internal `date_core.c`'s `num2int_with_frac` macro (`date_core.c:3296-3304`)
+ * over the `d_trunc` / `h_trunc` / `min_trunc` / `s_trunc` family
+ * (`date_core.c:3216-3283`): the whole part is `f_idiv(v, 1)` — floor, not
+ * truncate — and the fraction `f_mod(v, 1)`, which each `*_trunc` then divides
+ * by its own unit's share of a day. A fraction is legal only in the LAST
+ * argument supplied: the macro raises `"invalid fraction"` when `argc > n`,
+ * which is `argcGtN` here — Ruby's `argc` has no TS analogue, so
+ * the constructor's optional parameters are what carries the "was a later
+ * argument passed" that the C reads off its `switch (argc)` fall-through.
+ *
+ * `fr` comes back in **seconds** rather than as `*_trunc`'s day fraction:
+ * `add_frac` hands the day fraction to `d_lite_plus`, whose `T_FLOAT` arm
+ * multiplies it straight back by `DAY_IN_SECONDS` (`date_core.c:6094-6097`), so
+ * the two cancel and `unitInSeconds` is that product — `1` for a second,
+ * `3600` for an hour.
+ */
+function num2intWithFrac(
+  v: number,
+  unitInSeconds: number,
+  argcGtN: boolean,
+): [whole: number, fr: number] {
+  const whole = Math.floor(v);
+  const fr = v - whole;
+  if (fr !== 0) {
+    if (argcGtN) throw new DateError("invalid fraction");
+    return [whole, fr * unitInSeconds];
+  }
+  return [whole, 0];
+}
+
+/**
  * @internal `date_core.c` `c_valid_ordinal_p` (`date_core.c:674-695`) over
  * `c_ordinal_to_jd` (`date_core.c:556-564`), the `d`th day of year `y`. A
  * negative `d` counts back from the last day of the year — `-1` is 31 December
@@ -2623,6 +2681,11 @@ export class DateTime extends Date {
    * `c_valid_civil_p` and the time of day with `c_valid_time_p`, then stores the
    * day and day-fraction in UTC — which is what the two conversions below do.
    *
+   * Every time argument is split by {@link num2intWithFrac}, which raises
+   * `"invalid fraction"` for a fraction in any but the last argument supplied —
+   * `DateTime.new(2008, 3, 1, 6, 0.5, 0)` — and carries a legal one through
+   * `add_frac`, so `DateTime.new(2008, 3, 1, 6, 0.5)` is `06:00:30`.
+   *
    * A fractional `second` is split off by `num2int_with_frac` over `s_trunc`
    * (`date_core.c:3269-3303`): `f_idiv(s, 1)` — floor, not truncate — is the
    * whole second, and `f_mod(s, 1)` the remainder, which `s_trunc` divides by
@@ -2656,33 +2719,68 @@ export class DateTime extends Date {
   constructor(rjd: Temporal.PlainDate, df: number, sf: number, of: number);
   constructor(
     year: number | Temporal.PlainDate,
-    month = 1,
-    day = 1,
-    hour = 0,
-    minute = 0,
-    second = 0,
-    offset = 0,
+    month?: number,
+    day?: number,
+    hour?: number,
+    minute?: number,
+    second?: number,
+    offset?: number,
   ) {
     if (year instanceof Temporal.PlainDate) {
-      super(jdUtcToLocal(year, month, hour));
+      const [df, sf, of] = [month ?? 0, day ?? 0, hour ?? 0];
+      super(jdUtcToLocal(year, df, of));
       this.#date = year;
-      this.#df = month;
-      this.#sf = day;
-      this.#of = hour;
+      this.#df = df;
+      this.#sf = sf;
+      this.#of = of;
       return;
     }
-    super(year, month, day);
-    const rjd = cValidCivilP(year, month, day);
+    // `datetime_initialize`'s `switch (argc)` fall-through
+    // (`date_core.c:7826-7849`): the second, then the minute, then the hour,
+    // then the day each give up their fraction, under the `n` bounds
+    // `positive_inf`, `5`, `4` and `3`. Only the LAST argument supplied may
+    // carry one, so at most one of these fractions is ever nonzero — the rest
+    // raised — and `fr2` takes it in the C's own order.
+    const [s, sFr] = num2intWithFrac(second ?? 0, 1, false);
+    const [min, minFr] = num2intWithFrac(minute ?? 0, MINUTE_IN_SECONDS, second !== undefined);
+    const [h, hFr] = num2intWithFrac(
+      hour ?? 0,
+      HOUR_IN_SECONDS,
+      minute !== undefined || second !== undefined,
+    );
+    const [d, dFr] = num2intWithFrac(
+      day ?? 1,
+      DAY_IN_SECONDS,
+      hour !== undefined || minute !== undefined || second !== undefined,
+    );
+    let fr2 = 0;
+    if (sFr !== 0) fr2 = sFr;
+    if (minFr !== 0) fr2 = minFr;
+    if (hFr !== 0) fr2 = hFr;
+    if (dFr !== 0) fr2 = dFr;
+    const of = offset ?? 0;
+    super(year, month ?? 1, d);
+    const rjd = cValidCivilP(year, month ?? 1, d);
     if (rjd === null) throw new DateError("invalid date");
-    const s = Math.floor(second);
-    const fr = second - s;
-    const rt = cValidTimeP(hour, minute, s);
+    const rt = cValidTimeP(h, min, s);
     if (rt === null) throw new DateError("invalid date");
-    const df = timeToDf(rt[0], rt[1], rt[2]);
-    this.#date = jdLocalToUtc(rjd, df, offset);
-    this.#df = dfLocalToUtc(df, offset);
-    this.#sf = Math.round(secToNs(fr));
-    this.#of = offset;
+    const localDf = timeToDf(rt[0], rt[1], rt[2]);
+    let date = jdLocalToUtc(rjd, localDf, of);
+    let df = dfLocalToUtc(localDf, of);
+    // `add_frac()` (`date_core.c:3313-3317`) over `d_lite_plus`'s `T_FLOAT` arm
+    // (`date_core.c:6064-6135`): the fraction's whole seconds go to `df`,
+    // carrying a day where they overflow one, and the rounded remainder to
+    // `sf`. `fr2` is under a day by construction, so the C's `jd` term is 0 and
+    // its sign branch is never taken — `f_mod` leaves every fraction positive.
+    df += Math.floor(fr2);
+    if (df >= DAY_IN_SECONDS) {
+      date = date.add({ days: 1 });
+      df -= DAY_IN_SECONDS;
+    }
+    this.#date = date;
+    this.#df = df;
+    this.#sf = Math.round(secToNs(fr2 - Math.floor(fr2)));
+    this.#of = of;
   }
 
   /**
@@ -2792,11 +2890,12 @@ export class DateTime extends Date {
   }
 
   /**
-   * `DateTime#strftime` hands the formatter the real `sf`, truncated to whole
-   * nanoseconds: `date_strftime.c`'s `%N` takes the LEADING digits of the
-   * fraction rather than rounding it, which is what keeps
+   * `DateTime#strftime` hands the formatter the real `sf`, sub-nanosecond tail
+   * and all: `date_strftime.c`'s `%N` takes the LEADING digits of the fraction
+   * rather than rounding it, which is what keeps
    * `DateTime.parse("...00.9999999999").strftime("%N")` at `"999999999"` when
-   * the stored `sf` sits a fraction of a nanosecond above it.
+   * the stored `sf` sits a fraction of a nanosecond above it — and what lets
+   * `%12N` answer `"999999999900"`, reaching past the nanosecond for the tail.
    */
   override strftime(format: string): string {
     return strftime(
@@ -2809,7 +2908,7 @@ export class DateTime extends Date {
         hour: this.hour,
         min: this.min,
         sec: this.sec,
-        nsec: Math.trunc(this.#sf),
+        nsec: this.#sf,
         zone: this.zone,
         utcOffset: this.#of,
       },

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -135,6 +135,13 @@ function formatOffset(utcOffset: number, colons: number): string {
 }
 
 /**
+ * @internal The largest power of ten a sub-second nanosecond count — under
+ * `1e9` — can be scaled by and still land inside `Number.MAX_SAFE_INTEGER`:
+ * `1e9 * 1e6` is `1e15`, and `1e7` would overflow it. See {@link subsecDigits}.
+ */
+const MAX_EXACT_SUBSEC_SCALE = 6;
+
+/**
  * @internal `date_strftime.c`'s shared `%L`/`%N` arm
  * (`date_strftime.c:275-315`): the directive's own width prefix, defaulting to
  * `3` for `%L` and `9` for `%N`, scales `tmx_sec_fraction` by `10**precision`
@@ -147,13 +154,23 @@ function formatOffset(utcOffset: number, colons: number): string {
  * scale-and-floor the C does would drop `299999999` to `299999998` through a
  * double — and only a width past nine reaches for the sub-nanosecond tail
  * `DateTime.parse("...00.9999999999")` keeps.
+ *
+ * That tail runs out at fifteen digits: `sf` is under `1e9` nanoseconds, so
+ * scaling it by more than {@link MAX_EXACT_SUBSEC_SCALE} leaves
+ * `Number.MAX_SAFE_INTEGER` behind and the digits stop being the ones the value
+ * holds. MRI pads a width past its own Rational's digits with zeros —
+ * `DateTime.parse("...00.9999999999").strftime("%20N")` is
+ * `"99999999990000000000"` — so zeros are also the right answer past the double's
+ * cliff, and the recursion puts it exactly where the arithmetic stays exact.
  */
 function subsecDigits(nsec: number, precision: number): string {
   if (precision <= 9) {
     return String(Math.floor(nsec)).padStart(9, "0").slice(0, precision);
   }
   const extra = precision - 9;
-  if (extra > 15) return subsecDigits(nsec, 24).padEnd(precision, "0");
+  if (extra > MAX_EXACT_SUBSEC_SCALE) {
+    return subsecDigits(nsec, 9 + MAX_EXACT_SUBSEC_SCALE).padEnd(precision, "0");
+  }
   return String(Math.floor(nsec * 10 ** extra)).padStart(precision, "0");
 }
 

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -158,10 +158,20 @@ const MAX_EXACT_SUBSEC_SCALE = 6;
  * That tail runs out at fifteen digits: `sf` is under `1e9` nanoseconds, so
  * scaling it by more than {@link MAX_EXACT_SUBSEC_SCALE} leaves
  * `Number.MAX_SAFE_INTEGER` behind and the digits stop being the ones the value
- * holds. MRI pads a width past its own Rational's digits with zeros —
+ * holds. Past that the port pads zeros, which is NOT the C's general behaviour:
+ * `mul`/`div` (`date_strftime.c:288-303`) are exact Rational arithmetic under no
+ * ceiling at all, so `DateTime.new(2008, 3, 1, 6, 0, Rational(1, 3))` keeps
+ * emitting `3`s at any width MRI is given.
+ *
+ * That divergence is unreachable here, and it is `sf`'s own JS-number analogue
+ * (see {@link nsToSec}) rather than this cliff that makes it so: nothing can put
+ * a non-terminating fraction in `sf`. The constructor takes `second` as a
+ * `number` — there is no Rational-accepting overload — and rounds it to a whole
+ * nanosecond through `d_lite_plus`, so the only producer of a sub-nanosecond
+ * `sf` at all is `dtNewByFrags` over a decimal literal in a parsed string, whose
+ * expansion terminates. For those values MRI pads zeros too:
  * `DateTime.parse("...00.9999999999").strftime("%20N")` is
- * `"99999999990000000000"` — so zeros are also the right answer past the double's
- * cliff, and the recursion puts it exactly where the arithmetic stays exact.
+ * `"99999999990000000000"` on ruby 3.3.11.
  */
 function subsecDigits(nsec: number, precision: number): string {
   if (precision <= 9) {

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -172,6 +172,9 @@ function subsecDigits(nsec: number, precision: number): string {
  *
  * Only the directives the i18n format strings and the conformance mixins use
  * are recognised; Ruby leaves an unknown directive in place, and so does this.
+ * `date_strftime.c` reads a width prefix ahead of every directive
+ * (`date_strftime.c:160-230`); only the `%L`/`%N` arm honours one here, so a
+ * width on any other directive keeps falling through verbatim.
  * `%z` and `%Z` both come off the subject: `::Date` has no zone of its own and
  * answers UTC, while a `::Time` built through the public constructor is in the
  * local zone and answers its real offset and abbreviation.
@@ -216,9 +219,6 @@ export function strftime(subject: StrftimeSubject, format: string): string {
     "%": () => "%",
   };
 
-  // `date_strftime.c` reads a width prefix ahead of EVERY directive
-  // (`date_strftime.c:160-230`); only the `%L`/`%N` arm is honoured here, so a
-  // width on any other directive keeps falling through verbatim as before.
   return format.replace(/%(-?)(\d*)(:{0,3}[A-Za-z%])/g, (match, flag, width, spec) => {
     const fn = tokens[spec];
     if (!fn) return match;
@@ -2681,10 +2681,21 @@ export class DateTime extends Date {
    * `c_valid_civil_p` and the time of day with `c_valid_time_p`, then stores the
    * day and day-fraction in UTC — which is what the two conversions below do.
    *
-   * Every time argument is split by {@link num2intWithFrac}, which raises
-   * `"invalid fraction"` for a fraction in any but the last argument supplied —
-   * `DateTime.new(2008, 3, 1, 6, 0.5, 0)` — and carries a legal one through
-   * `add_frac`, so `DateTime.new(2008, 3, 1, 6, 0.5)` is `06:00:30`.
+   * `datetime_initialize`'s `switch (argc)` fall-through
+   * (`date_core.c:7826-7849`) splits the second, then the minute, then the
+   * hour, then the day through {@link num2intWithFrac}, under the `n` bounds
+   * `positive_inf`, `5`, `4` and `3`. Only the LAST argument supplied may carry
+   * a fraction, so at most one of the four is ever nonzero — the rest raise
+   * `"invalid fraction"`, as `DateTime.new(2008, 3, 1, 6, 0.5, 0)` does — and
+   * `fr2` takes it in the C's own order.
+   *
+   * `add_frac()` (`date_core.c:3313-3317`) then hands `fr2` to `d_lite_plus`'s
+   * `T_FLOAT` arm (`date_core.c:6064-6135`), which is what makes
+   * `DateTime.new(2008, 3, 1, 6, 0.5)` `06:00:30`: the fraction's whole seconds
+   * go to `df`, carrying a day where they overflow one, and the rounded
+   * remainder to `sf`. `fr2` is under a day by construction, so the C's `jd`
+   * term is `0` and its sign branch is never taken — `f_mod` leaves every
+   * fraction positive.
    *
    * A fractional `second` is split off by `num2int_with_frac` over `s_trunc`
    * (`date_core.c:3269-3303`): `f_idiv(s, 1)` — floor, not truncate — is the
@@ -2735,12 +2746,6 @@ export class DateTime extends Date {
       this.#of = of;
       return;
     }
-    // `datetime_initialize`'s `switch (argc)` fall-through
-    // (`date_core.c:7826-7849`): the second, then the minute, then the hour,
-    // then the day each give up their fraction, under the `n` bounds
-    // `positive_inf`, `5`, `4` and `3`. Only the LAST argument supplied may
-    // carry one, so at most one of these fractions is ever nonzero — the rest
-    // raised — and `fr2` takes it in the C's own order.
     const [s, sFr] = num2intWithFrac(second ?? 0, 1, false);
     const [min, minFr] = num2intWithFrac(minute ?? 0, MINUTE_IN_SECONDS, second !== undefined);
     const [h, hFr] = num2intWithFrac(
@@ -2758,20 +2763,15 @@ export class DateTime extends Date {
     if (minFr !== 0) fr2 = minFr;
     if (hFr !== 0) fr2 = hFr;
     if (dFr !== 0) fr2 = dFr;
-    const of = offset ?? 0;
+    const rof = offset ?? 0;
     super(year, month ?? 1, d);
     const rjd = cValidCivilP(year, month ?? 1, d);
     if (rjd === null) throw new DateError("invalid date");
     const rt = cValidTimeP(h, min, s);
     if (rt === null) throw new DateError("invalid date");
     const localDf = timeToDf(rt[0], rt[1], rt[2]);
-    let date = jdLocalToUtc(rjd, localDf, of);
-    let df = dfLocalToUtc(localDf, of);
-    // `add_frac()` (`date_core.c:3313-3317`) over `d_lite_plus`'s `T_FLOAT` arm
-    // (`date_core.c:6064-6135`): the fraction's whole seconds go to `df`,
-    // carrying a day where they overflow one, and the rounded remainder to
-    // `sf`. `fr2` is under a day by construction, so the C's `jd` term is 0 and
-    // its sign branch is never taken — `f_mod` leaves every fraction positive.
+    let date = jdLocalToUtc(rjd, localDf, rof);
+    let df = dfLocalToUtc(localDf, rof);
     df += Math.floor(fr2);
     if (df >= DAY_IN_SECONDS) {
       date = date.add({ days: 1 });
@@ -2780,7 +2780,7 @@ export class DateTime extends Date {
     this.#date = date;
     this.#df = df;
     this.#sf = Math.round(secToNs(fr2 - Math.floor(fr2)));
-    this.#of = of;
+    this.#of = rof;
   }
 
   /**

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -196,6 +196,51 @@ export const NO_JS_CALL_FORM = new Set([
   "has_key?", // ditto
 ]);
 
+/**
+ * The JS iteration callee an Enumerable iterator's faithful port would name if
+ * it named one at all. It is the anchor {@link LOOP_SKELETON_NAMES} is derived
+ * through, and it is a JS construct name rather than a Ruby one, so the derived
+ * population still comes entirely from the two existing tables.
+ */
+const JS_ITERATION_CALLEE = "forEach";
+
+/**
+ * The skeleton-stream names that stand for the SAME construct as a native
+ * loop, on either side: Ruby's block iterators and the JS iteration callee.
+ *
+ * Derived, not hand-maintained (RFC 0084) — a Ruby name qualifies when it is
+ * both an Enumerable idiom whose JS analogue is the iteration callback
+ * ({@link JS_ENUMERABLE_ALIASES}) and one whose faithful port emits no call at
+ * all ({@link NO_JS_CALL_FORM}), which is exactly the pairing that makes
+ * `xs.each { ... }` a `ref:each` on the Ruby side and a bare `loop` on the TS
+ * side of the same ported body.
+ */
+const LOOP_SKELETON_NAMES = new Set(
+  [...JS_ENUMERABLE_ALIASES]
+    .filter(([ruby, aliases]) => NO_JS_CALL_FORM.has(ruby) && aliases.includes(JS_ITERATION_CALLEE))
+    .flatMap(([ruby, aliases]) => [ruby, ...aliases]),
+);
+
+/**
+ * Fold a skeleton stream's block-iteration tokens onto `loop`, so Ruby's
+ * `xs.each { |x| save(x) }` (`ref:each ref:save`) and its faithful `for (const
+ * x of xs) this.save(x)` port (`loop ref:save`) read as the same sequence.
+ *
+ * Applied where the two streams are COMPARED, never in the extractors: they
+ * emit raw names by design (extract-ts-api.ts:extractSkeleton), and the Ruby↔TS
+ * conventions live here. `prism-codegen/score.ts:skeletonTokens` folds its
+ * `LOGICAL_OPS` and `ref:get` at comparison time for the same reason. The one
+ * function runs over both sides, since {@link LOOP_SKELETON_NAMES} carries the
+ * Ruby name and the JS analogue alike.
+ */
+export function foldSkeletonTokens(skeleton: string[]): string[] {
+  return skeleton.map((token) =>
+    token.startsWith("ref:") && LOOP_SKELETON_NAMES.has(token.slice("ref:".length))
+      ? "loop"
+      : token,
+  );
+}
+
 // The significant set (RFC 0047): admits EVERY ported Ruby call name as
 // significant, except `super` (which the module-mixin port structurally drops —
 // see the comment at the top of this section) and the NO_JS_CALL_FORM names
@@ -622,7 +667,8 @@ interface CallResult {
 
 /**
  * The ordered control + call skeleton of one name-matched (Ruby, TS) pair, both
- * sides UNCOLLAPSED — no `effectiveTsCalls` delegation union, no
+ * sides run through {@link foldSkeletonTokens} and otherwise UNCOLLAPSED — no
+ * `effectiveTsCalls` delegation union, no
  * `includeGraphCalls` merge, no dedup. Those are set operations by
  * construction; a sequence needs its own merge rule, and until
  * call-sequence-parity decides what it is, carrying the body's own stream and
@@ -2220,8 +2266,8 @@ export function main() {
             rubyName,
             tsFile,
             tsName,
-            ruby: rubySkeleton,
-            ts: tsSkeletons[0],
+            ruby: foldSkeletonTokens(rubySkeleton),
+            ts: foldSkeletonTokens(tsSkeletons[0]),
           });
         }
         const seqSets = tsCallSeqByFileName.get(tsFile)?.get(tsName);
@@ -2806,7 +2852,7 @@ export function main() {
       JSON.stringify(
         {
           generatedAt: new Date().toISOString(),
-          note: "Advisory, ungated. Ordered control + call skeleton per name-matched pair, both sides uncollapsed: if/loop/try/throw, new:Ctor, ref:<name>, in source order with duplicates.",
+          note: "Advisory, ungated. Ordered control + call skeleton per name-matched pair, both sides uncollapsed: if/loop/try/throw, new:Ctor, ref:<name>, in source order with duplicates. Ruby block iteration folds onto loop.",
           packages: [...new Set(results.map((r) => r.package))].sort(),
           skeletons: skeletonsFlat,
         },

--- a/scripts/api-compare/fold-skeleton-tokens.test.ts
+++ b/scripts/api-compare/fold-skeleton-tokens.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { foldSkeletonTokens } from "./compare.js";
+
+describe("foldSkeletonTokens", () => {
+  it("folds a Ruby block iteration onto the loop its for-of port tokens", () => {
+    // Ruby `xs.each { |x| save(x) }` — walk_for_skeleton records the `each`
+    // call, then the block body inline.
+    const ruby = ["ref:each", "ref:save"];
+    // Its faithful port, `for (const x of xs) this.save(x)` — extractSkeleton
+    // records the ForOfStatement as `loop`.
+    const ts = ["loop", "ref:save"];
+
+    expect(foldSkeletonTokens(ruby)).toEqual(foldSkeletonTokens(ts));
+  });
+
+  it("folds the JS iteration callee too, so a forEach port reads the same", () => {
+    expect(foldSkeletonTokens(["ref:forEach", "ref:save"])).toEqual(["loop", "ref:save"]);
+  });
+
+  it("leaves the other no-JS-call-form names alone", () => {
+    // `key?` is in NO_JS_CALL_FORM but ports to the `in` operator, not a loop.
+    expect(foldSkeletonTokens(["ref:key?", "if", "ref:to_s"])).toEqual([
+      "ref:key?",
+      "if",
+      "ref:to_s",
+    ]);
+  });
+
+  it("leaves control tokens and constructors untouched", () => {
+    const skeleton = ["if", "new:Relation", "try", "throw", "ref:get"];
+    expect(foldSkeletonTokens(skeleton)).toEqual(skeleton);
+  });
+});

--- a/scripts/api-compare/fold-skeleton-tokens.test.ts
+++ b/scripts/api-compare/fold-skeleton-tokens.test.ts
@@ -3,12 +3,8 @@ import { describe, expect, it } from "vitest";
 import { foldSkeletonTokens } from "./compare.js";
 
 describe("foldSkeletonTokens", () => {
-  it("folds a Ruby block iteration onto the loop its for-of port tokens", () => {
-    // Ruby `xs.each { |x| save(x) }` — walk_for_skeleton records the `each`
-    // call, then the block body inline.
+  it("matches Ruby `xs.each { |x| save(x) }` against its `for (const x of xs) this.save(x)` port", () => {
     const ruby = ["ref:each", "ref:save"];
-    // Its faithful port, `for (const x of xs) this.save(x)` — extractSkeleton
-    // records the ForOfStatement as `loop`.
     const ts = ["loop", "ref:save"];
 
     expect(foldSkeletonTokens(ruby)).toEqual(foldSkeletonTokens(ts));
@@ -18,8 +14,7 @@ describe("foldSkeletonTokens", () => {
     expect(foldSkeletonTokens(["ref:forEach", "ref:save"])).toEqual(["loop", "ref:save"]);
   });
 
-  it("leaves the other no-JS-call-form names alone", () => {
-    // `key?` is in NO_JS_CALL_FORM but ports to the `in` operator, not a loop.
+  it("leaves the no-JS-call-form names that are not loops alone, such as `key?`", () => {
     expect(foldSkeletonTokens(["ref:key?", "if", "ref:to_s"])).toEqual([
       "ref:key?",
       "if",


### PR DESCRIPTION
Three related `ruby/date` + api-compare fidelity fixes, verified against a live `ruby -rdate -e` on 3.3.11.

### `DateTime.new` guards a non-final fraction

`num2int_with_frac` (`date_core.c:3296-3304`) splits the fraction off each time argument and raises `Date::Error` `"invalid fraction"` when `argc > n` — the fraction is legal only in the LAST argument supplied. The `n` bounds are `datetime_initialize`'s: `3` for day, `4` for hour, `5` for minute and `positive_inf` for second (`date_core.c:7826-7849`), which is why a fractional second is always legal. The port had neither the guard nor the carry.

```ruby
DateTime.new(2008, 3, 1, 6, 0.5, 0)  # => Date::Error: invalid fraction
DateTime.new(2008, 3, 1, 6, 0.5)     # => 06:00:30
DateTime.new(2008, 3, 1, 6.5)        # => 06:30:00
DateTime.new(2008, 3, 1.5)           # => 12:00:00
```

The constructor now runs each argument through `num2intWithFrac` and hands the surviving fraction to `add_frac`'s `d_lite_plus` arithmetic (`date_core.c:3313-3317`, `6064-6135`) — whole seconds to `df` with a day's carry, the rounded remainder to `sf` — rather than relying on `time_to_df`'s multiplication landing on the same number. Ruby's `argc` has no TS analogue, so the implementation signature drops its defaults and applies them after the check, keeping "was it passed" observable.

### `%N` / `%L` take a width prefix

`date_strftime.c:275-315` reads the width off the directive and takes the LEADING `w` digits of the fraction, truncating rather than rounding. The formatter hardcoded 9 and 3, so `%3N` and `%12N` fell through verbatim.

```ruby
DateTime.new(2008, 3, 1, 6, 0, 0.5).strftime("%12N")               # => "500000000000"
DateTime.parse("2008-03-01T06:00:00.9999999999").strftime("%12N")  # => "999999999900"
DateTime.parse("2008-03-01T06:00:00.9999999999").strftime("%9N")   # => "999999999"
```

`subsecDigits` takes the first nine digits off the whole nanoseconds as digits — the C's scale-and-floor through a double would drop `299999999` to `299999998` — and only reaches for the sub-nanosecond tail past width nine, which is why `DateTime#strftime` now hands the formatter the real `sf` rather than truncating it. A width on any other directive still falls through verbatim, unchanged. `::Date` answers zeros at every width.

### Ruby block iteration folds onto `loop` in the skeleton stream

Ruby's `xs.each { |x| save(x) }` is a call, so `walk_for_skeleton` emits `ref:each ref:save`; its faithful `for (const x of xs) this.save(x)` port emits `loop ref:save`. Same construct, different first token, on every ported enumerable body — a false divergence waiting for `call-sequence-parity-in-wide-ratchet`.

`foldSkeletonTokens` folds both onto `loop` where the two streams are compared, leaving the extractors raw by design (`prism-codegen/score.ts:skeletonTokens` is the precedent). Its population is derived — `JS_ENUMERABLE_ALIASES` entries whose alias is the JS iteration callee and which are also in `NO_JS_CALL_FORM` — not a new hand-maintained list; `key?` and the other no-call-form names are untouched. `calls`, the `api:calls` verdict and `call-mismatches.json` are unchanged (ratchet: OK, 2377 baselined, same as main).

Closes-story: datetime-new-accepts-a-non-final-fraction
Closes-story: strftime-n-and-l-take-no-width-prefix
Closes-story: fold-ruby-block-iteration-onto-loop-in-skeletons
