### PR TITLE
fix(activerecord,scripts): protected-environment check reads the pool's migration context; exec_rollback_db_transaction sheds its invented guard and discard; test-compare's entry point is compare.ts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1521,7 +1521,7 @@ jobs:
         # --gates prints the adapter/feature gate-mismatch breakdown; --check
         # fails the step if activerecord's gate-mismatch count is non-zero
         # (hard zero, no baseline — RFC 0032 ar-gate-fidelity-burndown).
-        run: pnpm exec tsx scripts/test-compare/extract-ts-tests.ts && pnpm exec tsx scripts/test-compare/test-compare.ts --gates --check
+        run: pnpm exec tsx scripts/test-compare/extract-ts-tests.ts && pnpm exec tsx scripts/test-compare/compare.ts --gates --check
       - name: Assertion-mismatch ratchet
         # Only-shrink gate on the assertion-count / kind / value totals inside
         # name-matched tests (RFC 0025). Reads output/convention-comparison.json

--- a/docs/ruby-ts-conventions.md
+++ b/docs/ruby-ts-conventions.md
@@ -77,7 +77,7 @@ Test names are not an exception. Rails'
 (`activesupport/test/core_ext/string_ext_test.rb:1086`) is
 `it("TSE::Util.html_escape should escape unsafe characters")` in
 `core-ext/string-ext.test.ts`. It still credits: `normalizeErb` in
-`scripts/test-compare/test-compare.ts` applies this table to both sides of the
+`scripts/test-compare/compare.ts` applies this table to both sides of the
 comparison, so the Ruby name and the TSE-spelled trails name normalize to the
 same key. `ERB` survives in trails only where the text quotes the Ruby side —
 a JSDoc `Mirrors:` line naming `ERB::Util`, a Rails path like

--- a/eslint/expected-fixtures.mjs
+++ b/eslint/expected-fixtures.mjs
@@ -68,7 +68,7 @@ function loadExclude() {
  * `railtie→trailtie` aliases in scripts/parity/conventions.ts, and
  * AR has no erb→tse mappings. Naive kebab↔snake is sufficient. If the
  * rule is ever widened to actionpack/actionview/trailties, switch to
- * the shared `rubyToConventionTs` in scripts/test-compare/test-compare.ts.
+ * the shared `rubyToConventionTs` in scripts/test-compare/compare.ts.
  */
 export function trailsToRailsRel(absOrRelPath) {
   const norm = absOrRelPath.replace(/\\/g, "/");

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-rollback-db-transaction.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-rollback-db-transaction.trails.test.ts
@@ -1,0 +1,76 @@
+/**
+ * `PostgreSQLAdapter#execRollbackDbTransaction` — the port of
+ * `PostgreSQL::DatabaseStatements#exec_rollback_db_transaction`
+ * (`postgresql/database_statements.rb:78-81`), which is two lines:
+ * `cancel_any_running_query` then
+ * `internal_execute("ROLLBACK", "TRANSACTION", allow_retry: false, materialize_transactions: true)`.
+ *
+ * Trails-only: these pin what survives of the machinery the port had wrapped
+ * around those two lines, so a later reader can tell load-bearing bookkeeping
+ * from accretion (RFC 0085,
+ * `pg-exec-rollback-db-transaction-body-deviation`). Two of the three
+ * additions were deleted as unreachable; the `finally` is the one that stays,
+ * and the cases below are the failures it prevents.
+ */
+import { expect, it } from "vitest";
+import { describeIfPg, PG_TEST_URL } from "../support/describe-if-pg.js";
+import { PostgreSQLAdapter } from "./postgresql-adapter.js";
+
+function inTransaction(adapter: PostgreSQLAdapter): boolean {
+  return (adapter as unknown as { _inTransaction: boolean })._inTransaction;
+}
+
+function client(adapter: PostgreSQLAdapter): unknown {
+  return (adapter as unknown as { _client: unknown })._client;
+}
+
+describeIfPg("PostgreSQLAdapter exec_rollback_db_transaction", () => {
+  it("releases the transaction client so the next statement is not left mid-transaction", async () => {
+    const adapter = new PostgreSQLAdapter({ connectionString: PG_TEST_URL });
+    try {
+      await adapter.beginDbTransaction();
+      expect(inTransaction(adapter)).toBe(true);
+      expect(client(adapter)).not.toBeNull();
+
+      await adapter.execRollbackDbTransaction();
+
+      // Without the `finally`, `_inTransaction` stays true after the ROLLBACK
+      // and every later reader of it is wrong — the RETURNING savepoint wrap
+      // and the `CREATE INDEX CONCURRENTLY` guard both branch on it. This is
+      // the assertion that fails when the `finally` is dropped, and is why it
+      // is the one of the port's three additions that stayed.
+      expect(inTransaction(adapter)).toBe(false);
+      expect(client(adapter)).toBeNull();
+
+      await adapter.execute("SELECT 1");
+    } finally {
+      await adapter.disconnectBang();
+    }
+  });
+
+  it("releases the transaction client when the socket was severed under it", async () => {
+    const adapter = new PostgreSQLAdapter({ connectionString: PG_TEST_URL });
+    try {
+      await adapter.beginDbTransaction();
+
+      // Sever the socket the transaction is pinned to, so the ROLLBACK that
+      // follows cannot reach the server on the client it began on. The port
+      // used to carry its own `catch` here, discarding the raw connection on a
+      // connection-class error; the query path already recovers without it, so
+      // the ROLLBACK resolves and Rails' shape — which leaves invalidation to
+      // `with_raw_connection` (`abstract_adapter.rb:1016-1018`) — holds. What
+      // this method still owes either way is that `_inTransaction` is not left
+      // stranded true.
+      await (client(adapter) as { end(): Promise<void> }).end();
+
+      await adapter.execRollbackDbTransaction();
+
+      expect(inTransaction(adapter)).toBe(false);
+      expect(client(adapter)).toBeNull();
+
+      await adapter.execute("SELECT 1");
+    } finally {
+      await adapter.disconnectBang();
+    }
+  });
+});

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-rollback-db-transaction.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-rollback-db-transaction.trails.test.ts
@@ -1,16 +1,15 @@
 /**
  * `PostgreSQLAdapter#execRollbackDbTransaction` — the port of
  * `PostgreSQL::DatabaseStatements#exec_rollback_db_transaction`
- * (`postgresql/database_statements.rb:78-81`), which is two lines:
- * `cancel_any_running_query` then
- * `internal_execute("ROLLBACK", "TRANSACTION", allow_retry: false, materialize_transactions: true)`.
+ * (`postgresql/database_statements.rb:78-81`), which is `cancel_any_running_query`
+ * then `internal_execute("ROLLBACK", "TRANSACTION", ...)`.
  *
- * Trails-only: these pin what survives of the machinery the port had wrapped
- * around those two lines, so a later reader can tell load-bearing bookkeeping
- * from accretion (RFC 0085,
- * `pg-exec-rollback-db-transaction-body-deviation`). Two of the three
- * additions were deleted as unreachable; the `finally` is the one that stays,
- * and the cases below are the failures it prevents.
+ * Trails-only: these pin the audit of the three additions the port had wrapped
+ * around those two lines (RFC 0085,
+ * `pg-exec-rollback-db-transaction-body-deviation`). The `!_client` guard and
+ * the connection-error discard were deleted as unreachable; the first case
+ * below fails when the surviving `finally` is dropped, and the second is why
+ * the discard was not needed.
  */
 import { expect, it } from "vitest";
 import { describeIfPg, PG_TEST_URL } from "../support/describe-if-pg.js";
@@ -34,11 +33,6 @@ describeIfPg("PostgreSQLAdapter exec_rollback_db_transaction", () => {
 
       await adapter.execRollbackDbTransaction();
 
-      // Without the `finally`, `_inTransaction` stays true after the ROLLBACK
-      // and every later reader of it is wrong — the RETURNING savepoint wrap
-      // and the `CREATE INDEX CONCURRENTLY` guard both branch on it. This is
-      // the assertion that fails when the `finally` is dropped, and is why it
-      // is the one of the port's three additions that stayed.
       expect(inTransaction(adapter)).toBe(false);
       expect(client(adapter)).toBeNull();
 
@@ -52,15 +46,6 @@ describeIfPg("PostgreSQLAdapter exec_rollback_db_transaction", () => {
     const adapter = new PostgreSQLAdapter({ connectionString: PG_TEST_URL });
     try {
       await adapter.beginDbTransaction();
-
-      // Sever the socket the transaction is pinned to, so the ROLLBACK that
-      // follows cannot reach the server on the client it began on. The port
-      // used to carry its own `catch` here, discarding the raw connection on a
-      // connection-class error; the query path already recovers without it, so
-      // the ROLLBACK resolves and Rails' shape — which leaves invalidation to
-      // `with_raw_connection` (`abstract_adapter.rb:1016-1018`) — holds. What
-      // this method still owes either way is that `_inTransaction` is not left
-      // stranded true.
       await (client(adapter) as { end(): Promise<void> }).end();
 
       await adapter.execRollbackDbTransaction();

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1985,7 +1985,7 @@ export class PostgreSQLAdapter
     if (this._transactionManager.openTransactions > 0) {
       return this._transactionManager.commitTransaction();
     }
-    if (!this._client) throw new Error("No active transaction");
+    if (!this._client) throw new ActiveRecordError("No active transaction");
     try {
       await this.internalExecute("COMMIT", "TRANSACTION");
     } catch (e) {
@@ -2025,7 +2025,7 @@ export class PostgreSQLAdapter
     if (this._transactionManager.openTransactions > 0) {
       return this._transactionManager.rollbackTransaction();
     }
-    if (!this._client) throw new Error("No active transaction");
+    if (!this._client) throw new ActiveRecordError("No active transaction");
     try {
       await this.internalExecute("ROLLBACK", "TRANSACTION");
     } catch (e) {
@@ -2048,26 +2048,32 @@ export class PostgreSQLAdapter
     return this.execRollbackDbTransaction();
   }
 
-  // Mirrors: DatabaseStatements#exec_rollback_db_transaction (database_statements.rb:78)
+  // Mirrors: PostgreSQL::DatabaseStatements#exec_rollback_db_transaction
+  // (postgresql/database_statements.rb:78-81). `internalExecute` already
+  // defaults `allowRetry: false` / `materializeTransactions: true`, so the two
+  // statements below are Ruby's two lines.
+  //
+  // The `finally` is the one deviation left, and it is trails' single
+  // persistent pg.Client, not a Rails behaviour: Ruby's adapter *is* the
+  // connection, so it has no `@client` to release, whereas here
+  // `beginDbTransaction` pins one and `_inTransaction` is read by the RETURNING
+  // savepoint wrap and the `CREATE INDEX CONCURRENTLY` guard. Leaving it set
+  // after a ROLLBACK strands both — pinned by
+  // `postgresql-adapter.exec-rollback-db-transaction.trails.test.ts`. Note that
+  // ROLLBACK does not drop server-side prepared statements, so the
+  // StatementPool deliberately stays attached for the connection's life.
+  //
+  // The `!this._client` guard and the `_isConnectionError` → discard branch
+  // this method used to carry were audited out under RFC 0085: the TransactionManager
+  // never reaches here without an open transaction (the direct `rollback()`
+  // pair keeps its own guard), and the query path recovers from a severed
+  // socket on its own, so the discard only duplicated what Rails leaves to
+  // `with_raw_connection` (`abstract_adapter.rb:1016-1018`).
   async execRollbackDbTransaction(): Promise<void> {
     await this._cancelAnyRunningQuery();
-    if (!this._client) throw new Error("No active transaction");
     try {
       await this.internalExecute("ROLLBACK", "TRANSACTION");
-    } catch (e) {
-      // ROLLBACK on a poisoned socket (e.g. 08P01 after the cancel
-      // race) — tear down and reconnect; closing the socket implicitly
-      // aborts the server-side TX. Mirrors the pool-discard safety net
-      // the pre-collapse design got via PoolClient.release(err).
-      if (PostgreSQLAdapter._isConnectionError(e)) {
-        this._discardRawConnection();
-        return;
-      }
-      throw e;
     } finally {
-      // See commit() — ROLLBACK doesn't drop server-side prepared
-      // statements, so we keep the StatementPool attached for the
-      // duration of the connection's life.
       this._client = null;
       this._inTransaction = false;
     }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2048,27 +2048,18 @@ export class PostgreSQLAdapter
     return this.execRollbackDbTransaction();
   }
 
-  // Mirrors: PostgreSQL::DatabaseStatements#exec_rollback_db_transaction
-  // (postgresql/database_statements.rb:78-81). `internalExecute` already
-  // defaults `allowRetry: false` / `materializeTransactions: true`, so the two
-  // statements below are Ruby's two lines.
-  //
-  // The `finally` is the one deviation left, and it is trails' single
-  // persistent pg.Client, not a Rails behaviour: Ruby's adapter *is* the
-  // connection, so it has no `@client` to release, whereas here
-  // `beginDbTransaction` pins one and `_inTransaction` is read by the RETURNING
-  // savepoint wrap and the `CREATE INDEX CONCURRENTLY` guard. Leaving it set
-  // after a ROLLBACK strands both — pinned by
-  // `postgresql-adapter.exec-rollback-db-transaction.trails.test.ts`. Note that
-  // ROLLBACK does not drop server-side prepared statements, so the
-  // StatementPool deliberately stays attached for the connection's life.
-  //
-  // The `!this._client` guard and the `_isConnectionError` → discard branch
-  // this method used to carry were audited out under RFC 0085: the TransactionManager
-  // never reaches here without an open transaction (the direct `rollback()`
-  // pair keeps its own guard), and the query path recovers from a severed
-  // socket on its own, so the discard only duplicated what Rails leaves to
-  // `with_raw_connection` (`abstract_adapter.rb:1016-1018`).
+  /**
+   * Mirrors: `PostgreSQL::DatabaseStatements#exec_rollback_db_transaction`
+   * (`postgresql/database_statements.rb:78-81`). `internalExecute` already
+   * defaults `allowRetry: false` / `materializeTransactions: true`, so the two
+   * statements below are Ruby's two lines.
+   *
+   * Deviation, language-forced: the `finally` releases trails' single
+   * persistent pg.Client. Ruby's adapter *is* the connection and has no
+   * `@client` to release, whereas here `beginDbTransaction` pins one and
+   * `_inTransaction` gates the RETURNING savepoint wrap and the
+   * `CREATE INDEX CONCURRENTLY` guard.
+   */
   async execRollbackDbTransaction(): Promise<void> {
     await this._cancelAnyRunningQuery();
     try {

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -351,8 +351,7 @@ export class DatabaseTasks {
    * answers that list instead — the same override Rails' own
    * `migrator_class` test helper uses.
    */
-  /** @internal */
-  static async _migrationContextFor(
+  private static async _migrationContextFor(
     adapter: import("../connection-adapters/abstract-adapter.js").AbstractAdapter,
     dbConfig: DatabaseConfig,
   ): Promise<import("../migration.js").MigrationContext> {
@@ -1646,17 +1645,11 @@ export async function checkCurrentProtectedEnvironmentBang(
 ): Promise<void> {
   const { NoDatabaseError } = await import("../errors.js");
   const { EnvironmentMismatchError } = await import("../migration.js");
-  // Deviation: Rails uses `with_temporary_pool { |pool| pool.migration_context }`
-  // and rescues inside the block (`database_tasks.rb:635-636`, `:648-649`).
-  // `ConnectionPool#migrationContext` builds its collaborators over the pool's
-  // adapter proxy, which routes the synchronous `toSql` those queries need
-  // through `withConnection` and hands them a Promise instead of SQL; and
-  // `withTemporaryConnection` leases eagerly, so `NoDatabaseError` can surface
-  // from the lease. Both converge in
-  // `check-current-protected-environment-pool-migration-context-blocked-on-adapter-proxy`.
-  try {
-    await DatabaseTasks.withTemporaryConnection(dbConfig, async (adapter) => {
-      const migrationContext = await DatabaseTasks._migrationContextFor(adapter, dbConfig);
+  await DatabaseTasks.withTemporaryPool(dbConfig, async (pool) => {
+    // Ruby's block-level `rescue` (`database_tasks.rb:648-649`) covers the
+    // block body only; TS needs the explicit try/catch to scope it the same way.
+    try {
+      const migrationContext = pool.migrationContext;
       const current = migrationContext.currentEnvironment;
       const stored = await migrationContext.lastStoredEnvironment();
 
@@ -1667,11 +1660,11 @@ export async function checkCurrentProtectedEnvironmentBang(
       if (stored && stored !== current) {
         throw new EnvironmentMismatchError(current, stored);
       }
-    });
-  } catch (error) {
-    if (error instanceof NoDatabaseError) return;
-    throw error;
-  }
+    } catch (error) {
+      if (error instanceof NoDatabaseError) return;
+      throw error;
+    }
+  });
 }
 
 /** @internal */

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -1646,8 +1646,6 @@ export async function checkCurrentProtectedEnvironmentBang(
   const { NoDatabaseError } = await import("../errors.js");
   const { EnvironmentMismatchError } = await import("../migration.js");
   await DatabaseTasks.withTemporaryPool(dbConfig, async (pool) => {
-    // Ruby's block-level `rescue` (`database_tasks.rb:648-649`) covers the
-    // block body only; TS needs the explicit try/catch to scope it the same way.
     try {
       const migrationContext = pool.migrationContext;
       const current = migrationContext.currentEnvironment;

--- a/scripts/parity/README.md
+++ b/scripts/parity/README.md
@@ -1,0 +1,64 @@
+# Parity tooling — layout and baselines
+
+The parity comparison tools live in four sibling directories, all driven
+through the `parity:*` scripts in the root `package.json` (the older `api:*` /
+`test:compare` names are delegating aliases).
+
+| Directory                   | Subject compared                      | Entry point  |
+| --------------------------- | ------------------------------------- | ------------ |
+| `scripts/api-compare/`      | Ruby → TS public API surface          | `compare.ts` |
+| `scripts/test-compare/`     | Rails tests → trails tests            | `compare.ts` |
+| `scripts/fixtures-compare/` | Rails fixtures/models → trails ones   | `compare.ts` |
+| `scripts/schema-compare/`   | `schema.rb` → the canonical TS schema | `compare.ts` |
+
+`scripts/parity/` itself holds what all four share — `conventions.ts` (the
+Ruby→TS name and path translation table, and the source `docs/ruby-ts-conventions.md`
+is generated from), `unported-files.ts`, and the manifest writer.
+
+## Naming rules
+
+- **The main entry point of a compare dir is `compare.ts`**, with its test as
+  `compare.test.ts`. (`test-compare/test-compare.ts` was renamed to
+  `compare.ts` under RFC 0092; historic CI log parsing in
+  `scripts/sync-stats/sync.ts` still recognizes the old name.)
+- **A lint entry point is `lint-<subject>.ts`** — a file you can run directly,
+  which exits non-zero when its baseline has moved the wrong way. Everything a
+  lint entry point imports is a plain library module named for its contents,
+  not `lint-`-prefixed. `assertion-ratchet.ts` is such a library: it holds the
+  mark contract that `lint-assertion-mismatches.ts` enforces, and is not itself
+  an entry point.
+
+## Baselines, marks and excludes
+
+Every file below records **known, unfixed divergence**. They are all
+**only-shrink**: a row is a debt entry saying "we know this is wrong and have
+not fixed it yet", never a licence to leave it, to copy the shape into new
+code, or to add a sibling row for code you are writing right now. Converging a
+divergence makes its row stale and turns the gate red — delete that one row by
+hand.
+
+| Path                                        | Kind              | Enforced by                    |
+| ------------------------------------------- | ----------------- | ------------------------------ |
+| `api-compare/call-mismatches-exclude/`      | exclude (sharded) | `lint-call-mismatches.ts`      |
+| `api-compare/call-mismatches-wide-exclude/` | exclude (sharded) | `lint-call-mismatches.ts`      |
+| `api-compare/call-mismatches-unreviewed/`   | mark (sharded)    | `lint-call-mismatches.ts`      |
+| `api-compare/arity-exclude.json`            | exclude           | `lint-arity-excludes.ts`       |
+| `api-compare/inheritance-exclude.json`      | exclude           | `lint-inheritance-excludes.ts` |
+| `api-compare/body-pins.json`                | pin               | `lint-body-pins.ts`            |
+| `test-compare/assertion-mismatch-mark.json` | mark              | `lint-assertion-mismatches.ts` |
+| `schema-compare/invented-baseline.json`     | baseline          | `schema-compare/compare.ts`    |
+
+**Do not move these files.** They are referenced by path from CI workflow steps
+and from the lint tooling, and the sharded ones (`call-mismatches-*`) are split
+per source file so that sibling branches touching different files do not
+conflict.
+
+**Do not hand-edit the JSON, and do not `--write`/reseed to add a row.** Write
+through `serializeBaseline` (`api-compare/baseline-json.ts`): a naive
+`JSON.stringify`/`json.dumps` escapes non-ASCII punctuation such as em-dashes
+and reds the unit tests. A reseed rewrites the whole tree and buries the one
+row you meant to add in an unreviewable diff.
+
+For the api-compare call gate specifically, the debt metric is the **row
+count**, not the unreviewed-reason count — see
+[CONTRIBUTING.md](../../CONTRIBUTING.md#row-count-is-the-debt-metric-the-unreviewed-count-is-not).

--- a/scripts/parity/conventions.ts
+++ b/scripts/parity/conventions.ts
@@ -20,7 +20,7 @@ import * as path from "path";
  * escape unsafe characters"` (activesupport/test/core_ext/string_ext_test.rb:1086)
  * is `it("TSE::Util.html_escape should escape unsafe characters")` in
  * string-ext.test.ts. It still credits: `normalizeErb` in
- * scripts/test-compare/test-compare.ts applies this table to both sides of the
+ * scripts/test-compare/compare.ts applies this table to both sides of the
  * comparison, so the Ruby name and the TSE-spelled trails name normalize to
  * the same key. `ERB` survives in trails only where the text quotes the Ruby
  * side — a JSDoc `Mirrors:` line naming `ERB::Util`, a Rails path like
@@ -1150,7 +1150,7 @@ Test names are not an exception. Rails'
 (\`activesupport/test/core_ext/string_ext_test.rb:1086\`) is
 \`it("TSE::Util.html_escape should escape unsafe characters")\` in
 \`core-ext/string-ext.test.ts\`. It still credits: \`normalizeErb\` in
-\`scripts/test-compare/test-compare.ts\` applies this table to both sides of the
+\`scripts/test-compare/compare.ts\` applies this table to both sides of the
 comparison, so the Ruby name and the TSE-spelled trails name normalize to the
 same key. \`ERB\` survives in trails only where the text quotes the Ruby side —
 a JSDoc \`Mirrors:\` line naming \`ERB::Util\`, a Rails path like

--- a/scripts/sync-stats/sync.ts
+++ b/scripts/sync-stats/sync.ts
@@ -1719,6 +1719,8 @@ function extractStepLogs(rawLog: string): Map<string, string> {
     if (command.includes("api-compare/compare.ts")) {
       stepName = command.includes("--privates") ? "api_compare_privates" : "api_compare";
     } else if (
+      command.includes("test-compare/compare.ts") ||
+      // Pre-RFC-0092 entry-point names, kept so historic logs still parse.
       command.includes("test-compare/test-compare.ts") ||
       command.includes("test-compare/convention-compare.ts")
     ) {

--- a/scripts/test-compare/assertion-kinds.ts
+++ b/scripts/test-compare/assertion-kinds.ts
@@ -1,6 +1,6 @@
 // Normalizes Rails assertion method names and trails (vitest) matcher names to a
 // shared set of *canonical kinds* so test:compare can compare not just how MANY
-// assertions a matched pair makes (see `assertionCount` in test-compare.ts) but
+// assertions a matched pair makes (see `assertionCount` in compare.ts) but
 // WHAT each one checks. A count match can hide a semantic divergence: Rails
 // `assert_equal x, foo` (equality) vs trails `expect(foo).toBeTruthy()`
 // (truthiness) both count 1, but assert different things.

--- a/scripts/test-compare/assertion-values.ts
+++ b/scripts/test-compare/assertion-values.ts
@@ -1,4 +1,4 @@
-// Phase 3 of test:compare's assertion comparison (after count in test-compare.ts
+// Phase 3 of test:compare's assertion comparison (after count in compare.ts
 // and normalized *kind* in assertion-kinds.ts): compare the literal EXPECTED
 // VALUE each mapped assertion checks. A kind histogram treats `assert_equal 5,
 // foo` / `expect(foo).toEqual(5)` and `assert_equal 3, foo` /

--- a/scripts/test-compare/compare.test.ts
+++ b/scripts/test-compare/compare.test.ts
@@ -6,7 +6,7 @@ import {
   parseMinExtra,
   rubyToConventionTs,
   type ConventionFileResult,
-} from "./test-compare.js";
+} from "./compare.js";
 
 /** Build a ConventionFileResult with only the fields the helpers read. */
 function file(over: Partial<ConventionFileResult>): ConventionFileResult {

--- a/scripts/test-compare/compare.ts
+++ b/scripts/test-compare/compare.ts
@@ -20,7 +20,7 @@
  * shown for every package. Use --package to scope to one.
  *
  * Usage:
- *   npx tsx scripts/test-compare/test-compare.ts [--missing] [--json]
+ *   npx tsx scripts/test-compare/compare.ts [--missing] [--json]
  *     [--incomplete] [--gates] [--check] [--sort-extra] [--min-extra=N]
  *     [--package activesupport]
  *

--- a/scripts/test-compare/gate-check.test.ts
+++ b/scripts/test-compare/gate-check.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { GATE_ENFORCED_PACKAGES, gateMismatchOffenders } from "./test-compare.js";
+import { GATE_ENFORCED_PACKAGES, gateMismatchOffenders } from "./compare.js";
 
 describe("gateMismatchOffenders (hard-zero --check gate)", () => {
   it("enforces activerecord only", () => {

--- a/scripts/test-compare/gates.ts
+++ b/scripts/test-compare/gates.ts
@@ -257,7 +257,7 @@ export function gateFromGuardExpr(exprText: string, runsWhenTrue: boolean): Test
 }
 
 // ---------------------------------------------------------------------------
-// Gate-mismatch classification (consumed by test-compare.ts)
+// Gate-mismatch classification (consumed by compare.ts)
 // ---------------------------------------------------------------------------
 
 /**

--- a/scripts/test-compare/orchestrate.ts
+++ b/scripts/test-compare/orchestrate.ts
@@ -9,7 +9,7 @@
  *
  * Historically each node ran as its own process — `pnpm -s vendor:fetch`,
  * a second `pnpm -s vendor:fetch --print-test-paths` for the TEST_PATHS_JSON
- * handoff, `pnpm tsx extract-ts-tests.ts`, `pnpm tsx test-compare.ts` — so the
+ * handoff, `pnpm tsx extract-ts-tests.ts`, `pnpm tsx compare.ts` — so the
  * pipeline paid the ~1.7s tsx/Node cold start four times over. This entrypoint
  * pays it ONCE: every TypeScript phase runs in-process, and only the Ruby
  * extractor stays a subprocess (it's a `.rb`). The test-paths manifest that
@@ -33,7 +33,7 @@ import { promisify } from "node:util";
 import { runFetch } from "../../vendor/fetch.js";
 import { testPathsManifest } from "../../vendor/sources.js";
 import { main as extractTsTests } from "./extract-ts-tests.js";
-import { main as runCompare } from "./test-compare.js";
+import { main as runCompare } from "./compare.js";
 
 const execFileAsync = promisify(execFile);
 


### PR DESCRIPTION
Three bundled stories. The fourth, `move-adapter-specific-snapshot-off-ar-internal-metadata`, was **released unbuilt** — its own findings block says it "should be its own PR, not bundled" and that the surviving arm is larger than the stated ~160 LOC, over a seam (`loadSchema` / `canonical-schema-stamp.ts` / `test-setup-dy.ts`) that is explicitly reshaped one story at a time.

## 1. `checkCurrentProtectedEnvironmentBang` uses the pool's migration context

`check_current_protected_environment!` (`tasks/database_tasks.rb:635-649`) reads the migration context straight off the pool and rescues `NoDatabaseError` *inside* the block. The port could not, because `ConnectionPool#migrationContext` built its collaborators over the pool's adapter proxy, which turned the synchronous `toSql` those queries need into a Promise.

That blocker is gone on `origin/main`: `schemaMigration` / `internalMetadata` now take the pool itself (`connection-pool.ts:557-570`), not `_getAdapterProxy()`. So this is now the call-shape change it was always meant to be:

- `withTemporaryConnection` + `DatabaseTasks._migrationContextFor` → `withTemporaryPool` + `pool.migrationContext`, mirroring `database_tasks.rb:635-637`. The lease is now lazy, which is what let the rescue move.
- The `NoDatabaseError` rescue moved inside the block (`database_tasks.rb:648-649`). Ruby's block-level `rescue` covers the block body only; TS needs the explicit `try`/`catch` to scope it the same way.
- `DatabaseTasks._migrationContextFor` went back to `private` — its four remaining callers are all in-class.

## 2. Audit of the invented guard/discard/finally in `execRollbackDbTransaction`

Rails' `exec_rollback_db_transaction` (`postgresql/database_statements.rb:78-81`) is two lines. The port wrapped them in three additions; each was tested, and two are deleted.

**Guard `if (!this._client) throw new Error(...)` — deleted.** Unreachable: the TransactionManager never reaches this method without an open transaction, and the direct `beginDbTransaction()`/`rollback()` pair keeps its own guard.

**`catch` + `_isConnectionError` → `_discardRawConnection()` — deleted.** Rails leaves connection invalidation to `with_raw_connection`'s translate/invalidate loop (`abstract_adapter.rb:1016-1018`). Removing it left 160 PG test files / 2687 tests green, and a new test severs the transaction's socket and rolls back: the query path recovers on its own, so the branch only duplicated what Rails already delegates.

**`finally` clearing `_client` / `_inTransaction` — kept, and justified at the call site.** This one is load-bearing and is *not* a Rails behaviour to converge away: Ruby's adapter **is** the connection and has no `@client` to release, whereas here `beginDbTransaction` pins one and `_inTransaction` is read by the RETURNING savepoint wrap and the `CREATE INDEX CONCURRENTLY` guard. `postgresql-adapter.exec-rollback-db-transaction.trails.test.ts` pins it — the first assertion fails when the `finally` is dropped (verified).

Also: the bespoke `new Error("No active transaction")` is now `ActiveRecordError` at the two direct-pair sites that still need it. And `execRestartDbTransaction` already matches Rails exactly on `main` — the story's claim that the shape is duplicated there is stale.

`internalExecute` already defaults `allowRetry: false` / `materializeTransactions: true`, so Rails' explicit kwargs need no spelling out.

## 3. Compare entry-point and lint naming alignment

- `test-compare/test-compare.ts` → `test-compare/compare.ts` (with its test), so all four compare dirs use `compare.ts`. Updated the CI workflow step, `orchestrate.ts`, `gate-check.test.ts`, and the doc/comment references; `conventions.ts` regenerated `docs/ruby-ts-conventions.md`.
- `scripts/sync-stats/sync.ts` matches the new path **and** keeps the old ones, so historic CI logs still parse.
- `assertion-ratchet.ts` stays as-is: it is a library consumed by `lint-assertion-mismatches.ts`, not an entry point. All lint entry points already follow `lint-<subject>.ts`.
- New `scripts/parity/README.md` documents the four dirs, the naming rules, and every baseline / mark / exclude file with its enforcing lint — including that they are all only-shrink, must not be moved, and must be written through `serializeBaseline`. No baseline file moved.

## Verification

- `pnpm typecheck`, `pnpm lint` clean.
- `pnpm api:calls` ratchet OK; `api:extra` unchanged (this PR adds no public surface and makes one static private).
- PG lane (isolated container): 160 files / 2687 tests green across `adapters/postgresql/`, `connection-adapters/`, and the connection-lifecycle suites; plus the transaction suites and the protected-environment suites.
- sqlite lane: `database-tasks-protected-environments-env.trails.test.ts`, `tasks/database-tasks.test.ts`, `trailties/src/commands/db.test.ts` — 196 passed, no test renames.

Closes-story: check-current-protected-environment-pool-migration-context-blocked-on-adapter-proxy
Closes-story: pg-exec-rollback-db-transaction-body-deviation
Closes-story: compare-naming-alignment
