### PR TITLE
fix(activerecord): restoreWorkerConnection restores both worker pools; per-pool SCHEMA_FORMAT read; loud snapshot width degradation

### DIFF
--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1761,10 +1761,8 @@ export abstract class Migration {
     await databaseTasks.withTemporaryPoolForEach({ env: "test" }, async (pool) => {
       const dbConfig = pool.dbConfig;
       Schema.verbose = false;
-      // `databases.rake:537` — read per iteration, not hoisted: a `load_schema`
-      // inside the loop can move the fallback state, and `ENV["SCHEMA_FORMAT"]`
-      // is re-read each time round in Ruby. `DatabaseTasks.schemaFormat` is the
-      // trails home of Rails' global `ActiveRecord.schema_format`.
+      // `databases.rake:537` — `DatabaseTasks.schemaFormat` is the trails home
+      // of Rails' global `ActiveRecord.schema_format`.
       const schemaFormat = (getEnv("SCHEMA_FORMAT") ?? databaseTasks.schemaFormat) as SchemaFormat;
       await databaseTasks.loadSchema(dbConfig, schemaFormat);
     });

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1758,10 +1758,15 @@ export abstract class Migration {
     }
 
     const { Schema } = await import("./schema.js");
-    const schemaFormat = (getEnv("SCHEMA_FORMAT") ?? databaseTasks.schemaFormat) as SchemaFormat;
     await databaseTasks.withTemporaryPoolForEach({ env: "test" }, async (pool) => {
+      const dbConfig = pool.dbConfig;
       Schema.verbose = false;
-      await databaseTasks.loadSchema(pool.dbConfig, schemaFormat);
+      // `databases.rake:537` — read per iteration, not hoisted: a `load_schema`
+      // inside the loop can move the fallback state, and `ENV["SCHEMA_FORMAT"]`
+      // is re-read each time round in Ruby. `DatabaseTasks.schemaFormat` is the
+      // trails home of Rails' global `ActiveRecord.schema_format`.
+      const schemaFormat = (getEnv("SCHEMA_FORMAT") ?? databaseTasks.schemaFormat) as SchemaFormat;
+      await databaseTasks.loadSchema(dbConfig, schemaFormat);
     });
   }
 }

--- a/packages/activerecord/src/support/canonical-schema-stamp.ts
+++ b/packages/activerecord/src/support/canonical-schema-stamp.ts
@@ -59,11 +59,50 @@ const ADAPTER_SPECIFIC_TABLES_KEY = "adapter_specific_tables";
  *
  * The recorded half is small by construction (1 table on SQLite, 7 on MySQL,
  * 24 on PostgreSQL), so this is a backstop, not an expected path.
+ *
+ * The MySQL headroom is ~110 characters — roughly five more table names in
+ * `loadMysql2SpecificSchema` — so the backstop is close enough to trip that it
+ * must not trip *silently*: crossing it costs the whole memo (~2.5 min of
+ * MariaDB CI per run) with no failing test to say so. Hence
+ * {@link snapshotWidthDegraded}, and the one warning below.
  */
 const MYSQL_MAX_VALUE_LENGTH = 255;
 
 function fitsValueColumn(adapter: DatabaseAdapter, encoded: string): boolean {
   return adapter.adapterName !== "mysql" || encoded.length <= MYSQL_MAX_VALUE_LENGTH;
+}
+
+let widthDegraded = false;
+
+/**
+ * Whether this process has written an empty snapshot because the encoded set
+ * did not fit {@link MYSQL_MAX_VALUE_LENGTH} — i.e. whether the memo has
+ * switched itself off on this lane. Read back by `template-stamp.test.ts`.
+ *
+ * @internal
+ */
+export function snapshotWidthDegraded(): boolean {
+  return widthDegraded;
+}
+
+/**
+ * Reset, so the case that deliberately overflows the column does not leave the
+ * flag set for a later reader.
+ *
+ * @internal
+ */
+export function clearSnapshotWidthDegraded(): void {
+  widthDegraded = false;
+}
+
+function recordSnapshotWidthDegraded(encoded: string): void {
+  if (widthDegraded) return;
+  widthDegraded = true;
+  console.error(
+    `[canonical-schema-stamp] adapter-specific snapshot is ${encoded.length} chars, over ` +
+      `ar_internal_metadata.value's ${MYSQL_MAX_VALUE_LENGTH}-char MySQL width — the ` +
+      `per-boot memo is now OFF on this lane and every worker re-lays the adapter-specific arm.`,
+  );
 }
 
 /**
@@ -137,7 +176,12 @@ export async function stampCanonicalSchema(
   // An over-long value is written as empty rather than skipped: skipping would
   // leave an earlier, now-stale snapshot in place on a database whose metadata
   // table survived, and {@link adapterSpecificTables} reads empty as absent.
-  await metadata.set(ADAPTER_SPECIFIC_TABLES_KEY, fitsValueColumn(adapter, encoded) ? encoded : "");
+  if (fitsValueColumn(adapter, encoded)) {
+    await metadata.set(ADAPTER_SPECIFIC_TABLES_KEY, encoded);
+    return;
+  }
+  recordSnapshotWidthDegraded(encoded);
+  await metadata.set(ADAPTER_SPECIFIC_TABLES_KEY, "");
 }
 
 /**

--- a/packages/activerecord/src/support/connection.test.ts
+++ b/packages/activerecord/src/support/connection.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, afterEach, vi } from "vitest";
 import { DatabaseTasks } from "../tasks/database-tasks.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
 import { Base } from "../base.js";
-import { ARUnit2Model } from "../test-helpers/models/arunit2-model.js";
 import { connect, restoreWorkerConnection, testConfigurationHashes } from "./connection.js";
 import { SQLITE_FIXTURE_DATABASE, SQLITE_FIXTURE_DATABASE_2 } from "./config.js";
 
@@ -26,9 +25,8 @@ describe("connect", () => {
     // stubbed (`connection.rb:32-33`), displacing the worker's own same-named
     // pools for every later file in the vitest worker — invisible on the sqlite
     // lane, a different database on the others. `restoreWorkerConnection()`
-    // covers `arunit` only, so `arunit2` is re-established alongside it.
+    // covers both.
     await restoreWorkerConnection();
-    await ARUnit2Model.establishConnection("arunit2");
   });
 
   it("sets databaseConfiguration and returns the arunit config", async () => {

--- a/packages/activerecord/src/support/connection.ts
+++ b/packages/activerecord/src/support/connection.ts
@@ -440,6 +440,11 @@ const ADAPTER_SPECIFIC_PROBE_TABLE = "defaults";
  * is indistinguishable from one laid at boot: `canonicalSchemaUpToDate` is read
  * by a *starting* worker, and an unstamped in-memory database would be a state
  * boot never produces.
+ *
+ * Both of `connect`'s pools are restored, not just `arunit` — `connection.rb:33`
+ * opens `ARUnit2Model` on `arunit2` in the same breath, so a file that displaced
+ * the worker's pools gets both back and no caller has to know which halves this
+ * covers.
  */
 export async function restoreWorkerConnection(): Promise<void> {
   await Base.establishConnection("arunit");
@@ -450,9 +455,32 @@ export async function restoreWorkerConnection(): Promise<void> {
     const adapter = await Base.leaseConnection();
     await loadSchema(adapter);
     await stampCanonicalSchema(adapter);
-    return;
-  }
-  if (!(await connection.tableExists(ADAPTER_SPECIFIC_PROBE_TABLE))) {
+  } else if (!(await connection.tableExists(ADAPTER_SPECIFIC_PROBE_TABLE))) {
     await loadAdapterSpecificSchema(await Base.leaseConnection());
   }
+  await restoreSecondWorkerConnection();
+}
+
+/**
+ * The `arunit2` half of {@link restoreWorkerConnection} — `connection.rb:33`'s
+ * `ARUnit2Model.establish_connection :arunit2`, plus the same probe-and-reload
+ * the `arunit` half carries, for the same reason: under `ARCONN=sqlite3_mem` the
+ * displaced pool *was* the database, so re-establishing opens a brand-new empty
+ * `:memory:` one and the tables have to be laid again.
+ *
+ * The reload is gated on the probe rather than run unconditionally because
+ * `provisionSecondDatabase()` truncates on its already-provisioned path, and
+ * several callers invoke `restoreWorkerConnection()` per test — a caller that
+ * never displaced this pool must not lose its rows.
+ *
+ * Imported at call time: `setup-second-pool.ts` reads `activeLane` from this
+ * module, so a static import would close a cycle.
+ */
+async function restoreSecondWorkerConnection(): Promise<void> {
+  await ARUnit2Model.establishConnection("arunit2");
+  const { ARUNIT2_TABLES, provisionSecondDatabase } = await import("./setup-second-pool.js");
+  const arunit2 = await ARUnit2Model.leaseConnection();
+  const present = new Set(await arunit2.tables());
+  if ([...ARUNIT2_TABLES, "dogs"].every((name) => present.has(name))) return;
+  await provisionSecondDatabase();
 }

--- a/packages/activerecord/src/support/template-stamp.test.ts
+++ b/packages/activerecord/src/support/template-stamp.test.ts
@@ -14,7 +14,7 @@
  * The second probe covers every lane, MySQL included, by replaying the fast
  * path's arm against the worker's own database.
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import "../sqlite/better-sqlite3.js";
 import { Base } from "../base.js";
 import { bootOutcome } from "./boot-outcome.js";
@@ -25,6 +25,8 @@ import {
   canonicalSchemaUpToDate,
   adapterSpecificTables,
   stampCanonicalSchema,
+  snapshotWidthDegraded,
+  clearSnapshotWidthDegraded,
 } from "./canonical-schema-stamp.js";
 import { resetTestTables } from "./drop-all-tables.js";
 import { loadAdapterSpecificSchema } from "./load-schema-helper.js";
@@ -111,6 +113,37 @@ describe.skipIf(!runToken)("snapshot width backstop", () => {
       }
     } finally {
       await stampCanonicalSchema(connection, undefined, before ?? undefined);
+      clearSnapshotWidthDegraded();
+    }
+  });
+
+  it("says so when the memo switches itself off", async () => {
+    // The MySQL headroom is ~110 characters, so this backstop is close enough to
+    // trip in the ordinary course of adding a table to
+    // `loadMysql2SpecificSchema` — and tripping it costs the whole per-boot memo
+    // (~2.5 min of MariaDB CI per run) with no failing test and, before this,
+    // no log line either. The disablement has to be observable.
+    const connection = await Base.leaseConnection();
+    const before = await adapterSpecificTables(connection);
+    const oversized = Array.from({ length: 200 }, (_, i) => `padding_table_${i}`);
+    clearSnapshotWidthDegraded();
+    const warn = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await stampCanonicalSchema(connection, undefined, oversized);
+      if (connection.adapterName === "mysql") {
+        expect(snapshotWidthDegraded()).toBe(true);
+        expect(warn).toHaveBeenCalledTimes(1);
+        // Once per process, not once per stamp: every worker boot re-stamps.
+        await stampCanonicalSchema(connection, undefined, oversized);
+        expect(warn).toHaveBeenCalledTimes(1);
+      } else {
+        expect(snapshotWidthDegraded()).toBe(false);
+        expect(warn).not.toHaveBeenCalled();
+      }
+    } finally {
+      warn.mockRestore();
+      await stampCanonicalSchema(connection, undefined, before ?? undefined);
+      clearSnapshotWidthDegraded();
     }
   });
 });

--- a/packages/activerecord/src/support/template-stamp.test.ts
+++ b/packages/activerecord/src/support/template-stamp.test.ts
@@ -118,11 +118,8 @@ describe.skipIf(!runToken)("snapshot width backstop", () => {
   });
 
   it("says so when the memo switches itself off", async () => {
-    // The MySQL headroom is ~110 characters, so this backstop is close enough to
-    // trip in the ordinary course of adding a table to
-    // `loadMysql2SpecificSchema` — and tripping it costs the whole per-boot memo
-    // (~2.5 min of MariaDB CI per run) with no failing test and, before this,
-    // no log line either. The disablement has to be observable.
+    // ~110 characters of MySQL headroom, and crossing it costs the whole
+    // per-boot memo (~2.5 min of MariaDB CI per run) with no failing test.
     const connection = await Base.leaseConnection();
     const before = await adapterSpecificTables(connection);
     const oversized = Array.from({ length: 200 }, (_, i) => `padding_table_${i}`);


### PR DESCRIPTION
Three of the four bundled stories. `pg-maria-adapter-unique-flake-burndown-round-2` was released back — see below.

## `restoreWorkerConnection()` restores both worker pools

`connect()` (`support/connection.ts:411-412`) mirrors `ARTest.connect`
(`vendor/rails/activerecord/test/support/connection.rb:32-33`) and establishes
**both** pools — `Base` on `arunit`, `ARUnit2Model` on `arunit2`. But
`restoreWorkerConnection()` re-established only `arunit`, so a file that
displaced the worker's pools got half of them back and the caller had to
hand-restore the other half. PR #6180 hit exactly that: the PG and MariaDB
lanes failed the writing-pool census with
`ARUnit2Model (sqlite3:db/fixture_database_2.sqlite3)`, fixed at the call site
with an explicit `await ARUnit2Model.establishConnection("arunit2")`.

The helper now covers both, and that call site is gone. The `arunit2` arm gets
the same probe-and-reload the `arunit` arm has: under `ARCONN=sqlite3_mem` the
displaced pool *was* the database, so a plain re-establish opens a fresh empty
`:memory:` one. The reload is gated on the table probe rather than run
unconditionally, because `provisionSecondDatabase()` truncates on its
already-provisioned path and several callers invoke
`restoreWorkerConnection()` per test.

`setup-second-pool.ts` reads `activeLane` from `connection.ts`, so the import
is a call-time `await import()` rather than a static edge that would close a
cycle.

## `loadSchemaBang` reads `SCHEMA_FORMAT` inside the per-pool block

`databases.rake:531-539` reads the schema format **inside**
`with_temporary_pool_for_each`, after `ActiveRecord::Schema.verbose = false`:

```ruby
db_config = pool.db_config
ActiveRecord::Schema.verbose = false
schema_format = ENV.fetch("SCHEMA_FORMAT", ActiveRecord.schema_format).to_sym
ActiveRecord::Tasks::DatabaseTasks.load_schema(db_config, schema_format)
```

trails hoisted it above the loop. With one test config the two spellings agree;
with several they diverge after the first iteration, since a `load_schema` in
the loop can move the fallback state and Ruby re-reads `ENV` each time round.
Moved in, with the `dbConfig` local Rails extracts at `:533`.

On the fallback source: Rails reads the global `ActiveRecord.schema_format`;
trails has no such global — `DatabaseTasks.schemaFormat` is the single home of
that state and every reader in the package goes through it, so the two read the
same thing. Noted at the call site.

## Snapshot width degradation is no longer silent

`ar_internal_metadata.value` is `t.string` (`internal_metadata.rb:85-93`),
which MySQL renders `varchar(255)` (`abstract_mysql_adapter.rb:33`); PG and
SQLite impose no limit (`postgresql_adapter.rb:136`, `sqlite3_adapter.rb:71`).
Widening the column is not on the table — that shape is Rails'.

The existing backstop writes an over-long value empty and the boot falls back
to re-laying the adapter-specific arm, so correctness was already safe. The
problem was that it did so **silently**: MySQL headroom is ~110 characters,
roughly five more table names in `loadMysql2SpecificSchema`, and crossing it
takes ~2.5 min of MariaDB CI per run with no failing test and no log line.

The disablement is now surfaced — a `snapshotWidthDegraded()` reader plus one
`console.error` per process (not per stamp; every worker boot re-stamps) — and
`template-stamp.test.ts` pins it at the MySQL boundary alongside the existing
"survives a snapshot wider than the value column" case. The store itself still
sits on `ar_internal_metadata`; moving it to the run-token sidecar remains
open, but it is a materially larger change and the acceptance criteria admit
either route.

## Released: `pg-maria-adapter-unique-flake-burndown-round-2`

Released rather than closed. Its acceptance criteria require triaging 11 named
branches' historical CI runs to root cause and then re-measuring the
adapter-unique failure rate over a comparable window — neither is reproducible
from this worktree, and I would rather hand it back than close it on a
narrative. Worth noting the two fixes above are both in its class: the
`arunit2` half is a PG/MariaDB-only red by construction (invisible on SQLite,
where the displaced signature matches the baseline), and the snapshot memo is a
MariaDB-only cost.

## Testing

Green locally on the file lane and `ARCONN=sqlite3_mem`:
`support/connection.test.ts`, `support/template-stamp.test.ts`,
`cases/writing-pool-census.trails.test.ts`,
`connection-adapters/connection-handlers-multi-db.test.ts`,
`connection-handling.test.ts`,
`migration/load-schema-if-pending.trails.test.ts`, `ar-config.test.ts`,
`trailtie.test.ts`. `pnpm typecheck` and `pnpm api:calls` clean (no new
baseline rows).

Closes-story: restore-worker-connection-covers-only-arunit
Closes-story: load-schema-task-hoists-schema-format-out-of-the-pool-loop
Closes-story: schema-snapshot-silently-degrades-at-mysql-value-width
