### PR TITLE
fix(parity): percent-escape descriptor delimiters inside a call-argument string value

### DIFF
--- a/scripts/api-compare/call-args.test.ts
+++ b/scripts/api-compare/call-args.test.ts
@@ -93,9 +93,6 @@ describe("normalizeArg", () => {
     expect(normalizeArg("kwargs{opts=kwargs{k=str-interp}}")).toBeNull();
   });
 
-  // The delimiters both extractors escape inside a `str:` payload. Unescaped, a
-  // comma splits the kwargs body into a fragment with no `=` and the whole call
-  // site is silently skipped — the SQL-fragment arguments RFC 0095 §2 is for.
   it("unescapes a descriptor delimiter inside a string value", () => {
     expect(normalizeArg("str:%2C ")).toBe("str:, ");
     expect(normalizeArg("str:a%3Db%7Bc%7Dd")).toBe("str:a=b{c}d");

--- a/scripts/api-compare/call-args.test.ts
+++ b/scripts/api-compare/call-args.test.ts
@@ -93,6 +93,21 @@ describe("normalizeArg", () => {
     expect(normalizeArg("kwargs{opts=kwargs{k=str-interp}}")).toBeNull();
   });
 
+  // The delimiters both extractors escape inside a `str:` payload. Unescaped, a
+  // comma splits the kwargs body into a fragment with no `=` and the whole call
+  // site is silently skipped — the SQL-fragment arguments RFC 0095 §2 is for.
+  it("unescapes a descriptor delimiter inside a string value", () => {
+    expect(normalizeArg("str:%2C ")).toBe("str:, ");
+    expect(normalizeArg("str:a%3Db%7Bc%7Dd")).toBe("str:a=b{c}d");
+    expect(normalizeArg("str:100%25")).toBe("str:100%");
+  });
+
+  it("splits kwargs on the delimiters a string value does not carry", () => {
+    expect(normalizeArg("kwargs{last_word_connector=str:%2C or ,sep=str:a%3Db%7Bc%7Dd}")).toBe(
+      "kwargs{lastWordConnector=str:, or ,sep=str:a=b{c}d}",
+    );
+  });
+
   it("is uncomparable for a double-splat kwarg", () => {
     expect(normalizeArg("kwargs{**splat}")).toBeNull();
   });

--- a/scripts/api-compare/call-args.ts
+++ b/scripts/api-compare/call-args.ts
@@ -131,7 +131,10 @@ function normalizeLiteralArg(kind: LiteralValue["kind"], value: string): string 
 }
 
 /** Split a `kwargs{…}` body on its TOP-LEVEL commas — a value can itself be a
- *  `kwargs{…}`, whose commas are not separators. */
+ *  `kwargs{…}`, whose commas are not separators. A `,` inside a `str:` payload
+ *  is not one either, and never reaches here: both extractors percent-escape
+ *  the four grammar delimiters (extract-ruby-api.rb#escape_descriptor_text,
+ *  extract-ts-api.ts#escapeDescriptorText). */
 function splitPairs(body: string): string[] {
   const pairs: string[] = [];
   let depth = 0;
@@ -147,6 +150,21 @@ function splitPairs(body: string): string[] {
   }
   pairs.push(body.slice(start));
   return pairs;
+}
+
+/**
+ * Undo the extractors' delimiter escaping, once the descriptor has been split
+ * down to a single payload.
+ *
+ * Percent- rather than backslash-escaped, because a `str:` payload's backslash
+ * is NOT free: literals.ts#normalizeLiteral canonicalizes `\n` and friends, so a
+ * backslash escape here would consume the marker that arm reads and `"\\n"`
+ * would stop comparing equal to a real newline.
+ */
+function unescapeDescriptorText(text: string): string {
+  return text.replace(/%(25|2C|3D|7B|7D)/g, (_, hex: string) =>
+    String.fromCharCode(parseInt(hex, 16)),
+  );
 }
 
 /** Keys go through options-keys.ts#normalizeRubyKey — the same pipeline the
@@ -191,7 +209,9 @@ export function normalizeArg(descriptor: string): string | null {
   if (kind === "id" || kind === "call") return `ref:${normalizeRef(value)}`;
   if (kind === "const") return `const:${value}`;
   const literalKind = LITERAL_KINDS[kind];
-  return literalKind === undefined ? null : normalizeLiteralArg(literalKind, value);
+  return literalKind === undefined
+    ? null
+    : normalizeLiteralArg(literalKind, unescapeDescriptorText(value));
 }
 
 /** Normalize a whole argument list, or null when any member is opaque. */

--- a/scripts/api-compare/call-args.ts
+++ b/scripts/api-compare/call-args.ts
@@ -156,6 +156,12 @@ function splitPairs(body: string): string[] {
  * Undo the extractors' delimiter escaping, once the descriptor has been split
  * down to a single payload.
  *
+ * The descriptor grammar is a FLAT string split on `,` `=` `{` `}`, and a string
+ * value can contain every one of them — `injectJoin(list, collector, ", ")`.
+ * Unescaped, that comma splits a `kwargs{…}` into a fragment with no `=` and the
+ * whole call site is silently dropped as uncomparable, losing exactly the
+ * SQL-fragment arguments RFC 0095 §2 calls load-bearing.
+ *
  * Percent- rather than backslash-escaped, because a `str:` payload's backslash
  * is NOT free: literals.ts#normalizeLiteral canonicalizes `\n` and friends, so a
  * backslash escape here would consume the marker that arm reads and `"\\n"`

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -2480,15 +2480,8 @@ class ApiExtractor
     "str:#{escape_descriptor_text(parts.map { |p| p[1] }.join)}"
   end
 
-  # The descriptor grammar is a FLAT string the comparator splits on `,` `=` `{`
-  # `}` (call-args.ts#splitPairs), and a string value can contain every one of
-  # them — `to_sentence(last_word_connector: ", or ")`. Unescaped, that comma
-  # splits `kwargs{…}` into a fragment with no `=` and the whole call site is
-  # silently dropped as uncomparable, losing exactly the SQL-fragment arguments
-  # RFC 0095 §2 calls load-bearing. call-args.ts unescapes after splitting.
-  #
-  # Percent- rather than backslash-escaped so the payload's own backslash
-  # escapes stay intact for literals.ts#normalizeLiteral.
+  # The four grammar delimiters, so a string VALUE carrying one does not read as
+  # one. Rationale and the inverse: call-args.ts#unescapeDescriptorText.
   def escape_descriptor_text(text)
     text.gsub(/[%,={}]/) { |c| format("%%%02X", c.ord) }
   end

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -2477,7 +2477,20 @@ class ApiExtractor
     return "?" unless parts.is_a?(Array)
     return "str:" if parts.empty?
     return "str-interp" unless parts.all? { |p| p.is_a?(Array) && p[0] == :@tstring_content }
-    "str:#{parts.map { |p| p[1] }.join}"
+    "str:#{escape_descriptor_text(parts.map { |p| p[1] }.join)}"
+  end
+
+  # The descriptor grammar is a FLAT string the comparator splits on `,` `=` `{`
+  # `}` (call-args.ts#splitPairs), and a string value can contain every one of
+  # them — `to_sentence(last_word_connector: ", or ")`. Unescaped, that comma
+  # splits `kwargs{…}` into a fragment with no `=` and the whole call site is
+  # silently dropped as uncomparable, losing exactly the SQL-fragment arguments
+  # RFC 0095 §2 calls load-bearing. call-args.ts unescapes after splitting.
+  #
+  # Percent- rather than backslash-escaped so the payload's own backslash
+  # escapes stay intact for literals.ts#normalizeLiteral.
+  def escape_descriptor_text(text)
+    text.gsub(/[%,={}]/) { |c| format("%%%02X", c.ord) }
   end
 
   # A braced `{ … }` is the ObjectLiteralExpression the port writes, and the TS

--- a/scripts/api-compare/extract-ruby-api.test.ts
+++ b/scripts/api-compare/extract-ruby-api.test.ts
@@ -1500,6 +1500,23 @@ describe("Ruby extractor call-argument capture", () => {
     ]);
   });
 
+  it("escapes a descriptor delimiter inside a string value", () => {
+    const c = rubyCallArgs({
+      "foo.rb": `
+        class Foo
+          def m(list, collector)
+            inject_join(list, collector, ", ")
+            to_sentence(last_word_connector: ", or ", sep: "a=b{c}d")
+          end
+        end
+      `,
+    });
+    expect(argsOf(c["Foo#m"], "inject_join")).toEqual(["id:list", "id:collector", "str:%2C "]);
+    expect(argsOf(c["Foo#m"], "to_sentence")).toEqual([
+      "kwargs{last_word_connector=str:%2C or ,sep=str:a%3Db%7Bc%7Dd}",
+    ]);
+  });
+
   it("recurses into a nested keyword hash", () => {
     const c = rubyCallArgs({
       "foo.rb": `

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -2865,6 +2865,26 @@ describe("callArgs", () => {
   const site = (source: string, method = "create"): CallSite[] =>
     extractFromSource(source).instanceMethods.find((m) => m.name === method)!.callArgs!;
 
+  it("escapes a descriptor delimiter inside a string value", () => {
+    expect(
+      site(
+        `class Foo {
+          create() {
+            this.injectJoin(list, collector, ", ");
+            this.toSentence({ lastWordConnector: ", or ", sep: "a=b{c}d" });
+          }
+        }`,
+      ),
+    ).toEqual([
+      { name: "injectJoin", args: ["id:list", "id:collector", "str:%2C "], flags: [] },
+      {
+        name: "toSentence",
+        args: ["kwargs{lastWordConnector=str:%2C or ,sep=str:a%3Db%7Bc%7Dd}"],
+        flags: [],
+      },
+    ]);
+  });
+
   it("records one entry per syntactic call site, in source order", () => {
     const sites = site(
       `class Foo {

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -2831,6 +2831,20 @@ function unwrapArg(node: ts.Expression): ts.Expression {
   }
 }
 
+/**
+ * Mirrors extract-ruby-api.rb#escape_descriptor_text. The descriptor grammar is
+ * a FLAT string the comparator splits on `,` `=` `{` `}`
+ * (call-args.ts#splitPairs), and a string value can contain every one of them —
+ * `injectJoin(list, collector, ", ")`. Unescaped, that comma splits a
+ * `kwargs{…}` into a fragment with no `=` and the whole call site is silently
+ * dropped as uncomparable, losing exactly the SQL-fragment arguments RFC 0095
+ * §2 calls load-bearing. Percent- rather than backslash-escaped so the payload's
+ * own backslash escapes stay intact for literals.ts#normalizeLiteral.
+ */
+function escapeDescriptorText(text: string): string {
+  return text.replace(/[%,={}]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`);
+}
+
 function describeArg(node: ts.Expression, flags: string[]): string {
   const expr = unwrapArg(node);
   if (ts.isIdentifier(expr)) {
@@ -2840,7 +2854,7 @@ function describeArg(node: ts.Expression, flags: string[]): string {
   if (expr.kind === ts.SyntaxKind.ThisKeyword) return "id:this";
   if (ts.isNumericLiteral(expr) || ts.isBigIntLiteral(expr)) return `num:${expr.text}`;
   if (ts.isStringLiteral(expr) || ts.isNoSubstitutionTemplateLiteral(expr))
-    return `str:${expr.text}`;
+    return `str:${escapeDescriptorText(expr.text)}`;
   if (ts.isTemplateExpression(expr)) return "str-interp";
   if (expr.kind === ts.SyntaxKind.TrueKeyword) return "bool:true";
   if (expr.kind === ts.SyntaxKind.FalseKeyword) return "bool:false";

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -2832,14 +2832,9 @@ function unwrapArg(node: ts.Expression): ts.Expression {
 }
 
 /**
- * Mirrors extract-ruby-api.rb#escape_descriptor_text. The descriptor grammar is
- * a FLAT string the comparator splits on `,` `=` `{` `}`
- * (call-args.ts#splitPairs), and a string value can contain every one of them —
- * `injectJoin(list, collector, ", ")`. Unescaped, that comma splits a
- * `kwargs{…}` into a fragment with no `=` and the whole call site is silently
- * dropped as uncomparable, losing exactly the SQL-fragment arguments RFC 0095
- * §2 calls load-bearing. Percent- rather than backslash-escaped so the payload's
- * own backslash escapes stay intact for literals.ts#normalizeLiteral.
+ * Mirrors extract-ruby-api.rb#escape_descriptor_text: the four grammar
+ * delimiters, so a string VALUE carrying one does not read as one. Rationale
+ * and the inverse: call-args.ts#unescapeDescriptorText.
  */
 function escapeDescriptorText(text: string): string {
   return text.replace(/[%,={}]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`);

--- a/scripts/api-compare/extractor-schema.ts
+++ b/scripts/api-compare/extractor-schema.ts
@@ -41,7 +41,7 @@ import { hashParts } from "@blazetrails/parity/shared-cache";
  * ADDITIONS bump the token on their own (via {@link EXTRACTOR_OUTPUT_FIELDS} and
  * the source-hash inputs), so you rarely need to touch this by hand.
  */
-export const SCHEMA_VERSION_BASE = 9;
+export const SCHEMA_VERSION_BASE = 10;
 
 /**
  * Every per-method field the extractor can emit (mirrors `MethodInfo` in


### PR DESCRIPTION
Bundle of two RFC 0095 stories. One ships a fix; the other is blocked on an
unmerged dependency and is handed back with the blocker recorded.

## call-args-kwargs-string-comma-splitting — fixed

`call-args.ts#splitPairs` split a `kwargs{…}` descriptor on its top-level
commas while the descriptor grammar had no string boundaries at all: both
extractors emitted a string value as a bare, unquoted, unescaped `str:<text>`.
So `to_sentence(last_word_connector: ", or ")` split into `sep=str:` plus a
fragment with no `=`, `normalizeKwargs` returned null, and the **whole call
site** was silently skipped as uncomparable — an under-approximation, but it
dropped exactly the SQL-fragment arguments RFC 0095 §2 calls load-bearing.

**AC1 — the count, before the fix** (skip-reason tally over `rails-api.json` /
`ts-api.json` `callArgs`, 50 233 Ruby and 76 326 TS call sites):

| package    | sites lost |
| ---------- | ---------: |
| arel       |          0 |
| activerecord |        2 | (`associations/errors.rb#initialize` → `to_sentence`, both classes in the file) |
| trailties  |          5 | (`class_option` desc strings) |
| TS side    |          0 |

Non-zero, so AC2 applies.

**AC2/AC3 — the grammar.** Both extractors percent-escape `%` `,` `=` `{` `}`
inside a `str:` payload (`extract-ruby-api.rb#escape_descriptor_text`,
`extract-ts-api.ts#escapeDescriptorText`) and `call-args.ts` unescapes once the
descriptor is split down to a single payload. The grammar stays a flat string,
so `call-args-ratchet-and-ci-step` can still key a baseline row on `rubyArgs` as
text. Not JSON, per the story.

Percent- rather than backslash-escaped: `literals.ts#normalizeLiteral` already
owns the payload's own backslash escapes (`\n` and friends), and a backslash
marker here would consume them — the existing
`canonicalizes an escape through literals.ts` test catches it.

A test per side covers a string value containing each escaped character.

**AC4 — cache invalidation.** `callArgs`' value encoding changed while its key
stayed the same, which is exactly what `SCHEMA_VERSION_BASE` is for → bumped
9 → 10. The extractor source hashes and the Ruby manifest's `.rb` content hash
are the independent backstops.

**Verification.** `API_COMPARE_FORCE=1 pnpm api:compare --calls` — every total
identical (parity 75%, arity 7941/8032, option keys 112/17/72, literals 626/1,
calls 6213/1494). Post-fix tally: **0 lost sites in every package**, with
6 (arel) / 132 (activerecord) / … escaped descriptors now flowing through.
`pnpm api:calls` OK. `scripts/api-compare/` suite: 1010 passing.

## call-args-arel-population-recheck — blocked, not in this PR

AC1 requires `output/call-arg-mismatches.json` "under the shipped pairing", and
`call-args-artifact-and-report` is `status=blocked` and unstarted — the artifact
does not exist.

A throwaway harness cannot substitute. The ±3x spread the story tabulates is in
the per-**site** pairing policy *within* a name-matched method pair, and that
policy is still unchosen: the artifact story's AC only fixes the **method**
pairing (reuse the `checkCalls` pair). Any number produced now would be a fifth
policy, not the shipped one — and AC4 forbids comparator behavior change here,
so choosing one is out of scope.

Recorded via `pnpm tasks block` with that reasoning. One data point carried
forward for whoever picks it up: the comma-splitting loss above is **zero on
arel**, so it does not move the arel recheck number in either direction.

Closes-story: call-args-kwargs-string-comma-splitting
