### PR TITLE
fix(activerecord,activesupport): through reflection PK delegates to the source; OptionMerger gets full method_missing semantics

### DIFF
--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -20,6 +20,7 @@ import {
   type RenameKeyOptions,
   type XmlTypeInfo,
   resetCallbacks as asResetCallbacks,
+  withOptions,
 } from "@blazetrails/activesupport";
 import {
   humanAttributeName as translationHumanAttributeName,
@@ -529,19 +530,11 @@ export class Model {
    *     m.validates("email", { presence: true });
    *   });
    */
-  static withOptions(defaults: Record<string, unknown>, fn: (model: typeof Model) => void): void {
-    // Create a proxy that merges defaults into validates() calls
-    const proxy = new Proxy(this, {
-      get(target: typeof Model, prop: string | symbol) {
-        if (prop === "validates") {
-          return (attr: string, rules: Record<string, unknown>) => {
-            target.validates(attr, { ...defaults, ...rules });
-          };
-        }
-        return (target as unknown as Record<string | symbol, unknown>)[prop];
-      },
-    });
-    fn(proxy);
+  static withOptions(
+    options: Record<string, unknown>,
+    block?: (optionMerger: typeof Model) => void,
+  ): typeof Model | void {
+    return block ? withOptions(this, options, block) : withOptions(this, options);
   }
 
   // -- Validations (Phase 1100) --

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -520,9 +520,11 @@ export class Model {
   static _nullifyBlanks: string[] | true | false = false;
 
   /**
-   * Apply common options to multiple validation/callback calls.
-   *
-   * Mirrors: ActiveSupport::OptionMerger / with_options
+   * Mirrors: Object#with_options
+   * (activesupport/lib/active_support/core_ext/object/with_options.rb:92),
+   * which Ruby models reach as a receiverless class-body call. TypeScript
+   * cannot monkey-patch Object, so the class carries the entry point and the
+   * ported free function does the work.
    *
    * Usage:
    *   User.withOptions({ if: (r) => r.readAttribute("active") }, (m) => {
@@ -534,7 +536,7 @@ export class Model {
     options: Record<string, unknown>,
     block?: (optionMerger: typeof Model) => void,
   ): typeof Model | void {
-    return block ? withOptions(this, options, block) : withOptions(this, options);
+    return withOptions(this, options, block);
   }
 
   // -- Validations (Phase 1100) --

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1189,9 +1189,13 @@ export async function _loadSingularViaStatementCache(
  * first-step WHERE would match orphan through rows whose FK is null,
  * leaking them into the chain as phantom associations.
  *
- * Read from the OUTER reflection's `activeRecordPrimaryKey` —
- * that's the owner's own PK column(s), never a delegated downstream
- * target. `isNewRecord()` covers unsaved records; the explicit
+ * Read the columns the chain walk actually seeds from — the tail of
+ * `reflection.chain`'s `joinForeignKey`, which is what
+ * `last_scope_chain` reads off the owner
+ * (`disable_joins_association_scope.rb:20`). The outer reflection's own
+ * `activeRecordPrimaryKey` is not that: on a ThroughReflection it delegates to
+ * the source reflection (`reflection.rb:973-974`), so it describes the source
+ * edge, not the owner. `isNewRecord()` covers unsaved records; the explicit
  * PK-null check covers the defensive edge where a saved record
  * somehow has a null composite-PK component.
  *
@@ -1207,9 +1211,8 @@ export function ownerHasUnresolvedThroughKey(
   reflection: ReflectionLike | null | undefined,
 ): boolean {
   if (record.isNewRecord()) return true;
-  const activeRecordPk = reflection?.activeRecordPrimaryKey;
-  const ownerPkCols =
-    activeRecordPk == null ? [] : Array.isArray(activeRecordPk) ? activeRecordPk : [activeRecordPk];
+  const ownerFk = _ownerChainReflection(reflection)?.joinForeignKey;
+  const ownerPkCols = ownerFk == null ? [] : Array.isArray(ownerFk) ? ownerFk : [ownerFk];
   return ownerPkCols.some((col) => {
     const v = record._readAttribute(col);
     return v === null || v === undefined;

--- a/packages/activerecord/src/associations/disable-joins-composite-nested.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-nested.test.ts
@@ -32,7 +32,6 @@ import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
 import { Base, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
-import { findTarget } from "./has-many-association.js";
 import { fixtures } from "../test-fixtures.js";
 
 describe("DJAS composite-key + nested-through", () => {
@@ -171,13 +170,7 @@ describe("DJAS composite-key + nested-through", () => {
       if (typeof sql === "string") observed.push(sql);
     });
     try {
-      // No reader form yet: `shop.cknLineItemTags` routes through
-      // CollectionProxy#_throughOwnerCols, which rejects this composite
-      // owner PK / through FK pair ("1 pk vs 2 fk") — a separate seam from the
-      // loader under test here. See story
-      // converge-composite-through-collection-proxy-owner-cols.
-      const reflection = (CknShop as any)._reflectOnAssociation("cknLineItemTags");
-      const tags = await findTarget(shop, "cknLineItemTags", reflection.options);
+      const tags = await (shop as any).cknLineItemTags.toArray();
       expect(tags.map((t: any) => t.value).sort()).toEqual(["red", "sale"]);
     } finally {
       Notifications.unsubscribe(sub);
@@ -200,9 +193,7 @@ describe("DJAS composite-key + nested-through", () => {
     await CknTag.create({ ckn_line_item_id: orphanLi.id, value: "orphan-tag" });
 
     const unsaved = CknShop.new({ name: "unsaved" });
-    // Same CollectionProxy composite-through gap as above — no reader form.
-    const reflection = (CknShop as any)._reflectOnAssociation("cknLineItemTags");
-    const tags = await findTarget(unsaved, "cknLineItemTags", reflection.options);
+    const tags = await (unsaved as any).cknLineItemTags.toArray();
     expect(tags).toEqual([]);
     expect(tags.map((t: any) => t.value)).not.toContain("orphan-tag");
   });

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -1846,7 +1846,10 @@ export class ThroughReflection extends AbstractReflection {
   }
 
   get activeRecordPrimaryKey(): string | string[] {
-    return this._delegate.activeRecordPrimaryKey;
+    // Rails: `delegate :active_record_primary_key, ..., to: :source_reflection`
+    // (reflection.rb:973-974) — it pairs with #foreignKey, which delegates the
+    // same way, so a composite source edge yields matching arities.
+    return this.sourceReflection?.activeRecordPrimaryKey ?? this._delegate.activeRecordPrimaryKey;
   }
 
   get associationForeignKey(): string {

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -1845,10 +1845,12 @@ export class ThroughReflection extends AbstractReflection {
     return this.sourceReflection?.associationPrimaryKey ?? this._delegate.associationPrimaryKey;
   }
 
+  /**
+   * Rails: `delegate :active_record_primary_key, ..., to: :source_reflection`
+   * (reflection.rb:973-974). It pairs with #foreignKey, which delegates the
+   * same way, so a composite source edge yields matching arities.
+   */
   get activeRecordPrimaryKey(): string | string[] {
-    // Rails: `delegate :active_record_primary_key, ..., to: :source_reflection`
-    // (reflection.rb:973-974) — it pairs with #foreignKey, which delegates the
-    // same way, so a composite source edge yields matching arities.
     return this.sourceReflection?.activeRecordPrimaryKey ?? this._delegate.activeRecordPrimaryKey;
   }
 

--- a/packages/activesupport/src/core-ext/object/with-options.ts
+++ b/packages/activesupport/src/core-ext/object/with-options.ts
@@ -17,6 +17,11 @@ export function withOptions<T extends object, R>(
 export function withOptions<T extends object, R>(
   object: T,
   options: Record<string, unknown>,
+  block: ((optionMerger: T) => R) | undefined,
+): R | T;
+export function withOptions<T extends object, R>(
+  object: T,
+  options: Record<string, unknown>,
   block?: (optionMerger: T) => R,
 ): R | T {
   const optionMerger = new OptionMerger(object, options) as unknown as T;

--- a/packages/activesupport/src/core-ext/object/with-options.ts
+++ b/packages/activesupport/src/core-ext/object/with-options.ts
@@ -1,0 +1,29 @@
+/**
+ * Mirrors: Object#with_options
+ * (activesupport/lib/active_support/core_ext/object/with_options.rb:92)
+ *
+ * Ruby monkey-patches Object; TypeScript cannot, so the receiver is the first
+ * argument — the same shape `objectWith` uses for Object#with.
+ */
+
+import { OptionMerger } from "../../option-merger.js";
+
+export function withOptions<T extends object>(object: T, options: Record<string, unknown>): T;
+export function withOptions<T extends object, R>(
+  object: T,
+  options: Record<string, unknown>,
+  block: (optionMerger: T) => R,
+): R;
+export function withOptions<T extends object, R>(
+  object: T,
+  options: Record<string, unknown>,
+  block?: (optionMerger: T) => R,
+): R | T {
+  const optionMerger = new OptionMerger(object, options) as unknown as T;
+
+  if (block) {
+    return block(optionMerger);
+  } else {
+    return optionMerger;
+  }
+}

--- a/packages/activesupport/src/core-ext/object/with-options.ts
+++ b/packages/activesupport/src/core-ext/object/with-options.ts
@@ -4,6 +4,14 @@
  *
  * Ruby monkey-patches Object; TypeScript cannot, so the receiver is the first
  * argument — the same shape `objectWith` uses for Object#with.
+ *
+ * Only the `block.call(option_merger)` arm of `with_options.rb:96` is ported.
+ * The zero-arity arm rebinds `self` to the merger via `instance_eval`, and
+ * JavaScript has no way to rebind the lexical scope a function body already
+ * closed over — a zero-parameter block cannot reach the merger at all. So
+ * implicit-receiver `with_options` (`option_merger_test.rb:101-107`) has no
+ * form here; callers take the merger as the block's parameter. Tracked as
+ * `with-options-implicit-receiver-instance-eval-arm` under RFC 0023.
  */
 
 import { OptionMerger } from "../../option-merger.js";

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -457,6 +457,8 @@ export { EnvironmentInquirer } from "./environment-inquirer.js";
 export { getEnv } from "./environment.js";
 export { ExecutionContext } from "./execution-context.js";
 export { objectWith } from "./core-ext/object/with.js";
+export { withOptions } from "./core-ext/object/with-options.js";
+export { OptionMerger } from "./option-merger.js";
 export { ArrayInquirer, arrayInquiry } from "./array-inquirer.js";
 export { tryCall, tryWith, tryBang } from "./try.js";
 export { OrderedOptions, InheritableOptions } from "./ordered-options.js";

--- a/packages/activesupport/src/option-merger.test.ts
+++ b/packages/activesupport/src/option-merger.test.ts
@@ -1,12 +1,17 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { withOptions } from "./core-ext/object/with-options.js";
 
+/**
+ * Port of activesupport/test/option_merger_test.rb.
+ *
+ * Rails' test case *is* the receiver, and `context` below carries its private
+ * helpers `method_with_options` / `method_with_args`
+ * (option_merger_test.rb:139-155). Ruby's kwargs variants collapse onto one
+ * TypeScript shape — a trailing options object — so `method_with_kwargs` /
+ * `method_with_kwargs_only` have no separate form, and the assertions naming
+ * them fold into their `method_with_options` siblings.
+ */
 describe("OptionMergerTest", () => {
-  // Rails' test case *is* the receiver, and its private helpers below are
-  // `method_with_options` / `method_with_args` (option_merger_test.rb:139-155).
-  // Ruby's kwargs variants collapse onto one TS shape — a trailing options
-  // object — so `method_with_kwargs` / `method_with_kwargs_only` have no
-  // separate form here.
   const context = {
     methodWithArgs(...args: unknown[]): unknown[] {
       return args;

--- a/packages/activesupport/src/option-merger.test.ts
+++ b/packages/activesupport/src/option-merger.test.ts
@@ -1,111 +1,138 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
+import { withOptions } from "./core-ext/object/with-options.js";
 
 describe("OptionMergerTest", () => {
-  // withOptions creates a helper that deep-merges default options into calls
-  function withOptions<T extends Record<string, unknown>>(defaults: T) {
-    return {
-      merge(opts: Partial<T> = {}): T {
-        return deepMerge(defaults, opts) as T;
-      },
-    };
-  }
+  // Rails' test case *is* the receiver, and its private helpers below are
+  // `method_with_options` / `method_with_args` (option_merger_test.rb:139-155).
+  // Ruby's kwargs variants collapse onto one TS shape — a trailing options
+  // object — so `method_with_kwargs` / `method_with_kwargs_only` have no
+  // separate form here.
+  const context = {
+    methodWithArgs(...args: unknown[]): unknown[] {
+      return args;
+    },
+    methodWithOptions(options: Record<string, unknown> = {}): Record<string, unknown> {
+      return options;
+    },
+  };
 
-  function deepMerge(
-    target: Record<string, unknown>,
-    source: Record<string, unknown>,
-  ): Record<string, unknown> {
-    const result = { ...target };
-    for (const [k, v] of Object.entries(source)) {
-      if (
-        v !== null &&
-        typeof v === "object" &&
-        !Array.isArray(v) &&
-        typeof result[k] === "object" &&
-        result[k] !== null
-      ) {
-        result[k] = deepMerge(result[k] as Record<string, unknown>, v as Record<string, unknown>);
-      } else {
-        result[k] = v;
-      }
-    }
-    return result;
-  }
+  let options: Record<string, unknown>;
+
+  beforeEach(() => {
+    options = { hello: "world" };
+  });
 
   it("method with options merges string options", () => {
-    const m = withOptions({ class: "default" });
-    expect((m as any).merge({ id: "foo" })).toEqual({ class: "default", id: "foo" });
+    const localOptions = { cool: true };
+
+    withOptions(context, options, (o) => {
+      expect(context.methodWithOptions(localOptions)).toEqual(localOptions);
+      expect(o.methodWithOptions(localOptions)).toEqual({ ...options, ...localOptions });
+    });
   });
 
   it("method with options merges options when options are present", () => {
-    const m = withOptions({ html: { class: "btn" } });
-    expect((m as any).merge({ html: { id: "x" } })).toEqual({ html: { class: "btn", id: "x" } });
+    const localOptions = { cool: true };
+
+    withOptions(context, options, (o) => {
+      expect(context.methodWithOptions(localOptions)).toEqual(localOptions);
+      expect(o.methodWithOptions(localOptions)).toEqual({ ...options, ...localOptions });
+    });
   });
 
   it("method with options appends options when options are missing", () => {
-    const m = withOptions({ disabled: true });
-    expect((m as any).merge({})).toEqual({ disabled: true });
+    withOptions(context, options, (o) => {
+      expect(context.methodWithOptions()).toEqual({});
+      expect(o.methodWithOptions()).toEqual(options);
+    });
   });
 
   it("method with options copies options when options are missing", () => {
-    const defaults = { size: 10 };
-    const m = withOptions(defaults);
-    const result = (m as any).merge({});
-    result.size = 99;
-    expect(defaults.size).toBe(10); // original not mutated
+    withOptions(context, options, (o) => {
+      expect(o.methodWithOptions()).not.toBe(options);
+    });
   });
 
   it("method with options allows to overwrite options", () => {
-    const m = withOptions({ color: "red" });
-    expect((m as any).merge({ color: "blue" })).toEqual({ color: "blue" });
+    const localOptions = { hello: "moon" };
+    expect(Object.keys(options)).toEqual(Object.keys(localOptions));
+
+    withOptions(context, options, (o) => {
+      expect(context.methodWithOptions(localOptions)).toEqual(localOptions);
+      expect(o.methodWithOptions(localOptions)).toEqual({ ...options, ...localOptions });
+      expect(o.methodWithOptions(localOptions)).toEqual(localOptions);
+    });
+    withOptions(context, localOptions, (o) => {
+      expect(o.methodWithOptions(options)).toEqual({ ...localOptions, ...options });
+    });
   });
 
   it("nested method with options containing hashes merge", () => {
-    const m = withOptions({ style: { color: "red" } });
-    expect((m as any).merge({ style: { size: "big" } })).toEqual({
-      style: { color: "red", size: "big" },
+    withOptions(context, { conditions: { method: ":get" } }, (outer) => {
+      withOptions(outer, { conditions: { domain: "www" } }, (inner) => {
+        const expected = { conditions: { method: ":get", domain: "www" } };
+        expect(inner.methodWithOptions()).toEqual(expected);
+      });
     });
   });
 
   it("nested method with options containing hashes overwrite", () => {
-    const m = withOptions({ style: { color: "red" } });
-    expect((m as any).merge({ style: { color: "blue" } })).toEqual({ style: { color: "blue" } });
+    withOptions(context, { conditions: { method: ":get", domain: "www" } }, (outer) => {
+      withOptions(outer, { conditions: { method: ":post" } }, (inner) => {
+        const expected = { conditions: { method: ":post", domain: "www" } };
+        expect(inner.methodWithOptions()).toEqual(expected);
+      });
+    });
   });
 
   it("nested method with options containing hashes going deep", () => {
-    const m = withOptions({ a: { b: { c: 1 } } });
-    expect((m as any).merge({ a: { b: { d: 2 } } })).toEqual({ a: { b: { c: 1, d: 2 } } });
+    withOptions(
+      context,
+      { html: { class: "foo", style: { margin: 0, display: "block" } } },
+      (outer) => {
+        withOptions(
+          outer,
+          { html: { title: "bar", style: { margin: "1em", color: "#fff" } } },
+          (inner) => {
+            const expected = {
+              html: {
+                class: "foo",
+                title: "bar",
+                style: { margin: "1em", display: "block", color: "#fff" },
+              },
+            };
+            expect(inner.methodWithOptions()).toEqual(expected);
+          },
+        );
+      },
+    );
   });
 
   it("nested method with options using lambda as only argument", () => {
-    const fn = (opts: Record<string, unknown>) => ({ result: opts.value });
-    const defaults = { value: 42 };
-    expect(fn(defaults)).toEqual({ result: 42 });
+    const localLambda = () => ({ lambda: true });
+    withOptions(context, options, (o) => {
+      const merged = o.methodWithOptions(localLambda as never) as unknown as () => unknown;
+      expect(merged()).toEqual({ ...options, ...localLambda() });
+    });
   });
 
   it("proc as first argument with other options should still merge options", () => {
-    const m = withOptions({ shared: true });
-    expect((m as any).merge({ extra: "yes" })).toEqual({ shared: true, extra: "yes" });
-  });
+    const localProc = () => {};
+    const localOptions = { cool: true };
 
-  it("option merger class method", () => {
-    const m = withOptions({ type: "submit" });
-    expect((m as any).merge({})).toHaveProperty("type", "submit");
-  });
-
-  it("option merger implicit receiver", () => {
-    const m = withOptions({ class: "btn" });
-    const result = (m as any).merge({ id: "submit-btn" });
-    expect(result).toMatchObject({ class: "btn", id: "submit-btn" });
-  });
-
-  it("with options hash like", () => {
-    const options = { a: 1, b: 2 };
-    const m = withOptions(options);
-    expect((m as any).merge({ c: 3 })).toEqual({ a: 1, b: 2, c: 3 });
+    withOptions(context, options, (o) => {
+      expect(o.methodWithArgs(localProc, localOptions)).toEqual([
+        localProc,
+        { ...options, ...localOptions },
+      ]);
+    });
   });
 
   it("with options no block", () => {
-    const m = withOptions({ x: 10 });
-    expect((m as any).merge()).toEqual({ x: 10 });
+    const localOptions = { cool: true };
+    const scope = withOptions(context, options);
+
+    expect(context.methodWithOptions(localOptions)).toEqual(localOptions);
+    expect(scope.methodWithOptions(localOptions)).toEqual({ ...options, ...localOptions });
   });
 });

--- a/packages/activesupport/src/option-merger.test.ts
+++ b/packages/activesupport/src/option-merger.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { withOptions } from "./core-ext/object/with-options.js";
+import { OptionMerger } from "./option-merger.js";
 
 /**
  * Port of activesupport/test/option_merger_test.rb.
@@ -131,6 +132,23 @@ describe("OptionMergerTest", () => {
         { ...options, ...localOptions },
       ]);
     });
+  });
+
+  it("option merger class method", () => {
+    expect(new OptionMerger({}, {})).toBeInstanceOf(OptionMerger);
+  });
+
+  it("with options hash like", () => {
+    class HashLike {
+      constructor(hash: Record<string, unknown>) {
+        Object.assign(this, hash);
+      }
+    }
+    const localOptions = { cool: true };
+    const scope = withOptions(context, new HashLike(options) as Record<string, unknown>);
+
+    expect(context.methodWithOptions(localOptions)).toEqual(localOptions);
+    expect(scope.methodWithOptions(localOptions)).toEqual({ ...options, ...localOptions });
   });
 
   it("with options no block", () => {

--- a/packages/activesupport/src/option-merger.ts
+++ b/packages/activesupport/src/option-merger.ts
@@ -1,0 +1,57 @@
+/**
+ * Mirrors: ActiveSupport::OptionMerger
+ * (activesupport/lib/active_support/option_merger.rb)
+ */
+
+import { DeepMergeable } from "./deep-mergeable.js";
+import { isPlainObject } from "./hash-utils.js";
+
+export class OptionMerger {
+  private context: any;
+  private options: Record<string, unknown>;
+
+  constructor(context: any, options: Record<string, unknown>) {
+    this.context = context;
+    this.options = options;
+
+    // Ruby undefines every instance method so that `method_missing` sees the
+    // whole surface. JS has no `method_missing`, so the merger *is* a Proxy
+    // over the context whose `get` trap routes calls through `methodMissing`.
+    return new Proxy(context, {
+      get: (target: object, property: string | symbol): unknown => {
+        const value = Reflect.get(target, property);
+        if (typeof value !== "function") return value;
+        return (...args: unknown[]) => this.methodMissing(property as string, ...args);
+      },
+    }) as unknown as OptionMerger;
+  }
+
+  private methodMissing(method: string, ...args: unknown[]): unknown {
+    let options: Record<string, unknown> | null = null;
+
+    // Ruby's block travels outside `arguments`; in TypeScript it is a trailing
+    // positional argument, so hold it aside before applying Rails' rules — but
+    // only when it is not the lone argument, which is Ruby's Proc-arg branch
+    // below.
+    const block =
+      args.length > 1 && typeof args[args.length - 1] === "function" ? args.pop() : null;
+
+    if (args.length === 1 && typeof args[0] === "function") {
+      const proc = args.shift() as (...procArgs: unknown[]) => Record<string, unknown>;
+      args.push((...procArgs: unknown[]) =>
+        DeepMergeable.deepMerge(this.options, proc(...procArgs)),
+      );
+    } else if (isPlainObject(args[args.length - 1])) {
+      options = DeepMergeable.deepMerge(this.options, args.pop() as Record<string, unknown>);
+    } else {
+      options = this.options;
+    }
+
+    // Ruby forwards these as `**options`, and the double-splat materializes a
+    // fresh Hash — callers must not receive @options itself.
+    if (options) args.push({ ...options });
+    if (block) args.push(block);
+
+    return this.context[method](...args);
+  }
+}

--- a/packages/activesupport/src/option-merger.ts
+++ b/packages/activesupport/src/option-merger.ts
@@ -8,7 +8,10 @@ import { isPlainObject } from "./hash-utils.js";
  * Ruby undefines every instance method so `method_missing` sees the whole
  * surface. JavaScript has no `method_missing`, so the merger *is* a Proxy over
  * the context returned from the constructor, whose `get` trap routes every
- * forwarded function through {@link OptionMerger#methodMissing}.
+ * forwarded function through {@link OptionMerger#methodMissing}. Its
+ * `getPrototypeOf` trap keeps the merger an `OptionMerger` rather than an
+ * instance of the context's class, which is what Ruby gets for free from
+ * `OptionMerger.new` being a real object.
  *
  * `methodMissing` deviates from `option_merger.rb:16` on one point, forced by
  * the language: Ruby's block travels outside `arguments`, while TypeScript
@@ -27,6 +30,7 @@ export class OptionMerger {
     this.options = options;
 
     return new Proxy(context, {
+      getPrototypeOf: (): object => OptionMerger.prototype,
       get: (target: object, property: string | symbol): unknown => {
         const value = Reflect.get(target, property);
         if (typeof value !== "function") return value;

--- a/packages/activesupport/src/option-merger.ts
+++ b/packages/activesupport/src/option-merger.ts
@@ -1,11 +1,23 @@
-/**
- * Mirrors: ActiveSupport::OptionMerger
- * (activesupport/lib/active_support/option_merger.rb)
- */
-
 import { DeepMergeable } from "./deep-mergeable.js";
 import { isPlainObject } from "./hash-utils.js";
 
+/**
+ * Mirrors: ActiveSupport::OptionMerger
+ * (activesupport/lib/active_support/option_merger.rb)
+ *
+ * Ruby undefines every instance method so `method_missing` sees the whole
+ * surface. JavaScript has no `method_missing`, so the merger *is* a Proxy over
+ * the context returned from the constructor, whose `get` trap routes every
+ * forwarded function through {@link OptionMerger#methodMissing}.
+ *
+ * `methodMissing` deviates from `option_merger.rb:16` on one point, forced by
+ * the language: Ruby's block travels outside `arguments`, while TypeScript
+ * passes it as a trailing positional argument, so a trailing function argument
+ * is held aside before Rails' argument rules run — except when it is the lone
+ * argument, which is Ruby's `arguments.first.is_a?(Proc)` branch. Ruby's
+ * `**options` splat materializes a fresh Hash, so the forwarded options object
+ * is a copy and never `@options` itself.
+ */
 export class OptionMerger {
   private context: any;
   private options: Record<string, unknown>;
@@ -14,9 +26,6 @@ export class OptionMerger {
     this.context = context;
     this.options = options;
 
-    // Ruby undefines every instance method so that `method_missing` sees the
-    // whole surface. JS has no `method_missing`, so the merger *is* a Proxy
-    // over the context whose `get` trap routes calls through `methodMissing`.
     return new Proxy(context, {
       get: (target: object, property: string | symbol): unknown => {
         const value = Reflect.get(target, property);
@@ -28,11 +37,6 @@ export class OptionMerger {
 
   private methodMissing(method: string, ...args: unknown[]): unknown {
     let options: Record<string, unknown> | null = null;
-
-    // Ruby's block travels outside `arguments`; in TypeScript it is a trailing
-    // positional argument, so hold it aside before applying Rails' rules — but
-    // only when it is not the lone argument, which is Ruby's Proc-arg branch
-    // below.
     const block =
       args.length > 1 && typeof args[args.length - 1] === "function" ? args.pop() : null;
 
@@ -47,8 +51,6 @@ export class OptionMerger {
       options = this.options;
     }
 
-    // Ruby forwards these as `**options`, and the double-splat materializes a
-    // fresh Hash — callers must not receive @options itself.
     if (options) args.push({ ...options });
     if (block) args.push(block);
 


### PR DESCRIPTION
Two convergences.

**`ThroughReflection#activeRecordPrimaryKey`** delegated to the *delegate*
reflection; Rails delegates it to the **source** reflection
(`reflection.rb:973-974`), alongside `foreign_key` — which we already delegate
that way. The mismatch meant a scalar-PK owner whose source edge carries a
composite FK produced arity 1 vs 2, and `CollectionProxy#_throughOwnerCols`
raised `Composite primaryKey/foreignKey mismatch ... 1 pk vs 2 fk`. The two
`disable-joins-composite-nested.test.ts` cases that worked around it with the
free `findTarget` now route through the association reader
(`shop.cknLineItemTags`) and the "no reader form yet" notes are gone.

**`Model.withOptions`** was a bespoke proxy that intercepted only `validates`
and forwarded every other property raw and unbound. Ported
`ActiveSupport::OptionMerger` (`option_merger.rb`) and `Object#with_options`
(`core_ext/object/with_options.rb:92`) for real: the `get` trap routes every
forwarded function through `methodMissing`, which deep-merges the defaults into
the trailing options argument (explicit wins), handles the lone-Proc branch, and
binds to the context. `Model.withOptions` now just delegates. Nested
`withOptions` composes with inner winning, as in Rails.

`activesupport/src/option-merger.test.ts` was a self-contained fake that
exercised no product code; it is now a real port of `option_merger_test.rb`
against `withOptions`, keeping the Rails test names.

One deviation, justified at the call site: Ruby's block is outside `arguments`,
but TypeScript passes it as a trailing positional argument, so `methodMissing`
holds a trailing function argument aside before applying Rails' argument rules
(except when it is the lone argument — that is Ruby's Proc branch).

`move-adapter-specific-snapshot-off-ar-internal-metadata` was released, not
built: the story's own recorded findings say the `loadSchema` /
`canonical-schema-stamp` / `test-setup-dy` seam is reshaped one story at a time
and that the work must be its own PR, and it exceeds this PR's budget.

Closes-story: converge-composite-through-collection-proxy-owner-cols
Closes-story: with-options-full-option-merger-semantics

---

**Review round 1.** All three dropped `option_merger_test.rb` cases addressed:

- `test_option_merger_class_method` — was a real unverified divergence, as the
  reviewer said: the constructor returns a Proxy, so the merger read as an
  instance of the *context's* class. Added a `getPrototypeOf` trap so it is an
  `OptionMerger`, and ported the test.
- `test_with_options_hash_like` — ported; the receiver-side analogue is a class
  instance rather than a plain object literal.
- `test_option_merger_implicit_receiver` — genuinely unportable: it exercises
  `with_options.rb:96`'s zero-arity `instance_eval` arm, and JavaScript cannot
  rebind the scope a function body already closed over, so a zero-parameter
  block cannot reach the merger at all. Now documented in the `withOptions`
  JSDoc and filed as `0023-surfaced-deviations/with-options-implicit-receiver-instance-eval-arm`
  rather than left silent.
