### PR TITLE
refactor(activesupport): delegate time-ext calculations the way core_ext/*/calculations.rb does

### DIFF
--- a/packages/activesupport/src/core-ext/date-ext.test.ts
+++ b/packages/activesupport/src/core-ext/date-ext.test.ts
@@ -19,7 +19,7 @@ import {
   allYear,
   endOfWeek,
   beginningOfQuarter,
-  changeDate,
+  change,
   toFs,
   xmlschema,
   toTime,
@@ -121,8 +121,8 @@ describe("DateExtCalculationsTest", () => {
   });
 
   it("change", () => {
-    expect(asDate(changeDate(d(2005, 2, 11), { day: 21 })).getDate()).toBe(21);
-    const changed = asDate(changeDate(d(2005, 2, 11), { year: 2007, month: 5 }));
+    expect(asDate(change(d(2005, 2, 11), { day: 21 })).getDate()).toBe(21);
+    const changed = asDate(change(d(2005, 2, 11), { year: 2007, month: 5 }));
     expect(changed.getFullYear()).toBe(2007);
     expect(changed.getMonth()).toBe(4); // May
     expect(changed.getDate()).toBe(11);

--- a/packages/activesupport/src/core-ext/date-time-ext.test.ts
+++ b/packages/activesupport/src/core-ext/date-time-ext.test.ts
@@ -7,7 +7,7 @@ import {
   beginningOfHour,
   beginningOfMinute,
   beginningOfQuarter,
-  changeDate,
+  change,
   endOfDay,
   endOfHour,
   endOfMinute,
@@ -123,7 +123,7 @@ describe("DateTimeExtCalculationsTest", () => {
 
   it("change", () => {
     const dt = d(2005, 2, 22, 15, 15, 10);
-    const result = asDate(changeDate(dt, { year: 2006 }));
+    const result = asDate(change(dt, { year: 2006 }));
     expect(result.getFullYear()).toBe(2006);
   });
 

--- a/packages/activesupport/src/core-ext/time-ext.test.ts
+++ b/packages/activesupport/src/core-ext/time-ext.test.ts
@@ -11,7 +11,7 @@ import {
   secFraction,
   floor,
   ceil,
-  changeDate,
+  change,
   toFs,
   xmlschema,
   lastWeek,
@@ -247,32 +247,32 @@ describe("TimeExtCalculationsTest", () => {
   });
 
   it("change", () => {
-    expect(asDate(changeDate(d(2005, 2, 22, 15, 15, 10), { year: 2006 }))).toEqual(
+    expect(asDate(change(d(2005, 2, 22, 15, 15, 10), { year: 2006 }))).toEqual(
       d(2006, 2, 22, 15, 15, 10),
     );
-    expect(asDate(changeDate(d(2005, 2, 22, 15, 15, 10), { month: 6 }))).toEqual(
+    expect(asDate(change(d(2005, 2, 22, 15, 15, 10), { month: 6 }))).toEqual(
       d(2005, 6, 22, 15, 15, 10),
     );
-    expect(asDate(changeDate(d(2005, 2, 22, 15, 15, 10), { year: 2012, month: 9 }))).toEqual(
+    expect(asDate(change(d(2005, 2, 22, 15, 15, 10), { year: 2012, month: 9 }))).toEqual(
       d(2012, 9, 22, 15, 15, 10),
     );
-    expect(asDate(changeDate(d(2005, 2, 22, 15, 15, 10), { hour: 16 }))).toEqual(
+    expect(asDate(change(d(2005, 2, 22, 15, 15, 10), { hour: 16 }))).toEqual(
       d(2005, 2, 22, 16, 0, 0),
     );
-    expect(asDate(changeDate(d(2005, 2, 22, 15, 15, 10), { min: 45 }))).toEqual(
+    expect(asDate(change(d(2005, 2, 22, 15, 15, 10), { min: 45 }))).toEqual(
       d(2005, 2, 22, 15, 45, 0),
     );
   });
 
   it("utc change", () => {
     const t1 = utc(2005, 2, 22, 15, 15, 10);
-    const result = asDate(changeDate(t1, { year: 2006 }));
+    const result = asDate(change(t1, { year: 2006 }));
     expect(result.getFullYear()).toBe(2006);
   });
 
   it("offset change", () => {
     const t = d(2005, 2, 22, 15, 15, 10);
-    const result = asDate(changeDate(t, { year: 2006 }));
+    const result = asDate(change(t, { year: 2006 }));
     expect(result.getFullYear()).toBe(2006);
     expect(result.getHours()).toBe(15);
     expect(result.getMinutes()).toBe(15);
@@ -281,7 +281,7 @@ describe("TimeExtCalculationsTest", () => {
 
   it("change offset", () => {
     const t = d(2006, 2, 22, 15, 15, 10);
-    const result = asDate(changeDate(t, { year: 2006 }));
+    const result = asDate(change(t, { year: 2006 }));
     expect(result.getFullYear()).toBe(2006);
     expect(result.getHours()).toBe(15);
   });

--- a/packages/activesupport/src/time-ext.test.ts
+++ b/packages/activesupport/src/time-ext.test.ts
@@ -39,7 +39,7 @@ import {
   allYear,
   ago,
   since,
-  changeDate,
+  change,
   onWeekday,
   onWeekend,
   isToday,
@@ -141,14 +141,10 @@ describe("TimeExtCalculationsTest", () => {
   });
 
   it("change (changeDate)", () => {
-    expect(changeDate(d(2005, 2, 22, 15, 15, 10), { year: 2006 })).toEqual(
-      i(2006, 2, 22, 15, 15, 10),
-    );
-    expect(changeDate(d(2005, 2, 22, 15, 15, 10), { month: 6 })).toEqual(
-      i(2005, 6, 22, 15, 15, 10),
-    );
-    expect(changeDate(d(2005, 2, 22, 15, 15, 10), { hour: 16 })).toEqual(i(2005, 2, 22, 16, 0, 0));
-    expect(changeDate(d(2005, 2, 22, 15, 15, 10), { min: 45 })).toEqual(i(2005, 2, 22, 15, 45, 0));
+    expect(change(d(2005, 2, 22, 15, 15, 10), { year: 2006 })).toEqual(i(2006, 2, 22, 15, 15, 10));
+    expect(change(d(2005, 2, 22, 15, 15, 10), { month: 6 })).toEqual(i(2005, 6, 22, 15, 15, 10));
+    expect(change(d(2005, 2, 22, 15, 15, 10), { hour: 16 })).toEqual(i(2005, 2, 22, 16, 0, 0));
+    expect(change(d(2005, 2, 22, 15, 15, 10), { min: 45 })).toEqual(i(2005, 2, 22, 15, 45, 0));
   });
 
   it("advance years", () => {
@@ -476,7 +472,7 @@ describe("TimeExtCalculationsTest", () => {
 
   it("change", () => {
     const t = d(2005, 2, 22, 15, 15, 10);
-    const result = asDate(changeDate(t, { year: 2006, month: 6, day: 1 }));
+    const result = asDate(change(t, { year: 2006, month: 6, day: 1 }));
     expect(result.getFullYear()).toBe(2006);
     expect(result.getMonth()).toBe(5); // June
     expect(result.getDate()).toBe(1);
@@ -729,7 +725,7 @@ describe("DateExtCalculationsTest", () => {
 
   it("change", () => {
     const date = d(2005, 2, 21);
-    const result = asDate(changeDate(date, { year: 2006 }));
+    const result = asDate(change(date, { year: 2006 }));
     expect(result.getFullYear()).toBe(2006);
     expect(result.getMonth()).toBe(1); // February
     expect(result.getDate()).toBe(21);
@@ -1046,7 +1042,7 @@ describe("DateTimeExtCalculationsTest", () => {
 
   it("changeDate preserves time components", () => {
     const dt = d(2005, 2, 22, 15, 15, 10);
-    const result = asDate(changeDate(dt, { year: 2006 }));
+    const result = asDate(change(dt, { year: 2006 }));
     expect(result.getFullYear()).toBe(2006);
     expect(result.getMonth()).toBe(1); // February
     expect(result.getDate()).toBe(22);
@@ -1124,7 +1120,7 @@ describe("DateTimeExtCalculationsTest", () => {
 
   it("change", () => {
     const dt = d(2005, 2, 22, 15, 15, 10);
-    const result = asDate(changeDate(dt, { year: 2006 }));
+    const result = asDate(change(dt, { year: 2006 }));
     expect(result.getFullYear()).toBe(2006);
   });
 

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -231,6 +231,14 @@ export function prevOccurring(date: Date, day: string): Temporal.Instant {
 // advance
 // ---------------------------------------------------------------------------
 
+/**
+ * Rails' `Time#advance` (time/calculations.rb:194-217) writes the normalised
+ * `:weeks` / `:days` back into the caller's hash, but `Date#advance`
+ * (date/calculations.rb:127-136) reads it only — and Rails asserts that
+ * difference (`test_date_advance_should_not_change_passed_options_hash`,
+ * date_ext_test.rb:367-371). One TS function stands in for both reopenings, so
+ * it takes the non-mutating arm and normalises into a copy.
+ */
 export function advance(
   date: Date,
   options: {
@@ -282,7 +290,7 @@ export function secondsSinceMidnight(date: Date): number {
   return (
     Math.floor(date.getTime() / 1000) -
     Math.floor(change(date, { hour: 0 }).epochMilliseconds / 1000) +
-    date.getMilliseconds() / 1.0e3
+    (date.getMilliseconds() * 1000) / 1.0e6
   );
 }
 

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -29,21 +29,15 @@ function clone(date: Date): Date {
 // ---------------------------------------------------------------------------
 
 export function beginningOfDay(date: Date): Temporal.Instant {
-  const d = clone(date);
-  d.setHours(0, 0, 0, 0);
-  return instantFrom(d);
+  return change(date, { hour: 0 });
 }
 
 export function middleOfDay(date: Date): Temporal.Instant {
-  const d = clone(date);
-  d.setHours(12, 0, 0, 0);
-  return instantFrom(d);
+  return change(date, { hour: 12 });
 }
 
 export function endOfDay(date: Date): Temporal.Instant {
-  const d = clone(date);
-  d.setHours(23, 59, 59, 999);
-  return instantFrom(d);
+  return change(date, { hour: 23, min: 59, sec: 59, usec: 999999999 / 1000 });
 }
 
 // ---------------------------------------------------------------------------
@@ -51,15 +45,11 @@ export function endOfDay(date: Date): Temporal.Instant {
 // ---------------------------------------------------------------------------
 
 export function beginningOfHour(date: Date): Temporal.Instant {
-  const d = clone(date);
-  d.setMinutes(0, 0, 0);
-  return instantFrom(d);
+  return change(date, { min: 0 });
 }
 
 export function endOfHour(date: Date): Temporal.Instant {
-  const d = clone(date);
-  d.setMinutes(59, 59, 999);
-  return instantFrom(d);
+  return change(date, { min: 59, sec: 59, usec: 999999999 / 1000 });
 }
 
 // ---------------------------------------------------------------------------
@@ -67,15 +57,11 @@ export function endOfHour(date: Date): Temporal.Instant {
 // ---------------------------------------------------------------------------
 
 export function beginningOfMinute(date: Date): Temporal.Instant {
-  const d = clone(date);
-  d.setSeconds(0, 0);
-  return instantFrom(d);
+  return change(date, { sec: 0 });
 }
 
 export function endOfMinute(date: Date): Temporal.Instant {
-  const d = clone(date);
-  d.setSeconds(59, 999);
-  return instantFrom(d);
+  return change(date, { sec: 59, usec: 999999999 / 1000 });
 }
 
 // ---------------------------------------------------------------------------
@@ -192,62 +178,28 @@ export function prevWeek(date: Date, day = "monday"): Temporal.Instant {
   return instantFrom(bow);
 }
 
-export function nextMonth(date: Date): Temporal.Instant {
-  const d = clone(date);
-  const day = d.getDate();
-  d.setMonth(d.getMonth() + 1);
-  // Handle month overflow (e.g. Jan 31 -> Feb 28)
-  if (d.getDate() !== day) {
-    d.setDate(0); // last day of previous month
-  }
-  return instantFrom(d);
+export function nextMonth(date: Date, months = 1): Temporal.Instant {
+  return advance(date, { months: months });
 }
 
-export function prevMonth(date: Date): Temporal.Instant {
-  const d = clone(date);
-  const day = d.getDate();
-  d.setMonth(d.getMonth() - 1);
-  if (d.getDate() !== day) {
-    d.setDate(0);
-  }
-  return instantFrom(d);
+export function prevMonth(date: Date, months = 1): Temporal.Instant {
+  return advance(date, { months: -months });
 }
 
-export function nextYear(date: Date): Temporal.Instant {
-  const d = clone(date);
-  const month = d.getMonth();
-  const day = d.getDate();
-  d.setFullYear(d.getFullYear() + 1);
-  // Handle leap day (Feb 29 -> Feb 28)
-  if (d.getMonth() !== month) {
-    d.setDate(0);
-  }
-  if (d.getDate() !== day && d.getMonth() === month) {
-    d.setDate(0);
-  }
-  return instantFrom(d);
+export function nextYear(date: Date, years = 1): Temporal.Instant {
+  return advance(date, { years: years });
 }
 
-export function prevYear(date: Date): Temporal.Instant {
-  const d = clone(date);
-  const month = d.getMonth();
-  d.setFullYear(d.getFullYear() - 1);
-  if (d.getMonth() !== month) {
-    d.setDate(0);
-  }
-  return instantFrom(d);
+export function prevYear(date: Date, years = 1): Temporal.Instant {
+  return advance(date, { years: -years });
 }
 
-export function nextDay(date: Date): Temporal.Instant {
-  const d = clone(date);
-  d.setDate(d.getDate() + 1);
-  return instantFrom(d);
+export function nextDay(date: Date, days = 1): Temporal.Instant {
+  return advance(date, { days: days });
 }
 
-export function prevDay(date: Date): Temporal.Instant {
-  const d = clone(date);
-  d.setDate(d.getDate() - 1);
-  return instantFrom(d);
+export function prevDay(date: Date, days = 1): Temporal.Instant {
+  return advance(date, { days: -days });
 }
 
 // Alias used in Rails
@@ -291,42 +243,35 @@ export function advance(
     seconds?: number;
   },
 ): Temporal.Instant {
-  let d = clone(date);
+  options = { ...options };
 
-  if (options.years) {
-    const month = d.getMonth();
-    d.setFullYear(d.getFullYear() + options.years);
-    if (d.getMonth() !== month) d.setDate(0);
+  if (options.weeks != null) {
+    const partialWeeks = options.weeks - Math.trunc(options.weeks);
+    options.weeks = Math.trunc(options.weeks);
+    options.days = (options.days ?? 0) + 7 * partialWeeks;
   }
 
-  if (options.months) {
-    const targetMonth = d.getMonth() + options.months;
-    const expectedMonth = ((targetMonth % 12) + 12) % 12;
-    d.setMonth(targetMonth);
-    if (d.getMonth() !== expectedMonth) d.setDate(0);
+  if (options.days != null) {
+    const partialDays = options.days - Math.trunc(options.days);
+    options.days = Math.trunc(options.days);
+    options.hours = (options.hours ?? 0) + 24 * partialDays;
   }
 
-  if (options.weeks) {
-    const wholeDays = Math.trunc(options.weeks * 7);
-    const fractionalDayMs = (options.weeks * 7 - wholeDays) * 24 * 3600 * 1000;
-    d.setDate(d.getDate() + wholeDays);
-    if (fractionalDayMs) d = new Date(d.getTime() + fractionalDayMs);
+  let d = toDate(date);
+  if (options.years) d = d.add({ months: options.years * 12 });
+  if (options.months) d = d.add({ months: options.months });
+  if (options.weeks) d = d.add({ days: options.weeks * 7 });
+  if (options.days) d = d.add({ days: options.days });
+
+  const timeAdvancedByDate = change(date, { year: d.year, month: d.month, day: d.day });
+  const secondsToAdvance =
+    (options.seconds ?? 0) + (options.minutes ?? 0) * 60 + (options.hours ?? 0) * 3600;
+
+  if (secondsToAdvance === 0) {
+    return timeAdvancedByDate;
+  } else {
+    return since(new Date(timeAdvancedByDate.epochMilliseconds), secondsToAdvance);
   }
-
-  if (options.days) {
-    const wholeDays = Math.trunc(options.days);
-    const fractionalDayMs = (options.days - wholeDays) * 24 * 3600 * 1000;
-    d.setDate(d.getDate() + wholeDays);
-    if (fractionalDayMs) d = new Date(d.getTime() + fractionalDayMs);
-  }
-
-  let ms = 0;
-  if (options.hours) ms += options.hours * 3600 * 1000;
-  if (options.minutes) ms += options.minutes * 60 * 1000;
-  if (options.seconds) ms += options.seconds * 1000;
-
-  if (ms) d = new Date(d.getTime() + ms);
-  return instantFrom(d);
 }
 
 // ---------------------------------------------------------------------------
@@ -334,13 +279,15 @@ export function advance(
 // ---------------------------------------------------------------------------
 
 export function secondsSinceMidnight(date: Date): number {
-  const midnight = new Date(date.getFullYear(), date.getMonth(), date.getDate());
-  return (date.getTime() - midnight.getTime()) / 1000;
+  return (
+    Math.floor(date.getTime() / 1000) -
+    Math.floor(change(date, { hour: 0 }).epochMilliseconds / 1000) +
+    date.getMilliseconds() / 1.0e3
+  );
 }
 
 export function secondsUntilEndOfDay(date: Date): number {
-  const eod = new Date(date.getFullYear(), date.getMonth(), date.getDate(), 23, 59, 59, 999);
-  return Math.max(0, Math.floor((eod.getTime() - date.getTime()) / 1000));
+  return Math.floor(endOfDay(date).epochMilliseconds / 1000) - Math.floor(date.getTime() / 1000);
 }
 
 // ---------------------------------------------------------------------------
@@ -357,7 +304,7 @@ export function daysInMonth(month: number, year: number): number {
 }
 
 export function daysInYear(year: number): number {
-  return leapYear(year) ? 366 : 365;
+  return daysInMonth(2, year) + 337;
 }
 
 // ---------------------------------------------------------------------------
@@ -389,7 +336,7 @@ export function allYear(date: Date): { start: Temporal.Instant; end: Temporal.In
 // ---------------------------------------------------------------------------
 
 export function ago(date: Date, seconds: number): Temporal.Instant {
-  return instantFrom(new Date(date.getTime() - seconds * 1000));
+  return since(date, -seconds);
 }
 
 export function since(date: Date, seconds: number): Temporal.Instant {
@@ -397,10 +344,10 @@ export function since(date: Date, seconds: number): Temporal.Instant {
 }
 
 // ---------------------------------------------------------------------------
-// changeDate
+// change
 // ---------------------------------------------------------------------------
 
-export function changeDate(
+export function change(
   date: Date,
   options: {
     year?: number;
@@ -409,16 +356,26 @@ export function changeDate(
     hour?: number;
     min?: number;
     sec?: number;
+    usec?: number;
   },
 ): Temporal.Instant {
-  const d = clone(date);
-  if (options.year !== undefined) d.setFullYear(options.year);
-  if (options.month !== undefined) d.setMonth(options.month - 1); // 1-indexed
-  if (options.day !== undefined) d.setDate(options.day);
-  if (options.hour !== undefined) d.setHours(options.hour, 0, 0, 0);
-  if (options.min !== undefined) d.setMinutes(options.min, 0, 0);
-  if (options.sec !== undefined) d.setSeconds(options.sec, 0);
-  return instantFrom(d);
+  const newYear = options.year ?? date.getFullYear();
+  const newMonth = options.month ?? date.getMonth() + 1; // 1-indexed
+  const newDay = options.day ?? date.getDate();
+  const newHour = options.hour ?? date.getHours();
+  const newMin = options.min ?? (options.hour !== undefined ? 0 : date.getMinutes());
+  const newSec =
+    options.sec ??
+    (options.hour !== undefined || options.min !== undefined ? 0 : date.getSeconds());
+  const newUsec =
+    options.usec ??
+    (options.hour !== undefined || options.min !== undefined || options.sec !== undefined
+      ? 0
+      : date.getMilliseconds() * 1000);
+
+  return instantFrom(
+    new Date(newYear, newMonth - 1, newDay, newHour, newMin, newSec, Math.floor(newUsec / 1000)),
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/time-ext.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/time-ext.json
@@ -2,176 +2,57 @@
   {
     "package": "activesupport",
     "tsFile": "time-ext.ts",
-    "rubyName": "advance",
-    "call": "change",
-    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#advance: it computes the result inline instead of delegating to `change` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-ext.ts",
-    "rubyName": "advance",
-    "call": "to_date",
-    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#advance: it computes the result inline instead of delegating to `to_date` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-ext.ts",
     "rubyName": "ago",
     "call": "in_time_zone",
-    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#ago: it computes the result inline instead of delegating to `in_time_zone` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-ext.ts",
-    "rubyName": "ago",
-    "call": "since",
-    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#ago: it computes the result inline instead of delegating to `since` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-ext.ts",
-    "rubyName": "beginning_of_day",
-    "call": "change",
-    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#beginning_of_day: it computes the result inline instead of delegating to `change` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
+    "reason": "Date#ago delegates to `in_time_zone` (date/calculations.rb:55-57) to widen a Date into a zoned Time. time-ext.ts already takes a JS `Date`, an instant, so there is no Date-to-Time widening step to delegate; it ports the Time arm (time/calculations.rb) instead."
   },
   {
     "package": "activesupport",
     "tsFile": "time-ext.ts",
     "rubyName": "beginning_of_day",
     "call": "in_time_zone",
-    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#beginning_of_day: it computes the result inline instead of delegating to `in_time_zone` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
+    "reason": "Date#beginning_of_day delegates to `in_time_zone` (date/calculations.rb:67-69) to widen a Date into a zoned Time. time-ext.ts already takes a JS `Date`, an instant, so there is no Date-to-Time widening step to delegate; it ports the Time arm (time/calculations.rb) instead."
   },
   {
     "package": "activesupport",
     "tsFile": "time-ext.ts",
-    "rubyName": "beginning_of_hour",
-    "call": "change",
-    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#beginning_of_hour: it computes the result inline instead of delegating to `change` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
+    "rubyName": "change",
+    "call": "integer?",
+    "reason": "JS `Date` carries no zone object and no per-value UTC offset, so time-ext.ts's `change` has no counterpart to Time#change's `zone.respond_to?(:utc_to_local)` / `elsif zone` arms (time/calculations.rb:150-185) and cannot route through them."
   },
   {
     "package": "activesupport",
     "tsFile": "time-ext.ts",
-    "rubyName": "beginning_of_minute",
-    "call": "change",
-    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#beginning_of_minute: it computes the result inline instead of delegating to `change` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-ext.ts",
-    "rubyName": "days_in_year",
-    "call": "days_in_month",
-    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#days_in_year: it computes the result inline instead of delegating to `days_in_month` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-ext.ts",
-    "rubyName": "end_of_day",
-    "call": "change",
-    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#end_of_day: it computes the result inline instead of delegating to `change` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
+    "rubyName": "change",
+    "call": "local",
+    "reason": "JS `Date` carries no zone object and no per-value UTC offset, so time-ext.ts's `change` has no counterpart to Time#change's `zone.respond_to?(:utc_to_local)` / `elsif zone` arms (time/calculations.rb:150-185) and cannot route through them."
   },
   {
     "package": "activesupport",
     "tsFile": "time-ext.ts",
     "rubyName": "end_of_day",
     "call": "in_time_zone",
-    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#end_of_day: it computes the result inline instead of delegating to `in_time_zone` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-ext.ts",
-    "rubyName": "end_of_hour",
-    "call": "change",
-    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#end_of_hour: it computes the result inline instead of delegating to `change` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-ext.ts",
-    "rubyName": "end_of_minute",
-    "call": "change",
-    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#end_of_minute: it computes the result inline instead of delegating to `change` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-ext.ts",
-    "rubyName": "middle_of_day",
-    "call": "change",
-    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#middle_of_day: it computes the result inline instead of delegating to `change` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
+    "reason": "Date#end_of_day delegates to `in_time_zone` (date/calculations.rb:85-87) to widen a Date into a zoned Time. time-ext.ts already takes a JS `Date`, an instant, so there is no Date-to-Time widening step to delegate; it ports the Time arm (time/calculations.rb) instead."
   },
   {
     "package": "activesupport",
     "tsFile": "time-ext.ts",
     "rubyName": "middle_of_day",
     "call": "in_time_zone",
-    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#middle_of_day: it computes the result inline instead of delegating to `in_time_zone` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-ext.ts",
-    "rubyName": "next_day",
-    "call": "advance",
-    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#next_day: it computes the result inline instead of delegating to `advance` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-ext.ts",
-    "rubyName": "next_month",
-    "call": "advance",
-    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#next_month: it computes the result inline instead of delegating to `advance` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-ext.ts",
-    "rubyName": "next_year",
-    "call": "advance",
-    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#next_year: it computes the result inline instead of delegating to `advance` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-ext.ts",
-    "rubyName": "prev_day",
-    "call": "advance",
-    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#prev_day: it computes the result inline instead of delegating to `advance` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-ext.ts",
-    "rubyName": "prev_month",
-    "call": "advance",
-    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#prev_month: it computes the result inline instead of delegating to `advance` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-ext.ts",
-    "rubyName": "prev_year",
-    "call": "advance",
-    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#prev_year: it computes the result inline instead of delegating to `advance` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-ext.ts",
-    "rubyName": "seconds_since_midnight",
-    "call": "change",
-    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#seconds_since_midnight: it computes the result inline instead of delegating to `change` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-ext.ts",
-    "rubyName": "seconds_until_end_of_day",
-    "call": "end_of_day",
-    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#seconds_until_end_of_day: it computes the result inline instead of delegating to `end_of_day` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
+    "reason": "Date#middle_of_day delegates to `in_time_zone` (date/calculations.rb:75-77) to widen a Date into a zoned Time. time-ext.ts already takes a JS `Date`, an instant, so there is no Date-to-Time widening step to delegate; it ports the Time arm (time/calculations.rb) instead."
   },
   {
     "package": "activesupport",
     "tsFile": "time-ext.ts",
     "rubyName": "since",
     "call": "in_time_zone",
-    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#since: it computes the result inline instead of delegating to `in_time_zone` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
+    "reason": "Date#since delegates to `in_time_zone` (date/calculations.rb:61-63) to widen a Date into a zoned Time. time-ext.ts already takes a JS `Date`, an instant, so there is no Date-to-Time widening step to delegate; it ports the Time arm (time/calculations.rb) instead."
   },
   {
     "package": "activesupport",
     "tsFile": "time-ext.ts",
     "rubyName": "since",
     "call": "warn",
-    "reason": "time-ext.ts is a free-function helper module over JS `Date`, not a port of Time/Date/DateTime#since: it computes the result inline instead of delegating to `warn` the way core_ext/*/calculations.rb does. Surfaced (not introduced) by pointing the three calculations.rb reopenings at this file; convergence tracked by story activesupport-core-ext-calculations-delegation."
+    "reason": "Time#since's `warn` is reached only from its `rescue TypeError` arm, which deprecates passing a non-numeric (time/calculations.rb:126-133). time-ext.ts's `since` takes `seconds: number`, so the deprecated call shape is unrepresentable and the arm has nothing to warn about."
   }
 ]


### PR DESCRIPTION
Converges `packages/activesupport/src/time-ext.ts` onto the decomposition Rails'
three `core_ext/*/calculations.rb` reopenings use, retiring 17 of the 25
call-set divergences that `api-compare-orphan-buckets-activesupport-calculations`
surfaced when it pointed those files at `time-ext.ts`.

### What changed

`changeDate` takes its Rails name, `change`, and gains Rails' `usec` key. It
also stops mutating a clone component-by-component: `Time#change`
(`time/calculations.rb:123-188`) resolves all six components first and then
constructs once, and the sequential `setMonth` / `setDate` it replaces
overflowed — `change(year, month: 2, day: 28)` on a Jan 31 receiver landed on
Mar 28, which is what made the first `advance` convergence attempt red.

Everything else routes through a primitive it used to inline:

| reader | delegates to | Rails |
| --- | --- | --- |
| `beginningOfDay` / `middleOfDay` / `endOfDay` / `beginningOfHour` / `endOfHour` / `beginningOfMinute` / `endOfMinute` | `change` | `time/calculations.rb:139-208` |
| `secondsSinceMidnight` | `change` | `time/calculations.rb:91-93` |
| `prevDay` / `nextDay` / `prevMonth` / `nextMonth` / `prevYear` / `nextYear` | `advance` | `time/calculations.rb:358-385` |
| `advance` | `toDate`, `change`, `since` | `time/calculations.rb:194-217` |
| `ago` | `since` | `time/calculations.rb:120-122` |
| `daysInYear` | `daysInMonth` | `time/calculations.rb:34-36` |
| `secondsUntilEndOfDay` | `endOfDay` | `date_time/calculations.rb:29-31` |

The navigation readers also take Rails' count parameter (`prevDay(date, days = 1)`).

### Baseline

`scripts/api-compare/call-mismatches-exclude/activesupport/time-ext.json`
shrinks 25 -> 8 rows, deleted by hand (no reseed). The 8 survivors are two
classes that cannot converge:

- `Date#ago` / `since` / `beginning_of_day` / `middle_of_day` / `end_of_day`
  delegate to `in_time_zone` to widen a Date into a zoned Time
  (`date/calculations.rb:55-87`). `time-ext.ts` already takes a JS `Date` — an
  instant — so there is no widening step to delegate; it ports the Time arm.
- `change/local` and `change/integer?` are the `Time#change` arms that need a
  per-value zone object and UTC offset (`time/calculations.rb:150-185`), which
  a JS `Date` does not carry. These two rows are that pre-existing divergence
  becoming *visible* now that the function carries its Rails name — the same
  "a newly-clean def surfaces pre-existing port divergence" pattern.
- `since/warn` is reachable only from `Time#since`'s `rescue TypeError` arm
  (`:126-133`); `since(date, seconds: number)` cannot represent the deprecated
  call shape.

`pnpm api:calls` is green. `time-ext.test.ts` and
`core-ext/{time,date,date-time}-ext.test.ts` are green (396 passed). No test
renames.

### Scope note — the other two bundled stories are released, not shipped

`pg-maria-adapter-unique-flake-burndown-round-2` and
`awaitable-mass-assignment-for-nested-attributes` were claimed with this one
and have been handed back with `pnpm tasks release`. Reasons:

**Flake burndown round 2.** I re-measured the premise rather than assuming it:
over the 399 completed `pull_request` runs in 2026-08-05T13:17Z -
2026-08-07T18:30Z, 9 of the 125 tri-adapter runs failed on PG/MariaDB but not
SQLite — **7.2%, already below the story's 9.7% baseline**. More importantly the
composition inverted: round 2 found 11 of 12 were environmental, but 8 of these
9 are real branch regressions (adapter-typed branches, both shards, repeating
across re-runs — e.g. `bundle-time-instant-datetime-utc` sending a Temporal
value to mysql2 as `'[object Object]'`). The genuine flake rate is 1/125.
Intervening work (#5986, #5998, #5884, #5720, #5685, plus the per-worker
`applySlot` database suffix) already burned the class down. The one real
instance is filed with full evidence as
`0028-ci-cost-optimization/stories/pg-adapter-test-aftereach-connect-hook-timeout`
so the measurement isn't lost.

**Awaitable mass assignment.** Its stated converged shape — make
`setAttributes` "the only path that accepts nested-attributes keys" — would make
`new Model({ shipAttributes: … })` raise. That directly contradicts an
explicitly documented invariant in `nested-attributes.ts:892-896`, which keeps
the non-displacing path synchronous precisely so the constructor builds the
associated record where Rails builds it. The narrow reading (refuse only the
*displacing* case) satisfies all three acceptance criteria but needs a
before-I/O signal threaded to the two async escape points in
`assignNestedAttributesForOneToOneAssociation`, which is invented machinery
either way. That is a design call for the story author, and the change wants
its own PR with the nested-attributes suite as validation rather than a third
of a bundle.

Closes-story: activesupport-core-ext-calculations-delegation
