### PR TITLE
perf(scripts): port test-compare run.sh to a single-process orchestrate.ts

### DIFF
--- a/scripts/test-compare/extract-ts-tests.ts
+++ b/scripts/test-compare/extract-ts-tests.ts
@@ -61,7 +61,7 @@ function getPackageTestFiles(): Record<string, string[]> {
   return result;
 }
 
-function main() {
+export function main() {
   const manifest: TestManifest = {
     source: "typescript",
     generatedAt: new Date().toISOString(),

--- a/scripts/test-compare/orchestrate.ts
+++ b/scripts/test-compare/orchestrate.ts
@@ -1,0 +1,111 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * In-process orchestrator for `pnpm test:compare` (driver: run.sh).
+ *
+ * The pipeline is a small dependency DAG:
+ *
+ *   fetch ──┬─> ruby-extract ─┬─> compare   (needs both extracts)
+ *           └─> ts-extract  ──┘
+ *
+ * Historically each node ran as its own process — `pnpm -s vendor:fetch`,
+ * a second `pnpm -s vendor:fetch --print-test-paths` for the TEST_PATHS_JSON
+ * handoff, `pnpm tsx extract-ts-tests.ts`, `pnpm tsx test-compare.ts` — so the
+ * pipeline paid the ~1.7s tsx/Node cold start four times over. This entrypoint
+ * pays it ONCE: every TypeScript phase runs in-process, and only the Ruby
+ * extractor stays a subprocess (it's a `.rb`). The test-paths manifest that
+ * used to come from a whole extra fetch process is now just a
+ * `testPathsManifest()` call.
+ *
+ * Args ("$@" forwarded by run.sh — `--package`, `--missing`, `--json`,
+ * `--incomplete`, `--gates`, `--check`, …) are passed straight through to
+ * test-compare's main(); only `--cached` is consumed here.
+ *
+ * `TEST_COMPARE_FORCE=1` forces a full run end-to-end, mirroring
+ * `API_COMPARE_FORCE`: it overrides `--cached` and drops fetch's offline
+ * fast-path.
+ */
+import { execFile } from "node:child_process";
+import { access } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { runFetch } from "../../vendor/fetch.js";
+import { testPathsManifest } from "../../vendor/sources.js";
+import { main as extractTsTests } from "./extract-ts-tests.js";
+import { main as runCompare } from "./test-compare.js";
+
+const execFileAsync = promisify(execFile);
+
+const DIR = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(DIR, "../..");
+const OUTPUT_DIR = join(DIR, "output");
+
+const force = process.env.TEST_COMPARE_FORCE === "1";
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function runRubyExtract(): Promise<void> {
+  const { stdout, stderr } = await execFileAsync("ruby", [join(DIR, "extract-ruby-tests.rb")], {
+    cwd: ROOT,
+    env: {
+      ...process.env,
+      TEST_PATHS_JSON: JSON.stringify(testPathsManifest()),
+    },
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (stdout) process.stdout.write(stdout);
+  if (stderr) process.stderr.write(stderr);
+}
+
+/**
+ * Whether extraction can be skipped: `--cached` (or TEST_COMPARE_FORCE=0 with
+ * the flag) asked for it AND both manifests are already on disk. A missing
+ * manifest falls back to a full run, as run.sh's bash version did.
+ */
+async function cacheHit(cached: boolean): Promise<boolean> {
+  if (!cached) return false;
+  const present =
+    (await exists(join(OUTPUT_DIR, "rails-tests.json"))) &&
+    (await exists(join(OUTPUT_DIR, "ts-tests.json")));
+  if (present) {
+    process.stdout.write("==> Using cached rails-tests.json + ts-tests.json (--cached)\n");
+    return true;
+  }
+  process.stderr.write("==> --cached requested but cache missing; running full extract\n");
+  return false;
+}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+  const cached = argv.includes("--cached") && !force;
+  const forwardArgs = argv.filter((a) => a !== "--cached");
+
+  if (!(await cacheHit(cached))) {
+    // Phase A — fetch every source registered in vendor/sources.ts. On warm
+    // runs use the offline fast-path (trust the lockfile pins, skip per-source
+    // `git rev-parse`); FORCE takes the full verifying path.
+    await runFetch({ offline: !force });
+
+    // Phase B — ruby (subprocess) and ts (in-process) in parallel. Both only
+    // need fetch's vendored sources, which Phase A just produced. Per-package
+    // test paths reach the Ruby extractor through TEST_PATHS_JSON, built from
+    // vendor/sources.ts so the Ruby script carries no parallel package table.
+    await Promise.all([runRubyExtract(), extractTsTests()]);
+  }
+
+  // Phase C — compare needs both extracts.
+  runCompare(forwardArgs);
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? (err.stack ?? err.message) : err);
+  process.exit(1);
+});

--- a/scripts/test-compare/orchestrate.ts
+++ b/scripts/test-compare/orchestrate.ts
@@ -66,9 +66,9 @@ async function runRubyExtract(): Promise<void> {
 }
 
 /**
- * Whether extraction can be skipped: `--cached` (or TEST_COMPARE_FORCE=0 with
- * the flag) asked for it AND both manifests are already on disk. A missing
- * manifest falls back to a full run, as run.sh's bash version did.
+ * Whether extraction can be skipped: `--cached` asked for it AND both
+ * manifests are already on disk. A missing manifest falls back to a full run,
+ * with the same two messages run.sh's bash version printed.
  */
 async function cacheHit(cached: boolean): Promise<boolean> {
   if (!cached) return false;
@@ -89,19 +89,15 @@ async function main(): Promise<void> {
   const forwardArgs = argv.filter((a) => a !== "--cached");
 
   if (!(await cacheHit(cached))) {
-    // Phase A — fetch every source registered in vendor/sources.ts. On warm
-    // runs use the offline fast-path (trust the lockfile pins, skip per-source
-    // `git rev-parse`); FORCE takes the full verifying path.
+    // Warm runs take fetch's offline fast-path (trust the lockfile pins, skip
+    // per-source `git rev-parse`); FORCE takes the full verifying path.
     await runFetch({ offline: !force });
 
-    // Phase B — ruby (subprocess) and ts (in-process) in parallel. Both only
-    // need fetch's vendored sources, which Phase A just produced. Per-package
-    // test paths reach the Ruby extractor through TEST_PATHS_JSON, built from
-    // vendor/sources.ts so the Ruby script carries no parallel package table.
+    // Both extracts need only fetch's vendored sources, so they run in
+    // parallel: ruby as a subprocess, ts in-process.
     await Promise.all([runRubyExtract(), extractTsTests()]);
   }
 
-  // Phase C — compare needs both extracts.
   runCompare(forwardArgs);
 }
 

--- a/scripts/test-compare/run.sh
+++ b/scripts/test-compare/run.sh
@@ -1,48 +1,17 @@
 #!/usr/bin/env bash
-# Driver for `pnpm test:compare`. Forwards extra args ("$@") to
-# test-compare.ts so flags like `--package`, `--missing`, `--json`,
-# `--incomplete` reach the comparison step.
+# Driver for `pnpm test:compare`. Forwards any extra args ("$@") to the
+# orchestrator, which passes them through to test-compare's main() so flags
+# like `--package`, `--missing`, `--json`, `--incomplete` reach the comparison
+# step. `--cached` is consumed by the orchestrator (skip extraction when both
+# manifests exist).
 #
-# Special flag handled here (not forwarded to test-compare.ts):
-#   --cached   Skip the fetch + Ruby/TS extract steps if the cached
-#              output/rails-tests.json and output/ts-tests.json already
-#              exist. Falls back to a full run if either is missing.
+# orchestrate.ts runs the whole DAG (fetch → ruby∥ts extract → compare) in a
+# SINGLE tsx process. The previous version spawned a fresh process per step
+# (4 total, including a duplicate fetch for --print-test-paths) and paid the
+# ~1.7s cold start each time. See orchestrate.ts for the phase ordering and
+# TEST_COMPARE_FORCE semantics.
 set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOT="$(cd "$DIR/../.." && pwd)"
-OUT_DIR="$DIR/output"
 
-USE_CACHE=0
-FORWARD_ARGS=()
-for arg in "$@"; do
-  if [[ "$arg" == "--cached" ]]; then
-    USE_CACHE=1
-  else
-    FORWARD_ARGS+=("$arg")
-  fi
-done
-
-CACHE_HIT=0
-if [[ "$USE_CACHE" -eq 1 ]]; then
-  if [[ -f "$OUT_DIR/rails-tests.json" && -f "$OUT_DIR/ts-tests.json" ]]; then
-    CACHE_HIT=1
-    echo "==> Using cached rails-tests.json + ts-tests.json (--cached)"
-  else
-    echo "==> --cached requested but cache missing; running full extract" >&2
-  fi
-fi
-
-if [[ "$CACHE_HIT" -eq 0 ]]; then
-  # Single tsx invocation fetches every source registered in vendor/sources.ts.
-  pnpm -s vendor:fetch
-  # Per-package test paths come from vendor/sources.ts via --print-test-paths
-  # (single JSON map). The Ruby script no longer needs RAILS_DIR / RACK_DIR /
-  # GLOBALID_DIR — adding a new source is one entry in vendor/sources.ts and
-  # the manifest grows automatically.
-  TEST_PATHS_JSON="$(pnpm -s vendor:fetch --print-test-paths)" \
-    ruby "$DIR/extract-ruby-tests.rb"
-  pnpm tsx "$DIR/extract-ts-tests.ts"
-fi
-
-pnpm tsx "$DIR/test-compare.ts" "${FORWARD_ARGS[@]+"${FORWARD_ARGS[@]}"}"
+pnpm tsx "$DIR/orchestrate.ts" "$@"

--- a/scripts/test-compare/test-compare.ts
+++ b/scripts/test-compare/test-compare.ts
@@ -400,8 +400,7 @@ export function compareFileResults(
 // Main
 // ---------------------------------------------------------------------------
 
-function main() {
-  const args = process.argv.slice(2);
+export function main(args: string[] = process.argv.slice(2)) {
   const pkgIndex = args.indexOf("--package");
   let filterPkg: string | null = null;
   if (pkgIndex !== -1) {


### PR DESCRIPTION
Ports `scripts/test-compare/run.sh` to a single-process
`scripts/test-compare/orchestrate.ts`, modeled on
`scripts/api-compare/orchestrate.ts`. `run.sh` shrinks to the same 3-line
delegate api-compare's is.

The bash pipeline spawned four processes — `pnpm -s vendor:fetch`,
`pnpm -s vendor:fetch --print-test-paths`, `pnpm tsx extract-ts-tests.ts`,
`pnpm tsx test-compare.ts` — each paying the ~1.7s tsx/Node cold start. The
orchestrator pays it once: fetch runs in-process via `runFetch()`,
`TEST_PATHS_JSON` comes from an in-process `testPathsManifest()` call instead
of a second fetch process, ts-extract and compare are direct imports, and only
`extract-ruby-tests.rb` stays a subprocess (it's a `.rb`).

`extract-ts-tests.ts` and `test-compare.ts` export their `main()`; their
`require.main === module` guards are untouched, so the direct CI invocations
(`ci.yml` lines 1353/1524) keep working.

### Semantics

- `--cached` is consumed by the orchestrator with the bash behavior preserved:
  skip extraction when both `output/rails-tests.json` and `output/ts-tests.json`
  exist (same `==> Using cached ...` line), fall back to a full run otherwise
  (same stderr warning).
- `TEST_COMPARE_FORCE=1` mirrors `API_COMPARE_FORCE`: overrides `--cached` and
  drops fetch's offline fast-path.
- `--package`, `--missing`, `--json`, `--incomplete`, `--gates`, `--check` and
  the rest pass through unchanged.

### Measurements

| run | before | after |
| --- | --- | --- |
| full `pnpm test:compare` (warm) | 40.4s | 30.8s |
| `pnpm test:compare -- --cached` | — | 5.3s |

Comparison output is byte-identical to the pre-change run (deltas exactly
zero); the only diff in captured stdout is ordering — ts-extract's summary now
interleaves with the Ruby extractor because they run in parallel — plus fetch
printing `offline: pinned at <sha>` instead of `up to date at <sha>` on the
warm path.

`pnpm test:stubs` (chains `test:compare -- --missing --json`) verified working;
`pnpm vitest run scripts/test-compare` green (173 tests); typecheck and lint
clean.

Closes-story: test-compare-orchestrator
