### PR TITLE
fix(activerecord): quote_string is escape-only on every dialect; temporal binds dispatch through the adapter

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/quoting.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/quoting.test.ts
@@ -47,10 +47,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("quote string", async () => {
-      // Rails asserts quote_string("'") == "''" (escaped content, no wrapping
-      // quotes). Trails' quoteString wraps — round-trip the same "'" datum.
-      const rows = await adapter.execute("SELECT ? AS val", ["'"]);
-      expect(rows[0].val).toBe("'");
+      expect(adapter.quoteString("'")).toBe("''");
     });
 
     it("quote column name", async () => {

--- a/packages/activerecord/src/adapters/sqlite3/quoting.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/quoting.test.ts
@@ -39,12 +39,7 @@ describeIfSqlite("SQLite3QuotingTest", () => {
   });
 
   it("quote string", async () => {
-    // Rails asserts quote_string("'") == "''" (escaped content, no wrapping
-    // quotes). Trails' quoteString wraps — round-trip the same "'" datum.
-    await adapter.exec(`CREATE TABLE "quote_test" ("id" INTEGER PRIMARY KEY, "val" TEXT)`);
-    await adapter.executeMutation(`INSERT INTO "quote_test" ("val") VALUES ('''')`);
-    const rows = await adapter.execute(`SELECT "val" FROM "quote_test"`);
-    expect(rows[0].val).toBe("'");
+    expect(adapter.quoteString("'")).toBe("''");
   });
 
   it("quote column name", async () => {

--- a/packages/activerecord/src/base.trails.test.ts
+++ b/packages/activerecord/src/base.trails.test.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect } from "vitest";
 import { Base, UnknownPrimaryKey } from "./index.js";
 import { quoteSqlValue } from "./base.js";
+import { quotedDate as pgQuotedDate } from "./connection-adapters/postgresql/quoting.js";
 import { registerSubclass } from "./inheritance.js";
 import { Temporal } from "@blazetrails/date";
 import { Type } from "@blazetrails/activemodel";
@@ -17,6 +18,10 @@ import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/a
 import { reconcileVirtualAttributes, loadSchema } from "./model-schema.js";
 
 describe("quoteSqlValue", () => {
+  // Stands in for a PostgreSQLAdapter receiver: `quote` self-dispatches
+  // `quoted_date` onto it, exactly as the real adapter supplies it.
+  const pgHost = { quotedDate: pgQuotedDate };
+
   it("emits bare decimal for bigint (not quoted string)", () => {
     expect(quoteSqlValue(123n)).toBe("123");
     expect(quoteSqlValue(2n ** 62n)).toBe("4611686018427387904");
@@ -70,14 +75,15 @@ describe("quoteSqlValue", () => {
 
   it("renders the PG BC literal for a proleptic-year Instant (insert_all VALUES)", () => {
     // Regression guard: the PG inline VALUES path must carry the " BC" suffix
-    // and fixed-6 microseconds, matching the adapter's quoted_date.
+    // and fixed-6 microseconds — resolved from the connection's `quoted_date`
+    // (abstract/quoting.rb:85), not a dialect argument.
     const instant = Temporal.Instant.from("-000043-03-15T12:34:56.123456Z");
-    expect(quoteSqlValue(instant, "postgres")).toBe("'0044-03-15 12:34:56.123456 BC'");
+    expect(quoteSqlValue(instant, pgHost)).toBe("'0044-03-15 12:34:56.123456 BC'");
   });
 
   it("caps PG datetime literal fractional seconds at microseconds", () => {
     const instant = Temporal.Instant.from("2026-04-26T14:23:55.123456789Z");
-    expect(quoteSqlValue(instant, "postgres")).toBe("'2026-04-26 14:23:55.123456'");
+    expect(quoteSqlValue(instant, pgHost)).toBe("'2026-04-26 14:23:55.123456'");
   });
 });
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -105,8 +105,10 @@ import {
   createAssociationCache,
 } from "./association-cache.js";
 import { ConnectionHandler } from "./connection-adapters/abstract/connection-handler.js";
-import type { AdapterName } from "./connection-adapters/abstract-adapter.js";
-import { temporalToBindString } from "./connection-adapters/abstract/database-statements.js";
+import {
+  quote as abstractQuote,
+  type QuotingDispatchHost,
+} from "./connection-adapters/abstract/quoting.js";
 import * as ConnectionHandling from "./connection-handling.js";
 import type { DatabaseConfig } from "./database-configurations/database-config.js";
 import * as ModelSchema from "./model-schema.js";
@@ -355,13 +357,15 @@ import {
 } from "./multiparameter-attribute-assignment.js";
 
 /** @internal */
-export function quoteSqlValue(v: unknown, dialect?: AdapterName): string {
+export function quoteSqlValue(v: unknown, connection?: QuotingDispatchHost): string {
   if (v === null || v === undefined) return "NULL";
   if (typeof v === "number" || typeof v === "bigint") return String(v);
   if (typeof v === "boolean") return v ? "TRUE" : "FALSE";
   // Temporal date/time values reach here because value_for_database now yields
-  // the cast Temporal (not a pre-quoted SQL string). Render the dialect-correct
-  // literal via the same formatter the bind path uses, then SQL-quote it.
+  // the cast Temporal (not a pre-quoted SQL string). Rails renders these with
+  // `quote`, which dispatches `quoted_date` / `quoted_time` on the connection
+  // (abstract/quoting.rb:75-86) — so the dialect comes from the receiver, not a
+  // parameter.
   if (
     v instanceof Temporal.Instant ||
     v instanceof Temporal.PlainDateTime ||
@@ -369,7 +373,7 @@ export function quoteSqlValue(v: unknown, dialect?: AdapterName): string {
     v instanceof Temporal.PlainTime ||
     v instanceof Temporal.ZonedDateTime
   ) {
-    return `'${String(temporalToBindString(v, dialect)).replace(/'/g, "''")}'`;
+    return abstractQuote.call(connection ?? {}, v);
   }
   // boundary: defensive SQL literal quoting fallback for legacy callers.
   // Invalid (NaN) Date short-circuits to SQL NULL — toISOString() would throw

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -49,6 +49,7 @@ import { StatementPool as ConnectionStatementPool } from "./statement-pool.js";
 import type { SchemaCreation as MysqlSchemaCreation } from "./mysql/schema-creation.js";
 import {
   quote as mysqlQuote,
+  quoteString as mysqlQuoteString,
   quotedDate as mysqlQuotedDate,
   typeCast as mysqlTypeCast,
   castBoundValue as mysqlCastBoundValue,
@@ -166,18 +167,7 @@ const CR_SERVER_GONE_ERROR = 2006;
 const CR_SERVER_LOST = 2013;
 const ER_CLIENT_INTERACTION_TIMEOUT = 4031;
 
-// eslint-disable-next-line no-control-regex
-const QUOTE_STRING_RE = /['\\\x00\n\r\x1a]/g;
 type CreateTableArgs = Parameters<MysqlSchemaStatements["createTable"]>;
-
-const QUOTE_STRING_MAP: Record<string, string> = {
-  "'": "\\'",
-  "\\": "\\\\",
-  "\0": "\\0",
-  "\n": "\\n",
-  "\r": "\\r",
-  "\x1a": "\\Z",
-};
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class AbstractMysqlAdapter extends AbstractAdapter {
@@ -1198,7 +1188,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    * `'...'` for SQL-literal contexts.
    */
   override quoteString(s: string): string {
-    return s.replace(QUOTE_STRING_RE, (ch) => QUOTE_STRING_MAP[ch] ?? ch);
+    return mysqlQuoteString(s);
   }
 
   static dbconsole(

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -20,31 +20,16 @@ import {
   Attribute as ModelAttribute,
   RangeError as ActiveModelRangeError,
 } from "@blazetrails/activemodel";
-import { Notifications, BigDecimal } from "@blazetrails/activesupport";
-import { Temporal } from "@blazetrails/date";
+import { Notifications } from "@blazetrails/activesupport";
 import {
   TransactionIsolationError,
   NotImplementedError,
   RangeError as ARRangeError,
   StatementInvalid,
 } from "../../errors.js";
-import {
-  formatInstantForSql,
-  formatPlainDateTimeForSql,
-  formatPlainDateForSql,
-  formatPlainTimeForSql,
-  formatInstantForSqlMysql,
-  formatPlainDateTimeForSqlMysql,
-  formatPlainTimeForSqlMysql,
-  formatInstantForSqlPostgres,
-  formatPlainDateTimeForSqlPostgres,
-  formatPlainDateForSqlPostgres,
-  defaultSqlTimezone,
-} from "./sql-datetime.js";
-import { Value as TimeValue } from "../../type/time.js";
+
 import type { Quoting } from "./quoting.js";
 import type { ConnectionPool, NullPool } from "./connection-pool.js";
-import { DateInfinity, DateNegativeInfinity } from "@blazetrails/activemodel";
 import { TransactionManager } from "./transaction.js";
 import { exceedsBindParamsLimit } from "./database-limits.js";
 import { Result } from "../../result.js";
@@ -1279,74 +1264,6 @@ export function withYamlFallback(value: unknown): unknown {
     const proto = Object.getPrototypeOf(value);
     if (proto === Object.prototype || proto === null) return JSON.stringify(value);
   }
-  return value;
-}
-
-/**
- * Convert a Temporal value to its SQL wire-string form for use as a bound
- * parameter. Drivers (pg extended protocol, mysql2 prepared, better-sqlite3)
- * reject raw Temporal objects; this shim converts them at the bind boundary.
- * Returns the value unchanged when it is not a Temporal type.
- *
- * Called directly by the PostgreSQL/MySQL adapter bind paths (with an adapter
- * argument for infinity sentinels and dialect-specific datetime literals) and by
- * `Base.quoteSqlValue`. It is NOT a `type_casted_binds` producer: that slot goes
- * through the adapter-dispatched `Quoting#typeCastedBinds` (quoting.rb:224),
- * whose Temporal handling is `typeCast`'s own `quotedDate`/`quotedTime`.
- */
-export function temporalToBindString(
-  value: unknown,
-  adapter?: "sqlite" | "postgres" | "mysql",
-): unknown {
-  // Postgres infinity sentinels must become the wire strings pg expects.
-  // Gated to postgres adapter only — SQLite/MySQL have no infinity concept.
-  if (adapter === "postgres") {
-    if (value === DateInfinity) return "infinity";
-    if (value === DateNegativeInfinity) return "-infinity";
-  }
-  // Cast decimals are BigDecimal values; drivers need a primitive, so send the
-  // fixed ("F") form (Rails' `type_cast`: `when BigDecimal then value.to_s("F")`)
-  // rather than letting the driver JSON-stringify the object.
-  if (value instanceof BigDecimal) return value.toString("F");
-  // Adapter-specific datetime literals:
-  //   - MySQL/MariaDB DATETIME(6) caps fractional at 6 digits (strict mode rejects 7–9).
-  //   - PostgreSQL uses quoted_date semantics: fixed-6 microseconds + " BC" for years ≤ 0.
-  // This keeps the inline insert_all VALUES path (quoteSqlValue → here) consistent
-  // with the bind path (the adapter's quotedDate) for both dialects.
-  const mysql = adapter === "mysql";
-  const postgres = adapter === "postgres";
-  if (value instanceof Temporal.Instant)
-    return mysql
-      ? formatInstantForSqlMysql(value)
-      : postgres
-        ? formatInstantForSqlPostgres(value)
-        : formatInstantForSql(value);
-  if (value instanceof Temporal.PlainDateTime)
-    return mysql
-      ? formatPlainDateTimeForSqlMysql(value)
-      : postgres
-        ? formatPlainDateTimeForSqlPostgres(value)
-        : formatPlainDateTimeForSql(value);
-  if (value instanceof Temporal.PlainDate)
-    return postgres ? formatPlainDateForSqlPostgres(value) : formatPlainDateForSql(value);
-  // A `Type::Time::Value` is the time-of-day wrapper `Type::Time#serialize`
-  // produces; read its components back out in `default_timezone` the way
-  // `quoted_time` does, then take the PlainTime arm below.
-  if (value instanceof TimeValue) {
-    value = value.getobj().toZonedDateTimeISO(defaultSqlTimezone()).toPlainTime();
-  }
-  if (value instanceof Temporal.PlainTime) {
-    // SQLite stores time with a fixed 2000-01-01 date prefix so it can be
-    // read back as a datetime string by the cast layer.
-    const t = mysql ? formatPlainTimeForSqlMysql(value) : formatPlainTimeForSql(value);
-    return adapter === "sqlite" ? `2000-01-01 ${t}` : t;
-  }
-  if (value instanceof Temporal.ZonedDateTime)
-    return mysql
-      ? formatInstantForSqlMysql(value.toInstant())
-      : postgres
-        ? formatInstantForSqlPostgres(value.toInstant())
-        : formatInstantForSql(value.toInstant());
   return value;
 }
 

--- a/packages/activerecord/src/connection-adapters/abstract/precision-roundtrip.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/precision-roundtrip.test.ts
@@ -16,7 +16,7 @@ import {
   formatPlainTimeForSqlMysql,
 } from "./sql-datetime.js";
 import { quote as quoteFn, typeCast as typeCastFn } from "./quoting.js";
-import { temporalToBindString } from "./database-statements.js";
+import { quotedTime as sqliteQuotedTime } from "../sqlite3/quoting.js";
 
 // `quote` / `typeCast` require a host receiver (no receiver-less dispatch); bind
 // an empty host so date/time values route through the abstract module helpers.
@@ -115,36 +115,39 @@ describe("formatPlainTimeForSql", () => {
   });
 });
 
-describe("temporalToBindString", () => {
+// The bind path renders date/time values with `type_cast`, which dispatches
+// `quoted_date` / `quoted_time` on the connection (abstract/quoting.rb:103-104).
+// A bare `{}` receiver exercises the abstract formats.
+describe("typeCast of Temporal bind values", () => {
+  const bind = (v: unknown) => typeCast(v);
+
   it("converts Instant to UTC string", () => {
     const v = Temporal.Instant.from("2026-04-26T14:23:55.123456Z");
-    expect(temporalToBindString(v)).toBe("2026-04-26 14:23:55.123456");
+    expect(bind(v)).toBe("2026-04-26 14:23:55.123456");
   });
 
   it("converts PlainDateTime to string", () => {
     const v = Temporal.PlainDateTime.from("2026-04-26T14:23:55.000001");
-    expect(temporalToBindString(v)).toBe("2026-04-26 14:23:55.000001");
+    expect(bind(v)).toBe("2026-04-26 14:23:55.000001");
   });
 
   it("converts PlainDate to string", () => {
-    expect(temporalToBindString(Temporal.PlainDate.from("2026-04-26"))).toBe("2026-04-26");
+    expect(bind(Temporal.PlainDate.from("2026-04-26"))).toBe("2026-04-26");
   });
 
   it("converts PlainTime to string", () => {
-    expect(temporalToBindString(Temporal.PlainTime.from("14:23:55.123456"))).toBe(
-      "14:23:55.123456",
-    );
+    expect(bind(Temporal.PlainTime.from("14:23:55.123456"))).toBe("14:23:55.123456");
   });
 
   it("converts ZonedDateTime to UTC instant string", () => {
     const v = Temporal.ZonedDateTime.from("2026-04-26T16:23:55+02:00[Europe/Paris]");
-    expect(temporalToBindString(v)).toBe("2026-04-26 14:23:55");
+    expect(bind(v)).toBe("2026-04-26 14:23:55");
   });
 
   it("passes non-Temporal values through unchanged", () => {
-    expect(temporalToBindString(42)).toBe(42);
-    expect(temporalToBindString("hello")).toBe("hello");
-    expect(temporalToBindString(null)).toBe(null);
+    expect(bind(42)).toBe(42);
+    expect(bind("hello")).toBe("hello");
+    expect(bind(null)).toBe(null);
   });
 });
 
@@ -192,15 +195,17 @@ describe("SQLite/MySQL fixed-6 microsecond field (quoted_date parity)", () => {
   });
 });
 
-describe("temporalToBindString adapter=sqlite uses 2000-01-01 prefix for PlainTime", () => {
+// The 2000-01-01 prefix is SQLite's `quoted_time` override, reached by
+// receiver — the same dispatch Rails uses (abstract/quoting.rb:103).
+describe("typeCast on a SQLite receiver uses 2000-01-01 prefix for PlainTime", () => {
   it("wraps PlainTime in 2000-01-01 for sqlite", () => {
     const v = Temporal.PlainTime.from("14:23:55.123456");
-    expect(temporalToBindString(v, "sqlite")).toBe("2000-01-01 14:23:55.123456");
+    expect(typeCastFn.call({ quotedTime: sqliteQuotedTime }, v)).toBe("2000-01-01 14:23:55.123456");
   });
 
   it("returns bare time string for postgres", () => {
     const v = Temporal.PlainTime.from("14:23:55.123456");
-    expect(temporalToBindString(v, "postgres")).toBe("14:23:55.123456");
+    expect(typeCast(v)).toBe("14:23:55.123456");
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -47,6 +47,8 @@ export interface QuotingDispatchHost {
   /** @internal */
   quotedBinary?(value: unknown): string;
   /** @internal */
+  quoteString?(s: string): string;
+  /** @internal */
   quoteColumnName?(name: string): string;
   /** @internal */
   quotedTrue?(): string;
@@ -117,14 +119,17 @@ export function quoteTableName(this: QuotingDispatchHost, name: string): string 
  * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quote
  */
 export function quote(this: QuotingDispatchHost, value: unknown): string {
-  // rb:75 — `when String, Symbol, ActiveSupport::Multibyte::Chars`.
+  // rb:75-76 — `when String, Symbol, ActiveSupport::Multibyte::Chars` then
+  // `"'#{quote_string(value.to_s)}'"`. `quote_string` is self-dispatched, so the
+  // surrounding quotes are added here, once, and the dialect's escape rules come
+  // from the adapter's override.
   if (typeof value === "string") {
-    return `'${quoteString(value)}'`;
+    return `'${dispatchQuoteString(this, value)}'`;
   }
   if (typeof value === "symbol") {
     const desc = value.description;
     if (desc === undefined) throw new TypeError("Cannot quote a Symbol without a description");
-    return `'${quoteString(desc)}'`;
+    return `'${dispatchQuoteString(this, desc)}'`;
   }
   // Rails: `when true then quoted_true` / `when false then quoted_false`
   // (rb:77-78) — self-dispatched, so SQLite's `1`/`0` override applies to the
@@ -560,6 +565,17 @@ export function dispatchQuotedFalse(host: QuotingDispatchHost): string {
   return typeof host.quotedFalse === "function" ? host.quotedFalse() : quotedFalse();
 }
 
+/**
+ * Mirrors Rails' `quote_string(value.to_s)` inside `quote`
+ * (abstract/quoting.rb:75-76) — self-dispatched, so an adapter's escape-only
+ * override (PG's libpq `escape`, MySQL's backslash escapes, SQLite's `''`)
+ * applies to the inherited `quote`.
+ * @internal
+ */
+export function dispatchQuoteString(host: QuotingDispatchHost, s: string): string {
+  return typeof host.quoteString === "function" ? host.quoteString(s) : quoteString(s);
+}
+
 /** @internal */
 export function dispatchUnquotedTrue(host: QuotingDispatchHost): boolean | number {
   return typeof host.unquotedTrue === "function" ? host.unquotedTrue() : unquotedTrue();
@@ -702,16 +718,10 @@ export interface Quoting {
 
   /**
    * Mirrors: Quoting#quote_string — **escape-only**. Doubles `'` and
-   * applies any dialect-specific escape rules (MySQL `\\\0\n\r\Z`; PG
-   * may switch to `E'…'` form for backslashes inside `quote()`). Never
-   * adds surrounding `'`. For a fully-quoted SQL literal use
-   * `quote(value)` instead.
-   *
-   * Note: per-adapter standalone `quoteString` exports in
-   * `{sqlite3,mysql}/quoting.ts` historically wrap with surrounding
-   * `'...'` and are NOT escape-only. Adapter classes override
-   * `quoteString` to honor this contract; the standalones stay as
-   * literal-quoting helpers for legacy call sites.
+   * applies any dialect-specific escape rules (MySQL `\\\0\n\r\Z`).
+   * Never adds surrounding `'`; `quote` adds those once
+   * (abstract/quoting.rb:75-76, 131-133). For a fully-quoted SQL literal
+   * use `quote(value)` instead.
    */
   quoteString(s: string): string;
 

--- a/packages/activerecord/src/connection-adapters/mysql/datetime-bind.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/datetime-bind.test.ts
@@ -1,6 +1,7 @@
 import { Temporal } from "@blazetrails/date";
 import { describe, expect, it } from "vitest";
-import { temporalToBindString } from "../abstract/database-statements.js";
+import { typeCast as abstractTypeCast } from "../abstract/quoting.js";
+import { quotedDate as mysqlQuotedDate } from "./quoting.js";
 
 // MySQL/MariaDB datetime columns now use the base AR DateTime type (matching
 // Rails' `register_class_with_precision m, %r(datetime)i, Type::DateTime`);
@@ -8,7 +9,9 @@ import { temporalToBindString } from "../abstract/database-statements.js";
 // renders the SQL literal with the 6-digit fractional cap that DATETIME(6)
 // enforces. These cases pin that bind-string formatting.
 describe("MySQL datetime bind formatting", () => {
-  const bind = (v: unknown) => temporalToBindString(v, "mysql");
+  // Rails' `type_cast` dispatches `quoted_date` on the connection
+  // (abstract/quoting.rb:104), so the MySQL cap comes from the receiver.
+  const bind = (v: unknown) => abstractTypeCast.call({ quotedDate: mysqlQuotedDate }, v);
 
   it("emits YYYY-MM-DD HH:MM:SS.ffffff without T or Z", () => {
     const instant = Temporal.Instant.from("2026-05-08T14:32:00.123456Z");

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.test.ts
@@ -172,8 +172,11 @@ describe("MySQL quoting — quoteColumnName", () => {
     expect(quoteColumnName("foo`bar")).toBe("`foo``bar`");
   });
 
-  it("passes * through unquoted (column-list star)", () => {
-    expect(quoteColumnName("*")).toBe("*");
+  // Rails' quote_column_name is unconditional (mysql/quoting.rb:46-47) — a star
+  // projection never reaches it, because Arel's to_sql renders it as a
+  // SqlLiteral (arel/src/visitors/to-sql.ts).
+  it("quotes * like any other name", () => {
+    expect(quoteColumnName("*")).toBe("`*`");
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -4,8 +4,8 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::Quoting (module)
  *
  * In Rails, Quoting is a module mixed into AbstractMysqlAdapter.
- * Here we export standalone functions and an interface, matching
- * the pattern used by the PostgreSQL and SQLite3 adapters.
+ * Here we export standalone functions, matching the pattern used by
+ * the PostgreSQL and SQLite3 adapters.
  *
  * @boundary-file: SQL value quoting branches on `instanceof Date` alongside
  *   Temporal types; legacy Date values from custom-typed columns hit a
@@ -31,13 +31,6 @@ import { Value as TimeValue } from "../../type/time.js";
 import { BigDecimal } from "@blazetrails/activesupport";
 import { BinaryData } from "@blazetrails/activemodel";
 
-export interface Quoting {
-  unquotedTrue(): number;
-  unquotedFalse(): number;
-  quoteTableName(name: string): string;
-  quoteColumnName(name: string): string;
-}
-
 // Rails MySQL overrides unquoted_true/false (1/0) but NOT quoted_true/false,
 // which inherit the abstract "TRUE"/"FALSE" (mysql/quoting.rb).
 export function unquotedTrue(): number {
@@ -52,14 +45,13 @@ export function unquotedFalse(): number {
  * Mirrors: MySQL::Quoting#quote_table_name —
  * `"`#{name.gsub('`', '``').gsub('.', '`.`')}`"`. The whole name is wrapped in
  * backticks with `.` rewritten as `` `.` `` so `foo.bar` → `` `foo`.`bar` ``
- * (no `*` special-casing, unlike quoteColumnName).
+ * (mysql/quoting.rb:41-43).
  */
 export function quoteTableName(name: string): string {
   return `\`${name.replace(/`/g, "``").replace(/\./g, "`.`")}\``;
 }
 
 export function quoteColumnName(name: string): string {
-  if (name === "*") return name;
   return `\`${name.replace(/`/g, "``")}\``;
 }
 
@@ -76,15 +68,16 @@ const MYSQL_ESCAPE_MAP: Record<string, string> = {
 };
 
 /**
- * Quote a string value for use in SQL. Single/double quotes, backslash,
+ * Escape a string value for use in SQL. Single/double quotes, backslash,
  * and control characters (NUL, newline, carriage return, Ctrl-Z) are
- * escaped with backslashes. Mirrors Rails MySQL `quote_string`, which
- * delegates to `mysql2`'s connection-level escape — uses backslash-escapes
- * (not SQL-standard `''` doubling). The npm `mysql2` driver's `escape()`
- * matches this same shape.
+ * escaped with backslashes. Mirrors Rails MySQL `quote_string`
+ * (`abstract_mysql_adapter.rb`), which delegates to `mysql2`'s
+ * connection-level escape — backslash-escapes, not SQL-standard `''`
+ * doubling. **Escape-only**: the surrounding quotes are added once by
+ * `quote` (abstract/quoting.rb:75-76), as in Rails.
  */
 export function quoteString(value: string): string {
-  return `'${value.replace(MYSQL_ESCAPE_RE, (ch) => MYSQL_ESCAPE_MAP[ch] ?? ch)}'`;
+  return value.replace(MYSQL_ESCAPE_RE, (ch) => MYSQL_ESCAPE_MAP[ch] ?? ch);
 }
 
 /**
@@ -182,25 +175,15 @@ export function columnNameWithOrderMatcher(): RegExp {
  * only `quote_column_name` / `quote_table_name` / `cast_bound_value`, so a MySQL
  * `quote` runs the abstract `quote` and the MySQL-specific behaviour flows in
  * through the dispatched helpers (`quote_string`, `quoted_binary`,
- * `quoted_date`/`quoted_time`). We mirror that here: only the branches whose
- * dispatch the abstract `quote` doesn't thread through `this` (symbols, strings)
- * stay inline; the rest
- * delegates to {@link abstractQuote} with `this` threaded so the date/time
- * dispatch lands on MySQL's {@link quotedDate}. Non-finite numbers fall through
+ * `quoted_date`/`quoted_time`). We mirror that here: the whole body
+ * delegates to {@link abstractQuote} with `this` threaded so the string,
+ * date/time and binary dispatch land on MySQL's {@link quoteString} /
+ * {@link quotedDate} / {@link quotedBinary}. Non-finite numbers fall through
  * to the abstract `when Numeric then value.to_s` and render bare — Rails' MySQL
  * adapter has no non-finite override (only PG does). Booleans fall through to the
  * abstract `"TRUE"`/`"FALSE"`; binds serialize to 1/0 via {@link castBoundValue}.
  */
 export function quote(this: QuotingDispatchHost, value: unknown): string {
-  if (typeof value === "symbol") {
-    const desc = value.description;
-    if (desc === undefined) throw new TypeError("Cannot quote a Symbol without a description");
-    return quoteString(desc);
-  }
-  if (typeof value === "string") return quoteString(value);
-  // nil, BigDecimal, finite numbers/bigints, Class, and date/time all match the
-  // abstract `quote`. Thread `this` so `quoted_date`/`quoted_time` dispatch onto
-  // MySQL's microsecond-capped {@link quotedDate} (and the inherited quotedTime).
   return abstractQuote.call(this, value);
 }
 

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1,5 +1,6 @@
 import mysql from "mysql2/promise";
-import { Notifications } from "@blazetrails/activesupport";
+import { Temporal } from "@blazetrails/date";
+import { Notifications, BigDecimal } from "@blazetrails/activesupport";
 import { ArgumentError } from "@blazetrails/activemodel";
 import type { AbstractAdapter as DatabaseAdapter } from "./abstract-adapter.js";
 import type { IndexDefinition } from "./abstract/schema-definitions.js";
@@ -41,10 +42,9 @@ import {
   type Mysql2FieldDescriptor,
   type Mysql2RawResult,
 } from "./mysql2/database-statements.js";
-import {
-  temporalToBindString,
-  transactionIsolationLevels,
-} from "./abstract/database-statements.js";
+import { transactionIsolationLevels } from "./abstract/database-statements.js";
+import { dispatchQuotedDate, dispatchQuotedTime } from "./abstract/quoting.js";
+import { Value as TimeValue } from "../type/time.js";
 import { ActiveRecord } from "../ar-config.js";
 import { temporalTypeCast, TEMPORAL_POOL_OPTIONS } from "./mysql/temporal-type-cast.js";
 import type { SchemaSource } from "../schema-dumper.js";
@@ -893,8 +893,23 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         v = (v as { valueForDatabase: unknown }).valueForDatabase;
       }
       // `value_for_database` now yields cast Temporal values; convert to the SQL
-      // wire string the mysql2 driver expects (matching Rails' type_casted_binds).
-      v = temporalToBindString(v, "mysql");
+      // wire string the mysql2 driver expects. Rails' `type_cast` dispatches
+      // these through `self.quoted_time` / `self.quoted_date`
+      // (abstract/quoting.rb:103-104), so the microsecond capping comes from
+      // this adapter's `quotedDate` rather than a dialect argument.
+      if (v instanceof TimeValue || v instanceof Temporal.PlainTime) {
+        v = dispatchQuotedTime(this, v);
+      } else if (
+        v instanceof Temporal.Instant ||
+        v instanceof Temporal.PlainDateTime ||
+        v instanceof Temporal.PlainDate ||
+        v instanceof Temporal.ZonedDateTime
+      ) {
+        v = dispatchQuotedDate(this, v);
+      } else if (v instanceof BigDecimal) {
+        // Rails: `when BigDecimal then value.to_s("F")` (abstract/quoting.rb:101).
+        v = v.toString("F");
+      }
       // `BinaryType#serialize` yields a `Type::Binary::Data`; Rails' `type_cast`
       // unwraps it to its byte string at abstract/quoting.rb:96. This path
       // deliberately does not route through `typeCast` (see above), so unwrap

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1,12 +1,20 @@
 import pg from "pg";
 import { Temporal } from "@blazetrails/date";
-import { type Type, ValueType, ArgumentError, BinaryData } from "@blazetrails/activemodel";
+import {
+  type Type,
+  ValueType,
+  ArgumentError,
+  BinaryData,
+  DateInfinity,
+  DateNegativeInfinity,
+} from "@blazetrails/activemodel";
 import {
   singularize,
   Notifications,
   getErrorReporter,
   runLoadHooks,
   include,
+  BigDecimal,
 } from "@blazetrails/activesupport";
 import { sql as arelSql, Nodes, Visitors } from "@blazetrails/arel";
 import { isRubyTruthy } from "../ruby-truthy.js";
@@ -44,6 +52,8 @@ import {
   initializeInstanceTypeMap,
   initializeTypeMap as staticInitializeTypeMap,
 } from "./postgresql/type-map-init.js";
+import { dispatchQuotedTime } from "./abstract/quoting.js";
+import { Value as TimeValue } from "../type/time.js";
 import { inspectExplainOption } from "./abstract/database-statements.js";
 import type { ExplainOption } from "./abstract/database-statements.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./abstract-adapter.js";
@@ -90,7 +100,6 @@ import { StatementPool as GenericStatementPool } from "./statement-pool.js";
 import {
   transactionIsolationLevels,
   preprocessQuery,
-  temporalToBindString,
   extractTableRefFromInsertSql,
   sqlForInsert,
   execInsertReturningReadback,
@@ -3415,9 +3424,7 @@ export class PostgreSQLAdapter
 
   /**
    * Quote a value for inclusion in a SQL literal. PG-specific branches
-   * (XmlData, BitData, Range, ArrayData) fall through to the base
-   * dispatch, and strings use PG's `E'\\\\'`-escape form when a
-   * backslash is present.
+   * (XmlData, BitData, Range, ArrayData) fall through to the base dispatch.
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::Quoting#quote
    */
@@ -3425,6 +3432,15 @@ export class PostgreSQLAdapter
     // `.call(this)` so the inherited date/time dispatch resolves to this
     // adapter's `quotedDate` (BC-suffixing), mirroring PG#quote's `super`.
     return pgQuote.call(this, value);
+  }
+
+  /**
+   * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::Quoting#quote_string
+   * (postgresql/quoting.rb:127-131) — escape-only, so the inherited `quote`
+   * dispatches here instead of the abstract backslash-doubling escape.
+   */
+  override quoteString(s: string): string {
+    return pgQuoteString(s);
   }
 
   /**
@@ -3449,8 +3465,9 @@ export class PostgreSQLAdapter
    * Buffer so pg binds them as bytea; pg has no built-in coercion for
    * BinaryData and would `JSON.stringify` it otherwise, corrupting bytes
    * 128–255 (the PG-only encryption binary round-trip failure surfaced
-   * by Phase 9b-1). Other values flow through `temporalToBindString` for
-   * Temporal / infinity sentinel handling.
+   * by Phase 9b-1). Date/time values dispatch through this adapter's
+   * `quotedDate` / `quotedTime`, as Rails' `type_cast` does
+   * (abstract/quoting.rb:103-104).
    *
    * Mirrors Rails' `type_casted_binds` calling `type_cast` per value.
    * Detection is duck-typed (`bytes: Uint8Array`) rather than delegating
@@ -3461,6 +3478,10 @@ export class PostgreSQLAdapter
    * @internal
    */
   private _bindForPg(value: unknown): unknown {
+    // PG's date/time infinity sentinels are `Number.±Infinity`, so they must be
+    // intercepted before any numeric handling; pg wants the wire strings.
+    if (value === DateInfinity) return "infinity";
+    if (value === DateNegativeInfinity) return "-infinity";
     // Duck-type BinaryData detection: instanceof would silently miss across
     // module-identity splits (e.g. duplicated @blazetrails/activemodel copies
     // in the dep tree), in which case the wrapper would slip past as a plain
@@ -3477,8 +3498,8 @@ export class PostgreSQLAdapter
     }
     // Date/time Temporal values bind through the adapter's BC-aware `quotedDate`
     // (proleptic years ≤ 0 get the " BC" suffix); `value_for_database` now yields
-    // the cast Temporal rather than a pre-quoted string. PlainTime keeps the
-    // abstract path's 2000-01-01-stripped form via temporalToBindString below.
+    // the cast Temporal rather than a pre-quoted string. PlainTime takes the
+    // `quoted_time` arm below.
     if (
       value instanceof Temporal.Instant ||
       value instanceof Temporal.PlainDate ||
@@ -3503,7 +3524,15 @@ export class PostgreSQLAdapter
     ) {
       return this.typeCast(value);
     }
-    return temporalToBindString(value, "postgres");
+    // Rails: `when Type::Time::Value then quoted_time(value)`
+    // (abstract/quoting.rb:103).
+    if (value instanceof TimeValue || value instanceof Temporal.PlainTime) {
+      return dispatchQuotedTime(this, value);
+    }
+    // Rails: `when BigDecimal then value.to_s("F")` (abstract/quoting.rb:101) —
+    // the driver needs a primitive, not the wrapper object.
+    if (value instanceof BigDecimal) return value.toString("F");
+    return value;
   }
 
   /**
@@ -3958,7 +3987,7 @@ export class PostgreSQLAdapter
     if (value === null) return "NULL";
     if (typeof value === "number") return String(value);
     if (typeof value === "boolean") return value ? "TRUE" : "FALSE";
-    return pgQuoteString(String(value));
+    return `'${pgQuoteString(String(value))}'`;
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
@@ -405,7 +405,8 @@ describe("PostgreSQL quoting", () => {
     // objects needing a dedicated arm. They are not: `DateInfinity` IS
     // `Number.POSITIVE_INFINITY` (activemodel type/internal/sentinels.ts), so
     // they match the numeric arm and are returned identically, reaching
-    // `_bindForPg` → `temporalToBindString(v, "postgres")` exactly as before.
+    // `_bindForPg`, whose first two lines map them to the "infinity" wire
+    // strings exactly as before.
     // (On the typed path `OID::Date#serialize` has already mapped them to the
     // "infinity" wire string, so this is belt-and-braces.)
     expect(() => typeCast(DateInfinity)).not.toThrow();

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -85,11 +85,17 @@ export function quoteColumnName(name: string): string {
   return `"${name.replace(/"/g, '""')}"`;
 }
 
+/**
+ * Mirrors: PostgreSQL::Quoting#quote_string (postgresql/quoting.rb:127-131) —
+ * `connection.escape(s)`, which is **escape-only**: libpq's PQescapeStringConn
+ * doubles `'` and, with `standard_conforming_strings` on (the server default
+ * since 9.1, and what `configure_connection` leaves in place), treats a
+ * backslash as an ordinary character. The surrounding quotes are added by the
+ * caller — abstract `quote` (abstract/quoting.rb:75-76). Rails has no `E'`
+ * handling anywhere in postgresql/quoting.rb.
+ */
 export function quoteString(value: string): string {
-  if (value.includes("\\")) {
-    return `E'${value.replace(/\\/g, "\\\\").replace(/'/g, "''")}'`;
-  }
-  return `'${value.replace(/'/g, "''")}'`;
+  return value.replace(/'/g, "''");
 }
 
 export function quoteBinaryColumn(value: Buffer): string {
@@ -131,23 +137,25 @@ export function quotedBinary(
 
 export function quote(this: QuotingDispatchHost, value: unknown): string {
   if (value instanceof XmlData) {
-    return `xml ${quoteString(value.toString())}`;
+    return `xml '${quoteString(value.toString())}'`;
   }
   if (value instanceof BitData) {
     if (value.isBinary()) return `B'${value.toString()}'`;
     if (value.isHex()) return `X'${value.toString()}'`;
     return null as unknown as string;
   }
+  // rb: `when Numeric then value.finite? ? super : "'#{value}'"` — the
+  // non-finite literal is interpolated raw, not escaped.
   if (typeof value === "number" && !Number.isFinite(value)) {
-    return quoteString(String(value));
+    return `'${String(value)}'`;
   }
   if (value instanceof ArrayData) {
     // Rails: `quote(encode_array(value))` — one serialization path, the
     // encoder's delimiter (`;` for box[]), with per-element type_cast.
-    return quoteString(encodeArray.call(this, value));
+    return quote.call(this, encodeArray.call(this, value));
   }
   if (value instanceof Range) {
-    return quoteString(encodeRange.call(this, value));
+    return quote.call(this, encodeRange.call(this, value));
   }
   // Mirrors: PostgreSQL::Quoting#quote raises IntegerOutOf64BitRange for
   // integers exceeding the 64-bit signed range. Covers both bigint and
@@ -157,7 +165,8 @@ export function quote(this: QuotingDispatchHost, value: unknown): string {
     if (ActiveRecord.raiseIntWiderThan64bit) checkIntegerRange(value);
     return String(value);
   }
-  if (typeof value === "string") return quoteString(value);
+  // Rails' PG `quote` has no String/Symbol arm: both fall to `super`, which
+  // interpolates `quote_string` between quotes once (abstract/quoting.rb:75-76).
   // Thread `this` so the inherited date/time dispatch reaches PG's
   // BC-suffixing `quotedDate` (mirrors Rails' `super` call in PG#quote).
   return abstractQuote.call(this, value);

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -90,13 +90,7 @@ import { isWriteQuerySql } from "./sql-classification.js";
 import {
   quote as sqliteQuote,
   typeCast as sqliteTypeCast,
-  // Note: the standalone `quoteString` exported by sqlite3/quoting.ts
-  // returns a fully-quoted SQL literal (`'foo'`), not the escape-only
-  // form Rails' `quote_string` returns. The instance override below
-  // implements escape-only inline; the standalone is kept under an
-  // alias here for the few legacy call sites in this file that want
-  // the literal form.
-  quoteString as sqliteQuoteStringLiteral,
+  quoteString as sqliteQuoteString,
   quoteTableName,
   quoteColumnName,
   quoteTableNameForAssignment as sqliteQuoteTableNameForAssignment,
@@ -993,11 +987,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
    * Mirrors: ActiveRecord::ConnectionAdapters::SQLite3::Quoting overrides.
    */
   override quoteString(s: string): string {
-    // Mirrors: SQLite3::Quoting#quote_string — escape-only (no
-    // surrounding quotes). The standalone sqlite3/quoting.ts
-    // `quoteString` wraps for historical reasons; this override
-    // matches the Rails contract: just `'` → `''`.
-    return s.replace(/'/g, "''");
+    return sqliteQuoteString(s);
   }
 
   // quoteTableName / quoteColumnName ARE kept: Rails' SQLite3::Quoting defines
@@ -1978,12 +1968,12 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     if (schema) {
       sql =
         schema.toLowerCase() === "temp"
-          ? `SELECT sql FROM sqlite_temp_master WHERE type='table' AND name=${sqliteQuoteStringLiteral(bare)}`
-          : `SELECT sql FROM ${quoteColumnName(schema)}.sqlite_master WHERE type='table' AND name=${sqliteQuoteStringLiteral(bare)}`;
+          ? `SELECT sql FROM sqlite_temp_master WHERE type='table' AND name='${sqliteQuoteString(bare)}'`
+          : `SELECT sql FROM ${quoteColumnName(schema)}.sqlite_master WHERE type='table' AND name='${sqliteQuoteString(bare)}'`;
     } else {
-      sql = `SELECT sql FROM sqlite_temp_master WHERE type='table' AND name=${sqliteQuoteStringLiteral(bare)}
+      sql = `SELECT sql FROM sqlite_temp_master WHERE type='table' AND name='${sqliteQuoteString(bare)}'
              UNION ALL
-             SELECT sql FROM sqlite_master WHERE type='table' AND name=${sqliteQuoteStringLiteral(bare)}`;
+             SELECT sql FROM sqlite_master WHERE type='table' AND name='${sqliteQuoteString(bare)}'`;
     }
     await this.ensureConnected();
     const stmt = await this.driver.prepare(sql);
@@ -2016,15 +2006,15 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
 
   private quoteDefault(value: unknown): string {
     if (value === null) return "NULL";
-    if (typeof value === "string") return sqliteQuoteStringLiteral(value);
+    if (typeof value === "string") return `'${sqliteQuoteString(value)}'`;
     if (typeof value === "number") return String(value);
     if (typeof value === "boolean") return value ? "1" : "0";
     if (typeof value === "function") return String(value());
     // boundary: defensive Date branch in SQLite adapter literal quoting.
-    if (value instanceof globalThis.Date) return sqliteQuoteStringLiteral(value.toISOString());
+    if (value instanceof globalThis.Date) return `'${sqliteQuoteString(value.toISOString())}'`;
     // SqlLiteral or objects with toSql
     if (typeof (value as any)?.toSql === "function") return String((value as any).toSql());
-    return sqliteQuoteStringLiteral(String(value));
+    return `'${sqliteQuoteString(String(value))}'`;
   }
 
   // --- Schema introspection (drives SchemaCache.addAll) ---
@@ -2084,12 +2074,12 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
       // Schema-qualified name (e.g. "aux.widgets") — query the attached schema's catalog.
       const { sqliteMaster, bare } = this._sqliteMasterFor(name);
       const rows = (await this.schemaQuery(
-        `SELECT 1 AS one FROM ${sqliteMaster} WHERE type='table' AND name=${sqliteQuoteStringLiteral(bare)}`,
+        `SELECT 1 AS one FROM ${sqliteMaster} WHERE type='table' AND name='${sqliteQuoteString(bare)}'`,
       )) as Array<{ one: number }>;
       return rows.length > 0;
     }
     const rows = (await this.schemaQuery(
-      `SELECT name FROM pragma_table_list WHERE schema <> 'temp' AND name NOT IN ('sqlite_sequence', 'sqlite_schema') AND name = ${sqliteQuoteStringLiteral(name)} AND type IN ('table')`,
+      `SELECT name FROM pragma_table_list WHERE schema <> 'temp' AND name NOT IN ('sqlite_sequence', 'sqlite_schema') AND name = '${sqliteQuoteString(name)}' AND type IN ('table')`,
     )) as Array<{ name: string }>;
     return rows.length > 0;
   }
@@ -2368,7 +2358,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
 
   /** @internal */
   private async tableStructureSql(tableName: string, columnNames?: string[]): Promise<string[]> {
-    const querySql = `SELECT sql FROM (SELECT * FROM sqlite_master UNION ALL SELECT * FROM sqlite_temp_master) WHERE type = 'table' AND name = ${sqliteQuoteStringLiteral(tableName)}`;
+    const querySql = `SELECT sql FROM (SELECT * FROM sqlite_master UNION ALL SELECT * FROM sqlite_temp_master) WHERE type = 'table' AND name = '${sqliteQuoteString(tableName)}'`;
     const structStmt = await this.driver.prepare(querySql);
     const row = (await structStmt.get()) as { sql: string } | undefined;
     if (!row?.sql) return [];

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
@@ -26,16 +26,6 @@ import { Temporal } from "@blazetrails/date";
 import { BigDecimal } from "@blazetrails/activesupport";
 import { BinaryData } from "@blazetrails/activemodel";
 
-export interface Quoting {
-  quotedTrue(): string;
-  unquotedTrue(): number;
-  quotedFalse(): string;
-  unquotedFalse(): number;
-  quoteTableName(name: string): string;
-  quoteColumnName(name: string): string;
-  quoteString(value: string): string;
-}
-
 export function quotedTrue(): string {
   return "1";
 }
@@ -65,8 +55,14 @@ export function quoteColumnName(name: string): string {
   return `"${name.replace(/"/g, '""')}"`;
 }
 
+/**
+ * Mirrors: Quoting#quote_string — SQLite3 has no override, so this is the
+ * abstract contract (abstract/quoting.rb:131-133) minus the backslash arm:
+ * SQLite treats a backslash as an ordinary character, so only `'` is doubled.
+ * **Escape-only** — `quote` adds the surrounding quotes (rb:75-76).
+ */
 export function quoteString(value: string): string {
-  return `'${value.replace(/'/g, "''")}'`;
+  return value.replace(/'/g, "''");
 }
 
 /**
@@ -78,22 +74,15 @@ export function quoteString(value: string): string {
  * `quotedTime`. A host receiver is required — every invocation routes through
  * an adapter via `.call(this, value)`.
  *
- * The symbol and string branches stay inline because our abstract `quote`
- * renders those through the module-level, backslash-escaping `quoteString`
- * rather than dispatching through `this`, so delegating would lose SQLite's
- * `''`-only escaping. Booleans and binary DO dispatch through `this` (mirroring
- * Rails' `self.quoted_true` / `self.quoted_binary`), so both ride the inherited
- * abstract branch straight back to SQLite's `quotedTrue` / `quotedBinary`.
+ * Strings, symbols
+ * and booleans have no arm here, exactly as in Rails: they ride the inherited
+ * abstract branches, which self-dispatch `quote_string` / `quoted_true` /
+ * `quoted_false` (rb:75-78) back onto SQLite's overrides.
  */
 export function quote(this: QuotingDispatchHost, value: unknown): string {
-  if (typeof value === "number" && !Number.isFinite(value)) return quoteString(String(value));
-  if (typeof value === "symbol") {
-    if (value.description === undefined) {
-      throw new TypeError("can't quote a Symbol without a description");
-    }
-    return quoteString(value.description);
-  }
-  if (typeof value === "string") return quoteString(value);
+  // rb: `when Numeric then value.finite? ? super : "'#{value}'"` — the
+  // non-finite literal is interpolated raw, not escaped.
+  if (typeof value === "number" && !Number.isFinite(value)) return `'${String(value)}'`;
   // A *bare* `ArrayBuffer` has no Rails counterpart (Rails only ever sees
   // `Type::Binary::Data` here), and nothing in trails produces one — no internal
   // caller reaches this. It is a boundary affordance: `quoteDefaultExpression`

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -8,10 +8,11 @@ import type { Base } from "./base.js";
 import { stiName, isFinderNeedsTypeCondition } from "./inheritance.js";
 import type { Relation } from "./relation.js";
 import type { AdapterName } from "./connection-adapters/abstract-adapter.js";
+import type { QuotingDispatchHost } from "./connection-adapters/abstract/quoting.js";
 import { Result } from "./result.js";
 import { withPooledOrDirectConnection } from "./connection-handling.js";
 
-let _quoteSqlValue: ((v: unknown, dialect?: AdapterName) => string) | undefined;
+let _quoteSqlValue: ((v: unknown, connection?: QuotingDispatchHost) => string) | undefined;
 
 /**
  * @internal Receives base.ts's `quoteSqlValue` at module init. Importing it for
@@ -19,13 +20,15 @@ let _quoteSqlValue: ((v: unknown, dialect?: AdapterName) => string) | undefined;
  * leaving its own module-evaluation-time mixin wiring dependent on the graph's
  * entry order.
  */
-export function _registerQuoteSqlValue(fn: (v: unknown, dialect?: AdapterName) => string): void {
+export function _registerQuoteSqlValue(
+  fn: (v: unknown, connection?: QuotingDispatchHost) => string,
+): void {
   _quoteSqlValue = fn;
 }
 
-function quoteSqlValue(v: unknown, dialect?: AdapterName): string {
+function quoteSqlValue(v: unknown, connection?: QuotingDispatchHost): string {
   if (!_quoteSqlValue) throw new ActiveRecordError("ActiveRecord::Base has not finished loading");
-  return _quoteSqlValue(v, dialect);
+  return _quoteSqlValue(v, connection);
 }
 
 type ModelClass = typeof Base;
@@ -723,7 +726,10 @@ export class Builder implements InsertBuilder {
       if (arrayCols.has(key)) {
         return new Nodes.SqlLiteral(this._insertAll.connection.quote(value));
       }
-      return new Nodes.SqlLiteral(quoteSqlValue(value, this._dialect));
+      // Rails quotes every value with `connection.quote` (insert_all.rb Builder
+      // #values_list), so date/time literals resolve their dialect from the
+      // receiver's `quoted_date` / `quoted_time`.
+      return new Nodes.SqlLiteral(quoteSqlValue(value, this._insertAll.connection));
     });
     return new Nodes.ValuesList(rows);
   }

--- a/packages/activerecord/src/type-casted-binds-payload.trails.test.ts
+++ b/packages/activerecord/src/type-casted-binds-payload.trails.test.ts
@@ -61,8 +61,7 @@ describe("sql.active_record type_casted_binds", () => {
   });
 
   it("routes Temporal binds through the adapter's quoted_date", async () => {
-    // The deleted standalone helper converted Temporal values with
-    // `temporalToBindString`. Rails has no such helper: `type_cast` dispatches
+    // Rails has no bind-formatting helper: `type_cast` dispatches
     // Date/Time through `self.quoted_date` (abstract/quoting.rb:103-104), so the
     // adapter's own override is what fills the slot. This pins that the
     // conversion survived the sweep, and that it is the adapter's format —

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql-adapter.json
@@ -285,5 +285,12 @@
     "rubyName": "set_standard_conforming_strings",
     "call": "internal_execute",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "rubyName": "quote_string",
+    "call": "with_raw_connection",
+    "reason": "Language shortcoming: Rails' quote_string escapes through the live connection (`with_raw_connection { |c| c.escape(s) }`, postgresql/quoting.rb:127-131), but node-postgres exposes no escape entry point at all — sync or async — and `quote_string` is a sync method every `quote` call site depends on. The override reproduces libpq's standard_conforming_strings escaping inline in postgresql/quoting.ts (same divergence already baselined for that module's quote_string)."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql-adapter.json
@@ -205,6 +205,13 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "rubyName": "quote_string",
+    "call": "with_raw_connection",
+    "reason": "Language shortcoming: Rails' quote_string escapes through the live connection (`with_raw_connection { |c| c.escape(s) }`, postgresql/quoting.rb:127-131), but node-postgres exposes no escape entry point at all — sync or async — and `quote_string` is a sync method every `quote` call site depends on. The override reproduces libpq's standard_conforming_strings escaping inline in postgresql/quoting.ts (same divergence already baselined for that module's quote_string)."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "quoted_binary",
     "call": "escape_bytea",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -285,12 +292,5 @@
     "rubyName": "set_standard_conforming_strings",
     "call": "internal_execute",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "quote_string",
-    "call": "with_raw_connection",
-    "reason": "Language shortcoming: Rails' quote_string escapes through the live connection (`with_raw_connection { |c| c.escape(s) }`, postgresql/quoting.rb:127-131), but node-postgres exposes no escape entry point at all — sync or async — and `quote_string` is a sync method every `quote` call site depends on. The override reproduces libpq's standard_conforming_strings escaping inline in postgresql/quoting.ts (same divergence already baselined for that module's quote_string)."
   }
 ]


### PR DESCRIPTION
Four of the five bundled stories. The fifth,
`converge-execute-batch-through-raw-execute`, is **blocked**, not shipped — see
the bottom of this description.

## `quote_string` is escape-only (RFC 0077)

Rails' `quote_string` escapes and nothing else, in every layer —
`abstract/quoting.rb:131-133` (`gsub("\\", '\&\&').gsub("'", "''")`) and
`postgresql/quoting.rb:127-131` (`connection.escape(s)`). The surrounding quotes
are added once by the caller, in abstract `quote` (`rb:75-76`). trails' dialect
`quoteString` functions returned a finished literal instead, which is the root
cause of the String/Symbol arms PG and SQLite carried that Rails does not have.

- Abstract `quote` self-dispatches `quote_string` through a new
  `dispatchQuoteString`, alongside the existing `dispatchQuoted*` helpers.
- PG / SQLite / MySQL `quoteString` are now escape-only. PG's `E'`-prefix
  branch is gone: libpq's `PQescapeStringConn` is escape-only, and with
  `standard_conforming_strings` on (server default since 9.1) `'a\b'` and
  `E'a\\b'` denote the same string, so the rendered literal is unchanged.
- PG and SQLite `quote` drop their String/Symbol arms and fall through to
  abstract `quote`; their non-finite Numeric arm now interpolates raw
  (`"'#{value}'"`), and PG's array/range arms route through `quote`, matching
  `quote(encode_array(value))`.
- `PostgreSQLAdapter` gains the `quote_string` override Rails has; the MySQL
  and SQLite adapter overrides delegate to their module function instead of
  keeping a second inline escape table (`QUOTE_STRING_RE`/`_MAP` deleted).
- Callers that wanted the literal form (sqlite3-adapter's `sqlite_master`
  probes, PG's `quoteLiteral`) wrap at the call site.

One new call-baseline row: PG's adapter-level `quote_string` cannot call
`with_raw_connection` — node-postgres exposes no escape entry point at all, and
`quote_string` is sync. Same divergence already baselined for the module-level
function.

## Temporal binds dispatch through the adapter (RFC 0077)

Rails has no bind-formatting helper: `type_cast` dispatches date/time values
through `self.quoted_date` / `self.quoted_time` (`abstract/quoting.rb:103-104`),
so the adapter's own override is the single formatter. `temporalToBindString`
was a parallel one, switching on a `"sqlite" | "postgres" | "mysql"` argument.
It is deleted; the three remaining call sites resolve dialect by receiver:

- `PostgreSQLAdapter#_bindForPg` — infinity sentinels move to the top (they are
  `Number.±Infinity`, so they must be intercepted before any numeric handling),
  then `quotedDate` / `quotedTime` / the BigDecimal `to_s("F")` arm.
- `Mysql2Adapter#mysqlBinds` — `dispatchQuotedDate` / `dispatchQuotedTime`, so
  the microsecond cap comes from MySQL's `quotedDate`.
- `Base.quoteSqlValue` takes a connection instead of a dialect name, and
  `InsertAll::Builder` passes `this._insertAll.connection` — Rails quotes every
  `values_list` value with `connection.quote`.

## MySQL `quoteColumnName` `*` branch (RFC 0077)

`mysql/quoting.rb:46-47` is unconditional; trails returned `*` bare. A star
projection never reaches the adapter — Arel renders it as a `SqlLiteral`
(`arel/src/visitors/to-sql.ts:1350`) — so the branch was redundant as well as
divergent.

## Dead per-adapter `Quoting` interfaces (RFC 0077)

Deleted from `mysql/quoting.ts` and `sqlite3/quoting.ts`, as PG's was in #4895.
No importer; the contract lives at `abstract/quoting-interface.ts`. The
boolean-literal *functions* are untouched — Rails genuinely defines those.

## Verification

- `pnpm typecheck`, `pnpm lint` clean.
- All 132 suites under `connection-adapters/` + `adapters/` green (1897 tests),
  plus `insert-all`, `sanitize`, `base.trails`, `precision-roundtrip`,
  `type-casted-binds-payload`, `quoting-contract`.
- `pnpm api:calls` OK. `pnpm test:compare` unchanged at 15397/22727 (67.7%).

## `converge-execute-batch-through-raw-execute` — blocked, not in this PR

`rawExecute` calls `this.performQuery`, which is assigned on exactly one
prototype (`postgresql-adapter.ts:5028`); sqlite3 and mysql2 keep trails-shaped
**private** `_performQuery`, so `rawExecute` raises `NotImplementedError` there.
`rawExecute` also never calls `log`, so routing batches through it would stop
emitting `sql.active_record` for every fixture load / `truncate_tables` /
schema apply and take them out of `support/ddl-profile.ts`'s leaf patches.
Blocked with that reason; the prerequisite is
`wire-raw-execute-through-log` (already filed, ready) plus the new
`wire-perform-query-on-sqlite3-mysql2-prototypes`.

Also filed: `mysql-quote-override-has-no-rails-counterpart` — with the
String/Symbol arms gone, MySQL's `quote` is a pure delegation and Rails has no
MySQL `quote` override at all, so it and the `AbstractMysqlAdapter` override
should both go. Kept out of here to avoid rewriting two more test files.

Closes-story: converge-temporal-bind-formatting-onto-adapter
Closes-story: dialect-quotestring-returns-literal-not-escape-only
Closes-story: mysql-quote-column-name-star-branch-invented
Closes-story: remove-dead-per-adapter-quoting-interfaces
