### PR TITLE
fix(date,activerecord): Date seats the Julian day; DateTime's default return carries the offset; the adapter proxy consults no probe-key set

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -72,43 +72,6 @@ export class NullConfig {
 const NULL_CONFIG = new NullConfig();
 
 /**
- * Property keys a serializer, test matcher, or framework may probe on an
- * arbitrary object while walking it (vitest error serialization, `await`,
- * `JSON.stringify`, asymmetric matchers, React element checks, DOM sniffing).
- *
- * The adapter proxy (`_getAdapterProxy`) is reachable from any translated
- * error via its `connectionPool`; if the `get` trap fabricated a callable for
- * these keys, the probe would dispatch to a raw connection that has no such
- * method (`conn[prop] is not a function`). The trap returns `undefined` for
- * every key here — and for all symbol keys — so probes see a non-callable.
- * Add new probe keys here rather than sprinkling checks in the trap.
- */
-const ADAPTER_PROXY_PROBE_KEYS = new Set<string>([
-  // Promise / thenable duck-typing
-  "then",
-  "catch",
-  "finally",
-  // JSON / serializer hooks
-  "toJSON",
-  "toString",
-  "valueOf",
-  "inspect",
-  // vitest / jest asymmetric matchers and mock sniffing
-  "asymmetricMatch",
-  "$$typeof",
-  "_isMockFunction",
-  "getMockName",
-  // React / DOM element checks
-  "nodeType",
-  "nodeName",
-  "tagName",
-  // Object plumbing a walker may touch
-  "constructor",
-  "prototype",
-  "hasOwnProperty",
-]);
-
-/**
  * Mirrors: ActiveRecord::ConnectionAdapters::NullPool
  */
 export class NullPool implements AbstractPool {
@@ -553,25 +516,25 @@ export class ConnectionPool implements ReapablePool {
               (pool.activeConnection ?? pool.connections[0])?.adapterName ??
               adapterNameFromConfig(pool.dbConfig.adapter)
             );
-          // Don't fabricate a method for serialization/matcher/framework probes.
-          // When this proxy is reachable from an error's `connectionPool` (Rails
-          // stamps the pool onto every translated error), a serializer, `await`,
-          // or an asymmetric matcher walks keys like `then`/`toJSON`/`Symbol.*`/
-          // `asymmetricMatch`; returning a callable there would run `conn.then()`
-          // etc. against a raw connection that has no such method
-          // (`conn[prop] is not a function`). See ADAPTER_PROXY_PROBE_KEYS.
-          if (typeof prop === "symbol" || ADAPTER_PROXY_PROBE_KEYS.has(prop)) {
-            return undefined;
-          }
-          // Only dispatch names a real connection exposes as a method. When a
-          // connection already exists (it does whenever a translated error was
-          // raised — a query was mid-flight), an unrecognised probe key not in
-          // the deny set still resolves to a non-callable instead of a
-          // dispatcher that would blow up on `conn[prop] is not a function`.
-          // With no connection yet, fabricate optimistically so first-use
-          // dispatch (schemaMigration etc.) still works.
-          const sample = pool.activeConnection ?? pool.connections[0];
-          if (sample && typeof (sample as any)[prop] !== "function") {
+          // A symbol key is the one carve-out the language forces, exactly as
+          // on `NullPool` above: a JS `Symbol` cannot spell a Ruby send, so
+          // `Symbol.iterator`/`Symbol.toPrimitive` and friends are not sends
+          // the adapter is missing a method for. String keys get no carve-out —
+          // `adapter.then` and `adapter.toJSON` are sends, and `then` in
+          // particular must NOT answer a callable, or `await`ing anything that
+          // holds this proxy would drive it as a thenable.
+          if (typeof prop === "symbol") return undefined;
+          // Only dispatch names a real adapter exposes as a method — the send
+          // set is the adapter's, exactly as it is in Ruby. A live connection
+          // answers for it whenever one exists (it does whenever a translated
+          // error was raised — a query was mid-flight); with none yet, the base
+          // class every adapter extends does, so `then` and `toJSON` resolve to
+          // a non-callable both before and after the first checkout rather than
+          // to a dispatcher that would blow up on `conn[prop] is not a
+          // function` — or, for `then`, make this proxy a thenable.
+          const sample: object =
+            pool.activeConnection ?? pool.connections[0] ?? AbstractAdapter.prototype;
+          if (typeof (sample as any)[prop] !== "function") {
             return undefined;
           }
           return (...args: unknown[]) => {

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -516,8 +516,11 @@ export class ConnectionPool implements ReapablePool {
               (pool.activeConnection ?? pool.connections[0])?.adapterName ??
               adapterNameFromConfig(pool.dbConfig.adapter)
             );
-          // The one carve-out the language forces, as on `NullPool` above: a JS
-          // `Symbol` cannot spell a Ruby send.
+          // The carve-outs the language forces, as on `NullPool` above: neither
+          // a JS `Symbol` nor `constructor` spells a Ruby send — `constructor`
+          // is the object plumbing every JS walker reads to name a value's
+          // class, and dispatching it would call the adapter class without
+          // `new`.
           if (typeof prop === "symbol") return undefined;
           // The send set is the adapter's, as it is in Ruby — no name list. A
           // live connection answers for it whenever one exists (it does
@@ -528,6 +531,7 @@ export class ConnectionPool implements ReapablePool {
           // thenable to anything `await`ing an object that holds it.
           const sample: object =
             pool.activeConnection ?? pool.connections[0] ?? AbstractAdapter.prototype;
+          if (prop === "constructor") return (sample as any).constructor;
           if (typeof (sample as any)[prop] !== "function") {
             return undefined;
           }

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -516,22 +516,16 @@ export class ConnectionPool implements ReapablePool {
               (pool.activeConnection ?? pool.connections[0])?.adapterName ??
               adapterNameFromConfig(pool.dbConfig.adapter)
             );
-          // A symbol key is the one carve-out the language forces, exactly as
-          // on `NullPool` above: a JS `Symbol` cannot spell a Ruby send, so
-          // `Symbol.iterator`/`Symbol.toPrimitive` and friends are not sends
-          // the adapter is missing a method for. String keys get no carve-out —
-          // `adapter.then` and `adapter.toJSON` are sends, and `then` in
-          // particular must NOT answer a callable, or `await`ing anything that
-          // holds this proxy would drive it as a thenable.
+          // The one carve-out the language forces, as on `NullPool` above: a JS
+          // `Symbol` cannot spell a Ruby send.
           if (typeof prop === "symbol") return undefined;
-          // Only dispatch names a real adapter exposes as a method — the send
-          // set is the adapter's, exactly as it is in Ruby. A live connection
-          // answers for it whenever one exists (it does whenever a translated
-          // error was raised — a query was mid-flight); with none yet, the base
-          // class every adapter extends does, so `then` and `toJSON` resolve to
-          // a non-callable both before and after the first checkout rather than
-          // to a dispatcher that would blow up on `conn[prop] is not a
-          // function` — or, for `then`, make this proxy a thenable.
+          // The send set is the adapter's, as it is in Ruby — no name list. A
+          // live connection answers for it whenever one exists (it does
+          // whenever a translated error was raised); with none yet, the base
+          // class every adapter extends stands in, so a name no adapter defines
+          // never becomes a dispatcher that would blow up on
+          // `conn[prop] is not a function` — or, for `then`, make this proxy a
+          // thenable to anything `await`ing an object that holds it.
           const sample: object =
             pool.activeConnection ?? pool.connections[0] ?? AbstractAdapter.prototype;
           if (typeof (sample as any)[prop] !== "function") {

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -586,26 +586,33 @@ it("inspect does not show secrets", async () => {
   expect(pool2.inspect()).toMatch(/role="reading"/);
 });
 
-it("adapter proxy does not fabricate methods for serialization/matcher probe keys", async () => {
+it("adapter proxy treats a probe name as the send it is, with no carve-out set", async () => {
   const pool = makePool();
   const proxy = (
     pool as unknown as { _getAdapterProxy(): Record<PropertyKey, unknown> }
   )._getAdapterProxy();
 
-  // Keys a serializer / asymmetric matcher / framework walker may probe. None
-  // may resolve to a callable that would dispatch to a raw connection.
+  // `abstract/connection_pool.rb` gives the proxy no name set to consult: what
+  // an adapter answers is what its class defines. None of these is an
+  // AbstractAdapter method, so none fabricates a dispatcher — before a checkout
+  // as well as after, since the base class stands in for the sample connection.
   for (const key of [
     "then",
     "toJSON",
     "asymmetricMatch",
     "$$typeof",
     "nodeType",
-    "constructor",
-    "hasOwnProperty",
+    "getMockName",
+    "_isMockFunction",
   ]) {
     expect(typeof proxy[key]).not.toBe("function");
     expect(proxy[key]).toBeUndefined();
   }
+  // What Ruby *does* answer, it answers through the ancestor chain — the same
+  // reason `NullPool` lets `to_s` arrive as `Object.prototype.toString`.
+  expect(typeof proxy.hasOwnProperty).toBe("function");
+  // A JS `Symbol` cannot spell a Ruby send — the one carve-out the language
+  // forces, as on `NullPool`.
   expect(proxy[Symbol.iterator]).toBeUndefined();
 
   // The pool is stamped onto every translated error, so a serializer or matcher
@@ -614,6 +621,13 @@ it("adapter proxy does not fabricate methods for serialization/matcher probe key
   // `conn[prop] is not a function`.
   expect(() => JSON.stringify(proxy)).not.toThrow();
   expect(proxy).not.toEqual(expect.objectContaining({ id: 1 }));
+
+  // A deliberately failing assertion whose subject holds the proxy must report
+  // its own failure, not an error from the reporter — the guard
+  // `connection-pool.trails.test.ts` carries for `NullPool`.
+  expect(() => expect({ adapter: proxy, n: 1 }).toEqual({ adapter: proxy, n: 2 })).toThrow(
+    /expected/i,
+  );
 });
 
 it("adapter proxy still dispatches genuine adapter methods to the connection", async () => {
@@ -635,8 +649,8 @@ it("adapter proxy still dispatches genuine adapter methods to the connection", a
 it("adapter proxy does not fabricate a method for an unknown probe key once a connection exists", async () => {
   const pool = makePool();
   // Materialise a connection (as when a query is mid-flight and an error is
-  // translated). An arbitrary probe key not in the deny set must now resolve to
-  // a non-callable, since the live connection has no such method.
+  // translated). An arbitrary probe key must resolve to a non-callable, since
+  // the live connection has no such method.
   await pool.checkout();
   const proxy = (
     pool as unknown as { _getAdapterProxy(): Record<PropertyKey, unknown> }

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -611,6 +611,10 @@ it("adapter proxy treats a probe name as the send it is, with no carve-out set",
   // What Ruby *does* answer, it answers through the ancestor chain — the same
   // reason `NullPool` lets `to_s` arrive as `Object.prototype.toString`.
   expect(typeof proxy.hasOwnProperty).toBe("function");
+  // `constructor` is object plumbing, not a send: a walker reads it to name the
+  // value's class, so it answers the adapter class rather than a dispatcher
+  // that would call that class without `new`.
+  expect(proxy.constructor).toBe(AbstractAdapter);
   // A JS `Symbol` cannot spell a Ruby send — the one carve-out the language
   // forces, as on `NullPool`.
   expect(proxy[Symbol.iterator]).toBeUndefined();

--- a/packages/activesupport/src/i18n.test.ts
+++ b/packages/activesupport/src/i18n.test.ts
@@ -10,7 +10,7 @@ import type { TimeWithZone } from "./time-with-zone.js";
 I18n.setEnforceAvailableLocales(false);
 
 describe("I18nTest", () => {
-  let date: Temporal.PlainDate | Temporal.PlainDateTime;
+  let date: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.ZonedDateTime;
   let time: TimeWithZone;
 
   beforeEach(async () => {

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -829,10 +829,10 @@ describe("Date", () => {
     // Every expectation is `ruby 3.3.11 -rdate`'s `Date.jd(jd)` — under the
     // default `Date::ITALY`, so 2299160 is the Julian 1582-10-04 the reform
     // deleted ten days after, not the proleptic Gregorian 1582-10-14.
-    expect(new RubyDate(RubyDate.jd(2440588)).toS()).toBe("1970-01-01");
-    expect(new RubyDate(RubyDate.jd(2299161)).toS()).toBe("1582-10-15");
-    expect(new RubyDate(RubyDate.jd(2299160)).toS()).toBe("1582-10-04");
-    expect(new RubyDate(RubyDate.jd(2299160)).yday).toBe(277);
+    expect(strftime(RubyDate.jd(2440588), "%Y-%m-%d")).toBe("1970-01-01");
+    expect(strftime(RubyDate.jd(2299161), "%Y-%m-%d")).toBe("1582-10-15");
+    expect(strftime(RubyDate.jd(2299160), "%Y-%m-%d")).toBe("1582-10-04");
+    expect(strftime(RubyDate.jd(2299160), "%j")).toBe("277");
   });
 
   it("reads a Temporal subject's wday and yday off the Julian day too", () => {
@@ -886,17 +886,14 @@ describe("Date", () => {
   it("raises Date::Error on a civil date c_valid_civil_p rejects", () => {
     // Every expectation is `ruby 3.3.11 -rdate`'s `Date.new(y, m, d)` under the
     // default `Date::ITALY`, where 1582-10-10 is one of the ten days the reform
-    // deleted. 1500-02-29 is the one MRI accepts and this does not: it is a
-    // real Julian day with no proleptic Gregorian spelling for
-    // `Temporal.PlainDate` to seat (`plainDateFromJd`, date.ts).
+    // deleted.
     expect(() => new RubyDate(2001, 2, 29)).toThrow(RubyDate.Error);
     expect(civilOrError(1581, 12, 31)).toEqual([1581, 12, 31]);
     expect(civilOrError(1582, 10, 10)).toBe("E");
-    expect(civilOrError(1500, 2, 29)).toBe("E");
+    expect(civilOrError(1500, 2, 29)).toEqual([1500, 2, 29]);
     // c_find_ldom's scan makes February 1500 twenty-nine days long, as the
-    // Julian calendar has it, so the negative mday counts back from the 29th —
-    // and then hits the same missing seat.
-    expect(civilOrError(1500, 2, -1)).toBe("E");
+    // Julian calendar has it, so the negative mday counts back from the 29th.
+    expect(civilOrError(1500, 2, -1)).toEqual([1500, 2, 29]);
     expect(civilOrError(1582, 10, -1)).toEqual([1582, 10, 31]);
     expect(civilOrError(1900, 2, -1)).toEqual([1900, 2, 28]);
     expect(civilOrError(1900, 2, 29)).toBe("E");
@@ -905,6 +902,29 @@ describe("Date", () => {
     expect(civilOrError(2100, 2, 28)).toEqual([2100, 2, 28]);
     expect(civilOrError(2001, 13, 1)).toBe("E");
     expect(civilOrError(-4712, 1, 1)).toEqual([-4712, 1, 1]);
+  });
+
+  it("builds a Julian-only civil date, as the HAVE_JD state does", () => {
+    // ruby 3.3.11 -rdate: Julian leap years have no century rule, so 1500,
+    // 1400 and 1300 are all leap under `Date::ITALY` and 29 February is a real
+    // day none of them has a proleptic Gregorian spelling for.
+    //   Date.new(1500, 2, 29) #=> "1500-02-29", jd 2268992, wday 6
+    //   Date.new(1400, 2, 29) #=> "1400-02-29", jd 2232467, wday 0
+    //   Date.new(1300, 2, 29) #=> "1300-02-29", jd 2195942, wday 1
+    for (const [y, jd, wday] of [
+      [1500, 2268992, 6],
+      [1400, 2232467, 0],
+      [1300, 2195942, 1],
+    ] as const) {
+      const date = new RubyDate(y, 2, 29);
+      expect(date.toS()).toBe(`${y}-02-29`);
+      expect(date.jd).toBe(jd);
+      expect(date.wday).toBe(wday);
+      expect(date.yday).toBe(60);
+      // The `Temporal.PlainDate` seat is where the spelling runs out, not the
+      // gem-shaped object: `to_date` is the only thing that raises.
+      expect(() => date.toDate()).toThrow(RubyDate.Error);
+    }
   });
 });
 
@@ -959,6 +979,45 @@ describe("DateTime", () => {
     expect(datetime.zone).toBe("+09:00");
     expect(datetime.strftime("%Y-%m-%dT%H:%M:%S %z %:z %::z %:::z %Z")).toBe(
       "2008-03-01T06:00:00 +0900 +09:00 +09:00:00 +09 +09:00",
+    );
+  });
+
+  it("carries the offset into the default return too, not only the gem-shaped one", () => {
+    // ruby 3.3.11:
+    //   DateTime.parse("2008-03-01T06:00:00+09:00").to_s   #=> "2008-03-01T06:00:00+09:00"
+    //   DateTime.parse("2008-03-01T06:00:00").to_s         #=> "2008-03-01T06:00:00+00:00"
+    //   DateTime.strptime("2008-03-01T06:00:00+09:00").to_s
+    //     #=> "2008-03-01T06:00:00+09:00"
+    const zoned = RubyDateTime.parse("2008-03-01T06:00:00+09:00");
+    expect(zoned).toBeInstanceOf(Temporal.ZonedDateTime);
+    expect((zoned as Temporal.ZonedDateTime).offset).toBe("+09:00");
+    expect(strftime(zoned, "%Y-%m-%dT%H:%M:%S%:z")).toBe("2008-03-01T06:00:00+09:00");
+
+    // A string that named no zone leaves `of` at 0, which is the value
+    // `::DateTime` has no zone to spell — a bare PlainDateTime.
+    const plain = RubyDateTime.parse("2008-03-01T06:00:00");
+    expect(plain).toBeInstanceOf(Temporal.PlainDateTime);
+    expect(strftime(plain, "%Y-%m-%dT%H:%M:%S%:z")).toBe("2008-03-01T06:00:00+00:00");
+
+    expect(
+      strftime(RubyDateTime.strptime("2008-03-01T06:00:00+09:00"), "%Y-%m-%dT%H:%M:%S%:z"),
+    ).toBe("2008-03-01T06:00:00+09:00");
+  });
+
+  it("truncates a sub-minute offset in the seat, as of2str's own spelling does", () => {
+    // ruby 3.3.11:
+    //   Date._parse("2008-03-01T06:00:00-00:44:30")[:offset] #=> -2670
+    //   DateTime.parse("2008-03-01T06:00:00-00:44:30").zone  #=> "-00:44"
+    // `date_zone_to_diff` (date_parse.c:523-528) keeps the 30 seconds; a
+    // Temporal offset time zone is minute-precision and `of2str`
+    // (date_core.c:1973-1980) drops them too, so the seat agrees with `#zone`.
+    expect(RubyDate._parse("2008-03-01T06:00:00-00:44:30").offset).toBe(-2670);
+    expect(gemDateTime("2008-03-01T06:00:00-00:44:30").zone).toBe("-00:44");
+    const seat = RubyDateTime.parse("2008-03-01T06:00:00-00:44:30");
+    expect(seat).toBeInstanceOf(Temporal.ZonedDateTime);
+    expect((seat as Temporal.ZonedDateTime).offset).toBe("-00:44");
+    expect((seat as Temporal.ZonedDateTime).toPlainDateTime().toString()).toBe(
+      "2008-03-01T06:00:00",
     );
   });
 

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -2937,11 +2937,11 @@ const ITALY = 2299161;
  * @internal `date_core.c`'s `DEFAULT_SG` (`date_core.c:190`), the reform start
  * every constructor takes when none is passed. The `start` argument itself
  * (`Date::JULIAN` / `Date::GREGORIAN`, `date_core.c:188-189`) is not a
- * parameter here — `Date` is seated on `Temporal.PlainDate`, which can hold
- * only the spellings the proleptic Gregorian calendar has, so a Julian-only
- * civil date such as 1500-02-29 has no bearer. The conversions below are the
- * C's all the same, so every day both calendars can spell — which is every day
- * outside the ten the reform deleted — answers MRI's `wday`, `yday` and epoch.
+ * parameter here: `SimpleDateData` carries `sg` so that one process can hold
+ * dates under several reforms at once, and every trails entry point takes this
+ * one. The conversions below are the C's, over the C's own Julian-day state, so
+ * every civil date `Date::ITALY` names — including the Julian-only ones such as
+ * 1500-02-29 — is buildable and answers MRI's `wday`, `yday` and epoch.
  */
 const DEFAULT_SG = ITALY;
 
@@ -2995,22 +2995,20 @@ function dfUtcToLocal(df: number, of: number): number {
 
 /**
  * @internal `date_core.c` `jd_local_to_utc` (`date_core.c:922-932`), the day
- * half of the same move. The C carries the day on a Julian day number; `Date` is
- * seated on `Temporal.PlainDate`, so the `jd -= 1` / `jd += 1` the C writes are
- * a day subtracted from or added to the date.
+ * half of the same move, on the Julian day the C itself carries.
  */
-function jdLocalToUtc(jd: Temporal.PlainDate, df: number, of: number): Temporal.PlainDate {
+function jdLocalToUtc(jd: number, df: number, of: number): number {
   df -= of;
-  if (df < 0) return jd.subtract({ days: 1 });
-  if (df >= DAY_IN_SECONDS) return jd.add({ days: 1 });
+  if (df < 0) return jd - 1;
+  if (df >= DAY_IN_SECONDS) return jd + 1;
   return jd;
 }
 
 /** @internal `date_core.c` `jd_utc_to_local` (`date_core.c:933-943`). */
-function jdUtcToLocal(jd: Temporal.PlainDate, df: number, of: number): Temporal.PlainDate {
+function jdUtcToLocal(jd: number, df: number, of: number): number {
   df += of;
-  if (df < 0) return jd.subtract({ days: 1 });
-  if (df >= DAY_IN_SECONDS) return jd.add({ days: 1 });
+  if (df < 0) return jd - 1;
+  if (df >= DAY_IN_SECONDS) return jd + 1;
   return jd;
 }
 
@@ -3134,16 +3132,20 @@ function cValidCivilP(y: number, m: number, d: number, sg = DEFAULT_SG): number 
 }
 
 /**
- * @internal The `Temporal.PlainDate` a Julian day names — the seat `Date` keeps
- * its state on. `Date.jd` is `d_simple_new_internal` over a bare `HAVE_JD`
- * `SimpleDateData` in the C (`date_core.c:3036-3050`); here the day has to
- * become a civil date at the call, and a Julian-only day such as the one
- * 1500-02-29 names has no proleptic Gregorian spelling, so `Temporal` rejects
- * it where MRI builds it. That is the residue of the substrate, not of the
- * conversions above: RFC 0088 `date-state-onto-temporal-plaindate`.
+ * @internal The `Temporal.PlainDate` a Julian day names — the *return* seat,
+ * not the state. `Date` itself carries the Julian day (`SimpleDateData`'s
+ * `HAVE_JD` arm, `date_core.c:203-213`), so every civil date `Date::ITALY`
+ * names is buildable; this is only reached where RFC 0088's mapping table says
+ * a static answers `Temporal`, i.e. at {@link Date#toDate} and the statics over
+ * it.
  *
- * Not exported: it is the seam between the C's Julian day and the substrate,
- * reachable only from the constructors and `Date.jd` below.
+ * `Temporal.PlainDate` is proleptic Gregorian and can hold only the spellings
+ * that calendar has, so a Julian-only day such as the one 1500-02-29 names has
+ * no `Temporal` value and this raises. `new Date(1500, 2, 29)` itself does not:
+ * the gem-shaped object answers `to_s`, `jd`, `wday` and `yday` as MRI does,
+ * and only the conversion to the `Temporal` seat has nowhere to put it.
+ *
+ * Not exported: it is the seam between the C's Julian day and the substrate.
  */
 function plainDateFromJd(rjd: number): Temporal.PlainDate {
   const [y, m, d] = cJdToCivil(rjd);
@@ -3153,6 +3155,21 @@ function plainDateFromJd(rjd: number): Temporal.PlainDate {
     throw new DateError("invalid date");
   }
 }
+
+/**
+ * @internal The brand that selects `d_simple_new_internal`
+ * (`date_core.c:3036-3050`) / `d_complex_new_internal` (`date_core.c:3055-3071`)
+ * — the C's static "seat an already-resolved Julian day, validate nothing"
+ * constructors — over the public `Date.new` / `DateTime.new`.
+ *
+ * Both C functions are file-static, so `d_new_by_frags` and friends reach them
+ * while no Ruby caller can. TS has no member visibility between "the class
+ * body" and "exported", and both arms now take a leading `number`, so there is
+ * no type left to overload on: a JS `Symbol` as the first parameter is the
+ * brand that keeps the seam out of the public signature. It spells no Ruby
+ * Symbol — nothing reads it as a value.
+ */
+const SEAT: unique symbol = Symbol("d_simple_new_internal");
 
 /**
  * @internal `date_core.c` `c_valid_time_p` (`date_core.c:870-886`), which folds
@@ -3551,7 +3568,7 @@ export function dNewByFrags(hash: DateParts | null): Date {
   }
 
   if (jd === null) throw new DateError("invalid date");
-  return new Date(plainDateFromJd(jd));
+  return new Date(SEAT, jd);
 }
 
 /**
@@ -3648,7 +3665,7 @@ export function dtNewByFrags(hash: DateParts | null): DateTime {
   let of = to == null ? 0 : to instanceof Rational ? to.toI() : Math.trunc(to);
   if (of < -DAY_IN_SECONDS || of > DAY_IN_SECONDS) of = 0;
 
-  return new DateTime(jdLocalToUtc(plainDateFromJd(jd), df, of), dfLocalToUtc(df, of), sf, of);
+  return new DateTime(SEAT, jdLocalToUtc(jd, df, of), dfLocalToUtc(df, of), sf, of);
 }
 
 /**
@@ -3769,18 +3786,26 @@ export class Date {
    * Julian date such as 1500-02-29 is a real day with no proleptic Gregorian
    * spelling.
    *
-   * The stored half is the civil date, and the Julian day is derived from it on
-   * read ({@link Date#jd}) through {@link cCivilToJd} under {@link DEFAULT_SG} —
-   * so `wday`, `yday` and `%s` are the reform's readings, not
-   * `Temporal.PlainDate`'s proleptic ones. What the substrate still cannot hold
-   * is the second case above: a Julian-only spelling has no
-   * `Temporal.PlainDate`, so `Date.new(1500, 2, 29)` raises where MRI builds it
-   * (story `date-state-julian-only-spellings-unbuildable`). The `start`
-   * ARGUMENT is what has no bearer — `#start`, `#julian?` and `#new_start` are
-   * absent with it, and every conversion below takes the one `sg` MRI defaults
-   * to. RFC 0088 `date-state-onto-temporal-plaindate`.
+   * The stored half is the Julian day — the C's `HAVE_JD` arm — and the civil
+   * triple is decoded from it on read through {@link Date#getCCivil} over
+   * {@link cJdToCivil} under {@link DEFAULT_SG}, exactly as `get_c_civil`
+   * (`date_core.c:1297-1324`) does. Keeping the calendar-neutral half is what
+   * makes both cases above representable: `wday`, `yday` and `%s` are the
+   * reform's readings rather than proleptic ones, and `Date.new(1500, 2, 29)`
+   * builds, as MRI's does.
+   *
+   * The `start` ARGUMENT is what has no bearer — `#start`, `#julian?` and
+   * `#new_start` are absent with it, and every conversion below takes the one
+   * `sg` MRI defaults to. RFC 0088 `date-state-onto-temporal-plaindate`.
    */
-  readonly #date: Temporal.PlainDate;
+  readonly #jd: number;
+
+  /**
+   * @internal `ComplexDateData`/`SimpleDateData`'s civil fields, which
+   * `get_c_civil` (`date_core.c:1297-1324`) fills in on first read and the
+   * `HAVE_CIVIL` flag then marks present.
+   */
+  #civil?: [ry: number, rm: number, rdom: number];
 
   /**
    * Ruby `Date.new(year = -4712, month = 1, mday = 1)` (ruby/date,
@@ -3793,23 +3818,26 @@ export class Date {
    * which writes an already-resolved day straight into a fresh
    * `SimpleDateData` under `HAVE_JD` and validates nothing — every caller
    * (`d_new_by_frags`, `date_s_jd`, `date_s_ordinal`, `date_s_commercial`)
-   * has already established the date is buildable.
-   *
-   * It is a static C function the module-level `d_new_by_frags` calls; TS has
-   * no member visibility between "the class body" and "exported", so a
-   * `static #` seam would be unreachable from the module-level ports and a
-   * `WeakMap` seam would be machinery ruby/date has no counterpart for. This
-   * overload is the smallest seam that reaches `#date`.
+   * has already established the date is buildable. {@link SEAT} is the brand
+   * that selects it.
    */
-  constructor(rjd: Temporal.PlainDate);
-  constructor(year: number | Temporal.PlainDate = -4712, month = 1, day = 1) {
-    if (year instanceof Temporal.PlainDate) {
-      this.#date = year;
+  constructor(seat: typeof SEAT, rjd: number);
+  constructor(year: number | typeof SEAT = -4712, month = 1, day = 1) {
+    if (typeof year === "symbol") {
+      this.#jd = month;
       return;
     }
     const r = cValidCivilP(year, month, day);
     if (r === null) throw new DateError("invalid date");
-    this.#date = plainDateFromJd(r);
+    this.#jd = r;
+  }
+
+  /**
+   * @internal `date_core.c` `get_c_civil` (`date_core.c:1297-1324`), which
+   * decodes the local Julian day into the civil fields on first read.
+   */
+  protected getCCivil(): [ry: number, rm: number, rdom: number] {
+    return (this.#civil ??= cJdToCivil(this.jd));
   }
 
   /**
@@ -3820,7 +3848,7 @@ export class Date {
    * so the conversion happens at the call.
    */
   static jd(jd = 0): Temporal.PlainDate {
-    return new Date(plainDateFromJd(jd)).toDate();
+    return new Date(SEAT, jd).toDate();
   }
 
   /**
@@ -3832,7 +3860,7 @@ export class Date {
   static ordinal(year = -4712, yday = 1): Temporal.PlainDate {
     const r = cValidOrdinalP(year, yday);
     if (r === null) throw new DateError("invalid date");
-    return new Date(plainDateFromJd(r)).toDate();
+    return new Date(SEAT, r).toDate();
   }
 
   /**
@@ -3856,7 +3884,7 @@ export class Date {
   static commercial(cwyear = -4712, cweek = 1, cwday = 1): Temporal.PlainDate {
     const r = cValidCommercialP(cwyear, cweek, cwday);
     if (r === null) throw new DateError("invalid date");
-    return new Date(plainDateFromJd(r)).toDate();
+    return new Date(SEAT, r).toDate();
   }
 
   /**
@@ -3975,19 +4003,19 @@ export class Date {
   }
 
   get year(): number {
-    return this.#date.year;
+    return this.getCCivil()[0];
   }
 
   get mon(): number {
-    return this.#date.month;
+    return this.getCCivil()[1];
   }
 
   get month(): number {
-    return this.#date.month;
+    return this.getCCivil()[1];
   }
 
   get day(): number {
-    return this.#date.day;
+    return this.getCCivil()[2];
   }
 
   /**
@@ -3996,13 +4024,13 @@ export class Date {
    * `date_core.c:1486-1497`), the astronomical Julian day the date names. This
    * is the LOCAL day — `m_jd` (`date_core.c:1459-1469`) is the UTC one
    * `m_real_jd` and `tmx_m_secs` read, and the two part company on a
-   * `DateTime` with an offset. It is
-   * the calendar-neutral reading every field below is derived from, which is
-   * why they agree with MRI at and before the calendar reform where
+   * `DateTime` with an offset. It is the whole of `Date`'s state and the
+   * calendar-neutral reading every field above is decoded from, which is why
+   * they agree with MRI at and before the calendar reform where
    * `Temporal.PlainDate`'s own proleptic Gregorian readers do not.
    */
   get jd(): number {
-    return cCivilToJd(this.#date.year, this.#date.month, this.#date.day);
+    return this.#jd;
   }
 
   /**
@@ -4031,8 +4059,11 @@ export class Date {
    * Ruby `Date#to_date` (ruby/date, `date_core.c` `date_to_date`, `date_core.c:8977-8981`), which
    * answers the receiver's `::Date` value — `self` in MRI, because MRI's
    * `::Date` value *is* the gem object. trails' `::Date` value is
-   * `Temporal.PlainDate` (RFC 0088's mapping table), so `self` is spelled as
-   * the seat.
+   * `Temporal.PlainDate` (RFC 0088's mapping table), so `self` is converted to
+   * it here. `Temporal.PlainDate` is proleptic Gregorian, so a Julian-only
+   * civil date — 1500-02-29, a real day under `Date::ITALY` — has no value to
+   * convert to and this raises where the gem-shaped object itself is fine
+   * ({@link plainDateFromJd}).
    *
    * **This is the opt-in seam RFC 0088 left open**, and it is a conversion
    * method rather than an options argument or a parallel entry point because
@@ -4044,7 +4075,7 @@ export class Date {
    * The exported {@link dNewByFrags} / {@link dtNewByFrags} answer it directly.
    */
   toDate(): Temporal.PlainDate {
-    return this.#date;
+    return plainDateFromJd(this.jd);
   }
 
   /** Ruby `Date#to_s` (ruby/date, `date_core.c` `d_lite_to_s`). */
@@ -4123,15 +4154,14 @@ export class DateTime extends DateWithoutParseStatics {
    * Every reader converts back on the way out through {@link #mLocalJd} /
    * {@link #mLocalDf}, and the constructor converts in through
    * `jd_local_to_utc` / `df_local_to_utc`, as `dt_new_by_frags` does
-   * (`date_core.c:8311-8313`). The C carries the day as a Julian day number;
-   * `Date` is seated on `Temporal.PlainDate`, so this is that date.
+   * (`date_core.c:8311-8313`).
    */
-  readonly #date: Temporal.PlainDate;
+  readonly #jd: number;
   readonly #df: number;
   /**
    * @internal `ComplexDateData`'s `sf`, the sub-second part in **nanoseconds**
    * (`date_core.c:215-231`). `jd_local_to_utc` / `df_local_to_utc` do not touch
-   * it, so unlike {@link #date} and {@link #df} it is the same value read
+   * it, so unlike {@link #jd} and {@link #df} it is the same value read
    * locally or in UTC.
    *
    * The C's `d_lite_plus` T_FLOAT arm answers an Integer here
@@ -4142,15 +4172,6 @@ export class DateTime extends DateWithoutParseStatics {
    */
   readonly #sf: Rational;
   readonly #of: number;
-
-  /**
-   * @internal `ComplexDateData`'s civil fields, which the C comments as
-   * "decoded as local" and leaves to `get_c_civil` (`date_core.c:1297-1324`) to
-   * fill in on first read. The inherited `Date` state cannot stand in for them:
-   * it was written from the constructor's *pre-conversion* civil date, which a
-   * `24:00:00` time of day rolls off.
-   */
-  #civil?: Temporal.PlainDate;
 
   /**
    * Ruby `DateTime.new(y, m, d, h = 0, min = 0, s = 0, offset = 0)` (ruby/date,
@@ -4231,12 +4252,11 @@ export class DateTime extends DateWithoutParseStatics {
    * UTC (`date_core.c:8311-8313`) and the offset are written straight into a
    * fresh `ComplexDateData`, with neither a civil triple nor a time of day to
    * validate. The arguments are `d_complex_new_internal`'s own `rjd`, `df`,
-   * `sf` and `of`, in that order. Same TS shortcoming as {@link Date}'s
-   * counterpart overload.
+   * `sf` and `of`, in that order, behind the {@link SEAT} brand.
    */
-  constructor(rjd: Temporal.PlainDate, df: number, sf: Rational, of: number);
+  constructor(seat: typeof SEAT, rjd: number, df: number, sf: Rational, of: number);
   constructor(
-    year: number | Temporal.PlainDate,
+    year: number | typeof SEAT,
     month?: number,
     day?: number | Rational,
     hour?: number | Rational,
@@ -4244,12 +4264,13 @@ export class DateTime extends DateWithoutParseStatics {
     second?: number | Rational,
     offset?: number | Rational | string,
   ) {
-    if (year instanceof Temporal.PlainDate) {
-      const df = month ?? 0;
-      const sf = (day ?? new Rational(0, 1)) as Rational;
-      const of = (hour ?? 0) as number;
-      super(jdUtcToLocal(year, df, of));
-      this.#date = year;
+    if (typeof year === "symbol") {
+      const rjd = month as number;
+      const df = day as number;
+      const sf = hour as Rational;
+      const of = minute as number;
+      super(SEAT, jdUtcToLocal(rjd, df, of));
+      this.#jd = rjd;
       this.#df = df;
       this.#sf = sf;
       this.#of = of;
@@ -4285,14 +4306,14 @@ export class DateTime extends DateWithoutParseStatics {
       fr2 = fr2 instanceof Rational ? fr2.add(DAY_IN_SECONDS) : fr2 + DAY_IN_SECONDS;
     }
     const localDf = timeToDf(rh, rmin, rs);
-    let date = jdLocalToUtc(plainDateFromJd(rjd), localDf, rof);
+    let jd = jdLocalToUtc(rjd, localDf, rof);
     let df = dfLocalToUtc(localDf, rof);
     df += fr2 instanceof Rational ? fr2.div(1) : Math.floor(fr2);
     if (df >= DAY_IN_SECONDS) {
-      date = date.add({ days: 1 });
+      jd += 1;
       df -= DAY_IN_SECONDS;
     }
-    this.#date = date;
+    this.#jd = jd;
     this.#df = df;
     this.#sf =
       fr2 instanceof Rational
@@ -4306,7 +4327,7 @@ export class DateTime extends DateWithoutParseStatics {
    * `datetime_s_parse` → `dt_new_by_frags`), which is `Date.parse`'s
    * `Date._parse` followed by the DateTime-shaped build.
    */
-  static parse(str: string, comp = true): Temporal.PlainDateTime {
+  static parse(str: string, comp = true): Temporal.PlainDateTime | Temporal.ZonedDateTime {
     return dtNewByFrags(Date._parse(str, comp)).toDatetime();
   }
 
@@ -4329,7 +4350,10 @@ export class DateTime extends DateWithoutParseStatics {
    * calendar reform, which `Temporal.PlainDate` has no bearer for, so it is not
    * a parameter here.
    */
-  static strptime(str = JULIAN_EPOCH_DATETIME, fmt = "%FT%T%z"): Temporal.PlainDateTime {
+  static strptime(
+    str = JULIAN_EPOCH_DATETIME,
+    fmt = "%FT%T%z",
+  ): Temporal.PlainDateTime | Temporal.ZonedDateTime {
     return dtNewByFrags(Date._strptime(str, fmt)).toDatetime();
   }
 
@@ -4338,8 +4362,8 @@ export class DateTime extends DateWithoutParseStatics {
    * `local_jd` (`date_core.c:1326-1333`), the complex arm: the stored day read
    * back in local terms.
    */
-  #mLocalJd(): Temporal.PlainDate {
-    return jdUtcToLocal(this.#date, this.#df, this.#of);
+  #mLocalJd(): number {
+    return jdUtcToLocal(this.#jd, this.#df, this.#of);
   }
 
   /**
@@ -4351,47 +4375,23 @@ export class DateTime extends DateWithoutParseStatics {
   }
 
   /**
-   * @internal `date_core.c` `get_c_civil` (`date_core.c:1297-1324`), which
-   * decodes the local day into the civil fields on first read.
-   */
-  #getCCivil(): Temporal.PlainDate {
-    return (this.#civil ??= this.#mLocalJd());
-  }
-
-  override get year(): number {
-    return this.#getCCivil().year;
-  }
-
-  override get mon(): number {
-    return this.#getCCivil().month;
-  }
-
-  override get month(): number {
-    return this.#getCCivil().month;
-  }
-
-  override get day(): number {
-    return this.#getCCivil().day;
-  }
-
-  /**
    * Ruby `DateTime#jd` reads the LOCAL day, not the stored UTC one
-   * (`m_local_jd`, `date_core.c:1486-1497`), which is the day `wday` and `yday`
-   * are then `c_jd_to_wday` / `c_jd_to_ordinal` over.
+   * (`m_local_jd`, `date_core.c:1486-1497`), which is the day `wday`, `yday`
+   * and the inherited {@link Date#getCCivil} are then `c_jd_to_wday` /
+   * `c_jd_to_ordinal` / `c_jd_to_civil` over.
    */
   override get jd(): number {
-    const local = this.#mLocalJd();
-    return cCivilToJd(local.year, local.month, local.day);
+    return this.#mLocalJd();
   }
 
   /**
-   * Ruby `DateTime#to_date` (ruby/date, `date_core.c` `datetime_to_date`, `date_core.c:9069-9095`), the
-   * calendar day alone. The inherited {@link Date#toDate} cannot stand in: the
-   * `Date` half was written from the constructor's *pre-conversion* civil date,
-   * which a `24:00:00` time of day rolls off — same reason `#civil` exists.
+   * Ruby `DateTime#to_date` (ruby/date, `date_core.c` `datetime_to_date`,
+   * `date_core.c:9069-9095`), the calendar day alone: the C builds a fresh
+   * `Date` on `m_local_jd` — the LOCAL day, which is where a `24:00:00` time of
+   * day has already rolled the date on — and this is that `Date`'s seat.
    */
   override toDate(): Temporal.PlainDate {
-    return this.#getCCivil();
+    return new Date(SEAT, this.#mLocalJd()).toDate();
   }
 
   /**
@@ -4400,21 +4400,33 @@ export class DateTime extends DateWithoutParseStatics {
    * `::DateTime` value is `Temporal.PlainDateTime` (RFC 0088's mapping table),
    * read in LOCAL terms, as every reader above is.
    *
-   * The offset is NOT carried into the seat. A `Temporal` offset time zone is
-   * minute-precision, and `date_zone_to_diff` (`date_parse.c:523-528`) answers
-   * seconds — the sub-minute offsets `time.ts:26-28` keeps as a `number` for
-   * exactly this reason. It stays reachable as a `number` on the gem-shaped
-   * object ({@link DateTime#offset}, {@link DateTime#zone}), which RFC 0088
-   * lists as one of the three carve-outs where Temporal has no analogue.
+   * RFC 0088's mapping table says "+ offset where carried", so an `of` the
+   * string named comes out as a `Temporal.ZonedDateTime` in the offset time
+   * zone {@link of2str} spells, and an `of` of `0` — which is also what a
+   * string that named no zone leaves behind — as a bare `PlainDateTime`, the
+   * value `::DateTime` has when `m_of` is zero.
+   *
+   * **A sub-minute offset truncates to the minute in the seat.**
+   * `date_zone_to_diff` (`date_parse.c:523-528`) answers SECONDS — it multiplies
+   * the parsed `hh`, `mm` and `ss` out and keeps all three — while a `Temporal`
+   * offset time zone is minute-precision and has nowhere to put the seconds.
+   * The truncation is `of2str`'s own (`date_core.c:1973-1980`): its
+   * `"%c%02d:%02d"` drops the same seconds, so `DateTime#zone` already answers
+   * `"+00:44"` for the `-00:44:30`-style offsets that motivate the case, and
+   * spelling the zone with `of2str` makes the seat agree with `#zone` rather
+   * than inventing a third reading. The exact seconds stay reachable on the
+   * gem-shaped object ({@link DateTime#offset}, {@link DateTime#zone}); the
+   * `PlainDateTime` fallback was the alternative and is strictly lossier — it
+   * drops the whole offset rather than its last few seconds.
    *
    * `#sf` is a `Rational` of nanoseconds exact at any denominator, and
    * `PlainDateTime` holds nanoseconds; the sub-nanosecond tail truncates, as
    * `Time#nsec` does.
    */
-  toDatetime(): Temporal.PlainDateTime {
+  toDatetime(): Temporal.PlainDateTime | Temporal.ZonedDateTime {
     const [h, min, s] = dfToTime(this.#mLocalDf());
     const ns = Number(this.#sf.numerator / this.#sf.denominator);
-    return this.#getCCivil().toPlainDateTime({
+    const plain = this.toDate().toPlainDateTime({
       hour: h,
       minute: min,
       second: s,
@@ -4422,6 +4434,8 @@ export class DateTime extends DateWithoutParseStatics {
       microsecond: Math.floor(ns / 1000) % 1000,
       nanosecond: ns % 1000,
     });
+    if (this.#of === 0) return plain;
+    return plain.toZonedDateTime(of2str(this.#of));
   }
 
   /** Ruby `DateTime#hour` (ruby/date, `date_core.c` `d_lite_hour` over `m_hour`, `date_core.c:1919-1932`). */

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -3787,9 +3787,9 @@ export class Date {
    * spelling.
    *
    * The stored half is the Julian day — the C's `HAVE_JD` arm — and the civil
-   * triple is decoded from it on read through `get_c_civil` over
-   * {@link cJdToCivil} under {@link DEFAULT_SG}, exactly as `get_c_civil`
-   * (`date_core.c:1297-1324`) does. Keeping the calendar-neutral half is what
+   * triple is decoded from it on read through {@link cJdToCivil} under
+   * {@link DEFAULT_SG}, exactly as `get_s_civil` (`date_core.c:1189-1204`)
+   * does. Keeping the calendar-neutral half is what
    * makes both cases above representable: `wday`, `yday` and `%s` are the
    * reform's readings rather than proleptic ones, and `Date.new(1500, 2, 29)`
    * builds, as MRI's does.
@@ -3801,9 +3801,9 @@ export class Date {
   readonly #jd: number;
 
   /**
-   * @internal `ComplexDateData`/`SimpleDateData`'s civil fields, which
-   * `get_c_civil` (`date_core.c:1297-1324`) fills in on first read and the
-   * `HAVE_CIVIL` flag then marks present.
+   * @internal `SimpleDateData`'s civil fields (`date_core.c:203-213`), which
+   * the civil decode below fills in on first read and the `HAVE_CIVIL` flag
+   * then marks present.
    */
   #civil?: [ry: number, rm: number, rdom: number];
 
@@ -3833,8 +3833,15 @@ export class Date {
   }
 
   /**
-   * @internal `date_core.c` `get_c_civil` (`date_core.c:1297-1324`), which
-   * decodes the local Julian day into the civil fields on first read.
+   * @internal The C's civil decode, which fills the civil fields in on first
+   * read and sets `HAVE_CIVIL`. Ruby splits it in two by data shape, under an
+   * assertion each: `get_s_civil` (`date_core.c:1189-1204`) reads `x->s.jd`
+   * straight, and `get_c_civil` (`date_core.c:1297-1324`) reads
+   * `m_local_jd` — the stored UTC day taken back through `jd_utc_to_local`
+   * (`date_core.c:1326-1333`). One method stands in for both here because
+   * `this.jd` already IS that split: it is the stored day on `Date` and
+   * {@link DateTime#jd}'s `m_local_jd` on `DateTime`, so the branch the C makes
+   * on `simple_dat_p`/`complex_dat_p` is the one TS makes on the receiver.
    */
   #getCCivil(): [ry: number, rm: number, rdom: number] {
     return (this.#civil ??= cJdToCivil(this.jd));
@@ -4377,8 +4384,10 @@ export class DateTime extends DateWithoutParseStatics {
   /**
    * Ruby `DateTime#jd` reads the LOCAL day, not the stored UTC one
    * (`m_local_jd`, `date_core.c:1486-1497`), which is the day `wday`, `yday`
-   * and the inherited `get_c_civil` are then `c_jd_to_wday` /
-   * `c_jd_to_ordinal` / `c_jd_to_civil` over.
+   * and the inherited civil decode are then `c_jd_to_wday` /
+   * `c_jd_to_ordinal` / `c_jd_to_civil` over — which is what makes that decode
+   * `get_c_civil` (`date_core.c:1297-1324`) on a `DateTime` where it is
+   * `get_s_civil` (`:1189-1204`) on a `Date`.
    */
   override get jd(): number {
     return this.#mLocalJd();

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -3787,7 +3787,7 @@ export class Date {
    * spelling.
    *
    * The stored half is the Julian day — the C's `HAVE_JD` arm — and the civil
-   * triple is decoded from it on read through {@link Date#getCCivil} over
+   * triple is decoded from it on read through `get_c_civil` over
    * {@link cJdToCivil} under {@link DEFAULT_SG}, exactly as `get_c_civil`
    * (`date_core.c:1297-1324`) does. Keeping the calendar-neutral half is what
    * makes both cases above representable: `wday`, `yday` and `%s` are the
@@ -3836,7 +3836,7 @@ export class Date {
    * @internal `date_core.c` `get_c_civil` (`date_core.c:1297-1324`), which
    * decodes the local Julian day into the civil fields on first read.
    */
-  protected getCCivil(): [ry: number, rm: number, rdom: number] {
+  #getCCivil(): [ry: number, rm: number, rdom: number] {
     return (this.#civil ??= cJdToCivil(this.jd));
   }
 
@@ -4003,19 +4003,19 @@ export class Date {
   }
 
   get year(): number {
-    return this.getCCivil()[0];
+    return this.#getCCivil()[0];
   }
 
   get mon(): number {
-    return this.getCCivil()[1];
+    return this.#getCCivil()[1];
   }
 
   get month(): number {
-    return this.getCCivil()[1];
+    return this.#getCCivil()[1];
   }
 
   get day(): number {
-    return this.getCCivil()[2];
+    return this.#getCCivil()[2];
   }
 
   /**
@@ -4131,7 +4131,7 @@ export class Date {
  * therefore declare exactly what they answer.
  */
 const DateWithoutParseStatics: (new (year?: number, month?: number, day?: number) => Date) &
-  (new (rjd: Temporal.PlainDate) => Date) &
+  (new (seat: typeof SEAT, rjd: number) => Date) &
   Omit<typeof Date, "parse" | "strptime"> = Date;
 
 /**
@@ -4377,7 +4377,7 @@ export class DateTime extends DateWithoutParseStatics {
   /**
    * Ruby `DateTime#jd` reads the LOCAL day, not the stored UTC one
    * (`m_local_jd`, `date_core.c:1486-1497`), which is the day `wday`, `yday`
-   * and the inherited {@link Date#getCCivil} are then `c_jd_to_wday` /
+   * and the inherited `get_c_civil` are then `c_jd_to_wday` /
    * `c_jd_to_ordinal` / `c_jd_to_civil` over.
    */
   override get jd(): number {


### PR DESCRIPTION
Three RFC-0088 / RFC-0051 convergence stories. The fourth story in the bundle,
`move-adapter-specific-snapshot-off-ar-internal-metadata`, was **released
unbuilt** — its own findings block says it must be its own PR (`load-schema-helper.ts:526-532`
reshapes one story at a time) and that it is bigger than its 160 LOC estimate;
bundling it here would also have blown the 700 LOC ceiling.

## `Date` seats the Julian day (`date-state-julian-only-spellings-unbuildable`)

`Date`'s state was a `Temporal.PlainDate` — proleptic Gregorian, so it can hold
only the spellings that calendar has. Julian leap years have no century rule, so
1500-02-29, 1400-02-29 and 1300-02-29 are real days under `Date::ITALY` with no
proleptic Gregorian spelling, and `plainDateFromJd` raised where MRI builds them.

State is now the Julian day, the `HAVE_JD` arm of `SimpleDateData`
(`date_core.c:203-213`), with the civil triple decoded on read through
`get_c_civil` (`date_core.c:1297-1324`). `jd_local_to_utc` / `jd_utc_to_local`
(`date_core.c:922-943`) go back to the C's own `jd -= 1` / `jd += 1`; the
`Temporal` day arithmetic they had was wrong across the reform boundary for the
same reason. `Temporal.PlainDate` is now only the *return* seat, reached at
`to_date` — where a Julian-only day still has no value and raises, which is the
substrate limit rather than the port's.

Verified against `ruby 3.3.11 -rdate`:

```
Date.new(1500, 2, 29)  "1500-02-29"  jd 2268992  wday 6  yday 60
Date.new(1400, 2, 29)  "1400-02-29"  jd 2232467  wday 0  yday 60
Date.new(1300, 2, 29)  "1300-02-29"  jd 2195942  wday 1  yday 60
Date.new(1500, 2, -1)  "1500-02-29"
```

`civilOrError(1500, 2, 29)` flips from `"E"` to `[1500, 2, 29]`, and `(1500, 2, -1)`
with it — `c_find_ldom`'s scan already made February 1500 twenty-nine days long.

## `DateTime`'s default return carries the offset (`datetime-temporal-seat-drops-the-parsed-offset`)

`DateTime#to_datetime` read the local civil date and time of day and dropped `of`,
so `DateTime.parse("2008-03-01T06:00:00+09:00")` and the same string without a zone
answered the same `PlainDateTime` — RFC 0088's "+ offset where carried" half was
missing.

It now answers a `Temporal.ZonedDateTime` in the offset zone `of2str` spells
(`date_core.c:1973-1980`) whenever `of` is nonzero, and a `PlainDateTime` when it is
zero — the value `::DateTime` has when `m_of` is zero, which is also what a string
naming no zone leaves behind.

**Sub-minute offsets truncate to the minute in the seat**, decided and cited at the
call site. `date_zone_to_diff` (`date_parse.c:523-528`) answers seconds and a
`Temporal` offset zone is minute-precision. The truncation is `of2str`'s own — its
`"%c%02d:%02d"` drops the same seconds, so `DateTime#zone` already answers `"-00:44"`
for `-00:44:30` and the seat now agrees with `#zone` instead of inventing a third
reading. The `PlainDateTime` fallback was the alternative and is strictly lossier:
it drops the whole offset rather than its last few seconds. Exact seconds stay on
`DateTime#offset` / `#zone`.

## The adapter proxy consults no probe-key set (`adapter-proxy-trap-carves-out-string-probe-keys`)

`ADAPTER_PROXY_PROBE_KEYS` and its doc block are deleted; the trap's only carve-out
is `typeof prop === "symbol"`, exactly as `NullPool`'s trap has been since #6261 — a
JS `Symbol` cannot spell a Ruby send. The `pool` and `adapterName` data-property arms
stay (`abstract_adapter.rb:153`'s `@pool`).

The rule the code already stated — dispatch only names a real adapter exposes as a
method — now holds before the first checkout too: `AbstractAdapter.prototype` stands
in for the sample connection when the pool has no connection yet. That is what keeps
`then` from resolving to a callable and making the proxy a thenable, which is the
hazard the deleted set was standing in for. `_getAdapterProxy` has no non-test
callers on `main`, so the blast radius is the tests below.

The guard `connection-pool.trails.test.ts` carries for `NullPool` is now carried here
too: a deliberately failing assertion whose subject holds an adapter proxy reports its
own failure, not an error from the reporter.

## Checks

- `pnpm typecheck`, `pnpm build` clean.
- `pnpm api:calls` — OK, no new rows.
- `pnpm api:extra --package date` — 0 novel.
- `pnpm vitest run` over `packages/date`, `activesupport/src/i18n.test.ts`,
  `activemodel/src/type`, `connection-pool.test.ts`, `connection-pool.trails.test.ts`
  — 553 passed.
- 269 insertions / 210 deletions.

Closes-story: date-state-julian-only-spellings-unbuildable
Closes-story: datetime-temporal-seat-drops-the-parsed-offset
Closes-story: adapter-proxy-trap-carves-out-string-probe-keys
