### PR TITLE
fix(activerecord,activesupport): PG disconnect drains its socket; migrationConnection raises; Range/URI as_json arms; to_json typed string

### DIFF
--- a/packages/activemodel/src/dirty.test.ts
+++ b/packages/activemodel/src/dirty.test.ts
@@ -189,19 +189,19 @@ describe("DirtyTest", () => {
 
   it("to_json should work on model", () => {
     const p = new Person({ name: "Alice", age: 25 });
-    const json = p.toJSON() as string;
+    const json = p.toJSON();
     expect(JSON.parse(json)).toEqual({ name: "Alice", age: 25 });
   });
 
   it("to_json should work on model with :except string option", () => {
     const p = new Person({ name: "Alice", age: 25 });
-    const json = p.toJSON({ except: ["age"] }) as string;
+    const json = p.toJSON({ except: ["age"] });
     expect(JSON.parse(json)).toEqual({ name: "Alice" });
   });
 
   it("to_json should work on model with :except array option", () => {
     const p = new Person({ name: "Alice", age: 25 });
-    const json = p.toJSON({ except: ["name", "age"] }) as string;
+    const json = p.toJSON({ except: ["name", "age"] });
     expect(JSON.parse(json)).toEqual({});
   });
 
@@ -209,7 +209,7 @@ describe("DirtyTest", () => {
     const p = new Person({ name: "Alice", age: 25 });
     p.writeAttribute("name", "Bob");
     p.changesApplied();
-    const json = p.toJSON() as string;
+    const json = p.toJSON();
     expect(JSON.parse(json)).toEqual({ name: "Bob", age: 25 });
   });
 

--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -813,7 +813,7 @@ describe("Serialization", () => {
 
   it("toJson returns valid JSON string", () => {
     const p = new Post({ title: "Hello", body: "World", rating: 5 });
-    const parsed = JSON.parse(p.toJSON() as string);
+    const parsed = JSON.parse(p.toJSON());
     expect(parsed.title).toBe("Hello");
     expect(parsed.rating).toBe(5);
   });

--- a/packages/activemodel/src/serializers/json-serialization.test.ts
+++ b/packages/activemodel/src/serializers/json-serialization.test.ts
@@ -11,7 +11,7 @@ describe("JsonSerializationTest", () => {
     Person.includeRootInJson = true;
     try {
       const p = new Person({ name: "Alice" });
-      const json = JSON.parse(p.toJSON() as string);
+      const json = JSON.parse(p.toJSON());
       expect(json["person"]).toBeDefined();
       expect(json["person"]["name"]).toBe("Alice");
     } finally {
@@ -28,7 +28,7 @@ describe("JsonSerializationTest", () => {
     Person.includeRootInJson = "human";
     try {
       const p = new Person({ name: "Alice" });
-      const json = JSON.parse(p.toJSON() as string);
+      const json = JSON.parse(p.toJSON());
       expect(json["human"]).toBeDefined();
       expect(json["human"]["name"]).toBe("Alice");
     } finally {
@@ -158,7 +158,7 @@ describe("JsonSerializationTest", () => {
 
   it("should encode all encodable attributes", () => {
     const p = new JsonPerson({ name: "Alice", age: 30 });
-    const json = p.toJSON() as string;
+    const json = p.toJSON();
     const parsed = JSON.parse(json);
     expect(parsed.name).toBe("Alice");
     expect(parsed.age).toBe(30);
@@ -166,14 +166,14 @@ describe("JsonSerializationTest", () => {
 
   it("should allow attribute filtering with only", () => {
     const p = new JsonPerson({ name: "Alice", age: 30 });
-    const json = JSON.parse(p.toJSON({ only: ["name"] }) as string);
+    const json = JSON.parse(p.toJSON({ only: ["name"] }));
     expect(json.name).toBe("Alice");
     expect(json.age).toBeUndefined();
   });
 
   it("should allow attribute filtering with except", () => {
     const p = new JsonPerson({ name: "Alice", age: 30 });
-    const json = JSON.parse(p.toJSON({ except: ["age"] }) as string);
+    const json = JSON.parse(p.toJSON({ except: ["age"] }));
     expect(json.name).toBe("Alice");
     expect(json.age).toBeUndefined();
   });
@@ -214,7 +214,7 @@ describe("JsonSerializationTest", () => {
     }
     try {
       const p = new Person({ name: "Alice" });
-      const json = JSON.parse(p.toJSON() as string);
+      const json = JSON.parse(p.toJSON());
       expect(json).toEqual({ person: { name: "Alice" } });
     } finally {
       Person.includeRootInJson = false;
@@ -230,7 +230,7 @@ describe("JsonSerializationTest", () => {
     }
     try {
       const p = new Person({ name: "Alice" });
-      const json = JSON.parse(p.toJSON() as string);
+      const json = JSON.parse(p.toJSON());
       expect(json).toEqual({ human: { name: "Alice" } });
     } finally {
       Person.includeRootInJson = false;
@@ -275,7 +275,7 @@ describe("JsonSerializationTest", () => {
       }
     }
     const c = new Contact({ name: "Konata", age: 16 });
-    const json = c.toJSON() as string;
+    const json = c.toJSON();
     expect(json).not.toMatch(/"contact":/);
     expect(json).toMatch(/"name":"Konata"/);
   });
@@ -287,7 +287,7 @@ describe("JsonSerializationTest", () => {
       }
     }
     const c = new Contact({ name: "Konata" });
-    const json = c.toJSON() as string;
+    const json = c.toJSON();
     expect(json).not.toMatch(/"contact":/);
     expect(json).toMatch(/"name":"Konata"/);
   });

--- a/packages/activemodel/src/serializers/json.test.ts
+++ b/packages/activemodel/src/serializers/json.test.ts
@@ -219,7 +219,7 @@ describe("Serializers::JSON host", () => {
     const p = new Person();
     p._name = "Grace";
     p._age = 60;
-    const s = p.toJSON() as string;
+    const s = p.toJSON();
     expect(typeof s).toBe("string");
     expect(globalThis.JSON.parse(s)).toMatchObject({ name: "Grace", age: 60 });
   });

--- a/packages/activerecord/dx-tests/basic-crud.test-d.ts
+++ b/packages/activerecord/dx-tests/basic-crud.test-d.ts
@@ -202,7 +202,7 @@ describe("basic CRUD DX — defining and using a model", () => {
 
   it("serialization methods expose a JSON-ish shape", () => {
     const u = new User({ name: "dean", email: "d@example.com" });
-    expectTypeOf(u.toJSON()).toBeUnknown();
+    expectTypeOf(u.toJSON()).toBeString();
     expectTypeOf(u.asJson()).toEqualTypeOf<Record<string, unknown>>();
     expectTypeOf(u.attributes).toEqualTypeOf<Record<string, unknown>>();
   });

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -498,6 +498,9 @@ export class PostgreSQLAdapter
   // Backs the `active` getter so a torn-down adapter reports inactive
   // even before the next lazy acquire would notice the missing connection.
   private _closed = false;
+  // The in-flight `client.end()` started by the synchronous disconnectBang,
+  // surfaced through `whenClosed()` so the pool can await the socket drain.
+  private _closingDriver: Promise<void> | null = null;
   // Per-acquire generation. Each _doAcquire captures the current value; a
   // teardown that must invalidate the in-flight acquire bumps it. `discardBang`
   // (Rails' `discard!`) is the only teardown that bumps it AND records the
@@ -3004,8 +3007,9 @@ export class PostgreSQLAdapter
 
   /**
    * Mirrors Rails' `PostgreSQLAdapter#disconnect!`. Tears down the
-   * persistent connection asynchronously so no new queries can start;
-   * the underlying socket drains in the background.
+   * persistent connection synchronously so no new queries can start; the
+   * `client.end()` it starts is recorded in `_closingDriver` and surfaced
+   * through `whenClosed()`, which `ConnectionPool#disconnect` awaits.
    */
   override disconnectBang(): void {
     const conn = this._rawConnection;
@@ -3028,10 +3032,26 @@ export class PostgreSQLAdapter
     // is NOT recorded in _discardedAcquireGenerations, so _teardownRacedClient
     // end()s the socket (matching Rails' disconnect!) rather than abandoning it.
     if (this._acquiring) this._acquireGeneration++;
-    conn?.end().catch(() => {});
+    this._closingDriver = conn?.end().catch(() => {}) ?? null;
     // Rails' disconnect! calls reset_transaction; super.disconnectBang() does not.
     this.resetTransaction();
     super.disconnectBang();
+  }
+
+  /**
+   * The pending `client.end()` left in flight by `disconnectBang()`, which is
+   * synchronous as Rails' `disconnect!` is. `ConnectionPool#disconnect` awaits
+   * this, so `await pool.disconnect()` means the PG socket is actually closed
+   * — not merely that no further queries can start. Resolves immediately when
+   * nothing is draining.
+   *
+   * @noRailsEquivalent PERMANENT — Rails' `disconnect!`
+   * (postgresql_adapter.rb:386-392) closes the connection through libpq's
+   * synchronous `PG::Connection#close`, so there is no pending close for a
+   * Rails method to expose. node-pg's `Client#end()` is promise-returning.
+   */
+  whenClosed(): Promise<void> {
+    return this._closingDriver ?? Promise.resolve();
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -498,8 +498,6 @@ export class PostgreSQLAdapter
   // Backs the `active` getter so a torn-down adapter reports inactive
   // even before the next lazy acquire would notice the missing connection.
   private _closed = false;
-  // The in-flight `client.end()` started by the synchronous disconnectBang,
-  // surfaced through `whenClosed()` so the pool can await the socket drain.
   private _closingDriver: Promise<void> | null = null;
   // Per-acquire generation. Each _doAcquire captures the current value; a
   // teardown that must invalidate the in-flight acquire bumps it. `discardBang`

--- a/packages/activerecord/src/migration.trails.test.ts
+++ b/packages/activerecord/src/migration.trails.test.ts
@@ -43,13 +43,14 @@ describe("MigrationTest", () => {
       _poolOverride?: DatabaseAdapter;
     };
     const baseAdapter = Base.connection;
+    const basePool = Base.connectionPool();
     const override = newRawTestAdapter();
     internals.adapter = baseAdapter;
     expect(m.connection).toBe(baseAdapter);
     internals._connectionOverride = override;
     expect(m.connection).toBe(override);
     // connectionPool is independent — _connectionOverride must not affect it
-    expect(m.connectionPool).toBe(baseAdapter);
+    expect(m.connectionPool).toBe(basePool);
     delete internals._connectionOverride;
     expect(m.connection).toBe(baseAdapter);
     const poolOverride = newRawTestAdapter();
@@ -58,7 +59,7 @@ describe("MigrationTest", () => {
     // connection is independent — _poolOverride must not affect it
     expect(m.connection).toBe(baseAdapter);
     delete internals._poolOverride;
-    expect(m.connectionPool).toBe(baseAdapter);
+    expect(m.connectionPool).toBe(basePool);
   });
 
   it("migration context with async migration() proxy", async () => {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1372,14 +1372,12 @@ export abstract class Migration {
   }
 
   get connectionPool(): ConnectionPool {
-    // Mirrors Rails: @pool || DatabaseTasks.migration_connection_pool.
-    // _poolOverride is a real ConnectionPool when set by the migration runner.
-    // The adapter fallback is intentionally unsafe: DatabaseTasks.migrationConnectionPool
-    // is async (needs dynamic import to break the circular migration→base dependency),
-    // so we can't call it here synchronously. The cast is load-bearing until pool
-    // lookup is restructured — callers on the test/direct-construction path must not
-    // invoke pool-only methods (leaseConnection, withConnection, etc.).
-    return (this._poolOverride ?? this.adapter) as unknown as ConnectionPool;
+    // Mirrors Rails: @pool || DatabaseTasks.migration_connection_pool
+    // (migration.rb:1040-1042). `DatabaseTasks` is reached through the call-time config
+    // source for the same reason `Migrator#connection` does — naming
+    // `tasks/database-tasks.js` here would be a load-time edge back into a
+    // module that already imports this one.
+    return this._poolOverride ?? migrationArConfig()!.databaseTasks!().migrationConnectionPool();
   }
 
   // --- Execution (Rails: Migration#exec_migration, #execution_strategy, etc.) ---
@@ -2561,15 +2559,9 @@ export class Migrator {
    * (`migration.rb:1488-1491`). `DatabaseTasks` is reached through the
    * call-time config source: naming `tasks/database-tasks.js` here would be a
    * load-time edge back into a module that already imports this one.
-   *
-   * Rails' body is a bare delegation with no null branch — `migration_connection`
-   * is `migration_class.lease_connection`
-   * (`tasks/database_tasks.rb:533-535`), which raises rather than answering nil.
-   * The assertions keep that shape; adding a guard here would be a branch Rails
-   * does not have.
    */
   private get connection(): DatabaseAdapter {
-    return migrationArConfig()!.databaseTasks!().migrationConnection()!;
+    return migrationArConfig()!.databaseTasks!().migrationConnection();
   }
 
   /** @internal Mirrors: ActiveRecord::Migrator#ran? */

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1371,12 +1371,13 @@ export abstract class Migration {
     this._connectionOverride = conn;
   }
 
+  /**
+   * Mirrors: ActiveRecord::Migration#connection_pool (`migration.rb:1040-1042`).
+   * `DatabaseTasks` is reached through the call-time config source for the same
+   * reason `Migrator#connection` does — naming `tasks/database-tasks.js` here
+   * would be a load-time edge back into a module that already imports this one.
+   */
   get connectionPool(): ConnectionPool {
-    // Mirrors Rails: @pool || DatabaseTasks.migration_connection_pool
-    // (migration.rb:1040-1042). `DatabaseTasks` is reached through the call-time config
-    // source for the same reason `Migrator#connection` does — naming
-    // `tasks/database-tasks.js` here would be a load-time edge back into a
-    // module that already imports this one.
     return this._poolOverride ?? migrationArConfig()!.databaseTasks!().migrationConnectionPool();
   }
 

--- a/packages/activerecord/src/support/second-connection.ts
+++ b/packages/activerecord/src/support/second-connection.ts
@@ -22,7 +22,8 @@ import { HashConfig } from "../database-configurations/hash-config.js";
 /**
  * Checks a second `PostgreSQLAdapter` out of a pool for the given URL, calls
  * `fn` with it, then checks it back in and disconnects the pool on the way out
- * (success or failure).
+ * (success or failure). `pool.disconnect` awaits each connection's drain, so
+ * the second backend is fully closed by the time this returns.
  */
 export async function withSecondAdapter<T>(
   url: string,
@@ -47,12 +48,6 @@ export async function withSecondAdapter<T>(
       return await fn(adapter);
     } finally {
       pool.checkin(adapter as unknown as DatabaseAdapter);
-      // Closed explicitly, and awaited, before the pool is torn down: callers
-      // like `translate no connection exception to not established` terminate
-      // the FIRST adapter's backend from here, and only a fully-drained second
-      // connection guarantees that termination has landed on it by the time the
-      // block returns.
-      await adapter.close().catch(() => {});
     }
   } finally {
     await pool.disconnect(false).catch(() => {});

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -1361,12 +1361,13 @@ export class DatabaseTasks {
    * stay out of the import cycle); `_baseClass` is the same constant, wired at
    * base.ts module init by `_registerBase`, which is what this sync reader can
    * name — as Ruby names `ActiveRecord::Base` directly.
+   *
+   * The Rails-named `leaseConnection` is async (it awaits per-checkout
+   * `verifyBang` — see ConnectionPool#checkout), so this sync reader uses the
+   * `leaseConnectionSync` escape hatch, which resolves a pinned connection /
+   * establishes a first lease without the async verify.
    */
   static migrationConnection(): import("../connection-adapters/abstract-adapter.js").AbstractAdapter {
-    // The Rails-named `leaseConnection` is now async (it awaits per-checkout
-    // `verifyBang` — see ConnectionPool#checkout). This sync accessor uses the
-    // `leaseConnectionSync` escape hatch, which resolves a pinned connection /
-    // establishes a first lease without the async verify.
     return this._baseClass!.connectionPool().leaseConnectionSync();
   }
 

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -457,7 +457,7 @@ export class DatabaseTasks {
     };
 
     try {
-      const pool = await this.migrationConnectionPool();
+      const pool = this.migrationConnectionPool();
       if (!skipInitialize) await initializeDatabase(pool.dbConfig);
       await runMigration(await pool.leaseConnection(), pool.dbConfig);
     } finally {
@@ -490,7 +490,7 @@ export class DatabaseTasks {
    */
   static async runMigration(direction: "up" | "down", version: number | string): Promise<void> {
     this.checkTargetVersion(version);
-    const pool = await this.migrationConnectionPool();
+    const pool = this.migrationConnectionPool();
     const adapter = await pool.leaseConnection();
     const context = await this._migrationContextFor(adapter, pool.dbConfig);
     await context.run(direction, version);
@@ -501,7 +501,7 @@ export class DatabaseTasks {
     direction: "rollback" | "forward",
     steps: number,
   ): Promise<void> {
-    const pool = await this.migrationConnectionPool();
+    const pool = this.migrationConnectionPool();
     const adapter = await pool.leaseConnection();
     const dbConfig = pool.dbConfig;
     const context = await this._migrationContextFor(adapter, dbConfig);
@@ -1127,7 +1127,7 @@ export class DatabaseTasks {
    * (called by `rails db:version`).
    */
   static async currentVersion(): Promise<number> {
-    const pool = await this.migrationConnectionPool();
+    const pool = this.migrationConnectionPool();
     const adapter = await pool.leaseConnection();
     const migrator = await this._migratorFor(adapter, pool.dbConfig);
     return migrator.currentVersionReadOnly();
@@ -1351,24 +1351,28 @@ export class DatabaseTasks {
     setModuleBase(base);
   }
 
-  static migrationConnection():
-    | import("../connection-adapters/abstract-adapter.js").AbstractAdapter
-    | null {
-    if (!this._baseClass) return null;
-    try {
-      // The Rails-named `leaseConnection` is now async (it awaits per-checkout
-      // `verifyBang` — see ConnectionPool#checkout). This sync accessor uses the
-      // `leaseConnectionSync` escape hatch, which resolves a pinned connection /
-      // establishes a first lease without the async verify.
-      return this._baseClass.connectionPool().leaseConnectionSync();
-    } catch (error) {
-      if (error instanceof ConnectionNotDefined) return null;
-      throw error;
-    }
+  /**
+   * Mirrors `DatabaseTasks.migration_connection` (database_tasks.rb:533-535) —
+   * a bare delegation. `lease_connection` raises `ConnectionNotDefined` when
+   * nothing is established rather than answering nil, and no caller guards it,
+   * so neither does this.
+   *
+   * `migrationClass()` is the async spelling (it dynamic-imports base.js to
+   * stay out of the import cycle); `_baseClass` is the same constant, wired at
+   * base.ts module init by `_registerBase`, which is what this sync reader can
+   * name — as Ruby names `ActiveRecord::Base` directly.
+   */
+  static migrationConnection(): import("../connection-adapters/abstract-adapter.js").AbstractAdapter {
+    // The Rails-named `leaseConnection` is now async (it awaits per-checkout
+    // `verifyBang` — see ConnectionPool#checkout). This sync accessor uses the
+    // `leaseConnectionSync` escape hatch, which resolves a pinned connection /
+    // establishes a first lease without the async verify.
+    return this._baseClass!.connectionPool().leaseConnectionSync();
   }
 
-  static async migrationConnectionPool(): Promise<ConnectionPool> {
-    return (await this.migrationClass()).connectionPool();
+  /** Mirrors `DatabaseTasks.migration_connection_pool` (database_tasks.rb:537-539). */
+  static migrationConnectionPool(): ConnectionPool {
+    return this._baseClass!.connectionPool();
   }
 
   static async schemaUpToDate(

--- a/packages/activesupport/src/core-ext/object/json.ts
+++ b/packages/activesupport/src/core-ext/object/json.ts
@@ -153,7 +153,8 @@ export class Enumerable {
 /**
  * `Range#as_json` (json.rb:157-161), over trails' begin/end/exclusive triple
  * (`range-ext.ts`). `to_s` is the ported `Range#to_s` in
- * `core-ext/range/conversions.ts`.
+ * `core-ext/range/conversions.ts`. The dispatcher reaches this arm ahead of
+ * `Hash`, which a range would otherwise take as a plain object.
  */
 export class Range {
   static asJson(value: RangeValue<unknown>): string {
@@ -302,11 +303,11 @@ function pad2(value: number): string {
 /**
  * @noRailsEquivalent PERMANENT — a Hash-shaped object: a bare object literal
  * (`Object.prototype` or null prototype), not a class instance like `Date` that
- * defines its own JSON form. Stands in for Ruby's `Hash === value`.
+ * defines its own JSON form. Stands in for Ruby's `Hash === value`, so a Range
+ * — a plain object here, but not a Hash in Ruby — misses it, both in the
+ * dispatcher below and in `JSONGemEncoder#jsonify`.
  */
 export function isPlainObject(value: object): boolean {
-  // A Range is a plain object here but is not a Hash in Ruby, so it must miss
-  // this test in `jsonify` too, or it never reaches `Range#as_json`.
   if (isRange(value)) return false;
   const proto = globalThis.Object.getPrototypeOf(value);
   return proto === globalThis.Object.prototype || proto === null;
@@ -343,8 +344,6 @@ export function asJson(value: unknown, options?: EncodeOptions | null): unknown 
   if (value instanceof Error) return Exception.asJson(value);
   if (value instanceof URL) return Generic.asJson(value);
   if (globalThis.Array.isArray(value)) return Array.asJson(value, options);
-  // Precedes the Hash arm: trails' Range is a plain object, so it would
-  // otherwise be picked up as an attribute bag.
   if (isRange(value)) return Range.asJson(value);
   if (value instanceof Map || isPlainObject(value as object)) return Hash.asJson(value, options);
   if (

--- a/packages/activesupport/src/core-ext/object/json.ts
+++ b/packages/activesupport/src/core-ext/object/json.ts
@@ -2,7 +2,9 @@ import { Temporal } from "@blazetrails/date";
 
 import { ActiveSupportJSON } from "../../json.js";
 import { Encoding, type EncodeOptions } from "../../json/encoding.js";
+import { isRange, type Range as RangeValue } from "../../range-ext.js";
 import { BigDecimal as BigDecimalValue } from "../big-decimal/conversions.js";
+import { toS } from "../range/conversions.js";
 import * as instanceVariables from "./instance-variables.js";
 
 /**
@@ -37,21 +39,28 @@ export interface ToJsonWithActiveSupportEncoderHost {
  * Ruby discriminates on `::JSON::State`, the argument the JSON gem's encoder
  * passes. `JSON.stringify` has no state object: it calls `toJSON(key)` with
  * the property key, a string — so the string is the discriminator here.
+ *
+ * Both Ruby arms answer a String, so the arm callers reach — no argument or an
+ * options hash — is declared `string`. It is the *last* overload deliberately:
+ * `Included<>` derives a host's method type by inferring from the final
+ * signature, so that is the one the mixin hosts get.
  */
-export const ToJsonWithActiveSupportEncoder = {
-  toJSON(
-    this: ToJsonWithActiveSupportEncoderHost,
-    options?: EncodeOptions | string | null,
-  ): unknown {
-    if (typeof options === "string") {
-      // Called from JSON.stringify, forward it to the JSON serializer
-      return this.asJson();
-    } else {
-      // to_json is being invoked directly, use ActiveSupport's encoder
-      return ActiveSupportJSON.encode(this, options ?? undefined);
-    }
-  },
-};
+function toJSON(this: ToJsonWithActiveSupportEncoderHost, options: string): unknown;
+function toJSON(this: ToJsonWithActiveSupportEncoderHost, options?: EncodeOptions | null): string;
+function toJSON(
+  this: ToJsonWithActiveSupportEncoderHost,
+  options?: EncodeOptions | string | null,
+): unknown {
+  if (typeof options === "string") {
+    // Called from JSON.stringify, forward it to the JSON serializer
+    return this.asJson();
+  } else {
+    // to_json is being invoked directly, use ActiveSupport's encoder
+    return ActiveSupportJSON.encode(this, options ?? undefined);
+  }
+}
+
+export const ToJsonWithActiveSupportEncoder = { toJSON };
 
 /**
  * `Module#as_json` (json.rb:52-56). A JS class or function is the Module
@@ -138,6 +147,17 @@ export class Regexp {
 export class Enumerable {
   static asJson(value: Iterable<unknown>, options?: EncodeOptions | null): unknown[] {
     return Array.asJson([...value], options);
+  }
+}
+
+/**
+ * `Range#as_json` (json.rb:157-161), over trails' begin/end/exclusive triple
+ * (`range-ext.ts`). `to_s` is the ported `Range#to_s` in
+ * `core-ext/range/conversions.ts`.
+ */
+export class Range {
+  static asJson(value: RangeValue<unknown>): string {
+    return toS(value);
   }
 }
 
@@ -248,6 +268,16 @@ export class DateTime {
   }
 }
 
+/**
+ * `URI::Generic#as_json` (json.rb:230-234). JS `URL` is the analogue of Ruby's
+ * parsed-URI object, and `toString()` is its `to_s`.
+ */
+export class Generic {
+  static asJson(value: URL): string {
+    return value.toString();
+  }
+}
+
 /** `Exception#as_json` (json.rb:256-260). */
 export class Exception {
   static asJson(value: Error): string {
@@ -275,6 +305,9 @@ function pad2(value: number): string {
  * defines its own JSON form. Stands in for Ruby's `Hash === value`.
  */
 export function isPlainObject(value: object): boolean {
+  // A Range is a plain object here but is not a Hash in Ruby, so it must miss
+  // this test in `jsonify` too, or it never reaches `Range#as_json`.
+  if (isRange(value)) return false;
   const proto = globalThis.Object.getPrototypeOf(value);
   return proto === globalThis.Object.prototype || proto === null;
 }
@@ -308,7 +341,11 @@ export function asJson(value: unknown, options?: EncodeOptions | null): unknown 
   if (value instanceof BigDecimalValue) return BigDecimal.asJson(value);
   if (value instanceof RegExp) return Regexp.asJson(value);
   if (value instanceof Error) return Exception.asJson(value);
+  if (value instanceof URL) return Generic.asJson(value);
   if (globalThis.Array.isArray(value)) return Array.asJson(value, options);
+  // Precedes the Hash arm: trails' Range is a plain object, so it would
+  // otherwise be picked up as an attribute bag.
+  if (isRange(value)) return Range.asJson(value);
   if (value instanceof Map || isPlainObject(value as object)) return Hash.asJson(value, options);
   if (
     typeof (value as { [globalThis.Symbol.iterator]?: unknown })[globalThis.Symbol.iterator] ===

--- a/packages/activesupport/src/core-ext/range/conversions.ts
+++ b/packages/activesupport/src/core-ext/range/conversions.ts
@@ -27,8 +27,15 @@ function toFsDb(value: unknown): string {
   return String(value);
 }
 
-/** Ruby's `Range#to_s` (the `to_fs` fallback at conversions.rb:55). */
-function toS<T>(range: Range<T>): string {
+/**
+ * Ruby's `Range#to_s` (the `to_fs` fallback at conversions.rb:55).
+ *
+ * @noRailsEquivalent PERMANENT — `Range#to_s` is core Ruby, not a Rails
+ * reopening, so no Rails file declares it; it is exported from here, the Rails
+ * file whose `to_fs` falls back to it, rather than copied into
+ * `core-ext/object/json.ts` for `Range#as_json`.
+ */
+export function toS<T>(range: Range<T>): string {
   const begin = range.begin !== null ? String(range.begin) : "";
   const end = range.end !== null ? String(range.end) : "";
   return `${begin}${range.excludeEnd ? "..." : ".."}${end}`;

--- a/packages/activesupport/src/core-ext/range/overlap.ts
+++ b/packages/activesupport/src/core-ext/range/overlap.ts
@@ -1,4 +1,4 @@
-import type { Range } from "../../range-ext.js";
+import { isRange, type Range } from "../../range-ext.js";
 
 /**
  * `Range#overlap?` / `#overlaps?` (core_ext/range/overlap.rb:8,39), which Ruby
@@ -18,15 +18,6 @@ const toNum = <T extends number | Date>(v: T): number => (v instanceof Date ? v.
 function eq<T extends number | Date>(b: T | null, e: T | null): boolean {
   if (b === null || e === null) return b === e;
   return toNum(b) === toNum(e);
-}
-
-/**
- * Ruby's `value.is_a?(::Range)` (overlap.rb:9). trails' `Range` is a plain
- * object, so the type test is structural, as in `compare-range.ts`.
- */
-function isRange<T extends number | Date>(value: Range<T>): boolean {
-  // boundary: Date endpoints, as in range-ext.ts
-  return typeof value === "object" && value !== null && !(value instanceof Date);
 }
 
 /** Ruby's private `Range#_empty_range?` (overlap.rb:31). */

--- a/packages/activesupport/src/json/encoding.test.ts
+++ b/packages/activesupport/src/json/encoding.test.ts
@@ -7,6 +7,7 @@ import { TimeZone } from "../values/time-zone.js";
 import { Encoding } from "./encoding.js";
 import { asJson } from "../core-ext/object/json.js";
 import { BigDecimal } from "../core-ext/big-decimal/conversions.js";
+import { makeRange } from "../range-ext.js";
 
 /** Rails' `JSONTest::Hashlike` (encoding_test_cases.rb:16-20). */
 class Hashlike {
@@ -76,6 +77,19 @@ describe("TestJSONEncoding", () => {
     // fully-qualified constant path; a JS class carries only its own name.
     expect(ActiveSupportJSON.encode(Hashlike)).toBe('"Hashlike"');
     expect(ActiveSupportJSON.encode(People)).toBe('"People"');
+  });
+
+  it("range", () => {
+    // Rails' RangeTests (encoding_test_cases.rb:86-88).
+    expect(ActiveSupportJSON.encode(makeRange(1, 2))).toBe('"1..2"');
+    expect(ActiveSupportJSON.encode(makeRange(1, 2, true))).toBe('"1...2"');
+    expect(ActiveSupportJSON.encode(makeRange(1.5, 2.5))).toBe('"1.5..2.5"');
+  });
+
+  it("uri", () => {
+    // Rails' URITests (encoding_test_cases.rb:112). `URL#toString` normalizes
+    // an empty path to "/", where Ruby's `URI#to_s` echoes the input back.
+    expect(ActiveSupportJSON.encode(new URL("http://example.com"))).toBe('"http://example.com/"');
   });
 
   it("hash encoding", () => {

--- a/packages/activesupport/src/json/encoding.ts
+++ b/packages/activesupport/src/json/encoding.ts
@@ -62,7 +62,7 @@ export class JSONGemEncoder {
    * what base types of objects they are allowed to return or having to remember
    * to call `asJson` recursively.
    *
-   * Note: the `options` hash passed to `toJson` is only passed to `asJson`, not
+   * Note: the `options` hash passed to `toJSON` is only passed to `asJson`, not
    * any of this method's recursive `asJson` calls.
    *
    * Rails' private `JSONGemEncoder#jsonify` (encoding.rb:88-104). JS has a

--- a/packages/activesupport/src/range-ext.ts
+++ b/packages/activesupport/src/range-ext.ts
@@ -31,6 +31,23 @@ export function makeRange<T>(begin: T | null, end: T | null, excludeEnd = false)
 }
 
 /**
+ * Ruby's `value.is_a?(::Range)` (overlap.rb:9, json.rb dispatch). trails' Range
+ * is the data triple above rather than a class, so the test is structural.
+ *
+ * @noRailsEquivalent PERMANENT — the class test it stands in for has no TS
+ * analogue while `Range` is an interface; see the interface's own tag.
+ */
+export function isRange(value: unknown): value is Range<unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "begin" in value &&
+    "end" in value &&
+    typeof (value as Range<unknown>).excludeEnd === "boolean"
+  );
+}
+
+/**
  * cover? — returns true if a numeric/date range covers a scalar value
  * (endpoint comparison via `<=>`).
  */


### PR DESCRIPTION
Bundle of four related stories.

### 1. `pool.disconnect()` returns before the driver drains

Root-caused: it was a real drain bug, not node-pg's async error delivery.
`ConnectionPool#disconnect` already awaits every connection's `whenClosed()`
(`connection-pool.ts:972-994`), but `PostgreSQLAdapter` never implemented that
hook and `disconnectBang()` dropped the promise from node-pg's `client.end()`
(`conn?.end().catch(() => {})`), so the pool reported teardown complete with the
socket still open. The adapter now records that pending close in
`_closingDriver` and exposes `whenClosed()`, exactly as `sqlite3-adapter.ts`
does for async-only drivers. Rails' `disconnect!`
(`postgresql_adapter.rb:386-392`) closes through libpq synchronously and has
nothing to drain, so the hook keeps its `@noRailsEquivalent PERMANENT` framing.

`withSecondAdapter` drops its explicit `await adapter.close()`.

Verified on PG 17: all 67 `postgresql-adapter.test.ts` tests pass, including
`translate no connection exception to not established` and `PostgreSQLAdapter#active > returns false once the backend behind a live client is terminated`.
Reverting only the one-line `_closingDriver` assignment (keeping the
`withSecondAdapter` deletion) reds `translate no connection exception to not
established` again, so the fix is the load-bearing one.

### 2. `migrationConnection` returned null instead of raising

`DatabaseTasks.migrationConnection()` and `migrationConnectionPool()` are now
bare delegations, matching `database_tasks.rb:533-539`: non-nullable, with the
pool's `ConnectionNotDefined` allowed to escape as `lease_connection`'s does.
The `_baseClass` short-circuit and the `ConnectionNotDefined` catch are gone.

Callers converged rather than guarded:

- `Migrator#connection` (`migration.rb:1488-1491`) drops the trailing `!` and
  the JSDoc paragraph that justified it.
- `Migration#connectionPool` now reads
  `DatabaseTasks.migration_connection_pool` for real
  (`migration.rb:1040-1042`) instead of casting `this.adapter` to a
  `ConnectionPool` — the comment justifying that cast said
  `migrationConnectionPool` was async, which it no longer is.
- The four `await this.migrationConnectionPool()` sites in `database-tasks.ts`
  lose their now-pointless `await`.

### 3. `Range#as_json` and `URI::Generic#as_json`

Ported from `json.rb:157-161` and `json.rb:230-234`, in Rails' file order, each
a class of the Ruby name with `static asJson`. `Range`'s body calls the
existing `Range#to_s` in `core-ext/range/conversions.ts` (now exported, tagged
`@noRailsEquivalent` — `Range#to_s` is core Ruby, not a Rails reopening).

The discriminator is an exported `isRange()` in `range-ext.ts`, replacing
`overlap.ts`'s weaker private copy (which accepted any non-`Date` object where
Ruby spells `is_a?(::Range)`). `isPlainObject` — the stand-in for Ruby's
`Hash === value` — now answers false for a range, so `JSONGemEncoder#jsonify`'s
Hash arm no longer swallows one before it can reach `as_json`.

Tests `range` and `uri` added to `TestJSONEncoding`, named as
`encoding_test.rb:23` derives them, covering `encoding_test_cases.rb:86-88` and
`:112`. `URL#toString` normalizes an empty path to `/`, noted at the assertion.

### 4. `to_json` returns a String

`ToJsonWithActiveSupportEncoder#toJSON` gets two overloads: the
`JSON.stringify` protocol arm (`options: string`) first, the Ruby arm
(`options?: EncodeOptions | null`) last and typed `string`. Last is deliberate —
`Included<>` infers a host's method type from the final signature, so the mixin
hosts (`Model`, `ModelName`, `JSON`, `TransitionTable`) all get `string`.

The `as string` casts PR #6212 added across the four activemodel JSON test
files are gone, `basic-crud.test-d.ts` asserts `toBeString()` again, and
`json/encoding.ts:65` no longer names the retired `toJson` spelling.

### Gates

`pnpm typecheck`, `pnpm lint`, `pnpm api:calls` (ratchet OK), `pnpm api:compare`
and `pnpm test:compare` all clean; `api:extra --package activesupport` novel
count moves 383 → 382.

Closes-story: connection-pool-disconnect-returns-before-the-driver-drains
Closes-story: migration-connection-returns-null-instead-of-raising
Closes-story: port-range-and-uri-as-json-arms
Closes-story: to-json-returns-unknown-where-ruby-returns-a-string
