### PR TITLE
fix(date,activerecord): Date.parse answers a bare PlainDate; count projects Arel Count; PG decodes int8 as a number

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/integer.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/integer.test.ts
@@ -50,14 +50,16 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     it("integer types", async () => {
       // Verify that int2, int4, and int8 columns all come back through
-      // the pg driver as strings (int8) or numbers (int2/int4) as expected.
+      // the pg driver as numbers, int8 narrowing to a bigint past the
+      // safe-integer range.
       await adapter.executeMutation(`INSERT INTO "pg_int_types" DEFAULT VALUES`);
       const rows = await adapter.execute(`SELECT * FROM "pg_int_types"`);
       expect(typeof rows[0].small).toBe("number");
       expect(typeof rows[0].medium).toBe("number");
-      // pg-types returns int8 as string to avoid precision loss
-      expect(typeof rows[0].big).toBe("string");
-      expect(BigInt(rows[0].big as string)).toBe(9007199254740993n);
+      // The default is one past Number.MAX_SAFE_INTEGER, so the connection's
+      // int8 parser keeps it a bigint rather than truncating it onto a float.
+      expect(typeof rows[0].big).toBe("bigint");
+      expect(rows[0].big).toBe(9007199254740993n);
     });
 
     it("schema properly respects bigint ranges", async () => {

--- a/packages/activerecord/src/connection-adapters/postgresql/temporal-type-parsers.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/temporal-type-parsers.test.ts
@@ -18,6 +18,7 @@ const OID_TIME = 1083;
 const OID_TIMESTAMP = 1114;
 const OID_TIMESTAMPTZ = 1184;
 const OID_TIMETZ = 1266;
+const OID_INT8 = 20;
 
 function parse(oid: number, value: string): unknown {
   const parser = getTypeParser(oid, "text");
@@ -95,6 +96,21 @@ describe("getTypeParser — binary format", () => {
   it("delegates binary format to pg built-ins (always returns a function)", () => {
     expect(typeof getTypeParser(OID_TIMESTAMPTZ, "binary")).toBe("function");
     expect(typeof getTypeParser(OID_DATE, "binary")).toBe("function");
+  });
+});
+
+describe("getTypeParser — int8 (OID 20)", () => {
+  it("returns a number for a count(*) value", () => {
+    expect(parse(OID_INT8, "3")).toBe(3);
+  });
+
+  it("returns a bigint past the safe-integer range rather than truncating", () => {
+    expect(parse(OID_INT8, "9223372036854775807")).toBe(9223372036854775807n);
+    expect(parse(OID_INT8, "-9223372036854775808")).toBe(-9223372036854775808n);
+  });
+
+  it("returns a number at the safe-integer boundary", () => {
+    expect(parse(OID_INT8, String(Number.MAX_SAFE_INTEGER))).toBe(Number.MAX_SAFE_INTEGER);
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/postgresql/temporal-type-parsers.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/temporal-type-parsers.ts
@@ -1,5 +1,6 @@
 /**
- * Per-connection Temporal type parsers for the pg driver.
+ * Per-connection type parsers for the pg driver — the Temporal ones, plus
+ * `int8`.
  *
  * pg's default OID parsers decode timestamp/date columns into JS Date
  * objects, losing microsecond precision. By passing `{ types: { getTypeParser } }`
@@ -34,15 +35,38 @@ const OID_TIMESTAMP_ARRAY = 1115;
 const OID_TIMESTAMPTZ_ARRAY = 1185;
 const OID_TIMETZ_ARRAY = 1270;
 
+// `int8` (bigint), which `count(*)` also answers. pg's built-in text parser
+// leaves it a String because a 64-bit integer does not fit a JS number, so
+// every `select_values` reader of a numeric column answered `"3"` on PG and `3`
+// on sqlite/mysql. Rails has no such split: the pg gem's own type map decodes
+// int8 to an Integer, which is why `SchemaMigration#count` /
+// `InternalMetadata#count` are `select_values(...).first` with no coercion
+// (`schema_migration.rb:91-98`, `internal_metadata.rb:64-71`).
+const OID_INT8 = 20;
+
 // Text-format parsers receive strings; binary-format parsers receive Buffer.
 type PgParser = (value: string | Buffer) => unknown;
 
 const passthrough: PgParser = (v) => v;
 
-const TEMPORAL_PARSERS: ReadonlyMap<number, PgParser> = new Map<number, PgParser>([
+/**
+ * Decodes an `int8` the way `IntegerType#narrowBigInt` does: a safe-range value
+ * is a plain JS `number`, and a genuine bignum past float64's exact-integer
+ * range stays a `bigint` rather than truncating onto the nearest float.
+ * `BigIntegerType#castValue` accepts both, so this is the same contract
+ * better-sqlite3 and mysql2 already hand the type layer.
+ */
+const parseInt8: PgParser = (v) => {
+  const value = BigInt(v as string);
+  const num = Number(value);
+  return Number.isSafeInteger(num) ? num : value;
+};
+
+const CONNECTION_PARSERS: ReadonlyMap<number, PgParser> = new Map<number, PgParser>([
   [OID_TIMESTAMPTZ, (v) => parsePostgresInstant(v as string)],
   [OID_TIMESTAMP, (v) => parsePostgresTimestampAsInstant(v as string)],
   [OID_DATE, (v) => parsePostgresDate(v as string)],
+  [OID_INT8, parseInt8],
   [OID_DATE_ARRAY, passthrough],
   [OID_TIME_ARRAY, passthrough],
   [OID_TIMESTAMP_ARRAY, passthrough],
@@ -75,7 +99,7 @@ export function makeGetTypeParser(pgTypes: {
   return function getTypeParser(oid: number, format?: string): PgParser {
     const fmt = format || "text";
     if (fmt === "text") {
-      const parser = TEMPORAL_PARSERS.get(oid);
+      const parser = CONNECTION_PARSERS.get(oid);
       if (parser) return parser;
     }
     return pgTypes.getTypeParser(oid, fmt as "text" | "binary") as PgParser;

--- a/packages/activerecord/src/connection-adapters/postgresql/temporal-type-parsers.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/temporal-type-parsers.ts
@@ -35,13 +35,14 @@ const OID_TIMESTAMP_ARRAY = 1115;
 const OID_TIMESTAMPTZ_ARRAY = 1185;
 const OID_TIMETZ_ARRAY = 1270;
 
-// `int8` (bigint), which `count(*)` also answers. pg's built-in text parser
-// leaves it a String because a 64-bit integer does not fit a JS number, so
-// every `select_values` reader of a numeric column answered `"3"` on PG and `3`
-// on sqlite/mysql. Rails has no such split: the pg gem's own type map decodes
-// int8 to an Integer, which is why `SchemaMigration#count` /
-// `InternalMetadata#count` are `select_values(...).first` with no coercion
-// (`schema_migration.rb:91-98`, `internal_metadata.rb:64-71`).
+// `int8` (bigint), which `count(*)` also answers. pg leaves it a String because
+// a 64-bit integer does not fit a JS number, so `select_values` answered "3" on
+// PG and 3 elsewhere; the pg gem's type map decodes it to an Integer, which is
+// why Rails' counts are `select_values(...).first` with no coercion
+// (`schema_migration.rb:91-98`, `internal_metadata.rb:64-71`). Decoded the way
+// `IntegerType#narrowBigInt` does — safe range as a `number`, a genuine bignum
+// as a `bigint` rather than truncated onto the nearest float — which is the
+// contract better-sqlite3 and mysql2 already hand the type layer.
 const OID_INT8 = 20;
 
 // Text-format parsers receive strings; binary-format parsers receive Buffer.
@@ -49,13 +50,6 @@ type PgParser = (value: string | Buffer) => unknown;
 
 const passthrough: PgParser = (v) => v;
 
-/**
- * Decodes an `int8` the way `IntegerType#narrowBigInt` does: a safe-range value
- * is a plain JS `number`, and a genuine bignum past float64's exact-integer
- * range stays a `bigint` rather than truncating onto the nearest float.
- * `BigIntegerType#castValue` accepts both, so this is the same contract
- * better-sqlite3 and mysql2 already hand the type layer.
- */
 const parseInt8: PgParser = (v) => {
   const value = BigInt(v as string);
   const num = Number(value);

--- a/packages/activerecord/src/internal-metadata.ts
+++ b/packages/activerecord/src/internal-metadata.ts
@@ -196,21 +196,18 @@ export class InternalMetadata {
    * `internal_metadata.rb:64-71`. Rails ends the body in `.first`; Ruby's `Enumerable#first` has no JS
    * array counterpart, so the single value is read as `values[0]`.
    *
-   * `select_values` hands back the driver's raw value and node-postgres renders
-   * `count(*)`'s int8 (OID 20) as a String, so the `Number` coercion is
-   * load-bearing on PG rather than stylistic. `COUNT(*)` always yields exactly
-   * one row, and Rails' `.first` would answer `nil` for an empty set, not zero,
-   * so there is no `?? 0` fallback.
+   * `COUNT(*)` always yields exactly one row, and Rails' `.first` would answer
+   * `nil` for an empty set, not zero, so there is no `?? 0` fallback.
    *
    * @missingRailsCall first — Enumerable#first; a JS array indexes as values[0].
    */
   async count(): Promise<number> {
     const sm = new SelectManager(this.arelTable);
-    sm.project(new Nodes.NamedFunction("COUNT", [star]).as("cnt"));
+    sm.project(new Nodes.Count([star]));
     const values = await this._withConnection((connection) =>
       connection.selectValues(sm, `${this.constructor.name} Count`),
     );
-    return Number(values[0]);
+    return values[0] as number;
   }
 
   /**

--- a/packages/activerecord/src/internal-metadata.ts
+++ b/packages/activerecord/src/internal-metadata.ts
@@ -199,6 +199,12 @@ export class InternalMetadata {
    * `COUNT(*)` always yields exactly one row, and Rails' `.first` would answer
    * `nil` for an empty set, not zero, so there is no `?? 0` fallback.
    *
+   * PG's `int8` decode answers a `bigint` past `Number.MAX_SAFE_INTEGER`, so
+   * the value is a `number` here only because neither `schema_migrations` nor
+   * `ar_internal_metadata` can hold 2^53 rows. Ruby's Integer is arbitrary
+   * precision and needs no such reading; this carries the bignum under a
+   * `number` the way `IntegerType#narrowBigInt` (`integer.ts:218-221`) does.
+   *
    * @missingRailsCall first — Enumerable#first; a JS array indexes as values[0].
    */
   async count(): Promise<number> {

--- a/packages/activerecord/src/schema-migration.ts
+++ b/packages/activerecord/src/schema-migration.ts
@@ -148,6 +148,12 @@ export class SchemaMigration {
    * `COUNT(*)` always yields exactly one row, and Rails' `.first` would answer
    * `nil` for an empty set, not zero, so there is no `?? 0` fallback.
    *
+   * PG's `int8` decode answers a `bigint` past `Number.MAX_SAFE_INTEGER`, so
+   * the value is a `number` here only because neither `schema_migrations` nor
+   * `ar_internal_metadata` can hold 2^53 rows. Ruby's Integer is arbitrary
+   * precision and needs no such reading; this carries the bignum under a
+   * `number` the way `IntegerType#narrowBigInt` (`integer.ts:218-221`) does.
+   *
    * @missingRailsCall first — Enumerable#first; a JS array indexes as values[0].
    */
   async count(): Promise<number> {

--- a/packages/activerecord/src/schema-migration.ts
+++ b/packages/activerecord/src/schema-migration.ts
@@ -145,21 +145,18 @@ export class SchemaMigration {
    * `schema_migration.rb:91-98`. Rails ends the body in `.first`; Ruby's `Enumerable#first` has no JS
    * array counterpart, so the single value is read as `values[0]`.
    *
-   * `select_values` hands back the driver's raw value and node-postgres renders
-   * `count(*)`'s int8 (OID 20) as a String, so the `Number` coercion is
-   * load-bearing on PG rather than stylistic. `COUNT(*)` always yields exactly
-   * one row, and Rails' `.first` would answer `nil` for an empty set, not zero,
-   * so there is no `?? 0` fallback.
+   * `COUNT(*)` always yields exactly one row, and Rails' `.first` would answer
+   * `nil` for an empty set, not zero, so there is no `?? 0` fallback.
    *
    * @missingRailsCall first — Enumerable#first; a JS array indexes as values[0].
    */
   async count(): Promise<number> {
     const sm = new SelectManager(this.arelTable);
-    sm.project(new Nodes.NamedFunction("COUNT", [star]).as("cnt"));
+    sm.project(new Nodes.Count([star]));
     const values = await this._withConnection((connection) =>
       connection.selectValues(sm, `${this.constructor.name} Count`),
     );
-    return Number(values[0]);
+    return values[0] as number;
   }
 
   // Rails: connection.data_source_exists?(table_name) (schema_migration.rb:100-104).

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -29,7 +29,7 @@ const gemDate = (str: string, comp?: boolean) => dNewByFrags(RubyDate._parse(str
 const gemDateTime = (str: string, comp?: boolean) => dtNewByFrags(RubyDate._parse(str, comp));
 
 /** The `y-mm-dd` a date names, for a one-line assertion. */
-function ymd(date: RubyDate | Temporal.PlainDate | Temporal.PlainDateTime): string {
+function ymd(date: RubyDate | Temporal.PlainDate): string {
   const mon = date instanceof RubyDate ? date.mon : date.month;
   return `${date.year}-${String(mon).padStart(2, "0")}-${String(date.day).padStart(2, "0")}`;
 }

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -3881,19 +3881,8 @@ export class Date {
    * which is `Date._strptime` followed by `d_new_by_frags`. `start` is the
    * calendar reform, which `Temporal.PlainDate` has no bearer for, so it is not
    * a parameter here.
-   *
-   * The union return is TypeScript's static-side variance, not the port's
-   * shape: Ruby's `DateTime < Date` makes `datetime_s_strptime`'s DateTime a
-   * covariant override, while `Temporal.PlainDateTime` is not a subtype of
-   * `Temporal.PlainDate` (it answers no `toPlainDateTime`/`toPlainYearMonth`/
-   * `toPlainMonthDay`), so a `PlainDate`-only declaration here makes the
-   * {@link DateTime} override illegal (TS2417). This only ever answers a
-   * `PlainDate`.
    */
-  static strptime(
-    str = JULIAN_EPOCH_DATE,
-    fmt = "%F",
-  ): Temporal.PlainDate | Temporal.PlainDateTime {
+  static strptime(str = JULIAN_EPOCH_DATE, fmt = "%F"): Temporal.PlainDate {
     return dNewByFrags(Date._strptime(str, fmt)).toDate();
   }
 
@@ -3980,16 +3969,8 @@ export class Date {
    *
    * A string that named only a time of day answers no arm of
    * {@link rtValidDateFragsP} and raises.
-   *
-   * The union return is TypeScript's static-side variance, not the port's
-   * shape: Ruby's `DateTime < Date` makes `datetime_s_parse`'s DateTime a
-   * covariant override, while `Temporal.PlainDateTime` is not a subtype of
-   * `Temporal.PlainDate` (it answers no `toPlainDateTime`/`toPlainYearMonth`/
-   * `toPlainMonthDay`), so a `PlainDate`-only declaration here makes the
-   * {@link DateTime} override illegal (TS2417). This only ever answers a
-   * `PlainDate`.
    */
-  static parse(str: string, comp = true): Temporal.PlainDate | Temporal.PlainDateTime {
+  static parse(str: string, comp = true): Temporal.PlainDate {
     return dNewByFrags(Date._parse(str, comp)).toDate();
   }
 
@@ -4097,6 +4078,32 @@ export class Date {
 }
 
 /**
+ * @internal Ruby's `DateTime < Date` makes `datetime_s_parse` /
+ * `datetime_s_strptime` covariant overrides of the `::Date` ones
+ * (`date_core.c`), because `::DateTime` is a `::Date`. TypeScript has no such
+ * covariance available: `Temporal.PlainDateTime` is not a subtype of
+ * `Temporal.PlainDate` (it answers no
+ * `toPlainDateTime`/`toPlainYearMonth`/`toPlainMonthDay`), so
+ * `class DateTime extends Date` is rejected as TS2417 — "Class static side
+ * 'typeof DateTime' incorrectly extends base class static side 'typeof Date'"
+ * — the moment the two sides disagree on the return type. Neither a
+ * `this`-parameter, a `this`-keyed generic return, nor assigning the statics as
+ * module-level functions (the trails mixin idiom) sidesteps the check: TS
+ * compares the two static sides whatever shape the member takes.
+ *
+ * So `DateTime` extends `Date` under an alias whose STATIC side omits the two
+ * members it re-declares, which is the only shape that removes the comparison
+ * without weakening either declaration. This is a type-level alias only — the
+ * value is `Date` itself, so the runtime prototype chain, `instanceof`, and
+ * every inherited static are unchanged, and the instance side is `Date` intact.
+ * Both `Date.parse`/`Date.strptime` and `DateTime.parse`/`DateTime.strptime`
+ * therefore declare exactly what they answer.
+ */
+const DateWithoutParseStatics: (new (year?: number, month?: number, day?: number) => Date) &
+  (new (rjd: Temporal.PlainDate) => Date) &
+  Omit<typeof Date, "parse" | "strptime"> = Date;
+
+/**
  * @noRailsEquivalent PERMANENT — the `ruby/date` gem's `::DateTime`, a `::Date`
  * that also answers `hour`, `min` and `sec`. Defined in C
  * (`vendor/date/ext/date/date_core.c`), so it is outside `api:compare`'s
@@ -4105,7 +4112,7 @@ export class Date {
  * `time.formats` (i18n/lib/i18n/backend/base.rb:105-115), while `%Z` keeps
  * `::Date`'s offset spelling rather than `::Time`'s `"UTC"`.
  */
-export class DateTime extends Date {
+export class DateTime extends DateWithoutParseStatics {
   /**
    * @internal `ComplexDateData`'s fields (`date_core.c:215-231`): the day and
    * the day-fraction, both **in UTC**, and `of`, the offset in seconds east of
@@ -4299,7 +4306,7 @@ export class DateTime extends Date {
    * `datetime_s_parse` → `dt_new_by_frags`), which is `Date.parse`'s
    * `Date._parse` followed by the DateTime-shaped build.
    */
-  static override parse(str: string, comp = true): Temporal.PlainDateTime {
+  static parse(str: string, comp = true): Temporal.PlainDateTime {
     return dtNewByFrags(Date._parse(str, comp)).toDatetime();
   }
 
@@ -4322,7 +4329,7 @@ export class DateTime extends Date {
    * calendar reform, which `Temporal.PlainDate` has no bearer for, so it is not
    * a parameter here.
    */
-  static override strptime(str = JULIAN_EPOCH_DATETIME, fmt = "%FT%T%z"): Temporal.PlainDateTime {
+  static strptime(str = JULIAN_EPOCH_DATETIME, fmt = "%FT%T%z"): Temporal.PlainDateTime {
     return dtNewByFrags(Date._strptime(str, fmt)).toDatetime();
   }
 


### PR DESCRIPTION
Three related fidelity fixes.

**`Date.parse` / `Date.strptime` answer a bare `Temporal.PlainDate`.** They were
declared `PlainDate | PlainDateTime` purely so `DateTime`'s statics stayed a
legal override: Ruby's `DateTime < Date` makes `datetime_s_parse` a covariant
override (`date_core.c`), and TS has no such covariance because
`Temporal.PlainDateTime` is not a subtype of `Temporal.PlainDate`. Shapes tried
and rejected — a `this`-parameter (already established in #6264), a `this`-keyed
generic return, and assigning the statics as module-level functions (the trails
mixin idiom): TS compares the two static sides whatever shape the member takes
and reports TS2417 for all three. What works is `DateTime` extending a
**type-level** `Date` alias whose static side omits the two members it
re-declares — the value is `Date` itself, so the prototype chain, `instanceof`
and every inherited static are unchanged. Both classes now declare exactly what
they answer, and `date.trails.test.ts`'s `ymd` helper drops its widened
parameter.

**`SchemaMigration#count` / `InternalMetadata#count` project `Arel::Nodes::Count`.**
Rails builds `sm.project(*Arel::Nodes::Count.new([Arel.star]))`
(`schema_migration.rb:91-93`, `internal_metadata.rb:64-66`); trails used
`NamedFunction("COUNT", …)` under an invented `.as("cnt")` alias. `Nodes.Count`
already exists in `packages/arel` with a `to_sql` visitor, so both bodies now
project it bare and the emitted SQL carries no `AS cnt`.

**PG decodes `int8` as a number.** node-postgres renders `int8` (OID 20) as a
String, so every `select_values` reader of a numeric column answered `"3"` on PG
and `3` on sqlite/mysql — which is why both `count` bodies carried a `Number()`
coercion Rails does not have (the pg gem's own type map decodes int8 to an
Integer). The per-connection parser table now decodes it the way
`IntegerType#narrowBigInt` does: a safe-range value as a plain `number`, a
genuine bignum as a `bigint` rather than truncating onto the nearest float —
the same contract better-sqlite3 and mysql2 already hand the type layer. Both
coercions and their call-site justifications are gone.

`move-adapter-specific-snapshot-off-ar-internal-metadata` was claimed with this
bundle and released unbuilt: its own recorded findings establish that it is
larger than its estimate and must be its own PR, because it reshapes the
`loadSchema` / `canonical-schema-stamp` / `test-setup-dy` seam that
`load-schema-helper.ts:526-532` warns is reshaped one story at a time.

Closes-story: date-parse-union-return-is-ts-static-side-variance
Closes-story: collaborator-count-projects-namedfunction-not-arel-count
Closes-story: pg-int8-decodes-as-string-forcing-count-coercion
