### PR TITLE
refactor(activerecord): template globalSetup adapters lease from a real ConnectionPool

### DIFF
--- a/packages/activerecord/src/support/template-global-setup.ts
+++ b/packages/activerecord/src/support/template-global-setup.ts
@@ -150,7 +150,8 @@ const sqliteAdapter: DbTemplateAdapter = {
       () => new BetterSQLite3Adapter(templatePath) as unknown as DatabaseAdapter,
     );
     await buildTemplateSchema(adapter, runToken, async () => {
-      await pool.disconnect();
+      pool.releaseConnection();
+      await pool.disconnectBang();
       await (adapter as unknown as { close(): void | Promise<void> }).close();
     });
 
@@ -240,7 +241,8 @@ const pgAdapter: DbTemplateAdapter = {
       // a disconnect/terminate that also throws would replace the original
       // error. Swallow teardown errors so the meaningful one always surfaces.
       try {
-        await pool.disconnect();
+        pool.releaseConnection();
+        await pool.disconnectBang();
         await pgTerminateConnections(admin, templateDb);
       } catch {
         // best-effort cleanup; the template DB is dropped at teardown anyway
@@ -358,7 +360,8 @@ const mysqlAdapter: DbTemplateAdapter = {
             }) as unknown as DatabaseAdapter,
         );
         await buildTemplateSchema(adapter, runToken, async () => {
-          await pool.disconnect();
+          pool.releaseConnection();
+          await pool.disconnectBang();
         });
       }),
     );

--- a/packages/activerecord/src/support/template-global-setup.ts
+++ b/packages/activerecord/src/support/template-global-setup.ts
@@ -152,7 +152,6 @@ const sqliteAdapter: DbTemplateAdapter = {
     await buildTemplateSchema(adapter, runToken, async () => {
       pool.releaseConnection();
       await pool.disconnectBang();
-      await (adapter as unknown as { close(): void | Promise<void> }).close();
     });
 
     process.env[TEMPLATE_PATH_ENV] = templatePath;

--- a/packages/activerecord/src/support/template-global-setup.ts
+++ b/packages/activerecord/src/support/template-global-setup.ts
@@ -19,6 +19,10 @@ import "../sqlite/better-sqlite3.js";
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
 import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adapter.js";
 import { PostgreSQLAdapter } from "../connection-adapters/postgresql-adapter.js";
+import { ConnectionPool } from "../connection-adapters/abstract/connection-pool.js";
+import { ConnectionDescriptor } from "../connection-adapters/abstract/connection-descriptor.js";
+import { PoolConfig } from "../connection-adapters/pool-config.js";
+import { HashConfig } from "../database-configurations/hash-config.js";
 import { loadSchema } from "./load-schema-helper.js";
 import { stampCanonicalSchema } from "./canonical-schema-stamp.js";
 import {
@@ -57,6 +61,30 @@ import { activeLane } from "./connection.js";
 // base DB.
 function slotCount(): number {
   return workerForkCount() <= 1 ? 1 : slotPoolSize();
+}
+
+// Lease the template adapter out of a real ConnectionPool instead of
+// constructing it bare. A bare adapter keeps the constructor's NullPool seed
+// (`abstract-adapter.ts:833` = `abstract_adapter.rb:153`), so every
+// `connection.pool.db_config` read — `record_environment`
+// (`migration.rb:1512-1516`), `role` / `shard` / `inspect`
+// (`abstract_adapter.rb:286-296`) — reads `undefined` here where Ruby raises
+// NoMethodError. The env name is `arunit`, the entry `expandConfig` names for
+// the primary test connection (`connection.ts`, `config.example.yml`).
+async function pooledTemplateAdapter(
+  configurationHash: Record<string, unknown>,
+  adapterFactory: () => DatabaseAdapter,
+): Promise<{ adapter: DatabaseAdapter; pool: ConnectionPool }> {
+  const dbConfig = new HashConfig("arunit", "primary", configurationHash);
+  const poolConfig = new PoolConfig(
+    new ConnectionDescriptor("primary"),
+    dbConfig,
+    "writing",
+    "default",
+    { adapterFactory },
+  );
+  const pool = new ConnectionPool(poolConfig);
+  return { adapter: await pool.leaseConnection(), pool };
 }
 
 // Lay the canonical schema and stamp it, so the worker that claims this
@@ -117,10 +145,14 @@ const sqliteAdapter: DbTemplateAdapter = {
     const runToken = newRunToken();
     const templatePath = await templatePathFor(runToken);
 
-    const adapter = new BetterSQLite3Adapter(templatePath);
-    await buildTemplateSchema(adapter as unknown as DatabaseAdapter, runToken, () =>
-      adapter.close(),
+    const { adapter, pool } = await pooledTemplateAdapter(
+      { adapter: "sqlite3", database: templatePath },
+      () => new BetterSQLite3Adapter(templatePath) as unknown as DatabaseAdapter,
     );
+    await buildTemplateSchema(adapter, runToken, async () => {
+      await pool.disconnect();
+      await (adapter as unknown as { close(): void | Promise<void> }).close();
+    });
 
     process.env[TEMPLATE_PATH_ENV] = templatePath;
     process.env[RUN_TOKEN_ENV] = runToken;
@@ -186,10 +218,15 @@ const pgAdapter: DbTemplateAdapter = {
 
     await admin.query(`CREATE DATABASE ${quotePgDatabaseName(templateDb)}`);
 
-    const adapter = new PostgreSQLAdapter({
-      connectionString: settingsUrl("postgres", withDatabase(settings, templateDb)),
-      max: 1,
-    }) as unknown as DatabaseAdapter;
+    const templateSettings = withDatabase(settings, templateDb);
+    const { adapter, pool } = await pooledTemplateAdapter(
+      { adapter: "postgresql", ...driverConfig(templateSettings) },
+      () =>
+        new PostgreSQLAdapter({
+          connectionString: settingsUrl("postgres", templateSettings),
+          max: 1,
+        }) as unknown as DatabaseAdapter,
+    );
     try {
       await loadSchema(adapter);
       // Stamp ar_internal_metadata so every slot cloned from this template
@@ -203,7 +240,7 @@ const pgAdapter: DbTemplateAdapter = {
       // a disconnect/terminate that also throws would replace the original
       // error. Swallow teardown errors so the meaningful one always surfaces.
       try {
-        await (adapter as unknown as { disconnect(): Promise<void> }).disconnect?.();
+        await pool.disconnect();
         await pgTerminateConnections(admin, templateDb);
       } catch {
         // best-effort cleanup; the template DB is dropped at teardown anyway
@@ -310,13 +347,18 @@ const mysqlAdapter: DbTemplateAdapter = {
     // wall-clock cost at ~1× rather than N× sequential.
     await Promise.all(
       Array.from({ length: n }, (_, i) => i + 1).map(async (slot) => {
-        const adapter = new Mysql2Adapter({
-          ...driverConfig(withDatabase(settings, slotDatabaseName(baseDb, runToken, slot))),
-          connectionLimit: 1,
-          flags: ["FOUND_ROWS"],
-        }) as unknown as DatabaseAdapter;
+        const slotSettings = withDatabase(settings, slotDatabaseName(baseDb, runToken, slot));
+        const { adapter, pool } = await pooledTemplateAdapter(
+          { adapter: "mysql2", ...driverConfig(slotSettings) },
+          () =>
+            new Mysql2Adapter({
+              ...driverConfig(slotSettings),
+              connectionLimit: 1,
+              flags: ["FOUND_ROWS"],
+            }) as unknown as DatabaseAdapter,
+        );
         await buildTemplateSchema(adapter, runToken, async () => {
-          await (adapter as unknown as { disconnect(): Promise<void> }).disconnect?.();
+          await pool.disconnect();
         });
       }),
     );


### PR DESCRIPTION
## `template-global-setup-adapters-carry-a-real-pool`

`support/template-global-setup.ts` built its three bootstrap adapters bare, so
each carried the constructor's `NullPool` seed (`abstract-adapter.ts:833` =
`abstract_adapter.rb:153`): every `connection.pool.db_config` read — the
canonical-schema load and the `ar_internal_metadata` stamp
(`migration.rb:1512-1516`), plus `role` / `shard` / `inspect`
(`abstract_adapter.rb:286-296`) — answered `undefined` where Ruby raises
`NoMethodError`.

All three sites (sqlite template, PG template, per-slot MySQL) now lease their
adapter out of a real `ConnectionPool`, built from a `HashConfig` on the
`arunit` env with the existing driver construction handed in as the pool's
`adapterFactory`, and tear down through `pool.disconnect()`. This is the same
treatment `create-and-migrate-adapters-carry-a-real-pool` (#6197) gave the
task/CLI half.

### The re-check half of the acceptance criteria

- `connection-adapters/mysql2-adapter.ts:360` (`Mysql2Adapter.databaseExists`)
  is **already faithful and deliberately unchanged**: Rails'
  `self.database_exists?(config)` is a bare `new(config).database_exists?`
  (`abstract_adapter.rb:358-364`) — no pool.
- `tasks/mysql-database-tasks.ts:154,226` and
  `tasks/sqlite-database-tasks.ts:279` are still bare, and are real deviations
  — Rails' task classes reach their adapter via `establish_connection` +
  `Base.lease_connection` (`mysql_database_tasks.rb:70-74`,
  `sqlite_database_tasks.rb:15-37`). Converging them means restructuring those
  bodies onto the establish/lease pair, not wrapping them in an inline pool, so
  they are filed as `0051/database-tasks-adapters-carry-a-real-pool` rather
  than half-converged here.

No test renamed. `pnpm typecheck`, `pnpm api:calls` (ratchet OK, no new rows)
and `test-databases.test.ts` on the sqlite lane are green locally.

Closes-story: template-global-setup-adapters-carry-a-real-pool