### PR TITLE
refactor(activerecord): raw/second test adapters carry a real pool; drop the awaitable flag on _assignAttribute

### DIFF
--- a/packages/activerecord/src/associations/collection-awaitable-writers.trails.test.ts
+++ b/packages/activerecord/src/associations/collection-awaitable-writers.trails.test.ts
@@ -123,6 +123,20 @@ describe("CollectionAwaitableWriters", () => {
     expect(() => author.assignAttributes({ posts: [post] })).toThrow(/unknown attribute `posts`/);
   });
 
+  it("refuses the association key in place, leaving earlier keys assigned", async () => {
+    // Rails' `_assign_attributes` is a plain `each_pair`
+    // (activemodel/attribute_assignment.rb:60-64): the raise happens when the
+    // loop reaches the offending key, so every key before it is already
+    // assigned. The refusal this surface owes `posts` must keep that order.
+    const author = (await Author.create({ name: "Bill" })) as unknown as CollectionOwner;
+    const post = await Post.create({ title: "t", body: "b" });
+
+    expect(() => author.assignAttributes({ name: "Bob", posts: [post] })).toThrow(
+      /unknown attribute `posts`/,
+    );
+    expect((author as unknown as { name: string }).name).toBe("Bob");
+  });
+
   it("keeps in-memory assignment on construction", async () => {
     // Rails defers here too (`replace_records` without a save — the FK isn't
     // known yet), so the constructor's in-memory arm is faithful and autosave

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -944,31 +944,33 @@ export function _reapplyNestedAttrSetters(
 }
 
 /**
- * The association arm of Rails' `public_send("#{key}=", value)`
- * (attribute_assignment.rb:67-69). RFC 0087 §1 removed the generated
- * `#{name}=` property setter for the writers that do I/O at assignment —
- * `replace`'s diffed deletes+inserts (collection_association.rb:46-48) and
- * `ids_writer`'s resolving query (:61-83) — because a JS property setter
- * cannot await them, so the dispatch reaches them by their association-level
- * Rails names here instead.
+ * Resolves the association arm of Rails' `public_send("#{key}=", value)`
+ * (attribute_assignment.rb:67-69) to the writer it would reach. RFC 0087 §1
+ * removed the generated `#{name}=` property setter for the writers that do I/O
+ * at assignment — `replace`'s diffed deletes+inserts
+ * (collection_association.rb:46-48) and `ids_writer`'s resolving query (:61-83)
+ * — because a JS property setter cannot await them, so the dispatch finds them
+ * by their association-level Rails names here instead.
+ *
+ * Resolution only: the writer is returned unsent, so `respond_to?(setter)` and
+ * `public_send(setter, v)` stay separate steps and every caller of
+ * `_assignAttribute` gets the same one behaviour.
  */
-function associationWriterPromise(
+function associationWriter(
   self: AttributeIO,
   key: string,
-  value: unknown,
-): Promise<void> | undefined {
+): ((value: unknown) => unknown) | undefined {
   const ctor = (self as any).constructor as typeof Base;
   for (const ref of reflectOnAllAssociations(ctor)) {
     const name = String(ref.name);
     if (ref.isCollection()) {
-      if (key === name) return (self as any).association(name).writer(value);
+      if (key === name) return (value) => (self as any).association(name).writer(value);
       if (key === `${singularize(name)}Ids`)
-        return (self as any).association(name).idsWriter(value);
+        return (value) => (self as any).association(name).idsWriter(value);
     } else if (key === name && ref.macro === "hasOne") {
       // Rails' `#{name}=` removes the displaced record and saves the new one
       // inline (has_one_association.rb:59-84).
-      const result: unknown = (self as any).association(name).writer(value);
-      return result instanceof Promise ? (result as Promise<void>) : undefined;
+      return (value) => (self as any).association(name).writer(value);
     }
   }
   return undefined;
@@ -993,24 +995,18 @@ function associationWriterPromise(
  * (has_one_association.rb:69) a write; that promise is returned rather than
  * dropped.
  */
-function _assignAttribute(
-  self: AttributeIO,
-  key: string,
-  value: unknown,
-  awaitable: boolean,
-): Promise<void> | void {
+function _assignAttribute(self: AttributeIO, key: string, value: unknown): Promise<void> | void {
   const configs = (self as any).constructor?._nestedAttributeConfigs as
     | { associationName: string }[]
     | undefined;
   if (configs?.some((c) => `${c.associationName}Attributes` === key)) {
     return (self as any)[`set${camelize(key, true)}`](value) as Promise<void> | void;
   }
-  // Only an awaited caller can resolve these keys to a writer at all (see
-  // `associationWriterPromise`). On the synchronous surface there is genuinely
-  // no method for the key, so `attribute_writer_missing`
-  // (attribute_assignment.rb:71-73) answers, as in Rails when a setter is absent.
-  const associationWrite = awaitable ? associationWriterPromise(self, key, value) : undefined;
-  if (associationWrite) return associationWrite;
+  const writer = associationWriter(self, key);
+  if (writer) {
+    const result: unknown = writer(value);
+    return result instanceof Promise ? (result as Promise<void>) : undefined;
+  }
   const setter = findPrototypeSetter(self, key);
   if (setter) {
     const result: unknown = setter.call(self, value);
@@ -1053,7 +1049,19 @@ export function assignAttributes(this: AttributeIO, attrs: Record<string, unknow
   // sanitizer, so a blank strong-params object is a no-op rather than raising;
   // `isMassAssignmentEmpty` reads a wrapper's contents, not its own fields.
   if (isMassAssignmentEmpty(attrs)) return;
-  for (const pending of _assignAttributes(this, sanitizeForMassAssignment(attrs), false)) {
+  const newAttributes = sanitizeForMassAssignment(attrs);
+  // The one place the synchronous surface parts company with the awaitable one,
+  // and it lives here rather than in the shared `_assign_attribute` port:
+  // RFC 0087 §1 left no `#{key}=` property setter for the association writers
+  // that do I/O at assignment (collection_association.rb:46-48, :61-83;
+  // has_one_association.rb:59-84), so on a surface that cannot await them
+  // `respond_to?(setter)` is genuinely false and the key falls through to
+  // `writeAttribute`, which raises for a name that is not an attribute. Sent
+  // ahead of the loop so the write is never started, only refused.
+  for (const [key, value] of Object.entries(newAttributes)) {
+    if (associationWriter(this, key)) this.writeAttribute(key, value);
+  }
+  for (const pending of _assignAttributes(this, newAttributes)) {
     parkNestedReaderLoad(this as unknown as Base, pending);
   }
 }
@@ -1072,7 +1080,7 @@ export async function setAttributes(
 ): Promise<void> {
   assertHashAttributes(attrs);
   if (isMassAssignmentEmpty(attrs)) return;
-  for (const pending of _assignAttributes(this, sanitizeForMassAssignment(attrs), true)) {
+  for (const pending of _assignAttributes(this, sanitizeForMassAssignment(attrs))) {
     await pending;
   }
 }
@@ -1111,7 +1119,6 @@ function isNestedParameterHash(value: unknown): boolean {
 function* _assignAttributes(
   self: AttributeIO,
   attrs: Record<string, unknown>,
-  awaitable: boolean,
 ): Generator<Promise<void>, void, undefined> {
   let multiParameterAttributes: Record<string, unknown> | null = null;
   let nestedParameterAttributes: Record<string, unknown> | null = null;
@@ -1122,13 +1129,13 @@ function* _assignAttributes(
     } else if (isNestedParameterHash(value)) {
       (nestedParameterAttributes ??= {})[key] = value;
     } else {
-      const pending = _assignAttribute(self, key, value, awaitable);
+      const pending = _assignAttribute(self, key, value);
       if (pending) yield pending;
     }
   }
 
   if (nestedParameterAttributes) {
-    yield* assignNestedParameterAttributes(self, nestedParameterAttributes, awaitable);
+    yield* assignNestedParameterAttributes(self, nestedParameterAttributes);
   }
   if (multiParameterAttributes) {
     const multi = extractMultiparameterCallstack(multiParameterAttributes).multiparams;
@@ -1144,10 +1151,9 @@ function* _assignAttributes(
 function* assignNestedParameterAttributes(
   self: AttributeIO,
   pairs: Record<string, unknown>,
-  awaitable: boolean,
 ): Generator<Promise<void>, void, undefined> {
   for (const [k, v] of Object.entries(pairs)) {
-    const pending = _assignAttribute(self, k, v, awaitable);
+    const pending = _assignAttribute(self, k, v);
     if (pending) yield pending;
   }
 }

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -977,6 +977,13 @@ function associationWriter(
 }
 
 /**
+ * The send `_assignAttribute` deferred: an association writer resolved but not
+ * called, because only the driver knows whether the surface it runs on can
+ * await it. Yielded with its key so a driver that refuses it can name the key.
+ */
+type DeferredAssignment = () => Promise<void> | void;
+
+/**
  * Mirrors Rails' `_assign_attribute` (ActiveModel
  * attribute_assignment.rb:67-75): dispatch through the public setter when one
  * exists (store accessors write to the store hash, not a standalone attribute
@@ -995,7 +1002,11 @@ function associationWriter(
  * (has_one_association.rb:69) a write; that promise is returned rather than
  * dropped.
  */
-function _assignAttribute(self: AttributeIO, key: string, value: unknown): Promise<void> | void {
+function _assignAttribute(
+  self: AttributeIO,
+  key: string,
+  value: unknown,
+): Promise<void> | DeferredAssignment | void {
   const configs = (self as any).constructor?._nestedAttributeConfigs as
     | { associationName: string }[]
     | undefined;
@@ -1003,10 +1014,12 @@ function _assignAttribute(self: AttributeIO, key: string, value: unknown): Promi
     return (self as any)[`set${camelize(key, true)}`](value) as Promise<void> | void;
   }
   const writer = associationWriter(self, key);
-  if (writer) {
-    const result: unknown = writer(value);
-    return result instanceof Promise ? (result as Promise<void>) : undefined;
-  }
+  // Returned unsent. A JS property setter cannot await the I/O these writers do
+  // (collection_association.rb:46-48, :61-83; has_one_association.rb:59-84),
+  // which is why RFC 0087 §1 removed them, so `public_send(setter, v)`
+  // (attribute_assignment.rb:69) belongs to the driver that knows whether it can
+  // be awaited rather than to this shared body — which stays one behaviour.
+  if (writer) return () => writer(value) as Promise<void> | void;
   const setter = findPrototypeSetter(self, key);
   if (setter) {
     const result: unknown = setter.call(self, value);
@@ -1050,18 +1063,21 @@ export function assignAttributes(this: AttributeIO, attrs: Record<string, unknow
   // `isMassAssignmentEmpty` reads a wrapper's contents, not its own fields.
   if (isMassAssignmentEmpty(attrs)) return;
   const newAttributes = sanitizeForMassAssignment(attrs);
-  // The one place the synchronous surface parts company with the awaitable one,
-  // and it lives here rather than in the shared `_assign_attribute` port:
-  // RFC 0087 §1 left no `#{key}=` property setter for the association writers
-  // that do I/O at assignment (collection_association.rb:46-48, :61-83;
-  // has_one_association.rb:59-84), so on a surface that cannot await them
-  // `respond_to?(setter)` is genuinely false and the key falls through to
-  // `writeAttribute`, which raises for a name that is not an attribute. Sent
-  // ahead of the loop so the write is never started, only refused.
-  for (const [key, value] of Object.entries(newAttributes)) {
-    if (associationWriter(this, key)) this.writeAttribute(key, value);
-  }
-  for (const pending of _assignAttributes(this, newAttributes)) {
+  for (const [key, pending] of _assignAttributes(this, newAttributes)) {
+    if (typeof pending === "function") {
+      // The one place this surface parts company with the awaitable one, and it
+      // lives in this body rather than in the shared `_assign_attribute` port.
+      // RFC 0087 §1 left no `#{key}=` property setter for the association
+      // writers that do I/O at assignment, because a JS setter cannot await
+      // them, so here `respond_to?(setter)` (attribute_assignment.rb:70) is
+      // genuinely false and the key falls to `writeAttribute`, which raises for
+      // a name that is not an attribute. The deferred send is dropped unrun, so
+      // the write is refused rather than started — and refused in place, at the
+      // key Rails' `each_pair` (attribute_assignment.rb:8) is on, so every key
+      // before it is already assigned.
+      this.writeAttribute(key, newAttributes[key]);
+      continue;
+    }
     parkNestedReaderLoad(this as unknown as Base, pending);
   }
 }
@@ -1080,8 +1096,8 @@ export async function setAttributes(
 ): Promise<void> {
   assertHashAttributes(attrs);
   if (isMassAssignmentEmpty(attrs)) return;
-  for (const pending of _assignAttributes(this, sanitizeForMassAssignment(attrs))) {
-    await pending;
+  for (const [, pending] of _assignAttributes(this, sanitizeForMassAssignment(attrs))) {
+    await (typeof pending === "function" ? pending() : pending);
   }
 }
 
@@ -1104,9 +1120,10 @@ function isNestedParameterHash(value: unknown): boolean {
  * writer's `reject_if` / the built record's callbacks observe an owner whose
  * own attributes are already set. Nested runs before multiparameter (:21-22).
  *
- * Rails' body is a plain `each`; ours yields the promise a step answered so the
- * two entry points above can drive the same `each` — `assignAttributes` parking
- * each one, `setAttributes` awaiting it before the loop moves on. Written as a
+ * Rails' body is a plain `each`; ours yields what a step answered, keyed by the
+ * key it answered for, so the two entry points above can drive the same `each`
+ * — `assignAttributes` parking each promise and refusing each deferred send,
+ * `setAttributes` awaiting both before the loop moves on. Written as a
  * generator rather than duplicated per driver: the loop, its bucketing and its
  * exceptions stay one body, and they stay synchronous, so a bad multiparameter
  * key still raises out of `assignAttributes` where Rails raises out of
@@ -1119,7 +1136,7 @@ function isNestedParameterHash(value: unknown): boolean {
 function* _assignAttributes(
   self: AttributeIO,
   attrs: Record<string, unknown>,
-): Generator<Promise<void>, void, undefined> {
+): Generator<[string, Promise<void> | DeferredAssignment], void, undefined> {
   let multiParameterAttributes: Record<string, unknown> | null = null;
   let nestedParameterAttributes: Record<string, unknown> | null = null;
 
@@ -1130,7 +1147,7 @@ function* _assignAttributes(
       (nestedParameterAttributes ??= {})[key] = value;
     } else {
       const pending = _assignAttribute(self, key, value);
-      if (pending) yield pending;
+      if (pending) yield [key, pending];
     }
   }
 
@@ -1151,10 +1168,10 @@ function* _assignAttributes(
 function* assignNestedParameterAttributes(
   self: AttributeIO,
   pairs: Record<string, unknown>,
-): Generator<Promise<void>, void, undefined> {
+): Generator<[string, Promise<void> | DeferredAssignment], void, undefined> {
   for (const [k, v] of Object.entries(pairs)) {
     const pending = _assignAttribute(self, k, v);
-    if (pending) yield pending;
+    if (pending) yield [k, pending];
   }
 }
 

--- a/packages/activerecord/src/support/second-connection.ts
+++ b/packages/activerecord/src/support/second-connection.ts
@@ -1,26 +1,60 @@
 /**
  * Helper for tests that require a second independent database connection.
  *
- * Rails uses `@connection.pool.checkout` to obtain a second connection from the
- * same pool. We instead create a fresh `PostgreSQLAdapter` pointing at the same
- * URL, so the two adapters have fully independent connection pools with no
- * shared state.
+ * Rails obtains one with `@connection.pool.checkout`
+ * (`vendor/rails/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb`),
+ * so the second connection carries a real pool and answers `role` / `shard` /
+ * `db_config` the way `abstract_adapter.rb:286-296` expects. We build a real
+ * `ConnectionPool` over the same URL and check out of it, rather than
+ * constructing a bare `PostgreSQLAdapter` that would carry the constructor's
+ * `NullPool` seed (`abstract_adapter.rb:153`). The pool is its own rather than
+ * the first adapter's because the callers' first adapter is itself a bare
+ * standalone adapter, not a pool-owned connection.
  */
 
+import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
 import { PostgreSQLAdapter } from "../connection-adapters/postgresql-adapter.js";
+import { ConnectionPool } from "../connection-adapters/abstract/connection-pool.js";
+import { ConnectionDescriptor } from "../connection-adapters/abstract/connection-descriptor.js";
+import { PoolConfig } from "../connection-adapters/pool-config.js";
+import { HashConfig } from "../database-configurations/hash-config.js";
 
 /**
- * Opens a second `PostgreSQLAdapter` for the given URL, calls `fn` with it,
- * then closes the adapter on the way out (success or failure).
+ * Checks a second `PostgreSQLAdapter` out of a pool for the given URL, calls
+ * `fn` with it, then checks it back in and disconnects the pool on the way out
+ * (success or failure).
  */
 export async function withSecondAdapter<T>(
   url: string,
   fn: (adapter: PostgreSQLAdapter) => T | Promise<T>,
 ): Promise<T> {
-  const adapter = new PostgreSQLAdapter(url);
+  const dbConfig = new HashConfig("arunit", "primary", {
+    adapter: "postgresql",
+    url,
+    pool: 1,
+  });
+  const poolConfig = new PoolConfig(
+    new ConnectionDescriptor("primary"),
+    dbConfig,
+    "writing",
+    "default",
+    { adapterFactory: () => new PostgreSQLAdapter(url) as unknown as DatabaseAdapter },
+  );
+  const pool = new ConnectionPool(poolConfig);
   try {
-    return await fn(adapter);
+    const adapter = (await pool.checkout()) as unknown as PostgreSQLAdapter;
+    try {
+      return await fn(adapter);
+    } finally {
+      pool.checkin(adapter as unknown as DatabaseAdapter);
+      // Closed explicitly, and awaited, before the pool is torn down: callers
+      // like `translate no connection exception to not established` terminate
+      // the FIRST adapter's backend from here, and only a fully-drained second
+      // connection guarantees that termination has landed on it by the time the
+      // block returns.
+      await adapter.close().catch(() => {});
+    }
   } finally {
-    await adapter.close().catch(() => {});
+    await pool.disconnect(false).catch(() => {});
   }
 }

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -77,8 +77,9 @@ export type LeasedTestAdapter = DatabaseAdapter & {
 // graph reaching test-adapter.ts (or adapter-helper.ts, which imports it) would
 // snapshot the fixture database while Base rides the worker clone —
 // `test-adapter.trails.test.ts` asserts the two stay equal.
+const _primaryEnvConfig = (await testConfigurationHashes()).envConfig;
 const _primaryConfiguration: Record<string, unknown> = {
-  ...(await testConfigurationHashes()).envConfig.configurationHash,
+  ..._primaryEnvConfig.configurationHash,
 };
 
 /**
@@ -111,24 +112,68 @@ export let newRawTestAdapter: () => DatabaseAdapter;
 // per-adapter key whitelisting that keeps config-only keys out of the drivers.
 const adapterArgs = buildAdapterArg(_primaryConfiguration.adapter as string, _primaryConfiguration);
 
+const { HashConfig } = await import("./database-configurations/hash-config.js");
+const { PoolConfig } = await import("./connection-adapters/pool-config.js");
+const { ConnectionPool: RealConnectionPool } =
+  await import("./connection-adapters/abstract/connection-pool.js");
+const { ConnectionDescriptor } =
+  await import("./connection-adapters/abstract/connection-descriptor.js");
+
+/**
+ * Hands a freshly-constructed raw adapter its own real `ConnectionPool` and
+ * returns it.
+ *
+ * Rails never has a pool-less connection in a test: every adapter a test drives
+ * came out of `pool.checkout`, so `role` / `shard` / `db_config`
+ * (`abstract_adapter.rb:286-296`, all bare `@pool.` sends) answer. The
+ * constructor's `NullPool` seed (`abstract_adapter.rb:153`) answers none of
+ * them — in Ruby it raises `NoMethodError`, and only trails' cast hides that.
+ *
+ * The pool is built with `adapterFactory` returning this very adapter, so the
+ * adapter IS the pool's single connection rather than a second one: the
+ * driver-level cap of one server connection per raw adapter (max: 1 /
+ * connectionLimit: 1) is untouched, and `pool: 1` says the same thing at the
+ * pool layer. One pool per raw adapter, not one shared pool, so each keeps the
+ * independent schema reflection a standalone adapter has today.
+ *
+ * @internal
+ */
+function withRawTestPool(adapter: DatabaseAdapter): DatabaseAdapter {
+  const dbConfig = new HashConfig(_primaryEnvConfig.envName, _primaryEnvConfig.name, {
+    ..._primaryConfiguration,
+    pool: 1,
+  });
+  const poolConfig = new PoolConfig(
+    new ConnectionDescriptor("primary"),
+    dbConfig,
+    "writing",
+    "default",
+    { adapterFactory: () => adapter },
+  );
+  (adapter as unknown as { pool: unknown }).pool = new RealConnectionPool(poolConfig);
+  return adapter;
+}
+
 if (adapterType === "postgres") {
   const { PostgreSQLAdapter } = await import("./connection-adapters/postgresql-adapter.js");
   const [config] = adapterArgs as [Record<string, unknown>];
   // Constrain the driver pool to max: 1 so each pooled-adapter slot maps to
   // exactly one PG server connection (the outer ConnectionPool multiplexes).
   newRawTestAdapter = () =>
-    new PostgreSQLAdapter({ ...config, max: 1 }) as unknown as DatabaseAdapter;
+    withRawTestPool(new PostgreSQLAdapter({ ...config, max: 1 }) as unknown as DatabaseAdapter);
 } else if (adapterType === "mysql") {
   // Built from the config hash rather than a URL so a socket-configured run
   // (MYSQL_SOCK) reaches the driver — a URL cannot carry a socket path.
   const { Mysql2Adapter } = await import("./connection-adapters/mysql2-adapter.js");
   const [config] = adapterArgs as [Record<string, unknown>];
   newRawTestAdapter = () =>
-    new Mysql2Adapter({
-      ...config,
-      connectionLimit: 1,
-      flags: ["FOUND_ROWS"],
-    }) as unknown as DatabaseAdapter;
+    withRawTestPool(
+      new Mysql2Adapter({
+        ...config,
+        connectionLimit: 1,
+        flags: ["FOUND_ROWS"],
+      }) as unknown as DatabaseAdapter,
+    );
 } else {
   const { BetterSQLite3Adapter } = await import("./connection-adapters/better-sqlite3-adapter.js");
   // Recombined into the Rails-shaped single-hash form the adapter constructor
@@ -136,7 +181,8 @@ if (adapterType === "postgres") {
   // pool's resolver predates that overload.
   const [filename, options] = adapterArgs as [string, SQLite3AdapterOptions | undefined];
   const config: SQLite3Config = { ...options, database: filename };
-  newRawTestAdapter = () => new BetterSQLite3Adapter(config) as unknown as DatabaseAdapter;
+  newRawTestAdapter = () =>
+    withRawTestPool(new BetterSQLite3Adapter(config) as unknown as DatabaseAdapter);
 }
 
 // --- In-test pool for pool-mechanics suites ---------------------------------


### PR DESCRIPTION
Two of the three bundled stories. The third (`move-adapter-specific-snapshot-off-ar-internal-metadata`) has been **released, not shipped**: its own recorded findings say the run-token-sidecar arm is larger than the ceiling and that `load-schema-helper.ts:526-532`'s seam must be reshaped one story at a time, so it needs its own PR.

## 1. `raw-test-and-second-connection-adapters-carry-a-real-pool`

`newRawTestAdapter` (`test-adapter.ts`) and `withSecondAdapter` (`support/second-connection.ts`) both constructed adapters outside any pool, so each kept the constructor's `NullPool` seed (`abstract_adapter.rb:153`). `role` / `shard` / `db_config` are bare `@pool.` sends (`abstract_adapter.rb:286-296`) — `NoMethodError` in Ruby, `undefined` here only because of the cast the blocked follow-up story removes.

- `withSecondAdapter` builds a real `ConnectionPool` over the same URL and `checkout()`s from it — Rails' `@connection.pool.checkout` shape. It checks the connection back in and closes it explicitly before disconnecting the pool: `translate no connection exception to not established` terminates the *first* adapter's backend from inside the block, and only a fully-drained second connection guarantees that termination has landed by the time the block returns.
- `newRawTestAdapter` hands each adapter its own real `ConnectionPool` whose `adapterFactory` returns that very adapter, so the adapter **is** the pool's single connection. The driver-level cap (`max: 1` / `connectionLimit: 1`) is untouched and `pool: 1` says the same thing at the pool layer. One pool per raw adapter rather than one shared pool, so each keeps the independent schema reflection a standalone adapter has today.

No test renamed. Verified green on the sqlite file lane and on PG (local PG 17) for `postgresql-adapter{,.trails}.test.ts`, `test-adapter.trails`, `statement-pool`, `schema-cache`, `uniqueness-validation.trails`, `migration.trails`, `pooled-connections`, `connection-pool{,.trails}`.

## 2. `retire-awaitable-flag-on-assign-attribute`

`_assignAttributes`, `assignNestedParameterAttributes` and `_assignAttribute` carry Rails' parameter lists again (`attribute_assignment.rb:6,26,67`) — the `awaitable: boolean` PR #6204 threaded through all three is gone, and each is one behaviour again.

- `associationWriterPromise` becomes `associationWriter`: it *resolves* the writer and returns it unsent, so `respond_to?(setter)` and `public_send(setter, v)` stay separate steps (`attribute_assignment.rb:67-69`).
- `_assignAttribute` sends it unconditionally. Same body for both drivers.
- `_assignAttribute` returns that send **deferred** rather than performing it, and `_assignAttributes` yields it keyed by its key, so the split lives in the two drivers' bodies: `setAttributes` runs the deferred send, `assignAttributes` — the body that already deviates by parking — drops it unrun and routes the key through `writeAttribute`, which raises there. Because that happens inside the loop, the refusal lands at the same key and in the same order Rails' `each_pair` (`activemodel/attribute_assignment.rb:60-64`) would reach it, leaving every earlier key assigned. A regression test (`refuses the association key in place, leaving earlier keys assigned`) pins that ordering and fails on the pre-pass shape. Justified against the same Rails line as before: RFC 0087 §1 left no synchronous `#{key}=` for those writers because a JS setter cannot await `replace` (`collection_association.rb:46-48`), `ids_writer` (`:61-83`) or `has_one`'s displacing writer (`has_one_association.rb:59-84`), so `respond_to?(setter)` is genuinely false on this surface. Sent ahead of the loop so the write is **refused, never started** — the sync surface still performs no write it cannot await, and the raise and its message are unchanged from `main`.

`update` / `update!` still reach the writers through `setAttributes`. All of `packages/activerecord/src/associations/` plus the nested-attributes and persistence suites: 98 files, 2489 passed. No test renames.

## Gates

`pnpm typecheck`, `pnpm lint`, `pnpm api:calls` (ratchet OK, no new rows), `pnpm api:extra --package activerecord` (no new novel surface — `persistence.ts` stays at its pre-existing `deleteRow`) all clean.

Closes-story: raw-test-and-second-connection-adapters-carry-a-real-pool
Closes-story: retire-awaitable-flag-on-assign-attribute

