### PR TITLE
fix(activerecord): pass a nameless query's nil name through to the uncached sql payload

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -2621,7 +2621,7 @@ export class AbstractAdapter implements Quoting {
    */
   async log<T>(
     sql: string,
-    name: string | null | undefined = "SQL",
+    name: string | null = "SQL",
     binds: unknown[] = [],
     typeCastedBinds: unknown[] = [],
     isAsync = false,
@@ -2637,7 +2637,7 @@ export class AbstractAdapter implements Quoting {
         "sql.active_record",
         {
           sql,
-          name: name ?? "SQL",
+          name,
           binds,
           type_casted_binds: typeCastedBinds,
           async: isAsync,

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
@@ -346,7 +346,7 @@ describe("DatabaseStatements", () => {
       const host = {
         log,
         typeCastedBinds,
-        internalExecute: async (sql: string, name: string, opts?: { binds?: unknown[] }) =>
+        internalExecute: async (sql: string, name: string | null, opts?: { binds?: unknown[] }) =>
           log(sql, name, opts?.binds ?? [], [], false, async () => {
             throw new StatementInvalid("duplicate key value violates unique constraint");
           }),
@@ -368,7 +368,7 @@ describe("DatabaseStatements", () => {
       const host = {
         log,
         typeCastedBinds,
-        internalExecute: async (sql: string, name: string, opts?: { binds?: unknown[] }) =>
+        internalExecute: async (sql: string, name: string | null, opts?: { binds?: unknown[] }) =>
           log(sql, name, opts?.binds ?? [], [], false, async () => {
             throw new StatementInvalid("boom", { sql: "ORIGINAL", binds: [99] });
           }),

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -110,7 +110,7 @@ export interface DatabaseStatementsHost {
   /** @internal */
   internalExecute?(
     sql: string,
-    name?: string,
+    name?: string | null,
     opts?: {
       materializeTransactions?: boolean;
       allowRetry?: boolean;
@@ -128,7 +128,7 @@ export interface DatabaseStatementsHost {
   /** @internal */
   dirtyCurrentTransaction?(): void;
   /** @internal */
-  rawExecute?(sql: string, name?: string, binds?: unknown[]): Promise<unknown>;
+  rawExecute?(sql: string, name?: string | null, binds?: unknown[]): Promise<unknown>;
   /** @internal */
   castResult?(rawResult: unknown): Result;
   /** @internal */
@@ -145,7 +145,7 @@ export interface DatabaseStatementsHost {
   withinNewTransaction?<T>(opts: unknown, fn: (tx?: unknown) => Promise<T> | T): Promise<T>;
   disableReferentialIntegrity?(fn: () => Promise<void>, tables?: string[]): Promise<void>;
   /** @internal */
-  executeBatch?(statements: string[], name?: string): Promise<void>;
+  executeBatch?(statements: string[], name?: string | null): Promise<void>;
   /** @internal */
   buildTruncateStatement?(tableName: string): string;
   /** @internal */
@@ -417,7 +417,7 @@ export function selectAll(sql: string, _name?: string | null, _binds?: unknown[]
 export async function selectOne(
   this: DatabaseStatementsHost | void,
   sql: string,
-  name?: string | null,
+  name: string | null = null,
   binds?: unknown[],
 ): Promise<Record<string, unknown> | undefined> {
   const doSelect = (this as DatabaseStatementsHost)?.selectAll ?? selectAll;
@@ -433,7 +433,7 @@ export async function selectOne(
 export function selectValue(
   this: DatabaseStatementsHost | void,
   sql: string,
-  name?: string | null,
+  name: string | null = null,
   binds?: unknown[],
 ): Promise<unknown> {
   return selectRows.call(this, sql, name, binds).then((rows) => singleValueFromRows(rows));
@@ -447,7 +447,7 @@ export function selectValue(
 export function selectValues(
   this: DatabaseStatementsHost | void,
   sql: string,
-  name?: string | null,
+  name: string | null = null,
   binds?: unknown[],
 ): Promise<unknown[]> {
   return selectRows.call(this, sql, name, binds).then((rows) => rows.map((row) => row[0]));
@@ -461,7 +461,7 @@ export function selectValues(
 export async function selectRows(
   this: DatabaseStatementsHost | void,
   sql: string,
-  name?: string | null,
+  name: string | null = null,
   binds?: unknown[],
 ): Promise<unknown[][]> {
   const doSelect = (this as DatabaseStatementsHost)?.selectAll ?? selectAll;
@@ -511,7 +511,7 @@ export async function query(
   // Dispatch through the instance so an adapter's internalExecQuery override
   // wins, as Ruby's virtual call does.
   const run = (this.internalExecQuery ?? internalExecQuery).bind(this);
-  const result = await run(sql, name ?? "SQL", binds);
+  const result = await run(sql, name, binds);
   return result.rows;
 }
 
@@ -542,7 +542,7 @@ export function execute(_sql: string, _binds?: unknown[], _name?: string | null)
 export function execQuery(
   this: DatabaseStatementsHost | void,
   sql: string,
-  name: string = "SQL",
+  name: string | null = "SQL",
   binds: unknown[] = [],
 ): Promise<Result> {
   // Dispatch through the instance so an adapter's internalExecQuery override
@@ -561,7 +561,7 @@ export function execQuery(
 export function execInsert(
   this: DatabaseStatementsHost | void,
   sql: string,
-  name?: string | null,
+  name: string | null = null,
   binds: unknown[] = [],
   pk?: string | false | null,
   _sequenceName?: string | null,
@@ -579,7 +579,7 @@ export function execInsert(
   const run = ((this as DatabaseStatementsHost).internalExecQuery ?? internalExecQuery).bind(
     this as DatabaseStatementsHost,
   );
-  return run(sql, name ?? "SQL", binds);
+  return run(sql, name, binds);
 }
 
 /**
@@ -602,7 +602,7 @@ export function execInsert(
 export async function execInsertReturningReadback(
   this: DatabaseStatementsHost,
   sql: string,
-  name: string | null | undefined,
+  name: string | null,
   binds: unknown[],
   pk: string | false | null | undefined,
   returning: string[] | null | undefined,
@@ -623,7 +623,7 @@ export async function execInsertReturningReadback(
   // Dispatch through the instance so SQLite's bind-aware internalExecQuery
   // override (`.all()`) is used; PG/MySQL fall to the mixed-in default.
   const run = (this.internalExecQuery ?? internalExecQuery).bind(this);
-  const result = await run(returningSql, name ?? "SQL", returningBinds);
+  const result = await run(returningSql, name, returningBinds);
   this.dirtyCurrentTransaction?.();
   return result;
 }
@@ -636,7 +636,7 @@ export async function execInsertReturningReadback(
 export async function execDelete(
   this: DatabaseStatementsHost | void,
   sql: string,
-  name?: string | null,
+  name: string | null = null,
   binds: unknown[] = [],
 ): Promise<number> {
   const host = this as DatabaseStatementsHost;
@@ -644,7 +644,10 @@ export async function execDelete(
     throw new Error("execDelete requires execQuery on the adapter when binds are provided");
   }
   const doExecute = host?.execute?.bind(host) ?? execute;
-  return doExecute(sql) as Promise<number>;
+  // Rails: `affected_rows(internal_execute(sql, name, binds))` — the caller's
+  // label reaches the payload. trails' execute signature is (sql, binds, name),
+  // so the label goes in the third slot.
+  return doExecute(sql, binds, name) as Promise<number>;
 }
 
 /**
@@ -655,7 +658,7 @@ export async function execDelete(
 export async function execUpdate(
   this: DatabaseStatementsHost | void,
   sql: string,
-  name?: string | null,
+  name: string | null = null,
   binds: unknown[] = [],
 ): Promise<number> {
   const host = this as DatabaseStatementsHost;
@@ -663,7 +666,10 @@ export async function execUpdate(
     throw new Error("execUpdate requires execQuery on the adapter when binds are provided");
   }
   const doExecute = host?.execute?.bind(host) ?? execute;
-  return doExecute(sql) as Promise<number>;
+  // Rails: `affected_rows(internal_execute(sql, name, binds))` — the caller's
+  // label reaches the payload. trails' execute signature is (sql, binds, name),
+  // so the label goes in the third slot.
+  return doExecute(sql, binds, name) as Promise<number>;
 }
 
 /**
@@ -700,7 +706,7 @@ export function explain(_arel: unknown, _binds?: unknown[], _options?: unknown[]
 export async function insert(
   this: DatabaseStatementsHost | void,
   arel: unknown,
-  name?: string | null,
+  name: string | null = null,
   pk?: string | null,
   idValue?: unknown,
   sequenceName?: string | null,
@@ -721,7 +727,7 @@ export async function insert(
 export async function update(
   this: DatabaseStatementsHost | void,
   arel: unknown,
-  name?: string | null,
+  name: string | null = null,
   binds: unknown[] = [],
 ): Promise<number> {
   const [sql, resolvedBinds] = toSqlAndBinds(arel, binds);
@@ -736,7 +742,7 @@ export async function update(
 export async function deleteStatement(
   this: DatabaseStatementsHost | void,
   arel: unknown,
-  name?: string | null,
+  name: string | null = null,
   binds: unknown[] = [],
 ): Promise<number> {
   const [sql, resolvedBinds] = toSqlAndBinds(arel, binds);
@@ -755,12 +761,12 @@ export { deleteStatement as delete };
 export async function truncate(
   this: DatabaseStatementsHost & Pick<Quoting, "quoteTableName">,
   tableName: string,
-  name?: string | null,
+  name: string | null = null,
 ): Promise<unknown> {
   const sql = (this.buildTruncateStatement ?? buildTruncateStatement).call(this, tableName);
   // Rails: execute(build_truncate_statement(table_name), name). Trails' execute
   // signature is (sql, binds, name), so the log label goes in the third slot.
-  return (this.execute ?? execute).call(this, sql, [], name ?? undefined);
+  return (this.execute ?? execute).call(this, sql, [], name);
 }
 
 /**
@@ -1317,38 +1323,6 @@ export function highPrecisionCurrentTimestamp(): Nodes.SqlLiteral {
 }
 
 /**
- * Wraps query execution in a `sql.active_record` instrumentation event by
- * delegating to `AbstractAdapter#log` (abstract_adapter.rb:1134), the single
- * payload producer.
- */
-async function logSql<T>(
-  host: DatabaseStatementsHost,
-  sql: string,
-  name: string,
-  binds: unknown[] | undefined,
-  fn: () => Promise<T>,
-): Promise<T> {
-  const bindArray = binds ?? [];
-  // Non-null: `log` is mixed in on every AbstractAdapter (abstract_adapter.rb:1134),
-  // and `type_casted_binds` is `binds&.map` (quoting.rb:224-232) — nil only for a
-  // nil argument, which `bindArray` never is.
-  return host.log!(
-    sql,
-    name,
-    bindArray,
-    host.typeCastedBinds(bindArray)!,
-    false,
-    async (payload) => {
-      const result = await fn();
-      if (result instanceof Result) {
-        payload.row_count = result.length;
-      }
-      return result;
-    },
-  );
-}
-
-/**
  * Executes a raw query and returns an ActiveRecord::Result.
  * Delegates to rawExecute + castResult.
  *
@@ -1361,19 +1335,18 @@ async function logSql<T>(
 export async function rawExecQuery(
   this: DatabaseStatementsHost,
   sql: string,
-  name?: string | null,
+  name: string | null = null,
   binds?: unknown[],
 ): Promise<Result> {
   if (!this.rawExecute) {
     throw new Error("rawExecQuery requires rawExecute on the adapter");
   }
-  const sqlName = name ?? "SQL";
   // Rails is `cast_result(raw_execute(...))` and nothing else
   // (abstract/database_statements.rb:540-542): `raw_execute` is the single
   // logging site (`:553`) and materializes through `with_raw_connection`
   // (`:555`), so wrapping it again here would emit two `sql.active_record`
   // events for one query.
-  const rawResult = await this.rawExecute(sql, sqlName, binds);
+  const rawResult = await this.rawExecute(sql, name, binds);
   return this.castResult ? this.castResult(rawResult) : normalizeResult(rawResult);
 }
 
@@ -1392,11 +1365,10 @@ export async function rawExecQuery(
 export async function internalExecQuery(
   this: DatabaseStatementsHost,
   sql: string,
-  name?: string | null,
+  name: string | null = "SQL",
   binds?: unknown[],
   options?: { prepare?: boolean; allowRetry?: boolean; materializeTransactions?: boolean },
 ): Promise<Result> {
-  const sqlName = name ?? "SQL";
   // Rails is `cast_result(internal_execute(...))` and nothing else
   // (abstract/database_statements.rb:545-547). `internal_execute` reaches
   // `raw_execute` (`:588-591` → `:552-558`), which both logs (`:553`) and
@@ -1407,7 +1379,7 @@ export async function internalExecQuery(
     // reaches the driver and allow_retry / materialize_transactions survive
     // (Rails internal_exec_query(...) → internal_execute(...) → raw_execute).
     // trails carries all of them in the opts object rather than positionally.
-    const rawResult = await this.internalExecute(sql, sqlName, {
+    const rawResult = await this.internalExecute(sql, name, {
       binds,
       prepare: options?.prepare,
       allowRetry: options?.allowRetry,
@@ -1422,7 +1394,7 @@ export async function internalExecQuery(
   }
   // Fallback: delegate through this.execute only when there are no binds
   const doExecute = this?.execute?.bind(this) ?? execute;
-  const result = await doExecute(sql);
+  const result = await doExecute(sql, [], name);
   return normalizeResult(result);
 }
 
@@ -1494,10 +1466,10 @@ interface DatabaseStatementsDefaultsHost {
   execute(
     sql: string,
     binds?: unknown[],
-    name?: string,
+    name?: string | null,
     opts?: { allowRetry?: boolean },
   ): Promise<Record<string, unknown>[]>;
-  executeMutation(sql: string, binds?: unknown[], name?: string): Promise<number>;
+  executeMutation(sql: string, binds?: unknown[], name?: string | null): Promise<number>;
   selectAll(
     arel: unknown,
     name?: string | null,
@@ -1534,7 +1506,7 @@ interface DatabaseStatementsDefaultsHost {
 async function insertStatement(
   this: any,
   arel: unknown,
-  name?: string | null,
+  name: string | null = null,
   pk?: string | null,
   idValue?: unknown,
   sequenceName?: string | null,
@@ -1584,7 +1556,7 @@ export const DatabaseStatements = {
   async selectAll(
     this: DatabaseStatementsDefaultsHost,
     arel: unknown,
-    name?: string | null,
+    name: string | null = null,
     binds?: unknown[],
     opts?: { allowRetry?: boolean; preparable?: boolean | null },
   ): Promise<Result> {
@@ -1637,7 +1609,7 @@ export const DatabaseStatements = {
   async selectOne(
     this: DatabaseStatementsDefaultsHost,
     arel: unknown,
-    name?: string | null,
+    name: string | null = null,
     binds?: unknown[],
   ): Promise<Record<string, unknown> | undefined> {
     return (await this.selectAll(arel, name, binds)).first();
@@ -1646,7 +1618,7 @@ export const DatabaseStatements = {
   async selectValue(
     this: DatabaseStatementsDefaultsHost,
     arel: unknown,
-    name?: string | null,
+    name: string | null = null,
     binds?: unknown[],
   ): Promise<unknown> {
     const rows = await this.selectRows(arel, name, binds);
@@ -1656,7 +1628,7 @@ export const DatabaseStatements = {
   async selectValues(
     this: DatabaseStatementsDefaultsHost,
     arel: unknown,
-    name?: string | null,
+    name: string | null = null,
     binds?: unknown[],
   ): Promise<unknown[]> {
     const rows = await this.selectRows(arel, name, binds);
@@ -1666,7 +1638,7 @@ export const DatabaseStatements = {
   async selectRows(
     this: DatabaseStatementsDefaultsHost,
     arel: unknown,
-    name?: string | null,
+    name: string | null = null,
     binds?: unknown[],
   ): Promise<unknown[][]> {
     return (await this.selectAll(arel, name, binds)).rows;
@@ -1675,7 +1647,7 @@ export const DatabaseStatements = {
   async execQuery(
     this: DatabaseStatementsDefaultsHost,
     sql: string,
-    name?: string | null,
+    name: string | null = "SQL",
     binds?: unknown[],
     options?: { prepare?: boolean; allowRetry?: boolean; materializeTransactions?: boolean },
   ): Promise<Result> {
@@ -1683,38 +1655,38 @@ export const DatabaseStatements = {
     // once pool integration lands (connection-pool track). Real adapters that
     // override execQuery should forward allowRetry to their execute path.
     void options;
-    const rows = await this.execute(sql, binds, name ?? "SQL");
+    const rows = await this.execute(sql, binds, name);
     return Result.fromRowHashes(rows);
   },
 
   async execInsert(
     this: DatabaseStatementsDefaultsHost,
     sql: string,
-    name?: string | null,
+    name: string | null = null,
     binds?: unknown[],
     _pk?: string | false | null,
     _sequenceName?: string | null,
     _returning?: string[] | null,
   ): Promise<number> {
-    return this.executeMutation(sql, binds, name ?? "SQL");
+    return this.executeMutation(sql, binds, name);
   },
 
   async execDelete(
     this: DatabaseStatementsDefaultsHost,
     sql: string,
-    name?: string | null,
+    name: string | null = null,
     binds?: unknown[],
   ): Promise<number> {
-    return this.executeMutation(sql, binds, name ?? "SQL");
+    return this.executeMutation(sql, binds, name);
   },
 
   async execUpdate(
     this: DatabaseStatementsDefaultsHost,
     sql: string,
-    name?: string | null,
+    name: string | null = null,
     binds?: unknown[],
   ): Promise<number> {
-    return this.executeMutation(sql, binds, name ?? "SQL");
+    return this.executeMutation(sql, binds, name);
   },
 
   isWriteQuery(sql: string): boolean {
@@ -1746,7 +1718,7 @@ export const DatabaseStatements = {
   async update(
     this: any,
     arel: unknown,
-    name?: string | null,
+    name: string | null = null,
     binds: unknown[] = [],
   ): Promise<number> {
     const [sql, resolvedBinds] = toSqlAndBinds.call(this, arel, binds);
@@ -1756,7 +1728,7 @@ export const DatabaseStatements = {
   async delete(
     this: any,
     arel: unknown,
-    name?: string | null,
+    name: string | null = null,
     binds: unknown[] = [],
   ): Promise<number> {
     const [sql, resolvedBinds] = toSqlAndBinds.call(this, arel, binds);
@@ -1835,7 +1807,7 @@ export const DatabaseStatements = {
 export async function rawExecute(
   this: DatabaseStatementsHost,
   sql: string,
-  name?: string | null,
+  name: string | null = null,
   binds?: unknown[],
   prepare = false,
   isAsync = false,

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -644,9 +644,13 @@ export async function execDelete(
     throw new Error("execDelete requires execQuery on the adapter when binds are provided");
   }
   const doExecute = host?.execute?.bind(host) ?? execute;
-  // Rails: `affected_rows(internal_execute(sql, name, binds))` — the caller's
-  // label reaches the payload. trails' execute signature is (sql, binds, name),
-  // so the label goes in the third slot.
+  // Rails is `affected_rows(internal_execute(sql, name, binds))` (:165, :172).
+  // Two deviations remain here, both tracked by
+  // 0076-execute-primitive-convergence/exec-delete-update-through-internal-execute:
+  // the primitive is `execute` rather than `internal_execute` (the mixin's
+  // `affectedRows` is still the NotImplementedError hook at :570), and trails'
+  // `execute` takes (sql, binds, name), so the label goes in the third slot.
+  // Forwarding `name` at all is what this call site fixes.
   return doExecute(sql, binds, name) as Promise<number>;
 }
 
@@ -666,9 +670,13 @@ export async function execUpdate(
     throw new Error("execUpdate requires execQuery on the adapter when binds are provided");
   }
   const doExecute = host?.execute?.bind(host) ?? execute;
-  // Rails: `affected_rows(internal_execute(sql, name, binds))` — the caller's
-  // label reaches the payload. trails' execute signature is (sql, binds, name),
-  // so the label goes in the third slot.
+  // Rails is `affected_rows(internal_execute(sql, name, binds))` (:165, :172).
+  // Two deviations remain here, both tracked by
+  // 0076-execute-primitive-convergence/exec-delete-update-through-internal-execute:
+  // the primitive is `execute` rather than `internal_execute` (the mixin's
+  // `affectedRows` is still the NotImplementedError hook at :570), and trails'
+  // `execute` takes (sql, binds, name), so the label goes in the third slot.
+  // Forwarding `name` at all is what this call site fixes.
   return doExecute(sql, binds, name) as Promise<number>;
 }
 

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -409,7 +409,7 @@ export function makeCachedSelectAll(original: BaseSelectAll): BaseSelectAll {
   return async function cachedSelectAll(
     this: QueryCacheHost,
     arel: string | unknown,
-    name?: string | null,
+    name: string | null = null,
     binds?: unknown[],
     opts?: { allowRetry?: boolean; preparable?: boolean | null },
   ): Promise<Result> {

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -572,7 +572,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    */
   override async execInsert(
     sql: string,
-    name?: string | null,
+    name: string | null = null,
     binds: unknown[] = [],
     pk?: string | false | null,
     sequenceName?: string | null,
@@ -587,7 +587,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         binds,
         returning ?? null,
       );
-      const result = await this.internalExecQuery(returningSql, name ?? "SQL", returningBinds);
+      const result = await this.internalExecQuery(returningSql, name, returningBinds);
       this.dirtyCurrentTransaction();
       return result;
     }
@@ -599,7 +599,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   // routes through so cached reads never clear the cache.
   override async execQuery(
     sql: string,
-    name?: string | null,
+    name: string | null = "SQL",
     binds?: unknown[],
     options?: { prepare?: boolean; allowRetry?: boolean },
   ): Promise<Result> {
@@ -608,7 +608,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
 
   override async internalExecQuery(
     sql: string,
-    name?: string | null,
+    name: string | null = "SQL",
     binds?: unknown[],
     options?: { prepare?: boolean; allowRetry?: boolean },
   ): Promise<Result> {
@@ -908,7 +908,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   async execute(
     sql: string,
     binds: unknown[] = [],
-    name: string = "SQL",
+    name: string | null = "SQL",
     { allowRetry = false }: { allowRetry?: boolean } = {},
   ): Promise<Record<string, unknown>[]> {
     sql = this.preprocessQuery(sql);
@@ -955,7 +955,11 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * Execute an INSERT/UPDATE/DELETE and return affected rows or insert ID.
    * Wrapped in a `sql.active_record` notification — see `execute`.
    */
-  async executeMutation(sql: string, binds: unknown[] = [], name: string = "SQL"): Promise<number> {
+  async executeMutation(
+    sql: string,
+    binds: unknown[] = [],
+    name: string | null = "SQL",
+  ): Promise<number> {
     sql = this.preprocessQuery(sql);
     this._syncDatabaseTimezone();
     const driverSql = this.mysqlQuote(sql);
@@ -1120,7 +1124,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   // query_value/update path. Transaction-control callers ignore the return.
   override async internalExecute(
     sql: string,
-    name: string = "SQL",
+    name: string | null = "SQL",
     {
       materializeTransactions = true,
       allowRetry = false,

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1039,7 +1039,7 @@ export class PostgreSQLAdapter
   // routes through so cached reads never clear the cache.
   override async execQuery(
     sql: string,
-    name?: string | null,
+    name: string | null = "SQL",
     binds?: unknown[],
     options?: { prepare?: boolean; allowRetry?: boolean; materializeTransactions?: boolean },
   ): Promise<Result> {
@@ -1048,7 +1048,7 @@ export class PostgreSQLAdapter
 
   override async internalExecQuery(
     sql: string,
-    name?: string | null,
+    name: string | null = "SQL",
     binds?: unknown[],
     options?: { prepare?: boolean; allowRetry?: boolean; materializeTransactions?: boolean },
   ): Promise<Result> {
@@ -1067,7 +1067,7 @@ export class PostgreSQLAdapter
     const rewritten = this.rewriteBinds(sql, bindArray);
     const pgResult: ArrayQueryResult = await this.log(
       rewritten,
-      name ?? "SQL",
+      name,
       binds ?? [],
       bindArray,
       false,
@@ -1533,7 +1533,7 @@ export class PostgreSQLAdapter
   private async _instrumentedQueryOnClient(
     client: pg.Client,
     sql: string,
-    name: string,
+    name: string | null,
     binds: unknown[],
   ): Promise<Result> {
     const bindArray = this.typeCastedBinds(binds) ?? [];
@@ -1564,7 +1564,7 @@ export class PostgreSQLAdapter
   async execute(
     sql: string,
     binds: unknown[] = [],
-    name: string = "SQL",
+    name: string | null = "SQL",
     { allowRetry = false }: { allowRetry?: boolean } = {},
   ): Promise<Record<string, unknown>[]> {
     sql = this.preprocessQuery(sql);
@@ -1644,7 +1644,11 @@ export class PostgreSQLAdapter
    * declaration (abstract-adapter.ts, `executeMutation` on the
    * DatabaseStatements signature block) — read it there before changing this.
    */
-  async executeMutation(sql: string, binds: unknown[] = [], name: string = "SQL"): Promise<number> {
+  async executeMutation(
+    sql: string,
+    binds: unknown[] = [],
+    name: string | null = "SQL",
+  ): Promise<number> {
     sql = this.preprocessQuery(sql);
     // Mirrors `type_casted_binds` (abstract/quoting.rb:224). Without the typeCastedBinds unwrap, an INSERT
     // routed through executeMutation would bind a raw QueryAttribute to pg.
@@ -2100,7 +2104,7 @@ export class PostgreSQLAdapter
   // popped RELEASE/ROLLBACK TO SAVEPOINT frame — transaction on every exit.
   override async internalExecute(
     sql: string,
-    name: string = "SQL",
+    name: string | null = "SQL",
     {
       materializeTransactions = true,
       allowRetry = false,
@@ -2414,7 +2418,7 @@ export class PostgreSQLAdapter
    */
   override async execInsert(
     sql: string,
-    name?: string | null,
+    name: string | null = null,
     binds: unknown[] = [],
     pk?: string | false | null,
     sequenceName?: string | null,
@@ -2439,7 +2443,7 @@ export class PostgreSQLAdapter
       sql = this.preprocessQuery(sql);
       return this.withRawConnection(async (conn) => {
         const client = conn as unknown as pg.Client;
-        return this._instrumentedQueryOnClient(client, sql, name ?? "SQL", binds);
+        return this._instrumentedQueryOnClient(client, sql, name, binds);
       });
     }
     if (this._useInsertReturning) {
@@ -2494,7 +2498,7 @@ export class PostgreSQLAdapter
     // run on the same connection. withRawConnection pins both to one client.
     return this.withRawConnection(async (conn) => {
       const client = conn as unknown as pg.Client;
-      const insertResult = await this._instrumentedQueryOnClient(client, sql, name ?? "SQL", binds);
+      const insertResult = await this._instrumentedQueryOnClient(client, sql, name, binds);
       if (!sequenceName) return insertResult;
       const currvalSql = `SELECT currval(${this.quote(sequenceName)})`;
       return this._instrumentedQueryOnClient(client, currvalSql, "SQL", []);

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -461,7 +461,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   async execute(
     sql: string,
     binds: unknown[] = [],
-    name: string = "SQL",
+    name: string | null = "SQL",
   ): Promise<Record<string, unknown>[]> {
     sql = this.preprocessQuery(sql);
     await this.ensureConnected();
@@ -620,7 +620,11 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
    * one `performQuery` and differ only in what they answer — rows here, the
    * affected-row count or insert rowid there.
    */
-  async executeMutation(sql: string, binds: unknown[] = [], name: string = "SQL"): Promise<number> {
+  async executeMutation(
+    sql: string,
+    binds: unknown[] = [],
+    name: string | null = "SQL",
+  ): Promise<number> {
     // preprocessQuery runs Rails' check_if_write_query, which raises
     // ReadOnlyError while writes are prevented — see isPreventingWrites below.
     sql = this.preprocessQuery(sql);
@@ -684,7 +688,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
    */
   override async execInsert(
     sql: string,
-    name?: string | null,
+    name: string | null = null,
     binds: unknown[] = [],
     pk?: string | false | null,
     _sequenceName?: string | null,
@@ -699,7 +703,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
       returning,
     );
     if (readback !== undefined) return readback;
-    return this.executeMutation(sql, binds, name ?? "SQL");
+    return this.executeMutation(sql, binds, name);
   }
 
   /**
@@ -795,7 +799,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
    */
   override async rawExecute(
     sql: string,
-    name: string | null = "SQL",
+    name: string | null = null,
     binds: unknown[] = [],
     prepare = false,
     _async = false,
@@ -809,7 +813,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
       const driverBinds = binds.map(_driverBind, this) as SqliteBinds;
       return await this.log(
         sql,
-        name ?? "SQL",
+        name,
         binds,
         this.typeCastedBinds(binds),
         false,
@@ -873,7 +877,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     const prepare = options.prepare ?? false;
     return this.log(
       processed,
-      name ?? "SQL",
+      name,
       binds ?? [],
       this.typeCastedBinds(binds ?? []) ?? [],
       false,

--- a/packages/activerecord/src/log-subscriber.trails.test.ts
+++ b/packages/activerecord/src/log-subscriber.trails.test.ts
@@ -39,6 +39,48 @@ function makeEvent(payload: Record<string, unknown>): Event {
   return event;
 }
 
+describe("LogSubscriber nil payload name (trails)", () => {
+  let logger: CapturingLogger;
+  let subscriber: TestSubscriber;
+
+  beforeEach(() => {
+    logger = new CapturingLogger();
+    TestSubscriber.logger = logger;
+    BaseLogSubscriber.colorizeLogging = false;
+    LogSubscriber.colorizeLogging = false;
+    subscriber = new TestSubscriber();
+  });
+
+  afterEach(() => {
+    TestSubscriber.logger = null;
+    // The colorization arm below flips this global on; leaving it on would
+    // bleed ANSI escapes into every later file sharing the worker.
+    BaseLogSubscriber.colorizeLogging = false;
+    LogSubscriber.colorizeLogging = false;
+  });
+
+  // A nameless `select_all` now reaches the subscriber with `name: nil` rather
+  // than the `"SQL"` default, so pin the two places log_subscriber.rb:18-30
+  // reads it: `"#{payload[:name]} (…)"` interpolates nil to the empty string,
+  // and `colorize_payload_name`'s `payload_name.blank?` arm takes nil down the
+  // same MAGENTA branch as `"SQL"`. IGNORE_PAYLOAD_NAMES must not swallow it.
+  it("renders a nil name as the empty string and still logs", () => {
+    subscriber.sql(makeEvent({ sql: "select 1", name: null }));
+    expect(logger.messages.length).toBe(1);
+    expect(logger.messages[0]).toBe("   (0.0ms)  select 1");
+  });
+
+  it("colorizes a nil name the same as SQL", () => {
+    BaseLogSubscriber.colorizeLogging = true;
+    LogSubscriber.colorizeLogging = true;
+    subscriber.sql(makeEvent({ sql: "select 1", name: null }));
+    subscriber.sql(makeEvent({ sql: "select 1", name: "Topic Load" }));
+    expect(logger.messages[0]).toContain(BaseLogSubscriber.MAGENTA);
+    expect(logger.messages[0]).not.toContain(BaseLogSubscriber.CYAN);
+    expect(logger.messages[1]).toContain(BaseLogSubscriber.CYAN);
+  });
+});
+
 describe("LogSubscriber bigint bind rendering (trails)", () => {
   let logger: CapturingLogger;
   let subscriber: TestSubscriber;

--- a/packages/activerecord/src/log-subscriber.ts
+++ b/packages/activerecord/src/log-subscriber.ts
@@ -133,7 +133,7 @@ export class LogSubscriber extends BaseLogSubscriber {
       binds = `  ${safeJsonStringify(bindPairs)}`;
     }
 
-    const colorizedName = this.colorizePayloadName(name, payload.name as string | undefined);
+    const colorizedName = this.colorizePayloadName(name, payload.name as string | null | undefined);
     const colorizedSql = this.colorizeLogging
       ? this.color(sql, this.sqlColor(sql), { bold: true })
       : sql;
@@ -264,7 +264,7 @@ export class LogSubscriber extends BaseLogSubscriber {
     return [null, value];
   }
 
-  private colorizePayloadName(name: string, payloadName: string | undefined): string {
+  private colorizePayloadName(name: string, payloadName: string | null | undefined): string {
     if (!payloadName || payloadName === "" || payloadName === "SQL") {
       return this.color(name, BaseLogSubscriber.MAGENTA, { bold: true });
     }

--- a/packages/activerecord/src/query-cache.trails.test.ts
+++ b/packages/activerecord/src/query-cache.trails.test.ts
@@ -126,12 +126,17 @@ describe("cacheNotificationInfo payload (trails)", () => {
       });
     });
 
-    // query_cache.rb:313 is `name: name` — a nameless select_all yields a
-    // nameless cached payload, not the "SQL" default that `log`'s signature
-    // supplies on the uncached path.
+    // `select_all(arel, name = nil, ...)` (abstract/database_statements.rb:69)
+    // passes that nil down explicitly, so `log`'s `name = "SQL"` default
+    // (abstract_adapter.rb:1134) never fires and the uncached payload stays
+    // nameless — exactly what query_cache.rb:313's `name: name` records for
+    // the cached one. The two names are the same value.
     const cached = payloads.filter((p) => p.cached);
+    const uncached = payloads.filter((p) => !p.cached);
     expect(cached.length).toBe(1);
-    expect(cached[0].name).toBeUndefined();
+    expect(uncached.length).toBe(1);
+    expect(cached[0].name).toBeNull();
+    expect(uncached[0].name).toBe(cached[0].name);
   });
 });
 


### PR DESCRIPTION
Rails' `select_all(arel, name = nil, ...)`
(`abstract/database_statements.rb:69`) passes that `nil` **explicitly** down
through `internal_exec_query` → `internal_execute` → `raw_execute` →
`log(sql, name, ...)` (`abstract_adapter.rb:1134`), so `log`'s `name = "SQL"`
default never fires and a nameless query's `sql.active_record` payload carries
`name: nil`. trails passed `undefined`, which a TS default parameter swallows,
so the uncached payload said `name: "SQL"` while the cached one
(`query_cache.rb:313`, `name: name`) said nothing — the two disagreed.

The fix is the CLAUDE.md kwargs rule applied to the whole `name` chain:

- Every `name` parameter whose Rails counterpart defaults to `nil` now defaults
  to `null` (`select_all`/`select_one`/`select_value`/`select_values`/
  `select_rows`, `exec_insert`/`exec_delete`/`exec_update`,
  `insert`/`update`/`delete`/`truncate`, `raw_exec_query`, `raw_execute`,
  `QueryCache#select_all`), so an omitted name is a real nil rather than an
  `undefined` that re-triggers a downstream default.
- Every `name` parameter whose Rails counterpart defaults to `"SQL"` keeps that
  default (`exec_query`, `internal_execute`, `internal_exec_query`), which now
  fires only on genuine omission, exactly as Ruby's does.
- All 17 `name ?? "SQL"` coercion sites are gone — the four payload producers
  (`AbstractAdapter#log`, and the mysql2 / PostgreSQL / SQLite3 `log` call
  sites) plus the thirteen forwarding sites that baked the coercion in
  upstream. `log` now writes `name` into the payload verbatim.
- `query(...)`/`query_value(...)`/`query_values(...)` keep an optional (not
  defaulted) `name`, matching Ruby's arity-forwarding `(...)`: called with one
  argument they still land on `internal_execute`'s `"SQL"`.

`LogSubscriber#sql` already renders a nil name the way `log_subscriber.rb:18-30`
does — `"#{nil} (0.1ms)"` and `colorize_payload_name`'s `payload_name.blank?`
magenta arm — so only the parameter types widened to `string | null`.

`query-cache.trails.test.ts` "does not coerce a nameless query to SQL" now
asserts the cached and uncached payload names are equal, which is the real
Rails invariant; it failed on baseline (cached `undefined` vs uncached
`"SQL"`).

Closes-story: uncached-sql-payload-name-nil-passthrough
Closes-story: exec-query-wrappers-must-not-log

---

### Review rounds 1–2

**`exec_delete` / `exec_update` no-bind fallback dropped `name`** — fixed in
4d07db87e. Rails is `affected_rows(internal_execute(sql, name, binds))`
(`abstract/database_statements.rb:165,172`); both now forward `(sql, binds, name)`.

**`rawExecQuery` / `internalExecQuery` wrapped the call in a `logSql` Rails does
not have** — converged in 82c991928. The reviewer was right, and the root cause
was one level lower than the wrapper: trails' mixin `rawExecute` never called
`log` at all, so the instrumentation had been hoisted up into the two
`cast_result` wrappers. The call-set ratchet had this recorded as a baselined
divergence — `activerecord connection-adapters/abstract/database-statements.ts
raw_execute log` — which is now stale and retired by hand in 843132b3c (one row;
no reseed).

- `rawExecute` is now `database_statements.rb:552-559` line for line:
  `type_casted_binds` → `log(sql, name, binds, type_casted_binds, async:)` →
  `with_raw_connection(allow_retry:, materialize_transactions:)` →
  `perform_query(conn, sql, binds, type_casted_binds, prepare:,
  notification_payload:, batch:)`. The `notification_payload` now reaches
  `perform_query`, which is where Rails writes `row_count`.
- `rawExecQuery` is `castResult(rawExecute(...))` (`:540`).
- `internalExecQuery` is `castResult(internalExecute(...))` (`:546`), with
  `internalExecute` → `rawExecute` (`:589`) carrying the single log.
- The private `logSql` helper is gone — Rails has no such helper, and with one
  caller left it was exactly the extra indirection the wrapper divergence had
  created.

`database-statements.test.ts`'s "attaches sql and binds to a translated
StatementInvalid via set_query" needed its fake host reshaped, not its name or
assertions: `set_query` lives in `log` (`abstract_adapter.rb:1141-1143`), so a
Rails-shaped primitive raises from inside its own `log` rather than above it.
That is the only test that moved, and it now asserts the Rails decomposition.

Call-mismatch total 1490 → 1489; ratchet OK at 2122 baselined.


---

### Rebase onto main (#6311 overlap)

Rebased onto `e663fb165`. While this PR was blocked, sibling **#6311** landed
part of the same convergence under story `wire-raw-execute-through-log`: it
moved `log` into the mixin `rawExecute` and made `rawExecQuery` a pure
`castResult` wrapper. Where we overlap, main's version is kept — this PR no
longer touches the two parity baseline files, since #6311 retired the same
`raw_execute → log` row and decremented the same mark.

What remains from here is the part #6311 explicitly left open ("adapter routing
not"): `internalExecQuery` is now the pure `castResult(internalExecute(...))`
wrapper too (`database_statements.rb:546`). #6311's JSDoc had kept the wrapper's
`log` on the grounds that a host overriding `internalExecute` but not
`internalExecQuery` needs it for `set_query` context on a translated
StatementInvalid — that concern is real but is answered by shaping the host like
a real adapter, whose own primitive raises from inside its `log`
(`abstract_adapter.rb:1141-1143`), which is what the test fake now does. That
JSDoc is updated rather than left describing code that no longer wraps.

#6311's `rawExecute` body, its `row_count`-off-the-yielded-payload test, and its
sqlite3 `validateIndexLengthBang` / `copyTableIndexes` work are all intact —
verified by diffing this branch against `origin/main`.

Net diff is now 9 files, +152/−173.




---

### Review round 3

**`execDelete` / `execUpdate` call `execute`, not `internal_execute`** — the
reviewer is right, it is pre-existing, and it was not tracked anywhere in the
RFC 0076 cluster. Now filed as
`0076-execute-primitive-convergence/exec-delete-update-through-internal-execute`,
with the specific reason it could not ride along here: the direct port is
`affected_rows(internal_execute(sql, name, binds))` (`:165,172`), and the mixin's
`affectedRows` is still the `NotImplementedError` strategy hook at `:570`, so
converging these two bodies means giving the mixin a real `affectedRows` first.
The story also records that the trails-only `binds.length > 0` guard has no Rails
counterpart and must go with it.

The reviewer's sharper point — that the inline comment justified the slot
reordering but stayed silent on the primitive mismatch — is fixed in the code:
both call sites now name **both** deviations and cite the story, rather than
documenting the small one and letting the large one pass unremarked.



---

### Correction to the review summary (round 4)

The round-4 review is clean and I am not contesting it, but one factual claim in
it overstates what the new tests do, and it should not stand unchallenged in the
record: it says the two new `log-subscriber.trails.test.ts` tests "would fail on
the pre-fix baseline." They would not.

The only change to `log-subscriber.ts` in this PR is two **type widenings**
(`string | undefined` → `string | null | undefined`); there is no runtime change,
and `colorizePayloadName`'s `!payloadName` guard already treated `null` the same
as `""`. Those two tests construct the notification event directly with
`name: null`, so they exercise the subscriber without going through the adapter
and pass on `main` unchanged.

They are still worth having — `null` only became a *reachable* payload value
because of this PR, and nothing previously pinned how the subscriber renders it —
but they are coverage for a newly-reachable input, not regression tests.

The one assertion in this PR that genuinely fails on baseline is the tightened
`query-cache.trails.test.ts` check: before the fix the cached payload carried
`undefined` and the uncached one carried `"SQL"`, so asserting the two are equal
(and both nil) is red on `main` and green here. That test is the real proof the
bug existed.
