### PR TITLE
feat(globalid): port deconstructKeys, asJson, defaultLocator and parseEncodedGid on GlobalID

### DIFF
--- a/packages/globalid/src/global-id.test.ts
+++ b/packages/globalid/src/global-id.test.ts
@@ -144,11 +144,24 @@ describe("GlobalIDCreationTest", () => {
 
   it("as JSON", () => {
     const gid = GlobalID.create(fakeModel(5));
-    // Mirror Rails GlobalID#as_json — JSON.stringify(gid) calls toJSON() and
-    // serializes to the URI string, wrapped in quotes.
+    expect(gid.asJson()).toBe("gid://bcx/Person/5");
+    // Rails' `to_json`; here JSON.stringify(gid) routes through toJSON().
     expect(JSON.stringify(gid)).toBe('"gid://bcx/Person/5"');
-    expect(JSON.stringify(GlobalID.create(fakeModel(4, "Person::Child")))).toBe(
-      '"gid://bcx/Person::Child/4"',
+
+    const uuidGid = GlobalID.create(fakeModel(uuid, "PersonUuid"));
+    expect(uuidGid.asJson()).toBe(`gid://bcx/PersonUuid/${uuid}`);
+    expect(JSON.stringify(uuidGid)).toBe(`"gid://bcx/PersonUuid/${uuid}"`);
+
+    const namespacedGid = GlobalID.create(fakeModel(4, "Person::Child"));
+    expect(namespacedGid.asJson()).toBe("gid://bcx/Person::Child/4");
+    expect(JSON.stringify(namespacedGid)).toBe('"gid://bcx/Person::Child/4"');
+
+    const cpkGid = GlobalID.create(
+      fakeModel(["tenant-key-value", "id-value"], "CompositePrimaryKeyModel"),
+    );
+    expect(cpkGid.asJson()).toBe("gid://bcx/CompositePrimaryKeyModel/tenant-key-value/id-value");
+    expect(JSON.stringify(cpkGid)).toBe(
+      '"gid://bcx/CompositePrimaryKeyModel/tenant-key-value/id-value"',
     );
   });
 

--- a/packages/globalid/src/global-id.trails.test.ts
+++ b/packages/globalid/src/global-id.trails.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { setApp, _resetApp } from "./config.js";
+import { GlobalID } from "./global-id.js";
+import { Locator } from "./locator.js";
+
+// Members with no dedicated Rails test of their own: GlobalID#deconstruct_keys
+// (delegated to @uri), GlobalID.default_locator, and the private
+// GlobalID.parse_encoded_gid fallback exercised through .parse.
+describe("GlobalID (trails)", () => {
+  afterEach(() => {
+    _resetApp();
+  });
+
+  it("deconstruct_keys delegates to the uri", () => {
+    setApp("bcx");
+    const gid = GlobalID.create({ id: 5, constructor: { name: "Person" } }, { db: "primary" });
+    expect(gid.deconstructKeys()).toEqual({
+      app: "bcx",
+      modelName: "Person",
+      modelId: "5",
+      params: { db: "primary" },
+    });
+  });
+
+  it("default_locator sets Locator.default_locator", async () => {
+    const previous = Locator.defaultLocator;
+    const sentinel = { located: true };
+    const myLocator = {
+      locate: async () => sentinel,
+      locateMany: async () => [sentinel],
+    };
+    try {
+      await GlobalID.defaultLocator(myLocator);
+      expect(Locator.defaultLocator).toBe(myLocator);
+    } finally {
+      Locator.defaultLocator = previous;
+    }
+  });
+
+  it("parse falls back to parse_encoded_gid", () => {
+    setApp("bcx");
+    const gid = GlobalID.create({ id: 5, constructor: { name: "Person" } });
+    expect(GlobalID.parse(gid.toParam())!.toString()).toBe("gid://bcx/Person/5");
+    expect(GlobalID.parse("not a gid at all")).toBeNull();
+  });
+});

--- a/packages/globalid/src/global-id.ts
+++ b/packages/globalid/src/global-id.ts
@@ -38,10 +38,6 @@ export interface GlobalIDOptions {
 
 export class GlobalID {
   readonly uri: string;
-  // Rails' `attr_reader :uri` holds the URI::GID itself and the readers below
-  // are `delegate ... to: :uri`. Here `uri` is the string form (every trails
-  // caller reads it as one), so the parsed GID is kept alongside it and is
-  // what the delegated readers — including `deconstructKeys` — go through.
   private readonly _uri: GID;
 
   /** Mirrors: GlobalID#initialize(gid, options) */
@@ -64,7 +60,15 @@ export class GlobalID {
     return this._uri.params;
   }
 
-  /** Mirrors: GlobalID#deconstruct_keys — `delegate :deconstruct_keys, to: :uri`. */
+  /**
+   * Mirrors: GlobalID#deconstruct_keys — `delegate :deconstruct_keys, to: :uri`.
+   *
+   * Rails' `attr_reader :uri` holds the URI::GID itself and `app` /
+   * `model_name` / `model_id` / `params` / `deconstruct_keys` all delegate to
+   * it. Here the public `uri` is its string form (every trails caller reads it
+   * as one), so the parsed GID is held privately and is what those readers
+   * delegate through.
+   */
   deconstructKeys(keys: readonly string[] | null = null): GidComponents {
     return this._uri.deconstructKeys(keys);
   }

--- a/packages/globalid/src/global-id.ts
+++ b/packages/globalid/src/global-id.ts
@@ -1,10 +1,9 @@
 import { getApp } from "./config.js";
-import { GID, validateApp, type GidComponents } from "./uri/gid.js";
-// TYPE-ONLY on purpose: a runtime edge from here back into the
+import { GID, validateApp, type GidComponents } from "./uri/gid.js"; // TYPE-ONLY on purpose: a runtime edge from here back into the
 // global-id ↔ signed-global-id ↔ locator cycle would evaluate
 // `class SignedGlobalID extends GlobalID` while `GlobalID` is still in TDZ.
 // `find` therefore reaches Locator through a dynamic import.
-import type { LocateOptions, LocatorModel } from "./locator.js";
+import type { LocateOptions, LocatorLike, LocatorModel } from "./locator.js";
 import { constantize } from "@blazetrails/activesupport";
 
 /**
@@ -38,26 +37,35 @@ export interface GlobalIDOptions {
 
 export class GlobalID {
   readonly uri: string;
-  private readonly _components: GidComponents;
+  // Rails' `attr_reader :uri` holds the URI::GID itself and the readers below
+  // are `delegate ... to: :uri`. Here `uri` is the string form (every trails
+  // caller reads it as one), so the parsed GID is kept alongside it and is
+  // what the delegated readers — including `deconstructKeys` — go through.
+  private readonly _uri: GID;
 
   /** Mirrors: GlobalID#initialize(gid, options) */
   constructor(gid: string | GID, _options: GlobalIDOptions = {}) {
     const parsed = gid instanceof GID ? gid : GID.parse(gid);
     this.uri = parsed.toString();
-    this._components = parsed.deconstructKeys();
+    this._uri = parsed;
   }
 
   get app(): string {
-    return this._components.app;
+    return this._uri.app;
   }
   get modelName(): string {
-    return this._components.modelName;
+    return this._uri.modelName;
   }
   get modelId(): string | string[] {
-    return this._components.modelId;
+    return this._uri.modelId;
   }
   get params(): Record<string, string> {
-    return this._components.params;
+    return this._uri.params;
+  }
+
+  /** Mirrors: GlobalID#deconstruct_keys — `delegate :deconstruct_keys, to: :uri`. */
+  deconstructKeys(keys: readonly string[] | null = null): GidComponents {
+    return this._uri.deconstructKeys(keys);
   }
 
   /**
@@ -96,14 +104,36 @@ export class GlobalID {
     try {
       return new this(GID.parse(str), options);
     } catch {
-      try {
-        const b64 = str.replace(/-/g, "+").replace(/_/g, "/");
-        const decoded = atob(b64 + "=".repeat((4 - (b64.length % 4)) % 4));
-        return new this(GID.parse(decoded), options);
-      } catch {
-        return null;
-      }
+      return this.parseEncodedGid(str, options);
     }
+  }
+
+  /**
+   * Mirrors: GlobalID.parse_encoded_gid (private) —
+   * `new(Base64.urlsafe_decode64(gid), options) rescue nil`.
+   */
+  private static parseEncodedGid(gid: string, options: GlobalIDOptions): GlobalID | null {
+    try {
+      const b64 = gid.replace(/-/g, "+").replace(/_/g, "/");
+      const decoded = atob(b64 + "=".repeat((4 - (b64.length % 4)) % 4));
+      return new this(GID.parse(decoded), options);
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Mirrors: GlobalID.default_locator(default_locator) —
+   * `Locator.default_locator = default_locator`.
+   *
+   * Async because Locator is reached through a dynamic import: a runtime
+   * edge from here into the global-id ↔ signed-global-id ↔ locator cycle
+   * would evaluate `class SignedGlobalID extends GlobalID` with `GlobalID`
+   * still in TDZ (same constraint as `find` above).
+   */
+  static async defaultLocator(defaultLocator: LocatorLike): Promise<void> {
+    const { Locator } = await import("./locator.js");
+    Locator.defaultLocator = defaultLocator;
   }
 
   /** Mirrors: GlobalID#to_param — base64url without padding. */
@@ -116,13 +146,17 @@ export class GlobalID {
   }
 
   /**
-   * Mirrors: GlobalID#as_json — `JSON.stringify(gid)` produces `"gid://..."`.
-   * Rails' `as_json` calls `to_s`, so a SignedGlobalID serializes to its
-   * signed token rather than the bare URI; route through `toString()` to
-   * keep that polymorphism.
+   * Mirrors: GlobalID#as_json — `def as_json(*) = to_s`. Rails' `as_json`
+   * calls `to_s`, so a SignedGlobalID serializes to its signed token rather
+   * than the bare URI; route through `toString()` to keep that polymorphism.
    */
-  toJSON(): string {
+  asJson(): string {
     return this.toString();
+  }
+
+  /** @internal The JS serialization hook; delegates to the ported `asJson`. */
+  toJSON(): string {
+    return this.asJson();
   }
 
   /** @internal */

--- a/packages/globalid/src/global-id.ts
+++ b/packages/globalid/src/global-id.ts
@@ -1,5 +1,6 @@
 import { getApp } from "./config.js";
-import { GID, validateApp, type GidComponents } from "./uri/gid.js"; // TYPE-ONLY on purpose: a runtime edge from here back into the
+import { GID, validateApp, type GidComponents } from "./uri/gid.js";
+// TYPE-ONLY on purpose: a runtime edge from here back into the
 // global-id ↔ signed-global-id ↔ locator cycle would evaluate
 // `class SignedGlobalID extends GlobalID` while `GlobalID` is still in TDZ.
 // `find` therefore reaches Locator through a dynamic import.


### PR DESCRIPTION
Ports the four `GlobalID` members the `globalid:global_id.rb` bucket split
surfaced (`vendor/globalid/lib/global_id/global_id.rb`):

- **`deconstruct_keys` (:46)** — Rails delegates it to `@uri`. Trails' `uri` is
  the string form (every caller reads it as one), so the parsed `GID` is now
  kept alongside it and the delegated readers — `app`, `modelName`, `modelId`,
  `params`, and the new `deconstructKeys` — go through it, replacing the
  destructured-components field.
- **`as_json` (:78-80)** — ported at the Rails name as `asJson()`; `toJSON()`
  stays as the JS serialization hook and delegates to it.
- **`default_locator` (:34-36)** — `Locator.default_locator = default_locator`.
  Async, because `global-id.ts` reaches Locator through the dynamic import that
  breaks the `global-id ↔ signed-global-id ↔ locator` TDZ cycle (same constraint
  as `find`); justified at the call site.
- **`parse_encoded_gid` (:38-40, private)** — extracted out of `parse`'s catch
  as a private static, matching Rails' decomposition.

`pnpm api:compare --package globalid`: **80/80 methods (100%)**, 6/6 files
(was 76/80). `pnpm api:extra --package globalid` reports 0 novel names in
`global-id.ts`. `pnpm api:calls` OK, no new rows.

Tests: the ported "as JSON" test now covers all four `as_json`/`to_json` pairs
Rails asserts (`test/cases/global_id_test.rb:171-186`); `global-id.trails.test.ts`
covers `deconstructKeys`, `GlobalID.defaultLocator`, and the
`parseEncodedGid` fallback, none of which have a Rails test of their own.

The bundled story `move-adapter-specific-snapshot-off-ar-internal-metadata` was
**released, not built**: its own findings section establishes that the digest arm
is unsound, that the sidecar arm is materially larger than the stated 160 LOC,
and that it "should be its own PR, not bundled" — `load-schema-helper.ts:526-532`
warns that seam is reshaped one story at a time. It is back in the ready pool.

Closes-story: globalid-missing-members-surfaced-by-bucket-split
