### PR TITLE
test(activerecord),ci: port the second half of CommandRecorderTest; audit the bare arunit database and the virtualized-DX / trailties / leaf gates

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,19 @@ services:
     ports:
       - "${PG_PORT:-25432}:5432"
     environment:
+      # AUDITED (RFC 0028, audit-bare-arunit-database-still-needed): a *stamped*
+      # run never connects to this database — globalSetup's admin client targets
+      # `postgres` (support/template-global-setup.ts:179) and every worker
+      # resolves activerecord_unittest_<runToken>_<slot> through `applySlot`
+      # (support/config.ts:159-167). It is nonetheless NOT vestigial and must
+      # stay provisioned, on three counts:
+      #   1. the init script below runs *against* it, and its last statement is
+      #      `ALTER DATABASE activerecord_unittest OWNER TO rails`; CI feeds the
+      #      same file by hand with `psql -d activerecord_unittest` (ci.yml:997);
+      #   2. the activerecord-cli E2E connects to it by name via PG_TEST_URL
+      #      (ci.yml:1023);
+      #   3. `applySlot` falls back to this bare name whenever no run token is
+      #      stamped — a bare adapter script or a harness-less connection.
       POSTGRES_DB: activerecord_unittest
       POSTGRES_USER: postgres
       # Rails' postgresql: entries carry no credential (config.example.yml:74-81),
@@ -25,6 +38,13 @@ services:
     ports:
       - "${MYSQL_PORT:-13306}:3306"
     environment:
+      # AUDITED alongside POSTGRES_DB above. The MySQL admin connection carries
+      # no database at all (support/template-global-setup.ts:285-293), so a
+      # stamped run never touches this one either — but MYSQL_TEST_URL names it
+      # for the activerecord-cli E2E (ci.yml:1088) and the token-less `applySlot`
+      # fallback still resolves to it. Unlike Postgres, the init script does not
+      # need it: `mysql -uroot < 01-rails-user.sql` (ci.yml:1072) runs with no
+      # database selected and only CREATEs users and grants.
       MYSQL_DATABASE: activerecord_unittest
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
     volumes:

--- a/packages/activerecord/src/migration/command-recorder.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.test.ts
@@ -4,9 +4,6 @@ import { IrreversibleMigration } from "../migration.js";
 import { Table } from "../connection-adapters/abstract/schema-definitions.js";
 import { adapterSupports, itIfSupports } from "../support/supports.js";
 
-// Stands in for Rails' `CommandRecorder.new(ActiveRecord::Base.lease_connection)`:
-// the recorder asks its delegate the same capability questions the real
-// connection answers, so `supports_bulk_alter?` tracks the running lane.
 const abstractDelegate = {
   updateTableDefinition: (tableName: string, base: unknown) => new Table(tableName, base as never),
   supportsBulkAlter: () => adapterSupports("bulk_alter"),

--- a/packages/activerecord/src/migration/command-recorder.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.test.ts
@@ -738,11 +738,11 @@ describe("Migration", () => {
       const enable = recorder.inverseOf("removeUniqueConstraint", [
         "dogs",
         ["speed"],
-        { deferrable: ":deferred", name: "uniq_speed" },
+        { deferrable: "deferred", name: "uniq_speed" },
       ]);
       expect(enable).toEqual({
         cmd: "addUniqueConstraint",
-        args: ["dogs", ["speed"], { deferrable: ":deferred", name: "uniq_speed" }],
+        args: ["dogs", ["speed"], { deferrable: "deferred", name: "uniq_speed" }],
       });
     });
 

--- a/packages/activerecord/src/migration/command-recorder.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.test.ts
@@ -2,456 +2,22 @@ import { beforeEach, describe, it, expect } from "vitest";
 import { CommandRecorder } from "./command-recorder.js";
 import { IrreversibleMigration } from "../migration.js";
 import { Table } from "../connection-adapters/abstract/schema-definitions.js";
-import { Table as PgTable } from "../connection-adapters/postgresql/schema-definitions.js";
-import { Table as MysqlTable } from "../connection-adapters/mysql/schema-definitions.js";
+import { adapterSupports, itIfSupports } from "../support/supports.js";
 
+// Stands in for Rails' `CommandRecorder.new(ActiveRecord::Base.lease_connection)`:
+// the recorder asks its delegate the same capability questions the real
+// connection answers, so `supports_bulk_alter?` tracks the running lane.
 const abstractDelegate = {
   updateTableDefinition: (tableName: string, base: unknown) => new Table(tableName, base as never),
+  supportsBulkAlter: () => adapterSupports("bulk_alter"),
 };
-const pgDelegate = {
-  updateTableDefinition: (tableName: string, base: unknown) =>
-    new PgTable(tableName, base as never),
-};
-const mysqlDelegate = {
-  updateTableDefinition: (tableName: string, base: unknown) =>
-    new MysqlTable(tableName, base as never),
-};
-
-describe("CommandRecorder", () => {
-  describe("invertAddTimestamps / invertRemoveTimestamps", () => {
-    it("invertAddTimestamps returns removeTimestamps", () => {
-      const [cmd] = new CommandRecorder().invertAddTimestamps(["users"]);
-      expect(cmd).toBe("removeTimestamps");
-    });
-
-    it("invertRemoveTimestamps returns addTimestamps", () => {
-      const [cmd] = new CommandRecorder().invertRemoveTimestamps(["users"]);
-      expect(cmd).toBe("addTimestamps");
-    });
-  });
-
-  describe("invertAddReference / invertRemoveReference", () => {
-    it("invertAddReference returns removeReference", () => {
-      const [cmd] = new CommandRecorder().invertAddReference(["posts", "user"]);
-      expect(cmd).toBe("removeReference");
-    });
-
-    it("invertRemoveReference returns addReference", () => {
-      const [cmd] = new CommandRecorder().invertRemoveReference(["posts", "user"]);
-      expect(cmd).toBe("addReference");
-    });
-
-    it("invert_add_belongs_to_alias", () => {
-      const { cmd, args } = new CommandRecorder().inverseOf("addBelongsTo", ["table", "user"]);
-      expect(cmd).toBe("removeReference");
-      expect(args).toEqual(["table", "user"]);
-    });
-
-    it("invert_remove_belongs_to_alias", () => {
-      const { cmd, args } = new CommandRecorder().inverseOf("removeBelongsTo", ["table", "user"]);
-      expect(cmd).toBe("addReference");
-      expect(args).toEqual(["table", "user"]);
-    });
-  });
-
-  describe("invertAddForeignKey / invertRemoveForeignKey", () => {
-    it("invertAddForeignKey strips validate and returns removeForeignKey", () => {
-      const [cmd, args] = new CommandRecorder().invertAddForeignKey([
-        "posts",
-        "users",
-        { validate: false },
-      ]);
-      expect(cmd).toBe("removeForeignKey");
-      expect((args[2] as Record<string, unknown>)["validate"]).toBeUndefined();
-    });
-
-    it("invertRemoveForeignKey throws without second table", () => {
-      expect(() => new CommandRecorder().invertRemoveForeignKey(["posts"])).toThrow(
-        IrreversibleMigration,
-      );
-    });
-
-    it("invertRemoveForeignKey returns addForeignKey with toTable option", () => {
-      const [cmd, args] = new CommandRecorder().invertRemoveForeignKey([
-        "posts",
-        { toTable: "users" },
-      ]);
-      expect(cmd).toBe("addForeignKey");
-      expect(args[1]).toBe("users");
-    });
-  });
-
-  describe("invertAddCheckConstraint / invertRemoveCheckConstraint", () => {
-    it("invertAddCheckConstraint strips validate and returns removeCheckConstraint", () => {
-      const [cmd, args] = new CommandRecorder().invertAddCheckConstraint([
-        "users",
-        "age > 0",
-        { validate: true, ifNotExists: true },
-      ]);
-      expect(cmd).toBe("removeCheckConstraint");
-      const opts = args[2] as Record<string, unknown>;
-      expect(opts["validate"]).toBeUndefined();
-      expect(opts["ifExists"]).toBe(true);
-    });
-
-    it("invertRemoveCheckConstraint throws without expression", () => {
-      expect(() => new CommandRecorder().invertRemoveCheckConstraint(["users"])).toThrow(
-        IrreversibleMigration,
-      );
-    });
-
-    it("invertRemoveCheckConstraint returns addCheckConstraint", () => {
-      const [cmd] = new CommandRecorder().invertRemoveCheckConstraint(["users", "age > 0"]);
-      expect(cmd).toBe("addCheckConstraint");
-    });
-  });
-
-  describe("invertAddExclusionConstraint / invertRemoveExclusionConstraint", () => {
-    it("invertAddExclusionConstraint returns removeExclusionConstraint", () => {
-      const [cmd] = new CommandRecorder().invertAddExclusionConstraint(["rooms", "during WITH &&"]);
-      expect(cmd).toBe("removeExclusionConstraint");
-    });
-
-    it("invertRemoveExclusionConstraint throws without expression", () => {
-      expect(() => new CommandRecorder().invertRemoveExclusionConstraint(["rooms"])).toThrow(
-        IrreversibleMigration,
-      );
-    });
-  });
-
-  describe("invertAddUniqueConstraint / invertRemoveUniqueConstraint", () => {
-    it("invertAddUniqueConstraint throws when usingIndex given", () => {
-      expect(() =>
-        new CommandRecorder().invertAddUniqueConstraint(["users", { usingIndex: "idx" }]),
-      ).toThrow(IrreversibleMigration);
-    });
-
-    it("invertAddUniqueConstraint returns removeUniqueConstraint", () => {
-      const [cmd] = new CommandRecorder().invertAddUniqueConstraint(["users", "email"]);
-      expect(cmd).toBe("removeUniqueConstraint");
-    });
-
-    it("invertRemoveUniqueConstraint throws without column", () => {
-      expect(() => new CommandRecorder().invertRemoveUniqueConstraint(["users"])).toThrow(
-        IrreversibleMigration,
-      );
-    });
-
-    it("invertRemoveUniqueConstraint returns addUniqueConstraint", () => {
-      const [cmd] = new CommandRecorder().invertRemoveUniqueConstraint(["users", "email"]);
-      expect(cmd).toBe("addUniqueConstraint");
-    });
-
-    it("invertRemoveUniqueConstraint handles array column names without mistaking array for options", () => {
-      const [cmd] = new CommandRecorder().invertRemoveUniqueConstraint([
-        "users",
-        ["email", "name"],
-      ]);
-      expect(cmd).toBe("addUniqueConstraint");
-    });
-  });
-
-  describe("invertRemoveColumns", () => {
-    it("throws without type option", () => {
-      expect(() => new CommandRecorder().invertRemoveColumns(["users", "name", "age"])).toThrow(
-        IrreversibleMigration,
-      );
-    });
-
-    it("returns addColumns when type given", () => {
-      const [cmd] = new CommandRecorder().invertRemoveColumns([
-        "users",
-        "name",
-        { type: "string" },
-      ]);
-      expect(cmd).toBe("addColumns");
-    });
-  });
-
-  describe("invertRenameEnum", () => {
-    it("swaps name and new_name", () => {
-      const [cmd, args] = new CommandRecorder().invertRenameEnum(["status", "state"]);
-      expect(cmd).toBe("renameEnum");
-      expect(args).toEqual(["state", "status"]);
-    });
-
-    it("handles { to: newName } hash form", () => {
-      const [cmd, args] = new CommandRecorder().invertRenameEnum(["status", { to: "state" }]);
-      expect(cmd).toBe("renameEnum");
-      expect(args).toEqual(["state", "status"]);
-    });
-  });
-
-  describe("invertRenameEnumValue", () => {
-    it("swaps from/to values", () => {
-      const [cmd, args] = new CommandRecorder().invertRenameEnumValue([
-        "status",
-        { from: "active", to: "enabled" },
-      ]);
-      expect(cmd).toBe("renameEnumValue");
-      expect(args[1]).toEqual({ from: "enabled", to: "active" });
-    });
-
-    it("throws without from/to options", () => {
-      expect(() =>
-        new CommandRecorder().invertRenameEnumValue(["status", { value: "active" }]),
-      ).toThrow(IrreversibleMigration);
-    });
-  });
-
-  describe("invertDropEnum", () => {
-    it("throws without values arg", () => {
-      expect(() => new CommandRecorder().invertDropEnum(["my_enum"])).toThrow(
-        IrreversibleMigration,
-      );
-    });
-
-    it("throws when only options hash given (no values)", () => {
-      expect(() => new CommandRecorder().invertDropEnum(["my_enum", { schema: "public" }])).toThrow(
-        IrreversibleMigration,
-      );
-    });
-
-    it("returns createEnum when values array given", () => {
-      const [cmd] = new CommandRecorder().invertDropEnum(["my_enum", ["val1", "val2"]]);
-      expect(cmd).toBe("createEnum");
-    });
-  });
-
-  describe("invertDropVirtualTable", () => {
-    it("throws without type arg", () => {
-      expect(() => new CommandRecorder().invertDropVirtualTable(["my_table"])).toThrow(
-        IrreversibleMigration,
-      );
-    });
-
-    it("returns createVirtualTable when type given", () => {
-      const [cmd] = new CommandRecorder().invertDropVirtualTable(["my_table", "fts5"]);
-      expect(cmd).toBe("createVirtualTable");
-    });
-  });
-
-  describe("joinTableName / findJoinTableName", () => {
-    it("joinTableName returns sorted joined name", () => {
-      expect(new CommandRecorder().joinTableName("cats", "dogs")).toBe("cats_dogs");
-      expect(new CommandRecorder().joinTableName("dogs", "cats")).toBe("cats_dogs");
-    });
-
-    it("findJoinTableName uses tableName option when given", () => {
-      expect(new CommandRecorder().findJoinTableName("cats", "dogs", { tableName: "pets" })).toBe(
-        "pets",
-      );
-    });
-  });
-
-  describe("invertAddColumns", () => {
-    it("returns removeColumns", () => {
-      const [cmd] = new CommandRecorder().invertAddColumns(["users", "name", "age"]);
-      expect(cmd).toBe("removeColumns");
-    });
-  });
-
-  describe("invert change table (non-bulk)", () => {
-    it("accepts (tableName, fn) without explicit options", async () => {
-      const recorder = new CommandRecorder(abstractDelegate);
-      // short form: no options argument
-      await recorder.changeTable("fruits", async (t) => {
-        await t.string("name");
-      });
-      expect(recorder.commands[0].cmd).toBe("addColumn");
-    });
-
-    it("remove with multiple columns records a single removeColumns", async () => {
-      const recorder = new CommandRecorder(abstractDelegate);
-      await recorder.changeTable("fruits", async (t) => {
-        await t.remove("name", "kind", { type: "string" });
-      });
-      expect(recorder.commands).toEqual([
-        { cmd: "removeColumns", args: ["fruits", "name", "kind", { type: "string" }] },
-      ]);
-    });
-
-    it("removeIndex with an options hash records a nil column, not the hash", async () => {
-      const recorder = new CommandRecorder(abstractDelegate);
-      await recorder.changeTable("fruits", async (t) => {
-        await t.removeIndex({ name: "index_fruits_on_kind" });
-      });
-      expect(recorder.commands).toEqual([
-        { cmd: "removeIndex", args: ["fruits", undefined, { name: "index_fruits_on_kind" }] },
-      ]);
-    });
-
-    it("removeIndex with an explicit nil column keeps the second-argument options", async () => {
-      const recorder = new CommandRecorder(abstractDelegate);
-      await recorder.changeTable("fruits", async (t) => {
-        await t.removeIndex(undefined, { name: "index_fruits_on_kind" });
-      });
-      expect(recorder.commands).toEqual([
-        { cmd: "removeIndex", args: ["fruits", undefined, { name: "index_fruits_on_kind" }] },
-      ]);
-    });
-
-    it("removeIndex with a column inverts back to addIndex", async () => {
-      const recorder = new CommandRecorder(abstractDelegate);
-      await recorder.revert(async () => {
-        await recorder.changeTable("fruits", async (t) => {
-          await t.removeIndex("kind");
-        });
-      });
-      expect(recorder.commands).toEqual([{ cmd: "addIndex", args: ["fruits", "kind"] }]);
-    });
-
-    it("raises IrreversibleMigration when removeIndex lacks a column", async () => {
-      const recorder = new CommandRecorder(abstractDelegate);
-      await expect(
-        recorder.revert(async () => {
-          await recorder.changeTable("fruits", async (t) => {
-            await t.removeIndex({ name: "index_fruits_on_kind" });
-          });
-        }),
-      ).rejects.toThrow(IrreversibleMigration);
-    });
-
-    it("raises IrreversibleMigration when remove lacks type", async () => {
-      const recorder = new CommandRecorder(abstractDelegate);
-      await expect(
-        recorder.revert(async () => {
-          await recorder.changeTable("fruits", async (t) => {
-            await t.remove("kind"); // no type → not reversible
-          });
-        }),
-      ).rejects.toThrow(IrreversibleMigration);
-    });
-  });
-
-  describe("change_table surfaces adapter ColumnMethods shorthands (serial/bigserial)", () => {
-    // Mirrors Rails: the PG `ColumnMethods` mixin exposes `t.serial` /
-    // `t.bigserial` (SERIAL/BIGSERIAL) inside change_table — shorthands the
-    // adapter advertises via _columnMethodNames() beyond NATIVE_DATABASE_TYPES.
-    const pgLike = pgDelegate;
-
-    it("records addColumn for t.serial and t.bigserial (up adds)", async () => {
-      const recorder = new CommandRecorder(pgLike);
-      await recorder.changeTable("fruits", async (t) => {
-        await (t as any).serial("seq");
-        await (t as any).bigserial("big_seq");
-      });
-      expect(recorder.commands).toEqual([
-        { cmd: "addColumn", args: ["fruits", "seq", "serial"] },
-        { cmd: "addColumn", args: ["fruits", "big_seq", "bigserial"] },
-      ]);
-    });
-
-    it("reverts t.serial / t.bigserial to removeColumn (down removes)", async () => {
-      const recorder = new CommandRecorder(pgLike);
-      await recorder.revert(async () => {
-        await recorder.changeTable("fruits", async (t) => {
-          await (t as any).serial("seq");
-          await (t as any).bigserial("big_seq");
-        });
-      });
-      expect(recorder.commands).toEqual([
-        { cmd: "removeColumn", args: ["fruits", "big_seq", "bigserial"] },
-        { cmd: "removeColumn", args: ["fruits", "seq", "serial"] },
-      ]);
-    });
-
-    it("never exposes primary_key as a generic column shorthand", async () => {
-      const recorder = new CommandRecorder(pgDelegate);
-      await recorder.changeTable("fruits", async (t) => {
-        expect((t as unknown as Record<string, unknown>)["primary_key"]).toBeUndefined();
-        await t.primaryKey("token", "uuid");
-      });
-      expect(recorder.commands).toEqual([
-        { cmd: "addColumn", args: ["fruits", "token", "uuid", { primaryKey: true }] },
-      ]);
-    });
-
-    it("records the snake_case type for PG bitVarying (multi-word shorthand)", async () => {
-      const recorder = new CommandRecorder(pgDelegate);
-      await recorder.changeTable("fruits", async (t) => {
-        await (t as any).bitVarying("mask");
-      });
-      expect(recorder.commands).toEqual([
-        { cmd: "addColumn", args: ["fruits", "mask", "bit_varying"] },
-      ]);
-    });
-  });
-
-  describe("change_table surfaces adapter ColumnMethods shorthands (MySQL unsigned/blob)", () => {
-    // Mirrors Rails: the MySQL `ColumnMethods` mixin exposes `t.unsignedInteger`,
-    // `t.mediumtext`, `t.longblob`, ... inside change_table — shorthands the
-    // adapter advertises via _columnMethodNames() beyond NATIVE_DATABASE_TYPES.
-    //
-    // The proxy normalizes the camelCase method name back to the snake symbol
-    // Rails' `define_column_methods` records (`unsignedInteger` ->
-    // `unsigned_integer`); single-token shorthands (mediumtext, longblob) are
-    // unchanged.
-    const mysqlLike = mysqlDelegate;
-
-    it("records addColumn for MySQL shorthands (up adds)", async () => {
-      const recorder = new CommandRecorder(mysqlLike);
-      await recorder.changeTable("fruits", async (t) => {
-        await (t as any).unsignedInteger("qty");
-        await (t as any).mediumtext("notes");
-        await (t as any).longblob("payload");
-      });
-      expect(recorder.commands).toEqual([
-        { cmd: "addColumn", args: ["fruits", "qty", "unsigned_integer"] },
-        { cmd: "addColumn", args: ["fruits", "notes", "mediumtext"] },
-        { cmd: "addColumn", args: ["fruits", "payload", "longblob"] },
-      ]);
-    });
-
-    it("reverts MySQL shorthands to removeColumn (down removes)", async () => {
-      const recorder = new CommandRecorder(mysqlLike);
-      await recorder.revert(async () => {
-        await recorder.changeTable("fruits", async (t) => {
-          await (t as any).unsignedInteger("qty");
-          await (t as any).mediumtext("notes");
-        });
-      });
-      expect(recorder.commands).toEqual([
-        { cmd: "removeColumn", args: ["fruits", "notes", "mediumtext"] },
-        { cmd: "removeColumn", args: ["fruits", "qty", "unsigned_integer"] },
-      ]);
-    });
-  });
-
-  describe("bulk invert change table", () => {
-    it("records two changeTable commands from revert + revert-of-revert", async () => {
-      const delegate = { ...abstractDelegate, supportsBulkAlter: () => true };
-      const recorder = new CommandRecorder(delegate);
-
-      const block = async (t: Table) => {
-        await t.string("name");
-        await t.rename("kind", "cultivar");
-      };
-
-      await recorder.revert(async () => {
-        await recorder.changeTable("fruits", { bulk: true }, block);
-      });
-
-      await recorder.revert(async () => {
-        await recorder.revert(async () => {
-          await recorder.changeTable("fruits", { bulk: true }, block);
-        });
-      });
-
-      expect(recorder.commands).toHaveLength(2);
-      expect(recorder.commands[0].cmd).toBe("changeTable");
-      expect(recorder.commands[0].args[0]).toBe("fruits");
-      expect(recorder.commands[1].cmd).toBe("changeTable");
-      expect(recorder.commands[1].args[0]).toBe("fruits");
-    });
-  });
-});
 
 describe("Migration", () => {
   describe("CommandRecorderTest", () => {
     let recorder: CommandRecorder & {
       createTable(...args: unknown[]): void;
       execute(sql: string): void;
+      transaction(fn: () => Promise<void>): void;
       nonExistingMethod(name: string): void;
     };
 
@@ -561,6 +127,28 @@ describe("Migration", () => {
           });
         }),
       ).rejects.toThrow(IrreversibleMigration);
+    });
+
+    itIfSupports("bulk_alter", "bulk invert change table", async () => {
+      const block = async (t: Table) => {
+        await t.string("name");
+        await t.rename("kind", "cultivar");
+      };
+
+      await recorder.revert(async () => {
+        await recorder.changeTable("fruits", { bulk: true }, block);
+      });
+
+      await recorder.revert(async () => {
+        await recorder.revert(async () => {
+          await recorder.changeTable("fruits", { bulk: true }, block);
+        });
+      });
+
+      expect(recorder.commands.map(({ cmd, args }) => ({ cmd, args: args.slice(0, -1) }))).toEqual([
+        { cmd: "changeTable", args: ["fruits"] },
+        { cmd: "changeTable", args: ["fruits"] },
+      ]);
     });
 
     it("invert create table", async () => {
@@ -728,6 +316,64 @@ describe("Migration", () => {
       });
     });
 
+    itIfSupports("comments", "invert change column comment", () => {
+      expect(() =>
+        recorder.inverseOf("changeColumnComment", ["table", "column", "comment"]),
+      ).toThrow(IrreversibleMigration);
+    });
+
+    itIfSupports("comments", "invert change column comment with from and to", () => {
+      const change = recorder.inverseOf("changeColumnComment", [
+        "table",
+        "column",
+        { from: "old_value", to: "new_value" },
+      ]);
+      expect(change).toEqual({
+        cmd: "changeColumnComment",
+        args: ["table", "column", { from: "new_value", to: "old_value" }],
+      });
+    });
+
+    itIfSupports("comments", "invert change column comment with from and to with nil", () => {
+      const change = recorder.inverseOf("changeColumnComment", [
+        "table",
+        "column",
+        { from: undefined, to: "new_value" },
+      ]);
+      expect(change).toEqual({
+        cmd: "changeColumnComment",
+        args: ["table", "column", { from: "new_value", to: undefined }],
+      });
+    });
+
+    itIfSupports("comments", "invert change table comment", () => {
+      expect(() =>
+        recorder.inverseOf("changeColumnComment", ["table", "column", "comment"]),
+      ).toThrow(IrreversibleMigration);
+    });
+
+    itIfSupports("comments", "invert change table comment with from and to", () => {
+      const change = recorder.inverseOf("changeTableComment", [
+        "table",
+        { from: "old_value", to: "new_value" },
+      ]);
+      expect(change).toEqual({
+        cmd: "changeTableComment",
+        args: ["table", { from: "new_value", to: "old_value" }],
+      });
+    });
+
+    itIfSupports("comments", "invert change table comment with from and to with nil", () => {
+      const change = recorder.inverseOf("changeTableComment", [
+        "table",
+        { from: undefined, to: "new_value" },
+      ]);
+      expect(change).toEqual({
+        cmd: "changeTableComment",
+        args: ["table", { from: "new_value", to: undefined }],
+      });
+    });
+
     it("invert change column null", () => {
       const add = recorder.inverseOf("changeColumnNull", ["table", "column", true]);
       expect(add).toEqual({ cmd: "changeColumnNull", args: ["table", "column", false] });
@@ -821,6 +467,381 @@ describe("Migration", () => {
     it("invert rename index", () => {
       const rename = recorder.inverseOf("renameIndex", ["table", "old", "new"]);
       expect(rename).toEqual({ cmd: "renameIndex", args: ["table", "new", "old"] });
+    });
+
+    it("invert add timestamps", () => {
+      const remove = recorder.inverseOf("addTimestamps", ["table"]);
+      expect(remove).toEqual({ cmd: "removeTimestamps", args: ["table"] });
+    });
+
+    it("invert remove timestamps", () => {
+      const add = recorder.inverseOf("removeTimestamps", ["table", { null: true }]);
+      expect(add).toEqual({ cmd: "addTimestamps", args: ["table", { null: true }] });
+    });
+
+    it("invert add reference", () => {
+      const remove = recorder.inverseOf("addReference", [
+        "table",
+        "taggable",
+        { polymorphic: true },
+      ]);
+      expect(remove).toEqual({
+        cmd: "removeReference",
+        args: ["table", "taggable", { polymorphic: true }],
+      });
+    });
+
+    it("invert add belongs to alias", () => {
+      const remove = recorder.inverseOf("addBelongsTo", ["table", "user"]);
+      expect(remove).toEqual({ cmd: "removeReference", args: ["table", "user"] });
+    });
+
+    it("invert remove reference", () => {
+      const add = recorder.inverseOf("removeReference", [
+        "table",
+        "taggable",
+        { polymorphic: true },
+      ]);
+      expect(add).toEqual({
+        cmd: "addReference",
+        args: ["table", "taggable", { polymorphic: true }],
+      });
+    });
+
+    it("invert remove reference with index and foreign key", () => {
+      const add = recorder.inverseOf("removeReference", [
+        "table",
+        "taggable",
+        { index: true, foreignKey: true },
+      ]);
+      expect(add).toEqual({
+        cmd: "addReference",
+        args: ["table", "taggable", { index: true, foreignKey: true }],
+      });
+    });
+
+    it("invert remove belongs to alias", () => {
+      const add = recorder.inverseOf("removeBelongsTo", ["table", "user"]);
+      expect(add).toEqual({ cmd: "addReference", args: ["table", "user"] });
+    });
+
+    it("invert enable extension", () => {
+      const disable = recorder.inverseOf("enableExtension", ["uuid-ossp"]);
+      expect(disable).toEqual({ cmd: "disableExtension", args: ["uuid-ossp"] });
+    });
+
+    it("invert disable extension", () => {
+      const enable = recorder.inverseOf("disableExtension", ["uuid-ossp"]);
+      expect(enable).toEqual({ cmd: "enableExtension", args: ["uuid-ossp"] });
+    });
+
+    it("invert create schema", () => {
+      const disable = recorder.inverseOf("createSchema", ["myschema"]);
+      expect(disable).toEqual({ cmd: "dropSchema", args: ["myschema"] });
+    });
+
+    it("invert drop schema", () => {
+      const enable = recorder.inverseOf("dropSchema", ["myschema"]);
+      expect(enable).toEqual({ cmd: "createSchema", args: ["myschema"] });
+    });
+
+    it("invert add foreign key", () => {
+      const enable = recorder.inverseOf("addForeignKey", ["dogs", "people"]);
+      expect(enable).toEqual({ cmd: "removeForeignKey", args: ["dogs", "people"] });
+    });
+
+    it("invert remove foreign key", () => {
+      const enable = recorder.inverseOf("removeForeignKey", ["dogs", "people"]);
+      expect(enable).toEqual({ cmd: "addForeignKey", args: ["dogs", "people"] });
+    });
+
+    it("invert add foreign key with column", () => {
+      const enable = recorder.inverseOf("addForeignKey", [
+        "dogs",
+        "people",
+        { column: "owner_id" },
+      ]);
+      expect(enable).toEqual({
+        cmd: "removeForeignKey",
+        args: ["dogs", "people", { column: "owner_id" }],
+      });
+    });
+
+    it("invert remove foreign key with column", () => {
+      const enable = recorder.inverseOf("removeForeignKey", [
+        "dogs",
+        "people",
+        { column: "owner_id" },
+      ]);
+      expect(enable).toEqual({
+        cmd: "addForeignKey",
+        args: ["dogs", "people", { column: "owner_id" }],
+      });
+    });
+
+    it("invert add foreign key with column and name", () => {
+      const enable = recorder.inverseOf("addForeignKey", [
+        "dogs",
+        "people",
+        { column: "owner_id", name: "fk" },
+      ]);
+      expect(enable).toEqual({
+        cmd: "removeForeignKey",
+        args: ["dogs", "people", { column: "owner_id", name: "fk" }],
+      });
+    });
+
+    it("invert remove foreign key with column and name", () => {
+      const enable = recorder.inverseOf("removeForeignKey", [
+        "dogs",
+        "people",
+        { column: "owner_id", name: "fk" },
+      ]);
+      expect(enable).toEqual({
+        cmd: "addForeignKey",
+        args: ["dogs", "people", { column: "owner_id", name: "fk" }],
+      });
+    });
+
+    it("invert remove foreign key with primary key", () => {
+      const enable = recorder.inverseOf("removeForeignKey", [
+        "dogs",
+        "people",
+        { primaryKey: "person_id" },
+      ]);
+      expect(enable).toEqual({
+        cmd: "addForeignKey",
+        args: ["dogs", "people", { primaryKey: "person_id" }],
+      });
+    });
+
+    it("invert remove foreign key with primary key and to table in options", () => {
+      const enable = recorder.inverseOf("removeForeignKey", [
+        "dogs",
+        { toTable: "people", primaryKey: "uuid" },
+      ]);
+      expect(enable).toEqual({
+        cmd: "addForeignKey",
+        args: ["dogs", "people", { primaryKey: "uuid" }],
+      });
+    });
+
+    it("invert remove foreign key with on delete on update", () => {
+      const enable = recorder.inverseOf("removeForeignKey", [
+        "dogs",
+        "people",
+        { onDelete: "nullify", onUpdate: "cascade" },
+      ]);
+      expect(enable).toEqual({
+        cmd: "addForeignKey",
+        args: ["dogs", "people", { onDelete: "nullify", onUpdate: "cascade" }],
+      });
+    });
+
+    it("invert remove foreign key with to table in options", () => {
+      let enable = recorder.inverseOf("removeForeignKey", ["dogs", { toTable: "people" }]);
+      expect(enable).toEqual({ cmd: "addForeignKey", args: ["dogs", "people"] });
+
+      enable = recorder.inverseOf("removeForeignKey", [
+        "dogs",
+        { toTable: "people", column: "owner_id" },
+      ]);
+      expect(enable).toEqual({
+        cmd: "addForeignKey",
+        args: ["dogs", "people", { column: "owner_id" }],
+      });
+    });
+
+    it("invert remove foreign key is irreversible without to table", () => {
+      expect(() =>
+        recorder.inverseOf("removeForeignKey", ["dogs", { column: "owner_id" }]),
+      ).toThrow(IrreversibleMigration);
+
+      expect(() => recorder.inverseOf("removeForeignKey", ["dogs", { name: "fk" }])).toThrow(
+        IrreversibleMigration,
+      );
+
+      expect(() => recorder.inverseOf("removeForeignKey", ["dogs"])).toThrow(IrreversibleMigration);
+    });
+
+    it("invert transaction with irreversible inside is irreversible", async () => {
+      await expect(
+        recorder.revert(async () => {
+          await recorder.transaction(async () => {
+            recorder.execute("some sql");
+          });
+        }),
+      ).rejects.toThrow(IrreversibleMigration);
+    });
+
+    it("invert add check constraint", () => {
+      const enable = recorder.inverseOf("addCheckConstraint", [
+        "dogs",
+        "speed > 0",
+        { name: "speed_check" },
+      ]);
+      expect(enable).toEqual({
+        cmd: "removeCheckConstraint",
+        args: ["dogs", "speed > 0", { name: "speed_check" }],
+      });
+    });
+
+    it("invert add check constraint if not exists", () => {
+      const enable = recorder.inverseOf("addCheckConstraint", [
+        "dogs",
+        "speed > 0",
+        { name: "speed_check", ifNotExists: true },
+      ]);
+      expect(enable).toEqual({
+        cmd: "removeCheckConstraint",
+        args: ["dogs", "speed > 0", { name: "speed_check", ifExists: true }],
+      });
+    });
+
+    it("invert remove check constraint", () => {
+      const enable = recorder.inverseOf("removeCheckConstraint", [
+        "dogs",
+        "speed > 0",
+        { name: "speed_check" },
+      ]);
+      expect(enable).toEqual({
+        cmd: "addCheckConstraint",
+        args: ["dogs", "speed > 0", { name: "speed_check" }],
+      });
+    });
+
+    it("invert remove check constraint without expression", () => {
+      expect(() => recorder.inverseOf("removeCheckConstraint", ["dogs"])).toThrow(
+        IrreversibleMigration,
+      );
+    });
+
+    it("invert remove check constraint if exists", () => {
+      const enable = recorder.inverseOf("removeCheckConstraint", [
+        "dogs",
+        "speed > 0",
+        { name: "speed_check", ifExists: true },
+      ]);
+      expect(enable).toEqual({
+        cmd: "addCheckConstraint",
+        args: ["dogs", "speed > 0", { name: "speed_check", ifNotExists: true }],
+      });
+    });
+
+    it("invert add unique constraint constraint with using index", () => {
+      expect(() =>
+        recorder.inverseOf("addUniqueConstraint", ["dogs", { usingIndex: "unique_index" }]),
+      ).toThrow(IrreversibleMigration);
+    });
+
+    it("invert remove unique constraint constraint", () => {
+      const enable = recorder.inverseOf("removeUniqueConstraint", [
+        "dogs",
+        ["speed"],
+        { deferrable: ":deferred", name: "uniq_speed" },
+      ]);
+      expect(enable).toEqual({
+        cmd: "addUniqueConstraint",
+        args: ["dogs", ["speed"], { deferrable: ":deferred", name: "uniq_speed" }],
+      });
+    });
+
+    it("invert remove unique constraint constraint without options", () => {
+      const enable = recorder.inverseOf("removeUniqueConstraint", ["dogs", ["speed"]]);
+      expect(enable).toEqual({ cmd: "addUniqueConstraint", args: ["dogs", ["speed"]] });
+    });
+
+    it("invert remove unique constraint constraint without columns", () => {
+      expect(() =>
+        recorder.inverseOf("removeUniqueConstraint", ["dogs", { name: "uniq_speed" }]),
+      ).toThrow(IrreversibleMigration);
+    });
+
+    it("invert create enum", () => {
+      const drop = recorder.inverseOf("createEnum", ["color", ["blue", "green"]]);
+      expect(drop).toEqual({ cmd: "dropEnum", args: ["color", ["blue", "green"]] });
+    });
+
+    it("invert drop enum", () => {
+      const create = recorder.inverseOf("dropEnum", ["color", ["blue", "green"]]);
+      expect(create).toEqual({ cmd: "createEnum", args: ["color", ["blue", "green"]] });
+    });
+
+    it("invert drop enum without values", () => {
+      expect(() => recorder.inverseOf("dropEnum", ["color"])).toThrow(IrreversibleMigration);
+
+      expect(() => recorder.inverseOf("dropEnum", ["color", { ifExists: true }])).toThrow(
+        IrreversibleMigration,
+      );
+    });
+
+    it("invert rename enum", () => {
+      const enumCmd = recorder.inverseOf("renameEnum", ["dog_breed", "breed"]);
+      expect(enumCmd).toEqual({ cmd: "renameEnum", args: ["breed", "dog_breed"] });
+    });
+
+    it("invert rename enum with to option", () => {
+      const enumCmd = recorder.inverseOf("renameEnum", ["dog_breed", { to: "breed" }]);
+      expect(enumCmd).toEqual({ cmd: "renameEnum", args: ["breed", "dog_breed"] });
+    });
+
+    it("invert add enum value", () => {
+      expect(() => recorder.inverseOf("addEnumValue", ["dog_breed", "beagle"])).toThrow(
+        IrreversibleMigration,
+      );
+    });
+
+    it("invert rename enum value", () => {
+      const enumValue = recorder.inverseOf("renameEnumValue", [
+        "dog_breed",
+        { from: "retriever", to: "beagle" },
+      ]);
+      expect(enumValue).toEqual({
+        cmd: "renameEnumValue",
+        args: ["dog_breed", { from: "beagle", to: "retriever" }],
+      });
+    });
+
+    it("invert rename enum value without from", () => {
+      expect(() =>
+        recorder.inverseOf("renameEnumValue", ["dog_breed", { to: "retriever" }]),
+      ).toThrow(IrreversibleMigration);
+    });
+
+    it("invert rename enum value without to", () => {
+      expect(() =>
+        recorder.inverseOf("renameEnumValue", ["dog_breed", { from: "beagle" }]),
+      ).toThrow(IrreversibleMigration);
+    });
+
+    it("invert create virtual table", () => {
+      const drop = recorder.inverseOf("createVirtualTable", [
+        "searchables",
+        "fts5",
+        ["content", "meta UNINDEXED", "tokenize='porter ascii'"],
+      ]);
+      expect(drop).toEqual({
+        cmd: "dropVirtualTable",
+        args: ["searchables", "fts5", ["content", "meta UNINDEXED", "tokenize='porter ascii'"]],
+      });
+    });
+
+    it("invert drop virtual table", () => {
+      const create = recorder.inverseOf("dropVirtualTable", [
+        "searchables",
+        "fts5",
+        ["title", "content"],
+      ]);
+      expect(create).toEqual({
+        cmd: "createVirtualTable",
+        args: ["searchables", "fts5", ["title", "content"]],
+      });
+    });
+
+    it("invert drop virtual table without options", () => {
+      expect(() => recorder.inverseOf("dropVirtualTable", ["searchables"])).toThrow(
+        IrreversibleMigration,
+      );
     });
   });
 });

--- a/packages/activerecord/src/migration/command-recorder.trails.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.trails.test.ts
@@ -5,6 +5,30 @@
 
 import { describe, expect, it } from "vitest";
 import { CommandRecorder } from "./command-recorder.js";
+import { IrreversibleMigration } from "../migration.js";
+import { Table } from "../connection-adapters/abstract/schema-definitions.js";
+import { Table as PgTable } from "../connection-adapters/postgresql/schema-definitions.js";
+import { Table as MysqlTable } from "../connection-adapters/mysql/schema-definitions.js";
+
+const abstractDelegate = {
+  updateTableDefinition: (tableName: string, base: unknown) => new Table(tableName, base as never),
+};
+const pgDelegate = {
+  updateTableDefinition: (tableName: string, base: unknown) =>
+    new PgTable(tableName, base as never),
+};
+const mysqlDelegate = {
+  updateTableDefinition: (tableName: string, base: unknown) =>
+    new MysqlTable(tableName, base as never),
+};
+
+/**
+ * Adapter `ColumnMethods` shorthands (`t.serial`, `t.unsignedInteger`, …) are
+ * installed by the change_table proxy at runtime, so they are not on `Table`'s
+ * static type.
+ */
+const columnMethods = (t: Table): Record<string, (name: string) => Promise<void>> =>
+  t as unknown as Record<string, (name: string) => Promise<void>>;
 
 describe("CommandRecorder", () => {
   it("invertCreateTable strips ifNotExists even when fn is last arg", () => {
@@ -22,5 +46,222 @@ describe("CommandRecorder", () => {
     const [cmd, args] = new CommandRecorder().invertRemoveIndex(["users", ["email", "name"]]);
     expect(cmd).toBe("addIndex");
     expect(args[1]).toEqual(["email", "name"]);
+  });
+
+  describe("invertAddExclusionConstraint / invertRemoveExclusionConstraint", () => {
+    it("invertAddExclusionConstraint returns removeExclusionConstraint", () => {
+      const [cmd] = new CommandRecorder().invertAddExclusionConstraint(["rooms", "during WITH &&"]);
+      expect(cmd).toBe("removeExclusionConstraint");
+    });
+
+    it("invertRemoveExclusionConstraint throws without expression", () => {
+      expect(() => new CommandRecorder().invertRemoveExclusionConstraint(["rooms"])).toThrow(
+        IrreversibleMigration,
+      );
+    });
+  });
+
+  describe("invertRemoveColumns", () => {
+    it("throws without type option", () => {
+      expect(() => new CommandRecorder().invertRemoveColumns(["users", "name", "age"])).toThrow(
+        IrreversibleMigration,
+      );
+    });
+
+    it("returns addColumns when type given", () => {
+      const [cmd] = new CommandRecorder().invertRemoveColumns([
+        "users",
+        "name",
+        { type: "string" },
+      ]);
+      expect(cmd).toBe("addColumns");
+    });
+  });
+
+  describe("invertAddColumns", () => {
+    it("returns removeColumns", () => {
+      const [cmd] = new CommandRecorder().invertAddColumns(["users", "name", "age"]);
+      expect(cmd).toBe("removeColumns");
+    });
+  });
+
+  describe("joinTableName / findJoinTableName", () => {
+    it("joinTableName returns sorted joined name", () => {
+      expect(new CommandRecorder().joinTableName("cats", "dogs")).toBe("cats_dogs");
+      expect(new CommandRecorder().joinTableName("dogs", "cats")).toBe("cats_dogs");
+    });
+
+    it("findJoinTableName uses tableName option when given", () => {
+      expect(new CommandRecorder().findJoinTableName("cats", "dogs", { tableName: "pets" })).toBe(
+        "pets",
+      );
+    });
+  });
+
+  describe("invert change table (non-bulk)", () => {
+    it("accepts (tableName, fn) without explicit options", async () => {
+      const recorder = new CommandRecorder(abstractDelegate);
+      // short form: no options argument
+      await recorder.changeTable("fruits", async (t) => {
+        await t.string("name");
+      });
+      expect(recorder.commands[0].cmd).toBe("addColumn");
+    });
+
+    it("remove with multiple columns records a single removeColumns", async () => {
+      const recorder = new CommandRecorder(abstractDelegate);
+      await recorder.changeTable("fruits", async (t) => {
+        await t.remove("name", "kind", { type: "string" });
+      });
+      expect(recorder.commands).toEqual([
+        { cmd: "removeColumns", args: ["fruits", "name", "kind", { type: "string" }] },
+      ]);
+    });
+
+    it("removeIndex with an options hash records a nil column, not the hash", async () => {
+      const recorder = new CommandRecorder(abstractDelegate);
+      await recorder.changeTable("fruits", async (t) => {
+        await t.removeIndex({ name: "index_fruits_on_kind" });
+      });
+      expect(recorder.commands).toEqual([
+        { cmd: "removeIndex", args: ["fruits", undefined, { name: "index_fruits_on_kind" }] },
+      ]);
+    });
+
+    it("removeIndex with an explicit nil column keeps the second-argument options", async () => {
+      const recorder = new CommandRecorder(abstractDelegate);
+      await recorder.changeTable("fruits", async (t) => {
+        await t.removeIndex(undefined, { name: "index_fruits_on_kind" });
+      });
+      expect(recorder.commands).toEqual([
+        { cmd: "removeIndex", args: ["fruits", undefined, { name: "index_fruits_on_kind" }] },
+      ]);
+    });
+
+    it("removeIndex with a column inverts back to addIndex", async () => {
+      const recorder = new CommandRecorder(abstractDelegate);
+      await recorder.revert(async () => {
+        await recorder.changeTable("fruits", async (t) => {
+          await t.removeIndex("kind");
+        });
+      });
+      expect(recorder.commands).toEqual([{ cmd: "addIndex", args: ["fruits", "kind"] }]);
+    });
+
+    it("raises IrreversibleMigration when removeIndex lacks a column", async () => {
+      const recorder = new CommandRecorder(abstractDelegate);
+      await expect(
+        recorder.revert(async () => {
+          await recorder.changeTable("fruits", async (t) => {
+            await t.removeIndex({ name: "index_fruits_on_kind" });
+          });
+        }),
+      ).rejects.toThrow(IrreversibleMigration);
+    });
+
+    it("raises IrreversibleMigration when remove lacks type", async () => {
+      const recorder = new CommandRecorder(abstractDelegate);
+      await expect(
+        recorder.revert(async () => {
+          await recorder.changeTable("fruits", async (t) => {
+            await t.remove("kind"); // no type → not reversible
+          });
+        }),
+      ).rejects.toThrow(IrreversibleMigration);
+    });
+  });
+
+  describe("change_table surfaces adapter ColumnMethods shorthands (serial/bigserial)", () => {
+    // Mirrors Rails: the PG `ColumnMethods` mixin exposes `t.serial` /
+    // `t.bigserial` (SERIAL/BIGSERIAL) inside change_table — shorthands the
+    // adapter advertises via _columnMethodNames() beyond NATIVE_DATABASE_TYPES.
+    const pgLike = pgDelegate;
+
+    it("records addColumn for t.serial and t.bigserial (up adds)", async () => {
+      const recorder = new CommandRecorder(pgLike);
+      await recorder.changeTable("fruits", async (t) => {
+        await columnMethods(t).serial("seq");
+        await columnMethods(t).bigserial("big_seq");
+      });
+      expect(recorder.commands).toEqual([
+        { cmd: "addColumn", args: ["fruits", "seq", "serial"] },
+        { cmd: "addColumn", args: ["fruits", "big_seq", "bigserial"] },
+      ]);
+    });
+
+    it("reverts t.serial / t.bigserial to removeColumn (down removes)", async () => {
+      const recorder = new CommandRecorder(pgLike);
+      await recorder.revert(async () => {
+        await recorder.changeTable("fruits", async (t) => {
+          await columnMethods(t).serial("seq");
+          await columnMethods(t).bigserial("big_seq");
+        });
+      });
+      expect(recorder.commands).toEqual([
+        { cmd: "removeColumn", args: ["fruits", "big_seq", "bigserial"] },
+        { cmd: "removeColumn", args: ["fruits", "seq", "serial"] },
+      ]);
+    });
+
+    it("never exposes primary_key as a generic column shorthand", async () => {
+      const recorder = new CommandRecorder(pgDelegate);
+      await recorder.changeTable("fruits", async (t) => {
+        expect((t as unknown as Record<string, unknown>)["primary_key"]).toBeUndefined();
+        await t.primaryKey("token", "uuid");
+      });
+      expect(recorder.commands).toEqual([
+        { cmd: "addColumn", args: ["fruits", "token", "uuid", { primaryKey: true }] },
+      ]);
+    });
+
+    it("records the snake_case type for PG bitVarying (multi-word shorthand)", async () => {
+      const recorder = new CommandRecorder(pgDelegate);
+      await recorder.changeTable("fruits", async (t) => {
+        await columnMethods(t).bitVarying("mask");
+      });
+      expect(recorder.commands).toEqual([
+        { cmd: "addColumn", args: ["fruits", "mask", "bit_varying"] },
+      ]);
+    });
+  });
+
+  describe("change_table surfaces adapter ColumnMethods shorthands (MySQL unsigned/blob)", () => {
+    // Mirrors Rails: the MySQL `ColumnMethods` mixin exposes `t.unsignedInteger`,
+    // `t.mediumtext`, `t.longblob`, ... inside change_table — shorthands the
+    // adapter advertises via _columnMethodNames() beyond NATIVE_DATABASE_TYPES.
+    //
+    // The proxy normalizes the camelCase method name back to the snake symbol
+    // Rails' `define_column_methods` records (`unsignedInteger` ->
+    // `unsigned_integer`); single-token shorthands (mediumtext, longblob) are
+    // unchanged.
+    const mysqlLike = mysqlDelegate;
+
+    it("records addColumn for MySQL shorthands (up adds)", async () => {
+      const recorder = new CommandRecorder(mysqlLike);
+      await recorder.changeTable("fruits", async (t) => {
+        await columnMethods(t).unsignedInteger("qty");
+        await columnMethods(t).mediumtext("notes");
+        await columnMethods(t).longblob("payload");
+      });
+      expect(recorder.commands).toEqual([
+        { cmd: "addColumn", args: ["fruits", "qty", "unsigned_integer"] },
+        { cmd: "addColumn", args: ["fruits", "notes", "mediumtext"] },
+        { cmd: "addColumn", args: ["fruits", "payload", "longblob"] },
+      ]);
+    });
+
+    it("reverts MySQL shorthands to removeColumn (down removes)", async () => {
+      const recorder = new CommandRecorder(mysqlLike);
+      await recorder.revert(async () => {
+        await recorder.changeTable("fruits", async (t) => {
+          await columnMethods(t).unsignedInteger("qty");
+          await columnMethods(t).mediumtext("notes");
+        });
+      });
+      expect(recorder.commands).toEqual([
+        { cmd: "removeColumn", args: ["fruits", "notes", "mediumtext"] },
+        { cmd: "removeColumn", args: ["fruits", "qty", "unsigned_integer"] },
+      ]);
+    });
   });
 });

--- a/packages/activerecord/src/migration/command-recorder.trails.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.trails.test.ts
@@ -22,11 +22,6 @@ const mysqlDelegate = {
     new MysqlTable(tableName, base as never),
 };
 
-/**
- * Adapter `ColumnMethods` shorthands (`t.serial`, `t.unsignedInteger`, …) are
- * installed by the change_table proxy at runtime, so they are not on `Table`'s
- * static type.
- */
 const columnMethods = (t: Table): Record<string, (name: string) => Promise<void>> =>
   t as unknown as Record<string, (name: string) => Promise<void>>;
 

--- a/packages/activerecord/src/migration/command-recorder.ts
+++ b/packages/activerecord/src/migration/command-recorder.ts
@@ -576,6 +576,21 @@ export class CommandRecorder {
   }
 
   /** @internal */
+  invertCreateSchema(args: unknown[]): [string, unknown[]] {
+    return ["dropSchema", args];
+  }
+
+  /** @internal */
+  invertDropSchema(args: unknown[]): [string, unknown[]] {
+    return ["createSchema", args];
+  }
+
+  /** @internal */
+  invertCreateVirtualTable(args: unknown[]): [string, unknown[]] {
+    return ["dropVirtualTable", args];
+  }
+
+  /** @internal */
   invertDropEnum(args: unknown[]): [string, unknown[]] {
     // Mirror Rails: extract_options! strips trailing hash, then check second positional arg
     const a = args.slice();

--- a/scripts/ci-suite-coverage.test.ts
+++ b/scripts/ci-suite-coverage.test.ts
@@ -206,6 +206,45 @@ function gateRegex(yml: string, name: string): RegExp {
  *  (tsc-wrapper + type-virtualization) and scripts/guides-typecheck;
  *  AR consumption is the reason trails-tsc is also in AR_PKGS_RE.
  *
+ *  AUDIT: virtualized-dx-type-tests / trailties-tests / leaf-tests
+ *  (RFC 0028, audit-virtualized-dx-and-leaf-gates-against-real-inputs)
+ *  All three gate on plain `activerecord_affected` and so run on every
+ *  AR PR. The audit asked whether their real source closure is narrower
+ *  than the gate. It is not, for any of them — the gates stay as they
+ *  are. What each suite actually reads:
+ *
+ *  - virtualized-dx-type-tests runs `pnpm test:types:virtualized`
+ *    (package.json:20), which is `tsc -b packages/activerecord-cli`
+ *    followed by the tsc-wrapper CLI over
+ *    packages/activerecord/virtualized-dx-tests/tsconfig.json. That
+ *    tsconfig maps @blazetrails/activerecord to
+ *    packages/activerecord/src/index.ts — the WHOLE public type surface,
+ *    not the type-virtualization or tsc-wrapper subtrees — plus
+ *    activemodel, arel, activesupport, i18n, date and globalid src. So
+ *    the tempting narrowing (the story's own hypothesis: trails-tsc plus
+ *    AR's type-virtualization/tsc-wrapper subtrees) would drop coverage
+ *    of every AR type change the suite exists to catch.
+ *    It has the opposite defect instead: @blazetrails/i18n is in the
+ *    tsconfig's paths but in neither AR_PKGS_RE nor TRAILS_TSC_PKGS_RE,
+ *    so an i18n-only PR type-checks against it without running it.
+ *    Filed as a separate story rather than fixed here — closing it
+ *    widens the gate, which is a burn decision, not an audit finding.
+ *
+ *  - trailties-tests runs `pnpm vitest run packages/trailties`.
+ *    @blazetrails/activerecord is a runtime dependency
+ *    (trailties/package.json) imported by src/database.ts,
+ *    src/migration-loader.ts, src/schema-source.ts, src/commands/db.ts
+ *    and the generators — all of which have their own .test.ts. The AR
+ *    clause in TRAILTIES_PKGS_RE is load-bearing.
+ *
+ *  - leaf-tests' job-level `if` is exactly the union of its five
+ *    per-step `if`s, and AR appears there only through the "DX type
+ *    tests" step (`pnpm test:types`, whose vitest.dx-tests.config.ts
+ *    declares activerecord and trailties projects). Narrowing the job
+ *    gate below that union would skip a step that should have run; the
+ *    per-step gates already keep the unaffected leaves from executing,
+ *    so the measured burn is install cost, not suite cost.
+ *
  *  TSE_COMPILER_PKGS_RE
  *  tse_compiler_affected gates the tse-compiler step of leaf-tests.
  *  The package has

--- a/scripts/db-init/postgres/01-rails-role.sql
+++ b/scripts/db-init/postgres/01-rails-role.sql
@@ -15,5 +15,12 @@
 -- postgres_fdw (adapters/postgresql/foreign-table.test.ts, which also CREATEs a
 -- SERVER) and pg_hint_plan (adapters/postgresql/optimizer-hints.test.ts). Only
 -- the trusted ones (hstore, citext) would work under a plain owner.
+--
+-- The ALTER DATABASE below is why the bare `activerecord_unittest` database
+-- must exist even though no stamped run ever connects to it (audited under RFC
+-- 0028, audit-bare-arunit-database-still-needed): this file is fed to
+-- `psql -d activerecord_unittest` both by the compose entrypoint and by hand in
+-- CI (.github/workflows/ci.yml:997), so dropping the database would break
+-- provisioning itself.
 CREATE ROLE rails LOGIN CREATEDB SUPERUSER;
 ALTER DATABASE activerecord_unittest OWNER TO rails;


### PR DESCRIPTION
Bundles three stories: the second half of Rails' `CommandRecorderTest`, and two
CI audits that conclude "leave it alone" with the reasoning recorded where the
thing being audited lives.

## `port-command-recorder-test-cases-part-2`

Ports `command_recorder_test.rb:354-601` (`test_invert_add_timestamps` through
`test_invert_drop_virtual_table_without_options`) into
`Migration > CommandRecorderTest`, plus the seven adapter-gated cases the first
half deliberately skipped:

- `test_bulk_invert_change_table` (`:117`, `supports_bulk_alter?`) →
  `itIfSupports("bulk_alter", …)`, replacing the bespoke
  `describe("bulk invert change table")`.
- the six `supports_comments?` cases (`:249-278`) → `itIfSupports("comments", …)`.

The shared delegate now answers `supportsBulkAlter()` from the running lane, so
it stands in for Rails' `CommandRecorder.new(lease_connection)` rather than
hard-coding `true`.

Three `StraightReversions` entries turned out never to have been written out —
`invert_create_schema` / `invert_drop_schema` / `invert_create_virtual_table`
(`command_recorder.rb:154-172`) — so their tests failed until the methods were
added. Generating the whole table the way Rails does is filed separately as
`0023-surfaced-deviations/command-recorder-generate-straight-reversions`.

One bespoke test is dropped outright rather than moved:
`invertRemoveUniqueConstraint handles array column names without mistaking
array for options`. It is redundant with the newly-ported
`test_invert_remove_unique_constraint_constraint_without_options`, which passes
the same `["dogs", ["speed"]]` shape through `inverseOf`. Verified rather than
asserted: deleting the `!Array.isArray` guard in
`invertRemoveUniqueConstraint` (`command-recorder.ts:436`) reds exactly that
Rails-named test and nothing else, so the branch the bespoke test covered still
has a failing-on-baseline cover.

Every other remaining bespoke `invert*` describe is either superseded by its
Rails counterpart (deleted) or has no Rails equivalent and moves to
`command-recorder.trails.test.ts`: the exclusion-constraint pair,
`invertRemoveColumns`, `invertAddColumns`, `joinTableName / findJoinTableName`,
the non-bulk `change_table` group and the two adapter `ColumnMethods` shorthand
groups. The `as any` casts in the moved blocks are replaced with a typed
accessor rather than widening `no-explicit-any-test-exclude.json`.

`test:compare` for `migration/command_recorder_test.rb`: **42 OK / 51 miss /
47 extra → 93 OK / 0 miss / 0 extra**.

## `audit-bare-arunit-database-still-needed`

**Verdict: keep it.** A stamped run never connects to bare
`activerecord_unittest` — PG's admin client targets `postgres`
(`template-global-setup.ts:179`), MySQL's carries no database (`:285-293`), and
workers resolve `activerecord_unittest_<runToken>_<slot>` via `applySlot`
(`config.ts:159-167`). But it is not vestigial: on PG the init script is fed
*to* it and ends in `ALTER DATABASE activerecord_unittest OWNER TO rails`
(CI does the same by hand, `ci.yml:997`); `PG_TEST_URL` / `MYSQL_TEST_URL` name
it for the activerecord-cli E2E; and the token-less `applySlot` fallback still
resolves to it. Recorded in `docker-compose.yml` and
`scripts/db-init/postgres/01-rails-role.sql`. No CI service-container change.

## `audit-virtualized-dx-and-leaf-gates-against-real-inputs`

**Verdict: no gate narrows.** Written up in `scripts/ci-suite-coverage.test.ts`,
the documented home for gate rationale. In short:

- `virtualized-dx-type-tests` type-checks `virtualized-dx-tests/` with
  `@blazetrails/activerecord` mapped to `activerecord/src/index.ts` — the whole
  public type surface, not the `type-virtualization` / `tsc-wrapper` subtrees the
  story hypothesised. The proposed narrowing would drop exactly the coverage the
  suite exists for. It has the *opposite* defect: `@blazetrails/i18n` is in the
  tsconfig's paths but in no gate, so an i18n-only PR never runs it — filed as
  `0028-ci-cost-optimization/gate-virtualized-dx-on-i18n`, since fixing it widens
  a gate and that is a burn decision, not an audit finding.
- `trailties-tests` — AR is a runtime dep imported by `database.ts`,
  `migration-loader.ts`, `schema-source.ts`, `commands/db.ts` and the
  generators, all with their own tests. The AR clause is load-bearing.
- `leaf-tests` — the job-level `if` is already exactly the union of its five
  per-step `if`s; the per-step gates keep unaffected leaves from running, so the
  measured burn is install cost, not suite cost.

Nothing narrowed, so no new `ci-suite-coverage.test.ts` pins are added.

## Size

**Over the ceiling, and the earlier figure in this description was wrong.**
My task prompt's "Hard rules" block sets 700 LOC. The real diff is **1,223**
by the governing formula (additions + deletions, excluding lockfiles,
snapshots and `.md`): 783 insertions + 440 deletions. The "782" first quoted
here was a misread of `--shortstat`'s insertion count as the total. Correcting
that rather than defending it.

    docker-compose.yml                                   +20
    packages/activerecord/src/migration/command-recorder.ts    +15
    scripts/ci-suite-coverage.test.ts                    +39
    scripts/db-init/postgres/01-rails-role.sql            +7
    packages/activerecord/src/migration/command-recorder.test.ts   +461 -440
    packages/activerecord/src/migration/command-recorder.trails.test.ts  +241

Roughly 470 of that is the file-to-file move of pre-existing TS-only tests
(+241 in `.trails.test.ts` against the matching deletions), which the story's
acceptance criteria mandate and which is what drives `test:compare` extras to
0. The rest is the 45 newly-ported Rails cases and the deletion of the bespoke
describes they supersede.

I do not think the story as specified can be delivered under 700: the port and
the de-duplication it forces are one unit, and splitting them leaves
`test:compare` reporting extras for whichever half ships first. Splitting into
sibling PRs is also explicitly disallowed by the same rules. Flagging it for a
call rather than quietly dropping acceptance criteria to fit the number.

Closes-story: port-command-recorder-test-cases-part-2
Closes-story: audit-bare-arunit-database-still-needed
Closes-story: audit-virtualized-dx-and-leaf-gates-against-real-inputs

