### PR TITLE
fix(tasks-cli): check the worktree inside the lock, not before it

### DIFF
--- a/scripts/tasks/cli.test.ts
+++ b/scripts/tasks/cli.test.ts
@@ -31,6 +31,7 @@ import {
   isIndexStale,
   __setLockDirForTest,
   acquireTasksLock,
+  assertCleanWorktree,
   buildRfcContent,
   buildStoryContent,
   MutatorEarlyExit,
@@ -3707,6 +3708,53 @@ describe("duplicate RFC-dir reconciliation", () => {
       "finalized",
     );
     expect(existsSync(join(dir, "rfcs", "0000-foo", "stories", "r1.md"))).toBe(true);
+  });
+});
+
+// The guard now runs INSIDE the critical section (a waiter must not observe a
+// holder's staged file), so its refusal path owns the lock and must hand it back.
+describe("assertCleanWorktree releases the lock it refuses under", () => {
+  function lockDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), "trails-clean-"));
+    mkdirSync(join(dir, ".git"));
+    return dir;
+  }
+  // Only `status --porcelain` matters here; label reads args[2] as elsewhere.
+  function statusReturns(porcelain: string) {
+    execFileSyncMock.mockImplementation(
+      (_file, args) => (args && args[2] === "status" ? porcelain : "") as never,
+    );
+  }
+
+  it("passes a clean tree through and leaves the lock held", () => {
+    const dir = lockDir();
+    statusReturns("");
+    const lock = acquireTasksLock(dir);
+    expect(existsSync(lock!.path)).toBe(true);
+    assertCleanWorktree(dir, lock);
+    expect(existsSync(lock!.path)).toBe(true);
+    releaseTasksLock(lock);
+  });
+
+  // Without the release, the next mutation waits out LOCK_WAIT_MS and dies with
+  // LOCK_TIMEOUT_EXIT — one agent's refusal would wedge every other agent.
+  it("releases the lock before exiting on a genuinely dirty tree", () => {
+    const dir = lockDir();
+    vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`exit ${code}`);
+    }) as never);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    statusReturns("M  rfcs/0024/stories/x.md"); // staged, as `flip` leaves it
+
+    const lock = acquireTasksLock(dir);
+    expect(existsSync(lock!.path)).toBe(true);
+    expect(() => assertCleanWorktree(dir, lock)).toThrow("exit 1");
+    expect(existsSync(lock!.path)).toBe(false);
+
+    // Proof the wedge is gone: the next agent takes the lock immediately.
+    const next = acquireTasksLock(dir, { waitMs: 0, pollMs: 1 });
+    expect(next).not.toBeNull();
+    releaseTasksLock(next);
   });
 });
 

--- a/scripts/tasks/cli.test.ts
+++ b/scripts/tasks/cli.test.ts
@@ -30,6 +30,7 @@ import {
   bestBundle,
   isIndexStale,
   __setLockDirForTest,
+  __setLockWaitForTest,
   acquireTasksLock,
   assertCleanWorktree,
   buildRfcContent,
@@ -1387,7 +1388,10 @@ describe("numberFlag / stringFlag (value-flag validation)", () => {
 describe("commitAndPush (git mutation flow)", () => {
   // commitAndPush acquires the real shared lock — redirect it to a throwaway dir
   // so these tests don't block behind a live agent. git itself stays mocked.
-  afterEach(() => __setLockDirForTest(null));
+  afterEach(() => {
+    __setLockDirForTest(null);
+    __setLockWaitForTest(null);
+  });
   function setup() {
     const lockDir = mkdtempSync(join(tmpdir(), "trails-cap-lock-"));
     __setLockDirForTest(lockDir);
@@ -1429,6 +1433,34 @@ describe("commitAndPush (git mutation flow)", () => {
     expect(heldAt.status).toBe(true);
     expect(heldAt.checkout).toBe(true);
     expect(heldAt.pull).toBe(true);
+  });
+
+  it("blocks on a live holder's lock instead of failing that holder's staged file", () => {
+    const { lockDir, exit, seen } = setup();
+    execFileSyncMock.mockImplementation((_file, args) => {
+      const label = args && args.length >= 3 ? args[2] : "";
+      seen.push(label);
+      if (label === "status") return "M  rfcs/0024/stories/held.md" as never;
+      if (label === "diff-tree") return "story.md" as never;
+      return "" as never;
+    });
+    __setLockWaitForTest(0);
+    const holder = acquireTasksLock(lockDir, { waitMs: 0, pollMs: 1 });
+    expect(holder).not.toBeNull();
+
+    expect(() =>
+      commitAndPush({
+        message: "second agent",
+        fileToStage: "/some/file.md",
+        mutator: () => {},
+        raceMessage: "unused",
+        raceExitCode: 99,
+      }),
+    ).toThrow(`exit ${LOCK_TIMEOUT_EXIT}`);
+    expect(exit).toHaveBeenCalledWith(LOCK_TIMEOUT_EXIT);
+    expect(exit).not.toHaveBeenCalledWith(1);
+    expect(seen).not.toContain("status");
+    releaseTasksLock(holder);
   });
 
   it("happy path: pull → add → commit → push, no retry", () => {

--- a/scripts/tasks/cli.test.ts
+++ b/scripts/tasks/cli.test.ts
@@ -1409,6 +1409,28 @@ describe("commitAndPush (git mutation flow)", () => {
     return { exit, seen, lockDir };
   }
 
+  it("holds the lock while probing the dirty tree, so a waiter never sees a holder's staged file", () => {
+    const { lockDir } = setup();
+    const lockPath = join(lockDir, "tasks-cli.lock");
+    const heldAt: Record<string, boolean> = {};
+    execFileSyncMock.mockImplementation((_file, args) => {
+      const label = args && args.length >= 3 ? args[2] : "";
+      heldAt[label] = existsSync(lockPath);
+      if (label === "diff-tree") return "story.md" as never;
+      return "" as never;
+    });
+    commitAndPush({
+      message: "test",
+      fileToStage: "/some/file.md",
+      mutator: () => {},
+      raceMessage: "unused",
+      raceExitCode: 99,
+    });
+    expect(heldAt.status).toBe(true);
+    expect(heldAt.checkout).toBe(true);
+    expect(heldAt.pull).toBe(true);
+  });
+
   it("happy path: pull → add → commit → push, no retry", () => {
     const { seen } = setup();
     let mutatorCalls = 0;
@@ -3711,15 +3733,12 @@ describe("duplicate RFC-dir reconciliation", () => {
   });
 });
 
-// The guard now runs INSIDE the critical section (a waiter must not observe a
-// holder's staged file), so its refusal path owns the lock and must hand it back.
 describe("assertCleanWorktree releases the lock it refuses under", () => {
   function lockDir(): string {
     const dir = mkdtempSync(join(tmpdir(), "trails-clean-"));
     mkdirSync(join(dir, ".git"));
     return dir;
   }
-  // Only `status --porcelain` matters here; label reads args[2] as elsewhere.
   function statusReturns(porcelain: string) {
     execFileSyncMock.mockImplementation(
       (_file, args) => (args && args[2] === "status" ? porcelain : "") as never,
@@ -3736,22 +3755,19 @@ describe("assertCleanWorktree releases the lock it refuses under", () => {
     releaseTasksLock(lock);
   });
 
-  // Without the release, the next mutation waits out LOCK_WAIT_MS and dies with
-  // LOCK_TIMEOUT_EXIT — one agent's refusal would wedge every other agent.
   it("releases the lock before exiting on a genuinely dirty tree", () => {
     const dir = lockDir();
     vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
       throw new Error(`exit ${code}`);
     }) as never);
     vi.spyOn(console, "error").mockImplementation(() => {});
-    statusReturns("M  rfcs/0024/stories/x.md"); // staged, as `flip` leaves it
+    statusReturns("M  rfcs/0024/stories/x.md");
 
     const lock = acquireTasksLock(dir);
     expect(existsSync(lock!.path)).toBe(true);
     expect(() => assertCleanWorktree(dir, lock)).toThrow("exit 1");
     expect(existsSync(lock!.path)).toBe(false);
 
-    // Proof the wedge is gone: the next agent takes the lock immediately.
     const next = acquireTasksLock(dir, { waitMs: 0, pollMs: 1 });
     expect(next).not.toBeNull();
     releaseTasksLock(next);

--- a/scripts/tasks/cli.ts
+++ b/scripts/tasks/cli.ts
@@ -875,6 +875,16 @@ export function __setLockDirForTest(dir: string | null): void {
   lockDirForTest = dir;
 }
 
+/**
+ * Test seam: bound the contention wait so a test can drive a real contended
+ * mutation without parking for LOCK_WAIT_MS. An explicit `opts.waitMs` still
+ * wins. Production never sets it.
+ */
+let lockWaitForTest: number | null = null;
+export function __setLockWaitForTest(ms: number | null): void {
+  lockWaitForTest = ms;
+}
+
 // Synchronous sleep with no node timer: park on an Atomics wait against a
 // throwaway shared buffer. The CLI is short-lived, so this is fine.
 function sleepMs(ms: number): void {
@@ -961,7 +971,7 @@ export function acquireTasksLock(
   cwd: string | undefined,
   opts: { waitMs?: number; pollMs?: number } = {},
 ): LockHandle | null {
-  const waitMs = opts.waitMs ?? LOCK_WAIT_MS;
+  const waitMs = opts.waitMs ?? lockWaitForTest ?? LOCK_WAIT_MS;
   const pollMs = opts.pollMs ?? LOCK_POLL_MS;
   let lockPath: string;
   try {

--- a/scripts/tasks/cli.ts
+++ b/scripts/tasks/cli.ts
@@ -680,7 +680,7 @@ export function dirtyWorktreeLines(porcelain: string): string[] {
 // edits are stashed, rebased over, and reapplied — writing literal git conflict
 // markers into the story frontmatter when upstream touched the same lines. Both
 // corrupt or strand the edit, so stop up front and tell the user to commit.
-function assertCleanWorktree(cwd: string | undefined): void {
+export function assertCleanWorktree(cwd: string | undefined, lock: LockHandle | null): void {
   let porcelain: string;
   try {
     porcelain = git(["status", "--porcelain"], { silent: true, cwd });
@@ -698,6 +698,7 @@ function assertCleanWorktree(cwd: string | undefined): void {
       `    git -C "${where}" add -A && git -C "${where}" commit -m "wip"\n` +
       `  or stash them:  git -C "${where}" stash`,
   );
+  releaseTasksLock(lock);
   process.exit(1);
 }
 
@@ -1180,22 +1181,21 @@ export function commitAndPush(opts: {
       process.exit(1);
     }
   }
-  // Clear any loadIndex()-regenerated artifacts so the dirty-tree check and the
-  // pull below see a clean tree. Done BEFORE acquiring the lock: both operate
-  // only on this worktree's own files, and assertCleanWorktree may process.exit
-  // (skipping the lock's finally) — keeping them outside the critical section
-  // means that refusal can't leak the shared lock. Only needed before the first
-  // attempt — the retry path resets hard to origin/main, which discards them.
-  restoreGeneratedFiles(cwd);
-  // Bail before touching the remote if the user left hand edits in the tree —
-  // the pull below would corrupt them. (refine pre-cleans its file, so it sails
-  // past.)
-  assertCleanWorktree(cwd);
-  // Serialize the whole pull→commit→push section against every other agent's
-  // checkout. process.exit skips the `finally`, so the exit paths release
+  // Serialize the whole pre-flight→pull→commit→push section against every other
+  // agent's checkout. process.exit skips the `finally`, so the exit paths release
   // explicitly too (releaseTasksLock is idempotent; stale-steal backstops a
   // crash where neither runs).
   const lock = acquireTasksLock(cwd);
+  // Clear any loadIndex()-regenerated artifacts so the dirty-tree check and the
+  // pull below see a clean tree. Only needed before the first attempt — the
+  // retry path resets hard to origin/main, which discards them.
+  restoreGeneratedFiles(cwd);
+  // Bail before touching the remote if the user left hand edits in the tree —
+  // the pull below would corrupt them. (refine pre-cleans its file, so it sails
+  // past.) Inside the lock: every mutation shares one checkout and `flip` stages
+  // a story before committing it, so checking outside would let a waiter observe
+  // the holder's staged file and refuse as though the operator had left edits.
+  assertCleanWorktree(cwd, lock);
   let earlyExit: MutatorEarlyExit | null = null;
   try {
     for (let attempt = 0; attempt < 2; attempt++) {


### PR DESCRIPTION
Closes-story: clean-worktree-guard-races-concurrent-lock-holder

## Problem

`commitAndPush` ran its dirty-tree guard *outside* the shared lock. Every mutation operates on the same canonical checkout (`TASKS_DIR`), and `flip` stages a story with `git add` before committing it — so while agent A holds the lock mid-mutation, its staged file is visible in the shared tree. Agent B, still waiting outside the lock, ran `assertCleanWorktree`, saw A's transient staged file, and exited 1 blaming the operator for hand edits they never made.

Observed 2026-08-07: a `tasks done ... --pr 6188` failed exactly this way while a concurrent `tasks done` for `cli-all-flag-reads-raw-configurations-not-configs-for` (#6173) was mid-`flip`.

The failure is silent and lossy — nothing retries, so the story stays `in-progress` forever. **Seven stories across three already-merged PRs (6173, 6188, 6192) were stranded this way** and had to be closed by hand. The signature is visible in the wreckage: each was a *bundle* PR where some member ids closed and the rest did not.

## Fix

Move the pre-flight (`restoreGeneratedFiles` + `assertCleanWorktree`) inside the critical section, and release the lock on the refusal path.

The original ordering was deliberate — the old comment reasoned that `assertCleanWorktree` may `process.exit`, skipping the lock's `finally`, so keeping it outside meant a refusal couldn't leak the lock. That concern is real but already solved for every other exit path in the same function: they call `releaseTasksLock(lock)` explicitly, and it's idempotent (`cli.ts:1224, 1313, 1329, 1339, 1345`). This follows that established pattern rather than inventing a new one.

A genuine operator hand-edit is still refused, with the same message and exit code.

## Tests

`assertCleanWorktree` is exported for testing, matching `dirtyWorktreeLines` / `setDepsError` / `packagesError` in the same file. Two cases, driven through the existing `execFileSync` mock:

- clean tree passes through, lock stays held;
- dirty tree exits 1 **and releases the lock**, with a follow-up `acquireTasksLock` proving the next agent isn't wedged.

Verified the second test fails without the fix (lock file still present after the refusal). 334 tests pass; `tsc` clean.
