### PR TITLE
refactor(activerecord,activesupport): target loads go through an association instance; port TimeZone#<=>

### DIFF
--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -5,6 +5,7 @@
  * AssociationProxyTest, PreloaderTest, OverridingAssociationsTest,
  * GeneratedMethodsTest, and WithAnnotationsTest.
  */
+import { findCollectionTarget as findHasManyTarget } from "./test-helpers/find-collection-target.js";
 import { describe, it, expect, afterEach, beforeAll, beforeEach, vi } from "vitest";
 import { Base, association, reflectOnAssociation, registerModel, NameError, pp } from "./index.js";
 import { ArgumentError } from "@blazetrails/activemodel";
@@ -33,10 +34,7 @@ import { Member } from "./test-helpers/models/member.js";
 import { Membership } from "./test-helpers/models/membership.js";
 import { Human } from "./test-helpers/models/human.js";
 import { Interest } from "./test-helpers/models/interest.js";
-import {
-  findTarget as findHasManyTarget,
-  scope as hasManyScope,
-} from "./associations/has-many-association.js";
+import { scope as hasManyScope } from "./associations/has-many-association.js";
 import "./test-helpers/models/ship.js";
 import "./test-helpers/models/bird.js";
 import "./test-helpers/models/treasure.js";

--- a/packages/activerecord/src/associations/association-scope-cache.test.ts
+++ b/packages/activerecord/src/associations/association-scope-cache.test.ts
@@ -14,9 +14,9 @@
  * canonical `Author has_many :posts has_many :comments` fixtures instead of
  * synthetic `cache_*` tables.
  */
+import { findCollectionTarget as findHasManyTarget } from "../test-helpers/find-collection-target.js";
 import { describe, it, expect, beforeAll, afterEach, vi } from "vitest";
 import { registerModel, registerSubclass } from "../index.js";
-import { findTarget as findHasManyTarget } from "./has-many-association.js";
 import { AssociationScope } from "./association-scope.js";
 import { StatementCache } from "../statement-cache.js";
 import { fixtures } from "../test-fixtures.js";

--- a/packages/activerecord/src/associations/association-scope.test.ts
+++ b/packages/activerecord/src/associations/association-scope.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect } from "vitest";
 import { Base, registerModel, registerSubclass } from "../index.js";
 import { Associations } from "../associations.js";
 import { loadSingularTarget } from "../test-helpers/load-singular-target.js";
-import { findTarget } from "./has-many-association.js";
+import { findCollectionTarget as findTarget } from "../test-helpers/find-collection-target.js";
 import { AssociationScope, ReflectionProxy } from "./association-scope.js";
 import { fixtures } from "../test-fixtures.js";
 import { Author } from "../test-helpers/models/author.js";
@@ -494,7 +494,8 @@ describe("AssociationScope", () => {
     // (When the CPK includes "id", it collapses to "id" matching Rails'
     // join_id_for; only the no-id case is unrepresentable.)
     const { CompositePrimaryKeyMismatchError } = await import("../index.js");
-    const { findTarget } = await import("./has-many-association.js");
+    const { findCollectionTarget: findTarget } =
+      await import("../test-helpers/find-collection-target.js");
     class CpkAsOwner extends Base {
       declare a: number | null;
       declare b: number | null;

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -75,7 +75,6 @@ import {
 } from "./has-many-through-association.js";
 import {
   countRecords,
-  findTarget,
   scope as hasManyScope,
   setDifference,
   setIntersection,
@@ -883,6 +882,20 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * `strictLoadingValue` is applied afterward so it wins over cascade (Rails
    * applies `strict_loading_value` after `set_strict_loading` per record).
    */
+  private async _findTargetViaAssociation(queryExecutor?: () => Promise<Base[]>): Promise<Base[]> {
+    // A freshly built (uncached) holder rather than `record.association(name)`:
+    // this proxy IS the owner's holder for that name, so loading through the
+    // cached one would suppress the loader's writeback into it and mark it
+    // loaded behind the proxy's back.
+    const { _buildAssociationInstance } = await import("./instance-methods.js");
+    const assoc = _buildAssociationInstance.call(this._record, this._assocDef) as unknown as {
+      _queryExecutor?: () => Promise<Base[]>;
+      findTarget(): Promise<Base[]>;
+    };
+    assoc._queryExecutor = queryExecutor;
+    return assoc.findTarget();
+  }
+
   private async _execLoad(): Promise<T[]> {
     // Re-throw a foreign-key derivation error deferred from construction, so
     // the underivable-FK `ArgumentError` surfaces at load time (Rails'
@@ -898,12 +911,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
             _AssociationRelationCtor!.prototype as unknown as { toArray(): Promise<Base[]> }
           ).toArray.call(this)
       : undefined;
-    const results = (await findTarget(
-      this._record,
-      this._assocName,
-      this._assocDef.options,
-      queryExecutor,
-    )) as T[];
+    const results = (await this._findTargetViaAssociation(queryExecutor)) as T[];
     this._cascadeStrictLoading(results);
     // Relation's strict_loading wins over cascade — applied last to match
     // Rails: AssociationRelation#exec_queries runs set_strict_loading per
@@ -1808,7 +1816,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
         !this._assocDef.options.disableJoins &&
         !_routeThroughViaAssociationScope(this._record, refl, this._assocDef.options)
       ) {
-        const results = await findTarget(this._record, this._assocName, this._assocDef.options);
+        const results = await this._findTargetViaAssociation();
         return results.length;
       }
       // Routed shapes fall through to `countFn.call(this.scope())` below;

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -882,20 +882,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * `strictLoadingValue` is applied afterward so it wins over cascade (Rails
    * applies `strict_loading_value` after `set_strict_loading` per record).
    */
-  private async _findTargetViaAssociation(queryExecutor?: () => Promise<Base[]>): Promise<Base[]> {
-    // A freshly built (uncached) holder rather than `record.association(name)`:
-    // this proxy IS the owner's holder for that name, so loading through the
-    // cached one would suppress the loader's writeback into it and mark it
-    // loaded behind the proxy's back.
-    const { _buildAssociationInstance } = await import("./instance-methods.js");
-    const assoc = _buildAssociationInstance.call(this._record, this._assocDef) as unknown as {
-      _queryExecutor?: () => Promise<Base[]>;
-      findTarget(): Promise<Base[]>;
-    };
-    assoc._queryExecutor = queryExecutor;
-    return assoc.findTarget();
-  }
-
   private async _execLoad(): Promise<T[]> {
     // Re-throw a foreign-key derivation error deferred from construction, so
     // the underivable-FK `ArgumentError` surfaces at load time (Rails'
@@ -922,6 +908,23 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       for (const r of results) (r as any)._strictLoading = sv;
     }
     return results;
+  }
+
+  /**
+   * Runs `find_target` (`association.rb:248`) on a freshly built holder for
+   * this proxy's definition rather than on `record.association(name)`: this
+   * proxy IS the owner's holder for that name, so loading through the cached
+   * one would suppress the loader's writeback into it and mark it loaded
+   * behind the proxy's back.
+   */
+  private async _findTargetViaAssociation(queryExecutor?: () => Promise<Base[]>): Promise<Base[]> {
+    const { _buildAssociationInstance } = await import("./instance-methods.js");
+    const assoc = _buildAssociationInstance.call(this._record, this._assocDef) as unknown as {
+      _queryExecutor?: () => Promise<Base[]>;
+      findTarget(): Promise<Base[]>;
+    };
+    assoc._queryExecutor = queryExecutor;
+    return assoc.findTarget();
   }
 
   /**

--- a/packages/activerecord/src/associations/disable-joins-association-scope.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
 import { Base, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
-import { findTarget } from "./has-many-association.js";
+import { findCollectionTarget as findTarget } from "../test-helpers/find-collection-target.js";
 import { DisableJoinsAssociationScope } from "./disable-joins-association-scope.js";
 import { DisableJoinsAssociationRelation } from "../disable-joins-association-relation.js";
 import { fixtures } from "../test-fixtures.js";

--- a/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
@@ -18,7 +18,7 @@ import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
 import { Base, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
-import { findTarget } from "./has-many-association.js";
+import { findCollectionTarget as findTarget } from "../test-helpers/find-collection-target.js";
 import { DisableJoinsAssociationRelation } from "../disable-joins-association-relation.js";
 import { fixtures } from "../test-fixtures.js";
 

--- a/packages/activerecord/src/associations/disable-joins-routing-widening.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-routing-widening.test.ts
@@ -22,7 +22,7 @@ import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
 import { Base, registerModel } from "../index.js";
 import { Associations, association } from "../associations.js";
-import { findTarget } from "./has-many-association.js";
+import { findCollectionTarget as findTarget } from "../test-helpers/find-collection-target.js";
 import { fixtures } from "../test-fixtures.js";
 
 describe("DJAS routing widening — sourceType + polymorphic source", () => {

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -42,6 +42,15 @@ import { camelize, singularize, underscore } from "@blazetrails/activesupport";
  * Mirrors: ActiveRecord::Associations::HasManyAssociation
  */
 export class HasManyAssociation extends CollectionAssociation {
+  /**
+   * Set on an ad-hoc holder built by a CollectionProxy whose own Relation state
+   * has diverged from the seed (whereBang / orderBang / ...): `findTarget` then
+   * runs that mutated Relation instead of rebuilding the association scope.
+   * Rails has no counterpart because its CollectionProxy *is* the relation.
+   * @internal
+   */
+  _queryExecutor?: () => Promise<Base[]>;
+
   constructor(owner: Base, definition: AssociationDefinition) {
     super(owner, definition);
   }
@@ -154,8 +163,9 @@ export class HasManyAssociation extends CollectionAssociation {
    * Mirrors: ActiveRecord::Associations::Association#find_target
    * (association.rb:248) as reached through `CollectionAssociation#load_target`
    * (collection_association.rb:272). This is the association-instance entry
-   * point; it wraps the functional loader below, which the CollectionProxy and
-   * the through-association loaders reach without an association instance.
+   * point; it wraps the module-private loader below, which the CollectionProxy
+   * and the through-association loaders reach through an ad-hoc holder built by
+   * `_buildAssociationInstance`.
    */
   protected override async findTarget(): Promise<Base[]> {
     // Every caller assigns the returned records into this holder itself, so the
@@ -168,7 +178,7 @@ export class HasManyAssociation extends CollectionAssociation {
         this.owner,
         this.reflection.name,
         this.reflection.options,
-        undefined,
+        this._queryExecutor,
         this._skipStrictLoading,
       );
     } finally {
@@ -500,8 +510,9 @@ export function setIntersection(a: Base[], b: Base[]): Base[] {
  * Rails-shaped entry point (`ActiveRecord::Associations::Association#find_target`,
  * association.rb:248). It takes the owner/name/options triple rather than an
  * association instance because the CollectionProxy load path and the
- * through-association loaders reach the loader without one; that triple shape
- * is a trails-only calling convention, not Rails surface.
+ * through-association loaders build an *ad-hoc* holder for a name/options pair
+ * the model never declared that way; that triple shape is a trails-only
+ * calling convention, not Rails surface, and it is module-private.
  *
  * `skipStrictLoading` carries the association's `@skip_strict_loading`
  * (association.rb) into this loader, since the strict-loading check Rails runs
@@ -509,7 +520,7 @@ export function setIntersection(a: Base[], b: Base[]): Base[] {
  *
  * @internal
  */
-export async function findTarget(
+async function findTarget(
   record: Base,
   assocName: string,
   options: AssociationOptions,
@@ -577,8 +588,13 @@ export async function findTarget(
     // which the SQL JOIN cannot see — `_routeThroughViaAssociationScope` keeps
     // those on the 2-step loader.
     if (!_routeThroughViaAssociationScope(record, reflEarly, options)) {
-      const { findTarget: findThroughTarget } = await import("./has-many-through-association.js");
-      return findThroughTarget(record, assocName, options);
+      const { _buildAssociationInstance } = await import("./instance-methods.js");
+      const through = _buildAssociationInstance.call(record, {
+        name: assocName,
+        type: "hasMany",
+        options,
+      }) as unknown as { loadHasManyThrough(): Promise<Base[]> };
+      return through.loadHasManyThrough();
     }
     // Fall through into the AssociationScope path below.
   }

--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -2,6 +2,10 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
+import {
+  findCollectionTarget as findHasManyTarget,
+  findCollectionTarget as findHasManyThroughTarget,
+} from "../test-helpers/find-collection-target.js";
 import type { AssociationProxy } from "./collection-proxy.js";
 import { describe, it, expect, beforeAll } from "vitest";
 import { Notifications, throwAbort } from "@blazetrails/activesupport";
@@ -36,8 +40,6 @@ import { Bulb } from "../test-helpers/models/bulb.js";
 import { Developer, AuditLog } from "../test-helpers/models/developer.js";
 import { Project } from "../test-helpers/models/project.js";
 import { Associations, isAssociationCached } from "../associations.js";
-import { findTarget as findHasManyTarget } from "./has-many-association.js";
-import { findTarget as findHasManyThroughTarget } from "./has-many-through-association.js";
 import { DeleteRestrictionError } from "./errors.js";
 import { assertQueriesCount, assertNoQueries } from "../testing/query-assertions.js";
 

--- a/packages/activerecord/src/associations/has-many-mid-flight-reassignment.trails.test.ts
+++ b/packages/activerecord/src/associations/has-many-mid-flight-reassignment.trails.test.ts
@@ -13,7 +13,7 @@
 import { describe, it, expect } from "vitest";
 import { readdir, readFile } from "node:fs/promises";
 import { fixtures } from "../test-fixtures.js";
-import { findTarget } from "./has-many-association.js";
+import { findCollectionTarget as findTarget } from "../test-helpers/find-collection-target.js";
 import { Preloader } from "./preloader.js";
 import { AssociationTargetReplacedDuringLoad } from "../errors.js";
 import type { Base } from "../base.js";

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -1,7 +1,7 @@
 import type { Base } from "../base.js";
 import type { AssociationDefinition, AssociationOptions } from "../associations.js";
-import { association } from "./instance-methods.js";
-import { HasManyAssociation, findTarget as findHasManyTarget } from "./has-many-association.js";
+import { association, _buildAssociationInstance } from "./instance-methods.js";
+import { HasManyAssociation } from "./has-many-association.js";
 import {
   HasManyThroughCantAssociateThroughHasOneOrManyReflection,
   HasManyThroughNestedAssociationsAreReadonly,
@@ -54,6 +54,10 @@ export class HasManyThroughAssociation extends HasManyAssociation {
    * there agree by construction rather than by two copies of the gate.
    */
   protected override async findTarget(): Promise<Base[]> {
+    // A diverged CollectionProxy runs its own mutated Relation, which the
+    // through routing below would discard; `HasManyAssociation#findTarget` is
+    // where that executor is honored.
+    if (this._queryExecutor) return super.findTarget();
     if (!this.targetReflectionHasAssociatedRecord()) return [];
     const reflection = (this.owner.constructor as typeof Base)._reflectOnAssociation?.(
       this.reflection.name,
@@ -62,6 +66,19 @@ export class HasManyThroughAssociation extends HasManyAssociation {
       return _loadThroughViaDisableJoinsScope(this.owner, reflection, this.reflection.options);
     }
     return super.findTarget();
+  }
+
+  /**
+   * trails' two-step through loader: the through step is loaded first and its
+   * records drive a second query, for the shapes AssociationScope cannot build
+   * a single JOIN for. Rails has no counterpart — its `find_target` is always
+   * `scope.to_a` — so this is not `find_target` itself but the arm
+   * `HasManyAssociation#findTarget` routes to when
+   * `_routeThroughViaAssociationScope` says no.
+   * @internal
+   */
+  protected loadHasManyThrough(): Promise<Base[]> {
+    return loadHasManyThrough(this.owner, this.reflection.name, this.reflection.options);
   }
 
   /**
@@ -1098,12 +1115,30 @@ function targetReflectionHasAssociatedRecord(
 }
 
 /**
- * Mirrors: HasManyThroughAssociation#find_target
- * (has_many_through_association.rb:225).
- *
- * @internal
+ * Load a has_many target through a freshly built (uncached) holder. The
+ * through steps below name an association whose options are *not* the declared
+ * ones — a synthesised `sourceType` scope, or an owner that is a through
+ * record rather than this association's owner — so they must not reuse (or
+ * disturb) the owner's cached holder for that name.
  */
-export async function findTarget(
+function findHasManyTarget(
+  record: Base,
+  assocName: string,
+  options: AssociationOptions,
+): Promise<Base[]> {
+  const assoc = _buildAssociationInstance.call(record, {
+    name: assocName,
+    type: "hasMany",
+    options,
+  });
+  return (assoc as unknown as { findTarget(): Promise<Base[]> }).findTarget();
+}
+
+/**
+ * The body of `HasManyThroughAssociation#loadHasManyThrough` — trails' two-step
+ * through loader, for the shapes AssociationScope cannot build a JOIN for.
+ */
+async function loadHasManyThrough(
   record: Base,
   assocName: string,
   options: AssociationOptions,

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -52,11 +52,12 @@ export class HasManyThroughAssociation extends HasManyAssociation {
    * that loader is what runs it. The routing predicate stays the single one
    * `HasManyAssociation`'s loader consults, so the branch here and the branch
    * there agree by construction rather than by two copies of the gate.
+   *
+   * The `_queryExecutor` arm is a diverged CollectionProxy running its own
+   * mutated Relation, which the through routing would discard —
+   * `HasManyAssociation#findTarget` is where that executor is honored.
    */
   protected override async findTarget(): Promise<Base[]> {
-    // A diverged CollectionProxy runs its own mutated Relation, which the
-    // through routing below would discard; `HasManyAssociation#findTarget` is
-    // where that executor is honored.
     if (this._queryExecutor) return super.findTarget();
     if (!this.targetReflectionHasAssociatedRecord()) return [];
     const reflection = (this.owner.constructor as typeof Base)._reflectOnAssociation?.(

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -46,6 +46,10 @@ export class HasManyThroughAssociation extends HasManyAssociation {
    * `this`, exactly as Rails does, and delegates the query itself to
    * `HasManyAssociation#findTarget` (Rails' `super`).
    *
+   * `target_reflection_has_associated_record?` gates every arm, as it does in
+   * Rails (`return [] unless ...`, :227) — including the JOIN-routable one,
+   * which the flat loader used to reach without it.
+   *
    * Rails' `return scope.to_a if disable_joins` is trails'
    * `_loadThroughViaDisableJoinsScope`: `scope()`'s own `disable_joins` branch
    * (association.rb:302) builds the DisableJoinsAssociationScope relation, and

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -1,7 +1,6 @@
 import type { Base } from "../base.js";
 import type { AssociationDefinition, AssociationOptions } from "../associations.js";
-import { association } from "./instance-methods.js";
-import { findTarget as findHasManyTarget } from "./has-many-association.js";
+import { association, _buildAssociationInstance } from "./instance-methods.js";
 import { camelize, underscore } from "@blazetrails/activesupport";
 import { resolveAssocClass, _hmtNotFound } from "../associations.js";
 import { HasOneAssociation, sameRecord } from "./has-one-association.js";
@@ -65,6 +64,19 @@ export class HasOneThroughAssociation extends HasOneAssociation {
 
   constructor(owner: Base, definition: AssociationDefinition) {
     super(owner, definition);
+  }
+
+  /**
+   * trails' two-step through loader: the join record is loaded first and drives
+   * a second query, for the shapes AssociationScope cannot build a single JOIN
+   * for. Rails has no counterpart — its `find_target` is always `scope.first` —
+   * so this is not `find_target` itself but the arm
+   * `SingularAssociation#findTarget` routes to when
+   * `_routeThroughViaAssociationScope` says no.
+   * @internal
+   */
+  protected loadHasOneThrough(): Promise<Base | null> {
+    return loadHasOneThrough(this.owner, this.reflection.name, this.reflection.options);
   }
 
   override reset(): void {
@@ -725,10 +737,13 @@ function ensureNotNested(assoc: HasOneThroughAssociation): void {
 }
 
 /**
+ * The body of `HasOneThroughAssociation#loadHasOneThrough` — trails' two-step
+ * through loader, for the shapes AssociationScope cannot build a JOIN for.
+ *
  * Mirrors: SingularAssociation#find_target as inherited by
  * HasOneThroughAssociation (has_one_through_association.rb).
  */
-export async function findTarget(
+async function loadHasOneThrough(
   record: Base,
   assocName: string,
   options: AssociationOptions,
@@ -746,7 +761,15 @@ export async function findTarget(
   } else if (throughAssoc.type === "belongsTo") {
     throughRecord = (await association.call(record, throughAssoc.name).loadTarget()) as Base | null;
   } else if (throughAssoc.type === "hasMany") {
-    const throughRecords = await findHasManyTarget(record, throughAssoc.name, throughAssoc.options);
+    // A freshly built (uncached) holder: this loads the through step under the
+    // *through* association's own name and options, so it must not disturb the
+    // owner's cached holder for that name.
+    const throughHolder = _buildAssociationInstance.call(record, {
+      name: throughAssoc.name,
+      type: "hasMany",
+      options: throughAssoc.options,
+    }) as unknown as { findTarget(): Promise<Base[]> };
+    const throughRecords = await throughHolder.findTarget();
     throughRecord = throughRecords[0] ?? null;
   } else {
     throughRecord = null;

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -742,6 +742,10 @@ function ensureNotNested(assoc: HasOneThroughAssociation): void {
  *
  * Mirrors: SingularAssociation#find_target as inherited by
  * HasOneThroughAssociation (has_one_through_association.rb).
+ *
+ * A has_many through step is loaded on a freshly built (uncached) holder: it
+ * runs under the *through* association's own name and options, so it must not
+ * disturb the owner's cached holder for that name.
  */
 async function loadHasOneThrough(
   record: Base,
@@ -761,9 +765,6 @@ async function loadHasOneThrough(
   } else if (throughAssoc.type === "belongsTo") {
     throughRecord = (await association.call(record, throughAssoc.name).loadTarget()) as Base | null;
   } else if (throughAssoc.type === "hasMany") {
-    // A freshly built (uncached) holder: this loads the through step under the
-    // *through* association's own name and options, so it must not disturb the
-    // owner's cached holder for that name.
     const throughHolder = _buildAssociationInstance.call(record, {
       name: throughAssoc.name,
       type: "hasMany",

--- a/packages/activerecord/src/associations/instance-methods.ts
+++ b/packages/activerecord/src/associations/instance-methods.ts
@@ -20,7 +20,17 @@ import {
   type AssociationDefinition as AssocDef,
 } from "../associations.js";
 
-function buildAssociationInstance(this: Base, assocDef: AssocDef): AssociationInstance {
+/**
+ * Build the macro-specific Association for a definition, *without* caching it
+ * on the record. `association(name)` caches what it builds; the loaders that
+ * hold an ad-hoc definition (a through step carrying a synthesised `scope`, a
+ * through record standing in for the owner) build an uncached holder here
+ * instead, so loadedness, `_loaderWritebackSuppressed` and inverse wiring on
+ * the owner's real holder for that name are left alone.
+ *
+ * @internal
+ */
+export function _buildAssociationInstance(this: Base, assocDef: AssocDef): AssociationInstance {
   const opts = (assocDef.options ?? {}) as Record<string, unknown>;
   switch (assocDef.type) {
     case "belongsTo":
@@ -145,7 +155,7 @@ export function association(this: Base, name: string): AssociationInstance {
     throw _associationNotFound(this, name);
   }
 
-  const instance = buildAssociationInstance.call(this, assocDef);
+  const instance = _buildAssociationInstance.call(this, assocDef);
   this._associationInstances.set(name, instance);
   syncAssociationInstance.call(this, name, instance);
   return instance;

--- a/packages/activerecord/src/associations/inverse-associations.test.ts
+++ b/packages/activerecord/src/associations/inverse-associations.test.ts
@@ -1,6 +1,7 @@
 /**
  * Mirrors Rails activerecord/test/cases/associations/inverse_associations_test.rb
  */
+import { findCollectionTarget as findHasManyTarget } from "../test-helpers/find-collection-target.js";
 import { describe, it, expect, beforeAll } from "vitest";
 import { loadSingularTarget } from "../test-helpers/load-singular-target.js";
 import {
@@ -12,7 +13,6 @@ import {
   InverseOfAssociationRecursiveError,
   RecordNotFound,
 } from "../index.js";
-import { findTarget as findHasManyTarget } from "./has-many-association.js";
 import { fixtures } from "../test-fixtures.js";
 import { Branch, BrokenBranch } from "../test-helpers/models/branch.js";
 import { Human } from "../test-helpers/models/human.js";

--- a/packages/activerecord/src/associations/singular-association.ts
+++ b/packages/activerecord/src/associations/singular-association.ts
@@ -332,9 +332,9 @@ export class SingularAssociation extends Association {
           return _loadSingularThroughViaDisableJoinsScope(owner, reflection, options);
         }
         if (!_routeThroughViaAssociationScope(owner, reflection, options)) {
-          const { findTarget: findThroughTarget } =
-            await import("./has-one-through-association.js");
-          return findThroughTarget(owner, assocName, options);
+          return (
+            this as unknown as { loadHasOneThrough(): Promise<Base | null> }
+          ).loadHasOneThrough();
         }
         // Otherwise fall through to the scope path below.
       }

--- a/packages/activerecord/src/associations/source-type-validation.test.ts
+++ b/packages/activerecord/src/associations/source-type-validation.test.ts
@@ -32,7 +32,7 @@
 import { describe, it, expect } from "vitest";
 import { Base, registerModel } from "../index.js";
 import { Associations, association } from "../associations.js";
-import { findTarget } from "./has-many-association.js";
+import { findCollectionTarget as findTarget } from "../test-helpers/find-collection-target.js";
 import { fixtures } from "../test-fixtures.js";
 
 // Local model classes for testing invalid through-association configurations.

--- a/packages/activerecord/src/strict-loading.trails.test.ts
+++ b/packages/activerecord/src/strict-loading.trails.test.ts
@@ -7,10 +7,10 @@
  * strict-loading.test.ts (which mirrors strict_loading_test.rb) so the
  * convention file tracks Rails 1:1.
  */
+import { findCollectionTarget as findHasManyTarget } from "./test-helpers/find-collection-target.js";
 import { describe, it, expect } from "vitest";
 import { loadSingularTarget } from "./test-helpers/load-singular-target.js";
 import { StrictLoadingViolationError, registerModel } from "./index.js";
-import { findTarget as findHasManyTarget } from "./associations/has-many-association.js";
 import { fixtures } from "./test-fixtures.js";
 import { Developer, AuditLog } from "./test-helpers/models/developer.js";
 import { Ship } from "./test-helpers/models/ship.js";

--- a/packages/activerecord/src/test-helpers/find-collection-target.ts
+++ b/packages/activerecord/src/test-helpers/find-collection-target.ts
@@ -1,0 +1,27 @@
+import type { Base } from "../base.js";
+import type { AssociationOptions } from "../associations.js";
+import { _buildAssociationInstance } from "../associations/instance-methods.js";
+
+/**
+ * Runs a has_many load the way `CollectionProxy` and the through loaders do —
+ * `find_target` (`association.rb:248`) on an association holder — for an
+ * options set that is not necessarily the declared one.
+ *
+ * The holder is built fresh rather than taken from `record.association(name)`
+ * so the load leaves the record's real holder (its loadedness, its writeback
+ * suppression, its inverse wiring) untouched, which is what these tests want
+ * when they drive the loader directly.
+ *
+ * Test-only sugar: `find_target` is protected, as in Rails, so every call site
+ * would otherwise repeat the same cast. `async` so `check_validity!` — run when
+ * the holder is built, as in `Association#initialize` (`association.rb:41-45`) —
+ * surfaces as a rejection like every other load failure.
+ */
+export async function findCollectionTarget(
+  record: Base,
+  name: string,
+  options: AssociationOptions = {},
+): Promise<Base[]> {
+  const assoc = _buildAssociationInstance.call(record, { name, type: "hasMany", options });
+  return (assoc as unknown as { findTarget(): Promise<Base[]> }).findTarget();
+}

--- a/packages/activesupport/src/time-zone.test.ts
+++ b/packages/activesupport/src/time-zone.test.ts
@@ -683,10 +683,7 @@ describe("TimeZoneTest", () => {
     for (let i = 1; i < zones.length; i++) {
       const previous = zones[i - 1];
       const current = zones[i];
-      expect(
-        previous.utcOffset < current.utcOffset ||
-          (previous.utcOffset === current.utcOffset && previous.name < current.name),
-      ).toBe(true);
+      expect(previous.compareTo(current)).toBe(-1);
     }
     expect(zones.length).toBeGreaterThan(100);
     // Verify we get a reasonable set of zones

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -343,19 +343,17 @@ export class TimeZone {
 
   /**
    * Every Rails-named timezone: `@zones ||= zones_map.values.sort`
-   * (time_zone.rb:223-225), sorted by `<=>` — utc_offset, then name
-   * (time_zone.rb:333-337). `zones_map` keeps a MAPPING entry only when `[]`
-   * resolves it (`zones[name] = timezone if timezone`, time_zone.rb:288-291),
-   * hence the nullish filter.
+   * (time_zone.rb:223-225), sorted by `<=>` (time_zone.rb:333-337).
+   * `zones_map` keeps a MAPPING entry only when `[]` resolves it
+   * (`zones[name] = timezone if timezone`, time_zone.rb:288-291), hence the
+   * nullish filter.
    */
   static all(): TimeZone[] {
     if (zones) return zones;
     zones = Object.keys(MAPPING)
       .map((name) => TimeZone.find(name))
       .filter((zone): zone is TimeZone => zone != null)
-      .sort(
-        (a, b) => a.utcOffset - b.utcOffset || (a.name < b.name ? -1 : a.name > b.name ? 1 : 0),
-      );
+      .sort((a, b) => a.compareTo(b) ?? 0);
     return zones;
   }
 
@@ -734,6 +732,22 @@ export class TimeZone {
     const h = String(Math.floor(abs / 3600)).padStart(2, "0");
     const m = String(Math.floor((abs % 3600) / 60)).padStart(2, "0");
     return colon ? `${sign}${h}:${m}` : `${sign}${h}${m}`;
+  }
+
+  /**
+   * Compare this time zone to the parameter. The two are compared first on
+   * their offsets, and then by name (time_zone.rb:333-337). Returns
+   * `undefined` — Ruby's bare `return` — when the argument does not respond
+   * to `utc_offset`.
+   */
+  compareTo(zone: unknown): number | undefined {
+    if (typeof (zone as { utcOffset?: unknown } | null | undefined)?.utcOffset !== "number") {
+      return undefined;
+    }
+    const other = zone as TimeZone;
+    let result = this.utcOffset < other.utcOffset ? -1 : this.utcOffset > other.utcOffset ? 1 : 0;
+    if (result === 0) result = this.name < other.name ? -1 : this.name > other.name ? 1 : 0;
+    return result;
   }
 
   /**

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-many-through-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-many-through-association.json
@@ -51,6 +51,13 @@
   {
     "package": "activerecord",
     "tsFile": "associations/has-many-through-association.ts",
+    "rubyName": "find_target",
+    "call": "scope",
+    "reason": "Baseline (RFC 0084): `find_target` delegates to the module-private loader in the same file, which builds and runs the association scope; the body compared here is the delegating wrapper, so `scope` is called one frame down. Surfaced when the loader stopped being exported (RFC 0072)."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-many-through-association.ts",
     "rubyName": "stale_state",
     "call": "belongs_to?",
     "reason": "Rails ThroughAssociation#stale_state calls these; TS mirrors them in staleStateImpl (through-association.ts) which HasManyThroughAssociation#staleState delegates to."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/singular-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/singular-association.json
@@ -5,5 +5,12 @@
     "rubyName": "find_target",
     "call": "first",
     "reason": "Rails' `super.then(&:first)` is Array#first over the array Association#find_target already loaded, not Relation#first; take() (unordered LIMIT 1) is the SQL-level equivalent — Relation#first would route through ordered_relation and add the ORDER BY that has_one_associations_test `test_has_one_does_not_use_order_by` forbids. The statement-cache branch's literal .first() lives in the extracted _loadSingularViaStatementCache helper (associations.ts)."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/singular-association.ts",
+    "rubyName": "find_target",
+    "call": "scope",
+    "reason": "Baseline (RFC 0084): `find_target` delegates to the module-private loader in the same file, which builds and runs the association scope; the body compared here is the delegating wrapper, so `scope` is called one frame down. Surfaced when the loader stopped being exported (RFC 0072)."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/singular-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/singular-association.json
@@ -5,12 +5,5 @@
     "rubyName": "find_target",
     "call": "first",
     "reason": "Rails' `super.then(&:first)` is Array#first over the array Association#find_target already loaded, not Relation#first; take() (unordered LIMIT 1) is the SQL-level equivalent — Relation#first would route through ordered_relation and add the ORDER BY that has_one_associations_test `test_has_one_does_not_use_order_by` forbids. The statement-cache branch's literal .first() lives in the extracted _loadSingularViaStatementCache helper (associations.ts)."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/singular-association.ts",
-    "rubyName": "find_target",
-    "call": "scope",
-    "reason": "Baseline (RFC 0084): `find_target` delegates to the module-private loader in the same file, which builds and runs the association scope; the body compared here is the delegating wrapper, so `scope` is called one frame down. Surfaced when the loader stopped being exported (RFC 0072)."
   }
 ]


### PR DESCRIPTION
## What

Two RFC 0072 parity-burndown stories.

### 1. Retire the module-level `findTarget` engine exports

The `findTarget(record, assocName, options)` engines in
`has-many-association.ts`, `has-many-through-association.ts` and
`has-one-through-association.ts` are no longer exported (#6235 retired
`singular-association.ts`'s while this branch was open; what remains there is
its `:through` arm, which now routes to
`HasOneThroughAssociation#loadHasOneThrough` on `this` instead of importing the
sibling module's export) — each is module-private, reached only through the Rails-shaped
`find_target` instance method (`association.rb:248`,
`singular_association.rb:47-55`, `has_many_through_association.rb:225`), as in
Rails where the loader is a method on an `Association` built from a validated
reflection (`association.rb:41-45`).

Every caller now goes through an association instance:

- `CollectionProxy#_execLoad` and the `count` loader fallback
  (`collection-proxy.ts`) — the diverged-scope `queryExecutor` rides on the
  holder as `_queryExecutor` rather than a loader parameter.
- The cross-file routing arms (`has-many-association.ts` → the has_many-through
  two-step loader, `singular-association.ts` → the has_one-through one) reach
  them as `HasManyThroughAssociation#loadHasManyThrough` /
  `HasOneThroughAssociation#loadHasOneThrough`.
- The through loaders' own has_many steps.

#### One intended behavior change

Dispatching by macro means a CollectionProxy load of a `has_many :through` now
enters `HasManyThroughAssociation#findTarget` and so runs
`target_reflection_has_associated_record?`
(`has_many_through_association.rb:227`, `return [] unless ...`) on **every**
path. Previously the proxy called the flat loader directly and only reached the
equivalent check on the two-step arm, so a JOIN-routable through step whose
`belongs_to` foreign key is nil issued the JOIN instead of short-circuiting.
Rails runs that guard unconditionally at the top of `find_target`, so this is a
convergence, and it is the one load-path difference in this PR.

It is covered by the ported
`test_has_many_association_through_a_belongs_to_association_where_the_association_doesnt_exist`
(`has_many_through_associations_test.rb:937`,
`has-many-through-associations.test.ts:1442`), which reads `post.authorFavorites`
through the proxy with a nil `author_id`.

Callers that hold an *ad-hoc* `(name, options)` pair — a through step carrying
the synthesised `sourceType` scope, or a through record standing in for the
owner — build an **uncached** holder via `_buildAssociationInstance`, so the
owner's real cached holder for that name keeps its loadedness,
`_loaderWritebackSuppressed` state and inverse wiring. The loaders' bodies are
unchanged; apart from the guard described below, the load paths behave as
before and only the entry point moved.

Tests that drove the loader directly now go through
`test-helpers/find-collection-target.ts` (the collection sibling of the existing
`loadSingularTarget` helper). No test was renamed.
`singular-find-target-undeclared.trails.test.ts` is gone — #6235 deleted it for
the same reason this PR would have rewritten it: an undeclared name cannot reach
the loader at all any more, because `association` raises
`AssociationNotFoundError` first (`associations.rb:56`).

One `find_target`/`scope` call-mismatch row is baselined
(`has-many-through-association.ts`): with the export gone, the delegating
instance method is what the call comparison sees, and `scope` is called one
frame down in the same file.

### 2. Port `TimeZone#<=>` instead of inlining its comparator in `all()`

`ActiveSupport::TimeZone#<=>` (`time_zone.rb:333-337`) is ported as
`compareTo` — the name `docs/ruby-ts-conventions.md` maps `<=>` to, matching
`TimeWithZone#compareTo`. It compares on `utcOffset`, then `name`, and returns
`undefined` (Ruby's bare `return`) for an argument with no `utc_offset`.
`all()` (`time_zone.rb:224`) sorts with it; `time_zone_test.rb`'s
`test_all_sorted` asserts through it.

## Testing

`pnpm vitest run packages/activerecord/src/associations/` (92 files, 1997
tests), `associations.test.ts`, `strict-loading.trails.test.ts` and
`time-zone.test.ts` all green. `pnpm typecheck`, `pnpm api:compare`,
`pnpm api:calls` and `pnpm api:extra --package activerecord --novel-only`
(no new novel entries in `associations.ts` or the four association files) clean.

## Note on the third bundled story

`move-adapter-specific-snapshot-off-ar-internal-metadata` was released
unbuilt — its own recorded findings say the viable arm (the run-token sidecar)
is larger than one PR and that `loadSchema` / `canonical-schema-stamp.ts` /
`test-setup-dy.ts` must be reshaped one story at a time, so it does not belong
in this diff.

Closes-story: retire-module-level-find-target-engine-exports
Closes-story: time-zone-spaceship-comparator-is-inlined-in-all
