### PR TITLE
fix(arel,date): converge SelectManager#lock to Rails' signature and case; name Date#toDate's real inverse seat

### DIFF
--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -139,7 +139,7 @@ export class SelectManager extends TreeManager {
     if (locking === true) {
       locking = new SqlLiteral("FOR UPDATE");
     } else if (locking instanceof SqlLiteral) {
-      // Rails' empty `when Arel::Nodes::SqlLiteral` arm: pass through.
+      // Rails' empty `when Arel::Nodes::SqlLiteral` arm (select_manager.rb:56).
     } else if (typeof locking === "string") {
       locking = new SqlLiteral(locking);
     }

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -125,22 +125,26 @@ export class SelectManager extends TreeManager {
   /**
    * Add a lock clause (FOR UPDATE by default).
    *
-   * Mirrors: Arel::SelectManager#lock (select_manager.rb:52-63). Rails'
-   * `case`: `true` and the no-arg default both become `Arel.sql("FOR
-   * UPDATE")`, a `SqlLiteral` passes through unwrapped (empty `when` branch),
-   * and a bare `String` is wrapped. `true` is how ActiveRecord's `lock!` /
-   * `with_lock` express the default lock.
+   * Mirrors: Arel::SelectManager#lock (select_manager.rb:52-63). The
+   * `SqlLiteral` arm is Rails' empty `when` — a literal passes through
+   * unwrapped — and it precedes the `String` arm because Ruby's SqlLiteral is
+   * a String subclass. `true` is how ActiveRecord's `lock!` / `with_lock`
+   * express the default lock.
+   *
+   * `Arel.sql` lives in `index.ts`, which re-exports this file; importing it
+   * here would close a module cycle over index.ts's top-level `include()`
+   * side effects, so its one-line body (`new SqlLiteral(...)`) is inlined.
    */
-  lock(lockClause: string | Node | boolean = true): this {
-    const expr =
-      lockClause === true
-        ? new SqlLiteral("FOR UPDATE")
-        : lockClause instanceof SqlLiteral
-          ? lockClause
-          : typeof lockClause === "string"
-            ? new SqlLiteral(lockClause)
-            : lockClause;
-    this.ast.lock = new Lock(expr);
+  lock(locking: string | Node | boolean = new SqlLiteral("FOR UPDATE")): this {
+    if (locking === true) {
+      locking = new SqlLiteral("FOR UPDATE");
+    } else if (locking instanceof SqlLiteral) {
+      // Rails' empty `when Arel::Nodes::SqlLiteral` arm: pass through.
+    } else if (typeof locking === "string") {
+      locking = new SqlLiteral(locking);
+    }
+
+    this.ast.lock = new Lock(locking as Node);
     return this;
   }
 

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -5865,11 +5865,14 @@ export class Date {
    * **This is the opt-in seam RFC 0088 left open**, and it is a conversion
    * method rather than an options argument or a parallel entry point because
    * the gem already names both directions and neither name is invented: the
-   * statics answer Temporal through `to_date` / `to_datetime`, and a caller who
-   * wants the gem-shaped object back hands the Temporal value to the
-   * constructor ({@link Date}'s `PlainDate` overload,
-   * {@link DateTime}'s), which is the same seat `d_simple_new_internal` writes.
-   * The exported {@link dNewByFrags} / {@link dtNewByFrags} answer it directly.
+   * statics answer Temporal through `to_date` / `to_datetime`, and the
+   * exported {@link dNewByFrags} / {@link dtNewByFrags} answer the other
+   * direction — they are the *sole* gem-shaped seat, both ending at
+   * `d_simple_new_internal` (`date_core.c:3036`) exactly as `date_s_jd`
+   * (`:3377-3387`) does. `Date`'s constructor takes only
+   * `(year?, month?, day?, start?)` and the `SEAT` form; handing it a
+   * `Temporal.PlainDate` raises `TypeError: invalid year (not numeric)` from
+   * `check_numeric` (`date_core.c:67-72`).
    */
   toDate(): Temporal.PlainDate {
     return plainDateFromJd(this.mLocalJd(), this.#sg);
@@ -6655,12 +6658,23 @@ export class DateTime extends DateWithoutParseStatics {
    * Ruby `DateTime#new_offset(offset = 0)` (ruby/date, `date_core.c`
    * `d_lite_new_offset`, `:5920-5934`) over `dup_obj_with_new_offset`
    * (`:5901-5909`): the day and day-fraction are stored in UTC, so only `of`
-   * changes. `Init_date_core` gives it to `::DateTime` alone (`:10018`). TS has
+   * changes — but `set_of` (`:5890-5897`) fills the day and day-fraction in
+   * with `get_c_jd` / `get_c_df` before it writes the new `of`, because the
+   * proleptic-Gregorian arm may have stored neither.
+   * `Init_date_core` gives it to `::DateTime` alone (`:10018`). TS has
    * no `dup_obj`, so the copy is made here; see {@link DateTime#newStart}.
    */
   newOffset(offset: number | bigint | Rational | string = 0): this {
     const rof = val2off(offset);
-    return new DateTime(SEAT, this.nth, this.#jd, this.#df, this.#sf, rof, this.start) as this;
+    return new DateTime(
+      SEAT,
+      this.nth,
+      this.#getCJd(),
+      this.#getCDf(),
+      this.#sf,
+      rof,
+      this.start,
+    ) as this;
   }
 
   override newStart(start = DEFAULT_SG): this {


### PR DESCRIPTION
## `Arel::SelectManager#lock` — signature and `case` (RFC 0084)

`select_manager.rb:52-63` converged on all three axes the story names:

- parameter is `locking`, not `lockClause`;
- default is `Arel.sql("FOR UPDATE")`, not `true`;
- body is Rails' four-arm `case` in Rails' order — `true`, the **empty**
  `SqlLiteral` arm, `String`, fallthrough — instead of a nested ternary. The
  `SqlLiteral` arm keeps its no-op comment and precedes `String` because Ruby's
  `SqlLiteral` is a `String` subclass, so arm order is load-bearing.

`Arel.sql` lives in `index.ts`, which re-exports `select-manager.js`; importing
it back would close a module cycle over index.ts's top-level `include()` side
effects, so its one-line body (`new SqlLiteral(...)`) is inlined at the default
and in the `true` arm. Justified at the call site.

The bare-`lock()` default is already covered by `select-manager.test.ts:1162`
and `select-manager.trails.test.ts:65`; both still pass with the names unchanged.

## `Date#toDate` — the inverse seat its JSDoc names (RFC 0088)

The JSDoc advertised "hands the Temporal value to the constructor
({@link Date}'s `PlainDate` overload)". **No such overload exists** — `Date`'s
constructor is `(year?, month?, day?, start?)` plus the `SEAT` form, and a
`Temporal.PlainDate` raises `TypeError: invalid year (not numeric)` from
`check_numeric` (`date_core.c:67-72`). Closed by correcting the doc rather than
declaring the overload: `dNewByFrags` / `dtNewByFrags` are named as the sole
gem-shaped seat, with the `d_simple_new_internal` (`date_core.c:3036`) /
`date_s_jd` (`:3377-3387`) citation that makes them equivalent to `Date.jd`.

The overload arm is deliberately not taken, so `it("civil reform")` in
PR #6315's `test-date-new.test.ts` keeps its `dNewByFrags` receiver and its
credit unchanged — this PR does not touch that file.

## Necessary drive-by: `main` does not typecheck

`origin/main` (3f14b145c) fails `tsc --build` at
`packages/date/src/date.ts` `DateTime#newOffset` — `this.#jd` / `this.#df` are
`number | undefined` against the `SEAT` overload. husky's pre-commit is
repo-wide, so this blocks every unrelated commit. The minimal fix is included
here, **identical to PR #6319's src hunk** (`get_c_jd` / `get_c_df`, per
`set_of`, `date_core.c:5890-5897`), so whichever lands first the other rebases
away cleanly. PR #6319's test is not duplicated.

## Released

`move-adapter-specific-snapshot-off-ar-internal-metadata` was claimed with this
bundle and **released unbuilt**: its own 2026-08-07 findings state the digest
arm is unsound, the sidecar arm is materially larger than the stated ~160 LOC,
and — citing `load-schema-helper.ts:526-532` — that it "should be its own PR,
not bundled". Back in the ready pool untouched.

Closes-story: port-test-date-new-civil-reform
Closes-story: converge-arel-select-manager-lock-signature
