### PR TITLE
fix(api-compare,activerecord): deprecators.rb stops taking credit from deprecation.ts; NullPool raises on role/shard

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -1412,15 +1412,11 @@ export class AbstractAdapter implements Quoting {
   }
 
   get role(): string {
-    // Ruby's `@pool.role` (`abstract_adapter.rb:288`) is an unchecked send that
-    // raises NoMethodError on a NullPool — which Rails never reaches, because an
-    // adapter is only ever obtained from a real pool. The cast is that same
-    // unchecked read; no trails path reads `role` off a pool-less adapter either.
-    return (this.pool as ConnectionPool).role;
+    return this.pool.role;
   }
 
   get shard(): string {
-    return (this.pool as ConnectionPool).shard;
+    return this.pool.shard;
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -136,19 +136,26 @@ export class NullPool implements AbstractPool {
   declare readonly role: never;
   declare readonly shard: never;
 
+  /**
+   * Mirrors: ConnectionPool::NullPool#initialize
+   * (`abstract/connection_pool.rb:24-28`).
+   *
+   * The Proxy is a language shortcoming, not a Rails shape: Ruby's NullPool is
+   * a plain object, so a send it has no method for raises NoMethodError, while
+   * a JS read of a missing property is silently `undefined` — which is what let
+   * a pool-less adapter's `role` (`abstract_adapter.rb:288`) answer `undefined`
+   * and `inspect` (`:174-181`) render `shard="undefined"`. It is the only shape
+   * that raises *without* adding a `role`/`shard` member Rails' NullPool does
+   * not have.
+   *
+   * Only `role` and `shard` raise. Every other member Ruby's NullPool lacks is
+   * reached through a caller that duck-types the absence instead of sending
+   * unconditionally — `clearQueryCache`'s `this.pool?.clearQueryCache` against
+   * `query_cache.rb:232-234`'s bare `pool.clear_query_cache`. Those call sites
+   * are their own convergence (`0051/clear-query-cache-duck-types-the-pool`),
+   * not a licence to leave this one silent.
+   */
   constructor() {
-    // Ruby's NullPool is a plain object: a send it has no method for raises
-    // NoMethodError. A JS read of a missing property is silently `undefined`,
-    // which is what let a pool-less adapter's `role` answer `undefined` and
-    // `inspect` render `shard="undefined"` instead of failing. Ruby's dispatch
-    // is modelled with a Proxy because it is the only shape that raises
-    // *without* adding a `role`/`shard` member Rails' NullPool does not have.
-    // Only `role` and `shard` raise: every other member Ruby's NullPool lacks
-    // is reached through a caller that duck-types the absence instead of
-    // sending unconditionally (`clearQueryCache`'s `this.pool?.clearQueryCache`,
-    // query_cache.rb:232-234), and raising underneath those would be a
-    // behavior change unrelated to this reader. Those call sites are their own
-    // convergence, not a licence to leave this one silent.
     return new Proxy(this, {
       get(target, prop, receiver) {
         if (typeof prop === "symbol" || !NULL_POOL_UNDEFINED_METHODS.has(prop)) {

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::ConnectionPool
  */
 
+import { NoMethodError } from "@blazetrails/activemodel";
 import { adapterNameFromConfig } from "../abstract-adapter.js";
 import type { AbstractAdapter as DatabaseAdapter } from "../abstract-adapter.js";
 import type { DatabaseConfig } from "../../database-configurations/database-config.js";
@@ -108,6 +109,12 @@ const ADAPTER_PROXY_PROBE_KEYS = new Set<string>([
 ]);
 
 /**
+ * Sends Ruby's NullPool has no method for and trails must raise on rather than
+ * answer `undefined` — see the NullPool constructor.
+ */
+const NULL_POOL_UNDEFINED_METHODS = new Set<string>(["role", "shard"]);
+
+/**
  * Mirrors: ActiveRecord::ConnectionAdapters::NullPool
  */
 export class NullPool implements AbstractPool {
@@ -116,6 +123,43 @@ export class NullPool implements AbstractPool {
 
   private _serverVersion: unknown = null;
   private _schemaReflection: SchemaReflection | null = null;
+
+  /**
+   * Type-only, emitted nowhere. Ruby's NullPool answers neither `role` nor
+   * `shard` (`abstract/connection_pool.rb:14-51`), so `AbstractAdapter#role`'s
+   * bare `@pool.role` (`abstract_adapter.rb:288`) raises NoMethodError on a
+   * pool-less adapter. TS cannot read a property absent from one member of the
+   * `ConnectionPool | NullPool` union, so the member is declared as the type
+   * that produces no value — `never` — and `declare` keeps it out of the class,
+   * so it really is absent and the constructor's dispatch below raises on it.
+   */
+  declare readonly role: never;
+  declare readonly shard: never;
+
+  constructor() {
+    // Ruby's NullPool is a plain object: a send it has no method for raises
+    // NoMethodError. A JS read of a missing property is silently `undefined`,
+    // which is what let a pool-less adapter's `role` answer `undefined` and
+    // `inspect` render `shard="undefined"` instead of failing. Ruby's dispatch
+    // is modelled with a Proxy because it is the only shape that raises
+    // *without* adding a `role`/`shard` member Rails' NullPool does not have.
+    // Only `role` and `shard` raise: every other member Ruby's NullPool lacks
+    // is reached through a caller that duck-types the absence instead of
+    // sending unconditionally (`clearQueryCache`'s `this.pool?.clearQueryCache`,
+    // query_cache.rb:232-234), and raising underneath those would be a
+    // behavior change unrelated to this reader. Those call sites are their own
+    // convergence, not a licence to leave this one silent.
+    return new Proxy(this, {
+      get(target, prop, receiver) {
+        if (typeof prop === "symbol" || !NULL_POOL_UNDEFINED_METHODS.has(prop)) {
+          return Reflect.get(target, prop, receiver);
+        }
+        throw new NoMethodError(
+          `undefined method '${prop}' for an instance of ActiveRecord::ConnectionAdapters::NullPool`,
+        );
+      },
+    });
+  }
 
   /**
    * Mirrors: ConnectionPool::NullPool#server_version

--- a/packages/activerecord/src/connection-pool.trails.test.ts
+++ b/packages/activerecord/src/connection-pool.trails.test.ts
@@ -1159,4 +1159,17 @@ describe("NullPool member parity", () => {
     expect("role" in pool).toBe(false);
     expect("shard" in pool).toBe(false);
   });
+
+  it("raises on a pool-less adapter's role, shard and inspect", () => {
+    // The arm the old `this.pool as ConnectionPool` cast left silent: Ruby's
+    // `@pool.role` (abstract_adapter.rb:288) raises NoMethodError on a NullPool,
+    // where a JS read of a missing property answers `undefined` and `inspect`
+    // (abstract_adapter.rb:174-181) renders `shard="undefined"` — a pool-less
+    // adapter passing itself off as a writing/default one.
+    const adapter = new AbstractAdapter();
+    expect(adapter.pool).toBeInstanceOf(NullPool);
+    expect(() => adapter.role).toThrow(/undefined method 'role'/);
+    expect(() => adapter.shard).toThrow(/undefined method 'shard'/);
+    expect(() => adapter.inspect()).toThrow(/undefined method 'shard'/);
+  });
 });

--- a/packages/activerecord/src/connection-pool.trails.test.ts
+++ b/packages/activerecord/src/connection-pool.trails.test.ts
@@ -1160,12 +1160,7 @@ describe("NullPool member parity", () => {
     expect("shard" in pool).toBe(false);
   });
 
-  it("raises on a pool-less adapter's role, shard and inspect", () => {
-    // The arm the old `this.pool as ConnectionPool` cast left silent: Ruby's
-    // `@pool.role` (abstract_adapter.rb:288) raises NoMethodError on a NullPool,
-    // where a JS read of a missing property answers `undefined` and `inspect`
-    // (abstract_adapter.rb:174-181) renders `shard="undefined"` — a pool-less
-    // adapter passing itself off as a writing/default one.
+  it("raises NoMethodError on a pool-less adapter's role, shard and inspect", () => {
     const adapter = new AbstractAdapter();
     expect(adapter.pool).toBeInstanceOf(NullPool);
     expect(() => adapter.role).toThrow(/undefined method 'role'/);

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -1467,9 +1467,6 @@ describe("selectMisplacedFile", () => {
   });
 
   it("never clusters a bucket registered as a name collision", () => {
-    // `Deprecators`' delegating setters (deprecators.rb:19-49) are spelled like
-    // `Deprecation`'s own, so the bucket cleared all three thresholds against
-    // deprecation.ts with zero ported. It must read as missing, not 60%.
     expect(
       selectMisplacedFile(
         hits(["deprecation.ts", 6], ["b.ts", 1]),
@@ -1481,8 +1478,6 @@ describe("selectMisplacedFile", () => {
   });
 
   it("leaves an unregistered bucket's cluster alone", () => {
-    // The registration is per bucket, not per target file: behaviors.rb is a
-    // real port living in deprecation.ts and keeps its cluster.
     expect(
       selectMisplacedFile(
         hits(["deprecation.ts", 6], ["b.ts", 1]),

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -11,6 +11,7 @@ import {
   resolveModuleName,
   buildModuleIncluderFqns,
   dedupeRubyMethodInto,
+  NAME_COLLISION_CLUSTERS,
   selectMisplacedFile,
   MISPLACED_MIN_HITS,
   blazetrailsDepKeys,
@@ -1463,6 +1464,32 @@ describe("selectMisplacedFile", () => {
     // `.../index.ts` files (encryption/index.ts) carry ported bodies.
     const result = selectMisplacedFile(hits(["encryption/index.ts", 6], ["b.ts", 1]), 10);
     expect(result).toBe("encryption/index.ts");
+  });
+
+  it("never clusters a bucket registered as a name collision", () => {
+    // `Deprecators`' delegating setters (deprecators.rb:19-49) are spelled like
+    // `Deprecation`'s own, so the bucket cleared all three thresholds against
+    // deprecation.ts with zero ported. It must read as missing, not 60%.
+    expect(
+      selectMisplacedFile(
+        hits(["deprecation.ts", 6], ["b.ts", 1]),
+        10,
+        "activesupport:deprecation/deprecators.rb",
+      ),
+    ).toBeNull();
+    expect(NAME_COLLISION_CLUSTERS.has("activesupport:deprecation/deprecators.rb")).toBe(true);
+  });
+
+  it("leaves an unregistered bucket's cluster alone", () => {
+    // The registration is per bucket, not per target file: behaviors.rb is a
+    // real port living in deprecation.ts and keeps its cluster.
+    expect(
+      selectMisplacedFile(
+        hits(["deprecation.ts", 6], ["b.ts", 1]),
+        10,
+        "activesupport:deprecation/behaviors.rb",
+      ),
+    ).toBe("deprecation.ts");
   });
 
   it("accepts a clear leader even with multiple low-hit competitors", () => {

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -1468,6 +1468,10 @@ export interface SeenRubyMethod {
  * a bucket that genuinely lives there is spelled out in
  * `RUBY_FILE_TS_OVERRIDES`, which is the direct-match path and does not come
  * through here.
+ *
+ * A bucket registered in `NAME_COLLISION_CLUSTERS` is dropped before the vote
+ * for the same reason the barrel is: its hits are a coincidence of method
+ * names, not a port.
  */
 export const MISPLACED_MIN_HITS = 3;
 
@@ -1481,10 +1485,30 @@ function isPackageBarrel(file: string): boolean {
   return file === "index.ts";
 }
 
+/**
+ * Buckets whose cluster is a pure name collision: every hit is a TS method that
+ * belongs to an unrelated entity and happens to share a Ruby name, so the
+ * bucket has no port at all and must read as missing rather than partly ported.
+ * Keyed `<package>:<ruby file>`. Only-shrink: a row leaves when the file is
+ * ported, never when a better justification is found for keeping it.
+ *
+ * - `activesupport:deprecation/deprecators.rb` — trails has no `Deprecators`
+ *   class. `Deprecators`' delegating setters
+ *   (`vendor/rails/activesupport/lib/active_support/deprecation/deprecators.rb:19-49`)
+ *   are spelled exactly like `Deprecation`'s own `silenced=` / `behavior=` /
+ *   `disallowed_behavior=` / `disallowed_warnings=` / `silence`, so the bucket
+ *   scored 6/10 against `deprecation.ts` with zero ported.
+ */
+export const NAME_COLLISION_CLUSTERS: ReadonlySet<string> = new Set([
+  "activesupport:deprecation/deprecators.rb",
+]);
+
 export function selectMisplacedFile(
   fileHits: Map<string, number>,
   rubyMethodCount: number,
+  bucketKey?: string,
 ): string | null {
+  if (bucketKey !== undefined && NAME_COLLISION_CLUSTERS.has(bucketKey)) return null;
   let bestFile: string | null = null;
   let bestCount = 0;
   let secondCount = 0;
@@ -2402,7 +2426,7 @@ export function main() {
             fileHits.set(f, (fileHits.get(f) || 0) + 1);
           }
         }
-        misplacedActualFile = selectMisplacedFile(fileHits, seen.size);
+        misplacedActualFile = selectMisplacedFile(fileHits, seen.size, `${pkg}:${rubyFile}`);
       }
       const actualMethods = misplacedActualFile
         ? tsMethodsByFile.get(misplacedActualFile) || new Set<string>()


### PR DESCRIPTION
Two RFC stories, both about a silent answer standing in for a missing thing.

## 1. `deprecation/deprecators.rb` stops taking credit from `deprecation.ts`

Dropping the package barrel from the misplaced-file vote let this bucket find
its next-strongest cluster, which is a false pairing of the same species onto a
real file: trails has no `Deprecators` class at all, but `Deprecators`'
delegating setters (`deprecators.rb:19-49`) are spelled exactly like
`Deprecation`'s own `silenced=` / `behavior=` / `disallowed_behavior=` /
`disallowed_warnings=` / `silence`, so a zero-port bucket read as 60% ported.

`selectMisplacedFile` now takes the bucket key and drops a bucket registered in
`NAME_COLLISION_CLUSTERS`. The registry is only-shrink: a row leaves when the
file is ported.

A name-collision *guard* (a bucket whose Ruby class has no same-named TS entity
is not clustered) was tried first and is too crude — mixin modules ported as
`this`-typed functions have no same-named entity either, so it also dropped the
real `behaviors.rb ↦ deprecation.ts` and
`method_call_assertions.rb ↦ testing-helpers.ts` clusters (−10 methods).

`activesupport` goes 1015 → 1009 methods and 5 → 4 misplaced: exactly the six
false credits this story exists to remove. The barrel exclusion and the
`error_reporter_assertions.rb` `UNPORTED_FILES` entry are untouched.

## 2. `AbstractAdapter#role` / `#shard` no longer read through a cast

Both are now the bare `this.pool.role` / `this.pool.shard` of
`abstract_adapter.rb:288,294`. The `as ConnectionPool` cast turned Ruby's
`NoMethodError` on a pool-less adapter into `undefined` — and `inspect()`
(`abstract_adapter.rb:174-181`) into `shard="undefined"` — which would let a
future pool-less adapter pass itself off as a writing/default one.

The field is *not* retyped (that was #6207, correctly blocked) and there is no
`instanceof` branch in either body. Instead `NullPool` models Ruby's dispatch:
`role`/`shard` are `declare readonly … : never` (type-only, emitted nowhere, so
`"role" in pool` stays false and the `NullPool member parity` test passes
unchanged), and the constructor returns a Proxy whose `get` raises
`NoMethodError` for those two sends.

The trap covers `role`/`shard` only, not every member Ruby's NullPool lacks:
`clearQueryCache` duck-types the pool (`this.pool?.clearQueryCache`) where
`query_cache.rb:232-234` sends unconditionally, and raising underneath it reds
six SQLite introspection tests. Filed as
`0051/clear-query-cache-duck-types-the-pool`, which also retires
`NULL_POOL_UNDEFINED_METHODS`.

Closes-story: deprecators-bucket-clusters-onto-deprecation-ts
Closes-story: abstract-adapter-role-shard-cast-hides-ruby-nomethoderror
