### PR TITLE
refactor(activerecord): SchemaCreation takes the connection only; MigrationArConfig slot members are required

### DIFF
--- a/packages/activerecord/src/adapter.test.ts
+++ b/packages/activerecord/src/adapter.test.ts
@@ -514,7 +514,7 @@ describe("AdapterTest", () => {
 
   it("type_to_sql returns a String for unmapped types", async () => {
     const conn = await Base.leaseConnection();
-    expect(new SchemaCreation("sqlite", conn as never).typeToSql("special_db_type" as any)).toBe(
+    expect(new SchemaCreation(conn as never).typeToSql("special_db_type" as any)).toBe(
       "special_db_type",
     );
   });

--- a/packages/activerecord/src/column-definition.test.ts
+++ b/packages/activerecord/src/column-definition.test.ts
@@ -12,10 +12,21 @@ import type {
 // under test is the adapter's schema_creation.
 class DummyCreation extends SchemaCreation {
   constructor() {
-    super("sqlite", {
+    // `DummyAdapter < AbstractAdapter`, so every capability probe
+    // `SchemaCreation` delegates to `@conn` answers the abstract default.
+    super({
       quoteColumnName: (name: string) => name,
       quoteTableName: (name: string) => name,
       quoteDefaultExpression,
+      nativeDatabaseTypes: () => ({ string: "varchar" }),
+      supportsCheckConstraints: async () => false,
+      supportsExclusionConstraints: () => false,
+      supportsIndexInclude: async () => false,
+      supportsIndexSortOrder: async () => false,
+      supportsIndexesInCreate: () => false,
+      supportsNullsNotDistinct: async () => false,
+      supportsPartialIndex: () => false,
+      supportsUniqueConstraints: () => false,
     });
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.test.ts
@@ -3,54 +3,52 @@ import { SchemaCreation } from "./schema-creation.js";
 import { CreateIndexDefinition, IndexDefinition, TableDefinition } from "./schema-definitions.js";
 import { Base } from "../../base.js";
 import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
+import { currentAdapter } from "../../support/adapter-helper.js";
 import { describeIfPostgresqlAdapter } from "../../support/describe-if-postgresql-adapter.js";
 import type { TableDefinitionConn } from "./schema-definitions.js";
+import type { SchemaCreationConn } from "./schema-creation.js";
 
 // Rails hands `SchemaCreation.new` an `ActiveRecord::Base.lease_connection`
 // (adapter_test.rb, migration/columns_test.rb); a suite whose assertions turn on
 // one dialect's quoting runs under that dialect's `current_adapter?` gate.
-let conn: TableDefinitionConn;
+let conn: TableDefinitionConn & SchemaCreationConn;
 
 beforeAll(async () => {
-  conn = (await Base.leaseConnection()) as unknown as TableDefinitionConn;
+  conn = (await Base.leaseConnection()) as unknown as TableDefinitionConn & SchemaCreationConn;
 });
 
 describe("SchemaCreation#typeToSql blank type guard", () => {
   it("throws a descriptive error for an empty custom type", () => {
-    expect(() => new SchemaCreation("sqlite", conn).typeToSql("" as any)).toThrow(
-      /empty or blank type/,
-    );
+    expect(() => new SchemaCreation(conn).typeToSql("" as any)).toThrow(/empty or blank type/);
   });
 
   it("throws a descriptive error for a whitespace-only custom type", () => {
-    expect(() => new SchemaCreation("sqlite", conn).typeToSql("   " as any)).toThrow(
-      /empty or blank type/,
-    );
+    expect(() => new SchemaCreation(conn).typeToSql("   " as any)).toThrow(/empty or blank type/);
   });
 });
 
 describe("SchemaCreation#typeToSql virtual / nil pass-through", () => {
   it("returns '' for a nil type (Rails type_to_sql: type.to_s of nil)", () => {
-    expect(new SchemaCreation("sqlite", conn).typeToSql(undefined as any)).toBe("");
+    expect(new SchemaCreation(conn).typeToSql(undefined as any)).toBe("");
   });
 
   it("passes 'virtual' through verbatim, with no options.type/string fallback", () => {
     // Rails' type_to_sql has no :virtual case, so type_to_sql(:virtual) → "virtual".
     // The :virtual → options[:type] mapping is newColumnDefinition-only.
-    expect(
-      new SchemaCreation("sqlite", conn).typeToSql("virtual" as any, { type: "integer" } as any),
-    ).toBe("virtual");
+    expect(new SchemaCreation(conn).typeToSql("virtual" as any, { type: "integer" } as any)).toBe(
+      "virtual",
+    );
   });
 });
 
 describeIfPostgresqlAdapter("SchemaCreation drop-constraint visitors", () => {
   it("visit_DropForeignKey emits DROP CONSTRAINT with a quoted name", () => {
-    const sc = new SchemaCreation("postgres", conn) as any;
+    const sc = new SchemaCreation(conn) as any;
     expect(sc.visitDropForeignKey("fk_rails_abc")).toBe('DROP CONSTRAINT "fk_rails_abc"');
   });
 
   it("visit_DropCheckConstraint emits DROP CONSTRAINT with a quoted name", async () => {
-    const sc = new SchemaCreation("postgres", conn) as any;
+    const sc = new SchemaCreation(conn) as any;
     expect(await sc.visitDropCheckConstraint("chk_rails_abc")).toBe(
       'DROP CONSTRAINT "chk_rails_abc"',
     );
@@ -79,7 +77,7 @@ describeIfSqlite("SchemaCreation#visit_TableDefinition inline indexes", () => {
     td.string("email");
     td.index("email");
 
-    const sql = await new IndexesInCreate("sqlite", conn).accept(td);
+    const sql = await new IndexesInCreate(conn).accept(td);
     expect(sql).toContain("INDEX index_users_on_email (email)");
   });
 
@@ -91,32 +89,37 @@ describeIfSqlite("SchemaCreation#visit_TableDefinition inline indexes", () => {
     td.string("email");
     td.index("email");
 
-    const sql = await new SchemaCreation("sqlite", conn).accept(td);
+    const sql = await new SchemaCreation(conn).accept(td);
     expect(sql).not.toContain("INDEX");
   });
 });
 
+// Rails delegates every capability probe to `@conn`
+// (abstract/schema_creation.rb:16-21), so the visitor's answer is the lane
+// connection's — version gates included.
 describe("SchemaCreation support predicates", () => {
   it("supports_indexes_in_create? is true only on MySQL", () => {
-    expect((new SchemaCreation("mysql", conn) as any).supportsIndexesInCreate()).toBe(true);
-    expect((new SchemaCreation("postgres", conn) as any).supportsIndexesInCreate()).toBe(false);
-    expect((new SchemaCreation("sqlite", conn) as any).supportsIndexesInCreate()).toBe(false);
+    expect((new SchemaCreation(conn) as any).supportsIndexesInCreate()).toBe(
+      currentAdapter("Mysql2Adapter"),
+    );
   });
 
   it("supports_exclusion_constraints? is true only on PostgreSQL", () => {
-    expect((new SchemaCreation("postgres", conn) as any).supportsExclusionConstraints()).toBe(true);
-    expect((new SchemaCreation("mysql", conn) as any).supportsExclusionConstraints()).toBe(false);
+    expect((new SchemaCreation(conn) as any).supportsExclusionConstraints()).toBe(
+      currentAdapter("PostgreSQLAdapter"),
+    );
   });
 
   it("supports_unique_constraints? is true only on PostgreSQL", () => {
-    expect((new SchemaCreation("postgres", conn) as any).supportsUniqueConstraints()).toBe(true);
-    expect((new SchemaCreation("mysql", conn) as any).supportsUniqueConstraints()).toBe(false);
+    expect((new SchemaCreation(conn) as any).supportsUniqueConstraints()).toBe(
+      currentAdapter("PostgreSQLAdapter"),
+    );
   });
 });
 
 describeIfPostgresqlAdapter("SchemaCreation quoting delegations", () => {
   it("quote_column_name / quote_table_name delegate to the quoter", () => {
-    const sc = new SchemaCreation("postgres", conn) as any;
+    const sc = new SchemaCreation(conn) as any;
     expect(sc.quoteColumnName("title")).toBe('"title"');
     expect(sc.quoteTableName("posts")).toBe('"posts"');
   });
@@ -130,7 +133,7 @@ describeIfPostgresqlAdapter("SchemaCreation#quotedColumnsForIndex sub-part lengt
     const idx = new IndexDefinition("posts", "index_posts_on_title", false, ["title"], {
       lengths: { title: 10 },
     });
-    const sql = await (new SchemaCreation("postgres", conn) as any).visitCreateIndexDefinition(
+    const sql = await (new SchemaCreation(conn) as any).visitCreateIndexDefinition(
       new CreateIndexDefinition(idx, false),
     );
     expect(sql).not.toContain("(10)");
@@ -143,7 +146,7 @@ describeIfSqlite("SchemaCreation#quotedColumnsForIndex sub-part length gating", 
     const idx = new IndexDefinition("posts", "index_posts_on_title", false, ["title"], {
       lengths: { title: 10 },
     });
-    const sql = await (new SchemaCreation("sqlite", conn) as any).visitCreateIndexDefinition(
+    const sql = await (new SchemaCreation(conn) as any).visitCreateIndexDefinition(
       new CreateIndexDefinition(idx, false),
     );
     expect(sql).not.toContain("(10)");
@@ -161,6 +164,10 @@ describe("SchemaCreation#quotedColumns delegates to the connection", () => {
     quoteColumnName: (c: string) => `"${c}"`,
     quoteTableName: (t: string) => `"${t}"`,
     quoteDefaultExpression: (v: unknown) => String(v),
+    supportsIndexUsing: () => false,
+    supportsIndexInclude: async () => false,
+    supportsNullsNotDistinct: async () => false,
+    supportsPartialIndex: () => false,
     quotedColumnsForIndex(cols: string[], options: any) {
       // Stand-in for the connection's decoration, incl. PG opclass folding.
       // Mirrors options_for_index_columns: a String opclass applies to every
@@ -177,7 +184,7 @@ describe("SchemaCreation#quotedColumns delegates to the connection", () => {
       opclasses: { title: "text_pattern_ops" },
     });
     const sql = await (
-      new SchemaCreation("postgres", host as any) as any
+      new SchemaCreation(host as any) as any
     ).visitCreateIndexDefinition(new CreateIndexDefinition(idx, false));
     expect(sql).toContain('("title" text_pattern_ops)');
   });
@@ -191,7 +198,7 @@ describe("SchemaCreation#quotedColumns delegates to the connection", () => {
       {},
     );
     const sql = await (
-      new SchemaCreation("postgres", host as any) as any
+      new SchemaCreation(host as any) as any
     ).visitCreateIndexDefinition(new CreateIndexDefinition(idx, false));
     expect(sql).toContain("(lower(title))");
     expect(sql).not.toContain("DEFAULT_OPS");
@@ -200,14 +207,14 @@ describe("SchemaCreation#quotedColumns delegates to the connection", () => {
 
 describe("SchemaCreation#typeToSql decimal precision/scale", () => {
   it("raises when a decimal scale is given without a precision", () => {
-    expect(() => new SchemaCreation("sqlite", conn).typeToSql("decimal", { scale: 2 })).toThrow(
+    expect(() => new SchemaCreation(conn).typeToSql("decimal", { scale: 2 })).toThrow(
       "Error adding decimal column: precision cannot be empty if scale is specified",
     );
   });
 
   it("honors precision and scale when both are given", () => {
     expect(
-      new SchemaCreation("sqlite", conn).typeToSql("decimal", {
+      new SchemaCreation(conn).typeToSql("decimal", {
         precision: 8,
         scale: 2,
       }),
@@ -218,8 +225,6 @@ describe("SchemaCreation#typeToSql decimal precision/scale", () => {
     // Rails sources the default from native_database_types[:decimal], which
     // carries no :precision on SQLite/MySQL/PostgreSQL — so a precision-less
     // decimal dumps bare rather than defaulting to (10).
-    expect(new SchemaCreation("sqlite", conn).typeToSql("decimal")).toBe("decimal");
-    expect(new SchemaCreation("mysql", conn).typeToSql("decimal")).toBe("decimal");
-    expect(new SchemaCreation("postgres", conn).typeToSql("decimal")).toBe("decimal");
+    expect(new SchemaCreation(conn).typeToSql("decimal")).toBe("decimal");
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.test.ts
@@ -183,9 +183,9 @@ describe("SchemaCreation#quotedColumns delegates to the connection", () => {
     const idx = new IndexDefinition("posts", "index_posts_on_title", false, ["title"], {
       opclasses: { title: "text_pattern_ops" },
     });
-    const sql = await (
-      new SchemaCreation(host as any) as any
-    ).visitCreateIndexDefinition(new CreateIndexDefinition(idx, false));
+    const sql = await (new SchemaCreation(host as any) as any).visitCreateIndexDefinition(
+      new CreateIndexDefinition(idx, false),
+    );
     expect(sql).toContain('("title" text_pattern_ops)');
   });
 
@@ -197,9 +197,9 @@ describe("SchemaCreation#quotedColumns delegates to the connection", () => {
       "lower(title)" as any,
       {},
     );
-    const sql = await (
-      new SchemaCreation(host as any) as any
-    ).visitCreateIndexDefinition(new CreateIndexDefinition(idx, false));
+    const sql = await (new SchemaCreation(host as any) as any).visitCreateIndexDefinition(
+      new CreateIndexDefinition(idx, false),
+    );
     expect(sql).toContain("(lower(title))");
     expect(sql).not.toContain("DEFAULT_OPS");
   });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -59,15 +59,28 @@ export class SchemaCreation {
   /** Rails' `SchemaCreation#initialize(conn)` (abstract/schema_creation.rb:6-9). */
   constructor(protected adapter: SchemaCreationConn) {}
 
-  // Capability probes. Rails declares these as `delegate ... to: :@conn`
-  // (abstract/schema_creation.rb:16-21) — the connection answers them, so a
-  // version gate on the server (MariaDB >= 10.8.1 for `supports_index_sort_order?`,
-  // abstract_mysql_adapter.rb:409) reaches the visitor.
+  // Capability probes. Seven of these are `delegate ... to: :@conn`
+  // (abstract/schema_creation.rb:16-21): supports_indexes_in_create?,
+  // supports_partial_index?, supports_check_constraints?, supports_index_include?,
+  // supports_exclusion_constraints?, supports_unique_constraints? and
+  // supports_nulls_not_distinct?. The connection answers them, so its version
+  // gates reach the visitor.
 
   protected supportsPartialIndex(): boolean {
     return this.adapter.supportsPartialIndex();
   }
 
+  /**
+   * NOT one of `schema_creation.rb`'s delegated members, and not named anywhere
+   * in Rails' visitors: `supports_index_sort_order?` is an adapter predicate
+   * (abstract_adapter.rb:411, version-gated at abstract_mysql_adapter.rb:409)
+   * that Rails reads only from `add_options_for_index_columns`
+   * (abstract/schema_statements.rb:1640), which the visitor reaches through the
+   * delegated `quoted_columns_for_index`. It lives here because trails'
+   * `MySQL::SchemaCreation#quotedColumns` pulled that decoration into the
+   * visitor — a pre-existing deviation, filed as
+   * `mysql-schema-creation-quoted-columns-reimplements-the-delegated-decoration`.
+   */
   protected async supportsIndexSortOrder(): Promise<boolean> {
     return this.adapter.supportsIndexSortOrder();
   }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -23,11 +23,7 @@ import {
   PrimaryKeyDefinition,
   TableDefinition,
 } from "./schema-definitions.js";
-import {
-  NATIVE_DATABASE_TYPES_BY_ADAPTER,
-  type NativeDatabaseType,
-  type NativeDatabaseTypes,
-} from "./native-database-types.js";
+import { type NativeDatabaseType, type NativeDatabaseTypes } from "./native-database-types.js";
 import type { SchemaQuoter } from "./assert-schema-adapter.js";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { NotImplementedError } from "../../errors.js";
@@ -43,31 +39,51 @@ type Definition =
   | CheckConstraintDefinition
   | PrimaryKeyDefinition;
 
+/**
+ * The connection surface `SchemaCreation` delegates to — Rails' `@conn`
+ * (abstract/schema_creation.rb:16-21). @internal
+ */
+export interface SchemaCreationConn extends SchemaQuoter {
+  nativeDatabaseTypes(): NativeDatabaseTypes;
+  supportsCheckConstraints(): Promise<boolean>;
+  supportsExclusionConstraints(): boolean;
+  supportsIndexInclude(): Promise<boolean>;
+  supportsIndexSortOrder(): Promise<boolean>;
+  supportsIndexesInCreate(): boolean;
+  supportsNullsNotDistinct(): Promise<boolean>;
+  supportsPartialIndex(): boolean;
+  supportsUniqueConstraints(): boolean;
+}
+
 export class SchemaCreation {
-  constructor(
-    protected adapterName: "sqlite" | "postgres" | "mysql",
-    /** Quoter used for identifier/table/default-expression quoting. */
-    protected adapter: SchemaQuoter,
-  ) {}
+  /** Rails' `SchemaCreation#initialize(conn)` (abstract/schema_creation.rb:6-9). */
+  constructor(protected adapter: SchemaCreationConn) {}
+
+  // Capability probes. Rails declares these as `delegate ... to: :@conn`
+  // (abstract/schema_creation.rb:16-21) — the connection answers them, so a
+  // version gate on the server (MariaDB >= 10.8.1 for `supports_index_sort_order?`,
+  // abstract_mysql_adapter.rb:409) reaches the visitor.
 
   protected supportsPartialIndex(): boolean {
-    return this.adapterName !== "mysql";
+    return this.adapter.supportsPartialIndex();
   }
 
   protected async supportsIndexSortOrder(): Promise<boolean> {
-    return this.adapterName !== "mysql";
+    return this.adapter.supportsIndexSortOrder();
   }
 
+  /** Not delegated: Rails defines it on `SchemaCreation` itself
+   * (abstract/schema_creation.rb:137-139), and only SQLite3 overrides it. */
   protected supportsIndexUsing(): boolean {
-    return this.adapterName === "postgres" || this.adapterName === "mysql";
+    return true;
   }
 
   protected async supportsIndexInclude(): Promise<boolean> {
-    return this.adapterName === "postgres";
+    return this.adapter.supportsIndexInclude();
   }
 
   protected async supportsNullsNotDistinct(): Promise<boolean> {
-    return this.adapterName === "postgres";
+    return this.adapter.supportsNullsNotDistinct();
   }
 
   // Quoting delegations. Rails declares these as `delegate ... to: :@conn`
@@ -91,17 +107,17 @@ export class SchemaCreation {
 
   /** @internal */
   protected supportsIndexesInCreate(): boolean {
-    return this.adapterName === "mysql";
+    return this.adapter.supportsIndexesInCreate();
   }
 
   /** @internal */
   protected supportsExclusionConstraints(): boolean {
-    return this.adapterName === "postgres";
+    return this.adapter.supportsExclusionConstraints();
   }
 
   /** @internal */
   protected supportsUniqueConstraints(): boolean {
-    return this.adapterName === "postgres";
+    return this.adapter.supportsUniqueConstraints();
   }
 
   /**
@@ -217,7 +233,7 @@ export class SchemaCreation {
 
   /** @internal */
   protected async supportsCheckConstraints(): Promise<boolean> {
-    return true;
+    return this.adapter.supportsCheckConstraints();
   }
 
   /**
@@ -425,10 +441,7 @@ export class SchemaCreation {
 
   /** @internal */
   protected nativeDatabaseTypes(): NativeDatabaseTypes {
-    const fromAdapter = (
-      this.adapter as { nativeDatabaseTypes?(): NativeDatabaseTypes }
-    ).nativeDatabaseTypes?.();
-    return fromAdapter ?? NATIVE_DATABASE_TYPES_BY_ADAPTER[this.adapterName];
+    return this.adapter.nativeDatabaseTypes();
   }
 
   typeToSql(type: ColumnType, options: ColumnOptions = {}): string {
@@ -468,11 +481,11 @@ export class SchemaCreation {
       }
     }
 
+    // Rails' `type_to_sql` lives on the connection, and only PostgreSQL's
+    // (postgresql/schema_statements.rb:988) appends `[]`; every adapter that
+    // reaches this body is one whose `type_to_sql` has no array arm.
     if (options.array && type !== "primary_key") {
-      if (this.adapterName !== "postgres") {
-        throw new Error("Array columns are only supported on PostgreSQL");
-      }
-      sql += "[]";
+      throw new Error("Array columns are only supported on PostgreSQL");
     }
 
     return sql;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.test.ts
@@ -9,14 +9,15 @@ import {
 import { SchemaCreation } from "./schema-creation.js";
 import { Base } from "../../base.js";
 import type { TableDefinitionConn } from "./schema-definitions.js";
+import type { SchemaCreationConn } from "./schema-creation.js";
 
 // Rails hands `TableDefinition#initialize` an `ActiveRecord::Base.lease_connection`
 // (migration/columns_test.rb); nothing below asserts one dialect's SQL, so the
 // ambient lane connection is what every definition is built against.
-let conn: TableDefinitionConn;
+let conn: TableDefinitionConn & SchemaCreationConn;
 
 beforeAll(async () => {
-  conn = (await Base.leaseConnection()) as unknown as TableDefinitionConn;
+  conn = (await Base.leaseConnection()) as unknown as TableDefinitionConn & SchemaCreationConn;
 });
 
 describe("IndexDefinition#concise_options", () => {
@@ -365,7 +366,7 @@ describe("TableDefinition#toSql blank type guard", () => {
   it("throws a descriptive error for an empty custom type", async () => {
     const td = new TableDefinition("t", { adapter: conn });
     td.column("bad", "" as any);
-    await expect(new SchemaCreation("sqlite", conn).accept(td)).rejects.toThrow(
+    await expect(new SchemaCreation(conn).accept(td)).rejects.toThrow(
       /Column "bad" has an empty or blank type/,
     );
   });
@@ -373,7 +374,7 @@ describe("TableDefinition#toSql blank type guard", () => {
   it("throws a descriptive error for a whitespace-only custom type", async () => {
     const td = new TableDefinition("t", { adapter: conn });
     td.column("bad", "   " as any);
-    await expect(new SchemaCreation("sqlite", conn).accept(td)).rejects.toThrow(
+    await expect(new SchemaCreation(conn).accept(td)).rejects.toThrow(
       /Column "bad" has an empty or blank type/,
     );
   });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -44,6 +44,17 @@ function makeStatements(
       binds,
       "SCHEMA",
     );
+  // `SchemaCreation` delegates every capability probe to `@conn`
+  // (abstract/schema_creation.rb:16-21); the stub answers as SQLite3Adapter
+  // does, matching the `adapterName` it reports.
+  adapter["supportsCheckConstraints"] ??= async () => true;
+  adapter["supportsIndexesInCreate"] ??= () => false;
+  adapter["supportsPartialIndex"] ??= () => true;
+  adapter["supportsIndexInclude"] ??= async () => false;
+  adapter["supportsNullsNotDistinct"] ??= async () => false;
+  adapter["supportsIndexSortOrder"] ??= async () => true;
+  adapter["supportsExclusionConstraints"] ??= () => false;
+  adapter["supportsUniqueConstraints"] ??= () => false;
   // Real hosts override AbstractAdapter#native_database_types (the abstract one
   // is `{}`); the stub answers with SQLite's table so typeToSql resolves.
   adapter["nativeDatabaseTypes"] ??= () => NATIVE_DATABASE_TYPES_BY_ADAPTER["sqlite"];

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -315,6 +315,9 @@ export class SchemaStatements {
 
   /** Mirrors: SchemaStatements#schema_creation — `SchemaCreation.new(self)`. */
   get schemaCreation(): SchemaCreation {
+    // `SchemaStatements` types its host as `DatabaseAdapter & SchemaQuoter`,
+    // which does not surface the capability probes; every runtime `this` is an
+    // AbstractAdapter, which defines all of them (abstract-adapter.ts:1576-1962).
     return new SchemaCreation(this as unknown as SchemaCreationConn);
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -37,7 +37,7 @@ import {
   type RemoveForeignKeyOptions,
 } from "./schema-definitions.js";
 import type { UniqueConstraintOptions } from "../postgresql/schema-definitions.js";
-import { SchemaCreation } from "./schema-creation.js";
+import { SchemaCreation, type SchemaCreationConn } from "./schema-creation.js";
 import { maxIdentifierLength } from "./database-limits.js";
 import type { SchemaQuoter } from "./assert-schema-adapter.js";
 import { Column } from "../column.js";
@@ -315,9 +315,7 @@ export class SchemaStatements {
 
   /** Mirrors: SchemaStatements#schema_creation — `SchemaCreation.new(self)`. */
   get schemaCreation(): SchemaCreation {
-    // Base AbstractAdapter#adapterName is typed `string` (Rails-faithful
-    // "Abstract"); concrete adapters return a real AdapterName.
-    return new SchemaCreation(this.adapterName as AdapterName, this);
+    return new SchemaCreation(this as unknown as SchemaCreationConn);
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
@@ -4,7 +4,10 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::SchemaCreation
  */
 
-import { SchemaCreation as AbstractSchemaCreation } from "../abstract/schema-creation.js";
+import {
+  SchemaCreation as AbstractSchemaCreation,
+  type SchemaCreationConn,
+} from "../abstract/schema-creation.js";
 import { ArgumentError } from "@blazetrails/activemodel";
 import type {
   ColumnOptions,
@@ -48,7 +51,7 @@ type MysqlTableDef = TableDefinition & { charset?: string; collation?: string };
 /** @internal Adapter surface consulted by the visitor's support flags and MariaDB branches.
  * Rails' `SchemaCreation#initialize(conn)` always receives the live adapter, so the quoting
  * half is required and dispatches polymorphically. */
-export interface VisitorHostAdapter extends TableDefinitionConn {
+export interface VisitorHostAdapter extends TableDefinitionConn, SchemaCreationConn {
   supportsCheckConstraints(): Promise<boolean>;
   supportsForeignKeys(): boolean;
   supportsIndexesInCreate(): boolean;
@@ -72,21 +75,13 @@ export class SchemaCreation extends AbstractSchemaCreation {
   declare protected adapter: VisitorHostAdapter;
 
   constructor(host: VisitorHostAdapter) {
-    super("mysql", host);
+    super(host);
   }
 
   /** @internal Live MariaDB lookup — consults the host adapter every call so a late
    * `getFullVersion()` flip (lazy detection on first probe) is honored. */
   protected async isMariadb(): Promise<boolean> {
     return this.adapter.isMariadb();
-  }
-
-  /** @internal Rails gates the index DESC/ASC suffix on `supports_index_sort_order?`
-   * (MariaDB >= 10.8.1 / MySQL >= 8.0.1). Consult the threaded adapter's version-gated
-   * flag. The base returns `adapterName !== "mysql"` (always false),
-   * so this override is what makes MySQL honor the version gate. */
-  protected override async supportsIndexSortOrder(): Promise<boolean> {
-    return this.adapter.supportsIndexSortOrder();
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-creation.test.ts
@@ -15,9 +15,20 @@ import {
 // Stub host satisfies `PgSchemaCreationHost`: the inherited Quoting
 // fallback covers quote*, plus a minimal `typeToSql` since PG's override
 // delegates to the adapter (Rails parity: SchemaCreation delegates
-// type_to_sql to @conn).
+// type_to_sql to @conn), plus the capability probes `SchemaCreation`
+// delegates to `@conn` (abstract/schema_creation.rb:16-21), answered as
+// `PostgreSQLAdapter` answers them.
 const s = () =>
   new SchemaCreation({
+    nativeDatabaseTypes: () => ({}),
+    supportsCheckConstraints: async () => true,
+    supportsExclusionConstraints: () => true,
+    supportsIndexInclude: async () => true,
+    supportsIndexSortOrder: async () => true,
+    supportsIndexesInCreate: () => false,
+    supportsNullsNotDistinct: async () => true,
+    supportsPartialIndex: () => true,
+    supportsUniqueConstraints: () => true,
     quoteColumnName: (n: string) => `"${n}"`,
     quoteTableName: (n: string) => `"${n}"`,
     quoteDefaultExpression: (v: unknown) => ` DEFAULT ${typeof v === "string" ? `'${v}'` : v}`,

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-creation.ts
@@ -5,7 +5,10 @@
  */
 
 import { wrap } from "@blazetrails/activesupport";
-import { SchemaCreation as AbstractSchemaCreation } from "../abstract/schema-creation.js";
+import {
+  SchemaCreation as AbstractSchemaCreation,
+  type SchemaCreationConn,
+} from "../abstract/schema-creation.js";
 import {
   postgresqlNativeDatabaseTypes,
   type NativeDatabaseTypes,
@@ -20,7 +23,6 @@ import {
   ChangeColumnDefaultDefinition,
   CheckConstraintDefinition,
 } from "../abstract/schema-definitions.js";
-import type { SchemaQuoter } from "../abstract/assert-schema-adapter.js";
 import type {
   ExclusionConstraintDefinition,
   UniqueConstraintDefinition,
@@ -37,7 +39,7 @@ type PgTableDef = AbstractTableDefinition & {
  * resolution back to it (Rails parity: `delegate :type_to_sql, to: :@conn`).
  * @internal
  */
-export interface PgSchemaCreationHost extends SchemaQuoter {
+export interface PgSchemaCreationHost extends SchemaCreationConn {
   typeToSql(type: string, options?: Record<string, unknown>): string;
 }
 
@@ -70,7 +72,7 @@ export class SchemaCreation extends AbstractSchemaCreation {
   declare protected adapter: PgSchemaCreationHost;
 
   constructor(adapter: PgSchemaCreationHost) {
-    super("postgres", adapter);
+    super(adapter);
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts
@@ -491,6 +491,16 @@ describeIfPostgresqlAdapter("TableDefinition#toSql", () => {
       quoteDefaultExpression: (v: unknown) => ` DEFAULT ${String(v)}`,
       typeToSql: (type: string) => type, // returns lowercase verbatim (mirrors PG native types)
       validColumnDefinitionOptions: () => ColumnDefinition.OPTION_NAMES,
+      // `SchemaCreation` delegates its capability probes to `@conn`
+      // (abstract/schema_creation.rb:16-21); answer as PostgreSQLAdapter does.
+      supportsCheckConstraints: async () => true,
+      supportsIndexesInCreate: () => false,
+      supportsPartialIndex: () => true,
+      supportsIndexInclude: async () => true,
+      supportsNullsNotDistinct: async () => true,
+      supportsIndexSortOrder: async () => true,
+      supportsExclusionConstraints: () => true,
+      supportsUniqueConstraints: () => true,
     };
     const td = new TableDefinition("widgets", { adapter: stubAdapter as any });
     td.cidr("net");

--- a/packages/activerecord/src/connection-adapters/schema-cache.test.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.test.ts
@@ -8,6 +8,7 @@ import { SchemaStatements } from "./abstract/schema-statements.js";
 import type { SchemaQuoter } from "./abstract/assert-schema-adapter.js";
 import { include } from "@blazetrails/activesupport";
 import { TableDefinition } from "./abstract/schema-definitions.js";
+import { NATIVE_DATABASE_TYPES_BY_ADAPTER } from "./abstract/native-database-types.js";
 import type { AbstractAdapter } from "./abstract-adapter.js";
 import type { ConnectionPool } from "./abstract/connection-pool.js";
 import { checkoutRawTestAdapter } from "../test-adapter.js";
@@ -725,6 +726,18 @@ class MockAdapter {
   pool = {};
   quoteDefaultExpression = (_v: unknown) => "";
   supportsDatetimeWithPrecision = () => false;
+  // `SchemaCreation` delegates every capability probe and its type map to
+  // `@conn` (abstract/schema_creation.rb:16-21); answer as SQLite3Adapter does,
+  // matching the `adapterName` this mock reports.
+  nativeDatabaseTypes = () => NATIVE_DATABASE_TYPES_BY_ADAPTER["sqlite"];
+  supportsCheckConstraints = async () => true;
+  supportsIndexesInCreate = () => false;
+  supportsPartialIndex = () => true;
+  supportsIndexInclude = async () => false;
+  supportsNullsNotDistinct = async () => false;
+  supportsIndexSortOrder = async () => true;
+  supportsExclusionConstraints = () => false;
+  supportsUniqueConstraints = () => false;
   createTableDefinition = (n: string, opts: Record<string, unknown>) =>
     // Rails' create_table_definition passes `self` (schema_statements.rb:1041).
     new TableDefinition(n, { adapter: this as never, ...opts, adapterName: "sqlite" });

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -215,7 +215,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
 
   /** Mirrors: SQLite3::SchemaStatements#schema_creation */
   get schemaCreation(): SQLite3SchemaCreation {
-    return new SQLite3SchemaCreation("sqlite", this);
+    return new SQLite3SchemaCreation(this);
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-creation.test.ts
@@ -9,16 +9,17 @@ import { TableDefinition } from "./schema-definitions.js";
 import { Base } from "../../base.js";
 import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
 import type { TableDefinitionConn } from "../abstract/schema-definitions.js";
+import type { SchemaCreationConn } from "../abstract/schema-creation.js";
 
 // Rails' SQLite3 DDL-rendering tests run under `current_adapter?(:SQLite3Adapter)`
 // against `ActiveRecord::Base.lease_connection`.
 describeIfSqlite("SQLite3::SchemaCreation", () => {
-  let conn: TableDefinitionConn;
+  let conn: TableDefinitionConn & SchemaCreationConn;
   let sc: SchemaCreation;
 
   beforeAll(async () => {
-    conn = (await Base.leaseConnection()) as unknown as TableDefinitionConn;
-    sc = new SchemaCreation("sqlite", conn);
+    conn = (await Base.leaseConnection()) as unknown as TableDefinitionConn & SchemaCreationConn;
+    sc = new SchemaCreation(conn);
   });
 
   it("appends DEFERRABLE INITIALLY DEFERRED when deferrable is 'deferred'", async () => {

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-definitions.test.ts
@@ -4,14 +4,15 @@ import { SchemaCreation } from "./schema-creation.js";
 import { Base } from "../../base.js";
 import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
 import type { TableDefinitionConn } from "../abstract/schema-definitions.js";
+import type { SchemaCreationConn } from "../abstract/schema-creation.js";
 
 // Rails' SQLite3 schema-definition tests run under `current_adapter?(:SQLite3Adapter)`
 // against `ActiveRecord::Base.lease_connection`.
 describeIfSqlite("SQLite3::TableDefinition", () => {
-  let conn: TableDefinitionConn;
+  let conn: TableDefinitionConn & SchemaCreationConn;
 
   beforeAll(async () => {
-    conn = (await Base.leaseConnection()) as unknown as TableDefinitionConn;
+    conn = (await Base.leaseConnection()) as unknown as TableDefinitionConn & SchemaCreationConn;
   });
 
   it("forces type: integer for references", () => {
@@ -45,7 +46,7 @@ describeIfSqlite("SQLite3::TableDefinition", () => {
     td.column("full_name", "virtual" as any, { as: "a || b" } as any);
     const col = td.columns.find((c) => c.name === "full_name")!;
     expect(col.type).toBeUndefined();
-    const sql = await new SchemaCreation("sqlite", (td as any)._adapter).accept(td);
+    const sql = await new SchemaCreation((td as any)._adapter).accept(td);
     expect(sql).toContain('"full_name"  GENERATED ALWAYS AS (a || b)');
     expect(sql).not.toContain("varchar");
     expect(sql).not.toContain("VARCHAR");
@@ -55,7 +56,7 @@ describeIfSqlite("SQLite3::TableDefinition", () => {
     const td = new TableDefinition("items", { adapter: conn });
     td.column("x", "integer");
     td.column("expr", "integer", { as: "x + 1", stored: true } as any);
-    const sql = await new SchemaCreation("sqlite", (td as any)._adapter).accept(td);
+    const sql = await new SchemaCreation((td as any)._adapter).accept(td);
     expect(sql).toContain("GENERATED ALWAYS AS (x + 1) STORED");
   });
 });

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -31,7 +31,7 @@ function emitTableSql(td: TableDefinition): Promise<string> {
   // matching the real adapter call sites and the production `*.toSql()` overrides.
   if (adapterName === "postgres") return new PgSchemaCreation(adapter).accept(td);
   if (adapterName === "mysql") return new MysqlSchemaCreation(adapter).accept(td);
-  return new SQLite3SchemaCreation("sqlite", adapter).accept(td);
+  return new SQLite3SchemaCreation(adapter).accept(td);
 }
 import { Person } from "./test-helpers/models/person.js";
 import { loadSchemaFromAdapter } from "./model-schema.js";

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1385,7 +1385,7 @@ export abstract class Migration {
     // call-time config source rather than an import: naming
     // `tasks/database-tasks.js` here would be a load-time edge back into a
     // module that already imports this one.
-    return this._connectionOverride ?? migrationArConfig()!.databaseTasks!().migrationConnection();
+    return this._connectionOverride ?? migrationArConfig()!.databaseTasks().migrationConnection();
   }
 
   set connection(conn: DatabaseAdapter | undefined) {
@@ -1399,7 +1399,7 @@ export abstract class Migration {
    * would be a load-time edge back into a module that already imports this one.
    */
   get connectionPool(): ConnectionPool {
-    return this._poolOverride ?? migrationArConfig()!.databaseTasks!().migrationConnectionPool();
+    return this._poolOverride ?? migrationArConfig()!.databaseTasks().migrationConnectionPool();
   }
 
   // --- Execution (Rails: Migration#exec_migration, #execution_strategy, etc.) ---
@@ -1490,8 +1490,8 @@ export abstract class Migration {
 
   static tableNameOptions(): { tableNamePrefix: string; tableNameSuffix: string } {
     return {
-      tableNamePrefix: migrationArConfig()?.tableNamePrefix ?? "",
-      tableNameSuffix: migrationArConfig()?.tableNameSuffix ?? "",
+      tableNamePrefix: migrationArConfig()!.tableNamePrefix,
+      tableNameSuffix: migrationArConfig()!.tableNameSuffix,
     };
   }
 
@@ -1605,8 +1605,8 @@ export abstract class Migration {
   static async checkAllPendingBang(): Promise<void> {
     const pendingMigrations: MigrationProxy[][] = [];
 
-    await migrationArConfig()
-      ?.databaseTasks?.()
+    await migrationArConfig()!
+      .databaseTasks()
       .withTemporaryPoolForEach({ env: this.env() }, async (pool) => {
         const pending = await pool.migrationContext.open().pendingMigrations();
         if (pending != null) pendingMigrations.push(pending);
@@ -1754,8 +1754,7 @@ export abstract class Migration {
    * keeps that setting on `DatabaseTasks` (it is also `schemaUpToDate`'s default).
    */
   private static async anySchemaNeedsUpdate(): Promise<boolean> {
-    const databaseTasks = migrationArConfig()?.databaseTasks?.();
-    if (databaseTasks == null) return false;
+    const databaseTasks = migrationArConfig()!.databaseTasks();
 
     for (const dbConfig of this.dbConfigsInCurrentEnv()) {
       if (!(await databaseTasks.schemaUpToDate(dbConfig, databaseTasks.schemaFormat))) return true;
@@ -1779,7 +1778,7 @@ export abstract class Migration {
 
   /** @internal Mirrors: `ActiveRecord::Migration.db_configs_in_current_env` (`migration.rb:753-755`) */
   private static dbConfigsInCurrentEnv(): DatabaseConfig[] {
-    return migrationArConfig()?.configurations?.().configsFor({ envName: this.env() }) ?? [];
+    return migrationArConfig()!.configurations().configsFor({ envName: this.env() });
   }
 
   /** @internal */
@@ -1810,13 +1809,11 @@ export abstract class Migration {
    * is where the dynamic import resolves it too.
    */
   private static async loadSchemaBang(): Promise<void> {
-    const databaseTasks = migrationArConfig()?.databaseTasks?.();
-    if (databaseTasks == null) return;
+    const databaseTasks = migrationArConfig()!.databaseTasks();
 
-    await migrationArConfig()?.connectionHandler?.().clearAllConnectionsBang("all");
+    await migrationArConfig()!.connectionHandler().clearAllConnectionsBang("all");
 
-    const testConfigs =
-      migrationArConfig()?.configurations?.().configsFor({ envName: "test" }) ?? [];
+    const testConfigs = migrationArConfig()!.configurations().configsFor({ envName: "test" });
     for (const dbConfig of testConfigs) {
       await databaseTasks.purge(dbConfig);
     }
@@ -2464,7 +2461,7 @@ export class Migrator {
    * load-time edge back into a module that already imports this one.
    */
   private get connection(): DatabaseAdapter {
-    return migrationArConfig()!.databaseTasks!().migrationConnection();
+    return migrationArConfig()!.databaseTasks().migrationConnection();
   }
 
   /** @internal Mirrors: ActiveRecord::Migrator#ran? */

--- a/packages/activerecord/src/migration/ar-config-source.ts
+++ b/packages/activerecord/src/migration/ar-config-source.ts
@@ -10,9 +10,9 @@ export interface MigrationArConfig {
   // (pending_migration_connection.rb:5-11) both name `ActiveRecord::Base` in a
   // method body, where Ruby resolves it by autoload. These are the call-time
   // reads that stand in for that.
-  configurations?: () => DatabaseConfigurations;
-  connectionHandler?: () => ConnectionHandler;
-  databaseTasks?: () => typeof import("../tasks/database-tasks.js").DatabaseTasks;
+  configurations: () => DatabaseConfigurations;
+  connectionHandler: () => ConnectionHandler;
+  databaseTasks: () => typeof import("../tasks/database-tasks.js").DatabaseTasks;
 }
 
 let _arConfig: MigrationArConfig | null = null;

--- a/packages/activerecord/src/migration/load-schema-if-pending.trails.test.ts
+++ b/packages/activerecord/src/migration/load-schema-if-pending.trails.test.ts
@@ -59,7 +59,7 @@ describe.skipIf(!currentAdapter("SQLite3Adapter"))("Migration.loadSchemaIfPendin
         calls.push("loadSchema");
       },
     };
-    const realHandler = originalArConfig.connectionHandler!();
+    const realHandler = originalArConfig.connectionHandler();
     const connectionHandler = new Proxy(realHandler, {
       get(target, property, receiver) {
         if (property === "clearAllConnectionsBang") {

--- a/packages/activerecord/src/migration/pending-migration-connection.ts
+++ b/packages/activerecord/src/migration/pending-migration-connection.ts
@@ -15,7 +15,7 @@ import { migrationArConfig } from "./ar-config-source.js";
  * (`pending_migration_connection.rb:6,10`).
  */
 function connectionHandler(): ConnectionHandler {
-  const handler = migrationArConfig()?.connectionHandler?.();
+  const handler = migrationArConfig()?.connectionHandler();
   if (!handler) throw new ActiveRecordError("ActiveRecord::Base has not finished loading");
   return handler;
 }

--- a/packages/activerecord/src/support/stubbed-ddl-methods.test.ts
+++ b/packages/activerecord/src/support/stubbed-ddl-methods.test.ts
@@ -50,6 +50,16 @@ const NON_EMITTING: ReadonlyMap<string, string> = new Map([
   ["quotedColumnsForIndex", "renderer input — renders an index's column list"],
   ["nativeDatabaseTypes", "renderer input — the type map typeToSql reads, a read not an emitter"],
   ["supportsForeignKeys", "capability read — decides whether the renderer emits inline REFERENCES"],
+  [
+    "supportsCheckConstraints",
+    "capability read — decides whether the renderer emits inline CHECK constraints",
+  ],
+  ["supportsPartialIndex", "capability read — decides whether an index renders its WHERE clause"],
+  ["supportsIndexInclude", "capability read — decides whether an index renders INCLUDE (...)"],
+  [
+    "supportsNullsNotDistinct",
+    "capability read — decides whether an index renders NULLS NOT DISTINCT",
+  ],
   ["_config", "connection-config read the renderer consults, not a DDL emitter"],
 ]);
 


### PR DESCRIPTION
## What

Two convergences on the same seam.

**`SchemaCreation` takes the connection only.** Rails' `SchemaCreation#initialize(conn)` takes one argument, and every capability probe is a `delegate ... to: :@conn` (`abstract/schema_creation.rb:6-21`). trails took two — the first an invented `"sqlite" | "postgres" | "mysql"` dialect string — and reimplemented eight of the delegated predicates as comparisons against that label. Since the adapter's answers are version-gated (`supports_index_sort_order?` is `database_version >= 10.8.1` on MariaDB / `8.0.1` on MySQL, `abstract_mysql_adapter.rb:409`), a string comparison could never see the server version: a pre-10.8.1 MariaDB connection rendered DDL its server rejects.

- constructor drops `adapterName`; every construction site drops its dialect literal.
- The seven predicates Rails actually delegates (`supports_indexes_in_create?`, `supports_partial_index?`, `supports_check_constraints?`, `supports_index_include?`, `supports_exclusion_constraints?`, `supports_unique_constraints?`, `supports_nulls_not_distinct?`) delegate to the connection.
- `supportsIndexSortOrder` also delegates, but it is **not** in that Ruby delegate list and Rails names it in no visitor: it is an adapter predicate (`abstract_adapter.rb:411`) that Rails reads only from `add_options_for_index_columns` (`abstract/schema_statements.rb:1640`), reached through the delegated `quoted_columns_for_index`. It is on `SchemaCreationConn` solely because trails' `MySQL::SchemaCreation#quotedColumns` pulled that decoration into the visitor — a pre-existing deviation, now filed as `mysql-schema-creation-quoted-columns-reimplements-the-delegated-decoration` (RFC 0051) and cited in JSDoc at the call site. Routing it through the real connection is still what fixes the version-gate bug.
- `supportsIndexUsing` returns `true` on `SchemaCreation` itself — Rails defines it there, not on the connection (`abstract/schema_creation.rb:137-139`), and only `SQLite3::SchemaCreation` overrides it (`sqlite3/schema_creation.rb:14`).
- `MySQL::SchemaCreation`'s `supportsIndexSortOrder` override is gone: the base now does exactly what it did. Rebased onto #6226, so the four probes it made awaitable (`supportsIndexSortOrder`, `supportsIndexInclude`, `supportsNullsNotDistinct`, `supportsCheckConstraints`) delegate as `Promise<boolean>`; the rest stay sync.
- the two other `adapterName` readers went with it — `nativeDatabaseTypes()` asks the connection, and abstract `typeToSql`'s array arm always throws (only PostgreSQL's `type_to_sql` appends `[]`, `postgresql/schema_statements.rb`, and `PG::SchemaCreation` overrides `typeToSql` to the adapter's).
- `abstract/schema-creation.test.ts`'s "SchemaCreation support predicates" tests now read the lane's connection instead of the string-keyed invention.

**`MigrationArConfig` slot members are required.** `base.ts` registers `databaseTasks`, `configurations` and `connectionHandler` exactly once, unconditionally, so their optionality was unreachable — it only forced `migration.ts` to carry per-member `!` and `?.` chains that Rails spells as a bare constant reference (`migration.rb:1036-1038`). The slot read keeps its one `!` (the pre-registration window is real); the per-member assertions and the `?? ""` / `?? []` fallbacks that stood in for "config not registered" are gone, along with the two `if (databaseTasks == null) return` guards Rails has no counterpart for.

## Notes

`move-adapter-specific-snapshot-off-ar-internal-metadata` was claimed with these two and **released unbuilt**, not shipped here. Its own findings section says it needs its own PR: the arm that survives (the run-token sidecar) is bigger than its estimate, its key function has to be lane-conditional because `sqlite3_mem` gives each worker its own database, and `load-schema-helper.ts:526-532` warns that this seam is reshaped one story at a time.

## Testing

`pnpm typecheck`; migration, migrator, adapter, column-definition and every `schema-creation` / `schema-definitions` suite green locally on the sqlite lane. `pnpm api:calls` OK (there is no `api:calls:wide` script — RFC 0084 folded that ratchet into `api:calls`, one artifact and one baseline), `api:extra` unchanged (the new `SchemaCreationConn` is an interface declaration, excluded by kind).

Closes-story: migration-ar-config-slot-members-are-spuriously-optional
Closes-story: schema-creation-takes-a-dialect-string-instead-of-delegating-to-conn
