### PR TITLE
refactor(activerecord): changeColumnDefault takes defaultOrChanges; unordered collection-proxy assertions

### DIFF
--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -38,7 +38,12 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
   fixtures(["authors", "posts"]);
 
   // A fresh author owns only the posts we create here, so the loaded `posts`
-  // collection is the deterministic ["a", "b", "c"] set the assertions expect.
+  // collection is the deterministic {"a", "b", "c"} *set*. `Author.posts`
+  // carries no `-> { order(...) }` scope (`test/models/author.rb`), so its
+  // SELECT has no ORDER BY and the row order is whatever the server returns —
+  // PostgreSQL has been observed returning `c, a, b`. Assertions here compare
+  // sets (sorted) or read positions back off the loaded target; none of them
+  // may pin the row order of the unordered SELECT.
   async function authorWithPosts(): Promise<Author> {
     const author = await Author.create({ name: "Dev" });
     for (const title of ["a", "b", "c"]) {
@@ -73,7 +78,7 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
     const proxy = association<Post>(author, "posts");
     const titles: string[] = [];
     for (const p of proxy) titles.push(p.title);
-    expect(titles).toEqual(["a", "b", "c"]);
+    expect(titles.sort()).toEqual(["a", "b", "c"]);
   });
 
   it("supports numeric indexing (proxy[0]) — typed via the index signature", async () => {
@@ -82,27 +87,32 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
     // No `as any` needed — AssociationProxy declares
     // `[index: number]: T | undefined` (the runtime support comes from
     // `wrapCollectionProxy`'s `get` trap). Out-of-range returns undefined.
-    expect(proxy[0]?.title).toBe("a");
-    expect(proxy[2]?.title).toBe("c");
+    expect(proxy[0]).toBe(proxy.target[0]);
+    expect(proxy[2]).toBe(proxy.target[2]);
     expect(proxy[99]).toBeUndefined();
   });
 
   it("at(index) returns the record or undefined", async () => {
     const author = await authorWithPosts();
     const proxy = association<Post>(author, "posts");
-    expect(proxy.at(0)?.title).toBe("a");
-    expect(proxy.at(-1)?.title).toBe("c");
+    expect(proxy.at(0)).toBe(proxy.target[0]);
+    expect(proxy.at(-1)).toBe(proxy.target[2]);
     expect(proxy.at(99)).toBeUndefined();
   });
 
   it("map / filter / forEach delegate to the target", async () => {
     const author = await authorWithPosts();
     const proxy = association<Post>(author, "posts");
-    expect(proxy.map((p) => p.title)).toEqual(["a", "b", "c"]);
-    expect(proxy.filter((p) => p.title !== "b").map((p) => p.title)).toEqual(["a", "c"]);
+    expect(proxy.map((p) => p.title).sort()).toEqual(["a", "b", "c"]);
+    expect(
+      proxy
+        .filter((p) => p.title !== "b")
+        .map((p) => p.title)
+        .sort(),
+    ).toEqual(["a", "c"]);
     const seen: string[] = [];
     proxy.forEach((p) => seen.push(p.title));
-    expect(seen).toEqual(["a", "b", "c"]);
+    expect(seen.sort()).toEqual(["a", "b", "c"]);
   });
 
   it("some / every work", async () => {
@@ -118,16 +128,17 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
     // through the loaded records — e.g. `sort`, `reverse`, `join`.
     const author = await authorWithPosts();
     const proxy = association<Post>(author, "posts") as any;
+    const loaded = proxy.target.map((p: Post) => p.title);
     expect(
       (proxy.sort((a: Post, b: Post) => b.title.localeCompare(a.title)) as Post[]).map(
         (p: Post) => p.title,
       ),
     ).toEqual(["c", "b", "a"]);
-    expect((proxy.reverse() as Post[]).map((p: Post) => p.title)).toEqual(["c", "b", "a"]);
+    expect((proxy.reverse() as Post[]).map((p: Post) => p.title)).toEqual([...loaded].reverse());
     expect(proxy.join(",")).toBe(proxy.target.join(","));
     // Non-mutating: Ruby's `sort`/`reverse`, not `sort!`/`reverse!` — the
     // loaded target order is untouched.
-    expect(proxy.target.map((p: Post) => p.title)).toEqual(["a", "b", "c"]);
+    expect(proxy.target.map((p: Post) => p.title)).toEqual(loaded);
   });
 
   it("preserves Relation#includes (eager loading) — proxy.includes routes to Relation", async () => {
@@ -154,14 +165,14 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
     const v = proxy.values();
     expect(typeof v).toBe("object");
     expect(Array.isArray(v)).toBe(false); // confirms it's not the array iterator
-    expect([...(proxy as Iterable<Post>)].map((p) => p.title)).toEqual(["a", "b", "c"]);
+    expect([...(proxy as Iterable<Post>)].map((p) => p.title).sort()).toEqual(["a", "b", "c"]);
   });
 
   it("slice returns a plain array shallow copy", async () => {
     const author = await authorWithPosts();
     const proxy = association<Post>(author, "posts");
     const head = proxy.slice(0, 2);
-    expect(head.map((p) => p.title)).toEqual(["a", "b"]);
+    expect(head).toEqual(proxy.target.slice(0, 2));
     expect(Array.isArray(head)).toBe(true);
   });
 
@@ -169,7 +180,7 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
     const author = await authorWithPosts();
     const proxy = association<Post>(author, "posts");
     const concatenated = proxy.reduce((acc, p) => acc + p.title, "");
-    expect(concatenated).toBe("abc");
+    expect([...concatenated].sort().join("")).toBe("abc");
   });
 
   it("indexOf / flatMap work", async () => {
@@ -177,14 +188,9 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
     const proxy = association<Post>(author, "posts");
     const second = proxy.at(1)!;
     expect(proxy.indexOf(second)).toBe(1);
-    expect(proxy.flatMap((p) => [p.title, p.title.toUpperCase()])).toEqual([
-      "a",
-      "A",
-      "b",
-      "B",
-      "c",
-      "C",
-    ]);
+    expect(proxy.flatMap((p) => [p.title, p.title.toUpperCase()])).toEqual(
+      proxy.target.flatMap((p) => [p.title, p.title.toUpperCase()]),
+    );
   });
 
   it("array spread reads the loaded target", async () => {
@@ -193,7 +199,7 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
     // proxy is a thenable Relation; spread it via its iterator contract so the
     // lint sees an Iterable, not a Promise being spread.
     const titles = [...(proxy as Iterable<Post>)].map((p) => p.title);
-    expect(titles).toEqual(["a", "b", "c"]);
+    expect(titles.sort()).toEqual(["a", "b", "c"]);
   });
 
   it("Array.from reads the loaded target", async () => {
@@ -206,7 +212,7 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
     const author = await authorWithPosts();
     const proxy = association<Post>(author, "posts");
     const arr = await proxy;
-    expect(arr.map((p) => p.title)).toEqual(["a", "b", "c"]);
+    expect(arr.map((p) => p.title).sort()).toEqual(["a", "b", "c"]);
   });
 
   it("await proxy hydrates `_target` so subsequent sync ops work", async () => {
@@ -220,15 +226,17 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
     const proxy = association<Post>(author, "posts") as any;
     await proxy;
     expect(proxy.target.length).toBe(2);
-    expect(proxy[0]?.title).toBe("x");
-    expect([...proxy].map((p: Post) => p.title)).toEqual(["x", "y"]);
+    expect(proxy[0]).toBe(proxy.target[0]);
+    expect([...proxy].map((p: Post) => p.title).sort()).toEqual(["x", "y"]);
   });
 
   it("keys / entries work (values intentionally not added)", async () => {
     const author = await authorWithPosts();
     const proxy = association<Post>(author, "posts");
     expect([...proxy.keys()]).toEqual([0, 1, 2]);
-    expect([...proxy.entries()].map(([i, p]) => `${i}:${p.title}`)).toEqual(["0:a", "1:b", "2:c"]);
+    expect([...proxy.entries()].map(([i, p]) => `${i}:${p.title}`)).toEqual(
+      proxy.target.map((p, i) => `${i}:${p.title}`),
+    );
   });
 
   it("array methods accept a thisArg (matches Array.prototype signatures)", async () => {
@@ -238,7 +246,7 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
     const titles = proxy.map(function (this: { suffix: string }, p) {
       return p.title + this.suffix;
     }, ctx);
-    expect(titles).toEqual(["a!", "b!", "c!"]);
+    expect(titles.sort()).toEqual(["a!", "b!", "c!"]);
   });
 
   it("reduce supports the no-initial overload (Array.prototype parity)", async () => {
@@ -248,7 +256,7 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
     const concat = proxy.reduce((acc, p) => {
       return { ...acc, title: acc.title + p.title } as Post;
     });
-    expect(concat.title).toBe("abc");
+    expect([...concat.title].sort().join("")).toBe("abc");
   });
 
   it("Array.isArray returns false on the proxy (known limitation)", async () => {
@@ -269,8 +277,9 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
     // resolves to. We intentionally do NOT add an Array-style
     // `find(predicate)` overload — it would shadow the PK lookup.
     // For Array semantics use `Array.from(proxy).find(p => ...)`.
-    const found = await proxy.find((author as any).posts[0]?.id);
-    expect(found?.title).toBe("a");
+    const first = (author as any).posts[0];
+    const found = await proxy.find(first?.id);
+    expect(found?.title).toBe(first?.title);
   });
 
   it("toArray hydrates and caches the target — a second call returns the cached set", async () => {
@@ -360,11 +369,11 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
     const author = await authorWithPosts();
     const reader = (author as any).posts;
     expect(reader.target.length).toBe(3);
-    expect(reader[0]?.title).toBe("a");
-    expect(reader.map((p: Post) => p.title)).toEqual(["a", "b", "c"]);
+    expect(reader[0]).toBe(reader.target[0]);
+    expect(reader.map((p: Post) => p.title).sort()).toEqual(["a", "b", "c"]);
     const titles: string[] = [];
     for (const p of reader as Iterable<Post>) titles.push(p.title);
-    expect(titles).toEqual(["a", "b", "c"]);
+    expect(titles.sort()).toEqual(["a", "b", "c"]);
   });
 
   it("writer `author.posts = [...]` still flows through Association#writer", async () => {
@@ -416,7 +425,12 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
     const author = await authorWithPosts();
     const proxy = association<Post>(author, "posts") as any;
     expect(proxy.readTargets()).toBe(proxy.target);
-    expect(proxy.readTargets().map((p: Post) => p.title)).toEqual(["a", "b", "c"]);
+    expect(
+      proxy
+        .readTargets()
+        .map((p: Post) => p.title)
+        .sort(),
+    ).toEqual(["a", "b", "c"]);
   });
 
   it("targetsByPrimaryKey() keys loaded targets by primary key", async () => {

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -830,7 +830,7 @@ export class AbstractAdapter implements Quoting {
     // adapter carries a NullPool until a real ConnectionPool claims it (the pool
     // overwrites `pool` when it owns the connection), so `connection_pool` on a
     // connect-time error is a NullPool rather than null.
-    this.pool = new NullPool() as unknown as ConnectionPool;
+    this.pool = new NullPool();
   }
 
   protected _visitor!: Visitors.ToSql;
@@ -874,13 +874,8 @@ export class AbstractAdapter implements Quoting {
   _queryCache: Store | null = null;
 
   // Rails' @pool is a ConnectionPool once one owns the connection and a
-  // NullPool until then (abstract_adapter.rb:153). Ruby's ivar is untyped, so
-  // `@pool.role` / `@pool.shard` (abstract_adapter.rb:288,294) are unchecked
-  // sends that raise NoMethodError while the NullPool is still in the slot.
-  // The declared type is the pool those readers assume; the single cast is the
-  // NullPool seed itself, so the unchecked-ness sits at Rails' assignment
-  // rather than being re-asserted at each reader.
-  pool: ConnectionPool = new NullPool() as unknown as ConnectionPool;
+  // NullPool until then (abstract_adapter.rb:153).
+  pool: ConnectionPool | NullPool = new NullPool();
   logger: unknown = null;
   lock: unknown = null;
   /** Stable per-instance hex slot + monotonic source for {@link inspect}. @internal */
@@ -1409,11 +1404,15 @@ export class AbstractAdapter implements Quoting {
   }
 
   get role(): string {
-    return this.pool.role;
+    // Ruby's `@pool.role` (`abstract_adapter.rb:288`) is an unchecked send that
+    // raises NoMethodError on a NullPool — which Rails never reaches, because an
+    // adapter is only ever obtained from a real pool. The cast is that same
+    // unchecked read; no trails path reads `role` off a pool-less adapter either.
+    return (this.pool as ConnectionPool).role;
   }
 
   get shard(): string {
-    return this.pool.shard;
+    return (this.pool as ConnectionPool).shard;
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -264,7 +264,7 @@ export interface AbstractAdapter {
   changeColumnDefault(
     tableName: string,
     columnName: string,
-    options: { from?: unknown; to: unknown } | unknown,
+    defaultOrChanges: unknown,
   ): Promise<void>;
   changeColumnNull(
     tableName: string,
@@ -830,7 +830,7 @@ export class AbstractAdapter implements Quoting {
     // adapter carries a NullPool until a real ConnectionPool claims it (the pool
     // overwrites `pool` when it owns the connection), so `connection_pool` on a
     // connect-time error is a NullPool rather than null.
-    this.pool = new NullPool();
+    this.pool = new NullPool() as unknown as ConnectionPool;
   }
 
   protected _visitor!: Visitors.ToSql;
@@ -874,8 +874,13 @@ export class AbstractAdapter implements Quoting {
   _queryCache: Store | null = null;
 
   // Rails' @pool is a ConnectionPool once one owns the connection and a
-  // NullPool until then (abstract_adapter.rb:153).
-  pool: ConnectionPool | NullPool = new NullPool();
+  // NullPool until then (abstract_adapter.rb:153). Ruby's ivar is untyped, so
+  // `@pool.role` / `@pool.shard` (abstract_adapter.rb:288,294) are unchecked
+  // sends that raise NoMethodError while the NullPool is still in the slot.
+  // The declared type is the pool those readers assume; the single cast is the
+  // NullPool seed itself, so the unchecked-ness sits at Rails' assignment
+  // rather than being re-asserted at each reader.
+  pool: ConnectionPool = new NullPool() as unknown as ConnectionPool;
   logger: unknown = null;
   lock: unknown = null;
   /** Stable per-instance hex slot + monotonic source for {@link inspect}. @internal */
@@ -1404,15 +1409,11 @@ export class AbstractAdapter implements Quoting {
   }
 
   get role(): string {
-    // Ruby's `@pool.role` (`abstract_adapter.rb:288`) is an unchecked send that
-    // raises NoMethodError on a NullPool — which Rails never reaches, because an
-    // adapter is only ever obtained from a real pool. The cast is that same
-    // unchecked read; no trails path reads `role` off a pool-less adapter either.
-    return (this.pool as ConnectionPool).role;
+    return this.pool.role;
   }
 
   get shard(): string {
-    return (this.pool as ConnectionPool).shard;
+    return this.pool.shard;
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
@@ -9,6 +9,7 @@ import { parseTableOptions } from "./abstract-mysql-adapter.js";
 import { SchemaCreation as MysqlSchemaCreation } from "./mysql/schema-creation.js";
 import { quote as mysqlQuote } from "./mysql/quoting.js";
 import { NullPool } from "./abstract/connection-pool.js";
+import type { ConnectionPool } from "./abstract/connection-pool.js";
 
 function makeColumn(opts: { autoIncrement?: boolean; defaultFunction?: string | null } = {}) {
   return new Column("id", null, { sqlType: "bigint" }, false, {
@@ -78,7 +79,7 @@ describe("AbstractMysqlAdapter#renameColumnForAlter fallback", () => {
     const { AbstractMysqlAdapter } = await import("./abstract-mysql-adapter.js");
     const adapter = Object.create(AbstractMysqlAdapter.prototype);
     adapter.supportsRenameColumn = () => supportsRename;
-    adapter.pool = new NullPool();
+    adapter.pool = new NullPool() as unknown as ConnectionPool;
     adapter.getDatabaseVersion = async () => {};
     adapter.quoteColumnName = (s: string) => `\`${s}\``;
     adapter.columnDefinitions = async (_: string) => [
@@ -293,7 +294,7 @@ describe("AbstractMysqlAdapter#renameColumn wiring", () => {
     const { AbstractMysqlAdapter } = await import("./abstract-mysql-adapter.js");
     const adapter = Object.create(AbstractMysqlAdapter.prototype);
     const events: string[] = [];
-    adapter.pool = new NullPool();
+    adapter.pool = new NullPool() as unknown as ConnectionPool;
     adapter.supportsRenameColumn = () => true;
     adapter.getDatabaseVersion = async () => {};
     adapter.quoteColumnName = (s: string) => `\`${s}\``;
@@ -809,7 +810,7 @@ describe("AbstractMysqlAdapter#checkVersion", () => {
       typeof AbstractMysqlAdapter
     >;
     const { NullPool } = await import("./abstract/connection-pool.js");
-    adapter.pool = new NullPool();
+    adapter.pool = new NullPool() as unknown as ConnectionPool;
     (
       adapter as unknown as { getDatabaseVersion: () => InstanceType<typeof Version> }
     ).getDatabaseVersion = () => new Version("5.6.3");
@@ -826,7 +827,7 @@ describe("AbstractMysqlAdapter#checkVersion", () => {
       typeof AbstractMysqlAdapter
     >;
     const { NullPool } = await import("./abstract/connection-pool.js");
-    adapter.pool = new NullPool();
+    adapter.pool = new NullPool() as unknown as ConnectionPool;
     (
       adapter as unknown as { getDatabaseVersion: () => InstanceType<typeof Version> }
     ).getDatabaseVersion = () => new Version("5.6.4");

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
@@ -9,7 +9,6 @@ import { parseTableOptions } from "./abstract-mysql-adapter.js";
 import { SchemaCreation as MysqlSchemaCreation } from "./mysql/schema-creation.js";
 import { quote as mysqlQuote } from "./mysql/quoting.js";
 import { NullPool } from "./abstract/connection-pool.js";
-import type { ConnectionPool } from "./abstract/connection-pool.js";
 
 function makeColumn(opts: { autoIncrement?: boolean; defaultFunction?: string | null } = {}) {
   return new Column("id", null, { sqlType: "bigint" }, false, {
@@ -79,7 +78,7 @@ describe("AbstractMysqlAdapter#renameColumnForAlter fallback", () => {
     const { AbstractMysqlAdapter } = await import("./abstract-mysql-adapter.js");
     const adapter = Object.create(AbstractMysqlAdapter.prototype);
     adapter.supportsRenameColumn = () => supportsRename;
-    adapter.pool = new NullPool() as unknown as ConnectionPool;
+    adapter.pool = new NullPool();
     adapter.getDatabaseVersion = async () => {};
     adapter.quoteColumnName = (s: string) => `\`${s}\``;
     adapter.columnDefinitions = async (_: string) => [
@@ -294,7 +293,7 @@ describe("AbstractMysqlAdapter#renameColumn wiring", () => {
     const { AbstractMysqlAdapter } = await import("./abstract-mysql-adapter.js");
     const adapter = Object.create(AbstractMysqlAdapter.prototype);
     const events: string[] = [];
-    adapter.pool = new NullPool() as unknown as ConnectionPool;
+    adapter.pool = new NullPool();
     adapter.supportsRenameColumn = () => true;
     adapter.getDatabaseVersion = async () => {};
     adapter.quoteColumnName = (s: string) => `\`${s}\``;
@@ -810,7 +809,7 @@ describe("AbstractMysqlAdapter#checkVersion", () => {
       typeof AbstractMysqlAdapter
     >;
     const { NullPool } = await import("./abstract/connection-pool.js");
-    adapter.pool = new NullPool() as unknown as ConnectionPool;
+    adapter.pool = new NullPool();
     (
       adapter as unknown as { getDatabaseVersion: () => InstanceType<typeof Version> }
     ).getDatabaseVersion = () => new Version("5.6.3");
@@ -827,7 +826,7 @@ describe("AbstractMysqlAdapter#checkVersion", () => {
       typeof AbstractMysqlAdapter
     >;
     const { NullPool } = await import("./abstract/connection-pool.js");
-    adapter.pool = new NullPool() as unknown as ConnectionPool;
+    adapter.pool = new NullPool();
     (
       adapter as unknown as { getDatabaseVersion: () => InstanceType<typeof Version> }
     ).getDatabaseVersion = () => new Version("5.6.4");

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -675,12 +675,12 @@ export class SchemaStatements {
   async changeColumnDefault(
     tableName: string,
     columnName: string,
-    options: { from?: unknown; to: unknown } | unknown,
+    defaultOrChanges: unknown,
   ): Promise<void> {
     // Rails unwraps a Hash to its :to only when it carries BOTH :from and :to
     // (extract_new_default_value, schema_statements.rb:1820); a bare structured
     // default like `{ to: 1 }` without :from is the literal default.
-    const defaultVal = this.extractNewDefaultValue(options);
+    const defaultVal = this.extractNewDefaultValue(defaultOrChanges);
     const clause = await this.quoteDefaultExpression(defaultVal);
     await this.execute(
       `ALTER TABLE ${this.quoteColumnName(tableName)} ALTER COLUMN ${this.quoteColumnName(columnName)} SET DEFAULT ${clause || "NULL"}`,

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -658,14 +658,14 @@ export abstract class Migration {
   async changeColumnDefault(
     tableName: string,
     columnName: string,
-    options: { from?: unknown; to: unknown } | unknown,
+    defaultOrChanges: unknown,
   ): Promise<void> {
     if (this._recording) {
-      this._recorder.record("changeColumnDefault", [tableName, columnName, options]);
+      this._recorder.record("changeColumnDefault", [tableName, columnName, defaultOrChanges]);
       return;
     }
     tableName = this._pt(tableName);
-    await this.connection.changeColumnDefault(tableName, columnName, options);
+    await this.connection.changeColumnDefault(tableName, columnName, defaultOrChanges);
   }
 
   async changeColumnNull(
@@ -2597,10 +2597,7 @@ export class Migrator {
     if (this._internalMetadata.enabled) {
       // `NullConfig#env_name` is nil for a bare-adapter Migrator, as in Rails
       // (`abstract/connection_pool.rb:17-22`); the cast narrows, it does not default.
-      await this._internalMetadata.set(
-        "environment",
-        this.connection.pool.dbConfig.envName as string,
-      );
+      await this._internalMetadata.set("environment", this.connection.pool.dbConfig.envName);
     }
   }
 

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2597,7 +2597,10 @@ export class Migrator {
     if (this._internalMetadata.enabled) {
       // `NullConfig#env_name` is nil for a bare-adapter Migrator, as in Rails
       // (`abstract/connection_pool.rb:17-22`); the cast narrows, it does not default.
-      await this._internalMetadata.set("environment", this.connection.pool.dbConfig.envName);
+      await this._internalMetadata.set(
+        "environment",
+        this.connection.pool.dbConfig.envName as string,
+      );
     }
   }
 


### PR DESCRIPTION
Two small fixes in `activerecord`.

### 1. `changeColumnDefault` takes `defaultOrChanges`

`options: { from?: unknown; to: unknown } | unknown` collapses to `unknown`, so
the descriptor arm constrained nothing. Dropped to a bare `unknown` — Rails
makes the descriptor-vs-literal call at runtime in `extract_new_default_value`
(`schema_statements.rb:1820-1827`, unwraps only when the hash carries **both**
`:from` and `:to`), so `{ to: 1 }` is a legitimate structured default and the
value arm genuinely cannot be narrowed. Parameter renamed to `defaultOrChanges`
at every declaration/override (`abstract/schema-statements.ts`, the
`AbstractAdapter` interface, `Migration#changeColumnDefault`) to match Rails'
`default_or_changes`; the PG/MySQL/SQLite overrides and
`changeColumnDefaultForAlter` already used the Rails name. The two `{ to: 1 }`
call sites still typecheck and still land the literal default.

### 2. `collection-proxy.test.ts` no longer pins the row order of an unordered SELECT

`Author.posts` has no `-> { order(...) }` scope (`test/models/author.rb`), so
its SELECT has no `ORDER BY` and PG may return any order — observed as
`['c','a','b']` on #6199's PG lane. Assertions now compare sets (`.sort()`) or
read positions back off the loaded target, which is what the index / `at` /
`slice` tests are actually about. No `order` scope added to the canonical
models, and no test names changed.

Closes-story: change-column-default-descriptor-arm-absorbed-by-unknown
Closes-story: collection-proxy-asserts-order-of-unordered-association

### Dropped from this PR

**`abstract-adapter-role-shard-cast-hides-ruby-nomethoderror`** — the review is
right and the attempt is reverted. Declaring `pool: ConnectionPool` and moving
the cast onto the `NullPool` seed made the readers bare without changing
anything at runtime, while asserting `ConnectionPool` for *every* `this.pool.x`
reader — which makes the failure mode the story exists to close easier to
introduce, not harder — and multiplied the cast across six sites. That is
criterion 2 satisfied cosmetically and criterion 1 (routing the pool-less
construction sites through real pools) untouched, and criterion 1 is the whole
story. It is also bigger than the estimate: several of those sites are
pool-less by design — `support/schema-conn.ts` builds an adapter that is never
connected, `newRawTestAdapter` is raw on purpose, and
`support/second-connection.ts` needs Rails' `pool.checkout` ported first — so a
real `ConnectionPool` there is a behavioural change, not wiring. The story is
back to `ready` with those findings appended to its body, sequenced behind
`create-and-migrate-adapters-carry-a-real-pool`. `migration.ts:2597`'s
`envName as string` cast is restored with it.

**`move-adapter-specific-snapshot-off-ar-internal-metadata`** — released
unbuilt; its own findings block says it must be its own PR (the `loadSchema` /
`canonical-schema-stamp` / `test-setup-dy` seam is reshaped one story at a
time).
