### PR TITLE
fix(api-compare): core_ext/object/json.rb owns its bucket so Object#as_json pairs with core-ext/object/json.ts

### DIFF
--- a/scripts/api-compare/call-mismatches-exclude/activesupport/index.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/index.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activesupport",
-    "tsFile": "index.ts",
-    "rubyName": "as_json",
-    "call": "instance_values",
-    "reason": "Comparator mis-resolution, not a body gap: Ruby `Object#as_json` pairs by bare short name with `TimeWithZone#asJson` (time-with-zone.ts), while the real port — `Object.asJson` in core-ext/object/json.ts — does call `instanceValues`. The flag surfaced only because `instance_values` became a ported method; tracked by `object-as-json-pairs-with-time-with-zone-as-json`."
-  }
-]

--- a/scripts/api-compare/conventions.test.ts
+++ b/scripts/api-compare/conventions.test.ts
@@ -342,6 +342,18 @@ describe("RUBY_FILE_TS_OVERRIDES", () => {
     expect(rubyFileToTs("core_ext/date_time/calculations.rb", "activesupport")).toBe("time-ext.ts");
   });
 
+  it("gives core_ext/object/json.rb its own bucket", () => {
+    // `Object`, `Time`, `Hash` and the rest are each first opened by another
+    // core_ext file, so without the entry their `as_json` buckets there —
+    // `Object#as_json` under `object/acts_like.rb`, whose expected TS file does
+    // not exist, so the misplaced-file cluster landed it on the `index.ts`
+    // barrel and paired it with `TimeWithZone#asJson`.
+    expect(hasRubyFileTsOverride("core_ext/object/json.rb", "activesupport")).toBe(true);
+    expect(rubyFileToTs("core_ext/object/json.rb", "activesupport")).toBe(
+      "core-ext/object/json.ts",
+    );
+  });
+
   it("leaves the acts_like.rb reopenings on the default kebab-case rule", () => {
     expect(hasRubyFileTsOverride("core_ext/date/acts_like.rb", "activesupport")).toBe(false);
     expect(hasRubyFileTsOverride("core_ext/date_time/acts_like.rb", "activesupport")).toBe(false);

--- a/scripts/api-compare/conventions.ts
+++ b/scripts/api-compare/conventions.ts
@@ -182,6 +182,14 @@ export const RUBY_FILE_TS_OVERRIDES: Record<string, string> = {
   // `to_query` is defined on Object, Array and Hash by this one file; trails
   // carries all three arms on the hash helpers.
   "activesupport:core_ext/object/to_query.rb": "hash-utils.ts",
+  // `json.rb` reopens ~25 classes to define `as_json` on each, but `Object`,
+  // `Time`, `Hash` and friends are all first opened by another core_ext file,
+  // so their `as_json` buckets there and is measured against a TS counterpart
+  // that has none. `Object#as_json`'s landed on `index.ts` — the barrel the
+  // misplaced-file cluster picks for `object/acts_like.rb` — where it paired
+  // with `TimeWithZone#asJson`. The entry gives json.rb its own bucket, so
+  // every arm is measured against the file trails actually ports them to.
+  "activesupport:core_ext/object/json.rb": "core-ext/object/json.ts",
   "activesupport:core_ext/string/filters.rb": "string-utils.ts",
   "activesupport:core_ext/string/access.rb": "string-utils.ts",
   "activesupport:core_ext/string/indent.rb": "string-utils.ts",


### PR DESCRIPTION
Ruby `Object#as_json` (`vendor/rails/activesupport/lib/active_support/core_ext/object/json.rb:58-66`) was paired with `TimeWithZone#asJson`, reported under `tsFile: index.ts`.

Root cause: the extractor stamps `class Object` with `core_ext/object/acts_like.rb` (where its first method is defined), so every later reopening's methods — `as_json` among them — bucket there. `core-ext/object/acts-like.ts` does not exist, so the misplaced-file cluster picked the package barrel `index.ts`, which re-exports everything and therefore always wins the vote; `index.ts`'s `asJson` is `TimeWithZone`'s.

Fix: the mechanism for exactly this already exists — a `RUBY_FILE_TS_OVERRIDES` entry makes a reopening file own its own bucket (`splitOverriddenFileBuckets`). Added `activesupport:core_ext/object/json.rb` → `core-ext/object/json.ts`, so all ~25 `as_json` arms are measured against the file trails actually ports them to.

Result:
- The `index.ts` / `as_json` / `instance_values` row is deleted from `call-mismatches-exclude/activesupport/index.json` (the file is now empty and pruned). No new rows: `pnpm api:calls` green, exactly one mismatch removed, none added.
- `pnpm api:compare`: 74.5% → 74.6%. The 9 `as_json` duplicate expectations leave their host buckets (`object/acts_like.rb`, `object/blank.rb`, `date/acts_like.rb`, `array/access.rb`, …) and collapse onto json.rb's, so the denominator drops 9 and matched drops 1 — that 1 was the false credit this story is about (`Object#as_json` matched against `TimeWithZone#asJson` in the barrel).

Closes-story: object-as-json-pairs-with-time-with-zone-as-json
