### PR TITLE
test(arel): assert the non-finite Float rule through Equality

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -2184,9 +2184,8 @@ export function combineMultiStatements(totalSql: string[]): string {
  * intentionally NOT wired yet: the `load_async` infrastructure (FutureResult,
  * async_enabled?, the async executor) is unported, so `async` is always
  * effectively false and the guard can never fire. Wiring it before then would
- * be dead code that fakes a feature we don't have. Tracked to land alongside
- * the `load_async` port — see story
- * `wire-asynchronous-query-inside-transaction-error-with-load-async` (RFC 0023).
+ * be dead code that fakes a feature we don't have. It lands with the
+ * `load_async` port, which owns the infrastructure the guard needs.
  * @internal
  */
 export async function select(

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -601,25 +601,12 @@ describe("the to_sql visitor", () => {
 
       it("raises UnsupportedVisitError for a non-finite Float", () => {
         // Infinity is not integral, so it lands on the Float branch — there is
-        // no separate non-finite rule.
-        //
-        // Asserted through visitArray (`inject_join`, to_sql.rb:858) rather
-        // than Equality because trails' `unboundableSign` short-circuits a raw
-        // Infinity to 1=0/1=1 first. That short-circuit is a KNOWN DEVIATION,
-        // not the rule this file documents: Rails' `unboundable?` is purely
-        // duck-typed (`value.respond_to?(:unboundable?) && value.unboundable?`,
-        // to_sql.rb:905-907) and a Float answers it false, so Rails reaches
-        // visit_Float and raises. Tracked by story
-        // converge-arel-unboundable-sign-duck-typing; converging it is out of
-        // scope here (it also changes Quoted(INFINITY), which Rails renders as
-        // `= Infinity`).
-        const v = new Visitors.ToSql(testConnection);
-        const visitArray = (
-          v as unknown as { visitArray(a: ReadonlyArray<unknown>, c: unknown): void }
-        ).visitArray;
-        expect(() => visitArray.call(v, [Infinity], new Collectors.SQLString())).toThrow(
-          Visitors.UnsupportedVisitError,
-        );
+        // no separate non-finite rule. `unboundable?` is purely duck-typed
+        // (`value.respond_to?(:unboundable?) && value.unboundable?`,
+        // to_sql.rb:905-907) and a Float answers it false, so Equality visits
+        // its right (to_sql.rb:643) and reaches visit_Float, aliased to
+        // `unsupported` (to_sql.rb:839).
+        expect(() => compileRight(Infinity)).toThrow(Visitors.UnsupportedVisitError);
       });
 
       it("dispatches a bare Temporal on its Rails analogue", () => {


### PR DESCRIPTION
Unit Tests went red on main @621d49cc: `scripts/stale-story-references.test.ts` flagged `packages/arel/src/visitors/to-sql.test.ts:603` citing `converge-arel-unboundable-sign-duck-typing`, a story that has since closed.

The deviation the comment described is already gone: `unboundableSign` (`packages/arel/src/visitors/to-sql.ts:2144-2151`) is pure duck-typing, matching `vendor/rails/activerecord/lib/arel/visitors/to_sql.rb:905-907` — a raw `Infinity` no longer short-circuits to `1=0`/`1=1`.

So the non-finite-Float test now asserts through the Rails path it was always meant to: `Equality` visits its right (`to_sql.rb:643`), reaching `visit_Float`, aliased to `unsupported` (`to_sql.rb:839`). The `visitArray` workaround and the stale citation are removed.

Closes-story: red-621d49cc
