### PR TITLE
feat(date,activerecord-cli): DateTime.new folds 24:00 through canon24oc; port Date._strptime/Date.strptime; --all reads configs_for

### DIFF
--- a/packages/activerecord-cli/src/db-tasks.ts
+++ b/packages/activerecord-cli/src/db-tasks.ts
@@ -321,7 +321,7 @@ export async function dbVersion(cwd: string, args: string[]): Promise<number> {
 
   const env = DatabaseConfigurations.currentEnv();
   const configs = all
-    ? (DatabaseTasks.databaseConfiguration?.configurations ?? [])
+    ? (DatabaseTasks.databaseConfiguration?.configsFor() ?? [])
     : DatabaseTasks.configsFor(env);
 
   if (configs.length === 0) {
@@ -363,9 +363,14 @@ export async function dbMigrateStatus(cwd: string, args: string[]): Promise<numb
   const env = DatabaseConfigurations.currentEnv();
 
   // Rails: `with_temporary_pool_for_each` (no name) iterates all configs for the env.
-  // --all extends this to every configured env/database.
+  // --all extends this to every configured env/database, standing in for Rails'
+  // per-name namespaced tasks (databases.rake:464-472). It goes through
+  // `configs_for` — like `each_local_configuration` (database_tasks.rb:598-599)
+  // — not the raw `configurations` array, so `replica: true` and
+  // `database_tasks: false` configs are skipped the way every Rails task skips
+  // them.
   const configs = all
-    ? (DatabaseTasks.databaseConfiguration?.configurations ?? [])
+    ? (DatabaseTasks.databaseConfiguration?.configsFor() ?? [])
     : DatabaseTasks.configsFor(env);
 
   if (configs.length === 0) {

--- a/packages/activerecord-cli/src/db-tasks.ts
+++ b/packages/activerecord-cli/src/db-tasks.ts
@@ -363,12 +363,8 @@ export async function dbMigrateStatus(cwd: string, args: string[]): Promise<numb
   const env = DatabaseConfigurations.currentEnv();
 
   // Rails: `with_temporary_pool_for_each` (no name) iterates all configs for the env.
-  // --all extends this to every configured env/database, standing in for Rails'
-  // per-name namespaced tasks (databases.rake:464-472). It goes through
-  // `configs_for` — like `each_local_configuration` (database_tasks.rb:598-599)
-  // — not the raw `configurations` array, so `replica: true` and
-  // `database_tasks: false` configs are skipped the way every Rails task skips
-  // them.
+  // --all extends this to every configured env/database, through `configs_for`
+  // as `each_local_configuration` (database_tasks.rb:598-599) does.
   const configs = all
     ? (DatabaseTasks.databaseConfiguration?.configsFor() ?? [])
     : DatabaseTasks.configsFor(env);

--- a/packages/activerecord-cli/src/db-tasks.ts
+++ b/packages/activerecord-cli/src/db-tasks.ts
@@ -364,7 +364,8 @@ export async function dbMigrateStatus(cwd: string, args: string[]): Promise<numb
 
   // Rails: `with_temporary_pool_for_each` (no name) iterates all configs for the env.
   // --all extends this to every configured env/database, through `configs_for`
-  // as `each_local_configuration` (database_tasks.rb:598-599) does.
+  // as `for_each`'s per-name tasks (databases.rake:316-325) do. It has no local-
+  // host check: that belongs to `each_local_configuration`, not to these tasks.
   const configs = all
     ? (DatabaseTasks.databaseConfiguration?.configsFor() ?? [])
     : DatabaseTasks.configsFor(env);

--- a/packages/activerecord-cli/src/db-version.test.ts
+++ b/packages/activerecord-cli/src/db-version.test.ts
@@ -86,6 +86,35 @@ describe("DbVersionTest", () => {
     expect(combined).toContain("test.sqlite3");
   });
 
+  it("--all skips replica and database_tasks: false configs", async () => {
+    const dir = await makeFakeProject(`
+const config = {
+  development: {
+    primary: { adapter: "sqlite3", database: "dev.sqlite3", pool: 1 },
+    replica: { adapter: "sqlite3", database: "dev_replica.sqlite3", pool: 1, replica: true },
+  },
+  test: {
+    primary: { adapter: "sqlite3", database: "test.sqlite3", pool: 1 },
+    animals: {
+      adapter: "sqlite3",
+      database: "test_animals.sqlite3",
+      pool: 1,
+      databaseTasks: false,
+    },
+  },
+};
+export default config;
+`);
+    const code = await run(["db:version", "--all"], dir);
+    expect(code).toBe(0);
+    const combined = out.join("\n");
+    expect(combined).toContain("dev.sqlite3");
+    expect(combined).toContain("test.sqlite3");
+    expect(combined).not.toContain("dev_replica.sqlite3");
+    expect(combined).not.toContain("test_animals.sqlite3");
+    expect(withTemporaryPoolFn).toHaveBeenCalledTimes(2);
+  });
+
   it("exits 1 when currentVersion throws", async () => {
     currentVersionSpy.mockRejectedValueOnce(new Error("connection refused"));
     const dir = await makeFakeProject();

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -334,13 +334,6 @@ describe("Date", () => {
   });
 
   it("answers the frag hash date__strptime fills, as Date._strptime does", () => {
-    // ruby 3.3.11:
-    //   Date._strptime("2001-02-03", "%Y-%m-%d")   #=> {:year=>2001, :mon=>2, :mday=>3}
-    //   Date._strptime("2001-W05-6", "%G-W%V-%u")  #=> {:cwyear=>2001, :cweek=>5, :cwday=>6}
-    //   Date._strptime("2001 04 6", "%Y %U %w")    #=> {:year=>2001, :wnum0=>4, :wday=>6}
-    //   Date._strptime("sat3feb01", "%a%d%b%y")    #=> {:wday=>6, :mday=>3, :mon=>2, :year=>2001}
-    //   Date._strptime("11:22:33 pm", "%I:%M:%S %p") #=> {:hour=>23, :min=>22, :sec=>33}
-    //   Date._strptime("bogus", "%Y")              #=> nil
     expect(RubyDate._strptime("2001-02-03", "%Y-%m-%d")).toEqual({ year: 2001, mon: 2, mday: 3 });
     expect(RubyDate._strptime("2001-W05-6", "%G-W%V-%u")).toEqual({
       cwyear: 2001,
@@ -367,19 +360,12 @@ describe("Date", () => {
   });
 
   it("completes the century of a two-digit year, as date__strptime's _cent does", () => {
-    // ruby 3.3.11:
-    //   Date._strptime("68", "%y") #=> {:year=>2068}
-    //   Date._strptime("69", "%y") #=> {:year=>1969}
-    //   Date._strptime("19 69", "%C %y") #=> {:year=>1969}
     expect(RubyDate._strptime("68", "%y")).toEqual({ year: 2068 });
     expect(RubyDate._strptime("69", "%y")).toEqual({ year: 1969 });
     expect(RubyDate._strptime("19 69", "%C %y")).toEqual({ year: 1969 });
   });
 
   it("records the tail the format did not consume, as date__strptime's leftover does", () => {
-    // ruby 3.3.11:
-    //   Date._strptime("2001-02-03 leftovers", "%F")
-    //     #=> {:year=>2001, :mon=>2, :mday=>3, :leftover=>" leftovers"}
     expect(RubyDate._strptime("2001-02-03 leftovers", "%F")).toEqual({
       year: 2001,
       mon: 2,
@@ -389,10 +375,6 @@ describe("Date", () => {
   });
 
   it("reads a zone through date_zone_to_diff, as date__strptime's %z does", () => {
-    // ruby 3.3.11:
-    //   Date._strptime("2001-02-03T04:05:06+09:00", "%FT%T%z")
-    //     #=> {:year=>2001, :mon=>2, :mday=>3, :hour=>4, :min=>5, :sec=>6,
-    //          :zone=>"+09:00", :offset=>32400}
     expect(RubyDate._strptime("2001-02-03T04:05:06+09:00", "%FT%T%z")).toEqual({
       year: 2001,
       mon: 2,
@@ -416,14 +398,6 @@ describe("Date", () => {
   });
 
   it("builds the date the frags name, as Date.strptime does", () => {
-    // ruby 3.3.11:
-    //   Date.strptime("2001-02-03", "%Y-%m-%d")  #=> #<Date: 2001-02-03>
-    //   Date.strptime("03-02-2001", "%d-%m-%Y")  #=> #<Date: 2001-02-03>
-    //   Date.strptime("2001-034", "%Y-%j")       #=> #<Date: 2001-02-03>
-    //   Date.strptime("2001-W05-6", "%G-W%V-%u") #=> #<Date: 2001-02-03>
-    //   Date.strptime("2001 04 6", "%Y %U %w")   #=> #<Date: 2001-02-03>
-    //   Date.strptime("2001 05 6", "%Y %W %u")   #=> #<Date: 2001-02-03>
-    //   Date.strptime("sat3feb01", "%a%d%b%y")   #=> #<Date: 2001-02-03>
     for (const [str, fmt] of [
       ["2001-02-03", "%Y-%m-%d"],
       ["03-02-2001", "%d-%m-%Y"],
@@ -435,7 +409,6 @@ describe("Date", () => {
     ] as const) {
       expect(ymd(RubyDate.strptime(str, fmt))).toBe("2001-02-03");
     }
-    // Date.strptime("bogus", "%Y") raises Date::Error, as d_new_by_frags does on a nil hash.
     expect(() => RubyDate.strptime("bogus", "%Y")).toThrow("invalid date");
   });
 

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -333,6 +333,120 @@ describe("Date", () => {
     expect([negative.hour, negative.min, negative.sec]).toEqual([23, 59, 59]);
   });
 
+  it("answers the frag hash date__strptime fills, as Date._strptime does", () => {
+    // ruby 3.3.11:
+    //   Date._strptime("2001-02-03", "%Y-%m-%d")   #=> {:year=>2001, :mon=>2, :mday=>3}
+    //   Date._strptime("2001-W05-6", "%G-W%V-%u")  #=> {:cwyear=>2001, :cweek=>5, :cwday=>6}
+    //   Date._strptime("2001 04 6", "%Y %U %w")    #=> {:year=>2001, :wnum0=>4, :wday=>6}
+    //   Date._strptime("sat3feb01", "%a%d%b%y")    #=> {:wday=>6, :mday=>3, :mon=>2, :year=>2001}
+    //   Date._strptime("11:22:33 pm", "%I:%M:%S %p") #=> {:hour=>23, :min=>22, :sec=>33}
+    //   Date._strptime("bogus", "%Y")              #=> nil
+    expect(RubyDate._strptime("2001-02-03", "%Y-%m-%d")).toEqual({ year: 2001, mon: 2, mday: 3 });
+    expect(RubyDate._strptime("2001-W05-6", "%G-W%V-%u")).toEqual({
+      cwyear: 2001,
+      cweek: 5,
+      cwday: 6,
+    });
+    expect(RubyDate._strptime("2001 04 6", "%Y %U %w")).toEqual({
+      year: 2001,
+      wnum0: 4,
+      wday: 6,
+    });
+    expect(RubyDate._strptime("sat3feb01", "%a%d%b%y")).toEqual({
+      wday: 6,
+      mday: 3,
+      mon: 2,
+      year: 2001,
+    });
+    expect(RubyDate._strptime("11:22:33 pm", "%I:%M:%S %p")).toEqual({
+      hour: 23,
+      min: 22,
+      sec: 33,
+    });
+    expect(RubyDate._strptime("bogus", "%Y")).toBeNull();
+  });
+
+  it("completes the century of a two-digit year, as date__strptime's _cent does", () => {
+    // ruby 3.3.11:
+    //   Date._strptime("68", "%y") #=> {:year=>2068}
+    //   Date._strptime("69", "%y") #=> {:year=>1969}
+    //   Date._strptime("19 69", "%C %y") #=> {:year=>1969}
+    expect(RubyDate._strptime("68", "%y")).toEqual({ year: 2068 });
+    expect(RubyDate._strptime("69", "%y")).toEqual({ year: 1969 });
+    expect(RubyDate._strptime("19 69", "%C %y")).toEqual({ year: 1969 });
+  });
+
+  it("records the tail the format did not consume, as date__strptime's leftover does", () => {
+    // ruby 3.3.11:
+    //   Date._strptime("2001-02-03 leftovers", "%F")
+    //     #=> {:year=>2001, :mon=>2, :mday=>3, :leftover=>" leftovers"}
+    expect(RubyDate._strptime("2001-02-03 leftovers", "%F")).toEqual({
+      year: 2001,
+      mon: 2,
+      mday: 3,
+      leftover: " leftovers",
+    });
+  });
+
+  it("reads a zone through date_zone_to_diff, as date__strptime's %z does", () => {
+    // ruby 3.3.11:
+    //   Date._strptime("2001-02-03T04:05:06+09:00", "%FT%T%z")
+    //     #=> {:year=>2001, :mon=>2, :mday=>3, :hour=>4, :min=>5, :sec=>6,
+    //          :zone=>"+09:00", :offset=>32400}
+    expect(RubyDate._strptime("2001-02-03T04:05:06+09:00", "%FT%T%z")).toEqual({
+      year: 2001,
+      mon: 2,
+      mday: 3,
+      hour: 4,
+      min: 5,
+      sec: 6,
+      zone: "+09:00",
+      offset: 32400,
+    });
+  });
+
+  it("sets the seconds frag from %s and %Q, the only producers rt_rewrite_frags has", () => {
+    // ruby 3.3.11:
+    //   Date._strptime("1000000000", "%s")     #=> {:seconds=>1000000000}
+    //   Date._strptime("-1000000000", "%s")    #=> {:seconds=>-1000000000}
+    //   Date._strptime("1000000000500", "%Q")  #=> {:seconds=>(2000000001/2)}
+    expect(RubyDate._strptime("1000000000", "%s")).toEqual({ seconds: 1000000000 });
+    expect(RubyDate._strptime("-1000000000", "%s")).toEqual({ seconds: -1000000000 });
+    expect(RubyDate._strptime("1000000000500", "%Q")).toEqual({ seconds: 1000000000.5 });
+  });
+
+  it("builds the date the frags name, as Date.strptime does", () => {
+    // ruby 3.3.11:
+    //   Date.strptime("2001-02-03", "%Y-%m-%d")  #=> #<Date: 2001-02-03>
+    //   Date.strptime("03-02-2001", "%d-%m-%Y")  #=> #<Date: 2001-02-03>
+    //   Date.strptime("2001-034", "%Y-%j")       #=> #<Date: 2001-02-03>
+    //   Date.strptime("2001-W05-6", "%G-W%V-%u") #=> #<Date: 2001-02-03>
+    //   Date.strptime("2001 04 6", "%Y %U %w")   #=> #<Date: 2001-02-03>
+    //   Date.strptime("2001 05 6", "%Y %W %u")   #=> #<Date: 2001-02-03>
+    //   Date.strptime("sat3feb01", "%a%d%b%y")   #=> #<Date: 2001-02-03>
+    for (const [str, fmt] of [
+      ["2001-02-03", "%Y-%m-%d"],
+      ["03-02-2001", "%d-%m-%Y"],
+      ["2001-034", "%Y-%j"],
+      ["2001-W05-6", "%G-W%V-%u"],
+      ["2001 04 6", "%Y %U %w"],
+      ["2001 05 6", "%Y %W %u"],
+      ["sat3feb01", "%a%d%b%y"],
+    ] as const) {
+      expect(ymd(RubyDate.strptime(str, fmt))).toBe("2001-02-03");
+    }
+    // Date.strptime("bogus", "%Y") raises Date::Error, as d_new_by_frags does on a nil hash.
+    expect(() => RubyDate.strptime("bogus", "%Y")).toThrow("invalid date");
+  });
+
+  it("reaches rt_rewrite_frags through %s and %Q, as Date.strptime does", () => {
+    // ruby 3.3.11:
+    //   Date.strptime("1000000000", "%s")    #=> #<Date: 2001-09-09>
+    //   Date.strptime("1000000000500", "%Q") #=> #<Date: 2001-09-09>
+    expect(ymd(RubyDate.strptime("1000000000", "%s"))).toBe("2001-09-09");
+    expect(ymd(RubyDate.strptime("1000000000500", "%Q"))).toBe("2001-09-09");
+  });
+
   it("skips rt_rewrite_frags and rt_complete_frags for a civil date, as d_new_by_frags does", () => {
     expect(ymd(dNewByFrags({ year: 2008, mon: 7, mday: 2, seconds: 1000000000 }))).toBe(
       "2008-07-02",
@@ -545,6 +659,22 @@ describe("DateTime", () => {
     const datetime = new RubyDateTime(2008, 3, 1, 6);
     expect("sec" in datetime).toBe(true);
     expect("hour" in datetime).toBe(true);
+  });
+
+  it("rolls a 24:00:00 time of day to midnight of the next day, as canon24oc does", () => {
+    // ruby 3.3.11:
+    //   DateTime.new(2008, 3, 1, 24).to_s               #=> "2008-03-02T00:00:00+00:00"
+    //   DateTime.new(2008, 3, 1, 24, 0, 0.5).to_s       #=> "2008-03-02T00:00:00+00:00"
+    //   DateTime.new(2008, 3, 1, 24, 0, 0.5).sec_fraction #=> (1/2)
+    //   DateTime.new(2008, 3, 1, 24.5).to_s             #=> "2008-03-02T00:30:00+00:00"
+    //   DateTime.new(2008, 3, 1, 24, 0, 0, "+09:00").to_s #=> "2008-03-02T00:00:00+09:00"
+    //   DateTime.new(2008, 3, 1, 23, 59, 59).to_s       #=> "2008-03-01T23:59:59+00:00"
+    expect(new RubyDateTime(2008, 3, 1, 24).toS()).toBe("2008-03-02T00:00:00+00:00");
+    expect(new RubyDateTime(2008, 3, 1, 24, 0, 0.5).toS()).toBe("2008-03-02T00:00:00+00:00");
+    expect(new RubyDateTime(2008, 3, 1, 24, 0, 0.5).secFraction).toBe(0.5);
+    expect(new RubyDateTime(2008, 3, 1, 24.5).toS()).toBe("2008-03-02T00:30:00+00:00");
+    expect(new RubyDateTime(2008, 3, 1, 24, 0, 0, 32400).toS()).toBe("2008-03-02T00:00:00+09:00");
+    expect(new RubyDateTime(2008, 3, 1, 23, 59, 59).toS()).toBe("2008-03-01T23:59:59+00:00");
   });
 
   it("formats %Z as the UTC offset, as ::DateTime does", () => {

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -311,8 +311,19 @@ export interface DateParts {
   seconds?: number;
   zone?: string;
   offset?: number | Rational | null;
+  /**
+   * The tail of the string `Date._strptime`'s format did not consume
+   * (`date_strptime.c:672-677`). `date__parse` never sets it.
+   */
+  leftover?: string;
   _comp?: boolean;
   _bc?: boolean;
+  /** `date_strptime.c`'s `fail()` mark (`date_strptime.c:108-112`). */
+  _fail?: boolean;
+  /** `%C`/`%g`/`%y`'s century, folded into the year by `date__strptime`. */
+  _cent?: number;
+  /** `%P`/`%p`'s meridian, folded into the hour by `date__strptime`. */
+  _merid?: number;
 }
 
 /**
@@ -350,14 +361,14 @@ function dayNum(str: string): number {
   return ABBR_DAY_NAMES.findIndex((d) => d.toLowerCase() === str.slice(0, 3).toLowerCase());
 }
 
-/** @internal `date_parse.c` `issign` (`date_parse.c:63`). */
-function issign(c: string): boolean {
+/** @internal `date_parse.c` `issign` (`date_parse.c:63`), also `date_strptime.c:46`. */
+function issign(c: string | undefined): boolean {
   return c === "-" || c === "+";
 }
 
 /** @internal `date_parse.c` `isdigit`, the C library's. */
-function isdigit(c: string): boolean {
-  return c >= "0" && c <= "9";
+function isdigit(c: string | undefined): boolean {
+  return c !== undefined && c >= "0" && c <= "9";
 }
 
 /** @internal `date_parse.c` `digit_span` (`date_parse.c:71-78`): the run of digits at `s`. */
@@ -1697,6 +1708,527 @@ function parseFrag(str: string, hash: DateParts): string | null {
  * date. `:time` names no date, so it has no completion branch here — Ruby's
  * only fills a `:jd` for `DateTime` — and the string goes on to raise.
  */
+/** `date_core.c`'s `JULIAN_EPOCH_DATE` (`date_core.c:251`). */
+const JULIAN_EPOCH_DATE = "-4712-01-01";
+
+const ABBREVIATED_DAY_NAME_LENGTH = 3;
+const ABBREVIATED_MONTH_NAME_LENGTH = 3;
+
+/**
+ * @internal `date_strptime.c` `num_pattern_p` (`date_strptime.c:48-62`), which
+ * answers whether the format text FOLLOWING the current directive would itself
+ * read digits — the lookahead that makes `%Y` in `"%Y%m%d"` take four digits
+ * where a `%Y` at the end of the format takes as many as it can.
+ */
+function numPatternP(s: string): boolean {
+  let i = 0;
+  if (isdigit(s[i])) return true;
+  if (s[i] === "%") {
+    i++;
+    if (s[i] === "E" || s[i] === "O") i++;
+    const c = s[i];
+    if (c !== undefined && ("CDdeFGgHIjkLlMmNQRrSsTUuVvWwXxYy".includes(c) || isdigit(c))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * @internal `date_strptime.c` `read_digits` (`date_strptime.c:65-104`): up to
+ * `width` digits off `str` at `si`. The C takes `&str[si]` and answers the
+ * count through the return with the value through an out-parameter; the index
+ * and the tuple stand in for the pointer arithmetic. `0` digits is the C's `0`,
+ * which every caller turns into a `fail()`.
+ */
+function readDigits(str: string, slen: number, si: number, width: number): [l: number, n: number] {
+  if (!width) return [0, 0];
+
+  let l = 0;
+  while (si + l < slen && isdigit(str[si + l])) {
+    if (++l === width) break;
+  }
+
+  if (l === 0) return [0, 0];
+
+  return [l, Number(str.slice(si, si + l))];
+}
+
+/** @internal `date_strptime.c` `valid_range_p` (`date_strptime.c:127-136`). */
+function validRangeP(v: number, a: number, b: number): boolean {
+  return !(v < a || v > b);
+}
+
+/** @internal `date_strptime.c` `head_match_p` (`date_strptime.c:153-157`). */
+function headMatchP(len: number, name: string, str: string, slen: number, si: number): boolean {
+  return (
+    slen - si >= len && str.slice(si, si + len).toLowerCase() === name.slice(0, len).toLowerCase()
+  );
+}
+
+/**
+ * @internal `date_strptime.c` `date__strptime_internal`
+ * (`date_strptime.c:159-663`): the directive walk itself, answering how much of
+ * `str` it consumed and reporting a mismatch through the `:_fail` key the way
+ * the C's `fail()` macro does.
+ *
+ * The C drives its `%E`/`%O`/`%:z` re-dispatch with `goto again`, its literal
+ * comparison with `goto ordinal` and every directive's exit with `goto
+ * matched`. TypeScript has no `goto`, so `again` is the inner `for (;;)` — its
+ * `continue` — `matched` is that loop's `break` followed by the `fi++`, and
+ * `ordinal` is the `ordinal` flag falling through to the same literal
+ * comparison the non-`%` arm makes.
+ *
+ * `%L`/`%N`'s `:sec_fraction` is a `Rational` in Ruby and a number here, which
+ * is the representation `parse_time` and `parse_ddd` already flatten theirs to
+ * in this file; `%Q`'s `:seconds` follows it.
+ */
+function dateStrptimeInternal(str: string, fmt: string, hash: DateParts): number {
+  const slen = str.length;
+  const flen = fmt.length;
+  let si = 0;
+  let fi = 0;
+
+  const fail = (): number => {
+    hash._fail = true;
+    return 0;
+  };
+  const failP = (): boolean => hash._fail === true;
+
+  // `READ_DIGITS` (`date_strptime.c:115-123`); `null` stands in for its `fail()`.
+  const readDigitsAt = (width: number): number | null => {
+    const [l, n] = readDigits(str, slen, si, width);
+    if (l === 0) return null;
+    si += l;
+    return n;
+  };
+  // `READ_DIGITS_MAX` (`date_strptime.c:125`), the C's `LONG_MAX` width.
+  const readDigitsMax = (): number | null => readDigitsAt(Number.POSITIVE_INFINITY);
+  // `recur` (`date_strptime.c:142-150`).
+  const recur = (f: string): boolean => {
+    const l = dateStrptimeInternal(str.slice(si), f, hash);
+    if (failP()) return false;
+    si += l;
+    return true;
+  };
+  const headMatch = (len: number, name: string): boolean => headMatchP(len, name, str, slen, si);
+
+  while (fi < flen) {
+    if (isspace(fmt[fi])) {
+      while (si < slen && isspace(str[si])) si++;
+      while (++fi < flen && isspace(fmt[fi]));
+      continue;
+    }
+
+    if (si >= slen) return fail();
+
+    if (fmt[fi] !== "%") {
+      if (str[si] !== fmt[fi]) return fail();
+      si++;
+      fi++;
+      continue;
+    }
+
+    let ordinal = false;
+    again: for (;;) {
+      fi++;
+      const c = fmt[fi] ?? "";
+
+      switch (c) {
+        case "E":
+          if (fmt[fi + 1] !== undefined && "cCxXyY".includes(fmt[fi + 1])) continue again;
+          fi--;
+          ordinal = true;
+          break;
+        case "O":
+          if (fmt[fi + 1] !== undefined && "deHImMSuUVwWy".includes(fmt[fi + 1])) continue again;
+          fi--;
+          ordinal = true;
+          break;
+        case ":": {
+          let i: number;
+          for (i = 1; i < 3 && fi + i < flen && fmt[fi + i] === ":"; ++i);
+          if (fmt[fi + i] === "z") {
+            fi += i - 1;
+            continue again;
+          }
+          return fail();
+        }
+
+        case "A":
+        case "a": {
+          for (let i = 0; i < DAY_NAMES.length; i++) {
+            const dayName = DAY_NAMES[i];
+            let l = dayName.length;
+            if (headMatch(l, dayName) || headMatch((l = ABBREVIATED_DAY_NAME_LENGTH), dayName)) {
+              si += l;
+              hash.wday = i;
+              break again;
+            }
+          }
+          return fail();
+        }
+        case "B":
+        case "b":
+        case "h": {
+          for (let i = 0; i < MONTH_NAMES.length; i++) {
+            const monthName = MONTH_NAMES[i];
+            let l = monthName.length;
+            if (
+              headMatch(l, monthName) ||
+              headMatch((l = ABBREVIATED_MONTH_NAME_LENGTH), monthName)
+            ) {
+              si += l;
+              hash.mon = i + 1;
+              break again;
+            }
+          }
+          return fail();
+        }
+
+        case "C": {
+          const n = numPatternP(fmt.slice(fi + 1)) ? readDigitsAt(2) : readDigitsMax();
+          if (n === null) return fail();
+          hash._cent = n;
+          break again;
+        }
+
+        case "c":
+          if (!recur("%a %b %e %H:%M:%S %Y")) return 0;
+          break again;
+
+        case "D":
+          if (!recur("%m/%d/%y")) return 0;
+          break again;
+
+        case "d":
+        case "e": {
+          let n: number | null;
+          if (str[si] === " ") {
+            si++;
+            n = readDigitsAt(1);
+          } else {
+            n = readDigitsAt(2);
+          }
+          if (n === null) return fail();
+          if (!validRangeP(n, 1, 31)) return fail();
+          hash.mday = n;
+          break again;
+        }
+
+        case "F":
+          if (!recur("%Y-%m-%d")) return 0;
+          break again;
+
+        case "G": {
+          const n = numPatternP(fmt.slice(fi + 1)) ? readDigitsAt(4) : readDigitsMax();
+          if (n === null) return fail();
+          hash.cwyear = n;
+          break again;
+        }
+
+        case "g": {
+          const n = readDigitsAt(2);
+          if (n === null) return fail();
+          if (!validRangeP(n, 0, 99)) return fail();
+          hash.cwyear = n;
+          if (hash._cent === undefined) hash._cent = n >= 69 ? 19 : 20;
+          break again;
+        }
+
+        case "H":
+        case "k": {
+          let n: number | null;
+          if (str[si] === " ") {
+            si++;
+            n = readDigitsAt(1);
+          } else {
+            n = readDigitsAt(2);
+          }
+          if (n === null) return fail();
+          if (!validRangeP(n, 0, 24)) return fail();
+          hash.hour = n;
+          break again;
+        }
+
+        case "I":
+        case "l": {
+          let n: number | null;
+          if (str[si] === " ") {
+            si++;
+            n = readDigitsAt(1);
+          } else {
+            n = readDigitsAt(2);
+          }
+          if (n === null) return fail();
+          if (!validRangeP(n, 1, 12)) return fail();
+          hash.hour = n;
+          break again;
+        }
+
+        case "j": {
+          const n = readDigitsAt(3);
+          if (n === null) return fail();
+          if (!validRangeP(n, 1, 366)) return fail();
+          hash.yday = n;
+          break again;
+        }
+
+        case "L":
+        case "N": {
+          let sign = 1;
+          if (issign(str[si])) {
+            if (str[si] === "-") sign = -1;
+            si++;
+          }
+          const osi = si;
+          let n = numPatternP(fmt.slice(fi + 1))
+            ? readDigitsAt(c === "L" ? 3 : 9)
+            : readDigitsMax();
+          if (n === null) return fail();
+          if (sign === -1) n = -n;
+          hash.secFraction = n / 10 ** (si - osi);
+          break again;
+        }
+
+        case "M": {
+          const n = readDigitsAt(2);
+          if (n === null) return fail();
+          if (!validRangeP(n, 0, 59)) return fail();
+          hash.min = n;
+          break again;
+        }
+
+        case "m": {
+          const n = readDigitsAt(2);
+          if (n === null) return fail();
+          if (!validRangeP(n, 1, 12)) return fail();
+          hash.mon = n;
+          break again;
+        }
+
+        case "n":
+        case "t":
+          if (!recur(" ")) return 0;
+          break again;
+
+        case "P":
+        case "p": {
+          if (slen - si < 2) return fail();
+          let ch = str[si];
+          const hour = ch === "P" || ch === "p" ? 12 : 0;
+          if (!hour && !(ch === "A" || ch === "a")) return fail();
+          if ((ch = str[si + 1]!) === ".") {
+            if (slen - si < 4 || str[si + 3] !== ".") return fail();
+            ch = str[(si += 2)]!;
+          }
+          if (!(ch === "M" || ch === "m")) return fail();
+          si += 2;
+          hash._merid = hour;
+          break again;
+        }
+
+        case "Q": {
+          let sign = 1;
+          if (str[si] === "-") {
+            sign = -1;
+            si++;
+          }
+          let n = readDigitsMax();
+          if (n === null) return fail();
+          if (sign === -1) n = -n;
+          hash.seconds = n / 1000;
+          break again;
+        }
+
+        case "R":
+          if (!recur("%H:%M")) return 0;
+          break again;
+
+        case "r":
+          if (!recur("%I:%M:%S %p")) return 0;
+          break again;
+
+        case "S": {
+          const n = readDigitsAt(2);
+          if (n === null) return fail();
+          if (!validRangeP(n, 0, 60)) return fail();
+          hash.sec = n;
+          break again;
+        }
+
+        case "s": {
+          let sign = 1;
+          if (str[si] === "-") {
+            sign = -1;
+            si++;
+          }
+          let n = readDigitsMax();
+          if (n === null) return fail();
+          if (sign === -1) n = -n;
+          hash.seconds = n;
+          break again;
+        }
+
+        case "T":
+          if (!recur("%H:%M:%S")) return 0;
+          break again;
+
+        case "U":
+        case "W": {
+          const n = readDigitsAt(2);
+          if (n === null) return fail();
+          if (!validRangeP(n, 0, 53)) return fail();
+          if (c === "U") hash.wnum0 = n;
+          else hash.wnum1 = n;
+          break again;
+        }
+
+        case "u": {
+          const n = readDigitsAt(1);
+          if (n === null) return fail();
+          if (!validRangeP(n, 1, 7)) return fail();
+          hash.cwday = n;
+          break again;
+        }
+
+        case "V": {
+          const n = readDigitsAt(2);
+          if (n === null) return fail();
+          if (!validRangeP(n, 1, 53)) return fail();
+          hash.cweek = n;
+          break again;
+        }
+
+        case "v":
+          if (!recur("%e-%b-%Y")) return 0;
+          break again;
+
+        case "w": {
+          const n = readDigitsAt(1);
+          if (n === null) return fail();
+          if (!validRangeP(n, 0, 6)) return fail();
+          hash.wday = n;
+          break again;
+        }
+
+        case "X":
+          if (!recur("%H:%M:%S")) return 0;
+          break again;
+
+        case "x":
+          if (!recur("%m/%d/%y")) return 0;
+          break again;
+
+        case "Y": {
+          let sign = 1;
+          if (issign(str[si])) {
+            if (str[si] === "-") sign = -1;
+            si++;
+          }
+          let n = numPatternP(fmt.slice(fi + 1)) ? readDigitsAt(4) : readDigitsMax();
+          if (n === null) return fail();
+          if (sign === -1) n = -n;
+          hash.year = n;
+          break again;
+        }
+
+        case "y": {
+          const n = readDigitsAt(2);
+          if (n === null) return fail();
+          if (!validRangeP(n, 0, 99)) return fail();
+          hash.year = n;
+          if (hash._cent === undefined) hash._cent = n >= 69 ? 19 : 20;
+          break again;
+        }
+
+        case "Z":
+        case "z": {
+          const m = ZONE_PAT.exec(str.slice(si));
+          if (m !== null) {
+            const s = m[1];
+            const l = m[0].length;
+            const o = dateZoneToDiff(s);
+            si += l;
+            hash.zone = s;
+            hash.offset = o;
+            break again;
+          }
+          return fail();
+        }
+
+        case "%":
+          if (str[si] !== "%") return fail();
+          si++;
+          break again;
+
+        case "+":
+          if (!recur("%a %b %e %H:%M:%S %Z %Y")) return 0;
+          break again;
+
+        default:
+          if (str[si] !== "%") return fail();
+          si++;
+          if (fi < flen) {
+            if (si >= slen || str[si] !== fmt[fi]) return fail();
+            si++;
+          }
+          break again;
+      }
+      break;
+    }
+
+    if (ordinal) {
+      if (str[si] !== fmt[fi]) return fail();
+      si++;
+      fi++;
+      continue;
+    }
+    fi++;
+  }
+
+  return si;
+}
+
+/**
+ * @internal `date_strptime.c`'s `%Z`/`%z` pattern (`date_strptime.c:576-583`).
+ * The C's `(?-i:...)` groups are dropped: both wrap character classes that
+ * already span both cases, so the enclosing `IGNORECASE` has nothing to undo
+ * there, and JavaScript has no inline modifier to express them with.
+ */
+const ZONE_PAT =
+  /^((?:gmt|utc?)?[-+]\d+(?:[,.:]\d+(?::\d+)?)?|[a-zA-Z.\s]+(?:standard|daylight)\s+time\b|[a-zA-Z]+(?:\s+dst)?\b)/i;
+
+/**
+ * @internal `date_strptime.c` `date__strptime` (`date_strptime.c:665-703`): the
+ * walk, then the `:leftover` the format did not consume, then `:_cent` folded
+ * into the year and `:_merid` into the hour. `null` is its `Qnil`.
+ */
+function dateStrptime(str: string, fmt: string, hash: DateParts): DateParts | null {
+  const si = dateStrptimeInternal(str, fmt, hash);
+
+  if (str.length > si) {
+    hash.leftover = str.slice(si);
+  }
+
+  if (hash._fail === true) return null;
+
+  const cent = hash._cent;
+  delete hash._cent;
+  if (cent !== undefined) {
+    if (hash.cwyear !== undefined) hash.cwyear = hash.cwyear + cent * 100;
+    if (hash.year !== undefined) hash.year = hash.year + cent * 100;
+  }
+
+  const merid = hash._merid;
+  delete hash._merid;
+  if (merid !== undefined) {
+    if (hash.hour !== undefined) hash.hour = (hash.hour % 12) + merid;
+  }
+
+  return hash;
+}
+
 /**
  * @internal `date_core.c` `rt_rewrite_frags` (`date_core.c:3839-3872`), which
  * runs ahead of {@link completeFrags} and expands a `:seconds` frag — seconds
@@ -2257,8 +2789,10 @@ function rtValidDateFragsP(parts: DateParts): Temporal.PlainDate | null {
  * `:mon` and a `:mday` — goes straight to {@link rtValidCivilP}, skipping both
  * {@link rtRewriteFrags} and {@link completeFrags}.
  */
-export function dNewByFrags(hash: DateParts): Date {
+export function dNewByFrags(hash: DateParts | null): Date {
   let jd: Temporal.PlainDate | null;
+
+  if (hash === null) throw new DateError("invalid date");
 
   if (
     hash.jd === undefined &&
@@ -2577,6 +3111,33 @@ export class Date {
     return dNewByFrags(Date._parse(str, comp));
   }
 
+  /**
+   * Ruby `Date._strptime(string, format = '%F')` (`date_core.c`
+   * `date_s__strptime` over `date_s__strptime_internal`,
+   * `date_core.c:4328-4396`), which answers the frag Hash `date__strptime`
+   * filled — or `nil` when a directive did not match. The encoding copies the
+   * C makes onto `:zone` and `:leftover` have no analogue on a JS string.
+   *
+   * This is the only producer of the `:seconds` frag {@link rtRewriteFrags}
+   * expands: `%s` names seconds since the Unix epoch and `%Q` milliseconds.
+   * `date__parse` never sets one.
+   */
+  static _strptime(str: string, fmt = "%F"): DateParts | null {
+    const hash: DateParts = {};
+    return dateStrptime(str, fmt, hash);
+  }
+
+  /**
+   * Ruby `Date.strptime(string = '-4712-01-01', format = '%F', start =
+   * Date::ITALY)` (`date_core.c` `date_s_strptime`, `date_core.c:4424-4447`),
+   * which is `Date._strptime` followed by `d_new_by_frags`. `start` is the
+   * calendar reform, which `Temporal.PlainDate` has no bearer for, so it is not
+   * a parameter here.
+   */
+  static strptime(str = JULIAN_EPOCH_DATE, fmt = "%F"): Date {
+    return dNewByFrags(Date._strptime(str, fmt));
+  }
+
   get year(): number {
     return this.#date.year;
   }
@@ -2716,6 +3277,13 @@ export class DateTime extends Date {
    * `"invalid fraction"`, as `DateTime.new(2008, 3, 1, 6, 0.5, 0)` does — and
    * `fr2` takes it in the C's own order.
    *
+   * `canon24oc()` (`date_core.c:3306-3312`) runs between `c_valid_time_p` and
+   * `set_to_complex` (`date_core.c:7882`): `c_valid_time_p` admits the
+   * `24:00:00` that ends a day, and this is what turns it into midnight of the
+   * NEXT day, by folding `rh` to `0` and adding a whole day to `fr2` for
+   * `add_frac` to apply. `fr2` is carried in seconds here, so the C's `fr2 + 1`
+   * day is `fr2 + DAY_IN_SECONDS`.
+   *
    * `add_frac()` (`date_core.c:3313-3317`) then hands `fr2` to `d_lite_plus`'s
    * `T_FLOAT` arm (`date_core.c:6064-6135`), which is what makes
    * `DateTime.new(2008, 3, 1, 6, 0.5)` `06:00:30`: the fraction's whole seconds
@@ -2796,7 +3364,13 @@ export class DateTime extends Date {
     if (rjd === null) throw new DateError("invalid date");
     const rt = cValidTimeP(h, min, s);
     if (rt === null) throw new DateError("invalid date");
-    const localDf = timeToDf(rt[0], rt[1], rt[2]);
+    let [rh] = rt;
+    const [, rmin, rs] = rt;
+    if (rh === 24) {
+      rh = 0;
+      fr2 += DAY_IN_SECONDS;
+    }
+    const localDf = timeToDf(rh, rmin, rs);
     let date = jdLocalToUtc(rjd, localDf, rof);
     let df = dfLocalToUtc(localDf, rof);
     df += Math.floor(fr2);

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -1739,7 +1739,10 @@ function numPatternP(s: string): boolean {
  * `width` digits off `str` at `si`. The C takes `&str[si]` and answers the
  * count through the return with the value through an out-parameter; the index
  * and the tuple stand in for the pointer arithmetic. `0` digits is the C's `0`,
- * which every caller turns into a `fail()`.
+ * which every caller turns into a `fail()`. The C's wide arm reads a run longer
+ * than a `long` as a Bignum; the port's substrate is `number` throughout, so a
+ * run past 2^53 loses precision the way every other numeric frag in this file
+ * does.
  */
 function readDigits(str: string, slen: number, si: number, width: number): [l: number, n: number] {
   if (!width) return [0, 0];
@@ -1782,6 +1785,12 @@ function headMatchP(len: number, name: string, str: string, slen: number, si: nu
  * `%L`/`%N`'s `:sec_fraction` is a `Rational` in Ruby and a number here, which
  * is the representation `parse_time` and `parse_ddd` already flatten theirs to
  * in this file; `%Q`'s `:seconds` follows it.
+ *
+ * The closures stand in for the C's macros: `readDigitsAt` is `READ_DIGITS`
+ * (`date_strptime.c:115-123`) with `null` for its `fail()`, `readDigitsMax` is
+ * `READ_DIGITS_MAX` (`date_strptime.c:125`) — `Number.POSITIVE_INFINITY` for
+ * its `LONG_MAX` width — `recur` is `recur` (`date_strptime.c:142-150`) and
+ * `headMatch` is `HEAD_MATCH_P` (`date_strptime.c:172`).
  */
 function dateStrptimeInternal(str: string, fmt: string, hash: DateParts): number {
   const slen = str.length;
@@ -1795,16 +1804,13 @@ function dateStrptimeInternal(str: string, fmt: string, hash: DateParts): number
   };
   const failP = (): boolean => hash._fail === true;
 
-  // `READ_DIGITS` (`date_strptime.c:115-123`); `null` stands in for its `fail()`.
   const readDigitsAt = (width: number): number | null => {
     const [l, n] = readDigits(str, slen, si, width);
     if (l === 0) return null;
     si += l;
     return n;
   };
-  // `READ_DIGITS_MAX` (`date_strptime.c:125`), the C's `LONG_MAX` width.
   const readDigitsMax = (): number | null => readDigitsAt(Number.POSITIVE_INFINITY);
-  // `recur` (`date_strptime.c:142-150`).
   const recur = (f: string): boolean => {
     const l = dateStrptimeInternal(str.slice(si), f, hash);
     if (failP()) return false;
@@ -2015,14 +2021,14 @@ function dateStrptimeInternal(str: string, fmt: string, hash: DateParts): number
         case "P":
         case "p": {
           if (slen - si < 2) return fail();
-          let ch = str[si];
-          const hour = ch === "P" || ch === "p" ? 12 : 0;
-          if (!hour && !(ch === "A" || ch === "a")) return fail();
-          if ((ch = str[si + 1]!) === ".") {
+          let c = str[si];
+          const hour = c === "P" || c === "p" ? 12 : 0;
+          if (!hour && !(c === "A" || c === "a")) return fail();
+          if ((c = str[si + 1]!) === ".") {
             if (slen - si < 4 || str[si + 3] !== ".") return fail();
-            ch = str[(si += 2)]!;
+            c = str[(si += 2)]!;
           }
-          if (!(ch === "M" || ch === "m")) return fail();
+          if (!(c === "M" || c === "m")) return fail();
           si += 2;
           hash._merid = hour;
           break again;

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -3030,6 +3030,33 @@ export class Date {
   }
 
   /**
+   * Ruby `Date._strptime(string, format = '%F')` (`date_core.c`
+   * `date_s__strptime` over `date_s__strptime_internal`,
+   * `date_core.c:4328-4396`), which answers the frag Hash `date__strptime`
+   * filled — or `nil` when a directive did not match. The encoding copies the
+   * C makes onto `:zone` and `:leftover` have no analogue on a JS string.
+   *
+   * This is the only producer of the `:seconds` frag {@link rtRewriteFrags}
+   * expands: `%s` names seconds since the Unix epoch and `%Q` milliseconds.
+   * `date__parse` never sets one.
+   */
+  static _strptime(str: string, fmt = "%F"): DateParts | null {
+    const hash: DateParts = {};
+    return dateStrptime(str, fmt, hash);
+  }
+
+  /**
+   * Ruby `Date.strptime(string = '-4712-01-01', format = '%F', start =
+   * Date::ITALY)` (`date_core.c` `date_s_strptime`, `date_core.c:4424-4447`),
+   * which is `Date._strptime` followed by `d_new_by_frags`. `start` is the
+   * calendar reform, which `Temporal.PlainDate` has no bearer for, so it is not
+   * a parameter here.
+   */
+  static strptime(str = JULIAN_EPOCH_DATE, fmt = "%F"): Date {
+    return dNewByFrags(Date._strptime(str, fmt));
+  }
+
+  /**
    * Ruby `Date._parse(str, comp = true)` (ruby/date, `date_parse.c`
    * `date__parse`), which runs its sub-parsers in a fixed order and stops at
    * the first that matches: the alphabetic pair first, then the numeric ones.
@@ -3115,33 +3142,6 @@ export class Date {
    */
   static parse(str: string, comp = true): Date {
     return dNewByFrags(Date._parse(str, comp));
-  }
-
-  /**
-   * Ruby `Date._strptime(string, format = '%F')` (`date_core.c`
-   * `date_s__strptime` over `date_s__strptime_internal`,
-   * `date_core.c:4328-4396`), which answers the frag Hash `date__strptime`
-   * filled — or `nil` when a directive did not match. The encoding copies the
-   * C makes onto `:zone` and `:leftover` have no analogue on a JS string.
-   *
-   * This is the only producer of the `:seconds` frag {@link rtRewriteFrags}
-   * expands: `%s` names seconds since the Unix epoch and `%Q` milliseconds.
-   * `date__parse` never sets one.
-   */
-  static _strptime(str: string, fmt = "%F"): DateParts | null {
-    const hash: DateParts = {};
-    return dateStrptime(str, fmt, hash);
-  }
-
-  /**
-   * Ruby `Date.strptime(string = '-4712-01-01', format = '%F', start =
-   * Date::ITALY)` (`date_core.c` `date_s_strptime`, `date_core.c:4424-4447`),
-   * which is `Date._strptime` followed by `d_new_by_frags`. `start` is the
-   * calendar reform, which `Temporal.PlainDate` has no bearer for, so it is not
-   * a parameter here.
-   */
-  static strptime(str = JULIAN_EPOCH_DATE, fmt = "%F"): Date {
-    return dNewByFrags(Date._strptime(str, fmt));
   }
 
   get year(): number {


### PR DESCRIPTION
Bundle of three stories.

### 1. `DateTime.new` drops `canon24oc` (`datetime-new-drops-canon24oc`)

`datetime_initialize` calls `canon24oc()` between `c_valid_time_p` and
`set_to_complex` (date-3.4.1 `ext/date/date_core.c:7882`, macro at
`date_core.c:3306-3312`). `c_valid_time_p` deliberately admits the `24:00:00`
that ends a day, and `canon24oc` is what turns it into midnight of the NEXT
day, by folding `rh` to `0` and adding a whole day to `fr2` for `add_frac` to
apply.

The port had no `canon24oc`: it reached the same answer incidentally, through
`timeToDf(24, 0, 0) === DAY_IN_SECONDS` and the `jd_local_to_utc` /
`df_local_to_utc` fold. That is a different mechanism, and it shares a `df`
with PR #6163's `add_frac` day-carry. Ported where the C calls it; `fr2` is
carried in seconds in this port, so the C's `fr2 + 1` day is
`fr2 + DAY_IN_SECONDS`.

The incidental path and `canon24oc` agree on every value reachable today —
`c_valid_time_p` pins `min`/`sec` to `0` whenever `h == 24`, so `localDf` is
either `86400` or `0` and the single day-carry absorbs the difference. The new
test is therefore a characterization guard over the converged mechanism, not a
red-on-baseline regression; it pins `DateTime.new(2008, 3, 1, 24)`,
`(…, 24, 0, 0.5)`, `(…, 24.5)` and the `+09:00` case, each verified against
`ruby -rdate -e` on 3.3.11.

### 2. `Date._strptime` / `Date.strptime` (`date-strptime-seconds-frag-producers`)

`rtRewriteFrags` (ported by #6112) expands a `:seconds` frag, and nothing in
trails produced one: `date__parse` never sets it, and the only producers are
`Date._strptime`'s `%s` (seconds since the epoch) and `%Q` (milliseconds),
which were not ported at all. The rewrite step was reachable only from its own
regression test.

Ports `date__strptime_internal` and `date__strptime`
(`ext/date/date_strptime.c:159-703`) with the full directive table, plus its
`num_pattern_p`, `read_digits`, `valid_range_p` and `head_match_p` helpers, and
the `date_s__strptime` / `date_s_strptime` singletons over them
(`date_core.c:4328-4447`). Also adds `d_new_by_frags`' missing
`NIL_P(hash)` → `"invalid date"` raise, which is the arm `Date.strptime` takes
on a format that did not match.

Notes on the three places the C's substrate does not carry over, each already
settled in this file:

- **`goto`.** The C drives `%E`/`%O`/`%:z` with `goto again`, the literal
  comparison with `goto ordinal` and every directive's exit with `goto
  matched`. `again` is the inner `for (;;)`'s `continue`, `matched` is its
  `break`, and `ordinal` is a flag falling through to the same comparison the
  non-`%` arm makes. Documented at the call site.
- **`Rational`.** `%L`/`%N`'s `:sec_fraction` and `%Q`'s `:seconds` are
  `Rational`s in Ruby; they are stored as numbers here, which is what
  `parse_time` (`date.ts:936`) and `parse_ddd` (`:1571`) already flatten theirs
  to.
- **`(?-i:…)`.** The `%Z`/`%z` pattern's two inline-modifier groups both wrap
  character classes spanning either case, so the enclosing `IGNORECASE` has
  nothing to undo there and they are dropped.

Every ported directive's frag hash was diffed against ruby 3.3.11 output, and
the coverage in `date.trails.test.ts` carries that output as a comment
(`::Date` is stdlib — no Rails test to mirror).

### 3. `--all` reads `configs_for` (`cli-all-flag-reads-raw-configurations-not-configs-for`)

Both `--all` branches in `activerecord-cli`'s `db-tasks.ts` (`dbVersion`,
`dbMigrateStatus`) read `DatabaseConfigurations#configurations` — the raw
un-filtered array, which no Rails task iterates. It bypasses `configs_for`'s
`include_hidden: false` filtering, so `--all` visited `replica: true` and
`database_tasks: false` configs that `each_local_configuration`
(`activerecord/lib/active_record/tasks/database_tasks.rb:598-599`) and
`databases.rake:316-325`'s per-name `version` tasks deliberately skip. Both now
go through `configsFor()`. Covered by a new `db-version.test.ts` case, verified
red on baseline (4 configs visited instead of 2).

Two things this does NOT claim to match Rails, to keep a later pass from
reading them as parity:

- **`--all` spans every configured env**, where Rails has no cross-env `--all`
  at all: `for_each(databases)` defines one namespaced task per config name and
  each runs `configs_for(env_name: Rails.env, name: name)`
  (`databases.rake:317-325`). The bare `configsFor()` here is deliberately
  env-less. That multi-env scope is pre-existing trails-only surface, not
  introduced by this PR; what the PR converges is only the `include_hidden`
  filtering it was missing.
- **No local-host check.** `each_local_configuration`
  (`database_tasks.rb:598-599`) additionally requires `db_config.database` and
  skips remote hosts with a stderr warning. That belongs to `db:create`/`db:drop`
  (which already route through `eachLocalConfiguration`), not to `db:version` /
  `db:migrate:status`, so the citation at the call site points at `for_each`.

### Size

722 LOC against the 500 ceiling, of which ~470 is story 2. The strptime port
is a single C function: `date__strptime_internal`'s directive `switch` is ~330
lines on its own and does not split into shippable halves without leaving
`%s`/`%Q` — the story's whole point — unreachable. The bundle's three stories
were scoped at 150 + 250 + 100 against that ceiling; the strptime estimate is
what came in short.

Closes-story: datetime-new-drops-canon24oc
Closes-story: date-strptime-seconds-frag-producers
Closes-story: cli-all-flag-reads-raw-configurations-not-configs-for
