### PR TITLE
fix(date): DateTime#newOffset fills day and day-fraction via get_c_jd/get_c_df

### DIFF
--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -1758,6 +1758,17 @@ describe("DateTime", () => {
     ).toBe("1582-10-10T06:30:00+02:00[+02:00]");
     expect(() => RubyDateTime.parse("1582-10-10T06:30:00+02:00")).toThrow(RubyDate.Error);
   });
+
+  it("new_offset fills the day and day-fraction in on the proleptic-Gregorian seat", () => {
+    // `set_of` (`date_core.c:5890-5897`) runs `get_c_jd` / `get_c_df` before it
+    // writes the new offset, because `datetime_initialize`'s proleptic-Gregorian
+    // arm (`:7851-7870`) stores the civil triple and the time of day alone.
+    //   d = DateTime.new(2001, 2, 3, 4, 5, 6, "-02:00", Date::GREGORIAN)
+    //   d.new_offset("+09:00").to_s #=> "2001-02-03T15:05:06+09:00"
+    const d = new RubyDateTime(2001, 2, 3, 4, 5, 6, "-02:00", RubyDate.GREGORIAN);
+    const shifted = d.newOffset("+09:00");
+    expect([shifted.jd, shifted.hour, shifted.min, shifted.sec]).toEqual([2451944, 15, 5, 6]);
+  });
 });
 
 describe("Time", () => {

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -6655,12 +6655,23 @@ export class DateTime extends DateWithoutParseStatics {
    * Ruby `DateTime#new_offset(offset = 0)` (ruby/date, `date_core.c`
    * `d_lite_new_offset`, `:5920-5934`) over `dup_obj_with_new_offset`
    * (`:5901-5909`): the day and day-fraction are stored in UTC, so only `of`
-   * changes. `Init_date_core` gives it to `::DateTime` alone (`:10018`). TS has
+   * changes — but `set_of` (`:5890-5897`) fills the day and day-fraction in
+   * with `get_c_jd` / `get_c_df` before it writes the new `of`, because the
+   * proleptic-Gregorian arm may have stored neither.
+   * `Init_date_core` gives it to `::DateTime` alone (`:10018`). TS has
    * no `dup_obj`, so the copy is made here; see {@link DateTime#newStart}.
    */
   newOffset(offset: number | bigint | Rational | string = 0): this {
     const rof = val2off(offset);
-    return new DateTime(SEAT, this.nth, this.#jd, this.#df, this.#sf, rof, this.start) as this;
+    return new DateTime(
+      SEAT,
+      this.nth,
+      this.#getCJd(),
+      this.#getCDf(),
+      this.#sf,
+      rof,
+      this.start,
+    ) as this;
   }
 
   override newStart(start = DEFAULT_SG): this {


### PR DESCRIPTION
`main` @3f14b145 is red across Build & Type Check, Leaf Tests, Virtualized DX
Type Tests, Guides Code Type Check, AR PostgreSQL and Rails API/Test Comparison
on a single type error:

```
packages/date/src/date.ts(6663,16): error TS2769: No overload matches this call.
  Argument of type 'number | undefined' is not assignable to parameter of type 'number'.
```

`DateTime#newOffset` passed the raw `#jd` / `#df` fields straight into the
`SEAT` constructor. #6299 made both optional — `datetime_initialize`'s
proleptic-Gregorian arm (`date_core.c:7851-7870`) stores the civil triple and
the time of day with no Julian day and no day-fraction at all, and
`get_c_jd` / `get_c_df` fill them in on first read.

Ruby does the same fill: `d_lite_new_offset` (`date_core.c:5921-5934`) →
`dup_obj_with_new_offset` (`:5901-5909`) → `set_of` (`:5890-5897`), which runs
`get_c_jd(x)` and `get_c_df(x)` before writing the new `of`. So the fix is the
faithful one — read through `#getCJd()` / `#getCDf()`, exactly as the sibling
`newStart` already does.

The old code was a runtime bug as well as a type error: on a
`Date::GREGORIAN`-seated `DateTime`, `newOffset` produced an object with an
undefined day, and `jd` threw. The added trails test covers that seat and fails
on the parent commit.

Closes-story: red-3f14b145
