### PR TITLE
test(i18n,activerecord): port I18nBackendFallbacksWithChainTest and the first half of Rails' CommandRecorderTest

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1625,9 +1625,8 @@ export class Table {
   ): Promise<void> {
     this.raiseOnIfExistOptions(options as Record<string, unknown>);
     const { index: indexOpt, ...colOpts } = options;
-    // Ruby's `@base.add_column(name, column_name, type, **options)` passes no
-    // fourth argument at all when `options` is empty; the CommandRecorder
-    // records the arguments verbatim, so the empty hash must not be spread in.
+    // `@base.add_column(name, column_name, type, **options)` passes no fourth
+    // argument when `options` is empty, and CommandRecorder records args verbatim.
     if (Object.keys(colOpts).length === 0) {
       await this._schema.addColumn(this._tableName, columnName, type);
     } else {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1625,7 +1625,14 @@ export class Table {
   ): Promise<void> {
     this.raiseOnIfExistOptions(options as Record<string, unknown>);
     const { index: indexOpt, ...colOpts } = options;
-    await this._schema.addColumn(this._tableName, columnName, type, colOpts as ColumnOptions);
+    // Ruby's `@base.add_column(name, column_name, type, **options)` passes no
+    // fourth argument at all when `options` is empty; the CommandRecorder
+    // records the arguments verbatim, so the empty hash must not be spread in.
+    if (Object.keys(colOpts).length === 0) {
+      await this._schema.addColumn(this._tableName, columnName, type);
+    } else {
+      await this._schema.addColumn(this._tableName, columnName, type, colOpts as ColumnOptions);
+    }
     if (indexOpt) {
       const opts: AddIndexOptions = typeof indexOpt === "object" ? indexOpt : {};
       await this._schema.addIndex(this._tableName, columnName, opts);

--- a/packages/activerecord/src/migration/command-recorder.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { beforeEach, describe, it, expect } from "vitest";
 import { CommandRecorder } from "./command-recorder.js";
 import { IrreversibleMigration } from "../migration.js";
 import { Table } from "../connection-adapters/abstract/schema-definitions.js";
@@ -449,6 +449,16 @@ describe("CommandRecorder", () => {
 
 describe("Migration", () => {
   describe("CommandRecorderTest", () => {
+    let recorder: CommandRecorder & {
+      createTable(...args: unknown[]): void;
+      execute(sql: string): void;
+      nonExistingMethod(name: string): void;
+    };
+
+    beforeEach(() => {
+      recorder = new CommandRecorder(abstractDelegate) as typeof recorder;
+    });
+
     it("respond to delegates", () => {
       const recorder = new CommandRecorder({ america() {} }) as unknown as {
         america: unknown;
@@ -457,9 +467,6 @@ describe("Migration", () => {
     });
 
     it("send calls super", () => {
-      const recorder = new CommandRecorder(abstractDelegate) as unknown as {
-        nonExistingMethod(name: string): void;
-      };
       expect(() => recorder.nonExistingMethod("horses")).toThrow(TypeError);
     });
 
@@ -481,27 +488,23 @@ describe("Migration", () => {
     });
 
     it("inverse of raise exception on unknown commands", () => {
-      const recorder = new CommandRecorder(abstractDelegate);
       expect(() => recorder.inverseOf("execute", ["some sql"])).toThrow(IrreversibleMigration);
     });
 
     it("irreversible commands raise exception", async () => {
-      const recorder = new CommandRecorder(abstractDelegate);
       await expect(
         recorder.revert(async () => {
-          (recorder as unknown as { execute(sql: string): void }).execute("some sql");
+          recorder.execute("some sql");
         }),
       ).rejects.toThrow(IrreversibleMigration);
     });
 
     it("record", () => {
-      const recorder = new CommandRecorder(abstractDelegate);
       recorder.record("createTable", ["system_settings"]);
       expect(recorder.commands.length).toBe(1);
     });
 
     it("inverted commands are reversed", async () => {
-      const recorder = new CommandRecorder(abstractDelegate);
       await recorder.revert(async () => {
         recorder.record("createTable", ["hello"]);
         recorder.record("createTable", ["world"]);
@@ -512,9 +515,6 @@ describe("Migration", () => {
 
     it("revert order", async () => {
       const block = (t: Table) => t.string("name");
-      const recorder = new CommandRecorder(abstractDelegate) as unknown as CommandRecorder & {
-        createTable(...args: unknown[]): void;
-      };
       /* eslint-disable blazetrails/require-table-teardown */
       recorder.createTable("apples", block);
       await recorder.revert(async () => {
@@ -542,7 +542,6 @@ describe("Migration", () => {
     });
 
     it("invert change table", async () => {
-      const recorder = new CommandRecorder(abstractDelegate);
       await recorder.revert(async () => {
         await recorder.changeTable("fruits", async (t) => {
           await t.string("name");
@@ -565,7 +564,6 @@ describe("Migration", () => {
     });
 
     it("invert create table", async () => {
-      const recorder = new CommandRecorder(abstractDelegate);
       await recorder.revert(async () => {
         recorder.record("createTable", ["system_settings"]);
       });
@@ -574,7 +572,6 @@ describe("Migration", () => {
     });
 
     it("invert create table with if not exists", async () => {
-      const recorder = new CommandRecorder(abstractDelegate);
       await recorder.revert(async () => {
         recorder.record("createTable", ["system_settings", { ifNotExists: true }]);
       });
@@ -584,7 +581,7 @@ describe("Migration", () => {
 
     it("invert create table with options and block", () => {
       const block = () => {};
-      const dropTable = new CommandRecorder(abstractDelegate).inverseOf("createTable", [
+      const dropTable = recorder.inverseOf("createTable", [
         "people_reminders",
         { id: false },
         block,
@@ -597,7 +594,7 @@ describe("Migration", () => {
 
     it("invert drop table", () => {
       const block = () => {};
-      const createTable = new CommandRecorder(abstractDelegate).inverseOf("dropTable", [
+      const createTable = recorder.inverseOf("dropTable", [
         "people_reminders",
         { id: false },
         block,
@@ -610,7 +607,7 @@ describe("Migration", () => {
 
     it("invert drop table with if exists", () => {
       const block = () => {};
-      const createTable = new CommandRecorder(abstractDelegate).inverseOf("dropTable", [
+      const createTable = recorder.inverseOf("dropTable", [
         "people_reminders",
         { id: false, ifExists: true },
         block,
@@ -622,8 +619,7 @@ describe("Migration", () => {
     });
 
     it("invert drop table without a block nor option", () => {
-      const inverseOf = () =>
-        new CommandRecorder(abstractDelegate).inverseOf("dropTable", ["people_reminders"]);
+      const inverseOf = () => recorder.inverseOf("dropTable", ["people_reminders"]);
       expect(inverseOf).toThrow(IrreversibleMigration);
       expect(inverseOf).toThrow(
         "To avoid mistakes, drop_table is only reversible if given options or a block (can be empty).",
@@ -631,8 +627,7 @@ describe("Migration", () => {
     });
 
     it("invert drop table with multiple tables", () => {
-      const inverseOf = () =>
-        new CommandRecorder(abstractDelegate).inverseOf("dropTable", ["musics", "artists"]);
+      const inverseOf = () => recorder.inverseOf("dropTable", ["musics", "artists"]);
       expect(inverseOf).toThrow(IrreversibleMigration);
       expect(inverseOf).toThrow(
         "To avoid mistakes, drop_table is only reversible if given a single table name.",
@@ -640,12 +635,7 @@ describe("Migration", () => {
     });
 
     it("invert drop table with multiple tables and options", () => {
-      const inverseOf = () =>
-        new CommandRecorder(abstractDelegate).inverseOf("dropTable", [
-          "musics",
-          "artists",
-          { id: false },
-        ]);
+      const inverseOf = () => recorder.inverseOf("dropTable", ["musics", "artists", { id: false }]);
       expect(inverseOf).toThrow(IrreversibleMigration);
       expect(inverseOf).toThrow(
         "To avoid mistakes, drop_table is only reversible if given a single table name.",
@@ -654,8 +644,7 @@ describe("Migration", () => {
 
     it("invert drop table with multiple tables and block", () => {
       const block = () => {};
-      const inverseOf = () =>
-        new CommandRecorder(abstractDelegate).inverseOf("dropTable", ["musics", "artists", block]);
+      const inverseOf = () => recorder.inverseOf("dropTable", ["musics", "artists", block]);
       expect(inverseOf).toThrow(IrreversibleMigration);
       expect(inverseOf).toThrow(
         "To avoid mistakes, drop_table is only reversible if given a single table name.",
@@ -663,15 +652,12 @@ describe("Migration", () => {
     });
 
     it("invert create join table", () => {
-      const dropJoinTable = new CommandRecorder(abstractDelegate).inverseOf("createJoinTable", [
-        "musics",
-        "artists",
-      ]);
+      const dropJoinTable = recorder.inverseOf("createJoinTable", ["musics", "artists"]);
       expect(dropJoinTable).toEqual({ cmd: "dropJoinTable", args: ["musics", "artists"] });
     });
 
     it("invert create join table with table name", () => {
-      const dropJoinTable = new CommandRecorder(abstractDelegate).inverseOf("createJoinTable", [
+      const dropJoinTable = recorder.inverseOf("createJoinTable", [
         "musics",
         "artists",
         { tableName: "catalog" },
@@ -684,7 +670,7 @@ describe("Migration", () => {
 
     it("invert drop join table", () => {
       const block = () => {};
-      const createJoinTable = new CommandRecorder(abstractDelegate).inverseOf("dropJoinTable", [
+      const createJoinTable = recorder.inverseOf("dropJoinTable", [
         "musics",
         "artists",
         { tableName: "catalog" },
@@ -697,43 +683,29 @@ describe("Migration", () => {
     });
 
     it("invert rename table", () => {
-      const rename = new CommandRecorder(abstractDelegate).inverseOf("renameTable", ["old", "new"]);
+      const rename = recorder.inverseOf("renameTable", ["old", "new"]);
       expect(rename).toEqual({ cmd: "renameTable", args: ["new", "old"] });
     });
 
     it("invert add column", () => {
-      const remove = new CommandRecorder(abstractDelegate).inverseOf("addColumn", [
-        "table",
-        "column",
-        "type",
-        {},
-      ]);
+      const remove = recorder.inverseOf("addColumn", ["table", "column", "type", {}]);
       expect(remove).toEqual({ cmd: "removeColumn", args: ["table", "column", "type", {}] });
     });
 
     it("invert change column", () => {
-      expect(() =>
-        new CommandRecorder(abstractDelegate).inverseOf("changeColumn", [
-          "table",
-          "column",
-          "type",
-          {},
-        ]),
-      ).toThrow(IrreversibleMigration);
+      expect(() => recorder.inverseOf("changeColumn", ["table", "column", "type", {}])).toThrow(
+        IrreversibleMigration,
+      );
     });
 
     it("invert change column default", () => {
       expect(() =>
-        new CommandRecorder(abstractDelegate).inverseOf("changeColumnDefault", [
-          "table",
-          "column",
-          "default_value",
-        ]),
+        recorder.inverseOf("changeColumnDefault", ["table", "column", "default_value"]),
       ).toThrow(IrreversibleMigration);
     });
 
     it("invert change column default with from and to", () => {
-      const change = new CommandRecorder(abstractDelegate).inverseOf("changeColumnDefault", [
+      const change = recorder.inverseOf("changeColumnDefault", [
         "table",
         "column",
         { from: "old_value", to: "new_value" },
@@ -745,7 +717,7 @@ describe("Migration", () => {
     });
 
     it("invert change column default with from and to with boolean", () => {
-      const change = new CommandRecorder(abstractDelegate).inverseOf("changeColumnDefault", [
+      const change = recorder.inverseOf("changeColumnDefault", [
         "table",
         "column",
         { from: true, to: false },
@@ -757,49 +729,33 @@ describe("Migration", () => {
     });
 
     it("invert change column null", () => {
-      const add = new CommandRecorder(abstractDelegate).inverseOf("changeColumnNull", [
-        "table",
-        "column",
-        true,
-      ]);
+      const add = recorder.inverseOf("changeColumnNull", ["table", "column", true]);
       expect(add).toEqual({ cmd: "changeColumnNull", args: ["table", "column", false] });
     });
 
     it("invert remove column", () => {
-      const add = new CommandRecorder(abstractDelegate).inverseOf("removeColumn", [
-        "table",
-        "column",
-        "type",
-        {},
-      ]);
+      const add = recorder.inverseOf("removeColumn", ["table", "column", "type", {}]);
       expect(add).toEqual({ cmd: "addColumn", args: ["table", "column", "type", {}] });
     });
 
     it("invert remove column without type", () => {
-      expect(() =>
-        new CommandRecorder(abstractDelegate).inverseOf("removeColumn", ["table", "column"]),
-      ).toThrow(IrreversibleMigration);
+      expect(() => recorder.inverseOf("removeColumn", ["table", "column"])).toThrow(
+        IrreversibleMigration,
+      );
     });
 
     it("invert rename column", () => {
-      const rename = new CommandRecorder(abstractDelegate).inverseOf("renameColumn", [
-        "table",
-        "old",
-        "new",
-      ]);
+      const rename = recorder.inverseOf("renameColumn", ["table", "old", "new"]);
       expect(rename).toEqual({ cmd: "renameColumn", args: ["table", "new", "old"] });
     });
 
     it("invert add index", () => {
-      const remove = new CommandRecorder(abstractDelegate).inverseOf("addIndex", [
-        "table",
-        ["one", "two"],
-      ]);
+      const remove = recorder.inverseOf("addIndex", ["table", ["one", "two"]]);
       expect(remove).toEqual({ cmd: "removeIndex", args: ["table", ["one", "two"]] });
     });
 
     it("invert add index with name", () => {
-      const remove = new CommandRecorder(abstractDelegate).inverseOf("addIndex", [
+      const remove = recorder.inverseOf("addIndex", [
         "table",
         ["one", "two"],
         { name: "new_index" },
@@ -811,33 +767,29 @@ describe("Migration", () => {
     });
 
     it("invert add index with algorithm option", () => {
-      const remove = new CommandRecorder(abstractDelegate).inverseOf("addIndex", [
+      const remove = recorder.inverseOf("addIndex", [
         "table",
         "one",
-        { algorithm: ":concurrently" },
+        { algorithm: "concurrently" },
       ]);
       expect(remove).toEqual({
         cmd: "removeIndex",
-        args: ["table", "one", { algorithm: ":concurrently" }],
+        args: ["table", "one", { algorithm: "concurrently" }],
       });
     });
 
     it("invert remove index", () => {
-      const add = new CommandRecorder(abstractDelegate).inverseOf("removeIndex", ["table", "one"]);
+      const add = recorder.inverseOf("removeIndex", ["table", "one"]);
       expect(add).toEqual({ cmd: "addIndex", args: ["table", "one"] });
     });
 
     it("invert remove index with positional column", () => {
-      const add = new CommandRecorder(abstractDelegate).inverseOf("removeIndex", [
-        "table",
-        ["one", "two"],
-        { options: true },
-      ]);
+      const add = recorder.inverseOf("removeIndex", ["table", ["one", "two"], { options: true }]);
       expect(add).toEqual({ cmd: "addIndex", args: ["table", ["one", "two"], { options: true }] });
     });
 
     it("invert remove index with column", () => {
-      const add = new CommandRecorder(abstractDelegate).inverseOf("removeIndex", [
+      const add = recorder.inverseOf("removeIndex", [
         "table",
         { column: ["one", "two"], options: true },
       ]);
@@ -845,7 +797,7 @@ describe("Migration", () => {
     });
 
     it("invert remove index with name", () => {
-      const add = new CommandRecorder(abstractDelegate).inverseOf("removeIndex", [
+      const add = recorder.inverseOf("removeIndex", [
         "table",
         { column: ["one", "two"], name: "new_index" },
       ]);
@@ -856,28 +808,18 @@ describe("Migration", () => {
     });
 
     it("invert remove index with no special options", () => {
-      const add = new CommandRecorder(abstractDelegate).inverseOf("removeIndex", [
-        "table",
-        { column: ["one", "two"] },
-      ]);
+      const add = recorder.inverseOf("removeIndex", ["table", { column: ["one", "two"] }]);
       expect(add).toEqual({ cmd: "addIndex", args: ["table", ["one", "two"]] });
     });
 
     it("invert remove index with no column", () => {
-      expect(() =>
-        new CommandRecorder(abstractDelegate).inverseOf("removeIndex", [
-          "table",
-          { name: "new_index" },
-        ]),
-      ).toThrow(IrreversibleMigration);
+      expect(() => recorder.inverseOf("removeIndex", ["table", { name: "new_index" }])).toThrow(
+        IrreversibleMigration,
+      );
     });
 
     it("invert rename index", () => {
-      const rename = new CommandRecorder(abstractDelegate).inverseOf("renameIndex", [
-        "table",
-        "old",
-        "new",
-      ]);
+      const rename = recorder.inverseOf("renameIndex", ["table", "old", "new"]);
       expect(rename).toEqual({ cmd: "renameIndex", args: ["table", "new", "old"] });
     });
   });

--- a/packages/activerecord/src/migration/command-recorder.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.test.ts
@@ -18,129 +18,6 @@ const mysqlDelegate = {
 };
 
 describe("CommandRecorder", () => {
-  it("records commands", () => {
-    const recorder = new CommandRecorder();
-    recorder.record("addColumn", ["users", "name", "string"]);
-    expect(recorder.commands).toEqual([{ cmd: "addColumn", args: ["users", "name", "string"] }]);
-  });
-
-  it("reverting toggles and inverts commands", async () => {
-    const recorder = new CommandRecorder();
-    await recorder.revert(async () => {
-      recorder.record("addColumn", ["users", "name", "string"]);
-    });
-    expect(recorder.commands[0].cmd).toBe("removeColumn");
-  });
-
-  describe("inverseOf", () => {
-    it("returns the inverse command", () => {
-      const recorder = new CommandRecorder();
-      const result = recorder.inverseOf("addColumn", ["users", "name", "string"]);
-      expect(result).toEqual({ cmd: "removeColumn", args: ["users", "name", "string"] });
-    });
-
-    it("throws IrreversibleMigration for unknown commands", () => {
-      const recorder = new CommandRecorder();
-      expect(() => recorder.inverseOf("dropDatabase", [])).toThrow(IrreversibleMigration);
-    });
-  });
-
-  describe("invertCreateTable / invertDropTable", () => {
-    it("invertCreateTable removes ifNotExists and returns dropTable", () => {
-      const recorder = new CommandRecorder();
-      const [cmd, args] = recorder.invertCreateTable(["users", { ifNotExists: true }]);
-      expect(cmd).toBe("dropTable");
-      expect((args[1] as Record<string, unknown>)["ifNotExists"]).toBeUndefined();
-    });
-
-    it("invertCreateTable strips ifNotExists even when fn is last arg", () => {
-      const fn = () => {};
-      const [cmd, args] = new CommandRecorder().invertCreateTable([
-        "users",
-        { ifNotExists: true },
-        fn,
-      ]);
-      expect(cmd).toBe("dropTable");
-      expect((args[1] as Record<string, unknown>)["ifNotExists"]).toBeUndefined();
-    });
-
-    it("invertDropTable throws without options/block for single table", () => {
-      const recorder = new CommandRecorder();
-      expect(() => recorder.invertDropTable(["users"])).toThrow(IrreversibleMigration);
-    });
-
-    it("invertDropTable throws for multiple tables", () => {
-      const recorder = new CommandRecorder();
-      expect(() => recorder.invertDropTable(["users", "posts"])).toThrow(IrreversibleMigration);
-    });
-
-    it("invertDropTable returns createTable when options present", () => {
-      const recorder = new CommandRecorder();
-      const [cmd, args] = recorder.invertDropTable(["users", { force: true }]);
-      expect(cmd).toBe("createTable");
-      expect(args[0]).toBe("users");
-    });
-  });
-
-  describe("invertCreateJoinTable / invertDropJoinTable", () => {
-    it("invertCreateJoinTable returns dropJoinTable", () => {
-      const recorder = new CommandRecorder();
-      const [cmd] = recorder.invertCreateJoinTable(["cats", "dogs"]);
-      expect(cmd).toBe("dropJoinTable");
-    });
-
-    it("invertDropJoinTable returns createJoinTable", () => {
-      const recorder = new CommandRecorder();
-      const [cmd] = recorder.invertDropJoinTable(["cats", "dogs"]);
-      expect(cmd).toBe("createJoinTable");
-    });
-  });
-
-  describe("invertAddColumn / invertRemoveColumn", () => {
-    it("invertAddColumn returns removeColumn", () => {
-      const recorder = new CommandRecorder();
-      const [cmd] = recorder.invertAddColumn(["users", "age", "integer"]);
-      expect(cmd).toBe("removeColumn");
-    });
-
-    it("invertRemoveColumn throws without type", () => {
-      const recorder = new CommandRecorder();
-      expect(() => recorder.invertRemoveColumn(["users", "age"])).toThrow(IrreversibleMigration);
-    });
-
-    it("invertRemoveColumn returns addColumn when type given", () => {
-      const recorder = new CommandRecorder();
-      const [cmd] = recorder.invertRemoveColumn(["users", "age", "integer"]);
-      expect(cmd).toBe("addColumn");
-    });
-  });
-
-  describe("invertAddIndex / invertRemoveIndex", () => {
-    it("invertAddIndex returns removeIndex", () => {
-      const recorder = new CommandRecorder();
-      const [cmd] = recorder.invertAddIndex(["users", "email"]);
-      expect(cmd).toBe("removeIndex");
-    });
-
-    it("invertRemoveIndex throws without column", () => {
-      const recorder = new CommandRecorder();
-      expect(() => recorder.invertRemoveIndex(["users"])).toThrow(IrreversibleMigration);
-    });
-
-    it("invertRemoveIndex returns addIndex with column option", () => {
-      const recorder = new CommandRecorder();
-      const [cmd, args] = recorder.invertRemoveIndex(["users", { column: "email" }]);
-      expect(cmd).toBe("addIndex");
-      expect(args[1]).toBe("email");
-    });
-
-    it("invertRemoveIndex handles array column list without treating it as options", () => {
-      const [cmd, args] = new CommandRecorder().invertRemoveIndex(["users", ["email", "name"]]);
-      expect(cmd).toBe("addIndex");
-      expect(args[1]).toEqual(["email", "name"]);
-    });
-  });
-
   describe("invertAddTimestamps / invertRemoveTimestamps", () => {
     it("invertAddTimestamps returns removeTimestamps", () => {
       const [cmd] = new CommandRecorder().invertAddTimestamps(["users"]);
@@ -274,58 +151,6 @@ describe("CommandRecorder", () => {
     });
   });
 
-  describe("invertRenameTable / invertRenameColumn", () => {
-    it("invertRenameTable swaps table names", () => {
-      const [cmd, args] = new CommandRecorder().invertRenameTable(["old_users", "new_users"]);
-      expect(cmd).toBe("renameTable");
-      expect(args).toEqual(["new_users", "old_users"]);
-    });
-
-    it("invertRenameColumn swaps column names", () => {
-      const [cmd, args] = new CommandRecorder().invertRenameColumn([
-        "users",
-        "old_name",
-        "new_name",
-      ]);
-      expect(cmd).toBe("renameColumn");
-      expect(args).toEqual(["users", "new_name", "old_name"]);
-    });
-  });
-
-  describe("invertRenameIndex", () => {
-    it("swaps index names", () => {
-      const [cmd, args] = new CommandRecorder().invertRenameIndex(["users", "old_idx", "new_idx"]);
-      expect(cmd).toBe("renameIndex");
-      expect(args).toEqual(["users", "new_idx", "old_idx"]);
-    });
-  });
-
-  describe("invertChangeColumnDefault", () => {
-    it("throws without from/to options", () => {
-      expect(() => new CommandRecorder().invertChangeColumnDefault(["users", "age", 0])).toThrow(
-        IrreversibleMigration,
-      );
-    });
-
-    it("swaps from/to values", () => {
-      const [cmd, args] = new CommandRecorder().invertChangeColumnDefault([
-        "users",
-        "age",
-        { from: 0, to: 18 },
-      ]);
-      expect(cmd).toBe("changeColumnDefault");
-      expect(args[2] as Record<string, unknown>).toEqual({ from: 18, to: 0 });
-    });
-  });
-
-  describe("invertChangeColumnNull", () => {
-    it("flips the nullable boolean", () => {
-      const [cmd, args] = new CommandRecorder().invertChangeColumnNull(["users", "email", false]);
-      expect(cmd).toBe("changeColumnNull");
-      expect(args[2]).toBe(true);
-    });
-  });
-
   describe("invertRemoveColumns", () => {
     it("throws without type option", () => {
       expect(() => new CommandRecorder().invertRemoveColumns(["users", "name", "age"])).toThrow(
@@ -419,15 +244,6 @@ describe("CommandRecorder", () => {
     });
   });
 
-  describe("invert change column", () => {
-    it("throws IrreversibleMigration", () => {
-      const recorder = new CommandRecorder();
-      expect(() => recorder.inverseOf("changeColumn", ["table", "column", "string", {}])).toThrow(
-        IrreversibleMigration,
-      );
-    });
-  });
-
   describe("invertAddColumns", () => {
     it("returns removeColumns", () => {
       const [cmd] = new CommandRecorder().invertAddColumns(["users", "name", "age"]);
@@ -453,24 +269,6 @@ describe("CommandRecorder", () => {
       expect(recorder.commands).toEqual([
         { cmd: "removeColumns", args: ["fruits", "name", "kind", { type: "string" }] },
       ]);
-    });
-
-    it("reverts string + rename inside change_table block", async () => {
-      const recorder = new CommandRecorder(abstractDelegate);
-      await recorder.revert(async () => {
-        await recorder.changeTable("fruits", async (t) => {
-          await t.string("name");
-          await t.rename("kind", "cultivar");
-        });
-      });
-      // Reversed order and inverted: renameColumn first, then removeColumn
-      expect(recorder.commands).toHaveLength(2);
-      const [first, second] = recorder.commands;
-      expect(first.cmd).toBe("renameColumn");
-      expect(first.args).toEqual(["fruits", "cultivar", "kind"]);
-      expect(second.cmd).toBe("removeColumn");
-      expect(second.args[0]).toBe("fruits");
-      expect(second.args[1]).toBe("name");
     });
 
     it("removeIndex with an options hash records a nil column, not the hash", async () => {
@@ -539,8 +337,8 @@ describe("CommandRecorder", () => {
         await (t as any).bigserial("big_seq");
       });
       expect(recorder.commands).toEqual([
-        { cmd: "addColumn", args: ["fruits", "seq", "serial", {}] },
-        { cmd: "addColumn", args: ["fruits", "big_seq", "bigserial", {}] },
+        { cmd: "addColumn", args: ["fruits", "seq", "serial"] },
+        { cmd: "addColumn", args: ["fruits", "big_seq", "bigserial"] },
       ]);
     });
 
@@ -553,8 +351,8 @@ describe("CommandRecorder", () => {
         });
       });
       expect(recorder.commands).toEqual([
-        { cmd: "removeColumn", args: ["fruits", "big_seq", "bigserial", {}] },
-        { cmd: "removeColumn", args: ["fruits", "seq", "serial", {}] },
+        { cmd: "removeColumn", args: ["fruits", "big_seq", "bigserial"] },
+        { cmd: "removeColumn", args: ["fruits", "seq", "serial"] },
       ]);
     });
 
@@ -575,7 +373,7 @@ describe("CommandRecorder", () => {
         await (t as any).bitVarying("mask");
       });
       expect(recorder.commands).toEqual([
-        { cmd: "addColumn", args: ["fruits", "mask", "bit_varying", {}] },
+        { cmd: "addColumn", args: ["fruits", "mask", "bit_varying"] },
       ]);
     });
   });
@@ -599,9 +397,9 @@ describe("CommandRecorder", () => {
         await (t as any).longblob("payload");
       });
       expect(recorder.commands).toEqual([
-        { cmd: "addColumn", args: ["fruits", "qty", "unsigned_integer", {}] },
-        { cmd: "addColumn", args: ["fruits", "notes", "mediumtext", {}] },
-        { cmd: "addColumn", args: ["fruits", "payload", "longblob", {}] },
+        { cmd: "addColumn", args: ["fruits", "qty", "unsigned_integer"] },
+        { cmd: "addColumn", args: ["fruits", "notes", "mediumtext"] },
+        { cmd: "addColumn", args: ["fruits", "payload", "longblob"] },
       ]);
     });
 
@@ -614,8 +412,8 @@ describe("CommandRecorder", () => {
         });
       });
       expect(recorder.commands).toEqual([
-        { cmd: "removeColumn", args: ["fruits", "notes", "mediumtext", {}] },
-        { cmd: "removeColumn", args: ["fruits", "qty", "unsigned_integer", {}] },
+        { cmd: "removeColumn", args: ["fruits", "notes", "mediumtext"] },
+        { cmd: "removeColumn", args: ["fruits", "qty", "unsigned_integer"] },
       ]);
     });
   });
@@ -658,6 +456,15 @@ describe("Migration", () => {
       expect(typeof recorder.america).toBe("function");
     });
 
+    it("send calls super", () => {
+      // Ruby's `NoMethodError` for an undefined method is JS's `TypeError`:
+      // the proxy resolves the unknown name to `undefined`, and calling it throws.
+      const recorder = new CommandRecorder(abstractDelegate) as unknown as {
+        nonExistingMethod(name: string): void;
+      };
+      expect(() => recorder.nonExistingMethod("horses")).toThrow(TypeError);
+    });
+
     it("send delegates to record", () => {
       const recorder = new CommandRecorder({ createTable(_name: string) {} });
       // The recorder only records the command — no DDL runs, so there is no table to tear down.
@@ -673,6 +480,402 @@ describe("Migration", () => {
         },
       }) as unknown as { foo(kw: string): string };
       expect(recorder.foo("bar")).toBe("bar");
+    });
+
+    it("inverse of raise exception on unknown commands", () => {
+      const recorder = new CommandRecorder(abstractDelegate);
+      expect(() => recorder.inverseOf("execute", ["some sql"])).toThrow(IrreversibleMigration);
+    });
+
+    it("irreversible commands raise exception", async () => {
+      const recorder = new CommandRecorder(abstractDelegate);
+      await expect(
+        recorder.revert(async () => {
+          (recorder as unknown as { execute(sql: string): void }).execute("some sql");
+        }),
+      ).rejects.toThrow(IrreversibleMigration);
+    });
+
+    it("record", () => {
+      const recorder = new CommandRecorder(abstractDelegate);
+      recorder.record("createTable", ["system_settings"]);
+      expect(recorder.commands.length).toBe(1);
+    });
+
+    it("inverted commands are reversed", async () => {
+      const recorder = new CommandRecorder(abstractDelegate);
+      await recorder.revert(async () => {
+        recorder.record("createTable", ["hello"]);
+        recorder.record("createTable", ["world"]);
+      });
+      const tables = recorder.commands.map(({ args }) => args);
+      expect(tables).toEqual([["world"], ["hello"]]);
+    });
+
+    it("revert order", async () => {
+      // Ruby passes the block beside the args and `commands` carries it as a
+      // third element; a JS callback is an ordinary argument, so it rides in
+      // `args` instead.
+      const block = (t: Table) => t.string("name");
+      const recorder = new CommandRecorder(abstractDelegate) as unknown as CommandRecorder & {
+        createTable(...args: unknown[]): void;
+      };
+      // The recorder only records the commands — no DDL runs, so there is
+      // nothing to tear down.
+      /* eslint-disable blazetrails/require-table-teardown */
+      recorder.createTable("apples", block);
+      await recorder.revert(async () => {
+        recorder.createTable("bananas", block);
+        await recorder.revert(async () => {
+          recorder.createTable("clementines", block);
+          recorder.createTable("dates");
+        });
+        recorder.createTable("elderberries");
+      });
+      await recorder.revert(async () => {
+        recorder.createTable("figs", block);
+        recorder.createTable("grapes");
+      });
+      /* eslint-enable blazetrails/require-table-teardown */
+      expect(recorder.commands).toEqual([
+        { cmd: "createTable", args: ["apples", block] },
+        { cmd: "dropTable", args: ["elderberries"] },
+        { cmd: "createTable", args: ["clementines", block] },
+        { cmd: "createTable", args: ["dates"] },
+        { cmd: "dropTable", args: ["bananas", block] },
+        { cmd: "dropTable", args: ["grapes"] },
+        { cmd: "dropTable", args: ["figs", block] },
+      ]);
+    });
+
+    it("invert change table", async () => {
+      const recorder = new CommandRecorder(abstractDelegate);
+      await recorder.revert(async () => {
+        await recorder.changeTable("fruits", async (t) => {
+          await t.string("name");
+          await t.rename("kind", "cultivar");
+        });
+      });
+
+      expect(recorder.commands).toEqual([
+        { cmd: "renameColumn", args: ["fruits", "cultivar", "kind"] },
+        { cmd: "removeColumn", args: ["fruits", "name", "string"] },
+      ]);
+
+      await expect(
+        recorder.revert(async () => {
+          await recorder.changeTable("fruits", async (t) => {
+            await t.remove("kind");
+          });
+        }),
+      ).rejects.toThrow(IrreversibleMigration);
+    });
+
+    it("invert create table", async () => {
+      const recorder = new CommandRecorder(abstractDelegate);
+      await recorder.revert(async () => {
+        recorder.record("createTable", ["system_settings"]);
+      });
+      const dropTable = recorder.commands[0];
+      expect(dropTable).toEqual({ cmd: "dropTable", args: ["system_settings"] });
+    });
+
+    it("invert create table with if not exists", async () => {
+      const recorder = new CommandRecorder(abstractDelegate);
+      await recorder.revert(async () => {
+        recorder.record("createTable", ["system_settings", { ifNotExists: true }]);
+      });
+      const dropTable = recorder.commands[0];
+      expect(dropTable).toEqual({ cmd: "dropTable", args: ["system_settings", {}] });
+    });
+
+    it("invert create table with options and block", () => {
+      const block = () => {};
+      const dropTable = new CommandRecorder(abstractDelegate).inverseOf("createTable", [
+        "people_reminders",
+        { id: false },
+        block,
+      ]);
+      expect(dropTable).toEqual({
+        cmd: "dropTable",
+        args: ["people_reminders", { id: false }, block],
+      });
+    });
+
+    it("invert drop table", () => {
+      const block = () => {};
+      const createTable = new CommandRecorder(abstractDelegate).inverseOf("dropTable", [
+        "people_reminders",
+        { id: false },
+        block,
+      ]);
+      expect(createTable).toEqual({
+        cmd: "createTable",
+        args: ["people_reminders", { id: false }, block],
+      });
+    });
+
+    it("invert drop table with if exists", () => {
+      const block = () => {};
+      const createTable = new CommandRecorder(abstractDelegate).inverseOf("dropTable", [
+        "people_reminders",
+        { id: false, ifExists: true },
+        block,
+      ]);
+      expect(createTable).toEqual({
+        cmd: "createTable",
+        args: ["people_reminders", { id: false }, block],
+      });
+    });
+
+    it("invert drop table without a block nor option", () => {
+      expect(() =>
+        new CommandRecorder(abstractDelegate).inverseOf("dropTable", ["people_reminders"]),
+      ).toThrow(
+        "To avoid mistakes, drop_table is only reversible if given options or a block (can be empty).",
+      );
+    });
+
+    it("invert drop table with multiple tables", () => {
+      expect(() =>
+        new CommandRecorder(abstractDelegate).inverseOf("dropTable", ["musics", "artists"]),
+      ).toThrow("To avoid mistakes, drop_table is only reversible if given a single table name.");
+    });
+
+    it("invert drop table with multiple tables and options", () => {
+      expect(() =>
+        new CommandRecorder(abstractDelegate).inverseOf("dropTable", [
+          "musics",
+          "artists",
+          { id: false },
+        ]),
+      ).toThrow("To avoid mistakes, drop_table is only reversible if given a single table name.");
+    });
+
+    it("invert drop table with multiple tables and block", () => {
+      const block = () => {};
+      expect(() =>
+        new CommandRecorder(abstractDelegate).inverseOf("dropTable", ["musics", "artists", block]),
+      ).toThrow("To avoid mistakes, drop_table is only reversible if given a single table name.");
+    });
+
+    it("invert create join table", () => {
+      const dropJoinTable = new CommandRecorder(abstractDelegate).inverseOf("createJoinTable", [
+        "musics",
+        "artists",
+      ]);
+      expect(dropJoinTable).toEqual({ cmd: "dropJoinTable", args: ["musics", "artists"] });
+    });
+
+    it("invert create join table with table name", () => {
+      const dropJoinTable = new CommandRecorder(abstractDelegate).inverseOf("createJoinTable", [
+        "musics",
+        "artists",
+        { tableName: "catalog" },
+      ]);
+      expect(dropJoinTable).toEqual({
+        cmd: "dropJoinTable",
+        args: ["musics", "artists", { tableName: "catalog" }],
+      });
+    });
+
+    it("invert drop join table", () => {
+      const block = () => {};
+      const createJoinTable = new CommandRecorder(abstractDelegate).inverseOf("dropJoinTable", [
+        "musics",
+        "artists",
+        { tableName: "catalog" },
+        block,
+      ]);
+      expect(createJoinTable).toEqual({
+        cmd: "createJoinTable",
+        args: ["musics", "artists", { tableName: "catalog" }, block],
+      });
+    });
+
+    it("invert rename table", () => {
+      const rename = new CommandRecorder(abstractDelegate).inverseOf("renameTable", ["old", "new"]);
+      expect(rename).toEqual({ cmd: "renameTable", args: ["new", "old"] });
+    });
+
+    it("invert add column", () => {
+      const remove = new CommandRecorder(abstractDelegate).inverseOf("addColumn", [
+        "table",
+        "column",
+        "type",
+        {},
+      ]);
+      expect(remove).toEqual({ cmd: "removeColumn", args: ["table", "column", "type", {}] });
+    });
+
+    it("invert change column", () => {
+      expect(() =>
+        new CommandRecorder(abstractDelegate).inverseOf("changeColumn", [
+          "table",
+          "column",
+          "type",
+          {},
+        ]),
+      ).toThrow(IrreversibleMigration);
+    });
+
+    it("invert change column default", () => {
+      expect(() =>
+        new CommandRecorder(abstractDelegate).inverseOf("changeColumnDefault", [
+          "table",
+          "column",
+          "default_value",
+        ]),
+      ).toThrow(IrreversibleMigration);
+    });
+
+    it("invert change column default with from and to", () => {
+      const change = new CommandRecorder(abstractDelegate).inverseOf("changeColumnDefault", [
+        "table",
+        "column",
+        { from: "old_value", to: "new_value" },
+      ]);
+      expect(change).toEqual({
+        cmd: "changeColumnDefault",
+        args: ["table", "column", { from: "new_value", to: "old_value" }],
+      });
+    });
+
+    it("invert change column default with from and to with boolean", () => {
+      const change = new CommandRecorder(abstractDelegate).inverseOf("changeColumnDefault", [
+        "table",
+        "column",
+        { from: true, to: false },
+      ]);
+      expect(change).toEqual({
+        cmd: "changeColumnDefault",
+        args: ["table", "column", { from: false, to: true }],
+      });
+    });
+
+    it("invert change column null", () => {
+      const add = new CommandRecorder(abstractDelegate).inverseOf("changeColumnNull", [
+        "table",
+        "column",
+        true,
+      ]);
+      expect(add).toEqual({ cmd: "changeColumnNull", args: ["table", "column", false] });
+    });
+
+    it("invert remove column", () => {
+      const add = new CommandRecorder(abstractDelegate).inverseOf("removeColumn", [
+        "table",
+        "column",
+        "type",
+        {},
+      ]);
+      expect(add).toEqual({ cmd: "addColumn", args: ["table", "column", "type", {}] });
+    });
+
+    it("invert remove column without type", () => {
+      expect(() =>
+        new CommandRecorder(abstractDelegate).inverseOf("removeColumn", ["table", "column"]),
+      ).toThrow(IrreversibleMigration);
+    });
+
+    it("invert rename column", () => {
+      const rename = new CommandRecorder(abstractDelegate).inverseOf("renameColumn", [
+        "table",
+        "old",
+        "new",
+      ]);
+      expect(rename).toEqual({ cmd: "renameColumn", args: ["table", "new", "old"] });
+    });
+
+    it("invert add index", () => {
+      const remove = new CommandRecorder(abstractDelegate).inverseOf("addIndex", [
+        "table",
+        ["one", "two"],
+      ]);
+      expect(remove).toEqual({ cmd: "removeIndex", args: ["table", ["one", "two"]] });
+    });
+
+    it("invert add index with name", () => {
+      const remove = new CommandRecorder(abstractDelegate).inverseOf("addIndex", [
+        "table",
+        ["one", "two"],
+        { name: "new_index" },
+      ]);
+      expect(remove).toEqual({
+        cmd: "removeIndex",
+        args: ["table", ["one", "two"], { name: "new_index" }],
+      });
+    });
+
+    it("invert add index with algorithm option", () => {
+      const remove = new CommandRecorder(abstractDelegate).inverseOf("addIndex", [
+        "table",
+        "one",
+        { algorithm: ":concurrently" },
+      ]);
+      expect(remove).toEqual({
+        cmd: "removeIndex",
+        args: ["table", "one", { algorithm: ":concurrently" }],
+      });
+    });
+
+    it("invert remove index", () => {
+      const add = new CommandRecorder(abstractDelegate).inverseOf("removeIndex", ["table", "one"]);
+      expect(add).toEqual({ cmd: "addIndex", args: ["table", "one"] });
+    });
+
+    it("invert remove index with positional column", () => {
+      const add = new CommandRecorder(abstractDelegate).inverseOf("removeIndex", [
+        "table",
+        ["one", "two"],
+        { options: true },
+      ]);
+      expect(add).toEqual({ cmd: "addIndex", args: ["table", ["one", "two"], { options: true }] });
+    });
+
+    it("invert remove index with column", () => {
+      const add = new CommandRecorder(abstractDelegate).inverseOf("removeIndex", [
+        "table",
+        { column: ["one", "two"], options: true },
+      ]);
+      expect(add).toEqual({ cmd: "addIndex", args: ["table", ["one", "two"], { options: true }] });
+    });
+
+    it("invert remove index with name", () => {
+      const add = new CommandRecorder(abstractDelegate).inverseOf("removeIndex", [
+        "table",
+        { column: ["one", "two"], name: "new_index" },
+      ]);
+      expect(add).toEqual({
+        cmd: "addIndex",
+        args: ["table", ["one", "two"], { name: "new_index" }],
+      });
+    });
+
+    it("invert remove index with no special options", () => {
+      const add = new CommandRecorder(abstractDelegate).inverseOf("removeIndex", [
+        "table",
+        { column: ["one", "two"] },
+      ]);
+      expect(add).toEqual({ cmd: "addIndex", args: ["table", ["one", "two"]] });
+    });
+
+    it("invert remove index with no column", () => {
+      expect(() =>
+        new CommandRecorder(abstractDelegate).inverseOf("removeIndex", [
+          "table",
+          { name: "new_index" },
+        ]),
+      ).toThrow(IrreversibleMigration);
+    });
+
+    it("invert rename index", () => {
+      const rename = new CommandRecorder(abstractDelegate).inverseOf("renameIndex", [
+        "table",
+        "old",
+        "new",
+      ]);
+      expect(rename).toEqual({ cmd: "renameIndex", args: ["table", "new", "old"] });
     });
   });
 });

--- a/packages/activerecord/src/migration/command-recorder.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.test.ts
@@ -457,8 +457,6 @@ describe("Migration", () => {
     });
 
     it("send calls super", () => {
-      // Ruby's `NoMethodError` for an undefined method is JS's `TypeError`:
-      // the proxy resolves the unknown name to `undefined`, and calling it throws.
       const recorder = new CommandRecorder(abstractDelegate) as unknown as {
         nonExistingMethod(name: string): void;
       };
@@ -513,15 +511,10 @@ describe("Migration", () => {
     });
 
     it("revert order", async () => {
-      // Ruby passes the block beside the args and `commands` carries it as a
-      // third element; a JS callback is an ordinary argument, so it rides in
-      // `args` instead.
       const block = (t: Table) => t.string("name");
       const recorder = new CommandRecorder(abstractDelegate) as unknown as CommandRecorder & {
         createTable(...args: unknown[]): void;
       };
-      // The recorder only records the commands — no DDL runs, so there is
-      // nothing to tear down.
       /* eslint-disable blazetrails/require-table-teardown */
       recorder.createTable("apples", block);
       await recorder.revert(async () => {
@@ -629,34 +622,44 @@ describe("Migration", () => {
     });
 
     it("invert drop table without a block nor option", () => {
-      expect(() =>
-        new CommandRecorder(abstractDelegate).inverseOf("dropTable", ["people_reminders"]),
-      ).toThrow(
+      const inverseOf = () =>
+        new CommandRecorder(abstractDelegate).inverseOf("dropTable", ["people_reminders"]);
+      expect(inverseOf).toThrow(IrreversibleMigration);
+      expect(inverseOf).toThrow(
         "To avoid mistakes, drop_table is only reversible if given options or a block (can be empty).",
       );
     });
 
     it("invert drop table with multiple tables", () => {
-      expect(() =>
-        new CommandRecorder(abstractDelegate).inverseOf("dropTable", ["musics", "artists"]),
-      ).toThrow("To avoid mistakes, drop_table is only reversible if given a single table name.");
+      const inverseOf = () =>
+        new CommandRecorder(abstractDelegate).inverseOf("dropTable", ["musics", "artists"]);
+      expect(inverseOf).toThrow(IrreversibleMigration);
+      expect(inverseOf).toThrow(
+        "To avoid mistakes, drop_table is only reversible if given a single table name.",
+      );
     });
 
     it("invert drop table with multiple tables and options", () => {
-      expect(() =>
+      const inverseOf = () =>
         new CommandRecorder(abstractDelegate).inverseOf("dropTable", [
           "musics",
           "artists",
           { id: false },
-        ]),
-      ).toThrow("To avoid mistakes, drop_table is only reversible if given a single table name.");
+        ]);
+      expect(inverseOf).toThrow(IrreversibleMigration);
+      expect(inverseOf).toThrow(
+        "To avoid mistakes, drop_table is only reversible if given a single table name.",
+      );
     });
 
     it("invert drop table with multiple tables and block", () => {
       const block = () => {};
-      expect(() =>
-        new CommandRecorder(abstractDelegate).inverseOf("dropTable", ["musics", "artists", block]),
-      ).toThrow("To avoid mistakes, drop_table is only reversible if given a single table name.");
+      const inverseOf = () =>
+        new CommandRecorder(abstractDelegate).inverseOf("dropTable", ["musics", "artists", block]);
+      expect(inverseOf).toThrow(IrreversibleMigration);
+      expect(inverseOf).toThrow(
+        "To avoid mistakes, drop_table is only reversible if given a single table name.",
+      );
     });
 
     it("invert create join table", () => {

--- a/packages/activerecord/src/migration/command-recorder.trails.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.trails.test.ts
@@ -1,0 +1,26 @@
+/**
+ * TS-only cases with no counterpart in
+ * `activerecord/test/cases/migration/command_recorder_test.rb`.
+ */
+
+import { describe, expect, it } from "vitest";
+import { CommandRecorder } from "./command-recorder.js";
+
+describe("CommandRecorder", () => {
+  it("invertCreateTable strips ifNotExists even when fn is last arg", () => {
+    const fn = () => {};
+    const [cmd, args] = new CommandRecorder().invertCreateTable([
+      "users",
+      { ifNotExists: true },
+      fn,
+    ]);
+    expect(cmd).toBe("dropTable");
+    expect((args[1] as Record<string, unknown>)["ifNotExists"]).toBeUndefined();
+  });
+
+  it("invertRemoveIndex handles array column list without treating it as options", () => {
+    const [cmd, args] = new CommandRecorder().invertRemoveIndex(["users", ["email", "name"]]);
+    expect(cmd).toBe("addIndex");
+    expect(args[1]).toEqual(["email", "name"]);
+  });
+});

--- a/packages/i18n/src/backend/fallbacks.test.ts
+++ b/packages/i18n/src/backend/fallbacks.test.ts
@@ -1,8 +1,7 @@
 /**
  * Mirrors: i18n/test/backend/fallbacks_test.rb
  *
- * Not ported: `I18nBackendFallbacksWithChainTest` (there is no
- * `I18n::Backend::Chain` yet — story `i18n-backend-chain`), and the two
+ * Not ported: the two
  * `Thread.new` cases, which are the gem asserting that its thread-local
  * fallbacks store is visible from another thread. JS has no threads, so
  * `fallbacks()` is a single module-level binding (see `fallbacks.ts`) and both
@@ -16,6 +15,7 @@
 
 import { beforeEach, describe, expect, it } from "vitest";
 import { Fallbacks, fallbacks, setFallbacks } from "./fallbacks.js";
+import { Chain } from "./chain.js";
 import { Simple } from "./simple.js";
 import { config, exists, l, resetConfig, setLocale, t, type Locale } from "../i18n.js";
 import { resetClassConfig } from "../config.js";
@@ -344,6 +344,46 @@ describe("I18nBackendFallbacksLocalizeTest", () => {
 
   it("uses a fallback locale's translation for a key missing in the given locale", () => {
     expect(l(new Date(2010, 1, 3), { format: "%A", locale: "de-DE" })).toBe("Sunday");
+  });
+});
+
+describe("I18nBackendFallbacksWithChainTest", () => {
+  class ChainBackend extends Fallbacks(Chain) {}
+
+  beforeEach(() => {
+    const backend = setup();
+    backend.storeTranslations("de", { foo: "FOO", nested: { key: "value" } });
+    backend.storeTranslations("pt-BR", { foo: "Baz in :pt-BR" });
+    config().backend = new ChainBackend(new Simple(), backend);
+  });
+
+  it("falls back from de-DE to de when there is no translation for de-DE available", () => {
+    expect(t("foo", { locale: "de-DE" })).toBe("FOO");
+  });
+
+  it("exists? falls back from de-DE to de given a key missing from the given locale", () => {
+    expect(exists("foo", null, { locale: "de-DE" })).toBe(true);
+  });
+
+  it("exists? passes along the scope option", () => {
+    expect(exists("key", null, { locale: "de-DE", scope: "nested" })).toBe(true);
+  });
+
+  it("exists? should return false when fallback disabled given a key missing from the given locale", () => {
+    expect(exists("foo", null, { locale: "de-DE", fallback: false })).toBe(false);
+  });
+
+  it("falls back from de-DE to de when there is no translation for de-DE available when using arrays, too", () => {
+    expect(t(["foo", "foo"], { locale: "de-DE" })).toEqual(["FOO", "FOO"]);
+  });
+
+  it("should not raise error when enforce_available_locales is true, :'pt' is missing and default is a Symbol", () => {
+    config().enforceAvailableLocales = true;
+    try {
+      expect(t("model.attrs.foo", { locale: "pt-BR", default: [":attrs.foo", "Foo"] })).toBe("Foo");
+    } finally {
+      config().enforceAvailableLocales = false;
+    }
   });
 });
 

--- a/packages/i18n/src/backend/fallbacks.test.ts
+++ b/packages/i18n/src/backend/fallbacks.test.ts
@@ -1,9 +1,8 @@
 /**
  * Mirrors: i18n/test/backend/fallbacks_test.rb
  *
- * Not ported: the two
- * `Thread.new` cases, which are the gem asserting that its thread-local
- * fallbacks store is visible from another thread. JS has no threads, so
+ * Not ported: the two `Thread.new` cases, which are the gem asserting that its
+ * thread-local fallbacks store is visible from another thread. JS has no threads, so
  * `fallbacks()` is a single module-level binding (see `fallbacks.ts`) and both
  * cases assert the single-threaded behaviour the rest of the file already
  * covers.


### PR DESCRIPTION
Two bundled test-port stories.

## `i18n-fallbacks-with-chain-tests`

`Chain` and the `Fallbacks` mixin have both landed, so the six
`I18nBackendFallbacksWithChainTest` cases at
`i18n/test/backend/fallbacks_test.rb:303-348` can now be written as
`Fallbacks(Chain)`, mirroring the gem's `class Chain < I18n::Backend::Chain;
include I18n::Backend::Fallbacks; end`. The file header's "Not ported" note
narrows to the two `Thread.new` cases.

`test:compare` for `backend/fallbacks_test.rb`: **38 OK / 8 miss → 44 OK /
2 miss**, the two remaining being the thread cases.

## `port-command-recorder-test-cases`

Ports `CommandRecorderTest` from `test_send_calls_super` through
`test_invert_rename_index`
(`activerecord/test/cases/migration/command_recorder_test.rb:20-353`) under the
Rails `Migration > CommandRecorderTest` describe path, names verbatim, and
deletes the bespoke `invert*`-named describes those cases supersede.

`test:compare` for `migration/command_recorder_test.rb`: **4 OK / 89 miss /
73 extra → 42 OK / 51 miss / 47 extra**.

Two Rails cases in that range are deliberately left out because they are
adapter-gated (`supports_bulk_alter?` at :117, `supports_comments?` at
:249-278) and expressing the matching TS gate is its own piece of work; the
rest of the file, those gated cases, and the remaining bespoke describes are
filed as
`0064-ar-test-infra-layout-fidelity/port-command-recorder-test-cases-part-2`.

### One source change

`test_invert_change_table` asserts `[:remove_column, [:fruits, :name,
:string], nil]` — three args. Ruby's `Table#column` ends in
`@base.add_column(name, column_name, type, **options)`
(`activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb`),
and `**{}` passes no fourth argument at all; the TS body spread an empty
object in unconditionally, which `CommandRecorder#record` then stored
verbatim. Converged, and the five bespoke shorthand tests that had encoded the
divergent `{}` are updated.

The two deleted bespoke cases with no Rails counterpart —
`invertCreateTable strips ifNotExists even when fn is last arg` and
`invertRemoveIndex handles array column list without treating it as options` —
move to `command-recorder.trails.test.ts` per the TS-only-extras convention.
The ported group takes its `@recorder` from a `beforeEach`, mirroring
`command_recorder_test.rb:8-11`.

### Two forced deviations in the ported cases

- `test_send_calls_super` asserts `NoMethodError`. `CommandRecorder`'s
  `method_missing` stand-in is a Proxy (`command-recorder.ts:25-37`) that
  resolves an unknown name to `undefined`, so the JS analogue of that raise is
  the `TypeError` from calling it. Asserted as `TypeError`.
- Ruby's `commands` carries the block as a third element of each
  `[cmd, args, block]` triple; a JS callback is an ordinary argument, so it
  rides inside `args`. This shows up in `revert order`, `invert create table
  with options and block`, `invert drop table{,_with_if_exists}` and `invert
  drop join table`.

Closes-story: i18n-fallbacks-with-chain-tests
Closes-story: port-command-recorder-test-cases
