### PR TITLE
test(activerecord): pin SQLiteDatabaseTasks#purge's rescue clause; NullPool declares no schemaMigration/internalMetadata

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -131,6 +131,17 @@ export class NullPool implements AbstractPool {
   declare readonly shard: never;
 
   /**
+   * Same shape and same reason as `role`/`shard` above. Ruby's NullPool answers
+   * neither `schema_migration` nor `internal_metadata`
+   * (`abstract/connection_pool.rb:14-51`), so `#truncate_tables`' bare
+   * `pool.schema_migration.table_name` (`abstract/database_statements.rb:222-223`)
+   * raises NoMethodError on a pool-less adapter rather than truncating against
+   * a hardcoded default.
+   */
+  declare readonly schemaMigration: never;
+  declare readonly internalMetadata: never;
+
+  /**
    * Mirrors: ConnectionPool::NullPool#initialize
    * (`abstract/connection_pool.rb:24-28`).
    *

--- a/packages/activerecord/src/tasks/sqlite-database-tasks-purge.trails.test.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks-purge.trails.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Trails-only cover for `SQLiteDatabaseTasks#purge`
+ * (`sqlite_database_tasks.rb:30-37`). Rails' own `sqlite_rake_test.rb` is not
+ * in the vendored tree, so there is no test to port; what is pinned here is the
+ * single behavior the rescue clause decides. Ruby rescues `NoDatabaseError` and
+ * nothing else, so a `drop` that fails for any other reason propagates, and the
+ * `ensure` runs `create` on that path too.
+ *
+ * `drop` and `create` are stubbed so the assertions land on the rescue clause
+ * rather than on file I/O; `create` is counted because Ruby's `ensure` runs it
+ * on every path, including the raising one.
+ */
+import { describe, it, expect } from "vitest";
+import { SQLiteDatabaseTasks } from "./sqlite-database-tasks.js";
+import { NoDatabaseError } from "../errors.js";
+import { HashConfig } from "../database-configurations/hash-config.js";
+
+describe("SQLiteDatabaseTasks#purge", () => {
+  function tasksWith(dropError: Error): { tasks: SQLiteDatabaseTasks; created: () => number } {
+    const configuration = new HashConfig("development", "primary", {
+      adapter: "sqlite3",
+      database: ":memory:",
+    });
+    const tasks = new SQLiteDatabaseTasks(configuration);
+    let created = 0;
+    Object.assign(tasks, {
+      drop: async () => {
+        throw dropError;
+      },
+      create: async () => {
+        created += 1;
+      },
+      connection: async () => ({
+        disconnectBang: () => {},
+        whenClosed: async () => {},
+        reconnectBang: async () => {},
+      }),
+    });
+    return { tasks, created: () => created };
+  }
+
+  it("swallows NoDatabaseError and still creates", async () => {
+    const { tasks, created } = tasksWith(new NoDatabaseError("no such database"));
+    await expect(tasks.purge()).resolves.toBeUndefined();
+    expect(created()).toBe(1);
+  });
+
+  it("propagates every other error and still creates", async () => {
+    const { tasks, created } = tasksWith(Object.assign(new Error("EACCES"), { code: "EACCES" }));
+    await expect(tasks.purge()).rejects.toThrow("EACCES");
+    expect(created()).toBe(1);
+  });
+});


### PR DESCRIPTION
Follow-up to #6264, which merged while this PR was in review.

### What happened

Two workers were spawned for the same five-story bundle. #6264 (opened ~28
minutes after this branch was claimed) shipped the date story plus the same
three ActiveRecord convergences this PR carried, and merged first. Its versions
are equal or better — in particular its `purge` adds
`await connection.whenClosed()` to drain the async driver close before the
unlink (#1269), which this PR's version dropped when it removed the old
`pool.disconnect()`.

So the three duplicated convergences are **gone from this PR**; they are marked
done against #6264, which is the PR that actually shipped them. What is left is
the two things #6264 did not carry.

### 1. `purge` had no cover

`SQLiteDatabaseTasks#purge` is now `sqlite_database_tasks.rb:30-37`, but nothing
exercises it — `database-tasks.test.ts` stubs the task out at the registry, and
Rails' own `sqlite_rake_test.rb` is not in the vendored tree, so there is nothing
to port. This adds a trails-only test pinning the one thing the rescue clause
decides: `NoDatabaseError` is swallowed and every other class propagates, with
the `ensure`'s `create` running on both paths.

Both arms would have failed before #6264 — the old body had no `ensure`, so
`create` was skipped whenever an error propagated.

### 2. `NullPool` doesn't say it lacks the two readers

`truncateTables` now sends `pool.schemaMigration.tableName` /
`pool.internalMetadata.tableName` bare, which is what makes a pool-less adapter
raise instead of truncating against a hardcoded default. That works at runtime —
`NullPool`'s Proxy throws `NoMethodError` for any missing string key — but the
`ConnectionPool | NullPool` union doesn't record the absence, and Ruby's NullPool
defines neither reader (`abstract/connection_pool.rb:14-51`).

Declaring them `never` follows the `role`/`shard` precedent already in that file,
added for exactly this reason: `declare` keeps the member out of the emitted
class, so it really is absent and the Proxy still raises.

### Verification

`pnpm typecheck`, `pnpm lint` clean. 82 tests green across
`sqlite-database-tasks-purge.trails.test.ts` and `database-statements.test.ts`.
No baseline or allowlist changes — #6264 already deleted the two converged
`purge` call-mismatch rows and the file's unreviewed mark.

No `Closes-story` trailers: the three stories are closed by #6264.
