### PR TITLE
feat(activesupport): port core_ext/object/instance_variables.rb; Module/BigDecimal/Enumerable as_json arms

### DIFF
--- a/packages/activesupport/src/core-ext/object/instance-variables.test.ts
+++ b/packages/activesupport/src/core-ext/object/instance-variables.test.ts
@@ -1,24 +1,19 @@
 import { describe, expect, it } from "vitest";
 
+import { Object } from "./instance-variables.js";
+
 describe("ObjectInstanceVariableTest", () => {
+  /** Rails' `setup` (instance_variables_test.rb:7-11). */
+  function source(): object {
+    return { bar: "bar", baz: "baz" };
+  }
+
   it("instance variable names", () => {
-    class Obj {
-      name = "test";
-      value = 42;
-    }
-    const o = new Obj();
-    expect(Object.keys(o)).toContain("name");
-    expect(Object.keys(o)).toContain("value");
+    expect(Object.instanceVariableNames(source()).sort()).toEqual(["bar", "baz"]);
   });
 
   it("instance values", () => {
-    class Obj {
-      a = 1;
-      b = "two";
-    }
-    const o = new Obj();
-    expect(Object.values(o)).toContain(1);
-    expect(Object.values(o)).toContain("two");
+    expect(Object.instanceValues(source())).toEqual({ bar: "bar", baz: "baz" });
   });
 
   it("instance exec passes arguments to block", () => {
@@ -41,7 +36,7 @@ describe("ObjectInstanceVariableTest", () => {
   });
 
   it("instance exec with frozen obj", () => {
-    const obj = Object.freeze({ x: 10 });
+    const obj = globalThis.Object.freeze({ x: 10 });
     expect(() => {
       function instanceExec<T, R>(o: T, fn: (this: T) => R): R {
         return fn.call(o);

--- a/packages/activesupport/src/core-ext/object/instance-variables.ts
+++ b/packages/activesupport/src/core-ext/object/instance-variables.ts
@@ -7,8 +7,12 @@
  *
  * JavaScript has no instance variables; an object's own enumerable properties
  * are the analogue, so `Object.keys` stands in for Ruby's `instance_variables`.
- * They carry no leading `@`, which is why `instanceValues` has no `[1..-1]` to
- * strip and `instanceVariableNames` returns the names as they are.
+ *
+ * Ruby's two readers differ by the leading `@`: `instance_values` strips it
+ * (`ivar[1..-1]`, :17) and `instance_variable_names` keeps it (`["@y", "@x"]`,
+ * :23). JS property names never carry one, so the distinction collapses and
+ * both return the bare name. Synthesizing an `@` would invent a sigil no JS
+ * reader — `Object.keys`, `in`, a bracket access — would accept back.
  */
 export class Object {
   /** `Object#instance_values` (instance_variables.rb:14-18). */
@@ -23,8 +27,9 @@ export class Object {
 
   /**
    * `Object#instance_variable_names` (instance_variables.rb:24-26). Ruby's
-   * `map(&:name)` turns each ivar Symbol into its String; `Object.keys` already
-   * yields strings, so the map is the identity.
+   * `map(&:name)` turns each ivar Symbol into its String — `:@y` into `"@y"`.
+   * `Object.keys` already yields strings, and there is no `@` on them, so the
+   * map has nothing left to do.
    */
   static instanceVariableNames(self: object): string[] {
     return globalThis.Object.keys(self).map((ivar) => ivar);

--- a/packages/activesupport/src/core-ext/object/instance-variables.ts
+++ b/packages/activesupport/src/core-ext/object/instance-variables.ts
@@ -1,0 +1,32 @@
+/**
+ * Rails' `core_ext/object/instance_variables.rb`, which reopens `Object`.
+ *
+ * TypeScript cannot reopen built-ins, so the body lives on a class of the same
+ * name with `static` methods taking the receiver — the shape
+ * `core-ext/object/blank.ts` and `core-ext/object/json.ts` both use.
+ *
+ * JavaScript has no instance variables; an object's own enumerable properties
+ * are the analogue, so `Object.keys` stands in for Ruby's `instance_variables`.
+ * They carry no leading `@`, which is why `instanceValues` has no `[1..-1]` to
+ * strip and `instanceVariableNames` returns the names as they are.
+ */
+export class Object {
+  /** `Object#instance_values` (instance_variables.rb:14-18). */
+  static instanceValues(self: object): Record<string, unknown> {
+    return globalThis.Object.fromEntries(
+      globalThis.Object.keys(self).map((ivar) => [
+        ivar,
+        (self as globalThis.Record<string, unknown>)[ivar],
+      ]),
+    );
+  }
+
+  /**
+   * `Object#instance_variable_names` (instance_variables.rb:24-26). Ruby's
+   * `map(&:name)` turns each ivar Symbol into its String; `Object.keys` already
+   * yields strings, so the map is the identity.
+   */
+  static instanceVariableNames(self: object): string[] {
+    return globalThis.Object.keys(self).map((ivar) => ivar);
+  }
+}

--- a/packages/activesupport/src/core-ext/object/json.ts
+++ b/packages/activesupport/src/core-ext/object/json.ts
@@ -119,7 +119,7 @@ export class Float {
  * always true.
  */
 export class BigDecimal {
-  static asJson(value: BigDecimalValue): string | null {
+  static asJson(value: BigDecimalValue): string {
     return value.toString();
   }
 }

--- a/packages/activesupport/src/core-ext/object/json.ts
+++ b/packages/activesupport/src/core-ext/object/json.ts
@@ -2,6 +2,8 @@ import { Temporal } from "@blazetrails/date";
 
 import { ActiveSupportJSON } from "../../json.js";
 import { Encoding, type EncodeOptions } from "../../json/encoding.js";
+import { BigDecimal as BigDecimalValue } from "../big-decimal/conversions.js";
+import * as instanceVariables from "./instance-variables.js";
 
 /**
  * Rails' `core_ext/object/json.rb` — the `as_json` layer
@@ -52,17 +54,22 @@ export const ToJsonWithActiveSupportEncoder = {
 };
 
 /**
- * `Object#as_json` (json.rb:58-66).
- *
- * `instance_values` (core_ext/object/instance_variables.rb:14-18) is unported;
- * a spread of the object's own enumerable properties is its analogue.
+ * `Module#as_json` (json.rb:52-56). A JS class or function is the Module
+ * analogue, and `name` is the same reader Ruby's is.
  */
+export class Module {
+  static asJson(value: { name: string }): string {
+    return value.name;
+  }
+}
+
+/** `Object#as_json` (json.rb:58-66). */
 export class Object {
   static asJson(value: object, options?: EncodeOptions | null): unknown {
     if (typeof (value as { toHash?: unknown }).toHash === "function") {
       return Hash.asJson((value as { toHash(): unknown }).toHash(), options);
     }
-    return Hash.asJson({ ...value }, options);
+    return Hash.asJson(instanceVariables.Object.instanceValues(value), options);
   }
 }
 
@@ -104,10 +111,33 @@ export class Float {
   }
 }
 
+/**
+ * `BigDecimal#as_json` (json.rb:124-137) — a JSON *string*, deliberately, so a
+ * client parsing non-integer JSON numbers as floats can still recover the exact
+ * value. trails' `BigDecimal` (core-ext/big-decimal/conversions.ts) holds
+ * normalized digit strings, so it has no infinite or NaN value and `finite?` is
+ * always true.
+ */
+export class BigDecimal {
+  static asJson(value: BigDecimalValue): string | null {
+    return value.toString();
+  }
+}
+
 /** `Regexp#as_json` (json.rb:139-143). */
 export class Regexp {
   static asJson(value: RegExp): string {
     return globalThis.String(value);
+  }
+}
+
+/**
+ * `Enumerable#as_json` (json.rb:145-149). Ruby's `Enumerable` is our iterable —
+ * a `Set`, a generator — and `[...value]` is its `to_a`.
+ */
+export class Enumerable {
+  static asJson(value: Iterable<unknown>, options?: EncodeOptions | null): unknown[] {
+    return Array.asJson([...value], options);
   }
 }
 
@@ -262,6 +292,8 @@ export function asJson(value: unknown, options?: EncodeOptions | null): unknown 
   if (typeof value === "number") return Float.asJson(value);
   if (typeof value === "bigint") return Numeric.asJson(value);
 
+  if (typeof value === "function") return Module.asJson(value as { name: string });
+
   // A class of our own that defines `as_json`, exactly as Ruby's would.
   const own = (value as { asJson?: (o?: unknown) => unknown }).asJson;
   if (typeof own === "function") return own.call(value, options ?? undefined);
@@ -271,10 +303,17 @@ export function asJson(value: unknown, options?: EncodeOptions | null): unknown 
   }
   if (value instanceof Temporal.PlainDate) return Date.asJson(value);
   if (value instanceof Temporal.PlainDateTime) return DateTime.asJson(value);
+  if (value instanceof BigDecimalValue) return BigDecimal.asJson(value);
   if (value instanceof RegExp) return Regexp.asJson(value);
   if (value instanceof Error) return Exception.asJson(value);
   if (globalThis.Array.isArray(value)) return Array.asJson(value, options);
   if (value instanceof Map || isPlainObject(value as object)) return Hash.asJson(value, options);
+  if (
+    typeof (value as { [globalThis.Symbol.iterator]?: unknown })[globalThis.Symbol.iterator] ===
+    "function"
+  ) {
+    return Enumerable.asJson(value as Iterable<unknown>, options);
+  }
 
   // A JS built-in carrying its own JSON form (`Date`, …). Ruby's counterparts
   // define `as_json`; calling `toJSON` reaches the same primitive, where

--- a/packages/activesupport/src/core-ext/object/json.ts
+++ b/packages/activesupport/src/core-ext/object/json.ts
@@ -292,11 +292,13 @@ export function asJson(value: unknown, options?: EncodeOptions | null): unknown 
   if (typeof value === "number") return Float.asJson(value);
   if (typeof value === "bigint") return Numeric.asJson(value);
 
-  if (typeof value === "function") return Module.asJson(value as { name: string });
-
-  // A class of our own that defines `as_json`, exactly as Ruby's would.
+  // A class of our own that defines `as_json`, exactly as Ruby's would. A
+  // `def self.as_json` singleton outranks `Module#as_json` in Ruby's lookup,
+  // so this precedes the Module arm.
   const own = (value as { asJson?: (o?: unknown) => unknown }).asJson;
   if (typeof own === "function") return own.call(value, options ?? undefined);
+
+  if (typeof value === "function") return Module.asJson(value as { name: string });
 
   if (value instanceof Temporal.Instant || value instanceof Temporal.ZonedDateTime) {
     return Time.asJson(value);

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -449,6 +449,7 @@ export {
   String as BlankString,
   Time as BlankTime,
 } from "./core-ext/object/blank.js";
+export { Object as InstanceVariablesObject } from "./core-ext/object/instance-variables.js";
 export { Delegator, Tryable } from "./core-ext/object/try.js";
 export {
   isDuplicable,

--- a/packages/activesupport/src/json/encoding.test.ts
+++ b/packages/activesupport/src/json/encoding.test.ts
@@ -5,6 +5,8 @@ import { Temporal } from "@blazetrails/date";
 import { TimeWithZone } from "../time-with-zone.js";
 import { TimeZone } from "../values/time-zone.js";
 import { Encoding } from "./encoding.js";
+import { asJson } from "../core-ext/object/json.js";
+import { BigDecimal } from "../core-ext/big-decimal/conversions.js";
 
 /** Rails' `JSONTest::Hashlike` (encoding_test_cases.rb:16-20). */
 class Hashlike {
@@ -17,6 +19,22 @@ class Hashlike {
 class Bare {
   foo?: string;
   bar?: string;
+}
+
+/** Rails' `JSONTest::People` (encoding_test.rb:227-240) — a bare Enumerable. */
+class People {
+  #people = [
+    { name: "John", address: { city: "London", country: "UK" } },
+    { name: "Jean", address: { city: "Paris", country: "France" } },
+  ];
+
+  each(): IterableIterator<unknown> {
+    return this.#people[Symbol.iterator]();
+  }
+
+  [Symbol.iterator](): IterableIterator<unknown> {
+    return this.each();
+  }
 }
 
 function withStandardJsonTimeFormat(value: boolean, block: () => void): void {
@@ -41,6 +59,24 @@ function withTimePrecision(value: number, block: () => void): void {
 
 describe("TestJSONEncoding", () => {
   it.skip("process status");
+
+  it("numeric", () => {
+    // Rails' NumericTests (encoding_test_cases.rb:62-72); the RomanNumeral /
+    // CustomNumeric cases need Ruby's `Numeric` subclassing and are unported.
+    expect(ActiveSupportJSON.encode(1)).toBe("1");
+    expect(ActiveSupportJSON.encode(2.5)).toBe("2.5");
+    expect(ActiveSupportJSON.encode(NaN)).toBe("null");
+    expect(ActiveSupportJSON.encode(Infinity)).toBe("null");
+    expect(ActiveSupportJSON.encode(-Infinity)).toBe("null");
+    expect(ActiveSupportJSON.encode(new BigDecimal("2.5"))).toBe('"2.5"');
+  });
+
+  it("module", () => {
+    // Rails' ModuleTests (encoding_test_cases.rb:95-98). Ruby's `name` is the
+    // fully-qualified constant path; a JS class carries only its own name.
+    expect(ActiveSupportJSON.encode(Hashlike)).toBe('"Hashlike"');
+    expect(ActiveSupportJSON.encode(People)).toBe('"People"');
+  });
 
   it("hash encoding", () => {
     const h = { a: 1, b: "hello" };
@@ -169,23 +205,28 @@ describe("TestJSONEncoding", () => {
   });
 
   it("enumerable should generate json with as json", () => {
-    const items = [1, 2, 3];
-    expect(JSON.stringify(items)).toBe("[1,2,3]");
+    const json = asJson(new People(), { only: ["address", "city"] });
+    const expected = [{ address: { city: "London" } }, { address: { city: "Paris" } }];
+
+    expect(json).toEqual(expected);
   });
 
   it("enumerable should generate json with to json", () => {
-    const items = ["a", "b", "c"];
-    expect(JSON.stringify(items)).toBe('["a","b","c"]');
+    const json = ActiveSupportJSON.encode(new People(), { only: ["address", "city"] });
+    expect(json).toBe('[{"address":{"city":"London"}},{"address":{"city":"Paris"}}]');
   });
 
   it("enumerable should pass encoding options to children in as json", () => {
-    const items = [{ x: 1 }, { y: 2 }];
-    expect(JSON.parse(JSON.stringify(items))).toEqual(items);
+    const json = asJson(new People().each(), { only: ["address", "city"] });
+    const expected = [{ address: { city: "London" } }, { address: { city: "Paris" } }];
+
+    expect(json).toEqual(expected);
   });
 
   it("enumerable should pass encoding options to children in to json", () => {
-    const items = [true, false, null];
-    expect(JSON.stringify(items)).toBe("[true,false,null]");
+    const json = ActiveSupportJSON.encode(new People().each(), { only: ["address", "city"] });
+
+    expect(json).toBe('[{"address":{"city":"London"}},{"address":{"city":"Paris"}}]');
   });
 
   it("hash to json should not keep options around", () => {

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/index.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/index.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "activesupport",
+    "tsFile": "index.ts",
+    "rubyName": "as_json",
+    "call": "instance_values",
+    "reason": "Comparator mis-resolution, not a body gap: Ruby `Object#as_json` pairs by bare short name with `TimeWithZone#asJson` (time-with-zone.ts), while the real port — `Object.asJson` in core-ext/object/json.ts — does call `instanceValues`. The flag surfaced only because `instance_values` became a ported method; tracked by `object-as-json-pairs-with-time-with-zone-as-json`."
+  }
+]

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -1351,11 +1351,6 @@ export const UNPORTED_FILES: UnportedFile[] = [
     reason: "Method-table surgery to silence redefinition warnings; JS reassignment is silent.",
   },
   {
-    pattern: "core_ext/object/instance_variables.rb",
-    package: "activesupport",
-    reason: "Reflects over Ruby `@ivars`; JS has no ivar namespace of its own.",
-  },
-  {
     pattern: "starts_ends_with.rb",
     package: "activesupport",
     reason: "Aliases `start_with?`/`end_with?` for Symbol and String; both are native JS.",


### PR DESCRIPTION
Ports `core_ext/object/instance_variables.rb` and three more `as_json` arms from
`core_ext/object/json.rb`.

## `instance_values` / `instance_variable_names`

New `packages/activesupport/src/core-ext/object/instance-variables.ts` with the
two bodies from `instance_variables.rb:14-18` and `:24-26`, as a class of the
Ruby name with `static` methods taking the receiver — the shape
`core-ext/object/blank.ts` and `core-ext/object/json.ts` already use. JS has no
ivars; own enumerable properties are the analogue, and they carry no leading
`@`, which is why there is no `[1..-1]` to strip.

`Object#as_json` (`json.rb:58-66`) now calls `Object.instanceValues(value)`
where it spread `{ ...value }` inline, and its stand-in JSDoc note is gone.
`scripts/api-compare/unported-files.ts`'s `core_ext/object/instance_variables.rb`
entry is deleted — the file is ported now, so the "no ivar namespace" reason no
longer holds.

## Remaining `as_json` arms

- `Module#as_json` (`json.rb:52-56`) — a JS class/function, `name`.
- `BigDecimal#as_json` (`json.rb:124-137`) — a JSON *string*, deliberately.
  trails' `BigDecimal` holds normalized digit strings, so `finite?` is always
  true.
- `Enumerable#as_json` (`json.rb:145-149`) — any iterable; `[...value]` is `to_a`.

Each gets its dispatcher branch, most-specific first.

Not ported, with no dispatchable JS analogue: `Data`, `Struct`, `IO`,
`URI::Generic`, `Pathname`, `Process::Status`; `Range` (trails' `Range` is a
bare `{ begin, end, excludeEnd }` interface, so it reaches the `Hash` arm and
cannot be discriminated at runtime); and `Symbol` (a Ruby Symbol is a JS string
in trails per CLAUDE.md, so the `String` arm already produces `name`). No `SKIP_GROUPS` /
`ScopedSkipGroup` entry — measured, not assumed. `api:compare` buckets all of
`json.rb` under two method names (`as_json`, `to_json`); the unported arms have
no member of their own to suppress. Adding
`{ names: ["as_json"], rubyFiles: ["core_ext/object/json.rb"] }` to
`SCOPED_SKIP_GROUPS` takes activesupport from **1014/2309 to 1013/2308** — it
removes the one *matched* `as_json` pair from the numerator and suppresses
nothing that was missing. That is the concrete false negative: the skip hides
the ported arm, which is the opposite of the criterion's intent. The `dirty.rb`
precedent differs because there Rails' `as_json` override is the whole of that
file's `as_json` surface, so skipping it costs no match.

## Tests

The four `enumerable should ...` tests in `json/encoding.test.ts` were array
stubs; they now run Rails' `People` Enumerable (`encoding_test.rb:227-271`)
verbatim. Adds `numeric` and `module` for `NumericTests` / `ModuleTests`
(`encoding_test_cases.rb:62-72,95-98`), minus the `RomanNumeral` /
`CustomNumeric` cases that need Ruby `Numeric` subclassing. No test renamed.

## Gates

`api:compare --package activesupport` 1011 → 1013 matched; arity mismatches
unchanged at 31; `api:extra --package activesupport` 0 novel in both files.

`api:calls` surfaced one new row, baselined at
`call-mismatches-exclude/activesupport/index.json`: Ruby `Object#as_json` pairs
by bare short name with `TimeWithZone#asJson`, not with the real port in
`core-ext/object/json.ts`, so the gate reads the wrong body. Filed as
`object-as-json-pairs-with-time-with-zone-as-json` (RFC 0072).

## `abstract-adapter-role-shard-cast-hides-ruby-nomethoderror` is blocked, not in this PR

Its criterion 2 (bare `this.pool.role`) can only land after criterion 1, and the
remaining pool-less construction sites are pool-less **by design** — a real
`ConnectionPool` is a behavioural change at each, not a wiring change. Retyping
the field was tried on #6207 and correctly rejected. Split into three stories
under RFC 0051 and blocked on them:
`schema-conn-adapters-carry-a-real-pool`,
`raw-test-and-second-connection-adapters-carry-a-real-pool`,
`template-global-setup-adapters-carry-a-real-pool`. The reader cast at
`abstract-adapter.ts:1406-1416` comes out when the last one lands.

Closes-story: port-object-instance-values-for-as-json
Closes-story: port-remaining-as-json-arms-in-object-json

