### PR TITLE
refactor(trailties,activesupport,actionview): spell TSE everywhere in trails, including test names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,7 +238,14 @@ tasks repo enumerates these as convergence classes.
 - **NEVER rename or reword test names.** Test names are how `test:compare`
   matches our tests to Rails tests. If a test fails or the behavior doesn't
   match the name, fix the implementation — not the name. Read the
-  corresponding Rails test first.
+  corresponding Rails test first. This outranks the token renames in
+  [docs/ruby-ts-conventions.md](docs/ruby-ts-conventions.md): a test name keeps
+  Rails' spelling even where trails renames the token everywhere else, so
+  `it("ERB::Util.html_escape should escape unsafe characters")` stays `ERB`
+  inside `core-ext/string-ext.test.ts`. `test:compare` normalizes both sides,
+  so the verbatim name still credits against the TSE-spelled file. Everything
+  that is not a test name — file, directory, class, method, identifier — is
+  TSE.
 - **Canonical tables only — no bespoke tables.** In AR tests, get the canonical
   schema + fixtures through `fixtures({ ... })` (the endgame surface: one call
   wires the handler, transactional fixtures, and the canonical schema); never

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,14 +238,14 @@ tasks repo enumerates these as convergence classes.
 - **NEVER rename or reword test names.** Test names are how `test:compare`
   matches our tests to Rails tests. If a test fails or the behavior doesn't
   match the name, fix the implementation — not the name. Read the
-  corresponding Rails test first. This outranks the token renames in
-  [docs/ruby-ts-conventions.md](docs/ruby-ts-conventions.md): a test name keeps
-  Rails' spelling even where trails renames the token everywhere else, so
-  `it("ERB::Util.html_escape should escape unsafe characters")` stays `ERB`
-  inside `core-ext/string-ext.test.ts`. `test:compare` normalizes both sides,
-  so the verbatim name still credits against the TSE-spelled file. Everything
-  that is not a test name — file, directory, class, method, identifier — is
-  TSE.
+  corresponding Rails test first. The one thing that does change is the token
+  renames in [docs/ruby-ts-conventions.md](docs/ruby-ts-conventions.md), which
+  apply to test names too — trails spells `tse`, never `erb`, everywhere,
+  including inside a `describe`/`it` string. Rails'
+  `test "ERB::Util.html_escape should escape unsafe characters"` is
+  `it("TSE::Util.html_escape should escape unsafe characters")`; `test:compare`
+  normalizes both sides, so the renamed name still credits. `ERB` survives only
+  where the text quotes the Ruby side (a `Mirrors:` JSDoc line, a Rails path).
 - **Canonical tables only — no bespoke tables.** In AR tests, get the canonical
   schema + fixtures through `fixtures({ ... })` (the endgame surface: one call
   wires the handler, transactional fixtures, and the canonical schema); never

--- a/docs/ruby-ts-conventions.md
+++ b/docs/ruby-ts-conventions.md
@@ -72,6 +72,16 @@ trails:
 | `ERB`      | `TSE`        |
 | `Erb`      | `Tse`        |
 
+Test names are the exception. A `describe`/`it` string is `test:compare`'s
+match key and is copied verbatim from the Rails test, so it keeps Rails'
+spelling: `it("ERB::Util.html_escape should escape unsafe characters")` in
+`core-ext/string-ext.test.ts`, mirroring
+`activesupport/test/core_ext/string_ext_test.rb:1086`. `normalizeErb` in
+`scripts/test-compare/test-compare.ts` applies this table to both sides of the
+comparison, so the verbatim name still credits against the TSE-spelled file it
+lives in. Everything else — file names, directories, classes, methods,
+identifiers — is TSE.
+
 ## File paths
 
 Ruby `foo_bar.rb` → `foo-bar.ts` (kebab-case), with these path-segment aliases

--- a/docs/ruby-ts-conventions.md
+++ b/docs/ruby-ts-conventions.md
@@ -72,15 +72,17 @@ trails:
 | `ERB`      | `TSE`        |
 | `Erb`      | `Tse`        |
 
-Test names are the exception. A `describe`/`it` string is `test:compare`'s
-match key and is copied verbatim from the Rails test, so it keeps Rails'
-spelling: `it("ERB::Util.html_escape should escape unsafe characters")` in
-`core-ext/string-ext.test.ts`, mirroring
-`activesupport/test/core_ext/string_ext_test.rb:1086`. `normalizeErb` in
+Test names are not an exception. Rails'
+`test "ERB::Util.html_escape should escape unsafe characters"`
+(`activesupport/test/core_ext/string_ext_test.rb:1086`) is
+`it("TSE::Util.html_escape should escape unsafe characters")` in
+`core-ext/string-ext.test.ts`. It still credits: `normalizeErb` in
 `scripts/test-compare/test-compare.ts` applies this table to both sides of the
-comparison, so the verbatim name still credits against the TSE-spelled file it
-lives in. Everything else — file names, directories, classes, methods,
-identifiers — is TSE.
+comparison, so the Ruby name and the TSE-spelled trails name normalize to the
+same key. `ERB` survives in trails only where the text quotes the Ruby side —
+a JSDoc `Mirrors:` line naming `ERB::Util`, a Rails path like
+`core_ext/erb/util.rb`, or fixtures-compare's statuses for Rails YAML that
+genuinely is ERB.
 
 ## File paths
 

--- a/packages/actionpack/src/action-controller/controller/content-type.test.ts
+++ b/packages/actionpack/src/action-controller/controller/content-type.test.ts
@@ -102,12 +102,12 @@ describe("ContentTypeTest", () => {
     expect(c.response.charset).toBe("utf-8");
   });
 
-  it.skip("test nil default for erb", () => {
-    // pending: requires ERB template rendering (ActionView not yet ported)
+  it.skip("test nil default for tse", () => {
+    // pending: requires TSE template rendering (ActionView not yet ported)
   });
 
-  it.skip("test default for erb", () => {
-    // pending: requires ERB template rendering (ActionView not yet ported)
+  it.skip("test default for tse", () => {
+    // pending: requires TSE template rendering (ActionView not yet ported)
   });
 
   it.skip("test default for builder", () => {

--- a/packages/actionview/src/template/handlers/tse.test.ts
+++ b/packages/actionview/src/template/handlers/tse.test.ts
@@ -119,7 +119,7 @@ describe("Template::Handlers::Tse", () => {
     ).toThrow(/not yet implemented/);
   });
 
-  it("Tse.call mirrors `Handlers::ERB.call` and delegates to a fresh instance", () => {
+  it("Tse.call delegates to a fresh instance", () => {
     const code = Tse.call({ type: "text/html" }, "<%= name %>");
     expect(code).toMatch(/_ob\.append\(name\)/);
   });

--- a/packages/actionview/src/template/tag-helper.test.ts
+++ b/packages/actionview/src/template/tag-helper.test.ts
@@ -297,13 +297,13 @@ describe("TagHelperTest", () => {
     ).toBe('<div id="header"><div class="world"><span>hello</span></div></div>');
   });
 
-  it("content tag with block and options out of erb", () => {
+  it("content tag with block and options out of tse", () => {
     expect(contentTag("div", { class: "green" }, null, true, () => "Hello world!").toString()).toBe(
       '<div class="green">Hello world!</div>',
     );
   });
 
-  it("tag builder with block and options out of erb", () => {
+  it("tag builder with block and options out of tse", () => {
     const t = tag() as any;
     expect(t.div({ class: "green" }, () => "Hello world!").toString()).toBe(
       '<div class="green">Hello world!</div>',
@@ -778,20 +778,20 @@ describe("TagHelperTest", () => {
     );
   });
 
-  it("content tag with block and options outside out of erb", () => {
+  it("content tag with block and options outside out of tse", () => {
     expect(contentTag("a", "Create", { href: "create" }).toString()).toBe(
       contentTag("a", { href: "create" }, null, true, () => "Create").toString(),
     );
   });
 
-  it("tag builder with block and options outside out of erb", () => {
+  it("tag builder with block and options outside out of tse", () => {
     const t = tag() as any;
     expect(t.a("Create", { href: "create" }).toString()).toBe(
       t.a({ href: "create" }, () => "Create").toString(),
     );
   });
 
-  it("content tag with block and non string outside out of erb", () => {
+  it("content tag with block and non string outside out of tse", () => {
     expect(contentTag("p").toString()).toBe(
       contentTag("p", null, null, true, () => {
         for (let i = 0; i < 3; i++) {
@@ -802,7 +802,7 @@ describe("TagHelperTest", () => {
     );
   });
 
-  it("tag builder with block and non string outside out of erb", () => {
+  it("tag builder with block and non string outside out of tse", () => {
     const t = tag() as any;
     expect(t.p().toString()).toBe(
       t
@@ -816,7 +816,7 @@ describe("TagHelperTest", () => {
     );
   });
 
-  it("content tag nested in content tag out of erb", () => {
+  it("content tag nested in content tag out of tse", () => {
     expect(contentTag("p", contentTag("b", "Hello")).toString()).toBe("<p><b>Hello</b></p>");
     const t = tag() as any;
     expect(t.p(t.b("Hello")).toString()).toBe("<p><b>Hello</b></p>");

--- a/packages/activesupport/src/core-ext/string-ext.test.ts
+++ b/packages/activesupport/src/core-ext/string-ext.test.ts
@@ -737,50 +737,50 @@ describe("OutputSafetyTest", () => {
     expect(typeof safe.toString()).toBe("string");
   });
 
-  it("ERB::Util.html_escape should escape unsafe characters", () => {
+  it("TSE::Util.html_escape should escape unsafe characters", () => {
     const result = htmlEscape('<script>alert("xss")</script>');
     expect(result.toString()).toBe("&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;");
   });
 
-  it("ERB::Util.html_escape should correctly handle invalid UTF-8 strings", () => {
+  it("TSE::Util.html_escape should correctly handle invalid UTF-8 strings", () => {
     const result = htmlEscape("hello\uFFFDworld");
     expect(result.toString()).toContain("hello");
     expect(result.toString()).toContain("world");
   });
 
-  it("ERB::Util.html_escape should not escape safe strings", () => {
+  it("TSE::Util.html_escape should not escape safe strings", () => {
     const safe = htmlSafe("<b>bold</b>");
     const result = htmlEscape(safe);
     expect(result.toString()).toBe("<b>bold</b>");
   });
 
-  it("ERB::Util.html_escape_once only escapes once", () => {
+  it("TSE::Util.html_escape_once only escapes once", () => {
     const result = htmlEscapeOnce("&lt;already escaped&gt;");
     expect(result.toString()).toBe("&lt;already escaped&gt;");
     const raw = htmlEscapeOnce("<raw>");
     expect(raw.toString()).toBe("&lt;raw&gt;");
   });
 
-  it("ERB::Util.html_escape_once should correctly handle invalid UTF-8 strings", () => {
+  it("TSE::Util.html_escape_once should correctly handle invalid UTF-8 strings", () => {
     const result = htmlEscapeOnce("hello\uFFFDworld");
     expect(result.toString()).toContain("hello");
     expect(result.toString()).toContain("world");
   });
 
-  it("ERB::Util.html_escape_once preserves numeric character references", () => {
+  it("TSE::Util.html_escape_once preserves numeric character references", () => {
     expect(htmlEscapeOnce("&#123;").toString()).toBe("&#123;");
     expect(htmlEscapeOnce("&#x1F4A9;").toString()).toBe("&#x1F4A9;");
     expect(htmlEscapeOnce("&#X27;").toString()).toBe("&#X27;");
     expect(htmlEscapeOnce("&#x03BB;").toString()).toBe("&#x03BB;");
   });
 
-  it("ERB::Util.html_escape_once escapes invalid entity-like sequences", () => {
+  it("TSE::Util.html_escape_once escapes invalid entity-like sequences", () => {
     expect(htmlEscapeOnce("&1;").toString()).toBe("&amp;1;");
     expect(htmlEscapeOnce("&#1dfa3;").toString()).toBe("&amp;#1dfa3;");
     expect(htmlEscapeOnce("& #123;").toString()).toBe("&amp; #123;");
   });
 
-  it("ERB::Util.xml_name_escape should escape unsafe characters for XML names", () => {
+  it("TSE::Util.xml_name_escape should escape unsafe characters for XML names", () => {
     const unsafeChar = ">";
     const safeChar = "\u00C1";
     const safeCharAfterStart = "3";

--- a/packages/trailties/src/backtrace-cleaner.test.ts
+++ b/packages/trailties/src/backtrace-cleaner.test.ts
@@ -55,18 +55,18 @@ describe("BacktraceCleaner", () => {
 
   test("#clean should omit ActionView template methods names", () => {
     const backtrace = [
-      "app/views/application/index.html.erb:4:in `block in _app_views_application_index_html_erb__1234_5678'",
+      "app/views/application/index.html.tse:4:in `block in _app_views_application_index_html_tse__1234_5678'",
     ];
     const result = cleaner.clean(backtrace, "all");
-    expect(result[0]).toBe("app/views/application/index.html.erb:4");
+    expect(result[0]).toBe("app/views/application/index.html.tse:4");
   });
 
   test("#clean should omit ActionView template methods names on Ruby 3.4+", () => {
     const backtrace = [
-      "app/views/application/index.html.erb:4:in 'block in _app_views_application_index_html_erb__1234_5678'",
+      "app/views/application/index.html.tse:4:in 'block in _app_views_application_index_html_tse__1234_5678'",
     ];
     const result = cleaner.clean(backtrace, "all");
-    expect(result[0]).toBe("app/views/application/index.html.erb:4");
+    expect(result[0]).toBe("app/views/application/index.html.tse:4");
   });
 
   test("#clean_frame should consider traces from irb lines as User code", () => {
@@ -100,18 +100,18 @@ describe("BacktraceCleaner", () => {
 
   test("#clean_frame should omit ActionView template methods names", () => {
     const frame = cleaner.cleanFrame(
-      "app/views/application/index.html.erb:4:in `block in _app_views_application_index_html_erb__1234_5678'",
+      "app/views/application/index.html.tse:4:in `block in _app_views_application_index_html_tse__1234_5678'",
       "all",
     );
-    expect(frame).toBe("app/views/application/index.html.erb:4");
+    expect(frame).toBe("app/views/application/index.html.tse:4");
   });
 
   test("#clean_frame should omit ActionView template methods names on Ruby 3.4+", () => {
     const frame = cleaner.cleanFrame(
-      "app/views/application/index.html.erb:4:in 'block in _app_views_application_index_html_erb__1234_5678'",
+      "app/views/application/index.html.tse:4:in 'block in _app_views_application_index_html_tse__1234_5678'",
       "all",
     );
-    expect(frame).toBe("app/views/application/index.html.erb:4");
+    expect(frame).toBe("app/views/application/index.html.tse:4");
   });
 
   test("setRoot strips application root from absolute paths", () => {

--- a/packages/trailties/src/code-statistics-calculator.ts
+++ b/packages/trailties/src/code-statistics-calculator.ts
@@ -2,14 +2,14 @@
  * Port of railties/lib/rails/code_statistics_calculator.rb.
  *
  * Counts lines/codeLines/classes/methods in source text by file type.
- * Patterns mirror Rails' for rb/erb/css/scss/js/coffee; ts/tsx add TS
+ * Patterns mirror Rails' for rb/erb (spelled tse here)/css/scss/js/coffee; ts/tsx add TS
  * equivalents (function, arrow, class method shorthand with leading
  * keyword, get/set accessors).
  */
 
 export type FileType =
   | "rb"
-  | "erb"
+  | "tse"
   | "css"
   | "scss"
   | "js"
@@ -49,7 +49,7 @@ export const PATTERNS: Record<FileType, PatternSet> = {
   rb: RB,
   rake: RB,
   minitest: { ...RB, method: /^\s*(def|test)\s+['"_a-z]/ },
-  erb: { lineComment: /((^\s*<%#.*%>)|(<!--.*-->))/ },
+  tse: { lineComment: /((^\s*<%#.*%>)|(<!--.*-->))/ },
   css: { lineComment: /^\s*\/\*.*\*\// },
   scss: { lineComment: /((^\s*\/\*.*\*\/)|(^\s*\/\/))/ },
   js: {

--- a/packages/trailties/src/code-statistics.test.ts
+++ b/packages/trailties/src/code-statistics.test.ts
@@ -105,10 +105,10 @@ describe("CodeStatisticsCalculatorTest", () => {
     expect([calc.lines, calc.codeLines, calc.classes, calc.methods]).toEqual([8, 0, 0, 0]);
   });
 
-  it("skip ERB comments", () => {
+  it("skip TSE comments", () => {
     calc.addByString(
       "      <!-- This is an HTML comment -->\n      <%# This is a great comment! %>\n      <div>\n        <%= hello %>\n\n      </div>\n",
-      "erb",
+      "tse",
     );
     expect([calc.lines, calc.codeLines]).toEqual([6, 3]);
   });

--- a/packages/trailties/src/code-statistics.ts
+++ b/packages/trailties/src/code-statistics.ts
@@ -51,7 +51,7 @@ const HEADERS = [
   { key: "methods", label: "Methods" },
 ] as const;
 
-const FILE_PATTERN = /^(?!\.).*?\.(rb|js|ts|tsx|css|scss|coffee|rake|erb)$/;
+const FILE_PATTERN = /^(?!\.).*?\.(rb|js|ts|tsx|css|scss|coffee|rake|tse)$/;
 
 export class CodeStatistics {
   static directories: DirectoryPair[] = [...DEFAULT_DIRECTORIES];

--- a/packages/trailties/src/source-annotation-extractor.ts
+++ b/packages/trailties/src/source-annotation-extractor.ts
@@ -47,7 +47,7 @@ function registerDefaults(): void {
   registerExtensions(["ts", "js", "mjs", "cjs", "tsx", "jsx"], slash);
   registerExtensions(["css", "scss", "sass", "less"], slash);
   registerExtensions(["yml", "yaml"], (tag) => new RegExp(`#\\s*(${tag}):?\\s*(.*)$`));
-  registerExtensions(["ejs", "erb"], (tag) => new RegExp(`<%\\s*#\\s*(${tag}):?\\s*(.*?)\\s*%>`));
+  registerExtensions(["ejs", "tse"], (tag) => new RegExp(`<%\\s*#\\s*(${tag}):?\\s*(.*?)\\s*%>`));
 }
 
 registerDefaults();

--- a/scripts/api-compare/conventions.ts
+++ b/scripts/api-compare/conventions.ts
@@ -16,6 +16,14 @@ import * as path from "path";
  * `verb` / `superb` / `Herb` are untouched — the token still has to start at
  * the identifier or just after an underscore.
  *
+ * Test names are the one exception, and deliberately so: a `describe`/`it`
+ * string is `test:compare`'s match key and is copied verbatim from the Rails
+ * test, so `test "ERB::Util.html_escape should escape unsafe characters"`
+ * (activesupport/test/core_ext/string_ext_test.rb:1086) stays `ERB::Util…` in
+ * string-ext.test.ts. `normalizeErb` in scripts/test-compare/test-compare.ts
+ * applies this table to both sides of the comparison, so the verbatim name
+ * still credits against the TSE-spelled file it lives in.
+ *
  * Applied to every identifier that flows through `snakeToCamel` —
  * currently Ruby method names (via `rubyMethodToTs`) and constant
  * fragments embedded in dot-notation method names like
@@ -1133,6 +1141,16 @@ trails:
 | Ruby token | trails token |
 | ---------- | ------------ |
 ${renameRows}
+
+Test names are the exception. A \`describe\`/\`it\` string is \`test:compare\`'s
+match key and is copied verbatim from the Rails test, so it keeps Rails'
+spelling: \`it("ERB::Util.html_escape should escape unsafe characters")\` in
+\`core-ext/string-ext.test.ts\`, mirroring
+\`activesupport/test/core_ext/string_ext_test.rb:1086\`. \`normalizeErb\` in
+\`scripts/test-compare/test-compare.ts\` applies this table to both sides of the
+comparison, so the verbatim name still credits against the TSE-spelled file it
+lives in. Everything else — file names, directories, classes, methods,
+identifiers — is TSE.
 
 ## File paths
 

--- a/scripts/api-compare/conventions.ts
+++ b/scripts/api-compare/conventions.ts
@@ -16,13 +16,16 @@ import * as path from "path";
  * `verb` / `superb` / `Herb` are untouched — the token still has to start at
  * the identifier or just after an underscore.
  *
- * Test names are the one exception, and deliberately so: a `describe`/`it`
- * string is `test:compare`'s match key and is copied verbatim from the Rails
- * test, so `test "ERB::Util.html_escape should escape unsafe characters"`
- * (activesupport/test/core_ext/string_ext_test.rb:1086) stays `ERB::Util…` in
- * string-ext.test.ts. `normalizeErb` in scripts/test-compare/test-compare.ts
- * applies this table to both sides of the comparison, so the verbatim name
- * still credits against the TSE-spelled file it lives in.
+ * There is no exception for test names. `test "ERB::Util.html_escape should
+ * escape unsafe characters"` (activesupport/test/core_ext/string_ext_test.rb:1086)
+ * is `it("TSE::Util.html_escape should escape unsafe characters")` in
+ * string-ext.test.ts. It still credits: `normalizeErb` in
+ * scripts/test-compare/test-compare.ts applies this table to both sides of the
+ * comparison, so the Ruby name and the TSE-spelled trails name normalize to
+ * the same key. `ERB` survives in trails only where the text quotes the Ruby
+ * side — a JSDoc `Mirrors:` line naming `ERB::Util`, a Rails path like
+ * `core_ext/erb/util.rb`, or fixtures-compare's statuses for Rails YAML that
+ * genuinely is ERB.
  *
  * Applied to every identifier that flows through `snakeToCamel` —
  * currently Ruby method names (via `rubyMethodToTs`) and constant
@@ -1142,15 +1145,17 @@ trails:
 | ---------- | ------------ |
 ${renameRows}
 
-Test names are the exception. A \`describe\`/\`it\` string is \`test:compare\`'s
-match key and is copied verbatim from the Rails test, so it keeps Rails'
-spelling: \`it("ERB::Util.html_escape should escape unsafe characters")\` in
-\`core-ext/string-ext.test.ts\`, mirroring
-\`activesupport/test/core_ext/string_ext_test.rb:1086\`. \`normalizeErb\` in
+Test names are not an exception. Rails'
+\`test "ERB::Util.html_escape should escape unsafe characters"\`
+(\`activesupport/test/core_ext/string_ext_test.rb:1086\`) is
+\`it("TSE::Util.html_escape should escape unsafe characters")\` in
+\`core-ext/string-ext.test.ts\`. It still credits: \`normalizeErb\` in
 \`scripts/test-compare/test-compare.ts\` applies this table to both sides of the
-comparison, so the verbatim name still credits against the TSE-spelled file it
-lives in. Everything else — file names, directories, classes, methods,
-identifiers — is TSE.
+comparison, so the Ruby name and the TSE-spelled trails name normalize to the
+same key. \`ERB\` survives in trails only where the text quotes the Ruby side —
+a JSDoc \`Mirrors:\` line naming \`ERB::Util\`, a Rails path like
+\`core_ext/erb/util.rb\`, or fixtures-compare's statuses for Rails YAML that
+genuinely is ERB.
 
 ## File paths
 


### PR DESCRIPTION
Closes the last `erb` story: decide and record whether trails-side test names spell `TSE` or keep Rails' `ERB`.

**Decision: TSE everywhere in trails, no exceptions — test names included.**

`normalizeErb` (`scripts/test-compare/test-compare.ts:166-168`) applies `TOKEN_RENAMES` to both sides of the comparison, so a TSE-spelled trails test name normalizes to the same key as the Rails `ERB` one and still credits. `pnpm test:compare` is byte-identical before and after this branch (`15350/22647 tests | 780/1073 files | 188 misplaced`), confirming no name lost its match.

Renamed:
- `activesupport/src/core-ext/string-ext.test.ts` — 8 `ERB::Util.*` names → `TSE::Util.*` (`activesupport/test/core_ext/string_ext_test.rb:1086-1117`). `TSE::Util` is what the module is called here: `core-ext/tse/util.ts`.
- `actionview/src/template/tag-helper.test.ts` — 7 "… out of erb" → "… out of tse" (`actionview/test/template/tag_helper_test.rb`).
- `actionpack/…/content-type.test.ts` — 2 pending "default for erb" → "for tse" (`actionpack/test/controller/content_type_test.rb`).
- `actionview/…/handlers/tse.test.ts:122` — trails-authored name citing `Handlers::ERB.call`; reworded to `"Tse.call delegates to a fresh instance"`. The Rails counterpart it mirrors (`handlers/erb.rb`) is already recorded in `tse.ts:80`'s JSDoc, which is where the citation belongs.

Identifiers, not just names — these were live `erb` spellings in trails source, and trails templates are `.tse`:
- `trailties/src/code-statistics-calculator.ts` — `FileType` member and comment-pattern key `erb` → `tse` (`railties/lib/rails/code_statistics_calculator.rb:15`), plus `code-statistics.ts:54`'s `FILE_PATTERN` extension.
- `trailties/src/source-annotation-extractor.ts:50` — `registerExtensions(["ejs", "erb"])` → `["ejs", "tse"]` (`railties/lib/rails/source_annotation_extractor.rb:114`).
- `trailties/src/backtrace-cleaner.test.ts` — `index.html.erb` / `_…_index_html_erb__…` test data → `.tse` (`railties/test/backtrace_cleaner_test.rb:49-90`). The cleaner has no erb-specific logic, so this is data-only.

`ERB` now survives only where the text quotes the Ruby side: `Mirrors:` JSDoc naming `ERB::Util` / `Handlers::ERB`, Rails paths like `core_ext/erb/util.rb`, and fixtures-compare's `ERB-UNSUPPORTED` / `ERB-ALLOWED` statuses, which describe Rails YAML that genuinely is ERB.

Recorded in the two places a porter reads: `CLAUDE.md`'s test-name rule and the "Token renames" section of `docs/ruby-ts-conventions.md` (generated — the prose lives in `explainConventions`, regenerated with `pnpm api:conventions`), plus the `TOKEN_RENAMES` JSDoc.

Closes-story: sweep-remaining-erb-spellings-in-trails-test-names
