### PR TITLE
docs(website): guides use the Range class instead of makeRange

### DIFF
--- a/packages/website/docs/guides/activemodel-rails-deviations.md
+++ b/packages/website/docs/guides/activemodel-rails-deviations.md
@@ -118,9 +118,9 @@ The cross-package conventions — [method casing](./index.md#method-casing),
 
 - **`try :foo` → `?.`.** TypeScript's optional chaining replaces Ruby's
   safe-navigation helper.
-- **Range.** Ruby's `Range` becomes a plain `{ begin, end, excludeEnd }`
-  object from `@blazetrails/activesupport`. Relevant to validators like
-  `numericality: { within: makeRange(0, 100) }`.
+- **Range.** Ruby's core `Range` is ported as the `Range` class from
+  `@blazetrails/activesupport`. Relevant to validators like
+  `numericality: { within: new Range(0, 100) }`.
 
 ## Summary
 

--- a/packages/website/docs/guides/activerecord-rails-deviations.md
+++ b/packages/website/docs/guides/activerecord-rails-deviations.md
@@ -242,13 +242,13 @@ but:
   `post.isDraft()` and `post.draft()` (setter without persist) stay
   synchronous.
 
-## 8. Ranges: plain object
+## 8. Ranges: a `Range` class
 
-Ruby's `Range` (`1..10`, `1...10`, `Date.new(..)..Date.new(..)`) has
-no JS equivalent, so ActiveSupport exposes a plain typed object
-`{ begin, end, excludeEnd }` and helper functions. `where({ age:
-makeRange(18, 65) })` lowers to the right SQL via Arel. Rails passes
-real `Range` instances; we pass this struct.
+Ruby's `Range` (`1..10`, `1...10`, `Date.new(..)..Date.new(..)`) is a
+core class with no JS equivalent, so ActiveSupport ports it as a
+`Range` class carrying `begin`, `end` and `excludeEnd`, which Rails'
+`core_ext/range/*` reopenings extend. `where({ age: new Range(18, 65)
+})` lowers to the right SQL via Arel.
 
 See `packages/activesupport/src/range-ext.ts`.
 

--- a/packages/website/docs/guides/idioms.md
+++ b/packages/website/docs/guides/idioms.md
@@ -241,19 +241,19 @@ surfaces when you need runtime-typed access for generic code.
 | `post[:title]`         | `post.readAttribute("title")`         |
 | `post[:title] = "new"` | `post.writeAttribute("title", "new")` |
 
-## Ranges are plain objects
+## Ranges are a class
 
-Ruby `Range` (`1..10`, `1...10`) has no JS equivalent. Use
-`makeRange` from `@blazetrails/activesupport`.
+Ruby `Range` (`1..10`, `1...10`) has no JS equivalent. Use the `Range`
+class from `@blazetrails/activesupport`.
 
 ```ts
-import { makeRange } from "@blazetrails/activesupport";
+import { Range } from "@blazetrails/activesupport";
 
 // Rails:  Post.where(views: 100..1000)
-Post.where({ views: makeRange(100, 1000) });
+Post.where({ views: new Range(100, 1000) });
 
 // Rails:  Post.where(views: 100...1000)   # exclusive end
-Post.where({ views: makeRange(100, 1000, true) });
+Post.where({ views: new Range(100, 1000, true) });
 ```
 
 ## Per-async-flow state instead of thread locals


### PR DESCRIPTION
`Guides Code Type Check` went red on main at bf3b98b0:

```
packages/website/docs/guides/idioms.md:250:10: error TS2305:
Module '"@blazetrails/activesupport"' has no exported member 'makeRange'.
```

#6219 turned `Range` into a class (`activesupport/src/range-ext.ts:31`,
exported from `index.ts:525`) and removed the `makeRange` helper, but the
idioms guide's typechecked snippet still imported it.

The snippet now uses `new Range(100, 1000)` / `new Range(100, 1000, true)`.
Two prose references that still described a plain `{ begin, end, excludeEnd }`
struct — `activerecord-rails-deviations.md` §8 and
`activemodel-rails-deviations.md` — are updated to match.

`pnpm guides:typecheck`: ✓ All 17 code blocks type-check cleanly.

Docs-only.

Closes-story: red-bf3b98b0
