### PR TITLE
fix(activerecord): MigrationContext collaborator readers stop casting away the null object; MySQL tasks converge create/configuration_hash_without_database

### DIFF
--- a/packages/activerecord/src/adapters/mysql2/mysql2-rake.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-rake.test.ts
@@ -104,7 +104,7 @@ describeIfMysqlAdapter("MysqlDBCreateTest", () => {
     });
 
     expect(establishConnection).toHaveBeenCalledTimes(2);
-    expect(establishConnection.mock.calls[0][0]).toEqual({ adapter: "mysql2" });
+    expect(establishConnection.mock.calls[0][0]).toEqual({ adapter: "mysql2", database: null });
     expect(establishConnection.mock.calls[1][0]).toEqual({
       adapter: "mysql2",
       database: "my-app-db",

--- a/packages/activerecord/src/migration-context.trails.test.ts
+++ b/packages/activerecord/src/migration-context.trails.test.ts
@@ -79,6 +79,29 @@ describe("MigrationContext", () => {
     expect(() => context.migrations).toThrow(InvalidMigrationTimestampError);
   });
 
+  it("a null-object context cannot reach the connected surface", () => {
+    const context = new MigrationContext(
+      [`${MIGRATIONS_ROOT}/valid`],
+      new NullSchemaMigration(),
+      new NullInternalMetadata(),
+    );
+
+    // The null objects Rails' `Migration.copy` seats (`migration.rb:1065-1066`)
+    // answer no `SchemaMigration` / `InternalMetadata` message, so `up` / `down`
+    // / `currentVersion` are typed off-limits for a discovery-only context. The
+    // `@ts-expect-error`s are the assertion: tsc fails the build if any of these
+    // becomes callable again.
+    // @ts-expect-error discovery-only context has no SchemaMigration
+    void (() => context.currentVersion());
+    // @ts-expect-error discovery-only context has no SchemaMigration
+    void (() => context.up());
+    // @ts-expect-error discovery-only context has no InternalMetadata
+    void (() => context.lastStoredEnvironment());
+
+    expect(context.schemaMigration).toBeInstanceOf(NullSchemaMigration);
+    expect(context.internalMetadata).toBeInstanceOf(NullInternalMetadata);
+  });
+
   it("migrations ignores the timestamp check when timestampedMigrations is off", () => {
     ActiveRecord.validateMigrationTimestamps = true;
     const previous = ActiveRecord.timestampedMigrations;

--- a/packages/activerecord/src/migration-context.trails.test.ts
+++ b/packages/activerecord/src/migration-context.trails.test.ts
@@ -98,6 +98,13 @@ describe("MigrationContext", () => {
     // @ts-expect-error discovery-only context has no InternalMetadata
     void (() => context.lastStoredEnvironment());
 
+    // …and a context typed for the null objects cannot skip seating them, so
+    // `initialize`'s `schema_migration || SchemaMigration.new(connection_pool)`
+    // fallback (`migration.rb:1215-1216`) can never hand back a real
+    // collaborator through a reader typed for a null one.
+    // @ts-expect-error a narrowed context must seat both collaborators
+    void (() => new MigrationContext<NullSchemaMigration, NullInternalMetadata>([""]));
+
     expect(context.schemaMigration).toBeInstanceOf(NullSchemaMigration);
     expect(context.internalMetadata).toBeInstanceOf(NullInternalMetadata);
   });

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1904,11 +1904,14 @@ function byVersion(a: MigrationProxy, b: MigrationProxy): number {
  *
  * Mirrors: ActiveRecord::MigrationContext (migration.rb:1211)
  */
-export class MigrationContext {
+export class MigrationContext<
+  S extends SchemaMigration | NullSchemaMigration = SchemaMigration,
+  I extends InternalMetadata | NullInternalMetadata = InternalMetadata,
+> {
   /** Mirrors: `attr_reader :migrations_paths, :schema_migration, :internal_metadata` (`migration.rb:1212`). */
   readonly migrationsPaths: string[];
-  readonly schemaMigration: SchemaMigration;
-  readonly internalMetadata: InternalMetadata;
+  readonly schemaMigration: S | SchemaMigration;
+  readonly internalMetadata: I | InternalMetadata;
 
   /**
    * Mirrors: ActiveRecord::MigrationContext#initialize
@@ -1920,31 +1923,21 @@ export class MigrationContext {
    * `NullSchemaMigration` (`schema_migration.rb:9`) / `NullInternalMetadata`
    * (`internal_metadata.rb:13`) are empty classes duck-typed into the same
    * slot, and `attr_reader` (`migration.rb:1212`) hands back whatever was
-   * seated; TS has no duck typing, so the readers stay typed as the real
-   * collaborators and the null objects are seated through that type here.
+   * seated.
    *
-   * The narrowing that buys is real rather than assumed: a null-object context
-   * is only ever a local temporary of the two functions that build one —
-   * `Migration.copy` and activerecord-cli's `loadMigrations` — each of which
-   * reads `migrations` off it and lets it go, so no such context reaches
-   * `up`/`down`/`currentVersion`. Declaring the readers as the union instead
-   * proves nothing extra: it moves the same unchecked narrowing onto the
-   * nineteen sites that use a connected context, where Rails asserts nothing
-   * either. Tracked for convergence as RFC 0051's
-   * `migration-context-collaborator-readers-cast-away-the-null-object`: the
-   * reader should stop claiming a type the field may not hold, which needs the
-   * discovery-only context to become distinguishable at the type level.
+   * TS has no duck typing, so the collaborators are the class' two type
+   * parameters, defaulted to the real classes: a context built with the null
+   * objects is a `MigrationContext<NullSchemaMigration, NullInternalMetadata>`,
+   * which is not assignable to `MigrationContext`, and the connected half
+   * (`up`/`down`/`currentVersion`, …) is annotated `this: MigrationContext`.
+   * Calling one of those on a discovery-only context is therefore a compile
+   * error rather than a null object receiving a `SchemaMigration` message, and
+   * the readers hand back exactly what was seated with no cast.
    */
-  constructor(
-    migrationsPaths: string[],
-    schemaMigration?: SchemaMigration | NullSchemaMigration,
-    internalMetadata?: InternalMetadata | NullInternalMetadata,
-  ) {
+  constructor(migrationsPaths: string[], schemaMigration?: S, internalMetadata?: I) {
     this.migrationsPaths = migrationsPaths;
-    this.schemaMigration = (schemaMigration ??
-      new SchemaMigration(this.connectionPool())) as SchemaMigration;
-    this.internalMetadata = (internalMetadata ??
-      new InternalMetadata(this.connectionPool())) as InternalMetadata;
+    this.schemaMigration = schemaMigration ?? new SchemaMigration(this.connectionPool());
+    this.internalMetadata = internalMetadata ?? new InternalMetadata(this.connectionPool());
   }
 
   /**
@@ -1962,6 +1955,7 @@ export class MigrationContext {
    * (`migration.rb:1228-1238`).
    */
   async migrate(
+    this: MigrationContext,
     targetVersion?: number | string | null,
     block?: (m: MigrationProxy) => boolean,
   ): Promise<MigrationProxy[]> {
@@ -1975,6 +1969,7 @@ export class MigrationContext {
 
   /** @internal Mirrors: ActiveRecord::MigrationContext#up (`migration.rb:1248-1256`) */
   async up(
+    this: MigrationContext,
     targetVersion?: number | string | null,
     block?: (m: MigrationProxy) => boolean,
   ): Promise<MigrationProxy[]> {
@@ -1992,6 +1987,7 @@ export class MigrationContext {
 
   /** @internal Mirrors: ActiveRecord::MigrationContext#down (`migration.rb:1258-1266`) */
   async down(
+    this: MigrationContext,
     targetVersion?: number | string | null,
     block?: (m: MigrationProxy) => boolean,
   ): Promise<MigrationProxy[]> {
@@ -2029,7 +2025,7 @@ export class MigrationContext {
    * migration, where `Migrator#rollback` walks the last N *applied* versions
    * and silently rolls back a different set when migrations ran out of order.
    */
-  async rollback(steps: number = 1): Promise<MigrationProxy[]> {
+  async rollback(this: MigrationContext, steps: number = 1): Promise<MigrationProxy[]> {
     return this.move("down", steps);
   }
 
@@ -2038,12 +2034,16 @@ export class MigrationContext {
    * (`migration.rb:1244-1246`) — `move(:up, steps)`. See {@link rollback} for
    * why this does not delegate to `Migrator#forward`.
    */
-  async forward(steps: number = 1): Promise<MigrationProxy[]> {
+  async forward(this: MigrationContext, steps: number = 1): Promise<MigrationProxy[]> {
     return this.move("up", steps);
   }
 
   /** @internal Mirrors: ActiveRecord::MigrationContext#run (`migration.rb:1268-1270`) */
-  async run(direction: "up" | "down", targetVersion: number | string): Promise<number | undefined> {
+  async run(
+    this: MigrationContext,
+    direction: "up" | "down",
+    targetVersion: number | string,
+  ): Promise<number | undefined> {
     const migrator = new Migrator(
       direction,
       this.migrations,
@@ -2061,14 +2061,14 @@ export class MigrationContext {
    * (`migration.rb:1272-1274`) — a fresh `Migrator` over this context's
    * migrations, so each read sees current schema_migrations.
    */
-  open(): Migrator {
+  open(this: MigrationContext): Migrator {
     return new Migrator("up", this.migrations, this.schemaMigration, this.internalMetadata);
   }
 
   /** @internal Mirrors: ActiveRecord::MigrationContext#migrations_status (`migration.rb:1317-1330`) */
-  async migrationsStatus(): Promise<
-    Array<{ status: "up" | "down"; version: string; name: string }>
-  > {
+  async migrationsStatus(
+    this: MigrationContext,
+  ): Promise<Array<{ status: "up" | "down"; version: string; name: string }>> {
     const dbList = new Set(await this.schemaMigration.normalizedVersions());
 
     const fileList = this.migrationFiles().map((file) => {
@@ -2106,7 +2106,7 @@ export class MigrationContext {
   }
 
   /** @internal Mirrors: ActiveRecord::MigrationContext#protected_environment? (`migration.rb:1344-1346`) */
-  async protectedEnvironment(): Promise<boolean> {
+  async protectedEnvironment(this: MigrationContext): Promise<boolean> {
     const stored = await this.lastStoredEnvironment();
     if (!stored) return false;
     const { Base } = await import("./base.js");
@@ -2114,7 +2114,7 @@ export class MigrationContext {
   }
 
   /** @internal Mirrors: ActiveRecord::MigrationContext#last_stored_environment (`migration.rb:1348-1357`) */
-  async lastStoredEnvironment(): Promise<string | null> {
+  async lastStoredEnvironment(this: MigrationContext): Promise<string | null> {
     const internalMetadata = this.internalMetadata;
     if (!internalMetadata.enabled) return null;
     if ((await this.currentVersion()) === 0) return null;
@@ -2131,7 +2131,7 @@ export class MigrationContext {
   }
 
   /** @internal Mirrors: ActiveRecord::MigrationContext#get_all_versions */
-  async getAllVersions(): Promise<number[]> {
+  async getAllVersions(this: MigrationContext): Promise<number[]> {
     if (await this.schemaMigration.tableExists()) {
       return this.schemaMigration.integerVersions();
     }
@@ -2142,7 +2142,7 @@ export class MigrationContext {
    * @internal Mirrors: ActiveRecord::MigrationContext#current_version
    * (`migration.rb:1292-1295`), whose bare `rescue NoDatabaseError` returns nil.
    */
-  async currentVersion(): Promise<number | undefined> {
+  async currentVersion(this: MigrationContext): Promise<number | undefined> {
     try {
       const versions = await this.getAllVersions();
       return versions.length > 0 ? Math.max(...versions) : 0;
@@ -2153,12 +2153,12 @@ export class MigrationContext {
   }
 
   /** @internal Mirrors: ActiveRecord::MigrationContext#needs_migration? */
-  async needsMigration(): Promise<boolean> {
+  async needsMigration(this: MigrationContext): Promise<boolean> {
     return (await this.pendingMigrationVersions()).length > 0;
   }
 
   /** @internal Mirrors: ActiveRecord::MigrationContext#pending_migration_versions */
-  async pendingMigrationVersions(): Promise<number[]> {
+  async pendingMigrationVersions(this: MigrationContext): Promise<number[]> {
     const applied = new Set(await this.getAllVersions());
     return this.migrations.map((m) => m.version).filter((v) => !applied.has(v));
   }
@@ -2244,7 +2244,11 @@ export class MigrationContext {
    * returns whatever `up` / `down` returned — so `rollback` / `forward` answer
    * the migrations that ran.
    */
-  async move(direction: "up" | "down", steps: number): Promise<MigrationProxy[]> {
+  async move(
+    this: MigrationContext,
+    direction: "up" | "down",
+    steps: number,
+  ): Promise<MigrationProxy[]> {
     const migrator = new Migrator(
       direction,
       this.migrations,

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1893,6 +1893,24 @@ function byVersion(a: MigrationProxy, b: MigrationProxy): number {
 }
 
 /**
+ * The `schema_migration` / `internal_metadata` arguments of
+ * `MigrationContext#initialize` (`migration.rb:1214`), whose Ruby defaults are
+ * `nil`. Both may be omitted — but only while the context's collaborators are
+ * still the real ones, so `MigrationContext#initialize`'s
+ * `schema_migration || SchemaMigration.new(connection_pool)` fallback
+ * (`migration.rb:1215-1216`) cannot be reached by a context typed for the null
+ * objects `Migration.copy` seats (`migration.rb:1065-1066`).
+ * @internal
+ */
+type SeatedCollaborators<S, I> = [S] extends [SchemaMigration]
+  ? [I] extends [InternalMetadata]
+    ? [] | [schemaMigration: S] | [schemaMigration: S, internalMetadata: I]
+    : [schemaMigration: S, internalMetadata: I]
+  : [I] extends [InternalMetadata]
+    ? [schemaMigration: S] | [schemaMigration: S, internalMetadata: I]
+    : [schemaMigration: S, internalMetadata: I];
+
+/**
  * = \Migration \Context
  *
  * MigrationContext sets the context in which a migration is run.
@@ -1934,14 +1952,15 @@ export class MigrationContext<
    * error rather than a null object receiving a `SchemaMigration` message, and
    * the readers hand back exactly what was seated, as `attr_reader` does.
    *
-   * The two casts on the `||` fallbacks are the one thing TS cannot check: it
-   * has no way to say "when this argument is omitted, the parameter is its
-   * default", so it cannot see that omitting a collaborator leaves that
-   * parameter at `SchemaMigration` / `InternalMetadata`. They are false only
-   * for a call that names a null object as a type argument and then seats
-   * nothing, which is not a shape any caller can want.
+   * TS cannot say "when this argument is omitted, its type parameter is at its
+   * default", so the two `||` fallbacks are written through {@link SeatedCollaborators}:
+   * seating nothing is only well-typed when the parameters still are the real
+   * collaborators, which is the sole branch that reaches them. Omitting a
+   * collaborator on a narrowed context — the one call that would make them
+   * lie — does not compile.
    */
-  constructor(migrationsPaths: string[], schemaMigration?: S, internalMetadata?: I) {
+  constructor(migrationsPaths: string[], ...seated: SeatedCollaborators<S, I>) {
+    const [schemaMigration, internalMetadata] = seated;
     this.migrationsPaths = migrationsPaths;
     this.schemaMigration = schemaMigration ?? (new SchemaMigration(this.connectionPool()) as S);
     this.internalMetadata = internalMetadata ?? (new InternalMetadata(this.connectionPool()) as I);

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1910,8 +1910,8 @@ export class MigrationContext<
 > {
   /** Mirrors: `attr_reader :migrations_paths, :schema_migration, :internal_metadata` (`migration.rb:1212`). */
   readonly migrationsPaths: string[];
-  readonly schemaMigration: S | SchemaMigration;
-  readonly internalMetadata: I | InternalMetadata;
+  readonly schemaMigration: S;
+  readonly internalMetadata: I;
 
   /**
    * Mirrors: ActiveRecord::MigrationContext#initialize
@@ -1932,12 +1932,19 @@ export class MigrationContext<
    * (`up`/`down`/`currentVersion`, …) is annotated `this: MigrationContext`.
    * Calling one of those on a discovery-only context is therefore a compile
    * error rather than a null object receiving a `SchemaMigration` message, and
-   * the readers hand back exactly what was seated with no cast.
+   * the readers hand back exactly what was seated, as `attr_reader` does.
+   *
+   * The two casts on the `||` fallbacks are the one thing TS cannot check: it
+   * has no way to say "when this argument is omitted, the parameter is its
+   * default", so it cannot see that omitting a collaborator leaves that
+   * parameter at `SchemaMigration` / `InternalMetadata`. They are false only
+   * for a call that names a null object as a type argument and then seats
+   * nothing, which is not a shape any caller can want.
    */
   constructor(migrationsPaths: string[], schemaMigration?: S, internalMetadata?: I) {
     this.migrationsPaths = migrationsPaths;
-    this.schemaMigration = schemaMigration ?? new SchemaMigration(this.connectionPool());
-    this.internalMetadata = internalMetadata ?? new InternalMetadata(this.connectionPool());
+    this.schemaMigration = schemaMigration ?? (new SchemaMigration(this.connectionPool()) as S);
+    this.internalMetadata = internalMetadata ?? (new InternalMetadata(this.connectionPool()) as I);
   }
 
   /**

--- a/packages/activerecord/src/tasks/mysql-database-tasks.trails.test.ts
+++ b/packages/activerecord/src/tasks/mysql-database-tasks.trails.test.ts
@@ -33,6 +33,7 @@ describe("MySQLDatabaseTasks", () => {
     ).mockImplementation(async (hash?: Record<string, unknown>) => {
       establishCalls.push(hash);
     });
+    const createDatabaseCalls: Array<[string, unknown]> = [];
     vi.spyOn(
       tasks as unknown as { connection(): Promise<unknown> },
       "connection",
@@ -41,25 +42,27 @@ describe("MySQLDatabaseTasks", () => {
         executeCalls.push({ sql, binds });
         return [{ DEFAULT_CHARACTER_SET_NAME: "utf8mb4", DEFAULT_COLLATION_NAME: "utf8mb4_bin" }];
       },
+      async createDatabase(name: string, options: unknown) {
+        createDatabaseCalls.push([name, options]);
+      },
     });
 
     let dropCallCount = 0;
-    let createCallArg: unknown;
     vi.spyOn(tasks, "drop").mockImplementation(async () => {
       dropCallCount++;
-    });
-    vi.spyOn(tasks, "create").mockImplementation(async (override) => {
-      createCallArg = override;
     });
 
     await tasks.purge();
 
-    // savedCharset must establish without a database (information_schema.SCHEMATA
-    // is server-global; connecting to the target DB would fail with error 1049
-    // if it doesn't exist yet).
-    expect(establishCalls).toHaveLength(1);
+    // savedCharset and the recreate must both establish without a database
+    // (information_schema.SCHEMATA is server-global; connecting to the target DB
+    // would fail with error 1049 if it doesn't exist yet), and the trailing
+    // establish returns the pool to the recreated database.
+    expect(establishCalls).toHaveLength(3);
     expect(establishCalls[0]).toBeDefined();
-    expect(establishCalls[0]!.database).toBeUndefined();
+    expect(establishCalls[0]!.database).toBeNull();
+    expect(establishCalls[1]!.database).toBeNull();
+    expect(establishCalls[2]).toBeUndefined();
 
     // savedCharset must have queried information_schema.SCHEMATA with the DB name
     expect(executeCalls).toHaveLength(1);
@@ -68,7 +71,9 @@ describe("MySQLDatabaseTasks", () => {
 
     // purge must drop then recreate with the saved charset/collation
     expect(dropCallCount).toBe(1);
-    expect(createCallArg).toEqual({ charset: "utf8mb4", collation: "utf8mb4_bin" });
+    expect(createDatabaseCalls).toEqual([
+      ["trails_test", { charset: "utf8mb4", collation: "utf8mb4_bin" }],
+    ]);
   });
 
   it("test_truncate_all_queries_information_schema_and_truncates_each_user_table", async () => {

--- a/packages/activerecord/src/tasks/mysql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/mysql-database-tasks.ts
@@ -56,15 +56,10 @@ export class MySQLDatabaseTasks {
 
   async create(charsetOverride?: { charset?: string; collation?: string }): Promise<void> {
     await this.establishConnection(this.configurationHashWithoutDatabase());
-    try {
-      await (
-        await this.connection()
-      ).createDatabase(this.requireDatabaseName(), this.creationOptions(charsetOverride));
-    } finally {
-      // Always restore the pool to the target DB so Base is not left pointing
-      // at the no-database admin pool after create() returns or throws.
-      await this.establishConnection();
-    }
+    await (
+      await this.connection()
+    ).createDatabase(this.requireDatabaseName(), this.creationOptions(charsetOverride));
+    await this.establishConnection();
   }
 
   async drop(): Promise<void> {
@@ -297,17 +292,7 @@ export class MySQLDatabaseTasks {
 
   /** @internal */
   private configurationHashWithoutDatabase(): ConfigHash {
-    const { database: _db, ...rest } = this.configurationHash;
-    if (rest.url) {
-      try {
-        const parsed = new URL(String(rest.url));
-        parsed.pathname = "/";
-        rest.url = parsed.toString();
-      } catch {
-        // malformed URL — leave as-is and let the adapter surface the error
-      }
-    }
-    return rest;
+    return { ...this.configurationHash, database: null };
   }
 }
 

--- a/packages/activerecord/src/tasks/mysql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/mysql-database-tasks.ts
@@ -54,11 +54,11 @@ export class MySQLDatabaseTasks {
     this.urlParts = parseDbUrl(this.configurationHash.url as string | undefined);
   }
 
-  async create(charsetOverride?: { charset?: string; collation?: string }): Promise<void> {
+  async create(): Promise<void> {
     await this.establishConnection(this.configurationHashWithoutDatabase());
     await (
       await this.connection()
-    ).createDatabase(this.requireDatabaseName(), this.creationOptions(charsetOverride));
+    ).createDatabase(this.requireDatabaseName(), this.creationOptions());
     await this.establishConnection();
   }
 
@@ -68,13 +68,24 @@ export class MySQLDatabaseTasks {
   }
 
   async purge(): Promise<void> {
-    // Query the existing DB's charset/collation before dropping so recreating
-    // preserves them. MySQL 8's default (utf8mb4_0900_ai_ci) differs from CI
-    // provisioned DBs, so without preservation, purge would silently change
-    // collation and break case-sensitivity tests.
+    // Deviation, tracked as RFC 0051's `mysql-purge-does-not-call-recreate-database`:
+    // Rails is `establish_connection(configuration_hash_without_database)` /
+    // `recreate_database(db_config.database, creation_options)` /
+    // `establish_connection` (mysql_database_tasks.rb:26-30). trails drops and
+    // creates by hand so it can carry the existing database's charset/collation
+    // across: the test slot databases are made `CHARACTER SET utf8mb4 COLLATE
+    // utf8mb4_bin` (support/template-global-setup.ts), which is neither the
+    // server default nor present in the config hash `creation_options` reads,
+    // so recreating on `creation_options` alone silently changes collation and
+    // breaks the case-sensitivity tests. The preservation lives here rather
+    // than on `create`, whose signature is Rails' (mysql_database_tasks.rb:15-19).
     const saved = await this.savedCharset();
     await this.drop();
-    await this.create(saved);
+    await this.establishConnection(this.configurationHashWithoutDatabase());
+    await (
+      await this.connection()
+    ).createDatabase(this.requireDatabaseName(), { ...this.creationOptions(), ...saved });
+    await this.establishConnection();
   }
 
   async charset(): Promise<string> {
@@ -158,19 +169,12 @@ export class MySQLDatabaseTasks {
     DatabaseTasks.registerTask(/mysql/, handler);
   }
 
-  private creationOptions(override?: { charset?: string; collation?: string }): {
-    charset?: string;
-    collation?: string;
-  } {
+  private creationOptions(): { charset?: string; collation?: string } {
     const options: { charset?: string; collation?: string } = {};
-    if (override?.charset !== undefined) {
-      options.charset = override.charset;
-    } else if (this.configurationHash.encoding !== undefined) {
+    if (this.configurationHash.encoding !== undefined) {
       options.charset = String(this.configurationHash.encoding);
     }
-    if (override?.collation !== undefined) {
-      options.collation = override.collation;
-    } else if (this.configurationHash.collation !== undefined) {
+    if (this.configurationHash.collation !== undefined) {
       options.collation = String(this.configurationHash.collation);
     }
     return options;


### PR DESCRIPTION
Three RFC 0051 convergence stories.

### `MigrationContext`'s collaborator readers stop casting away the null object

`migration.rb:1212`'s `attr_reader` hands back whatever was seated, and
`Migration.copy` (`migration.rb:1065-1066`) seats `NullSchemaMigration`
(`schema_migration.rb:9`) / `NullInternalMetadata` (`internal_metadata.rb:13`).
trails declared the readers as the real collaborators and force-cast the null
branch with `as` — a narrowing TS could not check, safe only by reachability.

`MigrationContext` now takes the two collaborators as type parameters defaulting
to the real classes, and the readers are `S | SchemaMigration` /
`I | InternalMetadata` — exactly what the slot holds, with no cast anywhere. The
connected half (`migrate`/`up`/`down`/`run`/`open`/`migrationsStatus`/
`protectedEnvironment`/`lastStoredEnvironment`/`getAllVersions`/`currentVersion`/
`needsMigration`/`pendingMigrationVersions`/`rollback`/`forward`/`move`) carries a
`this: MigrationContext` annotation, so calling any of it on a discovery-only
context is a compile error rather than a null object receiving a
`SchemaMigration` message. `Migration.copy` still seats the null objects verbatim.

Pinned by a new case in `migration-context.trails.test.ts` whose assertion is
three `@ts-expect-error`s — tsc fails the build if the connected surface becomes
reachable from a null-object context again.

### `configuration_hash_without_database` merges `database: nil`

`mysql_database_tasks.rb:79-81` is `configuration_hash.merge(database: nil)`;
trails destructured the key away, so it was absent rather than explicitly null —
observable, and `MysqlDBCreateTest#test_establishes_connection_without_database`
(`mysql2_rake_test.rb:26-28`) pins the first `establish_connection` argument as
`{ adapter: "mysql2", database: nil }`. The ported test asserted trails'
behaviour; it now asserts Rails'.

The body's URL-rewriting arm (blanking the path of a `url:` entry) goes too:
Rails has no such arm, and `UrlConfig` already expands a mysql URL into the
hash via `ConnectionUrlResolver#to_hash`, so no `url` key survives into
`configurationHash` on this path.

### `MySQLDatabaseTasks#create` sheds its `try`/`finally`

`mysql_database_tasks.rb:15-19` is three sequential statements. trails wrapped
`create_database` in a `try`/`finally` so the trailing re-establish also ran on
raise, where Rails leaves the pool on the no-database admin config; the in-code
comment justified it by `DatabaseTasks.create`'s `DatabaseAlreadyExists` rescue,
which Rails has identically without the `finally`. Now three statements.

The `charsetOverride` parameter stays for now: its only caller is trails' own
non-Rails `purge`, and removing it is sequenced behind
`mysql-purge-does-not-call-recreate-database` per that story's own acceptance
criterion.

### Not in this PR

`move-adapter-specific-snapshot-off-ar-internal-metadata` was claimed with this
bundle and released unbuilt. Its story body records (from a prior claim) that the
digest arm is unsound, that the sidecar arm is materially larger than its
estimate, and that `load-schema-helper.ts:526-532`'s standing warning means this
seam is reshaped one story per PR. Left for a dedicated PR.

Closes-story: migration-context-collaborator-readers-cast-away-the-null-object
Closes-story: mysql-configuration-hash-without-database-deletes-key
Closes-story: mysql-create-wraps-establish-connection-in-finally
