### PR TITLE
fix(date,activerecord): the Temporal seat's limits are recorded; MigrationContext defaults its collaborators in the constructor

### DIFF
--- a/packages/activerecord-cli/src/db-helpers.ts
+++ b/packages/activerecord-cli/src/db-helpers.ts
@@ -45,10 +45,12 @@ export async function tryLoadModels(cwd: string): Promise<Record<string, unknown
   return import(pathToFileURL(modelsPath).href) as Promise<Record<string, unknown>>;
 }
 
+/**
+ * Discovery only, so the collaborators are the null objects `Migration.copy`
+ * hands its own contexts (migration.rb:1065-1066) rather than a pool lookup.
+ */
 export function loadMigrations(cwd: string): import("@blazetrails/activerecord").MigrationProxy[] {
   const paths = DatabaseTasks.migrationsPaths.map((p) => resolve(join(cwd, p)));
-  // Discovery only, so the collaborators are the null objects `Migration.copy`
-  // hands its own contexts (migration.rb:1065-1066) rather than a pool lookup.
   const migrations = new MigrationContext(
     paths,
     new NullSchemaMigration(),

--- a/packages/activerecord-cli/src/db-helpers.ts
+++ b/packages/activerecord-cli/src/db-helpers.ts
@@ -1,6 +1,12 @@
 import { join, resolve } from "path";
 import { getFsAsync } from "@blazetrails/activesupport";
-import { DatabaseTasks, DatabaseConfigurations, MigrationContext } from "@blazetrails/activerecord";
+import {
+  DatabaseTasks,
+  DatabaseConfigurations,
+  MigrationContext,
+  NullSchemaMigration,
+  NullInternalMetadata,
+} from "@blazetrails/activerecord";
 import { establishEnvironmentConnection, normalizeSqlitePaths } from "./environment.js";
 
 /**
@@ -41,7 +47,13 @@ export async function tryLoadModels(cwd: string): Promise<Record<string, unknown
 
 export function loadMigrations(cwd: string): import("@blazetrails/activerecord").MigrationProxy[] {
   const paths = DatabaseTasks.migrationsPaths.map((p) => resolve(join(cwd, p)));
-  const migrations = new MigrationContext(paths).migrations;
+  // Discovery only, so the collaborators are the null objects `Migration.copy`
+  // hands its own contexts (migration.rb:1065-1066) rather than a pool lookup.
+  const migrations = new MigrationContext(
+    paths,
+    new NullSchemaMigration(),
+    new NullInternalMetadata(),
+  ).migrations;
   DatabaseTasks.registerMigrations(migrations);
   return migrations;
 }

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -328,7 +328,7 @@ export {
   NoEnvironmentInSchemaError,
 } from "./migration.js";
 export { InternalMetadata, NullInternalMetadata } from "./internal-metadata.js";
-export { SchemaMigration } from "./schema-migration.js";
+export { SchemaMigration, NullSchemaMigration } from "./schema-migration.js";
 export type { MigrationProxy } from "./migration.js";
 export type { DelegatedTypeOptions } from "./delegated-type.js";
 

--- a/packages/activerecord/src/migration-context.trails.test.ts
+++ b/packages/activerecord/src/migration-context.trails.test.ts
@@ -12,8 +12,8 @@ import {
 } from "./migration.js";
 import { ActiveRecord } from "./ar-config.js";
 import { Base } from "./base.js";
-import { SchemaMigration } from "./schema-migration.js";
-import { InternalMetadata } from "./internal-metadata.js";
+import { SchemaMigration, NullSchemaMigration } from "./schema-migration.js";
+import { InternalMetadata, NullInternalMetadata } from "./internal-metadata.js";
 import { DatabaseConfigurations } from "./database-configurations.js";
 import { fixtures } from "./test-fixtures.js";
 
@@ -25,7 +25,11 @@ describe("MigrationContext", () => {
   });
 
   it("migrations reads this context's migrationsPaths", () => {
-    const context = new MigrationContext([`${MIGRATIONS_ROOT}/valid`]);
+    const context = new MigrationContext(
+      [`${MIGRATIONS_ROOT}/valid`],
+      new NullSchemaMigration(),
+      new NullInternalMetadata(),
+    );
 
     expect(context.migrations.map((m) => [m.version, m.name])).toEqual([
       [1, "ValidPeopleHaveLastNames"],
@@ -35,10 +39,11 @@ describe("MigrationContext", () => {
   });
 
   it("migrations merges every path it was given, sorted by version", () => {
-    const context = new MigrationContext([
-      `${MIGRATIONS_ROOT}/valid_with_timestamps`,
-      `${MIGRATIONS_ROOT}/to_copy_with_timestamps`,
-    ]);
+    const context = new MigrationContext(
+      [`${MIGRATIONS_ROOT}/valid_with_timestamps`, `${MIGRATIONS_ROOT}/to_copy_with_timestamps`],
+      new NullSchemaMigration(),
+      new NullInternalMetadata(),
+    );
 
     expect(context.migrations.map((m) => m.version)).toEqual([
       20090101010101, 20090101010202, 20100101010101, 20100201010101, 20100301010101,
@@ -46,8 +51,16 @@ describe("MigrationContext", () => {
   });
 
   it("two contexts over two directories do not collide", () => {
-    const valid = new MigrationContext([`${MIGRATIONS_ROOT}/valid`]);
-    const timestamped = new MigrationContext([`${MIGRATIONS_ROOT}/valid_with_timestamps`]);
+    const valid = new MigrationContext(
+      [`${MIGRATIONS_ROOT}/valid`],
+      new NullSchemaMigration(),
+      new NullInternalMetadata(),
+    );
+    const timestamped = new MigrationContext(
+      [`${MIGRATIONS_ROOT}/valid_with_timestamps`],
+      new NullSchemaMigration(),
+      new NullInternalMetadata(),
+    );
 
     expect(valid.migrations.map((m) => m.version)).toEqual([1, 2, 3]);
     expect(timestamped.migrations.map((m) => m.version)).toEqual([
@@ -57,7 +70,11 @@ describe("MigrationContext", () => {
 
   it("migrations raises for a migration timestamp in the future", () => {
     ActiveRecord.validateMigrationTimestamps = true;
-    const context = new MigrationContext([`${MIGRATIONS_ROOT}/future_timestamp`]);
+    const context = new MigrationContext(
+      [`${MIGRATIONS_ROOT}/future_timestamp`],
+      new NullSchemaMigration(),
+      new NullInternalMetadata(),
+    );
 
     expect(() => context.migrations).toThrow(InvalidMigrationTimestampError);
   });
@@ -67,7 +84,11 @@ describe("MigrationContext", () => {
     const previous = ActiveRecord.timestampedMigrations;
     ActiveRecord.timestampedMigrations = false;
     try {
-      const context = new MigrationContext([`${MIGRATIONS_ROOT}/future_timestamp`]);
+      const context = new MigrationContext(
+        [`${MIGRATIONS_ROOT}/future_timestamp`],
+        new NullSchemaMigration(),
+        new NullInternalMetadata(),
+      );
       expect(context.migrations).toHaveLength(1);
     } finally {
       ActiveRecord.timestampedMigrations = previous;

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -648,7 +648,7 @@ describe("MigrationTest", () => {
   it("migration context with default schema migration", async () => {
     const migrationsPath = `${MIGRATIONS_ROOT}/valid`;
     const adapter = Base.connection;
-    const schemaMigration = new SchemaMigration(adapter.pool);
+    const schemaMigration = adapter.pool.schemaMigration;
     const migrator = new MigrationContext([migrationsPath]);
     await migrator.migrate();
 

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -8,7 +8,7 @@ import { ArgumentError } from "@blazetrails/activemodel";
 import { BigDecimal } from "@blazetrails/activesupport";
 import { Base, Migrator, RecordNotUnique, StatementInvalid } from "./index.js";
 import { ActiveRecord } from "./ar-config.js";
-import { SchemaMigration } from "./schema-migration.js";
+import { SchemaMigration, NullSchemaMigration } from "./schema-migration.js";
 import type { MigrationProxy } from "./migration.js";
 import { ConcurrentMigrationError, MigrationContext } from "./migration.js";
 import { adapterType } from "./test-adapter.js";
@@ -41,7 +41,7 @@ import { Mysql2Adapter } from "./connection-adapters/mysql2-adapter.js";
 import { describeIfMysqlAdapter } from "./support/describe-if-mysql-adapter.js";
 import { leaseMysqlAdapter } from "./adapters/abstract-mysql-adapter/test-helper.js";
 import { anonymousMigration } from "./test-helpers/anonymous-migration.js";
-import { InternalMetadata } from "./internal-metadata.js";
+import { InternalMetadata, NullInternalMetadata } from "./internal-metadata.js";
 
 // Mirrors `MIGRATIONS_ROOT` from cases/helper.rb:14 — the directory the
 // versioned migration fixtures live under.
@@ -2271,7 +2271,11 @@ describe("MigrationTest", () => {
           // (year 9999) is definitely > tomorrow.
           const dir = new URL("./test-helpers/migrations/future_timestamp", import.meta.url)
             .pathname;
-          expect(() => new MigrationContext([dir]).migrations).toThrow(
+          expect(
+            () =>
+              new MigrationContext([dir], new NullSchemaMigration(), new NullInternalMetadata())
+                .migrations,
+          ).toThrow(
             /Invalid timestamp 99991231235959 for migration file: future_timestamp_migration/,
           );
         } finally {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1930,7 +1930,10 @@ export class MigrationContext {
    * `up`/`down`/`currentVersion`. Declaring the readers as the union instead
    * proves nothing extra: it moves the same unchecked narrowing onto the
    * nineteen sites that use a connected context, where Rails asserts nothing
-   * either.
+   * either. Tracked for convergence as RFC 0051's
+   * `migration-context-collaborator-readers-cast-away-the-null-object`: the
+   * reader should stop claiming a type the field may not hold, which needs the
+   * discovery-only context to become distinguishable at the type level.
    */
   constructor(
     migrationsPaths: string[],

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -36,8 +36,8 @@ import {
 } from "./connection-adapters/abstract/schema-statements.js";
 import type { UniqueConstraintOptions } from "./connection-adapters/postgresql/schema-definitions.js";
 import { CommandRecorder } from "./migration/command-recorder.js";
-import { SchemaMigration } from "./schema-migration.js";
-import { InternalMetadata } from "./internal-metadata.js";
+import { SchemaMigration, NullSchemaMigration } from "./schema-migration.js";
+import { InternalMetadata, NullInternalMetadata } from "./internal-metadata.js";
 import { DatabaseConfigurations } from "./database-configurations.js";
 import type { DatabaseConfig } from "./database-configurations/database-config.js";
 import { migrationArConfig } from "./migration/ar-config-source.js";
@@ -1515,7 +1515,14 @@ export abstract class Migration {
       fs.mkdirSync(destination, { recursive: true });
     }
 
-    const destinationMigrations = new MigrationContext([destination]).migrations;
+    const schemaMigration = new NullSchemaMigration();
+    const internalMetadata = new NullInternalMetadata();
+
+    const destinationMigrations = new MigrationContext(
+      [destination],
+      schemaMigration,
+      internalMetadata,
+    ).migrations;
     let last: MigrationProxy | undefined = destinationMigrations[destinationMigrations.length - 1];
 
     const copied: MigrationProxy[] = [];
@@ -1529,7 +1536,8 @@ export abstract class Migration {
         );
       }
       if (!fs.existsSync(sourcePath)) continue;
-      const sourceMigrations = new MigrationContext([sourcePath]).migrations;
+      const sourceMigrations = new MigrationContext([sourcePath], schemaMigration, internalMetadata)
+        .migrations;
 
       for (const source of sourceMigrations) {
         if (!source.filename) continue;
@@ -1897,39 +1905,32 @@ function byVersion(a: MigrationProxy, b: MigrationProxy): number {
  * Mirrors: ActiveRecord::MigrationContext (migration.rb:1211)
  */
 export class MigrationContext {
+  /** Mirrors: `attr_reader :migrations_paths, :schema_migration, :internal_metadata` (`migration.rb:1212`). */
   readonly migrationsPaths: string[];
-  private _schemaMigration?: SchemaMigration;
-  private _internalMetadata?: InternalMetadata;
+  readonly schemaMigration: SchemaMigration;
+  readonly internalMetadata: InternalMetadata;
 
   /**
-   * Rails defaults both collaborators from `connection_pool` right here —
-   * `schema_migration || SchemaMigration.new(connection_pool)`
-   * (`migration.rb:1214-1218`). The default is resolved on first read instead
-   * of in the constructor: Rails can name `connection_pool` eagerly because
-   * `DatabaseTasks.migration_connection_pool` always has one by the time a
-   * context is built, while trails builds connectionless contexts for file
-   * discovery (`migrations`, `migrationFiles`, `parseMigrationFilename` — the
-   * surface Rails' own context never consults `@schema_migration` from), where
-   * the pool lookup would throw at construction and take discovery with it.
+   * Mirrors: ActiveRecord::MigrationContext#initialize
+   * (`migration.rb:1214-1218`).
+   *
+   * A caller with no pool hands in the null objects `Migration.copy` does
+   * (`migration.rb:1065-1066`), which the discovery half (`migrations`,
+   * `migrationFiles`, `parseMigrationFilename`) never calls into. Rails'
+   * `NullSchemaMigration` / `NullInternalMetadata` are empty classes duck-typed
+   * into the same slot; TS has no duck typing, so they are seated through the
+   * declared type here.
    */
   constructor(
     migrationsPaths: string[],
-    schemaMigration?: SchemaMigration,
-    internalMetadata?: InternalMetadata,
+    schemaMigration?: SchemaMigration | NullSchemaMigration,
+    internalMetadata?: InternalMetadata | NullInternalMetadata,
   ) {
     this.migrationsPaths = migrationsPaths;
-    this._schemaMigration = schemaMigration;
-    this._internalMetadata = internalMetadata;
-  }
-
-  /** Mirrors: ActiveRecord::MigrationContext#schema_migration */
-  get schemaMigration(): SchemaMigration {
-    return (this._schemaMigration ??= new SchemaMigration(this.connectionPool()));
-  }
-
-  /** Mirrors: ActiveRecord::MigrationContext#internal_metadata */
-  get internalMetadata(): InternalMetadata {
-    return (this._internalMetadata ??= new InternalMetadata(this.connectionPool()));
+    this.schemaMigration = (schemaMigration ??
+      new SchemaMigration(this.connectionPool())) as SchemaMigration;
+    this.internalMetadata = (internalMetadata ??
+      new InternalMetadata(this.connectionPool())) as InternalMetadata;
   }
 
   /**

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1917,9 +1917,20 @@ export class MigrationContext {
    * A caller with no pool hands in the null objects `Migration.copy` does
    * (`migration.rb:1065-1066`), which the discovery half (`migrations`,
    * `migrationFiles`, `parseMigrationFilename`) never calls into. Rails'
-   * `NullSchemaMigration` / `NullInternalMetadata` are empty classes duck-typed
-   * into the same slot; TS has no duck typing, so they are seated through the
-   * declared type here.
+   * `NullSchemaMigration` (`schema_migration.rb:9`) / `NullInternalMetadata`
+   * (`internal_metadata.rb:13`) are empty classes duck-typed into the same
+   * slot, and `attr_reader` (`migration.rb:1212`) hands back whatever was
+   * seated; TS has no duck typing, so the readers stay typed as the real
+   * collaborators and the null objects are seated through that type here.
+   *
+   * The narrowing that buys is real rather than assumed: a null-object context
+   * is only ever a local temporary of the two functions that build one —
+   * `Migration.copy` and activerecord-cli's `loadMigrations` — each of which
+   * reads `migrations` off it and lets it go, so no such context reaches
+   * `up`/`down`/`currentVersion`. Declaring the readers as the union instead
+   * proves nothing extra: it moves the same unchecked narrowing onto the
+   * nineteen sites that use a connected context, where Rails asserts nothing
+   * either.
    */
   constructor(
     migrationsPaths: string[],

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -926,6 +926,32 @@ describe("Date", () => {
       expect(() => date.toDate()).toThrow(RubyDate.Error);
     }
   });
+
+  it("raises from every static that answers the seat for a Julian-only spelling", () => {
+    // ruby 3.3.11 -rdate answers "1500-02-29" from all six — the gem's `::Date`
+    // value is the gem object, so `date_to_date` (date_core.c:8977-8981) is
+    // `self` and never raises. trails' `::Date` value is `Temporal.PlainDate`,
+    // proleptic Gregorian, which has no 1500-02-29; RFC 0088's mapping table
+    // names this the seat's limit rather than narrowing the default return.
+    //   Date.civil(1500, 2, 29) / Date.jd(2268992) / Date.ordinal(1500, 60) /
+    //   Date.commercial(1500, 9, 6) / Date.parse("1500-02-29") /
+    //   Date.strptime("1500-02-29", "%Y-%m-%d")
+    const statics: Array<() => Temporal.PlainDate> = [
+      () => RubyDate.civil(1500, 2, 29),
+      () => RubyDate.jd(2268992),
+      () => RubyDate.ordinal(1500, 60),
+      () => RubyDate.commercial(1500, 9, 6),
+      () => RubyDate.parse("1500-02-29"),
+      () => RubyDate.strptime("1500-02-29", "%Y-%m-%d"),
+    ];
+    for (const build of statics) {
+      expect(build).toThrow(new RubyDate.Error("invalid date"));
+    }
+
+    // The gem-shaped builders the same statics run over answer it, so the
+    // spelling is reachable — only the Temporal seat cannot hold it.
+    expect(dNewByFrags(RubyDate._parse("1500-02-29")).toS()).toBe("1500-02-29");
+  });
 });
 
 describe("DateTime", () => {
@@ -1019,6 +1045,22 @@ describe("DateTime", () => {
     expect((seat as Temporal.ZonedDateTime).toPlainDateTime().toString()).toBe(
       "2008-03-01T06:00:00",
     );
+  });
+
+  it("names an instant the truncated offset moves, which the gem-shaped object still holds", () => {
+    // ruby 3.3.11:
+    //   DateTime.parse("2008-03-01T06:00:00-00:44:30").to_time.to_i #=> 1204353870
+    //   #=> 2008-03-01 06:44:30 UTC
+    // The seat's zone is minute-precision (`of2str`, date_core.c:1973-1980), so
+    // its instant is 06:44:00 UTC — 30 seconds early, the size of the seconds
+    // `date_zone_to_diff` (date_parse.c:523-528) kept and Temporal cannot. The
+    // exact offset stays reachable on the gem-shaped object, which is where a
+    // caller who needs the moment MRI names reads it from.
+    const seat = RubyDateTime.parse("2008-03-01T06:00:00-00:44:30") as Temporal.ZonedDateTime;
+    expect(Number(seat.epochNanoseconds / 1000000000n)).toBe(1204353870 - 30);
+
+    const gem = gemDateTime("2008-03-01T06:00:00-00:44:30");
+    expect(gem.offset.mul(86400).toI()).toBe(-2670);
   });
 
   it("spells a half-hour and a named zone's offset", () => {

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -945,7 +945,8 @@ describe("Date", () => {
       () => RubyDate.strptime("1500-02-29", "%Y-%m-%d"),
     ];
     for (const build of statics) {
-      expect(build).toThrow(new RubyDate.Error("invalid date"));
+      expect(build).toThrow(RubyDate.Error);
+      expect(build).toThrow("invalid date");
     }
 
     // The gem-shaped builders the same statics run over answer it, so the

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -4072,6 +4072,15 @@ export class Date {
    * convert to and this raises where the gem-shaped object itself is fine
    * ({@link plainDateFromJd}).
    *
+   * **RFC 0088 records the raise as the seat's limit** rather than narrowing
+   * the default return to the gem-shaped object for those days: its mapping
+   * table names the range, which is every Julian leap day a Gregorian century
+   * rule removes — 1500-02-29, 1400-02-29, 1300-02-29 and so on back before
+   * the 1582 reform. Every static that answers the seat inherits it, since
+   * `Date.civil`, `Date.jd`, `Date.ordinal`, `Date.commercial`, `Date.parse`
+   * and `Date.strptime` all end here; a caller who needs those days reads the
+   * gem-shaped object from {@link dNewByFrags} instead.
+   *
    * **This is the opt-in seam RFC 0088 left open**, and it is a conversion
    * method rather than an options argument or a parallel entry point because
    * the gem already names both directions and neither name is invented: the


### PR DESCRIPTION
Three related stories: two RFC 0088 seat decisions in `packages/date`, one RFC 0051 convergence in `MigrationContext`.

## 1. `Date#toDate`'s seat raises on a Julian-only spelling

`Temporal.PlainDate` is proleptic Gregorian, so a pre-reform Julian-only day
(1500-02-29 and every Julian leap day a Gregorian century rule removes) has no
value to convert to, and `Date#toDate` — MRI's `date_to_date`, `date_core.c:8977-8981`,
which is `self` and never raises — throws `Date::Error, "invalid date"`. Every
static over the seat inherits it.

Decision: **keep the raise as the seat's limit**, rather than narrowing the
default return to the gem-shaped object for those days. Recorded in RFC 0088's
mapping table (new "What the `Temporal` seat cannot hold" section, pushed to the
tasks repo) and named at the `toDate` call site with the affected range and the
statics. `date.trails.test.ts` now covers all six statics (`civil`, `jd`,
`ordinal`, `commercial`, `parse`, `strptime`) against live `ruby 3.3.11 -rdate`,
plus the gem-shaped builder that still answers `"1500-02-29"`.

## 2. The `DateTime` seat truncates a sub-minute offset

`date_zone_to_diff` (`date_parse.c:523-528`) keeps seconds — `-2670` for
`-00:44:30` — while a Temporal offset time zone is minute-precision, so the
seat's instant is up to 59s off. Same decision, same table section: the limit is
recorded rather than narrowed, since `of2str` (`date_core.c:1973-1980`) drops the
same seconds and the seat therefore agrees with `DateTime#zone`. A new test pins
the instant: `epochNanoseconds` names `1204353870 - 30`, against MRI's
`DateTime.parse("2008-03-01T06:00:00-00:44:30").to_time.to_i #=> 1204353870`, and
that `DateTime#offset` still holds the exact `-2670`.

## 3. `MigrationContext` defaults its collaborators in the constructor

Converges the deviation shipped in #6268. The constructor now reads as
`migration.rb:1214-1218` does — `schemaMigration ?? new SchemaMigration(this.connectionPool())`
— and `schemaMigration` / `internalMetadata` are plain readers (`attr_reader`,
`migration.rb:1212`) with no lazy `??=`. The comment explaining the lazy
deviation is gone.

The discovery-only call sites get what Rails gives its own: `Migration.copy`
seats `NullSchemaMigration` / `NullInternalMetadata` exactly as
`migration.rb:1065-1066` does, and `db-helpers.ts#loadMigrations` plus the
discovery tests do the same. The null objects are duck-typed into the slot in
Ruby; TS has no duck typing, so they are seated through the declared type at the
one assignment, noted there.

`migration-context` / `migrator` / `migration` / `pending-migrations` /
trailties `db` / activerecord-cli suites pass with their names unchanged.

`pnpm api:extra --package date` and `--package activerecord` clean; `pnpm api:calls` OK,
no new baseline rows.

## Reviewer follow-ups

**1. The `as SchemaMigration` / `as InternalMetadata` cast.** Kept, with the
justification now on the constructor's JSDoc. Rails' `attr_reader`
(`migration.rb:1212`) hands back whatever was seated, so the union is what the
slot really holds — but declaring it proves nothing extra in TS: it moves the
same unchecked narrowing onto the nineteen sites that use a *connected* context
(`up`/`down` at `:2058`, `:2121-2122`, the five `Migrator` constructions, the
`internalMetadata` reads), each of which would then need its own cast. What
makes the two flagged call sites safe is not the cast but reachability: a
null-object context is only ever a local temporary of the two functions that
build one — `Migration.copy` (`migration.rb:1065-1066`) and
activerecord-cli's `loadMigrations` — and each reads `migrations` off it and
lets it go. No null-object context escapes to `up`/`down`/`currentVersion`.
I measured the alternative before rejecting it: widening the two readers
produces exactly 19 `TS2339`/`TS2345` errors, all in code paths that only ever
see a real collaborator.

**Maintainer sign-off (second pass).** The reviewer correctly held this open as
a design tradeoff argued by the implementer rather than a Rails citation or a
language necessity, and asked for a maintainer decision. Taken: the cast stays,
and the deviation is now on the burndown ledger as RFC 0051's
`migration-context-collaborator-readers-cast-away-the-null-object`
(tasks repo `e25a88ea7`), which records the measurement, the rejected
generic-parameter shape, and the acceptance criterion that the reader must stop
claiming a type the field may not hold. The story id is cited at the call site,
so the debt is discoverable from the code rather than from this thread.

**2. RFC 0088's mapping table.** Confirmed updated, not just referenced — the
tasks repo is trunk-only, so it is already on `main` there as
`466bed1f2 docs(0088): record what the Temporal seat cannot hold in the mapping table`
(`rfcs/0088-date-gem-port/README.md`, +25). The diff:

```diff
diff --git a/rfcs/0088-date-gem-port/README.md b/rfcs/0088-date-gem-port/README.md
index 2b712ba3d..18390bdd8 100644
--- a/rfcs/0088-date-gem-port/README.md
+++ b/rfcs/0088-date-gem-port/README.md
@@ -122,6 +122,31 @@ Where a Ruby method answers a temporal value, **the TS method answers a
 Callers get Temporal without asking. This is the headline behavioral commitment
 of the RFC.
 
+#### What the `Temporal` seat cannot hold
+
+Two values the gem-shaped object carries have no `Temporal` spelling. Both are
+limits of the seat, not of the port: the gem-shaped object (`dNewByFrags` /
+`dtNewByFrags`, and the `Date` / `DateTime` classes themselves) answers them
+exactly, and the default return is _not_ narrowed for either case.
+
+- **A pre-reform `::Date` with a Julian-only spelling raises.**
+  `Temporal.PlainDate` is proleptic Gregorian, so every Julian leap day a
+  Gregorian century rule removes — 1500-02-29, 1400-02-29, 1300-02-29 and so on
+  back before the 1582 reform — has no value to convert to and `Date#to_date`
+  (`date_core.c:8977-8981`, which is `self` in MRI and never raises) throws
+  `Date::Error, "invalid date"`. Every static over the seat inherits this:
+  `Date.civil`, `Date.jd`, `Date.ordinal`, `Date.commercial`, `Date.parse`,
+  `Date.strptime`.
+- **A sub-minute offset on a `::DateTime` truncates to the minute, moving the
+  instant by up to 59 seconds.** `date_zone_to_diff` (`date_parse.c:523-528`)
+  answers seconds — `Date._parse("2008-03-01T06:00:00-00:44:30")[:offset]` is
+  `-2670` — while a `Temporal` offset time zone is minute-precision. The zone is
+  spelled with `of2str` (`date_core.c:1973-1980`), whose `"%c%02d:%02d"` drops
+  the same seconds, so the seat agrees with `DateTime#zone` (`"-00:44"`); the
+  cost is that `ZonedDateTime#epochNanoseconds` names 06:44:00 UTC where MRI
+  names 06:44:30. `DateTime#offset` / `#zone` on the gem-shaped object still
+  hold the exact value, as `::Time`'s `number` offset does for the same reason.
+
 ### 3. The Ruby-shaped object stays available as an option
 
 **A `Date` class still exists** — it is the gem's own API surface, it is what the
```

## Third pass

**Red CI was a real finding, now fixed.** `migration.test.ts`'s
`"migration context with default schema migration"` still passed both
collaborators explicitly, so the very default this PR ships had no coverage and
the test was indistinguishable from `"migrator versions"` — exactly what its own
comment said would change once the pool-defaulted constructor landed. It now
reads as Rails' `test_migration_context_with_default_schema_migration`
(`migration_test.rb:86-100`) does: `new MigrationContext([migrationsPath])` with
no collaborator args, letting `connectionPool()` resolve them, and the closing
`createVersion("3")` goes through the pool's own `schemaMigration` the way
Rails' `@schema_migration` (`migration_test.rb:48`, `@pool.schema_migration`)
does. That closes the reviewer's second finding too — the `??` branch is now
exercised against a live connected pool, in addition to the trails-only cover in
`migration-context.trails.test.ts`.

The two stale `migration-context-collaborators-need-a-pool` citations that
reddened `scripts/stale-story-references.test.ts` are gone: the one in
`migration.test.ts` described the deviation this PR removes and was deleted with
it, and `internal-metadata.ts:96` now cites the open successor that actually
owns its NullPool arm, `internal-metadata-takes-a-pool-nullpool-arm-reads-enabled`.

Closes-story: date-to-date-seat-raises-on-julian-only-spellings
Closes-story: datetime-seat-truncates-a-sub-minute-offset
Closes-story: migration-context-defaults-collaborators-in-the-constructor
