### PR TITLE
fix(i18n,date,activemodel,activerecord): load_yml/load_json take the Psych 4 arm; rt_rewrite_frags carries a Rational offset exactly

### DIFF
--- a/packages/activemodel/src/naming.test.ts
+++ b/packages/activemodel/src/naming.test.ts
@@ -62,27 +62,9 @@ describe("NamingTest", () => {
   });
 
   it("uncountable", () => {
-    ModelName.addUncountable("sheep");
+    Inflections.instance("en").uncountable("sheep");
     const name = new ModelName("Sheep");
     expect(name.plural).toBe("sheep");
-  });
-
-  it("addUncountable writes through to the shared activesupport inflector", async () => {
-    // Rails `ActiveSupport::Inflector.inflections { |i| i.uncountable ... }`
-    // writes to a shared store every inflection consumer reads. Ours
-    // must do the same so `pluralize` picks up custom uncountables.
-    const { pluralize, Inflections } = await import("@blazetrails/activesupport");
-    const word = "fizzbuzzuncountabletestword";
-    try {
-      ModelName.addUncountable(word);
-      expect(Inflections.instance("en").uncountables.has(word)).toBe(true);
-      expect(pluralize(word)).toBe(word);
-      const mn = new ModelName("Fizzbuzzuncountabletestword");
-      expect(mn.singular).toBe(word);
-      expect(mn.plural).toBe(word);
-    } finally {
-      Inflections.instance("en").uncountables.delete(word);
-    }
   });
 });
 
@@ -427,7 +409,7 @@ describe("ModelName collection is derived from plural", () => {
   });
 
   it("addUncountable on full singular keeps plural and collection in sync", () => {
-    ModelName.addUncountable("legal_status");
+    Inflections.instance("en").uncountable("legal_status");
     const name = new ModelName("Status", { namespace: "Legal" });
     expect(name.singular).toBe("legal_status");
     expect(name.plural).toBe("legal_status"); // uncountable per local table

--- a/packages/activemodel/src/naming.ts
+++ b/packages/activemodel/src/naming.ts
@@ -403,16 +403,6 @@ export class ModelName {
     return Inflections.instance(locale).uncountables;
   }
 
-  /**
-   * Register an uncountable word. Mirrors Rails
-   * `ActiveSupport::Inflector.inflections.uncountable(word)` — writes
-   * through to the shared inflector store so `pluralize("sheep")`,
-   * `ModelName`, and every other inflection consumer see it.
-   */
-  static addUncountable(word: string): void {
-    Inflections.instance("en").uncountable(word);
-  }
-
   private _cachedI18nKeys?: string[];
 
   private static _qualified(mn: ModelName): string {

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -63,7 +63,11 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
    * @internal Rails-private helper.
    */
   protected microseconds(time: DateParts): number {
-    return time.secFraction ? Math.trunc(time.secFraction * 1_000_000) : 0;
+    const secFraction = time.secFraction;
+    if (!secFraction) return 0;
+    return secFraction instanceof Rational
+      ? secFraction.mul(1_000_000).toI()
+      : Math.trunc(secFraction * 1_000_000);
   }
 
   /**

--- a/packages/activemodel/src/type/time.ts
+++ b/packages/activemodel/src/type/time.ts
@@ -155,7 +155,7 @@ export class TimeType extends ValueType<Temporal.Instant> {
     }
     if (timeHash == null || timeHash.hour == null) return null;
 
-    const { offset } = timeHash;
+    const { offset, secFraction } = timeHash;
     return this.newTime(
       timeHash.year,
       timeHash.mon,
@@ -163,7 +163,9 @@ export class TimeType extends ValueType<Temporal.Instant> {
       timeHash.hour,
       timeHash.min,
       timeHash.sec,
-      timeHash.secFraction,
+      secFraction instanceof Rational
+        ? secFraction.numerator / secFraction.denominator
+        : secFraction,
       offset instanceof Rational ? offset.numerator / offset.denominator : offset,
     );
   }

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.test.ts
@@ -4,12 +4,9 @@ import {
   parsePostgresInstant,
   parsePostgresTimestampAsInstant,
   parsePostgresDate,
-  parsePostgresTime,
-  parsePostgresTimeTz,
   parseMysqlInstant,
   parseMysqlDatetimeAsInstant,
   parseMysqlDate,
-  parseMysqlTime,
   DateInfinity,
   DateNegativeInfinity,
 } from "./temporal-wire.js";
@@ -145,60 +142,6 @@ describe("parsePostgresDate", () => {
   });
 });
 
-describe("parsePostgresTime", () => {
-  it("parses a time with microseconds", () => {
-    const result = parsePostgresTime("14:23:55.123456");
-    expect(result.toString()).toBe("14:23:55.123456");
-  });
-
-  it("parses a whole-second time", () => {
-    const result = parsePostgresTime("00:00:00");
-    expect(result.toString()).toBe("00:00:00");
-  });
-
-  it("normalizes 24:00:00 (PG end-of-day sentinel) to 00:00:00", () => {
-    expect(parsePostgresTime("24:00:00").toString()).toBe("00:00:00");
-  });
-
-  it("normalizes 24:00:00 with fractional seconds", () => {
-    expect(parsePostgresTime("24:00:00.000000").toString()).toBe("00:00:00");
-  });
-
-  it("does not normalize 24:01:00 — only 24:00:00 is a valid PG sentinel", () => {
-    expect(() => parsePostgresTime("24:01:00")).toThrow();
-  });
-});
-
-describe("parsePostgresTimeTz", () => {
-  it("parses timetz with two-digit offset", () => {
-    const { time, offset } = parsePostgresTimeTz("14:23:55.123456+02");
-    expect(time.toString()).toBe("14:23:55.123456");
-    expect(offset).toBe("+02:00");
-  });
-
-  it("parses timetz with full offset", () => {
-    const { time, offset } = parsePostgresTimeTz("14:23:55+05:30");
-    expect(time.toString()).toBe("14:23:55");
-    expect(offset).toBe("+05:30");
-  });
-
-  it("parses timetz with negative offset", () => {
-    const { time, offset } = parsePostgresTimeTz("08:00:00.000001-08");
-    expect(time.toString()).toBe("08:00:00.000001");
-    expect(offset).toBe("-08:00");
-  });
-
-  it("normalizes 24:00:00 timetz to 00:00:00", () => {
-    const { time, offset } = parsePostgresTimeTz("24:00:00+00");
-    expect(time.toString()).toBe("00:00:00");
-    expect(offset).toBe("+00:00");
-  });
-
-  it("throws on unparseable input", () => {
-    expect(() => parsePostgresTimeTz("not-a-time")).toThrow(RangeError);
-  });
-});
-
 describe("parseMysqlInstant", () => {
   it("treats the wire string as UTC (pinned session tz)", () => {
     const result = parseMysqlInstant("2026-04-26 14:23:55.123456");
@@ -239,18 +182,6 @@ describe("parseMysqlDate", () => {
 
   it("returns null for zero-date", () => {
     expect(parseMysqlDate("0000-00-00")).toBeNull();
-  });
-});
-
-describe("parseMysqlTime", () => {
-  it("parses a TIME string", () => {
-    const result = parseMysqlTime("14:23:55.123456");
-    expect(result.toString()).toBe("14:23:55.123456");
-  });
-
-  it("parses midnight", () => {
-    const result = parseMysqlTime("00:00:00");
-    expect(result.toString()).toBe("00:00:00");
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
@@ -41,8 +41,6 @@ function naiveIsoToInstant(iso: string): Temporal.Instant {
   return Temporal.PlainDateTime.from(iso).toZonedDateTime(defaultSqlTimezone()).toInstant();
 }
 
-export type TimeTzValue = { time: Temporal.PlainTime; offset: string };
-
 // ---------------------------------------------------------------------------
 // Postgres
 // ---------------------------------------------------------------------------
@@ -111,38 +109,6 @@ export function parsePostgresDate(
   );
 }
 
-/**
- * Parse a Postgres `time` wire string to `Temporal.PlainTime`.
- *
- * Wire format: `'HH:MM:SS[.ffffff]'`. Postgres allows `24:00:00` as a valid
- * end-of-day sentinel; Temporal rejects hour 24, so we normalize it to
- * `00:00:00` (midnight), matching Ruby Time's rollover behavior.
- */
-export function parsePostgresTime(text: string): Temporal.PlainTime {
-  return Temporal.PlainTime.from(normalizeTime24(text.trim()));
-}
-
-/**
- * Parse a Postgres `timetz` wire string.
- *
- * Wire format: `'HH:MM:SS[.ffffff]+HH'` or `'HH:MM:SS[.ffffff]±HH:MM'`.
- * Returns the time and offset separately — Temporal.PlainTime has no
- * timezone, so we preserve the offset as a sibling string.
- * `24:00:00` is normalized to `00:00:00` (see `parsePostgresTime`).
- */
-export function parsePostgresTimeTz(text: string): TimeTzValue {
-  // Split on first +/- that appears after the seconds portion
-  const match = /^(\d{2}:\d{2}:\d{2}(?:\.\d+)?)([-+]\d{2}(?::\d{2})?)$/.exec(text.trim());
-  if (!match) {
-    throw new RangeError(`Cannot parse timetz wire value: ${JSON.stringify(text)}`);
-  }
-  const [, timeStr, rawOffset] = match;
-  return {
-    time: Temporal.PlainTime.from(normalizeTime24(timeStr)),
-    offset: expandOffset(rawOffset),
-  };
-}
-
 // ---------------------------------------------------------------------------
 // MySQL
 // ---------------------------------------------------------------------------
@@ -189,17 +155,6 @@ export function parseMysqlDate(text: string): Temporal.PlainDate | null {
   const trimmed = text.trim();
   if (isZeroDate(trimmed)) return null;
   return Temporal.PlainDate.from(trimmed);
-}
-
-/**
- * Parse a MySQL `TIME` wire string to `Temporal.PlainTime`.
- *
- * Wire format: `'HH:MM:SS[.ffffff]'` (standard range, no sign). MySQL TIME
- * can be negative or exceed 24 h for interval values; those paths are the
- * cast layer's responsibility and are not handled here.
- */
-export function parseMysqlTime(text: string): Temporal.PlainTime {
-  return Temporal.PlainTime.from(text.trim());
 }
 
 // ---------------------------------------------------------------------------
@@ -332,17 +287,6 @@ function parseFraction(frac: string | undefined): {
  */
 function expandOffset(offset: string): string {
   return offset.replace(/^([-+]\d{2})$/, "$1:00");
-}
-
-/**
- * Normalize Postgres `24:00:00[.fraction]` (end-of-day sentinel) to
- * `00:00:00[.fraction]`. Only the exact sentinel is normalized; any other
- * `24:xx:xx` value is left unchanged so `Temporal.PlainTime.from` throws —
- * Postgres never emits those and they should not be silently corrupted.
- */
-function normalizeTime24(timeStr: string): string {
-  const match = /^24:00:00(\.\d+)?$/.exec(timeStr);
-  return match ? `00:00:00${match[1] ?? ""}` : timeStr;
 }
 
 function isZeroDate(text: string): boolean {

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -334,8 +334,6 @@ describe("Date", () => {
   });
 
   it("carries a Rational offset into sec_fraction exactly, as f_add does", () => {
-    // ruby 3.3.11: DateTime.strptime("1234567890 +9.5555", "%s %z") is
-    // 2009-02-14T09:04:49+09:33 with a sec_fraction of (4/5).
     const hash: DateParts = { seconds: 1234567890, offset: new Rational(171999, 5) };
     dNewByFrags(hash);
     expect([hash.hour, hash.min, hash.sec]).toEqual([9, 4, 49]);

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -333,6 +333,15 @@ describe("Date", () => {
     expect([negative.hour, negative.min, negative.sec]).toEqual([23, 59, 59]);
   });
 
+  it("carries a Rational offset into sec_fraction exactly, as f_add does", () => {
+    // ruby 3.3.11: DateTime.strptime("1234567890 +9.5555", "%s %z") is
+    // 2009-02-14T09:04:49+09:33 with a sec_fraction of (4/5).
+    const hash: DateParts = { seconds: 1234567890, offset: new Rational(171999, 5) };
+    dNewByFrags(hash);
+    expect([hash.hour, hash.min, hash.sec]).toEqual([9, 4, 49]);
+    expect(String(hash.secFraction)).toBe("4/5");
+  });
+
   it("answers the frag hash date__strptime fills, as Date._strptime does", () => {
     expect(RubyDate._strptime("2001-02-03", "%Y-%m-%d")).toEqual({ year: 2001, mon: 2, mday: 3 });
     expect(RubyDate._strptime("2001-W05-6", "%G-W%V-%u")).toEqual({

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -302,7 +302,7 @@ export interface DateParts {
   hour?: number;
   min?: number;
   sec?: number;
-  secFraction?: number;
+  secFraction?: number | Rational;
   /**
    * Seconds since the Unix epoch, which `rt_rewrite_frags` expands into a `:jd`
    * and a time of day. No ported sub-parser sets it: it is `Date._strptime`'s
@@ -585,6 +585,23 @@ export class Rational {
   /** `rational.c` `nurat_mul` (`Rational#*`), for the Integer multiplier this port needs. */
   mul(other: number): Rational {
     return new Rational(this.numerator * other, this.denominator);
+  }
+
+  /** `rational.c` `nurat_div` (`Rational#div`), the floored quotient, for the
+   * Integer divisor this port needs. */
+  div(other: number): number {
+    return Math.floor(this.numerator / (this.denominator * other));
+  }
+
+  /** `rational.c` `nurat_mod` (`Rational#%`), `self - other * (self.div other)`,
+   * for the Integer divisor this port needs. */
+  mod(other: number): Rational {
+    return this.add(-other * this.div(other));
+  }
+
+  /** `rational.c` `nurat_to_i` (`Rational#to_i`), which truncates toward zero. */
+  toI(): number {
+    return Math.trunc(this.numerator / this.denominator);
   }
 
   /** `rational.c` `nurat_round` (`Rational#round`), which rounds half away from zero. */
@@ -2246,35 +2263,50 @@ function dateStrptime(str: string, fmt: string, hash: DateParts): DateParts | nu
 }
 
 /**
+ * @internal `date_core.c`'s `f_idiv` macro (`date_core.c:43`), `x.div(y)`, which
+ * is `Integer#div` on a plain `:seconds` and `Rational#div` once an `:offset`
+ * has made it a `Rational`. Either way the quotient is an Integer.
+ */
+function fIdiv(x: number | Rational, y: number): number {
+  return x instanceof Rational ? x.div(y) : div(x, y);
+}
+
+/**
+ * @internal `date_core.c`'s `f_mod` macro (`date_core.c:44`), `x % y`, the
+ * remainder of {@link fIdiv} — a `Rational` whenever `x` is one, which is how
+ * an exact `:offset` reaches `:sec_fraction`.
+ */
+function fMod(x: number | Rational, y: number): number | Rational {
+  return x instanceof Rational ? x.mod(y) : mod(x, y);
+}
+
+/**
  * @internal `date_core.c` `rt_rewrite_frags` (`date_core.c:3839-3872`), which
  * runs ahead of {@link completeFrags} and expands a `:seconds` frag — seconds
  * since the Unix epoch — into the `:jd` and the time of day it names, folding
  * an `:offset` in first. The division is floored, so a negative `:seconds`
- * still lands on the day before the epoch with a positive time of day. A
- * `Rational` `:offset` is taken as its value: Ruby's `f_add` would carry the
- * fraction into `:sec_fraction`, and `Temporal` has no rational arithmetic.
+ * still lands on the day before the epoch with a positive time of day.
  */
 function rtRewriteFrags(hash: DateParts): DateParts {
-  const seconds = hash.seconds;
+  let seconds: number | Rational | undefined = hash.seconds;
   delete hash.seconds;
   if (seconds !== undefined) {
     const offset = hash.offset;
-    let s0 = seconds;
     if (offset != null) {
-      s0 += offset instanceof Rational ? offset.numerator / offset.denominator : offset;
+      seconds = offset instanceof Rational ? offset.add(seconds) : seconds + offset;
     }
 
-    const d = div(s0, DAY_IN_SECONDS);
-    let fr = mod(s0, DAY_IN_SECONDS);
+    const d = fIdiv(seconds, DAY_IN_SECONDS);
+    let fr = fMod(seconds, DAY_IN_SECONDS);
 
-    const h = div(fr, HOUR_IN_SECONDS);
-    fr = mod(fr, HOUR_IN_SECONDS);
+    const h = fIdiv(fr, HOUR_IN_SECONDS);
+    fr = fMod(fr, HOUR_IN_SECONDS);
 
-    const min = div(fr, MINUTE_IN_SECONDS);
-    fr = mod(fr, MINUTE_IN_SECONDS);
+    const min = fIdiv(fr, MINUTE_IN_SECONDS);
+    fr = fMod(fr, MINUTE_IN_SECONDS);
 
-    const sec = div(fr, 1);
-    fr = mod(fr, 1);
+    const sec = fIdiv(fr, 1);
+    fr = fMod(fr, 1);
 
     hash.jd = UNIX_EPOCH_IN_CJD + d;
     hash.hour = h;
@@ -2906,7 +2938,8 @@ export function dtNewByFrags(hash: DateParts): DateTime {
 
   const df = timeToDf(rh, rmin, rs);
 
-  const sf = hash.secFraction == null ? 0 : secToNs(hash.secFraction);
+  const f = hash.secFraction;
+  const sf = f == null ? 0 : secToNs(f instanceof Rational ? f.numerator / f.denominator : f);
 
   const t = hash.offset;
   let of = t == null ? 0 : t instanceof Rational ? t.numerator / t.denominator : t;

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -2938,10 +2938,10 @@ export function dtNewByFrags(hash: DateParts): DateTime {
 
   const df = timeToDf(rh, rmin, rs);
 
-  const f = hash.secFraction;
-  const sf = f == null ? 0 : secToNs(f instanceof Rational ? f.numerator / f.denominator : f);
+  let t: number | Rational | null | undefined = hash.secFraction;
+  const sf = t == null ? 0 : secToNs(t instanceof Rational ? t.numerator / t.denominator : t);
 
-  const t = hash.offset;
+  t = hash.offset;
   let of = t == null ? 0 : t instanceof Rational ? t.numerator / t.denominator : t;
   if (of < -DAY_IN_SECONDS || of > DAY_IN_SECONDS) of = 0;
 

--- a/packages/i18n/src/backend/base.file-loading.trails.test.ts
+++ b/packages/i18n/src/backend/base.file-loading.trails.test.ts
@@ -45,7 +45,16 @@ describe("I18n::Backend::Base file loading", () => {
     const overriding = new Overriding() as unknown as {
       loadYaml(f: string): [unknown, boolean];
     };
-    expect(overriding.loadYaml(filename)).toEqual([{ en: { foo: { bar: "baz" } } }, false]);
+    expect(overriding.loadYaml(filename)).toEqual([{ en: { foo: { bar: "baz" } } }, true]);
+  });
+
+  it("load_yml freezes the parsed data deeply", () => {
+    const filename = `${localesDir()}/en.yml`;
+    const loading = backend as unknown as { loadYml(f: string): [unknown, boolean] };
+    const [data, keysSymbolized] = loading.loadYml(filename);
+    expect(keysSymbolized).toBe(true);
+    expect(Object.isFrozen(data)).toBe(true);
+    expect(Object.isFrozen((data as { en: { foo: unknown } }).en.foo)).toBe(true);
   });
 
   it("raises InvalidLocaleData given a YAML file that is empty", () => {

--- a/packages/i18n/src/backend/base.ts
+++ b/packages/i18n/src/backend/base.ts
@@ -673,9 +673,11 @@ export abstract class Base {
    * `@blazetrails/activesupport/yaml`: the workspace edge runs
    * activesupport -> i18n, so consuming that re-export would invert it.
    *
-   * @missingRailsCall unsafe_load_file — Ruby's `YAML.unsafe_load_file`
-   * (base.rb:264) reads and parses in one call; the npm `yaml` package only
-   * parses, so the read is served from the preload (`preloadTranslationFiles`).
+   * @missingRailsCall load_file — `YAML.load_file` (base.rb:266) is the
+   * pre-Psych-4 arm, which no supported Ruby takes and there is no probe to
+   * reach it by; the arm this body does take, `unsafe_load_file`, reads and
+   * parses in one call, and the npm `yaml` package only parses, so the read is
+   * served from the preload (`preloadTranslationFiles`).
    */
   protected loadYml(filename: string): [unknown, boolean] {
     try {

--- a/packages/i18n/src/backend/base.ts
+++ b/packages/i18n/src/backend/base.ts
@@ -168,6 +168,18 @@ function readYaml(source: string): unknown {
   return yamlParse(source);
 }
 
+/**
+ * Psych's and `JSON.load_file`'s `freeze: true` (base.rb:264, base.rb:281),
+ * which freezes the whole parsed structure, not just its root.
+ */
+function deepFreeze(value: unknown): unknown {
+  if (typeof value !== "object" || value === null) return value;
+  if (Object.isFrozen(value)) return value;
+  Object.freeze(value);
+  for (const child of Object.values(value)) deepFreeze(child);
+  return value;
+}
+
 function readFile(filename: string): string {
   const contents = fileContents.get(filename);
   if (contents === undefined) {
@@ -647,10 +659,12 @@ export abstract class Base {
 
   /**
    * Loads a YAML translations file. The data must have locales as toplevel
-   * keys. Only the pre-Psych-4 arm of the gem's `YAML.respond_to?
-   * (:unsafe_load_file)` probe exists here — there is no Psych to probe, and
-   * `yaml`'s `parse` neither symbolizes nor freezes, so `keys_symbolized` is
-   * false.
+   * keys. There is no `YAML.respond_to?(:unsafe_load_file)` probe to port —
+   * JS has no second parser generation — so this takes the Psych 4 arm the gem
+   * takes on every supported Ruby (base.rb:263-264): `keys_symbolized` is
+   * true, and the parsed structure is frozen. Symbolizing keys is inherent in
+   * JS, where a Hash key is already a string, so what the flag buys is
+   * `store_translations` skipping the walk.
    *
    * The npm `yaml` package stands in for Psych, resolved on the
    * `preloadTranslationFiles` seam rather than imported at module scope, so a
@@ -665,7 +679,7 @@ export abstract class Base {
    */
   protected loadYml(filename: string): [unknown, boolean] {
     try {
-      return [readYaml(readFile(filename)), false];
+      return [deepFreeze(readYaml(readFile(filename))), true];
     } catch (e) {
       throw new InvalidLocaleData(filename, inspectError(e));
     }
@@ -683,8 +697,9 @@ export abstract class Base {
 
   /**
    * Loads a JSON translations file. The data must have locales as toplevel
-   * keys. As in #loadYml, only the arm of the gem's `JSON.respond_to?
-   * (:load_file)` probe that neither symbolizes nor freezes exists here.
+   * keys. As in #loadYml there is no `JSON.respond_to?(:load_file)` probe to
+   * port, so this takes the arm the gem takes (base.rb:280-281): symbolized —
+   * inherent in JS — and frozen.
    *
    * @missingRailsCall load_file — Ruby's `JSON.load_file` (base.rb:262) reads
    * and parses in one call; `JSON.parse` only parses, so the read is served
@@ -692,7 +707,7 @@ export abstract class Base {
    */
   protected loadJson(filename: string): [unknown, boolean] {
     try {
-      return [JSON.parse(readFile(filename)), false];
+      return [deepFreeze(JSON.parse(readFile(filename))), true];
     } catch (e) {
       throw new InvalidLocaleData(filename, inspectError(e));
     }

--- a/packages/i18n/src/backend/base.ts
+++ b/packages/i18n/src/backend/base.ts
@@ -673,9 +673,9 @@ export abstract class Base {
    * `@blazetrails/activesupport/yaml`: the workspace edge runs
    * activesupport -> i18n, so consuming that re-export would invert it.
    *
-   * @missingRailsCall load_file — Ruby's `YAML.load_file` (base.rb:265) reads
-   * and parses in one call; the npm `yaml` package only parses, so the read is
-   * served from the preload (`preloadTranslationFiles`).
+   * @missingRailsCall unsafe_load_file — Ruby's `YAML.unsafe_load_file`
+   * (base.rb:264) reads and parses in one call; the npm `yaml` package only
+   * parses, so the read is served from the preload (`preloadTranslationFiles`).
    */
   protected loadYml(filename: string): [unknown, boolean] {
     try {
@@ -701,7 +701,7 @@ export abstract class Base {
    * port, so this takes the arm the gem takes (base.rb:280-281): symbolized —
    * inherent in JS — and frozen.
    *
-   * @missingRailsCall load_file — Ruby's `JSON.load_file` (base.rb:262) reads
+   * @missingRailsCall load_file — Ruby's `JSON.load_file` (base.rb:281) reads
    * and parses in one call; `JSON.parse` only parses, so the read is served
    * from the preload (`preloadTranslationFiles`).
    */

--- a/packages/i18n/src/backend/base.ts
+++ b/packages/i18n/src/backend/base.ts
@@ -700,10 +700,10 @@ export abstract class Base {
   /**
    * Loads a JSON translations file. The data must have locales as toplevel
    * keys. As in #loadYml there is no `JSON.respond_to?(:load_file)` probe to
-   * port, so this takes the arm the gem takes (base.rb:280-281): symbolized —
+   * port, so this takes the arm the gem takes (base.rb:279-280): symbolized —
    * inherent in JS — and frozen.
    *
-   * @missingRailsCall load_file — Ruby's `JSON.load_file` (base.rb:281) reads
+   * @missingRailsCall load_file — Ruby's `JSON.load_file` (base.rb:280) reads
    * and parses in one call; `JSON.parse` only parses, so the read is served
    * from the preload (`preloadTranslationFiles`).
    */


### PR DESCRIPTION
Bundle of four RFC 0074 / 0088 convergence stories.

### `load_yml` / `load_json` take the arm Rails takes (`i18n`)

`base.rb:261-286` probes for Psych 4 / `JSON.load_file` and, on every Ruby this
repo targets, returns `[data, true]` with deeply-frozen data. trails hardcoded
the other arm. Both now return `true` for `keys_symbolized` and deep-freeze the
parsed structure (`freeze: true`); the stale "only the arm that neither
symbolizes nor freezes exists here" JSDoc is gone.

`Simple#store_translations` merges fine with frozen input: nested merges go
through `deepMerge`, which copies before mutating, and only the store's own
containers are mutated in place. `deepSymbolizeKeys` is now skipped on loaded
files, which is the point of the flag — JS object keys are already strings, so
the walk only ever produced a redundant deep copy.

### `ModelName.addUncountable` deleted (`activemodel`)

Rails has no `ActiveModel::Name.add_uncountable`; registering an uncountable
goes through the inflector store (`inflections.rb`, `Inflections#uncountable`),
which `ActiveModel::Name` only ever reads (`naming.rb:180`). The three test call
sites now use `Inflections.instance("en").uncountable(word)`, the Rails
spelling; the trails-only test that existed to cover the wrapper goes with it.

### Retired the unused time wire parsers (`activerecord`)

`parsePostgresTime`, `parsePostgresTimeTz`, `parseMysqlTime`, the `TimeTzValue`
type and the now-unreferenced `normalizeTime24` helper are deleted — #6154
stopped intercepting the driver-level `time` types, so the raw string reaches
`ActiveRecord::Type::Time#cast_value` and nothing called them. Their tests go
with them; `expandOffset` keeps its other caller.

### `rt_rewrite_frags` carries a Rational offset exactly (`date`)

`date_core.c:3839-3872` folds `:offset` into `:seconds` with `f_add`, which
keeps a `Rational` exact all the way into `:sec_fraction`. The port took the
Rational's value instead. Ports `f_idiv` / `f_mod` (`date_core.c:43-44`) as
`fIdiv` / `fMod` over `Rational#div` / `Rational#%` (`nurat_div`, `nurat_mod`),
so `:seconds` stays a Rational through the division chain. Verified against
ruby 3.3.11:

```
DateTime.strptime("1234567890 +9.5555", "%s %z")
# => 2009-02-14T09:04:49+09:33, sec_fraction (4/5)
```

The integer path is unchanged, and the value-taking note in the JSDoc is
deleted. `DateParts.secFraction` widens to `number | Rational`; the two
`activemodel` readers convert the same way they already convert `:offset`
(`Date._parse` never produces a Rational `:sec_fraction`, so this is a
type-level ripple only).

### Not in this PR

`migrator-connection-pins-adapter-at-construction` was claimed with the bundle
and **released back**, not shipped. Converging it means adopting Rails'
`Migrator.new(direction, migrations, schema_migration, internal_metadata,
target_version)` (`migration.rb:1478-1485`) and resolving `connection` globally
through `DatabaseTasks.migration_connection` — which rewrites ~110 `new
Migrator(...)` sites across four packages (`multi-db-migrator.test.ts` alone
drives two adapters concurrently and would have to move to
`withTemporaryPool`). That is roughly an order of magnitude over the PR ceiling;
the story's ~140 LOC estimate is wrong and it needs splitting before anyone
claims it again.

Closes-story: i18n-load-yml-json-take-the-psych4-arm
Closes-story: model-name-add-uncountable-is-invented-surface
Closes-story: retire-unused-time-wire-parsers
Closes-story: rt-rewrite-frags-rational-offset-exactness
