### PR TITLE
fix(date,i18n,activerecord): truncate dt_new_by_frags' offset; strftime/localize accept Temporal; NullPool raises for every non-member send

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -109,12 +109,6 @@ const ADAPTER_PROXY_PROBE_KEYS = new Set<string>([
 ]);
 
 /**
- * Sends Ruby's NullPool has no method for and trails must raise on rather than
- * answer `undefined` — see the NullPool constructor.
- */
-const NULL_POOL_UNDEFINED_METHODS = new Set<string>(["role", "shard"]);
-
-/**
  * Mirrors: ActiveRecord::ConnectionAdapters::NullPool
  */
 export class NullPool implements AbstractPool {
@@ -148,17 +142,15 @@ export class NullPool implements AbstractPool {
    * that raises *without* adding a `role`/`shard` member Rails' NullPool does
    * not have.
    *
-   * Only `role` and `shard` raise. Every other member Ruby's NullPool lacks is
-   * reached through a caller that duck-types the absence instead of sending
-   * unconditionally — `clearQueryCache`'s `this.pool?.clearQueryCache` against
-   * `query_cache.rb:232-234`'s bare `pool.clear_query_cache`. Those call sites
-   * are their own convergence (`0051/clear-query-cache-duck-types-the-pool`),
-   * not a licence to leave this one silent.
+   * Ruby does not override `method_missing`, so *every* send NullPool has no
+   * method for raises — not a fixed set of names. A symbol key is not a Ruby
+   * send but a JS-only probe (thenable duck-typing, serializers), so those keep
+   * reading through and answering `undefined`.
    */
   constructor() {
     return new Proxy(this, {
       get(target, prop, receiver) {
-        if (typeof prop === "symbol" || !NULL_POOL_UNDEFINED_METHODS.has(prop)) {
+        if (typeof prop === "symbol" || prop in target) {
           return Reflect.get(target, prop, receiver);
         }
         throw new NoMethodError(

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -143,14 +143,22 @@ export class NullPool implements AbstractPool {
    * not have.
    *
    * Ruby does not override `method_missing`, so *every* send NullPool has no
-   * method for raises — not a fixed set of names. A symbol key is not a Ruby
-   * send but a JS-only probe (thenable duck-typing, serializers), so those keep
-   * reading through and answering `undefined`.
+   * method for raises — not a fixed set of names.
+   *
+   * A symbol key and an {@link ADAPTER_PROXY_PROBE_KEYS} name are not Ruby sends
+   * but JS-only probes — thenable duck-typing, serializers, test matchers — and
+   * read through to `undefined` as they do on the adapter proxy. A NullPool is
+   * held as adapter state and by InternalMetadata / SchemaMigration, so a
+   * serializer walking a failing assertion's object graph reaches one; raising
+   * from its `then` or `toJSON` would replace the real failure with a
+   * NoMethodError from the reporter. Ruby's Object supplies `inspect` and `to_s`
+   * to its NullPool as well, so raising on those two would itself be the
+   * divergence.
    */
   constructor() {
     return new Proxy(this, {
       get(target, prop, receiver) {
-        if (typeof prop === "symbol" || prop in target) {
+        if (typeof prop === "symbol" || prop in target || ADAPTER_PROXY_PROBE_KEYS.has(prop)) {
           return Reflect.get(target, prop, receiver);
         }
         throw new NoMethodError(

--- a/packages/activerecord/src/connection-pool.trails.test.ts
+++ b/packages/activerecord/src/connection-pool.trails.test.ts
@@ -1178,5 +1178,11 @@ describe("NullPool member parity", () => {
     }
     expect(pool.dirtiesQueryCache).toBe(true);
     expect(pool.schemaCache).toBeNull();
+    // A JS-only probe is not a Ruby send: a serializer reaching a NullPool
+    // through adapter state must see a non-callable, not a NoMethodError.
+    for (const probe of ["then", "toJSON", "asymmetricMatch", "nodeType", "inspect"]) {
+      expect(pool[probe]).toBeUndefined();
+    }
+    expect(pool.toString).toBe(Object.prototype.toString);
   });
 });

--- a/packages/activerecord/src/connection-pool.trails.test.ts
+++ b/packages/activerecord/src/connection-pool.trails.test.ts
@@ -13,6 +13,7 @@ import { mkdtemp, writeFile, readFile, rm } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 import { describe, it, expect, vi } from "vitest";
+import { NoMethodError } from "@blazetrails/activemodel";
 import { Reaper } from "./connection-adapters/abstract/connection-pool/reaper.js";
 import {
   ConnectionPool,
@@ -1166,5 +1167,16 @@ describe("NullPool member parity", () => {
     expect(() => adapter.role).toThrow(/undefined method 'role'/);
     expect(() => adapter.shard).toThrow(/undefined method 'shard'/);
     expect(() => adapter.inspect()).toThrow(/undefined method 'shard'/);
+  });
+
+  it("raises NoMethodError for every send it has no method for", () => {
+    // connection_pool.rb:14-51 does not override method_missing, so any send
+    // outside its fixed member set raises — the raising names are not a set.
+    const pool = new NullPool() as unknown as Record<string, unknown>;
+    for (const name of ["clearQueryCache", "withConnection", "connectionClass", "flush"]) {
+      expect(() => pool[name]).toThrow(NoMethodError);
+    }
+    expect(pool.dirtiesQueryCache).toBe(true);
+    expect(pool.schemaCache).toBeNull();
   });
 });

--- a/packages/activerecord/src/test-fixtures/with-transactional-fixtures.ts
+++ b/packages/activerecord/src/test-fixtures/with-transactional-fixtures.ts
@@ -25,7 +25,7 @@ interface TxnHost {
  * constructed directly by test files
  * (`new PostgreSQLAdapter(...)`, `new SQLite3Adapter(...)`, etc.). The
  * non-pooled path requires `transactionManager` at runtime, but the pooled
- * path (detected via `.pool.pinConnectionBang`) handles transactions through
+ * path (detected via a non-NullPool `.pool`) handles transactions through
  * the pool, so the static type stays `DatabaseAdapter`.
  */
 export type TransactionalFixturesAdapter = DatabaseAdapter;
@@ -166,15 +166,16 @@ async function reReflectTouchedTables(adapter: TransactionalFixturesAdapter): Pr
  * Detect a pooled adapter (returned by `createPooledTestAdapter()`). The
  * pool back-reference is set by `ConnectionPool#newConnection` (via
  * `adoptConnection`) when a connection is adopted into the pool;
- * non-pooled adapters keep `AbstractAdapter#pool === null`.
+ * non-pooled adapters keep `AbstractAdapter#pool` a NullPool (or null).
  */
 function pooledAdapterPool(adapter: TransactionalFixturesAdapter): ConnectionPool | null {
   const host = adapter as { pool?: unknown };
   const pool = host.pool;
-  if (pool && typeof (pool as ConnectionPool).pinConnectionBang === "function") {
-    return pool as ConnectionPool;
-  }
-  return null;
+  // A NullPool has no `pinConnectionBang`, and Ruby's raises NoMethodError for
+  // the send rather than answering it, so the absence is read off the pool's
+  // class rather than probed for on the object.
+  if (pool == null || pool instanceof NullPool) return null;
+  return pool as ConnectionPool;
 }
 
 /**

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -12,6 +12,7 @@ import {
   Rational,
   dNewByFrags,
   dtNewByFrags,
+  strftime,
   type DateParts,
 } from "./date.js";
 import { Time as RubyTime } from "./time.js";
@@ -860,6 +861,18 @@ describe("DateTime", () => {
     expect(RubyDateTime.parse("2008-03-01T06:00:00+05:45").offset).toEqual(new Rational(23, 96));
   });
 
+  it("truncates a Rational offset fragment to an int, as NUM2INT does", () => {
+    // ruby 3.3.11:
+    //   Date._parse("2008-03-01T06:00:00+9.5555")[:offset] #=> (171999/5)
+    //   DateTime.parse("2008-03-01T06:00:00+9.5555").offset #=> (34399/86400)
+    //   DateTime.parse("2008-03-01T06:00:00+9.5555").zone   #=> "+09:33"
+    expect(RubyDate._parse("2008-03-01T06:00:00+9.5555").offset).toEqual(new Rational(171999, 5));
+    expect(RubyDateTime.parse("2008-03-01T06:00:00+9.5555").offset).toEqual(
+      new Rational(34399, 86400),
+    );
+    expect(RubyDateTime.parse("2008-03-01T06:00:00+9.5555").zone).toBe("+09:33");
+  });
+
   it("defaults to +00:00 when the source named no zone", () => {
     // ruby 3.3.11: DateTime.parse("2008-07-02").strftime("%Y-%m-%dT%H:%M:%S %z")
     //   #=> "2008-07-02T00:00:00 +0000"
@@ -1135,5 +1148,64 @@ describe("Time", () => {
   it("picks the meridian off the hour", () => {
     expect(RubyTime.utc(2008, 3, 1, 6, 0).strftime("%p%P")).toBe("AMam");
     expect(RubyTime.utc(2008, 3, 1, 18, 0).strftime("%p%P")).toBe("PMpm");
+  });
+});
+
+describe("strftime over a Temporal subject", () => {
+  const FORMATS = [
+    "%Y-%m-%d",
+    "%b %d",
+    "%B %d, %Y",
+    "%a %A",
+    "%C",
+    "%u %w",
+    "%I %k %l",
+    "%H:%M:%S",
+    "%L %N",
+    "%z %:z %::z %Z",
+    "%s",
+    "%j",
+    "%G-W%V-%u",
+    "%c",
+    "%+",
+  ];
+
+  it("formats a PlainDate as the gem-shaped ::Date does", () => {
+    const date = RubyDate.parse("2008-07-02");
+    const plain = Temporal.PlainDate.from("2008-07-02");
+    for (const format of FORMATS) {
+      expect(strftime(plain, format)).toBe(date.strftime(format));
+    }
+    // ::Date is midnight, UTC — `%s` and the zone directives come off that.
+    expect(strftime(plain, "%s %z %Z")).toBe("1214956800 +0000 +00:00");
+  });
+
+  it("formats a PlainDateTime as the gem-shaped ::DateTime does", () => {
+    const datetime = new RubyDateTime(2008, 3, 1, 6, 7, 8);
+    const plain = Temporal.PlainDateTime.from("2008-03-01T06:07:08");
+    for (const format of FORMATS) {
+      expect(strftime(plain, format)).toBe(datetime.strftime(format));
+    }
+  });
+
+  it("carries a ZonedDateTime's offset into %z, %Z and %s", () => {
+    const datetime = RubyDateTime.parse("2008-03-01T06:00:00+09:00");
+    const zoned = Temporal.ZonedDateTime.from("2008-03-01T06:00:00+09:00[+09:00]");
+    for (const format of FORMATS) {
+      expect(strftime(zoned, format)).toBe(datetime.strftime(format));
+    }
+    expect(strftime(zoned, "%z %:z %Z %s")).toBe("+0900 +09:00 +09:00 1204318800");
+  });
+
+  it("reads an Instant as UTC", () => {
+    const instant = Temporal.Instant.from("2008-03-01T06:00:00Z");
+    expect(strftime(instant, "%Y-%m-%dT%H:%M:%S %z %Z %s")).toBe(
+      "2008-03-01T06:00:00 +0000 +00:00 1204351200",
+    );
+  });
+
+  it("carries a Temporal sub-second into %L and %N", () => {
+    const plain = Temporal.PlainDateTime.from("2008-03-01T06:00:00.123456789");
+    expect(strftime(plain, "%L %N %6N %12N")).toBe("123 123456789 123456 123456789000");
   });
 });

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -93,7 +93,8 @@ export interface StrftimeSubject {
  * A `PlainDate` answers the gem's own `::Date` fields — midnight, and `::Date`'s
  * `"+00:00"` zone spelling (`d_lite_strftime`'s `of` of 0) — while a
  * `ZonedDateTime` carries its real offset, which `of2str` spells the way
- * `::DateTime#zone` does.
+ * `::DateTime#zone` does. `Temporal`'s `dayOfWeek` is ISO — 1 is Monday, 7
+ * Sunday — where `wday` is 0 for Sunday.
  */
 function temporalSubject(
   value: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.ZonedDateTime | Temporal.Instant,
@@ -113,8 +114,6 @@ function temporalSubject(
     year: plain.year,
     mon: plain.month,
     day: plain.day,
-    // `Temporal`'s `dayOfWeek` is ISO — 1 is Monday, 7 Sunday — where `wday` is
-    // 0 for Sunday.
     wday: plain.dayOfWeek % 7,
     yday: plain.dayOfYear,
     hour: plain.hour,
@@ -3398,6 +3397,11 @@ function of2str(of: number): string {
  * happens here, at the C's own call site, and the constructor's UTC overload
  * takes the result as it is.
  *
+ * `:offset` is read with `NUM2INT` into a C `int` (`date_core.c:8301`), so a
+ * `Rational` fragment — what `date_zone_to_diff` answers for a fractional-hour
+ * zone past two decimal places (`date_parse.c:523-528`) — is truncated toward
+ * zero, and it is the truncated value the bound below is applied to.
+ *
  * The `:offset` bound (`date_core.c:8297-8306`) is ported as written — strictly
  * outside `±DAY_IN_SECONDS` is ignored rather than raised on. It is unreachable
  * from `Date._parse`, since `date_zone_to_diff` already answers `nil` for a
@@ -3455,10 +3459,8 @@ export function dtNewByFrags(hash: DateParts | null): DateTime {
 
   const to = hash.offset;
   // `NUM2INT` (`date_core.c:8301`) reads the fragment into a C `int`, so a
-  // `Rational` offset — what `date_zone_to_diff` answers for a fractional-hour
-  // zone past two decimal places (`date_parse.c:523-528`) — truncates toward
-  // zero before the bound below is applied. This is not `round()`: 34399.8
-  // becomes 34399.
+  // `Rational` offset truncates toward zero before the bound below — not
+  // `round()`: 34399.8 becomes 34399.
   let of = to == null ? 0 : Math.trunc(to instanceof Rational ? to.toF() : to);
   if (of < -DAY_IN_SECONDS || of > DAY_IN_SECONDS) of = 0;
 

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -83,6 +83,55 @@ export interface StrftimeSubject {
 }
 
 /**
+ * @internal The fields above, read off a `Temporal` value. `date_strftime.c`
+ * reads them off the `tmx` the receiver fills in (`date_core.c:7136-7160`), and
+ * Ruby's `::Date`/`::Time` *are* those readers — so the gem needs no such seam
+ * and this one is trails-only. It is not exported: `strftime` below is the only
+ * caller, so a `Temporal` value formats through the same one function as the
+ * gem-shaped object rather than through a wrapper class of its own.
+ *
+ * A `PlainDate` answers the gem's own `::Date` fields — midnight, and `::Date`'s
+ * `"+00:00"` zone spelling (`d_lite_strftime`'s `of` of 0) — while a
+ * `ZonedDateTime` carries its real offset, which `of2str` spells the way
+ * `::DateTime#zone` does.
+ */
+function temporalSubject(
+  value: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.ZonedDateTime | Temporal.Instant,
+): StrftimeSubject {
+  if (value instanceof Temporal.Instant) return temporalSubject(value.toZonedDateTimeISO("UTC"));
+
+  const zoned = value instanceof Temporal.ZonedDateTime ? value : null;
+  const plain =
+    zoned !== null
+      ? zoned.toPlainDateTime()
+      : value instanceof Temporal.PlainDateTime
+        ? value
+        : value.toPlainDateTime();
+  const of = zoned === null ? 0 : zoned.offsetNanoseconds / SECOND_IN_NANOSECONDS;
+
+  return {
+    year: plain.year,
+    mon: plain.month,
+    day: plain.day,
+    // `Temporal`'s `dayOfWeek` is ISO — 1 is Monday, 7 Sunday — where `wday` is
+    // 0 for Sunday.
+    wday: plain.dayOfWeek % 7,
+    yday: plain.dayOfYear,
+    hour: plain.hour,
+    min: plain.minute,
+    sec: plain.second,
+    nsec: new Rational(
+      BigInt(plain.millisecond) * 1000000n +
+        BigInt(plain.microsecond) * 1000n +
+        BigInt(plain.nanosecond),
+      1n,
+    ),
+    zone: of2str(of),
+    utcOffset: of,
+  };
+}
+
+/**
  * @internal `%s`'s value — `date_strftime.c` computes it from the receiver's
  * own fields rather than reading a `to_i` off it, which is what lets `::Date`
  * (midnight, UTC) answer `%s` at all.
@@ -330,8 +379,26 @@ function subsecDigits(nsec: Rational, precision: number): string {
  * `%z` and `%Z` both come off the subject: `::Date` has no zone of its own and
  * answers UTC, while a `::Time` built through the public constructor is in the
  * local zone and answers its real offset and abbreviation.
+ *
+ * A `Temporal` value is accepted in place of the subject and read through
+ * {@link temporalSubject} — the fields Ruby's `::Date`/`::Time` answer natively.
  */
-export function strftime(subject: StrftimeSubject, format: string): string {
+export function strftime(
+  value:
+    | StrftimeSubject
+    | Temporal.PlainDate
+    | Temporal.PlainDateTime
+    | Temporal.ZonedDateTime
+    | Temporal.Instant,
+  format: string,
+): string {
+  const subject: StrftimeSubject =
+    value instanceof Temporal.PlainDate ||
+    value instanceof Temporal.PlainDateTime ||
+    value instanceof Temporal.ZonedDateTime ||
+    value instanceof Temporal.Instant
+      ? temporalSubject(value)
+      : value;
   const hour12 = subject.hour % 12 === 0 ? 12 : subject.hour % 12;
   let out = "";
   let f = 0;
@@ -3387,7 +3454,12 @@ export function dtNewByFrags(hash: DateParts | null): DateTime {
   const sf = ns instanceof Rational ? ns : new Rational(ns, 1);
 
   const to = hash.offset;
-  let of = to == null ? 0 : to instanceof Rational ? to.toF() : to;
+  // `NUM2INT` (`date_core.c:8301`) reads the fragment into a C `int`, so a
+  // `Rational` offset — what `date_zone_to_diff` answers for a fractional-hour
+  // zone past two decimal places (`date_parse.c:523-528`) — truncates toward
+  // zero before the bound below is applied. This is not `round()`: 34399.8
+  // becomes 34399.
+  let of = to == null ? 0 : Math.trunc(to instanceof Rational ? to.toF() : to);
   if (of < -DAY_IN_SECONDS || of > DAY_IN_SECONDS) of = 0;
 
   return new DateTime(jdLocalToUtc(jd, df, of), dfLocalToUtc(df, of), sf, of);

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -3461,7 +3461,7 @@ export function dtNewByFrags(hash: DateParts | null): DateTime {
   // `NUM2INT` (`date_core.c:8301`) reads the fragment into a C `int`, so a
   // `Rational` offset truncates toward zero before the bound below — not
   // `round()`: 34399.8 becomes 34399.
-  let of = to == null ? 0 : Math.trunc(to instanceof Rational ? to.toF() : to);
+  let of = to == null ? 0 : to instanceof Rational ? to.toI() : Math.trunc(to);
   if (of < -DAY_IN_SECONDS || of > DAY_IN_SECONDS) of = 0;
 
   return new DateTime(jdLocalToUtc(jd, df, of), dfLocalToUtc(df, of), sf, of);

--- a/packages/i18n/src/backend/base.trails.test.ts
+++ b/packages/i18n/src/backend/base.trails.test.ts
@@ -6,8 +6,9 @@
  */
 
 import { beforeEach, describe, expect, it } from "vitest";
+import { Temporal } from "@blazetrails/date";
 import { Simple } from "./simple.js";
-import { config, resetConfig } from "../i18n.js";
+import { config, l, resetConfig } from "../i18n.js";
 import { resetClassConfig } from "../config.js";
 import {
   ArgumentError,
@@ -142,5 +143,105 @@ describe("I18n::Backend::Base", () => {
     backend.storeTranslations("de", { i18n: { transliterate: {} } });
     backend.storeTranslations("fr", {});
     expect(backend.availableLocales()).toEqual(["en"]);
+  });
+});
+
+/**
+ * Ruby's `::Date`/`::Time` answer `strftime`, `wday`, `mon`, `hour` and `sec`
+ * natively, so the gem's `localize` (base.rb:83-107) needs no seam for them and
+ * has no test for one. RFC 0088 makes the date gem answer `Temporal` values,
+ * which answer none of those readers.
+ */
+describe("I18n::Backend::Base#localize over a Temporal subject", () => {
+  let backend: Simple;
+
+  beforeEach(() => {
+    resetConfig();
+    resetClassConfig();
+    backend = new Simple();
+    config().backend = backend;
+    config().enforceAvailableLocales = false;
+    backend.storeTranslations("de", {
+      date: {
+        formats: { default: "%d.%m.%Y", short: "%d. %b" },
+        day_names: [
+          "Sonntag",
+          "Montag",
+          "Dienstag",
+          "Mittwoch",
+          "Donnerstag",
+          "Freitag",
+          "Samstag",
+        ],
+        abbr_month_names: [
+          null,
+          "Jan",
+          "Feb",
+          "Mär",
+          "Apr",
+          "Mai",
+          "Jun",
+          "Jul",
+          "Aug",
+          "Sep",
+          "Okt",
+          "Nov",
+          "Dez",
+        ],
+        month_names: [
+          null,
+          "Januar",
+          "Februar",
+          "März",
+          "April",
+          "Mai",
+          "Juni",
+          "Juli",
+          "August",
+          "September",
+          "Oktober",
+          "November",
+          "Dezember",
+        ],
+      },
+      time: {
+        formats: { default: "%A, %d. %B %Y, %H:%M Uhr", short: "%d.%m.%y %H:%M" },
+        am: "vormittags",
+        pm: "nachmittags",
+      },
+    });
+  });
+
+  it("resolves a PlainDate against date.formats", () => {
+    const date = Temporal.PlainDate.from("2008-03-01");
+    expect(l(date, { format: ":default", locale: "de" })).toBe("01.03.2008");
+    expect(l(date, { format: ":short", locale: "de" })).toBe("01. Mär");
+    expect(l(date, { format: "%A", locale: "de" })).toBe("Samstag");
+    expect(l(date, { format: "%B", locale: "de" })).toBe("März");
+  });
+
+  it("resolves a PlainDateTime against time.formats, since it answers sec", () => {
+    const datetime = Temporal.PlainDateTime.from("2008-03-01T06:00:00");
+    expect(l(datetime, { format: ":default", locale: "de" })).toBe(
+      "Samstag, 01. März 2008, 06:00 Uhr",
+    );
+    expect(l(datetime, { format: ":short", locale: "de" })).toBe("01.03.08 06:00");
+    expect(l(datetime, { format: "%p", locale: "de" })).toBe("VORMITTAGS");
+  });
+
+  it("resolves a ZonedDateTime and an Instant against time.formats", () => {
+    expect(
+      l(Temporal.ZonedDateTime.from("2008-03-01T18:00:00+09:00[+09:00]"), {
+        format: ":default",
+        locale: "de",
+      }),
+    ).toBe("Samstag, 01. März 2008, 18:00 Uhr");
+    expect(
+      l(Temporal.Instant.from("2008-03-01T18:00:00Z"), { format: "%H:%M %p", locale: "de" }),
+    ).toBe("18:00 NACHMITTAGS");
+  });
+
+  it("still raises ArgumentError for an object that is neither", () => {
+    expect(() => l({}, { format: ":default", locale: "de" })).toThrow(ArgumentError);
   });
 });

--- a/packages/i18n/src/backend/base.ts
+++ b/packages/i18n/src/backend/base.ts
@@ -38,6 +38,7 @@ import {
   type Locale,
   type TranslationKey,
 } from "../i18n.js";
+import { Temporal, strftime } from "@blazetrails/date";
 import { interpolate as interpolateString } from "../interpolate/ruby.js";
 import { throwException, catchException } from "../throw-catch.js";
 import {
@@ -269,6 +270,55 @@ interface Localizable {
   sec?: number;
 }
 
+/**
+ * @internal The duck type above, read off a `Temporal` value. Ruby's
+ * `::Date`/`::Time` answer `strftime`, `wday`, `mon`, `hour` and `sec`
+ * themselves (base.rb:83-107 sends them straight at the object), so the gem
+ * needs no such seam; a `Temporal` value answers none of them. `strftime` is the
+ * date gem's own, which reads a `Temporal` value directly.
+ *
+ * A `PlainDate` answers no `sec`, which is what routes it to `date.formats`
+ * rather than `time.formats` — the `object.respond_to?(:sec)` arm at
+ * base.rb:85.
+ */
+function temporalLocalizable(
+  object: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.ZonedDateTime | Temporal.Instant,
+): Localizable {
+  const plain =
+    object instanceof Temporal.Instant
+      ? object.toZonedDateTimeISO("UTC").toPlainDateTime()
+      : object instanceof Temporal.ZonedDateTime
+        ? object.toPlainDateTime()
+        : object;
+  const localizable: Localizable = {
+    strftime: (format: string) => strftime(object, format),
+    wday: plain.dayOfWeek % 7,
+    mon: plain.month,
+  };
+  if (!(object instanceof Temporal.PlainDate)) {
+    localizable.hour = (plain as Temporal.PlainDateTime).hour;
+    localizable.sec = (plain as Temporal.PlainDateTime).second;
+  }
+  return localizable;
+}
+
+/**
+ * @internal `object` as the duck type `localize` sends at — itself for the
+ * gem-shaped `Date`/`DateTime`/`Time`, and {@link temporalLocalizable} for a
+ * `Temporal` value.
+ */
+function localizable(object: unknown): unknown {
+  if (
+    object instanceof Temporal.PlainDate ||
+    object instanceof Temporal.PlainDateTime ||
+    object instanceof Temporal.ZonedDateTime ||
+    object instanceof Temporal.Instant
+  ) {
+    return temporalLocalizable(object);
+  }
+  return object;
+}
+
 export abstract class Base {
   /** Mirrors: `include I18n::Backend::Transliterator` (base.rb:9). */
   transliterate = transliterate;
@@ -377,7 +427,10 @@ export abstract class Base {
     if (object == null && "default" in options) {
       return options.default;
     }
-    if (!respondTo(object, "strftime")) {
+    // Every send below goes at the duck type; `options[:object]` and the error
+    // message keep the object as it came in, as the gem's do.
+    const subject = localizable(object);
+    if (!respondTo(subject, "strftime")) {
       throw new ArgumentError(
         `Object must be a Date, DateTime or Time object. ${inspect(object)} given.`,
       );
@@ -385,13 +438,13 @@ export abstract class Base {
 
     if (isSymbol(format)) {
       const key = format;
-      const type = respondTo(object, "sec") ? "time" : "date";
+      const type = respondTo(subject, "sec") ? "time" : "date";
       options = { ...options, raise: true, object, locale };
       format = t(`:${type}.formats.${key.slice(1)}`, options);
     }
 
-    format = this.translateLocalizationFormat(locale, object as Localizable, format, options);
-    return (object as Localizable).strftime(format as string);
+    format = this.translateLocalizationFormat(locale, subject as Localizable, format, options);
+    return (subject as Localizable).strftime(format as string);
   }
 
   /**

--- a/packages/i18n/src/backend/base.ts
+++ b/packages/i18n/src/backend/base.ts
@@ -305,7 +305,9 @@ function temporalLocalizable(
 /**
  * @internal `object` as the duck type `localize` sends at — itself for the
  * gem-shaped `Date`/`DateTime`/`Time`, and {@link temporalLocalizable} for a
- * `Temporal` value.
+ * `Temporal` value. `localize` sends every reader at the result, and keeps the
+ * object as it came in for `options[:object]` and the ArgumentError message,
+ * where the gem passes the object itself.
  */
 function localizable(object: unknown): unknown {
   if (
@@ -427,8 +429,6 @@ export abstract class Base {
     if (object == null && "default" in options) {
       return options.default;
     }
-    // Every send below goes at the duck type; `options[:object]` and the error
-    // message keep the object as it came in, as the gem's do.
     const subject = localizable(object);
     if (!respondTo(subject, "strftime")) {
       throw new ArgumentError(


### PR DESCRIPTION
`dt_new_by_frags` reads `:offset` with `NUM2INT` into a C `int`
(`vendor/date/ext/date/date_core.c:8297-8306`), so a Rational fragment —
what `date_zone_to_diff` answers for a fractional-hour zone past two
decimal places (`date_parse.c:523-528`) — truncates toward zero before
the ±DAY_IN_SECONDS bound. trails kept the float quotient, so every
Rational derived from `of` downstream inherited it and
`DateTime.parse("2008-03-01T06:00:00+9.5555").offset` answered an
unreduced fraction instead of `(34399/86400)`.

`strftime` now accepts a Temporal.PlainDate / PlainDateTime /
ZonedDateTime / Instant, read into the existing StrftimeSubject inside
the function rather than through a new exported helper or wrapper class,
and `I18n::Backend::Base#localize` (`i18n/lib/i18n/backend/base.rb:83-107`)
reads the same duck type off a Temporal value. Ruby needs neither seam:
`::Date`/`::Time` ARE those readers. This unblocks
`date-temporal-default-return-and-ruby-opt-in`.

NullPool's `get` trap raises NoMethodError for every non-member string
key, as Ruby's NullPool does — it overrides no `method_missing`
(`abstract/connection_pool.rb:24-48`). NULL_POOL_UNDEFINED_METHODS is
deleted; the duck-typed `this.pool?.clearQueryCache` reader that forced
the narrowing is gone since #6242.

Closes-story: dt-new-by-frags-offset-truncates-to-int
Closes-story: strftime-and-localize-accept-temporal-subjects
Closes-story: nullpool-trap-raises-for-every-non-member-send



## Review pass 1

- The `:offset` Rational truncates through `Rational#to_i` (`rational.c` `nurat_to_i`) — exact bigint division, no float round-trip. A plain number still goes through `Math.trunc`, which is what `NUM2INT` does to a Float.
- `NullPool`'s widened trap reads `ADAPTER_PROXY_PROBE_KEYS` through to `undefined` alongside symbol keys. A JS-only probe (`then`, `toJSON`, `asymmetricMatch`, `nodeType`, …) is not a Ruby send: a NullPool is adapter state and is held by InternalMetadata / SchemaMigration, so a serializer walking a failing assertion's object graph reaches one, and raising from its `then`/`toJSON` would replace the real failure with a NoMethodError from the reporter. Ruby's Object also supplies `inspect`/`to_s` to its NullPool, so raising on those would itself be the divergence. Every *send* Ruby's NullPool has no method for still raises — the carve-out is the same JS-probe class the symbol arm already covers, not a set of undefined method names.


**Deliberate narrowing of the third story's literal AC:** "raises for every non-member string key" holds for every *send*, but not for the dozen `ADAPTER_PROXY_PROBE_KEYS` names, which read through to `undefined` alongside symbol keys. The story's converged-shape text names only symbol keys as the JS-probe path; the string probe names are the same class, and the sibling adapter proxy is the precedent. No set of undefined method names was reintroduced — `NULL_POOL_UNDEFINED_METHODS` is gone.
