### PR TITLE
test(activerecord,trailties): port SqliteDBCreate/Drop/Charset/Collation; InternalMetadata reads enabled off its pool; retire the pool structural casts

### DIFF
--- a/packages/activerecord/src/adapters/sqlite3/sqlite-rake.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite-rake.test.ts
@@ -11,6 +11,8 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { randomUUID } from "node:crypto";
 import * as activesupport from "@blazetrails/activesupport";
+import { stdout, stderr } from "@blazetrails/activesupport";
+import { NoMethodError } from "@blazetrails/activemodel";
 import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
 import { DatabaseTasks } from "../../tasks/database-tasks.js";
 import { SQLiteDatabaseTasks } from "../../tasks/sqlite-database-tasks.js";
@@ -32,55 +34,249 @@ function runSqlite3(database: string, sql: string): void {
   if (result.status !== 0) throw new Error(`sqlite3 failed: ${result.stderr}`);
 }
 
+/**
+ * Rails swaps `$stdout` / `$stderr` for a `StringIO` in `setup` and reads
+ * `.string` back (`sqlite_rake_test.rb:15-16, 86-87`). trails' analogue is the
+ * activesupport process adapter's streams, which is what `DatabaseTasks`
+ * writes its messages to.
+ */
+function captureStreams(): { out: () => string; err: () => string } {
+  let outString = "";
+  let errString = "";
+  vi.spyOn(stdout, "write").mockImplementation((chunk) => {
+    outString += String(chunk);
+    return true;
+  });
+  vi.spyOn(stderr, "write").mockImplementation((chunk) => {
+    errString += String(chunk);
+    return true;
+  });
+  return { out: () => outString, err: () => errString };
+}
+
 describeIfSqlite("SqliteDBCreateTest", () => {
-  it.skip("db checks database exists", () => {
-    // Not yet ported: asserts through Ruby's `assert_called_with(File, :exist?)`.
+  const database = "db_create.sqlite3";
+  let configuration: HashConfig;
+  let streams: ReturnType<typeof captureStreams>;
+
+  beforeEach(() => {
+    configuration = new HashConfig("development", "primary", {
+      adapter: "sqlite3",
+      database,
+    });
+    SQLiteDatabaseTasks.register();
+    streams = captureStreams();
   });
-  it.skip("when db created successfully outputs info to stdout", () => {
-    // Not yet ported: asserts on the `$stdout` StringIO the setup swaps in.
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
-  it.skip("db create when file exists", () => {
-    // Not yet ported: asserts on the `$stderr` StringIO the setup swaps in.
+
+  it("db checks database exists", async () => {
+    // `assert_called_with(File, :exist?, [@database], returns: false)`
+    // (`sqlite_rake_test.rb:25`) — trails reads the filesystem through the
+    // activesupport FsAdapter seam, so the spy sits there rather than on `fs`.
+    vi.spyOn(Base, "establishConnection").mockResolvedValue(undefined as never);
+    const existsSync = vi.spyOn(activesupport.getFs(), "existsSync").mockReturnValue(false);
+
+    await DatabaseTasks.create(configuration);
+
+    expect(existsSync).toHaveBeenCalledWith(database);
   });
-  it.skip("db create with file does nothing", () => {
-    // Not yet ported: asserts through Ruby's `assert_not_called`.
+
+  it("when db created successfully outputs info to stdout", async () => {
+    vi.spyOn(Base, "establishConnection").mockResolvedValue(undefined as never);
+    vi.spyOn(activesupport.getFs(), "existsSync").mockReturnValue(false);
+
+    await DatabaseTasks.create(configuration);
+
+    expect(streams.out()).toEqual(`Created database '${database}'\n`);
   });
-  it.skip("db create establishes a connection", () => {
-    // Not yet ported: stubs `Base.establish_connection` to collect its args.
+
+  it("db create when file exists", async () => {
+    vi.spyOn(activesupport.getFs(), "existsSync").mockReturnValue(true);
+
+    await DatabaseTasks.create(configuration);
+
+    expect(streams.err()).toEqual(`Database '${database}' already exists\n`);
   });
-  it.skip("db create with error prints message", () => {
-    // Not yet ported: asserts on the `$stderr` StringIO the setup swaps in.
+
+  it("db create with file does nothing", async () => {
+    vi.spyOn(activesupport.getFs(), "existsSync").mockReturnValue(true);
+    const establishConnection = vi.spyOn(Base, "establishConnection");
+
+    await DatabaseTasks.create(configuration);
+
+    expect(establishConnection).not.toHaveBeenCalled();
+  });
+
+  it("db create establishes a connection", async () => {
+    // Rails collects the args of the stubbed `establish_connection` and reads
+    // `configuration_hash` off the db_config it was handed
+    // (`sqlite_rake_test.rb:56-61`); trails hands it the configuration hash
+    // itself (`sqlite_database_tasks.rb:72-75`).
+    const calls: unknown[][] = [];
+    vi.spyOn(Base, "establishConnection").mockImplementation(async (...args: unknown[]) => {
+      calls.push(args);
+      return undefined as never;
+    });
+    vi.spyOn(activesupport.getFs(), "existsSync").mockReturnValue(false);
+
+    await DatabaseTasks.create(configuration);
+
+    expect(calls.map((c) => c[0])).toEqual([configuration.configuration]);
+  });
+
+  it("db create with error prints message", async () => {
+    vi.spyOn(activesupport.getFs(), "existsSync").mockReturnValue(false);
+    vi.spyOn(Base, "establishConnection").mockImplementation(() => {
+      throw new Error("boom");
+    });
+
+    await expect(DatabaseTasks.create(configuration)).rejects.toThrow(Error);
+    expect(streams.err()).toMatch(
+      `Couldn't create '${database}' database. Please check your configuration.`,
+    );
   });
 });
 
 describeIfSqlite("SqliteDBDropTest", () => {
-  it.skip("checks db dir is absolute", () => {
-    // Not yet ported: asserts through Ruby's `assert_called_with(File, :absolute_path?)`.
+  const root = "/rails/root";
+  const database = "db_create.sqlite3";
+  const databaseRoot = `${root}/${database}`;
+  let configuration: HashConfig;
+  let configurationRoot: HashConfig;
+  let streams: ReturnType<typeof captureStreams>;
+  let previousRoot: string;
+
+  beforeEach(() => {
+    configuration = new HashConfig("development", "primary", {
+      adapter: "sqlite3",
+      database,
+    });
+    configurationRoot = new HashConfig("development", "primary", {
+      adapter: "sqlite3",
+      database: databaseRoot,
+    });
+    SQLiteDatabaseTasks.register();
+    // Rails passes the root as `DatabaseTasks.drop @configuration, @root`'s
+    // trailing `*arguments`, which `database_adapter_for` forwards to the task
+    // constructor (`database_tasks.rb:566-572`). trails registers task
+    // singletons, so the root reaches `SQLiteDatabaseTasks` through
+    // `DatabaseTasks.root`.
+    previousRoot = DatabaseTasks.root;
+    DatabaseTasks.root = root;
+    streams = captureStreams();
   });
-  it.skip("removes file with absolute path", () => {
-    // Not yet ported: asserts through Ruby's `assert_called_with(FileUtils, :rm)`.
+
+  afterEach(() => {
+    DatabaseTasks.root = previousRoot;
+    vi.restoreAllMocks();
   });
-  it.skip("generates absolute path with given root", () => {
-    // Not yet ported: asserts through Ruby's `assert_called_with(File, :join)`.
+
+  it("checks db dir is absolute", async () => {
+    // `isAbsolute` is optional on the PathAdapter seam (a VFS need not model
+    // the distinction), so the spy target is narrowed to the arm that has it.
+    const pathAdapter = activesupport.getPath() as { isAbsolute(p: string): boolean };
+    const isAbsolute = vi.spyOn(pathAdapter, "isAbsolute").mockReturnValue(false);
+    vi.spyOn(activesupport.getFs(), "unlinkSync").mockImplementation(() => undefined);
+
+    await DatabaseTasks.drop(configuration);
+
+    expect(isAbsolute).toHaveBeenCalledWith(database);
   });
-  it.skip("removes file with relative path", () => {
-    // Not yet ported: asserts through Ruby's `assert_called_with(FileUtils, :rm)`.
+
+  it("removes file with absolute path", async () => {
+    const unlinkSync = vi
+      .spyOn(activesupport.getFs(), "unlinkSync")
+      .mockImplementation(() => undefined);
+
+    await DatabaseTasks.drop(configurationRoot);
+
+    expect(unlinkSync).toHaveBeenCalledWith(databaseRoot);
+    // Rails removes the two sidecars in one `FileUtils.rm_f([shm, wal])`
+    // (`sqlite_rake_test.rb:102`); trails unlinks each on its own.
+    expect(unlinkSync).toHaveBeenCalledWith(`${databaseRoot}-shm`);
+    expect(unlinkSync).toHaveBeenCalledWith(`${databaseRoot}-wal`);
   });
-  it.skip("when db dropped successfully outputs info to stdout", () => {
-    // Not yet ported: asserts on the `$stdout` StringIO the setup swaps in.
+
+  it("generates absolute path with given root", async () => {
+    const join = vi.spyOn(activesupport.getPath(), "join");
+    vi.spyOn(activesupport.getFs(), "unlinkSync").mockImplementation(() => undefined);
+
+    await DatabaseTasks.drop(configuration);
+
+    expect(join).toHaveBeenCalledWith(root, database);
+    expect(join).toHaveReturnedWith(`${root}/${database}`);
+  });
+
+  it("removes file with relative path", async () => {
+    const unlinkSync = vi
+      .spyOn(activesupport.getFs(), "unlinkSync")
+      .mockImplementation(() => undefined);
+
+    await DatabaseTasks.drop(configuration);
+
+    expect(unlinkSync).toHaveBeenCalledWith(databaseRoot);
+    expect(unlinkSync).toHaveBeenCalledWith(`${databaseRoot}-shm`);
+    expect(unlinkSync).toHaveBeenCalledWith(`${databaseRoot}-wal`);
+  });
+
+  it("when db dropped successfully outputs info to stdout", async () => {
+    vi.spyOn(activesupport.getFs(), "unlinkSync").mockImplementation(() => undefined);
+
+    await DatabaseTasks.drop(configuration);
+
+    expect(streams.out()).toEqual(`Dropped database '${database}'\n`);
   });
 });
 
 describeIfSqlite("SqliteDBCharsetTest", () => {
-  it.skip("db retrieves charset", () => {
-    // Not yet ported: asserts through Ruby's `assert_called(@connection, :encoding)`.
+  const database = "db_create.sqlite3";
+  let configuration: HashConfig;
+
+  beforeEach(() => {
+    configuration = new HashConfig("development", "primary", {
+      adapter: "sqlite3",
+      database,
+    });
+    SQLiteDatabaseTasks.register();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("db retrieves charset", async () => {
+    // Rails stubs `Base.lease_connection` with an object whose only member is
+    // `encoding` and asserts the send lands (`sqlite_rake_test.rb:142-146`);
+    // trails' `charset` leases the ambient connection, so the spy goes on its
+    // `encoding` getter (`sqlite_database_tasks.rb:39-41`).
+    const connection = await Base.connectionPool().leaseConnection();
+    const encoding = vi.spyOn(connection as unknown as { encoding: string }, "encoding", "get");
+
+    await DatabaseTasks.charset(configuration);
+
+    expect(encoding).toHaveBeenCalled();
   });
 });
 
 describeIfSqlite("SqliteDBCollationTest", () => {
-  it.skip("db retrieves collation", () => {
-    // Not yet ported: asserts `DatabaseTasks.collation` raises NoMethodError,
-    // which is Ruby's answer to a task class that defines no `collation`.
+  const database = "db_create.sqlite3";
+  let configuration: HashConfig;
+
+  beforeEach(() => {
+    configuration = new HashConfig("development", "primary", {
+      adapter: "sqlite3",
+      database,
+    });
+    SQLiteDatabaseTasks.register();
+  });
+
+  it("db retrieves collation", async () => {
+    // `database_tasks.rb:342-345` sends `collation` and SQLiteDatabaseTasks
+    // defines none, so the send raises.
+    await expect(DatabaseTasks.collation(configuration)).rejects.toBeInstanceOf(NoMethodError);
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -105,6 +105,16 @@ export class NullPool implements AbstractPool {
   declare readonly internalMetadata: never;
 
   /**
+   * Same shape and same reason again. Ruby's NullPool answers no
+   * `with_connection` (`abstract/connection_pool.rb:14-51`), so
+   * `SchemaMigration#with_connection`'s bare `@pool.with_connection`
+   * (`schema_migration.rb:22-24`) and `InternalMetadata`'s
+   * (`internal_metadata.rb:42`) raise NoMethodError on a pool-less
+   * collaborator rather than silently doing nothing.
+   */
+  declare readonly withConnection: never;
+
+  /**
    * Mirrors: ConnectionPool::NullPool#initialize
    * (`abstract/connection_pool.rb:24-28`).
    *

--- a/packages/activerecord/src/internal-metadata.trails.test.ts
+++ b/packages/activerecord/src/internal-metadata.trails.test.ts
@@ -68,3 +68,31 @@ describe("InternalMetadata built from a connection pool", () => {
     expect(await internalMetadata.tableExists()).toBe(true);
   });
 });
+
+describe("InternalMetadata built over a NullPool", () => {
+  // `enabled?` is `@pool.db_config.use_metadata_table?`
+  // (internal_metadata.rb:35-36) and NullPool's NullConfig answers nil for
+  // every key (abstract/connection_pool.rb:17-22), so a pool-less collaborator
+  // reads as disabled — it does not fall back to the default.
+  it("reads as disabled", () => {
+    expect(new InternalMetadata(new NullPool()).enabled).toBeFalsy();
+  });
+
+  // NullPool defines no `with_connection`, so the send raises NoMethodError
+  // rather than silently doing nothing (abstract/connection_pool.rb:14-51).
+  it("raises NoMethodError rather than silently no-opping on a write", async () => {
+    const internalMetadata = new InternalMetadata(new NullPool());
+    await expect(internalMetadata.deleteAllEntries()).rejects.toThrow(
+      /undefined method 'withConnection'/,
+    );
+  });
+
+  // NullPool#schema_cache answers nil (abstract/connection_pool.rb:38), so
+  // `@pool.schema_cache.data_source_exists?` (internal_metadata.rb:108) raises.
+  it("raises NoMethodError from tableExists", async () => {
+    const internalMetadata = new InternalMetadata(new NullPool());
+    await expect(internalMetadata.tableExists()).rejects.toThrow(
+      /undefined method 'data_source_exists\?' for nil/,
+    );
+  });
+});

--- a/packages/activerecord/src/internal-metadata.ts
+++ b/packages/activerecord/src/internal-metadata.ts
@@ -7,6 +7,8 @@
 import { Temporal } from "@blazetrails/date";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import type { ConnectionPool, NullPool } from "./connection-adapters/abstract/connection-pool.js";
+import type { BoundSchemaReflection } from "./connection-adapters/schema-cache.js";
+import { NoMethodError } from "@blazetrails/activemodel";
 import type { Base } from "./base.js";
 import { EnvironmentStorageError } from "./migration.js";
 import { ActiveRecordError } from "./errors.js";
@@ -79,25 +81,20 @@ export class InternalMetadata {
   private async _withConnection<T>(
     fn: (connection: DatabaseAdapter) => T | Promise<T>,
   ): Promise<T> {
-    return await (this._pool as ConnectionPool).withConnection(fn);
+    return await this._pool.withConnection(fn);
   }
 
   /**
    * Mirrors ActiveRecord::InternalMetadata#enabled?
    * (`internal_metadata.rb:35-36`) — `@pool.db_config.use_metadata_table?`.
    *
-   * Deviation: a `NullPool` answers `NULL_CONFIG`, whose every key is undefined
-   * (Rails' `NullConfig#method_missing` returns nil), so Rails would read that
-   * arm as disabled. Rails never gets there — its `InternalMetadata` is always
-   * built from a real pool — while trails builds one over bare, NullPool-backed
-   * adapters throughout the test suite and the trailties `db` commands, so the
-   * absent flag has to keep `DatabaseConfig#useMetadataTable`'s default. It
-   * converges once those call sites hold a pool
-   * (`migration-context-collaborators-need-a-pool`).
+   * A `NullPool` answers `NULL_CONFIG`, whose every key is undefined (Rails'
+   * `NullConfig#method_missing` returns nil, `abstract/connection_pool.rb:17-22`),
+   * so a pool-less collaborator reads as disabled here exactly as it does in
+   * Ruby. The return type carries that nil the way Ruby's predicate does.
    */
-  get enabled(): boolean {
-    const dbConfig = (this._pool as { dbConfig?: { useMetadataTable?: boolean } } | null)?.dbConfig;
-    return dbConfig?.useMetadataTable !== false;
+  get enabled(): boolean | null | undefined {
+    return this._pool.dbConfig.useMetadataTable;
   }
 
   // Rails: create_table(table_name, id: false) { |t| t.string :key, **...; t.string
@@ -224,9 +221,14 @@ export class InternalMetadata {
    * @internal
    */
   async tableExists(): Promise<boolean> {
-    const schemaCache = (this._pool as ConnectionPool).schemaCache as {
-      dataSourceExists(name: string): Promise<boolean | undefined>;
-    };
+    const schemaCache: BoundSchemaReflection | null = this._pool.schemaCache;
+    if (schemaCache === null) {
+      // Ruby's NullPool#schema_cache answers nil
+      // (`abstract/connection_pool.rb:38`), so the send in
+      // `@pool.schema_cache.data_source_exists?` raises NoMethodError on nil;
+      // JS would answer a TypeError, so raise Ruby's error here.
+      throw new NoMethodError("undefined method 'data_source_exists?' for nil");
+    }
     return (await schemaCache.dataSourceExists(this.tableName)) ?? false;
   }
 

--- a/packages/activerecord/src/internal-metadata.ts
+++ b/packages/activerecord/src/internal-metadata.ts
@@ -218,15 +218,15 @@ export class InternalMetadata {
    * (`internal_metadata.rb:108-110`) — `@pool.schema_cache.data_source_exists?`.
    * Unlike `SchemaMigration#table_exists?` this reads through the pool's schema
    * cache, not a checked-out connection; Rails has that difference deliberately.
+   *
+   * `NullPool#schema_cache` answers nil (`abstract/connection_pool.rb:38`), so
+   * the send raises NoMethodError on a pool-less collaborator. JS would answer
+   * a TypeError for the same read, so Ruby's error class is raised explicitly.
    * @internal
    */
   async tableExists(): Promise<boolean> {
     const schemaCache: BoundSchemaReflection | null = this._pool.schemaCache;
     if (schemaCache === null) {
-      // Ruby's NullPool#schema_cache answers nil
-      // (`abstract/connection_pool.rb:38`), so the send in
-      // `@pool.schema_cache.data_source_exists?` raises NoMethodError on nil;
-      // JS would answer a TypeError, so raise Ruby's error here.
       throw new NoMethodError("undefined method 'data_source_exists?' for nil");
     }
     return (await schemaCache.dataSourceExists(this.tableName)) ?? false;

--- a/packages/activerecord/src/schema-migration.ts
+++ b/packages/activerecord/src/schema-migration.ts
@@ -62,7 +62,7 @@ export class SchemaMigration {
   private async _withConnection<T>(
     fn: (connection: DatabaseAdapter) => T | Promise<T>,
   ): Promise<T> {
-    return await (this._pool as ConnectionPool).withConnection(fn);
+    return await this._pool.withConnection(fn);
   }
 
   get primaryKey(): string {

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -21,6 +21,7 @@ import {
   stdout,
   stderr,
 } from "@blazetrails/activesupport";
+import { NoMethodError } from "@blazetrails/activemodel";
 import { ActiveRecordError, ConnectionNotDefined } from "../errors.js";
 import type { Base } from "../base.js";
 
@@ -552,7 +553,17 @@ export class DatabaseTasks {
   ): Promise<string | null> {
     const config = this.resolveConfiguration(configuration);
     const handler = this.databaseAdapterFor(config);
-    return handler.charset ? handler.charset(config) : null;
+    // Ruby sends `charset` to the task instance (`database_tasks.rb:332-335`);
+    // a task class defining none raises NoMethodError. A trails handler is a
+    // plain object of optional members, so the missing send has to be raised
+    // rather than falling out of the language — see `collation` below, whose
+    // NoMethodError `SqliteDBCollationTest#test_db_retrieves_collation` asserts.
+    if (!handler.charset) {
+      throw new NoMethodError(
+        `undefined method 'charset' for an instance of ${handler.constructor.name}`,
+      );
+    }
+    return handler.charset(config);
   }
 
   static async charsetCurrent(environment?: string): Promise<string | null> {
@@ -568,10 +579,14 @@ export class DatabaseTasks {
   ): Promise<string | null> {
     const config = this.resolveConfiguration(configuration);
     const handler = this.databaseAdapterFor(config);
-    if (handler.collation) {
-      return handler.collation(config);
+    // `database_tasks.rb:342-345` — a bare send, and SQLiteDatabaseTasks
+    // defines no `collation`, so SQLite raises NoMethodError here.
+    if (!handler.collation) {
+      throw new NoMethodError(
+        `undefined method 'collation' for an instance of ${handler.constructor.name}`,
+      );
     }
-    return null;
+    return handler.collation(config);
   }
 
   static async collationCurrent(environment?: string): Promise<string | null> {

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -548,16 +548,21 @@ export class DatabaseTasks {
     }
   }
 
+  /**
+   * Mirrors: `DatabaseTasks.charset` (`database_tasks.rb:332-335`) — a bare
+   * send to the resolved task instance.
+   *
+   * Ruby gets the raise for free: a task class defining no `charset` answers
+   * NoMethodError. A trails handler is a plain object whose members are all
+   * optional (`registerTask` takes the object, not a class), so the absent
+   * send is raised explicitly; `constructor.name` stands in for Ruby's
+   * `.class.name` and reads `Object` for a handler registered as a literal.
+   */
   static async charset(
     configuration: DatabaseConfig | string | Record<string, unknown>,
   ): Promise<string | null> {
     const config = this.resolveConfiguration(configuration);
     const handler = this.databaseAdapterFor(config);
-    // Ruby sends `charset` to the task instance (`database_tasks.rb:332-335`);
-    // a task class defining none raises NoMethodError. A trails handler is a
-    // plain object of optional members, so the missing send has to be raised
-    // rather than falling out of the language — see `collation` below, whose
-    // NoMethodError `SqliteDBCollationTest#test_db_retrieves_collation` asserts.
     if (!handler.charset) {
       throw new NoMethodError(
         `undefined method 'charset' for an instance of ${handler.constructor.name}`,
@@ -574,13 +579,17 @@ export class DatabaseTasks {
     return this.charset(primary);
   }
 
+  /**
+   * Mirrors: `DatabaseTasks.collation` (`database_tasks.rb:342-345`). Same
+   * shape and same reason as {@link charset} above; `SQLiteDatabaseTasks`
+   * defines no `collation`, so SQLite raises here — which is what
+   * `SqliteDBCollationTest#test_db_retrieves_collation` asserts.
+   */
   static async collation(
     configuration: DatabaseConfig | string | Record<string, unknown>,
   ): Promise<string | null> {
     const config = this.resolveConfiguration(configuration);
     const handler = this.databaseAdapterFor(config);
-    // `database_tasks.rb:342-345` — a bare send, and SQLiteDatabaseTasks
-    // defines no `collation`, so SQLite raises NoMethodError here.
     if (!handler.collation) {
       throw new NoMethodError(
         `undefined method 'collation' for an instance of ${handler.constructor.name}`,

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.test.ts
@@ -7,7 +7,7 @@ import { randomUUID } from "node:crypto";
 import { SQLiteDatabaseTasks } from "./sqlite-database-tasks.js";
 import { DatabaseTasks } from "./database-tasks.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
-import { DatabaseAlreadyExists, NoDatabaseError } from "../errors.js";
+import { DatabaseAlreadyExists } from "../errors.js";
 import { SchemaDumper } from "../schema-dumper.js";
 import { Base } from "../base.js";
 
@@ -48,42 +48,6 @@ describe("SQLiteDatabaseTasks", () => {
     created.length = 0;
   });
 
-  it("test_db_create_creates_file", async () => {
-    const dbPath = tmpDbPath();
-    created.push(dbPath);
-    const config = new HashConfig("development", "primary", {
-      adapter: "sqlite3",
-      database: dbPath,
-    });
-    await new SQLiteDatabaseTasks(config).create();
-    expect(fs.existsSync(dbPath)).toBe(true);
-  });
-
-  it("test_db_create_when_file_exists_raises", async () => {
-    const dbPath = tmpDbPath();
-    created.push(dbPath);
-    fs.writeFileSync(dbPath, "");
-    const config = new HashConfig("development", "primary", {
-      adapter: "sqlite3",
-      database: dbPath,
-    });
-    await expect(new SQLiteDatabaseTasks(config).create()).rejects.toBeInstanceOf(
-      DatabaseAlreadyExists,
-    );
-  });
-
-  it("test_db_drop_removes_file", async () => {
-    const dbPath = tmpDbPath();
-    created.push(dbPath);
-    fs.writeFileSync(dbPath, "");
-    const config = new HashConfig("development", "primary", {
-      adapter: "sqlite3",
-      database: dbPath,
-    });
-    await new SQLiteDatabaseTasks(config).drop();
-    expect(fs.existsSync(dbPath)).toBe(false);
-  });
-
   it("create guards and connects against the same relative database", async () => {
     // `sqlite_database_tasks.rb:15-20` reads the raw `db_config.database` in both
     // halves; only `drop` joins `root` (`:23-24`).
@@ -108,24 +72,6 @@ describe("SQLiteDatabaseTasks", () => {
     fs.rmSync(root, { recursive: true, force: true });
   });
 
-  it("test_db_drop_missing_raises_no_database_error", async () => {
-    const dbPath = tmpDbPath();
-    const config = new HashConfig("development", "primary", {
-      adapter: "sqlite3",
-      database: dbPath,
-    });
-    await expect(new SQLiteDatabaseTasks(config).drop()).rejects.toBeInstanceOf(NoDatabaseError);
-  });
-
-  it("test_charset_returns_utf8", async () => {
-    const config = new HashConfig("development", "primary", {
-      adapter: "sqlite3",
-      database: ":memory:",
-    });
-    await Base.establishConnection(config.configuration as Record<string, unknown>);
-    await expect(new SQLiteDatabaseTasks(config).charset()).resolves.toBe("UTF-8");
-  });
-
   it("test_registers_with_database_tasks", () => {
     DatabaseTasks.clearRegisteredTasks();
     SQLiteDatabaseTasks.register();
@@ -146,63 +92,65 @@ describe("SQLiteDatabaseTasks", () => {
     const { BetterSQLite3Adapter } =
       await import("../connection-adapters/better-sqlite3-adapter.js");
     const seedAdapter = new BetterSQLite3Adapter(dbPath);
-    await seedAdapter.executeMutation(
-      "CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT NOT NULL, updated_at TEXT)",
-    );
-    await seedAdapter.executeMutation("CREATE INDEX index_widgets_on_name ON widgets(name)");
-    await seedAdapter.executeMutation(
-      "CREATE TRIGGER touch_widgets AFTER UPDATE ON widgets " +
-        "BEGIN " +
-        "UPDATE widgets SET updated_at = datetime('now') WHERE id = NEW.id; " +
-        "END",
-    );
-    await (seedAdapter as unknown as { close(): Promise<void> }).close();
-
-    // Rails' structure_dump reaches its adapter with a bare
-    // `ActiveRecord::Base.lease_connection` (sqlite_database_tasks.rb:43,68-70),
-    // so the task's db_config has to be the established one before it runs —
-    // which is the caller's job, as it is for `db:schema:dump`
-    // (database_tasks.rb:523-530).
-    await DatabaseTasks.withTemporaryConnection(sourceConfig, async () => {
-      await new SQLiteDatabaseTasks(sourceConfig).structureDump(dumpPath);
-    });
-
-    const dumped = fs.readFileSync(dumpPath, "utf8");
-    expect(dumped).toMatch(/CREATE TABLE widgets/);
-    expect(dumped).toMatch(/index_widgets_on_name/);
-    expect(dumped).toMatch(/CREATE TRIGGER touch_widgets/);
-
-    // Explicit teardown for the raw-created `widgets` table (the dbPath file is
-    // also unlinked in afterEach) to balance require-table-teardown.
-    const cleanupAdapter = new BetterSQLite3Adapter(dbPath);
-    await cleanupAdapter.executeMutation("DROP TABLE IF EXISTS widgets");
-    await (cleanupAdapter as unknown as { close(): Promise<void> }).close();
-
-    const targetConfig = new HashConfig("development", "primary", {
-      adapter: "sqlite3",
-      database: loadDbPath,
-    });
-    fs.writeFileSync(loadDbPath, "");
-    await DatabaseTasks.withTemporaryConnection(targetConfig, async () => {
-      await new SQLiteDatabaseTasks(targetConfig).structureLoad(dumpPath);
-    });
-
-    const loadedAdapter = new BetterSQLite3Adapter(loadDbPath);
     try {
-      const tables = (await loadedAdapter.execute(
-        "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name",
-      )) as Array<{ name: string }>;
-      expect(tables.map((r) => r.name)).toContain("widgets");
-      const idx = (await loadedAdapter.execute(
-        "SELECT name FROM sqlite_master WHERE type='index' AND name='index_widgets_on_name'",
-      )) as unknown[];
-      expect(idx.length).toBe(1);
-      const trigger = (await loadedAdapter.execute(
-        "SELECT name FROM sqlite_master WHERE type='trigger' AND name='touch_widgets'",
-      )) as unknown[];
-      expect(trigger.length).toBe(1);
+      await seedAdapter.executeMutation(
+        "CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT NOT NULL, updated_at TEXT)",
+      );
+      await seedAdapter.executeMutation("CREATE INDEX index_widgets_on_name ON widgets(name)");
+      await seedAdapter.executeMutation(
+        "CREATE TRIGGER touch_widgets AFTER UPDATE ON widgets " +
+          "BEGIN " +
+          "UPDATE widgets SET updated_at = datetime('now') WHERE id = NEW.id; " +
+          "END",
+      );
+      await (seedAdapter as unknown as { close(): Promise<void> }).close();
+
+      // Rails' structure_dump reaches its adapter with a bare
+      // `ActiveRecord::Base.lease_connection` (sqlite_database_tasks.rb:43,68-70),
+      // so the task's db_config has to be the established one before it runs —
+      // which is the caller's job, as it is for `db:schema:dump`
+      // (database_tasks.rb:523-530).
+      await DatabaseTasks.withTemporaryConnection(sourceConfig, async () => {
+        await new SQLiteDatabaseTasks(sourceConfig).structureDump(dumpPath);
+      });
+
+      const dumped = fs.readFileSync(dumpPath, "utf8");
+      expect(dumped).toMatch(/CREATE TABLE widgets/);
+      expect(dumped).toMatch(/index_widgets_on_name/);
+      expect(dumped).toMatch(/CREATE TRIGGER touch_widgets/);
+
+      const targetConfig = new HashConfig("development", "primary", {
+        adapter: "sqlite3",
+        database: loadDbPath,
+      });
+      fs.writeFileSync(loadDbPath, "");
+      await DatabaseTasks.withTemporaryConnection(targetConfig, async () => {
+        await new SQLiteDatabaseTasks(targetConfig).structureLoad(dumpPath);
+      });
+
+      const loadedAdapter = new BetterSQLite3Adapter(loadDbPath);
+      try {
+        const tables = (await loadedAdapter.execute(
+          "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name",
+        )) as Array<{ name: string }>;
+        expect(tables.map((r) => r.name)).toContain("widgets");
+        const idx = (await loadedAdapter.execute(
+          "SELECT name FROM sqlite_master WHERE type='index' AND name='index_widgets_on_name'",
+        )) as unknown[];
+        expect(idx.length).toBe(1);
+        const trigger = (await loadedAdapter.execute(
+          "SELECT name FROM sqlite_master WHERE type='trigger' AND name='touch_widgets'",
+        )) as unknown[];
+        expect(trigger.length).toBe(1);
+      } finally {
+        await (loadedAdapter as unknown as { close(): Promise<void> }).close();
+      }
     } finally {
-      await (loadedAdapter as unknown as { close(): Promise<void> }).close();
+      // Explicit teardown for the raw-created `widgets` table (the dbPath file is
+      // also unlinked in afterEach) to balance require-table-teardown.
+      const cleanupAdapter = new BetterSQLite3Adapter(dbPath);
+      await cleanupAdapter.executeMutation("DROP TABLE IF EXISTS widgets");
+      await (cleanupAdapter as unknown as { close(): Promise<void> }).close();
     }
   });
 });

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -49,11 +49,13 @@ import * as os from "node:os";
 async function establishMigrationConnection(
   adapter: unknown,
   database = ":memory:",
+  extra: Record<string, unknown> = {},
 ): Promise<void> {
   const { Base, HashConfig } = await import("@blazetrails/activerecord");
   const config = new HashConfig("test", "primary", {
     adapter: "sqlite3",
     database,
+    ...extra,
   });
   const pool = Base.connectionHandler.establishConnection(config, {
     owner: Base,
@@ -1448,14 +1450,16 @@ export class CreatePosts extends Migration {
   });
 
   // internal_metadata.rb:35-36 — `enabled?` is `@pool.db_config.use_metadata_table?`.
-  function disableMetadataTable(adapter: unknown): void {
-    // Override the pool's db_config rather than replacing the pool: Rails'
-    // @pool is always a pool object (abstract_adapter.rb:153), and the rest of
-    // the adapter reads schema_reflection off it during the migration.
-    Object.defineProperty((adapter as { pool: object }).pool, "dbConfig", {
-      value: { useMetadataTable: false },
-      configurable: true,
-    });
+  // Re-establish over the same adapter with `use_metadata_table: false` in the
+  // db_config, the way database.yml turns the flag off — `enabled?` reads
+  // `@pool.db_config.use_metadata_table?` (internal_metadata.rb:35-36), so the
+  // config is the only place to set it.
+  async function disableMetadataTable(adapter: unknown, database?: string): Promise<void> {
+    const { Base } = await import("@blazetrails/activerecord");
+    // Hand the adapter back before it is leased into the replacement pool.
+    Base.connectionHandler.removeConnection("Base");
+    (adapter as { expire(): void }).expire();
+    await establishMigrationConnection(adapter, database, { useMetadataTable: false });
   }
 
   it("InternalMetadata with enabled=false refuses set writes with EnvironmentStorageError", async () => {
@@ -1467,7 +1471,7 @@ export class CreatePosts extends Migration {
     const adapter = new BetterSQLite3Adapter(dbFile);
     await establishMigrationConnection(adapter, dbFile);
     try {
-      disableMetadataTable(adapter);
+      await disableMetadataTable(adapter, dbFile);
       const disabledMeta = new InternalMetadata(adapter.pool);
       expect(disabledMeta.enabled).toBe(false);
 
@@ -1514,7 +1518,7 @@ export class CreatePosts extends Migration {
             })("CreateWidgets", 20260101000000),
         },
       ];
-      disableMetadataTable(adapter);
+      await disableMetadataTable(adapter);
       const migrator = new Migrator(
         "up",
         migrations,
@@ -1560,7 +1564,7 @@ export class CreatePosts extends Migration {
       const enabledMeta = new InternalMetadata(adapter.pool);
       await enabledMeta.createTable();
       await enabledMeta.set("environment", "production");
-      disableMetadataTable(adapter);
+      await disableMetadataTable(adapter, dbFile);
 
       // Disabled context should still report null (no stale read).
       const context = new MigrationContext(


### PR DESCRIPTION
Ports the 13 stubbed `sqlite_rake_test.rb` tests (`SqliteDBCreateTest`,
`SqliteDBDropTest`, `SqliteDBCharsetTest`, `SqliteDBCollationTest`) — the file
now reports **17/17 matched** in `pnpm test:compare` with no assertion
mismatches.

- Ruby's `$stdout`/`$stderr` StringIO swaps (`sqlite_rake_test.rb:15-16,86-87`)
  land on the activesupport process adapter's streams, which is where
  `DatabaseTasks` writes its messages.
- `assert_called_with(File, :exist?/:absolute_path?/:join)` and
  `assert_called_with(FileUtils, :rm/:rm_f)` land on the `FsAdapter` /
  `PathAdapter` seams rather than on `node:fs`.
- Rails passes the root as `DatabaseTasks.drop`'s trailing `*arguments`; trails
  registers task singletons, so the drop suite sets `DatabaseTasks.root`.
- The five superseded trails-named duplicates in
  `tasks/sqlite-database-tasks.test.ts` are deleted.

`DatabaseTasks.charset` / `#collation` drop their `if (handler.x)` guards: Ruby
sends the message (`database_tasks.rb:332-345`), so a task class defining none
raises `NoMethodError` — which is exactly what
`SqliteDBCollationTest#test_db_retrieves_collation` asserts.

`InternalMetadata#enabled` is now the bare
`@pool.db_config.use_metadata_table?` (`internal_metadata.rb:35-36`). The
`!== false` softening and its deviation note are gone, so a `NullPool`-backed
collaborator reads as **disabled** exactly as in Ruby, and `db.test.ts` turns
the flag off through a real db_config instead of stubbing the pool.

`SchemaMigration` / `InternalMetadata` no longer cast the `NullPool` arm away:
`NullPool` declares `withConnection: never` alongside `role`/`shard`/
`schemaMigration`/`internalMetadata`, and `schemaCache` is read at its real
`BoundSchemaReflection | null` type with the nil arm raising `NoMethodError`
as `abstract/connection_pool.rb:38` demands. New tests pin both raises.

`migration-collaborator-call-mismatch-burndown` was already landed on main
(#6262/#6265) and is marked done separately — no baseline rows remain for
either collaborator.

Closes-story: port-sqlite-rake-create-drop-charset-collation-tests
Closes-story: internal-metadata-takes-a-pool-nullpool-arm-reads-enabled
Closes-story: retire-pool-structural-casts-in-migration-collaborators