### PR TITLE
fix(activerecord): retire the landed migration-context citation; import NoDatabaseError in the SQLite tasks test

### DIFF
--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -640,25 +640,16 @@ describe("MigrationTest", () => {
     );
   });
 
-  // Rails builds `MigrationContext.new(migrations_path)` here and lets it
-  // default `schema_migration` / `internal_metadata` off the connection pool
-  // (migration.rb:1214-1218) — that default is the only thing separating this
-  // case from `migrator versions`, which passes both explicitly
-  // (migration_test.rb:107). trails' MigrationContext takes an adapter, not a
-  // pool, so it has nothing to default from and both cases must pass them; the
-  // two bodies are therefore identical until story
-  // 0051/migration-context-collaborators-need-a-pool lands the pool-defaulted
-  // constructor, at which point this one drops its arguments and the
-  // distinction Rails is testing comes back.
+  // The point of this case is the argument-less constructor: Rails lets
+  // `MigrationContext` default `schema_migration` / `internal_metadata` off the
+  // connection pool (migration.rb:1214-1218), which is the only thing
+  // separating it from `migrator versions`, where both are passed explicitly
+  // (migration_test.rb:107).
   it("migration context with default schema migration", async () => {
     const migrationsPath = `${MIGRATIONS_ROOT}/valid`;
     const adapter = Base.connection;
     const schemaMigration = new SchemaMigration(adapter.pool);
-    const migrator = new MigrationContext(
-      [migrationsPath],
-      schemaMigration,
-      new InternalMetadata(adapter.pool),
-    );
+    const migrator = new MigrationContext([migrationsPath]);
     await migrator.migrate();
 
     expect(await migrator.currentVersion()).toBe(3);

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.test.ts
@@ -7,7 +7,7 @@ import { randomUUID } from "node:crypto";
 import { SQLiteDatabaseTasks } from "./sqlite-database-tasks.js";
 import { DatabaseTasks } from "./database-tasks.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
-import { DatabaseAlreadyExists } from "../errors.js";
+import { DatabaseAlreadyExists, NoDatabaseError } from "../errors.js";
 import { SchemaDumper } from "../schema-dumper.js";
 import { Base } from "../base.js";
 


### PR DESCRIPTION
Two CI reds on main, both one-liners.

**1. `Unit Tests` — stale story citation.**
`scripts/stale-story-references.test.ts` flags a comment naming
`migration-context-collaborators-need-a-pool`, which landed in #6268. That
comment said the test would drop its explicit collaborators once the story
landed; it has, so `migration context with default schema migration` now builds
`new MigrationContext([migrationsPath])` and lets the constructor default
`schemaMigration` / `internalMetadata` off the pool, matching
`migration_test.rb:86-100`. That restores the distinction from
`migrator versions` (`migration_test.rb:107`), which passes both explicitly and
is unchanged here.

**2. `Build & Type Check` — missing import.**
#6273 added `raises NoDatabaseError dropping an in-memory database, as
FileUtils.rm does` but never imported `NoDatabaseError`, so `tsc` fails with
TS2304 at `sqlite-database-tasks.test.ts:202` and takes every downstream job
(all AR lanes, Virtualized DX Type Tests, Rails API/Test Comparison) with it.
The assertion is correct — `sqlite_database_tasks.rb:22-28` has no in-memory arm
and `FileUtils.rm`'s `Errno::ENOENT` is rescued into `NoDatabaseError` — so this
adds the import and nothing else.

Closes-story: red-1fd85251
Closes-story: sqlite-database-tasks-test-missing-nodatabaseerror-import
