### PR TITLE
test(date): test_date_conv Date#+ arms, heuristic parse family; PG configureConnection argless

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1381,7 +1381,7 @@ export class PostgreSQLAdapter
       }
     }
     try {
-      await this.configureConnection(client);
+      await this.configureConnection();
       // Re-check teardown after every await: a concurrent reconnect
       // can null _rawConnection while configure is in flight.
       if (this._closed || this._rawConnection !== client) {
@@ -2902,7 +2902,7 @@ export class PostgreSQLAdapter
           // Rails' reset! ends in configure_connection
           // (postgresql_adapter.rb:371), so the dispatch goes through the
           // public, overridable hook.
-          return this.configureConnection(live).catch((error: unknown) => {
+          return this.configureConnection().catch((error: unknown) => {
             if (this._rawConnection === live) {
               this._rawConnection = null;
               this._connectionConfigured = false;
@@ -2935,13 +2935,11 @@ export class PostgreSQLAdapter
    * persistent client is configured exactly once per connection.
    *
    * Rails' `configure_connection` (postgresql_adapter.rb:956) is argless and
-   * operates on `@raw_connection`, so the argless call configures the current
-   * raw connection here too. The optional `client` parameter is the node-pg
-   * acquire-ordering escape hatch: `_acquireFreshClient` must configure the
-   * freshly-opened socket *before* installing it as `_rawConnection`, and libpq
-   * has no equivalent window because Rails' `connect` assigns `@raw_connection`
-   * first. Passing it is the only deviation, and it names the same connection
-   * Rails' body would have read.
+   * operates on `@raw_connection`, so this one is too. `_doAcquire` publishes
+   * the freshly-opened socket as `_rawConnection` before dispatching here, the
+   * way Rails' `connect` assigns `@raw_connection` before calling
+   * `configure_connection` — there is no pre-install window to configure
+   * through, and no parameter naming one.
    *
    * The inherited `reconnectBang` lifecycle calls this argless after the raw
    * `reconnect()` has nulled `_rawConnection`; PG opens the new connection
@@ -2950,8 +2948,8 @@ export class PostgreSQLAdapter
    *
    * @internal
    */
-  async configureConnection(client?: pg.Client): Promise<void> {
-    const conn = client ?? this._rawConnection;
+  async configureConnection(): Promise<void> {
+    const conn = this._rawConnection;
     if (!conn) return;
     return this._maybeConfigureConnection(conn);
   }

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -1534,15 +1534,6 @@ function parseDay(str: string, hash: DateParts): string | null {
 const NUMBER = "(?<!\\d)\\d";
 
 /**
- * @internal Onig's `\b` over a UTF-8 String is Unicode-aware, so it closes a
- * zone spelled in non-ASCII letters (`test_parse_utf8`'s `"日本"`); JS's `\b` is
- * defined over ASCII `\w` alone and would not. This is that boundary, in the
- * one position — the end of `parse_time`'s alphabetic zone alternatives
- * (`date_parse.c:720-723`) — where the difference is observable.
- */
-const WORD_BOUNDARY = "(?![\\p{L}\\p{N}_])";
-
-/**
  * @internal `date_parse.c` `parse_time2_cb` (`date_parse.c:613-653`): the hour/minute/second of the time
  * text `parse_time` matched, with `p`/`pm` moving the hour into the afternoon.
  */
@@ -1611,6 +1602,9 @@ function parseTimeCb(m: RegExpExecArray, hash: DateParts): number {
  * Onig's `[[:alpha:]]` is Unicode-aware over a UTF-8 String, so a zone spelled
  * in non-ASCII letters — `test_parse_utf8`'s `"日本"` — is a zone there. `\p{Alpha}`
  * under the `u` flag is the JS class with that repertoire; `[A-Za-z]` is not.
+ * The `\b` that closes each of those two alternatives is Unicode-aware for the
+ * same reason, and JS's is defined over ASCII `\w` alone — so it is spelled as
+ * the equivalent lookahead rather than as `\b`, which would reject `"日本"`.
  */
 function parseTime(str: string, hash: DateParts): string | null {
   const patSource =
@@ -1639,11 +1633,9 @@ function parseTime(str: string, hash: DateParts): string | null {
     "(" +
     "(?:gmt|utc?)?[-+]\\d+(?:[,.:]\\d+(?::\\d+)?)?" +
     "|" +
-    "[\\p{Alpha}.\\s]+(?:standard|daylight)\\stime" +
-    WORD_BOUNDARY +
+    "[\\p{Alpha}.\\s]+(?:standard|daylight)\\stime(?![\\p{L}\\p{N}_])" +
     "|" +
-    "[\\p{Alpha}]+(?:\\sdst)?" +
-    WORD_BOUNDARY +
+    "[\\p{Alpha}]+(?:\\sdst)?(?![\\p{L}\\p{N}_])" +
     ")" +
     ")?";
   return subx(str, " ", new RegExp(patSource, "iu"), hash, parseTimeCb);

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -1534,6 +1534,15 @@ function parseDay(str: string, hash: DateParts): string | null {
 const NUMBER = "(?<!\\d)\\d";
 
 /**
+ * @internal Onig's `\b` over a UTF-8 String is Unicode-aware, so it closes a
+ * zone spelled in non-ASCII letters (`test_parse_utf8`'s `"日本"`); JS's `\b` is
+ * defined over ASCII `\w` alone and would not. This is that boundary, in the
+ * one position — the end of `parse_time`'s alphabetic zone alternatives
+ * (`date_parse.c:720-723`) — where the difference is observable.
+ */
+const WORD_BOUNDARY = "(?![\\p{L}\\p{N}_])";
+
+/**
  * @internal `date_parse.c` `parse_time2_cb` (`date_parse.c:613-653`): the hour/minute/second of the time
  * text `parse_time` matched, with `p`/`pm` moving the hour into the afternoon.
  */
@@ -1598,6 +1607,10 @@ function parseTimeCb(m: RegExpExecArray, hash: DateParts): number {
  * Ruby turns `IGNORECASE` back off around the two alphabetic zone spellings
  * (`(?-i:…)`); the groups it guards are character classes that already span
  * both cases, so the ported pattern is the same language without the flag.
+ *
+ * Onig's `[[:alpha:]]` is Unicode-aware over a UTF-8 String, so a zone spelled
+ * in non-ASCII letters — `test_parse_utf8`'s `"日本"` — is a zone there. `\p{Alpha}`
+ * under the `u` flag is the JS class with that repertoire; `[A-Za-z]` is not.
  */
 function parseTime(str: string, hash: DateParts): string | null {
   const patSource =
@@ -1626,12 +1639,14 @@ function parseTime(str: string, hash: DateParts): string | null {
     "(" +
     "(?:gmt|utc?)?[-+]\\d+(?:[,.:]\\d+(?::\\d+)?)?" +
     "|" +
-    "[A-Za-z.\\s]+(?:standard|daylight)\\stime\\b" +
+    "[\\p{Alpha}.\\s]+(?:standard|daylight)\\stime" +
+    WORD_BOUNDARY +
     "|" +
-    "[A-Za-z]+(?:\\sdst)?\\b" +
+    "[\\p{Alpha}]+(?:\\sdst)?" +
+    WORD_BOUNDARY +
     ")" +
     ")?";
-  return subx(str, " ", new RegExp(patSource, "i"), hash, parseTimeCb);
+  return subx(str, " ", new RegExp(patSource, "iu"), hash, parseTimeCb);
 }
 
 /**
@@ -5436,7 +5451,7 @@ export class Date {
    * A string that named only a time of day answers no arm of
    * {@link rtValidDateFragsP} and raises.
    */
-  static parse(str: string, comp = true, start = DEFAULT_SG): Temporal.PlainDate {
+  static parse(str = JULIAN_EPOCH_DATE, comp = true, start = DEFAULT_SG): Temporal.PlainDate {
     return dNewByFrags(Date._parse(str, comp), val2sg(start)).toDate();
   }
 
@@ -7100,7 +7115,7 @@ export class DateTime extends DateWithoutParseStatics {
    * `Date._parse` followed by the DateTime-shaped build.
    */
   static parse(
-    str: string,
+    str = JULIAN_EPOCH_DATETIME,
     comp = true,
     start = DEFAULT_SG,
   ): Temporal.PlainDateTime | Temporal.ZonedDateTime {

--- a/packages/date/src/test-date-conv.test.ts
+++ b/packages/date/src/test-date-conv.test.ts
@@ -11,14 +11,13 @@
  * forbids `process.*`. The offset assertion it wraps is made directly instead —
  * a `ZonedDateTime` carries its own offset, so the host zone cannot change it.
  *
- * The five tests that build their subject with `Date#+` — `test_to_date__from_date`,
- * `test_to_datetime__from_date`, `test_to_time__from_datetime`,
- * `test_to_date__from_datetime` and `test_to_datetime__from_datetime` — are not
- * here: `d_lite_plus` (`date_core.c:4967`) is unported, so there is no way to
- * write `Date.new(2004, 9, 19) + 1.to_r/2`. They are filed against RFC 0088.
+ * The five tests that build their subject with `Date#+` read the day fraction
+ * off the gem-shaped receiver rather than off the converted value: MRI's
+ * `to_date` answers `self`, so `d2.day_fraction` there *is* `d.day_fraction`,
+ * while a `Temporal.PlainDate` has no time of day to carry one.
  */
 import { describe, it, expect } from "vitest";
-import { Temporal, Date, DateTime, Time } from "./index.js";
+import { Temporal, Date, DateTime, Rational, Time } from "./index.js";
 
 describe("TestDateConv", () => {
   it("to class", () => {
@@ -83,6 +82,46 @@ describe("TestDateConv", () => {
     expect(timeToDate(t).jd).toBe(d.jd);
   });
 
+  it("to time  from datetime", () => {
+    let d = new DateTime(2004, 9, 19, 1, 2, 3, new Rational(8, 24)).plus(
+      new Rational(456789, 86400000000),
+    );
+    let t = d.toTime();
+    expect([t.year, t.month, t.day, t.hour, t.minute, t.second, usec(t)]).toEqual([
+      2004, 9, 19, 1, 2, 3, 456789,
+    ]);
+    expect(t.offsetNanoseconds / 1_000_000_000).toBe(8 * 60 * 60);
+
+    d = new DateTime(2004, 9, 19, 1, 2, 3, 0).plus(new Rational(456789, 86400000000));
+    t = d.toTime().withTimeZone("UTC");
+    expect([t.year, t.month, t.day, t.hour, t.minute, t.second, usec(t)]).toEqual([
+      2004, 9, 19, 1, 2, 3, 456789,
+    ]);
+
+    d = new DateTime(1582, 10, 3, 1, 2, 3, 0).plus(new Rational(456789, 86400000000));
+    t = d.toTime().withTimeZone("UTC");
+    expect([t.year, t.month, t.day, t.hour, t.minute, t.second, usec(t)]).toEqual([
+      1582, 10, 13, 1, 2, 3, 456789,
+    ]);
+
+    d = new DateTime(2004, 9, 19, 1, 2, 3, 0).plus(new Rational(456789123, 86400000000000));
+    t = d.toTime().withTimeZone("UTC");
+    expect([t.year, t.month, t.day, t.hour, t.minute, t.second, nsec(t)]).toEqual([
+      2004, 9, 19, 1, 2, 3, 456789123,
+    ]);
+
+    // Ruby's last block asserts `t.subsec == Rational(456789123456789123, 10**18)`.
+    // `Temporal` holds nanoseconds, so the sub-nanosecond tail truncates here the
+    // way `Time#nsec` truncates it in MRI (see `DateTime#toDatetime`).
+    d = new DateTime(2004, 9, 19, 1, 2, 3, 0).plus(
+      new Rational(456789123456789123n, 86400000000000000000000n),
+    );
+    t = d.toTime().withTimeZone("UTC");
+    expect([t.year, t.month, t.day, t.hour, t.minute, t.second, nsec(t)]).toEqual([
+      2004, 9, 19, 1, 2, 3, 456789123,
+    ]);
+  });
+
   it("to date  from time", () => {
     let t = Time.mktime(2004, 9, 19, 1, 2, 3, 456789);
     let d = t.toDate();
@@ -95,6 +134,25 @@ describe("TestDateConv", () => {
     t = Time.utc(1582, 10, 13, 1, 2, 3, 456789);
     d = t.toDate();
     expect([d.year, d.month, d.day]).toEqual([1582, 10, 3]);
+  });
+
+  it("to date  from date", () => {
+    const d = new Date(2004, 9, 19).plus(new Rational(1, 2));
+    const d2 = d.toDate();
+    expect([d2.year, d2.month, d2.day]).toEqual([2004, 9, 19]);
+    expect((d.dayFraction as Rational).cmp(new Rational(1, 2))).toBe(0);
+  });
+
+  it("to date  from datetime", () => {
+    let d = new DateTime(2004, 9, 19, 1, 2, 3, new Rational(9, 24)).plus(
+      new Rational(456789, 86400000000),
+    );
+    let d2 = d.toDate();
+    expect([d2.year, d2.month, d2.day]).toEqual([2004, 9, 19]);
+
+    d = new DateTime(2004, 9, 19, 1, 2, 3, 0).plus(new Rational(456789, 86400000000));
+    d2 = d.toDate();
+    expect([d2.year, d2.month, d2.day]).toEqual([2004, 9, 19]);
   });
 
   it("to datetime  from time", () => {
@@ -119,11 +177,43 @@ describe("TestDateConv", () => {
     ]);
     expect(offsetSeconds(d)).toBe(0);
   });
+
+  it("to datetime  from date", () => {
+    const d = new Date(2004, 9, 19).plus(new Rational(1, 2));
+    const d2 = d.toDatetime();
+    expect([d2.year, d2.month, d2.day, d2.hour, d2.minute, d2.second, usec(d2)]).toEqual([
+      2004, 9, 19, 0, 0, 0, 0,
+    ]);
+    expect(offsetSeconds(d2)).toBe(0);
+  });
+
+  it("to datetime  from datetime", () => {
+    let d = new DateTime(2004, 9, 19, 1, 2, 3, new Rational(9, 24)).plus(
+      new Rational(456789, 86400000000),
+    );
+    let d2 = d.toDatetime();
+    expect([d2.year, d2.month, d2.day, d2.hour, d2.minute, d2.second, usec(d2)]).toEqual([
+      2004, 9, 19, 1, 2, 3, 456789,
+    ]);
+    expect(offsetSeconds(d2)).toBe(9 * 60 * 60);
+
+    d = new DateTime(2004, 9, 19, 1, 2, 3, 0).plus(new Rational(456789, 86400000000));
+    d2 = d.toDatetime();
+    expect([d2.year, d2.month, d2.day, d2.hour, d2.minute, d2.second, usec(d2)]).toEqual([
+      2004, 9, 19, 1, 2, 3, 456789,
+    ]);
+    expect(offsetSeconds(d2)).toBe(0);
+  });
 });
 
 /** Ruby `Time#usec` / `DateTime#sec_fraction`, off a Temporal value. */
 function usec(t: Temporal.ZonedDateTime | Temporal.PlainDateTime): number {
   return t.millisecond * 1000 + t.microsecond;
+}
+
+/** Ruby `Time#nsec`, off a Temporal value. */
+function nsec(t: Temporal.ZonedDateTime | Temporal.PlainDateTime): number {
+  return t.millisecond * 1_000_000 + t.microsecond * 1_000 + t.nanosecond;
 }
 
 /** Ruby `DateTime#offset`, in seconds rather than as a fraction of a day. */

--- a/packages/date/src/test-date-conv.test.ts
+++ b/packages/date/src/test-date-conv.test.ts
@@ -15,6 +15,12 @@
  * off the gem-shaped receiver rather than off the converted value: MRI's
  * `to_date` answers `self`, so `d2.day_fraction` there *is* `d.day_fraction`,
  * while a `Temporal.PlainDate` has no time of day to carry one.
+ *
+ * `test_to_time__from_datetime`'s last block asserts
+ * `t.subsec == Rational(456789123456789123, 10**18)`. `Temporal` holds
+ * nanoseconds, so the sub-nanosecond tail truncates in the seat the way
+ * `Time#nsec` truncates it in MRI (see `DateTime#toDatetime`); that block reads
+ * the nanosecond here.
  */
 import { describe, it, expect } from "vitest";
 import { Temporal, Date, DateTime, Rational, Time } from "./index.js";
@@ -110,9 +116,6 @@ describe("TestDateConv", () => {
       2004, 9, 19, 1, 2, 3, 456789123,
     ]);
 
-    // Ruby's last block asserts `t.subsec == Rational(456789123456789123, 10**18)`.
-    // `Temporal` holds nanoseconds, so the sub-nanosecond tail truncates here the
-    // way `Time#nsec` truncates it in MRI (see `DateTime#toDatetime`).
     d = new DateTime(2004, 9, 19, 1, 2, 3, 0).plus(
       new Rational(456789123456789123n, 86400000000000000000000n),
     );

--- a/packages/date/src/test-date-parse.test.ts
+++ b/packages/date/src/test-date-parse.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Port of ruby/date's `test/date/test_date_parse.rb`.
+ *
+ * RFC 0088 answers `Temporal` where MRI answers `Date`/`DateTime`
+ * (`vendor/sources.ts`'s `date` entry), so `Date.parse` / `DateTime.parse`
+ * assertions read the Temporal counterpart of the value Ruby asserts on.
+ * `Date._parse` answers the frag hash itself in both, with the hash keys
+ * camelCased by `docs/ruby-ts-conventions.md` (`:sec_fraction` is
+ * `secFraction`).
+ *
+ * The heuristic family's remaining tests are not here: `test__parse`'s table,
+ * `test__parse_too_long_year` (`limit:` kwarg), `test_parse__time` (`Time#to_s`
+ * and the `time` library's `iso8601`/`rfc2822`/`httpdate`/`xmlschema`),
+ * `test_parse__comp` (`DateTime.now`) and `test_parse__d_to_s`
+ * (`DateTime#to_s`) each need a reader this package has not ported. They are
+ * filed against RFC 0088.
+ */
+import { describe, it, expect } from "vitest";
+import { ArgumentError, Date, DateTime, Rational, dtNewByFrags, type DateParts } from "./date.js";
+
+/** Ruby's `h.values_at(...)` over the frag hash, `nil` for an absent key. */
+function valuesAt(h: DateParts, ...keys: (keyof DateParts)[]): unknown[] {
+  return keys.map((k) => h[k] ?? null);
+}
+
+describe("TestDateParse", () => {
+  it(" parse slash exp", () => {
+    const cases: [[string, boolean], (number | null)[]][] = [
+      // little
+      [
+        ["2/5/1999", false],
+        [1999, 5, 2, null, null, null, null, null, null],
+      ],
+      [
+        ["02/05/1999", false],
+        [1999, 5, 2, null, null, null, null, null, null],
+      ],
+      [
+        ["02/05/-1999", false],
+        [-1999, 5, 2, null, null, null, null, null, null],
+      ],
+      [
+        ["05/02", false],
+        [null, 5, 2, null, null, null, null, null, null],
+      ],
+      [
+        [" 5/ 2", false],
+        [null, 5, 2, null, null, null, null, null, null],
+      ],
+
+      [
+        ["2/5/'99", true],
+        [1999, 5, 2, null, null, null, null, null, null],
+      ],
+      [
+        ["2/5/0099", false],
+        [99, 5, 2, null, null, null, null, null, null],
+      ],
+      [
+        ["2/5/0099", true],
+        [99, 5, 2, null, null, null, null, null, null],
+      ],
+
+      [
+        ["2/5 1999", false],
+        [1999, 5, 2, null, null, null, null, null, null],
+      ],
+      [
+        ["2/5-1999", false],
+        [1999, 5, 2, null, null, null, null, null, null],
+      ],
+      [
+        ["2/5--1999", false],
+        [-1999, 5, 2, null, null, null, null, null, null],
+      ],
+
+      // big
+      [
+        ["99/5/2", false],
+        [99, 5, 2, null, null, null, null, null, null],
+      ],
+      [
+        ["99/5/2", true],
+        [1999, 5, 2, null, null, null, null, null, null],
+      ],
+
+      [
+        ["1999/5/2", false],
+        [1999, 5, 2, null, null, null, null, null, null],
+      ],
+      [
+        ["1999/05/02", false],
+        [1999, 5, 2, null, null, null, null, null, null],
+      ],
+      [
+        ["-1999/05/02", false],
+        [-1999, 5, 2, null, null, null, null, null, null],
+      ],
+
+      [
+        ["0099/5/2", false],
+        [99, 5, 2, null, null, null, null, null, null],
+      ],
+      [
+        ["0099/5/2", true],
+        [99, 5, 2, null, null, null, null, null, null],
+      ],
+
+      [
+        ["'99/5/2", false],
+        [99, 5, 2, null, null, null, null, null, null],
+      ],
+      [
+        ["'99/5/2", true],
+        [1999, 5, 2, null, null, null, null, null, null],
+      ],
+    ];
+    for (const [x, y] of cases) {
+      const h = Date._parse(...x);
+      const a = valuesAt(h, "year", "mon", "mday", "hour", "min", "sec", "zone", "offset", "wday");
+      expect(a, `<failed at ${x[0]}>`).toEqual(y);
+    }
+  });
+
+  it(" parse  2", () => {
+    let h = Date._parse("22:45:59.5");
+    expect(secFrag(h)).toEqual([22, 45, 59, new Rational(5, 10 ** 1)]);
+    h = Date._parse("22:45:59.05");
+    expect(secFrag(h)).toEqual([22, 45, 59, new Rational(5, 10 ** 2)]);
+    h = Date._parse("22:45:59.005");
+    expect(secFrag(h)).toEqual([22, 45, 59, new Rational(5, 10 ** 3)]);
+    h = Date._parse("22:45:59.0123");
+    expect(secFrag(h)).toEqual([22, 45, 59, new Rational(123, 10 ** 4)]);
+
+    h = Date._parse("224559.5");
+    expect(secFrag(h)).toEqual([22, 45, 59, new Rational(5, 10 ** 1)]);
+    h = Date._parse("224559.05");
+    expect(secFrag(h)).toEqual([22, 45, 59, new Rational(5, 10 ** 2)]);
+    h = Date._parse("224559.005");
+    expect(secFrag(h)).toEqual([22, 45, 59, new Rational(5, 10 ** 3)]);
+    h = Date._parse("224559.0123");
+    expect(secFrag(h)).toEqual([22, 45, 59, new Rational(123, 10 ** 4)]);
+
+    h = Date._parse("2006-w15-5");
+    expect(valuesAt(h, "cwyear", "cweek", "cwday")).toEqual([2006, 15, 5]);
+    h = Date._parse("2006w155");
+    expect(valuesAt(h, "cwyear", "cweek", "cwday")).toEqual([2006, 15, 5]);
+    h = Date._parse("06w155", false);
+    expect(valuesAt(h, "cwyear", "cweek", "cwday")).toEqual([6, 15, 5]);
+    h = Date._parse("06w155", true);
+    expect(valuesAt(h, "cwyear", "cweek", "cwday")).toEqual([2006, 15, 5]);
+
+    h = Date._parse("2006-w15");
+    expect(valuesAt(h, "cwyear", "cweek", "cwday")).toEqual([2006, 15, null]);
+    h = Date._parse("2006w15");
+    expect(valuesAt(h, "cwyear", "cweek", "cwday")).toEqual([2006, 15, null]);
+
+    h = Date._parse("-w15-5");
+    expect(valuesAt(h, "cwyear", "cweek", "cwday")).toEqual([null, 15, 5]);
+    h = Date._parse("-w155");
+    expect(valuesAt(h, "cwyear", "cweek", "cwday")).toEqual([null, 15, 5]);
+
+    h = Date._parse("-w15");
+    expect(valuesAt(h, "cwyear", "cweek", "cwday")).toEqual([null, 15, null]);
+    h = Date._parse("-w15");
+    expect(valuesAt(h, "cwyear", "cweek", "cwday")).toEqual([null, 15, null]);
+
+    h = Date._parse("-w-5");
+    expect(valuesAt(h, "cwyear", "cweek", "cwday")).toEqual([null, null, 5]);
+
+    h = Date._parse("--11-29");
+    expect(valuesAt(h, "year", "mon", "mday")).toEqual([null, 11, 29]);
+    h = Date._parse("--1129");
+    expect(valuesAt(h, "year", "mon", "mday")).toEqual([null, 11, 29]);
+    h = Date._parse("--11");
+    expect(valuesAt(h, "year", "mon", "mday")).toEqual([null, 11, null]);
+    h = Date._parse("---29");
+    expect(valuesAt(h, "year", "mon", "mday")).toEqual([null, null, 29]);
+    h = Date._parse("-333");
+    expect(valuesAt(h, "year", "yday")).toEqual([null, 333]);
+
+    h = Date._parse("2006-333");
+    expect(valuesAt(h, "year", "yday")).toEqual([2006, 333]);
+    h = Date._parse("2006333");
+    expect(valuesAt(h, "year", "yday")).toEqual([2006, 333]);
+    h = Date._parse("06333", false);
+    expect(valuesAt(h, "year", "yday")).toEqual([6, 333]);
+    h = Date._parse("06333", true);
+    expect(valuesAt(h, "year", "yday")).toEqual([2006, 333]);
+    h = Date._parse("333");
+    expect(valuesAt(h, "year", "yday")).toEqual([null, 333]);
+
+    h = Date._parse("");
+    expect(h).toEqual({});
+  });
+
+  it("parse", () => {
+    expect(Date.parse().equals(new Date().toDate())).toBe(true);
+    expect(Date.parse("2002-03-14").equals(new Date(2002, 3, 14).toDate())).toBe(true);
+
+    expect(
+      DateTime.parse("2002-03-14T11:22:33Z").equals(
+        new DateTime(2002, 3, 14, 11, 22, 33, 0).toDatetime(),
+      ),
+    ).toBe(true);
+    expect(
+      DateTime.parse("2002-03-14T11:22:33+09:00").equals(
+        new DateTime(2002, 3, 14, 11, 22, 33, new Rational(9, 24)).toDatetime(),
+      ),
+    ).toBe(true);
+    expect(
+      DateTime.parse("2002-03-14T11:22:33-09:00").equals(
+        new DateTime(2002, 3, 14, 11, 22, 33, new Rational(-9, 24)).toDatetime(),
+      ),
+    ).toBe(true);
+    expect(
+      DateTime.parse("2002-03-14T11:22:33.123456789-09:00").equals(
+        new DateTime(2002, 3, 14, 11, 22, 33, new Rational(-9, 24))
+          .plus(new Rational(123456789, 1000000000 * 86400))
+          .toDatetime(),
+      ),
+    ).toBe(true);
+  });
+
+  it("parse  2", () => {
+    let d1 = dtParse("2004-03-13T22:45:59.5");
+    let d2 = dtParse("2004-03-13T22:45:59");
+    expect(d2.plus(new Rational(5, 10 ** 1 * 86400)).equals(d1)).toBe(true);
+    d1 = dtParse("2004-03-13T22:45:59.05");
+    d2 = dtParse("2004-03-13T22:45:59");
+    expect(d2.plus(new Rational(5, 10 ** 2 * 86400)).equals(d1)).toBe(true);
+    d1 = dtParse("2004-03-13T22:45:59.005");
+    d2 = dtParse("2004-03-13T22:45:59");
+    expect(d2.plus(new Rational(5, 10 ** 3 * 86400)).equals(d1)).toBe(true);
+    d1 = dtParse("2004-03-13T22:45:59.0123");
+    d2 = dtParse("2004-03-13T22:45:59");
+    expect(d2.plus(new Rational(123, 10 ** 4 * 86400)).equals(d1)).toBe(true);
+    d1 = dtParse("2004-03-13T22:45:59.5");
+    d1 = d1.plus(new Rational(1, 2 * 86400));
+    d2 = dtParse("2004-03-13T22:46:00");
+    expect(d2.equals(d1)).toBe(true);
+  });
+
+  it(" parse odd offset", () => {
+    let h = DateTime._parse("2001-02-03T04:05:06+1");
+    expect(h.offset).toBe(3600);
+    h = DateTime._parse("2001-02-03T04:05:06+123");
+    expect(h.offset).toBe(4980);
+    h = DateTime._parse("2001-02-03T04:05:06+12345");
+    expect(h.offset).toBe(5025);
+  });
+
+  it("parse utf8", () => {
+    const h = DateTime._parse("Sun\u{3000}Aug 16 01:02:03 \u{65e5}\u{672c} 2009");
+    expect(h.year).toBe(2009);
+    expect(h.mon).toBe(8);
+    expect(h.mday).toBe(16);
+    expect(h.wday).toBe(0);
+    expect(h.hour).toBe(1);
+    expect(h.min).toBe(2);
+    expect(h.sec).toBe(3);
+    expect(h.zone).toBe("\u{65e5}\u{672c}");
+  });
+
+  it("parse  ex", () => {
+    expect(() => Date.parse("")).toThrow(Date.Error);
+    expect(() => DateTime.parse("")).toThrow(Date.Error);
+    expect(() => Date.parse("2001-02-29")).toThrow(Date.Error);
+    expect(() => DateTime.parse("2001-02-29T23:59:60")).toThrow(Date.Error);
+    expect(() => DateTime.parse("2001-03-01T23:59:60")).not.toThrow();
+    expect(() => DateTime.parse("2001-03-01T23:59:61")).toThrow(Date.Error);
+    expect(() => Date.parse("23:55")).toThrow(Date.Error);
+
+    // Ruby's two trailing `begin ... rescue ArgumentError => e` blocks assert
+    // that what `parse('')` raises is BOTH an ArgumentError and a Date::Error.
+    expect(() => Date.parse("")).toThrow(ArgumentError);
+    expect(() => DateTime.parse("")).toThrow(ArgumentError);
+  });
+});
+
+/**
+ * Ruby's `DateTime.parse` before `to_datetime`: `test_parse__2` adds a day
+ * fraction to the parsed value with `Date#+`, which only the gem-shaped object
+ * carries (RFC 0088's seat answers `Temporal`).
+ */
+function dtParse(str: string): DateTime {
+  return dtNewByFrags(Date._parse(str));
+}
+
+/** Ruby `h.values_at(:hour, :min, :sec, :sec_fraction)`. */
+function secFrag(h: DateParts): unknown[] {
+  return valuesAt(h, "hour", "min", "sec", "secFraction");
+}

--- a/packages/date/src/test-date-parse.test.ts
+++ b/packages/date/src/test-date-parse.test.ts
@@ -14,6 +14,10 @@
  * `test_parse__comp` (`DateTime.now`) and `test_parse__d_to_s`
  * (`DateTime#to_s`) each need a reader this package has not ported. They are
  * filed against RFC 0088.
+ *
+ * `test_parse__ex`'s two trailing `begin ... rescue ArgumentError => e` blocks
+ * assert that what `parse('')` raises is both an `ArgumentError` and a
+ * `Date::Error`; they are the last two expectations of `parse  ex`.
  */
 import { describe, it, expect } from "vitest";
 import { ArgumentError, Date, DateTime, Rational, dtNewByFrags, type DateParts } from "./date.js";
@@ -118,6 +122,10 @@ describe("TestDateParse", () => {
     for (const [x, y] of cases) {
       const h = Date._parse(...x);
       const a = valuesAt(h, "year", "mon", "mday", "hour", "min", "sec", "zone", "offset", "wday");
+      if (y[1] === -1) {
+        a[1] = -1;
+        a[2] = h.yday ?? null;
+      }
       expect(a, `<failed at ${x[0]}>`).toEqual(y);
     }
   });
@@ -271,8 +279,6 @@ describe("TestDateParse", () => {
     expect(() => DateTime.parse("2001-03-01T23:59:61")).toThrow(Date.Error);
     expect(() => Date.parse("23:55")).toThrow(Date.Error);
 
-    // Ruby's two trailing `begin ... rescue ArgumentError => e` blocks assert
-    // that what `parse('')` raises is BOTH an ArgumentError and a Date::Error.
     expect(() => Date.parse("")).toThrow(ArgumentError);
     expect(() => DateTime.parse("")).toThrow(ArgumentError);
   });


### PR DESCRIPTION
Bundle of three stories.

## `port-test-date-conv-date-plus-arms`

#6313 landed `Date#plus` (`date_core.c` `d_lite_plus`, all four operand arms),
`Date#dayFraction` and the `ComplexDateData` arm the story called the real
blocker, so what was left here was the five tests. They land in
`packages/date/src/test-date-conv.test.ts`, taking it to **12/12**.

The day-fraction assertions read the gem-shaped receiver rather than the
converted value: MRI's `to_date` answers `self`, so `d2.day_fraction` there
*is* `d.day_fraction`, while a `Temporal.PlainDate` has no time of day to carry
one. `test_to_time__from_datetime`'s `subsec` block asserts nanoseconds —
`Temporal` holds nanoseconds and the sub-nanosecond tail truncates exactly as
`Time#nsec` truncates it in MRI.

## `port-test-date-parse-heuristic`

7 of the family land in a new `packages/date/src/test-date-parse.test.ts`:
`test__parse_slash_exp`, `test__parse__2`, `test_parse`, `test_parse__2`,
`test__parse_odd_offset`, `test_parse_utf8`, `test_parse__ex`.
`test:compare --package date` credits all 7 (`date: 35/137, 5/10 files`).

Two real failures were fixed in `packages/date/src`:

- `Date.parse` / `DateTime.parse` had no default `str`. MRI's `rb_scan_args`
  `"03:"` arm supplies `JULIAN_EPOCH_DATE` / `JULIAN_EPOCH_DATETIME`
  (`date_core.c:4577`, `:8429`).
- `parse_time`'s alphabetic zone class was `[A-Za-z]`. Onig's `[[:alpha:]]`
  over a UTF-8 String is Unicode-aware (`date_parse.c:720-723`), which is what
  makes `"日本"` a zone; the trailing `\b` is spelled as a lookahead because
  JS's `\b` is defined over ASCII `\w` alone.

The remaining five — `test__parse`'s ~420-line table, and four blocked on an
unported reader (`limit:` + a `bigint` `:year`, `Time#to_s`/`iso8601`/…,
`DateTime.now`, `DateTime#to_s`) — are filed as
`0088/port-test-date-parse-heuristic-remainder` rather than growing this PR.

## `pg-configure-connection-drop-client-parameter`

`configureConnection` is argless, matching `postgresql_adapter.rb:956`. The
ordering inversion the story anticipated was not needed: `_doAcquire` already
publishes the fresh socket as `_rawConnection` before dispatching, the way
Rails' `connect` assigns `@raw_connection` first, and `resetBang`'s dispatch is
already guarded on `_rawConnection === live`. Both call sites therefore already
named the current raw connection; the parameter was dead.

## Drive-by

`DateTime#newOffset` passed `this.#jd` (`number | undefined`) where the seat
wants a `number`, which failed `tsc --build` on `main` and blocked
`api:compare` with `OutOfDateBuildInfoWithErrors` for `packages/date`. It now
reads the stored jd through `#getCJd()`, as the sibling `newStart` does.

Closes-story: port-test-date-conv-date-plus-arms
Closes-story: port-test-date-parse-heuristic
Closes-story: pg-configure-connection-drop-client-parameter
