### PR TITLE
refactor(activesupport): Time.zone= resolves through findZoneBang

### DIFF
--- a/packages/activesupport/src/time-zone-config.ts
+++ b/packages/activesupport/src/time-zone-config.ts
@@ -16,38 +16,27 @@ import { instantFrom } from "./temporal.js";
 // async request handling. For server contexts with overlapping requests,
 // consider using AsyncLocalStorage or passing the zone explicitly.
 let _zoneDefault: TimeZone | null = null;
-let _zone: TimeZone | null | undefined = undefined; // undefined = not set (falls through to default)
+// undefined = IsolatedExecutionState has no :time_zone key; null/false are the
+// values Rails stores verbatim when find_zone! resolves to them.
+let _zone: TimeZone | null | false | undefined = undefined;
 
 /**
  * Get the current Time.zone. Returns zone_default if not explicitly set.
+ * Mirrors `IsolatedExecutionState[:time_zone] || zone_default` (zones.rb:19-21),
+ * so a stored `nil`/`false` falls through to zone_default just as it does in Rails.
  */
 export function getZone(): TimeZone | null {
-  if (_zone !== undefined) return _zone;
+  if (_zone != null && _zone !== false) return _zone;
   return _zoneDefault;
 }
 
 /**
  * Set Time.zone. Accepts a TimeZone, a string name, null, or false.
- *
- * Rails stores nil and false verbatim; trails' zone slot has no such state, so
- * both reset to zone_default — which is also why this does not yet route through
- * `findZoneBang` the way zones.rb:42 does. See
- * 0072/converge-time-zone-setter-through-find-zone-bang.
+ * Mirrors `IsolatedExecutionState[:time_zone] = find_zone!(time_zone)`
+ * (zones.rb:41-43).
  */
 export function setZone(zone: TimeZone | string | null | false): void {
-  if (zone === null || zone === false) {
-    _zone = undefined; // Reset to zone_default
-    return;
-  }
-  if (zone instanceof TimeZone) {
-    _zone = zone;
-    return;
-  }
-  if (typeof zone === "string") {
-    _zone = TimeZone.find(zone);
-    return;
-  }
-  throw new ArgumentError(`Invalid time zone: ${zone}`);
+  _zone = findZoneBang(zone);
 }
 
 /**
@@ -84,7 +73,7 @@ export function setZoneDefault(zone: TimeZone | null): void {
 export function useZone<T>(zone: string | TimeZone, fn: () => T): T {
   const newZone = findZoneBang(zone);
   const prev = _zone;
-  _zone = newZone as TimeZone | null;
+  _zone = newZone;
   try {
     const result = fn();
     if (result != null && typeof (result as any).then === "function") {

--- a/packages/activesupport/src/time-zone-config.ts
+++ b/packages/activesupport/src/time-zone-config.ts
@@ -16,8 +16,7 @@ import { instantFrom } from "./temporal.js";
 // async request handling. For server contexts with overlapping requests,
 // consider using AsyncLocalStorage or passing the zone explicitly.
 let _zoneDefault: TimeZone | null = null;
-// undefined = IsolatedExecutionState has no :time_zone key; null/false are the
-// values Rails stores verbatim when find_zone! resolves to them.
+// undefined = IsolatedExecutionState has no :time_zone key.
 let _zone: TimeZone | null | false | undefined = undefined;
 
 /**

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/time-zone-config.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/time-zone-config.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activesupport",
-    "tsFile": "time-zone-config.ts",
-    "rubyName": "zone=",
-    "call": "find_zone!",
-    "reason": "`setZone` still resolves the argument inline instead of through `findZoneBang`, because trails maps `nil` onto 'unset, fall through to zone_default' where Rails stores nil. Converging the two needs the zone_default fallthrough settled first; `find_zone`/`use_zone` in this file already route through `findZoneBang`."
-  }
-]


### PR DESCRIPTION
`Time.zone=` was the last member of `core_ext/time/zones.rb` not routing through
`find_zone!`. Rails stores the resolved value verbatim
(`zones.rb:41-43`) and the reader expresses the fallthrough as
`IsolatedExecutionState[:time_zone] || zone_default` (`zones.rb:19-21`) — so a
stored `nil`/`false` reads back as `zone_default` without the setter needing a
special "unset" path.

- `setZone` is now `_zone = findZoneBang(zone)`, dropping the inline
  `TimeZone.find` / `instanceof` resolution (and picking up the numeric/Duration
  arm it never had).
- `getZone` expresses Ruby's `||`: `null`/`false` fall through to
  `_zoneDefault`.
- The `zone=` / `find_zone!` row is deleted from
  `scripts/api-compare/call-mismatches-exclude/activesupport/time-zone-config.json`
  (the file is now empty and removed).

`time-zone.test.ts`, `core-ext/time-with-zone.test.ts`, `date-ext.test.ts`,
`time-zone-converter.test.ts` and `test-helper.test.ts` are green;
`pnpm api:calls` is OK.

Bundled story `move-adapter-specific-snapshot-off-ar-internal-metadata` was
released unbuilt: its own recorded findings (2026-08-07) establish that the
digest arm is unsound, that the run-token-sidecar arm exceeds the 700 LOC
ceiling, and that the `load-schema-helper.ts:526-532` seam must be reshaped one
story at a time — "This story should be its own PR, not bundled."

Closes-story: converge-time-zone-setter-through-find-zone-bang
