### PR TITLE
feat(scripts): extract-ruby-api.rb emits per-call-site argument descriptors

### DIFF
--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -2445,8 +2445,8 @@ class ApiExtractor
       name = nested_call_name(node)
       name ? "call:#{name}" : "?"
     when :array then "array"
-    when :hash then "hash"
-    when :bare_assoc_hash then describe_kwargs(node[1], flags)
+    when :hash then describe_hash(node[1], flags)
+    when :bare_assoc_hash then describe_kwargs(node[1], flags) || "hash"
     when :binary then "binop:#{node[2]}"
     when :unary then "unary#{describe_arg(node[2], flags)}"
     when :ifop then "ternary"
@@ -2480,23 +2480,42 @@ class ApiExtractor
     "str:#{parts.map { |p| p[1] }.join}"
   end
 
+  # A braced `{ … }` is the ObjectLiteralExpression the port writes, and the TS
+  # extractor reads that as `kwargs{…}` — so a hash whose keys are all
+  # keyword-shaped has to read the same here or every such site is a guaranteed
+  # cross-language mismatch. Anything else (string, dynamic or no keys) is the
+  # opaque `hash` of RFC 0025 §1.
+  def describe_hash(node, flags)
+    return "hash" unless node.is_a?(Array) && node[0] == :assoclist_from_args
+    describe_kwargs(node[1], flags) || "hash"
+  end
+
+  # nil when the assoc list is not keyword-shaped, so the caller can fall back
+  # to the opaque descriptor rather than emit a `kwargs{}` full of `?`.
   def describe_kwargs(assocs, flags)
-    return "hash" unless assocs.is_a?(Array)
+    return nil unless assocs.is_a?(Array) && !assocs.empty?
 
     pairs = assocs.map do |assoc|
-      next "?" unless assoc.is_a?(Array)
+      return nil unless assoc.is_a?(Array)
       case assoc[0]
       when :assoc_new
-        key = assoc[1]
-        label = key.is_a?(Array) && key[0] == :@label ? key[1].chomp(":") : nil
-        label ? "#{label}=#{describe_arg(assoc[2], flags)}" : "?"
+        key = assoc_key_name(assoc[1])
+        return nil unless key
+        "#{key}=#{describe_arg(assoc[2], flags)}"
       when :assoc_splat
         flags << "splat"
         "**splat"
-      else "?"
+      else return nil
       end
     end
     "kwargs{#{pairs.join(",")}}"
+  end
+
+  # `k:` and `:k =>` both spell the bare identifier key a TS object literal has.
+  def assoc_key_name(key)
+    return nil unless key.is_a?(Array)
+    return key[1].chomp(":") if key[0] == :@label
+    ident_name(key[1]) if key[0] == :symbol_literal
   end
 
   def collect_dep_refs(node, constants, identifiers, refs)

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -662,6 +662,8 @@ class ApiExtractor
     method_info[:depRefs] = dep_info[:depRefs] unless dep_info[:depRefs].empty?
     method_info[:calls] = calls unless calls.empty?
     method_info[:weakCalls] = weak_calls unless weak_calls.empty?
+    call_args = collect_call_args(body)
+    method_info[:callArgs] = call_args unless call_args.empty?
     skeleton = collect_method_skeleton(body)
     method_info[:skeleton] = skeleton unless skeleton.empty?
     opt_keys = collect_option_keys(body, params, fqn)
@@ -718,6 +720,8 @@ class ApiExtractor
     method_info[:depRefs] = dep_info[:depRefs] unless dep_info[:depRefs].empty?
     method_info[:calls] = calls unless calls.empty?
     method_info[:weakCalls] = weak_calls unless weak_calls.empty?
+    call_args = collect_call_args(body)
+    method_info[:callArgs] = call_args unless call_args.empty?
     skeleton = collect_method_skeleton(body)
     method_info[:skeleton] = skeleton unless skeleton.empty?
     opt_keys = collect_option_keys(body, params, fqn)
@@ -2047,6 +2051,16 @@ class ApiExtractor
     [calls.uniq, weak_calls]
   end
 
+  # Every syntactic call site in the body, in source order, with its argument
+  # descriptors (RFC 0025 §1). Kept beside collect_method_calls rather than
+  # folded into it: `calls` is a de-duplicated NAME set, so it drops both the
+  # repeats and the zero-argument sites the argument comparator has to see.
+  def collect_call_args(body_node)
+    sites = []
+    walk_for_call_args(body_node, sites)
+    sites
+  end
+
   SKELETON_IF_NODES = %i[if elsif unless if_mod unless_mod ifop case].freeze
   SKELETON_LOOP_NODES = %i[while until while_mod until_mod for].freeze
   SKELETON_LOGICAL_OPS = [:"||", :"&&", :and, :or].freeze
@@ -2318,6 +2332,174 @@ class ApiExtractor
     end
 
     node.each { |child| walk_for_calls(child, calls, weak) if child.is_a?(Array) }
+  end
+
+  # The argument half of walk_for_calls (RFC 0025 §1). Every syntactic call
+  # site is recorded exactly ONCE: record_call_site is terminal — it walks the
+  # receiver, emits the site, then walks the arguments — so a `:method_add_arg`
+  # wrapping an `:fcall` never re-enters the inner node the naive traversal
+  # would record a second time.
+  def walk_for_call_args(node, sites)
+    return unless node.is_a?(Array)
+
+    case node[0]
+    when :method_add_arg, :method_add_block, :command, :command_call, :call, :fcall, :vcall, :super
+      record_call_site(node, sites, [])
+    when :zsuper
+      sites << { name: "super", args: [], flags: ["zsuper"] }
+    else
+      node.each { |child| walk_for_call_args(child, sites) if child.is_a?(Array) }
+    end
+  end
+
+  # Ripper hangs the argument node off a different slot per call shape: `node[2]`
+  # for `:command` and `:method_add_arg`, `node[4]` for `:command_call`,
+  # `node[1]` for `:super`, and nothing at all for a paren-less `:call`.
+  def record_call_site(node, sites, flags)
+    case node[0]
+    when :method_add_block
+      # `each { … }` — the block flags the call it wraps, and its body is walked
+      # after the site so the stream stays in source order.
+      record_call_site(node[1], sites, flags + ["block"])
+      node.drop(2).each { |child| walk_for_call_args(child, sites) if child.is_a?(Array) }
+      return
+    when :method_add_arg then callee, args = node[1], node[2]
+    when :command then callee, args = node, node[2]
+    when :command_call then callee, args = node, node[4]
+    when :super then callee, args = node, node[1]
+    else callee, args = node, nil
+    end
+
+    walk_for_call_args(callee[1], sites) if callee[0] == :call || callee[0] == :command_call
+
+    name = call_site_name(callee)
+    if name
+      site_flags = flags.dup
+      sites << { name: name, args: describe_args(args, site_flags), flags: site_flags }
+    end
+
+    walk_for_call_args(args, sites)
+  end
+
+  # The same name filter walk_for_calls applies, so the two streams pair up.
+  def call_site_name(callee)
+    return "super" if callee[0] == :super
+
+    name =
+      if callee[0] == :call || callee[0] == :command_call
+        callee[3].is_a?(Array) ? ident_name(callee[3]) : nil
+      else
+        ident_name(callee[1])
+      end
+    return nil unless name && !name.start_with?("_") && name =~ /\A[a-z]/
+    name
+  end
+
+  def describe_args(node, flags)
+    return [] unless node.is_a?(Array)
+    return [] if node.empty?
+
+    case node[0]
+    when :arg_paren then describe_args(node[1], flags)
+    when :args_add_block
+      flag_once(flags, "blockpass") if node[2].is_a?(Array)
+      describe_args(node[1], flags)
+    when :args_add_star
+      flag_once(flags, "splat")
+      describe_args(node[1], flags) + ["*splat"] +
+        node.drop(3).map { |child| describe_arg(child, flags) }
+    else
+      # A plain argument list is a bare Array of argument nodes.
+      return node.map { |child| describe_arg(child, flags) } if node[0].is_a?(Array)
+      [describe_arg(node, flags)]
+    end
+  end
+
+  # `unary<desc>`, `binop:<op>`, `ternary`, `array`, `hash`, `str-interp` and
+  # `?` are the OPAQUE descriptors of RFC 0025 §1 — emitted as-is so the
+  # comparator can recognise and skip the site rather than guess at it.
+  def describe_arg(node, flags)
+    return "?" unless node.is_a?(Array)
+
+    case node[0]
+    when :@int, :@float, :@rational, :@imaginary then "num:#{node[1]}"
+    when :@label then "sym:#{node[1].chomp(":")}"
+    when :@kw
+      case node[1]
+      when "true", "false" then "bool:#{node[1]}"
+      when "nil" then "nil"
+      else "id:#{node[1]}"
+      end
+    when :@ident, :@ivar, :@gvar, :@cvar then "id:#{node[1]}"
+    when :@const then "const:#{node[1]}"
+    when :var_ref, :var_field, :top_const_ref then describe_arg(node[1], flags)
+    when :const_path_ref then describe_arg(node[2], flags)
+    when :string_literal then describe_string(node[1])
+    when :symbol_literal then "sym:#{ident_name(node[1]) || "?"}"
+    when :dyna_symbol
+      literal = describe_string(node[1])
+      literal.start_with?("str:") ? "sym:#{literal.delete_prefix("str:")}" : "?"
+    when :vcall, :fcall then "id:#{ident_name(node[1]) || "?"}"
+    when :call, :command, :command_call, :method_add_arg, :method_add_block
+      name = nested_call_name(node)
+      name ? "call:#{name}" : "?"
+    when :array then "array"
+    when :hash then "hash"
+    when :bare_assoc_hash then describe_kwargs(node[1], flags)
+    when :binary then "binop:#{node[2]}"
+    when :unary then "unary#{describe_arg(node[2], flags)}"
+    when :ifop then "ternary"
+    when :paren then describe_args(node[1], flags).first || "?"
+    else "?"
+    end
+  end
+
+  # Nested calls are recorded by NAME only (RFC 0025 §1); `Foo.new` reads as
+  # `constructor`, matching what `new Foo()` already credits on the TS side.
+  def nested_call_name(node)
+    case node[0]
+    when :method_add_arg, :method_add_block then nested_call_name(node[1])
+    when :command then ident_name(node[1])
+    when :call, :command_call
+      name = node[3].is_a?(Array) ? ident_name(node[3]) : nil
+      name == "new" ? "constructor" : name
+    when :fcall, :vcall then ident_name(node[1])
+    end
+  end
+
+  # `[:string_content, part…]` for a `:string_literal`, a bare part list for a
+  # `:dyna_symbol`. An interpolated part makes the whole value opaque.
+  def describe_string(node)
+    return "?" unless node.is_a?(Array)
+
+    parts = node[0] == :string_content ? node.drop(1) : node
+    return "?" unless parts.is_a?(Array)
+    return "str:" if parts.empty?
+    return "str-interp" unless parts.all? { |p| p.is_a?(Array) && p[0] == :@tstring_content }
+    "str:#{parts.map { |p| p[1] }.join}"
+  end
+
+  def describe_kwargs(assocs, flags)
+    return "hash" unless assocs.is_a?(Array)
+
+    pairs = assocs.map do |assoc|
+      next "?" unless assoc.is_a?(Array)
+      case assoc[0]
+      when :assoc_new
+        key = assoc[1]
+        label = key.is_a?(Array) && key[0] == :@label ? key[1].chomp(":") : nil
+        label ? "#{label}=#{describe_arg(assoc[2], flags)}" : "?"
+      when :assoc_splat
+        flag_once(flags, "splat")
+        "**splat"
+      else "?"
+      end
+    end
+    "kwargs{#{pairs.join(",")}}"
+  end
+
+  def flag_once(flags, flag)
+    flags << flag unless flags.include?(flag)
   end
 
   def collect_dep_refs(node, constants, identifiers, refs)

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -2343,10 +2343,9 @@ class ApiExtractor
     return unless node.is_a?(Array)
 
     case node[0]
-    when :method_add_arg, :method_add_block, :command, :command_call, :call, :fcall, :vcall, :super
+    when :method_add_arg, :method_add_block, :command, :command_call, :call, :fcall, :vcall,
+         :super, :zsuper
       record_call_site(node, sites, [])
-    when :zsuper
-      sites << { name: "super", args: [], flags: ["zsuper"] }
     else
       node.each { |child| walk_for_call_args(child, sites) if child.is_a?(Array) }
     end
@@ -2367,6 +2366,7 @@ class ApiExtractor
     when :command then callee, args = node, node[2]
     when :command_call then callee, args = node, node[4]
     when :super then callee, args = node, node[1]
+    when :zsuper then callee, args, flags = node, nil, flags + ["zsuper"]
     else callee, args = node, nil
     end
 
@@ -2375,7 +2375,8 @@ class ApiExtractor
     name = call_site_name(callee)
     if name
       site_flags = flags.dup
-      sites << { name: name, args: describe_args(args, site_flags), flags: site_flags }
+      descriptors = describe_args(args, site_flags)
+      sites << { name: name, args: descriptors, flags: site_flags.uniq }
     end
 
     walk_for_call_args(args, sites)
@@ -2383,7 +2384,7 @@ class ApiExtractor
 
   # The same name filter walk_for_calls applies, so the two streams pair up.
   def call_site_name(callee)
-    return "super" if callee[0] == :super
+    return "super" if callee[0] == :super || callee[0] == :zsuper
 
     name =
       if callee[0] == :call || callee[0] == :command_call
@@ -2402,10 +2403,10 @@ class ApiExtractor
     case node[0]
     when :arg_paren then describe_args(node[1], flags)
     when :args_add_block
-      flag_once(flags, "blockpass") if node[2].is_a?(Array)
+      flags << "blockpass" if node[2].is_a?(Array)
       describe_args(node[1], flags)
     when :args_add_star
-      flag_once(flags, "splat")
+      flags << "splat"
       describe_args(node[1], flags) + ["*splat"] +
         node.drop(3).map { |child| describe_arg(child, flags) }
     else
@@ -2490,16 +2491,12 @@ class ApiExtractor
         label = key.is_a?(Array) && key[0] == :@label ? key[1].chomp(":") : nil
         label ? "#{label}=#{describe_arg(assoc[2], flags)}" : "?"
       when :assoc_splat
-        flag_once(flags, "splat")
+        flags << "splat"
         "**splat"
       else "?"
       end
     end
     "kwargs{#{pairs.join(",")}}"
-  end
-
-  def flag_once(flags, flag)
-    flags << flag unless flags.include?(flag)
   end
 
   def collect_dep_refs(node, constants, identifiers, refs)

--- a/scripts/api-compare/extract-ruby-api.test.ts
+++ b/scripts/api-compare/extract-ruby-api.test.ts
@@ -1465,7 +1465,7 @@ describe("Ruby extractor call-argument capture", () => {
       "foo.rb": `
         class Foo
           def m(a, b)
-            visit([1], { k: 1 }, "id #{a}", a + b, -a, a ? b : nil)
+            visit([1], { "k" => 1 }, "id #{a}", a + b, -a, a ? b : nil)
           end
         end
       `,
@@ -1497,6 +1497,45 @@ describe("Ruby extractor call-argument capture", () => {
     ]);
     expect(argsOf(c["Foo#m"], "build")).toEqual([
       "kwargs{scope=id:relation,on=str:posts,limit=num:1}",
+    ]);
+  });
+
+  it("recurses into a nested keyword hash", () => {
+    const c = rubyCallArgs({
+      "foo.rb": `
+        class Foo
+          def m
+            visit(a: { b: 1 }, c: { d: { e: :dump } })
+          end
+        end
+      `,
+    });
+    expect(argsOf(c["Foo#m"], "visit")).toEqual([
+      "kwargs{a=kwargs{b=num:1},c=kwargs{d=kwargs{e=sym:dump}}}",
+    ]);
+  });
+
+  it("reads a braced hash with keyword-shaped keys as kwargs, and any other as opaque", () => {
+    const c = rubyCallArgs({
+      "foo.rb": `
+        class Foo
+          def m(x)
+            visit({ a: 1 })
+            visit(:b => 2)
+            visit({})
+            visit({ "c" => 3 })
+            visit({ x => 4 })
+          end
+        end
+      `,
+    });
+    const sites = (c["Foo#m"] ?? []).filter((s) => s.name === "visit");
+    expect(sites.map((s) => s.args)).toEqual([
+      ["kwargs{a=num:1}"],
+      ["kwargs{b=num:2}"],
+      ["hash"],
+      ["hash"],
+      ["hash"],
     ]);
   });
 

--- a/scripts/api-compare/extract-ruby-api.test.ts
+++ b/scripts/api-compare/extract-ruby-api.test.ts
@@ -1388,3 +1388,214 @@ describe("Ruby extractor metaprogrammed method surface", () => {
     expect(m["Unresolvable.self"] ?? []).toEqual([]);
   });
 });
+
+describe("Ruby extractor call-argument capture", () => {
+  const RUBY_SCRIPT = path.join(HERE, "extract-ruby-api.rb");
+
+  interface CallSite {
+    name: string;
+    args: string[];
+    flags: string[];
+  }
+
+  // Returns a map of "<fqn>#<method>" -> the ordered callArgs stream.
+  function rubyCallArgs(fixtures: Record<string, string>): Record<string, CallSite[] | undefined> {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "call-args-rb-"));
+    try {
+      for (const [rel, src] of Object.entries(fixtures)) {
+        const p = path.join(dir, rel);
+        fs.mkdirSync(path.dirname(p), { recursive: true });
+        fs.writeFileSync(p, src);
+      }
+      const rels = JSON.stringify(Object.keys(fixtures));
+      const driver = `
+        require_relative ${JSON.stringify(RUBY_SCRIPT)}
+        require "json"
+        ex = ApiExtractor.new
+        JSON.parse(${JSON.stringify(rels)}).each do |rel|
+          ex.process_file(File.join(${JSON.stringify(dir)}, rel), ${JSON.stringify(dir)})
+        end
+        out = {}
+        ex.classes.each do |fqn, info|
+          (info[:instanceMethods] + info[:classMethods]).each do |m|
+            out["#{fqn}##{m[:name]}"] = m[:callArgs]
+          end
+        end
+        puts JSON.generate(out)
+      `;
+      const stdout = execFileSync("ruby", ["-e", driver], { encoding: "utf-8" });
+      return JSON.parse(stdout);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  // The arguments of the one site named `name`, or undefined if there is none.
+  function argsOf(sites: CallSite[] | undefined, name: string): string[] | undefined {
+    return sites?.find((s) => s.name === name)?.args;
+  }
+
+  it("emits a descriptor for every extractable argument form", () => {
+    const c = rubyCallArgs({
+      "foo.rb": `
+        class Foo
+          def m(param)
+            visit(param, @collector, count, 1, 2.5, "sql", true, false, nil, :dump, Nodes::Grouping)
+          end
+        end
+      `,
+    });
+    expect(argsOf(c["Foo#m"], "visit")).toEqual([
+      "id:param",
+      "id:@collector",
+      "id:count",
+      "num:1",
+      "num:2.5",
+      "str:sql",
+      "bool:true",
+      "bool:false",
+      "nil",
+      "sym:dump",
+      "const:Grouping",
+    ]);
+  });
+
+  it("emits opaque descriptors the comparator has to skip", () => {
+    const c = rubyCallArgs({
+      "foo.rb": `
+        class Foo
+          def m(a, b)
+            visit([1], { k: 1 }, "id #{a}", a + b, -a, a ? b : nil)
+          end
+        end
+      `,
+    });
+    expect(argsOf(c["Foo#m"], "visit")).toEqual([
+      "array",
+      "hash",
+      "str-interp",
+      "binop:+",
+      "unaryid:a",
+      "ternary",
+    ]);
+  });
+
+  it("records keyword arguments as keys plus value descriptors", () => {
+    const c = rubyCallArgs({
+      "foo.rb": `
+        class Foo
+          def m(object)
+            assert_valid_value(object, action: :dump)
+            build(scope: relation, on: "posts", limit: 1)
+          end
+        end
+      `,
+    });
+    expect(argsOf(c["Foo#m"], "assert_valid_value")).toEqual([
+      "id:object",
+      "kwargs{action=sym:dump}",
+    ]);
+    expect(argsOf(c["Foo#m"], "build")).toEqual([
+      "kwargs{scope=id:relation,on=str:posts,limit=num:1}",
+    ]);
+  });
+
+  it("records a nested call by name and Foo.new as a constructor", () => {
+    const c = rubyCallArgs({
+      "foo.rb": `
+        class Foo
+          def m(o)
+            visit(o.relation, Nodes::Grouping.new(o))
+          end
+        end
+      `,
+    });
+    expect(argsOf(c["Foo#m"], "visit")).toEqual(["call:relation", "call:constructor"]);
+  });
+
+  it("flags splat, double-splat, block-pass and block sites", () => {
+    const c = rubyCallArgs({
+      "foo.rb": `
+        class Foo
+          def m(args, opts, xs)
+            build(*args)
+            build(**opts)
+            xs.map(&:to_s)
+            xs.each { |x| save(x) }
+          end
+        end
+      `,
+    });
+    const sites = c["Foo#m"] ?? [];
+    expect(sites.find((s) => s.name === "build")).toEqual({
+      name: "build",
+      args: ["*splat"],
+      flags: ["splat"],
+    });
+    expect(sites.filter((s) => s.name === "build")[1]).toEqual({
+      name: "build",
+      args: ["kwargs{**splat}"],
+      flags: ["splat"],
+    });
+    expect(sites.find((s) => s.name === "map")?.flags).toEqual(["blockpass"]);
+    expect(sites.find((s) => s.name === "each")?.flags).toEqual(["block"]);
+    expect(argsOf(sites, "save")).toEqual(["id:x"]);
+  });
+
+  it("records bare super as a zsuper site and super(args) with its arguments", () => {
+    const c = rubyCallArgs({
+      "foo.rb": `
+        class Foo
+          def m(a)
+            super(a)
+          end
+
+          def n
+            super
+          end
+        end
+      `,
+    });
+    expect(argsOf(c["Foo#m"], "super")).toEqual(["id:a"]);
+    expect(c["Foo#n"]).toEqual([{ name: "super", args: [], flags: ["zsuper"] }]);
+  });
+
+  it("records each syntactic call site exactly once, receiver first", () => {
+    const c = rubyCallArgs({
+      "foo.rb": `
+        class Foo
+          def m
+            foo(bar(1))
+          end
+
+          def n(x)
+            o.visit x, collector
+          end
+        end
+      `,
+    });
+    expect(c["Foo#m"]).toEqual([
+      { name: "foo", args: ["call:bar"], flags: [] },
+      { name: "bar", args: ["num:1"], flags: [] },
+    ]);
+    expect((c["Foo#n"] ?? []).map((s) => s.name)).toEqual(["o", "visit", "collector"]);
+    expect(argsOf(c["Foo#n"], "visit")).toEqual(["id:x", "id:collector"]);
+  });
+
+  it("keeps a zero-argument call site in the stream", () => {
+    const c = rubyCallArgs({
+      "foo.rb": `
+        class Foo
+          def m
+            reset
+            reset
+          end
+        end
+      `,
+    });
+    expect(c["Foo#m"]).toEqual([
+      { name: "reset", args: [], flags: [] },
+      { name: "reset", args: [], flags: [] },
+    ]);
+  });
+});

--- a/scripts/api-compare/extract-ruby-api.test.ts
+++ b/scripts/api-compare/extract-ruby-api.test.ts
@@ -1553,11 +1553,21 @@ describe("Ruby extractor call-argument capture", () => {
           def n
             super
           end
+
+          def o
+            super do
+              reset
+            end
+          end
         end
       `,
     });
     expect(argsOf(c["Foo#m"], "super")).toEqual(["id:a"]);
     expect(c["Foo#n"]).toEqual([{ name: "super", args: [], flags: ["zsuper"] }]);
+    expect(c["Foo#o"]).toEqual([
+      { name: "super", args: [], flags: ["block", "zsuper"] },
+      { name: "reset", args: [], flags: [] },
+    ]);
   });
 
   it("records each syntactic call site exactly once, receiver first", () => {

--- a/scripts/parity/types.ts
+++ b/scripts/parity/types.ts
@@ -10,6 +10,21 @@ export interface LiteralValue {
   value?: string | boolean; // int/float token (underscores kept), string/symbol text, or boolean
 }
 
+/**
+ * One syntactic call site in a method body (RFC 0025 §1). `args` holds one
+ * descriptor per argument in order — `id:` / `num:` / `str:` / `bool:` / `nil`
+ * / `sym:` / `const:` / `call:` / `kwargs{k=…}` — plus the OPAQUE spellings
+ * (`?`, `array`, `hash`, `str-interp`, `binop:<op>`, `unary<desc>`, `ternary`,
+ * `*splat`) that mean "no cross-language agreement is possible here, skip the
+ * site". `flags` carries the per-site `splat` / `blockpass` / `block` /
+ * `zsuper` markers, which do the same for the site as a whole.
+ */
+export interface CallSite {
+  name: string;
+  args: string[];
+  flags: string[];
+}
+
 export interface ParamInfo {
   name: string;
   kind: "required" | "optional" | "rest" | "keyword" | "keyword_rest" | "block";
@@ -66,6 +81,15 @@ export interface MethodInfo {
    * extract-ruby-api.rb#walk_for_calls.
    */
   weakCalls?: string[];
+  /**
+   * Both extractors (RFC 0025 `## Call-argument fidelity`): every syntactic
+   * call site in the body, in source order, with its argument descriptors.
+   * `calls` / `callSeq` carry names only, so a port that calls `where` with a
+   * completely different argument list reads as identical to them. Ruby-side
+   * populated by extract-ruby-api.rb#collect_call_args; the TS side lands with
+   * `ts-extractor-emit-call-arguments`. Signal only; nothing gates on it yet.
+   */
+  callArgs?: CallSite[];
   /**
    * TS-side only (RFC 0083): the Ruby call names this declaration's JSDoc tags
    * as deliberately not made, via `@missingRailsCall <call> — <reason>`.


### PR DESCRIPTION
## Why

`calls` / `callSeq` carry call **names** only. A port can call `where` where Rails calls `where`, pass a completely different argument list, and every gate in the repo stays green — RFC 0084's own defect-shape table lists "wrong values / literals" as blind.

RFC 0025 `## Call-argument fidelity` (spike, 2026-08-08) measured **77% genuine divergence over 102 hand-classified rows** on the argument dimension, and found a defect class nothing else in the toolchain can see: trails moved `collector` to the **last** parameter across the whole arel visitor-helper family (`inject_join`, `collect_nodes_for`, `infix_value`, …, 23 call sites). `arity.ts` can't see it (counts match), `api:compare` can't (names match), `api:calls` can't (the calls are made).

This is the first of the six stories — the Ruby extractor half.

## What

`collect_call_args` walks the body beside `walk_for_calls` and emits `callArgs` per method: one entry per **syntactic** call site, in source order, `{ name, args, flags }`, with the descriptor grammar of the RFC's §1 table.

- `id:` / `num:` / `str:` / `bool:` / `nil` / `sym:` / `const:` / `call:` / `kwargs{k=…}`.
- Opaque, emitted as-is so the comparator can *skip* the site rather than guess: `?`, `array`, `hash`, `str-interp`, `binop:<op>`, `unary<desc>`, `ternary`, `*splat`.
- Per-site flags: `splat`, `blockpass`, `block`, `zsuper`.
- Nested calls by name only; `Foo.new` reads as `call:constructor`, matching what `new Foo()` already credits on the TS side.
- Site names are left raw (`new`, snake_case) — §2 normalization is the comparator's job, not the extractor's.

Every syntactic call site is recorded **exactly once**: `record_call_site` is terminal (receiver, then the site, then the arguments), so a `:method_add_arg` wrapping an `:fcall` never re-enters the inner node the naive traversal would record twice. A test pins `foo(bar(1))` to exactly two sites.

The spike used a consumed-node set keyed on the callee node for this; making the recorder terminal gets the same invariant with no extra state, so the set is not carried over.

## Review round 1 — nested `kwargs{}` (AC2)

The reviewer was right that AC2's "nested `kwargs{}`" was neither produced nor tested, and chasing it turned up a worse bug than a missing test.

RFC 0025 §1 has **two rows that both claim `foo({ a: 1 })`**: "keyword args / trailing hash" (→ `kwargs{k=<desc>,…}`) and "array / hash literal contents" (→ opaque `hash`). The first draft took the second reading. The tie-break is the TS counterpart, which is unambiguous — `ts-extractor-emit-call-arguments` maps `ObjectLiteralExpression` → `kwargs{…}` — so emitting `hash` here would have made **every braced-hash argument a guaranteed cross-language mismatch**, a systematic false-positive class seeded on day one.

Fixed: a `:hash` whose assocs are all keyword-shaped (`k:` or `:k =>`) reads as `kwargs{…}`; string-keyed, dynamic-keyed and empty hashes stay opaque, which is what the §1 "must skip" row is actually about. That is also what makes nesting reachable — `visit(a: { b: 1 })` is now `kwargs{a=kwargs{b=num:1}}`, where the old `=hash` value descriptor foreclosed it. Three tests added: nested (two levels deep), the keyword-shaped/opaque split across five hash spellings, and the `:k =>` key form.

Descriptors on vendored Rails after the fix (activerecord + activesupport + activemodel + actionpack): 697 `kwargs{…}`, 70 remaining opaque `hash` — all of them genuinely empty (`each_with_object({})`) or non-keyword.

## Additive — verified

`calls`, `weakCalls`, `skeleton`, `option_keys` and `bodyDigest` are **byte-identical** to `origin/main`. A/B'd by running both extractor versions over the vendored source and diffing every method record with `callArgs` stripped:

| package | files | methods | result |
| --- | ---: | ---: | --- |
| activerecord | 393 | 4,286 | identical |
| activemodel | 71 | 421 | identical |
| activesupport | 281 | 1,786 | identical |
| actionpack | — | — | identical |

Descriptor coverage on real Rails (activerecord): 13,730 sites, 1,649 flagged, 581 carrying an opaque descriptor, **239 bare `?`** — the fall-throughs are `:aref`, `:regexp_literal`, `:string_concat`, `:args_forward`, none of which are in the §1 table, so `?` is the conservative correct answer for each.

No `extractor-schema.ts` change: that token governs the **TS** extractor cache only (`EXTRACTOR_SOURCES`, `extractor-schema.ts:91`). The Ruby manifest keys on the content hash of `extract-ruby-api.rb` itself (`RAILS_INPUTS` / `railsCacheKey`, `orchestrate.ts:88-99`), so this edit self-invalidates and a stale cache cannot serve argument-less records. Registering `callArgs` in `EXTRACTOR_OUTPUT_FIELDS` belongs to `ts-extractor-emit-call-arguments`, keeping the two extractor stories parallel-safe with no shared edit.

Nothing reads `callArgs` yet, so parity % is unchanged and no artifact moves.

Closes-story: ruby-extractor-emit-call-arguments
