### PR TITLE
fix(sync-stats): pass --allow-escape-sequences when fetching job logs

### DIFF
--- a/scripts/sync-stats/job-log-fetch.test.ts
+++ b/scripts/sync-stats/job-log-fetch.test.ts
@@ -3,8 +3,7 @@ import { fileURLToPath } from "node:url";
 import { beforeAll, describe, expect, it } from "vitest";
 
 // sync.ts runs main() on import, so these guards read the source rather than
-// importing it. Both regressions they cover were silent: the feed kept exiting
-// 0 while ingesting nothing for four days.
+// importing it.
 const dir = fileURLToPath(new URL(".", import.meta.url));
 let source: string;
 
@@ -25,8 +24,6 @@ describe("sync-stats job log fetch", () => {
   });
 
   it("does not swallow the fetch failure as a rate-limit stop", () => {
-    // main() only downgrades RateLimitExhaustedError to a warning; anything
-    // else propagates to the top-level catch and exits non-zero.
     expect(source).toMatch(
       /if \(err instanceof RateLimitExhaustedError\) \{.*?\} else \{\s*throw err;/s,
     );

--- a/scripts/sync-stats/job-log-fetch.test.ts
+++ b/scripts/sync-stats/job-log-fetch.test.ts
@@ -1,0 +1,34 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { beforeAll, describe, expect, it } from "vitest";
+
+// sync.ts runs main() on import, so these guards read the source rather than
+// importing it. Both regressions they cover were silent: the feed kept exiting
+// 0 while ingesting nothing for four days.
+const dir = fileURLToPath(new URL(".", import.meta.url));
+let source: string;
+
+beforeAll(async () => {
+  source = await readFile(`${dir}sync.ts`, "utf8");
+});
+
+describe("sync-stats job log fetch", () => {
+  it("passes --allow-escape-sequences when fetching job logs", () => {
+    expect(source).toMatch(
+      /gh\(\s*`api --allow-escape-sequences repos\/\$\{REPO\}\/actions\/jobs\/\$\{jobId\}\/logs`\s*\)/,
+    );
+  });
+
+  it("fails the run when jobs were selected but no logs were fetched", () => {
+    expect(source).toMatch(/if \(fetched === 0\) \{\s*throw new JobLogFetchFailedError\(/);
+    expect(source).toMatch(/class JobLogFetchFailedError extends Error/);
+  });
+
+  it("does not swallow the fetch failure as a rate-limit stop", () => {
+    // main() only downgrades RateLimitExhaustedError to a warning; anything
+    // else propagates to the top-level catch and exits non-zero.
+    expect(source).toMatch(
+      /if \(err instanceof RateLimitExhaustedError\) \{.*?\} else \{\s*throw err;/s,
+    );
+  });
+});

--- a/scripts/sync-stats/sync.ts
+++ b/scripts/sync-stats/sync.ts
@@ -38,6 +38,15 @@ class RateLimitExhaustedError extends Error {
   }
 }
 
+class JobLogFetchFailedError extends Error {
+  constructor(selected: number) {
+    super(
+      `Job log fetch failed: selected ${selected} jobs and fetched 0. ` +
+        `The compare-stats feed is stalled; see the per-job warnings above.`,
+    );
+  }
+}
+
 function waitForCooldownAndInterval() {
   const cooldownRemaining = rateLimitCooldownUntil - Date.now();
   if (cooldownRemaining > 0) {
@@ -1886,7 +1895,9 @@ async function syncJobLogs(mode: "latest" | "refresh" | "backfill"): Promise<num
     const prNumber = job.pr_number as number;
 
     try {
-      const logs = gh(`api repos/${REPO}/actions/jobs/${jobId}/logs`);
+      // gh 2.97 refuses to print a response containing terminal escape
+      // sequences without this flag, and every CI job log is full of them.
+      const logs = gh(`api --allow-escape-sequences repos/${REPO}/actions/jobs/${jobId}/logs`);
       await RawJobLog.upsertAll(
         [
           {
@@ -1913,6 +1924,12 @@ async function syncJobLogs(mode: "latest" | "refresh" | "backfill"): Promise<num
   }
 
   console.log(`  Fetched ${fetched} job logs`);
+  // A run that selects jobs and fetches none is a broken feed, not a quiet
+  // no-op: gh 2.97's escape-sequence guard silently stalled this sync for
+  // days because every fetch failed while the run still exited 0.
+  if (fetched === 0) {
+    throw new JobLogFetchFailedError(jobsToFetch.length);
+  }
   return fetched;
 }
 

--- a/scripts/sync-stats/sync.ts
+++ b/scripts/sync-stats/sync.ts
@@ -1895,8 +1895,6 @@ async function syncJobLogs(mode: "latest" | "refresh" | "backfill"): Promise<num
     const prNumber = job.pr_number as number;
 
     try {
-      // gh 2.97 refuses to print a response containing terminal escape
-      // sequences without this flag, and every CI job log is full of them.
       const logs = gh(`api --allow-escape-sequences repos/${REPO}/actions/jobs/${jobId}/logs`);
       await RawJobLog.upsertAll(
         [
@@ -1924,9 +1922,6 @@ async function syncJobLogs(mode: "latest" | "refresh" | "backfill"): Promise<num
   }
 
   console.log(`  Fetched ${fetched} job logs`);
-  // A run that selects jobs and fetches none is a broken feed, not a quiet
-  // no-op: gh 2.97's escape-sequence guard silently stalled this sync for
-  // days because every fetch failed while the run still exited 0.
   if (fetched === 0) {
     throw new JobLogFetchFailedError(jobsToFetch.length);
   }


### PR DESCRIPTION
`gh` 2.97.0 refuses to print a response containing terminal escape sequences
unless `--allow-escape-sequences` is passed. CI job logs are full of them, so
every fetch in `syncJobLogs` has failed since 2026-07-31 — `raw_job_logs` (and
therefore `api_compare_stats`, `api_compare_privates_stats`,
`test_compare_stats`) stopped at PR #5945, while the nightly cron kept
reporting `ok`.

- `scripts/sync-stats/sync.ts:1889` now passes `--allow-escape-sequences`.
- `syncJobLogs` throws `JobLogFetchFailedError` when it selects N > 0 jobs and
  fetches 0. `main()` only downgrades `RateLimitExhaustedError` to a warning, so
  this propagates and exits non-zero — the cron wrapper records a failure and
  ringo's `/crons` page flags it. This is the guard that would have caught both
  this stall and `sync-stats-test-compare-regex-stale`.
- `job-log-fetch.test.ts` guards the flag, the zero-fetch throw, and the fact
  that the throw isn't swallowed by the rate-limit arm.

The backlog (#5945 → HEAD) is being backfilled with `pnpm stats:sync --missing`
against the live DB, which brings `i18n` and `date` into the stats tables for
the first time. `vendor/sources.ts` is untouched.

Closes-story: sync-stats-job-log-fetch-escape-sequences
