### PR TITLE
fix(scripts): RFC scaffold names parity:test, matching the 0000-template README

### DIFF
--- a/scripts/tasks/cli.test.ts
+++ b/scripts/tasks/cli.test.ts
@@ -3289,7 +3289,7 @@ describe("buildRfcContent", () => {
       "## Non-goals\n\nDeliberately descoped work, each with a one-line reason. This is where an\nRFC-level descoping decision lives canonically — don't leave it only in\nsession memory or a story comment.\n\n- **Name:** what it is, why it's out of scope.",
     );
     expect(content).toContain(
-      '## Verification\n\nHow we\'ll know the RFC worked — a concrete metric, count, or burndown target\n(e.g. "exclude list reaches zero entries", "test:compare delta ≥ +40"). State\nthe number, not a vibe.',
+      '## Verification\n\nHow we\'ll know the RFC worked — a concrete metric, count, or burndown target\n(e.g. "exclude list reaches zero entries", "parity:test delta ≥ +40"). State\nthe number, not a vibe.',
     );
     // The open-questions note must sit between the heading and the first question.
     expect(content).toContain(

--- a/scripts/tasks/cli.ts
+++ b/scripts/tasks/cli.ts
@@ -2974,7 +2974,7 @@ Ordered phases, referencing story IDs for each phase.
 ## Verification
 
 How we'll know the RFC worked — a concrete metric, count, or burndown target
-(e.g. "exclude list reaches zero entries", "test:compare delta ≥ +40"). State
+(e.g. "exclude list reaches zero entries", "parity:test delta ≥ +40"). State
 the number, not a vibe.
 
 ## Open questions


### PR DESCRIPTION
The tasks-repo RFC template README moved off the retired `test:compare` alias to `parity:test` (tasks `d9efb4af1`). `scripts/tasks/cli.ts`'s `buildRfcContent` still emitted the old name, so the byte-fidelity guard in `scripts/tasks/cli.test.ts` ("buildRfcContent body is byte-identical to every guarded template README section") failed on main, reddening Unit Tests at 930378e6.

Fix: emit `parity:test` in the generated `## Verification` section and update the matching literal in the scaffold-content assertion.

Verified: `pnpm vitest run scripts/tasks/cli.test.ts` — 336 passed (failed on baseline).

Closes-story: red-930378e6-r3