### PR TITLE
fix(activerecord): move PG/SQLite identifier quoters to ClassMethods

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -297,25 +297,14 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   }
 
   /**
-   * MySQL dialect overrides — backtick identifiers and integer bool
-   * coercion. Matches Rails:
+   * MySQL dialect overrides — integer bool coercion. Matches Rails:
    *
-   * - `quote_column_name` / `quote_table_name` — backticks
-   *   (`mysql/quoting.rb:46-52`).
    * - `unquoted_true` / `unquoted_false` → `1` / `0`
    *   (`mysql/quoting.rb:72-77`).
    *
    * `quotedTrue`/`quotedFalse` are NOT overridden — Rails MySQL inherits the
    * abstract `"TRUE"`/`"FALSE"`. Binds serialize to 1/0 via `cast_bound_value`.
    */
-  override quoteTableName(name: string): string {
-    return mysqlQuoteTableName(name);
-  }
-
-  override quoteColumnName(name: string): string {
-    return mysqlQuoteColumnName(name);
-  }
-
   // Defined as methods, not class fields: Rails declares these with `def`
   // (`mysql/quoting.rb:72-77`), and the inherited `type_cast` reaches them
   // through `self`. A field lives on the instance rather than the prototype,

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -206,6 +206,24 @@ export class PostgreSQLAdapter
     return pgColumnNameWithOrderMatcher();
   }
 
+  /**
+   * Mirrors: PostgreSQL::Quoting::ClassMethods#quote_column_name
+   * (postgresql/quoting.rb:46-48). Lives on the class, as in Rails — the
+   * instance quoter is the inherited `self.class` delegator
+   * (abstract/quoting.rb:135-138).
+   */
+  static override quoteColumnName(name: string): string {
+    return pgQuoteColumnName(name);
+  }
+
+  /**
+   * Mirrors: PostgreSQL::Quoting::ClassMethods#quote_table_name
+   * (postgresql/quoting.rb:54-56).
+   */
+  static override quoteTableName(name: string): string {
+    return pgQuoteTableName(name);
+  }
+
   // Mirrors Rails' PostgreSQLAdapter.dbconsole, which exports PG* env vars
   // before exec'ing psql. We can't mutate the process environment (no
   // process.* access), so we return the env map the PTY exec would set;
@@ -3358,14 +3376,6 @@ export class PostgreSQLAdapter
 
   supportsLazyTransactions(): boolean {
     return true;
-  }
-
-  quoteColumnName(name: string): string {
-    return pgQuoteColumnName(name);
-  }
-
-  quoteTableName(name: string): string {
-    return pgQuoteTableName(name);
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/quoting-contract.test.ts
+++ b/packages/activerecord/src/connection-adapters/quoting-contract.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect } from "vitest";
 import type { Quoting } from "./abstract/quoting.js";
 import { AbstractAdapter } from "./abstract-adapter.js";
 import { BetterSQLite3Adapter } from "./better-sqlite3-adapter.js";
+import { PostgreSQLAdapter } from "./postgresql-adapter.js";
+import { Mysql2Adapter } from "./mysql2-adapter.js";
+import { SQLite3Adapter } from "./sqlite3-adapter.js";
 
 // Compile-time guard: AbstractAdapter (the base, not a subclass) must
 // itself satisfy Quoting. A subclass-only assignment would let a
@@ -68,5 +71,37 @@ describe("Quoting interface", () => {
     } finally {
       adapter.disconnectBang();
     }
+  });
+});
+
+/**
+ * Rails puts every adapter's identifier quoters in `Quoting::ClassMethods`
+ * (`postgresql/quoting.rb:46,:54`, `sqlite3/quoting.rb:44,:48`,
+ * `mysql/quoting.rb:46,:50`); the instance methods are the abstract
+ * `self.class` delegators (`abstract/quoting.rb:135-143`).
+ */
+describe("Quoting::ClassMethods", () => {
+  it("every adapter class quotes identifiers on the class", () => {
+    expect(PostgreSQLAdapter.quoteColumnName("foo")).toBe('"foo"');
+    expect(PostgreSQLAdapter.quoteTableName("foo.bar")).toBe('"foo"."bar"');
+
+    expect(SQLite3Adapter.quoteColumnName("foo")).toBe('"foo"');
+    expect(SQLite3Adapter.quoteTableName("foo.bar")).toBe('"foo"."bar"');
+
+    expect(Mysql2Adapter.quoteColumnName("foo")).toBe("`foo`");
+    expect(Mysql2Adapter.quoteTableName("foo.bar")).toBe("`foo`.`bar`");
+  });
+
+  it("an adapter defining only the class quoter inherits the instance delegators", () => {
+    class QuotingOnlyAdapter extends AbstractAdapter {
+      static override quoteColumnName(name: string): string {
+        return `[${name}]`;
+      }
+    }
+    const adapter = Object.create(QuotingOnlyAdapter.prototype) as QuotingOnlyAdapter;
+
+    expect(adapter.quoteColumnName("foo")).toBe("[foo]");
+    // abstract/quoting.rb:65-68 — quote_table_name defaults to quote_column_name.
+    expect(adapter.quoteTableName("foo")).toBe("[foo]");
   });
 });

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -248,6 +248,23 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     return new RegExp(`^${ordered}(?:\\s*,\\s*${ordered})*$`, "i");
   }
 
+  /**
+   * Mirrors: SQLite3::Quoting::ClassMethods#quote_column_name
+   * (sqlite3/quoting.rb:44-46). Lives on the class, as in Rails — the instance
+   * quoter is the inherited `self.class` delegator (abstract/quoting.rb:135-138).
+   */
+  static override quoteColumnName(name: string): string {
+    return quoteColumnName(name);
+  }
+
+  /**
+   * Mirrors: SQLite3::Quoting::ClassMethods#quote_table_name
+   * (sqlite3/quoting.rb:48-50) — dot-split, so `foo.bar` → `"foo"."bar"`.
+   */
+  static override quoteTableName(name: string): string {
+    return quoteTableName(name);
+  }
+
   /** @internal */
   override arelVisitor(): Visitors.ToSql {
     return new Visitors.SQLite(this);
@@ -1019,21 +1036,6 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
    */
   override quoteString(s: string): string {
     return sqliteQuoteString(s);
-  }
-
-  // quoteTableName / quoteColumnName ARE kept: Rails' SQLite3::Quoting defines
-  // both explicitly (sqlite3/quoting.rb:44-50) — column → `"x"`, table →
-  // dot-split `"."` — while Rails' abstract leaves quote_column_name a
-  // NotImplementedError and quote_table_name a no-split default
-  // (abstract/quoting.rb:60-67). Inheriting Trails' broader abstract here would
-  // diverge from SQLite's concrete Rails method.
-
-  override quoteTableName(name: string): string {
-    return quoteTableName(name);
-  }
-
-  override quoteColumnName(name: string): string {
-    return quoteColumnName(name);
   }
 
   override quoteTableNameForAssignment(table: string, attr: string): string {


### PR DESCRIPTION
Rails puts every adapter's identifier quoters in `Quoting::ClassMethods`, not on
the instance — `postgresql/quoting.rb:46,:54`, `sqlite3/quoting.rb:44,:48`,
`mysql/quoting.rb:46,:50` — and the instance methods are thin `self.class`
delegators (`abstract/quoting.rb:135-143`).

`PostgreSQLAdapter` and `SQLite3Adapter` defined `quoteColumnName` /
`quoteTableName` only as instance overrides. They worked, because overriding
both means the inherited delegators are never reached — but the class-method
register stayed empty, so `PostgreSQLAdapter.quoteColumnName("x")` raised
`NotImplementedError` while `Mysql2Adapter.quoteColumnName("x")` answered. It
also made the abstract instance pair unusable for a PG/SQLite-shaped subclass:
defining only an instance `quoteColumnName` still got a raise from
`quoteTableName`, which goes class-side.

## Changes

- `PostgreSQLAdapter` / `SQLite3Adapter`: `quoteColumnName` and
  `quoteTableName` are now `static`, sitting beside `columnNameMatcher` /
  `columnNameWithOrderMatcher` as they do in `ClassMethods`. The instance
  overrides are gone; both adapters inherit the `abstract/quoting.rb:135-143`
  delegators.
- `AbstractMysqlAdapter`: dropped its instance `quoteTableName` /
  `quoteColumnName`. They duplicated the statics it already carried and have no
  counterpart in `mysql/quoting.rb`, whose defs are all inside `ClassMethods`.
- `quoting-contract.test.ts`: class-side quoting answers correctly on all three
  adapter classes, and a subclass defining only the static `quoteColumnName`
  gets the right `quoteTableName` off the inherited instance delegator
  (`abstract/quoting.rb:65-68` — `quote_table_name` defaults to
  `quote_column_name`).

## Not in scope

The story's context mentions PG's `QUOTED_COLUMN_NAMES` / `QUOTED_TABLE_NAMES`
memo maps (`postgresql/quoting.rb:9-10`) "moving with" the quoters. Those maps
have no trails counterpart today — the quoting module functions don't memoize at
all — so there was nothing to move. Adding the memoization is a behavioral
change independent of where the methods live; left out of this PR.

## Verification

- `quoting-contract`, `adapters/sqlite3/quoting`, `quoting`, `sanitize`,
  `sanitization-quoter`, `join-dependency-quoting`, `schema-dumper`, and all of
  `connection-adapters/sqlite3` + `connection-adapters/abstract` — green on
  sqlite3.
- `pnpm api:calls` OK (no new rows), `pnpm api:extra --package activerecord`
  unchanged, `pnpm lint` clean, `tsc --build --force` clean.

Closes-story: adapter-quoters-belong-in-classmethods
