### PR TITLE
refactor(activerecord): PostgreSQLAdapter#getDatabaseVersion is a pure fetch; the version memo lives on the pool

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -195,14 +195,18 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("reconnect after bad connection on check version", async () => {
-      // Cache the true version off a live connection.
       expect(await adapter.getDatabaseVersion()).toBeGreaterThan(0);
+      // Mimic a connection that hasn't checked and cached the server version yet
+      // (Rails: connection.pool.instance_variable_set(:@server_version, nil)).
+      (adapter.pool as unknown as { _serverVersion: unknown })._serverVersion = null;
       // Stub server_version to 0 (Rails: raw_connection.stub(:server_version, 0)).
       const versionSpy = vi.spyOn(adapter, "_serverVersion").mockResolvedValue(0);
-      await expect(adapter.getDatabaseVersion()).rejects.toBeInstanceOf(ConnectionFailed);
-      await expect(adapter.getDatabaseVersion()).rejects.toThrow(
-        "Could not determine PostgreSQL version",
+      const error = await adapter.reconnectBang().then(
+        () => null,
+        (e: unknown) => e,
       );
+      expect(error).toBeInstanceOf(ConnectionFailed);
+      expect((error as ConnectionFailed).message).toBe("Could not determine PostgreSQL version");
       versionSpy.mockRestore();
 
       // Can reconnect after a bad connection.

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -1327,7 +1327,7 @@ describe("PostgreSQLAdapter supports_* predicates (unit)", () => {
 
   function stubVersion(adapter: PostgreSQLAdapter, version: number): void {
     (adapter as any)._initialized = true;
-    (adapter as any)._hasOptimizerHints = false;
+    (adapter as any)._hasPgHintPlan = false;
     // `database_version` reads the pool memo (`abstract_adapter.rb:854-856`),
     // which is the only place the version is cached, so the stub is staged
     // there.

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3235,23 +3235,6 @@ export class PostgreSQLAdapter
       if (PostgreSQLAdapter._isConnectionError(error)) this._discardRawConnection();
       throw error;
     }
-    // Eagerly populate optimizer hints flag
-    if (this._hasOptimizerHints === null) {
-      try {
-        const result = await conn.query(
-          "SELECT COUNT(*) AS count FROM pg_available_extensions WHERE name = $1",
-          ["pg_hint_plan"],
-        );
-        this._hasOptimizerHints = Number(result.rows[0]?.count) > 0;
-      } catch (error) {
-        // Carry the version-probe block's recovery forward: tear down on a
-        // dead socket so the next _acquireFreshClient() opens a fresh pg.Client rather
-        // than handing back the stale handle (the recovery the former
-        // withClient body provided before being swallowed by a bare catch).
-        if (PostgreSQLAdapter._isConnectionError(error)) this._discardRawConnection();
-        this._hasOptimizerHints = false;
-      }
-    }
     return version;
   }
 
@@ -3396,10 +3379,16 @@ export class PostgreSQLAdapter
     return (await this.databaseVersion) >= 90400;
   }
 
-  private _hasOptimizerHints: boolean | null = null;
+  private _hasPgHintPlan?: boolean;
 
+  // Mirrors: PostgreSQLAdapter#supports_optimizer_hints?
+  // (postgresql_adapter.rb:444-449) — `unless defined?(@has_pg_hint_plan)`, so
+  // the `extension_available?` probe runs once, on first read.
   async supportsOptimizerHints(): Promise<boolean> {
-    return this._hasOptimizerHints ?? false;
+    if (this._hasPgHintPlan === undefined) {
+      this._hasPgHintPlan = await this.extensionAvailable("pg_hint_plan");
+    }
+    return this._hasPgHintPlan;
   }
 
   async supportsCommonTableExpressions(): Promise<boolean> {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql-adapter.json
@@ -303,13 +303,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "supports_optimizer_hints?",
-    "call": "extension_available?",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails postgresql_adapter.rb:444-449 memoizes `extension_available?(\"pg_hint_plan\")`; trails postgresql-adapter.ts:3442-3444 returns the `_hasOptimizerHints` flag populated by the same pg_extension count query (postgresql-adapter.ts:3257-3271)."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "translate_exception",
     "call": "match?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Finishes the PostgreSQL half of
`retire-pg-sqlite-get-database-version-memo-guards`.

#6237 landed the bulk of it while this PR was open — `_databaseVersion` is
gone, `getDatabaseVersion` reads through the pool memo, and
`_maybeConfigureConnection` opens with `super.configureConnection()`. This PR
was rebased down to the two pieces that story still asks for and that `main`
does not yet have.

**The `_hasOptimizerHints` warm leaves `get_database_version`.** Rails'
`get_database_version` (`postgresql_adapter.rb:635-643`) is a bare
`with_raw_connection { conn.server_version }` — on `main` it still ends with an
eager pg_hint_plan probe, the last residue of the retired memo. That probe
belongs to `supports_optimizer_hints?`, and now that the reader is async
(#6226) it can be Rails' own body verbatim
(`postgresql_adapter.rb:444-449`): `unless defined?(@has_pg_hint_plan)` →
`if (this._hasPgHintPlan === undefined)`, over a real
`extensionAvailable("pg_hint_plan")` call. The field takes Rails' identifier
(`@has_pg_hint_plan`), and the bespoke `SELECT COUNT(*)` is replaced by
`extension_available?`'s own SQL (`postgresql_adapter.rb:493-495`) by virtue of
calling it. This retires the
`supports_optimizer_hints? → extension_available?` baseline row, deleted by
hand rather than reseeded.

**`test_reconnect_after_bad_connection_on_check_version` matches its Rails
body.** `postgresql_adapter_test.rb:98-116` clears the *pool's*
`@server_version`, stubs `server_version` to 0, and asserts `reconnect!`
raises; the port on `main` calls `getDatabaseVersion()` directly and never
exercises `reconnect!`. Now it does both, on the pool memo.

The SQLite half of the story was already converged on `main` — `sqlite3-adapter.ts`
carries no `_databaseVersion` and `getDatabaseVersion` is the pure derivation of
`sqlite3_adapter.rb:476-478`. Its `get_database_version → query_value` baseline
row is a genuine remaining language-forced delta (documented at the call site),
not stale, so it stays.

Verified against a PostgreSQL 17 container.

Closes-story: retire-pg-sqlite-get-database-version-memo-guards
