### PR TITLE
fix(activerecord): StatementCache#execute passes Attribute binds to find_by_sql

### DIFF
--- a/packages/activerecord/src/bind-parameter.test.ts
+++ b/packages/activerecord/src/bind-parameter.test.ts
@@ -366,15 +366,8 @@ describe("BindParameterTest", () => {
     const sub = Notifications.subscribe("sql.active_record", (e: Event) => subscriber.call(e));
     try {
       await Topic.find(1);
-      // Rails asserts `attr.value == 1` on the QueryAttribute payload binds
-      // (bind_parameter_test.rb:148-152). trails type-casts binds to primitives
-      // in the relation layer, so the payload carries `[1]` rather than Attribute
-      // objects — the `?? attr` fallback matches the primitive trails emits. (The
-      // payload can't preserve Attribute objects without production changes; the
-      // stronger `binds are logged` assertion is deferred to RFC 0077 story
-      // `tosqlandbinds-preserve-attribute-binds` for that reason.)
       const message = subscriber.events.find((e) =>
-        (e.payload.binds as any[])?.some((attr) => Number(attr?.value ?? attr) === 1),
+        (e.payload.binds as any[])?.some((attr) => attr?.value === 1),
       );
       expect(message).toBeTruthy();
     } finally {

--- a/packages/activerecord/src/statement-cache.ts
+++ b/packages/activerecord/src/statement-cache.ts
@@ -254,9 +254,7 @@ export class StatementCache {
       if (this._queryBuilder instanceof PartialQuery) {
         return await this._model.findBySql(sql, [], { allowRetry, preparable: true });
       }
-      // Type-cast bind objects to primitives for the adapter
-      const castedBinds = bindValues.map((b) => (b instanceof Attribute ? b.valueForDatabase : b));
-      return await this._model.findBySql(sql, castedBinds, { allowRetry, preparable: true });
+      return await this._model.findBySql(sql, bindValues, { allowRetry, preparable: true });
     } catch (e) {
       // Mirrors statement_cache.rb:154 — `rescue ::RangeError` → `[]`. An
       // out-of-range bind (e.g. a belongs_to FK beyond the column's integer


### PR DESCRIPTION
Unit Tests on main @11f8d387 red: `scripts/stale-story-references.test.ts` flagged `packages/activerecord/src/bind-parameter.test.ts:369` naming the now-landed RFC 0077 story `tosqlandbinds-preserve-attribute-binds` (landed in #6293).

Rather than delete the citation, converge the divergence it described. Rails' `StatementCache#execute` hands `@bind_map.bind params` straight to `find_by_sql` (`activerecord/lib/active_record/statement_cache.rb:145-153`); trails unwrapped every `Attribute` to `valueForDatabase` first, so the `sql.active_record` payload carried primitives where Rails carries Attributes. With #6293 landed, adapters unwrap in `typeCastedBinds`, so the unwrap here is redundant as well as divergent.

`bind_parameter_test.rb:148-152` asserts `attr.value == 1` on the payload binds; the trails test now makes that assertion verbatim instead of the `?? attr` primitive fallback.

Local: `bind-parameter`, `statement-cache`, `finder`, `relations`, `query-cache`, `stale-story-references` green; `pnpm api:calls` OK.

Closes-story: red-11f8d387
