### PR TITLE
feat(date): Time string formatters, three more test_date.rb tests, mysql2 handle_warnings arity

### DIFF
--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1733,21 +1733,21 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   }
 
   /**
-   * Read pending warnings for `conn`, filter via {@link isWarningIgnored},
-   * and dispatch per the configured `dbWarningsAction`. Called from
-   * `performQuery` where Rails calls it (mysql2/database_statements.rb:102),
-   * while the connection is still held — warnings are connection-scoped.
+   * Read pending warnings for the adapter's raw connection, filter via
+   * {@link isWarningIgnored}, and dispatch per the configured
+   * `dbWarningsAction`. Called from `performQuery` where Rails calls it
+   * (mysql2/database_statements.rb:103), while the connection is still held —
+   * warnings are connection-scoped.
    *
-   * Rails reads `@raw_connection` for the SHOW WARNINGS round-trip, a field the
-   * adapter holds because ruby-mysql2 owns one socket per adapter. trails hands
-   * connections out of the pool per query, so the connection is a trailing
-   * optional parameter rather than a field; the Rails parameter and its
-   * position are unchanged, and an absent one is the base class's no-op.
+   * Rails reads `@raw_connection` for the SHOW WARNINGS round-trip
+   * (abstract_mysql_adapter.rb:770-784); `_client` is trails' spelling of that
+   * same ivar, so the connection is sourced the same way rather than passed in.
    *
    * Mirrors: AbstractMysqlAdapter#handle_warnings.
    * @internal
    */
-  override async handleWarnings(sql: string, conn?: mysql.Connection): Promise<void> {
+  override async handleWarnings(sql: string): Promise<void> {
+    const conn = this._client;
     if (!conn) return;
     const ctor = this.constructor as typeof Mysql2Adapter;
     const action = ctor.dbWarningsAction;

--- a/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
@@ -119,7 +119,7 @@ export function buildColumnTypes(
 interface PerformQueryHost {
   _affectedRowsBeforeWarnings?: number;
   _statements?: Map<string, unknown>;
-  handleWarnings?(sql: string, conn?: unknown): void | Promise<void>;
+  handleWarnings?(sql: string): void | Promise<void>;
   verified?(): void;
   _shouldPrepare?(binds: unknown[]): boolean;
   _trackPrepared?(conn: unknown, sql: string): void;
@@ -297,7 +297,7 @@ export async function performQuery(
   }
 
   this.verified?.();
-  await this.handleWarnings?.(sql, rawConnection);
+  await this.handleWarnings?.(sql);
 
   return { rows, fields: fieldList, affectedRows, insertId };
 }

--- a/packages/date/src/test-date-parse.test.ts
+++ b/packages/date/src/test-date-parse.test.ts
@@ -9,8 +9,7 @@
  * `secFraction`).
  *
  * The heuristic family's remaining tests are not here: `test__parse`'s table,
- * `test__parse_too_long_year` (`limit:` kwarg), `test_parse__time` (`Time#to_s`
- * and the `time` library's `iso8601`/`rfc2822`/`httpdate`/`xmlschema`),
+ * `test__parse_too_long_year` (`limit:` kwarg),
  * `test_parse__comp` (`DateTime.now`) and `test_parse__d_to_s`
  * (`DateTime#to_s`) each need a reader this package has not ported. They are
  * filed against RFC 0088.
@@ -30,6 +29,7 @@ import {
   dtNewByFrags,
   type DateParts,
 } from "./date.js";
+import { Time } from "./time.js";
 
 /** Ruby's `h.values_at(...)` over the frag hash, `nil` for an absent key. */
 function valuesAt(h: DateParts, ...keys: (keyof DateParts)[]): unknown[] {
@@ -277,6 +277,23 @@ describe("TestDateParse", () => {
     expect(h.min).toBe(2);
     expect(h.sec).toBe(3);
     expect(h.zone).toBe("\u{65e5}\u{672c}");
+  });
+
+  it("parse  time", () => {
+    const methods = ["toS", "asctime", "iso8601", "rfc2822", "httpdate", "xmlschema"] as const;
+
+    let t = Time.utc(2001, 2, 3, 4, 5, 6);
+    for (const m of methods) {
+      const d = dtParse(t[m]());
+      expect([d.year, d.mon, d.mday, d.hour, d.min, d.sec]).toEqual([2001, 2, 3, 4, 5, 6]);
+    }
+
+    t = Time.mktime(2001, 2, 3, 4, 5, 6);
+    for (const m of methods) {
+      if (m === "httpdate") continue;
+      const d = dtParse(t[m]());
+      expect([d.year, d.mon, d.mday, d.hour, d.min, d.sec]).toEqual([2001, 2, 3, 4, 5, 6]);
+    }
   });
 
   it("parse  ex", () => {

--- a/packages/date/src/test-date.test.ts
+++ b/packages/date/src/test-date.test.ts
@@ -1,11 +1,11 @@
 /**
  * Port of ruby/date's `test/date/test_date.rb`.
  *
- * `test_range_infinite_float`, `test_sub`, `test_hash` and
- * `test_infinity_comparison` are not here yet: each needs gem surface RFC 0088
- * has not ported (`Date.today`, `#+`/`#-`/`#>>`/`#<<`/`#succ`, `Marshal`,
- * `#hash`, and MRI's `flo_cmp` `infinite?` protocol for a `Float` receiver), so
- * they are filed against 0088 rather than stubbed here.
+ * `test_sub` is not here yet: it asserts that `#+`, `#-`, `#>>`, `#<<`,
+ * `#succ`, the four calendar readers and `Marshal.load` all answer the
+ * RECEIVER's class — `d_lite_plus` and friends build through
+ * `rb_obj_class(self)` — where the port's builders name `Date` outright, and it
+ * needs `Marshal` besides. It is filed against RFC 0088.
  */
 
 import { describe, it, expect } from "vitest";
@@ -17,7 +17,97 @@ import {
   dtNewByFrags,
 } from "./date.js";
 
+/**
+ * Ruby's `Float#<=>` (`ruby/numeric.c` `flo_cmp`, not vendored), which is the
+ * receiver of half of `test_infinity_comparison`'s assertions and of the
+ * `-Float::INFINITY` end of `test_range_infinite_float`'s second Range. JS has
+ * no `<=>` on a `number`, so the C's dispatch is spelled here: an infinite
+ * receiver asks the operand for `infinite?` and answers from the two signs,
+ * which is the protocol `Date::Infinity#infinite?` and `Date#infinite?` exist
+ * to serve. Anything else is a plain double comparison.
+ */
+function floCmp(a: number, b: unknown): number | null {
+  if (Number.isNaN(a)) return null;
+  if (typeof b === "number") return a === b ? 0 : a < b ? -1 : 1;
+  if (!Number.isFinite(a) && typeof (b as { isInfinite?: unknown }).isInfinite === "function") {
+    const i = (b as { isInfinite(): number | null | false }).isInfinite();
+    if (i === null || i === false) return a > 0 ? 1 : -1;
+    const j = i > 0 ? 1 : i < 0 ? -1 : 0;
+    return a > 0 ? (j > 0 ? 0 : 1) : j < 0 ? 0 : -1;
+  }
+  return null;
+}
+
+/** Ruby's `<=>` over the operands these tests put on either side of one. */
+function spaceship(a: unknown, b: unknown): number | null {
+  if (typeof a === "number") return floCmp(a, b);
+  return (a as RubyDate).cmp(b);
+}
+
+/**
+ * Ruby's `Range#cover?` (`ruby/range.c` `r_cover_p` over `r_less`) for the
+ * `begin...end` Ranges `test_range_infinite_float` builds, one endpoint of
+ * which is a `Float` rather than a `Date`. JS has no Range literal, so the
+ * exclusive-end Range and the one method the test calls on it are spelled out.
+ */
+class RubyRange {
+  constructor(
+    readonly begin: unknown,
+    readonly end: unknown,
+    readonly exclEnd: boolean,
+  ) {}
+
+  cover(val: unknown): boolean {
+    const beg = spaceship(this.begin, val);
+    if (beg === null || beg > 0) return false;
+    const end = spaceship(val, this.end);
+    return end !== null && end <= (this.exclEnd ? -1 : 0);
+  }
+}
+
+/**
+ * Ruby's `Hash` for the `Date` keys `test_hash` puts in one: a Hash buckets by
+ * `#hash` and settles a collision with `#eql?`, which is the pair the test is
+ * about, and a JS `Map` is identity-keyed instead. Only the three operations
+ * the test performs are here.
+ */
+class RubyHash {
+  readonly #buckets = new Map<number, [RubyDate, number][]>();
+
+  set(key: RubyDate, value: number): void {
+    const bucket = this.#buckets.get(key.hash()) ?? [];
+    this.#buckets.set(key.hash(), bucket);
+    const found = bucket.find(([k]) => k.isEql(key));
+    if (found) found[1] = value;
+    else bucket.push([key, value]);
+  }
+
+  get(key: RubyDate): number | undefined {
+    return this.#buckets.get(key.hash())?.find(([k]) => k.isEql(key))?.[1];
+  }
+
+  get size(): number {
+    let n = 0;
+    for (const bucket of this.#buckets.values()) n += bucket.length;
+    return n;
+  }
+}
+
 describe("TestDate", () => {
+  it("range infinite float", () => {
+    const today = new RubyDate(RubyDate.today());
+    let r = new RubyRange(today, Number.POSITIVE_INFINITY, true);
+    expect(r.begin).toBe(today);
+    expect(r.end).toEqual(Number.POSITIVE_INFINITY);
+    expect(r.cover(today.plus(1))).toEqual(true);
+    expect(r.cover(today.minus(1))).toEqual(false);
+    r = new RubyRange(Number.NEGATIVE_INFINITY, today, true);
+    expect(r.begin).toEqual(Number.NEGATIVE_INFINITY);
+    expect(r.end).toBe(today);
+    expect(r.cover(today.plus(1))).toEqual(false);
+    expect(r.cover(today.minus(1))).toEqual(true);
+  });
+
   it("const", () => {
     expect(RubyDate.MONTHNAMES[0]).toBeNull();
     expect(RubyDate.MONTHNAMES[1]).toEqual("January");
@@ -58,6 +148,28 @@ describe("TestDate", () => {
     expect(d2.equals(dt2)).toEqual(true);
   });
 
+  it("hash", () => {
+    let h = new RubyHash();
+    h.set(new RubyDate(1999, 5, 23), 0);
+    h.set(new RubyDate(1999, 5, 24), 1);
+    h.set(new RubyDate(1999, 5, 25), 2);
+    h.set(new RubyDate(1999, 5, 25), 9);
+    expect(h.size).toEqual(3);
+    expect(h.get(new RubyDate(1999, 5, 25))).toEqual(9);
+    expect(h.get(new RubyDateTime(1999, 5, 25))).toEqual(9);
+
+    h = new RubyHash();
+    h.set(new RubyDateTime(1999, 5, 23), 0);
+    h.set(new RubyDateTime(1999, 5, 24), 1);
+    h.set(new RubyDateTime(1999, 5, 25), 2);
+    h.set(new RubyDateTime(1999, 5, 25), 9);
+    expect(h.size).toEqual(3);
+    expect(h.get(new RubyDate(1999, 5, 25))).toEqual(9);
+    expect(h.get(new RubyDateTime(1999, 5, 25))).toEqual(9);
+
+    expect(typeof String(new RubyDate(1999, 5, 25).hash())).toEqual("string");
+  });
+
   it("freeze", () => {
     const d = new RubyDate();
     Object.freeze(d);
@@ -73,6 +185,19 @@ describe("TestDate", () => {
     expect(d1.cmp(d2)).toEqual(-1);
     expect(d1.cmp(d1)).toEqual(0);
     expect(d2.cmp(d1)).toEqual(1);
+  });
+
+  it("infinity comparison", () => {
+    expect(spaceship(Number.POSITIVE_INFINITY, new RubyDate.Infinity())).toEqual(0);
+    expect(new RubyDate.Infinity().compareTo(Number.POSITIVE_INFINITY)).toEqual(0);
+    expect(spaceship(Number.NEGATIVE_INFINITY, new RubyDate.Infinity().negate())).toEqual(0);
+    expect(new RubyDate.Infinity().negate().compareTo(Number.NEGATIVE_INFINITY)).toEqual(0);
+
+    expect(spaceship(Number.POSITIVE_INFINITY, new RubyDate.Infinity().negate())).toEqual(1);
+    expect(new RubyDate.Infinity().compareTo(Number.NEGATIVE_INFINITY)).toEqual(1);
+
+    expect(spaceship(Number.NEGATIVE_INFINITY, new RubyDate.Infinity())).toEqual(-1);
+    expect(new RubyDate.Infinity().negate().compareTo(Number.POSITIVE_INFINITY)).toEqual(-1);
   });
 
   it("deconstruct keys", () => {

--- a/packages/date/src/time.ts
+++ b/packages/date/src/time.ts
@@ -202,29 +202,6 @@ function subsecNanoseconds(sec: number | Rational): number {
 }
 
 /**
- * The day and month names `Time#rfc2822` and `Time#httpdate` print, which are
- * RFC 2822's own — deliberately NOT locale-dependent, which is why Ruby spells
- * them as private constants of its own rather than reaching for `strftime`'s
- * `%a`/`%b` (`ruby/lib/time.rb`, `Time::RFC2822_DAY_NAME` /
- * `Time::RFC2822_MONTH_NAME`).
- */
-const RFC2822_DAY_NAME = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
-const RFC2822_MONTH_NAME = [
-  "Jan",
-  "Feb",
-  "Mar",
-  "Apr",
-  "May",
-  "Jun",
-  "Jul",
-  "Aug",
-  "Sep",
-  "Oct",
-  "Nov",
-  "Dec",
-] as const;
-
-/**
  * @noRailsEquivalent PERMANENT — Ruby core `::Time`. Rails never defines the
  * class, only reopens it in `core_ext/time/*.rb`, so there is no Rails
  * counterpart for a port to converge on. trails carries only the members a
@@ -633,19 +610,10 @@ export class Time {
   /**
    * Ruby `Time#rfc2822` (`ruby/lib/time.rb`), RFC 2822's date-time. A UTC time
    * prints the `-0000` RFC 2822 reserves for "the local zone is unknown", not
-   * `+0000`; every other prints its own offset in hours and minutes, so a
-   * sub-minute offset truncates as MRI's `divmod` does.
+   * `+0000`; every other prints its own `%z` offset.
    */
   rfc2822(): string {
-    const head =
-      `${RFC2822_DAY_NAME[this.wday]}, ${pad2(this.day)} ` +
-      `${RFC2822_MONTH_NAME[this.mon - 1]} ${padYear(this.year)} ` +
-      `${pad2(this.hour)}:${pad2(this.min)}:${pad2(this.sec)} `;
-    if (this.isUtc()) return `${head}-0000`;
-    const off = this.utcOffset;
-    const sign = off < 0 ? "-" : "+";
-    const minutes = Math.trunc(Math.abs(off) / 60);
-    return `${head}${sign}${pad2(Math.trunc(minutes / 60))}${pad2(minutes % 60)}`;
+    return this.strftime("%a, %d %b %Y %T ") + (this.isUtc() ? "-0000" : this.strftime("%z"));
   }
 
   /**
@@ -653,28 +621,8 @@ export class Time {
    * format: the receiver taken to UTC and printed with the literal `GMT` zone.
    */
   httpdate(): string {
-    const t = this.getutc();
-    return (
-      `${RFC2822_DAY_NAME[t.wday]}, ${pad2(t.day)} ` +
-      `${RFC2822_MONTH_NAME[t.mon - 1]} ${padYear(t.year)} ` +
-      `${pad2(t.hour)}:${pad2(t.min)}:${pad2(t.sec)} GMT`
-    );
+    return this.getutc().strftime("%a, %d %b %Y %T GMT");
   }
 }
 
 Time.prototype.iso8601 = Time.prototype.xmlschema;
-
-/** MRI's `sprintf('%02d', n)`. */
-function pad2(n: number): string {
-  return String(n).padStart(2, "0");
-}
-
-/**
- * MRI's `sprintf('%0*d', year < 0 ? 5 : 4, year)` — the extra column a
- * negative year needs for its sign, so the digits still line up at four.
- */
-function padYear(year: number): string {
-  const width = year < 0 ? 5 : 4;
-  const digits = String(Math.abs(year)).padStart(year < 0 ? width - 1 : width, "0");
-  return year < 0 ? `-${digits}` : digits;
-}

--- a/packages/date/src/time.ts
+++ b/packages/date/src/time.ts
@@ -637,19 +637,15 @@ export class Time {
    * sub-minute offset truncates as MRI's `divmod` does.
    */
   rfc2822(): string {
-    return (
+    const head =
       `${RFC2822_DAY_NAME[this.wday]}, ${pad2(this.day)} ` +
       `${RFC2822_MONTH_NAME[this.mon - 1]} ${padYear(this.year)} ` +
-      `${pad2(this.hour)}:${pad2(this.min)}:${pad2(this.sec)} ` +
-      (this.isUtc()
-        ? "-0000"
-        : (() => {
-            const off = this.utcOffset;
-            const sign = off < 0 ? "-" : "+";
-            const abs = Math.trunc(Math.abs(off) / 60);
-            return `${sign}${pad2(Math.trunc(abs / 60))}${pad2(abs % 60)}`;
-          })())
-    );
+      `${pad2(this.hour)}:${pad2(this.min)}:${pad2(this.sec)} `;
+    if (this.isUtc()) return `${head}-0000`;
+    const off = this.utcOffset;
+    const sign = off < 0 ? "-" : "+";
+    const minutes = Math.trunc(Math.abs(off) / 60);
+    return `${head}${sign}${pad2(Math.trunc(minutes / 60))}${pad2(minutes % 60)}`;
   }
 
   /**

--- a/packages/date/src/time.ts
+++ b/packages/date/src/time.ts
@@ -202,6 +202,29 @@ function subsecNanoseconds(sec: number | Rational): number {
 }
 
 /**
+ * The day and month names `Time#rfc2822` and `Time#httpdate` print, which are
+ * RFC 2822's own — deliberately NOT locale-dependent, which is why Ruby spells
+ * them as private constants of its own rather than reaching for `strftime`'s
+ * `%a`/`%b` (`ruby/lib/time.rb`, `Time::RFC2822_DAY_NAME` /
+ * `Time::RFC2822_MONTH_NAME`).
+ */
+const RFC2822_DAY_NAME = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
+const RFC2822_MONTH_NAME = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+] as const;
+
+/**
  * @noRailsEquivalent PERMANENT — Ruby core `::Time`. Rails never defines the
  * class, only reopens it in `core_ext/time/*.rb`, so there is no Rails
  * counterpart for a port to converge on. trails carries only the members a
@@ -540,4 +563,122 @@ export class Time {
       format,
     );
   }
+
+  /**
+   * Ruby `Time#utc?` (`ruby/time.c` `time_utc_p`, not vendored — the gem's
+   * `lib/time.rb` and `date_core.c` both duck-type it), true for the times
+   * `Time.utc` builds. A time built from an offset is not a UTC time even when
+   * the offset is zero, which is the distinction `#to_s` and `#xmlschema`
+   * print.
+   */
+  isUtc(): boolean {
+    return this.#timeZoneId === "UTC";
+  }
+
+  /**
+   * Ruby `Time#getutc` (`ruby/time.c` `time_getutc`), the same instant in UTC.
+   * `lib/time.rb`'s `httpdate` reaches it as `dup.utc`, an in-place conversion
+   * of a copy; trails' `Time` is immutable, so the copy is the answer here.
+   */
+  getutc(): Time {
+    const plain = this.#plain.add({ seconds: -this.#utcOffset });
+    return new Time(
+      plain.year,
+      plain.month,
+      plain.day,
+      plain.hour,
+      plain.minute,
+      new Rational(plain.second, 1).add(new Rational(this.nsec, 1_000_000_000)),
+      "UTC",
+    );
+  }
+
+  /**
+   * Ruby `Time#to_s` (`ruby/time.c` `time_to_s`), which is `#inspect` without
+   * the sub-second: `"%Y-%m-%d %H:%M:%S UTC"` for a UTC time and
+   * `"%Y-%m-%d %H:%M:%S %z"` for every other, the C writing the two formats
+   * out as separate string literals exactly as this does.
+   */
+  toS(): string {
+    return this.strftime(this.isUtc() ? "%Y-%m-%d %H:%M:%S UTC" : "%Y-%m-%d %H:%M:%S %z");
+  }
+
+  /**
+   * Ruby `Time#asctime` (`ruby/time.c` `time_asctime`), the `asctime(3)`
+   * spelling — a blank-padded day of month, and no zone at all, so a local time
+   * and a UTC one print alike.
+   */
+  asctime(): string {
+    return this.strftime("%a %b %e %H:%M:%S %Y");
+  }
+
+  /**
+   * Ruby `Time#xmlschema(fraction_digits = 0)` (`ruby/lib/time.rb`), the
+   * ISO 8601 spelling XML Schema's `dateTime` names: `%FT%T`, then the
+   * requested number of sub-second digits, then `Z` for a UTC time or the
+   * `%:z` offset for any other.
+   */
+  xmlschema(fractionDigits = 0): string {
+    fractionDigits = Math.trunc(fractionDigits);
+    let s = this.strftime("%FT%T");
+    if (fractionDigits > 0) {
+      s += this.strftime(`.%${fractionDigits}N`);
+    }
+    return s + (this.isUtc() ? "Z" : this.strftime("%:z"));
+  }
+
+  /** Ruby `Time#iso8601` (`ruby/lib/time.rb`, `alias iso8601 xmlschema`). */
+  declare iso8601: (fractionDigits?: number) => string;
+
+  /**
+   * Ruby `Time#rfc2822` (`ruby/lib/time.rb`), RFC 2822's date-time. A UTC time
+   * prints the `-0000` RFC 2822 reserves for "the local zone is unknown", not
+   * `+0000`; every other prints its own offset in hours and minutes, so a
+   * sub-minute offset truncates as MRI's `divmod` does.
+   */
+  rfc2822(): string {
+    return (
+      `${RFC2822_DAY_NAME[this.wday]}, ${pad2(this.day)} ` +
+      `${RFC2822_MONTH_NAME[this.mon - 1]} ${padYear(this.year)} ` +
+      `${pad2(this.hour)}:${pad2(this.min)}:${pad2(this.sec)} ` +
+      (this.isUtc()
+        ? "-0000"
+        : (() => {
+            const off = this.utcOffset;
+            const sign = off < 0 ? "-" : "+";
+            const abs = Math.trunc(Math.abs(off) / 60);
+            return `${sign}${pad2(Math.trunc(abs / 60))}${pad2(abs % 60)}`;
+          })())
+    );
+  }
+
+  /**
+   * Ruby `Time#httpdate` (`ruby/lib/time.rb`), RFC 2616's preferred date
+   * format: the receiver taken to UTC and printed with the literal `GMT` zone.
+   */
+  httpdate(): string {
+    const t = this.getutc();
+    return (
+      `${RFC2822_DAY_NAME[t.wday]}, ${pad2(t.day)} ` +
+      `${RFC2822_MONTH_NAME[t.mon - 1]} ${padYear(t.year)} ` +
+      `${pad2(t.hour)}:${pad2(t.min)}:${pad2(t.sec)} GMT`
+    );
+  }
+}
+
+Time.prototype.iso8601 = Time.prototype.xmlschema;
+
+/** MRI's `sprintf('%02d', n)`. */
+function pad2(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+/**
+ * MRI's `sprintf('%0*d', year < 0 ? 5 : 4, year)` — the extra column a
+ * negative year needs for its sign, so the digits still line up at four.
+ */
+function padYear(year: number): string {
+  const width = year < 0 ? 5 : 4;
+  const digits = String(Math.abs(year)).padStart(year < 0 ? width - 1 : width, "0");
+  return year < 0 ? `-${digits}` : digits;
 }


### PR DESCRIPTION
Bundle of three stories.

## `port-time-string-formatters-for-parse-time`

Ports the six `::Time` string formatters onto `packages/date/src/time.ts` at
their Ruby names: `toS` / `asctime` (`ruby/time.c` `time_to_s`, `time_asctime`)
and `xmlschema` / `iso8601` / `rfc2822` / `httpdate` (`ruby/lib/time.rb`).
`iso8601` is `Time.prototype.iso8601 = Time.prototype.xmlschema`, matching
`lib/time.rb`'s `alias`. `utc?` and `getutc` come with them — `httpdate`'s
`dup.utc` needs a copy, and trails' `Time` is immutable.

Verified against MRI's output for `Time.utc(2001,2,3,4,5,6)` and
`Time.mktime(...)` under `TZ=America/New_York`, including the `-0000` RFC 2822
reserves for a UTC time and `asctime`'s blank-padded day.

That unblocks `test_parse__time` (`test_date_parse.rb:605-624`), which is
ported as `parse  time`.

## `port-test-date`

Three more of `test_date.rb`'s nine: `test_range_infinite_float`, `test_hash`
and `test_infinity_comparison`. The gem surface each was blocked on has since
landed (`Date#+`/`#-`, `#hash`, `#eql?`, `Date::Infinity#<=>`); what they also
need is Ruby *core*, not gem surface — `Range#cover?`, `Hash`'s `eql?`/`hash`
bucketing, and `Float#<=>`'s `infinite?` duck-typing (`ruby/numeric.c`
`flo_cmp`, which is what `Date::Infinity#infinite?` exists to serve). Those
three are spelled out in the test file next to the assertions that need them,
as `test_date_strftime.test.ts`'s `dateRange` already does for `Range#each`.

`test_date.rb` goes 5/9 → 8/9; the date package 102 → 105 of 137.

`test_sub` is the remaining one. It needs `rb_obj_class(self)` propagation
through every `Date` builder (`newStart`, `plus`, `minus`, `rshift`, `lshift`,
`succ`) plus `Marshal.dump`/`load`, which is its own diff — filed as
`port-test-date-sub-class-propagation` under RFC 0088.

## `mysql2-handle-warnings-drops-conn-parameter`

`handleWarnings(sql)` takes Rails' argument list again. It reads the adapter's
own raw connection — `_client`, trails' spelling of the `@raw_connection`
ivar `abstract_mysql_adapter.rb:770-784` reads — instead of a trailing
parameter, so the `conn` argument is gone from the mysql2 `PerformQueryHost`
interface and from the `performQuery` call site. Behaviour is unchanged: the
connection `performQuery` was handing in is the one `withRawConnection` yields,
which is that same field.

Closes-story: port-test-date
Closes-story: port-time-string-formatters-for-parse-time
Closes-story: mysql2-handle-warnings-drops-conn-parameter

---

## Review round 1

**Finding 1 — `rfc2822`/`httpdate` hand-rolled what `lib/time.rb` delegates to
`strftime`. Fixed.** The reviewer is right, and checked it against an installed
3.3.11 `lib/time.rb`: the `RFC2822_DAY_NAME` / `RFC2822_MONTH_NAME` sprintf form
I ported is the pre-1.9 shape of that file, not the one that ships today. Both
methods now read as Ruby's do —

```ts
rfc2822(): string {
  return this.strftime("%a, %d %b %Y %T ") + (this.isUtc() ? "-0000" : this.strftime("%z"));
}

httpdate(): string {
  return this.getutc().strftime("%a, %d %b %Y %T GMT");
}
```

— which drops the two invented constant arrays and the `pad2` / `padYear`
helpers (nothing else in the file used them). Output is byte-identical before
and after under both `TZ=America/New_York` and the half-hour `TZ=Asia/Kolkata`,
including `-0000` for a UTC time and `+0530` / the `Fri, 02 Feb 2001 22:35:06
GMT` day rollover for a local one.

**Finding 2 — the four `frozen?` assertions belong to `test__const`, not
`test_range_infinite_float`. No change.** `test_range_infinite_float` is
`test_date.rb:9-21` and is exactly ten lines: `today = Date.today`, then two
Ranges of four assertions each (`begin`, `end`, and two `cover?`). All eight
are ported at `test-date.test.ts`'s `it("range infinite float")`, none dropped.

The `assert(Date::ABBR_MONTHNAMES.frozen?)` block the finding quotes is
`test_date.rb:41-44`, inside `def test__const` (`:23-45`) — and it was already
ported, by PR #6311, as the last four expectations of `it("const")`
(`Object.isFrozen(RubyDate.ABBR_MONTHNAMES)` and friends). So the assertions
are present in this file under the Ruby test that actually makes them.

**Finding 3** — noted, no change requested.
