### PR TITLE
refactor(activerecord): DatabaseTasks config views Base.configurations; PG overrides match the abstract signatures

### DIFF
--- a/packages/activerecord-cli/src/db-tasks.ts
+++ b/packages/activerecord-cli/src/db-tasks.ts
@@ -168,22 +168,19 @@ export async function dbSchemaDump(cwd: string, _args: string[]): Promise<number
   }
 
   const env = DatabaseConfigurations.currentEnv();
-  const configs = DatabaseTasks.configsFor(env);
-  if (configs.length === 0) {
+  if (DatabaseTasks.configsFor(env).length === 0) {
     console.error(`ar: no database configuration found for environment "${env}"`);
     return 1;
   }
   try {
-    // Mirrors Rails' `db:schema:dump` rake task (`task dump: :load_config`):
-    // no model/environment load — just dump each config's schema inside a
-    // temporary pool so the dumper has a live connection.
-    for (const config of configs) {
-      await DatabaseTasks.withTemporaryPool(config, async () => {
-        await DatabaseTasks.dumpSchema(config);
-        const filename = DatabaseTasks.schemaDumpPath(config);
-        if (filename != null) console.log(`Dumped schema to ${filename}`);
-      });
-    }
+    // databases.rake:449-455 — `task dump: :load_config` does no model or
+    // environment load, just `with_temporary_pool_for_each { dump_schema }`.
+    await DatabaseTasks.withTemporaryPoolForEach({ env }, async (pool) => {
+      const dbConfig = pool.dbConfig;
+      await DatabaseTasks.dumpSchema(dbConfig);
+      const filename = DatabaseTasks.schemaDumpPath(dbConfig);
+      if (filename != null) console.log(`Dumped schema to ${filename}`);
+    });
     return 0;
   } catch (err) {
     console.error(`ar: db:schema:dump failed — ${String(err)}`);

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -305,6 +305,18 @@ export interface AbstractAdapter {
     },
   ): Promise<[IndexDefinition, string | undefined, boolean]>;
   /**
+   * schema_statements.rb:1837. PostgreSQL returns `[sql, proc]` when a
+   * `:comment` is present (postgresql/schema_statements.rb:1046-1049), hence
+   * the union.
+   * @internal
+   */
+  addColumnForAlter(
+    tableName: string,
+    columnName: string,
+    type: ColumnType,
+    options?: ColumnOptions,
+  ): Promise<string | [string, () => Promise<void>]>;
+  /**
    * drift-ok: concrete adapters may return `undefined` (MySQL short-circuits
    * `ifNotExists` when the index already exists), so the declared return type
    * widens the SchemaStatements base, which always returns a definition.

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -2394,7 +2394,7 @@ export class SchemaStatements {
     columnName: string,
     type: ColumnType,
     options: ColumnOptions = {},
-  ): Promise<string> {
+  ): Promise<string | [string, () => Promise<void>]> {
     const td = this.createTableDefinition(tableName);
     const cd = td.newColumnDefinition(columnName, type, options);
     return this.schemaCreation.accept(new AddColumnDefinition(cd));
@@ -2446,7 +2446,10 @@ export class SchemaStatements {
   }
 
   /** @internal */
-  async addTimestampsForAlter(tableName: string, options: ColumnOptions = {}): Promise<string[]> {
+  async addTimestampsForAlter(
+    tableName: string,
+    options: ColumnOptions = {},
+  ): Promise<Array<string | [string, () => Promise<void>]>> {
     const opts: ColumnOptions = { ...options };
     if (opts.null == null) opts.null = false;
     if (!("precision" in opts) && (this as any).supportsDatetimeWithPrecision?.()) {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -4234,7 +4234,7 @@ export class PostgreSQLAdapter
   async addIndexOptions(
     tableName: string,
     columnName: string | string[],
-    options: Record<string, unknown> = {},
+    options: Parameters<AbstractAdapter["addIndexOptions"]>[2] = {},
   ): Promise<[AbstractIndexDefinition, string | undefined, boolean]> {
     const opts = { ...options };
     if (typeof opts.where === "string") {
@@ -4352,21 +4352,18 @@ export class PostgreSQLAdapter
   async addColumnForAlter(
     tableName: string,
     columnName: string,
-    type: string,
-    options: Record<string, unknown> = {},
-  ): Promise<unknown> {
-    const col = this.createTableDefinition(tableName).newColumnDefinition(
-      columnName,
-      type,
-      options,
-    );
-    const sql = `ADD COLUMN ${await this.schemaCreation.accept(col)}`;
-    return "comment" in options
-      ? [
-          sql,
-          () => this.changeColumnComment(tableName, columnName, options.comment as string | null),
-        ]
-      : sql;
+    type: ColumnType,
+    options: ColumnOptions = {},
+  ): Promise<string | [string, () => Promise<void>]> {
+    // postgresql/schema_statements.rb:1046-1049 — `return super unless
+    // options.key?(:comment)`, else `[super, Proc.new { change_column_comment }]`.
+    if (!("comment" in options)) {
+      return super.addColumnForAlter(tableName, columnName, type, options);
+    }
+    return [
+      (await super.addColumnForAlter(tableName, columnName, type, options)) as string,
+      () => this.changeColumnComment(tableName, columnName, options.comment ?? null),
+    ];
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -3,12 +3,10 @@ import { Nodes } from "@blazetrails/arel";
 import { singularize, getCrypto } from "@blazetrails/activesupport";
 import { SchemaStatements as AbstractSchemaStatements } from "../abstract/schema-statements.js";
 import {
-  AlterTable,
   ChangeColumnDefinition,
   ChangeColumnDefaultDefinition,
   CheckConstraintDefinition,
   ForeignKeyDefinition,
-  TableDefinition as AbstractTableDefinition,
   type AddForeignKeyOptions,
   type ForeignKeyLookupOptions,
   type ColumnOptions,
@@ -62,7 +60,7 @@ function toS(value: unknown): string {
  * Only the members PG adds beyond `AbstractSchemaStatements` are listed: the
  * rest already reach `this` through the base class, and merging a second
  * declaration for them would collide with it — `PostgreSQLAdapter` narrows many
- * (`adapterName` to `AdapterName`, `addColumnForAlter` to `ColumnType`), which is
+ * (`adapterName` to `AdapterName`, `createAlterTable` to `PgAlterTable`), which is
  * legal on a class and is what Ruby's untyped override translates to, but
  * declaration merging demands identical types. `getDatabaseVersion` is the one
  * exception: a declaration-only `declare` field in the class body does outrank
@@ -75,9 +73,7 @@ function toS(value: unknown): string {
  * (TS2610). A real accessor override here would shadow `PostgreSQLAdapter`'s own
  * `type_map` once `include()` installs the module on the prototype, so `columns`
  * keeps its cast.
- *
- * The two members restated in the body are the reverse case: own members
- * TypeScript does accept, narrowed from the generic adapter's. @internal
+ * @internal
  */
 export interface SchemaStatements
   extends
@@ -820,23 +816,6 @@ export class SchemaStatements extends AbstractSchemaStatements {
   // ---------------------------------------------------------------------------
   // Alter table
   // ---------------------------------------------------------------------------
-
-  // Route the schema-definition factories back through the adapter so that
-  // base SchemaStatements methods invoked here (e.g. `super.addColumn` →
-  // `buildAddColumnDefinition` → `createAlterTable` → `createTableDefinition`)
-  // build PG-specific definitions. Without these, `this` resolves to the
-  // generic base factories and PG column normalization (virtual → underlying
-  // type, etc.) is silently dropped.
-  override createTableDefinition(
-    name: string,
-    options: Record<string, unknown> = {},
-  ): AbstractTableDefinition {
-    return this.createTableDefinition(name, options);
-  }
-
-  override createAlterTable(name: string): AlterTable {
-    return this.createAlterTable(name);
-  }
 
   override async changeColumn(
     tableName: string,

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -1,4 +1,13 @@
-import { describe, it, expect, beforeEach, afterEach, vi, type MockInstance } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+  type MockInstance,
+} from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -14,6 +23,15 @@ import { adapterType, ambientPoolConfiguration } from "../test-adapter.js";
 import { inMemoryDb } from "../support/adapter-helper.js";
 import { fixtures } from "../test-fixtures.js";
 import { anonymousMigration } from "../test-helpers/anonymous-migration.js";
+
+// database_tasks_test.rb:476-485 — Rails saves and restores
+// `ActiveRecord::Base.configurations` around a stubbed set rather than clearing
+// it: `DatabaseTasks.database_configuration` is a view over that one registry,
+// which also holds the suite's own `arunit` config.
+let originalConfigurations: DatabaseConfigurations | null = null;
+beforeAll(() => {
+  originalConfigurations = DatabaseTasks.databaseConfiguration;
+});
 
 describe("DatabaseTasksCheckProtectedEnvironmentsTest", () => {
   // Rails: `if current_adapter?(:SQLite3Adapter) && !in_memory_db?`
@@ -70,7 +88,7 @@ describe("DatabaseTasksCheckProtectedEnvironmentsTest", () => {
 
         await cleanup.executeMutation("DROP TABLE IF EXISTS ar_internal_metadata");
         await cleanup.close();
-        DatabaseTasks.databaseConfiguration = null;
+        DatabaseTasks.databaseConfiguration = originalConfigurations;
         DatabaseTasks.clearRegisteredTasks();
         fs.rmSync(tmp, { recursive: true, force: true });
       }
@@ -116,7 +134,7 @@ describe("DatabaseTasksCheckProtectedEnvironmentsTest", () => {
       const cleanup = new BetterSQLite3Adapter(dbFile);
       await cleanup.executeMutation("DROP TABLE IF EXISTS schema_migrations");
       await cleanup.close();
-      DatabaseTasks.databaseConfiguration = null;
+      DatabaseTasks.databaseConfiguration = originalConfigurations;
       DatabaseTasks.clearRegisteredTasks();
       fs.rmSync(tmp, { recursive: true, force: true });
     }
@@ -184,7 +202,7 @@ describe("DatabaseTasksCheckProtectedEnvironmentsMultiDatabaseTest", () => {
       );
     } finally {
       Base.protectedEnvironments = protectedEnvironments;
-      DatabaseTasks.databaseConfiguration = null;
+      DatabaseTasks.databaseConfiguration = originalConfigurations;
       DatabaseTasks.clearRegisteredTasks();
       fs.rmSync(tmp, { recursive: true, force: true });
     }
@@ -382,7 +400,7 @@ describe("DatabaseTasksCreateAllTest", () => {
   });
   afterEach(() => {
     DatabaseTasks.clearRegisteredTasks();
-    DatabaseTasks.databaseConfiguration = null;
+    DatabaseTasks.databaseConfiguration = originalConfigurations;
     vi.restoreAllMocks();
   });
 
@@ -464,7 +482,7 @@ describe("DatabaseTasksCreateCurrentTest", () => {
   });
   afterEach(() => {
     DatabaseTasks.clearRegisteredTasks();
-    DatabaseTasks.databaseConfiguration = null;
+    DatabaseTasks.databaseConfiguration = originalConfigurations;
     DatabaseTasks.env = "development";
     vi.restoreAllMocks();
   });
@@ -509,12 +527,10 @@ describe("DatabaseTasksCreateCurrentTest", () => {
   });
   it("establishes connection for the given environments", async () => {
     await DatabaseTasks.createCurrent("development");
-    expect(establishSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        adapter: "abstract",
-        database: "dev-db",
-      }),
-    );
+    // database_tasks_test.rb:588,708 — `assert_called_with(Base,
+    // :establish_connection, [:development])`: the bare env name, resolved
+    // through `Base.configurations`.
+    expect(establishSpy).toHaveBeenCalledWith("development");
   });
 });
 
@@ -549,7 +565,7 @@ describe("DatabaseTasksCreateCurrentThreeTierTest", () => {
   });
   afterEach(() => {
     DatabaseTasks.clearRegisteredTasks();
-    DatabaseTasks.databaseConfiguration = null;
+    DatabaseTasks.databaseConfiguration = originalConfigurations;
     DatabaseTasks.env = "development";
     vi.restoreAllMocks();
   });
@@ -584,12 +600,10 @@ describe("DatabaseTasksCreateCurrentThreeTierTest", () => {
 
   it("establishes connection for the given environments config", async () => {
     await DatabaseTasks.createCurrent("development");
-    expect(establishSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        adapter: "abstract",
-        database: "dev-db",
-      }),
-    );
+    // database_tasks_test.rb:588,708 — `assert_called_with(Base,
+    // :establish_connection, [:development])`: the bare env name, resolved
+    // through `Base.configurations`.
+    expect(establishSpy).toHaveBeenCalledWith("development");
   });
 });
 
@@ -607,7 +621,7 @@ describe("DatabaseTasksDropAllTest", () => {
   });
   afterEach(() => {
     DatabaseTasks.clearRegisteredTasks();
-    DatabaseTasks.databaseConfiguration = null;
+    DatabaseTasks.databaseConfiguration = originalConfigurations;
     vi.restoreAllMocks();
   });
 
@@ -686,7 +700,7 @@ describe("DatabaseTasksDropCurrentTest", () => {
   });
   afterEach(() => {
     DatabaseTasks.clearRegisteredTasks();
-    DatabaseTasks.databaseConfiguration = null;
+    DatabaseTasks.databaseConfiguration = originalConfigurations;
     DatabaseTasks.env = "development";
   });
 
@@ -751,7 +765,7 @@ describe("DatabaseTasksDropCurrentThreeTierTest", () => {
   });
   afterEach(() => {
     DatabaseTasks.clearRegisteredTasks();
-    DatabaseTasks.databaseConfiguration = null;
+    DatabaseTasks.databaseConfiguration = originalConfigurations;
     DatabaseTasks.env = "development";
   });
 
@@ -886,7 +900,7 @@ function databaseTasksMigrationTestCase(): MigrationTestCase {
     stdoutSpy?.mockRestore();
     stdoutSpy = undefined;
     DatabaseTasks.registerMigrations([]);
-    DatabaseTasks.databaseConfiguration = null;
+    DatabaseTasks.databaseConfiguration = originalConfigurations;
     DatabaseTasks.clearRegisteredTasks();
     try {
       Base.removeConnection();
@@ -1105,7 +1119,7 @@ describe("DatabaseTasksMigrateErrorTest", () => {
       } catch {
         /* no pool */
       }
-      DatabaseTasks.databaseConfiguration = null;
+      DatabaseTasks.databaseConfiguration = originalConfigurations;
       DatabaseTasks.registerMigrations([]);
       DatabaseTasks.clearRegisteredTasks();
       fs.rmSync(tmp, { recursive: true, force: true });
@@ -1116,7 +1130,7 @@ describe("DatabaseTasksMigrateErrorTest", () => {
 describe("DatabaseTasksPurgeCurrentTest", () => {
   afterEach(() => {
     DatabaseTasks.clearRegisteredTasks();
-    DatabaseTasks.databaseConfiguration = null;
+    DatabaseTasks.databaseConfiguration = originalConfigurations;
     DatabaseTasks.env = "development";
   });
 
@@ -1139,7 +1153,7 @@ describe("DatabaseTasksPurgeCurrentTest", () => {
 describe("DatabaseTasksPurgeAllTest", () => {
   afterEach(() => {
     DatabaseTasks.clearRegisteredTasks();
-    DatabaseTasks.databaseConfiguration = null;
+    DatabaseTasks.databaseConfiguration = originalConfigurations;
   });
 
   it("purge all local configurations", async () => {
@@ -1161,7 +1175,7 @@ describe("DatabaseTasksPurgeAllTest", () => {
 describe("DatabaseTasksTruncateAllTest", () => {
   afterEach(() => {
     DatabaseTasks.clearRegisteredTasks();
-    DatabaseTasks.databaseConfiguration = null;
+    DatabaseTasks.databaseConfiguration = originalConfigurations;
     DatabaseTasks.env = "development";
   });
 
@@ -1193,7 +1207,7 @@ describe("DatabaseTasksTruncateAllWithMultipleDatabasesTest", () => {
   });
   afterEach(() => {
     DatabaseTasks.clearRegisteredTasks();
-    DatabaseTasks.databaseConfiguration = null;
+    DatabaseTasks.databaseConfiguration = originalConfigurations;
     DatabaseTasks.env = "development";
   });
 
@@ -1249,7 +1263,7 @@ describe("DatabaseTasksTruncateAllWithMultipleDatabasesTest", () => {
 describe("DatabaseTasksCharsetTest", () => {
   afterEach(() => {
     DatabaseTasks.clearRegisteredTasks();
-    DatabaseTasks.databaseConfiguration = null;
+    DatabaseTasks.databaseConfiguration = originalConfigurations;
     DatabaseTasks.env = "development";
   });
 
@@ -1269,7 +1283,7 @@ describe("DatabaseTasksCharsetTest", () => {
 describe("DatabaseTasksCollationTest", () => {
   afterEach(() => {
     DatabaseTasks.clearRegisteredTasks();
-    DatabaseTasks.databaseConfiguration = null;
+    DatabaseTasks.databaseConfiguration = originalConfigurations;
     DatabaseTasks.env = "development";
   });
 

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -5,7 +5,11 @@
  */
 
 import { DatabaseConfig } from "../database-configurations/database-config.js";
-import { DatabaseConfigurations } from "../database-configurations.js";
+import {
+  DatabaseConfigurations,
+  configurationsStore,
+  setConfigurationsStore,
+} from "../database-configurations.js";
 import { ProtectedEnvironmentError } from "../migration.js";
 import type { ConnectionPool } from "../connection-adapters/abstract/connection-pool.js";
 import {
@@ -71,7 +75,20 @@ export class DatabaseTasks {
   static get name(): string {
     return "primary";
   }
-  static databaseConfiguration: DatabaseConfigurations | null = null;
+  // Rails' `attr_accessor :database_configuration` (database_tasks.rb:61) is an
+  // *input* to `ActiveRecord::Base.configurations`, never a rival store: every
+  // task-side reader goes through `Base.configurations.configs_for`
+  // (database_tasks.rb:514,517,552). So this reads and writes the one
+  // `@@configurations` registry (core.rb:71-79) that `Base.configurations`
+  // backs on to, rather than a second global that can drift out of step.
+  static get databaseConfiguration(): DatabaseConfigurations | null {
+    return configurationsStore();
+  }
+
+  static set databaseConfiguration(value: DatabaseConfigurations | null) {
+    setConfigurationsStore(value ?? DatabaseConfigurations.fromEnv({}));
+  }
+
   static dbDir: string = "db";
   private static _migrationsPaths: string[] = ["db/migrate"];
 
@@ -216,7 +233,6 @@ export class DatabaseTasks {
   }
 
   static async createAll(): Promise<void> {
-    if (!this.databaseConfiguration) return;
     // Rails: capture current db_config before iterating so we can restore it after.
     const { Base } = await import("../base.js");
     this._baseClass = Base;
@@ -244,20 +260,11 @@ export class DatabaseTasks {
         await this.create(config);
       }
     }
-    // Rails is `establish_connection(environment.to_sym)` (database_tasks.rb:653),
-    // which resolves through `Base.configurations`. trails cannot pass the bare env:
-    // `DatabaseTasks.databaseConfiguration` is a SEPARATE registry from
-    // `Base.configurations` (support/connection.ts:390-392 happens to set both, but
-    // callers reassign `databaseConfiguration` alone), so the env string would
-    // resolve against the wrong set of configs. findDbConfig mirrors what
-    // configurations.resolve(:env) does: forCurrentEnv configs first, then the first
-    // config for that env_name.
+    // database_tasks.rb:653 — `establish_connection(environment.to_sym)`, which
+    // resolves the bare env name through `Base.configurations`.
     const envName = this._normalizeEnv(environment);
-    const primaryConfig = this.databaseConfiguration?.findDbConfig(envName);
-    if (primaryConfig) {
-      const { Base } = await import("../base.js");
-      await Base.establishConnection(primaryConfig);
-    }
+    const { Base } = await import("../base.js");
+    await Base.establishConnection(envName);
   }
 
   static async drop(config: DatabaseConfig): Promise<void> {
@@ -280,7 +287,6 @@ export class DatabaseTasks {
   }
 
   static async dropAll(): Promise<void> {
-    if (!this.databaseConfiguration) return;
     for (const config of this.eachLocalConfiguration()) {
       await this.drop(config);
     }
@@ -520,7 +526,6 @@ export class DatabaseTasks {
   }
 
   static async purgeAll(): Promise<void> {
-    if (!this.databaseConfiguration) return;
     for (const config of this.eachLocalConfiguration()) {
       await this.purge(config);
     }
@@ -634,8 +639,8 @@ export class DatabaseTasks {
 
   /** @internal */
   static configsFor(environment: string): DatabaseConfig[] {
-    if (!this.databaseConfiguration) return [];
-    return this.databaseConfiguration.configsFor({ envName: environment });
+    // database_tasks.rb:551-553 — `Base.configurations.configs_for(**options)`.
+    return configurationsStore().configsFor({ envName: environment });
   }
 
   private static _normalizeEnv(environment?: string): string {
@@ -645,9 +650,9 @@ export class DatabaseTasks {
 
   /** @internal */
   static eachLocalConfiguration(): DatabaseConfig[] {
-    if (!this.databaseConfiguration) return [];
     const result: DatabaseConfig[] = [];
-    for (const c of this.databaseConfiguration.configsFor()) {
+    // database_tasks.rb:599 — `configs_for.each`, i.e. Base.configurations.
+    for (const c of configurationsStore().configsFor()) {
       if (!c.database) continue;
       if (this._localDatabase(c)) {
         result.push(c);
@@ -1239,10 +1244,6 @@ export class DatabaseTasks {
     block: (pool: ConnectionPool) => Promise<void>,
   ): Promise<void> {
     env = this._normalizeEnv(env);
-    // Rails reads `ActiveRecord::Base.configurations` here
-    // (`database_tasks.rb:514,517`), not `DatabaseTasks.database_configuration`
-    // — the two are distinct globals in trails, and only the former follows an
-    // app that assigned `Base.configurations` directly.
     if (name != null) {
       const dbConfig = (await this.migrationClass())
         .configurations()
@@ -1484,9 +1485,8 @@ export function resolveConfiguration(configuration: unknown): DatabaseConfig {
   // DatabaseConfig instances don't need a configurations registry — return as-is.
   // Avoids constructing a new DatabaseConfigurations (which mutates the global singleton).
   if (configuration instanceof DatabaseConfig) return configuration;
-  const configs = DatabaseTasks.databaseConfiguration;
-  if (!configs) throw new Error("DatabaseTasks.databaseConfiguration is not set");
-  return configs.resolve(configuration);
+  // database_tasks.rb:555-557 — `Base.configurations.resolve(configuration)`.
+  return configurationsStore().resolve(configuration);
 }
 
 function _errorToS(error: unknown): string {

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -260,11 +260,10 @@ export class DatabaseTasks {
         await this.create(config);
       }
     }
-    // database_tasks.rb:653 — `establish_connection(environment.to_sym)`, which
-    // resolves the bare env name through `Base.configurations`.
+    // database_tasks.rb:173 — `migration_class.establish_connection(environment.to_sym)`,
+    // which resolves the bare env name through `Base.configurations`.
     const envName = this._normalizeEnv(environment);
-    const { Base } = await import("../base.js");
-    await Base.establishConnection(envName);
+    await (await this.migrationClass()).establishConnection(envName);
   }
 
   static async drop(config: DatabaseConfig): Promise<void> {

--- a/packages/activerecord/src/test-setup-dy.ts
+++ b/packages/activerecord/src/test-setup-dy.ts
@@ -117,7 +117,3 @@ await recordBootLaidTables(await Base.leaseConnection());
 // after the canonical schema is in place.
 const { provisionSecondDatabase } = await import("./support/setup-second-pool.js");
 await provisionSecondDatabase();
-
-// Clear DatabaseTasks global state so database-tasks.test.ts starts from the
-// null invariant it expects and registers its own configurations per test.
-DatabaseTasks.databaseConfiguration = null;


### PR DESCRIPTION
Three RFC 0051 convergence stories.

**One config store.** `DatabaseTasks.databaseConfiguration` was a second global beside `Base.configurations`, so whether a task-side reader saw your config depended on which one you assigned. Rails has one: `database_tasks.rb:514,517` (`with_temporary_pool_for_each`), `:552` (`configs_for`), `:556` (`resolve_configuration`) all go through `Base.configurations`. `databaseConfiguration` becomes a view over that registry; `configsFor`, `eachLocalConfiguration` and `resolveConfiguration` resolve through it; the `create_all`/`drop_all`/`purge_all` null guards Rails has no counterpart for are gone; `createCurrent` establishes the bare env name (`database_tasks.rb:653`, asserted at `database_tasks_test.rb:588,708`).

`activerecord-cli`'s `dbSchemaDump` goes back to `withTemporaryPoolForEach` (`databases.rake:449-455`) — the explicit `configsFor` + `withTemporaryPool` loop from #6162 and the comment explaining the two globals are both deleted. Test resets save and restore the configurations the way `database_tasks_test.rb:476-485` does, since clearing now clears the suite's own `arunit` config too.

**PG overrides no longer widen.** `addColumnForAlter` and `addIndexOptions` carried `string` / `Record<string, unknown>` / `Promise<unknown>` where the abstract has `ColumnType` / `ColumnOptions`; both now carry the abstract signature, and `addColumnForAlter` defers to `super` the way `postgresql/schema_statements.rb:1046-1049` does instead of reimplementing the body. The abstract's return type is the `string | [string, proc]` union PG actually produces.

**Self-recursive stubs deleted.** `createTableDefinition` / `createAlterTable` in `postgresql/schema-statements-class.ts` called themselves; they were dead only because `include()` prefers class-body methods, so the adapter's own factories (`postgresql-adapter.ts:4257,4266`) were on the prototype. Rails has no counterpart. Deleting them typechecks as-is — no `Pick` entry needed, since adding one collides with the inherited declaration.

Closes-story: database-tasks-config-is-a-second-store-beside-base-configurations
Closes-story: pg-overrides-widen-abstract-schema-statement-signatures
Closes-story: pg-schema-statements-self-recursive-factory-stubs
