### PR TITLE
fix(activerecord,trailties): migration collaborators take only a pool; NullPool raises for string probe keys

### DIFF
--- a/packages/activerecord-cli/src/pending-migrations.ts
+++ b/packages/activerecord-cli/src/pending-migrations.ts
@@ -18,8 +18,8 @@ async function resolvePending(migrations: MigrationProxy[]): Promise<MigrationPr
     const migrator = new Migrator(
       "up",
       migrations,
-      new SchemaMigration(adapter),
-      new InternalMetadata(adapter),
+      new SchemaMigration(adapter.pool),
+      new InternalMetadata(adapter.pool),
     );
     pending = await migrator.pendingMigrationsReadOnly();
   });

--- a/packages/activerecord/src/active-record-schema.test.ts
+++ b/packages/activerecord/src/active-record-schema.test.ts
@@ -49,7 +49,7 @@ describe("ActiveRecordSchemaTest", () => {
   it("has primary key", async () => {
     const oldPrimaryKeyPrefixType = Base.primaryKeyPrefixType;
     Base.primaryKeyPrefixType = "table_name_with_underscore";
-    const schemaMigration = new SchemaMigration(adapter);
+    const schemaMigration = new SchemaMigration(adapter.pool);
     try {
       expect(schemaMigration.primaryKey).toBe("version");
 
@@ -107,14 +107,14 @@ describe("ActiveRecordSchemaTest", () => {
         await new Migrator(
           "up",
           [],
-          new SchemaMigration(adapter),
-          new InternalMetadata(adapter),
+          new SchemaMigration(adapter.pool),
+          new InternalMetadata(adapter.pool),
         ).currentVersion(),
       ).toBe(7);
     } finally {
       // Rails ensure: drop_table :nep_schema_migrations (dropTable resolves the
       // still-prefixed table name).
-      await new SchemaMigration(adapter).dropTable();
+      await new SchemaMigration(adapter.pool).dropTable();
       Base.tableNamePrefix = saved;
     }
   });

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/schema-migrations.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/schema-migrations.test.ts
@@ -43,7 +43,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
 
     it("initializes schema migrations for encoding utf8mb4", async () => {
       await withEncodingUtf8mb4(adapter, async () => {
-        const schemaMigration = new SchemaMigration(adapter);
+        const schemaMigration = new SchemaMigration(adapter.pool);
         const tableName = schemaMigration.tableName;
         await adapter.dropTable(tableName, { ifExists: true });
         await schemaMigration.createTable();
@@ -53,7 +53,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
 
     it("initializes internal metadata for encoding utf8mb4", async () => {
       await withEncodingUtf8mb4(adapter, async () => {
-        const internalMetadata = new InternalMetadata(adapter);
+        const internalMetadata = new InternalMetadata(adapter.pool);
         const tableName = internalMetadata.tableName;
         await adapter.dropTable(tableName, { ifExists: true });
         await internalMetadata.createTable();

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -173,14 +173,20 @@ export class NullPool implements AbstractPool {
    * (`abstract/connection_pool.rb:14-51`), so the send resolves up the ancestor
    * chain and answers a String rather than raising. JS has no `Object.prototype`
    * member of that name for `prop in target` to find, so the inherited method is
-   * declared here to keep the send answering. `Object#inspect` renders the class
-   * name and the instance variables; the `0x…` address it also prints is not
-   * reproducible and no caller reads it.
+   * declared here to keep the send answering.
+   *
+   * `Object#inspect` dumps the class name and every instance variable as
+   * `@name=value`. Ruby's NullPool carries two (`abstract/connection_pool.rb:24-28`)
+   * and this renders the one the port also carries. `@mutex` is absent rather
+   * than placeheld: JS has no thread to lock against, so the port has no such
+   * field, and printing a key for state that does not exist would be the larger
+   * divergence. The `0x…` address is dropped for the same reason
+   * `AbstractAdapter#inspect` has to synthesize its own — `object_id` has no
+   * counterpart — and no caller reads either.
    */
   inspect(): string {
-    return `#<ActiveRecord::ConnectionAdapters::NullPool server_version=${String(
-      this._serverVersion,
-    )}>`;
+    const v = this._serverVersion;
+    return `#<ActiveRecord::ConnectionAdapters::NullPool @server_version=${v == null ? "nil" : String(v)}>`;
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -149,7 +149,10 @@ export class NullPool implements AbstractPool {
    * spell a Ruby send, so `Symbol.iterator`/`Symbol.toPrimitive` and friends are
    * not sends NullPool is missing a method for and read through to `undefined`.
    * String keys get no such carve-out — `pool.then` and `pool.toJSON` are a
-   * NoMethodError in Ruby and are one here.
+   * NoMethodError in Ruby and are one here. What Ruby *does* answer, it answers
+   * through the ancestor chain: `to_s` arrives as `Object.prototype.toString`
+   * and so satisfies `prop in target`, and {@link inspect} is declared below for
+   * the same reason.
    */
   constructor() {
     return new Proxy(this, {
@@ -162,6 +165,22 @@ export class NullPool implements AbstractPool {
         );
       },
     });
+  }
+
+  /**
+   * Ruby's `Object#inspect`, which `NullPool` inherits: it defines no `inspect`
+   * of its own and overrides no `method_missing`
+   * (`abstract/connection_pool.rb:14-51`), so the send resolves up the ancestor
+   * chain and answers a String rather than raising. JS has no `Object.prototype`
+   * member of that name for `prop in target` to find, so the inherited method is
+   * declared here to keep the send answering. `Object#inspect` renders the class
+   * name and the instance variables; the `0x…` address it also prints is not
+   * reproducible and no caller reads it.
+   */
+  inspect(): string {
+    return `#<ActiveRecord::ConnectionAdapters::NullPool server_version=${String(
+      this._serverVersion,
+    )}>`;
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -145,20 +145,16 @@ export class NullPool implements AbstractPool {
    * Ruby does not override `method_missing`, so *every* send NullPool has no
    * method for raises — not a fixed set of names.
    *
-   * A symbol key and an {@link ADAPTER_PROXY_PROBE_KEYS} name are not Ruby sends
-   * but JS-only probes — thenable duck-typing, serializers, test matchers — and
-   * read through to `undefined` as they do on the adapter proxy. A NullPool is
-   * held as adapter state and by InternalMetadata / SchemaMigration, so a
-   * serializer walking a failing assertion's object graph reaches one; raising
-   * from its `then` or `toJSON` would replace the real failure with a
-   * NoMethodError from the reporter. Ruby's Object supplies `inspect` and `to_s`
-   * to its NullPool as well, so raising on those two would itself be the
-   * divergence.
+   * A symbol key is the one carve-out the language forces: a JS `Symbol` cannot
+   * spell a Ruby send, so `Symbol.iterator`/`Symbol.toPrimitive` and friends are
+   * not sends NullPool is missing a method for and read through to `undefined`.
+   * String keys get no such carve-out — `pool.then` and `pool.toJSON` are a
+   * NoMethodError in Ruby and are one here.
    */
   constructor() {
     return new Proxy(this, {
       get(target, prop, receiver) {
-        if (typeof prop === "symbol" || prop in target || ADAPTER_PROXY_PROBE_KEYS.has(prop)) {
+        if (typeof prop === "symbol" || prop in target) {
           return Reflect.get(target, prop, receiver);
         }
         throw new NoMethodError(

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-assume-migrated-upto-version-pool.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-assume-migrated-upto-version-pool.trails.test.ts
@@ -59,8 +59,8 @@ describe("SchemaStatements#assumeMigratedUptoVersion", () => {
     restore = pointPoolAt([VALID]);
     previousGlobalPaths = Migrator.migrationsPaths;
     Migrator.migrationsPaths = [OLD_AND_NEW_VERSIONS];
-    await new SchemaMigration(Base.connection).dropTable();
-    await new SchemaMigration(Base.connection).createTable();
+    await new SchemaMigration(Base.connection.pool).dropTable();
+    await new SchemaMigration(Base.connection.pool).createTable();
   });
 
   afterEach(() => {
@@ -70,7 +70,7 @@ describe("SchemaStatements#assumeMigratedUptoVersion", () => {
 
   it("backfills every known version up to the target through the pool's migration context", async () => {
     await assumeMigratedUptoVersion(3);
-    expect(await new SchemaMigration(Base.connection).integerVersions()).toEqual([1, 2, 3]);
+    expect(await new SchemaMigration(Base.connection.pool).integerVersions()).toEqual([1, 2, 3]);
   });
 
   it("does not re-insert a version the schema_migrations table already holds", async () => {
@@ -93,7 +93,7 @@ describe("SchemaStatements#assumeMigratedUptoVersion", () => {
   });
 
   it("reports no applied versions when schema_migrations does not exist", async () => {
-    await new SchemaMigration(Base.connection).dropTable();
+    await new SchemaMigration(Base.connection.pool).dropTable();
     expect(await Base.connectionPool().migrationContext.getAllVersions()).toEqual([]);
     expect(await Base.connectionPool().migrationContext.currentVersion()).toBe(0);
   });

--- a/packages/activerecord/src/connection-pool.trails.test.ts
+++ b/packages/activerecord/src/connection-pool.trails.test.ts
@@ -1178,11 +1178,23 @@ describe("NullPool member parity", () => {
     }
     expect(pool.dirtiesQueryCache).toBe(true);
     expect(pool.schemaCache).toBeNull();
-    // A JS-only probe is not a Ruby send: a serializer reaching a NullPool
-    // through adapter state must see a non-callable, not a NoMethodError.
+    // A JS-only probe name is a Ruby send too: `pool.then` is a NoMethodError
+    // in Ruby, so it is one here. Only a Symbol — which cannot spell a Ruby
+    // send at all — reads through alongside the members.
     for (const probe of ["then", "toJSON", "asymmetricMatch", "nodeType", "inspect"]) {
-      expect(pool[probe]).toBeUndefined();
+      expect(() => pool[probe]).toThrow(NoMethodError);
     }
     expect(pool.toString).toBe(Object.prototype.toString);
+    expect(pool[Symbol.toStringTag as unknown as string]).toBeUndefined();
+  });
+
+  it("lets a failing assertion whose subject holds a NullPool report its own failure", () => {
+    // The trap raising for every string send is only safe if no reporter walks
+    // a bare NullPool: a serializer that touched `then`/`toJSON` would replace
+    // the real failure with a NoMethodError of its own.
+    const adapter = new AbstractAdapter();
+    expect(() =>
+      expect({ pool: adapter.pool, n: 1 }).toEqual({ pool: adapter.pool, n: 2 }),
+    ).toThrow(/expected/i);
   });
 });

--- a/packages/activerecord/src/connection-pool.trails.test.ts
+++ b/packages/activerecord/src/connection-pool.trails.test.ts
@@ -1178,9 +1178,12 @@ describe("NullPool member parity", () => {
     }
     expect(pool.dirtiesQueryCache).toBe(true);
     expect(pool.schemaCache).toBeNull();
-    for (const probe of ["then", "toJSON", "asymmetricMatch", "nodeType", "inspect"]) {
+    for (const probe of ["then", "toJSON", "asymmetricMatch", "nodeType"]) {
       expect(() => pool[probe]).toThrow(NoMethodError);
     }
+    expect((pool.inspect as () => string)()).toMatch(
+      /^#<ActiveRecord::ConnectionAdapters::NullPool/,
+    );
     expect(pool.toString).toBe(Object.prototype.toString);
     expect(pool[Symbol.toStringTag as unknown as string]).toBeUndefined();
   });

--- a/packages/activerecord/src/connection-pool.trails.test.ts
+++ b/packages/activerecord/src/connection-pool.trails.test.ts
@@ -1178,9 +1178,6 @@ describe("NullPool member parity", () => {
     }
     expect(pool.dirtiesQueryCache).toBe(true);
     expect(pool.schemaCache).toBeNull();
-    // A JS-only probe name is a Ruby send too: `pool.then` is a NoMethodError
-    // in Ruby, so it is one here. Only a Symbol — which cannot spell a Ruby
-    // send at all — reads through alongside the members.
     for (const probe of ["then", "toJSON", "asymmetricMatch", "nodeType", "inspect"]) {
       expect(() => pool[probe]).toThrow(NoMethodError);
     }
@@ -1189,9 +1186,6 @@ describe("NullPool member parity", () => {
   });
 
   it("lets a failing assertion whose subject holds a NullPool report its own failure", () => {
-    // The trap raising for every string send is only safe if no reporter walks
-    // a bare NullPool: a serializer that touched `then`/`toJSON` would replace
-    // the real failure with a NoMethodError of its own.
     const adapter = new AbstractAdapter();
     expect(() =>
       expect({ pool: adapter.pool, n: 1 }).toEqual({ pool: adapter.pool, n: 2 }),

--- a/packages/activerecord/src/connection-pool.trails.test.ts
+++ b/packages/activerecord/src/connection-pool.trails.test.ts
@@ -1181,8 +1181,8 @@ describe("NullPool member parity", () => {
     for (const probe of ["then", "toJSON", "asymmetricMatch", "nodeType"]) {
       expect(() => pool[probe]).toThrow(NoMethodError);
     }
-    expect((pool.inspect as () => string)()).toMatch(
-      /^#<ActiveRecord::ConnectionAdapters::NullPool/,
+    expect((pool.inspect as () => string)()).toBe(
+      "#<ActiveRecord::ConnectionAdapters::NullPool @server_version=nil>",
     );
     expect(pool.toString).toBe(Object.prototype.toString);
     expect(pool[Symbol.toStringTag as unknown as string]).toBeUndefined();

--- a/packages/activerecord/src/internal-metadata.trails.test.ts
+++ b/packages/activerecord/src/internal-metadata.trails.test.ts
@@ -13,8 +13,6 @@ function fakeAdapter(defaultTimezone: string): DatabaseAdapter {
 
 type CurrentTimeHost = { currentTime(connection: DatabaseAdapter): string };
 
-// `currentTime` reads the connection it is handed, never the pool, so the
-// NullPool every pool-less adapter carries is enough to build one over.
 const metadataBuiltOverLocalAdapter = new InternalMetadata(
   new NullPool(),
 ) as unknown as CurrentTimeHost;

--- a/packages/activerecord/src/internal-metadata.trails.test.ts
+++ b/packages/activerecord/src/internal-metadata.trails.test.ts
@@ -4,18 +4,19 @@ import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { InternalMetadata } from "./internal-metadata.js";
 import { Base } from "./base.js";
 import { fixtures } from "./test-fixtures.js";
+import { NullPool } from "./connection-adapters/abstract/connection-pool.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 
 function fakeAdapter(defaultTimezone: string): DatabaseAdapter {
-  // `pool` is what the constructor discriminates an adapter on; a bare adapter
-  // carries a NullPool, and these cases only exercise `currentTime`.
-  return { defaultTimezone, pool: null } as unknown as DatabaseAdapter;
+  return { defaultTimezone } as unknown as DatabaseAdapter;
 }
 
 type CurrentTimeHost = { currentTime(connection: DatabaseAdapter): string };
 
+// `currentTime` reads the connection it is handed, never the pool, so the
+// NullPool every pool-less adapter carries is enough to build one over.
 const metadataBuiltOverLocalAdapter = new InternalMetadata(
-  fakeAdapter("local"),
+  new NullPool(),
 ) as unknown as CurrentTimeHost;
 
 function currentTime(defaultTimezone: string): string {

--- a/packages/activerecord/src/internal-metadata.ts
+++ b/packages/activerecord/src/internal-metadata.ts
@@ -66,12 +66,6 @@ export class NullInternalMetadata {
 
 export class InternalMetadata {
   private _pool: ConnectionPool | NullPool;
-  /**
-   * SEAM (delete in migration-collaborator-call-sites-pass-a-pool): the adapter
-   * an adapter-built instance was handed, kept because a `NullPool`-backed
-   * adapter cannot check a connection out.
-   */
-  private _fallbackAdapter?: DatabaseAdapter;
   readonly arelTable: Table;
 
   get primaryKey(): string {
@@ -92,18 +86,9 @@ export class InternalMetadata {
   /**
    * Mirrors `InternalMetadata#initialize` (`internal_metadata.rb:18-21`) — it
    * holds a pool.
-   *
-   * SEAM (delete in migration-collaborator-call-sites-pass-a-pool): the adapter
-   * arm. Every construction site still passes an adapter; given one, hold its
-   * pool and keep the adapter itself as the fallback connection.
    */
-  constructor(poolOrAdapter: ConnectionPool | NullPool | DatabaseAdapter) {
-    if ("pool" in poolOrAdapter) {
-      this._fallbackAdapter = poolOrAdapter;
-      this._pool = poolOrAdapter.pool;
-    } else {
-      this._pool = poolOrAdapter;
-    }
+  constructor(pool: ConnectionPool | NullPool) {
+    this._pool = pool;
     this.arelTable = new Table(this.tableName);
   }
 
@@ -111,8 +96,6 @@ export class InternalMetadata {
   private async _withConnection<T>(
     fn: (connection: DatabaseAdapter) => T | Promise<T>,
   ): Promise<T> {
-    // SEAM (delete in migration-collaborator-call-sites-pass-a-pool)
-    if (this._fallbackAdapter) return await fn(this._fallbackAdapter);
     return await (this._pool as ConnectionPool).withConnection(fn);
   }
 
@@ -245,14 +228,9 @@ export class InternalMetadata {
    * @internal
    */
   async tableExists(): Promise<boolean> {
-    // SEAM (delete in migration-collaborator-call-sites-pass-a-pool): a
-    // NullPool-backed adapter has no schema cache to read, so its connection
-    // stands in for one — it answers `dataSourceExists` the same way.
-    const schemaCache =
-      this._fallbackAdapter ??
-      ((this._pool as ConnectionPool).schemaCache as {
-        dataSourceExists(name: string): Promise<boolean | undefined>;
-      });
+    const schemaCache = (this._pool as ConnectionPool).schemaCache as {
+      dataSourceExists(name: string): Promise<boolean | undefined>;
+    };
     return (await schemaCache.dataSourceExists(this.tableName)) ?? false;
   }
 

--- a/packages/activerecord/src/migration-context.trails.test.ts
+++ b/packages/activerecord/src/migration-context.trails.test.ts
@@ -82,13 +82,13 @@ describe("MigrationContext connected surface", () => {
 
   beforeEach(async () => {
     const adapter = Base.connection;
-    const schemaMigration = new SchemaMigration(adapter);
+    const schemaMigration = new SchemaMigration(adapter.pool);
     await schemaMigration.createTable();
     await schemaMigration.deleteAllVersions();
     context = new MigrationContext(
       [`${MIGRATIONS_ROOT}/valid`],
       schemaMigration,
-      new InternalMetadata(adapter),
+      new InternalMetadata(adapter.pool),
     );
   });
 

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -123,7 +123,7 @@ afterEach(async () => {
     await adapter.dropTable(table, { ifExists: true });
   }
   try {
-    await new SchemaMigration(adapter).deleteAllVersions();
+    await new SchemaMigration(adapter.pool).deleteAllVersions();
   } catch {
     /* schema_migrations may not exist yet */
   }
@@ -201,8 +201,8 @@ describe("MigrationTest", () => {
     await new Migrator(
       "up",
       [migrateProxy(100, (m) => m.addColumn("people", "last_name", "string"))],
-      new SchemaMigration(adapter),
-      new InternalMetadata(adapter),
+      new SchemaMigration(adapter.pool),
+      new InternalMetadata(adapter.pool),
     ).migrate(100);
     expect(await personColumnNames(adapter)).toContain("last_name");
 
@@ -210,8 +210,8 @@ describe("MigrationTest", () => {
       new Migrator(
         "up",
         [migrateProxy(101, (m) => m.addColumn("people", "last_name", "string"))],
-        new SchemaMigration(adapter),
-        new InternalMetadata(adapter),
+        new SchemaMigration(adapter.pool),
+        new InternalMetadata(adapter.pool),
       ).migrate(101),
     ).rejects.toThrow();
   });
@@ -348,8 +348,8 @@ describe("MigrationTest", () => {
     await new Migrator(
       "up",
       [migrateProxy(100, (m) => m.addColumn("people", "last_name", "string"))],
-      new SchemaMigration(adapter),
-      new InternalMetadata(adapter),
+      new SchemaMigration(adapter.pool),
+      new InternalMetadata(adapter.pool),
     ).migrate(100);
     expect(await personColumnNames(adapter)).toContain("last_name");
 
@@ -361,8 +361,8 @@ describe("MigrationTest", () => {
           m.addColumn("people", "last_name", "string", { ifNotExists: true }),
         ),
       ],
-      new SchemaMigration(adapter),
-      new InternalMetadata(adapter),
+      new SchemaMigration(adapter.pool),
+      new InternalMetadata(adapter.pool),
     ).migrate(101);
     expect(await personColumnNames(adapter)).toContain("last_name");
   });
@@ -504,7 +504,7 @@ describe("MigrationTest", () => {
 
   it("schema migrations table name", async () => {
     const adapter = Base.connection;
-    const schemaMigration = new SchemaMigration(adapter);
+    const schemaMigration = new SchemaMigration(adapter.pool);
     const originalTableName = Base.schemaMigrationsTableName;
     const savedPrefix = Base.tableNamePrefix;
     const savedSuffix = Base.tableNameSuffix;
@@ -608,16 +608,16 @@ describe("MigrationTest", () => {
     await new Migrator(
       "up",
       [migrateProxy(100, (m) => m.addColumn("people", "last_name", "string"))],
-      new SchemaMigration(adapter),
-      new InternalMetadata(adapter),
+      new SchemaMigration(adapter.pool),
+      new InternalMetadata(adapter.pool),
     ).migrate(100);
     expect(await personColumnNames(adapter)).toContain("last_name");
 
     await new Migrator(
       "up",
       [migrateProxy(101, (m) => m.removeColumn("people", "last_name"))],
-      new SchemaMigration(adapter),
-      new InternalMetadata(adapter),
+      new SchemaMigration(adapter.pool),
+      new InternalMetadata(adapter.pool),
     ).migrate(101);
     expect(await personColumnNames(adapter)).not.toContain("last_name");
 
@@ -628,8 +628,8 @@ describe("MigrationTest", () => {
     const error: unknown = await new Migrator(
       "up",
       [migrateProxy(102, (m) => m.removeColumn("people", "last_name"))],
-      new SchemaMigration(adapter),
-      new InternalMetadata(adapter),
+      new SchemaMigration(adapter.pool),
+      new InternalMetadata(adapter.pool),
     )
       .migrate(102)
       .catch((e: unknown) => e);
@@ -653,11 +653,11 @@ describe("MigrationTest", () => {
   it("migration context with default schema migration", async () => {
     const migrationsPath = `${MIGRATIONS_ROOT}/valid`;
     const adapter = Base.connection;
-    const schemaMigration = new SchemaMigration(adapter);
+    const schemaMigration = new SchemaMigration(adapter.pool);
     const migrator = new MigrationContext(
       [migrationsPath],
       schemaMigration,
-      new InternalMetadata(adapter),
+      new InternalMetadata(adapter.pool),
     );
     await migrator.migrate();
 
@@ -675,11 +675,11 @@ describe("MigrationTest", () => {
   it("migrator versions", async () => {
     const migrationsPath = `${MIGRATIONS_ROOT}/valid`;
     const adapter = Base.connection;
-    const schemaMigration = new SchemaMigration(adapter);
+    const schemaMigration = new SchemaMigration(adapter.pool);
     const migrator = new MigrationContext(
       [migrationsPath],
       schemaMigration,
-      new InternalMetadata(adapter),
+      new InternalMetadata(adapter.pool),
     );
 
     await migrator.migrate();
@@ -699,8 +699,8 @@ describe("MigrationTest", () => {
     const adapter = await freshAdapterWithPeople();
     const migrator = new MigrationContext(
       [migrationsPath],
-      new SchemaMigration(adapter),
-      new InternalMetadata(adapter),
+      new SchemaMigration(adapter.pool),
+      new InternalMetadata(adapter.pool),
     );
     await migrator.migrate();
 
@@ -722,7 +722,7 @@ describe("MigrationTest", () => {
       "migrations",
       "valid",
     );
-    const schemaMigration = new SchemaMigration(adapter);
+    const schemaMigration = new SchemaMigration(adapter.pool);
     const migrator = new MigrationContext([migrationsPath], schemaMigration);
     try {
       await schemaMigration.dropTable();
@@ -743,16 +743,16 @@ describe("MigrationTest", () => {
           migration: () => anonymousMigration("First", 1),
         },
       ],
-      new SchemaMigration(adapter),
-      new InternalMetadata(adapter),
+      new SchemaMigration(adapter.pool),
+      new InternalMetadata(adapter.pool),
     );
     expect(withMigrations.migrations.length).toBeGreaterThan(0);
 
     const empty = new Migrator(
       "up",
       [],
-      new SchemaMigration(adapter),
-      new InternalMetadata(adapter),
+      new SchemaMigration(adapter.pool),
+      new InternalMetadata(adapter.pool),
     );
     expect(empty.migrations.length).toBe(0);
   });
@@ -769,8 +769,8 @@ describe("MigrationTest", () => {
     const migrator = new Migrator(
       "up",
       migrations,
-      new SchemaMigration(adapter),
-      new InternalMetadata(adapter),
+      new SchemaMigration(adapter.pool),
+      new InternalMetadata(adapter.pool),
     );
     expect(await migrator.currentVersion()).toBe(0);
     await migrator.migrate("20131219224947");
@@ -847,16 +847,16 @@ describe("MigrationTest", () => {
     await new Migrator(
       "up",
       [migrateProxy(100, (m) => m.addColumn("people", "last_name", "string"))],
-      new SchemaMigration(adapter),
-      new InternalMetadata(adapter),
+      new SchemaMigration(adapter.pool),
+      new InternalMetadata(adapter.pool),
     ).migrate(100);
     expect(await personColumnNames(adapter)).toContain("last_name");
 
     await new Migrator(
       "up",
       [migrateProxy(101, (m) => m.removeColumn("people", "last_name"))],
-      new SchemaMigration(adapter),
-      new InternalMetadata(adapter),
+      new SchemaMigration(adapter.pool),
+      new InternalMetadata(adapter.pool),
     ).migrate(101);
     expect(await personColumnNames(adapter)).not.toContain("last_name");
 
@@ -864,8 +864,8 @@ describe("MigrationTest", () => {
     await new Migrator(
       "up",
       [migrateProxy(102, (m) => m.removeColumn("people", "last_name", { ifExists: true }))],
-      new SchemaMigration(adapter),
-      new InternalMetadata(adapter),
+      new SchemaMigration(adapter.pool),
+      new InternalMetadata(adapter.pool),
     ).migrate(102);
     expect(await personColumnNames(adapter)).not.toContain("last_name");
   });
@@ -881,16 +881,16 @@ describe("MigrationTest", () => {
     await new Migrator(
       "up",
       [migrateProxy(100, (m) => m.addColumn("people", "last_name", type))],
-      new SchemaMigration(adapter),
-      new InternalMetadata(adapter),
+      new SchemaMigration(adapter.pool),
+      new InternalMetadata(adapter.pool),
     ).migrate(100);
     expect(await personColumnNames(adapter)).toContain("last_name");
 
     await new Migrator(
       "up",
       [migrateProxy(101, (m) => m.addColumn("people", "last_name", type, { ifNotExists: true }))],
-      new SchemaMigration(adapter),
-      new InternalMetadata(adapter),
+      new SchemaMigration(adapter.pool),
+      new InternalMetadata(adapter.pool),
     ).migrate(101);
     expect(await personColumnNames(adapter)).toContain("last_name");
   });
@@ -903,8 +903,8 @@ describe("MigrationTest", () => {
     await new Migrator(
       "up",
       [migrateProxy(100, (m) => m.addColumn("people", "last_name", "string"))],
-      new SchemaMigration(adapter),
-      new InternalMetadata(adapter),
+      new SchemaMigration(adapter.pool),
+      new InternalMetadata(adapter.pool),
     ).migrate(100);
     expect(await personColumnNames(adapter)).toContain("last_name");
 
@@ -915,8 +915,8 @@ describe("MigrationTest", () => {
           m.addColumn("people", "last_name", "boolean", { ifNotExists: true }),
         ),
       ],
-      new SchemaMigration(adapter),
-      new InternalMetadata(adapter),
+      new SchemaMigration(adapter.pool),
+      new InternalMetadata(adapter.pool),
     ).migrate(101);
     expect(await personColumnNames(adapter)).toContain("last_name");
   });
@@ -942,8 +942,8 @@ describe("MigrationTest", () => {
       migration.name === "ValidPeopleHaveLastNames";
     const migrator = new MigrationContext(
       [`${MIGRATIONS_ROOT}/valid`],
-      new SchemaMigration(adapter),
-      new InternalMetadata(adapter),
+      new SchemaMigration(adapter.pool),
+      new InternalMetadata(adapter.pool),
     );
     await migrator.migrate(null, nameFilter);
 
@@ -978,8 +978,8 @@ describe("MigrationTest", () => {
     const migrator = new Migrator(
       "up",
       migrations,
-      new SchemaMigration(adapter),
-      new InternalMetadata(adapter),
+      new SchemaMigration(adapter.pool),
+      new InternalMetadata(adapter.pool),
     );
     await expect(migrator.migrate()).rejects.toThrow("Something broke");
     // Migration should not be recorded as applied
@@ -1010,8 +1010,8 @@ describe("MigrationTest", () => {
       const migrator = new Migrator(
         "up",
         migrations,
-        new SchemaMigration(adapter),
-        new InternalMetadata(adapter),
+        new SchemaMigration(adapter.pool),
+        new InternalMetadata(adapter.pool),
       );
       await expect(migrator.migrate()).rejects.toThrow("Something broke");
       const versions = await migrator.getAllVersions();
@@ -1047,8 +1047,8 @@ describe("MigrationTest", () => {
     const migrator = new Migrator(
       "up",
       [proxy],
-      new SchemaMigration(adapter),
-      new InternalMetadata(adapter),
+      new SchemaMigration(adapter.pool),
+      new InternalMetadata(adapter.pool),
     );
     let err!: Error;
     try {
@@ -1078,8 +1078,8 @@ describe("MigrationTest", () => {
     const migrator = new Migrator(
       "up",
       [proxy],
-      new SchemaMigration(adapter),
-      new InternalMetadata(adapter),
+      new SchemaMigration(adapter.pool),
+      new InternalMetadata(adapter.pool),
     );
     let err!: Error;
     try {
@@ -1098,7 +1098,7 @@ describe("MigrationTest", () => {
   it("internal metadata table name", async () => {
     const adapter = Base.connection;
     const { InternalMetadata } = await import("./internal-metadata.js");
-    const internalMetadata = new InternalMetadata(adapter);
+    const internalMetadata = new InternalMetadata(adapter.pool);
     const originalTableName = Base.internalMetadataTableName;
     const savedPrefix = Base.tableNamePrefix;
     const savedSuffix = Base.tableNameSuffix;
@@ -1122,7 +1122,7 @@ describe("MigrationTest", () => {
   it("internal metadata stores environment when migration fails", async () => {
     const adapter = Base.connection;
     const { InternalMetadata } = await import("./internal-metadata.js");
-    const im = new InternalMetadata(adapter);
+    const im = new InternalMetadata(adapter.pool);
     await im.createTable();
 
     class FailingMigration extends Migration {
@@ -1139,8 +1139,8 @@ describe("MigrationTest", () => {
     const migrator = new Migrator(
       "up",
       [proxy],
-      new SchemaMigration(adapter),
-      new InternalMetadata(adapter),
+      new SchemaMigration(adapter.pool),
+      new InternalMetadata(adapter.pool),
     );
     await migrator.migrate().catch(() => {});
     const env = await im.get("environment");
@@ -1153,7 +1153,7 @@ describe("MigrationTest", () => {
   it("internal metadata stores environment when other data exists", async () => {
     const adapter = Base.connection;
     const { InternalMetadata } = await import("./internal-metadata.js");
-    const im = new InternalMetadata(adapter);
+    const im = new InternalMetadata(adapter.pool);
     await im.createTable();
     await im.set("custom_key", "custom_value");
 
@@ -1165,8 +1165,8 @@ describe("MigrationTest", () => {
     const migrator = new Migrator(
       "up",
       [proxy],
-      new SchemaMigration(adapter),
-      new InternalMetadata(adapter),
+      new SchemaMigration(adapter.pool),
+      new InternalMetadata(adapter.pool),
     );
     await migrator.migrate();
     expect(await im.get("environment")).toBe(envName(adapter));
@@ -1179,7 +1179,7 @@ describe("MigrationTest", () => {
 
     // migration_test.rb:727-730 — drop the table, then swap
     // `use_metadata_table: false` into the pool's db_config configuration_hash.
-    const im = new InternalMetadata(adapter);
+    const im = new InternalMetadata(adapter.pool);
     await im.dropTable();
 
     const { _setConfigurationHash } = await import("./database-configurations/database-config.js");
@@ -1199,8 +1199,8 @@ describe("MigrationTest", () => {
     const migrator = new Migrator(
       "up",
       [proxy],
-      new SchemaMigration(adapter),
-      new InternalMetadata(adapter),
+      new SchemaMigration(adapter.pool),
+      new InternalMetadata(adapter.pool),
     );
     try {
       await migrator.migrate();
@@ -1219,7 +1219,7 @@ describe("MigrationTest", () => {
   it("inserting a new entry into internal metadata", async () => {
     const adapter = Base.connection;
     const { InternalMetadata } = await import("./internal-metadata.js");
-    const im = new InternalMetadata(adapter);
+    const im = new InternalMetadata(adapter.pool);
     await im.createTable();
     try {
       await im.set("version", "foo");
@@ -1232,7 +1232,7 @@ describe("MigrationTest", () => {
   it("updating an existing entry into internal metadata", async () => {
     const adapter = Base.connection;
     const { InternalMetadata } = await import("./internal-metadata.js");
-    const im = new InternalMetadata(adapter);
+    const im = new InternalMetadata(adapter.pool);
     await im.createTable();
     await im.set("foo", "bar");
     await im.set("foo", "baz");
@@ -1246,7 +1246,7 @@ describe("MigrationTest", () => {
     // (no stale cache blocking re-creation) holds trivially in our implementation.
     const adapter = Base.connection;
     const { InternalMetadata } = await import("./internal-metadata.js");
-    const im = new InternalMetadata(adapter);
+    const im = new InternalMetadata(adapter.pool);
 
     // First transaction: create + write + commit
     await adapter.beginTransaction();
@@ -1280,7 +1280,7 @@ describe("MigrationTest", () => {
     // re-entrant across transactions. Verify that successive createTable() +
     // createVersion() pairs work correctly — the IF NOT EXISTS guard is idempotent.
     const adapter = Base.connection;
-    const sm = new SchemaMigration(adapter);
+    const sm = new SchemaMigration(adapter.pool);
 
     // First transaction: create + write + commit
     await adapter.beginTransaction();
@@ -1440,8 +1440,8 @@ describe("MigrationTest", () => {
     const migrator = new Migrator(
       "up",
       [],
-      new SchemaMigration(realAdapter),
-      new InternalMetadata(realAdapter),
+      new SchemaMigration(realAdapter.pool),
+      new InternalMetadata(realAdapter.pool),
     );
     const lockId = await migrator.generateMigratorAdvisoryLockId();
     const acquired = await (realAdapter as any).getAdvisoryLock(lockId);
@@ -1461,8 +1461,8 @@ describe("MigrationTest", () => {
     const migrator = new Migrator(
       "up",
       [],
-      new SchemaMigration(testAdapter),
-      new InternalMetadata(testAdapter),
+      new SchemaMigration(testAdapter.pool),
+      new InternalMetadata(testAdapter.pool),
     );
     const lockId = await migrator.generateMigratorAdvisoryLockId();
     // Must fit in a signed 63-bit integer
@@ -1491,8 +1491,8 @@ describe("MigrationTest", () => {
       const migrator = new Migrator(
         "up",
         [proxy],
-        new SchemaMigration(adapter),
-        new InternalMetadata(adapter),
+        new SchemaMigration(adapter.pool),
+        new InternalMetadata(adapter.pool),
       );
       await expect(migrator.migrate()).rejects.toThrow(ConcurrentMigrationError);
     } finally {
@@ -1522,8 +1522,8 @@ describe("MigrationTest", () => {
       const migrator = new Migrator(
         "up",
         [proxy],
-        new SchemaMigration(adapter),
-        new InternalMetadata(adapter),
+        new SchemaMigration(adapter.pool),
+        new InternalMetadata(adapter.pool),
       );
       await expect(migrator.run("up", 100)).rejects.toThrow(ConcurrentMigrationError);
     } finally {
@@ -1555,8 +1555,8 @@ describe("MigrationTest", () => {
         const migrator = new Migrator(
           "up",
           [proxy],
-          new SchemaMigration(realAdapter),
-          new InternalMetadata(realAdapter),
+          new SchemaMigration(realAdapter.pool),
+          new InternalMetadata(realAdapter.pool),
         );
         await migrator.migrate();
         expect(getSpy).toHaveBeenCalledTimes(1);
@@ -1585,8 +1585,8 @@ describe("MigrationTest", () => {
       const migrator = new Migrator(
         "up",
         [proxy],
-        new SchemaMigration(realAdapter),
-        new InternalMetadata(realAdapter),
+        new SchemaMigration(realAdapter.pool),
+        new InternalMetadata(realAdapter.pool),
         100,
       );
       const lockId = await migrator.generateMigratorAdvisoryLockId();

--- a/packages/activerecord/src/migration.trails.test.ts
+++ b/packages/activerecord/src/migration.trails.test.ts
@@ -74,7 +74,7 @@ describe("MigrationTest", () => {
     const adapter = Base.connection;
     // Nothing drops schema_migrations between tests, so start from a clean
     // versions table to assert currentVersion === 1.
-    await new SchemaMigration(adapter).dropTable();
+    await new SchemaMigration(adapter.pool).dropTable();
     const migrations: MigrationProxy[] = [
       {
         version: 1,
@@ -85,8 +85,8 @@ describe("MigrationTest", () => {
     const migrator = new Migrator(
       "up",
       migrations,
-      new SchemaMigration(adapter),
-      new InternalMetadata(adapter),
+      new SchemaMigration(adapter.pool),
+      new InternalMetadata(adapter.pool),
     );
     await migrator.migrate();
     expect(await migrator.currentVersion()).toBe(1);

--- a/packages/activerecord/src/migration/pending-migrations.test.ts
+++ b/packages/activerecord/src/migration/pending-migrations.test.ts
@@ -83,8 +83,8 @@ describe.skipIf(skip)("Migration", () => {
       const connection = await pool.leaseConnection();
       await new MigrationContext(
         pool.migrationsPaths,
-        new SchemaMigration(connection),
-        new InternalMetadata(connection),
+        new SchemaMigration(connection.pool),
+        new InternalMetadata(connection.pool),
       ).migrate();
       Migration.verbose = wasVerbose;
     };

--- a/packages/activerecord/src/migrator.test.ts
+++ b/packages/activerecord/src/migrator.test.ts
@@ -108,10 +108,10 @@ describe("MigratorTest", () => {
   // also stashes `@verbose_was` and its teardown restores it.
   beforeEach(async () => {
     adapter = Base.connection;
-    schemaMigration = new SchemaMigration(adapter);
+    schemaMigration = new SchemaMigration(adapter.pool);
     await schemaMigration.createTable();
     await schemaMigration.deleteAllVersions();
-    internalMetadata = new InternalMetadata(adapter);
+    internalMetadata = new InternalMetadata(adapter.pool);
     verboseWas = Migration.verbose;
   });
 

--- a/packages/activerecord/src/migrator.trails.test.ts
+++ b/packages/activerecord/src/migrator.trails.test.ts
@@ -75,8 +75,8 @@ let schemaMigration: SchemaMigration;
 let internalMetadata: InternalMetadata;
 
 beforeEach(async () => {
-  schemaMigration = new SchemaMigration(Base.connection);
-  internalMetadata = new InternalMetadata(Base.connection);
+  schemaMigration = new SchemaMigration(Base.connection.pool);
+  internalMetadata = new InternalMetadata(Base.connection.pool);
   await schemaMigration.dropTable();
   await internalMetadata.dropTable();
 });
@@ -96,7 +96,7 @@ describe("Migrator trails extensions", () => {
       internalMetadata,
     );
     await migrator.migrate();
-    const env = await new InternalMetadata(adapter).get("environment");
+    const env = await new InternalMetadata(adapter.pool).get("environment");
     expect(env).toBe(envName(adapter));
   });
 
@@ -117,7 +117,7 @@ describe("Migrator trails extensions", () => {
       set.mockRestore();
     }
     expect(environmentWrites).toBe(1);
-    expect(await new InternalMetadata(adapter).get("environment")).toBe(envName(adapter));
+    expect(await new InternalMetadata(adapter.pool).get("environment")).toBe(envName(adapter));
   });
 
   it("executeMigrationInTransaction skips migrations already in migrated", async () => {
@@ -131,8 +131,8 @@ describe("Migrator trails extensions", () => {
 
     // Called directly, so nothing has run `runnable()` / `_ensureSchemaTable()`
     // for us — the guards read `migrated`, which needs the table present.
-    await new SchemaMigration(adapter).createTable();
-    await new InternalMetadata(adapter).createTable();
+    await new SchemaMigration(adapter.pool).createTable();
+    await new InternalMetadata(adapter.pool).createTable();
 
     const up = new Migrator("up", [proxy], schemaMigration, internalMetadata);
     expect(await up.executeMigrationInTransaction(proxy)).toBe(1);
@@ -270,7 +270,7 @@ describe("Migrator trails extensions", () => {
       internalMetadata,
     );
     await migrator.migrate();
-    expect(await new InternalMetadata(adapter).get("environment")).toBeNull();
+    expect(await new InternalMetadata(adapter.pool).get("environment")).toBeNull();
   });
 
   it("CheckPending with a Migrator creates schema_migrations before reading it", async () => {
@@ -533,8 +533,8 @@ describe("Migrator advisory lock wrapping", () => {
     const migrator = new Migrator(
       "up",
       [],
-      new SchemaMigration(Base.connection),
-      new InternalMetadata(Base.connection),
+      new SchemaMigration(Base.connection.pool),
+      new InternalMetadata(Base.connection.pool),
     );
     withMigrationConnection(adapter);
     expect(migrator.isUseAdvisoryLock()).toBe(true);
@@ -548,8 +548,8 @@ describe("Migrator advisory lock wrapping", () => {
     const migrator = new Migrator(
       "up",
       [],
-      new SchemaMigration(Base.connection),
-      new InternalMetadata(Base.connection),
+      new SchemaMigration(Base.connection.pool),
+      new InternalMetadata(Base.connection.pool),
     );
     withMigrationConnection(adapter);
     expect(migrator.isUseAdvisoryLock()).toBe(false);
@@ -590,7 +590,7 @@ describe("Migrator advisory lock wrapping", () => {
     // Rails reads `down?` off the Migrator, so up and down are two Migrators.
     const up = new Migrator("up", [makeMigration(1, "M1")], schemaMigration, internalMetadata);
     const down = new Migrator("down", [makeMigration(1, "M1")], schemaMigration, internalMetadata);
-    await new SchemaMigration(adapter).createTable();
+    await new SchemaMigration(adapter.pool).createTable();
 
     expect(await up.migrated()).toEqual(new Set());
     await up.recordVersionStateAfterMigrating(1);

--- a/packages/activerecord/src/multi-db-migrator.test.ts
+++ b/packages/activerecord/src/multi-db-migrator.test.ts
@@ -65,10 +65,10 @@ describe("MultiDbMigratorTest", () => {
   beforeEach(async () => {
     adapterA = await Base.leaseConnection();
     adapterB = await ARUnit2Model.leaseConnection();
-    schemaMigrationA = new SchemaMigration(adapterA);
-    schemaMigrationB = new SchemaMigration(adapterB);
-    internalMetadataA = new InternalMetadata(adapterA);
-    internalMetadataB = new InternalMetadata(adapterB);
+    schemaMigrationA = new SchemaMigration(adapterA.pool);
+    schemaMigrationB = new SchemaMigration(adapterB.pool);
+    internalMetadataA = new InternalMetadata(adapterA.pool);
+    internalMetadataB = new InternalMetadata(adapterB.pool);
     await schemaMigrationA.createTable();
     await schemaMigrationB.createTable();
     await schemaMigrationA.deleteAllVersions();

--- a/packages/activerecord/src/multi-db-migrator.trails.test.ts
+++ b/packages/activerecord/src/multi-db-migrator.trails.test.ts
@@ -23,10 +23,10 @@ describe("MultiDbMigratorTest (trails)", () => {
   beforeEach(async () => {
     adapterA = await Base.leaseConnection();
     adapterB = await ARUnit2Model.leaseConnection();
-    schemaMigrationA = new SchemaMigration(adapterA);
-    schemaMigrationB = new SchemaMigration(adapterB);
-    internalMetadataA = new InternalMetadata(adapterA);
-    internalMetadataB = new InternalMetadata(adapterB);
+    schemaMigrationA = new SchemaMigration(adapterA.pool);
+    schemaMigrationB = new SchemaMigration(adapterB.pool);
+    internalMetadataA = new InternalMetadata(adapterA.pool);
+    internalMetadataB = new InternalMetadata(adapterB.pool);
     await schemaMigrationA.createTable();
     await schemaMigrationB.createTable();
     await schemaMigrationA.deleteAllVersions();

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -413,7 +413,7 @@ describe("SchemaDumperTest", () => {
     const { SchemaDumper: TopLevelDumper } = await import("./schema-dumper.js");
     const { SchemaMigration } = await import("./schema-migration.js");
     const adapter = Base.connection;
-    const sm = new SchemaMigration(adapter);
+    const sm = new SchemaMigration(adapter.pool);
     await sm.createTable();
     await sm.createVersion("20240601120000");
     const result = await TopLevelDumper.dumpWithVersion(adapter);

--- a/packages/activerecord/src/schema-dumper.trails.test.ts
+++ b/packages/activerecord/src/schema-dumper.trails.test.ts
@@ -274,8 +274,8 @@ describe("SchemaDumperAdapterTest", () => {
       await import("./connection-adapters/abstract/schema-dumper.js");
     const { SchemaMigration } = await import("./schema-migration.js");
     const { InternalMetadata } = await import("./internal-metadata.js");
-    await new SchemaMigration(adapter).createTable();
-    await new InternalMetadata(adapter).createTable();
+    await new SchemaMigration(adapter.pool).createTable();
+    await new InternalMetadata(adapter.pool).createTable();
     await adapter.createTable("reminders", {}, (t) => {
       t.string("name");
     });
@@ -289,7 +289,7 @@ describe("SchemaDumperAdapterTest", () => {
     const { SchemaDumper: TopLevelDumper } =
       await import("./connection-adapters/abstract/schema-dumper.js");
     const { SchemaMigration } = await import("./schema-migration.js");
-    const sm = new SchemaMigration(adapter);
+    const sm = new SchemaMigration(adapter.pool);
     await sm.createTable();
     await sm.deleteAllVersions();
     const result = await TopLevelDumper.dumpWithVersion(adapter);
@@ -300,7 +300,7 @@ describe("SchemaDumperAdapterTest", () => {
     const { SchemaDumper: TopLevelDumper } =
       await import("./connection-adapters/abstract/schema-dumper.js");
     const { SchemaMigration } = await import("./schema-migration.js");
-    const sm = new SchemaMigration(adapter);
+    const sm = new SchemaMigration(adapter.pool);
     await sm.createTable();
     // schema_migrations survives per-file truncation (truncate skips it by
     // design), so a prior run's version row can survive in the shared PG

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -524,7 +524,7 @@ export abstract class SchemaDumper {
     adapter: DatabaseAdapter,
     options: SchemaDumperOptions = {},
   ): Promise<string> {
-    const schemaMigration = new SchemaMigration(adapter);
+    const schemaMigration = new SchemaMigration(adapter.pool);
     let version = "0";
     if (await schemaMigration.tableExists()) {
       const versions = await schemaMigration.allVersions();

--- a/packages/activerecord/src/schema-migration.ts
+++ b/packages/activerecord/src/schema-migration.ts
@@ -47,29 +47,14 @@ export class NullSchemaMigration {
 
 export class SchemaMigration {
   private _pool: ConnectionPool | NullPool;
-  /**
-   * SEAM (delete in migration-collaborator-call-sites-pass-a-pool): the adapter
-   * an adapter-built instance was handed, kept because a `NullPool`-backed
-   * adapter cannot check a connection out.
-   */
-  private _fallbackAdapter?: DatabaseAdapter;
   readonly arelTable: Table;
 
   /**
    * Mirrors `SchemaMigration#initialize` (`schema_migration.rb:14-17`) — it
    * holds a pool.
-   *
-   * SEAM (delete in migration-collaborator-call-sites-pass-a-pool): the adapter
-   * arm. Every construction site still passes an adapter; given one, hold its
-   * pool and keep the adapter itself as the fallback connection.
    */
-  constructor(poolOrAdapter: ConnectionPool | NullPool | DatabaseAdapter) {
-    if ("pool" in poolOrAdapter) {
-      this._fallbackAdapter = poolOrAdapter;
-      this._pool = poolOrAdapter.pool;
-    } else {
-      this._pool = poolOrAdapter;
-    }
+  constructor(pool: ConnectionPool | NullPool) {
+    this._pool = pool;
     this.arelTable = new Table(this.tableName);
   }
 
@@ -77,20 +62,7 @@ export class SchemaMigration {
   private async _withConnection<T>(
     fn: (connection: DatabaseAdapter) => T | Promise<T>,
   ): Promise<T> {
-    // SEAM (delete in migration-collaborator-call-sites-pass-a-pool)
-    if (this._fallbackAdapter) return await fn(this._fallbackAdapter);
     return await (this._pool as ConnectionPool).withConnection(fn);
-  }
-
-  /**
-   * @internal The adapter this instance runs against. Rails holds `@pool` and
-   * exposes no such reader. It has no caller left in the repo — the story
-   * `migration-collaborator-call-sites-pass-a-pool` scopes its removal, so it
-   * is left here rather than deleted out from under that story.
-   */
-  get connection(): DatabaseAdapter {
-    // SEAM (delete in migration-collaborator-call-sites-pass-a-pool)
-    return this._fallbackAdapter!;
   }
 
   get primaryKey(): string {

--- a/packages/activerecord/src/schema.ts
+++ b/packages/activerecord/src/schema.ts
@@ -71,7 +71,7 @@ export class Schema extends Current {
     //   connection_pool.schema_migration.create_table
     //   connection.assume_migrated_upto_version(info[:version]) if info[:version]
     //   connection_pool.internal_metadata.create_table_and_set_flags(env)
-    const schemaMigration = new SchemaMigration(adapter);
+    const schemaMigration = new SchemaMigration(adapter.pool);
     await schemaMigration.createTable();
     if (info.version !== undefined) {
       // Go through SchemaStatements#assumeMigratedUptoVersion (reached
@@ -95,7 +95,7 @@ export class Schema extends Current {
       getEnv("TRAILS_ENV") ??
       getEnv("NODE_ENV") ??
       DatabaseConfigurations.defaultEnv;
-    const internalMetadata = new InternalMetadata(adapter);
+    const internalMetadata = new InternalMetadata(adapter.pool);
     await internalMetadata.createTableAndSetFlags(environment);
   }
 

--- a/packages/activerecord/src/support/canonical-schema-stamp.ts
+++ b/packages/activerecord/src/support/canonical-schema-stamp.ts
@@ -133,7 +133,7 @@ async function adapterSpecificHalf(adapter: DatabaseAdapter): Promise<string[]> 
  * @internal
  */
 export async function adapterSpecificTables(adapter: DatabaseAdapter): Promise<string[] | null> {
-  const metadata = new InternalMetadata(adapter);
+  const metadata = new InternalMetadata(adapter.pool);
   if (!(await metadata.tableExists())) return null;
   const raw = await metadata.get(ADAPTER_SPECIFIC_TABLES_KEY);
   if (raw == null || raw === "") return null;
@@ -169,7 +169,7 @@ export async function stampCanonicalSchema(
   laid?: readonly string[],
 ): Promise<void> {
   if (!runToken) return;
-  const metadata = new InternalMetadata(adapter);
+  const metadata = new InternalMetadata(adapter.pool);
   await metadata.createTableAndSetFlags("test", stampFor(runToken));
   const snapshot = laid ?? (await adapterSpecificHalf(adapter));
   const encoded = JSON.stringify([...snapshot].sort());
@@ -192,7 +192,7 @@ export async function stampCanonicalSchema(
 export async function canonicalSchemaUpToDate(adapter: DatabaseAdapter): Promise<boolean> {
   const runToken = getEnv(RUN_TOKEN_ENV);
   if (!runToken) return false;
-  const metadata = new InternalMetadata(adapter);
+  const metadata = new InternalMetadata(adapter.pool);
   if (!(await metadata.tableExists())) return false;
   return (await metadata.get("schema_sha1")) === stampFor(runToken);
 }

--- a/packages/activerecord/src/support/drop-all-tables.test.ts
+++ b/packages/activerecord/src/support/drop-all-tables.test.ts
@@ -55,6 +55,7 @@ describe("dropAllTables (PG connection-error retry, fake adapter)", () => {
         return [];
       }),
       executeMutation: vi.fn(async () => {}),
+      schemaCache: { clearBang() {} },
     } as unknown as DatabaseAdapter;
 
     await expect(dropAllTables(fakeAdapter)).resolves.toBeUndefined();
@@ -71,6 +72,7 @@ describe("dropAllTables (PG connection-error retry, fake adapter)", () => {
         throw appErr;
       }),
       executeMutation: vi.fn(async () => {}),
+      schemaCache: { clearBang() {} },
     } as unknown as DatabaseAdapter;
 
     await expect(dropAllTables(fakeAdapter)).rejects.toThrow(appErr);
@@ -96,6 +98,7 @@ describe("dropAllTables (PG connection-error retry, fake adapter)", () => {
         mutationCallCount++;
         if (mutationCallCount === 1) throw connErr;
       }),
+      schemaCache: { clearBang() {} },
     } as unknown as DatabaseAdapter;
 
     await expect(dropAllTables(fakeAdapter)).resolves.toBeUndefined();
@@ -213,7 +216,10 @@ describe("purge-only pre-snapshot path", () => {
     return { dropAllTablesModule, loadSchemaHelper };
   }
 
-  const inertAdapter = { adapterName: "none" } as unknown as DatabaseAdapter;
+  const inertAdapter = {
+    adapterName: "none",
+    schemaCache: { clearBang() {} },
+  } as unknown as DatabaseAdapter;
 
   // The sqlite arm lays its one table through createTable and nothing else, so
   // stubbing that member runs the arm without touching a database.

--- a/packages/activerecord/src/support/drop-all-tables.ts
+++ b/packages/activerecord/src/support/drop-all-tables.ts
@@ -164,6 +164,12 @@ async function resetTables(
       await resetSqliteTables(adapter, mode, bootLaid);
       break;
   }
+  // The drops here are raw `DROP TABLE` statements, not `SchemaStatements#drop_table`
+  // (`abstract/schema_statements.rb:485`), so nothing has cleared the pool's
+  // data-source cache — and `InternalMetadata#table_exists?` reads exactly that
+  // (`internal_metadata.rb:108-110`), so a stale entry reports a dropped
+  // `ar_internal_metadata` as present and the next read raises on the missing table.
+  adapter.schemaCache.clearBang();
 }
 
 /**

--- a/packages/activerecord/src/support/drop-all-tables.ts
+++ b/packages/activerecord/src/support/drop-all-tables.ts
@@ -148,6 +148,14 @@ export async function resetTestTables(adapter: DatabaseAdapter): Promise<void> {
 
 type ResetMode = "drop-all" | "reset";
 
+/**
+ * Drops or truncates per `mode`, then clears the pool's data-source cache: the
+ * drops are raw `DROP TABLE` statements rather than `SchemaStatements#drop_table`
+ * (`abstract/schema_statements.rb:485`), so nothing else invalidates the cache
+ * `InternalMetadata#table_exists?` reads (`internal_metadata.rb:108-110`) — a
+ * stale entry reports a dropped `ar_internal_metadata` as present and the next
+ * read raises on the missing table.
+ */
 async function resetTables(
   adapter: DatabaseAdapter,
   mode: ResetMode,
@@ -164,11 +172,6 @@ async function resetTables(
       await resetSqliteTables(adapter, mode, bootLaid);
       break;
   }
-  // The drops here are raw `DROP TABLE` statements, not `SchemaStatements#drop_table`
-  // (`abstract/schema_statements.rb:485`), so nothing has cleared the pool's
-  // data-source cache — and `InternalMetadata#table_exists?` reads exactly that
-  // (`internal_metadata.rb:108-110`), so a stale entry reports a dropped
-  // `ar_internal_metadata` as present and the next read raises on the missing table.
   adapter.schemaCache.clearBang();
 }
 

--- a/packages/activerecord/src/support/template-stamp.test.ts
+++ b/packages/activerecord/src/support/template-stamp.test.ts
@@ -18,8 +18,8 @@ import { describe, it, expect, vi } from "vitest";
 import "../sqlite/better-sqlite3.js";
 import { Base } from "../base.js";
 import { bootOutcome } from "./boot-outcome.js";
-import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adapter.js";
 import { InternalMetadata } from "../internal-metadata.js";
+import { newSqlitePool } from "./pooled-sqlite-adapter.js";
 import {
   canonicalSchemaStamp,
   canonicalSchemaUpToDate,
@@ -39,14 +39,14 @@ const sqliteActive = isSqliteRun() && !!templatePath && !!runToken;
 
 describe.skipIf(!sqliteActive)("sqlite template stamp", () => {
   it("the template file is stamped with the canonical schema SHA1", async () => {
-    const adapter = new BetterSQLite3Adapter(templatePath);
+    const pool = newSqlitePool(templatePath);
     try {
-      const metadata = new InternalMetadata(adapter);
+      const metadata = new InternalMetadata(pool);
       expect(await metadata.get("schema_sha1"), "template must carry the stamped schema_sha1").toBe(
         canonicalSchemaStamp(runToken),
       );
     } finally {
-      await adapter.close();
+      await pool.disconnectBang();
     }
   });
 });

--- a/packages/activerecord/src/tasks/database-tasks-rollback.trails.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks-rollback.trails.test.ts
@@ -49,7 +49,7 @@ describe("DatabaseTasksRollbackTest", () => {
     DatabaseTasks.registerMigrations([migration(3, "AnimalsOnly")], animals);
 
     await Base.establishConnection(primary);
-    const schemaMigration = new SchemaMigration(await Base.connectionPool().leaseConnection());
+    const schemaMigration = new SchemaMigration(Base.connectionPool());
     await schemaMigration.createTable();
     await schemaMigration.createVersion("2");
 
@@ -83,7 +83,7 @@ describe("DatabaseTasksRollbackTest", () => {
 
     DatabaseTasks.databaseConfiguration = null;
     await Base.establishConnection({ adapter: "sqlite3", database: ":memory:", pool: 1 });
-    const schemaMigration = new SchemaMigration(await Base.connectionPool().leaseConnection());
+    const schemaMigration = new SchemaMigration(Base.connectionPool());
     await schemaMigration.createTable();
     await schemaMigration.createVersion("1");
     await schemaMigration.createVersion("3");
@@ -111,7 +111,7 @@ describe("DatabaseTasksRollbackTest", () => {
 
     DatabaseTasks.databaseConfiguration = null;
     await Base.establishConnection({ adapter: "sqlite3", database: ":memory:", pool: 1 });
-    const schemaMigration = new SchemaMigration(await Base.connectionPool().leaseConnection());
+    const schemaMigration = new SchemaMigration(Base.connectionPool());
     await schemaMigration.createTable();
     await schemaMigration.createVersion("999");
 
@@ -138,7 +138,7 @@ describe("DatabaseTasksRollbackTest", () => {
 
     DatabaseTasks.databaseConfiguration = null;
     await Base.establishConnection({ adapter: "sqlite3", database: ":memory:", pool: 1 });
-    const schemaMigration = new SchemaMigration(await Base.connectionPool().leaseConnection());
+    const schemaMigration = new SchemaMigration(Base.connectionPool());
     await schemaMigration.createTable();
     await schemaMigration.createVersion("1");
 

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -1057,7 +1057,7 @@ describe("DatabaseTasksMigrateStatusTest", () => {
     if (skipMigrationTestCase) return;
     // Mirror Rails test setup: @schema_migration.create_table (database_tasks_test.rb:1169)
     const pool = Base.connectionPool();
-    await new SchemaMigration(await pool.leaseConnection()).createTable();
+    await new SchemaMigration(pool).createTable();
     DatabaseTasks.registerMigrations([
       {
         version: 1,

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -366,8 +366,8 @@ export class DatabaseTasks {
       }
     })(
       paths == null ? [] : Array.isArray(paths) ? paths : [paths],
-      new SchemaMigration(adapter),
-      new InternalMetadata(adapter),
+      new SchemaMigration(adapter.pool),
+      new InternalMetadata(adapter.pool),
     );
   }
 
@@ -381,8 +381,8 @@ export class DatabaseTasks {
     return new Migrator(
       "up",
       this._migrationsFor(dbConfig),
-      new SchemaMigration(adapter),
-      new InternalMetadata(adapter),
+      new SchemaMigration(adapter.pool),
+      new InternalMetadata(adapter.pool),
     );
   }
 
@@ -1055,7 +1055,7 @@ export class DatabaseTasks {
     try {
       const adapter = await this._migrationAdapter();
       const { InternalMetadata } = await import("../internal-metadata.js");
-      const metadata = new InternalMetadata(adapter);
+      const metadata = new InternalMetadata(adapter.pool);
       const sha1 = await this.schemaSha1(filename);
       await metadata.createTableAndSetFlags(config.envName, sha1);
     } catch (error) {
@@ -1392,7 +1392,7 @@ export class DatabaseTasks {
     }
 
     const { InternalMetadata } = await import("../internal-metadata.js");
-    const metadata = new InternalMetadata(adapter);
+    const metadata = new InternalMetadata(adapter.pool);
     if (!(await metadata.tableExists())) return false;
 
     const storedSha1 = await metadata.get("schema_sha1");
@@ -1441,7 +1441,7 @@ export class DatabaseTasks {
     }
 
     const { SchemaMigration } = await import("../schema-migration.js");
-    const migration = new SchemaMigration(adapter);
+    const migration = new SchemaMigration(adapter.pool);
     if (!(await migration.tableExists())) return;
 
     const versions = await migration.allVersions();
@@ -1662,7 +1662,7 @@ export async function initializeDatabase(dbConfig: DatabaseConfig): Promise<bool
         // Probe DB connectivity first — throws NoDatabaseError if the DB doesn't exist.
         // tableExists() swallows all errors internally so can't detect a missing DB.
         await adapter.execute("SELECT 1");
-        const sm = new SchemaMigration(adapter);
+        const sm = new SchemaMigration(adapter.pool);
         alreadyInitialized = await sm.tableExists();
         break;
       } catch (error) {

--- a/packages/activerecord/src/test-databases.test.ts
+++ b/packages/activerecord/src/test-databases.test.ts
@@ -289,7 +289,7 @@ describe("TestDatabasesTest", () => {
     // ensuring the table exists before the delete keeps both statements from
     // erroring inside the fixtures transaction (a failed DELETE would poison
     // the PG transaction with 25P02).
-    const schemaMigration = new SchemaMigration(adapter);
+    const schemaMigration = new SchemaMigration(adapter.pool);
     await schemaMigration.createTable();
     await schemaMigration.deleteVersion("1");
 
@@ -302,10 +302,10 @@ describe("TestDatabasesTest", () => {
     // `connection.pool.db_config.env_name`, so the stamp follows the pool the
     // adapter is checked out of, not any TRAILS_ENV/NODE_ENV reading.
     const adapter = Base.connection;
-    const schemaMigration = new SchemaMigration(adapter);
+    const schemaMigration = new SchemaMigration(adapter.pool);
     await schemaMigration.createTable();
     await schemaMigration.deleteVersion("1");
-    const internalMetadata = new InternalMetadata(adapter);
+    const internalMetadata = new InternalMetadata(adapter.pool);
     await internalMetadata.createTable();
     await internalMetadata.deleteAllEntries();
 

--- a/packages/activerecord/src/test-databases.ts
+++ b/packages/activerecord/src/test-databases.ts
@@ -27,8 +27,8 @@ export async function createAndMigrate(
     const migrator = new Migrator(
       "up",
       migrations,
-      new SchemaMigration(adapter),
-      new InternalMetadata(adapter),
+      new SchemaMigration(adapter.pool),
+      new InternalMetadata(adapter.pool),
     );
     await migrator.migrate();
   }

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -1465,6 +1465,7 @@ export class CreatePosts extends Migration {
 
     const dbFile = path.join(tmpDir, "disabled.sqlite3");
     const adapter = new BetterSQLite3Adapter(dbFile);
+    await establishMigrationConnection(adapter, dbFile);
     try {
       disableMetadataTable(adapter);
       const disabledMeta = new InternalMetadata(adapter.pool);

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -46,11 +46,14 @@ import * as os from "node:os";
 // (migration.rb:1036-1038, 1488-1491) — nothing pins an adapter to the
 // Migrator any more — so a case that drives a hand-built adapter has to
 // establish it as the migration pool's connection for the duration.
-async function establishMigrationConnection(adapter: unknown): Promise<void> {
+async function establishMigrationConnection(
+  adapter: unknown,
+  database = ":memory:",
+): Promise<void> {
   const { Base, HashConfig } = await import("@blazetrails/activerecord");
   const config = new HashConfig("test", "primary", {
     adapter: "sqlite3",
-    database: ":memory:",
+    database,
   });
   const pool = Base.connectionHandler.establishConnection(config, {
     owner: Base,
@@ -747,8 +750,8 @@ export class CreatePosts extends Migration {
     );
 
     const migrations = await discoverMigrations(tmpDir);
-    const schemaMigration = new SchemaMigration(adapter);
-    const internalMetadata = new InternalMetadata(adapter);
+    const schemaMigration = new SchemaMigration(adapter.pool);
+    const internalMetadata = new InternalMetadata(adapter.pool);
     const migrator = new Migrator("up", migrations, schemaMigration, internalMetadata);
     // `rollback` lives on MigrationContext (`migration.rb:1240-1242`); it reads
     // the same bookkeeping tables, over the same discovered migration list.
@@ -815,8 +818,8 @@ export class CreateComments extends Migration {
     const migrator = migrationContextFor(
       tmpDir,
       migrations,
-      new SchemaMigration(adapter),
-      new InternalMetadata(adapter),
+      new SchemaMigration(adapter.pool),
+      new InternalMetadata(adapter.pool),
     );
 
     // `MigrationContext#forward` is `move(:up, steps)` (`migration.rb:1244`),
@@ -859,8 +862,8 @@ export class CreatePosts extends Migration {
     const migrator = new Migrator(
       "up",
       migrations,
-      new SchemaMigration(adapter),
-      new InternalMetadata(adapter),
+      new SchemaMigration(adapter.pool),
+      new InternalMetadata(adapter.pool),
     );
 
     expect(await migrator.currentVersion()).toBe(0);
@@ -887,8 +890,8 @@ export class CreateWidgets extends Migration {
     const migrator = new Migrator(
       "up",
       migrations,
-      new SchemaMigration(adapter),
-      new InternalMetadata(adapter),
+      new SchemaMigration(adapter.pool),
+      new InternalMetadata(adapter.pool),
     );
 
     await migrator.run("up", "20260101000000");
@@ -912,8 +915,8 @@ export class CreateWidgets extends Migration {
     const migrator = new Migrator(
       "up",
       [],
-      new SchemaMigration(adapter),
-      new InternalMetadata(adapter),
+      new SchemaMigration(adapter.pool),
+      new InternalMetadata(adapter.pool),
     );
     await expect(migrator.run("up", "99999999999999")).rejects.toBeInstanceOf(
       UnknownMigrationVersionError,
@@ -939,8 +942,8 @@ export class CreatePosts extends Migration {
     const migrator = new Migrator(
       "up",
       migrations,
-      new SchemaMigration(adapter),
-      new InternalMetadata(adapter),
+      new SchemaMigration(adapter.pool),
+      new InternalMetadata(adapter.pool),
     );
 
     expect((await migrator.pendingMigrations()).length).toBe(1);
@@ -1296,12 +1299,13 @@ export class CreatePosts extends Migration {
 
     const dbFile = path.join(tmpDir, "prod.sqlite3");
     const adapter = new BetterSQLite3Adapter(dbFile);
+    await establishMigrationConnection(adapter, dbFile);
     try {
-      const internalMetadata = new InternalMetadata(adapter);
+      const internalMetadata = new InternalMetadata(adapter.pool);
       // Rails' last_stored_environment returns nil at current_version == 0, so
       // record a version (as database_tasks_test.rb does) to make the DB stamped.
-      await new SchemaMigration(adapter).createTable();
-      await new SchemaMigration(adapter).createVersion("1");
+      await new SchemaMigration(adapter.pool).createTable();
+      await new SchemaMigration(adapter.pool).createVersion("1");
       await internalMetadata.createTable();
       await internalMetadata.set("environment", "production");
     } finally {
@@ -1340,12 +1344,13 @@ export class CreatePosts extends Migration {
 
     const dbFile = path.join(tmpDir, "staging.sqlite3");
     const adapter = new BetterSQLite3Adapter(dbFile);
+    await establishMigrationConnection(adapter, dbFile);
     try {
-      const internalMetadata = new InternalMetadata(adapter);
+      const internalMetadata = new InternalMetadata(adapter.pool);
       // Rails' last_stored_environment returns nil at current_version == 0, so
       // record a version (as database_tasks_test.rb does) to make the DB stamped.
-      await new SchemaMigration(adapter).createTable();
-      await new SchemaMigration(adapter).createVersion("1");
+      await new SchemaMigration(adapter.pool).createTable();
+      await new SchemaMigration(adapter.pool).createVersion("1");
       await internalMetadata.createTable();
       await internalMetadata.set("environment", "staging");
     } finally {
@@ -1376,12 +1381,13 @@ export class CreatePosts extends Migration {
 
     const dbFile = path.join(tmpDir, "prod2.sqlite3");
     const adapter = new BetterSQLite3Adapter(dbFile);
+    await establishMigrationConnection(adapter, dbFile);
     try {
-      const internalMetadata = new InternalMetadata(adapter);
+      const internalMetadata = new InternalMetadata(adapter.pool);
       // Rails' last_stored_environment returns nil at current_version == 0, so
       // record a version (as database_tasks_test.rb does) to make the DB stamped.
-      await new SchemaMigration(adapter).createTable();
-      await new SchemaMigration(adapter).createVersion("1");
+      await new SchemaMigration(adapter.pool).createTable();
+      await new SchemaMigration(adapter.pool).createVersion("1");
       await internalMetadata.createTable();
       await internalMetadata.set("environment", "production");
     } finally {
@@ -1415,11 +1421,12 @@ export class CreatePosts extends Migration {
 
     const dbFile = path.join(tmpDir, "fresh.sqlite3");
     const adapter = new BetterSQLite3Adapter(dbFile);
+    await establishMigrationConnection(adapter, dbFile);
     const previousProtected = Base.protectedEnvironments;
     Base.protectedEnvironments = ["production"];
     try {
-      const internalMetadata = new InternalMetadata(adapter);
-      const context = new MigrationContext([], new SchemaMigration(adapter), internalMetadata);
+      const internalMetadata = new InternalMetadata(adapter.pool);
+      const context = new MigrationContext([], new SchemaMigration(adapter.pool), internalMetadata);
       // No environment stamped yet → false even though the current env is
       // in the protected list. Matches Rails' protected_environment? ==
       // nil semantics.
@@ -1429,8 +1436,8 @@ export class CreatePosts extends Migration {
       expect(await internalMetadata.tableExists()).toBe(false);
 
       // After stamping as production, the check reflects the protected state.
-      await new SchemaMigration(adapter).createTable();
-      await new SchemaMigration(adapter).createVersion("1");
+      await new SchemaMigration(adapter.pool).createTable();
+      await new SchemaMigration(adapter.pool).createVersion("1");
       await internalMetadata.createTable();
       await internalMetadata.set("environment", "production");
       expect(await context.protectedEnvironment()).toBe(true);
@@ -1460,7 +1467,7 @@ export class CreatePosts extends Migration {
     const adapter = new BetterSQLite3Adapter(dbFile);
     try {
       disableMetadataTable(adapter);
-      const disabledMeta = new InternalMetadata(adapter);
+      const disabledMeta = new InternalMetadata(adapter.pool);
       expect(disabledMeta.enabled).toBe(false);
 
       // createTable + createTableAndSetFlags silently no-op (Rails'
@@ -1510,8 +1517,8 @@ export class CreatePosts extends Migration {
       const migrator = new Migrator(
         "up",
         migrations,
-        new SchemaMigration(adapter),
-        new InternalMetadata(adapter),
+        new SchemaMigration(adapter.pool),
+        new InternalMetadata(adapter.pool),
       );
 
       // Migrate should succeed and NOT throw EnvironmentStorageError
@@ -1529,8 +1536,8 @@ export class CreatePosts extends Migration {
       // lastStoredEnvironment short-circuits to null when disabled.
       const context = new MigrationContext(
         [],
-        new SchemaMigration(adapter),
-        new InternalMetadata(adapter),
+        new SchemaMigration(adapter.pool),
+        new InternalMetadata(adapter.pool),
       );
       expect(await context.lastStoredEnvironment()).toBeNull();
     } finally {
@@ -1545,10 +1552,11 @@ export class CreatePosts extends Migration {
 
     const dbFile = path.join(tmpDir, "stale-metadata.sqlite3");
     const adapter = new BetterSQLite3Adapter(dbFile);
+    await establishMigrationConnection(adapter, dbFile);
     try {
       // Seed a real metadata table + environment value with a separate
       // enabled=true instance.
-      const enabledMeta = new InternalMetadata(adapter);
+      const enabledMeta = new InternalMetadata(adapter.pool);
       await enabledMeta.createTable();
       await enabledMeta.set("environment", "production");
       disableMetadataTable(adapter);
@@ -1556,8 +1564,8 @@ export class CreatePosts extends Migration {
       // Disabled context should still report null (no stale read).
       const context = new MigrationContext(
         [],
-        new SchemaMigration(adapter),
-        new InternalMetadata(adapter),
+        new SchemaMigration(adapter.pool),
+        new InternalMetadata(adapter.pool),
       );
       expect(await context.lastStoredEnvironment()).toBeNull();
       expect(await context.protectedEnvironment()).toBe(false);
@@ -1577,10 +1585,11 @@ export class CreatePosts extends Migration {
 
     const dbFile = path.join(tmpDir, "truncate.sqlite3");
     const seedAdapter = new BetterSQLite3Adapter(dbFile);
+    await establishMigrationConnection(seedAdapter, dbFile);
     try {
       await seedAdapter.executeMutation("CREATE TABLE posts (id INTEGER PRIMARY KEY, title TEXT)");
       await seedAdapter.executeMutation("INSERT INTO posts (title) VALUES ('a'), ('b')");
-      await new InternalMetadata(seedAdapter).createTableAndSetFlags("development");
+      await new InternalMetadata(seedAdapter.pool).createTableAndSetFlags("development");
       await seedAdapter.executeMutation(
         "CREATE TABLE IF NOT EXISTS schema_migrations (version VARCHAR NOT NULL PRIMARY KEY)",
       );

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -382,8 +382,8 @@ function createMigrator(
   return new Migrator(
     "up",
     migrations,
-    new SchemaMigration(adapter),
-    new InternalMetadata(adapter),
+    new SchemaMigration(adapter.pool),
+    new InternalMetadata(adapter.pool),
   );
 }
 
@@ -600,8 +600,8 @@ async function withMigrationTasksForDb(
     const migrator = new Migrator(
       "up",
       migrations,
-      new SchemaMigration(ctx.adapter),
-      new InternalMetadata(ctx.adapter),
+      new SchemaMigration(ctx.adapter.pool),
+      new InternalMetadata(ctx.adapter.pool),
     );
     opts.afterPending((await migrator.pendingMigrations()).length);
   }
@@ -662,8 +662,8 @@ async function runMigrateAll(targetVersion: string | null): Promise<void> {
           const migrator = new Migrator(
             "up",
             migrations,
-            new SchemaMigration(adapter),
-            new InternalMetadata(adapter),
+            new SchemaMigration(adapter.pool),
+            new InternalMetadata(adapter.pool),
           );
           const pending = await migrator.pendingMigrations();
           if (pending.length === 0) console.log(`${prefix}All migrations are up to date.`);
@@ -787,7 +787,7 @@ export function dbCommand(): Command {
     .action(async (opts: DatabaseOpts) => {
       await forEachDatabase(opts, async ({ adapter, prefix }) => {
         const envName = resolveEnv();
-        const internalMetadata = new InternalMetadata(adapter);
+        const internalMetadata = new InternalMetadata(adapter.pool);
         if (!internalMetadata.enabled) {
           const { EnvironmentStorageError } = await import("@blazetrails/activerecord");
           throw new EnvironmentStorageError();

--- a/packages/website/src/lib/frontiers/trail-cli.ts
+++ b/packages/website/src/lib/frontiers/trail-cli.ts
@@ -151,8 +151,8 @@ export function createTrailCLI(deps: TrailCliDeps) {
     const migrator = new Migrator(
       "up",
       proxies,
-      new SchemaMigration(adapter),
-      new InternalMetadata(adapter),
+      new SchemaMigration(adapter.pool),
+      new InternalMetadata(adapter.pool),
     );
     // Migration output goes to stdout (Rails' Migration#write is `puts`), and
     // the browser has no process — so the shim's stdout is pointed at this


### PR DESCRIPTION
Two of the three bundled stories. The third,
`date-temporal-default-return-and-ruby-opt-in`, is **released back to the
backlog** — see the note at the bottom.

## `nullpool-trap-carves-out-string-probe-keys`

`NullPool`'s `get` trap consulted `ADAPTER_PROXY_PROBE_KEYS` — a dozen string
names — alongside symbol keys. Ruby's `NullPool`
(`activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:24-48`)
defines a fixed member set and overrides no `method_missing`, so `pool.then`
and `pool.toJSON` are a `NoMethodError` there and are one here now. The trap
reads through for `typeof prop === "symbol"` (a JS `Symbol` cannot spell a Ruby
send — the one carve-out the language forces) and `prop in target`, nothing
else. The set itself stays, still consulted by the adapter proxy at
`connection-pool.ts:531`, which has the raw-connection dispatch problem it was
written for.

The carve-out's stated reason was that a vitest failure serializer walking a
failing assertion's object graph reaches a `NullPool` held as adapter state.
That is now pinned as a test rather than assumed: `connection-pool.trails.test.ts`
asserts a deliberately failing assertion whose subject holds a `NullPool` still
reports its own failure.

## `migration-collaborator-call-sites-pass-a-pool`

`SchemaMigration` and `InternalMetadata` take only a `ConnectionPool | NullPool`,
as in Ruby (`schema_migration.rb:14-17`, `internal_metadata.rb:18-21`). Gone:
the adapter-accepting constructor arm, `_fallbackAdapter`, its `_withConnection`
arm, the `tableExists` schema-cache stand-in, `SchemaMigration#connection`, and
both `SEAM` comments. Every construction site in `packages/` and `scripts/`
passes a pool.

The sites that held a bare `new BetterSQLite3Adapter(...)`, and so a `NullPool`
that cannot check a connection out, get a real pool:

- `trailties/src/commands/db.test.ts` — the file's own
  `establishMigrationConnection`, now parameterised by database rather than
  hardcoding `:memory:`.
- `activerecord/src/support/template-stamp.test.ts` — `newSqlitePool`, the
  existing standalone-pool helper.

One production-adjacent fix fell out. `resetTables`
(`support/drop-all-tables.ts`) issues raw `DROP TABLE` statements rather than
`SchemaStatements#drop_table` (`abstract/schema_statements.rb:485`), so nothing
cleared the pool's data-source cache — and `InternalMetadata#table_exists?` now
reads exactly that cache (`internal_metadata.rb:108-110`) instead of the
seam's live-connection stand-in. A stale entry reported a dropped
`ar_internal_metadata` as present and the next read raised on the missing
table. `resetTables` clears the cache.

## Verification

`pnpm typecheck` clean. `pnpm api:calls` clean (no new baseline rows).
`pnpm api:extra` — no new surface; `SchemaMigration#connection` was extra
surface and is deleted. `pnpm test:compare` / `pnpm api:compare` unmoved.
Locally green: `support/`, `tasks/`, `migration/`, `trailties`,
`activerecord-cli`, the migrator/schema/schema-dumper/test-databases files and
both collaborator test files.

## Story 1 released, not shipped

`date-temporal-default-return-and-ruby-opt-in` needs `Date.parse`/`civil`/`jd`/
`ordinal`/`commercial` and `DateTime.parse` to answer `Temporal`, which moves
135 call sites in `packages/date/src/date.trails.test.ts` alone plus the
`date.ts` return types and three consumer test files. Measured against the
526 LOC here, that does not fit under the 700 ceiling, and it carries a design
decision (the opt-in mechanism) that deserves its own review. Released with
`pnpm tasks release` so it can be claimed on its own.

Closes-story: nullpool-trap-carves-out-string-probe-keys
Closes-story: migration-collaborator-call-sites-pass-a-pool
