### PR TITLE
refactor(activerecord,api-compare): retire the nested-attributes property setter; bucket the activesupport core_ext orphans

### DIFF
--- a/packages/activerecord/src/associations/errors.ts
+++ b/packages/activerecord/src/associations/errors.ts
@@ -369,42 +369,6 @@ export class DeleteRestrictionError extends ActiveRecordError {
 }
 
 /**
- * Thrown when a one-to-one `#{name}_attributes=` nested-attributes assignment
- * would *displace* an existing associated record — build a replacement over a
- * record the association already holds, or over one that only exists in the DB.
- *
- * The sibling of {@link HasOnePersistedAssignmentError}, for the same reason:
- * Rails' `build_#{name}` → `set_new_record` → `replace(record, false)` runs
- * `load_target` (has_one_association.rb:59) and `remove_target!` (:69) inline
- * before `self.target = record` (:84), and neither the SELECT nor the
- * nullify/destroy save can be awaited from a JS property setter. Deferring them
- * to the owner's next `save()` is what RFC 0068 exists to kill, so the
- * synchronous setter refuses and names the awaitable writer instead. Nested
- * assignments that displace nothing — a fresh association, an `id`-matched
- * update, a reused unsaved build — stay on the synchronous setter.
- *
- * @noRailsEquivalent PERMANENT — Rails has no such error because `ship_attributes=` does
- * the displacement inline; a JS property setter's value expression cannot be
- * awaited by any caller syntax, so the write is unimplementable there and the
- * refusal is the honest port. Sibling of `HasOnePersistedAssignmentError` /
- * `CollectionPersistedAssignmentError` (RFC 0068 Design §2, §6).
- */
-export class NestedAttributesDisplacementError extends ActiveRecordError {
-  readonly association: string;
-
-  constructor(association: string) {
-    const cap = association.charAt(0).toUpperCase() + association.slice(1);
-    super(
-      `Cannot replace the existing \`${association}\` with \`${association}Attributes = ` +
-        `{...}\`: Rails removes the displaced record at assignment time, which ` +
-        `requires \`await\` in JS. Use \`await owner.set${cap}Attributes({...})\`.`,
-    );
-    this.name = "NestedAttributesDisplacementError";
-    this.association = association;
-  }
-}
-
-/**
  * Thrown when a `has_one` association is assigned by mass assignment —
  * `owner.assignAttributes({ account: x })`, `new Owner({ account: x })` — on a
  * *persisted* owner. (RFC 0087 §1 removed the native `=` setter that also

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -459,10 +459,8 @@ export class HasOneAssociation extends SingularAssociation {
    * record` (:84) is never reached when `remove_target!` raises (e.g. a failed
    * nullify save, has_one_association.rb:102-108).
    *
-   * There is no synchronous caller: the Rails-named `#{name}_attributes=`
-   * setter refuses a displacing assignment outright
-   * ({@link NestedAttributesDisplacementError}) rather than starting a removal
-   * it cannot await, so every caller here runs Rails' order intact.
+   * There is no synchronous caller: every writer that can displace a record is
+   * awaitable, so each of them runs Rails' order intact.
    *
    * No `isPersisted` pre-screen: Rails' `remove_target!` gates on persistence
    * only inside its `:destroy` and nullify arms; the `:delete` arm calls
@@ -487,17 +485,18 @@ export class HasOneAssociation extends SingularAssociation {
 
   /**
    * Whether a nested-attributes build over this association would reach DB I/O
-   * — the question the *synchronous* `#{name}_attributes=` setter has to answer
-   * before it starts, because it can await neither half of the `load_target`
-   * (has_one_association.rb:59) / `remove_target!` (:69) pair Rails runs inline.
+   * — the `load_target` (has_one_association.rb:59) / `remove_target!` (:69)
+   * pair Rails runs inline. Rails answers it by just running them; ours asks
+   * first, because a build that displaces nothing is pure in-memory work and
+   * has to stay synchronous for `new Model({shipAttributes: {…}})` to build the
+   * associated record inside the constructor, as Rails' does.
    *
    * True on both displacing arms: an already-loaded record to remove, and an
    * unloaded association whose `find_target?` (`findTargetNeeded`) says Rails
    * would query for one — the guard is `return target unless load_target ||
    * record`, and Ruby always evaluates the left operand, so a never-loaded
    * has_one on a persisted owner still discovers (and removes) the row. False
-   * when the build displaces nothing, which keeps the synchronous setter
-   * working for every non-displacing assignment.
+   * when the build displaces nothing, which keeps that assignment synchronous.
    *
    * `protected` because this is association-internal bookkeeping, not API
    * surface. The nested-attributes writer lives outside the class hierarchy and

--- a/packages/activerecord/src/associations/has-one-sync-build-displacement.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-sync-build-displacement.trails.test.ts
@@ -9,10 +9,7 @@
  * caller that can displace a persisted record issues the DB half itself. The
  * `build#{Name}` / `create#{Name}` accessors use `detachDisplacedTarget`. The
  * nested-attributes writer calls the same method from its *awaitable* half
- * (`await owner.set#{Name}Attributes({...})`), in Rails' order; the Rails-named
- * synchronous setter refuses a displacing assignment outright
- * (`NestedAttributesDisplacementError`) rather than deferring the write to the
- * owner's next `save()`. A *direct* `record.association(name).build(...)` runs
+ * (`await owner.set#{Name}Attributes({...})`), in Rails' order. A *direct* `record.association(name).build(...)` runs
  * the removal itself and returns the record wrapped in that promise for the
  * caller to `await`.
  *
@@ -22,12 +19,7 @@
  * guard rather than a change to the mirrored test.
  */
 import { describe, it, expect, beforeAll } from "vitest";
-import {
-  registerModel,
-  NestedAttributesDisplacementError,
-  RecordNotSaved,
-  type Base,
-} from "../index.js";
+import { registerModel, RecordNotSaved, type Base } from "../index.js";
 import { fixtures } from "../test-fixtures.js";
 import { Pirate } from "../test-helpers/models/pirate.js";
 import { Ship } from "../test-helpers/models/ship.js";
@@ -61,66 +53,19 @@ describe("has_one displacement via the synchronous build path", () => {
     expect((reloaded as unknown as { pirate_id: number | null }).pirate_id).toBe(null);
   });
 
-  it("refuses a displacing assignment through the synchronous setter", async () => {
-    const pirate = (await Pirate.create({ catchphrase: "Aye" })) as Base;
-    const displaced = (await Ship.create({
-      name: "Nights Dirty Lightning",
-      pirate_id: (pirate as unknown as { id: number }).id,
-    })) as Base;
-    await (pirate as unknown as { ship: Promise<Base | null> }).ship;
-
-    // Rails' `replace` removes the displaced row inline at the assignment
-    // expression; a property setter can neither await that nor defer it without
-    // reopening the two-row window, so it raises and names the awaitable writer.
-    expect(() => {
-      (pirate as unknown as { shipAttributes: unknown }).shipAttributes = {
-        name: "Davy Jones Gold Dagger",
-      };
-    }).toThrow(NestedAttributesDisplacementError);
-
-    // Nothing partial landed: the displaced record is still cached and attached.
-    expect((pirate.association("ship").target as unknown as { id: number }).id).toBe(
-      (displaced as unknown as { id: number }).id,
-    );
-    const reloaded = (await Ship.find((displaced as unknown as { id: number }).id)) as Base;
-    expect((reloaded as unknown as { pirate_id: number | null }).pirate_id).toBe(
-      (pirate as unknown as { id: number }).id,
-    );
-  });
-
-  it("refuses a displacing assignment over an unloaded child through the synchronous setter", async () => {
-    const pirate = (await Pirate.create({ catchphrase: "Aye" })) as Base;
-    const displaced = (await Ship.create({
-      name: "Nights Dirty Lightning",
-      pirate_id: (pirate as unknown as { id: number }).id,
-    })) as Base;
-
-    // Never loaded: Rails' `replace` guard is `return target unless load_target
-    // || record`, whose left operand always runs, so the assignment still owes a
-    // SELECT — which is exactly what the synchronous setter cannot await.
-    const refetched = (await Pirate.find((pirate as unknown as { id: number }).id)) as Base;
-    expect(() => {
-      (refetched as unknown as { shipAttributes: unknown }).shipAttributes = {
-        name: "Davy Jones Gold Dagger",
-      };
-    }).toThrow(NestedAttributesDisplacementError);
-
-    const reloaded = (await Ship.find((displaced as unknown as { id: number }).id)) as Base;
-    expect((reloaded as unknown as { pirate_id: number | null }).pirate_id).toBe(
-      (pirate as unknown as { id: number }).id,
-    );
-  });
-
-  it("keeps the synchronous setter working when the assignment displaces nothing", async () => {
+  it("keeps the writer synchronous when the assignment displaces nothing", async () => {
     const pirate = (await Pirate.create({ catchphrase: "Aye" })) as Base;
     // A loaded, empty association owes no load and has nothing to remove, so
-    // Rails' `replace` reduces to `self.target = record` — in-memory work a
-    // property setter can do.
+    // Rails' `replace` reduces to `self.target = record` — in-memory work, which
+    // the writer does inline rather than answering a promise for. That is what
+    // keeps `new Pirate({ shipAttributes: {...} })` building its ship inside the
+    // constructor, where Rails' `#{name}_attributes=` builds it.
     await (pirate as unknown as { ship: Promise<Base | null> }).ship;
 
-    (pirate as unknown as { shipAttributes: unknown }).shipAttributes = {
-      name: "Davy Jones Gold Dagger",
-    };
+    const pending = (
+      pirate as unknown as { setShipAttributes(a: object): Promise<void> | void }
+    ).setShipAttributes({ name: "Davy Jones Gold Dagger" });
+    expect(pending).toBeUndefined();
     await pirate.save();
 
     const ship = (await (pirate as unknown as { ship: Promise<Base | null> }).ship) as Base;
@@ -223,15 +168,19 @@ describe("has_one displacement via the synchronous build path", () => {
       throw new Error("build exploded");
     };
 
+    // The writer raises synchronously: `build_record` runs before anything is
+    // awaited (singular_association.rb:29-31).
     expect(() => {
-      (refetched as unknown as { shipAttributes: unknown }).shipAttributes = {
+      void (
+        refetched as unknown as { setShipAttributes(a: object): Promise<void> | void }
+      ).setShipAttributes({
         name: "Davy Jones Gold Dagger",
-      };
+      });
     }).toThrow("build exploded");
 
     // Rails is `build_record(...)` then `set_new_record` → `load_target`, so a
-    // raising build leaves the row untouched — the construction error surfaces,
-    // not the displacement refusal that would follow it.
+    // raising build leaves the row untouched — the construction error surfaces
+    // before the displacement query that would follow it.
     const reloaded = (await Ship.find((displaced as unknown as { id: number }).id)) as Base;
     expect((reloaded as unknown as { pirate_id: number | null }).pirate_id).toBe(
       (pirate as unknown as { id: number }).id,
@@ -300,10 +249,14 @@ describe("has_one displacement via the synchronous build path", () => {
       throw new Error("build exploded");
     };
 
+    // The writer raises synchronously: `build_record` runs before anything is
+    // awaited (singular_association.rb:29-31).
     expect(() => {
-      (pirate as unknown as { shipAttributes: unknown }).shipAttributes = {
+      void (
+        pirate as unknown as { setShipAttributes(a: object): Promise<void> | void }
+      ).setShipAttributes({
         name: "Davy Jones Gold Dagger",
-      };
+      });
     }).toThrow("build exploded");
 
     expect(detached).toBe(false);

--- a/packages/activerecord/src/associations/has-one-sync-build-displacement.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-sync-build-displacement.trails.test.ts
@@ -56,10 +56,8 @@ describe("has_one displacement via the synchronous build path", () => {
   it("keeps the writer synchronous when the assignment displaces nothing", async () => {
     const pirate = (await Pirate.create({ catchphrase: "Aye" })) as Base;
     // A loaded, empty association owes no load and has nothing to remove, so
-    // Rails' `replace` reduces to `self.target = record` — in-memory work, which
-    // the writer does inline rather than answering a promise for. That is what
-    // keeps `new Pirate({ shipAttributes: {...} })` building its ship inside the
-    // constructor, where Rails' `#{name}_attributes=` builds it.
+    // Rails' `replace` reduces to `self.target = record` — in-memory work the
+    // writer does inline rather than answering a promise for.
     await (pirate as unknown as { ship: Promise<Base | null> }).ship;
 
     const pending = (
@@ -168,8 +166,6 @@ describe("has_one displacement via the synchronous build path", () => {
       throw new Error("build exploded");
     };
 
-    // The writer raises synchronously: `build_record` runs before anything is
-    // awaited (singular_association.rb:29-31).
     expect(() => {
       void (
         refetched as unknown as { setShipAttributes(a: object): Promise<void> | void }
@@ -249,8 +245,6 @@ describe("has_one displacement via the synchronous build path", () => {
       throw new Error("build exploded");
     };
 
-    // The writer raises synchronously: `build_record` runs before anything is
-    // awaited (singular_association.rb:29-31).
     expect(() => {
       void (
         pirate as unknown as { setShipAttributes(a: object): Promise<void> | void }

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -197,8 +197,7 @@ export class HasOneThroughAssociation extends HasOneAssociation {
    * No load and no removal, for the same reason as `loadDisplacedForBuild`
    * above: a through `replace` has no `load_target`, so a nested-attributes
    * build issues no target SELECT and detaches no displaced *end* record for a
-   * has_one_through — there is nothing for the synchronous writer to await, and
-   * so nothing for it to refuse.
+   * has_one_through — so the writer has nothing to await.
    *
    * @internal
    */

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -249,7 +249,6 @@ export {
   EagerLoadPolymorphicError,
   DeleteRestrictionError,
   HasOnePersistedAssignmentError,
-  NestedAttributesDisplacementError,
   CollectionPersistedAssignmentError,
   CollectionIdsAssignmentError,
 } from "./associations/errors.js";

--- a/packages/activerecord/src/nested-attributes-displaced-removal-failure.trails.test.ts
+++ b/packages/activerecord/src/nested-attributes-displaced-removal-failure.trails.test.ts
@@ -7,22 +7,18 @@
  * (vendor/rails/activerecord/lib/active_record/associations/has_one_association.rb:95-115),
  * so `pirate.ship_attributes = {...}` surfaces the failure at the assignment
  * expression whether or not the owner is ever saved. A synchronous JS property
- * setter cannot raise on an async write — so it does not start one: the
- * awaitable `set#{Name}Attributes` writer runs the load, the removal and the
- * target install in Rails' order and raises at the assignment point, while the
- * Rails-named setter refuses a displacing assignment up front
- * (`NestedAttributesDisplacementError`) instead of parking a write that would
- * fail later.
+ * setter cannot raise on an async write, so the Rails name lands on the
+ * awaitable `set#{Name}Attributes` writer, which runs the load, the removal and
+ * the target install in Rails' order and raises at the assignment point.
  *
  * No Rails test covers a *failing* displacement removal, hence a trails-only
  * guard rather than a mirrored test.
  */
 import { describe, it, expect, beforeAll } from "vitest";
-import { registerModel, NestedAttributesDisplacementError, type Base } from "./index.js";
+import { registerModel, type Base } from "./index.js";
 import { fixtures } from "./test-fixtures.js";
 import { Pirate } from "./test-helpers/models/pirate.js";
 import { Ship } from "./test-helpers/models/ship.js";
-import { Bird } from "./test-helpers/models/bird.js";
 
 /**
  * A pirate with a loaded, persisted ship whose displacement removal is rigged
@@ -50,7 +46,6 @@ describe("nested-attributes displacement removal failure", () => {
   beforeAll(() => {
     registerModel(Pirate);
     registerModel(Ship);
-    registerModel(Bird);
   });
 
   it("detaches the displaced row at the assignment through the awaitable writer", async () => {
@@ -95,38 +90,5 @@ describe("nested-attributes displacement removal failure", () => {
     // (:69), so a raising removal leaves the OLD record cached — the ordering
     // the retired target swap could not express.
     expect(pirate.association("ship").target).toBe(displaced);
-  });
-
-  it("parks no removal for a synchronous displacing assignment to fail later", async () => {
-    const pirate = await pirateWithFailingRemoval();
-
-    // The setter refuses instead of starting a write it cannot await, so there
-    // is no deferred failure to surface at `save()` — and nothing that could
-    // become an unhandled rejection if the owner is never saved.
-    expect(() => {
-      (pirate as unknown as { shipAttributes: unknown }).shipAttributes = {
-        name: "Davy Jones Gold Dagger",
-      };
-    }).toThrow(NestedAttributesDisplacementError);
-
-    await expect(pirate.save()).resolves.toBe(true);
-  });
-
-  it("leaves an unrelated association's awaitable writer unaffected", async () => {
-    const pirate = await pirateWithFailingRemoval();
-
-    expect(() => {
-      (pirate as unknown as { shipAttributes: unknown }).shipAttributes = {
-        name: "Davy Jones Gold Dagger",
-      };
-    }).toThrow(NestedAttributesDisplacementError);
-
-    // With no parked removal, there is no owner-wide sticky failure left for an
-    // unrelated writer to inherit: the refusal was terminal at its own call site.
-    await expect(
-      (
-        pirate as unknown as { setBirdsAttributes: (a: unknown) => Promise<void> }
-      ).setBirdsAttributes([{ name: "Posideons Killer" }]),
-    ).resolves.toBeUndefined();
   });
 });

--- a/packages/activerecord/src/nested-attributes-unloaded-update.trails.test.ts
+++ b/packages/activerecord/src/nested-attributes-unloaded-update.trails.test.ts
@@ -114,7 +114,7 @@ describe("nested attributes update on an unloaded one-to-one association", () =>
     // back a rejected promise.
     expect(() =>
       (
-        pirate as unknown as { setShipAttributes(attributes: unknown): Promise<void> }
+        pirate as unknown as { setShipAttributes(attributes: unknown): Promise<void> | void }
       ).setShipAttributes({
         id: (ship as unknown as { id: number }).id,
         name: "Davy Jones Gold Dagger",

--- a/packages/activerecord/src/nested-attributes.test.ts
+++ b/packages/activerecord/src/nested-attributes.test.ts
@@ -401,9 +401,6 @@ describe("TestNestedAttributesOnAHasOneAssociation", () => {
     }).toThrow(/Cannot build association `looter'/);
   });
 
-  // Rails asserts `assert_respond_to @pirate, :ship_attributes=`
-  // (nested_attributes_test.rb:262-264); the Rails-named writer is a method here
-  // because it must be awaitable (RFC 0087 §1).
   it("should define an attribute writer method for the association", () => {
     const pirate = new Pirate();
     expect(typeof (pirate as any).setShipAttributes).toBe("function");
@@ -640,8 +637,6 @@ describe("TestNestedAttributesOnABelongsToAssociation", () => {
     return { ship, pirate };
   }
 
-  // Rails: `assert_respond_to @ship, :pirate_attributes=`
-  // (nested_attributes_test.rb:463-465).
   it("should define an attribute writer method for the association", () => {
     const ship = new Ship();
     expect(typeof (ship as any).setPirateAttributes).toBe("function");
@@ -860,10 +855,6 @@ function collectionAssociationTests(
   buildSetup: () => Promise<{ pirate: Pirate; child1: any; child2: any }>,
 ): void {
   const setter = `${associationName}Attributes`;
-  // Rails' `#{name}_attributes=`; here the awaitable writer that carries the
-  // Rails name (RFC 0087 §1).
-  // A collection assignment is pure in-memory work, so the writer completes
-  // inline — nothing to await, exactly as Rails' `#{name}_attributes=`.
   const write = (p: Pirate, value: unknown): void => {
     void (p as any)[`set${associationName[0].toUpperCase()}${associationName.slice(1)}Attributes`](
       value,
@@ -879,8 +870,6 @@ function collectionAssociationTests(
     };
   }
 
-  // Rails: `assert_respond_to @pirate, association_setter`
-  // (nested_attributes_test.rb:640-642).
   it("should define an attribute writer method for the association", async () => {
     const { pirate } = await buildSetup();
     expect(

--- a/packages/activerecord/src/nested-attributes.test.ts
+++ b/packages/activerecord/src/nested-attributes.test.ts
@@ -401,11 +401,12 @@ describe("TestNestedAttributesOnAHasOneAssociation", () => {
     }).toThrow(/Cannot build association `looter'/);
   });
 
+  // Rails asserts `assert_respond_to @pirate, :ship_attributes=`
+  // (nested_attributes_test.rb:262-264); the Rails-named writer is a method here
+  // because it must be awaitable (RFC 0087 §1).
   it("should define an attribute writer method for the association", () => {
     const pirate = new Pirate();
-    expect(() => {
-      (pirate as any).shipAttributes = {};
-    }).not.toThrow();
+    expect(typeof (pirate as any).setShipAttributes).toBe("function");
   });
 
   it("should build a new record if there is no id", async () => {
@@ -639,11 +640,11 @@ describe("TestNestedAttributesOnABelongsToAssociation", () => {
     return { ship, pirate };
   }
 
+  // Rails: `assert_respond_to @ship, :pirate_attributes=`
+  // (nested_attributes_test.rb:463-465).
   it("should define an attribute writer method for the association", () => {
     const ship = new Ship();
-    expect(() => {
-      (ship as any).pirateAttributes = {};
-    }).not.toThrow();
+    expect(typeof (ship as any).setPirateAttributes).toBe("function");
   });
 
   it("should build a new record if there is no id", async () => {
@@ -859,6 +860,15 @@ function collectionAssociationTests(
   buildSetup: () => Promise<{ pirate: Pirate; child1: any; child2: any }>,
 ): void {
   const setter = `${associationName}Attributes`;
+  // Rails' `#{name}_attributes=`; here the awaitable writer that carries the
+  // Rails name (RFC 0087 §1).
+  // A collection assignment is pure in-memory work, so the writer completes
+  // inline — nothing to await, exactly as Rails' `#{name}_attributes=`.
+  const write = (p: Pirate, value: unknown): void => {
+    void (p as any)[`set${associationName[0].toUpperCase()}${associationName.slice(1)}Attributes`](
+      value,
+    );
+  };
   const proxy = (p: Pirate) => (p as any)[associationName];
   const childName = childClass === Bird ? "Bird" : "Parrot";
 
@@ -869,18 +879,22 @@ function collectionAssociationTests(
     };
   }
 
+  // Rails: `assert_respond_to @pirate, association_setter`
+  // (nested_attributes_test.rb:640-642).
   it("should define an attribute writer method for the association", async () => {
     const { pirate } = await buildSetup();
-    expect(() => {
-      (pirate as any)[setter] = {};
-    }).not.toThrow();
+    expect(
+      typeof (pirate as any)[
+        `set${associationName[0].toUpperCase()}${associationName.slice(1)}Attributes`
+      ],
+    ).toBe("function");
   });
 
   it("should raise an UnknownAttributeError for non existing nested attributes for has many", async () => {
     const { pirate } = await buildSetup();
     await expect(
       (async () => {
-        (pirate as any)[setter] = [{ peg_leg: true }];
+        write(pirate, [{ peg_leg: true }]);
         await pirate.save();
       })(),
     ).rejects.toThrow(new RegExp(`unknown attribute 'peg_leg' for ${childName}`));
@@ -906,7 +920,7 @@ function collectionAssociationTests(
 
   it("should take an array and assign the attributes to the associated models", async () => {
     const { pirate, child1, child2 } = await buildSetup();
-    (pirate as any)[setter] = Object.values(await alternateParams(child1, child2));
+    write(pirate, Object.values(await alternateParams(child1, child2)));
     await pirate.save();
     expect([
       (await childClass.find(child1.id)).name,
@@ -916,7 +930,7 @@ function collectionAssociationTests(
 
   it("should also work with a HashWithIndifferentAccess", async () => {
     const { pirate, child1 } = await buildSetup();
-    (pirate as any)[setter] = { foo: { id: child1.id, name: "Grace OMalley" } };
+    write(pirate, { foo: { id: child1.id, name: "Grace OMalley" } });
     await pirate.save();
     expect((await childClass.find(child1.id)).name).toBe("Grace OMalley");
   });
@@ -932,7 +946,7 @@ function collectionAssociationTests(
   it("should not load association when updating existing records", async () => {
     const { pirate, child1 } = await buildSetup();
     await pirate.reload();
-    (pirate as any)[setter] = [{ id: child1.id, name: "Grace OMalley" }];
+    write(pirate, [{ id: child1.id, name: "Grace OMalley" }]);
     expect(proxy(pirate).loaded).toBe(false);
     await pirate.save();
     expect(proxy(pirate).loaded).toBe(false);
@@ -942,7 +956,7 @@ function collectionAssociationTests(
   it("should not overwrite unsaved updates when loading association", async () => {
     const { pirate, child1 } = await buildSetup();
     await pirate.reload();
-    (pirate as any)[setter] = [{ id: child1.id, name: "Grace OMalley" }];
+    write(pirate, [{ id: child1.id, name: "Grace OMalley" }]);
     const target = await proxy(pirate).loadTarget();
     expect(target.find((r: any) => String(r.id) === String(child1.id)).name).toBe("Grace OMalley");
   });
@@ -950,7 +964,7 @@ function collectionAssociationTests(
   it("should preserve order when not overwriting unsaved updates", async () => {
     const { pirate, child1 } = await buildSetup();
     await pirate.reload();
-    (pirate as any)[setter] = [{ id: child1.id, name: "Grace OMalley" }];
+    write(pirate, [{ id: child1.id, name: "Grace OMalley" }]);
     const target = await proxy(pirate).loadTarget();
     expect(String(target[0].id)).toBe(String(child1.id));
   });
@@ -969,7 +983,7 @@ function collectionAssociationTests(
   it("should not remove scheduled destroys when loading association", async () => {
     const { pirate, child1 } = await buildSetup();
     await pirate.reload();
-    (pirate as any)[setter] = [{ id: child1.id, _destroy: "1" }];
+    write(pirate, [{ id: child1.id, _destroy: "1" }]);
     const target = await proxy(pirate).loadTarget();
     expect(
       isMarkedForDestruction(target.find((r: any) => String(r.id) === String(child1.id))),
@@ -996,7 +1010,7 @@ function collectionAssociationTests(
     // unlike `attributes=`, surfaces the raw RecordNotFound).
     await proxy(pirate).load();
     expect(() => {
-      (pirate as any)[setter] = [{ id: 1234567890 }];
+      write(pirate, [{ id: 1234567890 }]);
     }).toThrow(RecordNotFound);
   });
 
@@ -1006,7 +1020,7 @@ function collectionAssociationTests(
     const otherChild = await proxy(otherPirate).createBang({ name: "Buccaneers Servant" });
     await proxy(pirate).load();
     expect(() => {
-      (pirate as any)[setter] = [{ id: otherChild.id }];
+      write(pirate, [{ id: otherChild.id }]);
     }).toThrow(RecordNotFound);
   });
 
@@ -1027,7 +1041,7 @@ function collectionAssociationTests(
   it("should not assign destroy key to a record", async () => {
     const { pirate } = await buildSetup();
     expect(() => {
-      (pirate as any)[setter] = { foo: { _destroy: "0" } };
+      write(pirate, { foo: { _destroy: "0" } });
     }).not.toThrow();
   });
 
@@ -1060,7 +1074,7 @@ function collectionAssociationTests(
     const attributes: Record<string, any> = {};
     attributes["123726353"] = { name: "Grace OMalley" };
     attributes["2"] = { name: "Privateers Greed" };
-    (pirate as any)[setter] = attributes;
+    write(pirate, attributes);
     const target = await proxy(pirate).loadTarget();
     expect(new Set(target.map((r: any) => r.name))).toEqual(
       new Set(["Posideons Killer", "Killer bandita Dionne", "Privateers Greed", "Grace OMalley"]),
@@ -1070,10 +1084,10 @@ function collectionAssociationTests(
   it("should raise an argument error if something else than a hash is passed", async () => {
     const { pirate } = await buildSetup();
     expect(() => {
-      (pirate as any)[setter] = {};
+      write(pirate, {});
     }).not.toThrow();
     expect(() => {
-      (pirate as any)[setter] = "foo";
+      write(pirate, "foo");
     }).toThrow(
       new RegExp(`Hash or Array expected for \`${associationName}\` attributes, got String`),
     );
@@ -1114,7 +1128,7 @@ function collectionAssociationTests(
       });
       const params = await alternateParams(child1, child2);
       params["baz"] = { id: record.id, _destroy: trueVariable };
-      (pirate as any)[setter] = params;
+      write(pirate, params);
       const before = Number(await proxy(pirate).count());
       await pirate.save();
       expect(Number(await proxy(await Pirate.find(pirate.id)).count())).toBe(before - 1);
@@ -1137,7 +1151,7 @@ function collectionAssociationTests(
     const params = await alternateParams(child1, child2);
     params["baz"] = { id: child1.id, _destroy: true };
     const before = Number(await proxy(pirate).count());
-    (pirate as any)[setter] = params;
+    write(pirate, params);
     expect(Number(await proxy(await Pirate.find(pirate.id)).count())).toBe(before);
     await pirate.save();
     expect(Number(await proxy(await Pirate.find(pirate.id)).count())).toBe(before - 1);
@@ -1158,7 +1172,7 @@ function collectionAssociationTests(
   it("assigning nested attributes target", async () => {
     const { pirate, child1, child2 } = await buildSetup();
     const params = Object.values(await alternateParams(child1, child2));
-    (pirate as any)[setter] = params;
+    write(pirate, params);
     await pirate.save();
     const nat = (
       pirate.association(associationName) as unknown as { nestedAttributesTarget: (Base | null)[] }
@@ -1173,7 +1187,7 @@ function collectionAssociationTests(
     const { pirate, child1, child2 } = await buildSetup();
     const params = Object.values(await alternateParams(child1, child2));
     params.splice(1, 0, {});
-    (pirate as any)[setter] = params;
+    write(pirate, params);
     await pirate.save();
     const nat = (
       pirate.association(associationName) as unknown as { nestedAttributesTarget: (Base | null)[] }

--- a/packages/activerecord/src/nested-attributes.trails.test.ts
+++ b/packages/activerecord/src/nested-attributes.trails.test.ts
@@ -250,4 +250,47 @@ describe("nested attributes assignment ordering (trails-only)", () => {
 
     expect(observed).toEqual(["Aye"]);
   });
+
+  // `_assign_attributes` and `assign_nested_parameter_attributes`
+  // (attribute_assignment.rb:9-23, 26-28) are plain `each` loops, so an
+  // assignment that reaches DB I/O — a displacing `#{name}_attributes=` running
+  // `load_target` / `remove_target!` (has_one_association.rb:59-69) — finishes
+  // before the next key is assigned.
+  it("finishes a displacing nested assignment before assigning the next key", async () => {
+    Pirate.acceptsNestedAttributesFor("parrots");
+    const pirate = (await Pirate.create({ catchphrase: "Aye" })) as unknown as Pirate;
+    await Ship.create({
+      name: "Nights Dirty Lightning",
+      pirate_id: (pirate as unknown as { id: number }).id,
+    });
+    await (pirate as unknown as { ship: Promise<Base | null> }).ship;
+
+    const events: string[] = [];
+    const assoc = pirate.association("ship") as unknown as {
+      detachDisplacedTarget: () => Promise<void>;
+    };
+    const removeTarget = assoc.detachDisplacedTarget.bind(assoc);
+    assoc.detachDisplacedTarget = async () => {
+      events.push("remove_target!:start");
+      await removeTarget();
+      events.push("remove_target!:end");
+    };
+
+    const config = (
+      Pirate as unknown as {
+        _nestedAttributeConfigs: { associationName: string; options: { rejectIf?: unknown } }[];
+      }
+    )._nestedAttributeConfigs.find((c) => c.associationName === "parrots")!;
+    config.options.rejectIf = () => {
+      events.push("parrots");
+      return false;
+    };
+
+    await pirate.assignAttributes({
+      shipAttributes: { name: "Davy Jones Gold Dagger" },
+      parrotsAttributes: { foo: { name: "Posideons Killer" } },
+    });
+
+    expect(events).toEqual(["remove_target!:start", "remove_target!:end", "parrots"]);
+  });
 });

--- a/packages/activerecord/src/nested-attributes.trails.test.ts
+++ b/packages/activerecord/src/nested-attributes.trails.test.ts
@@ -173,31 +173,25 @@ describe("nested attributes save wrapper argument forwarding (trails-only)", () 
 
   // `new Model(...)` / `Model.create(...)` reach the nested writer by Rails
   // name (`public_send("#{k}=")`, attribute_assignment.rb:35-48), not by
-  // hunting a `#{name}Attributes=` descriptor on the prototype. Deleting the
-  // property setter — which RFC 0087 does next — must therefore leave
-  // construction-time nested attributes assigned rather than silently skipped.
+  // hunting a `#{name}Attributes=` descriptor on the prototype. RFC 0087 §1
+  // deleted that property setter, so construction has none to find.
   it("assigns constructor nested attributes without the property setter", async () => {
     Pirate.acceptsNestedAttributesFor("ship");
-    const setterDescriptor = Object.getOwnPropertyDescriptor(Pirate.prototype, "shipAttributes")!;
-    delete (Pirate.prototype as unknown as Record<string, unknown>).shipAttributes;
+    expect(Object.getOwnPropertyDescriptor(Pirate.prototype, "shipAttributes")).toBeUndefined();
 
-    try {
-      const pirate = new Pirate({ catchphrase: "Arr", shipAttributes: { name: "Black Pearl" } });
-      await pirate.saveBang();
-      expect(
-        cols((await Ship.where({ pirate_id: readAttr(pirate, "id") }).first()) as Base).name,
-      ).toBe("Black Pearl");
+    const pirate = new Pirate({ catchphrase: "Arr", shipAttributes: { name: "Black Pearl" } });
+    await pirate.saveBang();
+    expect(
+      cols((await Ship.where({ pirate_id: readAttr(pirate, "id") }).first()) as Base).name,
+    ).toBe("Black Pearl");
 
-      const created = await Pirate.createBang({
-        catchphrase: "Aye",
-        shipAttributes: { name: "Flying Dutchman" },
-      });
-      expect(
-        cols((await Ship.where({ pirate_id: readAttr(created, "id") }).first()) as Base).name,
-      ).toBe("Flying Dutchman");
-    } finally {
-      Object.defineProperty(Pirate.prototype, "shipAttributes", setterDescriptor);
-    }
+    const created = await Pirate.createBang({
+      catchphrase: "Aye",
+      shipAttributes: { name: "Flying Dutchman" },
+    });
+    expect(
+      cols((await Ship.where({ pirate_id: readAttr(created, "id") }).first()) as Base).name,
+    ).toBe("Flying Dutchman");
   });
 
   it("forwards save options through the nested-attributes save wrapper", async () => {

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -6,7 +6,6 @@ import {
   association as collectionProxyFor,
 } from "./associations.js";
 import { ActiveRecordError, UnknownAttributeError, RecordNotFound } from "./errors.js";
-import { NestedAttributesDisplacementError } from "./associations/errors.js";
 import { singularize, camelize, underscore, isBlank } from "@blazetrails/activesupport";
 import { Table, UpdateManager } from "@blazetrails/arel";
 import {
@@ -178,9 +177,8 @@ export function acceptsNestedAttributesFor(
       this: Base,
       options?: { validate?: boolean; touch?: boolean },
     ): Promise<boolean> {
-      // Finish the reader load a nested-attributes assignment could not await
-      // (Rails' `send(association_name)` is synchronous), so the parent is never
-      // saved against a half-assigned graph.
+      // Finish the reader load the constructor re-dispatch could not await, so
+      // the parent is never saved against a half-assigned graph.
       await awaitPendingNestedReaderLoads(this);
       const result = await originalSave.call(this, options);
       if (!result) return false;
@@ -568,31 +566,26 @@ function generateAssociationWriter(
     (modelClass as any)._nestedAttributeSetterKeys = new Set<string>();
   }
   (modelClass as any)._nestedAttributeSetterKeys.add(attrName);
-  const assign: (record: Base, name: string, value: any, awaitable?: boolean) => unknown =
+  const assign: (record: Base, name: string, value: any) => Promise<void> | void =
     type === "collection"
       ? assignNestedAttributesForCollectionAssociation
       : assignNestedAttributesForOneToOneAssociation;
-  Object.defineProperty(modelClass.prototype, attrName, {
-    set(this: Base, value: any) {
-      assign(this, associationName, value);
-    },
-    configurable: true,
-  });
 
-  // The awaitable counterpart of the Rails-named `#{name}_attributes=` setter.
-  // Rails' writer loads, removes the displaced record and installs the
-  // replacement inline, raising at the assignment expression; a JS property
-  // setter cannot await, so this is the surface that reproduces that timing
-  // (RFC 0068's `set#{Name}` sugar, applied to nested attributes) — and the one
-  // the synchronous setter names when it refuses a displacing assignment.
-  // Collections get it too, for one uniform awaitable writer per association.
+  // Rails' `#{name}_attributes=` (nested_attributes.rb:401-404). Rails' writer
+  // loads, removes the displaced record and installs the replacement inline,
+  // raising at the assignment expression; a JS property setter can await none of
+  // that, so the Rails name lands on a `set#{Name}Attributes()` method — the
+  // settled trails shape for a Ruby `x=` that must be async (CLAUDE.md).
+  // Collections get it too, for one uniform writer per association.
   Object.defineProperty(modelClass.prototype, `set${camelize(attrName, true)}`, {
     // Deliberately not `async`: Ruby's writer raises at the assignment
     // expression, and an `async` body would turn every synchronous raise
     // (nested_attributes.rb:415's `Cannot build association` among them) into a
-    // rejection observed only at the `await`.
-    value(this: Base, value: any): Promise<void> {
-      return Promise.resolve(assign(this, associationName, value, true)) as Promise<void>;
+    // rejection observed only at the `await`. It answers a promise only when the
+    // assignment owes DB I/O, so an in-memory one also *completes* where Ruby's
+    // does — inside `new Model({...})`, before the constructor returns.
+    value(this: Base, value: any): Promise<void> | void {
+      return assign(this, associationName, value);
     },
     writable: true,
     configurable: true,
@@ -721,10 +714,10 @@ async function detachDisplacedThenSetNewRecord(
  *
  * Rails reads the existing record with `send(association_name)`
  * (nested_attributes.rb:434), a plain synchronous call; ours is a promise for an
- * unloaded association, which the Rails-named setter cannot await. Unlike the
- * displacement removal — which now refuses rather than defers
- * ({@link NestedAttributesDisplacementError}) — this deferral is a *read*, so no
- * DB state is in flight to race an interim insert.
+ * unloaded association. The writer itself awaits that load; this is for the one
+ * caller that cannot — the constructor re-dispatch in `_reapplyNestedAttrSetters`
+ * (persistence.ts). The deferral is a *read*, so no DB state is in flight to
+ * race an interim insert.
  * @internal
  */
 export function parkNestedReaderLoad(record: Base, load: Promise<void>): void {
@@ -804,11 +797,6 @@ export function assignNestedAttributesForOneToOneAssociation(
   record: Base,
   associationName: string,
   attributes: Record<string, unknown>,
-  // Whether the caller can `await` the result: true for the awaitable
-  // `set#{Name}Attributes` writer, false for the Rails-named
-  // `#{name}_attributes=` property setter, which refuses the assignments that
-  // need I/O rather than deferring them (RFC 0068 Design §6).
-  awaitable = false,
 ): Promise<void> | void {
   if (typeof attributes !== "object" || attributes === null || Array.isArray(attributes)) {
     throw new Error(
@@ -822,25 +810,17 @@ export function assignNestedAttributesForOneToOneAssociation(
   const updateOnly = options.updateOnly ?? false;
   const hasId = hasNestedId(attributes);
 
-  // Rails: `existing_record = send(association_name)`. The reader loads an
-  // unloaded association; a synchronous writer cannot await that, so the whole
-  // body is re-entered once it lands (`assoc.isLoaded()` is true by then, so
-  // this resolves and falls through).
+  // Rails: `existing_record = send(association_name)` (nested_attributes.rb:434).
+  // The reader loads an unloaded association; ours answers a promise for that
+  // load, so the whole body is re-entered once it lands (`assoc.isLoaded()` is
+  // true by then, so this resolves and falls through).
   const assoc = record.association(associationName) as unknown as OneToOneAssociation;
   if ((hasId || updateOnly) && assoc.isLoaded?.() === false && "reader" in assoc) {
     const read = assoc.reader;
     if (read instanceof Promise) {
-      const reentry = read.then(() =>
-        assignNestedAttributesForOneToOneAssociation(
-          record,
-          associationName,
-          attributes,
-          awaitable,
-        ),
+      return read.then(() =>
+        assignNestedAttributesForOneToOneAssociation(record, associationName, attributes),
       );
-      if (awaitable) return reentry;
-      parkNestedReaderLoad(record, reentry);
-      return;
     }
   }
   const existing = assoc.target ?? null;
@@ -905,14 +885,14 @@ export function assignNestedAttributesForOneToOneAssociation(
         if (assoc.displacementNeedsAwait?.() === true) {
           // DB I/O Rails runs inline before `self.target = record` (:84) — a
           // SELECT for a never-loaded association, then `remove_target!`'s
-          // nullify/destroy save. A property setter can neither await it nor
-          // defer it without reopening the order-undefined two-row window RFC
-          // 0068 exists to close, so it refuses and names the awaitable writer.
-          if (!awaitable) throw new NestedAttributesDisplacementError(associationName);
+          // nullify/destroy save. Returning the promise puts it at the
+          // assignment expression, where Rails runs it.
           return detachDisplacedThenSetNewRecord(assoc, built);
         }
         // Nothing to displace: Rails' `self.target = record` (:84) is all that
-        // remains of `replace`, and it is in-memory work.
+        // remains of `replace`, and it is in-memory work — so it stays
+        // synchronous, which is what lets `new Model({shipAttributes: …})` build
+        // the associated record inside the constructor Rails runs it in.
         if (built) assoc.setNewRecord(built);
       }
     }

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -1167,7 +1167,7 @@ export function assignAttributes(
 
   let multiParameterAttributes: Record<string, unknown> | null = null;
   let nestedParameterAttributes: Record<string, unknown> | null = null;
-  const pending: Promise<void>[] = [];
+  let pending: Promise<void> | undefined;
 
   for (const [key, value] of Object.entries(attrs)) {
     if (key.includes("(")) {
@@ -1175,22 +1175,38 @@ export function assignAttributes(
     } else if (isNestedParameterHash(value)) {
       (nestedParameterAttributes ??= {})[key] = value;
     } else {
-      const assigned = _assignAttribute(this, key, value);
-      if (assigned) pending.push(assigned);
+      pending = assignAfter(pending, () => _assignAttribute(this, key, value));
     }
   }
 
-  const pendingNested = nestedParameterAttributes
-    ? assignNestedParameterAttributes(this, nestedParameterAttributes)
-    : undefined;
-  if (pendingNested) pending.push(pendingNested);
-  if (multiParameterAttributes) {
-    executeMultiparameterAssignment(
-      this as any,
-      extractMultiparameterCallstack(multiParameterAttributes).multiparams,
-    );
+  if (nestedParameterAttributes) {
+    const nested = nestedParameterAttributes;
+    pending = assignAfter(pending, () => assignNestedParameterAttributes(this, nested));
   }
-  if (pending.length > 0) return Promise.all(pending).then(() => undefined);
+  if (multiParameterAttributes) {
+    const multi = extractMultiparameterCallstack(multiParameterAttributes).multiparams;
+    pending = assignAfter(pending, () => executeMultiparameterAssignment(this as any, multi));
+  }
+  return pending;
+}
+
+/**
+ * Run one step of Rails' `each` over the assignment list: inline when nothing
+ * is outstanding, chained behind `pending` when a previous step is still
+ * running. Rails' `_assign_attributes` (attribute_assignment.rb:9-23) is a plain
+ * `each`, so a step that reaches DB I/O — a displacing `#{name}_attributes=`
+ * running `load_target` / `remove_target!` (has_one_association.rb:59-69) —
+ * finishes before the next key is assigned. Chaining is how a JS caller that
+ * cannot block between iterations keeps that order; without it two displacing
+ * keys in one hash would issue their writes concurrently.
+ */
+function assignAfter(
+  pending: Promise<void> | undefined,
+  step: () => Promise<void> | void,
+): Promise<void> | undefined {
+  if (pending) return pending.then(() => step());
+  const started = step();
+  return started ?? undefined;
 }
 
 /**
@@ -1212,12 +1228,11 @@ function assignNestedParameterAttributes(
   self: AttributeIO,
   pairs: Record<string, unknown>,
 ): Promise<void> | void {
-  const pending: Promise<void>[] = [];
+  let pending: Promise<void> | undefined;
   for (const [k, v] of Object.entries(pairs)) {
-    const assigned = _assignAttribute(self, k, v);
-    if (assigned) pending.push(assigned);
+    pending = assignAfter(pending, () => _assignAttribute(self, k, v));
   }
-  if (pending.length > 0) return Promise.all(pending).then(() => undefined);
+  return pending;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -1095,22 +1095,6 @@ export function _reapplyNestedAttrSetters(
 }
 
 /**
- * The generated `set#{Name}Attributes` writer for a nested-attributes key
- * (`shipAttributes`), or undefined when `key` names no such association.
- */
-function nestedAttributesWriter(
-  self: AttributeIO,
-  key: string,
-): ((value: unknown) => Promise<void> | void) | undefined {
-  const configs = (self as any).constructor?._nestedAttributeConfigs as
-    | { associationName: string }[]
-    | undefined;
-  if (!configs?.some((c) => `${c.associationName}Attributes` === key)) return undefined;
-  const writer = (self as any)[`set${camelize(key, true)}`];
-  return typeof writer === "function" ? writer : undefined;
-}
-
-/**
  * Mirrors Rails' `_assign_attribute` (ActiveModel
  * attribute_assignment.rb:67-75): dispatch through the public setter when one
  * exists (store accessors write to the store hash, not a standalone attribute
@@ -1119,16 +1103,21 @@ function nestedAttributesWriter(
  * Rails lets setter exceptions propagate raw; ours additionally wraps them in
  * AttributeAssignmentError with the offending key/value for debugging. (That
  * wrapping is stricter than Rails but longstanding.)
+ *
+ * A `#{name}_attributes=` key dispatches to `set#{Name}Attributes`
+ * (nested-attributes.ts), which answers a promise when the assignment displaces
+ * a record and so owes Rails' inline `remove_target!`
+ * (has_one_association.rb:69) a write; that promise is returned rather than
+ * dropped.
  */
 function _assignAttribute(self: AttributeIO, key: string, value: unknown): Promise<void> | void {
   try {
-    // Rails' `public_send("#{k}=")` reaches `#{name}_attributes=` here; ours is
-    // the awaitable `set#{Name}Attributes` method (nested-attributes.ts), which
-    // answers a promise only when the assignment displaces a record and so owes
-    // Rails' inline `remove_target!` (has_one_association.rb:69) a write. Hand
-    // that promise back to the caller rather than dropping it.
-    const nestedWriter = nestedAttributesWriter(self, key);
-    if (nestedWriter) return nestedWriter.call(self, value);
+    const configs = (self as any).constructor?._nestedAttributeConfigs as
+      | { associationName: string }[]
+      | undefined;
+    if (configs?.some((c) => `${c.associationName}Attributes` === key)) {
+      return (self as any)[`set${camelize(key, true)}`](value) as Promise<void> | void;
+    }
     const setter = findPrototypeSetter(self, key);
     if (setter) {
       setter.call(self, value);
@@ -1159,6 +1148,11 @@ function _assignAttribute(self: AttributeIO, key: string, value: unknown): Promi
  * assigns the nested hashes only after the scalar pass (:21), so a nested
  * writer's `reject_if` / the built record's callbacks observe an owner whose
  * own attributes are already set. Nested runs before multiparameter (:21-22).
+ *
+ * Rails returns nil; this returns a promise when one of the assignments was a
+ * displacing `#{name}_attributes=` (see `_assignAttribute`), which Rails runs
+ * inline and JS cannot. Callers free to ignore the nil are equally free to
+ * ignore the promise.
  */
 export function assignAttributes(
   this: AttributeIO,
@@ -1173,7 +1167,6 @@ export function assignAttributes(
 
   let multiParameterAttributes: Record<string, unknown> | null = null;
   let nestedParameterAttributes: Record<string, unknown> | null = null;
-  // Assignments still owing DB I/O — see the `pendingNested` comment below.
   const pending: Promise<void>[] = [];
 
   for (const [key, value] of Object.entries(attrs)) {
@@ -1187,10 +1180,6 @@ export function assignAttributes(
     }
   }
 
-  // A nested assignment that displaces a record owes Rails' inline
-  // `remove_target!` a write, so it answers a promise; hand it to the caller.
-  // Rails' `assign_attributes` returns nil and every synchronous caller here
-  // still may ignore it, exactly as it ignores the nil.
   const pendingNested = nestedParameterAttributes
     ? assignNestedParameterAttributes(this, nestedParameterAttributes)
     : undefined;

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -667,11 +667,10 @@ function assignUpdateAttribute(self: any, key: string, value: unknown): Promise<
     | { associationName: string }[]
     | undefined;
   if (configs?.some((c) => `${c.associationName}Attributes` === key)) {
-    // The awaitable writer, for the same reason `#{singular}Ids` goes through
-    // `idsWriter` below: Rails' `#{name}_attributes=` runs `load_target` and
-    // `remove_target!` inline (has_one_association.rb:59-69), and `#update` is
-    // async, so it can await what the property setter refuses
-    // (`NestedAttributesDisplacementError`).
+    // The nested-attributes writer, for the same reason `#{singular}Ids` goes
+    // through `idsWriter` below: Rails' `#{name}_attributes=` runs `load_target`
+    // and `remove_target!` inline (has_one_association.rb:59-69), and `#update`
+    // is async, so it awaits them here.
     return self[`set${camelize(key, true)}`](value) as Promise<void>;
   }
   // Rails' #update → assign_attributes dispatches `id` through `public_send("id=")`,
@@ -1056,7 +1055,7 @@ function findPrototypeSetter(instance: object, key: string): ((v: unknown) => vo
 }
 
 /**
- * Re-dispatch any `*Attributes=` nested attribute setter keys that the Base
+ * Re-dispatch any `*Attributes` nested attribute keys that the Base
  * constructor wrote as plain attribute values (via `writeAttribute`) rather
  * than through the generated writer. Called by `create`/`createBang` after
  * construction so that `Model.create({commentsAttributes: [...]})` correctly
@@ -1068,9 +1067,12 @@ function findPrototypeSetter(instance: object, key: string): ((v: unknown) => vo
  * The name is the awaitable `set#{Name}Attributes` writer rather than the
  * `#{name}Attributes=` property setter: it is the one that reproduces Rails'
  * inline timing for the assignments that need I/O, and a JS property setter
- * cannot await. Since a constructor cannot await either, the returned promise
- * is parked and drained where the other deferred nested-attributes work is
- * drained — `save` (nested-attributes.ts:184).
+ * cannot await. The writer answers a promise only when the assignment owes DB
+ * I/O, which a record under construction cannot: it is new, so its has_one never
+ * queries (`find_target?` is false) and holds no loaded target. Should one ever
+ * arrive, a constructor cannot await it either, so it is parked and drained
+ * where the other deferred nested-attributes work is drained — `save`
+ * (nested-attributes.ts:182).
  */
 export function _reapplyNestedAttrSetters(
   ctor: PersistenceHost,
@@ -1083,12 +1085,29 @@ export function _reapplyNestedAttrSetters(
     if (own?.value instanceof Set) {
       for (const k of own.value as Set<string>) {
         if (Object.prototype.hasOwnProperty.call(attrs, k)) {
-          parkNestedReaderLoad(record, record[`set${camelize(k, true)}`](attrs[k]));
+          const pending = record[`set${camelize(k, true)}`](attrs[k]);
+          if (pending) parkNestedReaderLoad(record, pending);
         }
       }
     }
     cls = Object.getPrototypeOf(cls);
   }
+}
+
+/**
+ * The generated `set#{Name}Attributes` writer for a nested-attributes key
+ * (`shipAttributes`), or undefined when `key` names no such association.
+ */
+function nestedAttributesWriter(
+  self: AttributeIO,
+  key: string,
+): ((value: unknown) => Promise<void> | void) | undefined {
+  const configs = (self as any).constructor?._nestedAttributeConfigs as
+    | { associationName: string }[]
+    | undefined;
+  if (!configs?.some((c) => `${c.associationName}Attributes` === key)) return undefined;
+  const writer = (self as any)[`set${camelize(key, true)}`];
+  return typeof writer === "function" ? writer : undefined;
 }
 
 /**
@@ -1101,8 +1120,15 @@ export function _reapplyNestedAttrSetters(
  * AttributeAssignmentError with the offending key/value for debugging. (That
  * wrapping is stricter than Rails but longstanding.)
  */
-function _assignAttribute(self: AttributeIO, key: string, value: unknown): void {
+function _assignAttribute(self: AttributeIO, key: string, value: unknown): Promise<void> | void {
   try {
+    // Rails' `public_send("#{k}=")` reaches `#{name}_attributes=` here; ours is
+    // the awaitable `set#{Name}Attributes` method (nested-attributes.ts), which
+    // answers a promise only when the assignment displaces a record and so owes
+    // Rails' inline `remove_target!` (has_one_association.rb:69) a write. Hand
+    // that promise back to the caller rather than dropping it.
+    const nestedWriter = nestedAttributesWriter(self, key);
+    if (nestedWriter) return nestedWriter.call(self, value);
     const setter = findPrototypeSetter(self, key);
     if (setter) {
       setter.call(self, value);
@@ -1134,7 +1160,10 @@ function _assignAttribute(self: AttributeIO, key: string, value: unknown): void 
  * writer's `reject_if` / the built record's callbacks observe an owner whose
  * own attributes are already set. Nested runs before multiparameter (:21-22).
  */
-export function assignAttributes(this: AttributeIO, attrs: Record<string, unknown>): void {
+export function assignAttributes(
+  this: AttributeIO,
+  attrs: Record<string, unknown>,
+): Promise<void> | void {
   assertHashAttributes(attrs);
   // Mirrors ActiveModel::AttributeAssignment#assign_attributes: bail before
   // sanitizing so a blank strong-params object (always un-permitted) is a
@@ -1144,6 +1173,8 @@ export function assignAttributes(this: AttributeIO, attrs: Record<string, unknow
 
   let multiParameterAttributes: Record<string, unknown> | null = null;
   let nestedParameterAttributes: Record<string, unknown> | null = null;
+  // Assignments still owing DB I/O — see the `pendingNested` comment below.
+  const pending: Promise<void>[] = [];
 
   for (const [key, value] of Object.entries(attrs)) {
     if (key.includes("(")) {
@@ -1151,19 +1182,26 @@ export function assignAttributes(this: AttributeIO, attrs: Record<string, unknow
     } else if (isNestedParameterHash(value)) {
       (nestedParameterAttributes ??= {})[key] = value;
     } else {
-      _assignAttribute(this, key, value);
+      const assigned = _assignAttribute(this, key, value);
+      if (assigned) pending.push(assigned);
     }
   }
 
-  if (nestedParameterAttributes) {
-    assignNestedParameterAttributes(this, nestedParameterAttributes);
-  }
+  // A nested assignment that displaces a record owes Rails' inline
+  // `remove_target!` a write, so it answers a promise; hand it to the caller.
+  // Rails' `assign_attributes` returns nil and every synchronous caller here
+  // still may ignore it, exactly as it ignores the nil.
+  const pendingNested = nestedParameterAttributes
+    ? assignNestedParameterAttributes(this, nestedParameterAttributes)
+    : undefined;
+  if (pendingNested) pending.push(pendingNested);
   if (multiParameterAttributes) {
     executeMultiparameterAssignment(
       this as any,
       extractMultiparameterCallstack(multiParameterAttributes).multiparams,
     );
   }
+  if (pending.length > 0) return Promise.all(pending).then(() => undefined);
 }
 
 /**
@@ -1181,10 +1219,16 @@ function isNestedParameterHash(value: unknown): boolean {
  * (attribute_assignment.rb:26-28) — assign any deferred nested attributes after
  * the base attributes have been set.
  */
-function assignNestedParameterAttributes(self: AttributeIO, pairs: Record<string, unknown>): void {
+function assignNestedParameterAttributes(
+  self: AttributeIO,
+  pairs: Record<string, unknown>,
+): Promise<void> | void {
+  const pending: Promise<void>[] = [];
   for (const [k, v] of Object.entries(pairs)) {
-    _assignAttribute(self, k, v);
+    const assigned = _assignAttribute(self, k, v);
+    if (assigned) pending.push(assigned);
   }
+  if (pending.length > 0) return Promise.all(pending).then(() => undefined);
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/array-utils.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/array-utils.json
@@ -1,0 +1,16 @@
+[
+  {
+    "package": "activesupport",
+    "tsFile": "array-utils.ts",
+    "rubyName": "in_groups",
+    "call": "div",
+    "reason": "Ruby `size.div number` is Integer#div, floor division as a METHOD (grouping.rb:66). JS has no method form for it — `Math.floor(array.length / n)` (array-utils.ts:94) is the whole of it — so the call cannot survive the port."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "array-utils.ts",
+    "rubyName": "in_groups_of",
+    "call": "new",
+    "reason": "Ruby's `Array.new(padding, fill_with)` (grouping.rb:38) builds the pad run; JS spells the same allocation as an array literal/`fill`, with no constructor call to match."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/hash-utils.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/hash-utils.json
@@ -1,0 +1,16 @@
+[
+  {
+    "package": "activesupport",
+    "tsFile": "hash-utils.ts",
+    "rubyName": "stringify_keys",
+    "call": "transform_keys",
+    "reason": "Rails routes both key casts through `transform_keys` (keys.rb:11), the Hash primitive JS lacks: trails builds the result with an `Object.keys` loop (hash-utils.ts:145-148). Converging needs a ported `transformKeys` for plain objects to delegate to — filed as its own work, not resolvable inside the measurement fix that surfaced it."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "hash-utils.ts",
+    "rubyName": "symbolize_keys",
+    "call": "transform_keys",
+    "reason": "Same as `stringify_keys` above: Rails' `transform_keys` (keys.rb:22) has no JS Hash counterpart, so trails inlines the key loop."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/module-ext.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/module-ext.json
@@ -1,0 +1,23 @@
+[
+  {
+    "package": "activesupport",
+    "tsFile": "module-ext.ts",
+    "rubyName": "delegate",
+    "call": "first",
+    "reason": "Part of the same omission: the `location: caller_locations(1, 1).first` argument Rails passes to `Delegation.generate` for error backtraces has no caller in trails' inline generation."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "module-ext.ts",
+    "rubyName": "delegate",
+    "call": "generate",
+    "reason": "Rails' `delegate` is a thin front for `ActiveSupport::Delegation.generate` (delegation.rb:280), the module trails has not ported; `delegate` reimplements the method generation inline instead. A real divergence, surfaced (not introduced) by bucketing `core_ext/module/delegation.rb` on module-ext.ts."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "module-ext.ts",
+    "rubyName": "mattr_accessor",
+    "call": "first",
+    "reason": "Rails passes `location: caller_locations(1, 1).first` to `mattr_reader`/`mattr_writer` (attribute_accessors.rb:66) so a raised NameError points at the declaring line. trails generates the accessors directly with no location plumbing."
+  }
+]

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -1348,6 +1348,12 @@ export interface RubyEntity {
  * A mapped file gets its own bucket instead, holding only the methods it
  * defines. Splits carry no `includes`/`extends`: the include-flattened methods
  * belong to the home bucket, not to every file the entity is reopened in.
+ *
+ * A reopening file declared unported (UNPORTED_FILES) is split for the same
+ * reason with the opposite outcome: only a file that owns a bucket can be
+ * excluded by `isSourceUnported`, which the caller consults per bucket. Without
+ * the split, `version.rb`'s `.version` would sit in `active_record.rb`'s bucket
+ * and read as missing however the exclusion is spelled.
  */
 export function splitOverriddenFileBuckets(entity: RubyEntity, pkg: string): RubyEntity[] {
   const home = entity.info.file || "unknown.rb";
@@ -1355,7 +1361,12 @@ export function splitOverriddenFileBuckets(entity: RubyEntity, pkg: string): Rub
   const splitFiles = new Set(
     allMethods
       .map((m) => m.file)
-      .filter((f): f is string => f !== undefined && f !== home && hasRubyFileTsOverride(f, pkg)),
+      .filter(
+        (f): f is string =>
+          f !== undefined &&
+          f !== home &&
+          (hasRubyFileTsOverride(f, pkg) || isSourceUnported(f, pkg)),
+      ),
   );
   if (splitFiles.size === 0) return [entity];
 

--- a/scripts/api-compare/conventions.ts
+++ b/scripts/api-compare/conventions.ts
@@ -164,6 +164,37 @@ export const RUBY_FILE_TS_OVERRIDES: Record<string, string> = {
   "activesupport:core_ext/time/calculations.rb": "time-ext.ts",
   "activesupport:core_ext/date/calculations.rb": "time-ext.ts",
   "activesupport:core_ext/date_time/calculations.rb": "time-ext.ts",
+  // The activesupport `core_ext/*` reopenings. Ruby splits one class's extensions
+  // across a file per concern and reopens the class in each; the extractor stamps
+  // the entity with whichever reopening came first (`object/blank.rb` for String,
+  // `object/duplicable.rb` for Hash, …), so every other file's methods are
+  // measured against a TS counterpart that defines none of them. trails collapses
+  // each class's core_ext surface into one module — `hash-utils.ts`,
+  // `string-utils.ts`, `module-ext.ts`, `array-utils.ts` — so the mapping is
+  // many Ruby files to the one TS file, the same shape as `inflector.ts` above.
+  "activesupport:core_ext/hash/keys.rb": "hash-utils.ts",
+  "activesupport:core_ext/hash/reverse_merge.rb": "hash-utils.ts",
+  "activesupport:core_ext/hash/deep_transform_values.rb": "hash-utils.ts",
+  "activesupport:core_ext/object/deep_dup.rb": "hash-utils.ts",
+  // `to_query` is defined on Object, Array and Hash by this one file; trails
+  // carries all three arms on the hash helpers.
+  "activesupport:core_ext/object/to_query.rb": "hash-utils.ts",
+  "activesupport:core_ext/string/filters.rb": "string-utils.ts",
+  "activesupport:core_ext/string/access.rb": "string-utils.ts",
+  "activesupport:core_ext/string/indent.rb": "string-utils.ts",
+  "activesupport:core_ext/string/strip.rb": "string-utils.ts",
+  "activesupport:core_ext/module/attr_internal.rb": "module-ext.ts",
+  "activesupport:core_ext/module/attribute_accessors.rb": "module-ext.ts",
+  "activesupport:core_ext/module/introspection.rb": "module-ext.ts",
+  "activesupport:core_ext/module/delegation.rb": "module-ext.ts",
+  "activesupport:core_ext/module/anonymous.rb": "module-ext.ts",
+  "activesupport:core_ext/array/grouping.rb": "array-utils.ts",
+  "activesupport:core_ext/array/extract.rb": "array-utils.ts",
+  "activesupport:core_ext/array/wrap.rb": "array-utils.ts",
+  // Range keeps Rails' per-concern file layout in trails, so these map by the
+  // default rule — but Range's home bucket is `core_ext/range/each.rb`, so the
+  // reopening still needs the entry.
+  "activesupport:core_ext/range/overlap.rb": "core-ext/range/overlap.ts",
 };
 
 /** The explicit TS mapping for `rubyFile` in `pkg`, or undefined when unmapped. */

--- a/scripts/api-compare/unported-files.test.ts
+++ b/scripts/api-compare/unported-files.test.ts
@@ -83,10 +83,17 @@ describe("isSourceUnported package scoping", () => {
   });
 
   it("keeps i18n's exclusions from leaking into other packages", () => {
-    // `middleware.rb`, `version.rb` and `gettext` all appear in other gems.
+    // `middleware.rb` and `gettext` all appear in other gems.
     expect(isSourceUnported("middleware.rb", "actiondispatch")).toBe(false);
-    expect(isSourceUnported("version.rb", "activesupport")).toBe(false);
     expect(isSourceUnported("gettext.rb", "activesupport")).toBe(false);
+  });
+
+  it("anchors a leading-slash pattern to a path boundary", () => {
+    // `version.rb` is excluded in every package (the version lives in
+    // package.json), but `gem_version.rb` is ported and owns real surface.
+    expect(isSourceUnported("version.rb", "activesupport")).toBe(true);
+    expect(isSourceUnported("action_pack/version.rb", "actionpackversion")).toBe(true);
+    expect(isSourceUnported("gem_version.rb", "actionpackversion")).toBe(false);
   });
 
   it("treats an absent pkg argument as 'any package' to preserve legacy callers", () => {

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -10,6 +10,9 @@
 //   `pattern`  — substring match against the Ruby SOURCE file path
 //                (from extract-ruby-api.rb, e.g. "promise.rb").
 //                Consumed by isSourceUnported() → api:compare.
+//                A leading "/" anchors it to a path boundary, exactly as in
+//                `testFile` below: "/version.rb" matches the top-level
+//                `version.rb` and `<dir>/version.rb`, but NOT `gem_version.rb`.
 //                Omit for test-only entries where the source IS being ported.
 //   `testFile` — substring match against the Ruby TEST file path
 //                (from extract-ruby-tests.rb, e.g. "message_pack_test.rb").
@@ -1272,13 +1275,6 @@ export const UNPORTED_FILES: UnportedFile[] = [
       "explicitly by callers.",
   },
   {
-    pattern: "version.rb",
-    package: "i18n",
-    reason:
-      "Gem version constant. trails carries the version in package.json — no " +
-      "TS counterpart by design.",
-  },
-  {
     testFile: "i18n_test.rb",
     tests: ["exposes its VERSION constant"],
     reason:
@@ -1351,11 +1347,28 @@ export const UNPORTED_FILES: UnportedFile[] = [
       "loadable. Ruby-only wire format, same as test_date_marshal.rb above; the " +
       "rest of the file stays counted.",
   },
+  {
+    pattern: "/version.rb",
+    reason:
+      "`Module.version` / `VERSION` returns the gem version as a Gem::Version " +
+      "(e.g. active_record/version.rb:8). Every trails package carries its " +
+      "version in package.json, which is the JS ecosystem's registry for it, so " +
+      "there is nothing to port. Anchored (leading `/`) so it cannot also " +
+      "exclude `gem_version.rb`, which IS ported and owns real surface " +
+      "(`ActionPack.gem_version`).",
+  },
 ];
 
 export function isSourceUnported(file: string, pkg?: string): boolean {
   return UNPORTED_FILES.some((e) => {
-    if (!e.pattern || !file.includes(e.pattern)) return false;
+    if (!e.pattern) return false;
+    // A leading "/" anchors the pattern to a path boundary — same rule as
+    // `isTestFileUnported` below — so a basename entry cannot swallow a longer
+    // basename that ends with it (`version.rb` vs `gem_version.rb`).
+    const matched = e.pattern.startsWith("/")
+      ? file === e.pattern.slice(1) || file.includes(e.pattern)
+      : file.includes(e.pattern);
+    if (!matched) return false;
     // `package` only exists on the pattern-bearing variant of the union.
     const scope = "package" in e ? e.package : undefined;
     return scope === undefined || pkg === undefined || scope === pkg;


### PR DESCRIPTION
Bundle of two stories.

## 1. `delete-nested-attributes-deferred-displacement` (RFC 0087 §1)

`migrate-nested-attributes-assignments-to-awaitable-writer` (#6159) removed the
last caller of the generated `#{name}_attributes=` property setter, so this
deletes it. `set#{Name}Attributes` is now the only nested-attributes writer, and
it carries the Rails name under the settled trails shape for a Ruby `x=` that
must be async (CLAUDE.md).

Most of what the story lists as "deferred-displacement machinery" was already
gone on `main` — `detachDisplacedAtAssignment`, `parkDisplacedRemoval`,
`recordDisplacedRemovalFailure`, `awaitPendingDisplacedRemovals`,
`_pendingDisplacedRemovals`, `_displacedRemovalFailure`,
`prepareDetachDisplacedForSyncBuild` and `findThenDetachDisplaced` do not exist.
What was left, and what this deletes, is everything the *synchronous* setter
needed to survive without them:

- the `Object.defineProperty(prototype, attrName, { set })` arm of
  `generateAssociationWriter` (`nested-attributes.ts`);
- the `awaitable` parameter threaded through
  `assignNestedAttributesForOneToOneAssociation`, and with it
  `NestedAttributesDisplacementError` (`associations/errors.ts`) — the setter's
  refusal of a displacing assignment;
- `parkNestedReaderLoad` / `awaitPendingNestedReaderLoads` /
  `NestedReaderLoadHost` and the `save()` drain that emptied them: the reader
  load (`send(association_name)`, nested_attributes.rb:434) is now simply
  awaited where Rails reads it.

The unloaded displacement runs in Rails' order inside the writer —
`load_target` → `remove_target!` → `self.target = record`
(has_one_association.rb:59-84) — with no swap and nothing parked, which is what
`detachDisplacedThenSetNewRecord` already did on the awaitable arm.

`displacementNeedsAwait` stays. Its purpose changes and its JSDoc says so: it is
no longer "may the sync setter proceed" but "does this assignment owe DB I/O at
all". A nested assignment that displaces nothing is pure in-memory work and must
stay synchronous — that is what lets `new Pirate({ shipAttributes: {...} })`
build the ship inside the constructor, where Rails' `#{name}_attributes=` builds
it. So the writer returns `Promise<void> | void` rather than being `async`: a
raising `build_record` (the polymorphic `Cannot build association` arm,
nested_attributes.rb:451) still raises at the assignment expression instead of
rejecting a promise nobody awaits.

Two dispatch sites follow the writer:

- `_reapplyNestedAttrSetters` (`persistence.ts`) looks up
  `set#{Name}Attributes` instead of a prototype setter. A record under
  construction is new, so `find_target?` is false and no target is loaded —
  the writer's I/O arms are unreachable and the constructor stays synchronous.
- `_assignAttribute` routes a nested-attributes key to the writer (Rails'
  `public_send("#{k}=")`, attribute_assignment.rb:67-75) and hands back any
  promise, so `assignAttributes` returns `Promise<void> | void`. Callers that
  ignore it behave exactly as they did when Rails' `assign_attributes` returned
  `nil`. `_assign_attributes` and `assign_nested_parameter_attributes`
  (attribute_assignment.rb:9-23, 26-28) are plain `each` loops, so the steps run
  **sequentially**: a step that reaches DB I/O completes before the next key is
  assigned, and `assignAfter` chains the remaining steps behind it rather than
  letting two displacing keys in one hash issue their writes concurrently.
  Pinned by `finishes a displacing nested assignment before assigning the next
  key` (`nested-attributes.trails.test.ts`), which fails on a `Promise.all`
  version with `["parrots", "remove_target!:start"]`.

### Tests

- `has-one-sync-build-displacement.trails.test.ts`: the two "refuses a
  displacing assignment through the synchronous setter" guards are deleted (the
  contract is gone; the loaded and unloaded displacements are covered by the
  writer tests either side of them). "keeps the synchronous setter working when
  the assignment displaces nothing" becomes "keeps the writer synchronous when
  the assignment displaces nothing" and now asserts the writer answers
  `undefined` — the constructor-critical property.
- `nested-attributes-displaced-removal-failure.trails.test.ts`: the two parked
  removal guards are deleted; the three that pin the awaitable contract stay.
- Ported tests keep their names.
  `test_should_define_an_attribute_writer_method_for_the_association`
  (nested_attributes_test.rb:262, :463, :640) asserts the writer responds,
  which is what `assert_respond_to @pirate, :ship_attributes=` asserts.
  `test_limit_with_exceeding_records` (:976-981) goes back to
  `expect(...).toThrow` — Rails raises at the assignment expression and so does
  the writer, since a collection assignment does no I/O. The remaining
  collection call sites (`(pirate as any)[setter] = …`, computed and so missed
  by #6159's grep) move to the writer.

## 2. `api-compare-orphan-buckets-activesupport-core-ext-tail` (RFC 0072)

### `version.rb`

Resolved in every package at once. Two pieces, because either alone is inert:

- `isSourceUnported` gains the leading-`/` anchoring `isTestFileUnported`
  already had, so `pattern: "/version.rb"` matches `version.rb` and
  `<dir>/version.rb` but **not** `gem_version.rb`, which is ported and owns
  `ActionPack.gem_version`. Covered by a new unit test.
- `splitOverriddenFileBuckets` also splits a reopening file that is declared
  unported. The exclusion is consulted per bucket, so without the split
  `version.rb`'s `.version` sits in `active_record.rb`'s bucket and reads as
  missing however the pattern is spelled.

The i18n-scoped `version.rb` entry is deleted — the anchored global entry
subsumes it.

### core_ext buckets

`RUBY_FILE_TS_OVERRIDES` entries for the clusters whose trails home is
unambiguous: `core_ext/hash/{keys,reverse_merge,deep_transform_values}.rb` and
`core_ext/object/{to_query,deep_dup}.rb` → `hash-utils.ts`;
`core_ext/string/{filters,access,indent,strip}.rb` → `string-utils.ts`;
`core_ext/module/{attr_internal,attribute_accessors,introspection,delegation,anonymous}.rb`
→ `module-ext.ts`; `core_ext/array/{grouping,extract,wrap}.rb` →
`array-utils.ts`; `core_ext/range/overlap.rb` → `core-ext/range/overlap.ts`.

### Measurement deltas

| package | before | after |
| --- | --- | --- |
| activesupport | 918/2333 (39.3%) | 962/2324 (41.4%) |
| actionpackversion | 1/2 (50%) | 1/1 (100%) |
| activerecord | 6148/6148 | 6147/6147 |
| activemodel | 716/716 | 715/715 |
| rack | 474/490 | 473/489 |
| actionview | 993/2926 | 993/2925 |
| trailties | 480/1620 | 480/1619 |
| **overall** | **13151/17799 (73.9%)** | **13192/17784 (74.2%)** |

The single-method drops are `version.rb` leaving the denominator; in
activerecord, activemodel, rack, actionview and trailties it had been matching a
same-named TS member, so the numerator drops with it. Files 811/1053 → 829/1070.

Seven pre-existing call-mismatch rows surfaced with the new buckets (`Integer#div`,
`Array.new`, `transform_keys` ×2, `Delegation.generate`, `caller_locations(…).first`
×2). Added by hand through `serializeBaseline` with real reasons — no `--write`
reseed; `pnpm api:calls` and the reseed-drift check are both clean.

The remaining ~45 orphan files (the date/time conversions cluster, the Duration
cluster, and the genuinely-unported tail) are registered as
`api-compare-orphan-buckets-activesupport-core-ext-tail-2` with the full
inventory, per the story's split instruction.

## RFC 0068 Design §6

Updated in the tasks repo (`9ce376a46`): §6 and the changelog now record that
its refusal contract is retired here, and that `NestedAttributesDisplacementError`
and the `_pendingNestedReaderLoads` park/drain go with it.

## Size

641 LOC by the counted rule (326 insertions + 315 deletions), over the 500
ceiling. 315 of that is deletion and 55 is baseline JSON; the two stories share
no files, and the second one is already a split (the remaining ~45 orphan files
are registered as their own story). Flagging rather than assuming.

## Gates

`pnpm typecheck` ✓ · `pnpm lint` ✓ · `pnpm build` ✓ · 41 test files / 1353 tests
across the touched nested-attributes, has_one, persistence, autosave, HABTM and
`scripts/api-compare/` suites ✓ · `pnpm api:calls` OK (2384 baselined) ✓ ·
reseed-drift check clean ✓ · `pnpm api:extra --package activerecord` 0 novel ✓ ·
conventions doc up to date ✓ · api:compare deltas non-negative (table above) ✓

Closes-story: api-compare-orphan-buckets-activesupport-core-ext-tail
Closes-story: delete-nested-attributes-deferred-displacement
