### PR TITLE
fix(activesupport,scripts): Deprecation's constructor is positional; countryZones canonicalizes link names; test-compare shares the Ruby cache; gate the sync association writers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -407,6 +407,14 @@ jobs:
           scripts/ci/check-control-bytes.sh --self-test
           scripts/ci/check-control-bytes.sh
 
+      # RFC 0087 Verification: the synchronous association-writer machinery the
+      # campaign deleted stays deleted.
+      - name: Sync association writers
+        if: ${{ !cancelled() }}
+        run: |
+          scripts/ci/check-sync-association-writers.sh --self-test
+          scripts/ci/check-sync-association-writers.sh
+
       # RFC 0011 Phase 4 guardrail. AR work tracking moved to the tasks repo;
       # `docs/activerecord/` is frozen so the two-source-of-truth split can't
       # self-heal. Fail any PR that adds or modifies a file under that path,

--- a/packages/actionview/src/deprecator.ts
+++ b/packages/actionview/src/deprecator.ts
@@ -7,7 +7,7 @@ import { Deprecation } from "@blazetrails/activesupport";
 
 export { Deprecation as Deprecator };
 
-const _deprecator = new Deprecation({ gemName: "actionview" });
+const _deprecator = new Deprecation();
 
 export function deprecator(): Deprecation {
   return _deprecator;

--- a/packages/activemodel/src/deprecator.ts
+++ b/packages/activemodel/src/deprecator.ts
@@ -10,7 +10,7 @@ import { Deprecation } from "@blazetrails/activesupport";
 
 export { Deprecation as Deprecator };
 
-const _deprecator = new Deprecation({ gemName: "activemodel" });
+const _deprecator = new Deprecation();
 
 export function deprecator(): Deprecation {
   return _deprecator;

--- a/packages/activerecord/src/deprecator.ts
+++ b/packages/activerecord/src/deprecator.ts
@@ -14,7 +14,7 @@ import type { Migration } from "./migration.js";
 
 export { Deprecation as Deprecator };
 
-const _deprecator = new Deprecation({ gemName: "activerecord" });
+const _deprecator = new Deprecation();
 
 export function deprecator(): Deprecation {
   return _deprecator;

--- a/packages/activesupport/src/deprecation.test.ts
+++ b/packages/activesupport/src/deprecation.test.ts
@@ -127,17 +127,18 @@ describe("DeprecationTest", () => {
   });
 
   it("gem option stored on instance", () => {
-    const d = new Deprecation({ gemName: "MyGem" });
+    const d = new Deprecation("8.1", "MyGem");
     expect(d.gemName).toBe("MyGem");
   });
 
   it("horizon option stored on instance", () => {
-    const d = new Deprecation({ horizon: "3.0" });
-    expect(d.horizon).toBe("3.0");
+    const d = new Deprecation("3.0");
+    expect(d.deprecationHorizon).toBe("3.0");
   });
 
   it("silenced option in constructor", () => {
-    const d = new Deprecation({ silenced: true });
+    const d = new Deprecation();
+    d.silenced = true;
     expect(d.silenced).toBe(true);
   });
 
@@ -261,19 +262,20 @@ describe("DeprecationTest", () => {
   });
 
   it("custom gem_name", () => {
-    const d = new Deprecation({ gemName: "MyLib" });
+    const d = new Deprecation("2.0", "MyLib");
     expect(d.gemName).toBe("MyLib");
   });
 
   it("default gem_name is Rails", () => {
     const d = new Deprecation();
-    // No default gem, but we can set it
-    expect(d.gemName).toBeUndefined();
+    expect(d.gemName).toBe("Rails");
   });
 
   it("default deprecation_horizon is greater than the current Rails version", () => {
     const d = new Deprecation();
-    expect(d.horizon).toBeUndefined();
+    // Rails asserts against ActiveSupport::VERSION::STRING (8.0.2), which
+    // trails has no constant for.
+    expect(d.deprecationHorizon > "8.0.2").toBe(true);
   });
 
   it("disallowed_warnings with the default warning message", () => {

--- a/packages/activesupport/src/deprecation.ts
+++ b/packages/activesupport/src/deprecation.ts
@@ -27,8 +27,7 @@ export class Deprecation {
   private _silenced = false;
   // Rails: `attr_accessor :gem_name` (deprecation/reporting.rb:11).
   gemName: string;
-  // Rails: `attr_accessor :deprecation_horizon` — "The version number in which
-  // the deprecated behavior will be removed, by default." (deprecation.rb:65).
+  // Rails: `attr_accessor :deprecation_horizon` (deprecation.rb:65).
   deprecationHorizon: string;
   // Rails: `self.debug = false` (deprecation.rb:76).
   debug = false;
@@ -60,7 +59,6 @@ export class Deprecation {
   constructor(deprecationHorizon = "8.1", gemName = "Rails") {
     this.gemName = gemName;
     this.deprecationHorizon = deprecationHorizon;
-    // By default, warnings are not silenced and debugging is off.
     this.silenced = false;
     this.debug = false;
   }

--- a/packages/activesupport/src/deprecation.ts
+++ b/packages/activesupport/src/deprecation.ts
@@ -26,8 +26,10 @@ export class Deprecation {
     "stderr";
   private _silenced = false;
   // Rails: `attr_accessor :gem_name` (deprecation/reporting.rb:11).
-  gemName?: string;
-  horizon?: string;
+  gemName: string;
+  // Rails: `attr_accessor :deprecation_horizon` — "The version number in which
+  // the deprecated behavior will be removed, by default." (deprecation.rb:65).
+  deprecationHorizon: string;
   // Rails: `self.debug = false` (deprecation.rb:76).
   debug = false;
   disallowedWarnings: (string | RegExp | "all")[] = [];
@@ -47,10 +49,20 @@ export class Deprecation {
     this._silenced = silenced;
   }
 
-  constructor(options?: { horizon?: string; gemName?: string; silenced?: boolean }) {
-    this.horizon = options?.horizon;
-    this.gemName = options?.gemName;
-    if (options?.silenced != null) this.silenced = options.silenced;
+  /**
+   * It accepts two parameters on initialization. The first is a version of
+   * library and the second is a library name.
+   *
+   *   new Deprecation("2.0", "MyLibrary")
+   *
+   * Mirrors: ActiveSupport::Deprecation#initialize (deprecation.rb:71-79).
+   */
+  constructor(deprecationHorizon = "8.1", gemName = "Rails") {
+    this.gemName = gemName;
+    this.deprecationHorizon = deprecationHorizon;
+    // By default, warnings are not silenced and debugging is off.
+    this.silenced = false;
+    this.debug = false;
   }
 
   private _matchesDisallowed(msg: string): boolean {

--- a/packages/activesupport/src/deprecation/deprecators.test.ts
+++ b/packages/activesupport/src/deprecation/deprecators.test.ts
@@ -12,7 +12,7 @@ describe("DeprecationTest", () => {
   beforeEach(() => {
     deprecators = new Deprecators();
     for (const name of deprecatorNames) {
-      deprecators.set(name, new Deprecation({ horizon: "2.0", gemName: name }));
+      deprecators.set(name, new Deprecation("2.0", name));
     }
   });
 

--- a/packages/activesupport/src/hwia-module-string.test.ts
+++ b/packages/activesupport/src/hwia-module-string.test.ts
@@ -86,17 +86,18 @@ describe("DeprecationTest", () => {
   });
 
   it("gem option stored on instance", () => {
-    const d = new Deprecation({ gemName: "MyGem" });
+    const d = new Deprecation("8.1", "MyGem");
     expect(d.gemName).toBe("MyGem");
   });
 
   it("horizon option stored on instance", () => {
-    const d = new Deprecation({ horizon: "3.0" });
-    expect(d.horizon).toBe("3.0");
+    const d = new Deprecation("3.0");
+    expect(d.deprecationHorizon).toBe("3.0");
   });
 
   it("silenced option in constructor", () => {
-    const d = new Deprecation({ silenced: true });
+    const d = new Deprecation();
+    d.silenced = true;
     expect(d.silenced).toBe(true);
   });
 

--- a/packages/activesupport/src/time-zone.trails.test.ts
+++ b/packages/activesupport/src/time-zone.trails.test.ts
@@ -17,4 +17,24 @@ describe("TimeZoneTest", () => {
     expect(TimeZone.find("Moscow")).not.toBe(moscowBefore);
     expect(TimeZone.find("Moscow")!.name).toBe("Moscow");
   });
+
+  /**
+   * Rails' four `test_country_zones*` cases (time_zone_test.rb:850-867) all name
+   * ZONE-backed countries, where ECMA-402's country table and
+   * `TZInfo::Country#zone_identifiers` already agree. These pin the LINK-backed
+   * ones, where `Intl` reports the link name (`Europe/Vatican`) and TZInfo
+   * reports its canonical target (`Europe/Rome`) — the target being a MAPPING
+   * value is what puts `load_country_zones` (time_zone.rb:276-281) on the
+   * Rails-named branch. `ua` is the other arm: MAPPING still spells its key
+   * `Europe/Kiev` (time_zone.rb:101), the link name, so the canonical
+   * `Europe/Kyiv` misses `MAPPING.value?` and Rails takes `create(tz_id)`.
+   */
+  it("country zones for a link-backed country answer the canonical zone's Rails name", () => {
+    expect(TimeZone.countryZones("va")).toEqual([TimeZone.find("Rome")]);
+  });
+
+  it("country zones for a link-backed country whose canonical zone has no mapping answer the canonical name", () => {
+    expect(TimeZone.countryZones("ua").map((z) => z.name)).toContain("Europe/Kyiv");
+    expect(TimeZone.countryZones("ua").map((z) => z.name)).not.toContain("Europe/Kiev");
+  });
 });

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -171,6 +171,146 @@ const MAPPING: Record<string, string> = {
 };
 
 /**
+ * The tzdata backward-compatibility links, restricted to the identifiers
+ * `Intl.Locale#getTimeZones` reports for some country, each mapped to the
+ * canonical zone it links to.
+ *
+ * `TZInfo::Country#zone_identifiers` — what `load_country_zones`
+ * (time_zone.rb:275) actually reads — answers only canonical zones, so
+ * `TZInfo::Country.get("VA").zone_identifiers` is `["Europe/Rome"]`. ECMA-402's
+ * country table answers the link name instead (`Europe/Vatican`), and
+ * `Europe/Rome` is a MAPPING value while `Europe/Vatican` is not, so without
+ * this table `countryZones("va")` takes `create(tz_id)` and answers an
+ * IANA-named zone where Rails answers the Rails-named `Rome`. The runtime
+ * exposes no link table of its own —
+ * `Intl.DateTimeFormat#resolvedOptions().timeZone` echoes the link name back
+ * unchanged on node 24 — so it is carried here rather than derived.
+ */
+const CANONICAL_ZONE_IDENTIFIERS: Record<string, string> = {
+  "Africa/Accra": "Africa/Abidjan",
+  "Africa/Addis_Ababa": "Africa/Nairobi",
+  "Africa/Asmera": "Africa/Nairobi",
+  "Africa/Bamako": "Africa/Abidjan",
+  "Africa/Bangui": "Africa/Lagos",
+  "Africa/Banjul": "Africa/Abidjan",
+  "Africa/Blantyre": "Africa/Maputo",
+  "Africa/Brazzaville": "Africa/Lagos",
+  "Africa/Bujumbura": "Africa/Maputo",
+  "Africa/Conakry": "Africa/Abidjan",
+  "Africa/Dakar": "Africa/Abidjan",
+  "Africa/Dar_es_Salaam": "Africa/Nairobi",
+  "Africa/Djibouti": "Africa/Nairobi",
+  "Africa/Douala": "Africa/Lagos",
+  "Africa/Freetown": "Africa/Abidjan",
+  "Africa/Gaborone": "Africa/Maputo",
+  "Africa/Harare": "Africa/Maputo",
+  "Africa/Kampala": "Africa/Nairobi",
+  "Africa/Kigali": "Africa/Maputo",
+  "Africa/Kinshasa": "Africa/Lagos",
+  "Africa/Libreville": "Africa/Lagos",
+  "Africa/Lome": "Africa/Abidjan",
+  "Africa/Luanda": "Africa/Lagos",
+  "Africa/Lubumbashi": "Africa/Maputo",
+  "Africa/Lusaka": "Africa/Maputo",
+  "Africa/Malabo": "Africa/Lagos",
+  "Africa/Maseru": "Africa/Johannesburg",
+  "Africa/Mbabane": "Africa/Johannesburg",
+  "Africa/Mogadishu": "Africa/Nairobi",
+  "Africa/Niamey": "Africa/Lagos",
+  "Africa/Nouakchott": "Africa/Abidjan",
+  "Africa/Ouagadougou": "Africa/Abidjan",
+  "Africa/Porto-Novo": "Africa/Lagos",
+  "America/Anguilla": "America/Puerto_Rico",
+  "America/Antigua": "America/Puerto_Rico",
+  "America/Aruba": "America/Puerto_Rico",
+  "America/Blanc-Sablon": "America/Puerto_Rico",
+  "America/Buenos_Aires": "America/Argentina/Buenos_Aires",
+  "America/Catamarca": "America/Argentina/Catamarca",
+  "America/Cayman": "America/Panama",
+  "America/Coral_Harbour": "America/Panama",
+  "America/Cordoba": "America/Argentina/Cordoba",
+  "America/Creston": "America/Phoenix",
+  "America/Curacao": "America/Puerto_Rico",
+  "America/Dominica": "America/Puerto_Rico",
+  "America/Godthab": "America/Nuuk",
+  "America/Grenada": "America/Puerto_Rico",
+  "America/Guadeloupe": "America/Puerto_Rico",
+  "America/Indianapolis": "America/Indiana/Indianapolis",
+  "America/Jujuy": "America/Argentina/Jujuy",
+  "America/Kralendijk": "America/Puerto_Rico",
+  "America/Louisville": "America/Kentucky/Louisville",
+  "America/Lower_Princes": "America/Puerto_Rico",
+  "America/Marigot": "America/Puerto_Rico",
+  "America/Mendoza": "America/Argentina/Mendoza",
+  "America/Montserrat": "America/Puerto_Rico",
+  "America/Nassau": "America/Toronto",
+  "America/Port_of_Spain": "America/Puerto_Rico",
+  "America/St_Barthelemy": "America/Puerto_Rico",
+  "America/St_Kitts": "America/Puerto_Rico",
+  "America/St_Lucia": "America/Puerto_Rico",
+  "America/St_Thomas": "America/Puerto_Rico",
+  "America/St_Vincent": "America/Puerto_Rico",
+  "America/Tortola": "America/Puerto_Rico",
+  "Antarctica/DumontDUrville": "Pacific/Port_Moresby",
+  "Antarctica/McMurdo": "Pacific/Auckland",
+  "Antarctica/Syowa": "Asia/Riyadh",
+  "Arctic/Longyearbyen": "Europe/Berlin",
+  "Asia/Aden": "Asia/Riyadh",
+  "Asia/Bahrain": "Asia/Qatar",
+  "Asia/Brunei": "Asia/Kuching",
+  "Asia/Calcutta": "Asia/Kolkata",
+  "Asia/Katmandu": "Asia/Kathmandu",
+  "Asia/Kuala_Lumpur": "Asia/Singapore",
+  "Asia/Kuwait": "Asia/Riyadh",
+  "Asia/Muscat": "Asia/Dubai",
+  "Asia/Phnom_Penh": "Asia/Bangkok",
+  "Asia/Rangoon": "Asia/Yangon",
+  "Asia/Saigon": "Asia/Ho_Chi_Minh",
+  "Asia/Vientiane": "Asia/Bangkok",
+  "Atlantic/Faeroe": "Atlantic/Faroe",
+  "Atlantic/Reykjavik": "Africa/Abidjan",
+  "Atlantic/St_Helena": "Africa/Abidjan",
+  "Europe/Amsterdam": "Europe/Brussels",
+  "Europe/Bratislava": "Europe/Prague",
+  "Europe/Busingen": "Europe/Zurich",
+  "Europe/Copenhagen": "Europe/Berlin",
+  "Europe/Guernsey": "Europe/London",
+  "Europe/Isle_of_Man": "Europe/London",
+  "Europe/Jersey": "Europe/London",
+  "Europe/Kiev": "Europe/Kyiv",
+  "Europe/Ljubljana": "Europe/Belgrade",
+  "Europe/Luxembourg": "Europe/Brussels",
+  "Europe/Mariehamn": "Europe/Helsinki",
+  "Europe/Monaco": "Europe/Paris",
+  "Europe/Oslo": "Europe/Berlin",
+  "Europe/Podgorica": "Europe/Belgrade",
+  "Europe/San_Marino": "Europe/Rome",
+  "Europe/Sarajevo": "Europe/Belgrade",
+  "Europe/Skopje": "Europe/Belgrade",
+  "Europe/Stockholm": "Europe/Berlin",
+  "Europe/Vaduz": "Europe/Zurich",
+  "Europe/Vatican": "Europe/Rome",
+  "Europe/Zagreb": "Europe/Belgrade",
+  "Indian/Antananarivo": "Africa/Nairobi",
+  "Indian/Christmas": "Asia/Bangkok",
+  "Indian/Cocos": "Asia/Yangon",
+  "Indian/Comoro": "Africa/Nairobi",
+  "Indian/Kerguelen": "Indian/Maldives",
+  "Indian/Mahe": "Asia/Dubai",
+  "Indian/Mayotte": "Africa/Nairobi",
+  "Indian/Reunion": "Asia/Dubai",
+  "Pacific/Enderbury": "Pacific/Kanton",
+  "Pacific/Funafuti": "Pacific/Tarawa",
+  "Pacific/Majuro": "Pacific/Tarawa",
+  "Pacific/Midway": "Pacific/Pago_Pago",
+  "Pacific/Ponape": "Pacific/Guadalcanal",
+  "Pacific/Saipan": "Pacific/Guam",
+  "Pacific/Truk": "Pacific/Port_Moresby",
+  "Pacific/Wake": "Pacific/Tarawa",
+  "Pacific/Wallis": "Pacific/Tarawa",
+};
+
+/**
  * `Intl.Locale#getTimeZones` is ECMA-402's IANA country→zone table — the data
  * `TZInfo::Country#zone_identifiers` reads — and is shipped by every runtime
  * trails targets, but TypeScript's `lib.es5`/`lib.esnext.intl` do not declare
@@ -967,7 +1107,9 @@ export class TimeZone {
    * `TZInfo::Country.get(code).zone_identifiers` is
    * `Intl.Locale#getTimeZones` here — the same IANA country table, read off the
    * runtime's own tzdata rather than off a literal list, so a tzdata update
-   * moves the answer as it moves Rails'. `TZInfo::Country.get` RAISES
+   * moves the answer as it moves Rails'. It reports link names where TZInfo
+   * reports the canonical zone, so each identifier goes through
+   * {@link CANONICAL_ZONE_IDENTIFIERS} first. `TZInfo::Country.get` RAISES
    * `TZInfo::InvalidCountryCode` on a code it does not know and
    * `load_country_zones` does not rescue it, so an unknown code raises here
    * too; the class is `Error` rather than TZInfo's, for the same reason as
@@ -989,6 +1131,7 @@ export class TimeZone {
       throw new Error(`Invalid country code: ${code}`);
     }
     return country
+      .map((tzId) => CANONICAL_ZONE_IDENTIFIERS[tzId] ?? tzId)
       .flatMap((tzId) => {
         if (Object.values(MAPPING).includes(tzId)) {
           const memo: TimeZone[] = [];

--- a/scripts/ci/check-sync-association-writers.sh
+++ b/scripts/ci/check-sync-association-writers.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# RFC 0087 (awaitable association writers only), Verification. The campaign
+# deleted the synchronous association-writer machinery; this holds it at zero so
+# a later PR can't re-add a property setter "just for convenience".
+#
+# Deliberately NOT gated: `syncWrite`, `syncIdsWrite`,
+# `HasOnePersistedAssignmentError` and `CollectionIdsAssignmentError`. Those are
+# the campaign's residue, kept alive by a permanently synchronous
+# `assignAttributes` (RFC 0087 README §2) — gating them would red main forever.
+SYMBOL_RE='_pendingDisplacedRemovals|_displacedRemovalFailure|prepareDetachDisplacedForSyncBuild|findThenDetachDisplaced'
+
+usage() {
+  cat <<'MSG'
+Usage:
+  check-sync-association-writers.sh              scan every tracked file
+  check-sync-association-writers.sh PATH...      scan the given paths
+  check-sync-association-writers.sh --self-test  run the scanner's own cases
+
+Fails when synchronous association-writer machinery RFC 0087 deleted is
+reintroduced. An association writer is awaitable: build the record, then await
+the write. If you need one of these names back, converge the caller instead —
+see rfcs/0087-awaitable-association-writers-only in the tasks repo.
+MSG
+}
+
+scanPaths() {
+  local out status=0
+  out=$(mktemp)
+  LC_ALL=C xargs -0 -r grep -anHE "$SYMBOL_RE" >"$out" || true
+  if [ -s "$out" ]; then
+    cat "$out"
+    status=1
+  fi
+  rm -f "$out"
+  return "$status"
+}
+
+selfTestDir=""
+selfTestStatus=0
+
+selfTestCase() {
+  local label=$1 expectation=$2 body=$3 actual=flagged file="$selfTestDir/fixture.ts"
+  printf '%s\n' "$body" >"$file"
+  if printf '%s\0' "$file" | scanPaths >/dev/null; then actual=clean; fi
+  if [ "$actual" != "$expectation" ]; then
+    echo "self-test FAILED: $label was reported $actual, expected $expectation" >&2
+    selfTestStatus=1
+  fi
+}
+
+selfTest() {
+  selfTestDir=$(mktemp -d)
+  trap 'rm -rf "$selfTestDir"' EXIT
+
+  selfTestCase 'a _pendingDisplacedRemovals field' flagged 'private _pendingDisplacedRemovals = [];'
+  selfTestCase 'a _displacedRemovalFailure read' flagged 'if (this._displacedRemovalFailure) throw;'
+  selfTestCase 'a prepareDetachDisplacedForSyncBuild call' flagged 'this.prepareDetachDisplacedForSyncBuild(r);'
+  selfTestCase 'a findThenDetachDisplaced call' flagged 'await this.findThenDetachDisplaced(o);'
+  selfTestCase 'the retained syncWrite residue' clean 'reflection.syncWrite(owner, record);'
+  selfTestCase 'an ordinary awaitable writer' clean 'await owner.setAccount(account);'
+
+  [ "$selfTestStatus" -eq 0 ] && echo "check-sync-association-writers: self-test passed."
+  return "$selfTestStatus"
+}
+
+case "${1:-}" in
+  --self-test)
+    selfTest
+    exit
+    ;;
+  -h | --help)
+    usage
+    exit
+    ;;
+  --)
+    shift
+    ;;
+  -*)
+    echo "check-sync-association-writers: unknown option $1" >&2
+    usage >&2
+    exit 2
+    ;;
+esac
+
+candidates=$(mktemp)
+trap 'rm -f "$candidates"' EXIT
+
+if [ "$#" -gt 0 ]; then
+  printf '%s\0' "$@" >"$candidates"
+else
+  # The gate's own text names every symbol, so it excludes itself.
+  git ls-files -z ':!scripts/ci/check-sync-association-writers.sh' >"$candidates"
+  if [ ! -s "$candidates" ]; then
+    echo "check-sync-association-writers: git ls-files listed nothing; refusing to pass." >&2
+    exit 1
+  fi
+fi
+
+if scanPaths <"$candidates"; then
+  echo "check-sync-association-writers: no synchronous association writers found."
+else
+  echo >&2
+  usage >&2
+  exit 1
+fi

--- a/scripts/test-compare/orchestrate.ts
+++ b/scripts/test-compare/orchestrate.ts
@@ -78,10 +78,12 @@ async function runRubyExtract(): Promise<void> {
   if (stderr) process.stderr.write(stderr);
 }
 
-// The test-compare analogue of api-compare's `RAILS_INPUTS`: the lockfile
-// (re-fetch), sources.ts (registry edits, whence `testPathsManifest()`), and
-// the extractor script (output-shape changes). The shared cache keys on their
-// CONTENT, so a key computed in one worktree matches another's.
+/**
+ * The test-compare analogue of api-compare's `RAILS_INPUTS`: the lockfile
+ * (re-fetch), sources.ts (registry edits, whence `testPathsManifest()`), and
+ * the extractor script (output-shape changes). The shared cache keys on their
+ * CONTENT, so a key computed in one worktree matches another's.
+ */
 const RAILS_INPUTS = [
   join(ROOT, "vendor/sources.lock.json"),
   join(ROOT, "vendor/sources.ts"),

--- a/scripts/test-compare/orchestrate.ts
+++ b/scripts/test-compare/orchestrate.ts
@@ -21,12 +21,18 @@
  * test-compare's main(); only `--cached` is consumed here.
  *
  * `TEST_COMPARE_FORCE=1` forces a full run end-to-end, mirroring
- * `API_COMPARE_FORCE`: it overrides `--cached` and drops fetch's offline
- * fast-path.
+ * `API_COMPARE_FORCE`: it overrides `--cached`, drops fetch's offline
+ * fast-path, and bypasses the shared Rails-manifest cache.
+ *
+ * The Ruby extract is the dominant cost of a full run (~25s of ~31s), and every
+ * worktree extracts the same vendored Rails, so it goes through the same
+ * content-keyed cross-worktree cache api-compare uses
+ * (`scripts/api-compare/shared-cache.ts`): the first worktree to extract a
+ * given `vendor/` + extractor pays for all of them.
  */
 import { execFile } from "node:child_process";
-import { access } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
+import { access, readFile, stat, writeFile } from "node:fs/promises";
+import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 
@@ -34,6 +40,13 @@ import { runFetch } from "../../vendor/fetch.js";
 import { testPathsManifest } from "../../vendor/sources.js";
 import { main as extractTsTests } from "./extract-ts-tests.js";
 import { main as runCompare } from "./compare.js";
+import {
+  sharedCacheDir,
+  hashParts,
+  fileHash,
+  readShared,
+  writeShared,
+} from "../api-compare/shared-cache.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -63,6 +76,76 @@ async function runRubyExtract(): Promise<void> {
   });
   if (stdout) process.stdout.write(stdout);
   if (stderr) process.stderr.write(stderr);
+}
+
+// The test-compare analogue of api-compare's `RAILS_INPUTS`: the lockfile
+// (re-fetch), sources.ts (registry edits, whence `testPathsManifest()`), and
+// the extractor script (output-shape changes). The shared cache keys on their
+// CONTENT, so a key computed in one worktree matches another's.
+const RAILS_INPUTS = [
+  join(ROOT, "vendor/sources.lock.json"),
+  join(ROOT, "vendor/sources.ts"),
+  join(DIR, "extract-ruby-tests.rb"),
+];
+
+/** Content key for the Rails test manifest, or null if any input is missing. */
+async function railsCacheKey(): Promise<string | null> {
+  const inputs = await Promise.all(RAILS_INPUTS.map(fileHash));
+  if (inputs.some((h) => h === null)) return null;
+  return hashParts(inputs as string[]);
+}
+
+/**
+ * True when `output/rails-tests.json` is already newer than every input — this
+ * worktree is warm, so re-running Ruby would reproduce it byte for byte. Cheap
+ * stats, checked before the shared cache so the common warm path never pays a
+ * multi-MB read+rewrite. Unlike api-compare's extractor the Ruby side has no
+ * mtime gate of its own, so this is the only thing standing between a warm run
+ * and the ~25s subprocess.
+ */
+async function railsOutputFresh(railsOut: string): Promise<boolean> {
+  try {
+    const outMtime = (await stat(railsOut)).mtimeMs;
+    const inMtimes = await Promise.all(RAILS_INPUTS.map((p) => stat(p).then((s) => s.mtimeMs)));
+    return inMtimes.every((m) => outMtime >= m);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Run the Ruby extractor, but first consult the cross-worktree shared cache.
+ * A hit writes `output/rails-tests.json` directly and skips the subprocess; a
+ * miss runs Ruby and publishes the result for sibling worktrees.
+ * `TEST_COMPARE_FORCE=1` bypasses both layers, as `API_COMPARE_FORCE` does.
+ */
+async function runRubyExtractShared(): Promise<void> {
+  const railsOut = join(OUTPUT_DIR, "rails-tests.json");
+  if (!force && (await railsOutputFresh(railsOut))) {
+    process.stdout.write("Rails test manifest is current; skipping Ruby extract\n");
+    return;
+  }
+
+  const sharedDir = force ? null : await sharedCacheDir(ROOT);
+  const key = sharedDir ? await railsCacheKey() : null;
+
+  if (sharedDir && key) {
+    const cached = await readShared(sharedDir, "rails-tests", key);
+    if (cached !== null) {
+      await writeFile(railsOut, cached);
+      process.stdout.write("Rails test manifest served from shared cross-worktree cache\n");
+      return;
+    }
+  }
+
+  await runRubyExtract();
+
+  if (sharedDir && key) {
+    const produced = await readFile(railsOut, "utf-8").catch(() => null);
+    if (produced !== null) {
+      await writeShared(sharedDir, "rails-tests", key, produced, basename(ROOT));
+    }
+  }
 }
 
 /**
@@ -95,7 +178,7 @@ async function main(): Promise<void> {
 
     // Both extracts need only fetch's vendored sources, so they run in
     // parallel: ruby as a subprocess, ts in-process.
-    await Promise.all([runRubyExtract(), extractTsTests()]);
+    await Promise.all([runRubyExtractShared(), extractTsTests()]);
   }
 
   runCompare(forwardArgs);


### PR DESCRIPTION
Four of a five-story bundle. The fifth,
`migration-context-collaborator-readers-cast-away-the-null-object`, was
**released untouched**: its premise (the `as` cast on `MigrationContext`'s
collaborator readers, and `Migration.copy` seating the null objects) is
introduced by **open PR #6272**, not by `origin/main`. Building it here would
duplicate and conflict with that branch.

## Deprecation#initialize is positional

`deprecation.rb:71` takes `(deprecation_horizon = "8.1", gem_name = "Rails")` —
two positionals, both defaulted. trails had an invented
`{ horizon, gemName, silenced }` options object, which is why `api:compare`
scored the constructor's arity against a 2-positional Ruby method.

- constructor is `(deprecationHorizon = "8.1", gemName = "Rails")`, and its body
  mirrors `deprecation.rb:72-76` (`gemName`, `deprecationHorizon`,
  `silenced = false`, `debug = false`).
- `horizon` → `deprecationHorizon` (`attr_accessor :deprecation_horizon`,
  `deprecation.rb:65`). It leaves `api:extra`'s novel list for `deprecation.ts`
  (2 novel now: `deprecateMethod`, `DeprecationError`).
- the invented `silenced` option is gone; the two tests that used it assign
  `d.silenced = true` after construction, as Rails does.
- every `deprecator.ts` now constructs with **no arguments** — the per-gem
  `gemName` was itself invented: `activerecord/lib/active_record/deprecator.rb`,
  and its activemodel/actionview siblings, are all bare
  `ActiveSupport::Deprecation.new`.

`deprecation.rb`'s arity mismatch is gone from `output/arity-mismatches.json`.

## countryZones canonicalizes tzdata link names

`load_country_zones` (`time_zone.rb:275-284`) reads
`TZInfo::Country#zone_identifiers`, which answers only **canonical** zones;
ECMA-402's country table answers the **link** name instead:

```
TZInfo::Country.get("VA").zone_identifiers  # => ["Europe/Rome"]
new Intl.Locale("und-VA").getTimeZones()    # => ["Europe/Vatican"]
```

`Europe/Rome` is a `MAPPING` value and `Europe/Vatican` is not, so trails took
the `create(tz_id)` branch and answered an IANA-named zone where Rails answers
the Rails-named `Rome`.

`Intl.DateTimeFormat#resolvedOptions().timeZone` does **not** canonicalize —
checked on node 24, it echoes `Europe/Vatican` back unchanged — so the link
table is carried as data: `CANONICAL_ZONE_IDENTIFIERS`, 121 pairs covering
every identifier `getTimeZones` reports for some country whose canonical target
differs. Module-private, no runtime dependency. With it applied,
**244 of 249** country codes now reproduce `zone_identifiers` exactly; the
remaining 5 (AQ, AU, RU, TF, VN) differ in *membership* between CLDR and tzdata,
which no link table can reconcile and which this PR does not change.

Rails' four `test_country_zones*` cases all name ZONE-backed countries (`us`,
`ru`, `au`, `gb`, `sv`) and still pass; `time-zone.trails.test.ts` pins the
LINK-backed ones — including `ua`, where `MAPPING` still spells the key
`Europe/Kiev` (`time_zone.rb:101`) so the canonical `Europe/Kyiv` *misses*
`MAPPING.value?` and Rails takes `create(tz_id)`, exactly as trails now does.

## test-compare serves rails-tests.json from the shared cache

`scripts/test-compare/orchestrate.ts` always spawned
`ruby extract-ruby-tests.rb`, the dominant cost of a full run. It now uses the
same content-keyed cross-worktree cache api-compare uses
(`scripts/api-compare/shared-cache.ts` — reused, not reimplemented), keyed on
`vendor/sources.lock.json`, `vendor/sources.ts` and `extract-ruby-tests.rb`.
A miss runs Ruby and publishes for siblings; a same-worktree warm output skips
both layers on stats alone; `TEST_COMPARE_FORCE=1` bypasses everything.

Measured, `output/rails-tests.json` deleted before each:

| run | wall clock |
| --- | --- |
| cold (miss, runs Ruby, publishes) | 33.8s |
| cold worktree, shared-cache hit | **10.0s** |
| `TEST_COMPARE_FORCE=1` | 28.5s |

`rails-tests.json` byte-identical between the miss and the hit; comparison
output unchanged (15361/22664, 781/1074 files) across all three.

## RFC 0087 zero-gate

`scripts/ci/check-sync-association-writers.sh`, in the shape of
`check-control-bytes.sh` (self-test included), holds
`_pendingDisplacedRemovals`, `_displacedRemovalFailure`,
`prepareDetachDisplacedForSyncBuild` and `findThenDetachDisplaced` at zero.
Registered in `ci.yml` in the ungated lint job, so it runs on every PR.
`syncWrite`, `syncIdsWrite`, `HasOnePersistedAssignmentError` and
`CollectionIdsAssignmentError` are deliberately **not** gated — they are the
campaign's residue under a permanently synchronous `assignAttributes`
(RFC 0087 README §2), and gating them would red main forever.

## Checks

- `pnpm typecheck` clean; `api:calls` ratchet OK (no new rows).
- `pnpm api:extra --package activesupport`: `horizon` gone;
  `CANONICAL_ZONE_IDENTIFIERS` is module-private and unscored.
- `pnpm api:compare` / `pnpm test:compare` deltas non-negative.
- 409 insertions / 28 deletions.

Closes-story: test-compare-shared-ruby-cache
Closes-story: grep-gate-sync-association-writers-to-zero
Closes-story: country-zones-intl-reports-link-names-tzinfo-reports-canonical
Closes-story: deprecation-constructor-is-positional-with-rails-defaults
