### PR TITLE
refactor(activerecord): PG SchemaStatements merges the real adapter type; rename_index matches Rails

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -975,11 +975,13 @@ export class SchemaStatements {
   }
 
   async renameIndex(tableName: string, oldName: string, newName: string): Promise<void> {
+    oldName = String(oldName);
+    newName = String(newName);
     this.validateIndexLengthBang(tableName, newName);
 
+    // this is a naive implementation; some DBs may support this more efficiently (PostgreSQL, for instance)
     const oldIndexDef = (await this.indexes(tableName)).find((i) => i.name === oldName);
     if (!oldIndexDef) return;
-    await this.schemaCache.clearDataSourceCacheBang(tableName);
     await this.addIndex(tableName, oldIndexDef.columns, {
       name: newName,
       unique: oldIndexDef.unique,

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -55,42 +55,26 @@ function toS(value: unknown): string {
  * PostgreSQL's `SchemaStatements` is only ever mixed into `PostgreSQLAdapter`
  * (`include()` at the bottom of the adapter module), so its bodies call plain
  * `this` methods the way Rails' module does. This merged interface gives those
- * calls the PG adapter's type.
+ * calls the PG adapter's own type — `Pick`ed from `PostgreSQLAdapter` rather
+ * than restated by hand, so a signature can no longer drift from the adapter it
+ * describes.
  *
- * The `Omit`ted names already reach `this` from `AbstractSchemaStatements` with
- * a signature TypeScript will not let a narrower PG one merge over — a member
- * declared on a base class wins over a merged-interface property. `getDatabaseVersion`
- * is off that list: a declaration-only `declare` field in the class body does
- * outrank the inherited method (see the class), which is what removed
- * `resetPkSequenceBang`'s cast. The same trick cannot reach `typeMap`, which the
- * generic adapter declares as an accessor (TS2610) — `columns` still casts it.
- * The two restated below are the reverse case: own members TypeScript does
- * accept, narrowed from the generic adapter's. @internal
- */
-/**
- * PostgreSQL's `SchemaStatements` is only ever mixed into `PostgreSQLAdapter`
- * (`include()` at the bottom of the adapter module), so its bodies call plain
- * `this` methods the way Rails' module does. This merged interface gives those
- * calls the PG adapter's own type — not a hand-copied restatement of it, which
- * was free to drift from the adapter it claimed to describe.
- *
- * The `Omit`ted names are the members `PostgreSQLAdapter` *narrows* relative to
- * the signature this class already inherits from `AbstractSchemaStatements` (or
- * from `AbstractAdapter`, which the abstract statements module also declares).
- * A narrowing override is legal on a class and is what Ruby's untyped override
- * translates to; declaration merging, however, demands *identical* types and
- * rejects the pair. Each name below is therefore inherited from the abstract
- * base rather than merged in — the same method at runtime, since PG's override
- * is the one on the prototype. `getDatabaseVersion` is off the list: a
- * declaration-only `declare` field in the class body does outrank the inherited
- * method (see the class), which is what removed `resetPkSequenceBang`'s cast.
+ * Only the members PG adds beyond `AbstractSchemaStatements` are listed: the
+ * rest already reach `this` through the base class, and merging a second
+ * declaration for them would collide with it — `PostgreSQLAdapter` narrows many
+ * (`adapterName` to `AdapterName`, `addColumnForAlter` to `ColumnType`), which is
+ * legal on a class and is what Ruby's untyped override translates to, but
+ * declaration merging demands identical types. `getDatabaseVersion` is the one
+ * exception: a declaration-only `declare` field in the class body does outrank
+ * the inherited method (see the class), which is what removed
+ * `resetPkSequenceBang`'s cast.
  *
  * The same trick cannot reach `typeMap`: `AbstractAdapter` declares it as an
  * accessor (`abstract-adapter.ts:2543`), and TypeScript refuses to narrow an
  * inherited accessor from either a merged-interface member or a `declare` field
  * (TS2610). A real accessor override here would shadow `PostgreSQLAdapter`'s own
  * `type_map` once `include()` installs the module on the prototype, so `columns`
- * keeps its cast — a permanent TypeScript limitation, not deferred work.
+ * keeps its cast.
  *
  * The two members restated in the body are the reverse case: own members
  * TypeScript does accept, narrowed from the generic adapter's. @internal
@@ -98,46 +82,29 @@ function toS(value: unknown): string {
 export interface SchemaStatements
   extends
     PgSchemaAdapterPrivates,
-    Omit<
+    Pick<
       PostgreSQLAdapter,
-      // Narrowed by PostgreSQLAdapter; inherited from the abstract base instead.
-      | "adapterName"
-      | "addColumnForAlter"
-      | "addIndex"
-      | "addIndexOptions"
-      | "buildCreateIndexDefinition"
-      | "buildStatementPool"
-      | "canPerformCaseInsensitiveComparisonFor"
-      | "caseInsensitiveComparison"
-      | "close"
-      | "configureConnection"
-      | "createAlterTable"
-      | "createSchemaDumper"
-      | "createTableDefinition"
-      | "databaseVersion"
-      | "disableExtension"
-      | "disableReferentialIntegrity"
-      | "dumpSchemaInformation"
-      | "enableExtension"
-      | "execute"
-      | "explain"
-      | "extensions"
-      | "fetchTypeMetadata"
-      | "internalExecute"
-      | "lookupCastType"
-      | "lookupCastTypeFromColumn"
-      | "quoteDefaultExpression"
-      | "quotedScope"
-      | "reconnect"
-      | "removeColumns"
-      | "removeIndex"
-      | "returningColumnValues"
-      | "schemaCreation"
-      | "translateException"
-      | "typeMap"
-      // Restated below, narrowed from the generic adapter's.
-      | "logger"
-      | "nativeDatabaseTypes"
+      | "clearCacheBang"
+      | "dataSourceSql"
+      | "exec"
+      | "extractDefaultFunction"
+      | "extractSchemaQualifiedName"
+      | "extractValueFromDefault"
+      | "internalExecQuery"
+      | "loadAdditionalTypes"
+      | "maxIdentifierLength"
+      | "newColumnFromField"
+      | "queryValue"
+      | "queryValues"
+      | "quote"
+      | "quoteColumnName"
+      | "quoteTableName"
+      | "reloadTypeMap"
+      | "schemaQuery"
+      | "supportsIdentityColumns"
+      | "supportsNativePartitioning"
+      | "supportsVirtualColumns"
+      | "visitor"
     > {
   readonly logger: { warn?(message: string): void } | null;
   nativeDatabaseTypes(): Record<string, string | { name?: string; limit?: number }>;

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -1,5 +1,5 @@
-import { type Type, ValueType, ArgumentError } from "@blazetrails/activemodel";
-import { Nodes, Visitors } from "@blazetrails/arel";
+import { ValueType, ArgumentError } from "@blazetrails/activemodel";
+import { Nodes } from "@blazetrails/arel";
 import { singularize, getCrypto } from "@blazetrails/activesupport";
 import { SchemaStatements as AbstractSchemaStatements } from "../abstract/schema-statements.js";
 import {
@@ -15,7 +15,7 @@ import {
   type ColumnType,
 } from "../abstract/schema-definitions.js";
 import { HashLookupTypeMap } from "../../type/hash-lookup-type-map.js";
-import type { Result } from "../../result.js";
+import type { PostgreSQLAdapter } from "../postgresql-adapter.js";
 import { Column } from "./column.js";
 import { quoteColumnName as pgQuoteColumnName } from "./quoting.js";
 import { unquoteIdentifier, splitQuotedIdentifier, Name, Utils } from "./utils.js";
@@ -32,59 +32,16 @@ import {
 } from "./schema-definitions.js";
 
 /**
- * PG-specific adapter surface used by the schema/database/session statements
- * below. These members are private on `PostgreSQLAdapter`; the class reaches
- * them through a cast since the methods exist at runtime.
+ * The three members of the PG adapter's runtime surface that the
+ * `PostgreSQLAdapter` *type* does not carry: `query` is mixed in by `include()`
+ * from `abstract/database-statements.ts` rather than declared on the class, and
+ * `quoteLiteral` / `_schemaSearchPathMemo` are `private` there. The bodies below
+ * reach all three the way Rails' module does — plain `this` calls — so they are
+ * restated here and merged into the class's `this` type.
  */
-interface PgSchemaAdapter {
-  schemaQuery(sql: string, binds?: unknown[]): Promise<Record<string, unknown>[]>;
-  internalExecQuery(
-    sql: string,
-    name?: string | null,
-    binds?: unknown[],
-    options?: { prepare?: boolean; allowRetry?: boolean; materializeTransactions?: boolean },
-  ): Promise<Result>;
+interface PgSchemaAdapterPrivates {
   query(sql: string, name?: string | null, binds?: unknown[]): Promise<unknown[][]>;
-  queryValue(sql: string, name?: string | null, binds?: unknown[]): Promise<unknown>;
-  queryValues(sql: string, name?: string | null, binds?: unknown[]): Promise<unknown[]>;
-  exec(sql: string): Promise<void>;
-  execute(sql: string): Promise<unknown>;
-  internalExecute(sql: string, name?: string): Promise<unknown>;
-  clearCacheBang(): void;
-  quote(value: unknown): string;
-  quoteColumnName(name: string): string;
-  quoteTableName(name: string): string;
-  readonly logger: { warn?(message: string): void } | null;
   quoteLiteral(value: unknown): string;
-  supportsNativePartitioning(): boolean;
-  supportsIdentityColumns(): boolean;
-  supportsVirtualColumns(): boolean;
-  extractSchemaQualifiedName(string: string): [string | null, string];
-  maxIdentifierLength(): number;
-  dataSourceSql(name?: string | null, options?: { type?: string }): string;
-  quotedScope(
-    name?: string | null,
-    options?: { type?: string },
-  ): { schema: string; name: string | null; type: string | null };
-  readonly schemaCreation: {
-    actionSql(action: string, dependency: string): string;
-    accept(o: unknown): string;
-  };
-  readonly visitor: Visitors.ToSql;
-  loadAdditionalTypes(oids?: number[]): Promise<void>;
-  lookupCastTypeFromColumn(column: {
-    oid?: number | null;
-    fmod?: number | null;
-    sqlType?: string | null;
-    name?: string;
-  }): Type;
-  reloadTypeMap(): Promise<void>;
-  newColumnFromField(tableName: string, field: unknown[], definitions: unknown): Promise<Column>;
-  extractValueFromDefault(defaultExpr: string | null): unknown;
-  extractDefaultFunction(defaultValue: unknown, defaultExpr: string | null): string | null;
-  nativeDatabaseTypes(): Record<string, string | { name?: string; limit?: number }>;
-  createTableDefinition(name: string, options?: Record<string, unknown>): AbstractTableDefinition;
-  createAlterTable(name: string): AlterTable;
   // Connection-scoped memo backing Rails' @schema_search_path.
   _schemaSearchPathMemo: string | null;
 }
@@ -110,17 +67,78 @@ function toS(value: unknown): string {
  * The two restated below are the reverse case: own members TypeScript does
  * accept, narrowed from the generic adapter's. @internal
  */
-export interface SchemaStatements extends Omit<
-  PgSchemaAdapter,
-  | "execute"
-  | "internalExecute"
-  | "lookupCastTypeFromColumn"
-  | "schemaCreation"
-  | "quotedScope"
-  | "typeMap"
-  | "logger"
-  | "nativeDatabaseTypes"
-> {
+/**
+ * PostgreSQL's `SchemaStatements` is only ever mixed into `PostgreSQLAdapter`
+ * (`include()` at the bottom of the adapter module), so its bodies call plain
+ * `this` methods the way Rails' module does. This merged interface gives those
+ * calls the PG adapter's own type — not a hand-copied restatement of it, which
+ * was free to drift from the adapter it claimed to describe.
+ *
+ * The `Omit`ted names are the members `PostgreSQLAdapter` *narrows* relative to
+ * the signature this class already inherits from `AbstractSchemaStatements` (or
+ * from `AbstractAdapter`, which the abstract statements module also declares).
+ * A narrowing override is legal on a class and is what Ruby's untyped override
+ * translates to; declaration merging, however, demands *identical* types and
+ * rejects the pair. Each name below is therefore inherited from the abstract
+ * base rather than merged in — the same method at runtime, since PG's override
+ * is the one on the prototype. `getDatabaseVersion` is off the list: a
+ * declaration-only `declare` field in the class body does outrank the inherited
+ * method (see the class), which is what removed `resetPkSequenceBang`'s cast.
+ *
+ * The same trick cannot reach `typeMap`: `AbstractAdapter` declares it as an
+ * accessor (`abstract-adapter.ts:2543`), and TypeScript refuses to narrow an
+ * inherited accessor from either a merged-interface member or a `declare` field
+ * (TS2610). A real accessor override here would shadow `PostgreSQLAdapter`'s own
+ * `type_map` once `include()` installs the module on the prototype, so `columns`
+ * keeps its cast — a permanent TypeScript limitation, not deferred work.
+ *
+ * The two members restated in the body are the reverse case: own members
+ * TypeScript does accept, narrowed from the generic adapter's. @internal
+ */
+export interface SchemaStatements
+  extends
+    PgSchemaAdapterPrivates,
+    Omit<
+      PostgreSQLAdapter,
+      // Narrowed by PostgreSQLAdapter; inherited from the abstract base instead.
+      | "adapterName"
+      | "addColumnForAlter"
+      | "addIndex"
+      | "addIndexOptions"
+      | "buildCreateIndexDefinition"
+      | "buildStatementPool"
+      | "canPerformCaseInsensitiveComparisonFor"
+      | "caseInsensitiveComparison"
+      | "close"
+      | "configureConnection"
+      | "createAlterTable"
+      | "createSchemaDumper"
+      | "createTableDefinition"
+      | "databaseVersion"
+      | "disableExtension"
+      | "disableReferentialIntegrity"
+      | "dumpSchemaInformation"
+      | "enableExtension"
+      | "execute"
+      | "explain"
+      | "extensions"
+      | "fetchTypeMetadata"
+      | "internalExecute"
+      | "lookupCastType"
+      | "lookupCastTypeFromColumn"
+      | "quoteDefaultExpression"
+      | "quotedScope"
+      | "reconnect"
+      | "removeColumns"
+      | "removeIndex"
+      | "returningColumnValues"
+      | "schemaCreation"
+      | "translateException"
+      | "typeMap"
+      // Restated below, narrowed from the generic adapter's.
+      | "logger"
+      | "nativeDatabaseTypes"
+    > {
   readonly logger: { warn?(message: string): void } | null;
   nativeDatabaseTypes(): Record<string, string | { name?: string; limit?: number }>;
 }
@@ -668,7 +686,9 @@ export class SchemaStatements extends AbstractSchemaStatements {
     // yet in the map and load them in a single pg_type query before building
     // Column objects. This avoids N concurrent queries for wide tables.
     // TS2610: an inherited accessor cannot be narrowed, and overriding it here
-    // would shadow PostgreSQLAdapter's own `type_map` under `include()`.
+    // would shadow PostgreSQLAdapter's own `type_map` under `include()`. That is
+    // a permanent TypeScript limitation, not deferred work — the merged
+    // interface below cannot reach `typeMap` either, for the same reason.
     const typeMap = this.typeMap as HashLookupTypeMap;
     const missingOids = [
       ...new Set(rows.map((r) => Number(r.oid)).filter((oid) => !typeMap.has(oid))),


### PR DESCRIPTION
Two of the three bundled stories. The third,
`delete-nested-attributes-deferred-displacement`, was released back — see
"Story released" below.

## `pg-schema-statements-abstract-signature-divergences`

`PgSchemaAdapter` is gone. It was a 50-member hand-written restatement of
`PostgreSQLAdapter`'s surface, and nothing kept it honest: a signature could
drift from the adapter it claimed to describe and typecheck stayed green. The
merged interface now takes those members from the real `PostgreSQLAdapter` type
via `Pick`, so they cannot drift. What survives as a hand-written shape is
`PgSchemaAdapterPrivates`, exactly the three members the story predicted:
`query` (mixed in by `include()` from `abstract/database-statements.ts`, so not
declared on the class), `quoteLiteral` and `_schemaSearchPathMemo` (`private`
there).

**Why `Pick` and not `Omit`.** The story proposed
`extends Omit<PostgreSQLAdapter, …>` with a short omit list. I enumerated that
list to exhaustion rather than iterating one TS2320 at a time: it is **34**
names, not nine. But they are not 34 fidelity bugs. Every one is a member
`PostgreSQLAdapter` *narrows* relative to the signature the class already
inherits from `AbstractSchemaStatements` / `AbstractAdapter` — `adapterName`
returning `AdapterName` where the base returns `string`
(`abstract-adapter.ts:1236`, the RFC 0010 decision), `addColumnForAlter` taking
`ColumnType`/`ColumnOptions` where PG took `string`/`Record<string, unknown>`,
`buildStatementPool` taking `pg.Client`. A narrowing override is legal on a class
and is exactly what Ruby's untyped override
(`postgresql/schema_statements.rb`, `postgresql_adapter.rb` vs
`abstract/schema_statements.rb`) translates to. Declaration *merging* demands
identical types and rejects the pair — a TypeScript rule about interfaces, not a
divergence from Rails.

`Omit` is also the wrong tool independent of that. `api:extra` expands inherited
interface members, so `extends Omit<PostgreSQLAdapter, …>` pulls PG's whole
~270-member surface into this file's extra-surface count: I measured it at
**+173** over `main` (1398 → 1572 moved). `Pick` lists only what PG adds beyond
the abstract base — 21 names, all already used by the bodies here — and lands
**6 below** `main` instead. Same drift-proofing, no invented surface.

**`columns`' `as HashLookupTypeMap` — PERMANENT.** `AbstractAdapter` declares
`typeMap` as an accessor (`abstract-adapter.ts:2543`), and TypeScript will not
narrow an inherited accessor from either a merged-interface member or a
`declare` field (TS2610). A real accessor override in this module would shadow
`PostgreSQLAdapter`'s own `type_map` once `include()` installs the module on the
prototype. Recorded at the call site with the accessor cited.

## `rename-index-clears-schema-cache-and-drops-to-s-arms`

`renameIndex` now matches `abstract/schema_statements.rb:980-990` line for line.

- The `clearDataSourceCacheBang(tableName)` call is gone. Rails' `rename_index`
  does not touch the schema cache — not here and not in the MySQL override at
  `abstract_mysql_adapter.rb:359-367`. `addIndex` clears it a few lines later
  (`schema-statements.ts:526`), so no caller loses the invalidation; the only
  behaviour that changes is the path where Rails leaves the cache warm.
- Both `to_s` arms are back (`:981-982`), before `validate_index_length!` as at
  `:983`, so the validated value is the coerced one — the Symbol-or-String arm
  Rails' migration spelling (`rename_index :people, :old, :new`) depends on.
- The naive-implementation comment from `:984` comes with it.

`renameColumnIndexes` / `renameTableIndexes` (`:2100`, `:2110`) drive
`renameIndex` in a loop; neither reads the cache between iterations, so neither
was written against the clearing behaviour. `schema-cache.test.ts`'s
`renameIndex clears schema cache entry before RENAME SQL` still passes — it was
observing `addIndex`'s clear all along.

## Story released

`delete-nested-attributes-deferred-displacement` was claimed with this bundle and
handed back (`pnpm tasks release`) rather than half-shipped. Two reasons, both
worth recording for whoever picks it up:

1. **Size.** ~400 LOC on its own; landing it here would put the PR well past the
   ceiling with three stories in one review.
2. **An unresolved design question the story does not answer.** Its own symbols
   are already gone from `main` (#6159 renamed the machinery); what remains is
   the property setter, the `awaitable=false` arm, `parkNestedReaderLoad`, and
   `NestedAttributesDisplacementError`. The blocker is that
   `_reapplyNestedAttrSetters` (`persistence.ts:1063`) is called from the `Base`
   **constructor** (`base.ts:3316`), which cannot await. Deleting the property
   setter leaves two options and the story picks neither: dispatch to
   `set#{Name}Attributes` and drop the promise, reopening the order-undefined
   two-row window RFC 0068 closed; or keep the synchronous arm internally, which
   keeps the parked-promise machinery the acceptance criteria delete.
   `assignAttributes({shipAttributes: …})` has the same problem via
   `_assignAttribute`'s `findPrototypeSetter`. That is an RFC 0087 §1 decision.

## Verification

- `pnpm typecheck`, `pnpm build`, `pnpm lint` green.
- `pnpm api:calls` — ratchet OK, no new rows, no baseline edits.
  (`api:calls:wide` no longer exists as a script — RFC 0084 folded the wide
  ratchet into `api:calls`, one artifact and one baseline.)
- `pnpm api:compare` — Data layer 7816/7816 (100%), Overall 13151/17799 (73.9%),
  unchanged.
- `pnpm api:extra --package activerecord` — 1971 total vs 1977 on `main`
  (−6); novel unchanged at 579. `PgSchemaAdapterPrivates` is module-private.
- `schema-cache.test.ts`, `abstract/schema-statements-privates.test.ts`,
  `migration/change-table.test.ts`, `migration/command-recorder.test.ts`,
  `abstract/schema-definitions.test.ts` green locally. PG/MySQL lanes are CI's.

Closes-story: pg-schema-statements-abstract-signature-divergences
Closes-story: rename-index-clears-schema-cache-and-drops-to-s-arms
