### PR TITLE
refactor(activerecord): converge six adapter/migration deviations onto their Rails shapes

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -457,8 +457,9 @@ export class SchemaStatements {
       | [string, ...string[]]
       | [string, ...string[], { ifExists?: boolean; force?: boolean | "cascade" }]
   ): Promise<void> {
-    // TS has no kwargs: Rails' `*table_names, **options` arrives as a trailing
-    // options object on the rest parameter, split back out here.
+    // TS has no kwargs, so Rails' `*table_names, **options`
+    // (abstract/schema_statements.rb:540) arrives as a trailing options object
+    // on the rest parameter.
     const last = args[args.length - 1];
     const hasOptions = last !== null && last !== undefined && typeof last === "object";
     const tableNames = (hasOptions ? args.slice(0, -1) : args) as string[];

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -452,31 +452,17 @@ export class SchemaStatements {
     }
   }
 
-  /**
-   * Splits Rails' `*table_names, **options` splat into a tuple. Shared by
-   * SchemaStatements#dropTable and its dialect overrides so a new option
-   * added here is automatically picked up by subclasses.
-   * @internal
-   */
-  protected _splitTableNamesAndOptions(
-    args: ReadonlyArray<unknown>,
-  ): [string[], { ifExists?: boolean; force?: boolean | "cascade" }] {
-    const last = args[args.length - 1];
-    if (last !== null && last !== undefined && typeof last === "object") {
-      return [
-        args.slice(0, -1) as string[],
-        last as { ifExists?: boolean; force?: boolean | "cascade" },
-      ];
-    }
-    return [args as string[], {}];
-  }
-
   async dropTable(
     ...args:
       | [string, ...string[]]
       | [string, ...string[], { ifExists?: boolean; force?: boolean | "cascade" }]
   ): Promise<void> {
-    const [tableNames, options] = this._splitTableNamesAndOptions(args);
+    // TS has no kwargs: Rails' `*table_names, **options` arrives as a trailing
+    // options object on the rest parameter, split back out here.
+    const last = args[args.length - 1];
+    const hasOptions = last !== null && last !== undefined && typeof last === "object";
+    const tableNames = (hasOptions ? args.slice(0, -1) : args) as string[];
+    const options = (hasOptions ? last : {}) as { ifExists?: boolean; force?: boolean | "cascade" };
     if (tableNames.length === 0) {
       throw new ArgumentError("dropTable requires at least one table name");
     }
@@ -2034,11 +2020,7 @@ export class SchemaStatements {
       length?: number | Record<string, number>;
     } = {},
   ): Promise<Map<string, string>> {
-    const adapter = this as any;
-    if (
-      typeof adapter.supportsIndexSortOrder === "function" &&
-      (await adapter.supportsIndexSortOrder())
-    ) {
+    if (await this.supportsIndexSortOrder()) {
       quotedColumns = this.addIndexSortOrder(quotedColumns, options);
     }
     return quotedColumns;

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
@@ -479,6 +479,7 @@ describe("MySQL::SchemaStatements", () => {
   it("indexes: surfaces per-column prefix lengths from Sub_part", async () => {
     const idx = await indexHost([
       {
+        Table: "pages",
         Key_name: "index_pages_on_title",
         Column_name: "title",
         Non_unique: 1,
@@ -495,6 +496,7 @@ describe("MySQL::SchemaStatements", () => {
   it("indexes: surfaces desc orders when Collation is D", async () => {
     const idx = await indexHost([
       {
+        Table: "pages",
         Key_name: "index_pages_on_title",
         Column_name: "title",
         Non_unique: 1,
@@ -510,6 +512,7 @@ describe("MySQL::SchemaStatements", () => {
   it("indexes: surfaces desc orders for descending functional indexes", async () => {
     const idx = await indexHost([
       {
+        Table: "pages",
         Key_name: "index_pages_on_lower_title",
         Column_name: null,
         Expression: "lower(`title`)",
@@ -530,6 +533,7 @@ describe("MySQL::SchemaStatements", () => {
   it("indexes: collapses functional-index columns into a single SQL string", async () => {
     const idx = await indexHost([
       {
+        Table: "pages",
         Key_name: "index_pages_on_lower_title_and_pos",
         Column_name: null,
         Expression: "lower(`title`)",
@@ -539,6 +543,7 @@ describe("MySQL::SchemaStatements", () => {
         Collation: "A",
       },
       {
+        Table: "pages",
         Key_name: "index_pages_on_lower_title_and_pos",
         Column_name: "position",
         Expression: null,
@@ -563,6 +568,7 @@ describe("MySQL::SchemaStatements", () => {
     const idx = await indexHost(
       [
         {
+          Table: "pages",
           Key_name: "index_pages_on_lower_title_and_pos",
           Column_name: null,
           Expression: "lower(`title`)",
@@ -572,6 +578,7 @@ describe("MySQL::SchemaStatements", () => {
           Collation: "D",
         },
         {
+          Table: "pages",
           Key_name: "index_pages_on_lower_title_and_pos",
           Column_name: "position",
           Expression: null,

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
@@ -18,7 +18,6 @@ import {
   limitToSize,
   integerToSql,
   foreignKeys,
-  indexes,
   parseMysqlName,
 } from "./schema-statements.js";
 import type { RowFormatHost } from "./schema-statements.js";
@@ -468,7 +467,7 @@ describe("MySQL::SchemaStatements", () => {
     expect(fks[0].toTable).toBe("roc`kets");
   });
 
-  // Minimal IndexesHost: indexes() reads via schemaQuery and quotes the table
+  // Minimal host: indexes() reads via schemaQuery and quotes the table
   // name. Stub schemaQuery to return the `SHOW KEYS FROM` rows MySQL yields.
   const indexHost = (rows: Record<string, unknown>[], sortOrderSupported = true) =>
     Object.assign(Object.create(MysqlSchemaStatements.prototype) as MysqlSchemaStatements, {
@@ -478,57 +477,48 @@ describe("MySQL::SchemaStatements", () => {
     });
 
   it("indexes: surfaces per-column prefix lengths from Sub_part", async () => {
-    const idx = await indexes.call(
-      indexHost([
-        {
-          Key_name: "index_pages_on_title",
-          Column_name: "title",
-          Non_unique: 1,
-          Index_type: "BTREE",
-          Sub_part: 10,
-          Collation: "A",
-        },
-      ]),
-      "pages",
-    );
+    const idx = await indexHost([
+      {
+        Key_name: "index_pages_on_title",
+        Column_name: "title",
+        Non_unique: 1,
+        Index_type: "BTREE",
+        Sub_part: 10,
+        Collation: "A",
+      },
+    ]).indexes("pages");
     expect(idx).toHaveLength(1);
     expect(idx[0].lengths).toBe(10);
     expect(idx[0].orders).toEqual({});
   });
 
   it("indexes: surfaces desc orders when Collation is D", async () => {
-    const idx = await indexes.call(
-      indexHost([
-        {
-          Key_name: "index_pages_on_title",
-          Column_name: "title",
-          Non_unique: 1,
-          Index_type: "BTREE",
-          Sub_part: null,
-          Collation: "D",
-        },
-      ]),
-      "pages",
-    );
+    const idx = await indexHost([
+      {
+        Key_name: "index_pages_on_title",
+        Column_name: "title",
+        Non_unique: 1,
+        Index_type: "BTREE",
+        Sub_part: null,
+        Collation: "D",
+      },
+    ]).indexes("pages");
     expect(idx[0].orders).toBe("desc");
     expect(idx[0].lengths).toEqual({});
   });
 
   it("indexes: surfaces desc orders for descending functional indexes", async () => {
-    const idx = await indexes.call(
-      indexHost([
-        {
-          Key_name: "index_pages_on_lower_title",
-          Column_name: null,
-          Expression: "lower(`title`)",
-          Non_unique: 1,
-          Index_type: "BTREE",
-          Sub_part: null,
-          Collation: "D",
-        },
-      ]),
-      "pages",
-    );
+    const idx = await indexHost([
+      {
+        Key_name: "index_pages_on_lower_title",
+        Column_name: null,
+        Expression: "lower(`title`)",
+        Non_unique: 1,
+        Index_type: "BTREE",
+        Sub_part: null,
+        Collation: "D",
+      },
+    ]).indexes("pages");
     // Mirrors Rails' final `.map`: a functional index collapses its columns
     // into a single SQL string via add_options_for_index_columns, with the
     // DESC order baked inline and no separate orders/lengths Records.
@@ -538,29 +528,26 @@ describe("MySQL::SchemaStatements", () => {
   });
 
   it("indexes: collapses functional-index columns into a single SQL string", async () => {
-    const idx = await indexes.call(
-      indexHost([
-        {
-          Key_name: "index_pages_on_lower_title_and_pos",
-          Column_name: null,
-          Expression: "lower(`title`)",
-          Non_unique: 1,
-          Index_type: "BTREE",
-          Sub_part: null,
-          Collation: "A",
-        },
-        {
-          Key_name: "index_pages_on_lower_title_and_pos",
-          Column_name: "position",
-          Expression: null,
-          Non_unique: 1,
-          Index_type: "BTREE",
-          Sub_part: 4,
-          Collation: "D",
-        },
-      ]),
-      "pages",
-    );
+    const idx = await indexHost([
+      {
+        Key_name: "index_pages_on_lower_title_and_pos",
+        Column_name: null,
+        Expression: "lower(`title`)",
+        Non_unique: 1,
+        Index_type: "BTREE",
+        Sub_part: null,
+        Collation: "A",
+      },
+      {
+        Key_name: "index_pages_on_lower_title_and_pos",
+        Column_name: "position",
+        Expression: null,
+        Non_unique: 1,
+        Index_type: "BTREE",
+        Sub_part: 4,
+        Collation: "D",
+      },
+    ]).indexes("pages");
     // Expression columns pass through their parenthesized form; plain columns
     // are quoted with prefix length and DESC order baked in.
     expect(idx[0].columns).toBe("(lower(`title`)), `position`(4) DESC");
@@ -573,32 +560,29 @@ describe("MySQL::SchemaStatements", () => {
     // supports_index_sort_order? — false on MariaDB < 10.8.1 / MySQL < 8.0.1,
     // which drops the DESC/ASC suffix even when Collation="D". Prefix length
     // (via MySQL's add_index_length, ungated) is still baked in.
-    const idx = await indexes.call(
-      indexHost(
-        [
-          {
-            Key_name: "index_pages_on_lower_title_and_pos",
-            Column_name: null,
-            Expression: "lower(`title`)",
-            Non_unique: 1,
-            Index_type: "BTREE",
-            Sub_part: null,
-            Collation: "D",
-          },
-          {
-            Key_name: "index_pages_on_lower_title_and_pos",
-            Column_name: "position",
-            Expression: null,
-            Non_unique: 1,
-            Index_type: "BTREE",
-            Sub_part: 4,
-            Collation: "D",
-          },
-        ],
-        false,
-      ),
-      "pages",
-    );
+    const idx = await indexHost(
+      [
+        {
+          Key_name: "index_pages_on_lower_title_and_pos",
+          Column_name: null,
+          Expression: "lower(`title`)",
+          Non_unique: 1,
+          Index_type: "BTREE",
+          Sub_part: null,
+          Collation: "D",
+        },
+        {
+          Key_name: "index_pages_on_lower_title_and_pos",
+          Column_name: "position",
+          Expression: null,
+          Non_unique: 1,
+          Index_type: "BTREE",
+          Sub_part: 4,
+          Collation: "D",
+        },
+      ],
+      false,
+    ).indexes("pages");
     expect(idx[0].columns).toBe("(lower(`title`)), `position`(4)");
   });
 });

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -13,13 +13,9 @@ import { TableDefinition, Table as MysqlTable } from "./schema-definitions.js";
 import { Column } from "./column.js";
 import { SchemaStatements as BaseSchemaStatements } from "../abstract/schema-statements.js";
 import { SchemaCreation as MysqlSchemaCreation } from "./schema-creation.js";
-import {
-  CreateIndexDefinition,
-  ForeignKeyDefinition,
-  IndexDefinition,
-} from "../abstract/schema-definitions.js";
+import { ForeignKeyDefinition, IndexDefinition } from "../abstract/schema-definitions.js";
 import { quoteColumnName, unquoteIdentifier } from "./quoting.js";
-import type { AddIndexOptions, SchemaStatementsLike } from "../abstract/schema-definitions.js";
+import type { SchemaStatementsLike } from "../abstract/schema-definitions.js";
 import type { VisitorHostAdapter } from "./schema-creation.js";
 
 type CreateTableArgs = Parameters<BaseSchemaStatements["createTable"]>;
@@ -36,6 +32,130 @@ type CreateTableOptions = Extract<CreateTableArgs[1], { options?: string }>;
  * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements (partial)
  */
 export class MysqlSchemaStatements extends BaseSchemaStatements {
+  /** @internal
+   * Return user-defined indexes for the given table. Mirrors Rails'
+   * MySQL `indexes`: reads `SHOW KEYS FROM <table>`, skips the primary
+   * key, groups multi-column indexes by `Key_name`, maps `Index_type`
+   * (btree/hash → `using`; fulltext/spatial → `type`), and wraps
+   * functional-index `Expression` values in parens (unescaping `\'`).
+   * Returns `[]` when the table doesn't exist, matching Rails' rescue.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#indexes
+   */
+  async indexes(tableName: string): Promise<IndexDefinition[]> {
+    let rows: Array<Record<string, unknown>>;
+    try {
+      rows = await this.schemaQuery(`SHOW KEYS FROM ${this.quoteTableName(tableName)}`);
+    } catch (e) {
+      // Mirrors Rails' `rescue StatementInvalid` — a missing table yields []
+      // rather than propagating ER_NO_SUCH_TABLE.
+      const message = `${(e as { message?: string })?.message ?? ""} ${
+        (e as { cause?: { message?: string } })?.cause?.message ?? ""
+      }`;
+      if (/Table '.+' doesn't exist/.test(message)) return [];
+      throw e;
+    }
+
+    const byIndex = new Map<
+      string,
+      {
+        columns: string[];
+        unique: boolean;
+        using?: string;
+        type?: string;
+        comment?: string;
+        lengths: Record<string, number>;
+        orders: Record<string, string>;
+        expressions: Record<string, string>;
+      }
+    >();
+    let currentIndex: string | null = null;
+    for (const r of rows) {
+      const keyName = String((r.Key_name ?? r.KEY_NAME) as string);
+      if (currentIndex !== keyName) {
+        if (keyName === "PRIMARY") continue; // skip the primary key
+        currentIndex = keyName;
+
+        const idxType = String((r.Index_type ?? r.INDEX_TYPE ?? "BTREE") as string).toLowerCase();
+        let using: string | undefined;
+        let type: string | undefined;
+        if (idxType === "fulltext" || idxType === "spatial") {
+          type = idxType;
+        } else if (idxType === "btree" || idxType === "hash") {
+          using = idxType;
+        }
+        const nonUnique = Number(r.Non_unique ?? r.NON_UNIQUE ?? 0);
+        // Mirrors Rails' `row["Index_comment"].presence` — blank (incl. whitespace-only) → nil.
+        const rawComment = r.Index_comment ?? r.INDEX_COMMENT;
+        const comment =
+          rawComment != null && String(rawComment).trim() !== "" ? String(rawComment) : undefined;
+        byIndex.set(keyName, {
+          columns: [],
+          unique: nonUnique === 0,
+          using,
+          type,
+          comment,
+          lengths: {},
+          orders: {},
+          expressions: {},
+        });
+      }
+
+      const entry = byIndex.get(currentIndex)!;
+      // Mirrors Rails' `row[:Collation] == "D"` — descending column/expression.
+      const desc = String((r.Collation ?? r.COLLATION) as string) === "D";
+      const rawExpr = r.Expression ?? r.EXPRESSION;
+      if (rawExpr != null) {
+        // MySQL 8+ functional indexes carry the raw SQL in `Expression` (and
+        // NULL in `Column_name`). Unescape `\'` then wrap in parens unless the
+        // expression already is, matching Rails' IndexDefinition shape.
+        let expr = String(rawExpr).replace(/\\'/g, "'");
+        if (!expr.startsWith("(")) expr = `(${expr})`;
+        entry.columns.push(expr);
+        entry.expressions[expr] = expr;
+        if (desc) entry.orders[expr] = "desc";
+      } else {
+        const column = String((r.Column_name ?? r.COLUMN_NAME) as string);
+        entry.columns.push(column);
+        // Mirrors Rails' `lengths.merge!(col => Sub_part.to_i) if row[:Sub_part]`.
+        const subPart = r.Sub_part ?? r.SUB_PART;
+        if (subPart != null) entry.lengths[column] = Number(subPart);
+        if (desc) entry.orders[column] = "desc";
+      }
+    }
+    return await Promise.all(
+      Array.from(byIndex.entries()).map(
+        async ([name, { columns, unique, using, type, comment, lengths, orders, expressions }]) => {
+          // Mirrors Rails' final `.map`: a functional (expression) index collapses
+          // its columns array into a single SQL string via addOptionsForIndexColumns,
+          // baking prefix length and DESC/ASC order inline. Non-expression columns
+          // are quoted; expression columns pass through their parenthesized form.
+          // The separate lengths/orders Records are consumed here and dropped.
+          if (Object.keys(expressions).length > 0) {
+            const quotedColumns = new Map<string, string>(
+              columns.map((c) => [c, expressions[c] ?? quoteColumnName(c)]),
+            );
+            await this.addOptionsForIndexColumns(quotedColumns, { order: orders, length: lengths });
+            return new IndexDefinition(
+              tableName,
+              name,
+              unique,
+              Array.from(quotedColumns.values()).join(", "),
+              { using, type, comment },
+            );
+          }
+          return new IndexDefinition(tableName, name, unique, columns, {
+            lengths,
+            orders,
+            using,
+            type,
+            comment,
+          });
+        },
+      ),
+    );
+  }
+
   /** Mirrors: MySQL::SchemaStatements#schema_creation */
   override get schemaCreation(): MysqlSchemaCreation {
     return new MysqlSchemaCreation(this as unknown as VisitorHostAdapter);
@@ -44,37 +164,6 @@ export class MysqlSchemaStatements extends BaseSchemaStatements {
   /** Mirrors: MySQL::SchemaStatements#update_table_definition */
   override updateTableDefinition(tableName: string, base?: unknown): MysqlTable {
     return new MysqlTable(tableName, (base ?? this) as SchemaStatementsLike);
-  }
-
-  /**
-   * `Migration#addIndex` routes through `this.connection.addIndex(...)`, so
-   * we override here. Mirrors Rails' `AbstractMysqlAdapter#add_index` /
-   * `#build_create_index_definition` pair: pre-flight via
-   * `indexExists()` and emit `CREATE INDEX` without `IF NOT EXISTS`
-   * (MySQL doesn't support the keyword; MariaDB does but Rails
-   * standardizes on the pre-flight for portability). Without this, the
-   * second `addIndex(..., { ifNotExists: true })` call trips
-   * `ER_DUP_KEYNAME` on MariaDB because `MysqlSchemaCreation`
-   * correctly omits the keyword.
-   *
-   * Mirrors: AbstractMysqlAdapter#add_index +
-   * AbstractMysqlAdapter#build_create_index_definition
-   */
-  override async addIndex(
-    tableName: string,
-    columnName: string | string[],
-    options: AddIndexOptions = {},
-  ): Promise<void> {
-    const [idx, algorithmClause, ifNotExists] = await this.addIndexOptions(
-      tableName,
-      columnName,
-      options as Record<string, unknown>,
-    );
-    if (ifNotExists && (await this.indexExists(tableName, idx.columns, { name: idx.name }))) {
-      return;
-    }
-    const createDef = new CreateIndexDefinition(idx, algorithmClause);
-    await this.execute(await this.schemaCreation.accept(createDef));
   }
 
   /**
@@ -124,10 +213,16 @@ export class MysqlSchemaStatements extends BaseSchemaStatements {
           { ifExists?: boolean; force?: boolean | "cascade"; temporary?: boolean },
         ]
   ): Promise<void> {
-    const [tableNames, options] = this._splitTableNamesAndOptions(args) as [
-      string[],
-      { ifExists?: boolean; force?: boolean | "cascade"; temporary?: boolean },
-    ];
+    // TS has no kwargs: Rails' `*table_names, **options` arrives as a trailing
+    // options object on the rest parameter, split back out here.
+    const last = args[args.length - 1];
+    const hasOptions = last !== null && last !== undefined && typeof last === "object";
+    const tableNames = (hasOptions ? args.slice(0, -1) : args) as string[];
+    const options = (hasOptions ? last : {}) as {
+      ifExists?: boolean;
+      force?: boolean | "cascade";
+      temporary?: boolean;
+    };
     if (tableNames.length === 0) {
       throw new ArgumentError("dropTable requires at least one table name");
     }
@@ -631,144 +726,4 @@ export async function foreignKeys(
     );
   }
   return results;
-}
-
-/** @internal Host surface for {@link indexes}: runs `SHOW KEYS` via the schema
- * channel and quotes the (optionally schema-qualified) table name. */
-interface IndexesHost {
-  schemaQuery(sql: string, binds?: unknown[]): Promise<Record<string, unknown>[]>;
-  quoteTableName(name: string): string;
-  /** Named by Rails on the adapter itself (mysql/schema_statements.rb:62).
-   * @internal */
-  addOptionsForIndexColumns(
-    quotedColumns: Map<string, string>,
-    options: {
-      order?: string | Record<string, string>;
-      length?: number | Record<string, number>;
-    },
-  ): Promise<Map<string, string>>;
-}
-
-/** @internal
- * Return user-defined indexes for the given table. Mirrors Rails'
- * MySQL `indexes`: reads `SHOW KEYS FROM <table>`, skips the primary
- * key, groups multi-column indexes by `Key_name`, maps `Index_type`
- * (btree/hash → `using`; fulltext/spatial → `type`), and wraps
- * functional-index `Expression` values in parens (unescaping `\'`).
- * Returns `[]` when the table doesn't exist, matching Rails' rescue.
- *
- * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#indexes
- */
-export async function indexes(this: IndexesHost, tableName: string): Promise<IndexDefinition[]> {
-  let rows: Array<Record<string, unknown>>;
-  try {
-    rows = await this.schemaQuery(`SHOW KEYS FROM ${this.quoteTableName(tableName)}`);
-  } catch (e) {
-    // Mirrors Rails' `rescue StatementInvalid` — a missing table yields []
-    // rather than propagating ER_NO_SUCH_TABLE.
-    const message = `${(e as { message?: string })?.message ?? ""} ${
-      (e as { cause?: { message?: string } })?.cause?.message ?? ""
-    }`;
-    if (/Table '.+' doesn't exist/.test(message)) return [];
-    throw e;
-  }
-
-  const byIndex = new Map<
-    string,
-    {
-      columns: string[];
-      unique: boolean;
-      using?: string;
-      type?: string;
-      comment?: string;
-      lengths: Record<string, number>;
-      orders: Record<string, string>;
-      expressions: Record<string, string>;
-    }
-  >();
-  let currentIndex: string | null = null;
-  for (const r of rows) {
-    const keyName = String((r.Key_name ?? r.KEY_NAME) as string);
-    if (currentIndex !== keyName) {
-      if (keyName === "PRIMARY") continue; // skip the primary key
-      currentIndex = keyName;
-
-      const idxType = String((r.Index_type ?? r.INDEX_TYPE ?? "BTREE") as string).toLowerCase();
-      let using: string | undefined;
-      let type: string | undefined;
-      if (idxType === "fulltext" || idxType === "spatial") {
-        type = idxType;
-      } else if (idxType === "btree" || idxType === "hash") {
-        using = idxType;
-      }
-      const nonUnique = Number(r.Non_unique ?? r.NON_UNIQUE ?? 0);
-      // Mirrors Rails' `row["Index_comment"].presence` — blank (incl. whitespace-only) → nil.
-      const rawComment = r.Index_comment ?? r.INDEX_COMMENT;
-      const comment =
-        rawComment != null && String(rawComment).trim() !== "" ? String(rawComment) : undefined;
-      byIndex.set(keyName, {
-        columns: [],
-        unique: nonUnique === 0,
-        using,
-        type,
-        comment,
-        lengths: {},
-        orders: {},
-        expressions: {},
-      });
-    }
-
-    const entry = byIndex.get(currentIndex)!;
-    // Mirrors Rails' `row[:Collation] == "D"` — descending column/expression.
-    const desc = String((r.Collation ?? r.COLLATION) as string) === "D";
-    const rawExpr = r.Expression ?? r.EXPRESSION;
-    if (rawExpr != null) {
-      // MySQL 8+ functional indexes carry the raw SQL in `Expression` (and
-      // NULL in `Column_name`). Unescape `\'` then wrap in parens unless the
-      // expression already is, matching Rails' IndexDefinition shape.
-      let expr = String(rawExpr).replace(/\\'/g, "'");
-      if (!expr.startsWith("(")) expr = `(${expr})`;
-      entry.columns.push(expr);
-      entry.expressions[expr] = expr;
-      if (desc) entry.orders[expr] = "desc";
-    } else {
-      const column = String((r.Column_name ?? r.COLUMN_NAME) as string);
-      entry.columns.push(column);
-      // Mirrors Rails' `lengths.merge!(col => Sub_part.to_i) if row[:Sub_part]`.
-      const subPart = r.Sub_part ?? r.SUB_PART;
-      if (subPart != null) entry.lengths[column] = Number(subPart);
-      if (desc) entry.orders[column] = "desc";
-    }
-  }
-  return await Promise.all(
-    Array.from(byIndex.entries()).map(
-      async ([name, { columns, unique, using, type, comment, lengths, orders, expressions }]) => {
-        // Mirrors Rails' final `.map`: a functional (expression) index collapses
-        // its columns array into a single SQL string via addOptionsForIndexColumns,
-        // baking prefix length and DESC/ASC order inline. Non-expression columns
-        // are quoted; expression columns pass through their parenthesized form.
-        // The separate lengths/orders Records are consumed here and dropped.
-        if (Object.keys(expressions).length > 0) {
-          const quotedColumns = new Map<string, string>(
-            columns.map((c) => [c, expressions[c] ?? quoteColumnName(c)]),
-          );
-          await this.addOptionsForIndexColumns(quotedColumns, { order: orders, length: lengths });
-          return new IndexDefinition(
-            tableName,
-            name,
-            unique,
-            Array.from(quotedColumns.values()).join(", "),
-            { using, type, comment },
-          );
-        }
-        return new IndexDefinition(tableName, name, unique, columns, {
-          lengths,
-          orders,
-          using,
-          type,
-          comment,
-        });
-      },
-    ),
-  );
 }

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -59,6 +59,7 @@ export class MysqlSchemaStatements extends BaseSchemaStatements {
     const byIndex = new Map<
       string,
       {
+        table: string;
         columns: string[];
         unique: boolean;
         using?: string;
@@ -90,6 +91,9 @@ export class MysqlSchemaStatements extends BaseSchemaStatements {
         const comment =
           rawComment != null && String(rawComment).trim() !== "" ? String(rawComment) : undefined;
         byIndex.set(keyName, {
+          // Rails stores `row["Table"]` in the tuple (mysql/schema_statements.rb:24)
+          // and builds the IndexDefinition from it (`:67`), not from the argument.
+          table: String((r.Table ?? r.TABLE) as string),
           columns: [],
           unique: nonUnique === 0,
           using,
@@ -125,7 +129,10 @@ export class MysqlSchemaStatements extends BaseSchemaStatements {
     }
     return await Promise.all(
       Array.from(byIndex.entries()).map(
-        async ([name, { columns, unique, using, type, comment, lengths, orders, expressions }]) => {
+        async ([
+          name,
+          { table, columns, unique, using, type, comment, lengths, orders, expressions },
+        ]) => {
           // Mirrors Rails' final `.map`: a functional (expression) index collapses
           // its columns array into a single SQL string via addOptionsForIndexColumns,
           // baking prefix length and DESC/ASC order inline. Non-expression columns
@@ -137,14 +144,14 @@ export class MysqlSchemaStatements extends BaseSchemaStatements {
             );
             await this.addOptionsForIndexColumns(quotedColumns, { order: orders, length: lengths });
             return new IndexDefinition(
-              tableName,
+              table,
               name,
               unique,
               Array.from(quotedColumns.values()).join(", "),
               { using, type, comment },
             );
           }
-          return new IndexDefinition(tableName, name, unique, columns, {
+          return new IndexDefinition(table, name, unique, columns, {
             lengths,
             orders,
             using,

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -213,8 +213,9 @@ export class MysqlSchemaStatements extends BaseSchemaStatements {
           { ifExists?: boolean; force?: boolean | "cascade"; temporary?: boolean },
         ]
   ): Promise<void> {
-    // TS has no kwargs: Rails' `*table_names, **options` arrives as a trailing
-    // options object on the rest parameter, split back out here.
+    // TS has no kwargs, so Rails' `*table_names, **options`
+    // (abstract/schema_statements.rb:540) arrives as a trailing options object
+    // on the rest parameter.
     const last = args[args.length - 1];
     const hasOptions = last !== null && last !== undefined && typeof last === "object";
     const tableNames = (hasOptions ? args.slice(0, -1) : args) as string[];

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -3,7 +3,6 @@ import { Temporal } from "@blazetrails/date";
 import { BigDecimal } from "@blazetrails/activesupport";
 import { ArgumentError } from "@blazetrails/activemodel";
 import type { AbstractAdapter as DatabaseAdapter } from "./abstract-adapter.js";
-import type { IndexDefinition } from "./abstract/schema-definitions.js";
 import type { ExplainOption } from "./abstract/database-statements.js";
 import { sqlForInsert } from "./abstract/database-statements.js";
 import type { MysqlAdapterOptions } from "./pool-config.js";
@@ -47,10 +46,7 @@ import { temporalTypeCast, TEMPORAL_POOL_OPTIONS } from "./mysql/temporal-type-c
 import type { SchemaSource } from "../schema-dumper.js";
 import { SchemaDumper as MysqlSchemaDumper } from "./mysql/schema-dumper.js";
 import { abandonRawSocket } from "./abandon-raw-socket.js";
-import {
-  indexes as mysqlIndexes,
-  parseMysqlName as mysqlParseName,
-} from "./mysql/schema-statements.js";
+import { parseMysqlName as mysqlParseName } from "./mysql/schema-statements.js";
 
 /**
  * Mysql2-flavored StatementPool. Evicted entries send COM_STMT_CLOSE
@@ -1326,42 +1322,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     return dumper;
   }
 
-  // ── Schema DDL ──
-
-  /**
-   * Mirrors Rails' MySQL `drop_table` which emits `DROP TEMPORARY TABLE`
-   * when `temporary: true` is passed. The abstract base omits this keyword.
-   */
-  override async dropTable(
-    ...args:
-      | [string, ...string[]]
-      | [
-          string,
-          ...string[],
-          { ifExists?: boolean; force?: boolean | "cascade"; temporary?: boolean },
-        ]
-  ): Promise<void> {
-    const last = args[args.length - 1];
-    const hasOpts = last !== null && last !== undefined && typeof last === "object";
-    const tableNames = (hasOpts ? args.slice(0, -1) : args) as string[];
-    const options = (hasOpts ? last : {}) as {
-      ifExists?: boolean;
-      force?: boolean | "cascade";
-      temporary?: boolean;
-    };
-    if (tableNames.length === 0) {
-      throw new ArgumentError("dropTable requires at least one table name");
-    }
-    const temporary = options.temporary ? " TEMPORARY" : "";
-    const ifExists = options.ifExists ? " IF EXISTS" : "";
-    const cascade = options.force === "cascade" ? " CASCADE" : "";
-    const quoted = tableNames.map((n) => this.quoteTableName(n)).join(", ");
-    for (const name of tableNames) {
-      await this.schemaCache.clearDataSourceCacheBang(name);
-    }
-    await this.execute(`DROP${temporary} TABLE${ifExists} ${quoted}${cascade}`);
-  }
-
   // ── Schema introspection ──
   // Mirrors Rails' MySQL SchemaStatements (connection_adapters/mysql/
   // schema_statements.rb + abstract_mysql_adapter.rb). All queries
@@ -1431,18 +1391,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     if (names.length === 0) return null;
     if (names.length === 1) return names[0];
     return names;
-  }
-
-  /** Delegates to {@link mysqlIndexes} in `mysql/schema-statements.ts`. */
-  async indexes(tableName: string): Promise<IndexDefinition[]> {
-    return mysqlIndexes.call(
-      {
-        schemaQuery: this.schemaQuery.bind(this),
-        quoteTableName: this.quoteTableName.bind(this),
-        addOptionsForIndexColumns: this.addOptionsForIndexColumns.bind(this),
-      },
-      tableName,
-    );
   }
 
   supportsAdvisoryLocks(): boolean {

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -124,8 +124,9 @@ export class SchemaStatements extends AbstractSchemaStatements {
   override async dropTable(
     ...args: Parameters<AbstractSchemaStatements["dropTable"]>
   ): Promise<void> {
-    // TS has no kwargs: Rails' `*table_names, **options` arrives as a trailing
-    // options object on the rest parameter, split back out here.
+    // TS has no kwargs, so Rails' `*table_names, **options`
+    // (abstract/schema_statements.rb:540) arrives as a trailing options object
+    // on the rest parameter.
     const last = args[args.length - 1];
     const hasOptions = last !== null && last !== undefined && typeof last === "object";
     const tableNames = (hasOptions ? args.slice(0, -1) : args) as string[];

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -124,7 +124,12 @@ export class SchemaStatements extends AbstractSchemaStatements {
   override async dropTable(
     ...args: Parameters<AbstractSchemaStatements["dropTable"]>
   ): Promise<void> {
-    const [tableNames, options] = this._splitTableNamesAndOptions(args);
+    // TS has no kwargs: Rails' `*table_names, **options` arrives as a trailing
+    // options object on the rest parameter, split back out here.
+    const last = args[args.length - 1];
+    const hasOptions = last !== null && last !== undefined && typeof last === "object";
+    const tableNames = (hasOptions ? args.slice(0, -1) : args) as string[];
+    const options = (hasOptions ? last : {}) as { ifExists?: boolean; force?: boolean | "cascade" };
     if (tableNames.length === 0) {
       throw new ArgumentError("dropTable requires at least one table name");
     }

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -368,7 +368,9 @@ export class Migration {
    * (mirrors Rails `class << self; attr_accessor :delegate`, `migration.rb:684`).
    * Seeded with `Migration.delegate = new Migration()` at the bottom of this
    * file, exactly as Rails does at `migration.rb:813`.
-   * Distinct from the instance `delegate` getter, which returns the current adapter.
+   * Rails defines `delegate` and `nearest_delegate` only inside `class << self`
+   * (`migration.rb:684-689`); the instance side reaches the adapter through
+   * `connection` (`migration.rb:1006-1012`), never through a delegate reader.
    * @internal
    */
   static delegate: Migration | null = null;
@@ -1659,17 +1661,6 @@ export class Migration {
       return (delegate[name] as (...a: unknown[]) => unknown).apply(delegate, args);
     }
     throw new TypeError(`undefined method '${name}' for ${this.name}`);
-  }
-
-  // --- Delegation (Rails: Migration#nearest_delegate, #delegate) ---
-
-  /** Instance delegation target — returns the current adapter. Distinct from the class-level `Migration.delegate`. */
-  get delegate(): DatabaseAdapter {
-    return this.connection;
-  }
-
-  get nearestDelegate(): DatabaseAdapter {
-    return this.connection;
   }
 
   /** @internal */


### PR DESCRIPTION
Five small convergence stories, each deleting a trails-only shape in favour of the Rails one.

- **`addOptionsForIndexColumns` calls the predicate unconditionally**, matching `abstract/schema_statements.rb:1639-1645`. The duck-type probe and the `as any` on `this` are gone; `supportsIndexSortOrder` is already on `AbstractAdapter` (`abstract_adapter.rb:411`), which is what `SchemaStatements`' merged host interface types `this` as, so no new declaration was needed.
- **MySQL `addIndex` is defined once.** Rails declares the pair only on `AbstractMysqlAdapter` (`abstract_mysql_adapter.rb:445-458`); `MySQL::SchemaStatements` has neither. The duplicate `override addIndex` in `mysql/schema-statements.ts` is deleted, so MySQL index DDL flows through `AbstractMysqlAdapter#addIndex` → `buildCreateIndexDefinition`, whose JSDoc already states the `if_not_exists` pre-flight at `:455`'s position.
- **`dropTable`'s kwargs split is inline.** The bespoke protected `_splitTableNamesAndOptions` is deleted; each `dropTable` body splits the trailing options object off the rest parameter in the same three lines, mirroring `*table_names, **options` (`abstract/schema_statements.rb:540-545`). `mysql2-adapter.ts`'s `dropTable` was a byte-for-byte duplicate of the one `MysqlSchemaStatements` already mixes into `AbstractMysqlAdapter`, so it is deleted rather than respelled.
- **`Migration`'s instance `delegate` / `nearestDelegate` getters are deleted.** Rails defines both only inside `class << self` (`migration.rb:684-689`); the instance side reaches the adapter through `connection` (`migration.rb:1006-1012`). Neither getter had a call site.
- **MySQL `indexes` is a `MysqlSchemaStatements` member.** It was a module-level `this`-typed function invoked with a hand-built receiver; Rails mixes it into the adapter so `self` IS the adapter (`mysql/schema_statements.rb:8`). `IndexesHost` and `Mysql2Adapter#indexes` are deleted; the unit tests already built their host as `Object.create(MysqlSchemaStatements.prototype)` and now call `.indexes(...)` on it.

`adapter-class-sync-swallows-the-pool-error-rails-raises` left this PR on the rebase onto `main`: #6297 landed the same `adapterClassSync` convergence (with a fuller JSDoc), and its `sanitizeSqlForOrder` arm had already been retired by #6290, so the story is closed against #6297 and this branch no longer touches `connection-handling.ts`.

`move-adapter-specific-snapshot-off-ar-internal-metadata` was claimed with this bundle and **released unbuilt**: the story's own 2026-08-07 findings establish that its only sound arm (the run-token sidecar) is larger than the bundle ceiling and that `load-schema-helper.ts:526-532` requires that seam to be reshaped one story per PR.

`pnpm typecheck`, `pnpm lint`, `pnpm api:calls` (OK, no new rows) and `pnpm api:extra --package activerecord` (no `_splitTableNamesAndOptions`, no `nearestDelegate`) all clean; `api:compare` totals unchanged. Touched unit suites green locally.

Closes-story: add-options-for-index-columns-calls-the-predicate-unconditionally
Closes-story: dedupe-mysql-add-index-into-abstract-mysql-adapter
Closes-story: drop-table-splits-kwargs-through-a-bespoke-protected-helper
Closes-story: migration-instance-delegate-getters-have-no-rails-counterpart
Closes-story: mysql-indexes-is-an-adapter-method-not-a-shim-receiver
