### PR TITLE
feat(api-compare): file-level tags may declare bare-short-name moved coincidences; libsql.ts resolved

### DIFF
--- a/packages/activerecord/src/sqlite/libsql.ts
+++ b/packages/activerecord/src/sqlite/libsql.ts
@@ -1,3 +1,23 @@
+/**
+ * @noRailsEquivalent PERMANENT — Ruby binds exactly one SQLite driver
+ * (`gem "sqlite3"`, sqlite3_adapter.rb:14) and the sqlite3 gem's C extension,
+ * not Rails, owns the handle protocol: `SQLite3Adapter` calls
+ * `::SQLite3::Database.new` (sqlite3_adapter.rb:34-35) and then `prepare`,
+ * `close`, `closed?` on an object Rails does not define
+ * (sqlite3_adapter.rb:98, 207, 224). trails has to write
+ * that layer in TS, so this file is the `libsql` npm client's binding — the
+ * driver object literals and the connection/statement handles behind them —
+ * and no name it declares has a Rails method to converge onto. Its sibling
+ * subclass `connection-adapters/libsql-adapter.ts` carries the same reason.
+ * MOVED-BY-SHORT-NAME: close, databaseExists, isOpen, open, prepare. Those
+ * five score `moved` only because the oracle is one global set of bare
+ * camelized Ruby names with no owner attached: `close` resolves to
+ * `Rack::BodyProxy#close`, `prepare` to `Store::HashAccessor#prepare`,
+ * `isOpen` to `Transaction#open?` (abstract/transaction.rb), `open` to
+ * `SchemaCache#open` / `MigrationContext#open`, `databaseExists` to
+ * `AbstractAdapter#database_exists?` — which the port already carries on the
+ * adapter, at its Rails name, one layer above this driver.
+ */
 import Database from "libsql";
 import { getFs } from "@blazetrails/activesupport/fs-adapter";
 import { ConfigurationError } from "../errors.js";

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -2300,6 +2300,59 @@ describe("@noRailsEquivalent — extractor to report", () => {
     expect(gateFileTagRejections(report.fileTagRejections)).toContain("moved name(s)");
   });
 
+  it("accepts a file-level tag whose reason declares the moved name as a short-name coincidence", () => {
+    const report = reportFor(railsWithout([method("sync_replica")]), {
+      "connection-adapters/libsql-replica-adapter.ts": DRIVER_ADAPTER.replace(
+        "subclass onto.",
+        "subclass onto. MOVED-BY-SHORT-NAME: syncReplica.",
+      ),
+    });
+    expect(report.fileTagRejections).toEqual([]);
+    expect(report.packages[0].totalAllowlisted).toBe(2);
+    expect(report.packages[0].extraFiles.map((f) => f.tsFile)).not.toContain(
+      "connection-adapters/libsql-replica-adapter.ts",
+    );
+  });
+
+  it("still rejects when only some of the moved names are declared", () => {
+    const report = reportFor(railsWithout([method("sync_replica"), method("pragma")]), {
+      "connection-adapters/libsql-replica-adapter.ts": DRIVER_ADAPTER.replace(
+        "syncReplica(): void {}",
+        "syncReplica(): void {}\n      pragma(): void {}",
+      ).replace("subclass onto.", "subclass onto. MOVED-BY-SHORT-NAME: syncReplica."),
+    });
+    expect(report.fileTagRejections).toEqual([
+      {
+        package: "activerecord",
+        tsFile: "connection-adapters/libsql-replica-adapter.ts",
+        cause: "moved-names",
+        movedNames: ["pragma"],
+      },
+    ]);
+    expect(report.packages[0].totalAllowlisted).toBe(0);
+  });
+
+  it("rejects a declared name that no longer scores moved, so the declaration only shrinks", () => {
+    const report = reportFor(railsWithout(), {
+      "connection-adapters/libsql-replica-adapter.ts": DRIVER_ADAPTER.replace(
+        "subclass onto.",
+        "subclass onto. MOVED-BY-SHORT-NAME: syncReplica.",
+      ),
+    });
+    expect(report.fileTagRejections).toEqual([
+      {
+        package: "activerecord",
+        tsFile: "connection-adapters/libsql-replica-adapter.ts",
+        cause: "stale-moved-declaration",
+        staleMovedNames: ["syncReplica"],
+      },
+    ]);
+    expect(report.packages[0].totalAllowlisted).toBe(0);
+    expect(gateFileTagRejections(report.fileTagRejections)).toContain(
+      "no longer score moved: syncReplica",
+    );
+  });
+
   it("rejects a file-level tag when a Rails file maps onto the file", () => {
     const ruby = railsWithout();
     ruby.packages.activerecord.classes["ActiveRecord::ConnectionAdapters::SQLite3Adapter"] =

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -323,7 +323,7 @@ export interface TaggedEntry {
 export const FILE_TAG_NAME = "*";
 
 /** Why a file-level tag was refused — see `fileTagVerdict`. */
-export type FileTagRejectionCause = "counterpart-file" | "moved-names";
+export type FileTagRejectionCause = "counterpart-file" | "moved-names" | "stale-moved-declaration";
 
 export interface FileTagRejection {
   package: string;
@@ -331,8 +331,43 @@ export interface FileTagRejection {
   cause: FileTagRejectionCause;
   /** The Rails file that maps onto this TS file (`counterpart-file` only). */
   rubyFile?: string;
-  /** The names scoring `moved` (`moved-names` only). */
+  /** The names scoring `moved` and NOT declared (`moved-names` only). */
   movedNames?: string[];
+  /**
+   * Names the reason declares under `MOVED-BY-SHORT-NAME:` that no longer
+   * score `moved` (`stale-moved-declaration` only).
+   */
+  staleMovedNames?: string[];
+}
+
+/**
+ * The clause a file-level reason uses to declare, name by name, which of its
+ * `moved` scores are bare-short-name coincidences rather than misplaced ports.
+ *
+ * `moved` is decided by a single global Set of every camelized Ruby method
+ * name in Rails-land (`buildGlobalRubyCandidates`), with no file, class, or
+ * package attribution: a TS `close` on a libsql driver handle scores `moved`
+ * off `Rack::BodyProxy#close`, and `prepare` off `Store::HashAccessor#prepare`.
+ * For a file that binds a third-party JS client — a population Ruby does not
+ * have at all — every generic verb in the client's own protocol collides that
+ * way, and there is no Rails name for any of them to move onto.
+ *
+ * The declaration is what keeps that from re-opening the hole the moved gate
+ * exists to close (`postgresql/schema-statements-class.ts`, ~80 moved names of
+ * a genuinely renamed port). It is per-name and reviewed, not a mode switch:
+ * a moved name the reason does not list still refuses the blanket, and a
+ * listed name that stops scoring `moved` is stale and must be deleted, so the
+ * list can only shrink.
+ */
+const MOVED_BY_SHORT_NAME_RE = /MOVED-BY-SHORT-NAME:([^.]*)/;
+
+export function declaredCoincidentalMovedNames(reason: string): Set<string> {
+  const m = MOVED_BY_SHORT_NAME_RE.exec(reason);
+  if (!m) return new Set();
+  // The clause runs to the sentence's period; only identifiers count, so a
+  // stray prose word inside it is ignored rather than minted as a declaration
+  // no extra can ever match (which would read as permanent staleness).
+  return new Set(m[1].split(/[,\s]+/).filter((s) => /^[A-Za-z_$][\w$]*$/.test(s)));
 }
 
 /**
@@ -356,14 +391,36 @@ export interface FileTagRejection {
  *
  * `extras` is the FULL scored set, `--novel-only` notwithstanding: a moved name
  * refutes the claim whether or not this run is reporting moved names.
+ *
+ * A moved name the reason names in its `MOVED-BY-SHORT-NAME:` clause
+ * (`declaredCoincidentalMovedNames`) stops refuting it — see that clause for
+ * why the escape is per-name and reviewed. The declaration is only-shrink: a
+ * declared name that no longer scores `moved` is `stale-moved-declaration`,
+ * refused exactly as loudly as an undeclared moved name.
  */
 export function fileTagVerdict(
   rubyFile: string | null,
   extras: readonly ExtraName[],
+  reason = "",
 ): FileTagRejectionCause | null {
   if (rubyFile !== null) return "counterpart-file";
-  if (extras.some((e) => e.kind === "moved")) return "moved-names";
+  const declared = declaredCoincidentalMovedNames(reason);
+  const moved = new Set(extras.filter((e) => e.kind === "moved").map((e) => e.name));
+  if ([...moved].some((n) => !declared.has(n))) return "moved-names";
+  if ([...declared].some((n) => !moved.has(n))) return "stale-moved-declaration";
   return null;
+}
+
+/** The moved names in `extras` the reason does not declare — `moved-names`. */
+function undeclaredMovedNames(extras: readonly ExtraName[], reason: string): string[] {
+  const declared = declaredCoincidentalMovedNames(reason);
+  return extras.filter((e) => e.kind === "moved" && !declared.has(e.name)).map((e) => e.name);
+}
+
+/** Declared names that no longer score `moved` — `stale-moved-declaration`. */
+function staleMovedDeclarations(extras: readonly ExtraName[], reason: string): string[] {
+  const moved = new Set(extras.filter((e) => e.kind === "moved").map((e) => e.name));
+  return [...declaredCoincidentalMovedNames(reason)].filter((n) => !moved.has(n));
 }
 
 /**
@@ -1278,8 +1335,9 @@ function buildPackageReport(
       scored.push({ name, kind });
     }
 
-    if (fileTags[expectedTs] !== undefined) {
-      const cause = fileTagVerdict(rubyFile, scored);
+    const fileTagReason = fileTags[expectedTs];
+    if (fileTagReason !== undefined) {
+      const cause = fileTagVerdict(rubyFile, scored, fileTagReason);
       if (cause === null) {
         if (scored.length > 0) {
           matchedTagKeys.add(allowKeyOf({ package: pkg, tsFile: expectedTs, name: FILE_TAG_NAME }));
@@ -1293,7 +1351,10 @@ function buildPackageReport(
           cause,
           ...(rubyFile !== null ? { rubyFile } : {}),
           ...(cause === "moved-names"
-            ? { movedNames: scored.filter((e) => e.kind === "moved").map((e) => e.name) }
+            ? { movedNames: undeclaredMovedNames(scored, fileTagReason) }
+            : {}),
+          ...(cause === "stale-moved-declaration"
+            ? { staleMovedNames: staleMovedDeclarations(scored, fileTagReason) }
             : {}),
         });
       }
@@ -1614,18 +1675,31 @@ export function buildReport(
  */
 export function gateFileTagRejections(rejections: readonly FileTagRejection[]): string | null {
   if (rejections.length === 0) return null;
-  const lines = rejections.map((r) =>
-    r.cause === "counterpart-file"
-      ? `  - ${r.package}  ${r.tsFile} — Rails counterpart file ${r.rubyFile}`
-      : `  - ${r.package}  ${r.tsFile} — ${r.movedNames?.length ?? 0} moved name(s): ` +
-        (r.movedNames ?? []).slice(0, 8).join(", ") +
-        ((r.movedNames?.length ?? 0) > 8 ? ", …" : ""),
-  );
+  const list = (names: readonly string[] | undefined): string =>
+    (names ?? []).slice(0, 8).join(", ") + ((names?.length ?? 0) > 8 ? ", …" : "");
+  const lines = rejections.map((r) => {
+    if (r.cause === "counterpart-file") {
+      return `  - ${r.package}  ${r.tsFile} — Rails counterpart file ${r.rubyFile}`;
+    }
+    if (r.cause === "stale-moved-declaration") {
+      return (
+        `  - ${r.package}  ${r.tsFile} — ${r.staleMovedNames?.length ?? 0} ` +
+        `MOVED-BY-SHORT-NAME name(s) that no longer score moved: ${list(r.staleMovedNames)}`
+      );
+    }
+    return (
+      `  - ${r.package}  ${r.tsFile} — ${r.movedNames?.length ?? 0} moved name(s): ` +
+      list(r.movedNames)
+    );
+  });
   return (
     `\nextra-surface: ${rejections.length} file-level @noRailsEquivalent tag(s) claim a ` +
     "file has no Rails counterpart, but the report finds one. A `moved` name means the " +
     "name DOES exist in Rails, just in another file — a rename may be owed, and the " +
-    "blanket would hide it. Tag the names individually, or converge them:\n" +
+    "blanket would hide it. Tag the names individually, or converge them. If the moved " +
+    "score really is a bare-short-name coincidence against an unrelated Rails class, " +
+    "name each such name in a `MOVED-BY-SHORT-NAME: a, b, c` clause in the reason — and " +
+    "delete a listed name once it stops scoring moved:\n" +
     lines.join("\n") +
     "\n"
   );

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -340,6 +340,8 @@ export interface FileTagRejection {
   staleMovedNames?: string[];
 }
 
+const MOVED_BY_SHORT_NAME_RE = /MOVED-BY-SHORT-NAME:([^.]*)/;
+
 /**
  * The clause a file-level reason uses to declare, name by name, which of its
  * `moved` scores are bare-short-name coincidences rather than misplaced ports.
@@ -358,15 +360,17 @@ export interface FileTagRejection {
  * a moved name the reason does not list still refuses the blanket, and a
  * listed name that stops scoring `moved` is stale and must be deleted, so the
  * list can only shrink.
+ *
+ * The clause runs from the marker to the end of its sentence, and only
+ * identifier tokens in it count: a stray prose word is ignored rather than
+ * minted as a declaration no extra can ever match, which would read as
+ * permanent staleness. It cannot be spelled as a JSDoc `@tag` — a bare `@word`
+ * inside a `@noRailsEquivalent` reason truncates the reason (`proseTagAfter`,
+ * extract-ts-api.ts).
  */
-const MOVED_BY_SHORT_NAME_RE = /MOVED-BY-SHORT-NAME:([^.]*)/;
-
 export function declaredCoincidentalMovedNames(reason: string): Set<string> {
   const m = MOVED_BY_SHORT_NAME_RE.exec(reason);
   if (!m) return new Set();
-  // The clause runs to the sentence's period; only identifiers count, so a
-  // stray prose word inside it is ignored rather than minted as a declaration
-  // no extra can ever match (which would read as permanent staleness).
   return new Set(m[1].split(/[,\s]+/).filter((s) => /^[A-Za-z_$][\w$]*$/.test(s)));
 }
 


### PR DESCRIPTION
Resolves the third and last whole-file no-counterpart case from
`extra-surface-resolve-remaining-whole-file-cases`: `packages/activerecord/src/sqlite/libsql.ts`.

## Where the five `moved` scores resolve

`moved` is decided by one global Set of every camelized Ruby method name in
Rails-land (`buildGlobalRubyCandidates`, extra-surface.ts:1003) with no file,
class or package attribution. Resolving each name against the Rails manifest:

| TS name | Rails name(s) it is credited against |
| --- | --- |
| `close` | `Rack::BodyProxy#close`, `ActionDispatch::Response#close`, `ActiveSupport::Gzip::Stream#close`, `AbstractAdapter#close` (abstract_adapter.rb) — 20 in all |
| `prepare` | `ActiveRecord::Store::HashAccessor#prepare` (store.rb), `Response#prepare!`, `Reloader#prepare!` |
| `isOpen` | `Transaction#open?` (abstract/transaction.rb, transaction.rb) |
| `open` | `SchemaCache#open` (schema_cache.rb), `MigrationContext#open` (migration.rb), `FixtureSet::File#open`, `UploadedFile#open` |
| `databaseExists` | `AbstractAdapter#database_exists?`, `SQLite3Adapter#database_exists?` |

All five are members of `LibsqlConnection` / the `SqliteDriver` object literals
— the binding to the `libsql` npm client. Ruby binds exactly one SQLite driver
(`gem "sqlite3"`, sqlite3_adapter.rb:14) and the sqlite3 gem's C extension, not
Rails, owns the handle protocol: `new_client` calls `::SQLite3::Database.new`
(sqlite3_adapter.rb:34-35) and then `prepare` / `close` / `closed?` on an object
Rails does not define (sqlite3_adapter.rb:98, 207, 224). `databaseExists` is the
one name Rails does declare, and the port already carries it at its Rails name
on the adapter, one layer above this driver. So none of the five is a misplaced
port with a Rails home to move to — they are bare-short-name coincidences.

## What changed in the comparator

Rather than turning the moved gate off for this file (which would re-open the
`postgresql/schema-statements-class.ts` hole the gate exists to close — ~80
moved names of a genuinely renamed port), a file-level reason may now name,
per name, which of its `moved` scores it claims are coincidental:

    MOVED-BY-SHORT-NAME: close, databaseExists, isOpen, open, prepare.

- A moved name the reason does **not** list still refuses the blanket
  (`moved-names`, unchanged).
- A listed name that stops scoring `moved` is a new hard rejection
  (`stale-moved-declaration`), so the list is only-shrink — it cannot silently
  accumulate, and converging a name forces its deletion.
- Nobody can enumerate 80 names past review, which is what keeps the postgres
  counterexample refuted.

`sqlite/libsql.ts` then takes a file-level `@noRailsEquivalent PERMANENT` reason
naming the Rails `file:line` for each claim, matching the reason its sibling
subclass `connection-adapters/libsql-adapter.ts` already carries. No name is
tagged `CONVERGEABLE`.

## Movement

`pnpm api:extra --package activerecord` (activerecord):

| | before | after |
| --- | --- | --- |
| novel | 574 | **561** (−13) |
| moved | 1388 | **1383** (−5) |
| total | 1962 | 1944 |
| allowed | 83 | 101 |
| files | 260 | 259 |

`pnpm api:extra --package activerecord` exits 0; `pnpm vitest run
scripts/api-compare/extra-surface.test.ts` passes (92 tests, 3 new: the
declaration accepted, a partially-declared file still rejected, a stale
declaration rejected). `pnpm api:calls` OK; `pnpm typecheck` and `pnpm lint`
clean.

Closes-story: resolve-libsql-whole-file-no-counterpart-case
