### PR TITLE
refactor(activerecord,api-compare): PG DDL-quoting suite leases the ambient connection; a home bucket credits each reopening to its own file

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts
@@ -9,7 +9,10 @@ import {
   AlterTable,
   type SchemaStatementsConstraintLike,
 } from "./schema-definitions.js";
-import { SchemaCreation as PgSchemaCreation } from "./schema-creation.js";
+import {
+  SchemaCreation as PgSchemaCreation,
+  type PgSchemaCreationHost,
+} from "./schema-creation.js";
 import { Base } from "../../base.js";
 import { describeIfPostgresqlAdapter } from "../../support/describe-if-postgresql-adapter.js";
 import type { TableDefinitionConn } from "../abstract/schema-definitions.js";
@@ -511,7 +514,7 @@ describeIfPostgresqlAdapter("TableDefinition#toSql default quoting", () => {
     const td = new TableDefinition("messages", { adapter: leased });
     td.string("body", { default: "Bob's" });
     td.uniqueConstraint("body", { name: "unique_body" });
-    const sql = await new PgSchemaCreation(leased as never).accept(td);
+    const sql = await new PgSchemaCreation(leased as unknown as PgSchemaCreationHost).accept(td);
     expect(sql).toContain("Bob''s");
     expect(sql).toContain('CONSTRAINT "unique_body"');
   });

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeAll } from "vitest";
 import { SchemaDumper } from "../../schema-dumper.js";
 import { ColumnDefinition } from "../abstract/schema-definitions.js";
 import {
@@ -13,8 +13,6 @@ import { SchemaCreation as PgSchemaCreation } from "./schema-creation.js";
 import { Base } from "../../base.js";
 import { describeIfPostgresqlAdapter } from "../../support/describe-if-postgresql-adapter.js";
 import type { TableDefinitionConn } from "../abstract/schema-definitions.js";
-import { describeIfPg, PG_TEST_URL } from "../../support/describe-if-pg.js";
-import { PostgreSQLAdapter } from "../postgresql-adapter.js";
 
 // Rails hands `TableDefinition#initialize` / `SchemaCreation.new` an
 // `ActiveRecord::Base.lease_connection`, and its PostgreSQL DDL-rendering tests
@@ -508,22 +506,12 @@ describeIfPostgresqlAdapter("TableDefinition#toSql", () => {
   });
 });
 
-describeIfPg("TableDefinition#toSql default quoting", () => {
-  let conn: PostgreSQLAdapter;
-
-  beforeAll(() => {
-    conn = new PostgreSQLAdapter(PG_TEST_URL);
-  });
-
-  afterAll(() => {
-    conn.disconnect();
-  });
-
+describeIfPostgresqlAdapter("TableDefinition#toSql default quoting", () => {
   it("handles default values containing doubled single-quotes without mis-parsing", async () => {
-    const td = new TableDefinition("messages", { adapter: conn });
+    const td = new TableDefinition("messages", { adapter: leased });
     td.string("body", { default: "Bob's" });
     td.uniqueConstraint("body", { name: "unique_body" });
-    const sql = await new PgSchemaCreation(conn).accept(td);
+    const sql = await new PgSchemaCreation(leased as never).accept(td);
     expect(sql).toContain("Bob''s");
     expect(sql).toContain('CONSTRAINT "unique_body"');
   });

--- a/packages/activerecord/src/defaults.test.ts
+++ b/packages/activerecord/src/defaults.test.ts
@@ -14,7 +14,7 @@ import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/a
 import { Mysql2Adapter } from "./connection-adapters/mysql2-adapter.js";
 import { describeIfMysqlAdapter } from "./support/describe-if-mysql-adapter.js";
 import { isMariaDb, MYSQL_TEST_URL } from "./support/mysql-server-version.js";
-import { describeIfPg } from "./support/describe-if-pg.js";
+import { describeIfPostgresqlAdapter } from "./support/describe-if-postgresql-adapter.js";
 import { describeIfSqlite } from "./support/describe-if-sqlite.js";
 import { describeIfSupports, itIfSupports } from "./support/supports.js";
 import { fixtures } from "./test-fixtures.js";
@@ -247,7 +247,7 @@ describeIfSupports("text_column_with_default", "DefaultTextTest", () => {
 // Mirrors `PostgresqlDefaultExpressionTest` (defaults_test.rb), gated to the
 // PostgreSQLAdapter. The `defaults` table comes from postgresql_specific_schema.rb
 // and is laid at boot by the adapter-specific arm of loadSchema.
-describeIfPg("PostgresqlDefaultExpressionTest", () => {
+describeIfPostgresqlAdapter("PostgresqlDefaultExpressionTest", () => {
   let adapter: DatabaseAdapter;
 
   beforeEach(() => {

--- a/packages/activerecord/src/dirty.test.ts
+++ b/packages/activerecord/src/dirty.test.ts
@@ -27,7 +27,7 @@ import { TimeWithZone, getZone } from "@blazetrails/activesupport";
 import { Temporal } from "@blazetrails/date";
 
 import { itIfSupports } from "./support/supports.js";
-import { describeIfPg } from "./support/describe-if-pg.js";
+import { describeIfPostgresqlAdapter } from "./support/describe-if-postgresql-adapter.js";
 import { withTimezoneConfig } from "./test-helper.js";
 import { fixtures } from "./test-fixtures.js";
 import { rebuildCanonicalTables } from "./support/canonical-table-rebuild.js";
@@ -1184,7 +1184,7 @@ describe("DirtyTest", () => {
 // Mirrors: activerecord/test/cases/dirty_test.rb
 //   if current_adapter?(:PostgreSQLAdapter) && supports_identity_columns?
 // ==========================================================================
-describeIfPg("DirtyTest", () => {
+describeIfPostgresqlAdapter("DirtyTest", () => {
   fixtures([], { useTransactionalTests: false });
 
   itIfSupports(

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -36,7 +36,7 @@ function emitTableSql(td: TableDefinition): Promise<string> {
 import { Person } from "./test-helpers/models/person.js";
 import { loadSchemaFromAdapter } from "./model-schema.js";
 import { itIfSupports, describeIfSupports } from "./support/supports.js";
-import { describeIfPg } from "./support/describe-if-pg.js";
+import { describeIfPostgresqlAdapter } from "./support/describe-if-postgresql-adapter.js";
 import { Mysql2Adapter } from "./connection-adapters/mysql2-adapter.js";
 import { describeIfMysqlAdapter } from "./support/describe-if-mysql-adapter.js";
 import { leaseMysqlAdapter } from "./adapters/abstract-mysql-adapter/test-helper.js";
@@ -257,7 +257,7 @@ describe("MigrationTest", () => {
     );
   });
 
-  describeIfPg("IndexForTableWithSchemaMigrationTest", () => {
+  describeIfPostgresqlAdapter("IndexForTableWithSchemaMigrationTest", () => {
     // Schema-qualified `my_schema.values`: Rails' PG `index_name` strips the
     // schema (postgresql/schema_statements.rb) → `index_values_on_value`,
     // created in `my_schema` via the schema-qualified table, and `remove_index`
@@ -1745,7 +1745,7 @@ describe("MigrationTest", () => {
     });
   });
 
-  describeIfPg("PostgresqlIndexTest", () => {
+  describeIfPostgresqlAdapter("PostgresqlIndexTest", () => {
     // Mirrors PostgreSQLAdapterTest#test_invalid_index — a failed CONCURRENTLY
     // unique index is left behind marked invalid; Migration#indexExists must
     // forward `valid` to distinguish it, matching the adapter twin.

--- a/packages/activerecord/src/migration/change-table.test.ts
+++ b/packages/activerecord/src/migration/change-table.test.ts
@@ -5,7 +5,7 @@ import {
   type SchemaStatementsLike,
 } from "../connection-adapters/abstract/schema-definitions.js";
 import { Table as PgTable } from "../connection-adapters/postgresql/schema-definitions.js";
-import { describeIfPg } from "../support/describe-if-pg.js";
+import { describeIfPostgresqlAdapter } from "../support/describe-if-postgresql-adapter.js";
 
 type Call = { method: string; args: unknown[] };
 type ExpectFn = (method: string, returns: unknown, args: unknown[]) => void;
@@ -378,7 +378,7 @@ describe("Migration", () => {
     });
   });
 
-  describeIfPg("TableTest", () => {
+  describeIfPostgresqlAdapter("TableTest", () => {
     it("json creates json column", async () => {
       await withPgChangeTable(async (t, expect) => {
         expect("addColumn", null, ["delete_me", "foo", "json"]);

--- a/packages/activerecord/src/support/describe-if-pg.ts
+++ b/packages/activerecord/src/support/describe-if-pg.ts
@@ -48,5 +48,17 @@ export const pgHasHintPlan = probe.hasHintPlan;
  * than the `adapters/postgresql/` test-helper because suites outside that tree
  * gate on it too — a test file should never have to import glue from another
  * adapter's tree. Counterpart to `describeIfSqlite` / `describeIfMysqlAdapter`.
+ *
+ * This is a *server probe*, not the port of `current_adapter?(:PostgreSQLAdapter)`
+ * — it runs on the sqlite and mysql2 lanes too whenever a PostgreSQL server
+ * answers, so a suite under it cannot lease `Base.connection` and must bring
+ * its own adapter. A suite whose body is a plain `Base.connection` interaction
+ * belongs under `describeIfPostgresqlAdapter` instead; that distinction has
+ * been re-derived three times, so: the surviving users of this probe are the
+ * ones that construct a `PostgreSQLAdapter` from `PG_TEST_URL` (the whole
+ * `adapters/postgresql/` tree, `connection-adapters/postgresql/
+ * schema-statements.test.ts`, `postgresql-adapter.transaction-status.trails.
+ * test.ts`, `load-schema-helper-uuid-default.trails.test.ts`) plus the
+ * `pgAvailable` / `pgServerVersion` / `pgHasHintPlan` readers. Do not widen it.
  */
 export const describeIfPg = pgAvailable ? describe : (describe.skip as typeof describe);

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -8,6 +8,7 @@ import {
   tsShouldIncludeInIndex,
   flattenIncludedMethodInfos,
   mixinMethodCreditedToOwnFile,
+  reopeningMethodCreditedToOwnFile,
   resolveModuleName,
   buildModuleIncluderFqns,
   dedupeRubyMethodInto,
@@ -1399,7 +1400,11 @@ describe("dedupeRubyMethodInto", () => {
     dedupeRubyMethodInto(seen, rm("invert"), "Foo::C");
     expect(seen.size).toBe(1);
     // First insertion wins, so the FQN points at the first observer.
-    expect([...seen.values()][0]).toEqual({ rubyName: "invert", rubyModule: "Foo::A" });
+    expect([...seen.values()][0]).toEqual({
+      rubyName: "invert",
+      rubyModule: "Foo::A",
+      definedInFile: "x.rb",
+    });
   });
 });
 
@@ -1735,6 +1740,70 @@ describe("mixinMethodCreditedToOwnFile", () => {
         "base.rb",
         "activerecord",
         () => false,
+        tsMethodsByFile,
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("reopeningMethodCreditedToOwnFile", () => {
+  // `core_ext/object/acts_like.rb` is the first core_ext file to reopen Object,
+  // so `blank?`, `duplicable?` and `instance_values` all bucket under it while
+  // trails ports each to the file mirroring its own reopening.
+  const tsMethodsByFile = new Map([
+    ["core-ext/object/blank.ts", new Set(["isBlank", "isPresent"])],
+    ["core-ext/object/duplicable.ts", new Set(["isDuplicable"])],
+    ["core-ext/object/instance-variables.ts", new Set(["instanceValues"])],
+  ]);
+
+  it("credits each reopening's arm to the TS file mirroring that reopening", () => {
+    expect(
+      reopeningMethodCreditedToOwnFile(
+        { rubyName: "duplicable?", definedInFile: "core_ext/object/duplicable.rb" },
+        "core_ext/object/acts_like.rb",
+        "activesupport",
+        tsMethodsByFile,
+      ),
+    ).toEqual({ tsName: "isDuplicable", tsFile: "core-ext/object/duplicable.ts" });
+
+    expect(
+      reopeningMethodCreditedToOwnFile(
+        { rubyName: "instance_values", definedInFile: "core_ext/object/instance_variables.rb" },
+        "core_ext/object/acts_like.rb",
+        "activesupport",
+        tsMethodsByFile,
+      ),
+    ).toEqual({ tsName: "instanceValues", tsFile: "core-ext/object/instance-variables.ts" });
+  });
+
+  it("does not credit a method the home file defines itself", () => {
+    expect(
+      reopeningMethodCreditedToOwnFile(
+        { rubyName: "acts_like?", definedInFile: "core_ext/object/acts_like.rb" },
+        "core_ext/object/acts_like.rb",
+        "activesupport",
+        tsMethodsByFile,
+      ),
+    ).toBeNull();
+  });
+
+  it("does not credit a reopening arm that is unported in its own file", () => {
+    expect(
+      reopeningMethodCreditedToOwnFile(
+        { rubyName: "deep_dup", definedInFile: "core_ext/object/duplicable.rb" },
+        "core_ext/object/acts_like.rb",
+        "activesupport",
+        tsMethodsByFile,
+      ),
+    ).toBeNull();
+  });
+
+  it("does not credit when the reopening's TS file is absent from the run", () => {
+    expect(
+      reopeningMethodCreditedToOwnFile(
+        { rubyName: "to_query", definedInFile: "core_ext/object/to_query.rb" },
+        "core_ext/object/acts_like.rb",
+        "activesupport",
         tsMethodsByFile,
       ),
     ).toBeNull();

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -1326,6 +1326,44 @@ export function mixinMethodCreditedToOwnFile(
   return tsName === undefined ? null : { tsName, tsFile };
 }
 
+/**
+ * Is this method defined by a *reopening* of the class in another Ruby file,
+ * and ported to the TS file mirroring that reopening?
+ *
+ * Ruby reopens a class across many files but the extractor stamps ONE `file` on
+ * the entity, so a class's whole surface buckets under whichever reopening came
+ * first. `core_ext/object/acts_like.rb` is the first core_ext file to reopen
+ * `Object`, so `blank?` (`core_ext/object/blank.rb:14`), `duplicable?`
+ * (`core_ext/object/duplicable.rb:26`) and `instance_values`
+ * (`core_ext/object/instance_variables.rb:19`) all land in its bucket — and
+ * `RUBY_FILE_TS_OVERRIDES` maps a Ruby file to exactly ONE TS file, so at most
+ * one of those three arms could ever be measured against the file trails
+ * actually ports it to.
+ *
+ * So credit each arm to its own reopening's TS file, the same accounting
+ * `mixinMethodCreditedToOwnFile` gives an included method. Narrow by
+ * construction: the credit only lands when the reopening's mirrored TS file
+ * exists in this run AND really defines one of the method's TS candidates. An
+ * unported reopening arm (`acts_like?`, duck typing in JS) is credited nowhere
+ * and still reports missing.
+ */
+export function reopeningMethodCreditedToOwnFile(
+  rm: { rubyName: string; definedInFile?: string },
+  hostRubyFile: string,
+  pkg: string,
+  tsMethodsByFile: ReadonlyMap<string, Set<string>>,
+): { tsName: string; tsFile: string } | null {
+  const definedInFile = rm.definedInFile;
+  if (definedInFile === undefined || definedInFile === hostRubyFile) return null;
+  const candidates = rubyMethodToTs(rm.rubyName);
+  if (candidates === null) return null;
+  const tsFile = rubyFileToTs(definedInFile, pkg);
+  const reopeningTsMethods = tsMethodsByFile.get(tsFile);
+  if (reopeningTsMethods === undefined) return null;
+  const tsName = candidates.find((c) => reopeningTsMethods.has(c));
+  return tsName === undefined ? null : { tsName, tsFile };
+}
+
 /** A Ruby class or module, paired with the fully-qualified name it was found under. */
 export interface RubyEntity {
   fqn: string;
@@ -1420,6 +1458,7 @@ export function dedupeRubyMethodInto(
       rubyModule: itemFqn,
       umbrellaConfig: rm.umbrellaConfig,
       mixinFile: rm.mixinFile,
+      definedInFile: rm.file,
     });
   }
 }
@@ -1431,6 +1470,8 @@ export interface SeenRubyMethod {
   umbrellaConfig?: boolean;
   /** Set when the first sighting came in through `include`/`extend` — see `mixinMethodCreditedToOwnFile`. */
   mixinFile?: string;
+  /** The Ruby file that actually defines it — see `reopeningMethodCreditedToOwnFile`. */
+  definedInFile?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -2408,7 +2449,10 @@ export function main() {
         ? tsMethodsByFile.get(misplacedActualFile) || new Set<string>()
         : null;
 
-      for (const [_dedupeKey, { rubyName, rubyModule, umbrellaConfig, mixinFile }] of seen) {
+      for (const [
+        _dedupeKey,
+        { rubyName, rubyModule, umbrellaConfig, mixinFile, definedInFile },
+      ] of seen) {
         const tsCandidates = rubyMethodToTs(rubyName)!;
 
         // Check direct match first — find which candidate matched
@@ -2465,6 +2509,27 @@ export function main() {
             rubyModule,
             expectedFile: expectedTs,
             actualFile: creditedToMixin.tsFile,
+          });
+          continue;
+        }
+
+        // Defined by a reopening of this class in another Ruby file, and ported
+        // to that file's TS counterpart — see `reopeningMethodCreditedToOwnFile`.
+        const creditedToReopening = reopeningMethodCreditedToOwnFile(
+          { rubyName, definedInFile },
+          rubyFile,
+          pkg,
+          tsMethodsByFile,
+        );
+        if (creditedToReopening) {
+          fileMatched++;
+          checkArity(rubyName, creditedToReopening.tsName, creditedToReopening.tsFile);
+          moves.push({
+            tsName: creditedToReopening.tsName,
+            rubyName,
+            rubyModule,
+            expectedFile: expectedTs,
+            actualFile: creditedToReopening.tsFile,
           });
           continue;
         }

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -2514,7 +2514,7 @@ export function main() {
         }
 
         // Defined by a reopening of this class in another Ruby file, and ported
-        // to that file's TS counterpart — see `reopeningMethodCreditedToOwnFile`.
+        // there — see `reopeningMethodCreditedToOwnFile`.
         const creditedToReopening = reopeningMethodCreditedToOwnFile(
           { rubyName, definedInFile },
           rubyFile,

--- a/scripts/api-compare/conventions.ts
+++ b/scripts/api-compare/conventions.ts
@@ -190,14 +190,6 @@ export const RUBY_FILE_TS_OVERRIDES: Record<string, string> = {
   // with `TimeWithZone#asJson`. The entry gives json.rb its own bucket, so
   // every arm is measured against the file trails actually ports them to.
   "activesupport:core_ext/object/json.rb": "core-ext/object/json.ts",
-  // Object's home bucket: `acts_like.rb` is the first core_ext file to reopen
-  // Object, so every later reopening (`blank.rb`, `duplicable.rb`,
-  // `instance_variables.rb`) dedupes into it, and the bucket is really "Object's
-  // methods". Its expected path has no TS file — `acts_like?` is duck typing in
-  // JS and has no port — so it used to fall to the misplaced-file cluster, which
-  // latched onto the package barrel and scored it against unrelated re-exports.
-  // Point it at the reopening that carries the largest arm instead.
-  "activesupport:core_ext/object/acts_like.rb": "core-ext/object/blank.ts",
   "activesupport:core_ext/string/filters.rb": "string-utils.ts",
   "activesupport:core_ext/string/access.rb": "string-utils.ts",
   "activesupport:core_ext/string/indent.rb": "string-utils.ts",


### PR DESCRIPTION
Two bundled stories.

## 1. `TableDefinition#toSql default quoting` leases instead of building an adapter

PR #6217 moved ~107 DDL-rendering call sites onto `Base.leaseConnection` — what
Rails hands `SchemaCreation.new` / `TableDefinition#initialize`
(`activerecord/test/cases/adapter_test.rb`,
`.../migration/columns_test.rb`). One site was left because it was gated
differently: `describeIfPg` is a *server probe* that runs wherever a PostgreSQL
server answers — including the sqlite and mysql2 lanes — so a suite under it
cannot lease and must bring its own adapter.

This moves the suite to `describeIfPostgresqlAdapter` (#6217's port of
`current_adapter?(:PostgreSQLAdapter)`) and drops the
`new PostgreSQLAdapter(PG_TEST_URL)` / `disconnect()` pair.

**The audit** turned up four more mis-gated leasing suites — bodies that are
plain `Base.connection` interactions, each gated in Rails on
`current_adapter?(:PostgreSQLAdapter)`:

| trails | Rails |
| --- | --- |
| `defaults.test.ts` `PostgresqlDefaultExpressionTest` | `defaults_test.rb:147` |
| `dirty.test.ts` `DirtyTest` | `dirty_test.rb` |
| `migration.test.ts` `IndexForTableWithSchemaMigrationTest`, `PostgresqlIndexTest` | `migration_test.rb:1203` |
| `migration/change-table.test.ts` `TableTest` | `change_table_test.rb:342` |

Every surviving `describeIfPg` user constructs a `PostgreSQLAdapter` from
`PG_TEST_URL` and so genuinely needs the cross-lane probe. `describe-if-pg.ts`
now records the distinction (third time it has been re-derived). `describeIfPg`
itself is unchanged and not widened — `pgAvailable` / `pgServerVersion` /
`pgHasHintPlan` keep their readers.

No test renamed. `pnpm test:compare` totals are byte-identical before/after, and
`--check` (the hard-zero gate-mismatch gate) is green.

## 2. A home bucket credits each reopening to its own file

`RUBY_FILE_TS_OVERRIDES` maps one Ruby file to exactly one TS file, but a Ruby
class's home bucket can span several reopenings.
`core_ext/object/acts_like.rb` is the first core_ext file to reopen `Object`, so
`blank?`/`present?`/`presence` (`core_ext/object/blank.rb:14-46`), `duplicable?`
(`core_ext/object/duplicable.rb:26`) and `instance_values` /
`instance_variable_names` (`core_ext/object/instance_variables.rb:19-30`) all
bucket there — and at most one of those three arms could ever be measured
against the file trails actually ports it to.

`reopeningMethodCreditedToOwnFile` fixes the class of problem rather than the one
entry: it credits each arm to the TS file mirroring its own reopening, the same
accounting `mixinMethodCreditedToOwnFile` already gives an included method. It is
narrow by construction — the credit lands only when that TS file exists in the
run and really defines one of the method's TS candidates — so `acts_like?`, duck
typing in JS with no port, is credited nowhere and still reports missing.

The `activesupport:core_ext/object/acts_like.rb` override #6235 added is removed;
the barrel exclusion it shipped alongside is untouched.

### Numbers

`api:compare` activesupport **1015 → 1030 methods** (44.3% → 44.9%); no other
package moves. Two things move the other way and are both honest readings, not
regressions:

- **files 149 → 148.** `acts_like.rb` was borrowing `blank.rb`'s TS file for its
  file credit. With each arm credited to its own file, the bucket's only own
  member is the unported `acts_like?`, so the ✗ is now correct.
- **2 new arity mismatches**, both `core-ext/string/output-safety.ts:isHtmlSafe`
  (`ruby()` vs `ts(value)`) — pre-existing divergence whose pair is compared for
  the first time, the usual "faithful credit surfaces a real row" shape.

`pnpm api:calls` green (ratchet OK, no new rows). Unit test in
`scripts/api-compare/compare.test.ts`.

Closes-story: pg-ddl-quoting-suite-builds-its-own-adapter-instead-of-leasing
Closes-story: home-bucket-must-credit-each-reopening-to-its-own-file
