### PR TITLE
fix(activesupport,activerecord): methodMissingProxy public-send visibility and the NoMethodError arm

### DIFF
--- a/packages/activerecord/src/migration/command-recorder.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.test.ts
@@ -30,17 +30,12 @@ describe("Migration", () => {
     });
 
     it("send calls super", () => {
-      // Rails asserts NoMethodError from the `else super` arm
-      // (command_recorder.rb:403). The class is module-local to the proxy, so
-      // the assertion is on the Ruby class name it carries.
       expect(() => recorder.nonExistingMethod("horses")).toThrow(
-        /undefined method 'nonExistingMethod'/,
+        expect.objectContaining({
+          name: "NoMethodError",
+          message: expect.stringContaining("undefined method 'nonExistingMethod'"),
+        }) as unknown as Error,
       );
-      try {
-        recorder.nonExistingMethod("horses");
-      } catch (error) {
-        expect((error as Error).name).toBe("NoMethodError");
-      }
     });
 
     it("send delegates to record", () => {

--- a/packages/activerecord/src/migration/command-recorder.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.test.ts
@@ -30,7 +30,17 @@ describe("Migration", () => {
     });
 
     it("send calls super", () => {
-      expect(() => recorder.nonExistingMethod("horses")).toThrow(TypeError);
+      // Rails asserts NoMethodError from the `else super` arm
+      // (command_recorder.rb:403). The class is module-local to the proxy, so
+      // the assertion is on the Ruby class name it carries.
+      expect(() => recorder.nonExistingMethod("horses")).toThrow(
+        /undefined method 'nonExistingMethod'/,
+      );
+      try {
+        recorder.nonExistingMethod("horses");
+      } catch (error) {
+        expect((error as Error).name).toBe("NoMethodError");
+      }
     });
 
     it("send delegates to record", () => {

--- a/packages/activerecord/src/migration/command-recorder.trails.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.trails.test.ts
@@ -35,6 +35,23 @@ describe("CommandRecorder", () => {
     expect(recorder.america()).toBe("hi");
   });
 
+  it("does not forward a private delegate member, the way public_send does not", () => {
+    // command_recorder.rb:396,401 — respond_to?/public_send are public-only, and
+    // the trails spelling of a private member is the leading underscore.
+    const recorder = new CommandRecorder({ _secret: () => "no", visible: () => "yes" });
+    expect("_secret" in recorder).toBe(false);
+    expect("visible" in recorder).toBe(true);
+    expect(() => (recorder as unknown as { _secret(): string })._secret()).toThrow(
+      /undefined method '_secret'/,
+    );
+  });
+
+  it("a name no delegate answers raises NoMethodError only when called", () => {
+    const recorder = new CommandRecorder({}) as unknown as Record<string, () => void>;
+    expect(typeof recorder["nope"]).toBe("function");
+    expect(() => recorder["nope"]()).toThrow(/undefined method 'nope'/);
+  });
+
   it("invertCreateTable strips ifNotExists even when fn is last arg", () => {
     const fn = () => {};
     const [cmd, args] = new CommandRecorder().invertCreateTable([

--- a/packages/activerecord/src/migration/command-recorder.trails.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.trails.test.ts
@@ -36,8 +36,6 @@ describe("CommandRecorder", () => {
   });
 
   it("does not forward a private delegate member, the way public_send does not", () => {
-    // command_recorder.rb:396,401 — respond_to?/public_send are public-only, and
-    // the trails spelling of a private member is the leading underscore.
     const recorder = new CommandRecorder({ _secret: () => "no", visible: () => "yes" });
     expect("_secret" in recorder).toBe(false);
     expect("visible" in recorder).toBe(true);

--- a/packages/activerecord/src/migration/command-recorder.ts
+++ b/packages/activerecord/src/migration/command-recorder.ts
@@ -663,12 +663,13 @@ export class CommandRecorder {
   // private dispatch
   // ---------------------------------------------------------------------------
 
+  /**
+   * Mirrors `inverse_of`'s `respond_to?(method, true)` guard
+   * (command_recorder.rb:116): membership is tested before the read, because a
+   * name the recorder does not answer takes the proxy's `method_missing` arm.
+   */
   private _dispatchInvert(cmd: string, args: unknown[]): [string, unknown[]] {
     const methodName = `invert${cmd.charAt(0).toUpperCase()}${cmd.slice(1)}` as keyof this;
-    // Rails guards with `respond_to?(method, true)` (command_recorder.rb:116)
-    // before sending, so the membership test comes first: reading a name the
-    // recorder does not answer takes the proxy's `method_missing` arm, which
-    // hands back a NoMethodError-raising function.
     const method = methodName in this ? this[methodName] : undefined;
     if (typeof method === "function") {
       return (method as (args: unknown[]) => [string, unknown[]]).call(this, args);

--- a/packages/activerecord/src/migration/command-recorder.ts
+++ b/packages/activerecord/src/migration/command-recorder.ts
@@ -665,7 +665,11 @@ export class CommandRecorder {
 
   private _dispatchInvert(cmd: string, args: unknown[]): [string, unknown[]] {
     const methodName = `invert${cmd.charAt(0).toUpperCase()}${cmd.slice(1)}` as keyof this;
-    const method = this[methodName];
+    // Rails guards with `respond_to?(method, true)` (command_recorder.rb:116)
+    // before sending, so the membership test comes first: reading a name the
+    // recorder does not answer takes the proxy's `method_missing` arm, which
+    // hands back a NoMethodError-raising function.
+    const method = methodName in this ? this[methodName] : undefined;
     if (typeof method === "function") {
       return (method as (args: unknown[]) => [string, unknown[]]).call(this, args);
     }

--- a/packages/activesupport/src/method-missing-proxy.ts
+++ b/packages/activesupport/src/method-missing-proxy.ts
@@ -1,3 +1,42 @@
+import { NameError } from "./core-ext/name-error.js";
+
+/**
+ * Ruby's `NoMethodError`, raised by the `else super` arm. It subclasses this
+ * package's {@link NameError} because Ruby's does (`NoMethodError < NameError`),
+ * so a `rescue NameError` site catches it. Local to this module rather than
+ * exported: the raise site is the proxy, and callers identify it the way they
+ * identify any Ruby error class here — by `name` and message.
+ */
+class NoMethodError extends NameError {
+  constructor(message: string) {
+    super(message);
+    this.name = "NoMethodError";
+  }
+}
+
+/**
+ * Names JS itself probes for on an arbitrary object to decide whether it
+ * implements a protocol — `await x` reads `then`, structured comparison reads
+ * `toJSON`, vitest's matchers read `asymmetricMatch`/`$$typeof`. A raising
+ * function in those slots would be *called* by the probe, so they stay absent.
+ */
+const PROTOCOL_PROBES = new Set([
+  "then",
+  "catch",
+  "finally",
+  "toJSON",
+  "asymmetricMatch",
+  "$$typeof",
+  "nodeType",
+]);
+
+/** Mirrors `delegate.respond_to?(method)` — public members only. */
+function respondsTo(delegate: unknown, prop: string | symbol): boolean {
+  if (delegate == null) return false;
+  if (typeof prop === "string" && prop.startsWith("_")) return false;
+  return prop in Object(delegate);
+}
+
 /**
  * Ruby-style `method_missing` forwarding for a TypeScript object.
  *
@@ -30,42 +69,6 @@
  * No amount of porting removes the need for a TS-side shape, so this is the one
  * shared one, the way `include()` is the one shape for Ruby `include`.
  */
-/**
- * Ruby's `NoMethodError` (a subclass of `NameError`), raised by the `else super`
- * arm. Local to this module rather than exported: the raise site is the proxy,
- * and callers identify it the way they identify any Ruby error class here — by
- * `name` and message.
- */
-class NoMethodError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "NoMethodError";
-  }
-}
-
-/**
- * Names JS itself probes for on an arbitrary object to decide whether it
- * implements a protocol — `await x` reads `then`, structured comparison reads
- * `toJSON`, vitest's matchers read `asymmetricMatch`/`$$typeof`. A raising
- * function in those slots would be *called* by the probe, so they stay absent.
- */
-const PROTOCOL_PROBES = new Set([
-  "then",
-  "catch",
-  "finally",
-  "toJSON",
-  "asymmetricMatch",
-  "$$typeof",
-  "nodeType",
-]);
-
-/** Mirrors `delegate.respond_to?(method)` — public members only. */
-function respondsTo(delegate: unknown, prop: string | symbol): boolean {
-  if (delegate == null) return false;
-  if (typeof prop === "string" && prop.startsWith("_")) return false;
-  return prop in Object(delegate);
-}
-
 export function methodMissingProxy<T extends object>(
   target: T,
   /** `delegate` reads the forwarding target; `overrides` is consulted first. */

--- a/packages/activesupport/src/method-missing-proxy.ts
+++ b/packages/activesupport/src/method-missing-proxy.ts
@@ -12,11 +12,60 @@
  * (command_recorder.rb:400-404) — with functions bound to the delegate. When
  * `delegate(target)` returns `target` there is no own-property step (DelegateClass).
  *
+ * Both traps are *public*-only, because Rails asks `delegate.respond_to?(method)`
+ * and forwards with `delegate.public_send` (command_recorder.rb:396,401), neither
+ * of which sees a private or protected method. The TS analogue of "private" is
+ * the trails leading-underscore convention, so an `_`-prefixed delegate member is
+ * neither forwarded nor answered by `has`.
+ *
+ * A name the delegate does not answer takes Rails' `else super` arm and raises
+ * `NoMethodError` (command_recorder.rb:403). A `get` trap cannot raise there:
+ * `typeof x.foo === "function"` and `"foo" in x` both route through it, so
+ * throwing would blow up every feature probe. The read therefore returns a
+ * function that raises when *called*, which is exactly where Ruby's
+ * `method_missing` raises.
+ *
  * @noRailsEquivalent PERMANENT — Ruby resolves an undefined method through
  * `method_missing` at the language level; JS has no such hook, only `Proxy`.
  * No amount of porting removes the need for a TS-side shape, so this is the one
  * shared one, the way `include()` is the one shape for Ruby `include`.
  */
+/**
+ * Ruby's `NoMethodError` (a subclass of `NameError`), raised by the `else super`
+ * arm. Local to this module rather than exported: the raise site is the proxy,
+ * and callers identify it the way they identify any Ruby error class here — by
+ * `name` and message.
+ */
+class NoMethodError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NoMethodError";
+  }
+}
+
+/**
+ * Names JS itself probes for on an arbitrary object to decide whether it
+ * implements a protocol — `await x` reads `then`, structured comparison reads
+ * `toJSON`, vitest's matchers read `asymmetricMatch`/`$$typeof`. A raising
+ * function in those slots would be *called* by the probe, so they stay absent.
+ */
+const PROTOCOL_PROBES = new Set([
+  "then",
+  "catch",
+  "finally",
+  "toJSON",
+  "asymmetricMatch",
+  "$$typeof",
+  "nodeType",
+]);
+
+/** Mirrors `delegate.respond_to?(method)` — public members only. */
+function respondsTo(delegate: unknown, prop: string | symbol): boolean {
+  if (delegate == null) return false;
+  if (typeof prop === "string" && prop.startsWith("_")) return false;
+  return prop in Object(delegate);
+}
+
 export function methodMissingProxy<T extends object>(
   target: T,
   /** `delegate` reads the forwarding target; `overrides` is consulted first. */
@@ -33,14 +82,21 @@ export function methodMissingProxy<T extends object>(
       if (delegate !== proxyTarget && Reflect.has(proxyTarget, prop)) {
         return Reflect.get(proxyTarget, prop, receiver);
       }
-      const value = (delegate as Record<string | symbol, unknown> | null | undefined)?.[prop];
-      return typeof value === "function" ? value.bind(delegate) : value;
+      if (respondsTo(delegate, prop)) {
+        const value = (delegate as Record<string | symbol, unknown>)[prop];
+        return typeof value === "function" ? value.bind(delegate) : value;
+      }
+      if (typeof prop === "symbol" || PROTOCOL_PROBES.has(prop)) return undefined;
+      return () => {
+        throw new NoMethodError(
+          `undefined method '${prop}' for an instance of ${(proxyTarget as object).constructor.name}`,
+        );
+      };
     },
     has(proxyTarget, prop) {
       if (overrides !== undefined && prop in overrides) return true;
       if (Reflect.has(proxyTarget, prop)) return true;
-      const delegate = readDelegate(proxyTarget);
-      return delegate != null && prop in Object(delegate);
+      return respondsTo(readDelegate(proxyTarget), prop);
     },
   });
 }


### PR DESCRIPTION
Ports the two halves of Rails' `method_missing` the shared proxy was missing (`activerecord/lib/active_record/migration/command_recorder.rb:395-405`).

- **Visibility.** `respond_to?` / `public_send` (`command_recorder.rb:396,401`) are public-only, so `get` and `has` now skip `_`-prefixed delegate members — the trails spelling of private.
- **`else super`.** A name no delegate answers now reads back as a function that raises `NoMethodError` when called (`command_recorder.rb:403`). A `get` trap cannot raise directly: `typeof x.foo === "function"` and `"foo" in x` both route through it, so the raise moves to the send — exactly where Ruby raises. JS protocol probes (`then`, `toJSON`, `asymmetricMatch`, …) stay absent so `await`/matchers keep working.

`inverseOf`'s dispatch now tests membership before reading, mirroring Rails' `respond_to?(method, true)` guard (`command_recorder.rb:116`) — otherwise the new raising function would be called instead of the `IrreversibleMigration` arm.

`test_send_calls_super` (`command_recorder_test.rb:20-24`) now asserts the NoMethodError; the class is module-local to the proxy so it is identified by its Ruby class name.

Closes-story: method-missing-proxy-public-send-visibility-and-no-method-error
