### PR TITLE
feat(date): public strptime tests, rt_complete_frags' time arm, ::Time Rational second and 60th second

### DIFF
--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -1810,26 +1810,45 @@ describe("Time", () => {
 
   it("hands to_datetime's seat the whole second, the sub-second and the offset apart", () => {
     // ruby 3.3.11:
-    //   Time.new(2008, 3, 1, 6, 0, 7.25, 3600).to_datetime.strftime("%H:%M:%S.%6N%:z")
-    //     #=> "06:00:07.250000+01:00"
-    //   Time.new(2008, 3, 1, 6, 0, 7.25, -1800).to_datetime.zone #=> "-00:30"
+    //   Time.new(2008, 3, 1, 6, 0, 7.456789, 3600).to_datetime.strftime("%H:%M:%S.%9N%:z")
+    //     #=> "06:00:07.456788999+01:00"
+    //   Time.new(2008, 3, 1, 6, 0, 7.456789, -1800).to_datetime.zone #=> "-00:30"
     // `time_to_datetime` (date_core.c:8901-8935) passes `s`, `sf` in
     // nanoseconds and `of` in SECONDS as three separate fields of
     // `d_complex_new_internal`; folding `s` into `sf` or spelling `of` as a
     // fraction of a day is a lossier hand-over of the same values. A HALF-hour
     // offset is the one that catches the fraction spelling: `Rational(1800,
     // 86400)` and the seconds it came from only agree when nothing rounds.
-    const dt = new RubyTime(2008, 3, 1, 6, 0, 7.25, 3600).toDatetime();
+    const dt = new RubyTime(2008, 3, 1, 6, 0, 7.456789, 3600).toDatetime();
     expect((dt as Temporal.ZonedDateTime).offset).toBe("+01:00");
     expect((dt as Temporal.ZonedDateTime).toPlainDateTime().toString()).toBe(
-      "2008-03-01T06:00:07.25",
+      "2008-03-01T06:00:07.456788999",
     );
 
-    const west = new RubyTime(2008, 3, 1, 6, 0, 7.25, -1800).toDatetime();
+    const west = new RubyTime(2008, 3, 1, 6, 0, 7.456789, -1800).toDatetime();
     expect((west as Temporal.ZonedDateTime).offset).toBe("-00:30");
     expect((west as Temporal.ZonedDateTime).toPlainDateTime().toString()).toBe(
-      "2008-03-01T06:00:07.25",
+      "2008-03-01T06:00:07.456788999",
     );
+  });
+
+  it("rolls a 60th second into the next minute, as ::Time does", () => {
+    // ruby 3.3.11:
+    //   Time.utc(2015, 6, 30, 23, 59, 60)             #=> 2015-07-01 00:00:00 UTC
+    //   Time.utc(2015, 6, 30, 23, 59, 60).sec         #=> 0
+    //   Time.utc(2015, 6, 30, 23, 59, 60).strftime("%S") #=> "00"
+    //   Time.utc(2015, 6, 30, 23, 59, 60).to_datetime.to_s
+    //     #=> "2015-07-01T00:00:00+00:00"
+    //   Time.utc(2015, 6, 30, 23, 59, 61)             #=> ArgumentError
+    // MRI admits the 60th second and, with no `right/` zoneinfo loaded, rolls
+    // it; `Temporal` rejects it in the slot, so the roll is spelled in the
+    // constructor. This is what leaves `time_to_datetime`'s `s == 60` fold
+    // (`date_core.c:8913-8915`) unreachable on both runtimes.
+    const t = RubyTime.utc(2015, 6, 30, 23, 59, 60);
+    expect(t.sec).toBe(0);
+    expect(t.strftime("%Y-%m-%d %H:%M:%S")).toBe("2015-07-01 00:00:00");
+    expect(t.toDatetime().toString()).toBe("2015-07-01T00:00:00");
+    expect(() => RubyTime.utc(2015, 6, 30, 23, 59, 61)).toThrow(ArgumentError);
   });
 
   it("keeps the day the offset carries across midnight", () => {

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -2975,7 +2975,13 @@ function rtRewriteFrags(hash: DateParts): DateParts {
   return hash;
 }
 
-function completeFrags(parts: DateParts): void {
+/**
+ * @internal `date_core.c` `rt_complete_frags` (`date_core.c:3877-4116`). `klass`
+ * is read only by the `time` block below — `f_le_p(klass, cDateTime)`
+ * (`:4098`), which is what makes a time-only frag set answer TODAY's date
+ * through `DateTime.strptime` and stay a `Date::Error` through `Date.strptime`.
+ */
+function completeFrags(klass: typeof Date | typeof DateTime, parts: DateParts): void {
   const tab: [string | null, DateFrag[]][] = [
     ["time", ["hour", "min", "sec"]],
     [null, ["jd"]],
@@ -3067,6 +3073,18 @@ function completeFrags(parts: DateParts): void {
       parts.wday ??= 1;
     }
   }
+
+  if (g && k === "time") {
+    if (klass === DateTime || klass.prototype instanceof DateTime) {
+      const d = Temporal.Now.plainDateISO();
+      parts.jd ??= cCivilToJd(d.year, d.month, d.day);
+    }
+  }
+
+  if (parts.hour === undefined) parts.hour = 0;
+  if (parts.min === undefined) parts.min = 0;
+  if (parts.sec === undefined) parts.sec = 0;
+  else if (parts.sec > 59) parts.sec = 59;
 }
 
 /**
@@ -4219,7 +4237,7 @@ export function dNewByFrags(hash: DateParts | null, sg = DEFAULT_SG): Date {
     jd = rtValidCivilP(hash.year, hash.mon, hash.mday, sg);
   } else {
     hash = rtRewriteFrags(hash);
-    completeFrags(hash);
+    completeFrags(Date, hash);
     try {
       jd = rtValidDateFragsP(hash, sg);
     } catch {
@@ -4297,7 +4315,7 @@ export function dtNewByFrags(hash: DateParts | null, sg = DEFAULT_SG): DateTime 
     else if (hash.sec === 60) hash.sec = 59;
   } else {
     hash = rtRewriteFrags(hash);
-    completeFrags(hash);
+    completeFrags(DateTime, hash);
     try {
       jd = rtValidDateFragsP(hash, sg);
     } catch {
@@ -4701,7 +4719,7 @@ function expectNumeric(x: unknown): void {
  * `rb_num2int` refuses it, so it raises {@link FloatDomainError} here — the
  * error `f_idiv` reaches first in the C.
  */
-function fToR(x: number): Rational {
+export function fToR(x: number): Rational {
   if (!Number.isFinite(x)) throw new FloatDomainError(String(x));
   let n = x;
   let d = 1n;

--- a/packages/date/src/test-date-strptime.test.ts
+++ b/packages/date/src/test-date-strptime.test.ts
@@ -4,12 +4,19 @@
  * prefixes, and the arms that fail) and the public `Date.strptime` /
  * `DateTime.strptime` above it (lines 306-end).
  *
- * The public half answers RFC 0088's `Temporal` seat rather than a
+ * The public half calls `Date.strptime` / `DateTime.strptime` themselves, as
+ * the Ruby does. Those answer RFC 0088's `Temporal` seat rather than a
  * `Date`/`DateTime`, so `assert_equal(d, Date.strptime(...))` is spelled as an
- * equality between two seats and the members the seat cannot carry —
- * `sec_fraction`, `offset`, the gem's own `to_s` — are read off the
- * gem-shaped object the exported builders answer, which is the same object
- * MRI compares.
+ * equality between two seats and each reader is the seat's name for the same
+ * value: `mon` is `month`, `mday` is `day`, `min` is `minute`, `sec` is
+ * `second`, `yday` is `dayOfYear`, and the commercial triple `cwyear` /
+ * `cweek` / `cwday` is `yearOfWeek` / `weekOfYear` / `dayOfWeek`. Two have no
+ * seat reader and are read one step out: `sec_fraction` as the `millisecond`
+ * the same moment carries, and `d.strftime('%U')` through the exported
+ * {@link strftime}, which takes a `Temporal` subject. The gem's own `to_s` —
+ * the INPUT `Date.strptime(d.to_s)` parses — is the one thing built from a
+ * gem-shaped receiver, since it is a spelling no `Temporal` `toString`
+ * produces.
  *
  * `_strptime` answers the frag Hash itself rather than a date, so RFC 0088's
  * `Temporal`-by-default mapping does not reach these tests — the values below
@@ -33,8 +40,9 @@
 
 /* eslint-disable vitest/no-conditional-expect */
 
+import { Temporal } from "@js-temporal/polyfill";
 import { describe, it, expect } from "vitest";
-import { Date, DateTime, Rational, dtNewByFrags } from "./date.js";
+import { Date, DateTime, Rational, strftime } from "./date.js";
 import type { DateParts } from "./date.js";
 
 const STRFTIME_2001_02_03: Record<string, [string, DateParts]> = {
@@ -106,6 +114,22 @@ Object.assign(STRFTIME_2001_02_03, STRFTIME_2001_02_03_GNUext);
  *  Hash does not carry. */
 function valuesAt(h: DateParts | null, ...keys: (keyof DateParts)[]): unknown[] {
   return keys.map((key) => (h?.[key] === undefined ? null : h[key]));
+}
+
+/** Ruby's `[d.year, d.mon, d.mday, d.hour, d.min, d.sec]` off the `Temporal` seat. */
+function ymdhms(d: Temporal.PlainDateTime | Temporal.ZonedDateTime): number[] {
+  return [d.year, d.month, d.day, d.hour, d.minute, d.second];
+}
+
+/** Ruby's `[d.cwyear, d.cweek, d.cwday, d.hour, d.min, d.sec]`; the seat spells
+ *  the ISO week date `yearOfWeek` / `weekOfYear` / `dayOfWeek`. */
+function cwymdhms(d: Temporal.PlainDateTime | Temporal.ZonedDateTime): (number | undefined)[] {
+  return [d.yearOfWeek, d.weekOfYear, d.dayOfWeek, d.hour, d.minute, d.second];
+}
+
+/** Ruby's `[d.year, d.strftime(fmt).to_i, d.wday, d.hour, d.min, d.sec]`. */
+function wnumWdayHms(d: Temporal.PlainDateTime | Temporal.ZonedDateTime, fmt: string): number[] {
+  return [d.year, Number(strftime(d, fmt)), d.dayOfWeek % 7, d.hour, d.minute, d.second];
 }
 
 describe("TestDateStrptime", () => {
@@ -695,136 +719,68 @@ describe("TestDateStrptime", () => {
   });
 
   it("strptime  minus", () => {
-    let d = dtNewByFrags(Date._strptime("-1", "%s"));
-    expect([d.year, d.mon, d.mday, d.hour, d.min, d.sec]).toEqual([1969, 12, 31, 23, 59, 59]);
-    d = dtNewByFrags(Date._strptime("-86400", "%s"));
-    expect([d.year, d.mon, d.mday, d.hour, d.min, d.sec]).toEqual([1969, 12, 31, 0, 0, 0]);
+    let d = DateTime.strptime("-1", "%s");
+    expect(ymdhms(d)).toEqual([1969, 12, 31, 23, 59, 59]);
+    d = DateTime.strptime("-86400", "%s");
+    expect(ymdhms(d)).toEqual([1969, 12, 31, 0, 0, 0]);
 
-    d = dtNewByFrags(Date._strptime("-999", "%Q"));
-    expect([d.year, d.mon, d.mday, d.hour, d.min, d.sec, d.secFraction]).toEqual([
-      1969,
-      12,
-      31,
-      23,
-      59,
-      59,
-      new Rational(1, 1000),
-    ]);
-    d = dtNewByFrags(Date._strptime("-1000", "%Q"));
-    expect([d.year, d.mon, d.mday, d.hour, d.min, d.sec, d.secFraction]).toEqual([
-      1969,
-      12,
-      31,
-      23,
-      59,
-      59,
-      new Rational(0, 1),
-    ]);
+    // `sec_fraction` has no seat, so `Rational(1, 10**3)` is read as the
+    // millisecond the same moment carries; `(0/1)` is a whole second.
+    d = DateTime.strptime("-999", "%Q");
+    expect([...ymdhms(d), d.millisecond]).toEqual([1969, 12, 31, 23, 59, 59, 1]);
+    d = DateTime.strptime("-1000", "%Q");
+    expect([...ymdhms(d), d.millisecond]).toEqual([1969, 12, 31, 23, 59, 59, 0]);
   });
 
   it("strptime  comp", () => {
-    // `DateTime.now` has no seat of its own in this port, so `n` is the same
-    // "today" `rt_complete_frags` fills an absent year/mon/mday from — the
-    // LOCAL date, as `Time.now` gives it.
-    const jsNow = new globalThis.Date();
-    const n = dtNewByFrags({
-      year: jsNow.getFullYear(),
-      mon: jsNow.getMonth() + 1,
-      mday: jsNow.getDate(),
-    });
+    const n = DateTime.strptime(Temporal.Now.plainDateISO().toString(), "%F");
 
-    let d = dtNewByFrags(Date._strptime("073", "%j"));
-    expect([d.year, d.yday, d.hour, d.min, d.sec]).toEqual([n.year, 73, 0, 0, 0]);
-    d = dtNewByFrags(Date._strptime("13", "%d"));
-    expect([d.year, d.mon, d.mday, d.hour, d.min, d.sec]).toEqual([n.year, n.mon, 13, 0, 0, 0]);
+    let d = DateTime.strptime("073", "%j");
+    expect([d.year, d.dayOfYear, d.hour, d.minute, d.second]).toEqual([n.year, 73, 0, 0, 0]);
+    d = DateTime.strptime("13", "%d");
+    expect(ymdhms(d)).toEqual([n.year, n.month, 13, 0, 0, 0]);
 
-    d = dtNewByFrags(Date._strptime("Mar", "%b"));
-    expect([d.year, d.mon, d.mday, d.hour, d.min, d.sec]).toEqual([n.year, 3, 1, 0, 0, 0]);
-    d = dtNewByFrags(Date._strptime("2004", "%Y"));
-    expect([d.year, d.mon, d.mday, d.hour, d.min, d.sec]).toEqual([2004, 1, 1, 0, 0, 0]);
+    d = DateTime.strptime("Mar", "%b");
+    expect(ymdhms(d)).toEqual([n.year, 3, 1, 0, 0, 0]);
+    d = DateTime.strptime("2004", "%Y");
+    expect(ymdhms(d)).toEqual([2004, 1, 1, 0, 0, 0]);
 
-    d = dtNewByFrags(Date._strptime("Mar 13", "%b %d"));
-    expect([d.year, d.mon, d.mday, d.hour, d.min, d.sec]).toEqual([n.year, 3, 13, 0, 0, 0]);
-    d = dtNewByFrags(Date._strptime("Mar 2004", "%b %Y"));
-    expect([d.year, d.mon, d.mday, d.hour, d.min, d.sec]).toEqual([2004, 3, 1, 0, 0, 0]);
-    d = dtNewByFrags(Date._strptime("23:55", "%H:%M"));
-    expect([d.year, d.mon, d.mday, d.hour, d.min, d.sec]).toEqual([
-      n.year,
-      n.mon,
-      n.mday,
-      23,
-      55,
-      0,
-    ]);
-    d = dtNewByFrags(Date._strptime("23:55:30", "%H:%M:%S"));
-    expect([d.year, d.mon, d.mday, d.hour, d.min, d.sec]).toEqual([
-      n.year,
-      n.mon,
-      n.mday,
-      23,
-      55,
-      30,
-    ]);
+    d = DateTime.strptime("Mar 13", "%b %d");
+    expect(ymdhms(d)).toEqual([n.year, 3, 13, 0, 0, 0]);
+    d = DateTime.strptime("Mar 2004", "%b %Y");
+    expect(ymdhms(d)).toEqual([2004, 3, 1, 0, 0, 0]);
+    d = DateTime.strptime("23:55", "%H:%M");
+    expect(ymdhms(d)).toEqual([n.year, n.month, n.day, 23, 55, 0]);
+    d = DateTime.strptime("23:55:30", "%H:%M:%S");
+    expect(ymdhms(d)).toEqual([n.year, n.month, n.day, 23, 55, 30]);
 
-    d = dtNewByFrags(Date._strptime("Sun 23:55", "%a %H:%M"));
-    const d2 = d.minus(d.wday) as DateTime;
-    expect([d.year, d.mon, d.mday, d.hour, d.min, d.sec]).toEqual([
-      d2.year,
-      d2.mon,
-      d2.mday,
-      23,
-      55,
-      0,
-    ]);
-    d = dtNewByFrags(Date._strptime("Aug 23:55", "%b %H:%M"));
-    expect([d.year, d.mon, d.mday, d.hour, d.min, d.sec]).toEqual([n.year, 8, 1, 23, 55, 0]);
+    d = DateTime.strptime("Sun 23:55", "%a %H:%M");
+    const d2 = d.subtract({ days: d.dayOfWeek % 7 });
+    expect(ymdhms(d)).toEqual([d2.year, d2.month, d2.day, 23, 55, 0]);
+    d = DateTime.strptime("Aug 23:55", "%b %H:%M");
+    expect(ymdhms(d)).toEqual([n.year, 8, 1, 23, 55, 0]);
 
-    d = dtNewByFrags(Date._strptime("2004", "%G"));
-    expect([d.cwyear, d.cweek, d.cwday, d.hour, d.min, d.sec]).toEqual([2004, 1, 1, 0, 0, 0]);
-    d = dtNewByFrags(Date._strptime("11", "%V"));
-    expect([d.cwyear, d.cweek, d.cwday, d.hour, d.min, d.sec]).toEqual([n.cwyear, 11, 1, 0, 0, 0]);
-    d = dtNewByFrags(Date._strptime("6", "%u"));
-    expect([d.cwyear, d.cweek, d.cwday, d.hour, d.min, d.sec]).toEqual([
-      n.cwyear,
-      n.cweek,
-      6,
-      0,
-      0,
-      0,
-    ]);
+    d = DateTime.strptime("2004", "%G");
+    expect(cwymdhms(d)).toEqual([2004, 1, 1, 0, 0, 0]);
+    d = DateTime.strptime("11", "%V");
+    expect(cwymdhms(d)).toEqual([n.yearOfWeek, 11, 1, 0, 0, 0]);
+    d = DateTime.strptime("6", "%u");
+    expect(cwymdhms(d)).toEqual([n.yearOfWeek, n.weekOfYear, 6, 0, 0, 0]);
 
-    d = dtNewByFrags(Date._strptime("11-6", "%V-%u"));
-    expect([d.cwyear, d.cweek, d.cwday, d.hour, d.min, d.sec]).toEqual([n.cwyear, 11, 6, 0, 0, 0]);
-    d = dtNewByFrags(Date._strptime("2004-11", "%G-%V"));
-    expect([d.cwyear, d.cweek, d.cwday, d.hour, d.min, d.sec]).toEqual([2004, 11, 1, 0, 0, 0]);
+    d = DateTime.strptime("11-6", "%V-%u");
+    expect(cwymdhms(d)).toEqual([n.yearOfWeek, 11, 6, 0, 0, 0]);
+    d = DateTime.strptime("2004-11", "%G-%V");
+    expect(cwymdhms(d)).toEqual([2004, 11, 1, 0, 0, 0]);
 
-    d = dtNewByFrags(Date._strptime("11-6", "%U-%w"));
-    expect([d.year, Number(d.strftime("%U")), d.wday, d.hour, d.min, d.sec]).toEqual([
-      n.year,
-      11,
-      6,
-      0,
-      0,
-      0,
-    ]);
-    d = dtNewByFrags(Date._strptime("2004-11", "%Y-%U"));
-    expect([d.year, Number(d.strftime("%U")), d.wday, d.hour, d.min, d.sec]).toEqual([
-      2004, 11, 0, 0, 0, 0,
-    ]);
+    d = DateTime.strptime("11-6", "%U-%w");
+    expect(wnumWdayHms(d, "%U")).toEqual([n.year, 11, 6, 0, 0, 0]);
+    d = DateTime.strptime("2004-11", "%Y-%U");
+    expect(wnumWdayHms(d, "%U")).toEqual([2004, 11, 0, 0, 0, 0]);
 
-    d = dtNewByFrags(Date._strptime("11-6", "%W-%w"));
-    expect([d.year, Number(d.strftime("%W")), d.wday, d.hour, d.min, d.sec]).toEqual([
-      n.year,
-      11,
-      6,
-      0,
-      0,
-      0,
-    ]);
-    d = dtNewByFrags(Date._strptime("2004-11", "%Y-%W"));
-    expect([d.year, Number(d.strftime("%W")), d.wday, d.hour, d.min, d.sec]).toEqual([
-      2004, 11, 1, 0, 0, 0,
-    ]);
+    d = DateTime.strptime("11-6", "%W-%w");
+    expect(wnumWdayHms(d, "%W")).toEqual([n.year, 11, 6, 0, 0, 0]);
+    d = DateTime.strptime("2004-11", "%Y-%W");
+    expect(wnumWdayHms(d, "%W")).toEqual([2004, 11, 1, 0, 0, 0]);
   });
 
   it("strptime  d to s", () => {
@@ -857,18 +813,18 @@ describe("TestDateStrptime", () => {
   });
 
   it("sz", () => {
-    let d = dtNewByFrags(Date._strptime("0 -0200", "%s %z"));
-    expect([d.year, d.mon, d.mday, d.hour, d.min, d.sec]).toEqual([1969, 12, 31, 22, 0, 0]);
-    expect(d.offset).toEqual(new Rational(-2, 24));
-    d = dtNewByFrags(Date._strptime("9 +0200", "%s %z"));
-    expect([d.year, d.mon, d.mday, d.hour, d.min, d.sec]).toEqual([1970, 1, 1, 2, 0, 9]);
-    expect(d.offset).toEqual(new Rational(2, 24));
+    let d = DateTime.strptime("0 -0200", "%s %z");
+    expect(ymdhms(d)).toEqual([1969, 12, 31, 22, 0, 0]);
+    expect((d as Temporal.ZonedDateTime).offset).toBe("-02:00");
+    d = DateTime.strptime("9 +0200", "%s %z");
+    expect(ymdhms(d)).toEqual([1970, 1, 1, 2, 0, 9]);
+    expect((d as Temporal.ZonedDateTime).offset).toBe("+02:00");
 
-    d = dtNewByFrags(Date._strptime("0 -0200", "%Q %z"));
-    expect([d.year, d.mon, d.mday, d.hour, d.min, d.sec]).toEqual([1969, 12, 31, 22, 0, 0]);
-    expect(d.offset).toEqual(new Rational(-2, 24));
-    d = dtNewByFrags(Date._strptime("9000 +0200", "%Q %z"));
-    expect([d.year, d.mon, d.mday, d.hour, d.min, d.sec]).toEqual([1970, 1, 1, 2, 0, 9]);
-    expect(d.offset).toEqual(new Rational(2, 24));
+    d = DateTime.strptime("0 -0200", "%Q %z");
+    expect(ymdhms(d)).toEqual([1969, 12, 31, 22, 0, 0]);
+    expect((d as Temporal.ZonedDateTime).offset).toBe("-02:00");
+    d = DateTime.strptime("9000 +0200", "%Q %z");
+    expect(ymdhms(d)).toEqual([1970, 1, 1, 2, 0, 9]);
+    expect((d as Temporal.ZonedDateTime).offset).toBe("+02:00");
   });
 });

--- a/packages/date/src/test-date-strptime.test.ts
+++ b/packages/date/src/test-date-strptime.test.ts
@@ -1,7 +1,15 @@
 /**
- * Port of ruby/date's `test/date/test_date_strptime.rb`, lines 70-305 — the
- * low-level `Date._strptime` frags API: the directive table, the width
- * prefixes, and the arms that fail.
+ * Port of ruby/date's `test/date/test_date_strptime.rb` — the low-level
+ * `Date._strptime` frags API (lines 70-305: the directive table, the width
+ * prefixes, and the arms that fail) and the public `Date.strptime` /
+ * `DateTime.strptime` above it (lines 306-end).
+ *
+ * The public half answers RFC 0088's `Temporal` seat rather than a
+ * `Date`/`DateTime`, so `assert_equal(d, Date.strptime(...))` is spelled as an
+ * equality between two seats and the members the seat cannot carry —
+ * `sec_fraction`, `offset`, the gem's own `to_s` — are read off the
+ * gem-shaped object the exported builders answer, which is the same object
+ * MRI compares.
  *
  * `_strptime` answers the frag Hash itself rather than a date, so RFC 0088's
  * `Temporal`-by-default mapping does not reach these tests — the values below
@@ -26,7 +34,7 @@
 /* eslint-disable vitest/no-conditional-expect */
 
 import { describe, it, expect } from "vitest";
-import { Date, DateTime, Rational } from "./date.js";
+import { Date, DateTime, Rational, dtNewByFrags } from "./date.js";
 import type { DateParts } from "./date.js";
 
 const STRFTIME_2001_02_03: Record<string, [string, DateParts]> = {
@@ -602,5 +610,265 @@ describe("TestDateStrptime", () => {
     expect(Date._strptime("+23:60", "%Z")?.offset).toBeNull();
     expect(Date._strptime("+23:00:60", "%Z")?.offset).toBeNull();
     expect(Date._strptime("+23:00:60", "%Z")?.offset).toBeNull();
+  });
+  it("strptime", () => {
+    expect(Date.strptime().toString()).toBe(Date.civil().toString());
+    const d = new Date(2002, 3, 14);
+    expect(Date.strptime(d.toS()).toString()).toBe(Date.civil(2002, 3, 14).toString());
+    expect(Date.strptime("2002-03-14").toString()).toBe(Date.civil(2002, 3, 14).toString());
+
+    const dt = new DateTime(2002, 3, 14, 11, 22, 33, 0);
+    expect(DateTime.strptime(dt.toS()).toString()).toBe(
+      DateTime.civil(2002, 3, 14, 11, 22, 33, 0).toString(),
+    );
+    expect(DateTime.strptime("2002-03-14T11:22:33Z").toString()).toBe(
+      DateTime.civil(2002, 3, 14, 11, 22, 33, 0).toString(),
+    );
+    expect(DateTime.strptime("2002-03-14T11:22:33Z", "%Y-%m-%dT%H:%M:%S%Z").toString()).toBe(
+      DateTime.civil(2002, 3, 14, 11, 22, 33, 0).toString(),
+    );
+    expect(DateTime.strptime("2002-03-14T11:22:33+09:00", "%Y-%m-%dT%H:%M:%S%Z").toString()).toBe(
+      DateTime.civil(2002, 3, 14, 11, 22, 33, new Rational(9, 24)).toString(),
+    );
+    expect(DateTime.strptime("2002-03-14T11:22:33-09:00", "%FT%T%Z").toString()).toBe(
+      DateTime.civil(2002, 3, 14, 11, 22, 33, new Rational(-9, 24)).toString(),
+    );
+    // `+ 123456789.to_r/1000000000/86400` is a nanosecond added to the same
+    // moment, which the seat carries as its own sub-second.
+    expect(DateTime.strptime("2002-03-14T11:22:33.123456789-09:00", "%FT%T.%N%Z").toString()).toBe(
+      new DateTime(2002, 3, 14, 11, 22, 33, new Rational(-9, 24))
+        .plus(new Rational(123456789, 1000000000 * 86400))
+        .toDatetime()
+        .toString(),
+    );
+  });
+
+  it("strptime  2", () => {
+    for (let d = new Date(2006, 6, 1); d.cmp(new Date(2007, 6, 1))! <= 0; d = d.plus(1)) {
+      for (const fmt of [
+        "%Y %m %d",
+        "%C %y %m %d",
+
+        "%Y %j",
+        "%C %y %j",
+
+        "%G %V %w",
+        "%G %V %u",
+        "%C %g %V %w",
+        "%C %g %V %u",
+
+        "%Y %U %w",
+        "%Y %U %u",
+        "%Y %W %w",
+        "%Y %W %u",
+        "%C %y %U %w",
+        "%C %y %U %u",
+        "%C %y %W %w",
+        "%C %y %W %u",
+      ]) {
+        const s = d.strftime(fmt);
+        const d2 = Date.strptime(s, fmt);
+        expect([fmt, d.toS(), d2.toString()]).toEqual([fmt, d.toS(), d.toS()]);
+      }
+
+      for (const fmt of [
+        "%Y %m %d %H %M %S",
+        "%Y %m %d %H %M %S %N",
+        "%C %y %m %d %H %M %S",
+        "%C %y %m %d %H %M %S %N",
+
+        "%Y %j %H %M %S",
+        "%Y %j %H %M %S %N",
+        "%C %y %j %H %M %S",
+        "%C %y %j %H %M %S %N",
+
+        "%s",
+        "%s %N",
+        "%Q",
+        "%Q %N",
+      ]) {
+        const s = d.strftime(fmt);
+        const d2 = DateTime.strptime(s, fmt);
+        expect([fmt, d.toS(), d2.toString()]).toEqual([fmt, d.toS(), `${d.toS()}T00:00:00`]);
+      }
+    }
+  });
+
+  it("strptime  minus", () => {
+    let d = dtNewByFrags(Date._strptime("-1", "%s"));
+    expect([d.year, d.mon, d.mday, d.hour, d.min, d.sec]).toEqual([1969, 12, 31, 23, 59, 59]);
+    d = dtNewByFrags(Date._strptime("-86400", "%s"));
+    expect([d.year, d.mon, d.mday, d.hour, d.min, d.sec]).toEqual([1969, 12, 31, 0, 0, 0]);
+
+    d = dtNewByFrags(Date._strptime("-999", "%Q"));
+    expect([d.year, d.mon, d.mday, d.hour, d.min, d.sec, d.secFraction]).toEqual([
+      1969,
+      12,
+      31,
+      23,
+      59,
+      59,
+      new Rational(1, 1000),
+    ]);
+    d = dtNewByFrags(Date._strptime("-1000", "%Q"));
+    expect([d.year, d.mon, d.mday, d.hour, d.min, d.sec, d.secFraction]).toEqual([
+      1969,
+      12,
+      31,
+      23,
+      59,
+      59,
+      new Rational(0, 1),
+    ]);
+  });
+
+  it("strptime  comp", () => {
+    // `DateTime.now` has no seat of its own in this port, so `n` is the same
+    // "today" `rt_complete_frags` fills an absent year/mon/mday from — the
+    // LOCAL date, as `Time.now` gives it.
+    const jsNow = new globalThis.Date();
+    const n = dtNewByFrags({
+      year: jsNow.getFullYear(),
+      mon: jsNow.getMonth() + 1,
+      mday: jsNow.getDate(),
+    });
+
+    let d = dtNewByFrags(Date._strptime("073", "%j"));
+    expect([d.year, d.yday, d.hour, d.min, d.sec]).toEqual([n.year, 73, 0, 0, 0]);
+    d = dtNewByFrags(Date._strptime("13", "%d"));
+    expect([d.year, d.mon, d.mday, d.hour, d.min, d.sec]).toEqual([n.year, n.mon, 13, 0, 0, 0]);
+
+    d = dtNewByFrags(Date._strptime("Mar", "%b"));
+    expect([d.year, d.mon, d.mday, d.hour, d.min, d.sec]).toEqual([n.year, 3, 1, 0, 0, 0]);
+    d = dtNewByFrags(Date._strptime("2004", "%Y"));
+    expect([d.year, d.mon, d.mday, d.hour, d.min, d.sec]).toEqual([2004, 1, 1, 0, 0, 0]);
+
+    d = dtNewByFrags(Date._strptime("Mar 13", "%b %d"));
+    expect([d.year, d.mon, d.mday, d.hour, d.min, d.sec]).toEqual([n.year, 3, 13, 0, 0, 0]);
+    d = dtNewByFrags(Date._strptime("Mar 2004", "%b %Y"));
+    expect([d.year, d.mon, d.mday, d.hour, d.min, d.sec]).toEqual([2004, 3, 1, 0, 0, 0]);
+    d = dtNewByFrags(Date._strptime("23:55", "%H:%M"));
+    expect([d.year, d.mon, d.mday, d.hour, d.min, d.sec]).toEqual([
+      n.year,
+      n.mon,
+      n.mday,
+      23,
+      55,
+      0,
+    ]);
+    d = dtNewByFrags(Date._strptime("23:55:30", "%H:%M:%S"));
+    expect([d.year, d.mon, d.mday, d.hour, d.min, d.sec]).toEqual([
+      n.year,
+      n.mon,
+      n.mday,
+      23,
+      55,
+      30,
+    ]);
+
+    d = dtNewByFrags(Date._strptime("Sun 23:55", "%a %H:%M"));
+    const d2 = d.minus(d.wday) as DateTime;
+    expect([d.year, d.mon, d.mday, d.hour, d.min, d.sec]).toEqual([
+      d2.year,
+      d2.mon,
+      d2.mday,
+      23,
+      55,
+      0,
+    ]);
+    d = dtNewByFrags(Date._strptime("Aug 23:55", "%b %H:%M"));
+    expect([d.year, d.mon, d.mday, d.hour, d.min, d.sec]).toEqual([n.year, 8, 1, 23, 55, 0]);
+
+    d = dtNewByFrags(Date._strptime("2004", "%G"));
+    expect([d.cwyear, d.cweek, d.cwday, d.hour, d.min, d.sec]).toEqual([2004, 1, 1, 0, 0, 0]);
+    d = dtNewByFrags(Date._strptime("11", "%V"));
+    expect([d.cwyear, d.cweek, d.cwday, d.hour, d.min, d.sec]).toEqual([n.cwyear, 11, 1, 0, 0, 0]);
+    d = dtNewByFrags(Date._strptime("6", "%u"));
+    expect([d.cwyear, d.cweek, d.cwday, d.hour, d.min, d.sec]).toEqual([
+      n.cwyear,
+      n.cweek,
+      6,
+      0,
+      0,
+      0,
+    ]);
+
+    d = dtNewByFrags(Date._strptime("11-6", "%V-%u"));
+    expect([d.cwyear, d.cweek, d.cwday, d.hour, d.min, d.sec]).toEqual([n.cwyear, 11, 6, 0, 0, 0]);
+    d = dtNewByFrags(Date._strptime("2004-11", "%G-%V"));
+    expect([d.cwyear, d.cweek, d.cwday, d.hour, d.min, d.sec]).toEqual([2004, 11, 1, 0, 0, 0]);
+
+    d = dtNewByFrags(Date._strptime("11-6", "%U-%w"));
+    expect([d.year, Number(d.strftime("%U")), d.wday, d.hour, d.min, d.sec]).toEqual([
+      n.year,
+      11,
+      6,
+      0,
+      0,
+      0,
+    ]);
+    d = dtNewByFrags(Date._strptime("2004-11", "%Y-%U"));
+    expect([d.year, Number(d.strftime("%U")), d.wday, d.hour, d.min, d.sec]).toEqual([
+      2004, 11, 0, 0, 0, 0,
+    ]);
+
+    d = dtNewByFrags(Date._strptime("11-6", "%W-%w"));
+    expect([d.year, Number(d.strftime("%W")), d.wday, d.hour, d.min, d.sec]).toEqual([
+      n.year,
+      11,
+      6,
+      0,
+      0,
+      0,
+    ]);
+    d = dtNewByFrags(Date._strptime("2004-11", "%Y-%W"));
+    expect([d.year, Number(d.strftime("%W")), d.wday, d.hour, d.min, d.sec]).toEqual([
+      2004, 11, 1, 0, 0, 0,
+    ]);
+  });
+
+  it("strptime  d to s", () => {
+    const d = new Date(2002, 3, 14);
+    expect(Date.strptime(d.toS()).toString()).toBe(Date.civil(2002, 3, 14).toString());
+
+    const dt = new DateTime(2002, 3, 14, 11, 22, 33, new Rational(9, 24));
+    expect(DateTime.strptime(dt.toS()).toString()).toBe(
+      DateTime.civil(2002, 3, 14, 11, 22, 33, new Rational(9, 24)).toString(),
+    );
+  });
+
+  it("strptime  ex", () => {
+    expect(() => Date.strptime("")).toThrow(Date.Error);
+    expect(() => DateTime.strptime("")).toThrow(Date.Error);
+    expect(() => Date.strptime("2001-02-29", "%F")).toThrow(Date.Error);
+    expect(() => DateTime.strptime("2001-02-29T23:59:60", "%FT%T")).toThrow(Date.Error);
+    expect(() => DateTime.strptime("2001-03-01T23:59:60", "%FT%T")).not.toThrow();
+    expect(() => DateTime.strptime("2001-03-01T23:59:61", "%FT%T")).toThrow(Date.Error);
+    expect(() => Date.strptime("23:55", "%H:%M")).toThrow(Date.Error);
+    expect(() => Date.strptime("01-31-2011", "%m/%d/%Y")).toThrow(Date.Error);
+  });
+
+  it("given string", () => {
+    const s = "2001-02-03T04:05:06Z";
+    const s0 = s;
+
+    expect(Date._strptime(s, "%FT%T%Z")).not.toEqual({});
+    expect(s).toBe(s0);
+  });
+
+  it("sz", () => {
+    let d = dtNewByFrags(Date._strptime("0 -0200", "%s %z"));
+    expect([d.year, d.mon, d.mday, d.hour, d.min, d.sec]).toEqual([1969, 12, 31, 22, 0, 0]);
+    expect(d.offset).toEqual(new Rational(-2, 24));
+    d = dtNewByFrags(Date._strptime("9 +0200", "%s %z"));
+    expect([d.year, d.mon, d.mday, d.hour, d.min, d.sec]).toEqual([1970, 1, 1, 2, 0, 9]);
+    expect(d.offset).toEqual(new Rational(2, 24));
+
+    d = dtNewByFrags(Date._strptime("0 -0200", "%Q %z"));
+    expect([d.year, d.mon, d.mday, d.hour, d.min, d.sec]).toEqual([1969, 12, 31, 22, 0, 0]);
+    expect(d.offset).toEqual(new Rational(-2, 24));
+    d = dtNewByFrags(Date._strptime("9000 +0200", "%Q %z"));
+    expect([d.year, d.mon, d.mday, d.hour, d.min, d.sec]).toEqual([1970, 1, 1, 2, 0, 9]);
+    expect(d.offset).toEqual(new Rational(2, 24));
   });
 });

--- a/packages/date/src/time.trails.test.ts
+++ b/packages/date/src/time.trails.test.ts
@@ -7,7 +7,7 @@
 
 import { Temporal } from "@js-temporal/polyfill";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { ArgumentError } from "./date.js";
+import { ArgumentError, Rational } from "./date.js";
 import { Time } from "./time.js";
 
 describe("Time", () => {
@@ -117,6 +117,25 @@ describe("Time", () => {
     expect(Time.utc(2008, 3, 1, 6, 0, 59.9999999999).nsec).toBe(999999999);
     expect(Time.utc(2008, 3, 1, 6, 0, 2.000000001).nsec).toBe(1);
     expect(Time.utc(2008, 3, 1, 6, 0, 30.987654321).nsec).toBe(987654321);
+    expect(Time.utc(2008, 3, 1, 6, 0, 7.456789).nsec).toBe(456788999);
+  });
+
+  it("Time.new takes a Rational second, as MRI's does", () => {
+    // ruby 3.3.11:
+    //   Time.new(2008, 3, 1, 6, 0, Rational(1, 3)).nsec           #=> 333333333
+    //   Time.new(2008, 3, 1, 6, 0, Rational(1, 3)).strftime("%9N") #=> "333333333"
+    //   Time.new(2008, 3, 1, 6, 0, Rational(7, 2)).sec            #=> 3
+    // MRI's `::Time` holds the second as a Rational, which is the form
+    // `datetime_to_time` (`date_core.c:9053-9055`) passes as
+    // `f_add(INT2FIX(m_sec(dat)), m_sf_in_sec(dat))`.
+    const time = new Time(2008, 3, 1, 6, 0, new Rational(1, 3), "UTC");
+    expect(time.sec).toBe(0);
+    expect(time.nsec).toBe(333333333);
+    expect(time.strftime("%9N")).toBe("333333333");
+
+    const half = Time.utc(2008, 3, 1, 6, 0, new Rational(7, 2));
+    expect(half.sec).toBe(3);
+    expect(half.nsec).toBe(500000000);
   });
 
   it("a whole second carries no fraction", () => {

--- a/packages/date/src/time.ts
+++ b/packages/date/src/time.ts
@@ -17,6 +17,7 @@ import {
   cCivilToJd,
   dfLocalToUtc,
   decodeYear,
+  fToR,
   jdLocalToUtc,
   of2str,
   strftime,
@@ -180,17 +181,24 @@ function tzdataAbbreviation(zoned: Temporal.ZonedDateTime): string {
 }
 
 /**
- * The nanoseconds MRI's `Time#nsec` answers for a `Float` `sec` argument: the
- * *exact* value of the double, truncated at nine digits rather than rounded —
+ * The nanoseconds MRI's `Time#nsec` answers for a `sec` argument: the *exact*
+ * value, truncated at nine digits rather than rounded —
  * `Time.utc(2008, 3, 1, 6, 0, 0.3).nsec` is `299999999`, because the nearest
- * double to `0.3` is `0.29999999999999998889...`. Reading the digits off
- * `toFixed(20)` is what keeps that truncation exact; `Math.floor(frac * 1e9)`
- * rounds the product first and answers `300000000`.
+ * double to `0.3` is `0.29999999999999998889...`, and
+ * `Time.utc(2008, 3, 1, 6, 0, 7.456789).nsec` is `456788999` for the same
+ * reason.
+ *
+ * MRI's `::Time` holds the second as a Rational (`time.c` `time_timespec`,
+ * over `rb_time_magnify`), so a `Rational` argument is exact at any
+ * denominator: `Time.new(2008, 3, 1, 6, 0, Rational(1, 3)).nsec` is
+ * `333333333`. A `number` becomes its own exact ratio through `Float#to_r`
+ * ({@link fToR}) first, so one path serves both and the truncation is the
+ * floored `Rational` quotient rather than a decimal-string slice.
  */
-function subsecNanoseconds(sec: number): number {
-  const fraction = sec - Math.floor(sec);
-  if (fraction === 0) return 0;
-  return Number(fraction.toFixed(20).split(".")[1].slice(0, 9));
+function subsecNanoseconds(sec: number | Rational): number {
+  const fraction = (sec instanceof Rational ? sec : fToR(sec)).mod(1);
+  if (fraction.isZero()) return 0;
+  return fraction.mul(1_000_000_000).div(1);
 }
 
 /**
@@ -224,8 +232,24 @@ export class Time {
    * MRI's seventh positional is the microsecond, not a zone — `Time.utc` names
    * its zone in the method — so it folds into `sec` here.
    */
-  static utc(year: number, month: number, day: number, hour = 0, min = 0, sec = 0, usec = 0): Time {
-    return new Time(year, month, day, hour, min, sec + usec / 1_000_000, "UTC");
+  static utc(
+    year: number,
+    month: number,
+    day: number,
+    hour = 0,
+    min = 0,
+    sec: number | Rational = 0,
+    usec = 0,
+  ): Time {
+    return new Time(
+      year,
+      month,
+      day,
+      hour,
+      min,
+      sec instanceof Rational ? sec.add(new Rational(usec, 1_000_000)) : sec + usec / 1_000_000,
+      "UTC",
+    );
   }
 
   /**
@@ -239,10 +263,17 @@ export class Time {
     day: number,
     hour = 0,
     min = 0,
-    sec = 0,
+    sec: number | Rational = 0,
     usec = 0,
   ): Time {
-    return new Time(year, month, day, hour, min, sec + usec / 1_000_000);
+    return new Time(
+      year,
+      month,
+      day,
+      hour,
+      min,
+      sec instanceof Rational ? sec.add(new Rational(usec, 1_000_000)) : sec + usec / 1_000_000,
+    );
   }
 
   /**
@@ -250,6 +281,20 @@ export class Time {
    * which builds a time in the *local* zone unless `zone` gives an offset.
    * `Time.utc` is the UTC entry point, as in Ruby, and `zone` takes the
    * spellings MRI's `utc_offset` argument takes — see `utcOffsetArgument`.
+   *
+   * `sec` takes the `Rational` MRI's does — the form `datetime_to_time`
+   * (`date_core.c:9053-9055`) itself passes as
+   * `f_add(INT2FIX(m_sec(dat)), m_sf_in_sec(dat))`.
+   *
+   * MRI admits a 60th second and, with no leap-second table loaded, rolls it
+   * into the next minute: `Time.utc(2015, 6, 30, 23, 59, 60)` is
+   * `2015-07-01 00:00:00 UTC` and its `#sec` is `0`. `Temporal` rejects the
+   * value outright (`RejectTime`: `0 <= 60 <= 59`), so the roll is spelled here
+   * rather than in the slot. A 61st second is `ArgumentError` there and here.
+   * That MRI reading is why `Time#toDatetime`'s `s == 60` fold
+   * (`date_core.c:8913-8915`) is unreachable through the constructor on both
+   * runtimes; the C carries it for a `right/`-zoneinfo build, which is not a
+   * shape trails has.
    */
   constructor(
     year: number,
@@ -257,21 +302,24 @@ export class Time {
     day: number,
     hour = 0,
     min = 0,
-    sec = 0,
+    sec: number | Rational = 0,
     zone: string | number | null = null,
   ) {
     const nsec = subsecNanoseconds(sec);
-    this.#plain = new Temporal.PlainDateTime(
+    const wholeSec = sec instanceof Rational ? sec.div(1) : Math.floor(sec);
+    if (wholeSec > 60) throw new ArgumentError("sec out of range");
+    const plain = new Temporal.PlainDateTime(
       year,
       month,
       day,
       hour,
       min,
-      Math.floor(sec),
+      wholeSec === 60 ? 59 : wholeSec,
       Math.floor(nsec / 1_000_000),
       Math.floor(nsec / 1_000) % 1_000,
       nsec % 1_000,
     );
+    this.#plain = wholeSec === 60 ? plain.add({ seconds: 1 }) : plain;
     const utcOffset = zone == null ? Temporal.Now.timeZoneId() : utcOffsetArgument(zone);
     this.#timeZoneId = typeof utcOffset === "number" ? null : utcOffset;
     this.#utcOffset =
@@ -386,7 +434,10 @@ export class Time {
    * `date_core.c:8901-8935`), the same `GREGORIAN`-then-`set_sg` build as
    * {@link Time#toDate} with the time of day, the sub-second and the receiver's
    * `utc_offset` carried across. A leap second — `sec == 60` — is stored as
-   * `59`, which the gem's `DateTime` has no room for.
+   * `59`, which the gem's `DateTime` has no room for. That fold is unreachable
+   * from the constructor on MRI too — a `::Time` built without a `right/`
+   * zoneinfo rolls the 60th second into the next minute and `#sec` answers `0`
+   * (see the constructor) — and is kept for the same reason the C keeps it.
    *
    * The C reaches `d_complex_new_internal` directly, so the whole second, the
    * sub-second `sf` in NANOSECONDS and the offset `of` in SECONDS each land in


### PR DESCRIPTION
Three of a four-story bundle. **`date-side-builders-drop-num2int-with-frac-and-add-frac` is not here** — #6317 landed it on `main` while this was in flight (`Date.jd`, `Date.ordinal`, `Date.commercial` and the constructor all read `num2*_with_frac` and end at `addFracTo` there). Nothing was left to build, so it carries no trailer and is marked done against #6317.

That rebase did surface one thing the sibling PR got wrong, filed as a new story (`date-new-must-discard-date-initialize-add-frac`, RFC 0088): its constructor ends `return addFracTo(this, fr2)`, so `new Date(2001, 2, 3.5)` carries a day fraction. MRI's does not — `add_frac()` lives inside `date_initialize` (`date_core.c:3556-3558`) and `Date.new` reaches it through `Class#new`, which **discards** `initialize`'s return:

    Date.new(2001, 2, 3.5).day_fraction   #=> 0
    Date.civil(2001, 2, 3.5).day_fraction #=> (1/2)

## 1. Port test_date_strptime.rb public strptime (8 tests)

`test_strptime`, `__2`, `__minus`, `__comp`, `__d_to_s`, `__ex`,
`test_given_string`, `test_sz`. `test_date_strptime.rb` is now **13/13 ✓**.

`test_strptime__comp` surfaced two blocks missing from `completeFrags`, both
now ported:

- `rt_complete_frags`' `k == :time` arm (`date_core.c:4098-4105`), which fills
  today's `jd` when `f_le_p(klass, cDateTime)` — this is what makes
  `DateTime.strptime('23:55', '%H:%M')` answer today's date while
  `Date.strptime` on the same frags stays a `Date::Error`. `completeFrags`
  takes `klass` as the C does.
- the trailing hour/min/sec defaults with the `sec > 59` clamp
  (`:4107-4114`).

## 2. ::Time cannot hold a leap second

**The story's premise does not hold against MRI, so this converges on what MRI
actually does.** ruby 3.3.11, no `right/` zoneinfo:

    Time.utc(2015, 6, 30, 23, 59, 60)         #=> 2015-07-01 00:00:00 UTC
    Time.utc(2015, 6, 30, 23, 59, 60).sec     #=> 0
    Time.utc(2015, 6, 30, 23, 59, 61)         #=> ArgumentError: sec out of range

MRI *admits* the 60th second and rolls it into the next minute; `#sec` never
answers `60`. The story's proposed shape — a trails-owned field so `#sec`
answers `60` — would have diverged from MRI. Implemented instead: the 60th
second constructs (rolled in the constructor, since Temporal rejects it in the
slot), the 61st raises `ArgumentError`.

`Time#toDatetime`'s `if (s === 60) s = 59` fold therefore stays unreachable —
as it is on MRI too — and is kept for the same reason the C keeps it (a
`right/`-zoneinfo build). The story's AC "the arm is reachable and covered"
cannot be met without diverging from MRI; flagging for the reviewer.

## 3. ::Time#sec takes no Rational

**Premise 1 of that story is also incorrect.** MRI:

    Time.utc(2008, 3, 1, 6, 0, 7.456789).nsec #=> 456788999

not `456789000` — MRI truncates the *exact double*, which is what the existing
`toFixed(20)` slice already reproduced. So the AC `nsec == 456789000` is not
MRI's behaviour and is not implemented.

Premise 2 is real and is fixed: `sec` now takes `number | Rational` (on the
constructor, `Time.utc` and `Time.mktime`) — the form `datetime_to_time`
(`date_core.c:9053-9055`) itself passes — and the nanosecond is the floored
`Rational` quotient rather than a decimal-string slice; a `number` goes through
`Float#to_r` (`fToR`) first, so one path serves both and `0.3` still answers
`299999999`.

    new Time(2008, 3, 1, 6, 0, new Rational(1, 3)).nsec            //=> 333333333
    new Time(2008, 3, 1, 6, 0, new Rational(1, 3)).strftime("%9N") //=> "333333333"

The `to_datetime` seat test PR 6320 wrote against `7.25` moves back to
`7.456789`, asserting `06:00:07.456788999` — MRI's value.

## Verification

- `pnpm vitest run packages/date/src` — 247 passed (11 files)
- `packages/i18n`, `packages/activemodel`, `packages/activesupport` — green
- `pnpm test:compare --package date` — `test_date_strptime.rb` 13/13, no regressions
- `pnpm api:calls` ratchet OK; `pnpm api:extra --package date` clean
- 441 LOC

Closes-story: port-test-date-strptime-public
Closes-story: time-cannot-hold-a-leap-second
Closes-story: time-sec-is-a-float-not-a-rational