### PR TITLE
feat(activerecord,activesupport): respond_to_missing? has traps; pool-read record_environment; Date-arm calculations

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1853,9 +1853,9 @@ function wrapCollectionProxy<T extends Base = Base>(
       // indexOf/…) are absent from DELEGATION_RECORD_METHOD_NAMES, so they win here.
       const preferSyncRecordDelegate =
         typeof prop === "string" && target.loaded && DELEGATION_RECORD_METHOD_NAMES.has(prop);
-      if (value !== undefined && !preferSyncRecordDelegate) return value;
-      if (prop in target && !preferSyncRecordDelegate) return value;
       if (typeof prop === "symbol") return value;
+      if (Reflect.has(target, prop) && !preferSyncRecordDelegate) return value;
+      if (value !== undefined && !preferSyncRecordDelegate) return value;
 
       // Numeric indexing — `proxy[0]`, `proxy[1]` read the loaded target
       // via the public `target` accessor. Matches array semantics; same
@@ -1945,6 +1945,16 @@ function wrapCollectionProxy<T extends Base = Base>(
       }
 
       return scopeVal;
+    },
+    // delegation.rb:150-152 — `super || model.respond_to?(method)`, over the
+    // names the `get` trap above fabricates.
+    has(target: any, prop: string | symbol) {
+      if (Reflect.has(target, prop)) return true;
+      if (typeof prop === "symbol") return false;
+      const modelClass = target.model as typeof Base & { _scopes?: Map<string, unknown> };
+      if (modelClass._scopes?.has(prop)) return true;
+      if (delegateEnumerableMethod(prop, () => target.load()) !== undefined) return true;
+      return typeof (modelClass as any)[prop] === "function";
     },
   });
 }

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2229,7 +2229,6 @@ export class MigrationContext {
  * (Rails' `MigrationContext#open`).
  */
 type MigratorOptions = {
-  environment?: string;
   direction?: "up" | "down";
   targetVersion?: number | string | null;
 };
@@ -2242,7 +2241,6 @@ export class Migrator {
   private _migrations: MigrationProxy[];
   private _schemaMigration: SchemaMigration;
   private _internalMetadata: InternalMetadata;
-  private _environment: string;
   private readonly _options: MigratorOptions;
   private readonly _direction: "up" | "down";
   private readonly _targetVersion: number | null;
@@ -2292,11 +2290,6 @@ export class Migrator {
       this._schemaMigration = new SchemaMigration(direction);
       this._internalMetadata = new InternalMetadata(direction);
     }
-    this._environment =
-      options.environment ??
-      getEnv("TRAILS_ENV") ??
-      getEnv("NODE_ENV") ??
-      DatabaseConfigurations.defaultEnv;
     this.validate(migrations);
     this._migrations = this._sortMigrations(migrations);
   }
@@ -2568,20 +2561,13 @@ export class Migrator {
   async recordEnvironment(): Promise<void> {
     if (this.isDown()) return;
     if (this._internalMetadata.enabled) {
-      await this._internalMetadata.set("environment", this._recordedEnvironment());
+      // `NullConfig#env_name` is nil for a bare-adapter Migrator, as in Rails
+      // (`abstract/connection_pool.rb:17-22`); the cast narrows, it does not default.
+      await this._internalMetadata.set(
+        "environment",
+        this.connection.pool.dbConfig.envName as string,
+      );
     }
-  }
-
-  /**
-   * The env name stamped into `ar_internal_metadata`. Rails writes
-   * `connection.pool.db_config.env_name` straight through; a Migrator built on
-   * a bare adapter carries a NullPool, whose config answers nil for every key
-   * (Rails' `NullConfig#method_missing`), so fall back to the env name the
-   * Migrator resolved at construction rather than stamping undefined.
-   */
-  private _recordedEnvironment(): string {
-    const pool = this.connection.pool as { dbConfig?: { envName?: string } } | null;
-    return pool?.dbConfig?.envName ?? this._environment;
   }
 
   /**

--- a/packages/activerecord/src/relation/delegation.trails.test.ts
+++ b/packages/activerecord/src/relation/delegation.trails.test.ts
@@ -21,6 +21,8 @@ import {
 import { Post } from "../test-helpers/models/post.js";
 import { Comment } from "../test-helpers/models/comment.js";
 import { Company, Firm } from "../test-helpers/models/company.js";
+import { fixtures } from "../test-fixtures.js";
+import { registerModel } from "../index.js";
 // Loading these registers each delegate class with the relation family so the
 // carrier resolvers find their base ctor and `uncacheableMethods()` sees the
 // subclass-only methods (`target`, …).
@@ -235,5 +237,52 @@ describe("delegated records operators without an Array.prototype counterpart", (
     const same = { equals, id: 1 };
     expect(delegateArrayMethod("intersection", () => [post])!([same])).toEqual([post]);
     expect(delegateArrayMethod("difference", () => [post])!([same])).toEqual([]);
+  });
+});
+
+/**
+ * `respond_to_missing?` (delegation.rb:150-152) has no direct JS spelling — the
+ * `in` operator is what a `respond_to?`-style probe reaches, and it routes to a
+ * Proxy `has` trap. These assert both dispatch proxies answer `in` for every
+ * name their `get` trap fabricates.
+ */
+describe("respond_to_missing? — `in` on the dispatch proxies", () => {
+  fixtures(["posts", "comments"]);
+
+  registerModel(Post);
+  registerModel(Comment);
+
+  it("answers a named scope, a class method and a delegated array method on a Relation", () => {
+    const rel = Comment.all();
+    expect("containingTheLetterE" in rel).toBe(true);
+    expect("whatAreYou" in rel).toBe(true);
+    expect("toSentence" in rel).toBe(true);
+    expect("partition" in rel).toBe(true);
+    expect("noSuchThingAtAll" in rel).toBe(false);
+  });
+
+  it("answers a named scope, a class method and a delegated array method on a CollectionProxy", async () => {
+    const post = await Post.find(1);
+    const comments = post.comments as unknown as object;
+    expect(comments).toBeInstanceOf(CollectionProxy);
+    expect("containingTheLetterE" in comments).toBe(true);
+    expect("whatAreYou" in comments).toBe(true);
+    expect("toSentence" in comments).toBe(true);
+    expect("partition" in comments).toBe(true);
+    expect("noSuchThingAtAll" in comments).toBe(false);
+  });
+
+  it("keeps an own property whose value is undefined off the delegation path", async () => {
+    // `whatAreYou` is a real Comment class method, so the delegation path would
+    // fabricate a callable for it. An own field of the same name holding
+    // `undefined` must win: the property is defined here, it is just unset.
+    const rel = Comment.all() as unknown as Record<string, unknown>;
+    Object.defineProperty(rel, "whatAreYou", { value: undefined, configurable: true });
+    expect(rel.whatAreYou).toBeUndefined();
+
+    const post = await Post.find(1);
+    const comments = post.comments as unknown as Record<string, unknown>;
+    Object.defineProperty(comments, "whatAreYou", { value: undefined, configurable: true });
+    expect(comments.whatAreYou).toBeUndefined();
   });
 });

--- a/packages/activerecord/src/relation/delegation.ts
+++ b/packages/activerecord/src/relation/delegation.ts
@@ -751,8 +751,8 @@ export function wrapWithScopeProxy<T extends object>(rel: T): T {
     get(target: any, prop: string | symbol, receiver: any) {
       const value = Reflect.get(target, prop, receiver);
       if (typeof prop === "symbol") return value;
+      if (Reflect.has(target, prop)) return value;
       if (value !== undefined) return value;
-      if (prop in target) return value;
 
       const modelClass = target._model as typeof Base;
 
@@ -826,6 +826,16 @@ export function wrapWithScopeProxy<T extends object>(rel: T): T {
         return (...args: any[]) => delegator.apply(target, args);
       }
       return value;
+    },
+    // delegation.rb:150-152 — `super || model.respond_to?(method)`, over the
+    // names the `get` trap above fabricates.
+    has(target: any, prop: string | symbol) {
+      if (Reflect.has(target, prop)) return true;
+      if (typeof prop === "symbol") return false;
+      const modelClass = target._model as typeof Base;
+      if (modelClass._scopes.has(prop)) return true;
+      if (delegateEnumerableMethod(prop, () => target.toArray()) !== undefined) return true;
+      return typeof (modelClass as any)[prop] === "function";
     },
   });
 }

--- a/packages/activerecord/src/test-databases.test.ts
+++ b/packages/activerecord/src/test-databases.test.ts
@@ -6,6 +6,7 @@ import { DatabaseConfigurations } from "./database-configurations.js";
 import { DatabaseTasks } from "./tasks/database-tasks.js";
 import { fixtures } from "./test-fixtures.js";
 import { SchemaMigration } from "./schema-migration.js";
+import { InternalMetadata } from "./internal-metadata.js";
 import { anonymousMigration } from "./test-helpers/anonymous-migration.js";
 
 // Build a (minimal) DatabaseConfigurations whose `configsFor` returns the
@@ -294,6 +295,37 @@ describe("TestDatabasesTest", () => {
 
     await createAndMigrate([adapter], migrations);
     expect(log).toEqual(["up"]);
+  });
+
+  it("createAndMigrate stamps the environment from the adapter's pool", async () => {
+    // migration.rb:1512-1516 — `record_environment` writes
+    // `connection.pool.db_config.env_name`, so the stamp follows the pool the
+    // adapter is checked out of, not any TRAILS_ENV/NODE_ENV reading.
+    const adapter = Base.connection;
+    const schemaMigration = new SchemaMigration(adapter);
+    await schemaMigration.createTable();
+    await schemaMigration.deleteVersion("1");
+    const internalMetadata = new InternalMetadata(adapter);
+    await internalMetadata.createTable();
+    await internalMetadata.deleteAllEntries();
+
+    await createAndMigrate([adapter], [
+      {
+        version: 1,
+        name: "M1",
+        migration: () =>
+          anonymousMigration(
+            "M1",
+            1,
+            async () => {},
+            async () => {},
+          ),
+      },
+    ] as MigrationProxy[]);
+
+    expect(await internalMetadata.get("environment")).toBe(
+      (adapter.pool as { dbConfig: { envName: string } }).dbConfig.envName,
+    );
   });
 
   it("eachDatabase iterates all adapters", async () => {

--- a/packages/activerecord/src/test-databases.ts
+++ b/packages/activerecord/src/test-databases.ts
@@ -7,6 +7,8 @@
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import type { MigrationProxy } from "./migration.js";
 import { Migrator } from "./migration.js";
+import { SchemaMigration } from "./schema-migration.js";
+import { InternalMetadata } from "./internal-metadata.js";
 import { Base } from "./base.js";
 import { DatabaseTasks } from "./tasks/database-tasks.js";
 
@@ -20,15 +22,14 @@ export async function createAndMigrate(
   migrations: MigrationProxy[],
 ): Promise<void> {
   for (const adapter of adapters) {
-    // These adapters are handed in bare, so they carry a NullPool and
-    // `record_environment`'s `connection.pool.db_config.env_name`
-    // (migration.rb:1512-1516) answers nothing — the `environment` option is
-    // the only thing that keeps `ar_internal_metadata.environment` at "test"
-    // rather than whatever TRAILS_ENV/NODE_ENV happen to be. Rails' TestDatabases
-    // defines no `create_and_migrate`, so there is no Rails call shape to
-    // converge this to; it moves to the Rails-shaped arm once the adapters
-    // arrive with a real pool.
-    const migrator = new Migrator(adapter, migrations, { environment: "test" });
+    // Rails' TestDatabases defines no `create_and_migrate`; the Migrator it
+    // builds is the Rails one (`migration.rb:1421-1433`).
+    const migrator = new Migrator(
+      "up",
+      migrations,
+      new SchemaMigration(adapter),
+      new InternalMetadata(adapter),
+    );
     await migrator.up();
   }
 }

--- a/packages/activesupport/src/core-ext/date-ext.test.ts
+++ b/packages/activesupport/src/core-ext/date-ext.test.ts
@@ -1,16 +1,11 @@
 import { describe, it, expect } from "vitest";
-import type { Temporal } from "@blazetrails/date";
+import { Temporal } from "@blazetrails/date";
 import {
-  beginningOfDay,
-  middleOfDay,
-  endOfDay,
   endOfMonth,
   endOfYear,
   advance,
   prevDay,
   nextDay,
-  since,
-  ago,
   lastWeek,
   allDay,
   allWeek,
@@ -28,9 +23,16 @@ import {
   isFuture,
   isToday,
 } from "../time-ext.js";
+import * as DateExt from "../date-ext.js";
+import { setZone, resetZone } from "../time-zone-config.js";
+import { TimeZone } from "../values/time-zone.js";
 
 function d(year: number, month: number, day: number, hour = 0, min = 0, sec = 0, ms = 0): Date {
   return new Date(year, month - 1, day, hour, min, sec, ms);
+}
+
+function pd(year: number, month: number, day: number): Temporal.PlainDate {
+  return new Temporal.PlainDate(year, month, day);
 }
 
 function asDate(instant: Temporal.Instant): Date {
@@ -196,31 +198,77 @@ describe("DateExtCalculationsTest", () => {
   it.skip("tomorrow constructor when zone is set");
 
   it("since", () => {
-    const result = asDate(since(d(2005, 2, 21), 45));
-    expect(result.getSeconds()).toBe(45);
-    expect(result.getDate()).toBe(21);
+    const result = DateExt.since(pd(2005, 2, 21), 45);
+    expect(result.sec).toBe(45);
+    expect(result.day).toBe(21);
   });
 
-  it.skip("since when zone is set");
+  it("since when zone is set", () => {
+    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    setZone(zone);
+    try {
+      expect(DateExt.since(pd(2005, 2, 21), 45).toI()).toBe(
+        zone.local(2005, 2, 21, 0, 0, 45).toI(),
+      );
+      expect(DateExt.since(pd(2005, 2, 21), 45).timeZone).toBe(zone);
+    } finally {
+      resetZone();
+    }
+  });
 
   it("ago", () => {
-    const result = asDate(ago(d(2005, 2, 21), 45));
-    expect(result.getDate()).toBe(20);
-    expect(result.getHours()).toBe(23);
-    expect(result.getMinutes()).toBe(59);
-    expect(result.getSeconds()).toBe(15);
+    const result = DateExt.ago(pd(2005, 2, 21), 45);
+    expect(result.day).toBe(20);
+    expect(result.hour).toBe(23);
+    expect(result.min).toBe(59);
+    expect(result.sec).toBe(15);
   });
 
-  it.skip("ago when zone is set");
+  it("ago when zone is set", () => {
+    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    setZone(zone);
+    try {
+      expect(DateExt.ago(pd(2005, 2, 21), 45).toI()).toBe(
+        zone.local(2005, 2, 20, 23, 59, 15).toI(),
+      );
+      expect(DateExt.ago(pd(2005, 2, 21), 45).timeZone).toBe(zone);
+    } finally {
+      resetZone();
+    }
+  });
 
   it("middle of day", () => {
-    const result = asDate(middleOfDay(d(2005, 2, 21)));
-    expect(result.getHours()).toBe(12);
-    expect(result.getMinutes()).toBe(0);
+    const result = DateExt.middleOfDay(pd(2005, 2, 21));
+    expect(result.hour).toBe(12);
+    expect(result.min).toBe(0);
   });
 
-  it.skip("beginning of day when zone is set");
-  it.skip("end of day when zone is set");
+  it("beginning of day when zone is set", () => {
+    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    setZone(zone);
+    try {
+      expect(DateExt.beginningOfDay(pd(2005, 2, 21)).toI()).toBe(
+        zone.local(2005, 2, 21, 0, 0, 0).toI(),
+      );
+      expect(DateExt.beginningOfDay(pd(2005, 2, 21)).timeZone).toBe(zone);
+    } finally {
+      resetZone();
+    }
+  });
+
+  it("end of day when zone is set", () => {
+    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    setZone(zone);
+    try {
+      const endOfDayInZone = DateExt.endOfDay(pd(2005, 2, 21));
+      expect(endOfDayInZone.hour).toBe(23);
+      expect(endOfDayInZone.min).toBe(59);
+      expect(endOfDayInZone.sec).toBe(59);
+      expect(endOfDayInZone.timeZone).toBe(zone);
+    } finally {
+      resetZone();
+    }
+  });
 
   it("all day", () => {
     const { start, end } = allDay(d(2011, 6, 7));
@@ -315,17 +363,16 @@ describe("DateExtCalculationsTest", () => {
   });
 
   it("beginning of day", () => {
-    const date = d(2005, 2, 21, 10, 30, 45);
-    const result = asDate(beginningOfDay(date));
-    expect(result.getHours()).toBe(0);
-    expect(result.getMinutes()).toBe(0);
-    expect(result.getSeconds()).toBe(0);
+    const result = DateExt.beginningOfDay(pd(2005, 2, 21));
+    expect(result.hour).toBe(0);
+    expect(result.min).toBe(0);
+    expect(result.sec).toBe(0);
   });
 
   it("end of day", () => {
-    const date = d(2005, 2, 21, 10, 30, 45);
-    const result = asDate(endOfDay(date));
-    expect(result.getHours()).toBe(23);
-    expect(result.getMinutes()).toBe(59);
+    const result = DateExt.endOfDay(pd(2005, 2, 21));
+    expect(result.hour).toBe(23);
+    expect(result.min).toBe(59);
+    expect(result.sec).toBe(59);
   });
 });

--- a/packages/activesupport/src/date-ext.ts
+++ b/packages/activesupport/src/date-ext.ts
@@ -1,0 +1,172 @@
+/**
+ * The `Date` arm of ActiveSupport's calculations reopenings
+ * (`core_ext/date/calculations.rb`). Rails keeps `Date` and `Time` as separate
+ * receivers: a `Date` is a calendar day with no time-of-day and no zone, so its
+ * time-of-day calculations first widen the day into a zoned `Time` through
+ * `in_time_zone` and then delegate to the `Time` arm. `time-ext.ts` takes a JS
+ * `Date` — always an instant — and is that `Time` arm; this file is the `Date`
+ * one, keyed on `Temporal.PlainDate`, the calendar-day analogue.
+ *
+ * Mirrors: `class Date` (`core_ext/date/calculations.rb`)
+ */
+
+import { Temporal } from "@blazetrails/date";
+import { IsolatedExecutionState } from "./isolated-execution-state.js";
+import { TimeWithZone } from "./time-with-zone.js";
+import { TimeZone } from "./values/time-zone.js";
+import { ArgumentError, findZoneBang, getZone } from "./time-zone-config.js";
+
+/**
+ * Mirrors: `DateAndTime::Calculations::DAYS_INTO_WEEK`
+ * (`core_ext/date_and_time/calculations.rb:8-16`) — the week-start day names
+ * `Date.beginning_of_week=` validates against.
+ */
+const DAYS_INTO_WEEK: Record<string, number> = {
+  monday: 0,
+  tuesday: 1,
+  wednesday: 2,
+  thursday: 3,
+  friday: 4,
+  saturday: 5,
+  sunday: 6,
+};
+
+const BEGINNING_OF_WEEK = "beginning_of_week";
+
+let _beginningOfWeekDefault: string | null = null;
+
+/** Mirrors: `Date.beginning_of_week_default` (`date/calculations.rb:14`) */
+export function beginningOfWeekDefault(): string | null {
+  return _beginningOfWeekDefault;
+}
+
+/** Mirrors: `Date.beginning_of_week_default=` (`date/calculations.rb:14`) */
+export function setBeginningOfWeekDefault(weekStart: string | null): void {
+  _beginningOfWeekDefault = weekStart;
+}
+
+/**
+ * Mirrors: `Date.beginning_of_week` (`date/calculations.rb:19-21`)
+ *
+ * @missingRailsCall find_beginning_of_week! — the writer `beginning_of_week=`
+ * (`:27-29`) is what calls it, and it is ported as {@link setBeginningOfWeek};
+ * the comparator offers the bare accessor before `set*` for a Ruby writer, so
+ * both Ruby names resolve to this reader.
+ */
+export function beginningOfWeek(): string {
+  return (
+    IsolatedExecutionState.get<string>(BEGINNING_OF_WEEK) ?? beginningOfWeekDefault() ?? "monday"
+  );
+}
+
+/** Mirrors: `Date.beginning_of_week=` (`date/calculations.rb:27-29`) */
+export function setBeginningOfWeek(weekStart: string): void {
+  IsolatedExecutionState.set(BEGINNING_OF_WEEK, findBeginningOfWeekBang(weekStart));
+}
+
+/** Mirrors: `Date.find_beginning_of_week!` (`date/calculations.rb:32-35`) */
+export function findBeginningOfWeekBang(weekStart: string): string {
+  if (!Object.prototype.hasOwnProperty.call(DAYS_INTO_WEEK, weekStart)) {
+    throw new ArgumentError(`Invalid beginning of week: ${weekStart}`);
+  }
+  return weekStart;
+}
+
+/** Mirrors: `Date.yesterday` (`date/calculations.rb:38-40`) */
+export function yesterday(): Temporal.PlainDate {
+  return advance(current(), { days: -1 });
+}
+
+/** Mirrors: `Date.tomorrow` (`date/calculations.rb:43-45`) */
+export function tomorrow(): Temporal.PlainDate {
+  return advance(current(), { days: 1 });
+}
+
+/** Mirrors: `Date.current` (`date/calculations.rb:48-50`) */
+export function current(): Temporal.PlainDate {
+  const zone = getZone();
+  if (zone) {
+    const today = zone.today();
+    return new Temporal.PlainDate(today.year, today.month, today.day);
+  }
+  return Temporal.Now.plainDateISO();
+}
+
+/**
+ * Mirrors: `DateAndTime::Zones#in_time_zone` (`date_and_time/zones.rb:20-28`)
+ * for the `Date` receiver (`core_ext/date/zones.rb` mixes it in). A Date never
+ * `acts_like?(:time)`, so Rails' `time` local is always nil here and
+ * `time_with_zone` takes its `TimeWithZone.new(nil, zone, to_time(:utc))` arm —
+ * the day's midnight read in `zone`.
+ *
+ * The `else` arm is Ruby's `to_time`, a bare `Time` at local midnight. trails
+ * has no bare-Time receiver carrying the `since`/`middle_of_day`/`end_of_day`
+ * this method's five callers delegate to (`time-ext.ts` is a free-function
+ * module over JS `Date`), so the fallback is the same instant expressed in the
+ * system zone — `to_time`'s value under a TimeWithZone receiver.
+ */
+export function inTimeZone(date: Temporal.PlainDate, zone: unknown = getZone()): TimeWithZone {
+  const timeZone = findZoneBang(zone);
+  if (timeZone) {
+    return timeWithZone(date, timeZone);
+  }
+  return timeWithZone(date, TimeZone.find(Temporal.Now.timeZoneId()));
+}
+
+/** Mirrors: `DateAndTime::Zones#time_with_zone` (`date_and_time/zones.rb:32-38`) */
+function timeWithZone(date: Temporal.PlainDate, zone: TimeZone): TimeWithZone {
+  return zone.local(date.year, date.month, date.day);
+}
+
+/** Mirrors: `Date#ago` (`date/calculations.rb:55-57`) */
+export function ago(date: Temporal.PlainDate, seconds: number): TimeWithZone {
+  return inTimeZone(date).since(-seconds);
+}
+
+/** Mirrors: `Date#since` (`date/calculations.rb:61-63`) */
+export function since(date: Temporal.PlainDate, seconds: number): TimeWithZone {
+  return inTimeZone(date).since(seconds);
+}
+
+/** Mirrors: `Date#beginning_of_day` (`date/calculations.rb:67-69`) */
+export function beginningOfDay(date: Temporal.PlainDate): TimeWithZone {
+  return inTimeZone(date);
+}
+
+/** Mirrors: `Date#middle_of_day` (`date/calculations.rb:75-77`) */
+export function middleOfDay(date: Temporal.PlainDate): TimeWithZone {
+  return inTimeZone(date).middleOfDay();
+}
+
+/** Mirrors: `Date#end_of_day` (`date/calculations.rb:85-87`) */
+export function endOfDay(date: Temporal.PlainDate): TimeWithZone {
+  return inTimeZone(date).endOfDay();
+}
+
+/** Mirrors: `Date#advance` (`date/calculations.rb:127-135`) */
+export function advance(
+  date: Temporal.PlainDate,
+  options: { years?: number; months?: number; weeks?: number; days?: number },
+): Temporal.PlainDate {
+  let d = date;
+
+  if (options.years != null) d = d.add({ months: options.years * 12 });
+  if (options.months != null) d = d.add({ months: options.months });
+  if (options.weeks != null) d = d.add({ days: options.weeks * 7 });
+  if (options.days != null) d = d.add({ days: options.days });
+
+  return d;
+}
+
+/** Mirrors: `Date#change` (`date/calculations.rb:143-149`) */
+export function change(
+  date: Temporal.PlainDate,
+  options: { year?: number; month?: number; day?: number },
+): Temporal.PlainDate {
+  // `Hash#fetch` yields the stored value whenever the key is present, `nil` included.
+  return new Temporal.PlainDate(
+    "year" in options ? options.year! : date.year,
+    "month" in options ? options.month! : date.month,
+    "day" in options ? options.day! : date.day,
+  );
+}

--- a/packages/activesupport/src/date-ext.ts
+++ b/packages/activesupport/src/date-ext.ts
@@ -18,7 +18,7 @@ import { ArgumentError, findZoneBang, getZone } from "./time-zone-config.js";
 
 /**
  * Mirrors: `DateAndTime::Calculations::DAYS_INTO_WEEK`
- * (`core_ext/date_and_time/calculations.rb:7-15`) — the week-start day names
+ * (`core_ext/date_and_time/calculations.rb:8-16`) — the week-start day names
  * `Date.beginning_of_week=` validates against.
  */
 const DAYS_INTO_WEEK: Record<string, number> = {

--- a/packages/activesupport/src/date-ext.ts
+++ b/packages/activesupport/src/date-ext.ts
@@ -18,17 +18,17 @@ import { ArgumentError, findZoneBang, getZone } from "./time-zone-config.js";
 
 /**
  * Mirrors: `DateAndTime::Calculations::DAYS_INTO_WEEK`
- * (`core_ext/date_and_time/calculations.rb:8-16`) — the week-start day names
+ * (`core_ext/date_and_time/calculations.rb:7-15`) — the week-start day names
  * `Date.beginning_of_week=` validates against.
  */
 const DAYS_INTO_WEEK: Record<string, number> = {
-  monday: 0,
-  tuesday: 1,
-  wednesday: 2,
-  thursday: 3,
-  friday: 4,
-  saturday: 5,
-  sunday: 6,
+  sunday: 0,
+  monday: 1,
+  tuesday: 2,
+  wednesday: 3,
+  thursday: 4,
+  friday: 5,
+  saturday: 6,
 };
 
 const BEGINNING_OF_WEEK = "beginning_of_week";

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -838,6 +838,11 @@ export class TimeWithZone {
     return this.change({ hour: 0, min: 0, sec: 0 });
   }
 
+  /** Mirrors: `DateAndTime::Calculations#middle_of_day` (`date_and_time/calculations.rb:95-97`) */
+  middleOfDay(): TimeWithZone {
+    return this.change({ hour: 12, min: 0, sec: 0 });
+  }
+
   beginningOfHour(): TimeWithZone {
     return this.change({ min: 0, sec: 0 });
   }

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -838,7 +838,7 @@ export class TimeWithZone {
     return this.change({ hour: 0, min: 0, sec: 0 });
   }
 
-  /** Mirrors: `DateAndTime::Calculations#middle_of_day` (`date_and_time/calculations.rb:95-97`) */
+  /** Mirrors: `Time#middle_of_day` (`core_ext/time/calculations.rb:245-247`) */
   middleOfDay(): TimeWithZone {
     return this.change({ hour: 12, min: 0, sec: 0 });
   }

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/time-ext.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/time-ext.json
@@ -2,20 +2,6 @@
   {
     "package": "activesupport",
     "tsFile": "time-ext.ts",
-    "rubyName": "ago",
-    "call": "in_time_zone",
-    "reason": "Date#ago delegates to `in_time_zone` (date/calculations.rb:55-57) to widen a Date into a zoned Time. time-ext.ts already takes a JS `Date`, an instant, so there is no Date-to-Time widening step to delegate; it ports the Time arm (time/calculations.rb) instead."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-ext.ts",
-    "rubyName": "beginning_of_day",
-    "call": "in_time_zone",
-    "reason": "Date#beginning_of_day delegates to `in_time_zone` (date/calculations.rb:67-69) to widen a Date into a zoned Time. time-ext.ts already takes a JS `Date`, an instant, so there is no Date-to-Time widening step to delegate; it ports the Time arm (time/calculations.rb) instead."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-ext.ts",
     "rubyName": "change",
     "call": "integer?",
     "reason": "JS `Date` carries no zone object and no per-value UTC offset, so time-ext.ts's `change` has no counterpart to Time#change's `zone.respond_to?(:utc_to_local)` / `elsif zone` arms (time/calculations.rb:150-185) and cannot route through them."
@@ -26,27 +12,6 @@
     "rubyName": "change",
     "call": "local",
     "reason": "JS `Date` carries no zone object and no per-value UTC offset, so time-ext.ts's `change` has no counterpart to Time#change's `zone.respond_to?(:utc_to_local)` / `elsif zone` arms (time/calculations.rb:150-185) and cannot route through them."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-ext.ts",
-    "rubyName": "end_of_day",
-    "call": "in_time_zone",
-    "reason": "Date#end_of_day delegates to `in_time_zone` (date/calculations.rb:85-87) to widen a Date into a zoned Time. time-ext.ts already takes a JS `Date`, an instant, so there is no Date-to-Time widening step to delegate; it ports the Time arm (time/calculations.rb) instead."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-ext.ts",
-    "rubyName": "middle_of_day",
-    "call": "in_time_zone",
-    "reason": "Date#middle_of_day delegates to `in_time_zone` (date/calculations.rb:75-77) to widen a Date into a zoned Time. time-ext.ts already takes a JS `Date`, an instant, so there is no Date-to-Time widening step to delegate; it ports the Time arm (time/calculations.rb) instead."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-ext.ts",
-    "rubyName": "since",
-    "call": "in_time_zone",
-    "reason": "Date#since delegates to `in_time_zone` (date/calculations.rb:61-63) to widen a Date into a zoned Time. time-ext.ts already takes a JS `Date`, an instant, so there is no Date-to-Time widening step to delegate; it ports the Time arm (time/calculations.rb) instead."
   },
   {
     "package": "activesupport",

--- a/scripts/api-compare/conventions.test.ts
+++ b/scripts/api-compare/conventions.test.ts
@@ -330,13 +330,15 @@ describe("RUBY_FILE_TS_OVERRIDES", () => {
     expect(rubyFileToTs("interpolate/ruby.rb", "i18n")).toBe("interpolate/ruby.ts");
   });
 
-  it("maps all three activesupport calculations.rb reopenings onto time-ext.ts", () => {
+  it("maps the activesupport calculations.rb reopenings onto their receiver's file", () => {
     // `Time`, `Date` and `DateTime` are each first reopened elsewhere
     // (object/blank.rb:186, date/acts_like.rb:5, date_time/acts_like.rb:6), so
     // without these the 129 methods the calculations.rb files add are measured
-    // against files that define none of them.
+    // against files that define none of them. `Date` is its own receiver: its
+    // calculations widen through `in_time_zone` (date/calculations.rb:55-87)
+    // rather than operating on an instant.
     expect(rubyFileToTs("core_ext/time/calculations.rb", "activesupport")).toBe("time-ext.ts");
-    expect(rubyFileToTs("core_ext/date/calculations.rb", "activesupport")).toBe("time-ext.ts");
+    expect(rubyFileToTs("core_ext/date/calculations.rb", "activesupport")).toBe("date-ext.ts");
     expect(rubyFileToTs("core_ext/date_time/calculations.rb", "activesupport")).toBe("time-ext.ts");
   });
 

--- a/scripts/api-compare/conventions.ts
+++ b/scripts/api-compare/conventions.ts
@@ -151,10 +151,10 @@ export const RUBY_FILE_TS_OVERRIDES: Record<string, string> = {
   // `date_time/acts_like.rb:6` — so the three `calculations.rb` reopenings
   // (`time/calculations.rb:11`, `date/calculations.rb:10`,
   // `date_time/calculations.rb:5`) contribute 129 methods to buckets named
-  // after files that define none of them. trails ports all three onto the one
-  // `time-ext.ts` (its three test files — `core-ext/{time,date,date-time}-ext.test.ts`
-  // — all import from it), the same one-TS-file-for-several-reopenings shape as
-  // `inflector.ts` above.
+  // after files that define none of them. trails ports the `Time` and `DateTime`
+  // reopenings onto the one `time-ext.ts`, the same one-TS-file-for-several-
+  // reopenings shape as `inflector.ts` above; the `Date` reopening has its own
+  // receiver and its own file (see below).
   // `ActiveSupport::JSON` is defined by `json/decoding.rb:12` first, so the
   // module's whole singleton surface — `encode`/`dump` from
   // `json/encoding.rb:16-43` included — buckets there. trails splits the two
@@ -162,7 +162,10 @@ export const RUBY_FILE_TS_OVERRIDES: Record<string, string> = {
   // `json.ts`, `ActiveSupport::JSON::Encoding` on `json/encoding.ts`.
   "activesupport:json/decoding.rb": "json.ts",
   "activesupport:core_ext/time/calculations.rb": "time-ext.ts",
-  "activesupport:core_ext/date/calculations.rb": "time-ext.ts",
+  // The `Date` arm widens through `in_time_zone` before delegating to the
+  // `Time` arm (`date/calculations.rb:55-87`), so it has its own receiver —
+  // `Temporal.PlainDate` — and its own file.
+  "activesupport:core_ext/date/calculations.rb": "date-ext.ts",
   "activesupport:core_ext/date_time/calculations.rb": "time-ext.ts",
   // The activesupport `core_ext/*` reopenings. Ruby splits one class's extensions
   // across a file per concern and reopens the class in each; the extractor stamps


### PR DESCRIPTION
Three bundled stories.

## `relation-proxy-respond-to-missing`

`respond_to_missing?` (`delegation.rb:150-152` — `super || model.respond_to?(method)`)
has no JS spelling other than a Proxy `has` trap, and neither
`wrapWithScopeProxy` nor `wrapCollectionProxy` had one — so `in` answered false
for every name their `get` trap fabricates. Both gain a `has` trap answering for
own/prototype members, named scopes in `_scopes`, the delegated Array/Enumerable
set (asked through `delegateEnumerableMethod`, so the two traps can't drift) and
model class methods.

The ownership test now runs `Reflect.has(target, prop)` before the
value-undefined dispatch, mirroring `command-recorder.ts:25`.

## `create-and-migrate-adapters-carry-a-real-pool`

`createAndMigrate` moves to the Rails-shaped Migrator arm
(`migration.rb:1421-1433`, `(direction, migrations, schema_migration,
internal_metadata, target_version)`), and `record_environment` reads
`connection.pool.db_config.env_name` straight through
(`migration.rb:1512-1516`). `Migrator._environment`, its `_recordedEnvironment`
fallback arm and `MigratorOptions.environment` — none of which Rails has — are
gone.

Per the findings appended to the story, the premise "its adapters are handed in
bare, so they carry a NullPool" is false for the only caller, which passes
`Base.connection` (a real `ConnectionPool`); no pool needs minting. Acceptance
criterion 2 is therefore satisfied in its restated form: the stamp is the pool's
`env_name`, asserted against the pool read rather than the literal `"test"`,
which converging necessarily changes to `"arunit"`. The three
`migrator.trails.test.ts` sites that passed `{ environment: "test" }` already
asserted against the pool read and converge unchanged.

## `date-arm-calculations-widen-through-in-time-zone`

New `packages/activesupport/src/date-ext.ts` is the `Date` arm of
`core_ext/date/calculations.rb`, keyed on `Temporal.PlainDate` — the calendar-day
receiver `time-ext.ts` (an instant) cannot be. `ago` / `since` /
`beginningOfDay` / `middleOfDay` / `endOfDay` widen through `inTimeZone`
(`date_and_time/zones.rb:20-38`) and delegate (`:55-87`), which is exactly what
the five deleted `in_time_zone` baseline rows recorded as absent.
`activesupport:core_ext/date/calculations.rb` now maps there.

`TimeWithZone#middleOfDay` (`date_and_time/calculations.rb:95-97`) was missing
and is the delegate `Date#middle_of_day` needs.

`in_time_zone`'s `else` arm (`time || to_time`, a bare `Time`) has no trails
receiver carrying the `since`/`middle_of_day`/`end_of_day` the five callers
delegate to, so it returns `to_time`'s instant in the system zone under a
`TimeWithZone` receiver; documented at the site.

Tests land in the existing `core-ext/date-ext.test.ts`, which already carried
`it.skip` placeholders for `test_since_when_zone_is_set`,
`test_ago_when_zone_is_set`, `test_beginning_of_day_when_zone_is_set` and
`test_end_of_day_when_zone_is_set` — the four Rails tests that assert exactly
this widening. They are now real, and `since`/`ago`/`beginning of day`/`middle
of day`/`end of day` route through the Date arm.

`beginning_of_week=`'s call to `find_beginning_of_week!` carries a
`@missingRailsCall` receipt: the comparator offers the bare accessor before
`set*` for a Ruby writer, so both Ruby names resolve to the reader, and the call
lives in `setBeginningOfWeek`.

## Gates

- `pnpm api:calls` green (no new baselined rows; 5 deleted by hand).
- `api:compare` activesupport 968 → 972 matched (`date/calculations.rb` 11 → 15);
  no other bucket moves.
- `test:compare` unchanged (15339/22648, 780/1073 files); 4 skipped tests are now real.
- `pnpm lint`, `pnpm typecheck` clean.

Closes-story: relation-proxy-respond-to-missing
Closes-story: create-and-migrate-adapters-carry-a-real-pool
Closes-story: date-arm-calculations-widen-through-in-time-zone
