### PR TITLE
refactor(activerecord): Migration#connection names DatabaseTasks; no-setter arm raises UnknownAttributeError

### DIFF
--- a/packages/activerecord/src/active-record-schema.test.ts
+++ b/packages/activerecord/src/active-record-schema.test.ts
@@ -198,7 +198,7 @@ describe("ActiveRecordSchemaTest", () => {
       }
     }
     const m = new TsMig();
-    (m as any).adapter = adapter;
+    m.connection = adapter;
     await m.up();
     // Verify timestamps were added
     await adapter.executeMutation(
@@ -232,7 +232,7 @@ describe("ActiveRecordSchemaTest", () => {
         }
       }
       const m = new BulkTsMig();
-      (m as any).adapter = adapter;
+      m.connection = adapter;
       await m.up();
       // Rails asserts column_exists?(:has_timestamps, :created_at, precision: 6, null: false).
       // The TS adapter mirror: timestamps columns should both be present and the
@@ -261,7 +261,7 @@ describe("ActiveRecordSchemaTest", () => {
       }
     }
     const m = new TsOptMig();
-    (m as any).adapter = adapter;
+    m.connection = adapter;
     await m.up();
     // null: true means we can insert without providing timestamp values
     await adapter.executeMutation(`INSERT INTO "ts_opts" ("name") VALUES ('test')`);
@@ -284,7 +284,7 @@ describe("ActiveRecordSchemaTest", () => {
       }
     }
     const m = new AddTsMig();
-    (m as any).adapter = adapter;
+    m.connection = adapter;
     await m.up();
     // Verify timestamps were added
     await adapter.executeMutation(

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -5174,12 +5174,6 @@ registerMigrationArConfig({
   get tableNameSuffix() {
     return Base._tableNameSuffix;
   },
-  // Sync accessor for `Migration#connection`'s bare-migration fallback. Rails
-  // leases synchronously here; trails' Rails-named `leaseConnection` is now async
-  // (it awaits per-checkout `verifyBang`), so a synchronous migration getter
-  // uses the sync `leaseConnectionSync` escape hatch instead — it resolves a
-  // pinned connection / establishes a first lease without the async verify.
-  leaseConnection: () => Base.connectionPool().leaseConnectionSync(),
   configurations: () => Base.configurations(),
   connectionHandler: () => Base.connectionHandler,
   databaseTasks: () => DatabaseTasks,

--- a/packages/activerecord/src/migration.trails.test.ts
+++ b/packages/activerecord/src/migration.trails.test.ts
@@ -38,14 +38,15 @@ describe("MigrationTest", () => {
     }
     const m = new M();
     const internals = m as unknown as {
-      adapter: DatabaseAdapter;
       _connectionOverride?: DatabaseAdapter;
-      _poolOverride?: DatabaseAdapter;
+      _poolOverride?: unknown;
     };
+    // Both readers' second arm is DatabaseTasks.migration_connection /
+    // migration_connection_pool (migration.rb:1036-1042), which resolve off
+    // ActiveRecord::Base — so with no ivar set they answer Base's own.
     const baseAdapter = Base.connection;
     const basePool = Base.connectionPool();
     const override = await checkoutRawTestAdapter();
-    internals.adapter = baseAdapter;
     expect(m.connection).toBe(baseAdapter);
     internals._connectionOverride = override;
     expect(m.connection).toBe(override);

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -323,7 +323,6 @@ function announceMigrationText(header: string, message: string): string {
  * Mirrors: ActiveRecord::Migration
  */
 export abstract class Migration {
-  protected adapter!: DatabaseAdapter;
   /** @internal Per-migration connection override — mirrors Rails' @connection ivar. */
   protected _connectionOverride?: DatabaseAdapter;
   /** @internal Per-migration pool override — mirrors Rails' @pool ivar. */
@@ -1362,9 +1361,12 @@ export abstract class Migration {
   // --- Connection (Rails: Migration#connection, #connection_pool) ---
 
   get connection(): DatabaseAdapter {
-    // Rails: `@connection || ActiveRecord::Base.lease_connection`. A bare
-    // migration with no assigned connection leases one from the migration pool.
-    return this._connectionOverride ?? this.adapter ?? migrationArConfig()!.leaseConnection!();
+    // Rails: `@connection || DatabaseTasks.migration_connection`
+    // (`migration.rb:1036-1038`). `DatabaseTasks` is reached through the
+    // call-time config source rather than an import: naming
+    // `tasks/database-tasks.js` here would be a load-time edge back into a
+    // module that already imports this one.
+    return this._connectionOverride ?? migrationArConfig()!.databaseTasks!().migrationConnection();
   }
 
   set connection(conn: DatabaseAdapter | undefined) {

--- a/packages/activerecord/src/migration/ar-config-source.ts
+++ b/packages/activerecord/src/migration/ar-config-source.ts
@@ -1,4 +1,3 @@
-import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
 import type { DatabaseConfigurations } from "../database-configurations.js";
 import type { ConnectionHandler } from "../connection-adapters/abstract/connection-handler.js";
 
@@ -6,7 +5,6 @@ import type { ConnectionHandler } from "../connection-adapters/abstract/connecti
 export interface MigrationArConfig {
   tableNamePrefix: string;
   tableNameSuffix: string;
-  leaseConnection?: () => DatabaseAdapter;
   // `Migration.pending_migrations` (migration.rb:757-769) and
   // `PendingMigrationConnection.with_temporary_pool`
   // (pending_migration_connection.rb:5-11) both name `ActiveRecord::Base` in a

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -413,6 +413,8 @@ export function isPreviouslyPersisted(this: PersistenceRecordDispatch): boolean 
 interface AttributeIO {
   readAttribute(name: string): unknown;
   writeAttribute(name: string, value: unknown): void;
+  // `_assign_attribute`'s no-setter arm (attribute_assignment.rb:70-74).
+  attributeWriterMissing(name: string, value: unknown): void;
 }
 
 type TouchOption = boolean | string | string[];
@@ -969,7 +971,8 @@ function associationWriter(
  * Mirrors Rails' `_assign_attribute` (ActiveModel
  * attribute_assignment.rb:67-75): dispatch through the public setter when one
  * exists (store accessors write to the store hash, not a standalone attribute
- * slot). Falls back to writeAttribute for plain columns and unknown keys.
+ * slot). A key with no setter is `respond_to?(setter)` false, so it reaches
+ * `attribute_writer_missing` (:73) and raises `UnknownAttributeError`.
  *
  * Rails lets setter exceptions propagate raw — the only rescue is the
  * `NoMethodError` arm that reaches `attribute_writer_missing` (:71-74) — so a
@@ -998,7 +1001,7 @@ function _assignAttribute(self: AttributeIO, key: string, value: unknown): Promi
     const result: unknown = setter.call(self, value);
     if (result instanceof Promise) return result as Promise<void>;
   } else {
-    self.writeAttribute(key, value);
+    self.attributeWriterMissing(key, value);
   }
 }
 


### PR DESCRIPTION
Two of the three bundled stories. `move-adapter-specific-snapshot-off-ar-internal-metadata` was **released unbuilt** — its own 2026-08-07 findings block establishes that option 1 (the digest) is unsound and option 2 (the run-token sidecar) is bigger than the ceiling and, per `load-schema-helper.ts:526-532`'s standing warning about that seam, "should be its own PR, not bundled". Released rather than half-built.

Note: this branch has been rebased three times and sibling PRs on `main` have since landed parts of both stories independently. The scope below is what remains after those rebases; see "Overtaken by main" at the bottom.

## Migration#connection names DatabaseTasks

Rails (`activerecord/lib/active_record/migration.rb:1036-1042`):

```ruby
def connection
  @connection || ActiveRecord::Tasks::DatabaseTasks.migration_connection
end
```

- `#connection` is now two arms. The third `?? this.adapter ??` arm is gone, and so is the `protected adapter` field on `Migration` — it had no writer in `src/`, only four test lines in `active-record-schema.test.ts` that now set the Rails-shaped `connection` (i.e. `@connection`) instead.
- It reaches `DatabaseTasks` through the call-time `migrationArConfig().databaseTasks()` source, the indirection `Migrator#connection` already uses; a direct `tasks/database-tasks.js` import from `migration.ts` would be a load-time cycle edge.
- `MigrationArConfig.leaseConnection` then had no readers and is deleted from the slot interface and from the `base.ts` registration.

`migration.trails.test.ts`'s override-routing check asserts against `Base.connection` / `Base.connectionPool()` — the same objects `DatabaseTasks.migration_connection(_pool)` answer — rather than a hand-assigned `adapter`. No test renamed.

## The no-setter arm raises UnknownAttributeError

Rails' `_assign_attribute` (`activemodel/lib/active_model/attribute_assignment.rb:67-75`) rescues `NoMethodError` and, when `respond_to?(setter)` is false, calls `attribute_writer_missing(k.to_s, v)` (:73) — whose default raises `UnknownAttributeError`. trails' no-setter arm instead called `writeAttribute`, which raises `MissingAttributeError: can't write unknown attribute` — the wrong class with the wrong message on the one arm that stands in for "there is no setter here".

`_assignAttribute`'s else-branch now calls `self.attributeWriterMissing(key, value)`, resolved on `Model` (`activemodel/src/model.ts:2483` → `attribute-assignment.ts:20`). Since the association-writer arm returns before it (`persistence.ts:996-997`), that branch is now purely "no setter of any kind" — exactly Rails' `respond_to?(setter)`-false case.

## Overtaken by main during rebase

- **Story 1's `#connectionPool` half.** A sibling PR landed the identical `@pool || DatabaseTasks.migration_connection_pool` body and the sync `DatabaseTasks.migrationConnectionPool`. Took main's version; only the `#connection` half, the `adapter` field deletion and the `leaseConnection` deletion remain here.
- **Story 3's second acceptance criterion** ("`assignAttributes`' association refusal raises the same thing") **is now vacuous.** Main reverted RFC 0087 §1's refusal: `_assignAttribute` sends the association writer again (`persistence.ts:996`) and `assignAttributes` returns `Promise<void> | void`. There is no refusal arm left to route through `attributeWriterMissing`, and the five assertions that enshrined the old `MissingAttributeError` message were deleted by that revert, not by this PR — so the test files are back at main's version verbatim. Criterion 1 is met and is all that survives.

## Verification

`pnpm typecheck`, `pnpm lint`, `api:calls` (OK, no new rows), `api:extra` (no novel names; this PR only deletes surface). Green locally on `persistence.test.ts`, `nested-attributes.test.ts`, `migration.trails.test.ts`, `active-record-schema.test.ts`, `collection-awaitable-writers.trails.test.ts`, `has-one-persisted-setter-throws.trails.test.ts`, `constructor-form-and-hmt-insert.test.ts` (383 passed).

Closes-story: migration-connection-readers-name-lease-connection
Closes-story: assign-attribute-no-setter-arm-raises-missingattributeerror
