### PR TITLE
fix(activerecord,scripts): DDL wrappers restore by deleting the own property; retire the MySQL implicit-commit repair; test-compare prunes the shared cache

### DIFF
--- a/packages/activerecord/src/test-fixtures/with-transactional-fixtures.test.ts
+++ b/packages/activerecord/src/test-fixtures/with-transactional-fixtures.test.ts
@@ -11,7 +11,6 @@ import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adap
 import { NullTransaction } from "../connection-adapters/abstract/transaction.js";
 import { withTransactionalFixtures } from "./with-transactional-fixtures.js";
 import { fixtures } from "../test-fixtures.js";
-import { Computer } from "../test-helpers/models/computer.js";
 
 // Resolve a pool-leased adapter from the primary (schema-loaded) pool rather
 // than the divergent sidecar `_pool`. Rails has no sidecar test pool.
@@ -358,69 +357,57 @@ describe("concurrency isolation: two concurrent transaction chains stay independ
   });
 });
 
-// MySQL/MariaDB have no transactional DDL: a DDL statement implicitly commits
-// the open fixture transaction, so `teardown_fixtures`' unpin rolls back an
-// empty transaction and the rows this block seeded stay durable. A later block
-// that declares `fixtures([])` deletes nothing (a load only deletes the tables
-// it is about to fill, `abstract/database_statements.rb:486-495`) and inherits
-// them. Rails runs the same shape (`batches_test.rb:570` calls `add_index` in a
-// transactional `BatchesTest`) but never asserts an unseeded table is empty, so
-// the escape is invisible there. These two blocks run in order and are red on
-// the MySQL and MariaDB lanes without the teardown repair; on SQLite and
-// PostgreSQL the rollback already covers the rows and they pass either way.
-describe("fixture rows do not survive a MySQL DDL implicit commit", () => {
-  fixtures(["computers"]);
-
-  it("seeds rows and then runs DDL that implicitly commits the pin", async () => {
-    expect(Number(await Computer.count())).toBeGreaterThan(0);
-    const conn = Base.connection;
-    await conn.addIndex("computers", "system", { name: "idx_fixture_pin_escape" });
-    await conn.removeIndex("computers", { name: "idx_fixture_pin_escape" });
-  });
-});
-
-describe("fixture rows do not survive a MySQL DDL implicit commit (next block)", () => {
+// The DDL recording window wraps adapter methods per test
+// (`recordDdlTouchedTables`) and must leave no trace: a method it found on the
+// prototype is deleted at restore, not written back. Writing it back would make
+// it an OWN property of the pooled adapter for the rest of the run, silently
+// shadowing the prototype — a later test that spies by patching the prototype
+// would never see its spy fire and would pass vacuously. Rails wraps nothing
+// here (`test_fixtures.rb:113`, `:146` touch no adapter method), so there is
+// nothing to restore.
+//
+// The two blocks run in order: the first arms the window and runs DDL through
+// it, the second inspects the adapter from a `beforeAll` — the only point that
+// is after the first block's teardown and before the next window is armed.
+describe("the DDL recording window arms around a test's DDL", () => {
   fixtures([]);
 
-  it("starts with an empty table it did not seed", async () => {
-    expect(Number(await Computer.count())).toBe(0);
+  it("runs DDL through the wrapped method", async () => {
+    const conn = Base.connection;
+    await conn.addIndex("computers", "system", { name: "idx_own_property_restore" });
+    await conn.removeIndex("computers", { name: "idx_own_property_restore" });
   });
 });
 
-// The negative case. `teardown_fixtures` (`test_fixtures.rb:206-211`) issues no
-// DELETE, and the repair above is a recovery from an implicit commit, not a
-// per-test cleanup — so a pinned test that runs no DDL must leave teardown
-// exactly as Rails has it. Spying is the only way to see this: with the pin
-// intact the rollback removes the rows either way, so an unconditional DELETE
-// would be behaviorally invisible and silently reinstate what #6273 removed.
-describe("a pinned test that runs no DDL issues no teardown DELETE", () => {
-  const repairDeletes: string[] = [];
-  let target: Record<string, unknown>;
-  let original: unknown;
+describe("the DDL recording window leaves no own property behind", () => {
+  let ownAddIndex = true;
+  const spied: string[] = [];
 
-  // The instance, not the prototype: the implicit-commit guard wraps and then
-  // restores `executeMutation` as an OWN property, so an earlier block's guard
-  // has already shadowed the prototype by the time this one runs.
-  beforeAll(() => {
-    target = Base.connection as unknown as Record<string, unknown>;
-    original = target.executeMutation;
-    target.executeMutation = function (this: unknown, ...args: unknown[]) {
-      if (args[2] === "Fixture Delete") repairDeletes.push(String(args[0]));
+  beforeAll(async () => {
+    const conn = Base.connection as unknown as Record<string, unknown>;
+    ownAddIndex = Object.prototype.hasOwnProperty.call(conn, "addIndex");
+
+    const proto = Object.getPrototypeOf(Base.connection) as Record<string, unknown>;
+    const original = proto.addIndex;
+    proto.addIndex = function (this: unknown, ...args: unknown[]) {
+      spied.push(String(args[0]));
       return (original as (...a: unknown[]) => unknown).apply(this, args);
     };
+    try {
+      await Base.connection.addIndex("computers", "system", { name: "idx_proto_spy" });
+      await Base.connection.removeIndex("computers", { name: "idx_proto_spy" });
+    } finally {
+      proto.addIndex = original;
+    }
   });
 
-  afterAll(() => {
-    target.executeMutation = original;
+  fixtures([]);
+
+  it("restored addIndex by deleting it, not by assigning it back", () => {
+    expect(ownAddIndex).toBe(false);
   });
 
-  fixtures(["computers"]);
-
-  it("loads fixtures and runs no DDL", async () => {
-    expect(Number(await Computer.count())).toBeGreaterThan(0);
-  });
-
-  it("saw no repair DELETE from the previous test's teardown", () => {
-    expect(repairDeletes).toEqual([]);
+  it("lets a prototype-level spy installed afterwards fire", () => {
+    expect(spied).toEqual(["computers"]);
   });
 });

--- a/packages/activerecord/src/test-fixtures/with-transactional-fixtures.test.ts
+++ b/packages/activerecord/src/test-fixtures/with-transactional-fixtures.test.ts
@@ -357,18 +357,6 @@ describe("concurrency isolation: two concurrent transaction chains stay independ
   });
 });
 
-// The DDL recording window wraps adapter methods per test
-// (`recordDdlTouchedTables`) and must leave no trace: a method it found on the
-// prototype is deleted at restore, not written back. Writing it back would make
-// it an OWN property of the pooled adapter for the rest of the run, silently
-// shadowing the prototype — a later test that spies by patching the prototype
-// would never see its spy fire and would pass vacuously. Rails wraps nothing
-// here (`test_fixtures.rb:113`, `:146` touch no adapter method), so there is
-// nothing to restore.
-//
-// The two blocks run in order: the first arms the window and runs DDL through
-// it, the second inspects the adapter from a `beforeAll` — the only point that
-// is after the first block's teardown and before the next window is armed.
 describe("the DDL recording window arms around a test's DDL", () => {
   fixtures([]);
 
@@ -380,6 +368,8 @@ describe("the DDL recording window arms around a test's DDL", () => {
 });
 
 describe("the DDL recording window leaves no own property behind", () => {
+  // The `beforeAll` is the only point after the previous block's teardown and
+  // before this block's window is armed.
   let ownAddIndex = true;
   const spied: string[] = [];
 

--- a/packages/activerecord/src/test-fixtures/with-transactional-fixtures.ts
+++ b/packages/activerecord/src/test-fixtures/with-transactional-fixtures.ts
@@ -101,6 +101,12 @@ const DDL_TABLE_ARGS: Record<string, (args: unknown[]) => unknown[]> = {
  * (`abstract/schema_statements.rb:306,542`). Wrapping here keeps the ported
  * bodies faithful while preserving the per-table teardown below.
  *
+ * Restore *deletes* a method it found on the prototype rather than writing the
+ * original back: an assignment would leave an own property on the pooled
+ * adapter that shadows the prototype for the rest of the run, so a later
+ * prototype-level spy would never fire and its assertions would pass
+ * vacuously. Only a genuine own value is written back.
+ *
  * @internal
  */
 function recordDdlTouchedTables(adapter: TransactionalFixturesAdapter): () => void {
@@ -120,10 +126,6 @@ function recordDdlTouchedTables(adapter: TransactionalFixturesAdapter): () => vo
       return (original as (...a: unknown[]) => unknown).apply(this, args);
     };
   }
-  // A method found on the prototype is *deleted*, not written back: assigning
-  // the original would leave an own property on the pooled adapter that shadows
-  // the prototype for the rest of the run, so a later prototype-level spy would
-  // never fire and its assertions would pass vacuously.
   return () => {
     for (const [method, original, wasOwn] of originals) {
       if (wasOwn) target[method] = original;

--- a/packages/activerecord/src/test-fixtures/with-transactional-fixtures.ts
+++ b/packages/activerecord/src/test-fixtures/with-transactional-fixtures.ts
@@ -108,11 +108,11 @@ function recordDdlTouchedTables(adapter: TransactionalFixturesAdapter): () => vo
   if (!sc) return () => {};
   const pool = adapter.pool == null || adapter.pool instanceof NullPool ? null : adapter.pool;
   const target = adapter as unknown as Record<string, unknown>;
-  const originals: Array<[string, unknown]> = [];
+  const originals: Array<[string, unknown, boolean]> = [];
   for (const [method, tableArgs] of Object.entries(DDL_TABLE_ARGS)) {
     const original = target[method];
     if (typeof original !== "function") continue;
-    originals.push([method, original]);
+    originals.push([method, original, Object.prototype.hasOwnProperty.call(target, method)]);
     target[method] = function (this: unknown, ...args: unknown[]) {
       for (const name of tableArgs(args)) {
         if (typeof name === "string") sc.clearDataSourceCacheBang(pool, name);
@@ -120,8 +120,15 @@ function recordDdlTouchedTables(adapter: TransactionalFixturesAdapter): () => vo
       return (original as (...a: unknown[]) => unknown).apply(this, args);
     };
   }
+  // A method found on the prototype is *deleted*, not written back: assigning
+  // the original would leave an own property on the pooled adapter that shadows
+  // the prototype for the rest of the run, so a later prototype-level spy would
+  // never fire and its assertions would pass vacuously.
   return () => {
-    for (const [method, original] of originals) target[method] = original;
+    for (const [method, original, wasOwn] of originals) {
+      if (wasOwn) target[method] = original;
+      else delete target[method];
+    }
   };
 }
 
@@ -160,137 +167,6 @@ async function reReflectTouchedTables(adapter: TransactionalFixturesAdapter): Pr
       // best-effort re-reflect
     }
   }
-}
-
-/**
- * Statements that implicitly commit the open transaction on MySQL/MariaDB
- * (MySQL 8 reference, "Statements That Cause an Implicit Commit"). `TEMPORARY`
- * table DDL is the documented exception and is excluded.
- *
- * @internal
- */
-const MYSQL_IMPLICIT_COMMIT_STATEMENT =
-  /^\s*(?:CREATE\s+(?!TEMPORARY\b)|ALTER\s|DROP\s+(?!TEMPORARY\b)|RENAME\s+TABLE\b|TRUNCATE\b)/i;
-
-/** The SQL funnels a test can reach the server through. @internal */
-const SQL_ENTRY_POINTS = ["execute", "executeMutation", "internalExecQuery"];
-
-function isMysqlAdapter(adapter: TransactionalFixturesAdapter): boolean {
-  return /mysql|mariadb|trilogy/i.test(adapter.adapterName ?? "");
-}
-
-/**
- * Tables the running test's fixture load seeded, and whether a DDL statement
- * has implicitly committed the pin around them.
- *
- * Rails needs neither: on its MySQL lane the same escape happens (see
- * `guardMysqlImplicitCommit`), but nothing in its suite asserts that a table it
- * did not seed is empty, so the leak is invisible there. trails does assert
- * that, so the escape has to be repaired rather than tolerated.
- *
- * @internal
- */
-let pinBrokenByDdl = false;
-let seededFixtureTables: string[] = [];
-
-/**
- * The table a `DELETE FROM` names, unquoted. A fixture load prefixes its
- * inserts with one `DELETE FROM` per table it is about to fill
- * (`abstract/database_statements.rb:486-495`), so watching those under the pin
- * identifies the seeded set without the load having to announce it.
- *
- * @internal
- */
-const DELETE_FROM_TABLE = /^\s*DELETE\s+FROM\s+[`"[]?([^\s`"\].]+)/i;
-
-function forgetSeededFixtureTables(): void {
-  seededFixtureTables = [];
-  pinBrokenByDdl = false;
-}
-
-/**
- * Notice when a transactionally-pinned test issues DDL on MySQL/MariaDB.
- *
- * MySQL has no transactional DDL: the statement implicitly commits the open
- * fixture transaction, so `teardown_fixtures`' unpin (`test_fixtures.rb:206-211`)
- * rolls back an empty transaction and the rows this test seeded are already
- * durable. They then leak into every later `describe`, because a load only
- * deletes the tables it is about to fill
- * (`abstract/database_statements.rb:486-495`) — a `describe` declaring
- * `fixtures([])` deletes nothing and inherits whatever escaped.
- *
- * Rails runs this exact shape (`batches_test.rb:570` calls `add_index` inside a
- * transactional `BatchesTest`), so taking such files off the transactional path
- * would be a divergence, not a convergence. What Rails lacks is a test that
- * asserts an unseeded table is empty, which is why the escape is harmless there
- * and observable here. The pin is therefore repaired at teardown rather than
- * forbidden: see {@link repairEscapedFixtureRows}.
- *
- * Returns the restore function.
- *
- * @internal
- */
-function guardMysqlImplicitCommit(adapter: TransactionalFixturesAdapter): () => void {
-  if (!isMysqlAdapter(adapter)) return () => {};
-  const target = adapter as unknown as Record<string, unknown>;
-  const originals: Array<[string, unknown]> = [];
-  for (const method of SQL_ENTRY_POINTS) {
-    const original = target[method];
-    if (typeof original !== "function") continue;
-    originals.push([method, original]);
-    target[method] = function (this: unknown, ...args: unknown[]) {
-      const sql = args[0];
-      if (typeof sql === "string") {
-        if (MYSQL_IMPLICIT_COMMIT_STATEMENT.test(sql)) pinBrokenByDdl = true;
-        const deleted = DELETE_FROM_TABLE.exec(sql);
-        if (deleted && !seededFixtureTables.includes(deleted[1])) {
-          seededFixtureTables.push(deleted[1]);
-        }
-      }
-      return (original as (...a: unknown[]) => unknown).apply(this, args);
-    };
-  }
-  return () => {
-    for (const [method, original] of originals) target[method] = original;
-  };
-}
-
-/**
- * Undo what the rollback could not, and only that.
- *
- * This is deliberately NOT the per-test teardown DELETE that PR #6273 removed:
- * that one ran on every teardown on every adapter and put trails' teardown out
- * of step with `teardown_fixtures`, which issues no DELETE. This runs only when
- * MySQL has already destroyed the pin, and deletes only the tables this test's
- * own load filled — exactly the rows the rollback would have discarded on
- * SQLite and PostgreSQL. On the normal path (no DDL, or any non-MySQL adapter)
- * `pinBrokenByDdl` stays false and teardown remains cache/pool-reset only.
- *
- * Runs after the unpin, so the connection is live and the DELETEs commit.
- *
- * @internal
- */
-async function repairEscapedFixtureRows(adapter: TransactionalFixturesAdapter): Promise<void> {
-  const tables = seededFixtureTables;
-  const broken = pinBrokenByDdl;
-  forgetSeededFixtureTables();
-  // The gate that keeps this off the normal path: with the pin intact the
-  // rollback already discarded these rows, and issuing a DELETE anyway would be
-  // the unconditional teardown DELETE `teardown_fixtures` does not have.
-  if (!broken || tables.length === 0) return;
-  // One referential-integrity toggle for the whole set, the way
-  // `insert_fixtures_set` wraps its own `DELETE FROM`s
-  // (`abstract/database_statements.rb:483-497`) — otherwise a parent table's
-  // delete trips a child's foreign key.
-  await adapter.disableReferentialIntegrity(async () => {
-    for (const table of tables) {
-      await adapter.executeMutation(
-        `DELETE FROM ${adapter.quoteTableName(table)}`,
-        [],
-        "Fixture Delete",
-      );
-    }
-  }, tables);
 }
 
 /**
@@ -471,7 +347,6 @@ export function withTransactionalFixtures(
   // test_fixtures.rb:108-110 run_in_transaction? returns false for these).
   let _txnOpenedForTest = false;
   let _restoreDdlRecording: (() => void) | null = null;
-  let _restoreImplicitCommitGuard: (() => void) | null = null;
 
   beforeEach(async (ctx: TaskContext) => {
     const adapter = getAdapter();
@@ -490,8 +365,6 @@ export function withTransactionalFixtures(
       return;
     }
     _txnOpenedForTest = true;
-    // Arm the MySQL implicit-commit guard for the whole pinned window.
-    _restoreImplicitCommitGuard = guardMysqlImplicitCommit(adapter);
     // Open a recording window so teardown re-reflects only DDL-touched tables.
     if (invalidateSchemaCache) {
       adapter.internalSchemaCache?.recordTouchedTables();
@@ -573,26 +446,15 @@ export function withTransactionalFixtures(
     // pin. The failure is re-raised at the end of teardown so the rest of it
     // still runs — Rails raises straight out of the subscriber body, but its
     // pin is synchronous, so there is nothing left half-done to clean up.
-    // Disarm before teardown's own SQL: the unpin's ROLLBACK is not DDL, but
-    // the guard must not outlive the pin it protects.
-    _restoreImplicitCommitGuard?.();
-    _restoreImplicitCommitGuard = null;
     const pins = pendingPins;
     pendingPins = [];
     const pinResults = await Promise.allSettled(pins);
     if (!_txnOpenedForTest) {
-      // An unwrapped test (`uses_transaction`) commits its own rows; there is
-      // no pin to escape, so drop what it seeded rather than carry it into the
-      // next test's repair set.
-      forgetSeededFixtureTables();
       const failed = pinResults.find((r) => r.status === "rejected");
       if (failed) throw failed.reason;
       return;
     }
     const adapter = getAdapter();
-    // Only the scope that actually releases the pin may repair after it; a
-    // nested scope's teardown runs first, while the pin is still held.
-    let unpinned = false;
     if (fixtureConnectionPools !== null && pooledAdapterPool(adapter) !== null) {
       // Mirrors Rails test_fixtures.rb:206-211 teardown:
       //   @fixture_connection_pools.map(&:unpin_connection!)
@@ -606,20 +468,16 @@ export function withTransactionalFixtures(
           await pool.unpinConnectionBang();
         }
         fixtureConnectionPools = null;
-        unpinned = true;
       }
     } else {
       const t = tm(adapter);
       while (t.openTransactions > 0) await t.rollbackTransaction();
-      unpinned = true;
     }
     if (invalidateSchemaCache) {
       _restoreDdlRecording?.();
       _restoreDdlRecording = null;
       await reReflectTouchedTables(adapter);
     }
-    // After the unpin, so the DELETEs run on a live connection.
-    if (unpinned) await repairEscapedFixtureRows(adapter);
     const failed = pinResults.find((r) => r.status === "rejected");
     if (failed) throw failed.reason;
   });

--- a/scripts/test-compare/orchestrate.ts
+++ b/scripts/test-compare/orchestrate.ts
@@ -46,6 +46,7 @@ import {
   fileHash,
   readShared,
   writeShared,
+  pruneSharedCache,
 } from "../api-compare/shared-cache.js";
 
 const execFileAsync = promisify(execFile);
@@ -183,7 +184,39 @@ async function main(): Promise<void> {
     await Promise.all([runRubyExtractShared(), extractTsTests()]);
   }
 
+  await prune();
+
   runCompare(forwardArgs);
+}
+
+/**
+ * Prune the shared cache, api-compare's Phase D. The `rails-tests` entries this
+ * orchestrator publishes are content-keyed and therefore append-only — every
+ * `vendor/sources.lock.json` bump mints a new key and orphans the old multi-MB
+ * manifest — so a checkout that runs `test:compare` but never `api:compare`
+ * would otherwise grow the shared directory without bound.
+ *
+ * Unlike api-compare's, this runs *before* the comparison rather than after:
+ * `compare.ts`'s `main()` exits the process on a gate failure, so housekeeping
+ * placed after it would be skipped on exactly the runs that keep happening.
+ * It stays best-effort either way — every failure is swallowed, so it can
+ * change neither the comparison result nor the exit code. `TEST_COMPARE_FORCE=1`
+ * skips it, mirroring `API_COMPARE_FORCE`.
+ */
+async function prune(): Promise<void> {
+  if (force) return;
+  try {
+    const pruned = await pruneSharedCache(ROOT);
+    if (pruned.removedEntries || pruned.removedFragments || pruned.removedVersionDirs) {
+      process.stdout.write(
+        `Pruned shared cache: ${pruned.removedEntries} stale entr${pruned.removedEntries === 1 ? "y" : "ies"}, ` +
+          `${pruned.removedFragments} tmp fragment${pruned.removedFragments === 1 ? "" : "s"}, ` +
+          `${pruned.removedVersionDirs} superseded version dir${pruned.removedVersionDirs === 1 ? "" : "s"}\n`,
+      );
+    }
+  } catch {
+    // best-effort housekeeping
+  }
 }
 
 main().catch((err) => {


### PR DESCRIPTION
fix(activerecord,scripts): DDL wrappers restore by deleting the own property; retire the MySQL implicit-commit repair; test-compare prunes the shared cache

Three RFC 0064 / 0092 stories on the fixture harness and the parity tools.

## 1. The DDL recording window leaves no own property behind

`recordDdlTouchedTables` wraps adapter methods per test and restored them
with `target[method] = original`. `target` is the adapter *instance*, so
after the first test in a file the wrapped methods were own properties of
the pooled adapter permanently, shadowing the prototype for the rest of the
run. The cost was silent: a later test that spies by patching
`Object.getPrototypeOf(Base.connection)` never fired, its recording array
stayed empty, and its assertion passed vacuously.

Restore now deletes a method that was found on the prototype and writes back
only a genuine own value, captured at arm time. Rails has nothing to lose
here — `setup_fixtures` / `teardown_fixtures` (`test_fixtures.rb:113`, `:146`)
touch no adapter method.

## 2. The MySQL implicit-commit repair is retired

PR #6277 added `guardMysqlImplicitCommit` + `repairEscapedFixtureRows`:
trails-only machinery that watched the pinned connection on MySQL/MariaDB
and deleted the tables a test's fixture load filled when DDL implicitly
committed the pin. `teardown_fixtures` (`test_fixtures.rb:206-211`) unpins
the pools and stops, so this was tracked debt from the day it landed.

The audit it existed to serve: Rails is exposed to the same escape
(`batches_test.rb:570` calls `add_index` inside a transactional
`BatchesTest`) and does not care, because no Rails test asserts that a table
it did not seed is empty — a load only deletes the tables it is about to
fill (`abstract/database_statements.rb:486-495`), so a leaked row is simply
overwritten. Every trails assertion of a bare empty table
(`await Model.count()).toBe(0)` with no scope: `adapter`, `inheritance`,
`persistence`, `transaction-isolation`, `test-fixtures`) empties that table
inside the test itself — `truncate`, `truncateTables`, `destroyAll`,
`deleteAll`, an explicit `DELETE FROM` — so none observes a leak. The
`PersistenceTest` cases that did were converged at the assertion by #6273.

With nothing observing the escape, the mechanism and its state go:
`guardMysqlImplicitCommit`, `repairEscapedFixtureRows`,
`MYSQL_IMPLICIT_COMMIT_STATEMENT`, `DELETE_FROM_TABLE`, `SQL_ENTRY_POINTS`,
`isMysqlAdapter`, `pinBrokenByDdl`, `seededFixtureTables` and the `unpinned`
threading in `afterEach`. Teardown is pool-unpin and cache-reset only, as
`teardown_fixtures` is. The three test blocks that pinned the mechanism go
with it.

## 3. test-compare prunes the shared cache it writes

`test-compare-shared-ruby-cache` (#6276) taught test-compare to publish
`rails-tests` entries into the cross-worktree cache but never wired the
eviction half, so a checkout that runs `test:compare` and not `api:compare`
accumulated multi-MB manifests without bound (content keys are append-only).
`main()` now calls `pruneSharedCache(ROOT)`, skipped under
`TEST_COMPARE_FORCE=1` and swallowing every failure. It runs before the
comparison rather than after it: `compare.ts`'s `main()` exits the process on
a gate failure, so housekeeping placed after would be skipped on exactly the
runs that keep happening.

## Verification

Local MySQL 8 (own compose stack) with the repair removed:
`with-transactional-fixtures`, `test-fixtures`, `batches`, `persistence`,
`inheritance`, `adapter`, `transactions`, `query-cache`, `dirty`,
`timestamp`, `cache-key`, `primary-keys`, `migration/columns` — 933 tests,
all green. Same files green on sqlite. The new own-property regression is
red on baseline in both arms. `pnpm typecheck`, `pnpm api:calls`,
`pnpm test:compare` green.

`move-adapter-specific-snapshot-off-ar-internal-metadata` was claimed with
this bundle and released unbuilt: its own findings section establishes it is
larger than its estimate and must ship as its own PR.

Closes-story: fixture-harness-wrappers-restore-own-property-shadowing-prototype
Closes-story: retire-mysql-implicit-commit-repair-by-converging-empty-table-assertions
Closes-story: test-compare-never-prunes-the-shared-cache-it-writes



## The audit, listed

The observable shape is narrow: an assertion is leak-sensitive only if its
value depends on rows the block did **not** seed being absent, on an
**unscoped** model. A scoped count (`where`/`having`/an association proxy)
cannot see a foreign block's rows, and a table the test itself just emptied is
zero regardless of what leaked into it. Five greps over
`packages/activerecord/src/**/*.test.ts` cover the shape:

| # | pattern | hits | verdict |
|---|---------|------|---------|
| 1 | `await <Model>.count()).to(Be\|Equal)(0)` | 16 | all self-emptied inside the test |
| 2 | `await <Model>.(all\|toArray)()).to(Equal([])\|HaveLength(0))` | 1 | `relation-scoping.test.ts:350` — after its own `deleteAll()` |
| 3 | `await <Model>.(size\|length)()).to(Be\|Equal)(0)` | 0 | — |
| 4 | `await <Model>.(first\|last)()).toBe(Null\|Undefined)` | 1 | `relation-scoping.test.ts:537` — inside `where("name = 'Maiha'").scoping` |
| 5 | `await <Model>.exists()).toBe(false)` | 1 | `finder.test.ts:2618` — after its own `Topic.deleteAll()` |

Pattern 1's 16 hits, by file: `adapter.test.ts` (9 — `truncate` /
`truncateTables`, each preceded by a `toBeGreaterThan(0)` on the same table,
plus one `deleteAll` inside a rolled-back transaction),
`inheritance.test.ts:436,442` (after `Client.destroyAll()` /
`Cabbage.destroyAll()`), `persistence.test.ts:213` (after
`Topic.all().deleteAll()`), `transaction-isolation.test.ts:88,102,105` (a
`beforeEach` runs `Tag.destroyAll()`), `test-fixtures.test.ts:308` (after the
test's own `DELETE FROM authors`). Every one is a table the test emptied
itself, which is the only case where an absolute zero is correct — as Rails has
it: `test_destroy_many` asserts a delta,
`assert_difference("Client.count", -2)` (`persistence_test.rb:364-372`), not an
empty table. The `PersistenceTest` cases that did assert bare zero were
converged to that shape by #6273.

No hit anywhere observes a table it did not seed, so nothing in the suite can
see the escape the removed repair existed to hide — matching Rails, where the
same MySQL implicit commit happens (`batches_test.rb:570`) and goes unnoticed.
