### PR TITLE
fix(activemodel): port the Integer arm of sec_fraction after DateParts widened to bigint

### DIFF
--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -62,17 +62,17 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
    * Ruby's one line dispatches on the numeric tower and the two arms do not
    * agree — `(0.123456 * 1_000_000).to_i` is 123456, while the same Float
    * through `to_r` truncates to 123455. TS has no numeric receiver to
-   * dispatch on, so both arms are spelled out: the Rational one multiplies
-   * exactly, the Float one reproduces Ruby's float multiply.
+   * dispatch on, so the arms are spelled out: the Rational and Integer ones
+   * multiply exactly, the Float one reproduces Ruby's float multiply.
    *
    * @internal Rails-private helper.
    */
   protected microseconds(time: DateParts): number {
     const secFraction = time.secFraction;
     if (secFraction == null) return 0;
-    return secFraction instanceof Rational
-      ? secFraction.mul(1_000_000).toI()
-      : Math.trunc(secFraction * 1_000_000);
+    if (secFraction instanceof Rational) return secFraction.mul(1_000_000).toI();
+    if (typeof secFraction === "bigint") return Number(secFraction * 1_000_000n);
+    return Math.trunc(secFraction * 1_000_000);
   }
 
   /**

--- a/packages/activemodel/src/type/helpers/time-value.ts
+++ b/packages/activemodel/src/type/helpers/time-value.ts
@@ -168,7 +168,7 @@ export function newTime(
   hour: number | null | undefined,
   min: number | null | undefined,
   sec: number | null | undefined,
-  microsec: number | Rational | null | undefined,
+  microsec: number | bigint | Rational | null | undefined,
   offset?: number | Rational | null,
 ): Temporal.Instant | null {
   if (year == null || (year === 0 && mon === 0 && mday === 0)) return null;
@@ -176,7 +176,11 @@ export function newTime(
   // Treat missing month/day the same way rather than silently coercing to Jan 1.
   if (mon == null || mday == null) return null;
   const totalNano =
-    microsec instanceof Rational ? microsec.mul(1000).toI() : Math.trunc((microsec ?? 0) * 1000);
+    microsec instanceof Rational
+      ? microsec.mul(1000).toI()
+      : typeof microsec === "bigint"
+        ? Number(microsec * 1000n)
+        : Math.trunc((microsec ?? 0) * 1000);
   const components = {
     year,
     month: mon,


### PR DESCRIPTION
`Leaf Tests` and `Virtualized DX Type Tests` are red on main @77eb0ebd. Both run
`pnpm test:types`, and both fail on the same two **source** type errors:

```
TypeCheckError: Operator '*' cannot be applied to types 'number | bigint' and 'number'.
 ❯ packages/activemodel/src/type/date-time.ts:75:20

TypeCheckError: Argument of type 'number | bigint | Rational | undefined' is not
assignable to parameter of type 'number | Rational | null | undefined'.
 ❯ packages/activemodel/src/type/time.ts:170:7
```

## Root cause

#6255 (`strptime-seconds-frag-is-a-number`) widened `DateParts` so `%s` can carry
a bigint past 2^53 and `%Q` an exact `Rational`:

```diff
-  secFraction?: number | Rational;
+  secFraction?: number | bigint | Rational;
-  seconds?: number;
+  seconds?: number | bigint | Rational;
```

`rt_rewrite_frags` writes `hash.secFraction = fMod(seconds, DAY_IN_SECONDS)`
(`date.ts:2724`), so the bigint reaches `:sec_fraction`. `date.ts` itself took
the widening (`date.ts:3423`); the two **activemodel** readers of `:sec_fraction`
did not, and `pnpm typecheck` does not cover them — only the dx-tests projects do,
which is why it surfaced as a Leaf/DX red rather than at the merge of #6255.

## Fix

Ruby's `(time[:sec_fraction] * 1_000_000).to_i` (`date_time.rb:78`) dispatches on
the numeric tower, and Integer is a third member alongside Rational and Float —
exact, like Rational, unlike the Float arm that reproduces `0.123456 * 1_000_000`.
`ActiveModel::Type::DateTime#microseconds` and `TimeValue#new_time`'s `microsec`
(`time_value.rb:136-145`) each grow that arm. No behavior change on the existing
two arms.

`pnpm test:types`: 99 tests, 9 files, no type errors. `date-time.test.ts` +
`time.test.ts`: 58 passed.

Closes-story: red-77eb0ebd
