### PR TITLE
fix(activerecord,activesupport): polymorphic `_type` column first; `t.references foreign_key: true`; Time#change zone arms

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -2079,7 +2079,7 @@ export class AbstractAdapter implements Quoting {
 
   // --- Referential integrity & FK validation ---
 
-  async disableReferentialIntegrity(fn: () => Promise<void>): Promise<void> {
+  async disableReferentialIntegrity(fn: () => Promise<void>, _tables?: string[]): Promise<void> {
     await fn();
   }
 

--- a/packages/activerecord/src/support/canonical-schema.ts
+++ b/packages/activerecord/src/support/canonical-schema.ts
@@ -408,8 +408,8 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
   });
 
   await define("attachments", {}, (t) => {
-    t.bigInteger("record_id", { null: false });
     t.string("record_type", { null: false });
+    t.bigInteger("record_id", { null: false });
     t.index(["record_type", "record_id"], { name: "index_attachments_on_record" });
   });
 
@@ -668,8 +668,8 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
 
   await define("sharded_blog_posts", {}, (t) => {
     t.string("title");
-    t.bigInteger("parent_id");
     t.string("parent_type");
+    t.bigInteger("parent_id");
     t.index(["parent_type", "parent_id"], { name: "index_sharded_blog_posts_on_parent" });
     t.integer("blog_id");
     t.integer("revision");
@@ -718,8 +718,8 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
     t.integer("tags_count", { default: 0 });
     t.integer("children_count", { default: 0 });
     t.integer("parent_id");
-    t.bigInteger("author_id");
     t.string("author_type");
+    t.bigInteger("author_id");
     t.index(["author_type", "author_id"], { name: "index_comments_on_author" });
     t.string("resource_id");
     t.string("resource_type");
@@ -735,8 +735,8 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
   await define("comment_overlapping_counter_caches", {}, (t) => {
     t.integer("user_comments_count_id");
     t.integer("post_comments_count_id");
-    t.bigInteger("commentable_id");
     t.string("commentable_type");
+    t.bigInteger("commentable_id");
   });
 
   await define("companies", {}, (t) => {
@@ -1127,8 +1127,8 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
   await define("members", {}, (t) => {
     t.string("name");
     t.bigInteger("member_type_id");
-    t.bigInteger("admittable_id");
     t.string("admittable_type");
+    t.bigInteger("admittable_id");
   });
 
   await define("member_details", {}, (t) => {
@@ -1270,8 +1270,8 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
   await define("treasures", {}, (t) => {
     t.string("name");
     t.string("type");
-    t.bigInteger("looter_id");
     t.string("looter_type");
+    t.bigInteger("looter_id");
     t.index(["looter_type", "looter_id"], { name: "index_treasures_on_looter" });
     t.bigInteger("ship_id");
     t.index("ship_id");
@@ -1280,22 +1280,28 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
   await define("parrots_pirates", { id: false }, (t) => {
     t.bigInteger("parrot_id");
     t.index("parrot_id");
+    t.foreignKey("parrots", { column: "parrot_id" });
     t.bigInteger("pirate_id");
     t.index("pirate_id");
+    t.foreignKey("pirates", { column: "pirate_id" });
   });
 
   await define("parrots_treasures", { id: false }, (t) => {
     t.bigInteger("parrot_id");
     t.index("parrot_id");
+    t.foreignKey("parrots", { column: "parrot_id" });
     t.bigInteger("treasure_id");
     t.index("treasure_id");
+    t.foreignKey("treasures", { column: "treasure_id" });
   });
 
   await define("parrot_treasures", { id: false }, (t) => {
     t.bigInteger("parrot_id");
     t.index("parrot_id");
+    t.foreignKey("parrots", { column: "parrot_id" });
     t.bigInteger("treasure_id");
     t.index("treasure_id");
+    t.foreignKey("treasures", { column: "treasure_id" });
   });
 
   await define("people", {}, (t) => {
@@ -1540,10 +1546,10 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
 
   await define("sponsors", {}, (t) => {
     t.integer("club_id");
-    t.bigInteger("sponsorable_id");
     t.string("sponsorable_type");
-    t.bigInteger("sponsor_id");
+    t.bigInteger("sponsorable_id");
     t.string("sponsor_type");
+    t.bigInteger("sponsor_id");
   });
 
   await define("string_key_objects", { id: false }, (t) => {
@@ -1684,8 +1690,8 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
     t.string("poly_human_without_inverse_type");
     t.integer("puzzled_polymorphic_human_id");
     t.string("puzzled_polymorphic_human_type");
-    t.bigInteger("super_human_id");
     t.string("super_human_type");
+    t.bigInteger("super_human_id");
   });
 
   await define("interests", {}, (t) => {
@@ -1706,8 +1712,8 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
 
   await define("wheels", {}, (t) => {
     t.integer("size");
-    t.bigInteger("wheelable_id");
     t.string("wheelable_type");
+    t.bigInteger("wheelable_id");
     t.index(["wheelable_type", "wheelable_id"], { name: "index_wheels_on_wheelable" });
   });
 

--- a/packages/activerecord/src/support/drop-all-tables.ts
+++ b/packages/activerecord/src/support/drop-all-tables.ts
@@ -1,5 +1,6 @@
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
 import { ActiveRecordError } from "../errors.js";
+import { canonicalForeignKeyDependents } from "./canonical-schema.js";
 import { TEST_SCHEMA } from "../test-helpers/test-schema.js";
 
 /**
@@ -194,6 +195,19 @@ async function truncateNonEmpty(adapter: DatabaseAdapter, candidates: string[]):
       .join(" UNION ALL ");
     const rows = (await adapter.execute(probe)) as Array<{ t?: string; T?: string }>;
     toTruncate = rows.map((r) => r.t ?? r.T).filter((t): t is string => Boolean(t));
+    // A table nobody probed as non-empty still has to ride along when it holds a
+    // foreign key into one that did: PostgreSQL refuses to truncate a table an FK
+    // points at unless the referencing table is in the same statement, and it
+    // refuses whether or not that table holds rows.
+    const dependents = await canonicalForeignKeyDependents();
+    const wanted = new Set(toTruncate);
+    for (const name of toTruncate) {
+      for (const child of dependents.get(name) ?? []) {
+        if (wanted.has(child)) continue;
+        wanted.add(child);
+        toTruncate.push(child);
+      }
+    }
   } catch {
     toTruncate = candidates;
   }

--- a/packages/activerecord/src/test-fixtures.test.ts
+++ b/packages/activerecord/src/test-fixtures.test.ts
@@ -50,6 +50,13 @@ function makeAdapter(): DatabaseAdapter {
     createSavepoint: vi.fn(async () => {}),
     releaseSavepoint: vi.fn(async () => {}),
     rollbackToSavepoint: vi.fn(async () => {}),
+    // Rails wraps a fixture set's table_deletes in this
+    // (database_statements.rb:486-495) and every adapter defines it
+    // (abstract_adapter.rb:634), so the mock runs the block the way the base
+    // implementation does rather than making the caller guard for its absence.
+    disableReferentialIntegrity: async (fn: () => Promise<void>) => {
+      await fn();
+    },
     quote: (v: unknown) => (typeof v === "string" ? `'${v}'` : String(v)),
     quoteTableName: (n: string) => `"${n}"`,
     quoteColumnName: (n: string) => `"${n}"`,

--- a/packages/activerecord/src/test-fixtures.ts
+++ b/packages/activerecord/src/test-fixtures.ts
@@ -541,15 +541,34 @@ function useFixtures(
   afterEach(async () => {
     if (!fixtures) return;
     const fixtureConnection = getAdapter();
-    // Delete in reverse insertion order to respect FK constraints, each set
-    // through the connection it was seeded on.
+    // Delete in reverse insertion order, each set through the connection it was
+    // seeded on. Rails' fixture deletes are the `table_deletes` half of
+    // `insert_fixtures_set` and ride inside its `disable_referential_integrity`
+    // block (database_statements.rb:145-154), so a delete order an FK forbids —
+    // a table whose children the fixture set doesn't own, e.g. the HABTM join
+    // rows a test created itself — never reaches the database.
+    const deletesByAdapter = new Map<DatabaseAdapter, string[]>();
     for (const [key, { table }] of Object.entries(fixtures).reverse()) {
       const adapter = setAdapters.get(key) ?? fixtureConnection;
       if (!shouldDeleteFixtureRows(adapter, seededInTransaction.get(adapter) ?? false)) continue;
-      try {
-        await adapter.executeMutation(`DELETE FROM ${adapter.quoteTableName(table)}`);
-      } catch (e) {
-        if (!isTableMissingError(e)) throw e;
+      const tables = deletesByAdapter.get(adapter);
+      if (tables === undefined) deletesByAdapter.set(adapter, [table]);
+      else tables.push(table);
+    }
+    for (const [adapter, tables] of deletesByAdapter) {
+      const tableDeletes = async () => {
+        for (const table of tables) {
+          try {
+            await adapter.executeMutation(`DELETE FROM ${adapter.quoteTableName(table)}`);
+          } catch (e) {
+            if (!isTableMissingError(e)) throw e;
+          }
+        }
+      };
+      if (adapter.disableReferentialIntegrity) {
+        await adapter.disableReferentialIntegrity(tableDeletes, tables);
+      } else {
+        await tableDeletes();
       }
     }
     for (const key of Object.keys(store)) {

--- a/packages/activerecord/src/test-fixtures.ts
+++ b/packages/activerecord/src/test-fixtures.ts
@@ -565,11 +565,7 @@ function useFixtures(
           }
         }
       };
-      if (adapter.disableReferentialIntegrity) {
-        await adapter.disableReferentialIntegrity(tableDeletes, tables);
-      } else {
-        await tableDeletes();
-      }
+      await adapter.disableReferentialIntegrity(tableDeletes, tables);
     }
     for (const key of Object.keys(store)) {
       delete store[key];

--- a/packages/activerecord/src/test-fixtures.ts
+++ b/packages/activerecord/src/test-fixtures.ts
@@ -567,11 +567,15 @@ function useFixtures(
           }
         }
       };
-      // Rails wraps its table_deletes unconditionally, but a set no foreign key
-      // points into has nothing for the wrap to protect, and the wrap is not
-      // free: PostgreSQL's runs an `ALTER TABLE ... TRIGGER` pass inside a nested
-      // transaction, which a test that deliberately broke its connection's
-      // `begin_db_transaction` cannot survive.
+      // Rails wraps its table_deletes unconditionally (database_statements.rb:492).
+      // We cannot yet, because this loop deletes through the adapter captured at
+      // seed time, which a test may have evicted or poisoned by then — and PG's
+      // wrap opens a nested transaction that a connection whose
+      // `begin_db_transaction` raises re-raises through. Skipping the wrap where
+      // no foreign key points into the set keeps it off exactly those sets.
+      // Converging is tracked by
+      // 0064-ar-test-infra-layout-fidelity/converge-fixture-teardown-delete-onto-a-live-connection,
+      // which retires this conditional along with the stale-connection cause.
       if (tables.some((table) => (dependents?.get(table)?.length ?? 0) > 0)) {
         await adapter.disableReferentialIntegrity(tableDeletes, tables);
       } else {

--- a/packages/activerecord/src/test-fixtures.ts
+++ b/packages/activerecord/src/test-fixtures.ts
@@ -40,6 +40,7 @@ import {
   leaseFixtureConnection,
   leaseFixtureConnectionFor,
 } from "./test-fixtures/fixture-connection.js";
+import { canonicalForeignKeyDependents } from "./support/canonical-schema.js";
 
 /**
  * A tableless fixture entry: seeds rows directly into the named table with no
@@ -555,6 +556,7 @@ function useFixtures(
       if (tables === undefined) deletesByAdapter.set(adapter, [table]);
       else tables.push(table);
     }
+    const dependents = deletesByAdapter.size > 0 ? await canonicalForeignKeyDependents() : null;
     for (const [adapter, tables] of deletesByAdapter) {
       const tableDeletes = async () => {
         for (const table of tables) {
@@ -565,7 +567,16 @@ function useFixtures(
           }
         }
       };
-      await adapter.disableReferentialIntegrity(tableDeletes, tables);
+      // Rails wraps its table_deletes unconditionally, but a set no foreign key
+      // points into has nothing for the wrap to protect, and the wrap is not
+      // free: PostgreSQL's runs an `ALTER TABLE ... TRIGGER` pass inside a nested
+      // transaction, which a test that deliberately broke its connection's
+      // `begin_db_transaction` cannot survive.
+      if (tables.some((table) => (dependents?.get(table)?.length ?? 0) > 0)) {
+        await adapter.disableReferentialIntegrity(tableDeletes, tables);
+      } else {
+        await tableDeletes();
+      }
     }
     for (const key of Object.keys(store)) {
       delete store[key];

--- a/packages/activerecord/src/test-helpers/test-schema.ts
+++ b/packages/activerecord/src/test-helpers/test-schema.ts
@@ -114,8 +114,8 @@ export const TEST_SCHEMA: Schema = {
   attachments: {
     columns: {
       // Polymorphic reference expanded:
-      record_id: { type: "big_integer", null: false },
       record_type: { type: "string", null: false },
+      record_id: { type: "big_integer", null: false },
     },
     indexes: [{ columns: ["record_type", "record_id"], name: "index_attachments_on_record" }],
   },
@@ -445,8 +445,8 @@ export const TEST_SCHEMA: Schema = {
   sharded_blog_posts: {
     columns: {
       title: "string",
-      parent_id: "big_integer",
       parent_type: "string",
+      parent_id: "big_integer",
       blog_id: "integer",
       revision: "integer",
     },
@@ -501,8 +501,8 @@ export const TEST_SCHEMA: Schema = {
       tags_count: { type: "integer", default: 0 },
       children_count: { type: "integer", default: 0 },
       parent_id: "integer",
-      author_id: "big_integer",
       author_type: "string",
+      author_id: "big_integer",
       // Rails comment: kept as string so preload works when types don't match.
       resource_id: "string",
       resource_type: "string",
@@ -520,8 +520,8 @@ export const TEST_SCHEMA: Schema = {
   comment_overlapping_counter_caches: {
     user_comments_count_id: "integer",
     post_comments_count_id: "integer",
-    commentable_id: "big_integer",
     commentable_type: "string",
+    commentable_id: "big_integer",
   },
 
   companies: {
@@ -1022,8 +1022,8 @@ export const TEST_SCHEMA: Schema = {
   members: {
     name: "string",
     member_type_id: "big_integer",
-    admittable_id: "big_integer",
     admittable_type: "string",
+    admittable_id: "big_integer",
   },
 
   member_details: {
@@ -1189,8 +1189,8 @@ export const TEST_SCHEMA: Schema = {
     columns: {
       name: "string",
       type: "string",
-      looter_id: "big_integer",
       looter_type: "string",
+      looter_id: "big_integer",
       ship_id: "big_integer",
     },
     indexes: [
@@ -1205,6 +1205,10 @@ export const TEST_SCHEMA: Schema = {
       pirate_id: "big_integer",
     },
     indexes: [{ columns: "parrot_id" }, { columns: "pirate_id" }],
+    foreignKeys: [
+      { toTable: "parrots", column: "parrot_id" },
+      { toTable: "pirates", column: "pirate_id" },
+    ],
     primaryKey: false,
   },
 
@@ -1214,6 +1218,10 @@ export const TEST_SCHEMA: Schema = {
       treasure_id: "big_integer",
     },
     indexes: [{ columns: "parrot_id" }, { columns: "treasure_id" }],
+    foreignKeys: [
+      { toTable: "parrots", column: "parrot_id" },
+      { toTable: "treasures", column: "treasure_id" },
+    ],
     primaryKey: false,
   },
 
@@ -1223,6 +1231,10 @@ export const TEST_SCHEMA: Schema = {
       treasure_id: "big_integer",
     },
     indexes: [{ columns: "parrot_id" }, { columns: "treasure_id" }],
+    foreignKeys: [
+      { toTable: "parrots", column: "parrot_id" },
+      { toTable: "treasures", column: "treasure_id" },
+    ],
     primaryKey: false,
   },
 
@@ -1503,10 +1515,10 @@ export const TEST_SCHEMA: Schema = {
 
   sponsors: {
     club_id: "integer",
-    sponsorable_id: "big_integer",
     sponsorable_type: "string",
-    sponsor_id: "big_integer",
+    sponsorable_id: "big_integer",
     sponsor_type: "string",
+    sponsor_id: "big_integer",
   },
 
   // Rails declares `id: false` with an explicit `t.string :id, null: false`
@@ -1663,8 +1675,8 @@ export const TEST_SCHEMA: Schema = {
     poly_human_without_inverse_type: "string",
     puzzled_polymorphic_human_id: "integer",
     puzzled_polymorphic_human_type: "string",
-    super_human_id: "big_integer",
     super_human_type: "string",
+    super_human_id: "big_integer",
   },
 
   interests: {
@@ -1681,8 +1693,8 @@ export const TEST_SCHEMA: Schema = {
   wheels: {
     columns: {
       size: "integer",
-      wheelable_id: "big_integer",
       wheelable_type: "string",
+      wheelable_id: "big_integer",
     },
     indexes: [{ columns: ["wheelable_type", "wheelable_id"], name: "index_wheels_on_wheelable" }],
   },

--- a/packages/activesupport/src/time-ext.test.ts
+++ b/packages/activesupport/src/time-ext.test.ts
@@ -147,6 +147,43 @@ describe("TimeExtCalculationsTest", () => {
     expect(change(d(2005, 2, 22, 15, 15, 10), { min: 45 })).toEqual(i(2005, 2, 22, 15, 45, 0));
   });
 
+  it("change_preserves_offset_for_zoned_times_around_end_of_dst", () => {
+    // DST ended just before 2005-10-30 2:00:00 AM in US/Eastern, and clocks
+    // were rolled back 1 hour.
+    const at = (hour: number) =>
+      Temporal.ZonedDateTime.from({
+        timeZone: "US/Eastern",
+        year: 2005,
+        month: 10,
+        day: 30,
+        hour,
+      });
+    const eq = (actual: Temporal.ZonedDateTime, expected: Temporal.ZonedDateTime) =>
+      expect(actual.epochNanoseconds).toBe(expected.epochNanoseconds);
+
+    const midnight = at(0); // 2005-10-30 00:00:00 -0400
+    const oneAm1 = at(1); // 2005-10-30 01:00:00 -0400
+    const oneAm2 = at(2).subtract({ seconds: 3600 }); // 2005-10-30 01:00:00 -0500
+    const twoAm = at(2); // 2005-10-30 02:00:00 -0500
+    expect(Temporal.ZonedDateTime.compare(oneAm1, oneAm2)).toBe(-1);
+
+    eq(change(midnight, { hour: 1 }), oneAm1);
+    eq(change(midnight, { hour: 2 }), twoAm);
+
+    eq(change(oneAm1, { hour: 0 }), midnight);
+    eq(change(oneAm1, { hour: 1 }), oneAm1);
+    eq(change(oneAm1, { sec: 1 }), oneAm1.add({ seconds: 1 }));
+    eq(change(oneAm1, { hour: 2 }), twoAm);
+
+    eq(change(oneAm2, { hour: 0 }), midnight);
+    eq(change(oneAm2, { hour: 1 }), oneAm2);
+    eq(change(oneAm2, { sec: 1 }), oneAm2.add({ seconds: 1 }));
+    eq(change(oneAm2, { hour: 2 }), twoAm);
+
+    eq(change(twoAm, { hour: 1 }), oneAm2);
+    eq(change(twoAm, { hour: 0 }), midnight);
+  });
+
   it("advance years", () => {
     expect(advance(d(2005, 2, 28, 15, 15, 10), { years: 1 })).toEqual(i(2006, 2, 28, 15, 15, 10));
   });

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -392,54 +392,38 @@ export function change(
   date: Date | Temporal.ZonedDateTime,
   options: ChangeOptions,
 ): Temporal.Instant | Temporal.ZonedDateTime {
-  // Ruby reads the six components off the receiver directly; a JS `Date` and a
-  // `Temporal.ZonedDateTime` spell those readers differently, so resolve them once.
+  // Ruby reads the components off the receiver; a JS `Date` spells those readers
+  // differently, and reads them in the system's local zone, so widen it to the
+  // one shape both arms below share.
   const self =
-    date instanceof Date
-      ? {
-          year: date.getFullYear(),
-          month: date.getMonth() + 1, // 1-indexed
-          day: date.getDate(),
-          hour: date.getHours(),
-          min: date.getMinutes(),
-          sec: date.getSeconds(),
-          nsec: date.getMilliseconds() * 1_000_000,
-        }
-      : {
-          year: date.year,
-          month: date.month,
-          day: date.day,
-          hour: date.hour,
-          min: date.minute,
-          sec: date.second,
-          nsec: date.millisecond * 1_000_000 + date.microsecond * 1_000 + date.nanosecond,
-        };
+    date instanceof Date ? instantFrom(date).toZonedDateTimeISO(Temporal.Now.timeZoneId()) : date;
+  const nsec = self.millisecond * 1_000_000 + self.microsecond * 1_000 + self.nanosecond;
 
   const newYear = options.year ?? self.year;
   const newMonth = options.month ?? self.month;
   const newDay = options.day ?? self.day;
   const newHour = options.hour ?? self.hour;
-  const newMin = options.min ?? (options.hour !== undefined ? 0 : self.min);
+  const newMin = options.min ?? (options.hour !== undefined ? 0 : self.minute);
   let newSec =
-    options.sec ?? (options.hour !== undefined || options.min !== undefined ? 0 : self.sec);
+    options.sec ?? (options.hour !== undefined || options.min !== undefined ? 0 : self.second);
   const newUsec =
     options.usec ??
     (options.hour !== undefined || options.min !== undefined || options.sec !== undefined
       ? 0
-      : self.nsec / 1000);
+      : nsec / 1000);
 
   newSec += newUsec / 1_000_000;
 
   if (date instanceof Date) {
     // `elsif zone` (time/calculations.rb:173-174): a JS `Date` carries no zone
-    // object — it is always read in the system's local zone — so it lands here
-    // rather than on the `utc_to_local` arm below or the trailing `utc_offset` one.
+    // object, only the system's local zone, so it lands here rather than on the
+    // `utc_to_local` arm below or the trailing `utc_offset` one.
     return instantFrom(local(newSec, newMin, newHour, newDay, newMonth, newYear));
   }
 
   // `elsif zone.respond_to?(:utc_to_local)` (time/calculations.rb:150-172).
   const secFloor = Math.floor(newSec);
-  const nsec = Math.round((newSec - secFloor) * 1_000_000_000);
+  const newNsec = Math.round((newSec - secFloor) * 1_000_000_000);
   let newTime = Temporal.ZonedDateTime.from(
     {
       timeZone: date.timeZoneId,
@@ -449,9 +433,9 @@ export function change(
       hour: newHour,
       minute: newMin,
       second: secFloor,
-      millisecond: Math.floor(nsec / 1_000_000),
-      microsecond: Math.floor(nsec / 1_000) % 1_000,
-      nanosecond: nsec % 1_000,
+      millisecond: Math.floor(newNsec / 1_000_000),
+      microsecond: Math.floor(newNsec / 1_000) % 1_000,
+      nanosecond: newNsec % 1_000,
     },
     // Ruby's `Time.new` with a zone object picks the first chronological
     // occurrence of an ambiguous nominal time; `"compatible"` is the same choice.

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -355,35 +355,136 @@ export function since(date: Date, seconds: number): Temporal.Instant {
 // change
 // ---------------------------------------------------------------------------
 
+interface ChangeOptions {
+  year?: number;
+  month?: number;
+  day?: number;
+  hour?: number;
+  min?: number;
+  sec?: number;
+  usec?: number;
+}
+
+/**
+ * `::Time.local` (time/calculations.rb:174) — builds a time in the system's
+ * local zone, taking Ruby's reversed component order.
+ * @internal
+ */
+function local(
+  sec: number,
+  min: number,
+  hour: number,
+  day: number,
+  month: number,
+  year: number,
+): Date {
+  const secFloor = Math.floor(sec);
+  const nsec = Math.round((sec - secFloor) * 1_000_000_000);
+  return new Date(year, month - 1, day, hour, min, secFloor, Math.floor(nsec / 1_000_000));
+}
+
 export function change(
-  date: Date,
-  options: {
-    year?: number;
-    month?: number;
-    day?: number;
-    hour?: number;
-    min?: number;
-    sec?: number;
-    usec?: number;
-  },
-): Temporal.Instant {
-  const newYear = options.year ?? date.getFullYear();
-  const newMonth = options.month ?? date.getMonth() + 1; // 1-indexed
-  const newDay = options.day ?? date.getDate();
-  const newHour = options.hour ?? date.getHours();
-  const newMin = options.min ?? (options.hour !== undefined ? 0 : date.getMinutes());
-  const newSec =
-    options.sec ??
-    (options.hour !== undefined || options.min !== undefined ? 0 : date.getSeconds());
+  date: Temporal.ZonedDateTime,
+  options: ChangeOptions,
+): Temporal.ZonedDateTime;
+export function change(date: Date, options: ChangeOptions): Temporal.Instant;
+export function change(
+  date: Date | Temporal.ZonedDateTime,
+  options: ChangeOptions,
+): Temporal.Instant | Temporal.ZonedDateTime {
+  // Ruby reads the six components off the receiver directly; a JS `Date` and a
+  // `Temporal.ZonedDateTime` spell those readers differently, so resolve them once.
+  const self =
+    date instanceof Date
+      ? {
+          year: date.getFullYear(),
+          month: date.getMonth() + 1, // 1-indexed
+          day: date.getDate(),
+          hour: date.getHours(),
+          min: date.getMinutes(),
+          sec: date.getSeconds(),
+          nsec: date.getMilliseconds() * 1_000_000,
+        }
+      : {
+          year: date.year,
+          month: date.month,
+          day: date.day,
+          hour: date.hour,
+          min: date.minute,
+          sec: date.second,
+          nsec: date.millisecond * 1_000_000 + date.microsecond * 1_000 + date.nanosecond,
+        };
+
+  const newYear = options.year ?? self.year;
+  const newMonth = options.month ?? self.month;
+  const newDay = options.day ?? self.day;
+  const newHour = options.hour ?? self.hour;
+  const newMin = options.min ?? (options.hour !== undefined ? 0 : self.min);
+  let newSec =
+    options.sec ?? (options.hour !== undefined || options.min !== undefined ? 0 : self.sec);
   const newUsec =
     options.usec ??
     (options.hour !== undefined || options.min !== undefined || options.sec !== undefined
       ? 0
-      : date.getMilliseconds() * 1000);
+      : self.nsec / 1000);
 
-  return instantFrom(
-    new Date(newYear, newMonth - 1, newDay, newHour, newMin, newSec, Math.floor(newUsec / 1000)),
+  newSec += newUsec / 1_000_000;
+
+  if (date instanceof Date) {
+    // `elsif zone` (time/calculations.rb:173-174): a JS `Date` carries no zone
+    // object — it is always read in the system's local zone — so it lands here
+    // rather than on the `utc_to_local` arm below or the trailing `utc_offset` one.
+    return instantFrom(local(newSec, newMin, newHour, newDay, newMonth, newYear));
+  }
+
+  // `elsif zone.respond_to?(:utc_to_local)` (time/calculations.rb:150-172).
+  const secFloor = Math.floor(newSec);
+  const nsec = Math.round((newSec - secFloor) * 1_000_000_000);
+  let newTime = Temporal.ZonedDateTime.from(
+    {
+      timeZone: date.timeZoneId,
+      year: newYear,
+      month: newMonth,
+      day: newDay,
+      hour: newHour,
+      minute: newMin,
+      second: secFloor,
+      millisecond: Math.floor(nsec / 1_000_000),
+      microsecond: Math.floor(nsec / 1_000) % 1_000,
+      nanosecond: nsec % 1_000,
+    },
+    // Ruby's `Time.new` with a zone object picks the first chronological
+    // occurrence of an ambiguous nominal time; `"compatible"` is the same choice.
+    { disambiguation: "compatible" },
   );
+
+  // Some versions of Ruby have a bug where Time.new with a zone object and
+  // fractional seconds will end up with a broken utc_offset.
+  // This is fixed in Ruby 3.3.1 and 3.2.4
+  if (!Number.isInteger(newTime.offsetNanoseconds)) {
+    newTime = newTime.add({ nanoseconds: 0 });
+  }
+
+  // When there are two occurrences of a nominal time due to DST ending,
+  // `Time.new` chooses the first chronological occurrence (the one with a
+  // larger UTC offset). However, for `change`, we want to choose the
+  // occurrence that matches this time's UTC offset.
+  //
+  // If the new time's UTC offset is larger than this time's UTC offset, the
+  // new time might be a first chronological occurrence. So we add the offset
+  // difference to fast-forward the new time, and check if the result has the
+  // desired UTC offset (i.e. is the second chronological occurrence).
+  const offsetDifference = newTime.offsetNanoseconds - date.offsetNanoseconds;
+  let newTime2: Temporal.ZonedDateTime;
+  if (
+    offsetDifference > 0 &&
+    (newTime2 = newTime.add({ nanoseconds: offsetDifference })).offsetNanoseconds ===
+      date.offsetNanoseconds
+  ) {
+    return newTime2;
+  } else {
+    return newTime;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/time-ext.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/time-ext.json
@@ -2,20 +2,6 @@
   {
     "package": "activesupport",
     "tsFile": "time-ext.ts",
-    "rubyName": "change",
-    "call": "integer?",
-    "reason": "JS `Date` carries no zone object and no per-value UTC offset, so time-ext.ts's `change` has no counterpart to Time#change's `zone.respond_to?(:utc_to_local)` / `elsif zone` arms (time/calculations.rb:150-185) and cannot route through them."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-ext.ts",
-    "rubyName": "change",
-    "call": "local",
-    "reason": "JS `Date` carries no zone object and no per-value UTC offset, so time-ext.ts's `change` has no counterpart to Time#change's `zone.respond_to?(:utc_to_local)` / `elsif zone` arms (time/calculations.rb:150-185) and cannot route through them."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-ext.ts",
     "rubyName": "since",
     "call": "warn",
     "reason": "Time#since's `warn` is reached only from its `rescue TypeError` arm, which deprecates passing a non-numeric (time/calculations.rb:126-133). time-ext.ts's `since` takes `seconds: number`, so the deprecated call shape is unrepresentable and the arm has nothing to warn about."


### PR DESCRIPTION
`ReferenceDefinition#columns` unshifts the polymorphic `_type` column ahead of
the `_id` column (schema_definitions.rb:280-286) and `add_to` walks that array
in order (:233-236), so `t.references :record, polymorphic: true` emits
`record_type` then `record_id`. Both canonical sources declared the pair the
other way round for all ten polymorphic references in schema.rb; swap them.

`t.references :x, foreign_key: true` also builds a real FK constraint via
`table.foreign_key(foreign_table_name, **foreign_key_options)`
(schema_definitions.rb:242-244, :276-278, :296-300). The six calls in the
parrot/pirate/treasure block declared none; both sources now emit them against
the pluralized target table.

`Time#change` branches on the receiver's zone (time/calculations.rb:150-174):
the `utc_to_local` arm, its `utc_offset.integer?` repair, the DST-fold
selection at :160-171, and the `elsif zone` `::Time.local` fallback. `change`
now takes a `Temporal.ZonedDateTime` receiver so those arms exist —
`disambiguation: "compatible"` reproduces `Time.new`'s first-chronological
choice, and the offset-difference fast-forward picks the occurrence matching
the receiver's offset. The plain-`Date` entry point is the `elsif zone` arm.
Retires the `change -> local` and `change -> integer?` call-mismatch rows.

Closes-story: polymorphic-reference-type-column-comes-first
Closes-story: references-with-foreign-key-true-declare-no-constraint
Closes-story: time-change-zone-arms-and-dst-fold-selection

## Review notes

**The plain-`Date` arm is `elsif zone` (`:173`), not the final `else` (`:174`)
— deliberate.** The story's converged shape says "keep the plain-`Date` entry
point as the zone-less arm, mirroring Rails' final `else`", but Rails' final
`else` is `::Time.new(..., utc_offset)`: a receiver carrying a *frozen numeric
offset*, which is what a Ruby `Time` built from a literal offset has. A JS
`Date` has no such thing — `getFullYear()`/`getHours()` read it through the
system zone and `getTimezoneOffset()` is recomputed per instant, DST and all.
That is exactly `Time#change`'s `elsif zone` receiver, whose arm is
`::Time.local(new_sec, new_min, new_hour, new_day, new_month, new_year, ...)`
(`:173-174`) — so the `Date` arm routes there, through a private `local()`
taking Rails' reversed component order. Sending it to the final `else` instead
would have to invent a fixed offset the value does not carry, and would emit
the wrong instant across a DST boundary. This is also what retires the
`change -> local` baseline row rather than leaving it standing.

**`ArgumentError, "argument out of range"` (`:135`) and the `:offset` /
`:nsec` / `elsif utc?` arms remain unported.** Pre-existing on both sides of
this diff and outside all three stories' acceptance criteria; filed as
`0072-api-compare-parity-burndown/time-change-offset-nsec-utc-arms-and-usec-range-guard`
with the Rails line numbers.


**CI fallout from the six new FKs, fixed in this PR.** Real constraints on the
HABTM join tables broke two trails-side row-clearing paths that had no FK to
respect before:

- `test-fixtures.ts`'s `afterEach` issued its `DELETE FROM` statements bare.
  Rails' fixture deletes are the `table_deletes` half of `insert_fixtures_set`
  and ride inside its `disable_referential_integrity` block
  (`database_statements.rb:145-154`), so a delete order an FK forbids never
  reaches the database. The teardown now groups its deletes per connection and
  wraps each group the same way — which is what a HABTM test needs, since the
  join rows it creates itself are not in the fixture set and so are never
  deleted.
- `drop-all-tables.ts`'s `truncateNonEmpty` narrows the truncate set to the
  tables an `EXISTS` probe found non-empty. PostgreSQL refuses to truncate a
  table an FK points at unless the referencing table is in the same statement,
  empty or not, so the probed set is now widened over
  `canonicalForeignKeyDependents()` — the same closure
  `rebuildCanonicalTables` already walks to widen a drop set.

Verified on all three lanes locally against the files CI flagged
(`nested-attributes.test.ts`, `associations.test.ts`) plus the fixtures,
HABTM and schema-dumper suites.


**Follow-on to dropping the teardown's `disableReferentialIntegrity` guard.**
Removing it was right for real adapters — every Rails adapter defines
`disable_referential_integrity` (`abstract_adapter.rb:634`) and
`AbstractAdapter`'s is non-optional — but `test-fixtures.test.ts`'s hand-rolled
mock adapter didn't stub it, so all three lanes went red on
`adapter.disableReferentialIntegrity is not a function`. Fixed on the mock
rather than by restoring the guard: it now carries the base implementation's
body, like the other adapter methods it already stubs.


**The teardown wrap is now scoped to sets an FK actually points into.** Wrapping
every fixture teardown reddened `TransactionTest > connection removed from pool
when begin raises after successfully beginning a transaction` on PostgreSQL:
that test deliberately replaces its connection's `beginDbTransaction` with a
raise, and PG's `disableReferentialIntegrity` runs its `ALTER TABLE ... TRIGGER`
pass inside a nested transaction, so the teardown re-raised `begin failed` after
the assertions had passed. Rails wraps its `table_deletes` unconditionally, but
a set no foreign key points into has nothing for the wrap to protect — the
teardown now consults `canonicalForeignKeyDependents()` (the same edge map
`truncateNonEmpty` and `rebuildCanonicalTables` use) and takes the bare-delete
path otherwise, which is what every fixture set except the parrot/pirate/treasure
ones did before this PR. Verified causal: reverting just this hunk reproduces
`begin failed` on PG, reapplying it is green.


**On the conditional wrap: intended for this PR, tracked as debt, not
permanent.** Confirming explicitly, since the reviewer asked. It is a real
divergence from Rails' unconditional wrap and I am not claiming otherwise. The
narrower alternative suggested — skip only when `scopedTables` would be empty —
does not apply: `tables` is the delete set and is never empty at that point, so
that condition would never fire.

The root cause is one level down and predates this PR: `test-fixtures.ts`'s
`afterEach` delete loop is a trails invention with no Rails counterpart (Rails'
non-transactional `teardown_fixtures` deletes nothing; the rows go at the *next*
load, inside `insert_fixtures_set`, on a freshly-leased connection), and it
deletes through the adapter captured at seed time — which a test may have
evicted or poisoned by then. That is what makes PG's nested-transaction wrap
unsurvivable, and it is why the wrap cannot simply be made unconditional here.
Filed as
`0064-ar-test-infra-layout-fidelity/converge-fixture-teardown-delete-onto-a-live-connection`,
whose acceptance criteria explicitly require deleting this conditional once the
stale-connection cause is gone; the call-site comment now names that story.
