### PR TITLE
fix(activerecord): t.references transcribes as bigint + default index; settle RFC 0087's residual sync writers

### DIFF
--- a/packages/activerecord/src/adapters/sqlite3/bigint-roundtrip.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/bigint-roundtrip.test.ts
@@ -58,9 +58,11 @@ describeIfSqlite("SQLite3 bigint round-trip", () => {
       42,
     ]);
     const rows = await adapter.execute(`SELECT "score", "count" FROM "big_items"`);
-    // safeIntegers is enabled on this statement (BIGINT column present),
-    // so INTEGER column also comes back as bigint from the driver.
-    // IntegerType.cast converts it back to number — this is the type-layer contract.
+    // safeIntegers is enabled on this statement (BIGINT column present), so the
+    // driver hands the INTEGER column back as a bigint too; the adapter narrows
+    // that spill at the row boundary (_narrowSpilledBigInts), and
+    // IntegerType.cast accepts either spelling — the type-layer contract holds
+    // whichever side normalizes.
     expect(intType.cast(rows[0].count)).toBe(42);
   });
 

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -157,6 +157,13 @@ export class CollectionAssociation extends Association {
    *   deferring the writes to the owner's next `save()` (where a deferred
    *   delete can race an interim insert) we throw and name the awaitable
    *   Rails-named replacement (`await owner.items.replace([...])`).
+   *
+   * RFC 0087 §1 listed this for deletion with the property setter it backed.
+   * The setter is gone; this survives deliberately, because Rails'
+   * `assign_attributes` returns nil and assigns inline
+   * (`activemodel/lib/active_model/attribute_assignment.rb:32-35`) — trails
+   * matches that, so mass assignment can never await and this is its only
+   * route into the collection writer.
    */
   syncWrite(records: Base[]): void {
     // Rails' `replace` raises a class mismatch for every element as its very

--- a/packages/activerecord/src/associations/errors.ts
+++ b/packages/activerecord/src/associations/errors.ts
@@ -372,8 +372,11 @@ export class DeleteRestrictionError extends ActiveRecordError {
  * Thrown when a `has_one` association is assigned by mass assignment —
  * `owner.assignAttributes({ account: x })`, `new Owner({ account: x })` — on a
  * *persisted* owner. (RFC 0087 §1 removed the native `=` setter that also
- * raised this; the mass-assignment arm is retired by that RFC's
- * `retire-sync-association-mass-assignment-arms`.) This is a deliberate
+ * raised this. The mass-assignment arm is the campaign's deliberate residue:
+ * Rails' `assign_attributes` returns nil and does its work inline
+ * (`activemodel/lib/active_model/attribute_assignment.rb:32-35`), so trails'
+ * `assignAttributes` stays synchronous too — which leaves this the only way to
+ * report a write it cannot await.) This is a deliberate
  * trails-only deviation with no Rails counterpart: Rails'
  * `HasOneAssociation#replace` persists the displacement + new record inline at
  * assignment, which is synchronous DB I/O JS cannot do from a property setter.
@@ -444,6 +447,11 @@ export class CollectionPersistedAssignmentError extends ActiveRecordError {
  * rather than a catchable throw, and let an immediate `save()` race the
  * in-flight resolution. See RFC
  * 0068-awaitable-has-one-setter ("Why 'loud' beats 'deferred'").
+ *
+ * RFC 0087 §1 listed this class for deletion; it survives that campaign
+ * deliberately, for the same reason {@link HasOnePersistedAssignmentError}
+ * does — mass assignment is synchronous by design, so the ids arm keeps a
+ * permanent caller.
  */
 export class CollectionIdsAssignmentError extends ActiveRecordError {
   readonly association: string;

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -49,6 +49,13 @@ export class HasOneAssociation extends SingularAssociation {
    * reach the association through a structural handle rather than the class
    * type. The Rails-named surface is `writer` / `set#{Name}`.
    *
+   * RFC 0087 §1 listed this for deletion with the `#{name}=` property setter it
+   * backed. The setter is gone; this survives deliberately, because Rails'
+   * `assign_attributes` returns nil and assigns inline
+   * (`activemodel/lib/active_model/attribute_assignment.rb:32-35`) — trails
+   * matches that, so mass assignment can never await and this stays its route
+   * into the has_one writer.
+   *
    * @internal
    */
   protected syncWrite(record: Base | null): void {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -574,14 +574,43 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
 
   // Enable readBigInts on row-returning statements that expose bigint-declared
   // columns so the driver returns JS bigint rather than a lossy number.
-  // Non-bigint integer columns in the same row also return bigint when enabled —
-  // IntegerType.cast handles bigint → number for those.
   // stmt.reader gates out PRAGMA/EXPLAIN and other non-row statements.
   private _maybeEnableReadBigInts(sql: string, stmt: SqliteStatement): void {
     if (isWriteQuerySql(sql) || !stmt.reader) return;
     const cols = stmt.columns();
     if (cols.some((c) => c.type !== null && /bigint/i.test(c.type))) {
       stmt.setReadBigInts(true);
+    }
+  }
+
+  // readBigInts is statement-wide, so enabling it for one BIGINT column also
+  // turns every INTEGER column of the same row into a bigint. Ruby has a single
+  // Integer, and Rails' raw values carry no width: `Book#status_before_type_cast`
+  // over `t.integer :status` is `2`, and `Membership`'s integer `type` reaches
+  // `EnumType#cast` as `2` — a spilled `2n` misses both. Narrow the spill back
+  // at the row boundary so only bigint-declared columns keep the wide value, and
+  // only where the value still fits a JS number (above that, a bigint is the
+  // faithful reading and the alternative is silent precision loss).
+  private _narrowSpilledBigInts(stmt: SqliteStatement, rows: Record<string, unknown>[]): void {
+    const wide = new Set(
+      stmt
+        .columns()
+        .filter((c) => c.type !== null && /bigint/i.test(c.type))
+        .map((c) => c.name),
+    );
+    if (wide.size === 0) return;
+    for (const row of rows) {
+      for (const key of Object.keys(row)) {
+        const value = row[key];
+        if (
+          typeof value === "bigint" &&
+          !wide.has(key) &&
+          value >= BigInt(Number.MIN_SAFE_INTEGER) &&
+          value <= BigInt(Number.MAX_SAFE_INTEGER)
+        ) {
+          row[key] = Number(value);
+        }
+      }
     }
   }
 
@@ -813,6 +842,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
           result = Result.empty();
         } else {
           const rows = (await stmt.all(driverBinds)) as Record<string, unknown>[];
+          this._narrowSpilledBigInts(stmt, rows);
           payload.row_count = rows.length;
           result =
             rows.length > 0

--- a/packages/activerecord/src/support/canonical-schema.ts
+++ b/packages/activerecord/src/support/canonical-schema.ts
@@ -339,7 +339,7 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
   });
 
   await define("accounts", {}, (t) => {
-    t.integer("firm_id");
+    t.bigInteger("firm_id");
     t.string("firm_name");
     t.integer("credit_limit");
     t.string("status");
@@ -365,7 +365,8 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
     t.string("json_data", { limit: 1024, null: true });
     t.string("json_data_empty", { limit: 1024, null: true, default: "" });
     t.text("params");
-    t.integer("account_id");
+    t.bigInteger("account_id");
+    t.index("account_id");
     t.json("json_options");
   });
 
@@ -379,7 +380,8 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
     t.string("json_data", { limit: 1024, null: true });
     t.string("json_data_empty", { limit: 1024, null: true, default: "" });
     t.text("params");
-    t.integer("account_id");
+    t.bigInteger("account_id");
+    t.index("account_id");
   });
 
   await define("aircraft", {}, (t) => {
@@ -392,18 +394,23 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
   await define("articles", {}, (t) => {});
 
   await define("articles_magazines", {}, (t) => {
-    t.integer("article_id");
-    t.integer("magazine_id");
+    t.bigInteger("article_id");
+    t.index("article_id");
+    t.bigInteger("magazine_id");
+    t.index("magazine_id");
   });
 
   await define("articles_tags", {}, (t) => {
-    t.integer("article_id");
-    t.integer("tag_id");
+    t.bigInteger("article_id");
+    t.index("article_id");
+    t.bigInteger("tag_id");
+    t.index("tag_id");
   });
 
   await define("attachments", {}, (t) => {
-    t.integer("record_id", { null: false });
+    t.bigInteger("record_id", { null: false });
     t.string("record_type", { null: false });
+    t.index(["record_type", "record_id"], { name: "index_attachments_on_record" });
   });
 
   await define("audit_logs", {}, (t) => {
@@ -416,8 +423,10 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
 
   await define("authors", {}, (t) => {
     t.string("name", { null: false });
-    t.integer("author_address_id");
-    t.integer("author_address_extra_id");
+    t.bigInteger("author_address_id");
+    t.index("author_address_id");
+    t.bigInteger("author_address_extra_id");
+    t.index("author_address_extra_id");
     t.string("organization_id");
     t.string("owned_essay_id");
   });
@@ -447,7 +456,8 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
   });
 
   await define("books", {}, (t) => {
-    t.integer("author_id");
+    t.bigInteger("author_id");
+    t.index("author_id");
     t.string("format");
     t.integer("format_record_id");
     t.string("format_record_type");
@@ -476,7 +486,8 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
   });
 
   await define("encrypted_books", {}, (t) => {
-    t.integer("author_id");
+    t.bigInteger("author_id");
+    t.index("author_id");
     t.string("format");
     t.string("name", { limit: 1024, default: "<untitled>" });
     t.string("original_name");
@@ -493,7 +504,8 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
   });
 
   await define("branches", {}, (t) => {
-    t.integer("branch_id");
+    t.bigInteger("branch_id");
+    t.index("branch_id");
   });
 
   await define("bulbs", { serialPk: "ID" }, (t) => {
@@ -638,7 +650,8 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
   });
 
   await define("paragraphs", {}, (t) => {
-    t.integer("book_id");
+    t.bigInteger("book_id");
+    t.index("book_id");
   });
 
   await define("clothing_items", {}, (t) => {
@@ -655,8 +668,9 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
 
   await define("sharded_blog_posts", {}, (t) => {
     t.string("title");
-    t.integer("parent_id");
+    t.bigInteger("parent_id");
     t.string("parent_type");
+    t.index(["parent_type", "parent_id"], { name: "index_sharded_blog_posts_on_parent" });
     t.integer("blog_id");
     t.integer("revision");
   });
@@ -692,7 +706,8 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
   });
 
   await define("columns", {}, (t) => {
-    t.integer("record_id");
+    t.bigInteger("record_id");
+    t.index("record_id");
   });
 
   await define("comments", {}, (t) => {
@@ -703,8 +718,9 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
     t.integer("tags_count", { default: 0 });
     t.integer("children_count", { default: 0 });
     t.integer("parent_id");
-    t.integer("author_id");
+    t.bigInteger("author_id");
     t.string("author_type");
+    t.index(["author_type", "author_id"], { name: "index_comments_on_author" });
     t.string("resource_id");
     t.string("resource_type");
     t.integer("origin_id");
@@ -719,13 +735,13 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
   await define("comment_overlapping_counter_caches", {}, (t) => {
     t.integer("user_comments_count_id");
     t.integer("post_comments_count_id");
-    t.integer("commentable_id");
+    t.bigInteger("commentable_id");
     t.string("commentable_type");
   });
 
   await define("companies", {}, (t) => {
     t.string("type");
-    t.integer("firm_id");
+    t.bigInteger("firm_id");
     t.string("firm_name");
     t.string("name");
     t.bigInteger("client_of");
@@ -779,15 +795,17 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
   });
 
   await define("computers_developers", { id: false }, (t) => {
-    t.integer("computer_id");
-    t.integer("developer_id");
+    t.bigInteger("computer_id");
+    t.index("computer_id");
+    t.bigInteger("developer_id");
+    t.index("developer_id");
     t.datetime("created_at");
     t.datetime("updated_at");
   });
 
   await define("contracts", {}, (t) => {
-    t.integer("developer_id");
-    t.integer("company_id");
+    t.bigInteger("developer_id");
+    t.bigInteger("company_id");
     t.string("metadata");
     t.integer("count");
   });
@@ -802,8 +820,10 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
   });
 
   await define("customer_carriers", {}, (t) => {
-    t.integer("customer_id");
-    t.integer("carrier_id");
+    t.bigInteger("customer_id");
+    t.index("customer_id");
+    t.bigInteger("carrier_id");
+    t.index("carrier_id");
   });
 
   await define("dashboards", { id: false }, (t) => {
@@ -828,23 +848,28 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
 
   await define("dl_keyed_belongs_tos", { serialPk: "belongs_key" }, (t) => {
     t.integer("belongs_key");
-    t.integer("destroy_async_parent_id");
+    t.bigInteger("destroy_async_parent_id");
+    t.index("destroy_async_parent_id");
   });
 
   await define("dl_keyed_belongs_to_soft_deletes", {}, (t) => {
-    t.integer("destroy_async_parent_soft_delete_id");
+    t.bigInteger("destroy_async_parent_soft_delete_id");
+    t.index("destroy_async_parent_soft_delete_id", { name: "soft_del_parent" });
     t.boolean("deleted");
   });
 
   await define("dl_keyed_has_ones", { serialPk: "has_one_key" }, (t) => {
     t.integer("has_one_key");
-    t.integer("destroy_async_parent_id");
-    t.integer("destroy_async_parent_soft_delete_id");
+    t.bigInteger("destroy_async_parent_id");
+    t.index("destroy_async_parent_id");
+    t.bigInteger("destroy_async_parent_soft_delete_id");
+    t.index("destroy_async_parent_soft_delete_id");
   });
 
   await define("dl_keyed_has_manies", { serialPk: "many_key" }, (t) => {
     t.integer("many_key");
-    t.integer("destroy_async_parent_id");
+    t.bigInteger("destroy_async_parent_id");
+    t.index("destroy_async_parent_id");
   });
 
   await define("dl_keyed_has_many_throughs", { serialPk: "through_key" }, (t) => {
@@ -853,15 +878,17 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
 
   await define("dl_keyed_joins", { serialPk: "joins_key" }, (t) => {
     t.integer("joins_key");
-    t.integer("destroy_async_parent_id");
-    t.integer("dl_keyed_has_many_through_id");
+    t.bigInteger("destroy_async_parent_id");
+    t.index("destroy_async_parent_id");
+    t.bigInteger("dl_keyed_has_many_through_id");
+    t.index("dl_keyed_has_many_through_id");
   });
 
   await define("developers", {}, (t) => {
     t.string("name");
     t.string("first_name");
     t.integer("salary", { default: 70000 });
-    t.integer("firm_id");
+    t.bigInteger("firm_id");
     t.integer("mentor_id");
     t.datetime("legacy_created_at");
     t.datetime("legacy_updated_at");
@@ -931,7 +958,8 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
     t.string("writer_type");
     t.string("category_id");
     t.string("author_id");
-    t.integer("book_id");
+    t.bigInteger("book_id");
+    t.index("book_id");
   });
 
   await define("events", {}, (t) => {
@@ -943,8 +971,10 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
   await define("families", {}, (t) => {});
 
   await define("family_trees", {}, (t) => {
-    t.integer("family_id");
-    t.integer("member_id");
+    t.bigInteger("family_id");
+    t.index("family_id");
+    t.bigInteger("member_id");
+    t.index("member_id");
     t.string("token");
   });
 
@@ -1006,7 +1036,8 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
   });
 
   await define("iris", {}, (t) => {
-    t.integer("eye_id");
+    t.bigInteger("eye_id");
+    t.index("eye_id");
     t.string("color");
   });
 
@@ -1019,8 +1050,10 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
   });
 
   await define("jobs_pool", { id: false }, (t) => {
-    t.integer("job_id", { null: false });
-    t.integer("user_id", { null: false });
+    t.bigInteger("job_id", { null: false });
+    t.index("job_id");
+    t.bigInteger("user_id", { null: false });
+    t.index("user_id");
   });
 
   await define("keyboards", { serialPk: "key_number" }, (t) => {
@@ -1041,7 +1074,9 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
 
   await define("lessons_students", { id: false }, (t) => {
     t.bigInteger("lesson_id");
+    t.index("lesson_id");
     t.bigInteger("student_id");
+    t.index("student_id");
   });
 
   await define("students", {}, (t) => {
@@ -1091,8 +1126,8 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
 
   await define("members", {}, (t) => {
     t.string("name");
-    t.integer("member_type_id");
-    t.integer("admittable_id");
+    t.bigInteger("member_type_id");
+    t.bigInteger("admittable_id");
     t.string("admittable_type");
   });
 
@@ -1235,37 +1270,49 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
   await define("treasures", {}, (t) => {
     t.string("name");
     t.string("type");
-    t.integer("looter_id");
+    t.bigInteger("looter_id");
     t.string("looter_type");
-    t.integer("ship_id");
+    t.index(["looter_type", "looter_id"], { name: "index_treasures_on_looter" });
+    t.bigInteger("ship_id");
+    t.index("ship_id");
   });
 
   await define("parrots_pirates", { id: false }, (t) => {
-    t.integer("parrot_id");
-    t.integer("pirate_id");
+    t.bigInteger("parrot_id");
+    t.index("parrot_id");
+    t.bigInteger("pirate_id");
+    t.index("pirate_id");
   });
 
   await define("parrots_treasures", { id: false }, (t) => {
-    t.integer("parrot_id");
-    t.integer("treasure_id");
+    t.bigInteger("parrot_id");
+    t.index("parrot_id");
+    t.bigInteger("treasure_id");
+    t.index("treasure_id");
   });
 
   await define("parrot_treasures", { id: false }, (t) => {
-    t.integer("parrot_id");
-    t.integer("treasure_id");
+    t.bigInteger("parrot_id");
+    t.index("parrot_id");
+    t.bigInteger("treasure_id");
+    t.index("treasure_id");
   });
 
   await define("people", {}, (t) => {
     t.string("first_name", { null: false });
-    t.integer("primary_contact_id");
+    t.bigInteger("primary_contact_id");
+    t.index("primary_contact_id");
     t.string("gender", { limit: 1 });
-    t.integer("number1_fan_id");
+    t.bigInteger("number1_fan_id");
+    t.index("number1_fan_id");
     t.integer("lock_version", { null: false, default: 0 });
     t.string("comments");
     t.integer("followers_count", { default: 0 });
     t.integer("friends_too_count", { default: 0 });
-    t.integer("best_friend_id");
-    t.integer("best_friend_of_id");
+    t.bigInteger("best_friend_id");
+    t.index("best_friend_id");
+    t.bigInteger("best_friend_of_id");
+    t.index("best_friend_of_id");
     t.integer("insures", { null: false, default: 0 });
     t.datetime("born_at");
     t.integer("cars_count", { default: 0 });
@@ -1303,7 +1350,7 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
     // Rails: `t.references :author` — references default `index: true`, so
     // schema.rb emits index_posts_on_author_id (load-bearing for the SQLite
     // explain eager-loading plan: SEARCH posts USING INDEX, not SCAN).
-    t.integer("author_id");
+    t.bigInteger("author_id");
     t.index("author_id", { name: "index_posts_on_author_id" });
     t.string("title", { null: false });
     t.text("body", { null: false });
@@ -1344,8 +1391,10 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
   });
 
   await define("products", {}, (t) => {
-    t.integer("collection_id");
-    t.integer("type_id");
+    t.bigInteger("collection_id");
+    t.index("collection_id");
+    t.bigInteger("type_id");
+    t.index("type_id");
     t.string("name");
     t.decimal("price");
     t.decimal("discounted_price");
@@ -1358,7 +1407,7 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
   await define("projects", {}, (t) => {
     t.string("name");
     t.string("type");
-    t.integer("firm_id");
+    t.bigInteger("firm_id");
     t.integer("mentor_id");
   });
 
@@ -1402,10 +1451,14 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
   });
 
   await define("rooms", {}, (t) => {
-    t.integer("user_id");
-    t.integer("owner_id");
-    t.integer("landlord_id");
-    t.integer("tenant_id");
+    t.bigInteger("user_id");
+    t.index("user_id");
+    t.bigInteger("owner_id");
+    t.index("owner_id");
+    t.bigInteger("landlord_id");
+    t.index("landlord_id");
+    t.bigInteger("tenant_id");
+    t.index("tenant_id");
   });
 
   await define("seminars", {}, (t) => {
@@ -1468,12 +1521,15 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
   });
 
   await define("sinks", {}, (t) => {
-    t.integer("kitchen_id");
+    t.bigInteger("kitchen_id");
+    t.index("kitchen_id");
   });
 
   await define("shop_accounts", {}, (t) => {
-    t.integer("customer_id");
-    t.integer("customer_carrier_id");
+    t.bigInteger("customer_id");
+    t.index("customer_id");
+    t.bigInteger("customer_carrier_id");
+    t.index("customer_carrier_id");
   });
 
   await define("speedometers", { id: false }, (t) => {
@@ -1484,9 +1540,9 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
 
   await define("sponsors", {}, (t) => {
     t.integer("club_id");
-    t.integer("sponsorable_id");
+    t.bigInteger("sponsorable_id");
     t.string("sponsorable_type");
-    t.integer("sponsor_id");
+    t.bigInteger("sponsor_id");
     t.string("sponsor_type");
   });
 
@@ -1572,7 +1628,8 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
     t.string("locale", { null: false });
     t.string("key", { null: false });
     t.string("value", { null: false });
-    t.integer("attachment_id");
+    t.bigInteger("attachment_id");
+    t.index("attachment_id");
   });
 
   await define("tuning_pegs", {}, (t) => {
@@ -1591,7 +1648,8 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
   });
 
   await define("variants", {}, (t) => {
-    t.integer("product_id");
+    t.bigInteger("product_id");
+    t.index("product_id");
     t.string("name");
   });
 
@@ -1626,7 +1684,7 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
     t.string("poly_human_without_inverse_type");
     t.integer("puzzled_polymorphic_human_id");
     t.string("puzzled_polymorphic_human_type");
-    t.integer("super_human_id");
+    t.bigInteger("super_human_id");
     t.string("super_human_type");
   });
 
@@ -1648,8 +1706,9 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
 
   await define("wheels", {}, (t) => {
     t.integer("size");
-    t.integer("wheelable_id");
+    t.bigInteger("wheelable_id");
     t.string("wheelable_type");
+    t.index(["wheelable_type", "wheelable_id"], { name: "index_wheels_on_wheelable" });
   });
 
   await define("countries", { primaryKey: ["country_id"] }, (t) => {
@@ -1813,8 +1872,8 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
   });
 
   await define("courses_professors", { id: false, arunit2: true }, (t) => {
-    t.integer("course_id");
-    t.integer("professor_id");
+    t.bigInteger("course_id");
+    t.bigInteger("professor_id");
     t.index("course_id");
     t.index("professor_id");
   });

--- a/packages/activerecord/src/test-fixtures.test.ts
+++ b/packages/activerecord/src/test-fixtures.test.ts
@@ -278,15 +278,19 @@ describe("useFixtures by registry name", () => {
     // authors.david.author_address_id = ref("author_addresses", "david_address"),
     // and author_addresses.david_address declares id: 1. Read the persisted FK
     // straight from the row so the assertion doesn't depend on a reflected getter.
+    // Both columns are `t.references` bigints (schema.rb:91, 973), and a raw read
+    // hands back each driver's own wide-integer spelling — bigint on SQLite
+    // (readBigInts), a decimal string from node-postgres' int8 — so compare the
+    // numeric value rather than the driver's representation of it.
     const [a] = await Base.adapter.execute(
       `SELECT author_address_id FROM ${Base.adapter.quoteTableName(Author.tableName)} WHERE id = 1`,
     );
-    expect((a as { author_address_id: number }).author_address_id).toBe(1);
+    expect(Number((a as { author_address_id: unknown }).author_address_id)).toBe(1);
     // posts.welcome.author_id = ref("authors", "david"), authors.david declares id: 1.
     const [p] = await Base.adapter.execute(
       `SELECT author_id FROM ${Base.adapter.quoteTableName(Post.tableName)} WHERE id = 1`,
     );
-    expect((p as { author_id: number }).author_id).toBe(1);
+    expect(Number((p as { author_id: unknown }).author_id)).toBe(1);
   });
 
   it("isolation part 1 — a delete lands within the test", async () => {

--- a/packages/activerecord/src/test-helpers/test-schema.ts
+++ b/packages/activerecord/src/test-helpers/test-schema.ts
@@ -32,7 +32,7 @@ export const TEST_SCHEMA: Schema = {
   },
 
   accounts: {
-    firm_id: "integer",
+    firm_id: "big_integer",
     firm_name: "string",
     credit_limit: "integer",
     status: "string",
@@ -51,33 +51,39 @@ export const TEST_SCHEMA: Schema = {
   },
 
   admin_users: {
-    name: "string",
-    region_id: "integer",
-    settings: { type: "string", null: true, limit: 1024 },
-    parent: { type: "string", null: true, limit: 1024 },
-    spouse: { type: "string", null: true, limit: 1024 },
-    configs: { type: "string", null: true, limit: 1024 },
-    // MySQL does not allow defaults on blobs; Rails fakes it with a large
-    // varchar, mirrored here.
-    preferences: { type: "string", null: true, default: "", limit: 1024 },
-    json_data: { type: "string", null: true, limit: 1024 },
-    json_data_empty: { type: "string", null: true, default: "", limit: 1024 },
-    params: "text",
-    account_id: "integer",
-    json_options: "json",
+    columns: {
+      name: "string",
+      region_id: "integer",
+      settings: { type: "string", null: true, limit: 1024 },
+      parent: { type: "string", null: true, limit: 1024 },
+      spouse: { type: "string", null: true, limit: 1024 },
+      configs: { type: "string", null: true, limit: 1024 },
+      // MySQL does not allow defaults on blobs; Rails fakes it with a large
+      // varchar, mirrored here.
+      preferences: { type: "string", null: true, default: "", limit: 1024 },
+      json_data: { type: "string", null: true, limit: 1024 },
+      json_data_empty: { type: "string", null: true, default: "", limit: 1024 },
+      params: "text",
+      account_id: "big_integer",
+      json_options: "json",
+    },
+    indexes: [{ columns: "account_id" }],
   },
 
   admin_user_jsons: {
-    name: "string",
-    settings: { type: "string", null: true, limit: 1024 },
-    parent: { type: "string", null: true, limit: 1024 },
-    spouse: { type: "string", null: true, limit: 1024 },
-    configs: { type: "string", null: true, limit: 1024 },
-    preferences: { type: "string", null: true, default: "", limit: 1024 },
-    json_data: { type: "string", null: true, limit: 1024 },
-    json_data_empty: { type: "string", null: true, default: "", limit: 1024 },
-    params: "text",
-    account_id: "integer",
+    columns: {
+      name: "string",
+      settings: { type: "string", null: true, limit: 1024 },
+      parent: { type: "string", null: true, limit: 1024 },
+      spouse: { type: "string", null: true, limit: 1024 },
+      configs: { type: "string", null: true, limit: 1024 },
+      preferences: { type: "string", null: true, default: "", limit: 1024 },
+      json_data: { type: "string", null: true, limit: 1024 },
+      json_data_empty: { type: "string", null: true, default: "", limit: 1024 },
+      params: "text",
+      account_id: "big_integer",
+    },
+    indexes: [{ columns: "account_id" }],
   },
 
   aircraft: {
@@ -90,19 +96,28 @@ export const TEST_SCHEMA: Schema = {
   articles: {},
 
   articles_magazines: {
-    article_id: "integer",
-    magazine_id: "integer",
+    columns: {
+      article_id: "big_integer",
+      magazine_id: "big_integer",
+    },
+    indexes: [{ columns: "article_id" }, { columns: "magazine_id" }],
   },
 
   articles_tags: {
-    article_id: "integer",
-    tag_id: "integer",
+    columns: {
+      article_id: "big_integer",
+      tag_id: "big_integer",
+    },
+    indexes: [{ columns: "article_id" }, { columns: "tag_id" }],
   },
 
   attachments: {
-    // Polymorphic reference expanded:
-    record_id: { type: "integer", null: false },
-    record_type: { type: "string", null: false },
+    columns: {
+      // Polymorphic reference expanded:
+      record_id: { type: "big_integer", null: false },
+      record_type: { type: "string", null: false },
+    },
+    indexes: [{ columns: ["record_type", "record_id"], name: "index_attachments_on_record" }],
   },
 
   audit_logs: {
@@ -114,11 +129,14 @@ export const TEST_SCHEMA: Schema = {
   author_addresses: {},
 
   authors: {
-    name: { type: "string", null: false },
-    author_address_id: "integer",
-    author_address_extra_id: "integer",
-    organization_id: "string",
-    owned_essay_id: "string",
+    columns: {
+      name: { type: "string", null: false },
+      author_address_id: "big_integer",
+      author_address_extra_id: "big_integer",
+      organization_id: "string",
+      owned_essay_id: "string",
+    },
+    indexes: [{ columns: "author_address_id" }, { columns: "author_address_extra_id" }],
   },
 
   author_favorites: {
@@ -162,7 +180,7 @@ export const TEST_SCHEMA: Schema = {
   // ids fit either width, so the override is dropped.
   books: {
     columns: {
-      author_id: "integer",
+      author_id: "big_integer",
       format: "string",
       format_record_id: "integer",
       format_record_type: "string",
@@ -194,17 +212,21 @@ export const TEST_SCHEMA: Schema = {
       { columns: ["author_id", "name"], unique: true },
       { columns: "isbn", unique: true, where: "published_on IS NOT NULL" },
       { columns: "(lower(external_id))", unique: true },
+      { columns: "author_id" },
     ],
   },
 
   encrypted_books: {
-    author_id: "integer",
-    format: "string",
-    name: { type: "string", default: "<untitled>", limit: 1024 },
-    original_name: "string",
-    logo: "binary",
-    created_at: "datetime",
-    updated_at: "datetime",
+    columns: {
+      author_id: "big_integer",
+      format: "string",
+      name: { type: "string", default: "<untitled>", limit: 1024 },
+      original_name: "string",
+      logo: "binary",
+      created_at: "datetime",
+      updated_at: "datetime",
+    },
+    indexes: [{ columns: "author_id" }],
   },
 
   hardbacks: {},
@@ -215,7 +237,10 @@ export const TEST_SCHEMA: Schema = {
   },
 
   branches: {
-    branch_id: "integer",
+    columns: {
+      branch_id: "big_integer",
+    },
+    indexes: [{ columns: "branch_id" }],
   },
 
   bulbs: {
@@ -399,7 +424,10 @@ export const TEST_SCHEMA: Schema = {
   },
 
   paragraphs: {
-    book_id: "integer",
+    columns: {
+      book_id: "big_integer",
+    },
+    indexes: [{ columns: "book_id" }],
   },
 
   clothing_items: {
@@ -415,11 +443,16 @@ export const TEST_SCHEMA: Schema = {
   },
 
   sharded_blog_posts: {
-    title: "string",
-    parent_id: "integer",
-    parent_type: "string",
-    blog_id: "integer",
-    revision: "integer",
+    columns: {
+      title: "string",
+      parent_id: "big_integer",
+      parent_type: "string",
+      blog_id: "integer",
+      revision: "integer",
+    },
+    indexes: [
+      { columns: ["parent_type", "parent_id"], name: "index_sharded_blog_posts_on_parent" },
+    ],
   },
 
   sharded_comments: {
@@ -453,42 +486,48 @@ export const TEST_SCHEMA: Schema = {
   },
 
   columns: {
-    record_id: "integer",
+    columns: {
+      record_id: "big_integer",
+    },
+    indexes: [{ columns: "record_id" }],
   },
 
   comments: {
-    post_id: { type: "integer", null: false },
-    body: { type: "text", null: false },
-    type: "string",
-    label: { type: "integer", default: 0 },
-    tags_count: { type: "integer", default: 0 },
-    children_count: { type: "integer", default: 0 },
-    parent_id: "integer",
-    author_id: "integer",
-    author_type: "string",
-    // Rails comment: kept as string so preload works when types don't match.
-    resource_id: "string",
-    resource_type: "string",
-    origin_id: "integer",
-    origin_type: "string",
-    developer_id: "integer",
-    updated_at: "datetime",
-    deleted_at: "datetime",
-    comments: "integer",
-    company: "integer",
+    columns: {
+      post_id: { type: "integer", null: false },
+      body: { type: "text", null: false },
+      type: "string",
+      label: { type: "integer", default: 0 },
+      tags_count: { type: "integer", default: 0 },
+      children_count: { type: "integer", default: 0 },
+      parent_id: "integer",
+      author_id: "big_integer",
+      author_type: "string",
+      // Rails comment: kept as string so preload works when types don't match.
+      resource_id: "string",
+      resource_type: "string",
+      origin_id: "integer",
+      origin_type: "string",
+      developer_id: "integer",
+      updated_at: "datetime",
+      deleted_at: "datetime",
+      comments: "integer",
+      company: "integer",
+    },
+    indexes: [{ columns: ["author_type", "author_id"], name: "index_comments_on_author" }],
   },
 
   comment_overlapping_counter_caches: {
     user_comments_count_id: "integer",
     post_comments_count_id: "integer",
-    commentable_id: "integer",
+    commentable_id: "big_integer",
     commentable_type: "string",
   },
 
   companies: {
     columns: {
       type: "string",
-      firm_id: "integer",
+      firm_id: "big_integer",
       firm_name: "string",
       name: "string",
       client_of: "big_integer",
@@ -562,11 +601,12 @@ export const TEST_SCHEMA: Schema = {
   // Rails declares `id: false` — pure join table, no synthetic PK.
   computers_developers: {
     columns: {
-      computer_id: "integer",
-      developer_id: "integer",
+      computer_id: "big_integer",
+      developer_id: "big_integer",
       created_at: "datetime",
       updated_at: "datetime",
     },
+    indexes: [{ columns: "computer_id" }, { columns: "developer_id" }],
     primaryKey: false,
   },
 
@@ -577,8 +617,8 @@ export const TEST_SCHEMA: Schema = {
   // `having` row Rails sandwiches between goofy_string_id and guids).
 
   contracts: {
-    developer_id: "integer",
-    company_id: "integer",
+    developer_id: "big_integer",
+    company_id: "big_integer",
     metadata: "string",
     count: "integer",
   },
@@ -593,8 +633,11 @@ export const TEST_SCHEMA: Schema = {
   },
 
   customer_carriers: {
-    customer_id: "integer",
-    carrier_id: "integer",
+    columns: {
+      customer_id: "big_integer",
+      carrier_id: "big_integer",
+    },
+    indexes: [{ columns: "customer_id" }, { columns: "carrier_id" }],
   },
 
   // Rails declares `id: false` with a string `dashboard_id` column — the
@@ -628,30 +671,39 @@ export const TEST_SCHEMA: Schema = {
   dl_keyed_belongs_tos: {
     columns: {
       belongs_key: "integer",
-      destroy_async_parent_id: "integer",
+      destroy_async_parent_id: "big_integer",
     },
+    indexes: [{ columns: "destroy_async_parent_id" }],
     primaryKey: ["belongs_key"],
   },
 
   dl_keyed_belongs_to_soft_deletes: {
-    destroy_async_parent_soft_delete_id: "integer",
-    deleted: "boolean",
+    columns: {
+      destroy_async_parent_soft_delete_id: "big_integer",
+      deleted: "boolean",
+    },
+    indexes: [{ columns: "destroy_async_parent_soft_delete_id", name: "soft_del_parent" }],
   },
 
   dl_keyed_has_ones: {
     columns: {
       has_one_key: "integer",
-      destroy_async_parent_id: "integer",
-      destroy_async_parent_soft_delete_id: "integer",
+      destroy_async_parent_id: "big_integer",
+      destroy_async_parent_soft_delete_id: "big_integer",
     },
+    indexes: [
+      { columns: "destroy_async_parent_id" },
+      { columns: "destroy_async_parent_soft_delete_id" },
+    ],
     primaryKey: ["has_one_key"],
   },
 
   dl_keyed_has_manies: {
     columns: {
       many_key: "integer",
-      destroy_async_parent_id: "integer",
+      destroy_async_parent_id: "big_integer",
     },
+    indexes: [{ columns: "destroy_async_parent_id" }],
     primaryKey: ["many_key"],
   },
 
@@ -665,9 +717,10 @@ export const TEST_SCHEMA: Schema = {
   dl_keyed_joins: {
     columns: {
       joins_key: "integer",
-      destroy_async_parent_id: "integer",
-      dl_keyed_has_many_through_id: "integer",
+      destroy_async_parent_id: "big_integer",
+      dl_keyed_has_many_through_id: "big_integer",
     },
+    indexes: [{ columns: "destroy_async_parent_id" }, { columns: "dl_keyed_has_many_through_id" }],
     primaryKey: ["joins_key"],
   },
 
@@ -675,7 +728,7 @@ export const TEST_SCHEMA: Schema = {
     name: "string",
     first_name: "string",
     salary: { type: "integer", default: 70000 },
-    firm_id: "integer",
+    firm_id: "big_integer",
     mentor_id: "integer",
     legacy_created_at: "datetime",
     legacy_updated_at: "datetime",
@@ -754,13 +807,16 @@ export const TEST_SCHEMA: Schema = {
   },
 
   essays: {
-    type: "string",
-    name: "string",
-    writer_id: "string",
-    writer_type: "string",
-    category_id: "string",
-    author_id: "string",
-    book_id: "integer",
+    columns: {
+      type: "string",
+      name: "string",
+      writer_id: "string",
+      writer_type: "string",
+      category_id: "string",
+      author_id: "string",
+      book_id: "big_integer",
+    },
+    indexes: [{ columns: "book_id" }],
   },
 
   events: {
@@ -772,9 +828,12 @@ export const TEST_SCHEMA: Schema = {
   families: {},
 
   family_trees: {
-    family_id: "integer",
-    member_id: "integer",
-    token: "string",
+    columns: {
+      family_id: "big_integer",
+      member_id: "big_integer",
+      token: "string",
+    },
+    indexes: [{ columns: "family_id" }, { columns: "member_id" }],
   },
 
   frogs: {
@@ -852,8 +911,11 @@ export const TEST_SCHEMA: Schema = {
   },
 
   iris: {
-    eye_id: "integer",
-    color: "string",
+    columns: {
+      eye_id: "big_integer",
+      color: "string",
+    },
+    indexes: [{ columns: "eye_id" }],
   },
 
   items: {
@@ -866,9 +928,10 @@ export const TEST_SCHEMA: Schema = {
 
   jobs_pool: {
     columns: {
-      job_id: { type: "integer", null: false },
-      user_id: { type: "integer", null: false },
+      job_id: { type: "big_integer", null: false },
+      user_id: { type: "big_integer", null: false },
     },
+    indexes: [{ columns: "job_id" }, { columns: "user_id" }],
     primaryKey: false,
   },
 
@@ -901,6 +964,7 @@ export const TEST_SCHEMA: Schema = {
       lesson_id: "big_integer",
       student_id: "big_integer",
     },
+    indexes: [{ columns: "lesson_id" }, { columns: "student_id" }],
     primaryKey: false,
   },
 
@@ -957,8 +1021,8 @@ export const TEST_SCHEMA: Schema = {
 
   members: {
     name: "string",
-    member_type_id: "integer",
-    admittable_id: "integer",
+    member_type_id: "big_integer",
+    admittable_id: "big_integer",
     admittable_type: "string",
   },
 
@@ -1122,53 +1186,70 @@ export const TEST_SCHEMA: Schema = {
   },
 
   treasures: {
-    name: "string",
-    type: "string",
-    looter_id: "integer",
-    looter_type: "string",
-    ship_id: "integer",
+    columns: {
+      name: "string",
+      type: "string",
+      looter_id: "big_integer",
+      looter_type: "string",
+      ship_id: "big_integer",
+    },
+    indexes: [
+      { columns: ["looter_type", "looter_id"], name: "index_treasures_on_looter" },
+      { columns: "ship_id" },
+    ],
   },
 
   parrots_pirates: {
     columns: {
-      parrot_id: "integer",
-      pirate_id: "integer",
+      parrot_id: "big_integer",
+      pirate_id: "big_integer",
     },
+    indexes: [{ columns: "parrot_id" }, { columns: "pirate_id" }],
     primaryKey: false,
   },
 
   parrots_treasures: {
     columns: {
-      parrot_id: "integer",
-      treasure_id: "integer",
+      parrot_id: "big_integer",
+      treasure_id: "big_integer",
     },
+    indexes: [{ columns: "parrot_id" }, { columns: "treasure_id" }],
     primaryKey: false,
   },
 
   parrot_treasures: {
     columns: {
-      parrot_id: "integer",
-      treasure_id: "integer",
+      parrot_id: "big_integer",
+      treasure_id: "big_integer",
     },
+    indexes: [{ columns: "parrot_id" }, { columns: "treasure_id" }],
     primaryKey: false,
   },
 
   people: {
-    first_name: { type: "string", null: false },
-    primary_contact_id: "integer",
-    gender: { type: "string", limit: 1 },
-    number1_fan_id: "integer",
-    lock_version: { type: "integer", null: false, default: 0 },
-    comments: "string",
-    followers_count: { type: "integer", default: 0 },
-    friends_too_count: { type: "integer", default: 0 },
-    best_friend_id: "integer",
-    best_friend_of_id: "integer",
-    insures: { type: "integer", null: false, default: 0 },
-    born_at: "datetime",
-    cars_count: { type: "integer", default: 0 },
-    created_at: { type: "datetime", null: false },
-    updated_at: { type: "datetime", null: false },
+    columns: {
+      first_name: { type: "string", null: false },
+      primary_contact_id: "big_integer",
+      gender: { type: "string", limit: 1 },
+      number1_fan_id: "big_integer",
+      lock_version: { type: "integer", null: false, default: 0 },
+      comments: "string",
+      followers_count: { type: "integer", default: 0 },
+      friends_too_count: { type: "integer", default: 0 },
+      best_friend_id: "big_integer",
+      best_friend_of_id: "big_integer",
+      insures: { type: "integer", null: false, default: 0 },
+      born_at: "datetime",
+      cars_count: { type: "integer", default: 0 },
+      created_at: { type: "datetime", null: false },
+      updated_at: { type: "datetime", null: false },
+    },
+    indexes: [
+      { columns: "primary_contact_id" },
+      { columns: "number1_fan_id" },
+      { columns: "best_friend_id" },
+      { columns: "best_friend_of_id" },
+    ],
   },
 
   peoples_treasures: {
@@ -1207,7 +1288,7 @@ export const TEST_SCHEMA: Schema = {
 
   posts: {
     columns: {
-      author_id: "integer",
+      author_id: "big_integer",
       title: { type: "string", null: false },
       body: { type: "text", null: false },
       type: "string",
@@ -1256,11 +1337,14 @@ export const TEST_SCHEMA: Schema = {
   },
 
   products: {
-    collection_id: "integer",
-    type_id: "integer",
-    name: "string",
-    price: "decimal",
-    discounted_price: "decimal",
+    columns: {
+      collection_id: "big_integer",
+      type_id: "big_integer",
+      name: "string",
+      price: "decimal",
+      discounted_price: "decimal",
+    },
+    indexes: [{ columns: "collection_id" }, { columns: "type_id" }],
   },
 
   product_types: {
@@ -1270,7 +1354,7 @@ export const TEST_SCHEMA: Schema = {
   projects: {
     name: "string",
     type: "string",
-    firm_id: "integer",
+    firm_id: "big_integer",
     mentor_id: "integer",
   },
 
@@ -1314,10 +1398,18 @@ export const TEST_SCHEMA: Schema = {
   },
 
   rooms: {
-    user_id: "integer",
-    owner_id: "integer",
-    landlord_id: "integer",
-    tenant_id: "integer",
+    columns: {
+      user_id: "big_integer",
+      owner_id: "big_integer",
+      landlord_id: "big_integer",
+      tenant_id: "big_integer",
+    },
+    indexes: [
+      { columns: "user_id" },
+      { columns: "owner_id" },
+      { columns: "landlord_id" },
+      { columns: "tenant_id" },
+    ],
   },
 
   // PR 0.5f group: S-W range in Rails source order. Covers the second
@@ -1383,11 +1475,19 @@ export const TEST_SCHEMA: Schema = {
 
   prisoners: { ship_id: "integer" },
 
-  sinks: { kitchen_id: "integer" },
+  sinks: {
+    columns: {
+      kitchen_id: "big_integer",
+    },
+    indexes: [{ columns: "kitchen_id" }],
+  },
 
   shop_accounts: {
-    customer_id: "integer",
-    customer_carrier_id: "integer",
+    columns: {
+      customer_id: "big_integer",
+      customer_carrier_id: "big_integer",
+    },
+    indexes: [{ columns: "customer_id" }, { columns: "customer_carrier_id" }],
   },
 
   // Rails declares `id: false` with a string `speedometer_id` column; the
@@ -1403,9 +1503,9 @@ export const TEST_SCHEMA: Schema = {
 
   sponsors: {
     club_id: "integer",
-    sponsorable_id: "integer",
+    sponsorable_id: "big_integer",
     sponsorable_type: "string",
-    sponsor_id: "integer",
+    sponsor_id: "big_integer",
     sponsor_type: "string",
   },
 
@@ -1510,10 +1610,13 @@ export const TEST_SCHEMA: Schema = {
   },
 
   translations: {
-    locale: { type: "string", null: false },
-    key: { type: "string", null: false },
-    value: { type: "string", null: false },
-    attachment_id: "integer",
+    columns: {
+      locale: { type: "string", null: false },
+      key: { type: "string", null: false },
+      value: { type: "string", null: false },
+      attachment_id: "big_integer",
+    },
+    indexes: [{ columns: "attachment_id" }],
   },
 
   tuning_pegs: {
@@ -1528,8 +1631,11 @@ export const TEST_SCHEMA: Schema = {
   unused_belongs_to: { unused_destroy_async_id: "integer" },
 
   variants: {
-    product_id: "integer",
-    name: "string",
+    columns: {
+      product_id: "big_integer",
+      name: "string",
+    },
+    indexes: [{ columns: "product_id" }],
   },
 
   vertices: { label: "string" },
@@ -1557,7 +1663,7 @@ export const TEST_SCHEMA: Schema = {
     poly_human_without_inverse_type: "string",
     puzzled_polymorphic_human_id: "integer",
     puzzled_polymorphic_human_type: "string",
-    super_human_id: "integer",
+    super_human_id: "big_integer",
     super_human_type: "string",
   },
 
@@ -1573,9 +1679,12 @@ export const TEST_SCHEMA: Schema = {
   strict_zines: { title: "string" },
 
   wheels: {
-    size: "integer",
-    wheelable_id: "integer",
-    wheelable_type: "string",
+    columns: {
+      size: "integer",
+      wheelable_id: "big_integer",
+      wheelable_type: "string",
+    },
+    indexes: [{ columns: ["wheelable_type", "wheelable_id"], name: "index_wheels_on_wheelable" }],
   },
 
   // Rails declares `id: false` with `t.string :<x>_id, primary_key: true` —
@@ -1867,8 +1976,8 @@ export const ARUNIT2_SCHEMA: Schema = {
   professors: { name: { type: "string", null: false } },
   courses_professors: {
     columns: {
-      course_id: "integer",
-      professor_id: "integer",
+      course_id: "big_integer",
+      professor_id: "big_integer",
     },
     indexes: [{ columns: "course_id" }, { columns: "professor_id" }],
     primaryKey: false,

--- a/scripts/schema-compare/compare.test.ts
+++ b/scripts/schema-compare/compare.test.ts
@@ -805,6 +805,7 @@ describe("against the canonical registry", () => {
       throw new Error("expected the wrapper form for tables carrying indexes/FKs/a primary key");
     }
     expect(books.indexes?.map(describeIndex)).toEqual([
+      "(author_id)",
       "(author_id,name) unique=true",
       '(isbn) unique=true where="published_on IS NOT NULL"',
       "((lower(external_id))) unique=true",


### PR DESCRIPTION
## `t.references` → bigint + default index

`t.references :x` builds a **bigint** `x_id` column plus a default index on it
unless the call passes `index: false`
(`schema_definitions.rb:198-231`, `#columns` at `:280-292`,
`#index_options` at `:266-274`). Both canonical transcriptions of
`schema.rb` disagreed with that, inconsistently — `courses_professors` had the
index but `t.integer`, `lessons_students` had `t.bigInteger` but no index, and
~60 sibling references had neither. The two divergences usually cancel (an
integer FK against an integer PK is still a valid constraint), which is why no
lane was red.

This sweeps every `t.references` in `schema.rb` through both sources:

- `big_integer` `x_id` in all cases;
- an index on it for every call without `index: false`;
- `["x_type", "x_id"]` named `index_<table>_on_<x>` for a polymorphic
  reference (`polymorphic_index_name`), which is the single composite index
  Rails builds — not one per column;
- the declared `index: { name: :soft_del_parent }` at `schema.rb:508`.

`pnpm schema:compare`: transcription-drift **60 → 0**, inventions 0.

## RFC 0087's residual sync writers

Decision recorded: **shape 2 — narrow the gate.** `syncWrite`, `syncIdsWrite`,
`HasOnePersistedAssignmentError` and `CollectionIdsAssignmentError` were listed
for deletion by RFC 0087 §1 and survive deliberately. Rails'
`assign_attributes` returns nil and does its work inline
(`activemodel/lib/active_model/attribute_assignment.rb:32-35`), and the
campaign's own remaining story
`awaitable-mass-assignment-for-nested-attributes` converges trails onto exactly
that (`assignAttributes` returns `void`). A permanently synchronous mass
assignment gives these a permanent caller, so shape 1 is unreachable without
reversing that story — which would move away from Rails.

Each call site now says so explicitly. In the tasks repo (`ef9afd660`), RFC
0087 README §1/§2/§Verification and
`grep-gate-sync-association-writers-to-zero`'s symbol list are narrowed to the
four symbols genuinely at zero (`_pendingDisplacedRemovals`,
`_displacedRemovalFailure`, `prepareDetachDisplacedForSyncBuild`,
`findThenDetachDisplaced`), and the decision is written into this story.

## Verification

- `pnpm schema:compare` clean; `pnpm api:calls` ratchet OK; `pnpm build`,
  eslint clean on the touched files.
- Green locally (SQLite): `schema-dumper`, `base`, `migration`,
  `has-many-associations`, `has-one-associations`,
  `has-many-through-associations`, `nested-attributes.trails`,
  `associations/preloader/**`.

Closes-story: references-columns-are-bigint-and-indexed-across-canonical-schema
Closes-story: reconcile-residual-sync-writers-with-the-gate-list
