### PR TITLE
refactor(activerecord): Migrator#connection resolves DatabaseTasks.migration_connection per call

### DIFF
--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2561,6 +2561,12 @@ export class Migrator {
    * (`migration.rb:1488-1491`). `DatabaseTasks` is reached through the
    * call-time config source: naming `tasks/database-tasks.js` here would be a
    * load-time edge back into a module that already imports this one.
+   *
+   * Rails' body is a bare delegation with no null branch — `migration_connection`
+   * is `migration_class.lease_connection`
+   * (`tasks/database_tasks.rb:533-535`), which raises rather than answering nil.
+   * The assertions keep that shape; adding a guard here would be a branch Rails
+   * does not have.
    */
   private get connection(): DatabaseAdapter {
     return migrationArConfig()!.databaseTasks!().migrationConnection()!;

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2239,41 +2239,23 @@ export class MigrationContext {
   }
 }
 
-/**
- * Construction-time options. `direction` / `targetVersion` are the per-run
- * state Rails' `Migrator` holds as `@direction` / `@target_version`; a Migrator
- * built without them is the long-lived, MigrationContext-shaped instance
- * (Rails' `MigrationContext#open`).
- */
-type MigratorOptions = {
-  direction?: "up" | "down";
-  targetVersion?: number | string | null;
-};
-
 export class Migrator {
   /** Mirrors: ActiveRecord::Migrator.migrations_paths (`migration.rb:1407`) */
   static migrationsPaths: string[] = [];
 
-  private _adapter: DatabaseAdapter;
   private _migrations: MigrationProxy[];
   private _schemaMigration: SchemaMigration;
   private _internalMetadata: InternalMetadata;
-  private readonly _options: MigratorOptions;
   private readonly _direction: "up" | "down";
   private readonly _targetVersion: number | null;
   private _migratedVersions?: Set<number>;
 
   /**
-   * Mirrors: `ActiveRecord::Migrator#initialize` (`migration.rb:1421-1433`) —
+   * Mirrors: `ActiveRecord::Migrator#initialize` (`migration.rb:1418-1433`) —
    * `(direction, migrations, schema_migration, internal_metadata,
    * target_version = nil)`. The bookkeeping objects are arguments, as Rails has
    * them, so a multi-database caller can hand each Migrator its own pair
    * (`multi_db_migrator_test.rb:142,149`).
-   *
-   * The `(adapter, migrations, options)` arm is the shape trails carried before
-   * the widening; the remaining test call sites still pass it and split 2 of
-   * `migrator-connection-pins-adapter-at-construction` migrates them file by
-   * file, after which this overload goes away with `MigratorOptions`.
    */
   constructor(
     direction: "up" | "down",
@@ -2281,32 +2263,11 @@ export class Migrator {
     schemaMigration: SchemaMigration,
     internalMetadata: InternalMetadata,
     targetVersion?: number | string | null,
-  );
-  constructor(adapter: DatabaseAdapter, migrations: MigrationProxy[], options?: MigratorOptions);
-  constructor(
-    direction: "up" | "down" | DatabaseAdapter,
-    migrations: MigrationProxy[],
-    schemaMigration?: SchemaMigration | MigratorOptions,
-    internalMetadata?: InternalMetadata,
-    targetVersion?: number | string | null,
   ) {
-    const options: MigratorOptions =
-      typeof direction === "string"
-        ? { direction, targetVersion: targetVersion ?? null }
-        : ((schemaMigration as MigratorOptions | undefined) ?? {});
-    this._options = options;
-    this._direction = options.direction ?? "up";
-    this._targetVersion =
-      options.targetVersion == null ? null : toInteger(String(options.targetVersion));
-    if (typeof direction === "string") {
-      this._schemaMigration = schemaMigration as SchemaMigration;
-      this._internalMetadata = internalMetadata as InternalMetadata;
-      this._adapter = this._schemaMigration.connection;
-    } else {
-      this._adapter = direction;
-      this._schemaMigration = new SchemaMigration(direction);
-      this._internalMetadata = new InternalMetadata(direction);
-    }
+    this._direction = direction;
+    this._targetVersion = targetVersion == null ? null : toInteger(String(targetVersion));
+    this._schemaMigration = schemaMigration;
+    this._internalMetadata = internalMetadata;
     this.validate(migrations);
     this._migrations = this._sortMigrations(migrations);
   }
@@ -2314,19 +2275,6 @@ export class Migrator {
   /** @internal Mirrors: ActiveRecord::Migrator#migrations */
   get migrations(): MigrationProxy[] {
     return this.isDown() ? [...this._migrations].reverse() : this._sortMigrations(this._migrations);
-  }
-
-  /**
-   * Options for the per-run Migrator `run` / `up` / `down` each construct
-   * (Rails' `Migrator.new(direction, migrations, schema_migration,
-   * internal_metadata, target_version)`). The `new Migrator(...)` call itself
-   * stays inline at all three sites, as Rails writes it.
-   */
-  private _runOptions(
-    direction: "up" | "down",
-    targetVersion: number | string | null,
-  ): MigratorOptions {
-    return { ...this._options, direction, targetVersion };
   }
 
   // Rails: MIGRATOR_SALT = 2053462845 (Zlib.crc32("googol"))
@@ -2444,9 +2392,11 @@ export class Migrator {
     block?: (m: MigrationProxy) => boolean,
   ): Promise<MigrationProxy[]> {
     const migrator = new Migrator(
-      this._adapter,
+      "up",
       this._selectedMigrations(block),
-      this._runOptions("up", targetVersion ?? null),
+      this._schemaMigration,
+      this._internalMetadata,
+      targetVersion ?? null,
     );
     try {
       return migrator.isUseAdvisoryLock()
@@ -2469,9 +2419,11 @@ export class Migrator {
     block?: (m: MigrationProxy) => boolean,
   ): Promise<MigrationProxy[]> {
     const migrator = new Migrator(
-      this._adapter,
+      "down",
       this._selectedMigrations(block),
-      this._runOptions("down", targetVersion ?? null),
+      this._schemaMigration,
+      this._internalMetadata,
+      targetVersion ?? null,
     );
     try {
       return migrator.isUseAdvisoryLock()
@@ -2605,12 +2557,13 @@ export class Migrator {
   }
 
   /**
-   * @internal Mirrors: ActiveRecord::Migrator#connection — Rails reaches for
-   * `DatabaseTasks.migration_connection`; trails takes the adapter as a
-   * constructor argument, so this exposes it under Rails' name.
+   * @internal Mirrors: ActiveRecord::Migrator#connection
+   * (`migration.rb:1488-1491`). `DatabaseTasks` is reached through the
+   * call-time config source: naming `tasks/database-tasks.js` here would be a
+   * load-time edge back into a module that already imports this one.
    */
   private get connection(): DatabaseAdapter {
-    return this._adapter;
+    return migrationArConfig()!.databaseTasks!().migrationConnection()!;
   }
 
   /** @internal Mirrors: ActiveRecord::Migrator#ran? */
@@ -2648,7 +2601,6 @@ export class Migrator {
       if (_base?.logger) _base.logger.info?.(`Migrating to ${proxy.name} (${proxy.version})`);
 
       const loaded = (migration = await proxy.migration());
-      loaded.connection = this._adapter;
       await this.ddlTransaction(loaded, async () => {
         await loaded.migrate(this._direction);
         await this.recordVersionStateAfterMigrating(proxy.version);
@@ -2933,9 +2885,11 @@ export class Migrator {
    */
   async run(direction: "up" | "down", targetVersion: number | string): Promise<number | undefined> {
     const migrator = new Migrator(
-      this._adapter,
+      direction,
       this._migrations,
-      this._runOptions(direction, targetVersion),
+      this._schemaMigration,
+      this._internalMetadata,
+      targetVersion,
     );
     try {
       return migrator.isUseAdvisoryLock()

--- a/packages/activerecord/src/migrator.trails.test.ts
+++ b/packages/activerecord/src/migrator.trails.test.ts
@@ -1,7 +1,16 @@
 // trails-only Migrator cases with no counterpart in
 // vendor/rails/activerecord/test/cases/migrator_test.rb. See migrator.test.ts
 // for the faithful Rails mirror.
-import { describe, it, expect, beforeEach, afterEach, vi, type MockInstance } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  onTestFinished,
+  vi,
+  type MockInstance,
+} from "vitest";
 import { stdout } from "@blazetrails/activesupport";
 import {
   Migrator,
@@ -20,8 +29,18 @@ import { Base } from "./base.js";
 import { SchemaMigration } from "./schema-migration.js";
 import { InternalMetadata } from "./internal-metadata.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
+import { DatabaseTasks } from "./tasks/database-tasks.js";
 import { fixtures } from "./test-fixtures.js";
 import { anonymousMigration } from "./test-helpers/anonymous-migration.js";
+
+// `Migrator#connection` is `DatabaseTasks.migration_connection`
+// (migration.rb:1488-1491), so a case that needs the Migrator to run against a
+// stand-in adapter swaps that reader rather than handing one to the
+// constructor.
+function withMigrationConnection(adapter: DatabaseAdapter): void {
+  const spy = vi.spyOn(DatabaseTasks, "migrationConnection").mockReturnValue(adapter);
+  onTestFinished(() => spy.mockRestore());
+}
 
 /** The env name `record_environment` stamps: `connection.pool.db_config.env_name`. */
 function envName(adapter: DatabaseAdapter): string {
@@ -549,13 +568,15 @@ describe("Migrator advisory lock wrapping", () => {
       getAdvisoryLock: async (_id: unknown) => true,
       releaseAdvisoryLock: async (_id: unknown) => true,
       // currentDatabase intentionally absent
-    } as unknown as import("./connection-adapters/abstract-adapter.js").AbstractAdapter;
+    } as unknown as DatabaseAdapter;
+    const adapter = Base.connection;
     const migrator = new Migrator(
       "up",
       [],
-      new SchemaMigration(rawAdapter),
-      new InternalMetadata(rawAdapter),
+      new SchemaMigration(adapter),
+      new InternalMetadata(adapter),
     );
+    withMigrationConnection(rawAdapter);
     await expect(migrator.migrate()).rejects.toThrow("must implement currentDatabase()");
   });
 
@@ -570,9 +591,10 @@ describe("Migrator advisory lock wrapping", () => {
     const migrator = new Migrator(
       "up",
       [],
-      new SchemaMigration(adapter),
-      new InternalMetadata(adapter),
+      new SchemaMigration(Base.connection),
+      new InternalMetadata(Base.connection),
     );
+    withMigrationConnection(adapter);
     expect(migrator.isUseAdvisoryLock()).toBe(true);
   });
 
@@ -584,9 +606,10 @@ describe("Migrator advisory lock wrapping", () => {
     const migrator = new Migrator(
       "up",
       [],
-      new SchemaMigration(adapter),
-      new InternalMetadata(adapter),
+      new SchemaMigration(Base.connection),
+      new InternalMetadata(Base.connection),
     );
+    withMigrationConnection(adapter);
     expect(migrator.isUseAdvisoryLock()).toBe(false);
   });
 

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, onTestFinished, vi } from "vitest";
 import {
   env,
   setEnv,
@@ -18,6 +18,31 @@ import { InternalMetadata, Migrator, SchemaMigration } from "@blazetrails/active
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
+
+// `Migrator#connection` and `Migration#connection` both resolve
+// `ActiveRecord::Tasks::DatabaseTasks.migration_connection`
+// (migration.rb:1036-1038, 1488-1491) — nothing pins an adapter to the
+// Migrator any more — so a case that drives a hand-built adapter has to
+// establish it as the migration pool's connection for the duration.
+async function establishMigrationConnection(adapter: unknown): Promise<void> {
+  const { Base, HashConfig } = await import("@blazetrails/activerecord");
+  const config = new HashConfig("test", "primary", {
+    adapter: "sqlite3",
+    database: ":memory:",
+  });
+  const pool = Base.connectionHandler.establishConnection(config, {
+    owner: Base,
+    clobber: true,
+    adapterFactory: () => adapter as never,
+  });
+  // Lease eagerly so the adapter's `pool` back-reference is in place before the
+  // caller reads or overrides it (`record_environment` goes through
+  // `connection.pool.db_config`, migration.rb:1512-1516).
+  await pool.leaseConnection();
+  onTestFinished(() => {
+    Base.connectionHandler.removeConnection("Base");
+  });
+}
 
 describe("DbCommand", () => {
   it("has migrate subcommand", () => {
@@ -681,6 +706,7 @@ describe("full migration flow", () => {
     const { BetterSQLite3Adapter } =
       await import("@blazetrails/activerecord/connection-adapters/better-sqlite3-adapter.js");
     adapter = new BetterSQLite3Adapter(":memory:");
+    await establishMigrationConnection(adapter);
 
     fs.writeFileSync(
       path.join(tmpDir, "20260101000000-create-posts.ts"),
@@ -742,6 +768,7 @@ export class CreatePosts extends Migration {
     const { BetterSQLite3Adapter } =
       await import("@blazetrails/activerecord/connection-adapters/better-sqlite3-adapter.js");
     adapter = new BetterSQLite3Adapter(":memory:");
+    await establishMigrationConnection(adapter);
 
     const a = "20260101000000-create-posts.ts";
     const b = "20260102000000-create-comments.ts";
@@ -791,6 +818,7 @@ export class CreateComments extends Migration {
     const { BetterSQLite3Adapter } =
       await import("@blazetrails/activerecord/connection-adapters/better-sqlite3-adapter.js");
     adapter = new BetterSQLite3Adapter(":memory:");
+    await establishMigrationConnection(adapter);
 
     fs.writeFileSync(
       path.join(tmpDir, "20260101000000-create-posts.ts"),
@@ -818,6 +846,7 @@ export class CreatePosts extends Migration {
     const { BetterSQLite3Adapter } =
       await import("@blazetrails/activerecord/connection-adapters/better-sqlite3-adapter.js");
     adapter = new BetterSQLite3Adapter(":memory:");
+    await establishMigrationConnection(adapter);
 
     fs.writeFileSync(
       path.join(tmpDir, "20260101000000-create-widgets.ts"),
@@ -852,6 +881,7 @@ export class CreateWidgets extends Migration {
       await import("@blazetrails/activerecord/connection-adapters/better-sqlite3-adapter.js");
     const { UnknownMigrationVersionError } = await import("@blazetrails/activerecord");
     adapter = new BetterSQLite3Adapter(":memory:");
+    await establishMigrationConnection(adapter);
 
     const migrator = new Migrator(
       "up",
@@ -868,6 +898,7 @@ export class CreateWidgets extends Migration {
     const { BetterSQLite3Adapter } =
       await import("@blazetrails/activerecord/connection-adapters/better-sqlite3-adapter.js");
     adapter = new BetterSQLite3Adapter(":memory:");
+    await establishMigrationConnection(adapter);
 
     fs.writeFileSync(
       path.join(tmpDir, "20260101000000-create-posts.ts"),
@@ -1430,6 +1461,7 @@ export class CreatePosts extends Migration {
 
     const dbFile = path.join(tmpDir, "no-metadata-migrate.sqlite3");
     const adapter = new BetterSQLite3Adapter(dbFile);
+    await establishMigrationConnection(adapter);
     try {
       const migrations = [
         {


### PR DESCRIPTION
Split 3 of 3 from `migrator-connection-pins-adapter-at-construction`: the reader itself.

Rails' `Migrator` holds no adapter. `#connection` is
`ActiveRecord::Tasks::DatabaseTasks.migration_connection`
(`migration.rb:1488-1491`), re-resolved on every read, and `#initialize` is
`(direction, migrations, schema_migration, internal_metadata, target_version = nil)`
(`migration.rb:1418-1433`).

trails pinned the adapter at construction, so a `Migrator` built before a
connection swap kept the old one where Rails picks up the new one.

- `_adapter` is gone, along with the `(adapter, migrations, options)`
  constructor overload and `MigratorOptions`. The constructor now matches
  `migration.rb:1418-1433` exactly.
- `#connection` reads `DatabaseTasks.migrationConnection()` per call, through
  the call-time `migrationArConfig()` source (naming `tasks/database-tasks.js`
  directly would be a load-time edge back into a module that already imports
  `migration.ts`).
- `record_environment` reads `connection.pool.db_config.env_name` straight
  through (`migration.rb:1512-1516`); the construction-resolved `_environment`
  fallback and its `_recordedEnvironment` helper are deleted.
- `execute_migration_in_transaction` no longer assigns `migration.connection` —
  Rails leaves `Migration#connection` to resolve the same migration connection
  itself (`migration.rb:1036-1038`).
- `Migrator#up` / `#down` / `#run` build their per-run Migrator with the Rails
  argument list inline, so `_runOptions` goes too.
- The deviation JSDoc at the old `migration.ts:2488-2491` is deleted, not
  reworded.

Call sites that handed in a bare adapter move to the Rails shape:
`test-databases.ts` builds its own `SchemaMigration`/`InternalMetadata`, and the
trails-only tests that drive a stand-in adapter now swap the migration
connection (a `DatabaseTasks.migrationConnection` spy in
`migrator.trails.test.ts`, an established pool in `db.test.ts`) instead of
handing one to the constructor.

## Multi-database: the routing lives in `DatabaseTasks`, not in the Migrator

The story's Context anticipated that `multi-db-migrator.test.ts` would have to
move to `with_temporary_pool`. Reading the Rails source, it does not — and the
reason is the point of this split.

In Rails a `Migrator` never holds a second adapter. `ddl_transaction`
(`migration.rb:1584-1590`), `use_transaction?` (`:1592-1594`),
`with_advisory_lock` and `record_environment` all read the same private
`connection`, i.e. the one global `DatabaseTasks.migration_connection`. What
makes a secondary database migrate against *its own* connection is
`DatabaseTasks.migrate_all`, which wraps each config in
`with_temporary_connection` (`tasks/database_tasks.rb:254`) so the global reader
resolves to that database for the duration. trails already does exactly this —
`DatabaseTasks.migrateAll` routes every non-primary config through
`withTemporaryConnection` (`tasks/database-tasks.ts:1166-1174`), as does
`db.ts`'s `runMigrateAll`.

So this PR is what makes that routing effective rather than what breaks it:
before it, a Migrator built outside the temporary pool ignored the swap
entirely, which is the bug the story set out to fix. A `Migrator` that pinned
`adapterB` would be *less* faithful, not more.

`multi_db_migrator_test.rb` matches: it builds `migrator_a` / `migrator_b` from
two pools' `schema_migration` objects and lets both run against
`ActiveRecord::Base`'s migration connection. `multi-db-migrator.test.ts` is that
test, so it needed no change and stays green.

Closes-story: migrator-connection-resolves-per-call
