### PR TITLE
refactor(activerecord): raw test adapters come out of pool.checkout via leaseConnection

### DIFF
--- a/packages/activerecord/src/connection-adapters/schema-cache.test.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.test.ts
@@ -9,7 +9,7 @@ import type { SchemaQuoter } from "./abstract/assert-schema-adapter.js";
 import { include } from "@blazetrails/activesupport";
 import { TableDefinition } from "./abstract/schema-definitions.js";
 import type { AbstractAdapter } from "./abstract-adapter.js";
-import { newRawTestAdapter } from "../test-adapter.js";
+import { checkoutRawTestAdapter } from "../test-adapter.js";
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
@@ -814,7 +814,7 @@ describe("SchemaCache DDL invalidation", () => {
   }
 
   beforeEach(async () => {
-    adapter = newRawTestAdapter();
+    adapter = await checkoutRawTestAdapter();
     await adapter.dropTable("things", "stuff", { ifExists: true });
     await adapter.createTable("things", (t) => {
       t.string("name");

--- a/packages/activerecord/src/connection-adapters/statement-pool.test.ts
+++ b/packages/activerecord/src/connection-adapters/statement-pool.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { StatementPool } from "./statement-pool.js";
 import { isSqliteRun } from "../support/sqlite-template.js";
-import { newRawTestAdapter } from "../test-adapter.js";
+import { checkoutRawTestAdapter } from "../test-adapter.js";
 
 describe("StatementPoolTest", () => {
   it("#delete doesn't call dealloc if the statement didn't exist", async () => {
@@ -111,7 +111,7 @@ describe("StatementPoolTest", () => {
 
 describe("SQLite3 StatementPool integration", () => {
   it.skipIf(!isSqliteRun())("caches prepared statements across execute calls", async () => {
-    const adapter = newRawTestAdapter();
+    const adapter = await checkoutRawTestAdapter();
     const prepareSpy = vi.spyOn((adapter as any).driver, "prepare");
 
     try {

--- a/packages/activerecord/src/migration.trails.test.ts
+++ b/packages/activerecord/src/migration.trails.test.ts
@@ -18,14 +18,14 @@ import { ActiveRecord } from "./ar-config.js";
 import { Base } from "./base.js";
 import { SchemaMigration } from "./schema-migration.js";
 import { InternalMetadata } from "./internal-metadata.js";
-import { newRawTestAdapter } from "./test-adapter.js";
+import { checkoutRawTestAdapter } from "./test-adapter.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import { Table } from "./connection-adapters/abstract/schema-definitions.js";
 import { fixtures } from "./test-fixtures.js";
 import { anonymousMigration } from "./test-helpers/anonymous-migration.js";
 
 describe("MigrationTest", () => {
-  // Ride the primary schema-loaded pool (`Base.connection`); `newRawTestAdapter`
+  // Ride the primary schema-loaded pool (`Base.connection`); `checkoutRawTestAdapter`
   // supplies the *distinct* adapter objects the override-routing identity checks
   // need (Rails builds a second connection from the primary config rather than
   // leasing a standing sidecar pool).
@@ -44,7 +44,7 @@ describe("MigrationTest", () => {
     };
     const baseAdapter = Base.connection;
     const basePool = Base.connectionPool();
-    const override = newRawTestAdapter();
+    const override = await checkoutRawTestAdapter();
     internals.adapter = baseAdapter;
     expect(m.connection).toBe(baseAdapter);
     internals._connectionOverride = override;
@@ -53,7 +53,7 @@ describe("MigrationTest", () => {
     expect(m.connectionPool).toBe(basePool);
     delete internals._connectionOverride;
     expect(m.connection).toBe(baseAdapter);
-    const poolOverride = newRawTestAdapter();
+    const poolOverride = await checkoutRawTestAdapter();
     internals._poolOverride = poolOverride;
     expect(m.connectionPool).toBe(poolOverride);
     // connection is independent — _poolOverride must not affect it

--- a/packages/activerecord/src/test-adapter.trails.test.ts
+++ b/packages/activerecord/src/test-adapter.trails.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, expect, test } from "vitest";
 import { Base } from "./base.js";
-import { ambientPoolConfiguration, newRawTestAdapter } from "./test-adapter.js";
+import { ambientPoolConfiguration, checkoutRawTestAdapter } from "./test-adapter.js";
 import { currentAdapter, inMemoryDb } from "./support/adapter-helper.js";
 
 describe("ambientPoolConfiguration", () => {
@@ -19,7 +19,7 @@ describe("ambientPoolConfiguration", () => {
   // A `:memory:` database belongs to its own connection: on the sqlite3_mem lane
   // a second handle is a second, empty database by design.
   test.skipIf(inMemoryDb())("newRawTestAdapter opens the database Base rides", async () => {
-    const adapter = newRawTestAdapter();
+    const adapter = await checkoutRawTestAdapter();
     try {
       expect(await adapter.tableExists("posts")).toBe(true);
     } finally {
@@ -30,7 +30,7 @@ describe("ambientPoolConfiguration", () => {
   test.skipIf(!currentAdapter("SQLite3Adapter"))(
     "newRawTestAdapter opens sqlite with the ambient strict setting",
     async () => {
-      const adapter = newRawTestAdapter() as unknown as { _strictStrings: boolean } & {
+      const adapter = (await checkoutRawTestAdapter()) as unknown as { _strictStrings: boolean } & {
         disconnectBang(): Promise<void>;
       };
       try {

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -159,7 +159,7 @@ export async function checkoutRawTestAdapter(): Promise<DatabaseAdapter> {
     dbConfig,
     "writing",
     "default",
-    { adapterFactory: () => newRawTestAdapter() },
+    { adapterFactory: newRawTestAdapter },
   );
   return new RealConnectionPool(poolConfig).leaseConnection();
 }

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -97,8 +97,12 @@ export function ambientPoolConfiguration(): Record<string, unknown> {
  * Synchronous factory that creates a fresh underlying adapter on the PRIMARY
  * lane database — the same database `Base.connection` rides (on the file-backed
  * sqlite lane its connections share the worker DB, exactly like Rails'
- * file-backed `arunit`). Use this as the `adapterFactory` for a test-local
- * {@link ConnectionPool}, or when a test needs a distinct adapter object.
+ * file-backed `arunit`). This is the `adapterFactory` for a test-local
+ * {@link ConnectionPool} — Rails' `ConnectionPool#new_connection`
+ * (`connection_pool.rb`) — and nothing else: the adapter it returns still
+ * carries the constructor's `NullPool` seed (`abstract_adapter.rb:153`) until a
+ * pool adopts it. A test that wants a pool-owned adapter calls
+ * {@link checkoutRawTestAdapter}.
  *
  * Wired at module load, importing only the active lane's driver.
  *
@@ -120,25 +124,32 @@ const { ConnectionDescriptor } =
   await import("./connection-adapters/abstract/connection-descriptor.js");
 
 /**
- * Hands a freshly-constructed raw adapter its own real `ConnectionPool` and
- * returns it.
+ * Returns a raw test adapter that came out of `ConnectionPool#checkout` — via
+ * `lease_connection` (`connection_pool.rb:315-319`, `lease.connection ||=
+ * checkout`), which is the only route by which a Ruby connection ever acquires
+ * a pool: `new_connection` builds it and the pool owns it from birth. Nothing
+ * assigns `pool` from outside; `ConnectionPool#newConnection` sets the
+ * back-reference on the connection it just adopted.
  *
- * Rails never has a pool-less connection in a test: every adapter a test drives
- * came out of `pool.checkout`, so `role` / `shard` / `db_config`
- * (`abstract_adapter.rb:286-296`, all bare `@pool.` sends) answer. The
- * constructor's `NullPool` seed (`abstract_adapter.rb:153`) answers none of
- * them — in Ruby it raises `NoMethodError`, and only trails' cast hides that.
+ * So `role` / `shard` / `db_config` (`abstract_adapter.rb:286-296`, all bare
+ * `@pool.` sends) answer. The constructor's `NullPool` seed
+ * (`abstract_adapter.rb:153`) answers none of them — in Ruby it raises
+ * `NoMethodError`, and only trails' cast hides that.
  *
- * The pool is built with `adapterFactory` returning this very adapter, so the
- * adapter IS the pool's single connection rather than a second one: the
- * driver-level cap of one server connection per raw adapter (max: 1 /
- * connectionLimit: 1) is untouched, and `pool: 1` says the same thing at the
- * pool layer. One pool per raw adapter, not one shared pool, so each keeps the
- * independent schema reflection a standalone adapter has today.
+ * {@link newRawTestAdapter} is the pool's `adapterFactory`, so the driver-level
+ * cap of one server connection per raw adapter (max: 1 / connectionLimit: 1) is
+ * untouched, and `pool: 1` says the same thing at the pool layer. One pool per
+ * raw adapter, not one shared pool, so each keeps the independent schema
+ * reflection a standalone adapter has.
+ *
+ * The lease (rather than a bare `checkout`) is what keeps the pool's single
+ * connection re-entrant: `ConnectionPool#schemaCache`'s `BoundSchemaReflection`
+ * reaches the adapter through `withConnection`, which would otherwise block on
+ * a `pool: 1` pool whose only connection the caller holds.
  *
  * @internal
  */
-function withRawTestPool(adapter: DatabaseAdapter): DatabaseAdapter {
+export async function checkoutRawTestAdapter(): Promise<DatabaseAdapter> {
   const dbConfig = new HashConfig(_primaryEnvConfig.envName, _primaryEnvConfig.name, {
     ..._primaryConfiguration,
     pool: 1,
@@ -148,10 +159,9 @@ function withRawTestPool(adapter: DatabaseAdapter): DatabaseAdapter {
     dbConfig,
     "writing",
     "default",
-    { adapterFactory: () => adapter },
+    { adapterFactory: () => newRawTestAdapter() },
   );
-  (adapter as unknown as { pool: unknown }).pool = new RealConnectionPool(poolConfig);
-  return adapter;
+  return new RealConnectionPool(poolConfig).leaseConnection();
 }
 
 if (adapterType === "postgres") {
@@ -160,20 +170,18 @@ if (adapterType === "postgres") {
   // Constrain the driver pool to max: 1 so each pooled-adapter slot maps to
   // exactly one PG server connection (the outer ConnectionPool multiplexes).
   newRawTestAdapter = () =>
-    withRawTestPool(new PostgreSQLAdapter({ ...config, max: 1 }) as unknown as DatabaseAdapter);
+    new PostgreSQLAdapter({ ...config, max: 1 }) as unknown as DatabaseAdapter;
 } else if (adapterType === "mysql") {
   // Built from the config hash rather than a URL so a socket-configured run
   // (MYSQL_SOCK) reaches the driver — a URL cannot carry a socket path.
   const { Mysql2Adapter } = await import("./connection-adapters/mysql2-adapter.js");
   const [config] = adapterArgs as [Record<string, unknown>];
   newRawTestAdapter = () =>
-    withRawTestPool(
-      new Mysql2Adapter({
-        ...config,
-        connectionLimit: 1,
-        flags: ["FOUND_ROWS"],
-      }) as unknown as DatabaseAdapter,
-    );
+    new Mysql2Adapter({
+      ...config,
+      connectionLimit: 1,
+      flags: ["FOUND_ROWS"],
+    }) as unknown as DatabaseAdapter;
 } else {
   const { BetterSQLite3Adapter } = await import("./connection-adapters/better-sqlite3-adapter.js");
   // Recombined into the Rails-shaped single-hash form the adapter constructor
@@ -181,8 +189,7 @@ if (adapterType === "postgres") {
   // pool's resolver predates that overload.
   const [filename, options] = adapterArgs as [string, SQLite3AdapterOptions | undefined];
   const config: SQLite3Config = { ...options, database: filename };
-  newRawTestAdapter = () =>
-    withRawTestPool(new BetterSQLite3Adapter(config) as unknown as DatabaseAdapter);
+  newRawTestAdapter = () => new BetterSQLite3Adapter(config) as unknown as DatabaseAdapter;
 }
 
 // --- In-test pool for pool-mechanics suites ---------------------------------

--- a/packages/activerecord/src/validations/uniqueness-validation.trails.test.ts
+++ b/packages/activerecord/src/validations/uniqueness-validation.trails.test.ts
@@ -10,7 +10,7 @@ import { StrictValidationFailed } from "@blazetrails/activemodel";
 import { registerModel } from "../associations.js";
 import { fixtures } from "../test-fixtures.js";
 import { Topic } from "../test-helpers/models/topic.js";
-import { newRawTestAdapter } from "../test-adapter.js";
+import { checkoutRawTestAdapter } from "../test-adapter.js";
 import type { TestDatabaseAdapter } from "../test-adapter.js";
 import { rebuildCanonicalTables } from "../support/canonical-table-rebuild.js";
 import { assertQueriesCount, assertNoQueries } from "../testing/query-assertions.js";
@@ -93,7 +93,7 @@ describe("UniquenessCoveredByUniqueIndexAdapterResolutionTest", () => {
   }
 
   beforeAll(async () => {
-    adapter = newRawTestAdapter();
+    adapter = await checkoutRawTestAdapter();
     await rebuildCanonicalTables(adapter, ["topics"]);
     await adapter.addIndex("topics", "title", { unique: true, name: "topics_direct_index" });
     (DirectTopic as unknown as { _adapter: TestDatabaseAdapter })._adapter = adapter;


### PR DESCRIPTION
## `raw-test-adapters-should-come-from-pool-checkout`

PR #6210 gave `newRawTestAdapter` a real pool, but not Rails' *shape*: it built
the adapter first, then handed it a `ConnectionPool` whose `adapterFactory`
returned that same instance, assigning `adapter.pool` post-hoc. Ruby has no such
route — a connection comes out of `ConnectionPool#checkout`, which builds it via
`new_connection` and owns it from birth
(`connection_pool.rb:315-319`, `lease_connection` = `lease.connection ||= checkout`).
So the pool was never checked out of: `@checked_out` / the lease queue /
`active_connection?` described an empty pool that nonetheless had a live
connection, and each raw adapter allocated a throwaway pool it never used.

This splits the two roles Rails already keeps separate:

- **`newRawTestAdapter`** goes back to being exactly `ConnectionPool#new_connection`'s
  factory — a bare constructor call, carrying the constructor's `NullPool` seed
  (`abstract_adapter.rb:153`) until a pool adopts it. It is passed as
  `adapterFactory` at six sites (`connection-pool.test.ts`,
  `connection-pool.trails.test.ts`, `pooled-connections.test.ts`) and stays sync,
  which is what `newConnection` requires.
- **`checkoutRawTestAdapter()`** (new, async) builds the `pool: 1` pool from the
  ambient primary config with `newRawTestAdapter` as its `adapterFactory` and
  returns `pool.leaseConnection()`. The connection is therefore pool-owned from
  birth; nothing assigns `adapter.pool` from outside — `ConnectionPool#newConnection`
  sets the back-reference on the connection it just adopted.

`leaseConnection` rather than a bare `checkout` is deliberate and is also what
`lease_connection` does in Ruby: it keeps the single connection re-entrant, so
`ConnectionPool#schemaCache`'s `BoundSchemaReflection` reaching the adapter
through `withConnection` doesn't block on a `pool: 1` pool whose only connection
the caller holds. Same treatment as the merged
`template-global-setup-adapters-carry-a-real-pool` (#6211).

The seven direct-use call sites (`migration.trails.test.ts`,
`statement-pool.test.ts`, `schema-cache.test.ts`,
`uniqueness-validation.trails.test.ts`, `test-adapter.trails.test.ts`) now await
`checkoutRawTestAdapter()`. The one-server-connection cap (`max: 1` /
`connectionLimit: 1`) is untouched.

No test renamed. `pnpm typecheck`, `pnpm api:calls` (ratchet OK, no new rows),
`pnpm api:extra` (no new surface) and all eight touched test files green on the
sqlite lane locally.

Closes-story: raw-test-adapters-should-come-from-pool-checkout
