### PR TITLE
refactor(activesupport): MessageEncryptor signs through MessageVerifier; Range is a class

### DIFF
--- a/packages/activemodel/src/validations.ts
+++ b/packages/activemodel/src/validations.ts
@@ -1,3 +1,5 @@
+import { Range } from "@blazetrails/activesupport";
+
 import { Errors } from "./errors.js";
 import type { ConditionalOptions } from "./validator.js";
 import { VALIDATOR_DEFAULT_KEYS } from "./validator.js";
@@ -415,19 +417,16 @@ export function _validatesDefaultKeys(): string[] {
  * validator constructor expects. Mirrors Rails
  * `_parse_validates_options(options)`
  * (activemodel/lib/active_model/validations/validates.rb:166-177):
- * `true` → `{}`, plain hash → unchanged, Array → `{ in: options }`,
- * anything else → `{ with: options }`. Rails also routes `Range` to
- * `{ in: ... }`; TS has no first-class Range (see the note in
- * `validations/clusivity.ts`), so a Range-like dispatch slots in
- * here when one lands.
+ * `true` → `{}`, plain hash → unchanged, Range or Array → `{ in: options }`,
+ * anything else → `{ with: options }`.
  *
  * @internal Rails-private helper.
  */
 export function _parseValidatesOptions(options: unknown): Record<string, unknown> {
   if (options === true) return {};
-  if (Array.isArray(options)) return { in: options };
   if (options !== null && typeof options === "object" && options.constructor === Object) {
     return options as Record<string, unknown>;
   }
+  if (options instanceof Range || Array.isArray(options)) return { in: options };
   return { with: options };
 }

--- a/packages/activemodel/src/validations/clusivity.ts
+++ b/packages/activemodel/src/validations/clusivity.ts
@@ -17,11 +17,7 @@
  */
 import { resolveValue } from "./resolve-value.js";
 import { ArgumentError, NoMethodError } from "../attribute-assignment.js";
-import {
-  rangeIncludesValue,
-  rangeIncludesStringValue,
-  type RangeExt as Range,
-} from "@blazetrails/activesupport";
+import { Range } from "@blazetrails/activesupport";
 
 export { resolveValue };
 
@@ -89,7 +85,7 @@ export function checkValidityBang(this: ClusivityHost): void {
       typeof (d as Record<symbol, unknown>)[Symbol.iterator] === "function");
   const isCallable = typeof d === "function";
   // ActiveSupport Range responds to #cover? / #include? — accept it like Rails.
-  if (!isString && !hasIncludeMethod && !isIterable && !isCallable && !isRange(d)) {
+  if (!isString && !hasIncludeMethod && !isIterable && !isCallable && !(d instanceof Range)) {
     throw new ArgumentError(ERROR_MESSAGE);
   }
 }
@@ -174,17 +170,16 @@ export function delimiter(this: ClusivityHost): unknown {
  *     end
  *   end
  *
- * ActiveSupport's `Range` (range-ext.ts) is the first-class Range type
- * here: a numeric/date range dispatches to `cover?` (endpoint check),
- * everything else to `include?`.
+ * A numeric/date range dispatches to `cover?` (endpoint check), everything
+ * else to `include?`.
  *
  * @internal
  */
 export function inclusionMethod(enumerable: unknown): "include?" | "cover?" {
-  if (isRange(enumerable)) {
+  if (enumerable instanceof Range) {
     const endpoint = enumerable.begin ?? enumerable.end;
-    // boundary: range-ext's comparators (rangeIncludesValue) accept JS Date
-    // alongside number, coercing to epoch for ordering — mirror that here.
+    // boundary: range-ext's comparators accept JS Date alongside number,
+    // coercing to epoch for ordering — mirror that here.
     // Per clusivity.rb:40-50 only Numeric/Time/Date endpoints select cover?;
     // a String range falls through to include?, whose membership is the
     // succ-order enumeration check (not a lexicographic cover) Ruby applies
@@ -194,29 +189,13 @@ export function inclusionMethod(enumerable: unknown): "include?" | "cover?" {
   return "include?";
 }
 
-function isRange(members: unknown): members is Range<number | Date | string> {
-  return (
-    typeof members === "object" &&
-    members !== null &&
-    "begin" in members &&
-    "end" in members &&
-    "excludeEnd" in members
-  );
-}
-
 function testMembership(members: unknown, value: unknown, method: "include?" | "cover?"): boolean {
-  if (isRange(members)) {
-    const endpoint = members.begin ?? members.end;
-    // A string-endpoint Range arrives via inclusionMethod's include? branch.
+  if (members instanceof Range) {
     // Ruby's `Range#include?` on strings is succ-order membership, not the
-    // lexicographic `cover?` the numeric/date branch uses.
-    if (typeof endpoint === "string") {
-      return typeof value === "string" && rangeIncludesStringValue(members as Range<string>, value);
-    }
-    if (method === "cover?") {
-      // Range#cover? semantics — endpoint check against the range bounds.
-      return rangeIncludesValue(members as Range<number | Date>, value as number | Date);
-    }
+    // lexicographic `cover?` the numeric/date branch uses; `Range#include?`
+    // carries that split itself.
+    if (method === "cover?") return members.cover(value);
+    return members.isInclude(value);
   }
   return isMemberOf(members, value);
 }

--- a/packages/activemodel/src/validations/inclusion-validation.test.ts
+++ b/packages/activemodel/src/validations/inclusion-validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { makeRange } from "@blazetrails/activesupport";
+import { Range } from "@blazetrails/activesupport";
 import { Model } from "../index.js";
 import { InclusionValidator } from "./inclusion.js";
 
@@ -51,7 +51,7 @@ describe("InclusionValidationTest", () => {
     class Topic extends Model {
       static {
         this.attribute("price", "integer");
-        this.validates("price", { inclusion: { in: makeRange(null, 1000) } });
+        this.validates("price", { inclusion: { in: new Range(null, 1000) } });
       }
     }
     expect(await new Topic({ price: -100 }).isValid()).toBe(true);
@@ -65,7 +65,7 @@ describe("InclusionValidationTest", () => {
     class Topic extends Model {
       static {
         this.attribute("price", "integer");
-        this.validates("price", { inclusion: { in: makeRange(0, null) } });
+        this.validates("price", { inclusion: { in: new Range(0, null) } });
       }
     }
     expect(await new Topic({ price: -1 }).isValid()).toBe(false);
@@ -128,7 +128,7 @@ describe("InclusionValidationTest", () => {
     class Topic extends Model {
       static {
         this.attribute("title", "string");
-        this.validates("title", { inclusion: { in: makeRange("aaa", "bbb") } });
+        this.validates("title", { inclusion: { in: new Range("aaa", "bbb") } });
       }
     }
     expect(await new Topic({ title: "bbc" }).isValid()).toBe(false);

--- a/packages/activemodel/src/validations/validates.trails.test.ts
+++ b/packages/activemodel/src/validations/validates.trails.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+
+import { Range } from "@blazetrails/activesupport";
+
+import { Model } from "../index.js";
+
+describe("ValidatesTest (trails)", () => {
+  it("parses a Range option into :in, as validates.rb:170 does", () => {
+    expect(Model._parseValidatesOptions(new Range(6, 20))).toEqual({ in: new Range(6, 20) });
+    expect(Model._parseValidatesOptions([1, 2])).toEqual({ in: [1, 2] });
+    expect(Model._parseValidatesOptions(true)).toEqual({});
+    expect(Model._parseValidatesOptions({ in: [1] })).toEqual({ in: [1] });
+    expect(Model._parseValidatesOptions(/x/)).toEqual({ with: /x/ });
+  });
+});

--- a/packages/activerecord/src/callbacks.test.ts
+++ b/packages/activerecord/src/callbacks.test.ts
@@ -8,7 +8,7 @@
  * id 1).
  */
 import { describe, it, expect } from "vitest";
-import { makeRange, throwAbort } from "@blazetrails/activesupport";
+import { Range, throwAbort } from "@blazetrails/activesupport";
 import { Base, RecordNotSaved, RecordNotDestroyed, RecordInvalid } from "./index.js";
 import { fixtures } from "./test-fixtures.js";
 import { ContextualCallbacksDeveloper } from "./test-helpers/models/contextual-callbacks-developer.js";
@@ -106,7 +106,7 @@ class ImmutableDeveloper extends Base {
     this.tableName = "developers";
     this.attribute("name", "string");
     this.attribute("salary", "integer");
-    this.validates("salary", { inclusion: { in: makeRange(50000, 200000) } });
+    this.validates("salary", { inclusion: { in: new Range(50000, 200000) } });
     this.beforeSave((record: ImmutableDeveloper) => record.cancel());
     this.beforeDestroy((record: ImmutableDeveloper) => record.cancel());
   }
@@ -123,7 +123,7 @@ class DeveloperWithCanceledCallbacks extends Base {
     this.tableName = "developers";
     this.attribute("name", "string");
     this.attribute("salary", "integer");
-    this.validates("salary", { inclusion: { in: makeRange(50000, 200000) } });
+    this.validates("salary", { inclusion: { in: new Range(50000, 200000) } });
     this.beforeSave((record: DeveloperWithCanceledCallbacks) => record.cancel());
     this.beforeDestroy((record: DeveloperWithCanceledCallbacks) => record.cancel());
   }

--- a/packages/activerecord/src/validations/uniqueness-validation.test.ts
+++ b/packages/activerecord/src/validations/uniqueness-validation.test.ts
@@ -10,7 +10,7 @@
  */
 import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
 import { ArgumentError } from "@blazetrails/activemodel";
-import { makeRange } from "@blazetrails/activesupport";
+import { Range } from "@blazetrails/activesupport";
 import { Base } from "../index.js";
 import { registerModel } from "../associations.js";
 import { registerSubclass } from "../inheritance.js";
@@ -1006,7 +1006,7 @@ class BigIntTest extends Base {
   static {
     this.validates("engines_count", {
       uniqueness: true,
-      inclusion: { in: makeRange(0, INT_MAX_VALUE) },
+      inclusion: { in: new Range(0, INT_MAX_VALUE) },
     });
   }
 }
@@ -1015,7 +1015,7 @@ class BigIntTest extends Base {
 class BigIntReverseTest extends Base {
   static _tableName = "cars";
   static {
-    this.validates("engines_count", { inclusion: { in: makeRange(0, INT_MAX_VALUE) } });
+    this.validates("engines_count", { inclusion: { in: new Range(0, INT_MAX_VALUE) } });
     this.validates("engines_count", { uniqueness: true });
   }
 }

--- a/packages/activesupport/src/core-ext/object/json.ts
+++ b/packages/activesupport/src/core-ext/object/json.ts
@@ -2,9 +2,8 @@ import { Temporal } from "@blazetrails/date";
 
 import { ActiveSupportJSON } from "../../json.js";
 import { Encoding, type EncodeOptions } from "../../json/encoding.js";
-import { isRange, type Range as RangeValue } from "../../range-ext.js";
+import { Range as RangeValue } from "../../range-ext.js";
 import { BigDecimal as BigDecimalValue } from "../big-decimal/conversions.js";
-import { toS } from "../range/conversions.js";
 import * as instanceVariables from "./instance-variables.js";
 
 /**
@@ -151,14 +150,11 @@ export class Enumerable {
 }
 
 /**
- * `Range#as_json` (json.rb:157-161), over trails' begin/end/exclusive triple
- * (`range-ext.ts`). `to_s` is the ported `Range#to_s` in
- * `core-ext/range/conversions.ts`. The dispatcher reaches this arm ahead of
- * `Hash`, which a range would otherwise take as a plain object.
+ * `Range#as_json` (json.rb:157-161).
  */
 export class Range {
   static asJson(value: RangeValue<unknown>): string {
-    return toS(value);
+    return value.toS();
   }
 }
 
@@ -303,12 +299,10 @@ function pad2(value: number): string {
 /**
  * @noRailsEquivalent PERMANENT — a Hash-shaped object: a bare object literal
  * (`Object.prototype` or null prototype), not a class instance like `Date` that
- * defines its own JSON form. Stands in for Ruby's `Hash === value`, so a Range
- * — a plain object here, but not a Hash in Ruby — misses it, both in the
+ * defines its own JSON form. Stands in for Ruby's `Hash === value`, both in the
  * dispatcher below and in `JSONGemEncoder#jsonify`.
  */
 export function isPlainObject(value: object): boolean {
-  if (isRange(value)) return false;
   const proto = globalThis.Object.getPrototypeOf(value);
   return proto === globalThis.Object.prototype || proto === null;
 }
@@ -344,7 +338,7 @@ export function asJson(value: unknown, options?: EncodeOptions | null): unknown 
   if (value instanceof Error) return Exception.asJson(value);
   if (value instanceof URL) return Generic.asJson(value);
   if (globalThis.Array.isArray(value)) return Array.asJson(value, options);
-  if (isRange(value)) return Range.asJson(value);
+  if (value instanceof RangeValue) return Range.asJson(value);
   if (value instanceof Map || isPlainObject(value as object)) return Hash.asJson(value, options);
   if (
     typeof (value as { [globalThis.Symbol.iterator]?: unknown })[globalThis.Symbol.iterator] ===

--- a/packages/activesupport/src/core-ext/range-ext.test.ts
+++ b/packages/activesupport/src/core-ext/range-ext.test.ts
@@ -3,199 +3,197 @@ import { describe, it, expect } from "vitest";
 import { Temporal } from "@blazetrails/date";
 
 import { hours } from "../duration.js";
-import { makeRange, rangeIncludesValue, rangeIncludesStringValue } from "../range-ext.js";
+import { Range } from "../range-ext.js";
 import { instantFromDate } from "../testing/temporal-helpers.js";
 import { TimeWithZone } from "../time-with-zone.js";
 import { TimeZone } from "../values/time-zone.js";
-import { caseEquals, isInclude } from "./range/compare-range.js";
 import { succ } from "./string/succ.js";
-import { toFs, toFormattedS } from "./range/conversions.js";
-import { each, step } from "./range/each.js";
-import { overlap, overlaps } from "./range/overlap.js";
+import "./range/compare-range.js";
+import "./range/conversions.js";
+import "./range/each.js";
+import "./range/overlap.js";
 
 describe("RangeTest", () => {
   it("to fs from dates", () => {
-    const dateRange = makeRange(
+    const dateRange = new Range(
       Temporal.PlainDate.from("2005-12-10"),
       Temporal.PlainDate.from("2005-12-12"),
     );
-    expect(toFs(dateRange, "db")).toBe("BETWEEN '2005-12-10' AND '2005-12-12'");
-    expect(toFormattedS(dateRange, "db")).toBe("BETWEEN '2005-12-10' AND '2005-12-12'");
+    expect(dateRange.toFs("db")).toBe("BETWEEN '2005-12-10' AND '2005-12-12'");
+    expect(dateRange.toFormattedS("db")).toBe("BETWEEN '2005-12-10' AND '2005-12-12'");
   });
 
   it("to fs from times", () => {
-    const dateRange = makeRange(
+    const dateRange = new Range(
       new Date(Date.UTC(2005, 11, 10, 15, 30)),
       new Date(Date.UTC(2005, 11, 10, 17, 30)),
     );
-    expect(toFs(dateRange, "db")).toBe("BETWEEN '2005-12-10 15:30:00' AND '2005-12-10 17:30:00'");
+    expect(dateRange.toFs("db")).toBe("BETWEEN '2005-12-10 15:30:00' AND '2005-12-10 17:30:00'");
   });
 
   it("to fs with alphabets", () => {
-    expect(toFs(makeRange("a", "z"), "db")).toBe("BETWEEN 'a' AND 'z'");
-    expect(toFs(makeRange("a", null), "db")).toBe(">= 'a'");
-    expect(toFs(makeRange(null, "z"), "db")).toBe("<= 'z'");
+    expect(new Range("a", "z").toFs("db")).toBe("BETWEEN 'a' AND 'z'");
+    expect(new Range("a", null).toFs("db")).toBe(">= 'a'");
+    expect(new Range(null, "z").toFs("db")).toBe("<= 'z'");
   });
 
   it("to fs with numeric", () => {
-    expect(toFs(makeRange(1, 100), "db")).toBe("BETWEEN '1' AND '100'");
-    expect(toFs(makeRange(1, null), "db")).toBe(">= '1'");
-    expect(toFs(makeRange(null, 100), "db")).toBe("<= '100'");
+    expect(new Range(1, 100).toFs("db")).toBe("BETWEEN '1' AND '100'");
+    expect(new Range(1, null).toFs("db")).toBe(">= '1'");
+    expect(new Range(null, 100).toFs("db")).toBe("<= '100'");
   });
 
   it("to fs with format invalid format", () => {
-    const numberRange = makeRange(1, 100);
+    const numberRange = new Range(1, 100);
 
-    expect(toFs(numberRange, "not_existent")).toBe("1..100");
+    expect(numberRange.toFs("not_existent")).toBe("1..100");
   });
 
   it("date range", () => {
     const start = new Date("2023-01-01");
     const end = new Date("2023-12-31");
-    const r = makeRange(start, end);
-    expect(rangeIncludesValue(r, new Date("2023-06-15"))).toBe(true);
+    const r = new Range(start, end);
+    expect(r.cover(new Date("2023-06-15"))).toBe(true);
   });
 
   it("overlap last inclusive", () => {
-    expect(overlap(makeRange(1, 5), makeRange(5, 10))).toBe(true);
+    expect(new Range(1, 5).overlap(new Range(5, 10))).toBe(true);
   });
 
   it("overlap last exclusive", () => {
-    expect(overlap(makeRange(1, 5, true), makeRange(5, 10))).toBe(false);
+    expect(new Range(1, 5, true).overlap(new Range(5, 10))).toBe(false);
   });
 
   it("overlap first inclusive", () => {
-    expect(overlap(makeRange(5, 10), makeRange(1, 5))).toBe(true);
+    expect(new Range(5, 10).overlap(new Range(1, 5))).toBe(true);
   });
 
   it("overlap first exclusive", () => {
-    expect(overlap(makeRange(5, 10), makeRange(1, 5, true))).toBe(false);
+    expect(new Range(5, 10).overlap(new Range(1, 5, true))).toBe(false);
   });
 
   it("overlap with beginless range", () => {
-    expect(overlap(makeRange(null, 5), makeRange(3, 10))).toBe(true);
+    expect(new Range(null, 5).overlap(new Range(3, 10))).toBe(true);
   });
 
   it("overlap with two beginless ranges", () => {
-    expect(overlap(makeRange(null, 5), makeRange(null, 10))).toBe(true);
+    expect(new Range(null, 5).overlap(new Range(null, 10))).toBe(true);
   });
 
   it("overlaps alias", () => {
-    expect(overlaps(makeRange(1, 5), makeRange(3, 8))).toBe(true);
+    expect(new Range(1, 5).overlaps(new Range(3, 8))).toBe(true);
   });
 
   it("overlap behaves like ruby", () => {
-    expect(overlap(makeRange(1, 3), makeRange(5, 8))).toBe(false);
+    expect(new Range(1, 3).overlap(new Range(5, 8))).toBe(false);
   });
 
   it("should include identical inclusive", () => {
-    expect(isInclude(makeRange(1, 10), makeRange(1, 10))).toBe(true);
+    expect(new Range(1, 10).isInclude(new Range(1, 10))).toBe(true);
   });
 
   it("should include identical exclusive", () => {
-    expect(isInclude(makeRange(1, 10, true), makeRange(1, 10, true))).toBe(true);
+    expect(new Range(1, 10, true).isInclude(new Range(1, 10, true))).toBe(true);
   });
 
   it("should include other with exclusive end", () => {
-    expect(isInclude(makeRange(1, 10), makeRange(1, 11, true))).toBe(true);
+    expect(new Range(1, 10).isInclude(new Range(1, 11, true))).toBe(true);
   });
 
   it("include returns false for backwards", () => {
-    expect(isInclude(makeRange(1, 10), makeRange(5, 3))).toBe(false);
+    expect(new Range(1, 10).isInclude(new Range(5, 3))).toBe(false);
   });
 
   it("include returns false for empty exclusive end", () => {
-    expect(isInclude(makeRange(1, 5), makeRange(3, 3, true))).toBe(false);
+    expect(new Range(1, 5).isInclude(new Range(3, 3, true))).toBe(false);
   });
 
   it("include with endless range", () => {
-    expect(isInclude(makeRange(1, null), 2)).toBe(true);
+    expect(new Range(1, null).isInclude(2)).toBe(true);
   });
 
   it("should include range with endless range", () => {
-    expect(isInclude(makeRange(1, null), makeRange(2, 4))).toBe(true);
+    expect(new Range(1, null).isInclude(new Range(2, 4))).toBe(true);
   });
 
   it("should not include range with endless range", () => {
-    expect(isInclude(makeRange(1, null), makeRange(0, 4))).toBe(false);
+    expect(new Range(1, null).isInclude(new Range(0, 4))).toBe(false);
   });
 
   it("include with beginless range", () => {
-    expect(isInclude(makeRange(null, 2), 1)).toBe(true);
+    expect(new Range(null, 2).isInclude(1)).toBe(true);
   });
 
   it("should include range with beginless range", () => {
-    expect(isInclude(makeRange(null, 2), makeRange(-1, 1))).toBe(true);
+    expect(new Range(null, 2).isInclude(new Range(-1, 1))).toBe(true);
   });
 
   it("should not include range with beginless range", () => {
-    expect(isInclude(makeRange(null, 2), makeRange(-1, 3))).toBe(false);
+    expect(new Range(null, 2).isInclude(new Range(-1, 3))).toBe(false);
   });
 
   it("should compare identical inclusive", () => {
-    expect(caseEquals(makeRange(1, 10), makeRange(1, 10))).toBe(true);
+    expect(new Range(1, 10).caseEquals(new Range(1, 10))).toBe(true);
   });
 
   it("should compare identical exclusive", () => {
-    expect(caseEquals(makeRange(1, 10, true), makeRange(1, 10, true))).toBe(true);
+    expect(new Range(1, 10, true).caseEquals(new Range(1, 10, true))).toBe(true);
   });
 
   it("should compare other with exclusive end", () => {
-    expect(caseEquals(makeRange(1, 10), makeRange(1, 11, true))).toBe(true);
+    expect(new Range(1, 10).caseEquals(new Range(1, 11, true))).toBe(true);
   });
 
   it("compare returns false for backwards", () => {
-    expect(caseEquals(makeRange(1, 10), makeRange(5, 3))).toBe(false);
+    expect(new Range(1, 10).caseEquals(new Range(5, 3))).toBe(false);
   });
 
   it("compare returns false for empty exclusive end", () => {
-    expect(caseEquals(makeRange(1, 5), makeRange(3, 3, true))).toBe(false);
+    expect(new Range(1, 5).caseEquals(new Range(3, 3, true))).toBe(false);
   });
 
   it("should compare range with endless range", () => {
-    expect(caseEquals(makeRange(1, null), makeRange(2, 4))).toBe(true);
+    expect(new Range(1, null).caseEquals(new Range(2, 4))).toBe(true);
   });
 
   it("should not compare range with endless range", () => {
-    expect(caseEquals(makeRange(1, null), makeRange(0, 4))).toBe(false);
+    expect(new Range(1, null).caseEquals(new Range(0, 4))).toBe(false);
   });
 
   it("should compare range with beginless range", () => {
-    expect(caseEquals(makeRange(null, 2), makeRange(-1, 1))).toBe(true);
+    expect(new Range(null, 2).caseEquals(new Range(-1, 1))).toBe(true);
   });
 
   it("should not compare range with beginless range", () => {
-    expect(caseEquals(makeRange(null, 2), makeRange(-1, 3))).toBe(false);
+    expect(new Range(null, 2).caseEquals(new Range(-1, 3))).toBe(false);
   });
 
   it("exclusive end should not include identical with inclusive end", () => {
-    expect(isInclude(makeRange(1, 10, true), makeRange(1, 10))).toBe(false);
+    expect(new Range(1, 10, true).isInclude(new Range(1, 10))).toBe(false);
   });
 
   it("should not include overlapping first", () => {
-    expect(isInclude(makeRange(2, 8), makeRange(1, 3))).toBe(false);
+    expect(new Range(2, 8).isInclude(new Range(1, 3))).toBe(false);
   });
 
   it("should not include overlapping last", () => {
-    expect(isInclude(makeRange(2, 8), makeRange(5, 9))).toBe(false);
+    expect(new Range(2, 8).isInclude(new Range(5, 9))).toBe(false);
   });
 
   it("should include identical exclusive with floats", () => {
-    expect(isInclude(makeRange(1.0, 10.0, true), makeRange(1.0, 10.0, true))).toBe(true);
+    expect(new Range(1.0, 10.0, true).isInclude(new Range(1.0, 10.0, true))).toBe(true);
   });
 
   it("cover is not override", () => {
-    // Rails: `range.method(:include?) != range.method(:cover?)`. trails' native
-    // `cover?` is `rangeIncludesValue`, which `isInclude` delegates to rather
-    // than aliasing.
-    expect(isInclude).not.toBe(rangeIncludesValue);
+    // Rails: `range.method(:include?) != range.method(:cover?)`.
+    expect(Range.prototype.isInclude).not.toBe(Range.prototype.cover);
   });
   it("overlap on time", () => {
     const t1 = new Date("2023-01-01"),
       t2 = new Date("2023-06-01");
     const t3 = new Date("2023-03-01"),
       t4 = new Date("2023-12-31");
-    expect(overlap(makeRange(t1, t2), makeRange(t3, t4))).toBe(true);
+    expect(new Range(t1, t2).overlap(new Range(t3, t4))).toBe(true);
   });
 
   it("no overlap on time", () => {
@@ -203,7 +201,7 @@ describe("RangeTest", () => {
       t2 = new Date("2023-03-01");
     const t3 = new Date("2023-06-01"),
       t4 = new Date("2023-12-31");
-    expect(overlap(makeRange(t1, t2), makeRange(t3, t4))).toBe(false);
+    expect(new Range(t1, t2).overlap(new Range(t3, t4))).toBe(false);
   });
 
   it("each on time with zone", () => {
@@ -211,7 +209,7 @@ describe("RangeTest", () => {
       instantFromDate(new Date(Date.UTC(2006, 10, 28, 10, 30))),
       TimeZone.find("Eastern Time (US & Canada)"),
     );
-    expect(() => [...each(makeRange(twz.minus(hours(1)), twz))]).toThrow(TypeError);
+    expect(() => [...new Range(twz.minus(hours(1)), twz).each()]).toThrow(TypeError);
   });
 
   it("step on time with zone", () => {
@@ -219,46 +217,46 @@ describe("RangeTest", () => {
       instantFromDate(new Date(Date.UTC(2006, 10, 28, 10, 30))),
       TimeZone.find("Eastern Time (US & Canada)"),
     );
-    expect(() => [...step(makeRange(twz.minus(hours(1)), twz), 1)]).toThrow(TypeError);
+    expect(() => [...new Range(twz.minus(hours(1)), twz).step(1)]).toThrow(TypeError);
   });
   it.skip("cover on time with zone");
   it.skip("case equals on time with zone");
 
   it("date time with each", () => {
-    const r = makeRange(0, 4);
-    expect([...each(r)]).toEqual([0, 1, 2, 3, 4]);
+    const r = new Range(0, 4);
+    expect([...r.each()]).toEqual([0, 1, 2, 3, 4]);
   });
 
   it("string include uses succ order not lexicographic", () => {
     // Mirrors Ruby ("aaa".."bbb").include? — succ order (length, then lex).
-    const r = makeRange("aaa", "bbb");
-    expect(rangeIncludesStringValue(r, "aaa")).toBe(true);
-    expect(rangeIncludesStringValue(r, "abc")).toBe(true);
-    expect(rangeIncludesStringValue(r, "bbb")).toBe(true);
-    expect(rangeIncludesStringValue(r, "bbc")).toBe(false); // past end
-    expect(rangeIncludesStringValue(r, "aa")).toBe(false); // shorter than begin
-    expect(rangeIncludesStringValue(r, "aaab")).toBe(false); // longer than end
+    const r = new Range("aaa", "bbb");
+    expect(r.isInclude("aaa")).toBe(true);
+    expect(r.isInclude("abc")).toBe(true);
+    expect(r.isInclude("bbb")).toBe(true);
+    expect(r.isInclude("bbc")).toBe(false); // past end
+    expect(r.isInclude("aa")).toBe(false); // shorter than begin
+    expect(r.isInclude("aaab")).toBe(false); // longer than end
 
     // succ order, not lexical: "z" is shorter than "bbb" so it sorts before it,
     // even though "z" > "bbb" lexically. Ruby: ("a".."bbb").include?("z") == true.
-    const r2 = makeRange("a", "bbb");
-    expect(rangeIncludesStringValue(r2, "z")).toBe(true);
-    expect(rangeIncludesStringValue(r2, "ab")).toBe(true);
-    expect(rangeIncludesStringValue(makeRange("a", "z"), "mm")).toBe(false);
+    const r2 = new Range("a", "bbb");
+    expect(r2.isInclude("z")).toBe(true);
+    expect(r2.isInclude("ab")).toBe(true);
+    expect(new Range("a", "z").isInclude("mm")).toBe(false);
   });
 
   it("string include approximates succ for mixed character classes", () => {
     // Ruby's String#succ never produces "a1" from "a" (it carries within a
     // single character class and never mixes letters with digits), so
     // ("a".."bbb").include?("a1") == false. Faithful succ enumeration matches.
-    expect(rangeIncludesStringValue(makeRange("a", "bbb"), "a1")).toBe(false);
+    expect(new Range("a", "bbb").isInclude("a1")).toBe(false);
   });
 
   it("string include raises on beginless/endless ranges", () => {
     // Ruby's Range#include? raises TypeError on beginless/endless string
     // ranges ("cannot determine inclusion in beginless/endless ranges").
-    expect(() => rangeIncludesStringValue(makeRange(null, "bbb"), "z")).toThrow(TypeError);
-    expect(() => rangeIncludesStringValue(makeRange("a", null), "z")).toThrow(TypeError);
+    expect(() => new Range(null, "bbb").isInclude("z")).toThrow(TypeError);
+    expect(() => new Range("a", null).isInclude("z")).toThrow(TypeError);
   });
 
   it("string succ carries within character classes", () => {
@@ -284,7 +282,7 @@ describe("RangeTest", () => {
   });
 
   it("date time with step", () => {
-    const r = makeRange(0, 10);
-    expect([...step(r, 2)]).toEqual([0, 2, 4, 6, 8, 10]);
+    const r = new Range(0, 10);
+    expect([...r.step(2)]).toEqual([0, 2, 4, 6, 8, 10]);
   });
 });

--- a/packages/activesupport/src/core-ext/range/compare-range.ts
+++ b/packages/activesupport/src/core-ext/range/compare-range.ts
@@ -1,42 +1,28 @@
-import { type Range, rangeIncludesValue } from "../../range-ext.js";
+import { prepend } from "../../prepend.js";
+import { Range } from "../../range-ext.js";
 
 /**
  * `ActiveSupport::CompareWithRange`
  * (core_ext/range/compare_range.rb:2), which Ruby `prepend`s onto `Range`.
- *
- * JS has no `Range` class to reopen — trails carries the begin/end/exclusive
- * triple as data (`range-ext.ts`) — so the two prepended methods take the
- * receiver as their first parameter and `super` is `rangeIncludesValue`, the
- * native endpoint comparison. Ruby's native `Range#include?` iterates for
- * non-numeric endpoints; that arm is `rangeIncludesStringValue` (range-ext.ts)
- * and is outside these signatures, which take the numeric/`Date` endpoints the
- * range-vs-range comparison is defined over.
+ * `prepend()` is the trails idiom for `Module#prepend`, so `super` arrives as
+ * the wrapper's first argument.
  *
  * @boundary-file: endpoints are compared as `number` (JS `Date` coerced to
- *   epoch millis), exactly as `range-ext.ts`'s sibling comparators do — Ruby
- *   compares any `<=>`-able endpoint.
+ *   epoch millis), exactly as `range-ext.ts`'s comparators do — Ruby compares
+ *   any `<=>`-able endpoint.
  */
-
-/**
- * Ruby's `Range#max` on the `value.max` branch below (compare_range.rb:23,49).
- * Ruby raises `TypeError` for a non-Integer excluded end; mirror that rather
- * than silently comparing against a fractional endpoint.
- */
-function rangeMax<T extends number | Date>(range: Range<T>): T {
-  const end = range.end as T;
-  if (!range.excludeEnd) return end;
-  if (typeof end === "number") {
-    // Ruby's own `Range#max` message; activesupport has no ported TypeError.
-    // eslint-disable-next-line blazetrails/rails-error-parity
-    if (!Number.isInteger(end)) throw new TypeError("cannot exclude non Integer end value");
-    return (end - 1) as T;
-  }
-  // boundary: Date endpoints, as in range-ext.ts
-  return new Date(end.getTime() - 1) as T;
-}
 
 // boundary: Date endpoints, as in range-ext.ts
-const toNum = <T extends number | Date>(v: T): number => (v instanceof Date ? v.getTime() : v);
+const toNum = <T>(v: T): number => (v instanceof Date ? v.getTime() : (v as number));
+
+declare module "../../range-ext.js" {
+  interface Range<T> {
+    caseEquals(value: Range<T> | T): boolean;
+    isInclude(value: Range<T> | T): boolean;
+  }
+}
+
+type Super = (...args: unknown[]) => unknown;
 
 /**
  * Extends the default `Range#===` to support range comparisons.
@@ -50,13 +36,9 @@ const toNum = <T extends number | Date>(v: T): number => (v instanceof Date ? v.
  *  (5..9) === (11) # => false
  *
  * The given range must be fully bounded, with both start and end.
- *
- * @missingRailsCall last — Ruby reads the endpoint with `Range#last`
- * (compare_range.rb:24,50); trails' `Range` is the begin/end/exclusive triple
- * (range-ext.ts), whose endpoint field IS `end`, so there is no `last` to call.
  */
-export function caseEquals<T extends number | Date>(range: Range<T>, value: Range<T> | T): boolean {
-  if (isRange(value)) {
+export function caseEquals<T>(this: Range<T>, super_: Super, value: Range<T> | T): boolean {
+  if (value instanceof Range) {
     const isBackwardsOp = value.excludeEnd
       ? (a: number, b: number): boolean => a >= b
       : (a: number, b: number): boolean => a > b;
@@ -70,16 +52,16 @@ export function caseEquals<T extends number | Date>(range: Range<T>, value: Rang
     // 1...10 includes 1..9 but it does not include 1..10.
     // 1..10 includes 1...11 but it does not include 1...12.
     const operator =
-      range.excludeEnd && !value.excludeEnd
+      this.excludeEnd && !value.excludeEnd
         ? (a: number, b: number): boolean => a < b
         : (a: number, b: number): boolean => a <= b;
-    const valueMax = !range.excludeEnd && value.excludeEnd ? rangeMax(value) : value.end;
+    const valueMax = !this.excludeEnd && value.excludeEnd ? value.max() : value.last();
     return (
-      rangeIncludesValue(range, value.begin as T) &&
-      (range.end === null || operator(toNum(valueMax as T), toNum(range.end)))
+      (super_.call(this, value.first()) as boolean) &&
+      (this.end === null || operator(toNum(valueMax as T), toNum(this.last() as T)))
     );
   } else {
-    return rangeIncludesValue(range, value);
+    return super_.call(this, value) as boolean;
   }
 }
 
@@ -95,13 +77,9 @@ export function caseEquals<T extends number | Date>(range: Range<T>, value: Rang
  *  (5..9).include?(11) # => false
  *
  * The given range must be fully bounded, with both start and end.
- *
- * @missingRailsCall last — Ruby reads the endpoint with `Range#last`
- * (compare_range.rb:24,50); trails' `Range` is the begin/end/exclusive triple
- * (range-ext.ts), whose endpoint field IS `end`, so there is no `last` to call.
  */
-export function isInclude<T extends number | Date>(range: Range<T>, value: Range<T> | T): boolean {
-  if (isRange(value)) {
+export function isInclude<T>(this: Range<T>, super_: Super, value: Range<T> | T): boolean {
+  if (value instanceof Range) {
     const isBackwardsOp = value.excludeEnd
       ? (a: number, b: number): boolean => a >= b
       : (a: number, b: number): boolean => a > b;
@@ -115,24 +93,17 @@ export function isInclude<T extends number | Date>(range: Range<T>, value: Range
     // 1...10 includes 1..9 but it does not include 1..10.
     // 1..10 includes 1...11 but it does not include 1...12.
     const operator =
-      range.excludeEnd && !value.excludeEnd
+      this.excludeEnd && !value.excludeEnd
         ? (a: number, b: number): boolean => a < b
         : (a: number, b: number): boolean => a <= b;
-    const valueMax = !range.excludeEnd && value.excludeEnd ? rangeMax(value) : value.end;
+    const valueMax = !this.excludeEnd && value.excludeEnd ? value.max() : value.last();
     return (
-      rangeIncludesValue(range, value.begin as T) &&
-      (range.end === null || operator(toNum(valueMax as T), toNum(range.end)))
+      (super_.call(this, value.first()) as boolean) &&
+      (this.end === null || operator(toNum(valueMax as T), toNum(this.last() as T)))
     );
   } else {
-    return rangeIncludesValue(range, value);
+    return super_.call(this, value) as boolean;
   }
 }
 
-/**
- * Ruby's `value.is_a?(::Range)` (compare_range.rb:16,42). trails' `Range` is a
- * plain object, so the type test is structural.
- */
-function isRange<T extends number | Date>(value: Range<T> | T): value is Range<T> {
-  // boundary: Date endpoints, as in range-ext.ts
-  return typeof value === "object" && value !== null && !(value instanceof Date);
-}
+prepend(Range.prototype, { caseEquals, isInclude });

--- a/packages/activesupport/src/core-ext/range/conversions.ts
+++ b/packages/activesupport/src/core-ext/range/conversions.ts
@@ -1,16 +1,22 @@
 import { Temporal } from "@blazetrails/date";
 
-import type { Range } from "../../range-ext.js";
+import { Range } from "../../range-ext.js";
 import { toFs as timeToFs } from "../../time-ext.js";
 
 /**
  * `ActiveSupport::RangeWithFormat`
  * (core_ext/range/conversions.rb:5), which Ruby `prepend`s onto `Range`.
  *
- * JS has no `Range` class to reopen — trails carries the begin/end/exclusive
- * triple as data (`range-ext.ts`) — so `to_fs` takes the receiver as its first
- * parameter, exactly as `compare-range.ts` does.
+ * `to_fs` defines no `super` call, so it is mixed onto `Range` with the
+ * settled `this`-typed-function idiom rather than through `prepend()`.
  */
+
+declare module "../../range-ext.js" {
+  interface Range<T> {
+    toFs(format?: string): string | undefined;
+    toFormattedS(format?: string): string | undefined;
+  }
+}
 
 /**
  * Ruby's `start.to_fs(:db)` (conversions.rb:12,18,24). Ruby dispatches on the
@@ -25,20 +31,6 @@ function toFsDb(value: unknown): string {
   // boundary: as above, an Instant is bridged to the Date `toFs` accepts.
   if (value instanceof Temporal.Instant) return timeToFs(new Date(value.epochMilliseconds), "db");
   return String(value);
-}
-
-/**
- * Ruby's `Range#to_s` (the `to_fs` fallback at conversions.rb:55).
- *
- * @noRailsEquivalent PERMANENT — `Range#to_s` is core Ruby, not a Rails
- * reopening, so no Rails file declares it; it is exported from here, the Rails
- * file whose `to_fs` falls back to it, rather than copied into
- * `core-ext/object/json.ts` for `Range#as_json`.
- */
-export function toS<T>(range: Range<T>): string {
-  const begin = range.begin !== null ? String(range.begin) : "";
-  const end = range.end !== null ? String(range.end) : "";
-  return `${begin}${range.excludeEnd ? "..." : ".."}${end}`;
 }
 
 export const RANGE_FORMATS: Record<string, (start: unknown, stop: unknown) => string | undefined> =
@@ -84,13 +76,15 @@ export const RANGE_FORMATS: Record<string, (start: unknown, stop: unknown) => st
  * formatter returns `nil` when its `if`/`elsif` chain falls through
  * (conversions.rb:20-26).
  */
-export function toFs<T>(range: Range<T>, format: string = "default"): string | undefined {
+export function toFs<T>(this: Range<T>, format: string = "default"): string | undefined {
   const formatter = RANGE_FORMATS[format];
   if (formatter) {
-    return formatter(range.begin, range.end);
+    return formatter(this.begin, this.end);
   } else {
-    return toS(range);
+    return this.toS();
   }
 }
 
 export const toFormattedS = toFs;
+
+Object.assign(Range.prototype, { toFs, toFormattedS });

--- a/packages/activesupport/src/core-ext/range/each.ts
+++ b/packages/activesupport/src/core-ext/range/each.ts
@@ -1,53 +1,25 @@
-import type { Range } from "../../range-ext.js";
+import { prepend } from "../../prepend.js";
+import { Range } from "../../range-ext.js";
 import { TimeWithZone } from "../../time-with-zone.js";
 
 /**
  * `ActiveSupport::EachTimeWithZone`
- * (core_ext/range/each.rb:6), which Ruby `prepend`s onto `Range`.
- *
- * JS has no `Range` class to reopen — trails carries the begin/end/exclusive
- * triple as data (`range-ext.ts`) — so the receiver is the first parameter and
- * `super` is `enumerate`, the core `Range#each` / `Range#step` these two guard.
- * Ruby yields to a block; the TS analogue is a generator.
+ * (core_ext/range/each.rb:6), which Ruby `prepend`s onto `Range`. `prepend()`
+ * is the trails idiom for `Module#prepend`, so `super` — core `Range#each` /
+ * `Range#step` — arrives as the wrapper's first argument. Ruby yields to a
+ * block; the TS analogue is a generator.
  */
 
-/**
- * Ruby's `super` at each.rb:9,14 — core `Range#each` / `Range#step`, which JS
- * has no `Range` class to inherit from. Reached only through the two guarded
- * entry points below, which have already raised on a beginless range.
- */
-function* enumerate(range: Range<number | TimeWithZone>, n: number): Generator<number> {
-  let current = range.begin as number;
-  while (true) {
-    if (range.end !== null) {
-      const end = range.end as number;
-      if (range.excludeEnd ? current >= end : current > end) break;
-    }
-    yield current;
-    current += n;
-  }
+type SuperEach<T> = (...args: unknown[]) => unknown;
+
+export function* each<T>(this: Range<T>, super_: SuperEach<T>): Generator<T> {
+  ensureIterationAllowed.call(this);
+  yield* super_.call(this) as Generator<T>;
 }
 
-export function* each(range: Range<number | TimeWithZone>): Generator<number> {
-  ensureIterationAllowed(range);
-  yield* enumerate(range, 1);
-}
-
-export function* step(range: Range<number | TimeWithZone>, n: number = 1): Generator<number> {
-  ensureIterationAllowed(range);
-  yield* enumerate(range, n);
-}
-
-/**
- * Ruby's core `Range#first`, which `ensureIterationAllowed` calls for its
- * receiver's class — and which raises before that check on a beginless range.
- */
-function first(range: Range<number | TimeWithZone>): number | TimeWithZone {
-  if (range.begin === null) {
-    // eslint-disable-next-line blazetrails/rails-error-parity
-    throw new RangeError("cannot get the first element of beginless range");
-  }
-  return range.begin;
+export function* step<T>(this: Range<T>, super_: SuperEach<T>, n: number = 1): Generator<T> {
+  ensureIterationAllowed.call(this);
+  yield* super_.call(this, n) as Generator<T>;
 }
 
 /**
@@ -55,9 +27,11 @@ function first(range: Range<number | TimeWithZone>): number | TimeWithZone {
  * because the guard fires only for `TimeWithZone`, whose Ruby name is not
  * recoverable from the TS class.
  */
-function ensureIterationAllowed(range: Range<number | TimeWithZone>): void {
-  if (first(range) instanceof TimeWithZone) {
+function ensureIterationAllowed<T>(this: Range<T>): void {
+  if (this.first() instanceof TimeWithZone) {
     // eslint-disable-next-line blazetrails/rails-error-parity
     throw new TypeError("can't iterate from ActiveSupport::TimeWithZone");
   }
 }
+
+prepend(Range.prototype, { each, step });

--- a/packages/activesupport/src/core-ext/range/overlap.ts
+++ b/packages/activesupport/src/core-ext/range/overlap.ts
@@ -1,10 +1,10 @@
-import { isRange, type Range } from "../../range-ext.js";
+import { Range } from "../../range-ext.js";
 
 /**
  * `Range#overlap?` / `#overlaps?` (core_ext/range/overlap.rb:8,39), which Ruby
- * reopens `Range` to define. JS has no `Range` class to reopen — trails carries
- * the begin/end/exclusive triple as data (`range-ext.ts`) — so the receiver is
- * the first parameter, exactly as `compare-range.ts` does.
+ * reopens `Range` to define. The reopening is the settled `this`-typed-function
+ * mixin, assigned onto `Range.prototype` at the bottom of this file exactly
+ * where Ruby closes `class Range`.
  *
  * @boundary-file: endpoints are compared as `number` (JS `Date` coerced to
  *   epoch millis), as `range-ext.ts`'s sibling comparators do — Ruby compares
@@ -33,19 +33,19 @@ function _isEmptyRange<T extends number | Date>(b: T | null, e: T | null, excl: 
  *  (1..5).overlap?(4..6) # => true
  *  (1..5).overlap?(7..9) # => false
  */
-export function overlap<T extends number | Date>(range: Range<T>, other: Range<T>): boolean {
+export function overlap<T extends number | Date>(this: Range<T>, other: Range<T>): boolean {
   // eslint-disable-next-line blazetrails/rails-error-parity
-  if (!isRange(other)) throw new TypeError();
+  if (!(other instanceof Range)) throw new TypeError();
 
-  const selfBegin = range.begin;
+  const selfBegin = this.begin;
   const otherEnd = other.end;
   const otherExcl = other.excludeEnd;
 
   if (_isEmptyRange(selfBegin, otherEnd, otherExcl)) return false;
 
   const otherBegin = other.begin;
-  const selfEnd = range.end;
-  const selfExcl = range.excludeEnd;
+  const selfEnd = this.end;
+  const selfExcl = this.excludeEnd;
 
   if (_isEmptyRange(otherBegin, selfEnd, selfExcl)) return false;
   if (eq(selfBegin, otherBegin)) return true;
@@ -57,3 +57,12 @@ export function overlap<T extends number | Date>(range: Range<T>, other: Range<T
 }
 
 export const overlaps = overlap;
+
+declare module "../../range-ext.js" {
+  interface Range<T> {
+    overlap(other: Range<T>): boolean;
+    overlaps(other: Range<T>): boolean;
+  }
+}
+
+Object.assign(Range.prototype, { overlap, overlaps });

--- a/packages/activesupport/src/core-ext/string/succ.ts
+++ b/packages/activesupport/src/core-ext/string/succ.ts
@@ -1,8 +1,8 @@
 /**
  * `String#succ` — a Ruby *core* method, not a Rails extension, so it has no
  * `core_ext/string/*.rb` counterpart. It lives with the string core-ext rather
- * than with the range files that consume it (`rangeIncludesStringValue`
- * enumerates a string range by repeatedly applying it).
+ * than with the range files that consume it (`Range#include?` enumerates a
+ * string range by repeatedly applying it).
  *
  * @noRailsEquivalent PERMANENT — Ruby core `String#succ` (string.c
  * `rb_str_succ`), which Rails inherits rather than defines.

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -522,8 +522,7 @@ export {
 export type { AssertCalledOptions, CallRecord } from "./testing-helpers.js";
 export { currentTimeInstant } from "./time-travel.js";
 
-export { makeRange, rangeIncludesValue, rangeIncludesStringValue } from "./range-ext.js";
-export type { Range as RangeExt } from "./range-ext.js";
+export { Range } from "./range-ext.js";
 export { caseEquals, isInclude } from "./core-ext/range/compare-range.js";
 export { overlap, overlaps } from "./core-ext/range/overlap.js";
 // Note: core-ext/range's conversions and each are intentionally kept as subpath

--- a/packages/activesupport/src/json/encoding.test.ts
+++ b/packages/activesupport/src/json/encoding.test.ts
@@ -7,7 +7,7 @@ import { TimeZone } from "../values/time-zone.js";
 import { Encoding } from "./encoding.js";
 import { asJson } from "../core-ext/object/json.js";
 import { BigDecimal } from "../core-ext/big-decimal/conversions.js";
-import { makeRange } from "../range-ext.js";
+import { Range } from "../range-ext.js";
 
 /** Rails' `JSONTest::Hashlike` (encoding_test_cases.rb:16-20). */
 class Hashlike {
@@ -81,9 +81,9 @@ describe("TestJSONEncoding", () => {
 
   it("range", () => {
     // Rails' RangeTests (encoding_test_cases.rb:86-88).
-    expect(ActiveSupportJSON.encode(makeRange(1, 2))).toBe('"1..2"');
-    expect(ActiveSupportJSON.encode(makeRange(1, 2, true))).toBe('"1...2"');
-    expect(ActiveSupportJSON.encode(makeRange(1.5, 2.5))).toBe('"1.5..2.5"');
+    expect(ActiveSupportJSON.encode(new Range(1, 2))).toBe('"1..2"');
+    expect(ActiveSupportJSON.encode(new Range(1, 2, true))).toBe('"1...2"');
+    expect(ActiveSupportJSON.encode(new Range(1.5, 2.5))).toBe('"1.5..2.5"');
   });
 
   it("uri", () => {

--- a/packages/activesupport/src/message-encryptor.test.ts
+++ b/packages/activesupport/src/message-encryptor.test.ts
@@ -64,9 +64,7 @@ describe("MessageEncryptorTest", () => {
     expect(firstMessage).not.toEqual(secondMessage);
   });
 
-  // Needs Rails' wire format — story:
-  // converge-message-encryptor-sign-through-message-verifier.
-  it.skip("messing with either encrypted values causes failure", () => {
+  it("messing with either encrypted values causes failure", () => {
     const [text, iv] = (verifier.verify(encryptor.encryptAndSign(data)) as string).split("--") as [
       string,
       string,
@@ -90,8 +88,9 @@ describe("MessageEncryptorTest", () => {
     expect(encryptor.decryptAndVerify(message)).toEqual(data);
   });
 
-  // Rails' `Base64(payload)--digest` wire format, so this fails at `missing
-  // separator` — story: converge-message-encryptor-sign-through-message-verifier.
+  // Its payload is Marshal-serialized, so it fails at "Unsupported
+  // serialization format" — story:
+  // message-encryptor-marshal-payload-backwards-compatibility.
   it.skip("backwards compat for 64 bytes key", () => {
     // 64 bit key
     const secret = Buffer.from(

--- a/packages/activesupport/src/message-encryptor.ts
+++ b/packages/activesupport/src/message-encryptor.ts
@@ -1,4 +1,5 @@
 import { getCrypto } from "./crypto-adapter.js";
+import { MessageVerifier } from "./message-verifier.js";
 import { Codec, type MessageSerializer } from "./messages/codec.js";
 import type { ExpectedMetadataOptions, MetadataOptions } from "./messages/metadata.js";
 import {
@@ -51,10 +52,9 @@ export class MessageEncryptor extends Codec {
   declare fallBackTo: (fallback: this) => this;
 
   private secret: Buffer;
-  private signSecret: Buffer;
   private cipher: string;
-  private digest: string;
   private aeadMode: boolean;
+  private verifier?: MessageVerifier;
   private memoLengthOfEncodedIv?: number;
   private memoLengthOfEncodedAuthTag?: number;
 
@@ -83,17 +83,12 @@ export class MessageEncryptor extends Codec {
       forceLegacyMetadataSerializer: opts.forceLegacyMetadataSerializer,
     });
 
+    this.secret = typeof secret === "string" ? Buffer.from(secret) : secret;
     this.cipher = opts.cipher ?? (this.constructor as typeof MessageEncryptor).defaultCipher();
     this.aeadMode = this.newCipher().authenticated;
-    this.digest = opts.digest ?? "sha1";
-
-    this.secret = typeof secret === "string" ? Buffer.from(secret) : secret;
-
-    if (signSecret) {
-      this.signSecret = typeof signSecret === "string" ? Buffer.from(signSecret) : signSecret;
-    } else {
-      this.signSecret = this.secret;
-    }
+    this.verifier = !this.aeadMode
+      ? new MessageVerifier(signSecret ?? secret, { ...opts, serializer: NullSerializer })
+      : undefined;
 
     initializeRotator(
       this,
@@ -115,33 +110,19 @@ export class MessageEncryptor extends Codec {
   }
 
   createMessage(value: unknown, options: MetadataOptions = {}): string {
-    const encrypted = this.encrypt(this.serializeWithMetadata(value, options));
-    if (this.aeadMode) return encrypted;
-    return `${encrypted}${SEPARATOR}${this.sign(encrypted)}`;
+    return this.sign(this.encrypt(this.serializeWithMetadata(value, options)));
   }
 
   readMessage(message: string, options: ExpectedMetadataOptions = {}): unknown {
-    if (!message || typeof message !== "string") {
-      throw new Thrown("invalid_message_format", "invalid message string");
-    }
+    return this.deserializeWithMetadata(this.decrypt(this.verify(message)), options);
+  }
 
-    let encrypted = message;
+  private sign(data: string): string {
+    return this.verifier ? this.verifier.createMessage(data) : data;
+  }
 
-    if (!this.aeadMode) {
-      const lastDash = message.lastIndexOf(SEPARATOR);
-      if (lastDash === -1) {
-        throw new Thrown("invalid_message_format", "missing message digest");
-      }
-
-      encrypted = message.slice(0, lastDash);
-      const signature = message.slice(lastDash + SEPARATOR.length);
-
-      if (!this.verify(encrypted, signature)) {
-        throw new Thrown("invalid_message_format", "mismatched digest");
-      }
-    }
-
-    return this.deserializeWithMetadata(this.decrypt(encrypted), options);
+  private verify(data: string): string {
+    return this.verifier ? (this.verifier.readMessage(data) as string) : data;
   }
 
   private encrypt(data: string): string {
@@ -176,22 +157,6 @@ export class MessageEncryptor extends Codec {
       return decryptedData.toString("latin1");
     } catch (error) {
       throw new Thrown("invalid_message_format", error);
-    }
-  }
-
-  private sign(data: string): string {
-    return getCrypto().createHmac(this.digest, this.signSecret).update(data).digest("hex");
-  }
-
-  private verify(data: string, signature: string): boolean {
-    try {
-      const expected = this.sign(data);
-      const expectedBuf = Buffer.from(expected, "hex");
-      const sigBuf = Buffer.from(signature, "hex");
-      if (sigBuf.length !== expectedBuf.length) return false;
-      return getCrypto().timingSafeEqual(sigBuf, expectedBuf);
-    } catch {
-      return false;
     }
   }
 

--- a/packages/activesupport/src/range-ext.ts
+++ b/packages/activesupport/src/range-ext.ts
@@ -1,114 +1,166 @@
 /**
- * The `Range` data triple, plus the core `Range` methods Ruby provides and
- * Rails' `core_ext/range/*` files reopen. Those Rails files are ported
- * one-for-one under `core-ext/range/`.
+ * Ruby's core `Range` class, which Rails' `core_ext/range/*` files reopen.
+ * Those Rails files are ported one-for-one under `core-ext/range/`, and reopen
+ * this class the way Ruby reopens `Range`.
  *
- * @boundary-file: the Date-aware comparators here coerce `Date` ↔ epoch number
- *   for ordering since Rails' `Range#include?` accepts any `<=>`-comparable
- *   value. Temporal-typed ranges live elsewhere.
+ * @boundary-file: the comparators here coerce `Date` ↔ epoch number for
+ *   ordering since Rails' `Range#cover?` accepts any `<=>`-comparable value.
+ *   Temporal-typed ranges live elsewhere.
  */
 
 import { succ } from "./core-ext/string/succ.js";
 
+/** Ruby's `a <=> b` over the endpoint types trails' ranges carry. */
+function cmp(a: unknown, b: unknown): number {
+  // boundary: Date endpoints are compared as epoch millis.
+  const av = a instanceof Date ? a.getTime() : a;
+  const bv = b instanceof Date ? b.getTime() : b;
+  return (av as number) < (bv as number) ? -1 : (av as number) > (bv as number) ? 1 : 0;
+}
+
 /**
- * The value shape these helpers operate on. Ruby's `Range` is a core class
- * these core-ext files reopen; JS has no such class, so trails carries the
- * begin/end/exclusive triple as data instead.
+ * Ruby's core `Range`. Only the members Rails' reopenings and the framework
+ * call are defined; `begin`, `end` and `exclude_end?` are the three readers
+ * every one of them reads off the receiver.
  *
- * @noRailsEquivalent PERMANENT — the Ruby `Range` constant it collides with
- * is the core class itself, which cannot be "ported" to a TS declaration; the
- * Rails-declared `Range` classes (`Arel::Nodes::Range`, PG `OID::Range`) are
- * unrelated node/type classes.
+ * @noRailsEquivalent PERMANENT — `Range` is a core Ruby class, not a Rails
+ * declaration, so no Rails file declares it; the Rails-declared `Range`
+ * classes (`Arel::Nodes::Range`, PG `OID::Range`) are unrelated node/type
+ * classes.
  */
-export interface Range<T> {
-  begin: T | null; // null = beginless
-  end: T | null; // null = endless
-  excludeEnd: boolean; // true = exclusive end (like ...)
-}
+export class Range<T> {
+  constructor(
+    readonly begin: T | null, // null = beginless
+    readonly end: T | null, // null = endless
+    readonly excludeEnd: boolean = false, // true = exclusive end (like ...)
+  ) {}
 
-export function makeRange<T>(begin: T | null, end: T | null, excludeEnd = false): Range<T> {
-  return { begin, end, excludeEnd };
-}
-
-/**
- * Ruby's `value.is_a?(::Range)` (overlap.rb:9, json.rb dispatch). trails' Range
- * is the data triple above rather than a class, so the test is structural.
- *
- * @noRailsEquivalent PERMANENT — the class test it stands in for has no TS
- * analogue while `Range` is an interface; see the interface's own tag.
- */
-export function isRange(value: unknown): value is Range<unknown> {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "begin" in value &&
-    "end" in value &&
-    typeof (value as Range<unknown>).excludeEnd === "boolean"
-  );
-}
-
-/**
- * cover? — returns true if a numeric/date range covers a scalar value
- * (endpoint comparison via `<=>`).
- */
-export function rangeIncludesValue<T extends number | Date>(range: Range<T>, value: T): boolean {
-  const toNum = (v: T): number => (v instanceof Date ? v.getTime() : v);
-  const n = toNum(value);
-
-  if (range.begin !== null && n < toNum(range.begin)) return false;
-  if (range.end !== null) {
-    if (range.excludeEnd ? n >= toNum(range.end) : n > toNum(range.end)) return false;
-  }
-  return true;
-}
-
-const lexCmp = (a: string, b: string): number => (a < b ? -1 : a > b ? 1 : 0);
-
-/**
- * String `Range#include?` — membership in the `succ`-enumerated sequence from
- * `begin` to `end`, NOT a plain lexicographic cover. Ruby enumerates string
- * ranges by `String#succ` (range.c `rb_str_include_range_p` → `str_upto_each`),
- * so a value is a member only if it is actually *reachable* by repeatedly
- * applying `succ` to `begin` before passing `end`. This mirrors that
- * enumeration faithfully: `("a".."bbb").include?("z")` is true (`"z"` is
- * produced before the length guard trips), and `("a".."bbb").include?("a1")`
- * is false (`succ` mixes no character classes, so `"a1"` is never produced)
- * — unlike a `(length, lex)` window, which would wrongly admit `"a1"`.
- *
- * Beginless/endless string ranges have no enumerable sequence; Ruby raises
- * `TypeError: cannot determine inclusion in beginless/endless ranges` from
- * `Range#include?` (range.c `range_include_internal`), so this throws to match
- * rather than inventing an answer Ruby never produces.
- */
-export function rangeIncludesStringValue(range: Range<string>, value: string): boolean {
-  const { begin, end, excludeEnd } = range;
-
-  if (begin === null || end === null) {
-    throw new TypeError("cannot determine inclusion in beginless/endless ranges");
+  /** Raises before any other check on a beginless range, as Ruby does. */
+  first(): T {
+    if (this.begin === null) {
+      throw new RangeError("cannot get the first element of beginless range");
+    }
+    return this.begin;
   }
 
-  // Faithful `str_upto_each`: enumerate begin..end via succ, stopping at
-  // `end.succ`, when the exclusive end is reached, or when the current string
-  // grows past `end`'s length (succ is non-decreasing in length).
-  const n = lexCmp(begin, end);
-  if (n > 0 || (excludeEnd && n === 0)) return false;
-  const afterEnd = succ(end);
-  let current = begin;
-  let guard = 0;
-  while (current !== afterEnd) {
-    let next: string | null = null;
-    if (excludeEnd || current !== end) next = succ(current);
-    if (current === value) return true;
-    if (next === null) break;
-    current = next;
-    if (excludeEnd && current === end) break;
-    if (current.length > end.length || current.length === 0) break;
-    // The length guard above bounds enumeration to strings no longer than
-    // `end`, so this only trips for spans wider than ~26^5. Ruby would keep
-    // iterating (slow but correct); throw rather than return a wrong `false`.
-    if (++guard > 5_000_000) {
-      throw new RangeError("string range too large to enumerate for include?");
+  last(): T | null {
+    return this.end;
+  }
+
+  /**
+   * Ruby raises `TypeError` for a non-Integer excluded end rather than
+   * silently reporting a fractional maximum.
+   *
+   * @noRailsEquivalent PERMANENT — core Ruby `Range#max`, read by
+   * `compare_range.rb:24,50`. No Rails file declares it, so `api:extra` has
+   * no Ruby name to credit it against.
+   */
+  max(): T | null {
+    const end = this.end;
+    if (!this.excludeEnd || end === null) return end;
+    if (typeof end === "number") {
+      // Ruby's own `Range#max` message; activesupport has no ported TypeError.
+      if (!Number.isInteger(end)) throw new TypeError("cannot exclude non Integer end value");
+      return (end - 1) as T;
+    }
+    // boundary: Date endpoints, as above
+    return new Date((end as Date).getTime() - 1) as T;
+  }
+
+  /**
+   * @noRailsEquivalent PERMANENT — core Ruby `Range#to_s`, the fallback
+   * `conversions.rb:55` and `json.rb:160` reach. No Rails file declares it.
+   */
+  toS(): string {
+    const begin = this.begin !== null ? String(this.begin) : "";
+    const end = this.end !== null ? String(this.end) : "";
+    return `${begin}${this.excludeEnd ? "..." : ".."}${end}`;
+  }
+
+  /**
+   * Endpoint comparison — true when the range covers the scalar value.
+   *
+   * @noRailsEquivalent PERMANENT — core Ruby `Range#cover?`, the method
+   * `clusivity.rb:40-50` selects between. No Rails file declares it.
+   */
+  cover(value: T): boolean {
+    if (this.begin !== null && cmp(value, this.begin) < 0) return false;
+    if (this.end !== null) {
+      const c = cmp(value, this.end);
+      if (this.excludeEnd ? c >= 0 : c > 0) return false;
+    }
+    return true;
+  }
+
+  /**
+   * For a String range, membership in the `succ`-enumerated sequence from
+   * `begin` to `end`, NOT a plain lexicographic cover. Ruby enumerates string
+   * ranges by `String#succ` (range.c `rb_str_include_range_p` →
+   * `str_upto_each`), so a value is a member only if it is actually
+   * *reachable* by repeatedly applying `succ` to `begin` before passing `end`.
+   * This mirrors that enumeration faithfully: `("a".."bbb").include?("z")` is
+   * true (`"z"` is produced before the length guard trips), and
+   * `("a".."bbb").include?("a1")` is false (`succ` mixes no character classes,
+   * so `"a1"` is never produced) — unlike a `(length, lex)` window, which
+   * would wrongly admit `"a1"`.
+   *
+   * Beginless/endless string ranges have no enumerable sequence; Ruby raises
+   * `TypeError: cannot determine inclusion in beginless/endless ranges`
+   * (range.c `range_include_internal`), so this throws to match rather than
+   * inventing an answer Ruby never produces.
+   */
+  isInclude(value: T): boolean {
+    if (typeof this.begin !== "string" && typeof this.end !== "string") return this.cover(value);
+
+    const { begin, end, excludeEnd } = this as Range<string>;
+
+    if (begin === null || end === null) {
+      throw new TypeError("cannot determine inclusion in beginless/endless ranges");
+    }
+
+    // Faithful `str_upto_each`: enumerate begin..end via succ, stopping at
+    // `end.succ`, when the exclusive end is reached, or when the current
+    // string grows past `end`'s length (succ is non-decreasing in length).
+    const n = cmp(begin, end);
+    if (n > 0 || (excludeEnd && n === 0)) return false;
+    const afterEnd = succ(end);
+    let current = begin;
+    let guard = 0;
+    while (current !== afterEnd) {
+      let next: string | null = null;
+      if (excludeEnd || current !== end) next = succ(current);
+      if (current === value) return true;
+      if (next === null) break;
+      current = next;
+      if (excludeEnd && current === end) break;
+      if (current.length > end.length || current.length === 0) break;
+      // The length guard above bounds enumeration to strings no longer than
+      // `end`, so this only trips for spans wider than ~26^5. Ruby would keep
+      // iterating (slow but correct); throw rather than return a wrong `false`.
+      if (++guard > 5_000_000) {
+        throw new RangeError("string range too large to enumerate for include?");
+      }
+    }
+    return false;
+  }
+
+  caseEquals(value: T): boolean {
+    return this.cover(value);
+  }
+
+  *each(): Generator<T> {
+    yield* this.step(1);
+  }
+
+  *step(n: number = 1): Generator<T> {
+    let current = this.first() as number;
+    while (true) {
+      if (this.end !== null) {
+        const end = this.end as number;
+        if (this.excludeEnd ? current >= end : current > end) break;
+      }
+      yield current as T;
+      current += n;
     }
   }
-  return false;
 }

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/message-encryptor.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/message-encryptor.json
@@ -2,36 +2,8 @@
   {
     "package": "activesupport",
     "tsFile": "message-encryptor.ts",
-    "rubyName": "create_message",
-    "call": "order:encrypt,sign",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "message-encryptor.ts",
     "rubyName": "key_len",
     "call": "new",
     "reason": "Rails' key_len is `OpenSSL::Cipher.new(cipher).key_len`; trails has no OpenSSL::Cipher binding, so keyLen derives the byte length from the cipher name instead of instantiating a cipher."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "message-encryptor.ts",
-    "rubyName": "read_message",
-    "call": "order:verify,deserializeWithMetadata",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "message-encryptor.ts",
-    "rubyName": "sign",
-    "call": "create_message",
-    "reason": "Rails delegates signing to a nested `@verifier` MessageVerifier (`sign` -> `@verifier.create_message`); trails' encryptor HMACs inline, the same pre-existing structural divergence already recorded for `verify`."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "message-encryptor.ts",
-    "rubyName": "verify",
-    "call": "read_message",
-    "reason": "Rails delegates signing to a nested @verifier MessageVerifier (verify -> @verifier.read_message); trails' encryptor HMACs inline, a pre-existing structural divergence tracked separately from the Codec port."
   }
 ]


### PR DESCRIPTION
Bundle of two RFC 0072 convergence stories.

## 1. `MessageEncryptor` signs through a `MessageVerifier`

`message_encryptor.rb:186-190,269-275` builds a nested `MessageVerifier` with
`NullSerializer` and defines `sign`/`verify` as delegations to its
`create_message`/`read_message`, so `create_message` is
`sign(encrypt(serialize_with_metadata(...)))` and the wire format is
`Base64(<b64text>--<b64iv>)--<digest>` (`message_verifier.rb:310-315`).

trails HMACed inline and emitted `<b64text>--<b64iv>--<digest>`. It now holds a
`verifier` built exactly as Rails builds it, and `createMessage`/`readMessage`
are the one-line Rails bodies. The AEAD path is unchanged — Rails leaves
`@verifier` nil there, so `sign`/`verify` are identity.

- `messing with either encrypted values causes failure` un-skipped and passing.
- `backwards compat for 64 bytes key` gets past `missing separator` and now
  fails on the Marshal payload only; its skip comment points at
  `message-encryptor-marshal-payload-backwards-compatibility`.
- Four `call-mismatches` baseline rows converged and deleted (the two
  `sign`/`verify` delegation rows and the two `order:` rows they caused).

## 2. `Range` is a class

`range-ext.ts` now declares `class Range<T>` with the core Ruby members Rails'
reopenings read off the receiver — `begin`, `end`, `excludeEnd`, `first`,
`last`, `max`, `to_s`, `cover?`, `include?`, `===`, `each`, `step` — and the
four `core_ext/range/*.rb` ports reopen it where Ruby does:

- `compare-range.ts` / `each.ts` are `prepend()`ed, so `super` is a real
  argument rather than an inlined re-derivation. `super(value.first)` is now
  `super_.call(this, value.first())`.
- `conversions.ts` / `overlap.ts` mix onto `Range.prototype` at the bottom of
  the file, where Ruby closes `class Range`.
- `isRange()` and `conversions.ts`'s exported `toS` are deleted; `overlap.rb:9`'s
  `is_a?(::Range)` and `compare_range.rb:16,42` are `instanceof Range`.
- `json.ts`'s `isPlainObject` no longer special-cases a range (a `Range`
  instance is not a plain object), and the dispatcher's Range arm is an
  `instanceof`.
- `clusivity.ts` drops its own structural `isRange` and its comment about the
  missing class; the string-vs-numeric membership split now lives in
  `Range#include?` itself, where Ruby has it.
- The two `@missingRailsCall last` tags on `compare-range.ts` go away —
  `Range#last` exists now.

`makeRange` is gone; call sites are `new Range(...)`.

`pnpm api:extra --package activesupport` novel: **382 → 379**. `api:compare`
and `test:compare` deltas non-negative; `api:calls` green; `pnpm lint` and
`pnpm typecheck` clean.

Three core-Ruby members (`cover`, `max`, `toS`) carry `@noRailsEquivalent
PERMANENT` — no Rails file declares them, so `api:extra` has no Ruby name to
credit them against. They are the same claim the old interface-level tag made,
not a rehoming of the deleted free-function tags.

## Review round 1

**Finding 1 — `validations.ts:420`.** Fixed, and the finding was right about the
functional gap in the helper: `_parseValidatesOptions` now mirrors
`validates.rb:166-177` arm for arm — `TrueClass -> {}`, `Hash -> itself`,
`Range, Array -> { in: }`, else `{ with: }` — with the Hash arm moved ahead of
the Range/Array arm to match Ruby's `case` order. The stale comment is gone.
Covered by `validations/validates.trails.test.ts` (the arm has no Rails test of
its own; `validates_test.rb` exercises it only through `validates`).

One correction to the finding: a bare `Range` passed to `validates` does *not*
reach `_parseValidatesOptions` even after this fix, because `Model.validates`
(`model.ts:540-650`) never calls it at all — it is a hand-rolled per-key
dispatcher that re-implements only the `true -> {}` arm inline. So the
`Range, Array` and `else -> { with: }` arms are both unreachable through
`validates` today. That is a larger pre-existing divergence than this story,
and converging it means rewriting the dispatcher and re-porting
`validates_test.rb:104-121`; filed as
`0023-surfaced-deviations/validates-does-not-route-through-parse-validates-options`
with the Rails cites. The ported `validates with range` test is therefore left
as-is in this PR rather than converged to a shape that cannot pass yet.

**Finding 2 — `succ.ts:4`.** Fixed; the doc now names `Range#include?`.

**Size:** 792 LOC, over the 700 ceiling. The two stories are one refactor —
story 2 alone is ~700 — and splitting them would stack PRs over the same files.

Closes-story: converge-message-encryptor-sign-through-message-verifier
Closes-story: range-is-an-interface-not-a-class
