### PR TITLE
fix(activesupport): Time#change ports the :offset, :nsec and utc? arms and the usec range guard

### DIFF
--- a/packages/activesupport/src/core-ext/time-ext.test.ts
+++ b/packages/activesupport/src/core-ext/time-ext.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
-import type { Temporal } from "@blazetrails/date";
+import { Temporal } from "@blazetrails/date";
+import { ArgumentError } from "../hash-utils.js";
 import {
   nextDay,
   prevDay,
@@ -39,6 +40,29 @@ function d(year: number, month: number, day: number, hour = 0, min = 0, sec = 0,
 
 function utc(year: number, month = 1, day = 1, hour = 0, min = 0, sec = 0, ms = 0): Date {
   return new Date(Date.UTC(year, month - 1, day, hour, min, sec, ms));
+}
+
+function zoned(
+  timeZone: string,
+  year: number,
+  month: number,
+  day: number,
+  hour = 0,
+  minute = 0,
+  second = 0,
+  microsecond = 0,
+): Temporal.ZonedDateTime {
+  return Temporal.ZonedDateTime.from({
+    timeZone,
+    year,
+    month,
+    day,
+    hour,
+    minute,
+    second,
+    millisecond: Math.floor(microsecond / 1000),
+    microsecond: microsecond % 1000,
+  });
 }
 
 function withEnvTz<T>(tz: string, fn: () => T): T {
@@ -262,28 +286,56 @@ describe("TimeExtCalculationsTest", () => {
     expect(asDate(change(d(2005, 2, 22, 15, 15, 10), { min: 45 }))).toEqual(
       d(2005, 2, 22, 15, 45, 0),
     );
+
+    expect(() => change(d(2005, 1, 2, 11, 22, 33, 8), { usec: 1, nsec: 1 })).toThrow(ArgumentError);
+    expect(() => change(zoned("+03:00", 2015, 5, 9, 10, 0, 0), { nsec: 999999999 })).not.toThrow();
   });
 
   it("utc change", () => {
     const t1 = utc(2005, 2, 22, 15, 15, 10);
     const result = asDate(change(t1, { year: 2006 }));
     expect(result.getFullYear()).toBe(2006);
+
+    const t2 = zoned("UTC", 2005, 1, 2, 11, 22, 33, 2);
+    const changed = change(t2, { nsec: 8000 });
+    expect(changed.timeZoneId).toBe("UTC");
+    expect(changed.millisecond * 1000 + changed.microsecond).toBe(8);
   });
 
   it("offset change", () => {
-    const t = d(2005, 2, 22, 15, 15, 10);
-    const result = asDate(change(t, { year: 2006 }));
-    expect(result.getFullYear()).toBe(2006);
-    expect(result.getHours()).toBe(15);
-    expect(result.getMinutes()).toBe(15);
-    expect(result.getSeconds()).toBe(10);
+    const t = zoned("-08:00", 2005, 2, 22, 15, 15, 10);
+    expect(change(t, { year: 2006 }).equals(zoned("-08:00", 2006, 2, 22, 15, 15, 10))).toBe(true);
+    expect(change(t, { month: 6 }).equals(zoned("-08:00", 2005, 6, 22, 15, 15, 10))).toBe(true);
+    expect(change(t, { hour: 16 }).equals(zoned("-08:00", 2005, 2, 22, 16, 0, 0))).toBe(true);
+    expect(change(t, { hour: 16, min: 45 }).equals(zoned("-08:00", 2005, 2, 22, 16, 45, 0))).toBe(
+      true,
+    );
+
+    const t2 = zoned("-08:00", 2005, 2, 22, 15, 15, 0);
+    const withUsec = change(t2, { usec: 10 });
+    expect(withUsec.millisecond * 1000 + withUsec.microsecond).toBe(10);
+    expect(change(t2, { nsec: 10 }).nanosecond).toBe(10);
+    expect(() => change(t2, { usec: 1000000 })).toThrow(ArgumentError);
+    expect(() => change(t2, { nsec: 1000000000 })).toThrow(ArgumentError);
   });
 
   it("change offset", () => {
-    const t = d(2006, 2, 22, 15, 15, 10);
-    const result = asDate(change(t, { year: 2006 }));
-    expect(result.getFullYear()).toBe(2006);
-    expect(result.getHours()).toBe(15);
+    expect(
+      change(zoned("+01:00", 2006, 2, 22, 15, 15, 10), { offset: "-08:00" }).equals(
+        zoned("-08:00", 2006, 2, 22, 15, 15, 10),
+      ),
+    ).toBe(true);
+    expect(
+      change(zoned("+01:00", 2006, 2, 22, 15, 15, 10), { offset: -28800 }).equals(
+        zoned("-08:00", 2006, 2, 22, 15, 15, 10),
+      ),
+    ).toBe(true);
+    expect(() =>
+      change(zoned("+01:00", 2005, 2, 22, 15, 15, 45), { usec: 1000000, offset: "-08:00" }),
+    ).toThrow(ArgumentError);
+    expect(() =>
+      change(zoned("+01:00", 2005, 2, 22, 15, 15, 45), { nsec: 1000000000, offset: -28800 }),
+    ).toThrow(ArgumentError);
   });
 
   it.skip("change preserves offset for local times around end of dst");

--- a/packages/activesupport/src/core-ext/time-ext.test.ts
+++ b/packages/activesupport/src/core-ext/time-ext.test.ts
@@ -288,6 +288,9 @@ describe("TimeExtCalculationsTest", () => {
     );
 
     expect(() => change(d(2005, 1, 2, 11, 22, 33, 8), { usec: 1, nsec: 1 })).toThrow(ArgumentError);
+    expect(() => change(d(2005, 1, 2, 11, 22, 33, 8), { usec: 1, nsec: 1 })).toThrow(
+      "Can't change both :nsec and :usec at the same time: {usec: 1, nsec: 1}",
+    );
     expect(() => change(zoned("+03:00", 2015, 5, 9, 10, 0, 0), { nsec: 999999999 })).not.toThrow();
   });
 

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -11,6 +11,7 @@
 
 import { Temporal } from "@blazetrails/date";
 import { instantFrom } from "./temporal.js";
+import { ArgumentError } from "./hash-utils.js";
 
 const DAY_NAMES = ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"];
 
@@ -363,6 +364,9 @@ interface ChangeOptions {
   min?: number;
   sec?: number;
   usec?: number;
+  nsec?: number;
+  /** Ruby's `:offset` takes either a `"+HH:MM"` String or a seconds Integer. */
+  offset?: string | number;
 }
 
 /**
@@ -406,13 +410,63 @@ export function change(
   const newMin = options.min ?? (options.hour !== undefined ? 0 : self.minute);
   let newSec =
     options.sec ?? (options.hour !== undefined || options.min !== undefined ? 0 : self.second);
-  const newUsec =
-    options.usec ??
-    (options.hour !== undefined || options.min !== undefined || options.sec !== undefined
-      ? 0
-      : nsec / 1000);
+  const newOffset = options.offset ?? null;
+
+  let newUsec: number;
+  const newNsec = options.nsec;
+  if (newNsec !== undefined) {
+    if (options.usec !== undefined) {
+      throw new ArgumentError(
+        `Can't change both :nsec and :usec at the same time: ${Object.entries(options)
+          .map(([key, value]) => `${key}: ${String(value)}`)
+          .join(", ")}`,
+      );
+    }
+    newUsec = newNsec / 1000;
+  } else {
+    newUsec =
+      options.usec ??
+      (options.hour !== undefined || options.min !== undefined || options.sec !== undefined
+        ? 0
+        : nsec / 1000);
+  }
+
+  if (newUsec >= 1000000) throw new ArgumentError("argument out of range");
 
   newSec += newUsec / 1_000_000;
+
+  const secFloor = Math.floor(newSec);
+  const newNsecOfSec = Math.round((newSec - secFloor) * 1_000_000_000);
+  const newComponents = {
+    year: newYear,
+    month: newMonth,
+    day: newDay,
+    hour: newHour,
+    minute: newMin,
+    second: secFloor,
+    millisecond: Math.floor(newNsecOfSec / 1_000_000),
+    microsecond: Math.floor(newNsecOfSec / 1_000) % 1_000,
+    nanosecond: newNsecOfSec % 1_000,
+  };
+
+  if (newOffset !== null) {
+    // `if new_offset` (time/calculations.rb:145-146). Ruby's `::Time.new` takes
+    // the offset as a `"+HH:MM"` String or a seconds Integer; Temporal spells
+    // the same fixed-offset zone with the String form only.
+    const absOffset = typeof newOffset === "number" ? Math.abs(newOffset) : 0;
+    const timeZone =
+      typeof newOffset === "number"
+        ? `${newOffset < 0 ? "-" : "+"}${String(Math.floor(absOffset / 3600)).padStart(2, "0")}:${String(Math.floor((absOffset % 3600) / 60)).padStart(2, "0")}`
+        : newOffset;
+    const newTime = Temporal.ZonedDateTime.from({ timeZone, ...newComponents });
+    return date instanceof Date ? newTime.toInstant() : newTime;
+  }
+
+  if (self.timeZoneId === "UTC") {
+    // `elsif utc?` (time/calculations.rb:147-148).
+    const newTime = Temporal.ZonedDateTime.from({ timeZone: "UTC", ...newComponents });
+    return date instanceof Date ? newTime.toInstant() : newTime;
+  }
 
   if (date instanceof Date) {
     // `elsif zone` (time/calculations.rb:173-174): a JS `Date` carries no zone
@@ -422,21 +476,8 @@ export function change(
   }
 
   // `elsif zone.respond_to?(:utc_to_local)` (time/calculations.rb:150-172).
-  const secFloor = Math.floor(newSec);
-  const newNsec = Math.round((newSec - secFloor) * 1_000_000_000);
   let newTime = Temporal.ZonedDateTime.from(
-    {
-      timeZone: date.timeZoneId,
-      year: newYear,
-      month: newMonth,
-      day: newDay,
-      hour: newHour,
-      minute: newMin,
-      second: secFloor,
-      millisecond: Math.floor(newNsec / 1_000_000),
-      microsecond: Math.floor(newNsec / 1_000) % 1_000,
-      nanosecond: newNsec % 1_000,
-    },
+    { timeZone: date.timeZoneId, ...newComponents },
     // Ruby's `Time.new` with a zone object picks the first chronological
     // occurrence of an ambiguous nominal time; `"compatible"` is the same choice.
     { disambiguation: "compatible" },

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -463,10 +463,12 @@ export function change(
     return date instanceof Date ? newTime.toInstant() : newTime;
   }
 
-  if (self.timeZoneId === "UTC") {
-    // `elsif utc?` (time/calculations.rb:147-148).
-    const newTime = Temporal.ZonedDateTime.from({ timeZone: "UTC", ...newComponents });
-    return date instanceof Date ? newTime.toInstant() : newTime;
+  if (!(date instanceof Date) && self.timeZoneId === "UTC") {
+    // `elsif utc?` (time/calculations.rb:147-148). Ruby's `utc?` is an explicit
+    // flag set by `Time.utc`, never true for a `Time.local` receiver whatever
+    // the host zone is; a JS `Date` carries no such flag and reads back in the
+    // system zone, so it stays off this arm even under `TZ=UTC`.
+    return Temporal.ZonedDateTime.from({ timeZone: "UTC", ...newComponents });
   }
 
   if (date instanceof Date) {

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -417,9 +417,9 @@ export function change(
   if (newNsec !== undefined) {
     if (options.usec !== undefined) {
       throw new ArgumentError(
-        `Can't change both :nsec and :usec at the same time: ${Object.entries(options)
+        `Can't change both :nsec and :usec at the same time: {${Object.entries(options)
           .map(([key, value]) => `${key}: ${String(value)}`)
-          .join(", ")}`,
+          .join(", ")}}`,
       );
     }
     newUsec = newNsec / 1000;
@@ -453,10 +453,9 @@ export function change(
     // `if new_offset` (time/calculations.rb:145-146). Ruby's `::Time.new` takes
     // the offset as a `"+HH:MM"` String or a seconds Integer; Temporal spells
     // the same fixed-offset zone with the String form only.
-    const absOffset = typeof newOffset === "number" ? Math.abs(newOffset) : 0;
     const timeZone =
       typeof newOffset === "number"
-        ? `${newOffset < 0 ? "-" : "+"}${String(Math.floor(absOffset / 3600)).padStart(2, "0")}:${String(Math.floor((absOffset % 3600) / 60)).padStart(2, "0")}`
+        ? `${newOffset < 0 ? "-" : "+"}${String(Math.floor(Math.abs(newOffset) / 3600)).padStart(2, "0")}:${String(Math.floor((Math.abs(newOffset) % 3600) / 60)).padStart(2, "0")}`
         : newOffset;
     const newTime = Temporal.ZonedDateTime.from({ timeZone, ...newComponents });
     return date instanceof Date ? newTime.toInstant() : newTime;

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -418,7 +418,9 @@ export function change(
     if (options.usec !== undefined) {
       throw new ArgumentError(
         `Can't change both :nsec and :usec at the same time: {${Object.entries(options)
-          .map(([key, value]) => `${key}: ${String(value)}`)
+          .map(
+            ([key, value]) => `${key}: ${typeof value === "string" ? `"${value}"` : String(value)}`,
+          )
           .join(", ")}}`,
       );
     }


### PR DESCRIPTION
Ports the three `Time#change` option arms and the sub-second range guard that
`packages/activesupport/src/time-ext.ts` was missing
(`activesupport/lib/active_support/core_ext/time/calculations.rb:122-176`).

- `:132` `new_offset = options.fetch(:offset, nil)` and the `if new_offset` arm
  at `:145-146`. `ChangeOptions` now carries `offset` (Ruby takes a `"+HH:MM"`
  String or a seconds Integer; Temporal spells the fixed-offset zone with the
  String form only, so the Integer is formatted at the arm).
- `:132-137` the `:nsec` option, including the `ArgumentError` naming both keys
  when `:usec` is passed alongside it, and `new_usec = Rational(new_nsec, 1000)`.
- `:135` `raise ArgumentError, "argument out of range" if new_usec >= 1000000`.
- `:147-148` the `elsif utc?` arm building through `::Time.utc`.

Branches are in Rails' order: `offset` → `utc?` → the `Date`-receiver
(`elsif zone`) arm → `utc_to_local`. The Temporal component hash the three
building arms share is hoisted to one local; no new public surface.

Tests: `test_change`'s `usec`/`nsec` conflict and the `nsec: 999999999`
no-raise, `test_utc_change`'s `nsec: 8000`, and `test_offset_change` /
`test_change_offset` fleshed out against zoned receivers (they were
Date-receiver stubs that never exercised an offset). Existing callers
(`beginningOfDay`, `endOfDay`, `endOfHour`, `endOfMinute`, `advance`) pass
`usec: 999999999 / 1000`, below the guard, and stay green.

`pnpm api:calls` green (ratchet OK), `pnpm typecheck` clean.

Closes-story: time-change-offset-nsec-utc-arms-and-usec-range-guard
