### PR TITLE
refactor(activerecord,trailties): migrator test sites adopt Rails' ctor signature

### DIFF
--- a/packages/activerecord/src/active-record-schema.test.ts
+++ b/packages/activerecord/src/active-record-schema.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } 
 import { Base, Migration, Schema, TableDefinition } from "./index.js";
 import { Migrator } from "./migration.js";
 import { SchemaMigration } from "./schema-migration.js";
+import { InternalMetadata } from "./internal-metadata.js";
 
 import { adapterType } from "./test-adapter.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
@@ -103,7 +104,14 @@ describe("ActiveRecordSchemaTest", () => {
           t.string("color");
         });
       });
-      expect(await new Migrator(adapter, []).currentVersion()).toBe(7);
+      expect(
+        await new Migrator(
+          "up",
+          [],
+          new SchemaMigration(adapter),
+          new InternalMetadata(adapter),
+        ).currentVersion(),
+      ).toBe(7);
     } finally {
       // Rails ensure: drop_table :nep_schema_migrations (dropTable resolves the
       // still-prefixed table name).

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -199,15 +199,21 @@ describe("MigrationTest", () => {
     // with if_not_exists unset and must raise. Ride the canonical `people`
     // table via a Migrator, exactly as migration_test.rb does.
     const adapter = await freshAdapterWithPeople();
-    await new Migrator(adapter, [
-      migrateProxy(100, (m) => m.addColumn("people", "last_name", "string")),
-    ]).up(100);
+    await new Migrator(
+      "up",
+      [migrateProxy(100, (m) => m.addColumn("people", "last_name", "string"))],
+      new SchemaMigration(adapter),
+      new InternalMetadata(adapter),
+    ).up(100);
     expect(await personColumnNames(adapter)).toContain("last_name");
 
     await expect(
-      new Migrator(adapter, [
-        migrateProxy(101, (m) => m.addColumn("people", "last_name", "string")),
-      ]).up(101),
+      new Migrator(
+        "up",
+        [migrateProxy(101, (m) => m.addColumn("people", "last_name", "string"))],
+        new SchemaMigration(adapter),
+        new InternalMetadata(adapter),
+      ).up(101),
     ).rejects.toThrow();
   });
 
@@ -340,15 +346,25 @@ describe("MigrationTest", () => {
     // with if_not_exists: true and asserts it does not raise. Ride the canonical
     // `people` table via a Migrator, as migration_test.rb does.
     const adapter = await freshAdapterWithPeople();
-    await new Migrator(adapter, [
-      migrateProxy(100, (m) => m.addColumn("people", "last_name", "string")),
-    ]).up(100);
+    await new Migrator(
+      "up",
+      [migrateProxy(100, (m) => m.addColumn("people", "last_name", "string"))],
+      new SchemaMigration(adapter),
+      new InternalMetadata(adapter),
+    ).up(100);
     expect(await personColumnNames(adapter)).toContain("last_name");
 
     // if_not_exists: true must not raise even though the column already exists.
-    await new Migrator(adapter, [
-      migrateProxy(101, (m) => m.addColumn("people", "last_name", "string", { ifNotExists: true })),
-    ]).up(101);
+    await new Migrator(
+      "up",
+      [
+        migrateProxy(101, (m) =>
+          m.addColumn("people", "last_name", "string", { ifNotExists: true }),
+        ),
+      ],
+      new SchemaMigration(adapter),
+      new InternalMetadata(adapter),
+    ).up(101);
     expect(await personColumnNames(adapter)).toContain("last_name");
   });
 
@@ -590,23 +606,32 @@ describe("MigrationTest", () => {
     // the missing column, other adapters raise. Ride the canonical `people`
     // table via a Migrator, as migration_test.rb does.
     const adapter = await freshAdapterWithPeople();
-    await new Migrator(adapter, [
-      migrateProxy(100, (m) => m.addColumn("people", "last_name", "string")),
-    ]).up(100);
+    await new Migrator(
+      "up",
+      [migrateProxy(100, (m) => m.addColumn("people", "last_name", "string"))],
+      new SchemaMigration(adapter),
+      new InternalMetadata(adapter),
+    ).up(100);
     expect(await personColumnNames(adapter)).toContain("last_name");
 
-    await new Migrator(adapter, [
-      migrateProxy(101, (m) => m.removeColumn("people", "last_name")),
-    ]).up(101);
+    await new Migrator(
+      "up",
+      [migrateProxy(101, (m) => m.removeColumn("people", "last_name"))],
+      new SchemaMigration(adapter),
+      new InternalMetadata(adapter),
+    ).up(101);
     expect(await personColumnNames(adapter)).not.toContain("last_name");
 
     // Removing a missing column with if_not_exists unset: SQLite removes
     // columns via a table rebuild — copying every column except the dropped one
     // — so a missing column is a no-op (`assert_nothing_raised`). PG and MySQL
     // raise.
-    const error = await new Migrator(adapter, [
-      migrateProxy(102, (m) => m.removeColumn("people", "last_name")),
-    ])
+    const error = await new Migrator(
+      "up",
+      [migrateProxy(102, (m) => m.removeColumn("people", "last_name"))],
+      new SchemaMigration(adapter),
+      new InternalMetadata(adapter),
+    )
       .up(102)
       .catch((e) => e);
     expect(error?.message ?? "").toMatch(
@@ -710,16 +735,26 @@ describe("MigrationTest", () => {
 
   it("any migrations", async () => {
     const adapter = Base.connection;
-    const withMigrations = new Migrator(adapter, [
-      {
-        version: 1,
-        name: "First",
-        migration: () => anonymousMigration("First", 1),
-      },
-    ]);
+    const withMigrations = new Migrator(
+      "up",
+      [
+        {
+          version: 1,
+          name: "First",
+          migration: () => anonymousMigration("First", 1),
+        },
+      ],
+      new SchemaMigration(adapter),
+      new InternalMetadata(adapter),
+    );
     expect(withMigrations.migrations.length).toBeGreaterThan(0);
 
-    const empty = new Migrator(adapter, []);
+    const empty = new Migrator(
+      "up",
+      [],
+      new SchemaMigration(adapter),
+      new InternalMetadata(adapter),
+    );
     expect(empty.migrations.length).toBe(0);
   });
 
@@ -732,7 +767,12 @@ describe("MigrationTest", () => {
         migration: () => anonymousMigration("VersionCheck", 20131219224947),
       },
     ];
-    const migrator = new Migrator(adapter, migrations);
+    const migrator = new Migrator(
+      "up",
+      migrations,
+      new SchemaMigration(adapter),
+      new InternalMetadata(adapter),
+    );
     expect(await migrator.currentVersion()).toBe(0);
     await migrator.up("20131219224947");
     expect(await migrator.currentVersion()).toBe(20131219224947);
@@ -805,20 +845,29 @@ describe("MigrationTest", () => {
     // migration_c removes it again with if_exists: true and asserts nothing
     // raised. Ride the canonical `people` table via a Migrator.
     const adapter = await freshAdapterWithPeople();
-    await new Migrator(adapter, [
-      migrateProxy(100, (m) => m.addColumn("people", "last_name", "string")),
-    ]).up(100);
+    await new Migrator(
+      "up",
+      [migrateProxy(100, (m) => m.addColumn("people", "last_name", "string"))],
+      new SchemaMigration(adapter),
+      new InternalMetadata(adapter),
+    ).up(100);
     expect(await personColumnNames(adapter)).toContain("last_name");
 
-    await new Migrator(adapter, [
-      migrateProxy(101, (m) => m.removeColumn("people", "last_name")),
-    ]).up(101);
+    await new Migrator(
+      "up",
+      [migrateProxy(101, (m) => m.removeColumn("people", "last_name"))],
+      new SchemaMigration(adapter),
+      new InternalMetadata(adapter),
+    ).up(101);
     expect(await personColumnNames(adapter)).not.toContain("last_name");
 
     // if_exists: true must not raise even though the column is already gone.
-    await new Migrator(adapter, [
-      migrateProxy(102, (m) => m.removeColumn("people", "last_name", { ifExists: true })),
-    ]).up(102);
+    await new Migrator(
+      "up",
+      [migrateProxy(102, (m) => m.removeColumn("people", "last_name", { ifExists: true }))],
+      new SchemaMigration(adapter),
+      new InternalMetadata(adapter),
+    ).up(102);
     expect(await personColumnNames(adapter)).not.toContain("last_name");
   });
 
@@ -830,14 +879,20 @@ describe("MigrationTest", () => {
     // fallback, mirroring Rails' :char.
     const type = adapterType === "postgres" ? "char" : "binary";
     const adapter = await freshAdapterWithPeople();
-    await new Migrator(adapter, [
-      migrateProxy(100, (m) => m.addColumn("people", "last_name", type)),
-    ]).up(100);
+    await new Migrator(
+      "up",
+      [migrateProxy(100, (m) => m.addColumn("people", "last_name", type))],
+      new SchemaMigration(adapter),
+      new InternalMetadata(adapter),
+    ).up(100);
     expect(await personColumnNames(adapter)).toContain("last_name");
 
-    await new Migrator(adapter, [
-      migrateProxy(101, (m) => m.addColumn("people", "last_name", type, { ifNotExists: true })),
-    ]).up(101);
+    await new Migrator(
+      "up",
+      [migrateProxy(101, (m) => m.addColumn("people", "last_name", type, { ifNotExists: true }))],
+      new SchemaMigration(adapter),
+      new InternalMetadata(adapter),
+    ).up(101);
     expect(await personColumnNames(adapter)).toContain("last_name");
   });
 
@@ -846,16 +901,24 @@ describe("MigrationTest", () => {
     // it as :boolean with if_not_exists: true and asserts nothing raised (a
     // differing type is still a no-op). Ride canonical `people`.
     const adapter = await freshAdapterWithPeople();
-    await new Migrator(adapter, [
-      migrateProxy(100, (m) => m.addColumn("people", "last_name", "string")),
-    ]).up(100);
+    await new Migrator(
+      "up",
+      [migrateProxy(100, (m) => m.addColumn("people", "last_name", "string"))],
+      new SchemaMigration(adapter),
+      new InternalMetadata(adapter),
+    ).up(100);
     expect(await personColumnNames(adapter)).toContain("last_name");
 
-    await new Migrator(adapter, [
-      migrateProxy(101, (m) =>
-        m.addColumn("people", "last_name", "boolean", { ifNotExists: true }),
-      ),
-    ]).up(101);
+    await new Migrator(
+      "up",
+      [
+        migrateProxy(101, (m) =>
+          m.addColumn("people", "last_name", "boolean", { ifNotExists: true }),
+        ),
+      ],
+      new SchemaMigration(adapter),
+      new InternalMetadata(adapter),
+    ).up(101);
     expect(await personColumnNames(adapter)).toContain("last_name");
   });
 
@@ -913,7 +976,12 @@ describe("MigrationTest", () => {
           ),
       },
     ];
-    const migrator = new Migrator(adapter, migrations);
+    const migrator = new Migrator(
+      "up",
+      migrations,
+      new SchemaMigration(adapter),
+      new InternalMetadata(adapter),
+    );
     await expect(migrator.up()).rejects.toThrow("Something broke");
     // Migration should not be recorded as applied
     const versions = await migrator.getAllVersions();
@@ -940,7 +1008,12 @@ describe("MigrationTest", () => {
             ),
         },
       ];
-      const migrator = new Migrator(adapter, migrations);
+      const migrator = new Migrator(
+        "up",
+        migrations,
+        new SchemaMigration(adapter),
+        new InternalMetadata(adapter),
+      );
       await expect(migrator.migrate()).rejects.toThrow("Something broke");
       const versions = await migrator.getAllVersions();
       expect(versions).not.toContain(100);
@@ -972,7 +1045,12 @@ describe("MigrationTest", () => {
       name: "MigWithoutTx",
       migration: () => new MigWithoutTx(),
     };
-    const migrator = new Migrator(adapter, [proxy]);
+    const migrator = new Migrator(
+      "up",
+      [proxy],
+      new SchemaMigration(adapter),
+      new InternalMetadata(adapter),
+    );
     let err!: Error;
     try {
       await migrator.migrate();
@@ -998,7 +1076,12 @@ describe("MigrationTest", () => {
       name: "MigThatFailsToLoad",
       migration: () => Promise.reject(loadError),
     };
-    const migrator = new Migrator(adapter, [proxy]);
+    const migrator = new Migrator(
+      "up",
+      [proxy],
+      new SchemaMigration(adapter),
+      new InternalMetadata(adapter),
+    );
     let err!: Error;
     try {
       await migrator.migrate();
@@ -1054,7 +1137,12 @@ describe("MigrationTest", () => {
       name: "Failing",
       migration: () => new FailingMigration(),
     };
-    const migrator = new Migrator(adapter, [proxy]);
+    const migrator = new Migrator(
+      "up",
+      [proxy],
+      new SchemaMigration(adapter),
+      new InternalMetadata(adapter),
+    );
     await migrator.up().catch(() => {});
     const env = await im.get("environment");
     // Rails stamps the environment in `record_environment` BEFORE running the
@@ -1075,7 +1163,12 @@ describe("MigrationTest", () => {
       name: "M1",
       migration: () => anonymousMigration("M1", 1),
     };
-    const migrator = new Migrator(adapter, [proxy]);
+    const migrator = new Migrator(
+      "up",
+      [proxy],
+      new SchemaMigration(adapter),
+      new InternalMetadata(adapter),
+    );
     await migrator.up();
     expect(await im.get("environment")).toBe(envName(adapter));
     expect(await im.get("custom_key")).toBe("custom_value");
@@ -1104,7 +1197,12 @@ describe("MigrationTest", () => {
       name: "TestMigration",
       migration: () => anonymousMigration("TestMigration", 1),
     };
-    const migrator = new Migrator(adapter, [proxy]);
+    const migrator = new Migrator(
+      "up",
+      [proxy],
+      new SchemaMigration(adapter),
+      new InternalMetadata(adapter),
+    );
     try {
       await migrator.up();
 
@@ -1340,7 +1438,12 @@ describe("MigrationTest", () => {
 
   itIfSupports("advisory_locks", "migrator generates valid lock id", async () => {
     const realAdapter = Base.connection;
-    const migrator = new Migrator(realAdapter, []);
+    const migrator = new Migrator(
+      "up",
+      [],
+      new SchemaMigration(realAdapter),
+      new InternalMetadata(realAdapter),
+    );
     const lockId = await migrator.generateMigratorAdvisoryLockId();
     const acquired = await (realAdapter as any).getAdvisoryLock(lockId);
     try {
@@ -1356,7 +1459,12 @@ describe("MigrationTest", () => {
   itIfSupports("advisory_locks", "generate migrator advisory lock id", async () => {
     // SchemaAdapter now forwards currentDatabase() — no need to bypass the wrapper
     const testAdapter = Base.connection;
-    const migrator = new Migrator(testAdapter, []);
+    const migrator = new Migrator(
+      "up",
+      [],
+      new SchemaMigration(testAdapter),
+      new InternalMetadata(testAdapter),
+    );
     const lockId = await migrator.generateMigratorAdvisoryLockId();
     // Must fit in a signed 63-bit integer
     expect(lockId).toBeGreaterThanOrEqual(0n);
@@ -1381,7 +1489,12 @@ describe("MigrationTest", () => {
     const adapter = Base.connection;
     const getSpy = vi.spyOn(adapter as any, "getAdvisoryLock").mockResolvedValue(false);
     try {
-      const migrator = new Migrator(adapter, [proxy]);
+      const migrator = new Migrator(
+        "up",
+        [proxy],
+        new SchemaMigration(adapter),
+        new InternalMetadata(adapter),
+      );
       await expect(migrator.migrate()).rejects.toThrow(ConcurrentMigrationError);
     } finally {
       getSpy.mockRestore();
@@ -1407,7 +1520,12 @@ describe("MigrationTest", () => {
     const adapter = Base.connection;
     const getSpy = vi.spyOn(adapter as any, "getAdvisoryLock").mockResolvedValue(false);
     try {
-      const migrator = new Migrator(adapter, [proxy]);
+      const migrator = new Migrator(
+        "up",
+        [proxy],
+        new SchemaMigration(adapter),
+        new InternalMetadata(adapter),
+      );
       await expect(migrator.run("up", 100)).rejects.toThrow(ConcurrentMigrationError);
     } finally {
       getSpy.mockRestore();
@@ -1435,7 +1553,12 @@ describe("MigrationTest", () => {
           name: "NoOp",
           migration: () => anonymousMigration("NoOp", 200),
         };
-        const migrator = new Migrator(realAdapter, [proxy]);
+        const migrator = new Migrator(
+          "up",
+          [proxy],
+          new SchemaMigration(realAdapter),
+          new InternalMetadata(realAdapter),
+        );
         await migrator.migrate();
         expect(getSpy).toHaveBeenCalledTimes(1);
         expect(releaseSpy).toHaveBeenCalledWith(getSpy.mock.calls[0][0]);
@@ -1460,7 +1583,13 @@ describe("MigrationTest", () => {
         name: "NoOp",
         migration: () => anonymousMigration("NoOp", 100),
       };
-      const migrator = new Migrator(realAdapter, [proxy], { targetVersion: 100 });
+      const migrator = new Migrator(
+        "up",
+        [proxy],
+        new SchemaMigration(realAdapter),
+        new InternalMetadata(realAdapter),
+        100,
+      );
       const lockId = await migrator.generateMigratorAdvisoryLockId();
       const error = await migrator
         .withAdvisoryLock(async () => {

--- a/packages/activerecord/src/migration.trails.test.ts
+++ b/packages/activerecord/src/migration.trails.test.ts
@@ -17,6 +17,7 @@ import { DefaultStrategy } from "./migration/default-strategy.js";
 import { ActiveRecord } from "./ar-config.js";
 import { Base } from "./base.js";
 import { SchemaMigration } from "./schema-migration.js";
+import { InternalMetadata } from "./internal-metadata.js";
 import { newRawTestAdapter } from "./test-adapter.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import { Table } from "./connection-adapters/abstract/schema-definitions.js";
@@ -72,7 +73,12 @@ describe("MigrationTest", () => {
         migration: async () => anonymousMigration("AsyncFirst", 1),
       },
     ];
-    const migrator = new Migrator(adapter, migrations);
+    const migrator = new Migrator(
+      "up",
+      migrations,
+      new SchemaMigration(adapter),
+      new InternalMetadata(adapter),
+    );
     await migrator.up();
     expect(await migrator.currentVersion()).toBe(1);
   });

--- a/packages/activerecord/src/migrator.test.ts
+++ b/packages/activerecord/src/migrator.test.ts
@@ -90,7 +90,7 @@ describe("MigratorTest", () => {
       override get migrations(): MigrationProxy[] {
         return migrations;
       }
-    })([`${MIGRATIONS_ROOT}/valid`], new SchemaMigration(adapter), new InternalMetadata(adapter));
+    })([`${MIGRATIONS_ROOT}/valid`], schemaMigration, internalMetadata);
     return { calls, context };
   }
 
@@ -644,7 +644,6 @@ describe("MigratorTest", () => {
   it("migrator db has no schema migrations table", async () => {
     const { migrator } = migratorClass(3);
 
-    const schemaMigration = new SchemaMigration(adapter);
     await schemaMigration.dropTable();
     expect(await schemaMigration.tableExists()).toBe(false);
     await migrator.migrate(1);

--- a/packages/activerecord/src/migrator.test.ts
+++ b/packages/activerecord/src/migrator.test.ts
@@ -67,13 +67,15 @@ describe("MigratorTest", () => {
   fixtures({}, { useTransactionalTests: false });
 
   let adapter: DatabaseAdapter;
+  let schemaMigration: SchemaMigration;
+  let internalMetadata: InternalMetadata;
 
   // Rails' migrator_class(count) builds a MigrationContext subclass whose
   // #migrations returns the sensor list; in trails a Migrator carries its own
   // migrations, so this just wraps `sensors`.
   function migratorClass(count: number): { calls: Array<[string, number]>; migrator: Migrator } {
     const { calls, migrations } = sensors(count);
-    return { calls, migrator: new Migrator(adapter, migrations) };
+    return { calls, migrator: new Migrator("up", migrations, schemaMigration, internalMetadata) };
   }
 
   // Rails' migrator_class(count) subclasses MigrationContext and overrides
@@ -93,10 +95,8 @@ describe("MigratorTest", () => {
   }
 
   async function seedVersions(...versions: Array<string | number>): Promise<SchemaMigration> {
-    const sm = new SchemaMigration(adapter);
-    await sm.createTable();
-    for (const v of versions) await sm.createVersion(String(v));
-    return sm;
+    for (const v of versions) await schemaMigration.createVersion(String(v));
+    return schemaMigration;
   }
 
   let verboseWas: boolean;
@@ -108,9 +108,10 @@ describe("MigratorTest", () => {
   // also stashes `@verbose_was` and its teardown restores it.
   beforeEach(async () => {
     adapter = Base.connection;
-    const sm = new SchemaMigration(adapter);
-    await sm.createTable();
-    await sm.deleteAllVersions();
+    schemaMigration = new SchemaMigration(adapter);
+    await schemaMigration.createTable();
+    await schemaMigration.deleteAllVersions();
+    internalMetadata = new InternalMetadata(adapter);
     verboseWas = Migration.verbose;
   });
 
@@ -121,35 +122,35 @@ describe("MigratorTest", () => {
   it("migrator with duplicate names", () => {
     expect(() => {
       const list = [migration("Chunky"), migration("Chunky")];
-      new Migrator(adapter, list);
+      new Migrator("up", list, schemaMigration, internalMetadata);
     }).toThrow(/Multiple migrations have the name Chunky/);
   });
 
   it("migrator with duplicate versions", () => {
     expect(() => {
       const list = [migration("Foo", 1), migration("Bar", 1)];
-      new Migrator(adapter, list);
+      new Migrator("up", list, schemaMigration, internalMetadata);
     }).toThrow(DuplicateMigrationVersionError);
   });
 
   it("migrator with missing version numbers", async () => {
     const list = (): MigrationProxy[] => [migration("Foo", 1), migration("Bar", 2)];
 
-    await expect(new Migrator(adapter, list()).run("up", 3)).rejects.toThrow(
-      UnknownMigrationVersionError,
-    );
-    await expect(new Migrator(adapter, list()).run("up", -1)).rejects.toThrow(
-      UnknownMigrationVersionError,
-    );
-    await expect(new Migrator(adapter, list()).run("up", 0)).rejects.toThrow(
-      UnknownMigrationVersionError,
-    );
-    await expect(new Migrator(adapter, list()).migrate(3)).rejects.toThrow(
-      UnknownMigrationVersionError,
-    );
-    await expect(new Migrator(adapter, list()).migrate(-1)).rejects.toThrow(
-      UnknownMigrationVersionError,
-    );
+    await expect(
+      new Migrator("up", list(), schemaMigration, internalMetadata).run("up", 3),
+    ).rejects.toThrow(UnknownMigrationVersionError);
+    await expect(
+      new Migrator("up", list(), schemaMigration, internalMetadata).run("up", -1),
+    ).rejects.toThrow(UnknownMigrationVersionError);
+    await expect(
+      new Migrator("up", list(), schemaMigration, internalMetadata).run("up", 0),
+    ).rejects.toThrow(UnknownMigrationVersionError);
+    await expect(
+      new Migrator("up", list(), schemaMigration, internalMetadata).migrate(3),
+    ).rejects.toThrow(UnknownMigrationVersionError);
+    await expect(
+      new Migrator("up", list(), schemaMigration, internalMetadata).migrate(-1),
+    ).rejects.toThrow(UnknownMigrationVersionError);
   });
 
   it("finds migrations", () => {
@@ -219,7 +220,12 @@ describe("MigratorTest", () => {
   it("finds pending migrations", async () => {
     await seedVersions("1");
     const migrationList = [migration("foo", 1), migration("bar", 3)];
-    const migrations = await new Migrator(adapter, migrationList).pendingMigrations();
+    const migrations = await new Migrator(
+      "up",
+      migrationList,
+      schemaMigration,
+      internalMetadata,
+    ).pendingMigrations();
 
     expect(migrations).toHaveLength(1);
     expect(migrations[0].version).toBe(3);
@@ -231,8 +237,10 @@ describe("MigratorTest", () => {
     await seedVersions(2, 10);
 
     const status = await new Migrator(
-      adapter,
+      "up",
       new MigrationContext([path]).migrations,
+      schemaMigration,
+      internalMetadata,
     ).migrationsStatus();
     expect(status).toEqual([
       { status: "down", version: "001", name: "Valid people have last names" },
@@ -247,8 +255,10 @@ describe("MigratorTest", () => {
     await seedVersions(230, 231, 20210716122844, 20210716123013);
 
     const status = await new Migrator(
-      adapter,
+      "up",
       new MigrationContext([path]).migrations,
+      schemaMigration,
+      internalMetadata,
     ).migrationsStatus();
     expect(status).toEqual([
       { status: "up", version: "230", name: "Add people hobby" },
@@ -265,8 +275,10 @@ describe("MigratorTest", () => {
     await seedVersions(230, 231, 20210716123013);
 
     const status = await new Migrator(
-      adapter,
+      "up",
       new MigrationContext([path]).migrations,
+      schemaMigration,
+      internalMetadata,
     ).migrationsStatus();
     expect(status).toEqual([
       { status: "up", version: "230", name: "Add people hobby" },
@@ -281,8 +293,10 @@ describe("MigratorTest", () => {
     await seedVersions(2, 10);
 
     const status = await new Migrator(
-      adapter,
+      "up",
       new MigrationContext([path]).migrations,
+      schemaMigration,
+      internalMetadata,
     ).migrationsStatus();
     expect(status).toEqual([
       { status: "down", version: "001", name: "Valid people have last names" },
@@ -299,8 +313,10 @@ describe("MigratorTest", () => {
     await seedVersions(1, 2, 3);
 
     const status = await new Migrator(
-      adapter,
+      "up",
       new MigrationContext([path]).migrations,
+      schemaMigration,
+      internalMetadata,
     ).migrationsStatus();
     expect(status).toEqual([
       { status: "up", version: "001", name: "Valid people have last names" },
@@ -317,8 +333,10 @@ describe("MigratorTest", () => {
     await seedVersions("20100101010101", "20160528010101");
 
     const status = await new Migrator(
-      adapter,
+      "up",
       new MigrationContext(paths).migrations,
+      schemaMigration,
+      internalMetadata,
     ).migrationsStatus();
     expect(status).toEqual([
       { status: "down", version: "20090101010101", name: "People have hobbies" },
@@ -344,13 +362,18 @@ describe("MigratorTest", () => {
 
   it("migrator interleaved migrations", async () => {
     const one1 = trackedSensor("One", 1);
-    await new Migrator(adapter, [one1.proxy]).migrate();
+    await new Migrator("up", [one1.proxy], schemaMigration, internalMetadata).migrate();
     expect(one1.state.wentUp).toBe(true);
     expect(one1.state.wentDown).toBe(false);
 
     const one2 = trackedSensor("One", 1);
     const three2 = trackedSensor("Three", 3);
-    await new Migrator(adapter, [one2.proxy, three2.proxy]).migrate();
+    await new Migrator(
+      "up",
+      [one2.proxy, three2.proxy],
+      schemaMigration,
+      internalMetadata,
+    ).migrate();
     expect(one2.state.wentUp).toBe(false);
     expect(three2.state.wentUp).toBe(true);
     expect([one2, three2].every((s) => !s.state.wentDown)).toBe(true);
@@ -358,7 +381,12 @@ describe("MigratorTest", () => {
     const one3 = trackedSensor("One", 1);
     const two3 = trackedSensor("Two", 2);
     const three3 = trackedSensor("Three", 3);
-    await new Migrator(adapter, [one3.proxy, two3.proxy, three3.proxy]).down();
+    await new Migrator(
+      "up",
+      [one3.proxy, two3.proxy, three3.proxy],
+      schemaMigration,
+      internalMetadata,
+    ).down();
     expect(one3.state.wentDown).toBe(true);
     expect(two3.state.wentDown).toBe(false);
     expect(three3.state.wentDown).toBe(true);
@@ -368,7 +396,12 @@ describe("MigratorTest", () => {
     const m0 = trackedSensor(null, 0);
     const m1 = trackedSensor(null, 1);
     const m2 = trackedSensor(null, 2);
-    const migrator = new Migrator(adapter, [m0.proxy, m1.proxy, m2.proxy]);
+    const migrator = new Migrator(
+      "up",
+      [m0.proxy, m1.proxy, m2.proxy],
+      schemaMigration,
+      internalMetadata,
+    );
     await migrator.migrate();
     expect([m0, m1, m2].every((m) => m.state.wentUp)).toBe(true);
     expect([m0, m1, m2].every((m) => !m.state.wentDown)).toBe(true);
@@ -380,12 +413,22 @@ describe("MigratorTest", () => {
     const up0 = trackedSensor(null, 0);
     const up1 = trackedSensor(null, 1);
     const up2 = trackedSensor(null, 2);
-    await new Migrator(adapter, [up0.proxy, up1.proxy, up2.proxy]).migrate();
+    await new Migrator(
+      "up",
+      [up0.proxy, up1.proxy, up2.proxy],
+      schemaMigration,
+      internalMetadata,
+    ).migrate();
 
     const m0 = trackedSensor(null, 0);
     const m1 = trackedSensor(null, 1);
     const m2 = trackedSensor(null, 2);
-    const migrator = new Migrator(adapter, [m0.proxy, m1.proxy, m2.proxy]);
+    const migrator = new Migrator(
+      "up",
+      [m0.proxy, m1.proxy, m2.proxy],
+      schemaMigration,
+      internalMetadata,
+    );
     await migrator.down();
     expect([m0, m1, m2].every((m) => !m.state.wentUp)).toBe(true);
     expect([m0, m1, m2].every((m) => m.state.wentDown)).toBe(true);
@@ -394,25 +437,25 @@ describe("MigratorTest", () => {
 
   it("current version", async () => {
     await seedVersions("1000");
-    const migrator = new Migrator(adapter, []);
+    const migrator = new Migrator("up", [], schemaMigration, internalMetadata);
     expect(await migrator.currentVersion()).toBe(1000);
   });
 
   it("migrator one up", async () => {
     const { calls, migrations } = sensors(3);
 
-    await new Migrator(adapter, migrations).migrate(1);
+    await new Migrator("up", migrations, schemaMigration, internalMetadata).migrate(1);
     expect(calls).toEqual([["up", 1]]);
     calls.length = 0;
 
-    await new Migrator(adapter, migrations).migrate(2);
+    await new Migrator("up", migrations, schemaMigration, internalMetadata).migrate(2);
     expect(calls).toEqual([["up", 2]]);
   });
 
   it("migrator one down", async () => {
     const { calls, migrations } = sensors(3);
 
-    await new Migrator(adapter, migrations).migrate();
+    await new Migrator("up", migrations, schemaMigration, internalMetadata).migrate();
     expect(calls).toEqual([
       ["up", 1],
       ["up", 2],
@@ -420,7 +463,7 @@ describe("MigratorTest", () => {
     ]);
     calls.length = 0;
 
-    await new Migrator(adapter, migrations).migrate(1);
+    await new Migrator("up", migrations, schemaMigration, internalMetadata).migrate(1);
     expect(calls).toEqual([
       ["down", 3],
       ["down", 2],
@@ -430,17 +473,17 @@ describe("MigratorTest", () => {
   it("migrator one up one down", async () => {
     const { calls, migrations } = sensors(3);
 
-    await new Migrator(adapter, migrations).migrate(1);
+    await new Migrator("up", migrations, schemaMigration, internalMetadata).migrate(1);
     expect(calls).toEqual([["up", 1]]);
     calls.length = 0;
 
-    await new Migrator(adapter, migrations).migrate(0);
+    await new Migrator("up", migrations, schemaMigration, internalMetadata).migrate(0);
     expect(calls).toEqual([["down", 1]]);
   });
 
   it("migrator double up", async () => {
     const { calls, migrations } = sensors(3);
-    const migrator = new Migrator(adapter, migrations);
+    const migrator = new Migrator("up", migrations, schemaMigration, internalMetadata);
     expect(await migrator.currentVersion()).toBe(0);
 
     await migrator.migrate(1);
@@ -453,7 +496,7 @@ describe("MigratorTest", () => {
 
   it("migrator double down", async () => {
     const { calls, migrations } = sensors(3);
-    const migrator = new Migrator(adapter, migrations);
+    const migrator = new Migrator("up", migrations, schemaMigration, internalMetadata);
 
     expect(await migrator.currentVersion()).toBe(0);
 
@@ -484,13 +527,13 @@ describe("MigratorTest", () => {
       const { migrations } = sensors(3);
 
       Migration.verbose = true;
-      const upMigrator = new Migrator(adapter, migrations);
+      const upMigrator = new Migrator("up", migrations, schemaMigration, internalMetadata);
       await upMigrator.migrate(1);
       expect(lines.length).not.toBe(0);
 
       lines.length = 0;
 
-      const downMigrator = new Migrator(adapter, migrations);
+      const downMigrator = new Migrator("up", migrations, schemaMigration, internalMetadata);
       await downMigrator.migrate(0);
       expect(lines.length).not.toBe(0);
     } finally {
@@ -508,11 +551,11 @@ describe("MigratorTest", () => {
       const { migrations } = sensors(3);
 
       Migration.verbose = false;
-      const upMigrator = new Migrator(adapter, migrations);
+      const upMigrator = new Migrator("up", migrations, schemaMigration, internalMetadata);
       await upMigrator.migrate(1);
       expect(lines.length).toBe(0);
 
-      const downMigrator = new Migrator(adapter, migrations);
+      const downMigrator = new Migrator("up", migrations, schemaMigration, internalMetadata);
       await downMigrator.migrate(0);
       expect(lines.length).toBe(0);
     } finally {
@@ -524,17 +567,17 @@ describe("MigratorTest", () => {
     const { calls, migrations } = sensors(3);
 
     // migrate up to 1
-    await new Migrator(adapter, migrations).migrate(1);
+    await new Migrator("up", migrations, schemaMigration, internalMetadata).migrate(1);
     expect(calls).toEqual([["up", 1]]);
     calls.length = 0;
 
     // migrate down to 0
-    await new Migrator(adapter, migrations).migrate(0);
+    await new Migrator("up", migrations, schemaMigration, internalMetadata).migrate(0);
     expect(calls).toEqual([["down", 1]]);
     calls.length = 0;
 
     // migrate down to 0 again
-    await new Migrator(adapter, migrations).migrate(0);
+    await new Migrator("up", migrations, schemaMigration, internalMetadata).migrate(0);
     expect(calls).toEqual([]);
   });
 

--- a/packages/activerecord/src/migrator.trails.test.ts
+++ b/packages/activerecord/src/migrator.trails.test.ts
@@ -255,7 +255,6 @@ describe("Migrator trails extensions", () => {
   });
 
   it("CheckPending with a Migrator creates schema_migrations before reading it", async () => {
-    const schemaMigration = new SchemaMigration(adapter);
     await schemaMigration.dropTable();
     const migrator = new Migrator(
       "up",
@@ -600,7 +599,6 @@ describe("Migrator advisory lock wrapping", () => {
     addAdvisoryLockSupport(adapter);
     adapter.getAdvisoryLock = async () => true;
     adapter.releaseAdvisoryLock = async () => true;
-    const schemaMigration = new SchemaMigration(adapter);
     await schemaMigration.createTable();
 
     const migrator = new Migrator(
@@ -641,7 +639,6 @@ describe("Migrator advisory lock wrapping", () => {
 
   it("loadMigrated re-reads schema_migrations so repeated pending checks are not memoized", async () => {
     const adapter = Base.connection;
-    const schemaMigration = new SchemaMigration(adapter);
     await schemaMigration.createTable();
     const migrator = new Migrator(
       "up",

--- a/packages/activerecord/src/migrator.trails.test.ts
+++ b/packages/activerecord/src/migrator.trails.test.ts
@@ -52,9 +52,14 @@ fixtures({}, { useTransactionalTests: false });
 // version + environment state fresh (mirrors Rails' setup/teardown, which
 // deletes all versions around every test). File-scoped because the advisory-lock
 // describe runs `migrate()` too and needs the same fresh version table.
+let schemaMigration: SchemaMigration;
+let internalMetadata: InternalMetadata;
+
 beforeEach(async () => {
-  await new SchemaMigration(Base.connection).dropTable();
-  await new InternalMetadata(Base.connection).dropTable();
+  schemaMigration = new SchemaMigration(Base.connection);
+  internalMetadata = new InternalMetadata(Base.connection);
+  await schemaMigration.dropTable();
+  await internalMetadata.dropTable();
 });
 
 describe("Migrator trails extensions", () => {
@@ -65,9 +70,12 @@ describe("Migrator trails extensions", () => {
   });
 
   it("stores environment after up migration", async () => {
-    const migrator = new Migrator(adapter, [makeMigration(1, "M1")], {
-      environment: "test",
-    });
+    const migrator = new Migrator(
+      "up",
+      [makeMigration(1, "M1")],
+      schemaMigration,
+      internalMetadata,
+    );
     await migrator.up();
     const env = await new InternalMetadata(adapter).get("environment");
     expect(env).toBe(envName(adapter));
@@ -76,9 +84,10 @@ describe("Migrator trails extensions", () => {
   it("stamps the environment once per run, not once per migration", async () => {
     // migration.rb:1508-1512 stamps before the loop; :1528-1537 writes nothing.
     const migrator = new Migrator(
-      adapter,
+      "up",
       [makeMigration(1, "M1"), makeMigration(2, "M2"), makeMigration(3, "M3")],
-      { environment: "test" },
+      schemaMigration,
+      internalMetadata,
     );
     const set = vi.spyOn(InternalMetadata.prototype, "set");
     let environmentWrites: number;
@@ -106,22 +115,22 @@ describe("Migrator trails extensions", () => {
     await new SchemaMigration(adapter).createTable();
     await new InternalMetadata(adapter).createTable();
 
-    const up = new Migrator(adapter, [proxy]);
+    const up = new Migrator("up", [proxy], schemaMigration, internalMetadata);
     expect(await up.executeMigrationInTransaction(proxy)).toBe(1);
     expect(calls).toEqual([["up", 1]]);
 
-    const again = new Migrator(adapter, [proxy]);
+    const again = new Migrator("up", [proxy], schemaMigration, internalMetadata);
     expect(await again.executeMigrationInTransaction(proxy)).toBeUndefined();
     expect(calls).toEqual([["up", 1]]);
 
-    const down = new Migrator(adapter, [proxy], { direction: "down" });
+    const down = new Migrator("down", [proxy], schemaMigration, internalMetadata);
     expect(await down.executeMigrationInTransaction(proxy)).toBe(1);
     expect(calls).toEqual([
       ["up", 1],
       ["down", 1],
     ]);
 
-    const downAgain = new Migrator(adapter, [proxy], { direction: "down" });
+    const downAgain = new Migrator("down", [proxy], schemaMigration, internalMetadata);
     expect(await downAgain.executeMigrationInTransaction(proxy)).toBeUndefined();
     expect(calls).toHaveLength(2);
   });
@@ -131,11 +140,15 @@ describe("Migrator trails extensions", () => {
     // starts with `raise UnknownMigrationVersionError if invalid_target?`
     // (migration.rb:1503-1505); target 0 stays valid.
     const list = (): MigrationProxy[] => [makeMigration(1, "M1"), makeMigration(2, "M2")];
-    await expect(new Migrator(adapter, list()).up(3)).rejects.toThrow(UnknownMigrationVersionError);
-    await expect(new Migrator(adapter, list()).down(3)).rejects.toThrow(
-      UnknownMigrationVersionError,
-    );
-    await expect(new Migrator(adapter, list()).down(0)).resolves.toEqual([]);
+    await expect(
+      new Migrator("up", list(), schemaMigration, internalMetadata).up(3),
+    ).rejects.toThrow(UnknownMigrationVersionError);
+    await expect(
+      new Migrator("up", list(), schemaMigration, internalMetadata).down(3),
+    ).rejects.toThrow(UnknownMigrationVersionError);
+    await expect(
+      new Migrator("up", list(), schemaMigration, internalMetadata).down(0),
+    ).resolves.toEqual([]);
   });
 
   it("migrate to the current version runs an unapplied lower migration", async () => {
@@ -149,21 +162,21 @@ describe("Migrator trails extensions", () => {
         ran.push("2");
       });
 
-    await new Migrator(adapter, [m2()]).up();
+    await new Migrator("up", [m2()], schemaMigration, internalMetadata).up();
     expect(ran).toEqual(["2"]);
 
     ran.length = 0;
-    await new Migrator(adapter, [m1(), m2()]).migrate(2);
+    await new Migrator("up", [m1(), m2()], schemaMigration, internalMetadata).migrate(2);
     expect(ran).toEqual(["1"]);
   });
 
   it("pendingMigrations on a down migrator returns migrations in reverse order", async () => {
     const migrator = new Migrator(
-      adapter,
+      "down",
       [makeMigration(1, "M1"), makeMigration(2, "M2"), makeMigration(3, "M3")],
-      { direction: "down" },
+      schemaMigration,
+      internalMetadata,
     );
-    const schemaMigration = new SchemaMigration(adapter);
     await schemaMigration.createTable();
     await schemaMigration.createVersion("2");
 
@@ -176,25 +189,35 @@ describe("Migrator trails extensions", () => {
 
   it("migrate returns [] when both the current and target version are 0", async () => {
     const ran: string[] = [];
-    const migrator = new Migrator(adapter, [
-      makeMigration(0, "M0", async () => {
-        ran.push("0");
-      }),
-    ]);
+    const migrator = new Migrator(
+      "up",
+      [
+        makeMigration(0, "M0", async () => {
+          ran.push("0");
+        }),
+      ],
+      schemaMigration,
+      internalMetadata,
+    );
     await expect(migrator.migrate(0)).resolves.toEqual([]);
     expect(ran).toEqual([]);
   });
 
   it("migrate applies its block by selecting the migrations handed to the per-run Migrator", async () => {
     const ran: string[] = [];
-    const migrator = new Migrator(adapter, [
-      makeMigration(1, "M1", async () => {
-        ran.push("1");
-      }),
-      makeMigration(2, "M2", async () => {
-        ran.push("2");
-      }),
-    ]);
+    const migrator = new Migrator(
+      "up",
+      [
+        makeMigration(1, "M1", async () => {
+          ran.push("1");
+        }),
+        makeMigration(2, "M2", async () => {
+          ran.push("2");
+        }),
+      ],
+      schemaMigration,
+      internalMetadata,
+    );
     await migrator.migrate(null, (m) => m.version === 2);
     expect(ran).toEqual(["2"]);
   });
@@ -211,14 +234,22 @@ describe("Migrator trails extensions", () => {
       }),
     ];
 
-    await new Migrator(adapter, migrations()).up();
-    await new Migrator(adapter, migrations()).migrate(1, (m) => m.version !== 3);
+    await new Migrator("up", migrations(), schemaMigration, internalMetadata).up();
+    await new Migrator("up", migrations(), schemaMigration, internalMetadata).migrate(
+      1,
+      (m) => m.version !== 3,
+    );
     expect(reverted).toEqual(["2"]);
   });
 
   it("down does not stamp the environment", async () => {
     // Rails' record_environment returns early when down? (migration.rb:1511).
-    const migrator = new Migrator(adapter, [makeMigration(1, "M1")], { environment: "test" });
+    const migrator = new Migrator(
+      "up",
+      [makeMigration(1, "M1")],
+      schemaMigration,
+      internalMetadata,
+    );
     await migrator.down();
     expect(await new InternalMetadata(adapter).get("environment")).toBeNull();
   });
@@ -226,7 +257,12 @@ describe("Migrator trails extensions", () => {
   it("CheckPending with a Migrator creates schema_migrations before reading it", async () => {
     const schemaMigration = new SchemaMigration(adapter);
     await schemaMigration.dropTable();
-    const migrator = new Migrator(adapter, [makeMigration(1, "M1")]);
+    const migrator = new Migrator(
+      "up",
+      [makeMigration(1, "M1")],
+      schemaMigration,
+      internalMetadata,
+    );
     const check = new CheckPending(async () => "ok", { migrator });
 
     await expect(check.call({})).rejects.toThrow(PendingMigrationError);
@@ -286,7 +322,12 @@ describe("Migrator advisory lock wrapping", () => {
       return true;
     };
 
-    const migrator = new Migrator(adapter, [makeMigration(1, "M1")]);
+    const migrator = new Migrator(
+      "up",
+      [makeMigration(1, "M1")],
+      schemaMigration,
+      internalMetadata,
+    );
     await migrator.migrate();
     expect(lockLog).toEqual(["lock", "unlock"]);
   });
@@ -297,7 +338,12 @@ describe("Migrator advisory lock wrapping", () => {
     adapter.getAdvisoryLock = async () => false;
     adapter.releaseAdvisoryLock = async () => true;
 
-    const migrator = new Migrator(adapter, [makeMigration(1, "M1")]);
+    const migrator = new Migrator(
+      "up",
+      [makeMigration(1, "M1")],
+      schemaMigration,
+      internalMetadata,
+    );
     await expect(migrator.migrate()).rejects.toThrow(ConcurrentMigrationError);
   });
 
@@ -314,18 +360,28 @@ describe("Migrator advisory lock wrapping", () => {
       return true;
     };
 
-    const migrator = new Migrator(adapter, [
-      makeMigration(1, "Boom", async () => {
-        throw new Error("kaboom");
-      }),
-    ]);
+    const migrator = new Migrator(
+      "up",
+      [
+        makeMigration(1, "Boom", async () => {
+          throw new Error("kaboom");
+        }),
+      ],
+      schemaMigration,
+      internalMetadata,
+    );
     await expect(migrator.migrate()).rejects.toThrow("kaboom");
     expect(lockLog).toEqual(["lock", "unlock"]);
   });
 
   it("skips locking when adapter does not support advisory locks", async () => {
     const adapter = Base.connection;
-    const migrator = new Migrator(adapter, [makeMigration(1, "M1")]);
+    const migrator = new Migrator(
+      "up",
+      [makeMigration(1, "M1")],
+      schemaMigration,
+      internalMetadata,
+    );
     await migrator.migrate();
     expect(await migrator.currentVersion()).toBe(1);
   });
@@ -343,7 +399,12 @@ describe("Migrator advisory lock wrapping", () => {
       return true;
     };
 
-    const migrator = new Migrator(adapter, [makeMigration(1, "M1")]);
+    const migrator = new Migrator(
+      "up",
+      [makeMigration(1, "M1")],
+      schemaMigration,
+      internalMetadata,
+    );
     await migrator.migrate();
     lockLog.length = 0;
     await migrator.rollback(1);
@@ -363,7 +424,12 @@ describe("Migrator advisory lock wrapping", () => {
       return true;
     };
 
-    const migrator = new Migrator(adapter, [makeMigration(1, "M1")]);
+    const migrator = new Migrator(
+      "up",
+      [makeMigration(1, "M1")],
+      schemaMigration,
+      internalMetadata,
+    );
     await migrator.run("up", 1);
     expect(lockLog).toEqual(["lock", "unlock"]);
   });
@@ -390,14 +456,24 @@ describe("Migrator advisory lock wrapping", () => {
 
   it("wraps up in advisory lock", async () => {
     const { adapter, lockLog } = await lockableAdapter();
-    const migrator = new Migrator(adapter, [makeMigration(1, "M1")]);
+    const migrator = new Migrator(
+      "up",
+      [makeMigration(1, "M1")],
+      schemaMigration,
+      internalMetadata,
+    );
     await migrator.up();
     expect(lockLog).toEqual(["lock", "unlock"]);
   });
 
   it("wraps down in advisory lock", async () => {
     const { adapter, lockLog } = await lockableAdapter();
-    const migrator = new Migrator(adapter, [makeMigration(1, "M1")]);
+    const migrator = new Migrator(
+      "up",
+      [makeMigration(1, "M1")],
+      schemaMigration,
+      internalMetadata,
+    );
     await migrator.up();
     lockLog.length = 0;
     await migrator.down(0);
@@ -406,7 +482,12 @@ describe("Migrator advisory lock wrapping", () => {
 
   it("wraps forward in advisory lock", async () => {
     const { adapter, lockLog } = await lockableAdapter();
-    const migrator = new Migrator(adapter, [makeMigration(1, "M1")]);
+    const migrator = new Migrator(
+      "up",
+      [makeMigration(1, "M1")],
+      schemaMigration,
+      internalMetadata,
+    );
     await migrator.forward(1);
     expect(lockLog).toEqual(["lock", "unlock"]);
   });
@@ -416,7 +497,12 @@ describe("Migrator advisory lock wrapping", () => {
     addAdvisoryLockSupport(adapter);
     adapter.getAdvisoryLock = async () => true;
     adapter.releaseAdvisoryLock = async () => false;
-    const migrator = new Migrator(adapter, [makeMigration(1, "M1")]);
+    const migrator = new Migrator(
+      "up",
+      [makeMigration(1, "M1")],
+      schemaMigration,
+      internalMetadata,
+    );
     await expect(migrator.migrate()).rejects.toThrow(
       ConcurrentMigrationError.RELEASE_LOCK_FAILED_MESSAGE,
     );
@@ -432,7 +518,7 @@ describe("Migrator advisory lock wrapping", () => {
     };
     adapter.releaseAdvisoryLock = async () => true;
     adapter.currentDatabase = async () => "myapp_test";
-    const migrator = new Migrator(adapter, []);
+    const migrator = new Migrator("up", [], schemaMigration, internalMetadata);
     await migrator.migrate();
     // Ruby: Zlib.crc32("myapp_test") == 601888509
     // Rails: MIGRATOR_SALT (2053462845) * 601888509 == 1235955690063948105
@@ -449,7 +535,7 @@ describe("Migrator advisory lock wrapping", () => {
     };
     adapter.releaseAdvisoryLock = async () => true;
     adapter.currentDatabase = async () => "myapp_test";
-    const migrator = new Migrator(adapter, []);
+    const migrator = new Migrator("up", [], schemaMigration, internalMetadata);
     await migrator.migrate();
     await migrator.migrate();
     expect(lockIds[0]).toBe(lockIds[1]);
@@ -465,7 +551,12 @@ describe("Migrator advisory lock wrapping", () => {
       releaseAdvisoryLock: async (_id: unknown) => true,
       // currentDatabase intentionally absent
     } as unknown as import("./connection-adapters/abstract-adapter.js").AbstractAdapter;
-    const migrator = new Migrator(rawAdapter, []);
+    const migrator = new Migrator(
+      "up",
+      [],
+      new SchemaMigration(rawAdapter),
+      new InternalMetadata(rawAdapter),
+    );
     await expect(migrator.migrate()).rejects.toThrow("must implement currentDatabase()");
   });
 
@@ -477,7 +568,12 @@ describe("Migrator advisory lock wrapping", () => {
       isAdvisoryLocksEnabled: () => true,
       // currentDatabase intentionally absent
     } as unknown as DatabaseAdapter;
-    const migrator = new Migrator(adapter, []);
+    const migrator = new Migrator(
+      "up",
+      [],
+      new SchemaMigration(adapter),
+      new InternalMetadata(adapter),
+    );
     expect(migrator.isUseAdvisoryLock()).toBe(true);
   });
 
@@ -486,7 +582,12 @@ describe("Migrator advisory lock wrapping", () => {
       isAdvisoryLocksEnabled: () => false,
       currentDatabase: async () => "test_db",
     } as unknown as DatabaseAdapter;
-    const migrator = new Migrator(adapter, []);
+    const migrator = new Migrator(
+      "up",
+      [],
+      new SchemaMigration(adapter),
+      new InternalMetadata(adapter),
+    );
     expect(migrator.isUseAdvisoryLock()).toBe(false);
   });
 
@@ -502,7 +603,12 @@ describe("Migrator advisory lock wrapping", () => {
     const schemaMigration = new SchemaMigration(adapter);
     await schemaMigration.createTable();
 
-    const migrator = new Migrator(adapter, [makeMigration(1, "M1")]);
+    const migrator = new Migrator(
+      "up",
+      [makeMigration(1, "M1")],
+      schemaMigration,
+      internalMetadata,
+    );
     expect(await migrator.migrated()).toEqual(new Set());
 
     // Another process migrates version 1 while we wait for the lock.
@@ -518,7 +624,12 @@ describe("Migrator advisory lock wrapping", () => {
 
   it("record_version_state_after_migrating updates the migrated memo in place", async () => {
     const adapter = Base.connection;
-    const migrator = new Migrator(adapter, [makeMigration(1, "M1")]);
+    const migrator = new Migrator(
+      "up",
+      [makeMigration(1, "M1")],
+      schemaMigration,
+      internalMetadata,
+    );
     await new SchemaMigration(adapter).createTable();
 
     expect(await migrator.migrated()).toEqual(new Set());
@@ -532,7 +643,12 @@ describe("Migrator advisory lock wrapping", () => {
     const adapter = Base.connection;
     const schemaMigration = new SchemaMigration(adapter);
     await schemaMigration.createTable();
-    const migrator = new Migrator(adapter, [makeMigration(1, "M1")]);
+    const migrator = new Migrator(
+      "up",
+      [makeMigration(1, "M1")],
+      schemaMigration,
+      internalMetadata,
+    );
 
     expect(await migrator.pendingMigrations()).toHaveLength(1);
     await schemaMigration.recordVersion("1");
@@ -582,13 +698,18 @@ describe("Migrator drives migrations through Migration#migrate", () => {
     class SomeOtherClassName extends Migration {
       override async change(): Promise<void> {}
     }
-    const migrator = new Migrator(adapter, [
-      {
-        version: 1,
-        name: "CreateWidgets",
-        migration: () => new SomeOtherClassName("CreateWidgets", 1),
-      },
-    ]);
+    const migrator = new Migrator(
+      "up",
+      [
+        {
+          version: 1,
+          name: "CreateWidgets",
+          migration: () => new SomeOtherClassName("CreateWidgets", 1),
+        },
+      ],
+      schemaMigration,
+      internalMetadata,
+    );
     await migrator.up();
     const banners = chunks.join("").split("\n").filter(Boolean);
     expect(banners[0]).toMatch(/^== 1 CreateWidgets: migrating =+$/);
@@ -604,9 +725,12 @@ describe("Migrator drives migrations through Migration#migrate", () => {
       }
       override async change(): Promise<void> {}
     }
-    const migrator = new Migrator(adapter, [
-      { version: 1, name: "Shouty", migration: () => new Shouty("Shouty", 1) },
-    ]);
+    const migrator = new Migrator(
+      "up",
+      [{ version: 1, name: "Shouty", migration: () => new Shouty("Shouty", 1) }],
+      schemaMigration,
+      internalMetadata,
+    );
     await migrator.up();
     const output = chunks.join("");
     expect(output).toContain("!! migrating !!");
@@ -615,7 +739,12 @@ describe("Migrator drives migrations through Migration#migrate", () => {
   });
 
   it("announces each banner exactly once", async () => {
-    const migrator = new Migrator(adapter, [makeMigration(1, "M1")]);
+    const migrator = new Migrator(
+      "up",
+      [makeMigration(1, "M1")],
+      schemaMigration,
+      internalMetadata,
+    );
     await migrator.up();
     const output = chunks.join("");
     expect(output.match(/1 M1: migrating/g)).toHaveLength(1);
@@ -628,7 +757,12 @@ describe("Migrator drives migrations through Migration#migrate", () => {
     const was = Migration.verbose;
     Migration.verbose = false;
     try {
-      const migrator = new Migrator(adapter, [makeMigration(1, "M1")]);
+      const migrator = new Migrator(
+        "up",
+        [makeMigration(1, "M1")],
+        schemaMigration,
+        internalMetadata,
+      );
       await migrator.up();
       expect(chunks.join("")).toBe("");
     } finally {
@@ -655,62 +789,50 @@ describe("Migrator runnable direction awareness", () => {
 
   it("migrations is ascending going up and reversed going down", () => {
     const migrations = three();
-    const up = new Migrator(adapter, migrations);
+    const up = new Migrator("up", migrations, schemaMigration, internalMetadata);
     expect(up.migrations.map((m) => m.version)).toEqual([1, 2, 3]);
 
-    const down = new Migrator(adapter, migrations, { direction: "down" });
+    const down = new Migrator("down", migrations, schemaMigration, internalMetadata);
     expect(down.migrations.map((m) => m.version)).toEqual([3, 2, 1]);
   });
 
   it("runnable going up returns only unapplied migrations", async () => {
     const migrations = three();
-    await new Migrator(adapter, migrations).migrate(2);
+    await new Migrator("up", migrations, schemaMigration, internalMetadata).migrate(2);
 
-    const migrator = new Migrator(adapter, migrations, { direction: "up" });
+    const migrator = new Migrator("up", migrations, schemaMigration, internalMetadata);
     expect((await migrator.runnable()).map((m) => m.version)).toEqual([3]);
   });
 
   it("runnable going up stops at the target version", async () => {
     const migrations = three();
-    await new Migrator(adapter, migrations).migrate(1);
+    await new Migrator("up", migrations, schemaMigration, internalMetadata).migrate(1);
 
-    const migrator = new Migrator(adapter, migrations, {
-      direction: "up",
-      targetVersion: 2,
-    });
+    const migrator = new Migrator("up", migrations, schemaMigration, internalMetadata, 2);
     expect((await migrator.runnable()).map((m) => m.version)).toEqual([2]);
   });
 
   it("runnable going down to a target skips the target migration", async () => {
     const migrations = three();
-    await new Migrator(adapter, migrations).migrate();
+    await new Migrator("up", migrations, schemaMigration, internalMetadata).migrate();
 
-    const migrator = new Migrator(adapter, migrations, {
-      direction: "down",
-      targetVersion: 1,
-    });
+    const migrator = new Migrator("down", migrations, schemaMigration, internalMetadata, 1);
     expect((await migrator.runnable()).map((m) => m.version)).toEqual([3, 2]);
   });
 
   it("runnable going all the way down keeps every applied migration", async () => {
     const migrations = three();
-    await new Migrator(adapter, migrations).migrate();
+    await new Migrator("up", migrations, schemaMigration, internalMetadata).migrate();
 
-    const migrator = new Migrator(adapter, migrations, {
-      direction: "down",
-      targetVersion: 0,
-    });
+    const migrator = new Migrator("down", migrations, schemaMigration, internalMetadata, 0);
     expect((await migrator.runnable()).map((m) => m.version)).toEqual([3, 2, 1]);
   });
 
   it("runnable going down ignores migrations that never ran", async () => {
     const migrations = three();
-    await new Migrator(adapter, migrations).migrate(2);
+    await new Migrator("up", migrations, schemaMigration, internalMetadata).migrate(2);
 
-    const migrator = new Migrator(adapter, migrations, {
-      direction: "down",
-      targetVersion: 0,
-    });
+    const migrator = new Migrator("down", migrations, schemaMigration, internalMetadata, 0);
     expect((await migrator.runnable()).map((m) => m.version)).toEqual([2, 1]);
   });
 });

--- a/packages/activerecord/src/multi-db-migrator.test.ts
+++ b/packages/activerecord/src/multi-db-migrator.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Migrator } from "./index.js";
 import { SchemaMigration } from "./schema-migration.js";
+import { InternalMetadata } from "./internal-metadata.js";
 import type { MigrationProxy } from "./migration.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import { anonymousMigration } from "./test-helpers/anonymous-migration.js";
@@ -38,20 +39,24 @@ function sensor(
 describe("MultiDbMigratorTest", () => {
   let adapterA: DatabaseAdapter;
   let adapterB: DatabaseAdapter;
-  let smA: SchemaMigration;
-  let smB: SchemaMigration;
+  let schemaMigrationA: SchemaMigration;
+  let schemaMigrationB: SchemaMigration;
+  let internalMetadataA: InternalMetadata;
+  let internalMetadataB: InternalMetadata;
   let migrationsA: MigrationProxy[];
   let migrationsB: MigrationProxy[];
 
   beforeEach(async () => {
     adapterA = await Base.leaseConnection();
     adapterB = await ARUnit2Model.leaseConnection();
-    smA = new SchemaMigration(adapterA);
-    smB = new SchemaMigration(adapterB);
-    await smA.createTable();
-    await smB.createTable();
-    await smA.deleteAllVersions();
-    await smB.deleteAllVersions();
+    schemaMigrationA = new SchemaMigration(adapterA);
+    schemaMigrationB = new SchemaMigration(adapterB);
+    internalMetadataA = new InternalMetadata(adapterA);
+    internalMetadataB = new InternalMetadata(adapterB);
+    await schemaMigrationA.createTable();
+    await schemaMigrationB.createTable();
+    await schemaMigrationA.deleteAllVersions();
+    await schemaMigrationB.deleteAllVersions();
 
     migrationsA = [
       {
@@ -85,20 +90,20 @@ describe("MultiDbMigratorTest", () => {
   });
 
   afterEach(async () => {
-    await smA.deleteAllVersions();
-    await smB.deleteAllVersions();
+    await schemaMigrationA.deleteAllVersions();
+    await schemaMigrationB.deleteAllVersions();
   });
 
   it("schema migration is different for different connections", () => {
-    expect(smA).not.toBe(smB);
+    expect(schemaMigrationA).not.toBe(schemaMigrationB);
     expect(adapterA).not.toBe(adapterB);
     expect(Base.connectionPool().poolConfig.connectionDescriptor.name).toBe("Base");
     expect(ARUnit2Model.connectionPool().poolConfig.connectionDescriptor.name).toBe("ARUnit2Model");
   });
 
   it("finds migrations", () => {
-    const migratorA = new Migrator(adapterA, migrationsA);
-    const migratorB = new Migrator(adapterB, migrationsB);
+    const migratorA = new Migrator("up", migrationsA, schemaMigrationA, internalMetadataA);
+    const migratorB = new Migrator("up", migrationsB, schemaMigrationB, internalMetadataB);
 
     const listA = [
       [1, "ValidPeopleHaveLastNames"],
@@ -121,10 +126,10 @@ describe("MultiDbMigratorTest", () => {
   });
 
   it("migrations status", async () => {
-    await smA.createVersion("2");
-    await smA.createVersion("10");
+    await schemaMigrationA.createVersion("2");
+    await schemaMigrationA.createVersion("10");
 
-    const migratorA = new Migrator(adapterA, migrationsA);
+    const migratorA = new Migrator("up", migrationsA, schemaMigrationA, internalMetadataA);
     const statusA = await migratorA.migrationsStatus();
     expect(statusA).toEqual([
       { status: "down", version: "001", name: "Valid people have last names" },
@@ -133,8 +138,8 @@ describe("MultiDbMigratorTest", () => {
       { status: "up", version: "010", name: "********** NO FILE **********" },
     ]);
 
-    await smB.createVersion("4");
-    const migratorB = new Migrator(adapterB, migrationsB);
+    await schemaMigrationB.createVersion("4");
+    const migratorB = new Migrator("up", migrationsB, schemaMigrationB, internalMetadataB);
     const statusB = await migratorB.migrationsStatus();
     expect(statusB).toEqual([
       { status: "down", version: "001", name: "People have hobbies" },
@@ -145,7 +150,7 @@ describe("MultiDbMigratorTest", () => {
 
   it("get all versions", async () => {
     const sensorsA = [sensor(1, "S1"), sensor(2, "S2"), sensor(3, "S3")];
-    const migratorA = new Migrator(adapterA, sensorsA);
+    const migratorA = new Migrator("up", sensorsA, schemaMigrationA, internalMetadataA);
 
     await migratorA.up();
     expect(await migratorA.getAllVersions()).toEqual([1, 2, 3]);
@@ -160,7 +165,7 @@ describe("MultiDbMigratorTest", () => {
     expect(await migratorA.getAllVersions()).toEqual([]);
 
     const sensorsB = [sensor(1, "S1"), sensor(2, "S2")];
-    const migratorB = new Migrator(adapterB, sensorsB);
+    const migratorB = new Migrator("up", sensorsB, schemaMigrationB, internalMetadataB);
 
     await migratorB.up();
     expect(await migratorB.getAllVersions()).toEqual([1, 2]);
@@ -173,7 +178,7 @@ describe("MultiDbMigratorTest", () => {
   });
 
   it("finds pending migrations", async () => {
-    await smA.createVersion("1");
+    await schemaMigrationA.createVersion("1");
     const listA = [
       {
         version: 1,
@@ -186,12 +191,12 @@ describe("MultiDbMigratorTest", () => {
         migration: () => anonymousMigration("Bar", 3),
       },
     ];
-    const migratorA = new Migrator(adapterA, listA);
+    const migratorA = new Migrator("up", listA, schemaMigrationA, internalMetadataA);
     const pendingA = await migratorA.pendingMigrations();
     expect(pendingA.length).toBe(1);
     expect(pendingA[0].name).toBe("Bar");
 
-    await smB.createVersion("1");
+    await schemaMigrationB.createVersion("1");
     const listB = [
       {
         version: 1,
@@ -204,7 +209,7 @@ describe("MultiDbMigratorTest", () => {
         migration: () => anonymousMigration("Bar", 3),
       },
     ];
-    const migratorB = new Migrator(adapterB, listB);
+    const migratorB = new Migrator("up", listB, schemaMigrationB, internalMetadataB);
     const pendingB = await migratorB.pendingMigrations();
     expect(pendingB.length).toBe(1);
     expect(pendingB[0].name).toBe("Bar");
@@ -212,27 +217,27 @@ describe("MultiDbMigratorTest", () => {
 
   it("migrator db has no schema migrations table", async () => {
     const sensorsA = [sensor(1, "S1"), sensor(2, "S2"), sensor(3, "S3")];
-    const migratorA = new Migrator(adapterA, sensorsA);
+    const migratorA = new Migrator("up", sensorsA, schemaMigrationA, internalMetadataA);
 
-    await smA.dropTable();
-    expect(await smA.tableExists()).toBe(false);
+    await schemaMigrationA.dropTable();
+    expect(await schemaMigrationA.tableExists()).toBe(false);
     await migratorA.up(1);
-    expect(await smA.tableExists()).toBe(true);
+    expect(await schemaMigrationA.tableExists()).toBe(true);
     await migratorA.rollback();
 
     const sensorsB = [sensor(1, "S1"), sensor(2, "S2"), sensor(3, "S3")];
-    const migratorB = new Migrator(adapterB, sensorsB);
+    const migratorB = new Migrator("up", sensorsB, schemaMigrationB, internalMetadataB);
 
-    await smB.dropTable();
-    expect(await smB.tableExists()).toBe(false);
+    await schemaMigrationB.dropTable();
+    expect(await schemaMigrationB.tableExists()).toBe(false);
     await migratorB.up(1);
-    expect(await smB.tableExists()).toBe(true);
+    expect(await schemaMigrationB.tableExists()).toBe(true);
     await migratorB.rollback();
   });
 
   it("migrator forward", async () => {
     const sensorsA = [sensor(1, "S1"), sensor(2, "S2"), sensor(3, "S3")];
-    const migratorA = new Migrator(adapterA, sensorsA);
+    const migratorA = new Migrator("up", sensorsA, schemaMigrationA, internalMetadataA);
 
     await migratorA.up(1);
     expect(await migratorA.currentVersion()).toBe(1);
@@ -244,7 +249,7 @@ describe("MultiDbMigratorTest", () => {
     expect(await migratorA.currentVersion()).toBe(3);
 
     const sensorsB = [sensor(1, "S1"), sensor(2, "S2"), sensor(3, "S3")];
-    const migratorB = new Migrator(adapterB, sensorsB);
+    const migratorB = new Migrator("up", sensorsB, schemaMigrationB, internalMetadataB);
 
     await migratorB.up(1);
     expect(await migratorB.currentVersion()).toBe(1);

--- a/packages/activerecord/src/multi-db-migrator.trails.test.ts
+++ b/packages/activerecord/src/multi-db-migrator.trails.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Migrator } from "./index.js";
 import { SchemaMigration } from "./schema-migration.js";
+import { InternalMetadata } from "./internal-metadata.js";
 import type { MigrationProxy } from "./migration.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import { anonymousMigration } from "./test-helpers/anonymous-migration.js";
@@ -14,32 +15,46 @@ function noopMigration(version: number, name: string): MigrationProxy {
 describe("MultiDbMigratorTest (trails)", () => {
   let adapterA: DatabaseAdapter;
   let adapterB: DatabaseAdapter;
-  let smA: SchemaMigration;
-  let smB: SchemaMigration;
+  let schemaMigrationA: SchemaMigration;
+  let schemaMigrationB: SchemaMigration;
+  let internalMetadataA: InternalMetadata;
+  let internalMetadataB: InternalMetadata;
 
   beforeEach(async () => {
     adapterA = await Base.leaseConnection();
     adapterB = await ARUnit2Model.leaseConnection();
-    smA = new SchemaMigration(adapterA);
-    smB = new SchemaMigration(adapterB);
-    await smA.createTable();
-    await smB.createTable();
-    await smA.deleteAllVersions();
-    await smB.deleteAllVersions();
+    schemaMigrationA = new SchemaMigration(adapterA);
+    schemaMigrationB = new SchemaMigration(adapterB);
+    internalMetadataA = new InternalMetadata(adapterA);
+    internalMetadataB = new InternalMetadata(adapterB);
+    await schemaMigrationA.createTable();
+    await schemaMigrationB.createTable();
+    await schemaMigrationA.deleteAllVersions();
+    await schemaMigrationB.deleteAllVersions();
   });
 
   afterEach(async () => {
-    await smA.deleteAllVersions();
-    await smB.deleteAllVersions();
+    await schemaMigrationA.deleteAllVersions();
+    await schemaMigrationB.deleteAllVersions();
   });
 
   it("records versions only in the migrated connection's schema_migrations", async () => {
-    const migratorA = new Migrator(adapterA, [
-      noopMigration(1, "ValidPeopleHaveLastNames"),
-      noopMigration(2, "WeNeedReminders"),
-      noopMigration(3, "InnocentJointable"),
-    ]);
-    const migratorB = new Migrator(adapterB, [noopMigration(1, "PeopleHaveHobbies")]);
+    const migratorA = new Migrator(
+      "up",
+      [
+        noopMigration(1, "ValidPeopleHaveLastNames"),
+        noopMigration(2, "WeNeedReminders"),
+        noopMigration(3, "InnocentJointable"),
+      ],
+      schemaMigrationA,
+      internalMetadataA,
+    );
+    const migratorB = new Migrator(
+      "up",
+      [noopMigration(1, "PeopleHaveHobbies")],
+      schemaMigrationB,
+      internalMetadataB,
+    );
 
     await migratorA.up();
 

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -14,7 +14,7 @@ import {
   resolveSchemaFormat,
 } from "../database.js";
 import { discoverMigrations } from "../migration-loader.js";
-import { Migrator, SchemaMigration } from "@blazetrails/activerecord";
+import { InternalMetadata, Migrator, SchemaMigration } from "@blazetrails/activerecord";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
@@ -699,7 +699,12 @@ export class CreatePosts extends Migration {
     );
 
     const migrations = await discoverMigrations(tmpDir);
-    const migrator = new Migrator(adapter, migrations);
+    const migrator = new Migrator(
+      "up",
+      migrations,
+      new SchemaMigration(adapter),
+      new InternalMetadata(adapter),
+    );
 
     // Status before migrate
     const beforeStatus = await migrator.migrationsStatus();
@@ -758,7 +763,12 @@ export class CreateComments extends Migration {
     );
 
     const migrations = await discoverMigrations(tmpDir);
-    const migrator = new Migrator(adapter, migrations);
+    const migrator = new Migrator(
+      "up",
+      migrations,
+      new SchemaMigration(adapter),
+      new InternalMetadata(adapter),
+    );
 
     await migrator.forward(1);
     const posts = await adapter.execute(
@@ -792,7 +802,12 @@ export class CreatePosts extends Migration {
     );
 
     const migrations = await discoverMigrations(tmpDir);
-    const migrator = new Migrator(adapter, migrations);
+    const migrator = new Migrator(
+      "up",
+      migrations,
+      new SchemaMigration(adapter),
+      new InternalMetadata(adapter),
+    );
 
     expect(await migrator.currentVersion()).toBe(0);
     await migrator.migrate();
@@ -814,7 +829,12 @@ export class CreateWidgets extends Migration {
     );
 
     const migrations = await discoverMigrations(tmpDir);
-    const migrator = new Migrator(adapter, migrations);
+    const migrator = new Migrator(
+      "up",
+      migrations,
+      new SchemaMigration(adapter),
+      new InternalMetadata(adapter),
+    );
 
     await migrator.run("up", "20260101000000");
     expect(
@@ -833,7 +853,12 @@ export class CreateWidgets extends Migration {
     const { UnknownMigrationVersionError } = await import("@blazetrails/activerecord");
     adapter = new BetterSQLite3Adapter(":memory:");
 
-    const migrator = new Migrator(adapter, []);
+    const migrator = new Migrator(
+      "up",
+      [],
+      new SchemaMigration(adapter),
+      new InternalMetadata(adapter),
+    );
     await expect(migrator.run("up", "99999999999999")).rejects.toBeInstanceOf(
       UnknownMigrationVersionError,
     );
@@ -854,7 +879,12 @@ export class CreatePosts extends Migration {
     );
 
     const migrations = await discoverMigrations(tmpDir);
-    const migrator = new Migrator(adapter, migrations);
+    const migrator = new Migrator(
+      "up",
+      migrations,
+      new SchemaMigration(adapter),
+      new InternalMetadata(adapter),
+    );
 
     expect((await migrator.pendingMigrations()).length).toBe(1);
     await migrator.migrate();
@@ -1419,7 +1449,12 @@ export class CreatePosts extends Migration {
         },
       ];
       disableMetadataTable(adapter);
-      const migrator = new Migrator(adapter, migrations);
+      const migrator = new Migrator(
+        "up",
+        migrations,
+        new SchemaMigration(adapter),
+        new InternalMetadata(adapter),
+      );
 
       // Migrate should succeed and NOT throw EnvironmentStorageError
       // despite the stamping call site being hit.


### PR DESCRIPTION
Split 2 of 3 from `migrator-connection-pins-adapter-at-construction`.

Every `new Migrator(...)` in a test file now passes Rails' argument list
(`activerecord/lib/active_record/migration.rb:1478`) —
`(direction, migrations, schema_migration, internal_metadata, target_version)` —
instead of the trails `(adapter, migrations, options)` arm that split 1 kept
alive for them. No test construction site passes an adapter first any more.

Construction mirrors the Rails counterparts:

- `migrator_test.rb:26-29` stashes `@schema_migration` / `@internal_metadata` in
  `setup` and `:53,61,68` pass them → `migrator.test.ts` gains
  `schemaMigration` / `internalMetadata` in its `beforeEach` (and `seedVersions`
  now seeds through `@schema_migration`, as Rails does).
- `multi_db_migrator_test.rb:38-43` keeps the per-database pairs and `:142,149`
  pass them → `smA` / `smB` are renamed `schemaMigrationA` /
  `schemaMigrationB`, joined by `internalMetadataA` / `internalMetadataB`.
- Trails-only files with no Rails counterpart build the pair from the adapter at
  the call site, or from a file-scoped `beforeEach` where every case rides
  `Base.connection`.

The `{ environment: "test" }` option at three trails-only sites is dropped:
`record_environment` reads `connection.pool.db_config.env_name`
(`migration.rb:1512-1516`), which those tests already assert against, so the
option never changed the outcome.

Test names are unchanged. `packages/activerecord/src/test-databases.ts` keeps
the old arm deliberately — its bare adapters carry a NullPool, and it is split
3's to retire along with `MigratorOptions`.

**Size note:** this is a *single mechanical transformation* across seven test
files. It runs past the LOC ceiling only because one constructor argument
becomes four and prettier reflows each of ~140 call sites; there is no second
change in here to split out.

Migrator, migration, multi-db, active-record-schema and trailties `db` suites
green locally.

Closes-story: migrator-test-sites-adopt-rails-ctor-signature