### PR TITLE
feat(scripts): extract-ts-api.ts emits per-call-site argument descriptors

### DIFF
--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -2963,6 +2963,25 @@ describe("callArgs", () => {
     ]);
   });
 
+  it("describes an object spread as the double-splat, flagging the site", () => {
+    // extract-ruby-api.rb#describe_kwargs (:2495-2508) reads `:assoc_splat`
+    // (`**opts`) as `**splat` and flags the site; `{ ...opts }` is the same
+    // thing on this side, alone or beside ordinary keys.
+    expect(
+      site(
+        `class Foo {
+          create(opts: object) {
+            this.visit({ ...opts });
+            this.visit({ a: 1, ...opts });
+          }
+        }`,
+      ),
+    ).toEqual([
+      { name: "visit", args: ["kwargs{**splat}"], flags: ["splat"] },
+      { name: "visit", args: ["kwargs{a=num:1,**splat}"], flags: ["splat"] },
+    ]);
+  });
+
   it("describes a non-keyword or empty object literal as the opaque hash", () => {
     const sites = site(
       `class Foo {

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -3171,6 +3171,23 @@ describe("callArgs", () => {
     expect(flags.filter((f) => !shared.has(f))).toEqual([]);
   });
 
+  it("spells a site the same way the calls stream does", () => {
+    // The site name is RAW on both sides (Ruby leaves `new` / snake_case; §2
+    // normalization is the comparator's job), so what "raw" means here is
+    // whatever `calls` already records — the two TS streams must not diverge.
+    const cls = extractFromSource(
+      `class Foo {
+        create() {
+          this.buildRecord(1);
+          new Node(2);
+          super.save();
+        }
+      }`,
+    );
+    const create = cls.instanceMethods.find((m) => m.name === "create")!;
+    expect(create.callArgs!.map((s) => s.name)).toEqual(create.callSeq);
+  });
+
   it("leaves the existing calls stream unchanged", () => {
     const cls = extractFromSource(
       `class Foo {

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -3105,6 +3105,44 @@ describe("callArgs", () => {
     ]);
   });
 
+  it("drops a site whose name the Ruby extractor's own filter would drop", () => {
+    // extract-ruby-api.rb#call_site_name (:2385-2396) never emits a site named
+    // `_foo` or one that does not start with a lowercase letter, so recording
+    // one here would be a TS-only site that can never pair.
+    expect(
+      site(
+        `class Foo {
+          create() {
+            this._private(1);
+            Klass(2);
+            this.save(3);
+          }
+        }`,
+      ),
+    ).toEqual([{ name: "save", args: ["num:3"], flags: [] }]);
+  });
+
+  it("records sites for a file-local private helper, both declaration forms", () => {
+    const info = extractFromFiles("/p", {
+      "quoting.ts": `
+        export function quote(value: unknown): string {
+          return helper(value) + arrowHelper(value);
+        }
+        function helper(value: unknown): string {
+          return where(value);
+        }
+        const arrowHelper = (value: unknown): string => where(value, 1);
+      `,
+    });
+    const fns = fileFunctionsOf(info, "quoting.ts");
+    expect(fns.find((f) => f.name === "helper")!.callArgs).toEqual([
+      { name: "where", args: ["id:value"], flags: [] },
+    ]);
+    expect(fns.find((f) => f.name === "arrowHelper")!.callArgs).toEqual([
+      { name: "where", args: ["id:value", "num:1"], flags: [] },
+    ]);
+  });
+
   it("emits no descriptor outside the vocabulary the Ruby extractor shares", () => {
     // The other half of the extractor-skew vocabulary pin
     // (extractor-skew.test.ts): a descriptor spelling invented on one side only

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -22,9 +22,10 @@ import {
   tsLiteralValue,
 } from "./extract-ts-api.js";
 import { collectTsFileNames } from "./extra-surface.js";
+import { CALL_ARG_DESCRIPTOR_VOCABULARY } from "./extractor-skew.js";
 import { overlappingSubDirs, packageSrcDir } from "./config.js";
 import { COMPARED_TS_FILES, walkTsFilesSync } from "./ts-file-walk.js";
-import type { ClassInfo, MethodInfo, PackageInfo } from "@blazetrails/parity/types";
+import type { CallSite, ClassInfo, MethodInfo, PackageInfo } from "@blazetrails/parity/types";
 
 const VIRTUAL = "virtual.ts";
 
@@ -2857,5 +2858,292 @@ describe("@missingRailsCall extraction", () => {
     });
     const fns = fileFunctionsOf(info, "registry.ts");
     expect(fns.find((f) => f.name === "registerModel")!.missingRailsCalls).toEqual(["first"]);
+  });
+});
+
+describe("callArgs", () => {
+  const site = (source: string, method = "create"): CallSite[] =>
+    extractFromSource(source).instanceMethods.find((m) => m.name === method)!.callArgs!;
+
+  it("records one entry per syntactic call site, in source order", () => {
+    const sites = site(
+      `class Foo {
+        create() {
+          this.build(1);
+          this.save();
+        }
+      }`,
+    );
+    expect(sites).toEqual([
+      { name: "build", args: ["num:1"], flags: [] },
+      { name: "save", args: [], flags: [] },
+    ]);
+  });
+
+  it("records a nested call as its own site, by name in the outer argument list", () => {
+    // Two sites, not three: the recorder is terminal, so the outer site is
+    // emitted once and the inner one is reached through the arguments.
+    expect(
+      site(
+        `class Foo {
+          create() {
+            foo(bar(1));
+          }
+        }`,
+      ),
+    ).toEqual([
+      { name: "foo", args: ["call:bar"], flags: [] },
+      { name: "bar", args: ["num:1"], flags: [] },
+    ]);
+  });
+
+  it("emits no entry for a property read, so a read and a call differ", () => {
+    const read = site(
+      `class Foo {
+        create() {
+          this.foo;
+        }
+      }`,
+    );
+    const called = site(
+      `class Foo {
+        create() {
+          this.foo();
+        }
+      }`,
+    );
+    expect(read).toBeUndefined();
+    expect(called).toEqual([{ name: "foo", args: [], flags: [] }]);
+  });
+
+  it("describes each literal argument form of the shared grammar", () => {
+    expect(
+      site(
+        `class Foo {
+          create(value: unknown) {
+            this.visit(value, 1, "s", true, false, null, undefined, Klass, this.name, o.left);
+          }
+        }`,
+      ),
+    ).toEqual([
+      {
+        name: "visit",
+        args: [
+          "id:value",
+          "num:1",
+          "str:s",
+          "bool:true",
+          "bool:false",
+          "nil",
+          "nil",
+          "const:Klass",
+          "id:name",
+          "call:left",
+        ],
+        flags: [],
+      },
+    ]);
+  });
+
+  it("describes an object literal as kwargs, including shorthand and nesting", () => {
+    expect(
+      site(
+        `class Foo {
+          create(scope: unknown) {
+            this.visit({ scope, action: "dump", nested: { deep: 1 } });
+          }
+        }`,
+      ),
+    ).toEqual([
+      {
+        name: "visit",
+        args: ["kwargs{scope=id:scope,action=str:dump,nested=kwargs{deep=num:1}}"],
+        flags: [],
+      },
+    ]);
+  });
+
+  it("describes a non-keyword or empty object literal as the opaque hash", () => {
+    const sites = site(
+      `class Foo {
+        create(key: string) {
+          this.visit({});
+          this.visit({ [key]: 1 });
+          this.visit({ "a-b": 1 });
+        }
+      }`,
+    );
+    expect(sites.map((s) => s.args)).toEqual([["hash"], ["hash"], ["hash"]]);
+  });
+
+  it("emits the opaque descriptors for the forms the two languages cannot agree on", () => {
+    const sites = site(
+      `class Foo {
+        create(a: number, b: number) {
+          this.visit([1, 2]);
+          this.visit(\`x\${a}\`);
+          this.visit(a + b);
+          this.visit(!a);
+          this.visit(a ? b : a);
+        }
+      }`,
+    );
+    expect(sites.map((s) => s.args)).toEqual([
+      ["array"],
+      ["str-interp"],
+      ["binop:+"],
+      ["unaryid:a"],
+      ["ternary"],
+    ]);
+  });
+
+  it("flags a spread argument and a callback, and drops the callback from the list", () => {
+    expect(
+      site(
+        `class Foo {
+          create(args: unknown[]) {
+            this.visit(1, ...args);
+            this.each((x) => this.save(x));
+          }
+        }`,
+      ),
+    ).toEqual([
+      { name: "visit", args: ["num:1", "*splat"], flags: ["splat"] },
+      { name: "each", args: [], flags: ["block"] },
+      { name: "save", args: ["id:x"], flags: [] },
+    ]);
+  });
+
+  it("records `new Foo(...)` as constructor, matching the Ruby `new` mapping", () => {
+    expect(
+      site(
+        `class Foo {
+          create() {
+            this.visit(new Node(1));
+          }
+        }`,
+      ),
+    ).toEqual([
+      { name: "visit", args: ["call:constructor"], flags: [] },
+      { name: "constructor", args: ["num:1"], flags: [] },
+    ]);
+  });
+
+  it("unwraps await / as / non-null / parenthesized wrappers to the inner expression", () => {
+    expect(
+      site(
+        `class Foo {
+          async create(value: unknown) {
+            this.visit(await this.load(), (value as string), value!);
+          }
+        }`,
+      ),
+    ).toEqual([
+      { name: "visit", args: ["call:load", "id:value", "id:value"], flags: [] },
+      { name: "load", args: [], flags: [] },
+    ]);
+  });
+
+  it("walks the receiver before the site it receives, matching the Ruby order", () => {
+    expect(
+      site(
+        `class Foo {
+          create() {
+            this.klass().unscoped(1);
+          }
+        }`,
+      ),
+    ).toEqual([
+      { name: "klass", args: [], flags: [] },
+      { name: "unscoped", args: ["num:1"], flags: [] },
+    ]);
+  });
+
+  it("records sites for a bare super call and a file-level function", () => {
+    const cls = extractFromSource(
+      `class Foo extends Bar {
+        constructor(a: number) {
+          super(a);
+        }
+      }`,
+    );
+    const ctor = cls.instanceMethods.find((m) => m.name === "constructor")!;
+    expect(ctor.callArgs).toEqual([{ name: "super", args: ["id:a"], flags: [] }]);
+
+    const info = extractFromFiles("/p", {
+      "quoting.ts": `
+        export function quote(value: unknown): string {
+          return quoteString(typeCast(value));
+        }
+      `,
+    });
+    expect(fileFunctionsOf(info, "quoting.ts").find((f) => f.name === "quote")!.callArgs).toEqual([
+      { name: "quoteString", args: ["call:typeCast"], flags: [] },
+      { name: "typeCast", args: ["id:value"], flags: [] },
+    ]);
+  });
+
+  it("records sites for an object-literal member and a get accessor", () => {
+    const [member] = objectLiteralMethods(
+      `export const ClassMethods = {
+        create() {
+          this.save(1);
+        },
+      };`,
+    );
+    expect(member.callArgs).toEqual([{ name: "save", args: ["num:1"], flags: [] }]);
+
+    const cls = extractFromSource(
+      `class Foo {
+        get scope() {
+          return this.build("x");
+        }
+      }`,
+    );
+    expect(cls.instanceMethods.find((m) => m.name === "scope")!.callArgs).toEqual([
+      { name: "build", args: ["str:x"], flags: [] },
+    ]);
+  });
+
+  it("emits no descriptor outside the vocabulary the Ruby extractor shares", () => {
+    // The other half of the extractor-skew vocabulary pin
+    // (extractor-skew.test.ts): a descriptor spelling invented on one side only
+    // stops matching silently, so every descriptor the TS extractor can produce
+    // has to be one extract-ruby-api.rb#describe_arg also produces.
+    const shared = new Set<string>(CALL_ARG_DESCRIPTOR_VOCABULARY);
+    const kindOf = (desc: string): string => {
+      if (desc.startsWith("kwargs{")) return "kwargs{";
+      if (desc.startsWith("unary")) return "unary";
+      const colon = desc.indexOf(":");
+      return colon === -1 ? desc : desc.slice(0, colon + 1);
+    };
+    const sites = site(
+      `class Foo {
+        create(a: number, b: number, xs: unknown[], scope: unknown) {
+          this.visit(a, 1, "s", true, false, null, undefined, Klass, this.name, o.left);
+          this.visit({ scope, nested: { deep: 1 } }, {}, [1], \`x\${a}\`);
+          this.visit(a + b, !a, a ? b : a, ...xs, new Node(), this.load(), /re/);
+          this.each((x) => x);
+        }
+      }`,
+    );
+    const kinds = [...new Set(sites.flatMap((s) => s.args).map(kindOf))];
+    expect(kinds.filter((k) => k !== "?" && !shared.has(k))).toEqual([]);
+    const flags = [...new Set(sites.flatMap((s) => s.flags))];
+    expect(flags.filter((f) => !shared.has(f))).toEqual([]);
+  });
+
+  it("leaves the existing calls stream unchanged", () => {
+    const cls = extractFromSource(
+      `class Foo {
+        create() {
+          this.build(1);
+          this.save();
+        }
+      }`,
+    );
+    const create = cls.instanceMethods.find((m) => m.name === "create")!;
+    expect(create.calls).toEqual(["build", "save"]);
+    expect(create.callSeq).toEqual(["build", "save"]);
   });
 });

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -2783,8 +2783,9 @@ function recordCallSite(
  * here manufactures a TS-only site that can never pair with the Ruby stream.
  */
 function callSiteName(call: ts.CallExpression | ts.NewExpression): string | undefined {
-  // `new Foo(...)` is Ruby's `Foo.new(...)`, which conventions.ts maps to the
-  // TS `constructor` — the spelling collectCalls already records.
+  // `new Foo(...)` is Ruby's `Foo.new(...)`. TS has no method named `new`, so
+  // `constructor` IS this site's raw TS spelling — the one conventions.ts:952
+  // maps Ruby `new` onto, and the one `calls` / `callSeq` already record.
   if (ts.isNewExpression(call)) return "constructor";
   const callee = call.expression;
   if (callee.kind === ts.SyntaxKind.SuperKeyword) return "super";

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -41,6 +41,7 @@ import type {
   MethodInfo,
   ParamInfo,
   LiteralValue,
+  CallSite,
 } from "@blazetrails/parity/types";
 import {
   ROOT_DIR,
@@ -701,6 +702,7 @@ export function extractFromProgram(
         const fnOptionKeys = extractOptionKeys(node.parameters, checker);
         const fnCalls = extractCalls(node.body);
         const fnCallSeq = extractCallSeq(node.body);
+        const fnCallArgs = extractCallArgs(node.body);
         const fnSkeleton = extractSkeleton(node.body);
         const internal = hasInternalJsDocTag(node);
         const noRailsEquivalent = noRailsEquivalentReason(node);
@@ -717,6 +719,7 @@ export function extractFromProgram(
           ...(fnOptionKeys !== undefined ? { optionKeys: fnOptionKeys } : {}),
           ...(fnCalls !== undefined ? { calls: fnCalls } : {}),
           ...(fnCallSeq !== undefined ? { callSeq: fnCallSeq } : {}),
+          ...(fnCallArgs !== undefined ? { callArgs: fnCallArgs } : {}),
           ...(fnSkeleton !== undefined ? { skeleton: fnSkeleton } : {}),
           ...(fnMissingRailsCalls !== undefined ? { missingRailsCalls: fnMissingRailsCalls } : {}),
         });
@@ -918,6 +921,7 @@ export function extractFromProgram(
                 : undefined;
             const calls = extractCalls(body);
             const callSeq = extractCallSeq(body);
+            const callArgs = extractCallArgs(body);
             const internal = hasInternalJsDocTag(decl);
             // A renamed export (`export { withRoutesHelpers as with }`) is its
             // own surface entry: the declaration's tag justifies the DECLARED
@@ -951,6 +955,7 @@ export function extractFromProgram(
               ...(noRailsEquivalent !== undefined ? { noRailsEquivalent } : {}),
               ...(calls !== undefined ? { calls } : {}),
               ...(callSeq !== undefined ? { callSeq } : {}),
+              ...(callArgs !== undefined ? { callArgs } : {}),
               ...(exportedMissingRailsCalls !== undefined
                 ? { missingRailsCalls: exportedMissingRailsCalls }
                 : {}),
@@ -1826,6 +1831,7 @@ export function harvestObjectLiteralMethods(
     let optionKeys: string[] | null | undefined;
     let calls: string[] | undefined;
     let callSeq: string[] | undefined;
+    let callArgs: CallSite[] | undefined;
     let internal = hasInternalJsDocTag(prop);
     let noRailsEquivalent = noRailsEquivalentReason(prop);
     const propMissingRailsCalls = missingRailsCallTags(prop);
@@ -1835,6 +1841,7 @@ export function harvestObjectLiteralMethods(
       optionKeys = extractOptionKeys(prop.parameters, checker);
       calls = extractCalls(prop.body);
       callSeq = extractCallSeq(prop.body);
+      callArgs = extractCallArgs(prop.body);
     } else if (ts.isShorthandPropertyAssignment(prop)) {
       mname = prop.name.text;
       params = paramsOfCallableRef(prop.name, checker) ?? [];
@@ -1845,11 +1852,13 @@ export function harvestObjectLiteralMethods(
       mname = prop.name.text;
       calls = extractCalls(prop.body);
       callSeq = extractCallSeq(prop.body);
+      callArgs = extractCallArgs(prop.body);
     } else if (ts.isSetAccessorDeclaration(prop) && prop.name && ts.isIdentifier(prop.name)) {
       mname = prop.name.text;
       params = extractParameters(prop.parameters);
       calls = extractCalls(prop.body);
       callSeq = extractCallSeq(prop.body);
+      callArgs = extractCallArgs(prop.body);
     } else if (ts.isPropertyAssignment(prop) && ts.isIdentifier(prop.name)) {
       const init = prop.initializer;
       if (ts.isFunctionExpression(init) || ts.isArrowFunction(init)) {
@@ -1858,6 +1867,7 @@ export function harvestObjectLiteralMethods(
         optionKeys = extractOptionKeys(init.parameters, checker);
         calls = extractCalls(init.body);
         callSeq = extractCallSeq(init.body);
+        callArgs = extractCallArgs(init.body);
       } else {
         // `foo: bar` / `foo: NS.bar` — count if the RHS resolves to a
         // callable. Catches `readAttributeForValidation:
@@ -1887,6 +1897,7 @@ export function harvestObjectLiteralMethods(
       ...(optionKeys !== undefined ? { optionKeys } : {}),
       ...(calls !== undefined ? { calls } : {}),
       ...(callSeq !== undefined ? { callSeq } : {}),
+      ...(callArgs !== undefined ? { callArgs } : {}),
       ...(propMissingRailsCalls !== undefined ? { missingRailsCalls: propMissingRailsCalls } : {}),
     });
   }
@@ -2042,6 +2053,7 @@ export function extractClass(
       const suppressed = namespaceSelfDelegationName(member.body, checker) === memberName;
       const calls = suppressed ? undefined : extractCalls(member.body);
       const callSeq = suppressed ? undefined : extractCallSeq(member.body);
+      const callArgs = suppressed ? undefined : extractCallArgs(member.body);
       const skeleton = suppressed ? undefined : extractSkeleton(member.body);
       const delegatesTo = delegationTargetName(member.body, memberName, name, checker);
       if (delegatesTo) delegationTargets.add(delegatesTo);
@@ -2057,6 +2069,7 @@ export function extractClass(
         ...(optionKeys !== undefined ? { optionKeys } : {}),
         ...(calls !== undefined ? { calls } : {}),
         ...(callSeq !== undefined ? { callSeq } : {}),
+        ...(callArgs !== undefined ? { callArgs } : {}),
         ...(skeleton !== undefined ? { skeleton } : {}),
         ...(delegatesTo !== undefined ? { delegatesTo } : {}),
       };
@@ -2078,6 +2091,7 @@ export function extractClass(
       // calls here so calls-parity can flag a ported constructor that drops it.
       const calls = extractCalls(member.body);
       const callSeq = extractCallSeq(member.body);
+      const callArgs = extractCallArgs(member.body);
       const skeleton = extractSkeleton(member.body);
       instanceMethods.push({
         name: "constructor",
@@ -2089,9 +2103,11 @@ export function extractClass(
         ...tagged,
         ...(calls !== undefined ? { calls } : {}),
         ...(callSeq !== undefined ? { callSeq } : {}),
+        ...(callArgs !== undefined ? { callArgs } : {}),
         ...(skeleton !== undefined ? { skeleton } : {}),
       });
     } else if (ts.isGetAccessorDeclaration(member) && memberName) {
+      const callArgs = extractCallArgs(member.body);
       const method: MethodInfo = {
         name: memberName,
         visibility,
@@ -2101,6 +2117,7 @@ export function extractClass(
         isStatic,
         ...(internal ? { internal: true } : {}),
         ...tagged,
+        ...(callArgs !== undefined ? { callArgs } : {}),
       };
       if (isStatic) {
         classMethods.push(method);
@@ -2109,6 +2126,7 @@ export function extractClass(
       }
     } else if (ts.isSetAccessorDeclaration(member) && memberName) {
       const params = extractParameters(member.parameters);
+      const callArgs = extractCallArgs(member.body);
       const method: MethodInfo = {
         name: memberName,
         visibility,
@@ -2118,6 +2136,7 @@ export function extractClass(
         isStatic,
         ...(internal ? { internal: true } : {}),
         ...tagged,
+        ...(callArgs !== undefined ? { callArgs } : {}),
       };
       if (isStatic) {
         classMethods.push(method);
@@ -2692,6 +2711,174 @@ function extractSkeleton(node: ts.Node | undefined): string[] | undefined {
 function extractCalls(node: ts.Node | undefined): string[] | undefined {
   const names = collectCalls(node);
   return names === undefined ? undefined : [...names].sort();
+}
+
+/**
+ * Every SYNTACTIC call site in the body, in source order, with its argument
+ * descriptors (RFC 0025 `## Call-argument fidelity`, RFC 0095 §Design). The
+ * Ruby half is extract-ruby-api.rb#collect_call_args and the descriptor grammar
+ * is shared: `id:` / `num:` / `str:` / `bool:` / `nil` / `sym:` / `const:` /
+ * `call:` / `kwargs{k=…}`, plus the OPAQUE spellings (`?`, `array`, `hash`,
+ * `str-interp`, `binop:<op>`, `unary<desc>`, `ternary`, `*splat`) that tell the
+ * comparator to skip the site rather than guess at it, and the per-site
+ * `splat` / `blockpass` / `block` flags.
+ *
+ * Kept beside `collectCalls` rather than folded into it: that stream credits a
+ * bare property READ (`this.joinsValues`) as a call, because Ruby has no field
+ * access. A read is not a call site and carries no argument list, so recording
+ * it here would make "the TS body has no comparable site" indistinguishable
+ * from "the TS body calls it with zero arguments" — which manufactures rows.
+ */
+function extractCallArgs(node: ts.Node | undefined): CallSite[] | undefined {
+  if (!node) return undefined;
+  const sites: CallSite[] = [];
+  walkForCallArgs(node, sites);
+  return sites.length === 0 ? undefined : sites;
+}
+
+function walkForCallArgs(node: ts.Node, sites: CallSite[]): void {
+  const visit = (n: ts.Node): void => {
+    if (ts.isCallExpression(n) || ts.isNewExpression(n)) {
+      recordCallSite(n, sites, visit);
+      return;
+    }
+    ts.forEachChild(n, visit);
+  };
+  ts.forEachChild(node, visit);
+}
+
+/**
+ * Terminal, like extract-ruby-api.rb#record_call_site: the receiver is walked,
+ * then the site is emitted, then the arguments are walked — so `foo(bar(1))` is
+ * exactly two sites in source order, and no node is recorded twice.
+ */
+function recordCallSite(
+  call: ts.CallExpression | ts.NewExpression,
+  sites: CallSite[],
+  visit: (n: ts.Node) => void,
+): void {
+  const callee = call.expression;
+  if (!ts.isIdentifier(callee) && callee.kind !== ts.SyntaxKind.SuperKeyword) visit(callee);
+
+  const name = callSiteName(call);
+  if (name !== undefined) {
+    const flags: string[] = [];
+    const args = describeArgs(call.arguments, flags);
+    sites.push({ name, args, flags: [...new Set(flags)] });
+  }
+
+  call.arguments?.forEach(visit);
+}
+
+/** The same name collectCalls credits for the site, so the two streams pair up. */
+function callSiteName(call: ts.CallExpression | ts.NewExpression): string | undefined {
+  // `new Foo(...)` is Ruby's `Foo.new(...)`, which conventions.ts maps to the
+  // TS `constructor` — the spelling collectCalls already records.
+  if (ts.isNewExpression(call)) return "constructor";
+  const callee = call.expression;
+  if (ts.isIdentifier(callee)) return callee.text;
+  if (ts.isPropertyAccessExpression(callee)) return callee.name.text;
+  if (callee.kind === ts.SyntaxKind.SuperKeyword) return "super";
+  return undefined;
+}
+
+function describeArgs(args: ts.NodeArray<ts.Expression> | undefined, flags: string[]): string[] {
+  if (!args) return [];
+  const out: string[] = [];
+  for (const arg of args) {
+    const expr = unwrapArg(arg);
+    // Ruby drops a block (`each { … }`) and a block-pass (`&blk`) from the
+    // argument list and flags the site instead; the port's callback argument is
+    // the same thing, so it is flagged and dropped here too.
+    if (ts.isArrowFunction(expr) || ts.isFunctionExpression(expr)) {
+      flags.push("block");
+      continue;
+    }
+    if (ts.isSpreadElement(expr)) {
+      flags.push("splat");
+      out.push("*splat");
+      continue;
+    }
+    out.push(describeArg(expr, flags));
+  }
+  return out;
+}
+
+/** `await x`, `x as T`, `x!`, `(x)` and `x satisfies T` all describe as `x`. */
+function unwrapArg(node: ts.Expression): ts.Expression {
+  let expr = node;
+  for (;;) {
+    if (ts.isParenthesizedExpression(expr) || ts.isAwaitExpression(expr)) expr = expr.expression;
+    else if (ts.isAsExpression(expr) || ts.isSatisfiesExpression(expr)) expr = expr.expression;
+    else if (ts.isNonNullExpression(expr)) expr = expr.expression;
+    else return expr;
+  }
+}
+
+function describeArg(node: ts.Expression, flags: string[]): string {
+  const expr = unwrapArg(node);
+  if (ts.isIdentifier(expr)) {
+    if (expr.text === "undefined") return "nil";
+    return /^[A-Z]/.test(expr.text) ? `const:${expr.text}` : `id:${expr.text}`;
+  }
+  if (expr.kind === ts.SyntaxKind.ThisKeyword) return "id:this";
+  if (ts.isNumericLiteral(expr) || ts.isBigIntLiteral(expr)) return `num:${expr.text}`;
+  if (ts.isStringLiteral(expr) || ts.isNoSubstitutionTemplateLiteral(expr))
+    return `str:${expr.text}`;
+  if (ts.isTemplateExpression(expr)) return "str-interp";
+  if (expr.kind === ts.SyntaxKind.TrueKeyword) return "bool:true";
+  if (expr.kind === ts.SyntaxKind.FalseKeyword) return "bool:false";
+  if (expr.kind === ts.SyntaxKind.NullKeyword) return "nil";
+  if (ts.isNewExpression(expr)) return "call:constructor";
+  if (ts.isCallExpression(expr)) {
+    const name = callSiteName(expr);
+    return name === undefined ? "?" : `call:${name}`;
+  }
+  if (ts.isPropertyAccessExpression(expr)) {
+    // A property READ is Ruby's reader send (`x.foo`) or its ivar (`@foo`) —
+    // `const:` when the name is constant-shaped, matching `Foo::BAR`.
+    const name = expr.name.text;
+    if (/^[A-Z]/.test(name)) return `const:${name}`;
+    return expr.expression.kind === ts.SyntaxKind.ThisKeyword ? `id:${name}` : `call:${name}`;
+  }
+  if (ts.isObjectLiteralExpression(expr)) return describeObjectLiteral(expr, flags);
+  if (ts.isArrayLiteralExpression(expr)) return "array";
+  if (ts.isBinaryExpression(expr)) {
+    return `binop:${ts.tokenToString(expr.operatorToken.kind) ?? "?"}`;
+  }
+  if (ts.isPrefixUnaryExpression(expr) || ts.isPostfixUnaryExpression(expr)) {
+    return `unary${describeArg(expr.operand, flags)}`;
+  }
+  if (ts.isConditionalExpression(expr)) return "ternary";
+  if (ts.isArrowFunction(expr) || ts.isFunctionExpression(expr)) {
+    flags.push("blockpass");
+    return "?";
+  }
+  return "?";
+}
+
+/**
+ * An object literal is the port's spelling of Ruby's keyword arguments, and
+ * extract-ruby-api.rb#describe_hash reads a keyword-shaped `{ … }` as
+ * `kwargs{…}` for exactly that reason. Anything else — a computed, string or
+ * numeric key, or an empty literal — is the opaque `hash` of RFC 0025 §1.
+ */
+function describeObjectLiteral(node: ts.ObjectLiteralExpression, flags: string[]): string {
+  if (node.properties.length === 0) return "hash";
+  const pairs: string[] = [];
+  for (const prop of node.properties) {
+    if (ts.isShorthandPropertyAssignment(prop)) {
+      pairs.push(`${prop.name.text}=id:${prop.name.text}`);
+    } else if (ts.isSpreadAssignment(prop)) {
+      flags.push("splat");
+      pairs.push("**splat");
+    } else if (ts.isPropertyAssignment(prop) && ts.isIdentifier(prop.name)) {
+      pairs.push(`${prop.name.text}=${describeArg(prop.initializer, flags)}`);
+    } else {
+      return "hash";
+    }
+  }
+  return `kwargs{${pairs.join(",")}}`;
 }
 
 function collectCalls(node: ts.Node | undefined): string[] | undefined {

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -2721,7 +2721,7 @@ function extractCalls(node: ts.Node | undefined): string[] | undefined {
  * `call:` / `kwargs{k=…}`, plus the OPAQUE spellings (`?`, `array`, `hash`,
  * `str-interp`, `binop:<op>`, `unary<desc>`, `ternary`, `*splat`) that tell the
  * comparator to skip the site rather than guess at it, and the per-site
- * `splat` / `blockpass` / `block` flags.
+ * `splat` / `block` flags.
  *
  * Kept beside `collectCalls` rather than folded into it: that stream credits a
  * bare property READ (`this.joinsValues`) as a call, because Ruby has no field
@@ -2850,10 +2850,6 @@ function describeArg(node: ts.Expression, flags: string[]): string {
     return `unary${describeArg(expr.operand, flags)}`;
   }
   if (ts.isConditionalExpression(expr)) return "ternary";
-  if (ts.isArrowFunction(expr) || ts.isFunctionExpression(expr)) {
-    flags.push("blockpass");
-    return "?";
-  }
   return "?";
 }
 

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -1914,6 +1914,7 @@ export function extractFileLocalHelpers(
     if (!node.name) return out;
     if (isNotImplementedStub(node.body)) return out;
     const line = node.getSourceFile().getLineAndCharacterOfPosition(node.getStart()).line + 1;
+    const callArgs = extractCallArgs(node.body);
     out.push({
       name: node.name.text,
       visibility: "private",
@@ -1922,6 +1923,7 @@ export function extractFileLocalHelpers(
       line,
       file: relPath,
       internal: true,
+      ...(callArgs !== undefined ? { callArgs } : {}),
     });
     return out;
   }
@@ -1933,6 +1935,7 @@ export function extractFileLocalHelpers(
     if (!ts.isArrowFunction(init) && !ts.isFunctionExpression(init)) continue;
     if (isNotImplementedStub(init.body)) continue;
     const line = decl.getSourceFile().getLineAndCharacterOfPosition(decl.getStart()).line + 1;
+    const callArgs = extractCallArgs(init.body);
     out.push({
       name: decl.name.text,
       visibility: "private",
@@ -1941,6 +1944,7 @@ export function extractFileLocalHelpers(
       line,
       file: relPath,
       internal: true,
+      ...(callArgs !== undefined ? { callArgs } : {}),
     });
   }
   return out;
@@ -2744,7 +2748,9 @@ function walkForCallArgs(node: ts.Node, sites: CallSite[]): void {
     }
     ts.forEachChild(n, visit);
   };
-  ts.forEachChild(node, visit);
+  // The body ITSELF, not just its children: an expression-bodied arrow
+  // (`= (x) => where(x)`) IS the call site, and Ruby's body walk covers it.
+  visit(node);
 }
 
 /**
@@ -2770,16 +2776,25 @@ function recordCallSite(
   call.arguments?.forEach(visit);
 }
 
-/** The same name collectCalls credits for the site, so the two streams pair up. */
+/**
+ * The site name, under the SAME filter extract-ruby-api.rb#call_site_name
+ * applies (`:2385-2396`): a name starting with `_`, or with anything other than
+ * a lowercase letter, is dropped. Ruby never emits such a site, so recording one
+ * here manufactures a TS-only site that can never pair with the Ruby stream.
+ */
 function callSiteName(call: ts.CallExpression | ts.NewExpression): string | undefined {
   // `new Foo(...)` is Ruby's `Foo.new(...)`, which conventions.ts maps to the
   // TS `constructor` — the spelling collectCalls already records.
   if (ts.isNewExpression(call)) return "constructor";
   const callee = call.expression;
-  if (ts.isIdentifier(callee)) return callee.text;
-  if (ts.isPropertyAccessExpression(callee)) return callee.name.text;
   if (callee.kind === ts.SyntaxKind.SuperKeyword) return "super";
-  return undefined;
+  const name = ts.isIdentifier(callee)
+    ? callee.text
+    : ts.isPropertyAccessExpression(callee)
+      ? callee.name.text
+      : undefined;
+  if (name === undefined || name.startsWith("_") || !/^[a-z]/.test(name)) return undefined;
+  return name;
 }
 
 function describeArgs(args: ts.NodeArray<ts.Expression> | undefined, flags: string[]): string[] {

--- a/scripts/api-compare/extractor-schema.ts
+++ b/scripts/api-compare/extractor-schema.ts
@@ -74,6 +74,7 @@ export const EXTRACTOR_OUTPUT_FIELDS = [
   "depRefs",
   "calls",
   "callSeq",
+  "callArgs",
   "skeleton",
   "internal",
   "option_keys",

--- a/scripts/api-compare/extractor-skew.test.ts
+++ b/scripts/api-compare/extractor-skew.test.ts
@@ -1,7 +1,17 @@
 import { describe, expect, it } from "vitest";
+import * as fs from "fs/promises";
+import * as path from "path";
+import { fileURLToPath } from "node:url";
 
 import type { ApiManifest } from "@blazetrails/parity/types";
-import { describeExtractorSkew, detectExtractorSkew } from "./extractor-skew.js";
+import {
+  CALL_ARG_DESCRIPTOR_VOCABULARY,
+  RUBY_ONLY_CALL_ARG_DESCRIPTORS,
+  describeExtractorSkew,
+  detectExtractorSkew,
+} from "./extractor-skew.js";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
 
 function man(extractorHash: string | undefined): ApiManifest {
   return { source: "ruby", generatedAt: "now", extractorHash, packages: {} };
@@ -26,6 +36,25 @@ describe("detectExtractorSkew", () => {
 
   it("treats a missing target hash as skew", () => {
     expect(detectExtractorSkew(man("abcd1234"), man(undefined)).skewed).toBe(true);
+  });
+});
+
+describe("call-argument descriptor vocabulary", () => {
+  it("is spelled identically by both extractors", async () => {
+    const ruby = await fs.readFile(path.join(HERE, "extract-ruby-api.rb"), "utf-8");
+    const tsSource = await fs.readFile(path.join(HERE, "extract-ts-api.ts"), "utf-8");
+    const missing = CALL_ARG_DESCRIPTOR_VOCABULARY.filter(
+      (token) => !ruby.includes(token) || !tsSource.includes(token),
+    );
+    expect(missing).toEqual([]);
+  });
+
+  // The TS side of this pair — that the TS extractor emits nothing outside the
+  // vocabulary — is pinned in extract-ts-api.test.ts, where the extractor can be
+  // run over a fixture covering every argument form.
+  it("names the descriptors only the Ruby extractor produces", async () => {
+    const ruby = await fs.readFile(path.join(HERE, "extract-ruby-api.rb"), "utf-8");
+    for (const token of RUBY_ONLY_CALL_ARG_DESCRIPTORS) expect(ruby).toContain(token);
   });
 });
 

--- a/scripts/api-compare/extractor-skew.ts
+++ b/scripts/api-compare/extractor-skew.ts
@@ -16,6 +16,45 @@
  */
 import type { ApiManifest } from "@blazetrails/parity/types";
 
+/**
+ * The call-argument descriptor grammar BOTH extractors emit (RFC 0095 §Design,
+ * the §1 table): extract-ruby-api.rb#describe_arg and
+ * extract-ts-api.ts#describeArg. The comparator reads one stream against the
+ * other, so a spelling that drifts on one side alone silently stops matching —
+ * this list is the shared vocabulary the skew test pins against both sources.
+ */
+export const CALL_ARG_DESCRIPTOR_VOCABULARY = [
+  "id:",
+  "num:",
+  "str:",
+  "bool:",
+  "nil",
+  "const:",
+  "call:",
+  "constructor",
+  "kwargs{",
+  "array",
+  "hash",
+  "str-interp",
+  "binop:",
+  "unary",
+  "ternary",
+  "*splat",
+  "**splat",
+  "splat",
+  "blockpass",
+  "block",
+] as const;
+
+/**
+ * Descriptors only the RUBY side can produce. A Ruby Symbol is a JS string
+ * (CLAUDE.md "Symbols vs strings"), so the port spells `:dump` as `"dump"` and
+ * the TS extractor emits `str:` where Ruby emits `sym:`; normalization pairs
+ * them (RFC 0095 §Normalization). `zsuper` is Ruby's argument-less `super`,
+ * which has no TS spelling — `super(...)` there is always explicit.
+ */
+export const RUBY_ONLY_CALL_ARG_DESCRIPTORS = ["sym:", "zsuper"] as const;
+
 export interface ExtractorSkew {
   /** True when base and target were built by different extractor versions. */
   skewed: boolean;

--- a/scripts/api-compare/extractor-skew.ts
+++ b/scripts/api-compare/extractor-skew.ts
@@ -42,7 +42,6 @@ export const CALL_ARG_DESCRIPTOR_VOCABULARY = [
   "*splat",
   "**splat",
   "splat",
-  "blockpass",
   "block",
 ] as const;
 
@@ -51,9 +50,11 @@ export const CALL_ARG_DESCRIPTOR_VOCABULARY = [
  * (CLAUDE.md "Symbols vs strings"), so the port spells `:dump` as `"dump"` and
  * the TS extractor emits `str:` where Ruby emits `sym:`; normalization pairs
  * them (RFC 0095 §Normalization). `zsuper` is Ruby's argument-less `super`,
- * which has no TS spelling — `super(...)` there is always explicit.
+ * which has no TS spelling — `super(...)` there is always explicit. `blockpass`
+ * is Ruby's `&blk` / `&:foo`, which TS cannot distinguish from an ordinary
+ * function-valued argument; a callback the port passes is flagged `block`.
  */
-export const RUBY_ONLY_CALL_ARG_DESCRIPTORS = ["sym:", "zsuper"] as const;
+export const RUBY_ONLY_CALL_ARG_DESCRIPTORS = ["sym:", "zsuper", "blockpass"] as const;
 
 export interface ExtractorSkew {
   /** True when base and target were built by different extractor versions. */


### PR DESCRIPTION
## Why

`calls` / `callSeq` carry call **names** only, so a port can call `where`
where Rails calls `where`, pass a completely different argument list, and every
gate in the repo stays green — RFC 0084's defect-shape table lists "wrong
values / literals" as blind.

This is the TS half of RFC 0095's extractor pair;
`ruby-extractor-emit-call-arguments` (#6298) landed the Ruby half.

## What

`extractCallArgs` walks the body beside `collectCalls` and emits `callArgs` per
method / function / accessor: one entry per **syntactic** call site, in source
order, `{ name, args, flags }`, with the shared descriptor grammar of the RFC
§1 table.

- `id:` / `num:` / `str:` / `bool:` / `nil` / `const:` / `call:` / `kwargs{k=…}`.
- Opaque, emitted as-is so the comparator can *skip* the site rather than guess:
  `?`, `array`, `hash`, `str-interp`, `binop:<op>`, `unary<desc>`, `ternary`,
  `*splat`.
- Per-site flags: `splat`, `blockpass`, `block`.
- `new Foo(...)` reads as `constructor`, matching the Ruby `new` mapping
  `collectCalls` already credits; nested calls are recorded by name only.
- `await` / `as` / `!` / parenthesized wrappers unwrap to the inner expression.
- A keyword-shaped object literal is `kwargs{…}` (shorthand and nesting
  included); an empty, computed- or string-keyed one stays the opaque `hash`,
  which is what extract-ruby-api.rb#describe_hash settled on for the same
  reason.

**Property reads emit nothing.** `collectCalls` deliberately credits
`this.joinsValues` as a call because Ruby has no field access, but a read is not
a call site and carries no argument list — conflating it with a zero-argument
call would manufacture rows. A test pins that `this.foo` and `this.foo()`
differ in the stream.

`recordCallSite` is terminal — receiver, then the site, then the arguments —
mirroring `extract-ruby-api.rb#record_call_site`, so every syntactic site is
recorded exactly once. A test pins `foo(bar(1))` to two sites.

## Vocabulary skew (AC4)

`CALL_ARG_DESCRIPTOR_VOCABULARY` in `extractor-skew.ts` is checked against both
extractor sources, and a TS-side test asserts no descriptor the extractor emits
over a full-coverage fixture falls outside it — so a spelling invented on one
side alone can't silently stop matching. `sym:` and `zsuper` are declared
Ruby-only (a Ruby Symbol is a JS string, CLAUDE.md "Symbols vs strings"; TS has
no argument-less `super`).

## Cache

`callArgs` is registered in `EXTRACTOR_OUTPUT_FIELDS`, so the schema token
changes and cache entries predating the field are evicted. Per the RFC this is
the only story that touches `extractor-schema.ts`.

## Additive

`calls`, `callSeq`, `skeleton` and every other emitted field are untouched —
the new value is spread in beside them at each emit site, and a test re-pins
`calls` / `callSeq` on a body that now also carries `callArgs`. Class get/set
accessors gain `callArgs` where they previously carried no body-derived field
at all. Nothing reads `callArgs` yet, so parity % is unchanged and no artifact
moves.

Closes-story: ts-extractor-emit-call-arguments


## Review round 2 — the constructor site name (justification, no change)

The reviewer reads the two extractors correctly: Ruby emits the site as
`name: "new"` (`extract-ruby-api.rb:2385-2396`) and pre-maps only the nested
descriptor to `call:constructor` (`:2458-2467`). The conclusion inverts the
convention, though — **site names are RAW on both sides**, and `constructor`
IS this site's raw TS spelling.

- TS has no method named `new`. `new Foo()` invokes `Foo`'s **constructor**,
  which is the member name the TS AST, `api:compare` and this extractor all
  use. Emitting `new` would put a name in the TS stream that no TS body ever
  spells.
- `conventions.ts:952` maps Ruby `new` → `constructor`; that is exactly the
  §2 normalization the RFC assigns to the comparator, and the same step that
  turns Ruby `find_by` into `findBy`. By the "must match raw" reading, every
  snake_case site in the stream is a disagreement too.
- `collectCalls` already records this site as `constructor` in `calls` /
  `callSeq`, and the call-set gate pairs it with Ruby's `new` through that same
  mapping today. Spelling the argument stream differently from its sibling
  stream is what would actually manufacture rows.

Nested descriptors match the Ruby side exactly (`call:constructor`), which is
the one place Ruby pre-normalizes and where the two streams must agree
literally.

Added a test pinning `callArgs[].name` equal to `callSeq` for a body mixing a
plain call, a `new`, and a `super.` call, so the two TS streams cannot drift
apart.
