### PR TITLE
refactor(activerecord): createAll reads db_config off migrationConnection's pool; drop the ConnectionNotDefined rescue

### DIFF
--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -391,8 +391,15 @@ describe("DatabaseTasksCreateAllTest", () => {
   captureStdoutAndStderr();
 
   let created: string[];
-  beforeEach(() => {
+  // database_tasks_test.rb:722-729 — `with_stubbed_configurations_establish_connection`
+  // stubs `connection_handler.establish_connection` so `create_all`'s closing
+  // re-establish (database_tasks.rb:132) is a no-op. The suite's own ambient
+  // connection is what `migration_connection.pool.db_config` (:128) reads;
+  // trails' tasks suite has no ambient connection of its own, so lay one here.
+  beforeEach(async () => {
     created = [];
+    await Base.establishConnection(ambientPoolConfiguration());
+    vi.spyOn(Base, "establishConnection").mockResolvedValue(undefined);
     DatabaseTasks.registerTask("abstract", {
       create: async (config) => {
         created.push(config.database ?? "unknown");

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -246,22 +246,16 @@ export class DatabaseTasks {
   }
 
   static async createAll(): Promise<void> {
-    // Rails: capture current db_config before iterating so we can restore it after.
-    const migrationClass = this.migrationClass();
-    let originalConfig: DatabaseConfig | null = null;
-    try {
-      originalConfig = migrationClass.connectionDbConfig();
-    } catch (error) {
-      if (!(error instanceof ConnectionNotDefined)) throw error;
+    // The cast covers `AbstractAdapter#pool`'s declared `ConnectionPool |
+    // NullPool`: `NullPool#db_config` is `NullConfig`, which a leased connection
+    // can never be — Ruby, being untyped, needs no narrowing here.
+    const dbConfig = this.migrationConnection().pool.dbConfig as DatabaseConfig;
+
+    for (const dbConfig of this.eachLocalConfiguration()) {
+      await this.create(dbConfig);
     }
-    const configs = this.eachLocalConfiguration();
-    for (const config of configs) {
-      await this.create(config);
-    }
-    // Rails: re-establish connection to the original config after all creates.
-    if (originalConfig !== null) {
-      await migrationClass.establishConnection(originalConfig);
-    }
+
+    await this.migrationClass().establishConnection(dbConfig);
   }
 
   static async createCurrent(environment?: string, name?: string): Promise<void> {


### PR DESCRIPTION
Converges `DatabaseTasks.createAll` to `database_tasks.rb:127-133`.

Rails:

```ruby
def create_all
  db_config = migration_connection.pool.db_config
  each_local_configuration { |db_config| create(db_config) }
  migration_class.establish_connection(db_config)
end
```

- The config now comes from `migrationConnection().pool.dbConfig` (`:128`) — a
  real lease off the pool — instead of `Base.connectionDbConfig()`, which
  skipped the lease.
- The `ConnectionNotDefined` rescue is gone. With nothing established Rails
  raises out of `create_all`; trails swallowed it and skipped the re-establish.
- `migrationClass().establishConnection(dbConfig)` (`:132`) is now unconditional,
  matching Rails' unguarded call.

`DatabaseTasksCreateAllTest` had no ambient connection, so it depended on the
lenient arm. It now mirrors Rails'
`with_stubbed_configurations_establish_connection`
(`database_tasks_test.rb:722-729`): lay the suite's ambient connection and stub
`establishConnection` so the closing re-establish is a no-op. Test names
unchanged.

`packages/activerecord/src/tasks/` green (114 passed, 1 skipped).

The bundled `move-adapter-specific-snapshot-off-ar-internal-metadata` story is
NOT in this PR — it was released back. Its own recorded findings (2026-08-07)
say the surviving arm is bigger than the story's estimate, needs lane-conditional
keying that can't be validated on the sqlite lane alone, and that this seam
(`loadSchema` / `canonical-schema-stamp.ts` / `test-setup-dy.ts`) must be
reshaped one story at a time — explicitly "its own PR, not bundled".

Closes-story: converge-create-all-config-read-and-connection-not-defined-rescue
