### PR TITLE
feat(date): converge Date::Infinity nil-@d arms, port Date#eql?/#hash and test_date_conv; LogSubscriber.logger app fallback

### DIFF
--- a/packages/activesupport/src/log-subscriber.trails.test.ts
+++ b/packages/activesupport/src/log-subscriber.trails.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { LogSubscriber } from "./log-subscriber.js";
+import { _setTrailsLogger } from "./trails-logger-slot.js";
+import type { Logger } from "./logger.js";
+
+/**
+ * `LogSubscriber.logger`'s application-logger fallback
+ * (`activesupport/lib/active_support/log_subscriber.rb:93-97`). Rails has no
+ * test for it — `defined?(Rails)` is false in its own suite — so the coverage
+ * is trails-only and lives here rather than in the ported `log-subscriber.test.ts`.
+ */
+describe("LogSubscriber.logger fallback", () => {
+  afterEach(() => {
+    LogSubscriber.logger = null;
+    _setTrailsLogger(null);
+  });
+
+  it("falls back to Trails.logger when nothing has been assigned", () => {
+    const appLogger = { warn() {}, debug() {} };
+    _setTrailsLogger(appLogger);
+    expect(LogSubscriber.logger).toBe(appLogger);
+  });
+
+  it("answers null while there is no application logger", () => {
+    expect(LogSubscriber.logger).toBeNull();
+  });
+
+  it("lets an explicit assignment win over the fallback", () => {
+    const appLogger = { warn() {}, debug() {} };
+    const own = { warn() {}, debug() {} } as unknown as Logger;
+    _setTrailsLogger(appLogger);
+    LogSubscriber.logger = own;
+    expect(LogSubscriber.logger).toBe(own);
+  });
+
+  it("memoizes with Rails' `||=`, so a later Trails.logger does not retroactively win", () => {
+    const first = { warn() {}, debug() {} };
+    _setTrailsLogger(first);
+    expect(LogSubscriber.logger).toBe(first);
+
+    _setTrailsLogger({ warn() {}, debug() {} });
+    expect(LogSubscriber.logger).toBe(first);
+  });
+});

--- a/packages/activesupport/src/log-subscriber.ts
+++ b/packages/activesupport/src/log-subscriber.ts
@@ -1,6 +1,7 @@
 import { Subscriber, getClassState } from "./subscriber.js";
 import type { Event } from "./notifications/instrumenter.js";
 import type { Logger } from "./logger.js";
+import { trailsLogger } from "./trails-logger-slot.js";
 
 /**
  * Check whether a logger has a given level enabled.
@@ -91,8 +92,17 @@ export class LogSubscriber extends Subscriber {
 
   private static _logger: Logger | null = null;
 
+  /**
+   * Rails `LogSubscriber.logger`
+   * (`activesupport/lib/active_support/log_subscriber.rb:93-97`), which falls
+   * back to the application logger. `defined?(Rails) && Rails.respond_to?(:logger)`
+   * is a call-time constant resolution; `trailsLogger` is the zero-import slot
+   * `Trails.logger` writes itself into, read here at call time for the same
+   * reason. The memoization is Rails' `||=`, so a later `Trails.logger =` does
+   * not retroactively change a subscriber that has already read it.
+   */
   static get logger(): Logger | null {
-    return this._logger;
+    return (this._logger ??= trailsLogger as Logger | null);
   }
 
   static set logger(value: Logger | null) {
@@ -187,8 +197,15 @@ export class LogSubscriber extends Subscriber {
 
   eventLevels: Map<string, (logger: Logger) => boolean> = new Map();
 
+  /**
+   * Rails `LogSubscriber#logger`
+   * (`activesupport/lib/active_support/log_subscriber.rb:138-140`), which names
+   * `LogSubscriber` itself — NOT `self.class`. A subclass's own `logger=` sets
+   * a class-level ivar the instance path never reads, so every subscriber logs
+   * through the one base-class logger.
+   */
   get logger(): Logger | null {
-    return (this.constructor as typeof LogSubscriber).logger;
+    return LogSubscriber.logger;
   }
 
   get colorizeLogging(): boolean {

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -1194,7 +1194,6 @@ describe("Date", () => {
     expect(d.isEql(new RubyDateTime(2002, 3, 19, 0, 0, 0))).toBe(true);
     expect(d.isEql(new RubyDateTime(2002, 3, 19, 0, 0, 1))).toBe(false);
 
-    // `==` reaches `cmp_gen`'s Numeric arm; `eql?` stops at `!k_date_p`.
     expect(d.equals(d.ajd)).toBe(true);
     expect(d.isEql(d.ajd)).toBe(false);
     expect(d.isEql("2002-03-19")).toBe(false);
@@ -1815,9 +1814,6 @@ describe("Date::Infinity", () => {
   });
 
   it("builds from a NaN and stores Ruby's nil, raising per reader off it", () => {
-    // `lib/date.rb:19` is `@d = d <=> 0`, and `Float::NAN <=> 0` is nil, so the
-    // object BUILDS. Every reader that calls a method on `@d` then raises
-    // NoMethodError at its own call site, as Ruby does.
     const nan = new RubyDate.Infinity(Number.NaN);
     expect(() => nan.isInfinite()).toThrow("undefined method 'nonzero?' for nil");
     expect(() => nan.isNan()).toThrow("undefined method 'zero?' for nil");
@@ -1826,13 +1822,11 @@ describe("Date::Infinity", () => {
     expect(() => nan.coerce(1)).toThrow("undefined method '-@' for nil");
     expect(() => nan.toF()).toThrow("undefined method '>' for nil");
 
-    // `<=>` is the one operator nil answers, so these do not raise.
     expect(nan.compareTo(1000)).toBeNull();
     expect(nan.compareTo(Number.POSITIVE_INFINITY)).toBeNull();
     expect(nan.compareTo(new RubyDate.Infinity())).toBeNull();
     expect(nan.compareTo(new RubyDate.Infinity(Number.NaN))).toBe(0);
 
-    // `zero?`, `finite?` and `abs` never read `@d`.
     expect(nan.isZero()).toBe(false);
     expect(nan.isFinite()).toBe(false);
     expect(nan.abs().toF()).toBe(Number.POSITIVE_INFINITY);
@@ -1881,8 +1875,6 @@ describe("Date::Infinity", () => {
     expect(new RubyDate.Infinity().coerce(1)).toEqual([-1, 1]);
     expect(new RubyDate.Infinity(-1).coerce(new Rational(1, 2))).toEqual([1, -1]);
 
-    // The `else` arm is `super` — `Numeric#coerce`, `[Float(other), Float(self)]`,
-    // where `Float(self)` goes through `to_f` and so answers an infinity.
     expect(new RubyDate.Infinity().coerce("1.5")).toEqual([1.5, Number.POSITIVE_INFINITY]);
     expect(() => new RubyDate.Infinity().coerce("foo")).toThrow('invalid value for Float(): "foo"');
     expect(() => new RubyDate.Infinity().coerce(null)).toThrow("can't convert nil into Float");

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -1869,6 +1869,17 @@ describe("Date::Infinity", () => {
     const coercible = { coerce: () => [-1, 1] as [number, number] };
     expect(new RubyDate.Infinity().compareTo(coercible)).toBe(-1);
     expect(new RubyDate.Infinity().compareTo("foo")).toBeNull();
+
+    const equal = { coerce: () => [1, 1] as [number, number] };
+    expect(new RubyDate.Infinity().compareTo(equal)).toBe(0);
+
+    const incomparable = { coerce: () => [Number.NaN, 1] as [number, number] };
+    expect(new RubyDate.Infinity().compareTo(incomparable)).toBeNull();
+
+    const bothInfinite = {
+      coerce: () => [Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY] as [number, number],
+    };
+    expect(new RubyDate.Infinity().compareTo(bothInfinite)).toBe(0);
   });
 
   it("coerces a Numeric to the pair Ruby answers, and supers to Numeric#coerce otherwise", () => {

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -1186,6 +1186,25 @@ describe("Date", () => {
     expect(d0.england().start).toBe(2361222);
     expect(d0.gregorian().toS()).toBe("2000-02-03");
   });
+
+  it("answers eql? only for a Date, where == admits a Numeric", () => {
+    const d = new RubyDate(2002, 3, 19);
+    expect(d.isEql(new RubyDate(2002, 3, 19))).toBe(true);
+    expect(d.isEql(new RubyDate(2002, 3, 20))).toBe(false);
+    expect(d.isEql(new RubyDateTime(2002, 3, 19, 0, 0, 0))).toBe(true);
+    expect(d.isEql(new RubyDateTime(2002, 3, 19, 0, 0, 1))).toBe(false);
+
+    // `==` reaches `cmp_gen`'s Numeric arm; `eql?` stops at `!k_date_p`.
+    expect(d.equals(d.ajd)).toBe(true);
+    expect(d.isEql(d.ajd)).toBe(false);
+    expect(d.isEql("2002-03-19")).toBe(false);
+  });
+
+  it("hashes eql?-equal dates alike", () => {
+    expect(new RubyDate(2002, 3, 19).hash()).toBe(new RubyDate(2002, 3, 19).hash());
+    expect(new RubyDate(2002, 3, 19).hash()).not.toBe(new RubyDate(2002, 3, 20).hash());
+    expect(new RubyDate(2002, 3, 19).hash()).toBe(new RubyDateTime(2002, 3, 19, 0, 0, 0).hash());
+  });
 });
 
 describe("DateTime", () => {
@@ -1795,8 +1814,28 @@ describe("Date::Infinity", () => {
     expect(new RubyDate.Infinity(0).toF()).toBe(0);
   });
 
-  it("rejects a NaN, where Ruby's `d <=> 0` stores nil", () => {
-    expect(() => new RubyDate.Infinity(Number.NaN)).toThrow(TypeError);
+  it("builds from a NaN and stores Ruby's nil, raising per reader off it", () => {
+    // `lib/date.rb:19` is `@d = d <=> 0`, and `Float::NAN <=> 0` is nil, so the
+    // object BUILDS. Every reader that calls a method on `@d` then raises
+    // NoMethodError at its own call site, as Ruby does.
+    const nan = new RubyDate.Infinity(Number.NaN);
+    expect(() => nan.isInfinite()).toThrow("undefined method 'nonzero?' for nil");
+    expect(() => nan.isNan()).toThrow("undefined method 'zero?' for nil");
+    expect(() => nan.negate()).toThrow("undefined method '-@' for nil");
+    expect(() => nan.identity()).toThrow("undefined method '+@' for nil");
+    expect(() => nan.coerce(1)).toThrow("undefined method '-@' for nil");
+    expect(() => nan.toF()).toThrow("undefined method '>' for nil");
+
+    // `<=>` is the one operator nil answers, so these do not raise.
+    expect(nan.compareTo(1000)).toBeNull();
+    expect(nan.compareTo(Number.POSITIVE_INFINITY)).toBeNull();
+    expect(nan.compareTo(new RubyDate.Infinity())).toBeNull();
+    expect(nan.compareTo(new RubyDate.Infinity(Number.NaN))).toBe(0);
+
+    // `zero?`, `finite?` and `abs` never read `@d`.
+    expect(nan.isZero()).toBe(false);
+    expect(nan.isFinite()).toBe(false);
+    expect(nan.abs().toF()).toBe(Number.POSITIVE_INFINITY);
   });
 
   it("is neither zero nor finite, and is nan only at sign zero", () => {
@@ -1838,9 +1877,17 @@ describe("Date::Infinity", () => {
     expect(new RubyDate.Infinity().compareTo("foo")).toBeNull();
   });
 
-  it("coerces a Numeric to the pair Ruby answers, and raises otherwise", () => {
+  it("coerces a Numeric to the pair Ruby answers, and supers to Numeric#coerce otherwise", () => {
     expect(new RubyDate.Infinity().coerce(1)).toEqual([-1, 1]);
     expect(new RubyDate.Infinity(-1).coerce(new Rational(1, 2))).toEqual([1, -1]);
-    expect(() => new RubyDate.Infinity().coerce("foo")).toThrow(TypeError);
+
+    // The `else` arm is `super` — `Numeric#coerce`, `[Float(other), Float(self)]`,
+    // where `Float(self)` goes through `to_f` and so answers an infinity.
+    expect(new RubyDate.Infinity().coerce("1.5")).toEqual([1.5, Number.POSITIVE_INFINITY]);
+    expect(() => new RubyDate.Infinity().coerce("foo")).toThrow('invalid value for Float(): "foo"');
+    expect(() => new RubyDate.Infinity().coerce(null)).toThrow("can't convert nil into Float");
+    expect(() => new RubyDate.Infinity().coerce(new RubyDate(2001, 2, 3))).toThrow(
+      "can't convert Date into Float",
+    );
   });
 });

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -742,12 +742,11 @@ function rbFloat(val: unknown): number {
  * @internal Ruby `Numeric#coerce` (`numeric.c` `num_coerce`), which is what
  * {@link DateInfinity#coerce}'s `else` arm reaches through `super`
  * (ruby/date, `lib/date.rb:54`). Note the pair comes back `[y, x]` — the
- * OTHER operand first — on both arms.
+ * OTHER operand first — on both arms. `CLASS_OF` is total in Ruby (nil's class
+ * is `NilClass`) where `Object.getPrototypeOf(null)` raises, so a nullish `y`
+ * short-circuits to the unequal-classes arm that `Float()` then rejects.
  */
 function numCoerce(x: unknown, y: unknown): [number, number] {
-  // `CLASS_OF` is total in Ruby — nil's class is NilClass — where
-  // `Object.getPrototypeOf(null)` raises, so the nullish operand short-circuits
-  // to the unequal-classes arm `Float()` then rejects.
   if (y != null && Object.getPrototypeOf(x) === Object.getPrototypeOf(y))
     return [y as number, x as number];
   return [rbFloat(y), rbFloat(x)];
@@ -5710,14 +5709,12 @@ export class Date {
    * trails' `::Time` value is `Temporal.ZonedDateTime` (RFC 0088's mapping
    * table): `Time.local` is a zoned wall-clock time, so the local zone is named
    * rather than an offset frozen in, and the class is not `./time.ts`'s `Time`
-   * because that module imports this one.
+   * because that module imports this one. The C's `if (m_julian_p(adat))
+   * { self = g; }` reassignment is a conditional binding here — the repo's
+   * `@typescript-eslint/no-this-alias` forbids `let self = this`.
    */
   toTime(): Temporal.ZonedDateTime {
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
-    let self: Date = this;
-    if (self.isJulian) {
-      self = self.gregorian();
-    }
+    const self: Date = this.isJulian ? this.gregorian() : this;
     return new Temporal.PlainDateTime(Number(self.year), self.mon, self.day).toZonedDateTime(
       Temporal.Now.timeZoneId(),
     );
@@ -6477,14 +6474,12 @@ export class DateTime extends DateWithoutParseStatics {
    * `date_core.c:9032-9062`), `Time.new(y, m, d, h, min, sec + m_sf_in_sec, of)`
    * — the receiver's own offset carried across, where {@link Date#toTime}'s
    * `f_local3` has none to carry. A Julian receiver goes through
-   * `d_lite_gregorian` first, as it does there.
+   * `d_lite_gregorian` first, as it does there. The C's `if (m_julian_p(dat))
+   * { self = g; }` reassignment is a conditional binding here — the repo's
+   * `@typescript-eslint/no-this-alias` forbids `let self = this`.
    */
   override toTime(): Temporal.ZonedDateTime {
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
-    let self: DateTime = this;
-    if (self.isJulian) {
-      self = self.gregorian();
-    }
+    const self: DateTime = this.isJulian ? this.gregorian() : this;
     const ns = Number(self.#sf.numerator / self.#sf.denominator);
     return new Temporal.PlainDateTime(
       Number(self.year),

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -4445,7 +4445,10 @@ export class DateInfinity {
    * `coerce`. Ruby spells that fallback `rescue NoMethodError`; the equivalent
    * here is the presence check rather than a `catch`, because JS reports a
    * missing method as the same `TypeError` a real `coerce` would raise from
-   * inside itself, and Ruby lets that one through.
+   * inside itself, and Ruby lets that one through. The pair it answers goes
+   * back through `l <=> r` (`lib/date.rb:43`) — the same nil-producing
+   * {@link spaceship} the arms above use, so an incomparable or NaN-ish pair
+   * answers `nil` rather than a `NaN` a raw `Math.sign` would let out.
    */
   compareTo(other: unknown): number | null {
     if (other instanceof DateInfinity) return spaceship(this.d(), other.d());
@@ -4455,7 +4458,7 @@ export class DateInfinity {
     const coerce = (other as { coerce?: (x: unknown) => [number, number] } | null)?.coerce;
     if (typeof coerce === "function") {
       const [l, r] = coerce.call(other, this);
-      return Math.sign(l - r);
+      return spaceship(l, r);
     }
     return null;
   }

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -689,6 +689,71 @@ export class ArgumentError extends Error {
 }
 
 /**
+ * @internal Ruby core `NoMethodError`. It is here rather than imported because
+ * `@blazetrails/date` is the bottom of the dependency graph — activemodel's
+ * copy (`attribute-assignment.ts`) imports this package, not the reverse — and
+ * because {@link ArgumentError} above already sets the precedent for a Ruby
+ * core error class the gem raises being spelled locally.
+ *
+ * `Date::Infinity` is the one raiser: `lib/date.rb:19` stores `d <=> 0`, which
+ * is `nil` for a NaN, and every reader below then calls a method on that `nil`.
+ */
+class NoMethodError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NoMethodError";
+  }
+}
+
+/**
+ * @internal Ruby `<=>` as `Date::Infinity` uses it, which is three operators:
+ * `Float#<=>`, whose NaN arm answers `nil` and is what puts a `nil` in `@d`
+ * (`lib/date.rb:19`); `Integer#<=>` for a stored sign; and `NilClass#<=>` —
+ * inherited `Object#<=>`, which answers `0` for an identical operand and `nil`
+ * otherwise — once that `nil` is stored.
+ */
+function spaceship(a: number | null, b: number | null): number | null {
+  if (a === null || b === null) return a === b ? 0 : null;
+  if (a === b) return 0;
+  const c = Math.sign(a - b);
+  return Number.isNaN(c) ? null : c;
+}
+
+/**
+ * @internal Ruby `Float()` (`object.c` `rb_Float`), which converts through
+ * `to_f` and raises rather than answering `nil`.
+ */
+function rbFloat(val: unknown): number {
+  if (typeof val === "number") return val;
+  if (typeof val === "string") {
+    const f = Number(val.replace(/_/g, ""));
+    if (val.trim() === "" || Number.isNaN(f)) {
+      throw new ArgumentError(`invalid value for Float(): ${JSON.stringify(val)}`);
+    }
+    return f;
+  }
+  if (val == null) throw new TypeError("can't convert nil into Float");
+  const toF = (val as { toF?: () => number }).toF;
+  if (typeof toF === "function") return toF.call(val);
+  throw new TypeError(`can't convert ${(val as object).constructor.name} into Float`);
+}
+
+/**
+ * @internal Ruby `Numeric#coerce` (`numeric.c` `num_coerce`), which is what
+ * {@link DateInfinity#coerce}'s `else` arm reaches through `super`
+ * (ruby/date, `lib/date.rb:54`). Note the pair comes back `[y, x]` — the
+ * OTHER operand first — on both arms.
+ */
+function numCoerce(x: unknown, y: unknown): [number, number] {
+  // `CLASS_OF` is total in Ruby — nil's class is NilClass — where
+  // `Object.getPrototypeOf(null)` raises, so the nullish operand short-circuits
+  // to the unequal-classes arm `Float()` then rejects.
+  if (y != null && Object.getPrototypeOf(x) === Object.getPrototypeOf(y))
+    return [y as number, x as number];
+  return [rbFloat(y), rbFloat(x)];
+}
+
+/**
  * @internal The alternations `date_parse.c` builds its patterns from
  * (ruby/date, `date_parse.c` `ABBR_MONTHS` / `ABBR_DAYS`). Ruby matches the
  * abbreviation and lets the rest of the name run off the end of the token, so
@@ -4103,7 +4168,7 @@ export function dNewByFrags(hash: DateParts | null, sg = DEFAULT_SG): Date {
  * offset in seconds, which is what `DateTime#zone` answers. Seconds below the
  * minute are dropped, as the `"%c%02d:%02d"` format has nowhere to put them.
  */
-function of2str(of: number): string {
+export function of2str(of: number): string {
   const s = of < 0 ? "-" : "+";
   const a = of < 0 ? -of : of;
   const h = Math.floor(a / HOUR_IN_SECONDS);
@@ -4300,31 +4365,30 @@ class DateError extends ArgumentError {
  * gem defines is here, and none of Ruby's inherited `Numeric` surface is.
  */
 export class DateInfinity {
-  /** Ruby `@d` (ruby/date, `lib/date.rb:19`), the sign of the constructor's argument. */
-  readonly #d: number;
+  /**
+   * Ruby `@d` (ruby/date, `lib/date.rb:19`), the sign of the constructor's
+   * argument — or `nil`, for the NaN whose `<=> 0` has no answer.
+   */
+  readonly #d: number | null;
 
   /**
    * Ruby `Date::Infinity#initialize(d=1)` (ruby/date, `lib/date.rb:19`), which
    * stores `d <=> 0`.
    *
-   * `Float::NAN <=> 0` is `nil`, so Ruby stores `nil` and leaves an object
-   * whose every later reader raises `NoMethodError` off it — `nan?` on
-   * `nil.zero?`, `infinite?` on `nil.nonzero?`, `-@`/`coerce` on `-nil`, `to_f`
-   * on `nil > 0` (`lib/date.rb:27-28`, `:32`, `:51-57`, `:59-66`). JS raises on
-   * none of those: `-null` is `-0` and `null > 0` is `false`, so deferring the
-   * failure the way Ruby does would mean inventing a raise site in each of
-   * those six bodies. The rejection is therefore taken here, at the one point
-   * Ruby's `nil` is produced, so no member below has to carry a `null` arm Ruby
-   * does not have.
+   * `Float::NAN <=> 0` is `nil`, so Ruby BUILDS the object and stores `nil`.
+   * Each reader below then raises `NoMethodError` off that stored `nil` at its
+   * own call site, or — where the operator involved is `<=>` itself — answers
+   * `nil` without raising. JS raises on none of Ruby's `nil`-receiver sites
+   * (`-null` is `-0`, `null > 0` is `false`), so the raise is spelled
+   * explicitly in each body Ruby raises from, at the same operator and with
+   * the same message.
    */
   constructor(d: number = 1) {
-    const sign = Math.sign(d);
-    if (Number.isNaN(sign)) throw new TypeError("`d <=> 0` is nil for NaN");
-    this.#d = sign;
+    this.#d = spaceship(d, 0);
   }
 
   /** Ruby `Date::Infinity#d` (ruby/date, `lib/date.rb:21-23`), marked `protected`. */
-  protected d(): number {
+  protected d(): number | null {
     return this.#d;
   }
 
@@ -4344,12 +4408,16 @@ export class DateInfinity {
    * boolean.
    */
   isInfinite(): number | null {
-    return this.d() !== 0 ? this.d() : null;
+    const d = this.d();
+    if (d === null) throw new NoMethodError("undefined method 'nonzero?' for nil");
+    return d !== 0 ? d : null;
   }
 
   /** Ruby `Date::Infinity#nan?` (ruby/date, `lib/date.rb:28`), `d.zero?`. */
   isNan(): boolean {
-    return this.d() === 0;
+    const d = this.d();
+    if (d === null) throw new NoMethodError("undefined method 'zero?' for nil");
+    return d === 0;
   }
 
   /** Ruby `Date::Infinity#abs` (ruby/date, `lib/date.rb:30`). */
@@ -4359,12 +4427,16 @@ export class DateInfinity {
 
   /** Ruby `Date::Infinity#-@` (ruby/date, `lib/date.rb:32`). */
   negate(): DateInfinity {
-    return new (this.constructor as new (d?: number) => DateInfinity)(-this.d());
+    const d = this.d();
+    if (d === null) throw new NoMethodError("undefined method '-@' for nil");
+    return new (this.constructor as new (d?: number) => DateInfinity)(-d);
   }
 
   /** Ruby `Date::Infinity#+@` (ruby/date, `lib/date.rb:33`). */
   identity(): DateInfinity {
-    return new (this.constructor as new (d?: number) => DateInfinity)(+this.d());
+    const d = this.d();
+    if (d === null) throw new NoMethodError("undefined method '+@' for nil");
+    return new (this.constructor as new (d?: number) => DateInfinity)(+d);
   }
 
   /**
@@ -4377,9 +4449,9 @@ export class DateInfinity {
    * inside itself, and Ruby lets that one through.
    */
   compareTo(other: unknown): number | null {
-    if (other instanceof DateInfinity) return Math.sign(this.d() - other.d());
-    if (other === Number.POSITIVE_INFINITY) return Math.sign(this.d() - 1);
-    if (other === Number.NEGATIVE_INFINITY) return Math.sign(this.d() + 1);
+    if (other instanceof DateInfinity) return spaceship(this.d(), other.d());
+    if (other === Number.POSITIVE_INFINITY) return spaceship(this.d(), 1);
+    if (other === Number.NEGATIVE_INFINITY) return spaceship(this.d(), -1);
     if (typeof other === "number" || other instanceof Rational) return this.d();
     const coerce = (other as { coerce?: (x: unknown) => [number, number] } | null)?.coerce;
     if (typeof coerce === "function") {
@@ -4391,19 +4463,24 @@ export class DateInfinity {
 
   /**
    * Ruby `Date::Infinity#coerce` (ruby/date, `lib/date.rb:51-57`). The `else`
-   * arm is `super` — `Numeric#coerce`, whose `[Float(other), Float(self)]`
-   * cannot make a `Float` of a `Date::Infinity` and so raises `TypeError`.
-   * `Float()`'s own `ArgumentError` arm for an unparseable String is not
-   * modelled: the `:nodoc:` class is only ever coerced against a `Numeric`.
+   * arm is `super` — `Numeric#coerce` ({@link numCoerce}), which takes both
+   * sides through `Float()`; `Float(self)` succeeds, because `rb_Float`
+   * converts through `to_f` and {@link DateInfinity#toF} is defined.
    */
   coerce(other: unknown): [number, number] {
-    if (typeof other === "number" || other instanceof Rational) return [-this.d(), this.d()];
-    throw new TypeError(`can't convert ${String(other)} into Float`);
+    if (typeof other === "number" || other instanceof Rational) {
+      const d = this.d();
+      if (d === null) throw new NoMethodError("undefined method '-@' for nil");
+      return [-d, d];
+    } else {
+      return numCoerce(this, other);
+    }
   }
 
   /** Ruby `Date::Infinity#to_f` (ruby/date, `lib/date.rb:59-66`). */
   toF(): number {
     if (this.#d === 0) return 0;
+    if (this.#d === null) throw new NoMethodError("undefined method '>' for nil");
     if (this.#d > 0) {
       return Number.POSITIVE_INFINITY;
     } else {
@@ -5588,6 +5665,65 @@ export class Date {
   }
 
   /**
+   * Ruby `Date#eql?` (ruby/date, `date_core.c` `d_lite_eql_p`,
+   * `date_core.c:6924-6932`), registered on `cDate` next to `<=>` and `===`
+   * (`date_core.c:9794-9797`). It is NOT {@link Date#equals}: `==` admits a
+   * Numeric through `cmp_gen`, `eql?` answers `false` for it — `!k_date_p` is
+   * the first arm and there is no coercion tail, so a non-`Date` operand is
+   * `false` rather than `nil`.
+   */
+  isEql(other: unknown): boolean {
+    if (!(other instanceof Date)) return false;
+    return this.cmp(other) === 0;
+  }
+
+  /**
+   * Ruby `Date#hash` (ruby/date, `date_core.c` `d_lite_hash`,
+   * `date_core.c:6934-6948`), over the `nth`/`jd`/`df`/`sf` quadruple —
+   * the same four `cmp_dd` (`date_core.c:6707-6761`) compares, which is what
+   * makes {@link Date#isEql}-equal dates hash alike. The C reads the STORED
+   * `m_jd`, not `m_local_jd`, and does not canonicalize first; both are kept.
+   *
+   * The mixing function is not: `rb_memhash` is MRI's seeded siphash over the
+   * four machine words, an interpreter-private digest with no JS counterpart
+   * (and one whose `h[0]` is a raw `VALUE` — a pointer for a Bignum `nth`, so
+   * not even reproducible across two MRI runs). The quadruple is folded here
+   * instead, which is the property the C function exists for.
+   */
+  hash(): number {
+    const h: [bigint, number, number, Rational] = [this.nth, this.mJd(), this.mDf(), this.mSf()];
+    let v = 0;
+    for (const part of [h[0], h[1], h[2], h[3].numerator, h[3].denominator]) {
+      v = Math.imul(v ^ Number(BigInt.asIntN(32, BigInt(part))), 0x01000193) | 0;
+    }
+    return v;
+  }
+
+  /**
+   * Ruby `Date#to_time` (ruby/date, `date_core.c` `date_to_time`,
+   * `date_core.c:8949-8971`): midnight of the receiver's day in the LOCAL zone,
+   * `f_local3(rb_cTime, m_real_year, m_mon, m_mday)`. A Julian receiver is
+   * taken through `d_lite_gregorian` first, which is why
+   * `Date.new(2001, 2, 3, Date::JULIAN).to_time` is the 16th — the civil
+   * reading moves, the day does not.
+   *
+   * trails' `::Time` value is `Temporal.ZonedDateTime` (RFC 0088's mapping
+   * table): `Time.local` is a zoned wall-clock time, so the local zone is named
+   * rather than an offset frozen in, and the class is not `./time.ts`'s `Time`
+   * because that module imports this one.
+   */
+  toTime(): Temporal.ZonedDateTime {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    let self: Date = this;
+    if (self.isJulian) {
+      self = self.gregorian();
+    }
+    return new Temporal.PlainDateTime(Number(self.year), self.mon, self.day).toZonedDateTime(
+      Temporal.Now.timeZoneId(),
+    );
+  }
+
+  /**
    * Ruby `Date#to_date` (ruby/date, `date_core.c` `date_to_date`, `date_core.c:8977-8981`), which
    * answers the receiver's `::Date` value — `self` in MRI, because MRI's
    * `::Date` value *is* the gem object. trails' `::Date` value is
@@ -5617,6 +5753,26 @@ export class Date {
    */
   toDate(): Temporal.PlainDate {
     return plainDateFromJd(this.mLocalJd(), this.#sg);
+  }
+
+  /**
+   * Ruby `Date#to_datetime` (ruby/date, `date_core.c` `date_to_datetime`,
+   * `date_core.c:8992-9027`), the same day at midnight: the C copies the
+   * receiver's data into a fresh `DateTime` and, on the complex arm, zeroes
+   * `df`, `sf`, `hour`, `min` and `sec` — so a `Date` never carries a time of
+   * day across. `Date` is always the simple arm, whose copy is a straight
+   * `bdat->s = adat->s`; the seat below is that copy.
+   */
+  toDatetime(): Temporal.PlainDateTime | Temporal.ZonedDateTime {
+    return new DateTime(
+      SEAT,
+      this.nth,
+      this.mJd(),
+      0,
+      new Rational(0, 1),
+      0,
+      this.#sg,
+    ).toDatetime();
   }
 
   /**
@@ -6314,6 +6470,33 @@ export class DateTime extends DateWithoutParseStatics {
       this.#of,
       val2sg(start),
     ) as this;
+  }
+
+  /**
+   * Ruby `DateTime#to_time` (ruby/date, `date_core.c` `datetime_to_time`,
+   * `date_core.c:9032-9062`), `Time.new(y, m, d, h, min, sec + m_sf_in_sec, of)`
+   * — the receiver's own offset carried across, where {@link Date#toTime}'s
+   * `f_local3` has none to carry. A Julian receiver goes through
+   * `d_lite_gregorian` first, as it does there.
+   */
+  override toTime(): Temporal.ZonedDateTime {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    let self: DateTime = this;
+    if (self.isJulian) {
+      self = self.gregorian();
+    }
+    const ns = Number(self.#sf.numerator / self.#sf.denominator);
+    return new Temporal.PlainDateTime(
+      Number(self.year),
+      self.mon,
+      self.day,
+      self.hour,
+      self.min,
+      self.sec,
+      Math.floor(ns / 1000000),
+      Math.floor(ns / 1000) % 1000,
+      ns % 1000,
+    ).toZonedDateTime(of2str(self.#of));
   }
 
   /**

--- a/packages/date/src/test-date-conv.test.ts
+++ b/packages/date/src/test-date-conv.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Port of ruby/date's `test/date/test_date_conv.rb`.
+ *
+ * RFC 0088 answers `Temporal` where MRI answers `Date`/`DateTime`/`Time`
+ * (`vendor/sources.ts`'s `date` entry), so every assertion below reads the
+ * Temporal counterpart of the value Ruby asserts on: `Time` is
+ * `Temporal.ZonedDateTime`, `Date` is `Temporal.PlainDate`, and `DateTime` is
+ * `Temporal.PlainDateTime` — or a `ZonedDateTime`, once an offset is carried.
+ *
+ * Ruby's `with_tz` helper is not ported: it swaps `ENV["TZ"]`, and this repo
+ * forbids `process.*`. The offset assertion it wraps is made directly instead —
+ * a `ZonedDateTime` carries its own offset, so the host zone cannot change it.
+ *
+ * The five tests that build their subject with `Date#+` — `test_to_date__from_date`,
+ * `test_to_datetime__from_date`, `test_to_time__from_datetime`,
+ * `test_to_date__from_datetime` and `test_to_datetime__from_datetime` — are not
+ * here: `d_lite_plus` (`date_core.c:4967`) is unported, so there is no way to
+ * write `Date.new(2004, 9, 19) + 1.to_r/2`. They are filed against RFC 0088.
+ */
+import { describe, it, expect } from "vitest";
+import { Temporal, Date, DateTime, Time } from "./index.js";
+
+describe("TestDateConv", () => {
+  it("to class", () => {
+    const subjects = [new Time(2004, 9, 19, 1, 2, 3), new Date(2004, 9, 19)];
+    for (const o of subjects) {
+      expect(o.toTime()).toBeInstanceOf(Temporal.ZonedDateTime);
+      expect(o.toDate()).toBeInstanceOf(Temporal.PlainDate);
+    }
+    // trails' `::DateTime` value is a `PlainDateTime`, or a `ZonedDateTime`
+    // once an offset is carried — a local-zone `Time` carries one.
+    const isDatetime = (v: unknown): boolean =>
+      v instanceof Temporal.PlainDateTime || v instanceof Temporal.ZonedDateTime;
+    expect(isDatetime(new DateTime(2004, 9, 19, 1, 2, 3).toDatetime())).toBe(true);
+    expect(isDatetime(new Time(2004, 9, 19, 1, 2, 3).toDatetime())).toBe(true);
+    expect(isDatetime(new Date(2004, 9, 19).toDatetime())).toBe(true);
+  });
+
+  it("to time  from time", () => {
+    let t = Time.mktime(2004, 9, 19, 1, 2, 3, 456789);
+    let t2 = t.toTime();
+    expect([t2.year, t2.month, t2.day, t2.hour, t2.minute, t2.second, usec(t2)]).toEqual([
+      2004, 9, 19, 1, 2, 3, 456789,
+    ]);
+
+    t = Time.utc(2004, 9, 19, 1, 2, 3, 456789);
+    t2 = t.toTime().withTimeZone("UTC");
+    expect([t2.year, t2.month, t2.day, t2.hour, t2.minute, t2.second, usec(t2)]).toEqual([
+      2004, 9, 19, 1, 2, 3, 456789,
+    ]);
+
+    t = new Time(2004, 9, 19, 1, 2, 3, "+03:00");
+    t2 = t.toTime();
+    expect([t2.year, t2.month, t2.day, t2.hour, t2.minute, t2.second]).toEqual([
+      2004, 9, 19, 1, 2, 3,
+    ]);
+    expect(t2.offsetNanoseconds / 1_000_000_000).toBe(3 * 60 * 60);
+  });
+
+  it("to time  from date", () => {
+    const d = new Date(2004, 9, 19);
+    const t = d.toTime();
+    expect([t.year, t.month, t.day, t.hour, t.minute, t.second, usec(t)]).toEqual([
+      2004, 9, 19, 0, 0, 0, 0,
+    ]);
+  });
+
+  it("to time to date roundtrip  from gregorian date", () => {
+    const d = new Date(1582, 10, 15);
+    const t = d.toTime();
+    expect([t.year, t.month, t.day, t.hour, t.minute, t.second, usec(t)]).toEqual([
+      1582, 10, 15, 0, 0, 0, 0,
+    ]);
+    expect(toDateOf(t).equals(d.toDate())).toBe(true);
+    expect(jdOf(t)).toBe(d.jd);
+  });
+
+  it("to time to date roundtrip  from julian date", () => {
+    const d = new Date(1582, 10, 4);
+    const t = d.toTime();
+    expect([t.year, t.month, t.day, t.hour, t.minute, t.second, usec(t)]).toEqual([
+      1582, 10, 14, 0, 0, 0, 0,
+    ]);
+    expect(toDateOf(t).equals(d.toDate())).toBe(true);
+    expect(jdOf(t)).toBe(d.jd);
+  });
+
+  it("to date  from time", () => {
+    let t = Time.mktime(2004, 9, 19, 1, 2, 3, 456789);
+    let d = t.toDate();
+    expect([d.year, d.month, d.day]).toEqual([2004, 9, 19]);
+
+    t = Time.utc(2004, 9, 19, 1, 2, 3, 456789);
+    d = t.toDate();
+    expect([d.year, d.month, d.day]).toEqual([2004, 9, 19]);
+
+    t = Time.utc(1582, 10, 13, 1, 2, 3, 456789);
+    d = t.toDate(); // using ITALY
+    expect([d.year, d.month, d.day]).toEqual([1582, 10, 3]);
+  });
+
+  it("to datetime  from time", () => {
+    let t = Time.mktime(2004, 9, 19, 1, 2, 3, 456789);
+    let d = t.toDatetime();
+    expect([d.year, d.month, d.day, d.hour, d.minute, d.second, usec(d)]).toEqual([
+      2004, 9, 19, 1, 2, 3, 456789,
+    ]);
+    expect(offsetSeconds(d)).toBe(t.utcOffset);
+
+    t = Time.utc(2004, 9, 19, 1, 2, 3, 456789);
+    d = t.toDatetime();
+    expect([d.year, d.month, d.day, d.hour, d.minute, d.second, usec(d)]).toEqual([
+      2004, 9, 19, 1, 2, 3, 456789,
+    ]);
+    expect(offsetSeconds(d)).toBe(0);
+
+    t = Time.utc(1582, 10, 13, 1, 2, 3, 456789);
+    d = t.toDatetime(); // using ITALY
+    expect([d.year, d.month, d.day, d.hour, d.minute, d.second, usec(d)]).toEqual([
+      1582, 10, 3, 1, 2, 3, 456789,
+    ]);
+    expect(offsetSeconds(d)).toBe(0);
+  });
+});
+
+/** Ruby `Time#usec` / `DateTime#sec_fraction`, off a Temporal value. */
+function usec(t: Temporal.ZonedDateTime | Temporal.PlainDateTime): number {
+  return t.millisecond * 1000 + t.microsecond;
+}
+
+/** Ruby `DateTime#offset`, in seconds rather than as a fraction of a day. */
+function offsetSeconds(d: Temporal.ZonedDateTime | Temporal.PlainDateTime): number {
+  return d instanceof Temporal.ZonedDateTime ? d.offsetNanoseconds / 1_000_000_000 : 0;
+}
+
+/** Ruby `Time#to_date`, off the `Temporal.ZonedDateTime` `to_time` answers. */
+function toDateOf(t: Temporal.ZonedDateTime): Temporal.PlainDate {
+  return new Time(t.year, t.month, t.day, t.hour, t.minute, t.second).toDate();
+}
+
+/** Ruby `Time#to_date.jd`. */
+function jdOf(t: Temporal.ZonedDateTime): number | bigint {
+  return new Date(t.year, t.month, t.day, Date.GREGORIAN).newStart().jd;
+}

--- a/packages/date/src/test-date-conv.test.ts
+++ b/packages/date/src/test-date-conv.test.ts
@@ -27,8 +27,6 @@ describe("TestDateConv", () => {
       expect(o.toTime()).toBeInstanceOf(Temporal.ZonedDateTime);
       expect(o.toDate()).toBeInstanceOf(Temporal.PlainDate);
     }
-    // trails' `::DateTime` value is a `PlainDateTime`, or a `ZonedDateTime`
-    // once an offset is carried — a local-zone `Time` carries one.
     const isDatetime = (v: unknown): boolean =>
       v instanceof Temporal.PlainDateTime || v instanceof Temporal.ZonedDateTime;
     expect(isDatetime(new DateTime(2004, 9, 19, 1, 2, 3).toDatetime())).toBe(true);
@@ -71,8 +69,8 @@ describe("TestDateConv", () => {
     expect([t.year, t.month, t.day, t.hour, t.minute, t.second, usec(t)]).toEqual([
       1582, 10, 15, 0, 0, 0, 0,
     ]);
-    expect(toDateOf(t).equals(d.toDate())).toBe(true);
-    expect(jdOf(t)).toBe(d.jd);
+    expect(timeToDate(t).toDate().equals(d.toDate())).toBe(true);
+    expect(timeToDate(t).jd).toBe(d.jd);
   });
 
   it("to time to date roundtrip  from julian date", () => {
@@ -81,8 +79,8 @@ describe("TestDateConv", () => {
     expect([t.year, t.month, t.day, t.hour, t.minute, t.second, usec(t)]).toEqual([
       1582, 10, 14, 0, 0, 0, 0,
     ]);
-    expect(toDateOf(t).equals(d.toDate())).toBe(true);
-    expect(jdOf(t)).toBe(d.jd);
+    expect(timeToDate(t).toDate().equals(d.toDate())).toBe(true);
+    expect(timeToDate(t).jd).toBe(d.jd);
   });
 
   it("to date  from time", () => {
@@ -95,7 +93,7 @@ describe("TestDateConv", () => {
     expect([d.year, d.month, d.day]).toEqual([2004, 9, 19]);
 
     t = Time.utc(1582, 10, 13, 1, 2, 3, 456789);
-    d = t.toDate(); // using ITALY
+    d = t.toDate();
     expect([d.year, d.month, d.day]).toEqual([1582, 10, 3]);
   });
 
@@ -115,7 +113,7 @@ describe("TestDateConv", () => {
     expect(offsetSeconds(d)).toBe(0);
 
     t = Time.utc(1582, 10, 13, 1, 2, 3, 456789);
-    d = t.toDatetime(); // using ITALY
+    d = t.toDatetime();
     expect([d.year, d.month, d.day, d.hour, d.minute, d.second, usec(d)]).toEqual([
       1582, 10, 3, 1, 2, 3, 456789,
     ]);
@@ -133,12 +131,13 @@ function offsetSeconds(d: Temporal.ZonedDateTime | Temporal.PlainDateTime): numb
   return d instanceof Temporal.ZonedDateTime ? d.offsetNanoseconds / 1_000_000_000 : 0;
 }
 
-/** Ruby `Time#to_date`, off the `Temporal.ZonedDateTime` `to_time` answers. */
-function toDateOf(t: Temporal.ZonedDateTime): Temporal.PlainDate {
-  return new Time(t.year, t.month, t.day, t.hour, t.minute, t.second).toDate();
-}
-
-/** Ruby `Time#to_date.jd`. */
-function jdOf(t: Temporal.ZonedDateTime): number | bigint {
-  return new Date(t.year, t.month, t.day, Date.GREGORIAN).newStart().jd;
+/**
+ * Ruby `Time#to_date`, as the gem-shaped `Date` rather than the `PlainDate`
+ * {@link Time#toDate} answers — the roundtrip tests assert on `jd`, which only
+ * the gem object carries. The receiver is the `Temporal.ZonedDateTime` that is
+ * trails' `::Time` value, so it goes back through `Time` first.
+ */
+function timeToDate(t: Temporal.ZonedDateTime): Date {
+  const time = new Time(t.year, t.month, t.day, t.hour, t.minute, t.second);
+  return new Date(time.year, time.mon, time.day, Date.GREGORIAN).newStart();
 }

--- a/packages/date/src/time.ts
+++ b/packages/date/src/time.ts
@@ -8,7 +8,7 @@
  */
 
 import { Temporal } from "@js-temporal/polyfill";
-import { ArgumentError, Rational, strftime } from "./date.js";
+import { ArgumentError, Date, DateTime, Rational, of2str, strftime } from "./date.js";
 
 /**
  * The `utc_offset` argument MRI's `Time.new` accepts: `"UTC"`, an offset —
@@ -193,9 +193,30 @@ export class Time {
   /** @internal Seconds east of UTC — Ruby's `Time#utc_offset`. */
   readonly #utcOffset: number;
 
-  /** Ruby `Time.utc(year, month, day, hour = 0, min = 0, sec = 0)`. */
-  static utc(year: number, month: number, day: number, hour = 0, min = 0, sec = 0): Time {
-    return new Time(year, month, day, hour, min, sec, "UTC");
+  /**
+   * Ruby `Time.utc(year, month, day, hour = 0, min = 0, sec = 0, usec = 0)`.
+   * MRI's seventh positional is the microsecond, not a zone — `Time.utc` names
+   * its zone in the method — so it folds into `sec` here.
+   */
+  static utc(year: number, month: number, day: number, hour = 0, min = 0, sec = 0, usec = 0): Time {
+    return new Time(year, month, day, hour, min, sec + usec / 1_000_000, "UTC");
+  }
+
+  /**
+   * Ruby `Time.mktime(year, month, day, hour = 0, min = 0, sec = 0, usec = 0)`,
+   * the `Time.local` alias, which builds in the LOCAL zone. As with
+   * {@link Time.utc}, the seventh positional is the microsecond.
+   */
+  static mktime(
+    year: number,
+    month: number,
+    day: number,
+    hour = 0,
+    min = 0,
+    sec = 0,
+    usec = 0,
+  ): Time {
+    return new Time(year, month, day, hour, min, sec + usec / 1_000_000);
   }
 
   /**
@@ -305,6 +326,59 @@ export class Time {
   /** Ruby `Time#utc_offset`, the receiver's offset from UTC in seconds. */
   get utcOffset(): number {
     return this.#utcOffset;
+  }
+
+  /** Ruby `Time#gmt_offset`, the `utc_offset` alias. */
+  get gmtOffset(): number {
+    return this.#utcOffset;
+  }
+
+  /**
+   * Ruby `Time#to_time` (ruby/date, `date_core.c` `time_to_time`,
+   * `date_core.c:8860-8864`), which answers `self` — MRI's `::Time` value IS
+   * the receiver. trails' is `Temporal.ZonedDateTime` (RFC 0088's mapping
+   * table), so `self` is converted to it here, keeping the receiver's zone
+   * where it has one and its offset where it does not.
+   */
+  toTime(): Temporal.ZonedDateTime {
+    return this.#plain.toZonedDateTime(this.#timeZoneId ?? of2str(this.#utcOffset));
+  }
+
+  /**
+   * Ruby `Time#to_date` (ruby/date, `date_core.c` `time_to_date`,
+   * `date_core.c:8872-8892`), the receiver's civil day: the C builds it under
+   * `GREGORIAN` — a `::Time` is proleptic Gregorian, so 1582-10-13 is a real
+   * day for it — and then `set_sg(dat, DEFAULT_SG)` puts the reform back, which
+   * is why `Time.utc(1582, 10, 13).to_date` reads `1582-10-03`.
+   */
+  toDate(): Temporal.PlainDate {
+    return new Date(this.year, this.mon, this.day, Date.GREGORIAN).newStart().toDate();
+  }
+
+  /**
+   * Ruby `Time#to_datetime` (ruby/date, `date_core.c` `time_to_datetime`,
+   * `date_core.c:8901-8935`), the same `GREGORIAN`-then-`set_sg` build as
+   * {@link Time#toDate} with the time of day, the sub-second and the receiver's
+   * `utc_offset` carried across. A leap second — `sec == 60` — is stored as
+   * `59`, which the gem's `DateTime` has no room for.
+   */
+  toDatetime(): Temporal.PlainDateTime | Temporal.ZonedDateTime {
+    let s = this.sec;
+    if (s === 60) s = 59;
+    const sf = new Rational(BigInt(s) * 1_000_000_000n + BigInt(this.nsec), 1_000_000_000n);
+    const of = this.utcOffset;
+    return new DateTime(
+      this.year,
+      this.mon,
+      this.day,
+      this.hour,
+      this.min,
+      sf,
+      new Rational(of, 86400),
+      Date.GREGORIAN,
+    )
+      .newStart()
+      .toDatetime();
   }
 
   strftime(format: string): string {

--- a/packages/date/src/time.ts
+++ b/packages/date/src/time.ts
@@ -361,6 +361,12 @@ export class Time {
    * {@link Time#toDate} with the time of day, the sub-second and the receiver's
    * `utc_offset` carried across. A leap second — `sec == 60` — is stored as
    * `59`, which the gem's `DateTime` has no room for.
+   *
+   * The C reaches `d_complex_new_internal` directly and so hands it `s` and
+   * `sf` as separate fields, and `of` as seconds. That seat is private to
+   * `./date.ts`; the public constructor is the same one `DateTime.now` uses,
+   * and it takes the whole second and its fraction as one `second` and the
+   * offset as a fraction of a day — hence the two `Rational`s here.
    */
   toDatetime(): Temporal.PlainDateTime | Temporal.ZonedDateTime {
     let s = this.sec;


### PR DESCRIPTION
Four bundled stories.

## `Date::Infinity` — converge the NaN and `coerce`-super arms (`lib/date.rb:17-68`)

`initialize` is `@d = d <=> 0` (`lib/date.rb:19`), and `Float::NAN <=> 0` is
`nil`, so Ruby BUILDS the object and stores `nil`. trails rejected the NaN at
the constructor with a `TypeError` instead. That is now converged: `@d` is
`number | null`, and each of the six readers raises `NoMethodError` at the same
operator Ruby raises from, with Ruby's message —

| reader | `lib/date.rb` | on a `nil` `@d` |
| --- | --- | --- |
| `infinite?` | `:27` | `undefined method 'nonzero?' for nil` |
| `nan?` | `:28` | `undefined method 'zero?' for nil` |
| `-@` / `+@` | `:32-33` | `undefined method '-@' / '+@' for nil` |
| `coerce` (Numeric arm) | `:52` | `undefined method '-@' for nil` |
| `to_f` | `:61` | `undefined method '>' for nil` |
| `<=>` | `:36-40` | answers `nil` — no raise |

`<=>` itself is the one operator `nil` answers, so `spaceship()` models the
three Ruby operators involved (`Float#<=>`'s NaN arm, `Integer#<=>`,
`NilClass#<=>`) rather than each body carrying a `null` branch. `zero?`,
`finite?` and `abs` never read `@d` and are unchanged.

`coerce`'s `else` arm is now really `super` — `Numeric#coerce` (`numeric.c`
`num_coerce`), `[Float(other), Float(self)]`, where `Float(self)` succeeds
through `to_f`. `Float()`'s arms carry their own error classes and messages
(`ArgumentError` for an unparseable String, `TypeError` for nil / no `to_f`),
replacing the hand-written `TypeError`.

## `Date#eql?` and `Date#hash` (`date_core.c:6924-6948`)

The two unported neighbours of the comparison cluster #6307 landed, registered
on `cDate` right next to `<=>` / `===` (`date_core.c:9794-9797`). `eql?` is
`f_zero_p(d_lite_cmp)` behind a `!k_date_p` guard — `false`, not `nil`, for a
Numeric that `==` would have admitted through `cmp_gen`. `hash` reads the same
`nth`/`jd`/`df`/`sf` quadruple `cmp_dd` compares; `rb_memhash` itself is MRI's
seeded siphash over four machine words (with a raw `VALUE` in `h[0]`) and has
no reproducible counterpart, so the quadruple is folded instead.

## `test_date_conv.rb` — 7 of 12, plus the conversion cluster

Ported to `packages/date/src/test-date-conv.test.ts`; `test:compare --package date`
moves **1/137 → 8/137**. The conversions they needed are new:

- `Date#toTime` (`date_core.c:8949-8971`) — `f_local3`, Julian receiver through
  `d_lite_gregorian` first
- `Date#toDatetime` (`date_core.c:8992-9027`)
- `DateTime#toTime` (`date_core.c:9032-9062`) — offset carried across
- `Time#toTime` / `#toDate` / `#toDatetime` (`date_core.c:8860-8935`) — the
  `GREGORIAN`-then-`set_sg(DEFAULT_SG)` build, which is what makes
  `Time.utc(1582, 10, 13).to_date` read `1582-10-03`
- `Time.mktime`, and `Time.utc`'s `usec` positional

Per RFC 0088 these answer `Temporal` (`ZonedDateTime` for `::Time`,
`PlainDate` for `::Date`, `PlainDateTime`-or-`ZonedDateTime` for `::DateTime`),
so the assertions read the Temporal counterpart of each Ruby value —
`vendor/sources.ts:212-221` records those value mismatches as expected.

### Why the other 5 tests are not here (review finding, with the C citation)

Every one of the 5 builds its subject with `Date#+` / `DateTime#+` —
`d_lite_plus`, `date_core.c:5952-6270`, 319 lines of C across four operand arms
(`T_FIXNUM`, `T_BIGNUM`, `T_FLOAT`, `T_RATIONAL`). None of the 5 can be written
at all until it is ported, and it is a whole PR on its own next to this one's
579 LOC.

More than size, two of them are blocked on a **representational** gap, not a
missing method. `d_lite_plus`'s `T_RATIONAL` arm ends in
`d_complex_new_internal(rb_obj_class(self), nth, jd, df, sf, ...)`
(`date_core.c:6249-6259`) — `rb_obj_class(self)` is `Date`, so
`Date.new(2004, 9, 19) + 1.to_r/2` is a **`Date` carrying `ComplexDateData`**,
which is exactly what `test_to_date__from_date:114` and
`test_to_datetime__from_date:162` assert on (`d2.day_fraction == 1/2`). trails'
`Date` is simple-only by construction: `simpleDatP` is
`!(dat instanceof DateTime)`, and `Date#mDf()` / `Date#mSf()` answer `0` /
`Rational(0, 1)` unconditionally. Giving `Date` the complex arm is a change to
the core class's storage, and shipping `plus` without it would silently drop
the fraction — a wrong-value regression worse than the gap.

Shipping a Rational-only `plus` is not an option either: one Rails method is one
TS method, so the arms come as a set.

The story's own Notes anticipate this — *"If the port exceeds the PR LOC ceiling,
ship the part that fits and file the remainder as a sibling story — do not grow
the PR and do not open the sibling PR yourself."* Filed as
`0088-date-gem-port/port-test-date-conv-date-plus-arms`, carrying the `file:line`
list and the `ComplexDateData` blocker above so it is not re-derived. Ruby's `with_tz` helper is also not ported — it swaps `ENV["TZ"]` and this
repo forbids `process.*`; the offset assertion it wraps is made directly, and a
`ZonedDateTime` carries its own offset so the host zone cannot affect it.

## `LogSubscriber.logger` falls back to the application logger

`log_subscriber.rb:93-97`'s `@logger ||= Rails.logger` arm, through the
zero-import `trails-logger-slot.ts` #6282 added. Memoization is Rails' `||=`
(`??=` retries while nullish, so a `Trails.logger` set later is still picked
up, but one set later than the first successful read is not), and
`attr_writer :logger` still wins.

This surfaced a second divergence one line away: `LogSubscriber#logger`
(instance) read `this.constructor.logger` where `log_subscriber.rb:138-140`
hard-codes `LogSubscriber.logger`. With the fallback in place that made a
subclass cache its own `null` and shadow the base logger for the rest of the
suite. Converged rather than worked around.

Closes-story: converge-date-infinity-nan-and-coerce-arms-to-lib-date-rb
Closes-story: port-date-eql-p-and-hash
Closes-story: port-test-date-conv
Closes-story: log-subscriber-logger-falls-back-to-the-application-logger

