### PR TITLE
fix(i18n,date): to_sym in store_link/resolve_link; sec_fraction is always a Rational; Rational is bigint-backed

### DIFF
--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -112,7 +112,7 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
       timeHash.min,
       timeHash.sec,
       timeHash.secFraction,
-      offset instanceof Rational ? offset.numerator / offset.denominator : offset,
+      offset instanceof Rational ? offset.toF() : offset,
     );
   }
 

--- a/packages/activemodel/src/type/time.ts
+++ b/packages/activemodel/src/type/time.ts
@@ -162,10 +162,8 @@ export class TimeType extends ValueType<Temporal.Instant> {
       timeHash.hour,
       timeHash.min,
       timeHash.sec,
-      secFraction instanceof Rational
-        ? secFraction.numerator / secFraction.denominator
-        : secFraction,
-      offset instanceof Rational ? offset.numerator / offset.denominator : offset,
+      secFraction instanceof Rational ? secFraction.toF() : secFraction,
+      offset instanceof Rational ? offset.toF() : offset,
     );
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/sql-datetime.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/sql-datetime.ts
@@ -63,7 +63,7 @@ function strftimeSubject(v: {
     hour: v.hour,
     min: v.minute,
     sec: v.second,
-    nsec: v.millisecond * 1_000_000 + v.microsecond * 1_000 + v.nanosecond,
+    nsec: new Rational(v.millisecond * 1_000_000 + v.microsecond * 1_000 + v.nanosecond, 1),
     zone: "",
     utcOffset: 0,
   };
@@ -75,7 +75,7 @@ function strftimeSubject(v: {
  * value.usec)` when `usec > 0`.
  */
 function toFsDbWithUsec(subject: StrftimeSubject): string {
-  const nsec = subject.nsec instanceof Rational ? subject.nsec.div(1) : subject.nsec;
+  const nsec = subject.nsec.div(1);
   return strftime(subject, TIME_DB_FORMAT) + microsecondFraction(Math.floor(nsec / 1_000));
 }
 

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -11,7 +11,7 @@ import { currentTime } from "./time-travel.js";
 import { getZone } from "./time-zone-config.js";
 import { Temporal } from "@blazetrails/date";
 import { instantFrom } from "./temporal.js";
-import { strftime } from "@blazetrails/date";
+import { Rational, strftime } from "@blazetrails/date";
 import { Encoding } from "./json/encoding.js";
 
 /**
@@ -397,7 +397,7 @@ export class TimeWithZone {
         hour: l.hour,
         min: l.minute,
         sec: l.second,
-        nsec: this.nsec,
+        nsec: new Rational(this.nsec, 1),
         zone: "",
         utcOffset: this.utcOffset,
       },

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -340,6 +340,27 @@ describe("Date", () => {
     expect(String(hash.secFraction)).toBe("4/5");
   });
 
+  it("answers a Rational sec_fraction for every argument, as ns_to_sec does", () => {
+    // ruby 3.3.11 — `sec_fraction -> rational` (date_core.c:5623), which
+    // `ns_to_sec`'s `rb_rational_new2` (:993-998) answers whatever it is handed:
+    //   DateTime.new(2008, 3, 1, 6, 0, Rational(2)).sec_fraction #=> (0/1)
+    //   DateTime.new(2001, 2, 3, 4, 5, 6.5).sec_fraction         #=> (1/2)
+    expect(new RubyDateTime(2008, 3, 1, 6, 0, new Rational(2, 1)).secFraction).toEqual(
+      new Rational(0, 1),
+    );
+    expect(new RubyDateTime(2001, 2, 3, 4, 5, 6.5).secFraction).toEqual(new Rational(1, 2));
+  });
+
+  it("keeps a fraction literal past Number.MAX_SAFE_INTEGER exact, as an Integer numerator does", () => {
+    // ruby 3.3.11:
+    //   DateTime.parse("2008-03-01T06:00:00." + "1" * 20).sec_fraction
+    //   #=> (11111111111111111111/100000000000000000000)
+    const parsed = RubyDateTime.parse(`2008-03-01T06:00:00.${"1".repeat(20)}`);
+    expect(parsed.secFraction).toEqual(new Rational(11111111111111111111n, 100000000000000000000n));
+    // The same denominator drives %N's long division, which stays exact too.
+    expect(parsed.strftime("%20N")).toBe("11111111111111111111");
+  });
+
   it("answers the frag hash date__strptime fills, as Date._strptime does", () => {
     expect(RubyDate._strptime("2001-02-03", "%Y-%m-%d")).toEqual({ year: 2001, mon: 2, mday: 3 });
     expect(RubyDate._strptime("2001-W05-6", "%G-W%V-%u")).toEqual({
@@ -714,7 +735,7 @@ describe("DateTime", () => {
     //   DateTime.new(2008, 3, 1, 23, 59, 59).to_s       #=> "2008-03-01T23:59:59+00:00"
     expect(new RubyDateTime(2008, 3, 1, 24).toS()).toBe("2008-03-02T00:00:00+00:00");
     expect(new RubyDateTime(2008, 3, 1, 24, 0, 0.5).toS()).toBe("2008-03-02T00:00:00+00:00");
-    expect(new RubyDateTime(2008, 3, 1, 24, 0, 0.5).secFraction).toBe(0.5);
+    expect(new RubyDateTime(2008, 3, 1, 24, 0, 0.5).secFraction).toEqual(new Rational(1, 2));
     expect(new RubyDateTime(2008, 3, 1, 24.5).toS()).toBe("2008-03-02T00:30:00+00:00");
     expect(new RubyDateTime(2008, 3, 1, 24, 0, 0, "+09:00").toS()).toBe(
       "2008-03-02T00:00:00+09:00",
@@ -848,7 +869,7 @@ describe("DateTime", () => {
     const datetime = new RubyDateTime(2008, 3, 1, 6, 0, 0.5);
     expect(datetime.strftime("%N")).toBe("500000000");
     expect(datetime.strftime("%L")).toBe("500");
-    expect(datetime.secFraction).toBe(0.5);
+    expect(datetime.secFraction).toEqual(new Rational(1, 2));
     expect(datetime.sec).toBe(0);
     // ruby 3.3.11: DateTime.new(2008, 3, 1, 6, 0, 1.5).sec #=> 1
     expect(new RubyDateTime(2008, 3, 1, 6, 0, 1.5).sec).toBe(1);
@@ -887,7 +908,7 @@ describe("DateTime", () => {
     //   DateTime.new(2008, 3, 1, 6, 0, 0).sec_fraction   #=> (0/1)
     //   Date.new(2008, 3, 1).strftime("%N")              #=> "000000000"
     expect(new RubyDateTime(2008, 3, 1, 6, 0, 0).strftime("%N")).toBe("000000000");
-    expect(new RubyDateTime(2008, 3, 1, 6, 0, 0).secFraction).toBe(0);
+    expect(new RubyDateTime(2008, 3, 1, 6, 0, 0).secFraction).toEqual(new Rational(0, 1));
     expect(new RubyDate(2008, 3, 1).strftime("%N")).toBe("000000000");
   });
 
@@ -904,7 +925,7 @@ describe("DateTime", () => {
     // The second's bound is `positive_inf`, so a later argument never makes its
     // fraction illegal:
     //   DateTime.new(2008, 3, 1, 6, 0, 0.5, 3600).sec_fraction #=> (1/2)
-    expect(new RubyDateTime(2008, 3, 1, 6, 0, 0.5, 3600).secFraction).toBe(0.5);
+    expect(new RubyDateTime(2008, 3, 1, 6, 0, 0.5, 3600).secFraction).toEqual(new Rational(1, 2));
   });
 
   it("carries the fraction of a legal non-final argument through add_frac", () => {
@@ -917,7 +938,7 @@ describe("DateTime", () => {
     //   DateTime.new(2008, 3, 1.5).to_s         #=> "2008-03-01T12:00:00+00:00"
     const halfMinute = new RubyDateTime(2008, 3, 1, 6, 0.5);
     expect(halfMinute.strftime("%H:%M:%S")).toBe("06:00:30");
-    expect(halfMinute.secFraction).toBe(0);
+    expect(halfMinute.secFraction).toEqual(new Rational(0, 1));
     expect(new RubyDateTime(2008, 3, 1, 6, 0.25).strftime("%H:%M:%S")).toBe("06:00:15");
     expect(new RubyDateTime(2008, 3, 1, 6.5).strftime("%H:%M:%S")).toBe("06:30:00");
     expect(new RubyDateTime(2008, 3, 1, 23.75).strftime("%H:%M:%S")).toBe("23:45:00");

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -743,15 +743,6 @@ function iGcd(x: bigint, y: bigint): bigint {
 }
 
 /**
- * @internal Ruby's `Integer#div` — the floored quotient, which a `bigint` `/`
- * does not give (it truncates toward zero, as C does).
- */
-function bigFloorDiv(a: bigint, b: bigint): bigint {
-  const q = a / b;
-  return a % b !== 0n && a < 0n !== b < 0n ? q - 1n : q;
-}
-
-/**
  * Ruby's `Rational` (`rational.c`), as much of it as `date_zone_to_diff`'s
  * fractional-hour offset needs: `rb_rational_new` canonicalizes to lowest terms
  * (`rational.c` `nurat_s_canonicalize_internal`), `+` adds an Integer
@@ -818,7 +809,9 @@ export class Rational {
    * floored quotient — the method `date_core.c`'s `f_idiv` macro sends
    * (`date_core.c:43`) — for the Integer divisor this port needs. */
   div(other: number | bigint): number {
-    return Number(bigFloorDiv(this.numerator, this.denominator * BigInt(other)));
+    const den = this.denominator * BigInt(other);
+    const q = this.numerator / den;
+    return Number(this.numerator % den !== 0n && this.numerator < 0n !== den < 0n ? q - 1n : q);
   }
 
   /** `numeric.c` `num_modulo` (`Rational#%`, inherited from Numeric), which is
@@ -3199,9 +3192,8 @@ export function dtNewByFrags(hash: DateParts): DateTime {
 
   const t: number | Rational | null | undefined = hash.secFraction;
   const ns = t == null ? 0 : secToNs(t);
-  // `m_sf`'s only reader is `ns_to_sec`, whose FIXNUM arm is
-  // `rb_rational_new2(n, INT2FIX(SECOND_IN_NANOSECONDS))` (`date_core.c:993-998`),
-  // so an Integer `sf` is stored as the Rational it is always read back as.
+  // `ns_to_sec`, `m_sf`'s only reader, answers `rb_rational_new2` for an
+  // Integer `sf` (`date_core.c:993-998`), so the store carries the Rational.
   const sf = ns instanceof Rational ? ns : new Rational(ns, 1);
 
   const to = hash.offset;

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -77,7 +77,7 @@ export interface StrftimeSubject {
   hour: number;
   min: number;
   sec: number;
-  nsec: number | Rational;
+  nsec: Rational;
   zone: string;
   utcOffset: number;
 }
@@ -233,13 +233,13 @@ function fillPadding(padding: string, left: boolean, precision: number, i: numbe
  * denominator emits the same digits under numbers that stay exact — the C's
  * scale-and-floor through a double would also drop `299999999` to `299999998`.
  */
-function subsecDigits(nsec: number | Rational, precision: number): string {
-  const den = (nsec instanceof Rational ? nsec.denominator : 1) * SECOND_IN_NANOSECONDS;
-  let n = (nsec instanceof Rational ? nsec.numerator : nsec) % den;
+function subsecDigits(nsec: Rational, precision: number): string {
+  const den = nsec.denominator * BigInt(SECOND_IN_NANOSECONDS);
+  let n = nsec.numerator % den;
   let digits = "";
   for (let i = 0; i < precision; i++) {
-    n *= 10;
-    digits += Math.floor(n / den);
+    n *= 10n;
+    digits += n / den;
     n %= den;
   }
   return digits;
@@ -731,15 +731,24 @@ function shrinkSpace(s: string, l: number): string {
 }
 
 /** @internal `rational.c` `i_gcd`, the greatest common divisor a Rational reduces by. */
-function iGcd(x: number, y: number): number {
-  if (x < 0) x = -x;
-  if (y < 0) y = -y;
-  while (y !== 0) {
+function iGcd(x: bigint, y: bigint): bigint {
+  if (x < 0n) x = -x;
+  if (y < 0n) y = -y;
+  while (y !== 0n) {
     const t = x % y;
     x = y;
     y = t;
   }
   return x;
+}
+
+/**
+ * @internal Ruby's `Integer#div` — the floored quotient, which a `bigint` `/`
+ * does not give (it truncates toward zero, as C does).
+ */
+function bigFloorDiv(a: bigint, b: bigint): bigint {
+  const q = a / b;
+  return a % b !== 0n && a < 0n !== b < 0n ? q - 1n : q;
 }
 
 /**
@@ -756,69 +765,88 @@ function iGcd(x: number, y: number): number {
  */
 export class Rational {
   /** `rational.c` `nurat_numerator` (`Rational#numerator`).
+   *
+   * Ruby's is an Integer — arbitrary precision — so a `bigint` is the JS
+   * analogue, not a `number`: a `number` is exact only inside
+   * `Number.MAX_SAFE_INTEGER` and a parsed fraction literal of more than
+   * sixteen digits (`date_parse.c:2319-2325`) runs straight past it.
+   *
    * @noRailsEquivalent PERMANENT — Ruby core, part of the Rational above. */
-  readonly numerator: number;
+  readonly numerator: bigint;
 
   /** `rational.c` `nurat_denominator` (`Rational#denominator`).
    * @noRailsEquivalent PERMANENT — Ruby core, part of the Rational above. */
-  readonly denominator: number;
+  readonly denominator: bigint;
 
-  constructor(num: number, den: number) {
-    const g = iGcd(num, den);
-    this.numerator = num / g;
-    this.denominator = den / g;
+  constructor(num: number | bigint, den: number | bigint) {
+    const n = BigInt(num);
+    const d = BigInt(den);
+    const g = iGcd(n, d);
+    this.numerator = n / g;
+    this.denominator = d / g;
   }
 
   /** `rational.c` `nurat_add` (`Rational#+`), for the Integer addend this port needs. */
-  add(other: number): Rational {
-    return new Rational(this.numerator + other * this.denominator, this.denominator);
+  add(other: number | bigint): Rational {
+    return new Rational(this.numerator + BigInt(other) * this.denominator, this.denominator);
   }
 
   /** `rational.c` `nurat_mul` (`Rational#*`), for the Integer multiplier this
    * port needs. `f_muldiv` cancels the multiplier against the denominator
-   * BEFORE it multiplies (`rational.c` `f_muldiv`), which is not a mere
-   * optimisation here: `(9999999999/10000000000) * 1000000000` overflows
-   * `Number.MAX_SAFE_INTEGER` if the product is formed first. */
-  mul(other: number): Rational {
-    const g = iGcd(other, this.denominator);
-    return new Rational(this.numerator * (other / g), this.denominator / g);
+   * BEFORE it multiplies (`rational.c` `f_muldiv`). */
+  mul(other: number | bigint): Rational {
+    const o = BigInt(other);
+    const g = iGcd(o, this.denominator);
+    return new Rational(this.numerator * (o / g), this.denominator / g);
   }
 
   /** `rational.c` `nurat_div` (`Rational#/`), for the Integer divisor this port
    * needs, cancelled the same way {@link mul} is. */
-  quo(other: number): Rational {
-    const g = iGcd(this.numerator, other);
-    return new Rational(this.numerator / g, this.denominator * (other / g));
+  quo(other: number | bigint): Rational {
+    const o = BigInt(other);
+    const g = iGcd(this.numerator, o);
+    return new Rational(this.numerator / g, this.denominator * (o / g));
   }
 
   /** `numeric.c` `num_zero_p` (`Rational#zero?`, inherited from Numeric), what
    * `date_core.c`'s `f_zero_p` dispatches to for a Rational. */
   isZero(): boolean {
-    return this.numerator === 0;
+    return this.numerator === 0n;
   }
 
   /** `numeric.c` `num_div` (`Rational#div`, inherited from Numeric), the
    * floored quotient — the method `date_core.c`'s `f_idiv` macro sends
    * (`date_core.c:43`) — for the Integer divisor this port needs. */
-  div(other: number): number {
-    return Math.floor(this.numerator / (this.denominator * other));
+  div(other: number | bigint): number {
+    return Number(bigFloorDiv(this.numerator, this.denominator * BigInt(other)));
   }
 
   /** `numeric.c` `num_modulo` (`Rational#%`, inherited from Numeric), which is
    * `self - other * (self.div other)` there too — what `date_core.c`'s `f_mod`
    * dispatches to for a Rational — for the Integer divisor this port needs. */
-  mod(other: number): Rational {
-    return this.add(-other * this.div(other));
+  mod(other: number | bigint): Rational {
+    return this.add(-BigInt(other) * BigInt(this.div(other)));
   }
 
   /** `rational.c` `nurat_to_i` (`Rational#to_i`), which truncates toward zero. */
   toI(): number {
-    return Math.trunc(this.numerator / this.denominator);
+    return Number(this.numerator / this.denominator);
   }
 
   /** `rational.c` `nurat_round` (`Rational#round`), which rounds half away from zero. */
   round(): number {
-    return round(this.numerator / this.denominator);
+    const q = this.numerator / this.denominator;
+    const r = this.numerator % this.denominator;
+    const half =
+      (r < 0n ? -r : r) * 2n >= (this.denominator < 0n ? -this.denominator : this.denominator);
+    return Number(half ? q + (r < 0n !== this.denominator < 0n ? -1n : 1n) : q);
+  }
+
+  /** @internal The `Float` a Rational becomes at a `number` seam — `rational.c`
+   * `nurat_to_f`, which is what every reader that hands the value to a
+   * floating-point API needs. */
+  toF(): number {
+    return Number(this.numerator) / Number(this.denominator);
   }
 
   /** `rational.c` `nurat_to_s` (`Rational#to_s`). */
@@ -945,7 +973,7 @@ function dateZoneToDiff(str: string): number | Rational | null {
           } else {
             const denom = 10 ** (n - 2);
             const rat = new Rational(sec, denom).add(hour * 3600);
-            offset = rat.denominator === 1 ? rat.numerator : rat;
+            offset = rat.denominator === 1n ? Number(rat.numerator) : rat;
           }
           return offset;
         } else if (l > 2) {
@@ -1183,7 +1211,7 @@ function parseTime2Cb(m: RegExpExecArray, hash: DateParts): number {
   hash.hour = h;
   if (min !== null) hash.min = min;
   if (s !== null) hash.sec = s;
-  if (f !== undefined) hash.secFraction = new Rational(Number(f), 10 ** f.length);
+  if (f !== undefined) hash.secFraction = new Rational(BigInt(f), 10n ** BigInt(f.length));
 
   return 1;
 }
@@ -1818,7 +1846,7 @@ function parseDddCb(m: RegExpExecArray, hash: DateParts): number {
   if (s4 !== undefined) {
     const l4 = s4.length;
 
-    hash.secFraction = new Rational(Number(s4), 10 ** l4);
+    hash.secFraction = new Rational(BigInt(s4), 10n ** BigInt(l4));
   }
   if (s5 !== undefined) {
     const cs5 = s5;
@@ -2232,7 +2260,7 @@ function dateStrptimeInternal(str: string, fmt: string, hash: DateParts): number
             : readDigitsMax();
           if (n === null) return fail();
           if (sign === -1) n = -n;
-          hash.secFraction = new Rational(n, 10 ** (si - osi));
+          hash.secFraction = new Rational(n, 10n ** BigInt(si - osi));
           break again;
         }
 
@@ -2646,13 +2674,12 @@ function secToNs(s: number | Rational): number | Rational {
 }
 
 /**
- * @internal `date_core.c` `ns_to_sec` (`date_core.c:993-998`), the inverse. MRI
- * answers a Rational whatever it is handed; a whole-nanosecond count divides
- * out to a JS number here, which is the nearest analogue `Time#subsec` already
- * documents, and a Rational `sf` stays exact.
+ * @internal `date_core.c` `ns_to_sec` (`date_core.c:993-998`), the inverse:
+ * `rb_rational_new2(n, INT2FIX(SECOND_IN_NANOSECONDS))`, which answers a
+ * Rational unconditionally, whatever it is handed.
  */
-function nsToSec(n: number | Rational): number | Rational {
-  return n instanceof Rational ? n.quo(SECOND_IN_NANOSECONDS) : n / SECOND_IN_NANOSECONDS;
+function nsToSec(n: Rational): Rational {
+  return n.quo(SECOND_IN_NANOSECONDS);
 }
 
 /** @internal 1970-01-01, the day {@link UNIX_EPOCH_IN_CJD} numbers. */
@@ -3170,11 +3197,15 @@ export function dtNewByFrags(hash: DateParts): DateTime {
 
   const df = timeToDf(rh, rmin, rs);
 
-  let t: number | Rational | null | undefined = hash.secFraction;
-  const sf = t == null ? 0 : secToNs(t);
+  const t: number | Rational | null | undefined = hash.secFraction;
+  const ns = t == null ? 0 : secToNs(t);
+  // `m_sf`'s only reader is `ns_to_sec`, whose FIXNUM arm is
+  // `rb_rational_new2(n, INT2FIX(SECOND_IN_NANOSECONDS))` (`date_core.c:993-998`),
+  // so an Integer `sf` is stored as the Rational it is always read back as.
+  const sf = ns instanceof Rational ? ns : new Rational(ns, 1);
 
-  t = hash.offset;
-  let of = t == null ? 0 : t instanceof Rational ? t.numerator / t.denominator : t;
+  const to = hash.offset;
+  let of = to == null ? 0 : to instanceof Rational ? to.toF() : to;
   if (of < -DAY_IN_SECONDS || of > DAY_IN_SECONDS) of = 0;
 
   return new DateTime(jdLocalToUtc(jd, df, of), dfLocalToUtc(df, of), sf, of);
@@ -3233,8 +3264,8 @@ function offsetToSec(vof: number | Rational | string): number | null {
   if (vof instanceof Rational) {
     const vs = dayToSec(vof);
     let n: number;
-    if (vs.denominator === 1) {
-      n = vs.numerator;
+    if (vs.denominator === 1n) {
+      n = Number(vs.numerator);
     } else {
       n = vs.round();
       if (n < -DAY_IN_SECONDS || n > DAY_IN_SECONDS) return null;
@@ -3552,7 +3583,7 @@ export class Date {
         hour: 0,
         min: 0,
         sec: 0,
-        nsec: 0,
+        nsec: new Rational(0, 1),
         zone: "+00:00",
         utcOffset: 0,
       },
@@ -3592,11 +3623,13 @@ export class DateTime extends Date {
    * it, so unlike {@link #date} and {@link #df} it is the same value read
    * locally or in UTC.
    *
-   * The C's is a Rational, exact at any denominator; a whole-nanosecond count
-   * is a JS number here and only a value that carries a sub-nanosecond tail —
-   * a `Rational` `second`, or a parsed decimal literal — keeps the Rational.
+   * The C's `d_lite_plus` T_FLOAT arm answers an Integer here
+   * (`date_core.c:6094-6097`) and its T_RATIONAL arm a Rational
+   * (`:6174-6201`), but `m_sf`'s only reader is `ns_to_sec`, which answers a
+   * Rational either way (`:993-998`) — so the storage is uniformly a Rational,
+   * exact at any denominator, and the two arms differ only in their rounding.
    */
-  readonly #sf: number | Rational;
+  readonly #sf: Rational;
   readonly #of: number;
 
   /**
@@ -3690,7 +3723,7 @@ export class DateTime extends Date {
    * `sf` and `of`, in that order. Same TS shortcoming as {@link Date}'s
    * counterpart overload.
    */
-  constructor(rjd: Temporal.PlainDate, df: number, sf: number | Rational, of: number);
+  constructor(rjd: Temporal.PlainDate, df: number, sf: Rational, of: number);
   constructor(
     year: number | Temporal.PlainDate,
     month?: number,
@@ -3702,7 +3735,7 @@ export class DateTime extends Date {
   ) {
     if (year instanceof Temporal.PlainDate) {
       const df = month ?? 0;
-      const sf = day ?? 0;
+      const sf = (day ?? new Rational(0, 1)) as Rational;
       const of = (hour ?? 0) as number;
       super(jdUtcToLocal(year, df, of));
       this.#date = year;
@@ -3753,7 +3786,7 @@ export class DateTime extends Date {
     this.#sf =
       fr2 instanceof Rational
         ? (secToNs(fr2.mod(1)) as Rational)
-        : Math.round(secToNs(fr2 - Math.floor(fr2)) as number);
+        : new Rational(Math.round(secToNs(fr2 - Math.floor(fr2)) as number), 1);
     this.#of = rof;
   }
 
@@ -3840,7 +3873,7 @@ export class DateTime extends Date {
    * answers. The whole second stays on {@link sec}, exactly as `::Time` splits
    * them.
    */
-  get secFraction(): number | Rational {
+  get secFraction(): Rational {
     return nsToSec(this.#sf);
   }
 

--- a/packages/date/src/time.ts
+++ b/packages/date/src/time.ts
@@ -8,7 +8,7 @@
  */
 
 import { Temporal } from "@js-temporal/polyfill";
-import { ArgumentError, strftime } from "./date.js";
+import { ArgumentError, Rational, strftime } from "./date.js";
 
 /**
  * The `utc_offset` argument MRI's `Time.new` accepts: `"UTC"`, an offset —
@@ -318,7 +318,7 @@ export class Time {
         hour: this.hour,
         min: this.min,
         sec: this.sec,
-        nsec: this.nsec,
+        nsec: new Rational(this.nsec, 1),
         zone: this.zone ?? "",
         utcOffset: this.utcOffset,
       },

--- a/packages/i18n/src/backend/flatten.trails.test.ts
+++ b/packages/i18n/src/backend/flatten.trails.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Mirrors: i18n/lib/i18n/backend/flatten.rb:89-94 — `store_link` and
+ * `resolve_link` both normalize the locale through `to_sym`, so a link stored
+ * under one spelling of the locale is visible to a lookup under the other.
+ * The gem has no test for this (the Symbol type makes it unobservable in
+ * Ruby); trails spells a Symbol as a `":en"` string, so it needs one.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { KeyValue, type Store } from "./key-value.js";
+
+describe("I18nBackendFlattenTrailsTest", () => {
+  let backend: KeyValue;
+
+  beforeEach(() => {
+    backend = new KeyValue(new Map<string, string>() as Store);
+  });
+
+  it("store_link normalizes the locale through to_sym", () => {
+    backend.storeLink(":en", "foo.bar", ":foo.baz");
+
+    expect(backend.resolveLink("en", "foo.bar")).toBe("foo.baz");
+    expect(backend.resolveLink(":en", "foo.bar")).toBe("foo.baz");
+  });
+
+  it("resolve_link normalizes the locale through to_sym", () => {
+    backend.storeLink("en", "foo.bar", ":foo.baz");
+
+    expect(backend.resolveLink(":en", "foo.bar")).toBe("foo.baz");
+    expect(backend.links().get("en")?.get("foo.bar")).toBe("foo.baz");
+    expect(backend.links().get(":en")).toBeUndefined();
+  });
+});

--- a/packages/i18n/src/backend/flatten.ts
+++ b/packages/i18n/src/backend/flatten.ts
@@ -177,12 +177,14 @@ export function flattenTranslations(
 }
 
 export function storeLink(this: FlattenHost, locale: string, key: string, link: unknown): void {
+  locale = toSym(locale).slice(1);
   const byLocale = this.links().get(locale) ?? new Map<string, string>();
   this.links().set(locale, byLocale);
   byLocale.set(String(key), toS(link));
 }
 
 export function resolveLink(this: FlattenHost, locale: string, key: string): string {
+  [key, locale] = [String(key), toSym(locale).slice(1)];
   const localeLinks = this.links().get(locale) ?? new Map<string, string>();
   this.links().set(locale, localeLinks);
 


### PR DESCRIPTION
Bundle of three stories.

### `store_link` / `resolve_link` normalize the locale through `to_sym`

`flatten.rb:89-94` keys `links` by `locale.to_sym`; both ported bodies used the
raw `locale`, so a link stored under the `":en"` Symbol spelling and one looked
up under `"en"` landed in two different buckets. They now call the shared
`toSym(locale).slice(1)` as the five bodies PR #6177 converged do, and
`resolve_link` applies `key.to_s`.

### `DateTime#sec_fraction` answers a Rational unconditionally

`d_lite_sec_fraction` is `m_sf_in_sec` over `ns_to_sec`
(`date_core.c:1568-1572`, `:993-998`), whose FIXNUM arm is
`rb_rational_new2(n, INT2FIX(SECOND_IN_NANOSECONDS))` — a Rational whatever it
is handed, as `sec_fraction -> rational` (`:5623`) documents. `#sf`,
`StrftimeSubject.nsec` and `nsToSec` lose their `number | Rational` unions and
the `instanceof Rational` arms that served them; `sql-datetime.ts` reads the
Rational directly.

`sec_to_ns` keeps both arms, because `date_core.c:1053-1059` has both — it is
the store into `#sf` that normalizes, exactly where `ns_to_sec` would.

The constructor still has two arms, and correctly: `d_lite_plus`'s T_FLOAT arm
rounds to a whole nanosecond (`:6094-6097`) where its T_RATIONAL arm is exact
(`:6174-6201`).

### `Rational` is `bigint`-backed

Ruby's numerator/denominator are Integers. Ours were JS numbers, exact only
inside `Number.MAX_SAFE_INTEGER`, so `DateTime.parse("...00." + "1" * 20)`
could not answer the Rational MRI does. Both fields are now `bigint`, `i_gcd`
operates on `bigint`, and the parse producers build
`new Rational(BigInt(f), 10n ** BigInt(f.length))` mirroring
`rb_rational_new2(str2num(f), f_expt(INT2FIX(10), LONG2NUM(len)))`
(`date_parse.c:2319-2325`). `subsecDigits`' long division is exact at any
denominator. Readers at a `number` seam convert through `Rational#to_f`
(`rational.c` `nurat_to_f`).

Every changed value verified against `ruby -rdate -e` on 3.3.11:

```text
DateTime.new(2008, 3, 1, 6, 0, Rational(2)).sec_fraction  #=> (0/1)
DateTime.new(2001, 2, 3, 4, 5, 6.5).sec_fraction          #=> (1/2)
DateTime.parse("2008-03-01T06:00:00." + "1" * 20).sec_fraction
  #=> (11111111111111111111/100000000000000000000)
DateTime.parse("2008-03-01T06:00:00." + "1" * 20).strftime("%20N")
  #=> "11111111111111111111"
```

Closes-story: flatten-store-resolve-link-to-sym-parity
Closes-story: datetime-sec-fraction-is-always-a-rational
Closes-story: rational-is-number-backed-not-arbitrary-precision
