### PR TITLE
feat(date): Date takes a start argument and answers start/julian?/new_start

### DIFF
--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -1488,6 +1488,28 @@ describe("DateTime", () => {
     );
     expect(iso(RubyDateTime.commercial(1582, 41, 4))).toBe("1582-10-21T00:00:00");
 
+    // `num2num_with_frac` / `num2int_with_frac` (date_core.c:3286-3304): a
+    // fraction is legal only in the LAST argument SUPPLIED, and an explicitly
+    // passed later zero is supplied.
+    //   DateTime.jd(2451944.5).to_s        #=> "2001-02-03T12:00:00+00:00"
+    //   DateTime.jd(2451944, 1.5).to_s     #=> "2001-02-03T01:30:00+00:00"
+    //   DateTime.jd(2451944, 1.5, 0)       #=> raises Date::Error "invalid fraction"
+    //   DateTime.jd(2451944.5, 0)          #=> raises Date::Error "invalid fraction"
+    //   DateTime.jd(Rational(1, 2)).to_s   #=> "-4712-01-01T12:00:00+00:00"
+    //   DateTime.ordinal(2001, 34.5).to_s  #=> "2001-02-03T12:00:00+00:00"
+    //   DateTime.ordinal(2001, 34.5, 0)    #=> raises Date::Error "invalid fraction"
+    //   DateTime.commercial(2001, 5, 6.5).to_s #=> "2001-02-03T12:00:00+00:00"
+    expect(iso(RubyDateTime.jd(2451944.5))).toBe("2001-02-03T12:00:00");
+    expect(iso(RubyDateTime.jd(2451944, 1.5))).toBe("2001-02-03T01:30:00");
+    expect(() => RubyDateTime.jd(2451944, 1.5, 0)).toThrow("invalid fraction");
+    expect(() => RubyDateTime.jd(2451944.5, 0)).toThrow("invalid fraction");
+    // Temporal pads a negative ISO year to six digits where the gem's `to_s`
+    // does not; the day and the time of day are the gem's.
+    expect(iso(RubyDateTime.jd(new Rational(1, 2)))).toBe("-004712-01-01T12:00:00");
+    expect(iso(RubyDateTime.ordinal(2001, 34.5))).toBe("2001-02-03T12:00:00");
+    expect(() => RubyDateTime.ordinal(2001, 34.5, 0)).toThrow("invalid fraction");
+    expect(iso(RubyDateTime.commercial(2001, 5, 6.5))).toBe("2001-02-03T12:00:00");
+
     // canon24oc and add_frac, the tail all four share with DateTime.new.
     expect(iso(RubyDateTime.jd(2451944, 24))).toBe("2001-02-04T00:00:00");
     const half = RubyDateTime.jd(2451944, 0, 0, 0.5);

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -1446,6 +1446,55 @@ describe("DateTime", () => {
     expect(new RubyDate(2008, 3, 1).strftime("%12L")).toBe("000000000000");
   });
 
+  it("builds from a jd, an ordinal, a civil or a commercial date with a time of day and a start", () => {
+    // ruby 3.3.11 — DateTime has singleton methods of its own for all four
+    // (date_core.c:9971-9975), unlike Date's, which take a time of day, an
+    // offset and a trailing start:
+    //   DateTime.jd(2451944).to_s                    #=> "2001-02-03T00:00:00+00:00"
+    //   DateTime.jd(2451944, 4, 5, 6, "+7").to_s     #=> "2001-02-03T04:05:06+07:00"
+    //   DateTime.jd(2299160, 0, 0, 0, 0, Date::GREGORIAN).to_s
+    //                                                #=> "1582-10-14T00:00:00+00:00"
+    //   DateTime.jd(2299160).to_s                    #=> "1582-10-04T00:00:00+00:00"
+    //   DateTime.ordinal(2001, 34, 4, 5, 6, "+7").to_s #=> "2001-02-03T04:05:06+07:00"
+    //   DateTime.ordinal(1582, 355, 1, 2, 3, 0, Date::GREGORIAN).to_s
+    //                                                #=> "1582-12-21T01:02:03+00:00"
+    //   DateTime.civil(2001, 2, 3, 4, 5, 6, "+7").to_s #=> "2001-02-03T04:05:06+07:00"
+    //   DateTime.commercial(2001, 5, 6, 4, 5, 6, "+7").to_s
+    //                                                #=> "2001-02-03T04:05:06+07:00"
+    //   DateTime.commercial(1582, 41, 4, 0, 0, 0, 0, Date::GREGORIAN).to_s
+    //                                                #=> "1582-10-14T00:00:00+00:00"
+    //   DateTime.commercial(1582, 41, 4).to_s        #=> "1582-10-21T00:00:00+00:00"
+    //   DateTime.jd(2451944, 24).to_s                #=> "2001-02-04T00:00:00+00:00"
+    //   DateTime.jd(2451944, 0, 0, 0.5).sec_fraction #=> (1/2)
+    const iso = (v: Temporal.PlainDateTime | Temporal.ZonedDateTime) =>
+      v instanceof Temporal.ZonedDateTime ? v.toString({ timeZoneName: "never" }) : v.toString();
+
+    expect(iso(RubyDateTime.jd(2451944))).toBe("2001-02-03T00:00:00");
+    expect(iso(RubyDateTime.jd(2451944, 4, 5, 6, "+7"))).toBe("2001-02-03T04:05:06+07:00");
+    expect(iso(RubyDateTime.jd(2299160, 0, 0, 0, 0, RubyDate.GREGORIAN))).toBe(
+      "1582-10-14T00:00:00",
+    );
+    expect(iso(RubyDateTime.jd(2299160))).toBe("1582-10-04T00:00:00");
+    expect(iso(RubyDateTime.ordinal(2001, 34, 4, 5, 6, "+7"))).toBe("2001-02-03T04:05:06+07:00");
+    expect(iso(RubyDateTime.ordinal(1582, 355, 1, 2, 3, 0, RubyDate.GREGORIAN))).toBe(
+      "1582-12-21T01:02:03",
+    );
+    expect(iso(RubyDateTime.civil(2001, 2, 3, 4, 5, 6, "+7"))).toBe("2001-02-03T04:05:06+07:00");
+    expect(iso(RubyDateTime.commercial(2001, 5, 6, 4, 5, 6, "+7"))).toBe(
+      "2001-02-03T04:05:06+07:00",
+    );
+    expect(iso(RubyDateTime.commercial(1582, 41, 4, 0, 0, 0, 0, RubyDate.GREGORIAN))).toBe(
+      "1582-10-14T00:00:00",
+    );
+    expect(iso(RubyDateTime.commercial(1582, 41, 4))).toBe("1582-10-21T00:00:00");
+
+    // canon24oc and add_frac, the tail all four share with DateTime.new.
+    expect(iso(RubyDateTime.jd(2451944, 24))).toBe("2001-02-04T00:00:00");
+    const half = RubyDateTime.jd(2451944, 0, 0, 0.5);
+    expect(half).toBeInstanceOf(Temporal.PlainDateTime);
+    expect((half as Temporal.PlainDateTime).millisecond).toBe(500);
+  });
+
   it("takes a start argument after the offset, and keeps the time of day across new_start", () => {
     // ruby 3.3.11:
     //   dt = DateTime.new(1582, 10, 10, 6, 30, 0, "+02:00", Date::GREGORIAN)

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -953,6 +953,103 @@ describe("Date", () => {
     // spelling is reachable — only the Temporal seat cannot hold it.
     expect(dNewByFrags(RubyDate._parse("1500-02-29")).toS()).toBe("1500-02-29");
   });
+
+  it("takes a start argument, and Date::JULIAN/GREGORIAN select every day", () => {
+    // ruby 3.3.11:
+    //   Date.new(1582, 10, 10, Date::GREGORIAN).to_s #=> "1582-10-10"
+    //   Date.new(1582, 10, 10, Date::GREGORIAN).jd   #=> 2299156
+    //   Date.new(1582, 10, 10)                       #=> raises Date::Error
+    //   Date.jd(2299160, Date::GREGORIAN).to_s       #=> "1582-10-14"
+    //   Date.jd(2299160).to_s                        #=> "1582-10-04"
+    //   Date.new(2001, 2, 3, Date::JULIAN).jd        #=> 2451957
+    //   Date.new(2001, 2, 3).jd                      #=> 2451944
+    //   Date.new(1500, 3, 1, Date::GREGORIAN).yday   #=> 60
+    //   Date.new(1500, 3, 1).yday                    #=> 61
+    expect(new RubyDate(1582, 10, 10, RubyDate.GREGORIAN).toS()).toBe("1582-10-10");
+    expect(new RubyDate(1582, 10, 10, RubyDate.GREGORIAN).jd).toBe(2299156);
+    expect(() => new RubyDate(1582, 10, 10)).toThrow(RubyDate.Error);
+    expect(ymd(RubyDate.jd(2299160, RubyDate.GREGORIAN))).toBe("1582-10-14");
+    expect(ymd(RubyDate.jd(2299160))).toBe("1582-10-04");
+    expect(new RubyDate(2001, 2, 3, RubyDate.JULIAN).jd).toBe(2451957);
+    expect(new RubyDate(2001, 2, 3).jd).toBe(2451944);
+    expect(new RubyDate(1500, 3, 1, RubyDate.GREGORIAN).yday).toBe(60);
+    expect(new RubyDate(1500, 3, 1).yday).toBe(61);
+  });
+
+  it("takes a start argument on every static that builds a date", () => {
+    // ruby 3.3.11:
+    //   Date.ordinal(1582, 355, Date::GREGORIAN).to_s      #=> "1582-12-21"
+    //   Date.ordinal(1582, 355).to_s                       #=> "1582-12-31"
+    //   Date.commercial(1582, 41, 4, Date::GREGORIAN).to_s #=> "1582-10-14"
+    //   Date.commercial(1582, 41, 4).to_s                  #=> "1582-10-21"
+    //   Date.parse("1582-10-10", true, Date::GREGORIAN).to_s          #=> "1582-10-10"
+    //   Date.strptime("1582-10-10", "%F", Date::GREGORIAN).to_s       #=> "1582-10-10"
+    expect(ymd(RubyDate.ordinal(1582, 355, RubyDate.GREGORIAN))).toBe("1582-12-21");
+    expect(ymd(RubyDate.ordinal(1582, 355))).toBe("1582-12-31");
+    expect(ymd(RubyDate.commercial(1582, 41, 4, RubyDate.GREGORIAN))).toBe("1582-10-14");
+    expect(ymd(RubyDate.commercial(1582, 41, 4))).toBe("1582-10-21");
+    expect(ymd(RubyDate.parse("1582-10-10", true, RubyDate.GREGORIAN))).toBe("1582-10-10");
+    expect(ymd(RubyDate.strptime("1582-10-10", "%F", RubyDate.GREGORIAN))).toBe("1582-10-10");
+    expect(() => RubyDate.parse("1582-10-10")).toThrow(RubyDate.Error);
+  });
+
+  it("answers start, julian?, gregorian? and new_start off the start it carries", () => {
+    // ruby 3.3.11:
+    //   Date.new(2001, 2, 3).start                     #=> 2299161.0
+    //   Date.new(2001, 2, 3, Date::ENGLAND).start      #=> 2361222.0
+    //   Date.new(2001, 2, 3, Date::JULIAN).start       #=> Infinity
+    //   Date.new(2001, 2, 3, Date::GREGORIAN).start    #=> -Infinity
+    //   Date.new(2001, 2, 3, 0).start                  #=> 2299161.0
+    //   Date.new(1582, 10, 15).julian?                 #=> false
+    //   Date.new(1582, 10, 15).gregorian?              #=> true
+    //   Date.new(1582, 10, 4).julian?                  #=> true
+    //   Date.new(2001, 2, 3, Date::JULIAN).julian?     #=> true
+    //   Date.new(2001, 2, 3, Date::GREGORIAN).julian?  #=> false
+    //   Date.new(1752, 9, 2, Date::ENGLAND).julian?    #=> true
+    //   Date.new(1752, 9, 2, Date::ENGLAND).jd         #=> 2361221
+    //   Date.new(1752, 9, 2).jd                        #=> 2361210
+    expect(new RubyDate(2001, 2, 3).start).toBe(2299161);
+    expect(new RubyDate(2001, 2, 3, RubyDate.ENGLAND).start).toBe(2361222);
+    expect(new RubyDate(2001, 2, 3, RubyDate.JULIAN).start).toBe(Infinity);
+    expect(new RubyDate(2001, 2, 3, RubyDate.GREGORIAN).start).toBe(-Infinity);
+    // `val2sg` (date_core.c:3320-3327): a start outside the reform window is
+    // ignored and DEFAULT_SG taken, as `val2off` ignores a bad offset.
+    expect(new RubyDate(2001, 2, 3, 0).start).toBe(2299161);
+    expect(new RubyDate(2001, 2, 3, NaN).start).toBe(2299161);
+
+    expect(new RubyDate(1582, 10, 15).isJulian).toBe(false);
+    expect(new RubyDate(1582, 10, 15).isGregorian).toBe(true);
+    expect(new RubyDate(1582, 10, 4).isJulian).toBe(true);
+    expect(new RubyDate(2001, 2, 3, RubyDate.JULIAN).isJulian).toBe(true);
+    expect(new RubyDate(2001, 2, 3, RubyDate.GREGORIAN).isJulian).toBe(false);
+    expect(new RubyDate(1752, 9, 2, RubyDate.ENGLAND).isJulian).toBe(true);
+    expect(new RubyDate(1752, 9, 2, RubyDate.ENGLAND).jd).toBe(2361221);
+    expect(new RubyDate(1752, 9, 2).jd).toBe(2361210);
+  });
+
+  it("re-reads the same Julian day under a new start, as new_start does", () => {
+    // ruby 3.3.11:
+    //   d0 = Date.new(2000, 2, 3)
+    //   d0.new_start(Date::JULIAN).to_s #=> "2000-01-21"
+    //   d0.new_start(Date::JULIAN).jd   #=> 2451578
+    //   d0.new_start.start              #=> 2299161.0
+    //   d0.julian.to_s                  #=> "2000-01-21"
+    //   d0.italy.to_s                   #=> "2000-02-03"
+    //   d0.england.to_s                 #=> "2000-02-03"
+    //   d0.england.start                #=> 2361222.0
+    //   d0.gregorian.to_s               #=> "2000-02-03"
+    const d0 = new RubyDate(2000, 2, 3);
+    expect(d0.isJulian).toBe(false);
+    expect(d0.newStart(RubyDate.JULIAN).isJulian).toBe(true);
+    expect(d0.newStart(RubyDate.JULIAN).toS()).toBe("2000-01-21");
+    expect(d0.newStart(RubyDate.JULIAN).jd).toBe(2451578);
+    expect(d0.newStart(RubyDate.ENGLAND).newStart().start).toBe(2299161);
+    expect(d0.julian().toS()).toBe("2000-01-21");
+    expect(d0.italy().toS()).toBe("2000-02-03");
+    expect(d0.england().toS()).toBe("2000-02-03");
+    expect(d0.england().start).toBe(2361222);
+    expect(d0.gregorian().toS()).toBe("2000-02-03");
+  });
 });
 
 describe("DateTime", () => {
@@ -1347,6 +1444,28 @@ describe("DateTime", () => {
     expect(new RubyDate(2008, 3, 1).strftime("%3N")).toBe("000");
     expect(new RubyDate(2008, 3, 1).strftime("%12N")).toBe("000000000000");
     expect(new RubyDate(2008, 3, 1).strftime("%12L")).toBe("000000000000");
+  });
+
+  it("takes a start argument after the offset, and keeps the time of day across new_start", () => {
+    // ruby 3.3.11:
+    //   dt = DateTime.new(1582, 10, 10, 6, 30, 0, "+02:00", Date::GREGORIAN)
+    //   dt.to_s                       #=> "1582-10-10T06:30:00+02:00"
+    //   dt.jd                         #=> 2299156
+    //   dt.start                      #=> -Infinity
+    //   dt.new_start(Date::ITALY).to_s #=> "1582-09-30T06:30:00+02:00"
+    //   DateTime.parse("1582-10-10T06:30:00+02:00", true, Date::GREGORIAN).to_s
+    //     #=> "1582-10-10T06:30:00+02:00"
+    const dt = new RubyDateTime(1582, 10, 10, 6, 30, 0, "+02:00", RubyDate.GREGORIAN);
+    expect(dt.toS()).toBe("1582-10-10T06:30:00+02:00");
+    expect(dt.jd).toBe(2299156);
+    expect(dt.start).toBe(-Infinity);
+    expect(dt.newStart(RubyDate.ITALY).toS()).toBe("1582-09-30T06:30:00+02:00");
+    // The `Temporal.ZonedDateTime` seat spells its own zone in brackets after
+    // the offset, which the gem's `to_s` has no counterpart for.
+    expect(
+      RubyDateTime.parse("1582-10-10T06:30:00+02:00", true, RubyDate.GREGORIAN).toString(),
+    ).toBe("1582-10-10T06:30:00+02:00[+02:00]");
+    expect(() => RubyDateTime.parse("1582-10-10T06:30:00+02:00")).toThrow(RubyDate.Error);
   });
 });
 

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -1460,6 +1460,25 @@ describe("DateTime", () => {
     expect(dt.jd).toBe(2299156);
     expect(dt.start).toBe(-Infinity);
     expect(dt.newStart(RubyDate.ITALY).toS()).toBe("1582-09-30T06:30:00+02:00");
+
+    // `m_julian_p` (date_core.c:1683-1703) reads the STORED UTC day, not the
+    // local one `jd` answers, so an offset that carries the date across the
+    // reform flips the answer while `jd` is the same on both.
+    //   DateTime.new(1582, 10, 15, 0, 30, 0, "+02:00").jd       #=> 2299161
+    //   DateTime.new(1582, 10, 15, 0, 30, 0, "+02:00").julian?  #=> true
+    //   DateTime.new(1582, 10, 15, 23, 30, 0, "-02:00").jd      #=> 2299161
+    //   DateTime.new(1582, 10, 15, 23, 30, 0, "-02:00").julian? #=> false
+    // `dup_obj` copies the receiver's own class, so the aliases answer a
+    // DateTime with its time of day intact:
+    //   DateTime.new(1582, 10, 10, 6, 30, 0, "+02:00", Date::GREGORIAN).italy.to_s
+    //     #=> "1582-09-30T06:30:00+02:00"
+    expect(dt.italy()).toBeInstanceOf(RubyDateTime);
+    expect(dt.italy().toS()).toBe("1582-09-30T06:30:00+02:00");
+
+    const east = new RubyDateTime(1582, 10, 15, 0, 30, 0, "+02:00");
+    const west = new RubyDateTime(1582, 10, 15, 23, 30, 0, "-02:00");
+    expect([east.jd, west.jd]).toEqual([2299161, 2299161]);
+    expect([east.isJulian, west.isJulian]).toEqual([true, false]);
     // The `Temporal.ZonedDateTime` seat spells its own zone in brackets after
     // the offset, which the gem's `to_s` has no counterpart for.
     expect(

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -2934,16 +2934,65 @@ const UNIX_EPOCH_IN_CJD = 2440588;
 const ITALY = 2299161;
 
 /**
+ * @internal `date_core.c`'s `ENGLAND` (`date_core.c:187`), the Julian day of
+ * 1752-09-14 — the day the reform took effect in England and its colonies.
+ */
+const ENGLAND = 2361222;
+
+/**
+ * @internal `date_core.c`'s `JULIAN` (`date_core.c:188`), `positive_inf`. Every
+ * `sg` comparison is `jd < sg`, so an infinite start makes every day fall on
+ * the one side of the reform: under this one the date is read as Julian
+ * whatever it names.
+ */
+const JULIAN = Infinity;
+
+/** @internal `date_core.c`'s `GREGORIAN` (`date_core.c:189`), `negative_inf`. */
+const GREGORIAN = -Infinity;
+
+/**
  * @internal `date_core.c`'s `DEFAULT_SG` (`date_core.c:190`), the reform start
- * every constructor takes when none is passed. The `start` argument itself
- * (`Date::JULIAN` / `Date::GREGORIAN`, `date_core.c:188-189`) is not a
- * parameter here: `SimpleDateData` carries `sg` so that one process can hold
- * dates under several reforms at once, and every trails entry point takes this
- * one. The conversions below are the C's, over the C's own Julian-day state, so
- * every civil date `Date::ITALY` names — including the Julian-only ones such as
- * 1500-02-29 — is buildable and answers MRI's `wday`, `yday` and epoch.
+ * every constructor takes when none is passed. `SimpleDateData` carries `sg` so
+ * that one process can hold dates under several reforms at once, which is what
+ * the trailing `start` argument selects. The conversions below are the C's,
+ * over the C's own Julian-day state, so every civil date `Date::ITALY` names —
+ * including the Julian-only ones such as 1500-02-29 — is buildable and answers
+ * MRI's `wday`, `yday` and epoch.
  */
 const DEFAULT_SG = ITALY;
+
+/**
+ * @internal `date_core.c`'s `REFORM_BEGIN_JD` / `REFORM_END_JD`
+ * (`date_core.c:209-210`), the window a finite `start` has to fall in — ns
+ * 1582-01-01 through os 1930-12-31, the span over which the reform was actually
+ * adopted somewhere.
+ */
+const REFORM_BEGIN_JD = 2298874;
+const REFORM_END_JD = 2426355;
+
+/**
+ * @internal `date_core.c` `c_valid_start_p` (`date_core.c:888-898`): an
+ * infinite start is `Date::JULIAN` or `Date::GREGORIAN` and always valid, a
+ * `NaN` never is, and a finite one has to name a day inside the reform window.
+ */
+function cValidStartP(sg: number): boolean {
+  if (Number.isNaN(sg)) return false;
+  if (!Number.isFinite(sg)) return true;
+  if (sg < REFORM_BEGIN_JD || sg > REFORM_END_JD) return false;
+  return true;
+}
+
+/**
+ * @internal `date_core.c`'s `val2sg` macro (`date_core.c:3320-3327`), the macro
+ * every user-facing `start` argument is read through — the `start` counterpart
+ * of {@link val2off}: whatever {@link cValidStartP} rejects becomes
+ * {@link DEFAULT_SG}. The C's `rb_warning("invalid start is ignored")` is a
+ * `$VERBOSE`-only warning with no analogue here, as `val2off`'s is.
+ */
+function val2sg(vsg: number): number {
+  if (!cValidStartP(vsg)) return DEFAULT_SG;
+  return vsg;
+}
 
 /** @internal `date_core.c`'s seconds constants (`date_core.c:194-196`). */
 const MINUTE_IN_SECONDS = 60;
@@ -3147,8 +3196,8 @@ function cValidCivilP(y: number, m: number, d: number, sg = DEFAULT_SG): number 
  *
  * Not exported: it is the seam between the C's Julian day and the substrate.
  */
-function plainDateFromJd(rjd: number): Temporal.PlainDate {
-  const [y, m, d] = cJdToCivil(rjd);
+function plainDateFromJd(rjd: number, sg = DEFAULT_SG): Temporal.PlainDate {
+  const [y, m, d] = cJdToCivil(rjd, sg);
   try {
     return Temporal.PlainDate.from({ year: y, month: m, day: d }, { overflow: "reject" });
   } catch {
@@ -3351,19 +3400,19 @@ function cJdToOrdinal(jd: number, sg = DEFAULT_SG): [ry: number, rd: number] {
  * from Monday: the year's first day floored back to the Monday on or before it,
  * then `w` weeks and `d` days on.
  */
-function cCommercialToJd(y: number, w: number, d: number): number {
-  const rjd2 = cFindFdoy(y)! + 3;
+function cCommercialToJd(y: number, w: number, d: number, sg = DEFAULT_SG): number {
+  const rjd2 = cFindFdoy(y, sg)! + 3;
   return rjd2 - mod(rjd2, 7) + 7 * (w - 1) + (d - 1);
 }
 
 /** @internal `date_core.c` `c_jd_to_commercial` (`date_core.c:590-609`), the inverse of {@link cCommercialToJd}. */
-function cJdToCommercial(jd: number): [ry: number, rw: number, rd: number] {
-  const [a] = cJdToCivil(jd - 3);
+function cJdToCommercial(jd: number, sg = DEFAULT_SG): [ry: number, rw: number, rd: number] {
+  const [a] = cJdToCivil(jd - 3, sg);
   let ry: number;
-  let c2 = cCommercialToJd(a + 1, 1, 1);
+  let c2 = cCommercialToJd(a + 1, 1, 1, sg);
   if (jd >= c2) ry = a + 1;
   else {
-    c2 = cCommercialToJd(a, 1, 1);
+    c2 = cCommercialToJd(a, 1, 1, sg);
     ry = a;
   }
   const rw = 1 + div(jd - c2, 7);
@@ -3378,15 +3427,15 @@ function cJdToCommercial(jd: number): [ry: number, rw: number, rd: number] {
  * of the commercial year before rebuilding the date and rejecting it if the
  * round-trip does not name the same `y`/`w`/`d` back.
  */
-function cValidCommercialP(y: number, w: number, d: number): number | null {
+function cValidCommercialP(y: number, w: number, d: number, sg = DEFAULT_SG): number | null {
   if (d < 0) d += 8;
   if (w < 0) {
-    const c2 = cJdToCommercial(cCommercialToJd(y + 1, 1, 1) + w * 7);
+    const c2 = cJdToCommercial(cCommercialToJd(y + 1, 1, 1, sg) + w * 7, sg);
     if (c2[0] !== y) return null;
     w = c2[1];
   }
-  const rjd = cCommercialToJd(y, w, d);
-  const [ry, rw, rd] = cJdToCommercial(rjd);
+  const rjd = cCommercialToJd(y, w, d, sg);
+  const [ry, rw, rd] = cJdToCommercial(rjd, sg);
   if (y !== ry || w !== rw || d !== rd) return null;
   return rjd;
 }
@@ -3399,15 +3448,19 @@ function cValidCommercialP(y: number, w: number, d: number): number | null {
  * partial week before the year's first one. Week `0` is therefore empty in a
  * year whose 1 January is itself an `f`-day: there, 1 January opens week `1`.
  */
-function cWeeknumToJd(y: number, w: number, d: number, f: number): number {
-  const rjd2 = cFindFdoy(y)! + 6;
+function cWeeknumToJd(y: number, w: number, d: number, f: number, sg = DEFAULT_SG): number {
+  const rjd2 = cFindFdoy(y, sg)! + 6;
   return rjd2 - mod(rjd2 - f + 1, 7) - 7 + 7 * w + d;
 }
 
 /** @internal `date_core.c` `c_jd_to_weeknum` (`date_core.c:621-634`), the inverse of {@link cWeeknumToJd}. */
-function cJdToWeeknum(jd: number, f: number): [ry: number, rw: number, rd: number] {
-  const [ry] = cJdToCivil(jd);
-  const rjd = cFindFdoy(ry)! + 6;
+function cJdToWeeknum(
+  jd: number,
+  f: number,
+  sg = DEFAULT_SG,
+): [ry: number, rw: number, rd: number] {
+  const [ry] = cJdToCivil(jd, sg);
+  const rjd = cFindFdoy(ry, sg)! + 6;
   const j = jd - (rjd - mod(rjd - f + 1, 7)) + 7;
   return [ry, div(j, 7), mod(j, 7)];
 }
@@ -3419,15 +3472,21 @@ function cJdToWeeknum(jd: number, f: number): [ry: number, rw: number, rd: numbe
  * rather than a `1`..`7` one, so a negative day takes `7` where the commercial
  * one takes `8`.
  */
-function cValidWeeknumP(y: number, w: number, d: number, f: number): number | null {
+function cValidWeeknumP(
+  y: number,
+  w: number,
+  d: number,
+  f: number,
+  sg = DEFAULT_SG,
+): number | null {
   if (d < 0) d += 7;
   if (w < 0) {
-    const w2 = cJdToWeeknum(cWeeknumToJd(y + 1, 1, f, f) + w * 7, f);
+    const w2 = cJdToWeeknum(cWeeknumToJd(y + 1, 1, f, f, sg) + w * 7, f, sg);
     if (w2[0] !== y) return null;
     w = w2[1];
   }
-  const rjd = cWeeknumToJd(y, w, d, f);
-  const [ry, rw, rd] = cJdToWeeknum(rjd, f);
+  const rjd = cWeeknumToJd(y, w, d, f, sg);
+  const [ry, rw, rd] = cJdToWeeknum(rjd, f, sg);
   if (y !== ry || w !== rw || d !== rd) return null;
   return rjd;
 }
@@ -3446,8 +3505,8 @@ function rtValidJdP(jd: number): number {
  * `c_valid_ordinal_p` (`date_core.c:747-768`), which answers `nil` rather than
  * raising so its caller can fall through to the next kind of date.
  */
-function rtValidOrdinalP(y: number, d: number): number | null {
-  return cValidOrdinalP(y, d);
+function rtValidOrdinalP(y: number, d: number, sg = DEFAULT_SG): number | null {
+  return cValidOrdinalP(y, d, sg);
 }
 
 /**
@@ -3455,8 +3514,8 @@ function rtValidOrdinalP(y: number, d: number): number | null {
  * `c_valid_civil_p` (`date_core.c:766-790`), which answers `nil` rather than
  * raising so its caller can fall through to the next kind of date.
  */
-function rtValidCivilP(y: number, m: number, d: number): number | null {
-  return cValidCivilP(y, m, d);
+function rtValidCivilP(y: number, m: number, d: number, sg = DEFAULT_SG): number | null {
+  return cValidCivilP(y, m, d, sg);
 }
 
 /**
@@ -3479,23 +3538,22 @@ function rtValidCivilP(y: number, m: number, d: number): number | null {
  * (`date_core.c:4283-4300`) is what turns that `nil` into
  * `Date::Error, "invalid date"`.
  *
- * Ruby threads the calendar-reform start `sg` through every arm; the
- * `Temporal.PlainDate` substrate carries no reform, so the parameter is gone
- * and each arm answers the date itself rather than a Julian day.
+ * `sg` is the calendar-reform start every arm reads its date under, as Ruby
+ * threads it.
  */
-function rtValidDateFragsP(parts: DateParts): number | null {
+function rtValidDateFragsP(parts: DateParts, sg = DEFAULT_SG): number | null {
   if (parts.jd !== undefined) {
     const d = rtValidJdP(parts.jd);
     if (d !== null) return d;
   }
 
   if (parts.yday !== undefined && parts.year !== undefined) {
-    const d = rtValidOrdinalP(parts.year, parts.yday);
+    const d = rtValidOrdinalP(parts.year, parts.yday, sg);
     if (d !== null) return d;
   }
 
   if (parts.mday !== undefined && parts.mon !== undefined && parts.year !== undefined) {
-    const d = rtValidCivilP(parts.year, parts.mon, parts.mday);
+    const d = rtValidCivilP(parts.year, parts.mon, parts.mday, sg);
     if (d !== null) return d;
   }
 
@@ -3506,7 +3564,7 @@ function rtValidDateFragsP(parts: DateParts): number | null {
       if (wday !== undefined) if (wday === 0) wday = 7;
     }
     if (wday !== undefined && parts.cweek !== undefined && parts.cwyear !== undefined) {
-      const d = cValidCommercialP(parts.cwyear, parts.cweek, wday);
+      const d = cValidCommercialP(parts.cwyear, parts.cweek, wday, sg);
       if (d !== null) return d;
     }
   }
@@ -3518,7 +3576,7 @@ function rtValidDateFragsP(parts: DateParts): number | null {
       if (wday !== undefined) if (wday === 7) wday = 0;
     }
     if (wday !== undefined && parts.wnum0 !== undefined && parts.year !== undefined) {
-      const d = cValidWeeknumP(parts.year, parts.wnum0, wday, 0);
+      const d = cValidWeeknumP(parts.year, parts.wnum0, wday, 0, sg);
       if (d !== null) return d;
     }
   }
@@ -3529,7 +3587,7 @@ function rtValidDateFragsP(parts: DateParts): number | null {
     if (wday !== undefined) wday = mod(wday - 1, 7);
 
     if (wday !== undefined && parts.wnum1 !== undefined && parts.year !== undefined) {
-      const d = cValidWeeknumP(parts.year, parts.wnum1, wday, 1);
+      const d = cValidWeeknumP(parts.year, parts.wnum1, wday, 1, sg);
       if (d !== null) return d;
     }
   }
@@ -3544,7 +3602,7 @@ function rtValidDateFragsP(parts: DateParts): number | null {
  * `:mon` and a `:mday` — goes straight to {@link rtValidCivilP}, skipping both
  * {@link rtRewriteFrags} and {@link completeFrags}.
  */
-export function dNewByFrags(hash: DateParts | null): Date {
+export function dNewByFrags(hash: DateParts | null, sg = DEFAULT_SG): Date {
   let jd: number | null;
 
   if (hash === null) throw new DateError("invalid date");
@@ -3556,19 +3614,19 @@ export function dNewByFrags(hash: DateParts | null): Date {
     hash.mon !== undefined &&
     hash.mday !== undefined
   ) {
-    jd = rtValidCivilP(hash.year, hash.mon, hash.mday);
+    jd = rtValidCivilP(hash.year, hash.mon, hash.mday, sg);
   } else {
     hash = rtRewriteFrags(hash);
     completeFrags(hash);
     try {
-      jd = rtValidDateFragsP(hash);
+      jd = rtValidDateFragsP(hash, sg);
     } catch {
       jd = null;
     }
   }
 
   if (jd === null) throw new DateError("invalid date");
-  return new Date(SEAT, jd);
+  return new Date(SEAT, jd, sg);
 }
 
 /**
@@ -3616,7 +3674,7 @@ function of2str(of: number): string {
  * `DateTime.parse("2008-03-01T24:00:00")` is 2008-03-02T00:00:00. That now
  * falls out of the representation rather than being normalized here.
  */
-export function dtNewByFrags(hash: DateParts | null): DateTime {
+export function dtNewByFrags(hash: DateParts | null, sg = DEFAULT_SG): DateTime {
   let jd: number | null;
 
   if (hash === null) throw new DateError("invalid date");
@@ -3628,7 +3686,7 @@ export function dtNewByFrags(hash: DateParts | null): DateTime {
     hash.mon !== undefined &&
     hash.mday !== undefined
   ) {
-    jd = rtValidCivilP(hash.year, hash.mon, hash.mday);
+    jd = rtValidCivilP(hash.year, hash.mon, hash.mday, sg);
 
     if (hash.hour === undefined) hash.hour = 0;
     if (hash.min === undefined) hash.min = 0;
@@ -3638,7 +3696,7 @@ export function dtNewByFrags(hash: DateParts | null): DateTime {
     hash = rtRewriteFrags(hash);
     completeFrags(hash);
     try {
-      jd = rtValidDateFragsP(hash);
+      jd = rtValidDateFragsP(hash, sg);
     } catch {
       jd = null;
     }
@@ -3665,7 +3723,7 @@ export function dtNewByFrags(hash: DateParts | null): DateTime {
   let of = to == null ? 0 : to instanceof Rational ? to.toI() : Math.trunc(to);
   if (of < -DAY_IN_SECONDS || of > DAY_IN_SECONDS) of = 0;
 
-  return new DateTime(SEAT, jdLocalToUtc(jd, df, of), dfLocalToUtc(df, of), sf, of);
+  return new DateTime(SEAT, jdLocalToUtc(jd, df, of), dfLocalToUtc(df, of), sf, of, sg);
 }
 
 /**
@@ -3775,6 +3833,30 @@ export class Date {
   static Error = DateError;
 
   /**
+   * Ruby `Date::ITALY` (ruby/date, `date_core.c:186`), the Julian day of
+   * 1582-10-15 and the default `start`.
+   */
+  static ITALY = ITALY;
+
+  /**
+   * Ruby `Date::ENGLAND` (ruby/date, `date_core.c:187`), the Julian day of
+   * 1752-09-14.
+   */
+  static ENGLAND = ENGLAND;
+
+  /**
+   * Ruby `Date::JULIAN` (ruby/date, `date_core.c:188`), `Float::INFINITY` — a
+   * `start` under which every date is read as Julian.
+   */
+  static JULIAN = JULIAN;
+
+  /**
+   * Ruby `Date::GREGORIAN` (ruby/date, `date_core.c:189`), `-Float::INFINITY` —
+   * a `start` under which every date is read as (proleptic) Gregorian.
+   */
+  static GREGORIAN = GREGORIAN;
+
+  /**
    * @internal The whole of the state, where ruby/date's `SimpleDateData`
    * (`date_core.c:203-213`) carries a Julian day, a civil triple, the
    * calendar-reform start `sg` both are read under, and a `flags` word saying
@@ -3794,11 +3876,24 @@ export class Date {
    * reform's readings rather than proleptic ones, and `Date.new(1500, 2, 29)`
    * builds, as MRI's does.
    *
-   * The `start` ARGUMENT is what has no bearer — `#start`, `#julian?` and
-   * `#new_start` are absent with it, and every conversion below takes the one
-   * `sg` MRI defaults to. RFC 0088 `date-state-onto-temporal-plaindate`.
+   * The `start` ARGUMENT is {@link #sg} below: every conversion is read under
+   * it, and {@link Date#start}, {@link Date#isJulian} and
+   * {@link Date#newStart} answer off it.
    */
   readonly #jd: number;
+
+  /**
+   * @internal `SimpleDateData`'s `sg` (`date_core.c:203-213`), the
+   * calendar-reform start the date is read under — the `start` argument every
+   * constructor takes, {@link DEFAULT_SG} when none is passed.
+   *
+   * The C's `s_virtual_sg` (`date_core.c:1110-1120`) reads it back as
+   * `positive_inf`/`negative_inf` for a date outside the `Fixnum` Julian-day
+   * range, on the `nth` field that carries the overflow. There is no `nth`
+   * here — the Julian day is one JS number — so the virtual reading and the
+   * stored one never part company, and this field stands for both.
+   */
+  readonly #sg: number;
 
   /**
    * @internal `SimpleDateData`'s civil fields (`date_core.c:203-213`), which
@@ -3812,7 +3907,7 @@ export class Date {
    * `date_core.c` `date_s_civil`), which raises `Date::Error` on a civil date
    * `c_valid_civil_p` rejects.
    */
-  constructor(year?: number, month?: number, day?: number);
+  constructor(year?: number, month?: number, day?: number, start?: number);
   /**
    * @internal `date_core.c` `d_simple_new_internal` (`date_core.c:3036-3050`),
    * which writes an already-resolved day straight into a fresh
@@ -3821,15 +3916,18 @@ export class Date {
    * has already established the date is buildable. {@link SEAT} is the brand
    * that selects it.
    */
-  constructor(seat: typeof SEAT, rjd: number);
-  constructor(year: number | typeof SEAT = -4712, month = 1, day = 1) {
+  constructor(seat: typeof SEAT, rjd: number, sg: number);
+  constructor(year: number | typeof SEAT = -4712, month = 1, day = 1, start = DEFAULT_SG) {
     if (typeof year === "symbol") {
       this.#jd = month;
+      this.#sg = day;
       return;
     }
-    const r = cValidCivilP(year, month, day);
+    const sg = val2sg(start);
+    const r = cValidCivilP(year, month, day, sg);
     if (r === null) throw new DateError("invalid date");
     this.#jd = r;
+    this.#sg = sg;
   }
 
   /**
@@ -3844,7 +3942,7 @@ export class Date {
    * on `simple_dat_p`/`complex_dat_p` is the one TS makes on the receiver.
    */
   #getCCivil(): [ry: number, rm: number, rdom: number] {
-    return (this.#civil ??= cJdToCivil(this.jd));
+    return (this.#civil ??= cJdToCivil(this.jd, this.#sg));
   }
 
   /**
@@ -3854,8 +3952,8 @@ export class Date {
    * leaves the civil date to `get_s_civil`; there is one representation here,
    * so the conversion happens at the call.
    */
-  static jd(jd = 0): Temporal.PlainDate {
-    return new Date(SEAT, jd).toDate();
+  static jd(jd = 0, start = DEFAULT_SG): Temporal.PlainDate {
+    return new Date(SEAT, jd, val2sg(start)).toDate();
   }
 
   /**
@@ -3864,10 +3962,11 @@ export class Date {
    * `c_valid_ordinal_p` rejects. A negative `yday` counts back from the last day
    * of the year, so `Date.ordinal(2001, -1)` is 2001-12-31.
    */
-  static ordinal(year = -4712, yday = 1): Temporal.PlainDate {
-    const r = cValidOrdinalP(year, yday);
+  static ordinal(year = -4712, yday = 1, start = DEFAULT_SG): Temporal.PlainDate {
+    const sg = val2sg(start);
+    const r = cValidOrdinalP(year, yday, sg);
     if (r === null) throw new DateError("invalid date");
-    return new Date(SEAT, r).toDate();
+    return new Date(SEAT, r, sg).toDate();
   }
 
   /**
@@ -3877,8 +3976,8 @@ export class Date {
    * counts back from December and a negative `mday` from the month's end, so
    * `Date.civil(2001, -1, -1)` is 2001-12-31.
    */
-  static civil(year = -4712, month = 1, mday = 1): Temporal.PlainDate {
-    return new Date(year, month, mday).toDate();
+  static civil(year = -4712, month = 1, mday = 1, start = DEFAULT_SG): Temporal.PlainDate {
+    return new Date(year, month, mday, start).toDate();
   }
 
   /**
@@ -3888,10 +3987,11 @@ export class Date {
    * `cwday` counts back from Sunday and a negative `cweek` back from the end of
    * the commercial year, so `Date.commercial(2001, -1, -1)` is 2001-12-30.
    */
-  static commercial(cwyear = -4712, cweek = 1, cwday = 1): Temporal.PlainDate {
-    const r = cValidCommercialP(cwyear, cweek, cwday);
+  static commercial(cwyear = -4712, cweek = 1, cwday = 1, start = DEFAULT_SG): Temporal.PlainDate {
+    const sg = val2sg(start);
+    const r = cValidCommercialP(cwyear, cweek, cwday, sg);
     if (r === null) throw new DateError("invalid date");
-    return new Date(SEAT, r).toDate();
+    return new Date(SEAT, r, sg).toDate();
   }
 
   /**
@@ -3913,12 +4013,10 @@ export class Date {
   /**
    * Ruby `Date.strptime(string = '-4712-01-01', format = '%F', start =
    * Date::ITALY)` (`date_core.c` `date_s_strptime`, `date_core.c:4424-4447`),
-   * which is `Date._strptime` followed by `d_new_by_frags`. `start` is the
-   * calendar reform, which `Temporal.PlainDate` has no bearer for, so it is not
-   * a parameter here.
+   * which is `Date._strptime` followed by `d_new_by_frags`.
    */
-  static strptime(str = JULIAN_EPOCH_DATE, fmt = "%F"): Temporal.PlainDate {
-    return dNewByFrags(Date._strptime(str, fmt)).toDate();
+  static strptime(str = JULIAN_EPOCH_DATE, fmt = "%F", start = DEFAULT_SG): Temporal.PlainDate {
+    return dNewByFrags(Date._strptime(str, fmt), val2sg(start)).toDate();
   }
 
   /**
@@ -4005,8 +4103,8 @@ export class Date {
    * A string that named only a time of day answers no arm of
    * {@link rtValidDateFragsP} and raises.
    */
-  static parse(str: string, comp = true): Temporal.PlainDate {
-    return dNewByFrags(Date._parse(str, comp)).toDate();
+  static parse(str: string, comp = true, start = DEFAULT_SG): Temporal.PlainDate {
+    return dNewByFrags(Date._parse(str, comp), val2sg(start)).toDate();
   }
 
   get year(): number {
@@ -4058,8 +4156,97 @@ export class Date {
    * year, as the Julian leap day before it makes it in MRI.
    */
   get yday(): number {
-    const [, rd] = cJdToOrdinal(this.jd);
+    const [, rd] = cJdToOrdinal(this.jd, this.#sg);
     return rd;
+  }
+
+  /**
+   * Ruby `Date#julian?` (ruby/date, `date_core.c` `d_lite_julian_p`,
+   * `date_core.c:5679-5684`, over `m_julian_p`, `date_core.c:1683-1703`), true
+   * when the date falls before its own calendar reform:
+   * `(Date.new(1582, 10, 15) - 1).julian?` is true and
+   * `Date.new(1582, 10, 15).julian?` is false.
+   *
+   * The C's `isinf` arm is what makes `Date::JULIAN` julian everywhere and
+   * `Date::GREGORIAN` julian nowhere; the `jd < sg` below carries both directly,
+   * since `Infinity` and `-Infinity` compare that way — but the C tests the
+   * infinity explicitly, and so does this, because its answer for
+   * `Date::GREGORIAN` is `sg == positive_inf`, not the comparison.
+   */
+  get isJulian(): boolean {
+    const jd = this.jd;
+    const sg = this.#sg;
+    if (!Number.isFinite(sg)) return sg === JULIAN;
+    return jd < sg;
+  }
+
+  /**
+   * Ruby `Date#gregorian?` (ruby/date, `date_core.c` `d_lite_gregorian_p`,
+   * `date_core.c:5697-5702`, over `m_gregorian_p`, `date_core.c:1705-1708`).
+   */
+  get isGregorian(): boolean {
+    return !this.isJulian;
+  }
+
+  /**
+   * Ruby `Date#start` (ruby/date, `date_core.c` `d_lite_start`,
+   * `date_core.c:5751-5756`), the calendar-reform Julian day the date is read
+   * under: `Date.new(2001, 2, 3, Date::ENGLAND).start` is `2361222.0` and
+   * `Date.new(2001, 2, 3, Date::GREGORIAN).start` is `-Infinity`. The C answers
+   * a Double, which is a JS number.
+   */
+  get start(): number {
+    return this.#sg;
+  }
+
+  /**
+   * Ruby `Date#new_start(start = Date::ITALY)` (ruby/date, `date_core.c`
+   * `d_lite_new_start`, `date_core.c:5826-5839`), a copy of the receiver read
+   * under a different reform — the Julian day is kept and the civil triple
+   * decoded again, which is what makes `Date.new(2000, 2, 3).new_start(Date::JULIAN)`
+   * 2000-01-21.
+   *
+   * The C reaches its file-static `dup_obj_with_new_start`
+   * (`date_core.c:5801-5810`) from here and from `italy`/`england`/`julian`/
+   * `gregorian` alike. TS has no `dup_obj` — a copy has to name the class it is
+   * making — so this method IS that seam: `DateTime` overrides it to keep its
+   * time of day, and the four below call it rather than a private helper none
+   * of them could override.
+   */
+  newStart(start = DEFAULT_SG): Date {
+    return new Date(SEAT, this.jd, val2sg(start));
+  }
+
+  /**
+   * Ruby `Date#italy` (ruby/date, `date_core.c` `d_lite_italy`,
+   * `date_core.c:5848-5852`), `new_start` with `Date::ITALY`.
+   */
+  italy(): Date {
+    return this.newStart(ITALY);
+  }
+
+  /**
+   * Ruby `Date#england` (ruby/date, `date_core.c` `d_lite_england`,
+   * `date_core.c:5860-5864`), `new_start` with `Date::ENGLAND`.
+   */
+  england(): Date {
+    return this.newStart(ENGLAND);
+  }
+
+  /**
+   * Ruby `Date#julian` (ruby/date, `date_core.c` `d_lite_julian`,
+   * `date_core.c:5872-5876`), `new_start` with `Date::JULIAN`.
+   */
+  julian(): Date {
+    return this.newStart(JULIAN);
+  }
+
+  /**
+   * Ruby `Date#gregorian` (ruby/date, `date_core.c` `d_lite_gregorian`,
+   * `date_core.c:5884-5888`), `new_start` with `Date::GREGORIAN`.
+   */
+  gregorian(): Date {
+    return this.newStart(GREGORIAN);
   }
 
   /**
@@ -4091,7 +4278,7 @@ export class Date {
    * The exported {@link dNewByFrags} / {@link dtNewByFrags} answer it directly.
    */
   toDate(): Temporal.PlainDate {
-    return plainDateFromJd(this.jd);
+    return plainDateFromJd(this.jd, this.#sg);
   }
 
   /** Ruby `Date#to_s` (ruby/date, `date_core.c` `d_lite_to_s`). */
@@ -4146,8 +4333,13 @@ export class Date {
  * Both `Date.parse`/`Date.strptime` and `DateTime.parse`/`DateTime.strptime`
  * therefore declare exactly what they answer.
  */
-const DateWithoutParseStatics: (new (year?: number, month?: number, day?: number) => Date) &
-  (new (seat: typeof SEAT, rjd: number) => Date) &
+const DateWithoutParseStatics: (new (
+  year?: number,
+  month?: number,
+  day?: number,
+  start?: number,
+) => Date) &
+  (new (seat: typeof SEAT, rjd: number, sg: number) => Date) &
   Omit<typeof Date, "parse" | "strptime"> = Date;
 
 /**
@@ -4260,6 +4452,7 @@ export class DateTime extends DateWithoutParseStatics {
     minute?: number | Rational,
     second?: number | Rational,
     offset?: number | Rational | string,
+    start?: number,
   );
   /**
    * @internal `date_core.c` `d_complex_new_internal` (`date_core.c:3055-3071`),
@@ -4270,7 +4463,7 @@ export class DateTime extends DateWithoutParseStatics {
    * validate. The arguments are `d_complex_new_internal`'s own `rjd`, `df`,
    * `sf` and `of`, in that order, behind the {@link SEAT} brand.
    */
-  constructor(seat: typeof SEAT, rjd: number, df: number, sf: Rational, of: number);
+  constructor(seat: typeof SEAT, rjd: number, df: number, sf: Rational, of: number, sg: number);
   constructor(
     year: number | typeof SEAT,
     month?: number,
@@ -4279,13 +4472,14 @@ export class DateTime extends DateWithoutParseStatics {
     minute?: number | Rational,
     second?: number | Rational,
     offset?: number | Rational | string,
+    start = DEFAULT_SG,
   ) {
     if (typeof year === "symbol") {
       const rjd = month as number;
       const df = day as number;
       const sf = hour as Rational;
       const of = minute as number;
-      super(SEAT, jdUtcToLocal(rjd, df, of));
+      super(SEAT, jdUtcToLocal(rjd, df, of), second as number);
       this.#jd = rjd;
       this.#df = df;
       this.#sf = sf;
@@ -4310,8 +4504,9 @@ export class DateTime extends DateWithoutParseStatics {
     if (hFr !== 0) fr2 = hFr;
     if (dFr !== 0) fr2 = dFr;
     const rof = offset === undefined ? 0 : val2off(offset);
-    super(year, month ?? 1, d);
-    const rjd = cValidCivilP(year, month ?? 1, d);
+    const sg = val2sg(start);
+    super(year, month ?? 1, d, sg);
+    const rjd = cValidCivilP(year, month ?? 1, d, sg);
     if (rjd === null) throw new DateError("invalid date");
     const rt = cValidTimeP(h, min, s);
     if (rt === null) throw new DateError("invalid date");
@@ -4343,8 +4538,12 @@ export class DateTime extends DateWithoutParseStatics {
    * `datetime_s_parse` → `dt_new_by_frags`), which is `Date.parse`'s
    * `Date._parse` followed by the DateTime-shaped build.
    */
-  static parse(str: string, comp = true): Temporal.PlainDateTime | Temporal.ZonedDateTime {
-    return dtNewByFrags(Date._parse(str, comp)).toDatetime();
+  static parse(
+    str: string,
+    comp = true,
+    start = DEFAULT_SG,
+  ): Temporal.PlainDateTime | Temporal.ZonedDateTime {
+    return dtNewByFrags(Date._parse(str, comp), val2sg(start)).toDatetime();
   }
 
   /**
@@ -4362,15 +4561,14 @@ export class DateTime extends DateWithoutParseStatics {
    * '%FT%T%z', start = Date::ITALY)` (ruby/date, `date_core.c`
    * `datetime_s_strptime`, `date_core.c:8368-8392`), which is `Date._strptime`
    * followed by `dt_new_by_frags` — the DateTime-shaped build, so unlike
-   * `Date.strptime` it keeps the time of day the frags carry. `start` is the
-   * calendar reform, which `Temporal.PlainDate` has no bearer for, so it is not
-   * a parameter here.
+   * `Date.strptime` it keeps the time of day the frags carry.
    */
   static strptime(
     str = JULIAN_EPOCH_DATETIME,
     fmt = "%FT%T%z",
+    start = DEFAULT_SG,
   ): Temporal.PlainDateTime | Temporal.ZonedDateTime {
-    return dtNewByFrags(Date._strptime(str, fmt)).toDatetime();
+    return dtNewByFrags(Date._strptime(str, fmt), val2sg(start)).toDatetime();
   }
 
   /**
@@ -4403,13 +4601,24 @@ export class DateTime extends DateWithoutParseStatics {
   }
 
   /**
+   * Ruby has no `DateTime#new_start`: `d_lite_new_start` is inherited, and its
+   * `dup_obj` (`date_core.c:5801-5810`) copies the receiver's own class and
+   * `ComplexDateData` — day-fraction, sub-second and offset included — before
+   * `set_sg` writes the new reform in. TS has no `dup_obj`, so the copy is made
+   * here, where the fields are in scope; see {@link Date#newStart}.
+   */
+  override newStart(start = DEFAULT_SG): DateTime {
+    return new DateTime(SEAT, this.#jd, this.#df, this.#sf, this.#of, val2sg(start));
+  }
+
+  /**
    * Ruby `DateTime#to_date` (ruby/date, `date_core.c` `datetime_to_date`,
    * `date_core.c:9069-9095`), the calendar day alone: the C builds a fresh
    * `Date` on `m_local_jd` — the LOCAL day, which is where a `24:00:00` time of
    * day has already rolled the date on — and this is that `Date`'s seat.
    */
   override toDate(): Temporal.PlainDate {
-    return new Date(SEAT, this.#mLocalJd()).toDate();
+    return new Date(SEAT, this.#mLocalJd(), this.start).toDate();
   }
 
   /**

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -3067,6 +3067,35 @@ function timeToDf(h: number, min: number, s: number): number {
 }
 
 /**
+ * @internal `date_core.c`'s `add_frac` macro (`date_core.c:3313-3317`), which
+ * every `DateTime` builder ends with: `d_lite_plus(ret, fr2)` when `fr2` is
+ * nonzero. `fr2` is carried in seconds here (see {@link num2intWithFrac}), so
+ * this is `d_lite_plus`'s `T_FLOAT` arm (`date_core.c:6064-6135`) inlined — the
+ * whole seconds go to `df`, carrying a day where they overflow one, and the
+ * remainder to `sf` in nanoseconds. The `T_RATIONAL` arm
+ * (`date_core.c:6174-6201`) is the `Rational` branch: its
+ * `sf = f_mul(t, INT2FIX(SECOND_IN_NANOSECONDS))` has no round in it, which is
+ * what keeps a fraction exact at any denominator. `fr2` is under a day by
+ * construction, so the C's `jd` term is `0` and its sign branch is never taken.
+ */
+function addFrac(
+  jd: number,
+  df: number,
+  fr2: number | Rational,
+): [jd: number, df: number, sf: Rational] {
+  df += fr2 instanceof Rational ? fr2.div(1) : Math.floor(fr2);
+  if (df >= DAY_IN_SECONDS) {
+    jd += 1;
+    df -= DAY_IN_SECONDS;
+  }
+  const sf =
+    fr2 instanceof Rational
+      ? (secToNs(fr2.mod(1)) as Rational)
+      : new Rational(Math.round(secToNs(fr2 - Math.floor(fr2)) as number), 1);
+  return [jd, df, sf];
+}
+
+/**
  * @internal `date_core.c` `df_to_time` (`date_core.c:950-957`); the `h`/`min`/`s`
  * out-parameters come back as the tuple.
  */
@@ -4337,8 +4366,10 @@ export class Date {
  * module-level functions (the trails mixin idiom) sidesteps the check: TS
  * compares the two static sides whatever shape the member takes.
  *
- * So `DateTime` extends `Date` under an alias whose STATIC side omits the two
- * members it re-declares, which is the only shape that removes the comparison
+ * So `DateTime` extends `Date` under an alias whose STATIC side omits the
+ * members it re-declares — `parse` and `strptime`, and the four builders
+ * `Init_date_core` gives `DateTime` singleton methods of its own
+ * (`date_core.c:9971-9975`) — which is the only shape that removes the comparison
  * without weakening either declaration. This is a type-level alias only — the
  * value is `Date` itself, so the runtime prototype chain, `instanceof`, and
  * every inherited static are unchanged, and the instance side is `Date` intact.
@@ -4352,7 +4383,7 @@ const DateWithoutParseStatics: (new (
   start?: number,
 ) => Date) &
   (new (seat: typeof SEAT, rjd: number, sg: number) => Date) &
-  Omit<typeof Date, "parse" | "strptime"> = Date;
+  Omit<typeof Date, "parse" | "strptime" | "jd" | "ordinal" | "civil" | "commercial"> = Date;
 
 /**
  * @noRailsEquivalent PERMANENT — the `ruby/date` gem's `::DateTime`, a `::Date`
@@ -4529,20 +4560,123 @@ export class DateTime extends DateWithoutParseStatics {
       fr2 = fr2 instanceof Rational ? fr2.add(DAY_IN_SECONDS) : fr2 + DAY_IN_SECONDS;
     }
     const localDf = timeToDf(rh, rmin, rs);
-    let jd = jdLocalToUtc(rjd, localDf, rof);
-    let df = dfLocalToUtc(localDf, rof);
-    df += fr2 instanceof Rational ? fr2.div(1) : Math.floor(fr2);
-    if (df >= DAY_IN_SECONDS) {
-      jd += 1;
-      df -= DAY_IN_SECONDS;
-    }
+    const [jd, df, sf] = addFrac(jdLocalToUtc(rjd, localDf, rof), dfLocalToUtc(localDf, rof), fr2);
     this.#jd = jd;
     this.#df = df;
-    this.#sf =
-      fr2 instanceof Rational
-        ? (secToNs(fr2.mod(1)) as Rational)
-        : new Rational(Math.round(secToNs(fr2 - Math.floor(fr2)) as number), 1);
+    this.#sf = sf;
     this.#of = rof;
+  }
+
+  /**
+   * Ruby `DateTime.jd(jd = 0, hour = 0, minute = 0, second = 0, offset = 0,
+   * start = Date::ITALY)` (ruby/date, `date_core.c` `datetime_s_jd`,
+   * `date_core.c:7654-7711`), a singleton method of its own rather than
+   * `Date.jd` inherited (`date_core.c:9971`): it takes a time of day and an
+   * offset, and answers a `DateTime`.
+   *
+   * The C's `switch (argc)` fall-through splits the second, minute and hour
+   * through {@link num2intWithFrac} under the `n` bounds `positive_inf`, `3`
+   * and `2` — only the LAST argument supplied may carry a fraction — and
+   * `canon24oc` (`date_core.c:3306-3312`) is the `rh === 24` fold that turns
+   * the day-ending `24:00:00` `c_valid_time_p` admits into midnight of the next
+   * day.
+   */
+  static jd(
+    jd = 0,
+    hour: number | Rational = 0,
+    minute: number | Rational = 0,
+    second: number | Rational = 0,
+    offset: number | Rational | string = 0,
+    start = DEFAULT_SG,
+  ): Temporal.PlainDateTime | Temporal.ZonedDateTime {
+    const sg = val2sg(start);
+    const rof = val2off(offset);
+    const [s, sFr] = num2intWithFrac(second, 1, false);
+    const [min, minFr] = num2intWithFrac(minute, MINUTE_IN_SECONDS, second !== 0);
+    const [h, hFr] = num2intWithFrac(hour, HOUR_IN_SECONDS, minute !== 0 || second !== 0);
+    let fr2: number | Rational = 0;
+    if (sFr !== 0) fr2 = sFr;
+    if (minFr !== 0) fr2 = minFr;
+    if (hFr !== 0) fr2 = hFr;
+
+    const rt = cValidTimeP(h, min, s);
+    if (rt === null) throw new DateError("invalid date");
+    let [rh] = rt;
+    const [, rmin, rs] = rt;
+    if (rh === 24) {
+      rh = 0;
+      fr2 = fr2 instanceof Rational ? fr2.add(DAY_IN_SECONDS) : fr2 + DAY_IN_SECONDS;
+    }
+    const localDf = timeToDf(rh, rmin, rs);
+    const [rjd2, df, sf] = addFrac(jdLocalToUtc(jd, localDf, rof), dfLocalToUtc(localDf, rof), fr2);
+    return new DateTime(SEAT, rjd2, df, sf, rof, sg).toDatetime();
+  }
+
+  /**
+   * Ruby `DateTime.ordinal(year = -4712, yday = 1, hour = 0, minute = 0,
+   * second = 0, offset = 0, start = Date::ITALY)` (ruby/date, `date_core.c`
+   * `datetime_s_ordinal`, `date_core.c:7726-7791`, `:9972`), which raises
+   * `Date::Error` on a date `c_valid_ordinal_p` rejects and then reads the time
+   * of day exactly as {@link DateTime.jd} does — one `n` bound higher, since
+   * `yday` precedes them.
+   */
+  static ordinal(
+    year = -4712,
+    yday = 1,
+    hour: number | Rational = 0,
+    minute: number | Rational = 0,
+    second: number | Rational = 0,
+    offset: number | Rational | string = 0,
+    start = DEFAULT_SG,
+  ): Temporal.PlainDateTime | Temporal.ZonedDateTime {
+    const sg = val2sg(start);
+    const rjd = cValidOrdinalP(year, yday, sg);
+    if (rjd === null) throw new DateError("invalid date");
+    return DateTime.jd(rjd, hour, minute, second, offset, sg);
+  }
+
+  /**
+   * Ruby `DateTime.civil(year = -4712, month = 1, mday = 1, hour = 0,
+   * minute = 0, second = 0, offset = 0, start = Date::ITALY)` (ruby/date,
+   * `date_core.c` `datetime_s_civil`, `date_core.c:7796-7800`, `:9973`), which
+   * is `datetime_initialize` itself — the same C function `DateTime.new` is
+   * defined over (`:9974`) — so it is the constructor here too, answering the
+   * `Temporal` seat as `Date.civil` does.
+   */
+  static civil(
+    year = -4712,
+    month = 1,
+    mday: number | Rational = 1,
+    hour?: number | Rational,
+    minute?: number | Rational,
+    second?: number | Rational,
+    offset?: number | Rational | string,
+    start = DEFAULT_SG,
+  ): Temporal.PlainDateTime | Temporal.ZonedDateTime {
+    return new DateTime(year, month, mday, hour, minute, second, offset, start).toDatetime();
+  }
+
+  /**
+   * Ruby `DateTime.commercial(cwyear = -4712, cweek = 1, cwday = 1, hour = 0,
+   * minute = 0, second = 0, offset = 0, start = Date::ITALY)` (ruby/date,
+   * `date_core.c` `datetime_s_commercial`, `date_core.c:7912-7980`, `:9975`),
+   * the week-date counterpart, which raises `Date::Error` on a date
+   * `c_valid_commercial_p` rejects.
+   */
+  static commercial(
+    cwyear = -4712,
+    cweek = 1,
+    cwday = 1,
+    hour: number | Rational = 0,
+    minute: number | Rational = 0,
+    second: number | Rational = 0,
+    offset: number | Rational | string = 0,
+    start = DEFAULT_SG,
+  ): Temporal.PlainDateTime | Temporal.ZonedDateTime {
+    const sg = val2sg(start);
+    const rjd = cValidCommercialP(cwyear, cweek, cwday, sg);
+    if (rjd === null) throw new DateError("invalid date");
+    return DateTime.jd(rjd, hour, minute, second, offset, sg);
   }
 
   /**

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -3147,15 +3147,11 @@ function cJdToWday(jd: number): number {
  * receiver: the two arms hold different days, and each class passes its own.
  *
  * The `isinf` arm is what makes `Date::JULIAN` julian everywhere and
- * `Date::GREGORIAN` julian nowhere. `Infinity` / `-Infinity` would carry both
- * through the `jd < sg` comparison below on their own, but the C tests the
- * infinity first, and its answer there is `sg == positive_inf`.
- *
- * `s_virtual_sg` (`date_core.c:1110-1120`) is the `sg` the C reads here: it
- * answers an infinity for a date whose Julian day overflowed a `Fixnum`, on the
- * `nth` field that carries the overflow. There is no `nth` here — the Julian
- * day is one JS number — so the virtual reading and the stored one never part
- * company.
+ * `Date::GREGORIAN` julian nowhere. The `sg` it reads is `s_virtual_sg`
+ * (`date_core.c:1110-1120`), which answers an infinity for a date whose Julian
+ * day overflowed a `Fixnum`, on the `nth` field that carries the overflow;
+ * there is no `nth` here — the Julian day is one JS number — so the virtual
+ * reading and the stored one never part company.
  */
 function mJulianP(jd: number, sg: number): boolean {
   if (!Number.isFinite(sg)) return sg === JULIAN;
@@ -3912,12 +3908,6 @@ export class Date {
    * @internal `SimpleDateData`'s `sg` (`date_core.c:203-213`), the
    * calendar-reform start the date is read under — the `start` argument every
    * constructor takes, {@link DEFAULT_SG} when none is passed.
-   *
-   * The C's `s_virtual_sg` (`date_core.c:1110-1120`) reads it back as
-   * `positive_inf`/`negative_inf` for a date outside the `Fixnum` Julian-day
-   * range, on the `nth` field that carries the overflow. There is no `nth`
-   * here — the Julian day is one JS number — so the virtual reading and the
-   * stored one never part company, and this field stands for both.
    */
   readonly #sg: number;
 
@@ -4236,7 +4226,7 @@ export class Date {
    * `DateTime`.
    */
   newStart(start = DEFAULT_SG): this {
-    return new Date(SEAT, this.jd, val2sg(start)) as this;
+    return new Date(SEAT, this.#jd, val2sg(start)) as this;
   }
 
   /**

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -4574,30 +4574,56 @@ export class DateTime extends DateWithoutParseStatics {
    * `Date.jd` inherited (`date_core.c:9971`): it takes a time of day and an
    * offset, and answers a `DateTime`.
    *
-   * The C's `switch (argc)` fall-through splits the second, minute and hour
-   * through {@link num2intWithFrac} under the `n` bounds `positive_inf`, `3`
-   * and `2` — only the LAST argument supplied may carry a fraction — and
-   * `canon24oc` (`date_core.c:3306-3312`) is the `rh === 24` fold that turns
-   * the day-ending `24:00:00` `c_valid_time_p` admits into midnight of the next
-   * day.
+   * The C's `switch (argc)` fall-through splits `jd` through
+   * `num2num_with_frac(jd, 1)` (`date_core.c:7685-7686`) and the second, minute
+   * and hour through `num2int_with_frac` under the `n` bounds `positive_inf`,
+   * `3` and `2` ({@link num2intWithFrac}). A fraction is legal only in the LAST
+   * argument SUPPLIED — the macro raises `"invalid fraction"` when `argc > n` —
+   * so `DateTime.jd(2451944.5)` is noon while `DateTime.jd(2451944, 1.5, 0)`
+   * raises, and an explicitly passed later `0` is a supplied argument. That is
+   * why every field below is optional rather than defaulted: `undefined` is the
+   * C's "not in `argc`".
+   *
+   * The fields are read in the C's own order — highest `argc` case first — so
+   * an earlier one's fraction overwrites a later one's in `fr2`, and
+   * `canon24oc` (`date_core.c:3306-3312`) folds the day-ending `24:00:00`
+   * `c_valid_time_p` admits into midnight of the next day.
    */
   static jd(
-    jd = 0,
-    hour: number | Rational = 0,
-    minute: number | Rational = 0,
-    second: number | Rational = 0,
-    offset: number | Rational | string = 0,
-    start = DEFAULT_SG,
+    jd: number | Rational = 0,
+    hour?: number | Rational,
+    minute?: number | Rational,
+    second?: number | Rational,
+    offset?: number | Rational | string,
+    start?: number,
   ): Temporal.PlainDateTime | Temporal.ZonedDateTime {
-    const sg = val2sg(start);
-    const rof = val2off(offset);
-    const [s, sFr] = num2intWithFrac(second, 1, false);
-    const [min, minFr] = num2intWithFrac(minute, MINUTE_IN_SECONDS, second !== 0);
-    const [h, hFr] = num2intWithFrac(hour, HOUR_IN_SECONDS, minute !== 0 || second !== 0);
+    const sg = start === undefined ? DEFAULT_SG : val2sg(start);
+    const rof = offset === undefined ? 0 : val2off(offset);
+    const [s, sFr] = num2intWithFrac(second ?? 0, 1, false);
+    const [min, minFr] = num2intWithFrac(
+      minute ?? 0,
+      MINUTE_IN_SECONDS,
+      second !== undefined || offset !== undefined || start !== undefined,
+    );
+    const [h, hFr] = num2intWithFrac(
+      hour ?? 0,
+      HOUR_IN_SECONDS,
+      minute !== undefined || second !== undefined || offset !== undefined || start !== undefined,
+    );
+    const [rjd, jdFr] = num2intWithFrac(
+      jd,
+      DAY_IN_SECONDS,
+      hour !== undefined ||
+        minute !== undefined ||
+        second !== undefined ||
+        offset !== undefined ||
+        start !== undefined,
+    );
     let fr2: number | Rational = 0;
     if (sFr !== 0) fr2 = sFr;
     if (minFr !== 0) fr2 = minFr;
     if (hFr !== 0) fr2 = hFr;
+    if (jdFr !== 0) fr2 = jdFr;
 
     const rt = cValidTimeP(h, min, s);
     if (rt === null) throw new DateError("invalid date");
@@ -4608,7 +4634,11 @@ export class DateTime extends DateWithoutParseStatics {
       fr2 = fr2 instanceof Rational ? fr2.add(DAY_IN_SECONDS) : fr2 + DAY_IN_SECONDS;
     }
     const localDf = timeToDf(rh, rmin, rs);
-    const [rjd2, df, sf] = addFrac(jdLocalToUtc(jd, localDf, rof), dfLocalToUtc(localDf, rof), fr2);
+    const [rjd2, df, sf] = addFrac(
+      jdLocalToUtc(rjd, localDf, rof),
+      dfLocalToUtc(localDf, rof),
+      fr2,
+    );
     return new DateTime(SEAT, rjd2, df, sf, rof, sg).toDatetime();
   }
 
@@ -4616,23 +4646,68 @@ export class DateTime extends DateWithoutParseStatics {
    * Ruby `DateTime.ordinal(year = -4712, yday = 1, hour = 0, minute = 0,
    * second = 0, offset = 0, start = Date::ITALY)` (ruby/date, `date_core.c`
    * `datetime_s_ordinal`, `date_core.c:7726-7791`, `:9972`), which raises
-   * `Date::Error` on a date `c_valid_ordinal_p` rejects and then reads the time
-   * of day exactly as {@link DateTime.jd} does — one `n` bound higher, since
-   * `yday` precedes them.
+   * `Date::Error` on a date `c_valid_ordinal_p` rejects.
+   *
+   * `yday` itself takes a fraction — `num2int_with_frac(d, 2)`
+   * (`date_core.c:7758-7759`), so `DateTime.ordinal(2001, 34.5)` is noon — and
+   * the `n` bounds are one higher than {@link DateTime.jd}'s, since `year`
+   * precedes them. `year` is the one field with no fraction: the C hands `vy`
+   * straight to `valid_ordinal_p`.
    */
   static ordinal(
     year = -4712,
-    yday = 1,
-    hour: number | Rational = 0,
-    minute: number | Rational = 0,
-    second: number | Rational = 0,
-    offset: number | Rational | string = 0,
-    start = DEFAULT_SG,
+    yday: number | Rational = 1,
+    hour?: number | Rational,
+    minute?: number | Rational,
+    second?: number | Rational,
+    offset?: number | Rational | string,
+    start?: number,
   ): Temporal.PlainDateTime | Temporal.ZonedDateTime {
-    const sg = val2sg(start);
-    const rjd = cValidOrdinalP(year, yday, sg);
+    const sg = start === undefined ? DEFAULT_SG : val2sg(start);
+    const rof = offset === undefined ? 0 : val2off(offset);
+    const [s, sFr] = num2intWithFrac(second ?? 0, 1, false);
+    const [min, minFr] = num2intWithFrac(
+      minute ?? 0,
+      MINUTE_IN_SECONDS,
+      second !== undefined || offset !== undefined || start !== undefined,
+    );
+    const [h, hFr] = num2intWithFrac(
+      hour ?? 0,
+      HOUR_IN_SECONDS,
+      minute !== undefined || second !== undefined || offset !== undefined || start !== undefined,
+    );
+    const [d, dFr] = num2intWithFrac(
+      yday,
+      DAY_IN_SECONDS,
+      hour !== undefined ||
+        minute !== undefined ||
+        second !== undefined ||
+        offset !== undefined ||
+        start !== undefined,
+    );
+    let fr2: number | Rational = 0;
+    if (sFr !== 0) fr2 = sFr;
+    if (minFr !== 0) fr2 = minFr;
+    if (hFr !== 0) fr2 = hFr;
+    if (dFr !== 0) fr2 = dFr;
+
+    const rjd = cValidOrdinalP(year, d, sg);
     if (rjd === null) throw new DateError("invalid date");
-    return DateTime.jd(rjd, hour, minute, second, offset, sg);
+    const rt = cValidTimeP(h, min, s);
+    if (rt === null) throw new DateError("invalid date");
+    let [rh] = rt;
+    const [, rmin, rs] = rt;
+    if (rh === 24) {
+      rh = 0;
+      fr2 = fr2 instanceof Rational ? fr2.add(DAY_IN_SECONDS) : fr2 + DAY_IN_SECONDS;
+    }
+    const localDf = timeToDf(rh, rmin, rs);
+    const [rjd2, df, sf] = addFrac(
+      jdLocalToUtc(rjd, localDf, rof),
+      dfLocalToUtc(localDf, rof),
+      fr2,
+    );
+    return new DateTime(SEAT, rjd2, df, sf, rof, sg).toDatetime();
   }
 
   /**
@@ -4651,7 +4726,7 @@ export class DateTime extends DateWithoutParseStatics {
     minute?: number | Rational,
     second?: number | Rational,
     offset?: number | Rational | string,
-    start = DEFAULT_SG,
+    start?: number,
   ): Temporal.PlainDateTime | Temporal.ZonedDateTime {
     return new DateTime(year, month, mday, hour, minute, second, offset, start).toDatetime();
   }
@@ -4661,22 +4736,65 @@ export class DateTime extends DateWithoutParseStatics {
    * minute = 0, second = 0, offset = 0, start = Date::ITALY)` (ruby/date,
    * `date_core.c` `datetime_s_commercial`, `date_core.c:7912-7980`, `:9975`),
    * the week-date counterpart, which raises `Date::Error` on a date
-   * `c_valid_commercial_p` rejects.
+   * `c_valid_commercial_p` rejects. `cwday` carries the fraction
+   * (`num2int_with_frac(d, 3)`, `date_core.c:7945-7946`); `cweek` is `NUM2INT`
+   * and `cwyear` is handed straight to `valid_commercial_p`, so neither does.
    */
   static commercial(
     cwyear = -4712,
     cweek = 1,
-    cwday = 1,
-    hour: number | Rational = 0,
-    minute: number | Rational = 0,
-    second: number | Rational = 0,
-    offset: number | Rational | string = 0,
-    start = DEFAULT_SG,
+    cwday: number | Rational = 1,
+    hour?: number | Rational,
+    minute?: number | Rational,
+    second?: number | Rational,
+    offset?: number | Rational | string,
+    start?: number,
   ): Temporal.PlainDateTime | Temporal.ZonedDateTime {
-    const sg = val2sg(start);
-    const rjd = cValidCommercialP(cwyear, cweek, cwday, sg);
+    const sg = start === undefined ? DEFAULT_SG : val2sg(start);
+    const rof = offset === undefined ? 0 : val2off(offset);
+    const [s, sFr] = num2intWithFrac(second ?? 0, 1, false);
+    const [min, minFr] = num2intWithFrac(
+      minute ?? 0,
+      MINUTE_IN_SECONDS,
+      second !== undefined || offset !== undefined || start !== undefined,
+    );
+    const [h, hFr] = num2intWithFrac(
+      hour ?? 0,
+      HOUR_IN_SECONDS,
+      minute !== undefined || second !== undefined || offset !== undefined || start !== undefined,
+    );
+    const [d, dFr] = num2intWithFrac(
+      cwday,
+      DAY_IN_SECONDS,
+      hour !== undefined ||
+        minute !== undefined ||
+        second !== undefined ||
+        offset !== undefined ||
+        start !== undefined,
+    );
+    let fr2: number | Rational = 0;
+    if (sFr !== 0) fr2 = sFr;
+    if (minFr !== 0) fr2 = minFr;
+    if (hFr !== 0) fr2 = hFr;
+    if (dFr !== 0) fr2 = dFr;
+
+    const rjd = cValidCommercialP(cwyear, cweek, d, sg);
     if (rjd === null) throw new DateError("invalid date");
-    return DateTime.jd(rjd, hour, minute, second, offset, sg);
+    const rt = cValidTimeP(h, min, s);
+    if (rt === null) throw new DateError("invalid date");
+    let [rh] = rt;
+    const [, rmin, rs] = rt;
+    if (rh === 24) {
+      rh = 0;
+      fr2 = fr2 instanceof Rational ? fr2.add(DAY_IN_SECONDS) : fr2 + DAY_IN_SECONDS;
+    }
+    const localDf = timeToDf(rh, rmin, rs);
+    const [rjd2, df, sf] = addFrac(
+      jdLocalToUtc(rjd, localDf, rof),
+      dfLocalToUtc(localDf, rof),
+      fr2,
+    );
+    return new DateTime(SEAT, rjd2, df, sf, rof, sg).toDatetime();
   }
 
   /**

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -3136,6 +3136,32 @@ function cJdToWday(jd: number): number {
   return mod(jd + 1, 7);
 }
 
+/**
+ * @internal `date_core.c` `m_julian_p` (`date_core.c:1683-1703`), which reads
+ * the STORED Julian day — `x->s.jd` on the simple arm and `x->c.jd`, the UTC
+ * one, on the complex arm — rather than `m_local_jd`. So a `DateTime` whose
+ * offset carries it across the reform answers off the UTC day:
+ * `DateTime.new(1582, 10, 15, 0, 30, 0, "+02:00").julian?` is true while
+ * `DateTime.new(1582, 10, 15, 23, 30, 0, "-02:00")` is false, though both
+ * answer 2299161 to `jd`. That is why this takes the day rather than reading a
+ * receiver: the two arms hold different days, and each class passes its own.
+ *
+ * The `isinf` arm is what makes `Date::JULIAN` julian everywhere and
+ * `Date::GREGORIAN` julian nowhere. `Infinity` / `-Infinity` would carry both
+ * through the `jd < sg` comparison below on their own, but the C tests the
+ * infinity first, and its answer there is `sg == positive_inf`.
+ *
+ * `s_virtual_sg` (`date_core.c:1110-1120`) is the `sg` the C reads here: it
+ * answers an infinity for a date whose Julian day overflowed a `Fixnum`, on the
+ * `nth` field that carries the overflow. There is no `nth` here — the Julian
+ * day is one JS number — so the virtual reading and the stored one never part
+ * company.
+ */
+function mJulianP(jd: number, sg: number): boolean {
+  if (!Number.isFinite(sg)) return sg === JULIAN;
+  return jd < sg;
+}
+
 /** @internal `date_core.c`'s `DIV` macro (`date_core.c:168-170`), floored division. */
 function div(n: number, d: number): number {
   return Math.floor(n / d);
@@ -4167,17 +4193,11 @@ export class Date {
    * `(Date.new(1582, 10, 15) - 1).julian?` is true and
    * `Date.new(1582, 10, 15).julian?` is false.
    *
-   * The C's `isinf` arm is what makes `Date::JULIAN` julian everywhere and
-   * `Date::GREGORIAN` julian nowhere; the `jd < sg` below carries both directly,
-   * since `Infinity` and `-Infinity` compare that way — but the C tests the
-   * infinity explicitly, and so does this, because its answer for
-   * `Date::GREGORIAN` is `sg == positive_inf`, not the comparison.
+   * {@link mJulianP} reads the STORED day, which is `this.#jd` here and the UTC
+   * one on `DateTime` — hence the override there.
    */
   get isJulian(): boolean {
-    const jd = this.jd;
-    const sg = this.#sg;
-    if (!Number.isFinite(sg)) return sg === JULIAN;
-    return jd < sg;
+    return mJulianP(this.#jd, this.#sg);
   }
 
   /**
@@ -4211,17 +4231,19 @@ export class Date {
    * `gregorian` alike. TS has no `dup_obj` — a copy has to name the class it is
    * making — so this method IS that seam: `DateTime` overrides it to keep its
    * time of day, and the four below call it rather than a private helper none
-   * of them could override.
+   * of them could override. The `this` return type is `dup_obj`'s own
+   * `rb_obj_class(obj)`, which is why the four answer a `DateTime` on a
+   * `DateTime`.
    */
-  newStart(start = DEFAULT_SG): Date {
-    return new Date(SEAT, this.jd, val2sg(start));
+  newStart(start = DEFAULT_SG): this {
+    return new Date(SEAT, this.jd, val2sg(start)) as this;
   }
 
   /**
    * Ruby `Date#italy` (ruby/date, `date_core.c` `d_lite_italy`,
    * `date_core.c:5848-5852`), `new_start` with `Date::ITALY`.
    */
-  italy(): Date {
+  italy(): this {
     return this.newStart(ITALY);
   }
 
@@ -4229,7 +4251,7 @@ export class Date {
    * Ruby `Date#england` (ruby/date, `date_core.c` `d_lite_england`,
    * `date_core.c:5860-5864`), `new_start` with `Date::ENGLAND`.
    */
-  england(): Date {
+  england(): this {
     return this.newStart(ENGLAND);
   }
 
@@ -4237,7 +4259,7 @@ export class Date {
    * Ruby `Date#julian` (ruby/date, `date_core.c` `d_lite_julian`,
    * `date_core.c:5872-5876`), `new_start` with `Date::JULIAN`.
    */
-  julian(): Date {
+  julian(): this {
     return this.newStart(JULIAN);
   }
 
@@ -4245,7 +4267,7 @@ export class Date {
    * Ruby `Date#gregorian` (ruby/date, `date_core.c` `d_lite_gregorian`,
    * `date_core.c:5884-5888`), `new_start` with `Date::GREGORIAN`.
    */
-  gregorian(): Date {
+  gregorian(): this {
     return this.newStart(GREGORIAN);
   }
 
@@ -4607,8 +4629,19 @@ export class DateTime extends DateWithoutParseStatics {
    * `set_sg` writes the new reform in. TS has no `dup_obj`, so the copy is made
    * here, where the fields are in scope; see {@link Date#newStart}.
    */
-  override newStart(start = DEFAULT_SG): DateTime {
-    return new DateTime(SEAT, this.#jd, this.#df, this.#sf, this.#of, val2sg(start));
+  /**
+   * Ruby `DateTime#julian?` is `d_lite_julian_p` inherited, but `m_julian_p`
+   * (`date_core.c:1683-1703`) reads `x->c.jd` on the complex arm — the STORED
+   * UTC day, not the `m_local_jd` {@link DateTime#jd} answers. The stored day
+   * is private to each class, so the reading is made here; see
+   * {@link mJulianP}.
+   */
+  override get isJulian(): boolean {
+    return mJulianP(this.#jd, this.start);
+  }
+
+  override newStart(start = DEFAULT_SG): this {
+    return new DateTime(SEAT, this.#jd, this.#df, this.#sf, this.#of, val2sg(start)) as this;
   }
 
   /**


### PR DESCRIPTION
Story: RFC 0088 `date-start-argument-and-reform-surface-absent`.

The conversions in `packages/date/src/date.ts` already took an `sg`, but only ever `DEFAULT_SG` — the `start` argument that selects it, and the surface that exposes it, were absent. Now that `Date` carries `readonly #jd` (PR #6267), both are portable.

## What lands

- `Date::JULIAN` / `Date::GREGORIAN` (`date_core.c:188-189`, `positive_inf` / `negative_inf`) and `Date::ENGLAND` (`:187`) as class constants next to `Date::ITALY`. Every `sg` comparison is `jd < sg`, so `Infinity` / `-Infinity` carry them directly.
- `c_valid_start_p` (`:888-898`) and the `val2sg` macro (`:3320-3327`), the `start` counterpart of the existing `val2off`: a start outside the reform window `REFORM_BEGIN_JD..REFORM_END_JD` (`:209-210`) is ignored and `DEFAULT_SG` taken.
- `SimpleDateData`'s `sg` (`:203-213`) as `Date`'s `#sg`, and the trailing `start = Date::ITALY` argument on `Date.new` / `civil` / `jd` / `ordinal` / `commercial` / `parse` / `strptime` and the `DateTime` counterparts (`DateTime.new`'s comes after `offset`).
- `sg` threaded from the receiver through `c_commercial_to_jd`, `c_jd_to_commercial`, `c_weeknum_to_jd`, `c_jd_to_weeknum`, `c_valid_commercial_p`, `c_valid_weeknum_p`, `rt__valid_ordinal_p` / `rt__valid_civil_p` / `rt__valid_date_frags_p` and `d_new_by_frags` / `dt_new_by_frags` — each of which takes it in the C.
- `DateTime.jd` / `.ordinal` / `.civil` / `.commercial` — singleton methods of `DateTime`'s own (`:9971-9975`), not `Date`'s inherited, so they take a time of day, an `offset` and the trailing `start`. `datetime_s_civil` is `datetime_initialize` itself (`:9974`), so it is the constructor here too.
- `add_frac` (`:3313-3317`) as a function, which is the tail all five `DateTime` builders share; `DateTime.new` used to inline it.
- `#start` (`d_lite_start`), `#julian?` / `#gregorian?` (`d_lite_julian_p` over `m_julian_p`, including its `isinf` arm), `#new_start`, and `#italy` / `#england` / `#julian` / `#gregorian`.

## Deviation, justified at the call site

The C reaches its file-static `dup_obj_with_new_start` (`:5801-5810`) from `new_start` and from the four aliases alike. TS has no `dup_obj` — a copy has to name the class it is making — so `new_start` itself is that seam: `DateTime` overrides it to keep its day-fraction, sub-second and offset, and the four aliases call it rather than a private helper none of them could override.

## Verification

Every asserted value came from a live `ruby -rdate -e` on 3.3.11 and is quoted above its assertion. Acceptance criteria:

- `Date.new(1582, 10, 10, Date::GREGORIAN)` builds (jd 2299156) where the default raises ✅
- `Date.jd(2299160, Date::GREGORIAN)` is 1582-10-14, the default 1582-10-04 ✅
- `#start`, `#julian?`, `#gregorian?`, `#new_start` answer as MRI does ✅
- `m_julian_p` reads the STORED UTC day, so `DateTime.new(1582, 10, 15, 0, 30, 0, "+02:00").julian?` is true while the `-02:00` twin is false, though both answer `jd == 2299161` ✅
- default-`sg` behaviour unchanged — the pre-existing 112 `date.trails.test.ts` tests pass untouched ✅
