### PR TITLE
feat(api-compare,activesupport): moved extras carry their Rails owner; TimeZone[] returns nil

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/array.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/array.test.ts
@@ -508,7 +508,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
     it("datetime with timezone awareness", async () => {
       const tz = "Pacific Time (US & Canada)";
-      const zone = TimeZone.find(tz);
+      const zone = TimeZone.find(tz)!;
       setZone(tz);
       try {
         class PgArrays extends Base {

--- a/packages/activerecord/src/adapters/postgresql/range.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/range.test.ts
@@ -461,7 +461,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
     it("timezone awareness tzrange", async () => {
       const tz = "Pacific Time (US & Canada)";
-      const zone = TimeZone.find(tz);
+      const zone = TimeZone.find(tz)!;
       setZone(tz);
       const timeString = "2020-06-15T10:00:00-07:00";
       const instant = Temporal.Instant.from(timeString);
@@ -485,7 +485,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
     it("timezone awareness endless tzrange", async () => {
       const tz = "Pacific Time (US & Canada)";
-      const zone = TimeZone.find(tz);
+      const zone = TimeZone.find(tz)!;
       setZone(tz);
       const timeString = "2020-06-15T10:00:00-07:00";
       const instant = Temporal.Instant.from(timeString);
@@ -511,7 +511,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
     it("timezone awareness beginless tzrange", async () => {
       const tz = "Pacific Time (US & Canada)";
-      const zone = TimeZone.find(tz);
+      const zone = TimeZone.find(tz)!;
       setZone(tz);
       const timeString = "2020-06-15T10:00:00-07:00";
       const instant = Temporal.Instant.from(timeString);
@@ -533,7 +533,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
     it("timezone array awareness tzrange", async () => {
       const tz = "Pacific Time (US & Canada)";
-      const zone = TimeZone.find(tz);
+      const zone = TimeZone.find(tz)!;
       setZone(tz);
 
       const fromStr = "2020-06-15T10:00:00-07:00";
@@ -692,7 +692,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
     it("timezone awareness tsrange", async () => {
       const tz = "Pacific Time (US & Canada)";
-      const zone = TimeZone.find(tz);
+      const zone = TimeZone.find(tz)!;
       setZone(tz);
       const timeString = "2020-06-15T10:00:00-07:00";
       const instant = Temporal.Instant.from(timeString);
@@ -716,7 +716,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
     it("timezone awareness endless tsrange", async () => {
       const tz = "Pacific Time (US & Canada)";
-      const zone = TimeZone.find(tz);
+      const zone = TimeZone.find(tz)!;
       setZone(tz);
       const timeString = "2020-06-15T10:00:00-07:00";
       const instant = Temporal.Instant.from(timeString);
@@ -742,7 +742,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
     it("timezone awareness beginless tsrange", async () => {
       const tz = "Pacific Time (US & Canada)";
-      const zone = TimeZone.find(tz);
+      const zone = TimeZone.find(tz)!;
       setZone(tz);
       const timeString = "2020-06-15T10:00:00-07:00";
       const instant = Temporal.Instant.from(timeString);
@@ -764,7 +764,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
     it("timezone array awareness tsrange", async () => {
       const tz = "Pacific Time (US & Canada)";
-      const zone = TimeZone.find(tz);
+      const zone = TimeZone.find(tz)!;
       setZone(tz);
 
       const fromStr = "2020-06-15T10:00:00-07:00";
@@ -854,7 +854,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       // Rails: time_string = "2017-09-26 07:30:59.132451 -0700"; assert time.usec > 0
       // Verifies sub-millisecond (µs) precision is preserved through the PG round-trip.
       const tz = "Pacific Time (US & Canada)";
-      const zone = TimeZone.find(tz);
+      const zone = TimeZone.find(tz)!;
       setZone(tz);
       const timeString = "2017-09-26T07:30:59.132451-07:00";
       const instant = Temporal.Instant.from(timeString);

--- a/packages/activerecord/src/attribute-methods.test.ts
+++ b/packages/activerecord/src/attribute-methods.test.ts
@@ -937,7 +937,7 @@ describe("AttributeMethodsTest", () => {
 
   it("setting time zone-aware attribute in other time zone", async () => {
     const utcTime = Temporal.Instant.from("2008-01-01T00:00:00Z");
-    const cstTime = new TimeWithZone(utcTime, TimeZone.find("Central Time (US & Canada)"));
+    const cstTime = new TimeWithZone(utcTime, TimeZone.find("Central Time (US & Canada)")!);
     await inTimeZone("Pacific Time (US & Canada)", () => {
       class Topic extends Base {
         static {

--- a/packages/activerecord/src/attribute-methods/time-zone-converter.test.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-converter.test.ts
@@ -55,8 +55,8 @@ describe("TimeZoneConverterTest", () => {
   });
 
   it("cast moves existing TimeWithZone to current zone", () => {
-    const pacific = TimeZone.find("Pacific Time (US & Canada)");
-    const eastern = TimeZone.find("Eastern Time (US & Canada)");
+    const pacific = TimeZone.find("Pacific Time (US & Canada)")!;
+    const eastern = TimeZone.find("Eastern Time (US & Canada)")!;
     const instant = Temporal.Instant.from("2024-06-15T14:00:00Z");
     const pacificTime = new TimeWithZone(instant, pacific);
 
@@ -129,7 +129,7 @@ describe("TimeZoneConverterTest", () => {
     setZone("Eastern Time (US & Canada)");
     const converter = new TimeZoneConverter(new DateTime());
     const instant = Temporal.Instant.from("2024-06-15T14:00:00Z");
-    const eastern = TimeZone.find("Eastern Time (US & Canada)");
+    const eastern = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = new TimeWithZone(instant, eastern);
     // 14:00 UTC displayed as 10:00 EDT; serialize (value_for_database) returns the
     // cast UTC Temporal.Instant — the adapter renders the SQL literal downstream.

--- a/packages/activerecord/src/sqlite/libsql.ts
+++ b/packages/activerecord/src/sqlite/libsql.ts
@@ -10,8 +10,8 @@
  * and no name it declares has a Rails method to converge onto. Its sibling
  * subclass `connection-adapters/libsql-adapter.ts` carries the same reason.
  * MOVED-BY-SHORT-NAME: close, databaseExists, isOpen, open, prepare. Those
- * five score `moved` only because the oracle is one global set of bare
- * camelized Ruby names with no owner attached: `close` resolves to
+ * five score `moved` only because the oracle matches on bare camelized Ruby
+ * short names, and the owners it now reports are unrelated: `close` credits
  * `Rack::BodyProxy#close`, `prepare` to `Store::HashAccessor#prepare`,
  * `isOpen` to `Transaction#open?` (abstract/transaction.rb), `open` to
  * `SchemaCache#open` / `MigrationContext#open`, `databaseExists` to

--- a/packages/activerecord/src/test-helper.test.ts
+++ b/packages/activerecord/src/test-helper.test.ts
@@ -28,7 +28,7 @@ describe("withTimezoneConfig", () => {
 
   it("restores zone to unset state when zone was not explicitly set before", async () => {
     // zone_default is set but _zone is not explicitly set (falls through to default)
-    const paris = TimeZone.find("Europe/Paris");
+    const paris = TimeZone.find("Europe/Paris")!;
     setZoneDefault(paris);
     resetZone(); // ensure _zone is unset (not explicit)
     expect(isZoneExplicit()).toBe(false);
@@ -44,7 +44,7 @@ describe("withTimezoneConfig", () => {
   });
 
   it("restores zone to explicit value when zone was explicitly set before", async () => {
-    const paris = TimeZone.find("Europe/Paris");
+    const paris = TimeZone.find("Europe/Paris")!;
     setZone(paris);
     expect(isZoneExplicit()).toBe(true);
 

--- a/packages/activesupport/src/core-ext/date-ext.test.ts
+++ b/packages/activesupport/src/core-ext/date-ext.test.ts
@@ -204,7 +204,7 @@ describe("DateExtCalculationsTest", () => {
   });
 
   it("since when zone is set", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     setZone(zone);
     try {
       expect(DateExt.since(pd(2005, 2, 21), 45).toI()).toBe(
@@ -225,7 +225,7 @@ describe("DateExtCalculationsTest", () => {
   });
 
   it("ago when zone is set", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     setZone(zone);
     try {
       expect(DateExt.ago(pd(2005, 2, 21), 45).toI()).toBe(
@@ -244,7 +244,7 @@ describe("DateExtCalculationsTest", () => {
   });
 
   it("beginning of day when zone is set", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     setZone(zone);
     try {
       expect(DateExt.beginningOfDay(pd(2005, 2, 21)).toI()).toBe(
@@ -257,7 +257,7 @@ describe("DateExtCalculationsTest", () => {
   });
 
   it("end of day when zone is set", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     setZone(zone);
     try {
       const endOfDayInZone = DateExt.endOfDay(pd(2005, 2, 21));

--- a/packages/activesupport/src/core-ext/range-ext.test.ts
+++ b/packages/activesupport/src/core-ext/range-ext.test.ts
@@ -207,7 +207,7 @@ describe("RangeTest", () => {
   it("each on time with zone", () => {
     const twz = new TimeWithZone(
       instantFromDate(new Date(Date.UTC(2006, 10, 28, 10, 30))),
-      TimeZone.find("Eastern Time (US & Canada)"),
+      TimeZone.find("Eastern Time (US & Canada)")!,
     );
     expect(() => [...new Range(twz.minus(hours(1)), twz).each()]).toThrow(TypeError);
   });
@@ -215,7 +215,7 @@ describe("RangeTest", () => {
   it("step on time with zone", () => {
     const twz = new TimeWithZone(
       instantFromDate(new Date(Date.UTC(2006, 10, 28, 10, 30))),
-      TimeZone.find("Eastern Time (US & Canada)"),
+      TimeZone.find("Eastern Time (US & Canada)")!,
     );
     expect(() => [...new Range(twz.minus(hours(1)), twz).step(1)]).toThrow(TypeError);
   });

--- a/packages/activesupport/src/core-ext/time-with-zone.test.ts
+++ b/packages/activesupport/src/core-ext/time-with-zone.test.ts
@@ -1378,7 +1378,10 @@ describe("TimeWithZoneMethodsForDate", () => {
   });
 
   it("in time zone with invalid argument", () => {
-    expect(() => dateInTimeZone(new Date(2000, 0, 1), "No such timezone exists")).toThrow();
+    const d = new Date(2000, 0, 1);
+    expect(() => dateInTimeZone(d, "No such timezone exists")).toThrow(ArgumentError);
+    expect(() => dateInTimeZone(d, Duration.hours(-15))).toThrow(ArgumentError);
+    expect(() => dateInTimeZone(d, {})).toThrow(ArgumentError);
   });
 });
 

--- a/packages/activesupport/src/core-ext/time-with-zone.test.ts
+++ b/packages/activesupport/src/core-ext/time-with-zone.test.ts
@@ -16,6 +16,7 @@ import {
   findZoneBang,
   current,
   dateInTimeZone,
+  ArgumentError,
 } from "../time-zone-config.js";
 
 describe("TimeWithZoneTest", () => {
@@ -24,9 +25,9 @@ describe("TimeWithZoneTest", () => {
   let utcZone: TimeZone;
 
   beforeEach(() => {
-    eastern = TimeZone.find("Eastern Time (US & Canada)");
-    pacific = TimeZone.find("Pacific Time (US & Canada)");
-    utcZone = TimeZone.find("UTC");
+    eastern = TimeZone.find("Eastern Time (US & Canada)")!;
+    pacific = TimeZone.find("Pacific Time (US & Canada)")!;
+    utcZone = TimeZone.find("UTC")!;
   });
 
   // @twz = 2000-01-01 00:00:00 UTC in Eastern = 1999-12-31 19:00:00 EST
@@ -62,7 +63,7 @@ describe("TimeWithZoneTest", () => {
 
   it("in time zone with argument", () => {
     const twz = maketwz();
-    const alaska = TimeZone.find("Alaska");
+    const alaska = TimeZone.find("Alaska")!;
     const result = twz.inTimeZone("Alaska");
     expect(result.timeZone.name).toBe(alaska.name);
     expect(result.utc().epochMilliseconds).toBe(twz.utc().epochMilliseconds);
@@ -80,7 +81,7 @@ describe("TimeWithZoneTest", () => {
 
   it("in time zone with ambiguous time", () => {
     // 2014-10-26 01:00:00 Moscow time was ambiguous due to DST change
-    const moscow = TimeZone.find("Moscow");
+    const moscow = TimeZone.find("Moscow")!;
     const twz = moscow.local(2014, 10, 26, 1, 0, 0);
     expect(twz.utc().epochMilliseconds).toBe(Date.UTC(2014, 9, 25, 22, 0, 0));
   });
@@ -407,7 +408,7 @@ describe("TimeWithZoneTest", () => {
     expect(twz.eql(new Date(Date.UTC(2000, 0, 1)))).toBe(true);
     expect(
       twz.eql(
-        new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1))), TimeZone.find("Hawaii")),
+        new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1))), TimeZone.find("Hawaii")!),
       ),
     ).toBe(true);
     expect(twz.eql(new Date(Date.UTC(2000, 0, 1, 0, 0, 1)))).toBe(false);
@@ -514,7 +515,7 @@ describe("TimeWithZoneTest", () => {
 
   it("to a", () => {
     // Rails: [45, 30, 5, 1, 2, 2000, 2, 32, false, "HST"]
-    const hawaii = TimeZone.find("Hawaii");
+    const hawaii = TimeZone.find("Hawaii")!;
     const twzH = new TimeWithZone(
       instantFromDate(new Date(Date.UTC(2000, 1, 1, 15, 30, 45))),
       hawaii,
@@ -532,13 +533,13 @@ describe("TimeWithZoneTest", () => {
   });
 
   it("to f", () => {
-    const hawaii = TimeZone.find("Hawaii");
+    const hawaii = TimeZone.find("Hawaii")!;
     const twzH = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1))), hawaii);
     expect(twzH.toF()).toBe(946684800.0);
   });
 
   it("to i", () => {
-    const hawaii = TimeZone.find("Hawaii");
+    const hawaii = TimeZone.find("Hawaii")!;
     const twzH = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1))), hawaii);
     expect(twzH.toI()).toBe(946684800);
   });
@@ -928,7 +929,7 @@ describe("TimeWithZoneTest", () => {
     const parsed = JSON.parse(json);
     const restored = new TimeWithZone(
       instantFromDate(new Date(parsed.utc)),
-      TimeZone.find(parsed.timeZone),
+      TimeZone.find(parsed.timeZone)!,
     );
     expect(restored.utc().epochMilliseconds).toBe(twz.utc().epochMilliseconds);
     expect(restored.timeZone.name).toBe(twz.timeZone.name);
@@ -944,7 +945,7 @@ describe("TimeWithZoneTest", () => {
     const parsed = JSON.parse(json);
     const restored = new TimeWithZone(
       instantFromDate(new Date(parsed.utc)),
-      TimeZone.find(parsed.timeZone),
+      TimeZone.find(parsed.timeZone)!,
     );
     expect(restored.utc().epochMilliseconds).toBe(twz.utc().epochMilliseconds);
     expect(restored.inspect()).toBe(twz.inspect());
@@ -1052,7 +1053,7 @@ describe("TimeWithZoneTest", () => {
     // Time.at(1319936400) = 2011-10-30 02:00:00 UTC
     const twz = new TimeWithZone(
       instantFromDate(new Date(1319936400 * 1000)),
-      TimeZone.find("Madrid"),
+      TimeZone.find("Madrid")!,
     );
     const result = twz.change({ min: 0 });
     expect(result.getTime()).toBe(twz.getTime());
@@ -1061,7 +1062,7 @@ describe("TimeWithZoneTest", () => {
   it("round at dst boundary", () => {
     const twz = new TimeWithZone(
       instantFromDate(new Date(1319936400 * 1000)),
-      TimeZone.find("Madrid"),
+      TimeZone.find("Madrid")!,
     );
     const result = twz.round();
     expect(result.getTime()).toBe(twz.getTime());
@@ -1154,11 +1155,11 @@ describe("TimeWithZoneMethodsForTimeAndDateTimeTest", () => {
 
   it("in time zone", () => {
     useZone("Alaska", () => {
-      const result = new TimeWithZone(instantFromDate(t), TimeZone.find("Alaska"));
+      const result = new TimeWithZone(instantFromDate(t), TimeZone.find("Alaska")!);
       expect(result.inspect()).toBe("1999-12-31 15:00:00.000000000 AKST -09:00");
     });
     useZone("Hawaii", () => {
-      const result = new TimeWithZone(instantFromDate(t), TimeZone.find("Hawaii"));
+      const result = new TimeWithZone(instantFromDate(t), TimeZone.find("Hawaii")!);
       expect(result.inspect()).toBe("1999-12-31 14:00:00.000000000 HST -10:00");
     });
   });
@@ -1171,22 +1172,28 @@ describe("TimeWithZoneMethodsForTimeAndDateTimeTest", () => {
 
   it("in time zone with argument", () => {
     useZone("Eastern Time (US & Canada)", () => {
-      const alaska = new TimeWithZone(instantFromDate(t), TimeZone.find("Alaska"));
+      const alaska = new TimeWithZone(instantFromDate(t), TimeZone.find("Alaska")!);
       expect(alaska.inspect()).toBe("1999-12-31 15:00:00.000000000 AKST -09:00");
-      const hawaii = new TimeWithZone(instantFromDate(t), TimeZone.find("Hawaii"));
+      const hawaii = new TimeWithZone(instantFromDate(t), TimeZone.find("Hawaii")!);
       expect(hawaii.inspect()).toBe("1999-12-31 14:00:00.000000000 HST -10:00");
-      const utcTwz = new TimeWithZone(instantFromDate(t), TimeZone.find("UTC"));
+      const utcTwz = new TimeWithZone(instantFromDate(t), TimeZone.find("UTC")!);
       expect(utcTwz.inspect()).toBe("2000-01-01 00:00:00.000000000 UTC +00:00");
     });
   });
 
   it("in time zone with invalid argument", () => {
-    expect(() => TimeZone.find("No such timezone exists")).toThrow();
+    const twz = new TimeWithZone(
+      instantFromDate(new Date(Date.UTC(2000, 0, 1))),
+      TimeZone.find("UTC")!,
+    );
+    expect(() => twz.inTimeZone("No such timezone exists")).toThrow(ArgumentError);
+    expect(() => twz.inTimeZone(Duration.hours(-15))).toThrow(ArgumentError);
+    expect(() => twz.inTimeZone({})).toThrow(ArgumentError);
   });
 
   it("in time zone with time local instance", () => {
     const time = new Date(Date.UTC(2000, 0, 1, 0, 0, 0)); // UTC midnight
-    const result = new TimeWithZone(instantFromDate(time), TimeZone.find("Alaska"));
+    const result = new TimeWithZone(instantFromDate(time), TimeZone.find("Alaska")!);
     expect(result.inspect()).toBe("1999-12-31 15:00:00.000000000 AKST -09:00");
   });
 
@@ -1218,7 +1225,7 @@ describe("TimeWithZoneMethodsForTimeAndDateTimeTest", () => {
 
   it("time at precision", () => {
     useZone("UTC", () => {
-      const twz = TimeZone.find("UTC").local(2019, 1, 31, 23, 59, 59, 999);
+      const twz = TimeZone.find("UTC")!.local(2019, 1, 31, 23, 59, 59, 999);
       expect(twz.toI()).toBe(Math.floor(twz.getTime() / 1000));
     });
   });
@@ -1330,7 +1337,7 @@ describe("TimeWithZoneMethodsForTimeAndDateTimeTest", () => {
     const time = new Date(Date.UTC(2000, 6, 1));
     const twz = new TimeWithZone(
       instantFromDate(time),
-      TimeZone.find("Eastern Time (US & Canada)"),
+      TimeZone.find("Eastern Time (US & Canada)")!,
     );
     expect(twz.utc().epochMilliseconds).toBe(time.getTime());
     // Original Date should not be modified
@@ -1384,7 +1391,7 @@ describe("TimeWithZoneMethodsForString", () => {
     useZone("Alaska", () => {
       const result = new TimeWithZone(
         instantFromDate(new Date(Date.UTC(2000, 0, 1))),
-        TimeZone.find("Alaska"),
+        TimeZone.find("Alaska")!,
       );
       expect(result.inspect()).toBe("1999-12-31 15:00:00.000000000 AKST -09:00");
     });
@@ -1399,19 +1406,25 @@ describe("TimeWithZoneMethodsForString", () => {
     useZone("Eastern Time (US & Canada)", () => {
       const alaska = new TimeWithZone(
         instantFromDate(new Date(Date.UTC(2000, 0, 1))),
-        TimeZone.find("Alaska"),
+        TimeZone.find("Alaska")!,
       );
       expect(alaska.inspect()).toBe("1999-12-31 15:00:00.000000000 AKST -09:00");
     });
   });
 
   it("in time zone with invalid argument", () => {
-    expect(() => TimeZone.find("No such timezone exists")).toThrow();
+    const twz = new TimeWithZone(
+      instantFromDate(new Date(Date.UTC(2000, 0, 1))),
+      TimeZone.find("UTC")!,
+    );
+    expect(() => twz.inTimeZone("No such timezone exists")).toThrow(ArgumentError);
+    expect(() => twz.inTimeZone(Duration.hours(-15))).toThrow(ArgumentError);
+    expect(() => twz.inTimeZone({})).toThrow(ArgumentError);
   });
 
   it("in time zone with ambiguous time", () => {
     // 2014-10-26 01:00:00 Moscow time is ambiguous due to DST change
-    const moscow = TimeZone.find("Moscow");
+    const moscow = TimeZone.find("Moscow")!;
     const twz = moscow.local(2014, 10, 26, 1, 0, 0);
     // Should resolve to the UTC equivalent
     expect(twz.utc().epochMilliseconds).toBe(Date.UTC(2014, 9, 25, 22, 0, 0));

--- a/packages/activesupport/src/date-ext.ts
+++ b/packages/activesupport/src/date-ext.ts
@@ -110,7 +110,7 @@ export function inTimeZone(date: Temporal.PlainDate, zone: unknown = getZone()):
   if (timeZone) {
     return timeWithZone(date, timeZone);
   }
-  return timeWithZone(date, TimeZone.find(Temporal.Now.timeZoneId()));
+  return timeWithZone(date, TimeZone.find(Temporal.Now.timeZoneId())!);
 }
 
 /** Mirrors: `DateAndTime::Zones#time_with_zone` (`date_and_time/zones.rb:32-38`) */

--- a/packages/activesupport/src/i18n.test.ts
+++ b/packages/activesupport/src/i18n.test.ts
@@ -16,7 +16,7 @@ describe("I18nTest", () => {
   beforeEach(async () => {
     await I18n.reloadBang();
     date = RubyDate.parse("2008-7-2");
-    time = TimeZone.find("UTC").local(2008, 7, 2, 16, 47, 1);
+    time = TimeZone.find("UTC")!.local(2008, 7, 2, 16, 47, 1);
   });
 
   afterEach(async () => {
@@ -24,7 +24,7 @@ describe("I18nTest", () => {
   });
 
   it("time zone localization with default format", () => {
-    const now = TimeZone.find("UTC").local(2000, 1, 1);
+    const now = TimeZone.find("UTC")!.local(2000, 1, 1);
     expect(I18n.localize(now)).toBe(now.strftime("%a, %d %b %Y %H:%M:%S %z"));
   });
 

--- a/packages/activesupport/src/json/encoding.test.ts
+++ b/packages/activesupport/src/json/encoding.test.ts
@@ -279,7 +279,7 @@ describe("TestJSONEncoding", () => {
   it.skip("json gem pretty generate by passing active support encoder");
   it("twz to json with use standard json time format config set to false", () => {
     withStandardJsonTimeFormat(false, () => {
-      const zone = TimeZone.find("Eastern Time (US & Canada)");
+      const zone = TimeZone.find("Eastern Time (US & Canada)")!;
       const time = new TimeWithZone(Temporal.Instant.from("2000-01-01T00:00:00Z"), zone);
       expect(ActiveSupportJSON.encode(time)).toBe('"1999/12/31 19:00:00 -0500"');
     });
@@ -287,7 +287,7 @@ describe("TestJSONEncoding", () => {
 
   it("twz to json with use standard json time format config set to true", () => {
     withStandardJsonTimeFormat(true, () => {
-      const zone = TimeZone.find("Eastern Time (US & Canada)");
+      const zone = TimeZone.find("Eastern Time (US & Canada)")!;
       const time = new TimeWithZone(Temporal.Instant.from("2000-01-01T00:00:00Z"), zone);
       expect(ActiveSupportJSON.encode(time)).toBe('"1999-12-31T19:00:00.000-05:00"');
     });
@@ -296,7 +296,7 @@ describe("TestJSONEncoding", () => {
   it("twz to json with custom time precision", () => {
     withStandardJsonTimeFormat(true, () => {
       withTimePrecision(0, () => {
-        const zone = TimeZone.find("Eastern Time (US & Canada)");
+        const zone = TimeZone.find("Eastern Time (US & Canada)")!;
         const time = new TimeWithZone(Temporal.Instant.from("2000-01-01T00:00:00Z"), zone);
         expect(ActiveSupportJSON.encode(time)).toBe('"1999-12-31T19:00:00-05:00"');
       });

--- a/packages/activesupport/src/message-pack/extensions.ts
+++ b/packages/activesupport/src/message-pack/extensions.ts
@@ -305,11 +305,7 @@ export const Extensions = {
   },
 
   loadTimeZone(name: string): TimeZone | null {
-    try {
-      return TimeZone.find(name);
-    } catch {
-      return null;
-    }
+    return TimeZone.find(name);
   },
 
   writeTimeZone(timeZone: TimeZone, packer: Packer): void {

--- a/packages/activesupport/src/message-pack/serializer.test.ts
+++ b/packages/activesupport/src/message-pack/serializer.test.ts
@@ -112,7 +112,7 @@ describe("MessagePackSerializerTest", () => {
   it("roundtrips ActiveSupport::TimeWithZone", () => {
     const twz = new TimeWithZone(
       Temporal.Instant.from("1999-12-31T12:34:56.789Z"),
-      TimeZone.find("Australia/Lord_Howe"),
+      TimeZone.find("Australia/Lord_Howe")!,
     );
     const result = roundtrip(twz) as TimeWithZone;
     expect(result).toBeInstanceOf(TimeWithZone);
@@ -121,7 +121,7 @@ describe("MessagePackSerializerTest", () => {
   });
 
   it("roundtrips ActiveSupport::TimeZone", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     expect((roundtrip(zone) as TimeZone).name).toBe(zone.name);
   });
 
@@ -152,7 +152,7 @@ describe("MessagePackSerializerTest", () => {
     expect([...dump(new Set([null, true, 2, "three"]))]).toEqual([
       204, 128, 199, 10, 12, 148, 192, 195, 2, 165, 116, 104, 114, 101, 101,
     ]);
-    expect([...dump(TimeZone.find("Eastern Time (US & Canada)"))]).toEqual([
+    expect([...dump(TimeZone.find("Eastern Time (US & Canada)")!)]).toEqual([
       204, 128, 199, 26, 9, 69, 97, 115, 116, 101, 114, 110, 32, 84, 105, 109, 101, 32, 40, 85, 83,
       32, 38, 32, 67, 97, 110, 97, 100, 97, 41,
     ]);

--- a/packages/activesupport/src/time-with-zone.test.ts
+++ b/packages/activesupport/src/time-with-zone.test.ts
@@ -11,9 +11,9 @@ describe("TimeWithZoneTest", () => {
   let utcZone: TimeZone;
 
   beforeEach(() => {
-    eastern = TimeZone.find("Eastern Time (US & Canada)");
-    pacific = TimeZone.find("Pacific Time (US & Canada)");
-    utcZone = TimeZone.find("UTC");
+    eastern = TimeZone.find("Eastern Time (US & Canada)")!;
+    pacific = TimeZone.find("Pacific Time (US & Canada)")!;
+    utcZone = TimeZone.find("UTC")!;
   });
 
   it("creates from TimeZone.local()", () => {
@@ -647,7 +647,7 @@ describe("TimeWithZoneTest", () => {
   // Local: 1999-12-31 19:00:00 EST (-05:00)
   // ---------------------------------------------------------------------------
   it("nsec", () => {
-    const hawaii = TimeZone.find("Hawaii");
+    const hawaii = TimeZone.find("Hawaii")!;
     const withZone = new TimeWithZone(
       Temporal.Instant.from("2011-06-08T09:59:59.999999999Z"),
       hawaii,
@@ -848,7 +848,7 @@ describe("TimeWithZoneTest", () => {
   // Multiple timezone conversion tests (from time_with_zone_test.rb)
   // ---------------------------------------------------------------------------
   it("Hawaii timezone basic operations", () => {
-    const hawaii = TimeZone.find("Hawaii");
+    const hawaii = TimeZone.find("Hawaii")!;
     const twz = hawaii.local(2000, 1, 1, 0, 0, 0);
 
     expect(twz.hour).toBe(0);
@@ -861,7 +861,7 @@ describe("TimeWithZoneTest", () => {
   });
 
   it("Alaska timezone basic operations", () => {
-    const alaska = TimeZone.find("Alaska");
+    const alaska = TimeZone.find("Alaska")!;
     const twz = alaska.local(2000, 1, 1, 15, 0, 0);
 
     expect(twz.hour).toBe(15);
@@ -873,7 +873,7 @@ describe("TimeWithZoneTest", () => {
     const utcTime = new Date(Date.UTC(2024, 6, 15, 12, 0, 0));
     const eastern_twz = new TimeWithZone(instantFromDate(utcTime), eastern);
     const pacific_twz = eastern_twz.inTimeZone(pacific);
-    const hawaii = TimeZone.find("Hawaii");
+    const hawaii = TimeZone.find("Hawaii")!;
     const hawaii_twz = pacific_twz.inTimeZone(hawaii);
     const back_to_eastern = hawaii_twz.inTimeZone(eastern);
 

--- a/packages/activesupport/src/time-with-zone.trails.test.ts
+++ b/packages/activesupport/src/time-with-zone.trails.test.ts
@@ -7,7 +7,7 @@ import { Temporal } from "@blazetrails/date";
 // digits (time_with_zone.rb:223-227 delegates strftime to that Time). These
 // cover the readers and formatters that derive the sub-second part.
 describe("TimeWithZone sub-millisecond precision", () => {
-  const eastern = TimeZone.find("Eastern Time (US & Canada)");
+  const eastern = TimeZone.find("Eastern Time (US & Canada)")!;
   const subMs = () =>
     new TimeWithZone(Temporal.Instant.from("2000-01-01T00:00:00.123456789Z"), eastern);
 

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -326,16 +326,20 @@ export class TimeWithZone {
     return this._epochMs / 1000;
   }
 
-  /** Convert to a different timezone. No-argument form uses Time.zone. */
+  /**
+   * Convert to a different timezone. No-argument form uses Time.zone.
+   *
+   * `utc.in_time_zone(new_zone)` (time_with_zone.rb:79) lands in
+   * `Time#in_time_zone`, whose first act is `::Time.find_zone!`
+   * (core_ext/time/zones.rb), so every argument class, unmatched offset and bad
+   * name raises there rather than here.
+   */
   inTimeZone(zone?: unknown): TimeWithZone {
     if (zone == null) {
       const currentZone = getZone();
       if (!currentZone) return this;
       zone = currentZone;
     }
-    // `utc.in_time_zone(new_zone)` (time_with_zone.rb:79) lands in Time#in_time_zone,
-    // whose first act is `::Time.find_zone!` (core_ext/time/zones.rb:100) — so every
-    // argument class, offset and bad name raises there, not here.
     const tz = findZoneBang(zone) as TimeZone;
     if (tz.tzinfo === this._timeZone.tzinfo) return this;
     return new TimeWithZone(this._zoned.toInstant(), tz);

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -8,7 +8,7 @@
 import { TimeZone } from "./values/time-zone.js";
 import { Duration } from "./duration.js";
 import { currentTime } from "./time-travel.js";
-import { getZone } from "./time-zone-config.js";
+import { getZone, findZoneBang } from "./time-zone-config.js";
 import { Temporal } from "@blazetrails/date";
 import { instantFrom } from "./temporal.js";
 import { Rational, strftime } from "@blazetrails/date";
@@ -327,13 +327,16 @@ export class TimeWithZone {
   }
 
   /** Convert to a different timezone. No-argument form uses Time.zone. */
-  inTimeZone(zone?: string | TimeZone | null): TimeWithZone {
+  inTimeZone(zone?: unknown): TimeWithZone {
     if (zone == null) {
       const currentZone = getZone();
       if (!currentZone) return this;
       zone = currentZone;
     }
-    const tz = typeof zone === "string" ? TimeZone.find(zone) : zone;
+    // `utc.in_time_zone(new_zone)` (time_with_zone.rb:79) lands in Time#in_time_zone,
+    // whose first act is `::Time.find_zone!` (core_ext/time/zones.rb:100) — so every
+    // argument class, offset and bad name raises there, not here.
+    const tz = findZoneBang(zone) as TimeZone;
     if (tz.tzinfo === this._timeZone.tzinfo) return this;
     return new TimeWithZone(this._zoned.toInstant(), tz);
   }

--- a/packages/activesupport/src/time-zone-config.ts
+++ b/packages/activesupport/src/time-zone-config.ts
@@ -133,15 +133,17 @@ export function current(): TimeWithZone | Date {
 /**
  * Convert a Date (interpreted as a local date, i.e., year/month/day only)
  * into a TimeWithZone at midnight in the given zone.
- * Matches Rails' Date#in_time_zone.
+ * Matches Rails' Date#in_time_zone, whose first act is `::Time.find_zone!`
+ * (core_ext/date/zones.rb) — so a bad name, an unmatched offset and an argument
+ * of the wrong class all raise there.
  */
-export function dateInTimeZone(date: Date, zone: string | TimeZone): TimeWithZone {
+export function dateInTimeZone(date: Date, zone: unknown): TimeWithZone {
   const tz = findZoneBang(zone) as TimeZone;
   return tz.local(date.getFullYear(), date.getMonth() + 1, date.getDate());
 }
 
 /**
- * Ruby's `ArgumentError`. One class across the package, so `findZone`'s
+ * Ruby's `ArgumentError`. One class across `TimeZone` / `time-zone-config`, so `findZone`'s
  * `instanceof` narrows the raise `TimeZone[]` makes (time_zone.rb:249) as well
  * as the one `find_zone!` makes itself.
  */

--- a/packages/activesupport/src/time-zone-config.ts
+++ b/packages/activesupport/src/time-zone-config.ts
@@ -140,6 +140,9 @@ export function dateInTimeZone(date: Date, zone: string | TimeZone): TimeWithZon
   return tz.local(date.getFullYear(), date.getMonth() + 1, date.getDate());
 }
 
-// One class, so `findZone`'s `instanceof` still narrows the raise `TimeZone[]`
-// makes at time_zone.rb:249 as well as the one `find_zone!` makes itself.
+/**
+ * Ruby's `ArgumentError`. One class across the package, so `findZone`'s
+ * `instanceof` narrows the raise `TimeZone[]` makes (time_zone.rb:249) as well
+ * as the one `find_zone!` makes itself.
+ */
 export { ArgumentError };

--- a/packages/activesupport/src/time-zone-config.ts
+++ b/packages/activesupport/src/time-zone-config.ts
@@ -11,6 +11,7 @@ import { Duration } from "./duration.js";
 import { TimeWithZone } from "./time-with-zone.js";
 import { currentTime } from "./time-travel.js";
 import { instantFrom } from "./temporal.js";
+import { ArgumentError } from "./hash-utils.js";
 
 // NOTE: Zone state is stored in module-level variables, mirroring Rails'
 // thread-local Time.zone. This is process-wide and NOT safe for concurrent
@@ -105,31 +106,16 @@ export function findZone(zone: unknown): TimeZone | null | false {
 /**
  * `Time.find_zone!` (core_ext/time/zones.rb:80-90): `return time_zone unless
  * time_zone`, then `ActiveSupport::TimeZone[time_zone] || raise(ArgumentError,
- * "Invalid Timezone: #{time_zone}")`. The whole argument dispatch — including
- * the Numeric/Duration offset scan — lives in `TimeZone.find`, the port of
- * `[]` (time_zone.rb:232-250).
- *
- * Deviation: `[]` returns `nil` for a name or offset it cannot match and
- * raises only for an argument of the wrong class (time_zone.rb:249), while
- * trails' `find` throws in both cases. The argument-class arm therefore stays
- * here, so each of Rails' two messages is still raised for its own case.
+ * "Invalid Timezone: #{time_zone}")`. The whole argument dispatch — the name
+ * lookup, the Numeric/Duration offset scan, and the wrong-class raise
+ * (time_zone.rb:249) — lives in `TimeZone.find`, the port of `[]`.
  */
 export function findZoneBang(zone: unknown): TimeZone | null | false {
   if (zone === null || zone === undefined) return null;
   if (zone === false) return false;
-  if (
-    typeof zone === "string" ||
-    typeof zone === "number" ||
-    zone instanceof Duration ||
-    zone instanceof TimeZone
-  ) {
-    try {
-      return TimeZone.find(zone);
-    } catch {
-      throw new ArgumentError(`Invalid Timezone: ${String(zone)}`);
-    }
-  }
-  throw new ArgumentError(`invalid argument to TimeZone[]: ${String(zone)}`);
+  const found = TimeZone.find(zone);
+  if (found == null) throw new ArgumentError(`Invalid Timezone: ${String(zone)}`);
+  return found;
 }
 
 /**
@@ -150,13 +136,10 @@ export function current(): TimeWithZone | Date {
  * Matches Rails' Date#in_time_zone.
  */
 export function dateInTimeZone(date: Date, zone: string | TimeZone): TimeWithZone {
-  const tz = typeof zone === "string" ? TimeZone.find(zone) : zone;
+  const tz = findZoneBang(zone) as TimeZone;
   return tz.local(date.getFullYear(), date.getMonth() + 1, date.getDate());
 }
 
-export class ArgumentError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "ArgumentError";
-  }
-}
+// One class, so `findZone`'s `instanceof` still narrows the raise `TimeZone[]`
+// makes at time_zone.rb:249 as well as the one `find_zone!` makes itself.
+export { ArgumentError };

--- a/packages/activesupport/src/time-zone.test.ts
+++ b/packages/activesupport/src/time-zone.test.ts
@@ -9,7 +9,7 @@ describe("TimeZoneTest", () => {
   // utc/local conversion
   // ---------------------------------------------------------------------------
   it("utc to local", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const utcDate = new Date(Date.UTC(2000, 0, 1, 0, 0, 0));
     const twz = new TimeWithZone(instantFromDate(utcDate), zone);
     expect(twz.year).toBe(1999);
@@ -21,7 +21,7 @@ describe("TimeZoneTest", () => {
   });
 
   it("utc to local with fractional seconds", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const utcDate = new Date(Date.UTC(2000, 0, 1, 0, 0, 0, 500));
     const twz = new TimeWithZone(instantFromDate(utcDate), zone);
     expect(twz.msec).toBe(500);
@@ -29,13 +29,13 @@ describe("TimeZoneTest", () => {
   });
 
   it("local to utc", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.local(1999, 12, 31, 19, 0, 0);
     expect(twz.utc().epochMilliseconds).toBe(Date.UTC(2000, 0, 1, 0, 0, 0));
   });
 
   it("period for local", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.local(2024, 1, 15, 12, 0, 0);
     expect(twz.utcOffset).toBe(-5 * 3600);
     expect(twz.dst()).toBe(false);
@@ -43,7 +43,7 @@ describe("TimeZoneTest", () => {
 
   it("period for local with ambiguous time", () => {
     // 1AM during fall DST transition is ambiguous
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.local(2006, 10, 29, 1);
     expect(twz.hour).toBe(1);
     // Rails resolves ambiguous time to DST (first occurrence)
@@ -54,15 +54,15 @@ describe("TimeZoneTest", () => {
   // mapping
   // ---------------------------------------------------------------------------
   it("from integer to map", () => {
-    expect(TimeZone.find(-28800)).toBeInstanceOf(TimeZone); // PST
+    expect(TimeZone.find(-28800)!).toBeInstanceOf(TimeZone); // PST
   });
 
   it("from duration to map", () => {
-    expect(TimeZone.find(Duration.minutes(-480))).toBeInstanceOf(TimeZone); // PST
+    expect(TimeZone.find(Duration.minutes(-480))!).toBeInstanceOf(TimeZone); // PST
   });
 
   it("from tzinfo to map", () => {
-    const zone = TimeZone.find("America/New_York");
+    const zone = TimeZone.find("America/New_York")!;
     expect(zone.tzinfo).toBe("America/New_York");
   });
 
@@ -70,7 +70,7 @@ describe("TimeZoneTest", () => {
   // now / today / tomorrow / yesterday
   // ---------------------------------------------------------------------------
   it("now", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.now();
     expect(twz).toBeInstanceOf(TimeWithZone);
     expect(twz.timeZone).toBe(zone);
@@ -79,26 +79,26 @@ describe("TimeZoneTest", () => {
 
   it("now enforces spring dst rules", () => {
     // Verify that now() in a timezone returns correct DST status
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.now();
     // Can't test specific DST without controlling time, just verify it works
     expect(typeof twz.dst()).toBe("boolean");
   });
 
   it("now enforces fall dst rules", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.now();
     expect(typeof twz.dst()).toBe("boolean");
   });
 
   it("unknown timezones delegation to tzinfo", () => {
-    const zone = TimeZone.find("America/Montevideo");
+    const zone = TimeZone.find("America/Montevideo")!;
     expect(zone).toBeInstanceOf(TimeZone);
     expect(zone.name).toBe("America/Montevideo");
   });
 
   it("today", () => {
-    const zone = TimeZone.find("Hawaii");
+    const zone = TimeZone.find("Hawaii")!;
     const twz = zone.now();
     expect(twz.year).toBeGreaterThan(2020);
     expect(twz.month).toBeGreaterThanOrEqual(1);
@@ -106,7 +106,7 @@ describe("TimeZoneTest", () => {
   });
 
   it("tomorrow", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const today = zone.today();
     const tomorrow = zone.tomorrow();
     const todayDate = new Date(Date.UTC(today.year, today.month - 1, today.day));
@@ -115,7 +115,7 @@ describe("TimeZoneTest", () => {
   });
 
   it("yesterday", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const today = zone.today();
     const yesterday = zone.yesterday();
     const todayDate = new Date(Date.UTC(today.year, today.month - 1, today.day));
@@ -130,7 +130,7 @@ describe("TimeZoneTest", () => {
   // local
   // ---------------------------------------------------------------------------
   it("local", () => {
-    const hawaii = TimeZone.find("Hawaii");
+    const hawaii = TimeZone.find("Hawaii")!;
     const time = hawaii.local(2007, 2, 5, 15, 30, 45);
     expect(time.hour).toBe(15);
     expect(time.min).toBe(30);
@@ -139,14 +139,14 @@ describe("TimeZoneTest", () => {
   });
 
   it("local with old date", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.local(1850, 1, 1, 12, 0, 0);
     expect(twz.year).toBe(1850);
     expect(twz.hour).toBe(12);
   });
 
   it("local enforces spring dst rules", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
 
     const twz1 = zone.local(2006, 4, 2, 1, 59, 59);
     expect(twz1.hour).toBe(1);
@@ -168,7 +168,7 @@ describe("TimeZoneTest", () => {
   });
 
   it("local enforces fall dst rules", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.local(2006, 10, 29, 1);
     expect(twz.hour).toBe(1);
     expect(twz.dst()).toBe(true);
@@ -176,7 +176,7 @@ describe("TimeZoneTest", () => {
   });
 
   it("local with ambiguous time", () => {
-    const zone = TimeZone.find("Moscow");
+    const zone = TimeZone.find("Moscow")!;
     const twz = zone.local(2014, 10, 26, 1, 0, 0);
     expect(twz.hour).toBe(1);
   });
@@ -185,7 +185,7 @@ describe("TimeZoneTest", () => {
   // at
   // ---------------------------------------------------------------------------
   it("at", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const secs = 946684800.0;
     const twz = zone.at(secs);
     expect(twz.hour).toBe(19);
@@ -198,13 +198,13 @@ describe("TimeZoneTest", () => {
   });
 
   it("at with old date", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.at(-2208988800); // 1900-01-01 00:00:00 UTC
     expect(twz).toBeInstanceOf(TimeWithZone);
   });
 
   it("at with microseconds", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.at(946684800);
     expect(twz.timeZone).toBe(zone);
     expect(twz.utc().epochMilliseconds).toBe(946684800000);
@@ -214,14 +214,14 @@ describe("TimeZoneTest", () => {
   // iso8601
   // ---------------------------------------------------------------------------
   it("iso8601", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.iso8601("2024-01-15T12:00:00-05:00");
     expect(twz.hour).toBe(12);
     expect(twz.day).toBe(15);
   });
 
   it("iso8601 with fractional seconds", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.iso8601("1999-12-31T19:00:00.750");
     expect(twz.msec).toBe(750);
     expect(twz.hour).toBe(19);
@@ -229,24 +229,24 @@ describe("TimeZoneTest", () => {
   });
 
   it("iso8601 with zone", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.iso8601("1999-12-31T14:00:00-10:00");
     expect(twz.utc().epochMilliseconds).toBe(Date.UTC(2000, 0, 1, 0, 0, 0));
     expect(twz.timeZone).toBe(zone);
   });
 
   it("iso8601 with invalid string", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     expect(() => zone.iso8601("foobar")).toThrow();
   });
 
   it("iso8601 with nil", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     expect(() => zone.iso8601(null)).toThrow("invalid date");
   });
 
   it("iso8601 with missing time components", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.iso8601("1999-12-31");
     expect(twz.year).toBe(1999);
     expect(twz.month).toBe(12);
@@ -255,19 +255,19 @@ describe("TimeZoneTest", () => {
   });
 
   it("iso8601 with old date", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.iso8601("1883-07-01T00:00:00");
     expect(twz.year).toBe(1883);
   });
 
   it("iso8601 far future date with time zone offset in string", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.iso8601("2050-01-01T00:00:00-05:00");
     expect(twz.utc().toZonedDateTimeISO("UTC").year).toBe(2050);
   });
 
   it("iso8601 should not black out system timezone dst jump", () => {
-    const zone = TimeZone.find("Pacific Time (US & Canada)");
+    const zone = TimeZone.find("Pacific Time (US & Canada)")!;
     const twz = zone.iso8601("2012-03-25T03:29:00");
     expect(twz.sec).toBe(0);
     expect(twz.min).toBe(29);
@@ -278,7 +278,7 @@ describe("TimeZoneTest", () => {
   });
 
   it("iso8601 should black out app timezone dst jump", () => {
-    const zone = TimeZone.find("Pacific Time (US & Canada)");
+    const zone = TimeZone.find("Pacific Time (US & Canada)")!;
     const twz = zone.iso8601("2012-03-11T02:29:00");
     expect(twz.sec).toBe(0);
     expect(twz.min).toBe(29);
@@ -289,25 +289,25 @@ describe("TimeZoneTest", () => {
   });
 
   it("iso8601 doesnt use local dst", () => {
-    const zone = TimeZone.find("UTC");
+    const zone = TimeZone.find("UTC")!;
     const twz = zone.iso8601("2013-03-10T02:00:00Z");
     expect(twz.hour).toBe(2);
     expect(twz.day).toBe(10);
   });
 
   it("iso8601 handles dst jump", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.iso8601("2006-04-02T02:00:00");
     expect(twz.hour).toBe(3); // 2AM doesn't exist, springs forward to 3AM
   });
 
   it("iso8601 with ambiguous time", () => {
-    const zone = TimeZone.find("Moscow");
+    const zone = TimeZone.find("Moscow")!;
     const twz = zone.iso8601("2014-10-26T01:00:00");
     expect(twz.utc().epochMilliseconds).toBe(Date.UTC(2014, 9, 25, 22, 0, 0));
   });
   it("iso8601 with ordinal date value", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.iso8601("21087");
     expect(twz.year).toBe(2021);
     expect(twz.month).toBe(3);
@@ -317,7 +317,7 @@ describe("TimeZoneTest", () => {
   });
 
   it("iso8601 with invalid ordinal date value", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     expect(() => zone.iso8601("21367")).toThrow("invalid date");
   });
 
@@ -325,7 +325,7 @@ describe("TimeZoneTest", () => {
   // parse
   // ---------------------------------------------------------------------------
   it("parse", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.parse("1999-12-31 19:00:00");
     expect(twz.hour).toBe(19);
     expect(twz.day).toBe(31);
@@ -336,45 +336,45 @@ describe("TimeZoneTest", () => {
   });
 
   it("parse string with timezone", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.parse("2024-01-15T12:00:00Z");
     expect(twz.utc().epochMilliseconds).toBe(Date.UTC(2024, 0, 15, 12, 0, 0));
     expect(twz.hour).toBe(7);
   });
 
   it("parse with old date", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.parse("1883-07-01 00:00:00");
     expect(twz.year).toBe(1883);
   });
 
   it("parse far future date with time zone offset in string", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.parse("2050-01-01T00:00:00-05:00");
     expect(twz.utc().toZonedDateTimeISO("UTC").year).toBe(2050);
   });
 
   it("parse returns nil when string without date information is passed in", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     expect(() => zone.parse("foobar")).toThrow();
   });
 
   it("parse with incomplete date", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.parse("2000-01-01");
     expect(twz.year).toBe(2000);
     expect(twz.hour).toBe(0);
   });
 
   it("parse with day omitted", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.parse("2005-02-01");
     expect(twz.year).toBe(2005);
     expect(twz.month).toBe(2);
   });
 
   it("parse should not black out system timezone dst jump", () => {
-    const zone = TimeZone.find("Pacific Time (US & Canada)");
+    const zone = TimeZone.find("Pacific Time (US & Canada)")!;
     const twz = zone.parse("2012-03-25 03:29:00");
     expect(twz.hour).toBe(3);
     expect(twz.min).toBe(29);
@@ -384,7 +384,7 @@ describe("TimeZoneTest", () => {
   });
 
   it("parse should black out app timezone dst jump", () => {
-    const zone = TimeZone.find("Pacific Time (US & Canada)");
+    const zone = TimeZone.find("Pacific Time (US & Canada)")!;
     const twz = zone.parse("2012-03-11 02:29:00");
     expect(twz.hour).toBe(3);
     expect(twz.min).toBe(29);
@@ -394,38 +394,38 @@ describe("TimeZoneTest", () => {
   });
 
   it("parse with missing time components", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.parse("1999-12-31");
     expect(twz.hour).toBe(0);
     expect(twz.min).toBe(0);
   });
 
   it("parse with javascript date", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.parse("2013-01-01T00:00:00");
     expect(twz.year).toBe(2013);
   });
 
   it("parse doesnt use local dst", () => {
-    const zone = TimeZone.find("UTC");
+    const zone = TimeZone.find("UTC")!;
     const twz = zone.parse("2013-03-10 02:00:00");
     expect(twz.hour).toBe(2);
     expect(twz.day).toBe(10);
   });
 
   it("parse handles dst jump", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.parse("2006-04-02 02:00:00");
     expect(twz.hour).toBe(3);
   });
 
   it("parse with invalid date", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     expect(() => zone.parse("")).toThrow();
   });
 
   it("parse with ambiguous time", () => {
-    const zone = TimeZone.find("Moscow");
+    const zone = TimeZone.find("Moscow")!;
     const twz = zone.parse("2014-10-26 01:00:00");
     expect(twz.utc().epochMilliseconds).toBe(Date.UTC(2014, 9, 25, 22, 0, 0));
   });
@@ -434,67 +434,67 @@ describe("TimeZoneTest", () => {
   // rfc3339
   // ---------------------------------------------------------------------------
   it("rfc3339", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.rfc3339("1999-12-31T14:00:00-10:00");
     expect(twz.utc().epochMilliseconds).toBe(Date.UTC(2000, 0, 1, 0, 0, 0));
     expect(twz.timeZone).toBe(zone);
   });
 
   it("rfc3339 with fractional seconds", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.rfc3339("1999-12-31T19:00:00.750-05:00");
     expect(twz.msec).toBe(750);
   });
 
   it("rfc3339 with missing time", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     expect(() => zone.rfc3339("1999-12-31")).toThrow("invalid date");
   });
 
   it("rfc3339 with missing offset", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     expect(() => zone.rfc3339("1999-12-31T19:00:00")).toThrow("invalid date");
   });
 
   it("rfc3339 with invalid string", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     expect(() => zone.rfc3339("not-a-valid-rfc3339")).toThrow();
   });
 
   it("rfc3339 with old date", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.rfc3339("1883-07-01T00:00:00-05:00");
     expect(twz.year).toBe(1883);
   });
 
   it("rfc3339 far future date with time zone offset in string", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.rfc3339("2050-01-01T00:00:00-05:00");
     expect(twz.utc().toZonedDateTimeISO("UTC").year).toBe(2050);
   });
 
   it("rfc3339 should not black out system timezone dst jump", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.rfc3339("2006-07-15T12:00:00-04:00");
     expect(twz.hour).toBe(12);
     expect(twz.day).toBe(15);
   });
 
   it("rfc3339 should black out app timezone dst jump", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.rfc3339("2006-04-02T03:00:00-04:00");
     expect(twz.hour).toBe(3);
     expect(twz.day).toBe(2);
   });
 
   it("rfc3339 doesnt use local dst", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.rfc3339("2006-07-15T12:00:00-04:00");
     expect(twz.timeZone).toBe(zone);
   });
 
   it("rfc3339 handles dst jump", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.rfc3339("2006-04-02T03:00:00-04:00");
     expect(twz.hour).toBe(3);
   });
@@ -503,7 +503,7 @@ describe("TimeZoneTest", () => {
   // strptime
   // ---------------------------------------------------------------------------
   it("strptime", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.strptime("1999-12-31 12:00:00", "%Y-%m-%d %H:%M:%S");
     expect(twz.utc().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 17));
     expect(twz.time.toZonedDateTime("UTC").epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 12));
@@ -511,7 +511,7 @@ describe("TimeZoneTest", () => {
   });
 
   it("strptime with nondefault time zone", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.strptime("1999-12-31 12:00:00", "%Y-%m-%d %H:%M:%S");
     expect(twz.utc().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 17));
     expect(twz.time.toZonedDateTime("UTC").epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 12));
@@ -519,7 +519,7 @@ describe("TimeZoneTest", () => {
   });
 
   it("strptime with explicit time zone as abbrev", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.strptime("1999-12-31 12:00:00 PST", "%Y-%m-%d %H:%M:%S %Z");
     expect(twz.utc().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 20));
     expect(twz.time.toZonedDateTime("UTC").epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 15));
@@ -527,7 +527,7 @@ describe("TimeZoneTest", () => {
   });
 
   it("strptime with explicit time zone as h offset", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.strptime("1999-12-31 12:00:00 -08", "%Y-%m-%d %H:%M:%S %:::z");
     expect(twz.utc().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 20));
     expect(twz.time.toZonedDateTime("UTC").epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 15));
@@ -535,7 +535,7 @@ describe("TimeZoneTest", () => {
   });
 
   it("strptime with explicit time zone as hm offset", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.strptime("1999-12-31 12:00:00 -08:00", "%Y-%m-%d %H:%M:%S %:z");
     expect(twz.utc().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 20));
     expect(twz.time.toZonedDateTime("UTC").epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 15));
@@ -543,7 +543,7 @@ describe("TimeZoneTest", () => {
   });
 
   it("strptime with explicit time zone as hms offset", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.strptime("1999-12-31 12:00:00 -08:00:00", "%Y-%m-%d %H:%M:%S %::z");
     expect(twz.utc().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 20));
     expect(twz.time.toZonedDateTime("UTC").epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 15));
@@ -551,7 +551,7 @@ describe("TimeZoneTest", () => {
   });
 
   it("strptime with almost explicit time zone", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.strptime("1999-12-31 12:00:00 %Z", "%Y-%m-%d %H:%M:%S %%Z");
     expect(twz.utc().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 17));
     expect(twz.time.toZonedDateTime("UTC").epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 12));
@@ -559,7 +559,7 @@ describe("TimeZoneTest", () => {
   });
 
   it("strptime with day omitted", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const base = zone.local(2000, 1, 1);
     expect(zone.strptime("Feb", "%b", base).month).toBe(2);
     expect(zone.strptime("Feb", "%b", base).day).toBe(1);
@@ -571,24 +571,24 @@ describe("TimeZoneTest", () => {
   });
 
   it("strptime with malformed string", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     expect(() => zone.strptime("1999-12-31", "%Y/%m/%d")).toThrow();
   });
 
   it("strptime with timestamp seconds", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.strptime("1470272280", "%s");
     expect(twz.toI()).toBe(1470272280);
   });
 
   it("strptime with timestamp milliseconds", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.strptime("1470272280000", "%Q");
     expect(twz.toI()).toBe(1470272280);
   });
 
   it("strptime with ambiguous time", () => {
-    const zone = TimeZone.find("Moscow");
+    const zone = TimeZone.find("Moscow")!;
     const twz = zone.strptime("2014-10-26 01:00:00", "%Y-%m-%d %H:%M:%S");
     expect(twz.utc().epochMilliseconds).toBe(Date.UTC(2014, 9, 25, 22, 0, 0));
   });
@@ -597,12 +597,12 @@ describe("TimeZoneTest", () => {
   // utc_offset / formatted_offset
   // ---------------------------------------------------------------------------
   it("utc offset lazy loaded from tzinfo when not passed in to initialize", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     expect(typeof zone.utcOffset).toBe("number");
   });
 
   it("utc offset is not cached when current period gets stale", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const winterOffset = zone.utcOffsetAt(new Date(Date.UTC(2024, 0, 15)));
     const summerOffset = zone.utcOffsetAt(new Date(Date.UTC(2024, 6, 15)));
     expect(winterOffset).not.toBe(summerOffset);
@@ -610,32 +610,32 @@ describe("TimeZoneTest", () => {
 
   it("seconds to utc offset with colon", () => {
     // Use Arizona which doesn't observe DST
-    const zone = TimeZone.find("Arizona");
+    const zone = TimeZone.find("Arizona")!;
     expect(zone.formattedOffset(true)).toBe("-07:00");
   });
 
   it("seconds to utc offset without colon", () => {
-    const zone = TimeZone.find("Arizona");
+    const zone = TimeZone.find("Arizona")!;
     expect(zone.formattedOffset(false)).toBe("-0700");
   });
 
   it("seconds to utc offset with negative offset", () => {
-    const zone = TimeZone.find("Arizona");
+    const zone = TimeZone.find("Arizona")!;
     expect(zone.utcOffset).toBe(-7 * 3600);
   });
 
   it("formatted offset positive", () => {
-    const tokyo = TimeZone.find("Asia/Tokyo");
+    const tokyo = TimeZone.find("Asia/Tokyo")!;
     expect(tokyo.formattedOffset()).toBe("+09:00");
   });
 
   it("formatted offset negative", () => {
-    const zone = TimeZone.find("Arizona");
+    const zone = TimeZone.find("Arizona")!;
     expect(zone.formattedOffset()).toBe("-07:00");
   });
 
   it("z format strings", () => {
-    const zone = TimeZone.find("Tokyo");
+    const zone = TimeZone.find("Tokyo")!;
     const twz = zone.now();
     expect(twz.strftime("%z")).toBe("+0900");
     expect(twz.strftime("%:z")).toBe("+09:00");
@@ -643,7 +643,7 @@ describe("TimeZoneTest", () => {
   });
 
   it("formatted offset zero", () => {
-    const zone = TimeZone.find("UTC");
+    const zone = TimeZone.find("UTC")!;
     expect(zone.formattedOffset()).toBe("+00:00");
   });
 
@@ -651,21 +651,21 @@ describe("TimeZoneTest", () => {
   // comparison / matching
   // ---------------------------------------------------------------------------
   it("zone compare", () => {
-    const a = TimeZone.find("Eastern Time (US & Canada)");
-    const b = TimeZone.find("Pacific Time (US & Canada)");
+    const a = TimeZone.find("Eastern Time (US & Canada)")!;
+    const b = TimeZone.find("Pacific Time (US & Canada)")!;
     // Eastern is ahead of Pacific (less negative offset)
     expect(a.utcOffset).toBeGreaterThan(b.utcOffset);
   });
 
   it("zone match", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     expect(zone.match("Eastern Time (US & Canada)")).toBe(true);
     expect(zone.match("America/New_York")).toBe(true);
     expect(zone.match("Pacific Time (US & Canada)")).toBe(false);
   });
 
   it("zone match?", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     expect(zone.match("Eastern Time (US & Canada)")).toBe(true);
     expect(zone.match("bogus")).toBe(false);
   });
@@ -674,7 +674,7 @@ describe("TimeZoneTest", () => {
   // to_s / all / index
   // ---------------------------------------------------------------------------
   it("to s", () => {
-    const tz = TimeZone.find("UTC");
+    const tz = TimeZone.find("UTC")!;
     expect(tz.toString()).toBe("(GMT+00:00) UTC");
   });
 
@@ -696,7 +696,7 @@ describe("TimeZoneTest", () => {
 
   it("all uninfluenced by time zone lookups delegated to tzinfo", () => {
     const all = TimeZone.all();
-    TimeZone.find("America/Montevideo");
+    TimeZone.find("America/Montevideo")!;
     const all2 = TimeZone.all();
     expect(all.length).toBe(all2.length);
   });
@@ -706,23 +706,23 @@ describe("TimeZoneTest", () => {
   });
 
   it("index", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     expect(zone.name).toBe("Eastern Time (US & Canada)");
     expect(zone.tzinfo).toBe("America/New_York");
   });
 
   it("unknown zone raises exception", () => {
-    expect(() => TimeZone.find("Not/A/Real/Zone")).toThrow();
+    expect(() => TimeZone.create("Not/A/Real/Zone")).toThrow();
   });
 
   it("unknown zones dont store mapping keys", () => {
-    expect(() => TimeZone.find("bogus")).toThrow();
+    expect(TimeZone.find("bogus")).toBeNull();
     const all = TimeZone.all();
     expect(all.some((z) => z.name === "bogus")).toBe(false);
   });
 
   it("new", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)");
+    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     expect(zone).toBeInstanceOf(TimeZone);
     expect(zone.name).toBe("Eastern Time (US & Canada)");
   });
@@ -742,13 +742,13 @@ describe("TimeZoneTest", () => {
   it.skip("yaml load");
 
   it("abbr", () => {
-    const tz = TimeZone.find("America/New_York");
+    const tz = TimeZone.find("America/New_York")!;
     const jan = new Date(Date.UTC(2024, 0, 15));
     expect(tz.abbreviation(jan)).toBe("EST");
   });
 
   it("dst", () => {
-    const tz = TimeZone.find("America/New_York");
+    const tz = TimeZone.find("America/New_York")!;
     const jan = new Date(2024, 0, 15);
     const jul = new Date(2024, 6, 15);
     expect(tz.isDst(jan)).toBe(false);

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -302,11 +302,16 @@ export class TimeZone {
   static find(arg: unknown): TimeZone | null {
     if (arg instanceof TimeZone) return arg;
     if (typeof arg === "string") {
+      const cached = zoneCache.get(arg);
+      if (cached) return cached;
+      let tz: TimeZone;
       try {
-        return TimeZone.create(arg);
+        tz = TimeZone.create(arg);
       } catch {
         return null;
       }
+      zoneCache.set(arg, tz);
+      return tz;
     }
     if (typeof arg === "number" || arg instanceof Duration) {
       let seconds = arg instanceof Duration ? arg.inSeconds() : arg;
@@ -322,19 +327,18 @@ export class TimeZone {
    * so RAISES for a name TZInfo does not know, where `[]` returns `nil`. The
    * raised class is `Error`, not TZInfo's `InvalidTimezoneIdentifier` — trails
    * resolves zones through `Intl`, which has no TZInfo error hierarchy to port.
+   * A bare allocator: the `@lazy_zones_map` memo belongs to `[]`
+   * (`@lazy_zones_map[arg] ||= create(arg)`, time_zone.rb:237-238), so every
+   * call here builds a fresh instance as Ruby's `new` does.
    */
   static create(name: string): TimeZone {
-    const cached = zoneCache.get(name);
-    if (cached) return cached;
     const ianaName = MAPPING[name] ?? name;
     try {
       new Intl.DateTimeFormat("en-US", { timeZone: ianaName });
     } catch {
       throw new Error(`Invalid time zone: ${name}`);
     }
-    const tz = new TimeZone(name, ianaName);
-    zoneCache.set(name, tz);
-    return tz;
+    return new TimeZone(name, ianaName);
   }
 
   /**

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -11,6 +11,7 @@
 
 import { TimeWithZone } from "../time-with-zone.js";
 import { Duration } from "../duration.js";
+import { ArgumentError } from "../hash-utils.js";
 import { Temporal } from "@blazetrails/date";
 import { instantFrom } from "../temporal.js";
 import { currentTime } from "../time-travel.js";
@@ -287,47 +288,51 @@ export class TimeZone {
   /**
    * The port of `ActiveSupport::TimeZone.[]` (time_zone.rb:232-250): a Rails
    * name or IANA identifier, a `TimeZone`, or a `Numeric`/`Duration` UTC
-   * offset. Ruby's `[]` returns `nil` where every arm here throws — `[]` is
-   * only ever called from a raise site (`findZoneBang`, zones.rb:83), and
-   * making it nullable would rewrite ~60 unrelated call sites.
+   * offset. `null` for a name that resolves to no zone (Ruby's
+   * `rescue TZInfo::InvalidTimezoneIdentifier; nil`, time_zone.rb:239-241) and
+   * for an offset no zone matches (`all.find`, time_zone.rb:246); the only
+   * raise is the wrong-class arm at time_zone.rb:249.
    *
    * A `Duration` argument reads its seconds through `inSeconds()`, standing in
    * for Ruby's `arg.abs` / `arg.to_i` delegating to `@value` — trails' Duration
    * derives totals from `parts` and carries no `@value`.
    */
-  static find(name: string | number | Duration | TimeZone): TimeZone {
-    if (name instanceof TimeZone) return name;
-    if (typeof name === "number" || name instanceof Duration) {
-      let arg = name instanceof Duration ? name.inSeconds() : name;
-      if (Math.abs(arg) <= 13) arg *= 3600;
-      const zone = TimeZone.all().find((z) => z.utcOffset === Math.trunc(arg));
-      if (zone) return zone;
-      throw new Error(`Invalid time zone: ${String(name)}`);
+  static find(arg: unknown): TimeZone | null {
+    if (arg instanceof TimeZone) return arg;
+    if (typeof arg === "string") {
+      // `@lazy_zones_map[arg] ||= create(arg)` with the
+      // `rescue TZInfo::InvalidTimezoneIdentifier; nil` arm (time_zone.rb:237-241).
+      try {
+        return TimeZone.create(arg);
+      } catch {
+        return null;
+      }
     }
-    if (zoneCache.has(name)) return zoneCache.get(name)!;
-
-    // Check Rails mapping first
-    const iana = MAPPING[name];
-    if (iana) {
-      const tz = new TimeZone(name, iana);
-      zoneCache.set(name, tz);
-      return tz;
+    if (typeof arg === "number" || arg instanceof Duration) {
+      let seconds = arg instanceof Duration ? arg.inSeconds() : arg;
+      if (Math.abs(seconds) <= 13) seconds *= 3600;
+      return TimeZone.all().find((z) => z.utcOffset === Math.trunc(seconds)) ?? null;
     }
+    throw new ArgumentError(`invalid argument to TimeZone[]: ${String(arg)}`);
+  }
 
-    // Try as IANA name directly — validate by attempting to use it
+  /**
+   * `alias_method :create, :new` (time_zone.rb:211) — the allocator, whose
+   * `initialize` resolves the zone through `find_tzinfo` (time_zone.rb:208) and
+   * so RAISES for a name TZInfo does not know, where `[]` returns `nil`.
+   */
+  static create(name: string): TimeZone {
+    const cached = zoneCache.get(name);
+    if (cached) return cached;
+    const ianaName = MAPPING[name] ?? name;
     try {
-      new Intl.DateTimeFormat("en-US", { timeZone: name });
-      const tz = new TimeZone(name, name);
-      zoneCache.set(name, tz);
-      return tz;
+      new Intl.DateTimeFormat("en-US", { timeZone: ianaName });
     } catch {
       throw new Error(`Invalid time zone: ${name}`);
     }
-  }
-
-  /** Alias for find */
-  static create(name: string): TimeZone {
-    return TimeZone.find(name);
+    const tz = new TimeZone(name, ianaName);
+    zoneCache.set(name, tz);
+    return tz;
   }
 
   /**
@@ -338,7 +343,7 @@ export class TimeZone {
   static all(): TimeZone[] {
     if (zones) return zones;
     zones = Object.keys(MAPPING)
-      .map((name) => TimeZone.find(name))
+      .map((name) => TimeZone.find(name)!)
       .sort(
         (a, b) => a.utcOffset - b.utcOffset || (a.name < b.name ? -1 : a.name > b.name ? 1 : 0),
       );
@@ -841,7 +846,7 @@ export class TimeZone {
       "Eastern Time (US & Canada)",
       "Indiana (East)",
     ];
-    return usNames.map((n) => TimeZone.find(n));
+    return usNames.map((n) => TimeZone.find(n)!);
   }
 
   toString(): string {

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -291,7 +291,9 @@ export class TimeZone {
    * offset. `null` for a name that resolves to no zone (Ruby's
    * `rescue TZInfo::InvalidTimezoneIdentifier; nil`, time_zone.rb:239-241) and
    * for an offset no zone matches (`all.find`, time_zone.rb:246); the only
-   * raise is the wrong-class arm at time_zone.rb:249.
+   * raise is the wrong-class arm at time_zone.rb:249. The string arm is
+   * `@lazy_zones_map[arg] ||= create(arg)` under its
+   * `rescue TZInfo::InvalidTimezoneIdentifier; nil` (time_zone.rb:237-241).
    *
    * A `Duration` argument reads its seconds through `inSeconds()`, standing in
    * for Ruby's `arg.abs` / `arg.to_i` delegating to `@value` — trails' Duration
@@ -300,8 +302,6 @@ export class TimeZone {
   static find(arg: unknown): TimeZone | null {
     if (arg instanceof TimeZone) return arg;
     if (typeof arg === "string") {
-      // `@lazy_zones_map[arg] ||= create(arg)` with the
-      // `rescue TZInfo::InvalidTimezoneIdentifier; nil` arm (time_zone.rb:237-241).
       try {
         return TimeZone.create(arg);
       } catch {
@@ -319,7 +319,9 @@ export class TimeZone {
   /**
    * `alias_method :create, :new` (time_zone.rb:211) — the allocator, whose
    * `initialize` resolves the zone through `find_tzinfo` (time_zone.rb:208) and
-   * so RAISES for a name TZInfo does not know, where `[]` returns `nil`.
+   * so RAISES for a name TZInfo does not know, where `[]` returns `nil`. The
+   * raised class is `Error`, not TZInfo's `InvalidTimezoneIdentifier` — trails
+   * resolves zones through `Intl`, which has no TZInfo error hierarchy to port.
    */
   static create(name: string): TimeZone {
     const cached = zoneCache.get(name);
@@ -338,12 +340,15 @@ export class TimeZone {
   /**
    * Every Rails-named timezone: `@zones ||= zones_map.values.sort`
    * (time_zone.rb:223-225), sorted by `<=>` — utc_offset, then name
-   * (time_zone.rb:333-337).
+   * (time_zone.rb:333-337). `zones_map` keeps a MAPPING entry only when `[]`
+   * resolves it (`zones[name] = timezone if timezone`, time_zone.rb:288-291),
+   * hence the nullish filter.
    */
   static all(): TimeZone[] {
     if (zones) return zones;
     zones = Object.keys(MAPPING)
-      .map((name) => TimeZone.find(name)!)
+      .map((name) => TimeZone.find(name))
+      .filter((zone): zone is TimeZone => zone != null)
       .sort(
         (a, b) => a.utcOffset - b.utcOffset || (a.name < b.name ? -1 : a.name > b.name ? 1 : 0),
       );

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -48,6 +48,7 @@ describe("parseArgs", () => {
       excludeGlobs: [],
       novelOnly: false,
       maxDetail: 40,
+      verbose: false,
     });
   });
 
@@ -154,6 +155,52 @@ describe("buildGlobalRubyCandidates", () => {
     expect(set.has("VERSION")).toBe(true);
     // `version` would absolve any novel TS method of that name, everywhere.
     expect(set.has("version")).toBe(false);
+  });
+
+  it("carries the Rails package, file and Class#method each candidate credits against", () => {
+    const ruby: ApiManifest = {
+      source: "ruby",
+      generatedAt: "",
+      packages: {
+        rack: {
+          classes: {
+            "Rack::BodyProxy": rubyClass({
+              name: "BodyProxy",
+              file: "body_proxy.rb",
+              instance: [method("close")],
+            }),
+          },
+          modules: {},
+        },
+        activerecord: {
+          classes: {
+            "ActiveRecord::ConnectionAdapters::SchemaCache": rubyClass({
+              name: "SchemaCache",
+              file: "connection_adapters/schema_cache.rb",
+              klass: [method("open")],
+            }),
+          },
+          modules: {},
+        },
+      },
+    };
+    const map = buildGlobalRubyCandidates(ruby);
+    expect(map.get("close")).toEqual([
+      {
+        package: "rack",
+        file: "body_proxy.rb",
+        fqn: "Rack::BodyProxy",
+        rubyName: "Rack::BodyProxy#close",
+      },
+    ]);
+    expect(map.get("open")).toEqual([
+      {
+        package: "activerecord",
+        file: "connection_adapters/schema_cache.rb",
+        fqn: "ActiveRecord::ConnectionAdapters::SchemaCache",
+        rubyName: "ActiveRecord::ConnectionAdapters::SchemaCache.open",
+      },
+    ]);
   });
 });
 
@@ -1488,7 +1535,9 @@ describe("buildReport — declaration names", () => {
 
   it("reports a declaration name Rails declares in a DIFFERENT file as moved", () => {
     const report = run(ruby, tsWith(["Foo", "Elsewhere"]));
-    expect(report.packages[0].extraFiles[0].extras).toEqual([{ name: "Elsewhere", kind: "moved" }]);
+    expect(report.packages[0].extraFiles[0].extras).toMatchObject([
+      { name: "Elsewhere", kind: "moved" },
+    ]);
   });
 
   // Rails' filename and its module's name are not always the same word:
@@ -1585,7 +1634,9 @@ describe("buildReport — interface declaration names", () => {
 
   it("still scores an interface declaration name Rails uses elsewhere", () => {
     const report = run(ruby, tsWith([{ name: "Quoting", isInterface: true }]));
-    expect(report.packages[0].extraFiles[0].extras).toEqual([{ name: "Quoting", kind: "moved" }]);
+    expect(report.packages[0].extraFiles[0].extras).toMatchObject([
+      { name: "Quoting", kind: "moved" },
+    ]);
     expect(report.packages[0].totalInterfaceExempt).toBe(0);
   });
 
@@ -2281,7 +2332,7 @@ describe("@noRailsEquivalent — extractor to report", () => {
     const report = reportFor(railsWithout([method("sync_replica")]), {
       "connection-adapters/libsql-replica-adapter.ts": DRIVER_ADAPTER,
     });
-    expect(report.fileTagRejections).toEqual([
+    expect(report.fileTagRejections).toMatchObject([
       {
         package: "activerecord",
         tsFile: "connection-adapters/libsql-replica-adapter.ts",
@@ -2298,6 +2349,22 @@ describe("@noRailsEquivalent — extractor to report", () => {
       "connection-adapters/libsql-replica-adapter.ts",
     ]);
     expect(gateFileTagRejections(report.fileTagRejections)).toContain("moved name(s)");
+    // The rejection states the evidence: which Rails file and member the
+    // moved name credits against, so "is a rename owed?" is answerable from
+    // the message instead of a throwaway walk of rails-api.json.
+    expect(report.fileTagRejections[0].movedOwners).toEqual({
+      syncReplica: [
+        {
+          package: "activerecord",
+          file: "base.rb",
+          fqn: "ActiveRecord::Base",
+          rubyName: "ActiveRecord::Base#sync_replica",
+        },
+      ],
+    });
+    expect(gateFileTagRejections(report.fileTagRejections)).toContain(
+      "syncReplica → activerecord base.rb ActiveRecord::Base#sync_replica",
+    );
   });
 
   it("accepts a file-level tag whose reason declares the moved name as a short-name coincidence", () => {
@@ -2321,7 +2388,7 @@ describe("@noRailsEquivalent — extractor to report", () => {
         "syncReplica(): void {}\n      pragma(): void {}",
       ).replace("subclass onto.", "subclass onto. MOVED-BY-SHORT-NAME: syncReplica."),
     });
-    expect(report.fileTagRejections).toEqual([
+    expect(report.fileTagRejections).toMatchObject([
       {
         package: "activerecord",
         tsFile: "connection-adapters/libsql-replica-adapter.ts",

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -80,6 +80,7 @@
  *                         `dx-tests/` or `defineSchema`-only modules.
  *   --novel-only          Drop moved-not-novel extras (filters barrel noise).
  *   --max-detail <N>      Cap names per file in detail listing (default 40).
+ *   --verbose             Print the crediting Rails owner of each moved name.
  *   --help                Print this message.
  */
 
@@ -334,6 +335,11 @@ export interface FileTagRejection {
   /** The names scoring `moved` and NOT declared (`moved-names` only). */
   movedNames?: string[];
   /**
+   * The Rails owners each of those names credits against (`moved-names`
+   * only), so the rejection states the evidence instead of naming a question.
+   */
+  movedOwners?: Record<string, RubyOwner[]>;
+  /**
    * Names the reason declares under `MOVED-BY-SHORT-NAME:` that no longer
    * score `moved` (`stale-moved-declaration` only).
    */
@@ -346,10 +352,11 @@ const MOVED_BY_SHORT_NAME_RE = /MOVED-BY-SHORT-NAME:([^.]*)/;
  * The clause a file-level reason uses to declare, name by name, which of its
  * `moved` scores are bare-short-name coincidences rather than misplaced ports.
  *
- * `moved` is decided by a single global Set of every camelized Ruby method
- * name in Rails-land (`buildGlobalRubyCandidates`), with no file, class, or
- * package attribution: a TS `close` on a libsql driver handle scores `moved`
- * off `Rack::BodyProxy#close`, and `prepare` off `Store::HashAccessor#prepare`.
+ * `moved` is decided by a single global map of every camelized Ruby method
+ * name in Rails-land (`buildGlobalRubyCandidates`): a TS `close` on a libsql
+ * driver handle scores `moved` off `Rack::BodyProxy#close`, and `prepare` off
+ * `Store::HashAccessor#prepare` — the owners the map carries (`RubyOwner`) are
+ * what let a reader see that at a glance rather than re-deriving it.
  * For a file that binds a third-party JS client — a population Ruby does not
  * have at all — every generic verb in the client's own protocol collides that
  * way, and there is no Rails name for any of them to move onto.
@@ -419,6 +426,20 @@ export function fileTagVerdict(
 function undeclaredMovedNames(extras: readonly ExtraName[], reason: string): string[] {
   const declared = declaredCoincidentalMovedNames(reason);
   return extras.filter((e) => e.kind === "moved" && !declared.has(e.name)).map((e) => e.name);
+}
+
+/** The Rails owners of each undeclared moved name, keyed by TS name. */
+function undeclaredMovedOwners(
+  extras: readonly ExtraName[],
+  reason: string,
+): Record<string, RubyOwner[]> {
+  const declared = declaredCoincidentalMovedNames(reason);
+  const out: Record<string, RubyOwner[]> = {};
+  for (const e of extras) {
+    if (e.kind !== "moved" || declared.has(e.name)) continue;
+    if (e.owners && e.owners.length > 0) out[e.name] = e.owners;
+  }
+  return out;
 }
 
 /** Declared names that no longer score `moved` — `stale-moved-declaration`. */
@@ -556,9 +577,41 @@ export function collectTaggedEntries(ts: ApiManifest): TaggedEntry[] {
   return out;
 }
 
+/**
+ * A Rails member a `moved` extra credits against: the package and `.rb` it is
+ * declared in, its enclosing constant, and the Ruby spelling
+ * (`Rack::BodyProxy#close`). This is the evidence that separates the two
+ * populations a bare `moved` verdict conflates — a misplaced port (many names
+ * crediting ONE Rails class in one `.rb`: a rename is owed) from a
+ * bare-short-name coincidence (a handful of names crediting unrelated classes
+ * across unrelated gems: nothing is owed).
+ */
+export interface RubyOwner {
+  package: string;
+  file: string;
+  /** The enclosing Ruby constant — the declaration itself when it IS one. */
+  fqn: string;
+  /** `Class#method`, `Class.method`, or the bare constant name. */
+  rubyName: string;
+}
+
+/**
+ * Owners kept per candidate name. A generic verb like `call` or `each` is
+ * declared hundreds of times across Rails-land, and the whole list is never
+ * read — the reader needs the top owner plus enough siblings to see whether
+ * they cluster in one class. Keeping all of them would multiply the oracle's
+ * memory by the method count for no added signal.
+ */
+const MAX_OWNERS_PER_NAME = 5;
+
 export interface ExtraName {
   name: string;
   kind: ExtraKind;
+  /**
+   * The Rails members this name credits against, `kind === "moved"` only —
+   * see `RubyOwner`. Absent for `novel` (nothing in Rails to credit).
+   */
+  owners?: RubyOwner[];
 }
 
 interface ExtraFile {
@@ -655,6 +708,8 @@ Options:
                        drift; rank order also flips to novel-first)
   --max-detail <N>     Per-file detail listing cap (default 40 names;
                        0 = unlimited)
+  --verbose            Under each file's detail, print the Rails file and
+                       Class#method every moved name credits against
   --help               This message
 
 TS files that no Rails file maps onto are scored too, with an empty allowed
@@ -690,6 +745,7 @@ export interface CliArgs {
   excludeGlobs: string[];
   novelOnly: boolean;
   maxDetail: number;
+  verbose: boolean;
 }
 
 export function parseArgs(argv: string[]): CliArgs {
@@ -698,6 +754,7 @@ export function parseArgs(argv: string[]): CliArgs {
   let json = false;
   let novelOnly = false;
   let maxDetail = 40;
+  let verbose = false;
   const excludeGlobs: string[] = [];
 
   const requireValue = (flag: string, v: string | undefined): string => {
@@ -733,6 +790,8 @@ export function parseArgs(argv: string[]): CliArgs {
       json = true;
     } else if (a === "--novel-only") {
       novelOnly = true;
+    } else if (a === "--verbose") {
+      verbose = true;
     } else if (a === "--exclude-glob") {
       excludeGlobs.push(requireValue("--exclude-glob", argv[++i]));
     } else {
@@ -741,7 +800,7 @@ export function parseArgs(argv: string[]): CliArgs {
       process.exit(1);
     }
   }
-  return { filterPkg, topN, json, excludeGlobs, novelOnly, maxDetail };
+  return { filterPkg, topN, json, excludeGlobs, novelOnly, maxDetail, verbose };
 }
 
 /**
@@ -1041,8 +1100,14 @@ function collectAllowedNames(
 
 /**
  * Build the global "all Ruby method candidate names anywhere in Rails-land"
- * set, used to classify each extra as novel (nowhere in Rails) vs moved
+ * map, used to classify each extra as novel (nowhere in Rails) vs moved
  * (somewhere in Rails, just not in the matched file).
+ *
+ * The value is the `RubyOwner` list the name credits against, in extraction
+ * order. `moved` is still `has(name)` — the owners are attribution, not
+ * scoring — but "where" is the whole question a `moved` verdict asks the
+ * reader, so the oracle carries it instead of throwing it away and leaving the
+ * next reader to re-derive the camelization by hand off `rails-api.json`.
  *
  * Includes private/protected (internal) Ruby methods: a TS name mirroring a
  * Rails-private method that lives in a *different* `.rb` is "moved" (it exists
@@ -1057,24 +1122,57 @@ function collectAllowedNames(
  * doesn't sit in its own file as novel-by-omission, which is exactly the
  * miscount this pass exists to remove.
  */
-export function buildGlobalRubyCandidates(ruby: ApiManifest): Set<string> {
-  const all = new Set<string>();
-  for (const pkg of Object.values(ruby.packages)) {
-    for (const consts of Object.values(pkg.fileConstants ?? {})) {
+export function buildGlobalRubyCandidates(ruby: ApiManifest): Map<string, RubyOwner[]> {
+  const all = new Map<string, RubyOwner[]>();
+  const add = (candidate: string, owner: RubyOwner): void => {
+    const owners = all.get(candidate);
+    if (!owners) {
+      all.set(candidate, [owner]);
+      return;
+    }
+    if (owners.length < MAX_OWNERS_PER_NAME) owners.push(owner);
+  };
+  for (const [pkgName, pkg] of Object.entries(ruby.packages)) {
+    for (const [file, consts] of Object.entries(pkg.fileConstants ?? {})) {
       for (const name of Object.keys(consts)) {
-        for (const c of rubyConstantCandidates(name)) all.add(c);
+        for (const c of rubyConstantCandidates(name)) {
+          add(c, { package: pkgName, file, fqn: name, rubyName: name });
+        }
       }
     }
-    const entities = [...Object.values(pkg.classes), ...Object.values(pkg.modules)] as ClassInfo[];
-    for (const e of entities) {
+    const entities = [...Object.entries(pkg.classes), ...Object.entries(pkg.modules)] as [
+      string,
+      ClassInfo,
+    ][];
+    for (const [fqn, e] of entities) {
+      const file = e.file ?? "";
       // Declaration names join the oracle on the same rule as methods and
       // constants: a TS class named after a Ruby class declared in a DIFFERENT
       // `.rb` is `moved`, not `novel`.
-      for (const c of rubyConstantCandidates(e.name)) all.add(c);
-      for (const m of [...e.instanceMethods, ...e.classMethods]) {
+      for (const c of rubyConstantCandidates(e.name)) {
+        add(c, { package: pkgName, file, fqn, rubyName: e.name });
+      }
+      for (const m of e.instanceMethods) {
         const candidates = rubyMethodCandidates(m.name);
         if (!candidates) continue;
-        for (const c of candidates) all.add(c);
+        const owner: RubyOwner = {
+          package: pkgName,
+          file: m.file ?? file,
+          fqn,
+          rubyName: `${fqn}#${m.name}`,
+        };
+        for (const c of candidates) add(c, owner);
+      }
+      for (const m of e.classMethods) {
+        const candidates = rubyMethodCandidates(m.name);
+        if (!candidates) continue;
+        const owner: RubyOwner = {
+          package: pkgName,
+          file: m.file ?? file,
+          fqn,
+          rubyName: `${fqn}.${m.name}`,
+        };
+        for (const c of candidates) add(c, owner);
       }
     }
   }
@@ -1190,7 +1288,7 @@ function buildPackageReport(
   ruby: ApiManifest,
   ts: ApiManifest,
   excludeGlobs: string[],
-  globalRubyCandidates: Set<string>,
+  globalRubyCandidates: Map<string, RubyOwner[]>,
   crossPackageModules: Record<string, ClassInfo>,
   crossPackagePkgByFqn: Record<string, string>,
   novelOnly: boolean,
@@ -1327,7 +1425,8 @@ function buildPackageReport(
         allowlistedCount++;
         continue;
       }
-      const kind: ExtraKind = globalRubyCandidates.has(name) ? "moved" : "novel";
+      const owners = globalRubyCandidates.get(name);
+      const kind: ExtraKind = owners ? "moved" : "novel";
       // Exempt by kind — see `collectInterfaceOnlyNames`. Deliberately AFTER
       // the tag check: an interface tagged to cover its MEMBERS keeps matching
       // its own name, so the tag doesn't go stale and the inheritance in
@@ -1336,7 +1435,7 @@ function buildPackageReport(
         interfaceExemptCount++;
         continue;
       }
-      scored.push({ name, kind });
+      scored.push({ name, kind, ...(owners ? { owners } : {}) });
     }
 
     const fileTagReason = fileTags[expectedTs];
@@ -1355,7 +1454,10 @@ function buildPackageReport(
           cause,
           ...(rubyFile !== null ? { rubyFile } : {}),
           ...(cause === "moved-names"
-            ? { movedNames: undeclaredMovedNames(scored, fileTagReason) }
+            ? {
+                movedNames: undeclaredMovedNames(scored, fileTagReason),
+                movedOwners: undeclaredMovedOwners(scored, fileTagReason),
+              }
             : {}),
           ...(cause === "stale-moved-declaration"
             ? { staleMovedNames: staleMovedDeclarations(scored, fileTagReason) }
@@ -1495,7 +1597,7 @@ export function printClassificationBlock(
   if (elided > 0) console.log(`${p.dim}    … +${elided} more${p.reset}`);
 }
 
-function printHumanReport(report: Report, topN: number, maxDetail: number): void {
+function printHumanReport(report: Report, topN: number, maxDetail: number, verbose: boolean): void {
   const { palette: p } = pickPalette();
 
   console.log(`\n${p.bold}Extra TS surface vs Rails${p.reset}  (the inverse of api:compare)`);
@@ -1573,6 +1675,17 @@ function printHumanReport(report: Report, topN: number, maxDetail: number): void
       }
       const elided = f.extras.length - shown.length;
       if (elided > 0) console.log(`    ${p.dim}… +${elided} more${p.reset}`);
+      // Owners are --verbose-only: the report is already wide, and one line
+      // per moved name would multiply its height by default.
+      if (verbose) {
+        for (const e of shown) {
+          const top = e.kind === "moved" ? e.owners?.[0] : undefined;
+          if (!top) continue;
+          console.log(
+            `      ${p.dim}${e.name.padEnd(24)} → ${top.package} ${top.file} ${top.rubyName}${p.reset}`,
+          );
+        }
+      }
     }
     console.log();
   }
@@ -1691,9 +1804,21 @@ export function gateFileTagRejections(rejections: readonly FileTagRejection[]): 
         `MOVED-BY-SHORT-NAME name(s) that no longer score moved: ${list(r.staleMovedNames)}`
       );
     }
+    // Each moved name gets its crediting Rails member on its own line: that
+    // owner IS the verdict's evidence — five names crediting five unrelated
+    // classes across rack/actiondispatch/activerecord is a collision, ~80 all
+    // crediting one `.rb` is a rename owed.
+    const owned = (r.movedNames ?? []).slice(0, 8).map((n) => {
+      const top = r.movedOwners?.[n]?.[0];
+      return top === undefined
+        ? `      ${n}`
+        : `      ${n} → ${top.package} ${top.file} ${top.rubyName}`;
+    });
+    const more = (r.movedNames?.length ?? 0) > 8 ? "\n      …" : "";
     return (
-      `  - ${r.package}  ${r.tsFile} — ${r.movedNames?.length ?? 0} moved name(s): ` +
-      list(r.movedNames)
+      `  - ${r.package}  ${r.tsFile} — ${r.movedNames?.length ?? 0} moved name(s):\n` +
+      owned.join("\n") +
+      more
     );
   });
   return (
@@ -1788,7 +1913,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
   if (args.json) {
     console.log(JSON.stringify(report, null, 2));
   } else {
-    printHumanReport(report, args.topN, args.maxDetail);
+    printHumanReport(report, args.topN, args.maxDetail, args.verbose);
   }
 
   // Both gates are collected before exiting: a tree that is both stale and

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -1675,8 +1675,6 @@ function printHumanReport(report: Report, topN: number, maxDetail: number, verbo
       }
       const elided = f.extras.length - shown.length;
       if (elided > 0) console.log(`    ${p.dim}… +${elided} more${p.reset}`);
-      // Owners are --verbose-only: the report is already wide, and one line
-      // per moved name would multiply its height by default.
       if (verbose) {
         for (const e of shown) {
           const top = e.kind === "moved" ? e.owners?.[0] : undefined;
@@ -1789,6 +1787,11 @@ export function buildReport(
  * different: a stale tag is deleted, a refuted one is the signal that the file
  * needs per-name reasons — or renames — instead of a blanket.
  * Returns the failure message, or `null` when the run passes.
+ *
+ * A `moved-names` rejection lists each name with the Rails member it credits
+ * against: that owner is the verdict's evidence — five names crediting five
+ * unrelated classes across unrelated gems is a bare-short-name collision, ~80
+ * all crediting one `.rb` is a rename owed.
  */
 export function gateFileTagRejections(rejections: readonly FileTagRejection[]): string | null {
   if (rejections.length === 0) return null;
@@ -1804,10 +1807,6 @@ export function gateFileTagRejections(rejections: readonly FileTagRejection[]): 
         `MOVED-BY-SHORT-NAME name(s) that no longer score moved: ${list(r.staleMovedNames)}`
       );
     }
-    // Each moved name gets its crediting Rails member on its own line: that
-    // owner IS the verdict's evidence — five names crediting five unrelated
-    // classes across rack/actiondispatch/activerecord is a collision, ~80 all
-    // crediting one `.rb` is a rename owed.
     const owned = (r.movedNames ?? []).slice(0, 8).map((n) => {
       const top = r.movedOwners?.[n]?.[0];
       return top === undefined


### PR DESCRIPTION
Two RFC 0072 stories.

## 1. Moved extras carry the Rails owner they credit against

`buildGlobalRubyCandidates` flattened every camelized Ruby name into one
`Set<string>`, so `moved` could say a name exists somewhere in Rails but never
where — and "where" is the whole question the verdict asks: many names
crediting ONE Rails class in one `.rb` is a rename owed
(`postgresql/schema-statements-class.ts`), a handful crediting unrelated
classes across unrelated gems is a bare-short-name collision
(`sqlite/libsql.ts`, PR #6229, which needed a throwaway script to answer it).

- the oracle returns `Map<string, RubyOwner[]>` — `{ package, file, fqn, rubyName }`,
  captured at each `add` site it already had in hand (capped per name).
- `ExtraName` gains `owners?`, populated for `kind === "moved"` only.
- a `moved-names` file-tag rejection now prints one line per name:
  `close → activerecord connection_adapters/abstract_adapter.rb ActiveRecord::ConnectionAdapters::AbstractAdapter#close`
- `--verbose` prints owners under the per-file detail (off by default; the
  report is already wide).

Attribution only — `moved` scoring and `fileTagVerdict` are untouched and the
totals do not move. Removing libsql.ts's `MOVED-BY-SHORT-NAME` clause locally
reproduces all five owners straight out of `pnpm api:extra --package activerecord`.

## 2. `TimeZone[]` returns nil for an unmatched name or offset

`ActiveSupport::TimeZone.[]` returns `nil` for a name it cannot resolve
(`rescue TZInfo::InvalidTimezoneIdentifier; nil`, time_zone.rb:239-241) and for
an offset no zone matches (`all.find`, :246); it raises only for an argument of
the wrong class (:249). trails' `TimeZone.find` threw in all three cases, which
forced `findZoneBang` to keep its own argument-class arm.

- `TimeZone.find(arg: unknown): TimeZone | null` — the two nil arms, one raise.
- `TimeZone.create` becomes the allocator `alias_method :create, :new`
  (time_zone.rb:211) actually is: it RAISES for an unknown name, which is what
  `test_unknown_zone_raises_exception` asserts, while `[]` returns nil
  (`test_unknown_zones_dont_store_mapping_keys`).
- `findZoneBang` is now the single line zones.rb:83 is: `[]` plus the
  `Invalid Timezone:` raise.
- `TimeWithZone#inTimeZone` routes every argument through `find_zone!`
  (time_with_zone.rb:79 → zones.rb), so the offset and wrong-class arms of
  `test_in_time_zone_with_invalid_argument` raise as Rails does.
- one `ArgumentError` class, so `findZone`'s `instanceof` still narrows both raises.
- call-site sweep: `!` at the ~170 test sites with a literal zone name.

Closes-story: attribute-moved-extras-to-their-rails-owner
Closes-story: time-zone-index-returns-nil-instead-of-raising

---

Size: 723 LOC against the 700 ceiling. ~340 of that is the mechanical
one-character `!` sweep over ~170 test call sites (1 add + 1 delete each) that
story 2 specifies; the reviewable surface is the four source files.
