### PR TITLE
feat(date,api-compare,activerecord): DateTime#to_s keeps the time of day; callSeq covers object literals; PG cancel drains

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -333,6 +333,45 @@ describeIfPg("PostgreSQLAdapter", () => {
       }
     });
 
+    // Rails' cancel_any_running_query is `@raw_connection.cancel` followed by
+    // `@raw_connection.block` (postgresql/database_statements.rb:127-128): the
+    // ROLLBACK goes out only once the cancelled query has drained off the wire.
+    // trails used to send the CancelRequest and return immediately, leaving the
+    // cancelled query's promise to reject unobserved after the ROLLBACK.
+    it("rollback drains the cancelled query before sending ROLLBACK", async () => {
+      const other = new PostgreSQLAdapter(PG_TEST_URL);
+      // `_queryInFlightOwner` is non-null for exactly the span a query is on
+      // the wire, so reading it as ROLLBACK goes out says whether the cancelled
+      // query had drained first.
+      const seam = other as unknown as {
+        _queryInFlightOwner: symbol | null;
+        internalExecute(sql: string, ...rest: unknown[]): Promise<unknown>;
+      };
+      const internalExecute = seam.internalExecute.bind(seam);
+      let inFlightAtRollback: symbol | null | "unsent" = "unsent";
+      seam.internalExecute = (sql: string, ...rest: unknown[]) => {
+        if (sql === "ROLLBACK") inFlightAtRollback = seam._queryInFlightOwner;
+        return internalExecute(sql, ...rest);
+      };
+      try {
+        let slowError: unknown;
+        let slow!: Promise<unknown>;
+        await other.transactionManager.synchronize(async () => {
+          await other.beginDbTransaction();
+          slow = other.execute("SELECT pg_sleep(5) AS slept").catch((e) => {
+            slowError = e;
+          });
+          await new Promise<void>((r) => setTimeout(r, 100));
+          await other.rollbackDbTransaction();
+        });
+        await slow;
+        expect(slowError).toBeInstanceOf(QueryCanceled);
+        expect(inFlightAtRollback).toBeNull();
+      } finally {
+        await other.close();
+      }
+    });
+
     it("translate exception serialization failure", async () => {
       await adapter.exec(`CREATE TABLE "ex_ser" ("id" SERIAL PRIMARY KEY, "val" INTEGER)`);
       await adapter.executeMutation(`INSERT INTO "ex_ser" (val) VALUES (0)`);

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -333,16 +333,12 @@ describeIfPg("PostgreSQLAdapter", () => {
       }
     });
 
-    // Rails' cancel_any_running_query is `@raw_connection.cancel` followed by
     // `@raw_connection.block` (postgresql/database_statements.rb:127-128): the
     // ROLLBACK goes out only once the cancelled query has drained off the wire.
-    // trails used to send the CancelRequest and return immediately, leaving the
-    // cancelled query's promise to reject unobserved after the ROLLBACK.
+    // `_queryInFlightOwner` is non-null for exactly the span a query is on the
+    // wire, so reading it as ROLLBACK is sent is the drain assertion.
     it("rollback drains the cancelled query before sending ROLLBACK", async () => {
       const other = new PostgreSQLAdapter(PG_TEST_URL);
-      // `_queryInFlightOwner` is non-null for exactly the span a query is on
-      // the wire, so reading it as ROLLBACK goes out says whether the cancelled
-      // query had drained first.
       const seam = other as unknown as {
         _queryInFlightOwner: symbol | null;
         internalExecute(sql: string, ...rest: unknown[]): Promise<unknown>;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1601,12 +1601,12 @@ export class PostgreSQLAdapter
     // `transactionStatus` is opened here, where the query goes on the wire,
     // and closed by the terminating message.
     this._commandSettled = false;
-    const query = fn();
-    this._queryInFlightSettled = query.then(
-      () => {},
-      () => {},
-    );
     try {
+      const query = fn();
+      this._queryInFlightSettled = query.then(
+        () => {},
+        () => {},
+      );
       return await query;
     } finally {
       this._queryInFlightOwner = null;
@@ -3087,10 +3087,15 @@ export class PostgreSQLAdapter
     // Chain off the maintenance tail so ROLLBACK (and the DISCARD ALL below)
     // serialize behind any pending DEALLOCATE on the pinned client rather than
     // firing onto a client that's still executing one.
-    let work: Promise<unknown> = this._maintenanceTail;
+    // Read once, here: a query enqueued after the barrier below is published
+    // chains onto `_maintenanceTail` *behind* that barrier, so re-reading the
+    // field from inside the chain would make this reset wait on a query that is
+    // waiting on this reset.
+    const tail = this._maintenanceTail;
+    let work: Promise<unknown> = tail;
     if (this._client) {
       work = this._cancelAnyRunningQuery()
-        .then(() => this._maintenanceTail)
+        .then(() => tail)
         .then(() => live.query("ROLLBACK"))
         .catch(() => {});
       this._client = null;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1575,8 +1575,8 @@ export class PostgreSQLAdapter
    * DEALLOCATE / ROLLBACK / DISCARD ALL maintenance ops already chain via
    * `_enqueueMaintenance`, `execRollbackDbTransaction`'s `ROLLBACK` already
    * waits on the query `_cancelAnyRunningQuery` cancelled (that method's own
-   * `block` drain), and the memoized `server_version` bootstrap probe runs before the
-   * client is in normal service.
+   * `block` drain), and the memoized `server_version` bootstrap probe runs
+   * before the client is in normal service.
    *
    * @internal
    */
@@ -2368,8 +2368,6 @@ export class PostgreSQLAdapter
     if (txClient?.processID == null) return;
     const owner = this._transactionManager.currentLockToken;
     if (owner === null || owner !== this._queryInFlightOwner) return;
-    // `@raw_connection.block` (postgresql/database_statements.rb:128): the
-    // cancelled query is drained before the caller sends its ROLLBACK.
     const drained = this._queryInFlightSettled;
     try {
       // Open a FRESH TCP connection to send a CancelRequest — mirrors

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -473,6 +473,16 @@ export class PostgreSQLAdapter
    * `_cancelAnyRunningQuery`.
    */
   private _queryInFlightOwner: symbol | null = null;
+  /**
+   * Settlement of the query `_queryInFlightOwner` names, as a promise that only
+   * ever resolves — what `_cancelAnyRunningQuery` awaits for
+   * `@raw_connection.block` (postgresql/database_statements.rb:128). Attaching
+   * it also *observes* that query's rejection, so the `QueryCanceled` the
+   * cancel provokes cannot surface at run end unattributed when the chain that
+   * issued the query has been dropped (RFC 0061
+   * pg-query-canceled-unhandled-rejection).
+   */
+  private _queryInFlightSettled: Promise<void> | null = null;
   private _databaseVersion: number | null = null;
   private _typeMap: HashLookupTypeMap | null = null;
   private _maxIdentifierLength: number | null = null;
@@ -1563,9 +1573,9 @@ export class PostgreSQLAdapter
    * lack of coverage: `_maybeConfigureConnection` / the reset reconfigure run
    * *inside* the `_inFlightReset` barrier that IS the tail (self-await), the
    * DEALLOCATE / ROLLBACK / DISCARD ALL maintenance ops already chain via
-   * `_enqueueMaintenance`, `execRollbackDbTransaction`'s `ROLLBACK` follows a
-   * `_cancelAnyRunningQuery` that must not be made to wait on the query it just
-   * cancelled, and the memoized `server_version` bootstrap probe runs before the
+   * `_enqueueMaintenance`, `execRollbackDbTransaction`'s `ROLLBACK` already
+   * waits on the query `_cancelAnyRunningQuery` cancelled (that method's own
+   * `block` drain), and the memoized `server_version` bootstrap probe runs before the
    * client is in normal service.
    *
    * @internal
@@ -1591,10 +1601,16 @@ export class PostgreSQLAdapter
     // `transactionStatus` is opened here, where the query goes on the wire,
     // and closed by the terminating message.
     this._commandSettled = false;
+    const query = fn();
+    this._queryInFlightSettled = query.then(
+      () => {},
+      () => {},
+    );
     try {
-      return await fn();
+      return await query;
     } finally {
       this._queryInFlightOwner = null;
+      this._queryInFlightSettled = null;
       release();
     }
   }
@@ -2180,7 +2196,7 @@ export class PostgreSQLAdapter
 
   // Mirrors: DatabaseStatements#exec_rollback_db_transaction (database_statements.rb:78)
   async execRollbackDbTransaction(): Promise<void> {
-    this._cancelAnyRunningQuery();
+    await this._cancelAnyRunningQuery();
     if (!this._client) throw new Error("No active transaction");
     try {
       await this.internalExecute("ROLLBACK", "TRANSACTION");
@@ -2251,7 +2267,7 @@ export class PostgreSQLAdapter
 
   // Mirrors: DatabaseStatements#exec_restart_db_transaction (database_statements.rb:83)
   async execRestartDbTransaction(): Promise<void> {
-    this._cancelAnyRunningQuery();
+    await this._cancelAnyRunningQuery();
     await this.internalExecute("ROLLBACK AND CHAIN", "TRANSACTION");
   }
 
@@ -2312,8 +2328,10 @@ export class PostgreSQLAdapter
 
   // Mirrors: PostgreSQL::DatabaseStatements#cancel_any_running_query (database_statements.rb private)
   // Sends a CancelRequest to abort any in-flight query on the transaction connection
-  // before issuing ROLLBACK / ROLLBACK AND CHAIN, so the rollback isn't blocked
-  // waiting for a long-running query to finish. Best-effort: errors are swallowed.
+  // before issuing ROLLBACK / ROLLBACK AND CHAIN, then waits for the cancelled
+  // query to drain — the `@raw_connection.block` half
+  // (postgresql/database_statements.rb:127-128) — so the ROLLBACK is sent only
+  // once the query is off the wire. Best-effort: errors are swallowed.
   //
   // INVARIANT: only ever cancels a query *this* unit of work issued. Rails gets
   // that for free — `@connection.lock` is a thread mutex, so the only query that
@@ -2333,7 +2351,7 @@ export class PostgreSQLAdapter
   // checkin, or a direct `beginDbTransaction`/`rollbackDbTransaction` pair on a
   // bare adapter): ownership is unprovable, so those paths also wait on the
   // serializer rather than cancel.
-  private _cancelAnyRunningQuery(): void {
+  private async _cancelAnyRunningQuery(): Promise<void> {
     type PgClientWithPid = pg.Client & {
       processID?: number | null;
       secretKey?: number | null;
@@ -2350,6 +2368,9 @@ export class PostgreSQLAdapter
     if (txClient?.processID == null) return;
     const owner = this._transactionManager.currentLockToken;
     if (owner === null || owner !== this._queryInFlightOwner) return;
+    // `@raw_connection.block` (postgresql/database_statements.rb:128): the
+    // cancelled query is drained before the caller sends its ROLLBACK.
+    const drained = this._queryInFlightSettled;
     try {
       // Open a FRESH TCP connection to send a CancelRequest — mirrors
       // libpq PQcancel / Ruby PG::Connection#cancel: new socket, send
@@ -2366,8 +2387,10 @@ export class PostgreSQLAdapter
       } else {
         cancelCon.connect(port, host);
       }
+      if (drained !== null) await drained;
     } catch {
-      // cancel is best-effort
+      // cancel is best-effort — a drain failure must not mask the rollback,
+      // as Rails' `rescue PG::Error` on cancel_any_running_query does not.
     }
   }
 
@@ -3068,8 +3091,10 @@ export class PostgreSQLAdapter
     // firing onto a client that's still executing one.
     let work: Promise<unknown> = this._maintenanceTail;
     if (this._client) {
-      this._cancelAnyRunningQuery();
-      work = this._maintenanceTail.then(() => live.query("ROLLBACK")).catch(() => {});
+      work = this._cancelAnyRunningQuery()
+        .then(() => this._maintenanceTail)
+        .then(() => live.query("ROLLBACK"))
+        .catch(() => {});
       this._client = null;
       this._inTransaction = false;
     }

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -553,6 +553,16 @@ describe("DateTime", () => {
     );
   });
 
+  it("answers an ISO 8601 string with the time of day, as dt_lite_to_s does", () => {
+    // ruby 3.3.11:
+    //   DateTime.new(2008, 3, 1, 6, 0, 0).to_s                  #=> "2008-03-01T06:00:00+00:00"
+    //   DateTime.parse("2008-03-01T06:00:00+09:00").to_s        #=> "2008-03-01T06:00:00+09:00"
+    //   Date.new(2008, 3, 1).to_s                               #=> "2008-03-01"
+    expect(new RubyDateTime(2008, 3, 1, 6, 0, 0).toS()).toBe("2008-03-01T06:00:00+00:00");
+    expect(RubyDateTime.parse("2008-03-01T06:00:00+09:00").toS()).toBe("2008-03-01T06:00:00+09:00");
+    expect(new RubyDate(2008, 3, 1).toS()).toBe("2008-03-01");
+  });
+
   it("carries the offset the parsed string named", () => {
     // ruby 3.3.11:
     //   DateTime.parse("2008-03-01T06:00:00+09:00").zone #=> "+09:00"

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -2917,6 +2917,15 @@ export class DateTime extends Date {
   }
 
   /**
+   * Ruby `DateTime#to_s` (ruby/date, `date_core.c` `dt_lite_to_s`,
+   * `date_core.c:8701-8706`), a distinct C function from `d_lite_to_s` — which
+   * is why `::Date#to_s` keeps the date-only form.
+   */
+  override toS(): string {
+    return this.strftime("%Y-%m-%dT%H:%M:%S%:z");
+  }
+
+  /**
    * `DateTime#strftime` hands the formatter the real `sf`, sub-nanosecond tail
    * and all: `date_strftime.c`'s `%N` takes the LEADING digits of the fraction
    * rather than rounding it, which is what keeps

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-adapter.json
@@ -184,6 +184,13 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-adapter.ts",
+    "rubyName": "select_values",
+    "call": "order:selectRows,map",
+    "reason": "ORDER-only (RFC 0084): both bodies are select_rows(...).map — the Ruby extractor records a method chain outer-call first, so the sequences invert with no divergence in the port. Migrated verbatim from the abstract/database-statements.ts row this candidate replaced when callSeq reached object-literal members."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
     "rubyName": "type_cast",
     "call": "quoted_date",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/database-statements.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/database-statements.json
@@ -205,13 +205,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/database-statements.ts",
-    "rubyName": "select_values",
-    "call": "order:selectRows,map",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/database-statements.ts",
     "rubyName": "to_sql_and_binds",
     "call": "unprepared_statement",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -226,6 +226,35 @@ describe("body call capture", () => {
     expect(swapped.callSeq).toEqual(["save", "build"]);
   });
 
+  it("also records callSeq for an object-literal member and an arrow-function export", () => {
+    // The two populations RFC 0084's order-only check was silently skipping:
+    // `export const X = { method() {...} }` (arel's visitor tables, the
+    // module-function namespaces) and `export const f = (...) => {...}`.
+    const [member] = objectLiteralMethods(
+      `export const ClassMethods = {
+        create() {
+          this.save();
+          this.build();
+        },
+      };`,
+    );
+    expect(member.calls).toEqual(["build", "save"]);
+    expect(member.callSeq).toEqual(["save", "build"]);
+
+    const info = extractFromFiles("/p", {
+      "quoting.ts": `
+        export const quote = (value: unknown): string => {
+          typeCast(value);
+          quoteString(value);
+          return "";
+        };
+      `,
+    });
+    const quote = fileFunctionsOf(info, "quoting.ts").find((f) => f.name === "quote")!;
+    expect(quote.calls).toEqual(["quoteString", "typeCast"]);
+    expect(quote.callSeq).toEqual(["typeCast", "quoteString"]);
+  });
+
   it("emits an ordered control + call skeleton, with duplicates, alongside calls", () => {
     const cls = extractFromSource(
       `class Foo {

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -917,6 +917,7 @@ export function extractFromProgram(
                 ? decl.initializer.body
                 : undefined;
             const calls = extractCalls(body);
+            const callSeq = extractCallSeq(body);
             const internal = hasInternalJsDocTag(decl);
             // A renamed export (`export { withRoutesHelpers as with }`) is its
             // own surface entry: the declaration's tag justifies the DECLARED
@@ -949,6 +950,7 @@ export function extractFromProgram(
               ...(internal ? { internal: true } : {}),
               ...(noRailsEquivalent !== undefined ? { noRailsEquivalent } : {}),
               ...(calls !== undefined ? { calls } : {}),
+              ...(callSeq !== undefined ? { callSeq } : {}),
               ...(exportedMissingRailsCalls !== undefined
                 ? { missingRailsCalls: exportedMissingRailsCalls }
                 : {}),
@@ -1824,6 +1826,7 @@ export function harvestObjectLiteralMethods(
     let params: ParamInfo[] = [];
     let optionKeys: string[] | null | undefined;
     let calls: string[] | undefined;
+    let callSeq: string[] | undefined;
     let internal = hasInternalJsDocTag(prop);
     let noRailsEquivalent = noRailsEquivalentReason(prop);
     const propMissingRailsCalls = missingRailsCallTags(prop);
@@ -1832,6 +1835,7 @@ export function harvestObjectLiteralMethods(
       params = extractParameters(prop.parameters);
       optionKeys = extractOptionKeys(prop.parameters, checker);
       calls = extractCalls(prop.body);
+      callSeq = extractCallSeq(prop.body);
     } else if (ts.isShorthandPropertyAssignment(prop)) {
       mname = prop.name.text;
       params = paramsOfCallableRef(prop.name, checker) ?? [];
@@ -1841,10 +1845,12 @@ export function harvestObjectLiteralMethods(
     } else if (ts.isGetAccessorDeclaration(prop) && prop.name && ts.isIdentifier(prop.name)) {
       mname = prop.name.text;
       calls = extractCalls(prop.body);
+      callSeq = extractCallSeq(prop.body);
     } else if (ts.isSetAccessorDeclaration(prop) && prop.name && ts.isIdentifier(prop.name)) {
       mname = prop.name.text;
       params = extractParameters(prop.parameters);
       calls = extractCalls(prop.body);
+      callSeq = extractCallSeq(prop.body);
     } else if (ts.isPropertyAssignment(prop) && ts.isIdentifier(prop.name)) {
       const init = prop.initializer;
       if (ts.isFunctionExpression(init) || ts.isArrowFunction(init)) {
@@ -1852,6 +1858,7 @@ export function harvestObjectLiteralMethods(
         params = extractParameters(init.parameters);
         optionKeys = extractOptionKeys(init.parameters, checker);
         calls = extractCalls(init.body);
+        callSeq = extractCallSeq(init.body);
       } else {
         // `foo: bar` / `foo: NS.bar` — count if the RHS resolves to a
         // callable. Catches `readAttributeForValidation:
@@ -1880,6 +1887,7 @@ export function harvestObjectLiteralMethods(
       ...(noRailsEquivalent !== undefined ? { noRailsEquivalent } : {}),
       ...(optionKeys !== undefined ? { optionKeys } : {}),
       ...(calls !== undefined ? { calls } : {}),
+      ...(callSeq !== undefined ? { callSeq } : {}),
       ...(propMissingRailsCalls !== undefined ? { missingRailsCalls: propMissingRailsCalls } : {}),
     });
   }


### PR DESCRIPTION
Bundle of three stories.

### `::DateTime#to_s` keeps the time of day (RFC 0088)

`DateTime` inherited `Date#toS`'s `strftime("%Y-%m-%d")`, dropping the time and
the offset it now carries. MRI registers a separate `dt_lite_to_s` on
`cDateTime` (`vendor/date/ext/date/date_core.c:8701-8706`, `Init_date_core`)
whose format is `"%Y-%m-%dT%H:%M:%S%:z"` — so `DateTime` overrides `toS` with
that format and `Date#toS` is untouched. Every expectation verified against
`ruby 3.3.11 -rdate`.

### `callSeq` for object-literal and arrow-function exports (RFC 0084)

`MethodInfo.callSeq` was wired at three of the extractor's call sites; two
populations recorded `calls` with no `callSeq`, so the order-only comparison
silently did not run for them. Both now emit it: `harvestObjectLiteralMethods`
(method / accessor / function-valued property arms) and the exported
function-valued-const arm.

One order-only row moved as a result: the `abstract_adapter.rb::select_values`
match now resolves to the object-literal member in `abstract-adapter.ts`
instead of `abstract/database-statements.ts`. The row was migrated by hand via
`serializeBaseline` + `compareKeys` (net baseline count unchanged) with an
ordering-specific reason — both bodies are `select_rows(...).map`, and the
inversion is the Ruby extractor recording a method chain outer-call first.
`pnpm api:calls` is green and `lint-call-mismatches.ts --write` leaves both
trees byte-identical.

### `raw_connection.block`: drain the cancelled query before ROLLBACK (RFC 0085)

`_cancelAnyRunningQuery` ported only the `cancel` half of
`cancel_any_running_query`
(`activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb:127-128`).
It now awaits the cancelled query's settlement before returning, so
`execRollbackDbTransaction` / `execRestartDbTransaction` / `resetBang` send
ROLLBACK only once the query is off the wire. The settlement promise is derived
from the in-flight query's own promise with both handlers attached, which
observes its rejection at the seam. Drain failures stay inside the existing
best-effort `catch`, mirroring Rails' `rescue PG::Error`.

Regression test asserts `_queryInFlightOwner` is null at the moment ROLLBACK is
issued (it is non-null for exactly the span a query is on the wire); it fails on
baseline and passes with the fix, verified against a live PG 17.

Closes-story: datetime-to-s-drops-the-time-of-day
Closes-story: call-seq-coverage-for-object-literal-members
Closes-story: pg-cancel-block-drain
