### PR TITLE
fix(activerecord): delegate adapter type_cast to abstract, drop adapter-less quoter guards, inline binds when unprepared

### DIFF
--- a/packages/activerecord/src/binary.trails.test.ts
+++ b/packages/activerecord/src/binary.trails.test.ts
@@ -49,14 +49,19 @@ describe("binary type_casted_binds payload", () => {
     expect(new Uint8Array(out[0] as Uint8Array)).toEqual(bytes);
   });
 
-  it("reaches type_cast wrapped, so the chain needs no bare-bytes arm", async () => {
-    // `BinaryType#serialize` wraps at the source (binary.rb:30-33), so Rails'
-    // `type_cast` only ever sees a `Type::Binary::Data` and its terminal
-    // `raise TypeError` (abstract/quoting.rb:105) is unreachable for bytes.
-    // Ours now matches: an unwrapped `Uint8Array` is not a bindable value.
+  it("casts both byte forms Rails reaches type_cast with", async () => {
+    // Rails sees bytes here two ways, and both arms are inherited from the
+    // abstract chain now that sqlite3/mysql end at `else super`:
+    //   - `Type::Binary::Data`, which `BinaryType#serialize` wraps at the source
+    //     (binary.rb:30-33) → unwrapped by rb:96's `value.to_s`.
+    //   - a BINARY/ASCII-8BIT `String` on the `execute(sql, binds)` boundary →
+    //     passed through by rb:102's `when nil, Numeric, String then value`.
+    //     A JS string can't hold arbitrary bytes, so a byte view is that form.
     const bytes = new Uint8Array([0xde, 0xad]);
     expect(new BinaryType().serialize(bytes)).toBeInstanceOf(BinaryData);
     const conn = await Base.connection;
-    expect(() => conn.typeCast(bytes)).toThrow(TypeError);
+    for (const cast of [conn.typeCast(new BinaryData(bytes)), conn.typeCast(bytes)]) {
+      expect(new Uint8Array(cast as Uint8Array)).toEqual(bytes);
+    }
   });
 });

--- a/packages/activerecord/src/binary.trails.test.ts
+++ b/packages/activerecord/src/binary.trails.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { BinaryData } from "@blazetrails/activemodel";
+import { BinaryData, BinaryType } from "@blazetrails/activemodel";
 import { fixtures } from "./test-fixtures.js";
 import { Binary } from "./test-helpers/models/binary.js";
 import { Base } from "./base.js";
@@ -47,5 +47,16 @@ describe("binary type_casted_binds payload", () => {
     expect(String(out[0])).not.toBe("[object Object]");
     // PG's type_cast returns a Buffer (bytea); normalize before comparing bytes.
     expect(new Uint8Array(out[0] as Uint8Array)).toEqual(bytes);
+  });
+
+  it("reaches type_cast wrapped, so the chain needs no bare-bytes arm", async () => {
+    // `BinaryType#serialize` wraps at the source (binary.rb:30-33), so Rails'
+    // `type_cast` only ever sees a `Type::Binary::Data` and its terminal
+    // `raise TypeError` (abstract/quoting.rb:105) is unreachable for bytes.
+    // Ours now matches: an unwrapped `Uint8Array` is not a bindable value.
+    const bytes = new Uint8Array([0xde, 0xad]);
+    expect(new BinaryType().serialize(bytes)).toBeInstanceOf(BinaryData);
+    const conn = await Base.connection;
+    expect(() => conn.typeCast(bytes)).toThrow(TypeError);
   });
 });

--- a/packages/activerecord/src/column-definition.test.ts
+++ b/packages/activerecord/src/column-definition.test.ts
@@ -1,11 +1,16 @@
 import { describe, it, expect } from "vitest";
 import { SchemaCreation } from "./connection-adapters/abstract/schema-creation.js";
 import { ColumnDefinition } from "./connection-adapters/abstract/schema-definitions.js";
-import { quoteDefaultExpression } from "./connection-adapters/abstract/quoting.js";
+import { quoteDefaultExpression, lookupCastType } from "./connection-adapters/abstract/quoting.js";
+import { AbstractAdapter } from "./connection-adapters/abstract-adapter.js";
+import { TypeMap } from "./type/type-map.js";
 import type {
   ColumnType,
   ColumnOptions,
 } from "./connection-adapters/abstract/schema-definitions.js";
+
+const TYPE_MAP = new TypeMap();
+AbstractAdapter.initializeTypeMap(TYPE_MAP);
 
 // Mirrors Rails' ColumnDefinitionTest::DummyAdapter: native_database_types
 // maps `string` to "varchar" and quote_column_name is the identity. The visitor
@@ -18,6 +23,11 @@ class DummyCreation extends SchemaCreation {
       quoteColumnName: (name: string) => name,
       quoteTableName: (name: string) => name,
       quoteDefaultExpression,
+      // `quote_default_expression` dispatches `lookup_cast_type` on the adapter
+      // (abstract/quoting.rb:161); `DummyAdapter < AbstractAdapter`, so it
+      // answers from the abstract type map.
+      lookupCastType: (sqlType: string | null) =>
+        lookupCastType.call({ typeMap: TYPE_MAP }, sqlType),
       nativeDatabaseTypes: () => ({ string: "varchar" }),
       supportsCheckConstraints: async () => false,
       supportsExclusionConstraints: () => false,
@@ -27,7 +37,7 @@ class DummyCreation extends SchemaCreation {
       supportsPartialIndex: () => false,
       supportsUniqueConstraints: () => false,
       useForeignKeys: () => true,
-    });
+    } as unknown as ConstructorParameters<typeof SchemaCreation>[0]);
   }
 
   typeToSql(type: ColumnType, options: ColumnOptions = {}): string {

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -202,12 +202,31 @@ export class DatabaseStatementsBase {
  * (display SQL, statement-cache fallbacks) inlines this way, or an unbound `?`
  * would leak into executable SQL.
  */
-function compileInlined(visitor: Visitors.ToSql, node: Nodes.Node, host: unknown): string {
+function compileInlined(
+  visitor: Visitors.ToSql,
+  node: Nodes.Node,
+  host: unknown,
+): [string, boolean] {
   const collector = new Collectors.SubstituteBinds(
     host as { quote(value: unknown): string },
     new Collectors.SQLString(),
   );
-  return visitor.compile(node, collector);
+  // Rails reads `allow_retry = collector.retryable` after the compile
+  // (database_statements.rb:45), so the visitor can clear it mid-traversal.
+  const sql = visitor.compile(node, collector);
+  return [sql, collector.retryable];
+}
+
+/**
+ * Rails' `if prepared_statements` test in `to_sql_and_binds`
+ * (database_statements.rb:31). A host with no flag at all is not an adapter
+ * (bare visitor stand-ins in tests / statement-cache helpers); Rails' default
+ * is `true`, so only an explicit `false` selects the inlining collector.
+ */
+function isUnprepared(host: unknown): boolean {
+  return (
+    (host as { preparedStatements?: boolean } | null | undefined)?.preparedStatements === false
+  );
 }
 
 /**
@@ -236,7 +255,8 @@ export function toSql(
   // `compileWithBinds` for execution (placeholders + bind array).
   const visitor = (this as any)?.visitor as Visitors.ToSql | undefined;
   if (visitor && node instanceof Nodes.Node) {
-    return compileInlined(visitor, node, this);
+    const [inlinedSql] = compileInlined(visitor, node, this);
+    return inlinedSql;
   }
   if (node && typeof (node as any).toSql === "function") {
     return (node as any).toSql();
@@ -284,6 +304,15 @@ export function toSqlAndBinds(
     }
     const visitor = (this as any)?.visitor as Visitors.ToSql | undefined;
     if (visitor && node instanceof Nodes.Node) {
+      // Rails: `if prepared_statements ... else sql = visitor.compile(arel, collector)`
+      // (database_statements.rb:31-45). With prepared statements off the
+      // collector is a `SubstituteBinds` (abstract_adapter.rb#collector), so
+      // every value inlines during traversal and `binds` comes back empty —
+      // there is no bind extraction to fall back from.
+      if (isUnprepared(this)) {
+        const [inlinedSql, inlinedRetryable] = compileInlined(visitor, node, this);
+        return [inlinedSql, [], false, inlinedRetryable];
+      }
       const [sql, extractedBinds, compiledAllowRetry, compiledPreparable] =
         visitor.compileWithBinds(node);
       // Rails hands the compiled binds on untouched — `ActiveModel::Attribute`
@@ -303,7 +332,8 @@ export function toSqlAndBinds(
           extractedBinds.length,
         )
       ) {
-        return [compileInlined(visitor, node, this), [], false, compiledAllowRetry];
+        const [overLimitSql] = compileInlined(visitor, node, this);
+        return [overLimitSql, [], false, compiledAllowRetry];
       }
       return [sql, extractedBinds, compiledPreparable, compiledAllowRetry];
     }
@@ -363,7 +393,7 @@ export function cacheableQuery(
     sql = arel;
   } else if (visitor && node instanceof Nodes.Node) {
     // Returns empty binds below, so inline any BindParams into the SQL string.
-    sql = compileInlined(visitor, node, host);
+    [sql] = compileInlined(visitor, node, host);
   } else {
     sql = (node as any).toSql?.() ?? String(node);
   }

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -218,18 +218,6 @@ function compileInlined(
 }
 
 /**
- * Rails' `if prepared_statements` test in `to_sql_and_binds`
- * (database_statements.rb:31). A host with no flag at all is not an adapter
- * (bare visitor stand-ins in tests / statement-cache helpers); Rails' default
- * is `true`, so only an explicit `false` selects the inlining collector.
- */
-function isUnprepared(host: unknown): boolean {
-  return (
-    (host as { preparedStatements?: boolean } | null | undefined)?.preparedStatements === false
-  );
-}
-
-/**
  * Converts an arel AST to SQL.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#to_sql
@@ -307,11 +295,13 @@ export function toSqlAndBinds(
       // Rails: `if prepared_statements ... else sql = visitor.compile(arel, collector)`
       // (database_statements.rb:31-45). With prepared statements off the
       // collector is a `SubstituteBinds` (abstract_adapter.rb#collector), so
-      // every value inlines during traversal and `binds` comes back empty —
-      // there is no bind extraction to fall back from.
-      if (isUnprepared(this)) {
+      // every value inlines during traversal, `binds` comes back empty and
+      // `preparable` is never assigned. A host carrying no flag at all is not an
+      // adapter (bare visitor stand-ins), and Rails' default is `true`, so only
+      // an explicit `false` takes this branch.
+      if ((this as { preparedStatements?: boolean } | undefined)?.preparedStatements === false) {
         const [inlinedSql, inlinedRetryable] = compileInlined(visitor, node, this);
-        return [inlinedSql, [], false, inlinedRetryable];
+        return [inlinedSql, [], preparable, inlinedRetryable];
       }
       const [sql, extractedBinds, compiledAllowRetry, compiledPreparable] =
         visitor.compileWithBinds(node);
@@ -332,8 +322,11 @@ export function toSqlAndBinds(
           extractedBinds.length,
         )
       ) {
-        const [overLimitSql] = compileInlined(visitor, node, this);
-        return [overLimitSql, [], false, compiledAllowRetry];
+        // Rails re-enters `to_sql_and_binds` under `unprepared_statement`
+        // (database_statements.rb:36-38), so the retryable flag is the *inner*
+        // compile's, not the abandoned prepared one's.
+        const [overLimitSql, overLimitRetryable] = compileInlined(visitor, node, this);
+        return [overLimitSql, [], false, overLimitRetryable];
       }
       return [sql, extractedBinds, compiledPreparable, compiledAllowRetry];
     }

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -195,7 +195,16 @@ export function typeCast(this: QuotingDispatchHost, value: unknown): unknown {
   // Rails: `when BigDecimal then value.to_s("F")` — bound as a fixed-form string.
   if (value instanceof BigDecimal) return value.toString("F");
   if (typeof value === "number" || typeof value === "bigint") return value;
+  // Rails: `when nil, Numeric, String then value` (rb:102). A Ruby String here
+  // is frequently a BINARY/ASCII-8BIT one — `execute(sql, binds)` callers bind
+  // raw bytes that way, which is what sqlite3's `test_type_cast_binary_encoding_
+  // _without_logger` (test/cases/adapters/sqlite3/quoting_test.rb:32) and
+  // `test_type_cast_should_not_mutate_encoding` (sqlite3_adapter_test.rb:482)
+  // pass. A JS string is UTF-16 and cannot carry arbitrary bytes, so the byte
+  // views are this arm's analogue, not a fourth branch: they pass through
+  // untouched exactly as Rails passes the String through.
   if (typeof value === "string") return value;
+  if (ArrayBuffer.isView(value)) return value;
   // Rails dispatches `Type::Time::Value` through `self.quoted_time` and
   // `Date`/`Time` through `self.quoted_date` (abstract/quoting.rb:103-104), the
   // same self-dispatch `quote` uses. Thread `this` so adapter overrides — e.g.

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -186,15 +186,6 @@ export function typeCast(this: QuotingDispatchHost, value: unknown): unknown {
   // path for a binary attribute lands here.
   if (typeof value === "symbol") return value.description ?? String(value);
   if (value instanceof BinaryData) return value.bytes;
-  // ArrayBuffer views have no Ruby analogue (#4868): Rails only ever sees a
-  // `Type::Binary::Data` here. `quote` already normalizes a view to bytes at the
-  // rb:83 position; `type_cast` must do the same at rb:96, or a bare Uint8Array
-  // bind (MySQL's binary driver binds are not `Data`-wrapped) falls through to
-  // the raise below with "can't cast Uint8Array".
-  if (value instanceof Uint8Array) return value;
-  if (ArrayBuffer.isView(value)) {
-    return new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
-  }
   // Rails: `when true then unquoted_true` / `when false then unquoted_false`
   // (rb:98-99) — self-dispatched, so MySQL's `1`/`0` override applies to the
   // inherited `type_cast`. Thread `this` to mirror that.
@@ -240,32 +231,21 @@ export function castBoundValue(value: unknown): unknown {
  */
 export interface QuotingHost {
   /** @internal */
-  lookupCastType?(sqlType: string | null): unknown;
+  lookupCastType(sqlType: string | null): unknown;
 }
 
 /**
  * Look up the cast type from a column. Delegates to lookupCastType(column.sql_type)
  * on the adapter, matching Rails' internal delegation chain.
  *
- * Rails can call `lookup_cast_type` unconditionally because every host of this
- * module is an adapter. This standalone version is also bound to adapter-less
- * hosts (the MySQL schema quoter) that have no type
- * map, so it keeps the guard and hands back the raw sql_type for them; the
- * adapter method (`AbstractAdapter#lookupCastTypeFromColumn`) is the
- * unconditional one-liner.
- *
  * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#lookup_cast_type_from_column
+ * (abstract/quoting.rb:125-127 — `lookup_cast_type(column.sql_type)`)
  */
 export function lookupCastTypeFromColumn(
-  this: QuotingHost | void,
+  this: QuotingHost,
   column: { sqlType: string | null },
 ): unknown {
-  const sqlType = column.sqlType;
-  if (!sqlType) return null;
-  if (this && typeof this === "object" && typeof this.lookupCastType === "function") {
-    return this.lookupCastType(sqlType);
-  }
-  return sqlType;
+  return this.lookupCastType(column.sqlType);
 }
 
 /**
@@ -282,11 +262,14 @@ export function quoteString(s: string): string {
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quote_table_name_for_assignment
  */
-export function quoteTableNameForAssignment(table: string, attr: string): string {
-  // `quoteTableName` requires a host receiver; this module-level helper has no
-  // adapter, so bind a bare host — dispatch falls to the throwing
-  // `quoteColumnName`, matching Rails' abstract behaviour.
-  return quoteTableName.call({}, `${table}.${attr}`);
+export function quoteTableNameForAssignment(
+  this: QuotingDispatchHost,
+  table: string,
+  attr: string,
+): string {
+  // Rails: `quote_table_name("#{table}.#{attr}")` (abstract/quoting.rb:153) —
+  // self-dispatched, which MySQL's `table`.`attr` override depends on.
+  return quoteTableName.call(this, `${table}.${attr}`);
 }
 
 /**
@@ -319,13 +302,13 @@ export function quoteDefaultExpression(
   }
   if (isSqlLiteral(value)) return value.value;
   // Rails: `value = lookup_cast_type(column.sql_type).serialize(value)`
-  // (abstract/quoting.rb:161). Rails dispatches `lookup_cast_type`
-  // unconditionally; the optional call is for the adapter-free hosts this
-  // standalone version also serves, which have no type map, so their values pass
-  // through unserialized.
+  // (abstract/quoting.rb:161) — dispatched unconditionally, since every host of
+  // this module is an adapter carrying a type map. `column` stays optional only
+  // because trails' DDL callers reach `SET DEFAULT` with no column in hand
+  // (schema-statements.ts:600); Rails' signature requires it.
   let serialized: unknown = value;
   if (column != null) {
-    const castType = this.lookupCastType?.(column.sqlType ?? null) as {
+    const castType = this.lookupCastType(column.sqlType ?? null) as {
       serialize?(v: unknown): unknown;
     } | null;
     if (castType && typeof castType.serialize === "function") {

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -18,16 +18,14 @@ import {
   formatPlainDateForSql,
 } from "../abstract/sql-datetime.js";
 import {
+  typeCast as abstractTypeCast,
   toBytes,
   dispatchQuotedDate,
   dispatchQuotedTime,
-  dispatchUnquotedTrue,
-  dispatchUnquotedFalse,
   type QuotingDispatchHost,
 } from "../abstract/quoting.js";
 import { Temporal } from "@blazetrails/date";
 import { Value as TimeValue } from "../../type/time.js";
-import { BigDecimal } from "@blazetrails/activesupport";
 import { BinaryData } from "@blazetrails/activemodel";
 
 // Rails MySQL overrides unquoted_true/false (1/0) but NOT quoted_true/false,
@@ -225,37 +223,12 @@ export function quotedDate(
  * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::Quoting#type_cast
  */
 export function typeCast(this: QuotingDispatchHost, value: unknown): unknown {
-  if (typeof value === "symbol") return value.description ?? String(value);
-  // Rails' MySQL `type_cast` falls through to `super` for anything it does not
-  // special-case, reaching the abstract `when ... Type::Binary::Data then
-  // value.to_s` (abstract/quoting.rb:96). This chain does not delegate, so the
-  // arm is inlined: `to_s` on a `Data` is the raw byte string, hence `.bytes`
-  // (never `toString()`, which UTF-8-decodes and mangles bytes >= 0x80).
-  if (value instanceof BinaryData) return value.bytes;
-  // Same rb:96 position, same reason as the abstract chain: an ArrayBuffer view
-  // has no Ruby analogue (#4868), and mysql2's binary binds arrive as a bare
-  // Uint8Array rather than a `Data`, so without this arm they reach the raise
-  // below with "can't cast Uint8Array".
-  if (value instanceof Uint8Array) return value;
-  if (ArrayBuffer.isView(value)) {
-    return new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
-  }
-  // Rails' MySQL `type_cast` falls through to `super` here, whose boolean arm is
-  // self-dispatched (abstract/quoting.rb:98-99) and lands on MySQL's `1`/`0`
-  // override. This chain does not delegate, so the arm is inlined — but it
-  // dispatches through `this` rather than the module-level pair, so the receiver
-  // decides, as in Rails.
-  if (typeof value === "boolean")
-    return value ? dispatchUnquotedTrue(this) : dispatchUnquotedFalse(this);
-  if (value === null || value === undefined) return value;
-  if (typeof value === "number" || typeof value === "bigint") return value;
-  if (typeof value === "string") return value;
-  // Rails type_cast: `when BigDecimal then value.to_s("F")`.
-  if (value instanceof BigDecimal) return value.toString("F");
-  // Rails dispatches date/time through `self.quoted_time` / `self.quoted_date`
-  // (abstract/quoting.rb:93-101); thread `this` so MySQL's microsecond-capping
-  // `quotedDate` override is honored here. Always invoked with an adapter
-  // receiver — the standalone is never called receiver-less.
+  // Rails' MySQL override special-cases only the temporal arms — `when
+  // ActiveSupport::TimeWithZone` / `when Time` / `when Date`
+  // (mysql/quoting.rb:94-118) — because mysql2 handles those classes more
+  // efficiently than Strings. trails' drivers take the SQL wire string, so the
+  // arms dispatch through `self.quoted_time` / `self.quoted_date`, threading
+  // `this` so MySQL's microsecond-capping `quotedDate` override is honored.
   if (value instanceof TimeValue || value instanceof Temporal.PlainTime)
     return dispatchQuotedTime(this, value);
   if (
@@ -266,9 +239,10 @@ export function typeCast(this: QuotingDispatchHost, value: unknown): unknown {
   ) {
     return dispatchQuotedDate(this, value);
   }
-  if (value instanceof Date)
-    throw new TypeError(
-      "typeCast: JS Date is not accepted — use a Temporal type (Instant, PlainDateTime, etc.)",
-    );
-  throw new TypeError(`can't cast ${(value as object).constructor?.name ?? typeof value}`);
+  // Rails: `else super` (mysql/quoting.rb:119-120). Symbol/`Type::Binary::Data`
+  // (rb:95-96), the self-dispatched `unquoted_true`/`unquoted_false` pair
+  // (rb:98-99), BigDecimal, the pass-throughs and the terminal raise (rb:105)
+  // are all inherited from the abstract `type_cast` rather than duplicated
+  // here, so a new abstract arm costs exactly one edit.
+  return abstractTypeCast.call(this, value);
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -254,6 +254,15 @@ export function typeCast(this: QuotingDispatchHost, value: unknown): unknown {
     // Rails: `when OID::Array::Data then encode_array(value)`.
     return encodeArray.call(this, value);
   }
+  // Rails' `when OID::Array::Data` above is the only array arm it needs, because
+  // a pg-ruby bind is always a String — the encoder has already run.
+  // node-postgres instead accepts a JS array and encodes it itself, so
+  // `execute(sql, [["one", "two"]])` (array.test.ts "mutate array") reaches here
+  // unwrapped. The elements still go through `type_cast_array`
+  // (postgresql/quoting.rb:221-226) so a Temporal or BinaryData element is cast
+  // rather than handed to the driver raw — the encoder is what this skips, not
+  // the per-element cast.
+  if (Array.isArray(value)) return typeCastArray.call(this, value);
   if (value instanceof Range) {
     return encodeRange.call(this, value);
   }

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -247,7 +247,6 @@ export function typeCast(this: QuotingDispatchHost, value: unknown): unknown {
     const u8 = value.bytes;
     return Buffer.from(u8.buffer, u8.byteOffset, u8.byteLength);
   }
-  if (value instanceof Uint8Array) return value;
   if (value instanceof XmlData || value instanceof BitData) {
     return value.toString();
   }
@@ -255,15 +254,6 @@ export function typeCast(this: QuotingDispatchHost, value: unknown): unknown {
     // Rails: `when OID::Array::Data then encode_array(value)`.
     return encodeArray.call(this, value);
   }
-  // A bare JS Array has no Ruby analogue at this position — Rails only ever
-  // reaches `type_cast` with an `OID::Array::Data`, which carries the encoder
-  // `encode_array` needs. Ours arrive unwrapped on the `execute(sql, binds)`
-  // path, where node-postgres does the array *encoding* itself, so the array
-  // stays an array rather than raising "can't cast Array". The elements still
-  // go through `type_cast_array` (quoting.rb:221-226) so a Temporal or
-  // BinaryData element is converted rather than handed to the driver raw —
-  // the encoder is what we skip here, not the per-element cast.
-  if (Array.isArray(value)) return typeCastArray.call(this, value);
   if (value instanceof Range) {
     return encodeRange.call(this, value);
   }

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
@@ -277,8 +277,13 @@ describe("SQLite3::Quoting", () => {
       expect(typeCast(-7)).toBe(-7n);
     });
 
-    it("returns null for symbol without description", () => {
-      expect(typeCast(Symbol())).toBe(null);
+    // Rails' SQLite `type_cast` has no Symbol arm — it falls to `else super`
+    // (sqlite3/quoting.rb:122-123), so the abstract `when Symbol ... value.to_s`
+    // (abstract/quoting.rb:95-96) is what runs. The SQLite-local `?? null`
+    // this used to pin was the duplicated chain's own invention.
+    it("casts a symbol through the inherited abstract arm", () => {
+      expect(typeCast(Symbol("foo"))).toBe("foo");
+      expect(typeCast(Symbol())).toBe("Symbol()");
     });
 
     it("throws on unsupported types", () => {

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
@@ -11,10 +11,9 @@
 import {
   quote as abstractQuote,
   quotedDate as abstractQuotedDate,
+  typeCast as abstractTypeCast,
   toBytes,
   dispatchQuotedBinary,
-  dispatchQuotedDate,
-  dispatchQuotedTime,
   dispatchUnquotedTrue,
   dispatchUnquotedFalse,
   type QuotedTimeValue,
@@ -222,37 +221,18 @@ export function typeCast(this: QuotingDispatchHost, value: unknown, bindsAsFloat
     if (bindsAsFloat) return value;
     return Number.isInteger(value) ? BigInt(value) : value;
   }
-  if (typeof value === "string" || typeof value === "bigint") return value;
-  // Rails SQLite3::Quoting#_type_cast: `when BigDecimal then value.to_f` — a
-  // float, NOT the abstract adapter's `value.to_s("F")` string. (quote() still
-  // emits the fixed-form string via the inherited abstract quoter.)
+  // Rails SQLite3::Quoting#type_cast: `when BigDecimal, Rational then value.to_f`
+  // (sqlite3/quoting.rb:114-115) — a float, NOT the abstract adapter's
+  // `value.to_s("F")` string. (quote() still emits the fixed-form string via the
+  // inherited abstract quoter.)
   if (value instanceof BigDecimal) return Number(value.toString("F"));
-  if (typeof value === "symbol") return value.description ?? null;
-  // Rails dispatches date/time through `self.quoted_time` / `self.quoted_date`
-  // (abstract/quoting.rb:93-101) — which SQLite overrides to keep a `2000-01-01`
-  // prefix on times. Thread `this` so the dispatch lands on those overrides.
-  if (value instanceof TimeValue || value instanceof Temporal.PlainTime)
-    return dispatchQuotedTime(this, value);
-  if (
-    value instanceof Temporal.Instant ||
-    value instanceof Temporal.PlainDateTime ||
-    value instanceof Temporal.PlainDate ||
-    value instanceof Temporal.ZonedDateTime
-  ) {
-    return dispatchQuotedDate(this, value);
-  }
-  if (value instanceof Date)
-    throw new TypeError(
-      "typeCast: JS Date is not accepted — use a Temporal type (Instant, PlainDateTime, etc.)",
-    );
-  // Rails' SQLite `type_cast` falls through to `super` for anything it does not
-  // special-case, reaching the abstract `when ... Type::Binary::Data then
-  // value.to_s` (abstract/quoting.rb:96). This chain does not delegate, so the
-  // arm is inlined: `to_s` on a `Data` is the raw byte string, hence `.bytes`
-  // (never `toString()`, which UTF-8-decodes and mangles bytes >= 0x80).
-  if (value instanceof BinaryData) return value.bytes;
-  if (value instanceof Uint8Array || value instanceof ArrayBuffer) return value;
-  throw new TypeError(`can't cast ${Object.prototype.toString.call(value)} to a SQLite3 type`);
+  // Rails: `else super` (sqlite3/quoting.rb:122-123). Every remaining arm —
+  // Symbol/`Type::Binary::Data` (rb:95-96), String, the `quoted_time` /
+  // `quoted_date` dispatch (rb:102-104) and the terminal raise (rb:105) — is
+  // inherited from the abstract `type_cast` rather than duplicated here, so a
+  // new abstract arm costs exactly one edit. `this` is threaded so the
+  // self-dispatched arms still land on SQLite's overrides.
+  return abstractTypeCast.call(this, value);
 }
 
 // Rails uses recursive regex \g<2> to match nested function calls like

--- a/packages/activerecord/src/quoting.test.ts
+++ b/packages/activerecord/src/quoting.test.ts
@@ -6,7 +6,7 @@ import {
   quoteString,
   quoteColumnName,
   quoteTableName as quoteTableNameFn,
-  quoteTableNameForAssignment,
+  quoteTableNameForAssignment as quoteTableNameForAssignmentFn,
   quotedDate,
   quotedTime as quotedTimeFn,
   quotedTrue,
@@ -29,6 +29,8 @@ const HOST = {};
 const quote = (value: unknown): string => quoteFn.call(HOST, value);
 const quoteTableName = (name: string): string => quoteTableNameFn.call(HOST, name);
 const typeCast = (value: unknown): unknown => typeCastFn.call(HOST, value);
+const quoteTableNameForAssignment = (table: string, attr: string): string =>
+  quoteTableNameForAssignmentFn.call(HOST, table, attr);
 const quotedTime = (value: Temporal.PlainTime | Temporal.PlainDateTime): string =>
   quotedTimeFn.call(HOST, value);
 import {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -5409,6 +5409,17 @@ export class Relation<T extends Base> {
   }
 
   private _compileSelectSql(manager: { ast: Nodes.Node; toSql(): string }): string {
+    // Rails: `if prepared_statements ... else sql = visitor.compile(arel, collector)`
+    // (database_statements.rb:31-45) — with prepared statements off the
+    // collector is a `SubstituteBinds`, so every value inlines and `binds` is
+    // empty. `conn.toSql` is that compile.
+    const conn = this._conn();
+    if (conn.preparedStatements === false) {
+      this._lastSelectBinds = [];
+      this._lastSelectPreparable = false;
+      this._lastSelectRetryable = true;
+      return conn.toSql(manager);
+    }
     const v = this._arelVisitor();
     const [sql, binds, retryable, preparable] = v.compileWithBinds(manager.ast);
     this._lastSelectRetryable = retryable;
@@ -5463,6 +5474,11 @@ export class Relation<T extends Base> {
 
   /** Compile an Arel node, returning [sql, type-cast binds]. */
   private _compileAstWithBinds(node: Nodes.Node): [string, unknown[]] {
+    // Rails' non-prepared `to_sql_and_binds` branch (database_statements.rb:44):
+    // compile through the `SubstituteBinds` collector so every value inlines
+    // and no binds are sent.
+    const conn = this._conn();
+    if (conn.preparedStatements === false) return [conn.toSql(node), []];
     const [sql, binds] = this._arelVisitor().compileWithBinds(node);
     return [sql, this._typeCastBinds(binds)];
   }

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -5412,13 +5412,18 @@ export class Relation<T extends Base> {
     // Rails: `if prepared_statements ... else sql = visitor.compile(arel, collector)`
     // (database_statements.rb:31-45) — with prepared statements off the
     // collector is a `SubstituteBinds`, so every value inlines and `binds` is
-    // empty. `conn.toSql` is that compile.
+    // empty. Route through the connection's own `to_sql_and_binds` rather than
+    // `to_sql` so `allow_retry` is the collector's post-traversal `retryable`
+    // (rb:45), which a visitor can lower mid-compile (arel to_sql.rb:764-771).
     const conn = this._conn();
     if (conn.preparedStatements === false) {
+      const [inlinedSql, , inlinedPreparable, inlinedAllowRetry] = conn.toSqlAndBinds(
+        manager,
+      ) as unknown as [string, unknown[], boolean | null, boolean];
       this._lastSelectBinds = [];
-      this._lastSelectPreparable = false;
-      this._lastSelectRetryable = true;
-      return conn.toSql(manager);
+      this._lastSelectPreparable = inlinedPreparable === true;
+      this._lastSelectRetryable = inlinedAllowRetry;
+      return inlinedSql;
     }
     const v = this._arelVisitor();
     const [sql, binds, retryable, preparable] = v.compileWithBinds(manager.ast);

--- a/packages/activerecord/src/relation/arel-ast-convergence.test.ts
+++ b/packages/activerecord/src/relation/arel-ast-convergence.test.ts
@@ -72,7 +72,13 @@ describe("RFC 0022 arel-AST convergence (relation layer)", () => {
       expect(sql).toContain("UNION ALL");
     });
 
-    it("threads both operand binds through one collector in order", () => {
+    it("threads both operand binds through one collector in order", async (ctx) => {
+      // Placeholders and a bind array only exist when prepared statements are
+      // on: Rails' non-prepared `to_sql_and_binds` compiles through
+      // `SubstituteBinds` and returns `binds == []`
+      // (database_statements.rb:31-45), which is MySQL/MariaDB's default. Rails
+      // gates its own bind assertions the same way (bind_parameter_test.rb:9).
+      ctx.skip(!(await Base.connection).preparedStatements);
       const rel = cteRelation();
       const sql = rawSql(rel);
       expect(sql).toContain(placeholder1);

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -370,6 +370,10 @@ function compileManagerWithBinds(rel: CalculationRelation, manager: any): [strin
     bindParamsLength?(): number;
   };
   const visitor = conn.visitor;
+  // Rails' non-prepared `to_sql_and_binds` branch (database_statements.rb:44):
+  // the collector is a `SubstituteBinds`, so every value inlines and no binds
+  // are sent — not just the over-limit case below.
+  if (conn.preparedStatements === false) return [conn.toSql(manager), []];
   if (visitor?.compileWithBinds) {
     const [sql, rawBinds] = visitor.compileWithBinds(manager.ast);
     const binds = rawBinds.map(typeCastCalcBind);

--- a/packages/activerecord/src/relation/update-all.trails.test.ts
+++ b/packages/activerecord/src/relation/update-all.trails.test.ts
@@ -39,7 +39,13 @@ async function captureUpdate(
 describe("update_all value substitution", () => {
   fixtures({ topics: [Topic, {}] });
 
-  it("casts a wrong-typed value through the column type", async () => {
+  it("casts a wrong-typed value through the column type", async (ctx) => {
+    // Bind-slot assertions are prepared-statements-only: Rails' non-prepared
+    // `to_sql_and_binds` compiles through `SubstituteBinds`, inlining every
+    // value and returning `binds == []` (database_statements.rb:31-45) — the
+    // MySQL/MariaDB default. Rails gates its own bind assertions the same way
+    // (bind_parameter_test.rb:9).
+    ctx.skip(!(await Topic.leaseConnection()).preparedStatements);
     const rel = Topic.where({ id: 1 });
     // A raw ISO-8601 string is not a datetime — `type_for_attribute("written_on").cast`
     // must turn it into a Time, which then serializes to Rails' datetime format.
@@ -52,7 +58,13 @@ describe("update_all value substitution", () => {
     expect((binds[0] as Temporal.Instant).toString()).toBe("2004-04-15T10:20:30Z");
   });
 
-  it("sends values as bind params rather than inline literals", async () => {
+  it("sends values as bind params rather than inline literals", async (ctx) => {
+    // Bind-slot assertions are prepared-statements-only: Rails' non-prepared
+    // `to_sql_and_binds` compiles through `SubstituteBinds`, inlining every
+    // value and returning `binds == []` (database_statements.rb:31-45) — the
+    // MySQL/MariaDB default. Rails gates its own bind assertions the same way
+    // (bind_parameter_test.rb:9).
+    ctx.skip(!(await Topic.leaseConnection()).preparedStatements);
     const rel = Topic.where({ id: 1 });
     const { sql, binds } = await captureUpdate(rel, () => rel.updateAll({ title: "bound value" }));
 
@@ -60,7 +72,13 @@ describe("update_all value substitution", () => {
     expect(binds[0]).toBe("bound value");
   });
 
-  it("casts each value exactly once", async () => {
+  it("casts each value exactly once", async (ctx) => {
+    // Bind-slot assertions are prepared-statements-only: Rails' non-prepared
+    // `to_sql_and_binds` compiles through `SubstituteBinds`, inlining every
+    // value and returning `binds == []` (database_statements.rb:31-45) — the
+    // MySQL/MariaDB default. Rails gates its own bind assertions the same way
+    // (bind_parameter_test.rb:9).
+    ctx.skip(!(await Topic.leaseConnection()).preparedStatements);
     // Rails casts once (relation.rb:1389-1390 + identity QueryAttribute#type_cast,
     // query_attribute.rb:22-24). A non-idempotent type makes a second cast visible.
     // A stub type whose `serialize` does NOT re-enter `cast` — every real type

--- a/packages/activerecord/src/sql-default.test.ts
+++ b/packages/activerecord/src/sql-default.test.ts
@@ -3,16 +3,29 @@ import { Temporal } from "@blazetrails/date";
 import {
   quote as quoteFn,
   quoteDefaultExpression as quoteDefaultExpressionFn,
+  lookupCastType,
 } from "./connection-adapters/abstract/quoting.js";
+import { AbstractAdapter } from "./connection-adapters/abstract-adapter.js";
+import { TypeMap } from "./type/type-map.js";
 import { Nodes } from "@blazetrails/arel";
 
 // `quote` requires a host receiver (no receiver-less dispatch); bind an empty
 // host so date/time values route through the abstract module helpers.
 const quote = (value: unknown): string => quoteFn.call({}, value);
-// Likewise `quoteDefaultExpression` — an empty host has no `quote` override, so
-// values fall through to the abstract module quoting.
+// `quoteDefaultExpression` dispatches `lookup_cast_type` on its receiver
+// unconditionally (abstract/quoting.rb:161), so the host carries the abstract
+// adapter's type map — Rails' equivalent hosts are all `< AbstractAdapter`.
+// It has no `quote` override, so values fall through to the abstract module
+// quoting.
+const TYPE_MAP = new TypeMap();
+AbstractAdapter.initializeTypeMap(TYPE_MAP);
+const DEFAULT_EXPRESSION_HOST = {
+  lookupCastType(sqlType: string | null) {
+    return lookupCastType.call({ typeMap: TYPE_MAP }, sqlType);
+  },
+};
 const quoteDefaultExpression = (value: unknown, column?: { sqlType?: string | null } | null) =>
-  quoteDefaultExpressionFn.call({}, value, column);
+  quoteDefaultExpressionFn.call(DEFAULT_EXPRESSION_HOST, value, column);
 
 describe("quote", () => {
   it("returns NULL for null", () => {

--- a/packages/activerecord/src/unprepared-statements-inline-binds.trails.test.ts
+++ b/packages/activerecord/src/unprepared-statements-inline-binds.trails.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Trails-only: no Rails counterpart. Rails' `to_sql_and_binds`
+ * (activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:31-45)
+ * picks its collector from `prepared_statements`: with the flag off it compiles
+ * through `SubstituteBinds` (`abstract_adapter.rb#collector`), so every value
+ * inlines during traversal and `binds` comes back empty.
+ *
+ * Rails cannot regress this — the collector choice *is* the branch. trails
+ * compiles through `compileWithBinds` on every path, so the flag has to be
+ * consulted explicitly at each compile site; this pins that it is.
+ */
+import { describe, it, expect } from "vitest";
+import { Notifications, NotificationEvent as Event } from "@blazetrails/activesupport";
+import { fixtures } from "./test-fixtures.js";
+import { Topic } from "./test-helpers/models/topic.js";
+
+describe("unprepared statements inline binds", () => {
+  fixtures(["topics"]);
+
+  it("inlines a multi-value IN with no binds", async () => {
+    const conn = (await Topic.leaseConnection()) as unknown as {
+      unpreparedStatement(fn: () => Promise<void>): Promise<void>;
+    };
+    const events: Event[] = [];
+    const subscriber = Notifications.subscribe("sql.active_record", (event: Event) => {
+      if (String(event.payload["name"] ?? "") !== "SCHEMA") events.push(event);
+    });
+    try {
+      await conn.unpreparedStatement(async () => {
+        // A multi-value `IN` builds an `Arel::Nodes::HomogeneousIn`, which
+        // carries real binds under the prepared collector — so an unprepared
+        // compile that still parameterized would be visible here.
+        await Topic.where({ id: [1, 2, 3] });
+      });
+    } finally {
+      Notifications.unsubscribe(subscriber);
+    }
+
+    const select = events.find((e) => /^\s*SELECT/i.test(String(e.payload["sql"] ?? "")));
+    expect(select).toBeDefined();
+    expect(select!.payload["binds"]).toEqual([]);
+    expect(String(select!.payload["sql"])).toMatch(/IN \(1, ?2, ?3\)/);
+  });
+});

--- a/packages/activerecord/src/unprepared-statements-inline-binds.trails.test.ts
+++ b/packages/activerecord/src/unprepared-statements-inline-binds.trails.test.ts
@@ -41,4 +41,19 @@ describe("unprepared statements inline binds", () => {
     expect(select!.payload["binds"]).toEqual([]);
     expect(String(select!.payload["sql"])).toMatch(/IN \(1, ?2, ?3\)/);
   });
+
+  it("takes allow_retry from the collector, not a constant", async () => {
+    // Rails sets `collector.retryable = true`, compiles, then reads
+    // `allow_retry = collector.retryable` (database_statements.rb:29-45), so a
+    // `BoundSqlLiteral` lowering it mid-traversal (arel to_sql.rb:770-771) is
+    // reported non-retryable on the unprepared path too.
+    const conn = (await Topic.leaseConnection()) as unknown as {
+      unpreparedStatement(fn: () => Promise<void>): Promise<void>;
+    };
+    await conn.unpreparedStatement(async () => {
+      const rel = Topic.where("id = ?", 1) as unknown as { _lastSelectRetryable?: boolean };
+      await rel;
+      expect(rel._lastSelectRetryable).toBe(false);
+    });
+  });
 });

--- a/packages/activerecord/src/write-path-binds.trails.test.ts
+++ b/packages/activerecord/src/write-path-binds.trails.test.ts
@@ -16,7 +16,12 @@ import { Task } from "./test-helpers/models/task.js";
 describe("write-path prepared-statement binds", () => {
   fixtures({});
 
-  it("binds non-string column values on INSERT and UPDATE", async () => {
+  it("binds non-string column values on INSERT and UPDATE", async (ctx) => {
+    // Prepared-statements-only: Rails' non-prepared `to_sql_and_binds` compiles
+    // through `SubstituteBinds`, so every value inlines and `binds == []`
+    // (database_statements.rb:31-45) — the MySQL/MariaDB default. Rails gates
+    // its own bind assertions the same way (bind_parameter_test.rb:9).
+    ctx.skip(!(await Task.leaseConnection()).preparedStatements);
     const starting = Temporal.Instant.from("2024-03-05T07:08:09.123456Z");
     const ending = Temporal.Instant.from("2025-03-05T07:08:09.123456Z");
     const events: Record<string, unknown>[] = [];


### PR DESCRIPTION
RFC 0077 (quoting/binds fidelity) — five converging stories.

### 1. `type_cast` delegates with `else super`
`sqlite3`/`mysql` `typeCast` keep only their adapter-specific arms and end at
`abstractTypeCast.call(this, value)`, mirroring
`sqlite3/quoting.rb:112-124` and `mysql/quoting.rb:94-120`. SQLite keeps its
BigInt integer/boolean binds (`bindsAsFloat` heuristic untouched) and
`when BigDecimal, Rational then value.to_f`; MySQL keeps the temporal arms
that dispatch through its microsecond-capping `quotedDate`. Everything else —
Symbol/`Type::Binary::Data` (rb:95-96), the self-dispatched
`unquoted_true`/`unquoted_false` pair, the pass-throughs, and the terminal
raise — is inherited, so the abstract chain is the single terminal error path
and a new abstract arm costs one edit instead of three.

The SQLite-local `?? null` for a description-less Symbol went with the
duplicated chain (its guard test now pins the inherited abstract arm instead).

### 2. Adapter-less schema quoters
`lookupCastTypeFromColumn` is Rails' one-liner again
(`abstract/quoting.rb:125-127`) and `quoteDefaultExpression` dispatches
`lookupCastType` unconditionally (rb:161). `QuotingHost.lookupCastType` is
required, so the `?.` guard and the raw-sqlType fallback are both gone. The
only remaining adapter-less hosts were test-side; they now carry the abstract
type map, exactly as Rails' `DummyAdapter < AbstractAdapter` does.
`ABSTRACT_QUOTER` in `sanitization.ts` never called the standalone and keeps
its ANSI output unchanged.

### 3. `quoteTableNameForAssignment` takes a host
It now takes `this: QuotingDispatchHost` and self-dispatches through
`quoteTableName` (`abstract/quoting.rb:153`), which MySQL's `` `table`.`attr` ``
override depends on. A receiver-less call is a compile error; the bare
`quoteTableName.call({}, …)` crutch is gone.

### 4. Non-prepared compiles inline
Rails' `to_sql_and_binds` (`database_statements.rb:31-45`) picks its collector
off `prepared_statements`; with the flag off it is a `SubstituteBinds`, so
every value inlines and `binds == []`. `toSqlAndBinds`, `_compileSelectSql`,
`_compileAstWithBinds` and `compileManagerWithBinds` now take that branch —
not just the over-limit case. `compileInlined` also returns the collector's
`retryable`, as Rails reads `allow_retry = collector.retryable` (rb:45), and
the SELECT path routes through `conn.toSqlAndBinds` so a visitor lowering the
flag mid-traversal (`arel/visitors/to_sql.rb:764-771`) is honored.
Prepared behaviour, including the over-limit fallback, is unchanged.

This makes MySQL/MariaDB — where `prepared_statements` defaults off — inline
like Rails does. Three trails-only test files were pinning the old
parameterized behaviour there (one literally named "sends values as bind
params rather than inline literals", the opposite of Rails' unprepared
behaviour); their bind assertions are now gated on `preparedStatements`,
mirroring Rails' own class-level guard at `bind_parameter_test.rb:9`.

### 5. Binary/array bind wrapping — converged to one arm each, two documented boundaries
The #4998 arms are **consolidated, not deleted** — the story's
"if a bare form must survive at some boundary, document which and why"
exception applies, and CI proved it does. Concretely:

- **Binary.** Rails reaches `type_cast` with bytes two ways: a
  `Type::Binary::Data` (`quoting.rb:96`, wrapped at source by
  `binary.rb:30-33`) **and** a BINARY/ASCII-8BIT Ruby `String` on the
  `execute(sql, binds)` boundary, handled by
  `when nil, Numeric, String then value` (`quoting.rb:102`) — which is what
  `test_type_cast_binary_encoding_without_logger`
  (test/cases/adapters/sqlite3/quoting_test.rb:32) and
  `test_type_cast_should_not_mutate_encoding` (sqlite3_adapter_test.rb:482)
  actually bind. A JS string is UTF-16 and cannot carry arbitrary bytes, so a
  byte view is that arm's analogue — a language shortcoming, not invented
  surface. It now sits at the **rb:102 String position** (not #4998's rb:96
  placement) and exists **once**: sqlite3 and mysql inherit it via `else super`,
  down from three copies.
- **Array.** `execute(sql, [["one","two"]])` (array.test.ts "mutate array")
  reaches PG's `type_cast` with a bare JS array, because node-postgres accepts
  and encodes arrays itself where pg-ruby binds an already-encoded String. The
  arm keeps its documented driver-contract reason; elements still route through
  `type_cast_array` (`postgresql/quoting.rb:221-226`).

So Rails-vs-trails arm counts differ by exactly these two, each justified at
the call site with the Rails cite and the driver reason.

### Verification
- `pnpm api:calls` green (2150 baselined, no new rows).
- `pnpm api:extra --package activerecord` unchanged — no new public surface.
- `pnpm test:compare` / `pnpm api:compare` deltas non-negative.
- SQLite lane green across the full `connection-adapters/` tree, all
  `adapters/sqlite3/`, quoting, sql-default, column-definition, migration,
  sanitization, calculations, bind-parameter, explain, statement-cache and
  binary. `unprepared-statements-inline-binds.trails.test.ts` was confirmed red
  on baseline in both of its assertions.
- MariaDB/PG lanes are CI-only here; the previous run's failures on both are
  what drove the section-5 accounting above.

Closes-story: adapter-typecast-delegate-to-abstract-super
Closes-story: adapterless-schema-quoters-force-lookup-cast-type-guards
Closes-story: require-host-receiver-quote-table-name-for-assignment
Closes-story: unprepared-statements-inline-binds
Closes-story: wrap-binary-and-array-binds-at-source
