### PR TITLE
fix(activerecord): fixture teardown deletes on a live connection; DatabaseStatements host holds a real pool; MigrationContext defaults its collaborators

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
@@ -44,6 +44,12 @@ import { ActiveRecord } from "../../ar-config.js";
 import type { QueryTransformer } from "../../query-transformers.js";
 import type { Quoting } from "./quoting.js";
 import { fixtures } from "../../test-fixtures.js";
+import { newSqlitePool } from "../../support/pooled-sqlite-adapter.js";
+
+// Rails' DatabaseStatements host is an AbstractAdapter, whose @pool is a real
+// ConnectionPool (abstract_adapter.rb:153), so the mock hosts below hold one
+// rather than a two-member literal standing in for it.
+const pool = newSqlitePool();
 
 describe("DatabaseStatements", () => {
   // `to_sql` compiles through `Table.engine`'s connection (arel/nodes/node.rb:148-153),
@@ -93,6 +99,7 @@ describe("DatabaseStatements", () => {
     it("wraps block in begin/commit on success", async () => {
       const calls: string[] = [];
       const host: DatabaseStatementsHost = {
+        pool,
         beginDbTransaction: async () => {
           calls.push("begin");
         },
@@ -114,6 +121,7 @@ describe("DatabaseStatements", () => {
 
     it("catches Rollback errors and returns undefined", async () => {
       const host: DatabaseStatementsHost = {
+        pool,
         beginDbTransaction: async () => {},
         commitDbTransaction: async () => {},
         rollbackDbTransaction: async () => {},
@@ -192,6 +200,7 @@ describe("DatabaseStatements", () => {
     it("sets written on open transaction for write queries", () => {
       const txn = { open: true, written: false };
       const host: DatabaseStatementsHost = {
+        pool,
         currentTransaction: () => txn,
         isWriteQuery: () => true,
       };
@@ -202,6 +211,7 @@ describe("DatabaseStatements", () => {
     it("does not set written for read queries", () => {
       const txn = { open: true, written: false };
       const host: DatabaseStatementsHost = {
+        pool,
         currentTransaction: () => txn,
         isWriteQuery: () => false,
       };
@@ -213,6 +223,7 @@ describe("DatabaseStatements", () => {
   describe("is transaction open", () => {
     it("returns true when transaction is open", () => {
       const host: DatabaseStatementsHost = {
+        pool,
         currentTransaction: () => ({ open: true }),
       };
       expect(isTransactionOpen.call(host)).toBe(true);
@@ -220,6 +231,7 @@ describe("DatabaseStatements", () => {
 
     it("returns false when no transaction", () => {
       const host: DatabaseStatementsHost = {
+        pool,
         currentTransaction: () => ({ open: false }),
       };
       expect(isTransactionOpen.call(host)).toBe(false);
@@ -299,6 +311,7 @@ describe("DatabaseStatements", () => {
       const { insertFixturesSet } = await import("./database-statements.js");
       const host: DatabaseStatementsHost &
         Pick<Quoting, "quote" | "quoteTableName" | "quoteColumnName"> = {
+        pool,
         execute: async (sql: string) => {
           executed.push(sql);
         },
@@ -330,6 +343,7 @@ describe("DatabaseStatements", () => {
       let scopedTables: string[] | undefined;
       const host: DatabaseStatementsHost &
         Pick<Quoting, "quote" | "quoteTableName" | "quoteColumnName"> = {
+        pool,
         execute: async () => {},
         transaction: async <T>(fn: (tx?: unknown) => Promise<T> | T) => {
           await fn();
@@ -359,10 +373,8 @@ describe("DatabaseStatements", () => {
       const { truncateTables } = await import("./database-statements.js");
       const executed: string[] = [];
       let scopedTables: string[] | undefined;
-      const host: DatabaseStatementsHost &
-        Pick<Quoting, "quoteTableName"> & {
-          pool: NonNullable<DatabaseStatementsHost["pool"]>;
-        } = {
+      const host: DatabaseStatementsHost & Pick<Quoting, "quoteTableName"> = {
+        pool,
         execute: async (sql: string) => {
           executed.push(sql);
         },
@@ -371,10 +383,6 @@ describe("DatabaseStatements", () => {
           await fn();
         },
         quoteTableName: (n: string) => `"${n}"`,
-        pool: {
-          schemaMigration: { tableName: "schema_migrations" },
-          internalMetadata: { tableName: "ar_internal_metadata" },
-        },
       };
 
       // schema_migrations / ar_internal_metadata are filtered out before scoping.
@@ -395,6 +403,7 @@ describe("DatabaseStatements", () => {
     } {
       const executed: Array<{ sql: string; name?: string | null; receiver: unknown }> = [];
       const host: QuoterHost = {
+        pool,
         async execute(sql: string, _binds?: unknown[], name?: string | null) {
           // captures `this` to verify receiver is preserved
           executed.push({ sql, name, receiver: this });
@@ -491,13 +500,14 @@ describe("performQuery", () => {
 
 describe("preprocessQuery", () => {
   it("returns sql unchanged when no write guard or transaction", () => {
-    const host: DatabaseStatementsHost = {};
+    const host: DatabaseStatementsHost = { pool };
     expect(preprocessQuery.call(host, "SELECT 1")).toBe("SELECT 1");
   });
 
   it("calls checkIfWriteQuery on the host", () => {
     let checked: string | undefined;
     const host: DatabaseStatementsHost = {
+      pool,
       checkIfWriteQuery(sql) {
         checked = sql;
       },
@@ -520,7 +530,7 @@ describe("preprocessQuery", () => {
     }
 
     it("applies registered transformers in order, threading the connection", () => {
-      const host: DatabaseStatementsHost = {};
+      const host: DatabaseStatementsHost = { pool };
       const seen: unknown[] = [];
       withTransformers(
         [
@@ -540,7 +550,7 @@ describe("preprocessQuery", () => {
     });
 
     it("does not double-apply when a transformer re-enters preprocessQuery", () => {
-      const host: DatabaseStatementsHost = {};
+      const host: DatabaseStatementsHost = { pool };
       let nested = "";
       withTransformers(
         [
@@ -565,6 +575,7 @@ describe("preprocessQuery", () => {
 describe("select", () => {
   it("delegates to internalExecQuery and returns a Result", async () => {
     const host: DatabaseStatementsHost = {
+      pool,
       async internalExecute(_sql, _name, _binds) {
         return [{ id: 1 }];
       },
@@ -578,6 +589,7 @@ describe("execInsert", () => {
   function makeInsertHost(supportsReturning: boolean) {
     let capturedSql = "";
     const host: DatabaseStatementsHost = {
+      pool,
       supportsInsertReturning: () => supportsReturning,
       quoteColumnName: (c) => `"${c}"`,
       internalExecute: async (sql: string) => {
@@ -612,7 +624,7 @@ describe("execInsert", () => {
 
 describe("sqlForInsert", () => {
   it("returns sql and binds unchanged when adapter does not support RETURNING", () => {
-    const host: DatabaseStatementsHost = { supportsInsertReturning: () => false };
+    const host: DatabaseStatementsHost = { pool, supportsInsertReturning: () => false };
     const [sql, binds] = sqlForInsert.call(host, "INSERT INTO t (x) VALUES (1)", "id", [], null);
     expect(sql).toBe("INSERT INTO t (x) VALUES (1)");
     expect(binds).toEqual([]);
@@ -620,6 +632,7 @@ describe("sqlForInsert", () => {
 
   it("appends RETURNING clause when pk is supplied and adapter supports it", () => {
     const host: DatabaseStatementsHost = {
+      pool,
       supportsInsertReturning: () => true,
       quoteColumnName: (c) => `"${c}"`,
     };
@@ -629,6 +642,7 @@ describe("sqlForInsert", () => {
 
   it("uses explicit returning list when provided", () => {
     const host: DatabaseStatementsHost = {
+      pool,
       supportsInsertReturning: () => true,
       quoteColumnName: (c) => `"${c}"`,
     };
@@ -647,6 +661,7 @@ describe("sqlForInsert", () => {
     // want any pk-derived RETURNING column. extractTableRefFromInsertSql /
     // primaryKey lookup must be skipped too.
     const host: DatabaseStatementsHost = {
+      pool,
       supportsInsertReturning: () => true,
       quoteColumnName: (c) => `"${c}"`,
       primaryKey: () => {
@@ -659,6 +674,7 @@ describe("sqlForInsert", () => {
 
   it("still honours explicit returning list when pk=false", () => {
     const host: DatabaseStatementsHost = {
+      pool,
       supportsInsertReturning: () => true,
       quoteColumnName: (c) => `"${c}"`,
     };
@@ -716,13 +732,13 @@ describe("defaultInsertValue", () => {
 
 describe("returningColumnValues", () => {
   it("returns [first value of first row] from result", () => {
-    const host: DatabaseStatementsHost = {};
+    const host: DatabaseStatementsHost = { pool };
     const result = new Result(["id"], [[42]]);
     expect(returningColumnValues.call(host, result)).toEqual([42]);
   });
 
   it("returns [undefined] for empty result", () => {
-    const host: DatabaseStatementsHost = {};
+    const host: DatabaseStatementsHost = { pool };
     expect(returningColumnValues.call(host, Result.empty())).toEqual([undefined]);
   });
 });
@@ -738,6 +754,7 @@ describe("buildFixtureSql / buildFixtureStatements / buildTruncateStatement(s) /
   function makeHost(quoter: { q?: (n: string) => string } = {}): FixtureHost {
     const q = quoter.q ?? ((n: string) => `"${n}"`);
     return {
+      pool,
       quote: (v: unknown) => (typeof v === "string" ? `'${v}'` : String(v)),
       quoteTableName: q,
       quoteColumnName: q,
@@ -824,6 +841,7 @@ describe("buildFixtureSql / buildFixtureStatements / buildTruncateStatement(s) /
 
     it("uses adapter quote() for value escaping", () => {
       const host: FixtureHost = {
+        pool,
         quote: (v: unknown) => (typeof v === "string" ? `E'${v}'` : String(v)),
         quoteTableName: (n) => `"${n}"`,
         quoteColumnName: (n) => `"${n}"`,

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -43,6 +43,7 @@ import {
 } from "./sql-datetime.js";
 import { Value as TimeValue } from "../../type/time.js";
 import type { Quoting } from "./quoting.js";
+import type { ConnectionPool, NullPool } from "./connection-pool.js";
 import { DateInfinity, DateNegativeInfinity } from "@blazetrails/activemodel";
 import { TransactionManager } from "./transaction.js";
 import { exceedsBindParamsLimit } from "./database-limits.js";
@@ -165,7 +166,9 @@ export interface DatabaseStatementsHost {
   resetIsolationLevel?(): void | Promise<void>;
   emptyInsertStatementValue?(pk?: string | null): string;
   transaction?<T>(fn: (tx?: unknown) => Promise<T> | T, opts?: unknown): Promise<T | undefined>;
-  pool?: { schemaMigration: { tableName: string }; internalMetadata: { tableName: string } };
+  // Rails' host is an AbstractAdapter, whose @pool is a real ConnectionPool or
+  // the NullPool assigned in initialize (abstract_adapter.rb:153) — never absent.
+  pool: ConnectionPool | NullPool;
   /** @internal */
   checkIfWriteQuery?(sql: string): void;
   /** @internal */
@@ -747,8 +750,7 @@ export async function truncate(
  * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#truncate_tables
  */
 export async function truncateTables(
-  this: DatabaseStatementsHost &
-    Pick<Quoting, "quoteTableName"> & { pool: NonNullable<DatabaseStatementsHost["pool"]> },
+  this: DatabaseStatementsHost & Pick<Quoting, "quoteTableName">,
   ...tableNames: string[]
 ): Promise<void> {
   const schemaMigrationTable = this.pool.schemaMigration.tableName;
@@ -1637,7 +1639,7 @@ export const DatabaseStatements = {
     // SQL string passes through both unchanged, an Arel manager compiles here.
     arel = arelFromRelation(arel);
     const [sql, compiledBinds, compiledPreparable, compiledAllowRetry] = toSqlAndBinds.call(
-      this as DatabaseStatementsHost,
+      this as unknown as DatabaseStatementsHost,
       arel,
       binds ?? [],
       opts?.preparable ?? null,

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -1537,6 +1537,7 @@ export { deleteStatement as remove };
 // ---------------------------------------------------------------------------
 
 interface DatabaseStatementsDefaultsHost {
+  pool: ConnectionPool | NullPool;
   execute(
     sql: string,
     binds?: unknown[],
@@ -1639,7 +1640,7 @@ export const DatabaseStatements = {
     // SQL string passes through both unchanged, an Arel manager compiles here.
     arel = arelFromRelation(arel);
     const [sql, compiledBinds, compiledPreparable, compiledAllowRetry] = toSqlAndBinds.call(
-      this as unknown as DatabaseStatementsHost,
+      this as DatabaseStatementsHost,
       arel,
       binds ?? [],
       opts?.preparable ?? null,

--- a/packages/activerecord/src/migration-context.trails.test.ts
+++ b/packages/activerecord/src/migration-context.trails.test.ts
@@ -184,11 +184,14 @@ describe("MigrationContext connected surface", () => {
     await expect(context.forward(1)).rejects.toThrow(UnknownMigrationVersionError);
   });
 
-  it("a context built without a schemaMigration raises rather than half-answering", () => {
+  it("a context built without a schemaMigration defaults it from the connection pool", () => {
     const discoveryOnly = new MigrationContext([`${MIGRATIONS_ROOT}/valid`]);
 
+    // Discovery never consults the collaborators, so it answers regardless.
     expect(discoveryOnly.migrations).toHaveLength(3);
-    expect(() => discoveryOnly.schemaMigration).toThrow(/without a schema_migration/);
-    expect(() => discoveryOnly.internalMetadata).toThrow(/without an internal_metadata/);
+    // Rails: `schema_migration || SchemaMigration.new(connection_pool)`
+    // (migration.rb:1214-1218).
+    expect(discoveryOnly.schemaMigration).toBeInstanceOf(SchemaMigration);
+    expect(discoveryOnly.internalMetadata).toBeInstanceOf(InternalMetadata);
   });
 });

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1898,15 +1898,19 @@ function byVersion(a: MigrationProxy, b: MigrationProxy): number {
  */
 export class MigrationContext {
   readonly migrationsPaths: string[];
-  private readonly _schemaMigration?: SchemaMigration;
-  private readonly _internalMetadata?: InternalMetadata;
+  private _schemaMigration?: SchemaMigration;
+  private _internalMetadata?: InternalMetadata;
 
   /**
-   * Rails defaults `schema_migration` / `internal_metadata` from
-   * `connection_pool` (`migration.rb:1214-1218`); trails has no pool to reach
-   * from here, so they stay optional. A context built without them still
-   * answers the connectionless half — `migrationsPaths`, `migrations` and the
-   * file discovery under it — which is all the CLI's bootstrap needs.
+   * Rails defaults both collaborators from `connection_pool` right here —
+   * `schema_migration || SchemaMigration.new(connection_pool)`
+   * (`migration.rb:1214-1218`). The default is resolved on first read instead
+   * of in the constructor: Rails can name `connection_pool` eagerly because
+   * `DatabaseTasks.migration_connection_pool` always has one by the time a
+   * context is built, while trails builds connectionless contexts for file
+   * discovery (`migrations`, `migrationFiles`, `parseMigrationFilename` — the
+   * surface Rails' own context never consults `@schema_migration` from), where
+   * the pool lookup would throw at construction and take discovery with it.
    */
   constructor(
     migrationsPaths: string[],
@@ -1920,18 +1924,22 @@ export class MigrationContext {
 
   /** Mirrors: ActiveRecord::MigrationContext#schema_migration */
   get schemaMigration(): SchemaMigration {
-    if (!this._schemaMigration) {
-      throw new MigrationError("MigrationContext was built without a schema_migration");
-    }
-    return this._schemaMigration;
+    return (this._schemaMigration ??= new SchemaMigration(this.connectionPool()));
   }
 
   /** Mirrors: ActiveRecord::MigrationContext#internal_metadata */
   get internalMetadata(): InternalMetadata {
-    if (!this._internalMetadata) {
-      throw new MigrationError("MigrationContext was built without an internal_metadata");
-    }
-    return this._internalMetadata;
+    return (this._internalMetadata ??= new InternalMetadata(this.connectionPool()));
+  }
+
+  /**
+   * Mirrors: ActiveRecord::MigrationContext#connection_pool
+   * (`migration.rb:1365-1367`). `DatabaseTasks` is reached through the
+   * call-time config source rather than an import, for the same reason
+   * `Migration#connection_pool` does.
+   */
+  private connectionPool(): ConnectionPool {
+    return migrationArConfig()!.databaseTasks().migrationConnectionPool();
   }
 
   /**

--- a/packages/activerecord/src/test-fixtures.ts
+++ b/packages/activerecord/src/test-fixtures.ts
@@ -40,7 +40,6 @@ import {
   leaseFixtureConnection,
   leaseFixtureConnectionFor,
 } from "./test-fixtures/fixture-connection.js";
-import { canonicalForeignKeyDependents } from "./support/canonical-schema.js";
 
 /**
  * A tableless fixture entry: seeds rows directly into the named table with no
@@ -484,7 +483,6 @@ function useFixtures(
   // database seeds through that model's pool. Read in afterEach — see
   // shouldDeleteFixtureRows.
   const seededInTransaction = new Map<DatabaseAdapter, boolean>();
-  const setAdapters = new Map<string, DatabaseAdapter>();
 
   // TODO(fixtures-adoption Spike S1): seed once per worker in a global beforeAll
   // (before the pinned transaction opens) when transactional fixtures are
@@ -504,7 +502,6 @@ function useFixtures(
     // a single insert_fixtures_set.
     const groups = new Map<DatabaseAdapter, { prepared: PreparedFixtureSet[]; keys: string[] }>();
     seededInTransaction.clear();
-    setAdapters.clear();
     for (const [key, { table, model, data }] of Object.entries(fixtures)) {
       // Auto-register the (object-map) model, mirroring the by-name path's
       // `resolveFixtureNames` (fixtures-register-model-on-resolution, #4348):
@@ -517,7 +514,6 @@ function useFixtures(
         registerModel(model);
       }
       const adapter = await leaseFixtureConnectionFor(model, fixtureConnection);
-      setAdapters.set(key, adapter);
       let group = groups.get(adapter);
       if (group === undefined) {
         group = { prepared: [], keys: [] };
@@ -549,16 +545,25 @@ function useFixtures(
     // a table whose children the fixture set doesn't own, e.g. the HABTM join
     // rows a test created itself — never reaches the database.
     const deletesByAdapter = new Map<DatabaseAdapter, string[]>();
-    for (const [key, { table }] of Object.entries(fixtures).reverse()) {
-      const adapter = setAdapters.get(key) ?? fixtureConnection;
+    for (const [, { table, model }] of Object.entries(fixtures).reverse()) {
+      // Re-lease, rather than reusing the connection this set was seeded on.
+      // Rails never touches the seeding connection again in `teardown_fixtures`
+      // — the deletes are the `table_deletes` half of the *next*
+      // `insert_fixtures_set` (database_statements.rb:486-495), which runs on a
+      // freshly-leased connection. A test may deliberately have poisoned or
+      // evicted the seed-time connection (transactions.test.ts "connection
+      // removed from pool when begin raises…"), and teardown must not resurrect
+      // it.
+      const adapter = await leaseFixtureConnectionFor(model, fixtureConnection);
       if (!shouldDeleteFixtureRows(adapter, seededInTransaction.get(adapter) ?? false)) continue;
       const tables = deletesByAdapter.get(adapter);
       if (tables === undefined) deletesByAdapter.set(adapter, [table]);
       else tables.push(table);
     }
-    const dependents = deletesByAdapter.size > 0 ? await canonicalForeignKeyDependents() : null;
     for (const [adapter, tables] of deletesByAdapter) {
-      const tableDeletes = async () => {
+      // Rails wraps its table_deletes in disable_referential_integrity
+      // unconditionally (database_statements.rb:492).
+      await adapter.disableReferentialIntegrity(async () => {
         for (const table of tables) {
           try {
             await adapter.executeMutation(`DELETE FROM ${adapter.quoteTableName(table)}`);
@@ -566,21 +571,7 @@ function useFixtures(
             if (!isTableMissingError(e)) throw e;
           }
         }
-      };
-      // Rails wraps its table_deletes unconditionally (database_statements.rb:492).
-      // We cannot yet, because this loop deletes through the adapter captured at
-      // seed time, which a test may have evicted or poisoned by then — and PG's
-      // wrap opens a nested transaction that a connection whose
-      // `begin_db_transaction` raises re-raises through. Skipping the wrap where
-      // no foreign key points into the set keeps it off exactly those sets.
-      // Converging is tracked by
-      // 0064-ar-test-infra-layout-fidelity/converge-fixture-teardown-delete-onto-a-live-connection,
-      // which retires this conditional along with the stale-connection cause.
-      if (tables.some((table) => (dependents?.get(table)?.length ?? 0) > 0)) {
-        await adapter.disableReferentialIntegrity(tableDeletes, tables);
-      } else {
-        await tableDeletes();
-      }
+      }, tables);
     }
     for (const key of Object.keys(store)) {
       delete store[key];

--- a/packages/activerecord/src/test-fixtures.ts
+++ b/packages/activerecord/src/test-fixtures.ts
@@ -312,13 +312,18 @@ function useTablelessFixtures(
   afterEach(async () => {
     const adapter = getAdapter();
     if (shouldDeleteFixtureRows(adapter, seededInTransaction)) {
-      for (const { table } of [...entries].reverse()) {
-        try {
-          await adapter.executeMutation(`DELETE FROM ${adapter.quoteTableName(table)}`);
-        } catch (e) {
-          if (!isTableMissingError(e)) throw e;
+      const tables = [...entries].reverse().map(({ table }) => table);
+      // Rails wraps its table_deletes in disable_referential_integrity
+      // unconditionally (database_statements.rb:492).
+      await adapter.disableReferentialIntegrity(async () => {
+        for (const table of tables) {
+          try {
+            await adapter.executeMutation(`DELETE FROM ${adapter.quoteTableName(table)}`);
+          } catch (e) {
+            if (!isTableMissingError(e)) throw e;
+          }
         }
-      }
+      }, tables);
     }
     for (const key of keys) delete store[key];
   });


### PR DESCRIPTION
Bundle of four stories; three land here, the fourth is blocked (below).

## 1. Fixture teardown deletes on a live connection (RFC 0064)

Rails has no per-test fixture-delete step. `teardown_fixtures` resets the cache
and the pool and stops there; the rows go away at the *next* load, because
`insert_fixtures_set` prefixes the inserts with `table_deletes` and runs the
pair inside one `disable_referential_integrity` block **on a freshly-leased
connection** (`database_statements.rb:486-495`).

`test-fixtures.ts`'s `afterEach` deleted through the adapter captured at seed
time. A test may deliberately have broken or evicted that connection —
`transactions.test.ts` "connection removed from pool when begin raises after
successfully beginning a transaction" monkeypatches `beginDbTransaction` to
raise and asserts the connection is removed from the pool — so teardown ran on a
dead connection.

The delete now re-leases, via the same `leaseFixtureConnectionFor` the seed uses.
With that, the second divergence retires with it: the
`disableReferentialIntegrity` wrap is unconditional, matching
`database_statements.rb:492`, and the `canonicalForeignKeyDependents()`
conditional PR #6198 needed (PG's wrap opens a nested transaction the poisoned
connection re-raised through) is deleted, along with the now-dead `setAdapters`
map.

## 2. `DatabaseStatementsHost.pool` is the real pool union (RFC 0051)

It was `pool?: { schemaMigration: { tableName: string }; internalMetadata: {
tableName: string } }`. Rails' host is an `AbstractAdapter`, whose `@pool` is a
real `ConnectionPool` or the `NullPool` assigned in `initialize`
(`abstract_adapter.rb:153`) and is never absent — trails matches that at
`abstract-adapter.ts:878`. So the `?` described no adapter that exists, only the
mock host literals in `database-statements.test.ts`, and the two-member shape
let a host satisfy the type while being nothing like a pool.

Now `pool: ConnectionPool | NullPool`, non-optional. `truncateTables` drops its
`this`-type intersection and reads `this.pool.schemaMigration.tableName` bare
against the declared member — `NullPool` declares both readers as `never`
(#6263), so a pool-less adapter still fails there rather than truncating against
hardcoded defaults. The mock hosts hold a real pool from
`support/pooled-sqlite-adapter.ts`; no bespoke pool literal remains.

## 3. `MigrationContext` defaults its collaborators from a pool (RFC 0051)

Rails: `@schema_migration = schema_migration || SchemaMigration.new(connection_pool)`
(`migration.rb:1214-1218`), with the private `connection_pool` reaching
`DatabaseTasks.migration_connection_pool` (`migration.rb:1365-1367`).

trails had optional args and getters that threw
`"MigrationContext was built without a schema_migration"`. Both getters now
default from a private `connectionPool()` that mirrors `migration.rb:1365-1367`,
reached through the call-time config source (`migrationArConfig()`) for the same
reason `Migration#connectionPool` does — naming `tasks/database-tasks.js` here
would be a load-time edge back into a module that already imports this one. The
throwing getters are gone.

The one deliberate difference from Rails, stated in a comment at the
constructor: the default resolves on **first read** rather than in the
constructor. Rails can name `connection_pool` eagerly because
`DatabaseTasks.migration_connection_pool` always has one by then; trails builds
connectionless contexts for file discovery (`migrations`, `migrationFiles`,
`parseMigrationFilename` — the surface Rails' own context never consults
`@schema_migration` from), where an eager lookup would throw at construction and
take discovery with it. This is the "collaborators simply not consulted on the
discovery paths" resolution the story called for, without optional-arg throwing
getters.

`SchemaMigration#connection` and `MigrationContext#open`'s use of it were
already gone on `main` (the two sequenced-ahead stories shipped); nothing left to
do there.

The trails-only test that pinned the throwing getters now pins the converged
behavior instead: discovery answers without a pool, and the collaborators
default to real `SchemaMigration` / `InternalMetadata` instances.

## 4. Blocked: `methodMissingProxy` visibility from the private manifest (RFC 0093)

Not in this PR. The manifest the story wants to drive `respondsTo()` from,
`eslint/rails-private-methods.json`, is not reachable from a runtime package:

- it is **not committed** (`git ls-files eslint/` lists only the rule and its
  config), and per `eslint/rails-private-jsdoc.config.mjs:4-10` it "only exists
  in the `rails-comparison` CI job (the one with Ruby)". Every other job —
  including the package builds and every unit-test lane — runs without it;
- `eslint/rails-private-jsdoc.mjs:26-31` reads it with **sync `fs`** and degrades
  to `{ files: {} }` when absent. A shipped runtime package can do neither:
  `node:*` and `process.*` are banned there, fs must be async, and an eager JSON
  import would fail the build wherever Ruby is absent.

Blocked with that reason, and the prerequisite is filed as
`0093-proxy-dynamic-method-consistency/rails-private-method-set-must-be-a-committed-runtime-artifact`:
make the private set a committed, freshness-gated artifact a runtime package can
import.

## Verification

`pnpm typecheck`, `pnpm api:calls` (ratchet OK, no new rows), `pnpm api:extra`
(no new surface — this PR only removes members), and locally green:
`test-fixtures`, `transactions`, `fixtures`, `naked-fixtures`,
`habtm-destroy-order`, `database-statements`, `migration`, `migration-context`,
`migrator`, `multi-db-migrator`, `trailties`.

Closes-story: converge-fixture-teardown-delete-onto-a-live-connection
Closes-story: database-statements-host-pool-is-an-optional-duck-type
Closes-story: migration-context-collaborators-need-a-pool
