### PR TITLE
refactor(activerecord): CommentOrChanges requires both descriptor keys; MigrationContext test sites pass bookkeeping objects; _commandSettled flips at every issue site

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -10,7 +10,6 @@
 
 import { inspectExplainOption } from "./abstract/database-statements.js";
 import type { ExplainOption } from "./abstract/database-statements.js";
-import type { CommentOrChanges } from "./abstract/schema-statements.js";
 import {
   isWriteQuery as mysqlIsWriteQuery,
   maxAllowedPacket as mysqlMaxAllowedPacket,

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -10,6 +10,7 @@
 
 import { inspectExplainOption } from "./abstract/database-statements.js";
 import type { ExplainOption } from "./abstract/database-statements.js";
+import type { CommentOrChanges } from "./abstract/schema-statements.js";
 import {
   isWriteQuery as mysqlIsWriteQuery,
   maxAllowedPacket as mysqlMaxAllowedPacket,
@@ -688,10 +689,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return val && val.trim().length > 0 ? val : null;
   }
 
-  async changeTableComment(
-    tableName: string,
-    commentOrChanges: string | Record<string, string | null>,
-  ): Promise<void> {
+  async changeTableComment(tableName: string, commentOrChanges: CommentOrChanges): Promise<void> {
     const raw = this.extractNewCommentValue(commentOrChanges);
     // Mirrors Rails: `comment = "" if comment.nil?` then `COMMENT #{quote(comment)}`.
     const c = raw == null ? "" : String(raw);

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -221,8 +221,13 @@ export interface ValidateConstraintStatements {
   ): Promise<void>;
 }
 
-/** A comment argument: either the new value, or Rails' `{ from:, to: }` change hash. */
-export type CommentOrChanges = string | null | { from?: string | null; to?: string | null };
+/**
+ * A comment argument: either the new value, or Rails' `{ from:, to: }` change hash.
+ * Both keys are required: `extract_new_default_value` only unwraps when the hash
+ * `has_key?(:from) && has_key?(:to)`
+ * (activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:1820-1827).
+ */
+export type CommentOrChanges = string | null | { from: string | null; to: string | null };
 
 /**
  * Comment DDL that only adapters supporting `supportsComments` implement.
@@ -1867,7 +1872,7 @@ export class SchemaStatements {
   async changeColumnComment(
     _tableName: string,
     _columnName: string,
-    _commentOrChanges: string | null | { from?: string; to?: string },
+    _commentOrChanges: CommentOrChanges,
   ): Promise<void> {
     throw new Error(
       `NotImplementedError: ${this.adapterName} does not support changing column comments`,

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -354,7 +354,11 @@ export class PostgreSQLAdapter
       pgDeallocSerializers.set(value, (deallocSql) => {
         this._pendingDeallocate = (this._pendingDeallocate ?? Promise.resolve())
           .then(() => {
-            this._commandSettled = false;
+            // Only the pinned client's wire cycle is what transactionStatus
+            // reports on; a parked DEALLOCATE that outlives a reconnect would
+            // otherwise strand the flag false, since the ReadyForQuery listener
+            // that re-arms it is attached per pg.Client.
+            if (this._rawConnection === value) this._commandSettled = false;
             return value.query(deallocSql);
           })
           .then(

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -77,6 +77,7 @@ import { captureUnwrappedExecute, dirtiesQueryCache } from "./abstract/query-cac
 import { SchemaStatements } from "./postgresql/schema-statements-class.js";
 import type { SchemaStatements as AbstractSchemaStatements } from "./abstract/schema-statements.js";
 import type {
+  CommentOrChanges,
   JoinTableOptions,
   ValidateConstraintStatements,
   CommentStatements,
@@ -352,7 +353,10 @@ export class PostgreSQLAdapter
       // DEALLOCATE under the connection's control (postgresql_adapter.rb:307).
       pgDeallocSerializers.set(value, (deallocSql) => {
         this._pendingDeallocate = (this._pendingDeallocate ?? Promise.resolve())
-          .then(() => value.query(deallocSql))
+          .then(() => {
+            this._commandSettled = false;
+            return value.query(deallocSql);
+          })
           .then(
             () => {},
             () => {},
@@ -468,6 +472,14 @@ export class PostgreSQLAdapter
    * — but node-pg settles the query promise on the terminating message, so
    * without this the caller can read the status back in that gap and see a
    * command that is over reported as PQTRANS_ACTIVE.
+   *
+   * The invariant is that it is set `false` immediately before *every*
+   * `client.query` issued on the pinned client — `_performQuery`, `exec`, the
+   * `_bt_ret_*` savepoint wrapper in `executeMutation`, and both DEALLOCATE
+   * sites (statement-pool eviction and `DEALLOCATE ALL` at checkout) — and back
+   * to `true` only by the terminating-message handlers in
+   * `_attachReadyForQueryListener`. Miss an issue site and `transactionStatus`
+   * answers IDLE/INTRANS while that command is mid-cycle.
    */
   private _commandSettled = true;
   private _databaseVersion: number | null = null;
@@ -1457,6 +1469,7 @@ export class PostgreSQLAdapter
   private async _maybeDrainOrphanedPreparedStatements(client: pg.Client): Promise<void> {
     if (!this._needsDeallocateAll) return;
     this._needsDeallocateAll = false;
+    this._commandSettled = false;
     await client.query("DEALLOCATE ALL");
   }
 
@@ -1905,9 +1918,15 @@ export class PostgreSQLAdapter
             // fails and we re-run without it.
             payload.sql = withReturning;
             try {
-              if (useSavepoint) await client.query(`SAVEPOINT "${spName}"`);
+              if (useSavepoint) {
+                this._commandSettled = false;
+                await client.query(`SAVEPOINT "${spName}"`);
+              }
               const result = await this._performQuery(client, withReturning, binds, payload);
-              if (useSavepoint) await client.query(`RELEASE SAVEPOINT "${spName}"`);
+              if (useSavepoint) {
+                this._commandSettled = false;
+                await client.query(`RELEASE SAVEPOINT "${spName}"`);
+              }
               const affected = this.affectedRows(result);
               payload.row_count = affected;
               if (result.rows.length > 1) {
@@ -1927,7 +1946,9 @@ export class PostgreSQLAdapter
               // originally written for.
               if (err instanceof PreparedStatementCacheExpired) throw err;
               if (useSavepoint) {
+                this._commandSettled = false;
                 await client.query(`ROLLBACK TO SAVEPOINT "${spName}"`).catch(() => {});
+                this._commandSettled = false;
                 await client.query(`RELEASE SAVEPOINT "${spName}"`).catch(() => {});
               }
               payload.sql = pgSql;
@@ -4642,13 +4663,10 @@ export interface PostgreSQLAdapter {
   changeColumnComment(
     tableName: string,
     columnName: string,
-    commentOrChanges: string | null | { from?: string | null; to?: string | null },
+    commentOrChanges: CommentOrChanges,
   ): Promise<void>;
 
-  changeTableComment(
-    tableName: string,
-    commentOrChanges: string | null | { from?: string | null; to?: string | null },
-  ): Promise<void>;
+  changeTableComment(tableName: string, commentOrChanges: CommentOrChanges): Promise<void>;
 
   /** @internal */
   validateConstraint(tableName: string, constraintName: string): Promise<void>;

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -2,6 +2,7 @@ import { ValueType, ArgumentError } from "@blazetrails/activemodel";
 import { Nodes } from "@blazetrails/arel";
 import { singularize, getCrypto } from "@blazetrails/activesupport";
 import { SchemaStatements as AbstractSchemaStatements } from "../abstract/schema-statements.js";
+import type { CommentOrChanges } from "../abstract/schema-statements.js";
 import {
   ChangeColumnDefinition,
   ChangeColumnDefaultDefinition,
@@ -954,7 +955,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
   override async changeColumnComment(
     tableName: string,
     columnName: string,
-    commentOrChanges: string | null | { from?: string | null; to?: string | null },
+    commentOrChanges: CommentOrChanges,
   ): Promise<void> {
     // Mirrors PostgreSQL::SchemaStatements#change_column_comment: clear the
     // statement cache and unwrap the {from:, to:} change hash before issuing
@@ -968,7 +969,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
 
   override async changeTableComment(
     tableName: string,
-    commentOrChanges: string | null | { from?: string | null; to?: string | null },
+    commentOrChanges: CommentOrChanges,
   ): Promise<void> {
     // Mirrors PostgreSQL::SchemaStatements#change_table_comment.
     this.clearCacheBang();

--- a/packages/activerecord/src/migrator.test.ts
+++ b/packages/activerecord/src/migrator.test.ts
@@ -154,7 +154,11 @@ describe("MigratorTest", () => {
   });
 
   it("finds migrations", () => {
-    const migrations = new MigrationContext([`${MIGRATIONS_ROOT}/valid`]).migrations;
+    const migrations = new MigrationContext(
+      [`${MIGRATIONS_ROOT}/valid`],
+      schemaMigration,
+      internalMetadata,
+    ).migrations;
 
     (
       [
@@ -169,8 +173,11 @@ describe("MigratorTest", () => {
   });
 
   it("finds migrations in subdirectories", () => {
-    const migrations = new MigrationContext([`${MIGRATIONS_ROOT}/valid_with_subdirectories`])
-      .migrations;
+    const migrations = new MigrationContext(
+      [`${MIGRATIONS_ROOT}/valid_with_subdirectories`],
+      schemaMigration,
+      internalMetadata,
+    ).migrations;
 
     (
       [
@@ -189,7 +196,8 @@ describe("MigratorTest", () => {
       `${MIGRATIONS_ROOT}/valid_with_timestamps`,
       `${MIGRATIONS_ROOT}/to_copy_with_timestamps`,
     ];
-    const migrations = new MigrationContext(directories).migrations;
+    const migrations = new MigrationContext(directories, schemaMigration, internalMetadata)
+      .migrations;
 
     (
       [
@@ -206,13 +214,21 @@ describe("MigratorTest", () => {
   });
 
   it("finds migrations in numbered directory", () => {
-    const migrations = new MigrationContext([`${MIGRATIONS_ROOT}/10_urban`]).migrations;
+    const migrations = new MigrationContext(
+      [`${MIGRATIONS_ROOT}/10_urban`],
+      schemaMigration,
+      internalMetadata,
+    ).migrations;
     expect(migrations[0].version).toBe(9);
     expect(migrations[0].name).toBe("AddExpressions");
   });
 
   it("relative migrations", () => {
-    const list = new MigrationContext([`${MIGRATIONS_ROOT}/valid`]).migrations;
+    const list = new MigrationContext(
+      [`${MIGRATIONS_ROOT}/valid`],
+      schemaMigration,
+      internalMetadata,
+    ).migrations;
     const migrationProxy = list.find((item) => item.name === "ValidPeopleHaveLastNames");
     expect(migrationProxy).toBeTruthy();
   });
@@ -238,7 +254,7 @@ describe("MigratorTest", () => {
 
     const status = await new Migrator(
       "up",
-      new MigrationContext([path]).migrations,
+      new MigrationContext([path], schemaMigration, internalMetadata).migrations,
       schemaMigration,
       internalMetadata,
     ).migrationsStatus();
@@ -256,7 +272,7 @@ describe("MigratorTest", () => {
 
     const status = await new Migrator(
       "up",
-      new MigrationContext([path]).migrations,
+      new MigrationContext([path], schemaMigration, internalMetadata).migrations,
       schemaMigration,
       internalMetadata,
     ).migrationsStatus();
@@ -276,7 +292,7 @@ describe("MigratorTest", () => {
 
     const status = await new Migrator(
       "up",
-      new MigrationContext([path]).migrations,
+      new MigrationContext([path], schemaMigration, internalMetadata).migrations,
       schemaMigration,
       internalMetadata,
     ).migrationsStatus();
@@ -294,7 +310,7 @@ describe("MigratorTest", () => {
 
     const status = await new Migrator(
       "up",
-      new MigrationContext([path]).migrations,
+      new MigrationContext([path], schemaMigration, internalMetadata).migrations,
       schemaMigration,
       internalMetadata,
     ).migrationsStatus();
@@ -314,7 +330,7 @@ describe("MigratorTest", () => {
 
     const status = await new Migrator(
       "up",
-      new MigrationContext([path]).migrations,
+      new MigrationContext([path], schemaMigration, internalMetadata).migrations,
       schemaMigration,
       internalMetadata,
     ).migrationsStatus();
@@ -334,7 +350,7 @@ describe("MigratorTest", () => {
 
     const status = await new Migrator(
       "up",
-      new MigrationContext(paths).migrations,
+      new MigrationContext(paths, schemaMigration, internalMetadata).migrations,
       schemaMigration,
       internalMetadata,
     ).migrationsStatus();


### PR DESCRIPTION
Three convergences from a five-story bundle; two stories were released unbuilt (see below).

### `CommentOrChanges` requires both descriptor keys (RFC 0051)

Rails' `extract_new_default_value` only unwraps the change hash when it
`has_key?(:from) && has_key?(:to)`
(`activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:1820-1827`;
`alias :extract_new_comment_value :extract_new_default_value`). The TS type had
both keys optional, so `{ from: "old", to: undefined }` typechecked and the
unwrap returned `undefined` from a `string | null` position — a type-accuracy
gap on direct-to-adapter calls (`Migration#changeColumnComment` rejects it with
`ArgumentError` before it can get there).

The arm now reads `{ from: string | null; to: string | null }`, and all six
hand-rolled spellings of the parameter use `CommentOrChanges` — no adapter
re-declares the shape inline:

- `abstract/schema-statements.ts:1870` (was `{ from?: string; to?: string }`)
- `postgresql/schema-statements-class.ts:957,971`
- `postgresql-adapter.ts:4645,4650`
- `abstract-mysql-adapter.ts:693` (was `string | Record<string, string | null>`,
  no nil arm) and `:844` (was `{ from: unknown; to: string | null }`)

With `to` required, `changeColumnComment`'s `undefined → null` normalization is
unreachable and is removed along with the trails-only test pinning it —
`abstract_mysql_adapter.rb:391-394` is just extract-then-`change_column`, which
is now what the body is.

The remaining `as string | null` inside `extractNewCommentValue`'s callers is
removed by the open #6195, which types the alias's return; the two PRs touch
adjacent lines in these files and whichever lands second will need a trivial
rebase.

### `MigrationContext` test sites pass the bookkeeping objects (RFC 0051)

`migrator_test.rb` passes `@schema_migration, @internal_metadata` at every
`MigrationContext.new` (`:93`, `:102`, `:112`, `:125`). All eleven sites in
`migrator.test.ts` were bare `new MigrationContext([path])`, leaving the context
to build its own `SchemaMigration` / `InternalMetadata` from the adapter. The
objects were already in scope from PR #6194's `beforeEach`. Test names
unchanged; `pnpm test:compare` delta is zero.

### `_commandSettled` flips at every issue site (RFC 0085)

PR #6189 retired the pinned-query mutex and re-homed the flag's flip from
`_serializePinnedQuery` to the individual issuing sites, missing two groups.
Both are now covered (option 1 of the story's two — option 2, deriving the
window from node-pg's own state, is what the flag exists to correct, since
node-pg settles the query promise on CommandComplete rather than ReadyForQuery):

- the `_bt_ret_*` SAVEPOINT / RELEASE SAVEPOINT / ROLLBACK TO SAVEPOINT queries
  in `executeMutation`'s INSERT-without-RETURNING path
- the statement-pool eviction DEALLOCATE parked by the `_rawConnection`
  setter's serializer, and the checkout-time `DEALLOCATE ALL`

Without them `transactionStatus` could answer `PQTRANS_IDLE`/`PQTRANS_INTRANS`
while one of those was mid-cycle, mis-gating `_cancelAnyRunningQuery`
(`postgresql/database_statements.rb:127-128`). The `DEALLOCATE ALL` site runs
after `_attachReadyForQueryListener`, so the flag is always re-armed. The
docblock now states the invariant instead of describing only the motivation.

### Released unbuilt

- `move-adapter-specific-snapshot-off-ar-internal-metadata` — its own findings
  section says it must be its own PR (five PRs reshaped that seam in one
  evening and three broke only in the merge) and that it is larger than its
  160 LOC estimate.
- `pg-maria-adapter-unique-flake-burndown-round-2` — an open-ended triage of
  eleven branches against a fresh CI-data window, with no code target that fits
  alongside this.

Closes-story: converge-comment-or-changes-descriptor-spellings
Closes-story: migration-context-test-sites-pass-bookkeeping-objects
Closes-story: pg-command-settled-not-flipped-at-every-issue-site
