### PR TITLE
refactor(activemodel,activerecord): fold the errors Map-default proxies; awaitable setAttributes for nested attributes

### DIFF
--- a/packages/activemodel/src/errors.ts
+++ b/packages/activemodel/src/errors.ts
@@ -15,6 +15,28 @@ export type ErrorDetailHash = { error: string; [k: string]: unknown };
 const EMPTY_ARRAY: readonly never[] = Object.freeze([]);
 
 /**
+ * The JS spelling of Ruby's `hash.default = value` (errors.rb:268-273, :276-284):
+ * override only `get` so a missing key answers `defaultValue`, and bind every
+ * other Map method to the raw target, since Map's internal slots require the
+ * real receiver. Deliberately no `has` trap — `hash.default` does not make
+ * `key?` true.
+ *
+ * @noRailsEquivalent JS has no Hash#default; Ruby's one-line assignment needs a
+ * Proxy here, and one helper is better than a copy per getter.
+ */
+function mapWithDefault<K, V, D>(map: Map<K, V>, defaultValue: D): Map<K, V | D> {
+  return new Proxy(map, {
+    get(target, prop) {
+      if (prop === "get") {
+        return (key: K) => target.get(key) ?? defaultValue;
+      }
+      const val = Reflect.get(target, prop, target);
+      return typeof val === "function" ? val.bind(target) : val;
+    },
+  }) as Map<K, V | D>;
+}
+
+/**
  * Errors — collects validation error messages on a model.
  *
  * Mirrors: ActiveModel::Errors
@@ -166,17 +188,7 @@ export class Errors<TBase extends object = object> {
    * `.get()` returns the singleton frozen `[]`. Mirrors Rails `errors.rb:268-273`.
    */
   get messages(): Map<string, readonly string[]> {
-    const base = this.toHash(false);
-    // Proxy: missing key returns EMPTY_ARRAY (Rails hash.default = EMPTY_ARRAY).
-    return new Proxy(base, {
-      get(target, prop, receiver) {
-        if (prop === "get") {
-          return (key: string) => target.get(key) ?? EMPTY_ARRAY;
-        }
-        const val = Reflect.get(target, prop, target);
-        return typeof val === "function" ? val.bind(target) : val;
-      },
-    });
+    return mapWithDefault(this.toHash(false), EMPTY_ARRAY);
   }
 
   /**
@@ -194,18 +206,7 @@ export class Errors<TBase extends object = object> {
         errors.map((e) => e.details as ErrorDetailHash),
       );
     }
-    // Proxy: override only `get` so missing keys return EMPTY_ARRAY (Rails
-    // hash.default = EMPTY_ARRAY). All other Map methods bound to target so
-    // native Map internals (`size`, `forEach`, etc.) keep the correct receiver.
-    return new Proxy(map, {
-      get(target, prop, receiver) {
-        if (prop === "get") {
-          return (key: string) => target.get(key) ?? EMPTY_ARRAY;
-        }
-        const val = Reflect.get(target, prop, target);
-        return typeof val === "function" ? val.bind(target) : val;
-      },
-    });
+    return mapWithDefault(map, EMPTY_ARRAY);
   }
 
   /**

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -543,7 +543,7 @@ async function createThroughRecord(
 
     if (throughRecord) {
       if (throughRecord.isNewRecord?.()) {
-        await throughRecord.assignAttributes?.(attrs);
+        throughRecord.assignAttributes?.(attrs);
       } else {
         await throughRecord.update?.(attrs);
       }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -4679,6 +4679,7 @@ export interface Base extends Included<typeof AutosaveAssociation> {
   slice(...keys: string[]): Record<string, unknown>;
   valuesAt(...keys: string[]): unknown[];
   assignAttributes(attrs: Record<string, unknown>): void;
+  setAttributes(attrs: Record<string, unknown>): Promise<void>;
   updateAttribute(name: string, value: unknown): Promise<boolean | undefined>;
   updateAttributeBang(name: string, value: unknown): Promise<true | undefined>;
   updateColumn(name: string, value: unknown): Promise<boolean>;
@@ -4865,6 +4866,7 @@ include(Base, {
   slice: _Persistence.slice,
   valuesAt: _Persistence.valuesAt,
   assignAttributes: _Persistence.assignAttributes,
+  setAttributes: _Persistence.setAttributes,
   updateAttribute: _Persistence.updateAttribute,
   updateAttributeBang: _Persistence.updateAttributeBang,
   updateColumn: _Persistence.updateColumn,

--- a/packages/activerecord/src/nested-attributes.trails.test.ts
+++ b/packages/activerecord/src/nested-attributes.trails.test.ts
@@ -249,7 +249,9 @@ describe("nested attributes assignment ordering (trails-only)", () => {
   // (attribute_assignment.rb:9-23, 26-28) are plain `each` loops, so an
   // assignment that reaches DB I/O — a displacing `#{name}_attributes=` running
   // `load_target` / `remove_target!` (has_one_association.rb:59-69) — finishes
-  // before the next key is assigned.
+  // before the next key is assigned. `setAttributes` is the awaitable surface
+  // that keeps that order (RFC 0087); `assignAttributes` answers nil like Rails
+  // and parks the displacing write for `save` to drain.
   it("finishes a displacing nested assignment before assigning the next key", async () => {
     Pirate.acceptsNestedAttributesFor("parrots");
     const pirate = (await Pirate.create({ catchphrase: "Aye" })) as unknown as Pirate;
@@ -280,7 +282,7 @@ describe("nested attributes assignment ordering (trails-only)", () => {
       return false;
     };
 
-    await pirate.assignAttributes({
+    await pirate.setAttributes({
       shipAttributes: { name: "Davy Jones Gold Dagger" },
       parrotsAttributes: { foo: { name: "Posideons Killer" } },
     });

--- a/packages/activerecord/src/nested-attributes.trails.test.ts
+++ b/packages/activerecord/src/nested-attributes.trails.test.ts
@@ -245,6 +245,26 @@ describe("nested attributes assignment ordering (trails-only)", () => {
     expect(observed).toEqual(["Aye"]);
   });
 
+  // `assign_attributes` returns nil (attribute_assignment.rb:28-35); the write a
+  // displacing key owes `remove_target!` is parked on the owner and drained by
+  // `save`, the deferral the constructor's nested re-dispatch already uses.
+  it("returns nothing from assignAttributes and drains the displacing write on save", async () => {
+    const pirate = (await Pirate.create({ catchphrase: "Aye" })) as unknown as Pirate;
+    const displaced = await Ship.create({
+      name: "Nights Dirty Lightning",
+      pirate_id: (pirate as unknown as { id: number }).id,
+    });
+    await (pirate as unknown as { ship: Promise<Base | null> }).ship;
+
+    expect(
+      pirate.assignAttributes({ shipAttributes: { name: "Davy Jones Gold Dagger" } }),
+    ).toBeUndefined();
+    await pirate.save();
+
+    const reloaded = await Ship.find((displaced as unknown as { id: number }).id);
+    expect((reloaded as unknown as { pirate_id: number | null }).pirate_id).toBe(null);
+  });
+
   // `_assign_attributes` and `assign_nested_parameter_attributes`
   // (attribute_assignment.rb:9-23, 26-28) are plain `each` loops, so an
   // assignment that reaches DB I/O — a displacing `#{name}_attributes=` running

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -1140,14 +1140,9 @@ function _assignAttribute(self: AttributeIO, key: string, value: unknown): Promi
 }
 
 /**
- * Mirrors: ActiveRecord::AttributeAssignment#_assign_attributes
- * (attribute_assignment.rb:6-22), reached through
- * ActiveModel's `assign_attributes` (:32-35).
- *
- * Rails buckets multiparameter keys AND Hash values out of the main loop and
- * assigns the nested hashes only after the scalar pass (:21), so a nested
- * writer's `reject_if` / the built record's callbacks observe an owner whose
- * own attributes are already set. Nested runs before multiparameter (:21-22).
+ * Mirrors: ActiveModel::AttributeAssignment#assign_attributes
+ * (attribute_assignment.rb:28-35) — raise unless the argument is a Hash, return
+ * on a blank one, then sanitize and hand off to `_assign_attributes`.
  *
  * Rails returns nil and so does this. A displacing `#{name}_attributes=` key
  * (see `_assignAttribute`) owes a write that Rails runs inline and JS cannot;
@@ -1168,17 +1163,12 @@ export function assignAttributes(this: AttributeIO, attrs: Record<string, unknow
 }
 
 /**
- * Awaitable `attributes=` — Rails aliases `attributes=` to `assign_attributes`
- * (activemodel attribute_assignment.rb:37), and RFC 0087 spells an awaitable
- * writer `set#{Name}`. This is the entry point for a hash whose nested-attributes
- * key displaces an existing record: Rails' `load_target` / `remove_target!`
- * (has_one_association.rb:59-69) run inline inside the `each`, so the write must
- * finish before the next key is assigned, and only an awaited caller can hold
- * that order.
- *
- * @noRailsEquivalent The awaitable half of Rails' `attributes=`
- * (activemodel attribute_assignment.rb:37); a TS `set` accessor cannot be
- * awaited, so RFC 0087's `set#{Name}` spelling carries it.
+ * Awaitable `attributes=`. This is the entry point for a hash whose
+ * nested-attributes key displaces an existing record: Rails' `load_target` /
+ * `remove_target!` (has_one_association.rb:59-69) run inline inside the `each`,
+ * so the write must finish before the next key is assigned, and only an awaited
+ * caller can hold that order.
+
  */
 export async function setAttributes(
   this: AttributeIO,
@@ -1203,7 +1193,12 @@ function isNestedParameterHash(value: unknown): boolean {
 
 /**
  * Mirrors: ActiveRecord::AttributeAssignment#_assign_attributes
- * (attribute_assignment.rb:9-28).
+ * (attribute_assignment.rb:6-23).
+ *
+ * Rails buckets multiparameter keys AND Hash values out of the main loop and
+ * assigns the nested hashes only after the scalar pass (:21), so a nested
+ * writer's `reject_if` / the built record's callbacks observe an owner whose
+ * own attributes are already set. Nested runs before multiparameter (:21-22).
  *
  * Rails' body is a plain `each`; ours yields the promise a step answered so the
  * two entry points above can drive the same `each` — `assignAttributes` parking

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -1149,7 +1149,12 @@ function _assignAttribute(self: AttributeIO, key: string, value: unknown): Promi
  * on this synchronous surface it is parked on the record and drained by `save`,
  * exactly as the constructor's nested re-dispatch parks its own
  * (`_reapplyNestedAttrSetters`). `setAttributes` is the awaitable surface that
- * runs those writes in key order.
+ * runs those writes in key order — it orders the nested keys, it is not the
+ * only path that accepts them: `#{name}_attributes=` is an ordinary generated
+ * writer (nested_attributes.rb:386-392) and Rails hands it to `assign_attributes`
+ * from `ActiveModel::API#initialize` (api.rb:81, reached through
+ * `Base#initialize`'s `super`, core.rb:471-478) and from `update` / `update!`
+ * (persistence.rb:563-580), none of which can await.
  *
  * The parking is uniform: every step after a displacing key — later scalar
  * keys, the nested pass and the multiparameter pass alike — is assigned while

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -1149,64 +1149,46 @@ function _assignAttribute(self: AttributeIO, key: string, value: unknown): Promi
  * writer's `reject_if` / the built record's callbacks observe an owner whose
  * own attributes are already set. Nested runs before multiparameter (:21-22).
  *
- * Rails returns nil; this returns a promise when one of the assignments was a
- * displacing `#{name}_attributes=` (see `_assignAttribute`), which Rails runs
- * inline and JS cannot. Callers free to ignore the nil are equally free to
- * ignore the promise.
+ * Rails returns nil and so does this. A displacing `#{name}_attributes=` key
+ * (see `_assignAttribute`) owes a write that Rails runs inline and JS cannot;
+ * on this synchronous surface it is parked on the record and drained by `save`,
+ * exactly as the constructor's nested re-dispatch parks its own
+ * (`_reapplyNestedAttrSetters`). `setAttributes` is the awaitable surface that
+ * runs those writes in key order.
  */
-export function assignAttributes(
-  this: AttributeIO,
-  attrs: Record<string, unknown>,
-): Promise<void> | void {
+export function assignAttributes(this: AttributeIO, attrs: Record<string, unknown>): void {
   assertHashAttributes(attrs);
   // Mirrors ActiveModel::AttributeAssignment#assign_attributes: bail before
   // sanitizing so a blank strong-params object (always un-permitted) is a
   // no-op rather than raising, then unwrap/forbid via sanitize_for_mass_assignment.
   if (Object.keys(attrs).length === 0) return;
-  attrs = sanitizeForMassAssignment(attrs);
-
-  let multiParameterAttributes: Record<string, unknown> | null = null;
-  let nestedParameterAttributes: Record<string, unknown> | null = null;
-  let pending: Promise<void> | undefined;
-
-  for (const [key, value] of Object.entries(attrs)) {
-    if (key.includes("(")) {
-      (multiParameterAttributes ??= {})[key] = value;
-    } else if (isNestedParameterHash(value)) {
-      (nestedParameterAttributes ??= {})[key] = value;
-    } else {
-      pending = assignAfter(pending, () => _assignAttribute(this, key, value));
-    }
+  for (const pending of _assignAttributes(this, sanitizeForMassAssignment(attrs))) {
+    parkNestedReaderLoad(this as unknown as Base, pending);
   }
-
-  if (nestedParameterAttributes) {
-    const nested = nestedParameterAttributes;
-    pending = assignAfter(pending, () => assignNestedParameterAttributes(this, nested));
-  }
-  if (multiParameterAttributes) {
-    const multi = extractMultiparameterCallstack(multiParameterAttributes).multiparams;
-    pending = assignAfter(pending, () => executeMultiparameterAssignment(this as any, multi));
-  }
-  return pending;
 }
 
 /**
- * Run one step of Rails' `each` over the assignment list: inline when nothing
- * is outstanding, chained behind `pending` when a previous step is still
- * running. Rails' `_assign_attributes` (attribute_assignment.rb:9-23) is a plain
- * `each`, so a step that reaches DB I/O — a displacing `#{name}_attributes=`
- * running `load_target` / `remove_target!` (has_one_association.rb:59-69) —
- * finishes before the next key is assigned. Chaining is how a JS caller that
- * cannot block between iterations keeps that order; without it two displacing
- * keys in one hash would issue their writes concurrently.
+ * Awaitable `attributes=` — Rails aliases `attributes=` to `assign_attributes`
+ * (activemodel attribute_assignment.rb:37), and RFC 0087 spells an awaitable
+ * writer `set#{Name}`. This is the entry point for a hash whose nested-attributes
+ * key displaces an existing record: Rails' `load_target` / `remove_target!`
+ * (has_one_association.rb:59-69) run inline inside the `each`, so the write must
+ * finish before the next key is assigned, and only an awaited caller can hold
+ * that order.
+ *
+ * @noRailsEquivalent The awaitable half of Rails' `attributes=`
+ * (activemodel attribute_assignment.rb:37); a TS `set` accessor cannot be
+ * awaited, so RFC 0087's `set#{Name}` spelling carries it.
  */
-function assignAfter(
-  pending: Promise<void> | undefined,
-  step: () => Promise<void> | void,
-): Promise<void> | undefined {
-  if (pending) return pending.then(() => step());
-  const started = step();
-  return started ?? undefined;
+export async function setAttributes(
+  this: AttributeIO,
+  attrs: Record<string, unknown>,
+): Promise<void> {
+  assertHashAttributes(attrs);
+  if (Object.keys(attrs).length === 0) return;
+  for (const pending of _assignAttributes(this, sanitizeForMassAssignment(attrs))) {
+    await pending;
+  }
 }
 
 /**
@@ -1220,19 +1202,57 @@ function isNestedParameterHash(value: unknown): boolean {
 }
 
 /**
+ * Mirrors: ActiveRecord::AttributeAssignment#_assign_attributes
+ * (attribute_assignment.rb:9-28).
+ *
+ * Rails' body is a plain `each`; ours yields the promise a step answered so the
+ * two entry points above can drive the same `each` — `assignAttributes` parking
+ * each one, `setAttributes` awaiting it before the loop moves on. Written as a
+ * generator rather than duplicated per driver: the loop, its bucketing and its
+ * exceptions stay one body, and they stay synchronous, so a bad multiparameter
+ * key still raises out of `assignAttributes` where Rails raises out of
+ * `assign_attributes`.
+ */
+function* _assignAttributes(
+  self: AttributeIO,
+  attrs: Record<string, unknown>,
+): Generator<Promise<void>, void, undefined> {
+  let multiParameterAttributes: Record<string, unknown> | null = null;
+  let nestedParameterAttributes: Record<string, unknown> | null = null;
+
+  for (const [key, value] of Object.entries(attrs)) {
+    if (key.includes("(")) {
+      (multiParameterAttributes ??= {})[key] = value;
+    } else if (isNestedParameterHash(value)) {
+      (nestedParameterAttributes ??= {})[key] = value;
+    } else {
+      const pending = _assignAttribute(self, key, value);
+      if (pending) yield pending;
+    }
+  }
+
+  if (nestedParameterAttributes) {
+    yield* assignNestedParameterAttributes(self, nestedParameterAttributes);
+  }
+  if (multiParameterAttributes) {
+    const multi = extractMultiparameterCallstack(multiParameterAttributes).multiparams;
+    executeMultiparameterAssignment(self as any, multi);
+  }
+}
+
+/**
  * Mirrors: ActiveRecord::AttributeAssignment#assign_nested_parameter_attributes
  * (attribute_assignment.rb:26-28) — assign any deferred nested attributes after
  * the base attributes have been set.
  */
-function assignNestedParameterAttributes(
+function* assignNestedParameterAttributes(
   self: AttributeIO,
   pairs: Record<string, unknown>,
-): Promise<void> | void {
-  let pending: Promise<void> | undefined;
+): Generator<Promise<void>, void, undefined> {
   for (const [k, v] of Object.entries(pairs)) {
-    pending = assignAfter(pending, () => _assignAttribute(self, k, v));
+    const pending = _assignAttribute(self, k, v);
+    if (pending) yield pending;
   }
-  return pending;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -1150,6 +1150,15 @@ function _assignAttribute(self: AttributeIO, key: string, value: unknown): Promi
  * exactly as the constructor's nested re-dispatch parks its own
  * (`_reapplyNestedAttrSetters`). `setAttributes` is the awaitable surface that
  * runs those writes in key order.
+ *
+ * The parking is uniform: every step after a displacing key — later scalar
+ * keys, the nested pass and the multiparameter pass alike — is assigned while
+ * that write is still in flight, because a `void` return has nothing for the
+ * loop to block on. Rails' `each` (attribute_assignment.rb:9-22) orders them,
+ * and so does `setAttributes`; on this surface only `save`'s drain does. The
+ * steps are all in-memory attribute writes (`assign_multiparameter_attributes`
+ * builds a date/time or aggregation and writes the slot), so none of them reads
+ * or writes the association state the parked write is settling.
  */
 export function assignAttributes(this: AttributeIO, attrs: Record<string, unknown>): void {
   assertHashAttributes(attrs);
@@ -1207,6 +1216,10 @@ function isNestedParameterHash(value: unknown): boolean {
  * exceptions stay one body, and they stay synchronous, so a bad multiparameter
  * key still raises out of `assignAttributes` where Rails raises out of
  * `assign_attributes`.
+ *
+ * `assign_multiparameter_attributes` (:22) is not a yield point: our
+ * `executeMultiparameterAssignment` is synchronous and answers nothing, so
+ * there is no promise to hand a driver.
  */
 function* _assignAttributes(
   self: AttributeIO,


### PR DESCRIPTION
Two of the three bundled stories; the third is released (see below).

## `fold-errors-map-default-proxies`

`Errors#messages` and `Errors#details` each wrapped a fresh `Map` in a
byte-identical Proxy standing in for Ruby's `hash.default = EMPTY_ARRAY`
(`errors.rb:268-273`, `:276-284`) — two copies that could only drift apart.
Both now call one private `mapWithDefault(map, EMPTY_ARRAY)`. No behavior
change: still overrides only `get`, still binds every other Map method to the
raw target (Map internal slots need the real receiver), and still deliberately
has no `has` trap, because `hash.default` does not make `key?` true.

`pnpm api:extra --package activemodel` reports `errors.ts — 0 novel`.

## `awaitable-mass-assignment-for-nested-attributes`

Rails' `assign_attributes` (`activemodel/lib/active_model/attribute_assignment.rb:32-35`)
returns nil and does its work inline. Ours returned `Promise<void> | void`,
because a nested-attributes key that displaces an existing record owes Rails'
inline `load_target` / `remove_target!` (`has_one_association.rb:59-69`) a
write — so `attributes=` (base.ts) and any user caller could silently drop it.

- `assignAttributes` returns `void` again. A displacing key's write is parked
  on the record and drained by `save`, exactly as the constructor's nested
  re-dispatch (`_reapplyNestedAttrSetters`) already parks its own — nothing is
  dropped, and the rejection is captured rather than surfacing unhandled.
- `setAttributes` is the awaitable surface: RFC 0087's `set#{Name}` spelling of
  Rails' `attributes=` alias (`attribute_assignment.rb:37`), which a TS `set`
  accessor cannot carry. It awaits each step, so a displacing write finishes
  before the next key is assigned.
- `assignAfter` is deleted. `_assign_attributes` /
  `assign_nested_parameter_attributes` (`attribute_assignment.rb:6-23`, `:26-28`) are now
  one generator body that yields the promise a step answered, and the two entry
  points drive the same `each`. Written as a generator rather than duplicated
  per driver so the loop, its bucketing and its exceptions stay one body *and*
  stay synchronous — a bad multiparameter key still raises out of
  `assignAttributes` where Rails raises out of `assign_attributes`, which a
  plain `async` body would have turned into a rejection.

### Why `setAttributes` is not the *only* path for nested-attributes keys

The story's converged-shape narrative asks for one more thing than its
acceptance criteria: "make it the only path that accepts nested-attributes
keys". This PR deliberately does not do that, because implementing it literally
would introduce a Rails deviation larger than the one the story removes.

`#{name}_attributes=` is an ordinary generated writer
(`nested_attributes.rb:386-392`), reached by name through
`_assign_attribute` like any other setter. Rails routes its own primary
entry points straight into `assign_attributes` with those keys in hand:
`ActiveModel::API#initialize` (`api.rb:81`), reached from
`ActiveRecord::Base#initialize`'s `super` (`core.rb:471-478`), and
`Persistence#update` / `#update!` (`persistence.rb:563-580`). Rejecting a
nested key in `assignAttributes` would therefore break
`Model.new({shipAttributes: …})`, `Model.create`, and `record.update`, none of
which can await — the exact surface Rails supports.

So the nested key stays accepted on both paths and the write it owes is parked
and drained by `save`, which is the settled trails idiom for a Rails-inline
write on a surface that cannot await (`_reapplyNestedAttrSetters` already parks
the constructor's). `setAttributes` is the path that *orders* those writes, not
the only path that permits the keys. All three acceptance criteria — `void`
return, `assignAfter` deleted, ordering guard holding on the awaitable surface
— are met, and the deviation the story exists to retire (mass assignment
answering a promise) is gone.

### Ordering on the synchronous surface

`assignAttributes` no longer defers the steps that follow a displacing nested
key: where `assignAfter` chained them behind the in-flight promise, they now run
while it is still settling. That is uniform, not specific to the multiparameter
pass — later scalar keys and the nested pass are in the same position — and it
is what a `void` return means: there is nothing for the loop to block on. Rails'
`each` (`attribute_assignment.rb:9-22`) orders them, and so does `setAttributes`;
on the synchronous surface only `save`'s drain does.

It is safe because every one of those steps is an in-memory attribute write.
`executeMultiparameterAssignment` (`multiparameter-attribute-assignment.ts:88`)
is synchronous, returns nothing, and only builds a date/time or aggregation and
writes the slot — it never reads or writes the association state the parked
`remove_target!` is settling. It is also not a yield point for that reason: it
answers no promise a driver could take. Recorded in the `assignAttributes` and
`_assignAttributes` JSDoc.

`setAttributes` needs no `@noRailsEquivalent`: `pnpm api:extra` scores it
*moved*, not novel — it is Rails' `attributes=` under the settled TS spelling,
implemented in the file that already holds `assignAttributes`.

The ordering guard `finishes a displacing nested assignment before assigning
the next key` (`nested-attributes.trails.test.ts`) now exercises
`setAttributes` and still holds, and a new guard pins the synchronous arm:
`assignAttributes` answers `undefined` for a displacing key and `save` still
nullifies the displaced row. It fails on baseline, where the call answered a
promise. The sibling sync guard `assigns nested
parameter hashes after the base attributes` still runs on `assignAttributes`.

## Released: `move-adapter-specific-snapshot-off-ar-internal-metadata`

Handed back unbuilt (`pnpm tasks release`), not deferred silently. Its own
2026-08-07 findings block says the surviving arm (the run-token sidecar) is
bigger than the story's 160 LOC estimate — the blocker is a lane-conditional
key, since `sqlite3_mem` gives every worker its own database while PG/MySQL
slots are shared — and states outright that it "should be its own PR, not
bundled", citing `load-schema-helper.ts:526-532`'s standing warning that this
seam is reshaped one story at a time. Bundling it here would have been the
exact failure mode that warning records.

Closes-story: fold-errors-map-default-proxies
Closes-story: awaitable-mass-assignment-for-nested-attributes
