### PR TITLE
refactor(activerecord): clearQueryCache sends bare to the pool

### DIFF
--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
@@ -14,28 +14,14 @@ import type {
   SyncSqliteStatement,
 } from "../../sqlite-adapter.js";
 import { assertLogged } from "./test-helper.js";
-import { ConnectionPool } from "../../connection-adapters/abstract/connection-pool.js";
-import { PoolConfig } from "../../connection-adapters/pool-config.js";
-import { ConnectionDescriptor } from "../../connection-adapters/abstract/connection-descriptor.js";
-import { HashConfig } from "../../database-configurations/hash-config.js";
-import type { AbstractAdapter as DatabaseAdapter } from "../../connection-adapters/abstract-adapter.js";
+import { newSqlitePool } from "../../support/pooled-sqlite-adapter.js";
+import type { ConnectionPool } from "../../connection-adapters/abstract/connection-pool.js";
 
 let adapter: SQLite3Adapter;
 let pool: ConnectionPool;
 
-// Checked out of a real pool, not constructed bare: the alter_table rebuild
-// ends in `clear_query_cache`, whose `pool.clear_query_cache`
-// (query_cache.rb:232-234) is an unchecked send a NullPool cannot answer.
 beforeEach(async () => {
-  pool = new ConnectionPool(
-    new PoolConfig(
-      new ConnectionDescriptor("primary"),
-      new HashConfig("test", "primary", { adapter: "sqlite3", database: ":memory:" }),
-      "writing",
-      "default",
-      { adapterFactory: () => new BetterSQLite3Adapter(":memory:") as unknown as DatabaseAdapter },
-    ),
-  );
+  pool = newSqlitePool();
   adapter = (await pool.checkout()) as unknown as SQLite3Adapter;
 });
 

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
@@ -14,11 +14,29 @@ import type {
   SyncSqliteStatement,
 } from "../../sqlite-adapter.js";
 import { assertLogged } from "./test-helper.js";
+import { ConnectionPool } from "../../connection-adapters/abstract/connection-pool.js";
+import { PoolConfig } from "../../connection-adapters/pool-config.js";
+import { ConnectionDescriptor } from "../../connection-adapters/abstract/connection-descriptor.js";
+import { HashConfig } from "../../database-configurations/hash-config.js";
+import type { AbstractAdapter as DatabaseAdapter } from "../../connection-adapters/abstract-adapter.js";
 
 let adapter: SQLite3Adapter;
+let pool: ConnectionPool;
 
-beforeEach(() => {
-  adapter = new BetterSQLite3Adapter(":memory:");
+// Checked out of a real pool, not constructed bare: the alter_table rebuild
+// ends in `clear_query_cache`, whose `pool.clear_query_cache`
+// (query_cache.rb:232-234) is an unchecked send a NullPool cannot answer.
+beforeEach(async () => {
+  pool = new ConnectionPool(
+    new PoolConfig(
+      new ConnectionDescriptor("primary"),
+      new HashConfig("test", "primary", { adapter: "sqlite3", database: ":memory:" }),
+      "writing",
+      "default",
+      { adapterFactory: () => new BetterSQLite3Adapter(":memory:") as unknown as DatabaseAdapter },
+    ),
+  );
+  adapter = (await pool.checkout()) as unknown as SQLite3Adapter;
 });
 
 async function createExampleTable(): Promise<void> {
@@ -35,7 +53,7 @@ afterEach(async () => {
   await adapter.exec(
     `DROP TABLE IF EXISTS items; DROP TABLE IF EXISTS typed; DROP TABLE IF EXISTS no_pk; DROP TABLE IF EXISTS bin_esc; DROP TABLE IF EXISTS enc_test; DROP TABLE IF EXISTS def_vals; DROP TABLE IF EXISTS strict_items; DROP TABLE IF EXISTS custom_pk_src; DROP TABLE IF EXISTS custom_pk_dest; DROP TABLE IF EXISTS cpk_src; DROP TABLE IF EXISTS cpk_dest; DROP TABLE IF EXISTS custom_pk; DROP TABLE IF EXISTS change_pk; DROP TABLE IF EXISTS barcodes; DROP TABLE IF EXISTS test; DROP TABLE IF EXISTS testings; DROP TABLE IF EXISTS rowid_test; DROP TABLE IF EXISTS rowid_lower; DROP TABLE IF EXISTS text_pk; DROP TABLE IF EXISTS mixed_case; DROP TABLE IF EXISTS auto_inc; DROP TABLE IF EXISTS cpk; DROP TABLE IF EXISTS ex; DROP TABLE IF EXISTS json_defs`,
   );
-  await adapter.close();
+  await pool.disconnect();
   Notifications.unsubscribeAll();
 });
 

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.trails.test.ts
@@ -1,17 +1,38 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { SQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "../../connection-adapters/better-sqlite3-adapter.js";
+import { ConnectionPool } from "../../connection-adapters/abstract/connection-pool.js";
+import { PoolConfig } from "../../connection-adapters/pool-config.js";
+import { ConnectionDescriptor } from "../../connection-adapters/abstract/connection-descriptor.js";
+import { HashConfig } from "../../database-configurations/hash-config.js";
+import type { AbstractAdapter as DatabaseAdapter } from "../../connection-adapters/abstract-adapter.js";
 import { isInMemoryDatabase } from "../../sqlite/sqlite-uri.js";
 
 describe("SqliteAdapter", () => {
   let adapter: SQLite3Adapter;
+  let pool: ConnectionPool;
 
-  beforeEach(() => {
-    adapter = new BetterSQLite3Adapter(":memory:");
+  // Checked out of a real pool, not constructed bare: `removeColumn` rebuilds
+  // the table and ends in `clear_query_cache`, whose `pool.clear_query_cache`
+  // (query_cache.rb:232-234) is an unchecked send that a NullPool adapter
+  // cannot answer.
+  beforeEach(async () => {
+    pool = new ConnectionPool(
+      new PoolConfig(
+        new ConnectionDescriptor("primary"),
+        new HashConfig("test", "primary", { adapter: "sqlite3", database: ":memory:" }),
+        "writing",
+        "default",
+        {
+          adapterFactory: () => new BetterSQLite3Adapter(":memory:") as unknown as DatabaseAdapter,
+        },
+      ),
+    );
+    adapter = (await pool.checkout()) as unknown as SQLite3Adapter;
   });
 
   afterEach(async () => {
-    await adapter.close();
+    await pool.disconnect();
   });
 
   // TS-only coverage for the alter_table rebuild: a typeless column has BLOB

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.trails.test.ts
@@ -1,37 +1,21 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { SQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "../../connection-adapters/better-sqlite3-adapter.js";
-import { ConnectionPool } from "../../connection-adapters/abstract/connection-pool.js";
-import { PoolConfig } from "../../connection-adapters/pool-config.js";
-import { ConnectionDescriptor } from "../../connection-adapters/abstract/connection-descriptor.js";
-import { HashConfig } from "../../database-configurations/hash-config.js";
-import type { AbstractAdapter as DatabaseAdapter } from "../../connection-adapters/abstract-adapter.js";
+import { newSqlitePool } from "../../support/pooled-sqlite-adapter.js";
+import type { ConnectionPool } from "../../connection-adapters/abstract/connection-pool.js";
 import { isInMemoryDatabase } from "../../sqlite/sqlite-uri.js";
 
 describe("SqliteAdapter", () => {
   let adapter: SQLite3Adapter;
   let pool: ConnectionPool;
 
-  // Checked out of a real pool, not constructed bare: `removeColumn` rebuilds
-  // the table and ends in `clear_query_cache`, whose `pool.clear_query_cache`
-  // (query_cache.rb:232-234) is an unchecked send that a NullPool adapter
-  // cannot answer.
   beforeEach(async () => {
-    pool = new ConnectionPool(
-      new PoolConfig(
-        new ConnectionDescriptor("primary"),
-        new HashConfig("test", "primary", { adapter: "sqlite3", database: ":memory:" }),
-        "writing",
-        "default",
-        {
-          adapterFactory: () => new BetterSQLite3Adapter(":memory:") as unknown as DatabaseAdapter,
-        },
-      ),
-    );
+    pool = newSqlitePool();
     adapter = (await pool.checkout()) as unknown as SQLite3Adapter;
   });
 
   afterEach(async () => {
+    await adapter.exec(`DROP TABLE IF EXISTS "affinities"`);
     await pool.disconnect();
   });
 
@@ -52,8 +36,6 @@ describe("SqliteAdapter", () => {
       expect(columns.find((c) => c.name === "untyped")?.sqlType).toBe("");
       const rows = await adapter.selectAll(`SELECT typeof("untyped") AS t FROM "affinities"`);
       expect(rows.rows[0]?.[0]).toBe("integer");
-
-      await adapter.dropTable("affinities");
     });
   });
 

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -159,13 +159,13 @@ export interface QueryCachePool {
   disableQueryCache?<T>(fn: () => T | Promise<T>, opts?: { dirties?: boolean }): T | Promise<T>;
   enableQueryCacheBang?(): void;
   disableQueryCacheBang?(): void;
-  clearQueryCache?(): void;
+  clearQueryCache(): void;
   dirtiesQueryCache?: boolean;
 }
 
 export interface QueryCacheHost extends DatabaseStatementsHost {
   _queryCache: Store | null;
-  pool?: DatabaseStatementsHost["pool"] & QueryCachePool;
+  pool: DatabaseStatementsHost["pool"] & QueryCachePool;
   // Mixed in from the QueryCache module below. Dispatched through `this` (not
   // the module-level functions) so a per-connection override is honored, as in
   // Rails' `def connection.cache_notification_info`.
@@ -422,11 +422,7 @@ export function disableQueryCacheBang(this: QueryCacheHost): void {
  * Mirrors: ActiveRecord::ConnectionAdapters::QueryCache#clear_query_cache
  */
 export function clearQueryCache(this: QueryCacheHost): void {
-  if (this.pool?.clearQueryCache) {
-    this.pool.clearQueryCache();
-    return;
-  }
-  this._queryCache?.clear();
+  this.pool.clearQueryCache();
 }
 
 /** The base (uncached) `selectAll` signature the override wraps via `super`. */

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.foreign-key-prefix.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.foreign-key-prefix.trails.test.ts
@@ -2,12 +2,34 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import type { SQLite3Adapter } from "./sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "./better-sqlite3-adapter.js";
 import { Base } from "../base.js";
+import { ConnectionPool } from "./abstract/connection-pool.js";
+import { PoolConfig } from "./pool-config.js";
+import { ConnectionDescriptor } from "./abstract/connection-descriptor.js";
+import { HashConfig } from "../database-configurations/hash-config.js";
+import type { AbstractAdapter as DatabaseAdapter } from "./abstract-adapter.js";
+
+// Checked out of a real pool, not constructed bare: the alter_table rebuild
+// ends in `clear_query_cache`, whose `pool.clear_query_cache`
+// (query_cache.rb:232-234) is an unchecked send a NullPool cannot answer.
+function newPool(): ConnectionPool {
+  return new ConnectionPool(
+    new PoolConfig(
+      new ConnectionDescriptor("primary"),
+      new HashConfig("test", "primary", { adapter: "sqlite3", database: ":memory:" }),
+      "writing",
+      "default",
+      { adapterFactory: () => new BetterSQLite3Adapter(":memory:") as unknown as DatabaseAdapter },
+    ),
+  );
+}
 
 describe("SQLite3Adapter addForeignKey under a table name prefix/suffix", () => {
   let adapter: SQLite3Adapter;
+  let pool: ConnectionPool;
 
   beforeEach(async () => {
-    adapter = new BetterSQLite3Adapter(":memory:");
+    pool = newPool();
+    adapter = (await pool.checkout()) as unknown as SQLite3Adapter;
     Base.tableNamePrefix = "p_";
     Base.tableNameSuffix = "_s";
     await adapter.createTable("p_rockets_s", { force: true }, (t) => {
@@ -22,7 +44,7 @@ describe("SQLite3Adapter addForeignKey under a table name prefix/suffix", () => 
     Base.tableNamePrefix = "";
     Base.tableNameSuffix = "";
     await adapter.dropTable("p_astronauts_s", "p_rockets_s", { ifExists: true });
-    await adapter.close();
+    await pool.disconnect();
   });
 
   it("reflects the singly prefixed table", async () => {
@@ -44,9 +66,11 @@ describe("SQLite3Adapter addForeignKey under a table name prefix/suffix", () => 
 
 describe("SQLite3Adapter alterTable under a table name prefix/suffix", () => {
   let adapter: SQLite3Adapter;
+  let pool: ConnectionPool;
 
   beforeEach(async () => {
-    adapter = new BetterSQLite3Adapter(":memory:");
+    pool = newPool();
+    adapter = (await pool.checkout()) as unknown as SQLite3Adapter;
     Base.tableNamePrefix = "p_";
     Base.tableNameSuffix = "_s";
     await adapter.createTable("p_rockets_s", { force: true }, (t) => {
@@ -61,7 +85,7 @@ describe("SQLite3Adapter alterTable under a table name prefix/suffix", () => {
     Base.tableNamePrefix = "";
     Base.tableNameSuffix = "";
     await adapter.dropTable("p_astronauts_s", "p_rockets_s", "rockets", { ifExists: true });
-    await adapter.close();
+    await pool.disconnect();
   });
 
   it("keeps a rebuilt foreign key pointing at the affixed table", async () => {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.foreign-key-prefix.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.foreign-key-prefix.trails.test.ts
@@ -1,34 +1,15 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import type { SQLite3Adapter } from "./sqlite3-adapter.js";
-import { BetterSQLite3Adapter } from "./better-sqlite3-adapter.js";
 import { Base } from "../base.js";
-import { ConnectionPool } from "./abstract/connection-pool.js";
-import { PoolConfig } from "./pool-config.js";
-import { ConnectionDescriptor } from "./abstract/connection-descriptor.js";
-import { HashConfig } from "../database-configurations/hash-config.js";
-import type { AbstractAdapter as DatabaseAdapter } from "./abstract-adapter.js";
-
-// Checked out of a real pool, not constructed bare: the alter_table rebuild
-// ends in `clear_query_cache`, whose `pool.clear_query_cache`
-// (query_cache.rb:232-234) is an unchecked send a NullPool cannot answer.
-function newPool(): ConnectionPool {
-  return new ConnectionPool(
-    new PoolConfig(
-      new ConnectionDescriptor("primary"),
-      new HashConfig("test", "primary", { adapter: "sqlite3", database: ":memory:" }),
-      "writing",
-      "default",
-      { adapterFactory: () => new BetterSQLite3Adapter(":memory:") as unknown as DatabaseAdapter },
-    ),
-  );
-}
+import { newSqlitePool } from "../support/pooled-sqlite-adapter.js";
+import type { ConnectionPool } from "./abstract/connection-pool.js";
 
 describe("SQLite3Adapter addForeignKey under a table name prefix/suffix", () => {
   let adapter: SQLite3Adapter;
   let pool: ConnectionPool;
 
   beforeEach(async () => {
-    pool = newPool();
+    pool = newSqlitePool();
     adapter = (await pool.checkout()) as unknown as SQLite3Adapter;
     Base.tableNamePrefix = "p_";
     Base.tableNameSuffix = "_s";
@@ -69,7 +50,7 @@ describe("SQLite3Adapter alterTable under a table name prefix/suffix", () => {
   let pool: ConnectionPool;
 
   beforeEach(async () => {
-    pool = newPool();
+    pool = newSqlitePool();
     adapter = (await pool.checkout()) as unknown as SQLite3Adapter;
     Base.tableNamePrefix = "p_";
     Base.tableNameSuffix = "_s";

--- a/packages/activerecord/src/connection-adapters/sqlite3-introspection.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-introspection.test.ts
@@ -3,34 +3,18 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { SQLite3Adapter } from "./sqlite3-adapter.js";
-import { BetterSQLite3Adapter } from "./better-sqlite3-adapter.js";
-import { ConnectionPool } from "./abstract/connection-pool.js";
-import { PoolConfig } from "./pool-config.js";
-import { ConnectionDescriptor } from "./abstract/connection-descriptor.js";
-import { HashConfig } from "../database-configurations/hash-config.js";
-import type { AbstractAdapter as DatabaseAdapter } from "./abstract-adapter.js";
+import { newSqlitePool } from "../support/pooled-sqlite-adapter.js";
+import type { ConnectionPool } from "./abstract/connection-pool.js";
 
 describe("SQLite3Adapter schema introspection", () => {
   let adapter: SQLite3Adapter;
   let pool: ConnectionPool;
   let tmpDir: string;
 
-  // Checked out of a real pool, not constructed bare: `removeColumn` rebuilds
-  // the table and ends in `clear_query_cache`, whose `pool.clear_query_cache`
-  // (query_cache.rb:232-234) is an unchecked send that a NullPool adapter
-  // cannot answer.
   beforeEach(async () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-sqlite-introspect-"));
     const file = path.join(tmpDir, "db.sqlite3");
-    pool = new ConnectionPool(
-      new PoolConfig(
-        new ConnectionDescriptor("primary"),
-        new HashConfig("test", "primary", { adapter: "sqlite3", database: file }),
-        "writing",
-        "default",
-        { adapterFactory: () => new BetterSQLite3Adapter(file) as unknown as DatabaseAdapter },
-      ),
-    );
+    pool = newSqlitePool(file);
     adapter = (await pool.checkout()) as unknown as SQLite3Adapter;
   });
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-introspection.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-introspection.test.ts
@@ -4,14 +4,34 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { SQLite3Adapter } from "./sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "./better-sqlite3-adapter.js";
+import { ConnectionPool } from "./abstract/connection-pool.js";
+import { PoolConfig } from "./pool-config.js";
+import { ConnectionDescriptor } from "./abstract/connection-descriptor.js";
+import { HashConfig } from "../database-configurations/hash-config.js";
+import type { AbstractAdapter as DatabaseAdapter } from "./abstract-adapter.js";
 
 describe("SQLite3Adapter schema introspection", () => {
   let adapter: SQLite3Adapter;
+  let pool: ConnectionPool;
   let tmpDir: string;
 
-  beforeEach(() => {
+  // Checked out of a real pool, not constructed bare: `removeColumn` rebuilds
+  // the table and ends in `clear_query_cache`, whose `pool.clear_query_cache`
+  // (query_cache.rb:232-234) is an unchecked send that a NullPool adapter
+  // cannot answer.
+  beforeEach(async () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-sqlite-introspect-"));
-    adapter = new BetterSQLite3Adapter(path.join(tmpDir, "db.sqlite3"));
+    const file = path.join(tmpDir, "db.sqlite3");
+    pool = new ConnectionPool(
+      new PoolConfig(
+        new ConnectionDescriptor("primary"),
+        new HashConfig("test", "primary", { adapter: "sqlite3", database: file }),
+        "writing",
+        "default",
+        { adapterFactory: () => new BetterSQLite3Adapter(file) as unknown as DatabaseAdapter },
+      ),
+    );
+    adapter = (await pool.checkout()) as unknown as SQLite3Adapter;
   });
 
   afterEach(async () => {
@@ -24,7 +44,7 @@ describe("SQLite3Adapter schema introspection", () => {
         "DROP TABLE IF EXISTS widgets; DROP TABLE IF EXISTS memberships; DROP TABLE IF EXISTS temp_widgets; DROP TABLE IF EXISTS aux.widgets",
       )
       .catch(() => undefined);
-    await adapter.close();
+    await pool.disconnect();
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 

--- a/packages/activerecord/src/migration/foreign-key.test.ts
+++ b/packages/activerecord/src/migration/foreign-key.test.ts
@@ -18,7 +18,7 @@ import { ArgumentError } from "@blazetrails/activemodel";
 import { StatementInvalid } from "../errors.js";
 import type { ReferentialAction } from "../connection-adapters/abstract/schema-definitions.js";
 import { fixtures } from "../test-fixtures.js";
-import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adapter.js";
+import { newSqlitePool } from "../support/pooled-sqlite-adapter.js";
 import {
   ambientConnection,
   withCompositeRocketTables,
@@ -666,7 +666,8 @@ describeIfSupports("foreign_keys", "Migration", () => {
     });
 
     it("does not create foreign keys when bypassed by config", async () => {
-      const connection = new BetterSQLite3Adapter(":memory:", { foreignKeys: false });
+      const pool = newSqlitePool(":memory:", { foreignKeys: false });
+      const connection = await pool.checkout();
 
       try {
         // These live in this test's own `:memory:` connection, disconnected in
@@ -686,7 +687,7 @@ describeIfSupports("foreign_keys", "Migration", () => {
         const foreignKeys = await connection.foreignKeys("astronauts");
         expect(foreignKeys.length).toBe(0);
       } finally {
-        connection.disconnectBang();
+        await pool.disconnect();
       }
     });
 

--- a/packages/activerecord/src/support/canonical-table-rebuild.test.ts
+++ b/packages/activerecord/src/support/canonical-table-rebuild.test.ts
@@ -3,6 +3,7 @@ import "../sqlite/better-sqlite3.js";
 import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adapter.js";
 import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
 import { loadCanonicalSchema } from "./canonical-schema.js";
+import { newSqlitePool } from "./pooled-sqlite-adapter.js";
 import type { FkSafeDropPlanHost } from "./canonical-table-rebuild.js";
 import {
   bulkInboundFkHost,
@@ -29,7 +30,8 @@ async function dumpSchema(adapter: AbstractAdapter): Promise<string> {
 
 describe("rebuildCanonicalTables", () => {
   test("drops + recreates a named subset to its canonical shape", async () => {
-    const adapter = new BetterSQLite3Adapter(":memory:") as unknown as AbstractAdapter;
+    const pool = newSqlitePool();
+    const adapter = (await pool.checkout()) as unknown as AbstractAdapter;
     try {
       await loadCanonicalSchema(adapter);
       const canonical = await dumpSchema(adapter);
@@ -43,12 +45,13 @@ describe("rebuildCanonicalTables", () => {
       await rebuildCanonicalTables(adapter, ["topics"]);
       expect(await dumpSchema(adapter)).toBe(canonical);
     } finally {
-      await (adapter as unknown as BetterSQLite3Adapter).close();
+      await pool.disconnect();
     }
   });
 
   test("rebuilds a referencing table when only its target was named", async () => {
-    const adapter = new BetterSQLite3Adapter(":memory:") as unknown as AbstractAdapter;
+    const pool = newSqlitePool();
+    const adapter = (await pool.checkout()) as unknown as AbstractAdapter;
     try {
       await loadCanonicalSchema(adapter);
       const canonical = await dumpSchema(adapter);
@@ -60,12 +63,13 @@ describe("rebuildCanonicalTables", () => {
       expect(dump).toBe(canonical);
       expect(dump).toContain('CONSTRAINT "fk_name" FOREIGN KEY ("fk_id")');
     } finally {
-      await (adapter as unknown as BetterSQLite3Adapter).close();
+      await pool.disconnect();
     }
   });
 
   test("drops a foreign key reaching in from a table it is not rebuilding", async () => {
-    const adapter = new BetterSQLite3Adapter(":memory:") as unknown as AbstractAdapter;
+    const pool = newSqlitePool();
+    const adapter = (await pool.checkout()) as unknown as AbstractAdapter;
     const sqlite = adapter as unknown as BetterSQLite3Adapter;
     try {
       await loadCanonicalSchema(adapter);
@@ -82,19 +86,20 @@ describe("rebuildCanonicalTables", () => {
       expect(await sqlite.foreignKeys("lessons_students")).toEqual([]);
       expect(await dumpSchema(adapter)).toBe(canonical);
     } finally {
-      await sqlite.close();
+      await pool.disconnect();
     }
   });
 
   test("throws on an unknown canonical table name", async () => {
-    const adapter = new BetterSQLite3Adapter(":memory:") as unknown as AbstractAdapter;
+    const pool = newSqlitePool();
+    const adapter = (await pool.checkout()) as unknown as AbstractAdapter;
     try {
       await loadCanonicalSchema(adapter);
       await expect(rebuildCanonicalTables(adapter, ["topics", "not_a_real_table"])).rejects.toThrow(
         /unknown canonical table\(s\): not_a_real_table/,
       );
     } finally {
-      await (adapter as unknown as BetterSQLite3Adapter).close();
+      await pool.disconnect();
     }
   });
 });
@@ -301,7 +306,8 @@ async function tableNames(adapter: AbstractAdapter): Promise<Set<string>> {
 
 describe("ensureCanonicalTables", () => {
   test("creates only the missing named tables, restoring canonical shape", async () => {
-    const adapter = new BetterSQLite3Adapter(":memory:") as unknown as AbstractAdapter;
+    const pool = newSqlitePool();
+    const adapter = (await pool.checkout()) as unknown as AbstractAdapter;
     try {
       await loadCanonicalSchema(adapter);
       const canonical = await dumpSchema(adapter);
@@ -315,12 +321,13 @@ describe("ensureCanonicalTables", () => {
       expect(await tableNames(adapter)).toContain("topics");
       expect(await dumpSchema(adapter)).toBe(canonical);
     } finally {
-      await (adapter as unknown as BetterSQLite3Adapter).close();
+      await pool.disconnect();
     }
   });
 
   test("is a no-op when every named table already exists", async () => {
-    const adapter = new BetterSQLite3Adapter(":memory:") as unknown as AbstractAdapter;
+    const pool = newSqlitePool();
+    const adapter = (await pool.checkout()) as unknown as AbstractAdapter;
     try {
       await loadCanonicalSchema(adapter);
       // A drifted `topics` must survive: ensure creates nothing (all present)
@@ -332,19 +339,20 @@ describe("ensureCanonicalTables", () => {
       await ensureCanonicalTables(adapter, ["topics", "authors"]);
       expect(await dumpSchema(adapter)).toBe(drifted);
     } finally {
-      await (adapter as unknown as BetterSQLite3Adapter).close();
+      await pool.disconnect();
     }
   });
 
   test("throws on an unknown canonical table name", async () => {
-    const adapter = new BetterSQLite3Adapter(":memory:") as unknown as AbstractAdapter;
+    const pool = newSqlitePool();
+    const adapter = (await pool.checkout()) as unknown as AbstractAdapter;
     try {
       await loadCanonicalSchema(adapter);
       await expect(ensureCanonicalTables(adapter, ["topics", "not_a_real_table"])).rejects.toThrow(
         /unknown canonical table\(s\): not_a_real_table/,
       );
     } finally {
-      await (adapter as unknown as BetterSQLite3Adapter).close();
+      await pool.disconnect();
     }
   });
 });

--- a/packages/activerecord/src/support/pooled-sqlite-adapter.ts
+++ b/packages/activerecord/src/support/pooled-sqlite-adapter.ts
@@ -1,0 +1,35 @@
+import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adapter.js";
+import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
+import { ConnectionPool } from "../connection-adapters/abstract/connection-pool.js";
+import { PoolConfig } from "../connection-adapters/pool-config.js";
+import { ConnectionDescriptor } from "../connection-adapters/abstract/connection-descriptor.js";
+import { HashConfig } from "../database-configurations/hash-config.js";
+
+/**
+ * A standalone SQLite pool for tests that need an adapter of their own rather
+ * than the ambient connection.
+ *
+ * A bare `new BetterSQLite3Adapter(...)` holds a `NullPool`, and Rails'
+ * `QueryCache#clear_query_cache` (`abstract/query_cache.rb:232-234`) is the
+ * unchecked send `pool.clear_query_cache` — which a `NullPool` cannot answer,
+ * exactly as in Ruby. Every DDL path that rebuilds a SQLite table
+ * (`alter_table`, and so `add_foreign_key` / `remove_column`) ends there, so
+ * those tests check their adapter out of a real pool.
+ */
+export function newSqlitePool(
+  database = ":memory:",
+  options?: ConstructorParameters<typeof BetterSQLite3Adapter>[1],
+): ConnectionPool {
+  return new ConnectionPool(
+    new PoolConfig(
+      new ConnectionDescriptor("primary"),
+      new HashConfig("test", "primary", { adapter: "sqlite3", database }),
+      "writing",
+      "default",
+      {
+        adapterFactory: () =>
+          new BetterSQLite3Adapter(database, options) as unknown as AbstractAdapter,
+      },
+    ),
+  );
+}


### PR DESCRIPTION
## What

`clearQueryCache` (`connection-adapters/abstract/query-cache.ts`) duck-typed the
pool: `if (this.pool?.clearQueryCache) { ... } else this._queryCache?.clear()`.
Rails' `QueryCache#clear_query_cache`
(`activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:232-234`)
is the bare unchecked send `pool.clear_query_cache`, which raises NoMethodError on
a pool-less adapter (`@pool = NullPool.new`, `abstract_adapter.rb:153`). The
fallback made such an adapter look like it cleared a pool cache it never had.

- `clearQueryCache` is now `this.pool.clearQueryCache()` — no `?.`, no
  `_queryCache` arm; `QueryCachePool#clearQueryCache` and `QueryCacheHost#pool`
  are no longer optional.
- The pool-less call sites that relied on the fallback — SQLite `alterTable`
  → `removeColumn` (`sqlite3-adapter.ts:2354`), reached from four suites that
  constructed a bare `BetterSQLite3Adapter` — now check the adapter out of a real
  `ConnectionPool`. No test names changed.

## Not in this PR

The third acceptance criterion (delete `NULL_POOL_UNDEFINED_METHODS` and let the
NullPool `get` trap raise for every non-member key) cannot land here: that
constant does not exist on `main`, it is introduced by the still-open #6240
(`NullPool raises on role/shard`). This PR removes the reader that blocked it, so
#6240's follow-up can widen the trap without stacking.

Closes-story: clear-query-cache-duck-types-the-pool
