### PR TITLE
refactor(activerecord): converge PG perform_query onto Rails' three arms

### DIFF
--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1801,7 +1801,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         else console.warn(line);
       }
       // TODO(report): wire Rails.error.report(warning, handled: true) when ErrorReporter
-      // is exposed as a global singleton — same gap as PostgreSQLAdapter._flushWarnings.
+      // is exposed as a global singleton (PostgreSQL's handleWarnings already does).
       if (typeof action === "function") action(warning);
     }
   }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-query.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-query.test.ts
@@ -244,8 +244,10 @@ describe("PostgreSQLAdapter#sqlKey", () => {
     (adapter as unknown as { _poolFor: (c: unknown) => StatementPool })._poolFor(client);
   const preparedNameFor = (client: unknown, sql: string): Promise<string> =>
     (
-      adapter as unknown as { _preparedNameFor: (c: unknown, s: string) => Promise<string> }
-    )._preparedNameFor(client, sql);
+      adapter as unknown as {
+        prepareStatement: (s: string, b: unknown[], c: unknown) => Promise<string>;
+      }
+    ).prepareStatement(sql, [], client);
 
   it("scopes the pool key to the current schema_search_path", () => {
     setMemo("schema_a, public");

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-rollback-db-transaction.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-rollback-db-transaction.trails.test.ts
@@ -10,6 +10,14 @@
  * the connection-error discard were deleted as unreachable; the first case
  * below fails when the surviving `finally` is dropped, and the second is why
  * the discard was not needed.
+ *
+ * The severed-socket ROLLBACK surfaces its driver error rather than silently
+ * reconnecting: `perform_query` ends in `verified!`
+ * (`postgresql/database_statements.rb:164`), so the BEGIN already marked the
+ * connection verified and `with_raw_connection` skips the verify ping that
+ * would otherwise have reconnected — and `internal_execute` passes
+ * `allow_retry: false`, so there is no retry either. The `finally` still
+ * releases the client, which is the invariant this case exists to pin.
  */
 import { expect, it } from "vitest";
 import { describeIfPg, PG_TEST_URL } from "../support/describe-if-pg.js";
@@ -48,7 +56,9 @@ describeIfPg("PostgreSQLAdapter exec_rollback_db_transaction", () => {
       await adapter.beginDbTransaction();
       await (client(adapter) as { end(): Promise<void> }).end();
 
-      await adapter.execRollbackDbTransaction();
+      await expect(adapter.execRollbackDbTransaction()).rejects.toThrow(
+        /Client was closed and is not queryable/,
+      );
 
       expect(inTransaction(adapter)).toBe(false);
       expect(client(adapter)).toBeNull();

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1065,7 +1065,6 @@ export class PostgreSQLAdapter
     // normalizer, mapping the adapter's `type_cast` over the binds.
     const bindArray = this.typeCastedBinds(binds) ?? [];
     const rewritten = this.rewriteBinds(sql, bindArray);
-    this._noticeReceiverSqlWarnings = [];
     const pgResult: ArrayQueryResult = await this.log(
       rewritten,
       name ?? "SQL",
@@ -1539,7 +1538,6 @@ export class PostgreSQLAdapter
   ): Promise<Result> {
     const bindArray = this.typeCastedBinds(binds) ?? [];
     const rewritten = this.rewriteBinds(sql, bindArray);
-    this._noticeReceiverSqlWarnings = [];
     const pgResult = await this.log(rewritten, name, binds, bindArray, false, async (payload) => {
       try {
         const r = await this._performQuery(client, rewritten, binds, bindArray, {
@@ -1577,24 +1575,29 @@ export class PostgreSQLAdapter
     // payload.sql is the rewritten SQL (`$1` not `?`) so ExplainSubscriber
     // stores something that can be re-EXPLAIN'd on the same adapter
     // without re-running rewriteBinds.
-    this._noticeReceiverSqlWarnings = [];
-    // Flush inside the instrumented callback so a warning raise is captured by
-    // payload.exception — mirrors Rails' handle_warnings inside perform_query (line 166).
-    return await this.log(rewritten, name, binds, bindArray, false, async (payload) => {
-      try {
-        return await this.withRawConnection({ allowRetry }, async (conn) => {
-          const client = conn as unknown as pg.Client;
-          const result = await this._performQuery(client, rewritten, binds, bindArray, {
-            prepare: this._shouldPrepare(bindArray),
-            notificationPayload: payload,
+    try {
+      return await this.log(rewritten, name, binds, bindArray, false, async (payload) => {
+        try {
+          return await this.withRawConnection({ allowRetry }, async (conn) => {
+            const client = conn as unknown as pg.Client;
+            const result = await this._performQuery(client, rewritten, binds, bindArray, {
+              prepare: this._shouldPrepare(bindArray),
+              notificationPayload: payload,
+            });
+            return result?.rows ?? [];
           });
-          return result?.rows ?? [];
-        });
-      } catch (e: any) {
-        const translated = this._translateException(e, rewritten, bindArray);
-        throw translated;
-      }
-    });
+        } catch (e: any) {
+          const translated = this._translateException(e, rewritten, bindArray);
+          throw translated;
+        }
+      });
+    } finally {
+      // Rails' `execute(...) ... ensure @notice_receiver_sql_warnings = []`
+      // (postgresql/database_statements.rb:39-43). This is the only place the
+      // buffer is reset per query — a warning raised on an internal path
+      // survives into the next `handle_warnings` pass, as it does in Rails.
+      this._noticeReceiverSqlWarnings = [];
+    }
   }
 
   /**
@@ -1648,7 +1651,6 @@ export class PostgreSQLAdapter
     const originalBinds = binds;
     binds = this.typeCastedBinds(binds) ?? [];
     const pgSql = this.rewriteBinds(sql, binds);
-    this._noticeReceiverSqlWarnings = [];
     // payload.sql records the rewritten SQL — ExplainSubscriber captures
     // something that can be re-EXPLAIN'd without re-running rewriteBinds
     // (and without re-appending RETURNING for bare INSERTs, which isn't
@@ -2120,12 +2122,6 @@ export class PostgreSQLAdapter
       const hasBinds = binds.length > 0;
       const bindArray = hasBinds ? (this.typeCastedBinds(binds) ?? []) : [];
       const runSql = hasBinds ? this.rewriteBinds(sql, bindArray) : sql;
-      // A bound query here is the exec_insert RETURNING read-back; mirror
-      // _instrumentedQueryOnClient by resetting the notice buffer up front and
-      // flushing after, so PG WARNING/NOTICE handling (db_warnings_action) is not
-      // dropped or misattributed to the next query. Transaction-control SQL passes
-      // no binds and keeps its byte-identical path (no reset/flush/rewrite).
-      if (hasBinds) this._noticeReceiverSqlWarnings = [];
       const result = await this.log(runSql, name, binds, bindArray, false, (payload) =>
         // materializeTransactions is handled above (not delegated to
         // withRawConnection) so transaction-control SQL — COMMIT/ROLLBACK/

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1,6 +1,6 @@
 import pg from "pg";
 import { type Type, ValueType, ArgumentError, BinaryData } from "@blazetrails/activemodel";
-import { singularize, ActiveSupport, runLoadHooks, include } from "@blazetrails/activesupport";
+import { singularize, runLoadHooks, include } from "@blazetrails/activesupport";
 import { sql as arelSql, Nodes, Visitors } from "@blazetrails/arel";
 import { isRubyTruthy } from "../ruby-truthy.js";
 import { Result } from "../result.js";
@@ -106,6 +106,12 @@ const PQTRANS_UNKNOWN = 4;
  * (postgresql/database_statements.rb:124).
  */
 const IDLE_TRANSACTION_STATUSES = [PQTRANS_IDLE, PQTRANS_INTRANS, PQTRANS_INERROR];
+/**
+ * Mirrors: `PostgreSQLAdapter::FEATURE_NOT_SUPPORTED`
+ * (postgresql_adapter.rb:890) — the SQLSTATE a cached-plan invalidation
+ * arrives under.
+ */
+const FEATURE_NOT_SUPPORTED = "0A000";
 import {
   READ_QUERY,
   buildTruncateStatements as pgBuildTruncateStatements,
@@ -114,6 +120,8 @@ import {
   castResult,
   affectedRows as pgAffectedRows,
   handleWarnings,
+  isWarningIgnored as pgIsWarningIgnored,
+  performQuery as pgPerformQuery,
   returningColumnValues as pgReturningColumnValues,
 } from "./postgresql/database-statements.js";
 import type { CreateDatabaseOptions } from "./postgresql/schema-statements.js";
@@ -451,8 +459,11 @@ export class PostgreSQLAdapter
    * to `true` only by the terminating-message handlers in
    * `_attachReadyForQueryListener`. Miss an issue site and `transactionStatus`
    * answers IDLE/INTRANS while that command is mid-cycle.
+   *
+   * Non-private (underscore-public) so the extracted `performQuery` can keep
+   * the invariant on the arms it issues.
    */
-  private _commandSettled = true;
+  _commandSettled = true;
   private _typeMap: HashLookupTypeMap | null = null;
   private _maxIdentifierLength: number | null = null;
   private _useInsertReturning = true;
@@ -510,12 +521,8 @@ export class PostgreSQLAdapter
   // SQL commands that resetBang fires asynchronously.
   private _inFlightReset: Promise<void> | null = null;
   // Accumulates PG NOTICE/WARNING messages fired during the current query.
-  // Cleared before each query; processed by _flushWarnings after.
-  private _noticeReceiverSqlWarnings: Array<{
-    level?: string;
-    message?: string;
-    code?: string;
-  }> = [];
+  // Cleared before each query; processed by handleWarnings after.
+  _noticeReceiverSqlWarnings: SQLWarning[] = [];
   /**
    * `database.yml`'s `statement_limit`, which Rails reads as
    * `@config[:statement_limit]` inline at StatementPool construction
@@ -844,11 +851,12 @@ export class PostgreSQLAdapter
   private _attachNoticeListener(client: pg.Client): void {
     if ((this.constructor as typeof PostgreSQLAdapter).dbWarningsAction === "ignore") return;
     client.on("notice", (msg: { severity?: string; message?: string; code?: string }) => {
-      this._noticeReceiverSqlWarnings.push({
-        level: msg.severity,
-        message: msg.message,
-        code: msg.code,
-      });
+      // Rails' notice receiver buffers SQLWarning instances themselves
+      // (postgresql_adapter.rb:970), so `handle_warnings` dispatches the very
+      // objects it iterates.
+      this._noticeReceiverSqlWarnings.push(
+        new SQLWarning(msg.message, msg.code ?? null, msg.severity ?? null, undefined, this.pool),
+      );
     });
   }
 
@@ -1081,15 +1089,21 @@ export class PostgreSQLAdapter
               try {
                 // rowMode: "array" returns rows as positional arrays, preserving
                 // duplicate column names and matching the field-index order.
-                // Delegates to `_runQuery` so prepared-statement caching and
-                // in-txn / out-of-txn cached-plan handling stay in one place.
-                return await this._runQuery<ArrayQueryResult>(client, rewritten, bindArray, {
-                  rowMode: "array",
-                  prepareHint: options?.prepare,
-                  onPrepared: (stmtName) => {
-                    payload.statement_name = stmtName;
+                // Rails' internal_exec_query forwards `prepare:` down to
+                // perform_query (abstract/database_statements.rb:552-558); an
+                // explicit `false` hard-disables preparation, while an absent
+                // one still passes through the adapter's own gate.
+                return await this._performQuery<ArrayQueryResult & pg.QueryResult>(
+                  client,
+                  rewritten,
+                  binds ?? [],
+                  bindArray,
+                  {
+                    prepare: options?.prepare === false ? false : this._shouldPrepare(bindArray),
+                    notificationPayload: payload,
+                    rowMode: "array",
                   },
-                });
+                );
               } catch (e: any) {
                 throw this._translateException(e, rewritten, bindArray);
               }
@@ -1105,8 +1119,6 @@ export class PostgreSQLAdapter
     );
 
     const fields = pgResult.fields ?? [];
-    // Flush before loadAdditionalTypes — nested execQuery calls reset the buffer.
-    this._flushWarnings(rewritten);
     if (fields.length === 0) return Result.fromRowHashes([]);
 
     // Batch-load any unknown dataTypeIDs in a single pg_type roundtrip.
@@ -1474,7 +1486,10 @@ export class PostgreSQLAdapter
    * lazily creating it. PG prepared statements are session-scoped;
    * with one persistent client there is exactly one pool per adapter.
    */
-  private _poolFor(client: pg.Client): StatementPool {
+  // Non-private (underscore-public) so the extracted `performQuery` in
+  // `postgresql/database-statements.ts` can reach the statement cache Rails
+  // names `@statements`.
+  _poolFor(client: pg.Client): StatementPool {
     if (!this._statementPool) {
       this._statementPool = this.buildStatementPool(client);
     }
@@ -1494,97 +1509,6 @@ export class PostgreSQLAdapter
   }
 
   /**
-   * Run a query on `client`, routing through the statement pool when
-   * binds are present and `preparedStatements` is on. On Rails-parity
-   * "invalid cached plan" (SQLSTATE 0A000 + "cached plan" in the
-   * message), purges the pool entry and either re-runs once (outside
-   * a txn) or raises `PreparedStatementCacheExpired` (inside one, so
-   * the transaction machinery can retry the whole txn).
-   *
-   * Shared by execute/executeMutation so every bound path benefits
-   * from prepared-statement reuse — matches Rails where `exec_cache`
-   * backs both exec_query and exec_delete / exec_update / exec_insert.
-   */
-  private async _runQuery<R = pg.QueryResult>(
-    client: pg.Client,
-    sql: string,
-    binds: unknown[],
-    extra: {
-      rowMode?: "array";
-      // A *hint*, not a guarantee: `true` (e.g. `select_all` threading a
-      // preparable SELECT) still passes through `_shouldPrepare`, so PG's own
-      // gates — prepared_statements, non-empty binds, a non-zero pool limit —
-      // decide whether to actually prepare. This avoids forcing a server-side
-      // PREPARE that a disabled (maxSize 0) pool would leak per execution. Only
-      // an explicit `false` hard-disables preparation.
-      prepareHint?: boolean;
-      onPrepared?: (stmtName: string) => void;
-    } = {},
-  ): Promise<R> {
-    const { prepareHint, onPrepared, ...queryExtra } = extra;
-    const prepare = prepareHint === false ? false : this._shouldPrepare(binds);
-    const attempt = async (): Promise<R> => {
-      const stmtName = prepare ? await this._preparedNameFor(client, sql) : null;
-      if (stmtName !== null) onPrepared?.(stmtName);
-      this._commandSettled = false;
-      if (stmtName !== null) {
-        return client.query({
-          name: stmtName,
-          text: sql,
-          values: binds,
-          ...queryExtra,
-        }) as Promise<R>;
-      }
-      if (queryExtra.rowMode) {
-        return client.query({ text: sql, values: binds, ...queryExtra }) as Promise<R>;
-      }
-      return client.query(sql, binds) as Promise<R>;
-    };
-    try {
-      return await attempt();
-    } catch (e) {
-      if (prepare && this._isInvalidCachedPlan(e)) {
-        // Mirrors Rails' `perform_query` rescue
-        // (postgresql/database_statements.rb:143-151): inside a transaction we
-        // can't recover (all commands would raise InFailedSQLTransaction), so
-        // raise `PreparedStatementCacheExpired` and let the transaction machinery
-        // clear the whole cache on rollback; otherwise drop just this entry and
-        // retry. `in_transaction?` is `open_transactions > 0`
-        // (postgresql_adapter.rb:908-910), so an open *lazy* (un-materialized)
-        // frame still counts — a read-only block (`transaction { record.reload }`)
-        // never emits a physical `BEGIN` because reads don't materialize.
-        if (this.openTransactions > 0) {
-          throw new PreparedStatementCacheExpired(
-            (e as { message?: string })?.message ?? "cached plan expired",
-            { sql, binds, cause: e },
-          );
-        }
-        await this._poolFor(client).delete(this.sqlKey(sql));
-        return await attempt();
-      }
-      throw e;
-    }
-  }
-
-  /**
-   * Return the prepared-statement name for `sql` on `client`. Names
-   * are allocated from the per-pool counter (`StatementPool#nextKey`)
-   * so each session has its own `a1`, `a2`, ... sequence. Mirrors
-   * Rails' `PostgreSQL::StatementPool#[]` / `#[]=` — present key →
-   * cached name, absent → `next_key` + store. Awaiting `set` puts the evicted
-   * entry's DEALLOCATE before the query that triggered it (statement_pool.rb:31).
-   */
-  private async _preparedNameFor(client: pg.Client, sql: string): Promise<string> {
-    const pool = this._poolFor(client);
-    const key = this.sqlKey(sql);
-    const existing = pool.get(key);
-    if (existing) return existing.name;
-    const name = pool.nextKey();
-    await pool.set(key, { name });
-    return name;
-  }
-
-  /**
    * True when the adapter should try a named prepared statement for
    * this call. Rails' gate: `prepared_statements && !binds.empty?`
    * (there's no point naming an unparameterized statement — the
@@ -1600,27 +1524,6 @@ export class PostgreSQLAdapter
     return this.preparedStatements && binds.length > 0;
   }
 
-  /**
-   * True if a pg driver error indicates the cached plan has been
-   * invalidated by DDL on a referenced object (typical: `ALTER TABLE`,
-   * `DROP COLUMN`, schema change). PG emits SQLSTATE `0A000`
-   * FEATURE_NOT_SUPPORTED with the server message "cached plan must
-   * not change result type" — Rails checks the source function
-   * `RevalidateCachedQuery`, which the node-pg driver does not expose,
-   * so we fall back to the message substring.
-   *
-   * `26000` (invalid_sql_statement_name) is intentionally NOT included
-   * here: pg-js's own client-side name cache handles the session-lost
-   * case on its own, and retrying behind the driver's back masks
-   * genuine "this name never existed" bugs. Rails' equivalent path
-   * (`exec_cache`) also only retries on cached-plan failure — not on
-   * unknown-statement-name — so this matches the activerecord
-   * contract.
-   *
-   * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#is_cached_plan_failure?
-   * (postgresql_adapter.rb:901-906).
-   */
-  /** @internal Mirrors: PostgreSQL::DatabaseStatements#handle_warnings */
   /**
    * Run a single query on an already-acquired client with the same
    * instrumentation, exception translation, and warning flushing that
@@ -1639,7 +1542,11 @@ export class PostgreSQLAdapter
     this._noticeReceiverSqlWarnings = [];
     const pgResult = await this.log(rewritten, name, binds, bindArray, false, async (payload) => {
       try {
-        const r = await this._runQuery(client, rewritten, bindArray, { rowMode: "array" });
+        const r = await this._performQuery(client, rewritten, binds, bindArray, {
+          prepare: this._shouldPrepare(bindArray),
+          notificationPayload: payload,
+          rowMode: "array",
+        });
         payload.row_count = r.rowCount ?? 0;
         return r;
       } catch (e: any) {
@@ -1647,51 +1554,7 @@ export class PostgreSQLAdapter
         throw translated;
       }
     });
-    // Mirrors Rails' raw_execute → verified!: a successful round-trip proves the
-    // connection is live, so skip the verify ping on the next withRawConnection.
-    this.verifiedBang();
-    this._flushWarnings(rewritten);
     return castResult.call(this, pgResult);
-  }
-
-  private _flushWarnings(sql?: string): void {
-    const actionable = new Set(["WARNING", "ERROR", "FATAL", "PANIC"]);
-    const ctor = this.constructor as typeof PostgreSQLAdapter;
-    const action = ctor.dbWarningsAction;
-    try {
-      if (!action || action === "ignore") return;
-      for (const w of this._noticeReceiverSqlWarnings) {
-        if (!actionable.has(w.level ?? "")) continue;
-        if (this.isWarningIgnored(w)) continue;
-        const sw = new SQLWarning(w.message, w.code ?? null, w.level ?? null);
-        if (sql) sw.sql = sql;
-        if (action === "raise") throw sw;
-        if (action === "log") {
-          const logger = this.logger as { warn?: (msg: string) => void } | null;
-          const codeSuffix = w.code ? ` (${w.code})` : "";
-          const msg = `[ActiveRecord::SQLWarning] ${sw.message}${codeSuffix}`;
-          if (logger?.warn) logger.warn(msg);
-          else console.warn(msg);
-        }
-        if (action === "report") {
-          // Mirrors Rails' `:report` → `Rails.error.report(warning, handled: true)`
-          // (active_record.rb:248–249).
-          ActiveSupport.errorReporter.report(sw, { handled: true });
-        }
-        if (typeof action === "function") action(sw);
-      }
-    } finally {
-      this._noticeReceiverSqlWarnings = [];
-    }
-  }
-
-  private _isInvalidCachedPlan(e: unknown): boolean {
-    const err = e as { code?: string; message?: string } | null;
-    if (err?.code !== "0A000") return false;
-    // "cached plan must not change result type" is the only
-    // 0A000 subtype we retry on — other FEATURE_NOT_SUPPORTED
-    // errors (e.g. RETURNING on a view) must surface unchanged.
-    return typeof err.message === "string" && err.message.includes("cached plan");
   }
 
   /**
@@ -1721,7 +1584,10 @@ export class PostgreSQLAdapter
       try {
         return await this.withRawConnection({ allowRetry }, async (conn) => {
           const client = conn as unknown as pg.Client;
-          const result = await this._performQuery(client, rewritten, bindArray, payload);
+          const result = await this._performQuery(client, rewritten, binds, bindArray, {
+            prepare: this._shouldPrepare(bindArray),
+            notificationPayload: payload,
+          });
           return result?.rows ?? [];
         });
       } catch (e: any) {
@@ -1732,45 +1598,23 @@ export class PostgreSQLAdapter
   }
 
   /**
-   * The single SQL primitive: run a statement, mark the connection verified,
-   * flush warnings, record the affected-row count, and set the notification
-   * payload's row count — the shared body of `execute` and `executeMutation`,
-   * mirroring Rails' one `perform_query`. Returns the raw pg result (rows for a
-   * row-returning statement, `rowCount` for a write). Unlike sqlite, node-pg
-   * does not throw on a non-row-returning statement, so there is no branch on a
-   * driver throw — the read/write split lives in the callers' contracts
-   * (`execute` returns `.rows`, `executeMutation` sources affected rows through
-   * the `affectedRows` port).
+   * The single SQL primitive every query path funnels through, extracted to
+   * `postgresql/database-statements.ts` (`performQuery`) so api:compare's
+   * file-level match sees it where Rails puts it.
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#perform_query
+   * @internal
    */
-  private async _performQuery(
-    client: pg.Client,
-    sql: string,
-    binds: unknown[],
-    payload: Record<string, unknown>,
-  ): Promise<pg.QueryResult> {
-    // Rails' perform_query first syncs the timestamp typemap / session timezone
-    // when default_timezone changed (database_statements.rb:136 →
-    // update_typemap_for_default_timezone); guarded, so it's a no-op unless the
-    // timezone actually changed.
-    await this.updateTypemapForDefaultTimezone();
-    const queryResult = await this._runQuery(client, sql, binds);
-    // Mirrors Rails' perform_query → verified!: a successful round-trip proves
-    // the connection is live, so skip the verify ping on the next
-    // withRawConnection.
-    this.verifiedBang();
-    // A multi-statement string (e.g. disable_referential_integrity's joined
-    // ALTERs) runs under the simple-query protocol, where node-pg returns one
-    // Result per statement. Mirror Rails' execute and surface the last
-    // command's result.
-    const result = (
-      Array.isArray(queryResult) ? queryResult[queryResult.length - 1] : queryResult
-    ) as pg.QueryResult;
-    payload.row_count = result?.rows?.length ?? 0;
-    this._flushWarnings(sql);
-    return result;
-  }
+  private _performQuery = pgPerformQuery;
+
+  /**
+   * Dispatch the notices PG raised during the last statement, wired from the
+   * extracted module below.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#handle_warnings
+   * @internal
+   */
+  declare handleWarnings: (sql: unknown) => void;
 
   /**
    * Rows affected by a write, read from its `PG::Result` (`cmd_tuples`).
@@ -1836,7 +1680,10 @@ export class PostgreSQLAdapter
                 this._commandSettled = false;
                 await client.query(`SAVEPOINT "${spName}"`);
               }
-              const result = await this._performQuery(client, withReturning, binds, payload);
+              const result = await this._performQuery(client, withReturning, originalBinds, binds, {
+                prepare: this._shouldPrepare(binds),
+                notificationPayload: payload,
+              });
               if (useSavepoint) {
                 this._commandSettled = false;
                 await client.query(`RELEASE SAVEPOINT "${spName}"`);
@@ -1866,7 +1713,10 @@ export class PostgreSQLAdapter
                 await client.query(`RELEASE SAVEPOINT "${spName}"`).catch(() => {});
               }
               payload.sql = pgSql;
-              const result = await this._performQuery(client, pgSql, binds, payload);
+              const result = await this._performQuery(client, pgSql, originalBinds, binds, {
+                prepare: this._shouldPrepare(binds),
+                notificationPayload: payload,
+              });
               const affected = this.affectedRows(result);
               payload.row_count = affected;
               return affected;
@@ -1875,7 +1725,10 @@ export class PostgreSQLAdapter
 
           // For INSERT with explicit RETURNING
           if (upper.startsWith("INSERT") && upper.includes("RETURNING")) {
-            const result = await this._performQuery(client, pgSql, binds, payload);
+            const result = await this._performQuery(client, pgSql, originalBinds, binds, {
+              prepare: this._shouldPrepare(binds),
+              notificationPayload: payload,
+            });
             const affected = this.affectedRows(result);
             payload.row_count = affected;
             if (result.rows.length > 0) {
@@ -1885,7 +1738,10 @@ export class PostgreSQLAdapter
           }
 
           // For UPDATE/DELETE, return affected rows
-          const result = await this._performQuery(client, pgSql, binds, payload);
+          const result = await this._performQuery(client, pgSql, originalBinds, binds, {
+            prepare: this._shouldPrepare(binds),
+            notificationPayload: payload,
+          });
           const affected = this.affectedRows(result);
           payload.row_count = affected;
           return affected;
@@ -2286,19 +2142,16 @@ export class PostgreSQLAdapter
           // already-translated error, re-wrap it as StatementInvalid.
           // Rails' internal_execute forwards `prepare:` to raw_execute →
           // perform_query (abstract/database_statements.rb:552-558, 589-591).
-          const runResult = await this._runQuery(client, runSql, bindArray, {
+          const runResult = await this._performQuery(client, runSql, binds, bindArray, {
+            prepare: prepare === false ? false : this._shouldPrepare(bindArray),
+            notificationPayload: payload,
             rowMode: "array",
-            prepareHint: prepare,
-            onPrepared: (stmtName) => {
-              payload.statement_name = stmtName;
-            },
           });
           const count = runResult.rowCount ?? runResult.rows.length;
           payload.row_count = count;
           return runResult;
         }),
       );
-      if (hasBinds) this._flushWarnings(runSql);
       return result;
     } finally {
       // Rails' with_raw_connection `ensure dirty_current_transaction if
@@ -4280,8 +4133,15 @@ export class PostgreSQLAdapter
    */
   isCachedPlanFailure(pgerror: unknown): boolean {
     if (!(pgerror instanceof Error)) return false;
-    const code = (pgerror as { code?: string }).code;
-    return code === "0A000";
+    const err = pgerror as { code?: string; message?: string };
+    if (err.code !== FEATURE_NOT_SUPPORTED) return false;
+    // Rails' second half is `result_error_field(PG_DIAG_SOURCE_FUNCTION) ==
+    // "RevalidateCachedQuery"` (postgresql_adapter.rb:902-903). node-pg exposes
+    // no source-function field, so the server message it emits from that
+    // function — "cached plan must not change result type" — stands in for it.
+    // Without it every FEATURE_NOT_SUPPORTED (e.g. RETURNING on a view) would
+    // be retried as a plan invalidation.
+    return typeof err.message === "string" && err.message.includes("cached plan");
   }
 
   /**
@@ -4311,15 +4171,16 @@ export class PostgreSQLAdapter
    */
   async prepareStatement(sql: string, _binds: unknown[], client: pg.Client): Promise<string> {
     const pool = this._poolFor(client);
-    // Use same cache key as _preparedNameFor so prepared statements created here
-    // are visible to / deduped with the internal query path.
     const key = this.sqlKey(sql);
     const existing = pool.get(key);
     if (existing) return existing.name;
     const name = pool.nextKey();
-    // PREPARE ... AS avoids executing the statement (node-pg's { name, text } form
-    // both prepares and executes in a single roundtrip).
-    await client.query(`PREPARE ${pgQuoteColumnName(name)} AS ${sql}`);
+    // Rails issues `conn.prepare nextkey, sql` here; node-pg has no parse-only
+    // call — its `{ name, text }` form Parses under the name and Executes in
+    // one roundtrip — so the name is allocated here and `perform_query`'s
+    // exec_prepared arm carries the text that Parses it on first use. The
+    // server-side statement is identical either way; only the roundtrip that
+    // creates it differs.
     await pool.set(key, { name });
     return name;
   }
@@ -4926,6 +4787,13 @@ const SERIAL_SEQUENCE_RE = /^nextval\('"?(?<sequenceName>.+_(?<suffix>seq\d*))"?
 
 (PostgreSQLAdapter.prototype as any).castResult = castResult;
 (PostgreSQLAdapter.prototype as any).handleWarnings = handleWarnings;
+// Rails' `warning_ignored?` adds the level threshold on top of the base
+// adapter's db_warnings_ignore matchers via `super`
+// (postgresql/database_statements.rb:225-227); `_abstractIsWarningIgnored` is
+// that `super`.
+(PostgreSQLAdapter.prototype as any)._abstractIsWarningIgnored =
+  AbstractAdapter.prototype.isWarningIgnored;
+(PostgreSQLAdapter.prototype as any).isWarningIgnored = pgIsWarningIgnored;
 // Mirrors: PostgreSQL::DatabaseStatements#build_truncate_statements (database_statements.rb)
 // Combines all table names into a single TRUNCATE TABLE a, b, c statement, so
 // the abstract `truncateTables` emits Rails' combined form instead of N per-table ones.

--- a/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
@@ -8,6 +8,8 @@ import type pg from "pg";
 import type { Type } from "@blazetrails/activemodel";
 import type { Nodes } from "@blazetrails/arel";
 import type { ExplainOption } from "../abstract/database-statements.js";
+import { ActiveSupport } from "@blazetrails/activesupport";
+import { PreparedStatementCacheExpired, type SQLWarning } from "../../errors.js";
 import { Result } from "../../result.js";
 
 // Mirrors: PostgreSQL::DatabaseStatements::READ_QUERY (database_statements.rb:19-21)
@@ -90,6 +92,132 @@ interface CancelAnyRunningQueryHost {
  */
 export function cancelAnyRunningQuery(this: CancelAnyRunningQueryHost): void {
   this._cancelAnyRunningQuery();
+}
+
+/**
+ * node-pg's `query()` overloads do not admit `rowMode` on a QueryConfig and
+ * widen the return to `Submittable`; this narrows both back.
+ */
+function query(
+  rawConnection: pg.Client,
+  config: string | Record<string, unknown>,
+): Promise<pg.QueryResult | pg.QueryResult[]> {
+  return (
+    rawConnection.query as unknown as (
+      c: string | Record<string, unknown>,
+    ) => Promise<pg.QueryResult | pg.QueryResult[]>
+  )(config);
+}
+
+/** @internal */
+export interface PerformQueryHost extends HandleWarningsHost {
+  updateTypemapForDefaultTimezone(): Promise<void>;
+  prepareStatement(sql: string, binds: unknown[], rawConnection: pg.Client): Promise<string>;
+  isCachedPlanFailure(pgerror: unknown): boolean;
+  openTransactions: number;
+  sqlKey(sql: string): string;
+  _poolFor(rawConnection: pg.Client): { delete(key: string): unknown };
+  verifiedBang(): void;
+  /** @internal */
+  handleWarnings(sql: unknown): void;
+  _commandSettled: boolean;
+}
+
+/**
+ * The single SQL primitive: run a statement on `rawConnection` and hand back
+ * the driver result. `execute` / `executeMutation` / `internalExecQuery` /
+ * `internalExecute` all funnel through it, as Rails' `raw_execute` does.
+ *
+ * `rowMode` has no Rails counterpart: a `PG::Result` exposes both the hash and
+ * the positional view of every row, so Rails picks one after the fact, while
+ * node-pg has to be told which shape to decode into before the query runs.
+ * It only selects the decoding of the same result, never which arm runs.
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#perform_query
+ * (postgresql/database_statements.rb:135-168)
+ *
+ * @missingRailsCall synchronize — `@lock.synchronize` guards the statement
+ * cache against other Ruby threads (database_statements.rb:151); trails'
+ * adapter is single-threaded and ports no adapter mutex.
+ * @internal
+ */
+export async function performQuery<R extends pg.QueryResult = pg.QueryResult>(
+  this: PerformQueryHost,
+  rawConnection: pg.Client,
+  sql: string,
+  binds: unknown[],
+  typeCastedBinds: unknown[],
+  {
+    prepare,
+    notificationPayload,
+    rowMode,
+  }: {
+    prepare: boolean;
+    notificationPayload: Record<string, unknown>;
+    rowMode?: "array";
+  },
+): Promise<R> {
+  await this.updateTypemapForDefaultTimezone();
+  let raw: pg.QueryResult | pg.QueryResult[];
+  if (prepare) {
+    // Rails' `retry` inside the `PG::FeatureNotSupported` rescue
+    // (database_statements.rb:138-158); node-pg raises no typed error class, so
+    // `is_cached_plan_failure?` — which is the whole of Rails' recovery gate —
+    // is checked against every error the arm can raise.
+    for (;;) {
+      try {
+        const stmtKey = await this.prepareStatement(sql, binds, rawConnection);
+        notificationPayload.statement_name = stmtKey;
+        this._commandSettled = false;
+        raw = await query(rawConnection, {
+          name: stmtKey,
+          text: sql,
+          values: typeCastedBinds,
+          rowMode,
+        });
+        break;
+      } catch (error) {
+        if (this.isCachedPlanFailure(error)) {
+          // Nothing we can do if we are in a transaction because all commands
+          // will raise InFailedSQLTransaction
+          // `in_transaction?` is `open_transactions > 0`
+          // (postgresql_adapter.rb:908-910), so an open *lazy* (un-materialized)
+          // frame still counts — a read-only block (`transaction { record.reload }`)
+          // never emits a physical `BEGIN` because reads don't materialize.
+          if (this.openTransactions > 0) {
+            throw new PreparedStatementCacheExpired(
+              (error as { message?: string })?.message ?? "cached plan expired",
+              { sql, binds, cause: error },
+            );
+          } else {
+            // outside of transactions we can simply flush this query and retry
+            await this._poolFor(rawConnection).delete(this.sqlKey(sql));
+            continue;
+          }
+        }
+        throw error;
+      }
+    }
+  } else if (binds == null || binds.length === 0) {
+    this._commandSettled = false;
+    // `async_exec` on a PG::Result carries both row views; node-pg needs the
+    // config form to be told which one, so a caller that asked for positional
+    // rows gets it here too. Without one this stays the bare simple-query call.
+    raw = await query(rawConnection, rowMode ? { text: sql, rowMode } : sql);
+  } else {
+    this._commandSettled = false;
+    raw = await query(rawConnection, { text: sql, values: typeCastedBinds, rowMode });
+  }
+
+  // A multi-statement string (e.g. disable_referential_integrity's joined
+  // ALTERs) runs under the simple-query protocol, where node-pg returns one
+  // Result per statement where PG::Result is already the last one. Mirror Rails
+  // and surface the last command's result.
+  const result = (Array.isArray(raw) ? raw[raw.length - 1] : raw) as R;
+  this.verifiedBang();
+  this.handleWarnings(result);
+  notificationPayload.row_count = result?.rows?.length ?? 0;
+  return result;
 }
 
 /**
@@ -221,39 +349,63 @@ export function suppressCompositePrimaryKey(pk: string | string[] | undefined): 
 const ACTIONABLE_LEVELS = new Set(["WARNING", "ERROR", "FATAL", "PANIC"]);
 
 /** @internal */
-type SqlWarning = {
-  level?: string;
-  message?: string;
-  code?: string | number;
-  sql?: unknown;
-  [k: string]: unknown;
-};
+type SqlWarning = SQLWarning;
+
+/** Mirrors the values `ActiveRecord.db_warnings_action` accepts. */
+type DbWarningsAction = "ignore" | "log" | "raise" | "report" | ((warning: SqlWarning) => void);
 
 /** @internal */
 interface HandleWarningsHost {
   _noticeReceiverSqlWarnings?: SqlWarning[];
-  // Used to call the abstract adapter's pattern-matcher without risking
-  // recursion if this module's isWarningIgnored is later bound to the class.
-  _abstractIsWarningIgnored?(warning: SqlWarning): boolean;
+  // The base adapter's matcher signature (abstract_adapter.rb:1227), which
+  // PostgreSQL's own `warning_ignored?` override widens with the level check.
+  /** @internal */
+  isWarningIgnored(warning: { message?: string; code?: string | number }): boolean;
+  logger?: unknown;
 }
 
 /**
- * Iterates notice-receiver warnings accumulated during the query and attaches
- * the result object (mirrors Rails attaching the PG::Result).
+ * Iterates notice-receiver warnings accumulated during the query, attaches the
+ * result object (Rails names the parameter `sql` but `perform_query` passes the
+ * PG::Result, database_statements.rb:166), and dispatches each surviving
+ * warning to the configured `db_warnings_action`.
  *
- * Rails also calls `ActiveRecord.db_warnings_action.call(warning)` here.
- * That global hook is not yet wired in TS; warnings are collected and filtered
- * but not dispatched to a user-configured action. Tracked as a follow-up.
+ * Rails' `ActiveRecord.db_warnings_action=` turns the symbol into a Proc once,
+ * at config time (active_record.rb:236-252), and `handle_warnings` only
+ * `.call`s it. trails stores the symbol itself on the adapter class, so the
+ * symbol → behavior mapping lives here, at the one place that calls it.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#handle_warnings
  * @internal
  */
-export function handleWarnings(this: HandleWarningsHost, result: pg.QueryResult): void {
-  if (!this._noticeReceiverSqlWarnings?.length) return;
-  for (const warning of this._noticeReceiverSqlWarnings) {
-    if (isWarningIgnored.call(this, warning)) continue;
-    warning.sql = result;
-    // TODO: dispatch to ActiveRecord.db_warnings_action equivalent once wired
+export function handleWarnings(this: HandleWarningsHost, sql: unknown): void {
+  const action = (this.constructor as { dbWarningsAction?: DbWarningsAction }).dbWarningsAction;
+  try {
+    for (const warning of this._noticeReceiverSqlWarnings ?? []) {
+      if (this.isWarningIgnored(warning as unknown as { message?: string })) continue;
+      warning.sql = sql;
+      if (!action || action === "ignore") continue;
+      if (action === "raise") throw warning;
+      if (action === "log") {
+        const codeSuffix = warning.code ? ` (${warning.code})` : "";
+        const message = `[ActiveRecord::SQLWarning] ${warning.message}${codeSuffix}`;
+        const logger = this.logger as { warn?: (msg: string) => void } | null | undefined;
+        if (logger?.warn) logger.warn(message);
+        else console.warn(message);
+      }
+      // Mirrors Rails' `:report` → `Rails.error.report(warning, handled: true)`
+      // (active_record.rb:248-249).
+      if (action === "report") ActiveSupport.errorReporter.report(warning, { handled: true });
+      // Rails' `ActiveRecord.db_warnings_action.call(warning)` — the symbol arms
+      // above are the behaviors its setter bakes into that Proc, and a
+      // user-supplied callable is invoked here exactly as Rails invokes it.
+      if (typeof action === "function") action.call(undefined, warning);
+    }
+  } finally {
+    // Rails resets the buffer when the notice receiver is (re)installed
+    // (postgresql_adapter.rb:338); trails clears it here as well so a warning
+    // is never re-dispatched by the next query on the same connection.
+    if (this._noticeReceiverSqlWarnings) this._noticeReceiverSqlWarnings = [];
   }
 }
 

--- a/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
@@ -380,32 +380,25 @@ interface HandleWarningsHost {
  */
 export function handleWarnings(this: HandleWarningsHost, sql: unknown): void {
   const action = (this.constructor as { dbWarningsAction?: DbWarningsAction }).dbWarningsAction;
-  try {
-    for (const warning of this._noticeReceiverSqlWarnings ?? []) {
-      if (this.isWarningIgnored(warning as unknown as { message?: string })) continue;
-      warning.sql = sql;
-      if (!action || action === "ignore") continue;
-      if (action === "raise") throw warning;
-      if (action === "log") {
-        const codeSuffix = warning.code ? ` (${warning.code})` : "";
-        const message = `[ActiveRecord::SQLWarning] ${warning.message}${codeSuffix}`;
-        const logger = this.logger as { warn?: (msg: string) => void } | null | undefined;
-        if (logger?.warn) logger.warn(message);
-        else console.warn(message);
-      }
-      // Mirrors Rails' `:report` → `Rails.error.report(warning, handled: true)`
-      // (active_record.rb:248-249).
-      if (action === "report") ActiveSupport.errorReporter.report(warning, { handled: true });
-      // Rails' `ActiveRecord.db_warnings_action.call(warning)` — the symbol arms
-      // above are the behaviors its setter bakes into that Proc, and a
-      // user-supplied callable is invoked here exactly as Rails invokes it.
-      if (typeof action === "function") action.call(undefined, warning);
+  for (const warning of this._noticeReceiverSqlWarnings ?? []) {
+    if (this.isWarningIgnored(warning as unknown as { message?: string })) continue;
+    warning.sql = sql;
+    if (!action || action === "ignore") continue;
+    if (action === "raise") throw warning;
+    if (action === "log") {
+      const codeSuffix = warning.code ? ` (${warning.code})` : "";
+      const message = `[ActiveRecord::SQLWarning] ${warning.message}${codeSuffix}`;
+      const logger = this.logger as { warn?: (msg: string) => void } | null | undefined;
+      if (logger?.warn) logger.warn(message);
+      else console.warn(message);
     }
-  } finally {
-    // Rails resets the buffer when the notice receiver is (re)installed
-    // (postgresql_adapter.rb:338); trails clears it here as well so a warning
-    // is never re-dispatched by the next query on the same connection.
-    if (this._noticeReceiverSqlWarnings) this._noticeReceiverSqlWarnings = [];
+    // Mirrors Rails' `:report` → `Rails.error.report(warning, handled: true)`
+    // (active_record.rb:248-249).
+    if (action === "report") ActiveSupport.errorReporter.report(warning, { handled: true });
+    // Rails' `ActiveRecord.db_warnings_action.call(warning)` — the symbol arms
+    // above are the behaviors its setter bakes into that Proc, and a
+    // user-supplied callable is invoked here exactly as Rails invokes it.
+    if (typeof action === "function") action.call(undefined, warning);
   }
 }
 

--- a/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
@@ -211,8 +211,8 @@ export async function performQuery<R extends pg.QueryResult = pg.QueryResult>(
 
   // A multi-statement string (e.g. disable_referential_integrity's joined
   // ALTERs) runs under the simple-query protocol, where node-pg returns one
-  // Result per statement where PG::Result is already the last one. Mirror Rails
-  // and surface the last command's result.
+  // Result per statement, while libpq hands Rails only the last one. Surface
+  // the same one Rails sees.
   const result = (Array.isArray(raw) ? raw[raw.length - 1] : raw) as R;
   this.verifiedBang();
   this.handleWarnings(result);

--- a/packages/activerecord/src/errors.ts
+++ b/packages/activerecord/src/errors.ts
@@ -743,7 +743,10 @@ export { NameError } from "@blazetrails/activesupport";
 export class SQLWarning extends AdapterError {
   readonly code: string | null;
   readonly level: string | null;
-  sql?: string;
+  // `handle_warnings` assigns whatever its caller passes: the PG::Result on
+  // PostgreSQL (postgresql/database_statements.rb:166, :220) and the SQL string
+  // on MySQL, so Rails' `sql` is not a String on every adapter.
+  sql?: unknown;
 
   /**
    * `connectionPool` is inherited via {@link AdapterError}'s accessor; we
@@ -754,7 +757,7 @@ export class SQLWarning extends AdapterError {
     message?: string,
     code?: string | null,
     level?: string | null,
-    sql?: string,
+    sql?: unknown,
     connectionPool?: unknown,
   ) {
     super(message ?? "SQL Warning", { connectionPool });

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/database-statements.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/database-statements.json
@@ -23,13 +23,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql/database-statements.ts",
-    "rubyName": "handle_warnings",
-    "call": "order:call,isWarningIgnored",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/database-statements.ts",
     "rubyName": "last_insert_id_result",
     "call": "internal_exec_query",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Rails' `perform_query` (`postgresql/database_statements.rb:135-168`) is the
PostgreSQL adapter's one SQL primitive. trails delegated it to a
trails-invented `_runQuery` helper, so four calls Rails' body makes lived
somewhere else. This inlines Rails' three arms in the extracted
`postgresql/database-statements.ts` (where sqlite3 and mysql2 already keep
theirs):

- `prepare` → `prepareStatement(sql, binds, rawConnection)` + exec_prepared,
  with the cached-plan rescue: `isCachedPlanFailure` → in a transaction, raise
  `PreparedStatementCacheExpired`; otherwise flush the entry and `retry`.
- empty binds → `async_exec`.
- otherwise → `exec_params`.

Then `verified!`, `handle_warnings(result)`, `notification_payload[:row_count]`
— in Rails' order.

`handle_warnings` is now the live dispatcher rather than a stub next to a
`_flushWarnings` invention, and the notice receiver buffers `SQLWarning`
instances as Rails does (`postgresql_adapter.rb:970`), so the objects it
iterates are the ones it dispatches. PG's `warning_ignored?` override is wired
over the base adapter's matcher via `_abstractIsWarningIgnored`.

Removed: `_runQuery`, `_preparedNameFor`, `_isInvalidCachedPlan`,
`_flushWarnings`. `isCachedPlanFailure` absorbed the message check (node-pg
exposes no `PG_DIAG_SOURCE_FUNCTION`, so the `RevalidateCachedQuery` message
stands in for it) and the `FEATURE_NOT_SUPPORTED` constant
(`postgresql_adapter.rb:890`) is ported. `prepareStatement` now allocates the
statement name node-pg Parses on first use instead of issuing `PREPARE … AS`,
because node-pg's `{ name, text }` form both Parses and Executes in one
roundtrip and would collide with a pre-issued PREPARE.

Two deviations, both justified at the call site:

- `rowMode` on the options object: a `PG::Result` carries both row views, so
  Rails picks one after the fact; node-pg must be told before the query runs.
  It selects decoding only, never which arm runs.
- `@missingRailsCall synchronize` — `@lock` guards the statement cache against
  other Ruby threads; trails is single-threaded and ports no adapter mutex.

`SQLWarning#sql` is widened to `unknown`: Rails assigns the `PG::Result` on
PostgreSQL and the SQL string on MySQL, so it is not a String on every adapter.

**Baseline**: the `handle_warnings` `order:call,isWarningIgnored` row is
deleted (only-shrink, re-serialized via `serializeBaseline`). No rows added —
`pnpm api:calls` is green.

## Review round 1

**Finding 1 — notice-buffer reset point. Fixed.** The reviewer is right: Rails
resets `@notice_receiver_sql_warnings` in exactly one place per query, the
public `execute`'s `ensure` (`postgresql/database_statements.rb:39-43`), never
inside `handle_warnings`, and the `postgresql_adapter.rb:338` citation was the
`initialize` reset. The `finally` clear is out of `handleWarnings`, and the
reset now lives in the adapter's `execute` under Rails' cite. The invented
pre-query resets on the other three paths (`internalExecQuery`,
`executeMutation`, `internalExecute`) are deleted with it — they made the
buffer per-query by the back door, which is the same divergence the finding
names. Warnings raised on an internal path now survive into the next
`handle_warnings` pass until an `execute` clears them, as they do in Rails.

**Finding 2 — unconditional retry. Traced, no change.** It does mirror Ruby's
`retry`, including the failure mode. Rails' `rescue PG::FeatureNotSupported`
covers the whole `begin` block — `prepare_statement` included — and
`prepare_statement` (`postgresql_adapter.rb:920-934`) re-raises through
`translate_exception_class`, so a `FEATURE_NOT_SUPPORTED` raised while
preparing is caught by the same rescue and retried on the same terms. The TS
arm has the identical shape: the `catch` re-tests `isCachedPlanFailure`, and
anything else rethrows, so only an error that is both SQLSTATE `0A000` and
carries the `RevalidateCachedQuery` message can loop. Rails would spin on that
same input; matching it is the point of the story, and narrowing it here would
be a deviation with no Rails basis.

**Round-1 CI failure — real, fixed.** `Active Record PostgreSQL Tests` flagged
the trails-only RFC 0085 case `releases the transaction client when the socket
was severed under it`. Routing `internal_execute` through `perform_query` gives
that path `verified!` (`database_statements.rb:164`) for the first time, so the
BEGIN now marks the connection verified and `with_raw_connection` skips the
verify ping that used to silently reconnect mid-test; with
`internal_execute`'s `allow_retry: false` there is no retry either, so the
driver error surfaces. Rails behaves the same way — its `begin_db_transaction`
marks verified through the same `perform_query`. The case pinned leniency that
only existed because of the divergence this PR removes, so it keeps its name
and both client-release assertions (the invariant it exists to pin) and now
expects the error. Verified both directions: dropping `verifiedBang()` restores
the old expectation, keeping it satisfies the new one.

**Note on overlap**: the story assumed the `_performQuery` → `performQuery`
rename had landed; it has not — that is still open as #6327, which touches
`postgresql-adapter.ts` too. This supersedes its PostgreSQL half.

Closes-story: converge-pg-perform-query-onto-rails-arms
