### PR TITLE
feat(i18n,date,activemodel,activerecord): Locale::Tag::Rfc4646; strftime width prefix on every directive; multiparameter Hash branch in cast; with_advisory_lock guards

### DIFF
--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -41,7 +41,6 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
     if (value instanceof Date) {
       return this.applySecondsPrecision(Temporal.Instant.fromEpochMilliseconds(value.getTime()));
     }
-    if (isHash(value)) return this.valueFromMultiparameterAssignment(value);
     const str = String(value).trim();
     if (str === "") return null;
     return this.fastStringToTime(str) ?? this.fallbackStringToTime(str);
@@ -150,6 +149,19 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
 
   get isUtc(): boolean {
     return isUtc();
+  }
+
+  /**
+   * Mirrors: AcceptsMultiparameterTime::InstanceMethods#cast
+   * (accepts_multiparameter_time.rb:16-22). The nil guard stays in
+   * `Value#cast` (value.rb:53-55), which is `super`.
+   */
+  override cast(value: unknown): DateTimeCastResult | null {
+    if (isHash(value)) {
+      return this.valueFromMultiparameterAssignment(value);
+    } else {
+      return super.cast(value);
+    }
   }
 
   /**

--- a/packages/activemodel/src/type/time.ts
+++ b/packages/activemodel/src/type/time.ts
@@ -133,7 +133,6 @@ export class TimeType extends ValueType<Temporal.Instant> {
    * @internal Rails-private helper.
    */
   protected castValue(value: unknown): Temporal.Instant | null {
-    if (isHash(value)) return this.valueFromMultiparameterAssignment(value);
     if (typeof value !== "string") {
       if (value instanceof Temporal.PlainDateTime) {
         value = value.toZonedDateTime(this.#zoneId()).toInstant();
@@ -216,6 +215,19 @@ export class TimeType extends ValueType<Temporal.Instant> {
         "5": 0,
       }).cast(values) as Temporal.Instant | null) ?? null
     );
+  }
+
+  /**
+   * Mirrors: AcceptsMultiparameterTime::InstanceMethods#cast
+   * (accepts_multiparameter_time.rb:16-22). The nil guard stays in
+   * `Value#cast` (value.rb:53-55), which is `super`.
+   */
+  override cast(value: unknown): Temporal.Instant | null {
+    if (isHash(value)) {
+      return this.valueFromMultiparameterAssignment(value);
+    } else {
+      return super.cast(value);
+    }
   }
 
   /**

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2248,6 +2248,12 @@ export class Migrator {
    * `#run` (migration.rb:1447, 1461), never inside this body. Adapters that
    * cannot lock answer `isAdvisoryLocksEnabled()` falsey.
    *
+   * The one call with no Rails counterpart is `_ensureSchemaTable()`: Rails
+   * creates the bookkeeping tables in `Migrator#initialize`
+   * (migration.rb:1470-1476), and a TS constructor cannot await, so they are
+   * ensured at the one point that must see them — before `loadMigrated` reads
+   * schema_migrations.
+   *
    * @internal Mirrors: ActiveRecord::Migrator#with_advisory_lock
    */
   async withAdvisoryLock<T>(fn: () => Promise<T>): Promise<T> {
@@ -2256,10 +2262,6 @@ export class Migrator {
     if (!gotLock) {
       throw new ConcurrentMigrationError();
     }
-    // No Rails counterpart here: Rails creates the bookkeeping tables in
-    // `Migrator#initialize` (migration.rb:1470-1476). A TS constructor cannot
-    // await, so they are ensured at the one point that must see them — before
-    // `loadMigrated` reads schema_migrations.
     await this._ensureSchemaTable();
     await this.loadMigrated();
     // Capture fn error so we can release the lock before re-throwing (no-unsafe-finally).

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2239,34 +2239,27 @@ export class Migrator {
 
   /**
    * Wrap a block with an advisory lock to prevent concurrent migrations.
-   * If the adapter doesn't support advisory locks, runs without locking.
    *
    * Once the lock is held, `loadMigrated` reloads schema_migrations to be sure
    * it wasn't changed by another process while we blocked (migration.rb:1601).
-   * Rails' `Migrator` creates the bookkeeping tables in `initialize`; a
-   * constructor cannot await, so they are ensured here before the reload can
-   * query them.
+   *
+   * Whether the adapter can take a lock at all is the *caller's* question:
+   * `use_advisory_lock?` (migration.rb:1596-1598) is checked by `#migrate` /
+   * `#run` (migration.rb:1447, 1461), never inside this body. Adapters that
+   * cannot lock answer `isAdvisoryLocksEnabled()` falsey.
    *
    * @internal Mirrors: ActiveRecord::Migrator#with_advisory_lock
    */
   async withAdvisoryLock<T>(fn: () => Promise<T>): Promise<T> {
-    if (
-      !this.connection.supportsAdvisoryLocks?.() ||
-      !this.connection.getAdvisoryLock ||
-      !this.connection.releaseAdvisoryLock
-    ) {
-      return fn();
-    }
-    if (typeof this.connection.currentDatabase !== "function") {
-      throw new Error(
-        `${this.connection.constructor.name} must implement currentDatabase() to support advisory-locked migrations`,
-      );
-    }
     const lockId = await this.generateMigratorAdvisoryLockId();
     const gotLock = await this.connection.getAdvisoryLock(lockId);
     if (!gotLock) {
       throw new ConcurrentMigrationError();
     }
+    // No Rails counterpart here: Rails creates the bookkeeping tables in
+    // `Migrator#initialize` (migration.rb:1470-1476). A TS constructor cannot
+    // await, so they are ensured at the one point that must see them — before
+    // `loadMigrated` reads schema_migrations.
     await this._ensureSchemaTable();
     await this.loadMigrated();
     // Capture fn error so we can release the lock before re-throwing (no-unsafe-finally).
@@ -2279,7 +2272,6 @@ export class Migrator {
     } catch (e) {
       fnError = e;
     }
-    // releaseAdvisoryLock is guaranteed present (checked in the guard above).
     // Any non-true return — false or undefined — is treated as failure, matching
     // Rails: `release_advisory_lock(...) or raise` (migration.rb:1608-1612).
     let released: boolean | undefined;
@@ -2360,7 +2352,9 @@ export class Migrator {
       this._runOptions("up", targetVersion ?? null),
     );
     try {
-      return await migrator.withAdvisoryLock(() => migrator.migrateWithoutLock());
+      return migrator.isUseAdvisoryLock()
+        ? await migrator.withAdvisoryLock(() => migrator.migrateWithoutLock())
+        : await migrator.migrateWithoutLock();
     } finally {
       this._invalidateMigrated();
     }
@@ -2383,7 +2377,9 @@ export class Migrator {
       this._runOptions("down", targetVersion ?? null),
     );
     try {
-      return await migrator.withAdvisoryLock(() => migrator.migrateWithoutLock());
+      return migrator.isUseAdvisoryLock()
+        ? await migrator.withAdvisoryLock(() => migrator.migrateWithoutLock())
+        : await migrator.migrateWithoutLock();
     } finally {
       this._invalidateMigrated();
     }
@@ -2399,7 +2395,7 @@ export class Migrator {
       throw new Error(`Invalid steps: ${steps}. Must be a non-negative integer.`);
     }
     let rolledBack: MigrationProxy[] = [];
-    await this.withAdvisoryLock(async () => {
+    const body = async (): Promise<void> => {
       await this._ensureSchemaTable();
       const applied = await this.migrated();
       const appliedMigrations = this._migrations.filter((m) => applied.has(m.version)).reverse();
@@ -2409,7 +2405,12 @@ export class Migrator {
         await this._runMigration(proxy, "down");
       }
       rolledBack = toRollback;
-    });
+    };
+    if (this.isUseAdvisoryLock()) {
+      await this.withAdvisoryLock(body);
+    } else {
+      await body();
+    }
     return rolledBack;
   }
 
@@ -2422,14 +2423,19 @@ export class Migrator {
     if (!Number.isInteger(steps) || steps < 0) {
       throw new Error(`Invalid steps: ${steps}. Must be a non-negative integer.`);
     }
-    await this.withAdvisoryLock(async () => {
+    const body = async (): Promise<void> => {
       const pending = await this.pendingMigrations();
       const toRun = pending.slice(0, steps);
 
       for (const proxy of toRun) {
         await this._runMigration(proxy, "up");
       }
-    });
+    };
+    if (this.isUseAdvisoryLock()) {
+      await this.withAdvisoryLock(body);
+    } else {
+      await body();
+    }
   }
 
   /**
@@ -2571,10 +2577,9 @@ export class Migrator {
    * Rails gates solely on `connection.advisory_locks_enabled?`
    * (`supports_advisory_locks? && @advisory_locks_enabled`), mirrored here by
    * `isAdvisoryLocksEnabled()`. The `currentDatabase` requirement is enforced at
-   * the point it's actually needed — `withAdvisoryLock` /
-   * `generateMigratorAdvisoryLockId`, which throw if an advisory-lock-capable
-   * adapter can't supply the DB name — rather than silently skipping the lock
-   * here (which Rails never does).
+   * the point it's actually needed — `generateMigratorAdvisoryLockId`, which
+   * throws if an advisory-lock-capable adapter can't supply the DB name —
+   * rather than silently skipping the lock here (which Rails never does).
    */
   isUseAdvisoryLock(): boolean {
     return !!this.connection.isAdvisoryLocksEnabled?.();
@@ -2804,7 +2809,9 @@ export class Migrator {
       this._runOptions(direction, targetVersion),
     );
     try {
-      return await migrator.withAdvisoryLock(() => migrator.runWithoutLock());
+      return migrator.isUseAdvisoryLock()
+        ? await migrator.withAdvisoryLock(() => migrator.runWithoutLock())
+        : await migrator.runWithoutLock();
     } finally {
       this._invalidateMigrated();
     }

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2584,7 +2584,7 @@ export class Migrator {
    * rather than silently skipping the lock here (which Rails never does).
    */
   isUseAdvisoryLock(): boolean {
-    return !!this.connection.isAdvisoryLocksEnabled?.();
+    return this.connection.isAdvisoryLocksEnabled();
   }
 
   /** @internal Mirrors: ActiveRecord::Migrator#generate_migrator_advisory_lock_id */

--- a/packages/activerecord/src/migrator.trails.test.ts
+++ b/packages/activerecord/src/migrator.trails.test.ts
@@ -460,6 +460,7 @@ describe("Migrator advisory lock wrapping", () => {
     const rawAdapter = {
       adapterName: "sqlite" as const,
       supportsAdvisoryLocks: () => true,
+      isAdvisoryLocksEnabled: () => true,
       getAdvisoryLock: async (_id: unknown) => true,
       releaseAdvisoryLock: async (_id: unknown) => true,
       // currentDatabase intentionally absent

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -604,7 +604,6 @@ describe("Date", () => {
     const dt = new RubyDateTime(2008, 3, 1, 6, 7, 8.5);
     expect(dt.strftime("%_S")).toBe(" 8");
     expect(dt.strftime("%_m")).toBe(" 3");
-    // `%0` sets the pad character and then reads the width from the same digits.
     expect(dt.strftime("%0S")).toBe("08");
     expect(dt.strftime("%00S")).toBe("08");
   });
@@ -649,6 +648,9 @@ describe("Date", () => {
     expect(new RubyDate(-12345, 1, 1).toS()).toBe("-12345-01-01");
     expect(new RubyDate(12345, 1, 1).toS()).toBe("12345-01-01");
     expect(new RubyDate(1, 1, 1).strftime("%F")).toBe("0001-01-01");
+    // `%C` and `%y` go through the C's floored `div`/`mod`, so a BC year
+    // answers `ruby 3.3.11 -rdate`'s `"-1"` and `"99"`, not `"-1"` and `"-1"`.
+    expect(new RubyDate(-1, 3, 1).strftime("%Y|%-Y|%6Y|%C|%y")).toBe("-0001|-1|-00001|-1|99");
   });
 
   const civilOrError = (

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -573,6 +573,60 @@ describe("Date", () => {
     expect(date.strftime("%Q")).toBe("%Q");
   });
 
+  it("honours the width prefix ahead of every directive, as date_strftime does", () => {
+    // Every expectation is `ruby 3.3.11 -rdate`'s answer for the same receiver.
+    const dt = new RubyDateTime(2008, 3, 1, 6, 7, 8.5);
+    expect(dt.strftime("%12S")).toBe("000000000008");
+    expect(dt.strftime("%6m")).toBe("000003");
+    expect(dt.strftime("%4d")).toBe("0001");
+    expect(dt.strftime("%2j")).toBe("61");
+    expect(dt.strftime("%1Y")).toBe("2008");
+    expect(dt.strftime("%3u")).toBe("006");
+    expect(dt.strftime("%4s")).toBe("1204351628");
+    expect(dt.strftime("%5e")).toBe("    1");
+    expect(dt.strftime("%2L")).toBe("50");
+    expect(dt.strftime("%20N")).toBe("50000000000000000000");
+    expect(new RubyDate(2008, 3, 1).strftime("%6m")).toBe("000003");
+  });
+
+  it("fills a width on the text and recursive arms, as FILL_PADDING does", () => {
+    const dt = new RubyDateTime(2008, 3, 1, 6, 7, 8.5);
+    expect(dt.strftime("%12A")).toBe("    Saturday");
+    expect(dt.strftime("%012A")).toBe("0000Saturday");
+    expect(dt.strftime("%_12A")).toBe("    Saturday");
+    expect(dt.strftime("%10F")).toBe("2008-03-01");
+    expect(dt.strftime("%10x")).toBe("  03/01/08");
+    expect(dt.strftime("%12%")).toBe("           %");
+    expect(dt.strftime("%6n")).toBe("     \n");
+  });
+
+  it("reads the padding character off the _ and 0 flags", () => {
+    const dt = new RubyDateTime(2008, 3, 1, 6, 7, 8.5);
+    expect(dt.strftime("%_S")).toBe(" 8");
+    expect(dt.strftime("%_m")).toBe(" 3");
+    // `%0` sets the pad character and then reads the width from the same digits.
+    expect(dt.strftime("%0S")).toBe("08");
+    expect(dt.strftime("%00S")).toBe("08");
+  });
+
+  it("subtracts the punctuation from a width on the %z arm", () => {
+    const dt = new RubyDateTime(2008, 3, 1, 6, 7, 8.5);
+    expect(dt.strftime("%5z")).toBe("+0000");
+    expect(dt.strftime("%8z")).toBe("+0000000");
+    expect(dt.strftime("%-z")).toBe("+000");
+    const east = new RubyDateTime(2008, 3, 1, 6, 0, 0, "+05:30");
+    expect(east.strftime("%8:z")).toBe("+0005:30");
+    expect(east.strftime("%-:::z")).toBe("+5:30");
+    expect(east.strftime("%_9z")).toBe("     +530");
+  });
+
+  it("leaves a width-qualified unknown directive alone", () => {
+    const dt = new RubyDateTime(2008, 3, 1, 6, 7, 8.5);
+    expect(dt.strftime("%9q")).toBe("%9q");
+    expect(dt.strftime("%^b")).toBe("%^b");
+    expect(dt.strftime("%Ez")).toBe("%Ez");
+  });
+
   it("resolves the ordinal and week-date arms", () => {
     expect(RubyDate.parse("2008070").strftime("%Y-%m-%d")).toBe("2008-03-10");
     expect(RubyDate.parse("2001-W05-6").strftime("%Y-%m-%d")).toBe("2001-02-03");

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -622,6 +622,13 @@ describe("Date", () => {
   it("leaves a width-qualified unknown directive alone", () => {
     const dt = new RubyDateTime(2008, 3, 1, 6, 7, 8.5);
     expect(dt.strftime("%9q")).toBe("%9q");
+    // `FLAG_FOUND` (date_strftime.c:90-93) — a flag AFTER a width is unknown,
+    // where the same flag before it is honoured.
+    expect(dt.strftime("%3-S")).toBe("%3-S");
+    expect(dt.strftime("%3_S")).toBe("%3_S");
+    expect(dt.strftime("%-3S")).toBe("8");
+    expect(dt.strftime("%_3S")).toBe("  8");
+    expect(dt.strftime("%0-S")).toBe("8");
     expect(dt.strftime("%^b")).toBe("%^b");
     expect(dt.strftime("%Ez")).toBe("%Ez");
   });

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -58,17 +58,6 @@ function pad2(n: number): string {
 }
 
 /**
- * @internal `date_strftime.c`'s `%Y` arm: `FMT('0', 0 <= y ? 4 : 5, "ld", y)`
- * (ruby/date, `date_strftime.c:236-247`), so a non-negative year pads to four
- * digits and a negative one pads to five columns counting the sign — `-0001`,
- * not `-1`. `Date#to_s` is `strftimev("%Y-%m-%d")` (`date_core.c:6967-6970`),
- * which is why a pre-1000 date renders as `0001-01-01`.
- */
-function padYear(year: number): string {
-  return year < 0 ? `-${String(-year).padStart(4, "0")}` : String(year).padStart(4, "0");
-}
-
-/**
  * @internal The fields the one C `strftime(3)` behind both `Date#strftime` and
  * `Time#strftime` reads off its receiver. It is not the public surface of
  * either class — `Date` deliberately answers no `hour`/`sec` — so each caller
@@ -111,27 +100,107 @@ function epochSeconds(subject: StrftimeSubject): number {
 }
 
 /**
- * @internal The four spellings `date_strftime.c`'s `%z` arm gives the offset,
- * picked by how many colons preceded the directive: none is `"+0900"`, one is
- * `"+09:00"`, two is `"+09:00:00"`, and three is the shortest form that loses
- * nothing — MRI shows the minute and second only when they are nonzero, so
- * `+09:00:00` is `"+09"` while `+05:30` stays `"+05:30"`. All four come off the
- * one offset in seconds, which is why the subject carries a number rather than
- * a string: `%::z` and `%:::z` are the only spellings that can show a
- * sub-minute offset.
+ * @internal `date_strftime.c`'s `%z` arm (`date_strftime.c:625-716`), which
+ * picks its spelling from how many colons preceded the directive: none is
+ * `"+0900"`, one is `"+09:00"`, two is `"+09:00:00"`, and three is the shortest
+ * form that loses nothing — MRI shows the minute and second only when they are
+ * nonzero, so `+09:00:00` is `"+09"` while `+05:30` stays `"+05:30"`. All four
+ * come off the one offset in seconds, which is why the subject carries a number
+ * rather than a string: `%::z` and `%:::z` are the only spellings that can show
+ * a sub-minute offset.
+ *
+ * Unlike every other arm this one does its own width arithmetic rather than
+ * going through `FMT`: the width counts the whole rendering, so the C subtracts
+ * the punctuation the spelling will add and pads the HOUR field with what is
+ * left. `hw` is the hour field's own default width, which the `-` flag narrows
+ * to one column for a single-digit hour.
  */
-function formatOffset(utcOffset: number, colons: number): string {
-  const sign = utcOffset < 0 ? "-" : "+";
-  const abs = Math.abs(utcOffset);
-  const hour = pad2(Math.floor(abs / 3600));
-  const min = pad2(Math.floor(abs / 60) % 60);
-  const sec = pad2(abs % 60);
-  if (colons === 0) return `${sign}${hour}${min}`;
-  if (colons === 1) return `${sign}${hour}:${min}`;
-  if (colons === 2) return `${sign}${hour}:${min}:${sec}`;
-  if (abs % 60 !== 0) return `${sign}${hour}:${min}:${sec}`;
-  if (Math.floor(abs / 60) % 60 !== 0) return `${sign}${hour}:${min}`;
-  return `${sign}${hour}`;
+function formatOffset(
+  utcOffset: number,
+  colons: number,
+  precision: number,
+  left: boolean,
+  padding: string,
+): string {
+  let off = utcOffset;
+  const aoff = Math.abs(off);
+
+  const hl = Math.floor(aoff / 3600) < 10 ? 1 : 2;
+  let hw = 2;
+  if (left && hl === 1) hw = 1;
+
+  switch (colons) {
+    case 0:
+      precision = precision <= 3 + hw ? hw : precision - 3;
+      break;
+    case 1:
+      precision = precision <= 4 + hw ? hw : precision - 4;
+      break;
+    case 2:
+      precision = precision <= 7 + hw ? hw : precision - 7;
+      break;
+    default:
+      if (aoff % 3600 === 0) precision = precision <= 1 + hw ? hw : precision - 1;
+      else if (aoff % 60 === 0) precision = precision <= 4 + hw ? hw : precision - 4;
+      else precision = precision <= 7 + hw ? hw : precision - 7;
+      break;
+  }
+
+  let out = "";
+  if (padding === " " && precision > hl) {
+    out += " ".repeat(precision - hl);
+    precision = hl;
+  }
+  if (off < 0) {
+    off = -off;
+    out += "-";
+  } else {
+    out += "+";
+  }
+  out += String(Math.floor(off / 3600)).padStart(precision, "0");
+  off = off % 3600;
+  if (colons === 3 && off === 0) return out;
+  if (1 <= colons) out += ":";
+  out += pad2(Math.floor(off / 60));
+  off = off % 60;
+  if (colons === 3 && off === 0) return out;
+  if (2 <= colons) out += `:${pad2(off)}`;
+  return out;
+}
+
+/**
+ * @internal `date_strftime.c`'s `FMT` macro (`date_strftime.c:105-116`): the
+ * directive's own width, defaulting to `defPrec` and collapsed to a single
+ * column by the `-` flag, with the arm's own default padding character unless
+ * the format string named one.
+ */
+function fmt(
+  padding: string,
+  left: boolean,
+  precision: number,
+  defPad: string,
+  defPrec: number,
+  val: number,
+): string {
+  if (precision <= 0) precision = defPrec;
+  if (left) precision = 1;
+  const sign = val < 0 ? "-" : "";
+  const digits = String(Math.abs(val));
+  return padding === "0" || (padding === "" && defPad === "0")
+    ? sign + digits.padStart(Math.max(precision - sign.length, 0), "0")
+    : (sign + digits).padStart(precision, " ");
+}
+
+/**
+ * @internal `date_strftime.c`'s `FILL_PADDING` macro
+ * (`date_strftime.c:95-104`), and the same left-fill the `STRFTIME` macro
+ * (`date_strftime.c:117-133`) applies to a recursively expanded format: the
+ * blanks that carry an already-formatted `i`-column answer out to the
+ * requested width.
+ */
+function fillPadding(padding: string, left: boolean, precision: number, i: number): string {
+  if (!left && precision > i) return (padding === "" ? " " : padding).repeat(precision - i);
+  return "";
 }
 
 /**
@@ -197,63 +266,190 @@ function subsecDigits(nsec: number, precision: number): string {
  * "module-private" and "exported". Callers use `Date#strftime` /
  * `DateTime#strftime` / `Time#strftime`, never this.
  *
+ * The scan mirrors `date_strftime.c`'s `again:` switch
+ * (`date_strftime.c:160-235`): the `-` and `_` flags, the padding character and
+ * the width are read ahead of EVERY directive, and each arm then formats
+ * through `fmt` / `fillPadding` with the C's own defaults for that arm rather
+ * than a hardcoded pad.
+ *
  * Only the directives the i18n format strings and the conformance mixins use
  * are recognised; Ruby leaves an unknown directive in place, and so does this.
- * `date_strftime.c` reads a width prefix ahead of every directive
- * (`date_strftime.c:160-230`); only the `%L`/`%N` arm honours one here, so a
- * width on any other directive keeps falling through verbatim.
+ * The `^`, `#`, `E` and `O` flags are among the unrecognised ones, so `%^b`
+ * still falls through verbatim rather than upcasing.
  * `%z` and `%Z` both come off the subject: `::Date` has no zone of its own and
  * answers UTC, while a `::Time` built through the public constructor is in the
  * local zone and answers its real offset and abbreviation.
  */
 export function strftime(subject: StrftimeSubject, format: string): string {
   const hour12 = subject.hour % 12 === 0 ? 12 : subject.hour % 12;
-  const tokens: Record<string, (precision: number) => string> = {
-    Y: () => padYear(subject.year),
-    C: () => pad2(Math.floor(subject.year / 100)),
-    y: () => pad2(subject.year % 100),
-    m: () => pad2(subject.mon),
-    d: () => pad2(subject.day),
-    e: () => String(subject.day).padStart(2, " "),
-    j: () => String(subject.yday).padStart(3, "0"),
-    F: () => `${padYear(subject.year)}-${pad2(subject.mon)}-${pad2(subject.day)}`,
-    A: () => DAY_NAMES[subject.wday],
-    a: () => ABBR_DAY_NAMES[subject.wday],
-    B: () => MONTH_NAMES[subject.mon - 1],
-    b: () => ABBR_MONTH_NAMES[subject.mon - 1],
-    h: () => ABBR_MONTH_NAMES[subject.mon - 1],
-    u: () => String(subject.wday === 0 ? 7 : subject.wday),
-    w: () => String(subject.wday),
-    H: () => pad2(subject.hour),
-    k: () => String(subject.hour).padStart(2, " "),
-    I: () => pad2(hour12),
-    l: () => String(hour12).padStart(2, " "),
-    M: () => pad2(subject.min),
-    S: () => pad2(subject.sec),
-    L: (precision) => subsecDigits(subject.nsec, precision <= 0 ? 3 : precision),
-    N: (precision) => subsecDigits(subject.nsec, precision <= 0 ? 9 : precision),
-    s: () => String(epochSeconds(subject)),
-    p: () => (subject.hour < 12 ? "AM" : "PM"),
-    P: () => (subject.hour < 12 ? "am" : "pm"),
-    x: () => `${pad2(subject.mon)}/${pad2(subject.day)}/${pad2(subject.year % 100)}`,
-    z: () => formatOffset(subject.utcOffset, 0),
-    ":z": () => formatOffset(subject.utcOffset, 1),
-    "::z": () => formatOffset(subject.utcOffset, 2),
-    ":::z": () => formatOffset(subject.utcOffset, 3),
-    Z: () => subject.zone,
-    n: () => "\n",
-    t: () => "\t",
-    "%": () => "%",
-  };
+  let out = "";
+  let f = 0;
 
-  return format.replace(/%(-?)(\d*)(:{0,3}[A-Za-z%])/g, (match, flag, width, spec) => {
-    const fn = tokens[spec];
-    if (!fn) return match;
-    if (width !== "" && spec !== "L" && spec !== "N") return match;
-    let result = fn(width === "" ? -1 : Number(width));
-    if (flag === "-") result = result.replace(/^[0 ]+/, "") || "0";
-    return result;
-  });
+  while (f < format.length) {
+    if (format[f] !== "%") {
+      out += format[f];
+      f++;
+      continue;
+    }
+
+    const sp = f;
+    let precision = -1;
+    let left = false;
+    let padding = "";
+    let colons = 0;
+    let g = f + 1;
+    let spec: string | undefined;
+
+    for (;;) {
+      const c = format[g];
+      if (c === "-") {
+        left = true;
+        g++;
+        continue;
+      }
+      if (c === "_") {
+        padding = " ";
+        g++;
+        continue;
+      }
+      if (c !== undefined && isdigit(c)) {
+        if (c === "0") padding = "0";
+        const [prec, e] = strtoul(format, g);
+        precision = prec;
+        g = e;
+        continue;
+      }
+      if (c === ":") {
+        let l = 0;
+        while (format[g + l] === ":") l++;
+        if (format[g + l] === "z" && l <= 3) {
+          colons = l;
+          g += l;
+          continue;
+        }
+      }
+      spec = c;
+      break;
+    }
+
+    // The value arms — `FMT` / `FMTV` — and the two that build their own answer.
+    const num = (defPad: string, defPrec: number, val: number): string =>
+      fmt(padding, left, precision, defPad, defPrec, val);
+    // The `break` arms and the recursively expanded `STRFTIME` ones, which are
+    // carried out to the requested width by `FILL_PADDING`.
+    const text = (value: string): string =>
+      fillPadding(padding, left, precision, value.length) + value;
+
+    let formatted: string | undefined;
+    switch (spec) {
+      case "Y":
+        // `FMT('0', 0 <= y ? 4 : 5, "ld", y)` (date_strftime.c:236-247), so a
+        // non-negative year pads to four digits and a negative one pads to five
+        // columns counting the sign — `-0001`, not `-1`. `Date#to_s` is
+        // `strftimev("%Y-%m-%d")` (date_core.c:6967-6970), which is why a
+        // pre-1000 date renders as `0001-01-01`.
+        formatted = num("0", 0 <= subject.year ? 4 : 5, subject.year);
+        break;
+      case "C":
+        formatted = num("0", 2, Math.floor(subject.year / 100));
+        break;
+      case "y":
+        formatted = num("0", 2, subject.year % 100);
+        break;
+      case "m":
+        formatted = num("0", 2, subject.mon);
+        break;
+      case "d":
+      case "e":
+        formatted = num(spec === "d" ? "0" : " ", 2, subject.day);
+        break;
+      case "j":
+        formatted = num("0", 3, subject.yday);
+        break;
+      case "F":
+        formatted = text(strftime(subject, "%Y-%m-%d"));
+        break;
+      case "x":
+        formatted = text(strftime(subject, "%m/%d/%y"));
+        break;
+      case "A":
+        formatted = text(DAY_NAMES[subject.wday]);
+        break;
+      case "a":
+        formatted = text(ABBR_DAY_NAMES[subject.wday]);
+        break;
+      case "B":
+        formatted = text(MONTH_NAMES[subject.mon - 1]);
+        break;
+      case "b":
+      case "h":
+        formatted = text(ABBR_MONTH_NAMES[subject.mon - 1]);
+        break;
+      case "u":
+        formatted = num("0", 1, subject.wday === 0 ? 7 : subject.wday);
+        break;
+      case "w":
+        formatted = num("0", 1, subject.wday);
+        break;
+      case "H":
+      case "k":
+        formatted = num(spec === "H" ? "0" : " ", 2, subject.hour);
+        break;
+      case "I":
+      case "l":
+        formatted = num(spec === "I" ? "0" : " ", 2, hour12);
+        break;
+      case "M":
+        formatted = num("0", 2, subject.min);
+        break;
+      case "S":
+        formatted = num("0", 2, subject.sec);
+        break;
+      case "L":
+      case "N": {
+        const w = spec === "L" ? 3 : 9;
+        if (precision <= 0) precision = w;
+        formatted = subsecDigits(subject.nsec, precision);
+        break;
+      }
+      case "s":
+        formatted = num("0", 1, epochSeconds(subject));
+        break;
+      case "p":
+        formatted = text(subject.hour < 12 ? "AM" : "PM");
+        break;
+      case "P":
+        formatted = text(subject.hour < 12 ? "am" : "pm");
+        break;
+      case "z":
+        formatted = formatOffset(subject.utcOffset, colons, precision, left, padding);
+        break;
+      case "Z":
+        formatted = text(subject.zone);
+        break;
+      case "n":
+        formatted = text("\n");
+        break;
+      case "t":
+        formatted = text("\t");
+        break;
+      case "%":
+        formatted = text("%");
+        break;
+    }
+
+    if (formatted === undefined) {
+      // `unknown:` (date_strftime.c:591-599) — the directive, flags and all,
+      // goes out verbatim with the padding state thrown away.
+      out += spec === undefined ? format.slice(sp) : format.slice(sp, g + 1);
+      f = spec === undefined ? format.length : g + 1;
+      continue;
+    }
+    out += formatted;
+    f = g + 1;
+  }
+
+  return out;
 }
 
 export class ArgumentError extends Error {

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -346,7 +346,7 @@ export function strftime(subject: StrftimeSubject, format: string): string {
       if (c === ":") {
         let l = 0;
         while (format[g + l] === ":") l++;
-        if (format[g + l] === "z" && l <= 3) {
+        if (format[g + l] === "z") {
           colons = l;
           g += l;
           continue;
@@ -438,6 +438,7 @@ export function strftime(subject: StrftimeSubject, format: string): string {
         formatted = text(subject.hour < 12 ? "am" : "pm");
         break;
       case "z":
+        if (colons > 3) break;
         formatted = formatOffset(subject.utcOffset, colons, precision, left, padding);
         break;
       case "Z":

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -268,9 +268,14 @@ function subsecDigits(nsec: number, precision: number): string {
  *
  * The scan mirrors `date_strftime.c`'s `again:` switch
  * (`date_strftime.c:160-235`): the `-` and `_` flags, the padding character and
- * the width are read ahead of EVERY directive, and each arm then formats
- * through `fmt` / `fillPadding` with the C's own defaults for that arm rather
- * than a hardcoded pad.
+ * the width are read ahead of EVERY directive. `num` is then the `FMT` / `FMTV`
+ * macro over a value arm and `text` is `FILL_PADDING` over a `break` arm or a
+ * recursively expanded `STRFTIME` one, each carrying the arm's own default
+ * width and padding character rather than a hardcoded pad. A directive with no
+ * arm goes out verbatim, flags and all, as `unknown:` (`date_strftime.c:591-599`)
+ * does — `%Y`'s five columns for a negative year (`FMT('0', 0 <= y ? 4 : 5)`,
+ * `date_strftime.c:236-247`) are why `Date#to_s` renders a pre-1000 date as
+ * `0001-01-01`.
  *
  * Only the directives the i18n format strings and the conformance mixins use
  * are recognised; Ruby leaves an unknown directive in place, and so does this.
@@ -332,29 +337,21 @@ export function strftime(subject: StrftimeSubject, format: string): string {
       break;
     }
 
-    // The value arms — `FMT` / `FMTV` — and the two that build their own answer.
     const num = (defPad: string, defPrec: number, val: number): string =>
       fmt(padding, left, precision, defPad, defPrec, val);
-    // The `break` arms and the recursively expanded `STRFTIME` ones, which are
-    // carried out to the requested width by `FILL_PADDING`.
     const text = (value: string): string =>
       fillPadding(padding, left, precision, value.length) + value;
 
     let formatted: string | undefined;
     switch (spec) {
       case "Y":
-        // `FMT('0', 0 <= y ? 4 : 5, "ld", y)` (date_strftime.c:236-247), so a
-        // non-negative year pads to four digits and a negative one pads to five
-        // columns counting the sign — `-0001`, not `-1`. `Date#to_s` is
-        // `strftimev("%Y-%m-%d")` (date_core.c:6967-6970), which is why a
-        // pre-1000 date renders as `0001-01-01`.
         formatted = num("0", 0 <= subject.year ? 4 : 5, subject.year);
         break;
       case "C":
-        formatted = num("0", 2, Math.floor(subject.year / 100));
+        formatted = num("0", 2, div(subject.year, 100));
         break;
       case "y":
-        formatted = num("0", 2, subject.year % 100);
+        formatted = num("0", 2, mod(subject.year, 100));
         break;
       case "m":
         formatted = num("0", 2, subject.mon);
@@ -439,8 +436,6 @@ export function strftime(subject: StrftimeSubject, format: string): string {
     }
 
     if (formatted === undefined) {
-      // `unknown:` (date_strftime.c:591-599) — the directive, flags and all,
-      // goes out verbatim with the padding state thrown away.
       out += spec === undefined ? format.slice(sp) : format.slice(sp, g + 1);
       f = spec === undefined ? format.length : g + 1;
       continue;

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -192,6 +192,17 @@ function fmt(
 }
 
 /**
+ * @internal `date_strftime.c`'s `FLAG_FOUND` macro
+ * (`date_strftime.c:90-93`), which sends a `-` or `_` that follows a width
+ * straight to `unknown:` — so MRI answers `%3-S` verbatim where `%-3S` is `8`.
+ * Its other two arms, the `%E`/`%O` locale extensions and `%:`, are both
+ * unreachable here: neither can set its flag and go on to read another.
+ */
+function flagFound(precision: number): boolean {
+  return precision > 0;
+}
+
+/**
  * @internal `date_strftime.c`'s `FILL_PADDING` macro
  * (`date_strftime.c:95-104`), and the same left-fill the `STRFTIME` macro
  * (`date_strftime.c:117-133`) applies to a recursively expanded format: the
@@ -307,13 +318,21 @@ export function strftime(subject: StrftimeSubject, format: string): string {
 
     for (;;) {
       const c = format[g];
-      if (c === "-") {
-        left = true;
+      if (c === "_") {
+        if (flagFound(precision)) {
+          spec = c;
+          break;
+        }
+        padding = " ";
         g++;
         continue;
       }
-      if (c === "_") {
-        padding = " ";
+      if (c === "-") {
+        if (flagFound(precision)) {
+          spec = c;
+          break;
+        }
+        left = true;
         g++;
         continue;
       }

--- a/packages/i18n/src/locale/fallbacks.ts
+++ b/packages/i18n/src/locale/fallbacks.ts
@@ -132,7 +132,7 @@ export class Fallbacks extends Map<Locale, Locale[]> {
   ): Locale[] {
     let result: Locale[] = [];
     for (const tag of tags == null ? [] : ([] as Locale[]).concat(tags)) {
-      const tags = tagFor(tag)
+      const tags = tagFor(tag)!
         .selfAndParents()
         .map((t) => t.toSym())
         .filter((t) => !exclude.includes(t));

--- a/packages/i18n/src/locale/tag.ts
+++ b/packages/i18n/src/locale/tag.ts
@@ -8,6 +8,9 @@
 import { Simple } from "./tag/simple.js";
 import type { Parents } from "./tag/parents.js";
 
+export { Simple } from "./tag/simple.js";
+export { Rfc4646 } from "./tag/rfc4646.js";
+
 let implementationStore: TagImplementation | undefined;
 
 /** The surface a tag implementation exposes: a factory, and the tag it makes. */

--- a/packages/i18n/src/locale/tag.ts
+++ b/packages/i18n/src/locale/tag.ts
@@ -13,9 +13,14 @@ export { Rfc4646 } from "./tag/rfc4646.js";
 
 let implementationStore: TagImplementation | undefined;
 
-/** The surface a tag implementation exposes: a factory, and the tag it makes. */
+/**
+ * The surface a tag implementation exposes: a factory, and the tag it makes.
+ * `Rfc4646.tag` answers nil for a tag that is not valid RFC 4646
+ * (rfc4646.rb:20), so the factory is nilable — `Simple.tag` (simple.rb:8-10)
+ * never is.
+ */
 export interface TagImplementation {
-  tag(...tag: string[]): Parents;
+  tag(...tag: string[]): Parents | null;
 }
 
 /**
@@ -39,6 +44,6 @@ export function setImplementation(value: TagImplementation): void {
  * Factory method for locale tags. Delegates to the current locale tag
  * implementation.
  */
-export function tag(tag: string): Parents {
+export function tag(tag: string): Parents | null {
   return implementation().tag(tag);
 }

--- a/packages/i18n/src/locale/tag/rfc4646.test.ts
+++ b/packages/i18n/src/locale/tag/rfc4646.test.ts
@@ -1,0 +1,157 @@
+/** Mirrors: i18n/test/locale/tag/rfc4646_test.rb */
+
+import { describe, expect, it, beforeEach } from "vitest";
+
+import { Rfc4646, Parser } from "./rfc4646.js";
+
+describe("I18nLocaleTagRfc4646ParserTest", () => {
+  it("Rfc4646::Parser given a valid tag 'de' returns an array of subtags", () => {
+    expect(Parser.match("de")).toEqual(["de", null, null, null, null, null, null]);
+  });
+
+  it("Rfc4646::Parser given a valid tag 'de-DE' returns an array of subtags", () => {
+    expect(Parser.match("de-DE")).toEqual(["de", null, "DE", null, null, null, null]);
+  });
+
+  it("Rfc4646::Parser given a valid lowercase tag 'de-latn-de-variant-x-phonebk' returns an array of subtags", () => {
+    expect(Parser.match("de-latn-de-variant-x-phonebk")).toEqual([
+      "de",
+      "latn",
+      "de",
+      "variant",
+      null,
+      "x-phonebk",
+      null,
+    ]);
+  });
+
+  it("Rfc4646::Parser given a valid uppercase tag 'DE-LATN-DE-VARIANT-X-PHONEBK' returns an array of subtags", () => {
+    expect(Parser.match("DE-LATN-DE-VARIANT-X-PHONEBK")).toEqual([
+      "DE",
+      "LATN",
+      "DE",
+      "VARIANT",
+      null,
+      "X-PHONEBK",
+      null,
+    ]);
+  });
+
+  it("Rfc4646::Parser given an invalid tag 'a-DE' it returns false", () => {
+    expect(Parser.match("a-DE")).toBe(false);
+  });
+
+  it("Rfc4646::Parser given an invalid tag 'de-419-DE' it returns false", () => {
+    expect(Parser.match("de-419-DE")).toBe(false);
+  });
+});
+
+// Tag for the locale 'de-Latn-DE-Variant-a-ext-x-phonebk-i-klingon'
+
+describe("I18nLocaleTagSubtagsTest", () => {
+  let tag: Rfc4646;
+
+  beforeEach(() => {
+    const subtags = ["de", "Latn", "DE", "variant", "a-ext", "x-phonebk", "i-klingon"];
+    tag = new Rfc4646(...subtags);
+  });
+
+  it("returns 'de' as the language subtag in lowercase", () => {
+    expect(tag.language).toBe("de");
+  });
+
+  it("returns 'Latn' as the script subtag in titlecase", () => {
+    expect(tag.script).toBe("Latn");
+  });
+
+  it("returns 'DE' as the region subtag in uppercase", () => {
+    expect(tag.region).toBe("DE");
+  });
+
+  it("returns 'variant' as the variant subtag in lowercase", () => {
+    expect(tag.variant).toBe("variant");
+  });
+
+  it("returns 'a-ext' as the extension subtag", () => {
+    expect(tag.extension).toBe("a-ext");
+  });
+
+  it("returns 'x-phonebk' as the privateuse subtag", () => {
+    expect(tag.privateuse).toBe("x-phonebk");
+  });
+
+  it("returns 'i-klingon' as the grandfathered subtag", () => {
+    expect(tag.grandfathered).toBe("i-klingon");
+  });
+
+  it("returns a formatted tag string from #to_s", () => {
+    expect(tag.toString()).toBe("de-Latn-DE-variant-a-ext-x-phonebk-i-klingon");
+  });
+
+  it("returns an array containing the formatted subtags from #to_a", () => {
+    expect(tag.toA()).toEqual(["de", "Latn", "DE", "variant", "a-ext", "x-phonebk", "i-klingon"]);
+  });
+
+  // Tag inheritance
+
+  it("#parent returns 'de-Latn-DE-variant-a-ext-x-phonebk' as the parent of 'de-Latn-DE-variant-a-ext-x-phonebk-i-klingon'", () => {
+    const tag = new Rfc4646("de", "Latn", "DE", "variant", "a-ext", "x-phonebk", "i-klingon");
+    expect(tag.parent()!.toString()).toBe("de-Latn-DE-variant-a-ext-x-phonebk");
+  });
+
+  it("#parent returns 'de-Latn-DE-variant-a-ext' as the parent of 'de-Latn-DE-variant-a-ext-x-phonebk'", () => {
+    const tag = new Rfc4646("de", "Latn", "DE", "variant", "a-ext", "x-phonebk");
+    expect(tag.parent()!.toString()).toBe("de-Latn-DE-variant-a-ext");
+  });
+
+  it("#parent returns 'de-Latn-DE-variant' as the parent of 'de-Latn-DE-variant-a-ext'", () => {
+    const tag = new Rfc4646("de", "Latn", "DE", "variant", "a-ext");
+    expect(tag.parent()!.toString()).toBe("de-Latn-DE-variant");
+  });
+
+  it("#parent returns 'de-Latn-DE' as the parent of 'de-Latn-DE-variant'", () => {
+    const tag = new Rfc4646("de", "Latn", "DE", "variant");
+    expect(tag.parent()!.toString()).toBe("de-Latn-DE");
+  });
+
+  it("#parent returns 'de-Latn' as the parent of 'de-Latn-DE'", () => {
+    const tag = new Rfc4646("de", "Latn", "DE");
+    expect(tag.parent()!.toString()).toBe("de-Latn");
+  });
+
+  it("#parent returns 'de' as the parent of 'de-Latn'", () => {
+    const tag = new Rfc4646("de", "Latn");
+    expect(tag.parent()!.toString()).toBe("de");
+  });
+
+  // TODO RFC4647 says: "If no language tag matches the request, the "default" value is returned."
+  // where should we set the default language?
+
+  it("#parent returns an array of 5 parents for 'de-Latn-DE-variant-a-ext-x-phonebk-i-klingon'", () => {
+    const parents = [
+      "de-Latn-DE-variant-a-ext-x-phonebk-i-klingon",
+      "de-Latn-DE-variant-a-ext-x-phonebk",
+      "de-Latn-DE-variant-a-ext",
+      "de-Latn-DE-variant",
+      "de-Latn-DE",
+      "de-Latn",
+      "de",
+    ];
+    const tag = new Rfc4646("de", "Latn", "DE", "variant", "a-ext", "x-phonebk", "i-klingon");
+    expect(tag.selfAndParents().map((t) => t.toString())).toEqual(parents);
+  });
+
+  it("returns an array of 5 parents for 'de-Latn-DE-variant-a-ext-x-phonebk-i-klingon'", () => {
+    const parents = [
+      "de-Latn-DE-variant-a-ext-x-phonebk-i-klingon",
+      "de-Latn-DE-variant-a-ext-x-phonebk",
+      "de-Latn-DE-variant-a-ext",
+      "de-Latn-DE-variant",
+      "de-Latn-DE",
+      "de-Latn",
+      "de",
+    ];
+    const tag = new Rfc4646("de", "Latn", "DE", "variant", "a-ext", "x-phonebk", "i-klingon");
+    expect(tag.selfAndParents().map((t) => t.toString())).toEqual(parents);
+  });
+});

--- a/packages/i18n/src/locale/tag/rfc4646.ts
+++ b/packages/i18n/src/locale/tag/rfc4646.ts
@@ -1,0 +1,153 @@
+/**
+ * Mirrors: i18n/lib/i18n/locale/tag/rfc4646.rb
+ *
+ * RFC 4646/47 compliant Locale tag implementation that parses locale tags to
+ * subtags such as language, script, region, variant etc.
+ *
+ * For more information see by http://en.wikipedia.org/wiki/IETF_language_tag
+ *
+ * Rfc4646::Parser does not implement grandfathered tags.
+ */
+
+import type { Locale } from "../../i18n.js";
+import { parent, parents, selfAndParents, type Parents } from "./parents.js";
+
+export const RFC4646_SUBTAGS = [
+  "language",
+  "script",
+  "region",
+  "variant",
+  "extension",
+  "privateuse",
+  "grandfathered",
+] as const;
+
+export const RFC4646_FORMATS: Record<string, string> = {
+  language: "downcase",
+  script: "capitalize",
+  region: "upcase",
+  variant: "downcase",
+};
+
+/** @internal Ruby's `String#downcase` / `#capitalize` / `#upcase`, for `send`. */
+const STRING_FORMATS: Record<string, (value: string) => string> = {
+  downcase: (value) => value.toLowerCase(),
+  capitalize: (value) => value.charAt(0).toUpperCase() + value.slice(1).toLowerCase(),
+  upcase: (value) => value.toUpperCase(),
+};
+
+export class Rfc4646 implements Parents {
+  /**
+   * Parses the given tag and returns a Tag instance if it is valid.
+   * Returns false if the given tag is not valid according to RFC 4646.
+   */
+  static tag(tag: string): Rfc4646 | false {
+    const matches = Rfc4646.parser().match(tag);
+    return matches ? new Rfc4646(...matches) : false;
+  }
+
+  static parser(): typeof Parser {
+    parserStore ??= Parser;
+    return parserStore;
+  }
+
+  static setParser(parser: typeof Parser): void {
+    parserStore = parser;
+  }
+
+  /** @internal `Struct.new(*RFC4646_SUBTAGS)`'s slots, which the readers below read as `self[name]`. */
+  readonly #slots: Record<string, string | null> = {};
+
+  #tag?: string;
+
+  constructor(...values: (string | null)[]) {
+    RFC4646_SUBTAGS.forEach((name, i) => {
+      this.#slots[name] = values[i] ?? null;
+    });
+  }
+
+  /** Mirrors: `include Parents` (rfc4646.rb:30). */
+  parent = parent;
+  parents = parents;
+  selfAndParents = selfAndParents;
+
+  /**
+   * @internal The block `RFC4646_FORMATS.each { |name, format| define_method(name)
+   * { self[name].send(format) unless self[name].nil? } }` (rfc4646.rb:32-34)
+   * installs, plus the plain slot reader `Struct` generates for the three
+   * subtags that carry no format. TypeScript has no `define_method`, so the
+   * seven readers are written out and share the one block body.
+   */
+  #subtag(name: string): string | null {
+    const value = this.#slots[name];
+    if (value == null) return null;
+    const format = RFC4646_FORMATS[name];
+    return format === undefined ? value : STRING_FORMATS[format](value);
+  }
+
+  get language(): string | null {
+    return this.#subtag("language");
+  }
+
+  get script(): string | null {
+    return this.#subtag("script");
+  }
+
+  get region(): string | null {
+    return this.#subtag("region");
+  }
+
+  get variant(): string | null {
+    return this.#subtag("variant");
+  }
+
+  get extension(): string | null {
+    return this.#subtag("extension");
+  }
+
+  get privateuse(): string | null {
+    return this.#subtag("privateuse");
+  }
+
+  get grandfathered(): string | null {
+    return this.#subtag("grandfathered");
+  }
+
+  toSym(): Locale {
+    return this.toString();
+  }
+
+  toString(): string {
+    this.#tag ??= this.toA()
+      .filter((subtag) => subtag != null)
+      .join("-");
+    return this.#tag;
+  }
+
+  toA(): string[] {
+    return RFC4646_SUBTAGS.map((attr) => this[attr]) as string[];
+  }
+}
+
+export const Parser = {
+  /**
+   * The gem writes PATTERN under `/x`, whose whitespace and `#` comments are
+   * stripped here. The grandfathered line is `/* ... *\/` in the source, which
+   * `/x` reads as a literal `/`, so that alternative demands a trailing slash
+   * and no real tag reaches it — the gem's way of parking it.
+   */
+  PATTERN:
+    /^(?:([a-z]{2,3}(?:(?:-[a-z]{3}){0,3})?|[a-z]{4}|[a-z]{5,8})(?:-([a-z]{4}))?(?:-([a-z]{2}|\d{3}))?(?:-([0-9a-z]{5,8}|\d[0-9a-z]{3}))*(?:-([0-9a-wyz](?:-[0-9a-z]{2,8})+))*(?:-(x(?:-[0-9a-z]{1,8})+))?|(x(?:-[0-9a-z]{1,8})+)|\/*([a-z]{1,3}(?:-[0-9a-z]{2,8}){1,2})*\/)$/i,
+
+  match(tag: string): (string | null)[] | false {
+    const matched = Parser.PATTERN.exec(String(tag));
+    if (matched === null) return false;
+    const c = Array.from(matched)
+      .slice(1)
+      .map((capture) => capture ?? null);
+    // TODO c[7] is grandfathered, throw a NotImplemented exception here?
+    return [...c.slice(0, 5), c[5] === null ? (c[6] ?? null) : c[5], c[7] ?? null];
+  },
+};
+
+let parserStore: typeof Parser | undefined;

--- a/packages/i18n/src/locale/tag/rfc4646.ts
+++ b/packages/i18n/src/locale/tag/rfc4646.ts
@@ -22,6 +22,11 @@ export const RFC4646_SUBTAGS = [
   "grandfathered",
 ] as const;
 
+/**
+ * The `String` method each subtag's reader sends itself. A Ruby Symbol is a JS
+ * string, and these are method names rather than values whose Symbol-ness
+ * discriminates, so they carry no leading colon.
+ */
 export const RFC4646_FORMATS: Record<string, string> = {
   language: "downcase",
   script: "capitalize",
@@ -40,10 +45,14 @@ export class Rfc4646 implements Parents {
   /**
    * Parses the given tag and returns a Tag instance if it is valid.
    * Returns false if the given tag is not valid according to RFC 4646.
+   *
+   * The gem's docstring says false, but `new(*matches) if matches`
+   * (rfc4646.rb:20) answers `nil` on the `Parser.match` false — it is `Parser`
+   * that answers false, and this returns nil.
    */
-  static tag(tag: string): Rfc4646 | false {
+  static tag(tag: string): Rfc4646 | null {
     const matches = Rfc4646.parser().match(tag);
-    return matches ? new Rfc4646(...matches) : false;
+    return matches ? new Rfc4646(...matches) : null;
   }
 
   static parser(): typeof Parser {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/migration.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/migration.json
@@ -178,7 +178,7 @@
     "package": "activerecord",
     "tsFile": "migration.ts",
     "rubyName": "with_advisory_lock",
-    "call": "order:connection,getAdvisoryLock",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+    "call": "order:constructor,releaseAdvisoryLock",
+    "reason": "Ruby `raise ConcurrentMigrationError` names the class without constructing it (migration.rb:1604), so Rails' only `.new` is the RELEASE_LOCK_FAILED one after `release_advisory_lock`; TypeScript has no `throw SomeError` spelling, so the port's first `throw new` necessarily precedes it."
   }
 ]

--- a/scripts/api-compare/unported-files.test.ts
+++ b/scripts/api-compare/unported-files.test.ts
@@ -70,6 +70,7 @@ describe("isSourceUnported package scoping", () => {
       "locale/fallbacks.rb",
       "locale/tag.rb",
       "locale/tag/parents.rb",
+      "locale/tag/rfc4646.rb",
       "locale/tag/simple.rb",
       "utils.rb",
     ]);

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -1258,14 +1258,6 @@ export const UNPORTED_FILES: UnportedFile[] = [
       "Sits at test/i18n/, outside the `gettext/` prefix above.",
   },
   {
-    pattern: "locale/tag/rfc4646.rb",
-    package: "i18n",
-    reason:
-      "The alternative `Locale::Tag` implementation. `Tag.implementation` " +
-      "defaults to `Tag::Simple` in the gem and nothing selects this one, so " +
-      "the fallback chain never reaches it — story i18n-locale-tag-rfc4646.",
-  },
-  {
     pattern: "middleware.rb",
     testFile: "i18n/middleware_test.rb",
     package: "i18n",


### PR DESCRIPTION
Four bundled stories.

### `i18n-locale-tag-rfc4646` — port `I18n::Locale::Tag::Rfc4646`

`packages/i18n/src/locale/tag/rfc4646.ts` ports `i18n/lib/i18n/locale/tag/rfc4646.rb`:
`RFC4646_SUBTAGS` / `RFC4646_FORMATS`, the `Struct`-shaped tag with its four
formatting readers, `include Parents`, and `Rfc4646::Parser` over the RFC 4646
subtag grammar. `PATTERN` is the `/x` regexp with its whitespace and comments
stripped; the grandfathered alternative keeps the literal `/` the gem's
`/* ... */` compiles to under `/x`, which is what parks that branch.

`define_method` has no TS spelling, so the seven readers are written out and
share the one block body (`#subtag`). `Rfc4646.tag` answers `null`, not `false`
— the gem's docstring says false but `new(*matches) if matches` (rfc4646.rb:20)
is `nil`; it is `Parser.match` that answers false. `Tag` now re-exports both
implementations, as `tag.rb:6-7` autoloads both — and `TagImplementation.tag` /
`Tag.tag` widen to `Parents | null`, because that is the gem's real contract
once `Rfc4646` can be the implementation (`tag.rb:20-22` returns whatever
`Rfc4646.tag` answers). Without it `Tag.setImplementation(Rfc4646)` does not
typecheck, which would ship the class unable to be the thing it exists to be.
The one consumer, `Locale::Fallbacks#compute`, takes a `!` — `fallbacks.rb:95`
calls `.self_and_parents` on that value unguarded too.

`api:extra` reports five of the readers as novel (`extension`, `grandfathered`,
`privateuse`, `region`, `variant`): the extractor cannot see a member `Struct.new`
or `define_method` installs, so they have a Ruby counterpart it has no way to
name. `#subtag`'s JSDoc directly above them carries the trace.

`i18n/test/locale/tag/rfc4646_test.rb` is
ported verbatim alongside — 23/23 matched by `test:compare` — and the
`unported-files.ts` entry is deleted, so `api:compare` now counts i18n at
**17/17 files, 248/248 methods**.

### `strftime-honours-no-width-outside-n-and-l`

`packages/date/src/date.ts:strftime` now scans flags, padding character and
width once ahead of every directive, mirroring `date_strftime.c:160-235`'s
`again:` switch, and each arm formats through the equivalent of
`FMT(def_pad, def_prec, ...)` / `FILL_PADDING` / `STRFTIME` with the C's own
per-arm defaults rather than a hardcoded `padStart`. The `-` flag is now
`precision = 1` at the parse (`date_strftime.c:109`) instead of a post-hoc strip.
`%z` does its own width arithmetic, as the C arm does, subtracting the
punctuation the spelling will add, and rejects a colon run longer than three to
`unknown:` as its `default:` case does. `FLAG_FOUND` (`date_strftime.c:90-93`) is
ported too, so a flag that follows a width goes to `unknown:` — `%3-S` is
verbatim where `%-3S` is `"8"`. (Its other two arms, the `%E`/`%O` locale
extensions and `%:`, are unreachable here: neither can set its flag and go on to
read another.)

Every expectation in the new tests was taken from a live `ruby 3.3.11 -rdate`.
A differential run over ~600 (subject, format) pairs — every supported
directive bare, with `-`, with `_`, with widths, and in both flag/width orders —
agrees with MRI except
for two pre-existing, out-of-scope categories: the `%^`/`%#`/`%E`/`%O` case and
POSIX-extension flags (unimplemented before and after, still falling through
verbatim), and year-1 `wday`/`%s`, which come off the constructor, not
`strftime`.

Three forms change, each a divergence and each MRI-verified: MRI's `%L`/`%N` arm
ignores the `-` flag entirely, `%-z` narrows the hour field to one column, and
`%C`/`%y` now go through the C's own floored `div`/`mod` (`date_strftime.c:248`,
`252`) — already in `date.ts` as `date_core.c`'s `DIV`/`MOD` — so a BC year
answers `"99"` rather than `"-1"`. Every other bare and `-` form is
byte-identical to before.

### `multiparameter-hash-branch-belongs-in-cast`

`TimeType` and `DateTimeType` override `cast` with the Hash branch, per
`accepts_multiparameter_time.rb:16-22`; neither `castValue` carries an `isHash`
arm any more. The nil guard stays in `Value#cast` (`value.rb:53-55`), which is
`super`. Externally invisible — the existing multiparameter tests pass unchanged.

### `with-advisory-lock-carries-guards-rails-lacks`

`Migrator#withAdvisoryLock` opens with `generateMigratorAdvisoryLockId()` and
`connection.getAdvisoryLock(lockId)`, as `migration.rb:1600-1613` does. The
capability gate and the `currentDatabase` probe are gone; the capability
question is back at the callers, which now spell
`isUseAdvisoryLock() ? withAdvisoryLock(...) : ...` exactly as
`migration.rb:1447` / `1461` do. `_ensureSchemaTable()` stays, justified at the
call site against `migration.rb:1470-1476` — a TS constructor cannot await.

One call-parity row moves: the converged `order:connection,getAdvisoryLock` row
is deleted, and an `order:constructor,releaseAdvisoryLock` row is added — Ruby's
`raise ConcurrentMigrationError` names the class without constructing it, so
Rails' only `.new` is the RELEASE_LOCK_FAILED one after `release_advisory_lock`,
and TypeScript has no `throw SomeError` spelling.

### Size

752 additions + 124 deletions = 876 against a 700 ceiling. The bundle is four
stories whose own estimates sum past it (~300 + ~110 + ~90 plus the gem port and
its verbatim test file); nothing here is severable without leaving a claimed
story unshipped.

### Gates

`pnpm typecheck`, `pnpm lint`, `pnpm api:compare` (i18n +1 file, +9 methods),
`pnpm api:calls` (OK, baseline net 0), `pnpm test:compare` (+23), and the touched
suites — date, i18n, activesupport, activemodel/type, migration/migrator — all
green locally. Advisory-lock suites skip on SQLite; PG and MariaDB run in CI.

Closes-story: i18n-locale-tag-rfc4646
Closes-story: multiparameter-hash-branch-belongs-in-cast
Closes-story: strftime-honours-no-width-outside-n-and-l
Closes-story: with-advisory-lock-carries-guards-rails-lacks
