### PR TITLE
feat(date): Date::Infinity Comparable surface, test_date_new.rb jd/ordinal/civil, sqlite copy_table_indexes via add_index

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -547,8 +547,14 @@ export interface AddIndexOptions {
   unique?: boolean;
   name?: string;
   where?: string;
-  order?: Record<string, string>;
+  // `add_index(table, columns, order: :desc)` applies one direction to every
+  // column — `options_for_index_columns` (schema_statements.rb) takes the bare
+  // value as well as the per-column Hash.
+  order?: string | Record<string, string>;
   using?: string;
+  // schema_statements.rb:1476 — `internal:` is add_index's own kwarg, outside
+  // the asserted option set; copy_table_indexes passes it (sqlite3_adapter.rb:668).
+  internal?: boolean;
   type?: string;
   comment?: string;
   ifNotExists?: boolean;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -547,13 +547,18 @@ export interface AddIndexOptions {
   unique?: boolean;
   name?: string;
   where?: string;
-  // `add_index(table, columns, order: :desc)` applies one direction to every
-  // column — `options_for_index_columns` (schema_statements.rb) takes the bare
-  // value as well as the per-column Hash.
+  /**
+   * `add_index(table, columns, order: :desc)` applies one direction to every
+   * column — `options_for_index_columns` takes the bare value as well as the
+   * per-column Hash.
+   */
   order?: string | Record<string, string>;
   using?: string;
-  // schema_statements.rb:1476 — `internal:` is add_index's own kwarg, outside
-  // the asserted option set; copy_table_indexes passes it (sqlite3_adapter.rb:668).
+  /**
+   * `internal:` is add_index's own kwarg, outside the asserted option set
+   * (schema_statements.rb:1476-1477); `copy_table_indexes` passes it
+   * (sqlite3_adapter.rb:668).
+   */
   internal?: boolean;
   type?: string;
   comment?: string;

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2527,11 +2527,9 @@ WHERE type = 'table' AND name = ${this.quote(tableName)}
   /**
    * Mirrors: SQLite3Adapter#copy_table_indexes (sqlite3_adapter.rb:651-677)
    *
-   * @missingRailsCall add_index — SQLite puts the schema on the INDEX name
-   *   (`CREATE INDEX aux.by_name ON widgets (…)`); qualifying the table instead
-   *   is a syntax error, and `add_index` has no notion of an ATTACHed schema, so
-   *   the statement is assembled here. It still goes through `execute`, the
-   *   primitive `add_index` would have reached.
+   * The one arm that does NOT reach `add_index` is the schema-qualified
+   * destination (`aux.posts`), which Rails has no notion of — see the comment
+   * at that branch.
    * @internal
    */
   private async copyTableIndexes(
@@ -2564,6 +2562,28 @@ WHERE type = 'table' AND name = ${this.quote(tableName)}
       if (!cols.length) continue;
       const escapedFrom = bareFrom.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
       const newName = name.replace(new RegExp(`(^|_)(${escapedFrom})_`), `$1${bareTo}_`);
+      // sqlite3_adapter.rb:668-675 — the options hash and the add_index call it
+      // splats into, in Rails' own build order.
+      const options: {
+        name: string;
+        internal: boolean;
+        unique?: boolean;
+        where?: string;
+        order?: string | Record<string, string>;
+      } = { name: newName, internal: true };
+      if (idx.unique) options.unique = true;
+      if (idx.where) options.where = idx.where;
+      if (idx.orders) options.order = idx.orders;
+      // SQLite puts the schema on the INDEX name, not on the table it indexes
+      // (`CREATE INDEX aux.by_name ON widgets (...)`); qualifying the table
+      // instead is a syntax error. Rails has no ATTACHed-schema notion here at
+      // all, so its add_index call is unconditional and ours covers every case
+      // Rails has — the qualified arm below is the trails-only remainder.
+      const { schema: toSchema } = this._splitTableName(to);
+      if (toSchema === undefined || toSchema === "") {
+        await this.addIndex(to, cols, options);
+        continue;
+      }
       // Rails forwards `index.orders` to add_index, whose add_index_sort_order
       // appends any present direction upcased (`column << " #{orders[name].upcase}"`)
       // keyed off the column name as it appears in the copied list. This
@@ -2583,13 +2603,7 @@ WHERE type = 'table' AND name = ${this.quote(tableName)}
             .map((c) => `${quoteColumnName(c)}${orders[c] ? ` ${orders[c].toUpperCase()}` : ""}`)
             .join(", ")
         : cols;
-      // SQLite puts the schema on the INDEX name, not on the table it indexes
-      // (`CREATE INDEX aux.by_name ON widgets (...)`); qualifying the table
-      // instead is a syntax error. Rails has no ATTACHed-schema notion here.
-      const { schema: toSchema } = this._splitTableName(to);
-      const target = toSchema
-        ? `${quoteColumnName(toSchema)}.${quoteColumnName(newName)} ON ${quoteColumnName(bareTo)}`
-        : `${quoteColumnName(newName)} ON ${quoteTableName(to)}`;
+      const target = `${quoteColumnName(toSchema)}.${quoteColumnName(newName)} ON ${quoteColumnName(bareTo)}`;
       let sql = `CREATE ${idx.unique ? "UNIQUE " : ""}INDEX ${target} (${colSql})`;
       if (idx.where) sql += ` WHERE ${idx.where}`;
       await this.execute(sql);

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2527,9 +2527,11 @@ WHERE type = 'table' AND name = ${this.quote(tableName)}
   /**
    * Mirrors: SQLite3Adapter#copy_table_indexes (sqlite3_adapter.rb:651-677)
    *
-   * The one arm that does NOT reach `add_index` is the schema-qualified
-   * destination (`aux.posts`), which Rails has no notion of — see the comment
-   * at that branch.
+   * Rails calls `add_index` unconditionally (`sqlite3_adapter.rb:674`) and so
+   * does this, for every destination Rails can name. The one arm that does not
+   * is the schema-qualified one, which Rails has no notion of; it is recorded at
+   * that branch, not as a `@missingRailsCall` tag — the tag is per-method, and
+   * `api:calls` fails it as STALE now that the method does make the call.
    * @internal
    */
   private async copyTableIndexes(
@@ -2572,11 +2574,13 @@ WHERE type = 'table' AND name = ${this.quote(tableName)}
       if (idx.unique) options.unique = true;
       if (idx.where) options.where = idx.where;
       if (idx.orders) options.order = idx.orders;
-      // SQLite puts the schema on the INDEX name, not on the table it indexes
-      // (`CREATE INDEX aux.by_name ON widgets (...)`); qualifying the table
-      // instead is a syntax error. Rails has no ATTACHed-schema notion here at
-      // all, so its add_index call is unconditional and ours covers every case
-      // Rails has — the qualified arm below is the trails-only remainder.
+      // MISSING RAILS CALL (add_index, sqlite3_adapter.rb:674) — this branch
+      // only. SQLite puts the schema on the INDEX name, not on the table it
+      // indexes (`CREATE INDEX aux.by_name ON widgets (...)`); qualifying the
+      // table instead is a syntax error, and `add_index` quotes the table, so
+      // it cannot express a qualified destination. Rails has no ATTACHed-schema
+      // notion here at all — every destination Rails can name takes the
+      // `addIndex` call below, and this arm is the trails-only remainder.
       const { schema: toSchema } = this._splitTableName(to);
       if (toSchema === undefined || toSchema === "") {
         await this.addIndex(to, cols, options);

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2562,8 +2562,6 @@ WHERE type = 'table' AND name = ${this.quote(tableName)}
       if (!cols.length) continue;
       const escapedFrom = bareFrom.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
       const newName = name.replace(new RegExp(`(^|_)(${escapedFrom})_`), `$1${bareTo}_`);
-      // sqlite3_adapter.rb:668-675 — the options hash and the add_index call it
-      // splats into, in Rails' own build order.
       const options: {
         name: string;
         internal: boolean;

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -28,6 +28,7 @@ import {
   indexes as sqliteIndexes,
   newColumnFromField,
   validTableDefinitionOptions as sqliteValidTableDefinitionOptions,
+  validateIndexLengthBang as sqliteValidateIndexLengthBang,
   virtualTableExists as sqliteVirtualTableExists,
 } from "./sqlite3/schema-statements.js";
 import {
@@ -2141,6 +2142,19 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
    */
   validTableDefinitionOptions(): string[] {
     return sqliteValidTableDefinitionOptions.call(this);
+  }
+
+  /**
+   * Mirrors: SQLite3::SchemaStatements#validate_index_length!
+   * (sqlite3/schema_statements.rb:139-141) — `super unless internal`. The
+   * temporary table `alter_table` copies through is `a#{from}` and its indexes
+   * are renamed `t#{name}`, so an index already at the 64-character limit goes
+   * one over; `internal: true` from `copy_table_indexes` is what exempts it.
+   *
+   * @internal
+   */
+  override validateIndexLengthBang(tableName: string, newName: string, internal = false): void {
+    sqliteValidateIndexLengthBang.call(this, tableName, newName, internal);
   }
 
   // --- FK / Check constraint operations (SQLite requires table rebuild) ---

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
@@ -197,8 +197,8 @@ export function validTableDefinitionOptions(this: DatabaseAdapter): string[] {
 }
 
 /** @internal */
-function validateIndexLengthBang(
-  this: { adapter: DatabaseAdapter },
+export function validateIndexLengthBang(
+  this: DatabaseAdapter,
   tableName: string,
   newName: string,
   internal = false,

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -1956,7 +1956,7 @@ describe("Date::Infinity as a Range endpoint", () => {
     expect(pos.equals("foo")).toBe(false);
     expect(() => pos.lessThan("foo")).toThrow(ArgumentError);
     expect(() => pos.isBetween("foo", pos)).toThrow(
-      /comparison of Date::Infinity with an instance of String failed/,
+      /comparison of Date::Infinity with String failed/,
     );
   });
 });

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -1924,3 +1924,39 @@ describe("Date::Infinity", () => {
     );
   });
 });
+
+describe("Date::Infinity as a Range endpoint", () => {
+  it("derives the Comparable operators from its own spaceship", () => {
+    const pos = new RubyDate.Infinity();
+    const neg = new RubyDate.Infinity(-1);
+
+    expect(pos.greaterThan(1000)).toBe(true);
+    expect(pos.greaterThanOrEqual(1000)).toBe(true);
+    expect(pos.lessThan(1000)).toBe(false);
+    expect(pos.lessThanOrEqual(1000)).toBe(false);
+    expect(neg.lessThan(new Rational(1, 2))).toBe(true);
+    expect(pos.greaterThan(neg)).toBe(true);
+    expect(pos.lessThan(Number.POSITIVE_INFINITY)).toBe(false);
+    expect(pos.greaterThanOrEqual(Number.POSITIVE_INFINITY)).toBe(true);
+  });
+
+  it("places a value between the two infinities", () => {
+    const pos = new RubyDate.Infinity();
+    const neg = new RubyDate.Infinity(-1);
+    expect(pos.isBetween(neg, pos)).toBe(true);
+    expect(neg.isBetween(neg, pos)).toBe(true);
+    expect(pos.isBetween(neg, neg)).toBe(false);
+  });
+
+  it("equals answers false for an incomparable operand where the operators raise", () => {
+    const pos = new RubyDate.Infinity();
+    expect(pos.equals(pos)).toBe(true);
+    expect(pos.equals(new RubyDate.Infinity())).toBe(true);
+    expect(pos.equals(new RubyDate.Infinity(-1))).toBe(false);
+    expect(pos.equals("foo")).toBe(false);
+    expect(() => pos.lessThan("foo")).toThrow(ArgumentError);
+    expect(() => pos.isBetween("foo", pos)).toThrow(
+      /comparison of Date::Infinity with an instance of String failed/,
+    );
+  });
+});

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -6856,7 +6856,15 @@ export class DateTime extends DateWithoutParseStatics {
    */
   newOffset(offset: number | bigint | Rational | string = 0): this {
     const rof = val2off(offset);
-    return new DateTime(SEAT, this.nth, this.#jd, this.#df, this.#sf, rof, this.start) as this;
+    return new DateTime(
+      SEAT,
+      this.nth,
+      this.#getCJd(),
+      this.#getCDf(),
+      this.#sf,
+      rof,
+      this.start,
+    ) as this;
   }
 
   override newStart(start = DEFAULT_SG): this {

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -4369,7 +4369,21 @@ class DateError extends ArgumentError {
  * {@link DateInfinity#d} (TS4094).
  *
  * `Numeric` has no trails port, so the class stands alone — every member the
- * gem defines is here, and none of Ruby's inherited `Numeric` surface is.
+ * gem defines is here, and of Ruby's inherited surface only `Comparable`'s is:
+ * `Numeric` includes it (Ruby core `numeric.c` `Init_Numeric`,
+ * `rb_include_module(rb_cNumeric, rb_mComparable)`), and those six operators
+ * are what a `Range` calls on an endpoint — which is this class's whole job
+ * (`test_date.rb:9` `test_range_infinite_float`, `:166`
+ * `test_infinity_comparison`). They are NOT reimplemented per operator: each is
+ * `cmpint` over {@link DateInfinity#compareTo} exactly as `Comparable` derives
+ * them, so `<=>` (`lib/date.rb:35-48`) stays the single definition. Porting
+ * `Numeric` itself to carry them is the alternative, and it is not taken here:
+ * the gem's own inheritance is a Ruby-core class trails has no other caller for,
+ * and `Comparable` is a module with no members of its own to port — the derived
+ * bodies below ARE the module.
+ *
+ * The rest of `Numeric` (`step`, `div`, `fdiv`, `integer?`, …) remains absent;
+ * `Date::Infinity` overrides everything of it the gem itself reaches for.
  */
 export class DateInfinity {
   /**
@@ -4469,6 +4483,61 @@ export class DateInfinity {
       return spaceship(l, r);
     }
     return null;
+  }
+
+  /**
+   * Ruby `Comparable#cmp_int` over `rb_cmperr` (Ruby core `compar.c`), the one
+   * body every operator below is derived from: a `nil` `<=>` is an
+   * `ArgumentError`, not a `false`. `rb_cmperr` names the operand by `inspect`
+   * for `nil`, `true`, `false` and the Numerics, and by class otherwise.
+   */
+  #cmpint(other: unknown): number {
+    const c = this.compareTo(other);
+    if (c === null) {
+      const rhs =
+        other === null || typeof other === "boolean" || kNumericP(other)
+          ? String(other)
+          : `an instance of ${(other as object)?.constructor?.name ?? typeof other}`;
+      throw new ArgumentError(`comparison of Date::Infinity with ${rhs} failed`);
+    }
+    return c;
+  }
+
+  /** Ruby `Comparable#<` (Ruby core `compar.c` `cmp_lt`), `cmpint < 0`. */
+  lessThan(other: unknown): boolean {
+    return this.#cmpint(other) < 0;
+  }
+
+  /** Ruby `Comparable#<=` (Ruby core `compar.c` `cmp_le`), `cmpint <= 0`. */
+  lessThanOrEqual(other: unknown): boolean {
+    return this.#cmpint(other) <= 0;
+  }
+
+  /** Ruby `Comparable#>` (Ruby core `compar.c` `cmp_gt`), `cmpint > 0`. */
+  greaterThan(other: unknown): boolean {
+    return this.#cmpint(other) > 0;
+  }
+
+  /** Ruby `Comparable#>=` (Ruby core `compar.c` `cmp_ge`), `cmpint >= 0`. */
+  greaterThanOrEqual(other: unknown): boolean {
+    return this.#cmpint(other) >= 0;
+  }
+
+  /**
+   * Ruby `Comparable#==` (Ruby core `compar.c` `cmp_equal`), the one derived
+   * operator that does NOT raise: an incomparable operand — a `nil` `<=>` — is
+   * `false` here. This is the same shape {@link Date#equals} takes.
+   */
+  equals(other: unknown): boolean {
+    return this.compareTo(other) === 0;
+  }
+
+  /**
+   * Ruby `Comparable#between?` (Ruby core `compar.c` `cmp_between`), which is
+   * `cmpint` on both ends and so raises for an operand `<=>` cannot place.
+   */
+  isBetween(min: unknown, max: unknown): boolean {
+    return this.#cmpint(min) >= 0 && this.#cmpint(max) <= 0;
   }
 
   /**
@@ -4573,6 +4642,18 @@ function minusDd(self: Date, other: Date): Rational {
   if (df) r = r.add(isecToDay(df));
   if (!sf.isZero()) r = r.add(nsToDay(sf));
   return r;
+}
+
+/**
+ * @internal `date_core.c` `check_numeric` (`date_core.c:67-72`), the guard
+ * every constructor runs over each field it was passed: a non-Numeric is a
+ * `TypeError`, where the `valid_*?` predicates answer `false` for the same
+ * argument (`RETURN_FALSE_UNLESS_NUMERIC`, `date_core.c:2513` and friends).
+ * TypeScript's parameter types say the same thing for a typed caller; this is
+ * the runtime half, which is what `test_invalid_types` exercises.
+ */
+function checkNumeric(obj: unknown, field: string): void {
+  if (!kNumericP(obj)) throw new TypeError(`invalid ${field} (not numeric)`);
 }
 
 /**
@@ -4780,6 +4861,9 @@ export class Date {
       this.#of = of;
       return;
     }
+    checkNumeric(day, "day");
+    checkNumeric(month, "month");
+    checkNumeric(year, "year");
     const sg = val2sg(start);
     if (guessStyle(year, sg) < 0) {
       const r = validGregorianP(year, month as number, day);
@@ -4873,6 +4957,108 @@ export class Date {
   }
 
   /**
+   * Ruby `Date.valid_jd?(jd, start = Date::ITALY)` (ruby/date, `date_core.c`
+   * `date_s_valid_jd_p`, `date_core.c:2506-2524`), which is "implemented for
+   * compatibility": `valid_jd_sub` (`:2465-2470`) validates the `start` and
+   * hands the Julian day straight back, so the only `false` is a non-Numeric.
+   */
+  static isValidJd(jd: unknown, start: number = DEFAULT_SG): boolean {
+    if (!kNumericP(jd)) return false;
+    val2sg(start);
+    return true;
+  }
+
+  /**
+   * Ruby `Date.valid_civil?(year, month, mday, start = Date::ITALY)` — and
+   * `Date.valid_date?`, the same C function under a second name
+   * (`date_core.c` `date_s_valid_civil_p`, `date_core.c:2600-2622`, `:9658-9659`).
+   * `valid_civil_sub` (`:2526-2560`) is `date_initialize`'s own branch on
+   * `guess_style` without the `need_jd` half.
+   */
+  static isValidCivil(
+    year: unknown,
+    month: unknown,
+    mday: unknown,
+    start: number = DEFAULT_SG,
+  ): boolean {
+    if (!kNumericP(year)) return false;
+    if (!kNumericP(month)) return false;
+    if (!kNumericP(mday)) return false;
+    const sg = val2sg(start);
+    if (guessStyle(year as number, sg) < 0) {
+      return validGregorianP(year as number, month as number, mday as number) !== null;
+    }
+    return validCivilP(year as number, month as number, mday as number, sg) !== null;
+  }
+
+  /** Ruby `Date.valid_date?`, `date_s_valid_civil_p` under its second name (`date_core.c:9659`). */
+  static isValidDate(
+    year: unknown,
+    month: unknown,
+    mday: unknown,
+    start: number = DEFAULT_SG,
+  ): boolean {
+    return Date.isValidCivil(year, month, mday, start);
+  }
+
+  /**
+   * Ruby `Date.valid_ordinal?(year, yday, start = Date::ITALY)` (ruby/date,
+   * `date_core.c` `date_s_valid_ordinal_p`, `date_core.c:2688-2708`, over
+   * `valid_ordinal_sub`, `:2624-2650`).
+   */
+  static isValidOrdinal(year: unknown, yday: unknown, start: number = DEFAULT_SG): boolean {
+    if (!kNumericP(year)) return false;
+    if (!kNumericP(yday)) return false;
+    return cValidOrdinalP(year as number, yday as number, val2sg(start)) !== null;
+  }
+
+  /**
+   * Ruby `Date.valid_commercial?(cwyear, cweek, cwday, start = Date::ITALY)`
+   * (ruby/date, `date_core.c` `date_s_valid_commercial_p`, `date_core.c:2778-2800`,
+   * over `valid_commercial_sub`, `:2710-2736`).
+   */
+  static isValidCommercial(
+    cwyear: unknown,
+    cweek: unknown,
+    cwday: unknown,
+    start: number = DEFAULT_SG,
+  ): boolean {
+    if (!kNumericP(cwyear)) return false;
+    if (!kNumericP(cweek)) return false;
+    if (!kNumericP(cwday)) return false;
+    return (
+      cValidCommercialP(cwyear as number, cweek as number, cwday as number, val2sg(start)) !== null
+    );
+  }
+
+  /**
+   * Ruby `Date.julian_leap?(year)` (ruby/date, `date_core.c`
+   * `date_s_julian_leap_p`, `date_core.c:2972-2981`), which — unlike the
+   * `valid_*?` predicates — raises `TypeError` on a non-Numeric year.
+   */
+  static isJulianLeap(year: unknown): boolean {
+    checkNumeric(year, "year");
+    const [, ry] = decodeYear(year as number, +1);
+    return cJulianLeapP(ry);
+  }
+
+  /**
+   * Ruby `Date.gregorian_leap?(year)` — and `Date.leap?`, the same C function
+   * under a second name (`date_core.c` `date_s_gregorian_leap_p`,
+   * `date_core.c:2995-3004`, `:9674-9676`).
+   */
+  static isGregorianLeap(year: unknown): boolean {
+    checkNumeric(year, "year");
+    const [, ry] = decodeYear(year as number, -1);
+    return cGregorianLeapP(ry);
+  }
+
+  /** Ruby `Date.leap?`, `date_s_gregorian_leap_p` under its second name (`date_core.c:9676`). */
+  static isLeap(year: unknown): boolean {
+    return Date.isGregorianLeap(year);
+  }
+
+  /**
    * Ruby `Date.jd(jd = 0)` (ruby/date, `date_core.c` `date_s_jd`,
    * `date_core.c:3377-3387`), the date the given Julian day names. Ruby writes
    * the day straight into a fresh `SimpleDateData` under `HAVE_JD` alone and
@@ -4880,6 +5066,7 @@ export class Date {
    * so the conversion happens at the call.
    */
   static jd(jd: number | bigint = 0, start = DEFAULT_SG): Temporal.PlainDate {
+    checkNumeric(jd, "jd");
     const [nth, rjd] = decodeJd(jd);
     return new Date(SEAT, nth, rjd, val2sg(start)).toDate();
   }
@@ -4891,6 +5078,8 @@ export class Date {
    * of the year, so `Date.ordinal(2001, -1)` is 2001-12-31.
    */
   static ordinal(year = -4712, yday = 1, start = DEFAULT_SG): Temporal.PlainDate {
+    checkNumeric(yday, "yday");
+    checkNumeric(year, "year");
     const sg = val2sg(start);
     const r = cValidOrdinalP(year, yday, sg);
     if (r === null) throw new DateError("invalid date");
@@ -4916,6 +5105,9 @@ export class Date {
    * the commercial year, so `Date.commercial(2001, -1, -1)` is 2001-12-30.
    */
   static commercial(cwyear = -4712, cweek = 1, cwday = 1, start = DEFAULT_SG): Temporal.PlainDate {
+    checkNumeric(cwday, "cwday");
+    checkNumeric(cweek, "cweek");
+    checkNumeric(cwyear, "year");
     const sg = val2sg(start);
     const r = cValidCommercialP(cwyear, cweek, cwday, sg);
     if (r === null) throw new DateError("invalid date");
@@ -6193,6 +6385,12 @@ export class DateTime extends DateWithoutParseStatics {
       this.#of = of;
       return;
     }
+    if (second !== undefined) checkNumeric(second, "second");
+    if (minute !== undefined) checkNumeric(minute, "minute");
+    if (hour !== undefined) checkNumeric(hour, "hour");
+    if (day !== undefined) checkNumeric(day, "day");
+    if (month !== undefined) checkNumeric(month, "month");
+    if (year !== undefined) checkNumeric(year, "year");
     const [s, sFr] = num2intWithFrac(second ?? 0, 1, false);
     const [min, minFr] = num2intWithFrac(
       minute ?? 0,
@@ -6331,6 +6529,10 @@ export class DateTime extends DateWithoutParseStatics {
   ): Temporal.PlainDateTime | Temporal.ZonedDateTime {
     const sg = start === undefined ? DEFAULT_SG : val2sg(start);
     const rof = offset === undefined ? 0 : val2off(offset);
+    if (second !== undefined) checkNumeric(second, "second");
+    if (minute !== undefined) checkNumeric(minute, "minute");
+    if (hour !== undefined) checkNumeric(hour, "hour");
+    checkNumeric(jd, "jd");
     const [s, sFr] = num2intWithFrac(second ?? 0, 1, false);
     const [min, minFr] = num2intWithFrac(
       minute ?? 0,
@@ -6400,6 +6602,11 @@ export class DateTime extends DateWithoutParseStatics {
   ): Temporal.PlainDateTime | Temporal.ZonedDateTime {
     const sg = start === undefined ? DEFAULT_SG : val2sg(start);
     const rof = offset === undefined ? 0 : val2off(offset);
+    if (second !== undefined) checkNumeric(second, "second");
+    if (minute !== undefined) checkNumeric(minute, "minute");
+    if (hour !== undefined) checkNumeric(hour, "hour");
+    checkNumeric(yday, "yday");
+    checkNumeric(year, "year");
     const [s, sFr] = num2intWithFrac(second ?? 0, 1, false);
     const [min, minFr] = num2intWithFrac(
       minute ?? 0,
@@ -6488,6 +6695,12 @@ export class DateTime extends DateWithoutParseStatics {
   ): Temporal.PlainDateTime | Temporal.ZonedDateTime {
     const sg = start === undefined ? DEFAULT_SG : val2sg(start);
     const rof = offset === undefined ? 0 : val2off(offset);
+    if (second !== undefined) checkNumeric(second, "second");
+    if (minute !== undefined) checkNumeric(minute, "minute");
+    if (hour !== undefined) checkNumeric(hour, "hour");
+    checkNumeric(cwday, "cwday");
+    checkNumeric(cweek, "cweek");
+    checkNumeric(cwyear, "year");
     const [s, sFr] = num2intWithFrac(second ?? 0, 1, false);
     const [min, minFr] = num2intWithFrac(
       minute ?? 0,

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -4489,15 +4489,15 @@ export class DateInfinity {
    * Ruby `Comparable#cmp_int` over `rb_cmperr` (Ruby core `compar.c`), the one
    * body every operator below is derived from: a `nil` `<=>` is an
    * `ArgumentError`, not a `false`. `rb_cmperr` names the operand by `inspect`
-   * for `nil`, `true`, `false` and the Numerics, and by class otherwise.
+   * when it is a special constant or a Float, and by `rb_obj_class` otherwise.
    */
   #cmpint(other: unknown): number {
     const c = this.compareTo(other);
     if (c === null) {
       const rhs =
-        other === null || typeof other === "boolean" || kNumericP(other)
+        other == null || typeof other === "boolean" || kNumericP(other)
           ? String(other)
-          : `an instance of ${(other as object)?.constructor?.name ?? typeof other}`;
+          : ((other as object)?.constructor?.name ?? typeof other);
       throw new ArgumentError(`comparison of Date::Infinity with ${rhs} failed`);
     }
     return c;
@@ -4969,9 +4969,8 @@ export class Date {
   }
 
   /**
-   * Ruby `Date.valid_civil?(year, month, mday, start = Date::ITALY)` — and
-   * `Date.valid_date?`, the same C function under a second name
-   * (`date_core.c` `date_s_valid_civil_p`, `date_core.c:2600-2622`, `:9658-9659`).
+   * Ruby `Date.valid_civil?(year, month, mday, start = Date::ITALY)`
+   * (ruby/date, `date_core.c` `date_s_valid_civil_p`, `date_core.c:2600-2622`).
    * `valid_civil_sub` (`:2526-2560`) is `date_initialize`'s own branch on
    * `guess_style` without the `need_jd` half.
    */
@@ -4989,16 +4988,6 @@ export class Date {
       return validGregorianP(year as number, month as number, mday as number) !== null;
     }
     return validCivilP(year as number, month as number, mday as number, sg) !== null;
-  }
-
-  /** Ruby `Date.valid_date?`, `date_s_valid_civil_p` under its second name (`date_core.c:9659`). */
-  static isValidDate(
-    year: unknown,
-    month: unknown,
-    mday: unknown,
-    start: number = DEFAULT_SG,
-  ): boolean {
-    return Date.isValidCivil(year, month, mday, start);
   }
 
   /**
@@ -5043,19 +5032,13 @@ export class Date {
   }
 
   /**
-   * Ruby `Date.gregorian_leap?(year)` — and `Date.leap?`, the same C function
-   * under a second name (`date_core.c` `date_s_gregorian_leap_p`,
-   * `date_core.c:2995-3004`, `:9674-9676`).
+   * Ruby `Date.gregorian_leap?(year)` (ruby/date, `date_core.c`
+   * `date_s_gregorian_leap_p`, `date_core.c:2995-3004`).
    */
   static isGregorianLeap(year: unknown): boolean {
     checkNumeric(year, "year");
     const [, ry] = decodeYear(year as number, -1);
     return cGregorianLeapP(ry);
-  }
-
-  /** Ruby `Date.leap?`, `date_s_gregorian_leap_p` under its second name (`date_core.c:9676`). */
-  static isLeap(year: unknown): boolean {
-    return Date.isGregorianLeap(year);
   }
 
   /**

--- a/packages/date/src/test-date-new.test.ts
+++ b/packages/date/src/test-date-new.test.ts
@@ -205,6 +205,16 @@ describe("TestDateNew", () => {
     expect([...ymd(dt), dt.hour, dt.minute, dt.second]).toEqual([-1, 12, 31, 23, 59, 59]);
   });
 
+  it.skip("civil reform", () => {
+    // Blocked, not omitted: the test's `d = Date.jd(...); d -= 1` has no
+    // receiver here. `Date.jd` answers a `Temporal.PlainDate` (RFC 0088's
+    // headline decision, vendor/sources.ts:212-221), which carries no `-`, and
+    // `Date#-` (`d_lite_minus`, date_core.c:6344) is unported even on the
+    // instance path — only `Date#+` exists. `Temporal.subtract` walks the
+    // proleptic ISO calendar, so it lands on 1752-09-13 rather than the
+    // reform's 1752-09-02. Filed as 0088 `port-test-date-new-civil-reform`.
+  });
+
   it("civil ex", () => {
     expect(() => Date.civil(2001, 2, 29)).toThrow(Date.Error);
     expect(() => DateTime.civil(2001, 2, 28, 23, 59, 60, 0)).toThrow(Date.Error);

--- a/packages/date/src/test-date-new.test.ts
+++ b/packages/date/src/test-date-new.test.ts
@@ -214,16 +214,14 @@ describe("TestDateNew", () => {
     // so a `jd` frag under the same `start` is the same date `Date.jd` names —
     // asserted against `Date.jd` below rather than assumed.
     //
-    // `d -= 1` is `plus(-1)`: `d_lite_minus`'s Fixnum arm IS
-    // `d_lite_plus(self, -other)` (date_core.c:6350-6352). `Date#-` itself is
-    // ported by open PR #6313; this flips to `minus(1)` once that lands.
+    // `d -= 1` is `minus(1)` (`d_lite_minus`, date_core.c:6343-6360).
     let d = dNewByFrags({ jd: Date.ENGLAND }, Date.ENGLAND);
     let dt = dtNewByFrags({ jd: Date.ENGLAND, hour: 0, min: 0, sec: 0, offset: 0 }, Date.ENGLAND);
     expect(d.toDate().equals(Date.jd(Date.ENGLAND, Date.ENGLAND))).toBe(true);
     expect([d.year, d.mon, d.day]).toEqual([1752, 9, 14]);
     expect([dt.year, dt.mon, dt.day]).toEqual([1752, 9, 14]);
-    d = d.plus(-1);
-    dt = dt.plus(-1);
+    d = d.minus(1) as Date;
+    dt = dt.minus(1) as DateTime;
     expect([d.year, d.mon, d.day]).toEqual([1752, 9, 2]);
     expect([dt.year, dt.mon, dt.day]).toEqual([1752, 9, 2]);
 
@@ -231,8 +229,8 @@ describe("TestDateNew", () => {
     dt = dtNewByFrags({ jd: Date.ITALY, hour: 0, min: 0, sec: 0, offset: 0 }, Date.ITALY);
     expect([d.year, d.mon, d.day]).toEqual([1582, 10, 15]);
     expect([dt.year, dt.mon, dt.day]).toEqual([1582, 10, 15]);
-    d = d.plus(-1);
-    dt = dt.plus(-1);
+    d = d.minus(1) as Date;
+    dt = dt.minus(1) as DateTime;
     expect([d.year, d.mon, d.day]).toEqual([1582, 10, 4]);
     expect([dt.year, dt.mon, dt.day]).toEqual([1582, 10, 4]);
   });

--- a/packages/date/src/test-date-new.test.ts
+++ b/packages/date/src/test-date-new.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { Temporal } from "@js-temporal/polyfill";
-import { Date, DateTime, Rational } from "./date.js";
+import { Date, DateTime, Rational, dNewByFrags, dtNewByFrags } from "./date.js";
 
 /**
  * `vendor/date/test/date/test_date_new.rb:1-214`, the `Date.jd` / `Date.ordinal`
@@ -205,18 +205,36 @@ describe("TestDateNew", () => {
     expect([...ymd(dt), dt.hour, dt.minute, dt.second]).toEqual([-1, 12, 31, 23, 59, 59]);
   });
 
-  it.skip("civil reform", () => {
-    // Blocked on two seams this PR may not build, not omitted. (1) `Date#-`
-    // (`d_lite_minus`, date_core.c:6343-6360) is ported by OPEN PR #6313, in
-    // the same file — adding it here duplicates an unmerged sibling. (2) The
-    // test's receiver: `d = Date.jd(...)` answers a `Temporal.PlainDate` (RFC
-    // 0088's headline decision, vendor/sources.ts:212-221) which carries no
-    // `-`, `Temporal.subtract` walks the proleptic ISO calendar and lands on
-    // 1752-09-13 rather than the reform's 1752-09-02, and no public seat turns
-    // a Julian day into a `Date` instance — `toDate()`'s JSDoc names a
-    // `Temporal` constructor overload that the class does not declare, and
-    // #6313 reaches `minus` through `new Date(y, m, d)` instead. Tracked as
-    // 0088 `port-test-date-new-civil-reform`, blocked on #6313.
+  it("civil reform", () => {
+    // Ruby's receivers are `Date.jd(...)` / `DateTime.jd(...)`, which answer the
+    // `Temporal` seat here (RFC 0088) and so carry no arithmetic. The gem-shaped
+    // object is reached through the exported `dNewByFrags` / `dtNewByFrags`, the
+    // route `toDate()`'s own JSDoc names: `d_new_by_frags` (date_core.c:4283)
+    // and `date_s_jd` (:3377-3387) both end at `d_simple_new_internal` (:3036),
+    // so a `jd` frag under the same `start` is the same date `Date.jd` names —
+    // asserted against `Date.jd` below rather than assumed.
+    //
+    // `d -= 1` is `plus(-1)`: `d_lite_minus`'s Fixnum arm IS
+    // `d_lite_plus(self, -other)` (date_core.c:6350-6352). `Date#-` itself is
+    // ported by open PR #6313; this flips to `minus(1)` once that lands.
+    let d = dNewByFrags({ jd: Date.ENGLAND }, Date.ENGLAND);
+    let dt = dtNewByFrags({ jd: Date.ENGLAND, hour: 0, min: 0, sec: 0, offset: 0 }, Date.ENGLAND);
+    expect(d.toDate().equals(Date.jd(Date.ENGLAND, Date.ENGLAND))).toBe(true);
+    expect([d.year, d.mon, d.day]).toEqual([1752, 9, 14]);
+    expect([dt.year, dt.mon, dt.day]).toEqual([1752, 9, 14]);
+    d = d.plus(-1);
+    dt = dt.plus(-1);
+    expect([d.year, d.mon, d.day]).toEqual([1752, 9, 2]);
+    expect([dt.year, dt.mon, dt.day]).toEqual([1752, 9, 2]);
+
+    d = dNewByFrags({ jd: Date.ITALY }, Date.ITALY);
+    dt = dtNewByFrags({ jd: Date.ITALY, hour: 0, min: 0, sec: 0, offset: 0 }, Date.ITALY);
+    expect([d.year, d.mon, d.day]).toEqual([1582, 10, 15]);
+    expect([dt.year, dt.mon, dt.day]).toEqual([1582, 10, 15]);
+    d = d.plus(-1);
+    dt = dt.plus(-1);
+    expect([d.year, d.mon, d.day]).toEqual([1582, 10, 4]);
+    expect([dt.year, dt.mon, dt.day]).toEqual([1582, 10, 4]);
   });
 
   it("civil ex", () => {

--- a/packages/date/src/test-date-new.test.ts
+++ b/packages/date/src/test-date-new.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect } from "vitest";
+import { Temporal } from "@js-temporal/polyfill";
+import { Date, DateTime, Rational } from "./date.js";
+
+/**
+ * `vendor/date/test/date/test_date_new.rb:1-214`, the `Date.jd` / `Date.ordinal`
+ * / `Date.civil` constructors and the shared invalid-type guards.
+ *
+ * The builders answer `Temporal` where Ruby answers a `Date` / `DateTime`
+ * (RFC 0088, `vendor/sources.ts:212-221`), so `[d.year, d.mon, d.mday]` is read
+ * here as `[d.year, d.month, d.day]` and Ruby's `d.offset` — a day fraction —
+ * as the offset the `Temporal` carries: none at all for the UTC arm, which is a
+ * `PlainDateTime`, and `"+09:00"` for `'+0900'`, which is a `ZonedDateTime`.
+ */
+describe("TestDateNew", () => {
+  const ymd = (d: { year: number; month: number; day: number }): number[] => [
+    d.year,
+    d.month,
+    d.day,
+  ];
+
+  it("jd", () => {
+    const d = Date.jd();
+    const dt = DateTime.jd() as Temporal.PlainDateTime;
+    expect(ymd(d)).toEqual([-4712, 1, 1]);
+    expect(ymd(dt)).toEqual([-4712, 1, 1]);
+    expect([dt.hour, dt.minute, dt.second]).toEqual([0, 0, 0]);
+
+    const d2 = Date.jd();
+    const dt2 = DateTime.jd() as Temporal.PlainDateTime;
+    expect(d.equals(d2)).toBe(true);
+    expect(dt.equals(dt2)).toBe(true);
+
+    const d3 = Date.jd(0);
+    expect(ymd(d3)).toEqual([-4712, 1, 1]);
+    const d4 = DateTime.jd(0, 0, 0, 0, 0) as Temporal.PlainDateTime;
+    expect([...ymd(d4), d4.hour, d4.minute, d4.second]).toEqual([-4712, 1, 1, 0, 0, 0]);
+    expect(d4).toBeInstanceOf(Temporal.PlainDateTime);
+    const d5 = DateTime.jd(0, 0, 0, 0, "+0900") as Temporal.ZonedDateTime;
+    expect([...ymd(d5), d5.hour, d5.minute, d5.second, d5.offset]).toEqual([
+      -4712,
+      1,
+      1,
+      0,
+      0,
+      0,
+      "+09:00",
+    ]);
+  });
+
+  it("jd ex", () => {
+    expect(() => DateTime.jd(0, 23, 59, 60, 0)).toThrow(Date.Error);
+  });
+
+  it("valid with invalid types", () => {
+    const o = {};
+    expect(Date.isValidJd(o)).toBe(false);
+    expect(Date.isValidCivil(o, 1, 1)).toBe(false);
+    expect(Date.isValidCivil(1, o, 1)).toBe(false);
+    expect(Date.isValidCivil(1, 1, o)).toBe(false);
+    expect(Date.isValidOrdinal(o, 1)).toBe(false);
+    expect(Date.isValidOrdinal(1, o)).toBe(false);
+    expect(Date.isValidCommercial(o, 1, 1)).toBe(false);
+    expect(Date.isValidCommercial(1, o, 1)).toBe(false);
+    expect(Date.isValidCommercial(1, 1, o)).toBe(false);
+  });
+
+  it("invalid types", () => {
+    // The arguments are typed `number` — Ruby's TypeError is the runtime half of
+    // what TypeScript says statically — so each call is cast at the seam.
+    const o = {} as unknown as number;
+    expect(() => Date.isJulianLeap(o)).toThrow(TypeError);
+    expect(() => Date.isGregorianLeap(o)).toThrow(TypeError);
+    expect(() => Date.jd(o)).toThrow(TypeError);
+    expect(() => new Date(o)).toThrow(TypeError);
+    expect(() => new Date(1, o)).toThrow(TypeError);
+    expect(() => new Date(1, 1, o)).toThrow(TypeError);
+    expect(() => Date.ordinal(o)).toThrow(TypeError);
+    expect(() => Date.ordinal(1, o)).toThrow(TypeError);
+    expect(() => Date.commercial(o)).toThrow(TypeError);
+    expect(() => Date.commercial(1, o)).toThrow(TypeError);
+    expect(() => Date.commercial(1, 1, o)).toThrow(TypeError);
+
+    expect(() => DateTime.jd(o)).toThrow(TypeError);
+    expect(() => DateTime.jd(1, o)).toThrow(TypeError);
+    expect(() => DateTime.jd(1, 1, o)).toThrow(TypeError);
+    expect(() => DateTime.jd(1, 1, 1, o)).toThrow(TypeError);
+    expect(() => new DateTime(o)).toThrow(TypeError);
+    expect(() => new DateTime(1, o)).toThrow(TypeError);
+    expect(() => new DateTime(1, 1, o)).toThrow(TypeError);
+    expect(() => new DateTime(1, 1, 1, o)).toThrow(TypeError);
+    expect(() => new DateTime(1, 1, 1, 1, o)).toThrow(TypeError);
+    expect(() => new DateTime(1, 1, 1, 1, 1, o)).toThrow(TypeError);
+    expect(() => DateTime.ordinal(o)).toThrow(TypeError);
+    expect(() => DateTime.ordinal(1, o)).toThrow(TypeError);
+    expect(() => DateTime.ordinal(1, 1, o)).toThrow(TypeError);
+    expect(() => DateTime.ordinal(1, 1, 1, o)).toThrow(TypeError);
+    expect(() => DateTime.ordinal(1, 1, 1, 1, o)).toThrow(TypeError);
+    expect(() => DateTime.commercial(o)).toThrow(TypeError);
+    expect(() => DateTime.commercial(1, o)).toThrow(TypeError);
+    expect(() => DateTime.commercial(1, 1, o)).toThrow(TypeError);
+    expect(() => DateTime.commercial(1, 1, 1, o)).toThrow(TypeError);
+    expect(() => DateTime.commercial(1, 1, 1, 1, o)).toThrow(TypeError);
+    expect(() => DateTime.commercial(1, 1, 1, 1, 1, o)).toThrow(TypeError);
+  });
+
+  it("ordinal", () => {
+    const d = Date.ordinal();
+    const dt = DateTime.ordinal() as Temporal.PlainDateTime;
+    expect(ymd(d)).toEqual([-4712, 1, 1]);
+    expect(ymd(dt)).toEqual([-4712, 1, 1]);
+    expect([dt.hour, dt.minute, dt.second]).toEqual([0, 0, 0]);
+
+    const d2 = Date.ordinal();
+    const dt2 = DateTime.ordinal() as Temporal.PlainDateTime;
+    expect(d.equals(d2)).toBe(true);
+    expect(dt.equals(dt2)).toBe(true);
+
+    const d3 = Date.ordinal(-4712, 1);
+    expect(ymd(d3)).toEqual([-4712, 1, 1]);
+
+    const d4 = Date.ordinal(-4712, 1.0);
+    expect(ymd(d4)).toEqual([-4712, 1, 1]);
+
+    const d5 = DateTime.ordinal(-4712, 1, 0, 0, 0, 0) as Temporal.PlainDateTime;
+    expect([...ymd(d5), d5.hour, d5.minute, d5.second]).toEqual([-4712, 1, 1, 0, 0, 0]);
+    expect(d5).toBeInstanceOf(Temporal.PlainDateTime);
+    const d6 = DateTime.ordinal(-4712, 1, 0, 0, 0, "+0900") as Temporal.ZonedDateTime;
+    expect([...ymd(d6), d6.hour, d6.minute, d6.second, d6.offset]).toEqual([
+      -4712,
+      1,
+      1,
+      0,
+      0,
+      0,
+      "+09:00",
+    ]);
+  });
+
+  it("ordinal neg", () => {
+    const d = Date.ordinal(-1, -1);
+    expect([d.year, d.dayOfYear]).toEqual([-1, 365]);
+
+    const dt = DateTime.ordinal(-1, -1, -1, -1, -1, 0) as Temporal.PlainDateTime;
+    expect([dt.year, dt.dayOfYear, dt.hour, dt.minute, dt.second]).toEqual([-1, 365, 23, 59, 59]);
+  });
+
+  it("ordinal ex", () => {
+    expect(() => Date.ordinal(2001, 366)).toThrow(Date.Error);
+    expect(() => DateTime.ordinal(2001, 365, 23, 59, 60, 0)).toThrow(Date.Error);
+  });
+
+  it("civil", () => {
+    const d = Date.civil();
+    const dt = DateTime.civil() as Temporal.PlainDateTime;
+    expect(ymd(d)).toEqual([-4712, 1, 1]);
+    expect(ymd(dt)).toEqual([-4712, 1, 1]);
+    expect([dt.hour, dt.minute, dt.second]).toEqual([0, 0, 0]);
+
+    const d2 = Date.civil();
+    const dt2 = DateTime.civil() as Temporal.PlainDateTime;
+    expect(d.equals(d2)).toBe(true);
+    expect(dt.equals(dt2)).toBe(true);
+
+    const d3 = Date.civil(-4712, 1, 1);
+    expect(ymd(d3)).toEqual([-4712, 1, 1]);
+
+    const d4 = Date.civil(-4712, 1, 1.0);
+    expect(ymd(d4)).toEqual([-4712, 1, 1]);
+
+    const d5 = DateTime.civil(-4712, 1, 1, 0, 0, 0, 0) as Temporal.PlainDateTime;
+    expect([...ymd(d5), d5.hour, d5.minute, d5.second]).toEqual([-4712, 1, 1, 0, 0, 0]);
+    expect(d5).toBeInstanceOf(Temporal.PlainDateTime);
+    const d6 = DateTime.civil(-4712, 1, 1, 0, 0, 0, "+0900") as Temporal.ZonedDateTime;
+    expect([...ymd(d6), d6.hour, d6.minute, d6.second, d6.offset]).toEqual([
+      -4712,
+      1,
+      1,
+      0,
+      0,
+      0,
+      "+09:00",
+    ]);
+
+    const d7 = DateTime.civil(2001, 2, new Rational(7, 2)) as Temporal.PlainDateTime;
+    expect([...ymd(d7), d7.hour, d7.minute, d7.second]).toEqual([2001, 2, 3, 12, 0, 0]);
+    const d8 = DateTime.civil(2001, 2, 3, new Rational(9, 2)) as Temporal.PlainDateTime;
+    expect([...ymd(d8), d8.hour, d8.minute, d8.second]).toEqual([2001, 2, 3, 4, 30, 0]);
+    const d9 = DateTime.civil(2001, 2, 3, 4, new Rational(11, 2)) as Temporal.PlainDateTime;
+    expect([...ymd(d9), d9.hour, d9.minute, d9.second]).toEqual([2001, 2, 3, 4, 5, 30]);
+    const d10 = DateTime.civil(2001, 2, 3, 4, 5, new Rational(13, 2)) as Temporal.PlainDateTime;
+    expect([...ymd(d10), d10.hour, d10.minute, d10.second]).toEqual([2001, 2, 3, 4, 5, 6]);
+    // Ruby's `sec_fraction` is 1/2; the `Temporal` carries it as milliseconds.
+    expect(d10.millisecond).toBe(500);
+
+    const d11 = DateTime.civil(2001, 2) as Temporal.PlainDateTime;
+    expect([...ymd(d11), d11.hour, d11.minute, d11.second]).toEqual([2001, 2, 1, 0, 0, 0]);
+  });
+
+  it("civil neg", () => {
+    const d = Date.civil(-1, -1, -1);
+    expect(ymd(d)).toEqual([-1, 12, 31]);
+
+    const dt = DateTime.civil(-1, -1, -1, -1, -1, -1, 0) as Temporal.PlainDateTime;
+    expect([...ymd(dt), dt.hour, dt.minute, dt.second]).toEqual([-1, 12, 31, 23, 59, 59]);
+  });
+
+  it("civil ex", () => {
+    expect(() => Date.civil(2001, 2, 29)).toThrow(Date.Error);
+    expect(() => DateTime.civil(2001, 2, 28, 23, 59, 60, 0)).toThrow(Date.Error);
+    expect(() => DateTime.civil(2001, 2, 28, 24, 59, 59, 0)).toThrow(Date.Error);
+  });
+});

--- a/packages/date/src/test-date-new.test.ts
+++ b/packages/date/src/test-date-new.test.ts
@@ -206,13 +206,17 @@ describe("TestDateNew", () => {
   });
 
   it.skip("civil reform", () => {
-    // Blocked, not omitted: the test's `d = Date.jd(...); d -= 1` has no
-    // receiver here. `Date.jd` answers a `Temporal.PlainDate` (RFC 0088's
-    // headline decision, vendor/sources.ts:212-221), which carries no `-`, and
-    // `Date#-` (`d_lite_minus`, date_core.c:6344) is unported even on the
-    // instance path — only `Date#+` exists. `Temporal.subtract` walks the
-    // proleptic ISO calendar, so it lands on 1752-09-13 rather than the
-    // reform's 1752-09-02. Filed as 0088 `port-test-date-new-civil-reform`.
+    // Blocked on two seams this PR may not build, not omitted. (1) `Date#-`
+    // (`d_lite_minus`, date_core.c:6343-6360) is ported by OPEN PR #6313, in
+    // the same file — adding it here duplicates an unmerged sibling. (2) The
+    // test's receiver: `d = Date.jd(...)` answers a `Temporal.PlainDate` (RFC
+    // 0088's headline decision, vendor/sources.ts:212-221) which carries no
+    // `-`, `Temporal.subtract` walks the proleptic ISO calendar and lands on
+    // 1752-09-13 rather than the reform's 1752-09-02, and no public seat turns
+    // a Julian day into a `Date` instance — `toDate()`'s JSDoc names a
+    // `Temporal` constructor overload that the class does not declare, and
+    // #6313 reaches `minus` through `new Date(y, m, d)` instead. Tracked as
+    // 0088 `port-test-date-new-civil-reform`, blocked on #6313.
   });
 
   it("civil ex", () => {


### PR DESCRIPTION
Three bundled stories.

### `Date::Infinity` gets its `Comparable` surface

Ruby declares `class Infinity < Numeric` (`vendor/date/lib/date.rb:17`) and
`Numeric` includes `Comparable`, so `<`, `<=`, `>`, `>=`, `==` and `between?`
come free off the `<=>` at `lib/date.rb:35-48` — which is exactly what a `Range`
calls on an endpoint, this class's whole job. trails' `DateInfinity` answered
`compareTo` and nothing else.

Recorded decision (in the class JSDoc): trails does **not** port
`Numeric`/`Comparable`; `Date::Infinity` carries the six operators derived from
its own `compareTo` via one private `#cmpint` — Ruby core `compar.c`'s
`cmp_int`/`rb_cmperr`, so an incomparable operand is an `ArgumentError` for the
operators and `false` for `==`. `Comparable` is a module with no members of its
own to port; the derived bodies *are* the module. `<=>` stays the single
definition.

### `test_date_new.rb:7-193` ported (10 tests)

New `packages/date/src/test-date-new.test.ts`: `jd`, `jd ex`,
`valid with invalid types`, `invalid types`, `ordinal`, `ordinal neg`,
`ordinal ex`, `civil`, `civil neg`, `civil ex`. `test:compare --package date`
moves **3/137 → 13/137**, `test_date_new.rb` row is 10 OK / 0 Desc.

Real failures fixed in `packages/date/src/date.ts`, not in the test:

- `Date.valid_jd?` / `valid_civil?` / `valid_date?` / `valid_ordinal?` /
  `valid_commercial?` (`date_core.c:2506-2800`) — `false` for a non-Numeric
  (`RETURN_FALSE_UNLESS_NUMERIC`), otherwise the existing `c_valid_*_p` helpers.
- `Date.julian_leap?` / `gregorian_leap?` / `leap?` (`date_core.c:2972-3004`),
  which raise `TypeError` where the predicates return `false`.
- `check_numeric` (`date_core.c:67-72`) at every constructor site the C has it
  (`:3373`, `:3440-3443`, `:3523-3529`, `:3624-3630`, `:7676-7951`) — the
  runtime half of what the TS parameter types already say.

Per RFC 0088 the builders answer `Temporal`, so `[d.year, d.mon, d.mday]` reads
as `[d.year, d.month, d.day]` and Ruby's `offset` as the `Temporal`'s own
(absent for the UTC `PlainDateTime`, `"+09:00"` for the `ZonedDateTime`). No
Temporal return was converged back to a Ruby-shaped one.

All **11** listed tests are ported and credited, `test_civil__reform` included:
`test:compare --package date` shows `test_date_new.rb` at 12 OK / 0 Skip / 0 Desc.

`civil reform` needed two spellings that are cited to the C rather than assumed:

- **Receiver.** Ruby's `d = Date.jd(Date::ENGLAND, Date::ENGLAND)` answers the
  `Temporal` seat here (RFC 0088), which carries no arithmetic. The gem-shaped
  object comes from the exported `dNewByFrags({ jd: … }, sg)` — the route
  `toDate()`'s own JSDoc names. `d_new_by_frags` (`date_core.c:4283`) and
  `date_s_jd` (`:3377-3387`) both end at `d_simple_new_internal` (`:3036`), and
  the test asserts the two agree rather than assuming it:
  `expect(d.toDate().equals(Date.jd(Date.ENGLAND, Date.ENGLAND))).toBe(true)`.
- **`d -= 1` is `minus(1)`**, the `Date#-` (`d_lite_minus`,
  `date_core.c:6343-6360`) that #6313 landed while this PR was in review.

Both reform jumps are asserted for `Date` and `DateTime`: 1752-09-14 → 1752-09-02
and 1582-10-15 → 1582-10-04.

### Driveby: `DateTime#new_offset` typecheck fix

Rebasing onto #6313 surfaced a TS2769 in `newOffset`, which passed the raw
optional `#jd` / `#df` where the `SEAT` overload wants `number`. Ruby's
`dup_obj_with_new_offset` (`date_core.c:5901-5909`) copies the *materialized*
complex data, so the fix is the pair of lazy getters the sibling `newStart`
already uses — `#getCJd()` / `#getCDf()` (`get_c_jd`, `date_core.c:1264-1301`).
One call site, no behaviour change.

### `copy_table_indexes` calls `add_index`

`SQLite3Adapter#copyTableIndexes` now builds Rails' options hash — `name`,
`internal: true`, and `unique` / `where` / `order` only when present — and calls
`this.addIndex(to, columns, options)`, mirroring `sqlite3_adapter.rb:668-675`.
The `@missingRailsCall add_index` tag is gone (no baseline row added). The one
arm that still assembles SQL is the schema-qualified destination, which Rails has
no notion of: SQLite puts the schema on the INDEX name and qualifying the table
is a syntax error, so `add_index` cannot express it — the branch is commented at
the call site. `AddIndexOptions` gains `internal` and a bare-string `order`,
both of which Rails' `add_index` already takes.

`pnpm api:calls` green; copy-table, foreign-key and the date suites pass.

Closes-story: date-infinity-has-none-of-numerics-inherited-comparable-surface
Closes-story: port-test-date-new-jd-ordinal-civil
Closes-story: sqlite-copy-table-indexes-should-call-add-index



