### PR TITLE
refactor(date,activesupport): c_civil_to_jd/c_jd_to_civil and c_ordinal_to_jd at their Rails names; port ToJsonWithActiveSupportEncoder

### DIFF
--- a/packages/actionpack/src/action-dispatch/journey/gtg/transition-table.test.ts
+++ b/packages/actionpack/src/action-dispatch/journey/gtg/transition-table.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { ActiveSupportJSON } from "@blazetrails/activesupport";
 import { Parser } from "../parser.js";
 import { Or } from "../nodes/node.js";
 import { Builder } from "./builder.js";
@@ -59,7 +60,7 @@ describe("ActionDispatch::Journey::GTG::TransitionTable", () => {
       "/articles/:id/edit(.:format)",
       "/articles/:id(.:format)",
     ]);
-    const json = t.toJSON() as {
+    const json = ActiveSupportJSON.decode(t.toJSON() as string) as {
       regexp_states: Record<string, Record<string, number>>;
       string_states: Record<string, Record<string, number>>;
       stdparam_states: Record<string, Record<string, number>>;

--- a/packages/actionpack/src/action-dispatch/journey/gtg/transition-table.ts
+++ b/packages/actionpack/src/action-dispatch/journey/gtg/transition-table.ts
@@ -43,16 +43,17 @@ function anchorPreservingFlags(re: RegExp): RegExp {
   return new RegExp(`^(?:${re.source})$`, flags.join(""));
 }
 
-/**
- * Generalized Transition table — the DFA produced by Builder. Implements the
- * `TransitionTableLike` shape that `Simulator` consumes. Mirrors Rails'
- * `ActionDispatch::Journey::GTG::TransitionTable`.
- */
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging -- Ruby `include` (json.rb:47-49); the class/interface merge is how `include()` surfaces on the type side.
 export interface TransitionTable {
   /** `ActiveSupport::ToJsonWithActiveSupportEncoder#to_json` (json.rb:35-43). */
   toJSON: Included<typeof ToJsonWithActiveSupportEncoder>["toJSON"];
 }
+
+/**
+ * Generalized Transition table — the DFA produced by Builder. Implements the
+ * `TransitionTableLike` shape that `Simulator` consumes. Mirrors Rails'
+ * `ActionDispatch::Journey::GTG::TransitionTable`.
+ */
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class TransitionTable implements TransitionTableLike, DotHost {
   /** @internal */

--- a/packages/actionpack/src/action-dispatch/journey/gtg/transition-table.ts
+++ b/packages/actionpack/src/action-dispatch/journey/gtg/transition-table.ts
@@ -1,4 +1,9 @@
-import { getChildProcess } from "@blazetrails/activesupport";
+import {
+  getChildProcess,
+  include,
+  ToJsonWithActiveSupportEncoder,
+  type Included,
+} from "@blazetrails/activesupport";
 import { toDot, type DotHost, type DotTransition } from "../nfa/dot.js";
 import { Symbol as SymbolNode, Terminal, type Node } from "../nodes/node.js";
 import { renderVisualizer } from "../visualizer.js";
@@ -43,6 +48,12 @@ function anchorPreservingFlags(re: RegExp): RegExp {
  * `TransitionTableLike` shape that `Simulator` consumes. Mirrors Rails'
  * `ActionDispatch::Journey::GTG::TransitionTable`.
  */
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging -- Ruby `include` (json.rb:47-49); the class/interface merge is how `include()` surfaces on the type side.
+export interface TransitionTable {
+  /** `ActiveSupport::ToJsonWithActiveSupportEncoder#to_json` (json.rb:35-43). */
+  toJSON: Included<typeof ToJsonWithActiveSupportEncoder>["toJSON"];
+}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class TransitionTable implements TransitionTableLike, DotHost {
   /** @internal */
   private readonly _stdparamStates = new Map<number, Map<RegExp, number>>();
@@ -211,10 +222,6 @@ export class TransitionTable implements TransitionTableLike, DotHost {
     };
   }
 
-  toJSON(): Record<string, unknown> {
-    return this.asJson();
-  }
-
   /**
    * Render the DFA as SVG by shelling out to the Graphviz `dot` binary, the
    * same way Rails does. Returns an empty string when `dot` is unavailable
@@ -263,7 +270,7 @@ export class TransitionTable implements TransitionTableLike, DotHost {
     });
     return renderVisualizer({
       title,
-      states: `function tt() { return ${JSON.stringify(this.asJson())}; }`,
+      states: `function tt() { return ${this.toJSON()}; }`,
       svg: this.toSvg(),
       funRoutes,
       paths: paths.map((p) => p.toString()),
@@ -287,3 +294,5 @@ function sample<T>(xs: readonly T[], n: number): T[] {
   }
   return out;
 }
+
+include(TransitionTable, ToJsonWithActiveSupportEncoder);

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -244,17 +244,18 @@ function _xmlTypeInfo(
   return { types, nested };
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging -- Ruby `include` (json.rb:47-49); the class/interface merge is how `include()` surfaces on the type side.
+export interface Model {
+  /** `ActiveSupport::ToJsonWithActiveSupportEncoder#to_json` (json.rb:35-43). */
+  toJSON: Included<typeof ToJsonWithActiveSupportEncoder>["toJSON"];
+}
+
 /**
  * Model — the base class that bundles Attributes, Validations, Callbacks,
  * Dirty tracking, Serialization, and Naming.
  *
  * Mirrors: ActiveModel::Model (with all the included modules)
  */
-// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging -- Ruby `include` (json.rb:47-49); the class/interface merge is how `include()` surfaces on the type side.
-export interface Model {
-  /** `ActiveSupport::ToJsonWithActiveSupportEncoder#to_json` (json.rb:35-43). */
-  toJSON: Included<typeof ToJsonWithActiveSupportEncoder>["toJSON"];
-}
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class Model {
   // Allow dynamic attribute access (e.g., record.title) for properties

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -21,6 +21,9 @@ import {
   type XmlTypeInfo,
   resetCallbacks as asResetCallbacks,
   withOptions,
+  include,
+  ToJsonWithActiveSupportEncoder,
+  type Included,
 } from "@blazetrails/activesupport";
 import {
   humanAttributeName as translationHumanAttributeName,
@@ -247,6 +250,12 @@ function _xmlTypeInfo(
  *
  * Mirrors: ActiveModel::Model (with all the included modules)
  */
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging -- Ruby `include` (json.rb:47-49); the class/interface merge is how `include()` surfaces on the type side.
+export interface Model {
+  /** `ActiveSupport::ToJsonWithActiveSupportEncoder#to_json` (json.rb:35-43). */
+  toJSON: Included<typeof ToJsonWithActiveSupportEncoder>["toJSON"];
+}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class Model {
   // Allow dynamic attribute access (e.g., record.title) for properties
   // defined at runtime via Model.attribute().
@@ -2270,17 +2279,6 @@ export class Model {
   }
 
   /**
-   * JSON.stringify hook — delegates to `asJson()` so
-   * `JSON.stringify(model)` produces the same output as
-   * `model.toJson()`. Without this, the default walker would
-   * enumerate internal fields (`_attributes`, `_dirty`, `errors`, …)
-   * and potentially throw on BigInt attributes.
-   */
-  toJSON(): unknown {
-    return this.asJson();
-  }
-
-  /**
    * Deserialize a JSON string into this model's attributes.
    *
    * Mirrors: ActiveModel::Serializers::JSON#from_json (json.rb:144-149)
@@ -2625,3 +2623,5 @@ function _rejectOnOption(conditions?: CallbackConditions): void {
     throw new ArgumentError("Unknown key: :on. Valid keys are: :if, :unless, :prepend");
   }
 }
+
+include(Model, ToJsonWithActiveSupportEncoder);

--- a/packages/activemodel/src/naming.ts
+++ b/packages/activemodel/src/naming.ts
@@ -4,6 +4,9 @@ import {
   singularize,
   humanize,
   Inflections,
+  include,
+  ToJsonWithActiveSupportEncoder,
+  type Included,
 } from "@blazetrails/activesupport";
 import { ArgumentError } from "./attribute-assignment.js";
 
@@ -75,6 +78,12 @@ export interface ModelLike {
   modelName?: ModelName;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging -- Ruby `include` (json.rb:47-49); the class/interface merge is how `include()` surfaces on the type side.
+export interface ModelName {
+  /** `ActiveSupport::ToJsonWithActiveSupportEncoder#to_json` (json.rb:35-43). */
+  toJSON: Included<typeof ToJsonWithActiveSupportEncoder>["toJSON"];
+}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class ModelName {
   /** Bare class name (no separators), e.g. `"Post"`. */
   readonly name: string;
@@ -410,9 +419,6 @@ export class ModelName {
     // the single-string sort key Rails' `String#<=>` compares.
     return mn.name;
   }
-
-  /** JSON.stringify hook — delegates to `asJson`. */
-  toJSON(): string {
-    return this.asJson();
-  }
 }
+
+include(ModelName, ToJsonWithActiveSupportEncoder);

--- a/packages/activesupport/src/core-ext/object/json.ts
+++ b/packages/activesupport/src/core-ext/object/json.ts
@@ -1,5 +1,6 @@
 import { Temporal } from "@blazetrails/date";
 
+import { ActiveSupportJSON } from "../../json.js";
 import { Encoding, type EncodeOptions } from "../../json/encoding.js";
 
 /**
@@ -12,6 +13,43 @@ import { Encoding, type EncodeOptions } from "../../json/encoding.js";
  * — the same shape `core-ext/object/blank.ts` uses for `blank?`/`present?` —
  * and the free `asJson()` below stands in for Ruby's method lookup.
  */
+
+/**
+ * The receiver `ToJsonWithActiveSupportEncoder#to_json` is mixed into.
+ * Ruby's `super` reaches the JSON gem's `to_json`; the JS analogue is the
+ * receiver's own `as_json` value, which `JSON.stringify` then serializes.
+ */
+export interface ToJsonWithActiveSupportEncoderHost {
+  asJson(options?: EncodeOptions | null): unknown;
+}
+
+/**
+ * `ActiveSupport::ToJsonWithActiveSupportEncoder#to_json` (json.rb:35-43),
+ * the hook that routes `to_json` through ActiveSupport's encoder rather than
+ * the JSON gem's. Ruby includes it into `[Enumerable, Object, Array,
+ * FalseClass, Float, Hash, Integer, NilClass, String, TrueClass]`
+ * (json.rb:47-49); TypeScript cannot reopen built-ins, so it is assigned onto
+ * the classes of ours that define an `asJson` (the mixin idiom — a
+ * `this`-typed function).
+ *
+ * Ruby discriminates on `::JSON::State`, the argument the JSON gem's encoder
+ * passes. `JSON.stringify` has no state object: it calls `toJSON(key)` with
+ * the property key, a string — so the string is the discriminator here.
+ */
+export const ToJsonWithActiveSupportEncoder = {
+  toJSON(
+    this: ToJsonWithActiveSupportEncoderHost,
+    options?: EncodeOptions | string | null,
+  ): unknown {
+    if (typeof options === "string") {
+      // Called from JSON.stringify, forward it to the JSON serializer
+      return this.asJson();
+    } else {
+      // to_json is being invoked directly, use ActiveSupport's encoder
+      return ActiveSupportJSON.encode(this, options ?? undefined);
+    }
+  },
+};
 
 /**
  * `Object#as_json` (json.rb:58-66).

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -231,6 +231,11 @@ export {
 } from "./hash-utils.js";
 
 export {
+  ToJsonWithActiveSupportEncoder,
+  type ToJsonWithActiveSupportEncoderHost,
+} from "./core-ext/object/json.js";
+
+export {
   wrap,
   inGroupsOf,
   inGroups,

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -115,10 +115,10 @@ function msecs(subject: StrftimeSubject): number {
  * @internal `m_local_jd` (`date_core.c:1485-1497`), the Julian day the
  * week-number readers below work off. The subject carries the civil date and no
  * `df`, so the `complex_dat_p` arm's `local_jd` shift has no bearer and the
- * conversion is {@link jdOf} over it.
+ * conversion is {@link cCivilToJd} over it.
  */
 function mLocalJd(subject: StrftimeSubject): number {
-  return jdOf(new Temporal.PlainDate(subject.year, subject.mon, subject.day));
+  return cCivilToJd(subject.year, subject.mon, subject.day);
 }
 
 /**
@@ -2740,8 +2740,8 @@ function completeFrags(parts: DateParts): void {
       cwyear: d.yearOfWeek ?? undefined,
       cweek: d.weekOfYear ?? undefined,
       cwday: d.dayOfWeek,
-      wnum0: cJdToWeeknum(jdOf(d), 0)[1],
-      wnum1: cJdToWeeknum(jdOf(d), 1)[1],
+      wnum0: cJdToWeeknum(cCivilToJd(d.year, d.month, d.day), 0)[1],
+      wnum1: cJdToWeeknum(cCivilToJd(d.year, d.month, d.day), 1)[1],
     };
 
     if (k === "ordinal") {
@@ -2762,7 +2762,8 @@ function completeFrags(parts: DateParts): void {
       parts.cweek ??= 1;
       parts.cwday ??= 1;
     } else if (k === "wday") {
-      parts.jd = jdOf(d.subtract({ days: d.dayOfWeek % 7 }).add({ days: parts.wday as number }));
+      const w = d.subtract({ days: d.dayOfWeek % 7 }).add({ days: parts.wday as number });
+      parts.jd = cCivilToJd(w.year, w.month, w.day);
     } else if (k === "wnum0") {
       for (const el of a) {
         if (parts[el] !== undefined) break;
@@ -2874,24 +2875,26 @@ function dfToTime(df: number): [h: number, min: number, s: number] {
 }
 
 /**
- * @internal Ruby `Date#jd` (`date_core.c` `d_lite_jd`, `date_core.c:5249`), the
- * reader `rt_complete_frags`' `:wday` branch takes its `:jd` off. `Temporal` has
- * no Julian day, so the number is the day count from the Unix epoch Ruby
- * anchors its own `Time`-to-`:jd` conversion on.
+ * @internal `date_core.c` `c_civil_to_jd` (`date_core.c:502-524`), the Julian
+ * day of the civil date `y`-`m`-`d`. The C's `jd -= b` correction rides on the
+ * calendar-reform start `sg`, and its `ns` out-parameter reports which side of
+ * the reform the answer landed on; `Temporal.PlainDate` is proleptic Gregorian
+ * and carries no reform, so neither has a bearer here and the conversion is the
+ * day count from the Unix epoch {@link UNIX_EPOCH_IN_CJD} numbers.
  */
-function jdOf(d: Temporal.PlainDate): number {
-  return UNIX_EPOCH_IN_CJD + d.since(UNIX_EPOCH).days;
+function cCivilToJd(y: number, m: number, d: number): number {
+  return UNIX_EPOCH_IN_CJD + new Temporal.PlainDate(y, m, d).since(UNIX_EPOCH).days;
 }
 
 /**
- * @internal The inverse of {@link jdOf}. ruby/date reads a Julian day back as a
- * civil date through `c_jd_to_civil` (`date_core.c:526-555`), whose century
- * correction is skipped for a day before the calendar-reform start `sg` — the
- * Julian arm. `Temporal.PlainDate` is proleptic Gregorian and carries no reform,
- * so the arm has no bearer here and the conversion is the day count alone.
+ * @internal `date_core.c` `c_jd_to_civil` (`date_core.c:526-554`), the inverse
+ * of {@link cCivilToJd}; the `ry`/`rm`/`rdom` out-parameters come back as the
+ * tuple. The C's `jd < sg` arm skips the century correction for a day before
+ * the calendar reform and has no bearer here, as on {@link cCivilToJd}.
  */
-function jdToPlainDate(jd: number): Temporal.PlainDate {
-  return UNIX_EPOCH.add({ days: jd - UNIX_EPOCH_IN_CJD });
+function cJdToCivil(jd: number): [ry: number, rm: number, rdom: number] {
+  const r = UNIX_EPOCH.add({ days: jd - UNIX_EPOCH_IN_CJD });
+  return [r.year, r.month, r.day];
 }
 
 /** @internal `date_core.c`'s `DIV` macro (`date_core.c:168-170`), floored division. */
@@ -3012,18 +3015,24 @@ function num2intWithFrac(
  * negative `d` counts back from the last day of the year — `-1` is 31 December
  * — and is rejected when the walk leaves `y`.
  *
- * Ruby rejects by round-tripping back through `c_jd_to_ordinal`
- * (`date_core.c:566-575`), which is how a walk that left `y` comes back naming
- * a different year. `Temporal.PlainDate` is proleptic Gregorian, so that round
- * trip collapses to reading `#year` back.
+ * Ruby rejects by round-tripping back through {@link cJdToOrdinal}, which is
+ * how a walk that left `y` comes back naming a different year.
  */
 function cValidOrdinalP(y: number, d: number): Temporal.PlainDate | null {
-  const fdoy = jdToPlainDate(cFindFdoy(y));
-  if (d < 0) d = fdoy.daysInYear + d + 1;
-  if (d < 1) return null;
-  const r = fdoy.add({ days: d - 1 });
-  if (r.year !== y) return null;
-  return r;
+  let ry2: number;
+  let rd2: number;
+
+  if (d < 0) {
+    const rjd2 = cFindLdoy(y);
+
+    [ry2, rd2] = cJdToOrdinal(rjd2 + d + 1);
+    if (ry2 !== y) return null;
+    d = rd2;
+  }
+  const rjd = cOrdinalToJd(y, d);
+  [ry2, rd2] = cJdToOrdinal(rjd);
+  if (ry2 !== y || rd2 !== d) return null;
+  return new Temporal.PlainDate(...cJdToCivil(rjd));
 }
 
 /**
@@ -3032,10 +3041,41 @@ function cValidOrdinalP(y: number, d: number): Temporal.PlainDate | null {
  * reform can delete 1 January itself; `Temporal.PlainDate` is proleptic
  * Gregorian and carries no reform, so the scan collapses to 1 January. The C's
  * `sg` argument and its `ns` out-parameter both ride on that reform and have no
- * bearer here, as on {@link jdToPlainDate}.
+ * bearer here, as on {@link cJdToCivil}.
  */
 function cFindFdoy(y: number): number {
-  return jdOf(new Temporal.PlainDate(y, 1, 1));
+  return cCivilToJd(y, 1, 1);
+}
+
+/**
+ * @internal `date_core.c` `c_find_ldoy` (`date_core.c:467-476`), the Julian day
+ * of the last day of year `y`. As on {@link cFindFdoy}, Ruby scans December
+ * backwards because the calendar reform can delete 31 December itself and the
+ * scan collapses to 31 December here.
+ */
+function cFindLdoy(y: number): number {
+  return cCivilToJd(y, 12, 31);
+}
+
+/**
+ * @internal `date_core.c` `c_ordinal_to_jd` (`date_core.c:556-564`), the Julian
+ * day of the `d`th day of year `y`. The C's `ns` out-parameter reports which
+ * side of the calendar reform the answer landed on and has no bearer here, as
+ * on {@link cCivilToJd}.
+ */
+function cOrdinalToJd(y: number, d: number): number {
+  return cFindFdoy(y) + d - 1;
+}
+
+/**
+ * @internal `date_core.c` `c_jd_to_ordinal` (`date_core.c:566-575`), the
+ * inverse of {@link cOrdinalToJd}; the `ry`/`rd` out-parameters come back as
+ * the tuple.
+ */
+function cJdToOrdinal(jd: number): [ry: number, rd: number] {
+  const [ry] = cJdToCivil(jd);
+  const rjd = cFindFdoy(ry);
+  return [ry, jd - rjd + 1];
 }
 
 /**
@@ -3051,7 +3091,7 @@ function cCommercialToJd(y: number, w: number, d: number): number {
 
 /** @internal `date_core.c` `c_jd_to_commercial` (`date_core.c:590-609`), the inverse of {@link cCommercialToJd}. */
 function cJdToCommercial(jd: number): [ry: number, rw: number, rd: number] {
-  const a = jdToPlainDate(jd - 3).year;
+  const [a] = cJdToCivil(jd - 3);
   let ry: number;
   let c2 = cCommercialToJd(a + 1, 1, 1);
   if (jd >= c2) ry = a + 1;
@@ -3081,7 +3121,7 @@ function cValidCommercialP(y: number, w: number, d: number): Temporal.PlainDate 
   const rjd = cCommercialToJd(y, w, d);
   const [ry, rw, rd] = cJdToCommercial(rjd);
   if (y !== ry || w !== rw || d !== rd) return null;
-  return jdToPlainDate(rjd);
+  return new Temporal.PlainDate(...cJdToCivil(rjd));
 }
 
 /**
@@ -3099,7 +3139,7 @@ function cWeeknumToJd(y: number, w: number, d: number, f: number): number {
 
 /** @internal `date_core.c` `c_jd_to_weeknum` (`date_core.c:621-634`), the inverse of {@link cWeeknumToJd}. */
 function cJdToWeeknum(jd: number, f: number): [ry: number, rw: number, rd: number] {
-  const ry = jdToPlainDate(jd).year;
+  const [ry] = cJdToCivil(jd);
   const rjd = cFindFdoy(ry) + 6;
   const j = jd - (rjd - mod(rjd - f + 1, 7)) + 7;
   return [ry, div(j, 7), mod(j, 7)];
@@ -3122,7 +3162,7 @@ function cValidWeeknumP(y: number, w: number, d: number, f: number): Temporal.Pl
   const rjd = cWeeknumToJd(y, w, d, f);
   const [ry, rw, rd] = cJdToWeeknum(rjd, f);
   if (y !== ry || w !== rw || d !== rd) return null;
-  return jdToPlainDate(rjd);
+  return new Temporal.PlainDate(...cJdToCivil(rjd));
 }
 
 /**
@@ -3131,7 +3171,7 @@ function cValidWeeknumP(y: number, w: number, d: number, f: number): Temporal.Pl
  * to reject.
  */
 function rtValidJdP(jd: number): Temporal.PlainDate {
-  return jdToPlainDate(jd);
+  return new Temporal.PlainDate(...cJdToCivil(jd));
 }
 
 /**
@@ -3516,7 +3556,7 @@ export class Date {
    * so the conversion happens at the call.
    */
   static jd(jd = 0): Date {
-    return new Date(jdToPlainDate(jd));
+    return new Date(new Temporal.PlainDate(...cJdToCivil(jd)));
   }
 
   /**

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -2762,8 +2762,8 @@ function completeFrags(parts: DateParts): void {
       parts.cweek ??= 1;
       parts.cwday ??= 1;
     } else if (k === "wday") {
-      const w = d.subtract({ days: d.dayOfWeek % 7 }).add({ days: parts.wday as number });
-      parts.jd = cCivilToJd(w.year, w.month, w.day);
+      const d2 = d.subtract({ days: d.dayOfWeek % 7 }).add({ days: parts.wday as number });
+      parts.jd = cCivilToJd(d2.year, d2.month, d2.day);
     } else if (k === "wnum0") {
       for (const el of a) {
         if (parts[el] !== undefined) break;


### PR DESCRIPTION
Three JDN/JSON fidelity ports, plus one story closed as already-fixed in main.

### `packages/date` — the JDN conversions at their C names

`jdOf` / `jdToPlainDate` were invented names standing in for the ruby/date C
functions every JDN site in the file goes through. Renamed to their C names with
the C's argument lists:

- `cCivilToJd(y, m, d)` — `date_core.c:502-524`
- `cJdToCivil(jd)` → `[ry, rm, rdom]` — `date_core.c:526-554`

`Temporal.PlainDate` stays the substrate; only the name and signature changed, so
no behavior moves. The C's `jd -= b` correction and its `jd < sg` Julian arm are
reform-only and stay unported, as the old docstring already recorded.

Callers updated: `mLocalJd`, `rtCompleteFrags`' `wnum0`/`wnum1`/`wday` arms,
`cFindFdoy`, `cJdToCommercial`, `cValidCommercialP`, `cJdToWeeknum`,
`cValidWeeknumP`, `rtValidJdP`, `Date.jd`.

### `packages/date` — `c_ordinal_to_jd` behind `c_valid_ordinal_p`

`cValidOrdinalP` was the odd validator out: its siblings round-trip through
`cJdToCommercial` / `cJdToWeeknum`, but it read `Temporal.PlainDate#year` back
because it had no `cJdToOrdinal` to call. Ported the missing halves —
`cOrdinalToJd` (`date_core.c:556-564`), `cJdToOrdinal` (`566-575`) and
`cFindLdoy` (`467-476`) — and rewrote `cValidOrdinalP` as the C is
(`674-695`): normalize a negative `d` off the last day of the year, build the
jd, read it back, reject when `ry2`/`rd2` disagree. The old `d < 1` guard is
what the C's round-trip rejection already answers.

### `packages/activesupport` — `ToJsonWithActiveSupportEncoder`

Ported `ActiveSupport::ToJsonWithActiveSupportEncoder#to_json`
(`core_ext/object/json.rb:34-45`) — the hook that routes `to_json` through
ActiveSupport's encoder rather than the JSON gem's — and `include()`d it into
`ActiveModel::Name`, `ActiveModel::Model` and
`Journey::GTG::TransitionTable`, retiring the hand-rolled `toJSON` delegates
each of them carried (`naming.ts:414`, `model.ts:2278`,
`transition-table.ts:213`), which were three local re-derivations of the same
Rails module.

Ruby discriminates on `::JSON::State`, the argument the JSON gem's encoder
passes. `JSON.stringify` has no state object — it calls `toJSON(key)` with the
property key, a **string** — so the string is the discriminator here, and that
arm returns the `as_json` value for `stringify` to serialize (Ruby's `super`).
The direct arm returns `ActiveSupport::JSON.encode(self, options)`.

Two call sites converged onto it while in there:
`transition_table.rb:132` interpolates `#{to_json}` into the visualizer's
`function tt()`, and the Rails test decodes `table.to_json`
(`transition_table_test.rb:18`) — both now do the same.

`core_ext/object/json.rb` moves 1/6 → 2/6; `api:extra` reports 0 novel names in
that file; `api:calls` ratchet OK.

### `mysql-warning-count-mismatch-did-not-raise` — no work, already fixed

The failing MariaDB run cited in the story is from branch
`remove-global-reset-and-skip-shield-after-canonical-bur-1de1`, i.e. #5719's own
branch, and #5719 diagnosed and fixed the root cause in that same branch before
merging (`8ba1938e4`): MariaDB, unlike MySQL, leaves the previous statement's
diagnostics area in place when the next statement reads no table, so the
note-level case's `DROP TABLE IF EXISTS` Note 1051 was still what `SHOW
WARNINGS` returned for the mismatch case's `SELECT 'x'` — a non-empty warning
list, no mismatch, `execute` resolves. The `beforeEach` now clears it with a
derived-table `SELECT`. Not a port divergence; nothing left to build, so it is
not part of this PR and was closed against #5719.

Closes-story: port-c-civil-to-jd-and-c-jd-to-civil-at-their-rails-names
Closes-story: port-c-ordinal-to-jd-behind-c-valid-ordinal-p
Closes-story: port-to-json-with-active-support-encoder
