### PR TITLE
refactor(api-compare,activesupport,activerecord): bucket the core_ext orphan tail; one method_missing proxy; deallocate the evicted statement inline

### DIFF
--- a/packages/activemodel/src/type/normalized-value.ts
+++ b/packages/activemodel/src/type/normalized-value.ts
@@ -1,3 +1,5 @@
+import { methodMissingProxy } from "@blazetrails/activesupport";
+
 import { Type } from "./value.js";
 
 /**
@@ -62,8 +64,11 @@ export function unwrapNormalization(type: Type): Type {
  *
  * Mirrors: ActiveRecord::Normalization::NormalizedValueType, a
  * `DelegateClass(ActiveModel::Type::Value)` overriding `cast`, `serialize`, and
- * `serialize_cast_value`. We model the DelegateClass with a Proxy so the full
- * surface of the wrapped type is forwarded.
+ * `serialize_cast_value`. We model the DelegateClass with `methodMissingProxy`,
+ * whose delegate IS the wrapped type — so every non-overridden read goes through
+ * its delegate branch and binds to the wrapped type, and `deserialize` (which
+ * internally calls `this.cast`) uses that type's un-normalized cast rather than
+ * this decorator's normalizing one.
  *
  * @param token optional identity used by the attribute-decoration pipeline to
  *   recognize "already decorated by this normalization" during seed + pending
@@ -115,15 +120,9 @@ export function normalizedValueType(
     [NORMALIZED_TOKEN]: token,
   };
 
-  const proxy = new Proxy(castType, {
-    get(target, prop, receiver) {
-      if (prop in overrides) return overrides[prop];
-      const value = Reflect.get(target, prop, target);
-      // Bind delegated methods to the underlying type so that, e.g.,
-      // `deserialize` (which internally calls `this.cast`) uses the underlying
-      // type's un-normalized cast rather than the proxy's normalizing one.
-      return typeof value === "function" ? value.bind(target) : value;
-    },
+  const proxy = methodMissingProxy(castType, {
+    overrides,
+    delegate: (target) => target,
   }) as unknown as Type;
   return proxy;
 }

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.trails.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.trails.test.ts
@@ -58,7 +58,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
         // LRU eviction. With one cached statement, setMaxSize(1) just
         // records the new limit; eviction happens on the next insert
         // via our Mysql2StatementPool#dealloc (conn.unprepare).
-        pool.setMaxSize(1);
+        await pool.setMaxSize(1);
         await adapter.execute("SELECT ? AS s", ["a"]);
         expect(pool.length).toBe(1);
       } finally {

--- a/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
@@ -39,7 +39,7 @@ describeIfPg("PostgreSQLAdapter", () => {
         const pool = adapter._statementPoolForTest()!;
         // Rails' matching test sets statement_limit = 1 and asserts
         // LRU eviction. setMaxSize immediately evicts excess entries.
-        pool.setMaxSize(1);
+        await pool.setMaxSize(1);
         await adapter.execute("SELECT $1::text", ["a"]);
         expect(pool.length).toBe(1);
       } finally {
@@ -74,7 +74,7 @@ describeIfPg("PostgreSQLAdapter", () => {
         await adapter.execute("SELECT $1::text", ["a"]);
         const pool = adapter._statementPoolForTest()!;
         expect(pool.length).toBe(2);
-        pool.clear();
+        await pool.clear();
         expect(pool.length).toBe(0);
       } finally {
         await adapter.rollback();
@@ -183,7 +183,7 @@ describeIfPg("PostgreSQLAdapter", () => {
         await adapter.execute("SELECT $1::text", ["a"]);
         const pool = adapter._statementPoolForTest()!;
         expect(pool.length).toBe(2);
-        adapter.clearCacheBang();
+        await adapter.clearCacheBang();
         expect(pool.length).toBe(0);
         // Pool itself remains attached — counter continues from where
         // it left off so we never collide with a still-PREPAREd name
@@ -208,7 +208,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       await adapter.rollback();
       // Same pool object survives the rollback (session-scoped lifetime).
       expect(adapter._statementPoolForTest()).toBe(pool);
-      adapter.clearCacheBang();
+      await adapter.clearCacheBang();
       expect(pool.length).toBe(0);
     });
 
@@ -234,7 +234,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       const conn = adapter._rawConnectionForTest();
       // @ts-expect-error — driving the reset path by force-clearing _rawConnection.
       adapter._rawConnection = null;
-      adapter.clearCacheBang();
+      await adapter.clearCacheBang();
       expect(adapter._needsDeallocateAllForTest()).toBe(true);
       // Restore so the afterEach close() doesn't double-end.
       // @ts-expect-error — restoring _rawConnection for cleanup.
@@ -274,7 +274,7 @@ describeIfPg("PostgreSQLAdapter", () => {
         // Same pool object — session-scoped lifetime.
         expect(newTxnPool).toBe(failedPool);
         expect(newTxnPool.length).toBeGreaterThan(0);
-        adapter.clearCacheBang();
+        await adapter.clearCacheBang();
         expect(newTxnPool.length).toBe(0);
       } finally {
         await adapter.rollback();

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -1282,7 +1282,7 @@ export class AbstractAdapter implements Quoting {
         this._verified = true;
 
         await this.resetTransaction({ restore: opts.restoreTransactions ?? false }, async () => {
-          this.clearCacheBang();
+          await this.clearCacheBang();
           await this.attemptConfigureConnection();
         });
         return;
@@ -1355,7 +1355,7 @@ export class AbstractAdapter implements Quoting {
   disconnectBang(): void {
     // Mirrors Rails AbstractAdapter#disconnect! (abstract_adapter.rb): the
     // raw-connection-dirty reset is what lets the next reconnect restore.
-    this.clearCacheBang();
+    void this.clearCacheBang();
     this.resetTransaction();
     this._rawConnectionDirty = false;
     this._connection = null;
@@ -1384,7 +1384,15 @@ export class AbstractAdapter implements Quoting {
     this.verifiedBang();
   }
 
-  clearCacheBang(): void {
+  /**
+   * Clear the connection's prepared-statement cache. Rails' `clear_cache!` is
+   * synchronous because `dealloc` blocks on libpq; node-pg's DEALLOCATE is a
+   * promise, so the PostgreSQL override hands back the pool's dealloc chain and
+   * every call site that can await does.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter#clear_cache!
+   */
+  clearCacheBang(): void | Promise<void> {
     // Subclasses with statement caches override this
   }
 
@@ -1664,8 +1672,8 @@ export class AbstractAdapter implements Quoting {
     this.disconnectBang();
   }
 
-  clearCache(): void {
-    this.clearCacheBang();
+  clearCache(): void | Promise<void> {
+    return this.clearCacheBang();
   }
 
   get transactionManager(): TransactionManager {
@@ -1855,7 +1863,7 @@ export class AbstractAdapter implements Quoting {
   discardBang(): void {}
 
   resetBang(): void {
-    this.clearCacheBang();
+    void this.clearCacheBang();
     this.resetTransaction();
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -1161,10 +1161,10 @@ export class TransactionManager {
    *     @connection.clear_cache!
    */
   /** @internal */
-  private afterFailureActions(transaction: unknown, error: unknown): void {
+  private afterFailureActions(transaction: unknown, error: unknown): void | Promise<void> {
     if (!(transaction instanceof RealTransaction)) return;
     if (!(error instanceof PreparedStatementCacheExpired)) return;
-    this._connection.clearCacheBang?.();
+    return this._connection.clearCacheBang?.();
   }
 
   /**
@@ -1258,7 +1258,7 @@ export class TransactionManager {
         // cache-clear work runs. PG's adapter retains a WeakRef to the
         // just-released txn client so the post-rollback `clearCacheBang`
         // can still reach the StatementPool (see `_lastReleasedTxnClient`).
-        this.afterFailureActions(transaction, e);
+        await this.afterFailureActions(transaction, e);
         throw e;
       }
 

--- a/packages/activerecord/src/connection-adapters/connection-management.ts
+++ b/packages/activerecord/src/connection-adapters/connection-management.ts
@@ -1,3 +1,5 @@
+import { methodMissingProxy } from "@blazetrails/activesupport";
+
 import { Base } from "../base.js";
 
 /**
@@ -70,16 +72,7 @@ export class BodyProxy {
    */
   static wrap(originalCdr: (() => void) | null, body: RackBody): BodyProxy {
     const target = new BodyProxy(originalCdr, body);
-    return new Proxy(target, {
-      get(proxyTarget, prop, receiver) {
-        if (prop in proxyTarget) return Reflect.get(proxyTarget, prop, receiver);
-        const value = (body as Record<string | symbol, unknown>)?.[prop];
-        return typeof value === "function" ? value.bind(body) : value;
-      },
-      has(proxyTarget, prop) {
-        return prop in proxyTarget || prop in Object(body);
-      },
-    });
+    return methodMissingProxy(target, { delegate: (proxyTarget) => proxyTarget.body });
   }
 
   closedQ(): boolean {

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -317,7 +317,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // repeatedly would keep its original insertion position and get
     // evicted the moment any other distinct query came along.
     if (pool.get(sql)) return;
-    pool.set(sql, { sql, key: pool.nextKey() });
+    void pool.set(sql, { sql, key: pool.nextKey() });
   }
 
   /**
@@ -344,8 +344,8 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * each cached statement on the adapter's sole connection.
    */
   override clearCacheBang(): void {
-    super.clearCacheBang();
-    this._statementPool?.clear();
+    void super.clearCacheBang();
+    void this._statementPool?.clear();
   }
   private _database: string | undefined;
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-query.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-query.test.ts
@@ -242,9 +242,9 @@ describe("PostgreSQLAdapter#sqlKey", () => {
   };
   const poolFor = (client: unknown): StatementPool =>
     (adapter as unknown as { _poolFor: (c: unknown) => StatementPool })._poolFor(client);
-  const preparedNameFor = (client: unknown, sql: string): string =>
+  const preparedNameFor = (client: unknown, sql: string): Promise<string> =>
     (
-      adapter as unknown as { _preparedNameFor: (c: unknown, s: string) => string }
+      adapter as unknown as { _preparedNameFor: (c: unknown, s: string) => Promise<string> }
     )._preparedNameFor(client, sql);
 
   it("scopes the pool key to the current schema_search_path", () => {
@@ -259,14 +259,14 @@ describe("PostgreSQLAdapter#sqlKey", () => {
     expect(sqlKey("SELECT 1")).toBe("-SELECT 1");
   });
 
-  it("preparing the same SQL under two different search paths yields two pool entries", () => {
+  it("preparing the same SQL under two different search paths yields two pool entries", async () => {
     const fakeClient = { query: async () => undefined, release: () => {} };
     const pool = poolFor(fakeClient);
 
     setMemo("schema_a, public");
-    const nameA = preparedNameFor(fakeClient, "SELECT * FROM widgets");
+    const nameA = await preparedNameFor(fakeClient, "SELECT * FROM widgets");
     setMemo("schema_b, public");
-    const nameB = preparedNameFor(fakeClient, "SELECT * FROM widgets");
+    const nameB = await preparedNameFor(fakeClient, "SELECT * FROM widgets");
 
     expect(nameA).not.toBe(nameB);
     expect(pool.keys).toContain("schema_a, public-SELECT * FROM widgets");
@@ -275,7 +275,7 @@ describe("PostgreSQLAdapter#sqlKey", () => {
 
     // Re-keying under the original path reuses the original entry — no stale leak.
     setMemo("schema_a, public");
-    expect(preparedNameFor(fakeClient, "SELECT * FROM widgets")).toBe(nameA);
+    expect(await preparedNameFor(fakeClient, "SELECT * FROM widgets")).toBe(nameA);
     expect(pool.length).toBe(2);
   });
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -344,29 +344,6 @@ export class PostgreSQLAdapter
   }
   private set _rawConnection(value: pg.Client | null) {
     this._connection = value as unknown as AbstractAdapter | null;
-    if (value) {
-      // Register this client's DEALLOCATE serializer so a StatementPool built
-      // for it (via buildStatementPool) parks its DEALLOCATE where the eviction
-      // site can await it — without the pool constructor needing a
-      // non-Rails-shaped extra argument. Mirrors Rails, where
-      // StatementPool#dealloc reaches @connection.@raw_connection to issue the
-      // DEALLOCATE under the connection's control (postgresql_adapter.rb:307).
-      pgDeallocSerializers.set(value, (deallocSql) => {
-        this._pendingDeallocate = (this._pendingDeallocate ?? Promise.resolve())
-          .then(() => {
-            // Only the pinned client's wire cycle is what transactionStatus
-            // reports on; a parked DEALLOCATE that outlives a reconnect would
-            // otherwise strand the flag false, since the ReadyForQuery listener
-            // that re-arms it is attached per pg.Client.
-            if (this._rawConnection === value) this._commandSettled = false;
-            return value.query(deallocSql);
-          })
-          .then(
-            () => {},
-            () => {},
-          );
-      });
-    }
   }
   /**
    * The node-pg analogue of `PG::Connection.conndefaults_hash.keys + [:requiressl]`
@@ -542,14 +519,6 @@ export class PostgreSQLAdapter
   // this before proceeding so no query can interleave between the two
   // SQL commands that resetBang fires asynchronously.
   private _inFlightReset: Promise<void> | null = null;
-  // The DEALLOCATE issued by the most recent statement-pool eviction, or null.
-  // Rails deallocates the evicted entry inline, under the connection lock,
-  // before the query that triggered the eviction is sent (statement_pool.rb:31,
-  // postgresql_adapter.rb:307); `StatementPool#dealloc` is sync here too, so the
-  // promise is parked in this slot and awaited at the eviction site instead.
-  // Every other ordering is Rails' own: the connection lock covers the query's
-  // whole life, so nothing else can be on the wire.
-  private _pendingDeallocate: Promise<void> | null = null;
   // Accumulates PG NOTICE/WARNING messages fired during the current query.
   // Cleared before each query; processed by _flushWarnings after.
   private _noticeReceiverSqlWarnings: Array<{
@@ -1520,22 +1489,6 @@ export class PostgreSQLAdapter
   }
 
   /**
-   * Await (and clear) the DEALLOCATE parked by the most recent statement-pool
-   * eviction. `StatementPool#dealloc` is sync — it mirrors Rails' sync
-   * `dealloc` — so the eviction's `client.query` cannot be awaited where it is
-   * issued; this is that await, at the site Rails deallocates inline from
-   * (statement_pool.rb:31).
-   *
-   * @internal
-   */
-  private async _drainPendingDeallocate(): Promise<void> {
-    const pending = this._pendingDeallocate;
-    if (pending === null) return;
-    this._pendingDeallocate = null;
-    await pending;
-  }
-
-  /**
    * Tear down the single StatementPool. Called from `close()` /
    * `reconnect()` only — commit/rollback keep the pool attached
    * because PG prepared statements are session-scoped, not
@@ -1578,9 +1531,8 @@ export class PostgreSQLAdapter
     const { prepareHint, onPrepared, ...queryExtra } = extra;
     const prepare = prepareHint === false ? false : this._shouldPrepare(binds);
     const attempt = async (): Promise<R> => {
-      const stmtName = prepare ? this._preparedNameFor(client, sql) : null;
+      const stmtName = prepare ? await this._preparedNameFor(client, sql) : null;
       if (stmtName !== null) onPrepared?.(stmtName);
-      await this._drainPendingDeallocate();
       this._commandSettled = false;
       if (stmtName !== null) {
         return client.query({
@@ -1614,7 +1566,7 @@ export class PostgreSQLAdapter
             { sql, binds, cause: e },
           );
         }
-        this._poolFor(client).delete(this.sqlKey(sql));
+        await this._poolFor(client).delete(this.sqlKey(sql));
         return await attempt();
       }
       throw e;
@@ -1626,15 +1578,16 @@ export class PostgreSQLAdapter
    * are allocated from the per-pool counter (`StatementPool#nextKey`)
    * so each session has its own `a1`, `a2`, ... sequence. Mirrors
    * Rails' `PostgreSQL::StatementPool#[]` / `#[]=` — present key →
-   * cached name, absent → `next_key` + store.
+   * cached name, absent → `next_key` + store. Awaiting `set` puts the evicted
+   * entry's DEALLOCATE before the query that triggered it (statement_pool.rb:31).
    */
-  private _preparedNameFor(client: pg.Client, sql: string): string {
+  private async _preparedNameFor(client: pg.Client, sql: string): Promise<string> {
     const pool = this._poolFor(client);
     const key = this.sqlKey(sql);
     const existing = pool.get(key);
     if (existing) return existing.name;
     const name = pool.nextKey();
-    pool.set(key, { name });
+    await pool.set(key, { name });
     return name;
   }
 
@@ -2638,7 +2591,7 @@ export class PostgreSQLAdapter
   // Mirrors: PostgreSQLAdapter#session_auth= (postgresql_adapter.rb:625)
   // Returns a Promise so callers can await the SET SESSION AUTHORIZATION round-trip.
   async sessionAuth(user: string): Promise<void> {
-    this.clearCacheBang();
+    await this.clearCacheBang();
     const quoted = user.toUpperCase() === "DEFAULT" ? "DEFAULT" : pgQuoteColumnName(user);
     await this.execute(`SET SESSION AUTHORIZATION ${quoted}`);
   }
@@ -2786,7 +2739,6 @@ export class PostgreSQLAdapter
     await this.withRawConnection(async (conn) => {
       const client = conn as unknown as pg.Client;
       try {
-        await this._drainPendingDeallocate();
         this._commandSettled = false;
         await client.query(sql);
       } catch (e) {
@@ -2969,13 +2921,9 @@ export class PostgreSQLAdapter
     // only AFTER ROLLBACK's response is processed (matching the
     // sequence in Rails' reset!, postgresql_adapter.rb:371-382).
     const live = this._rawConnection;
-    // Sequence behind any pending eviction DEALLOCATE so ROLLBACK (and the
-    // DISCARD ALL below) don't fire onto a client that is still running one.
-    const pendingDeallocate = this._pendingDeallocate ?? Promise.resolve();
-    let work: Promise<unknown> = pendingDeallocate;
+    let work: Promise<unknown> = Promise.resolve();
     if (this._client) {
       work = this._cancelAnyRunningQuery()
-        .then(() => pendingDeallocate)
         .then(() => live.query("ROLLBACK"))
         .catch(() => {});
       this._client = null;
@@ -3155,11 +3103,13 @@ export class PostgreSQLAdapter
    * PG-specific dealloc override). If the connection has been torn
    * down (post-disconnect/reconnect failure window) we mark
    * `_needsDeallocateAll` so the next acquire drains the server side.
+   * Returns the pool's chained DEALLOCATEs so the caller can await them before
+   * putting its own query on the socket; Rails' `clear_cache!` blocks on them.
    */
-  override clearCacheBang(): void {
-    super.clearCacheBang();
+  override clearCacheBang(): void | Promise<void> {
+    void super.clearCacheBang();
     if (this._rawConnection && this._statementPool) {
-      this._statementPool.clear();
+      return this._statementPool.clear();
     } else if (this._statementPool) {
       this._statementPool.reset();
       this._needsDeallocateAll = true;
@@ -4455,6 +4405,9 @@ export class PostgreSQLAdapter
   /**
    * Prepare a statement on the given client, caching by sql_key.
    * Mirrors: PostgreSQLAdapter#prepare_statement
+   *
+   * Awaiting `set` puts any eviction's DEALLOCATE before the caller's
+   * Bind+Execute, so it lands on an idle client (statement_pool.rb:31).
    * @internal
    */
   async prepareStatement(sql: string, _binds: unknown[], client: pg.Client): Promise<string> {
@@ -4468,11 +4421,7 @@ export class PostgreSQLAdapter
     // PREPARE ... AS avoids executing the statement (node-pg's { name, text } form
     // both prepares and executes in a single roundtrip).
     await client.query(`PREPARE ${pgQuoteColumnName(name)} AS ${sql}`);
-    pool.set(key, { name });
-    // `set` may have evicted an LRU entry. Drain its DEALLOCATE before
-    // returning so the caller's Bind+Execute lands on an idle client — Rails
-    // deallocs the evicted entry inline in StatementPool#[]=.
-    await this._drainPendingDeallocate();
+    await pool.set(key, { name });
     return name;
   }
 
@@ -4513,6 +4462,12 @@ export class PostgreSQLAdapter
 
   /**
    * Build the per-adapter StatementPool (used on initialization).
+   *
+   * `onIssue` keeps `_commandSettled`'s invariant across the eviction
+   * DEALLOCATE, guarded on the client still being the pinned one: a DEALLOCATE
+   * outliving a reconnect would strand the flag false, since the
+   * ReadyForQuery listener that re-arms it is attached per `pg.Client`.
+   *
    * Mirrors: PostgreSQLAdapter#build_statement_pool
    * @internal
    */
@@ -4520,6 +4475,9 @@ export class PostgreSQLAdapter
     return new StatementPool(
       client,
       PostgreSQLAdapter.typeCastConfigToInteger(this._statementLimit) as number,
+      () => {
+        if (this._rawConnection === client) this._commandSettled = false;
+      },
     );
   }
 
@@ -4937,17 +4895,6 @@ export interface PreparedStatement {
 }
 
 /**
- * Maps a pinned `pg.Client` to its owning adapter's DEALLOCATE serializer
- * (populated by the adapter's `_rawConnection` setter). A `StatementPool`'s
- * `dealloc` looks the client up here so the adapter can await the DEALLOCATE at
- * the eviction site (as Rails does inline, statement_pool.rb:31), without the
- * pool constructor needing a non-Rails-shaped extra argument. A
- * `WeakMap` so entries vanish when the client is GC'd. Clients no adapter owns
- * (standalone pools) are absent → the prior best-effort fire-and-forget path.
- */
-const pgDeallocSerializers = new WeakMap<pg.Client, (deallocSql: string) => void>();
-
-/**
  * PG-flavored StatementPool. Backs the per-connection statement cache;
  * `dealloc` sends `DEALLOCATE` for the evicted name. PG prepared
  * statements are session-scoped, and after the dual-pool collapse the
@@ -4963,10 +4910,18 @@ export class StatementPool extends GenericStatementPool<PreparedStatement> {
   // session-scoped nature of PG prepared statements and lets the
   // adapter own zero state about naming.
   private _counter = 0;
+  private _deallocating: Promise<void> = Promise.resolve();
+  private _onIssue: () => void;
 
-  constructor(client: pg.Client, maxSize = 1000) {
+  /**
+   * Rails' pool takes the connection (`postgresql_adapter.rb:296`) and reaches
+   * `@connection.@raw_connection` at dealloc time; trails' holds the client, so
+   * `onIssue` is the one piece of connection state it still needs.
+   */
+  constructor(client: pg.Client, maxSize = 1000, onIssue: () => void = () => {}) {
     super(maxSize);
     this._client = client;
+    this._onIssue = onIssue;
   }
 
   /**
@@ -4983,8 +4938,12 @@ export class StatementPool extends GenericStatementPool<PreparedStatement> {
    * does not exist") and errors against a closed connection — the
    * statement is already gone on the server either way. Node-pg
    * surfaces the same as error codes / messages.
+   *
+   * Rails' `dealloc` blocks, so a `clear` deallocating N entries sends them one
+   * at a time. node-pg does not, so each DEALLOCATE chains onto the one before
+   * it (`_deallocating`), and that chain is what `[]=` / `clear` hand back.
    */
-  protected override dealloc(stmt: PreparedStatement): void {
+  protected override dealloc(stmt: PreparedStatement): void | Promise<void> {
     const client = this._client;
     if (!client) return;
     // Best-effort async cleanup. The server drops prepared statements on
@@ -4994,18 +4953,16 @@ export class StatementPool extends GenericStatementPool<PreparedStatement> {
     // of raising, so a leaked caller-supplied name can't produce a synchronous
     // throw at the call site.
     const deallocSql = `DEALLOCATE ${pgQuoteColumnName(stmt.name)}`;
-    const serialize = pgDeallocSerializers.get(client);
-    if (serialize) {
-      // Adapter-owned client: hand the DEALLOCATE to the adapter, which awaits
-      // it at the eviction site before the query that triggered the eviction
-      // goes out — Rails' inline dealloc. It swallows errors.
-      serialize(deallocSql);
-      return;
-    }
-    // Standalone pool whose client no adapter owns: keep the prior best-effort
-    // fire-and-forget. The empty `.catch` keeps node from treating a post-close
-    // DEALLOCATE as an unhandled rejection.
-    client.query(deallocSql).catch(() => {});
+    this._deallocating = this._deallocating
+      .then(() => {
+        this._onIssue();
+        return client.query(deallocSql);
+      })
+      .then(
+        () => {},
+        () => {},
+      );
+    return this._deallocating;
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -833,7 +833,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
     type: ColumnType,
     options: ColumnOptions & { using?: string; castAs?: string } = {},
   ): Promise<void> {
-    this.clearCacheBang();
+    await this.clearCacheBang();
     const parts = await this.changeColumnForAlter(tableName, columnName, type, options);
     const sqls = parts.filter((v): v is string => typeof v === "string");
     const procs = parts.filter((v): v is () => Promise<void> => typeof v === "function");
@@ -857,7 +857,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
     // cache, defer to the abstract implementation (which builds an AlterTable
     // and accepts it through schema_creation), then propagate :comment via
     // change_column_comment.
-    this.clearCacheBang();
+    await this.clearCacheBang();
     await super.addColumn(tableName, columnName, type, options);
     if ("comment" in options) {
       await this.changeColumnComment(tableName, columnName, options.comment ?? null);
@@ -869,7 +869,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
     columnName: string,
     newColumnName: string,
   ): Promise<void> {
-    this.clearCacheBang();
+    await this.clearCacheBang();
     await this.execute(
       `ALTER TABLE ${this.quoteTableName(tableName)} RENAME COLUMN ${this.quoteColumnName(columnName)} TO ${this.quoteColumnName(newColumnName)}`,
     );
@@ -933,7 +933,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
     // Mirrors PostgreSQL::SchemaStatements#change_column_null: validate the
     // boolean argument and clear the statement cache before issuing DDL.
     this.validateChangeColumnNullArgumentBang(nullable);
-    this.clearCacheBang();
+    await this.clearCacheBang();
     const quotedTable = this.quoteTableName(tableName);
     const quotedCol = this.quoteColumnName(columnName);
     if (!nullable && defaultValue != null) {
@@ -960,7 +960,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
     // Mirrors PostgreSQL::SchemaStatements#change_column_comment: clear the
     // statement cache and unwrap the {from:, to:} change hash before issuing
     // the COMMENT ON statement.
-    this.clearCacheBang();
+    await this.clearCacheBang();
     const comment = this.extractNewCommentValue(commentOrChanges);
     await this.execute(
       `COMMENT ON COLUMN ${this.quoteTableName(tableName)}.${this.quoteColumnName(columnName)} IS ${this.quote(comment)}`,
@@ -972,7 +972,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
     commentOrChanges: CommentOrChanges,
   ): Promise<void> {
     // Mirrors PostgreSQL::SchemaStatements#change_table_comment.
-    this.clearCacheBang();
+    await this.clearCacheBang();
     const comment = this.extractNewCommentValue(commentOrChanges);
     await this.execute(
       `COMMENT ON TABLE ${this.quoteTableName(tableName)} IS ${this.quote(comment)}`,

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -403,7 +403,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     // the native driver opens a file handle that would otherwise leak.
     if (options.statementLimit !== undefined) {
       this._statementLimit = options.statementLimit;
-      this._statementPool.setMaxSize(
+      void this._statementPool.setMaxSize(
         SQLite3Adapter.typeCastConfigToInteger(this._statementLimit) as number,
       );
     }
@@ -567,7 +567,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     if (!stmt) {
       stmt = await this.driver.prepare(sql);
       this._maybeEnableReadBigInts(sql, stmt);
-      this._statementPool.set(sql, stmt);
+      void this._statementPool.set(sql, stmt);
     }
     return stmt;
   }
@@ -1386,8 +1386,8 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   }
 
   override clearCacheBang(): void {
-    super.clearCacheBang();
-    this._statementPool.clear();
+    void super.clearCacheBang();
+    void this._statementPool.clear();
   }
 
   override disconnectBang(): void {

--- a/packages/activerecord/src/connection-adapters/statement-pool.test.ts
+++ b/packages/activerecord/src/connection-adapters/statement-pool.test.ts
@@ -4,7 +4,7 @@ import { isSqliteRun } from "../support/sqlite-template.js";
 import { newRawTestAdapter } from "../test-adapter.js";
 
 describe("StatementPoolTest", () => {
-  it("#delete doesn't call dealloc if the statement didn't exist", () => {
+  it("#delete doesn't call dealloc if the statement didn't exist", async () => {
     const dealloced: string[] = [];
     class TestPool extends StatementPool<string> {
       protected dealloc(stmt: string): void {
@@ -12,11 +12,11 @@ describe("StatementPoolTest", () => {
       }
     }
     const pool = new TestPool();
-    pool.delete("nonexistent");
+    await pool.delete("nonexistent");
     expect(dealloced).toHaveLength(0);
   });
 
-  it("#delete calls dealloc when statement exists", () => {
+  it("#delete calls dealloc when statement exists", async () => {
     const dealloced: string[] = [];
     class TestPool extends StatementPool<string> {
       protected dealloc(stmt: string): void {
@@ -24,13 +24,13 @@ describe("StatementPoolTest", () => {
       }
     }
     const pool = new TestPool();
-    pool.set("key", "prepared_stmt");
-    pool.delete("key");
+    await pool.set("key", "prepared_stmt");
+    await pool.delete("key");
     expect(dealloced).toEqual(["prepared_stmt"]);
     expect(pool.length).toBe(0);
   });
 
-  it("clear calls dealloc for each statement", () => {
+  it("clear calls dealloc for each statement", async () => {
     const dealloced: string[] = [];
     class TestPool extends StatementPool<string> {
       protected dealloc(stmt: string): void {
@@ -38,14 +38,14 @@ describe("StatementPoolTest", () => {
       }
     }
     const pool = new TestPool();
-    pool.set("a", "stmt_a");
-    pool.set("b", "stmt_b");
-    pool.clear();
+    await pool.set("a", "stmt_a");
+    await pool.set("b", "stmt_b");
+    await pool.clear();
     expect(dealloced.sort()).toEqual(["stmt_a", "stmt_b"]);
     expect(pool.length).toBe(0);
   });
 
-  it("reset clears without calling dealloc", () => {
+  it("reset clears without calling dealloc", async () => {
     const dealloced: string[] = [];
     class TestPool extends StatementPool<string> {
       protected dealloc(stmt: string): void {
@@ -53,17 +53,17 @@ describe("StatementPoolTest", () => {
       }
     }
     const pool = new TestPool();
-    pool.set("a", "stmt_a");
-    pool.set("b", "stmt_b");
+    await pool.set("a", "stmt_a");
+    await pool.set("b", "stmt_b");
     pool.reset();
     expect(dealloced).toHaveLength(0);
     expect(pool.length).toBe(0);
   });
 
-  it("each iterates over all entries", () => {
+  it("each iterates over all entries", async () => {
     const pool = new StatementPool<string>();
-    pool.set("a", "1");
-    pool.set("b", "2");
+    await pool.set("a", "1");
+    await pool.set("b", "2");
     const entries: [string, string][] = [];
     pool.each((key, stmt) => entries.push([key, stmt]));
     expect(entries).toEqual([
@@ -72,7 +72,7 @@ describe("StatementPoolTest", () => {
     ]);
   });
 
-  it("evicts oldest when exceeding max size", () => {
+  it("evicts oldest when exceeding max size", async () => {
     const dealloced: string[] = [];
     class TestPool extends StatementPool<string> {
       protected dealloc(stmt: string): void {
@@ -80,9 +80,9 @@ describe("StatementPoolTest", () => {
       }
     }
     const pool = new TestPool(2);
-    pool.set("a", "1");
-    pool.set("b", "2");
-    pool.set("c", "3");
+    await pool.set("a", "1");
+    await pool.set("b", "2");
+    await pool.set("c", "3");
     expect(pool.length).toBe(2);
     expect(pool.has("a")).toBe(false);
     expect(pool.has("b")).toBe(true);
@@ -90,20 +90,20 @@ describe("StatementPoolTest", () => {
     expect(dealloced).toEqual(["1"]);
   });
 
-  it("LRU: get moves entry to end", () => {
+  it("LRU: get moves entry to end", async () => {
     const pool = new StatementPool<string>(2);
-    pool.set("a", "1");
-    pool.set("b", "2");
+    await pool.set("a", "1");
+    await pool.set("b", "2");
     pool.get("a"); // touch a, making b the oldest
-    pool.set("c", "3"); // should evict b, not a
+    await pool.set("c", "3"); // should evict b, not a
     expect(pool.has("a")).toBe(true);
     expect(pool.has("b")).toBe(false);
     expect(pool.has("c")).toBe(true);
   });
 
-  it("isKey is an alias for has", () => {
+  it("isKey is an alias for has", async () => {
     const pool = new StatementPool<string>();
-    pool.set("a", "1");
+    await pool.set("a", "1");
     expect(pool.isKey("a")).toBe(true);
     expect(pool.isKey("b")).toBe(false);
   });
@@ -141,7 +141,7 @@ describe("SQLite3 StatementPool integration", () => {
     }
   });
 
-  it("setMaxSize shrinks and evicts LRU entries through dealloc", () => {
+  it("setMaxSize shrinks and evicts LRU entries through dealloc", async () => {
     const dealloced: string[] = [];
     class TestPool extends StatementPool<string> {
       protected dealloc(stmt: string): void {
@@ -149,18 +149,18 @@ describe("SQLite3 StatementPool integration", () => {
       }
     }
     const pool = new TestPool(5);
-    pool.set("a", "stmt_a");
-    pool.set("b", "stmt_b");
-    pool.set("c", "stmt_c");
+    await pool.set("a", "stmt_a");
+    await pool.set("b", "stmt_b");
+    await pool.set("c", "stmt_c");
     // Touch "a" so it's moved to MRU — LRU order becomes b, c, a.
     pool.get("a");
-    pool.setMaxSize(1);
+    await pool.setMaxSize(1);
     expect(pool.length).toBe(1);
     expect(pool.has("a")).toBe(true);
     expect(dealloced).toEqual(["stmt_b", "stmt_c"]);
   });
 
-  it("setMaxSize(0) evicts everything and blocks new inserts", () => {
+  it("setMaxSize(0) evicts everything and blocks new inserts", async () => {
     const dealloced: string[] = [];
     class TestPool extends StatementPool<string> {
       protected dealloc(stmt: string): void {
@@ -168,15 +168,32 @@ describe("SQLite3 StatementPool integration", () => {
       }
     }
     const pool = new TestPool(5);
-    pool.set("a", "stmt_a");
-    pool.set("b", "stmt_b");
-    pool.setMaxSize(0);
+    await pool.set("a", "stmt_a");
+    await pool.set("b", "stmt_b");
+    await pool.setMaxSize(0);
     expect(pool.length).toBe(0);
     expect(dealloced.sort()).toEqual(["stmt_a", "stmt_b"]);
     // set() is a no-op when maxSize is 0 — matches Rails' behavior
     // where statement_limit = 0 disables caching.
-    pool.set("c", "stmt_c");
+    await pool.set("c", "stmt_c");
     expect(pool.length).toBe(0);
+  });
+
+  it("threads an asynchronous dealloc back to the eviction site", async () => {
+    const order: string[] = [];
+    class TestPool extends StatementPool<string> {
+      private _chain: Promise<void> = Promise.resolve();
+      protected dealloc(stmt: string): Promise<void> {
+        this._chain = this._chain.then(() => Promise.resolve()).then(() => void order.push(stmt));
+        return this._chain;
+      }
+    }
+    const pool = new TestPool(1);
+    await pool.set("a", "stmt_a");
+    await pool.set("b", "stmt_b");
+    order.push("eviction-site-resumed");
+    await pool.clear();
+    expect(order).toEqual(["stmt_a", "eviction-site-resumed", "stmt_b"]);
   });
 
   it("setMaxSize rejects negative / non-integer values", () => {

--- a/packages/activerecord/src/connection-adapters/statement-pool.ts
+++ b/packages/activerecord/src/connection-adapters/statement-pool.ts
@@ -25,20 +25,23 @@ export class StatementPool<T = unknown> {
    * least-recently-used statements via `dealloc` — matches Rails'
    * behavior when `statement_limit` is changed mid-session.
    */
-  setMaxSize(maxSize: number): void {
+  setMaxSize(maxSize: number): void | Promise<void> {
     if (!Number.isInteger(maxSize) || maxSize < 0) {
       throw new RangeError(
         `StatementPool#setMaxSize expected a finite non-negative integer; got ${String(maxSize)}`,
       );
     }
     this._maxSize = maxSize;
+    const deallocating: Array<Promise<void>> = [];
     while (this._statements.size > this._maxSize) {
       const firstKey = this._statements.keys().next().value;
       if (firstKey === undefined) break;
       const evicted = this._statements.get(firstKey)!;
       this._statements.delete(firstKey);
-      this.dealloc(evicted);
+      const pending = this.dealloc(evicted);
+      if (pending) deallocating.push(pending);
     }
+    if (deallocating.length > 0) return Promise.all(deallocating).then(() => {});
   }
 
   get(key: string): T | undefined {
@@ -50,17 +53,20 @@ export class StatementPool<T = unknown> {
     return stmt;
   }
 
-  set(key: string, stmt: T): void {
+  set(key: string, stmt: T): void | Promise<void> {
     if (this._maxSize <= 0) return;
     this._statements.delete(key);
+    const deallocating: Array<Promise<void>> = [];
     while (this._statements.size >= this._maxSize) {
       const firstKey = this._statements.keys().next().value;
       if (firstKey === undefined) break;
       const evicted = this._statements.get(firstKey)!;
       this._statements.delete(firstKey);
-      this.dealloc(evicted);
+      const pending = this.dealloc(evicted);
+      if (pending) deallocating.push(pending);
     }
     this._statements.set(key, stmt);
+    if (deallocating.length > 0) return Promise.all(deallocating).then(() => {});
   }
 
   has(key: string): boolean {
@@ -72,19 +78,22 @@ export class StatementPool<T = unknown> {
     return this.has(key);
   }
 
-  delete(key: string): T | undefined {
+  delete(key: string): T | undefined | Promise<T | undefined> {
     if (!this._statements.has(key)) return undefined;
     const stmt = this._statements.get(key) as T;
     this._statements.delete(key);
-    this.dealloc(stmt);
-    return stmt;
+    const pending = this.dealloc(stmt);
+    return pending ? pending.then(() => stmt) : stmt;
   }
 
-  clear(): void {
+  clear(): void | Promise<void> {
+    const deallocating: Array<Promise<void>> = [];
     for (const stmt of this._statements.values()) {
-      this.dealloc(stmt);
+      const pending = this.dealloc(stmt);
+      if (pending) deallocating.push(pending);
     }
     this._statements.clear();
+    if (deallocating.length > 0) return Promise.all(deallocating).then(() => {});
   }
 
   /**
@@ -116,9 +125,14 @@ export class StatementPool<T = unknown> {
    * Deallocate a prepared statement. Subclasses override this to
    * release adapter-specific resources (e.g. PG DEALLOCATE).
    *
+   * Rails' `dealloc` blocks on libpq (postgresql_adapter.rb:307), so `[]=` is
+   * done with the eviction by the time it returns. node-pg returns a promise, so
+   * an override may return it and the mutating methods thread it back to the
+   * eviction site, which awaits where Rails blocks.
+   *
    * Mirrors: ActiveRecord::ConnectionAdapters::StatementPool#dealloc
    */
-  protected dealloc(_stmt: T): void {
+  protected dealloc(_stmt: T): void | Promise<void> {
     // Base implementation is a no-op; adapter-specific pools override.
   }
 }

--- a/packages/activerecord/src/migration/command-recorder.trails.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.trails.test.ts
@@ -26,6 +26,15 @@ const columnMethods = (t: Table): Record<string, (name: string) => Promise<void>
   t as unknown as Record<string, (name: string) => Promise<void>>;
 
 describe("CommandRecorder", () => {
+  it("forwards a non-function delegate member the way public_send does", () => {
+    const recorder = new CommandRecorder({ encoding: "utf8", america: () => "hi" }) as unknown as {
+      encoding: string;
+      america: () => string;
+    };
+    expect(recorder.encoding).toBe("utf8");
+    expect(recorder.america()).toBe("hi");
+  });
+
   it("invertCreateTable strips ifNotExists even when fn is last arg", () => {
     const fn = () => {};
     const [cmd, args] = new CommandRecorder().invertCreateTable([

--- a/packages/activerecord/src/migration/command-recorder.ts
+++ b/packages/activerecord/src/migration/command-recorder.ts
@@ -4,6 +4,8 @@
  * Mirrors: ActiveRecord::Migration::CommandRecorder
  */
 
+import { methodMissingProxy } from "@blazetrails/activesupport";
+
 import { IrreversibleMigration } from "../migration.js";
 import type { Table } from "../connection-adapters/abstract/schema-definitions.js";
 import {
@@ -22,19 +24,7 @@ export class CommandRecorder {
     // (command_recorder.rb:395-406), which forward any method the recorder does
     // not define to the delegate. JS has no method_missing, so the forwarding
     // lives in a Proxy returned from the constructor — class-wide, as in Rails.
-    return new Proxy(this, {
-      get(target, prop, receiver) {
-        if (Reflect.has(target, prop)) return Reflect.get(target, prop, receiver);
-        const delegate = target._delegate as Record<string | symbol, unknown> | null;
-        const forwarded = delegate?.[prop];
-        return typeof forwarded === "function" ? forwarded.bind(delegate) : undefined;
-      },
-      has(target, prop) {
-        if (Reflect.has(target, prop)) return true;
-        const delegate = target._delegate as Record<string | symbol, unknown> | null;
-        return delegate != null && prop in delegate;
-      },
-    });
+    return methodMissingProxy(this, { delegate: (target) => target._delegate });
   }
 
   get delegate(): unknown {

--- a/packages/activerecord/src/support/canonical-schema.ts
+++ b/packages/activerecord/src/support/canonical-schema.ts
@@ -2211,7 +2211,7 @@ export async function loadCanonicalSchema(adapter: DatabaseAdapter): Promise<voi
   }
   // create_table/drop_table clear the connection's prepared statements in Rails;
   // mirror that so PostgreSQL doesn't reuse a stale cached plan (0A000).
-  (adapter as { clearCacheBang?: () => void }).clearCacheBang?.();
+  await (adapter as { clearCacheBang?: () => void | Promise<void> }).clearCacheBang?.();
 }
 
 /** Memoized dependent-table edges, built once per module instance. */

--- a/packages/activerecord/src/support/canonical-table-rebuild.ts
+++ b/packages/activerecord/src/support/canonical-table-rebuild.ts
@@ -324,7 +324,7 @@ export async function rebuildCanonicalTables(
   for (const def of defs) {
     await runTable(adapter, ss, typeMap, def);
   }
-  (adapter as { clearCacheBang?: () => void }).clearCacheBang?.();
+  await (adapter as { clearCacheBang?: () => void | Promise<void> }).clearCacheBang?.();
 }
 
 /**
@@ -363,5 +363,6 @@ export async function ensureCanonicalTables(
     await runTable(adapter, ss, typeMap, def);
     created = true;
   }
-  if (created) (adapter as { clearCacheBang?: () => void }).clearCacheBang?.();
+  if (created)
+    await (adapter as { clearCacheBang?: () => void | Promise<void> }).clearCacheBang?.();
 }

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -497,6 +497,7 @@ export type { ClassMethods } from "./callbacks.js";
 export { Concern, MultipleIncludedBlocks, MultiplePrependBlocks } from "./concern.js";
 export { include, extend, included, extended } from "./include.js";
 export type { Included, Extended } from "./include.js";
+export { methodMissingProxy } from "./method-missing-proxy.js";
 export { prepend } from "./prepend.js";
 export type { PrependMethod, PrependModule } from "./prepend.js";
 export { ClassAttribute } from "./class-attribute.js";

--- a/packages/activesupport/src/method-missing-proxy.ts
+++ b/packages/activesupport/src/method-missing-proxy.ts
@@ -1,0 +1,46 @@
+/**
+ * Ruby-style `method_missing` forwarding for a TypeScript object.
+ *
+ * Ruby wrappers define `method_missing` / `respond_to_missing?` to forward what
+ * they don't define to the wrapped delegate. The trails idiom is a `Proxy` whose
+ * `get` falls through to the delegate and whose `has` mirrors
+ * `respond_to_missing?` — the role `include()` plays for Ruby `include`.
+ *
+ * `delegate` is read on every access, because the wrappers that need this can
+ * swap it after construction, as Ruby re-reads the ivar. A forwarded value comes
+ * back whether or not it is callable — `public_send` makes no such distinction
+ * (command_recorder.rb:400-404) — with functions bound to the delegate. When
+ * `delegate(target)` returns `target` there is no own-property step (DelegateClass).
+ *
+ * @noRailsEquivalent PERMANENT — Ruby resolves an undefined method through
+ * `method_missing` at the language level; JS has no such hook, only `Proxy`.
+ * No amount of porting removes the need for a TS-side shape, so this is the one
+ * shared one, the way `include()` is the one shape for Ruby `include`.
+ */
+export function methodMissingProxy<T extends object>(
+  target: T,
+  /** `delegate` reads the forwarding target; `overrides` is consulted first. */
+  options: {
+    delegate: (target: T) => unknown;
+    overrides?: Record<string | symbol, unknown>;
+  },
+): T {
+  const { delegate: readDelegate, overrides } = options;
+  return new Proxy(target, {
+    get(proxyTarget, prop, receiver) {
+      if (overrides !== undefined && prop in overrides) return overrides[prop];
+      const delegate = readDelegate(proxyTarget);
+      if (delegate !== proxyTarget && Reflect.has(proxyTarget, prop)) {
+        return Reflect.get(proxyTarget, prop, receiver);
+      }
+      const value = (delegate as Record<string | symbol, unknown> | null | undefined)?.[prop];
+      return typeof value === "function" ? value.bind(delegate) : value;
+    },
+    has(proxyTarget, prop) {
+      if (overrides !== undefined && prop in overrides) return true;
+      if (Reflect.has(proxyTarget, prop)) return true;
+      const delegate = readDelegate(proxyTarget);
+      return delegate != null && prop in Object(delegate);
+    },
+  });
+}

--- a/packages/activesupport/src/time-zone-config.ts
+++ b/packages/activesupport/src/time-zone-config.ts
@@ -27,11 +27,15 @@ export function getZone(): TimeZone | null {
 }
 
 /**
- * Set Time.zone. Accepts a TimeZone, a string name, or null.
- * Passing null resets to zone_default.
+ * Set Time.zone. Accepts a TimeZone, a string name, null, or false.
+ *
+ * Rails stores nil and false verbatim; trails' zone slot has no such state, so
+ * both reset to zone_default — which is also why this does not yet route through
+ * `findZoneBang` the way zones.rb:42 does. See
+ * 0072/converge-time-zone-setter-through-find-zone-bang.
  */
-export function setZone(zone: TimeZone | string | null): void {
-  if (zone === null) {
+export function setZone(zone: TimeZone | string | null | false): void {
+  if (zone === null || zone === false) {
     _zone = undefined; // Reset to zone_default
     return;
   }
@@ -78,11 +82,9 @@ export function setZoneDefault(zone: TimeZone | null): void {
  * callbacks would observe the wrong zone after the first await.
  */
 export function useZone<T>(zone: string | TimeZone, fn: () => T): T {
-  if (typeof zone === "string") {
-    zone = TimeZone.find(zone);
-  }
+  const newZone = findZoneBang(zone);
   const prev = _zone;
-  _zone = zone;
+  _zone = newZone as TimeZone | null;
   try {
     const result = fn();
     if (result != null && typeof (result as any).then === "function") {
@@ -98,26 +100,17 @@ export function useZone<T>(zone: string | TimeZone, fn: () => T): T {
 
 /**
  * Find a timezone, returning null if not found (no exception).
- * Matches Rails' Time.find_zone (without bang).
+ * Matches Rails' `Time.find_zone`: `find_zone!(time_zone) rescue nil` — one
+ * implementation, the bang form, with the ArgumentError swallowed
+ * (core_ext/time/zones.rb:97-99).
  */
-export function findZone(zone: unknown): TimeZone | null {
-  if (zone === null || zone === undefined) return null;
-  if (zone instanceof TimeZone) return zone;
-  if (typeof zone === "string") {
-    try {
-      return TimeZone.find(zone);
-    } catch {
-      return null;
-    }
+export function findZone(zone: unknown): TimeZone | null | false {
+  try {
+    return findZoneBang(zone);
+  } catch (e) {
+    if (e instanceof ArgumentError) return null;
+    throw e;
   }
-  if (typeof zone === "number") {
-    try {
-      return TimeZone.find(zone.toString());
-    } catch {
-      return null;
-    }
-  }
-  return null;
 }
 
 /**

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/array-inquirer.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/array-inquirer.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "activesupport",
+    "tsFile": "array-inquirer.ts",
+    "rubyName": "inquiry",
+    "call": "new",
+    "reason": "Rails' `Array#inquiry` is `ArrayInquirer.new(self)`; trails' `arrayInquiry` does construct one (`new ArrayInquirer<T>(...items)`, array-inquirer.ts:58) — the spread makes it a different arity, so the matcher does not pair the two."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/enumerable-utils.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/enumerable-utils.json
@@ -2,6 +2,13 @@
   {
     "package": "activesupport",
     "tsFile": "enumerable-utils.ts",
+    "rubyName": "in?",
+    "call": "new",
+    "reason": "`new` here is `ArgumentError.new` in Rails' `rescue NoMethodError` arm (object/inclusion.rb:22). `isIn` type-switches on the collection instead of rescuing, so no argument can reach a receiver without `include?` and the arm has nothing to raise from."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "enumerable-utils.ts",
     "rubyName": "in_order_of",
     "call": "compact",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/module-ext.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/module-ext.json
@@ -16,6 +16,27 @@
   {
     "package": "activesupport",
     "tsFile": "module-ext.ts",
+    "rubyName": "descendants",
+    "call": "concat",
+    "reason": "Rails' `Class#descendants` walks the subclass tree itself (class/subclasses.rb:20); trails delegates the whole walk to `DescendantsTracker.descendants`, where Rails' own DescendantsTracker keeps it."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "module-ext.ts",
+    "rubyName": "descendants",
+    "call": "flat_map",
+    "reason": "Same one-line delegation to `DescendantsTracker.descendants` — the recursion, and its `flat_map`, live there."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "module-ext.ts",
+    "rubyName": "descendants",
+    "call": "subclasses",
+    "reason": "Same delegation; the tracker reads the subclass set directly, not through this file's `subclasses`."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "module-ext.ts",
     "rubyName": "mattr_accessor",
     "call": "first",
     "reason": "Rails passes `location: caller_locations(1, 1).first` to `mattr_reader`/`mattr_writer` (attribute_accessors.rb:66) so a raised NameError points at the declaring line. trails generates the accessors directly with no location plumbing."

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/time-ext.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/time-ext.json
@@ -5,5 +5,40 @@
     "rubyName": "since",
     "call": "warn",
     "reason": "Time#since's `warn` is reached only from its `rescue TypeError` arm, which deprecates passing a non-numeric (time/calculations.rb:126-133). time-ext.ts's `since` takes `seconds: number`, so the deprecated call shape is unrepresentable and the arm has nothing to warn about."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "to_date",
+    "call": "parse",
+    "reason": "`::Date.parse(self, false)` in `String#to_date`; trails' `toDate` takes an already-parsed `Date` and reads its calendar fields."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "to_fs",
+    "call": "strftime",
+    "reason": "`strftime` is Ruby's C-level time formatter. JS has no strftime; each named DATE_FORMATS entry is expanded with `Intl`/`toISOString` in `toFs`."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "to_time",
+    "call": "getlocal",
+    "reason": "`getlocal` re-zones a Ruby Time to the system offset. A JS `Date` is already an absolute instant with no attached zone, so `toTime` has nothing to re-zone."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "to_time",
+    "call": "new",
+    "reason": "`::Time.new(...)` builds the Time from the parsed parts; trails routes string parsing through `@blazetrails/date` and returns the instant it produces."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "xmlschema",
+    "call": "in_time_zone",
+    "reason": "Rails' `Date#xmlschema` goes through `in_time_zone.xmlschema` to pick up `Time.zone`; trails' is the zoneless arm, and `TimeWithZone#xmlschema` is the zone-aware one."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/time-zone-config.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/time-zone-config.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "activesupport",
+    "tsFile": "time-zone-config.ts",
+    "rubyName": "zone=",
+    "call": "find_zone!",
+    "reason": "`setZone` still resolves the argument inline instead of through `findZoneBang`, because trails maps `nil` onto 'unset, fall through to zone_default' where Rails stores nil. Converging the two needs the zone_default fallthrough settled first; `find_zone`/`use_zone` in this file already route through `findZoneBang`."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/transliterate.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/transliterate.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "activesupport",
+    "tsFile": "transliterate.ts",
+    "rubyName": "transliterate",
+    "call": "include?",
+    "reason": "`ALLOWED_ENCODINGS_FOR_TRANSLITERATE.include?(string.encoding)` guards Ruby's per-String Encoding (transliterate.rb:66). JS strings carry no encoding tag, so there is no encoding to check and no arm to port."
+  }
+]

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -1629,11 +1629,9 @@ describe("splitOverriddenFileBuckets", () => {
     expect(out.map((e) => e.info.file)).toEqual([
       "inflector/inflections.rb",
       "inflector/methods.rb",
+      "inflector/transliterate.rb",
     ]);
-    expect(out[0].info.instanceMethods.map((im) => im.name)).toEqual([
-      "inflections",
-      "transliterate",
-    ]);
+    expect(out[0].info.instanceMethods.map((im) => im.name)).toEqual(["inflections"]);
     expect(out[1].info.instanceMethods.map((im) => im.name)).toEqual([
       "deconstantize",
       "constantize",
@@ -1660,7 +1658,9 @@ describe("splitOverriddenFileBuckets", () => {
       fqn: "ActiveSupport::Inflector",
       info: { ...inflector, file: "inflector/methods.rb" },
     };
-    expect(splitOverriddenFileBuckets(entity, "activesupport")).toEqual([entity]);
+    const out = splitOverriddenFileBuckets(entity, "activesupport");
+    expect(out[0].info.file).toBe("inflector/methods.rb");
+    expect(out[0].info.instanceMethods).toHaveLength(3);
   });
 });
 

--- a/scripts/api-compare/conventions.ts
+++ b/scripts/api-compare/conventions.ts
@@ -198,6 +198,37 @@ export const RUBY_FILE_TS_OVERRIDES: Record<string, string> = {
   // default rule — but Range's home bucket is `core_ext/range/each.rb`, so the
   // reopening still needs the entry.
   "activesupport:core_ext/range/overlap.rb": "core-ext/range/overlap.ts",
+  // The conversions cluster. `toFs` / `toTime` / `toDate` / `xmlschema` take an
+  // instant receiver, so Time, Date and DateTime all read them off `time-ext.ts`;
+  // only `date/calculations.rb`'s Date arm has its own receiver and file.
+  "activesupport:core_ext/time/conversions.rb": "time-ext.ts",
+  "activesupport:core_ext/date/conversions.rb": "time-ext.ts",
+  "activesupport:core_ext/date_time/conversions.rb": "time-ext.ts",
+  "activesupport:core_ext/time/compatibility.rb": "time-ext.ts",
+  "activesupport:core_ext/date_time/compatibility.rb": "time-ext.ts",
+  "activesupport:core_ext/time/acts_like.rb": "time-ext.ts",
+  "activesupport:core_ext/string/conversions.rb": "time-ext.ts",
+  "activesupport:core_ext/string/zones.rb": "time-ext.ts",
+  "activesupport:core_ext/time/zones.rb": "time-zone-config.ts",
+  "activesupport:core_ext/numeric/time.rb": "duration.ts",
+  "activesupport:core_ext/integer/time.rb": "duration.ts",
+  "activesupport:core_ext/date/blank.rb": "core-ext/object/blank.ts",
+  "activesupport:core_ext/date_time/blank.rb": "core-ext/object/blank.ts",
+  "activesupport:core_ext/pathname/blank.rb": "core-ext/object/blank.ts",
+  "activesupport:core_ext/hash/slice.rb": "hash-utils.ts",
+  "activesupport:core_ext/hash/except.rb": "hash-utils.ts",
+  "activesupport:core_ext/hash/deep_merge.rb": "hash-utils.ts",
+  "activesupport:core_ext/hash/indifferent_access.rb": "hash-with-indifferent-access.ts",
+  "activesupport:core_ext/array/conversions.rb": "array-utils.ts",
+  "activesupport:core_ext/string/exclude.rb": "string-utils.ts",
+  "activesupport:core_ext/object/inclusion.rb": "enumerable-utils.ts",
+  "activesupport:core_ext/object/with.rb": "core-ext/object/with.ts",
+  "activesupport:core_ext/class/subclasses.rb": "module-ext.ts",
+  "activesupport:core_ext/kernel/reporting.rb": "module-ext.ts",
+  "activesupport:core_ext/module/redefine_method.rb": "class-attribute.ts",
+  "activesupport:core_ext/array/inquiry.rb": "array-inquirer.ts",
+  "activesupport:core_ext/string/inquiry.rb": "string-inquirer.ts",
+  "activesupport:inflector/transliterate.rb": "transliterate.ts",
 };
 
 /** The explicit TS mapping for `rubyFile` in `pkg`, or undefined when unmapped. */

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -1339,6 +1339,73 @@ export const UNPORTED_FILES: UnportedFile[] = [
       "loadable. Ruby-only wire format, same as test_date_marshal.rb above; the " +
       "rest of the file stays counted.",
   },
+  // The activesupport `core_ext/*` tail with no trails counterpart (RFC 0072).
+  {
+    pattern: "core_ext/module/attribute_accessors_per_thread.rb",
+    package: "activesupport",
+    reason: "Stores the value per `Thread.current`; JS has no thread-local storage.",
+  },
+  {
+    pattern: "core_ext/module/remove_method.rb",
+    package: "activesupport",
+    reason: "Method-table surgery to silence redefinition warnings; JS reassignment is silent.",
+  },
+  {
+    pattern: "core_ext/object/instance_variables.rb",
+    package: "activesupport",
+    reason: "Reflects over Ruby `@ivars`; JS has no ivar namespace of its own.",
+  },
+  {
+    pattern: "starts_ends_with.rb",
+    package: "activesupport",
+    reason: "Aliases `start_with?`/`end_with?` for Symbol and String; both are native JS.",
+  },
+  {
+    pattern: "core_ext/string/multibyte.rb",
+    package: "activesupport",
+    reason:
+      "`mb_chars` returns a Multibyte::Chars proxy and `is_utf8?` reports a Ruby Encoding; " +
+      "JS strings carry no encoding tag and are already Unicode.",
+  },
+  {
+    pattern: "core_ext/kernel/singleton_class.rb",
+    package: "activesupport",
+    reason:
+      "Ruby metaprogramming with no JS equivalent; trails assigns to the class object directly.",
+  },
+  {
+    pattern: "core_ext/pathname/existence.rb",
+    package: "activesupport",
+    reason:
+      "Ruby's Pathname is not ported (trails paths are strings) and the check is async in JS.",
+  },
+  {
+    pattern: "core_ext/regexp.rb",
+    package: "activesupport",
+    reason: "Reads the `//m` bit out of Ruby's options bitmask; JS `RegExp` exposes `.multiline`.",
+  },
+  {
+    pattern: "core_ext/integer/multiple.rb",
+    package: "activesupport",
+    reason: "Pre-1.0: `Integer#multiple_of?` is unported and has no trails caller.",
+  },
+  {
+    pattern: "core_ext/module/deprecation.rb",
+    package: "activesupport",
+    reason:
+      "Pre-1.0: class-body sugar over `Deprecation#deprecate_methods`; trails calls the " +
+      "deprecator directly (`deprecation.ts#deprecateMethod`).",
+  },
+  {
+    pattern: "core_ext/object/with_options.rb",
+    package: "activesupport",
+    reason: "Pre-1.0: needs ActiveSupport::OptionMerger, not ported yet (RFC 0093).",
+  },
+  {
+    pattern: "core_ext/string/behavior.rb",
+    package: "activesupport",
+    reason: "Pre-1.0: one arm of `acts_like?`; trails ports the Time/Date arms only.",
+  },
   {
     pattern: "/version.rb",
     reason:


### PR DESCRIPTION
Three bundled stories. The fourth, `pg-maria-adapter-unique-flake-burndown-round-2`,
was released rather than shipped — see the note at the bottom.

## 1. `api-compare-orphan-buckets-activesupport-core-ext-tail-2`

Second slice of the RFC 0072 orphan-bucket burndown. Every remaining
activesupport `core_ext/*` orphan file now either names its real TS home in
`RUBY_FILE_TS_OVERRIDES` or carries an `UNPORTED_FILES` entry with a reason:

- **28 new `RUBY_FILE_TS_OVERRIDES` entries.** The date/time conversions cluster
  joins the already-mapped `calculations.rb` trio on `time-ext.ts`
  (`{time,date,date_time}/conversions.rb`, `{time,date_time}/compatibility.rb`,
  `time/acts_like.rb`, `string/{conversions,zones}.rb`); `time/zones.rb` →
  `time-zone-config.ts`; the Duration cluster (`numeric/time.rb`,
  `integer/time.rb`) → `duration.ts`; `{date,date_time,pathname}/blank.rb` →
  `core-ext/object/blank.ts`; plus the hash / array / string / object / class /
  kernel / module / inquirer / transliterate remainder.
- **13 new `UNPORTED_FILES` entries** for the tail with no trails counterpart at
  all (verified by name lookup against `output/ts-api.json`): the Ruby-only ones
  (`attribute_accessors_per_thread`, `remove_method`, `instance_variables`,
  `{symbol,string}/starts_ends_with`, `string/multibyte`,
  `kernel/singleton_class`, `pathname/existence`, `regexp.rb`) and four pre-1.0
  ones (`integer/multiple`, `module/deprecation`, `object/with_options`,
  `string/behavior`).

The orphan query now returns nothing for activesupport that is not covered by
one of the two.

**Per-package deltas** (measurement fixes, not new porting work):

| package | before (main) | after |
| --- | --- | --- |
| activesupport | 974/2324 (41.9%) | 1011/2307 (43.8%) |
| **Overall** | **13213/17793 (74.3%)** | **13250/17776 (74.5%)** |

The denominator drops by 17 because the `UNPORTED_FILES` entries take those
methods out of the population; the +37 numerator is the newly-measured buckets
finding their real TS homes. Rebased onto #6197, which moved
`core_ext/date/calculations.rb` to the new `date-ext.ts`: the conversions
members (`toFs`/`toTime`/`toDate`/`xmlschema`) take an instant receiver and stay
on `time-ext.ts`, so that split is preserved here.

**Newly-surfaced call-mismatch rows.** The new buckets exposed 17 pre-existing
divergences. Two converged for real — `find_zone` and `use_zone` now route
through `findZoneBang`, exactly as `core_ext/time/zones.rb:61,97` does. The
other 15 got hand-written reasons via `serializeBaseline` (no `--write`
reseed). `Time.zone=` is the one that could not converge here: trails maps
`nil` onto "unset, fall through to `zone_default`" where Rails stores nil, so
converging it means settling the fallthrough first — filed as
`0072/converge-time-zone-setter-through-find-zone-bang`.

## 2. `extract-method-missing-proxy-helper`

New `methodMissingProxy` in `@blazetrails/activesupport` (tagged
`@noRailsEquivalent PERMANENT` — Ruby resolves an undefined method through
`method_missing` at the language level and JS has only `Proxy`, so this is the
one shared shape for it, the way `include()` is for Ruby `include`). All three
hand-rolled sites adopt it:

- `migration/command-recorder.ts` (`CommandRecorder#method_missing`,
  `command_recorder.rb:395-406`)
- `connection-adapters/connection-management.ts` (`BodyProxy`)
- `activemodel/type/normalized-value.ts` (`DelegateClass(ActiveModel::Type::Value)`)

`normalized-value.ts` passes `delegate: (target) => target`, which is the shape
that makes the helper skip its own-property step and bind every delegated method
to the underlying type — preserving un-normalized `cast` dispatch through
`deserialize`, which its comment explains and its normalization tests prove. It
also gains the `has` trap (`respond_to_missing?`) it lacked.

## 3. `pg-statement-pool-dealloc-inline-not-parked`

`_pendingDeallocate` and `_drainPendingDeallocate` are gone. The eviction path is
async end-to-end instead (option 1 from the story):

- `StatementPool#dealloc` may now return a promise; `set`/`clear`/`delete`/
  `setMaxSize` collect the evictions' promises and hand them back.
- PG's `dealloc` chains each DEALLOCATE onto the previous one (`_deallocating`)
  and returns the chain, so a `clear()` evicting N entries never puts a second
  query on a busy socket.
- The eviction sites — `_preparedNameFor`, `prepareStatement`, the cached-plan
  `pool.delete` — `await` it, which is exactly where `statement_pool.rb:31`
  blocks on it.
- `clearCacheBang` returns the pool's chain; the six PG DDL sites in
  `postgresql/schema-statements-class.ts`, `reconnect`, `afterFailureActions`
  and the canonical-schema helpers await it.
- `resetBang` no longer reads a deallocate slot; the `_runQuery`/`exec` drains
  are gone.

The sqlite3 and mysql2 pools keep synchronous `dealloc`, so `settle` returns
`undefined` for them and their call sites cost no microtask.

A regression test in `connection-adapters/statement-pool.test.ts` covers the new
contract and **fails on the baseline**: an asynchronous `dealloc` must be
threaded back to the eviction site, so `set`'s eviction lands before the caller
resumes and `clear` waits for every dealloc it started.

`_commandSettled`'s invariant from #6199 (flip it immediately before every
`client.query` on the pinned client) moves with the DEALLOCATE: the block that
carried it is gone, so `buildStatementPool` hands the pool an `onIssue` callback
that flips the flag inside `dealloc`, guarded on the client still being the
pinned one. Rails' pool takes the connection itself (`postgresql_adapter.rb:296`)
and reads `@raw_connection` at dealloc time; trails' holds the client, so that
callback is the one piece of connection state it still needs.

**Verification**: a `--trace-deprecation` run of
`packages/activerecord/src/adapters/postgresql/`,
`connection-adapters/`, `migration/` and the activesupport core-ext suites —
243 files, 4405 tests — emits zero `already executing a query` warnings and
passes.

## Review round 1

**`CommandRecorder` forwarding a non-function delegate member.** Keeping the
converged behavior; the old `: undefined` fallback was the deviation.
`command_recorder.rb:400-404` forwards with `delegate.public_send(method, ...)`,
which returns whatever the delegate's method returns — Ruby has no separate
data-property read, so an `attr_reader` on the delegate comes back as its value.
The `: undefined` arm modeled nothing in Rails and silently dropped every
non-method delegate member.

Reachability, as asked: no caller reads a non-function property off a recorder.
Enumerating a real adapter delegate gives 66 non-function members not defined on
`CommandRecorder`, and every consumer of a recorder touches only methods —
`Table` (the `bulk` path, `schema-definitions.ts`) calls `addColumn`, `addIndex`,
`addReference`, `addTimestamps`, `removeColumns`, `removeIndex`, `renameColumn`
and nothing else; `migration.ts` reads only `changeTable`, `record`, `revert`,
`reverting`, `commands`, `replay`, all of which `CommandRecorder` defines itself
and which therefore take the own-property branch. The changed arm is unreachable
today, and where it does fire it now matches Rails.

Pinned by a new trails-only test, `forwards a non-function delegate member the
way public_send does`, verified to fail against the old fallback.

## Released: `pg-maria-adapter-unique-flake-burndown-round-2`

Handed back rather than half-done. Its acceptance criteria are a triage of 11
named branches plus a *re-measurement* of the adapter-unique failure rate over a
fresh comparable window — the measured baseline window closed 2026-07-31, a week
ago. That is an investigation with its own cadence, not a slice that fits
alongside three code stories under the LOC ceiling, and shipping a partial
triage would have burned the worklist without moving the rate.

Closes-story: api-compare-orphan-buckets-activesupport-core-ext-tail-2
Closes-story: extract-method-missing-proxy-helper
Closes-story: pg-statement-pool-dealloc-inline-not-parked
