### PR TITLE
fix(activerecord,activesupport): run_cmd redirects the child's stdout to the output file

### DIFF
--- a/packages/activerecord/src/tasks/sqlite-database-tasks-run-cmd.trails.test.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks-run-cmd.trails.test.ts
@@ -5,11 +5,6 @@ import * as path from "node:path";
 import { randomUUID } from "node:crypto";
 import { runCmd } from "./sqlite-database-tasks.js";
 
-// Trails-only coverage for `run_cmd`'s output redirect
-// (vendor/rails/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb:72-74:
-// `Kernel.system(cmd, *args, out: out)`). Rails hands the child an fd, so the
-// bytes it writes reach the file untouched; a decode/re-encode through a
-// JS string replaces anything that is not valid UTF-8 with U+FFFD.
 describe("SQLiteDatabaseTasks run_cmd output redirect", () => {
   const created: string[] = [];
 

--- a/packages/activerecord/src/tasks/sqlite-database-tasks-run-cmd.trails.test.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks-run-cmd.trails.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { randomUUID } from "node:crypto";
+import { runCmd } from "./sqlite-database-tasks.js";
+
+// Trails-only coverage for `run_cmd`'s output redirect
+// (vendor/rails/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb:72-74:
+// `Kernel.system(cmd, *args, out: out)`). Rails hands the child an fd, so the
+// bytes it writes reach the file untouched; a decode/re-encode through a
+// JS string replaces anything that is not valid UTF-8 with U+FFFD.
+describe("SQLiteDatabaseTasks run_cmd output redirect", () => {
+  const created: string[] = [];
+
+  afterEach(() => {
+    for (const file of created) {
+      try {
+        fs.unlinkSync(file);
+      } catch {
+        // ignore
+      }
+    }
+    created.length = 0;
+  });
+
+  function tmpOutPath(): string {
+    const out = path.join(os.tmpdir(), `trails-run-cmd-${process.pid}-${randomUUID()}.out`);
+    created.push(out);
+    return out;
+  }
+
+  it("writes the child's stdout bytes verbatim", async () => {
+    const out = tmpOutPath();
+    await runCmd("printf", ["\\377\\n"], out);
+    expect(Array.from(fs.readFileSync(out))).toEqual([0xff, 0x0a]);
+  });
+
+  it("truncates an existing output file", async () => {
+    const out = tmpOutPath();
+    fs.writeFileSync(out, "stale contents that are longer than the new output");
+    await runCmd("printf", ["ok"], out);
+    expect(fs.readFileSync(out, "utf8")).toBe("ok");
+  });
+
+  it("raises with the failed command and its stderr", async () => {
+    const out = tmpOutPath();
+    await expect(runCmd("sh", ["-c", "echo boom 1>&2; exit 3"], out)).rejects.toThrow(
+      /failed to execute:\nsh -c[\s\S]*Exit status: 3[\s\S]*stderr:\nboom/,
+    );
+  });
+});

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.ts
@@ -371,7 +371,10 @@ function splitSqlStatements(sql: string): string[] {
 /** @internal */
 export async function runCmd(cmd: string, args: string[], out: string): Promise<void> {
   const childProcess = await getChildProcessAsync();
-  const result: SpawnSyncResult = childProcess.spawnSync(cmd, args, { encoding: "utf8" });
+  // `out` redirects the child's stdout at the fd level, matching
+  // `Kernel.system(cmd, *args, out: out)` — the bytes sqlite3 writes land in
+  // the file verbatim rather than round-tripping through a decoded string.
+  const result: SpawnSyncResult = childProcess.spawnSync(cmd, args, { encoding: "utf8", out });
   if (result.error || result.status !== 0 || result.signal) {
     const details: string[] = [];
     if (result.error) details.push(`Error: ${result.error.message}`);
@@ -382,7 +385,6 @@ export async function runCmd(cmd: string, args: string[], out: string): Promise<
     if (result.stdout) details.push(`stdout:\n${String(result.stdout).trimEnd()}`);
     throw new Error(runCmdError(cmd, args) + (details.length ? details.join("\n") + "\n" : ""));
   }
-  getFs().writeFileSync(out, result.stdout ?? "");
 }
 
 /** @internal */

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.ts
@@ -371,9 +371,6 @@ function splitSqlStatements(sql: string): string[] {
 /** @internal */
 export async function runCmd(cmd: string, args: string[], out: string): Promise<void> {
   const childProcess = await getChildProcessAsync();
-  // `out` redirects the child's stdout at the fd level, matching
-  // `Kernel.system(cmd, *args, out: out)` — the bytes sqlite3 writes land in
-  // the file verbatim rather than round-tripping through a decoded string.
   const result: SpawnSyncResult = childProcess.spawnSync(cmd, args, { encoding: "utf8", out });
   if (result.error || result.status !== 0 || result.signal) {
     const details: string[] = [];

--- a/packages/activesupport/src/child-process-adapter.ts
+++ b/packages/activesupport/src/child-process-adapter.ts
@@ -7,6 +7,7 @@
  */
 
 import { env as processEnv } from "./process-adapter.js";
+import { getFs } from "./fs-adapter.js";
 
 export interface SpawnSyncOptions {
   input?: string | Uint8Array;
@@ -18,6 +19,13 @@ export interface SpawnSyncOptions {
    */
   encoding?: "utf8" | "utf-8";
   cwd?: string;
+  /**
+   * Path to redirect the child's stdout to, mirroring Ruby's
+   * `Kernel.system(cmd, *args, out: path)`. The child writes to the file
+   * descriptor directly, so its bytes land in the file untouched (no decode /
+   * re-encode) and are not buffered in memory. `stdout` comes back empty.
+   */
+  out?: string;
 }
 
 export interface SpawnSyncResult {
@@ -62,15 +70,22 @@ type NodeChildProcess = {
 function wrap(cp: NodeChildProcess): ChildProcessAdapter {
   return {
     spawnSync(cmd, args, options) {
-      const result = cp.spawnSync(cmd, args, {
-        input: options?.input,
-        // Default to the trailties-managed env (from process-adapter), not
-        // the host's ambient process.env, so child processes see the
-        // env trailties controls. Explicit `env` still wins.
-        env: options?.env ?? ({ ...processEnv } as NodeJS.ProcessEnv),
-        encoding: options?.encoding ?? "utf8",
-        cwd: options?.cwd,
-      });
+      const outFd = options?.out != null ? getFs().openSync(options.out, "w") : null;
+      let result: NodeSpawnSyncResult;
+      try {
+        result = cp.spawnSync(cmd, args, {
+          input: options?.input,
+          // Default to the trailties-managed env (from process-adapter), not
+          // the host's ambient process.env, so child processes see the
+          // env trailties controls. Explicit `env` still wins.
+          env: options?.env ?? ({ ...processEnv } as NodeJS.ProcessEnv),
+          encoding: options?.encoding ?? "utf8",
+          cwd: options?.cwd,
+          ...(outFd !== null ? { stdio: ["pipe", outFd, "pipe"] } : {}),
+        });
+      } finally {
+        if (outFd !== null) getFs().closeSync(outFd);
+      }
       return {
         status: result.status,
         signal: result.signal,


### PR DESCRIPTION
`run_cmd` in `sqlite_database_tasks.rb:72-74` is
`fail run_cmd_error(cmd, args) unless Kernel.system(cmd, *args, out: out)` —
Ruby redirects the child's stdout to the file at the OS level, so the bytes
`sqlite3` writes land in the file untouched.

trails captured stdout as a decoded UTF-8 string and then wrote it, so a dump
containing bytes that are not valid UTF-8 round-tripped through U+FFFD, and the
whole dump was buffered in memory against `maxBuffer`.

- `SpawnSyncOptions` (`activesupport/src/child-process-adapter.ts`) gains an
  `out` path; the node adapter opens it through the fs adapter and maps it onto
  `spawnSync`'s `stdio: ["pipe", fd, "pipe"]`, closing the fd in a `finally`.
- `runCmd` passes `out` through instead of `writeFileSync`-ing the captured
  string. The error path (`failed to execute:` plus exit status / signal /
  stderr) is unchanged — stderr is still piped and captured.

Regression test (`sqlite-database-tasks-run-cmd.trails.test.ts`) asserts the
child's bytes reach the file verbatim; it fails on baseline (`EF BF BD 0A`
instead of `FF 0A`).

The second story in this bundle,
`move-adapter-specific-snapshot-off-ar-internal-metadata`, was **released
unbuilt, not included here**: its own findings section states it must be its own
PR (the `loadSchema` / `canonical-schema-stamp` / `test-setup-dy` seam is
reshaped one story at a time) and that the remaining arm is larger than the
bundle's LOC ceiling.

Closes-story: run-cmd-redirects-stdout-instead-of-buffering
