### PR TITLE
fix(activerecord,activemodel): structureDump/Load take the root; SchemaCreation delegates useForeignKeys

### DIFF
--- a/packages/activerecord/src/adapters/sqlite3/sqlite-rake.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite-rake.test.ts
@@ -133,7 +133,7 @@ describeIfSqlite("SqliteStructureDumpTest", () => {
     const filename = awesomeFile();
     created.push(filename);
 
-    await DatabaseTasks.structureDump(configuration, filename);
+    await DatabaseTasks.structureDump(configuration, filename, "/rails/root");
 
     expect(fs.existsSync(dbfile)).toBeTruthy();
     expect(fs.existsSync(filename)).toBeTruthy();
@@ -152,7 +152,7 @@ describeIfSqlite("SqliteStructureDumpTest", () => {
     runSqlite3(database, "CREATE TABLE ignored_foo(id INTEGER)");
     SchemaDumper.ignoreTables = [/^prefix_/, "ignored_foo"];
 
-    await DatabaseTasks.structureDump(configuration, filename);
+    await DatabaseTasks.structureDump(configuration, filename, "/rails/root");
 
     expect(fs.existsSync(dbfile)).toBeTruthy();
     expect(fs.existsSync(filename)).toBeTruthy();
@@ -175,7 +175,7 @@ describeIfSqlite("SqliteStructureDumpTest", () => {
     let message = "";
     DatabaseTasks.structureDumpFlags = ["--noop"];
     await expect(
-      DatabaseTasks.structureDump(configuration, filename).catch((e: Error) => {
+      DatabaseTasks.structureDump(configuration, filename, "/rails/root").catch((e: Error) => {
         message = e.message;
         throw e;
       }),
@@ -222,7 +222,7 @@ describeIfSqlite("SqliteStructureLoadTest", () => {
     });
 
     fs.writeFileSync(filename, "select datetime('now', 'localtime');\n");
-    await DatabaseTasks.structureLoad(configuration, filename);
+    await DatabaseTasks.structureLoad(configuration, filename, "/rails/root");
 
     expect(fs.existsSync(dbfile)).toBeTruthy();
   });

--- a/packages/activerecord/src/column-definition.test.ts
+++ b/packages/activerecord/src/column-definition.test.ts
@@ -27,7 +27,7 @@ class DummyCreation extends SchemaCreation {
       supportsNullsNotDistinct: async () => false,
       supportsPartialIndex: () => false,
       supportsUniqueConstraints: () => false,
-      isUseForeignKeys: () => true,
+      useForeignKeys: () => true,
     });
   }
 

--- a/packages/activerecord/src/column-definition.test.ts
+++ b/packages/activerecord/src/column-definition.test.ts
@@ -27,6 +27,7 @@ class DummyCreation extends SchemaCreation {
       supportsNullsNotDistinct: async () => false,
       supportsPartialIndex: () => false,
       supportsUniqueConstraints: () => false,
+      isUseForeignKeys: () => true,
     });
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -427,7 +427,7 @@ export interface AbstractAdapter {
     toTable: string,
     options?: Record<string, unknown>,
   ): Record<string, unknown>;
-  isUseForeignKeys(): boolean;
+  useForeignKeys(): boolean;
   removeForeignKey(
     fromTable: string,
     toTableOrOptions?: string | RemoveForeignKeyOptions,

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -53,18 +53,19 @@ export interface SchemaCreationConn extends SchemaQuoter {
   supportsNullsNotDistinct(): Promise<boolean>;
   supportsPartialIndex(): boolean;
   supportsUniqueConstraints(): boolean;
+  isUseForeignKeys(): boolean;
 }
 
 export class SchemaCreation {
   /** Rails' `SchemaCreation#initialize(conn)` (abstract/schema_creation.rb:6-9). */
   constructor(protected adapter: SchemaCreationConn) {}
 
-  // Capability probes. Seven of these are `delegate ... to: :@conn`
+  // Capability probes. Eight of these are `delegate ... to: :@conn`
   // (abstract/schema_creation.rb:16-21): supports_indexes_in_create?,
   // supports_partial_index?, supports_check_constraints?, supports_index_include?,
-  // supports_exclusion_constraints?, supports_unique_constraints? and
-  // supports_nulls_not_distinct?. The connection answers them, so its version
-  // gates reach the visitor.
+  // supports_exclusion_constraints?, supports_unique_constraints?,
+  // supports_nulls_not_distinct? and use_foreign_keys?. The connection answers
+  // them, so its version gates reach the visitor.
 
   protected supportsPartialIndex(): boolean {
     return this.adapter.supportsPartialIndex();
@@ -236,12 +237,7 @@ export class SchemaCreation {
 
   /** @internal */
   protected useForeignKeys(): boolean {
-    const host = this.adapter as unknown as {
-      supportsForeignKeys?: () => boolean;
-      _config?: { foreignKeys?: boolean };
-    };
-    const supports = host.supportsForeignKeys?.() ?? true;
-    return supports && host._config?.foreignKeys !== false;
+    return this.adapter.isUseForeignKeys();
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -53,7 +53,7 @@ export interface SchemaCreationConn extends SchemaQuoter {
   supportsNullsNotDistinct(): Promise<boolean>;
   supportsPartialIndex(): boolean;
   supportsUniqueConstraints(): boolean;
-  isUseForeignKeys(): boolean;
+  useForeignKeys(): boolean;
 }
 
 export class SchemaCreation {
@@ -237,7 +237,7 @@ export class SchemaCreation {
 
   /** @internal */
   protected useForeignKeys(): boolean {
-    return this.adapter.isUseForeignKeys();
+    return this.adapter.useForeignKeys();
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
@@ -271,7 +271,7 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
     // would short-circuit removeForeignKey via the use_foreign_keys? guard; opt
     // in so the recursion-prone base path is actually exercised.
     class FkStub extends StubAdapter {
-      isUseForeignKeys() {
+      useForeignKeys() {
         return true;
       }
     }
@@ -340,7 +340,7 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
     // resolution when the name doesn't match. If the ifExists probe wrongly
     // sliced in `name`, this would silently no-op instead.
     class FkStub extends StubAdapter {
-      isUseForeignKeys() {
+      useForeignKeys() {
         return true;
       }
       foreignKeys(_table: string) {
@@ -368,7 +368,7 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
       }
     }
     const stub = new NoFkAdapter();
-    expect((stub as any).isUseForeignKeys()).toBe(false);
+    expect((stub as any).useForeignKeys()).toBe(false);
     await stub.addForeignKey("articles", "authors", { column: "author_id" });
     expect(executed).toBe(false);
   });
@@ -385,7 +385,7 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
       }
     }
     const stub = new NoFkAdapter();
-    expect((stub as any).isUseForeignKeys()).toBe(false);
+    expect((stub as any).useForeignKeys()).toBe(false);
     await expect(
       stub.removeForeignKey("articles", { name: "fk_whatever" }),
     ).resolves.toBeUndefined();
@@ -415,7 +415,7 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
     const stub = new DisabledFkAdapter();
     expect(stub.supportsForeignKeys()).toBe(true);
     expect((stub as any).isForeignKeysEnabled()).toBe(false);
-    expect((stub as any).isUseForeignKeys()).toBe(false);
+    expect((stub as any).useForeignKeys()).toBe(false);
     await stub.addForeignKey("articles", "authors", { column: "author_id" });
     await expect(
       stub.removeForeignKey("articles", { name: "fk_whatever" }),

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -55,6 +55,7 @@ function makeStatements(
   adapter["supportsIndexSortOrder"] ??= async () => true;
   adapter["supportsExclusionConstraints"] ??= () => false;
   adapter["supportsUniqueConstraints"] ??= () => false;
+  adapter["isUseForeignKeys"] ??= () => true;
   // Real hosts override AbstractAdapter#native_database_types (the abstract one
   // is `{}`); the stub answers with SQLite's table so typeToSql resolves.
   adapter["nativeDatabaseTypes"] ??= () => NATIVE_DATABASE_TYPES_BY_ADAPTER["sqlite"];

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -55,7 +55,7 @@ function makeStatements(
   adapter["supportsIndexSortOrder"] ??= async () => true;
   adapter["supportsExclusionConstraints"] ??= () => false;
   adapter["supportsUniqueConstraints"] ??= () => false;
-  adapter["isUseForeignKeys"] ??= () => true;
+  adapter["useForeignKeys"] ??= () => true;
   // Real hosts override AbstractAdapter#native_database_types (the abstract one
   // is `{}`); the stub answers with SQLite's table so typeToSql resolves.
   adapter["nativeDatabaseTypes"] ??= () => NATIVE_DATABASE_TYPES_BY_ADAPTER["sqlite"];

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1890,10 +1890,7 @@ export class SchemaStatements {
   }
 
   isUseForeignKeys(): boolean {
-    const adapter = this as any;
-    const supportsForeignKeys =
-      typeof adapter.supportsForeignKeys === "function" ? adapter.supportsForeignKeys() : true;
-    return supportsForeignKeys && this.isForeignKeysEnabled();
+    return this.supportsForeignKeys() && this.isForeignKeysEnabled();
   }
 
   async bulkChangeTable(

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -766,7 +766,7 @@ export class SchemaStatements {
     options: AddForeignKeyOptions = {},
   ): Promise<void> {
     // Rails: return unless use_foreign_keys?
-    if (!this.isUseForeignKeys()) return;
+    if (!this.useForeignKeys()) return;
     // Mirrors Rails' add_foreign_key short-circuit:
     //   return if options[:if_not_exists] == true &&
     //     foreign_key_exists?(from_table, to_table, **options.slice(:column))
@@ -806,7 +806,7 @@ export class SchemaStatements {
     options: RemoveForeignKeyOptions = {},
   ): Promise<void> {
     // Rails: return unless use_foreign_keys?
-    if (!this.isUseForeignKeys()) return;
+    if (!this.useForeignKeys()) return;
     // Mirrors Rails remove_foreign_key(from_table, to_table = nil, **options):
     // resolve the actual constraint via foreign_key_for! (matching column /
     // name / to_table against the live foreign keys) rather than deriving a
@@ -1889,7 +1889,7 @@ export class SchemaStatements {
     return SchemaDumper.create(this as Parameters<typeof SchemaDumper.create>[0], options);
   }
 
-  isUseForeignKeys(): boolean {
+  useForeignKeys(): boolean {
     return this.supportsForeignKeys() && this.isForeignKeysEnabled();
   }
 
@@ -2243,7 +2243,7 @@ export class SchemaStatements {
     fromTable: string,
     options: ForeignKeyLookupOptions = {},
   ): Promise<ForeignKeyDefinition | undefined> {
-    if (!this.isUseForeignKeys()) return undefined;
+    if (!this.useForeignKeys()) return undefined;
     const fks = await this.foreignKeys(fromTable);
     return fks.find((fk) => fk.isDefinedFor(options));
   }

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
@@ -53,7 +53,6 @@ type MysqlTableDef = TableDefinition & { charset?: string; collation?: string };
  * half is required and dispatches polymorphically. */
 export interface VisitorHostAdapter extends TableDefinitionConn, SchemaCreationConn {
   supportsCheckConstraints(): Promise<boolean>;
-  supportsForeignKeys(): boolean;
   supportsIndexesInCreate(): boolean;
   /** Version-gated: MariaDB ≥ 10.8.1 / MySQL ≥ 8.0.1 — fetches the server
    * version on demand, so it is awaitable. */
@@ -189,18 +188,6 @@ export class SchemaCreation extends AbstractSchemaCreation {
   /** @internal Delegates to the adapter when wired (Rails: `@conn.supports_indexes_in_create?`). */
   protected supportsIndexesInCreate(): boolean {
     return this.adapter.supportsIndexesInCreate();
-  }
-
-  /** @internal Mirrors Rails' `use_foreign_keys?` (`supports_foreign_keys? &&
-   * foreign_keys_enabled?`). The enabled half reads `adapter._config.foreignKeys`, matching
-   * `SchemaStatements#isForeignKeysEnabled`. */
-  protected useForeignKeys(): boolean {
-    const supports = this.adapter.supportsForeignKeys();
-    // `_config` is protected on the real adapter, so read it via a narrow cast
-    // (mirrors `SchemaStatements#isForeignKeysEnabled`).
-    const host = this.adapter as { _config?: { foreignKeys?: boolean } };
-    const enabled = host._config?.foreignKeys !== false;
-    return supports && enabled;
   }
 
   /** @internal Delegates to the adapter; honors MySQL 8.0.16+ / MariaDB 10.2.1+ version gating. */

--- a/packages/activerecord/src/connection-adapters/pool-config.ts
+++ b/packages/activerecord/src/connection-adapters/pool-config.ts
@@ -313,7 +313,7 @@ export interface TrailsAdapterOptions {
   // locking (read by `advisoryLocksEnabled?`). Defaults to true.
   advisoryLocks?: boolean | string;
   // Mirrors: database.yml `foreign_keys` — set false to disable foreign-key DDL
-  // (read by `foreignKeysEnabled?` / `isUseForeignKeys`). Defaults to true.
+  // (read by `foreignKeysEnabled?` / `useForeignKeys`). Defaults to true.
   foreignKeys?: boolean;
 }
 

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-creation.test.ts
@@ -29,7 +29,7 @@ const s = () =>
     supportsNullsNotDistinct: async () => true,
     supportsPartialIndex: () => true,
     supportsUniqueConstraints: () => true,
-    isUseForeignKeys: () => true,
+    useForeignKeys: () => true,
     quoteColumnName: (n: string) => `"${n}"`,
     quoteTableName: (n: string) => `"${n}"`,
     quoteDefaultExpression: (v: unknown) => ` DEFAULT ${typeof v === "string" ? `'${v}'` : v}`,

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-creation.test.ts
@@ -29,6 +29,7 @@ const s = () =>
     supportsNullsNotDistinct: async () => true,
     supportsPartialIndex: () => true,
     supportsUniqueConstraints: () => true,
+    isUseForeignKeys: () => true,
     quoteColumnName: (n: string) => `"${n}"`,
     quoteTableName: (n: string) => `"${n}"`,
     quoteDefaultExpression: (v: unknown) => ` DEFAULT ${typeof v === "string" ? `'${v}'` : v}`,

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts
@@ -501,6 +501,7 @@ describeIfPostgresqlAdapter("TableDefinition#toSql", () => {
       supportsIndexSortOrder: async () => true,
       supportsExclusionConstraints: () => true,
       supportsUniqueConstraints: () => true,
+      isUseForeignKeys: () => true,
     };
     const td = new TableDefinition("widgets", { adapter: stubAdapter as any });
     td.cidr("net");

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts
@@ -501,7 +501,7 @@ describeIfPostgresqlAdapter("TableDefinition#toSql", () => {
       supportsIndexSortOrder: async () => true,
       supportsExclusionConstraints: () => true,
       supportsUniqueConstraints: () => true,
-      isUseForeignKeys: () => true,
+      useForeignKeys: () => true,
     };
     const td = new TableDefinition("widgets", { adapter: stubAdapter as any });
     td.cidr("net");

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.test.ts
@@ -171,7 +171,7 @@ describe("SchemaStatements#addForeignKey use_foreign_keys? guard", () => {
       }),
     } as unknown as DatabaseAdapter;
     const ss = withSchemaStatements(adapter);
-    expect(ss.isUseForeignKeys()).toBe(false);
+    expect(ss.useForeignKeys()).toBe(false);
     await ss.addForeignKey("articles", "authors", { column: "author_id" });
     expect(executed).toEqual([]);
   });

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -1117,7 +1117,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
     // Rails PG `add_foreign_key` is `assert_valid_deferrable(deferrable); super`,
     // and the abstract `super` begins with `return unless use_foreign_keys?`.
     // We replicate the abstract body inline here, so replicate the guard too.
-    if (!this.isUseForeignKeys()) return;
+    if (!this.useForeignKeys()) return;
     if (options.ifNotExists === true) {
       // foreignKeyExists routes through foreignKeyFor/isDefinedFor, which
       // compares `column` element-wise, so composite (array) columns match by

--- a/packages/activerecord/src/connection-adapters/raw-connection-overload.test.ts
+++ b/packages/activerecord/src/connection-adapters/raw-connection-overload.test.ts
@@ -168,7 +168,7 @@ describe("deprecated raw-connection initialize overload", () => {
 describe("config-hash constructor retains foreignKeys in _config", () => {
   type FkGuards = {
     isForeignKeysEnabled(): boolean;
-    isUseForeignKeys(): boolean;
+    useForeignKeys(): boolean;
   };
   const guards = (adapter: PostgreSQLAdapter | Mysql2Adapter) => adapter as unknown as FkGuards;
 
@@ -176,21 +176,21 @@ describe("config-hash constructor retains foreignKeys in _config", () => {
     const disabled = new PostgreSQLAdapter({ foreignKeys: false });
     expect(disabled.supportsForeignKeys()).toBe(true);
     expect(guards(disabled).isForeignKeysEnabled()).toBe(false);
-    expect(guards(disabled).isUseForeignKeys()).toBe(false);
+    expect(guards(disabled).useForeignKeys()).toBe(false);
 
     const enabled = new PostgreSQLAdapter({});
     expect(guards(enabled).isForeignKeysEnabled()).toBe(true);
-    expect(guards(enabled).isUseForeignKeys()).toBe(true);
+    expect(guards(enabled).useForeignKeys()).toBe(true);
   });
 
   it("Mysql2Adapter honors foreignKeys:false and defaults to true", () => {
     const disabled = new Mysql2Adapter({ foreignKeys: false, _fakeConnection: true } as never);
     expect(disabled.supportsForeignKeys()).toBe(true);
     expect(guards(disabled).isForeignKeysEnabled()).toBe(false);
-    expect(guards(disabled).isUseForeignKeys()).toBe(false);
+    expect(guards(disabled).useForeignKeys()).toBe(false);
 
     const enabled = new Mysql2Adapter({ _fakeConnection: true } as never);
     expect(guards(enabled).isForeignKeysEnabled()).toBe(true);
-    expect(guards(enabled).isUseForeignKeys()).toBe(true);
+    expect(guards(enabled).useForeignKeys()).toBe(true);
   });
 });

--- a/packages/activerecord/src/connection-adapters/schema-cache.test.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.test.ts
@@ -738,7 +738,7 @@ class MockAdapter {
   supportsIndexSortOrder = async () => true;
   supportsExclusionConstraints = () => false;
   supportsUniqueConstraints = () => false;
-  isUseForeignKeys = () => true;
+  useForeignKeys = () => true;
   createTableDefinition = (n: string, opts: Record<string, unknown>) =>
     // Rails' create_table_definition passes `self` (schema_statements.rb:1041).
     new TableDefinition(n, { adapter: this as never, ...opts, adapterName: "sqlite" });

--- a/packages/activerecord/src/connection-adapters/schema-cache.test.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.test.ts
@@ -738,6 +738,7 @@ class MockAdapter {
   supportsIndexSortOrder = async () => true;
   supportsExclusionConstraints = () => false;
   supportsUniqueConstraints = () => false;
+  isUseForeignKeys = () => true;
   createTableDefinition = (n: string, opts: Record<string, unknown>) =>
     // Rails' create_table_definition passes `self` (schema_statements.rb:1041).
     new TableDefinition(n, { adapter: this as never, ...opts, adapterName: "sqlite" });

--- a/packages/activerecord/src/support/stubbed-ddl-methods.test.ts
+++ b/packages/activerecord/src/support/stubbed-ddl-methods.test.ts
@@ -49,7 +49,7 @@ const NON_EMITTING: ReadonlyMap<string, string> = new Map([
   ["quoteDefaultExpression", "renderer input — renders a column default, emits nothing itself"],
   ["quotedColumnsForIndex", "renderer input — renders an index's column list"],
   ["nativeDatabaseTypes", "renderer input — the type map typeToSql reads, a read not an emitter"],
-  ["supportsForeignKeys", "capability read — decides whether the renderer emits inline REFERENCES"],
+  ["useForeignKeys", "capability read — decides whether the renderer emits inline REFERENCES"],
   [
     "supportsCheckConstraints",
     "capability read — decides whether the renderer emits inline CHECK constraints",
@@ -60,7 +60,6 @@ const NON_EMITTING: ReadonlyMap<string, string> = new Map([
     "supportsNullsNotDistinct",
     "capability read — decides whether an index renders NULLS NOT DISTINCT",
   ],
-  ["_config", "connection-config read the renderer consults, not a DDL emitter"],
 ]);
 
 /**

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -814,32 +814,40 @@ export class DatabaseTasks {
     }
   }
 
+  /**
+   * Mirrors: `structure_dump` (`tasks/database_tasks.rb:362-367`). What is left
+   * in Ruby's `*arguments` once `filename` is shifted off is the `root`
+   * forwarded to the task constructor by `database_adapter_for`
+   * (`sqlite_rake_test.rb:182` passes `"/rails/root"` there); the flags come
+   * only from `structure_dump_flags_for`, never from the caller.
+   */
   static async structureDump(
     configuration: DatabaseConfig | string | Record<string, unknown>,
     filename: string,
-    extraFlags?: string | string[] | null,
+    root?: string,
   ): Promise<void> {
     const config = this.resolveConfiguration(configuration);
-    const flags = extraFlags ?? this.structureDumpFlagsFor(config.adapter);
+    const flags = this.structureDumpFlagsFor(config.adapter);
     const handler = this.databaseAdapterFor(config);
     if (!handler.structureDump) {
       throw new Error(`Adapter '${config.adapter}' does not support structureDump`);
     }
-    await handler.structureDump(config, filename, flags);
+    await handler.structureDump(config, filename, flags, root);
   }
 
+  /** Mirrors: `structure_load` (`tasks/database_tasks.rb:369-374`). See {@link structureDump}. */
   static async structureLoad(
     configuration: DatabaseConfig | string | Record<string, unknown>,
     filename: string,
-    extraFlags?: string | string[] | null,
+    root?: string,
   ): Promise<void> {
     const config = this.resolveConfiguration(configuration);
-    const flags = extraFlags ?? this.structureLoadFlagsFor(config.adapter);
+    const flags = this.structureLoadFlagsFor(config.adapter);
     const handler = this.databaseAdapterFor(config);
     if (!handler.structureLoad) {
       throw new Error(`Adapter '${config.adapter}' does not support structureLoad`);
     }
-    await handler.structureLoad(config, filename, flags);
+    await handler.structureLoad(config, filename, flags, root);
   }
 
   /**
@@ -1547,15 +1555,23 @@ export interface DatabaseTaskHandler {
   truncateAll?(config: DatabaseConfig): Promise<void>;
   charset?(config: DatabaseConfig): Promise<string | null>;
   collation?(config: DatabaseConfig): Promise<string | null>;
+  /**
+   * `flags` is what `structure_dump_flags_for` computed and `root` is Ruby's
+   * leftover `*arguments`, which `database_adapter_for` forwards to the task
+   * constructor (`database_tasks.rb:566-572`). trails registers task
+   * singletons, so both reach the handler on the one call it gets.
+   */
   structureDump?(
     config: DatabaseConfig,
     filename: string,
-    extraFlags?: string | string[] | null,
+    flags?: string | string[] | null,
+    root?: string,
   ): Promise<void>;
   structureLoad?(
     config: DatabaseConfig,
     filename: string,
-    extraFlags?: string | string[] | null,
+    flags?: string | string[] | null,
+    root?: string,
   ): Promise<void>;
 }
 

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.ts
@@ -304,10 +304,10 @@ export class SQLiteDatabaseTasks {
       purge: async (config) => new SQLiteDatabaseTasks(config).purge(),
       charset: async (config) => new SQLiteDatabaseTasks(config).charset(),
       truncateAll: async (config) => new SQLiteDatabaseTasks(config).truncateAll(),
-      structureDump: async (config, filename, flags) =>
-        new SQLiteDatabaseTasks(config).structureDump(filename, flags),
-      structureLoad: async (config, filename, flags) =>
-        new SQLiteDatabaseTasks(config).structureLoad(filename, flags),
+      structureDump: async (config, filename, flags, root) =>
+        new SQLiteDatabaseTasks(config, root).structureDump(filename, flags),
+      structureLoad: async (config, filename, flags, root) =>
+        new SQLiteDatabaseTasks(config, root).structureLoad(filename, flags),
     });
   }
 }


### PR DESCRIPTION
Two convergence stories from RFC 0051, plus the evidence that closed a third from RFC 0061.

## `DatabaseTasks.structureDump` / `structureLoad` take the root

`database_tasks.rb:362-374` shifts `filename` off `*arguments` and forwards
what remains — the **root** — to the task constructor via `database_adapter_for`
(:566-572); the flags come only from `structure_dump_flags_for` /
`structure_load_flags_for` (:619-631). trails declared the trailing parameter
`extraFlags`, which made the root unreachable through the facade and let a
caller pre-empt the per-adapter Hash form.

The trailing parameter is now `root`. `databaseAdapterFor` returns registered
task *singletons* rather than task classes (the shape
`0023-surfaced-deviations/database-tasks-registry-holds-singletons-not-task-classes`
covers), so the handler gets `(config, filename, flags, root)` on the one call
it receives and constructs its task with the root — only `SQLiteDatabaseTasks`
takes one, matching `sqlite3_database_tasks.rb`. `DatabaseTasks.dumpSchema` was
already calling with two arguments and is unaffected; no caller passed flags
positionally.

The four ported tests now pass the `"/rails/root"` Rails passes at
`sqlite_rake_test.rb:182`, `:197`, `:223` and `:257`.

## `SchemaCreation#useForeignKeys` delegates

`use_foreign_keys?` is one of the `delegate ... to: :@conn` members
(`abstract/schema_creation.rb:16-21`); PR #6247 converged the rest of that
line and left this one as the sole inline reimplementation — a structural cast
plus a `?? true` optional-call arm Rails has no counterpart for, and a
duplicate of `foreign_keys_enabled?` inside the visitor.

It now delegates, `useForeignKeys` joins `SchemaCreationConn`, and the
connection's `useForeignKeys` is `supportsForeignKeys() &&
isForeignKeysEnabled()` exactly as `abstract/schema_statements.rb:1545-1547`
writes it (its own `typeof … === "function" ? … : true` guard goes too —
`AbstractAdapter` defines `supportsForeignKeys` at `abstract_adapter.rb`). The
byte-identical MySQL visitor override is deleted. The five mock adapters that
stand in for `@conn` gain the member.

**One mechanical rename, in its own commit** (`isUseForeignKeys` ->
`useForeignKeys`, 25 sites): the adapter-side member was already spelled
`isUseForeignKeys` before this PR, and reusing it for the new
`SchemaCreationConn` member would have left the delegated predicate diverging
from the story's stated converged shape. `use_foreign_keys?` is verb-led — the
same shape as every neighbour on `schema_creation.rb:16-21`'s `delegate` line,
none of which take an `is*` prefix — and `docs/ruby-ts-conventions.md:20`
reserves that prefix for the bare-noun fallback (`valid?` -> `isValid`). So
the name converges rather than the new member inheriting the old deviation.
`api:compare` and `api:calls` are byte-identical either side of the rename.

## `mysql-half-of-connection-handler-is-connected-flake` — closed, no code

Marked done against #5705; nothing was left to build.

Run [30601215884](https://github.com/blazetrailsdev/trails/actions/runs/30601215884)
ran at `efcc8bf`, on the branch that became #5705, and at that commit
`connection-handler.test.ts` read:

```ts
const config = new HashConfig("development", "primary", ambientPoolConfiguration());
handler.establishConnection(config, { owner: "primary" });
const pool = handler.retrieveConnectionPool("primary")!;
await pool.leaseConnection();          // <- no verify
expect(handler.isConnected("primary")).toBe(true);
```

The CI log pins the assertion to lines 528-531 of that file, not the current
539. That same commit had just switched the test off a hardcoded `sqlite3`
config onto `ambientPoolConfiguration()`, and checkout is lazy — a non-pinned
`leaseConnection()` does not verify. `SQLite3Adapter#isConnected` is
`this.driver?.isOpen()` over a driver opened eagerly, so it answered true;
`Mysql2Adapter#isConnected` is `_client !== null` over a socket that had not
been opened yet, so it answered false. That is the whole MariaDB half, and it
is why the failure was adapter-unique.

`78a236012` (#5705 itself) added the `.verifyBang()` the test carries today,
which is why it has not recurred. No MySQL-side divergence: `_ensureClient`
resolves from a non-null `_client`, from a same-generation in-flight promise,
or from a fresh connect that assigns `this._client = conn` before returning —
the only way it can answer with `_client` null is a concurrent generation bump
from `disconnectBang` / `reconnect` / `close`, and this test issues none.

## Rebased onto `ee8f6d386`

This PR previously carried a four-line `activemodel` fix for the `bigint`
`secFraction` arm, needed only because it broke `pnpm typecheck` on `main` and
so blocked every commit through the husky pre-commit. #6257 has since landed
the same fix, so the rebase drops it: the diff is now `activerecord`-only and
touches nothing outside the two stories.

Closes-story: database-tasks-structure-dump-trailing-arg-is-flags-not-root
Closes-story: schema-creation-use-foreign-keys-reimplements-the-delegated-predicate
