### PR TITLE
feat(tasks-cli): author and edit story packages

### DIFF
--- a/scripts/tasks/cli.test.ts
+++ b/scripts/tasks/cli.test.ts
@@ -1178,6 +1178,7 @@ status: draft
 updated: 2026-06-04
 rfc: "0000-your-slug"
 cluster: cluster-name-1
+packages: [] # optional subset of the parent RFC's packages; empty inherits the RFC's list
 deps: []
 deps-rfc: []
 est-loc: null
@@ -2351,6 +2352,7 @@ describe("buildStoryContent", () => {
     expect(content).toContain(`status: draft`);
     expect(content).toContain(`rfc: "0005-gaps"`);
     expect(content).toContain(`cluster: null`);
+    expect(content).toContain(`packages: []`);
     expect(content).toContain(`deps: []`);
     expect(content).toContain(`deps-rfc: []`);
     expect(content).toContain(`est-loc: null`);
@@ -2980,6 +2982,47 @@ describe("newStory cluster validation", () => {
     const msg = vi.mocked(console.error).mock.calls[0]?.[0] as string;
     expect(msg).toMatch(/scaffold/);
     expect(msg).toMatch(/conversion/);
+  });
+});
+
+describe("newStory packages validation", () => {
+  function makeRfcDir(dir: string, rfcSlug: string, packages: string[]) {
+    mkdirSync(join(dir, ".git"));
+    mkdirSync(join(dir, "rfcs", rfcSlug, "stories"), { recursive: true });
+    const pkgsYaml = packages.map((p) => `  - ${p}`).join("\n");
+    writeFileSync(
+      join(dir, "rfcs", rfcSlug, "README.md"),
+      `---\nrfc: "${rfcSlug}"\ntitle: "test"\nstatus: active\npackages:\n${pkgsYaml}\n---\n`,
+    );
+  }
+
+  it("writes packages declared by the parent RFC into the story frontmatter", () => {
+    execFileSyncMock.mockImplementation((_file, args) => {
+      const label = args && args.length >= 3 ? args[2] : "";
+      if (label === "symbolic-ref") return "main" as never;
+      if (label === "diff-tree") return "story.md" as never;
+      return "" as never;
+    });
+    const dir = mkdtempSync(join(tmpdir(), "tasks-test-"));
+    makeRfcDir(dir, "0005-gaps", ["activerecord", "arel"]);
+    newStory("0005-gaps", "my-story", { packages: ["arel"], allowEmpty: true }, dir);
+    const out = readFileSync(join(dir, "rfcs", "0005-gaps", "stories", "my-story.md"), "utf8");
+    expect(out).toContain(`packages: ["arel"]`);
+  });
+
+  it("exits 1 for a package the parent RFC does not declare", () => {
+    vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`exit ${code}`);
+    }) as never);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const dir = mkdtempSync(join(tmpdir(), "tasks-test-"));
+    makeRfcDir(dir, "0005-gaps", ["activerecord", "arel"]);
+    expect(() => newStory("0005-gaps", "my-story", { packages: ["actionview"] }, dir)).toThrow(
+      /exit 1/,
+    );
+    const msg = vi.mocked(console.error).mock.calls[0]?.[0] as string;
+    expect(msg).toMatch(/actionview/);
+    expect(msg).toMatch(/activerecord, arel/);
   });
 });
 

--- a/scripts/tasks/cli.test.ts
+++ b/scripts/tasks/cli.test.ts
@@ -54,6 +54,7 @@ import {
   rewriteRfcRefs,
   parseCsv,
   setDepsError,
+  packagesError,
   formatFiles,
   formatRows,
   gitCommonDir,
@@ -1320,6 +1321,35 @@ describe("setDepsError", () => {
     const idx = index([story({ id: "a" })]);
     expect(setDepsError(idx, "a", "deps", [])).toBeNull();
     expect(setDepsError(idx, "a", "deps-rfc", [])).toBeNull();
+  });
+});
+
+describe("packagesError", () => {
+  const declared = ["activerecord", "arel"];
+
+  it("accepts packages the parent RFC declares", () => {
+    expect(packagesError(declared, ["arel"], "0013-pg")).toBeNull();
+    expect(packagesError(declared, ["activerecord", "arel"], "0013-pg")).toBeNull();
+  });
+
+  it("accepts an empty array (clearing the field)", () => {
+    expect(packagesError(declared, [], "0013-pg")).toBeNull();
+  });
+
+  it("rejects a package the parent RFC does not declare, listing the valid ones", () => {
+    const msg = packagesError(declared, ["actionview"], "0013-pg");
+    expect(msg).toMatch(/"actionview" not declared in 0013-pg\/README\.md/);
+    expect(msg).toMatch(/valid packages: activerecord, arel/);
+  });
+
+  it("names every undeclared package, not just the first", () => {
+    const msg = packagesError(declared, ["actionview", "arel", "rack"], "0013-pg");
+    expect(msg).toMatch(/"actionview", "rack"/);
+    expect(msg).not.toMatch(/"arel",/);
+  });
+
+  it("constrains nothing when the RFC declares no packages", () => {
+    expect(packagesError([], ["anything"], "0013-pg")).toBeNull();
   });
 });
 

--- a/scripts/tasks/cli.ts
+++ b/scripts/tasks/cli.ts
@@ -119,9 +119,6 @@ export interface StoryEntry {
   // absent from index.json files built before the override existed.
   raw_status?: string | null;
   cluster: string | null;
-  // Authored packages only; empty means "inherit the parent RFC's list", which
-  // display consumers resolve. Optional: absent from index.json files built
-  // before the field existed.
   packages?: string[];
   deps: string[];
   deps_rfc: string[];
@@ -2158,10 +2155,23 @@ function setDeps(id: string, kind: "deps" | "deps-rfc", csv: string): void {
   console.log(`set ${id} ${kind} = [${items.join(", ")}]`);
 }
 
-// Replaces a story's `packages` array. Mirrors setDeps, but the reference check
-// is containment in the parent RFC's declared `packages` — the same rule
-// validate-lib.mjs enforces, applied here so the edit fails before any commit.
-// An empty csv clears the array, which restores the inherit-from-RFC display.
+/**
+ * Returns why `items` may not be a story's packages under `rfcSlug`, or null
+ * when the edit is legal. An RFC declaring no packages constrains nothing —
+ * the same escape the `cluster` check takes, with validate.mjs as the backstop.
+ * Pure so both authoring paths (`new`, `set-packages`) share one rule and one
+ * message, and so the rule is testable without git.
+ */
+export function packagesError(declared: string[], items: string[], rfcSlug: string): string | null {
+  if (declared.length === 0) return null;
+  const unknown = items.filter((p) => !declared.includes(p));
+  if (unknown.length === 0) return null;
+  return (
+    `package(s) ${unknown.map((p) => `"${p}"`).join(", ")} not declared in ${rfcSlug}/README.md\n` +
+    `  valid packages: ${declared.join(", ")}`
+  );
+}
+
 function setPackages(id: string, csv: string): void {
   inGitTasks();
   const index = loadIndex();
@@ -2181,13 +2191,10 @@ function setPackages(id: string, csv: string): void {
   }
 
   const declared = index.rfcs.find((r) => r.id === entry.rfc)?.packages ?? [];
-  const unknown = items.filter((p) => !declared.includes(p));
-  if (declared.length > 0 && unknown.length > 0) {
+  const error = packagesError(declared, items, entry.rfc);
+  if (error !== null) {
     restoreGeneratedFiles(TASKS_DIR);
-    console.error(
-      `error: package(s) ${unknown.map((p) => `"${p}"`).join(", ")} not declared in ${entry.rfc}/README.md\n` +
-        `  valid packages: ${declared.join(", ")}`,
-    );
+    console.error(`error: ${error}`);
     process.exit(1);
   }
 
@@ -2396,10 +2403,10 @@ function reindex(): void {
 
 // ──────────────────── new story ────────────────────
 
-// Returns the cluster names declared in an RFC's README.md frontmatter, parsed
+// Returns the string list under `key` in an RFC's README.md frontmatter, parsed
 // with the same yaml.load semantics as tasks/scripts/lib.mjs (block sequences,
 // flow sequences, quoted values, comments all handled). Returns [] when the
-// README is missing, unparseable, or has no clusters field — the caller passes
+// README is missing, unparseable, or has no such field — the caller passes
 // through, and validate.mjs will catch any structural error later.
 function readRfcStringList(tasksDir: string, rfcSlug: string, key: string): string[] {
   const readmePath = join(tasksDir, "rfcs", rfcSlug, "README.md");
@@ -2421,14 +2428,10 @@ function readRfcStringList(tasksDir: string, rfcSlug: string, key: string): stri
   }
 }
 
-// The closed set a story's `cluster` must come from.
 function readRfcClusters(tasksDir: string, rfcSlug: string): string[] {
   return readRfcStringList(tasksDir, rfcSlug, "clusters");
 }
 
-// The closed set a story's `packages` must be a subset of. Empty (or an
-// unreadable README) means the RFC declares none, in which case the containment
-// check is skipped and validate.mjs is the backstop.
 function readRfcPackages(tasksDir: string, rfcSlug: string): string[] {
   return readRfcStringList(tasksDir, rfcSlug, "packages");
 }
@@ -2510,9 +2513,6 @@ export function buildStoryContent(
   const title = opts.title ?? storySlug;
   const deps = opts.deps ?? [];
   const depsYaml = deps.length === 0 ? "[]" : `[${deps.map((d) => qs(d)).join(", ")}]`;
-  // Empty `packages` is the normal case: the story then displays its parent
-  // RFC's packages as inherited. Only narrow it when the story really is
-  // scoped to a subset.
   const packages = opts.packages ?? [];
   const packagesYaml = packages.length === 0 ? "[]" : `[${packages.map((p) => qs(p)).join(", ")}]`;
   // A caller-supplied body (`--body-file`) replaces the empty skeleton, trimmed
@@ -2623,13 +2623,9 @@ export function newStory(
     }
   }
   if (opts.packages != null && opts.packages.length > 0) {
-    const declared = readRfcPackages(tasksDir, rfcSlug);
-    const unknown = opts.packages.filter((p) => !declared.includes(p));
-    if (declared.length > 0 && unknown.length > 0) {
-      console.error(
-        `error: package(s) ${unknown.map((p) => `"${p}"`).join(", ")} not declared in ${rfcSlug}/README.md\n` +
-          `  valid packages: ${declared.join(", ")}`,
-      );
+    const error = packagesError(readRfcPackages(tasksDir, rfcSlug), opts.packages, rfcSlug);
+    if (error !== null) {
+      console.error(`error: ${error}`);
       process.exit(1);
     }
   }
@@ -3660,7 +3656,6 @@ function main(): void {
     }
     case "set-packages": {
       const id = pos[0];
-      // As with set-deps, an explicit empty csv clears; a missing one is usage.
       const csv = pos[1];
       if (!id || csv === undefined) usage();
       setPackages(id, csv);

--- a/scripts/tasks/cli.ts
+++ b/scripts/tasks/cli.ts
@@ -119,6 +119,10 @@ export interface StoryEntry {
   // absent from index.json files built before the override existed.
   raw_status?: string | null;
   cluster: string | null;
+  // Authored packages only; empty means "inherit the parent RFC's list", which
+  // display consumers resolve. Optional: absent from index.json files built
+  // before the field existed.
+  packages?: string[];
   deps: string[];
   deps_rfc: string[];
   est_loc: number | null;
@@ -730,6 +734,7 @@ const FRONTMATTER_KEY_ORDER = [
   "updated",
   "rfc",
   "cluster",
+  "packages",
   "deps",
   "deps-rfc",
   "est-loc",
@@ -2153,6 +2158,45 @@ function setDeps(id: string, kind: "deps" | "deps-rfc", csv: string): void {
   console.log(`set ${id} ${kind} = [${items.join(", ")}]`);
 }
 
+// Replaces a story's `packages` array. Mirrors setDeps, but the reference check
+// is containment in the parent RFC's declared `packages` — the same rule
+// validate-lib.mjs enforces, applied here so the edit fails before any commit.
+// An empty csv clears the array, which restores the inherit-from-RFC display.
+function setPackages(id: string, csv: string): void {
+  inGitTasks();
+  const index = loadIndex();
+  const entry = index.stories.find((s) => s.id === id);
+  if (!entry) {
+    restoreGeneratedFiles(TASKS_DIR);
+    console.error(`error: story "${id}" not found in index`);
+    process.exit(1);
+  }
+  const items = parseCsv(csv);
+
+  const current = entry.packages ?? [];
+  if (current.length === items.length && current.every((p, i) => p === items[i])) {
+    restoreGeneratedFiles(TASKS_DIR);
+    console.log(`${id} packages already [${items.join(", ")}]`);
+    return;
+  }
+
+  const declared = index.rfcs.find((r) => r.id === entry.rfc)?.packages ?? [];
+  const unknown = items.filter((p) => !declared.includes(p));
+  if (declared.length > 0 && unknown.length > 0) {
+    restoreGeneratedFiles(TASKS_DIR);
+    console.error(
+      `error: package(s) ${unknown.map((p) => `"${p}"`).join(", ")} not declared in ${entry.rfc}/README.md\n` +
+        `  valid packages: ${declared.join(", ")}`,
+    );
+    process.exit(1);
+  }
+
+  flip([id], `set-packages: ${id}`, RETRY_MSG(id), 4, (targets) =>
+    setFrontmatterList(targets[0].file, "packages", items),
+  );
+  console.log(`set ${id} packages = [${items.join(", ")}]`);
+}
+
 // Single exit point for a refine agent: commit whatever it edited in the
 // story file in place, push with the same rebase-retry as the other
 // mutations, and print a machine-readable summary the orchestration layer
@@ -2357,7 +2401,7 @@ function reindex(): void {
 // flow sequences, quoted values, comments all handled). Returns [] when the
 // README is missing, unparseable, or has no clusters field — the caller passes
 // through, and validate.mjs will catch any structural error later.
-function readRfcClusters(tasksDir: string, rfcSlug: string): string[] {
+function readRfcStringList(tasksDir: string, rfcSlug: string, key: string): string[] {
   const readmePath = join(tasksDir, "rfcs", rfcSlug, "README.md");
   let text: string;
   try {
@@ -2368,13 +2412,25 @@ function readRfcClusters(tasksDir: string, rfcSlug: string): string[] {
   const fmMatch = text.match(/^---\n([\s\S]*?)\n---/);
   if (!fmMatch) return [];
   try {
-    const fm = parseYaml(fmMatch[1]) as { clusters?: unknown } | null;
-    const clusters = fm?.clusters;
-    if (!Array.isArray(clusters)) return [];
-    return clusters.filter((c): c is string => typeof c === "string");
+    const fm = parseYaml(fmMatch[1]) as Record<string, unknown> | null;
+    const list = fm?.[key];
+    if (!Array.isArray(list)) return [];
+    return list.filter((c): c is string => typeof c === "string");
   } catch {
     return [];
   }
+}
+
+// The closed set a story's `cluster` must come from.
+function readRfcClusters(tasksDir: string, rfcSlug: string): string[] {
+  return readRfcStringList(tasksDir, rfcSlug, "clusters");
+}
+
+// The closed set a story's `packages` must be a subset of. Empty (or an
+// unreadable README) means the RFC declares none, in which case the containment
+// check is skipped and validate.mjs is the backstop.
+function readRfcPackages(tasksDir: string, rfcSlug: string): string[] {
+  return readRfcStringList(tasksDir, rfcSlug, "packages");
 }
 
 // Reads the `status:` scalar from an RFC's README.md frontmatter, parsed with
@@ -2441,6 +2497,7 @@ export function buildStoryContent(
     title?: string;
     status?: StoryStatus;
     cluster?: string | null;
+    packages?: string[];
     estLoc?: number | null;
     deps?: string[];
     priority?: number | null;
@@ -2453,6 +2510,11 @@ export function buildStoryContent(
   const title = opts.title ?? storySlug;
   const deps = opts.deps ?? [];
   const depsYaml = deps.length === 0 ? "[]" : `[${deps.map((d) => qs(d)).join(", ")}]`;
+  // Empty `packages` is the normal case: the story then displays its parent
+  // RFC's packages as inherited. Only narrow it when the story really is
+  // scoped to a subset.
+  const packages = opts.packages ?? [];
+  const packagesYaml = packages.length === 0 ? "[]" : `[${packages.map((p) => qs(p)).join(", ")}]`;
   // A caller-supplied body (`--body-file`) replaces the empty skeleton, trimmed
   // to a single leading blank line and one trailing newline so the file is
   // prettier-clean regardless of how the source file was whitespaced.
@@ -2471,6 +2533,7 @@ status: ${opts.status ?? "draft"}
 updated: ${opts.date}
 rfc: ${qs(rfcSlug)}
 cluster: ${opts.cluster != null ? opts.cluster : "null"}
+packages: ${packagesYaml}
 deps: ${depsYaml}
 deps-rfc: []
 est-loc: ${opts.estLoc != null ? opts.estLoc : "null"}
@@ -2510,6 +2573,7 @@ export function newStory(
     title?: string;
     status?: StoryStatus;
     cluster?: string;
+    packages?: string[];
     estLoc?: number | null;
     deps?: string[];
     priority?: number | null;
@@ -2554,6 +2618,17 @@ export function newStory(
       console.error(
         `error: cluster "${opts.cluster}" is not declared in ${rfcSlug}/README.md\n` +
           `  valid clusters: ${validClusters.join(", ")}`,
+      );
+      process.exit(1);
+    }
+  }
+  if (opts.packages != null && opts.packages.length > 0) {
+    const declared = readRfcPackages(tasksDir, rfcSlug);
+    const unknown = opts.packages.filter((p) => !declared.includes(p));
+    if (declared.length > 0 && unknown.length > 0) {
+      console.error(
+        `error: package(s) ${unknown.map((p) => `"${p}"`).join(", ")} not declared in ${rfcSlug}/README.md\n` +
+          `  valid packages: ${declared.join(", ")}`,
       );
       process.exit(1);
     }
@@ -3448,10 +3523,12 @@ function main(): void {
       const statusRaw = stringFlag(flags, "status");
       if (statusRaw !== undefined && !STORY_STATUSES.includes(statusRaw as StoryStatus)) usage();
       const depsRaw = stringFlag(flags, "deps");
+      const packagesRaw = stringFlag(flags, "packages");
       newStory(rfcSlug, storySlug, {
         title: stringFlag(flags, "title"),
         status: statusRaw as StoryStatus | undefined,
         cluster: stringFlag(flags, "cluster"),
+        packages: packagesRaw !== undefined ? parseCsv(packagesRaw) : [],
         estLoc: estLocRaw !== undefined ? Number(estLocRaw) : null,
         deps: depsRaw
           ? depsRaw
@@ -3581,6 +3658,14 @@ function main(): void {
       setDeps(id, cmd === "set-deps" ? "deps" : "deps-rfc", csv);
       break;
     }
+    case "set-packages": {
+      const id = pos[0];
+      // As with set-deps, an explicit empty csv clears; a missing one is usage.
+      const csv = pos[1];
+      if (!id || csv === undefined) usage();
+      setPackages(id, csv);
+      break;
+    }
     default:
       usage();
   }
@@ -3611,7 +3696,8 @@ function usage(): never {
              [--priority <N> | --priority --clear]   (RFC-level default priority for its un-prioritized stories)
   set-deps <id> <csv>                          (replace deps; checks references + cycles; empty csv clears)
   set-deps-rfc <id> <csv>                      (replace deps-rfc; checks references; empty csv clears)
-  new <rfc-slug> <story-slug> [--title "text"] [--status <v>] [--cluster <name>] [--est-loc <N>] [--deps <csv>] [--priority <N>] [--body-file <path>] [--allow-empty]
+  set-packages <id> <csv>                      (replace packages; must be declared by the parent RFC; empty csv clears)
+  new <rfc-slug> <story-slug> [--title "text"] [--status <v>] [--cluster <name>] [--packages <csv>] [--est-loc <N>] [--deps <csv>] [--priority <N>] [--body-file <path>] [--allow-empty]
   finalize <0000-slug> [--dry-run]             (assign the next RFC number: rename dir, rewrite refs, rebuild index)
   new-rfc <slug> [--title "text"] [--owner @handle] [--packages <csv>] [--clusters <csv>] [--related <csv>] [--body-file <path>]
   reindex | build                              (rebuild the index in place)


### PR DESCRIPTION
Adds `packages` support to the tasks CLI, matching the `packages` field just added to story frontmatter in `blazetrailsdev/tasks`.

- `pnpm tasks new <rfc> <story> --packages <csv>` seeds the field.
- `pnpm tasks set-packages <id> <csv>` replaces it; an empty csv clears it, which restores the inherit-from-parent-RFC display.
- Both reject packages the parent RFC does not declare, failing before any commit — the same containment rule `validate-lib.mjs` enforces (and that `cluster` already follows).
- `readRfcClusters` is generalized to `readRfcStringList` so the packages lookup reuses it.

Verified end-to-end against the real tasks checkout: `set-packages phase2a-read-path activerecord` wrote and pushed the field; `set-packages phase2a-read-path arel` was rejected with the valid-packages list.