### PR TITLE
test(activesupport): record the legacy Ruby-Marshal ciphertext case as Ruby-only

### DIFF
--- a/packages/activesupport/src/message-encryptor.test.ts
+++ b/packages/activesupport/src/message-encryptor.test.ts
@@ -204,18 +204,10 @@ describe("MessageEncryptorTest", () => {
     assertAeadNotDecrypted(encryptor, [text, iv, authTag.slice(0, -1)].join("--"));
   });
 
-  // The historic payload is Marshal-serialized — story:
-  // message-encryptor-marshal-payload-backwards-compatibility.
+  // The historic ciphertext decrypts to the Ruby Marshal bytes
+  // `\x04\x08I"\x12Ruby on Rails\x06:\x06ET` — an ivar-wrapped Ruby String.
   it.skip("backwards compatibility decrypt previously encrypted messages without metadata", () => {
-    const secret = Buffer.from(
-      "b7f0bc57b11860abf08110a424f434eca1dcc1dd44afa9b814cd189a99208029",
-      "hex",
-    );
-    const encryptor = new MessageEncryptor(secret, { cipher: "aes-256-gcm" });
-    const encryptedMessage =
-      "9cVnFs2O3lL9SPvIJuxBOLS51nDiBMw=--YNI5HAfHEmZ7VDpl--ddFJ6tXA0iH+XGcCgMINYQ==";
-
-    expect(encryptor.decryptAndVerify(encryptedMessage)).toEqual("Ruby on Rails");
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — marshal
   });
 
   // No Ruby `#inspect` analogue — same open decision as

--- a/packages/activesupport/src/messages/serializer-with-fallback.ts
+++ b/packages/activesupport/src/messages/serializer-with-fallback.ts
@@ -11,7 +11,13 @@
  * trails has no Ruby Marshal runtime, so the `:marshal` format is backed by the
  * fidelity `coder` (`cache/coder.ts`) — the same trails Marshal-equivalent the
  * cache serializers use — behind Rails' `\x04\x08` Marshal signature so
- * cross-format detection still works. `MessagePackWithFallback#available?` is
+ * cross-format detection still works. That signature is the only thing the
+ * `:marshal` format shares with Ruby's wire format: a payload produced by
+ * Ruby's `Marshal.dump` is NOT readable here, and by decision it never will be
+ * — Marshal is a Ruby-only wire format, excluded project-wide in
+ * `scripts/api-compare/unported-files.ts` (marshalling.rb,
+ * marshal_serialization_test.rb, and the legacy-ciphertext case in
+ * message_encryptor_test.rb). `MessagePackWithFallback#available?` is
  * likewise constant-true: message_pack is a bundled dep here, with no dynamic
  * require to rescue.
  */

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -902,6 +902,22 @@ export const UNPORTED_FILES: UnportedFile[] = [
       "rather than exact bytes.",
   },
 
+  // --- activesupport: legacy Ruby-Marshal ciphertext ---
+  {
+    testFile: "message_encryptor_test.rb",
+    tests: ["backwards compatibility decrypt previously encrypted messages without metadata"],
+    reason:
+      "Decrypts a ciphertext minted before message metadata existed " +
+      "(message_encryptor_test.rb:147-154). The plaintext is the Ruby Marshal " +
+      'payload `\\x04\\x08I"\\x12Ruby on Rails\\x06:\\x06ET` — an ivar-wrapped ' +
+      "Ruby String — so passing it requires a real Ruby Marshal wire reader. " +
+      "trails has no Ruby Marshal runtime: the `:marshal` serializer in " +
+      "messages/serializer-with-fallback.ts is a trails-native codec behind " +
+      "Rails' `\\x04\\x08` signature, matching the project-wide Marshal " +
+      "exclusion above (marshalling.rb / marshal_serialization_test.rb). " +
+      "Ruby-only wire format.",
+  },
+
   // === TC100 Phase 0 Story H-3: residual JS-runtime-impossible skips ===
   // These are live `it.skip` in otherwise-portable AR test files whose
   // underlying behavior cannot exist in a single-threaded JS runtime:


### PR DESCRIPTION
## What

Resolves the open decision behind Rails'
`test_backwards_compatibility_decrypt_previously_encrypted_messages_without_metadata`
(`vendor/rails/activesupport/test/message_encryptor_test.rb:147-154`), which was
sitting as a bare `it.skip` with a story pointer.

## The finding

Decrypting the historic ciphertext by hand (aes-256-gcm, the literal secret from
the Rails test) yields:

```
04 08 49 22 12 52 75 62 79 20 6f 6e 20 52 61 69 6c 73 06 3a 06 45 54
"\x04\x08I\"\x12Ruby on Rails\x06:\x06ET"
```

That is a Ruby Marshal 4.8 stream: an ivar-wrapped Ruby `String` carrying
`:E => true`. Passing this test requires a real Ruby Marshal **wire** reader.

trails has none, by standing decision. The `:marshal` serializer in
`packages/activesupport/src/messages/serializer-with-fallback.ts` is a
trails-native codec placed behind Rails' `\x04\x08` signature so cross-format
detection works — it shares the signature with Ruby and nothing else. The same
decision already excludes `marshalling.rb`, `marshal_serialization_test.rb`, and
a dozen scattered `Marshal.dump`/`load` round-trip cases in
`scripts/api-compare/unported-files.ts`; this case is the same class.

## What changed

- `scripts/api-compare/unported-files.ts` — per-test entry for
  `message_encryptor_test.rb` with the Marshal bytes and the reason, next to the
  existing globalid Marshal-token exclusion.
- `packages/activesupport/src/message-encryptor.test.ts` — the bare `it.skip`
  becomes the repo's standard
  `// PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — marshal`
  annotation, matching `associations/extension.test.ts:139-144`.
- `packages/activesupport/src/messages/serializer-with-fallback.ts` — the header
  doc now states the consequence explicitly: a payload produced by Ruby's
  `Marshal.dump` is not readable here and by decision will not be.

`SKIP_GROUPS` (the acceptance criteria's suggested register) is `api:compare`'s
member-name skip table; a Rails **test** belongs in `unported-files.ts`, which is
where every other Marshal case is recorded.

## Verification

- `pnpm vitest run packages/activesupport/src/message-encryptor.test.ts packages/activesupport/src/messages/serializer-with-fallback.test.ts` — green.
- `pnpm vitest run scripts/api-compare/unported-files.test.ts scripts/api-compare/unported-overmatch.test.ts` — green (the new entry over-match guard passes).
- `pnpm typecheck` — clean. `pnpm test:compare` — 15344/22647 (67.8%), no regression.

Closes-story: message-encryptor-marshal-payload-backwards-compatibility
