### PR TITLE
refactor(activerecord,scripts): retire the per-test DDL adapter wrappers; rename the shared parity cache

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/array.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/array.test.ts
@@ -121,11 +121,18 @@ describeIfPg("PostgreSQLAdapter", () => {
           this.attribute("id", "integer");
         }
       }
-      await PgArrays.loadSchema();
-      // Rails: assert_equal([4, 4, 2], PgArray.column_defaults["score"])
-      expect((PgArrays as any).columnDefaults["score"]).toEqual([4, 4, 2]);
-      // Rails: assert_equal([4, 4, 2], PgArray.new.score)
-      expect((new PgArrays() as any).score).toEqual([4, 4, 2]);
+      try {
+        // Rails: PgArray.reset_column_information (array_test.rb:85)
+        PgArrays.resetColumnInformation();
+        await PgArrays.loadSchema();
+        // Rails: assert_equal([4, 4, 2], PgArray.column_defaults["score"])
+        expect((PgArrays as any).columnDefaults["score"]).toEqual([4, 4, 2]);
+        // Rails: assert_equal([4, 4, 2], PgArray.new.score)
+        expect((new PgArrays() as any).score).toEqual([4, 4, 2]);
+      } finally {
+        // Rails: ensure PgArray.reset_column_information (array_test.rb:90)
+        PgArrays.resetColumnInformation();
+      }
     });
     it("default strings", async () => {
       await adapter.addColumn("pg_arrays", "names", "string", {
@@ -139,11 +146,18 @@ describeIfPg("PostgreSQLAdapter", () => {
           this.attribute("id", "integer");
         }
       }
-      await PgArrays.loadSchema();
-      // Rails: assert_equal(["foo", "bar"], PgArray.column_defaults["names"])
-      expect((PgArrays as any).columnDefaults["names"]).toEqual(["foo", "bar"]);
-      // Rails: assert_equal(["foo", "bar"], PgArray.new.names)
-      expect((new PgArrays() as any).names).toEqual(["foo", "bar"]);
+      try {
+        // Rails: PgArray.reset_column_information (array_test.rb:95)
+        PgArrays.resetColumnInformation();
+        await PgArrays.loadSchema();
+        // Rails: assert_equal(["foo", "bar"], PgArray.column_defaults["names"])
+        expect((PgArrays as any).columnDefaults["names"]).toEqual(["foo", "bar"]);
+        // Rails: assert_equal(["foo", "bar"], PgArray.new.names)
+        expect((new PgArrays() as any).names).toEqual(["foo", "bar"]);
+      } finally {
+        // Rails: ensure PgArray.reset_column_information (array_test.rb:100)
+        PgArrays.resetColumnInformation();
+      }
     });
     it("schema dump with shorthand", async () => {
       const output = await SchemaDumper.dumpTableSchema(adapter, "pg_arrays");

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -407,10 +407,6 @@ export class SchemaStatements {
       throw new Error("Options `:force` and `:if_not_exists` cannot be used simultaneously.");
     }
 
-    if (options.ifNotExists && (await this.tableExists(name))) {
-      return;
-    }
-
     const td = this.buildCreateTableDefinition(name, options, definer);
 
     if (options.force) {

--- a/packages/activerecord/src/connection-adapters/schema-cache.test.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.test.ts
@@ -458,21 +458,6 @@ describe("SchemaCacheTest", () => {
     expect(cache.isCached("users")).toBe(false);
   });
 
-  it("records touched tables between recordTouchedTables and takeTouchedTables", () => {
-    const cache = new SchemaCache();
-    // No recording window: clears are not tracked.
-    cache.clearDataSourceCacheBang(null, "before");
-    cache.recordTouchedTables();
-    cache.clearDataSourceCacheBang(null, "users");
-    cache.clearDataSourceCacheBang(null, "posts");
-    cache.clearDataSourceCacheBang(null, "users");
-    const touched = cache.takeTouchedTables();
-    expect([...touched].sort()).toEqual(["posts", "users"]);
-    // takeTouchedTables closes the window — subsequent clears are not tracked.
-    cache.clearDataSourceCacheBang(null, "after");
-    expect([...cache.takeTouchedTables()]).toEqual([]);
-  });
-
   it("#columns_hash? is populated by #columns_hash", async () => {
     const cache = new SchemaCache();
     cache.setColumns("users", [makeColumn("id", "integer")]);

--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -130,14 +130,6 @@ export class SchemaCache {
   private _dataSourceExists = new Map<string, boolean>();
   private _indexes = new Map<string, IndexDefinition[]>();
   private _version: string | number | null = null;
-  // When non-null, records the name of every table passed to
-  // `clearDataSourceCacheBang` — i.e. every table touched by DDL
-  // (`create_table` / `drop_table` / `add_column` / … all funnel through it).
-  // The AR test harness opens a recording window per test so teardown can
-  // re-reflect only the DDL-touched tables instead of clearing the whole
-  // cache (mirrors Rails' per-table `clear_data_source_cache!`). Off (null)
-  // by default so production paths never pay the bookkeeping.
-  private _touchedTables: Set<string> | null = null;
 
   static _loadFrom(filename: string): SchemaCache | null {
     try {
@@ -473,32 +465,8 @@ export class SchemaCache {
     );
   }
 
-  /**
-   * Begin (or reset) a recording window. Subsequent
-   * `clearDataSourceCacheBang` calls record their table name until
-   * {@link takeTouchedTables} is called. Test-harness only.
-   *
-   * @internal
-   */
-  recordTouchedTables(): void {
-    this._touchedTables = new Set();
-  }
-
-  /**
-   * Return the tables touched since the last {@link recordTouchedTables} and
-   * close the recording window. Test-harness only.
-   *
-   * @internal
-   */
-  takeTouchedTables(): Set<string> {
-    const touched = this._touchedTables ?? new Set<string>();
-    this._touchedTables = null;
-    return touched;
-  }
-
   // Rails: clear_data_source_cache!(_connection, name)
   clearDataSourceCacheBang(_connection: unknown, name: string): void {
-    this._touchedTables?.add(name);
     this._columns.delete(name);
     this._columnsHash.delete(name);
     this._primaryKeys.delete(name);

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -35,7 +35,6 @@ import { captureSql } from "./testing/sql-capture.js";
 import { ClothingItem, ClothingItemSized } from "./test-helpers/models/clothing-item.js";
 import { Dashboard } from "./test-helpers/models/dashboard.js";
 import { queryConstraints, queryConstraintsList } from "./persistence.js";
-import { reloadSchemaFromCache } from "./model-schema.js";
 // Imported under an alias: a top-level `Topic`/`Item` binding would make
 // esbuild rename the bespoke in-function `class Topic`/`class Item`
 // declarations in the later (still-bespoke) describe blocks to `Topic2`/`Item2`,
@@ -1520,11 +1519,7 @@ describe("PersistenceTest", () => {
 
   it("becomes after reload schema from cache", () => {
     (Reply as any).defineAttributeMethods();
-    // Rails calls `Reply.serialize(:content)` purely to invoke
-    // `reload_schema_from_cache` (persistence_test.rb). That resets the class'
-    // schema state only — unlike `reset_column_information` it does not clear
-    // the pool's schema-cache entry (model_schema.rb:526).
-    reloadSchemaFromCache.call(Reply as never);
+    Reply.serialize("content"); // invoke reload_schema_from_cache
     const t = topics("first");
     expect(t.becomes(Reply)).toBeInstanceOf(Reply);
     expect(t.becomes(Reply).title).toBe("The First Topic");

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -35,6 +35,7 @@ import { captureSql } from "./testing/sql-capture.js";
 import { ClothingItem, ClothingItemSized } from "./test-helpers/models/clothing-item.js";
 import { Dashboard } from "./test-helpers/models/dashboard.js";
 import { queryConstraints, queryConstraintsList } from "./persistence.js";
+import { reloadSchemaFromCache } from "./model-schema.js";
 // Imported under an alias: a top-level `Topic`/`Item` binding would make
 // esbuild rename the bespoke in-function `class Topic`/`class Item`
 // declarations in the later (still-bespoke) describe blocks to `Topic2`/`Item2`,
@@ -1519,7 +1520,11 @@ describe("PersistenceTest", () => {
 
   it("becomes after reload schema from cache", () => {
     (Reply as any).defineAttributeMethods();
-    Reply.resetColumnInformation(); // mirrors Reply.serialize(:content) reload
+    // Rails calls `Reply.serialize(:content)` purely to invoke
+    // `reload_schema_from_cache` (persistence_test.rb). That resets the class'
+    // schema state only — unlike `reset_column_information` it does not clear
+    // the pool's schema-cache entry (model_schema.rb:526).
+    reloadSchemaFromCache.call(Reply as never);
     const t = topics("first");
     expect(t.becomes(Reply)).toBeInstanceOf(Reply);
     expect(t.becomes(Reply).title).toBe("The First Topic");

--- a/packages/activerecord/src/test-fixtures.ts
+++ b/packages/activerecord/src/test-fixtures.ts
@@ -565,8 +565,7 @@ export function fixtures(
   fixturesOrNames: FixtureMap | readonly FixtureName[] | readonly TablelessFixtureEntry[],
   options: FixturesOptions | undefined = undefined,
 ): Record<string, unknown> {
-  const { usesTransaction, invalidateSchemaCache, useTransactionalTests, connection } =
-    options ?? {};
+  const { usesTransaction, useTransactionalTests, connection } = options ?? {};
 
   // Caller-supplied connection/adapter thunk wins over the default handler
   // connection: multi-database suites seed through a model-specific
@@ -578,10 +577,7 @@ export function fixtures(
   // real DML, visible across pooled connections. Mirrors the direct-adapter
   // escape hatch the view/signed-id suites used before converging here.
   if (useTransactionalTests !== false) {
-    withTransactionalFixtures(getConnection, {
-      usesTransaction,
-      invalidateSchemaCache,
-    });
+    withTransactionalFixtures(getConnection, { usesTransaction });
   }
 
   return useFixtures(fixturesOrNames as FixtureMap, getConnection);

--- a/packages/activerecord/src/test-fixtures/with-transactional-fixtures.test.ts
+++ b/packages/activerecord/src/test-fixtures/with-transactional-fixtures.test.ts
@@ -88,49 +88,6 @@ describe("withTransactionalFixtures", () => {
   });
 });
 
-// DDL executed inside an it() body populates the adapter's SchemaCache.
-// The outer-transaction rollback reverts the DDL at the DB level, but the
-// cache entries it produced would otherwise survive into the next test —
-// reporting columns that no longer exist. The helper's afterEach re-reflects
-// the DDL-touched tables after rollback (per-table, not a blanket clear) to
-// keep that in-memory reflection in sync with the rolled-back DB.
-describe("withTransactionalFixtures (schema-cache invalidation)", () => {
-  let adapter: SQLite3Adapter;
-
-  beforeAll(async () => {
-    adapter = new BetterSQLite3Adapter(":memory:");
-    await adapter.createTable("cache_inval_users", (t) => t.string("name"));
-  });
-
-  afterAll(async () => {
-    await adapter.close();
-  });
-
-  withTransactionalFixtures(() => adapter);
-
-  // Direct-adapter reads (`adapter.columns(...)`) bypass SchemaCache —
-  // SQLite3Adapter#columns runs PRAGMA against the live DB. To actually
-  // exercise `internalSchemaCache.clear()`, populate the cache directly via
-  // `setColumns` (simulating how Model.loadSchema warms it in real
-  // adapter use) and then assert `isColumnsHash` flips false
-  // after rollback.
-  it("warming the schema cache inside a test leaves it populated", async () => {
-    await adapter.addColumn("cache_inval_users", "extra", "string");
-    const cols = await adapter.columns("cache_inval_users");
-    adapter.internalSchemaCache.setColumns("cache_inval_users", cols);
-    expect(adapter.internalSchemaCache.isColumnsHash(adapter.pool, "cache_inval_users")).toBe(true);
-  });
-
-  it("next test sees an empty schema cache because afterEach cleared it", async () => {
-    // Without `internalSchemaCache.clear()` in the helper, this would be true —
-    // the cached hash from the previous test would still report the
-    // rolled-back `extra` column.
-    expect(adapter.internalSchemaCache.isColumnsHash(adapter.pool, "cache_inval_users")).toBe(
-      false,
-    );
-  });
-});
-
 // Adapter-cluster files (adapters/postgresql/*.test.ts, etc.) construct a
 // raw DatabaseAdapter directly instead of leasing one from a pool (Base.connection
 // or createPooledTestAdapter()). The helper must accept that shape —
@@ -161,81 +118,6 @@ describe("withTransactionalFixtures (raw adapter)", () => {
   it("sees zero rows because the previous insert rolled back", async () => {
     const rows = await query(`SELECT * FROM raw_fixture_users`);
     expect(rows).toHaveLength(0);
-  });
-});
-
-// Teardown re-reflects ONLY the DDL-touched tables (the `clear_data_source_cache!`
-// shape), so a warmed entry for an untouched table survives into the next test
-// instead of being wiped by a blanket clear.
-describe("withTransactionalFixtures (per-table re-reflection preserves untouched entries)", () => {
-  let adapter: SQLite3Adapter;
-
-  beforeAll(async () => {
-    adapter = new BetterSQLite3Adapter(":memory:");
-    await adapter.createTable("pertable_touched", (t) => t.string("name"));
-    await adapter.createTable("pertable_untouched", (t) => t.string("name"));
-  });
-
-  afterAll(async () => {
-    await adapter.close();
-  });
-
-  withTransactionalFixtures(() => adapter);
-
-  it("touches one table via DDL while another stays warm", async () => {
-    // Warm both entries (raw adapters don't auto-warm; mimic Model.loadSchema).
-    adapter.internalSchemaCache.setColumns(
-      "pertable_touched",
-      await adapter.columns("pertable_touched"),
-    );
-    adapter.internalSchemaCache.setColumns(
-      "pertable_untouched",
-      await adapter.columns("pertable_untouched"),
-    );
-    // DDL on one table records it as touched.
-    await adapter.addColumn("pertable_touched", "extra", "string");
-    expect(adapter.internalSchemaCache.isColumnsHash(adapter.pool, "pertable_untouched")).toBe(
-      true,
-    );
-  });
-
-  it("next test: touched table re-reflected (cold), untouched entry survives", () => {
-    expect(adapter.internalSchemaCache.isColumnsHash(adapter.pool, "pertable_touched")).toBe(false);
-    expect(adapter.internalSchemaCache.isColumnsHash(adapter.pool, "pertable_untouched")).toBe(
-      true,
-    );
-  });
-});
-
-// When `invalidateSchemaCache: false`, the helper skips the per-table
-// re-reflection in afterEach. Cached column reflection survives across tests
-// — pay this cost only when the file does pure DML.
-describe("withTransactionalFixtures (invalidateSchemaCache: false)", () => {
-  let adapter: SQLite3Adapter;
-
-  beforeAll(async () => {
-    adapter = new BetterSQLite3Adapter(":memory:");
-    await adapter.createTable("opt_out_cache_users", (t) => t.string("name"));
-  });
-
-  afterAll(async () => {
-    await adapter.close();
-  });
-
-  withTransactionalFixtures(() => adapter, { invalidateSchemaCache: false });
-
-  it("warming the schema cache leaves it populated", async () => {
-    const cols = await adapter.columns("opt_out_cache_users");
-    adapter.internalSchemaCache.setColumns("opt_out_cache_users", cols);
-    expect(adapter.internalSchemaCache.isColumnsHash(adapter.pool, "opt_out_cache_users")).toBe(
-      true,
-    );
-  });
-
-  it("next test still sees the cached columns because the opt-out skipped clear()", () => {
-    expect(adapter.internalSchemaCache.isColumnsHash(adapter.pool, "opt_out_cache_users")).toBe(
-      true,
-    );
   });
 });
 

--- a/packages/activerecord/src/test-fixtures/with-transactional-fixtures.ts
+++ b/packages/activerecord/src/test-fixtures/with-transactional-fixtures.ts
@@ -66,112 +66,6 @@ async function eagerWarmSchemaCache(adapter: TransactionalFixturesAdapter): Prom
 }
 
 /**
- * The DDL methods whose table names the recording window has to capture,
- * mapped to the arguments naming a table. Rails' schema statements clear the
- * schema cache from `create_table` and `drop_table` only
- * (`abstract/schema_statements.rb:306,542`), so every other method here would
- * otherwise go unrecorded — the harness notes them itself rather than have the
- * ported bodies carry a clear Rails does not have.
- *
- * @internal
- */
-const DDL_TABLE_ARGS: Record<string, (args: unknown[]) => unknown[]> = {
-  createTable: (args) => [args[0]],
-  dropTable: (args) => args,
-  changeTable: (args) => [args[0]],
-  addColumn: (args) => [args[0]],
-  removeColumn: (args) => [args[0]],
-  removeColumns: (args) => [args[0]],
-  renameColumn: (args) => [args[0]],
-  changeColumn: (args) => [args[0]],
-  changeColumnDefault: (args) => [args[0]],
-  changeColumnNull: (args) => [args[0]],
-  addIndex: (args) => [args[0]],
-  removeIndex: (args) => [args[0]],
-  renameIndex: (args) => [args[0]],
-  renameTable: (args) => [args[0], args[1]],
-};
-
-/**
- * Record every table the test's DDL touches, and clear its cache entry as the
- * DDL runs, for the duration of one test. Returns the restore function.
- *
- * This lives in the harness because Rails' DDL methods do not invalidate the
- * schema cache — only `create_table`'s non-force arm and `drop_table` do
- * (`abstract/schema_statements.rb:306,542`). Wrapping here keeps the ported
- * bodies faithful while preserving the per-table teardown below.
- *
- * Restore *deletes* a method it found on the prototype rather than writing the
- * original back: an assignment would leave an own property on the pooled
- * adapter that shadows the prototype for the rest of the run, so a later
- * prototype-level spy would never fire and its assertions would pass
- * vacuously. Only a genuine own value is written back.
- *
- * @internal
- */
-function recordDdlTouchedTables(adapter: TransactionalFixturesAdapter): () => void {
-  const sc = adapter.internalSchemaCache;
-  if (!sc) return () => {};
-  const pool = adapter.pool == null || adapter.pool instanceof NullPool ? null : adapter.pool;
-  const target = adapter as unknown as Record<string, unknown>;
-  const originals: Array<[string, unknown, boolean]> = [];
-  for (const [method, tableArgs] of Object.entries(DDL_TABLE_ARGS)) {
-    const original = target[method];
-    if (typeof original !== "function") continue;
-    originals.push([method, original, Object.prototype.hasOwnProperty.call(target, method)]);
-    target[method] = function (this: unknown, ...args: unknown[]) {
-      for (const name of tableArgs(args)) {
-        if (typeof name === "string") sc.clearDataSourceCacheBang(pool, name);
-      }
-      return (original as (...a: unknown[]) => unknown).apply(this, args);
-    };
-  }
-  return () => {
-    for (const [method, original, wasOwn] of originals) {
-      if (wasOwn) target[method] = original;
-      else delete target[method];
-    }
-  };
-}
-
-/**
- * Re-reflect only the tables a test's DDL touched, leaving every other
- * cached entry intact. DDL executed inside an `it()` body — `addColumn`,
- * `createTable`, `changeTable`, etc. — is captured by the recording window
- * {@link recordDdlTouchedTables} opened in `beforeEach`. The outer
- * transaction's rollback reverts that DDL on the database side, so
- * re-reflecting each touched table restores its cache entry to the
- * rolled-back shape (or drops it if the table no longer exists).
- * Unchanged-table entries persist across tests, mirroring Rails'
- * per-table `clear_data_source_cache!` rather than a blanket clear.
- *
- * @internal
- */
-async function reReflectTouchedTables(adapter: TransactionalFixturesAdapter): Promise<void> {
-  const sc = adapter.internalSchemaCache;
-  if (!sc) return;
-  const touched = sc.takeTouchedTables();
-  if (touched.size === 0) return;
-  const pool = adapter.pool == null || adapter.pool instanceof NullPool ? null : adapter.pool;
-  for (const table of touched) {
-    // Drop the stale (post-DDL) entry first, then re-read the rolled-back
-    // shape from the live DB. Raw adapters without a pool can't re-reflect
-    // async, so the clear alone is the per-table analogue of the old blanket
-    // `clear()` — the entry re-warms lazily on the next read.
-    sc.clearDataSourceCacheBang(pool, table);
-    if (pool === null) continue;
-    try {
-      // `add` is a no-op when the table no longer exists post-rollback
-      // (its `dataSourceExists` guard returns false); otherwise it re-reads
-      // the rolled-back columns/primary-key/indexes from the live DB.
-      await sc.add(pool, table);
-    } catch {
-      // best-effort re-reflect
-    }
-  }
-}
-
-/**
  * Detect a pooled adapter (returned by `createPooledTestAdapter()`). The
  * pool back-reference is set by `ConnectionPool#newConnection` (via
  * `adoptConnection`) when a connection is adopted into the pool;
@@ -276,18 +170,6 @@ async function pinConnectionPool(pool: ConnectionPool): Promise<void> {
  */
 export interface WithTransactionalFixturesOptions {
   /**
-   * Whether to re-reflect the schema cache for the tables a test's DDL
-   * touched after the outer transaction rolls back. Defaults to `true`.
-   *
-   * Unlike the historical behavior (a blanket `schemaCache.clear()`), only
-   * tables touched by `addColumn` / `createTable` / `changeTable` etc. during
-   * the test are re-reflected; unchanged entries persist across tests,
-   * mirroring Rails' persistent, pool-scoped schema cache. Files that do pure
-   * DML can set this to `false` to skip the per-test bookkeeping entirely.
-   */
-  invalidateSchemaCache?: boolean;
-
-  /**
    * Whether to eagerly warm the per-connection `SchemaCache` for all tables
    * once before the first test runs, so synchronous `columnsHash()` reads are
    * served warm. Defaults to `true`. Set to `false` for low-level adapter
@@ -335,11 +217,8 @@ export function withTransactionalFixtures(
   getAdapter: () => TransactionalFixturesAdapter,
   options: WithTransactionalFixturesOptions = {},
 ): void {
-  const {
-    invalidateSchemaCache = true,
-    eagerWarmSchemaCache: eagerWarm = true,
-    usesTransaction: usesTransactionNames = [],
-  } = options;
+  const { eagerWarmSchemaCache: eagerWarm = true, usesTransaction: usesTransactionNames = [] } =
+    options;
   // Eager warm runs lazily before the first test rather than in this helper's
   // beforeAll: callers register their schema-setup beforeAll *after* calling
   // the helper, so the schema does not yet exist when our beforeAll fires.
@@ -348,7 +227,6 @@ export function withTransactionalFixtures(
   // Tests in usesTransaction run without a wrapping transaction (Rails parity:
   // test_fixtures.rb:108-110 run_in_transaction? returns false for these).
   let _txnOpenedForTest = false;
-  let _restoreDdlRecording: (() => void) | null = null;
 
   beforeEach(async (ctx: TaskContext) => {
     const adapter = getAdapter();
@@ -367,11 +245,6 @@ export function withTransactionalFixtures(
       return;
     }
     _txnOpenedForTest = true;
-    // Open a recording window so teardown re-reflects only DDL-touched tables.
-    if (invalidateSchemaCache) {
-      adapter.internalSchemaCache?.recordTouchedTables();
-      _restoreDdlRecording = recordDdlTouchedTables(adapter);
-    }
     const pool = pooledAdapterPool(adapter);
     if (pool) {
       // Mirrors Rails test_fixtures.rb:177-184 pin/lease lifecycle:
@@ -474,11 +347,6 @@ export function withTransactionalFixtures(
     } else {
       const t = tm(adapter);
       while (t.openTransactions > 0) await t.rollbackTransaction();
-    }
-    if (invalidateSchemaCache) {
-      _restoreDdlRecording?.();
-      _restoreDdlRecording = null;
-      await reReflectTouchedTables(adapter);
     }
     const failed = pinResults.find((r) => r.status === "rejected");
     if (failed) throw failed.reason;

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -63,7 +63,7 @@ import {
   dependencyKey,
   hashParts,
   type ReadSet,
-} from "./shared-cache.js";
+} from "@blazetrails/parity/shared-cache";
 import { extractorSchemaToken } from "./extractor-schema.js";
 import { staleBuilds, staleBuildMessage } from "./build-freshness.js";
 import { NEGATED_CALL_PREFIX } from "./enumerable-idioms.js";
@@ -1697,8 +1697,7 @@ export function fileLevelNoRailsEquivalentReason(sourceFile: ts.SourceFile): str
  * in `TAGS_ALLOWED_AFTER_NO_RAILS_EQUIVALENT` are accepted, and anything else
  * — `@internal` above all — is prose that wrapped onto a continuation line.
  * That makes tag order load-bearing: a deliberate `@internal` must precede
- * `@noRailsEquivalent`, as schema-cache.ts `recordTouchedTables` already
- * writes it. `lineLeading` rides along so the caller can point at the fix that
+ * `@noRailsEquivalent`. `lineLeading` rides along so the caller can point at the fix that
  * actually applies.
  */
 function proseTagAfter(tag: ts.JSDocTag): { name: string; lineLeading: boolean } | undefined {

--- a/scripts/api-compare/extractor-schema.ts
+++ b/scripts/api-compare/extractor-schema.ts
@@ -33,7 +33,7 @@
  */
 import * as fs from "fs/promises";
 import * as path from "path";
-import { hashParts } from "./shared-cache.js";
+import { hashParts } from "@blazetrails/parity/shared-cache";
 
 /**
  * Base version for output-shape changes that AREN'T a new field name — e.g. a

--- a/scripts/api-compare/orchestrate.ts
+++ b/scripts/api-compare/orchestrate.ts
@@ -56,7 +56,7 @@ import {
   readShared,
   writeShared,
   pruneSharedCache,
-} from "./shared-cache.js";
+} from "@blazetrails/parity/shared-cache";
 
 const execFileAsync = promisify(execFile);
 
@@ -170,11 +170,17 @@ async function main(): Promise<void> {
   // failure here can never affect the comparison result.
   if (!force) {
     const pruned = await pruneSharedCache(ROOT);
-    if (pruned.removedEntries || pruned.removedFragments || pruned.removedVersionDirs) {
+    if (
+      pruned.removedEntries ||
+      pruned.removedFragments ||
+      pruned.removedVersionDirs ||
+      pruned.removedLegacyDir
+    ) {
       process.stdout.write(
         `Pruned shared cache: ${pruned.removedEntries} stale entr${pruned.removedEntries === 1 ? "y" : "ies"}, ` +
           `${pruned.removedFragments} tmp fragment${pruned.removedFragments === 1 ? "" : "s"}, ` +
-          `${pruned.removedVersionDirs} superseded version dir${pruned.removedVersionDirs === 1 ? "" : "s"}\n`,
+          `${pruned.removedVersionDirs} superseded version dir${pruned.removedVersionDirs === 1 ? "" : "s"}` +
+          `${pruned.removedLegacyDir ? ", plus the pre-rename api-compare-cache tree" : ""}\n`,
       );
     }
   }

--- a/scripts/parity/package.json
+++ b/scripts/parity/package.json
@@ -6,6 +6,7 @@
   "description": "Rails-parity tooling core: conventions, manifests, baselines, caching (plus the SQL parity pipeline under pipeline/)",
   "exports": {
     "./conventions": "./conventions.ts",
+    "./shared-cache": "./shared-cache.ts",
     "./types": "./types.ts",
     "./unported-files": "./unported-files.ts",
     "./write-json-manifest": "./write-json-manifest.ts"

--- a/scripts/parity/shared-cache.test.ts
+++ b/scripts/parity/shared-cache.test.ts
@@ -39,7 +39,7 @@ describe("sharedCacheDir", () => {
     const root = mkTmp();
     fs.mkdirSync(path.join(root, ".git"));
     expect(await sharedCacheDir(root)).toBe(
-      path.join(root, ".git", "api-compare-cache", `v${CACHE_VERSION}`),
+      path.join(root, ".git", "parity-cache", `v${CACHE_VERSION}`),
     );
   });
 
@@ -50,7 +50,7 @@ describe("sharedCacheDir", () => {
     const worktree = mkTmp();
     fs.writeFileSync(path.join(worktree, ".git"), `gitdir: ${worktreeGit}\n`);
     expect(await sharedCacheDir(worktree)).toBe(
-      path.join(repo, ".git", "api-compare-cache", `v${CACHE_VERSION}`),
+      path.join(repo, ".git", "parity-cache", `v${CACHE_VERSION}`),
     );
   });
 
@@ -107,13 +107,18 @@ describe("pruneSharedCache", () => {
     return root;
   }
   function cacheParent(root: string): string {
-    return path.join(root, ".git", "api-compare-cache");
+    return path.join(root, ".git", "parity-cache");
   }
   function currentDir(root: string): string {
     return path.join(cacheParent(root), `v${CACHE_VERSION}`);
   }
 
-  const EMPTY = { removedEntries: 0, removedFragments: 0, removedVersionDirs: 0 };
+  const EMPTY = {
+    removedEntries: 0,
+    removedFragments: 0,
+    removedVersionDirs: 0,
+    removedLegacyDir: false,
+  };
 
   it("no-ops cleanly when there is no cache or no .git", async () => {
     expect(await pruneSharedCache(mkTmp())).toEqual(EMPTY);
@@ -134,7 +139,7 @@ describe("pruneSharedCache", () => {
     fs.utimesSync(fresh, new Date(now - 1 * DAY), new Date(now - 1 * DAY));
 
     const result = await pruneSharedCache(root, { now, maxAgeMs: 14 * DAY });
-    expect(result).toEqual({ removedEntries: 1, removedFragments: 0, removedVersionDirs: 0 });
+    expect(result).toEqual({ ...EMPTY, removedEntries: 1 });
     expect(fs.existsSync(stale)).toBe(false);
     expect(fs.existsSync(fresh)).toBe(true);
   });
@@ -156,6 +161,19 @@ describe("pruneSharedCache", () => {
     expect(result.removedEntries).toBe(0);
     expect(fs.existsSync(staleTmp)).toBe(false);
     expect(fs.existsSync(unrelated)).toBe(true);
+  });
+
+  it("removes the superseded pre-rename api-compare-cache tree", async () => {
+    const root = mkRoot();
+    fs.mkdirSync(currentDir(root), { recursive: true });
+    const legacy = path.join(root, ".git", "api-compare-cache", "v2");
+    fs.mkdirSync(legacy, { recursive: true });
+    fs.writeFileSync(path.join(legacy, "rails-api-abc.json"), "{}");
+
+    const result = await pruneSharedCache(root, { now: 0, maxAgeMs: DAY });
+    expect(result.removedLegacyDir).toBe(true);
+    expect(fs.existsSync(path.join(root, ".git", "api-compare-cache"))).toBe(false);
+    expect(fs.existsSync(currentDir(root))).toBe(true);
   });
 
   it("removes superseded version dirs but never the current or a newer one", async () => {

--- a/scripts/parity/shared-cache.ts
+++ b/scripts/parity/shared-cache.ts
@@ -418,7 +418,7 @@ export async function pruneSharedCache(
     await fs.rm(legacyDir, { recursive: true, force: true });
     result.removedLegacyDir = true;
   } catch {
-    // absent (the common case, once swept) or unremovable — best-effort
+    // best-effort
   }
   const now = opts.now ?? Date.now();
   const maxAgeMs = opts.maxAgeMs ?? CACHE_MAX_AGE_MS;

--- a/scripts/parity/shared-cache.ts
+++ b/scripts/parity/shared-cache.ts
@@ -1,5 +1,6 @@
 /**
- * Cross-worktree shared cache for `pnpm api:compare`.
+ * Cross-worktree shared cache for the `parity:*` tools (`api:compare` and
+ * `test:compare` both read and write it).
  *
  * Every worktree extracts the SAME vendored Rails sources and TS packages, so
  * the expensive extracts (ruby `rails-api.json`, the TS Compiler-API pass)
@@ -17,7 +18,14 @@ import * as fs from "fs/promises";
 import * as path from "path";
 import { createHash } from "crypto";
 
-export const CACHE_VERSION = 2;
+export const CACHE_VERSION = 3;
+
+/**
+ * The pre-rename directory name. `api-compare-cache` claimed one of the two
+ * tools that write here; `pruneSharedCache` removes the whole tree so the
+ * rename doesn't orphan it in every checkout forever.
+ */
+const LEGACY_CACHE_DIR_NAME = "api-compare-cache";
 
 /**
  * Default staleness horizon for cache entries: an entry whose mtime is older
@@ -52,7 +60,7 @@ export async function sharedCacheDir(rootDir: string): Promise<string | null> {
     const gitdir = path.resolve(rootDir, match[1].trim());
     commonDir = path.dirname(path.dirname(gitdir));
   }
-  return path.join(commonDir, "api-compare-cache", `v${CACHE_VERSION}`);
+  return path.join(commonDir, "parity-cache", `v${CACHE_VERSION}`);
 }
 
 /** sha1 over NUL-delimited parts (delimiter prevents boundary ambiguity). */
@@ -368,6 +376,8 @@ export interface PruneResult {
   removedFragments: number;
   /** Superseded `v<N>` (N < CACHE_VERSION) sibling directories removed wholesale. */
   removedVersionDirs: number;
+  /** Whether the superseded pre-rename `api-compare-cache` tree was removed. */
+  removedLegacyDir: boolean;
 }
 
 /**
@@ -376,7 +386,9 @@ export interface PruneResult {
  *   1. Entry files (and crashed-writer `.tmp-` fragments) in the current
  *      `v${CACHE_VERSION}` dir whose mtime is older than `maxAgeMs` — orphaned
  *      content keys and partial writes (see CACHE_MAX_AGE_MS).
- *   2. Sibling `v<N>` directories left behind by a SUPERSEDED CACHE_VERSION,
+ *   2. The pre-rename `api-compare-cache` tree, wholesale — the rename to
+ *      `parity-cache` moved the parent, so nothing else would ever reclaim it.
+ *   3. Sibling `v<N>` directories left behind by a SUPERSEDED CACHE_VERSION,
  *      i.e. only N < CACHE_VERSION. Higher-numbered dirs belong to a newer code
  *      version that may be running concurrently (a bisect or mixed-version
  *      parallel run); wiping those would mutually destroy the live cache, so we
@@ -391,10 +403,23 @@ export async function pruneSharedCache(
   rootDir: string,
   opts: { now?: number; maxAgeMs?: number } = {},
 ): Promise<PruneResult> {
-  const result: PruneResult = { removedEntries: 0, removedFragments: 0, removedVersionDirs: 0 };
+  const result: PruneResult = {
+    removedEntries: 0,
+    removedFragments: 0,
+    removedVersionDirs: 0,
+    removedLegacyDir: false,
+  };
   const currentDir = await sharedCacheDir(rootDir);
   if (!currentDir) return result;
   const parent = path.dirname(currentDir);
+  const legacyDir = path.join(path.dirname(parent), LEGACY_CACHE_DIR_NAME);
+  try {
+    await fs.stat(legacyDir);
+    await fs.rm(legacyDir, { recursive: true, force: true });
+    result.removedLegacyDir = true;
+  } catch {
+    // absent (the common case, once swept) or unremovable — best-effort
+  }
   const now = opts.now ?? Date.now();
   const maxAgeMs = opts.maxAgeMs ?? CACHE_MAX_AGE_MS;
 

--- a/scripts/test-compare/orchestrate.ts
+++ b/scripts/test-compare/orchestrate.ts
@@ -47,7 +47,7 @@ import {
   readShared,
   writeShared,
   pruneSharedCache,
-} from "../api-compare/shared-cache.js";
+} from "@blazetrails/parity/shared-cache";
 
 const execFileAsync = promisify(execFile);
 
@@ -207,11 +207,17 @@ async function prune(): Promise<void> {
   if (force) return;
   try {
     const pruned = await pruneSharedCache(ROOT);
-    if (pruned.removedEntries || pruned.removedFragments || pruned.removedVersionDirs) {
+    if (
+      pruned.removedEntries ||
+      pruned.removedFragments ||
+      pruned.removedVersionDirs ||
+      pruned.removedLegacyDir
+    ) {
       process.stdout.write(
         `Pruned shared cache: ${pruned.removedEntries} stale entr${pruned.removedEntries === 1 ? "y" : "ies"}, ` +
           `${pruned.removedFragments} tmp fragment${pruned.removedFragments === 1 ? "" : "s"}, ` +
-          `${pruned.removedVersionDirs} superseded version dir${pruned.removedVersionDirs === 1 ? "" : "s"}\n`,
+          `${pruned.removedVersionDirs} superseded version dir${pruned.removedVersionDirs === 1 ? "" : "s"}` +
+          `${pruned.removedLegacyDir ? ", plus the pre-rename api-compare-cache tree" : ""}\n`,
       );
     }
   } catch {


### PR DESCRIPTION
## What

Two related pieces of test/parity infrastructure convergence.

### 1. Retire the per-test DDL adapter monkey-patching

`recordDdlTouchedTables` wrapped fourteen adapter DDL methods (`DDL_TABLE_ARGS`) on the pooled adapter for the duration of every transactional test so it could clear the schema cache per touched table and re-reflect them at teardown.

Rails patches nothing: `setup_fixtures` / `teardown_fixtures` (`test_fixtures.rb:113`, `:146`, `:206-211`) pin and unpin pools and touch no adapter method. It needs no harness recording because the DDL bodies clear the cache themselves — `create_table`'s non-force arm (`abstract/schema_statements.rb:306`) and `drop_table` (`:542`) — and **our ported bodies already do** (`schema-statements.ts:425`, `:494`). The wrapper was papering over nothing.

Deleted: `DDL_TABLE_ARGS`, `recordDdlTouchedTables`, `reReflectTouchedTables`, the `_restoreDdlRecording` threading, the `invalidateSchemaCache` option on `WithTransactionalFixturesOptions` (and its pass-through from `fixtures()`), and `SchemaCache`'s `recordTouchedTables` / `takeTouchedTables` / `_touchedTables` recording window. The other twelve DDL methods now go unrecorded exactly as Rails leaves them — no `clear_cache!` was added where Rails has none.

`withTransactionalFixtures` now patches no adapter method, like `setup_fixtures`.

**Review follow-up:** `createTable`'s ported body had an invented `if (ifNotExists && await tableExists(name)) return;` early return *before* the clear, so the `if_not_exists:` arm never reached it. Rails has no such branch — it builds the table definition, then clears on every non-`force` call and lets `CREATE TABLE IF NOT EXISTS` do the work (`schema_statements.rb:301,303,306`), and our `SchemaCreation` already emits the modifier. The early return is gone and the body now follows Rails' order (build `td` → `force` / clear branch → execute), which converged a baselined `order:dropTable,buildCreateTableDefinition` call-mismatch row (deleted by hand; baseline is 2154 → 2153).

**Second review round:** the same body's `force:` arm was also converged rather than deferred — and PR #6287 landed the identical convergence independently while this PR was in review, so on rebase git dropped my commit as "patch contents already upstream". Story `converge-create-table-force-arm-to-rails-unconditional-drop-table` (which I filed) is already `done` against #6287, so its trailer is removed from this PR.

What remains here from that thread is the `ifNotExists` early return, which #6287 did not touch: it still sat above the clear on main, so `createTable(..., { ifNotExists: true })` skipped the schema-cache clear entirely. Removed, with the body now in Rails' order (`build_create_table_definition` → `force`/clear branch → `execute`).

### 3. Rename the shared cross-worktree cache off api-compare's name

Two tools read and write it, so `api-compare-cache` → `parity-cache` (matching the `parity:*` script namespace), `shared-cache.ts` moves from `scripts/api-compare/` to `scripts/parity/` and is imported as `@blazetrails/parity/shared-cache` by both orchestrators. `CACHE_VERSION` bumps 2 → 3 (the rename invalidates the tree anyway, so the bump rides along rather than adding a second invalidation), and `pruneSharedCache` removes the superseded `api-compare-cache` tree wholesale on first run — otherwise the rename orphans it in every checkout forever.

Verified locally: `pnpm api:compare` and `pnpm test:compare` both write and hit `<common-git-dir>/parity-cache/v3/` (`rails-api-*`, `rails-tests-*`, `ts-*` entries all land there), and the first run reported `plus the pre-rename api-compare-cache tree`.

## Verification

- `pnpm typecheck`, `pnpm lint --fix` clean
- `pnpm api:compare` / `pnpm test:compare` deltas non-negative; `pnpm api:calls` ratchet OK (no new rows); `pnpm api:extra` unchanged (surface only shrinks)
- `pnpm vitest run scripts/api-compare scripts/parity scripts/test-compare` — 1256 passed
- SQLite lane: persistence, migration (+ trails/context), schema-dumper, locking, reserved-word, hot-compatibility, active-record-schema, model-schema, base, connection-pool, schema-cache, test-fixtures/**, adapters/sqlite3/** all green

Closes-story: converge-ddl-schema-cache-recording-into-the-ported-ddl-bodies
Closes-story: rename-shared-parity-cache-off-the-api-compare-name
