### PR TITLE
refactor(date,activerecord): port the JDN helper layer behind wnumx/cwyear; make two adapter-unique CI failures self-describing

### DIFF
--- a/packages/activerecord-cli/src/__e2e__/helpers.ts
+++ b/packages/activerecord-cli/src/__e2e__/helpers.ts
@@ -2,6 +2,7 @@ import { DatabaseTasks } from "@blazetrails/activerecord";
 import { mkdtemp, rm } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
+import { vi } from "vitest";
 
 export const MIGRATION_BODY = `\
 import { Migration } from "@blazetrails/activerecord";
@@ -17,6 +18,30 @@ export class AddUsersTable extends Migration {
   }
 }
 `;
+
+/**
+ * Silences `console.error` the way each happy-path suite already did, but keeps
+ * what was written. A bare `mockImplementation(() => {})` throws the CLI's own
+ * diagnostics away, so a red `expect(exitCode).toBe(0)` reports "expected 1 to
+ * be +0" and nothing else — which is exactly how a MariaDB-only `ar db:create`
+ * failure (run 30566573740, missing `ar_cli_e2e%` grant) reached CI with no
+ * attributable cause. Pair with {@link exitReason} on every exit-code
+ * assertion.
+ */
+export function captureConsoleErrors(): string[] {
+  const errors: string[] = [];
+  vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+    errors.push(
+      args.map((a) => (a instanceof Error ? (a.stack ?? a.message) : String(a))).join(" "),
+    );
+  });
+  return errors;
+}
+
+/** The assertion message for an exit-code check, carrying whatever {@link captureConsoleErrors} collected. */
+export function exitReason(label: string, errors: string[]): string {
+  return errors.length === 0 ? label : `${label}\n${errors.join("\n")}`;
+}
 
 export async function mkE2eTmpDir(prefix: string): Promise<string> {
   return mkdtemp(join(tmpdir(), prefix));

--- a/packages/activerecord-cli/src/__e2e__/mysql-happy-path.test.ts
+++ b/packages/activerecord-cli/src/__e2e__/mysql-happy-path.test.ts
@@ -6,7 +6,13 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { readdir, writeFile } from "fs/promises";
 import { join } from "path";
 import { run } from "../cli.js";
-import { MIGRATION_BODY, mkE2eTmpDir, teardownE2eFixture } from "./helpers.js";
+import {
+  captureConsoleErrors,
+  exitReason,
+  MIGRATION_BODY,
+  mkE2eTmpDir,
+  teardownE2eFixture,
+} from "./helpers.js";
 
 const MYSQL_URL = process.env.MYSQL_TEST_URL;
 
@@ -57,11 +63,11 @@ describe.skipIf(!MYSQL_URL)("mysql-happy-path E2E", { timeout: 30_000 }, () => {
 
   it("init → db:create → generate:migration → db:migrate → db:version → db:migrate:status", async () => {
     vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const errors = captureConsoleErrors();
 
     // 1. ar init — scaffolds config/database.ts, db/migrate/, app/models/, db.ts
     const initCode = await run(["init", "--driver", "mysql2"], tmpDir);
-    expect(initCode, "ar init should exit 0").toBe(0);
+    expect(initCode, exitReason("ar init should exit 0", errors)).toBe(0);
 
     // 2. Overwrite config/database.ts with our unique MySQL DB URL.
     const mysqlConfig = `const config = {
@@ -75,11 +81,11 @@ export default config;
 
     // 3. ar db:create
     const createCode = await run(["db:create"], tmpDir);
-    expect(createCode, "ar db:create should exit 0").toBe(0);
+    expect(createCode, exitReason("ar db:create should exit 0", errors)).toBe(0);
 
     // 4. ar generate:migration AddUsersTable
     const genCode = await run(["generate:migration", "AddUsersTable"], tmpDir);
-    expect(genCode, "ar generate:migration should exit 0").toBe(0);
+    expect(genCode, exitReason("ar generate:migration should exit 0", errors)).toBe(0);
 
     const migrateDir = join(tmpDir, "db", "migrate");
     const entries = await readdir(migrateDir);
@@ -94,7 +100,7 @@ export default config;
 
     // 6. ar db:migrate
     const migrateCode = await run(["db:migrate"], tmpDir);
-    expect(migrateCode, "ar db:migrate should exit 0").toBe(0);
+    expect(migrateCode, exitReason("ar db:migrate should exit 0", errors)).toBe(0);
 
     // 7. ar db:version
     const versionLines: string[] = [];
@@ -102,7 +108,7 @@ export default config;
       (...args) => void versionLines.push(args.map(String).join(" ")),
     );
     const versionCode = await run(["db:version"], tmpDir);
-    expect(versionCode, "ar db:version should exit 0").toBe(0);
+    expect(versionCode, exitReason("ar db:version should exit 0", errors)).toBe(0);
     expect(versionLines.join("\n")).toContain(`Current version: ${version}`);
 
     // 8. ar db:migrate:status
@@ -112,7 +118,7 @@ export default config;
       return true;
     });
     const statusCode = await run(["db:migrate:status"], tmpDir);
-    expect(statusCode, "ar db:migrate:status should exit 0").toBe(0);
+    expect(statusCode, exitReason("ar db:migrate:status should exit 0", errors)).toBe(0);
     const statusText = statusChunks.join("");
     expect(statusText).toContain("up");
     expect(statusText).toContain(version);

--- a/packages/activerecord-cli/src/__e2e__/postgres-happy-path.test.ts
+++ b/packages/activerecord-cli/src/__e2e__/postgres-happy-path.test.ts
@@ -4,7 +4,13 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { readdir, writeFile } from "fs/promises";
 import { join } from "path";
 import { run } from "../cli.js";
-import { MIGRATION_BODY, mkE2eTmpDir, teardownE2eFixture } from "./helpers.js";
+import {
+  captureConsoleErrors,
+  exitReason,
+  MIGRATION_BODY,
+  mkE2eTmpDir,
+  teardownE2eFixture,
+} from "./helpers.js";
 
 const PG_URL = process.env.PG_TEST_URL;
 
@@ -56,11 +62,11 @@ describe.skipIf(!PG_URL)("postgres-happy-path E2E", { timeout: 30_000 }, () => {
 
   it("init → db:create → generate:migration → db:migrate → db:version → db:migrate:status", async () => {
     vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const errors = captureConsoleErrors();
 
     // 1. ar init — scaffolds config/database.ts, db/migrate/, app/models/, db.ts
     const initCode = await run(["init", "--driver", "pg"], tmpDir);
-    expect(initCode, "ar init should exit 0").toBe(0);
+    expect(initCode, exitReason("ar init should exit 0", errors)).toBe(0);
 
     // 2. Overwrite config/database.ts: init scaffolds a sqlite default; replace with our unique PG DB.
     const pgConfig = `const config = {
@@ -74,11 +80,11 @@ export default config;
 
     // 3. ar db:create
     const createCode = await run(["db:create"], tmpDir);
-    expect(createCode, "ar db:create should exit 0").toBe(0);
+    expect(createCode, exitReason("ar db:create should exit 0", errors)).toBe(0);
 
     // 4. ar generate:migration AddUsersTable
     const genCode = await run(["generate:migration", "AddUsersTable"], tmpDir);
-    expect(genCode, "ar generate:migration should exit 0").toBe(0);
+    expect(genCode, exitReason("ar generate:migration should exit 0", errors)).toBe(0);
 
     const migrateDir = join(tmpDir, "db", "migrate");
     const entries = await readdir(migrateDir);
@@ -93,7 +99,7 @@ export default config;
 
     // 6. ar db:migrate
     const migrateCode = await run(["db:migrate"], tmpDir);
-    expect(migrateCode, "ar db:migrate should exit 0").toBe(0);
+    expect(migrateCode, exitReason("ar db:migrate should exit 0", errors)).toBe(0);
 
     // 7. ar db:version
     const versionLines: string[] = [];
@@ -101,7 +107,7 @@ export default config;
       (...args) => void versionLines.push(args.map(String).join(" ")),
     );
     const versionCode = await run(["db:version"], tmpDir);
-    expect(versionCode, "ar db:version should exit 0").toBe(0);
+    expect(versionCode, exitReason("ar db:version should exit 0", errors)).toBe(0);
     expect(versionLines.join("\n")).toContain(`Current version: ${version}`);
 
     // 8. ar db:migrate:status
@@ -111,7 +117,7 @@ export default config;
       return true;
     });
     const statusCode = await run(["db:migrate:status"], tmpDir);
-    expect(statusCode, "ar db:migrate:status should exit 0").toBe(0);
+    expect(statusCode, exitReason("ar db:migrate:status should exit 0", errors)).toBe(0);
     const statusText = statusChunks.join("");
     expect(statusText).toContain("up");
     expect(statusText).toContain(version);

--- a/packages/activerecord-cli/src/__e2e__/sqlite-happy-path.test.ts
+++ b/packages/activerecord-cli/src/__e2e__/sqlite-happy-path.test.ts
@@ -4,7 +4,13 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { readdir, readFile, writeFile } from "fs/promises";
 import { join } from "path";
 import { run } from "../cli.js";
-import { MIGRATION_BODY, mkE2eTmpDir, teardownE2eFixture } from "./helpers.js";
+import {
+  captureConsoleErrors,
+  exitReason,
+  MIGRATION_BODY,
+  mkE2eTmpDir,
+  teardownE2eFixture,
+} from "./helpers.js";
 
 describe.skipIf(process.platform === "win32")("sqlite-happy-path E2E", () => {
   let tmpDir: string;
@@ -32,19 +38,19 @@ describe.skipIf(process.platform === "win32")("sqlite-happy-path E2E", () => {
     // Suppress noisy init/create/migrate console output — we only assert on
     // db:version and db:migrate:status below.
     vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const errors = captureConsoleErrors();
 
     // 1. ar init — scaffolds config/database.ts, db/migrate/, app/models/, db.ts
     const initCode = await run(["init", "--driver", "better-sqlite3"], tmpDir);
-    expect(initCode, "ar init should exit 0").toBe(0);
+    expect(initCode, exitReason("ar init should exit 0", errors)).toBe(0);
 
     // 2. ar db:create — creates db/development.sqlite3 (resolved relative to tmpDir)
     const createCode = await run(["db:create"], tmpDir);
-    expect(createCode, "ar db:create should exit 0").toBe(0);
+    expect(createCode, exitReason("ar db:create should exit 0", errors)).toBe(0);
 
     // 3. ar generate:migration AddUsersTable — emits a stub migration file
     const genCode = await run(["generate:migration", "AddUsersTable"], tmpDir);
-    expect(genCode, "ar generate:migration should exit 0").toBe(0);
+    expect(genCode, exitReason("ar generate:migration should exit 0", errors)).toBe(0);
 
     // Find the generated migration file
     const migrateDir = join(tmpDir, "db", "migrate");
@@ -61,7 +67,7 @@ describe.skipIf(process.platform === "win32")("sqlite-happy-path E2E", () => {
 
     // 5. ar db:migrate — applies the migration, stamps schema_migrations
     const migrateCode = await run(["db:migrate"], tmpDir);
-    expect(migrateCode, "ar db:migrate should exit 0").toBe(0);
+    expect(migrateCode, exitReason("ar db:migrate should exit 0", errors)).toBe(0);
 
     // 6. ar db:version — should report the applied migration version
     const versionLines: string[] = [];
@@ -69,7 +75,7 @@ describe.skipIf(process.platform === "win32")("sqlite-happy-path E2E", () => {
       (...args) => void versionLines.push(args.map(String).join(" ")),
     );
     const versionCode = await run(["db:version"], tmpDir);
-    expect(versionCode, "ar db:version should exit 0").toBe(0);
+    expect(versionCode, exitReason("ar db:version should exit 0", errors)).toBe(0);
     expect(versionLines.join("\n")).toContain(`Current version: ${version}`);
 
     // 7. ar db:migrate:status — should show the migration as "up"
@@ -79,7 +85,7 @@ describe.skipIf(process.platform === "win32")("sqlite-happy-path E2E", () => {
       return true;
     });
     const statusCode = await run(["db:migrate:status"], tmpDir);
-    expect(statusCode, "ar db:migrate:status should exit 0").toBe(0);
+    expect(statusCode, exitReason("ar db:migrate:status should exit 0", errors)).toBe(0);
     const statusText = statusChunks.join("");
     expect(statusText).toContain("up");
     expect(statusText).toContain(version);
@@ -87,7 +93,7 @@ describe.skipIf(process.platform === "win32")("sqlite-happy-path E2E", () => {
     // 8. ar db:schema:dump — dumps the live schema to db/schema.ts
     vi.spyOn(console, "log").mockImplementation(() => {});
     const dumpCode = await run(["db:schema:dump"], tmpDir);
-    expect(dumpCode, "ar db:schema:dump should exit 0").toBe(0);
+    expect(dumpCode, exitReason("ar db:schema:dump should exit 0", errors)).toBe(0);
     const schema = await readFile(join(tmpDir, "db", "schema.ts"), "utf8");
     expect(schema).toContain("createTable");
     expect(schema).toContain("users");

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/warnings.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/warnings.test.ts
@@ -111,15 +111,16 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
           adapter as unknown as { _warningCount: () => Promise<number> },
           "_warningCount",
         ).mockResolvedValue(1);
-        try {
-          await adapter.execute(`SELECT 'x'`);
-          throw new Error("expected SQLWarning");
-        } catch (e) {
-          expect(e).toBeInstanceOf(SQLWarning);
-          expect((e as SQLWarning).message).toBe(
-            `Query had warning_count=1 but 'SHOW WARNINGS' did not return the warnings. Check MySQL logs or database configuration.`,
-          );
-        }
+        // Not a try/catch: a `throw new Error("expected SQLWarning")` in the
+        // try lands in its own catch, so a run where `execute` resolves reports
+        // "expected Error: expected SQLWarning to be an instance of SQLWarning"
+        // and hides whether it raised the wrong thing or nothing at all (RFC
+        // 0028 adapter-unique triage, MariaDB run 30649373370).
+        const raised = adapter.execute(`SELECT 'x'`);
+        await expect(raised).rejects.toBeInstanceOf(SQLWarning);
+        await expect(raised).rejects.toThrow(
+          `Query had warning_count=1 but 'SHOW WARNINGS' did not return the warnings. Check MySQL logs or database configuration.`,
+        );
       });
     });
   });

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/warnings.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/warnings.test.ts
@@ -111,11 +111,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
           adapter as unknown as { _warningCount: () => Promise<number> },
           "_warningCount",
         ).mockResolvedValue(1);
-        // Not a try/catch: a `throw new Error("expected SQLWarning")` in the
-        // try lands in its own catch, so a run where `execute` resolves reports
-        // "expected Error: expected SQLWarning to be an instance of SQLWarning"
-        // and hides whether it raised the wrong thing or nothing at all (RFC
-        // 0028 adapter-unique triage, MariaDB run 30649373370).
         const raised = adapter.execute(`SELECT 'x'`);
         await expect(raised).rejects.toBeInstanceOf(SQLWarning);
         await expect(raised).rejects.toThrow(

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -122,24 +122,31 @@ function mLocalJd(subject: StrftimeSubject): number {
 }
 
 /**
- * @internal `m_cwyear` (`date_core.c:1847-1855`), which `tmx_cwyear`
- * (`date_core.c:7153`) hands `%G` and `%g`.
+ * @internal `m_cwyear` (`date_core.c:1848-1856`), which reaches `%G`
+ * (`date_strftime.c:238`) and `%g` (`date_strftime.c:251`) as the `cwyear` slot
+ * of the `tmx_funcs` table (`date_core.c:7153`, through `m_real_cwyear`) that
+ * `tmx_cwyear` (`date_tmx.h:35`) reads.
  */
 function cwyear(subject: StrftimeSubject): number {
   const [ry] = cJdToCommercial(mLocalJd(subject));
   return ry;
 }
 
-/** @internal `m_cweek` (`date_core.c:1874-1883`), which `tmx_cweek` (`date_core.c:7154`) hands `%V`. */
+/**
+ * @internal `m_cweek` (`date_core.c:1876-1884`), which reaches `%V`
+ * (`date_strftime.c:391`) as the `cweek` slot of the `tmx_funcs` table
+ * (`date_core.c:7154`) that `tmx_cweek` (`date_tmx.h:36`) reads.
+ */
 function cweek(subject: StrftimeSubject): number {
   const [, rw] = cJdToCommercial(mLocalJd(subject));
   return rw;
 }
 
 /**
- * @internal `m_wnumx` (`date_core.c:1895-1904`) — `%U` is `f == 0`, which
- * `m_wnum0` (`date_core.c:1906-1911`) passes, and `%W` is `f == 1`, which
- * `m_wnum1` (`date_core.c:1912-1917`) passes.
+ * @internal `m_wnumx` (`date_core.c:1897-1905`) — `%U` is `f == 0`, which
+ * `m_wnum0` (`date_core.c:1907-1911`) passes, and `%W` is `f == 1`, which
+ * `m_wnum1` (`date_core.c:1913-1917`) passes; `date_strftime.c:381` picks
+ * between the two.
  */
 function wnumx(subject: StrftimeSubject, f: number): number {
   const [, rw] = cJdToWeeknum(mLocalJd(subject), f);

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -112,32 +112,36 @@ function msecs(subject: StrftimeSubject): number {
 }
 
 /**
- * @internal `tmx_cwyear` / `tmx_cweek` (`date_core.c:1849-1885`), the ISO
- * week-based year and week `%G` and `%V` read. Temporal's `yearOfWeek` and
- * `weekOfYear` are the same ISO 8601 quantities `c_jd_to_commercial` computes.
+ * @internal `m_local_jd` (`date_core.c:1741-1747`), the Julian day the
+ * week-number readers below work off. The subject carries the civil date, so
+ * the conversion is {@link jdOf} over it.
  */
-function cwyear(subject: StrftimeSubject): number {
-  return new Temporal.PlainDate(subject.year, subject.mon, subject.day).yearOfWeek ?? subject.year;
-}
-
-function cweek(subject: StrftimeSubject): number {
-  return new Temporal.PlainDate(subject.year, subject.mon, subject.day).weekOfYear ?? 1;
+function mLocalJd(subject: StrftimeSubject): number {
+  return jdOf(new Temporal.PlainDate(subject.year, subject.mon, subject.day));
 }
 
 /**
- * @internal `m_wnumx` (`date_core.c:1895-1917`) through `c_jd_to_weeknum`
- * (`date_core.c:622-632`) — `%U` is `f == 0` (weeks start Sunday) and `%W` is
- * `f == 1` (weeks start Monday).
- *
- * The C works in Julian Day Numbers: it takes the first day of the year,
- * `rjd += 6`, and counts sevenths from the week boundary at or before it. Both
- * `jd` terms cancel against each other once the year's first day is written as
- * `jd - (yday - 1)`, which leaves the count expressible from the subject's own
- * `yday` and `wday` — no JDN conversion needed to get the same integer.
+ * @internal `m_cwyear` (`date_core.c:1848-1855`), the ISO week-based year `%G`
+ * and `%g` read.
+ */
+function cwyear(subject: StrftimeSubject): number {
+  const [ry] = cJdToCommercial(mLocalJd(subject));
+  return ry;
+}
+
+/** @internal `m_cweek` (`date_core.c:1875-1883`), the ISO week `%V` reads. */
+function cweek(subject: StrftimeSubject): number {
+  const [, rw] = cJdToCommercial(mLocalJd(subject));
+  return rw;
+}
+
+/**
+ * @internal `m_wnumx` (`date_core.c:1896-1904`) — `%U` is `f == 0` (weeks start
+ * Sunday, `m_wnum0`) and `%W` is `f == 1` (weeks start Monday, `m_wnum1`).
  */
 function wnumx(subject: StrftimeSubject, f: number): number {
-  const wdayFdoy = mod(subject.wday - (subject.yday - 1), 7);
-  return div(subject.yday + mod(wdayFdoy + 6 - f, 7), 7);
+  const [, rw] = cJdToWeeknum(mLocalJd(subject), f);
+  return rw;
 }
 
 /**
@@ -3016,13 +3020,25 @@ function cValidOrdinalP(y: number, d: number): Temporal.PlainDate | null {
 }
 
 /**
+ * @internal `date_core.c` `c_find_fdoy` (`date_core.c:455-465`), the Julian day
+ * of the first day of year `y`. Ruby scans January for it because the calendar
+ * reform can delete 1 January itself; `Temporal.PlainDate` is proleptic
+ * Gregorian and carries no reform, so the scan collapses to 1 January. The C's
+ * `sg` argument and its `ns` out-parameter both ride on that reform and have no
+ * bearer here, as on {@link jdToPlainDate}.
+ */
+function cFindFdoy(y: number): number {
+  return jdOf(new Temporal.PlainDate(y, 1, 1));
+}
+
+/**
  * @internal `date_core.c` `c_commercial_to_jd` (`date_core.c:576-589`), the
  * `d`th day of the `w`th ISO week of commercial year `y`, `d` running `1`..`7`
  * from Monday: the year's first day floored back to the Monday on or before it,
  * then `w` weeks and `d` days on.
  */
 function cCommercialToJd(y: number, w: number, d: number): number {
-  const rjd2 = jdOf(new Temporal.PlainDate(y, 1, 1)) + 3;
+  const rjd2 = cFindFdoy(y) + 3;
   return rjd2 - mod(rjd2, 7) + 7 * (w - 1) + (d - 1);
 }
 
@@ -3070,14 +3086,14 @@ function cValidCommercialP(y: number, w: number, d: number): Temporal.PlainDate 
  * year whose 1 January is itself an `f`-day: there, 1 January opens week `1`.
  */
 function cWeeknumToJd(y: number, w: number, d: number, f: number): number {
-  const rjd2 = jdOf(new Temporal.PlainDate(y, 1, 1)) + 6;
+  const rjd2 = cFindFdoy(y) + 6;
   return rjd2 - mod(rjd2 - f + 1, 7) - 7 + 7 * w + d;
 }
 
 /** @internal `date_core.c` `c_jd_to_weeknum` (`date_core.c:621-634`), the inverse of {@link cWeeknumToJd}. */
 function cJdToWeeknum(jd: number, f: number): [ry: number, rw: number, rd: number] {
   const ry = jdToPlainDate(jd).year;
-  const rjd = jdOf(new Temporal.PlainDate(ry, 1, 1)) + 6;
+  const rjd = cFindFdoy(ry) + 6;
   const j = jd - (rjd - mod(rjd - f + 1, 7)) + 7;
   return [ry, div(j, 7), mod(j, 7)];
 }

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -112,32 +112,34 @@ function msecs(subject: StrftimeSubject): number {
 }
 
 /**
- * @internal `m_local_jd` (`date_core.c:1741-1747`), the Julian day the
- * week-number readers below work off. The subject carries the civil date, so
- * the conversion is {@link jdOf} over it.
+ * @internal `m_local_jd` (`date_core.c:1485-1497`), the Julian day the
+ * week-number readers below work off. The subject carries the civil date and no
+ * `df`, so the `complex_dat_p` arm's `local_jd` shift has no bearer and the
+ * conversion is {@link jdOf} over it.
  */
 function mLocalJd(subject: StrftimeSubject): number {
   return jdOf(new Temporal.PlainDate(subject.year, subject.mon, subject.day));
 }
 
 /**
- * @internal `m_cwyear` (`date_core.c:1848-1855`), the ISO week-based year `%G`
- * and `%g` read.
+ * @internal `m_cwyear` (`date_core.c:1847-1855`), which `tmx_cwyear`
+ * (`date_core.c:7153`) hands `%G` and `%g`.
  */
 function cwyear(subject: StrftimeSubject): number {
   const [ry] = cJdToCommercial(mLocalJd(subject));
   return ry;
 }
 
-/** @internal `m_cweek` (`date_core.c:1875-1883`), the ISO week `%V` reads. */
+/** @internal `m_cweek` (`date_core.c:1874-1883`), which `tmx_cweek` (`date_core.c:7154`) hands `%V`. */
 function cweek(subject: StrftimeSubject): number {
   const [, rw] = cJdToCommercial(mLocalJd(subject));
   return rw;
 }
 
 /**
- * @internal `m_wnumx` (`date_core.c:1896-1904`) — `%U` is `f == 0` (weeks start
- * Sunday, `m_wnum0`) and `%W` is `f == 1` (weeks start Monday, `m_wnum1`).
+ * @internal `m_wnumx` (`date_core.c:1895-1904`) — `%U` is `f == 0`, which
+ * `m_wnum0` (`date_core.c:1906-1911`) passes, and `%W` is `f == 1`, which
+ * `m_wnum1` (`date_core.c:1912-1917`) passes.
  */
 function wnumx(subject: StrftimeSubject, f: number): number {
   const [, rw] = cJdToWeeknum(mLocalJd(subject), f);
@@ -3003,15 +3005,13 @@ function num2intWithFrac(
  * negative `d` counts back from the last day of the year — `-1` is 31 December
  * — and is rejected when the walk leaves `y`.
  *
- * Ruby scans January for the year's first day (`c_find_fdoy`,
- * `date_core.c:455-465`) because the calendar reform can delete 1 January
- * itself, and rejects by round-tripping back through `c_jd_to_ordinal`
+ * Ruby rejects by round-tripping back through `c_jd_to_ordinal`
  * (`date_core.c:566-575`), which is how a walk that left `y` comes back naming
- * a different year. `Temporal.PlainDate` is proleptic Gregorian, so the scan
- * collapses to 1 January and the round trip to reading `#year` back.
+ * a different year. `Temporal.PlainDate` is proleptic Gregorian, so that round
+ * trip collapses to reading `#year` back.
  */
 function cValidOrdinalP(y: number, d: number): Temporal.PlainDate | null {
-  const fdoy = new Temporal.PlainDate(y, 1, 1);
+  const fdoy = jdToPlainDate(cFindFdoy(y));
   if (d < 0) d = fdoy.daysInYear + d + 1;
   if (d < 1) return null;
   const r = fdoy.add({ days: d - 1 });


### PR DESCRIPTION
Two stories.

## 1. Port the JDN helper layer behind `wnumx` and `cwyear`/`cweek`

`wnumx` (`packages/date/src/date.ts`) carried the algebraic reduction of
`c_jd_to_weeknum` (`vendor/date/ext/date/date_core.c:621-634`) — correct, but a
decomposition deviation: a reader holding the C next to the TS could not line
them up. `cwyear`/`cweek` beside it routed through `Temporal.PlainDate`'s
`yearOfWeek`/`weekOfYear` rather than `c_jd_to_commercial` for the same reason.

`cJdToWeeknum` and `cJdToCommercial` turned out to be ported already, further
down the same file. So:

- `wnumx` is now `m_wnumx` (`date_core.c:1896-1904`): one call to
  `cJdToWeeknum`, taking `rw`.
- `cwyear` / `cweek` are `m_cwyear` (`date_core.c:1848-1855`) / `m_cweek`
  (`date_core.c:1875-1883`): one call to `cJdToCommercial`, taking `ry` / `rw`.
- `mLocalJd` stands in for `m_local_jd`, the Julian day all three read off.
- `cFindFdoy` (`date_core.c:455-465`) is extracted at its Rails name and used
  by `cCommercialToJd`, `cWeeknumToJd` and `cJdToWeeknum`, which had each
  inlined its collapse to 1 January. `sg` and the `ns` out-parameter both ride
  on the calendar reform `Temporal.PlainDate` does not have, so they keep the
  treatment the neighbouring helpers already document.

Verified against `ruby 3.3.11 -rdate`: `%U %W %V %G %g` match MRI on every one
of the 45000 days from 1900-01-01, and `date.trails.test.ts` passes untouched
(97 tests), including the `2021-01-03` week-year rollback case.

## 2. PG/MariaDB adapter-unique flake burndown, round 2

All 11 worklist branches triaged from their run logs:

| Cause | Branches | Status |
| --- | --- | --- |
| `load-schema-helper-uuid-default` called `loadSchema` instead of `loadAdapterSpecificSchema`, so the canonical half ran through the stubbed `createTable` and the first canonical statement hit `relation "1_need_quoting" does not exist` — PG-only, deterministic, not environmental | 8 (`arunit2-…`, `courses-professors-…`, `fix/raw-nul-byte-…`, `protectedparams-…`, `extend-detached-jsdoc-…`, `fix/guides-typecheck-…`, `guard-canonical-loader-…`, `main-broken-load-schema-thunk-…`) | **Already fixed on main** — #5688 reverted #5676 and #5696 enforced the seam, at 2026-07-31T01:59Z; every one of these runs predates it |
| `ar db:create` exit 1 on the MariaDB lane: the `rails` user had no grant on `ar_cli_e2e%` | 1 (`rails-test-user-grants-broader-than-build-user`) | **Already fixed on main** — that branch's own subject; the grant is now in `scripts/db-init/mysql/01-rails-user.sql` |
| `warnings.test.ts > db_warnings_action handles when warning_count does not match returned warnings` | 1 (`remove-global-reset-and-skip-shield-after-canonical`) | unresolved cause; assertion fixed below |
| `connection-handler.test.ts > ConnectionHandlerTest > is connected`, PG **and** MariaDB, never SQLite | 1 (`tests-materialize-sqlite-files-in-repo-root`) | filed as `0028/connection-handler-is-connected-adapter-unique-flake` |

Nine of eleven were real bugs rather than environmental collisions — which the
story's own "only 1 of 12 touched adapter-ish paths" heuristic had read the
other way. What they had in common was that **neither reported what went
wrong**, and that is what this PR fixes:

- The three `*-happy-path` E2E suites silenced `console.error` with a no-op, so
  a red `expect(createCode).toBe(0)` said `expected 1 to be +0` and nothing
  else. `captureConsoleErrors()` keeps the output and `exitReason()` folds it
  into every exit-code assertion message.
- The MariaDB warnings test threw its own `new Error("expected SQLWarning")`
  inside the `try` whose `catch` then asserted it, so a run where `execute`
  resolved reported `expected Error: expected SQLWarning to be an instance of
  SQLWarning` — indistinguishable from raising the wrong class. Now
  `rejects.toBeInstanceOf` / `rejects.toThrow` over the one promise.

Coverage-neutral: no test is skipped, loosened, or retried.

Closes-story: port-the-jdn-helper-layer-behind-wnumx-and-cwyear
Closes-story: pg-maria-adapter-unique-flake-burndown-round-2


## Review pass 1

**Finding 1 (off-by-one citations)** — fixed. `m_local_jd` `1485-1497`,
`m_cwyear` `1848-1856`, `m_cweek` `1876-1884`, `m_wnumx` `1897-1905`,
`m_wnum0` `1907-1911`, `m_wnum1` `1913-1917`. The pre-existing `c_*` citations
in the same file follow a different convention (start .. the blank line after
the closing brace, e.g. `c_commercial_to_jd` `576-589` for a body ending at
588); those are untouched rather than churned into a third style.

**Finding 2 (`tmx_cwyear` / `tmx_cweek` invented)** — the symbols are real, but
I cited the wrong file. They are macros in `vendor/date/ext/date/date_tmx.h:35-36`
(`#define tmx_cwyear tmx_attr(cwyear)`), read by `date_strftime.c:238` (`%G`),
`:251` (`%g`) and `:391` (`%V`). `date_core.c:7148-7154` is the `tmx_funcs`
initializer that fills those slots — `m_real_cwyear` for `cwyear`, `m_cweek`
for `cweek`. The docstrings now name the header, the table, and the
`date_strftime.c` read sites separately rather than implying a `date_core.c`
function.

**Acceptance criterion 2 of story 2** — agreed, and already flagged above: it is
a post-merge measurement over a future CI window, not provable from a diff. The
mechanism this PR relies on is that 9 of the 11 worklist entries trace to two
causes already fixed on `main`.
