### PR TITLE
fix(activerecord): PG configureConnection runs the 9.3 version floor check

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.check-version.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.check-version.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+describe("PostgreSQLAdapter#checkVersion", () => {
+  it("raises when the warmed version is too old", async () => {
+    const { PostgreSQLAdapter } = await import("./postgresql-adapter.js");
+    const adapter = Object.create(PostgreSQLAdapter.prototype) as InstanceType<
+      typeof PostgreSQLAdapter
+    >;
+    (adapter as unknown as { _databaseVersion: number })._databaseVersion = 90_2_00;
+    expect(() => adapter.checkVersion()).toThrow(
+      "Your version of PostgreSQL (90200) is too old. Active Record supports PostgreSQL >= 9.3.",
+    );
+  });
+
+  it("does not raise when the warmed version is supported", async () => {
+    const { PostgreSQLAdapter } = await import("./postgresql-adapter.js");
+    const adapter = Object.create(PostgreSQLAdapter.prototype) as InstanceType<
+      typeof PostgreSQLAdapter
+    >;
+    (adapter as unknown as { _databaseVersion: number })._databaseVersion = 9_03_00;
+    expect(() => adapter.checkVersion()).not.toThrow();
+  });
+});

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -793,6 +793,11 @@ export class PostgreSQLAdapter
       const version = await this._serverVersion(client);
       if (version !== 0) this._databaseVersion = version;
     }
+    // `super`'s check_version (abstract_adapter.rb:1212-1214), at the position
+    // Rails calls it from. Skipped when the probe came back zero: that path is
+    // owned by getDatabaseVersion()'s ConnectionFailed handling, not by the
+    // version floor.
+    if (this._databaseVersion !== null) this.checkVersion();
     // Rails resets @mapped_default_timezone = nil while installing decoders in
     // configure_connection (postgresql_adapter.rb:1112) so the next
     // update_typemap_for_default_timezone re-applies the session timezone. This
@@ -3164,6 +3169,20 @@ export class PostgreSQLAdapter
   // Feature support predicates
   // Mirrors: PostgreSQLAdapter supports_* methods
   // ---------------------------------------------------------------------------
+
+  // Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#check_version
+  // (postgresql_adapter.rb:669-673). Rails' `database_version` issues the
+  // round-trip itself when unmemoized; trails' sync getter cannot, so
+  // `_maybeConfigureConnection` fills the memo at the position Rails' `super`
+  // occupies, one line before this runs.
+  override checkVersion(): void {
+    if (this.databaseVersion < 9_03_00) {
+      // < 9.3
+      throw new Error(
+        `Your version of PostgreSQL (${this.databaseVersion}) is too old. Active Record supports PostgreSQL >= 9.3.`,
+      );
+    }
+  }
 
   // Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#build_insert_sql.
   // Like the SQLite form, but the timestamp-touch guard uses

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3170,20 +3170,6 @@ export class PostgreSQLAdapter
   // Mirrors: PostgreSQLAdapter supports_* methods
   // ---------------------------------------------------------------------------
 
-  // Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#check_version
-  // (postgresql_adapter.rb:669-673). Rails' `database_version` issues the
-  // round-trip itself when unmemoized; trails' sync getter cannot, so
-  // `_maybeConfigureConnection` fills the memo at the position Rails' `super`
-  // occupies, one line before this runs.
-  override checkVersion(): void {
-    if (this.databaseVersion < 9_03_00) {
-      // < 9.3
-      throw new Error(
-        `Your version of PostgreSQL (${this.databaseVersion}) is too old. Active Record supports PostgreSQL >= 9.3.`,
-      );
-    }
-  }
-
   // Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#build_insert_sql.
   // Like the SQLite form, but the timestamp-touch guard uses
   // `<table>.<col> IS NOT DISTINCT FROM excluded.<col>` (Rails qualifies the
@@ -3212,6 +3198,20 @@ export class PostgreSQLAdapter
     const ret = insert.returning();
     if (ret) sql += ` RETURNING ${ret}`;
     return sql;
+  }
+
+  // Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#check_version
+  // (postgresql_adapter.rb:669-673). Rails' `database_version` issues the
+  // round-trip itself when unmemoized; trails' sync getter cannot, so
+  // `_maybeConfigureConnection` fills the memo at the position Rails' `super`
+  // occupies, one line before this runs.
+  override checkVersion(): void {
+    if (this.databaseVersion < 9_03_00) {
+      // < 9.3
+      throw new Error(
+        `Your version of PostgreSQL (${this.databaseVersion}) is too old. Active Record supports PostgreSQL >= 9.3.`,
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
PG's version floor check did not exist in trails. Rails'
`PostgreSQLAdapter#configure_connection` opens with `super`
(`postgresql_adapter.rb:956-957`), and `AbstractAdapter#configure_connection`
(`abstract_adapter.rb:1212-1214`) is `check_version`, which PG overrides
(`postgresql_adapter.rb:669-673`) to raise below 9.3. trails' PG adapter never
called `checkVersion()` from anywhere and had no override.

- Port `PostgreSQLAdapter#checkVersion` — same floor (`9_03_00`), same
  `raise "..."` (RuntimeError → plain `Error`), same message string.
- Call it from `_maybeConfigureConnection` immediately after the version-memo
  fill, the position Rails' `super` occupies. The memo is filled by the line
  above, so this is a plain sync read with no re-entry into the acquire path.
  It is skipped when the probe returned zero — that path stays owned by
  `getDatabaseVersion()`'s ConnectionFailed handling.
- Test in the shape of the existing `AbstractMysqlAdapter#checkVersion`
  coverage.

Closes-story: pg-configure-connection-never-calls-check-version
