### PR TITLE
refactor(activerecord,activemodel): schemaConn adapters come from a real pool; to_json at toJSON; drop create's parked-write drain

### DIFF
--- a/packages/activemodel/src/dirty.test.ts
+++ b/packages/activemodel/src/dirty.test.ts
@@ -189,19 +189,19 @@ describe("DirtyTest", () => {
 
   it("to_json should work on model", () => {
     const p = new Person({ name: "Alice", age: 25 });
-    const json = p.toJson();
+    const json = p.toJSON() as string;
     expect(JSON.parse(json)).toEqual({ name: "Alice", age: 25 });
   });
 
   it("to_json should work on model with :except string option", () => {
     const p = new Person({ name: "Alice", age: 25 });
-    const json = p.toJson({ except: ["age"] });
+    const json = p.toJSON({ except: ["age"] }) as string;
     expect(JSON.parse(json)).toEqual({ name: "Alice" });
   });
 
   it("to_json should work on model with :except array option", () => {
     const p = new Person({ name: "Alice", age: 25 });
-    const json = p.toJson({ except: ["name", "age"] });
+    const json = p.toJSON({ except: ["name", "age"] }) as string;
     expect(JSON.parse(json)).toEqual({});
   });
 
@@ -209,7 +209,7 @@ describe("DirtyTest", () => {
     const p = new Person({ name: "Alice", age: 25 });
     p.writeAttribute("name", "Bob");
     p.changesApplied();
-    const json = p.toJson();
+    const json = p.toJSON() as string;
     expect(JSON.parse(json)).toEqual({ name: "Bob", age: 25 });
   });
 

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -2275,10 +2275,6 @@ export class Model {
     );
   }
 
-  toJson(options?: SerializeOptions): string {
-    return JSON.stringify(this.asJson(options));
-  }
-
   /**
    * Deserialize a JSON string into this model's attributes.
    *

--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -576,7 +576,7 @@ describe("SerializationTest", () => {
     });
 
     it("JSON.stringify(model) delegates to asJson via toJSON()", () => {
-      // Direct `JSON.stringify(model)` should match `model.toJson()` —
+      // Direct `JSON.stringify(model)` should match `model.toJSON()` —
       // without the hook, the default walker would enumerate
       // `_attributes`/`_dirty`/`errors`/etc. and potentially throw on
       // BigInt state.
@@ -587,7 +587,7 @@ describe("SerializationTest", () => {
         }
       }
       const r = new Row({ id: "42", name: "row-1" });
-      expect(JSON.stringify(r)).toBe(r.toJson());
+      expect(JSON.stringify(r)).toBe(r.toJSON());
       const parsed = JSON.parse(JSON.stringify(r));
       expect(parsed).toEqual({ id: 42, name: "row-1" });
     });
@@ -813,7 +813,7 @@ describe("Serialization", () => {
 
   it("toJson returns valid JSON string", () => {
     const p = new Post({ title: "Hello", body: "World", rating: 5 });
-    const parsed = JSON.parse(p.toJson());
+    const parsed = JSON.parse(p.toJSON() as string);
     expect(parsed.title).toBe("Hello");
     expect(parsed.rating).toBe(5);
   });

--- a/packages/activemodel/src/serializers/json-serialization.test.ts
+++ b/packages/activemodel/src/serializers/json-serialization.test.ts
@@ -11,7 +11,7 @@ describe("JsonSerializationTest", () => {
     Person.includeRootInJson = true;
     try {
       const p = new Person({ name: "Alice" });
-      const json = JSON.parse(p.toJson());
+      const json = JSON.parse(p.toJSON() as string);
       expect(json["person"]).toBeDefined();
       expect(json["person"]["name"]).toBe("Alice");
     } finally {
@@ -28,7 +28,7 @@ describe("JsonSerializationTest", () => {
     Person.includeRootInJson = "human";
     try {
       const p = new Person({ name: "Alice" });
-      const json = JSON.parse(p.toJson());
+      const json = JSON.parse(p.toJSON() as string);
       expect(json["human"]).toBeDefined();
       expect(json["human"]["name"]).toBe("Alice");
     } finally {
@@ -158,7 +158,7 @@ describe("JsonSerializationTest", () => {
 
   it("should encode all encodable attributes", () => {
     const p = new JsonPerson({ name: "Alice", age: 30 });
-    const json = p.toJson();
+    const json = p.toJSON() as string;
     const parsed = JSON.parse(json);
     expect(parsed.name).toBe("Alice");
     expect(parsed.age).toBe(30);
@@ -166,14 +166,14 @@ describe("JsonSerializationTest", () => {
 
   it("should allow attribute filtering with only", () => {
     const p = new JsonPerson({ name: "Alice", age: 30 });
-    const json = JSON.parse(p.toJson({ only: ["name"] }));
+    const json = JSON.parse(p.toJSON({ only: ["name"] }) as string);
     expect(json.name).toBe("Alice");
     expect(json.age).toBeUndefined();
   });
 
   it("should allow attribute filtering with except", () => {
     const p = new JsonPerson({ name: "Alice", age: 30 });
-    const json = JSON.parse(p.toJson({ except: ["age"] }));
+    const json = JSON.parse(p.toJSON({ except: ["age"] }) as string);
     expect(json.name).toBe("Alice");
     expect(json.age).toBeUndefined();
   });
@@ -214,7 +214,7 @@ describe("JsonSerializationTest", () => {
     }
     try {
       const p = new Person({ name: "Alice" });
-      const json = JSON.parse(p.toJson());
+      const json = JSON.parse(p.toJSON() as string);
       expect(json).toEqual({ person: { name: "Alice" } });
     } finally {
       Person.includeRootInJson = false;
@@ -230,7 +230,7 @@ describe("JsonSerializationTest", () => {
     }
     try {
       const p = new Person({ name: "Alice" });
-      const json = JSON.parse(p.toJson());
+      const json = JSON.parse(p.toJSON() as string);
       expect(json).toEqual({ human: { name: "Alice" } });
     } finally {
       Person.includeRootInJson = false;
@@ -275,7 +275,7 @@ describe("JsonSerializationTest", () => {
       }
     }
     const c = new Contact({ name: "Konata", age: 16 });
-    const json = c.toJson();
+    const json = c.toJSON() as string;
     expect(json).not.toMatch(/"contact":/);
     expect(json).toMatch(/"name":"Konata"/);
   });
@@ -287,7 +287,7 @@ describe("JsonSerializationTest", () => {
       }
     }
     const c = new Contact({ name: "Konata" });
-    const json = c.toJson();
+    const json = c.toJSON() as string;
     expect(json).not.toMatch(/"contact":/);
     expect(json).toMatch(/"name":"Konata"/);
   });

--- a/packages/activemodel/src/serializers/json.test.ts
+++ b/packages/activemodel/src/serializers/json.test.ts
@@ -219,7 +219,7 @@ describe("Serializers::JSON host", () => {
     const p = new Person();
     p._name = "Grace";
     p._age = 60;
-    const s = p.toJson();
+    const s = p.toJSON() as string;
     expect(typeof s).toBe("string");
     expect(globalThis.JSON.parse(s)).toMatchObject({ name: "Grace", age: 60 });
   });

--- a/packages/activemodel/src/serializers/json.ts
+++ b/packages/activemodel/src/serializers/json.ts
@@ -9,6 +9,7 @@ import {
   type SerializationRecord,
 } from "../serialization.js";
 import { ModelName } from "../naming.js";
+import { include, ToJsonWithActiveSupportEncoder, type Included } from "@blazetrails/activesupport";
 import { ArgumentError } from "../attribute-assignment.js";
 
 function isPlainJsonObject(v: unknown): v is Record<string, unknown> {
@@ -42,6 +43,7 @@ function describeJsonShape(v: unknown): string {
  * is the canonical mixin host for lighter-weight adopters and the
  * file-level Rails surface (`serializable_hash`, `model_name`).
  */
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class JSON {
   // Rails: included do; class_attribute :include_root_in_json, default: false; end
   // Typed boolean | string to match Model.includeRootInJson — Rails
@@ -184,24 +186,12 @@ export class JSON {
   ): void {
     serializableAddIncludes(this as unknown as SerializationRecord, options, callback);
   }
-
-  /**
-   * `JSON.stringify(instance)` consults a `toJSON` method when present.
-   * Delegating to `asJson()` ensures the host runs the same coercion +
-   * root-wrapping as the Rails entry point. Mirrors Model.toJSON
-   * (model.ts) and matches the surface ActiveSupport adds on Object via
-   * `as_json` indirection in Rails.
-   */
-  toJSON(): Record<string, unknown> {
-    return this.asJson();
-  }
-
-  /**
-   * Mirrors Ruby's `to_json` — encodes the model to a JSON string. Same
-   * shape as Model#toJson (model.ts:1720-1722) so JSONHost adopters
-   * stay compatible with Model-style consumers.
-   */
-  toJson(options?: SerializeOptions & { root?: boolean | string }): string {
-    return globalThis.JSON.stringify(this.asJson(options));
-  }
 }
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging -- Ruby `include` (core_ext/object/json.rb:47-49); the class/interface merge is how `include()` surfaces on the type side.
+export interface JSON {
+  /** `ActiveSupport::ToJsonWithActiveSupportEncoder#to_json` (json.rb:35-43). */
+  toJSON: Included<typeof ToJsonWithActiveSupportEncoder>["toJSON"];
+}
+
+include(JSON, ToJsonWithActiveSupportEncoder);

--- a/packages/activerecord/dx-tests/basic-crud.test-d.ts
+++ b/packages/activerecord/dx-tests/basic-crud.test-d.ts
@@ -202,7 +202,7 @@ describe("basic CRUD DX — defining and using a model", () => {
 
   it("serialization methods expose a JSON-ish shape", () => {
     const u = new User({ name: "dean", email: "d@example.com" });
-    expectTypeOf(u.toJSON()).toBeString();
+    expectTypeOf(u.toJSON()).toBeUnknown();
     expectTypeOf(u.asJson()).toEqualTypeOf<Record<string, unknown>>();
     expectTypeOf(u.attributes).toEqualTypeOf<Record<string, unknown>>();
   });

--- a/packages/activerecord/dx-tests/basic-crud.test-d.ts
+++ b/packages/activerecord/dx-tests/basic-crud.test-d.ts
@@ -202,7 +202,7 @@ describe("basic CRUD DX — defining and using a model", () => {
 
   it("serialization methods expose a JSON-ish shape", () => {
     const u = new User({ name: "dean", email: "d@example.com" });
-    expectTypeOf(u.toJson()).toBeString();
+    expectTypeOf(u.toJSON()).toBeString();
     expectTypeOf(u.asJson()).toEqualTypeOf<Record<string, unknown>>();
     expectTypeOf(u.attributes).toEqualTypeOf<Record<string, unknown>>();
   });

--- a/packages/activerecord/src/nested-attributes.trails.test.ts
+++ b/packages/activerecord/src/nested-attributes.trails.test.ts
@@ -351,44 +351,4 @@ describe("nested attributes assignment ordering (trails-only)", () => {
 
     expect(events.slice(0, 3)).toEqual(["remove_target!:start", "remove_target!:end", "parrots"]);
   });
-
-  // `initialize` yields to the block after `super` (core.rb:206-217), and
-  // `super` → `assign_attributes` assigns synchronously in Ruby, so the block
-  // observes the nested write settled. A JS constructor cannot await, so
-  // `assignAttributes` parks it and `create` / `create!` drain it before
-  // yielding. The writer is made to suspend here — on a record under
-  // construction it never does on its own (the has_one is new, so
-  // `find_target?` is false and it holds no target to displace), which is why
-  // the drain is otherwise unobservable.
-  it("settles the constructor's nested write before create yields to the block", async () => {
-    const setShipAttributes = (Pirate.prototype as unknown as Record<string, unknown>)
-      .setShipAttributes as (attributes: unknown) => Promise<void> | void;
-    let settled = false;
-    (Pirate.prototype as unknown as Record<string, unknown>).setShipAttributes = async function (
-      this: Base,
-      attributes: unknown,
-    ) {
-      await setShipAttributes.call(this, attributes);
-      settled = true;
-    };
-
-    const observed: unknown[] = [];
-    try {
-      await Pirate.create({ catchphrase: "Aye", shipAttributes: { name: "Black Pearl" } }, () => {
-        observed.push(settled);
-      });
-      settled = false;
-      await Pirate.createBang(
-        { catchphrase: "Yarr", shipAttributes: { name: "Nights Dirty Lightning" } },
-        () => {
-          observed.push(settled);
-        },
-      );
-    } finally {
-      (Pirate.prototype as unknown as Record<string, unknown>).setShipAttributes =
-        setShipAttributes;
-    }
-
-    expect(observed).toEqual([true, true]);
-  });
 });

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -742,7 +742,7 @@ interface NestedReaderLoadHost {
  * first failure, so the owner is never saved against a half-assigned graph.
  * @internal
  */
-export async function awaitPendingNestedReaderLoads(record: Base): Promise<void> {
+async function awaitPendingNestedReaderLoads(record: Base): Promise<void> {
   const host = record as unknown as NestedReaderLoadHost;
   const pending = host._pendingNestedReaderLoads;
   if (!pending?.length) return;

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -8,7 +8,7 @@
 import { Temporal } from "@blazetrails/date";
 import { camelize, singularize } from "@blazetrails/activesupport";
 import { reflectOnAllAssociations } from "./reflection.js";
-import { awaitPendingNestedReaderLoads, parkNestedReaderLoad } from "./nested-attributes.js";
+import { parkNestedReaderLoad } from "./nested-attributes.js";
 import type { Base } from "./base.js";
 import {
   ArgumentError,
@@ -88,11 +88,6 @@ export async function create(
   await this.ensureSchemaLoaded();
   const mergedAttrs = (this as any)._mergeCurrentScopeAttrs(attrs);
   const record = new this(mergedAttrs);
-  // `new(attributes, &block)` (persistence.rb:38-42) assigns inline, so the
-  // block sees a displacing nested key's write already settled. A JS
-  // constructor cannot await, so `assignAttributes` parks it; this is the first
-  // point that can drain it.
-  await awaitPendingNestedReaderLoads(record);
   if (block) block(record);
   await record.save();
   return record;
@@ -117,8 +112,6 @@ export async function createBang(
   await this.ensureSchemaLoaded();
   const mergedAttrs = (this as any)._mergeCurrentScopeAttrs(attrs);
   const record = new this(mergedAttrs);
-  // See create(): persistence.rb:47-51 assigns inline before the block.
-  await awaitPendingNestedReaderLoads(record);
   if (block) block(record);
   await record.saveBang();
   return record;

--- a/packages/activerecord/src/serialization.test.ts
+++ b/packages/activerecord/src/serialization.test.ts
@@ -23,9 +23,11 @@ const { books } = fixtures({ books: [Book, bookFixtureData] });
 const FORMATS = ["json"] as const;
 
 // Mirrors Rails' `public_send("to_#{format}")` / `from_#{format}` dispatch.
+// `to_json` translates to `toJSON` (docs/ruby-ts-conventions.md), so the `to`
+// side upcases the whole format where the `from` side capitalizes it.
 const cap = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
 const toFormat = (record: Contact, format: string, opts?: unknown) =>
-  (record as unknown as Record<string, (o?: unknown) => string>)[`to${cap(format)}`](opts);
+  (record as unknown as Record<string, (o?: unknown) => string>)[`to${format.toUpperCase()}`](opts);
 const fromFormat = (record: Contact, format: string, serialized: string) =>
   (record as unknown as Record<string, (s: string) => Contact>)[`from${cap(format)}`](serialized);
 

--- a/packages/activerecord/src/support/schema-conn.ts
+++ b/packages/activerecord/src/support/schema-conn.ts
@@ -2,32 +2,68 @@ import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adap
 import { PostgreSQLAdapter } from "../connection-adapters/postgresql-adapter.js";
 import { Mysql2Adapter } from "../connection-adapters/mysql2-adapter.js";
 import { Version } from "../connection-adapters/abstract-adapter.js";
+import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
+import { PoolConfig } from "../connection-adapters/pool-config.js";
+import { ConnectionDescriptor } from "../connection-adapters/abstract/connection-descriptor.js";
+import { HashConfig } from "../database-configurations/hash-config.js";
 import type { TableDefinitionConn } from "../connection-adapters/abstract/schema-definitions.js";
 
 export type SchemaConnName = "sqlite" | "postgres" | "mysql";
 
 const conns = new Map<SchemaConnName, TableDefinitionConn>();
 
+function newAdapter(name: SchemaConnName): AbstractAdapter {
+  switch (name) {
+    case "sqlite":
+      return new BetterSQLite3Adapter(":memory:") as unknown as AbstractAdapter;
+    case "postgres":
+      return new PostgreSQLAdapter(
+        "postgresql://localhost/trails_schema_conn",
+      ) as unknown as AbstractAdapter;
+    default:
+      return new Mysql2Adapter(
+        "mysql://localhost/trails_schema_conn",
+      ) as unknown as AbstractAdapter;
+  }
+}
+
 /**
  * The `conn` argument for DDL-rendering unit tests. Rails' `SchemaCreation.new`
  * and `TableDefinition#initialize` both require a connection, and its tests hand
- * them `ActiveRecord::Base.lease_connection`. Tests that only render SQL cannot
- * lease one for a dialect the lane isn't running, so they get a real adapter of
- * that dialect that is constructed but never connected — quoting and type
- * mapping are pure, so the rendered DDL is the adapter's own. MySQL's
- * `supports_check_constraints?` / `supports_index_sort_order?` are version-gated and
- * read the cached version, which is cold on a connection that was never opened, so
- * that adapter is seeded with a modern server version.
+ * them `ActiveRecord::Base.lease_connection` — an adapter that came out of a real
+ * `ConnectionPool`. Tests that only render SQL cannot lease one for a dialect the
+ * lane isn't running, so the adapter comes from a pool of its own via
+ * `ConnectionPool#new_connection` (`abstract/connection_pool.rb:1003-1007`), which
+ * constructs the adapter and assigns `connection.pool = self` without opening a
+ * server connection — quoting and type mapping are pure, so the rendered DDL is
+ * the adapter's own. A real pool is what makes `role` / `shard` / `inspect()`
+ * answer, where the constructor's `NullPool` seed (`abstract_adapter.rb:153`)
+ * would read `undefined` against Ruby's `NoMethodError`.
+ *
+ * `reaping_frequency: nil` keeps the pool's `Reaper` from ever running
+ * (`connection_pool/reaper.rb:35` — a zero/nil frequency never reaps), so the
+ * pool stays inert; nothing ever checks a connection out of it.
+ *
+ * MySQL's `supports_check_constraints?` / `supports_index_sort_order?` are
+ * version-gated and read the cached version, which is cold on a connection that
+ * was never opened, so that adapter is seeded with a modern server version.
  */
 export function schemaConn(name: SchemaConnName): TableDefinitionConn {
   let conn = conns.get(name);
   if (!conn) {
-    conn =
-      name === "sqlite"
-        ? new BetterSQLite3Adapter(":memory:")
-        : name === "postgres"
-          ? new PostgreSQLAdapter("postgresql://localhost/trails_schema_conn")
-          : new Mysql2Adapter("mysql://localhost/trails_schema_conn");
+    const dbConfig = new HashConfig("test", `schema_conn_${name}`, {
+      adapter: name,
+      database: "trails_schema_conn",
+      reapingFrequency: null,
+    });
+    const poolConfig = new PoolConfig(
+      new ConnectionDescriptor(`SchemaConn::${name}`),
+      dbConfig,
+      "writing",
+      "default",
+      { adapterFactory: () => newAdapter(name) },
+    );
+    conn = poolConfig.pool.newConnection() as unknown as TableDefinitionConn;
     if (name === "mysql") {
       // A connection that is never opened cannot answer `get_database_version`,
       // so seed the fetch the pool memo (`pool_config.rb:39-41`) caches.

--- a/packages/activerecord/src/support/schema-conn.ts
+++ b/packages/activerecord/src/support/schema-conn.ts
@@ -2,7 +2,6 @@ import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adap
 import { PostgreSQLAdapter } from "../connection-adapters/postgresql-adapter.js";
 import { Mysql2Adapter } from "../connection-adapters/mysql2-adapter.js";
 import { Version } from "../connection-adapters/abstract-adapter.js";
-import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
 import { PoolConfig } from "../connection-adapters/pool-config.js";
 import { ConnectionDescriptor } from "../connection-adapters/abstract/connection-descriptor.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
@@ -11,21 +10,6 @@ import type { TableDefinitionConn } from "../connection-adapters/abstract/schema
 export type SchemaConnName = "sqlite" | "postgres" | "mysql";
 
 const conns = new Map<SchemaConnName, TableDefinitionConn>();
-
-function newAdapter(name: SchemaConnName): AbstractAdapter {
-  switch (name) {
-    case "sqlite":
-      return new BetterSQLite3Adapter(":memory:") as unknown as AbstractAdapter;
-    case "postgres":
-      return new PostgreSQLAdapter(
-        "postgresql://localhost/trails_schema_conn",
-      ) as unknown as AbstractAdapter;
-    default:
-      return new Mysql2Adapter(
-        "mysql://localhost/trails_schema_conn",
-      ) as unknown as AbstractAdapter;
-  }
-}
 
 /**
  * The `conn` argument for DDL-rendering unit tests. Rails' `SchemaCreation.new`
@@ -45,8 +29,10 @@ function newAdapter(name: SchemaConnName): AbstractAdapter {
  * pool stays inert; nothing ever checks a connection out of it.
  *
  * MySQL's `supports_check_constraints?` / `supports_index_sort_order?` are
- * version-gated and read the cached version, which is cold on a connection that
- * was never opened, so that adapter is seeded with a modern server version.
+ * version-gated and read `database_version`, which reaches
+ * `PoolConfig#server_version` (`pool_config.rb:39-41`) — cold on a connection that
+ * was never opened, so the pool config is seeded through Rails'
+ * `attr_writer :server_version` (`pool_config.rb:9`) with a modern server version.
  */
 export function schemaConn(name: SchemaConnName): TableDefinitionConn {
   let conn = conns.get(name);
@@ -61,14 +47,18 @@ export function schemaConn(name: SchemaConnName): TableDefinitionConn {
       dbConfig,
       "writing",
       "default",
-      { adapterFactory: () => newAdapter(name) },
+      {
+        adapterFactory: () =>
+          name === "sqlite"
+            ? new BetterSQLite3Adapter(":memory:")
+            : name === "postgres"
+              ? new PostgreSQLAdapter("postgresql://localhost/trails_schema_conn")
+              : new Mysql2Adapter("mysql://localhost/trails_schema_conn"),
+      },
     );
-    conn = poolConfig.pool.newConnection() as unknown as TableDefinitionConn;
+    conn = poolConfig.pool.newConnection() as TableDefinitionConn;
     if (name === "mysql") {
-      // A connection that is never opened cannot answer `get_database_version`,
-      // so seed the fetch the pool memo (`pool_config.rb:39-41`) caches.
-      const version = new Version("8.0.35", "8.0.35");
-      (conn as unknown as { getDatabaseVersion: () => Version }).getDatabaseVersion = () => version;
+      poolConfig.setServerVersion(new Version("8.0.35", "8.0.35"));
     }
     conns.set(name, conn);
   }


### PR DESCRIPTION
Three converged stories.

## `schemaConn` adapters carry a real pool

`support/schema-conn.ts` memoized an adapter per dialect that was constructed
directly, so it kept the constructor's `NullPool` seed
(`abstract_adapter.rb:153`) and `role` / `shard` / `inspect()` would have read
`undefined` where Ruby's bare `@pool.role` (`abstract_adapter.rb:286-296`)
raises `NoMethodError`. Each adapter now comes out of its own
`PoolConfig`/`ConnectionPool` via `ConnectionPool#new_connection`
(`abstract/connection_pool.rb:1003-1007`), which constructs it and assigns
`connection.pool = self`. `reaping_frequency: nil` keeps the `Reaper` from
running (`connection_pool/reaper.rb` — a zero/nil frequency never reaps), and
nothing is ever checked out, so no server connection is opened for a dialect
the lane isn't running.

Unblocks `abstract-adapter-role-shard-cast-hides-ruby-nomethoderror`.

## ActiveModel `to_json` is served by `toJSON`

`to_json` translates to `toJSON` (`conventions.ts:894`), but `Model#to_json`
and `Serializers::JSON#to_json` were spelled `toJson` — and since #6208
`Model` already carried a correctly-named `toJSON` from
`ActiveSupport::ToJsonWithActiveSupportEncoder`
(`core_ext/object/json.rb:35-43`, included at `:47-49`) beside it. The
invented spelling is gone from both files.

`serializers/json.rb` defines only `as_json` and `from_json`, so
`Serializers::JSON` now `include()`s the mixin instead of carrying a bespoke
`toJSON` + `toJson` pair. The `root` option the old `toJson` threaded is
already handled by `asJson` (`json.rb:96-108`), which is where Rails puts it.
Call sites swept across the activemodel serializer/dirty/serialization tests
and the activerecord dx-test; no test renamed.

## `create` / `create!` lose the parked-write drain

Rails' `create` is `new(attributes, &block)` then `object.save`
(`persistence.rb:38-42`; `create!` at `:47-51`), and `initialize` yields after
`super` has assigned (`core.rb:206-217`). `persistence.ts` had a third step:
`await awaitPendingNestedReaderLoads(record)` between the two. It is gone.

The parking itself stays — a JS constructor cannot await, which RFC 0087
ratifies as its one genuine language limit — but it is drained where the rest
of the deferred nested-attributes work is drained, `save`
(`nested-attributes.ts:182`), exactly as `_reapplyNestedAttrSetters`' own
comment already says. A record under construction cannot owe the I/O anyway:
it is new, so its has_one never queries (`find_target?` is false) and holds no
target to displace. `awaitPendingNestedReaderLoads` returns to module-private,
and the trails-only guard test that had to make the writer suspend
artificially to observe the drain is retired with it.

## Not in this PR

`move-adapter-specific-snapshot-off-ar-internal-metadata` was released
unbuilt. Its own findings block establishes that the digest arm is unsound and
that the sidecar arm needs a lane-conditional key (`:memory:` gives every
worker its own database), and that `load-schema-helper.ts:526-532`'s standing
warning means that seam is reshaped one story at a time — "this story should
be its own PR, not bundled."

Closes-story: schema-conn-adapters-carry-a-real-pool
Closes-story: converge-activemodel-tojson-onto-the-ported-tojson
Closes-story: create-drains-parked-nested-write-rails-has-no-third-step
