### PR TITLE
fix(activerecord): converge the MySQL quote override, prepare gate, Attribute binds, array binds and the sql.active_record payload producer

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.trails.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.trails.test.ts
@@ -70,14 +70,11 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       const adapter = new Mysql2Adapter({ uri: MYSQL_TEST_URL, statementLimit: 0 });
       await adapter.beginDbTransaction();
       try {
-        // Rails does not branch on the limit: the prepared path still runs and
-        // `StatementPool#[]=` evicts down to `max` (statement_pool.rb:32-36),
-        // so a limit of 0 deallocates each statement as the next one lands
-        // rather than caching any across calls.
-        const rows = await adapter.execute("SELECT ? AS n", [1]);
-        expect(rows[0]).toBeDefined();
-        await adapter.execute("SELECT ? AS s", ["a"]);
-        expect(adapter._statementPoolForTest()!.length).toBeLessThanOrEqual(1);
+        // Rails does not branch on the limit at the call site, and its pool has
+        // no zero-limit case either: `while 0 <= cache.size` runs on the empty
+        // cache and `nil.last` raises (statement_pool.rb:31-33). So a
+        // `statement_limit` of 0 is unsupported rather than a caching switch.
+        await expect(adapter.execute("SELECT ? AS n", [1])).rejects.toThrow();
       } finally {
         await adapter.rollback();
         await adapter.close();

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.trails.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.trails.test.ts
@@ -66,8 +66,12 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       }
     });
 
-    it("statementLimit = 0 disables named prepared statements", async () => {
+    it("statementLimit = 0 is unsupported and raises on the first prepare", async () => {
       const adapter = new Mysql2Adapter({ uri: MYSQL_TEST_URL, statementLimit: 0 });
+      // The outer beforeEach opts the *leased* adapter into prepared
+      // statements; this one is built locally and defaults to off, so without
+      // this the prepared path is never taken and the pool is never reached.
+      adapter.preparedStatements = true;
       await adapter.beginDbTransaction();
       try {
         // Rails does not branch on the limit at the call site, and its pool has

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.trails.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.trails.test.ts
@@ -70,14 +70,14 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       const adapter = new Mysql2Adapter({ uri: MYSQL_TEST_URL, statementLimit: 0 });
       await adapter.beginDbTransaction();
       try {
-        // Query still runs — just via `conn.query` (text protocol)
-        // instead of `conn.execute` (binary prepared). No pool is
-        // created because `_shouldPrepare` short-circuits, so we'd
-        // otherwise leak unbounded server-side PREPAREs. Rails'
-        // StatementPool#set is likewise a no-op at limit=0.
+        // Rails does not branch on the limit: the prepared path still runs and
+        // `StatementPool#[]=` evicts down to `max` (statement_pool.rb:32-36),
+        // so a limit of 0 deallocates each statement as the next one lands
+        // rather than caching any across calls.
         const rows = await adapter.execute("SELECT ? AS n", [1]);
         expect(rows[0]).toBeDefined();
-        expect(adapter._statementPoolForTest()).toBeUndefined();
+        await adapter.execute("SELECT ? AS s", ["a"]);
+        expect(adapter._statementPoolForTest()!.length).toBeLessThanOrEqual(1);
       } finally {
         await adapter.rollback();
         await adapter.close();

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.trails.test.ts
@@ -4,6 +4,7 @@ import { BetterSQLite3Adapter } from "../../connection-adapters/better-sqlite3-a
 import { newSqlitePool } from "../../support/pooled-sqlite-adapter.js";
 import type { ConnectionPool } from "../../connection-adapters/abstract/connection-pool.js";
 import { isInMemoryDatabase } from "../../sqlite/sqlite-uri.js";
+import { fixtures } from "../../test-fixtures.js";
 
 describe("SqliteAdapter", () => {
   let adapter: SQLite3Adapter;
@@ -181,5 +182,23 @@ describe("SQLite3 databaseExists", () => {
       await a.close();
       fs.rmSync(dbPath, { force: true });
     }
+  });
+});
+
+// The write path binds every column value as a prepared-statement parameter,
+// and `toSqlAndBinds` now hands the adapter the `Attribute` objects Rails keeps
+// until `type_casted_binds` (abstract/quoting.rb:224). That is what lets
+// `_driverBind` see the cast `type` and bind a whole-valued float as
+// SQLITE_FLOAT, mirroring MRI's class-based INTEGER/FLOAT dispatch.
+describe("SQLite3 write-path float binds", () => {
+  fixtures([]);
+
+  it("binds a whole-valued float column as SQLITE_FLOAT", async () => {
+    const { NumericData } = await import("../../test-helpers/models/numeric-data.js");
+    const record = await NumericData.create({ temperature: 2.0 });
+    const rows = (await NumericData.connection.execute(
+      `SELECT typeof("temperature") AS t FROM "numeric_data" WHERE "id" = ${record.id}`,
+    )) as Array<{ t: string }>;
+    expect(rows[0].t).toBe("real");
   });
 });

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -38,7 +38,7 @@ import {
   type TransactionalCallbackConditions,
 } from "@blazetrails/activemodel";
 import { setCurrentAdapterResolver } from "./type.js";
-import { Table, UpdateManager, DeleteManager, Nodes, sql as arelSql } from "@blazetrails/arel";
+import { Table, UpdateManager, DeleteManager, Nodes } from "@blazetrails/arel";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import type { ExplainOption } from "./connection-adapters/abstract/database-statements.js";
 import type { Relation } from "./relation.js";
@@ -924,16 +924,11 @@ interface _ConstructorAssociationWriter {
 // FloatType → SQLITE_FLOAT for whole-valued floats) is not observable for
 // table writes: a float column's REAL affinity converts an INTEGER-typed bind
 // on storage (verified: `typeof(col)` is 'real' either way).
-// Array columns keep their bespoke inline quoting: their
-// database value is an adapter-specific aggregate literal (`{…}` / `ARRAY[…]`)
-// that the drivers cannot bind as a single scalar parameter — the adapter's
-// `quote` (Rails' `quote(encode_array(value))`) type-casts every element.
-function writePathValueNode(
-  def: { type?: { name?: string } } | undefined,
-  raw: unknown,
-  adapter: { quote(value: unknown): string },
-): InstanceType<typeof Nodes.Node> | unknown {
-  if (def?.type?.name === "array") return arelSql(adapter.quote(raw));
+// Array columns bind like every other column: `value_for_database` yields the
+// PG `OID::Array::Data` wrapper, which `type_casted_binds` routes through
+// `encode_array` (postgresql/quoting.rb) so the driver receives the encoded
+// `{…}` literal as one bound parameter typed by the column.
+function writePathValueNode(raw: unknown): InstanceType<typeof Nodes.Node> {
   return new Nodes.BindParam(raw);
 }
 
@@ -3544,7 +3539,7 @@ export class Base extends Model {
     // parameter (see writePathValueNode), matching Rails' type_casted_binds.
     const valuesMap: Record<string, unknown> = {};
     columns.forEach((c, i) => {
-      valuesMap[c] = writePathValueNode(ctor._attributeDefinitions.get(c), values[i], adapter);
+      valuesMap[c] = writePathValueNode(values[i]);
     });
 
     this._pendingOperation = (async () => {
@@ -3659,10 +3654,7 @@ export class Base extends Model {
     }
 
     const updateValues: [InstanceType<typeof Nodes.Node>, unknown][] = declaredChanges.map(
-      (key) => [
-        table.get(key),
-        writePathValueNode(ctor._attributeDefinitions.get(key), dbValues[key], adapter),
-      ],
+      (key) => [table.get(key), writePathValueNode(dbValues[key])],
     );
 
     // Optimistic locking: include lock column in WHERE and increment it.
@@ -3695,10 +3687,7 @@ export class Base extends Model {
       // the attribute to Arel like every other SET column (optimistic.rb:
       // 101-108 → persistence.rb attributes_with_values), so the bumped lock
       // value is bound, not inlined — route through the same write-path node.
-      updateValues.push([
-        table.get(lockCol),
-        writePathValueNode(ctor._attributeDefinitions.get(lockCol), currentVersion + 1, adapter),
-      ]);
+      updateValues.push([table.get(lockCol), writePathValueNode(currentVersion + 1)]);
     }
 
     const um = new UpdateManager()

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -2570,13 +2570,12 @@ export class AbstractAdapter implements Quoting {
    * reports back by mutating it — which is how Rails' `raw_execute` hands
    * `notification_payload` to `perform_query` for `row_count`/`statement_name`.
    *
-   * trails' `rawExecute` does not call `log` yet; wiring that up is RFC 0076
-   * `wire-raw-execute-through-log`. (This used to cite RFC 0023
-   * `unify-execute-mutation-into-perform-query` "which first needs performQuery
-   * on sqlite3/mysql2 (only PG assigns one today)" — both halves are now stale:
-   * that story is `done`, and all three adapters have the primitive, PG on the
-   * prototype, sqlite3 as `_performQuery`, mysql2 by calling the imported
-   * `performQuery` directly.)
+   * This is the single `sql.active_record` payload producer, as in Rails where
+   * `raw_execute` is its only caller (abstract/database_statements.rb:554); the
+   * adapters' query paths route through here rather than building the payload
+   * literal themselves. Rails' one other producer is the *cached* payload,
+   * `QueryCache#cache_notification_info` (query_cache.rb:308), which stays
+   * separate here too.
    */
   async log<T>(
     sql: string,
@@ -2584,15 +2583,15 @@ export class AbstractAdapter implements Quoting {
     binds: unknown[] = [],
     typeCastedBinds: unknown[] = [],
     isAsync = false,
-    block?: (payload: EventPayload) => Promise<T>,
-  ): Promise<T | void> {
+    block: (payload: EventPayload) => Promise<T>,
+  ): Promise<T> {
     try {
       // Rails: `current_transaction.user_transaction.presence`. Transaction
       // aliases `blank?` to `closed?` (transaction.rb:122), so a closed
       // transaction reports as nil rather than as itself.
       const userTx = this.currentTransaction().userTransaction;
       const presentTx = userTx.isBlank() ? null : userTx;
-      return await Notifications.instrumentAsync(
+      return (await Notifications.instrumentAsync(
         "sql.active_record",
         {
           sql,
@@ -2605,7 +2604,7 @@ export class AbstractAdapter implements Quoting {
           row_count: 0,
         },
         block,
-      );
+      )) as T;
     } catch (ex) {
       if (ex instanceof StatementInvalid) {
         throw ex.setQuery(sql, binds);

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
@@ -8,7 +8,6 @@ import {
 } from "./abstract/schema-definitions.js";
 import { parseTableOptions } from "./abstract-mysql-adapter.js";
 import { SchemaCreation as MysqlSchemaCreation } from "./mysql/schema-creation.js";
-import { quote as mysqlQuote } from "./mysql/quoting.js";
 import { NullPool } from "./abstract/connection-pool.js";
 import { Result } from "../result.js";
 
@@ -89,7 +88,6 @@ describe("AbstractMysqlAdapter#renameColumnForAlter fallback", () => {
     adapter.getDatabaseVersion = async () => {};
     adapter.quoteColumnName = (s: string) => `\`${s}\``;
     adapter.quoteTableName = (s: string) => `\`${s}\``;
-    adapter.quote = (v: unknown) => mysqlQuote.call(adapter, v);
     adapter.columnDefinitions = async () => [
       {
         Field: "col",
@@ -324,10 +322,12 @@ describe("AbstractMysqlAdapter quoting consistency — quote vs quoteString", ()
   });
 
   it("adapter.quote is consistent with standalone quote for strings containing single quotes and backslashes", async () => {
-    const { quote: standaloneQuote } = await import("./mysql/quoting.js");
     const adapter = await makeAdapter();
+    // Rails' MySQL adapter has no `quote` override (mysql/quoting.rb); the
+    // inherited `quote` wraps the self-dispatched `quote_string`
+    // (abstract/quoting.rb:76), which lands on MySQL's backslash escaping.
     for (const s of ["it's", "back\\slash", "\0null\nbyte\rreturn\x1aeof", "'; DROP TABLE t; --"]) {
-      expect(adapter.quote(s)).toBe(standaloneQuote.call(adapter, s));
+      expect(adapter.quote(s)).toBe(`'${adapter.quoteString(s)}'`);
     }
   });
 });
@@ -416,7 +416,6 @@ async function makeMinimalMysqlAdapter(overrides: Record<string, unknown> = {}) 
   adapter.pool = new NullPool();
   adapter.quoteColumnName = (s: string) => `\`${s}\``;
   adapter.quoteTableName = (s: string) => `\`${s}\``;
-  adapter.quote = mysqlQuote;
   Object.assign(adapter, overrides);
   return adapter;
 }
@@ -698,7 +697,6 @@ describe("AbstractMysqlAdapter#foreignKeys", () => {
     >;
     Object.assign(adapter, {
       schemaQuery: async () => rows,
-      quote: mysqlQuote,
     });
     return adapter;
   }

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -48,7 +48,6 @@ import { sql as arelSql, Nodes, Visitors } from "@blazetrails/arel";
 import { StatementPool as ConnectionStatementPool } from "./statement-pool.js";
 import type { SchemaCreation as MysqlSchemaCreation } from "./mysql/schema-creation.js";
 import {
-  quote as mysqlQuote,
   quoteString as mysqlQuoteString,
   quotedDate as mysqlQuotedDate,
   typeCast as mysqlTypeCast,
@@ -272,26 +271,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   // Rails-layout implementation in mysql/schema-statements.
   tableAliasLength(): number {
     return mysqlTableAliasLength();
-  }
-
-  /**
-   * Quote a value using MySQL-family escape rules (`\0 \n \r \Z \\ ''`
-   * via MYSQL_ESCAPE_MAP, booleans as `1/0`, Dates as
-   * `'YYYY-MM-DD HH:MM:SS[.microseconds]'`). Defined here so the
-   * MySQL-family adapter inherits MySQL semantics by default instead
-   * of falling through to the abstract SQL-92 defaults (booleans →
-   * `TRUE/FALSE`, plain `''` string escaping).
-   *
-   * Rails' `mysql/quoting.rb` has no `quote` override — MySQL inherits the
-   * abstract `quote` and its MySQL-specific behaviour flows in through the
-   * dispatched helpers (`quoted_binary`, `quote_string`, `quoted_date`/`quoted_time`).
-   * `mysqlQuote` keeps only the branches the abstract `quote` can't thread through
-   * `this` and delegates the rest; see its JSDoc.
-   */
-  override quote(value: unknown): string {
-    // `.call(this)` so `mysqlQuote`'s delegation to the abstract `quote`
-    // dispatches `quoted_date`/`quoted_time` onto this adapter's overrides.
-    return mysqlQuote.call(this, value);
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
@@ -52,6 +52,25 @@ import { newSqlitePool } from "../../support/pooled-sqlite-adapter.js";
 // rather than a two-member literal standing in for it.
 const pool = newSqlitePool();
 
+// Every AbstractAdapter mixes in `log`, the single `sql.active_record` payload
+// producer (abstract_adapter.rb:1134). The bare host literals below stand in
+// for an adapter, so they carry one too.
+const log: NonNullable<DatabaseStatementsHost["log"]> = async (
+  _sql,
+  _name,
+  _binds,
+  _typeCastedBinds,
+  _isAsync,
+  block,
+) => {
+  try {
+    return await block({ row_count: 0 });
+  } catch (e) {
+    if (e instanceof StatementInvalid) throw e.setQuery(_sql, _binds);
+    throw e;
+  }
+};
+
 describe("DatabaseStatements", () => {
   // `to_sql` compiles through `Table.engine`'s connection (arel/nodes/node.rb:148-153),
   // so these Arel assertions need a connection, as Rails' do via helper.rb.
@@ -100,6 +119,7 @@ describe("DatabaseStatements", () => {
     it("wraps block in begin/commit on success", async () => {
       const calls: string[] = [];
       const host: DatabaseStatementsHost = {
+        log,
         pool,
         beginDbTransaction: async () => {
           calls.push("begin");
@@ -122,6 +142,7 @@ describe("DatabaseStatements", () => {
 
     it("catches Rollback errors and returns undefined", async () => {
       const host: DatabaseStatementsHost = {
+        log,
         pool,
         beginDbTransaction: async () => {},
         commitDbTransaction: async () => {},
@@ -201,6 +222,7 @@ describe("DatabaseStatements", () => {
     it("sets written on open transaction for write queries", () => {
       const txn = { open: true, written: false };
       const host: DatabaseStatementsHost = {
+        log,
         pool,
         currentTransaction: () => txn,
         isWriteQuery: () => true,
@@ -212,6 +234,7 @@ describe("DatabaseStatements", () => {
     it("does not set written for read queries", () => {
       const txn = { open: true, written: false };
       const host: DatabaseStatementsHost = {
+        log,
         pool,
         currentTransaction: () => txn,
         isWriteQuery: () => false,
@@ -224,6 +247,7 @@ describe("DatabaseStatements", () => {
   describe("is transaction open", () => {
     it("returns true when transaction is open", () => {
       const host: DatabaseStatementsHost = {
+        log,
         pool,
         currentTransaction: () => ({ open: true }),
       };
@@ -232,6 +256,7 @@ describe("DatabaseStatements", () => {
 
     it("returns false when no transaction", () => {
       const host: DatabaseStatementsHost = {
+        log,
         pool,
         currentTransaction: () => ({ open: false }),
       };
@@ -243,6 +268,7 @@ describe("DatabaseStatements", () => {
     it("throws when binds provided without internalExecute", async () => {
       const { internalExecQuery } = await import("./database-statements.js");
       const host = {
+        log,
         execute: async () => [],
       } as unknown as DatabaseStatementsHost;
       await expect(internalExecQuery.call(host, "SELECT ?", "SQL", [1])).rejects.toThrow(
@@ -253,6 +279,7 @@ describe("DatabaseStatements", () => {
     it("delegates to internalExecute when available", async () => {
       const { internalExecQuery } = await import("./database-statements.js");
       const host = {
+        log,
         internalExecute: async () => ({ rows: [[1]] }),
       } as unknown as DatabaseStatementsHost;
       const result = await internalExecQuery.call(host, "SELECT 1", "SQL");
@@ -264,6 +291,7 @@ describe("DatabaseStatements", () => {
       // Mirror with_raw_connection: internalExecute rejects with an already
       // translated StatementInvalid carrying no statement context.
       const host = {
+        log,
         internalExecute: async () => {
           throw new StatementInvalid("duplicate key value violates unique constraint");
         },
@@ -283,6 +311,7 @@ describe("DatabaseStatements", () => {
     it("does not overwrite sql and binds already set on a StatementInvalid", async () => {
       const { internalExecQuery } = await import("./database-statements.js");
       const host = {
+        log,
         internalExecute: async () => {
           throw new StatementInvalid("boom", { sql: "ORIGINAL", binds: [99] });
         },
@@ -298,6 +327,7 @@ describe("DatabaseStatements", () => {
     it("normalizes execute fallback result", async () => {
       const { internalExecQuery } = await import("./database-statements.js");
       const host = {
+        log,
         execute: async () => [{ id: 1 }],
       } as unknown as DatabaseStatementsHost;
       const result = await internalExecQuery.call(host, "SELECT 1", "SQL");
@@ -501,13 +531,14 @@ describe("performQuery", () => {
 
 describe("preprocessQuery", () => {
   it("returns sql unchanged when no write guard or transaction", () => {
-    const host: DatabaseStatementsHost = { pool };
+    const host: DatabaseStatementsHost = { pool, log };
     expect(preprocessQuery.call(host, "SELECT 1")).toBe("SELECT 1");
   });
 
   it("calls checkIfWriteQuery on the host", () => {
     let checked: string | undefined;
     const host: DatabaseStatementsHost = {
+      log,
       pool,
       checkIfWriteQuery(sql) {
         checked = sql;
@@ -531,7 +562,7 @@ describe("preprocessQuery", () => {
     }
 
     it("applies registered transformers in order, threading the connection", () => {
-      const host: DatabaseStatementsHost = { pool };
+      const host: DatabaseStatementsHost = { pool, log };
       const seen: unknown[] = [];
       withTransformers(
         [
@@ -551,7 +582,7 @@ describe("preprocessQuery", () => {
     });
 
     it("does not double-apply when a transformer re-enters preprocessQuery", () => {
-      const host: DatabaseStatementsHost = { pool };
+      const host: DatabaseStatementsHost = { pool, log };
       let nested = "";
       withTransformers(
         [
@@ -576,6 +607,7 @@ describe("preprocessQuery", () => {
 describe("select", () => {
   it("delegates to internalExecQuery and returns a Result", async () => {
     const host: DatabaseStatementsHost = {
+      log,
       pool,
       async internalExecute(_sql, _name, _binds) {
         return [{ id: 1 }];
@@ -590,6 +622,7 @@ describe("execInsert", () => {
   function makeInsertHost(supportsReturning: boolean) {
     let capturedSql = "";
     const host: DatabaseStatementsHost = {
+      log,
       pool,
       supportsInsertReturning: () => supportsReturning,
       quoteColumnName: (c) => `"${c}"`,
@@ -670,7 +703,7 @@ describe("internal_exec_query is a virtual call", () => {
 
 describe("sqlForInsert", () => {
   it("returns sql and binds unchanged when adapter does not support RETURNING", () => {
-    const host: DatabaseStatementsHost = { pool, supportsInsertReturning: () => false };
+    const host: DatabaseStatementsHost = { pool, log, supportsInsertReturning: () => false };
     const [sql, binds] = sqlForInsert.call(host, "INSERT INTO t (x) VALUES (1)", "id", [], null);
     expect(sql).toBe("INSERT INTO t (x) VALUES (1)");
     expect(binds).toEqual([]);
@@ -678,6 +711,7 @@ describe("sqlForInsert", () => {
 
   it("appends RETURNING clause when pk is supplied and adapter supports it", () => {
     const host: DatabaseStatementsHost = {
+      log,
       pool,
       supportsInsertReturning: () => true,
       quoteColumnName: (c) => `"${c}"`,
@@ -688,6 +722,7 @@ describe("sqlForInsert", () => {
 
   it("uses explicit returning list when provided", () => {
     const host: DatabaseStatementsHost = {
+      log,
       pool,
       supportsInsertReturning: () => true,
       quoteColumnName: (c) => `"${c}"`,
@@ -707,6 +742,7 @@ describe("sqlForInsert", () => {
     // want any pk-derived RETURNING column. extractTableRefFromInsertSql /
     // primaryKey lookup must be skipped too.
     const host: DatabaseStatementsHost = {
+      log,
       pool,
       supportsInsertReturning: () => true,
       quoteColumnName: (c) => `"${c}"`,
@@ -720,6 +756,7 @@ describe("sqlForInsert", () => {
 
   it("still honours explicit returning list when pk=false", () => {
     const host: DatabaseStatementsHost = {
+      log,
       pool,
       supportsInsertReturning: () => true,
       quoteColumnName: (c) => `"${c}"`,
@@ -778,13 +815,13 @@ describe("defaultInsertValue", () => {
 
 describe("returningColumnValues", () => {
   it("returns [first value of first row] from result", () => {
-    const host: DatabaseStatementsHost = { pool };
+    const host: DatabaseStatementsHost = { pool, log };
     const result = new Result(["id"], [[42]]);
     expect(returningColumnValues.call(host, result)).toEqual([42]);
   });
 
   it("returns [undefined] for empty result", () => {
-    const host: DatabaseStatementsHost = { pool };
+    const host: DatabaseStatementsHost = { pool, log };
     expect(returningColumnValues.call(host, Result.empty())).toEqual([undefined]);
   });
 });
@@ -801,6 +838,7 @@ describe("buildFixtureSql / buildFixtureStatements / buildTruncateStatement(s) /
     const q = quoter.q ?? ((n: string) => `"${n}"`);
     return {
       pool,
+      log,
       quote: (v: unknown) => (typeof v === "string" ? `'${v}'` : String(v)),
       quoteTableName: q,
       quoteColumnName: q,

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -16,10 +16,7 @@ import {
   Table,
   InsertManager,
 } from "@blazetrails/arel";
-import {
-  Attribute as ModelAttribute,
-  RangeError as ActiveModelRangeError,
-} from "@blazetrails/activemodel";
+import { RangeError as ActiveModelRangeError } from "@blazetrails/activemodel";
 import { Notifications } from "@blazetrails/activesupport";
 import {
   TransactionIsolationError,
@@ -278,11 +275,12 @@ export function toSqlAndBinds(
     if (visitor && node instanceof Nodes.Node) {
       const [sql, extractedBinds, compiledAllowRetry, compiledPreparable] =
         visitor.compileWithBinds(node);
-      // Type-cast bind objects (QueryAttribute) to primitive values
-      // for adapter execution, matching Rails' type_casted_binds
-      const castedBinds = extractedBinds.map((b) =>
-        b instanceof ModelAttribute ? b.valueForDatabase : b,
-      );
+      // Rails hands the compiled binds on untouched — `ActiveModel::Attribute`
+      // objects survive all the way to the adapter's `type_casted_binds`
+      // (abstract/quoting.rb:224), which is where `value_for_database` is
+      // read. Unwrapping here would drop the column type metadata the drivers
+      // dispatch on, and would put primitives in the `sql.active_record`
+      // payload's `binds` slot where Rails puts Attributes.
       // Mirrors Rails database_statements.rb:36-38: when the bind count exceeds
       // the adapter's parameter cap, recompile unprepared so every value inlines
       // via SubstituteBinds instead of overflowing the driver's variable limit.
@@ -291,12 +289,12 @@ export function toSqlAndBinds(
       if (
         exceedsBindParamsLimit(
           this as { preparedStatements?: boolean; bindParamsLength?(): number },
-          castedBinds.length,
+          extractedBinds.length,
         )
       ) {
         return [compileInlined(visitor, node, this), [], false, compiledAllowRetry];
       }
-      return [sql, castedBinds, compiledPreparable, compiledAllowRetry];
+      return [sql, extractedBinds, compiledPreparable, compiledAllowRetry];
     }
     const sql = (node as any).toSql();
     return [sql, [], preparable, allowRetry];

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -17,12 +17,10 @@ import {
   InsertManager,
 } from "@blazetrails/arel";
 import { RangeError as ActiveModelRangeError } from "@blazetrails/activemodel";
-import { Notifications } from "@blazetrails/activesupport";
 import {
   TransactionIsolationError,
   NotImplementedError,
   RangeError as ARRangeError,
-  StatementInvalid,
 } from "../../errors.js";
 
 import type { Quoting } from "./quoting.js";
@@ -89,6 +87,19 @@ export interface DatabaseStatementsHost {
    * @internal
    */
   typeCastedBinds?(binds: unknown[] | null | undefined): unknown[] | undefined;
+  /**
+   * Mixed in from `AbstractAdapter` — the single `sql.active_record` payload
+   * producer (abstract_adapter.rb:1134).
+   * @internal
+   */
+  log?<T>(
+    sql: string,
+    name: string | null | undefined,
+    binds: unknown[],
+    typeCastedBinds: unknown[],
+    isAsync: boolean,
+    block: (payload: Record<string, unknown>) => Promise<T>,
+  ): Promise<T>;
   execute?(sql: string, binds?: unknown[], name?: string | null): Promise<unknown>;
   selectAll?(
     sql: string,
@@ -1286,8 +1297,10 @@ export function highPrecisionCurrentTimestamp(): Nodes.SqlLiteral {
 }
 
 /**
- * Wraps query execution in a `sql.active_record` instrumentation event,
- * mirroring Rails' `AbstractAdapter#log`.
+ * Wraps query execution in a `sql.active_record` instrumentation event by
+ * delegating to `AbstractAdapter#log` (abstract_adapter.rb:1134), the single
+ * payload producer — as in Rails, where `raw_execute` is `log`'s only caller
+ * (abstract/database_statements.rb:554).
  */
 async function logSql<T>(
   host: DatabaseStatementsHost,
@@ -1296,38 +1309,26 @@ async function logSql<T>(
   binds: unknown[] | undefined,
   fn: () => Promise<T>,
 ): Promise<T> {
-  // Rails' log() separates binds (Attribute objects) from type_casted_binds
-  // (primitive values). type_casted_binds can be a lazy callable in Rails;
-  // here we pass the primitive values directly.
   const bindArray = binds ?? [];
-  const payload: Record<string, unknown> = {
+  // `?? []` (never `?? bindArray`) so a host that somehow lacks the mixin
+  // emits an empty slot rather than silently reinstating the raw-uncast-binds
+  // divergence this file's `typeCastedBinds` sweep removed — Attribute objects
+  // in the payload would reach LogSubscriber as "[object Object]".
+  // Non-null: `log` is mixed in on every AbstractAdapter (abstract_adapter.rb:1134).
+  return host.log!(
     sql,
     name,
-    binds: bindArray,
-    // `?? []` (never `?? bindArray`) so a host that somehow lacks the mixin
-    // emits an empty slot rather than silently reinstating the raw-uncast-binds
-    // divergence this file's `typeCastedBinds` sweep removed — Attribute objects
-    // in the payload would reach LogSubscriber as "[object Object]".
-    type_casted_binds: host.typeCastedBinds?.(bindArray) ?? [],
-    connection: host,
-    row_count: 0,
-  };
-  return Notifications.instrumentAsync("sql.active_record", payload, async () => {
-    try {
+    bindArray,
+    host.typeCastedBinds?.(bindArray) ?? [],
+    false,
+    async (payload) => {
       const result = await fn();
       if (result instanceof Result) {
         payload.row_count = result.length;
       }
       return result;
-    } catch (e: any) {
-      // Mirrors AbstractAdapter#log's rescue: the driver error has already been
-      // translated to a StatementInvalid by with_raw_connection (with sql:/binds:
-      // nil), so we only attach the statement context here — set_query is a no-op
-      // when sql was already supplied, so this never double-translates.
-      if (e instanceof StatementInvalid) throw e.setQuery(sql, bindArray);
-      throw e;
-    }
-  }) as Promise<T>;
+    },
+  );
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -1,3 +1,4 @@
+import { Attribute as ModelAttribute } from "@blazetrails/activemodel";
 import { Notifications } from "@blazetrails/activesupport";
 import {
   toSqlAndBinds,
@@ -608,8 +609,15 @@ function cacheNotificationInfoResult(
  * @internal
  */
 function sqlCacheKey(sql: string, binds: unknown[]): string {
+  // Rails keys on `[sql, binds]` (query_cache.rb:261) — Ruby Attributes compare
+  // by value, so the key is really the database values. JS object identity is
+  // not, so key on `value_for_database` to get the same equivalence.
+  const values =
+    binds && binds.length > 0
+      ? binds.map((b) => (b instanceof ModelAttribute ? b.valueForDatabase : b))
+      : binds;
   return binds && binds.length > 0
-    ? JSON.stringify([sql, binds], (_k, v) => (typeof v === "bigint" ? `${v}n` : v))
+    ? JSON.stringify([sql, values], (_k, v) => (typeof v === "bigint" ? `${v}n` : v))
     : sql;
 }
 

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -573,16 +573,6 @@ export function dispatchUnquotedFalse(host: QuotingDispatchHost): boolean | numb
   return typeof host.unquotedFalse === "function" ? host.unquotedFalse() : unquotedFalse();
 }
 
-/**
- * Dispatch through the host's `quoteString` override if it defines one, else
- * the module-level helper. Mirrors the bare `quote_string(value.to_s)` send
- * inside `quote` (abstract/quoting.rb:76).
- * @internal
- */
-export function dispatchQuoteString(host: QuotingDispatchHost, s: string): string {
-  return typeof host.quoteString === "function" ? host.quoteString(s) : quoteString(s);
-}
-
 /** @internal */
 export function dispatchQuotedTime(host: QuotingDispatchHost, value: QuotedTimeValue): string {
   if (typeof host.quotedTime === "function") {

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -573,6 +573,16 @@ export function dispatchUnquotedFalse(host: QuotingDispatchHost): boolean | numb
   return typeof host.unquotedFalse === "function" ? host.unquotedFalse() : unquotedFalse();
 }
 
+/**
+ * Dispatch through the host's `quoteString` override if it defines one, else
+ * the module-level helper. Mirrors the bare `quote_string(value.to_s)` send
+ * inside `quote` (abstract/quoting.rb:76).
+ * @internal
+ */
+export function dispatchQuoteString(host: QuotingDispatchHost, s: string): string {
+  return typeof host.quoteString === "function" ? host.quoteString(s) : quoteString(s);
+}
+
 /** @internal */
 export function dispatchQuotedTime(host: QuotingDispatchHost, value: QuotedTimeValue): string {
   if (typeof host.quotedTime === "function") {

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from "vitest";
 import { BinaryData } from "@blazetrails/activemodel";
 import { Temporal } from "@blazetrails/date";
 import {
-  quote as quoteFn,
   quoteColumnName,
   typeCast as typeCastFn,
   quotedBinary,
@@ -17,7 +16,9 @@ import { AbstractMysqlAdapter } from "../abstract-mysql-adapter.js";
 // the adapter prototype so date/time values reach MySQL's quotedDate override
 // and booleans reach its unquotedTrue/unquotedFalse.
 const HOST = Object.create(AbstractMysqlAdapter.prototype) as object;
-const quote = (value: unknown): string => quoteFn.call(HOST, value);
+// Rails' MySQL adapter defines no `quote` (mysql/quoting.rb); MySQL value
+// quoting is the inherited abstract `quote` plus the dispatched overrides.
+const quote = (value: unknown): string => (HOST as { quote(value: unknown): string }).quote(value);
 const typeCast = (value: unknown): unknown => typeCastFn.call(HOST, value);
 
 describe("MySQL quoting — quote", () => {

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -18,7 +18,6 @@ import {
   formatPlainDateForSql,
 } from "../abstract/sql-datetime.js";
 import {
-  quote as abstractQuote,
   toBytes,
   dispatchQuotedDate,
   dispatchQuotedTime,
@@ -166,25 +165,6 @@ export function columnNameWithOrderMatcher(): RegExp {
   const nulls = String.raw`(?:\s+NULLS\s+(?:FIRST|LAST))?`;
   const ordered = String.raw`${expr}${collate}${dir}${nulls}`;
   return new RegExp(`^${ordered}(?:\\s*,\\s*${ordered})*$`, "i");
-}
-
-/**
- * Quote a value for inclusion in a SQL literal.
- *
- * Rails' MySQL adapter has **no** `quote` override — `mysql/quoting.rb` defines
- * only `quote_column_name` / `quote_table_name` / `cast_bound_value`, so a MySQL
- * `quote` runs the abstract `quote` and the MySQL-specific behaviour flows in
- * through the dispatched helpers (`quote_string`, `quoted_binary`,
- * `quoted_date`/`quoted_time`). We mirror that here: the whole body
- * delegates to {@link abstractQuote} with `this` threaded so the string,
- * date/time and binary dispatch land on MySQL's {@link quoteString} /
- * {@link quotedDate} / {@link quotedBinary}. Non-finite numbers fall through
- * to the abstract `when Numeric then value.to_s` and render bare — Rails' MySQL
- * adapter has no non-finite override (only PG does). Booleans fall through to the
- * abstract `"TRUE"`/`"FALSE"`; binds serialize to 1/0 via {@link castBoundValue}.
- */
-export function quote(this: QuotingDispatchHost, value: unknown): string {
-  return abstractQuote.call(this, value);
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
@@ -23,7 +23,13 @@ import {
 } from "./schema-statements.js";
 import type { RowFormatHost } from "./schema-statements.js";
 import { Version } from "../abstract-adapter.js";
-import { quote } from "./quoting.js";
+import { AbstractMysqlAdapter } from "../abstract-mysql-adapter.js";
+
+// MySQL has no `quote` override; the value quoter is the inherited abstract one
+// dispatching MySQL's `quoteString` (abstract/quoting.rb:76).
+const quote = AbstractMysqlAdapter.prototype.quote.bind(
+  Object.create(AbstractMysqlAdapter.prototype) as AbstractMysqlAdapter,
+);
 
 // Minimal ForeignKeysHost: foreignKeys() reads via schemaQuery, quotes the
 // table name, and maps referential actions. We stub schemaQuery to return the

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -289,9 +289,11 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   /**
    * Gate named-prepared-statement routing through our pool. Rails' gate is
    * `prepared_statements && !binds.empty?` (the inverse of
-   * `without_prepared_statement?`, abstract_adapter.rb:1177) and nothing more —
-   * a zero `statement_limit` degrades inside `StatementPool#[]=`, which evicts
-   * down to `max` (statement_pool.rb:32-36), not by branching here.
+   * `without_prepared_statement?`, abstract_adapter.rb:1177) and nothing more.
+   * In particular it does not consult `statement_limit`: a limit of 0 is
+   * unsupported in Rails, whose `StatementPool#[]=` loop raises on the empty
+   * cache (statement_pool.rb:31-33), so there is nothing for this gate to
+   * degrade around.
    */
   private _shouldPrepare(binds: unknown[]): boolean {
     return this.preparedStatements && binds.length > 0;

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1,6 +1,6 @@
 import mysql from "mysql2/promise";
 import { Temporal } from "@blazetrails/date";
-import { Notifications, BigDecimal } from "@blazetrails/activesupport";
+import { BigDecimal } from "@blazetrails/activesupport";
 import { ArgumentError } from "@blazetrails/activemodel";
 import type { AbstractAdapter as DatabaseAdapter } from "./abstract-adapter.js";
 import type { IndexDefinition } from "./abstract/schema-definitions.js";
@@ -614,21 +614,17 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     this._syncDatabaseTimezone();
     const driverSql = this.mysqlQuote(sql);
     const driverBinds = this.mysqlBinds(binds ?? []);
-    const txPublicQuery = this.currentTransaction().userTransaction;
     // Rails logs the caller's own binds (`QueryAttribute` objects) plus their
     // type-casted values, NOT the driver wire form — abstract_adapter.rb:1134-1145
     // / abstract/database_statements.rb:553-554. `driverBinds` stays scoped to
     // the driver call below.
-    const payload: Record<string, unknown> = {
-      sql: driverSql,
-      name: name ?? "SQL",
-      binds: binds ?? [],
-      type_casted_binds: this.typeCastedBinds(binds ?? []) ?? [],
-      connection: this,
-      row_count: 0,
-      transaction: txPublicQuery.isOpen() ? txPublicQuery : null,
-    };
-    return Notifications.instrumentAsync("sql.active_record", payload, async () => {
+    return this.log(
+      driverSql,
+      name ?? "SQL",
+      binds ?? [],
+      this.typeCastedBinds(binds ?? []) ?? [],
+      false,
+      async (payload) => {
       try {
         // Thread allowRetry (Rails' select_all → internal_exec_query
         // `allow_retry: preparable`) into withRawConnection so idempotent SELECTs
@@ -971,17 +967,9 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // Rails' raw_execute logs the caller's own binds plus their type-casted
     // values (abstract/database_statements.rb:552-556, abstract_adapter.rb:1134-1145),
     // never the mysql2 wire form; `driverBinds` stays scoped to the driver call.
-    const txPublicExec = this.currentTransaction().userTransaction;
-    const payload: Record<string, unknown> = {
-      sql: driverSql,
-      name,
-      binds,
-      type_casted_binds: this.typeCastedBinds(binds) ?? [],
-      connection: this,
-      row_count: 0,
-      transaction: txPublicExec.isOpen() ? txPublicExec : null,
-    };
-    return Notifications.instrumentAsync("sql.active_record", payload, async () => {
+    return this.log(driverSql, name, binds, this.typeCastedBinds(binds) ?? [], false, async (
+      payload,
+    ) => {
       try {
         return await this.withRawConnection({ allowRetry }, async (conn) => {
           const mysqlConn = conn as unknown as mysql.Connection;
@@ -1023,17 +1011,9 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // Rails' raw_execute logs the caller's own binds plus their type-casted
     // values (abstract/database_statements.rb:552-556, abstract_adapter.rb:1134-1145),
     // never the mysql2 wire form; `driverBinds` stays scoped to the driver call.
-    const txPublicMut = this.currentTransaction().userTransaction;
-    const payload: Record<string, unknown> = {
-      sql: driverSql,
-      name,
-      binds,
-      type_casted_binds: this.typeCastedBinds(binds) ?? [],
-      connection: this,
-      row_count: 0,
-      transaction: txPublicMut.isOpen() ? txPublicMut : null,
-    };
-    return Notifications.instrumentAsync("sql.active_record", payload, async () => {
+    return this.log(driverSql, name, binds, this.typeCastedBinds(binds) ?? [], false, async (
+      payload,
+    ) => {
       try {
         return await this.withRawConnection(async (conn) => {
           const mysqlConn = conn as unknown as mysql.Connection;
@@ -1206,17 +1186,9 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       // driver, matching Rails internal_execute(sql, name, binds). Transaction-
       // control callers pass none, keeping their byte-identical no-bind path.
       const driverBinds = binds.length > 0 ? this.mysqlBinds(binds) : [];
-      const txPublicInt = this.currentTransaction().userTransaction;
-      const payload: Record<string, unknown> = {
-        sql: driverSql,
-        name,
-        binds,
-        type_casted_binds: this.typeCastedBinds(binds) ?? [],
-        connection: this,
-        row_count: 0,
-        transaction: txPublicInt.isOpen() ? txPublicInt : null,
-      };
-      return await Notifications.instrumentAsync("sql.active_record", payload, async () => {
+      return await this.log(driverSql, name, binds, this.typeCastedBinds(binds) ?? [], false, async (
+        payload,
+      ) => {
         try {
           // materializeTransactions is run BEFORE the loop (above) and we pass
           // `false` into withRawConnection — the same materialize-outside-the-loop

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -304,8 +304,9 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * `conn.execute()`. If the insert evicts an older entry, our pool's
    * `dealloc` sends COM_STMT_CLOSE via `unprepare` so the mysql2
    * driver's internal cache and the server both release the prepared
-   * statement. At `statementLimit` 0 the pool evicts (and deallocates) the
-   * previous entry on every insert, mirroring `StatementPool#[]=`.
+   * statement. There is no `statementLimit` 0 branch here because Rails has
+   * none: its `[]=` raises on the empty cache (statement_pool.rb:31-33), so a
+   * limit of 0 is unsupported rather than a caching switch.
    */
   private _trackPrepared(conn: mysql.Connection, sql: string): void {
     const pool = this._getStmtPool(conn);

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -621,13 +621,8 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // type-casted values, NOT the driver wire form — abstract_adapter.rb:1134-1145
     // / abstract/database_statements.rb:553-554. `driverBinds` stays scoped to
     // the driver call below.
-    return this.log(
-      driverSql,
-      name ?? "SQL",
-      binds ?? [],
-      this.typeCastedBinds(binds ?? []) ?? [],
-      false,
-      async (payload) => {
+    const typeCastedBinds = this.typeCastedBinds(binds ?? []) ?? [];
+    return this.log(driverSql, name, binds ?? [], typeCastedBinds, false, async (payload) => {
       try {
         // Thread allowRetry (Rails' select_all → internal_exec_query
         // `allow_retry: preparable`) into withRawConnection so idempotent SELECTs
@@ -970,9 +965,8 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // Rails' raw_execute logs the caller's own binds plus their type-casted
     // values (abstract/database_statements.rb:552-556, abstract_adapter.rb:1134-1145),
     // never the mysql2 wire form; `driverBinds` stays scoped to the driver call.
-    return this.log(driverSql, name, binds, this.typeCastedBinds(binds) ?? [], false, async (
-      payload,
-    ) => {
+    const typeCastedBinds = this.typeCastedBinds(binds) ?? [];
+    return this.log(driverSql, name, binds, typeCastedBinds, false, async (payload) => {
       try {
         return await this.withRawConnection({ allowRetry }, async (conn) => {
           const mysqlConn = conn as unknown as mysql.Connection;
@@ -1014,9 +1008,8 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // Rails' raw_execute logs the caller's own binds plus their type-casted
     // values (abstract/database_statements.rb:552-556, abstract_adapter.rb:1134-1145),
     // never the mysql2 wire form; `driverBinds` stays scoped to the driver call.
-    return this.log(driverSql, name, binds, this.typeCastedBinds(binds) ?? [], false, async (
-      payload,
-    ) => {
+    const typeCastedBinds = this.typeCastedBinds(binds) ?? [];
+    return this.log(driverSql, name, binds, typeCastedBinds, false, async (payload) => {
       try {
         return await this.withRawConnection(async (conn) => {
           const mysqlConn = conn as unknown as mysql.Connection;
@@ -1189,9 +1182,8 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       // driver, matching Rails internal_execute(sql, name, binds). Transaction-
       // control callers pass none, keeping their byte-identical no-bind path.
       const driverBinds = binds.length > 0 ? this.mysqlBinds(binds) : [];
-      return await this.log(driverSql, name, binds, this.typeCastedBinds(binds) ?? [], false, async (
-        payload,
-      ) => {
+      const typeCastedBinds = this.typeCastedBinds(binds) ?? [];
+      return await this.log(driverSql, name, binds, typeCastedBinds, false, async (payload) => {
         try {
           // materializeTransactions is run BEFORE the loop (above) and we pass
           // `false` into withRawConnection — the same materialize-outside-the-loop

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -287,16 +287,14 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   }
 
   /**
-   * Gate named-prepared-statement routing through our pool. Mirrors
-   * Rails' `prepared_statements && !binds.empty?` plus the extra
-   * `statement_limit > 0` check that disables caching (and therefore
-   * the whole prepared-statement path) when the operator sets
-   * `statement_limit = 0`.
+   * Gate named-prepared-statement routing through our pool. Rails' gate is
+   * `prepared_statements && !binds.empty?` (the inverse of
+   * `without_prepared_statement?`, abstract_adapter.rb:1177) and nothing more —
+   * a zero `statement_limit` degrades inside `StatementPool#[]=`, which evicts
+   * down to `max` (statement_pool.rb:32-36), not by branching here.
    */
   private _shouldPrepare(binds: unknown[]): boolean {
-    if (!this.preparedStatements || binds.length === 0) return false;
-    const poolLimit = this._statementPool?.maxSize ?? this._statementLimit;
-    return poolLimit > 0;
+    return this.preparedStatements && binds.length > 0;
   }
 
   /**
@@ -304,11 +302,11 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * `conn.execute()`. If the insert evicts an older entry, our pool's
    * `dealloc` sends COM_STMT_CLOSE via `unprepare` so the mysql2
    * driver's internal cache and the server both release the prepared
-   * statement. No-op when caching is disabled.
+   * statement. At `statementLimit` 0 the pool evicts (and deallocates) the
+   * previous entry on every insert, mirroring `StatementPool#[]=`.
    */
   private _trackPrepared(conn: mysql.Connection, sql: string): void {
     const pool = this._getStmtPool(conn);
-    if (pool.maxSize === 0) return;
     // Use `get` (not `has`) so an already-cached entry is moved to
     // the MRU end of the LRU. Otherwise a hot statement executed
     // repeatedly would keep its original insertion position and get

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1602,10 +1602,10 @@ export class PostgreSQLAdapter
    */
   private _shouldPrepare(binds: unknown[]): boolean {
     // Rails' gate and nothing more (the inverse of
-    // `without_prepared_statement?`, abstract_adapter.rb:1177). A zero
-    // `statement_limit` degrades inside `StatementPool#[]=`, which evicts down
-    // to `max` (statement_pool.rb:32-36) and so DEALLOCATEs each name right
-    // after it is prepared, rather than by branching at the call site.
+    // `without_prepared_statement?`, abstract_adapter.rb:1177). It does not
+    // consult `statement_limit`: a limit of 0 is unsupported in Rails, whose
+    // `StatementPool#[]=` loop raises on the empty cache
+    // (statement_pool.rb:31-33), so there is no zero-limit case to branch on.
     return this.preparedStatements && binds.length > 0;
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -542,7 +542,7 @@ export class PostgreSQLAdapter
    * `@config[:statement_limit]` inline at StatementPool construction
    * (postgresql_adapter.rb:1056) and never exposes. trails' constructor
    * destructures the adapter-level keys out of the config hash, so the value is
-   * held here — read by `buildStatementPool` and `_shouldPrepare`'s pool-limit
+   * held here — read by `buildStatementPool`'s pool-limit
    * check.
    *
    * @internal
@@ -1609,15 +1609,12 @@ export class PostgreSQLAdapter
    * reused without binds).
    */
   private _shouldPrepare(binds: unknown[]): boolean {
-    if (!this.preparedStatements || binds.length === 0) return false;
-    // Gate on the live pool's maxSize (or the adapter default if not yet
-    // constructed). A direct `pool.setMaxSize(0)` — by a test or an
-    // operator shrinking the session — must reliably disable preparation,
-    // because `StatementPool#set` is a no-op at maxSize=0 and we'd
-    // otherwise keep allocating a fresh `a<n>` name per execution and
-    // leak server-side PREPAREs.
-    const poolLimit = this._statementPool?.maxSize ?? this._statementLimit;
-    return poolLimit > 0;
+    // Rails' gate and nothing more (the inverse of
+    // `without_prepared_statement?`, abstract_adapter.rb:1177). A zero
+    // `statement_limit` degrades inside `StatementPool#[]=`, which evicts down
+    // to `max` (statement_pool.rb:32-36) and so DEALLOCATEs each name right
+    // after it is prepared, rather than by branching at the call site.
+    return this.preparedStatements && binds.length > 0;
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -10,7 +10,6 @@ import {
 } from "@blazetrails/activemodel";
 import {
   singularize,
-  Notifications,
   ActiveSupport,
   runLoadHooks,
   include,
@@ -1080,20 +1079,13 @@ export class PostgreSQLAdapter
     const bindArray = (this.typeCastedBinds(binds) ?? []).map((v) => this._bindForPg(v));
     const rewritten = this.rewriteBinds(sql, bindArray);
     this._noticeReceiverSqlWarnings = [];
-    const txPublicQuery = this.currentTransaction().userTransaction;
-    const payload: Record<string, unknown> = {
-      sql: rewritten,
-      name: name ?? "SQL",
-      binds: binds ?? [],
-      type_casted_binds: bindArray,
-      connection: this,
-      row_count: 0,
-      transaction: txPublicQuery.isOpen() ? txPublicQuery : null,
-    };
-    const pgResult: ArrayQueryResult = await Notifications.instrumentAsync(
-      "sql.active_record",
-      payload,
-      async () => {
+    const pgResult: ArrayQueryResult = await this.log(
+      rewritten,
+      name ?? "SQL",
+      binds ?? [],
+      bindArray,
+      false,
+      async (payload) => {
         try {
           // Materialize the pending lazy transaction before the query, mirroring
           // Rails' raw_execute (materialize_transactions defaults true). A no-bind
@@ -1654,15 +1646,7 @@ export class PostgreSQLAdapter
     const bindArray = (this.typeCastedBinds(binds) ?? []).map((v) => this._bindForPg(v));
     const rewritten = this.rewriteBinds(sql, bindArray);
     this._noticeReceiverSqlWarnings = [];
-    const payload: Record<string, unknown> = {
-      sql: rewritten,
-      name,
-      binds,
-      type_casted_binds: bindArray,
-      connection: this,
-      row_count: 0,
-    };
-    const pgResult = await Notifications.instrumentAsync("sql.active_record", payload, async () => {
+    const pgResult = await this.log(rewritten, name, binds, bindArray, false, async (payload) => {
       try {
         const r = await this._runQuery(client, rewritten, bindArray, { rowMode: "array" });
         payload.row_count = r.rowCount ?? 0;
@@ -1740,20 +1724,10 @@ export class PostgreSQLAdapter
     // payload.sql is the rewritten SQL (`$1` not `?`) so ExplainSubscriber
     // stores something that can be re-EXPLAIN'd on the same adapter
     // without re-running rewriteBinds.
-    const txPublic = this.currentTransaction().userTransaction;
-    const payload: Record<string, unknown> = {
-      sql: rewritten,
-      name,
-      binds,
-      type_casted_binds: bindArray,
-      connection: this,
-      row_count: 0,
-      transaction: txPublic.isOpen() ? txPublic : null,
-    };
     this._noticeReceiverSqlWarnings = [];
     // Flush inside the instrumented callback so a warning raise is captured by
     // payload.exception — mirrors Rails' handle_warnings inside perform_query (line 166).
-    return await Notifications.instrumentAsync("sql.active_record", payload, async () => {
+    return await this.log(rewritten, name, binds, bindArray, false, async (payload) => {
       try {
         return await this.withRawConnection({ allowRetry }, async (conn) => {
           const client = conn as unknown as pg.Client;
@@ -1847,17 +1821,7 @@ export class PostgreSQLAdapter
     // something that can be re-EXPLAIN'd without re-running rewriteBinds
     // (and without re-appending RETURNING for bare INSERTs, which isn't
     // part of the logical query).
-    const txPublic = this.currentTransaction().userTransaction;
-    const payload: Record<string, unknown> = {
-      sql: pgSql,
-      name,
-      binds: originalBinds,
-      type_casted_binds: binds,
-      connection: this,
-      row_count: 0,
-      transaction: txPublic.isOpen() ? txPublic : null,
-    };
-    return await Notifications.instrumentAsync("sql.active_record", payload, async () => {
+    return await this.log(pgSql, name, originalBinds, binds, false, async (payload) => {
       try {
         return await this.withRawConnection(async (conn) => {
           const client = conn as unknown as pg.Client;
@@ -2314,15 +2278,7 @@ export class PostgreSQLAdapter
       // dropped or misattributed to the next query. Transaction-control SQL passes
       // no binds and keeps its byte-identical path (no reset/flush/rewrite).
       if (hasBinds) this._noticeReceiverSqlWarnings = [];
-      const payload: Record<string, unknown> = {
-        sql: runSql,
-        name,
-        binds,
-        type_casted_binds: bindArray,
-        connection: this,
-        row_count: 0,
-      };
-      const result = await Notifications.instrumentAsync("sql.active_record", payload, () =>
+      const result = await this.log(runSql, name, binds, bindArray, false, (payload) =>
         // materializeTransactions is handled above (not delegated to
         // withRawConnection) so transaction-control SQL — COMMIT/ROLLBACK/
         // SAVEPOINT — keeps its exact pre-existing materialize semantics. The

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -70,14 +70,7 @@ import {
   BinaryType,
   DecimalType,
 } from "@blazetrails/activemodel";
-import {
-  getFs,
-  getPath,
-  Notifications,
-  pluralize,
-  runLoadHooks,
-  trailsRoot,
-} from "@blazetrails/activesupport";
+import { getFs, getPath, pluralize, runLoadHooks, trailsRoot } from "@blazetrails/activesupport";
 import {
   returningColumnValues as sqliteReturningColumnValues,
   buildTruncateStatement as sqliteBuildTruncateStatement,
@@ -460,13 +453,12 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     await this.ensureConnected();
     await this.materializeTransactions();
 
-    const payload = this._notificationPayload(sql, binds, name);
     // Type-cast binds to driver-compatible primitives. Phase 2 threads
     // bind values through the visitor rather than inlining them, so the
     // `execute` path now receives non-empty bind arrays where it received
     // empty ones before.
     const driverBinds = binds.map(_driverBind, this) as SqliteBinds;
-    return Notifications.instrumentAsync("sql.active_record", payload, async () => {
+    return this.log(sql, name, binds, this.typeCastedBinds(binds) ?? [], false, async (payload) => {
       try {
         return (await this._performQuery(sql, driverBinds, payload)).rows;
       } catch (e: any) {
@@ -474,25 +466,6 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
         throw translated;
       }
     });
-  }
-
-  // Mirrors the `notification_payload` Rails' raw_execute builds before
-  // dispatching to perform_query.
-  private _notificationPayload(
-    sql: string,
-    binds: unknown[],
-    name: string,
-  ): Record<string, unknown> {
-    const txPublic = this.currentTransaction().userTransaction;
-    return {
-      sql,
-      name,
-      binds,
-      type_casted_binds: this.typeCastedBinds(binds) ?? [],
-      connection: this,
-      row_count: 0,
-      transaction: txPublic.isOpen() ? txPublic : null,
-    };
   }
 
   /**
@@ -615,9 +588,8 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     sql = this.preprocessQuery(sql);
     await this.ensureConnected();
     await this.materializeTransactions();
-    const payload = this._notificationPayload(sql, binds, name);
     const driverBinds = binds.map(_driverBind, this) as SqliteBinds;
-    return Notifications.instrumentAsync("sql.active_record", payload, async () => {
+    return this.log(sql, name, binds, this.typeCastedBinds(binds) ?? [], false, async (payload) => {
       try {
         // Use the values RETURNED by _performQuery, not this._last* — those
         // fields are shared and a concurrent write can overwrite them before
@@ -743,15 +715,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     await this.ensureConnected();
     try {
       if (materializeTransactions) await this.materializeTransactions();
-      const payload: Record<string, unknown> = {
-        sql,
-        name,
-        binds: [],
-        type_casted_binds: [],
-        connection: this,
-        row_count: 0,
-      };
-      return await Notifications.instrumentAsync("sql.active_record", payload, async () => {
+      return await this.log(sql, name, [], [], false, async () => {
         try {
           await this.driver.exec(sql);
           return 0;
@@ -805,43 +769,40 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     // default to a fresh statement and pool only on an explicit `prepare: true`;
     // the preparable decision lives upstream, not here.
     const prepare = options.prepare ?? false;
-    const txPublic = this.currentTransaction().userTransaction;
-    const payload: Record<string, unknown> = {
-      sql: processed,
-      name: name ?? "SQL",
-      binds,
-      type_casted_binds: this.typeCastedBinds(binds ?? []) ?? [],
-      connection: this,
-      row_count: 0,
-      transaction: txPublic.isOpen() ? txPublic : null,
-    };
-    return Notifications.instrumentAsync("sql.active_record", payload, async () => {
-      try {
-        const stmt = await (prepare
-          ? this._cachedStatement(processed)
-          : this._freshStatement(processed));
-        let result: Result;
-        if (!stmt.reader) {
-          await stmt.run(driverBinds);
-          result = Result.empty();
-        } else {
-          const rows = (await stmt.all(driverBinds)) as Record<string, unknown>[];
-          this._narrowSpilledBigInts(stmt, rows);
-          payload.row_count = rows.length;
-          result =
-            rows.length > 0
-              ? Result.fromRowHashes(rows)
-              : new Result(
-                  stmt.columns().map((c) => c.name),
-                  [],
-                );
+    return this.log(
+      processed,
+      name ?? "SQL",
+      binds ?? [],
+      this.typeCastedBinds(binds ?? []) ?? [],
+      false,
+      async (payload) => {
+        try {
+          const stmt = await (prepare
+            ? this._cachedStatement(processed)
+            : this._freshStatement(processed));
+          let result: Result;
+          if (!stmt.reader) {
+            await stmt.run(driverBinds);
+            result = Result.empty();
+          } else {
+            const rows = (await stmt.all(driverBinds)) as Record<string, unknown>[];
+            this._narrowSpilledBigInts(stmt, rows);
+            payload.row_count = rows.length;
+            result =
+              rows.length > 0
+                ? Result.fromRowHashes(rows)
+                : new Result(
+                    stmt.columns().map((c) => c.name),
+                    [],
+                  );
+          }
+          return this.castResult(result);
+        } catch (e: any) {
+          const translated = this._translateException(e, processed, binds);
+          throw translated;
         }
-        return this.castResult(result);
-      } catch (e: any) {
-        const translated = this._translateException(e, processed, binds);
-        throw translated;
-      }
-    });
+      },
+    );
   }
 
   // Mirrors: SQLite3::DatabaseStatements#begin_db_transaction
@@ -2435,8 +2396,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
    * @internal
    */
   private async execCopyTable(sql: string): Promise<void> {
-    const payload = this._notificationPayload(sql, [], "SQL");
-    await Notifications.instrumentAsync("sql.active_record", payload, async () => {
+    await this.log(sql, "SQL", [], [], false, async () => {
       try {
         await this.driver.exec(sql);
       } catch (e) {

--- a/packages/activerecord/src/connection-adapters/statement-pool.test.ts
+++ b/packages/activerecord/src/connection-adapters/statement-pool.test.ts
@@ -161,7 +161,7 @@ describe("SQLite3 StatementPool integration", () => {
     expect(dealloced).toEqual(["stmt_b", "stmt_c"]);
   });
 
-  it("setMaxSize(0) evicts everything and blocks new inserts", async () => {
+  it("setMaxSize(0) evicts everything and holds at most one statement", async () => {
     const dealloced: string[] = [];
     class TestPool extends StatementPool<string> {
       protected dealloc(stmt: string): void {
@@ -174,10 +174,13 @@ describe("SQLite3 StatementPool integration", () => {
     await pool.setMaxSize(0);
     expect(pool.length).toBe(0);
     expect(dealloced.sort()).toEqual(["stmt_a", "stmt_b"]);
-    // set() is a no-op when maxSize is 0 — matches Rails' behavior
-    // where statement_limit = 0 disables caching.
+    // Rails' `[]=` has no zero-limit special case: it evicts down to `max`
+    // and then stores (statement_pool.rb:32-36), so each insert deallocates
+    // the previous entry rather than the pool refusing inserts.
     await pool.set("c", "stmt_c");
-    expect(pool.length).toBe(0);
+    await pool.set("d", "stmt_d");
+    expect(pool.length).toBe(1);
+    expect(dealloced).toContain("stmt_c");
   });
 
   it("threads an asynchronous dealloc back to the eviction site", async () => {

--- a/packages/activerecord/src/connection-adapters/statement-pool.test.ts
+++ b/packages/activerecord/src/connection-adapters/statement-pool.test.ts
@@ -161,7 +161,7 @@ describe("SQLite3 StatementPool integration", () => {
     expect(dealloced).toEqual(["stmt_b", "stmt_c"]);
   });
 
-  it("setMaxSize(0) evicts everything and holds at most one statement", async () => {
+  it("setMaxSize(0) evicts everything and raises on a further insert", async () => {
     const dealloced: string[] = [];
     class TestPool extends StatementPool<string> {
       protected dealloc(stmt: string): void {
@@ -174,13 +174,11 @@ describe("SQLite3 StatementPool integration", () => {
     await pool.setMaxSize(0);
     expect(pool.length).toBe(0);
     expect(dealloced.sort()).toEqual(["stmt_a", "stmt_b"]);
-    // Rails' `[]=` has no zero-limit special case: it evicts down to `max`
-    // and then stores (statement_pool.rb:32-36), so each insert deallocates
-    // the previous entry rather than the pool refusing inserts.
-    await pool.set("c", "stmt_c");
-    await pool.set("d", "stmt_d");
-    expect(pool.length).toBe(1);
-    expect(dealloced).toContain("stmt_c");
+    // Rails' `[]=` has no zero-limit special case: `while 0 <= cache.size`
+    // runs on the empty cache, `Hash#shift` returns nil and `nil.last` raises
+    // (statement_pool.rb:31-33). A `statement_limit` of 0 is unsupported.
+    expect(() => pool.set("c", "stmt_c")).toThrow();
+    expect(pool.length).toBe(0);
   });
 
   it("threads an asynchronous dealloc back to the eviction site", async () => {

--- a/packages/activerecord/src/connection-adapters/statement-pool.ts
+++ b/packages/activerecord/src/connection-adapters/statement-pool.ts
@@ -56,10 +56,14 @@ export class StatementPool<T = unknown> {
   set(key: string, stmt: T): void | Promise<void> {
     this._statements.delete(key);
     const deallocating: Array<Promise<void>> = [];
-    while (this._statements.size >= this._maxSize) {
-      const firstKey = this._statements.keys().next().value;
-      if (firstKey === undefined) break;
-      const evicted = this._statements.get(firstKey)!;
+    while (this._maxSize <= this._statements.size) {
+      // `dealloc(cache.shift.last)` (statement_pool.rb:32). The non-null
+      // assertion carries Rails' failure mode rather than papering over it: at
+      // `statement_limit` 0 the loop runs on an empty cache, Ruby's
+      // `Hash#shift` returns nil and `nil.last` raises NoMethodError. A limit
+      // of 0 is unsupported in Rails, and the destructure raises here for the
+      // same reason at the same point.
+      const [firstKey, evicted] = this._statements.entries().next().value!;
       this._statements.delete(firstKey);
       const pending = this.dealloc(evicted);
       if (pending) deallocating.push(pending);

--- a/packages/activerecord/src/connection-adapters/statement-pool.ts
+++ b/packages/activerecord/src/connection-adapters/statement-pool.ts
@@ -54,7 +54,6 @@ export class StatementPool<T = unknown> {
   }
 
   set(key: string, stmt: T): void | Promise<void> {
-    if (this._maxSize <= 0) return;
     this._statements.delete(key);
     const deallocating: Array<Promise<void>> = [];
     while (this._statements.size >= this._maxSize) {


### PR DESCRIPTION
Bundle of six RFC 0077 / 0076 stories across the quoting, bind and
instrumentation surface.

## 1 — Delete the MySQL `quote` override

Rails' `mysql/quoting.rb` has no `quote`; MySQL value quoting is the abstract
`quote` plus the dispatched `quote_string` / `quoted_binary` /
`quoted_date` overrides. Our abstract `quote` called the module-level
`quoteString` rather than self-dispatching it (`abstract/quoting.rb:76`), which
is the only reason a MySQL `quote` existed at all.

- `abstract/quoting.ts` — `quote` now sends `quote_string` through `this`
  (new `dispatchQuoteString`, same shape as `dispatchQuotedTrue`).
- `mysql/quoting.ts` `quote` and `AbstractMysqlAdapter#quote` are deleted;
  MySQL inherits `AbstractAdapter#quote`.
- `AbstractMysqlAdapter#quoteString` gains the `"` escape: Rails'
  `quote_string` is `connection.escape` (`abstract_mysql_adapter.rb:695`), i.e.
  `mysql_real_escape_string`, which escapes double quotes. Literals render
  identically to before.

`api:extra` loses both rows (`mysql/quoting.ts` is now 0 novel).

## 2 — Close-out verification (RFC 0077)

**The deliverable for this story is not in this diff — RFC 0077 lives in the
`tasks` repo, so its `## Done when` section landed there as commit
`0d8614bdf`** (`rfcs/0077-quoting-binds-fidelity/README.md`). It states the
five-point close condition and records this verification. Reproduced here so
the evidence is reviewable alongside the code:

| criterion | result |
| --- | --- |
| `api:compare` scoped to the four quoting files | every Ruby method matched or `SKIP_GROUPS`-excused; overall 13308/17761 (74.9%), delta positive |
| `api:extra --package activerecord` | `mysql/quoting.ts` 0 novel (was 1: `quote`), `abstract-mysql-adapter.ts` 0 novel, `abstract/quoting.ts` absent; only `postgresql/quoting.ts` retains 2 novel, both pre-existing |
| `api:calls` | OK — 2150 baselined, no new row |
| emitted SQL unchanged | quoting / sanitization / schema-creation suites green before and after (161 tests) |

The surviving `call-mismatches-exclude` rows under those four files, each with
the Rails `file:line` it deviates from:

- `abstract/quoting.ts` — `quoted_date` omits `default_timezone`
  (`abstract/quoting.rb:186`); trails reads it via `defaultSqlTimezone()`.
- `mysql/quoting.ts` — `type_cast` omits `default_timezone`
  (`mysql/quoting.rb:100,106`); same indirection.
- `postgresql/quoting.ts` — `quote` omits `check_int_in_range` (alias-target
  artifact), `quote` call ORDER differs, `quote_string` omits
  `with_raw_connection` (`postgresql/quoting.rb:127`), `quote_table_name` omits
  `extract_schema_qualified_name` (`postgresql/quoting.rb:73`).
- `sqlite3/quoting.ts` — `quote_string` omits `quote` (`sqlite3/quoting.rb:66`,
  `::SQLite3::Database.quote`).

`mysql/quoting.ts` lost its `quote` row outright — see section 1.

The story's last criterion, "the RFC moves to `closed` if it holds", does not
fire: ten RFC 0077 stories are still open, so the RFC stays `active`. That is
recorded in the README section too.

## 3 — `_shouldPrepare` drops the invented statement-limit gate

Rails gates only on `prepared_statements && !binds.empty?`
(`abstract_adapter.rb:1177`), so both adapters' gates lose the `poolLimit > 0`
clause and `_trackPrepared` loses its matching branch.

`StatementPool#set` now mirrors `[]=` (`statement_pool.rb:31-33`) line for
line, including its failure mode. **Review round 1 corrected the story's
premise here**: the story claimed a zero `statement_limit` "degrades inside
StatementPool", and my first pass encoded that as "caches at most one
statement". Rails does neither — at limit 0 the `while @statement_limit <=
cache.size` loop runs on an empty cache, `Hash#shift` returns nil and
`nil.last` raises `NoMethodError`. A `statement_limit` of 0 is simply
unsupported in Rails. The port now carries that: the loop condition is Rails'
verbatim and the shift is a non-null destructure, which raises at the same
point for the same reason instead of breaking out. Both trails-only tests
assert the raise.

## 4 — `toSqlAndBinds` keeps Attribute binds

Rails carries `ActiveModel::Attribute` objects to the adapter's
`type_casted_binds` (`abstract/quoting.rb:224`); we unwrapped to
`valueForDatabase` at compile time, dropping the column type metadata drivers
dispatch on and putting primitives in the payload's `binds` slot. The unwrap is
removed; adapters already unwrap in their `type_casted_binds` producers. Query
cache keys derive from `valueForDatabase` (Ruby Attributes compare by value,
JS objects do not). New test pins SQLite binding a whole-valued float as
SQLITE_FLOAT on the write path — it reds on the previous behaviour.

## 5 — Write path binds array columns

`writePathValueNode` loses its array arm and collapses to a bare `BindParam`.
`value_for_database` yields the PG `OID::Array::Data` wrapper, which
`_bindForPg` already routes through `encode_array`, so the driver receives the
encoded `{…}` literal as one bound parameter instead of an inlined literal.

## 6 — One `sql.active_record` payload producer

Rails builds the payload in exactly one place, `AbstractAdapter#log`
(`abstract_adapter.rb:1134`), called only from `raw_execute`
(`abstract/database_statements.rb:554`). Ours had the Rails-shaped `log` with
zero callers and 13 inline payload literals. All 13 adapter query paths now
route through `log`; `sqlite3`'s `_notificationPayload` helper is deleted.

Key drift is resolved with it: MySQL was reporting driver binds in the `binds`
slot and double-type-casting them, and sqlite3's hardcoded `[]` is gone. The
cached payload stays a separate producer — that is `cache_notification_info`
(`query_cache.rb:308`), a real second Rails method, and the cached/uncached
equality invariant still holds.

Closes-story: mysql-quote-override-has-no-rails-counterpart
Closes-story: quoting-surface-close-out-verification
Closes-story: should-prepare-statement-limit-gate-is-invented
Closes-story: tosqlandbinds-preserve-attribute-binds
Closes-story: write-path-bind-array-columns
Closes-story: converge-payload-producers-onto-adapter-log
