### PR TITLE
test(activerecord,activesupport): enroll the PG/MySQL rake tests in test:compare; TimeZone gains clear and zonesMap

### DIFF
--- a/packages/activerecord/src/adapters/mysql2/mysql2-rake.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-rake.test.ts
@@ -1,103 +1,137 @@
-import { describe, it } from "vitest";
+/**
+ * Mirrors Rails activerecord/test/cases/adapters/mysql2/mysql2_rake_test.rb.
+ *
+ * Despite the file name nothing here drives Rake: every test calls
+ * `ActiveRecord::Tasks::DatabaseTasks` directly, against `MySQLDatabaseTasks`,
+ * so the tests port straight across wherever the Ruby stubbing they lean on
+ * has an analogue.
+ */
+import { it, expect, afterEach, vi } from "vitest";
+import { describeIfMysqlAdapter } from "../../support/describe-if-mysql-adapter.js";
+import { DatabaseTasks } from "../../tasks/database-tasks.js";
+import { MySQLDatabaseTasks } from "../../tasks/mysql-database-tasks.js";
+import { HashConfig } from "../../database-configurations/hash-config.js";
+import { Base } from "../../base.js";
 
-describe("MysqlDBCreateTest", () => {
+/**
+ * `ActiveRecord::Base.stub(:lease_connection, @connection)`
+ * (`mysql2_rake_test.rb:235`). trails' task classes reach the connection
+ * through `Base.connectionPool().leaseConnection()`
+ * (`mysql-database-tasks.ts:283`), so the pool is where the double goes.
+ */
+function stubLeaseConnection(connection: unknown): void {
+  vi.spyOn(Base, "connectionPool").mockReturnValue({
+    leaseConnection: async () => connection,
+  } as unknown as ReturnType<typeof Base.connectionPool>);
+}
+
+function configuration(overrides: Record<string, unknown> = {}): HashConfig {
+  return new HashConfig("default_env", "primary", {
+    adapter: "mysql2",
+    database: "my-app-db",
+    ...overrides,
+  });
+}
+
+describeIfMysqlAdapter("MysqlDBCreateTest", () => {
   it.skip("establishes connection without database", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
+    // Not yet ported: asserts through Ruby's `assert_called(..., times: 2)`.
   });
   it.skip("creates database with no default options", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
+    // Not yet ported: asserts through Ruby's `assert_called_with`.
   });
   it.skip("creates database with given encoding", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
+    // Not yet ported: asserts through Ruby's `assert_called_with`.
   });
   it.skip("creates database with given collation", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
+    // Not yet ported: asserts through Ruby's `assert_called_with`.
   });
   it.skip("when database created successfully outputs info to stdout", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
+    // Not yet ported: asserts on the `$stdout` StringIO the setup swaps in.
   });
   it.skip("create when database exists outputs info to stderr", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
+    // Not yet ported: asserts on the `$stderr` StringIO the setup swaps in.
   });
 });
 
-describe("MysqlDBCreateWithInvalidPermissionsTest", () => {
+describeIfMysqlAdapter("MysqlDBCreateWithInvalidPermissionsTest", () => {
   it.skip("raises error", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
+    // Not yet ported: raises a `Mysql2::Error` from the stubbed connection,
+    // the driver error class trails has no analogue for here.
   });
 });
 
-describe("MySQLDBDropTest", () => {
+describeIfMysqlAdapter("MySQLDBDropTest", () => {
   it.skip("establishes connection to mysql database", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
+    // Not yet ported: asserts through Ruby's `assert_called`.
   });
   it.skip("drops database", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
+    // Not yet ported: asserts through Ruby's `assert_called_with`.
   });
   it.skip("when database dropped successfully outputs info to stdout", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
+    // Not yet ported: asserts on the `$stdout` StringIO the setup swaps in.
   });
 });
 
-describe("MySQLPurgeTest", () => {
-  it.skip("establishes connection without database", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
+describeIfMysqlAdapter("MySQLPurgeTest", () => {
+  // All three assert on `recreate_database` (`mysql_database_tasks.rb:29-31`),
+  // which trails' `purge` does not call — it drops and re-creates, preserving
+  // the live charset/collation (`mysql-database-tasks.ts:105-113`). That is a
+  // production divergence to converge, not a test-porting gap.
+  it.skip("establishes connection without database", () => {});
+  it.skip("recreates database with no default options", () => {});
+  it.skip("recreates database with the given options", () => {});
+});
+
+describeIfMysqlAdapter("MysqlDBCharsetTest", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
-  it.skip("recreates database with no default options", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
-  });
-  it.skip("recreates database with the given options", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
+
+  it("db retrieves charset", async () => {
+    const charset = vi.fn(async () => "utf8mb4");
+    stubLeaseConnection({ charset });
+    MySQLDatabaseTasks.register();
+
+    await DatabaseTasks.charset(configuration());
+
+    expect(charset).toHaveBeenCalled();
   });
 });
 
-describe("MysqlDBCharsetTest", () => {
-  it.skip("db retrieves charset", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
+describeIfMysqlAdapter("MysqlDBCollationTest", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("db retrieves collation", async () => {
+    const collation = vi.fn(async () => "utf8mb4_general_ci");
+    stubLeaseConnection({ collation });
+    MySQLDatabaseTasks.register();
+
+    await DatabaseTasks.collation(configuration());
+
+    expect(collation).toHaveBeenCalled();
   });
 });
 
-describe("MysqlDBCollationTest", () => {
-  it.skip("db retrieves collation", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
-  });
+describeIfMysqlAdapter("MySQLStructureDumpTest", () => {
+  // Rails pins the exact `mysqldump` argv through
+  // `assert_called_with(Kernel, :system, ...)` (`mysql2_rake_test.rb:269-279`).
+  it.skip("structure dump", () => {});
+  it.skip("structure dump with extra flags", () => {});
+  it.skip("structure dump with hash extra flags for a different driver", () => {});
+  it.skip("structure dump with hash extra flags for the correct driver", () => {});
+  it.skip("structure dump with ignore tables", () => {});
+  it.skip("warn when external structure dump command execution fails", () => {});
+  it.skip("structure dump with port number", () => {});
+  it.skip("structure dump with ssl", () => {});
 });
 
-describe("MySQLStructureDumpTest", () => {
-  it.skip("structure dump", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
-  });
-  it.skip("structure dump with extra flags", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
-  });
-  it.skip("structure dump with hash extra flags for a different driver", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
-  });
-  it.skip("structure dump with hash extra flags for the correct driver", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
-  });
-  it.skip("structure dump with ignore tables", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
-  });
-  it.skip("warn when external structure dump command execution fails", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
-  });
-  it.skip("structure dump with port number", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
-  });
-  it.skip("structure dump with ssl", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
-  });
-});
-
-describe("MySQLStructureLoadTest", () => {
-  it.skip("structure load", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
-  });
-  it.skip("structure load with hash extra flags for a different driver", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
-  });
-  it.skip("structure load with hash extra flags for the correct driver", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
-  });
+describeIfMysqlAdapter("MySQLStructureLoadTest", () => {
+  // Rails pins the exact `mysql` argv through
+  // `assert_called_with(Kernel, :system, ...)` (`mysql2_rake_test.rb:391-400`).
+  it.skip("structure load", () => {});
+  it.skip("structure load with hash extra flags for a different driver", () => {});
+  it.skip("structure load with hash extra flags for the correct driver", () => {});
 });

--- a/packages/activerecord/src/adapters/mysql2/mysql2-rake.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-rake.test.ts
@@ -6,7 +6,7 @@
  * so the tests port straight across wherever the Ruby stubbing they lean on
  * has an analogue.
  */
-import { it, expect, afterEach, vi } from "vitest";
+import { it, expect, beforeEach, vi } from "vitest";
 import { describeIfMysqlAdapter } from "../../support/describe-if-mysql-adapter.js";
 import { DatabaseTasks } from "../../tasks/database-tasks.js";
 import { MySQLDatabaseTasks } from "../../tasks/mysql-database-tasks.js";
@@ -14,22 +14,29 @@ import { HashConfig } from "../../database-configurations/hash-config.js";
 import { Base } from "../../base.js";
 
 /**
- * `ActiveRecord::Base.stub(:lease_connection, @connection)`
+ * `ActiveRecord::Base.stub(:lease_connection, @connection, &block)`
  * (`mysql2_rake_test.rb:235`). trails' task classes reach the connection
  * through `Base.connectionPool().leaseConnection()`
  * (`mysql-database-tasks.ts:283`), so the pool is where the double goes.
  */
-function stubLeaseConnection(connection: unknown): void {
-  vi.spyOn(Base, "connectionPool").mockReturnValue({
+async function withStubbedConnection(
+  connection: unknown,
+  block: () => Promise<void>,
+): Promise<void> {
+  const spy = vi.spyOn(Base, "connectionPool").mockReturnValue({
     leaseConnection: async () => connection,
   } as unknown as ReturnType<typeof Base.connectionPool>);
+  try {
+    await block();
+  } finally {
+    spy.mockRestore();
+  }
 }
 
-function configuration(overrides: Record<string, unknown> = {}): HashConfig {
+function configuration(): HashConfig {
   return new HashConfig("default_env", "primary", {
     adapter: "mysql2",
     database: "my-app-db",
-    ...overrides,
   });
 }
 
@@ -84,32 +91,32 @@ describeIfMysqlAdapter("MySQLPurgeTest", () => {
 });
 
 describeIfMysqlAdapter("MysqlDBCharsetTest", () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
+  beforeEach(() => {
+    MySQLDatabaseTasks.register();
   });
 
   it("db retrieves charset", async () => {
     const charset = vi.fn(async () => "utf8mb4");
-    stubLeaseConnection({ charset });
-    MySQLDatabaseTasks.register();
 
-    await DatabaseTasks.charset(configuration());
+    await withStubbedConnection({ charset }, async () => {
+      await DatabaseTasks.charset(configuration());
+    });
 
     expect(charset).toHaveBeenCalled();
   });
 });
 
 describeIfMysqlAdapter("MysqlDBCollationTest", () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
+  beforeEach(() => {
+    MySQLDatabaseTasks.register();
   });
 
   it("db retrieves collation", async () => {
     const collation = vi.fn(async () => "utf8mb4_general_ci");
-    stubLeaseConnection({ collation });
-    MySQLDatabaseTasks.register();
 
-    await DatabaseTasks.collation(configuration());
+    await withStubbedConnection({ collation }, async () => {
+      await DatabaseTasks.collation(configuration());
+    });
 
     expect(collation).toHaveBeenCalled();
   });

--- a/packages/activerecord/src/adapters/postgresql/postgresql-rake.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-rake.test.ts
@@ -14,22 +14,30 @@ import { HashConfig } from "../../database-configurations/hash-config.js";
 import { Base } from "../../base.js";
 
 /**
- * `ActiveRecord::Base.stub(:lease_connection, @connection)`
- * (`postgresql_rake_test.rb:290`). trails' task classes reach the connection
- * through `Base.connectionPool().leaseConnection()`
+ * `with_stubbed_connection` (`postgresql_rake_test.rb:272-274`), which is
+ * `ActiveRecord::Base.stub(:lease_connection, @connection, &block)`. trails'
+ * task classes reach the connection through
+ * `Base.connectionPool().leaseConnection()`
  * (`postgresql-database-tasks.ts:179`), so the pool is where the double goes.
  */
-function stubLeaseConnection(connection: unknown): void {
-  vi.spyOn(Base, "connectionPool").mockReturnValue({
+async function withStubbedConnection(
+  connection: unknown,
+  block: () => Promise<void>,
+): Promise<void> {
+  const spy = vi.spyOn(Base, "connectionPool").mockReturnValue({
     leaseConnection: async () => connection,
   } as unknown as ReturnType<typeof Base.connectionPool>);
+  try {
+    await block();
+  } finally {
+    spy.mockRestore();
+  }
 }
 
-function configuration(overrides: Record<string, unknown> = {}): HashConfig {
+function configuration(): HashConfig {
   return new HashConfig("default_env", "primary", {
     adapter: "postgresql",
     database: "my-app-db",
-    ...overrides,
   });
 }
 
@@ -85,10 +93,11 @@ describeIfPostgresqlAdapter("PostgreSQLPurgeTest", () => {
       createDatabase: vi.fn(async () => {}),
       dropDatabase: vi.fn(async () => {}),
     };
+    // `ActiveRecord::Base.stub(:establish_connection, nil)`
+    // (`postgresql_rake_test.rb:236`).
     vi.spyOn(Base, "establishConnection").mockResolvedValue(
       undefined as unknown as Awaited<ReturnType<typeof Base.establishConnection>>,
     );
-    stubLeaseConnection(connection);
     PostgreSQLDatabaseTasks.register();
   });
 
@@ -99,7 +108,7 @@ describeIfPostgresqlAdapter("PostgreSQLPurgeTest", () => {
   it.skip("clears active connections", () => {
     // Not yet ported: `purge` clears the handler's active connections
     // (`postgresql_rake_test.rb:208-216`), which trails' `purge` does not do —
-    // a production divergence, not a test-porting one.
+    // a production divergence, not a test-porting gap.
   });
 
   it.skip("establishes connection to postgresql database", () => {
@@ -108,13 +117,17 @@ describeIfPostgresqlAdapter("PostgreSQLPurgeTest", () => {
   });
 
   it("drops database", async () => {
-    await DatabaseTasks.purge(configuration());
+    await withStubbedConnection(connection, async () => {
+      await DatabaseTasks.purge(configuration());
+    });
 
     expect(connection.dropDatabase).toHaveBeenCalledWith("my-app-db");
   });
 
   it("creates database", async () => {
-    await DatabaseTasks.purge(configuration());
+    await withStubbedConnection(connection, async () => {
+      await DatabaseTasks.purge(configuration());
+    });
 
     expect(connection.createDatabase).toHaveBeenCalledWith("my-app-db", {
       adapter: "postgresql",
@@ -130,32 +143,32 @@ describeIfPostgresqlAdapter("PostgreSQLPurgeTest", () => {
 });
 
 describeIfPostgresqlAdapter("PostgreSQLDBCharsetTest", () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
+  beforeEach(() => {
+    PostgreSQLDatabaseTasks.register();
   });
 
   it("db retrieves charset", async () => {
     const encoding = vi.fn(async () => "UTF8");
-    stubLeaseConnection({ encoding });
-    PostgreSQLDatabaseTasks.register();
 
-    await DatabaseTasks.charset(configuration());
+    await withStubbedConnection({ encoding }, async () => {
+      await DatabaseTasks.charset(configuration());
+    });
 
     expect(encoding).toHaveBeenCalled();
   });
 });
 
 describeIfPostgresqlAdapter("PostgreSQLDBCollationTest", () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
+  beforeEach(() => {
+    PostgreSQLDatabaseTasks.register();
   });
 
   it("db retrieves collation", async () => {
     const collation = vi.fn(async () => "en_US.UTF-8");
-    stubLeaseConnection({ collation });
-    PostgreSQLDatabaseTasks.register();
 
-    await DatabaseTasks.collation(configuration());
+    await withStubbedConnection({ collation }, async () => {
+      await DatabaseTasks.collation(configuration());
+    });
 
     expect(collation).toHaveBeenCalled();
   });

--- a/packages/activerecord/src/adapters/postgresql/postgresql-rake.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-rake.test.ts
@@ -1,133 +1,191 @@
-import { describe, it } from "vitest";
+/**
+ * Mirrors Rails activerecord/test/cases/adapters/postgresql/postgresql_rake_test.rb.
+ *
+ * Despite the file name nothing here drives Rake: every test calls
+ * `ActiveRecord::Tasks::DatabaseTasks` directly, against
+ * `PostgreSQLDatabaseTasks`, so the tests port straight across wherever the
+ * Ruby stubbing they lean on has an analogue.
+ */
+import { it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describeIfPostgresqlAdapter } from "../../support/describe-if-postgresql-adapter.js";
+import { DatabaseTasks } from "../../tasks/database-tasks.js";
+import { PostgreSQLDatabaseTasks } from "../../tasks/postgresql-database-tasks.js";
+import { HashConfig } from "../../database-configurations/hash-config.js";
+import { Base } from "../../base.js";
 
-describe("PostgreSQLDBCreateTest", () => {
+/**
+ * `ActiveRecord::Base.stub(:lease_connection, @connection)`
+ * (`postgresql_rake_test.rb:290`). trails' task classes reach the connection
+ * through `Base.connectionPool().leaseConnection()`
+ * (`postgresql-database-tasks.ts:179`), so the pool is where the double goes.
+ */
+function stubLeaseConnection(connection: unknown): void {
+  vi.spyOn(Base, "connectionPool").mockReturnValue({
+    leaseConnection: async () => connection,
+  } as unknown as ReturnType<typeof Base.connectionPool>);
+}
+
+function configuration(overrides: Record<string, unknown> = {}): HashConfig {
+  return new HashConfig("default_env", "primary", {
+    adapter: "postgresql",
+    database: "my-app-db",
+    ...overrides,
+  });
+}
+
+describeIfPostgresqlAdapter("PostgreSQLDBCreateTest", () => {
   it.skip("establishes connection to postgresql database", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
+    // Not yet ported: asserts through a `Minitest::Mock` expecting two
+    // `establish_connection` calls in order.
   });
   it.skip("creates database with default encoding", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
+    // Not yet ported: asserts through Ruby's `assert_called_with`.
   });
   it.skip("creates database with given encoding", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
+    // Not yet ported: asserts through Ruby's `assert_called_with`.
   });
   it.skip("creates database with given collation and ctype", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
+    // Not yet ported: asserts through Ruby's `assert_called_with`.
   });
   it.skip("establishes connection to new database", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
+    // Not yet ported: asserts through Ruby's `assert_called_with`.
   });
   it.skip("db create with error prints message", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
+    // Not yet ported: asserts on the `$stderr` StringIO the setup swaps in.
   });
   it.skip("when database created successfully outputs info to stdout", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
+    // Not yet ported: asserts on the `$stdout` StringIO the setup swaps in.
   });
   it.skip("create when database exists outputs info to stderr", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
+    // Not yet ported: asserts on the `$stderr` StringIO the setup swaps in.
   });
 });
 
-describe("PostgreSQLDBDropTest", () => {
+describeIfPostgresqlAdapter("PostgreSQLDBDropTest", () => {
   it.skip("establishes connection to postgresql database", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
+    // Not yet ported: asserts through a `Minitest::Mock` expecting two
+    // `establish_connection` calls in order.
   });
   it.skip("drops database", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
+    // Not yet ported: asserts through Ruby's `assert_called_with`.
   });
   it.skip("when database dropped successfully outputs info to stdout", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
+    // Not yet ported: asserts on the `$stdout` StringIO the setup swaps in.
   });
 });
 
-describe("PostgreSQLPurgeTest", () => {
+describeIfPostgresqlAdapter("PostgreSQLPurgeTest", () => {
+  let connection: {
+    createDatabase: ReturnType<typeof vi.fn>;
+    dropDatabase: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    connection = {
+      createDatabase: vi.fn(async () => {}),
+      dropDatabase: vi.fn(async () => {}),
+    };
+    vi.spyOn(Base, "establishConnection").mockResolvedValue(
+      undefined as unknown as Awaited<ReturnType<typeof Base.establishConnection>>,
+    );
+    stubLeaseConnection(connection);
+    PostgreSQLDatabaseTasks.register();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it.skip("clears active connections", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
+    // Not yet ported: `purge` clears the handler's active connections
+    // (`postgresql_rake_test.rb:208-216`), which trails' `purge` does not do —
+    // a production divergence, not a test-porting one.
   });
+
   it.skip("establishes connection to postgresql database", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
+    // Not yet ported: asserts through a `Minitest::Mock` expecting two
+    // `establish_connection` calls in order.
   });
-  it.skip("drops database", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
+
+  it("drops database", async () => {
+    await DatabaseTasks.purge(configuration());
+
+    expect(connection.dropDatabase).toHaveBeenCalledWith("my-app-db");
   });
-  it.skip("creates database", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
+
+  it("creates database", async () => {
+    await DatabaseTasks.purge(configuration());
+
+    expect(connection.createDatabase).toHaveBeenCalledWith("my-app-db", {
+      adapter: "postgresql",
+      database: "my-app-db",
+      encoding: "utf8",
+    });
   });
+
   it.skip("establishes connection", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
+    // Not yet ported: asserts through a `Minitest::Mock` expecting two
+    // `establish_connection` calls in order.
   });
 });
 
-describe("PostgreSQLDBCharsetTest", () => {
-  it.skip("db retrieves charset", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
+describeIfPostgresqlAdapter("PostgreSQLDBCharsetTest", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("db retrieves charset", async () => {
+    const encoding = vi.fn(async () => "UTF8");
+    stubLeaseConnection({ encoding });
+    PostgreSQLDatabaseTasks.register();
+
+    await DatabaseTasks.charset(configuration());
+
+    expect(encoding).toHaveBeenCalled();
   });
 });
 
-describe("PostgreSQLDBCollationTest", () => {
-  it.skip("db retrieves collation", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
+describeIfPostgresqlAdapter("PostgreSQLDBCollationTest", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("db retrieves collation", async () => {
+    const collation = vi.fn(async () => "en_US.UTF-8");
+    stubLeaseConnection({ collation });
+    PostgreSQLDatabaseTasks.register();
+
+    await DatabaseTasks.collation(configuration());
+
+    expect(collation).toHaveBeenCalled();
   });
 });
 
-describe("PostgreSQLStructureDumpTest", () => {
-  it.skip("structure dump", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
-  });
-  it.skip("structure dump header comments removed", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
-  });
-  it.skip("structure dump with env", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
-  });
-  it.skip("structure dump with ssl env", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
-  });
-  it.skip("structure dump with extra flags", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
-  });
-  it.skip("structure dump with hash extra flags for a different driver", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
-  });
-  it.skip("structure dump with hash extra flags for the correct driver", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
-  });
-  it.skip("structure dump with ignore tables", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
-  });
-  it.skip("structure dump with schema search path", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
-  });
-  it.skip("structure dump with schema search path and dump schemas all", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
-  });
-  it.skip("structure dump with dump schemas string", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
-  });
-  it.skip("structure dump execution fails", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
-  });
+describeIfPostgresqlAdapter("PostgreSQLStructureDumpTest", () => {
+  // Rails pins the exact `pg_dump` argv through
+  // `assert_called_with(Kernel, :system, ...)` (`postgresql_rake_test.rb:335-344`).
+  it.skip("structure dump", () => {});
+  it.skip("structure dump header comments removed", () => {});
+  it.skip("structure dump with env", () => {});
+  it.skip("structure dump with ssl env", () => {});
+  it.skip("structure dump with extra flags", () => {});
+  it.skip("structure dump with hash extra flags for a different driver", () => {});
+  it.skip("structure dump with hash extra flags for the correct driver", () => {});
+  it.skip("structure dump with ignore tables", () => {});
+  it.skip("structure dump with schema search path", () => {});
+  it.skip("structure dump with schema search path and dump schemas all", () => {});
+  it.skip("structure dump with dump schemas string", () => {});
+  it.skip("structure dump execution fails", () => {});
 });
 
-describe("PostgreSQLStructureLoadTest", () => {
-  it.skip("structure load", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
-  });
-  it.skip("structure load with extra flags", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
-  });
-  it.skip("structure load with env", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
-  });
-  it.skip("structure load with ssl env", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
-  });
-  it.skip("structure load with hash extra flags for a different driver", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
-  });
-  it.skip("structure load with hash extra flags for the correct driver", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
-  });
-  it.skip("structure load accepts path with spaces", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — rake
-  });
+describeIfPostgresqlAdapter("PostgreSQLStructureLoadTest", () => {
+  // Rails pins the exact `psql` argv through
+  // `assert_called_with(Kernel, :system, ...)` (`postgresql_rake_test.rb:506-516`).
+  it.skip("structure load", () => {});
+  it.skip("structure load with extra flags", () => {});
+  it.skip("structure load with env", () => {});
+  it.skip("structure load with ssl env", () => {});
+  it.skip("structure load with hash extra flags for a different driver", () => {});
+  it.skip("structure load with hash extra flags for the correct driver", () => {});
+  it.skip("structure load accepts path with spaces", () => {});
 });

--- a/packages/activerecord/src/tasks/mysql-database-tasks.trails.test.ts
+++ b/packages/activerecord/src/tasks/mysql-database-tasks.trails.test.ts
@@ -12,28 +12,6 @@ function config(overrides: Record<string, unknown> = {}): HashConfig {
 }
 
 describe("MySQLDatabaseTasks", () => {
-  it("test_db_retrieves_charset", async () => {
-    const tasks = new MySQLDatabaseTasks(config());
-    const charsetMock = vi.fn(async () => "utf8mb4");
-    vi.spyOn(
-      tasks as unknown as { connection(): Promise<unknown> },
-      "connection",
-    ).mockResolvedValue({ charset: charsetMock });
-    await expect(tasks.charset()).resolves.toBe("utf8mb4");
-    expect(charsetMock).toHaveBeenCalledOnce();
-  });
-
-  it("test_db_retrieves_collation", async () => {
-    const tasks = new MySQLDatabaseTasks(config());
-    const collationMock = vi.fn(async () => "utf8mb4_general_ci");
-    vi.spyOn(
-      tasks as unknown as { connection(): Promise<unknown> },
-      "connection",
-    ).mockResolvedValue({ collation: collationMock });
-    await expect(tasks.collation()).resolves.toBe("utf8mb4_general_ci");
-    expect(collationMock).toHaveBeenCalledOnce();
-  });
-
   it("test_using_database_configurations_is_true", () => {
     expect(MySQLDatabaseTasks.usingDatabaseConfigurations()).toBe(true);
   });

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.trails.test.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.trails.test.ts
@@ -14,28 +14,6 @@ function config(overrides: Record<string, unknown> = {}): HashConfig {
 }
 
 describe("PostgreSQLDatabaseTasks", () => {
-  it("test_db_retrieves_charset", async () => {
-    const tasks = new PostgreSQLDatabaseTasks(config());
-    const encodingMock = vi.fn(async () => "UTF8");
-    vi.spyOn(
-      tasks as unknown as { connection(): Promise<unknown> },
-      "connection",
-    ).mockResolvedValue({ encoding: encodingMock });
-    await expect(tasks.charset()).resolves.toBe("UTF8");
-    expect(encodingMock).toHaveBeenCalledOnce();
-  });
-
-  it("test_db_retrieves_collation", async () => {
-    const tasks = new PostgreSQLDatabaseTasks(config());
-    const collationMock = vi.fn(async () => "en_US.UTF-8");
-    vi.spyOn(
-      tasks as unknown as { connection(): Promise<unknown> },
-      "connection",
-    ).mockResolvedValue({ collation: collationMock });
-    await expect(tasks.collation()).resolves.toBe("en_US.UTF-8");
-    expect(collationMock).toHaveBeenCalledOnce();
-  });
-
   it("test_using_database_configurations_is_true", () => {
     expect(PostgreSQLDatabaseTasks.usingDatabaseConfigurations()).toBe(true);
   });

--- a/packages/activesupport/src/time-zone.trails.test.ts
+++ b/packages/activesupport/src/time-zone.trails.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { TimeZone } from "./values/time-zone.js";
+
+describe("TimeZoneTest", () => {
+  it("clear resets the memos", () => {
+    const before = TimeZone.all();
+    const usBefore = TimeZone.usZones();
+    const moscowBefore = TimeZone.find("Moscow");
+
+    TimeZone.clear();
+
+    const after = TimeZone.all();
+    expect(after).not.toBe(before);
+    expect(after.map((zone) => zone.name)).toEqual(before.map((zone) => zone.name));
+    expect(TimeZone.usZones()).not.toBe(usBefore);
+    expect(TimeZone.find("Moscow")).not.toBe(moscowBefore);
+    expect(TimeZone.find("Moscow")!.name).toBe("Moscow");
+  });
+});

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -189,6 +189,8 @@ const zoneCache = new Map<string, TimeZone>();
 let zones: TimeZone[] | null = null;
 /** `@country_zones` (time_zone.rb:260), a `Concurrent::Map` keyed by Alpha2 code. */
 const countryZonesMemo = new Map<string, TimeZone[]>();
+/** `@zones_map` (time_zone.rb:287), the memo `zones_map` reads through. */
+let zonesMapMemo: Record<string, TimeZone> | null = null;
 
 /**
  * Stands in for `TZInfo::InvalidTimezoneIdentifier` (`tzinfo/timezone.rb:26`,
@@ -412,16 +414,9 @@ export class TimeZone {
   /**
    * Every Rails-named timezone: `@zones ||= zones_map.values.sort`
    * (time_zone.rb:223-225), sorted by `<=>` (time_zone.rb:333-337).
-   * `zones_map` keeps a MAPPING entry only when `[]` resolves it
-   * (`zones[name] = timezone if timezone`, time_zone.rb:288-291), hence the
-   * nullish filter.
    */
   static all(): TimeZone[] {
-    if (zones) return zones;
-    zones = Object.keys(MAPPING)
-      .map((name) => TimeZone.find(name))
-      .filter((zone): zone is TimeZone => zone != null)
-      .sort((a, b) => a.compareTo(b) ?? 0);
+    zones ??= Object.values(TimeZone.#zonesMap()).sort((a, b) => a.compareTo(b) ?? 0);
     return zones;
   }
 
@@ -949,6 +944,19 @@ export class TimeZone {
   }
 
   /**
+   * `clear` (time_zone.rb:264-269): drops all four memos — `@lazy_zones_map`,
+   * `@country_zones`, `@zones` and `@zones_map`. Rails' railtie calls it on
+   * reload; here it is what gives a caller that has moved tzdata or stubbed
+   * `Intl` a clean slate.
+   */
+  static clear(): void {
+    zoneCache.clear();
+    countryZonesMemo.clear();
+    zones = null;
+    zonesMapMemo = null;
+  }
+
+  /**
    * `load_country_zones` (time_zone.rb:283-296): every zone identifier the
    * country has, each replaced by the Rails-named zones that MAP to it when
    * MAPPING has any — `gb` answers both `Edinburgh` and `London` for
@@ -994,6 +1002,20 @@ export class TimeZone {
         return [TimeZone.create(tzId)];
       })
       .sort((a, b) => a.compareTo(b) ?? 0);
+  }
+
+  /**
+   * `zones_map` (time_zone.rb:286-291): every MAPPING name that `[]` resolves,
+   * keyed by that name — `zones[name] = timezone if timezone`, hence the
+   * nullish guard — under the `@zones_map` memo `all` reads through.
+   */
+  static #zonesMap(): Record<string, TimeZone> {
+    zonesMapMemo ??= Object.keys(MAPPING).reduce<Record<string, TimeZone>>((zones, name) => {
+      const timezone = TimeZone.find(name);
+      if (timezone != null) zones[name] = timezone;
+      return zones;
+    }, {});
+    return zonesMapMemo;
   }
 
   toString(): string {

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -192,6 +192,31 @@ import {
 // permanently invisible to the gate — exactly the fidelity gap it exists to
 // catch. Same reason `delete` (Map#delete), `merge`, `fetch` — all real JS call
 // forms — stay in.
+//
+// MEASURED, 2026-08-08 (RFC 0092 `positional-idiom-analogues`): the question
+// "can the comparator tell an Array/Hash receiver from a Relation/association
+// one?" was put to the data, and the answer is no beyond what is already done.
+// The comparator's only receiver signal is the extractor's inert-receiver
+// filter (RFC 0083 `weakCalls` / {@link dropWeakCalls}), which drops a call
+// name when EVERY occurrence in the Ruby body sat on a local variable or a
+// literal. It is already applied to the population these rows come from, and
+// it has already taken everything it can prove: of the 106 activerecord
+// call-mismatch rows for `first`/`last`/`any?`/`size`/`include?`, **zero** are
+// weak. What survives is ivars (`@stack.last`, `@inserts.first`), bare
+// self-calls (23 of the 36 `any?` rows have no receiver at all), constants and
+// method chains — and those same arms carry the real query triggers:
+// `scope.first` (`associations/singular_association.rb:52`), `records.first` /
+// `records.last` (`relation/finder_methods.rb:584,637`), `target.first`
+// (`associations/has_many_association.rb:36`), `group_values.any?`
+// (`relation/calculations.rb:223,446`), `default_scopes.any?`
+// (`scoping/default.rb:56,157`). An ivar or a reader can hold either an Array
+// or a Relation, so no receiver-token rule separates them; the audit's
+// token proxy misclassifies in both directions. A property-analogue table or a
+// `NO_JS_CALL_FORM` entry for these names would therefore buy ~90 row deletions
+// at the price of making a dropped query trigger permanently invisible, so the
+// tables are deliberately left alone and those rows go to the reason-text
+// route (per-row human review), not to a mechanism. See the matching note in
+// enumerable-idioms.ts.
 export const NO_JS_CALL_FORM = new Set([
   "to_s", // template literal / implicit String() coercion — `${x}`
   "each", // for...of loop — no .forEach callee

--- a/scripts/api-compare/enumerable-idioms.ts
+++ b/scripts/api-compare/enumerable-idioms.ts
@@ -14,6 +14,18 @@
  * pairs are deliberately absent. Aliases are consulted only to decide whether a
  * TS body already makes a call; they never widen which Ruby calls count as
  * ported, so adding one can never introduce a new mismatch.
+ *
+ * NO POSITIONAL/PROPERTY ANALOGUES HERE, and that is a measured decision, not
+ * an oversight (RFC 0092 `positional-idiom-analogues`, 2026-08-08). `first` →
+ * `[0]`, `last` → `.at(-1)`, `size` → `.length`, `any?` → `.length > 0` are
+ * property or index forms, not call names, so they could only be credited
+ * through `NO_JS_CALL_FORM` (compare.ts) — which suppresses the Ruby call for
+ * EVERY receiver. The evidence against doing that is recorded at that table's
+ * "DELIBERATELY NOT suppressed" comment: the one receiver distinction the
+ * comparator has (the RFC 0083 inert-receiver filter) is already applied, and
+ * zero of the 106 surviving activerecord rows for these names are inert, while
+ * several are genuine Relation receivers whose `.first`/`.any?` runs a query.
+ * Those rows are handed to the reason-text route instead.
  */
 export const JS_ENUMERABLE_ALIASES = new Map<string, string[]>([
   ["any?", ["some"]],

--- a/scripts/parity/unported-files.ts
+++ b/scripts/parity/unported-files.ts
@@ -223,18 +223,6 @@ export const UNPORTED_FILES: UnportedFile[] = [
   },
   // --- Permanently not-portable: Rake tasks / dbconsole PTY ---
   {
-    testFile: "adapters/postgresql/postgresql_rake_test.rb",
-    reason:
-      "Tests Rake db:create/drop/migrate tasks via shell exec. " +
-      "Rake and PTY shell-out have no Node.js equivalent; Trails uses migration scripts instead.",
-  },
-  {
-    testFile: "adapters/mysql2/mysql2_rake_test.rb",
-    reason:
-      "Tests Rake db:create/drop/migrate tasks for MySQL via shell exec. " +
-      "Rake and PTY shell-out have no Node.js equivalent.",
-  },
-  {
     testFile: "adapters/postgresql/dbconsole_test.rb",
     reason:
       "Tests `rails dbconsole` PTY/exec invocation for PostgreSQL. " +


### PR DESCRIPTION
Three of the four bundled stories. The fourth,
`move-adapter-specific-snapshot-off-ar-internal-metadata`, was **released
unbuilt** — see the last section for why.

## 1. Enroll `postgresql_rake_test.rb` / `mysql2_rake_test.rb` in `test:compare`

The `UNPORTED_FILES` reason ("Rake and PTY shell-out have no Node.js
equivalent") was wrong the same way the SQLite one was: despite the file names
nothing in either file drives Rake — every test calls
`ActiveRecord::Tasks::DatabaseTasks` directly against `PostgreSQLDatabaseTasks`
/ `MySQLDatabaseTasks`. Both whole-file entries are gone.

New files, mirroring the SQLite sibling's shape, with the Rails test classes as
`describe` names and the Rails test names verbatim:

- `packages/activerecord/src/adapters/postgresql/postgresql-rake.test.ts` —
  **4 matched / 33 skipped** of 37.
- `packages/activerecord/src/adapters/mysql2/mysql2-rake.test.ts` —
  **2 matched / 24 skipped** of 26.

Ported: `PostgreSQLDBCharsetTest#db retrieves charset`,
`PostgreSQLDBCollationTest#db retrieves collation`, `PostgreSQLPurgeTest#drops
database` and `#creates database`, `MysqlDBCharsetTest#db retrieves charset`,
`MysqlDBCollationTest#db retrieves collation`. Rails' `Base.stub(:lease_connection,
@connection)` becomes a spy on `Base.connectionPool()`, which is where trails'
task classes reach the connection (`postgresql-database-tasks.ts:179`,
`mysql-database-tasks.ts:283`).

Skipped stubs each name the Ruby-specific mechanism that blocks them
(`assert_called_with`, `Minitest::Mock`, the `$stdout`/`$stderr` StringIO swap,
the pinned `pg_dump` / `mysqldump` argv).

Trails-only tests moved to `*.trails.test.ts` siblings
(`tasks/{postgresql,mysql}-database-tasks.trails.test.ts`); the two that
duplicated the now-Rails-named charset/collation ports were deleted rather than
kept in both places. No test was renamed.

Measured: `pnpm test:compare` overall 15361 → 15367 matched, extras unchanged;
`--check` (the hard-zero gate-mismatch gate) exits 0; `pnpm
test:assertions:ratchet` OK.

**One divergence surfaced, filed not fixed.** All three `MySQLPurgeTest` tests
assert on `recreate_database` (`mysql_database_tasks.rb:29-31`), which trails'
`purge` does not call — it drops and re-creates from the live charset
(`mysql-database-tasks.ts:105-113`). That is a production convergence, out of
scope here; filed as
`0051-migration-schema-statements-fidelity/mysql-purge-does-not-call-recreate-database`
and named in the skip comment.

## 2. `TimeZone.clear` and `zonesMap`

`clear` (`time_zone.rb:264-269`) resets all four memos — `zoneCache`
(`@lazy_zones_map`), `countryZonesMemo` (`@country_zones`), `zones` (`@zones`)
and the new `zonesMapMemo` (`@zones_map`). `zonesMap` is extracted as the
private helper Rails extracts (`:286-291`), and `all()` is now
`zones ??= Object.values(zonesMap()).sort(...)` (`:223-225`) instead of doing
the MAPPING walk, the nullish filter and the sort in one body.

`api:extra` for `values/time-zone.ts` does not grow: `clear` matches Ruby
`clear`, and `zonesMap` is `#`-private.

## 3. Positional idiom analogues — determination: **the comparator cannot distinguish receivers, so no table change**

The question was whether `first`/`last`/`any?`/`size` can be credited from
their JS property/index analogues without blinding the gate to a dropped query
trigger. Evidence, not assertion:

The comparator's only receiver signal is the RFC 0083 inert-receiver filter
(`extract-ruby-api.rb#inert_receiver?` → `weakCalls` →
`compare.ts#dropWeakCalls`), which drops a Ruby call name when **every**
occurrence in the body sat on a provable local variable or literal. It is
already applied to this population, and it has already taken everything it can
prove: **of the 106 activerecord call-mismatch rows for
`first`/`last`/`any?`/`size`/`include?`, zero are weak.**

What survives is ivars, bare self-calls (23 of the 36 `any?` rows have no
receiver at all), constants and method chains — and those arms carry the real
query triggers. Five hand-checked Relation-receiver rows:

| Rails site | call |
| --- | --- |
| `associations/singular_association.rb:52` `scope.first` | `find_target` |
| `relation/finder_methods.rb:584` `records.first` | `find_take` |
| `relation/finder_methods.rb:637` `records.last` | `find_last` |
| `associations/has_many_association.rb:36` `target.first` | `handle_dependency` |
| `relation/calculations.rb:223,446` `group_values.any?` | `calculate` / `perform_calculation` |
| `scoping/default.rb:56,157` `default_scopes.any?` | `scope_attributes?` / `build_default_scope` |

An ivar or a reader can hold either an Array or a Relation, so no
receiver-token rule separates them — the audit's token proxy misclassifies in
both directions, which is also why the addendum's third outcome (a per-row
predicate) does not rescue it: the join is mechanically easy (I did it), but the
classification still needs a human reading the body. That is the reason-text
route.

So: `JS_ENUMERABLE_ALIASES` and `NO_JS_CALL_FORM` are unchanged, the
"DELIBERATELY NOT suppressed" comment is **extended with the measurement rather
than deleted**, and a matching note lands in `enumerable-idioms.ts` so the next
reader does not re-derive this. `pnpm api:calls` is green with no baseline
movement.

## 4. Released: `move-adapter-specific-snapshot-off-ar-internal-metadata`

Released with `pnpm tasks release`, unbuilt and unclaimed, on the strength of
its own recorded 2026-08-07 findings: the digest arm is unsound (the consumer
needs the *laid* set as `purgeToCanonicalTables`' protected list), the sidecar
arm needs a lane-conditional cross-process key (`sqlite3_mem` gives every worker
its own database) plus `sweepStaleDbFiles`/`sweepRunDbFiles` registration, and
`load-schema-helper.ts:526-532` warns this seam is reshaped one story at a time.
Its own note says it should be its own PR. It also cannot be verified locally —
its acceptance criteria require a green MariaDB lane, and no MySQL server is
reachable from this worktree.

Closes-story: enroll-pg-and-mysql-rake-tests-in-test-compare
Closes-story: positional-idiom-analogues
Closes-story: time-zone-clear-and-zones-map-not-ported
