### PR TITLE
fix(date,activerecord): Date/DateTime carry decode_year's nth; valid_civil_p truncates; order matcher off adapter_class

### DIFF
--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -759,29 +759,35 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         // on every withRawConnection call.
         this._client = conn;
         this._statementPool = null;
-        // Configure the freshly-opened socket exactly as Rails does on every
-        // fresh connect (attempt_configure_connection via connect!/reconnect!).
-        // trails' connectBang opens the raw socket directly (bypassing verify!),
-        // so without this the eager query-loop connect would never configure
-        // its first connection. Gated by _connectionConfigured so a following
-        // verifyBang/reconnectBang can't double-configure.
+        // Rails has no configure-inside-raw-connect: every dispatch flows
+        // through connect!/reconnect!/verify! (mysql2_adapter.rb:144 opens the
+        // socket and nothing else). `reconnect()` passes configure=false and is
+        // already that shape — reconnectBang's attemptConfigureConnection is
+        // its single dispatch — and so is `connectBang()`, which routes through
+        // verifyBang.
+        //
+        // The one caller left that can reach an UNCONFIGURED socket is
+        // `rawConnectionForBlock()` → `getConn()`: withRawConnection runs its
+        // pre-loop `connectBang()` only when
+        // `_connection === null && isReconnectCanRestoreState()`
+        // (abstract-adapter.ts:2383), so a dirty raw connection or a
+        // non-restorable transaction stack skips the lifecycle entirely and the
+        // acquisition seam opens the first socket itself. Without this the
+        // query would run on a socket that never saw configure_connection.
+        // What deviates is the dispatch SITE, not the dispatch: the call is
+        // `attempt_configure_connection` (abstract_adapter.rb:1216) itself, so
+        // there is one teardown-on-failure implementation rather than a
+        // bespoke copy of it here. Retiring the site means the acquisition seam
+        // must stop opening sockets — tracked separately.
+        //
         // Await so the connect-once warm + checkVersion complete before the
         // socket is handed out — a too-old server rejects the connect (Rails'
-        // configure_connection → check_version raises during connect).
-        // `reconnect()` passes configure=false: it opens the socket only
-        // (Rails' `Mysql2Adapter#connect`, mysql2_adapter.rb:144) and leaves
-        // the single overridable-hook dispatch to reconnectBang's
-        // attemptConfigureConnection, so a user override never observes
-        // duplicate configure_connection calls per connect
+        // configure_connection → check_version raises during connect). The
+        // `_connectionConfigured` gate keeps a following
+        // verifyBang/reconnectBang from double-configuring, so a user override
+        // never observes duplicate configure_connection calls per connect
         // (adapter_test.rb:852).
-        if (configure) {
-          try {
-            await this.configureConnection();
-          } catch (configureError) {
-            this.disconnectBang();
-            throw configureError;
-          }
-        }
+        if (configure) await this.attemptConfigureConnection();
         return conn;
       },
       (err) => {

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -525,10 +525,16 @@ export function adapterClass(this: typeof Base): Promise<new (...args: any[]) =>
  * Synchronous, non-leasing variant of {@link adapterClass}. Resolves the
  * adapter constructor from a directly-assigned `_adapter` (test/simple setups)
  * or the pool's pre-warmed sync adapter cache, without ever leasing a
- * connection. Returns `null` when no pool/adapter is resolvable yet. Mirrors
- * Rails' `model.adapter_class` — a class-level lookup that does not check out a
- * connection — for code paths (e.g. `column_name_with_order_matcher`) that only
- * need static adapter metadata.
+ * connection. Mirrors Rails' `model.adapter_class` — a class-level lookup that
+ * does not check out a connection — for code paths (e.g.
+ * `column_name_with_order_matcher`) that only need static adapter metadata.
+ *
+ * `connection_pool` resolves `strict: true` (connection_handling.rb:342), so
+ * `adapter_class` (connection_handling.rb:338) RAISES for a model with no
+ * established connection; the pool error propagates here for the same reason,
+ * rather than being answered as a `null` every caller has to re-raise. `null`
+ * is left for the one condition Rails cannot be in — the adapter module not yet
+ * imported, which Ruby's autoload does synchronously and ESM cannot.
  */
 export function adapterClassSync(
   this: typeof Base,
@@ -537,13 +543,9 @@ export function adapterClassSync(
   if (directAdapter) {
     return directAdapter.constructor as new (...args: any[]) => DatabaseAdapter;
   }
-  let pool: ConnectionPool | undefined;
-  try {
-    pool = connectionPool.call(this);
-  } catch {
-    return null;
-  }
-  return pool.dbConfig.adapterClassSync() as (new (...args: any[]) => DatabaseAdapter) | null;
+  return connectionPool.call(this).dbConfig.adapterClassSync() as
+    | (new (...args: any[]) => DatabaseAdapter)
+    | null;
 }
 
 export function removeConnection(this: typeof Base): DatabaseConfig | undefined {

--- a/packages/activerecord/src/sanitization-quoter.test.ts
+++ b/packages/activerecord/src/sanitization-quoter.test.ts
@@ -104,6 +104,21 @@ describe("sanitization class-method dispatch threads `this.connection`", () => {
     expect(ClassMethods.sanitizeSqlArray.call({}, "")).toBe("");
   });
 
+  // Rails reads the order matcher off `adapter_class`
+  // (sanitization.rb:84-89 over connection_handling.rb:338), a class-level
+  // lookup that checks out no connection and raises when there is no pool to
+  // read a `db_config` from. So an adapterless host raises here rather than
+  // falling back to the abstract matcher, which would permit an ORDER BY
+  // spelling its own adapter rejects.
+  it("raises ConnectionNotDefined for sanitizeSqlForOrder with no adapter class", () => {
+    const host = {
+      ...ClassMethods,
+      connection: mysqlQuoter,
+      adapterClassSync: () => null,
+    };
+    expect(() => host.sanitizeSqlForOrder(["id = ?", 1])).toThrow(ConnectionNotDefined);
+  });
+
   it("propagates non-ConnectionNotDefined errors from host.connection", () => {
     const host = {
       get connection(): never {

--- a/packages/activerecord/src/sanitization-quoter.test.ts
+++ b/packages/activerecord/src/sanitization-quoter.test.ts
@@ -106,15 +106,17 @@ describe("sanitization class-method dispatch threads `this.connection`", () => {
 
   // Rails reads the order matcher off `adapter_class`
   // (sanitization.rb:84-89 over connection_handling.rb:338), a class-level
-  // lookup that checks out no connection and raises when there is no pool to
-  // read a `db_config` from. So an adapterless host raises here rather than
+  // lookup that checks out no connection and whose `connection_pool` resolves
+  // `strict: true` — so an adapterless host surfaces that error rather than
   // falling back to the abstract matcher, which would permit an ORDER BY
   // spelling its own adapter rejects.
-  it("raises ConnectionNotDefined for sanitizeSqlForOrder with no adapter class", () => {
+  it("surfaces the adapter_class lookup error for sanitizeSqlForOrder", () => {
     const host = {
       ...ClassMethods,
       connection: mysqlQuoter,
-      adapterClassSync: () => null,
+      adapterClassSync: (): never => {
+        throw new ConnectionNotDefined("No database connection defined.");
+      },
     };
     expect(() => host.sanitizeSqlForOrder(["id = ?", 1])).toThrow(ConnectionNotDefined);
   });

--- a/packages/activerecord/src/sanitization.ts
+++ b/packages/activerecord/src/sanitization.ts
@@ -283,19 +283,12 @@ export function sanitizeSqlForOrder(
       // (sanitization.rb:85-88); `disallowRawSqlBang` skips Node instances, so
       // `Arel.sql("field(id, ?)")` is permitted and only the substituted
       // result is returned.
-      // Rails reads the matcher off `adapter_class`, a class-level lookup that
-      // checks out no connection and raises when there is no pool to read a
-      // `db_config` from (connection_handling.rb:338). trails'
-      // `adapterClassSync` answers null there instead, so the raise is explicit
-      // — never a fall back to the abstract matcher, whose permissiveness no
-      // adapter asked for.
       // `column_name_with_order_matcher` is in `Quoting::ClassMethods`
       // (abstract/quoting.rb:33), so it is a static the adapter constructor
       // type does not carry.
       const adapterClass = this.adapterClassSync() as {
         columnNameWithOrderMatcher(): RegExp;
-      } | null;
-      if (!adapterClass) throw new ConnectionNotDefined();
+      };
       this.disallowRawSqlBang(
         [first as string | symbol | Nodes.Node],
         adapterClass.columnNameWithOrderMatcher(),

--- a/packages/activerecord/src/sanitization.ts
+++ b/packages/activerecord/src/sanitization.ts
@@ -5,7 +5,6 @@
  */
 
 import { Nodes, sql as arelSql } from "@blazetrails/arel";
-import { columnNameWithOrderMatcher as abstractColumnNameWithOrderMatcher } from "./connection-adapters/abstract/quoting.js";
 import type { Quoting } from "./connection-adapters/abstract/quoting.js";
 import {
   ConnectionNotDefined,
@@ -203,23 +202,6 @@ function quoterFor(host: QuoterHost): Quoter {
 }
 
 /**
- * Resolves the adapter's `column_name_with_order_matcher`
- * (Rails `adapter_class.column_name_with_order_matcher`), falling back to the
- * abstract matcher when no connection is resolvable. @internal
- */
-function orderMatcherFor(host: QuoterHost): RegExp {
-  let conn: unknown;
-  try {
-    conn = host.connection;
-  } catch (err) {
-    if (!(err instanceof ConnectionNotDefined)) throw err;
-  }
-  const matcher = (conn as { constructor?: { columnNameWithOrderMatcher?: () => RegExp } } | null)
-    ?.constructor?.columnNameWithOrderMatcher;
-  return typeof matcher === "function" ? matcher() : abstractColumnNameWithOrderMatcher();
-}
-
-/**
  * Threads the active adapter as the quoter, matching Rails'
  * `connection.quote` dispatch.
  *
@@ -283,6 +265,7 @@ export function sanitizeSqlForAssignment(
  */
 export function sanitizeSqlForOrder(
   this: QuoterHost & {
+    adapterClassSync(): unknown;
     disallowRawSqlBang(args: (string | symbol | Nodes.Node)[], permit?: RegExp): void;
     sanitizeSqlArray(template: string, ...binds: unknown[]): string;
   },
@@ -300,7 +283,22 @@ export function sanitizeSqlForOrder(
       // (sanitization.rb:85-88); `disallowRawSqlBang` skips Node instances, so
       // `Arel.sql("field(id, ?)")` is permitted and only the substituted
       // result is returned.
-      this.disallowRawSqlBang([first as string | symbol | Nodes.Node], orderMatcherFor(this));
+      // Rails reads the matcher off `adapter_class` — a class-level lookup
+      // that checks out no connection (connection_handling.rb:338, over
+      // `connection_pool.db_config.adapter_class`) — so this does too, and a
+      // host with no adapter to resolve raises rather than falling back to the
+      // abstract matcher, which is a permissiveness no adapter asked for.
+      // `column_name_with_order_matcher` lives in `Quoting::ClassMethods`
+      // (abstract/quoting.rb:33) and so is a static on each concrete adapter
+      // class, which the adapter constructor type does not carry.
+      const adapterClass = this.adapterClassSync() as {
+        columnNameWithOrderMatcher(): RegExp;
+      } | null;
+      if (!adapterClass) throw new ConnectionNotDefined();
+      this.disallowRawSqlBang(
+        [first as string | symbol | Nodes.Node],
+        adapterClass.columnNameWithOrderMatcher(),
+      );
       const sanitized = this.sanitizeSqlArray(firstText, ...condition.slice(1));
       return arelSql(sanitized);
     }

--- a/packages/activerecord/src/sanitization.ts
+++ b/packages/activerecord/src/sanitization.ts
@@ -283,14 +283,15 @@ export function sanitizeSqlForOrder(
       // (sanitization.rb:85-88); `disallowRawSqlBang` skips Node instances, so
       // `Arel.sql("field(id, ?)")` is permitted and only the substituted
       // result is returned.
-      // Rails reads the matcher off `adapter_class` — a class-level lookup
-      // that checks out no connection (connection_handling.rb:338, over
-      // `connection_pool.db_config.adapter_class`) — so this does too, and a
-      // host with no adapter to resolve raises rather than falling back to the
-      // abstract matcher, which is a permissiveness no adapter asked for.
-      // `column_name_with_order_matcher` lives in `Quoting::ClassMethods`
-      // (abstract/quoting.rb:33) and so is a static on each concrete adapter
-      // class, which the adapter constructor type does not carry.
+      // Rails reads the matcher off `adapter_class`, a class-level lookup that
+      // checks out no connection and raises when there is no pool to read a
+      // `db_config` from (connection_handling.rb:338). trails'
+      // `adapterClassSync` answers null there instead, so the raise is explicit
+      // — never a fall back to the abstract matcher, whose permissiveness no
+      // adapter asked for.
+      // `column_name_with_order_matcher` is in `Quoting::ClassMethods`
+      // (abstract/quoting.rb:33), so it is a static the adapter constructor
+      // type does not carry.
       const adapterClass = this.adapterClassSync() as {
         columnNameWithOrderMatcher(): RegExp;
       } | null;

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -996,6 +996,26 @@ describe("Date", () => {
     );
   });
 
+  it("threads decode_jd through the frags builders and the jd statics", () => {
+    // ruby 3.3.11 -rdate — `d_new_by_frags` (date_core.c:4315) and
+    // `dt_new_by_frags` (:8311) decode the Julian day rt__valid_*_p answered
+    // back into the stored `nth`, which is the same object `Date.jd` /
+    // `DateTime.jd` build (date_core.c:7697):
+    //   Date.jd(2**70).to_s #=> "3232350070754114273-01-08"
+    //   Date.jd(2**70).jd   #=> 1180591620717411303424
+    //   Date.jd(2**70).wday #=> 3
+    //   DateTime.jd(2**70, 1, 2, 3).to_s
+    //     #=> "3232350070754114273-01-08T01:02:03+00:00"
+    const d = dNewByFrags({ jd: 2n ** 70n });
+    expect(d.toS()).toBe("3232350070754114273-01-08");
+    expect(d.jd).toBe(1180591620717411303424n);
+    expect(d.year).toBe(3232350070754114273n);
+    expect(d.wday).toBe(3);
+    const dt = dtNewByFrags({ jd: 2n ** 70n, hour: 1, min: 2, sec: 3 });
+    expect(dt.toS()).toBe("3232350070754114273-01-08T01:02:03+00:00");
+    expect(dt.jd).toBe(1180591620717411303424n);
+  });
+
   it("truncates a fractional year through valid_civil_p, as decode_year does", () => {
     // ruby 3.3.11 -rdate — valid_civil_p (date_core.c:2246-2277) runs
     // decode_year before c_valid_civil_p's `int y`, and the truncation is of

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -1057,6 +1057,26 @@ describe("Date", () => {
     expect(dNewByFrags(RubyDate._parse("1500-02-29")).toS()).toBe("1500-02-29");
   });
 
+  it("raises from the seat for a day past Temporal's range, decoded nth and all", () => {
+    // The `nth` a Julian day past CM_PERIOD carries (date_core.c:1393-1412) is
+    // ~year 580000 at its smallest, and `Temporal.PlainDate` stops at ±271821 —
+    // so every static that answers the seat raises for one, the same way and
+    // for the same reason the Julian-only spelling above does. MRI answers a
+    // `::Date`/`::DateTime`, its own gem object:
+    //   Date.jd(2**70).to_s #=> "3232350070754114273-01-08"
+    //   DateTime.jd(2**70, 1, 2, 3).to_s
+    //     #=> "3232350070754114273-01-08T01:02:03+00:00"
+    expect(() => RubyDate.jd(2n ** 70n)).toThrow(RubyDate.Error);
+    expect(() => RubyDateTime.jd(2n ** 70n, 1, 2, 3)).toThrow(RubyDate.Error);
+
+    // The decode itself is intact underneath: the gem-shaped builders those
+    // statics run over answer the day, `nth` and all.
+    expect(dNewByFrags({ jd: 2n ** 70n }).toS()).toBe("3232350070754114273-01-08");
+    expect(dtNewByFrags({ jd: 2n ** 70n, hour: 1, min: 2, sec: 3 }).toS()).toBe(
+      "3232350070754114273-01-08T01:02:03+00:00",
+    );
+  });
+
   it("takes a start argument, and Date::JULIAN/GREGORIAN select every day", () => {
     // ruby 3.3.11:
     //   Date.new(1582, 10, 10, Date::GREGORIAN).to_s #=> "1582-10-10"

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -874,7 +874,7 @@ describe("Date", () => {
     year: number,
     month: number,
     day: number,
-  ): [number, number, number] | "E" => {
+  ): [number | bigint, number, number] | "E" => {
     try {
       const date = new RubyDate(year, month, day);
       return [date.year, date.mon, date.day];
@@ -956,6 +956,58 @@ describe("Date", () => {
     // default start too, and answers the same day:
     //   Date.new(600000, 1, 1).jd #=> 220866560
     expect(new RubyDate(600000, 1, 1).jd).toBe(220866560);
+  });
+
+  it("carries decode_year's nth, so a year past a double stays exact", () => {
+    // ruby 3.3.11 -rdate — the year and the day are Bignums, split into a
+    // `nth` and an `int` residue by decode_year/decode_jd
+    // (date_core.c:1342-1412):
+    //   Date.new(2**70, 1, 1).to_s #=> "1180591620717411303424-01-01"
+    //   Date.new(2**70, 1, 1).jd   #=> 431202235029879099711900
+    //   Date.new(2**70, 1, 1).year #=> 1180591620717411303424
+    //   Date.new(2**70, 1, 1).wday #=> 4
+    //   Date.new(2**70, 1, 1).julian? #=> false
+    const d = new RubyDate(2n ** 70n, 1, 1);
+    expect(d.toS()).toBe("1180591620717411303424-01-01");
+    expect(d.jd).toBe(431202235029879099711900n);
+    expect(d.year).toBe(1180591620717411303424n);
+    expect(d.wday).toBe(4);
+    expect(d.mon).toBe(1);
+    expect(d.day).toBe(1);
+    expect(d.isJulian).toBe(false);
+    // The residue year is validated as the real one is, so a day the residue's
+    // February does not have raises:
+    //   Date.new(2**70, 3, 1).to_s #=> "1180591620717411303424-03-01"
+    //   Date.new(2**70, 2, 30) #=> Date::Error: invalid date
+    expect(new RubyDate(2n ** 70n, 3, 1).toS()).toBe("1180591620717411303424-03-01");
+    expect(() => new RubyDate(2n ** 70n, 2, 30)).toThrow("invalid date");
+    // A negative nth is the mirror, and strftime spells the whole year:
+    //   Date.new(-(2**70), 1, 1).to_s #=> "-1180591620717411303424-01-01"
+    //   Date.new(2**70, 1, 1).strftime("%C|%y|%A") #=> "11805916207174113034|24|Thursday"
+    expect(new RubyDate(-(2n ** 70n), 1, 1).toS()).toBe("-1180591620717411303424-01-01");
+    expect(d.strftime("%C|%y|%A")).toBe("11805916207174113034|24|Thursday");
+    // date_s_jd runs decode_jd on the day it is given:
+    //   Date.jd(2**70).jd #=> 1180591620717411303424
+    // DateTime carries the same nth on ComplexDateData:
+    //   DateTime.new(2**70, 1, 1, 1, 2, 3).to_s
+    //     #=> "1180591620717411303424-01-01T01:02:03+00:00"
+    expect(new RubyDateTime(2n ** 70n, 1, 1, 1, 2, 3).toS()).toBe(
+      "1180591620717411303424-01-01T01:02:03+00:00",
+    );
+  });
+
+  it("truncates a fractional year through valid_civil_p, as decode_year does", () => {
+    // ruby 3.3.11 -rdate — valid_civil_p (date_core.c:2246-2277) runs
+    // decode_year before c_valid_civil_p's `int y`, and the truncation is of
+    // the 4712-SHIFTED year, so it rounds toward -4712 rather than toward zero:
+    //   Date.new(-2000.5, 1, 1).to_s #=> "-2001-01-01"
+    //   Date.new(1600.5, 1, 1).to_s  #=> "1600-01-01"
+    //   Date.new(1600.5, 1, 1).jd    #=> 2305448
+    //   Date.new(-2000.5, 1, 1, Date::JULIAN).to_s #=> "-2001-01-01"
+    expect(new RubyDate(-2000.5, 1, 1).toS()).toBe("-2001-01-01");
+    expect(new RubyDate(1600.5, 1, 1).toS()).toBe("1600-01-01");
+    expect(new RubyDate(1600.5, 1, 1).jd).toBe(2305448);
+    expect(new RubyDate(-2000.5, 1, 1, RubyDate.JULIAN).toS()).toBe("-2001-01-01");
   });
 
   it("raises from every static that answers the seat for a Julian-only spelling", () => {

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -3220,7 +3220,9 @@ function mJulianP(jd: number, sg: number): boolean {
 /**
  * @internal `date_core.c` `s_virtual_sg` (`date_core.c:1110-1120`) and
  * `c_virtual_sg` (`date_core.c:1122-1131`), which differ only in the union arm
- * they read and so are one function here, taking the fields. A date whose day
+ * they read and so are one function here, taking the fields — which makes it
+ * `m_virtual_sg` (`date_core.c:1135-1142`), their dispatcher, at every call
+ * site. A date whose day
  * outran a `Fixnum` — `nth` nonzero — is read proleptically whatever its stored
  * `sg` says: a positive `nth` is far enough past the reform to be Gregorian
  * everywhere and a negative one far enough before it to be Julian everywhere.

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -3222,9 +3222,8 @@ function mJulianP(jd: number, sg: number): boolean {
  * `c_virtual_sg` (`date_core.c:1122-1131`), which differ only in the union arm
  * they read and so are one function here, taking the fields — which makes it
  * `m_virtual_sg` (`date_core.c:1135-1142`), their dispatcher, at every call
- * site. A date whose day
- * outran a `Fixnum` — `nth` nonzero — is read proleptically whatever its stored
- * `sg` says: a positive `nth` is far enough past the reform to be Gregorian
+ * site. A date whose day outran a `Fixnum` — `nth` nonzero — is read
+ * proleptically whatever its stored `sg` says: a positive `nth` is far enough past the reform to be Gregorian
  * everywhere and a negative one far enough before it to be Julian everywhere.
  */
 function virtualSg(nth: bigint, sg: number): number {
@@ -3271,9 +3270,19 @@ function cJulianLeapP(y: number): boolean {
   return mod(y, 4) === 0;
 }
 
+/** @internal `date_core.c` `c_gregorian_leap_p` (`date_core.c:709-713`). */
+function cGregorianLeapP(y: number): boolean {
+  return (mod(y, 4) === 0 && y % 100 !== 0) || mod(y, 400) === 0;
+}
+
 /** @internal `date_core.c` `c_julian_last_day_of_month` (`date_core.c:714-720`). */
 function cJulianLastDayOfMonth(y: number, m: number): number {
   return MONTHTAB[cJulianLeapP(y) ? 1 : 0][m];
+}
+
+/** @internal `date_core.c` `c_gregorian_last_day_of_month` (`date_core.c:723-728`). */
+function cGregorianLastDayOfMonth(y: number, m: number): number {
+  return MONTHTAB[cGregorianLeapP(y) ? 1 : 0][m];
 }
 
 /**
@@ -3289,16 +3298,6 @@ function cValidJulianP(y: number, m: number, d: number): [rm: number, rd: number
   if (d < 0) d = last + d + 1;
   if (d < 1 || d > last) return null;
   return [m, d];
-}
-
-/** @internal `date_core.c` `c_gregorian_leap_p` (`date_core.c:709-713`). */
-function cGregorianLeapP(y: number): boolean {
-  return (mod(y, 4) === 0 && y % 100 !== 0) || mod(y, 400) === 0;
-}
-
-/** @internal `date_core.c` `c_gregorian_last_day_of_month` (`date_core.c:723-728`). */
-function cGregorianLastDayOfMonth(y: number, m: number): number {
-  return MONTHTAB[cGregorianLeapP(y) ? 1 : 0][m];
 }
 
 /**

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -69,7 +69,7 @@ function pad2(n: number): string {
  * `time.ts` constructs one.
  */
 export interface StrftimeSubject {
-  year: number;
+  year: number | bigint;
   mon: number;
   day: number;
   wday: number;
@@ -172,10 +172,13 @@ function msecs(subject: StrftimeSubject): number {
  * @internal `m_local_jd` (`date_core.c:1485-1497`), the Julian day the
  * week-number readers below work off. The subject carries the civil date and no
  * `df`, so the `complex_dat_p` arm's `local_jd` shift has no bearer and the
- * conversion is {@link cCivilToJd} over it.
+ * conversion is {@link cCivilToJd} over it. The subject carries the REAL year,
+ * `nth` and all, where the C's `c_civil_to_jd` takes the residue `int`, so the
+ * conversion back is where the magnitude drops — as it does in the C's own
+ * `int` day, which is what these week readers are defined over.
  */
 function mLocalJd(subject: StrftimeSubject): number {
-  return cCivilToJd(subject.year, subject.mon, subject.day);
+  return cCivilToJd(Number(subject.year), subject.mon, subject.day);
 }
 
 /**
@@ -291,12 +294,12 @@ function fmt(
   precision: number,
   defPad: string,
   defPrec: number,
-  val: number,
+  val: number | bigint,
 ): string {
   if (precision <= 0) precision = defPrec;
   if (left) precision = 1;
   const sign = val < 0 ? "-" : "";
-  const digits = String(Math.abs(val));
+  const digits = String(typeof val === "bigint" ? (val < 0n ? -val : val) : Math.abs(val));
   return padding === "0" || (padding === "" && defPad === "0")
     ? sign + digits.padStart(Math.max(precision - sign.length, 0), "0")
     : (sign + digits).padStart(precision, " ");
@@ -510,7 +513,7 @@ export function strftime(
       break;
     }
 
-    const num = (defPad: string, defPrec: number, val: number): string =>
+    const num = (defPad: string, defPrec: number, val: number | bigint): string =>
       fmt(padding, left, precision, defPad, defPrec, val);
     const text = (value: string): string =>
       fillPadding(padding, left, precision, value.length) +
@@ -526,7 +529,12 @@ export function strftime(
     let formatted: string | undefined;
     switch (spec) {
       case "Y":
-        formatted = num("0", 0 <= subject.year ? 4 : 5, subject.year);
+        // `date_strftime.c:236-246`: a Fixnum year widens to 5 for the sign,
+        // where a Bignum one takes the plain default of 4.
+        formatted =
+          typeof subject.year === "bigint"
+            ? num("0", 4, subject.year)
+            : num("0", 0 <= subject.year ? 4 : 5, subject.year);
         break;
       case "C":
         formatted = num("0", 2, div(subject.year, 100));
@@ -2971,6 +2979,22 @@ const REFORM_BEGIN_YEAR = 1582;
 const REFORM_END_YEAR = 1930;
 
 /**
+ * @internal `date_core.c`'s calendar periods (`date_core.c:200-205`): the
+ * Julian and Gregorian cycles, their least common multiple with the week, and
+ * the largest multiple of it a `Fixnum` day can hold. `CM_PERIOD` days are
+ * `CM_PERIOD_JCY` Julian years and `CM_PERIOD_GCY` Gregorian ones exactly, and
+ * a whole number of weeks besides, which is what lets {@link decodeYear} and
+ * {@link decodeJd} split a value into a multiple of the period plus a residue
+ * without moving the weekday.
+ */
+const JC_PERIOD0 = 1461; /* 365.25 * 4 */
+const GC_PERIOD0 = 146097; /* 365.2425 * 400 */
+const CM_PERIOD0 = 71149239; /* (lcm 7 1461 146097) */
+const CM_PERIOD = Math.trunc(0xfffffff / CM_PERIOD0) * CM_PERIOD0;
+const CM_PERIOD_JCY = (CM_PERIOD / JC_PERIOD0) * 4;
+const CM_PERIOD_GCY = (CM_PERIOD / GC_PERIOD0) * 400;
+
+/**
  * @internal `date_core.c`'s `REFORM_BEGIN_JD` / `REFORM_END_JD`
  * (`date_core.c:209-210`), the window a finite `start` has to fall in — ns
  * 1582-01-01 through os 1930-12-31, the span over which the reform was actually
@@ -3185,24 +3209,48 @@ function cJdToWday(jd: number): number {
  * receiver: the two arms hold different days, and each class passes its own.
  *
  * The `isinf` arm is what makes `Date::JULIAN` julian everywhere and
- * `Date::GREGORIAN` julian nowhere. The `sg` it reads is `s_virtual_sg`
- * (`date_core.c:1110-1120`), which answers an infinity for a date whose Julian
- * day overflowed a `Fixnum`, on the `nth` field that carries the overflow;
- * there is no `nth` here — the Julian day is one JS number — so the virtual
- * reading and the stored one never part company.
+ * `Date::GREGORIAN` julian nowhere. The `sg` its callers read is
+ * {@link virtualSg}, which answers an infinity once `nth` is nonzero.
  */
 function mJulianP(jd: number, sg: number): boolean {
   if (!Number.isFinite(sg)) return sg === JULIAN;
   return jd < sg;
 }
 
+/**
+ * @internal `date_core.c` `s_virtual_sg` (`date_core.c:1110-1120`) and
+ * `c_virtual_sg` (`date_core.c:1122-1131`), which differ only in the union arm
+ * they read and so are one function here, taking the fields. A date whose day
+ * outran a `Fixnum` — `nth` nonzero — is read proleptically whatever its stored
+ * `sg` says: a positive `nth` is far enough past the reform to be Gregorian
+ * everywhere and a negative one far enough before it to be Julian everywhere.
+ */
+function virtualSg(nth: bigint, sg: number): number {
+  if (!Number.isFinite(sg)) return sg;
+  if (nth === 0n) return sg;
+  else if (nth < 0n) return JULIAN;
+  return GREGORIAN;
+}
+
 /** @internal `date_core.c`'s `DIV` macro (`date_core.c:168-170`), floored division. */
-function div(n: number, d: number): number {
+function div(n: number, d: number): number;
+function div(n: bigint, d: number): bigint;
+function div(n: number | bigint, d: number): number | bigint;
+function div(n: number | bigint, d: number): number | bigint {
+  if (typeof n === "bigint") {
+    const bd = BigInt(d);
+    const q = n / bd;
+    return n % bd !== 0n && n < 0n !== bd < 0n ? q - 1n : q;
+  }
   return Math.floor(n / d);
 }
 
 /** @internal `date_core.c`'s `MOD` macro (`date_core.c:169-171`), floored modulo. */
-function mod(n: number, d: number): number {
+function mod(n: number, d: number): number;
+function mod(n: bigint, d: number): bigint;
+function mod(n: number | bigint, d: number): number | bigint;
+function mod(n: number | bigint, d: number): number | bigint {
+  if (typeof n === "bigint") return n - BigInt(d) * div(n, d);
   return n - d * div(n, d);
 }
 
@@ -3215,6 +3263,31 @@ const MONTHTAB: readonly (readonly number[])[] = [
   [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
   [0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
 ];
+
+/** @internal `date_core.c` `c_julian_leap_p` (`date_core.c:702-707`). */
+function cJulianLeapP(y: number): boolean {
+  return mod(y, 4) === 0;
+}
+
+/** @internal `date_core.c` `c_julian_last_day_of_month` (`date_core.c:714-720`). */
+function cJulianLastDayOfMonth(y: number, m: number): number {
+  return MONTHTAB[cJulianLeapP(y) ? 1 : 0][m];
+}
+
+/**
+ * @internal `date_core.c` `c_valid_julian_p` (`date_core.c:729-745`), the
+ * PROLEPTIC Julian twin of {@link cValidGregorianP} — the arm
+ * {@link validCivilP} takes for a year far enough before the reform that no
+ * `sg` can put it after one.
+ */
+function cValidJulianP(y: number, m: number, d: number): [rm: number, rd: number] | null {
+  if (m < 0) m += 13;
+  if (m < 1 || m > 12) return null;
+  const last = cJulianLastDayOfMonth(y, m);
+  if (d < 0) d = last + d + 1;
+  if (d < 1 || d > last) return null;
+  return [m, d];
+}
 
 /** @internal `date_core.c` `c_gregorian_leap_p` (`date_core.c:709-713`). */
 function cGregorianLeapP(y: number): boolean {
@@ -3246,28 +3319,112 @@ function cValidGregorianP(y: number, m: number, d: number): [rm: number, rd: num
 
 /**
  * @internal `date_core.c` `valid_gregorian_p` (`date_core.c:2229-2236`), which
- * is `decode_year` under a negative style followed by {@link cValidGregorianP}.
- * The C's `ry`/`rm`/`rd` out-parameters come back as the tuple; its `nth` does
- * not, for the reason {@link guessStyle} states.
- *
- * `decode_year` (`date_core.c:1342-1371`) reduces to the shift, the `FIX2INT`
- * its Bignum arm ends at, and the unshift once `nth` is out: the year is
- * shifted by 4712, divided by `CM_PERIOD_GCY` into an `nth` that is zero over
- * the whole representable range, and shifted back. That leaves the identity but
- * for the truncation, which is what answers `Date.new(2000.5, 1, 1)` as
- * 2000-01-01 and `Date.new(-2000.5, 1, 1, Date::GREGORIAN)` as -2001-01-01 in
- * MRI — the truncation is of the SHIFTED value, so it rounds toward -4712
- * rather than toward zero.
+ * is {@link decodeYear} under a negative style followed by
+ * {@link cValidGregorianP}. The C's `nth`/`ry`/`rm`/`rd` out-parameters come
+ * back as the tuple.
  */
 function validGregorianP(
-  y: number,
+  y: number | bigint,
   m: number,
   d: number,
-): [ry: number, rm: number, rd: number] | null {
-  const ry = Math.trunc(y + 4712) - 4712;
+): [nth: bigint, ry: number, rm: number, rd: number] | null {
+  const [nth, ry] = decodeYear(y, -1);
   const r = cValidGregorianP(ry, m, d);
   if (r === null) return null;
-  return [ry, r[0], r[1]];
+  return [nth, ry, r[0], r[1]];
+}
+
+/**
+ * @internal `date_core.c`'s `FIXNUM_P` (ruby.h), the test `guess_style` and
+ * `decode_year` branch on: an Integer small enough for Ruby to hold unboxed.
+ * A JS number stops being one where it stops being a safe integer — a
+ * fraction is not an Integer at all and takes the same arm — and a `bigint`
+ * outside that range is the `Bignum` the C's `big:` label is for.
+ */
+function fixnumP(y: number | bigint): boolean {
+  if (typeof y === "bigint") return -MAX_SAFE_INTEGER_BIG <= y && y <= MAX_SAFE_INTEGER_BIG;
+  return Number.isSafeInteger(y);
+}
+
+const MAX_SAFE_INTEGER_BIG = BigInt(Number.MAX_SAFE_INTEGER);
+
+/**
+ * @internal Ruby's `rb_big_norm` (`bignum.c`), which every Integer arithmetic
+ * result passes through: a Bignum small enough for a Fixnum comes back AS a
+ * Fixnum, so `Date.new(600000, 1, 1).jd` is one Integer whatever `nth` the
+ * split gave it. TS has no such unified Integer, so the same normalization is
+ * what keeps a `bigint` out of the answers a JS number holds exactly.
+ */
+function bigNorm(n: bigint): number | bigint {
+  if (-MAX_SAFE_INTEGER_BIG <= n && n <= MAX_SAFE_INTEGER_BIG) return Number(n);
+  return n;
+}
+
+/**
+ * @internal `date_core.c` `decode_year` (`date_core.c:1342-1371`), which splits
+ * a year of any magnitude into a count of whole calendar periods — `nth` — and
+ * a residue year that always fits an `int`, so every conversion below can keep
+ * taking `int`s. The value divided is the year SHIFTED by 4712, so the
+ * truncation the C's `FIX2INT` performs on its `big:` arm rounds toward -4712
+ * rather than toward zero: `Date.new(-2000.5, 1, 1)` is -2001-01-01 and
+ * `Date.new(2000.5, 1, 1)` is 2000-01-01 in MRI.
+ *
+ * The C's `FIXNUM_P` arm and its `big:` label are both here: the first is exact
+ * in a JS number, and the second is exact only for a `bigint` argument — a
+ * `double` that large has already lost the low bits before this is reached.
+ */
+function decodeYear(y: number | bigint, style: number): [nth: bigint, ry: number] {
+  const period = style < 0 ? CM_PERIOD_GCY : CM_PERIOD_JCY;
+  if (typeof y === "number" && fixnumP(y) && y < Number.MAX_SAFE_INTEGER - 4712) {
+    let it = y + 4712; /* shift */
+    const inth = div(it, period);
+    if (inth) it = mod(it, period);
+    return [BigInt(inth), it - 4712 /* unshift */];
+  }
+  if (typeof y === "number") {
+    let t = y + 4712; /* shift */
+    const nth = div(t, period);
+    if (nth) t = mod(t, period);
+    return [BigInt(nth), Math.trunc(t) - 4712 /* unshift */];
+  }
+  let t = y + 4712n; /* shift */
+  const nth = div(t, period);
+  if (nth) t = mod(t, period);
+  return [nth, Number(t) - 4712 /* unshift */];
+}
+
+/**
+ * @internal `date_core.c` `encode_year` (`date_core.c:1373-1390`), the way back
+ * from a `nth` and a residue year to the year the date names — a `bigint` once
+ * `nth` is nonzero, as MRI's is a Bignum.
+ */
+function encodeYear(nth: bigint, y: number, style: number): number | bigint {
+  const period = style < 0 ? CM_PERIOD_GCY : CM_PERIOD_JCY;
+  if (nth === 0n) return y;
+  return bigNorm(BigInt(period) * nth + BigInt(y));
+}
+
+/**
+ * @internal `date_core.c` `decode_jd` (`date_core.c:1393-1402`), the Julian-day
+ * counterpart of {@link decodeYear} over {@link CM_PERIOD}. The same `nth`
+ * carries both, which is what keeps the split consistent: `CM_PERIOD` days are
+ * `CM_PERIOD_GCY` Gregorian years.
+ */
+function decodeJd(jd: number | bigint): [nth: bigint, rjd: number] {
+  if (typeof jd === "bigint") {
+    const nth = div(jd, CM_PERIOD);
+    if (nth === 0n) return [nth, Number(jd)];
+    return [nth, Number(mod(jd, CM_PERIOD))];
+  }
+  const nth = div(jd, CM_PERIOD);
+  if (nth === 0) return [0n, jd];
+  return [BigInt(nth), mod(jd, CM_PERIOD)];
+}
+
+/** @internal `date_core.c` `encode_jd` (`date_core.c:1404-1412`). */
+function encodeJd(nth: bigint, jd: number): number | bigint {
+  if (nth === 0n) return jd;
+  return bigNorm(BigInt(CM_PERIOD) * nth + BigInt(jd));
 }
 
 /**
@@ -3277,19 +3434,15 @@ function validGregorianP(
  * `0` means the reform round trip under `sg` decides.
  *
  * The C's middle arm — `!FIXNUM_P(y)`, a year Ruby holds as something other
- * than a Fixnum — is written here as the range a JS number stops being one
- * over, which is what a non-integer or out-of-safe-range `y` is. Beyond it the C
- * decomposes the year into `nth` plus a residue (`decode_year`,
- * `date_core.c:1342-1371`) so the Julian day still fits a Fixnum; trails
- * carries the whole Julian day in a JS number instead, which is exact up to
- * `Number.MAX_SAFE_INTEGER` — roughly year ±2.4e10 — and loses precision, not
- * range, above that. Years past that limit are the documented gap.
+ * than a Fixnum ({@link fixnumP}) — reads such a year proleptically without
+ * ever comparing it to the reform years, because {@link decodeYear} is about to
+ * fold it into a `nth` and a residue that no longer names the same century.
  */
-function guessStyle(y: number, sg: number): number {
+function guessStyle(y: number | bigint, sg: number): number {
   let style = 0;
 
   if (!Number.isFinite(sg)) style = sg;
-  else if (!Number.isSafeInteger(y)) style = y > 0 ? GREGORIAN : JULIAN;
+  else if (!fixnumP(y)) style = y > 0 ? GREGORIAN : JULIAN;
   else {
     if (y < REFORM_BEGIN_YEAR) style = JULIAN;
     else if (y > REFORM_END_YEAR) style = GREGORIAN;
@@ -3310,6 +3463,10 @@ function guessStyle(y: number, sg: number): number {
  * The C's `rm`/`rd` out-parameters are the folded month and day, which every
  * caller re-derives from the `rjd` it keeps, so `rjd` alone comes back — `null`
  * for the C's `0`.
+ *
+ * `y` is an ALREADY-DECODED integer year, as the C's `int y` is: the truncation
+ * and the `nth` split are {@link validCivilP}'s, which is what every constructor
+ * reaches this through.
  */
 function cValidCivilP(y: number, m: number, d: number, sg = DEFAULT_SG): number | null {
   let ry: number;
@@ -3329,6 +3486,35 @@ function cValidCivilP(y: number, m: number, d: number, sg = DEFAULT_SG): number 
   [ry, rm, rd] = cJdToCivil(rjd, sg);
   if (ry !== y || rm !== m || rd !== d) return null;
   return rjd;
+}
+
+/**
+ * @internal `date_core.c` `valid_civil_p` (`date_core.c:2246-2277`), the year-
+ * decoding wrapper every constructor's non-proleptic arm goes through: it
+ * re-reads {@link guessStyle} and either validates the residue year under the
+ * reform ({@link cValidCivilP}, whose `int y` this is what supplies) or, where
+ * the style is proleptic, under the plain calendar and converts by hand.
+ *
+ * The C's `ry`/`rm`/`rd` out-parameters are the folded triple every caller
+ * re-derives from `rjd`, so the `nth` and the `rjd` alone come back.
+ */
+function validCivilP(
+  y: number | bigint,
+  m: number,
+  d: number,
+  sg: number,
+): [nth: bigint, rjd: number] | null {
+  const style = guessStyle(y, sg);
+
+  if (style === 0) {
+    const jd = cValidCivilP(Number(y), m, d, sg);
+    if (jd === null) return null;
+    return decodeJd(jd);
+  }
+  const [nth, ry] = decodeYear(y, style);
+  const r = style < 0 ? cValidGregorianP(ry, m, d) : cValidJulianP(ry, m, d);
+  if (r === null) return null;
+  return [nth, cCivilToJd(ry, r[0], r[1], style)];
 }
 
 /**
@@ -3777,7 +3963,7 @@ export function dNewByFrags(hash: DateParts | null, sg = DEFAULT_SG): Date {
   }
 
   if (jd === null) throw new DateError("invalid date");
-  return new Date(SEAT, jd, sg);
+  return new Date(SEAT, 0n, jd, sg);
 }
 
 /**
@@ -3874,7 +4060,7 @@ export function dtNewByFrags(hash: DateParts | null, sg = DEFAULT_SG): DateTime 
   let of = to == null ? 0 : to instanceof Rational ? to.toI() : Math.trunc(to);
   if (of < -DAY_IN_SECONDS || of > DAY_IN_SECONDS) of = 0;
 
-  return new DateTime(SEAT, jdLocalToUtc(jd, df, of), dfLocalToUtc(df, of), sf, of, sg);
+  return new DateTime(SEAT, 0n, jdLocalToUtc(jd, df, of), dfLocalToUtc(df, of), sf, of, sg);
 }
 
 /**
@@ -4039,6 +4225,20 @@ export class Date {
   #jd?: number;
 
   /**
+   * @internal `SimpleDateData`'s `nth` (`date_core.c:203-213`), the count of
+   * whole {@link CM_PERIOD}s the Julian day — and, over
+   * {@link CM_PERIOD_GCY}/{@link CM_PERIOD_JCY}, the year — sits above zero. It
+   * is what keeps `Date.new(2**70, 1, 1)` exact: the residue in {@link #jd} and
+   * the civil triple stays an `int`, as the C's does, and every conversion
+   * below keeps taking `int`s while {@link encodeJd} / {@link encodeYear} put
+   * the magnitude back on the way out.
+   *
+   * Not `#`-private: {@link DateTime} reads it, and `ComplexDateData` carries
+   * the same field (`date_core.c:215-231`).
+   */
+  nth: bigint;
+
+  /**
    * @internal `SimpleDateData`'s `sg` (`date_core.c:203-213`), the
    * calendar-reform start the date is read under — the `start` argument every
    * constructor takes, {@link DEFAULT_SG} when none is passed.
@@ -4057,7 +4257,7 @@ export class Date {
    * `date_core.c` `date_s_civil`), which raises `Date::Error` on a civil date
    * `c_valid_civil_p` rejects.
    */
-  constructor(year?: number, month?: number, day?: number, start?: number);
+  constructor(year?: number | bigint, month?: number, day?: number, start?: number);
   /**
    * @internal `date_core.c` `d_simple_new_internal` (`date_core.c:3036-3050`),
    * which writes an already-resolved day straight into a fresh
@@ -4066,23 +4266,33 @@ export class Date {
    * has already established the date is buildable. {@link SEAT} is the brand
    * that selects it.
    */
-  constructor(seat: typeof SEAT, rjd: number, sg: number);
-  constructor(year: number | typeof SEAT = -4712, month = 1, day = 1, start = DEFAULT_SG) {
+  constructor(seat: typeof SEAT, nth: bigint, rjd: number, sg: number);
+  constructor(
+    year: number | bigint | typeof SEAT = -4712,
+    month: number | bigint = 1,
+    day = 1,
+    start = DEFAULT_SG,
+  ) {
     if (typeof year === "symbol") {
-      this.#jd = month;
-      this.#sg = day;
+      this.nth = month as bigint;
+      this.#jd = day;
+      this.#sg = start;
       return;
     }
     const sg = val2sg(start);
     if (guessStyle(year, sg) < 0) {
-      const r = validGregorianP(year, month, day);
+      const r = validGregorianP(year, month as number, day);
       if (r === null) throw new DateError("invalid date");
+      const [nth, ry, rm, rd] = r;
+      this.nth = nth;
       this.#sg = sg;
-      this.#civil = r;
+      this.#civil = [ry, rm, rd];
     } else {
-      const r = cValidCivilP(year, month, day, sg);
+      const r = validCivilP(year, month as number, day, sg);
       if (r === null) throw new DateError("invalid date");
-      this.#jd = r;
+      const [nth, rjd] = r;
+      this.nth = nth;
+      this.#jd = rjd;
       this.#sg = sg;
     }
   }
@@ -4096,9 +4306,21 @@ export class Date {
   #getSJd(): number {
     if (this.#jd === undefined) {
       const [year, mon, mday] = this.#civil as [number, number, number];
-      this.#jd = cCivilToJd(year, mon, mday, this.#sg);
+      this.#jd = cCivilToJd(year, mon, mday, virtualSg(this.nth, this.#sg));
     }
     return this.#jd;
+  }
+
+  /**
+   * @internal `date_core.c` `m_local_jd` (`date_core.c:1486-1497`), the STORED
+   * day read back in local terms — the residue day every conversion below is
+   * taken over, where {@link Date#jd} answers `m_real_local_jd`
+   * (`date_core.c:1499-1510`), the same day with {@link nth} encoded back in.
+   * The C branches on `simple_dat_p`; TS branches on the receiver, so
+   * {@link DateTime} overrides this and the simple arm is here.
+   */
+  mLocalJd(): number {
+    return this.#getSJd();
   }
 
   /**
@@ -4108,12 +4330,13 @@ export class Date {
    * straight, and `get_c_civil` (`date_core.c:1297-1324`) reads
    * `m_local_jd` — the stored UTC day taken back through `jd_utc_to_local`
    * (`date_core.c:1326-1333`). One method stands in for both here because
-   * `this.jd` already IS that split: it is the stored day on `Date` and
-   * {@link DateTime#jd}'s `m_local_jd` on `DateTime`, so the branch the C makes
-   * on `simple_dat_p`/`complex_dat_p` is the one TS makes on the receiver.
+   * `m_local_jd` already IS that split: {@link Date#mLocalJd} is the stored day
+   * on `Date` and the offset-corrected one on `DateTime`, so the branch the C
+   * makes on `simple_dat_p`/`complex_dat_p` is the one TS makes on the
+   * receiver.
    */
   #getCCivil(): [ry: number, rm: number, rdom: number] {
-    return (this.#civil ??= cJdToCivil(this.jd, this.#sg));
+    return (this.#civil ??= cJdToCivil(this.mLocalJd(), virtualSg(this.nth, this.#sg)));
   }
 
   /**
@@ -4123,8 +4346,9 @@ export class Date {
    * leaves the civil date to `get_s_civil`; there is one representation here,
    * so the conversion happens at the call.
    */
-  static jd(jd = 0, start = DEFAULT_SG): Temporal.PlainDate {
-    return new Date(SEAT, jd, val2sg(start)).toDate();
+  static jd(jd: number | bigint = 0, start = DEFAULT_SG): Temporal.PlainDate {
+    const [nth, rjd] = decodeJd(jd);
+    return new Date(SEAT, nth, rjd, val2sg(start)).toDate();
   }
 
   /**
@@ -4137,7 +4361,7 @@ export class Date {
     const sg = val2sg(start);
     const r = cValidOrdinalP(year, yday, sg);
     if (r === null) throw new DateError("invalid date");
-    return new Date(SEAT, r, sg).toDate();
+    return new Date(SEAT, 0n, r, sg).toDate();
   }
 
   /**
@@ -4162,7 +4386,7 @@ export class Date {
     const sg = val2sg(start);
     const r = cValidCommercialP(cwyear, cweek, cwday, sg);
     if (r === null) throw new DateError("invalid date");
-    return new Date(SEAT, r, sg).toDate();
+    return new Date(SEAT, 0n, r, sg).toDate();
   }
 
   /**
@@ -4278,8 +4502,18 @@ export class Date {
     return dNewByFrags(Date._parse(str, comp), val2sg(start)).toDate();
   }
 
-  get year(): number {
-    return this.#getCCivil()[0];
+  /**
+   * Ruby `Date#year` (ruby/date, `date_core.c` `d_lite_year`,
+   * `date_core.c:5302-5306`) over `m_real_year` (`date_core.c:1746-1762`): the
+   * residue year `m_year` holds with {@link nth} encoded back in, which is a
+   * `bigint` — MRI's Bignum — once the year outruns a `Fixnum`.
+   */
+  get year(): number | bigint {
+    const nth = this.nth;
+    const year = this.#getCCivil()[0];
+
+    if (nth === 0n) return year;
+    return encodeYear(nth, year, this.isGregorian ? -1 : +1);
   }
 
   get mon(): number {
@@ -4305,8 +4539,8 @@ export class Date {
    * they agree with MRI at and before the calendar reform where
    * `Temporal.PlainDate`'s own proleptic Gregorian readers do not.
    */
-  get jd(): number {
-    return this.#getSJd();
+  get jd(): number | bigint {
+    return encodeJd(this.nth, this.mLocalJd());
   }
 
   /**
@@ -4316,7 +4550,7 @@ export class Date {
    * Saturday under `Date::ITALY` and a Monday read proleptically.
    */
   get wday(): number {
-    return cJdToWday(this.jd);
+    return cJdToWday(this.mLocalJd());
   }
 
   /**
@@ -4327,7 +4561,7 @@ export class Date {
    * year, as the Julian leap day before it makes it in MRI.
    */
   get yday(): number {
-    const [, rd] = cJdToOrdinal(this.jd, this.#sg);
+    const [, rd] = cJdToOrdinal(this.mLocalJd(), virtualSg(this.nth, this.#sg));
     return rd;
   }
 
@@ -4342,7 +4576,7 @@ export class Date {
    * one on `DateTime` — hence the override there.
    */
   get isJulian(): boolean {
-    return mJulianP(this.#getSJd(), this.#sg);
+    return mJulianP(this.#getSJd(), virtualSg(this.nth, this.#sg));
   }
 
   /**
@@ -4381,7 +4615,7 @@ export class Date {
    * `DateTime`.
    */
   newStart(start = DEFAULT_SG): this {
-    return new Date(SEAT, this.#getSJd(), val2sg(start)) as this;
+    return new Date(SEAT, this.nth, this.#getSJd(), val2sg(start)) as this;
   }
 
   /**
@@ -4445,7 +4679,7 @@ export class Date {
    * The exported {@link dNewByFrags} / {@link dtNewByFrags} answer it directly.
    */
   toDate(): Temporal.PlainDate {
-    return plainDateFromJd(this.jd, this.#sg);
+    return plainDateFromJd(this.mLocalJd(), this.#sg);
   }
 
   /** Ruby `Date#to_s` (ruby/date, `date_core.c` `d_lite_to_s`). */
@@ -4503,12 +4737,12 @@ export class Date {
  * therefore declare exactly what they answer.
  */
 const DateWithoutParseStatics: (new (
-  year?: number,
+  year?: number | bigint,
   month?: number,
   day?: number,
   start?: number,
 ) => Date) &
-  (new (seat: typeof SEAT, rjd: number, sg: number) => Date) &
+  (new (seat: typeof SEAT, nth: bigint, rjd: number, sg: number) => Date) &
   Omit<typeof Date, "parse" | "strptime" | "jd" | "ordinal" | "civil" | "commercial"> = Date;
 
 /**
@@ -4528,7 +4762,7 @@ export class DateTime extends DateWithoutParseStatics {
    * `Date._parse` answers as `:offset`. A `Temporal` offset time zone is
    * minute-precision and could not hold `date_zone_to_diff`'s seconds.
    *
-   * Every reader converts back on the way out through {@link #mLocalJd} /
+   * Every reader converts back on the way out through {@link mLocalJd} /
    * {@link #mLocalDf}, and the constructor converts in through
    * `jd_local_to_utc` / `df_local_to_utc`, as `dt_new_by_frags` does
    * (`date_core.c:8311-8313`).
@@ -4623,7 +4857,7 @@ export class DateTime extends DateWithoutParseStatics {
    * emitting `3`s.
    */
   constructor(
-    year: number,
+    year: number | bigint,
     month: number,
     day: number | Rational,
     hour?: number | Rational,
@@ -4641,10 +4875,18 @@ export class DateTime extends DateWithoutParseStatics {
    * validate. The arguments are `d_complex_new_internal`'s own `rjd`, `df`,
    * `sf` and `of`, in that order, behind the {@link SEAT} brand.
    */
-  constructor(seat: typeof SEAT, rjd: number, df: number, sf: Rational, of: number, sg: number);
   constructor(
-    year: number | typeof SEAT,
-    month?: number,
+    seat: typeof SEAT,
+    nth: bigint,
+    rjd: number,
+    df: number,
+    sf: Rational,
+    of: number,
+    sg: number,
+  );
+  constructor(
+    year: number | bigint | typeof SEAT,
+    month?: number | bigint,
     day?: number | Rational,
     hour?: number | Rational,
     minute?: number | Rational,
@@ -4653,11 +4895,12 @@ export class DateTime extends DateWithoutParseStatics {
     start?: number,
   ) {
     if (typeof year === "symbol") {
-      const rjd = month as number;
-      const df = day as number;
-      const sf = hour as Rational;
-      const of = minute as number;
-      super(SEAT, jdUtcToLocal(rjd, df, of), second as number);
+      const nth = month as bigint;
+      const rjd = day as number;
+      const df = hour as number;
+      const sf = minute as Rational;
+      const of = second as number;
+      super(SEAT, nth, jdUtcToLocal(rjd, df, of), offset as number);
       this.#jd = rjd;
       this.#df = df;
       this.#sf = sf;
@@ -4691,16 +4934,18 @@ export class DateTime extends DateWithoutParseStatics {
     if (dFr !== 0) fr2 = dFr;
     const rof = offset === undefined ? 0 : val2off(offset);
     const sg = start === undefined ? DEFAULT_SG : val2sg(start);
+    let nth: bigint;
     let rjd: number;
     if (guessStyle(year, sg) < 0) {
-      const r = validGregorianP(year, month ?? 1, d);
+      const r = validGregorianP(year, (month as number) ?? 1, d);
       if (r === null) throw new DateError("invalid date");
-      const [ry, rm, rd] = r;
+      const [rnth, ry, rm, rd] = r;
+      nth = rnth;
       rjd = cCivilToJd(ry, rm, rd, sg);
     } else {
-      const r = cValidCivilP(year, month ?? 1, d, sg);
+      const r = validCivilP(year, (month as number) ?? 1, d, sg);
       if (r === null) throw new DateError("invalid date");
-      rjd = r;
+      [nth, rjd] = r;
     }
     const rt = cValidTimeP(h, min, s);
     if (rt === null) throw new DateError("invalid date");
@@ -4712,7 +4957,7 @@ export class DateTime extends DateWithoutParseStatics {
     }
     const localDf = timeToDf(rh, rmin, rs);
     const [jd, df, sf] = addFrac(jdLocalToUtc(rjd, localDf, rof), dfLocalToUtc(localDf, rof), fr2);
-    super(SEAT, jdUtcToLocal(jd, df, rof), sg);
+    super(SEAT, nth, jdUtcToLocal(jd, df, rof), sg);
     this.#jd = jd;
     this.#df = df;
     this.#sf = sf;
@@ -4791,7 +5036,7 @@ export class DateTime extends DateWithoutParseStatics {
       dfLocalToUtc(localDf, rof),
       fr2,
     );
-    return new DateTime(SEAT, rjd2, df, sf, rof, sg).toDatetime();
+    return new DateTime(SEAT, 0n, rjd2, df, sf, rof, sg).toDatetime();
   }
 
   /**
@@ -4859,7 +5104,7 @@ export class DateTime extends DateWithoutParseStatics {
       dfLocalToUtc(localDf, rof),
       fr2,
     );
-    return new DateTime(SEAT, rjd2, df, sf, rof, sg).toDatetime();
+    return new DateTime(SEAT, 0n, rjd2, df, sf, rof, sg).toDatetime();
   }
 
   /**
@@ -4946,7 +5191,7 @@ export class DateTime extends DateWithoutParseStatics {
       dfLocalToUtc(localDf, rof),
       fr2,
     );
-    return new DateTime(SEAT, rjd2, df, sf, rof, sg).toDatetime();
+    return new DateTime(SEAT, 0n, rjd2, df, sf, rof, sg).toDatetime();
   }
 
   /**
@@ -4990,9 +5235,13 @@ export class DateTime extends DateWithoutParseStatics {
   /**
    * @internal `date_core.c` `m_local_jd` (`date_core.c:1486-1497`) over
    * `local_jd` (`date_core.c:1326-1333`), the complex arm: the stored day read
-   * back in local terms.
+   * back in local terms. It is the day `wday`, `yday` and the inherited civil
+   * decode are `c_jd_to_wday` / `c_jd_to_ordinal` / `c_jd_to_civil` over — which
+   * is what makes that decode `get_c_civil` (`date_core.c:1297-1324`) on a
+   * `DateTime` where it is `get_s_civil` (`:1189-1204`) on a `Date` — and what
+   * `Date#jd`, inherited, encodes {@link Date#nth} back into.
    */
-  #mLocalJd(): number {
+  override mLocalJd(): number {
     return jdUtcToLocal(this.#jd, this.#df, this.#of);
   }
 
@@ -5002,18 +5251,6 @@ export class DateTime extends DateWithoutParseStatics {
    */
   #mLocalDf(): number {
     return dfUtcToLocal(this.#df, this.#of);
-  }
-
-  /**
-   * Ruby `DateTime#jd` reads the LOCAL day, not the stored UTC one
-   * (`m_local_jd`, `date_core.c:1486-1497`), which is the day `wday`, `yday`
-   * and the inherited civil decode are then `c_jd_to_wday` /
-   * `c_jd_to_ordinal` / `c_jd_to_civil` over — which is what makes that decode
-   * `get_c_civil` (`date_core.c:1297-1324`) on a `DateTime` where it is
-   * `get_s_civil` (`:1189-1204`) on a `Date`.
-   */
-  override get jd(): number {
-    return this.#mLocalJd();
   }
 
   /**
@@ -5031,11 +5268,19 @@ export class DateTime extends DateWithoutParseStatics {
    * {@link mJulianP}.
    */
   override get isJulian(): boolean {
-    return mJulianP(this.#jd, this.start);
+    return mJulianP(this.#jd, virtualSg(this.nth, this.start));
   }
 
   override newStart(start = DEFAULT_SG): this {
-    return new DateTime(SEAT, this.#jd, this.#df, this.#sf, this.#of, val2sg(start)) as this;
+    return new DateTime(
+      SEAT,
+      this.nth,
+      this.#jd,
+      this.#df,
+      this.#sf,
+      this.#of,
+      val2sg(start),
+    ) as this;
   }
 
   /**
@@ -5045,7 +5290,7 @@ export class DateTime extends DateWithoutParseStatics {
    * day has already rolled the date on — and this is that `Date`'s seat.
    */
   override toDate(): Temporal.PlainDate {
-    return new Date(SEAT, this.#mLocalJd(), this.start).toDate();
+    return new Date(SEAT, this.nth, this.mLocalJd(), this.start).toDate();
   }
 
   /**

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -713,7 +713,7 @@ const ABBR_DAYS = "sun|mon|tue|wed|thu|fri|sat";
  * answers `{... :offset => nil}` there.
  */
 export interface DateParts {
-  jd?: number;
+  jd?: number | bigint;
   year?: number;
   mon?: number;
   mday?: number;
@@ -3638,6 +3638,23 @@ function num2intWithFrac(
 }
 
 /**
+ * @internal `date_core.c`'s `num2num_with_frac` macro (`date_core.c:3286-3294`),
+ * which differs from {@link num2intWithFrac} (`:3296-3305`) only in NOT running
+ * the truncated whole through `NUM2INT`: `datetime_s_jd` (`date_core.c:7685`)
+ * takes its Julian day this way so a day past a `Fixnum` reaches `decode_jd`
+ * whole. A JS number is not narrowed either way, so that arm is the `int` one;
+ * a `bigint` is the `Bignum` the macro keeps, and carries no fraction.
+ */
+function num2numWithFrac(
+  v: number | bigint | Rational,
+  unitInSeconds: number,
+  argcGtN: boolean,
+): [whole: number | bigint, fr: number | Rational] {
+  if (typeof v === "bigint") return [v, 0];
+  return num2intWithFrac(v, unitInSeconds, argcGtN);
+}
+
+/**
  * @internal `date_core.c` `c_valid_ordinal_p` (`date_core.c:674-695`) over
  * `c_ordinal_to_jd` (`date_core.c:556-564`), the `d`th day of year `y`. A
  * negative `d` counts back from the last day of the year — `-1` is 31 December
@@ -3834,7 +3851,7 @@ function cValidWeeknumP(
  * answers the Julian day back: every integer names a day, so there is nothing
  * to reject.
  */
-function rtValidJdP(jd: number): number {
+function rtValidJdP(jd: number | bigint): number | bigint {
   return jd;
 }
 
@@ -3849,11 +3866,21 @@ function rtValidOrdinalP(y: number, d: number, sg = DEFAULT_SG): number | null {
 
 /**
  * @internal `date_core.c` `rt__valid_civil_p` (`date_core.c:4141-4155`) over
- * `c_valid_civil_p` (`date_core.c:766-790`), which answers `nil` rather than
- * raising so its caller can fall through to the next kind of date.
+ * {@link validCivilP} (`date_core.c:2246-2277`), which answers `nil` rather
+ * than raising so its caller can fall through to the next kind of date. The
+ * `nth` the split leaves goes straight back in through {@link encodeJd}
+ * (`date_core.c:4152`): the answer is one whole Julian day, which
+ * `d_new_by_frags` / `dt_new_by_frags` decode again on the way into the object.
  */
-function rtValidCivilP(y: number, m: number, d: number, sg = DEFAULT_SG): number | null {
-  return cValidCivilP(y, m, d, sg);
+function rtValidCivilP(
+  y: number | bigint,
+  m: number,
+  d: number,
+  sg = DEFAULT_SG,
+): number | bigint | null {
+  const r = validCivilP(y, m, d, sg);
+  if (r === null) return null;
+  return encodeJd(r[0], r[1]);
 }
 
 /**
@@ -3879,7 +3906,7 @@ function rtValidCivilP(y: number, m: number, d: number, sg = DEFAULT_SG): number
  * `sg` is the calendar-reform start every arm reads its date under, as Ruby
  * threads it.
  */
-function rtValidDateFragsP(parts: DateParts, sg = DEFAULT_SG): number | null {
+function rtValidDateFragsP(parts: DateParts, sg = DEFAULT_SG): number | bigint | null {
   if (parts.jd !== undefined) {
     const d = rtValidJdP(parts.jd);
     if (d !== null) return d;
@@ -3941,7 +3968,7 @@ function rtValidDateFragsP(parts: DateParts, sg = DEFAULT_SG): number | null {
  * {@link rtRewriteFrags} and {@link completeFrags}.
  */
 export function dNewByFrags(hash: DateParts | null, sg = DEFAULT_SG): Date {
-  let jd: number | null;
+  let jd: number | bigint | null;
 
   if (hash === null) throw new DateError("invalid date");
 
@@ -3964,7 +3991,8 @@ export function dNewByFrags(hash: DateParts | null, sg = DEFAULT_SG): Date {
   }
 
   if (jd === null) throw new DateError("invalid date");
-  return new Date(SEAT, 0n, jd, sg);
+  const [nth, rjd] = decodeJd(jd);
+  return new Date(SEAT, nth, rjd, sg);
 }
 
 /**
@@ -4013,7 +4041,7 @@ function of2str(of: number): string {
  * falls out of the representation rather than being normalized here.
  */
 export function dtNewByFrags(hash: DateParts | null, sg = DEFAULT_SG): DateTime {
-  let jd: number | null;
+  let jd: number | bigint | null;
 
   if (hash === null) throw new DateError("invalid date");
 
@@ -4061,7 +4089,8 @@ export function dtNewByFrags(hash: DateParts | null, sg = DEFAULT_SG): DateTime 
   let of = to == null ? 0 : to instanceof Rational ? to.toI() : Math.trunc(to);
   if (of < -DAY_IN_SECONDS || of > DAY_IN_SECONDS) of = 0;
 
-  return new DateTime(SEAT, 0n, jdLocalToUtc(jd, df, of), dfLocalToUtc(df, of), sf, of, sg);
+  const [nth, rjd] = decodeJd(jd);
+  return new DateTime(SEAT, nth, jdLocalToUtc(rjd, df, of), dfLocalToUtc(df, of), sf, of, sg);
 }
 
 /**
@@ -4988,7 +5017,7 @@ export class DateTime extends DateWithoutParseStatics {
    * `c_valid_time_p` admits into midnight of the next day.
    */
   static jd(
-    jd: number | Rational = 0,
+    jd: number | bigint | Rational = 0,
     hour?: number | Rational,
     minute?: number | Rational,
     second?: number | Rational,
@@ -5008,7 +5037,9 @@ export class DateTime extends DateWithoutParseStatics {
       HOUR_IN_SECONDS,
       minute !== undefined || second !== undefined || offset !== undefined || start !== undefined,
     );
-    const [rjd, jdFr] = num2intWithFrac(
+    // `num2num_with_frac`, not `num2int_with_frac` (`date_core.c:7685`): the
+    // day stays whole so `decode_jd` below can split one past a `Fixnum`.
+    const [rjd, jdFr] = num2numWithFrac(
       jd,
       DAY_IN_SECONDS,
       hour !== undefined ||
@@ -5032,12 +5063,13 @@ export class DateTime extends DateWithoutParseStatics {
       fr2 = fr2 instanceof Rational ? fr2.add(DAY_IN_SECONDS) : fr2 + DAY_IN_SECONDS;
     }
     const localDf = timeToDf(rh, rmin, rs);
+    const [nth, rrjd] = decodeJd(rjd);
     const [rjd2, df, sf] = addFrac(
-      jdLocalToUtc(rjd, localDf, rof),
+      jdLocalToUtc(rrjd, localDf, rof),
       dfLocalToUtc(localDf, rof),
       fr2,
     );
-    return new DateTime(SEAT, 0n, rjd2, df, sf, rof, sg).toDatetime();
+    return new DateTime(SEAT, nth, rjd2, df, sf, rof, sg).toDatetime();
   }
 
   /**
@@ -5100,12 +5132,13 @@ export class DateTime extends DateWithoutParseStatics {
       fr2 = fr2 instanceof Rational ? fr2.add(DAY_IN_SECONDS) : fr2 + DAY_IN_SECONDS;
     }
     const localDf = timeToDf(rh, rmin, rs);
+    const [nth, rrjd] = decodeJd(rjd);
     const [rjd2, df, sf] = addFrac(
-      jdLocalToUtc(rjd, localDf, rof),
+      jdLocalToUtc(rrjd, localDf, rof),
       dfLocalToUtc(localDf, rof),
       fr2,
     );
-    return new DateTime(SEAT, 0n, rjd2, df, sf, rof, sg).toDatetime();
+    return new DateTime(SEAT, nth, rjd2, df, sf, rof, sg).toDatetime();
   }
 
   /**
@@ -5187,12 +5220,13 @@ export class DateTime extends DateWithoutParseStatics {
       fr2 = fr2 instanceof Rational ? fr2.add(DAY_IN_SECONDS) : fr2 + DAY_IN_SECONDS;
     }
     const localDf = timeToDf(rh, rmin, rs);
+    const [nth, rrjd] = decodeJd(rjd);
     const [rjd2, df, sf] = addFrac(
-      jdLocalToUtc(rjd, localDf, rof),
+      jdLocalToUtc(rrjd, localDf, rof),
       dfLocalToUtc(localDf, rof),
       fr2,
     );
-    return new DateTime(SEAT, 0n, rjd2, df, sf, rof, sg).toDatetime();
+    return new DateTime(SEAT, nth, rjd2, df, sf, rof, sg).toDatetime();
   }
 
   /**

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -5004,7 +5004,15 @@ export class DateTime extends DateWithoutParseStatics {
    * The C's `switch (argc)` fall-through splits `jd` through
    * `num2num_with_frac(jd, 1)` (`date_core.c:7685-7686`) and the second, minute
    * and hour through `num2int_with_frac` under the `n` bounds `positive_inf`,
-   * `3` and `2` ({@link num2intWithFrac}). A fraction is legal only in the LAST
+   * `3` and `2` ({@link num2intWithFrac}) — the day keeps its own macro
+   * ({@link num2numWithFrac}) so {@link decodeJd} can split one past a
+   * `Fixnum`, as `d_complex_new_internal` is handed the `nth`
+   * (`date_core.c:7697-7702`). Such a day is outside `Temporal.PlainDateTime`'s
+   * range and so raises at the seat this static answers, exactly as the
+   * Julian-only spellings RFC 0088's mapping table already names do; the
+   * gem-shaped {@link dtNewByFrags} carries it.
+   *
+   * A fraction is legal only in the LAST
    * argument SUPPLIED — the macro raises `"invalid fraction"` when `argc > n` —
    * so `DateTime.jd(2451944.5)` is noon while `DateTime.jd(2451944, 1.5, 0)`
    * raises, and an explicitly passed later `0` is a supplied argument. That is

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/sanitization.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/sanitization.json
@@ -31,6 +31,13 @@
     "package": "activerecord",
     "tsFile": "sanitization.ts",
     "rubyName": "sanitize_sql_for_order",
+    "call": "order:constructor,disallowRawSqlBang",
+    "reason": "Call ORDER only: Rails' one `new` is the `String.new(condition.first)` AFTER disallow_raw_sql!, while `adapter_class` (connection_handling.rb:338) raises on its own when there is no pool to read a db_config from - trails' adapterClassSync answers null instead, so the equivalent raise is an explicit `new ConnectionNotDefined()` before the call. Converges when adapterClassSync propagates the pool error."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "sanitization.ts",
+    "rubyName": "sanitize_sql_for_order",
     "call": "sql",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/sanitization.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/sanitization.json
@@ -32,7 +32,7 @@
     "tsFile": "sanitization.ts",
     "rubyName": "sanitize_sql_for_order",
     "call": "order:constructor,disallowRawSqlBang",
-    "reason": "Call ORDER only: Rails' one `new` is the `String.new(condition.first)` AFTER disallow_raw_sql!, while `adapter_class` (connection_handling.rb:338) raises on its own when there is no pool to read a db_config from - trails' adapterClassSync answers null instead, so the equivalent raise is an explicit `new ConnectionNotDefined()` before the call. Converges when adapterClassSync propagates the pool error."
+    "reason": "Call ORDER only: Rails' one `new` is the `String.new(condition.first)` AFTER disallow_raw_sql!, while `adapter_class` (connection_handling.rb:338) raises on its own when there is no pool to read a db_config from - trails' adapterClassSync answers null instead, so the equivalent raise is an explicit `new ConnectionNotDefined()` before the call. Converges with story adapter-class-sync-swallows-the-pool-error-rails-raises (RFC 0077), which makes adapterClassSync propagate that error."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/sanitization.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/sanitization.json
@@ -31,13 +31,6 @@
     "package": "activerecord",
     "tsFile": "sanitization.ts",
     "rubyName": "sanitize_sql_for_order",
-    "call": "order:constructor,disallowRawSqlBang",
-    "reason": "Call ORDER only: Rails' one `new` is the `String.new(condition.first)` AFTER disallow_raw_sql!, while `adapter_class` (connection_handling.rb:338) raises on its own when there is no pool to read a db_config from - trails' adapterClassSync answers null instead, so the equivalent raise is an explicit `new ConnectionNotDefined()` before the call. Converges with story adapter-class-sync-swallows-the-pool-error-rails-raises (RFC 0077), which makes adapterClassSync propagate that error."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "sanitization.ts",
-    "rubyName": "sanitize_sql_for_order",
     "call": "sql",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },


### PR DESCRIPTION
Four related fidelity fixes: two in the `date` gem port (the `nth` split and
the `valid_civil_p` truncation it shares), one in `sanitization.rb`'s order
matcher, one in the mysql2 connect lifecycle.

## `Date`/`DateTime` carry `nth` (`date_core.c:1342-1412`)

`decodeYear` / `encodeYear` / `decodeJd` / `encodeJd` are ported at their C
names, over the `CM_PERIOD` / `CM_PERIOD_JCY` / `CM_PERIOD_GCY` constants
(`date_core.c:200-205`), and `SimpleDateData`/`ComplexDateData`'s `nth` is now a
field on both classes. The residue day and civil triple stay JS numbers — the
C's `int`s — so the hot path is unchanged, and `encode*` puts the magnitude back
on the way out through `bigNorm` (Ruby's `rb_big_norm`, so an answer that fits a
Fixnum stays a JS number). `s_virtual_sg` / `c_virtual_sg`
(`date_core.c:1110-1131`) come with it, since a nonzero `nth` reads proleptic
whatever `sg` says.

Verified against `ruby -rdate -e`:

```
Date.new(2**70, 1, 1).to_s #=> "1180591620717411303424-01-01"
Date.new(2**70, 1, 1).jd   #=> 431202235029879099711900
Date.new(2**70, 1, 1).strftime("%C|%y|%A") #=> "11805916207174113034|24|Thursday"
```

`%Y`'s Bignum arm takes the plain default width of 4 rather than the Fixnum
arm's sign-widened 5 (`date_strftime.c:236-246`). The range-limit prose in
`guessStyle`'s doc is deleted.

## `valid_civil_p` truncates the year (`date_core.c:2246-2277`)

Ported at its C name, running `decodeYear` before `cValidCivilP` — which keeps
taking an already-decoded `int y`, as the C's does — with the proleptic arms
over `c_valid_gregorian_p` / the newly-ported `c_valid_julian_p`
(`date_core.c:729-745`). The truncation is of the 4712-SHIFTED year, so
`Date.new(-2000.5, 1, 1)` is `-2001-01-01` and `Date.new(1600.5, 1, 1)` is
`1600-01-01`, both as MRI answers.

## `sanitize_sql_for_order` reads `adapter_class`

`orderMatcherFor` is deleted. Rails reads the matcher off the adapter CLASS
(`sanitization.rb:84-89` over `connection_handling.rb:338`), a lookup that
checks out no connection and raises when there is no pool — so the port does
too, with no `host.connection` read, no `ConnectionNotDefined` catch, and no
fallback to the abstract matcher.

## mysql2: one configure teardown, not two

Inventory of the direct `_ensureClient()` callers: `connect()` is driven by
`connectBang()`, which routes through `verifyBang`; `reconnect()` already
passes `configure=false` and dispatches once via `attemptConfigureConnection`.
The one caller that can still reach an unconfigured socket is
`rawConnectionForBlock()` → `getConn()`: `withRawConnection` runs its pre-loop
`connectBang()` only when `_connection === null && isReconnectCanRestoreState()`
(`abstract-adapter.ts:2383`), so a dirty raw connection or a non-restorable
stack skips the lifecycle and the acquisition seam opens the first socket
itself. The inline configure therefore stays, but its bespoke
`disconnectBang()`-on-failure teardown is gone: it now calls
`attemptConfigureConnection` (`abstract_adapter.rb:1216`) itself, so there is
one teardown implementation. Justified at the call site; retiring the last
dispatch site needs the acquisition seam to stop opening sockets, filed as
`mysql2-raw-connection-seam-must-not-open-sockets` (RFC 0076).

`adapterClassSync` now propagates the `connectionPool` error rather than
answering `null` for it — `connection_pool` resolves `strict: true`
(`connection_handling.rb:342`), so `adapter_class` raises by itself and no
caller has to re-derive the raise. `null` is left only for the condition Ruby's
synchronous autoload cannot be in: the adapter module not yet imported. With
that, `sanitizeSqlForOrder` needs no guard of its own and the PR adds **no**
baseline row.

## `decode_jd` on the frags builders and the JD statics

`rt__valid_civil_p` goes through `valid_civil_p` and `encode_jd`s its `nth`
(`date_core.c:4152`); `d_new_by_frags` (`:4315`) and `dt_new_by_frags` (`:8311`)
decode that day back into the stored `nth`; `datetime_s_jd` takes its day with
`num2num_with_frac`, not `num2int_with_frac` (`:7685`), and `decode_jd`s it
(`:7697`) — all ported, with `DateParts.jd` widened to the Integer the frag
actually is. Covered end to end against
`Date.jd(2**70)` / `DateTime.jd(2**70, 1, 2, 3)`.

The one limb left is `Date._parse`'s year fragment, which is still built with
`Number(...)`; widening it needs the `valid_ordinal_p` / `valid_commercial_p`
decode arms that are not ported yet, so it is filed as
`parse-year-fragment-loses-exactness-past-max-safe-integer` (RFC 0088).

Closes-story: date-carries-no-nth-so-huge-years-lose-exactness
Closes-story: valid-civil-p-skips-decode-years-truncation
Closes-story: order-matcher-reads-a-connection-not-the-adapter-class
Closes-story: mysql2-retire-inline-ensureclient-configure
Closes-story: adapter-class-sync-swallows-the-pool-error-rails-raises
