### PR TITLE
refactor(actionview): retire the TemplateHandlerRegistry back-compat object

### DIFF
--- a/packages/actionview/src/digestor.test.ts
+++ b/packages/actionview/src/digestor.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, it } from "vitest";
 
 import { Digestor } from "./digestor.js";
 import { LookupContext } from "./lookup-context.js";
-import { TemplateHandlerRegistry } from "./template/handlers.js";
+import { TemplateHandlers } from "./template/handlers.js";
 import { InMemoryResolver } from "./resolver/in-memory-resolver.js";
 
 function withFinder(source: string): LookupContext {
-  TemplateHandlerRegistry.register({
+  TemplateHandlers.registerTemplateHandler("html", {
     extensions: ["html"],
     render: (s) => s,
   });

--- a/packages/actionview/src/index.ts
+++ b/packages/actionview/src/index.ts
@@ -1,9 +1,4 @@
-export {
-  type TemplateHandler,
-  type RenderContext,
-  TemplateHandlers,
-  TemplateHandlerRegistry,
-} from "./template/handlers.js";
+export { type TemplateHandler, type RenderContext, TemplateHandlers } from "./template/handlers.js";
 export { Raw as RawHandler } from "./template/handlers/raw.js";
 export {
   Tse as TseHandler,

--- a/packages/actionview/src/lookup-context.ts
+++ b/packages/actionview/src/lookup-context.ts
@@ -17,7 +17,7 @@
  */
 
 import type { RenderContext } from "./template/handlers.js";
-import { TemplateHandlerRegistry } from "./template/handlers.js";
+import { TemplateHandlers } from "./template/handlers.js";
 import type { TemplateResolver } from "./resolver/resolver.js";
 import type { Template } from "./template.js";
 import { Jaro } from "@blazetrails/did-you-mean";
@@ -41,7 +41,7 @@ function registerDetail(name: string, proc: DefaultProc): void {
 registerDetail("locale", () => ["en"]);
 registerDetail("formats", () => ["html", "text", "js", "css", "xml", "json"]);
 registerDetail("variants", () => []);
-registerDetail("handlers", () => TemplateHandlerRegistry.extensions as DetailValue);
+registerDetail("handlers", () => TemplateHandlers.extensions() as DetailValue);
 
 /** Whitelist of format symbols recognized by `formats=`. */
 const VALID_FORMAT_SYMBOLS: ReadonlySet<string> = new Set([
@@ -550,7 +550,7 @@ export class LookupContext {
    * @internal
    */
   findTemplate(name: string, prefix: string, format: string): Template | null {
-    const extensions = TemplateHandlerRegistry.extensions;
+    const extensions = TemplateHandlers.extensions();
     if (extensions.length === 0) return null;
 
     for (const resolver of this.resolvers) {
@@ -573,7 +573,7 @@ export class LookupContext {
    * @internal
    */
   findLayout(name: string, format: string): Template | null {
-    const extensions = TemplateHandlerRegistry.extensions;
+    const extensions = TemplateHandlers.extensions();
     if (extensions.length === 0) return null;
 
     for (const resolver of this.resolvers) {
@@ -718,11 +718,11 @@ export class LookupContext {
     locals: Record<string, unknown>,
     context: RenderContext,
   ): Promise<string> {
-    const handler = TemplateHandlerRegistry.handlerForExtension(template.extension);
+    const handler = TemplateHandlers.handlerForExtension(template.extension);
     if (!handler) {
       throw new Error(
         `No template handler registered for ".${template.extension}". ` +
-          `Register one with TemplateHandlerRegistry.register(handler).`,
+          `Register one with TemplateHandlers.registerTemplateHandler(extension, handler).`,
       );
     }
 

--- a/packages/actionview/src/template-details.ts
+++ b/packages/actionview/src/template-details.ts
@@ -6,7 +6,7 @@
  */
 
 import type { TemplateHandler } from "./template/handlers.js";
-import { TemplateHandlerRegistry } from "./template/handlers.js";
+import { TemplateHandlers } from "./template/handlers.js";
 
 export type DetailKey = string | symbol | null;
 
@@ -107,7 +107,7 @@ export class TemplateDetails {
    */
   handlerClass(): TemplateHandler | undefined {
     if (typeof this.handler !== "string") return undefined;
-    return TemplateHandlerRegistry.handlerForExtension(this.handler);
+    return TemplateHandlers.handlerForExtension(this.handler);
   }
 
   /**

--- a/packages/actionview/src/template/handlers.ts
+++ b/packages/actionview/src/template/handlers.ts
@@ -129,29 +129,3 @@ export const TemplateHandlers = {
     cachedExtensions = null;
   },
 };
-
-/**
- * Back-compat alias. The previous name was `TemplateHandlerRegistry`; the
- * Rails-mirroring name is `TemplateHandlers`.
- *
- * @deprecated Use {@link TemplateHandlers}.
- */
-export const TemplateHandlerRegistry = {
-  register(handler: TemplateHandler): void {
-    for (const ext of handler.extensions) {
-      TemplateHandlers.registerTemplateHandler(ext, handler);
-    }
-  },
-  handlerForExtension(ext: string): TemplateHandler | undefined {
-    return TemplateHandlers.handlerForExtension(ext);
-  },
-  get extensions(): string[] {
-    return TemplateHandlers.extensions();
-  },
-  has(ext: string): boolean {
-    return TemplateHandlers.registeredTemplateHandler(ext) !== undefined;
-  },
-  clear(): void {
-    TemplateHandlers.clear();
-  },
-};

--- a/packages/trailties/src/server/application.ts
+++ b/packages/trailties/src/server/application.ts
@@ -51,7 +51,8 @@ export class Application {
    * keep working.
    */
   private setupViews(): void {
-    ActionView.TemplateHandlerRegistry.register(new ActionView.RawHandler());
+    const rawHandler = new ActionView.RawHandler();
+    ActionView.TemplateHandlers.registerTemplateHandler(...rawHandler.extensions, rawHandler);
 
     // Add file system resolver pointing to the app's views directory
     const viewsPath = path.join(this.cwd, "src", "app", "views");


### PR DESCRIPTION
`TemplateHandlerRegistry` was a `@deprecated` object literal in `packages/actionview/src/template/handlers.ts` forwarding to `TemplateHandlers` under non-Rails names (`register`, `handlerForExtension`, `extensions`, `has`, `clear`). Rails spells these `register_template_handler` / `registered_template_handler` / `template_handler_extensions` / `handler_for_extension` (vendor/rails/actionview/lib/action_view/template/handlers.rb:33-63).

Deleted it and swept its callers onto `TemplateHandlers` at the Rails names: `lookup-context.ts`, `template-details.ts`, `digestor.test.ts`, `index.ts`, and `trailties/src/server/application.ts` (which now registers the Raw handler's own extensions variadically, matching `register_template_handler(*extensions, handler)`).

`pnpm api:extra --package actionview` no longer scores `TemplateHandlerRegistry` or `has`; no allowlist rows added.

Closes-story: retire-template-handler-registry-back-compat-object