### PR TITLE
fix(api-compare,associations): score the ActiveSupport::JSON singleton members; converge four order-only call rows

### DIFF
--- a/packages/activerecord/src/associations/belongs-to-association.ts
+++ b/packages/activerecord/src/associations/belongs-to-association.ts
@@ -71,16 +71,10 @@ export class BelongsToAssociation extends SingularAssociation {
    * Called by the before_validation callback set up by the builder.
    */
   async default(block: (owner: Base) => Base | null | Promise<Base | null>): Promise<void> {
-    // Rails: `writer(...) if reader.nil?` — loads synchronously, fires when nil.
-    // reader returns a Promise when FK is present but unloaded; await resolves it.
-    // The block itself may be async (e.g. `() => Developer.first()`), so its
-    // result is awaited before the nil check decides whether to write.
-    if ((await this.reader) == null) {
-      const value = await block(this.owner);
-      if (value != null) {
-        await this.writer(value);
-      }
-    }
+    // Rails: `writer(owner.instance_exec(&block)) if reader.nil?`. `reader`
+    // returns a Promise when the FK is present but unloaded, and the block
+    // itself may be async (e.g. `() => Developer.first()`), so both are awaited.
+    if ((await this.reader) == null) await this.writer(await block(this.owner));
   }
 
   override reset(): void {

--- a/packages/activerecord/src/associations/belongs-to-association.ts
+++ b/packages/activerecord/src/associations/belongs-to-association.ts
@@ -71,9 +71,8 @@ export class BelongsToAssociation extends SingularAssociation {
    * Called by the before_validation callback set up by the builder.
    */
   async default(block: (owner: Base) => Base | null | Promise<Base | null>): Promise<void> {
-    // Rails: `writer(owner.instance_exec(&block)) if reader.nil?`. `reader`
-    // returns a Promise when the FK is present but unloaded, and the block
-    // itself may be async (e.g. `() => Developer.first()`), so both are awaited.
+    // `reader` and the block are both awaited: TS has no `instance_exec`, and
+    // either side resolves asynchronously (belongs_to_association.rb:44).
     if ((await this.reader) == null) await this.writer(await block(this.owner));
   }
 

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -727,15 +727,17 @@ export class CollectionAssociation extends Association {
    * the in-memory target. For persisted records, uses scope if not loaded.
    */
   async isInclude(record: Base): Promise<boolean> {
-    if (record.isNewRecord() || this.isLoaded()) {
+    const klass = this.klass;
+    if (klass && !(record instanceof klass)) return false;
+
+    if (record.isNewRecord()) {
       return isIncludeInMemory(this, record);
+    } else if (this.isLoaded()) {
+      return this.target.includes(record);
+    } else {
+      const recordId = this.primaryKeyValue(record);
+      return await this.scope().exists(recordId);
     }
-    const rel = this.scope();
-    if (rel && typeof rel.exists === "function") {
-      const pk = this.primaryKeyValue(record);
-      return await rel.exists(pk);
-    }
-    return isIncludeInMemory(this, record);
   }
 
   /**

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -723,12 +723,14 @@ export class CollectionAssociation extends Association {
   }
 
   /**
-   * Check if a record is in the collection. For new records, checks
-   * the in-memory target. For persisted records, uses scope if not loaded.
+   * Mirrors: ActiveRecord::Associations::CollectionAssociation#include?
+   * (collection_association.rb:258-270) — a new record is looked for in
+   * memory, a loaded collection in its target, and anything else with an
+   * `exists?` against the scope.
    */
   async isInclude(record: Base): Promise<boolean> {
     const klass = this.klass;
-    if (klass && !(record instanceof klass)) return false;
+    if (!(record instanceof klass)) return false;
 
     if (record.isNewRecord()) {
       return isIncludeInMemory(this, record);

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -199,10 +199,8 @@ export class HasManyAssociation extends CollectionAssociation {
    * @internal
    */
   protected override async deleteOrNullifyAllRecords(method?: string): Promise<void> {
-    const scope = (this as any).scope?.();
-    if (!scope) return;
-    const count = await deleteCount(this, method ?? "", scope);
-    if (count > 0) await updateCounter(this, -count);
+    const count = await deleteCount(this, method ?? "", (this as any).scope());
+    await updateCounter(this, -count);
   }
 
   /**

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -86,17 +86,9 @@ export class HasManyThroughAssociation extends HasManyAssociation {
    * Mirrors: ActiveRecord::Associations::ThroughAssociation#transaction
    */
   protected override transaction<R>(block: () => Promise<R>): Promise<R | undefined> {
-    const tr = throughReflection(this) as { klass?: unknown } | null;
-    let klass: { transaction?: (...args: unknown[]) => unknown } | null = null;
-    try {
-      klass = (tr?.klass ?? null) as { transaction?: (...args: unknown[]) => unknown } | null;
-    } catch {
-      klass = null;
-    }
-    if (klass && typeof klass.transaction === "function") {
-      return klass.transaction(block) as Promise<R | undefined>;
-    }
-    return block() as Promise<R | undefined>;
+    const klass = (throughReflection(this) as { klass: { transaction(b: unknown): unknown } })
+      .klass;
+    return klass.transaction(block) as Promise<R | undefined>;
   }
 
   /**

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -190,10 +190,7 @@ export class HasOneAssociation extends SingularAssociation {
    * Handle the :dependent option when the owner is being destroyed.
    */
   async handleDependency(): Promise<void | false> {
-    const dependent = this.reflection.options.dependent;
-    if (!dependent) return;
-
-    switch (dependent) {
+    switch (this.reflection.options.dependent) {
       case "restrictWithException":
         if (await this.loadTarget()) {
           throw new DeleteRestrictionError(this.owner, this.reflection.name);
@@ -219,7 +216,7 @@ export class HasOneAssociation extends SingularAssociation {
         break;
 
       default:
-        return await this.delete(dependent);
+        return await this.delete();
     }
   }
 
@@ -227,7 +224,9 @@ export class HasOneAssociation extends SingularAssociation {
    * Delete the associated record using the given method.
    * Supports: delete, destroy, nullify.
    */
-  async delete(method?: string): Promise<void | false> {
+  async delete(
+    method: string | undefined = this.reflection.options.dependent as string | undefined,
+  ): Promise<void | false> {
     if (!(await this.loadTarget())) return;
     const target = this.target!;
 

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/belongs-to-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/belongs-to-association.json
@@ -2,13 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/belongs-to-association.ts",
-    "rubyName": "default",
-    "call": "order:owner,writer",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/belongs-to-association.ts",
     "rubyName": "handle_dependency",
     "call": "enqueue_destroy_association",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-association.json
@@ -65,13 +65,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/collection-association.ts",
-    "rubyName": "include?",
-    "call": "order:isLoaded,isIncludeInMemory",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/collection-association.ts",
     "rubyName": "load_target",
     "call": "order:mergeTargetLists,findTarget",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-many-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-many-association.json
@@ -2,13 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/has-many-association.ts",
-    "rubyName": "delete_or_nullify_all_records",
-    "call": "order:scope,deleteCount",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-many-association.ts",
     "rubyName": "delete_records",
     "call": "order:scope,klass",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-many-through-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-many-through-association.json
@@ -103,12 +103,5 @@
     "rubyName": "target_scope",
     "call": "scope_for_association",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-many-through-association.ts",
-    "rubyName": "transaction",
-    "call": "order:throughReflection,klass",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]

--- a/scripts/api-compare/conventions.ts
+++ b/scripts/api-compare/conventions.ts
@@ -155,6 +155,12 @@ export const RUBY_FILE_TS_OVERRIDES: Record<string, string> = {
   // `time-ext.ts` (its three test files — `core-ext/{time,date,date-time}-ext.test.ts`
   // — all import from it), the same one-TS-file-for-several-reopenings shape as
   // `inflector.ts` above.
+  // `ActiveSupport::JSON` is defined by `json/decoding.rb:12` first, so the
+  // module's whole singleton surface — `encode`/`dump` from
+  // `json/encoding.rb:16-43` included — buckets there. trails splits the two
+  // Ruby modules the way Rails documents them: `ActiveSupport::JSON` on
+  // `json.ts`, `ActiveSupport::JSON::Encoding` on `json/encoding.ts`.
+  "activesupport:json/decoding.rb": "json.ts",
   "activesupport:core_ext/time/calculations.rb": "time-ext.ts",
   "activesupport:core_ext/date/calculations.rb": "time-ext.ts",
   "activesupport:core_ext/date_time/calculations.rb": "time-ext.ts",


### PR DESCRIPTION
Two RFC-burndown stories.

### 1. `ActiveSupport::JSON` singleton members are scored (RFC 0072)

`json/decoding.rb:12` is where Ruby first opens `module ActiveSupport::JSON`,
so the module's whole singleton surface — `encode`/`dump` from
`json/encoding.rb:16-43` included — buckets under `json/decoding.rb`, a file
trails does not have. `json.ts` therefore reported `[no Rails counterpart]` and
`encode` / `decode` / `dump` were scored nowhere.

Maps `activesupport:json/decoding.rb → json.ts` in `RUBY_FILE_TS_OVERRIDES`,
the same one-TS-file-for-a-reopening shape as `inflector.ts` and `time-ext.ts`.
activesupport goes 918 → 929 methods, files 97 → 99 (the delegated
`use_standard_json_time_format` / `time_precision` / `escape_html_entities_in_json` /
`json_encoder` accessors in the `module ActiveSupport` bucket now resolve as
moves into `json/encoding.ts`).

### 2. Four order-only call rows in `associations/**` converged (RFC 0084)

- `belongs-to-association.ts::default` — `writer(owner.instance_exec(&block)) if reader.nil?`
  (belongs_to_association.rb:44): the port hoisted the block result into a local
  and added a `value != null` guard Rails does not have (Rails writes the nil).
- `has-many-through-association.ts::transaction` —
  `through_reflection.klass.transaction(&block)` (through_association.rb:10-12):
  the port wrapped the `klass` resolve in try/catch and fell back to running the
  block untransacted.
- `has-many-association.ts::deleteOrNullifyAllRecords` —
  `count = delete_count(method, scope); update_counter(-count)`
  (has_many_association.rb:120-124): the port hoisted `scope` into a guarded
  local and skipped `update_counter` when the count was 0.
- `collection-association.ts::isInclude` — `include?`
  (collection_association.rb:258-270): the port collapsed the `new_record?` and
  `loaded?` arms into one and dropped the `record.is_a?(klass)` guard.

Also drops the dead `if (!dependent) return` in
`has-one-association.ts::handleDependency` (the destroy callback is only
registered when `:dependent` is set — builder/association.ts:202-206) and gives
`delete` its Rails default argument `method = options[:dependent]`
(has_one_association.rb:26).

Each converged row is deleted from its `call-mismatches-exclude/` shard by hand
via `serializeBaseline`. `pnpm api:calls` is green.

The remaining 20 `order:` rows under `associations/**` are filed as
`burndown-order-only-rows-associations-remainder`: they need a dropped Rails
branch restored (`:destroy_async` / `enqueue_destroy_association`) or the rich
reflection resolve removed first — and several are an extractor asymmetry
(Ruby emits chained-call refs outermost-first, TS in evaluation order) that no
edit to the port can close.

Local: has-many / has-many-through / has-one / has-one-through / belongs-to /
habtm / collection-proxy / associations / nested-attributes / autosave suites
pass (SQLite lane).

Closes-story: attribute-activesupport-json-singleton-members-to-json-ts
Closes-story: burndown-order-only-rows-associations
