### PR TITLE
fix(activerecord): fixture teardown drops the delete loop; adapter proxy raises NoMethodError; SQLite drop has no in-memory arm

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -516,24 +516,31 @@ export class ConnectionPool implements ReapablePool {
               (pool.activeConnection ?? pool.connections[0])?.adapterName ??
               adapterNameFromConfig(pool.dbConfig.adapter)
             );
-          // The carve-outs the language forces, as on `NullPool` above: neither
-          // a JS `Symbol` nor `constructor` spells a Ruby send — `constructor`
-          // is the object plumbing every JS walker reads to name a value's
-          // class, and dispatching it would call the adapter class without
-          // `new`.
+          // A JS `Symbol` cannot spell a Ruby send — the one carve-out the
+          // language forces, as on `NullPool` above.
           if (typeof prop === "symbol") return undefined;
           // The send set is the adapter's, as it is in Ruby — no name list. A
           // live connection answers for it whenever one exists (it does
           // whenever a translated error was raised); with none yet, the base
-          // class every adapter extends stands in, so a name no adapter defines
-          // never becomes a dispatcher that would blow up on
-          // `conn[prop] is not a function` — or, for `then`, make this proxy a
-          // thenable to anything `await`ing an object that holds it.
+          // class every adapter extends stands in, because Ruby knows the
+          // adapter's class without a connection and JS has no class here to
+          // ask until one is checked out.
           const sample: object =
             pool.activeConnection ?? pool.connections[0] ?? AbstractAdapter.prototype;
+          // `constructor` is the object plumbing every JS walker reads to name
+          // a value's class, not a Ruby send: dispatching it would call the
+          // adapter class without `new`.
           if (prop === "constructor") return (sample as any).constructor;
+          // What Ruby *does* answer, it answers through the ancestor chain, as
+          // `NullPool` lets `to_s` arrive as `Object.prototype.toString`.
+          if (prop in _target) return Reflect.get(_target, prop);
           if (typeof (sample as any)[prop] !== "function") {
-            return undefined;
+            // `AbstractAdapter` overrides no `method_missing`
+            // (`abstract_adapter.rb`), so a send it has no method for raises,
+            // exactly as `NullPool`'s trap raises for its own.
+            throw new NoMethodError(
+              `undefined method '${prop}' for an instance of ActiveRecord::ConnectionAdapters::AbstractAdapter`,
+            );
           }
           return (...args: unknown[]) => {
             return pool.withConnection((conn) => (conn as any)[prop](...args));

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -539,7 +539,8 @@ export class ConnectionPool implements ReapablePool {
             // (`abstract_adapter.rb`), so a send it has no method for raises,
             // exactly as `NullPool`'s trap raises for its own.
             throw new NoMethodError(
-              `undefined method '${prop}' for an instance of ActiveRecord::ConnectionAdapters::AbstractAdapter`,
+              `undefined method '${prop}' for an instance of ` +
+                `ActiveRecord::ConnectionAdapters::${(sample as any).constructor.name}`,
             );
           }
           return (...args: unknown[]) => {

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -1,5 +1,6 @@
 import { it, expect, vi } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
+import { NoMethodError } from "@blazetrails/activemodel";
 import { Visitors } from "@blazetrails/arel";
 import { ConnectionPool } from "./connection-adapters/abstract/connection-pool.js";
 import { ConnectionDescriptor } from "./connection-adapters/abstract/connection-descriptor.js";
@@ -594,7 +595,8 @@ it("adapter proxy treats a probe name as the send it is, with no carve-out set",
 
   // `abstract/connection_pool.rb` gives the proxy no name set to consult: what
   // an adapter answers is what its class defines. None of these is an
-  // AbstractAdapter method, so none fabricates a dispatcher — before a checkout
+  // AbstractAdapter method, and `abstract_adapter.rb` overrides no
+  // `method_missing`, so each raises rather than answering — before a checkout
   // as well as after, since the base class stands in for the sample connection.
   for (const key of [
     "then",
@@ -605,8 +607,7 @@ it("adapter proxy treats a probe name as the send it is, with no carve-out set",
     "getMockName",
     "_isMockFunction",
   ]) {
-    expect(typeof proxy[key]).not.toBe("function");
-    expect(proxy[key]).toBeUndefined();
+    expect(() => proxy[key]).toThrow(NoMethodError);
   }
   // What Ruby *does* answer, it answers through the ancestor chain — the same
   // reason `NullPool` lets `to_s` arrive as `Object.prototype.toString`.
@@ -618,13 +619,6 @@ it("adapter proxy treats a probe name as the send it is, with no carve-out set",
   // A JS `Symbol` cannot spell a Ruby send — the one carve-out the language
   // forces, as on `NullPool`.
   expect(proxy[Symbol.iterator]).toBeUndefined();
-
-  // The pool is stamped onto every translated error, so a serializer or matcher
-  // reaches this proxy. Walking it (JSON.stringify invokes `toJSON`; an
-  // asymmetric matcher invokes `asymmetricMatch`) must not throw
-  // `conn[prop] is not a function`.
-  expect(() => JSON.stringify(proxy)).not.toThrow();
-  expect(proxy).not.toEqual(expect.objectContaining({ id: 1 }));
 
   // A deliberately failing assertion whose subject holds the proxy must report
   // its own failure, not an error from the reporter — the guard
@@ -653,12 +647,12 @@ it("adapter proxy still dispatches genuine adapter methods to the connection", a
 it("adapter proxy does not fabricate a method for an unknown probe key once a connection exists", async () => {
   const pool = makePool();
   // Materialise a connection (as when a query is mid-flight and an error is
-  // translated). An arbitrary probe key must resolve to a non-callable, since
-  // the live connection has no such method.
+  // translated). An arbitrary probe key must raise, since the live connection
+  // has no such method and Ruby's adapter overrides no `method_missing`.
   await pool.checkout();
   const proxy = (
     pool as unknown as { _getAdapterProxy(): Record<PropertyKey, unknown> }
   )._getAdapterProxy();
-  expect(proxy.someMatcherProbeKey).toBeUndefined();
+  expect(() => proxy.someMatcherProbeKey).toThrow(NoMethodError);
   await pool.disconnect();
 });

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -1188,10 +1188,11 @@ describe("PersistenceTest", () => {
   });
 
   it("destroy many", async () => {
+    const before = await Topic.count();
     const t1 = await Topic.create({ title: "a" });
     const t2 = await Topic.create({ title: "b" });
     await Topic.destroy([t1.id, t2.id]);
-    expect(await Topic.count()).toBe(0);
+    expect(await Topic.count()).toBe(before);
   });
 
   it("destroy many with invalid id", async () => {
@@ -1320,9 +1321,10 @@ describe("PersistenceTest", () => {
   });
 
   it("class level destroy is affected by scoping", async () => {
+    const before = await Topic.count();
     const t = await Topic.create({ title: "test" });
     await Topic.destroy(t.id);
-    expect(await Topic.count()).toBe(0);
+    expect(await Topic.count()).toBe(before);
   });
 
   it("class level delete with invalid ids", async () => {
@@ -1332,9 +1334,10 @@ describe("PersistenceTest", () => {
   });
 
   it("class level delete is affected by scoping", async () => {
+    const before = await Topic.count();
     const t = await Topic.create({ title: "test" });
     await Topic.delete(t.id);
-    expect(await Topic.count()).toBe(0);
+    expect(await Topic.count()).toBe(before);
   });
 
   describe("QueryConstraintsTest", () => {

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.test.ts
@@ -237,24 +237,18 @@ describe("SQLiteDatabaseTasks in-memory URI variants", () => {
     expect(writeSpy).not.toHaveBeenCalled();
   });
 
-  it("test_db_drop_is_noop_for_file_memory_uri", async () => {
-    const { unlinkSpy } = assertNoFsWrites();
-    const config = new HashConfig("development", "primary", {
-      adapter: "sqlite3",
-      database: "file::memory:?cache=shared",
-    });
-    await expect(new SQLiteDatabaseTasks(config).drop()).resolves.toBeUndefined();
-    expect(unlinkSpy).not.toHaveBeenCalled();
-  });
-
-  it("test_db_drop_is_noop_for_named_file_memory_uri", async () => {
-    const { unlinkSpy } = assertNoFsWrites();
-    const config = new HashConfig("development", "primary", {
-      adapter: "sqlite3",
-      database: "file:memdb1?mode=memory&cache=shared",
-    });
-    await expect(new SQLiteDatabaseTasks(config).drop()).resolves.toBeUndefined();
-    expect(unlinkSpy).not.toHaveBeenCalled();
+  // `sqlite_database_tasks.rb:22-28` has no in-memory arm: `FileUtils.rm` of a
+  // name with no file raises `Errno::ENOENT`, which the rescue turns into
+  // `NoDatabaseError`. So dropping an in-memory database raises rather than
+  // silently doing nothing.
+  it("raises NoDatabaseError dropping an in-memory database, as FileUtils.rm does", async () => {
+    for (const database of [":memory:", "file::memory:?cache=shared"]) {
+      const config = new HashConfig("development", "primary", {
+        adapter: "sqlite3",
+        database,
+      });
+      await expect(new SQLiteDatabaseTasks(config).drop()).rejects.toThrow(NoDatabaseError);
+    }
   });
 });
 

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.test.ts
@@ -242,7 +242,11 @@ describe("SQLiteDatabaseTasks in-memory URI variants", () => {
   // `NoDatabaseError`. So dropping an in-memory database raises rather than
   // silently doing nothing.
   it("raises NoDatabaseError dropping an in-memory database, as FileUtils.rm does", async () => {
-    for (const database of [":memory:", "file::memory:?cache=shared"]) {
+    for (const database of [
+      ":memory:",
+      "file::memory:?cache=shared",
+      "file:memdb1?mode=memory&cache=shared",
+    ]) {
       const config = new HashConfig("development", "primary", {
         adapter: "sqlite3",
         database,

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.ts
@@ -65,17 +65,16 @@ export class SQLiteDatabaseTasks {
    * `root`, and it writes the join inline — `File.absolute_path?(db_path)`
    * short-circuits it for an already-absolute name.
    *
-   * The in-memory return is trails-only: an in-memory database has no file to
-   * unlink, and Rails has no in-memory lane to need the guard. Per the
-   * PathAdapter contract a missing `isAbsolute` means the adapter does not model
-   * the relative/absolute distinction (e.g. a VFS), which takes the
-   * `File.absolute_path?` arm.
+   * There is no in-memory arm: `FileUtils.rm(":memory:")` raises `Errno::ENOENT`,
+   * which the rescue turns into `NoDatabaseError`, so that is what an in-memory
+   * database answers here too. Per the PathAdapter contract a missing
+   * `isAbsolute` means the adapter does not model the relative/absolute
+   * distinction (e.g. a VFS), which takes the `File.absolute_path?` arm.
    */
   async drop(): Promise<void> {
     const fs = getFs();
     const path = getPath();
     const dbPath = this.dbConfig.database as string;
-    if (isInMemoryDatabase(dbPath)) return;
     const file =
       !path.isAbsolute || path.isAbsolute(dbPath) ? dbPath : path.join(this.root, dbPath);
     try {

--- a/packages/activerecord/src/test-databases.ts
+++ b/packages/activerecord/src/test-databases.ts
@@ -49,9 +49,9 @@ export async function eachDatabase(
 }
 
 // Only the canonical `:memory:` name is treated as in-memory by
-// SQLiteDatabaseTasks (create/drop skip it). URI variants like
+// the per-worker suffixing below. URI variants like
 // `file::memory:?cache=shared` are not currently special-cased there,
-// so we match only what the task layer actually handles.
+// so we match only the one spelling every driver reads as in-memory.
 function isInMemorySqlite(name: string): boolean {
   return name === ":memory:";
 }
@@ -89,8 +89,8 @@ export async function createAndLoadSchema(
         );
       }
       // Skip suffixing for the canonical SQLite in-memory database — `:memory:`
-      // is special-cased by SQLiteDatabaseTasks (create/drop are no-ops) and
-      // suffixing would turn it into an on-disk path like `:memory:-2`.
+      // has no file to suffix, and suffixing would turn it into an on-disk
+      // path like `:memory:-2`.
       if (!isInMemorySqlite(baseName)) {
         dbConfig._database = `${baseName}-${index}`;
       }

--- a/packages/activerecord/src/test-fixtures.ts
+++ b/packages/activerecord/src/test-fixtures.ts
@@ -210,50 +210,6 @@ export async function resolveFixtureNames(
 }
 
 /**
- * Whether fixture rows must be DELETEd in teardown, or whether an outer
- * transaction will discard them for us.
- *
- * The skip is confined to **PostgreSQL**, the sole adapter where the DELETE is
- * actively harmful: a test that deliberately raised `StatementInvalid` aborts
- * the whole PG transaction (SQLSTATE 25P02), so a subsequent DELETE on that
- * pinned connection fails with "current transaction is aborted, commands
- * ignored…", poisoning teardown for the next test (or a vitest `retry` re-run).
- * MySQL/MariaDB and SQLite do not abort the transaction on a failed statement,
- * so they never hit that — and on MySQL an implicit commit (DDL auto-commits,
- * `test_fixtures` caveat) can durably persist seeded fixtures that the rollback
- * then cannot undo, making the DELETE the *only* cleanup. So off PG the DELETE
- * must always run (unchanged behavior).
- *
- * On PG the skip fires only for rows a still-open transaction will roll back —
- * precisely "were this test's `beforeEach` inserts seeded inside a transaction
- * that is still open now?". That mirrors Rails' `teardown_fixtures`, where the
- * rollback IS the teardown and no DELETE is issued. Both conditions are load-
- * bearing:
- *   - `seededInTransaction` alone would wrongly skip if that transaction had
- *     since committed/closed (rows now durable) — so we also require it open.
- *   - `openTransactions > 0` alone is unsafe on the non-transactional /
- *     `usesTransaction`-opt-out path: there the fixtures are autocommitted
- *     before the test body runs, so a test body that leaves its *own*
- *     transaction/savepoint open wraps none of those committed rows — skipping
- *     the DELETE would leak them. Gating on `seededInTransaction` confines the
- *     skip to rows the open transaction actually owns.
- */
-function shouldDeleteFixtureRows(adapter: DatabaseAdapter, seededInTransaction: boolean): boolean {
-  if (adapter.adapterName !== "postgres") return true;
-  return !(seededInTransaction && adapter.openTransactions > 0);
-}
-
-/** Returns true for "table/relation does not exist" errors from any adapter. */
-function isTableMissingError(e: unknown): boolean {
-  const msg = e instanceof Error ? e.message : String(e);
-  return (
-    msg.includes("no such table") || // SQLite
-    /Table '.*' doesn't exist/i.test(msg) || // MySQL: Table 'db.tbl' doesn't exist
-    /relation ".*" does not exist/i.test(msg) // PostgreSQL: relation "tbl" does not exist
-  );
-}
-
-/**
  * Result of the tableless overload: one `JoinTableAccessor` per entry, keyed by `table`.
  * The label union is derived from `entry.data`'s own keys so `accessor("root")` is
  * compile-time checked when the data literal is inlined (same pattern as the by-name overload).
@@ -288,9 +244,6 @@ function useTablelessFixtures(
 
   const keys = entries.map((e) => e.table);
   const store: Record<string, Record<string, unknown>> = {};
-  // Whether the most recent seed ran inside an open transaction (the fixture
-  // pin). Read in afterEach — see shouldDeleteFixtureRows.
-  let seededInTransaction = false;
 
   beforeEach(async () => {
     const adapter = getAdapter();
@@ -303,28 +256,16 @@ function useTablelessFixtures(
       tables.push(table);
     }
     const results = await insertPreparedFixtureSets(adapter, prepared);
-    seededInTransaction = adapter.openTransactions > 0;
     results.forEach((result, i) => {
       store[tables[i]] = result;
     });
   });
 
-  afterEach(async () => {
-    const adapter = getAdapter();
-    if (shouldDeleteFixtureRows(adapter, seededInTransaction)) {
-      const tables = [...entries].reverse().map(({ table }) => table);
-      // Rails wraps its table_deletes in disable_referential_integrity
-      // unconditionally (database_statements.rb:492).
-      await adapter.disableReferentialIntegrity(async () => {
-        for (const table of tables) {
-          try {
-            await adapter.executeMutation(`DELETE FROM ${adapter.quoteTableName(table)}`);
-          } catch (e) {
-            if (!isTableMissingError(e)) throw e;
-          }
-        }
-      }, tables);
-    }
+  // Rails' `teardown_fixtures` (`test_fixtures.rb`) issues no DELETE: it resets
+  // the fixture cache and the pinned pool and stops. The rows go away at the
+  // next load, because `insert_fixtures_set` prefixes its inserts with
+  // `table_deletes` (`abstract/database_statements.rb:486-495`).
+  afterEach(() => {
     for (const key of keys) delete store[key];
   });
 
@@ -483,11 +424,6 @@ function useFixtures(
 
   // Per-test mutable state: populated in beforeEach, cleared in afterEach.
   const store: Record<string, Record<string, unknown>> = {};
-  // Whether the most recent seed ran inside an open transaction (the fixture
-  // pin), keyed by seeding connection — a set whose model lives in another
-  // database seeds through that model's pool. Read in afterEach — see
-  // shouldDeleteFixtureRows.
-  const seededInTransaction = new Map<DatabaseAdapter, boolean>();
 
   // TODO(fixtures-adoption Spike S1): seed once per worker in a global beforeAll
   // (before the pinned transaction opens) when transactional fixtures are
@@ -506,7 +442,6 @@ function useFixtures(
     // by `model_class.connection_pool` and merges each group's table_rows into
     // a single insert_fixtures_set.
     const groups = new Map<DatabaseAdapter, { prepared: PreparedFixtureSet[]; keys: string[] }>();
-    seededInTransaction.clear();
     for (const [key, { table, model, data }] of Object.entries(fixtures)) {
       // Auto-register the (object-map) model, mirroring the by-name path's
       // `resolveFixtureNames` (fixtures-register-model-on-resolution, #4348):
@@ -533,51 +468,20 @@ function useFixtures(
     }
     for (const [adapter, group] of groups) {
       const results = await insertPreparedFixtureSets(adapter, group.prepared);
-      seededInTransaction.set(adapter, adapter.openTransactions > 0);
       results.forEach((result, i) => {
         store[group.keys[i]] = result;
       });
     }
   });
 
-  afterEach(async () => {
-    if (!fixtures) return;
-    const fixtureConnection = getAdapter();
-    // Delete in reverse insertion order, each set through the connection it was
-    // seeded on. Rails' fixture deletes are the `table_deletes` half of
-    // `insert_fixtures_set` and ride inside its `disable_referential_integrity`
-    // block (database_statements.rb:145-154), so a delete order an FK forbids —
-    // a table whose children the fixture set doesn't own, e.g. the HABTM join
-    // rows a test created itself — never reaches the database.
-    const deletesByAdapter = new Map<DatabaseAdapter, string[]>();
-    for (const [, { table, model }] of Object.entries(fixtures).reverse()) {
-      // Re-lease, rather than reusing the connection this set was seeded on.
-      // Rails never touches the seeding connection again in `teardown_fixtures`
-      // — the deletes are the `table_deletes` half of the *next*
-      // `insert_fixtures_set` (database_statements.rb:486-495), which runs on a
-      // freshly-leased connection. A test may deliberately have poisoned or
-      // evicted the seed-time connection (transactions.test.ts "connection
-      // removed from pool when begin raises…"), and teardown must not resurrect
-      // it.
-      const adapter = await leaseFixtureConnectionFor(model, fixtureConnection);
-      if (!shouldDeleteFixtureRows(adapter, seededInTransaction.get(adapter) ?? false)) continue;
-      const tables = deletesByAdapter.get(adapter);
-      if (tables === undefined) deletesByAdapter.set(adapter, [table]);
-      else tables.push(table);
-    }
-    for (const [adapter, tables] of deletesByAdapter) {
-      // Rails wraps its table_deletes in disable_referential_integrity
-      // unconditionally (database_statements.rb:492).
-      await adapter.disableReferentialIntegrity(async () => {
-        for (const table of tables) {
-          try {
-            await adapter.executeMutation(`DELETE FROM ${adapter.quoteTableName(table)}`);
-          } catch (e) {
-            if (!isTableMissingError(e)) throw e;
-          }
-        }
-      }, tables);
-    }
+  // Rails' `teardown_fixtures` (`test_fixtures.rb`) issues no DELETE at all: it
+  // resets the fixture cache and the shared pool and stops. The rows go away at
+  // the *next* load, whose `insert_fixtures_set` prefixes the inserts with a
+  // `DELETE FROM` per table it is about to fill
+  // (`abstract/database_statements.rb:486-495`), all inside that call's single
+  // `disable_referential_integrity` block on a freshly-leased connection. So
+  // teardown only drops this scope's resolved rows.
+  afterEach(() => {
     for (const key of Object.keys(store)) {
       delete store[key];
     }


### PR DESCRIPTION
Three RFC 0064 / RFC 0051 deviation-convergence stories.

### Fixture teardown has no delete loop
Rails' `teardown_fixtures` (`activerecord/lib/active_record/test_fixtures.rb`) issues no DELETE: it resets the fixture cache and the shared pool and stops. The rows go away at the *next* load, because `insert_fixtures_set` prefixes the inserts with `table_deletes` (`abstract/database_statements.rb:486-495`).

`insertPreparedFixtureSets` already passes the tables it is about to fill as `tablesToDelete`, so the DELETE + INSERT pair already runs as one batch inside one `disable_referential_integrity` block on a freshly-leased connection. This drops the per-test `afterEach` delete loop from both `useFixtures` and `useTablelessFixtures`, and with it the trails-invented `shouldDeleteFixtureRows` guard and its PostgreSQL/MySQL special cases — deleted, not relocated. `isTableMissingError` and the `seededInTransaction` bookkeeping go with them.

### The adapter proxy raises NoMethodError
`ConnectionPool#_getAdapterProxy`'s trap answered `undefined` for a string key no adapter defines. `AbstractAdapter` overrides no `method_missing`, so Ruby dispatches and raises `NoMethodError` — which is what `NullPool`'s trap already does for its own sends (#6261, #6267). The trap now raises.

Kept, each justified at the call site: the `typeof prop === "symbol"` carve-out (a JS `Symbol` cannot spell a Ruby send), the `pool`/`adapterName` data-property arms (`abstract_adapter.rb:153`'s `@pool`), the `constructor` arm (object plumbing a walker reads to name a class — dispatching it would call the adapter class without `new`), and the `AbstractAdapter.prototype` stand-in, which the raise does not subsume: with no checkout yet there is no other object to ask which sends the adapter answers. `Object.prototype` members read through, as on `NullPool`.

### SQLiteDatabaseTasks#drop has no in-memory arm
`FileUtils.rm(":memory:")` raises `Errno::ENOENT`, which `sqlite_database_tasks.rb:22-28`'s rescue turns into `NoDatabaseError` — so Rails' answer for an in-memory database is `NoDatabaseError`, not a silent no-op. The `isInMemoryDatabase(dbPath)` early return is gone and `drop` is the Ruby line for line. `purge` still rescues `NoDatabaseError`, so the in-memory purge path is unchanged. The two trails-only `test_db_drop_is_noop_for_*` tests are replaced by one pinning the Rails behaviour.

`DatabaseTasks.drop` (`database-tasks.ts:270-290`) already rescues `NoDatabaseError` and writes "Database '…' does not exist" to stderr, mirroring `database_tasks.rb`'s own `rescue ActiveRecord::NoDatabaseError`, so a bootstrap-level `dropCurrent`/`dropAll` over a `sqlite3_mem` config is still handled at that layer rather than throwing uncaught.

Local, default sqlite file lane: `transactions`, `statement-invalid`, `fixtures`, `persistence`, `callbacks`, `dirty`, `timestamp`, `base`, `relations`, `multiple-db`, `query-cache`, `associations/**`, `connection-pool`, `tasks/**` — green.

Local, `ARCONN=sqlite3_mem`: `tasks/**`, `connection-pool`, `fixtures`, `transactions`, `persistence`, `timestamp`, `base`, `relations`, `associations/**`, `callbacks`, `dirty` — green (2982 tests over the two runs).

`pnpm api:calls` OK, no new rows; `pnpm api:extra --package activerecord` unchanged (nothing public added); `test:compare` unchanged — the two retired `test_db_drop_is_noop_for_*` names have no Rails counterpart, so they scored as TS-only extras.

Closes-story: fixture-teardown-has-no-delete-rails-deletes-at-next-load
Closes-story: adapter-proxy-answers-undefined-where-ruby-raises-nomethoderror
Closes-story: sqlite-database-tasks-drop-invents-an-in-memory-noop

