### PR TITLE
refactor(activerecord): PostgreSQLAdapter reads databaseVersion through the pool memo

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -197,8 +197,6 @@ describeIfPg("PostgreSQLAdapter", () => {
     it("reconnect after bad connection on check version", async () => {
       // Cache the true version off a live connection.
       expect(await adapter.getDatabaseVersion()).toBeGreaterThan(0);
-      // Mimic a connection that hasn't checked and cached the server version yet.
-      (adapter as unknown as { _databaseVersion: number | null })._databaseVersion = null;
       // Stub server_version to 0 (Rails: raw_connection.stub(:server_version, 0)).
       const versionSpy = vi.spyOn(adapter, "_serverVersion").mockResolvedValue(0);
       await expect(adapter.getDatabaseVersion()).rejects.toBeInstanceOf(ConnectionFailed);
@@ -209,7 +207,6 @@ describeIfPg("PostgreSQLAdapter", () => {
 
       // Can reconnect after a bad connection.
       await adapter.reconnectBang();
-      (adapter as unknown as { _databaseVersion: number | null })._databaseVersion = null;
       expect(await adapter.getDatabaseVersion()).toBeGreaterThan(0);
     });
 

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -1327,12 +1327,11 @@ describe("PostgreSQLAdapter supports_* predicates (unit)", () => {
 
   function stubVersion(adapter: PostgreSQLAdapter, version: number): void {
     (adapter as any)._initialized = true;
-    (adapter as any)._databaseVersion = version;
     (adapter as any)._hasOptimizerHints = false;
     // `database_version` reads the pool memo (`abstract_adapter.rb:854-856`),
-    // so restubbing the adapter's own version has to clear the memo too —
-    // otherwise the first stub's value is the one every later read answers.
-    (adapter.pool as unknown as { _serverVersion: unknown })._serverVersion = null;
+    // which is the only place the version is cached, so the stub is staged
+    // there.
+    (adapter.pool as unknown as { _serverVersion: unknown })._serverVersion = version;
   }
 
   it("always-true predicates return true regardless of version", async () => {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -463,7 +463,6 @@ export class PostgreSQLAdapter
    * answers IDLE/INTRANS while that command is mid-cycle.
    */
   private _commandSettled = true;
-  private _databaseVersion: number | null = null;
   private _typeMap: HashLookupTypeMap | null = null;
   private _maxIdentifierLength: number | null = null;
   private _useInsertReturning = true;
@@ -782,22 +781,10 @@ export class PostgreSQLAdapter
    */
   private async _maybeConfigureConnection(client: pg.Client): Promise<void> {
     if (this._connectionConfigured) return;
-    // Deviation, language-forced: Rails' configure_connection opens with `super`
-    // (postgresql_adapter.rb:957), whose check_version reads the lazy sync
-    // `database_version`. Ours cannot self-fetch, so the memo is filled at that
-    // same position. Issued DIRECTLY on `client`, like the SET statements below:
-    // getDatabaseVersion() acquires its own client and would re-enter the
-    // acquire machinery still holding `_acquiring`. A zero version is left
-    // uncached so getDatabaseVersion()'s ConnectionFailed path still owns it.
-    if (this._databaseVersion === null) {
-      const version = await this._serverVersion(client);
-      if (version !== 0) this._databaseVersion = version;
-    }
-    // `super`'s check_version (abstract_adapter.rb:1212-1214), at the position
-    // Rails calls it from. Skipped when the probe came back zero: that path is
-    // owned by getDatabaseVersion()'s ConnectionFailed handling, not by the
-    // version floor.
-    if (this._databaseVersion !== null) await this.checkVersion();
+    // Mirrors: `super` at the top of PostgreSQLAdapter#configure_connection
+    // (postgresql_adapter.rb:957) — warms the pool's server_version memo and
+    // runs check_version (abstract_adapter.rb:1212-1214).
+    await super.configureConnection();
     // Rails resets @mapped_default_timezone = nil while installing decoders in
     // configure_connection (postgresql_adapter.rb:1112) so the next
     // update_typemap_for_default_timezone re-applies the session timezone. This
@@ -3224,37 +3211,34 @@ export class PostgreSQLAdapter
   }
 
   /**
-   * Fetch and cache the server version number. Called automatically on
-   * the first query via _ensureInitialized(). Version-dependent
-   * supports_* methods throw if called before initialization.
+   * Mirrors: PostgreSQLAdapter#get_database_version
+   * (`postgresql_adapter.rb:634-643`) — a pure fetch, run at most once through
+   * the pool memo (`pool_config.rb:39-41`,
+   * `abstract/connection_pool.rb:30-32`) that `configureConnection` warms at
+   * connect time.
+   *
+   * Deviation, language-forced: Rails' `with_raw_connection` is re-entrant on
+   * `@raw_connection`, so this runs on the connection being configured. Ours
+   * takes the published `_rawConnection` when there is one for the same reason
+   * — `_acquireFreshClient()` would await the very acquire this call is nested
+   * inside.
    */
   async getDatabaseVersion(): Promise<number> {
-    if (this._databaseVersion !== null) return this._databaseVersion;
-    // Off the withRawConnection loop: this is a memoized bootstrap probe run
-    // during init / schema introspection (lock-free). Acquire the raw client
-    // directly via _acquireFreshClient(); tear down on a dead socket so the next caller
-    // gets a fresh connection (the recovery withClient used to provide).
-    {
-      const client = await this._acquireFreshClient();
-      try {
-        const version = await this._serverVersion(client);
-        // Mirrors Rails' get_database_version: a zero version means the version
-        // probe failed (e.g. a half-open connection), so don't cache it — raise
-        // ConnectionFailed so the reconnect path can retry.
-        if (version === 0) {
-          throw new ConnectionFailed("Could not determine PostgreSQL version");
-        }
-        this._databaseVersion = version;
-      } catch (error) {
-        if (PostgreSQLAdapter._isConnectionError(error)) this._discardRawConnection();
-        throw error;
+    const conn = this._rawConnection ?? (await this._acquireFreshClient());
+    let version: number;
+    try {
+      version = await this._serverVersion(conn);
+      if (version === 0) {
+        throw new ConnectionFailed("Could not determine PostgreSQL version");
       }
+    } catch (error) {
+      if (PostgreSQLAdapter._isConnectionError(error)) this._discardRawConnection();
+      throw error;
     }
     // Eagerly populate optimizer hints flag
     if (this._hasOptimizerHints === null) {
       try {
-        const client = await this._acquireFreshClient();
-        const result = await client.query(
+        const result = await conn.query(
           "SELECT COUNT(*) AS count FROM pg_available_extensions WHERE name = $1",
           ["pg_hint_plan"],
         );
@@ -3268,7 +3252,7 @@ export class PostgreSQLAdapter
         this._hasOptimizerHints = false;
       }
     }
-    return this._databaseVersion;
+    return version;
   }
 
   /**


### PR DESCRIPTION
Retires `PostgreSQLAdapter`'s `_databaseVersion` field, so PG reads the server
version through the single pool memo Rails has.

Rebased onto #6226, which landed the other half: `databaseVersion` fetches on
demand, the PG getter override is already gone, and the `number` narrowing
already rides on declaration merging. What remained is the adapter-level memo.

- `getDatabaseVersion()` is now the pure fetch of `postgresql_adapter.rb:634-643`:
  probe `server_version`, raise `ConnectionFailed` on zero, return. No local memo
  — `pool_config.rb:39-41` / `abstract/connection_pool.rb:30-32` is the only cache.
  It runs on the published `_rawConnection` when there is one, mirroring Rails'
  re-entrant `with_raw_connection`; that is what lets the nested call from
  `configureConnection` work without re-entering the acquire stack.
- `_maybeConfigureConnection` now opens with `await super.configureConnection()`,
  the `super` at `postgresql_adapter.rb:957`, which warms `pool.serverVersion(this)`
  and runs `checkVersion()` (`abstract_adapter.rb:1212-1214`) — replacing the
  hand-rolled memo fill and the conditional `checkVersion()` that stood in for it.

No new `@noRailsEquivalent` tag and no new writer on `NullPool` — the memo it
needed already exists there (`abstract/connection_pool.rb:30-32`), contrary to the
story's premise.

Tests that staged or cleared the private field now stage the pool memo, or drop
the line entirely where a re-fetch is now unconditional.

Local: `connection-adapters/` + `adapters/postgresql/` green against PG 17
(2667 passed). `pnpm api:extra` shows no new extra surface (`postgresql-adapter.ts`
novel set unchanged: `exec`, `executeMutation`); `pnpm api:calls` ratchet OK;
`pnpm test:compare` unchanged.

Closes-story: retire-pg-database-version-override
