### PR TITLE
feat(date,activesupport): port test_date_arith next_*/step/upto/downto; LEVEL_CHECKS reads the logger predicate

### DIFF
--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -32,7 +32,7 @@ type CreateTableOptions = Extract<CreateTableArgs[1], { options?: string }>;
  * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements (partial)
  */
 export class MysqlSchemaStatements extends BaseSchemaStatements {
-  /** @internal
+  /**
    * Return user-defined indexes for the given table. Mirrors Rails'
    * MySQL `indexes`: reads `SHOW KEYS FROM <table>`, skips the primary
    * key, groups multi-column indexes by `Key_name`, maps `Index_type`

--- a/packages/activesupport/src/log-subscriber.ts
+++ b/packages/activesupport/src/log-subscriber.ts
@@ -4,34 +4,6 @@ import type { Logger } from "./logger.js";
 import { trailsLogger } from "./trails-logger-slot.js";
 
 /**
- * Check whether a logger has a given level enabled.
- * Rails' LEVEL_CHECKS call `logger.debug?`, `logger.info?`, etc.
- * Our Logger class defines these as getter properties (`get "debug?"()`),
- * but Base.logger can be a simple duck-typed object without them.
- * Treat missing predicates as "enabled" (not silenced) so logging
- * isn't suppressed for valid loggers that lack ActiveSupport predicates.
- */
-function isLevelEnabled(logger: Logger, level: string): boolean {
-  // Try Rails-style predicate getter: `debug?`, `info?`, etc.
-  const predicate = (logger as any)[`${level}?`];
-  if (typeof predicate === "boolean") return predicate;
-
-  // Try camelCase flag: `debugEnabled`, `infoEnabled`, etc.
-  const flag = (logger as any)[`${level}Enabled`];
-  if (typeof flag === "boolean") return flag;
-
-  // Try numeric level comparison (Logger.DEBUG=0, INFO=1, etc.)
-  if (typeof (logger as any).level === "number") {
-    const priorities: Record<string, number> = { debug: 0, info: 1, warn: 2, error: 3, fatal: 4 };
-    const required = priorities[level];
-    if (required !== undefined) return (logger as any).level <= required;
-  }
-
-  // No way to tell — assume enabled (don't suppress logging)
-  return true;
-}
-
-/**
  * ActiveSupport::LogSubscriber — a Subscriber that dispatches events
  * to a logger. Provides ANSI coloring helpers and log-level gating.
  *
@@ -84,10 +56,16 @@ export class LogSubscriber extends Subscriber {
     (getClassState(this) as any)._logLevels = value;
   }
 
+  /**
+   * Rails `LogSubscriber::LEVEL_CHECKS`
+   * (`activesupport/lib/active_support/log_subscriber.rb:86-90`), three lambdas
+   * that ask the logger its own predicate. Trails' {@link Logger} spells those
+   * as `get "debug?"()` getters, so the call is a property read.
+   */
   static readonly LEVEL_CHECKS: Record<string, (logger: Logger) => boolean> = {
-    debug: (logger) => !isLevelEnabled(logger, "debug"),
-    info: (logger) => !isLevelEnabled(logger, "info"),
-    error: (logger) => !isLevelEnabled(logger, "error"),
+    debug: (logger) => !logger["debug?"],
+    info: (logger) => !logger["info?"],
+    error: (logger) => !logger["error?"],
   };
 
   private static _logger: Logger | null = null;

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -4542,10 +4542,11 @@ function expectNumeric(x: unknown): void {
 
 /**
  * @internal `date_core.c` `f_cmp` (`:74-86`), the `<=>` dispatch the C's
- * arithmetic reaches for a non-Fixnum operand. The Fixnum fast path is the
- * `FIXNUM_P(x) && FIXNUM_P(y)` arm; everything else goes through `rb_cmpint`,
- * which raises `ArgumentError` for the `nil` a `<=>` that declines to answer
- * gives back. `test_step__compare`
+ * arithmetic reaches for a non-Fixnum operand. The `FIXNUM_P(x) && FIXNUM_P(y)`
+ * arm is the subtraction below; it is widened to every JS `number` because
+ * Ruby's non-Fixnum Float reaches `Float#<=>`, which answers the same sign.
+ * Everything else goes through `rb_cmpint`, which raises `ArgumentError` for
+ * the `nil` a `<=>` that declines to answer gives back. `test_step__compare`
  * (`vendor/date/test/date/test_date_arith.rb:290-303`) asserts both arms of
  * that through `Date#step`'s step argument.
  */

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -4546,7 +4546,10 @@ function expectNumeric(x: unknown): void {
  * arm is the subtraction below; it is widened to every JS `number` because
  * Ruby's non-Fixnum Float reaches `Float#<=>`, which answers the same sign.
  * Everything else goes through `rb_cmpint`, which raises `ArgumentError` for
- * the `nil` a `<=>` that declines to answer gives back. `test_step__compare`
+ * the `nil` a `<=>` that declines to answer gives back — including the `nil`
+ * Ruby's own `Object#<=>` answers for an unrelated operand, which is why an
+ * object carrying no `cmp` at all takes that arm rather than failing on the
+ * call. `test_step__compare`
  * (`vendor/date/test/date/test_date_arith.rb:290-303`) asserts both arms of
  * that through `Date#step`'s step argument.
  */
@@ -4557,12 +4560,40 @@ function fCmp(x: unknown, y: number): number {
     else if (c < 0) return -1;
     return 0;
   }
-  const c = (x as { cmp(y: number): number | null }).cmp(y);
+  const cmp = (x as { cmp?: (y: number) => number | null | undefined } | null)?.cmp;
+  const c = typeof cmp === "function" ? cmp.call(x, y) : null;
   if (c === null || c === undefined) {
     const klass = x === null || x === undefined ? String(x) : (x.constructor?.name ?? "Object");
     throw new ArgumentError(`comparison of ${klass} with ${y} failed`);
   }
   return c > 0 ? 1 : c < 0 ? -1 : 0;
+}
+
+/**
+ * @internal The loop of `date_core.c` `d_lite_upto` (`:6665-6671`) as a
+ * generator, driving both arms of {@link Date#upto} the way
+ * {@link dLiteStepEnum} drives {@link Date#step}. The C writes this loop out
+ * rather than calling `d_lite_step`, so it is its own body here too.
+ */
+function* dLiteUptoEnum(self: Date, max: Date): Generator<Date> {
+  let date = self;
+  while (date.cmp(max)! <= 0) {
+    yield date;
+    date = date.plus(1);
+  }
+}
+
+/**
+ * @internal The loop of `date_core.c` `d_lite_downto` (`:6686-6692`), the
+ * counterpart to {@link dLiteUptoEnum} and, like it, written out in the C
+ * rather than delegated to `d_lite_step`.
+ */
+function* dLiteDowntoEnum(self: Date, min: Date): Generator<Date> {
+  let date = self;
+  while (date.cmp(min)! >= 0) {
+    yield date;
+    date = date.plus(-1);
+  }
 }
 
 /**
@@ -5824,22 +5855,30 @@ export class Date {
 
   /**
    * Ruby `Date#upto(max)` (ruby/date, `date_core.c` `d_lite_upto`,
-   * `:6659-6672`), equivalent to {@link Date#step} with `max` and `1`.
+   * `:6659-6672`). Documented as equivalent to {@link Date#step} with `max` and
+   * `1`, but the C is its own loop over `d_lite_cmp` and `d_lite_plus` and does
+   * not dispatch through `d_lite_step`, so this does not either.
    */
   upto(max: Date): Generator<this>;
   upto(max: Date, block: (date: this) => void): this;
   upto(max: Date, block?: (date: this) => void): this | Generator<this> {
-    return block === undefined ? this.step(max, 1) : this.step(max, 1, block);
+    if (block === undefined) return dLiteUptoEnum(this, max) as Generator<this>;
+    for (const date of dLiteUptoEnum(this, max)) block(date as this);
+    return this;
   }
 
   /**
    * Ruby `Date#downto(min)` (ruby/date, `date_core.c` `d_lite_downto`,
-   * `:6680-6693`), equivalent to {@link Date#step} with `min` and `-1`.
+   * `:6680-6693`). Documented as equivalent to {@link Date#step} with `min` and
+   * `-1`, but the C is its own loop over `d_lite_cmp` and `d_lite_plus` and
+   * does not dispatch through `d_lite_step`, so this does not either.
    */
   downto(min: Date): Generator<this>;
   downto(min: Date, block: (date: this) => void): this;
   downto(min: Date, block?: (date: this) => void): this | Generator<this> {
-    return block === undefined ? this.step(min, -1) : this.step(min, -1, block);
+    if (block === undefined) return dLiteDowntoEnum(this, min) as Generator<this>;
+    for (const date of dLiteDowntoEnum(this, min)) block(date as this);
+    return this;
   }
 
   /**

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -4541,6 +4541,23 @@ function expectNumeric(x: unknown): void {
 }
 
 /**
+ * @internal `Float#to_r` (`rational.c` `float_to_r`), the exact binary value of
+ * a JS number. `d_lite_rshift`'s `f_add3` answers a Float for a Float `other`
+ * and its `f_idiv` / `f_mod` then work in Float; the value is the same either
+ * way, and carrying it as an exact {@link Rational} lets the one `else` arm
+ * serve both Numerics.
+ */
+function fToR(x: number): Rational {
+  let n = x;
+  let d = 1n;
+  while (!Number.isInteger(n)) {
+    n *= 2;
+    d *= 2n;
+  }
+  return new Rational(BigInt(n), d);
+}
+
+/**
  * @internal `f_mul(n, INT2FIX(12))` as `d_lite_next_year` / `d_lite_prev_year`
  * (`date_core.c:6554-6563`, `:6571-6580`) apply it — the one place the month
  * wrappers scale their argument before handing it to `Date#>>` / `Date#<<`,
@@ -5791,13 +5808,19 @@ export class Date {
    * canonicalizes a denominator of 1 back to an Integer, which is what puts
    * `Date.new(2000,1,31).next_year(Rational(1,2))` — `f_mul(n, 12)` is `(6/1)`,
    * so `t` is an Integer — on the C's `FIXNUM_P(t)` arm and answers 2000-07-31.
-   * The `else` arm is the C's `f_idiv` / `f_mod` pair, and a `t` that is
-   * genuinely fractional falls out of it as a fractional month, which
-   * `valid_civil_p` rejects exactly as the C's `FIX2INT` of a Rational does not
-   * survive.
+   * The `else` arm is the C's `f_idiv` / `f_mod` pair. Its `FIX2INT` is the
+   * non-Fixnum `rb_num2int`, which TRUNCATES: `f_mod` is a floor-mod, so the
+   * remainder is non-negative and the truncation is the bigint division below.
+   * That is what keeps `Date.new(2000,1,31) >> Rational(1,2)` on 2000-01-31 and
+   * puts `>> Rational(3,2)` on 2000-02-29 rather than walking into February by
+   * the fraction. A non-integral Float takes the same arm through
+   * {@link fToR}, since `Float#to_r` is exact and `f_idiv` / `f_mod` read the
+   * same integers off it that the C's Float arithmetic does.
    */
   rshift(other: number | bigint | Rational): this {
-    const t = new Rational(BigInt(this.year) * 12n + BigInt(this.mon - 1), 1).add(other);
+    const t = new Rational(BigInt(this.year) * 12n + BigInt(this.mon - 1), 1).add(
+      typeof other === "number" && !Number.isInteger(other) ? fToR(other) : other,
+    );
     let y: number | bigint;
     let m: number;
     if (t.denominator === 1n) {
@@ -5809,7 +5832,7 @@ export class Date {
       let q = t.numerator / d12;
       if (t.numerator % d12 !== 0n && t.numerator < 0n) q -= 1n;
       y = bigNorm(q);
-      m = t.toF() - 12 * Number(q) + 1;
+      m = Number((t.numerator - q * d12) / t.denominator) + 1;
     }
     let d = this.mday;
     const sg = this.start;

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -4541,6 +4541,58 @@ function expectNumeric(x: unknown): void {
 }
 
 /**
+ * @internal `date_core.c` `f_cmp` (`:74-86`), the `<=>` dispatch the C's
+ * arithmetic reaches for a non-Fixnum operand. The Fixnum fast path is the
+ * `FIXNUM_P(x) && FIXNUM_P(y)` arm; everything else goes through `rb_cmpint`,
+ * which raises `ArgumentError` for the `nil` a `<=>` that declines to answer
+ * gives back. `test_step__compare`
+ * (`vendor/date/test/date/test_date_arith.rb:290-303`) asserts both arms of
+ * that through `Date#step`'s step argument.
+ */
+function fCmp(x: unknown, y: number): number {
+  if (typeof x === "number" && typeof y === "number") {
+    const c = x - y;
+    if (c > 0) return 1;
+    else if (c < 0) return -1;
+    return 0;
+  }
+  const c = (x as { cmp(y: number): number | null }).cmp(y);
+  if (c === null || c === undefined) {
+    const klass = x === null || x === undefined ? String(x) : (x.constructor?.name ?? "Object");
+    throw new ArgumentError(`comparison of ${klass} with ${y} failed`);
+  }
+  return c > 0 ? 1 : c < 0 ? -1 : 0;
+}
+
+/**
+ * @internal The loop of `date_core.c` `d_lite_step` (`:6631-6652`) — the three
+ * arms of the sign of `f_cmp(step, 0)` — as a generator, so the block arm and
+ * the `RETURN_ENUMERATOR` arm of {@link Date#step} both drive it, exactly as
+ * the C reaches the one body twice.
+ */
+function* dLiteStepEnum(
+  self: Date,
+  limit: Date,
+  step: number | bigint | Rational,
+): Generator<Date> {
+  let date = self;
+  const c = fCmp(step, 0);
+  if (c < 0) {
+    while (date.cmp(limit)! >= 0) {
+      yield date;
+      date = date.plus(step);
+    }
+  } else if (c === 0) {
+    for (;;) yield date;
+  } else {
+    while (date.cmp(limit)! <= 0) {
+      yield date;
+      date = date.plus(step);
+    }
+  }
+}
+
+/**
  * @internal `date_core.c` `minus_dd` (`:6272-6321`), the difference between two
  * dates in days, as a Rational: the whole {@link CM_PERIOD}s, days,
  * day-fraction and sub-second, each carried into the term below, then summed.
@@ -5660,10 +5712,30 @@ export class Date {
     return this.plus(-other);
   }
 
+  /** Ruby `Date#next_day(n = 1)` (ruby/date, `date_core.c` `d_lite_next_day`,
+   *  `:6369-6377`), which is `Date#+` of `n`. */
+  nextDay(n: number | bigint | Rational = 1): this {
+    return this.plus(n);
+  }
+
   /** Ruby `Date#prev_day(n = 1)` (ruby/date, `date_core.c` `d_lite_prev_day`,
    *  `:6386-6395`), which is `Date#-` of `n`. */
   prevDay(n: number | bigint | Rational = 1): this {
     return this.minus(n) as this;
+  }
+
+  /** Ruby `Date#next` (ruby/date, `date_core.c` `d_lite_next`, `:6408-6412`),
+   *  which is `Date#next_day` of no argument. Ruby registers `succ` as a second
+   *  name for the same C function (`date_core.c:9779-9780`), so
+   *  {@link Date#succ} is that alias. */
+  next(): this {
+    return this.nextDay();
+  }
+
+  /** Ruby `Date#succ` — the second name `date_core.c:9780` registers for
+   *  `d_lite_next`. */
+  succ(): this {
+    return this.next();
   }
 
   /**
@@ -5696,16 +5768,77 @@ export class Date {
     return this.rshift(-other);
   }
 
+  /** Ruby `Date#next_month(n = 1)` (ruby/date, `date_core.c`
+   *  `d_lite_next_month`, `:6520-6529`), which is `Date#>>` of `n`. */
+  nextMonth(n: number | bigint = 1): this {
+    return this.rshift(n);
+  }
+
   /** Ruby `Date#prev_month(n = 1)` (ruby/date, `date_core.c`
    *  `d_lite_prev_month`, `:6537-6546`), which is `Date#<<` of `n`. */
   prevMonth(n: number | bigint = 1): this {
     return this.lshift(n);
   }
 
+  /** Ruby `Date#next_year(n = 1)` (ruby/date, `date_core.c` `d_lite_next_year`,
+   *  `:6554-6563`), which is `Date#>>` of `n * 12`. */
+  nextYear(n: number | bigint = 1): this {
+    return this.rshift(typeof n === "bigint" ? n * 12n : n * 12);
+  }
+
   /** Ruby `Date#prev_year(n = 1)` (ruby/date, `date_core.c` `d_lite_prev_year`,
    *  `:6571-6580`), which is `Date#<<` of `n * 12`. */
   prevYear(n: number | bigint = 1): this {
     return this.lshift(typeof n === "bigint" ? n * 12n : n * 12);
+  }
+
+  /**
+   * Ruby `Date#step(limit, step = 1)` (ruby/date, `date_core.c` `d_lite_step`,
+   * `:6614-6653`): the block is called with `self`, then each `date + step`,
+   * for as long as the date stays on `limit`'s side of the comparison. The
+   * three arms are the sign of `f_cmp(step, 0)` — a negative step walks down
+   * while `date <=> limit >= 0`, a positive one walks up while `<= 0`, and a
+   * zero step yields forever (the `step can't be 0` raise is `#if 0`'d out in
+   * the C).
+   *
+   * `RETURN_ENUMERATOR` is the no-block arm: TS has no `rb_block_given_p`, so
+   * an omitted `block` answers the generator that drives the same loop, which
+   * is what the gem's `test_step__noblock` exercises through `to_a`.
+   */
+  step(limit: Date, step?: number | bigint | Rational): Generator<this>;
+  step(
+    limit: Date,
+    step: number | bigint | Rational | undefined,
+    block: (date: this) => void,
+  ): this;
+  step(
+    limit: Date,
+    step: number | bigint | Rational = 1,
+    block?: (date: this) => void,
+  ): this | Generator<this> {
+    if (block === undefined) return dLiteStepEnum(this, limit, step) as Generator<this>;
+    for (const date of dLiteStepEnum(this, limit, step)) block(date as this);
+    return this;
+  }
+
+  /**
+   * Ruby `Date#upto(max)` (ruby/date, `date_core.c` `d_lite_upto`,
+   * `:6659-6672`), equivalent to {@link Date#step} with `max` and `1`.
+   */
+  upto(max: Date): Generator<this>;
+  upto(max: Date, block: (date: this) => void): this;
+  upto(max: Date, block?: (date: this) => void): this | Generator<this> {
+    return block === undefined ? this.step(max, 1) : this.step(max, 1, block);
+  }
+
+  /**
+   * Ruby `Date#downto(min)` (ruby/date, `date_core.c` `d_lite_downto`,
+   * `:6680-6693`), equivalent to {@link Date#step} with `min` and `-1`.
+   */
+  downto(min: Date): Generator<this>;
+  downto(min: Date, block: (date: this) => void): this;
+  downto(min: Date, block?: (date: this) => void): this | Generator<this> {
+    return block === undefined ? this.step(min, -1) : this.step(min, -1, block);
   }
 
   /**
@@ -6660,7 +6793,15 @@ export class DateTime extends DateWithoutParseStatics {
    */
   newOffset(offset: number | bigint | Rational | string = 0): this {
     const rof = val2off(offset);
-    return new DateTime(SEAT, this.nth, this.#jd, this.#df, this.#sf, rof, this.start) as this;
+    return new DateTime(
+      SEAT,
+      this.nth,
+      this.#getCJd(),
+      this.#getCDf(),
+      this.#sf,
+      rof,
+      this.start,
+    ) as this;
   }
 
   override newStart(start = DEFAULT_SG): this {

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -4541,6 +4541,17 @@ function expectNumeric(x: unknown): void {
 }
 
 /**
+ * @internal `f_mul(n, INT2FIX(12))` as `d_lite_next_year` / `d_lite_prev_year`
+ * (`date_core.c:6554-6563`, `:6571-6580`) apply it — the one place the month
+ * wrappers scale their argument before handing it to `Date#>>` / `Date#<<`,
+ * and the reason those two take every Numeric `d_lite_rshift` does.
+ */
+function fMul12(n: number | bigint | Rational): number | bigint | Rational {
+  if (n instanceof Rational) return n.mul(12);
+  return typeof n === "bigint" ? n * 12n : n * 12;
+}
+
+/**
  * @internal `date_core.c` `f_cmp` (`:74-86`), the `<=>` dispatch the C's
  * arithmetic reaches for a non-Fixnum operand. The `FIXNUM_P(x) && FIXNUM_P(y)`
  * arm is the subtraction below; it is widened to every JS `number` because
@@ -5775,11 +5786,31 @@ export class Date {
    * date `other` months after the receiver. When the new month has no such day
    * the last day of it is used — the `while` walking `d` down, which is why
    * `Date.new(2000,1,31) >> 1` is 2000-02-29.
+   *
+   * `other` is any Numeric, so `t` is carried as a {@link Rational}: Ruby
+   * canonicalizes a denominator of 1 back to an Integer, which is what puts
+   * `Date.new(2000,1,31).next_year(Rational(1,2))` — `f_mul(n, 12)` is `(6/1)`,
+   * so `t` is an Integer — on the C's `FIXNUM_P(t)` arm and answers 2000-07-31.
+   * The `else` arm is the C's `f_idiv` / `f_mod` pair, and a `t` that is
+   * genuinely fractional falls out of it as a fractional month, which
+   * `valid_civil_p` rejects exactly as the C's `FIX2INT` of a Rational does not
+   * survive.
    */
-  rshift(other: number | bigint): this {
-    const t = BigInt(this.year) * 12n + BigInt(this.mon - 1) + BigInt(other);
-    const y = bigNorm(div(t, 12));
-    const m = Number(mod(t, 12)) + 1;
+  rshift(other: number | bigint | Rational): this {
+    const t = new Rational(BigInt(this.year) * 12n + BigInt(this.mon - 1), 1).add(other);
+    let y: number | bigint;
+    let m: number;
+    if (t.denominator === 1n) {
+      const it = t.numerator;
+      y = bigNorm(div(it, 12));
+      m = Number(mod(it, 12)) + 1;
+    } else {
+      const d12 = t.denominator * 12n;
+      let q = t.numerator / d12;
+      if (t.numerator % d12 !== 0n && t.numerator < 0n) q -= 1n;
+      y = bigNorm(q);
+      m = t.toF() - 12 * Number(q) + 1;
+    }
     let d = this.mday;
     const sg = this.start;
 
@@ -5796,32 +5827,32 @@ export class Date {
 
   /** Ruby `Date#<<` (ruby/date, `date_core.c` `d_lite_lshift`, `:6507-6512`),
    *  which is `Date#>>` of the negated argument. */
-  lshift(other: number | bigint): this {
-    return this.rshift(-other);
+  lshift(other: number | bigint | Rational): this {
+    return this.rshift(other instanceof Rational ? other.mul(-1) : -other);
   }
 
   /** Ruby `Date#next_month(n = 1)` (ruby/date, `date_core.c`
    *  `d_lite_next_month`, `:6520-6529`), which is `Date#>>` of `n`. */
-  nextMonth(n: number | bigint = 1): this {
+  nextMonth(n: number | bigint | Rational = 1): this {
     return this.rshift(n);
   }
 
   /** Ruby `Date#prev_month(n = 1)` (ruby/date, `date_core.c`
    *  `d_lite_prev_month`, `:6537-6546`), which is `Date#<<` of `n`. */
-  prevMonth(n: number | bigint = 1): this {
+  prevMonth(n: number | bigint | Rational = 1): this {
     return this.lshift(n);
   }
 
   /** Ruby `Date#next_year(n = 1)` (ruby/date, `date_core.c` `d_lite_next_year`,
    *  `:6554-6563`), which is `Date#>>` of `n * 12`. */
-  nextYear(n: number | bigint = 1): this {
-    return this.rshift(typeof n === "bigint" ? n * 12n : n * 12);
+  nextYear(n: number | bigint | Rational = 1): this {
+    return this.rshift(fMul12(n));
   }
 
   /** Ruby `Date#prev_year(n = 1)` (ruby/date, `date_core.c` `d_lite_prev_year`,
    *  `:6571-6580`), which is `Date#<<` of `n * 12`. */
-  prevYear(n: number | bigint = 1): this {
-    return this.lshift(typeof n === "bigint" ? n * 12n : n * 12);
+  prevYear(n: number | bigint | Rational = 1): this {
+    return this.lshift(fMul12(n));
   }
 
   /**

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -689,6 +689,21 @@ export class ArgumentError extends Error {
 }
 
 /**
+ * @internal Ruby core `FloatDomainError`, a `RangeError` subclass, spelled
+ * locally for the reason {@link NoMethodError} below is. `rb_num2int` — what
+ * `FIX2INT` is for the non-Fixnum operand of `d_lite_rshift`'s `f_idiv` /
+ * `f_mod` arm (`date_core.c:6459`) — raises it for a non-finite Float, with the
+ * Float's own `to_s` as the message: `Date.new(2000,1,31) >> Float::INFINITY`
+ * is `FloatDomainError: Infinity`.
+ */
+class FloatDomainError extends RangeError {
+  constructor(message: string) {
+    super(message);
+    this.name = "FloatDomainError";
+  }
+}
+
+/**
  * @internal Ruby core `NoMethodError`. It is here rather than imported because
  * `@blazetrails/date` is the bottom of the dependency graph — activemodel's
  * copy (`attribute-assignment.ts`) imports this package, not the reverse — and
@@ -4545,9 +4560,12 @@ function expectNumeric(x: unknown): void {
  * a JS number. `d_lite_rshift`'s `f_add3` answers a Float for a Float `other`
  * and its `f_idiv` / `f_mod` then work in Float; the value is the same either
  * way, and carrying it as an exact {@link Rational} lets the one `else` arm
- * serve both Numerics.
+ * serve both Numerics. A non-finite Float has no exact ratio and Ruby's own
+ * `rb_num2int` refuses it, so it raises {@link FloatDomainError} here — the
+ * error `f_idiv` reaches first in the C.
  */
 function fToR(x: number): Rational {
+  if (!Number.isFinite(x)) throw new FloatDomainError(String(x));
   let n = x;
   let d = 1n;
   while (!Number.isInteger(n)) {

--- a/packages/date/src/test-date-arith.test.ts
+++ b/packages/date/src/test-date-arith.test.ts
@@ -1,9 +1,16 @@
 /**
- * Port of `vendor/date/test/date/test_date_arith.rb` lines 10-152 — the gem's
- * own suite, which RFC 0088 makes the measure of the date port. Ruby's `+`,
- * `-`, `<=>` and `<<` have no TS syntax that dispatches to a method, so they
- * are the named methods `docs/ruby-ts-conventions.md` ("Operators") calls for:
- * `plus`, `minus`, `cmp`, `lshift`.
+ * Port of `vendor/date/test/date/test_date_arith.rb` — the gem's own suite,
+ * which RFC 0088 makes the measure of the date port. Ruby's `+`, `-`, `<=>`,
+ * `<<` and `>>` have no TS syntax that dispatches to a method, so they are the
+ * named methods `docs/ruby-ts-conventions.md` ("Operators") calls for: `plus`,
+ * `minus`, `cmp`, `lshift`, `rshift`.
+ *
+ * `test_next`'s `Date.today` / `DateTime.now` arms (`:161-172`) are not here:
+ * neither `date_s_today` (`date_core.c:3789-3826`) nor `datetime_s_now`
+ * (`:8134-8228`) is implemented, and RFC 0088's construction statics answer a
+ * `Temporal.PlainDate`, which carries no `next`/`succ` — so the return shape is
+ * a decision the port of those two has to make. Filed against 0088 as
+ * `port-date-today-and-datetime-now`.
  */
 import { describe, it, expect } from "vitest";
 import { ArgumentError, Date, DateTime, Rational, Time } from "./index.js";
@@ -138,12 +145,6 @@ describe("TestDateArith", () => {
     expect([d.year, d.mon, d.mday]).toEqual([2001, 1, 1]);
     d = new Date(2000, 12, 31).succ();
     expect([d.year, d.mon, d.mday]).toEqual([2001, 1, 1]);
-
-    // Ruby's `Date.today` / `DateTime.now` arms are not ported: RFC 0088's
-    // construction statics answer a `Temporal.PlainDate`, which carries no
-    // `next`/`succ`, and neither `date_s_today` (`date_core.c:3789-3826`) nor
-    // `datetime_s_now` (`date_core.c:8134-8228`) is implemented yet. Filed
-    // against 0088 as `port-date-today-and-datetime-now`.
   });
 
   it("next day", () => {

--- a/packages/date/src/test-date-arith.test.ts
+++ b/packages/date/src/test-date-arith.test.ts
@@ -6,7 +6,7 @@
  * `plus`, `minus`, `cmp`, `lshift`.
  */
 import { describe, it, expect } from "vitest";
-import { Date, DateTime, Rational, Time } from "./index.js";
+import { ArgumentError, Date, DateTime, Rational, Time } from "./index.js";
 
 /** `test_date_arith.rb:6-8` — a `Numeric` whose `to_r` answers itself, so the C's
  *  `f_to_r` retry makes no progress and the arm raises. */
@@ -131,5 +131,137 @@ describe("TestDateArith", () => {
     expect([d.year, d.mon, d.mday]).toEqual([1990, 1, 31]);
     d = new Date(2000, 1, 31).prevYear(100);
     expect([d.year, d.mon, d.mday]).toEqual([1900, 1, 31]);
+  });
+
+  it("next", () => {
+    let d = new Date(2000, 12, 31).next();
+    expect([d.year, d.mon, d.mday]).toEqual([2001, 1, 1]);
+    d = new Date(2000, 12, 31).succ();
+    expect([d.year, d.mon, d.mday]).toEqual([2001, 1, 1]);
+
+    // Ruby's `Date.today` / `DateTime.now` arms are not ported: RFC 0088's
+    // construction statics answer a `Temporal.PlainDate`, which carries no
+    // `next`/`succ`, and neither `date_s_today` (`date_core.c:3789-3826`) nor
+    // `datetime_s_now` (`date_core.c:8134-8228`) is implemented yet. Filed
+    // against 0088 as `port-date-today-and-datetime-now`.
+  });
+
+  it("next day", () => {
+    let d = new Date(2000, 12, 31).nextDay();
+    expect([d.year, d.mon, d.mday]).toEqual([2001, 1, 1]);
+    d = new Date(2000, 12, 31).nextDay(2);
+    expect([d.year, d.mon, d.mday]).toEqual([2001, 1, 2]);
+    d = new Date(2001, 1, 1).nextDay(-2);
+    expect([d.year, d.mon, d.mday]).toEqual([2000, 12, 30]);
+
+    const dt = new DateTime(2000, 2, 29).nextDay(new Rational(1, 2));
+    expect([dt.year, dt.mon, dt.mday, dt.hour, dt.min, dt.sec]).toEqual([2000, 2, 29, 12, 0, 0]);
+  });
+
+  it("next month", () => {
+    let d = new Date(2000, 1, 31).rshift(-1);
+    expect([d.year, d.mon, d.mday]).toEqual([1999, 12, 31]);
+    d = new Date(2000, 1, 31).rshift(1);
+    expect([d.year, d.mon, d.mday]).toEqual([2000, 2, 29]);
+    d = new Date(2000, 1, 31).rshift(12);
+    expect([d.year, d.mon, d.mday]).toEqual([2001, 1, 31]);
+    d = new Date(2000, 1, 31).rshift(13);
+    expect([d.year, d.mon, d.mday]).toEqual([2001, 2, 28]);
+  });
+
+  it("next month 2", () => {
+    let d = new Date(2000, 1, 31).nextMonth(-1);
+    expect([d.year, d.mon, d.mday]).toEqual([1999, 12, 31]);
+    d = new Date(2000, 1, 31).nextMonth();
+    expect([d.year, d.mon, d.mday]).toEqual([2000, 2, 29]);
+    d = new Date(2000, 1, 31).nextMonth(12);
+    expect([d.year, d.mon, d.mday]).toEqual([2001, 1, 31]);
+    d = new Date(2000, 1, 31).nextMonth(13);
+    expect([d.year, d.mon, d.mday]).toEqual([2001, 2, 28]);
+  });
+
+  it("next year", () => {
+    let d = new Date(2000, 1, 31).nextYear(-1);
+    expect([d.year, d.mon, d.mday]).toEqual([1999, 1, 31]);
+    d = new Date(2000, 1, 31).nextYear();
+    expect([d.year, d.mon, d.mday]).toEqual([2001, 1, 31]);
+    d = new Date(2000, 1, 31).nextYear(10);
+    expect([d.year, d.mon, d.mday]).toEqual([2010, 1, 31]);
+    d = new Date(2000, 1, 31).nextYear(100);
+    expect([d.year, d.mon, d.mday]).toEqual([2100, 1, 31]);
+  });
+
+  it("downto", () => {
+    const p = new Date(2001, 1, 14);
+    const q = new Date(2001, 1, 7);
+    let i = 0;
+    p.downto(q, () => {
+      i += 1;
+    });
+    expect(i).toBe(8);
+  });
+
+  it("downto noblock", () => {
+    const p = new Date(2001, 1, 14);
+    const q = new Date(2001, 1, 7);
+    const e = p.downto(q);
+    expect([...e].length).toBe(8);
+  });
+
+  it("upto", () => {
+    const p = new Date(2001, 1, 14);
+    const q = new Date(2001, 1, 21);
+    let i = 0;
+    p.upto(q, () => {
+      i += 1;
+    });
+    expect(i).toBe(8);
+  });
+
+  it("upto noblock", () => {
+    const p = new Date(2001, 1, 14);
+    const q = new Date(2001, 1, 21);
+    const e = p.upto(q);
+    expect([...e].length).toBe(8);
+  });
+
+  it("step", () => {
+    const p = new Date(2001, 1, 14);
+    const q = new Date(2001, 1, 21);
+    let i = 0;
+    p.step(q, 2, () => {
+      i += 1;
+    });
+    expect(i).toBe(4);
+
+    i = 0;
+    p.step(q, undefined, () => {
+      i += 1;
+    });
+    expect(i).toBe(8);
+  });
+
+  it("step noblock", () => {
+    const p = new Date(2001, 1, 14);
+    const q = new Date(2001, 1, 21);
+    let e = p.step(q, 2);
+    expect([...e].length).toBe(4);
+
+    e = p.step(q);
+    expect([...e].length).toBe(8);
+  });
+
+  it("step compare", () => {
+    const p = new Date(2000, 1, 1);
+    const q = new Date(1999, 12, 31);
+    let o: object = { cmp: () => undefined };
+    expect(() => [...p.step(q, o as never)]).toThrow(ArgumentError);
+
+    o = { cmp: () => 2 };
+    const a: Date[] = [];
+    p.step(q, o as never, (d) => {
+      a.push(d);
+    });
+    expect(a).toEqual([]);
   });
 });


### PR DESCRIPTION
Ports the second half of `vendor/date/test/date/test_date_arith.rb` (11 tests,
`:153-303`) plus the `Date` methods it exercises, and lands two small
convergences.

### `packages/date`

- `nextDay` (`date_core.c:6369-6377`), `next` / `succ` (`:6408-6412`;
  `Init_date_core` registers both names for the one C function at
  `:9779-9780`), `nextMonth` (`:6520-6529`), `nextYear` (`:6554-6563`).
- `step` (`d_lite_step`, `:6614-6653`) with `upto` (`:6659-6672`) and `downto`
  (`:6680-6693`). The block is an optional trailing parameter; an omitted one
  is the C's `RETURN_ENUMERATOR` arm and answers the generator that drives the
  same three-armed loop, which is what `test_step__noblock` reads through
  `to_a`.
- `fCmp` (`f_cmp`, `:74-86`) — its `rb_cmpint` tail is the `ArgumentError`
  `test_step__compare` asserts for a step whose `<=>` answers `nil`.

`test:compare --package date` now reads `test_date_arith.rb` 23/23 ✓ (package:
35/137, 4/10 files).

`test_next`'s `Date.today` / `DateTime.now` arms are **not** ported: neither
`date_s_today` (`date_core.c:3789-3826`) nor `datetime_s_now` (`:8134-8228`) is
implemented, and RFC 0088's construction statics answer a `Temporal.PlainDate`,
which carries no `next`/`succ` — so the return shape is a decision that story
has to make. Filed as `0088-date-gem-port/port-date-today-and-datetime-now`
(draft) with the C `file:line` in hand; the omission is commented at the test.

### `MysqlSchemaStatements#indexes`

Drops its `@internal` tag. Rails' `indexes` sits above the `private` keyword
(`mysql/schema_statements.rb:8` vs `:143`), so the tag — correct while the body
was a shim helper, before #6300 moved it onto the adapter — was hiding a public
ported method from `api:compare`. `addIndexLength` / `addOptionsForIndexColumns`
(`:229`, `:236`) keep theirs. `pnpm api:calls` stays clean, no new row.

### `LogSubscriber::LEVEL_CHECKS`

Calls the logger's own predicate as Rails does (`log_subscriber.rb:86-90`);
trails' `Logger` spells them `get "debug?"()`, so it is a property read. The
invented `isLevelEnabled` fallback chain — a `${level}Enabled` flag, a hardcoded
severity table, and an "assume enabled" tail that silently kept logging on for
an object Rails would have raised `NoMethodError` on — is deleted. No caller
was relying on it; `log-subscriber.test.ts` (activesupport 15, activerecord 21)
green unchanged.

### Drive-by

`DateTime#newOffset` reads `#getCJd()` / `#getCDf()` rather than the
possibly-unmaterialized `#jd` / `#df`, as `newStart` alongside it already does.
The raw reads left `pnpm typecheck` red on `origin/main` after #6313, which
blocks every commit through husky.

### Not in this PR

`move-adapter-specific-snapshot-off-ar-internal-metadata` was claimed with this
bundle and **released unbuilt**. Its own findings block (2026-08-07) says the
work is bigger than its estimate and that
`loadSchema` / `loadCanonicalSchema` / `loadAdapterSpecificSchema` /
`canonical-schema-stamp.ts` / `test-setup-dy.ts` are reshaped one story at a
time — "This story should be its own PR, not bundled"
(`load-schema-helper.ts:526-532` carries the same standing warning). Left for a
dedicated PR rather than folded in here.

### Review round 1

Two fixed, one answered.

**`upto` / `downto` dispatching through `step` — fixed.** `d_lite_upto`
(`date_core.c:6659-6672`) and `d_lite_downto` (`:6680-6693`) each write their own
loop over `d_lite_cmp` / `d_lite_plus` and never reach `d_lite_step`, so they now
have their own bodies here too (`dLiteUptoEnum` / `dLiteDowntoEnum`, alongside
`dLiteStepEnum`). The "equivalent to #step" wording is the C's own doc comment
and stays in the JSDoc, but it is no longer the implementation.

**`fCmp` on a step with no `cmp` — fixed.** Ruby's `Object.new` does answer
`<=>`; `Object#<=>` returns `nil` for an unrelated operand, so `rb_cmpint`
(`date_core.c:74-86`) raises `ArgumentError: comparison of Object with 0 failed`
rather than `NoMethodError`. An absent `cmp` now takes the `nil` arm instead of
failing on the call, so `p.step(q, {} as never)` raises that same
`ArgumentError`, not a JS `TypeError`.

**`nextMonth` / `nextYear` rejecting a `Rational` — fixed; my round-1 reply was
wrong.** I read `m = FIX2INT(f_mod(t, twelve)) + 1` (`date_core.c:6459`) as
proof the C could not carry a Rational, and missed that Ruby canonicalizes a
denominator of 1 back to an Integer: `f_mul(Rational(1,2), 12)` is `(6/1)`, so
`t` is an Integer and `d_lite_rshift` takes its `FIXNUM_P(t)` fast path. Your
`Date.new(2000,1,31).next_year(1/2r) # => 2000-07-31` is the C behaving
normally, not an edge.

So the narrowing is converged at its source rather than papered over at the
wrappers:

- `rshift` (`:6441-6478`) carries `t` as a `Rational` and branches on
  `denominator === 1n` — the C's `FIXNUM_P(t)` arm — with the `else` being its
  `f_idiv` / `f_mod` pair. `lshift`, `nextMonth`, `prevMonth`, `nextYear` and
  `prevYear` all widen to `number | bigint | Rational` behind it.
- `fMul12` is the `f_mul(n, INT2FIX(12))` of `d_lite_next_year` /
  `d_lite_prev_year` (`:6554-6563`, `:6571-6580`).

Checked against the built `dist`: `nextYear(Rational(1,2))` → 2000-07-31 (your
number), `prevYear(Rational(1,2))` → 1999-07-31, `nextMonth(Rational(6,2))` →
2000-04-30. `pnpm api:calls` still OK, date suite 190 green.

### Review round 3

**Fractional-month arm — fixed.** `FIX2INT` on a non-Fixnum is `rb_num2int`,
which **truncates**; I had used the fraction's full value, which walked the date
into the next month. `f_mod` is a floor-mod so the remainder is non-negative,
and the truncation is just the bigint division of the remainder by its
denominator (`date_core.c:6459`).

**Non-integer Float — fixed.** `1.5` no longer dies in `Rational.add`'s
`BigInt()`; a non-integral number is taken through `fToR` (`Float#to_r`, exact
in binary), so it reaches the same `else` arm. The C's `f_add3` answers a Float
and does `f_idiv` / `f_mod` in Float, which reads the same integers off the
exact ratio.

Against the built `dist`, all matching Ruby:

| call | result |
| --- | --- |
| `Date.new(2000,1,31) >> Rational(1,2)` | `2000-01-31` |
| `>> Rational(3,2)` | `2000-02-29` |
| `>> 1.5` | `2000-02-29` |
| `>> Rational(-1,2)` | `1999-12-31` |
| `<< 1.5` | `1999-11-30` (`f_mod(23998.5, 12)` is `10.5`, truncating to month 11) |
| `>> 1` / `>> 13` | `2000-02-29` / `2001-02-28` |
| `next_year(Rational(1,2))` / `prev_year(Rational(1,2))` | `2000-07-31` / `1999-07-31` |

`pnpm api:calls` OK, `pnpm lint` clean, date suite 190 green.

### Review round 4

**`fToR` hanging on a non-finite Float — fixed.** Real bug: `n *= 2` never
reaches an integer for `Infinity` / `-Infinity` / `NaN`, so the loop spun. Ruby
refuses these at `rb_num2int` — what `FIX2INT` is for the non-Fixnum arm of
`d_lite_rshift` (`date_core.c:6459`) — with the Float's own `to_s` as the
message, so `fToR` now raises a `FloatDomainError` carrying exactly that:

| call | result |
| --- | --- |
| `>> Float::INFINITY` | `FloatDomainError: Infinity` |
| `>> -Float::INFINITY` | `FloatDomainError: -Infinity` |
| `>> Float::NAN` | `FloatDomainError: NaN` |

`FloatDomainError` is spelled locally as a `RangeError` subclass (Ruby's own
ancestry), for the reason `NoMethodError` above it already is: this package is
the bottom of the dependency graph. It is `@internal`, so no new public surface.
`>> 1.5` still answers February; suite 190 green, `api:calls` OK, lint clean.

Closes-story: port-test-date-arith-iteration
Closes-story: mysql-indexes-is-public-in-rails-not-internal
Closes-story: converge-log-subscriber-level-checks-to-rails-predicates




