### PR TITLE
refactor(activesupport): port core_ext/object/json.rb; jsonify takes Rails' branch order

### DIFF
--- a/packages/activesupport/src/core-ext/object/json.ts
+++ b/packages/activesupport/src/core-ext/object/json.ts
@@ -89,7 +89,9 @@ export class Array {
  * value is recursed with the same options.
  *
  * Ruby's Hash is our plain object and our `Map`; `Array(attrs)` is the scalar-or
- * -list coercion inline in each arm.
+ * -list coercion inline in each arm. `if attrs = options[:only]` (`:178`) is
+ * Ruby-truthy, so a stored `false` falls through to the `except` arm — the
+ * index signature on `EncodeOptions` lets one reach here.
  */
 export class Hash {
   static asJson(value: unknown, options?: EncodeOptions | null): Record<string, unknown> {
@@ -100,13 +102,13 @@ export class Hash {
 
     let subset = entries;
     if (options) {
-      let attrs;
-      if ((attrs = options.only) != null) {
+      let attrs: unknown;
+      if ((attrs = options.only) != null && attrs !== false) {
         const keys = new Set(
           (globalThis.Array.isArray(attrs) ? attrs : [attrs]).map(globalThis.String),
         );
         subset = entries.filter(([k]) => keys.has(globalThis.String(k)));
-      } else if ((attrs = options.except) != null) {
+      } else if ((attrs = options.except) != null && attrs !== false) {
         const keys = new Set(
           (globalThis.Array.isArray(attrs) ? attrs : [attrs]).map(globalThis.String),
         );

--- a/packages/activesupport/src/core-ext/object/json.ts
+++ b/packages/activesupport/src/core-ext/object/json.ts
@@ -1,0 +1,247 @@
+import { Temporal } from "@blazetrails/date";
+
+import { Encoding, type EncodeOptions } from "../../json/encoding.js";
+
+/**
+ * Rails' `core_ext/object/json.rb` — the `as_json` layer
+ * `JSONGemEncoder#jsonify` dispatches through (json/encoding.rb:100).
+ *
+ * Ruby reopens every core class and defines `as_json` on it; method lookup then
+ * picks the right one. TypeScript cannot reopen built-ins, so each Ruby class'
+ * body lives on a class of the same name with a `static asJson(value, options)`
+ * — the same shape `core-ext/object/blank.ts` uses for `blank?`/`present?` —
+ * and the free `asJson()` below stands in for Ruby's method lookup.
+ */
+
+/**
+ * `Object#as_json` (json.rb:58-64).
+ *
+ * `instance_values` (core_ext/object/instance_variables.rb:14-18) is unported;
+ * a spread of the object's own enumerable properties is its analogue.
+ */
+export class Object {
+  static asJson(value: object, options?: EncodeOptions | null): unknown {
+    if (typeof (value as { toHash?: unknown }).toHash === "function") {
+      return Hash.asJson((value as { toHash(): unknown }).toHash(), options);
+    }
+    return Hash.asJson({ ...value }, options);
+  }
+}
+
+/** `TrueClass#as_json` / `FalseClass#as_json` (json.rb:78-88). */
+export class TrueClass {
+  static asJson(value: boolean): boolean {
+    return value;
+  }
+}
+
+/** `NilClass#as_json` (json.rb:90-94). */
+export class NilClass {
+  static asJson(value: null | undefined): null | undefined {
+    return value;
+  }
+}
+
+/** `String#as_json` (json.rb:96-100). */
+export class String {
+  static asJson(value: string): string {
+    return value;
+  }
+}
+
+/** `Numeric#as_json` (json.rb:108-112). */
+export class Numeric {
+  static asJson(value: number | bigint): number | bigint {
+    return value;
+  }
+}
+
+/**
+ * `Float#as_json` (json.rb:114-120) — Infinity and NaN encode to `null`, since
+ * "Infinity"/"NaN" are not valid JSON.
+ */
+export class Float {
+  static asJson(value: number): number | null {
+    return globalThis.Number.isFinite(value) ? value : null;
+  }
+}
+
+/** `Regexp#as_json` (json.rb:136-140). */
+export class Regexp {
+  static asJson(value: RegExp): string {
+    return globalThis.String(value);
+  }
+}
+
+/** `Array#as_json` (json.rb:154-163). */
+export class Array {
+  static asJson(value: unknown[], options?: EncodeOptions | null): unknown[] {
+    if (options) {
+      return value.map((v) => asJson(v, options));
+    } else {
+      return value.map((v) => asJson(v));
+    }
+  }
+}
+
+/**
+ * `Hash#as_json` (json.rb:165-188) — `only`/`except` select a subset, then every
+ * value is recursed with the same options.
+ *
+ * Ruby's Hash is our plain object and our `Map`; `Array(attrs)` is the scalar-or
+ * -list coercion inline in each arm.
+ */
+export class Hash {
+  static asJson(value: unknown, options?: EncodeOptions | null): Record<string, unknown> {
+    const entries =
+      value instanceof Map
+        ? [...value.entries()]
+        : globalThis.Object.entries(value as globalThis.Record<string, unknown>);
+
+    let subset = entries;
+    if (options) {
+      let attrs;
+      if ((attrs = options.only) != null) {
+        const keys = new Set(
+          (globalThis.Array.isArray(attrs) ? attrs : [attrs]).map(globalThis.String),
+        );
+        subset = entries.filter(([k]) => keys.has(globalThis.String(k)));
+      } else if ((attrs = options.except) != null) {
+        const keys = new Set(
+          (globalThis.Array.isArray(attrs) ? attrs : [attrs]).map(globalThis.String),
+        );
+        subset = entries.filter(([k]) => !keys.has(globalThis.String(k)));
+      }
+    }
+
+    const result: globalThis.Record<string, unknown> = {};
+    if (options) {
+      for (const [k, v] of subset) result[globalThis.String(k)] = asJson(v, options);
+    } else {
+      for (const [k, v] of subset) result[globalThis.String(k)] = asJson(v);
+    }
+    return result;
+  }
+}
+
+/**
+ * `Time#as_json` (json.rb:190-198), over our Temporal analogues: `Instant` and
+ * `ZonedDateTime`. `xmlschema` renders a zero offset as "Z"
+ * (`formatted_offset(true, 'Z')`), which the ZonedDateTime arm reproduces.
+ */
+export class Time {
+  static asJson(value: Temporal.Instant | Temporal.ZonedDateTime): string {
+    const digits =
+      Encoding.timePrecision as Temporal.ToStringPrecisionOptions["fractionalSecondDigits"];
+
+    if (value instanceof Temporal.Instant) {
+      if (Encoding.useStandardJsonTimeFormat) {
+        return value.toString({ fractionalSecondDigits: digits });
+      }
+      return slashFormat(value.toZonedDateTimeISO("UTC"), "+0000");
+    }
+
+    if (Encoding.useStandardJsonTimeFormat) {
+      const formatted = value.toString({ fractionalSecondDigits: digits, timeZoneName: "never" });
+      return value.offsetNanoseconds === 0 ? `${formatted.slice(0, -6)}Z` : formatted;
+    }
+    return slashFormat(value, value.offset.replaceAll(":", ""));
+  }
+}
+
+/** `Date#as_json` (json.rb:200-208), over `Temporal.PlainDate`. */
+export class Date {
+  static asJson(value: Temporal.PlainDate): string {
+    if (Encoding.useStandardJsonTimeFormat) {
+      return value.toString();
+    } else {
+      return `${value.year}/${pad2(value.month)}/${pad2(value.day)}`;
+    }
+  }
+}
+
+/**
+ * `DateTime#as_json` (json.rb:210-218), over the zoneless
+ * `Temporal.PlainDateTime` — whose `xmlschema` carries Ruby's default `+00:00`
+ * offset.
+ */
+export class DateTime {
+  static asJson(value: Temporal.PlainDateTime): string {
+    const digits =
+      Encoding.timePrecision as Temporal.ToStringPrecisionOptions["fractionalSecondDigits"];
+
+    if (Encoding.useStandardJsonTimeFormat) {
+      return `${value.toString({ fractionalSecondDigits: digits })}+00:00`;
+    } else {
+      return slashFormat(value, "+0000");
+    }
+  }
+}
+
+/** `Exception#as_json` (json.rb:250-254). */
+export class Exception {
+  static asJson(value: Error): string {
+    return value.message;
+  }
+}
+
+function slashFormat(
+  value: Temporal.ZonedDateTime | Temporal.PlainDateTime,
+  offset: string,
+): string {
+  return (
+    `${value.year}/${pad2(value.month)}/${pad2(value.day)} ` +
+    `${pad2(value.hour)}:${pad2(value.minute)}:${pad2(value.second)} ${offset}`
+  );
+}
+
+function pad2(value: number): string {
+  return globalThis.String(value).padStart(2, "0");
+}
+
+/**
+ * @noRailsEquivalent PERMANENT — a Hash-shaped object: a bare object literal
+ * (`Object.prototype` or null prototype), not a class instance like `Date` that
+ * defines its own JSON form. Stands in for Ruby's `Hash === value`.
+ */
+export function isPlainObject(value: object): boolean {
+  const proto = globalThis.Object.getPrototypeOf(value);
+  return proto === globalThis.Object.prototype || proto === null;
+}
+
+/**
+ * Ruby resolves `value.as_json` by method lookup across the
+ * classes this file reopens; TypeScript cannot reopen built-ins, so one
+ * dispatcher selects the arm the receiver's class would have provided. The
+ * arms are ordered most-specific first, as Ruby's lookup is.
+ */
+export function asJson(value: unknown, options?: EncodeOptions | null): unknown {
+  if (value == null) return NilClass.asJson(value);
+  if (typeof value === "boolean") return TrueClass.asJson(value);
+  if (typeof value === "string") return String.asJson(value);
+  if (typeof value === "number") return Float.asJson(value);
+  if (typeof value === "bigint") return Numeric.asJson(value);
+
+  // A class of our own that defines `as_json`, exactly as Ruby's would.
+  const own = (value as { asJson?: (o?: unknown) => unknown }).asJson;
+  if (typeof own === "function") return own.call(value, options ?? undefined);
+
+  if (value instanceof Temporal.Instant || value instanceof Temporal.ZonedDateTime) {
+    return Time.asJson(value);
+  }
+  if (value instanceof Temporal.PlainDate) return Date.asJson(value);
+  if (value instanceof Temporal.PlainDateTime) return DateTime.asJson(value);
+  if (value instanceof RegExp) return Regexp.asJson(value);
+  if (value instanceof Error) return Exception.asJson(value);
+  if (globalThis.Array.isArray(value)) return Array.asJson(value, options);
+  if (value instanceof Map || isPlainObject(value as object)) return Hash.asJson(value, options);
+
+  // A JS built-in carrying its own JSON form (`Date`, …). Ruby's counterparts
+  // define `as_json`; calling `toJSON` reaches the same primitive, where
+  // recursing into the instance as an attribute bag would emit `{}`.
+  if (typeof (value as { toJSON?: unknown }).toJSON === "function") {
+    return (value as { toJSON(): unknown }).toJSON();
+  }
+
+  return Object.asJson(value as object, options);
+}

--- a/packages/activesupport/src/core-ext/object/json.ts
+++ b/packages/activesupport/src/core-ext/object/json.ts
@@ -4,7 +4,7 @@ import { Encoding, type EncodeOptions } from "../../json/encoding.js";
 
 /**
  * Rails' `core_ext/object/json.rb` — the `as_json` layer
- * `JSONGemEncoder#jsonify` dispatches through (json/encoding.rb:100).
+ * `JSONGemEncoder#jsonify` dispatches through (json/encoding.rb:103).
  *
  * Ruby reopens every core class and defines `as_json` on it; method lookup then
  * picks the right one. TypeScript cannot reopen built-ins, so each Ruby class'
@@ -14,7 +14,7 @@ import { Encoding, type EncodeOptions } from "../../json/encoding.js";
  */
 
 /**
- * `Object#as_json` (json.rb:58-64).
+ * `Object#as_json` (json.rb:58-66).
  *
  * `instance_values` (core_ext/object/instance_variables.rb:14-18) is unported;
  * a spread of the object's own enumerable properties is its analogue.
@@ -28,28 +28,28 @@ export class Object {
   }
 }
 
-/** `TrueClass#as_json` / `FalseClass#as_json` (json.rb:78-88). */
+/** `TrueClass#as_json` / `FalseClass#as_json` (json.rb:80-90). */
 export class TrueClass {
   static asJson(value: boolean): boolean {
     return value;
   }
 }
 
-/** `NilClass#as_json` (json.rb:90-94). */
+/** `NilClass#as_json` (json.rb:92-96). */
 export class NilClass {
   static asJson(value: null | undefined): null | undefined {
     return value;
   }
 }
 
-/** `String#as_json` (json.rb:96-100). */
+/** `String#as_json` (json.rb:98-102). */
 export class String {
   static asJson(value: string): string {
     return value;
   }
 }
 
-/** `Numeric#as_json` (json.rb:108-112). */
+/** `Numeric#as_json` (json.rb:110-114). */
 export class Numeric {
   static asJson(value: number | bigint): number | bigint {
     return value;
@@ -57,7 +57,7 @@ export class Numeric {
 }
 
 /**
- * `Float#as_json` (json.rb:114-120) — Infinity and NaN encode to `null`, since
+ * `Float#as_json` (json.rb:116-122) — Infinity and NaN encode to `null`, since
  * "Infinity"/"NaN" are not valid JSON.
  */
 export class Float {
@@ -66,14 +66,14 @@ export class Float {
   }
 }
 
-/** `Regexp#as_json` (json.rb:136-140). */
+/** `Regexp#as_json` (json.rb:139-143). */
 export class Regexp {
   static asJson(value: RegExp): string {
     return globalThis.String(value);
   }
 }
 
-/** `Array#as_json` (json.rb:154-163). */
+/** `Array#as_json` (json.rb:163-172). */
 export class Array {
   static asJson(value: unknown[], options?: EncodeOptions | null): unknown[] {
     if (options) {
@@ -85,7 +85,7 @@ export class Array {
 }
 
 /**
- * `Hash#as_json` (json.rb:165-188) — `only`/`except` select a subset, then every
+ * `Hash#as_json` (json.rb:174-197) — `only`/`except` select a subset, then every
  * value is recursed with the same options.
  *
  * Ruby's Hash is our plain object and our `Map`; `Array(attrs)` is the scalar-or
@@ -125,7 +125,7 @@ export class Hash {
 }
 
 /**
- * `Time#as_json` (json.rb:190-198), over our Temporal analogues: `Instant` and
+ * `Time#as_json` (json.rb:200-208), over our Temporal analogues: `Instant` and
  * `ZonedDateTime`. `xmlschema` renders a zero offset as "Z"
  * (`formatted_offset(true, 'Z')`), which the ZonedDateTime arm reproduces.
  */
@@ -149,7 +149,7 @@ export class Time {
   }
 }
 
-/** `Date#as_json` (json.rb:200-208), over `Temporal.PlainDate`. */
+/** `Date#as_json` (json.rb:210-218), over `Temporal.PlainDate`. */
 export class Date {
   static asJson(value: Temporal.PlainDate): string {
     if (Encoding.useStandardJsonTimeFormat) {
@@ -161,7 +161,7 @@ export class Date {
 }
 
 /**
- * `DateTime#as_json` (json.rb:210-218), over the zoneless
+ * `DateTime#as_json` (json.rb:220-228), over the zoneless
  * `Temporal.PlainDateTime` — whose `xmlschema` carries Ruby's default `+00:00`
  * offset.
  */
@@ -178,7 +178,7 @@ export class DateTime {
   }
 }
 
-/** `Exception#as_json` (json.rb:250-254). */
+/** `Exception#as_json` (json.rb:256-260). */
 export class Exception {
   static asJson(value: Error): string {
     return value.message;

--- a/packages/activesupport/src/json/encoding.test.ts
+++ b/packages/activesupport/src/json/encoding.test.ts
@@ -1,11 +1,23 @@
 import { describe, it, expect } from "vitest";
 
-import { slice, except } from "../hash-utils.js";
 import { ActiveSupportJSON } from "../json.js";
 import { Temporal } from "@blazetrails/date";
 import { TimeWithZone } from "../time-with-zone.js";
 import { TimeZone } from "../values/time-zone.js";
 import { Encoding } from "./encoding.js";
+
+/** Rails' `JSONTest::Hashlike` (encoding_test_cases.rb:16-20). */
+class Hashlike {
+  toHash(): Record<string, unknown> {
+    return { foo: "hello", bar: "world" };
+  }
+}
+
+/** Stands in for Rails' bare `Object.new` with `@foo`/`@bar` set (encoding_test.rb:151-153). */
+class Bare {
+  foo?: string;
+  bar?: string;
+}
 
 function withStandardJsonTimeFormat(value: boolean, block: () => void): void {
   const old = Encoding.useStandardJsonTimeFormat;
@@ -89,15 +101,13 @@ describe("TestJSONEncoding", () => {
   });
 
   it("hash should allow key filtering with only", () => {
-    const h = { a: 1, b: 2, c: 3 };
-    const filtered = slice(h, "a", "c");
-    expect(JSON.stringify(filtered)).toBe('{"a":1,"c":3}');
+    expect(ActiveSupportJSON.encode({ a: 1, b: 2, c: 3 }, { only: "a" })).toBe('{"a":1}');
   });
 
   it("hash should allow key filtering with except", () => {
-    const h = { a: 1, b: 2, c: 3 };
-    const filtered = except(h, "b");
-    expect(JSON.stringify(filtered)).toBe('{"a":1,"c":3}');
+    expect(ActiveSupportJSON.encode({ foo: "bar", b: 2, c: 3 }, { except: ["foo", "c"] })).toBe(
+      '{"b":2}',
+    );
   });
 
   it("time to json includes local offset", () => {
@@ -119,8 +129,22 @@ describe("TestJSONEncoding", () => {
     expect(parsed.nested.y).toBeCloseTo(2.75);
   });
 
-  it.skip("hash like with options");
-  it.skip("object to json with options");
+  it("hash like with options", () => {
+    const h = new Hashlike();
+    const json = ActiveSupportJSON.encode(h, { only: ["foo"] });
+
+    expect(JSON.parse(json)).toEqual({ foo: "hello" });
+  });
+
+  it("object to json with options", () => {
+    const obj = new Bare();
+    obj.foo = "hello";
+    obj.bar = "world";
+    const json = ActiveSupportJSON.encode(obj, { only: ["foo"] });
+
+    expect(JSON.parse(json)).toEqual({ foo: "hello" });
+  });
+
   it.skip("struct to json with options");
   it.skip("struct to json with options nested");
 

--- a/packages/activesupport/src/json/encoding.ts
+++ b/packages/activesupport/src/json/encoding.ts
@@ -24,7 +24,7 @@ export class JSONGemEncoder {
    *
    * Rails escapes more than the JSON gem natively does: U+2028 and U+2029, and
    * optionally `>`, `<`, `&`, to work around certain browser problems
-   * (encoding.rb:57-69).
+   * (encoding.rb:60-70).
    *
    * Deviation: Ruby's `@options.fetch(:escape_html_entities, ...)`
    * (encoding.rb:63) returns the *stored* value whenever the key is present —
@@ -65,7 +65,7 @@ export class JSONGemEncoder {
    * Note: the `options` hash passed to `toJson` is only passed to `asJson`, not
    * any of this method's recursive `asJson` calls.
    *
-   * Rails' private `JSONGemEncoder#jsonify` (encoding.rb:85-102). JS has a
+   * Rails' private `JSONGemEncoder#jsonify` (encoding.rb:88-104). JS has a
    * single numeric type, so Ruby's `Integer`-in-the-first-arm / `Float`-in-the
    * -`Numeric`-arm split collapses onto `Float#as_json`, whose finite values
    * are returned unchanged; a `bigint` takes the `Integer` arm.
@@ -99,7 +99,7 @@ export class JSONGemEncoder {
    * Encode a "jsonified" data structure. Rails' private
    * `JSONGemEncoder#stringify` calls
    * `JSON.generate(jsonified, quirks_mode: true, max_nesting: false)`
-   * (encoding.rb:105-107); `quirks_mode` — emitting a bare scalar at the root
+   * (encoding.rb:108-111); `quirks_mode` — emitting a bare scalar at the root
    * rather than raising — is `JSON.stringify`'s only behaviour, and it has no
    * nesting limit to lift. `JSON.stringify` returns `undefined` for `undefined`,
    * which has no Ruby analogue, so it becomes `null` as Ruby's `nil` would.
@@ -122,7 +122,7 @@ let _timePrecision = 3;
 
 /**
  * Rails' `ActiveSupport::JSON::Encoding` singleton accessors
- * (encoding.rb:113-130). A class with `static` accessors rather than an object
+ * (encoding.rb:114-130). A class with `static` accessors rather than an object
  * literal so `class << self; attr_accessor ...` maps member-for-member.
  */
 export class Encoding {

--- a/packages/activesupport/src/json/encoding.ts
+++ b/packages/activesupport/src/json/encoding.ts
@@ -1,4 +1,4 @@
-import { Temporal } from "@blazetrails/date";
+import { asJson, Float, isPlainObject } from "../core-ext/object/json.js";
 
 /**
  * Serialization options threaded through `as_json` — only the subset Rails'
@@ -12,25 +12,11 @@ export interface EncodeOptions {
   [key: string]: unknown;
 }
 
-/** Normalized form after `Array(attrs)` coercion: `only`/`except` are always lists. */
-interface NormalizedOptions {
-  only?: Array<string | number>;
-  except?: Array<string | number>;
-  [key: string]: unknown;
-}
-
 export class JSONGemEncoder {
   readonly options: EncodeOptions;
 
-  /**
-   * Ruby applies `only`/`except` coercion inside each `as_json`; trails
-   * coerces once so every recursion level sees the same list form.
-   */
-  private readonly normalizedOptions: NormalizedOptions;
-
   constructor(options?: EncodeOptions | null) {
     this.options = options ?? {};
-    this.normalizedOptions = normalizeOptions(this.options);
   }
 
   /**
@@ -40,14 +26,6 @@ export class JSONGemEncoder {
    * optionally `>`, `<`, `&`, to work around certain browser problems
    * (encoding.rb:57-69).
    *
-   * Deviation: Rails' `unless options.empty?` guard (encoding.rb:53-55) is
-   * dropped. It only decides whether to run `as_json(options)` *before*
-   * `jsonify`, and Ruby's `jsonify` reaches `value.as_json` for every
-   * non-primitive in its `else` arm anyway (encoding.rb:100). Here `jsonify` IS
-   * that traversal, so gating it on a non-empty options hash would skip the
-   * `asJson` calls — and the raises they exist to surface, e.g. `Type#asJson` —
-   * for the common no-options encode.
-   *
    * Deviation: Ruby's `@options.fetch(:escape_html_entities, ...)`
    * (encoding.rb:63) returns the *stored* value whenever the key is present —
    * including a stored nil, which `??` would replace with the default — and JS
@@ -55,6 +33,9 @@ export class JSONGemEncoder {
    * follows Ruby truthiness (nil and false only).
    */
   encode(value: unknown): string {
+    if (Object.keys(this.options).length !== 0) {
+      value = asJson(value, this.options);
+    }
     let json = this.stringify(this.jsonify(value));
 
     const escapeHtmlEntities =
@@ -81,60 +62,37 @@ export class JSONGemEncoder {
    * what base types of objects they are allowed to return or having to remember
    * to call `asJson` recursively.
    *
-   * Rails' private `JSONGemEncoder#jsonify` (encoding.rb:85-102).
+   * Note: the `options` hash passed to `toJson` is only passed to `asJson`, not
+   * any of this method's recursive `asJson` calls.
    *
-   * Deviation: Rails dispatches on Ruby type (`String, Integer, Symbol, nil,
-   * true, false` / `Numeric` / `Hash` / `Array` / else `as_json`). This body
-   * keeps trails' existing branch order, because the `as_json` layer it would
-   * dispatch through — `core_ext/object/json.rb` — is unported (0/6). Converging
-   * the two is tracked by `converge-jsonify-branch-order-onto-rails-as-json`.
-   *
-   * Three branches carry behaviour the Ruby case statement gets for free:
-   * `toHash` unwraps HashWithIndifferentAccess, a Hash subclass in Ruby, so its
-   * contents rather than its Map-backed internals are traversed. Only true
-   * Hashes (plain objects / Maps) take `only`/`except` key filtering — other
-   * objects (Date, RegExp, …) carry their own JSON form and are left to
-   * `toJSON`, which recursing into them as attribute bags would lose (a `Date`
-   * would emit `{}`). The final branch is Rails' `Object#as_json`, which is
-   * `instance_values.as_json(options)` (core_ext/object/json.rb:62-64): a
-   * generic object becomes a hash of its instance variables and the traversal
-   * recurses into each. That recursion is what lets a nested type instance
-   * reach `Type#asJson`'s raise (value.rb:145) instead of `stringify` silently
-   * dumping the type's internals.
+   * Rails' private `JSONGemEncoder#jsonify` (encoding.rb:85-102). JS has a
+   * single numeric type, so Ruby's `Integer`-in-the-first-arm / `Float`-in-the
+   * -`Numeric`-arm split collapses onto `Float#as_json`, whose finite values
+   * are returned unchanged; a `bigint` takes the `Integer` arm.
    */
   private jsonify(value: unknown): unknown {
-    if (value == null) return value;
-
-    const asJson = (value as { asJson?: (o?: unknown) => unknown }).asJson;
-    if (typeof asJson === "function") return asJson.call(value, this.normalizedOptions);
-
-    const temporal = temporalAsJson(value);
-    if (temporal !== undefined) return temporal;
-
-    if (Array.isArray(value)) return value.map((v) => this.jsonify(v));
-
-    if (typeof (value as { toHash?: unknown }).toHash === "function") {
-      return this.jsonify((value as { toHash(): unknown }).toHash());
-    }
-
-    if (value instanceof Map || isPlainObject(value)) {
-      const entries = value instanceof Map ? [...value.entries()] : Object.entries(value);
-      const keep = filterHashKeys(
-        entries.map(([k]) => k),
-        this.normalizedOptions,
-      );
+    if (
+      typeof value === "string" ||
+      typeof value === "bigint" ||
+      value == null ||
+      value === true ||
+      value === false
+    ) {
+      return value;
+    } else if (typeof value === "number") {
+      return Float.asJson(value);
+    } else if (value instanceof Map || isPlainObject(value as object)) {
       const result: Record<string, unknown> = {};
+      const entries = value instanceof Map ? value.entries() : Object.entries(value as object);
       for (const [k, v] of entries) {
-        if (keep.has(k)) result[String(k)] = this.jsonify(v);
+        result[String(k)] = this.jsonify(v);
       }
       return result;
+    } else if (Array.isArray(value)) {
+      return value.map((v) => this.jsonify(v));
+    } else {
+      return this.jsonify(asJson(value));
     }
-
-    if (typeof value === "object" && typeof (value as { toJSON?: unknown }).toJSON !== "function") {
-      return this.jsonify({ ...value });
-    }
-
-    return value;
   }
 
   /**
@@ -149,100 +107,6 @@ export class JSONGemEncoder {
   private stringify(jsonified: unknown): string {
     return JSON.stringify(jsonified) ?? "null";
   }
-}
-
-/**
- * Rails' `Time#as_json` / `DateTime#as_json` / `Date#as_json`
- * (core_ext/object/json.rb:200-228), dispatched over our Temporal analogues:
- * `Instant`/`ZonedDateTime` for `Time`, `PlainDateTime` for the zoneless
- * `DateTime` (whose `xmlschema` carries Ruby's default `+00:00` offset), and
- * `PlainDate` for `Date`. `xmlschema` renders a zero offset as "Z"
- * (`formatted_offset(true, 'Z')`), which the ZonedDateTime arm reproduces.
- */
-function temporalAsJson(value: unknown): string | undefined {
-  const digits =
-    Encoding.timePrecision as Temporal.ToStringPrecisionOptions["fractionalSecondDigits"];
-
-  if (value instanceof Temporal.Instant) {
-    if (Encoding.useStandardJsonTimeFormat)
-      return value.toString({ fractionalSecondDigits: digits });
-    return slashFormat(value.toZonedDateTimeISO("UTC"), "+0000");
-  }
-
-  if (value instanceof Temporal.ZonedDateTime) {
-    if (Encoding.useStandardJsonTimeFormat) {
-      const formatted = value.toString({ fractionalSecondDigits: digits, timeZoneName: "never" });
-      return value.offsetNanoseconds === 0 ? `${formatted.slice(0, -6)}Z` : formatted;
-    }
-    return slashFormat(value, value.offset.replaceAll(":", ""));
-  }
-
-  if (value instanceof Temporal.PlainDateTime) {
-    if (Encoding.useStandardJsonTimeFormat) {
-      return `${value.toString({ fractionalSecondDigits: digits })}+00:00`;
-    }
-    return slashFormat(value, "+0000");
-  }
-
-  if (value instanceof Temporal.PlainDate) {
-    return Encoding.useStandardJsonTimeFormat
-      ? value.toString()
-      : `${value.year}/${pad2(value.month)}/${pad2(value.day)}`;
-  }
-
-  return undefined;
-}
-
-function slashFormat(
-  value: Temporal.ZonedDateTime | Temporal.PlainDateTime,
-  offset: string,
-): string {
-  return (
-    `${value.year}/${pad2(value.month)}/${pad2(value.day)} ` +
-    `${pad2(value.hour)}:${pad2(value.minute)}:${pad2(value.second)} ${offset}`
-  );
-}
-
-function pad2(value: number): string {
-  return String(value).padStart(2, "0");
-}
-
-/**
- * A Hash-shaped object: a bare object literal (`Object.prototype` or null
- * prototype), not a class instance like `Date` that defines its own JSON form.
- */
-function isPlainObject(value: object): boolean {
-  const proto = Object.getPrototypeOf(value);
-  return proto === Object.prototype || proto === null;
-}
-
-/**
- * Mirrors `Hash#as_json`'s key filtering: `only` keeps the listed keys, `except`
- * drops them, comparing by stringified key (Rails compares the raw keys, but our
- * option lists arrive as strings/numbers, so normalize both sides).
- */
-function filterHashKeys(keys: unknown[], options: NormalizedOptions): Set<unknown> {
-  const norm = (v: unknown) => String(v);
-  if (options.only != null) {
-    const only = new Set(options.only.map(norm));
-    return new Set(keys.filter((k) => only.has(norm(k))));
-  }
-  if (options.except != null) {
-    const except = new Set(options.except.map(norm));
-    return new Set(keys.filter((k) => !except.has(norm(k))));
-  }
-  return new Set(keys);
-}
-
-/**
- * Ruby `Array(x)`: nil → absent (default = all attrs), scalar → [scalar],
- * list → list. Coerced once up front so the Hash filter and every forwarded
- * `asJson(options)` (whose `only`/`except` filters assume a list) agree.
- */
-function normalizeOptions(options: EncodeOptions): NormalizedOptions {
-  const wrap = (v: string | number | Array<string | number> | undefined) =>
-    v == null ? undefined : Array.isArray(v) ? v : [v];
-  return { ...options, only: wrap(options.only), except: wrap(options.except) };
 }
 
 /**

--- a/packages/activesupport/src/messages/message-metadata-tests.ts
+++ b/packages/activesupport/src/messages/message-metadata-tests.ts
@@ -41,7 +41,7 @@ export function freezeTime(
  * that decode the time back as a string. JS equality has no such coercion, so
  * the two spellings `ActiveSupport::JSON` can render an instant in —
  * `xmlschema` and the `use_standard_json_time_format = false` slash format
- * (json.ts `temporalAsJson`) — are compared the same way here.
+ * (`core-ext/object/json.ts` `Time.asJson`) — are compared the same way here.
  */
 expect.addEqualityTesters([
   function (a: unknown, b: unknown): boolean | undefined {


### PR DESCRIPTION
Ports `core_ext/object/json.rb` — the `as_json` layer `JSONGemEncoder#jsonify`
dispatches through — and converges `jsonify` onto Rails' branch order.

## What moved

`packages/activesupport/src/core-ext/object/json.ts` (new) carries the arms
`jsonify` was inlining: `Object#as_json` (json.rb:58-64), `Hash#as_json` with
its `only`/`except` subset (`:165-188`), `Array#as_json` (`:154-163`),
`Numeric`/`Float` (`:108-120`), `Regexp` (`:136-140`), `Exception` (`:250-254`),
and `Time`/`Date`/`DateTime` (`:190-218`) over their Temporal analogues. Each
Ruby class is a class of the same name with a `static asJson(value, options)`,
the shape `core-ext/object/blank.ts` already uses for `blank?`/`present?`.

TypeScript cannot reopen built-ins, so one `asJson()` dispatcher stands in for
Ruby's method lookup, arms ordered most-specific first.

## What converged

- `jsonify` is Rails' single-argument `case` (encoding.rb:85-102), arm for arm:
  primitives → value, `Numeric` → `as_json`, `Hash`, `Array`, else
  `jsonify value.as_json`. JS has one numeric type, so Ruby's
  `Integer`-first-arm / `Float`-in-`Numeric` split collapses onto
  `Float#as_json`; a `bigint` takes the `Integer` arm.
- `encode` restores `unless options.empty?` (encoding.rb:53-55). With a real
  `as_json` layer the `else` arm still reaches `asJson` for every non-primitive,
  so the raises it exists to surface (`Type#asJson`, activemodel `type/value.ts:108`) still fire —
  that is why the guard could not be restored before.
- `temporalAsJson`, `filterHashKeys`, `isPlainObject` and `normalizeOptions` are
  gone from `json/encoding.ts`. `normalizeOptions` was redundant: `Array(attrs)`
  belongs inside `Hash#as_json`, and activemodel already coerces via its own
  `rubyArray`.

## Tests

`hash should allow key filtering with only` / `with except` now use Rails'
bodies — they were asserting on `slice`/`except` directly and never reached the
encoder. `hash like with options` and `object to json with options` are
unskipped. No test renamed.

## Gates

`core_ext/object/json.rb` 0/6 → 1/6; `json/encoding.rb` stays 13/13; activesupport
overall 972 → 973, files 117 → 118.

The 6 is small because `api:compare` keys each Ruby class to a single home file,
and `Object`, `Hash`, `Array`, `Time`, `Date`, `DateTime`, `String`, `Numeric`,
`Float`, `NilClass`, `TrueClass` are all homed elsewhere (`core_ext/object/blank.rb`,
`core_ext/array/access.rb`, `core_ext/date/acts_like.rb`, …). This file's own six
are `Data#as_json`, `Regexp#multiline?`, `Pathname#blank?`/`present?`/`existence`,
and `ToJsonWithActiveSupportEncoder#to_json`. The thirteen classes ported here
show up as `moved` in `api:extra` — credited against their home files — not as
misses, which is why the file count moves by one rather than by thirteen.
`api:extra` clean, `api:calls` OK (there is no `api:calls:wide` script — RFC 0084 folded it into `api:calls`), lint clean, `test:compare` +2.

## Not in this PR

`move-adapter-specific-snapshot-off-ar-internal-metadata` was bundled with this
story and is released back. Its own findings say it must be its own PR — the
`load-schema-helper.ts:526-532` seam is reshaped one story at a time — and the
sidecar arm is larger than the bundle allowed for.

Closes-story: converge-jsonify-branch-order-onto-rails-as-json
