### PR TITLE
fix(date,activerecord): constructor fraction bounds and guess_style's proleptic arms; adapter overrides onto the prototype; drop the adapter-free ANSI quoter

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -339,8 +339,13 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    * `quotedTrue`/`quotedFalse` are NOT overridden — Rails MySQL inherits the
    * abstract `"TRUE"`/`"FALSE"`. Binds serialize to 1/0 via `cast_bound_value`.
    */
-  override quoteTableName = mysqlQuoteTableName;
-  override quoteColumnName = mysqlQuoteColumnName;
+  override quoteTableName(name: string): string {
+    return mysqlQuoteTableName(name);
+  }
+
+  override quoteColumnName(name: string): string {
+    return mysqlQuoteColumnName(name);
+  }
 
   // Defined as methods, not class fields: Rails declares these with `def`
   // (`mysql/quoting.rb:72-77`), and the inherited `type_cast` reaches them

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -73,19 +73,6 @@ type TemporalDateLike =
   | Temporal.PlainTime;
 
 /**
- * ANSI double-quote identifier quoter (`""`-escaped). Not a Rails-layer
- * method — Rails' abstract `Quoting` has no `quote_identifier`. This is the
- * SQL-92 fallback used only by the `ABSTRACT_QUOTER` crutch in
- * `sanitization.ts`; every real adapter quotes through its own
- * dialect-specific helper.
- *
- * @internal
- */
-export function quoteIdentifier(name: string): string {
-  return `"${name.replace(/"/g, '""')}"`;
-}
-
-/**
  * Quotes the column name. Must be implemented by subclasses — the abstract
  * layer raises, mirroring Rails where every adapter defines its own.
  *

--- a/packages/activerecord/src/connection-adapters/adapter-overrides-on-prototype.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/adapter-overrides-on-prototype.trails.test.ts
@@ -16,8 +16,6 @@ describe("adapter overrides live on the prototype, as Rails' `def` does", () => 
 
     expect(adapter.quoteColumnName("email")).toBe("`email`");
     expect(adapter.quoteTableName("foo.bar")).toBe("`foo`.`bar`");
-    // quote_table_name_for_assignment dispatches back through the receiver
-    // (`abstract/quoting.rb:153-155`), so it degrades with them.
     expect(adapter.quoteTableNameForAssignment("foo", "bar")).toBe("`foo`.`bar`");
   });
 

--- a/packages/activerecord/src/connection-adapters/adapter-overrides-on-prototype.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/adapter-overrides-on-prototype.trails.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { AbstractMysqlAdapter } from "./abstract-mysql-adapter.js";
+import { PostgreSQLAdapter } from "./postgresql-adapter.js";
+
+// Trails-specific guard (no Rails counterpart, because Ruby has no way to
+// express the bug): Rails declares every adapter override with `def`, so it
+// lands on the class and any receiver of that class resolves it. A TS class
+// FIELD (`override quoteTableName = mysqlQuoteTableName;`) lands on the
+// instance instead, so a receiver derived from the prototype alone silently
+// resolves the abstract member — a plausible wrong result rather than a crash,
+// and the abstract quoter emits ANSI double quotes where MySQL wants backticks
+// (`mysql/quoting.rb:46-52`, `postgresql/referential_integrity.rb:5-36`).
+describe("adapter overrides live on the prototype, as Rails' `def` does", () => {
+  it("resolves the MySQL identifier quoters through the adapter override", () => {
+    const adapter = Object.create(AbstractMysqlAdapter.prototype) as AbstractMysqlAdapter;
+
+    expect(adapter.quoteColumnName("email")).toBe("`email`");
+    expect(adapter.quoteTableName("foo.bar")).toBe("`foo`.`bar`");
+    // quote_table_name_for_assignment dispatches back through the receiver
+    // (`abstract/quoting.rb:153-155`), so it degrades with them.
+    expect(adapter.quoteTableNameForAssignment("foo", "bar")).toBe("`foo`.`bar`");
+  });
+
+  it("resolves PostgreSQL's disable_referential_integrity through the adapter override", () => {
+    expect(Object.hasOwn(PostgreSQLAdapter.prototype, "disableReferentialIntegrity")).toBe(true);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3877,7 +3877,12 @@ export class PostgreSQLAdapter
   // Mirrors: ReferentialIntegrity#disable_referential_integrity. Extracted to
   // postgresql/referential-integrity.ts (Rails houses this in the
   // ReferentialIntegrity module, not schema_statements.rb).
-  override disableReferentialIntegrity = disableReferentialIntegrity;
+  override disableReferentialIntegrity(
+    fn: () => Promise<void>,
+    scopedTables?: string[],
+  ): Promise<void> {
+    return disableReferentialIntegrity.call(this, fn, scopedTables);
+  }
 
   // Mirrors: ReferentialIntegrity#check_all_foreign_keys_valid!
   checkAllForeignKeysValidBang = checkAllForeignKeysValidBang;

--- a/packages/activerecord/src/sanitization-quoter.test.ts
+++ b/packages/activerecord/src/sanitization-quoter.test.ts
@@ -97,6 +97,13 @@ describe("sanitization class-method dispatch threads `this.connection`", () => {
     ).toThrow(ConnectionNotDefined);
   });
 
+  // Rails opens `with_connection` per quoting branch, and the `statement.blank?`
+  // arm sits between them (sanitization.rb:174-175) — it answers the statement
+  // back without ever asking for a connection.
+  it("answers a blank statement without asking for a connection", () => {
+    expect(ClassMethods.sanitizeSqlArray.call({}, "")).toBe("");
+  });
+
   it("propagates non-ConnectionNotDefined errors from host.connection", () => {
     const host = {
       get connection(): never {

--- a/packages/activerecord/src/sanitization-quoter.test.ts
+++ b/packages/activerecord/src/sanitization-quoter.test.ts
@@ -77,15 +77,24 @@ describe("sanitization class-method dispatch threads `this.connection`", () => {
     expect(ClassMethods.sanitizeSqlArray.call(mysqlHost, "name = ?", "x")).toBe("name = 'x'");
   });
 
-  it("falls back to abstract quoter when host.connection throws ConnectionNotDefined", () => {
+  // Rails has no adapter-free quoter: every `sanitize_sql_array` branch runs
+  // inside `with_connection { |c| ... }` (sanitization.rb:167-179) and the
+  // abstract `quote_column_name` is `raise NotImplementedError`
+  // (abstract/quoting.rb:61). A host with no connection therefore surfaces the
+  // connection error rather than emitting the ANSI SQL no adapter asked for —
+  // which on MySQL would have been silently wrong.
+  it("raises ConnectionNotDefined when host.connection has no adapter", () => {
     const host = {
       get connection(): never {
         throw new ConnectionNotDefined("No database connection defined.");
       },
     };
-    expect(ClassMethods.sanitizeSqlHashForAssignment.call(host, { name: "x" }, "users")).toBe(
-      `"users"."name" = 'x'`,
-    );
+    expect(() =>
+      ClassMethods.sanitizeSqlHashForAssignment.call(host, { name: "x" }, "users"),
+    ).toThrow(ConnectionNotDefined);
+    expect(() =>
+      ClassMethods.sanitizeSqlHashForAssignment.call({}, { name: "x" }, "users"),
+    ).toThrow(ConnectionNotDefined);
   });
 
   it("propagates non-ConnectionNotDefined errors from host.connection", () => {

--- a/packages/activerecord/src/sanitization.ts
+++ b/packages/activerecord/src/sanitization.ts
@@ -189,7 +189,8 @@ interface QuoterHost {
 
 /**
  * Resolves quoting via `connection`, which is the `with_connection { |c| ... }`
- * every `sanitize_sql_array` branch runs inside (sanitization.rb:167-179).
+ * each QUOTING branch of `sanitize_sql_array` opens for itself
+ * (sanitization.rb:167-179) — never the `statement.blank?` arm between them.
  * Rails has no adapter-free quoter to fall back to — `quote_column_name` is
  * `raise NotImplementedError` on the abstract (abstract/quoting.rb:61) — so a
  * caller with no connection surfaces the connection error rather than emitting

--- a/packages/activerecord/src/sanitization.ts
+++ b/packages/activerecord/src/sanitization.ts
@@ -5,13 +5,7 @@
  */
 
 import { Nodes, sql as arelSql } from "@blazetrails/arel";
-import {
-  quote as abstractQuote,
-  quoteIdentifier as abstractQuoteIdentifier,
-  quoteString as abstractQuoteString,
-  castBoundValue as abstractCastBoundValue,
-  columnNameWithOrderMatcher as abstractColumnNameWithOrderMatcher,
-} from "./connection-adapters/abstract/quoting.js";
+import { columnNameWithOrderMatcher as abstractColumnNameWithOrderMatcher } from "./connection-adapters/abstract/quoting.js";
 import type { Quoting } from "./connection-adapters/abstract/quoting.js";
 import {
   ConnectionNotDefined,
@@ -24,26 +18,6 @@ export type Quoter = Pick<
   Quoting,
   "quote" | "quoteColumnName" | "quoteTableNameForAssignment" | "quoteString" | "castBoundValue"
 >;
-
-/**
- * Guarded no-connection fallback, used only by {@link quoterFor} when a model
- * class has no resolvable adapter (e.g. `connection` raises
- * `ConnectionNotDefined`). Every connected caller quotes through the live
- * adapter's quoter; this pins SQL-92 rules purely so sanitization can still
- * run before a connection is established. @internal
- */
-const ABSTRACT_QUOTER: Quoter = {
-  // `abstractQuote` requires a host receiver; this ANSI fallback has no adapter,
-  // so bind a bare host — date/time values route through the module helpers.
-  quote: (v) => abstractQuote.call({}, v),
-  quoteColumnName: (n) => abstractQuoteIdentifier(n),
-  // ANSI fallback: the abstract `quoteTableNameForAssignment` delegates to the
-  // throwing `quoteColumnName`, so render `"table"."attr"` directly here.
-  quoteTableNameForAssignment: (t, a) =>
-    `${abstractQuoteIdentifier(t)}.${abstractQuoteIdentifier(a)}`,
-  quoteString: (s) => abstractQuoteString(s),
-  castBoundValue: (v) => abstractCastBoundValue(v),
-};
 
 /** @internal */
 function _sanitizeSqlArray(quoter: Quoter, template: string, binds: unknown[]): string {
@@ -204,17 +178,16 @@ interface QuoterHost {
 }
 
 /**
- * Resolves quoting via `connection`. Only `ConnectionNotDefined` triggers
- * fallback to the abstract quoter; other errors propagate. @internal
+ * Resolves quoting via `connection`, which is the `with_connection { |c| ... }`
+ * every `sanitize_sql_array` branch runs inside (sanitization.rb:167-179).
+ * Rails has no adapter-free quoter to fall back to — `quote_column_name` is
+ * `raise NotImplementedError` on the abstract (abstract/quoting.rb:61) — so a
+ * caller with no connection surfaces the connection error rather than emitting
+ * ANSI SQL no adapter asked for. @internal
  */
 function quoterFor(host: QuoterHost): Quoter {
-  let conn: Quoter | null | undefined;
-  try {
-    conn = host.connection as Quoter | null | undefined;
-  } catch (err) {
-    if (!(err instanceof ConnectionNotDefined)) throw err;
-  }
-  if (!conn || typeof conn.quote !== "function") return ABSTRACT_QUOTER;
+  const conn = host.connection as Quoter | null | undefined;
+  if (!conn || typeof conn.quote !== "function") throw new ConnectionNotDefined();
   return conn;
 }
 

--- a/packages/activerecord/src/sanitization.ts
+++ b/packages/activerecord/src/sanitization.ts
@@ -19,17 +19,26 @@ export type Quoter = Pick<
   "quote" | "quoteColumnName" | "quoteTableNameForAssignment" | "quoteString" | "castBoundValue"
 >;
 
-/** @internal */
-function _sanitizeSqlArray(quoter: Quoter, template: string, binds: unknown[]): string {
+/**
+ * `withConnection` is Rails' `with_connection { |c| ... }`, which each quoting
+ * branch opens for itself (sanitization.rb:167-179) — the `statement.blank?`
+ * arm between them answers without one, so the lookup cannot be hoisted ahead
+ * of it. @internal
+ */
+function _sanitizeSqlArray(
+  withConnection: () => Quoter,
+  template: string,
+  binds: unknown[],
+): string {
   const statement = template;
   const [first] = binds;
 
   if (isPlainHash(first) && /:\w+/.test(statement)) {
-    return replaceNamedBindVariables(quoter, statement, first as Record<string, unknown>);
+    return replaceNamedBindVariables(withConnection(), statement, first as Record<string, unknown>);
   }
 
   if (statement.includes("?")) {
-    return replaceBindVariables(quoter, statement, binds);
+    return replaceBindVariables(withConnection(), statement, binds);
   }
 
   if (statement === "") {
@@ -37,6 +46,7 @@ function _sanitizeSqlArray(quoter: Quoter, template: string, binds: unknown[]): 
     return statement;
   }
 
+  const quoter = withConnection();
   // Format-string support (e.g., "name = '%s'", "id = %d") — Rails:
   //   statement % values.collect { |v| connection.quote_string(v.to_s) }
   // Ruby's Kernel#format applies after each value is quoted to a string, so
@@ -215,7 +225,7 @@ function orderMatcherFor(host: QuoterHost): RegExp {
  * Mirrors: ActiveRecord::Sanitization::ClassMethods#sanitize_sql_array
  */
 export function sanitizeSqlArray(this: QuoterHost, template: string, ...binds: unknown[]): string {
-  return _sanitizeSqlArray(quoterFor(this), template, binds);
+  return _sanitizeSqlArray(() => quoterFor(this), template, binds);
 }
 
 /**

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -927,6 +927,37 @@ describe("Date", () => {
     }
   });
 
+  it("takes guess_style's proleptic arms for an infinite start, as date_initialize does", () => {
+    // ruby 3.3.11 -rdate — `Date::GREGORIAN` is proleptic Gregorian everywhere,
+    // so 1500 has no leap day and 1582-10-10 is a real day the reform never
+    // deleted; `Date::JULIAN` is proleptic Julian everywhere, so 1900 does have
+    // one:
+    //   Date.new(1500, 2, 29, Date::GREGORIAN) #=> Date::Error: invalid date
+    //   Date.new(1500, 2, 28, Date::GREGORIAN).jd #=> 2268982
+    //   Date.new(1582, 10, 10, Date::GREGORIAN).to_s #=> "1582-10-10"
+    //   Date.new(1900, 2, 29, Date::JULIAN).to_s #=> "1900-02-29"
+    //   Date.new(2000, 1, 1, Date::JULIAN).jd #=> 2451558
+    expect(() => new RubyDate(1500, 2, 29, RubyDate.GREGORIAN)).toThrow("invalid date");
+    expect(new RubyDate(1500, 2, 28, RubyDate.GREGORIAN).jd).toBe(2268982);
+    expect(new RubyDate(1582, 10, 10, RubyDate.GREGORIAN).toS()).toBe("1582-10-10");
+    expect(new RubyDate(1900, 2, 29, RubyDate.JULIAN).toS()).toBe("1900-02-29");
+    expect(new RubyDate(2000, 1, 1, RubyDate.JULIAN).jd).toBe(2451558);
+    // datetime_initialize takes the same two arms:
+    //   DateTime.new(1500, 2, 29, 0, 0, 0, 0, Date::GREGORIAN) #=> Date::Error
+    //   DateTime.new(1900, 2, 29, 1, 2, 3, 0, Date::JULIAN).to_s
+    //     #=> "1900-02-29T01:02:03+00:00"
+    expect(() => new RubyDateTime(1500, 2, 29, 0, 0, 0, 0, RubyDate.GREGORIAN)).toThrow(
+      "invalid date",
+    );
+    expect(new RubyDateTime(1900, 2, 29, 1, 2, 3, 0, RubyDate.JULIAN).toS()).toBe(
+      "1900-02-29T01:02:03+00:00",
+    );
+    // A year past REFORM_END_YEAR takes the proleptic Gregorian arm under the
+    // default start too, and answers the same day:
+    //   Date.new(600000, 1, 1).jd #=> 220866560
+    expect(new RubyDate(600000, 1, 1).jd).toBe(220866560);
+  });
+
   it("raises from every static that answers the seat for a Julian-only spelling", () => {
     // ruby 3.3.11 -rdate answers "1500-02-29" from all six — the gem's `::Date`
     // value is the gem object, so `date_to_date` (date_core.c:8977-8981) is
@@ -1323,6 +1354,23 @@ describe("DateTime", () => {
     // fraction illegal:
     //   DateTime.new(2008, 3, 1, 6, 0, 0.5, 3600).sec_fraction #=> (1/2)
     expect(new RubyDateTime(2008, 3, 1, 6, 0, 0.5, 3600).secFraction).toEqual(new Rational(1, 2));
+  });
+
+  it("counts the offset and the start among the positions the fraction bound reads", () => {
+    // ruby 3.3.11 — num2int_with_frac's `argc > n` counts EVERY position, so an
+    // offset or a start makes an earlier fraction illegal:
+    //   DateTime.new(2008, 3, 1, 6, 0.5, 0, "+09:00")          #=> Date::Error: invalid fraction
+    //   DateTime.new(2008, 3, 1, 6, 0.5, 0, 0, Date::ITALY)    #=> Date::Error: invalid fraction
+    //   DateTime.new(2008, 3, 1.5, 0, 0, 0, "+09:00")          #=> Date::Error: invalid fraction
+    expect(() => new RubyDateTime(2008, 3, 1, 6, 0.5, undefined, "+09:00")).toThrow(
+      "invalid fraction",
+    );
+    expect(
+      () => new RubyDateTime(2008, 3, 1, 6, 0.5, undefined, undefined, RubyDate.ITALY),
+    ).toThrow("invalid fraction");
+    expect(() => new RubyDateTime(2008, 3, 1.5, undefined, undefined, undefined, "+09:00")).toThrow(
+      "invalid fraction",
+    );
   });
 
   it("carries the fraction of a legal non-final argument through add_frac", () => {

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -3250,18 +3250,21 @@ function cValidGregorianP(y: number, m: number, d: number): [rm: number, rd: num
  * The C's `ry`/`rm`/`rd` out-parameters come back as the tuple; its `nth` does
  * not, for the reason {@link guessStyle} states.
  *
- * `decode_year` (`date_core.c:1342-1371`) reduces to the `FIX2INT` its Bignum
- * arm ends at once `nth` is out: the year is shifted by 4712, divided by
- * `CM_PERIOD_GCY` into an `nth` that is zero over the whole representable
- * range, and shifted back — the identity, but for the truncation, which is what
- * answers `Date.new(2000.5, 1, 1)` as 2000-01-01 in MRI.
+ * `decode_year` (`date_core.c:1342-1371`) reduces to the shift, the `FIX2INT`
+ * its Bignum arm ends at, and the unshift once `nth` is out: the year is
+ * shifted by 4712, divided by `CM_PERIOD_GCY` into an `nth` that is zero over
+ * the whole representable range, and shifted back. That leaves the identity but
+ * for the truncation, which is what answers `Date.new(2000.5, 1, 1)` as
+ * 2000-01-01 and `Date.new(-2000.5, 1, 1, Date::GREGORIAN)` as -2001-01-01 in
+ * MRI — the truncation is of the SHIFTED value, so it rounds toward -4712
+ * rather than toward zero.
  */
 function validGregorianP(
   y: number,
   m: number,
   d: number,
 ): [ry: number, rm: number, rd: number] | null {
-  const ry = Math.trunc(y);
+  const ry = Math.trunc(y + 4712) - 4712;
   const r = cValidGregorianP(ry, m, d);
   if (r === null) return null;
   return [ry, r[0], r[1]];
@@ -3273,9 +3276,9 @@ function validGregorianP(
  * negative style is proleptic Gregorian, a positive one proleptic Julian, and
  * `0` means the reform round trip under `sg` decides.
  *
- * The C's middle arm — `!FIXNUM_P(y)`, a Bignum year — has no reachable
- * analogue: every `y` here is a JS number, which is the `FIXNUM` case, so the
- * arm is written as the range where a Bignum year begins. Beyond it the C
+ * The C's middle arm — `!FIXNUM_P(y)`, a year Ruby holds as something other
+ * than a Fixnum — is written here as the range a JS number stops being one
+ * over, which is what a non-integer or out-of-safe-range `y` is. Beyond it the C
  * decomposes the year into `nth` plus a residue (`decode_year`,
  * `date_core.c:1342-1371`) so the Julian day still fits a Fixnum; trails
  * carries the whole Julian day in a JS number instead, which is exact up to

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -2962,6 +2962,15 @@ const GREGORIAN = -Infinity;
 const DEFAULT_SG = ITALY;
 
 /**
+ * @internal `date_core.c`'s `REFORM_BEGIN_YEAR` / `REFORM_END_YEAR`
+ * (`date_core.c:207-208`), the years {@link guessStyle} brackets: a year before
+ * the first is proleptic Julian whatever `sg` says, and one after the last
+ * proleptic Gregorian.
+ */
+const REFORM_BEGIN_YEAR = 1582;
+const REFORM_END_YEAR = 1930;
+
+/**
  * @internal `date_core.c`'s `REFORM_BEGIN_JD` / `REFORM_END_JD`
  * (`date_core.c:209-210`), the window a finite `start` has to fall in — ns
  * 1582-01-01 through os 1930-12-31, the span over which the reform was actually
@@ -3195,6 +3204,71 @@ function div(n: number, d: number): number {
 /** @internal `date_core.c`'s `MOD` macro (`date_core.c:169-171`), floored modulo. */
 function mod(n: number, d: number): number {
   return n - d * div(n, d);
+}
+
+/**
+ * @internal `date_core.c`'s `monthtab` (`date_core.c:697-700`), the last day of
+ * each month indexed by leap year then by month, with a `0` in the unused
+ * zeroth column so the month is its own index.
+ */
+const MONTHTAB: readonly (readonly number[])[] = [
+  [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
+  [0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
+];
+
+/** @internal `date_core.c` `c_gregorian_leap_p` (`date_core.c:709-713`). */
+function cGregorianLeapP(y: number): boolean {
+  return (mod(y, 4) === 0 && y % 100 !== 0) || mod(y, 400) === 0;
+}
+
+/** @internal `date_core.c` `c_gregorian_last_day_of_month` (`date_core.c:723-728`). */
+function cGregorianLastDayOfMonth(y: number, m: number): number {
+  return MONTHTAB[cGregorianLeapP(y) ? 1 : 0][m];
+}
+
+/**
+ * @internal `date_core.c` `c_valid_gregorian_p` (`date_core.c:747-765`), the
+ * PROLEPTIC Gregorian validity check — it reads no `sg` and does no Julian-day
+ * round trip, so it accepts exactly the days the Gregorian calendar has,
+ * extended in both directions. A negative `m` counts back from a thirteenth
+ * month and a negative `d` from the month's last day, as in
+ * {@link cValidCivilP}. The C's `rm`/`rd` out-parameters come back as the
+ * tuple, `null` for its `0`.
+ */
+function cValidGregorianP(y: number, m: number, d: number): [rm: number, rd: number] | null {
+  if (m < 0) m += 13;
+  if (m < 1 || m > 12) return null;
+  const last = cGregorianLastDayOfMonth(y, m);
+  if (d < 0) d = last + d + 1;
+  if (d < 1 || d > last) return null;
+  return [m, d];
+}
+
+/**
+ * @internal `date_core.c` `guess_style` (`date_core.c:1414-1433`), which
+ * answers `-inf`, `+inf` or `0` for the calendar the year and start select: a
+ * negative style is proleptic Gregorian, a positive one proleptic Julian, and
+ * `0` means the reform round trip under `sg` decides.
+ *
+ * The C's middle arm — `!FIXNUM_P(y)`, a Bignum year — has no reachable
+ * analogue: every `y` here is a JS number, which is the `FIXNUM` case, so the
+ * arm is written as the range where a Bignum year begins. Beyond it the C
+ * decomposes the year into `nth` plus a residue (`decode_year`,
+ * `date_core.c:1342-1371`) so the Julian day still fits a Fixnum; trails
+ * carries the whole Julian day in a JS number instead, which is exact up to
+ * `Number.MAX_SAFE_INTEGER` — roughly year ±2.4e10 — and loses precision, not
+ * range, above that. Years past that limit are the documented gap.
+ */
+function guessStyle(y: number, sg: number): number {
+  let style = 0;
+
+  if (!Number.isFinite(sg)) style = sg;
+  else if (!Number.isSafeInteger(y)) style = y > 0 ? GREGORIAN : JULIAN;
+  else {
+    if (y < REFORM_BEGIN_YEAR) style = JULIAN;
+    else if (y > REFORM_END_YEAR) style = GREGORIAN;
+  }
+  return style;
 }
 
 /**
@@ -3930,8 +4004,13 @@ export class Date {
    * The `start` ARGUMENT is {@link #sg} below: every conversion is read under
    * it, and {@link Date#start}, {@link Date#isJulian} and
    * {@link Date#newStart} answer off it.
+   *
+   * It is optional because `date_initialize`'s proleptic-Gregorian arm
+   * (`date_core.c:3532-3542`) stores `HAVE_CIVIL` alone with no Julian day at
+   * all; {@link Date.#getSJd} is `get_s_jd` (`date_core.c:1168-1187`), which
+   * fills it in on first read.
    */
-  readonly #jd: number;
+  #jd?: number;
 
   /**
    * @internal `SimpleDateData`'s `sg` (`date_core.c:203-213`), the
@@ -3969,10 +4048,32 @@ export class Date {
       return;
     }
     const sg = val2sg(start);
-    const r = cValidCivilP(year, month, day, sg);
-    if (r === null) throw new DateError("invalid date");
-    this.#jd = r;
-    this.#sg = sg;
+    if (guessStyle(year, sg) < 0) {
+      const r = cValidGregorianP(year, month, day);
+      if (r === null) throw new DateError("invalid date");
+      const [rm, rd] = r;
+      this.#sg = sg;
+      this.#civil = [year, rm, rd];
+    } else {
+      const r = cValidCivilP(year, month, day, sg);
+      if (r === null) throw new DateError("invalid date");
+      this.#jd = r;
+      this.#sg = sg;
+    }
+  }
+
+  /**
+   * @internal `date_core.c` `get_s_jd` (`date_core.c:1168-1187`), the lazy half
+   * of `SimpleDateData`: when the proleptic-Gregorian arm of `date_initialize`
+   * stored the civil triple alone, the Julian day is `c_civil_to_jd` of it
+   * under `s_virtual_sg` — the stored `sg` — computed on first read and kept.
+   */
+  #getSJd(): number {
+    if (this.#jd === undefined) {
+      const [year, mon, mday] = this.#civil as [number, number, number];
+      this.#jd = cCivilToJd(year, mon, mday, this.#sg);
+    }
+    return this.#jd;
   }
 
   /**
@@ -4180,7 +4281,7 @@ export class Date {
    * `Temporal.PlainDate`'s own proleptic Gregorian readers do not.
    */
   get jd(): number {
-    return this.#jd;
+    return this.#getSJd();
   }
 
   /**
@@ -4216,7 +4317,7 @@ export class Date {
    * one on `DateTime` — hence the override there.
    */
   get isJulian(): boolean {
-    return mJulianP(this.#jd, this.#sg);
+    return mJulianP(this.#getSJd(), this.#sg);
   }
 
   /**
@@ -4255,7 +4356,7 @@ export class Date {
    * `DateTime`.
    */
   newStart(start = DEFAULT_SG): this {
-    return new Date(SEAT, this.#jd, val2sg(start)) as this;
+    return new Date(SEAT, this.#getSJd(), val2sg(start)) as this;
   }
 
   /**
@@ -4440,9 +4541,18 @@ export class DateTime extends DateWithoutParseStatics {
    * (`date_core.c:8297-8306`, which sets `of` itself under its own seconds
    * bound rather than going through `val2off`).
    *
-   * `datetime_initialize` (`date_core.c:5147-5220`) validates the civil date with
-   * `c_valid_civil_p` and the time of day with `c_valid_time_p`, then stores the
-   * day and day-fraction in UTC — which is what the two conversions below do.
+   * `datetime_initialize` (`date_core.c:7850-7893`) branches on
+   * {@link guessStyle}: its negative arm validates the civil date with
+   * `c_valid_gregorian_p` — proleptic Gregorian, no reform round trip — and
+   * stores `HAVE_CIVIL | HAVE_TIME` with no Julian day, while its positive/zero
+   * arm goes through `c_valid_civil_p` under `sg` and stores `jd_local_to_utc`
+   * of it too. Both then validate the time of day with `c_valid_time_p`.
+   *
+   * The Julian day the C's negative arm leaves out is computed eagerly here,
+   * with the `get_c_jd` (`date_core.c:1262-1301`) body the C would run on first
+   * read — `c_civil_to_jd` under the stored `sg` — because `add_frac` is applied
+   * in place below rather than by handing `self` to `d_lite_plus`, so there is
+   * no point at which the day is still unread.
    *
    * `datetime_initialize`'s `switch (argc)` fall-through
    * (`date_core.c:7826-7849`) splits the second, then the minute, then the
@@ -4515,7 +4625,7 @@ export class DateTime extends DateWithoutParseStatics {
     minute?: number | Rational,
     second?: number | Rational,
     offset?: number | Rational | string,
-    start = DEFAULT_SG,
+    start?: number,
   ) {
     if (typeof year === "symbol") {
       const rjd = month as number;
@@ -4530,16 +4640,24 @@ export class DateTime extends DateWithoutParseStatics {
       return;
     }
     const [s, sFr] = num2intWithFrac(second ?? 0, 1, false);
-    const [min, minFr] = num2intWithFrac(minute ?? 0, MINUTE_IN_SECONDS, second !== undefined);
+    const [min, minFr] = num2intWithFrac(
+      minute ?? 0,
+      MINUTE_IN_SECONDS,
+      second !== undefined || offset !== undefined || start !== undefined,
+    );
     const [h, hFr] = num2intWithFrac(
       hour ?? 0,
       HOUR_IN_SECONDS,
-      minute !== undefined || second !== undefined,
+      minute !== undefined || second !== undefined || offset !== undefined || start !== undefined,
     );
     const [d, dFr] = num2intWithFrac(
       day ?? 1,
       DAY_IN_SECONDS,
-      hour !== undefined || minute !== undefined || second !== undefined,
+      hour !== undefined ||
+        minute !== undefined ||
+        second !== undefined ||
+        offset !== undefined ||
+        start !== undefined,
     );
     let fr2: number | Rational = 0;
     if (sFr !== 0) fr2 = sFr;
@@ -4547,10 +4665,18 @@ export class DateTime extends DateWithoutParseStatics {
     if (hFr !== 0) fr2 = hFr;
     if (dFr !== 0) fr2 = dFr;
     const rof = offset === undefined ? 0 : val2off(offset);
-    const sg = val2sg(start);
-    super(year, month ?? 1, d, sg);
-    const rjd = cValidCivilP(year, month ?? 1, d, sg);
-    if (rjd === null) throw new DateError("invalid date");
+    const sg = start === undefined ? DEFAULT_SG : val2sg(start);
+    let rjd: number;
+    if (guessStyle(year, sg) < 0) {
+      const r = cValidGregorianP(year, month ?? 1, d);
+      if (r === null) throw new DateError("invalid date");
+      const [rm, rd] = r;
+      rjd = cCivilToJd(year, rm, rd, sg);
+    } else {
+      const r = cValidCivilP(year, month ?? 1, d, sg);
+      if (r === null) throw new DateError("invalid date");
+      rjd = r;
+    }
     const rt = cValidTimeP(h, min, s);
     if (rt === null) throw new DateError("invalid date");
     let [rh] = rt;
@@ -4561,6 +4687,7 @@ export class DateTime extends DateWithoutParseStatics {
     }
     const localDf = timeToDf(rh, rmin, rs);
     const [jd, df, sf] = addFrac(jdLocalToUtc(rjd, localDf, rof), dfLocalToUtc(localDf, rof), fr2);
+    super(SEAT, jdUtcToLocal(jd, df, rof), sg);
     this.#jd = jd;
     this.#df = df;
     this.#sf = sf;

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -3245,6 +3245,29 @@ function cValidGregorianP(y: number, m: number, d: number): [rm: number, rd: num
 }
 
 /**
+ * @internal `date_core.c` `valid_gregorian_p` (`date_core.c:2229-2236`), which
+ * is `decode_year` under a negative style followed by {@link cValidGregorianP}.
+ * The C's `ry`/`rm`/`rd` out-parameters come back as the tuple; its `nth` does
+ * not, for the reason {@link guessStyle} states.
+ *
+ * `decode_year` (`date_core.c:1342-1371`) reduces to the `FIX2INT` its Bignum
+ * arm ends at once `nth` is out: the year is shifted by 4712, divided by
+ * `CM_PERIOD_GCY` into an `nth` that is zero over the whole representable
+ * range, and shifted back — the identity, but for the truncation, which is what
+ * answers `Date.new(2000.5, 1, 1)` as 2000-01-01 in MRI.
+ */
+function validGregorianP(
+  y: number,
+  m: number,
+  d: number,
+): [ry: number, rm: number, rd: number] | null {
+  const ry = Math.trunc(y);
+  const r = cValidGregorianP(ry, m, d);
+  if (r === null) return null;
+  return [ry, r[0], r[1]];
+}
+
+/**
  * @internal `date_core.c` `guess_style` (`date_core.c:1414-1433`), which
  * answers `-inf`, `+inf` or `0` for the calendar the year and start select: a
  * negative style is proleptic Gregorian, a positive one proleptic Julian, and
@@ -4049,11 +4072,10 @@ export class Date {
     }
     const sg = val2sg(start);
     if (guessStyle(year, sg) < 0) {
-      const r = cValidGregorianP(year, month, day);
+      const r = validGregorianP(year, month, day);
       if (r === null) throw new DateError("invalid date");
-      const [rm, rd] = r;
       this.#sg = sg;
-      this.#civil = [year, rm, rd];
+      this.#civil = r;
     } else {
       const r = cValidCivilP(year, month, day, sg);
       if (r === null) throw new DateError("invalid date");
@@ -4668,10 +4690,10 @@ export class DateTime extends DateWithoutParseStatics {
     const sg = start === undefined ? DEFAULT_SG : val2sg(start);
     let rjd: number;
     if (guessStyle(year, sg) < 0) {
-      const r = cValidGregorianP(year, month ?? 1, d);
+      const r = validGregorianP(year, month ?? 1, d);
       if (r === null) throw new DateError("invalid date");
-      const [rm, rd] = r;
-      rjd = cCivilToJd(year, rm, rd, sg);
+      const [ry, rm, rd] = r;
+      rjd = cCivilToJd(ry, rm, rd, sg);
     } else {
       const r = cValidCivilP(year, month ?? 1, d, sg);
       if (r === null) throw new DateError("invalid date");

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql-adapter.json
@@ -100,6 +100,20 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "rubyName": "disable_referential_integrity",
+    "call": "collect",
+    "reason": "The body lives in postgresql/referential-integrity.ts — Rails houses it in the ReferentialIntegrity module too (postgresql/referential_integrity.rb:5-36) — and makes both calls there; the adapter member is the include seam."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "rubyName": "disable_referential_integrity",
+    "call": "quote_table_name",
+    "reason": "The body lives in postgresql/referential-integrity.ts — Rails houses it in the ReferentialIntegrity module too (postgresql/referential_integrity.rb:5-36) — and makes both calls there; the adapter member is the include seam."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "disconnect!",
     "call": "synchronize",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -278,19 +292,5 @@
     "rubyName": "set_standard_conforming_strings",
     "call": "internal_execute",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "disable_referential_integrity",
-    "call": "collect",
-    "reason": "The body lives in postgresql/referential-integrity.ts — Rails houses it in the ReferentialIntegrity module too (postgresql/referential_integrity.rb:5-36) — and makes both calls there; the adapter member is the include seam."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "disable_referential_integrity",
-    "call": "quote_table_name",
-    "reason": "The body lives in postgresql/referential-integrity.ts — Rails houses it in the ReferentialIntegrity module too (postgresql/referential_integrity.rb:5-36) — and makes both calls there; the adapter member is the include seam."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql-adapter.json
@@ -278,5 +278,19 @@
     "rubyName": "set_standard_conforming_strings",
     "call": "internal_execute",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "rubyName": "disable_referential_integrity",
+    "call": "collect",
+    "reason": "The body lives in postgresql/referential-integrity.ts — Rails houses it in the ReferentialIntegrity module too (postgresql/referential_integrity.rb:5-36) — and makes both calls there; the adapter member is the include seam."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "rubyName": "disable_referential_integrity",
+    "call": "quote_table_name",
+    "reason": "The body lives in postgresql/referential-integrity.ts — Rails houses it in the ReferentialIntegrity module too (postgresql/referential_integrity.rb:5-36) — and makes both calls there; the adapter member is the include seam."
   }
 ]


### PR DESCRIPTION
Bundle of five stories. Four ship; one is blocked on an unmerged dependency and was handed back.

## `date` — constructor fraction bound counts every position (`datetime-constructor-fraction-bound-ignores-offset-and-start`)

`num2int_with_frac` (`date_core.c:3296-3303`) raises `"invalid fraction"` when `argc > n`, and `argc` counts **every** position — `offset` and `start` included. The `DateTime` constructor ORed in only the later fraction-bearing fields, so `new DateTime(2008, 3, 1, 6, 0.5, undefined, "+09:00")` silently accepted a fraction MRI rejects at `argc == 7 > 5`. The three bounds now OR in every later position, exactly as the `DateTime.jd` / `.ordinal` / `.commercial` builders in the same file already do (#6285).

`start`'s default moved off the parameter into the body (`start === undefined ? DEFAULT_SG : val2sg(start)`, as `DateTime.jd` spells it) — a TS default parameter is never `undefined` inside, so the presence test needs the bare optional.

## `date` — `guess_style`'s proleptic arms (`datetime-constructors-skip-guess-style-proleptic-arms`)

`date_initialize` (`date_core.c:3532-3555`) and `datetime_initialize` (`:7850-7893`) branch on `guess_style` (`:1414-1433`): a negative style takes a **proleptic Gregorian** arm over `valid_gregorian_p` with no reform round trip; otherwise `valid_civil_p` under `sg`. Both constructors now make that branch, over ported `guess_style`, `valid_gregorian_p`, `c_valid_gregorian_p`, `c_gregorian_last_day_of_month` and `c_gregorian_leap_p`. `valid_gregorian_p` keeps the C decomposition, and with `nth` out its `decode_year` reduces to the `FIX2INT` truncation that answers `Date.new(2000.5, 1, 1)` as 2000-01-01 in MRI.

`Date`'s `#jd` became optional with a `get_s_jd` (`:1168-1187`) that fills it on first read, mirroring the C's `HAVE_CIVIL`-only state. `DateTime` computes the same value eagerly, because `add_frac` is applied in place there rather than by handing `self` to `d_lite_plus` — noted at the call site.

**`nth`:** the C's `decode_year` split exists so the Julian day stays a Fixnum. A JS number carries the whole day exactly to `Number.MAX_SAFE_INTEGER` (~year ±2.4e10), so there is no `nth` to carry below that and precision, not range, is what runs out above it. The limit is stated in `guess_style`'s doc, per the story's second acceptance option.

Every value verified against `ruby 3.3.11 -rdate`, including the ones a Julian/Gregorian start newly changes:

| | MRI | trails |
|---|---|---|
| `Date.new(1500,2,29,Date::GREGORIAN)` | `Date::Error` | `Date::Error` |
| `Date.new(1500,2,28,Date::GREGORIAN).jd` | `2268982` | `2268982` |
| `Date.new(1582,10,10,Date::GREGORIAN).to_s` | `"1582-10-10"` | same |
| `Date.new(1900,2,29,Date::JULIAN).to_s` | `"1900-02-29"` | same |
| `Date.new(2000,1,1,Date::JULIAN).jd` | `2451558` | `2451558` |
| `DateTime.new(1900,2,29,1,2,3,0,Date::JULIAN).to_s` | `"1900-02-29T01:02:03+00:00"` | same |
| `Date.new(600000,1,1).jd` | `220866560` | `220866560` |

## `activerecord` — overrides become prototype methods (`adapter-override-fields-should-be-prototype-methods`)

Rails declares adapter overrides with `def`. The three remaining `override x = fn;` class fields landed on the *instance*, so a receiver derived from the prototype alone resolved the abstract member instead — a plausible wrong result, not a crash (backticks silently becoming ANSI double quotes). `quoteTableName` / `quoteColumnName` (`abstract-mysql-adapter.ts`) and `disableReferentialIntegrity` (`postgresql-adapter.ts`) are now methods, matching the already-converged `unquotedTrue` / `unquotedFalse` pair beside them. A trails guard pins the prototype-derived host.

The PG conversion surfaces two call rows: the member was a field, so its body was never compared. The body itself is in `postgresql/referential-integrity.ts` — where Rails also houses it (`postgresql/referential_integrity.rb:5-36`) — and does make both calls; the two rows are baselined with that reason.

## `activerecord` — the adapter-free ANSI quoter is gone (`remove-adapter-free-ansi-quoter-fallbacks`)

Rails has no adapter-free identifier quoter: every `sanitize_sql_array` branch runs inside `with_connection` (`sanitization.rb:167-179`) and abstract `quote_column_name` is `raise NotImplementedError` (`abstract/quoting.rb:61`). `sanitization.ts`'s `ABSTRACT_QUOTER` and the standalone `quoteIdentifier` it was the last consumer of are deleted; `quoterFor` now lets the connection error propagate rather than emitting ANSI SQL that is simply wrong on MySQL. `ABSTRACT_SCHEMA_QUOTER` was already gone; its stale doc comment went with the function.

The one test pinning the crutch now pins the raise instead.

## Handed back: `mysql-quote-override-absent-in-rails`

Blocked (`pnpm tasks block`) on its own declared dependency, `dialect-quotestring-returns-literal-not-escape-only`, which is in-progress on #6288 — and this repo does not stack PRs. MySQL's `quoteString` still returns a **full** literal (`'...'`) rather than Rails' escape-only `quote_string`, so deleting the MySQL `quote` override today would route strings through abstract `quote`'s `'${quoteString(v)}'` and double-quote every one.

The story's behavioral question is already answered on `main`: the non-finite-Float arm is gone and the finding is recorded at `mysql/quoting.ts` — Rails' MySQL sends `Float::INFINITY` through abstract `quote`'s `when Numeric then value.to_s` (`abstract/quoting.rb:82`) with no guard. Only the override's deletion remains, and it unblocks the moment #6288 lands.

Closes-story: datetime-constructor-fraction-bound-ignores-offset-and-start
Closes-story: datetime-constructors-skip-guess-style-proleptic-arms
Closes-story: adapter-override-fields-should-be-prototype-methods
Closes-story: remove-adapter-free-ansi-quoter-fallbacks
