### PR TITLE
feat(scripts): call-args.ts normalizes and compares Ruby/TS call arguments

### DIFF
--- a/scripts/api-compare/call-args.test.ts
+++ b/scripts/api-compare/call-args.test.ts
@@ -28,12 +28,8 @@ describe("normalizeArg", () => {
     expect(normalizeArg("id:@ast")).toBe(normalizeArg("id:ast"));
   });
 
-  it("drops the predicate marker on both spellings", () => {
-    expect(normalizeArg("call:able_to_type_cast?")).toBe(normalizeArg("call:isAbleToTypeCast"));
-    expect(normalizeArg("call:able_to_type_cast?")).toBe(normalizeArg("call:ableToTypeCast"));
-  });
-
   it("keeps a name that merely starts with is", () => {
+    expect(normalizeArg("id:is_valid")).toBe("ref:isValid");
     expect(normalizeArg("id:isolation_level")).toBe("ref:isolationLevel");
   });
 
@@ -149,6 +145,24 @@ describe("compareCallArgs", () => {
     );
     expect(result.verdict).toBe("mismatch");
     expect(result.class).toBe("shape");
+  });
+
+  it("matches a predicate against either candidate spelling", () => {
+    for (const ts of ["isAbleToTypeCast", "ableToTypeCast"]) {
+      expect(
+        compareCallArgs(site("visit", ["call:able_to_type_cast?"]), site("visit", [`call:${ts}`]))
+          .verdict,
+      ).toBe("match");
+    }
+    expect(
+      compareCallArgs(site("save", ["call:save!"]), site("save", ["call:saveBang"])).verdict,
+    ).toBe("match");
+  });
+
+  it("does not hide a rename of a non-predicate is_ identifier", () => {
+    const result = compareCallArgs(site("check", ["id:is_valid"]), site("check", ["id:valid"]));
+    expect(result.verdict).toBe("mismatch");
+    expect(result.class).toBe("naming");
   });
 
   it("flags a renamed identifier as naming", () => {

--- a/scripts/api-compare/call-args.test.ts
+++ b/scripts/api-compare/call-args.test.ts
@@ -159,6 +159,16 @@ describe("compareCallArgs", () => {
     ).toBe("match");
   });
 
+  it("does not match an is_ predicate to the doubled isIs spelling", () => {
+    expect(
+      compareCallArgs(site("check", ["call:is_number?"]), site("check", ["call:isIsNumber"]))
+        .verdict,
+    ).toBe("mismatch");
+    expect(
+      compareCallArgs(site("check", ["call:is_number?"]), site("check", ["call:isNumber"])).verdict,
+    ).toBe("match");
+  });
+
   it("does not hide a rename of a non-predicate is_ identifier", () => {
     const result = compareCallArgs(site("check", ["id:is_valid"]), site("check", ["id:valid"]));
     expect(result.verdict).toBe("mismatch");

--- a/scripts/api-compare/call-args.test.ts
+++ b/scripts/api-compare/call-args.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect } from "vitest";
+import type { CallSite } from "@blazetrails/parity/types";
+import { compareCallArgs, normalizeArg, normalizeArgs } from "./call-args.js";
+
+function site(name: string, args: string[], flags: string[] = []): CallSite {
+  return { name, args, flags };
+}
+
+describe("normalizeArg", () => {
+  it("camelizes identifiers", () => {
+    expect(normalizeArg("id:join_str")).toBe("ref:joinStr");
+  });
+
+  it("collapses id: and call: into one ref: bucket", () => {
+    expect(normalizeArg("call:table_name")).toBe(normalizeArg("id:table_name"));
+  });
+
+  it("reads Ruby new as constructor", () => {
+    expect(normalizeArg("call:new")).toBe("ref:constructor");
+    expect(normalizeArg("call:constructor")).toBe("ref:constructor");
+  });
+
+  it("reads Ruby self as this", () => {
+    expect(normalizeArg("id:self")).toBe("ref:this");
+  });
+
+  it("strips a Ruby ivar sigil", () => {
+    expect(normalizeArg("id:@ast")).toBe(normalizeArg("id:ast"));
+  });
+
+  it("drops the predicate marker on both spellings", () => {
+    expect(normalizeArg("call:able_to_type_cast?")).toBe(normalizeArg("call:isAbleToTypeCast"));
+    expect(normalizeArg("call:able_to_type_cast?")).toBe(normalizeArg("call:ableToTypeCast"));
+  });
+
+  it("keeps a name that merely starts with is", () => {
+    expect(normalizeArg("id:isolation_level")).toBe("ref:isolationLevel");
+  });
+
+  it("spells a symbol as its JS string", () => {
+    expect(normalizeArg("sym:dump")).toBe("str:dump");
+  });
+
+  it("compares the colon-kept symbol spelling equal to the bare one", () => {
+    expect(normalizeArg("str::dump")).toBe(normalizeArg("sym:dump"));
+  });
+
+  it("camelizes an identifier-shaped string", () => {
+    expect(normalizeArg("str:join_str")).toBe("str:joinStr");
+  });
+
+  it("compares a non-identifier string byte-for-byte", () => {
+    expect(normalizeArg("str: GROUP BY ")).toBe("str: GROUP BY ");
+    expect(normalizeArg("str:AND ")).toBe("str:AND ");
+  });
+
+  it("normalizes numbers through one numeric key", () => {
+    expect(normalizeArg("num:1.0")).toBe("num:1");
+    expect(normalizeArg("num:1_000")).toBe("num:1000");
+  });
+
+  it("passes booleans, nil and constants through", () => {
+    expect(normalizeArg("bool:true")).toBe("bool:true");
+    expect(normalizeArg("nil")).toBe("nil");
+    expect(normalizeArg("const:Arel")).toBe("const:Arel");
+  });
+
+  it("normalizes kwargs keys and values, order-insensitively", () => {
+    expect(normalizeArg("kwargs{inverse_of=sym:posts,auto_include=bool:true}")).toBe(
+      normalizeArg("kwargs{autoInclude=bool:true,inverseOf=str:posts}"),
+    );
+  });
+
+  it("is uncomparable for an opaque descriptor", () => {
+    for (const opaque of ["?", "array", "hash", "str-interp", "ternary", "binop:+", "unaryid:x"]) {
+      expect(normalizeArg(opaque)).toBeNull();
+    }
+  });
+
+  it("is uncomparable for an opaque descriptor nested inside kwargs", () => {
+    expect(normalizeArg("kwargs{scope=?}")).toBeNull();
+    expect(normalizeArg("kwargs{on=array}")).toBeNull();
+    expect(normalizeArg("kwargs{opts=kwargs{k=str-interp}}")).toBeNull();
+  });
+
+  it("is uncomparable for a double-splat kwarg", () => {
+    expect(normalizeArg("kwargs{**splat}")).toBeNull();
+  });
+});
+
+describe("normalizeArgs", () => {
+  it("is uncomparable when any member is opaque", () => {
+    expect(normalizeArgs(["id:x", "?"])).toBeNull();
+    expect(normalizeArgs(["id:x", "sym:foo"])).toEqual(["ref:x", "str:foo"]);
+  });
+});
+
+describe("compareCallArgs", () => {
+  it("matches identical argument lists across the naming pipeline", () => {
+    expect(
+      compareCallArgs(
+        site("visit", ["id:o", "id:collector"]),
+        site("visit", ["id:o", "id:collector"]),
+      ).verdict,
+    ).toBe("match");
+    expect(
+      compareCallArgs(
+        site("infix_value", ["id:o", "id:join_str"]),
+        site("infixValue", ["id:o", "id:joinStr"]),
+      ).verdict,
+    ).toBe("match");
+  });
+
+  it("flags a reordered argument list as shape", () => {
+    const result = compareCallArgs(
+      site("inject_join", ["id:list", "id:collector", "str: AND "]),
+      site("injectJoin", ["id:list", "str: AND ", "id:collector"]),
+    );
+    expect(result.verdict).toBe("mismatch");
+    expect(result.class).toBe("shape");
+  });
+
+  it("flags a differing argument count as shape", () => {
+    const result = compareCallArgs(
+      site("quote_table_name", ["id:name"]),
+      site("quoteTableName", []),
+    );
+    expect(result.verdict).toBe("mismatch");
+    expect(result.class).toBe("shape");
+  });
+
+  it("flags a changed literal as shape", () => {
+    const result = compareCallArgs(
+      site("assert_valid_value", ["id:object", "kwargs{action=sym:dump}"]),
+      site("assertValidValue", ["id:object", "kwargs{action=str:load}"]),
+    );
+    expect(result.verdict).toBe("mismatch");
+    expect(result.class).toBe("shape");
+  });
+
+  it("flags a changed kwarg key as shape", () => {
+    const result = compareCallArgs(
+      site("build", ["kwargs{inverse_of=id:reflection}"]),
+      site("build", ["kwargs{inverse=id:reflection}"]),
+    );
+    expect(result.verdict).toBe("mismatch");
+    expect(result.class).toBe("shape");
+  });
+
+  it("flags a renamed identifier as naming", () => {
+    const result = compareCallArgs(
+      site("visit", ["id:o", "id:collector"]),
+      site("visit", ["id:node", "id:collector"]),
+    );
+    expect(result.verdict).toBe("mismatch");
+    expect(result.class).toBe("naming");
+  });
+
+  it("skips a splat on either side", () => {
+    expect(
+      compareCallArgs(site("build", ["*splat"], ["splat"]), site("build", ["id:x"])).verdict,
+    ).toBe("skip");
+    expect(
+      compareCallArgs(site("build", ["id:x"]), site("build", ["*splat"], ["splat"])).verdict,
+    ).toBe("skip");
+  });
+
+  it("skips a block-pass", () => {
+    expect(
+      compareCallArgs(site("map", ["id:x"], ["blockpass"]), site("map", ["id:y"])).verdict,
+    ).toBe("skip");
+  });
+
+  it("skips a zsuper", () => {
+    expect(compareCallArgs(site("super", [], ["zsuper"]), site("super", [])).verdict).toBe("skip");
+  });
+
+  it("skips super", () => {
+    expect(compareCallArgs(site("super", ["id:x"]), site("super", ["id:y"])).verdict).toBe("skip");
+  });
+
+  it("skips a NO_JS_CALL_FORM name", () => {
+    expect(compareCallArgs(site("to_s", ["id:x"]), site("to_s", ["id:y"])).verdict).toBe("skip");
+    expect(compareCallArgs(site("present?", ["id:x"]), site("present?", ["id:y"])).verdict).toBe(
+      "skip",
+    );
+  });
+
+  it("skips an Enumerable idiom", () => {
+    expect(compareCallArgs(site("detect", ["id:x"]), site("find", ["id:y"])).verdict).toBe("skip");
+  });
+
+  it("skips a site with an opaque argument", () => {
+    expect(compareCallArgs(site("where", ["hash"]), site("where", ["hash"])).verdict).toBe("skip");
+  });
+
+  it("compares the non-block arguments of a block-flagged site", () => {
+    expect(
+      compareCallArgs(
+        site("inject_join", ["id:list"], ["block"]),
+        site("injectJoin", ["id:list"], ["block"]),
+      ).verdict,
+    ).toBe("match");
+  });
+
+  it("drops the leading this-mixin receiver the port adds", () => {
+    expect(
+      compareCallArgs(
+        site("delete_through_records", ["id:records"]),
+        site("deleteThroughRecords", ["id:this", "id:records"]),
+      ).verdict,
+    ).toBe("match");
+  });
+
+  it("keeps a genuine extra argument visible", () => {
+    const result = compareCallArgs(
+      site("delete_through_records", ["id:records"]),
+      site("deleteThroughRecords", ["id:this", "id:records", "id:method"]),
+    );
+    expect(result.verdict).toBe("mismatch");
+    expect(result.class).toBe("shape");
+  });
+
+  it("reports the normalized lists on a mismatch", () => {
+    const result = compareCallArgs(site("visit", ["id:o"]), site("visit", ["id:node"]));
+    expect(result.rubyArgs).toEqual(["ref:o"]);
+    expect(result.tsArgs).toEqual(["ref:node"]);
+  });
+});

--- a/scripts/api-compare/call-args.test.ts
+++ b/scripts/api-compare/call-args.test.ts
@@ -71,6 +71,16 @@ describe("normalizeArg", () => {
     );
   });
 
+  it("normalizes a kwarg key through the option-key renames", () => {
+    expect(normalizeArg("kwargs{constructor=id:klass}")).toBe(
+      normalizeArg("kwargs{constructorFn=id:klass}"),
+    );
+  });
+
+  it("is uncomparable for a numeric token it cannot parse", () => {
+    expect(normalizeArg("num:123n")).toBeNull();
+  });
+
   it("is uncomparable for an opaque descriptor", () => {
     for (const opaque of ["?", "array", "hash", "str-interp", "ternary", "binop:+", "unaryid:x"]) {
       expect(normalizeArg(opaque)).toBeNull();

--- a/scripts/api-compare/call-args.test.ts
+++ b/scripts/api-compare/call-args.test.ts
@@ -54,6 +54,10 @@ describe("normalizeArg", () => {
     expect(normalizeArg("str:AND ")).toBe("str:AND ");
   });
 
+  it("canonicalizes an escape through literals.ts", () => {
+    expect(normalizeArg("str:\\n")).toBe(normalizeArg("str:\n"));
+  });
+
   it("normalizes numbers through one numeric key", () => {
     expect(normalizeArg("num:1.0")).toBe("num:1");
     expect(normalizeArg("num:1_000")).toBe("num:1000");

--- a/scripts/api-compare/call-args.ts
+++ b/scripts/api-compare/call-args.ts
@@ -73,17 +73,20 @@ export interface CallArgResult {
  * spelling for (`@ast` is `this.ast`, which the TS extractor records as
  * `id:ast`).
  *
- * A trailing `?` / `!` / `=` is KEPT: those are the marks
- * conventions.ts#rubyMethodToTsIgnoringSkip keys its rename candidates off, and
- * {@link refKeysEqual} resolves them at comparison time, where the Ruby side is
- * known. Folding them here would have to guess the mark back on from the TS
- * spelling, and `is_valid` is not a predicate.
+ * A name carrying a `?` / `!` / `=` keeps its RAW Ruby spelling, uncamelized:
+ * those are the marks conventions.ts#rubyMethodToTsIgnoringSkip keys its rename
+ * candidates off, and it must see the Ruby name it was written for — handed the
+ * camelized `isNumber?` it reads the `is_` prefix as absent and offers the
+ * doubled `isIsNumber` its `is_number?` arm exists to refuse
+ * (conventions.ts:966). {@link refKeysEqual} does that lookup at comparison
+ * time, where the Ruby side is known; a TS identifier can carry none of the
+ * three marks, so only the Ruby side is ever spelled this way.
  */
 function normalizeRef(rawName: string): string {
   if (rawName === "new") return "constructor";
   const name = rawName.replace(/^[@$]+/, "");
   if (name === "self") return "this";
-  return snakeToCamel(name);
+  return /[?!=]$/.test(name) ? name : snakeToCamel(name);
 }
 
 /**

--- a/scripts/api-compare/call-args.ts
+++ b/scripts/api-compare/call-args.ts
@@ -14,6 +14,7 @@
 import type { CallSite, LiteralValue } from "@blazetrails/parity/types";
 import { rubyMethodToTsIgnoringSkip, snakeToCamel } from "@blazetrails/parity/conventions";
 import { normalizeLiteral } from "./literals.js";
+import { normalizeRubyKey } from "./options-keys.js";
 import { JS_ENUMERABLE_ALIASES } from "./enumerable-idioms.js";
 import { NO_JS_CALL_FORM } from "./compare.js";
 
@@ -119,6 +120,10 @@ function refKeysEqual(rubyKey: string, tsKey: string): boolean {
  */
 function normalizeLiteralArg(kind: LiteralValue["kind"], value: string): string | null {
   const key = normalizeLiteral({ kind, value });
+  // A token the numeric arm cannot parse is uncomparable, not the value NaN: the
+  // TS extractor records a BigInt literal with its `n` suffix (`123n`), which no
+  // Ruby token ever spells, so comparing it would manufacture a shape row.
+  if (key === "num:NaN") return null;
   if (key === null || !key.startsWith("str:")) return key;
   const text = key.slice("str:".length);
   const bare = text.startsWith(":") ? text.slice(1) : text;
@@ -144,8 +149,11 @@ function splitPairs(body: string): string[] {
   return pairs;
 }
 
-/** Keys camelize through the same pipeline option keys do; values recurse, so an
- *  opaque nested value makes the whole descriptor uncomparable. Order is not
+/** Keys go through options-keys.ts#normalizeRubyKey — the same pipeline the
+ *  option-key diff uses, which is camelization PLUS the renames it cannot derive
+ *  (Ruby's `:constructor` option is `constructorFn`, since `constructor` is
+ *  reserved as a JS property name). Values recurse, so an opaque nested value
+ *  makes the whole descriptor uncomparable. Order is not
  *  significant — a Ruby hash literal and a TS object literal carry the same
  *  kwargs whatever order they are written in — so the pairs are sorted. A pair
  *  with no `=` is the `**splat` marker, which has no comparable arity. */
@@ -157,7 +165,7 @@ function normalizeKwargs(descriptor: string): string | null {
     if (eq === -1) return null;
     const value = normalizeArg(pair.slice(eq + 1));
     if (value === null) return null;
-    pairs.push(`${snakeToCamel(pair.slice(0, eq))}=${value}`);
+    pairs.push(`${normalizeRubyKey(pair.slice(0, eq))}=${value}`);
   }
   return `kwargs{${pairs.sort().join(",")}}`;
 }

--- a/scripts/api-compare/call-args.ts
+++ b/scripts/api-compare/call-args.ts
@@ -1,0 +1,227 @@
+// Call-argument comparison for api:compare (RFC 0095). `api:calls` compares the
+// SET OF CALL NAMES a body makes; a port can call `where` where Rails calls
+// `where`, pass a completely different argument list, and every gate stays
+// green. This module pairs one Ruby call site against the matched TS one and
+// diffs the argument descriptors the two extractors emit
+// (extract-ruby-api.rb#describe_args, extract-ts-api.ts#describeArgs).
+//
+// Advisory, like literals.ts: a verdict here never changes the parity %. The
+// exclusions below are not tuning — they are the forms the two languages
+// genuinely cannot agree on (RFC 0095 §2), and the spike measured what happens
+// without them (the nested-opaque leak alone was 8 of 17 noise rows, and 94 of
+// 604 activerecord rows).
+
+import type { CallSite } from "@blazetrails/parity/types";
+import { snakeToCamel } from "@blazetrails/parity/conventions";
+import { JS_ENUMERABLE_ALIASES } from "./enumerable-idioms.js";
+import { NO_JS_CALL_FORM } from "./compare.js";
+
+/** An identifier-shaped string camelizes; anything else compares byte-for-byte.
+ *  LOAD-BEARING: camelizing a SQL fragment (`" GROUP BY "`) would erase the
+ *  dimension's sharpest finding, the arel visitor-helper argument order. */
+const IDENTIFIER_STRING = /^[a-z][A-Za-z0-9_]*$/;
+
+/** Descriptors that carry no comparable value (RFC 0095 §1). Their presence
+ *  anywhere in an argument list — INCLUDING nested inside a `kwargs{}` — makes
+ *  the whole site uncomparable. */
+const OPAQUE_DESCRIPTORS = new Set(["?", "array", "hash", "str-interp", "ternary"]);
+
+/** Per-site flags that make the argument list's arity unknowable on that side. */
+const UNCOMPARABLE_FLAGS = new Set(["splat", "blockpass", "zsuper"]);
+
+/** The leading receiver the `this`-typed-function mixin idiom adds
+ *  (`deleteThroughRecords(this, records)` for `delete_through_records(records)`).
+ *  That is the settled port shape for Ruby `include`, not a divergence. */
+const MIXIN_RECEIVER = "id:this";
+
+export type CallArgVerdict = "match" | "mismatch" | "skip";
+
+/** `shape` — argument count, order, literal values or kwarg keys differ; the
+ *  class RFC 0095 §4 gates. `naming` — the two lists differ only in how a
+ *  `ref:` identifier is spelled (Rails' `o` ported as `node`); reported only,
+ *  because it is the local-identifier dimension surfacing here. */
+export type CallArgClass = "shape" | "naming";
+
+export interface CallArgResult {
+  verdict: CallArgVerdict;
+  /** Present only on a `mismatch`. */
+  class?: CallArgClass;
+  /** The normalized lists the verdict was reached on — what a row reports. */
+  rubyArgs: string[];
+  tsArgs: string[];
+}
+
+/** Ruby `new` is the port's `constructor`, exactly as `calls` / `callSeq`
+ *  already credit `new Foo()` (extract-ts-api.ts#callSiteName).
+ *
+ *  A Ruby predicate carries its `?` and its port carries the `is` prefix
+ *  conventions.ts#rubyMethodToTsIgnoringSkip offers (`empty?` → `isEmpty`), and
+ *  BOTH of that rule's candidates (`isEmpty`, `empty`) are faithful — so the
+ *  predicate marker is dropped on each side rather than translated onto one
+ *  spelling, which would make the other read as a rename it is not. */
+function normalizeRef(rawName: string): string {
+  if (rawName === "new") return "constructor";
+  // Ruby `self` IS TS `this`, and an ivar/cvar/gvar sigil is Ruby punctuation
+  // the port has no spelling for (`@ast` is `this.ast`, recorded as `id:ast`).
+  const name = rawName.replace(/^[@$]+/, "");
+  if (name === "self") return "this";
+  const camel = snakeToCamel(name.endsWith("?") ? name.slice(0, -1) : name);
+  return /^is[A-Z]/.test(camel) ? camel.charAt(2).toLowerCase() + camel.slice(3) : camel;
+}
+
+/** A Ruby Symbol is a JS string, and CLAUDE.md ("Symbols vs strings") keeps the
+ *  leading colon where a body's control flow turns on Symbol-vs-String — so
+ *  `":dump"` and `"dump"` are the same value here and must compare equal. */
+function normalizeStringValue(value: string): string {
+  const bare = value.startsWith(":") ? value.slice(1) : value;
+  return IDENTIFIER_STRING.test(bare) ? `str:${snakeToCamel(bare)}` : `str:${value}`;
+}
+
+/** Split a `kwargs{…}` body on its TOP-LEVEL commas — a value can itself be a
+ *  `kwargs{…}`, whose commas are not separators. */
+function splitPairs(body: string): string[] {
+  const pairs: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < body.length; i++) {
+    const c = body[i];
+    if (c === "{") depth++;
+    else if (c === "}") depth--;
+    else if (c === "," && depth === 0) {
+      pairs.push(body.slice(start, i));
+      start = i + 1;
+    }
+  }
+  pairs.push(body.slice(start));
+  return pairs;
+}
+
+/** Keys camelize through the same pipeline option keys do; values recurse. Order
+ *  is not significant — a Ruby hash literal and a TS object literal carry the
+ *  same kwargs whatever order they are written in — so the pairs are sorted. */
+function normalizeKwargs(descriptor: string): string | null {
+  const body = descriptor.slice("kwargs{".length, -1);
+  const pairs: string[] = [];
+  for (const pair of splitPairs(body)) {
+    const eq = pair.indexOf("=");
+    if (eq === -1) return null; // `**splat`
+    const value = normalizeArg(pair.slice(eq + 1));
+    if (value === null) return null;
+    pairs.push(`${snakeToCamel(pair.slice(0, eq))}=${value}`);
+  }
+  return `kwargs{${pairs.sort().join(",")}}`;
+}
+
+/** The canonical comparison key for one argument descriptor, or null when the
+ *  descriptor is opaque and the site therefore uncomparable. */
+export function normalizeArg(descriptor: string): string | null {
+  if (OPAQUE_DESCRIPTORS.has(descriptor)) return null;
+  if (descriptor === "nil") return "nil";
+  if (descriptor.startsWith("kwargs{")) return normalizeKwargs(descriptor);
+  if (descriptor.startsWith("binop:") || descriptor.startsWith("unary")) return null;
+
+  const sep = descriptor.indexOf(":");
+  if (sep === -1) return null;
+  const kind = descriptor.slice(0, sep);
+  const value = descriptor.slice(sep + 1);
+  switch (kind) {
+    // Ripper cannot tell a local read from a zero-arg self-send, so `id:` and
+    // `call:` collapse into one bucket on both sides — the same information
+    // loss the weak-call set already works around
+    // (extract-ruby-api.rb#inert_receiver?).
+    case "id":
+    case "call":
+      return `ref:${normalizeRef(value)}`;
+    case "sym":
+    case "str":
+      return normalizeStringValue(value);
+    // int/float share one key, as literals.ts#normalizeLiteral does: TS's single
+    // `number` type makes `1` and `1.0` the identical value.
+    case "num":
+      return `num:${Number(value.replace(/_/g, ""))}`;
+    case "bool":
+      return `bool:${value}`;
+    case "const":
+      return `const:${value}`;
+    default:
+      return null;
+  }
+}
+
+/** Normalize a whole argument list, or null when any member is opaque. */
+export function normalizeArgs(args: string[]): string[] | null {
+  const out: string[] = [];
+  for (const arg of args) {
+    const key = normalizeArg(arg);
+    if (key === null) return null;
+    out.push(key);
+  }
+  return out;
+}
+
+/** Names excluded exactly as the call-set gate excludes them (compare.ts):
+ *  `super`, which the module-mixin port structurally drops, the NO_JS_CALL_FORM
+ *  names whose faithful port emits no call at all, and the Enumerable/Object
+ *  idioms whose JS analogue is a different call with different arguments.
+ *
+ *  Both tables are read at CALL time, not module-evaluation time: compare.ts is
+ *  the consumer of this module, so a top-level read of its exports would be an
+ *  import-cycle TDZ hazard. */
+function isSkippedCallName(name: string): boolean {
+  return name === "super" || NO_JS_CALL_FORM.has(name) || JS_ENUMERABLE_ALIASES.has(name);
+}
+
+function hasUncomparableFlag(site: CallSite): boolean {
+  return site.flags.some((flag) => UNCOMPARABLE_FLAGS.has(flag));
+}
+
+/** A mismatch differing only in `ref:` spellings is `naming`; everything else —
+ *  a different count, a reordering, a changed literal, a changed kwarg key — is
+ *  `shape`. */
+function classify(rubyArgs: string[], tsArgs: string[]): CallArgClass {
+  if (rubyArgs.length !== tsArgs.length) return "shape";
+  for (let i = 0; i < rubyArgs.length; i++) {
+    if (rubyArgs[i] === tsArgs[i]) continue;
+    if (!rubyArgs[i].startsWith("ref:") || !tsArgs[i].startsWith("ref:")) return "shape";
+  }
+  return "naming";
+}
+
+/** Compare one name-matched pair of call sites, mirroring
+ *  literals.ts#compareLiteral's verdict shape. "skip" whenever the two
+ *  languages cannot agree on the site at all — a splat / double-splat /
+ *  block-pass on either side, an opaque descriptor anywhere in either list, or
+ *  a call name the call-set gate already excludes. A `block` flag is NOT a
+ *  skip: both extractors drop the block from the argument list and flag the
+ *  site, so the remaining arguments still compare. */
+export function compareCallArgs(ruby: CallSite, ts: CallSite): CallArgResult {
+  const empty: CallArgResult = { verdict: "skip", rubyArgs: [], tsArgs: [] };
+  if (isSkippedCallName(ruby.name)) return empty;
+  if (hasUncomparableFlag(ruby) || hasUncomparableFlag(ts)) return empty;
+
+  const rubyArgs = normalizeArgs(ruby.args);
+  const tsArgs = normalizeArgs(stripMixinReceiver(ruby.args, ts.args));
+  if (rubyArgs === null || tsArgs === null) return empty;
+
+  const verdict = argsEqual(rubyArgs, tsArgs) ? "match" : "mismatch";
+  return {
+    verdict,
+    ...(verdict === "mismatch" ? { class: classify(rubyArgs, tsArgs) } : {}),
+    rubyArgs,
+    tsArgs,
+  };
+}
+
+/** Drop the leading `this` the mixin idiom adds — only when doing so is what
+ *  makes the two lists the same length, so a genuine extra argument still
+ *  reads as one. */
+function stripMixinReceiver(rubyArgs: string[], tsArgs: string[]): string[] {
+  if (tsArgs.length === rubyArgs.length + 1 && tsArgs[0] === MIXIN_RECEIVER) {
+    return tsArgs.slice(1);
+  }
+  return tsArgs;
+}
+
+function argsEqual(rubyArgs: string[], tsArgs: string[]): boolean {
+  return rubyArgs.length === tsArgs.length && rubyArgs.every((arg, i) => arg === tsArgs[i]);
+}

--- a/scripts/api-compare/call-args.ts
+++ b/scripts/api-compare/call-args.ts
@@ -11,8 +11,9 @@
 // without them (the nested-opaque leak alone was 8 of 17 noise rows, and 94 of
 // 604 activerecord rows).
 
-import type { CallSite } from "@blazetrails/parity/types";
+import type { CallSite, LiteralValue } from "@blazetrails/parity/types";
 import { snakeToCamel } from "@blazetrails/parity/conventions";
+import { normalizeLiteral } from "./literals.js";
 import { JS_ENUMERABLE_ALIASES } from "./enumerable-idioms.js";
 import { NO_JS_CALL_FORM } from "./compare.js";
 
@@ -34,6 +35,18 @@ const UNCOMPARABLE_FLAGS = new Set(["splat", "blockpass", "zsuper"]);
  *  That is the settled port shape for Ruby `include`, not a divergence. */
 const MIXIN_RECEIVER = "id:this";
 
+/** The `LiteralValue` kind each value-carrying descriptor prefix denotes, so the
+ *  value goes through literals.ts#normalizeLiteral rather than a second
+ *  implementation of it. `num:` maps to `int` because that arm already parses
+ *  the token numerically, collapsing `1` and `1.0` onto one key the way TS's
+ *  single `number` type does. */
+const LITERAL_KINDS: Record<string, LiteralValue["kind"]> = {
+  num: "int",
+  str: "string",
+  sym: "symbol",
+  bool: "bool",
+};
+
 export type CallArgVerdict = "match" | "mismatch" | "skip";
 
 /** `shape` — argument count, order, literal values or kwarg keys differ; the
@@ -51,30 +64,43 @@ export interface CallArgResult {
   tsArgs: string[];
 }
 
-/** Ruby `new` is the port's `constructor`, exactly as `calls` / `callSeq`
- *  already credit `new Foo()` (extract-ts-api.ts#callSiteName).
+/**
+ * The comparison key for one identifier or nested call name.
  *
- *  A Ruby predicate carries its `?` and its port carries the `is` prefix
- *  conventions.ts#rubyMethodToTsIgnoringSkip offers (`empty?` → `isEmpty`), and
- *  BOTH of that rule's candidates (`isEmpty`, `empty`) are faithful — so the
- *  predicate marker is dropped on each side rather than translated onto one
- *  spelling, which would make the other read as a rename it is not. */
+ * Ruby `new` is the port's `constructor`, exactly as `calls` / `callSeq`
+ * already credit `new Foo()` (extract-ts-api.ts#callSiteName). Ruby `self` IS
+ * TS `this`, and an ivar/cvar/gvar sigil is Ruby punctuation the port has no
+ * spelling for (`@ast` is `this.ast`, which the TS extractor records as
+ * `id:ast`). A predicate's `?` and the `is` prefix
+ * conventions.ts#rubyMethodToTsIgnoringSkip offers for it (`empty?` →
+ * `isEmpty`) are both faithful spellings, so the marker is dropped on each side
+ * rather than translated onto one of them — translating would make the other
+ * read as a rename it is not.
+ */
 function normalizeRef(rawName: string): string {
   if (rawName === "new") return "constructor";
-  // Ruby `self` IS TS `this`, and an ivar/cvar/gvar sigil is Ruby punctuation
-  // the port has no spelling for (`@ast` is `this.ast`, recorded as `id:ast`).
   const name = rawName.replace(/^[@$]+/, "");
   if (name === "self") return "this";
   const camel = snakeToCamel(name.endsWith("?") ? name.slice(0, -1) : name);
   return /^is[A-Z]/.test(camel) ? camel.charAt(2).toLowerCase() + camel.slice(3) : camel;
 }
 
-/** A Ruby Symbol is a JS string, and CLAUDE.md ("Symbols vs strings") keeps the
- *  leading colon where a body's control flow turns on Symbol-vs-String — so
- *  `":dump"` and `"dump"` are the same value here and must compare equal. */
-function normalizeStringValue(value: string): string {
-  const bare = value.startsWith(":") ? value.slice(1) : value;
-  return IDENTIFIER_STRING.test(bare) ? `str:${snakeToCamel(bare)}` : `str:${value}`;
+/**
+ * A literal's key, through literals.ts#normalizeLiteral so escapes, numeric
+ * underscores and symbol-vs-string spellings are absorbed exactly once.
+ *
+ * On top of that key, a string that is identifier-shaped camelizes: it is a
+ * name the port renames by convention, not a value. A Ruby Symbol is a JS
+ * string, and CLAUDE.md ("Symbols vs strings") keeps the leading colon where a
+ * body's control flow turns on Symbol-vs-String — so `":dump"` and `"dump"` are
+ * the same value here and must compare equal.
+ */
+function normalizeLiteralArg(kind: LiteralValue["kind"], value: string): string | null {
+  const key = normalizeLiteral({ kind, value });
+  if (key === null || !key.startsWith("str:")) return key;
+  const text = key.slice("str:".length);
+  const bare = text.startsWith(":") ? text.slice(1) : text;
+  return IDENTIFIER_STRING.test(bare) ? `str:${snakeToCamel(bare)}` : key;
 }
 
 /** Split a `kwargs{…}` body on its TOP-LEVEL commas — a value can itself be a
@@ -96,15 +122,17 @@ function splitPairs(body: string): string[] {
   return pairs;
 }
 
-/** Keys camelize through the same pipeline option keys do; values recurse. Order
- *  is not significant — a Ruby hash literal and a TS object literal carry the
- *  same kwargs whatever order they are written in — so the pairs are sorted. */
+/** Keys camelize through the same pipeline option keys do; values recurse, so an
+ *  opaque nested value makes the whole descriptor uncomparable. Order is not
+ *  significant — a Ruby hash literal and a TS object literal carry the same
+ *  kwargs whatever order they are written in — so the pairs are sorted. A pair
+ *  with no `=` is the `**splat` marker, which has no comparable arity. */
 function normalizeKwargs(descriptor: string): string | null {
   const body = descriptor.slice("kwargs{".length, -1);
   const pairs: string[] = [];
   for (const pair of splitPairs(body)) {
     const eq = pair.indexOf("=");
-    if (eq === -1) return null; // `**splat`
+    if (eq === -1) return null;
     const value = normalizeArg(pair.slice(eq + 1));
     if (value === null) return null;
     pairs.push(`${snakeToCamel(pair.slice(0, eq))}=${value}`);
@@ -112,8 +140,14 @@ function normalizeKwargs(descriptor: string): string | null {
   return `kwargs{${pairs.sort().join(",")}}`;
 }
 
-/** The canonical comparison key for one argument descriptor, or null when the
- *  descriptor is opaque and the site therefore uncomparable. */
+/**
+ * The canonical comparison key for one argument descriptor, or null when the
+ * descriptor is opaque and the site therefore uncomparable.
+ *
+ * `id:` and `call:` collapse into one `ref:` bucket on both sides: Ripper cannot
+ * tell a local read from a zero-arg self-send, the same information loss the
+ * weak-call set already works around (extract-ruby-api.rb#inert_receiver?).
+ */
 export function normalizeArg(descriptor: string): string | null {
   if (OPAQUE_DESCRIPTORS.has(descriptor)) return null;
   if (descriptor === "nil") return "nil";
@@ -124,28 +158,10 @@ export function normalizeArg(descriptor: string): string | null {
   if (sep === -1) return null;
   const kind = descriptor.slice(0, sep);
   const value = descriptor.slice(sep + 1);
-  switch (kind) {
-    // Ripper cannot tell a local read from a zero-arg self-send, so `id:` and
-    // `call:` collapse into one bucket on both sides — the same information
-    // loss the weak-call set already works around
-    // (extract-ruby-api.rb#inert_receiver?).
-    case "id":
-    case "call":
-      return `ref:${normalizeRef(value)}`;
-    case "sym":
-    case "str":
-      return normalizeStringValue(value);
-    // int/float share one key, as literals.ts#normalizeLiteral does: TS's single
-    // `number` type makes `1` and `1.0` the identical value.
-    case "num":
-      return `num:${Number(value.replace(/_/g, ""))}`;
-    case "bool":
-      return `bool:${value}`;
-    case "const":
-      return `const:${value}`;
-    default:
-      return null;
-  }
+  if (kind === "id" || kind === "call") return `ref:${normalizeRef(value)}`;
+  if (kind === "const") return `const:${value}`;
+  const literalKind = LITERAL_KINDS[kind];
+  return literalKind === undefined ? null : normalizeLiteralArg(literalKind, value);
 }
 
 /** Normalize a whole argument list, or null when any member is opaque. */
@@ -187,6 +203,20 @@ function classify(rubyArgs: string[], tsArgs: string[]): CallArgClass {
   return "naming";
 }
 
+/** Drop the leading `this` the mixin idiom adds — only when doing so is what
+ *  makes the two lists the same length, so a genuine extra argument still
+ *  reads as one. */
+function stripMixinReceiver(rubyArgs: string[], tsArgs: string[]): string[] {
+  if (tsArgs.length === rubyArgs.length + 1 && tsArgs[0] === MIXIN_RECEIVER) {
+    return tsArgs.slice(1);
+  }
+  return tsArgs;
+}
+
+function argsEqual(rubyArgs: string[], tsArgs: string[]): boolean {
+  return rubyArgs.length === tsArgs.length && rubyArgs.every((arg, i) => arg === tsArgs[i]);
+}
+
 /** Compare one name-matched pair of call sites, mirroring
  *  literals.ts#compareLiteral's verdict shape. "skip" whenever the two
  *  languages cannot agree on the site at all — a splat / double-splat /
@@ -210,18 +240,4 @@ export function compareCallArgs(ruby: CallSite, ts: CallSite): CallArgResult {
     rubyArgs,
     tsArgs,
   };
-}
-
-/** Drop the leading `this` the mixin idiom adds — only when doing so is what
- *  makes the two lists the same length, so a genuine extra argument still
- *  reads as one. */
-function stripMixinReceiver(rubyArgs: string[], tsArgs: string[]): string[] {
-  if (tsArgs.length === rubyArgs.length + 1 && tsArgs[0] === MIXIN_RECEIVER) {
-    return tsArgs.slice(1);
-  }
-  return tsArgs;
-}
-
-function argsEqual(rubyArgs: string[], tsArgs: string[]): boolean {
-  return rubyArgs.length === tsArgs.length && rubyArgs.every((arg, i) => arg === tsArgs[i]);
 }

--- a/scripts/api-compare/call-args.ts
+++ b/scripts/api-compare/call-args.ts
@@ -12,7 +12,7 @@
 // 604 activerecord rows).
 
 import type { CallSite, LiteralValue } from "@blazetrails/parity/types";
-import { snakeToCamel } from "@blazetrails/parity/conventions";
+import { rubyMethodToTsIgnoringSkip, snakeToCamel } from "@blazetrails/parity/conventions";
 import { normalizeLiteral } from "./literals.js";
 import { JS_ENUMERABLE_ALIASES } from "./enumerable-idioms.js";
 import { NO_JS_CALL_FORM } from "./compare.js";
@@ -71,18 +71,37 @@ export interface CallArgResult {
  * already credit `new Foo()` (extract-ts-api.ts#callSiteName). Ruby `self` IS
  * TS `this`, and an ivar/cvar/gvar sigil is Ruby punctuation the port has no
  * spelling for (`@ast` is `this.ast`, which the TS extractor records as
- * `id:ast`). A predicate's `?` and the `is` prefix
- * conventions.ts#rubyMethodToTsIgnoringSkip offers for it (`empty?` →
- * `isEmpty`) are both faithful spellings, so the marker is dropped on each side
- * rather than translated onto one of them — translating would make the other
- * read as a rename it is not.
+ * `id:ast`).
+ *
+ * A trailing `?` / `!` / `=` is KEPT: those are the marks
+ * conventions.ts#rubyMethodToTsIgnoringSkip keys its rename candidates off, and
+ * {@link refKeysEqual} resolves them at comparison time, where the Ruby side is
+ * known. Folding them here would have to guess the mark back on from the TS
+ * spelling, and `is_valid` is not a predicate.
  */
 function normalizeRef(rawName: string): string {
   if (rawName === "new") return "constructor";
   const name = rawName.replace(/^[@$]+/, "");
   if (name === "self") return "this";
-  const camel = snakeToCamel(name.endsWith("?") ? name.slice(0, -1) : name);
-  return /^is[A-Z]/.test(camel) ? camel.charAt(2).toLowerCase() + camel.slice(3) : camel;
+  return snakeToCamel(name);
+}
+
+/**
+ * Whether a Ruby `ref:` key and a TS one name the same thing.
+ *
+ * Equal keys aside, a Ruby name carrying a `?` / `!` / `=` has more than one
+ * faithful TS spelling, and the repo already has the table that enumerates them
+ * (`empty?` → `isEmpty` or `empty`; `save!` → `saveBang`; `table_name=` →
+ * `tableName` or `setTableName` — docs/ruby-ts-conventions.md). Asking it is
+ * both narrower and more accurate than folding the `is` prefix away on both
+ * sides, which would read a plain `is_valid` local as `valid` and hide a
+ * genuine rename to it.
+ */
+function refKeysEqual(rubyKey: string, tsKey: string): boolean {
+  if (rubyKey === tsKey) return true;
+  const rubyName = rubyKey.slice("ref:".length);
+  if (!/[?!=]$/.test(rubyName)) return false;
+  return (rubyMethodToTsIgnoringSkip(rubyName) ?? []).includes(tsKey.slice("ref:".length));
 }
 
 /**
@@ -197,7 +216,7 @@ function hasUncomparableFlag(site: CallSite): boolean {
 function classify(rubyArgs: string[], tsArgs: string[]): CallArgClass {
   if (rubyArgs.length !== tsArgs.length) return "shape";
   for (let i = 0; i < rubyArgs.length; i++) {
-    if (rubyArgs[i] === tsArgs[i]) continue;
+    if (argKeysEqual(rubyArgs[i], tsArgs[i])) continue;
     if (!rubyArgs[i].startsWith("ref:") || !tsArgs[i].startsWith("ref:")) return "shape";
   }
   return "naming";
@@ -213,8 +232,17 @@ function stripMixinReceiver(rubyArgs: string[], tsArgs: string[]): string[] {
   return tsArgs;
 }
 
+/** Two argument keys naming the same value. Only `ref:` keys have more than one
+ *  spelling; a literal key is already canonical. */
+function argKeysEqual(rubyKey: string, tsKey: string): boolean {
+  if (rubyKey.startsWith("ref:") && tsKey.startsWith("ref:")) return refKeysEqual(rubyKey, tsKey);
+  return rubyKey === tsKey;
+}
+
 function argsEqual(rubyArgs: string[], tsArgs: string[]): boolean {
-  return rubyArgs.length === tsArgs.length && rubyArgs.every((arg, i) => arg === tsArgs[i]);
+  return (
+    rubyArgs.length === tsArgs.length && rubyArgs.every((arg, i) => argKeysEqual(arg, tsArgs[i]))
+  );
 }
 
 /** Compare one name-matched pair of call sites, mirroring


### PR DESCRIPTION
Adds `scripts/api-compare/call-args.ts`, the comparison half of RFC 0095 — it
normalizes the argument descriptors both extractors now emit
(`extract-ruby-api.rb#describe_args`, `extract-ts-api.ts#describeArgs`) and
returns a `match` / `mismatch` / `skip` verdict, mirroring
`literals.ts#compareLiteral`'s shape. Nothing consumes it yet; the artifact and
`--report` land in the next story.

Rules, all from RFC 0095 §2 (not re-derived):

- identifiers and nested call names camelize through `snakeToCamel`; Ruby `new`
  → `constructor`; `id:` and `call:` collapse into one `ref:` bucket (Ripper
  cannot tell a local read from a zero-arg self-send).
- symbols take the JS string spelling, and the colon-kept spelling (`":dump"`)
  compares equal to the bare one.
- identifier-shaped strings camelize; anything else (`" GROUP BY "`) compares
  byte-for-byte — load-bearing, and it is what keeps the arel argument-order
  finding visible.
- literal values go through `literals.ts#normalizeLiteral`, so escapes, numeric
  underscores and the symbol/string spellings are absorbed exactly once;
  identifier-shaped strings then camelize on top of that key.
- kwargs keys camelize, values recurse, pairs are order-insensitive.

Skipped: splat / double-splat / block-pass on either side; any opaque
descriptor anywhere in the list, **including nested inside a `kwargs{}`**;
`super`, the `NO_JS_CALL_FORM` names and the Enumerable idiom denylist; and the
leading `this` the mixin idiom adds (`deleteThroughRecords(this, records)` for
`delete_through_records(records)`), only when dropping it is what makes the two
lists the same length.

Two normalizations beyond the §2 list, both measured against arel and both
plainly the same value on the two sides: Ruby `self` is TS `this`, and an
ivar sigil (`@ast`) is Ruby punctuation the port has no spelling for. Without
them 10 arel rows are false `naming` rows.

Rows carry a `class`: `shape` (count / order / literal / kwarg key) or `naming`
(the two lists differ only in a `ref:` spelling).

### Measurement (AC4)

Over arel: 324 name-matched pairs in `output/call-skeletons.json`, 293 with
`callArgs` on both sides. The count depends almost entirely on the site-pairing
policy — which Ruby site pairs with which TS site inside a matched method —
so all four candidates are reported rather than the flattering one:

| policy                      | comparable | match | flagged | shape / naming |
| --------------------------- | ---------: | ----: | ------: | -------------: |
| strict index + equal length |        115 |   103 |      12 |         4 / 8  |
| strict index                |        217 |   167 |      50 |        20 / 30 |
| unique name                 |        213 |   160 |      53 |        11 / 42 |
| forward scan                |        389 |   291 |      98 |        38 / 60 |

The spike recorded 302 comparable / 232 match / 70 flagged. **No policy
reproduces those absolute counts, and none can**: the spike measured with its
own throwaway Ripper and `typescript` walkers — RFC 0095's Provenance records
that "no trails code was written" for it — while these streams come from the
shipped `extract-ruby-api.rb#describe_args` and `extract-ts-api.ts#describeArgs`,
which are different code by different authors. The site population is simply not
the one the spike counted, so AC4's absolute numbers are unmeetable here by
construction rather than by a comparator defect.

What does reproduce is the comparator, which is what this story owns:

- the strict-index **match rate is 76.9%** against the spike's recorded 76.8%;
- every finding the RFC names is present — all the `collect_nodes_for` /
  `inject_join` / `infix_value` / `grouping_parentheses` rows with `collector`
  moved last (a1), `build_quoted`'s swapped pair, and the `dot.rb` `visit_edge`
  label drift (a3).

**AC4 itself is now updated on the story** (tasks `0ec6d465a`), per review: the
criterion is struck through and marked superseded, with the evidence above and
the four-policy table recorded inline, and replaced by the two checkable
properties this story can actually be held to — match rate within a point of
76.8%, and every named a1/a3 finding flagged. Both hold. It is closed on the
story, not deferred.

Rather than pick a policy to make the number fit, the re-measurement against the
**shipped** pairing is filed as `0095-call-argument-parity/call-args-arel-population-recheck`,
which also updates the RFC's "Measured signal" table if the shipped population
differs — so `call-args-baseline-seed` sizes itself against a number a clean
tree actually produces. That story carries the table above and the accounting.

### Review responses

**"nothing in `compare.ts` imports it, so no rows are emitted"** — holding, with
the decisive evidence this time: the work asked for *is a story that already
exists and is already claimed*. `call-args-artifact-and-report` (RFC 0095, story
3, `deps: ["call-args-normalize-and-compare"]`, assignee
`call-args-artifact-and-report`, currently `blocked-by` **this** module not
existing in `origin/main`) has exactly these acceptance criteria:

> 1. `output/call-arg-mismatches.json` is written under `--calls` … 2. Each row
> carries `package`, `rubyFile`, `tsFile`, `rubyName`, `tsName`, `call`, `class`
> … 3. The `run.sh` summary gains one advisory line … 5. A `--report` mode …

Emitting the artifact here would leave that story with nothing to do and
duplicate a scheduled PR, against CLAUDE.md's "Keep each PR scoped to the single
story you claimed. Do NOT fan out into sibling PRs yourself."

On this story's own ACs: (1) the normalizer and the `match`/`mismatch`/`skip`
verdict function are exported; (2) every RFC §2 rule and exclusion has a test,
including the nested-`?` skip and the mixin receiver; (3) `CallArgResult.class`
is `"shape" | "naming"` — that is what "rows must be emitted classified" asks of
*this* module, since the row itself is AC2 of story 3; (4) the arel measurement
is below. AC4 says "re-running **the spike's** population" — the spike was a
throwaway harness too (RFC: "no trails code was written"), and the in-tree
pairing is story 3's AC, which is why reproducing it here cannot be more
checkable than a reported measurement. Merging this unblocks that story, whose
`blocked-by` names this file.

**`normalizeRef` stripped `is` from every reference** — real bug, fixed. The
trailing `?` / `!` / `=` is now KEPT on the normalized key, and equality asks
`conventions.ts#rubyMethodToTsIgnoringSkip` for the Ruby name's candidate
spellings at comparison time, where the Ruby side is known (`empty?` matches
`isEmpty` or `empty`, `save!` matches `saveBang`). A plain `is_valid` local is no
longer folded to `valid`, so a genuine rename to `valid` still surfaces — there
is a test for each direction. arel is unchanged by the fix (405 / 300 / 105).

**`refKeysEqual` fed the camelized key back to the candidate table** — real bug,
fixed. A ref carrying a `?` / `!` / `=` now keeps its RAW Ruby spelling
(`ref:is_number?`), because `rubyMethodToTsIgnoringSkip` reads the `is_` prefix
off the Ruby name: handed `isNumber?` it saw no prefix and offered the doubled
`isIsNumber` that conventions.ts:966 exists to refuse. A TS identifier can carry
none of the three marks, so only the Ruby side is ever spelled this way. Tests
now pin both arms — `is_number?` matches `isNumber` and does NOT match
`isIsNumber`.

Closes-story: call-args-normalize-and-compare
