### PR TITLE
feat(date): Date._parse's limit: kwarg and Bignum :year, the valid_*_p wrappers, strftime's accumulated ERANGE bound

### DIFF
--- a/packages/activemodel/src/type/date.ts
+++ b/packages/activemodel/src/type/date.ts
@@ -117,7 +117,7 @@ export class DateType extends ValueType<DateCastResult> {
    * @internal Rails-private helper.
    */
   protected newDate(
-    year: number | null | undefined,
+    year: number | bigint | null | undefined,
     mon: number | null | undefined,
     mday: number | null | undefined,
   ): Temporal.PlainDate | null {
@@ -126,7 +126,12 @@ export class DateType extends ValueType<DateCastResult> {
     // month/day the same way rather than silently coercing to Jan 1.
     if (mon == null || mday == null) return null;
     try {
-      return Temporal.PlainDate.from({ year, month: mon, day: mday }, { overflow: "reject" });
+      // A Bignum `:year` becomes the `Infinity` `Temporal` rejects; see
+      // `newTime` (helpers/time-value.ts).
+      return Temporal.PlainDate.from(
+        { year: Number(year), month: mon, day: mday },
+        { overflow: "reject" },
+      );
     } catch {
       return null;
     }

--- a/packages/activemodel/src/type/date.ts
+++ b/packages/activemodel/src/type/date.ts
@@ -112,7 +112,9 @@ export class DateType extends ValueType<DateCastResult> {
    *   end
    *
    * `0000-00-00` short-circuits to null per Rails. Out-of-range
-   * components are caught and become null (matches `rescue nil`).
+   * components are caught and become null (matches `rescue nil`) — including a
+   * Bignum `:year`, which `Number` makes the `Infinity` Temporal rejects, as in
+   * `newTime` (helpers/time-value.ts).
    *
    * @internal Rails-private helper.
    */
@@ -126,8 +128,6 @@ export class DateType extends ValueType<DateCastResult> {
     // month/day the same way rather than silently coercing to Jan 1.
     if (mon == null || mday == null) return null;
     try {
-      // A Bignum `:year` becomes the `Infinity` `Temporal` rejects; see
-      // `newTime` (helpers/time-value.ts).
       return Temporal.PlainDate.from(
         { year: Number(year), month: mon, day: mday },
         { overflow: "reject" },

--- a/packages/activemodel/src/type/helpers/time-value.ts
+++ b/packages/activemodel/src/type/helpers/time-value.ts
@@ -152,6 +152,11 @@ export function userInputInTimeZone(
  * default zone (`isUtc()` → "UTC", else host-local), matching Rails'
  * `is_utc?` branching.
  *
+ * `year` is read the way `Time.utc`'s year argument is, and so takes the
+ * Bignum `::Date._parse` answers for a year past a JS number (ruby/date,
+ * `date_parse.c`'s `str2num`): `Number` makes it the `Infinity` Temporal
+ * rejects, which lands on the same `rescue nil` MRI's `RangeError` does.
+ *
  * `microsec` is read the way `Time.utc`'s microsecond argument is: a Rational
  * one carries sub-microsecond resolution down into `nsec`, which is what
  * `Type::Time` relies on when it hands a raw `:sec_fraction` straight through
@@ -182,9 +187,6 @@ export function newTime(
         ? Number(microsec * 1000n)
         : Math.trunc((microsec ?? 0) * 1000);
   const components = {
-    // `::Date._parse` answers a Bignum `:year` for a year past a JS number
-    // (ruby/date, `date_parse.c`'s `str2num`); `Number` makes it the
-    // `Infinity` `Temporal` rejects below, which is the `rescue nil` arm.
     year: Number(year),
     month: mon,
     day: mday,

--- a/packages/activemodel/src/type/helpers/time-value.ts
+++ b/packages/activemodel/src/type/helpers/time-value.ts
@@ -162,7 +162,7 @@ export function userInputInTimeZone(
  */
 export function newTime(
   this: TimezoneAware | void,
-  year: number | null | undefined,
+  year: number | bigint | null | undefined,
   mon: number | null | undefined,
   mday: number | null | undefined,
   hour: number | null | undefined,
@@ -182,7 +182,10 @@ export function newTime(
         ? Number(microsec * 1000n)
         : Math.trunc((microsec ?? 0) * 1000);
   const components = {
-    year,
+    // `::Date._parse` answers a Bignum `:year` for a year past a JS number
+    // (ruby/date, `date_parse.c`'s `str2num`); `Number` makes it the
+    // `Infinity` `Temporal` rejects below, which is the `rescue nil` arm.
+    year: Number(year),
     month: mon,
     day: mday,
     hour: hour ?? 0,

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -1095,33 +1095,35 @@ describe("Date", () => {
     expect(dNewByFrags(RubyDate._parse("1500-02-29")).toS()).toBe("1500-02-29");
   });
 
+  /**
+   * `valid_ordinal_p` / `valid_commercial_p` (date_core.c:2199-2227, :2274-2302)
+   * wrap the int-level `c_valid_*_p` in the same `guess_style` branch
+   * `valid_civil_p` (:2246-2277) has: a year past `REFORM_END_YEAR` is
+   * proleptic Gregorian, so it is `decode_year`d into a `nth` and a residue
+   * year FIRST and validated there. One `CM_PERIOD` is `CM_PERIOD_GCY` = 584388
+   * Gregorian years (date_core.c:207-208), so year 600000 is past one.
+   *
+   * ruby 3.3.11 -rdate:
+   *   Date.ordinal(600000, 60).to_s      #=> "600000-02-29"
+   *   Date.ordinal(600000, 60).jd        #=> 220866619
+   *   Date.commercial(600000, 9, 6).to_s #=> "600000-03-04"
+   *   Date.commercial(600000, 9, 6).jd   #=> 220866623
+   *
+   * The `Temporal` seat reads the RESIDUE day (`m_local_jd`) and so spells the
+   * residue year, which is what `Date.civil` and `Date.weeknum` already answer
+   * for the same day (filed as `date-seat-drops-nth-and-spells-the-residue-year`).
+   * All four agreeing is the point: hardcoding `nth = 0` handed the seat the
+   * WHOLE Julian day and made ordinal/commercial raise instead. The frags path
+   * over the same wrappers (`rt__valid_ordinal_p`, `rt__valid_commercial_p`,
+   * date_core.c:4125-4168) keeps MRI's whole answer, `nth` and all, since it
+   * answers the gem-shaped object.
+   */
   it("takes ordinal's and commercial's nth from valid_*_p, as civil already does", () => {
-    // `valid_ordinal_p` / `valid_commercial_p` (date_core.c:2199-2226, :2273-2301)
-    // wrap the int-level `c_valid_*_p` in the same `guess_style` branch
-    // `valid_civil_p` (:2246-2277) has: a year past REFORM_END_YEAR is
-    // proleptic Gregorian, so it is `decode_year`d into a `nth` and a residue
-    // year FIRST and validated there. One CM_PERIOD is CM_PERIOD_GCY = 584388
-    // Gregorian years (date_core.c:207-208), so year 600000 is past one.
-    //
-    // ruby 3.3.11 -rdate:
-    //   Date.ordinal(600000, 60).to_s     #=> "600000-02-29"
-    //   Date.ordinal(600000, 60).jd       #=> 220866619
-    //   Date.commercial(600000, 9, 6).to_s #=> "600000-03-04"
-    //   Date.commercial(600000, 9, 6).jd   #=> 220866623
-    //
-    // The `Temporal` seat reads the RESIDUE day (`m_local_jd`) and so spells
-    // the residue year, which is what `Date.civil` and `Date.weeknum` already
-    // answer for the same day — the point here is that all four now agree,
-    // where hardcoding `nth = 0` handed the seat the WHOLE Julian day and made
-    // ordinal/commercial raise instead.
     expect(RubyDate.ordinal(600000, 60).toString()).toBe(RubyDate.civil(600000, 2, 29).toString());
     expect(RubyDate.commercial(600000, 9, 6).toString()).toBe(
       RubyDate.civil(600000, 3, 4).toString(),
     );
 
-    // The frags path over the same wrappers (`rt__valid_ordinal_p`,
-    // `rt__valid_commercial_p`, date_core.c:4125-4167) keeps MRI's whole
-    // answer, `nth` and all, since it answers the gem-shaped object.
     const o = dNewByFrags({ year: 600000, yday: 60 });
     expect([o.toS(), o.jd, o.year]).toEqual(["600000-02-29", 220866619, 600000]);
     const c = dNewByFrags({ cwyear: 600000, cweek: 9, cwday: 6 });
@@ -1970,17 +1972,19 @@ describe("strftime over a Temporal subject", () => {
     );
   });
 
+  /**
+   * `date_strftime` writes every field into the ONE buffer
+   * `date_strftime_alloc` sized and gives up against
+   * `char *endp = s + maxsize` (date_strftime.c:54, date_core.c:7081-7097), so
+   * a format whose fields are individually short still fails once their TOTAL
+   * runs past it. Thirteen copies is the smallest count whose precision
+   * (100_000) is itself inside `1024 * flen` (= 106_496); twelve copies raise
+   * on the precision instead.
+   *
+   * ruby 3.3.11 -rdate:
+   *   Date.new(2001, 2, 3).strftime("%100000Y" * 13) #=> Errno::ERANGE
+   */
   it("bounds the accumulated output, not one field, at 1024 * format length", () => {
-    // `date_strftime` writes every field into the ONE buffer
-    // `date_strftime_alloc` sized, and gives up against
-    // `char *endp = s + maxsize` (date_strftime.c:54, date_core.c:7081-7097),
-    // so a format whose fields are individually short still fails once their
-    // TOTAL runs past it. Thirteen copies is the smallest count whose
-    // precision (100_000) is itself inside `1024 * flen` (= 106_496) — twelve
-    // copies raise on the precision instead.
-    //
-    // ruby 3.3.11 -rdate:
-    //   Date.new(2001, 2, 3).strftime("%100000Y" * 13) #=> Errno::ERANGE
     const d = Temporal.PlainDate.from("2001-02-03");
     expect(() => strftime(d, "%100000Y".repeat(13))).toThrow(ERANGE);
   });

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -9,6 +9,7 @@ import {
   ArgumentError,
   Date as RubyDate,
   DateTime as RubyDateTime,
+  ERANGE,
   Rational,
   dNewByFrags,
   dtNewByFrags,
@@ -1094,6 +1095,39 @@ describe("Date", () => {
     expect(dNewByFrags(RubyDate._parse("1500-02-29")).toS()).toBe("1500-02-29");
   });
 
+  it("takes ordinal's and commercial's nth from valid_*_p, as civil already does", () => {
+    // `valid_ordinal_p` / `valid_commercial_p` (date_core.c:2199-2226, :2273-2301)
+    // wrap the int-level `c_valid_*_p` in the same `guess_style` branch
+    // `valid_civil_p` (:2246-2277) has: a year past REFORM_END_YEAR is
+    // proleptic Gregorian, so it is `decode_year`d into a `nth` and a residue
+    // year FIRST and validated there. One CM_PERIOD is CM_PERIOD_GCY = 584388
+    // Gregorian years (date_core.c:207-208), so year 600000 is past one.
+    //
+    // ruby 3.3.11 -rdate:
+    //   Date.ordinal(600000, 60).to_s     #=> "600000-02-29"
+    //   Date.ordinal(600000, 60).jd       #=> 220866619
+    //   Date.commercial(600000, 9, 6).to_s #=> "600000-03-04"
+    //   Date.commercial(600000, 9, 6).jd   #=> 220866623
+    //
+    // The `Temporal` seat reads the RESIDUE day (`m_local_jd`) and so spells
+    // the residue year, which is what `Date.civil` and `Date.weeknum` already
+    // answer for the same day — the point here is that all four now agree,
+    // where hardcoding `nth = 0` handed the seat the WHOLE Julian day and made
+    // ordinal/commercial raise instead.
+    expect(RubyDate.ordinal(600000, 60).toString()).toBe(RubyDate.civil(600000, 2, 29).toString());
+    expect(RubyDate.commercial(600000, 9, 6).toString()).toBe(
+      RubyDate.civil(600000, 3, 4).toString(),
+    );
+
+    // The frags path over the same wrappers (`rt__valid_ordinal_p`,
+    // `rt__valid_commercial_p`, date_core.c:4125-4167) keeps MRI's whole
+    // answer, `nth` and all, since it answers the gem-shaped object.
+    const o = dNewByFrags({ year: 600000, yday: 60 });
+    expect([o.toS(), o.jd, o.year]).toEqual(["600000-02-29", 220866619, 600000]);
+    const c = dNewByFrags({ cwyear: 600000, cweek: 9, cwday: 6 });
+    expect([c.toS(), c.jd]).toEqual(["600000-03-04", 220866623]);
+  });
+
   it("raises from the seat for a day past Temporal's range, decoded nth and all", () => {
     // The `nth` a Julian day past CM_PERIOD carries (date_core.c:1393-1412) is
     // ~year 580000 at its smallest, and `Temporal.PlainDate` stops at ±271821 —
@@ -1934,6 +1968,21 @@ describe("strftime over a Temporal subject", () => {
     expect(strftime(instant, "%Y-%m-%dT%H:%M:%S %z %Z %s")).toBe(
       "2008-03-01T06:00:00 +0000 +00:00 1204351200",
     );
+  });
+
+  it("bounds the accumulated output, not one field, at 1024 * format length", () => {
+    // `date_strftime` writes every field into the ONE buffer
+    // `date_strftime_alloc` sized, and gives up against
+    // `char *endp = s + maxsize` (date_strftime.c:54, date_core.c:7081-7097),
+    // so a format whose fields are individually short still fails once their
+    // TOTAL runs past it. Thirteen copies is the smallest count whose
+    // precision (100_000) is itself inside `1024 * flen` (= 106_496) — twelve
+    // copies raise on the precision instead.
+    //
+    // ruby 3.3.11 -rdate:
+    //   Date.new(2001, 2, 3).strftime("%100000Y" * 13) #=> Errno::ERANGE
+    const d = Temporal.PlainDate.from("2001-02-03");
+    expect(() => strftime(d, "%100000Y".repeat(13))).toThrow(ERANGE);
   });
 
   it("carries a Temporal sub-second into %L and %N", () => {

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -429,8 +429,15 @@ export const Errno = { ERANGE };
  * string grows on its own, so that bound is the only part of the C's buffer
  * machinery that is observable — and it is observable, as the two
  * {@link ERANGE} arms are what `test_strftime` asserts: a precision past it
- * (`date_strftime.c:577-582`) and a rendered field past it
- * (`FILL_PADDING`, `date_strftime.c:124-126`).
+ * (`date_strftime.c:577-582`) and output past it (`FILL_PADDING`,
+ * `date_strftime.c:124-126`, over `NEEDS`, `:94`).
+ *
+ * The second bound is over the ACCUMULATED output, not the field alone: the C
+ * writes every field into the one buffer and measures against
+ * `char *endp = s + maxsize` (`date_strftime.c:54`), so a format whose fields
+ * are each short but whose total runs past `endp` fails there too — which is
+ * what `'%100000Y' * 13` does, thirteen fields none of which is itself past
+ * `1024 * flen`.
  */
 export function strftime(
   value:
@@ -711,7 +718,7 @@ export function strftime(
       f = spec === undefined ? format.length : g + 1;
       continue;
     }
-    if (formatted.length > maxsize) throw new ERANGE(format);
+    if (out.length + formatted.length > maxsize) throw new ERANGE(format);
     out += formatted;
     f = g + 1;
   }
@@ -832,11 +839,19 @@ const ABBR_DAYS = "sun|mon|tue|wed|thu|fri|sat";
  */
 export interface DateParts {
   jd?: number | bigint;
-  year?: number;
+  /**
+   * The year, which is a `bigint` once the token outruns a JS number: the C
+   * reads it with `str2num` (`date_parse.c:51`), Ruby's arbitrary-precision
+   * `String#to_i`, so `Date._parse("Jan 1" + "0" * 100_000, limit: 100_010)`
+   * answers a 100,001-digit `:year` — the same Bignum {@link Date#year} already
+   * answers. Normalized through {@link bigNorm}, so an ordinary year is a
+   * `number` as MRI's is a Fixnum.
+   */
+  year?: number | bigint;
   mon?: number;
   mday?: number;
   yday?: number;
-  cwyear?: number;
+  cwyear?: number | bigint;
   cweek?: number;
   cwday?: number;
   wday?: number;
@@ -891,6 +906,24 @@ type DateFrag =
   | "hour"
   | "min"
   | "sec";
+
+/**
+ * @internal `date_parse.c`'s `cstr2num` / `str2num` macros
+ * (`date_parse.c:50-51`), both `rb_cstr_to_inum(s, 10, 0)`: base ten with
+ * `badcheck` off, so a span carrying no digits reads as `0` rather than
+ * raising, and the answer is a Ruby Integer — arbitrary precision, hence a
+ * `bigint` past what a JS number holds exactly ({@link bigNorm}).
+ */
+function cstr2num(s: string): number | bigint {
+  const m = /^[+-]?\d*/.exec(s)!;
+  if (!/\d/.test(m[0])) return 0;
+  return bigNorm(BigInt(m[0]));
+}
+
+/** @internal `date_parse.c`'s `f_negate` macro (`date_parse.c:20`), `-x`. */
+function fNegate(x: number | bigint): number | bigint {
+  return typeof x === "bigint" ? bigNorm(-x) : -x;
+}
 
 /** @internal `date_parse.c` `comp_year69`: `69` is 1969, `68` is 2068. */
 function compYear69(y: number): number {
@@ -1478,7 +1511,7 @@ function s3e(
       const l = digitSpan(y, s, ep);
       ep = s + l;
       if (l > 2) c = false;
-      hash.year = Number(y.slice(bp, ep));
+      hash.year = cstr2num(y.slice(bp, ep));
     }
   }
 
@@ -1792,7 +1825,7 @@ function parseIso21Cb(m: RegExpExecArray, hash: DateParts): number {
   const w = m[2];
   const d = m[3];
 
-  if (y !== undefined) hash.cwyear = Number(y);
+  if (y !== undefined) hash.cwyear = cstr2num(y);
   hash.cweek = Number(w);
   if (d !== undefined) hash.cwday = Number(d);
 
@@ -1860,7 +1893,7 @@ function parseIso25Cb(m: RegExpExecArray, hash: DateParts): number {
   const y = m[1];
   const d = m[2];
 
-  hash.year = Number(y);
+  hash.year = cstr2num(y);
   hash.yday = Number(d);
 
   return 1;
@@ -1958,7 +1991,7 @@ function parseJisCb(m: RegExpExecArray, hash: DateParts): number {
 
   const ep = gengo(e[0]);
 
-  hash.year = Number(y) + ep;
+  hash.year = fAdd(cstr2num(y), ep) as number | bigint;
   hash.mon = Number(mon);
   hash.mday = Number(d);
 
@@ -2050,7 +2083,7 @@ function parseDot(str: string, hash: DateParts): string | null {
 /** @internal `date_parse.c` `parse_year_cb` (`date_parse.c:1662-1670`). */
 function parseYearCb(m: RegExpExecArray, hash: DateParts): number {
   const y = m[1];
-  hash.year = Number(y);
+  hash.year = cstr2num(y);
   return 1;
 }
 
@@ -3077,8 +3110,10 @@ function dateStrptime(str: string, fmt: string, hash: DateParts): DateParts | nu
   const cent = hash._cent;
   delete hash._cent;
   if (cent !== undefined) {
-    if (hash.cwyear !== undefined) hash.cwyear = hash.cwyear + cent * 100;
-    if (hash.year !== undefined) hash.year = hash.year + cent * 100;
+    if (hash.cwyear !== undefined) {
+      hash.cwyear = fAdd(hash.cwyear, cent * 100) as number | bigint;
+    }
+    if (hash.year !== undefined) hash.year = fAdd(hash.year, cent * 100) as number | bigint;
   }
 
   const merid = hash._merid;
@@ -3742,6 +3777,37 @@ function cValidGregorianP(y: number, m: number, d: number): [rm: number, rd: num
 }
 
 /**
+ * @internal `date_core.c` `valid_ordinal_p` (`date_core.c:2199-2226`), the
+ * year-decoding wrapper `Date.ordinal` goes through: it re-reads
+ * {@link guessStyle} and either validates the year under the reform
+ * ({@link cValidOrdinalP}, whose `int y` this is what supplies) or decodes it
+ * into a `nth` and a residue year first and validates that proleptically.
+ *
+ * As with {@link validCivilP}, the C's `ry`/`rd` out-parameters are the folded
+ * pair every caller re-derives from `rjd`, so the `nth` and the `rjd` alone
+ * come back — which is also why the C's second `decode_year` (`:2218`, the
+ * `nth` non-zero arm) has nothing left to write and is not here: it fills only
+ * `ry`, from a `nth2` the C itself discards.
+ */
+function validOrdinalP(
+  y: number | bigint,
+  d: number,
+  sg: number,
+): [nth: bigint, rjd: number] | null {
+  const style = guessStyle(y, sg);
+
+  if (style === 0) {
+    const jd = cValidOrdinalP(Number(y), d, sg);
+    if (jd === null) return null;
+    return decodeJd(jd);
+  }
+  const [nth, ry] = decodeYear(y, style);
+  const rjd = cValidOrdinalP(ry, d, style);
+  if (rjd === null) return null;
+  return [nth, rjd];
+}
+
+/**
  * @internal `date_core.c` `valid_gregorian_p` (`date_core.c:2229-2236`), which
  * is {@link decodeYear} under a negative style followed by
  * {@link cValidGregorianP}. The C's `nth`/`ry`/`rm`/`rd` out-parameters come
@@ -3957,6 +4023,79 @@ function validCivilP(
   const r = style < 0 ? cValidGregorianP(ry, m, d) : cValidJulianP(ry, m, d);
   if (r === null) return null;
   return [nth, cCivilToJd(ry, r[0], r[1], style)];
+}
+
+/**
+ * @internal `date_core.c` `valid_commercial_p` (`date_core.c:2273-2301`), the
+ * week-date counterpart of {@link validOrdinalP} — the same `guess_style`
+ * branch over {@link cValidCommercialP}.
+ */
+function validCommercialP(
+  y: number | bigint,
+  w: number,
+  d: number,
+  sg: number,
+): [nth: bigint, rjd: number] | null {
+  const style = guessStyle(y, sg);
+
+  if (style === 0) {
+    const jd = cValidCommercialP(Number(y), w, d, sg);
+    if (jd === null) return null;
+    return decodeJd(jd);
+  }
+  const [nth, ry] = decodeYear(y, style);
+  const rjd = cValidCommercialP(ry, w, d, style);
+  if (rjd === null) return null;
+  return [nth, rjd];
+}
+
+/**
+ * @internal `date_core.c` `valid_weeknum_p` (`date_core.c:2303-2329`), the
+ * `:wnum0`/`:wnum1` counterpart of {@link validCommercialP}.
+ */
+function validWeeknumP(
+  y: number | bigint,
+  w: number,
+  d: number,
+  f: number,
+  sg: number,
+): [nth: bigint, rjd: number] | null {
+  const style = guessStyle(y, sg);
+
+  if (style === 0) {
+    const jd = cValidWeeknumP(Number(y), w, d, f, sg);
+    if (jd === null) return null;
+    return decodeJd(jd);
+  }
+  const [nth, ry] = decodeYear(y, style);
+  const rjd = cValidWeeknumP(ry, w, d, f, style);
+  if (rjd === null) return null;
+  return [nth, rjd];
+}
+
+/**
+ * @internal `date_core.c` `valid_nth_kday_p` (`date_core.c:2331-2358`), the
+ * `n`th-weekday counterpart of {@link validWeeknumP}. `:nodoc:` and
+ * `#ifndef NDEBUG` in the C, as {@link Date.nthKday} itself is.
+ */
+function validNthKdayP(
+  y: number | bigint,
+  m: number,
+  n: number,
+  k: number,
+  sg: number,
+): [nth: bigint, rjd: number] | null {
+  const style = guessStyle(y, sg);
+
+  if (style === 0) {
+    const jd = cValidNthKdayP(Number(y), m, n, k, sg);
+    if (jd === null) return null;
+    return decodeJd(jd);
+  }
+  const [nth, ry] = decodeYear(y, style);
+  const rjd = cValidNthKdayP(ry, m, n, k, style);
+  if (rjd === null) return null;
+  return [nth, rjd];
 }
 
 /**
@@ -4355,12 +4494,16 @@ function rtValidJdP(jd: number | bigint): number | bigint {
 }
 
 /**
- * @internal `date_core.c` `rt__valid_ordinal_p` (`date_core.c:4126-4139`) over
- * `c_valid_ordinal_p` (`date_core.c:747-768`), which answers `nil` rather than
- * raising so its caller can fall through to the next kind of date.
+ * @internal `date_core.c` `rt__valid_ordinal_p` (`date_core.c:4125-4138`) over
+ * {@link validOrdinalP} (`date_core.c:2199-2226`), which answers `nil` rather
+ * than raising so its caller can fall through to the next kind of date. As in
+ * {@link rtValidCivilP}, the `nth` the split leaves goes straight back in
+ * through {@link encodeJd} (`date_core.c:4136`).
  */
-function rtValidOrdinalP(y: number, d: number, sg = DEFAULT_SG): number | null {
-  return cValidOrdinalP(y, d, sg);
+function rtValidOrdinalP(y: number | bigint, d: number, sg = DEFAULT_SG): number | bigint | null {
+  const r = validOrdinalP(y, d, sg);
+  if (r === null) return null;
+  return encodeJd(r[0], r[1]);
 }
 
 /**
@@ -4378,6 +4521,37 @@ function rtValidCivilP(
   sg = DEFAULT_SG,
 ): number | bigint | null {
   const r = validCivilP(y, m, d, sg);
+  if (r === null) return null;
+  return encodeJd(r[0], r[1]);
+}
+
+/**
+ * @internal `date_core.c` `rt__valid_commercial_p` (`date_core.c:4154-4167`)
+ * over {@link validCommercialP}, the same shape as {@link rtValidCivilP}.
+ */
+function rtValidCommercialP(
+  y: number | bigint,
+  w: number,
+  d: number,
+  sg = DEFAULT_SG,
+): number | bigint | null {
+  const r = validCommercialP(y, w, d, sg);
+  if (r === null) return null;
+  return encodeJd(r[0], r[1]);
+}
+
+/**
+ * @internal `date_core.c` `rt__valid_weeknum_p` (`date_core.c:4169-4182`) over
+ * {@link validWeeknumP}, the same shape as {@link rtValidCivilP}.
+ */
+function rtValidWeeknumP(
+  y: number | bigint,
+  w: number,
+  d: number,
+  f: number,
+  sg = DEFAULT_SG,
+): number | bigint | null {
+  const r = validWeeknumP(y, w, d, f, sg);
   if (r === null) return null;
   return encodeJd(r[0], r[1]);
 }
@@ -4428,7 +4602,7 @@ function rtValidDateFragsP(parts: DateParts, sg = DEFAULT_SG): number | bigint |
       if (wday !== undefined) if (wday === 0) wday = 7;
     }
     if (wday !== undefined && parts.cweek !== undefined && parts.cwyear !== undefined) {
-      const d = cValidCommercialP(parts.cwyear, parts.cweek, wday, sg);
+      const d = rtValidCommercialP(parts.cwyear, parts.cweek, wday, sg);
       if (d !== null) return d;
     }
   }
@@ -4440,7 +4614,7 @@ function rtValidDateFragsP(parts: DateParts, sg = DEFAULT_SG): number | bigint |
       if (wday !== undefined) if (wday === 7) wday = 0;
     }
     if (wday !== undefined && parts.wnum0 !== undefined && parts.year !== undefined) {
-      const d = cValidWeeknumP(parts.year, parts.wnum0, wday, 0, sg);
+      const d = rtValidWeeknumP(parts.year, parts.wnum0, wday, 0, sg);
       if (d !== null) return d;
     }
   }
@@ -4451,7 +4625,7 @@ function rtValidDateFragsP(parts: DateParts, sg = DEFAULT_SG): number | bigint |
     if (wday !== undefined) wday = mod(wday - 1, 7);
 
     if (wday !== undefined && parts.wnum1 !== undefined && parts.year !== undefined) {
-      const d = cValidWeeknumP(parts.year, parts.wnum1, wday, 1, sg);
+      const d = rtValidWeeknumP(parts.year, parts.wnum1, wday, 1, sg);
       if (d !== null) return d;
     }
   }
@@ -4599,6 +4773,45 @@ export function dtNewByFrags(hash: DateParts | null, sg = DEFAULT_SG): DateTime 
  */
 function round(x: number): number {
   return x < 0 ? -Math.round(-x) : Math.round(x);
+}
+
+/**
+ * @internal The `limit:` kwarg every `Date._parse`-family singleton takes
+ * (`date_core.c` `get_limit` / `check_limit`, `date_core.c:4452-4479`). Ruby's
+ * trailing kwargs Hash is the trailing options object here, so an omitted one
+ * is the C's `NIL_P(opt)` — the 128-character default — and an explicit
+ * `{ limit: null }` is the C's `NIL_P(limit)`, which is `SIZE_MAX`, i.e. no
+ * bound at all.
+ */
+interface ParseOpt {
+  limit?: number | null;
+}
+
+/** @internal `date_core.c` `get_limit` (`date_core.c:4452-4461`). */
+function getLimit(opt: ParseOpt | undefined): number {
+  if (opt !== undefined) {
+    const limit = opt.limit;
+    if (limit == null) return Infinity;
+    return limit;
+  }
+  return 128;
+}
+
+/**
+ * @internal `date_core.c` `check_limit` (`date_core.c:4467-4479`), which runs
+ * BEFORE any sub-parser so a pathological string is rejected rather than
+ * walked. A `nil` string is let through to the sub-parser that answers `{}` for
+ * it (`NIL_P(str)`, `date_core.c:4471`). The C measures `RSTRING_LEN` — bytes —
+ * where a JS string measures UTF-16 code units; the gem's own tests are ASCII,
+ * where the two agree.
+ */
+function checkLimit(str: string | null | undefined, opt: ParseOpt | undefined): void {
+  if (str == null) return;
+  const slen = str.length;
+  const limit = getLimit(opt);
+  if (slen > limit) {
+    throw new ArgumentError(`string length (${slen}) exceeds the limit ${limit}`);
+  }
 }
 
 /** @internal `date_core.c` `day_to_sec` (`date_core.c:1029-1035`). */
@@ -5684,7 +5897,7 @@ export class Date {
    * of the year, so `Date.ordinal(2001, -1)` is 2001-12-31.
    */
   static ordinal(
-    year = -4712,
+    year: number | bigint = -4712,
     yday: number | Rational = 1,
     start = DEFAULT_SG,
   ): Temporal.PlainDate {
@@ -5692,9 +5905,9 @@ export class Date {
     checkNumeric(year, "year");
     const sg = val2sg(start);
     const [d, fr2] = num2intWithFrac(yday, 1, false);
-    const r = cValidOrdinalP(year, d, sg);
+    const r = validOrdinalP(year, d, sg);
     if (r === null) throw new DateError("invalid date");
-    return addFracTo(new Date(SEAT, 0n, r, sg), fr2).toDate();
+    return addFracTo(new Date(SEAT, r[0], r[1], sg), fr2).toDate();
   }
 
   /**
@@ -5727,7 +5940,7 @@ export class Date {
    * the commercial year, so `Date.commercial(2001, -1, -1)` is 2001-12-30.
    */
   static commercial(
-    cwyear = -4712,
+    cwyear: number | bigint = -4712,
     cweek = 1,
     cwday: number | Rational = 1,
     start = DEFAULT_SG,
@@ -5737,9 +5950,9 @@ export class Date {
     checkNumeric(cwyear, "year");
     const sg = val2sg(start);
     const [d, fr2] = num2intWithFrac(cwday, 1, false);
-    const r = cValidCommercialP(cwyear, cweek, d, sg);
+    const r = validCommercialP(cwyear, cweek, d, sg);
     if (r === null) throw new DateError("invalid date");
-    return addFracTo(new Date(SEAT, 0n, r, sg), fr2).toDate();
+    return addFracTo(new Date(SEAT, r[0], r[1], sg), fr2).toDate();
   }
 
   /**
@@ -5758,7 +5971,7 @@ export class Date {
    * day never moves midnight off its own date.
    */
   static weeknum(
-    year = -4712,
+    year: number | bigint = -4712,
     week = 0,
     day: number | Rational = 1,
     firstday = 0,
@@ -5766,10 +5979,9 @@ export class Date {
   ): Temporal.PlainDate {
     const sg = val2sg(start);
     const [d, fr2] = num2intWithFrac(day, 1, false);
-    const rjd = cValidWeeknumP(year, week, d, firstday, sg);
-    if (rjd === null) throw new DateError("invalid date");
-    const [nth, rrjd] = decodeJd(rjd);
-    return addFracTo(new Date(SEAT, nth, rrjd, sg), fr2).toDate();
+    const r = validWeeknumP(year, week, d, firstday, sg);
+    if (r === null) throw new DateError("invalid date");
+    return addFracTo(new Date(SEAT, r[0], r[1], sg), fr2).toDate();
   }
 
   /**
@@ -5781,7 +5993,7 @@ export class Date {
    * (`num2int_with_frac(k, positive_inf)`, `date_core.c:3741`).
    */
   static nthKday(
-    year = -4712,
+    year: number | bigint = -4712,
     month = 1,
     n = 1,
     k: number | Rational = 1,
@@ -5789,10 +6001,9 @@ export class Date {
   ): Temporal.PlainDate {
     const sg = val2sg(start);
     const [rk, fr2] = num2intWithFrac(k, 1, false);
-    const rjd = cValidNthKdayP(year, month, n, rk, sg);
-    if (rjd === null) throw new DateError("invalid date");
-    const [nth, rrjd] = decodeJd(rjd);
-    return addFracTo(new Date(SEAT, nth, rrjd, sg), fr2).toDate();
+    const r = validNthKdayP(year, month, n, rk, sg);
+    if (r === null) throw new DateError("invalid date");
+    return addFracTo(new Date(SEAT, r[0], r[1], sg), fr2).toDate();
   }
 
   /**
@@ -5867,8 +6078,13 @@ export class Date {
    * editing it (`date_parse.c:2186-2229`). `:_comp` starts out as `comp`
    * (`date_parse.c:2172`) and only ever turns false, so an absent one is `comp`,
    * and the year is completed only within `0..99` (`date_parse.c:2267-2287`).
+   *
+   * `date_s__parse_internal` (`date_core.c:4481-4499`) {@link checkLimit}s the
+   * string against the `limit:` kwarg first, so a string past the limit raises
+   * `ArgumentError` before `date__parse` runs at all.
    */
-  static _parse(str: string, comp = true): DateParts {
+  static _parse(str: string, comp = true, opt?: ParseOpt): DateParts {
+    checkLimit(str, opt);
     const hash: DateParts = {};
     str = parseDay(str, hash) ?? str;
     str = parseTime(str, hash) ?? str;
@@ -5892,16 +6108,18 @@ export class Date {
     if (/[a-z]/i.test(str)) str = parseBc(str, hash) ?? str;
     if (/\d/.test(str)) parseFrag(str, hash);
     if (hash._bc) {
-      if (hash.cwyear !== undefined) hash.cwyear = -hash.cwyear + 1;
-      if (hash.year !== undefined) hash.year = -hash.year + 1;
+      if (hash.cwyear !== undefined) {
+        hash.cwyear = fAdd(fNegate(hash.cwyear), 1) as number | bigint;
+      }
+      if (hash.year !== undefined) hash.year = fAdd(fNegate(hash.year), 1) as number | bigint;
     }
     delete hash._bc;
     if (comp && hash._comp !== false) {
       if (hash.cwyear !== undefined && hash.cwyear >= 0 && hash.cwyear <= 99) {
-        hash.cwyear = compYear69(hash.cwyear);
+        hash.cwyear = compYear69(Number(hash.cwyear));
       }
       if (hash.year !== undefined && hash.year >= 0 && hash.year <= 99) {
-        hash.year = compYear69(hash.year);
+        hash.year = compYear69(Number(hash.year));
       }
     }
     {
@@ -5928,8 +6146,13 @@ export class Date {
    * A string that named only a time of day answers no arm of
    * {@link rtValidDateFragsP} and raises.
    */
-  static parse(str = JULIAN_EPOCH_DATE, comp = true, start = DEFAULT_SG): Temporal.PlainDate {
-    return dNewByFrags(Date._parse(str, comp), val2sg(start)).toDate();
+  static parse(
+    str = JULIAN_EPOCH_DATE,
+    comp = true,
+    start = DEFAULT_SG,
+    opt?: ParseOpt,
+  ): Temporal.PlainDate {
+    return dNewByFrags(Date._parse(str, comp, opt), val2sg(start)).toDate();
   }
 
   /**
@@ -5939,7 +6162,8 @@ export class Date {
    * for a string that is not one. Unlike {@link Date._parse} it guesses
    * nothing — the pattern is anchored end to end.
    */
-  static _rfc2822(str: string): DateParts {
+  static _rfc2822(str: string, opt?: ParseOpt): DateParts {
+    checkLimit(str, opt);
     return dateRfc2822(str);
   }
 
@@ -5948,8 +6172,8 @@ export class Date {
    * `rb_define_singleton_method` onto `date_s__rfc2822` itself): RFC 822 is
    * what RFC 2822 obsoleted, and the gem parses both with the one function.
    */
-  static _rfc822(str: string): DateParts {
-    return Date._rfc2822(str);
+  static _rfc822(str: string, opt?: ParseOpt): DateParts {
+    return Date._rfc2822(str, opt);
   }
 
   /**
@@ -5958,13 +6182,21 @@ export class Date {
    * `date_core.c:4855-4877`), which is `Date._rfc2822` followed by
    * `d_new_by_frags`.
    */
-  static rfc2822(str = JULIAN_EPOCH_DATETIME_RFC3339, start = DEFAULT_SG): Temporal.PlainDate {
-    return dNewByFrags(Date._rfc2822(str), val2sg(start)).toDate();
+  static rfc2822(
+    str = JULIAN_EPOCH_DATETIME_RFC3339,
+    start = DEFAULT_SG,
+    opt?: ParseOpt,
+  ): Temporal.PlainDate {
+    return dNewByFrags(Date._rfc2822(str, opt), val2sg(start)).toDate();
   }
 
   /** Ruby `Date.rfc822` (ruby/date, `date_core.c:9465`), `Date.rfc2822`'s alias. */
-  static rfc822(str = JULIAN_EPOCH_DATETIME_RFC3339, start = DEFAULT_SG): Temporal.PlainDate {
-    return Date.rfc2822(str, start);
+  static rfc822(
+    str = JULIAN_EPOCH_DATETIME_RFC3339,
+    start = DEFAULT_SG,
+    opt?: ParseOpt,
+  ): Temporal.PlainDate {
+    return Date.rfc2822(str, start, opt);
   }
 
   /**
@@ -5973,7 +6205,8 @@ export class Date {
    * `date_parse.c`): the frags of an RFC 2616 date-time in any of its three
    * formats, and an empty hash for a string that is none of them.
    */
-  static _httpdate(str: string): DateParts {
+  static _httpdate(str: string, opt?: ParseOpt): DateParts {
+    checkLimit(str, opt);
     return dateHttpdate(str);
   }
 
@@ -5982,8 +6215,12 @@ export class Date {
    * Date::ITALY, limit: 128)` (ruby/date, `date_core.c` `date_s_httpdate`,
    * `date_core.c:4923-4945`).
    */
-  static httpdate(str = JULIAN_EPOCH_DATETIME_HTTPDATE, start = DEFAULT_SG): Temporal.PlainDate {
-    return dNewByFrags(Date._httpdate(str), val2sg(start)).toDate();
+  static httpdate(
+    str = JULIAN_EPOCH_DATETIME_HTTPDATE,
+    start = DEFAULT_SG,
+    opt?: ParseOpt,
+  ): Temporal.PlainDate {
+    return dNewByFrags(Date._httpdate(str, opt), val2sg(start)).toDate();
   }
 
   /**
@@ -7573,8 +7810,8 @@ export class DateTime extends DateWithoutParseStatics {
     if (hFr !== 0) fr2 = hFr;
     if (dFr !== 0) fr2 = dFr;
 
-    const rjd = cValidOrdinalP(year, d, sg);
-    if (rjd === null) throw new DateError("invalid date");
+    const r = validOrdinalP(year, d, sg);
+    if (r === null) throw new DateError("invalid date");
     const rt = cValidTimeP(h, min, s);
     if (rt === null) throw new DateError("invalid date");
     let [rh] = rt;
@@ -7584,7 +7821,7 @@ export class DateTime extends DateWithoutParseStatics {
       fr2 = fr2 instanceof Rational ? fr2.add(DAY_IN_SECONDS) : fr2 + DAY_IN_SECONDS;
     }
     const localDf = timeToDf(rh, rmin, rs);
-    const [nth, rrjd] = decodeJd(rjd);
+    const [nth, rrjd] = r;
     const [rjd2, df, sf] = addFrac(
       jdLocalToUtc(rrjd, localDf, rof),
       dfLocalToUtc(localDf, rof),
@@ -7667,8 +7904,8 @@ export class DateTime extends DateWithoutParseStatics {
     if (hFr !== 0) fr2 = hFr;
     if (dFr !== 0) fr2 = dFr;
 
-    const rjd = cValidCommercialP(cwyear, cweek, d, sg);
-    if (rjd === null) throw new DateError("invalid date");
+    const r = validCommercialP(cwyear, cweek, d, sg);
+    if (r === null) throw new DateError("invalid date");
     const rt = cValidTimeP(h, min, s);
     if (rt === null) throw new DateError("invalid date");
     let [rh] = rt;
@@ -7678,7 +7915,7 @@ export class DateTime extends DateWithoutParseStatics {
       fr2 = fr2 instanceof Rational ? fr2.add(DAY_IN_SECONDS) : fr2 + DAY_IN_SECONDS;
     }
     const localDf = timeToDf(rh, rmin, rs);
-    const [nth, rrjd] = decodeJd(rjd);
+    const [nth, rrjd] = r;
     const [rjd2, df, sf] = addFrac(
       jdLocalToUtc(rrjd, localDf, rof),
       dfLocalToUtc(localDf, rof),
@@ -7734,8 +7971,8 @@ export class DateTime extends DateWithoutParseStatics {
     if (hFr !== 0) fr2 = hFr;
     if (dFr !== 0) fr2 = dFr;
 
-    const rjd = cValidWeeknumP(year, week, d, firstday, sg);
-    if (rjd === null) throw new DateError("invalid date");
+    const r = validWeeknumP(year, week, d, firstday, sg);
+    if (r === null) throw new DateError("invalid date");
     const rt = cValidTimeP(h, min, s);
     if (rt === null) throw new DateError("invalid date");
     let [rh] = rt;
@@ -7745,7 +7982,7 @@ export class DateTime extends DateWithoutParseStatics {
       fr2 = fr2 instanceof Rational ? fr2.add(DAY_IN_SECONDS) : fr2 + DAY_IN_SECONDS;
     }
     const localDf = timeToDf(rh, rmin, rs);
-    const [nth, rrjd] = decodeJd(rjd);
+    const [nth, rrjd] = r;
     const [rjd2, df, sf] = addFrac(
       jdLocalToUtc(rrjd, localDf, rof),
       dfLocalToUtc(localDf, rof),
@@ -7800,8 +8037,8 @@ export class DateTime extends DateWithoutParseStatics {
     if (hFr !== 0) fr2 = hFr;
     if (kFr !== 0) fr2 = kFr;
 
-    const rjd = cValidNthKdayP(year, month, n, rk, sg);
-    if (rjd === null) throw new DateError("invalid date");
+    const r = validNthKdayP(year, month, n, rk, sg);
+    if (r === null) throw new DateError("invalid date");
     const rt = cValidTimeP(h, min, s);
     if (rt === null) throw new DateError("invalid date");
     let [rh] = rt;
@@ -7811,7 +8048,7 @@ export class DateTime extends DateWithoutParseStatics {
       fr2 = fr2 instanceof Rational ? fr2.add(DAY_IN_SECONDS) : fr2 + DAY_IN_SECONDS;
     }
     const localDf = timeToDf(rh, rmin, rs);
-    const [nth, rrjd] = decodeJd(rjd);
+    const [nth, rrjd] = r;
     const [rjd2, df, sf] = addFrac(
       jdLocalToUtc(rrjd, localDf, rof),
       dfLocalToUtc(localDf, rof),
@@ -7880,8 +8117,9 @@ export class DateTime extends DateWithoutParseStatics {
     str = JULIAN_EPOCH_DATETIME,
     comp = true,
     start = DEFAULT_SG,
+    opt?: ParseOpt,
   ): Temporal.PlainDateTime | Temporal.ZonedDateTime {
-    return dtNewByFrags(Date._parse(str, comp), val2sg(start)).toDatetime();
+    return dtNewByFrags(Date._parse(str, comp, opt), val2sg(start)).toDatetime();
   }
 
   /**
@@ -7893,16 +8131,18 @@ export class DateTime extends DateWithoutParseStatics {
   static rfc2822(
     str = JULIAN_EPOCH_DATETIME_RFC3339,
     start = DEFAULT_SG,
+    opt?: ParseOpt,
   ): Temporal.PlainDateTime | Temporal.ZonedDateTime {
-    return dtNewByFrags(Date._rfc2822(str), val2sg(start)).toDatetime();
+    return dtNewByFrags(Date._rfc2822(str, opt), val2sg(start)).toDatetime();
   }
 
   /** Ruby `DateTime.rfc822` (ruby/date, `date_core.c:9598`), `DateTime.rfc2822`'s alias. */
   static rfc822(
     str = JULIAN_EPOCH_DATETIME_RFC3339,
     start = DEFAULT_SG,
+    opt?: ParseOpt,
   ): Temporal.PlainDateTime | Temporal.ZonedDateTime {
-    return DateTime.rfc2822(str, start);
+    return DateTime.rfc2822(str, start, opt);
   }
 
   /**
@@ -7913,8 +8153,9 @@ export class DateTime extends DateWithoutParseStatics {
   static httpdate(
     str = JULIAN_EPOCH_DATETIME_HTTPDATE,
     start = DEFAULT_SG,
+    opt?: ParseOpt,
   ): Temporal.PlainDateTime | Temporal.ZonedDateTime {
-    return dtNewByFrags(Date._httpdate(str), val2sg(start)).toDatetime();
+    return dtNewByFrags(Date._httpdate(str, opt), val2sg(start)).toDatetime();
   }
 
   /**

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -1991,7 +1991,7 @@ function parseJisCb(m: RegExpExecArray, hash: DateParts): number {
 
   const ep = gengo(e[0]);
 
-  hash.year = fAdd(cstr2num(y), ep) as number | bigint;
+  hash.year = fAdd(cstr2num(y), ep);
   hash.mon = Number(mon);
   hash.mday = Number(d);
 
@@ -3110,10 +3110,8 @@ function dateStrptime(str: string, fmt: string, hash: DateParts): DateParts | nu
   const cent = hash._cent;
   delete hash._cent;
   if (cent !== undefined) {
-    if (hash.cwyear !== undefined) {
-      hash.cwyear = fAdd(hash.cwyear, cent * 100) as number | bigint;
-    }
-    if (hash.year !== undefined) hash.year = fAdd(hash.year, cent * 100) as number | bigint;
+    if (hash.cwyear !== undefined) hash.cwyear = fAdd(hash.cwyear, cent * 100);
+    if (hash.year !== undefined) hash.year = fAdd(hash.year, cent * 100);
   }
 
   const merid = hash._merid;
@@ -3136,6 +3134,11 @@ function dateStrptime(str: string, fmt: string, hash: DateParts): DateParts | nu
  * makes the sum one, which is how an exact `:seconds` survives folding an
  * `:offset` in (`date_core.c:3850`).
  */
+function fAdd(x: number | bigint, y: number | bigint): number | bigint;
+function fAdd(
+  x: number | bigint | Rational,
+  y: number | bigint | Rational,
+): number | bigint | Rational;
 function fAdd(
   x: number | bigint | Rational,
   y: number | bigint | Rational,
@@ -3777,7 +3780,7 @@ function cValidGregorianP(y: number, m: number, d: number): [rm: number, rd: num
 }
 
 /**
- * @internal `date_core.c` `valid_ordinal_p` (`date_core.c:2199-2226`), the
+ * @internal `date_core.c` `valid_ordinal_p` (`date_core.c:2199-2227`), the
  * year-decoding wrapper `Date.ordinal` goes through: it re-reads
  * {@link guessStyle} and either validates the year under the reform
  * ({@link cValidOrdinalP}, whose `int y` this is what supplies) or decodes it
@@ -4026,7 +4029,7 @@ function validCivilP(
 }
 
 /**
- * @internal `date_core.c` `valid_commercial_p` (`date_core.c:2273-2301`), the
+ * @internal `date_core.c` `valid_commercial_p` (`date_core.c:2274-2302`), the
  * week-date counterpart of {@link validOrdinalP} — the same `guess_style`
  * branch over {@link cValidCommercialP}.
  */
@@ -4050,7 +4053,7 @@ function validCommercialP(
 }
 
 /**
- * @internal `date_core.c` `valid_weeknum_p` (`date_core.c:2303-2329`), the
+ * @internal `date_core.c` `valid_weeknum_p` (`date_core.c:2304-2332`), the
  * `:wnum0`/`:wnum1` counterpart of {@link validCommercialP}.
  */
 function validWeeknumP(
@@ -4074,7 +4077,7 @@ function validWeeknumP(
 }
 
 /**
- * @internal `date_core.c` `valid_nth_kday_p` (`date_core.c:2331-2358`), the
+ * @internal `date_core.c` `valid_nth_kday_p` (`date_core.c:2336-2364`), the
  * `n`th-weekday counterpart of {@link validWeeknumP}. `:nodoc:` and
  * `#ifndef NDEBUG` in the C, as {@link Date.nthKday} itself is.
  */
@@ -4495,7 +4498,7 @@ function rtValidJdP(jd: number | bigint): number | bigint {
 
 /**
  * @internal `date_core.c` `rt__valid_ordinal_p` (`date_core.c:4125-4138`) over
- * {@link validOrdinalP} (`date_core.c:2199-2226`), which answers `nil` rather
+ * {@link validOrdinalP} (`date_core.c:2199-2227`), which answers `nil` rather
  * than raising so its caller can fall through to the next kind of date. As in
  * {@link rtValidCivilP}, the `nth` the split leaves goes straight back in
  * through {@link encodeJd} (`date_core.c:4136`).
@@ -4526,7 +4529,7 @@ function rtValidCivilP(
 }
 
 /**
- * @internal `date_core.c` `rt__valid_commercial_p` (`date_core.c:4154-4167`)
+ * @internal `date_core.c` `rt__valid_commercial_p` (`date_core.c:4155-4168`)
  * over {@link validCommercialP}, the same shape as {@link rtValidCivilP}.
  */
 function rtValidCommercialP(
@@ -4541,7 +4544,7 @@ function rtValidCommercialP(
 }
 
 /**
- * @internal `date_core.c` `rt__valid_weeknum_p` (`date_core.c:4169-4182`) over
+ * @internal `date_core.c` `rt__valid_weeknum_p` (`date_core.c:4170-4183`) over
  * {@link validWeeknumP}, the same shape as {@link rtValidCivilP}.
  */
 function rtValidWeeknumP(
@@ -6079,7 +6082,7 @@ export class Date {
    * (`date_parse.c:2172`) and only ever turns false, so an absent one is `comp`,
    * and the year is completed only within `0..99` (`date_parse.c:2267-2287`).
    *
-   * `date_s__parse_internal` (`date_core.c:4481-4499`) {@link checkLimit}s the
+   * `date_s__parse_internal` (`date_core.c:4481-4498`) {@link checkLimit}s the
    * string against the `limit:` kwarg first, so a string past the limit raises
    * `ArgumentError` before `date__parse` runs at all.
    */
@@ -6108,10 +6111,8 @@ export class Date {
     if (/[a-z]/i.test(str)) str = parseBc(str, hash) ?? str;
     if (/\d/.test(str)) parseFrag(str, hash);
     if (hash._bc) {
-      if (hash.cwyear !== undefined) {
-        hash.cwyear = fAdd(fNegate(hash.cwyear), 1) as number | bigint;
-      }
-      if (hash.year !== undefined) hash.year = fAdd(fNegate(hash.year), 1) as number | bigint;
+      if (hash.cwyear !== undefined) hash.cwyear = fAdd(fNegate(hash.cwyear), 1);
+      if (hash.year !== undefined) hash.year = fAdd(fNegate(hash.year), 1);
     }
     delete hash._bc;
     if (comp && hash._comp !== false) {
@@ -7769,7 +7770,7 @@ export class DateTime extends DateWithoutParseStatics {
    * straight to `valid_ordinal_p`.
    */
   static ordinal(
-    year = -4712,
+    year: number | bigint = -4712,
     yday: number | Rational = 1,
     hour?: number | Rational,
     minute?: number | Rational,
@@ -7861,7 +7862,7 @@ export class DateTime extends DateWithoutParseStatics {
    * and `cwyear` is handed straight to `valid_commercial_p`, so neither does.
    */
   static commercial(
-    cwyear = -4712,
+    cwyear: number | bigint = -4712,
     cweek = 1,
     cwday: number | Rational = 1,
     hour?: number | Rational,
@@ -7933,7 +7934,7 @@ export class DateTime extends DateWithoutParseStatics {
    * `firstday` and `year` do not.
    */
   static weeknum(
-    year = -4712,
+    year: number | bigint = -4712,
     week = 0,
     day: number | Rational = 1,
     firstday = 0,
@@ -7999,7 +8000,7 @@ export class DateTime extends DateWithoutParseStatics {
    * (`num2int_with_frac(k, 4)`, `date_core.c:8089-8090`).
    */
   static nthKday(
-    year = -4712,
+    year: number | bigint = -4712,
     month = 1,
     n = 1,
     k: number | Rational = 1,

--- a/packages/date/src/test-date-parse.test.ts
+++ b/packages/date/src/test-date-parse.test.ts
@@ -267,6 +267,26 @@ describe("TestDateParse", () => {
     expect(h.offset).toBe(5025);
   });
 
+  /**
+   * Ruby's `EnvUtil.timeout(3)` guards against the quadratic sub-parser walk
+   * the `limit:` here is what makes safe; there is no vitest analogue and the
+   * ported walk is linear, so only the assertions carry over.
+   */
+  it(" parse too long year", () => {
+    let str = "Jan 1" + "0".repeat(100_000);
+    let h = Date._parse(str, true, { limit: 100_010 });
+    // Ruby's `Math.log10(h[:year])` over a Bignum. JS `Math.log10` takes a
+    // number, which this 100_001-digit year is not, so the same base-ten log is
+    // read off the digit count.
+    expect(String(h.year).length - 1).toBe(100_000);
+    expect(h.mon).toBe(1);
+
+    str = "Jan - 1" + "0".repeat(100_000);
+    h = Date._parse(str, true, { limit: 100_010 });
+    expect(h.mon).toBe(1);
+    expect(h).not.toHaveProperty("year");
+  });
+
   it("parse utf8", () => {
     const h = DateTime._parse("Sun\u{3000}Aug 16 01:02:03 \u{65e5}\u{672c} 2009");
     expect(h.year).toBe(2009);
@@ -368,6 +388,30 @@ describe("TestDateParse", () => {
 
     const dt = DateTime.httpdate("Sat, 03 Feb 2001 04:05:06 GMT", Date.ITALY + 10);
     expect(dt.equals(new DateTime(2001, 2, 3, 4, 5, 6, "+00:00").toDatetime())).toBe(true);
+  });
+
+  /**
+   * Ruby asserts the same raise for every `_`-parser and its builder. The
+   * `_iso8601`, `_rfc3339`, `_xmlschema` and `_jisx0301` families are not
+   * ported yet (RFC 0088), so their arms are absent rather than renamed.
+   */
+  it("length limit", () => {
+    expect(() => Date._parse("1".repeat(1000))).toThrow(ArgumentError);
+    expect(() => Date._rfc2822("1".repeat(1000))).toThrow(ArgumentError);
+    expect(() => Date._rfc822("1".repeat(1000))).toThrow(ArgumentError);
+    expect(() => Date._httpdate("1".repeat(1000))).toThrow(ArgumentError);
+
+    expect(() => Date.parse("1".repeat(1000))).toThrow(ArgumentError);
+    expect(() => Date.rfc2822("1".repeat(1000))).toThrow(ArgumentError);
+    expect(() => Date.rfc822("1".repeat(1000))).toThrow(ArgumentError);
+    expect(() => Date.httpdate("1".repeat(1000))).toThrow(ArgumentError);
+
+    expect(() => DateTime.parse("1".repeat(1000))).toThrow(ArgumentError);
+    expect(() => DateTime.rfc2822("1".repeat(1000))).toThrow(ArgumentError);
+    expect(() => DateTime.rfc822("1".repeat(1000))).toThrow(ArgumentError);
+    expect(() => DateTime.httpdate("1".repeat(1000))).toThrow(ArgumentError);
+
+    expect(() => Date._parse("Jan " + "9".repeat(1000000))).toThrow(ArgumentError);
   });
 });
 

--- a/packages/date/src/test-date-parse.test.ts
+++ b/packages/date/src/test-date-parse.test.ts
@@ -270,14 +270,13 @@ describe("TestDateParse", () => {
   /**
    * Ruby's `EnvUtil.timeout(3)` guards against the quadratic sub-parser walk
    * the `limit:` here is what makes safe; there is no vitest analogue and the
-   * ported walk is linear, so only the assertions carry over.
+   * ported walk is linear, so only the assertions carry over. Ruby's
+   * `Math.log10(h[:year])` is read off the digit count: JS `Math.log10` takes a
+   * number, which this 100_001-digit year is not.
    */
   it(" parse too long year", () => {
     let str = "Jan 1" + "0".repeat(100_000);
     let h = Date._parse(str, true, { limit: 100_010 });
-    // Ruby's `Math.log10(h[:year])` over a Bignum. JS `Math.log10` takes a
-    // number, which this 100_001-digit year is not, so the same base-ten log is
-    // read off the digit count.
     expect(String(h.year).length - 1).toBe(100_000);
     expect(h.mon).toBe(1);
 


### PR DESCRIPTION
Three RFC 0088 stories, all in `packages/date/src/date.ts`.

### `limit:` and a Bignum `:year`

`Date._parse` / `Date.parse` / `DateTime.parse` take the `limit:` kwarg
(`date_core.c` `get_limit` / `check_limit`, `:4452-4479`) as the settled
trailing-options-object idiom: an omitted object is the C's `NIL_P(opt)`
(128 characters), `{ limit: null }` its `NIL_P(limit)` (`SIZE_MAX`). The check
runs before any sub-parser, with MRI's message and raise site.

`DateParts.year` / `.cwyear` widen to `number | bigint`. The C reads a year
token with `str2num` (`date_parse.c:51`), `rb_cstr_to_inum` — arbitrary
precision — ported as `cstr2num` and normalized through `bigNorm`, so an
ordinary year stays a `number` as MRI's stays a Fixnum. That is what lets
`Date._parse("Jan 1" + "0" * 100_000, limit: 100_010)` answer the 100_001-digit
year `test__parse_too_long_year` asserts.

`ActiveModel::Type::Date#new_date` / `Helpers::TimeValue#new_time` take the
widened year; a Bignum becomes the `Infinity` `Temporal` rejects, which is
Rails' `rescue nil` arm.

### The four `valid_*_p` wrappers

The VALUE-level `valid_ordinal_p` (`date_core.c:2199-2226`),
`valid_commercial_p` (`:2273-2301`), `valid_weeknum_p` (`:2303-2329`) and
`valid_nth_kday_p` (`:2331-2358`) are ported over the already-present
`c_valid_*_p`, in the shape `validCivilP` established (the C's `ry`/`rm`/`rd`
out-parameters are the folded triple every caller re-derives from `rjd`, so
`[nth, rjd]` comes back). `Date`/`DateTime`'s `ordinal`, `commercial`,
`weeknum` and `nthKday` take `nth` from the wrapper instead of hardcoding `0n`
or re-deriving it with `decodeJd`, and the widened `:year` pulls
`rt__valid_ordinal_p` onto `validOrdinalP` and adds the two missing
`rt__valid_commercial_p` / `rt__valid_weeknum_p` (`date_core.c:4154-4182`) that
`rt__valid_date_frags_p` had been calling the int-level helpers in place of.

Filed while doing this: `date-seat-drops-nth-and-spells-the-residue-year` —
`Date#toDate` reads `mLocalJd()`, the residue day, so every static answering
the `Temporal` seat spells the residue year for a date past one `CM_PERIOD`.
Pre-existing and shared by `Date.civil` / `Date.weeknum`; this PR makes
`ordinal` / `commercial` agree with them rather than raising, which is the
correct three-way agreement over an incorrect shared answer.

### `strftime`'s ERANGE bound

The second `Errno::ERANGE` guard moves from the single rendered field to the
accumulated output, which is what the C measures: it writes every field into
the one buffer and gives up against `char *endp = s + maxsize`
(`date_strftime.c:54`). `'%100000Y' * 13` is the case — thirteen fields, none
itself past `1024 * flen`, total far past it — and MRI raises there.

### Verification

- `pnpm parity:test --package date`: `test_date_parse.rb` 8 → 10 (`parse too
  long year`, `length limit`); overall 101 → 103 / 137. No package regresses.
- `pnpm parity:api:calls` ratchet OK; `date` is not in the api-compare
  population, so no new extra surface.
- `pnpm typecheck` clean; `packages/date/src` and `packages/activemodel/src/type`
  green (581 tests).

Closes-story: date-parse-limit-kwarg-and-bignum-year
Closes-story: port-valid-p-wrappers-so-builders-stop-hardcoding-nth
Closes-story: strftime-erange-bounds-a-field-not-the-buffer