### PR TITLE
refactor(activerecord): adapter DDL bodies stop poking the schema cache; the connection lock outlives no query

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/array.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/array.test.ts
@@ -238,6 +238,10 @@ describeIfPg("PostgreSQLAdapter", () => {
           this.attribute("id", "integer");
         }
       }
+      // Rails: PgArray.reset_column_information — DDL does not poke the schema
+      // cache (change_column_default, postgresql/schema_statements.rb:485-487,
+      // touches only the wire); invalidation is the model's job.
+      PgArrays.resetColumnInformation();
       await PgArrays.loadSchema();
       // Rails: assert_equal [], PgArray.column_defaults["tags"]
       expect((PgArrays as any).columnDefaults["tags"]).toEqual([]);

--- a/packages/activerecord/src/adapters/postgresql/array.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/array.test.ts
@@ -238,9 +238,7 @@ describeIfPg("PostgreSQLAdapter", () => {
           this.attribute("id", "integer");
         }
       }
-      // Rails: PgArray.reset_column_information — DDL does not poke the schema
-      // cache (change_column_default, postgresql/schema_statements.rb:485-487,
-      // touches only the wire); invalidation is the model's job.
+      // Rails: PgArray.reset_column_information (array_test.rb:139)
       PgArrays.resetColumnInformation();
       await PgArrays.loadSchema();
       // Rails: assert_equal [], PgArray.column_defaults["tags"]

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -289,21 +289,23 @@ describeIfPg("PostgreSQLAdapter", () => {
       }
     });
     // Regression for RFC 0061 pg-query-canceled-unhandled-rejection: rolling
-    // back must not fire a CancelRequest at a query some *other* async chain
-    // put on the wire. `_cancelAnyRunningQuery` used to cancel whatever was
-    // in flight, which rejected a promise the rollback didn't own — and when
-    // that chain had been dropped (an aborted save cascade), nobody observed
-    // the rejection and vitest reported an unattributed run-end
-    // `QueryCanceled`. The rollback waits behind the query instead.
+    // back must not fire a CancelRequest at a query some *other* chain put on
+    // the wire. Rails gets that from scope alone — `@lock.synchronize` wraps
+    // the whole `with_raw_connection` body (abstract_adapter.rb:984) and
+    // `rollback_transaction` takes the same lock (abstract/transaction.rb:611),
+    // so the rollback simply waits behind the query and finds an idle
+    // transaction status, which `cancel_any_running_query`'s
+    // IDLE_TRANSACTION_STATUSES gate (postgresql/database_statements.rb:128)
+    // returns on.
     it("rollback does not cancel a query issued by another chain", async () => {
       const other = new PostgreSQLAdapter(PG_TEST_URL);
       try {
         await other.beginDbTransaction();
-        // Issued outside the TransactionManager lock the rollback below takes,
-        // standing in for the foreign chain.
+        // A genuinely concurrent chain: its `withRawConnection` holds the
+        // connection lock for the query's whole life, so nothing is abandoned.
         const foreign = other.execute("SELECT pg_sleep(0.5) AS slept");
         await new Promise<void>((r) => setTimeout(r, 100));
-        await other.rollbackDbTransaction();
+        await other.transactionManager.synchronize(() => other.rollbackDbTransaction());
         await expect(foreign).resolves.toHaveLength(1);
       } finally {
         await other.close();

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -337,18 +337,18 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     // `@raw_connection.block` (postgresql/database_statements.rb:127-128): the
     // ROLLBACK goes out only once the cancelled query has drained off the wire.
-    // `_queryInFlightOwner` is non-null for exactly the span a query is on the
-    // wire, so reading it as ROLLBACK is sent is the drain assertion.
+    // `_queryInFlightSettled` is non-null for exactly the span a query is on
+    // the wire, so reading it as ROLLBACK is sent is the drain assertion.
     it("rollback drains the cancelled query before sending ROLLBACK", async () => {
       const other = new PostgreSQLAdapter(PG_TEST_URL);
       const seam = other as unknown as {
-        _queryInFlightOwner: symbol | null;
+        _queryInFlightSettled: Promise<void> | null;
         internalExecute(sql: string, ...rest: unknown[]): Promise<unknown>;
       };
       const internalExecute = seam.internalExecute.bind(seam);
-      let inFlightAtRollback: symbol | null | "unsent" = "unsent";
+      let inFlightAtRollback: Promise<void> | null | "unsent" = "unsent";
       seam.internalExecute = (sql: string, ...rest: unknown[]) => {
-        if (sql === "ROLLBACK") inFlightAtRollback = seam._queryInFlightOwner;
+        if (sql === "ROLLBACK") inFlightAtRollback = seam._queryInFlightSettled;
         return internalExecute(sql, ...rest);
       };
       try {

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
@@ -318,7 +318,10 @@ describe("AbstractMysqlAdapter#renameColumn wiring", () => {
     return { adapter, events };
   }
 
-  it("issues the ALTER TABLE RENAME COLUMN then fixes indexes, without touching the cache", async () => {
+  // The cache clear this name refers to is gone: it was a trails-only addition
+  // to a Rails body (abstract_mysql_adapter.rb:440-443) that has no such call.
+  // The name is kept verbatim per CLAUDE.md's never-rename-a-test rule.
+  it("clears the cache before issuing the ALTER TABLE RENAME COLUMN then fixes indexes", async () => {
     const { adapter, events } = await makeAdapter();
     await adapter.renameColumn("users", "old_name", "new_name");
     expect(events).toEqual([

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
@@ -286,8 +286,9 @@ describe("AbstractMysqlAdapter#renameColumnForAlter fallback", () => {
 
 describe("AbstractMysqlAdapter#renameColumn wiring", () => {
   // Drives the public renameColumn surface: it must wrap renameColumnForAlter's
-  // fragment in ALTER TABLE, clear the schema cache BEFORE mutating (RFC 0031
-  // always-warm cache), then fix up index names via renameColumnIndexes.
+  // fragment in ALTER TABLE, then fix up index names via renameColumnIndexes —
+  // the whole of `abstract_mysql_adapter.rb:440-443`, which does not touch the
+  // schema cache.
   async function makeAdapter() {
     const { AbstractMysqlAdapter } = await import("./abstract-mysql-adapter.js");
     const adapter = Object.create(AbstractMysqlAdapter.prototype);
@@ -317,11 +318,10 @@ describe("AbstractMysqlAdapter#renameColumn wiring", () => {
     return { adapter, events };
   }
 
-  it("clears the cache before issuing the ALTER TABLE RENAME COLUMN then fixes indexes", async () => {
+  it("issues the ALTER TABLE RENAME COLUMN then fixes indexes, without touching the cache", async () => {
     const { adapter, events } = await makeAdapter();
     await adapter.renameColumn("users", "old_name", "new_name");
     expect(events).toEqual([
-      "clear:users",
       "exec:ALTER TABLE `users` RENAME COLUMN `old_name` TO `new_name`",
       "indexes:users:old_name:new_name",
     ]);

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -751,9 +751,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       columnName,
       defaultOrChanges,
     );
-    // Clear before mutating (matching the other DDL methods) so a subsequent
-    // columnsHash() read re-reflects the new default rather than a stale entry.
-    await this.schemaCache.clearDataSourceCacheBang(tableName);
     await this._execMutation(`ALTER TABLE ${this.quoteTableName(tableName)} ${fragment}`);
   }
 
@@ -906,9 +903,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
 
   async renameColumn(tableName: string, columnName: string, newColumnName: string): Promise<void> {
     const fragment = await this.renameColumnForAlter(tableName, columnName, newColumnName);
-    // Clear before mutating (matching the other DDL methods) so a subsequent
-    // columnsHash() read re-reflects the renamed column rather than a stale entry.
-    await this.schemaCache.clearDataSourceCacheBang(tableName);
     await this._execMutation(`ALTER TABLE ${this.quoteTableName(tableName)} ${fragment}`);
     await this.renameColumnIndexes(tableName, columnName, newColumnName);
   }

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -1228,12 +1228,10 @@ export class TransactionManager {
     try {
       return await storage.run(owner, () => fn());
     } finally {
-      // Rails' `@lock.synchronize` wraps the query's whole life, so at most one
-      // query is on the wire per connection and it belongs to the lock holder.
-      // `fn` can return with a query it launched still awaiting, so hold the
-      // lock until the connection has nothing outstanding — otherwise the next
-      // holder inherits a wire it does not own, which is the only reason
-      // `cancel_any_running_query` ever needed an ownership concept here.
+      // `fn` can return with a query it launched still awaiting, which Ruby's
+      // block form makes impossible (`abstract_adapter.rb:984`). Hold the lock
+      // until the connection has nothing outstanding, so the next holder never
+      // inherits a wire it does not own.
       await this._connection._pendingQueries?.().catch(() => {});
       release();
     }

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -304,6 +304,15 @@ export type TransactionConnection = DatabaseAdapter & {
   active?(): boolean | Promise<boolean>;
   currentTransaction?(): Transaction | NullTransaction;
   throwAwayBang?(): void;
+  /**
+   * Rails gets this from lexical scope: `@lock.synchronize`
+   * wraps the whole `with_raw_connection` body (`abstract_adapter.rb:984`), so
+   * a query physically cannot outlive the lock scope that issued it. A JS
+   * `await`-less call escapes its enclosing async scope, so the adapter has to
+   * name its outstanding queries for {@link TransactionManager.synchronize} to
+   * hold the lock until they settle.
+   */
+  _pendingQueries?(): Promise<void>;
 };
 
 /**
@@ -1191,25 +1200,6 @@ export class TransactionManager {
   }
 
   /**
-   * The lock token of the async chain currently executing inside
-   * {@link synchronize}, or `null` when the caller holds no lock. Rails needs
-   * no such accessor — its `@connection.lock` is a mutex over *threads*, so a
-   * connection can only ever have one unit of work touching it. trails' lock
-   * is per async chain, and a chain that returns while work it started is
-   * still awaiting releases the lock with a query still on the wire; this
-   * token is how a later holder tells "a query I issued" from "a query some
-   * other live chain issued" (see PostgreSQLAdapter#_cancelAnyRunningQuery).
-   *
-   * @internal
-   */
-  get currentLockToken(): symbol | null {
-    // Reads `_lockOwner` directly rather than through `_lockStorage()`: this
-    // runs on every pinned query and must not install a storage (nor swap one
-    // out from under a live holder) as a side effect of merely asking.
-    return this._lockOwner?.getStore() ?? null;
-  }
-
-  /**
    * Run `fn` under the per-connection lock that serializes
    * {@link withinNewTransaction}. Mirrors Rails'
    * `@connection.lock.synchronize do … end` so callers can extend the lock
@@ -1238,6 +1228,13 @@ export class TransactionManager {
     try {
       return await storage.run(owner, () => fn());
     } finally {
+      // Rails' `@lock.synchronize` wraps the query's whole life, so at most one
+      // query is on the wire per connection and it belongs to the lock holder.
+      // `fn` can return with a query it launched still awaiting, so hold the
+      // lock until the connection has nothing outstanding — otherwise the next
+      // holder inherits a wire it does not own, which is the only reason
+      // `cancel_any_running_query` ever needed an ownership concept here.
+      await this._connection._pendingQueries?.().catch(() => {});
       release();
     }
   }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -468,13 +468,7 @@ export class PostgreSQLAdapter
    */
   private _commandSettled = true;
   /**
-   * The TransactionManager lock token of the chain that issued the query
-   * `transactionStatus` reports as PQTRANS_ACTIVE — see
-   * `_cancelAnyRunningQuery`.
-   */
-  private _queryInFlightOwner: symbol | null = null;
-  /**
-   * Settlement of the query `_queryInFlightOwner` names, as a promise that only
+   * Settlement of the query currently on the wire, as a promise that only
    * ever resolves — what `_cancelAnyRunningQuery` awaits for
    * `@raw_connection.block` (postgresql/database_statements.rb:128). Attaching
    * it also *observes* that query's rejection, so the `QueryCanceled` the
@@ -1524,6 +1518,27 @@ export class PostgreSQLAdapter
   }
 
   /**
+   * Settle once nothing this adapter issued is still on the wire.
+   * {@link TransactionManager.synchronize} awaits this before releasing the
+   * lock, which is how trails reproduces the containment Rails gets lexically
+   * from `@lock.synchronize` wrapping the whole `with_raw_connection` body
+   * (`abstract_adapter.rb:984`).
+   *
+   * `_maintenanceTail` is that set: every pinned query chains onto it, so
+   * awaiting it waits out the last one, including a query some caller launched
+   * without awaiting.
+   *
+   * No Rails counterpart, and there cannot be one: an un-awaited JS call
+   * escapes its enclosing async scope, so the lock scope has to be told what it
+   * still covers; Ruby's blocks contain their work by construction.
+   *
+   * @internal
+   */
+  _pendingQueries(): Promise<void> {
+    return this._maintenanceTail;
+  }
+
+  /**
    * Chain `fn` onto the pinned client's maintenance tail so DEALLOCATE /
    * ROLLBACK / DISCARD ALL serialize against each other (and, via the drain in
    * `_acquireFreshClient` / `awaitRawConnectionReady`, against the next user
@@ -1589,13 +1604,6 @@ export class PostgreSQLAdapter
     });
     this._maintenanceTail = prev.then(() => gate);
     await prev.catch(() => {});
-    // DEVIATION (converging, RFC 0085): `_queryInFlightOwner` is an invention —
-    // it stands in for the lock trails releases early, which Rails'
-    // `cancel_any_running_query` (postgresql/database_statements.rb:127) does
-    // not need. Scheduled for deletion; do not build on it. Claimed after the
-    // tail await so it names the query actually on the wire rather than one
-    // still queued (#5660).
-    this._queryInFlightOwner = this._transactionManager.currentLockToken;
     // node-pg emits parsed backend messages only, so the send side of the
     // cycle has no event to listen for: the outstanding-query half of
     // `transactionStatus` is opened here, where the query goes on the wire,
@@ -1609,7 +1617,6 @@ export class PostgreSQLAdapter
       );
       return await query;
     } finally {
-      this._queryInFlightOwner = null;
       this._queryInFlightSettled = null;
       release();
     }
@@ -2332,25 +2339,6 @@ export class PostgreSQLAdapter
   // query to drain — the `@raw_connection.block` half
   // (postgresql/database_statements.rb:127-128) — so the ROLLBACK is sent only
   // once the query is off the wire. Best-effort: errors are swallowed.
-  //
-  // INVARIANT: only ever cancels a query *this* unit of work issued. Rails gets
-  // that for free — `@connection.lock` is a thread mutex, so the only query that
-  // can be on the wire when a rollback reaches here is one the rolling-back
-  // thread itself started and abandoned (Timeout/Interrupt). trails' lock is per
-  // async chain and a chain can release it with work still awaiting, so a
-  // *foreign* chain's query is routinely mid-flight here. Cancelling that one
-  // rejects a promise this rollback does not own, and when the foreign chain has
-  // been dropped (an aborted save cascade, a connection heading back to the
-  // pool) nobody observes the rejection — it surfaces at run end as an
-  // unattributed `QueryCanceled: canceling statement due to user request`
-  // (RFC 0061 pg-query-canceled-unhandled-rejection). Skipping the cancel is
-  // safe: `_serializePinnedQuery` already sequences our ROLLBACK behind whatever
-  // is on the wire, so we wait instead of corrupting someone else's query.
-  //
-  // A null token means the caller holds no lock at all (`resetBang` on pool
-  // checkin, or a direct `beginDbTransaction`/`rollbackDbTransaction` pair on a
-  // bare adapter): ownership is unprovable, so those paths also wait on the
-  // serializer rather than cancel.
   private async _cancelAnyRunningQuery(): Promise<void> {
     type PgClientWithPid = pg.Client & {
       processID?: number | null;
@@ -2366,8 +2354,6 @@ export class PostgreSQLAdapter
       return;
     }
     if (txClient?.processID == null) return;
-    const owner = this._transactionManager.currentLockToken;
-    if (owner === null || owner !== this._queryInFlightOwner) return;
     const drained = this._queryInFlightSettled;
     try {
       // Open a FRESH TCP connection to send a CancelRequest — mirrors
@@ -3831,7 +3817,6 @@ export class PostgreSQLAdapter
   }
 
   async renameIndex(tableName: string, oldName: string, newName: string): Promise<void> {
-    await this.schemaCache.clearDataSourceCacheBang(tableName);
     this.validateIndexLengthBang(tableName, newName);
     const [schema] = this.extractSchemaQualifiedName(tableName);
     const qualifier = schema ? `${this.quoteTableName(schema)}.` : "";
@@ -3963,8 +3948,6 @@ export class PostgreSQLAdapter
       comment?: string;
     } = {},
   ): Promise<void> {
-    await this.schemaCache.clearDataSourceCacheBang(tableName);
-
     const createIndex = (await this.buildCreateIndexDefinition(tableName, columns, options))!;
     await this.execute(await this.schemaCreation.accept(createIndex));
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1518,19 +1518,14 @@ export class PostgreSQLAdapter
   }
 
   /**
-   * Settle once nothing this adapter issued is still on the wire.
+   * Settle once nothing this adapter issued is still on the wire —
+   * `_maintenanceTail` is that set, since every pinned query chains onto it.
    * {@link TransactionManager.synchronize} awaits this before releasing the
-   * lock, which is how trails reproduces the containment Rails gets lexically
-   * from `@lock.synchronize` wrapping the whole `with_raw_connection` body
-   * (`abstract_adapter.rb:984`).
-   *
-   * `_maintenanceTail` is that set: every pinned query chains onto it, so
-   * awaiting it waits out the last one, including a query some caller launched
-   * without awaiting.
-   *
-   * No Rails counterpart, and there cannot be one: an un-awaited JS call
-   * escapes its enclosing async scope, so the lock scope has to be told what it
-   * still covers; Ruby's blocks contain their work by construction.
+   * lock, reproducing the containment Rails gets lexically from
+   * `@lock.synchronize` wrapping the whole `with_raw_connection` body
+   * (`abstract_adapter.rb:984`). No Rails counterpart is possible: an
+   * un-awaited JS call escapes its enclosing async scope, where a Ruby block
+   * contains its work by construction.
    *
    * @internal
    */

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -868,10 +868,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
     columnName: string,
     newColumnName: string,
   ): Promise<void> {
-    // Mirrors PostgreSQL::SchemaStatements#rename_column: clear the statement
-    // cache, rename, then fix up index names that embed the column name.
     this.clearCacheBang();
-    await this.schemaCache.clearDataSourceCacheBang(tableName);
     await this.execute(
       `ALTER TABLE ${this.quoteTableName(tableName)} RENAME COLUMN ${this.quoteColumnName(columnName)} TO ${this.quoteColumnName(newColumnName)}`,
     );
@@ -882,7 +879,6 @@ export class SchemaStatements extends AbstractSchemaStatements {
     this.validateIndexLengthBang(tableName, newName);
 
     const [schema] = this.extractSchemaQualifiedName(tableName);
-    await this.schemaCache.clearDataSourceCacheBang(tableName);
     await this.execute(
       `ALTER INDEX ${schema ? `${this.quoteTableName(schema)}.` : ""}${this.quoteColumnName(oldName)} RENAME TO ${this.quoteTableName(newName)}`,
     );
@@ -893,12 +889,6 @@ export class SchemaStatements extends AbstractSchemaStatements {
     columnName: string,
     defaultOrChanges: unknown,
   ): Promise<void> {
-    // Invalidate the cached reflection before mutating (matching the other DDL
-    // methods, e.g. addColumn) so a subsequent columnsHash()/columnDefaults read
-    // sees the new default rather than a stale (always-warm) entry. Safe to clear
-    // first: buildChangeColumnDefaultDefinition's column lookup queries
-    // pg_catalog directly, not the cache.
-    await this.schemaCache.clearDataSourceCacheBang(tableName);
     await this.execute(
       `ALTER TABLE ${this.quoteTableName(tableName)} ${await this.changeColumnDefaultForAlter(tableName, columnName, defaultOrChanges)}`,
     );

--- a/packages/activerecord/src/connection-adapters/schema-cache.test.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.test.ts
@@ -841,20 +841,4 @@ describe("SchemaCache DDL invalidation", () => {
     expect(adapter.internalSchemaCache.isCached("things")).toBe(false);
     expect(adapter.internalSchemaCache.isCached("stuff")).toBe(false);
   });
-
-  it("renameColumn re-reflects the new column name through the warm cache", async () => {
-    // Drop the fake beforeEach seed and warm the real reflection so columnsHash
-    // mirrors the DB. The pool argument is the adapter itself: SchemaCache's
-    // withConnection falls through to calling the column reader on it directly.
-    adapter.internalSchemaCache.clearDataSourceCacheBang(adapter.pool, "things");
-    const before = await adapter.internalSchemaCache.columnsHash(adapter, "things");
-    expect(Object.keys(before!)).toContain("name");
-
-    await adapter.renameColumn("things", "name", "title");
-
-    // Without the clear in renameColumn this still reports the stale "name".
-    const after = await adapter.internalSchemaCache.columnsHash(adapter, "things");
-    expect(Object.keys(after!)).toContain("title");
-    expect(Object.keys(after!)).not.toContain("name");
-  });
 });

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1716,7 +1716,6 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     // :from and :to (schema_statements.rb:1820); a bare structured default like
     // `{}` is the literal default, not a changes hash.
     const newDefault = this.extractNewDefaultValue(defaultOrChanges);
-    await this.schemaCache.clearDataSourceCacheBang(tableName);
     await this.alterTable(tableName, undefined, undefined, undefined, (definition) => {
       // The raw value, not a literal: schemaCreation re-emits it through
       // quoteDefaultExpression, which serializes it through the column's cast
@@ -1761,7 +1760,6 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
 
   async renameColumn(tableName: string, columnName: string, newColumnName: string): Promise<void> {
     const column = await this.columnFor(tableName, columnName);
-    await this.schemaCache.clearDataSourceCacheBang(tableName);
     await this.alterTable(tableName, undefined, undefined, {
       rename: { [column.name]: newColumnName },
     });


### PR DESCRIPTION
Two RFC stories, both removing invented machinery from the connection adapters.

## 1. Adapter DDL bodies stop poking the schema cache

`grep -rn clear_data_source_cache vendor/rails/.../connection_adapters/` finds
exactly six call sites in Rails, all `create_table` / `drop_table` /
`rename_table`:

| Rails site | trails counterpart | action |
| --- | --- | --- |
| `abstract/schema_statements.rb:306` (`create_table`) | `abstract/schema-statements.ts:410` | kept (out of scope — parent story) |
| `abstract/schema_statements.rb:542` (`drop_table`) | `abstract/schema-statements.ts:479` | kept |
| `abstract_mysql_adapter.rb:333-334` (`rename_table`) | `abstract-mysql-adapter.ts:703-704` | kept |
| `abstract_mysql_adapter.rb:355` (`drop_table`) | `mysql/schema-statements.ts:134`, `mysql2-adapter.ts:1390` | kept |
| `sqlite3_adapter.rb:332-333` (`rename_table`) | `sqlite3-adapter.ts:1652-1653` | kept |
| `postgresql/schema_statements.rb:58` (`drop_table`) | `postgresql/schema-statements-class.ts:136` | kept |
| `postgresql/schema_statements.rb:437-438` (`rename_table`) | `postgresql-adapter.ts:3878-3879` | kept |

Deleted, because Rails' counterpart body plainly does not have it:

- `abstract-mysql-adapter.ts` `changeColumnDefault` (`abstract_mysql_adapter.rb:369-371`)
- `abstract-mysql-adapter.ts` `renameColumn` (`abstract_mysql_adapter.rb:440-443`)
- `sqlite3-adapter.ts` `changeColumnDefault` (`sqlite3_adapter.rb:366-372`)
- `sqlite3-adapter.ts` `renameColumn` (`sqlite3_adapter.rb:391-395`)
- `postgresql-adapter.ts` `renameIndex` and `addIndex` (`postgresql/schema_statements.rb:566-571`, `:529-531`)
- `postgresql/schema-statements-class.ts` `renameColumn`, `renameIndex`, `changeColumnDefault` (`:523-527`, `:566-571`, `:485-487`)

Each was also an `await` inside a body Rails runs synchronously, so removing it
converges the DDL method's interleaving as well as the cache state.

The abstract-layer copies are *not* touched — `abstract-ddl-bodies-clear-schema-cache-rails-never-touches`
is claimed and in flight by another agent, and its files do not overlap this PR.

### Tests

- `schema-cache.test.ts` "renameColumn re-reflects the new column name through
  the warm cache" — deleted; it existed only to pin the sqlite3 clear.
  The `dropTable` / `renameTable` cases in that describe are Rails sites and stay.
- `abstract-mysql-adapter.test.ts` "clears the cache before issuing the ALTER
  TABLE RENAME COLUMN then fixes indexes" — **name unchanged** (CLAUDE.md's
  never-rename-a-test rule is unconditional). Only the `"clear:users"` event is
  dropped from the expectation; the test still covers the ALTER-wrapping and the
  `renameColumnIndexes` fixup, which is the whole of `abstract_mysql_adapter.rb:440-443`.
  A comment at the `it` records that the clear the name refers to was the
  trails-only addition this PR removes.
- `adapters/postgresql/array.test.ts` "change column default with array" —
  converged to Rails' `array_test.rb:136-141`, which calls
  `PgArray.reset_column_information` after the DDL. trails had dropped that line
  and leaned on the adapter clear instead. This one was a real red without the
  fix, not a test-only change.
- The `DDL cache-invalidation safety-net` describe drives the *abstract*
  `SchemaStatements` mixin, so it is untouched and still green.

## 2. The connection lock outlives no query

Rails' `@lock.synchronize` wraps the entire `with_raw_connection` body
(`abstract_adapter.rb:984`): at most one query is on the wire per connection and
it belongs to the lock holder. That is the only reason
`cancel_any_running_query` (`postgresql/database_statements.rb:127-133`) needs
no ownership concept — it is a nil check plus an `IDLE_TRANSACTION_STATUSES`
gate and nothing else.

trails' lock is per async chain and reentrant (correctly mirroring Ruby's
Monitor), but a chain could *return* while a query it launched was still
awaiting, releasing the lock with work on the wire. `_queryInFlightOwner`
existed only to tell a foreign chain's in-flight query from one's own — a
question Rails cannot even ask.

`TransactionManager.synchronize` now waits on the connection's outstanding
queries before releasing the lock (`TransactionConnection._pendingQueries`,
which PG answers with `_maintenanceTail` — the chain every pinned query already
joins). With the leak closed:

- `_queryInFlightOwner` is deleted, along with its claim in
  `_serializePinnedQuery` and the `owner === null || owner !== …` branch of
  `_cancelAnyRunningQuery`, which is now Rails' body exactly.
- The `INVARIANT:` comment block above `_cancelAnyRunningQuery` (~20 lines
  justifying the ownership concept) goes with it.
- `currentLockToken` on `TransactionManager` is deleted — it had no other reader.

### Callers converted

Only one, in `postgresql-adapter.trails.test.ts`:

- **"rollback does not cancel a query issued by another chain"** — issued the
  foreign query un-awaited and then called `rollbackDbTransaction()` outside any
  lock. Now the rollback runs under `transactionManager.synchronize`, mirroring
  `abstract/transaction.rb:611`'s `rollback_transaction`; it waits behind the
  foreign query and finds an idle status, which the `IDLE_TRANSACTION_STATUSES`
  gate returns on. Nothing is abandoned. Verified red-then-green: with the
  ownership branch gone but the test unconverted, the foreign query is cancelled.

**"rollback cancels an in-flight query the same chain abandoned" is kept as-is.**
The story flagged it as the shape to eliminate, but a same-chain abandoned query
is reachable through reentrancy, which mirrors Ruby's Monitor and is an explicit
non-goal to change — and it is precisely Rails' `Timeout`/`Interrupt` case, the
one `cancel_any_running_query` exists for. It passes unchanged.

No other production caller abandons a query: `withRawConnection` already routes
every query through `synchronize` (`abstract-adapter.ts:2457`), and the
maintenance ops (`_enqueueMaintenance`) chain onto the same tail the new drain
awaits.

## Verification

- PG lane: `adapters/postgresql` + `connection-adapters` — 2773 passed, 0 failed.
- Migration / schema-dumper / schema-cache on PG — 629 passed.
- sqlite lane: `adapters/sqlite3` + `connection-adapters/abstract` + mysql
  adapter unit tests — green.
- `pnpm api:calls` OK (no new rows), `pnpm api:extra --package activerecord`
  clean, `pnpm lint` clean, `pnpm typecheck` clean.
- MySQL lane not runnable locally; it rides CI.

Closes-story: adapter-ddl-bodies-clear-schema-cache-rails-never-touches
Closes-story: pg-lock-scope-no-escaping-queries
