### PR TITLE
feat(date): port Date::Infinity and exclude test_memsize from the date population

### DIFF
--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -1770,3 +1770,60 @@ describe("strftime over a Temporal subject", () => {
     expect(strftime(plain, "%L %N %6N %12N")).toBe("123 123456789 123456 123456789000");
   });
 });
+
+describe("Date::Infinity", () => {
+  it("answers false for Date#infinite?", () => {
+    expect(new RubyDate(2001, 2, 3).isInfinite()).toBe(false);
+  });
+
+  it("reduces its argument to a sign", () => {
+    expect(new RubyDate.Infinity().toF()).toBe(Number.POSITIVE_INFINITY);
+    expect(new RubyDate.Infinity(-7).toF()).toBe(Number.NEGATIVE_INFINITY);
+    expect(new RubyDate.Infinity(0).toF()).toBe(0);
+  });
+
+  it("is neither zero nor finite, and is nan only at sign zero", () => {
+    const inf = new RubyDate.Infinity();
+    expect(inf.isZero()).toBe(false);
+    expect(inf.isFinite()).toBe(false);
+    expect(inf.isInfinite()).toBe(1);
+    expect(inf.negate().isInfinite()).toBe(-1);
+    expect(new RubyDate.Infinity(0).isInfinite()).toBeNull();
+    expect(inf.isNan()).toBe(false);
+    expect(new RubyDate.Infinity(0).isNan()).toBe(true);
+  });
+
+  it("answers a positive infinity for abs, and flips sign for -@ / +@", () => {
+    expect(new RubyDate.Infinity(-1).abs().toF()).toBe(Number.POSITIVE_INFINITY);
+    expect(new RubyDate.Infinity(1).negate().toF()).toBe(Number.NEGATIVE_INFINITY);
+    expect(new RubyDate.Infinity(-1).identity().toF()).toBe(Number.NEGATIVE_INFINITY);
+  });
+
+  it("compares against another Infinity, a Float infinity and a Numeric", () => {
+    const pos = new RubyDate.Infinity();
+    const neg = new RubyDate.Infinity(-1);
+    expect(pos.compareTo(neg)).toBe(1);
+    expect(neg.compareTo(pos)).toBe(-1);
+    expect(pos.compareTo(new RubyDate.Infinity())).toBe(0);
+
+    expect(pos.compareTo(Number.POSITIVE_INFINITY)).toBe(0);
+    expect(neg.compareTo(Number.POSITIVE_INFINITY)).toBe(-1);
+    expect(pos.compareTo(Number.NEGATIVE_INFINITY)).toBe(1);
+    expect(neg.compareTo(Number.NEGATIVE_INFINITY)).toBe(0);
+
+    expect(pos.compareTo(1000)).toBe(1);
+    expect(neg.compareTo(new Rational(1, 2))).toBe(-1);
+  });
+
+  it("falls back to the other value's coerce, and answers nil without one", () => {
+    const coercible = { coerce: () => [-1, 1] as [number, number] };
+    expect(new RubyDate.Infinity().compareTo(coercible)).toBe(-1);
+    expect(new RubyDate.Infinity().compareTo("foo")).toBeNull();
+  });
+
+  it("coerces a Numeric to the pair Ruby answers, and raises otherwise", () => {
+    expect(new RubyDate.Infinity().coerce(1)).toEqual([-1, 1]);
+    expect(new RubyDate.Infinity(-1).coerce(new Rational(1, 2))).toEqual([1, -1]);
+    expect(() => new RubyDate.Infinity().coerce("foo")).toThrow(TypeError);
+  });
+});

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -1782,6 +1782,10 @@ describe("Date::Infinity", () => {
     expect(new RubyDate.Infinity(0).toF()).toBe(0);
   });
 
+  it("rejects a NaN, where Ruby's `d <=> 0` stores nil", () => {
+    expect(() => new RubyDate.Infinity(Number.NaN)).toThrow(TypeError);
+  });
+
   it("is neither zero nor finite, and is nan only at sign zero", () => {
     const inf = new RubyDate.Infinity();
     expect(inf.isZero()).toBe(false);

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -4253,28 +4253,31 @@ export class DateInfinity {
   /**
    * Ruby `Date::Infinity#<=>` (ruby/date, `lib/date.rb:35-48`). The `Numeric`
    * arm answers `d` itself — the sign — rather than a spaceship of the two
-   * values, and the `coerce` fallback answers `nil` when `other` has no
-   * `coerce` (Ruby rescues the `NoMethodError`; JS raises a `TypeError` for
-   * the same call, which is what is caught here).
+   * values, and the `coerce` fallback answers `nil` for an `other` that has no
+   * `coerce`. Ruby spells that fallback `rescue NoMethodError`; the equivalent
+   * here is the presence check rather than a `catch`, because JS reports a
+   * missing method as the same `TypeError` a real `coerce` would raise from
+   * inside itself, and Ruby lets that one through.
    */
   compareTo(other: unknown): number | null {
     if (other instanceof DateInfinity) return Math.sign(this.d() - other.d());
     if (other === Number.POSITIVE_INFINITY) return Math.sign(this.d() - 1);
     if (other === Number.NEGATIVE_INFINITY) return Math.sign(this.d() + 1);
     if (typeof other === "number" || other instanceof Rational) return this.d();
-    try {
-      const [l, r] = (other as { coerce(x: unknown): [number, number] }).coerce(this);
+    const coerce = (other as { coerce?: (x: unknown) => [number, number] } | null)?.coerce;
+    if (typeof coerce === "function") {
+      const [l, r] = coerce.call(other, this);
       return Math.sign(l - r);
-    } catch (error) {
-      if (!(error instanceof TypeError)) throw error;
     }
     return null;
   }
 
   /**
    * Ruby `Date::Infinity#coerce` (ruby/date, `lib/date.rb:51-57`). The `else`
-   * arm is `super` — `Numeric#coerce`, which raises `TypeError` for a value
-   * it cannot make a `Float` of.
+   * arm is `super` — `Numeric#coerce`, whose `[Float(other), Float(self)]`
+   * cannot make a `Float` of a `Date::Infinity` and so raises `TypeError`.
+   * `Float()`'s own `ArgumentError` arm for an unparseable String is not
+   * modelled: the `:nodoc:` class is only ever coerced against a `Numeric`.
    */
   coerce(other: unknown): [number, number] {
     if (typeof other === "number" || other instanceof Rational) return [-this.d(), this.d()];

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -4184,6 +4184,115 @@ class DateError extends ArgumentError {
 }
 
 /**
+ * Ruby `Date::Infinity` (ruby/date, `lib/date.rb:17-68`), the `:nodoc:`
+ * `Numeric` subclass a `Range` of dates uses as an unbounded endpoint. It is
+ * reached as `Date.Infinity`, the name Ruby nests it under; this binding is
+ * spelled `DateInfinity` for the same reason {@link DateError} is spelled that
+ * way — `Infinity` is a global, so declaring one shadows it for the whole
+ * module (`no-shadow-restricted-names`) and {@link JULIAN} / {@link GREGORIAN}
+ * are that global. A class EXPRESSION assigned straight to `Date.Infinity`
+ * would keep the name, but declaration emit rejects it over the `protected`
+ * {@link DateInfinity#d} (TS4094).
+ *
+ * `Numeric` has no trails port, so the class stands alone — every member the
+ * gem defines is here, and none of Ruby's inherited `Numeric` surface is.
+ */
+export class DateInfinity {
+  /** Ruby `@d` (ruby/date, `lib/date.rb:19`), the sign of the constructor's argument. */
+  readonly #d: number;
+
+  /** Ruby `Date::Infinity#initialize(d=1)` (ruby/date, `lib/date.rb:19`). */
+  constructor(d: number = 1) {
+    this.#d = Math.sign(d);
+  }
+
+  /** Ruby `Date::Infinity#d` (ruby/date, `lib/date.rb:21-23`), marked `protected`. */
+  protected d(): number {
+    return this.#d;
+  }
+
+  /** Ruby `Date::Infinity#zero?` (ruby/date, `lib/date.rb:25`). */
+  isZero(): false {
+    return false;
+  }
+
+  /** Ruby `Date::Infinity#finite?` (ruby/date, `lib/date.rb:26`). */
+  isFinite(): false {
+    return false;
+  }
+
+  /**
+   * Ruby `Date::Infinity#infinite?` (ruby/date, `lib/date.rb:27`), which
+   * answers `d.nonzero?` — the sign itself, or `nil` when it is zero — not a
+   * boolean.
+   */
+  isInfinite(): number | null {
+    return this.d() !== 0 ? this.d() : null;
+  }
+
+  /** Ruby `Date::Infinity#nan?` (ruby/date, `lib/date.rb:28`), `d.zero?`. */
+  isNan(): boolean {
+    return this.d() === 0;
+  }
+
+  /** Ruby `Date::Infinity#abs` (ruby/date, `lib/date.rb:30`). */
+  abs(): DateInfinity {
+    return new (this.constructor as new (d?: number) => DateInfinity)();
+  }
+
+  /** Ruby `Date::Infinity#-@` (ruby/date, `lib/date.rb:32`). */
+  negate(): DateInfinity {
+    return new (this.constructor as new (d?: number) => DateInfinity)(-this.d());
+  }
+
+  /** Ruby `Date::Infinity#+@` (ruby/date, `lib/date.rb:33`). */
+  identity(): DateInfinity {
+    return new (this.constructor as new (d?: number) => DateInfinity)(+this.d());
+  }
+
+  /**
+   * Ruby `Date::Infinity#<=>` (ruby/date, `lib/date.rb:35-48`). The `Numeric`
+   * arm answers `d` itself — the sign — rather than a spaceship of the two
+   * values, and the `coerce` fallback answers `nil` when `other` has no
+   * `coerce` (Ruby rescues the `NoMethodError`; JS raises a `TypeError` for
+   * the same call, which is what is caught here).
+   */
+  compareTo(other: unknown): number | null {
+    if (other instanceof DateInfinity) return Math.sign(this.d() - other.d());
+    if (other === Number.POSITIVE_INFINITY) return Math.sign(this.d() - 1);
+    if (other === Number.NEGATIVE_INFINITY) return Math.sign(this.d() + 1);
+    if (typeof other === "number" || other instanceof Rational) return this.d();
+    try {
+      const [l, r] = (other as { coerce(x: unknown): [number, number] }).coerce(this);
+      return Math.sign(l - r);
+    } catch (error) {
+      if (!(error instanceof TypeError)) throw error;
+    }
+    return null;
+  }
+
+  /**
+   * Ruby `Date::Infinity#coerce` (ruby/date, `lib/date.rb:51-57`). The `else`
+   * arm is `super` — `Numeric#coerce`, which raises `TypeError` for a value
+   * it cannot make a `Float` of.
+   */
+  coerce(other: unknown): [number, number] {
+    if (typeof other === "number" || other instanceof Rational) return [-this.d(), this.d()];
+    throw new TypeError(`can't convert ${String(other)} into Float`);
+  }
+
+  /** Ruby `Date::Infinity#to_f` (ruby/date, `lib/date.rb:59-66`). */
+  toF(): number {
+    if (this.#d === 0) return 0;
+    if (this.#d > 0) {
+      return Number.POSITIVE_INFINITY;
+    } else {
+      return Number.NEGATIVE_INFINITY;
+    }
+  }
+}
+
+/**
  * @noRailsEquivalent PERMANENT — the `ruby/date` gem's `::Date`. Rails never
  * defines the class, only reopens it. The gem does have a counterpart now that
  * it is vendored, but it is C — `vendor/date/ext/date/date_core.c` — and
@@ -4715,6 +4824,18 @@ export class Date {
   /** Ruby `Date#to_s` (ruby/date, `date_core.c` `d_lite_to_s`). */
   toS(): string {
     return this.strftime("%Y-%m-%d");
+  }
+
+  /**
+   * Ruby `Date::Infinity` (ruby/date, `lib/date.rb:17-68`) at the name Ruby
+   * nests it under. The class itself is {@link DateInfinity} above — see its
+   * own comment for why the binding is spelled that way.
+   */
+  static Infinity = DateInfinity;
+
+  /** Ruby `Date#infinite?` (ruby/date, `lib/date.rb:13-15`), which returns `false`. */
+  isInfinite(): false {
+    return false;
   }
 
   /**

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -4201,9 +4201,24 @@ export class DateInfinity {
   /** Ruby `@d` (ruby/date, `lib/date.rb:19`), the sign of the constructor's argument. */
   readonly #d: number;
 
-  /** Ruby `Date::Infinity#initialize(d=1)` (ruby/date, `lib/date.rb:19`). */
+  /**
+   * Ruby `Date::Infinity#initialize(d=1)` (ruby/date, `lib/date.rb:19`), which
+   * stores `d <=> 0`.
+   *
+   * `Float::NAN <=> 0` is `nil`, so Ruby stores `nil` and leaves an object
+   * whose every later reader raises `NoMethodError` off it — `nan?` on
+   * `nil.zero?`, `infinite?` on `nil.nonzero?`, `-@`/`coerce` on `-nil`, `to_f`
+   * on `nil > 0` (`lib/date.rb:27-28`, `:32`, `:51-57`, `:59-66`). JS raises on
+   * none of those: `-null` is `-0` and `null > 0` is `false`, so deferring the
+   * failure the way Ruby does would mean inventing a raise site in each of
+   * those six bodies. The rejection is therefore taken here, at the one point
+   * Ruby's `nil` is produced, so no member below has to carry a `null` arm Ruby
+   * does not have.
+   */
   constructor(d: number = 1) {
-    this.#d = Math.sign(d);
+    const sign = Math.sign(d);
+    if (Number.isNaN(sign)) throw new TypeError("`d <=> 0` is nil for NaN");
+    this.#d = sign;
   }
 
   /** Ruby `Date::Infinity#d` (ruby/date, `lib/date.rb:21-23`), marked `protected`. */

--- a/scripts/parity/unported-files.ts
+++ b/scripts/parity/unported-files.ts
@@ -1325,6 +1325,19 @@ export const UNPORTED_FILES: UnportedFile[] = [
       "Not applicable: JS has no Marshal, and the wire format is Ruby-only.",
   },
   {
+    testFile: "test_date_new.rb",
+    className: "TestDateNew",
+    // As with the TestSH entry below, `tests` matches the extracted description
+    // — the `def test_` name with its `test_` prefix stripped. `test_memsize`
+    // extracts as `memsize`; a `test_`-prefixed entry here is a silent no-op.
+    tests: ["memsize"],
+    reason:
+      "`ObjectSpace.memsize_of` is Ruby's heap-introspection API, and the test " +
+      "asserts the byte size the C `SimpleDateData`/`ComplexDateData` structs " +
+      "allocate. JS has no analogue and the port has no C struct layout to " +
+      "measure; the rest of the file stays counted.",
+  },
+  {
     testFile: "test_switch_hitter.rb",
     className: "TestSH",
     // `tests` matches the extracted description, which is the `def test_` name


### PR DESCRIPTION
Two of a three-story bundle from RFC 0088.

## `exclude-test-memsize-from-the-date-test-population`

`vendor/date/test/date/test_date_new.rb:324-332` asserts
`ObjectSpace.memsize_of` — the byte size of the C `SimpleDateData` struct. JS has
no heap-introspection analogue and the port has no C struct to measure, so the
test can never be credited and permanently capped the `date` package below 100%.
Added as a per-test `UNPORTED_FILES` entry named `memsize` (the extractor strips
the `test_` prefix; a `test_`-prefixed entry is a silent no-op), alongside the
existing `ractor` / `marshal*` entries.

`pnpm test:compare` moves the `date` population from `0/138` to `0/137`, proving
the entry is live. `scripts/parity/unported-overmatch.test.ts` stays green.

## `port-date-infinity-from-lib-date-rb`

`vendor/date/lib/date.rb` is the gem's entire Ruby-visible surface, and none of
it was ported. Adds `Date#infinite?` (`lib/date.rb:13-15`) and all twelve members
of `Date::Infinity` (`lib/date.rb:17-68`): `initialize`, the protected `d`,
`zero?`, `finite?`, `infinite?`, `nan?`, `abs`, `-@`, `+@`, `<=>`, `coerce` and
`to_f`.

- `infinite?` answers `d.nonzero?` — the sign or `nil`, not a boolean.
- `<=>` keeps all five arms in Ruby's order: `Infinity`, `+Float::INFINITY`,
  `-Float::INFINITY`, `Numeric` (which answers `d` itself), and the `coerce`
  fallback that returns `nil` when `other` has no `coerce`.
- The binding is spelled `DateInfinity` and reached as `Date.Infinity` — the same
  shape `DateError` / `Date.Error` already uses in this file. A top-level
  `class Infinity` shadows the global that `JULIAN` / `GREGORIAN` are
  (`no-shadow-restricted-names`), and a class expression assigned straight to
  `Date.Infinity` is rejected by declaration emit over the `protected` `d`
  (TS4094).
- `compareApi` stays `false` for the `date` source.

Coverage in `date.trails.test.ts`, per the story.

## Not in this PR

`port-test-date-arith-operators` was released back to the pool. Every one of its
12 tests needs `Date#+`, `Date#-`, `Date#<=>`, `>>`/`<<` and
`DateTime#new_offset`, none of which exist in `packages/date/src` — porting
`d_lite_plus` (`date_core.c:5953-6210`, four arms across simple and complex date
data), `minus_dd`, `cmp_dd` and `d_lite_rshift`, plus the `m_nth`/`m_df`/`m_sf`
accessors and `canonicalize_jd` they need, is well past the LOC ceiling on top of
the two stories above. It needs a dedicated PR.

Closes-story: exclude-test-memsize-from-the-date-test-population
Closes-story: port-date-infinity-from-lib-date-rb