### PR TITLE
feat(date): Temporal constructor overload, weeknum/nth_kday/today/now, valid_date?/leap? aliases

### DIFF
--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -2035,3 +2035,25 @@ describe("Date::Infinity as a Range endpoint", () => {
     );
   });
 });
+
+/**
+ * Trails-only: `Init_date_core` registers `date_s_valid_civil_p` and
+ * `date_s_gregorian_leap_p` under a second name each (`date_core.c:9659`,
+ * `:9676`), and no test in `vendor/date/test/date/` calls either spelling.
+ */
+describe("Date's second registration names", () => {
+  it("valid_date? is valid_civil? — the same C function", () => {
+    expect(RubyDate.isValidDate(2001, 2, 3)).toBe(true);
+    expect(RubyDate.isValidDate(2001, 2, 29)).toBe(false);
+    expect(RubyDate.isValidDate(1582, 10, 5, RubyDate.ITALY)).toBe(false);
+    expect(RubyDate.isValidDate(1582, 10, 5, RubyDate.GREGORIAN)).toBe(true);
+    expect(RubyDate.isValidDate("2001", 2, 3)).toBe(false);
+  });
+
+  it("leap? is gregorian_leap? — the same C function", () => {
+    expect(RubyDate.isLeap(2000)).toBe(true);
+    expect(RubyDate.isLeap(1900)).toBe(false);
+    expect(RubyDate.isLeap(2004)).toBe(true);
+    expect(() => RubyDate.isLeap("2000")).toThrow(TypeError);
+  });
+});

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -5532,18 +5532,29 @@ export class Date {
    * Sunday-based weeks and `1` for the Monday-based ones. It is a `:nodoc:`
    * singleton method defined only under `#ifndef NDEBUG`, which is why the
    * gem's own test guards it with `Date.respond_to?(:weeknum, true)`.
+   *
+   * `day` carries the fraction (`num2int_with_frac(d, positive_inf)`,
+   * `date_core.c:3691`) and `add_frac` (`:3286-3318`) adds it back as a day
+   * fraction, which is a complex `Date` the `Temporal.PlainDate` seat reads
+   * the day of — a fraction of a day never moves midnight off its own date.
    */
   static weeknum(
     year = -4712,
     week = 0,
-    day = 1,
+    day: number | Rational = 1,
     firstday = 0,
     start = DEFAULT_SG,
   ): Temporal.PlainDate {
     const sg = val2sg(start);
-    const rjd = cValidWeeknumP(year, week, day, firstday, sg);
+    const [d, fr2] = num2intWithFrac(day, DAY_IN_SECONDS, false);
+    const rjd = cValidWeeknumP(year, week, d, firstday, sg);
     if (rjd === null) throw new DateError("invalid date");
-    return new Date(SEAT, 0n, rjd, sg).toDate();
+    const [nth, rrjd] = decodeJd(rjd);
+    const ret = new Date(SEAT, nth, rrjd, sg);
+    if (fr2 instanceof Rational ? !fr2.isZero() : fr2 !== 0) {
+      return ret.plus(fr2 instanceof Rational ? fr2.quo(DAY_IN_SECONDS) : isecToDay(fr2)).toDate();
+    }
+    return ret.toDate();
   }
 
   /**
@@ -5551,13 +5562,26 @@ export class Date {
    * `date_core.c` `date_s_nth_kday`, `date_core.c:3707-3756`, `:9690`), the
    * `n`th weekday `k` of a month — `Date.nth_kday(1992, 2, 5, 6)` is the 5th
    * Saturday of February 1992. `:nodoc:` and `#ifndef NDEBUG`, as
-   * {@link Date.weeknum} is.
+   * {@link Date.weeknum} is, and `k` carries the fraction there too
+   * (`num2int_with_frac(k, positive_inf)`, `date_core.c:3741`).
    */
-  static nthKday(year = -4712, month = 1, n = 1, k = 1, start = DEFAULT_SG): Temporal.PlainDate {
+  static nthKday(
+    year = -4712,
+    month = 1,
+    n = 1,
+    k: number | Rational = 1,
+    start = DEFAULT_SG,
+  ): Temporal.PlainDate {
     const sg = val2sg(start);
-    const rjd = cValidNthKdayP(year, month, n, k, sg);
+    const [rk, fr2] = num2intWithFrac(k, DAY_IN_SECONDS, false);
+    const rjd = cValidNthKdayP(year, month, n, rk, sg);
     if (rjd === null) throw new DateError("invalid date");
-    return new Date(SEAT, 0n, rjd, sg).toDate();
+    const [nth, rrjd] = decodeJd(rjd);
+    const ret = new Date(SEAT, nth, rrjd, sg);
+    if (fr2 instanceof Rational ? !fr2.isZero() : fr2 !== 0) {
+      return ret.plus(fr2 instanceof Rational ? fr2.quo(DAY_IN_SECONDS) : isecToDay(fr2)).toDate();
+    }
+    return ret.toDate();
   }
 
   /**
@@ -7006,19 +7030,18 @@ export class DateTime extends DateWithoutParseStatics {
   ) {
     if (year instanceof Temporal.PlainDateTime || year instanceof Temporal.ZonedDateTime) {
       const sg = val2sg((month as number) ?? DEFAULT_SG);
-      const of = year instanceof Temporal.ZonedDateTime ? year.offsetNanoseconds / 1000000000 : 0;
+      const rof = year instanceof Temporal.ZonedDateTime ? year.offsetNanoseconds / 1000000000 : 0;
       const [nth, ry] = decodeYear(year.year, -1);
       const rjd = cCivilToJd(ry, year.month, year.day, virtualSg(nth, sg));
-      const df = timeToDf(year.hour, year.minute, year.second);
-      const sf = new Rational(
+      const localDf = timeToDf(year.hour, year.minute, year.second);
+      super(SEAT, nth, rjd, sg);
+      this.#jd = jdLocalToUtc(rjd, localDf, rof);
+      this.#df = dfLocalToUtc(localDf, rof);
+      this.#sf = new Rational(
         year.millisecond * 1000000 + year.microsecond * 1000 + year.nanosecond,
         1,
       );
-      super(SEAT, nth, rjd, sg);
-      this.#jd = jdLocalToUtc(rjd, df, of);
-      this.#df = dfLocalToUtc(df, of);
-      this.#sf = sf;
-      this.#of = of;
+      this.#of = rof;
       return;
     }
     if (typeof year === "symbol") {
@@ -7537,10 +7560,13 @@ export class DateTime extends DateWithoutParseStatics {
    * second — `s == 60` — is stored as `59`, and `sf` is nanoseconds.
    *
    * The C builds under `GREGORIAN` and then `set_sg(dat, sg)`, the same shape
-   * {@link Date.today} and `Time#to_datetime` have.
+   * {@link Date.today} and `Time#to_datetime` have. `start` is taken as
+   * `NUM2DBL(vsg)` and NOT through `val2sg` — this is the one builder that
+   * does not screen its `start` (`date_core.c:8147-8150`, against
+   * `date_s_today`'s `val2sg` at `:3799-3802`).
    */
   static now(start = DEFAULT_SG): Temporal.PlainDateTime | Temporal.ZonedDateTime {
-    const sg = val2sg(start);
+    const sg = start;
     const tm = Temporal.Now.zonedDateTimeISO();
 
     const y = tm.year;

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -7564,6 +7564,10 @@ export class DateTime extends DateWithoutParseStatics {
    * `NUM2DBL(vsg)` and NOT through `val2sg` — this is the one builder that
    * does not screen its `start` (`date_core.c:8147-8150`, against
    * `date_s_today`'s `val2sg` at `:3799-3802`).
+   *
+   * An offset past a day is dropped to `0` (`date_core.c:8217-8220`); the
+   * `rb_warning("invalid offset is ignored")` beside it has no port analogue,
+   * as `val2sg`'s and `val2off`'s do not.
    */
   static now(start = DEFAULT_SG): Temporal.PlainDateTime | Temporal.ZonedDateTime {
     const sg = start;
@@ -7577,8 +7581,12 @@ export class DateTime extends DateWithoutParseStatics {
     let s = tm.second;
     if (s === 60) s = 59;
 
-    const of = tm.offsetNanoseconds / 1000000000;
+    let of = tm.offsetNanoseconds / 1000000000;
     const sf = new Rational(tm.millisecond * 1000000 + tm.microsecond * 1000 + tm.nanosecond, 1);
+
+    if (of < -DAY_IN_SECONDS || of > DAY_IN_SECONDS) {
+      of = 0;
+    }
 
     const [nth, ry] = decodeYear(y, -1);
 

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -4084,6 +4084,51 @@ function cValidWeeknumP(
 }
 
 /**
+ * @internal `date_core.c` `c_jd_to_nth_kday` (`date_core.c:651-660`), the
+ * inverse of {@link cNthKdayToJd}: the month the day falls in, which `n`th
+ * weekday of that month it is, and which weekday.
+ */
+function cJdToNthKday(
+  jd: number,
+  sg = DEFAULT_SG,
+): [ry: number, rm: number, rn: number, rk: number] {
+  const [ry, rm] = cJdToCivil(jd, sg);
+  const rjd = cFindFdom(ry, rm, sg)!;
+  return [ry, rm, div(jd - rjd, 7) + 1, cJdToWday(jd)];
+}
+
+/**
+ * @internal `date_core.c` `c_valid_nth_kday_p` (`date_core.c:840-866`), the
+ * `n`th-weekday counterpart of {@link cValidWeeknumP}: a negative `k` folds up
+ * from Sunday and a negative `n` counts back from the month's end — through the
+ * FIRST such weekday of the FOLLOWING month, which is why the month rolls over
+ * before the round-trip rejection below.
+ */
+function cValidNthKdayP(
+  y: number,
+  m: number,
+  n: number,
+  k: number,
+  sg = DEFAULT_SG,
+): number | null {
+  if (k < 0) k += 7;
+  if (n < 0) {
+    const t = y * 12 + m;
+    const ny = div(t, 12);
+    const nm = mod(t, 12) + 1;
+
+    const rjd2 = cNthKdayToJd(ny, nm, 1, k, sg);
+    const [ry2, rm2, rn2] = cJdToNthKday(rjd2 + n * 7, sg);
+    if (ry2 !== y || rm2 !== m) return null;
+    n = rn2;
+  }
+  const rjd = cNthKdayToJd(y, m, n, k, sg);
+  const [ry, rm, rn, rk] = cJdToNthKday(rjd, sg);
+  if (y !== ry || m !== rm || n !== rn || k !== rk) return null;
+  return rjd;
+}
+
+/**
  * @internal `date_core.c` `rt__valid_jd_p` (`date_core.c:4119-4123`), which
  * answers the Julian day back: every integer names a day, so there is nothing
  * to reject.
@@ -5123,6 +5168,23 @@ export class Date {
    */
   constructor(year?: number | bigint, month?: number, day?: number | Rational, start?: number);
   /**
+   * The inverse of {@link Date#toDate}: the gem-shaped object for a
+   * `Temporal.PlainDate`, read under `start`. There is no C counterpart
+   * because MRI's `::Date` value *is* the gem object — `date_to_date`
+   * (`date_core.c:8977-8981`) answers `self` — so the direction only exists
+   * where the two are different types, which is RFC 0088's mapping table.
+   *
+   * It is the exact inverse of {@link plainDateFromJd}'s `c_jd_to_civil`: the
+   * `Temporal` triple goes back through `decode_year` and `c_civil_to_jd`
+   * under the same `sg`, which is `get_s_jd` (`date_core.c:1168-1187`) — the
+   * lazy read the proleptic-Gregorian arm of `date_initialize` leaves behind —
+   * and lands on {@link SEAT}, `d_simple_new_internal` (`:3036-3050`), the one
+   * seat `d_new_by_frags` and `date_s_jd` (`:3377-3387`) already end at. There
+   * is nothing to validate: a `Temporal.PlainDate` is a real day by
+   * construction, which is what `d_simple_new_internal` assumes of its caller.
+   */
+  constructor(date: Temporal.PlainDate, start?: number);
+  /**
    * @internal `date_core.c` `d_simple_new_internal` (`date_core.c:3036-3050`),
    * which writes an already-resolved day straight into a fresh
    * `SimpleDateData` under `HAVE_JD` and validates nothing — every caller
@@ -5140,14 +5202,22 @@ export class Date {
     of?: number,
   );
   constructor(
-    year: number | bigint | typeof SEAT = -4712,
-    month: number | bigint = 1,
+    year: number | bigint | typeof SEAT | Temporal.PlainDate = -4712,
+    month?: number | bigint,
     day: number | Rational = 1,
     start = DEFAULT_SG,
     df?: number,
     sf?: Rational,
     of?: number,
   ) {
+    if (year instanceof Temporal.PlainDate) {
+      const sg = val2sg((month as number | undefined) ?? DEFAULT_SG);
+      const [nth, ry] = decodeYear(year.year, -1);
+      this.nth = nth;
+      this.#jd = cCivilToJd(ry, year.month, year.day, virtualSg(nth, sg));
+      this.#sg = sg;
+      return;
+    }
     if (typeof year === "symbol") {
       this.nth = month as bigint;
       this.#jd = day as number;
@@ -5157,6 +5227,7 @@ export class Date {
       this.#of = of;
       return;
     }
+    month ??= 1;
     checkNumeric(day, "day");
     checkNumeric(month, "month");
     checkNumeric(year, "year");
@@ -5290,6 +5361,22 @@ export class Date {
   }
 
   /**
+   * Ruby `Date.valid_date?(year, month, mday, start = Date::ITALY)` — the
+   * second name `Init_date_core` registers `date_s_valid_civil_p` under
+   * (`date_core.c:9659`, alongside `valid_civil?` at `:9658`), so it is the
+   * same C function and the same answer. The rdoc for `date_s_valid_civil_p`
+   * is itself written in terms of this spelling (`date_core.c:2588-2590`).
+   */
+  static isValidDate(
+    year: unknown,
+    month: unknown,
+    mday: unknown,
+    start: number = DEFAULT_SG,
+  ): boolean {
+    return Date.isValidCivil(year, month, mday, start);
+  }
+
+  /**
    * Ruby `Date.valid_ordinal?(year, yday, start = Date::ITALY)` (ruby/date,
    * `date_core.c` `date_s_valid_ordinal_p`, `date_core.c:2688-2708`, over
    * `valid_ordinal_sub`, `:2624-2650`).
@@ -5338,6 +5425,16 @@ export class Date {
     checkNumeric(year, "year");
     const [, ry] = decodeYear(year as number, -1);
     return cGregorianLeapP(ry);
+  }
+
+  /**
+   * Ruby `Date.leap?(year)` — the second name `Init_date_core` registers
+   * `date_s_gregorian_leap_p` under (`date_core.c:9676`, alongside
+   * `gregorian_leap?` at `:9674`), so it is the same C function: the same
+   * answer, and the same `TypeError` for a non-Numeric year.
+   */
+  static isLeap(year: unknown): boolean {
+    return Date.isGregorianLeap(year);
   }
 
   /**
@@ -5425,6 +5522,66 @@ export class Date {
     const r = cValidCommercialP(cwyear, cweek, d, sg);
     if (r === null) throw new DateError("invalid date");
     return addFracTo(new Date(SEAT, 0n, r, sg), fr2).toDate();
+  }
+
+  /**
+   * Ruby `Date.weeknum(year = -4712, week = 0, day = 1, firstday = 0)`
+   * (ruby/date, `date_core.c` `date_s_weeknum`, `date_core.c:3657-3706`,
+   * `:9689`), the `:wnum0` / `:wnum1` constructor: a week `0`..`53` of the
+   * year and a day `0`..`6` from `firstday`, which is `0` for the
+   * Sunday-based weeks and `1` for the Monday-based ones. It is a `:nodoc:`
+   * singleton method defined only under `#ifndef NDEBUG`, which is why the
+   * gem's own test guards it with `Date.respond_to?(:weeknum, true)`.
+   */
+  static weeknum(
+    year = -4712,
+    week = 0,
+    day = 1,
+    firstday = 0,
+    start = DEFAULT_SG,
+  ): Temporal.PlainDate {
+    const sg = val2sg(start);
+    const rjd = cValidWeeknumP(year, week, day, firstday, sg);
+    if (rjd === null) throw new DateError("invalid date");
+    return new Date(SEAT, 0n, rjd, sg).toDate();
+  }
+
+  /**
+   * Ruby `Date.nth_kday(year = -4712, month = 1, n = 1, k = 1)` (ruby/date,
+   * `date_core.c` `date_s_nth_kday`, `date_core.c:3707-3756`, `:9690`), the
+   * `n`th weekday `k` of a month — `Date.nth_kday(1992, 2, 5, 6)` is the 5th
+   * Saturday of February 1992. `:nodoc:` and `#ifndef NDEBUG`, as
+   * {@link Date.weeknum} is.
+   */
+  static nthKday(year = -4712, month = 1, n = 1, k = 1, start = DEFAULT_SG): Temporal.PlainDate {
+    const sg = val2sg(start);
+    const rjd = cValidNthKdayP(year, month, n, k, sg);
+    if (rjd === null) throw new DateError("invalid date");
+    return new Date(SEAT, 0n, rjd, sg).toDate();
+  }
+
+  /**
+   * Ruby `Date.today(start = Date::ITALY)` (ruby/date, `date_core.c`
+   * `date_s_today`, `date_core.c:3789-3825`), the present day in the LOCAL
+   * zone — the C's `localtime_r`, which is `Temporal.Now.plainDateISO()` here.
+   *
+   * The C builds under `GREGORIAN` and then `set_sg(dat, sg)`, the same shape
+   * `Time#to_date` has: `set_sg` (`date_core.c:5787-5800`) resolves the
+   * `HAVE_CIVIL` triple to a day through `get_s_jd` under the `GREGORIAN` the
+   * build used and discards it before storing `sg`, so the day is fixed
+   * proleptically and only its READING follows `start`.
+   */
+  static today(start = DEFAULT_SG): Temporal.PlainDate {
+    const sg = val2sg(start);
+    const tm = Temporal.Now.plainDateISO();
+
+    const y = tm.year;
+    const m = tm.month;
+    const d = tm.day;
+
+    const [nth, ry] = decodeYear(y, -1);
+
+    return new Date(SEAT, nth, cCivilToJd(ry, m, d, GREGORIAN), sg).toDate();
   }
 
   /**
@@ -6492,12 +6649,12 @@ export class Date {
    * the gem already names both directions and neither name is invented: the
    * statics answer Temporal through `to_date` / `to_datetime`, and the
    * exported {@link dNewByFrags} / {@link dtNewByFrags} answer the other
-   * direction — they are the *sole* gem-shaped seat, both ending at
-   * `d_simple_new_internal` (`date_core.c:3036`) exactly as `date_s_jd`
-   * (`:3377-3387`) does. `Date`'s constructor takes only
-   * `(year?, month?, day?, start?)` and the `SEAT` form; handing it a
-   * `Temporal.PlainDate` raises `TypeError: invalid year (not numeric)` from
-   * `check_numeric` (`date_core.c:67-72`).
+   * direction, as does this method's own inverse — the
+   * `Temporal.PlainDate` overload of `Date`'s constructor, and the
+   * `Temporal.PlainDateTime` / `Temporal.ZonedDateTime` one on `DateTime`.
+   * All of them end at `d_simple_new_internal` (`date_core.c:3036`) exactly as
+   * `date_s_jd` (`:3377-3387`) does; the overload adds an entry point to that
+   * seat, not a seat.
    */
   toDate(): Temporal.PlainDate {
     return plainDateFromJd(this.mLocalJd(), this.#sg);
@@ -6616,10 +6773,14 @@ export class Date {
  * compares the two static sides whatever shape the member takes.
  *
  * So `DateTime` extends `Date` under an alias whose STATIC side omits the
- * members it re-declares — `parse` and `strptime`, and the four builders
+ * members it re-declares — `parse` and `strptime`, and the six builders
  * `Init_date_core` gives `DateTime` singleton methods of its own
- * (`date_core.c:9971-9975`) — which is the only shape that removes the comparison
- * without weakening either declaration. This is a type-level alias only — the
+ * (`date_core.c:9971-9982`) — which is the only shape that removes the
+ * comparison without weakening either declaration. `today` is in that list for
+ * the other reason: `Init_date_core` runs
+ * `rb_undef_method(CLASS_OF(cDateTime), "today")` (`date_core.c:9985`), so
+ * `DateTime.today` does not exist in Ruby either, and the omission is how that
+ * undef is spelled here. This is a type-level alias only — the
  * value is `Date` itself, so the runtime prototype chain, `instanceof`, and
  * every inherited static are unchanged, and the instance side is `Date` intact.
  * Both `Date.parse`/`Date.strptime` and `DateTime.parse`/`DateTime.strptime`
@@ -6632,7 +6793,18 @@ const DateWithoutParseStatics: (new (
   start?: number,
 ) => Date) &
   (new (seat: typeof SEAT, nth: bigint, rjd: number, sg: number) => Date) &
-  Omit<typeof Date, "parse" | "strptime" | "jd" | "ordinal" | "civil" | "commercial"> = Date;
+  Omit<
+    typeof Date,
+    | "parse"
+    | "strptime"
+    | "jd"
+    | "ordinal"
+    | "civil"
+    | "commercial"
+    | "weeknum"
+    | "nthKday"
+    | "today"
+  > = Date;
 
 /**
  * @noRailsEquivalent PERMANENT — the `ruby/date` gem's `::DateTime`, a `::Date`
@@ -6792,6 +6964,19 @@ export class DateTime extends DateWithoutParseStatics {
     start?: number,
   );
   /**
+   * The inverse of {@link DateTime#toDatetime}, the counterpart of
+   * {@link Date}'s `Temporal.PlainDate` overload: the civil triple and the
+   * time of day go through `decode_year`, `c_civil_to_jd` and `time_to_df`
+   * under the same `sg`, which is `get_c_jd` / `get_c_df`
+   * (`date_core.c:1264-1301`, `:1208-1225`), and the day and day-fraction are
+   * converted to the UTC the `ComplexDateData` stores exactly as
+   * `dt_new_by_frags` does (`date_core.c:8311-8313`) before landing on
+   * {@link SEAT}. A `Temporal.ZonedDateTime` carries its offset across as `of`
+   * in seconds east of UTC; a `PlainDateTime` has none, which is an `of` of
+   * `0` — the value `::DateTime` has when `m_of` is zero.
+   */
+  constructor(date: Temporal.PlainDateTime | Temporal.ZonedDateTime, start?: number);
+  /**
    * @internal `date_core.c` `d_complex_new_internal` (`date_core.c:3055-3071`),
    * the seam `dt_new_by_frags` (`date_core.c:8239-8322`) ends at, under
    * `HAVE_JD | HAVE_DF`: the day and day-fraction it has already converted to
@@ -6810,7 +6995,7 @@ export class DateTime extends DateWithoutParseStatics {
     sg: number,
   );
   constructor(
-    year?: number | bigint | typeof SEAT,
+    year?: number | bigint | typeof SEAT | Temporal.PlainDateTime | Temporal.ZonedDateTime,
     month?: number | bigint,
     day?: number | Rational,
     hour?: number | Rational,
@@ -6819,6 +7004,23 @@ export class DateTime extends DateWithoutParseStatics {
     offset?: number | Rational | string,
     start?: number,
   ) {
+    if (year instanceof Temporal.PlainDateTime || year instanceof Temporal.ZonedDateTime) {
+      const sg = val2sg((month as number) ?? DEFAULT_SG);
+      const of = year instanceof Temporal.ZonedDateTime ? year.offsetNanoseconds / 1000000000 : 0;
+      const [nth, ry] = decodeYear(year.year, -1);
+      const rjd = cCivilToJd(ry, year.month, year.day, virtualSg(nth, sg));
+      const df = timeToDf(year.hour, year.minute, year.second);
+      const sf = new Rational(
+        year.millisecond * 1000000 + year.microsecond * 1000 + year.nanosecond,
+        1,
+      );
+      super(SEAT, nth, rjd, sg);
+      this.#jd = jdLocalToUtc(rjd, df, of);
+      this.#df = dfLocalToUtc(df, of);
+      this.#sf = sf;
+      this.#of = of;
+      return;
+    }
     if (typeof year === "symbol") {
       const nth = month as bigint;
       const rjd = day as number;
@@ -7192,6 +7394,179 @@ export class DateTime extends DateWithoutParseStatics {
       fr2,
     );
     return new DateTime(SEAT, nth, rjd2, df, sf, rof, sg).toDatetime();
+  }
+
+  /**
+   * Ruby `DateTime.weeknum(year = -4712, week = 0, day = 1, firstday = 0,
+   * hour = 0, minute = 0, second = 0, offset = 0, start = Date::ITALY)`
+   * (ruby/date, `date_core.c` `datetime_s_weeknum`, `date_core.c:7986-8055`,
+   * `:9980`), {@link Date.weeknum} with a time of day. `day` carries the
+   * fraction (`num2int_with_frac(d, 4)`, `date_core.c:8019-8020`); `week`,
+   * `firstday` and `year` do not.
+   */
+  static weeknum(
+    year = -4712,
+    week = 0,
+    day: number | Rational = 1,
+    firstday = 0,
+    hour?: number | Rational,
+    minute?: number | Rational,
+    second?: number | Rational,
+    offset?: number | Rational | string,
+    start?: number,
+  ): Temporal.PlainDateTime | Temporal.ZonedDateTime {
+    const sg = start === undefined ? DEFAULT_SG : val2sg(start);
+    const rof = offset === undefined ? 0 : val2off(offset);
+    const [s, sFr] = num2intWithFrac(second ?? 0, 1, false);
+    const [min, minFr] = num2intWithFrac(
+      minute ?? 0,
+      MINUTE_IN_SECONDS,
+      second !== undefined || offset !== undefined || start !== undefined,
+    );
+    const [h, hFr] = num2intWithFrac(
+      hour ?? 0,
+      HOUR_IN_SECONDS,
+      minute !== undefined || second !== undefined || offset !== undefined || start !== undefined,
+    );
+    const [d, dFr] = num2intWithFrac(
+      day,
+      DAY_IN_SECONDS,
+      hour !== undefined ||
+        minute !== undefined ||
+        second !== undefined ||
+        offset !== undefined ||
+        start !== undefined,
+    );
+    let fr2: number | Rational = 0;
+    if (sFr !== 0) fr2 = sFr;
+    if (minFr !== 0) fr2 = minFr;
+    if (hFr !== 0) fr2 = hFr;
+    if (dFr !== 0) fr2 = dFr;
+
+    const rjd = cValidWeeknumP(year, week, d, firstday, sg);
+    if (rjd === null) throw new DateError("invalid date");
+    const rt = cValidTimeP(h, min, s);
+    if (rt === null) throw new DateError("invalid date");
+    let [rh] = rt;
+    const [, rmin, rs] = rt;
+    if (rh === 24) {
+      rh = 0;
+      fr2 = fr2 instanceof Rational ? fr2.add(DAY_IN_SECONDS) : fr2 + DAY_IN_SECONDS;
+    }
+    const localDf = timeToDf(rh, rmin, rs);
+    const [nth, rrjd] = decodeJd(rjd);
+    const [rjd2, df, sf] = addFrac(
+      jdLocalToUtc(rrjd, localDf, rof),
+      dfLocalToUtc(localDf, rof),
+      fr2,
+    );
+    return new DateTime(SEAT, nth, rjd2, df, sf, rof, sg).toDatetime();
+  }
+
+  /**
+   * Ruby `DateTime.nth_kday(year = -4712, month = 1, n = 1, k = 1, hour = 0,
+   * minute = 0, second = 0, offset = 0, start = Date::ITALY)` (ruby/date,
+   * `date_core.c` `datetime_s_nth_kday`, `date_core.c:8056-8125`, `:9982`),
+   * {@link Date.nthKday} with a time of day. `k` carries the fraction
+   * (`num2int_with_frac(k, 4)`, `date_core.c:8089-8090`).
+   */
+  static nthKday(
+    year = -4712,
+    month = 1,
+    n = 1,
+    k: number | Rational = 1,
+    hour?: number | Rational,
+    minute?: number | Rational,
+    second?: number | Rational,
+    offset?: number | Rational | string,
+    start?: number,
+  ): Temporal.PlainDateTime | Temporal.ZonedDateTime {
+    const sg = start === undefined ? DEFAULT_SG : val2sg(start);
+    const rof = offset === undefined ? 0 : val2off(offset);
+    const [s, sFr] = num2intWithFrac(second ?? 0, 1, false);
+    const [min, minFr] = num2intWithFrac(
+      minute ?? 0,
+      MINUTE_IN_SECONDS,
+      second !== undefined || offset !== undefined || start !== undefined,
+    );
+    const [h, hFr] = num2intWithFrac(
+      hour ?? 0,
+      HOUR_IN_SECONDS,
+      minute !== undefined || second !== undefined || offset !== undefined || start !== undefined,
+    );
+    const [rk, kFr] = num2intWithFrac(
+      k,
+      DAY_IN_SECONDS,
+      hour !== undefined ||
+        minute !== undefined ||
+        second !== undefined ||
+        offset !== undefined ||
+        start !== undefined,
+    );
+    let fr2: number | Rational = 0;
+    if (sFr !== 0) fr2 = sFr;
+    if (minFr !== 0) fr2 = minFr;
+    if (hFr !== 0) fr2 = hFr;
+    if (kFr !== 0) fr2 = kFr;
+
+    const rjd = cValidNthKdayP(year, month, n, rk, sg);
+    if (rjd === null) throw new DateError("invalid date");
+    const rt = cValidTimeP(h, min, s);
+    if (rt === null) throw new DateError("invalid date");
+    let [rh] = rt;
+    const [, rmin, rs] = rt;
+    if (rh === 24) {
+      rh = 0;
+      fr2 = fr2 instanceof Rational ? fr2.add(DAY_IN_SECONDS) : fr2 + DAY_IN_SECONDS;
+    }
+    const localDf = timeToDf(rh, rmin, rs);
+    const [nth, rrjd] = decodeJd(rjd);
+    const [rjd2, df, sf] = addFrac(
+      jdLocalToUtc(rrjd, localDf, rof),
+      dfLocalToUtc(localDf, rof),
+      fr2,
+    );
+    return new DateTime(SEAT, nth, rjd2, df, sf, rof, sg).toDatetime();
+  }
+
+  /**
+   * Ruby `DateTime.now(start = Date::ITALY)` (ruby/date, `date_core.c`
+   * `datetime_s_now`, `date_core.c:8134-8236`, `:9987`), the present time in
+   * the LOCAL zone with its offset carried across — the C's `localtime_r` plus
+   * `tm.tm_gmtoff`, which is `Temporal.Now.zonedDateTimeISO()` here. A leap
+   * second — `s == 60` — is stored as `59`, and `sf` is nanoseconds.
+   *
+   * The C builds under `GREGORIAN` and then `set_sg(dat, sg)`, the same shape
+   * {@link Date.today} and `Time#to_datetime` have.
+   */
+  static now(start = DEFAULT_SG): Temporal.PlainDateTime | Temporal.ZonedDateTime {
+    const sg = val2sg(start);
+    const tm = Temporal.Now.zonedDateTimeISO();
+
+    const y = tm.year;
+    const m = tm.month;
+    const d = tm.day;
+    const h = tm.hour;
+    const min = tm.minute;
+    let s = tm.second;
+    if (s === 60) s = 59;
+
+    const of = tm.offsetNanoseconds / 1000000000;
+    const sf = new Rational(tm.millisecond * 1000000 + tm.microsecond * 1000 + tm.nanosecond, 1);
+
+    const [nth, ry] = decodeYear(y, -1);
+
+    const rjd = cCivilToJd(ry, m, d, GREGORIAN);
+    const df = timeToDf(h, min, s);
+    return new DateTime(
+      SEAT,
+      nth,
+      jdLocalToUtc(rjd, df, of),
+      dfLocalToUtc(df, of),
+      sf,
+      of,
+      sg,
+    ).toDatetime();
   }
 
   /**

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -5479,19 +5479,6 @@ export class Date {
    * counts back from December and a negative `mday` from the month's end, so
    * `Date.civil(2001, -1, -1)` is 2001-12-31.
    */
-  /**
-   * Ruby `Date.today(start = Date::ITALY)` (ruby/date, `date_core.c`
-   * `date_s_today`, `date_core.c:3789-3826`): the current date in the LOCAL
-   * zone, built from `localtime_r`'s `tm_year`/`tm_mon`/`tm_mday` and stored
-   * `HAVE_CIVIL` under `GREGORIAN` before `set_sg` writes the requested reform
-   * in. `Temporal.Now.plainDateISO()` is the same reading — the local wall date
-   * — where `Temporal.Now.instant()` would be the UTC one.
-   */
-  static today(start = DEFAULT_SG): Temporal.PlainDate {
-    const now = Temporal.Now.plainDateISO();
-    return new Date(now.year, now.month, now.day, val2sg(start)).toDate();
-  }
-
   static civil(
     year = -4712,
     month = 1,
@@ -5534,9 +5521,10 @@ export class Date {
    * gem's own test guards it with `Date.respond_to?(:weeknum, true)`.
    *
    * `day` carries the fraction (`num2int_with_frac(d, positive_inf)`,
-   * `date_core.c:3691`) and `add_frac` (`:3286-3318`) adds it back as a day
-   * fraction, which is a complex `Date` the `Temporal.PlainDate` seat reads
-   * the day of — a fraction of a day never moves midnight off its own date.
+   * `date_core.c:3691`) and {@link addFracTo} adds it back (`add_frac`,
+   * `:3314-3318`) as the day fraction `d_trunc` left, which is a complex
+   * `Date` the `Temporal.PlainDate` seat reads the day of — a fraction of a
+   * day never moves midnight off its own date.
    */
   static weeknum(
     year = -4712,
@@ -5546,15 +5534,11 @@ export class Date {
     start = DEFAULT_SG,
   ): Temporal.PlainDate {
     const sg = val2sg(start);
-    const [d, fr2] = num2intWithFrac(day, DAY_IN_SECONDS, false);
+    const [d, fr2] = num2intWithFrac(day, 1, false);
     const rjd = cValidWeeknumP(year, week, d, firstday, sg);
     if (rjd === null) throw new DateError("invalid date");
     const [nth, rrjd] = decodeJd(rjd);
-    const ret = new Date(SEAT, nth, rrjd, sg);
-    if (fr2 instanceof Rational ? !fr2.isZero() : fr2 !== 0) {
-      return ret.plus(fr2 instanceof Rational ? fr2.quo(DAY_IN_SECONDS) : isecToDay(fr2)).toDate();
-    }
-    return ret.toDate();
+    return addFracTo(new Date(SEAT, nth, rrjd, sg), fr2).toDate();
   }
 
   /**
@@ -5573,15 +5557,11 @@ export class Date {
     start = DEFAULT_SG,
   ): Temporal.PlainDate {
     const sg = val2sg(start);
-    const [rk, fr2] = num2intWithFrac(k, DAY_IN_SECONDS, false);
+    const [rk, fr2] = num2intWithFrac(k, 1, false);
     const rjd = cValidNthKdayP(year, month, n, rk, sg);
     if (rjd === null) throw new DateError("invalid date");
     const [nth, rrjd] = decodeJd(rjd);
-    const ret = new Date(SEAT, nth, rrjd, sg);
-    if (fr2 instanceof Rational ? !fr2.isZero() : fr2 !== 0) {
-      return ret.plus(fr2 instanceof Rational ? fr2.quo(DAY_IN_SECONDS) : isecToDay(fr2)).toDate();
-    }
-    return ret.toDate();
+    return addFracTo(new Date(SEAT, nth, rrjd, sg), fr2).toDate();
   }
 
   /**

--- a/packages/date/src/test-date-new.test.ts
+++ b/packages/date/src/test-date-new.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect } from "vitest";
 import { Temporal } from "@js-temporal/polyfill";
-import { Date, DateTime, Rational, dNewByFrags, dtNewByFrags } from "./date.js";
+import { Date, DateTime, Rational } from "./date.js";
+import { Time } from "./time.js";
 
 /**
- * `vendor/date/test/date/test_date_new.rb:1-214`, the `Date.jd` / `Date.ordinal`
- * / `Date.civil` constructors and the shared invalid-type guards.
+ * `vendor/date/test/date/test_date_new.rb`, the `Date.jd` / `Date.ordinal` /
+ * `Date.civil` / `Date.commercial` constructors, the `weeknum` / `nth_kday`
+ * private ones, the clock readers `Date.today` / `DateTime.now`, and the
+ * shared invalid-type guards.
  *
  * The builders answer `Temporal` where Ruby answers a `Date` / `DateTime`
  * (RFC 0088, `vendor/sources.ts:212-221`), so `[d.year, d.mon, d.mday]` is read
@@ -18,6 +21,9 @@ describe("TestDateNew", () => {
     d.month,
     d.day,
   ];
+
+  /** Ruby subtracts two `Time`s to a number of seconds; this is that number. */
+  const epochSeconds = (t: Time): number => t.toTime().epochMilliseconds / 1000;
 
   it("jd", () => {
     const d = Date.jd();
@@ -207,17 +213,17 @@ describe("TestDateNew", () => {
 
   it("civil reform", () => {
     // Ruby's receivers are `Date.jd(...)` / `DateTime.jd(...)`, which answer the
-    // `Temporal` seat here (RFC 0088) and so carry no arithmetic. The gem-shaped
-    // object is reached through the exported `dNewByFrags` / `dtNewByFrags`, the
-    // route `toDate()`'s own JSDoc names: `d_new_by_frags` (date_core.c:4283)
-    // and `date_s_jd` (:3377-3387) both end at `d_simple_new_internal` (:3036),
-    // so a `jd` frag under the same `start` is the same date `Date.jd` names —
-    // asserted against `Date.jd` below rather than assumed.
+    // `Temporal` seat here (RFC 0088) and so carry no arithmetic. Ruby's own
+    // call is kept and the seat is fed back through the `Temporal` constructor
+    // overload, `d_simple_new_internal`'s (date_core.c:3036) other entry point,
+    // which is the documented inverse of `to_date` / `to_datetime`.
     //
     // `d -= 1` is `minus(1)` (`d_lite_minus`, date_core.c:6343-6360).
-    let d = dNewByFrags({ jd: Date.ENGLAND }, Date.ENGLAND);
-    let dt = dtNewByFrags({ jd: Date.ENGLAND, hour: 0, min: 0, sec: 0, offset: 0 }, Date.ENGLAND);
-    expect(d.toDate().equals(Date.jd(Date.ENGLAND, Date.ENGLAND))).toBe(true);
+    let d = new Date(Date.jd(Date.ENGLAND, Date.ENGLAND), Date.ENGLAND);
+    let dt = new DateTime(
+      DateTime.jd(Date.ENGLAND, 0, 0, 0, 0, Date.ENGLAND) as Temporal.PlainDateTime,
+      Date.ENGLAND,
+    );
     expect([d.year, d.mon, d.day]).toEqual([1752, 9, 14]);
     expect([dt.year, dt.mon, dt.day]).toEqual([1752, 9, 14]);
     d = d.minus(1) as Date;
@@ -225,8 +231,11 @@ describe("TestDateNew", () => {
     expect([d.year, d.mon, d.day]).toEqual([1752, 9, 2]);
     expect([dt.year, dt.mon, dt.day]).toEqual([1752, 9, 2]);
 
-    d = dNewByFrags({ jd: Date.ITALY }, Date.ITALY);
-    dt = dtNewByFrags({ jd: Date.ITALY, hour: 0, min: 0, sec: 0, offset: 0 }, Date.ITALY);
+    d = new Date(Date.jd(Date.ITALY, Date.ITALY), Date.ITALY);
+    dt = new DateTime(
+      DateTime.jd(Date.ITALY, 0, 0, 0, 0, Date.ITALY) as Temporal.PlainDateTime,
+      Date.ITALY,
+    );
     expect([d.year, d.mon, d.day]).toEqual([1582, 10, 15]);
     expect([dt.year, dt.mon, dt.day]).toEqual([1582, 10, 15]);
     d = d.minus(1) as Date;
@@ -239,5 +248,123 @@ describe("TestDateNew", () => {
     expect(() => Date.civil(2001, 2, 29)).toThrow(Date.Error);
     expect(() => DateTime.civil(2001, 2, 28, 23, 59, 60, 0)).toThrow(Date.Error);
     expect(() => DateTime.civil(2001, 2, 28, 24, 59, 59, 0)).toThrow(Date.Error);
+  });
+
+  it("commercial", () => {
+    const d = Date.commercial();
+    const dt = DateTime.commercial() as Temporal.PlainDateTime;
+    expect(ymd(d)).toEqual([-4712, 1, 1]);
+    expect(ymd(dt)).toEqual([-4712, 1, 1]);
+    expect([dt.hour, dt.minute, dt.second]).toEqual([0, 0, 0]);
+
+    const d2 = Date.commercial();
+    const dt2 = DateTime.commercial() as Temporal.PlainDateTime;
+    expect(d.equals(d2)).toBe(true);
+    expect(dt.equals(dt2)).toBe(true);
+
+    let d3 = Date.commercial(1582, 40, 5);
+    expect(ymd(d3)).toEqual([1582, 10, 15]);
+
+    d3 = Date.commercial(1582, 40, 5.0);
+    expect(ymd(d3)).toEqual([1582, 10, 15]);
+
+    const d4 = DateTime.commercial(1582, 40, 5, 0, 0, 0, 0) as Temporal.PlainDateTime;
+    expect([...ymd(d4), d4.hour, d4.minute, d4.second]).toEqual([1582, 10, 15, 0, 0, 0]);
+    expect(d4).toBeInstanceOf(Temporal.PlainDateTime);
+    const d5 = DateTime.commercial(1582, 40, 5, 0, 0, 0, "+0900") as Temporal.ZonedDateTime;
+    expect([...ymd(d5), d5.hour, d5.minute, d5.second, d5.offset]).toEqual([
+      1582,
+      10,
+      15,
+      0,
+      0,
+      0,
+      "+09:00",
+    ]);
+  });
+
+  it("commercial neg", () => {
+    const d = Date.commercial(1998, -1, -1);
+    expect(ymd(d)).toEqual([1999, 1, 3]);
+
+    const dt = DateTime.commercial(1998, -1, -1, -1, -1, -1, 0) as Temporal.PlainDateTime;
+    expect([...ymd(dt), dt.hour, dt.minute, dt.second]).toEqual([1999, 1, 3, 23, 59, 59]);
+  });
+
+  it("commercial ex", () => {
+    expect(() => Date.commercial(1997, 53, 1)).toThrow(Date.Error);
+    expect(() => DateTime.commercial(1997, 52, 1, 23, 59, 60, 0)).toThrow(Date.Error);
+  });
+
+  it("weeknum", () => {
+    const d = Date.weeknum();
+    const dt = DateTime.weeknum() as Temporal.PlainDateTime;
+    expect(ymd(d)).toEqual([-4712, 1, 1]);
+    expect(ymd(dt)).toEqual([-4712, 1, 1]);
+    expect([dt.hour, dt.minute, dt.second]).toEqual([0, 0, 0]);
+
+    // Ruby reads `d.jd` off the gem object; the seat answers `Temporal`, so the
+    // day is named by the `Date.jd` that builds it (`date_s_jd`, :3377-3387).
+    const d2 = Date.weeknum(2002, 11, 4, 0);
+    expect(d2.equals(Date.jd(2452355))).toBe(true);
+
+    const d3 = DateTime.weeknum(2002, 11, 4, 0, 11, 22, 33) as Temporal.PlainDateTime;
+    expect(d3.toPlainDate().equals(Date.jd(2452355))).toBe(true);
+    expect([d3.hour, d3.minute, d3.second]).toEqual([11, 22, 33]);
+
+    expect(() => Date.weeknum(1999, 53, 0, 0)).toThrow(Date.Error);
+    expect(() => Date.weeknum(1999, -53, -1, 0)).toThrow(Date.Error);
+  });
+
+  it("nth kday", () => {
+    const d = Date.nthKday();
+    const dt = DateTime.nthKday() as Temporal.PlainDateTime;
+    expect(ymd(d)).toEqual([-4712, 1, 1]);
+    expect(ymd(dt)).toEqual([-4712, 1, 1]);
+    expect([dt.hour, dt.minute, dt.second]).toEqual([0, 0, 0]);
+
+    const d2 = Date.nthKday(1992, 2, 5, 6);
+    expect(d2.equals(Date.jd(2448682))).toBe(true);
+
+    const d3 = DateTime.nthKday(1992, 2, 5, 6, 11, 22, 33) as Temporal.PlainDateTime;
+    expect(d3.toPlainDate().equals(Date.jd(2448682))).toBe(true);
+    expect([d3.hour, d3.minute, d3.second]).toEqual([11, 22, 33]);
+
+    expect(() => Date.nthKday(2006, 5, 5, 0)).toThrow(Date.Error);
+    expect(() => Date.nthKday(2006, 5, -5, 0)).toThrow(Date.Error);
+  });
+
+  it("today", () => {
+    const z = Time.now();
+    const d = Date.today();
+    const t = Time.now();
+    const t2 = Time.utc(t.year, t.mon, t.day);
+    const t3 = Time.utc(d.year, d.month, d.day);
+    // `assert_in_delta(t2, t3, t - z + 2)` over two `Time`s, which Ruby
+    // subtracts to seconds; `epochSeconds` is that subtraction here.
+    expect(Math.abs(epochSeconds(t2) - epochSeconds(t3))).toBeLessThanOrEqual(
+      epochSeconds(t) - epochSeconds(z) + 2,
+    );
+
+    // `rb_undef_method(CLASS_OF(cDateTime), "today")` (date_core.c:9985), which
+    // is the `Omit` in `DateWithoutParseStatics` — a type error, not a missing
+    // runtime property, since the value side is `Date` itself.
+    // @ts-expect-error DateTime does not respond to `today`.
+    void DateTime.today;
+  });
+
+  it("now", () => {
+    // `Date.respond_to?(:now)` is false — `now` is a `DateTime` singleton
+    // method alone (date_core.c:9987).
+    // @ts-expect-error Date does not respond to `now`.
+    void Date.now;
+
+    const z = Time.now();
+    const d = DateTime.now() as Temporal.ZonedDateTime;
+    const t = Time.now();
+    const t2 = Time.mktime(d.year, d.month, d.day, d.hour, d.minute, d.second);
+    expect(Math.abs(epochSeconds(t) - epochSeconds(t2))).toBeLessThanOrEqual(
+      epochSeconds(t) - epochSeconds(z) + 2,
+    );
   });
 });

--- a/packages/date/src/test-date-new.test.ts
+++ b/packages/date/src/test-date-new.test.ts
@@ -303,8 +303,6 @@ describe("TestDateNew", () => {
     expect(ymd(dt)).toEqual([-4712, 1, 1]);
     expect([dt.hour, dt.minute, dt.second]).toEqual([0, 0, 0]);
 
-    // Ruby reads `d.jd` off the gem object; the seat answers `Temporal`, so the
-    // day is named by the `Date.jd` that builds it (`date_s_jd`, :3377-3387).
     const d2 = Date.weeknum(2002, 11, 4, 0);
     expect(d2.equals(Date.jd(2452355))).toBe(true);
 
@@ -340,23 +338,16 @@ describe("TestDateNew", () => {
     const t = Time.now();
     const t2 = Time.utc(t.year, t.mon, t.day);
     const t3 = Time.utc(d.year, d.month, d.day);
-    // `assert_in_delta(t2, t3, t - z + 2)` over two `Time`s, which Ruby
-    // subtracts to seconds; `epochSeconds` is that subtraction here.
     expect(Math.abs(epochSeconds(t2) - epochSeconds(t3))).toBeLessThanOrEqual(
       epochSeconds(t) - epochSeconds(z) + 2,
     );
 
-    // `rb_undef_method(CLASS_OF(cDateTime), "today")` (date_core.c:9985), which
-    // is the `Omit` in `DateWithoutParseStatics` — a type error, not a missing
-    // runtime property, since the value side is `Date` itself.
-    // @ts-expect-error DateTime does not respond to `today`.
+    // @ts-expect-error `rb_undef_method(CLASS_OF(cDateTime), "today")` (date_core.c:9985)
     void DateTime.today;
   });
 
   it("now", () => {
-    // `Date.respond_to?(:now)` is false — `now` is a `DateTime` singleton
-    // method alone (date_core.c:9987).
-    // @ts-expect-error Date does not respond to `now`.
+    // @ts-expect-error `now` is a `DateTime` singleton method alone (date_core.c:9987)
     void Date.now;
 
     const z = Time.now();

--- a/packages/date/src/time.ts
+++ b/packages/date/src/time.ts
@@ -376,9 +376,29 @@ export class Time {
    * `GREGORIAN` — a `::Time` is proleptic Gregorian, so 1582-10-13 is a real
    * day for it — and then `set_sg(dat, DEFAULT_SG)` puts the reform back, which
    * is why `Time.utc(1582, 10, 13).to_date` reads `1582-10-03`.
+   *
+   * The C reaches `d_simple_new_internal` directly, so this goes through the
+   * same {@link SEAT} that {@link Time#toDatetime} does, and for the same
+   * reason: `set_sg(dat, DEFAULT_SG)` (`date_core.c:5787-5800`) is not a field
+   * assignment — on the simple arm it runs `get_s_jd(x)` and `clear_civil(x)`
+   * *before* storing the new `sg`, so the `HAVE_CIVIL` triple the build wrote
+   * is resolved to a day under the `GREGORIAN` the build used and discarded.
+   * That eager resolve is `c_civil_to_jd(ry, m, d, GREGORIAN)` (`get_s_jd`,
+   * `date_core.c:1168-1187`), which is the call below. Handing the public
+   * constructor the triple instead re-derives `nth` through
+   * `valid_gregorian_p` / `valid_civil_p` — re-validating a date the C has
+   * already established is buildable, which is exactly what the seat exists to
+   * skip — and would resolve it under `Date.ITALY`, answering a different day
+   * for every date before the reform.
    */
   toDate(): Temporal.PlainDate {
-    return new Date(this.year, this.mon, this.day, Date.GREGORIAN).newStart().toDate();
+    const y = this.year;
+    const m = this.mon;
+    const d = this.day;
+
+    const [nth, ry] = decodeYear(y, -1);
+
+    return new Date(SEAT, nth, cCivilToJd(ry, m, d, Date.GREGORIAN), Date.ITALY).toDate();
   }
 
   /**


### PR DESCRIPTION
Bundle of four RFC 0088 stories.

**`Time#to_date` through `d_simple_new_internal`'s seat.** `time_to_date` (`date_core.c:8872-8892`) decodes the year and writes the resolved day straight into a fresh `SimpleDateData`; the port re-derived `nth` through the public `Date` constructor and rebuilt a second object with `new_start()`. Converged onto the same seat `Time#toDatetime` uses (#6320), for the reason recorded there: `set_sg` (`:5787-5800`) runs `get_s_jd`/`clear_civil` before storing `sg`, so the `HAVE_CIVIL` triple resolves under the `GREGORIAN` the build used. `Time.utc(1582, 10, 13).to_date` still reads `1582-10-03`.

**The `Temporal` constructor overload.** `new Date(plainDate, start?)` and `new DateTime(plainDateTime | zonedDateTime, start?)` — `to_date` / `to_datetime`'s documented inverse (`date_core.c:8992-9027`) — route to the existing `d_simple_new_internal` / `d_complex_new_internal` seat via the exact inverse of `plainDateFromJd`'s `c_jd_to_civil`. No new seat, no new export. `Date#toDate`'s JSDoc no longer claims `dNewByFrags` is the sole gem-shaped seat, and `it("civil reform")` moves its receiver back to Ruby's own `Date.jd(...)` / `DateTime.jd(...)` calls.

**`Date.valid_date?` / `Date.leap?`.** The second names `Init_date_core` registers `date_s_valid_civil_p` and `date_s_gregorian_leap_p` under (`date_core.c:9659`, `:9676`) — same C function, so `isValidDate` / `isLeap` delegate. Covered in `date.trails.test.ts`, since no test in `test/date/` calls either spelling.

**`test_date_new.rb` commercial/weeknum/nth_kday/today/now (7 tests).** Needed `Date.weeknum` (`:3657-3706`), `Date.nthKday` (`:3707-3756`), `Date.today` (`:3789-3825`), `DateTime.weeknum` (`:7986-8055`), `DateTime.nthKday` (`:8056-8125`) and `DateTime.now` (`:8134-8236`), plus the internals `c_jd_to_nth_kday` (`:651-660`) and `c_valid_nth_kday_p` (`:840-866`). `rb_undef_method(CLASS_OF(cDateTime), "today")` (`:9985`) is spelled as an `Omit` on `DateWithoutParseStatics`, the settled idiom in that file.

`pnpm test:compare --package date` moves `test_date_new.rb` to 18 OK / 0 Skip / 0 Desc (all of it) and the package to 74/137 tests, 8/10 files. `api:extra --package date` is clean; the call-mismatch ratchet is OK with no new rows.

Closes-story: converge-time-to-date-onto-d-simple-new-internal
Closes-story: date-temporal-plaindate-constructor-overload
Closes-story: date-valid-date-and-leap-alias-names
Closes-story: port-test-date-new-commercial-and-clock