### PR TITLE
fix(activerecord): retarget the RETURNING-rows citation at the live successor story

### DIFF
--- a/packages/activerecord/src/sqlite/statement-reader.test.ts
+++ b/packages/activerecord/src/sqlite/statement-reader.test.ts
@@ -67,7 +67,7 @@ const adapters: [string, () => SQLite3Adapter, boolean][] = [
 // trails invention; Rails branches on `column_count.zero?` alone. Removing the
 // isWrite gate would cost `executeMutation` the atomic RunResult rowid that PR
 // 4893 introduced, so it is tracked separately as
-// sqlite-perform-query-iswrite-gate-drops-returning-rows.
+// sqlite-performquery-contract-deviations-need-lock.
 describe.each(adapters)("SQLite3Adapter RETURNING rows — %s", (_name, build, available) => {
   it.skipIf(!available)("internalExecQuery returns the RETURNING rows", async () => {
     const adapter = build();


### PR DESCRIPTION
Unit Tests went red on main @a55f218b: `scripts/stale-story-references.test.ts >
no comment or markdown paragraph in the tree names a story that has already
landed` flagged

    packages/activerecord/src/sqlite/statement-reader.test.ts:65 sqlite-perform-query-iswrite-gate-drops-returning-rows

That story was closed as merged into
`sqlite-performquery-contract-deviations-need-lock` (`0076-execute-primitive-convergence`):
same root cause (no connection lock), one fix, and splitting them would
double-claim the same PR. The deviation the comment describes is still live, so
the comment stays — it just needs to name the story that now tracks it. The
successor is `status: ready`, so the gate passes.

Verified: `pnpm vitest run scripts/stale-story-references.test.ts` — 17 passed.

Closes-story: red-a55f218b-r2
