### PR TITLE
refactor(activerecord,activesupport): SQLite tasks use a bare connection; TimeZone[] resolves numeric offsets

### DIFF
--- a/packages/activerecord/src/tasks/sqlite-database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.test.ts
@@ -112,7 +112,14 @@ describe("SQLiteDatabaseTasks", () => {
     );
     await (seedAdapter as unknown as { close(): Promise<void> }).close();
 
-    await new SQLiteDatabaseTasks(sourceConfig).structureDump(dumpPath);
+    // Rails' structure_dump reaches its adapter with a bare
+    // `ActiveRecord::Base.lease_connection` (sqlite_database_tasks.rb:43,68-70),
+    // so the task's db_config has to be the established one before it runs —
+    // which is the caller's job, as it is for `db:schema:dump`
+    // (database_tasks.rb:523-530).
+    await DatabaseTasks.withTemporaryConnection(sourceConfig, async () => {
+      await new SQLiteDatabaseTasks(sourceConfig).structureDump(dumpPath);
+    });
 
     const dumped = fs.readFileSync(dumpPath, "utf8");
     expect(dumped).toMatch(/CREATE TABLE widgets/);
@@ -130,7 +137,9 @@ describe("SQLiteDatabaseTasks", () => {
       database: loadDbPath,
     });
     fs.writeFileSync(loadDbPath, "");
-    await new SQLiteDatabaseTasks(targetConfig).structureLoad(dumpPath);
+    await DatabaseTasks.withTemporaryConnection(targetConfig, async () => {
+      await new SQLiteDatabaseTasks(targetConfig).structureLoad(dumpPath);
+    });
 
     const loadedAdapter = new BetterSQLite3Adapter(loadDbPath);
     try {

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.ts
@@ -127,75 +127,73 @@ export class SQLiteDatabaseTasks {
 
   async structureDump(filename: string, extraFlags?: string | string[] | null): Promise<void> {
     void extraFlags;
-    return this.withOperationAdapter(async (adapter) => {
-      const { SchemaDumper } = await import("../connection-adapters/abstract/schema-dumper.js");
-      const ignoreTables = SchemaDumper.ignoreTables;
+    const adapter = await this.connection();
+    const { SchemaDumper } = await import("../connection-adapters/abstract/schema-dumper.js");
+    const ignoreTables = SchemaDumper.ignoreTables;
 
-      // Order so that dependencies resolve during structure_load: create
-      // tables + views first, then their indexes and triggers (which both
-      // reference those tables). Rails' equivalent orders by `type DESC`
-      // because its CLI path runs through sqlite3's shell which resolves
-      // forward-referenced triggers lazily; when re-executing as a script
-      // through better-sqlite3's `db.exec` the statements are applied
-      // strictly in order, so triggers-before-tables would fail.
-      const typeOrder =
-        "CASE type WHEN 'table' THEN 0 WHEN 'view' THEN 1 " +
-        "WHEN 'index' THEN 2 WHEN 'trigger' THEN 3 ELSE 4 END";
-      // Skip SQLite internals (sqlite_sequence, sqlite_stat*, etc.)
-      // — their names are reserved, so re-emitting their CREATE
-      // statements during structureLoad would fail. Rails' .schema CLI
-      // path filters these implicitly; we replicate that here.
-      let where = "WHERE sql IS NOT NULL AND name NOT LIKE 'sqlite_%'";
-      let binds: unknown[] = [];
+    // Order so that dependencies resolve during structure_load: create
+    // tables + views first, then their indexes and triggers (which both
+    // reference those tables). Rails' equivalent orders by `type DESC`
+    // because its CLI path runs through sqlite3's shell which resolves
+    // forward-referenced triggers lazily; when re-executing as a script
+    // through better-sqlite3's `db.exec` the statements are applied
+    // strictly in order, so triggers-before-tables would fail.
+    const typeOrder =
+      "CASE type WHEN 'table' THEN 0 WHEN 'view' THEN 1 " +
+      "WHEN 'index' THEN 2 WHEN 'trigger' THEN 3 ELSE 4 END";
+    // Skip SQLite internals (sqlite_sequence, sqlite_stat*, etc.)
+    // — their names are reserved, so re-emitting their CREATE
+    // statements during structureLoad would fail. Rails' .schema CLI
+    // path filters these implicitly; we replicate that here.
+    let where = "WHERE sql IS NOT NULL AND name NOT LIKE 'sqlite_%'";
+    let binds: unknown[] = [];
 
-      if (ignoreTables.length > 0) {
-        const tablesRows = await adapter.execute(
-          "SELECT tbl_name FROM sqlite_master WHERE type IN ('table','view','index','trigger')",
-        );
-        const allTables = Array.from(
-          new Set(tablesRows.map((r) => String(r.tbl_name ?? "")).filter(Boolean)),
-        );
-        const excluded = allTables.filter((name) =>
-          ignoreTables.some((pat) => {
-            if (pat instanceof RegExp) {
-              // Reset lastIndex so global/sticky regex patterns don't
-              // produce false negatives across repeated .test() calls.
-              pat.lastIndex = 0;
-              return pat.test(name);
-            }
-            return pat === name;
-          }),
-        );
-        if (excluded.length > 0) {
-          const placeholders = excluded.map(() => "?").join(", ");
-          where += ` AND tbl_name NOT IN (${placeholders})`;
-          binds = excluded;
-        }
+    if (ignoreTables.length > 0) {
+      const tablesRows = await adapter.execute(
+        "SELECT tbl_name FROM sqlite_master WHERE type IN ('table','view','index','trigger')",
+      );
+      const allTables = Array.from(
+        new Set(tablesRows.map((r) => String(r.tbl_name ?? "")).filter(Boolean)),
+      );
+      const excluded = allTables.filter((name) =>
+        ignoreTables.some((pat) => {
+          if (pat instanceof RegExp) {
+            // Reset lastIndex so global/sticky regex patterns don't
+            // produce false negatives across repeated .test() calls.
+            pat.lastIndex = 0;
+            return pat.test(name);
+          }
+          return pat === name;
+        }),
+      );
+      if (excluded.length > 0) {
+        const placeholders = excluded.map(() => "?").join(", ");
+        where += ` AND tbl_name NOT IN (${placeholders})`;
+        binds = excluded;
       }
+    }
 
-      const query = `SELECT sql || ';' AS sql FROM sqlite_master ${where} ORDER BY ${typeOrder}, tbl_name, name`;
-      const rows = await adapter.execute(query, binds);
-      const output = rows.map((r) => String(r.sql ?? "")).join("\n");
-      getFs().writeFileSync(filename, output);
-    });
+    const query = `SELECT sql || ';' AS sql FROM sqlite_master ${where} ORDER BY ${typeOrder}, tbl_name, name`;
+    const rows = await adapter.execute(query, binds);
+    const output = rows.map((r) => String(r.sql ?? "")).join("\n");
+    getFs().writeFileSync(filename, output);
   }
 
   async structureLoad(filename: string, extraFlags?: string | string[] | null): Promise<void> {
     void extraFlags;
     const sql = getFs().readFileSync(filename, "utf8");
-    return this.withOperationAdapter(async (adapter) => {
-      // SQLite's `db.exec` runs an entire script in one shot, so it's safe
-      // for dumps containing trigger bodies (CREATE TRIGGER ... BEGIN ...;
-      // ...; END) where naive semicolon splitting would break.
-      const exec = (adapter as unknown as { exec?: (sql: string) => Promise<void> | void }).exec;
-      if (typeof exec === "function") {
-        await exec.call(adapter, sql);
-      } else {
-        for (const statement of splitSqlStatements(sql)) {
-          await adapter.executeMutation(statement);
-        }
+    const adapter = await this.connection();
+    // SQLite's `db.exec` runs an entire script in one shot, so it's safe
+    // for dumps containing trigger bodies (CREATE TRIGGER ... BEGIN ...;
+    // ...; END) where naive semicolon splitting would break.
+    const exec = (adapter as unknown as { exec?: (sql: string) => Promise<void> | void }).exec;
+    if (typeof exec === "function") {
+      await exec.call(adapter, sql);
+    } else {
+      for (const statement of splitSqlStatements(sql)) {
+        await adapter.executeMutation(statement);
       }
-    });
+    }
   }
 
   /**
@@ -214,39 +212,38 @@ export class SQLiteDatabaseTasks {
    * the PG/MySQL truncateAll implementations provide.
    */
   async truncateAll(): Promise<void> {
-    return this.withOperationAdapter(async (adapter) => {
-      const bookkeeping = metadataTableNames();
-      const rows = (
-        (await adapter.execute(
-          "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'",
-        )) as Array<{ name: string }>
-      ).filter((r) => !bookkeeping.has(r.name));
-      const withFks = adapter as DatabaseAdapter & {
-        disableReferentialIntegrity?: (fn: () => Promise<void>) => Promise<void>;
-      };
-      const run = async () => {
-        for (const row of rows) {
-          await adapter.executeMutation(`DELETE FROM "${row.name.replace(/"/g, '""')}"`);
-        }
-        // Match TRUNCATE/RESTART IDENTITY semantics by clearing the
-        // AUTOINCREMENT counters for the truncated tables. Rails'
-        // SQLite3Adapter#truncate_tables does the same thing.
-        // sqlite_sequence only exists once any AUTOINCREMENT column has
-        // been created — silently skip when it's absent.
-        const hasSequence = (await adapter.execute(
-          "SELECT name FROM sqlite_master WHERE type='table' AND name='sqlite_sequence'",
-        )) as Array<{ name: string }>;
-        if (hasSequence.length > 0 && rows.length > 0) {
-          const list = rows.map((r) => `'${r.name.replace(/'/g, "''")}'`).join(", ");
-          await adapter.executeMutation(`DELETE FROM sqlite_sequence WHERE name IN (${list})`);
-        }
-      };
-      if (typeof withFks.disableReferentialIntegrity === "function") {
-        await withFks.disableReferentialIntegrity(run);
-      } else {
-        await run();
+    const adapter = await this.connection();
+    const bookkeeping = metadataTableNames();
+    const rows = (
+      (await adapter.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'",
+      )) as Array<{ name: string }>
+    ).filter((r) => !bookkeeping.has(r.name));
+    const withFks = adapter as DatabaseAdapter & {
+      disableReferentialIntegrity?: (fn: () => Promise<void>) => Promise<void>;
+    };
+    const run = async () => {
+      for (const row of rows) {
+        await adapter.executeMutation(`DELETE FROM "${row.name.replace(/"/g, '""')}"`);
       }
-    });
+      // Match TRUNCATE/RESTART IDENTITY semantics by clearing the
+      // AUTOINCREMENT counters for the truncated tables. Rails'
+      // SQLite3Adapter#truncate_tables does the same thing.
+      // sqlite_sequence only exists once any AUTOINCREMENT column has
+      // been created — silently skip when it's absent.
+      const hasSequence = (await adapter.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='sqlite_sequence'",
+      )) as Array<{ name: string }>;
+      if (hasSequence.length > 0 && rows.length > 0) {
+        const list = rows.map((r) => `'${r.name.replace(/'/g, "''")}'`).join(", ");
+        await adapter.executeMutation(`DELETE FROM sqlite_sequence WHERE name IN (${list})`);
+      }
+    };
+    if (typeof withFks.disableReferentialIntegrity === "function") {
+      await withFks.disableReferentialIntegrity(run);
+    } else {
+      await run();
+    }
   }
 
   private resolveDbPath(): string {
@@ -262,25 +259,6 @@ export class SQLiteDatabaseTasks {
 
   private async connection(): Promise<DatabaseAdapter> {
     return Base.connectionPool().leaseConnection();
-  }
-
-  /**
-   * Run `fn` against a pool-leased connection scoped to this task's db_config,
-   * through Rails' own `DatabaseTasks.with_temporary_connection`
-   * (`tasks/database_tasks.rb:523-530`), which restores the prior connection on
-   * the way out. Rails' `structure_dump` / `structure_load`
-   * (`sqlite_database_tasks.rb:43-58,60-66`) reach the adapter with bare
-   * `connection` because their db_config is already the established one; trails
-   * runs both through the adapter for configs that may not be, so the scoped
-   * helper is what keeps `Base` unmoved either way.
-   *
-   * In-memory databases are the exception: a second pool on `:memory:` opens an
-   * unrelated empty database, so those reuse the caller's already-leased
-   * connection (`connection`, `sqlite_database_tasks.rb:68-70`).
-   */
-  private async withOperationAdapter<T>(fn: (adapter: DatabaseAdapter) => Promise<T>): Promise<T> {
-    if (isInMemoryDatabase(this.resolveDbPath())) return fn(await this.connection());
-    return DatabaseTasks.withTemporaryConnection(this.dbConfig, fn);
   }
 
   /** @internal */

--- a/packages/activesupport/src/core-ext/time-with-zone.test.ts
+++ b/packages/activesupport/src/core-ext/time-with-zone.test.ts
@@ -1228,6 +1228,8 @@ describe("TimeWithZoneMethodsForTimeAndDateTimeTest", () => {
     expect(getZone()!.name).toBe("Alaska");
     setZone("Alaska");
     expect(getZone()!.name).toBe("Alaska");
+    setZone(Duration.hours(-9));
+    expect(getZone()!.name).toBe("Alaska");
     setZone(null);
     expect(getZone()).toBeNull();
   });
@@ -1276,18 +1278,22 @@ describe("TimeWithZoneMethodsForTimeAndDateTimeTest", () => {
 
   it("time zone setter with invalid zone", () => {
     expect(() => setZone("No such timezone exists")).toThrow();
+    expect(() => setZone(Duration.hours(-15))).toThrow();
+    expect(() => setZone({} as unknown as string)).toThrow();
   });
 
   it("find zone without bang returns nil if time zone can not be found", () => {
     expect(findZone("No such timezone exists")).toBeNull();
-    expect(findZone(-54000)).toBeNull();
+    expect(findZone(Duration.hours(-15))).toBeNull();
     expect(findZone({})).toBeNull();
   });
 
   it("find zone with bang raises if time zone can not be found", () => {
-    expect(() => findZoneBang("No such timezone exists")).toThrow(/Invalid time zone/);
-    expect(() => findZoneBang(-54000)).toThrow(/Invalid time zone/);
-    expect(() => findZoneBang({})).toThrow(/Invalid time zone/);
+    expect(() => findZoneBang("No such timezone exists")).toThrow(
+      "Invalid Timezone: No such timezone exists",
+    );
+    expect(() => findZoneBang(Duration.hours(-15))).toThrow("Invalid Timezone: -54000");
+    expect(() => findZoneBang({})).toThrow(/invalid argument to TimeZone\[\]/);
   });
 
   it("find zone with bang doesnt raises with nil and false", () => {

--- a/packages/activesupport/src/time-zone-config.ts
+++ b/packages/activesupport/src/time-zone-config.ts
@@ -103,17 +103,26 @@ export function findZone(zone: unknown): TimeZone | null | false {
 }
 
 /**
- * Find a timezone, raising if not found.
- * Matches Rails' Time.find_zone!
+ * `Time.find_zone!` (core_ext/time/zones.rb:80-90): `return time_zone unless
+ * time_zone`, then `ActiveSupport::TimeZone[time_zone] || raise(ArgumentError,
+ * "Invalid Timezone: #{time_zone}")`. The whole argument dispatch — including
+ * the Numeric/Duration offset scan — lives in `TimeZone.find`, the port of
+ * `[]` (time_zone.rb:232-250).
+ *
+ * Deviation: `[]` returns `nil` for a name or offset it cannot match and
+ * raises only for an argument of the wrong class (time_zone.rb:249), while
+ * trails' `find` throws in both cases. The argument-class arm therefore stays
+ * here, so each of Rails' two messages is still raised for its own case.
  */
 export function findZoneBang(zone: unknown): TimeZone | null | false {
   if (zone === null || zone === undefined) return null;
   if (zone === false) return false;
-  if (zone instanceof TimeZone) return zone;
-  // `ActiveSupport::TimeZone[time_zone] || raise(ArgumentError, "Invalid
-  // Timezone: #{time_zone}")` (zones.rb:83). A Numeric/Duration offset is
-  // resolved by `TimeZone[]` itself (time_zone.rb:244-246), not here.
-  if (typeof zone === "string" || typeof zone === "number" || zone instanceof Duration) {
+  if (
+    typeof zone === "string" ||
+    typeof zone === "number" ||
+    zone instanceof Duration ||
+    zone instanceof TimeZone
+  ) {
     try {
       return TimeZone.find(zone);
     } catch {

--- a/packages/activesupport/src/time-zone-config.ts
+++ b/packages/activesupport/src/time-zone-config.ts
@@ -7,6 +7,7 @@
  */
 
 import { TimeZone } from "./values/time-zone.js";
+import { Duration } from "./duration.js";
 import { TimeWithZone } from "./time-with-zone.js";
 import { currentTime } from "./time-travel.js";
 import { instantFrom } from "./temporal.js";
@@ -34,7 +35,7 @@ export function getZone(): TimeZone | null {
  * Mirrors `IsolatedExecutionState[:time_zone] = find_zone!(time_zone)`
  * (zones.rb:41-43).
  */
-export function setZone(zone: TimeZone | string | null | false): void {
+export function setZone(zone: TimeZone | string | number | Duration | null | false): void {
   _zone = findZoneBang(zone);
 }
 
@@ -109,21 +110,17 @@ export function findZoneBang(zone: unknown): TimeZone | null | false {
   if (zone === null || zone === undefined) return null;
   if (zone === false) return false;
   if (zone instanceof TimeZone) return zone;
-  if (typeof zone === "string") {
+  // `ActiveSupport::TimeZone[time_zone] || raise(ArgumentError, "Invalid
+  // Timezone: #{time_zone}")` (zones.rb:83). A Numeric/Duration offset is
+  // resolved by `TimeZone[]` itself (time_zone.rb:244-246), not here.
+  if (typeof zone === "string" || typeof zone === "number" || zone instanceof Duration) {
     try {
       return TimeZone.find(zone);
     } catch {
-      throw new ArgumentError(`Invalid time zone: ${zone}`);
+      throw new ArgumentError(`Invalid Timezone: ${String(zone)}`);
     }
   }
-  if (typeof zone === "number") {
-    try {
-      return TimeZone.find(zone.toString());
-    } catch {
-      throw new ArgumentError(`Invalid time zone: ${zone}`);
-    }
-  }
-  throw new ArgumentError(`Invalid time zone: invalid argument to TimeZone[]`);
+  throw new ArgumentError(`invalid argument to TimeZone[]: ${String(zone)}`);
 }
 
 /**

--- a/packages/activesupport/src/time-zone.test.ts
+++ b/packages/activesupport/src/time-zone.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { TimeZone } from "./values/time-zone.js";
+import { Duration } from "./duration.js";
 import { TimeWithZone } from "./time-with-zone.js";
 import { instantFromDate } from "./testing/temporal-helpers.js";
 
@@ -53,19 +54,11 @@ describe("TimeZoneTest", () => {
   // mapping
   // ---------------------------------------------------------------------------
   it("from integer to map", () => {
-    const eastern = TimeZone.find("Eastern Time (US & Canada)");
-    const offset = eastern.utcOffset;
-    const zones = TimeZone.all().filter((z) => z.utcOffset === offset);
-    expect(zones.length).toBeGreaterThan(0);
-    expect(zones.some((z) => z.name === "Eastern Time (US & Canada)")).toBe(true);
+    expect(TimeZone.find(-28800)).toBeInstanceOf(TimeZone); // PST
   });
 
   it("from duration to map", () => {
-    const eastern = TimeZone.find("Eastern Time (US & Canada)");
-    const offset = eastern.utcOffset;
-    expect(offset).toBeLessThan(0);
-    const zones = TimeZone.all().filter((z) => z.utcOffset === offset);
-    expect(zones.length).toBeGreaterThan(0);
+    expect(TimeZone.find(Duration.minutes(-480))).toBeInstanceOf(TimeZone); // PST
   });
 
   it("from tzinfo to map", () => {
@@ -687,6 +680,14 @@ describe("TimeZoneTest", () => {
 
   it("all sorted", () => {
     const zones = TimeZone.all();
+    for (let i = 1; i < zones.length; i++) {
+      const previous = zones[i - 1];
+      const current = zones[i];
+      expect(
+        previous.utcOffset < current.utcOffset ||
+          (previous.utcOffset === current.utcOffset && previous.name < current.name),
+      ).toBe(true);
+    }
     expect(zones.length).toBeGreaterThan(100);
     // Verify we get a reasonable set of zones
     expect(zones.some((z) => z.name === "UTC")).toBe(true);

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -170,7 +170,7 @@ const MAPPING: Record<string, string> = {
 };
 
 const zoneCache = new Map<string, TimeZone>();
-// `@zones` (time_zone.rb:224) — memoizes the sorted zone list.
+/** `@zones` (time_zone.rb:224). */
 let zones: TimeZone[] | null = null;
 
 /**
@@ -285,17 +285,19 @@ export class TimeZone {
   }
 
   /**
-   * Find a timezone by Rails name or IANA identifier, or by a `Numeric` /
-   * `Duration` UTC offset — the port of `ActiveSupport::TimeZone.[]`
-   * (values/time_zone.rb:232-250). Ruby's `[]` returns `nil` where this throws;
-   * `findZoneBang` is the raise site that converts (core_ext/time/zones.rb:83).
+   * The port of `ActiveSupport::TimeZone.[]` (time_zone.rb:232-250): a Rails
+   * name or IANA identifier, a `TimeZone`, or a `Numeric`/`Duration` UTC
+   * offset. Ruby's `[]` returns `nil` where every arm here throws — `[]` is
+   * only ever called from a raise site (`findZoneBang`, zones.rb:83), and
+   * making it nullable would rewrite ~60 unrelated call sites.
+   *
+   * A `Duration` argument reads its seconds through `inSeconds()`, standing in
+   * for Ruby's `arg.abs` / `arg.to_i` delegating to `@value` — trails' Duration
+   * derives totals from `parts` and carries no `@value`.
    */
-  static find(name: string | number | Duration): TimeZone {
-    // `when Numeric, ActiveSupport::Duration` (time_zone.rb:244-246): an offset
-    // of 13 or less is hours, anything larger is already seconds.
+  static find(name: string | number | Duration | TimeZone): TimeZone {
+    if (name instanceof TimeZone) return name;
     if (typeof name === "number" || name instanceof Duration) {
-      // `arg.abs` / `arg.to_i` on a Duration delegate to its seconds value
-      // (`inSeconds` here — trails' Duration carries no `@value`).
       let arg = name instanceof Duration ? name.inSeconds() : name;
       if (Math.abs(arg) <= 13) arg *= 3600;
       const zone = TimeZone.all().find((z) => z.utcOffset === Math.trunc(arg));
@@ -328,11 +330,12 @@ export class TimeZone {
     return TimeZone.find(name);
   }
 
-  /** Returns all Rails-named timezones */
+  /**
+   * Every Rails-named timezone: `@zones ||= zones_map.values.sort`
+   * (time_zone.rb:223-225), sorted by `<=>` — utc_offset, then name
+   * (time_zone.rb:333-337).
+   */
   static all(): TimeZone[] {
-    // `zones_map.values.sort` (time_zone.rb:224) — `<=>` (time_zone.rb:333-337)
-    // orders by utc_offset, then by name. `[]`'s Numeric arm takes the first
-    // zone at the requested offset, so the order is behavioral.
     if (zones) return zones;
     zones = Object.keys(MAPPING)
       .map((name) => TimeZone.find(name))
@@ -687,10 +690,11 @@ export class TimeZone {
   }
 
   /**
-   * `tzinfo.current_period.base_utc_offset` (time_zone.rb:317-319) — the
-   * standard-time offset, so it does not move when DST is in effect. Intl
-   * reports the offset *at* an instant, so the standard offset is the smaller
-   * of the January and July offsets (the same derivation `isDst` uses).
+   * `@utc_offset || tzinfo.current_period.base_utc_offset`
+   * (time_zone.rb:317-319) — the standard-time offset, which does not move
+   * when DST is in effect. Intl only reports the offset *at* an instant, so
+   * the standard offset is the smaller of the January and July offsets (the
+   * derivation `isDst` already uses).
    */
   get utcOffset(): number {
     const now = new Date();

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -10,6 +10,7 @@
  */
 
 import { TimeWithZone } from "../time-with-zone.js";
+import { Duration } from "../duration.js";
 import { Temporal } from "@blazetrails/date";
 import { instantFrom } from "../temporal.js";
 import { currentTime } from "../time-travel.js";
@@ -169,6 +170,8 @@ const MAPPING: Record<string, string> = {
 };
 
 const zoneCache = new Map<string, TimeZone>();
+// `@zones` (time_zone.rb:224) — memoizes the sorted zone list.
+let zones: TimeZone[] | null = null;
 
 /**
  * Get timezone abbreviation and offset for a given IANA zone at a specific instant.
@@ -282,9 +285,23 @@ export class TimeZone {
   }
 
   /**
-   * Find a timezone by Rails name or IANA identifier.
+   * Find a timezone by Rails name or IANA identifier, or by a `Numeric` /
+   * `Duration` UTC offset — the port of `ActiveSupport::TimeZone.[]`
+   * (values/time_zone.rb:232-250). Ruby's `[]` returns `nil` where this throws;
+   * `findZoneBang` is the raise site that converts (core_ext/time/zones.rb:83).
    */
-  static find(name: string): TimeZone {
+  static find(name: string | number | Duration): TimeZone {
+    // `when Numeric, ActiveSupport::Duration` (time_zone.rb:244-246): an offset
+    // of 13 or less is hours, anything larger is already seconds.
+    if (typeof name === "number" || name instanceof Duration) {
+      // `arg.abs` / `arg.to_i` on a Duration delegate to its seconds value
+      // (`inSeconds` here — trails' Duration carries no `@value`).
+      let arg = name instanceof Duration ? name.inSeconds() : name;
+      if (Math.abs(arg) <= 13) arg *= 3600;
+      const zone = TimeZone.all().find((z) => z.utcOffset === Math.trunc(arg));
+      if (zone) return zone;
+      throw new Error(`Invalid time zone: ${String(name)}`);
+    }
     if (zoneCache.has(name)) return zoneCache.get(name)!;
 
     // Check Rails mapping first
@@ -313,7 +330,16 @@ export class TimeZone {
 
   /** Returns all Rails-named timezones */
   static all(): TimeZone[] {
-    return Object.keys(MAPPING).map((name) => TimeZone.find(name));
+    // `zones_map.values.sort` (time_zone.rb:224) — `<=>` (time_zone.rb:333-337)
+    // orders by utc_offset, then by name. `[]`'s Numeric arm takes the first
+    // zone at the requested offset, so the order is behavioral.
+    if (zones) return zones;
+    zones = Object.keys(MAPPING)
+      .map((name) => TimeZone.find(name))
+      .sort(
+        (a, b) => a.utcOffset - b.utcOffset || (a.name < b.name ? -1 : a.name > b.name ? 1 : 0),
+      );
+    return zones;
   }
 
   /**
@@ -661,10 +687,16 @@ export class TimeZone {
   }
 
   /**
-   * UTC offset in seconds for the current moment.
+   * `tzinfo.current_period.base_utc_offset` (time_zone.rb:317-319) — the
+   * standard-time offset, so it does not move when DST is in effect. Intl
+   * reports the offset *at* an instant, so the standard offset is the smaller
+   * of the January and July offsets (the same derivation `isDst` uses).
    */
   get utcOffset(): number {
-    return getZoneInfo(this.tzinfo, new Date()).utcOffsetSeconds;
+    const now = new Date();
+    const jan = getZoneInfo(this.tzinfo, new Date(now.getFullYear(), 0, 1)).utcOffsetSeconds;
+    const jul = getZoneInfo(this.tzinfo, new Date(now.getFullYear(), 6, 1)).utcOffsetSeconds;
+    return Math.min(jan, jul);
   }
 
   /**


### PR DESCRIPTION
Two fidelity convergences.

## 1. `SQLiteDatabaseTasks#withOperationAdapter` retired

Rails' `structure_dump` / `structure_load` / `truncate_tables` reach their
adapter with a bare `ActiveRecord::Base.lease_connection`
(`tasks/sqlite_database_tasks.rb:43,60,68-70`) — no branch, no temporary pool.
The helper (added by #6213, itself a collapse of three worse ones) existed
because a call site's `db_config` might not be the established one, and because
`:memory:` names a fresh empty database on every open.

All three call sites now use `connection()`, matching Rails and the PG/MySQL
task classes (`postgresql-database-tasks.ts:47`, `mysql-database-tasks.ts:153`).
The `:memory:` branch disappears with the helper: a bare lease *is* the
in-memory-safe path, so the `sqlite3_mem` lane needs no arm of its own.

**Caller audit.** The registry entries construct `new SQLiteDatabaseTasks(config)`
per call, so the only gap is a caller invoking a task method without having
established that config. The single one left was the `structure_dump` /
`structure_load` round-trip test; it now wraps itself in Rails' own
`DatabaseTasks.withTemporaryConnection` (`database_tasks.rb:523-530`) — fixed at
the caller, not worked around in the task class. `trailties`' `truncateAll`
callers already establish (`commands/db.ts:699`, and #6213 fixed the test).

## 2. `find_zone!`'s numeric arm scans utc_offset

Rails routes a Numeric/Duration offset through `ActiveSupport::TimeZone[]`
(`values/time_zone.rb:244-246`):

```ruby
when Numeric, ActiveSupport::Duration
  arg *= 3600 if arg.abs <= 13
  all.find { |z| z.utc_offset == arg.to_i }
```

`findZoneBang` instead stringified the number and looked the offset up as a zone
*name*, so `Time.zone = -5` — the example `zones.rb:23` documents — raised where
Rails resolves Eastern. The arm moves to `TimeZone.find`, the port of `[]`, and
`findZoneBang` delegates as `zones.rb:83` does.

Two divergences the arm depends on converge with it:

- **`all()` is sorted and memoized** — `zones_map.values.sort` (`:224`) with
  `<=>` ordering by utc_offset then name (`:333-337`), memoized as `@zones`.
  `[]` returns the *first* zone at the requested offset, so the order is
  behavioral: unsorted, `-5.hours` picked Eastern where Rails picks Bogota.
- **`utcOffset` is the standard-time offset** —
  `tzinfo.current_period.base_utc_offset` (`:317-319`), not the offset at the
  current instant. The old getter moved under DST, which made `Time.zone = -9`
  resolve Alaska in January and raise in July.

Raise sites keep Rails' messages verbatim: `Invalid Timezone: #{time_zone}`
(`zones.rb:88`) and `invalid argument to TimeZone[]` (`time_zone.rb:249`).

## Tests

`time_zone_test.rb`'s `test_from_integer_to_map` / `test_from_duration_to_map`
were placeholders filtering `all()` by hand; they now assert what Rails asserts
(`TimeZone[-28800]`, `TimeZone[-480.minutes]`). `test_all_sorted` gained the
ordering loop Rails has, and `test_time_zone_getter_and_setter`,
`test_time_zone_setter_with_invalid_zone` and
`test_find_zone_with_bang_raises_if_time_zone_can_not_be_found` gained their
missing `-9.hours` / `-15.hours` / `Object.new` arms and exact messages. Each
fails on the baseline.

Green locally: `time-zone.test.ts`, `core-ext/time-with-zone.test.ts`,
`time-with-zone.{test,trails.test}.ts`, `time-ext`, `core-ext/{time,date,date-time,range}-ext`,
`json/encoding`, `i18n`, `message-pack/serializer`, `time-zone-converter`,
`type/date-time`, `sqlite-database-tasks.test.ts`, `database-tasks.test.ts`,
`database-tasks-truncate-tables.trails.test.ts`,
`trailties/src/commands/db.test.ts`. `api:calls` OK, `api:extra` adds no novel
surface, typecheck + eslint clean.

Closes-story: retire-sqlite-tasks-with-operation-adapter
Closes-story: find-zone-bang-numeric-arm-scans-utc-offset
