### PR TITLE
feat(date,arel): TestSH constructors/representation (10 tests) with the seats they exercise; Dot visitor edge convergence

### DIFF
--- a/packages/arel/src/visitors/dot.test.ts
+++ b/packages/arel/src/visitors/dot.test.ts
@@ -340,7 +340,7 @@ describe("TestDot", () => {
       );
     });
 
-    it("UpdateStatement walks groups and havings (Trails fields)", () => {
+    it("UpdateStatement emits Rails' seven edges and no groups/havings", () => {
       const stmt = new UpdateManager()
         .table(users)
         .set([[users.get("name"), "x"]])
@@ -348,19 +348,23 @@ describe("TestDot", () => {
         .having(users.get("active").eq(true)).ast;
       const out = dot.compile(stmt);
       expect(out).toContain("UpdateStatement");
-      expect(out).toMatch(/-> \d+ \[label="groups"\];/);
-      expect(out).toMatch(/-> \d+ \[label="havings"\];/);
+      expect(out).not.toMatch(/-> \d+ \[label="groups"\];/);
+      expect(out).not.toMatch(/-> \d+ \[label="havings"\];/);
+      expect(out).toMatch(/-> \d+ \[label="values"\];/);
+      expect(out).toMatch(/-> \d+ \[label="key"\];/);
     });
 
-    it("DeleteStatement walks groups and havings (Trails fields)", () => {
+    it("DeleteStatement emits Rails' six edges and no groups/havings", () => {
       const stmt = new DeleteManager()
         .from(users)
         .group(users.get("dept"))
         .having(users.get("active").eq(true)).ast;
       const out = dot.compile(stmt);
       expect(out).toContain("DeleteStatement");
-      expect(out).toMatch(/-> \d+ \[label="groups"\];/);
-      expect(out).toMatch(/-> \d+ \[label="havings"\];/);
+      expect(out).not.toMatch(/-> \d+ \[label="groups"\];/);
+      expect(out).not.toMatch(/-> \d+ \[label="havings"\];/);
+      expect(out).toMatch(/-> \d+ \[label="wheres"\];/);
+      expect(out).toMatch(/-> \d+ \[label="key"\];/);
     });
 
     it("repeated equal scalar primitives dedupe onto one DotNode (Rails singleton parity)", () => {
@@ -403,16 +407,9 @@ describe("TestDot", () => {
       expect(stringUsersMatches.length).toBe(2);
     });
 
-    it("Extract walks expr + field (Trails shape, not Rails' expressions + alias)", () => {
+    it("Extract walks expressions + alias, as Rails does", () => {
       const node = new Nodes.Extract(users.get("created_at"), "year");
-      const out = dot.compile(node);
-      expect(out).toContain("Extract");
-      expect(out).toMatch(/-> \d+ \[label="expr"\];/);
-      expect(out).toMatch(/-> \d+ \[label="field"\];/);
-      expect(out).toContain("year");
-      // No edges to nil-shaped Rails fields.
-      expect(out).not.toMatch(/-> \d+ \[label="expressions"\];/);
-      expect(out).not.toMatch(/-> \d+ \[label="alias"\];/);
+      expect(() => dot.compile(node)).toThrow(/undefined method 'expressions' for Extract/);
     });
 
     it("Exists walks expressions + alias (no spurious distinct edge)", () => {

--- a/packages/arel/src/visitors/dot.ts
+++ b/packages/arel/src/visitors/dot.ts
@@ -194,14 +194,9 @@ export class Dot extends Visitor {
     this.visitNoEdges(o);
   }
 
-  /**
-   * Trails' Extract extends Unary with `expr` + `field` (rather than Rails'
-   * Function-shaped `expressions` + `alias`). Walk the actual fields so the
-   * graph reflects the AST instead of emitting nil edges.
-   */
   protected visitArelNodesExtract(o: Nodes.Extract): void {
-    this.visitEdge(o, "expr");
-    this.visitEdge(o, "field");
+    this.visitEdge(o, "expressions");
+    this.visitEdge(o, "alias");
   }
 
   protected visitArelNodesNamedFunction(o: Nodes.NamedFunction): void {
@@ -243,8 +238,6 @@ export class Dot extends Visitor {
     this.visitEdge(o, "relation");
     this.visitEdge(o, "wheres");
     this.visitEdge(o, "values");
-    this.visitEdge(o, "groups");
-    this.visitEdge(o, "havings");
     this.visitEdge(o, "orders");
     this.visitEdge(o, "limit");
     this.visitEdge(o, "offset");
@@ -254,8 +247,6 @@ export class Dot extends Visitor {
   protected visitArelNodesDeleteStatement(o: Nodes.DeleteStatement): void {
     this.visitEdge(o, "relation");
     this.visitEdge(o, "wheres");
-    this.visitEdge(o, "groups");
-    this.visitEdge(o, "havings");
     this.visitEdge(o, "orders");
     this.visitEdge(o, "limit");
     this.visitEdge(o, "offset");

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -359,6 +359,33 @@ function subsecDigits(nsec: Rational, precision: number): string {
   return digits;
 }
 
+/** @internal C's `INT_MAX` from `limits.h`, the first half of `date_strftime.c:579`'s
+ *  precision rejection. */
+const INT_MAX = 2147483647;
+
+/**
+ * Ruby `Errno::ERANGE`, the `SystemCallError` `date_strftime_alloc` raises
+ * through `rb_sys_fail(format)` (`date_core.c:7095`) when the formatter cannot
+ * render a directive inside the buffer it is willing to grow to.
+ *
+ * @noRailsEquivalent PERMANENT — Ruby core, like the `Rational` above. Rails
+ * defines no `Errno`; it inherits Ruby's, and `Date#strftime` raises this one.
+ */
+export class ERANGE extends Error {
+  constructor(format: string) {
+    super(format);
+    this.name = "Errno::ERANGE";
+  }
+}
+
+/**
+ * Ruby's `Errno` module at the name Ruby nests {@link ERANGE} under, so a
+ * caller spells the rescue `Errno.ERANGE` as Ruby spells `Errno::ERANGE`.
+ *
+ * @noRailsEquivalent PERMANENT — Ruby core; see {@link ERANGE}.
+ */
+export const Errno = { ERANGE };
+
 /**
  * @internal Ruby routes `Date#strftime` and `Time#strftime` through the same C
  * formatter, so trails has one implementation rather than a copy per class.
@@ -396,6 +423,14 @@ function subsecDigits(nsec: Rational, precision: number): string {
  *
  * A `Temporal` value is accepted in place of the subject and read through
  * {@link temporalSubject} — the fields Ruby's `::Date`/`::Time` answer natively.
+ *
+ * `maxsize` is `1024 * flen`, the size `date_strftime_alloc` doubles its buffer
+ * up to before it gives up and `rb_sys_fail`s (`date_core.c:7081-7097`). A JS
+ * string grows on its own, so that bound is the only part of the C's buffer
+ * machinery that is observable — and it is observable, as the two
+ * {@link ERANGE} arms are what `test_strftime` asserts: a precision past it
+ * (`date_strftime.c:577-582`) and a rendered field past it
+ * (`FILL_PADDING`, `date_strftime.c:124-126`).
  */
 export function strftime(
   value:
@@ -414,6 +449,7 @@ export function strftime(
       ? temporalSubject(value)
       : value;
   const hour12 = subject.hour % 12 === 0 ? 12 : subject.hour % 12;
+  const maxsize = 1024 * format.length;
   let out = "";
   let f = 0;
 
@@ -478,6 +514,7 @@ export function strftime(
       if (c !== undefined && isdigit(c)) {
         if (c === "0") padding = "0";
         const [prec, e] = strtoul(format, g);
+        if (prec > INT_MAX || prec > maxsize) throw new ERANGE(format);
         precision = prec;
         g = e;
         continue;
@@ -674,6 +711,7 @@ export function strftime(
       f = spec === undefined ? format.length : g + 1;
       continue;
     }
+    if (formatted.length > maxsize) throw new ERANGE(format);
     out += formatted;
     f = g + 1;
   }
@@ -4370,6 +4408,18 @@ function offsetToSec(vof: number | bigint | Rational | string): number | null {
 }
 
 /**
+ * @internal `date_core.c`'s `add_frac()` macro (`date_core.c:3313-3317`), the
+ * tail every `Date` class method shares: a nonzero day-fraction makes the
+ * answer `d_lite_plus(ret, fr2)` — a `Date` backed by `ComplexDateData` — and a
+ * zero one leaves `ret` alone. The C spells it as a macro over a fixed `ret` /
+ * `fr2` pair, which is why it takes no arguments there and two here.
+ */
+function addFracTo(ret: Date, fr2: number | Rational): Date {
+  if (fr2 instanceof Rational ? fr2.isZero() : fr2 === 0) return ret;
+  return ret.plus(fr2);
+}
+
+/**
  * @internal `date_core.c` `val2off` (`date_core.c:5071-5077`), the macro every
  * user-facing `offset` argument is read through: whatever `offset_to_sec`
  * rejects warns `"invalid offset is ignored"` and becomes `0`.
@@ -5054,8 +5104,24 @@ export class Date {
    * Ruby `Date.new(year = -4712, month = 1, mday = 1)` (ruby/date,
    * `date_core.c` `date_s_civil`), which raises `Date::Error` on a civil date
    * `c_valid_civil_p` rejects.
+   *
+   * `mday` is the only argument `date_initialize` reads a fraction off —
+   * `num2int_with_frac(d, positive_inf)` (`date_core.c:3524`), whose
+   * `positive_inf` is why it never raises `"invalid fraction"`. That fraction
+   * comes back in DAYS here (a `unitInSeconds` of `1`) because its consumer is
+   * `d_lite_plus`, which takes days; the {@link DateTime} constructor scales to
+   * seconds instead because its consumer is {@link addFrac}.
+   *
+   * `add_frac()` (`date_core.c:3557`, the macro at `:3313-3317`) then answers
+   * `d_lite_plus(self, fr2)` — a DIFFERENT object from the one being
+   * initialized, carrying `ComplexDateData` for the day-fraction. Ruby returns
+   * it because `date_s_civil` returns `date_initialize`'s `ret` rather than the
+   * allocated receiver, and a JS constructor may override its own result the
+   * same way. So `Date.new(2001, 1, 1) + Rational(1, 2)` and
+   * `Date.new(2001, 1, Rational(3, 2))` are both a `Date` with a
+   * `day_fraction`, and neither is a `DateTime`.
    */
-  constructor(year?: number | bigint, month?: number, day?: number, start?: number);
+  constructor(year?: number | bigint, month?: number, day?: number | Rational, start?: number);
   /**
    * @internal `date_core.c` `d_simple_new_internal` (`date_core.c:3036-3050`),
    * which writes an already-resolved day straight into a fresh
@@ -5076,7 +5142,7 @@ export class Date {
   constructor(
     year: number | bigint | typeof SEAT = -4712,
     month: number | bigint = 1,
-    day = 1,
+    day: number | Rational = 1,
     start = DEFAULT_SG,
     df?: number,
     sf?: Rational,
@@ -5084,7 +5150,7 @@ export class Date {
   ) {
     if (typeof year === "symbol") {
       this.nth = month as bigint;
-      this.#jd = day;
+      this.#jd = day as number;
       this.#sg = start;
       this.#df = df;
       this.#sf = sf;
@@ -5095,21 +5161,24 @@ export class Date {
     checkNumeric(month, "month");
     checkNumeric(year, "year");
     const sg = val2sg(start);
+    const [d, fr2] = num2intWithFrac(day, 1, false);
     if (guessStyle(year, sg) < 0) {
-      const r = validGregorianP(year, month as number, day);
+      const r = validGregorianP(year, month as number, d);
       if (r === null) throw new DateError("invalid date");
       const [nth, ry, rm, rd] = r;
       this.nth = nth;
       this.#sg = sg;
       this.#civil = [ry, rm, rd];
     } else {
-      const r = validCivilP(year, month as number, day, sg);
+      const r = validCivilP(year, month as number, d, sg);
       if (r === null) throw new DateError("invalid date");
       const [nth, rjd] = r;
       this.nth = nth;
       this.#jd = rjd;
       this.#sg = sg;
     }
+
+    return addFracTo(this, fr2);
   }
 
   /**
@@ -5278,10 +5347,12 @@ export class Date {
    * leaves the civil date to `get_s_civil`; there is one representation here,
    * so the conversion happens at the call.
    */
-  static jd(jd: number | bigint = 0, start = DEFAULT_SG): Temporal.PlainDate {
+  static jd(jd: number | bigint | Rational = 0, start = DEFAULT_SG): Temporal.PlainDate {
     checkNumeric(jd, "jd");
-    const [nth, rjd] = decodeJd(jd);
-    return new Date(SEAT, nth, rjd, val2sg(start)).toDate();
+    const [j, fr2] = num2numWithFrac(jd, 1, false);
+    const [nth, rjd] = decodeJd(j);
+    const ret = new Date(SEAT, nth, rjd, val2sg(start));
+    return addFracTo(ret, fr2).toDate();
   }
 
   /**
@@ -5290,13 +5361,18 @@ export class Date {
    * `c_valid_ordinal_p` rejects. A negative `yday` counts back from the last day
    * of the year, so `Date.ordinal(2001, -1)` is 2001-12-31.
    */
-  static ordinal(year = -4712, yday = 1, start = DEFAULT_SG): Temporal.PlainDate {
+  static ordinal(
+    year = -4712,
+    yday: number | Rational = 1,
+    start = DEFAULT_SG,
+  ): Temporal.PlainDate {
     checkNumeric(yday, "yday");
     checkNumeric(year, "year");
     const sg = val2sg(start);
-    const r = cValidOrdinalP(year, yday, sg);
+    const [d, fr2] = num2intWithFrac(yday, 1, false);
+    const r = cValidOrdinalP(year, d, sg);
     if (r === null) throw new DateError("invalid date");
-    return new Date(SEAT, 0n, r, sg).toDate();
+    return addFracTo(new Date(SEAT, 0n, r, sg), fr2).toDate();
   }
 
   /**
@@ -5306,7 +5382,25 @@ export class Date {
    * counts back from December and a negative `mday` from the month's end, so
    * `Date.civil(2001, -1, -1)` is 2001-12-31.
    */
-  static civil(year = -4712, month = 1, mday = 1, start = DEFAULT_SG): Temporal.PlainDate {
+  /**
+   * Ruby `Date.today(start = Date::ITALY)` (ruby/date, `date_core.c`
+   * `date_s_today`, `date_core.c:3789-3826`): the current date in the LOCAL
+   * zone, built from `localtime_r`'s `tm_year`/`tm_mon`/`tm_mday` and stored
+   * `HAVE_CIVIL` under `GREGORIAN` before `set_sg` writes the requested reform
+   * in. `Temporal.Now.plainDateISO()` is the same reading — the local wall date
+   * — where `Temporal.Now.instant()` would be the UTC one.
+   */
+  static today(start = DEFAULT_SG): Temporal.PlainDate {
+    const now = Temporal.Now.plainDateISO();
+    return new Date(now.year, now.month, now.day, val2sg(start)).toDate();
+  }
+
+  static civil(
+    year = -4712,
+    month = 1,
+    mday: number | Rational = 1,
+    start = DEFAULT_SG,
+  ): Temporal.PlainDate {
     return new Date(year, month, mday, start).toDate();
   }
 
@@ -5317,14 +5411,20 @@ export class Date {
    * `cwday` counts back from Sunday and a negative `cweek` back from the end of
    * the commercial year, so `Date.commercial(2001, -1, -1)` is 2001-12-30.
    */
-  static commercial(cwyear = -4712, cweek = 1, cwday = 1, start = DEFAULT_SG): Temporal.PlainDate {
+  static commercial(
+    cwyear = -4712,
+    cweek = 1,
+    cwday: number | Rational = 1,
+    start = DEFAULT_SG,
+  ): Temporal.PlainDate {
     checkNumeric(cwday, "cwday");
     checkNumeric(cweek, "cweek");
     checkNumeric(cwyear, "year");
     const sg = val2sg(start);
-    const r = cValidCommercialP(cwyear, cweek, cwday, sg);
+    const [d, fr2] = num2intWithFrac(cwday, 1, false);
+    const r = cValidCommercialP(cwyear, cweek, d, sg);
     if (r === null) throw new DateError("invalid date");
-    return new Date(SEAT, 0n, r, sg).toDate();
+    return addFracTo(new Date(SEAT, 0n, r, sg), fr2).toDate();
   }
 
   /**
@@ -7405,6 +7505,11 @@ export class DateTime extends DateWithoutParseStatics {
    * `DateTime.parse("...00.9999999999").strftime("%N")` at `"999999999"` when
    * the stored `sf` sits a fraction of a nanosecond above it — and what lets
    * `%12N` answer `"999999999900"`, reaching past the nanosecond for the tail.
+   *
+   * `dt_lite_strftime` (`date_core.c:8721-8726`) is a distinct C function from
+   * `d_lite_strftime` (`:7245-7249`) only for its default format, which is why
+   * `DateTime.new(2001,2,3).strftime` carries the time of day where
+   * `Date#strftime` stops at the day.
    */
   override strftime(format = "%Y-%m-%dT%H:%M:%S%:z"): string {
     return strftime(

--- a/packages/date/src/test-switch-hitter.test.ts
+++ b/packages/date/src/test-switch-hitter.test.ts
@@ -1,0 +1,333 @@
+/**
+ * Port of the ruby/date gem's `test/date/test_switch_hitter.rb` (`TestSH`).
+ *
+ * The gem's own `test/date/` suite is RFC 0088's fidelity measure —
+ * `api:compare` cannot score a C extension, so `vendor/sources.ts` sets
+ * `compareApi: false` for this package and `test:compare` carries the gate.
+ *
+ * The constructors are exercised on the GEM-SHAPED objects rather than on the
+ * `Temporal` seat the statics answer, for the reason `test-date-attr.test.ts`
+ * gives: `#mon`, `#mday`, `#cwyear`, `#yday` and `#offset` have no
+ * `Temporal.PlainDate` counterpart, and `Date.new` / `DateTime.new` are the
+ * gem-shaped spelling of the same C function `Date.civil` / `DateTime.civil`
+ * are defined over (`date_core.c:9973-9974`). No `Temporal` return is
+ * converged back to a Ruby-shaped one here.
+ *
+ * Ruby's `Encoding::US_ASCII` assertions in `test_zone` / `test_to_s` /
+ * `test_inspect` have no JS analogue — a JS string carries no encoding tag —
+ * so the ported assertion is the property the Ruby one is checking for: the
+ * answer is ASCII-only.
+ *
+ * `test_canon24oc`'s three static spellings answer the `Temporal` seat, which
+ * has no `#hour`/`#offset`, so each is asserted through the seat's own
+ * `toString` — a `PlainDateTime` with no zone IS the `offset == 0` the Ruby
+ * asserts. The `DateTime.new` arm is the one that reaches `canon24oc`
+ * (`date_core.c:7885-7888`) on the gem-shaped object, so it keeps the Ruby's
+ * full reader tuple.
+ */
+
+import { describe, it, expect } from "vitest";
+import { Date as RubyDate, DateTime as RubyDateTime, ERANGE, Rational } from "./date.js";
+
+/* eslint-disable no-control-regex */
+
+/** Ruby `String#encoding == Encoding::US_ASCII`; see the file comment. */
+function isUsAscii(s: string): boolean {
+  return /^[\x00-\x7f]*$/.test(s);
+}
+
+describe("TestSH", () => {
+  it("new", () => {
+    [new RubyDate(), new RubyDateTime()].forEach((d) => {
+      expect([d.year, d.mon, d.mday]).toEqual([-4712, 1, 1]);
+    });
+
+    [new RubyDate(2001), new RubyDateTime(2001)].forEach((d) => {
+      expect([d.year, d.mon, d.mday]).toEqual([2001, 1, 1]);
+    });
+
+    let d = new RubyDate(2001, 2, 3);
+    expect([d.year, d.mon, d.mday]).toEqual([2001, 2, 3]);
+    d = new RubyDate(2001, 2, new Rational(7, 2));
+    expect([d.year, d.mon, d.mday]).toEqual([2001, 2, 3]);
+    d = new RubyDate(2001, 2, 3, RubyDate.JULIAN);
+    expect([d.year, d.mon, d.mday]).toEqual([2001, 2, 3]);
+    d = new RubyDate(2001, 2, 3, RubyDate.GREGORIAN);
+    expect([d.year, d.mon, d.mday]).toEqual([2001, 2, 3]);
+
+    d = new RubyDate(2001, -12, -31);
+    expect([d.year, d.mon, d.mday]).toEqual([2001, 1, 1]);
+    d = new RubyDate(2001, -12, -31, RubyDate.JULIAN);
+    expect([d.year, d.mon, d.mday]).toEqual([2001, 1, 1]);
+    d = new RubyDate(2001, -12, -31, RubyDate.GREGORIAN);
+    expect([d.year, d.mon, d.mday]).toEqual([2001, 1, 1]);
+
+    let dt = new RubyDateTime(2001, 2, 3, 4, 5, 6);
+    expect([dt.year, dt.mon, dt.mday, dt.hour, dt.min, dt.sec, dt.offset]).toEqual([
+      2001,
+      2,
+      3,
+      4,
+      5,
+      6,
+      new Rational(0, 1),
+    ]);
+    dt = new RubyDateTime(2001, 2, 3, 4, 5, 6, 0);
+    expect([dt.year, dt.mon, dt.mday, dt.hour, dt.min, dt.sec, dt.offset]).toEqual([
+      2001,
+      2,
+      3,
+      4,
+      5,
+      6,
+      new Rational(0, 1),
+    ]);
+    dt = new RubyDateTime(2001, 2, 3, 4, 5, 6, new Rational(9, 24));
+    expect([dt.year, dt.mon, dt.mday, dt.hour, dt.min, dt.sec, dt.offset]).toEqual([
+      2001,
+      2,
+      3,
+      4,
+      5,
+      6,
+      new Rational(9, 24),
+    ]);
+    dt = new RubyDateTime(2001, 2, 3, 4, 5, 6, 0.375);
+    expect([dt.year, dt.mon, dt.mday, dt.hour, dt.min, dt.sec, dt.offset]).toEqual([
+      2001,
+      2,
+      3,
+      4,
+      5,
+      6,
+      new Rational(9, 24),
+    ]);
+    dt = new RubyDateTime(2001, 2, 3, 4, 5, 6, "+09:00");
+    expect([dt.year, dt.mon, dt.mday, dt.hour, dt.min, dt.sec, dt.offset]).toEqual([
+      2001,
+      2,
+      3,
+      4,
+      5,
+      6,
+      new Rational(9, 24),
+    ]);
+    dt = new RubyDateTime(2001, 2, 3, 4, 5, 6, "-09:00");
+    expect([dt.year, dt.mon, dt.mday, dt.hour, dt.min, dt.sec, dt.offset]).toEqual([
+      2001,
+      2,
+      3,
+      4,
+      5,
+      6,
+      new Rational(-9, 24),
+    ]);
+    dt = new RubyDateTime(2001, -12, -31, -4, -5, -6, "-09:00");
+    expect([dt.year, dt.mon, dt.mday, dt.hour, dt.min, dt.sec, dt.offset]).toEqual([
+      2001,
+      1,
+      1,
+      20,
+      55,
+      54,
+      new Rational(-9, 24),
+    ]);
+    dt = new RubyDateTime(2001, -12, -31, -4, -5, -6, "-09:00", RubyDate.JULIAN);
+    expect([dt.year, dt.mon, dt.mday, dt.hour, dt.min, dt.sec, dt.offset]).toEqual([
+      2001,
+      1,
+      1,
+      20,
+      55,
+      54,
+      new Rational(-9, 24),
+    ]);
+    dt = new RubyDateTime(2001, -12, -31, -4, -5, -6, "-09:00", RubyDate.GREGORIAN);
+    expect([dt.year, dt.mon, dt.mday, dt.hour, dt.min, dt.sec, dt.offset]).toEqual([
+      2001,
+      1,
+      1,
+      20,
+      55,
+      54,
+      new Rational(-9, 24),
+    ]);
+  });
+
+  it("jd", () => {
+    let d = RubyDate.jd();
+    expect([d.year, d.month, d.day]).toEqual([-4712, 1, 1]);
+    d = RubyDate.jd(0);
+    expect([d.year, d.month, d.day]).toEqual([-4712, 1, 1]);
+    d = RubyDate.jd(2451944);
+    expect([d.year, d.month, d.day]).toEqual([2001, 2, 3]);
+
+    expect(RubyDateTime.jd().toString()).toBe("-004712-01-01T00:00:00");
+    expect(RubyDateTime.jd(0).toString()).toBe("-004712-01-01T00:00:00");
+    expect(RubyDateTime.jd(2451944).toString()).toBe("2001-02-03T00:00:00");
+    expect(RubyDateTime.jd(2451944, 4, 5, 6).toString()).toBe("2001-02-03T04:05:06");
+    expect(RubyDateTime.jd(2451944, 4, 5, 6, 0).toString()).toBe("2001-02-03T04:05:06");
+    expect(RubyDateTime.jd(2451944, 4, 5, 6, "+9:00").toString()).toBe(
+      "2001-02-03T04:05:06+09:00[+09:00]",
+    );
+    expect(RubyDateTime.jd(2451944, -4, -5, -6, "-9:00").toString()).toBe(
+      "2001-02-03T20:55:54-09:00[-09:00]",
+    );
+  });
+
+  it("ordinal", () => {
+    let d = RubyDate.ordinal();
+    expect([d.year, d.dayOfYear]).toEqual([-4712, 1]);
+    d = RubyDate.ordinal(-4712, 1);
+    expect([d.year, d.dayOfYear]).toEqual([-4712, 1]);
+
+    d = RubyDate.ordinal(2001, 2);
+    expect([d.year, d.dayOfYear]).toEqual([2001, 2]);
+    d = RubyDate.ordinal(2001, 2, RubyDate.JULIAN);
+    expect([d.year, d.dayOfYear]).toEqual([2001, 2]);
+    d = RubyDate.ordinal(2001, 2, RubyDate.GREGORIAN);
+    expect([d.year, d.dayOfYear]).toEqual([2001, 2]);
+
+    d = RubyDate.ordinal(2001, -2, RubyDate.JULIAN);
+    expect([d.year, d.dayOfYear]).toEqual([2001, 364]);
+    d = RubyDate.ordinal(2001, -2, RubyDate.GREGORIAN);
+    expect([d.year, d.dayOfYear]).toEqual([2001, 364]);
+
+    expect(RubyDateTime.ordinal().toString()).toBe("-004712-01-01T00:00:00");
+    expect(RubyDateTime.ordinal(-4712, 1).toString()).toBe("-004712-01-01T00:00:00");
+    expect(RubyDateTime.ordinal(2001, 34).toString()).toBe("2001-02-03T00:00:00");
+    expect(RubyDateTime.ordinal(2001, 34, 4, 5, 6).toString()).toBe("2001-02-03T04:05:06");
+    expect(RubyDateTime.ordinal(2001, 34, 4, 5, 6, 0).toString()).toBe("2001-02-03T04:05:06");
+    expect(RubyDateTime.ordinal(2001, 34, 4, 5, 6, "+9:00").toString()).toBe(
+      "2001-02-03T04:05:06+09:00[+09:00]",
+    );
+    expect(RubyDateTime.ordinal(2001, 34, -4, -5, -6, "-9:00").toString()).toBe(
+      "2001-02-03T20:55:54-09:00[-09:00]",
+    );
+  });
+
+  it("commercial", () => {
+    expect(RubyDate.commercial().toString()).toBe("-004712-01-01");
+    expect(RubyDate.commercial(-4712, 1, 1).toString()).toBe("-004712-01-01");
+
+    expect(RubyDate.commercial(2001, 2, 3).toString()).toBe("2001-01-10");
+    expect(RubyDate.commercial(2001, 2, 3, RubyDate.JULIAN).toString()).toBe("2001-01-11");
+    expect(RubyDate.commercial(2001, 2, 3, RubyDate.GREGORIAN).toString()).toBe("2001-01-10");
+
+    expect(RubyDate.commercial(2001, -2, -3).toString()).toBe("2001-12-21");
+    expect(RubyDate.commercial(2001, -2, -3, RubyDate.JULIAN).toString()).toBe("2001-12-22");
+    expect(RubyDate.commercial(2001, -2, -3, RubyDate.GREGORIAN).toString()).toBe("2001-12-21");
+
+    expect(RubyDateTime.commercial().toString()).toBe("-004712-01-01T00:00:00");
+    expect(RubyDateTime.commercial(-4712, 1, 1).toString()).toBe("-004712-01-01T00:00:00");
+    expect(RubyDateTime.commercial(2001, 5, 6).toString()).toBe("2001-02-03T00:00:00");
+    expect(RubyDateTime.commercial(2001, 5, 6, 4, 5, 6).toString()).toBe("2001-02-03T04:05:06");
+    expect(RubyDateTime.commercial(2001, 5, 6, 4, 5, 6, 0).toString()).toBe("2001-02-03T04:05:06");
+    expect(RubyDateTime.commercial(2001, 5, 6, 4, 5, 6, "+9:00").toString()).toBe(
+      "2001-02-03T04:05:06+09:00[+09:00]",
+    );
+    expect(RubyDateTime.commercial(2001, 5, 6, -4, -5, -6, "-9:00").toString()).toBe(
+      "2001-02-03T20:55:54-09:00[-09:00]",
+    );
+  });
+
+  it("fractional", () => {
+    expect(RubyDate.jd(2451944.0).toString()).toBe("2001-02-03");
+    expect(RubyDate.jd(new Rational(2451944, 1)).toString()).toBe("2001-02-03");
+    expect(RubyDate.jd(2451944.5).toString()).toBe("2001-02-03");
+    expect(RubyDate.jd(new Rational(4903889, 2)).toString()).toBe("2001-02-03");
+
+    let p = RubyDate.civil(2001, 2, 3.0);
+    expect([p.year, p.month, p.day]).toEqual([2001, 2, 3]);
+    p = RubyDate.civil(2001, 2, new Rational(3, 1));
+    expect([p.year, p.month, p.day]).toEqual([2001, 2, 3]);
+    p = RubyDate.civil(2001, 2, 3.5);
+    expect([p.year, p.month, p.day]).toEqual([2001, 2, 3]);
+    p = RubyDate.civil(2001, 2, new Rational(7, 2));
+    expect([p.year, p.month, p.day]).toEqual([2001, 2, 3]);
+
+    p = RubyDate.ordinal(2001, 2.0);
+    expect([p.year, p.dayOfYear]).toEqual([2001, 2]);
+    p = RubyDate.ordinal(2001, new Rational(2, 1));
+    expect([p.year, p.dayOfYear]).toEqual([2001, 2]);
+
+    expect(RubyDate.commercial(2001, 2, 3.0).toString()).toBe("2001-01-10");
+    expect(RubyDate.commercial(2001, 2, new Rational(3, 1)).toString()).toBe("2001-01-10");
+
+    expect(RubyDateTime.jd(2451944.0).toString()).toBe("2001-02-03T00:00:00");
+    expect(RubyDateTime.jd(new Rational(2451944, 1)).toString()).toBe("2001-02-03T00:00:00");
+    expect(RubyDateTime.jd(2451944.5).toString()).toBe("2001-02-03T12:00:00");
+    expect(RubyDateTime.jd(new Rational(4903889, 2)).toString()).toBe("2001-02-03T12:00:00");
+
+    expect(RubyDateTime.civil(2001, 2, 3.0).toString()).toBe("2001-02-03T00:00:00");
+    expect(RubyDateTime.civil(2001, 2, new Rational(3, 1)).toString()).toBe("2001-02-03T00:00:00");
+    expect(RubyDateTime.civil(2001, 2, 3.5).toString()).toBe("2001-02-03T12:00:00");
+    expect(RubyDateTime.civil(2001, 2, new Rational(7, 2)).toString()).toBe("2001-02-03T12:00:00");
+    expect(RubyDateTime.civil(2001, 2, 3, 4.5).toString()).toBe("2001-02-03T04:30:00");
+    expect(RubyDateTime.civil(2001, 2, 3, new Rational(9, 2)).toString()).toBe(
+      "2001-02-03T04:30:00",
+    );
+    expect(RubyDateTime.civil(2001, 2, 3, 4, 5.5).toString()).toBe("2001-02-03T04:05:30");
+    expect(RubyDateTime.civil(2001, 2, 3, 4, new Rational(11, 2)).toString()).toBe(
+      "2001-02-03T04:05:30",
+    );
+
+    expect(RubyDateTime.ordinal(2001, 2.0).toString()).toBe("2001-01-02T00:00:00");
+    expect(RubyDateTime.ordinal(2001, new Rational(2, 1)).toString()).toBe("2001-01-02T00:00:00");
+
+    expect(RubyDateTime.commercial(2001, 2, 3.0).toString()).toBe("2001-01-10T00:00:00");
+    expect(RubyDateTime.commercial(2001, 2, new Rational(3, 1)).toString()).toBe(
+      "2001-01-10T00:00:00",
+    );
+  });
+
+  it("canon24oc", () => {
+    let d = RubyDateTime.jd(2451943, 24);
+    expect(d.toString()).toBe("2001-02-03T00:00:00");
+    d = RubyDateTime.ordinal(2001, 33, 24);
+    expect(d.toString()).toBe("2001-02-03T00:00:00");
+    const dt = new RubyDateTime(2001, 2, 2, 24);
+    expect([dt.year, dt.mon, dt.mday, dt.hour, dt.min, dt.sec, dt.offset]).toEqual([
+      2001,
+      2,
+      3,
+      0,
+      0,
+      0,
+      new Rational(0, 1),
+    ]);
+    d = RubyDateTime.commercial(2001, 5, 5, 24);
+    expect(d.toString()).toBe("2001-02-03T00:00:00");
+  });
+
+  it("strftime", () => {
+    const today = RubyDate.today();
+    expect(() => new RubyDate(today.year, today.month, today.day).strftime("%100000z")).toThrow(
+      ERANGE,
+    );
+    expect(() => new RubyDate(2n ** 10000n).strftime("%Y")).toThrow(ERANGE);
+    expect(new RubyDate(1850).strftime("%s")).toBe("-3786825600");
+    expect(new RubyDate(1850).strftime("%Q")).toBe("-3786825600000");
+  });
+
+  it("zone", () => {
+    const d = new RubyDateTime(2001, 2, 3);
+    expect(isUsAscii(d.zone)).toBe(true);
+  });
+
+  it("to s", () => {
+    let d: RubyDate = new RubyDate(2001, 2, 3);
+    expect(isUsAscii(d.toS())).toBe(true);
+    expect(isUsAscii(d.strftime())).toBe(true);
+    d = new RubyDateTime(2001, 2, 3);
+    expect(isUsAscii(d.toS())).toBe(true);
+    expect(isUsAscii(d.strftime())).toBe(true);
+  });
+
+  it("inspect", () => {
+    let d: RubyDate = new RubyDate(2001, 2, 3);
+    expect(isUsAscii(d.inspect())).toBe(true);
+    d = new RubyDateTime(2001, 2, 3);
+    expect(isUsAscii(d.inspect())).toBe(true);
+  });
+});


### PR DESCRIPTION
Two bundled stories. Two others from the bundle are not here:

- `port-test-date-arith-fractional-arms` — **superseded upstream while this was
  in flight.** #6312 landed `d_lite_plus`'s `T_FLOAT` arm and
  `Date#dNewInternal`'s `ComplexDateData` answer; #6313 landed
  `DateTime#new_offset`, `offset_to_sec`'s `default:` arm and `test_new_offset`.
  Nothing was left to build, so the story carries no trailer here.
- `move-adapter-specific-snapshot-off-ar-internal-metadata` — **released
  unbuilt.** Its own findings block says it must be its own PR
  (`load-schema-helper.ts:526-532`'s one-story-at-a-time warning) and that it is
  bigger than its estimate. It is back in the ready pool.

## date — `TestSH` lines 7-299, all ten tests

The first push shipped five and filed the rest; review pushed back, correctly.
The blocker I claimed — that the `Temporal` seat cannot answer the readers —
was only true for `#dayOfWeek`. `PlainDate` carries `year`/`month`/`day`/
`dayOfYear`, and the rest read back through the seat's own `toString`. All ten
are here now, with the implementation each one needed:

- **`Date`'s constructor reads a fractional `mday`** — `num2int_with_frac(d,
  positive_inf)` (`date_core.c:3524`) and `add_frac()` (`:3557`). `add_frac`
  answers a *different* object than the one being initialized, and Ruby returns
  it because `date_s_civil` returns `date_initialize`'s `ret` rather than the
  allocated receiver; a JS constructor may override its own result the same way.
  So `Date.new(2001, 2, Rational('3.5'))` is a `Date` carrying a day-fraction —
  not a `DateTime` — and `#mday` is `3`.
- **`Date.jd` / `.ordinal` / `.commercial` / `.civil` take their fraction.**
  Each C body runs its argument through `num2num_with_frac` /
  `num2int_with_frac` and ends at the same `add_frac()` macro (`:3374`, `:3441`,
  `:3625`, `:3524`); none of the four did. `Date.jd(Rational(2451944))` threw
  `RangeError: NaN cannot be converted to a BigInt` before this. The macro is
  `addFracTo`, shared by all five call sites as the C shares it. They sit after
  the `check_numeric` calls #6322 landed while this was in flight, which are the
  C lines immediately above them (`:3373`, `:3440`, `:3624`).
  This is the reviewer's `Date.civil(2001, 2, Rational('3.5'))` path, now
  directly covered by `test_fractional`.
- **`strftime` defaults** — `"%Y-%m-%d"` for `Date` (`d_lite_strftime`,
  `:7245-7249`) and `"%Y-%m-%dT%H:%M:%S%:z"` for `DateTime` (`dt_lite_strftime`,
  `:8721-8726`). The default format is the *only* difference between the two C
  functions.
- **`Errno::ERANGE`** off `date_strftime_alloc`'s `1024 * flen` give-up bound
  (`:7081-7097`). That product is the only part of the C's buffer machinery a JS
  string makes observable, and both of `test_strftime`'s raise arms are measured
  against it: a precision past it (`date_strftime.c:577-582`) and a rendered
  field past it (`FILL_PADDING`, `:124-126`).
- **`Date.today`** (`date_s_today`, `:3789-3826`), the local wall date, which
  `test_strftime` calls.
`pnpm test:compare --package date` credits all ten `TestSH` tests; the package
reads 75/137, 9/10 files after rebasing onto the sibling date PRs that landed
alongside this one. The sibling story I filed for the deferred five is closed as
superseded.

Rebased onto `main` after #6319 landed the `DateTime#newOffset` `get_c_jd` /
`get_c_df` fix this PR originally carried — that hunk is gone from the diff,
since it is now upstream.

### Where the assertions sit

Constructors are asserted on the gem-shaped objects, for the reason
`test-date-attr.test.ts` already gives: `#mon`, `#mday` and `#offset` have no
`Temporal.PlainDate` counterpart, and `Date.new` is the gem-shaped spelling of
the same C function `Date.civil` is defined over (`:9973-9974`). The statics are
asserted through the seat — `year`/`month`/`day`/`dayOfYear` directly, and
`toString` where Ruby reads a member the seat does not carry. `#cwday` is the
one reader with no seat correspondence at all: `dayOfWeek` is computed from the
ISO rendering of the civil fields, so a Julian-reform date answers the wrong
weekday, and those assertions go through `toString` rather than enshrine the
artifact. `Encoding::US_ASCII` has no JS analogue, so those assertions become
the property the Ruby is checking for: the answer is ASCII-only. No `Temporal`
return is converged back to a Ruby-shaped one anywhere.

## arel — Dot visitor edges

Surfaced by the RFC 0095 call-argument comparator (#6309); invisible to
`api:compare`, `arity.ts` and `api:calls` because every call is `visit_edge`.

- `visitArelNodesExtract` passes `"expressions"` then `"alias"`
  (`dot.rb:109-112`). Neither exists on `Nodes::Extract` (`extract.rb` carries
  `expr` + `field`), so MRI raises `NoMethodError` out of `visit_edge`'s
  `public_send` — and `visitEdge` already mirrors that raise. The test asserting
  the invented `expr`/`field` walk encoded the divergence, so it is re-derived to
  the Rails shape rather than preserved.
- `visitArelNodesUpdateStatement` emits Rails' seven edges and
  `visitArelNodesDeleteStatement` its six (`dot.rb:148-165`). The invented
  `"groups"` / `"havings"` edges are **deleted**, not reordered — they shifted
  every following label, which is how the comparator surfaced them as 8 rows of
  apparent label drift. The nodes do carry those fields
  (`update_statement.rb:6`, `delete_statement.rb:6`); Rails' visitor simply does
  not walk them.

`pnpm api:calls`: OK, no new rows. `tsc --build --force`, `pnpm lint` and the
touched vitest files: clean.

Closes-story: port-test-switch-hitter-construction
Closes-story: converge-arel-dot-visit-edge-sites
