### PR TITLE
refactor(activerecord): databaseVersion fetches on demand; version-gated predicates go async

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
@@ -42,12 +42,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     // next test in this worker gets a live one.
     clearVersionCache(adapter);
     await adapter.verifyBang();
-    // Rails' `database_version` re-runs the query once the stub is gone, so its
-    // @connection is never left without one. Ours is a sync reader over an async
-    // fetch and `verifyBang` won't re-configure an already-live connection, so
-    // refill the memo this hook just emptied — otherwise the next test in this
-    // worker inherits a permanently cold version.
-    await adapter.pool.serverVersion(adapter);
   });
 
   describe("ConnectionTest", () => {
@@ -332,7 +326,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       });
       try {
         await adapter.renameColumnForAlter("bar_baz", "foo", "foo2");
-        if (adapter.supportsRenameColumn()) {
+        if (await adapter.supportsRenameColumn()) {
           expect(names).not.toContain("SCHEMA");
         } else {
           expect(names).toContain("SCHEMA");

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-explain.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-explain.test.ts
@@ -139,8 +139,8 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
   // members of the MySQLExplainTest class. These exercise the adapter directly
   // (no DB rows), so they need no fixtures.
   describe("explain helpers (trails-only)", () => {
-    it("buildExplainClause renders FORMAT=JSON without parens for { format: 'json' }", () => {
-      const clause = adapter.buildExplainClause([{ format: "json" }]);
+    it("buildExplainClause renders FORMAT=JSON without parens for { format: 'json' }", async () => {
+      const clause = await adapter.buildExplainClause([{ format: "json" }]);
       expect(clause).toBe("EXPLAIN FORMAT=JSON for:");
     });
 
@@ -154,8 +154,8 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       );
     });
 
-    it("buildExplainClause rejects unknown format", () => {
-      expect(() => adapter.buildExplainClause([{ format: "bogus" }])).toThrow();
+    it("buildExplainClause rejects unknown format", async () => {
+      await expect(adapter.buildExplainClause([{ format: "bogus" }])).rejects.toThrow();
     });
 
     it("explain executes with { format: 'json' } and returns JSON plan", async () => {

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-explain.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-explain.test.ts
@@ -38,8 +38,8 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     // MariaDB >= 10.1 prints a bare ANALYZE clause (no EXPLAIN prefix).
     let explainOpt: string;
     let expectedClause: string;
-    beforeAll(() => {
-      const ver = adapter.databaseVersion;
+    beforeAll(async () => {
+      const ver = await adapter.databaseVersion;
       const supportsAnalyze = isMariaDb && ver.compare("10.1.0") >= 0;
       // `version <= "10.0"` expressed as `Version("10.0") >= version`.
       const supportsExplainAnalyze = isMariaDb
@@ -144,10 +144,11 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       expect(clause).toBe("EXPLAIN FORMAT=JSON for:");
     });
 
-    it("buildExplainClause combines string flag and format hash space-separated", () => {
-      const clause = adapter.buildExplainClause(["analyze", { format: "json" }]);
+    it("buildExplainClause combines string flag and format hash space-separated", async () => {
+      const clause = await adapter.buildExplainClause(["analyze", { format: "json" }]);
       // MariaDB >= 10.1 drops the EXPLAIN prefix for ANALYZE (analyze_without_explain?).
-      const analyzeWithoutExplain = isMariaDb && adapter.databaseVersion.compare("10.1.0") >= 0;
+      const analyzeWithoutExplain =
+        isMariaDb && (await adapter.databaseVersion).compare("10.1.0") >= 0;
       expect(clause).toBe(
         analyzeWithoutExplain ? "ANALYZE FORMAT=JSON for:" : "EXPLAIN ANALYZE FORMAT=JSON for:",
       );

--- a/packages/activerecord/src/adapters/postgresql/explain.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/explain.test.ts
@@ -105,18 +105,18 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(result).toContain("Result");
     });
 
-    it("buildExplainClause renders FORMAT JSON for { format: 'json' }", () => {
-      const clause = adapter.buildExplainClause([{ format: "json" }]);
+    it("buildExplainClause renders FORMAT JSON for { format: 'json' }", async () => {
+      const clause = await adapter.buildExplainClause([{ format: "json" }]);
       expect(clause).toBe("EXPLAIN (FORMAT JSON) for:");
     });
 
-    it("buildExplainClause combines string flags and format hash", () => {
-      const clause = adapter.buildExplainClause(["analyze", { format: "json" }]);
+    it("buildExplainClause combines string flags and format hash", async () => {
+      const clause = await adapter.buildExplainClause(["analyze", { format: "json" }]);
       expect(clause).toBe("EXPLAIN (ANALYZE, FORMAT JSON) for:");
     });
 
-    it("buildExplainClause rejects unknown format", () => {
-      expect(() => adapter.buildExplainClause([{ format: "bogus" }])).toThrow();
+    it("buildExplainClause rejects unknown format", async () => {
+      await expect(adapter.buildExplainClause([{ format: "bogus" }])).rejects.toThrow();
     });
 
     it("explain executes with { format: 'json' } and returns JSON plan", async () => {

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -1330,10 +1330,9 @@ describe("PostgreSQLAdapter supports_* predicates (unit)", () => {
     (adapter as any)._databaseVersion = version;
     (adapter as any)._hasOptimizerHints = false;
     // `database_version` reads the pool memo (`abstract_adapter.rb:854-856`),
-    // so restubbing the adapter's own version has to restamp the memo too.
-    (
-      adapter.pool as unknown as { poolConfig: { setServerVersion(v: unknown): void } }
-    ).poolConfig.setServerVersion(version);
+    // so restubbing the adapter's own version has to clear the memo too —
+    // otherwise the first stub's value is the one every later read answers.
+    (adapter.pool as unknown as { _serverVersion: unknown })._serverVersion = null;
   }
 
   it("always-true predicates return true regardless of version", async () => {

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -1329,79 +1329,79 @@ describe("PostgreSQLAdapter supports_* predicates (unit)", () => {
     (adapter as any)._initialized = true;
     (adapter as any)._databaseVersion = version;
     (adapter as any)._hasOptimizerHints = false;
+    // `database_version` reads the pool memo (`abstract_adapter.rb:854-856`),
+    // so restubbing the adapter's own version has to restamp the memo too.
+    (
+      adapter.pool as unknown as { poolConfig: { setServerVersion(v: unknown): void } }
+    ).poolConfig.setServerVersion(version);
   }
 
-  it("always-true predicates return true regardless of version", () => {
+  it("always-true predicates return true regardless of version", async () => {
     const adapter = makeAdapter();
     stubVersion(adapter, 90300);
     expect(adapter.supportsBulkAlter()).toBe(true);
-    expect(adapter.supportsIndexSortOrder()).toBe(true);
+    expect(await adapter.supportsIndexSortOrder()).toBe(true);
     expect(adapter.supportsPartialIndex()).toBe(true);
-    expect(adapter.supportsExpressionIndex()).toBe(true);
+    expect(await adapter.supportsExpressionIndex()).toBe(true);
     expect(adapter.supportsTransactionIsolation()).toBe(true);
     expect(adapter.supportsForeignKeys()).toBe(true);
-    expect(adapter.supportsCheckConstraints()).toBe(true);
+    expect(await adapter.supportsCheckConstraints()).toBe(true);
     expect(adapter.supportsViews()).toBe(true);
-    expect(adapter.supportsJson()).toBe(true);
+    expect(await adapter.supportsJson()).toBe(true);
     expect(adapter.supportsComments()).toBe(true);
     expect(adapter.supportsSavepoints()).toBe(true);
-    expect(adapter.supportsInsertReturning()).toBe(true);
+    expect(await adapter.supportsInsertReturning()).toBe(true);
     expect(adapter.supportsDdlTransactions()).toBe(true);
     expect(adapter.supportsAdvisoryLocks()).toBe(true);
     expect(adapter.supportsExplain()).toBe(true);
     expect(adapter.supportsExtensions()).toBe(true);
     expect(adapter.supportsMaterializedViews()).toBe(true);
     expect(adapter.supportsForeignTables()).toBe(true);
-    expect(adapter.supportsCommonTableExpressions()).toBe(true);
+    expect(await adapter.supportsCommonTableExpressions()).toBe(true);
     expect(adapter.supportsLazyTransactions()).toBe(true);
   });
 
-  it("version-gated predicates respect version thresholds", () => {
+  it("version-gated predicates respect version thresholds", async () => {
     const adapter = makeAdapter();
 
     stubVersion(adapter, 90300);
-    expect(adapter.supportsInsertOnConflict()).toBe(false);
-    expect(adapter.supportsPgcryptoUuid()).toBe(false);
-    expect(adapter.supportsIdentityColumns()).toBe(false);
-    expect(adapter.supportsPartitionedIndexes()).toBe(false);
-    expect(adapter.supportsVirtualColumns()).toBe(false);
-    expect(adapter.supportsRestartDbTransaction()).toBe(false);
-    expect(adapter.supportsNullsNotDistinct()).toBe(false);
+    expect(await adapter.supportsInsertOnConflict()).toBe(false);
+    expect(await adapter.supportsPgcryptoUuid()).toBe(false);
+    expect(await adapter.supportsIdentityColumns()).toBe(false);
+    expect(await adapter.supportsPartitionedIndexes()).toBe(false);
+    expect(await adapter.supportsVirtualColumns()).toBe(false);
+    expect(await adapter.supportsRestartDbTransaction()).toBe(false);
+    expect(await adapter.supportsNullsNotDistinct()).toBe(false);
 
     stubVersion(adapter, 90500);
-    expect(adapter.supportsInsertOnConflict()).toBe(true);
-    expect(adapter.supportsInsertOnDuplicateSkip()).toBe(true);
-    expect(adapter.supportsInsertOnDuplicateUpdate()).toBe(true);
-    expect(adapter.supportsInsertConflictTarget()).toBe(true);
-    expect(adapter.supportsPgcryptoUuid()).toBe(true);
+    expect(await adapter.supportsInsertOnConflict()).toBe(true);
+    expect(await adapter.supportsInsertOnDuplicateSkip()).toBe(true);
+    expect(await adapter.supportsInsertOnDuplicateUpdate()).toBe(true);
+    expect(await adapter.supportsInsertConflictTarget()).toBe(true);
+    expect(await adapter.supportsPgcryptoUuid()).toBe(true);
 
     stubVersion(adapter, 100000);
-    expect(adapter.supportsIdentityColumns()).toBe(true);
-    expect(adapter.supportsNativePartitioning()).toBe(true);
+    expect(await adapter.supportsIdentityColumns()).toBe(true);
+    expect(await adapter.supportsNativePartitioning()).toBe(true);
 
     stubVersion(adapter, 110000);
-    expect(adapter.supportsPartitionedIndexes()).toBe(true);
-    expect(adapter.supportsIndexInclude()).toBe(true);
+    expect(await adapter.supportsPartitionedIndexes()).toBe(true);
+    expect(await adapter.supportsIndexInclude()).toBe(true);
 
     stubVersion(adapter, 120000);
-    expect(adapter.supportsVirtualColumns()).toBe(true);
-    expect(adapter.supportsRestartDbTransaction()).toBe(true);
+    expect(await adapter.supportsVirtualColumns()).toBe(true);
+    expect(await adapter.supportsRestartDbTransaction()).toBe(true);
 
     stubVersion(adapter, 150000);
-    expect(adapter.supportsNullsNotDistinct()).toBe(true);
+    expect(await adapter.supportsNullsNotDistinct()).toBe(true);
   });
 
-  it("databaseVersion throws before initialization", () => {
-    const adapter = makeAdapter();
-    expect(() => adapter.databaseVersion).toThrow(/not available yet/);
-  });
-
-  it("indexAlgorithms returns concurrently", () => {
+  it("indexAlgorithms returns concurrently", async () => {
     const adapter = makeAdapter();
     expect(adapter.indexAlgorithms()).toEqual({ concurrently: "CONCURRENTLY" });
   });
 
-  it("typeToSql emits TIMESTAMP(n) with explicit precision", () => {
+  it("typeToSql emits TIMESTAMP(n) with explicit precision", async () => {
     const adapter = makeAdapter();
     expect(adapter.typeToSql("datetime", { precision: 6 })).toBe("timestamp(6)");
     expect(adapter.typeToSql("datetime", { precision: 0 })).toBe("timestamp(0)");

--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -1002,7 +1002,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(indexLine).toContain(`"companies", ["firm_id", "type"]`);
       expect(indexLine).not.toContain(`["firm_id", "type", "name"`);
       expect(indexLine?.includes(`include: ["name","account_id"]`)).toBe(
-        adapter.supportsIndexInclude(),
+        await adapter.supportsIndexInclude(),
       );
     });
   });

--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -1011,8 +1011,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     itIfSupports("nulls_not_distinct", "nulls not distinct is dumped", async () => {
       try {
         await adapter.exec(`CREATE TABLE trains (id serial primary key, name varchar(50))`);
-        await adapter.getDatabaseVersion();
-        if (!adapter.supportsNullsNotDistinct()) return;
+        if (!(await adapter.supportsNullsNotDistinct())) return;
         await adapter.exec(
           `CREATE INDEX trains_name ON trains USING btree(name) NULLS NOT DISTINCT`,
         );
@@ -1026,8 +1025,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     itIfSupports("nulls_not_distinct", "nulls distinct is dumped", async () => {
       try {
         await adapter.exec(`CREATE TABLE trains (id serial primary key, name varchar(50))`);
-        await adapter.getDatabaseVersion();
-        if (!adapter.supportsNullsNotDistinct()) return;
+        if (!(await adapter.supportsNullsNotDistinct())) return;
         await adapter.exec(`CREATE INDEX trains_name ON trains USING btree(name) NULLS DISTINCT`);
         const lines: string[] = [];
         await adapter.createSchemaDumper(adapter).dumpTable(lines, "trains");

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -3552,7 +3552,7 @@ export class Base extends Model {
       // Adapters that can't (MySQL 8, older SQLite) surface only the scalar
       // generated id, so leave `returning` null and fall back to writing that
       // id into the first still-unset returning column below.
-      const returningColumns = ctor._returningColumnsForInsert(adapter as any);
+      const returningColumns = await ctor._returningColumnsForInsert(adapter as any);
       const supportsReturning =
         (await (
           adapter as { supportsInsertReturning?(): Promise<boolean> }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -3554,7 +3554,9 @@ export class Base extends Model {
       // id into the first still-unset returning column below.
       const returningColumns = ctor._returningColumnsForInsert(adapter as any);
       const supportsReturning =
-        (adapter as { supportsInsertReturning?(): boolean }).supportsInsertReturning?.() ?? false;
+        (await (
+          adapter as { supportsInsertReturning?(): Promise<boolean> }
+        ).supportsInsertReturning?.()) ?? false;
       const returning = supportsReturning && returningColumns.length > 0 ? returningColumns : null;
 
       // Route through the ported `_insert_record` class method

--- a/packages/activerecord/src/connection-adapters/abstract-adapter-version.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter-version.trails.test.ts
@@ -27,12 +27,11 @@ describe("AbstractAdapter::Version", () => {
   });
 });
 
-// Rails' `database_version` (`abstract_adapter.rb:854-856`) fetches on demand,
-// so `check_version` and every `supports_*?` predicate read it with no
-// preparation. trails' sync getter cannot self-fetch, so `configureConnection`
-// (`abstract_adapter.rb:1212-1214`) fills the pool memo instead. These pin that:
-// without them, callers go back to hand-warming.
-describe("AbstractAdapter#configureConnection", () => {
+// Rails' `database_version` (`abstract_adapter.rb:854-856`) is
+// `pool.server_version(self)`, which issues the round-trip on demand — so
+// `check_version` and every `supports_*?` predicate read it from any state,
+// including an adapter that has never connected. These pin that.
+describe("AbstractAdapter#databaseVersion", () => {
   class AsyncVersionAdapter extends AbstractAdapter {
     fetches = 0;
     override async getDatabaseVersion(): Promise<Version> {
@@ -41,18 +40,17 @@ describe("AbstractAdapter#configureConnection", () => {
     }
   }
 
-  it("makes databaseVersion readable with no caller-side warm", async () => {
+  it("is readable from a standalone adapter that has never connected", async () => {
     const adapter = new AsyncVersionAdapter();
-    expect(() => adapter.databaseVersion).toThrow();
-    await adapter.configureConnection();
-    expect(adapter.databaseVersion.toString()).toBe("8.0.31");
+
+    expect(String(await adapter.databaseVersion)).toBe("8.0.31");
   });
 
-  it("fetches the version once, before checkVersion reads it", async () => {
+  it("fetches once, however many readers ask", async () => {
     const seen: string[] = [];
     class CheckingAdapter extends AsyncVersionAdapter {
-      override checkVersion(): void {
-        seen.push(this.databaseVersion.toString());
+      override async checkVersion(): Promise<void> {
+        seen.push(String(await this.databaseVersion));
       }
     }
     const adapter = new CheckingAdapter();

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.lifecycle.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.lifecycle.test.ts
@@ -81,7 +81,7 @@ describe("AbstractAdapter connection lifecycle privates", () => {
   it("configureConnection invokes checkVersion", async () => {
     const a = new AbstractAdapter();
     let called = 0;
-    a.checkVersion = () => void (called += 1);
+    a.checkVersion = async () => void (called += 1);
     await a.configureConnection();
     expect(called).toBe(1);
   });

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.test.ts
@@ -31,18 +31,18 @@ class TestAdapter extends AbstractAdapter {
 }
 
 describe("AbstractAdapter#returnValueAfterInsert", () => {
-  it("returns true when column isAutoPopulated (has default function)", () => {
+  it("returns true when column isAutoPopulated (has default function)", async () => {
     const adapter = new TestAdapter();
     const col = new Column("id", null, new SqlTypeMetadata({ sqlType: "uuid" }), false, {
       defaultFunction: "gen_random_uuid()",
     });
-    expect(adapter.returnValueAfterInsert(col)).toBe(true);
+    expect(await adapter.returnValueAfterInsert(col)).toBe(true);
   });
 
-  it("returns false when column is not auto-populated", () => {
+  it("returns false when column is not auto-populated", async () => {
     const adapter = new TestAdapter();
     const col = new Column("name", null, new SqlTypeMetadata({ sqlType: "varchar" }));
-    expect(adapter.returnValueAfterInsert(col)).toBe(false);
+    expect(await adapter.returnValueAfterInsert(col)).toBe(false);
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -339,7 +339,7 @@ export interface AbstractAdapter {
   /** @internal */
   indexAlgorithm(algorithm?: string): string | undefined;
   /** @internal */
-  quotedColumnsForIndex(columnNames: string[], options?: Record<string, unknown>): string;
+  quotedColumnsForIndex(columnNames: string[], options?: Record<string, unknown>): Promise<string>;
   /** @internal */
   optionsForIndexColumns(
     options: string | Record<string, string> | undefined,
@@ -352,7 +352,7 @@ export interface AbstractAdapter {
       opclass?: string | Record<string, string>;
       length?: number | Record<string, number>;
     },
-  ): Map<string, string>;
+  ): Promise<Map<string, string>>;
   removeIndex(
     tableName: string,
     columnOrOptions?:
@@ -617,7 +617,7 @@ export interface AbstractAdapter {
   /** @internal Extracts the RETURNING values from an INSERT result. Adapters
    *  override for full-row dispatch (PG/SQLite/MySQL); the base yields a single
    *  value. Mirrors DatabaseStatements#returning_column_values. */
-  returningColumnValues?(result: Result): unknown[] | undefined;
+  returningColumnValues?(result: Result): unknown[] | undefined | Promise<unknown[] | undefined>;
   /** @internal Builds the per-table TRUNCATE statement; SQLite overrides with
    *  `DELETE FROM`. Mirrors DatabaseStatements#build_truncate_statement. */
   buildTruncateStatement(tableName: string): string;
@@ -894,7 +894,7 @@ export class AbstractAdapter implements Quoting {
    * `"EXPLAIN for:"` default lives in the `ActiveRecord::Explain` module and
    * only the PG/MySQL adapters carry a private override.
    */
-  buildExplainClause(options: ExplainOption[] = []): string {
+  async buildExplainClause(options: ExplainOption[] = []): Promise<string> {
     if (options.length === 0) return "EXPLAIN for:";
     const parts = options.map((o) => {
       if (typeof o === "string") return o.toUpperCase();
@@ -1581,20 +1581,20 @@ export class AbstractAdapter implements Quoting {
     return false;
   }
 
-  supportsInsertReturning(): boolean {
+  async supportsInsertReturning(): Promise<boolean> {
     return false;
   }
 
   /** @internal */
-  returnValueAfterInsert(column: Column): boolean {
+  async returnValueAfterInsert(column: Column): Promise<boolean> {
     return column.isAutoPopulated();
   }
 
-  supportsInsertOnDuplicateSkip(): boolean {
+  async supportsInsertOnDuplicateSkip(): Promise<boolean> {
     return false;
   }
 
-  supportsInsertOnDuplicateUpdate(): boolean {
+  async supportsInsertOnDuplicateUpdate(): Promise<boolean> {
     return false;
   }
 
@@ -1616,7 +1616,7 @@ export class AbstractAdapter implements Quoting {
     return false;
   }
 
-  supportsExpressionIndex(): boolean {
+  async supportsExpressionIndex(): Promise<boolean> {
     return false;
   }
 
@@ -1628,7 +1628,7 @@ export class AbstractAdapter implements Quoting {
     return false;
   }
 
-  supportsCheckConstraints(): boolean {
+  async supportsCheckConstraints(): Promise<boolean> {
     return false;
   }
 
@@ -1640,7 +1640,7 @@ export class AbstractAdapter implements Quoting {
     return false;
   }
 
-  supportsJson(): boolean {
+  async supportsJson(): Promise<boolean> {
     return false;
   }
 
@@ -1873,11 +1873,11 @@ export class AbstractAdapter implements Quoting {
     return false;
   }
 
-  supportsPartitionedIndexes(): boolean {
+  async supportsPartitionedIndexes(): Promise<boolean> {
     return false;
   }
 
-  supportsIndexSortOrder(): boolean {
+  async supportsIndexSortOrder(): Promise<boolean> {
     return false;
   }
 
@@ -1896,7 +1896,7 @@ export class AbstractAdapter implements Quoting {
     return true;
   }
 
-  supportsCommonTableExpressions(): boolean {
+  async supportsCommonTableExpressions(): Promise<boolean> {
     return false;
   }
 
@@ -1919,7 +1919,7 @@ export class AbstractAdapter implements Quoting {
 
   // --- Capability flags (batch 3) ---
 
-  supportsIndexInclude(): boolean {
+  async supportsIndexInclude(): Promise<boolean> {
     return false;
   }
 
@@ -1947,7 +1947,7 @@ export class AbstractAdapter implements Quoting {
     return false;
   }
 
-  supportsVirtualColumns(): boolean {
+  async supportsVirtualColumns(): Promise<boolean> {
     return false;
   }
 
@@ -1955,15 +1955,15 @@ export class AbstractAdapter implements Quoting {
     return false;
   }
 
-  supportsOptimizerHints(): boolean {
+  async supportsOptimizerHints(): Promise<boolean> {
     return false;
   }
 
-  supportsInsertConflictTarget(): boolean {
+  async supportsInsertConflictTarget(): Promise<boolean> {
     return false;
   }
 
-  supportsNullsNotDistinct(): boolean {
+  async supportsNullsNotDistinct(): Promise<boolean> {
     return false;
   }
 
@@ -1979,7 +1979,7 @@ export class AbstractAdapter implements Quoting {
     return false;
   }
 
-  supportsRestartDbTransaction(): boolean {
+  async supportsRestartDbTransaction(): Promise<boolean> {
     return false;
   }
 
@@ -2178,19 +2178,15 @@ export class AbstractAdapter implements Quoting {
 
   // Mirrors: AbstractAdapter#database_version (`abstract_adapter.rb:854-856`)
   // — `pool.server_version(self)`, the pool-level memo that makes every
-  // adapter's `get_database_version` a pure fetch run at most once. Overrides
-  // may narrow to `Version` or `number`.
-  get databaseVersion(): Version | number {
-    const v = this.pool.serverVersion(this) as Version | number | Promise<Version | number>;
-    if (v instanceof Promise) {
-      throw new Error(
-        "databaseVersion is only available synchronously after getDatabaseVersion() has resolved; await getDatabaseVersion() first",
-      );
-    }
-    return v;
+  // adapter's `get_database_version` a pure fetch run at most once. The memo
+  // is filled on demand, so this reads correctly from an adapter that has
+  // never connected; the fetch it may have to run is what makes the value
+  // awaitable. Overrides may narrow to `Version` or `number`.
+  get databaseVersion(): Version | number | Promise<Version | number> {
+    return this.pool.serverVersion(this) as Version | number | Promise<Version | number>;
   }
 
-  checkVersion(): void {
+  async checkVersion(): Promise<void> {
     checkVersionMixin.call(this as any);
   }
 
@@ -2531,16 +2527,7 @@ export class AbstractAdapter implements Quoting {
 
   /** @internal Mirrors: AbstractAdapter#configure_connection (`abstract_adapter.rb:1212-1214`) */
   configureConnection(..._args: unknown[]): void | Promise<void> {
-    // Deviation, language-forced: Rails' body is `check_version` alone because
-    // `database_version` (`abstract_adapter.rb:854-856`) is a sync reader that
-    // issues its own round-trip. `getDatabaseVersion()` is a real await, so the
-    // sync getter cannot self-fetch; filling the pool memo at the point Rails
-    // establishes the connection is what keeps every version-gated `supports*()`
-    // read a plain memo hit. The sync arm keeps SQLite's `configure_connection`
-    // synchronous, as Rails' is.
-    const serverVersion = this.pool.serverVersion(this);
-    if (serverVersion instanceof Promise) return serverVersion.then(() => this.checkVersion());
-    this.checkVersion();
+    return this.checkVersion();
   }
 
   /** @internal Mirrors: AbstractAdapter#translate_exception_class */

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.full-version.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.full-version.trails.test.ts
@@ -20,15 +20,15 @@ describe("Mysql2Adapter#full_version", () => {
     return adapter;
   }
 
-  it("answers the full version string the Version carries", () => {
-    expect(adapterWith(new Version("10.6.5", "5.5.5-10.6.5-MariaDB")).fullVersion()).toBe(
+  it("answers the full version string the Version carries", async () => {
+    expect(await adapterWith(new Version("10.6.5", "5.5.5-10.6.5-MariaDB")).fullVersion()).toBe(
       "5.5.5-10.6.5-MariaDB",
     );
-    expect(adapterWith(new Version("10.6.5", "5.5.5-10.6.5-MariaDB")).isMariadb()).toBe(true);
+    expect(await adapterWith(new Version("10.6.5", "5.5.5-10.6.5-MariaDB")).isMariadb()).toBe(true);
   });
 
-  it("answers nil, not an empty string, when the Version carries none", () => {
-    expect(adapterWith(new Version("10.6.5")).fullVersion()).toBeNull();
-    expect(adapterWith(new Version("10.6.5")).isMariadb()).toBe(false);
+  it("answers nil, not an empty string, when the Version carries none", async () => {
+    expect(await adapterWith(new Version("10.6.5")).fullVersion()).toBeNull();
+    expect(await adapterWith(new Version("10.6.5")).isMariadb()).toBe(false);
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
@@ -686,7 +686,7 @@ describe("AbstractMysqlAdapter#checkVersion", () => {
     (
       adapter as unknown as { getDatabaseVersion: () => InstanceType<typeof Version> }
     ).getDatabaseVersion = () => new Version("5.6.4");
-    expect(() => adapter.checkVersion()).not.toThrow();
+    await expect(adapter.checkVersion()).resolves.toBeUndefined();
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
@@ -24,28 +24,30 @@ describe("AbstractMysqlAdapter#returnValueAfterInsert", () => {
     const { AbstractMysqlAdapter } = await import("./abstract-mysql-adapter.js");
     const adapter = Object.create(AbstractMysqlAdapter.prototype);
     adapter.supportsInsertReturning = () => false;
-    expect(adapter.returnValueAfterInsert(makeColumn({ autoIncrement: true }))).toBe(true);
+    expect(await adapter.returnValueAfterInsert(makeColumn({ autoIncrement: true }))).toBe(true);
   });
 
   it("returns false for non-auto-increment column when INSERT RETURNING not supported", async () => {
     const { AbstractMysqlAdapter } = await import("./abstract-mysql-adapter.js");
     const adapter = Object.create(AbstractMysqlAdapter.prototype);
     adapter.supportsInsertReturning = () => false;
-    expect(adapter.returnValueAfterInsert(makeColumn({ autoIncrement: false }))).toBe(false);
+    expect(await adapter.returnValueAfterInsert(makeColumn({ autoIncrement: false }))).toBe(false);
   });
 
   it("returns true for auto-populated column (default function) when INSERT RETURNING supported", async () => {
     const { AbstractMysqlAdapter } = await import("./abstract-mysql-adapter.js");
     const adapter = Object.create(AbstractMysqlAdapter.prototype);
     adapter.supportsInsertReturning = () => true;
-    expect(adapter.returnValueAfterInsert(makeColumn({ defaultFunction: "uuid()" }))).toBe(true);
+    expect(await adapter.returnValueAfterInsert(makeColumn({ defaultFunction: "uuid()" }))).toBe(
+      true,
+    );
   });
 
   it("returns false for plain column when INSERT RETURNING supported", async () => {
     const { AbstractMysqlAdapter } = await import("./abstract-mysql-adapter.js");
     const adapter = Object.create(AbstractMysqlAdapter.prototype);
     adapter.supportsInsertReturning = () => true;
-    expect(adapter.returnValueAfterInsert(makeColumn())).toBe(false);
+    expect(await adapter.returnValueAfterInsert(makeColumn())).toBe(false);
   });
 });
 
@@ -667,8 +669,8 @@ describe("AbstractMysqlAdapter#checkVersion", () => {
     (
       adapter as unknown as { getDatabaseVersion: () => InstanceType<typeof Version> }
     ).getDatabaseVersion = () => new Version("5.6.3");
-    expect(() => adapter.checkVersion()).toThrow(DatabaseVersionError);
-    expect(() => adapter.checkVersion()).toThrow(
+    await expect(adapter.checkVersion()).rejects.toThrow(DatabaseVersionError);
+    await expect(adapter.checkVersion()).rejects.toThrow(
       "Your version of MySQL (5.6.3) is too old. Active Record supports MySQL >= 5.6.4.",
     );
   });

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1008,23 +1008,24 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     if (await this.isMariadb()) sql += ` AND cc.table_name = ${scope.name}`;
 
     const rows = await this.schemaQuery(sql);
-    const isMariadb = await this.isMariadb();
 
-    return rows.map((row) => {
-      const name = row["name"] as string;
-      let expression = row["expression"] as string;
-      if (expression.startsWith("(") && expression.endsWith(")")) {
-        expression = expression.slice(1, -1);
-      }
-      expression = this.stripWhitespaceCharacters(expression);
-      if (!isMariadb) {
-        // MySQL returns check constraints expression in an already escaped form.
-        // This leads to duplicate escaping later (e.g. when the expression is
-        // used in the SchemaDumper).
-        expression = expression.replace(/\\'/g, "'");
-      }
-      return new CheckConstraintDefinition(tableName, expression, name);
-    });
+    return Promise.all(
+      rows.map(async (row) => {
+        const name = row["name"] as string;
+        let expression = row["expression"] as string;
+        if (expression.startsWith("(") && expression.endsWith(")")) {
+          expression = expression.slice(1, -1);
+        }
+        expression = this.stripWhitespaceCharacters(expression);
+        if (!(await this.isMariadb())) {
+          // MySQL returns check constraints expression in an already escaped form.
+          // This leads to duplicate escaping later (e.g. when the expression is
+          // used in the SchemaDumper).
+          expression = expression.replace(/\\'/g, "'");
+        }
+        return new CheckConstraintDefinition(tableName, expression, name);
+      }),
+    );
   }
 
   async tableOptions(tableName: string): Promise<Record<string, string>> {

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -381,7 +381,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    * body, the same split `getFullVersion` uses.
    * @internal
    */
-  fullVersion(): string | null {
+  async fullVersion(): Promise<string | null> {
     throw new Error(`${this.constructor.name} must implement fullVersion()`);
   }
 
@@ -392,8 +392,8 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    * arm — a Version built without a full version string
    * (`abstract_adapter.rb:248`) — is spelled out.
    */
-  isMariadb(): boolean {
-    const fullVersion = this.fullVersion();
+  async isMariadb(): Promise<boolean> {
+    const fullVersion = await this.fullVersion();
     return fullVersion != null && /mariadb/i.test(fullVersion);
   }
 
@@ -406,25 +406,25 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return using === "btree" || super.defaultIndexType(using);
   }
 
-  supportsIndexSortOrder(): boolean {
+  async supportsIndexSortOrder(): Promise<boolean> {
     // Rails: `mariadb? ? database_version >= "10.8.1" : database_version >= "8.0.1"`
     // (abstract_mysql_adapter.rb#supports_index_sort_order?).
-    if (this.isMariadb()) return this.databaseVersion.compare("10.8.1") >= 0;
-    return this.databaseVersion.compare("8.0.1") >= 0;
+    if (await this.isMariadb()) return (await this.databaseVersion).compare("10.8.1") >= 0;
+    return (await this.databaseVersion).compare("8.0.1") >= 0;
   }
 
-  supportsExpressionIndex(): boolean {
+  async supportsExpressionIndex(): Promise<boolean> {
     // Mirror Rails `!mariadb? && database_version >= "8.0.13"`
     // (abstract_mysql_adapter.rb:104) — MariaDB is excluded.
-    if (this.isMariadb()) return false;
-    return this.databaseVersion.compare("8.0.13") >= 0;
+    if (await this.isMariadb()) return false;
+    return (await this.databaseVersion).compare("8.0.13") >= 0;
   }
 
   supportsTransactionIsolation(): boolean {
     return true;
   }
 
-  supportsRestartDbTransaction(): boolean {
+  async supportsRestartDbTransaction(): Promise<boolean> {
     return true;
   }
 
@@ -440,17 +440,18 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return true;
   }
 
-  supportsCheckConstraints(): boolean {
-    if (this.isMariadb()) {
+  async supportsCheckConstraints(): Promise<boolean> {
+    if (await this.isMariadb()) {
       // Rails' two-branch MariaDB floor (abstract_mysql_adapter.rb:128-132):
       // 10.3.10+, or a pre-10.3 series from 10.2.22 — 10.3.0..10.3.9 is
       // excluded, which a single `>= 10.2.22` would wrongly admit.
       return (
-        this.databaseVersion.compare("10.3.10") >= 0 ||
-        (this.databaseVersion.compare("10.3") < 0 && this.databaseVersion.compare("10.2.22") >= 0)
+        (await this.databaseVersion).compare("10.3.10") >= 0 ||
+        ((await this.databaseVersion).compare("10.3") < 0 &&
+          (await this.databaseVersion).compare("10.2.22") >= 0)
       );
     }
-    return this.databaseVersion.compare("8.0.16") >= 0;
+    return (await this.databaseVersion).compare("8.0.16") >= 0;
   }
 
   supportsViews(): boolean {
@@ -461,39 +462,39 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return true;
   }
 
-  supportsVirtualColumns(): boolean {
-    return this.isMariadb() || this.databaseVersion.compare("5.7.5") >= 0;
+  async supportsVirtualColumns(): Promise<boolean> {
+    return (await this.isMariadb()) || (await this.databaseVersion).compare("5.7.5") >= 0;
   }
 
-  supportsOptimizerHints(): boolean {
-    if (this.isMariadb()) return false;
-    return this.databaseVersion.compare("5.7.7") >= 0;
+  async supportsOptimizerHints(): Promise<boolean> {
+    if (await this.isMariadb()) return false;
+    return (await this.databaseVersion).compare("5.7.7") >= 0;
   }
 
-  supportsCommonTableExpressions(): boolean {
-    if (this.isMariadb()) return this.databaseVersion.compare("10.2.1") >= 0;
-    return this.databaseVersion.compare("8.0.1") >= 0;
+  async supportsCommonTableExpressions(): Promise<boolean> {
+    if (await this.isMariadb()) return (await this.databaseVersion).compare("10.2.1") >= 0;
+    return (await this.databaseVersion).compare("8.0.1") >= 0;
   }
 
   supportsAdvisoryLocks(): boolean {
     return true;
   }
 
-  supportsInsertOnDuplicateSkip(): boolean {
+  async supportsInsertOnDuplicateSkip(): Promise<boolean> {
     return true;
   }
 
-  supportsInsertOnDuplicateUpdate(): boolean {
+  async supportsInsertOnDuplicateUpdate(): Promise<boolean> {
     return true;
   }
 
-  supportsInsertReturning(): boolean {
-    if (this.isMariadb()) return this.databaseVersion.compare("10.5.0") >= 0;
+  async supportsInsertReturning(): Promise<boolean> {
+    if (await this.isMariadb()) return (await this.databaseVersion).compare("10.5.0") >= 0;
     return false;
   }
 
-  returnValueAfterInsert(column: Column): boolean {
-    return this.supportsInsertReturning()
+  async returnValueAfterInsert(column: Column): Promise<boolean> {
+    return (await this.supportsInsertReturning())
       ? column.isAutoPopulated()
       : column.isAutoIncrementedByDb();
   }
@@ -503,7 +504,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    *  routes the caller to the `last_inserted_id` path. *
    * @internal
    */
-  override returningColumnValues(result: Result): unknown[] | undefined {
+  override returningColumnValues(result: Result): Promise<unknown[] | undefined> {
     return mysqlReturningColumnValues.call(this, result);
   }
 
@@ -515,12 +516,12 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return true;
   }
 
-  supportsJson(): boolean {
+  async supportsJson(): Promise<boolean> {
     // Mirror Rails `!mariadb? && database_version >= "5.7.8"`
     // (mysql2_adapter.rb:70 / trilogy_adapter.rb:95) — MariaDB JSON is a
     // LONGTEXT alias, so Rails reports it unsupported.
-    if (this.isMariadb()) return false;
-    return this.databaseVersion.compare("5.7.8") >= 0;
+    if (await this.isMariadb()) return false;
+    return (await this.databaseVersion).compare("5.7.8") >= 0;
   }
 
   supportsComments(): boolean {
@@ -704,7 +705,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   }
 
   async renameIndex(tableName: string, oldName: string, newName: string): Promise<void> {
-    if (this.supportsRenameIndex()) {
+    if (await this.supportsRenameIndex()) {
       this.validateIndexLengthBang(tableName, newName);
 
       await this._execMutation(
@@ -988,7 +989,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   declare extractForeignKeyAction: typeof mysqlExtractForeignKeyAction;
 
   async checkConstraints(tableName: string): Promise<CheckConstraintDefinition[]> {
-    if (!this.supportsCheckConstraints()) {
+    if (!(await this.supportsCheckConstraints())) {
       // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:545
       throw new NotImplementedError("check constraints are not supported by this database");
     }
@@ -1004,9 +1005,10 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
         AND cc.constraint_schema = ${scope.schema}`;
     // MariaDB lacks the schema+name uniqueness MySQL's JOIN relies on, so it
     // additionally filters cc.table_name (mirrors Rails).
-    if (this.isMariadb()) sql += ` AND cc.table_name = ${scope.name}`;
+    if (await this.isMariadb()) sql += ` AND cc.table_name = ${scope.name}`;
 
     const rows = await this.schemaQuery(sql);
+    const isMariadb = await this.isMariadb();
 
     return rows.map((row) => {
       const name = row["name"] as string;
@@ -1015,7 +1017,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
         expression = expression.slice(1, -1);
       }
       expression = this.stripWhitespaceCharacters(expression);
-      if (!this.isMariadb()) {
+      if (!isMariadb) {
         // MySQL returns check constraints expression in an already escaped form.
         // This leads to duplicate escaping later (e.g. when the expression is
         // used in the SchemaDumper).
@@ -1177,14 +1179,11 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   }
 
   // Mirrors: ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#check_version
-  // (abstract_mysql_adapter.rb:684-688). Rails' `database_version` issues the
-  // round-trip itself when unmemoized; trails' sync getter cannot, so
-  // `AbstractAdapter#configureConnection` fills the pool memo before invoking
-  // this — the same ordering, one call site earlier.
-  override checkVersion(): void {
-    if (this.databaseVersion.compare("5.6.4") < 0) {
+  // (abstract_mysql_adapter.rb:684-688).
+  override async checkVersion(): Promise<void> {
+    if ((await this.databaseVersion).compare("5.6.4") < 0) {
       throw new DatabaseVersionError(
-        `Your version of MySQL (${this.databaseVersion}) is too old. Active Record supports MySQL >= 5.6.4.`,
+        `Your version of MySQL (${await this.databaseVersion}) is too old. Active Record supports MySQL >= 5.6.4.`,
       );
     }
   }
@@ -1355,9 +1354,9 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::DatabaseStatements#build_explain_clause
    */
-  override buildExplainClause(options: ExplainOption[] = []): string {
+  override async buildExplainClause(options: ExplainOption[] = []): Promise<string> {
     if (options.length === 0) return "EXPLAIN for:";
-    return `${this._explainClause(options)} for:`;
+    return `${await this._explainClause(options)} for:`;
   }
 
   /**
@@ -1367,8 +1366,8 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::DatabaseStatements#analyze_without_explain?
    */
-  protected analyzeWithoutExplain(): boolean {
-    return this.isMariadb() && this.databaseVersion.compare("10.1.0") >= 0;
+  protected async analyzeWithoutExplain(): Promise<boolean> {
+    return (await this.isMariadb()) && (await this.databaseVersion).compare("10.1.0") >= 0;
   }
 
   /**
@@ -1377,9 +1376,9 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    * (`_explainStatementClause`), applying the MariaDB `ANALYZE`-without-
    * `EXPLAIN` rewrite. Mirrors MySQL::DatabaseStatements#build_explain_clause.
    */
-  private _explainClause(options: ExplainOption[]): string {
+  private async _explainClause(options: ExplainOption[]): Promise<string> {
     const clause = `EXPLAIN ${this._validateExplainOptions(options).join(" ")}`;
-    return this.analyzeWithoutExplain() && clause.includes("ANALYZE")
+    return (await this.analyzeWithoutExplain()) && clause.includes("ANALYZE")
       ? clause.replace("EXPLAIN ", "")
       : clause;
   }
@@ -1423,7 +1422,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    * Compose the actual `EXPLAIN ...` SQL clause that prefixes the query —
    * distinct from `buildExplainClause`, which builds the printed header.
    */
-  protected _explainStatementClause(options: ExplainOption[]): string {
+  protected async _explainStatementClause(options: ExplainOption[]): Promise<string> {
     if (options.length === 0) return "EXPLAIN";
     return this._explainClause(options);
   }
@@ -1647,21 +1646,21 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   }
 
   /** @internal */
-  supportsInsertRawAliasSyntax(): boolean {
-    if (this.isMariadb()) return false;
-    return this.databaseVersion.compare("8.0.19") >= 0;
+  async supportsInsertRawAliasSyntax(): Promise<boolean> {
+    if (await this.isMariadb()) return false;
+    return (await this.databaseVersion).compare("8.0.19") >= 0;
   }
 
   /** @internal */
-  supportsRenameIndex(): boolean {
-    if (this.isMariadb()) return this.databaseVersion.compare("10.5.2") >= 0;
-    return this.databaseVersion.compare("5.7.6") >= 0;
+  async supportsRenameIndex(): Promise<boolean> {
+    if (await this.isMariadb()) return (await this.databaseVersion).compare("10.5.2") >= 0;
+    return (await this.databaseVersion).compare("5.7.6") >= 0;
   }
 
   /** @internal */
-  supportsRenameColumn(): boolean {
-    if (this.isMariadb()) return this.databaseVersion.compare("10.5.2") >= 0;
-    return this.databaseVersion.compare("8.0.3") >= 0;
+  async supportsRenameColumn(): Promise<boolean> {
+    if (await this.isMariadb()) return (await this.databaseVersion).compare("10.5.2") >= 0;
+    return (await this.databaseVersion).compare("8.0.3") >= 0;
   }
 
   /**
@@ -1762,7 +1761,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     columnName: string,
     newColumnName: string,
   ): Promise<string> {
-    if (this.supportsRenameColumn()) {
+    if (await this.supportsRenameColumn()) {
       return this.renameColumnSql(tableName, columnName, newColumnName);
     }
     const column = (await this.columnFor(tableName, columnName)) as MysqlColumn;
@@ -1994,7 +1993,7 @@ export class StatementPool extends ConnectionStatementPool<MysqlPreparedStatemen
  * @internal
  */
 export interface AbstractMysqlAdapter {
-  get databaseVersion(): Version;
+  get databaseVersion(): Version | Promise<Version>;
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -1604,7 +1604,7 @@ async function insertStatement(
     // id so the single PK/auto-populated column is still filled. Returned as an
     // array to match Rails' `returning_column_values` shape.
     if (result instanceof Result) {
-      const rv = (this.returningColumnValues ?? returningColumnValues).call(this, result);
+      const rv = await (this.returningColumnValues ?? returningColumnValues).call(this, result);
       // `undefined` first element means no value was extracted (no RETURNING
       // clause emitted) — fall back to the insert id. A real `null` is a
       // legitimate RETURNING value and must be preserved, so guard on

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.test.ts
@@ -49,9 +49,11 @@ describeIfPostgresqlAdapter("SchemaCreation drop-constraint visitors", () => {
     expect(sc.visitDropForeignKey("fk_rails_abc")).toBe('DROP CONSTRAINT "fk_rails_abc"');
   });
 
-  it("visit_DropCheckConstraint emits DROP CONSTRAINT with a quoted name", () => {
+  it("visit_DropCheckConstraint emits DROP CONSTRAINT with a quoted name", async () => {
     const sc = new SchemaCreation("postgres", conn) as any;
-    expect(sc.visitDropCheckConstraint("chk_rails_abc")).toBe('DROP CONSTRAINT "chk_rails_abc"');
+    expect(await sc.visitDropCheckConstraint("chk_rails_abc")).toBe(
+      'DROP CONSTRAINT "chk_rails_abc"',
+    );
   });
 });
 
@@ -124,11 +126,11 @@ describeIfPostgresqlAdapter("SchemaCreation quoting delegations", () => {
 // exclusively in AbstractMysqlAdapter#add_index_length; the abstract visitor
 // must NOT, or it emits invalid `("name"(10))` on PG/SQLite.
 describeIfPostgresqlAdapter("SchemaCreation#quotedColumnsForIndex sub-part length gating", () => {
-  it("does not append sub-part length on postgres", () => {
+  it("does not append sub-part length on postgres", async () => {
     const idx = new IndexDefinition("posts", "index_posts_on_title", false, ["title"], {
       lengths: { title: 10 },
     });
-    const sql = (new SchemaCreation("postgres", conn) as any).visitCreateIndexDefinition(
+    const sql = await (new SchemaCreation("postgres", conn) as any).visitCreateIndexDefinition(
       new CreateIndexDefinition(idx, false),
     );
     expect(sql).not.toContain("(10)");
@@ -137,11 +139,11 @@ describeIfPostgresqlAdapter("SchemaCreation#quotedColumnsForIndex sub-part lengt
 });
 
 describeIfSqlite("SchemaCreation#quotedColumnsForIndex sub-part length gating", () => {
-  it("does not append sub-part length on sqlite", () => {
+  it("does not append sub-part length on sqlite", async () => {
     const idx = new IndexDefinition("posts", "index_posts_on_title", false, ["title"], {
       lengths: { title: 10 },
     });
-    const sql = (new SchemaCreation("sqlite", conn) as any).visitCreateIndexDefinition(
+    const sql = await (new SchemaCreation("sqlite", conn) as any).visitCreateIndexDefinition(
       new CreateIndexDefinition(idx, false),
     );
     expect(sql).not.toContain("(10)");
@@ -170,17 +172,17 @@ describe("SchemaCreation#quotedColumns delegates to the connection", () => {
     },
   };
 
-  it("routes an array column set through host.quotedColumnsForIndex", () => {
+  it("routes an array column set through host.quotedColumnsForIndex", async () => {
     const idx = new IndexDefinition("posts", "index_posts_on_title", false, ["title"], {
       opclasses: { title: "text_pattern_ops" },
     });
-    const sql = (new SchemaCreation("postgres", host as any) as any).visitCreateIndexDefinition(
-      new CreateIndexDefinition(idx, false),
-    );
+    const sql = await (
+      new SchemaCreation("postgres", host as any) as any
+    ).visitCreateIndexDefinition(new CreateIndexDefinition(idx, false));
     expect(sql).toContain('("title" text_pattern_ops)');
   });
 
-  it("emits a String column set verbatim without delegating", () => {
+  it("emits a String column set verbatim without delegating", async () => {
     const idx = new IndexDefinition(
       "posts",
       "index_posts_on_expr",
@@ -188,9 +190,9 @@ describe("SchemaCreation#quotedColumns delegates to the connection", () => {
       "lower(title)" as any,
       {},
     );
-    const sql = (new SchemaCreation("postgres", host as any) as any).visitCreateIndexDefinition(
-      new CreateIndexDefinition(idx, false),
-    );
+    const sql = await (
+      new SchemaCreation("postgres", host as any) as any
+    ).visitCreateIndexDefinition(new CreateIndexDefinition(idx, false));
     expect(sql).toContain("(lower(title))");
     expect(sql).not.toContain("DEFAULT_OPS");
   });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -111,7 +111,7 @@ export class SchemaCreation {
    * base supplies an identifier-quoting default so the shared visitor type-checks.
    * @internal
    */
-  protected quotedIncludeColumns(o: string | string[]): string {
+  protected async quotedIncludeColumns(o: string | string[]): Promise<string> {
     if (typeof o === "string") return o;
     return o.map((c) => this.adapter.quoteColumnName(c)).join(", ");
   }
@@ -318,7 +318,7 @@ export class SchemaCreation {
     if (this.supportsIndexUsing() && index.using) parts.push(`USING ${index.using}`);
     parts.push(`(${await this.quotedColumns(index)})`);
     if ((await this.supportsIndexInclude()) && index.include && index.include.length > 0) {
-      parts.push(`INCLUDE (${this.quotedIncludeColumns(index.include)})`);
+      parts.push(`INCLUDE (${await this.quotedIncludeColumns(index.include)})`);
     }
     if ((await this.supportsNullsNotDistinct()) && index.nullsNotDistinct)
       parts.push("NULLS NOT DISTINCT");

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -54,7 +54,7 @@ export class SchemaCreation {
     return this.adapterName !== "mysql";
   }
 
-  protected supportsIndexSortOrder(): boolean {
+  protected async supportsIndexSortOrder(): Promise<boolean> {
     return this.adapterName !== "mysql";
   }
 
@@ -62,11 +62,11 @@ export class SchemaCreation {
     return this.adapterName === "postgres" || this.adapterName === "mysql";
   }
 
-  protected supportsIndexInclude(): boolean {
+  protected async supportsIndexInclude(): Promise<boolean> {
     return this.adapterName === "postgres";
   }
 
-  protected supportsNullsNotDistinct(): boolean {
+  protected async supportsNullsNotDistinct(): Promise<boolean> {
     return this.adapterName === "postgres";
   }
 
@@ -163,13 +163,13 @@ export class SchemaCreation {
       }
     }
 
-    if (this.supportsCheckConstraints()) {
+    if (await this.supportsCheckConstraints()) {
       for (const chk of o.checkConstraints) {
         statements.push(this.visitCheckConstraintDefinition(chk));
       }
     }
 
-    statements.push(...this.tableConstraintStatements(o));
+    statements.push(...(await this.tableConstraintStatements(o)));
 
     if (statements.length > 0) sql += ` (${statements.join(", ")})`;
     sql = this.addTableOptionsBang(sql, o);
@@ -200,7 +200,7 @@ export class SchemaCreation {
    * `send` would raise for any other adapter.
    * @internal
    */
-  protected visitIndexDefinition(_o: IndexDefinition, _create = false): string {
+  protected visitIndexDefinition(_o: IndexDefinition, _create = false): Promise<string> {
     // @nie disposition=TODO
     throw new NotImplementedError();
   }
@@ -216,7 +216,7 @@ export class SchemaCreation {
   }
 
   /** @internal */
-  protected supportsCheckConstraints(): boolean {
+  protected async supportsCheckConstraints(): Promise<boolean> {
     return true;
   }
 
@@ -225,7 +225,7 @@ export class SchemaCreation {
    * (e.g. PostgreSQL exclusion/unique constraints). Returns empty by default.
    * @internal
    */
-  protected tableConstraintStatements(_o: TableDefinition): string[] {
+  protected async tableConstraintStatements(_o: TableDefinition): Promise<string[]> {
     return [];
   }
 
@@ -280,7 +280,7 @@ export class SchemaCreation {
       parts.push(this.visitAddCheckConstraint(chk));
     }
     for (const name of o.checkConstraintDrops) {
-      parts.push(this.visitDropCheckConstraint(name));
+      parts.push(await this.visitDropCheckConstraint(name));
     }
     for (const name of o.constraintDrops) {
       parts.push(this.visitDropConstraint(name));
@@ -304,7 +304,7 @@ export class SchemaCreation {
     return `ADD ${this.visitForeignKeyDefinition(o)}`;
   }
 
-  protected visitCreateIndexDefinition(o: CreateIndexDefinition): string {
+  protected async visitCreateIndexDefinition(o: CreateIndexDefinition): Promise<string> {
     const index = o.index;
     const parts: string[] = ["CREATE"];
     if (index.unique) parts.push("UNIQUE");
@@ -316,11 +316,12 @@ export class SchemaCreation {
       `${this.adapter.quoteColumnName(index.name)} ON ${this.adapter.quoteTableName(index.table)}`,
     );
     if (this.supportsIndexUsing() && index.using) parts.push(`USING ${index.using}`);
-    parts.push(`(${this.quotedColumns(index)})`);
-    if (this.supportsIndexInclude() && index.include && index.include.length > 0) {
+    parts.push(`(${await this.quotedColumns(index)})`);
+    if ((await this.supportsIndexInclude()) && index.include && index.include.length > 0) {
       parts.push(`INCLUDE (${this.quotedIncludeColumns(index.include)})`);
     }
-    if (this.supportsNullsNotDistinct() && index.nullsNotDistinct) parts.push("NULLS NOT DISTINCT");
+    if ((await this.supportsNullsNotDistinct()) && index.nullsNotDistinct)
+      parts.push("NULLS NOT DISTINCT");
     if (this.supportsPartialIndex() && index.where) parts.push(`WHERE ${index.where}`);
     return parts.join(" ");
   }
@@ -337,16 +338,16 @@ export class SchemaCreation {
    * the parallel `quotedIncludeColumns` delegation.
    * @internal
    */
-  protected quotedColumnsForIndex(
+  protected async quotedColumnsForIndex(
     columnNames: string[],
     options: {
       length?: number | Record<string, number>;
       order?: string | Record<string, string>;
       opclass?: string | Record<string, string>;
     },
-  ): string {
+  ): Promise<string> {
     const host = this.adapter as SchemaQuoter & {
-      quotedColumnsForIndex?(cols: string[], options: Record<string, unknown>): string;
+      quotedColumnsForIndex?(cols: string[], options: Record<string, unknown>): Promise<string>;
     };
     if (typeof host.quotedColumnsForIndex === "function") {
       return host.quotedColumnsForIndex(columnNames, options);
@@ -493,7 +494,7 @@ export class SchemaCreation {
   }
 
   /** @internal */
-  protected visitDropCheckConstraint(name: string): string {
+  protected async visitDropCheckConstraint(name: string): Promise<string> {
     return `DROP CONSTRAINT ${this.quoteColumnName(name)}`;
   }
 
@@ -508,7 +509,7 @@ export class SchemaCreation {
    * "(data->'foo')"); otherwise delegate to `quoted_columns_for_index`.
    * @internal
    */
-  protected quotedColumns(o: IndexDefinition): string {
+  protected async quotedColumns(o: IndexDefinition): Promise<string> {
     return typeof o.columns === "string"
       ? o.columns
       : this.quotedColumnsForIndex(o.columns, o.columnOptions());

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
@@ -293,7 +293,7 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
     class SuperCallingAdapter extends SqliteCapturingAdapter {
       changeColumnDefaultCalls = 0;
       addCheckConstraintCalls = 0;
-      supportsCheckConstraints() {
+      async supportsCheckConstraints() {
         return true;
       }
       quoteColumnName(name: string) {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -488,25 +488,25 @@ describe("SchemaStatements privates (PR 8)", () => {
 });
 
 describe("SchemaStatements#quotedColumnsForIndex", () => {
-  it("quotes column names without options", () => {
+  it("quotes column names without options", async () => {
     const ss = makeStatements();
-    expect(ss.quotedColumnsForIndex(["id", "name"])).toBe('"id", "name"');
+    expect(await ss.quotedColumnsForIndex(["id", "name"])).toBe('"id", "name"');
   });
 
-  it("appends sort order when adapter supports it and order option is given", () => {
+  it("appends sort order when adapter supports it and order option is given", async () => {
     const ss = makeStatements({
       supportsIndexSortOrder: () => true,
     });
-    expect(ss.quotedColumnsForIndex(["id", "name"], { order: { id: "desc", name: "asc" } })).toBe(
-      '"id" DESC, "name" ASC',
-    );
+    expect(
+      await ss.quotedColumnsForIndex(["id", "name"], { order: { id: "desc", name: "asc" } }),
+    ).toBe('"id" DESC, "name" ASC');
   });
 
-  it("ignores sort order when adapter does not support it", () => {
+  it("ignores sort order when adapter does not support it", async () => {
     const ss = makeStatements({
       supportsIndexSortOrder: () => false,
     });
-    expect(ss.quotedColumnsForIndex(["id", "name"], { order: { id: "desc" } })).toBe(
+    expect(await ss.quotedColumnsForIndex(["id", "name"], { order: { id: "desc" } })).toBe(
       '"id", "name"',
     );
   });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -847,10 +847,10 @@ export class SchemaStatements {
       [key: string]: unknown;
     } = {},
   ): Promise<void> {
-    const support = this as { supportsCheckConstraints?: () => boolean };
+    const support = this as { supportsCheckConstraints?: () => Promise<boolean> };
     if (
       typeof support.supportsCheckConstraints === "function" &&
-      !support.supportsCheckConstraints()
+      !(await support.supportsCheckConstraints())
     )
       return;
 
@@ -1849,12 +1849,17 @@ export class SchemaStatements {
     );
   }
 
-  quotedColumnsForIndex(columnNames: string[], options: Record<string, unknown> = {}): string {
+  async quotedColumnsForIndex(
+    columnNames: string[],
+    options: Record<string, unknown> = {},
+  ): Promise<string> {
     const quotedColumns = new Map(columnNames.map((name) => [name, this.quoteColumnName(name)]));
     return Array.from(
-      this.addOptionsForIndexColumns(
-        quotedColumns,
-        options as { order?: string | Record<string, string> },
+      (
+        await this.addOptionsForIndexColumns(
+          quotedColumns,
+          options as { order?: string | Record<string, string> },
+        )
       ).values(),
     ).join(", ");
   }
@@ -2008,16 +2013,19 @@ export class SchemaStatements {
   }
 
   /** @internal */
-  addOptionsForIndexColumns(
+  async addOptionsForIndexColumns(
     quotedColumns: Map<string, string>,
     options: {
       order?: string | Record<string, string>;
       opclass?: string | Record<string, string>;
       length?: number | Record<string, number>;
     } = {},
-  ): Map<string, string> {
+  ): Promise<Map<string, string>> {
     const adapter = this as any;
-    if (typeof adapter.supportsIndexSortOrder === "function" && adapter.supportsIndexSortOrder()) {
+    if (
+      typeof adapter.supportsIndexSortOrder === "function" &&
+      (await adapter.supportsIndexSortOrder())
+    ) {
       quotedColumns = this.addIndexSortOrder(quotedColumns, options);
     }
     return quotedColumns;
@@ -2304,7 +2312,7 @@ export class SchemaStatements {
     const adapter = this as any;
     if (
       typeof adapter.supportsCheckConstraints === "function" &&
-      !adapter.supportsCheckConstraints()
+      !(await adapter.supportsCheckConstraints())
     ) {
       return undefined;
     }

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -299,7 +299,7 @@ export type TransactionConnection = DatabaseAdapter & {
   restartDbTransaction?(): void | Promise<void>;
   resetIsolationLevel?(): void | Promise<void>;
   supportsLazyTransactions?(): boolean;
-  supportsRestartDbTransaction?(): boolean;
+  supportsRestartDbTransaction?(): Promise<boolean>;
   addTransactionRecord?(record: unknown): void;
   active?(): boolean | Promise<boolean>;
   currentTransaction?(): Transaction | NullTransaction;
@@ -866,14 +866,7 @@ export class RealTransaction extends Transaction {
 
     this._instrumenter.finish("restart");
 
-    let supportsRestart = false;
-    try {
-      supportsRestart = !!this.connection.supportsRestartDbTransaction?.();
-    } catch {
-      // databaseVersion may not be loaded yet; fall back to rollback+begin
-    }
-
-    if (supportsRestart) {
+    if (await this.connection.supportsRestartDbTransaction?.()) {
       this._instrumenter.start();
       await this.connection.restartDbTransaction?.();
     } else {

--- a/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
@@ -57,8 +57,8 @@ export function isWriteQuery(sql: string): boolean {
 }
 
 export interface BuildExplainClauseHost {
-  isMariadb?(): boolean;
-  databaseVersion?: Version;
+  isMariadb?(): Promise<boolean>;
+  databaseVersion?: Version | Promise<Version>;
 }
 
 /**
@@ -66,13 +66,13 @@ export interface BuildExplainClauseHost {
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::DatabaseStatements#build_explain_clause
  */
-export function buildExplainClause(
+export async function buildExplainClause(
   this: BuildExplainClauseHost | void,
   options: ExplainOption[] = [],
-): string {
+): Promise<string> {
   if (options.length === 0) return "EXPLAIN";
   const clause = `EXPLAIN ${options.map((o) => (typeof o === "string" ? o.toUpperCase() : `FORMAT=${(o as { format: string }).format.toUpperCase()}`)).join(" ")}`;
-  if (isAnalyzeWithoutExplain.call(this) && clause.includes("ANALYZE")) {
+  if ((await isAnalyzeWithoutExplain.call(this)) && clause.includes("ANALYZE")) {
     return clause.replace("EXPLAIN ", "");
   }
   return clause;
@@ -90,11 +90,13 @@ interface AutoIncrementColumnHost {
 /**
  * @internal
  */
-export function isAnalyzeWithoutExplain(this: BuildExplainClauseHost | void): boolean {
+export async function isAnalyzeWithoutExplain(
+  this: BuildExplainClauseHost | void,
+): Promise<boolean> {
   const host = this as BuildExplainClauseHost | null;
-  if (!host?.isMariadb?.()) return false;
+  if (!(await host?.isMariadb?.())) return false;
   // Rails: `database_version >= "10.1.0"` (mysql/database_statements.rb:50).
-  return (host.databaseVersion?.compare("10.1.0") ?? -1) >= 0;
+  return ((await host?.databaseVersion)?.compare("10.1.0") ?? -1) >= 0;
 }
 
 /** @internal */
@@ -200,7 +202,9 @@ export async function explain(
   options: ExplainOption[] = [],
 ): Promise<string> {
   const sql =
-    buildExplainClause.call(this, options) + " " + abstractToSql.call(this as any, arel, binds);
+    (await buildExplainClause.call(this, options)) +
+    " " +
+    abstractToSql.call(this as any, arel, binds);
   const start = Date.now();
   const result = await internalExecQuery.call(this as any, String(sql), "EXPLAIN", binds);
   const elapsed = (Date.now() - start) / 1000;

--- a/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
@@ -80,7 +80,7 @@ export function buildExplainClause(
 
 interface SupportsInsertReturningHost {
   /** @internal */
-  supportsInsertReturning?(): boolean;
+  supportsInsertReturning?(): Promise<boolean>;
 }
 
 interface AutoIncrementColumnHost {
@@ -105,11 +105,11 @@ export function defaultInsertValue(column: AutoIncrementColumnHost): Nodes.SqlLi
 }
 
 /** @internal */
-export function returningColumnValues(
+export async function returningColumnValues(
   this: SupportsInsertReturningHost | void,
   result: Result,
-): unknown[] | undefined {
-  if ((this as SupportsInsertReturningHost | null)?.supportsInsertReturning?.()) {
+): Promise<unknown[] | undefined> {
+  if (await (this as SupportsInsertReturningHost | null)?.supportsInsertReturning?.()) {
     return result.rows[0] as unknown[] | undefined;
   }
   // Falls back to abstract base behavior (last_inserted_id path)

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.test.ts
@@ -42,12 +42,12 @@ describeIfMysqlAdapter("MySQL::SchemaCreation", () => {
     // The lane's leased connection is MariaDB in CI, so the MySQL arm of
     // `mariadb?` (mysql/schema_creation.rb:35) is selected explicitly.
     const mysql = new SchemaCreation(mysqlConn({ isMariadb: () => false }));
-    expect((mysql as any).visitDropCheckConstraint("chk")).toBe("DROP CHECK chk");
+    expect(await (mysql as any).visitDropCheckConstraint("chk")).toBe("DROP CHECK chk");
   });
 
   it("visitDropCheckConstraint uses CONSTRAINT for MariaDB", async () => {
     const mdb = new SchemaCreation(mysqlConn({ isMariadb: () => true }));
-    expect((mdb as any).visitDropCheckConstraint("chk")).toBe("DROP CONSTRAINT chk");
+    expect(await (mdb as any).visitDropCheckConstraint("chk")).toBe("DROP CONSTRAINT chk");
   });
 
   it("visitAlterTable routes FK/check drops through the MySQL visitors", async () => {
@@ -87,12 +87,14 @@ describeIfMysqlAdapter("MySQL::SchemaCreation", () => {
 
   it("visitIndexDefinition generates inline INDEX sql", async () => {
     const idx = new IndexDefinition("users", "idx_users_email", false, ["email"]);
-    expect((sc as any).visitIndexDefinition(idx, false)).toBe("INDEX `idx_users_email` (`email`)");
+    expect(await (sc as any).visitIndexDefinition(idx, false)).toBe(
+      "INDEX `idx_users_email` (`email`)",
+    );
   });
 
   it("visitIndexDefinition generates CREATE UNIQUE INDEX with table", async () => {
     const idx = new IndexDefinition("users", "idx", true, ["email"]);
-    expect((sc as any).visitIndexDefinition(idx, true)).toBe(
+    expect(await (sc as any).visitIndexDefinition(idx, true)).toBe(
       "CREATE UNIQUE INDEX `idx` ON `users` (`email`)",
     );
   });
@@ -111,7 +113,7 @@ describeIfMysqlAdapter("MySQL::SchemaCreation", () => {
   it("visitCreateIndexDefinition appends algorithm", async () => {
     const idx = new IndexDefinition("users", "idx", false, ["col"]);
     const def = new CreateIndexDefinition(idx, false, "INPLACE");
-    expect((sc as any).visitCreateIndexDefinition(def)).toContain("INPLACE");
+    expect(await (sc as any).visitCreateIndexDefinition(def)).toContain("INPLACE");
   });
 
   it("emits inline index sort order when the adapter supports it", async () => {
@@ -119,7 +121,9 @@ describeIfMysqlAdapter("MySQL::SchemaCreation", () => {
     const idx = new IndexDefinition("users", "idx", false, ["email"], {
       orders: { email: "desc" },
     });
-    expect((withHost as any).visitIndexDefinition(idx, false)).toBe("INDEX `idx` (`email` DESC)");
+    expect(await (withHost as any).visitIndexDefinition(idx, false)).toBe(
+      "INDEX `idx` (`email` DESC)",
+    );
   });
 
   it("drops inline index sort order when the adapter version gate is unsupported", async () => {
@@ -127,7 +131,7 @@ describeIfMysqlAdapter("MySQL::SchemaCreation", () => {
     const idx = new IndexDefinition("users", "idx", false, ["email"], {
       orders: { email: "desc" },
     });
-    expect((withHost as any).visitIndexDefinition(idx, false)).toBe("INDEX `idx` (`email`)");
+    expect(await (withHost as any).visitIndexDefinition(idx, false)).toBe("INDEX `idx` (`email`)");
   });
 
   it("addTableOptionsBang appends charset and collation", async () => {

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
@@ -49,13 +49,13 @@ type MysqlTableDef = TableDefinition & { charset?: string; collation?: string };
  * Rails' `SchemaCreation#initialize(conn)` always receives the live adapter, so the quoting
  * half is required and dispatches polymorphically. */
 export interface VisitorHostAdapter extends TableDefinitionConn {
-  supportsCheckConstraints(): boolean;
+  supportsCheckConstraints(): Promise<boolean>;
   supportsForeignKeys(): boolean;
   supportsIndexesInCreate(): boolean;
-  /** Version-gated: MariaDB ≥ 10.8.1 / MySQL ≥ 8.0.1. Reads the cached version
-   * synchronously and yields false when cold — warm via `getDatabaseVersion`. */
-  supportsIndexSortOrder(): boolean;
-  isMariadb(): boolean;
+  /** Version-gated: MariaDB ≥ 10.8.1 / MySQL ≥ 8.0.1 — fetches the server
+   * version on demand, so it is awaitable. */
+  supportsIndexSortOrder(): Promise<boolean>;
+  isMariadb(): Promise<boolean>;
   quote(value: unknown): string;
   /** Rails' `index_in_create` builds the IndexDefinition through `@conn.add_index_options`
    * (mysql/schema_creation.rb:99). */
@@ -77,7 +77,7 @@ export class SchemaCreation extends AbstractSchemaCreation {
 
   /** @internal Live MariaDB lookup — consults the host adapter every call so a late
    * `getFullVersion()` flip (lazy detection on first probe) is honored. */
-  protected isMariadb(): boolean {
+  protected async isMariadb(): Promise<boolean> {
     return this.adapter.isMariadb();
   }
 
@@ -85,7 +85,7 @@ export class SchemaCreation extends AbstractSchemaCreation {
    * (MariaDB >= 10.8.1 / MySQL >= 8.0.1). Consult the threaded adapter's version-gated
    * flag. The base returns `adapterName !== "mysql"` (always false),
    * so this override is what makes MySQL honor the version gate. */
-  protected override supportsIndexSortOrder(): boolean {
+  protected override async supportsIndexSortOrder(): Promise<boolean> {
     return this.adapter.supportsIndexSortOrder();
   }
 
@@ -179,8 +179,8 @@ export class SchemaCreation extends AbstractSchemaCreation {
   }
 
   /** @internal */
-  protected visitDropCheckConstraint(name: string): string {
-    return `DROP ${this.isMariadb() ? "CONSTRAINT" : "CHECK"} ${name}`;
+  protected override async visitDropCheckConstraint(name: string): Promise<string> {
+    return `DROP ${(await this.isMariadb()) ? "CONSTRAINT" : "CHECK"} ${name}`;
   }
 
   /** @internal */
@@ -209,7 +209,7 @@ export class SchemaCreation extends AbstractSchemaCreation {
   }
 
   /** @internal Delegates to the adapter; honors MySQL 8.0.16+ / MariaDB 10.2.1+ version gating. */
-  protected supportsCheckConstraints(): boolean {
+  protected async supportsCheckConstraints(): Promise<boolean> {
     return this.adapter.supportsCheckConstraints();
   }
 
@@ -246,13 +246,13 @@ export class SchemaCreation extends AbstractSchemaCreation {
   }
 
   /** @internal */
-  protected override visitCreateIndexDefinition(o: CreateIndexDefinition): string {
-    const sql = this.visitIndexDefinition(o.index, true);
+  protected override async visitCreateIndexDefinition(o: CreateIndexDefinition): Promise<string> {
+    const sql = await this.visitIndexDefinition(o.index, true);
     return o.algorithm ? `${sql} ${o.algorithm}` : sql;
   }
 
   /** @internal */
-  protected visitIndexDefinition(o: IndexDefinition, create = false): string {
+  protected async visitIndexDefinition(o: IndexDefinition, create = false): Promise<string> {
     const indexType = o.type?.toUpperCase() ?? (o.unique ? "UNIQUE" : undefined);
 
     const parts: string[] = create ? ["CREATE"] : [];
@@ -261,13 +261,13 @@ export class SchemaCreation extends AbstractSchemaCreation {
     parts.push(this.adapter.quoteColumnName(o.name));
     if (o.using) parts.push(`USING ${o.using}`);
     if (create) parts.push(`ON ${this.adapter.quoteTableName(o.table)}`);
-    parts.push(`(${this.quotedColumns(o)})`);
+    parts.push(`(${await this.quotedColumns(o)})`);
 
     return this.addSqlCommentBang(parts.join(" "), o.comment);
   }
 
   /** @internal */
-  protected override quotedColumns(o: { columns: string | string[] }): string {
+  protected override async quotedColumns(o: { columns: string | string[] }): Promise<string> {
     if (typeof o.columns === "string") return o.columns;
     const idx = o as IndexDefinition;
     const quotedMap = new Map<string, string>(
@@ -279,7 +279,7 @@ export class SchemaCreation extends AbstractSchemaCreation {
         length: idx.lengths as Record<string, number> | number | undefined,
         order: idx.orders as Record<string, string> | string | undefined,
       },
-      this.supportsIndexSortOrder(),
+      await this.supportsIndexSortOrder(),
     );
     return [...quotedMap.values()].join(", ");
   }
@@ -317,7 +317,7 @@ export class SchemaCreation extends AbstractSchemaCreation {
     }
     if (mo.as) {
       sql += ` AS (${mo.as})`;
-      if (mo.stored) sql += this.isMariadb() ? " PERSISTENT" : " STORED";
+      if (mo.stored) sql += (await this.isMariadb()) ? " PERSISTENT" : " STORED";
     }
     return this.addSqlCommentBang(await super.addColumnOptions(sql, options), mo.comment);
   }

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
@@ -45,8 +45,8 @@ const quoteHost = { quote };
 function rowFormatHost(isMariadb: boolean, version: string, probeResult = 0) {
   const queries: string[] = [];
   return {
-    isMariadb: () => isMariadb,
-    pool: { serverVersion: async () => new Version(version) },
+    isMariadb: async () => isMariadb,
+    databaseVersion: Promise.resolve(new Version(version)),
     queryValue: async (sql: string) => {
       queries.push(sql);
       return probeResult;
@@ -460,7 +460,7 @@ describe("MySQL::SchemaStatements", () => {
   const indexHost = (rows: Record<string, unknown>[], sortOrderSupported = true) => ({
     schemaQuery: async () => rows,
     quoteTableName: (n: string) => `\`${n}\``,
-    supportsIndexSortOrder: () => sortOrderSupported,
+    supportsIndexSortOrder: async () => sortOrderSupported,
   });
 
   it("indexes: surfaces per-column prefix lengths from Sub_part", async () => {

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -162,25 +162,18 @@ interface QuotedScopeHost {
  * on the slot reproduces.
  */
 export interface RowFormatHost {
-  isMariadb(): boolean;
-  pool: { serverVersion(connection: unknown): unknown };
+  isMariadb(): Promise<boolean>;
+  readonly databaseVersion: Version | number | Promise<Version | number>;
   queryValue(sql: string, name?: string): Promise<unknown>;
   _defaultRowFormat?: string | null;
 }
 
-/** @internal */
+/** @internal Mirrors: MySQL::SchemaStatements#row_format_dynamic_by_default?
+ * (mysql/schema_statements.rb:146-152) */
 export async function isRowFormatDynamicByDefault(this: RowFormatHost): Promise<boolean> {
-  // Rails' `row_format_dynamic_by_default?` (mysql/schema_statements.rb:146-152)
-  // is sync, reading `database_version` — a reader that fetches on demand and so
-  // works on a standalone, not-yet-connected adapter. Ours cannot, and
-  // `create_table` on such an adapter reaches here before anything has opened a
-  // socket, so the await stands in for Rails' lazy read. Converging it needs the
-  // version-gated predicates to go async (RFC 0072
-  // `make-version-gated-predicates-async`).
-  const databaseVersion = (await this.pool.serverVersion(this)) as Version;
-  return this.isMariadb()
-    ? databaseVersion.compare("10.2.2") >= 0
-    : databaseVersion.compare("5.7.9") >= 0;
+  return (await this.isMariadb())
+    ? ((await this.databaseVersion) as Version).compare("10.2.2") >= 0
+    : ((await this.databaseVersion) as Version).compare("5.7.9") >= 0;
 }
 
 /** @internal */
@@ -652,7 +645,7 @@ interface IndexesHost {
   // false, `add_options_for_index_columns`'s `super` skips the DESC/ASC suffix
   // (abstract/schema_statements.rb#add_index_sort_order), so a functional
   // index's collapsed columns string must omit the order even when Collation="D".
-  supportsIndexSortOrder(): boolean;
+  supportsIndexSortOrder(): Promise<boolean>;
 }
 
 /** @internal
@@ -746,6 +739,7 @@ export async function indexes(this: IndexesHost, tableName: string): Promise<Ind
       if (desc) entry.orders[column] = "desc";
     }
   }
+  const supportsIndexSortOrder = await this.supportsIndexSortOrder();
   return Array.from(byIndex.entries()).map(
     ([name, { columns, unique, using, type, comment, lengths, orders, expressions }]) => {
       // Mirrors Rails' final `.map`: a functional (expression) index collapses
@@ -760,7 +754,7 @@ export async function indexes(this: IndexesHost, tableName: string): Promise<Ind
         addOptionsForIndexColumns(
           quotedColumns,
           { order: orders, length: lengths },
-          this.supportsIndexSortOrder(),
+          supportsIndexSortOrder,
         );
         return new IndexDefinition(
           tableName,

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -582,7 +582,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     returning?: string[] | null,
   ): Promise<Result | number> {
     const inferredFromPk = pk !== false && pk != null;
-    if (this.supportsInsertReturning() && (returning?.length || inferredFromPk)) {
+    if ((await this.supportsInsertReturning()) && (returning?.length || inferredFromPk)) {
       const [returningSql, returningBinds] = sqlForInsert.call(
         this as never,
         sql,
@@ -1735,8 +1735,8 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    *
    * @internal
    */
-  override fullVersion(): string | null {
-    return this.databaseVersion.fullVersionString;
+  override async fullVersion(): Promise<string | null> {
+    return (await this.databaseVersion).fullVersionString;
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1326,7 +1326,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     binds: unknown[] = [],
     options: ExplainOption[] = [],
   ): Promise<string> {
-    const clause = this._explainStatementClause(options);
+    const clause = await this._explainStatementClause(options);
     const start = Date.now();
     const result = await this.internalExecQuery(`${clause} ${sql}`, "EXPLAIN", binds);
     const elapsed = (Date.now() - start) / 1000;
@@ -1730,8 +1730,8 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   }
 
   /**
-   * Mirrors: Mysql2Adapter#full_version (mysql2_adapter.rb:164-166). Sync like
-   * Rails, because `database_version` is the memo `configureConnection` warms.
+   * Mirrors: Mysql2Adapter#full_version (mysql2_adapter.rb:164-166) — a bare
+   * `database_version.full_version_string`, which fetches on demand.
    *
    * @internal
    */

--- a/packages/activerecord/src/connection-adapters/pool-server-version.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/pool-server-version.trails.test.ts
@@ -25,7 +25,7 @@ describe("ConnectionPool#server_version", () => {
 
     expect(String(await adapter.pool.serverVersion(adapter))).toBe("8.0.35");
     expect(String(await adapter.pool.serverVersion(adapter))).toBe("8.0.35");
-    expect(adapter.databaseVersion.fullVersionString).toBe("8.0.35");
+    expect((await adapter.databaseVersion).fullVersionString).toBe("8.0.35");
   });
 
   it("get_database_version itself is a pure derivation, not a memo", async () => {
@@ -44,18 +44,16 @@ describe("ConnectionPool#server_version", () => {
     expect(String(await adapter.pool.serverVersion(adapter))).toBe("5.7.9");
   });
 
-  it("databaseVersion raises before the memo is warm, since the fetch is async", () => {
+  it("databaseVersion fetches on demand, so a never-connected adapter can read it", async () => {
     const adapter = adapterFetching(["8.0.35"]);
 
-    expect(() => adapter.databaseVersion).toThrow(/only available synchronously/);
+    expect(await adapter.databaseVersion).toBeInstanceOf(Version);
   });
 
   it("answers a Version, so MySQL's version gates read it", async () => {
     const adapter = adapterFetching(["8.0.35"]);
-    await adapter.pool.serverVersion(adapter);
 
-    expect(adapter.databaseVersion).toBeInstanceOf(Version);
-    expect(adapter.supportsExpressionIndex()).toBe(true);
+    expect(await adapter.supportsExpressionIndex()).toBe(true);
   });
 
   // The fetch opens the connection, and `connect()` runs `configureConnection`

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.check-version.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.check-version.test.ts
@@ -3,21 +3,25 @@ import { describe, expect, it } from "vitest";
 describe("PostgreSQLAdapter#checkVersion", () => {
   it("raises when the warmed version is too old", async () => {
     const { PostgreSQLAdapter } = await import("./postgresql-adapter.js");
+    const { NullPool } = await import("./abstract/connection-pool.js");
     const adapter = Object.create(PostgreSQLAdapter.prototype) as InstanceType<
       typeof PostgreSQLAdapter
     >;
-    (adapter as unknown as { _databaseVersion: number })._databaseVersion = 90_2_00;
-    expect(() => adapter.checkVersion()).toThrow(
+    adapter.pool = new NullPool();
+    (adapter as unknown as { getDatabaseVersion: () => number }).getDatabaseVersion = () => 90_2_00;
+    await expect(adapter.checkVersion()).rejects.toThrow(
       "Your version of PostgreSQL (90200) is too old. Active Record supports PostgreSQL >= 9.3.",
     );
   });
 
   it("does not raise when the warmed version is supported", async () => {
     const { PostgreSQLAdapter } = await import("./postgresql-adapter.js");
+    const { NullPool } = await import("./abstract/connection-pool.js");
     const adapter = Object.create(PostgreSQLAdapter.prototype) as InstanceType<
       typeof PostgreSQLAdapter
     >;
-    (adapter as unknown as { _databaseVersion: number })._databaseVersion = 9_03_00;
-    expect(() => adapter.checkVersion()).not.toThrow();
+    adapter.pool = new NullPool();
+    (adapter as unknown as { getDatabaseVersion: () => number }).getDatabaseVersion = () => 9_03_00;
+    await expect(adapter.checkVersion()).resolves.toBeUndefined();
   });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2412,7 +2412,7 @@ export class PostgreSQLAdapter
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#build_explain_clause
    */
-  override buildExplainClause(options: ExplainOption[] = []): string {
+  override async buildExplainClause(options: ExplainOption[] = []): Promise<string> {
     if (options.length === 0) return "EXPLAIN for:";
     const parts = this._validateExplainOptions(options);
     return `EXPLAIN (${parts.join(", ")}) for:`;
@@ -3275,48 +3275,35 @@ export class PostgreSQLAdapter
   }
 
   /**
-   * Synchronous version check. Populated lazily on first query via
-   * _ensureInitialized(). Throws if accessed before any query has run.
-   */
-  get databaseVersion(): number {
-    if (this._databaseVersion === null) {
-      throw new Error(
-        "databaseVersion is not available yet — call getDatabaseVersion() after connecting",
-      );
-    }
-    return this._databaseVersion;
-  }
-
-  /**
    * Mirrors Rails' `PostgreSQLAdapter#postgresql_version`, an alias for
    * `database_version` (postgresql_adapter.rb). Public so callers can read the
    * connected server's numeric version without going through the protected
    * `databaseVersion` getter directly.
    */
-  postgresqlVersion(): number {
-    return this.databaseVersion;
+  async postgresqlVersion(): Promise<number> {
+    return await this.databaseVersion;
   }
 
   supportsBulkAlter(): boolean {
     return true;
   }
-  supportsIndexSortOrder(): boolean {
+  async supportsIndexSortOrder(): Promise<boolean> {
     return true;
   }
   // Rails: `index.using == :btree || super` (postgresql_adapter.rb#default_index_type?).
   override defaultIndexType(using?: string): boolean {
     return using === "btree" || super.defaultIndexType(using);
   }
-  supportsPartitionedIndexes(): boolean {
-    return this.databaseVersion >= 110000;
+  async supportsPartitionedIndexes(): Promise<boolean> {
+    return (await this.databaseVersion) >= 110000;
   }
   supportsPartialIndex(): boolean {
     return true;
   }
-  supportsIndexInclude(): boolean {
-    return this.databaseVersion >= 110000;
+  async supportsIndexInclude(): Promise<boolean> {
+    return (await this.databaseVersion) >= 110000;
   }
-  supportsExpressionIndex(): boolean {
+  async supportsExpressionIndex(): Promise<boolean> {
     return true;
   }
   supportsTransactionIsolation(): boolean {
@@ -3325,7 +3312,7 @@ export class PostgreSQLAdapter
   supportsForeignKeys(): boolean {
     return true;
   }
-  supportsCheckConstraints(): boolean {
+  async supportsCheckConstraints(): Promise<boolean> {
     return true;
   }
   supportsExclusionConstraints(): boolean {
@@ -3346,7 +3333,7 @@ export class PostgreSQLAdapter
   supportsDatetimeWithPrecision(): boolean {
     return true;
   }
-  supportsJson(): boolean {
+  async supportsJson(): Promise<boolean> {
     return true;
   }
   supportsComments(): boolean {
@@ -3355,35 +3342,35 @@ export class PostgreSQLAdapter
   supportsSavepoints(): boolean {
     return true;
   }
-  supportsRestartDbTransaction(): boolean {
-    return this.databaseVersion >= 120000;
+  async supportsRestartDbTransaction(): Promise<boolean> {
+    return (await this.databaseVersion) >= 120000;
   }
-  supportsInsertReturning(): boolean {
+  async supportsInsertReturning(): Promise<boolean> {
     return true;
   }
-  supportsInsertOnConflict(): boolean {
-    return this.databaseVersion >= 90500;
+  async supportsInsertOnConflict(): Promise<boolean> {
+    return (await this.databaseVersion) >= 90500;
   }
-  supportsInsertOnDuplicateSkip(): boolean {
-    return this.supportsInsertOnConflict();
+  async supportsInsertOnDuplicateSkip(): Promise<boolean> {
+    return await this.supportsInsertOnConflict();
   }
-  supportsInsertOnDuplicateUpdate(): boolean {
-    return this.supportsInsertOnConflict();
+  async supportsInsertOnDuplicateUpdate(): Promise<boolean> {
+    return await this.supportsInsertOnConflict();
   }
-  supportsInsertConflictTarget(): boolean {
-    return this.supportsInsertOnConflict();
+  async supportsInsertConflictTarget(): Promise<boolean> {
+    return await this.supportsInsertOnConflict();
   }
-  supportsVirtualColumns(): boolean {
-    return this.databaseVersion >= 120000;
+  async supportsVirtualColumns(): Promise<boolean> {
+    return (await this.databaseVersion) >= 120000;
   }
-  supportsIdentityColumns(): boolean {
-    return this.databaseVersion >= 100000;
+  async supportsIdentityColumns(): Promise<boolean> {
+    return (await this.databaseVersion) >= 100000;
   }
-  supportsNullsNotDistinct(): boolean {
-    return this.databaseVersion >= 150000;
+  async supportsNullsNotDistinct(): Promise<boolean> {
+    return (await this.databaseVersion) >= 150000;
   }
-  supportsNativePartitioning(): boolean {
-    return this.databaseVersion >= 100000;
+  async supportsNativePartitioning(): Promise<boolean> {
+    return (await this.databaseVersion) >= 100000;
   }
 
   indexAlgorithms(): Record<string, string> {
@@ -3424,17 +3411,17 @@ export class PostgreSQLAdapter
   supportsForeignTables(): boolean {
     return true;
   }
-  supportsPgcryptoUuid(): boolean {
-    return this.databaseVersion >= 90400;
+  async supportsPgcryptoUuid(): Promise<boolean> {
+    return (await this.databaseVersion) >= 90400;
   }
 
   private _hasOptimizerHints: boolean | null = null;
 
-  supportsOptimizerHints(): boolean {
+  async supportsOptimizerHints(): Promise<boolean> {
     return this._hasOptimizerHints ?? false;
   }
 
-  supportsCommonTableExpressions(): boolean {
+  async supportsCommonTableExpressions(): Promise<boolean> {
     return true;
   }
 
@@ -4307,14 +4294,14 @@ export class PostgreSQLAdapter
    * to the base (sort order) via `super`.
    * @internal
    */
-  addOptionsForIndexColumns(
+  async addOptionsForIndexColumns(
     quotedColumns: Map<string, string>,
     options: {
       order?: string | Record<string, string>;
       opclass?: string | Record<string, string>;
       length?: number | Record<string, number>;
     } = {},
-  ): Map<string, string> {
+  ): Promise<Map<string, string>> {
     quotedColumns = this.addIndexOpclass(quotedColumns, options);
     return super.addOptionsForIndexColumns(quotedColumns, options);
   }
@@ -4580,6 +4567,11 @@ export class PostgreSQLAdapter
 // is declared here — the same shape AbstractAdapter uses for `SchemaStatements`.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface PostgreSQLAdapter {
+  /** Rails' PG `database_version` (`postgresql_adapter.rb`) is the server
+   * version *integer*; the inherited getter's `Version | number` is narrowed
+   * here by declaration merging rather than by an override Rails does not have. */
+  get databaseVersion(): number | Promise<number>;
+
   /** @internal */
   validateIndexLengthBang(tableName: string, newName: string, internal?: boolean): void;
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -797,7 +797,7 @@ export class PostgreSQLAdapter
     // Rails calls it from. Skipped when the probe came back zero: that path is
     // owned by getDatabaseVersion()'s ConnectionFailed handling, not by the
     // version floor.
-    if (this._databaseVersion !== null) this.checkVersion();
+    if (this._databaseVersion !== null) await this.checkVersion();
     // Rails resets @mapped_default_timezone = nil while installing decoders in
     // configure_connection (postgresql_adapter.rb:1112) so the next
     // update_typemap_for_default_timezone re-applies the session timezone. This
@@ -3201,15 +3201,12 @@ export class PostgreSQLAdapter
   }
 
   // Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#check_version
-  // (postgresql_adapter.rb:669-673). Rails' `database_version` issues the
-  // round-trip itself when unmemoized; trails' sync getter cannot, so
-  // `_maybeConfigureConnection` fills the memo at the position Rails' `super`
-  // occupies, one line before this runs.
-  override checkVersion(): void {
-    if (this.databaseVersion < 9_03_00) {
+  // (postgresql_adapter.rb:669-673).
+  override async checkVersion(): Promise<void> {
+    if ((await this.databaseVersion) < 9_03_00) {
       // < 9.3
       throw new Error(
-        `Your version of PostgreSQL (${this.databaseVersion}) is too old. Active Record supports PostgreSQL >= 9.3.`,
+        `Your version of PostgreSQL (${await this.databaseVersion}) is too old. Active Record supports PostgreSQL >= 9.3.`,
       );
     }
   }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2398,7 +2398,7 @@ export class PostgreSQLAdapter
     binds: unknown[] = [],
     options: ExplainOption[] = [],
   ): Promise<string> {
-    const clause = this._explainStatementClause(options);
+    const clause = await this._explainStatementClause(options);
     const result = await this.internalExecQuery(`${clause} ${sql}`, "EXPLAIN", binds);
     const printer = new ExplainPrettyPrinter();
     return printer.pp(result.toArray());
@@ -2483,7 +2483,7 @@ export class PostgreSQLAdapter
    * printed header. Options are validated against the adapter's
    * allowlist before interpolation.
    */
-  private _explainStatementClause(options: ExplainOption[]): string {
+  private async _explainStatementClause(options: ExplainOption[]): Promise<string> {
     if (options.length === 0) return "EXPLAIN";
     const validated = this._validateExplainOptions(options);
     return `EXPLAIN (${validated.join(", ")})`;
@@ -4703,7 +4703,7 @@ export interface PostgreSQLAdapter {
 
   foreignKeys(tableName: string): Promise<ForeignKeyDefinition[]>;
 
-  quotedIncludeColumnsForIndex(columnNames: string | string[]): string;
+  quotedIncludeColumnsForIndex(columnNames: string | string[]): Promise<string>;
 
   /** @internal */
   columnNamesFromColumnNumbers(tableOid: number, columnNumbers: number[]): Promise<string[]>;

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-creation.test.ts
@@ -77,30 +77,32 @@ describe("PostgreSQL SchemaCreation", () => {
     expect(sql).toContain("DEFERRABLE INITIALLY DEFERRED");
   });
 
-  it("visitUniqueConstraintDefinition: basic + NULLS NOT DISTINCT + USING INDEX", () => {
+  it("visitUniqueConstraintDefinition: basic + NULLS NOT DISTINCT + USING INDEX", async () => {
     expect(
-      s().visitUniqueConstraintDefinition(new UniqueConstraintDefinition("t", "e", { name: "u" })),
+      await s().visitUniqueConstraintDefinition(
+        new UniqueConstraintDefinition("t", "e", { name: "u" }),
+      ),
     ).toContain('CONSTRAINT "u" UNIQUE');
     expect(
-      s().visitUniqueConstraintDefinition(
+      await s().visitUniqueConstraintDefinition(
         new UniqueConstraintDefinition("t", "e", { name: "u", nullsNotDistinct: true }),
       ),
     ).toContain("NULLS NOT DISTINCT");
     expect(
-      s().visitUniqueConstraintDefinition(
+      await s().visitUniqueConstraintDefinition(
         new UniqueConstraintDefinition("t", "e", { name: "u", usingIndex: "idx" }),
       ),
     ).toContain('USING INDEX "idx"');
   });
 
-  it("visitAddExclusionConstraint / visitAddUniqueConstraint", () => {
+  it("visitAddExclusionConstraint / visitAddUniqueConstraint", async () => {
     expect(
       s().visitAddExclusionConstraint(
         new ExclusionConstraintDefinition("t", "e WITH &&", { name: "c" }),
       ),
     ).toMatch(/^ADD CONSTRAINT/);
     expect(
-      s().visitAddUniqueConstraint(new UniqueConstraintDefinition("t", "col", { name: "c" })),
+      await s().visitAddUniqueConstraint(new UniqueConstraintDefinition("t", "col", { name: "c" })),
     ).toMatch(/^ADD CONSTRAINT/);
   });
 
@@ -170,9 +172,9 @@ describe("PostgreSQL SchemaCreation", () => {
     expect(sql).not.toContain("CONSTRAINT");
   });
 
-  it("visitUniqueConstraintDefinition: unnamed constraint omits CONSTRAINT prefix", () => {
+  it("visitUniqueConstraintDefinition: unnamed constraint omits CONSTRAINT prefix", async () => {
     const uc = new UniqueConstraintDefinition("t", "col", {});
-    const sql = s().visitUniqueConstraintDefinition(uc);
+    const sql = await s().visitUniqueConstraintDefinition(uc);
     expect(sql).toMatch(/^UNIQUE/);
     expect(sql).not.toContain("CONSTRAINT");
   });

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-creation.test.ts
@@ -199,17 +199,17 @@ describe("PostgreSQL SchemaCreation", () => {
     expect(sql).toContain(", VALIDATE CONSTRAINT");
   });
 
-  it("quotedIncludeColumns + tableModifierInCreate", () => {
-    expect(s().quotedIncludeColumnsForIndex("a, b")).toBe("a, b");
-    expect(s().quotedIncludeColumnsForIndex(["a", "b"])).toBe('"a", "b"');
-    expect(s().quotedIncludeColumns("raw, expr")).toBe("raw, expr");
-    expect(s().quotedIncludeColumns(["a", "b"])).toBe('"a", "b"');
+  it("quotedIncludeColumns + tableModifierInCreate", async () => {
+    expect(await s().quotedIncludeColumnsForIndex("a, b")).toBe("a, b");
+    expect(await s().quotedIncludeColumnsForIndex(["a", "b"])).toBe('"a", "b"');
+    expect(await s().quotedIncludeColumns("raw, expr")).toBe("raw, expr");
+    expect(await s().quotedIncludeColumns(["a", "b"])).toBe('"a", "b"');
     expect(s().tableModifierInCreate({ temporary: true })).toBe(" TEMPORARY");
     expect(s().tableModifierInCreate({ unlogged: true })).toBe(" UNLOGGED");
     expect(s().tableModifierInCreate({})).toBe("");
   });
 
-  it("quotedIncludeColumnsForIndex delegates to the adapter when threaded", () => {
+  it("quotedIncludeColumnsForIndex delegates to the adapter when threaded", async () => {
     const sc = new SchemaCreation({
       quoteColumnName: (n: string) => `"${n}"`,
       quoteTableName: (n: string) => `"${n}"`,
@@ -217,7 +217,7 @@ describe("PostgreSQL SchemaCreation", () => {
       typeToSql: (type: string) => type,
       quotedIncludeColumnsForIndex: () => "<<delegated>>",
     } as any) as any;
-    expect(sc.quotedIncludeColumnsForIndex(["a", "b"])).toBe("<<delegated>>");
+    expect(await sc.quotedIncludeColumnsForIndex(["a", "b"])).toBe("<<delegated>>");
   });
 
   // Rails' PostgreSQLAdapter#native_database_types replaces the constant's raw

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-creation.ts
@@ -345,9 +345,9 @@ export class SchemaCreation extends AbstractSchemaCreation {
    * shim is wired).
    * @internal
    */
-  protected quotedIncludeColumnsForIndex(o: string | string[]): string {
+  protected async quotedIncludeColumnsForIndex(o: string | string[]): Promise<string> {
     const host = this.adapter as PgSchemaCreationHost & {
-      quotedIncludeColumnsForIndex?(columns: string | string[]): string;
+      quotedIncludeColumnsForIndex?(columns: string | string[]): Promise<string>;
     };
     if (typeof host.quotedIncludeColumnsForIndex === "function") {
       return host.quotedIncludeColumnsForIndex(o);
@@ -362,7 +362,7 @@ export class SchemaCreation extends AbstractSchemaCreation {
    * (postgresql/schema_creation.rb:143-144).
    * @internal
    */
-  protected override quotedIncludeColumns(o: string | string[]): string {
+  protected override async quotedIncludeColumns(o: string | string[]): Promise<string> {
     return typeof o === "string" ? o : this.quotedIncludeColumnsForIndex(o);
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-creation.ts
@@ -133,9 +133,13 @@ export class SchemaCreation extends AbstractSchemaCreation {
     }
     if (Array.isArray(o.uniqueConstraintAdds) && o.uniqueConstraintAdds.length > 0) {
       pgParts.push(
-        (o.uniqueConstraintAdds as UniqueConstraintDefinition[])
-          .map((con) => this.visitAddUniqueConstraint(con))
-          .join(", "),
+        (
+          await Promise.all(
+            (o.uniqueConstraintAdds as UniqueConstraintDefinition[]).map((con) =>
+              this.visitAddUniqueConstraint(con),
+            ),
+          )
+        ).join(", "),
       );
     }
     if (pgParts.length > 0) {
@@ -184,11 +188,11 @@ export class SchemaCreation extends AbstractSchemaCreation {
   }
 
   /** @internal */
-  protected visitUniqueConstraintDefinition(o: UniqueConstraintDefinition): string {
+  protected async visitUniqueConstraintDefinition(o: UniqueConstraintDefinition): Promise<string> {
     const p: string[] = [];
     if (o.name) p.push("CONSTRAINT", this.adapter.quoteColumnName(o.name));
     p.push("UNIQUE");
-    if (this.supportsNullsNotDistinct() && o.nullsNotDistinct) p.push("NULLS NOT DISTINCT");
+    if ((await this.supportsNullsNotDistinct()) && o.nullsNotDistinct) p.push("NULLS NOT DISTINCT");
     if (o.usingIndex) {
       p.push(`USING INDEX ${this.adapter.quoteColumnName(o.usingIndex)}`);
     } else {
@@ -216,8 +220,8 @@ export class SchemaCreation extends AbstractSchemaCreation {
   }
 
   /** @internal */
-  protected visitAddUniqueConstraint(o: UniqueConstraintDefinition): string {
-    return `ADD ${this.visitUniqueConstraintDefinition(o)}`;
+  protected async visitAddUniqueConstraint(o: UniqueConstraintDefinition): Promise<string> {
+    return `ADD ${await this.visitUniqueConstraintDefinition(o)}`;
   }
 
   /**
@@ -318,7 +322,9 @@ export class SchemaCreation extends AbstractSchemaCreation {
   }
 
   /** @internal */
-  protected override tableConstraintStatements(o: AbstractTableDefinition): string[] {
+  protected override async tableConstraintStatements(
+    o: AbstractTableDefinition,
+  ): Promise<string[]> {
     if ((o as { as?: unknown }).as) return [];
     const pg = o as PgTableDef;
     const result: string[] = [];
@@ -326,7 +332,7 @@ export class SchemaCreation extends AbstractSchemaCreation {
       result.push(this.visitExclusionConstraintDefinition(exc));
     }
     for (const uc of pg.uniqueConstraints ?? []) {
-      result.push(this.visitUniqueConstraintDefinition(uc));
+      result.push(await this.visitUniqueConstraintDefinition(uc));
     }
     return result;
   }

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -250,10 +250,10 @@ export class SchemaStatements extends AbstractSchemaStatements {
     return Number(count) > 0;
   }
 
-  quotedIncludeColumnsForIndex(columnNames: string | string[]): string {
+  async quotedIncludeColumnsForIndex(columnNames: string | string[]): Promise<string> {
     if (typeof columnNames === "string") return this.quoteColumnName(columnNames);
     const quotedColumns = new Map(columnNames.map((name) => [name, this.quoteColumnName(name)]));
-    return Array.from(this.addOptionsForIndexColumns(quotedColumns).values()).join(", ");
+    return Array.from((await this.addOptionsForIndexColumns(quotedColumns)).values()).join(", ");
   }
 
   // ---------------------------------------------------------------------------
@@ -395,7 +395,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
     if (inherited.length > 0) {
       options.options = `INHERITS (${inherited.join(", ")})`;
     }
-    if (!options.options && this.supportsNativePartitioning()) {
+    if (!options.options && (await this.supportsNativePartitioning())) {
       const partDef = await this.tablePartitionDefinition(tableName);
       if (partDef) options.options = `PARTITION BY ${partDef}`;
     }
@@ -416,10 +416,10 @@ export class SchemaStatements extends AbstractSchemaStatements {
       attgenerated: string | null;
     }[]
   > {
-    const identityCol = this.supportsIdentityColumns()
+    const identityCol = (await this.supportsIdentityColumns())
       ? "attidentity"
       : `${this.quote("")}::varchar`;
-    const generatedCol = this.supportsVirtualColumns()
+    const generatedCol = (await this.supportsVirtualColumns())
       ? "attgenerated"
       : `${this.quote("")}::varchar`;
     const rows = await this.schemaQuery(

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.database-version.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.database-version.trails.test.ts
@@ -25,6 +25,6 @@ describe("SQLite3Adapter database version", () => {
   it("databaseVersion answers through the pool memo", async () => {
     adapter = new BetterSQLite3Adapter({ database: ":memory:" });
     const version = await adapter.getDatabaseVersion();
-    expect(adapter.databaseVersion.toString()).toBe(version.toString());
+    expect(String(await adapter.databaseVersion)).toBe(version.toString());
   });
 });

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1472,15 +1472,14 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   /**
    * Mirrors: SQLite3Adapter#get_database_version (`sqlite3_adapter.rb:476-478`)
    * — a pure fetch, run at most once through the pool memo
-   * (`pool_config.rb:39-41`) that `configureConnection` fills at connect time.
+   * (`pool_config.rb:39-41`), which `database_version` fills on demand.
    *
    * Deviation, language-forced: Rails reads the value through
-   * `query_value(..., "SCHEMA")`, whose trails counterpart is `async`, and the
-   * version-gated `supports*()` readers are sync. The query is issued on the
-   * driver so an in-process driver can answer synchronously; an async-only
-   * driver (no `openSync()`) answers a Promise, which the pool memo resolves.
-   * Nothing is open on the deferred async-checkout path, where Rails has no
-   * connection to ask at all.
+   * `query_value(..., "SCHEMA")`, whose trails counterpart is `async`. The
+   * query is issued on the driver so an in-process driver can answer
+   * synchronously; an async-only driver (no `openSync()`) answers a Promise,
+   * which the pool memo resolves. Nothing is open on the deferred
+   * async-checkout path, where Rails has no connection to ask at all.
    */
   override getDatabaseVersion(): Version | Promise<Version> {
     const driver = this.driver as SqliteConnection | undefined;
@@ -2919,8 +2918,8 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
         "The retries option is deprecated and will be removed in Rails 8.1. Use timeout instead.\n",
       );
     }
-    // Base only runs the sync version check; SQLite's PRAGMAs are the async
-    // work, awaited by the driver-async branch below. Void the base call.
+    // Base only runs the version check; SQLite's PRAGMAs are the async work,
+    // awaited by the driver-async branch below. Void the base call.
     void super.configureConnection();
     const stmts = this.configurePragmas();
     const warn = (label: string, e: unknown) =>

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2918,14 +2918,21 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
         "The retries option is deprecated and will be removed in Rails 8.1. Use timeout instead.\n",
       );
     }
-    // Base only runs the version check; SQLite's PRAGMAs are the async work,
-    // awaited by the driver-async branch below. Void the base call.
-    void super.configureConnection();
+    // Rails runs `super` — i.e. `check_version` — before the pragmas
+    // (`sqlite3_adapter.rb:835-838`) and lets it raise. `checkVersion` is async
+    // here, so its result has to be threaded into what this returns rather than
+    // voided, or a too-old-SQLite error becomes an unhandled rejection instead
+    // of one `attemptConfigureConnection` can see. On the sync-driver path the
+    // pragmas still run synchronously — callers get a configured adapter as
+    // soon as the constructor returns — so only the check's *settlement*, not
+    // its start, trails them.
+    const checked = super.configureConnection();
     const stmts = this.configurePragmas();
     const warn = (label: string, e: unknown) =>
       console.warn(`${label} failed: ${e instanceof Error ? e.message : String(e)}`);
     if (this.driverIsAsync()) {
       return (async () => {
+        await checked;
         for (const [sql, label] of stmts) {
           try {
             await this.driver.pragma(sql);
@@ -2942,6 +2949,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
         warn(label, e);
       }
     }
+    return checked;
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1257,15 +1257,15 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     return true;
   }
 
-  supportsExpressionIndex(): boolean {
-    return this.databaseVersion.compare("3.9.0") >= 0;
+  async supportsExpressionIndex(): Promise<boolean> {
+    return (await this.databaseVersion).compare("3.9.0") >= 0;
   }
 
   override supportsForeignKeys(): boolean {
     return true;
   }
 
-  override supportsCheckConstraints(): boolean {
+  override async supportsCheckConstraints(): Promise<boolean> {
     return true;
   }
 
@@ -1277,16 +1277,16 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     return true;
   }
 
-  override supportsJson(): boolean {
+  override async supportsJson(): Promise<boolean> {
     return true;
   }
 
-  override supportsCommonTableExpressions(): boolean {
-    return this.databaseVersion.compare("3.8.3") >= 0;
+  override async supportsCommonTableExpressions(): Promise<boolean> {
+    return (await this.databaseVersion).compare("3.8.3") >= 0;
   }
 
-  supportsInsertReturning(): boolean {
-    return this.databaseVersion.compare("3.35.0") >= 0;
+  async supportsInsertReturning(): Promise<boolean> {
+    return (await this.databaseVersion).compare("3.35.0") >= 0;
   }
 
   /** Mirrors: SQLite3::DatabaseStatements#returning_column_values — the full
@@ -1321,31 +1321,31 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     return this.executeMutation(this.buildTruncateStatement(tableName), [], name ?? "SQL");
   }
 
-  supportsInsertOnConflict(): boolean {
-    return this.databaseVersion.compare("3.24.0") >= 0;
+  async supportsInsertOnConflict(): Promise<boolean> {
+    return (await this.databaseVersion).compare("3.24.0") >= 0;
   }
 
-  override supportsInsertOnDuplicateSkip(): boolean {
-    return this.supportsInsertOnConflict();
+  override async supportsInsertOnDuplicateSkip(): Promise<boolean> {
+    return await this.supportsInsertOnConflict();
   }
 
-  override supportsInsertOnDuplicateUpdate(): boolean {
-    return this.supportsInsertOnConflict();
+  override async supportsInsertOnDuplicateUpdate(): Promise<boolean> {
+    return await this.supportsInsertOnConflict();
   }
 
-  override supportsInsertConflictTarget(): boolean {
-    return this.supportsInsertOnConflict();
+  override async supportsInsertConflictTarget(): Promise<boolean> {
+    return await this.supportsInsertOnConflict();
   }
 
   override supportsConcurrentConnections(): boolean {
     return !this._memoryDatabase;
   }
 
-  override supportsVirtualColumns(): boolean {
-    return this.databaseVersion.compare("3.31.0") >= 0;
+  override async supportsVirtualColumns(): Promise<boolean> {
+    return (await this.databaseVersion).compare("3.31.0") >= 0;
   }
 
-  override supportsIndexSortOrder(): boolean {
+  override async supportsIndexSortOrder(): Promise<boolean> {
     return true;
   }
 
@@ -1496,10 +1496,10 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     return toVersion(row);
   }
 
-  override checkVersion(): void {
-    if (this.databaseVersion.compare("3.8.0") < 0) {
+  override async checkVersion(): Promise<void> {
+    if ((await this.databaseVersion).compare("3.8.0") < 0) {
       throw new Error(
-        `Your version of SQLite (${this.databaseVersion}) is too old. Active Record supports SQLite >= 3.8.`,
+        `Your version of SQLite (${await this.databaseVersion}) is too old. Active Record supports SQLite >= 3.8.`,
       );
     }
   }
@@ -2363,7 +2363,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     // as a bare table name and returns zero rows.
     const { schema, bare } = this._splitTableName(tableName);
     const pragmaPrefix = schema ? `${quoteColumnName(schema)}.` : "";
-    const pragma = this.supportsVirtualColumns() ? "table_xinfo" : "table_info";
+    const pragma = (await this.supportsVirtualColumns()) ? "table_xinfo" : "table_info";
     return this.schemaQuery(`PRAGMA ${pragmaPrefix}${pragma}(${quoteColumnName(bare)})`);
   }
 
@@ -3138,7 +3138,7 @@ dirtiesQueryCache(SQLite3Adapter, "execQuery", "execute");
  * @internal
  */
 export interface SQLite3Adapter {
-  get databaseVersion(): Version;
+  get databaseVersion(): Version | Promise<Version>;
 }
 /* eslint-enable @typescript-eslint/no-unsafe-declaration-merging */
 

--- a/packages/activerecord/src/explain.test.ts
+++ b/packages/activerecord/src/explain.test.ts
@@ -125,7 +125,7 @@ describe("ExplainTest", () => {
     let called = 0;
     adapter.explain = async () => `query plan ${sqls[called++]}`;
     try {
-      const clause = buildExplainClause(adapter);
+      const clause = await buildExplainClause(adapter);
       const expected = sqls.map((sql) => `${clause} ${sql}\nquery plan ${sql}`).join("\n\n");
       expect(await Base.execExplain(queries)).toBe(expected);
     } finally {
@@ -149,7 +149,7 @@ describe("ExplainTest", () => {
     let called = 0;
     adapter.explain = async () => `query plan ${sqls[called++]}`;
     try {
-      const clause = buildExplainClause(adapter);
+      const clause = await buildExplainClause(adapter);
       const expected = [
         `${clause} ${sqls[0]} [1]\nquery plan ${sqls[0]}`,
         `${clause} ${sqls[1]} [2]\nquery plan ${sqls[1]}`,

--- a/packages/activerecord/src/explain.ts
+++ b/packages/activerecord/src/explain.ts
@@ -86,7 +86,10 @@ export function renderBind(connection: any, attr: unknown): [string | null, unkn
  *
  * @internal
  */
-export function buildExplainClause(connection: any, options: ExplainOption[] = []): string {
+export async function buildExplainClause(
+  connection: any,
+  options: ExplainOption[] = [],
+): Promise<string> {
   if (connection && typeof connection.buildExplainClause === "function") {
     return connection.buildExplainClause(options);
   }

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -445,11 +445,11 @@ export class InsertAll {
     // wrapper adapter that forgets to delegate doesn't silently fall through
     // and emit a bogus conflict target.
     const conn = this.connection as {
-      supportsInsertConflictTarget?: () => boolean;
+      supportsInsertConflictTarget?: () => Promise<boolean>;
     };
     const supports =
       typeof conn.supportsInsertConflictTarget === "function"
-        ? conn.supportsInsertConflictTarget()
+        ? await conn.supportsInsertConflictTarget()
         : false;
     if (!supports) {
       // Rails returns nil for a nil unique_by even when conflict targets are

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -65,7 +65,7 @@ export class InsertAll {
    * Builder.conflictTarget can read `index.columns` / `index.where`.
    */
   uniqueBy: string | string[] | IndexDefinition | undefined;
-  returning: string | string[] | Nodes.SqlLiteral | false = false;
+  returning: string | string[] | Nodes.SqlLiteral | false | undefined;
 
   onDuplicate: "skip" | "update" | Nodes.SqlLiteral | undefined;
   updateOnly: string | string[] | undefined;
@@ -83,7 +83,6 @@ export class InsertAll {
   // `@returning = primary_keys if @returning == true`), so it can be
   // re-resolved to the schema-cache value once that's available.
   private _returningDefaulted = false;
-  private _returningFromSupport = false;
 
   static async execute(
     relation: Relation<any>,
@@ -121,8 +120,6 @@ export class InsertAll {
         (Array.isArray(options.returning) && options.returning.length === 0)
           ? false
           : options.returning;
-    } else {
-      this._returningFromSupport = true;
     }
 
     if (this.inserts.length === 0) {
@@ -190,19 +187,20 @@ export class InsertAll {
     // conflict target see the schema-cache value rather than the model's
     // configured primary key. findUniqueIndexFor still reads model.primaryKey
     // directly for its `unique_by || model.primary_key` match.
-    if (this._returningFromSupport) {
-      this._returningFromSupport = false;
-      const supportsReturning =
-        typeof (this.connection as any).supportsInsertReturning === "function"
-          ? await (this.connection as any).supportsInsertReturning()
-          : false;
-      this.returning = supportsReturning ? this.primaryKeys() : false;
-      this._returningDefaulted = supportsReturning;
-    }
-    await this.ensureValidOptionsForConnectionBang();
-
     if (this._schemaCachePrimaryKeys === undefined) {
       this._schemaCachePrimaryKeys = await this.dbPrimaryKeys();
+      // Rails runs this in the constructor (`insert_all.rb:38`), keyed off
+      // `@returning.nil?`; `supports_insert_returning?` is async here, so it
+      // rides the same deferral `@unique_by` already takes and `returning`
+      // stays undefined — Ruby's nil — until now.
+      if (this.returning === undefined) {
+        const supportsReturning =
+          typeof (this.connection as any).supportsInsertReturning === "function"
+            ? await (this.connection as any).supportsInsertReturning()
+            : false;
+        this.returning = supportsReturning ? this.primaryKeys() : false;
+        this._returningDefaulted = supportsReturning;
+      }
       if (this._returningDefaulted) {
         // Rails: `@returning = primary_keys` then `@returning = false if
         // @returning == []` (insert_all.rb:39-40). For an id-less table the
@@ -215,6 +213,7 @@ export class InsertAll {
     if (!this._uniqueByResolved) {
       this.uniqueBy = await this.findUniqueIndexFor(this.uniqueBy);
       this._uniqueByResolved = true;
+      await this.ensureValidOptionsForConnectionBang();
     }
     if (this._updatableColumns) return;
     const exclude = new Set([...this.readonlyColumns(), ...this.uniqueByColumns()]);

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -65,7 +65,7 @@ export class InsertAll {
    * Builder.conflictTarget can read `index.columns` / `index.where`.
    */
   uniqueBy: string | string[] | IndexDefinition | undefined;
-  returning: string | string[] | Nodes.SqlLiteral | false;
+  returning: string | string[] | Nodes.SqlLiteral | false = false;
 
   onDuplicate: "skip" | "update" | Nodes.SqlLiteral | undefined;
   updateOnly: string | string[] | undefined;
@@ -83,6 +83,7 @@ export class InsertAll {
   // `@returning = primary_keys if @returning == true`), so it can be
   // re-resolved to the schema-cache value once that's available.
   private _returningDefaulted = false;
+  private _returningFromSupport = false;
 
   static async execute(
     relation: Relation<any>,
@@ -121,12 +122,7 @@ export class InsertAll {
           ? false
           : options.returning;
     } else {
-      const supportsReturning =
-        typeof (this.connection as any).supportsInsertReturning === "function"
-          ? (this.connection as any).supportsInsertReturning()
-          : false;
-      this.returning = supportsReturning ? this.primaryKeys() : false;
-      this._returningDefaulted = supportsReturning;
+      this._returningFromSupport = true;
     }
 
     if (this.inserts.length === 0) {
@@ -148,7 +144,6 @@ export class InsertAll {
 
     this.verifyAttributeNamesAreKnown();
     this.configureOnDuplicateUpdateLogic();
-    this.ensureValidOptionsForConnectionBang();
   }
 
   async execute(): Promise<Result> {
@@ -195,6 +190,17 @@ export class InsertAll {
     // conflict target see the schema-cache value rather than the model's
     // configured primary key. findUniqueIndexFor still reads model.primaryKey
     // directly for its `unique_by || model.primary_key` match.
+    if (this._returningFromSupport) {
+      this._returningFromSupport = false;
+      const supportsReturning =
+        typeof (this.connection as any).supportsInsertReturning === "function"
+          ? await (this.connection as any).supportsInsertReturning()
+          : false;
+      this.returning = supportsReturning ? this.primaryKeys() : false;
+      this._returningDefaulted = supportsReturning;
+    }
+    await this.ensureValidOptionsForConnectionBang();
+
     if (this._schemaCachePrimaryKeys === undefined) {
       this._schemaCachePrimaryKeys = await this.dbPrimaryKeys();
       if (this._returningDefaulted) {
@@ -365,11 +371,11 @@ export class InsertAll {
   }
 
   /** @internal */
-  private ensureValidOptionsForConnectionBang(): void {
+  private async ensureValidOptionsForConnectionBang(): Promise<void> {
     if (
       this.returning &&
       typeof (this.connection as any).supportsInsertReturning === "function" &&
-      !(this.connection as any).supportsInsertReturning()
+      !(await (this.connection as any).supportsInsertReturning())
     ) {
       throw new Error(
         `${(this.connection as any).constructor?.name ?? "Adapter"} does not support INSERT...RETURNING`,

--- a/packages/activerecord/src/migration/foreign-key.test.ts
+++ b/packages/activerecord/src/migration/foreign-key.test.ts
@@ -709,12 +709,12 @@ describeIfSupports("foreign_keys", "Migration", () => {
 
         if (adapterType === "mysql") {
           const mysqlConn = conn as unknown as {
-            isMariadb?: () => boolean;
+            isMariadb?: () => Promise<boolean>;
             databaseVersion: unknown;
           };
-          if (mysqlConn.isMariadb?.() === true) {
+          if ((await mysqlConn.isMariadb?.()) === true) {
             expect(message).toMatch(/Duplicate key on write or update/);
-          } else if (String(mysqlConn.databaseVersion) < "8.0") {
+          } else if (String(await mysqlConn.databaseVersion) < "8.0") {
             expect(message).toMatch(/Can't write; duplicate key in table/);
           } else {
             expect(message).toMatch(/Duplicate foreign key constraint name/);

--- a/packages/activerecord/src/migration/unique-constraint.test.ts
+++ b/packages/activerecord/src/migration/unique-constraint.test.ts
@@ -68,7 +68,7 @@ describeIfSupports("unique_constraints", "Migration", () => {
 
       await connection.getDatabaseVersion();
       // eslint-disable-next-line vitest/no-conditional-in-test -- mirrors Rails' inline `if supports_nulls_not_distinct?` guard (PG 15+)
-      if (connection.supportsNullsNotDistinct()) {
+      if (await connection.supportsNullsNotDistinct()) {
         const constraint = uniqueConstraints.find((c) => c.name === expectedNullsNotDistinct.name)!;
         expect(constraint.tableName).toBe("test_unique_constraints");
         expect(constraint.name).toBe(expectedNullsNotDistinct.name);

--- a/packages/activerecord/src/model-schema-returning-columns.trails.test.ts
+++ b/packages/activerecord/src/model-schema-returning-columns.trails.test.ts
@@ -17,12 +17,12 @@ describe("_returningColumnsForInsert memoization", () => {
   // Base class type; narrow to just the surface these tests drive.
   const schemaHost = Topic as unknown as {
     _returningColumnsForInsert(connection: {
-      returnValueAfterInsert(column: { name: string }): boolean;
-    }): string[];
+      returnValueAfterInsert(column: { name: string }): Promise<boolean>;
+    }): Promise<string[]>;
     resetColumnInformation(): void;
   };
 
-  it("does not let a subclass reuse the base's memo", () => {
+  it("does not let a subclass reuse the base's memo", async () => {
     // Ruby class instance variables are NOT inherited, so Rails' `||=` on
     // @_returning_columns_for_insert is genuinely per-class (model_schema.rb
     // :436-443). A plain JS static read walks the prototype chain, so without
@@ -43,11 +43,11 @@ describe("_returningColumnsForInsert memoization", () => {
     )._returningColumnsForInsertCache = sentinel;
 
     const connection = {
-      returnValueAfterInsert: (column: { name: string }) => column.name === "id",
+      returnValueAfterInsert: async (column: { name: string }) => column.name === "id",
     };
     const child = Child as unknown as typeof schemaHost;
 
-    expect(child._returningColumnsForInsert(connection)).not.toEqual(sentinel);
+    expect(await child._returningColumnsForInsert(connection)).not.toEqual(sentinel);
     expect(
       (Parent as unknown as { _returningColumnsForInsertCache?: string[] })
         ._returningColumnsForInsertCache,
@@ -58,17 +58,17 @@ describe("_returningColumnsForInsert memoization", () => {
     await Topic.loadSchema();
     let calls = 0;
     const connection = {
-      returnValueAfterInsert(column: { name: string }) {
+      async returnValueAfterInsert(column: { name: string }) {
         calls += 1;
         return column.name === "id";
       },
     };
 
-    expect(schemaHost._returningColumnsForInsert(connection)).toEqual(["id"]);
+    expect(await schemaHost._returningColumnsForInsert(connection)).toEqual(["id"]);
     const first = calls;
     expect(first).toBeGreaterThan(0);
 
-    expect(schemaHost._returningColumnsForInsert(connection)).toEqual(["id"]);
+    expect(await schemaHost._returningColumnsForInsert(connection)).toEqual(["id"]);
     expect(calls).toBe(first);
   });
 
@@ -76,19 +76,19 @@ describe("_returningColumnsForInsert memoization", () => {
     await Topic.loadSchema();
     let calls = 0;
     const connection = {
-      returnValueAfterInsert(column: { name: string }) {
+      async returnValueAfterInsert(column: { name: string }) {
         calls += 1;
         return column.name === "id";
       },
     };
 
-    schemaHost._returningColumnsForInsert(connection);
+    await schemaHost._returningColumnsForInsert(connection);
     const first = calls;
 
     schemaHost.resetColumnInformation();
     await Topic.loadSchema();
 
-    expect(schemaHost._returningColumnsForInsert(connection)).toEqual(["id"]);
+    expect(await schemaHost._returningColumnsForInsert(connection)).toEqual(["id"]);
     expect(calls).toBeGreaterThan(first);
   });
 
@@ -105,20 +105,20 @@ describe("_returningColumnsForInsert memoization", () => {
 
     let calls = 0;
     const connection = {
-      returnValueAfterInsert(column: { name: string }) {
+      async returnValueAfterInsert(column: { name: string }) {
         calls += 1;
         return column.name === "id";
       },
     };
 
-    sub._returningColumnsForInsert(connection);
+    await sub._returningColumnsForInsert(connection);
     const afterSubMemo = calls;
     // The descendant really did compute (and now owns) a memo of its own.
     expect(afterSubMemo).toBeGreaterThan(0);
     expect(Object.prototype.hasOwnProperty.call(Reply, "_returningColumnsForInsertCache")).toBe(
       true,
     );
-    sub._returningColumnsForInsert(connection);
+    await sub._returningColumnsForInsert(connection);
     expect(calls).toBe(afterSubMemo);
 
     // Resetting the BASE leaves the descendant's own `_columns` in place — a
@@ -133,8 +133,8 @@ describe("_returningColumnsForInsert memoization", () => {
     schemaHost.resetColumnInformation();
     await Reply.loadSchema();
 
-    const memoized = sub._returningColumnsForInsert(connection);
+    const memoized = await sub._returningColumnsForInsert(connection);
     Reflect.deleteProperty(Reply, "_returningColumnsForInsertCache");
-    expect(memoized).toEqual(sub._returningColumnsForInsert(connection));
+    expect(memoized).toEqual(await sub._returningColumnsForInsert(connection));
   });
 });

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -683,10 +683,10 @@ export function realInheritanceColumn(this: SchemaHost, value: string | null): v
 
 export const _inheritanceColumn = realInheritanceColumn;
 
-export function _returningColumnsForInsert(
+export async function _returningColumnsForInsert(
   this: SchemaHost,
-  connection: { returnValueAfterInsert?(column: { name: string }): boolean },
-): string[] {
+  connection: { returnValueAfterInsert?(column: { name: string }): Promise<boolean> },
+): Promise<string[]> {
   // Mirrors Rails _returning_columns_for_insert: the columns the DB auto-populates
   // on INSERT (auto-increment / serial / identity columns and DB-computed
   // defaults), falling back to the PK when the adapter reports none.
@@ -707,11 +707,14 @@ export function _returningColumnsForInsert(
   }
   const cols = columns.call(this) as { name: string; isAutoPopulated?: unknown }[];
   const memoize = (value: string[]): string[] => (this._returningColumnsForInsertCache = value);
-  const autoPopulated = cols
-    .filter(
-      (c) => typeof c.isAutoPopulated === "function" && connection.returnValueAfterInsert?.(c),
-    )
-    .map((c) => c.name);
+  const keep = await Promise.all(
+    cols.map(
+      async (c) =>
+        typeof c.isAutoPopulated === "function" &&
+        ((await connection.returnValueAfterInsert?.(c)) ?? false),
+    ),
+  );
+  const autoPopulated = cols.filter((_c, i) => keep[i]).map((c) => c.name);
   if (autoPopulated.length > 0) return memoize(autoPopulated);
   // PK fallback. Restrict to columns that actually exist on the table: Rails
   // reflects `primary_key` as nil for a table without that column (e.g. an

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -1887,9 +1887,10 @@ describe("PersistenceTest", () => {
     if (adapterType === "postgres") {
       // Mirror postgresql_specific_schema.rb `create_table :defaults`.
       const pg = connection as PostgreSQLAdapter;
+      const supportsVirtualColumns = await pg.supportsVirtualColumns();
       await pg.createTable("defaults", { force: true }, (t) => {
         const d = t as PgTableDefinition;
-        if (pg.supportsVirtualColumns()) {
+        if (supportsVirtualColumns) {
           d.virtual("virtual_stored_number", {
             type: "integer",
             as: "random_number * 10",
@@ -1977,7 +1978,7 @@ describe("PersistenceTest", () => {
   it.skipIf(adapterType !== "postgres")("fills auto populated columns on creation", async () => {
     await withDefaultsTable(async (record) => {
       expect(record.ruby_on_rails).toBe("Ruby on Rails");
-      if ((Base.connection as PostgreSQLAdapter).supportsVirtualColumns()) {
+      if (await (Base.connection as PostgreSQLAdapter).supportsVirtualColumns()) {
         expect(record.virtual_stored_number).not.toBeNull();
       }
       expect(record.random_number).not.toBeNull();
@@ -1990,7 +1991,7 @@ describe("PersistenceTest", () => {
       // returns binary columns as raw bytes, so decode to compare.
       expect(Buffer.from(record.binary_default_function).toString()).toBe("A");
 
-      if ((Base.connection as PostgreSQLAdapter).supportsIdentityColumns()) {
+      if (await (Base.connection as PostgreSQLAdapter).supportsIdentityColumns()) {
         class IdentityTable extends Base {
           static _tableName = "postgresql_identity_table";
         }
@@ -2017,13 +2018,13 @@ describe("PersistenceTest", () => {
 
   // Rails: `elsif current_adapter?(:Mysql2Adapter, :TrilogyAdapter)`.
   it.skipIf(adapterType !== "mysql")("fills auto populated columns on creation", async () => {
-    await withDefaultsTable((record) => {
+    await withDefaultsTable(async (record) => {
       expect(record.char1).not.toBeNull();
       const supportsDefaultExpression =
         (
           Base.connection as { supportsDefaultExpression?: () => boolean }
         ).supportsDefaultExpression?.() ?? false;
-      if (supportsDefaultExpression && Base.connection.supportsInsertReturning?.()) {
+      if (supportsDefaultExpression && (await Base.connection.supportsInsertReturning?.())) {
         expect(record.uuid).not.toBeNull();
       }
     });

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2957,7 +2957,7 @@ export class Relation<T extends Base> {
     // exec_queries path means a real relation always yields at least one
     // captured query (with adapter-quoted SQL — backticks on MySQL), and a
     // query-less relation (`.none()`) yields empty output, matching Rails.
-    const clause = this.buildExplainClause(adapter, options);
+    const clause = await this.buildExplainClause(adapter, options);
     const parts: string[] = [];
     for (const [sql, binds] of queries) {
       let msg = `${clause} ${sql}`;
@@ -3101,7 +3101,10 @@ export class Relation<T extends Base> {
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter#build_explain_clause
    */
-  private buildExplainClause(adapter: DatabaseAdapter, options: ExplainOption[]): string {
+  private async buildExplainClause(
+    adapter: DatabaseAdapter,
+    options: ExplainOption[],
+  ): Promise<string> {
     if (typeof adapter.buildExplainClause === "function") {
       return adapter.buildExplainClause(options);
     }

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -55,9 +55,9 @@ describe("SchemaDumperTest", () => {
   // mirror that by consulting the live adapter flag rather than blanket-excluding
   // the MySQL family — the CI MariaDB 11 lane supports it, so `companies` dumps
   // the descending `order:` exactly as Rails does there.
-  function dumpsIndexSortOrder(): boolean {
+  async function dumpsIndexSortOrder(): Promise<boolean> {
     return (
-      Base.adapter as unknown as { supportsIndexSortOrder(): boolean }
+      Base.adapter as unknown as { supportsIndexSortOrder(): Promise<boolean> }
     ).supportsIndexSortOrder();
   }
 
@@ -218,7 +218,7 @@ describe("SchemaDumperTest", () => {
     const base =
       'await ctx.addIndex("companies", ["firm_id", "type", "rating"], { name: "company_index"';
     const lengthPart = adapterType === "mysql" ? ", length: { type: 10 }" : "";
-    const orderPart = dumpsIndexSortOrder() ? ', order: { rating: "desc" }' : "";
+    const orderPart = (await dumpsIndexSortOrder()) ? ', order: { rating: "desc" }' : "";
     expect(line).toBe(`${base}${lengthPart}${orderPart} });`);
   });
 
@@ -250,7 +250,7 @@ describe("SchemaDumperTest", () => {
     // Rails IndexDefinition#concise_options collapses a uniform order map to a
     // scalar (`order: :desc`); backends that don't surface sort order here emit a
     // plain index (schema_dumper_test.rb:203-211).
-    const expected = dumpsIndexSortOrder()
+    const expected = (await dumpsIndexSortOrder())
       ? 'await ctx.addIndex("companies", ["name", "rating"], { name: "index_companies_on_name_and_rating", order: "desc" });'
       : 'await ctx.addIndex("companies", ["name", "rating"], { name: "index_companies_on_name_and_rating" });';
     expect(line).toBe(expected);

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -781,8 +781,7 @@ export abstract class SchemaDumper {
     // @connection.supports_check_constraints?`): adapters whose checkConstraints
     // raises NotImplementedError when unsupported (e.g. MySQL <8.0.16, MariaDB
     // <10.2.1) must not be queried.
-    if (host.supportsCheckConstraints && !(await host.supportsCheckConstraints()))
-      return undefined;
+    if (host.supportsCheckConstraints && !(await host.supportsCheckConstraints())) return undefined;
     const checkConstraints = ((await host.checkConstraints(tableName)) ?? []) as {
       expression: string;
       name?: string;

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -773,7 +773,7 @@ export abstract class SchemaDumper {
     const host = this._hookHost("checkConstraints") as
       | {
           checkConstraints: (t: string) => Promise<unknown[]>;
-          supportsCheckConstraints?: () => boolean;
+          supportsCheckConstraints?: () => Promise<boolean>;
         }
       | undefined;
     if (!host) return undefined;
@@ -781,7 +781,8 @@ export abstract class SchemaDumper {
     // @connection.supports_check_constraints?`): adapters whose checkConstraints
     // raises NotImplementedError when unsupported (e.g. MySQL <8.0.16, MariaDB
     // <10.2.1) must not be queried.
-    if (host.supportsCheckConstraints && !host.supportsCheckConstraints()) return undefined;
+    if (host.supportsCheckConstraints && !(await host.supportsCheckConstraints()))
+      return undefined;
     const checkConstraints = ((await host.checkConstraints(tableName)) ?? []) as {
       expression: string;
       name?: string;

--- a/packages/activerecord/src/store.test.ts
+++ b/packages/activerecord/src/store.test.ts
@@ -175,7 +175,7 @@ describe("StoreTest", () => {
   });
 
   it("saved changes tracking for accessors with json column", async (ctx) => {
-    ctx.skip((Base.connection as any).isMariadb?.() ?? false);
+    ctx.skip((await (Base.connection as any).isMariadb?.()) ?? false);
     (john as any).enableFriendRequests = true;
     expect((john as any).enableFriendRequestsChanged()).toBe(true);
 

--- a/packages/activerecord/src/support/canonical-schema.ts
+++ b/packages/activerecord/src/support/canonical-schema.ts
@@ -269,15 +269,6 @@ let _registry: CanonicalTableDef[] | null = null;
 export async function prepareSchema(
   adapter: DatabaseAdapter,
 ): Promise<{ ss: SchemaStatements; typeMap: Record<string, string | undefined> }> {
-  // Rails' schema loader always runs on a checked-out — therefore connected —
-  // connection, because `checkout` ends in `verify!` (`abstract_adapter.rb:759`).
-  // trails' adapters connect lazily on the first query, so the DDL below would
-  // otherwise be the first thing to touch a cold adapter, and the version-gated
-  // predicates `create_table` reads (`row_format_dynamic_by_default?`,
-  // `supports_index_sort_order?`) are sync. Establishing the connection here is
-  // what Rails' checkout does; `configure_connection` fills the version memo on
-  // the way through, so no ported body needs a warm of its own.
-  await adapter.verifyBang();
   const ss = adapter as unknown as SchemaStatements;
   const typeMap =
     adapter.adapterName === "postgres"

--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -22,7 +22,7 @@ import { STUBBED_DDL_METHODS } from "./stubbed-ddl-methods.js";
  */
 async function loadPostgresqlSpecificSchema(adapter: PostgreSQLAdapter): Promise<void> {
   await adapter.enableExtension("uuid-ossp");
-  if (adapter.supportsPgcryptoUuid()) await adapter.enableExtension("pgcrypto");
+  if (await adapter.supportsPgcryptoUuid()) await adapter.enableExtension("pgcrypto");
 
   // `uuid_default = supports_pgcrypto_uuid? ? {} : { default: "uuid_generate_v4()" }`
   // (line 7), splatted into the three `id: :uuid` tables below. With pgcrypto the
@@ -30,7 +30,7 @@ async function loadPostgresqlSpecificSchema(adapter: PostgreSQLAdapter): Promise
   // does not exist, so the PK falls back to uuid-ossp's `uuid_generate_v4()`.
   // The bare string (not a thunk) is Rails verbatim: quoteDefaultExpression emits
   // a `()`-bearing string unquoted on a uuid column.
-  const uuidDefault: { default?: string } = adapter.supportsPgcryptoUuid()
+  const uuidDefault: { default?: string } = (await adapter.supportsPgcryptoUuid())
     ? {}
     : { default: "uuid_generate_v4()" };
 
@@ -54,9 +54,10 @@ async function loadPostgresqlSpecificSchema(adapter: PostgreSQLAdapter): Promise
     pg.uuid("uuid_parent_id");
   });
 
+  const supportsVirtualColumns = await adapter.supportsVirtualColumns();
   await adapter.createTable("defaults", { force: true }, (t) => {
     const pg = t as PgTableDefinition;
-    if (adapter.supportsVirtualColumns()) {
+    if (supportsVirtualColumns) {
       pg.virtual("virtual_stored_number", {
         type: "integer",
         as: "random_number * 10",
@@ -88,7 +89,7 @@ async function loadPostgresqlSpecificSchema(adapter: PostgreSQLAdapter): Promise
     pg.text("multiline_default", { default: "--- []\n\n" });
   });
 
-  if (adapter.supportsIdentityColumns()) {
+  if (await adapter.supportsIdentityColumns()) {
     await adapter.dropTable("postgresql_identity_table", { ifExists: true });
     await adapter.execute(
       "create table postgresql_identity_table (\n" +
@@ -266,7 +267,7 @@ async function loadPostgresqlSpecificSchema(adapter: PostgreSQLAdapter): Promise
     });
   });
 
-  if (adapter.supportsPartitionedIndexes()) {
+  if (await adapter.supportsPartitionedIndexes()) {
     await adapter.createTable(
       "measurements",
       { id: false, force: true, options: "PARTITION BY LIST (city_id)" },
@@ -299,7 +300,7 @@ async function loadPostgresqlSpecificSchema(adapter: PostgreSQLAdapter): Promise
     ifNotExists: true,
   });
 
-  if (adapter.supportsInsertReturning()) {
+  if (await adapter.supportsInsertReturning()) {
     await adapter.createTable(
       "pk_autopopulated_by_a_trigger_records",
       { force: true, id: false },
@@ -340,9 +341,10 @@ async function loadPostgresqlSpecificSchema(adapter: PostgreSQLAdapter): Promise
  * worker and so cannot pull in `supports.ts`'s `vitest` import.
  */
 async function loadMysql2SpecificSchema(adapter: AbstractMysqlAdapter): Promise<void> {
-  const supportsDefaultExpression = adapter.isMariadb()
-    ? adapter.databaseVersion.compare("10.2.1") >= 0
-    : adapter.databaseVersion.compare("8.0.13") >= 0;
+  const databaseVersion = await adapter.databaseVersion;
+  const supportsDefaultExpression = (await adapter.isMariadb())
+    ? databaseVersion.compare("10.2.1") >= 0
+    : databaseVersion.compare("8.0.13") >= 0;
 
   await adapter.createTable("datetime_defaults", { force: true }, (t) => {
     t.datetime("modified_datetime", { precision: null, default: () => "CURRENT_TIMESTAMP" });
@@ -427,7 +429,7 @@ async function loadMysql2SpecificSchema(adapter: AbstractMysqlAdapter): Promise<
     "CREATE PROCEDURE topics(IN num INT) SQL SECURITY INVOKER\nBEGIN\n  SELECT * FROM topics LIMIT num;\nEND\n",
   );
 
-  if (adapter.supportsInsertReturning()) {
+  if (await adapter.supportsInsertReturning()) {
     await adapter.createTable(
       "pk_autopopulated_by_a_trigger_records",
       { force: true, id: false },

--- a/packages/activerecord/src/support/schema-types.ts
+++ b/packages/activerecord/src/support/schema-types.ts
@@ -219,10 +219,10 @@ export function columnsOf(table: TableSchema): Record<string, ColumnSpec> {
  * @internal
  */
 export async function supportsExpressionIndex(adapter: DatabaseAdapter): Promise<boolean> {
-  const a = adapter as { supportsExpressionIndex?: () => boolean };
+  const a = adapter as { supportsExpressionIndex?: () => Promise<boolean> };
   if (typeof a.supportsExpressionIndex !== "function") return false;
   try {
-    return a.supportsExpressionIndex();
+    return await a.supportsExpressionIndex();
   } catch {
     return false;
   }

--- a/packages/activerecord/src/support/stubbed-ddl-methods.test.ts
+++ b/packages/activerecord/src/support/stubbed-ddl-methods.test.ts
@@ -20,16 +20,6 @@ const NON_EMITTING: ReadonlyMap<string, string> = new Map([
     "read — picks the per-adapter type map and gates schema.rb's inline adapter clauses",
   ],
   [
-    "verifyBang",
-    "connection readiness — Rails' `verify!` (`abstract_adapter.rb:759`), which the loader runs before any DDL; emits none itself",
-  ],
-  ["active", "liveness read `verifyBang` branches on, not a DDL emitter"],
-  [
-    "completeAsyncConnect",
-    "settles SQLite's async open so `active` can answer; connection setup, emits no DDL",
-  ],
-  ["verifiedBang", "post-verify bookkeeping — stamps `_lastActivity`/`_verified`, emits no DDL"],
-  [
     "validateCreateTableOptionsBang",
     "option validation — raises on an unknown key, emits no DDL of its own",
   ],

--- a/packages/activerecord/src/support/supports-live-adapter.trails.test.ts
+++ b/packages/activerecord/src/support/supports-live-adapter.trails.test.ts
@@ -48,8 +48,6 @@ describe("supports table vs. the live adapter", () => {
 
   it("answers each feature key exactly as the connection does", async () => {
     const connection = (await Base.leaseConnection()) as unknown as LiveConnection;
-    await connection.getDatabaseVersion();
-
     const drift: string[] = [];
 
     for (const feature of SUPPORTS_FEATURES) {
@@ -59,7 +57,9 @@ describe("supports table vs. the live adapter", () => {
         live = helperAnswer;
       } else {
         const method = connection[methodName(feature)];
-        live = typeof method === "function" && (method as () => boolean).call(connection) === true;
+        live =
+          typeof method === "function" &&
+          (await (method as () => boolean | Promise<boolean>).call(connection)) === true;
       }
       const table = adapterSupports(feature);
       if (table !== live) drift.push(`${feature}: table=${table} adapter=${live}`);

--- a/packages/activerecord/src/support/supports-live-adapter.trails.test.ts
+++ b/packages/activerecord/src/support/supports-live-adapter.trails.test.ts
@@ -8,18 +8,21 @@ import { adapterSupports, SUPPORTS_FEATURES } from "./supports.js";
 const MYSQL_FAMILY = ["Mysql2Adapter", "TrilogyAdapter"] as const;
 
 type LiveConnection = {
-  isMariadb?(): boolean;
-  databaseVersion: Version | number;
+  isMariadb?(): Promise<boolean>;
+  databaseVersion: Version | number | Promise<Version | number>;
   getDatabaseVersion(): Promise<Version | number>;
 } & Record<string, unknown>;
 
-function mysqlAtLeast(connection: LiveConnection, version: string): boolean {
-  return (connection.databaseVersion as Version).compare(version) >= 0;
+async function mysqlAtLeast(connection: LiveConnection, version: string): Promise<boolean> {
+  return ((await connection.databaseVersion) as Version).compare(version) >= 0;
 }
 
-function adapterHelperSupport(feature: string, connection: LiveConnection): boolean | undefined {
+async function adapterHelperSupport(
+  feature: string,
+  connection: LiveConnection,
+): Promise<boolean | undefined> {
   const mysql = currentAdapter(...MYSQL_FAMILY);
-  const mariadb = mysql && connection.isMariadb?.() === true;
+  const mariadb = mysql && (await connection.isMariadb?.()) === true;
   switch (feature) {
     case "default_expression":
       if (currentAdapter("PostgreSQLAdapter")) return true;
@@ -51,7 +54,7 @@ describe("supports table vs. the live adapter", () => {
     const drift: string[] = [];
 
     for (const feature of SUPPORTS_FEATURES) {
-      const helperAnswer = adapterHelperSupport(feature, connection);
+      const helperAnswer = await adapterHelperSupport(feature, connection);
       let live: boolean;
       if (helperAnswer !== undefined) {
         live = helperAnswer;


### PR DESCRIPTION
Rails' `database_version` (`abstract_adapter.rb:854-856`) is
`pool.server_version(self)` — it issues the round-trip, and therefore connects,
on demand, from any state. trails' getter instead threw unless something had
already warmed the pool memo, so PR #6149 filled it by construction at
connection establishment (shape 2). That shape cannot cover an adapter whose
first operation is a version-gated read — a standalone `new Mysql2Adapter(...)`
calling `createTable` has no connect event to hang a fill on — which is why
#6149 had to leave `MySQL::SchemaStatements#row_format_dynamic_by_default?`
diverged.

This is shape 1. `AbstractAdapter#databaseVersion` now returns
`pool.serverVersion(this)` directly — Rails' body, call for call — which makes
it awaitable, and the version-gated `supports_*?` predicates await it.

The blast radius follows the readers, as the story anticipated: the
schema-creation visitors (`quotedColumns`, `visitCreateIndexDefinition`,
`visitIndexDefinition`, `visitUniqueConstraintDefinition`,
`quotedIncludeColumns`), `quotedColumnsForIndex` /
`addOptionsForIndexColumns`, `build_explain_clause`,
`return_value_after_insert?` / `_returning_columns_for_insert`, and `mariadb?`
(`abstract_mysql_adapter.rb:92-94`), which reads `full_version` off the same
version and so must fetch on demand too.

## Converged

- `row_format_dynamic_by_default?` / `default_row_format`
  (`mysql/schema_statements.rb:146-154`) are the Rails bodies again — no
  `pool.serverVersion` reach-through, and `mariadb?` is evaluated first, as
  Rails evaluates it. The comment #6149 left explaining why it could not be is
  gone with it.
- `AbstractAdapter#configure_connection` is `check_version` alone
  (`abstract_adapter.rb:1212-1214`).
- `PostgreSQLAdapter` drops its bespoke throwing `databaseVersion` override.
  Rails has no such override; the base getter is now correct for PG.
- `Transaction#restart` (`transaction.rb:464-476`) drops the try/catch that
  existed only because `supports_restart_db_transaction?` could throw on a cold
  version.
- `InsertAll` keys the deferred `@returning` resolution off Ruby's own nil
  sentinel (`insert_all.rb:38`, `@returning.nil?`) rather than a bespoke flag,
  and `ensure_valid_options_for_connection!` runs once in Rails' constructor
  order (after `find_unique_index_for`).

## Shape-2 scaffolding removed

Per the story's third criterion — none of it has a Rails counterpart:

- the `verifyBang()` call in `support/canonical-schema.ts` `prepareSchema`;
- the memo refill in `adapters/abstract-mysql-adapter/connection.test.ts`'s
  `afterEach`;
- the four `NON_EMITTING` entries that call pulled onto the canonical lay path
  (`verifyBang`, `active`, `completeAsyncConnect`, `verifiedBang`);
- the memo fill in `AbstractAdapter#configureConnection`.

## Size — over the ceiling, and why it cannot be split

**~1070 LOC against a 700 ceiling.** Flagging it rather than burying it.

The change is a single type-propagation: the moment `databaseVersion` becomes
awaitable, every reader must await in the same commit or the package does not
compile. There is no intermediate state that builds, so this cannot become two
PRs from `main` with non-overlapping files, and stacking is disallowed. Every
predicate that went async was checked to have at least one genuinely
version-gated implementation — none were widened for uniformity.

Roughly half the diff is one-word `async`/`await` edits on existing lines
(counted as +1/−1 each) and deletions of the shape-2 scaffolding; the
review-bearing surface is much smaller than the raw number suggests. Happy to
split differently if a reviewer sees a seam I don't.

## Tests

`pool-server-version.trails.test.ts` and `abstract-adapter-version.trails.test.ts`
pinned the old shape ("databaseVersion raises before the memo is warm",
"makes databaseVersion readable with no caller-side warm"); both now pin the
acceptance criterion instead — the version is readable from a standalone,
never-connected adapter. Same for `postgresql-adapter.trails.test.ts`'s
"databaseVersion throws before initialization". All three are `.trails.test.ts`
files with no Rails counterpart; no Rails-matched test name was renamed, and
`test:compare` is unchanged.

## CI history worth knowing about

Four red rounds, all real bugs in this diff, all one class: a now-async call in
a position TypeScript accepts silently — a Promise interpolated into a template
literal (`[object Promise]` reaching SQL on the EXPLAIN and INCLUDE paths), one
behind `as any`, one as a `.filter()` predicate
(`_returning_columns_for_insert`, which put dropped columns into RETURNING),
and one failing an `rv.length > 0` check. Each round I fixed the report and
then swept for the rest of the class; the `.call(this, …)` invocation form is
what the earlier sweeps missed.

Local runs could not have caught most of these: the PG and MySQL vitest
projects are excluded from the sqlite lane, so CI was the first execution of
those files.

## Gates

`pnpm api:calls` OK, no new rows. `api:extra` unchanged (no new public names —
signature changes plus one deletion). `api:compare` / `test:compare` deltas
measured at exactly zero against a rebuilt `origin/main`, and CI's
`Rails API/Test Comparison` job passes. Lint is clean apart from one
pre-existing `no-unnecessary-type-assertion` error in
`packages/actionpack/.../transition-table.test.ts` that is present on `main`
and outside this diff.

(The review brief asks for `pnpm api:calls:wide`; no such script exists —
RFC 0084 folded it into `api:calls`, which is the single gate over a single
artifact.)

## Not in this PR

`move-adapter-specific-snapshot-off-ar-internal-metadata` was claimed in the
same bundle and is **not** included; it has been released back for separate
scheduling. Its own recorded findings (2026-08-07) say the run-token sidecar
arm is larger than its 160 LOC estimate and that "this story should be its own
PR, not bundled" — the `load-schema-helper.ts:526` seam it reshapes is the same
one this PR touches, and five PRs reshaping it in one evening is what produced
that warning.

Closes-story: make-version-gated-predicates-async
