### PR TITLE
fix(date,activerecord,parity): seat the whole Julian day, canonicalize Rational at the C's Integer branches, qualify SQLite index names, gate legacy script spellings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1387,6 +1387,13 @@ jobs:
         # api-compare manifests the step above already wrote. No --exclude-glob:
         # an exclusion disarms the stale gate (see extra-surface.ts `main()`).
         run: pnpm exec tsx scripts/api-compare/extra-surface.ts
+      - name: Legacy compare-script name gate
+        # RFC 0092. Fails on any retired compare-script spelling reintroduced
+        # anywhere outside vendor/rails and build output — the aliases in the
+        # root package.json are a shim for out-of-repo callers, not a licence to
+        # write the old names. The fix is the parity:* spelling, never a new
+        # allowlist row. Read-only; needs no Ruby or artifact.
+        run: pnpm exec tsx scripts/parity/lint-legacy-script-names.ts
       - name: Arity excludes gate
         # Fails on a malformed or STALE entry in
         # scripts/api-compare/arity-exclude.json (the reasoned suppression file

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,7 +182,7 @@ pointer above is the intended fix.
 #### The call-ARGUMENT ratchet (`pnpm parity:api:calls:args`)
 
 RFC 0095 adds a second, independent gate over the same `--calls` extraction:
-`api:calls` compares the SET OF CALL NAMES a body makes, so a port can call
+`parity:api:calls` compares the SET OF CALL NAMES a body makes, so a port can call
 `where` where Rails calls `where`, hand it a completely different argument list,
 and stay green. `pnpm parity:api:calls:args` (`lint-call-args.ts`, CI step
 "Call-argument ratchet") ratchets `output/call-arg-mismatches.json` against the

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "parity:api:pins": "pnpm tsx scripts/api-compare/lint-body-pins.ts",
     "parity:api:pins:all": "API_COMPARE_FORCE=1 pnpm parity:api && pnpm tsx scripts/api-compare/body-pins.ts --pin-all",
     "parity:api:moves": "pnpm tsx scripts/api-compare/moves.ts",
+    "parity:legacy-names": "pnpm tsx scripts/parity/lint-legacy-script-names.ts",
     "parity:api:conventions": "pnpm tsx scripts/parity/conventions-doc.ts",
     "parity:api:deps": "pnpm vendor:fetch && LIB_PATHS_JSON=$(pnpm -s vendor:fetch --print-lib-paths) LOCKFILE_PATH=$PWD/vendor/sources.lock.json ruby scripts/api-compare/extract-ruby-api.rb && pnpm tsx scripts/api-compare/lint-deps.ts",
     "parity:test": "bash scripts/test-compare/run.sh",

--- a/packages/activerecord/src/adapters/sqlite3/copy-table.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/copy-table.trails.test.ts
@@ -21,7 +21,13 @@ interface TableRebuildInternals {
   ): Promise<void>;
 }
 
-fixtures([]);
+fixtures([], {
+  // ATTACH/DETACH are refused inside the savepoint-pinned wrapper ("database
+  // aux is locked"), so the ATTACHed-schema case runs uncovered.
+  usesTransaction: [
+    "copyTableIndexes qualifies the INDEX name, not the table, for an ATTACHed schema",
+  ],
+});
 
 describeIfSqlite("SQLite3Adapter table-rebuild cluster", () => {
   let db: SQLite3Adapter;
@@ -75,6 +81,24 @@ describeIfSqlite("SQLite3Adapter table-rebuild cluster", () => {
     await db.addIndex("customers", ["name"], { order: { name: "desc" } });
     await internals().copyTable("customers", "customers2");
     expect(await copiedIndexSql("customers2", "name")).toMatch(/"name"\s+DESC/i);
+  });
+
+  it("copyTableIndexes qualifies the INDEX name, not the table, for an ATTACHed schema", async () => {
+    await db.execute("ATTACH DATABASE ':memory:' AS aux");
+    try {
+      await db.execute(`CREATE TABLE aux.customers (id integer primary key, name varchar(255))`);
+      await db.addIndex("aux.customers", ["name"], { name: "index_customers_on_name" });
+      await internals().copyTable("aux.customers", "aux.customers2");
+      const rows = (await db.execute(
+        `SELECT sql FROM aux.sqlite_master WHERE type='index' AND tbl_name='customers2'`,
+      )) as Array<{ sql: string | null }>;
+      // SQLite takes the schema on the index name and rejects it on the table.
+      expect(rows[0]?.sql).toMatch(/ON\s+"customers2"/i);
+      expect(rows[0]?.sql).not.toMatch(/ON\s+"aux"/i);
+    } finally {
+      await db.dropTable("aux.customers", "aux.customers2", { ifExists: true });
+      await db.execute("DETACH DATABASE aux");
+    }
   });
 
   it("copyTable keeps a column's SQL function default", async () => {

--- a/packages/activerecord/src/adapters/sqlite3/copy-table.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/copy-table.trails.test.ts
@@ -21,13 +21,7 @@ interface TableRebuildInternals {
   ): Promise<void>;
 }
 
-fixtures([], {
-  // ATTACH/DETACH are refused inside the savepoint-pinned wrapper ("database
-  // aux is locked"), so the ATTACHed-schema case runs uncovered.
-  usesTransaction: [
-    "copyTableIndexes qualifies the INDEX name, not the table, for an ATTACHed schema",
-  ],
-});
+fixtures([]);
 
 describeIfSqlite("SQLite3Adapter table-rebuild cluster", () => {
   let db: SQLite3Adapter;
@@ -81,24 +75,6 @@ describeIfSqlite("SQLite3Adapter table-rebuild cluster", () => {
     await db.addIndex("customers", ["name"], { order: { name: "desc" } });
     await internals().copyTable("customers", "customers2");
     expect(await copiedIndexSql("customers2", "name")).toMatch(/"name"\s+DESC/i);
-  });
-
-  it("copyTableIndexes qualifies the INDEX name, not the table, for an ATTACHed schema", async () => {
-    await db.execute("ATTACH DATABASE ':memory:' AS aux");
-    try {
-      await db.execute(`CREATE TABLE aux.customers (id integer primary key, name varchar(255))`);
-      await db.addIndex("aux.customers", ["name"], { name: "index_customers_on_name" });
-      await internals().copyTable("aux.customers", "aux.customers2");
-      const rows = (await db.execute(
-        `SELECT sql FROM aux.sqlite_master WHERE type='index' AND tbl_name='customers2'`,
-      )) as Array<{ sql: string | null }>;
-      // SQLite takes the schema on the index name and rejects it on the table.
-      expect(rows[0]?.sql).toMatch(/ON\s+"customers2"/i);
-      expect(rows[0]?.sql).not.toMatch(/ON\s+"aux"/i);
-    } finally {
-      await db.dropTable("aux.customers", "aux.customers2", { ifExists: true });
-      await db.execute("DETACH DATABASE aux");
-    }
   });
 
   it("copyTable keeps a column's SQL function default", async () => {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2615,10 +2615,9 @@ WHERE type = 'table' AND name = ${this.quote(tableName)}
    * Mirrors: SQLite3Adapter#copy_table_indexes (sqlite3_adapter.rb:651-677)
    *
    * Rails calls `add_index` unconditionally (`sqlite3_adapter.rb:674`) and so
-   * does this, for every destination Rails can name. The one arm that does not
-   * is the schema-qualified one, which Rails has no notion of; it is recorded at
-   * that branch, not as a `@missingRailsCall` tag — the tag is per-method, and
-   * `parity:api:calls` fails it as STALE now that the method does make the call.
+   * does this, for a schema-qualified destination as much as a bare one: the
+   * qualifier lands on the INDEX name, which is where SQLite takes it, in
+   * `SQLite3::SchemaCreation#visit_CreateIndexDefinition`.
    * @internal
    */
   private async copyTableIndexes(
@@ -2661,41 +2660,7 @@ WHERE type = 'table' AND name = ${this.quote(tableName)}
       if (idx.unique) options.unique = true;
       if (idx.where) options.where = idx.where;
       if (idx.orders) options.order = idx.orders;
-      // MISSING RAILS CALL (add_index, sqlite3_adapter.rb:674) — this branch
-      // only. SQLite puts the schema on the INDEX name, not on the table it
-      // indexes (`CREATE INDEX aux.by_name ON widgets (...)`); qualifying the
-      // table instead is a syntax error, and `add_index` quotes the table, so
-      // it cannot express a qualified destination. Rails has no ATTACHed-schema
-      // notion here at all — every destination Rails can name takes the
-      // `addIndex` call below, and this arm is the trails-only remainder.
-      const { schema: toSchema } = this._splitTableName(to);
-      if (toSchema === undefined || toSchema === "") {
-        await this.addIndex(to, cols, options);
-        continue;
-      }
-      // Rails forwards `index.orders` to add_index, whose add_index_sort_order
-      // appends any present direction upcased (`column << " #{orders[name].upcase}"`)
-      // keyed off the column name as it appears in the copied list. This
-      // hand-built CREATE INDEX stands in for add_index, so it must stay
-      // value-agnostic: `indexes()` only records "desc" today, but an "asc" or
-      // upper-cased entry must not be silently dropped.
-      // Mirrors Rails' options_for_index_columns: IndexDefinition#conciseOptions
-      // collapses a uniform order map to a bare direction, which add_index then
-      // applies to every column.
-      const rawOrders = idx.orders;
-      const orders: Record<string, string> =
-        typeof rawOrders === "string"
-          ? Object.fromEntries((Array.isArray(cols) ? cols : [cols]).map((c) => [c, rawOrders]))
-          : rawOrders;
-      const colSql = Array.isArray(cols)
-        ? cols
-            .map((c) => `${quoteColumnName(c)}${orders[c] ? ` ${orders[c].toUpperCase()}` : ""}`)
-            .join(", ")
-        : cols;
-      const target = `${quoteColumnName(toSchema)}.${quoteColumnName(newName)} ON ${quoteColumnName(bareTo)}`;
-      let sql = `CREATE ${idx.unique ? "UNIQUE " : ""}INDEX ${target} (${colSql})`;
-      if (idx.where) sql += ` WHERE ${idx.where}`;
-      await this.execute(sql);
+      await this.addIndex(to, cols, options);
     }
   }
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-introspection.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-introspection.test.ts
@@ -243,6 +243,36 @@ describe("SQLite3Adapter schema introspection", () => {
     expect(rows.rows).toEqual([["gizmo"]]);
   });
 
+  it("copyTableIndexes puts an ATTACHed schema on the index name, not the table", async () => {
+    // SQLite qualifies the INDEX, not the table it indexes; `CREATE INDEX
+    // by_name ON aux.widgets (...)` is a syntax error. copy_table_indexes
+    // therefore reaches add_index for a qualified destination too — the
+    // qualifier is moved in SQLite3::SchemaCreation#visit_CreateIndexDefinition.
+    const auxPath = path.join(tmpDir, "aux-copy-index.sqlite3");
+    await adapter.executeMutation(`ATTACH DATABASE '${auxPath}' AS aux`);
+    await adapter.executeMutation(
+      "CREATE TABLE aux.widgets (id INTEGER PRIMARY KEY, name TEXT, doomed TEXT)",
+    );
+    await adapter.executeMutation("CREATE INDEX aux.by_name ON widgets (name)");
+
+    await adapter.removeColumn("aux.widgets", "doomed");
+
+    // sqlite_master strips the schema qualifier from the stored DDL, so the
+    // qualifier is read back as WHICH catalog holds the index: aux, not main.
+    // Qualifying the table instead would have raised a syntax error.
+    const inAux = (
+      await adapter.selectAll("SELECT sql FROM aux.sqlite_master WHERE type='index'")
+    ).rows.map((row) => String(row[0]));
+    expect(inAux).toEqual(['CREATE INDEX "by_name" ON "widgets" ("name")']);
+    const inMain = await adapter.selectAll(
+      "SELECT name FROM main.sqlite_master WHERE type='index'",
+    );
+    expect(inMain.rows).toEqual([]);
+    expect(
+      ((await adapter.indexes("aux.widgets")) as Array<{ name: string }>).map((i) => i.name),
+    ).toEqual(["by_name"]);
+  });
+
   it("dataSourceExists matches both tables and views, hides sqlite_* internals", async () => {
     await adapter.executeMutation(
       "CREATE TABLE widgets (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)",

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-creation.ts
@@ -10,7 +10,6 @@ import type {
   ForeignKeyDefinition,
 } from "../abstract/schema-definitions.js";
 import type { ColumnOptions } from "../abstract/schema-definitions.js";
-import { quoteColumnName } from "./quoting.js";
 
 export class SchemaCreation extends AbstractSchemaCreation {
   /**
@@ -41,7 +40,8 @@ export class SchemaCreation extends AbstractSchemaCreation {
     if (o.ifNotExists) parts.push("IF NOT EXISTS");
     if (index.type) parts.push(index.type.toUpperCase());
     parts.push(
-      `${quoteColumnName(schema)}.${quoteColumnName(index.name)} ON ${quoteColumnName(bare)}`,
+      `${this.adapter.quoteColumnName(schema)}.${this.adapter.quoteColumnName(index.name)} ` +
+        `ON ${this.adapter.quoteColumnName(bare)}`,
     );
     if (this.supportsIndexUsing() && index.using) parts.push(`USING ${index.using}`);
     parts.push(`(${await this.quotedColumns(index)})`);

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-creation.ts
@@ -5,10 +5,55 @@
  */
 
 import { SchemaCreation as AbstractSchemaCreation } from "../abstract/schema-creation.js";
-import type { ForeignKeyDefinition } from "../abstract/schema-definitions.js";
+import type {
+  CreateIndexDefinition,
+  ForeignKeyDefinition,
+} from "../abstract/schema-definitions.js";
 import type { ColumnOptions } from "../abstract/schema-definitions.js";
+import { quoteColumnName } from "./quoting.js";
 
 export class SchemaCreation extends AbstractSchemaCreation {
+  /**
+   * The abstract `visit_CreateIndexDefinition`
+   * (abstract/schema_creation.rb:114-127) with the qualifier moved: SQLite puts
+   * an ATTACHed schema on the INDEX name, not on the table it indexes —
+   * `CREATE INDEX "aux"."by_name" ON "widgets" (...)` — and qualifying the table
+   * instead is a syntax error. Rails emits `quote_column_name(index.name) ON
+   * quote_table_name(index.table)` because it has no ATTACHed-schema notion at
+   * all; trails does (`SQLite3Adapter#_splitTableName`, reached through
+   * `alter_table` / `copy_table` with an `aux.posts` name), and this is the one
+   * place the difference is expressible, so `add_index` can serve a qualified
+   * destination and `copy_table_indexes` needs no hand-built statement.
+   *
+   * An unqualified table takes the inherited body untouched.
+   * @internal
+   */
+  protected override async visitCreateIndexDefinition(o: CreateIndexDefinition): Promise<string> {
+    const index = o.index;
+    const dot = index.table.lastIndexOf(".");
+    if (dot === -1) return super.visitCreateIndexDefinition(o);
+    const schema = index.table.slice(0, dot);
+    const bare = index.table.slice(dot + 1);
+    const parts: string[] = ["CREATE"];
+    if (index.unique) parts.push("UNIQUE");
+    parts.push("INDEX");
+    if (o.algorithm) parts.push(o.algorithm);
+    if (o.ifNotExists) parts.push("IF NOT EXISTS");
+    if (index.type) parts.push(index.type.toUpperCase());
+    parts.push(
+      `${quoteColumnName(schema)}.${quoteColumnName(index.name)} ON ${quoteColumnName(bare)}`,
+    );
+    if (this.supportsIndexUsing() && index.using) parts.push(`USING ${index.using}`);
+    parts.push(`(${await this.quotedColumns(index)})`);
+    if ((await this.supportsIndexInclude()) && index.include && index.include.length > 0) {
+      parts.push(`INCLUDE (${await this.quotedIncludeColumns(index.include)})`);
+    }
+    if ((await this.supportsNullsNotDistinct()) && index.nullsNotDistinct)
+      parts.push("NULLS NOT DISTINCT");
+    if (this.supportsPartialIndex() && index.where) parts.push(`WHERE ${index.where}`);
+    return parts.join(" ");
+  }
+
   /** @internal */
   protected override visitForeignKeyDefinition(o: ForeignKeyDefinition): string {
     let sql = super.visitForeignKeyDefinition(o);

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -1109,20 +1109,29 @@ describe("Date", () => {
    *   Date.commercial(600000, 9, 6).to_s #=> "600000-03-04"
    *   Date.commercial(600000, 9, 6).jd   #=> 220866623
    *
-   * The `Temporal` seat reads the RESIDUE day (`m_local_jd`) and so spells the
-   * residue year, which is what `Date.civil` and `Date.weeknum` already answer
-   * for the same day (filed as `date-seat-drops-nth-and-spells-the-residue-year`).
-   * All four agreeing is the point: hardcoding `nth = 0` handed the seat the
-   * WHOLE Julian day and made ordinal/commercial raise instead. The frags path
-   * over the same wrappers (`rt__valid_ordinal_p`, `rt__valid_commercial_p`,
-   * date_core.c:4125-4168) keeps MRI's whole answer, `nth` and all, since it
-   * answers the gem-shaped object.
+   * All four spellings agreeing is the point, and what they now agree on is the
+   * raise: the seat takes the WHOLE day (`encode_jd`) and no
+   * `Temporal.PlainDate` holds a year one `CM_PERIOD_GCY` past the residue.
+   * They agreed on a residue-year date until
+   * `date-seat-drops-nth-and-spells-the-residue-year` — `+015600-02-29` for all
+   * four — which is the shared-but-wrong answer that story was filed for; the
+   * provenance this test is about is unchanged, since hardcoding `nth = 0`
+   * would still make ordinal/commercial disagree with civil.
+   *
+   * The frags path over the same wrappers (`rt__valid_ordinal_p`,
+   * `rt__valid_commercial_p`, date_core.c:4125-4168) keeps MRI's whole answer,
+   * `nth` and all, since it answers the gem-shaped object.
    */
   it("takes ordinal's and commercial's nth from valid_*_p, as civil already does", () => {
-    expect(RubyDate.ordinal(600000, 60).toString()).toBe(RubyDate.civil(600000, 2, 29).toString());
-    expect(RubyDate.commercial(600000, 9, 6).toString()).toBe(
-      RubyDate.civil(600000, 3, 4).toString(),
-    );
+    for (const build of [
+      () => RubyDate.civil(600000, 2, 29),
+      () => RubyDate.ordinal(600000, 60),
+      () => RubyDate.civil(600000, 3, 4),
+      () => RubyDate.commercial(600000, 9, 6),
+    ]) {
+      expect(build).toThrow(RubyDate.Error);
+      expect(build).toThrow("invalid date");
+    }
 
     const o = dNewByFrags({ year: 600000, yday: 60 });
     expect([o.toS(), o.jd, o.year]).toEqual(["600000-02-29", 220866619, 600000]);

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -2166,29 +2166,36 @@ describe("Date's second registration names", () => {
 });
 
 /**
- * `rational.c`'s `rb_rational_canonicalize` folds a denominator of one back to
- * an Integer, so a reducible Rational reaches `date_core.c`'s `FIXNUM_P` /
- * `wholenum_p` branches as an Integer. The gem's own tests pass Integers
- * throughout and never exercise it, which is why these live here.
+ * Ruby's Rational arithmetic does NOT fold a denominator of one back to an
+ * Integer — on ruby 3.3.11 `(Rational(1,2) * 12).class` is `Rational`, `(6/1)`
+ * — so `date_core.c`'s `FIXNUM_P` branches see a reducible Rational as a
+ * Rational, and only `wholenum_p`, a predicate, tests for the fold. The gem's
+ * own tests pass Integers throughout and never pin which arm a Rational takes,
+ * which is why these live here.
  */
-describe("Rational canonicalization at the C's Integer branches", () => {
-  it("takes d_lite_rshift's FIXNUM_P arm for a reducible f_mul(n, 12)", () => {
+describe("a reducible Rational operand at the C's Integer branches", () => {
+  it("takes d_lite_rshift's f_idiv/f_mod arm, never the FIXNUM_P one", () => {
     // ruby 3.3.11 -rdate:
     //   Date.new(2000,1,31).next_year(Rational(1,2)).to_s #=> "2000-07-31"
     //   (Date.new(2000,1,31) >> Rational(1,2)).to_s       #=> "2000-01-31"
     //   (Date.new(2000,1,31) >> Rational(3,2)).to_s       #=> "2000-02-29"
+    //   (Date.new(2000,1,31) >> Rational(23,2)).to_s      #=> "2000-12-31"
     //   Date.new(2000,1,31).next_year(Rational(4,2)).to_s #=> "2002-01-31"
+    // 23/2 is the case that pins the arm: FIX2INT truncates the 11.5 months
+    // f_mod leaves, which is the else arm's arithmetic and not a Fixnum one.
     expect(new RubyDate(2000, 1, 31).nextYear(new Rational(1, 2)).toS()).toBe("2000-07-31");
     expect(new RubyDate(2000, 1, 31).rshift(new Rational(1, 2)).toS()).toBe("2000-01-31");
     expect(new RubyDate(2000, 1, 31).rshift(new Rational(3, 2)).toS()).toBe("2000-02-29");
+    expect(new RubyDate(2000, 1, 31).rshift(new Rational(23, 2)).toS()).toBe("2000-12-31");
     expect(new RubyDate(2000, 1, 31).nextYear(new Rational(4, 2)).toS()).toBe("2002-01-31");
   });
 
   it("takes d_lite_plus's wholenum_p re-dispatch for a whole Rational", () => {
-    // ruby 3.3.11 -rdate: a Rational(2,1) addend is the Integer 2, so the day
-    // is whole and the result is a simple Date — no day_fraction at all.
-    //   (Date.new(2001,1,1) + Rational(2,1)).to_s        #=> "2001-01-03"
-    //   (Date.new(2001,1,1) + Rational(2,1)).jd           #=> 2451913
+    // ruby 3.3.11 -rdate: wholenum_p is a predicate over the denominator, so a
+    // Rational(2,1) addend re-dispatches through rb_rational_num as the Integer
+    // 2 and the sum is a whole day.
+    //   (Date.new(2001,1,1) + Rational(2,1)).to_s #=> "2001-01-03"
+    //   (Date.new(2001,1,1) + Rational(2,1)).jd   #=> 2451913
     const d = new RubyDate(2001, 1, 1).plus(new Rational(2, 1));
     expect(d.toS()).toBe("2001-01-03");
     expect(d.jd).toBe(2451913);

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -1148,6 +1148,25 @@ describe("Date", () => {
     expect(dtNewByFrags({ jd: 2n ** 70n, hour: 1, min: 2, sec: 3 }).toS()).toBe(
       "3232350070754114273-01-08T01:02:03+00:00",
     );
+
+    // A year one CM_PERIOD_GCY (584388) past the residue is the smallest such
+    // day, and it is the one the residue reading answered a plausible date for
+    // — 600000 came back spelled "+015600-..." from every one of these.
+    //   Date.civil(600000, 2, 29).to_s      #=> "600000-02-29"
+    //   Date.ordinal(600000, 60).to_s       #=> "600000-02-29"
+    //   Date.commercial(600000, 9, 6).to_s  #=> "600000-03-04"
+    //   Date.civil(600000, 2, 29).jd        #=> 220866619
+    for (const build of [
+      () => RubyDate.civil(600000, 2, 29),
+      () => RubyDate.ordinal(600000, 60),
+      () => RubyDate.commercial(600000, 9, 6),
+      () => RubyDate.weeknum(600000, 9, 6),
+    ]) {
+      expect(build).toThrow(RubyDate.Error);
+      expect(build).toThrow("invalid date");
+    }
+    expect(dNewByFrags({ year: 600000, yday: 60 }).toS()).toBe("600000-02-29");
+    expect(dNewByFrags({ year: 600000, yday: 60 }).jd).toBe(220866619);
   });
 
   it("takes a start argument, and Date::JULIAN/GREGORIAN select every day", () => {
@@ -2143,5 +2162,35 @@ describe("Date's second registration names", () => {
     expect(RubyDate.isLeap(1900)).toBe(false);
     expect(RubyDate.isLeap(2004)).toBe(true);
     expect(() => RubyDate.isLeap("2000")).toThrow(TypeError);
+  });
+});
+
+/**
+ * `rational.c`'s `rb_rational_canonicalize` folds a denominator of one back to
+ * an Integer, so a reducible Rational reaches `date_core.c`'s `FIXNUM_P` /
+ * `wholenum_p` branches as an Integer. The gem's own tests pass Integers
+ * throughout and never exercise it, which is why these live here.
+ */
+describe("Rational canonicalization at the C's Integer branches", () => {
+  it("takes d_lite_rshift's FIXNUM_P arm for a reducible f_mul(n, 12)", () => {
+    // ruby 3.3.11 -rdate:
+    //   Date.new(2000,1,31).next_year(Rational(1,2)).to_s #=> "2000-07-31"
+    //   (Date.new(2000,1,31) >> Rational(1,2)).to_s       #=> "2000-01-31"
+    //   (Date.new(2000,1,31) >> Rational(3,2)).to_s       #=> "2000-02-29"
+    //   Date.new(2000,1,31).next_year(Rational(4,2)).to_s #=> "2002-01-31"
+    expect(new RubyDate(2000, 1, 31).nextYear(new Rational(1, 2)).toS()).toBe("2000-07-31");
+    expect(new RubyDate(2000, 1, 31).rshift(new Rational(1, 2)).toS()).toBe("2000-01-31");
+    expect(new RubyDate(2000, 1, 31).rshift(new Rational(3, 2)).toS()).toBe("2000-02-29");
+    expect(new RubyDate(2000, 1, 31).nextYear(new Rational(4, 2)).toS()).toBe("2002-01-31");
+  });
+
+  it("takes d_lite_plus's wholenum_p re-dispatch for a whole Rational", () => {
+    // ruby 3.3.11 -rdate: a Rational(2,1) addend is the Integer 2, so the day
+    // is whole and the result is a simple Date — no day_fraction at all.
+    //   (Date.new(2001,1,1) + Rational(2,1)).to_s        #=> "2001-01-03"
+    //   (Date.new(2001,1,1) + Rational(2,1)).jd           #=> 2451913
+    const d = new RubyDate(2001, 1, 1).plus(new Rational(2, 1));
+    expect(d.toS()).toBe("2001-01-03");
+    expect(d.jd).toBe(2451913);
   });
 });

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -1134,8 +1134,11 @@ function iGcd(x: bigint, y: bigint): bigint {
  * fractional-hour offset needs: `rb_rational_new` canonicalizes to lowest terms
  * (`rational.c` `nurat_s_canonicalize_internal`), `+` adds an Integer
  * (`rational.c` `nurat_add`), and `numerator`/`denominator` read the parts back
- * out. A Rational never becomes an Integer on its own in Ruby — the caller asks
- * whether the denominator is one and takes the numerator itself.
+ * out. Ruby DOES fold a Rational back to an Integer on its own — every result
+ * passes through `rb_rational_canonicalize` and `Rational(1,2) * 12` is the
+ * Integer `6` — but a TS constructor answers its own class, so the fold lives
+ * in {@link rbRationalCanonicalize} / {@link wholenumP} instead and the ported
+ * bodies that branch on it apply it where the C's `FIXNUM_P` sees it.
  *
  * @noRailsEquivalent PERMANENT — Ruby core, like the `::Date` below it. Rails
  * defines no Rational; it inherits Ruby's, and `Date._parse` answers one for a
@@ -1266,6 +1269,43 @@ export class Rational {
   inspect(): string {
     return `(${this.toString()})`;
   }
+}
+
+/**
+ * @internal `date_core.c` `wholenum_p` (`date_core.c:3183-3206`), true for an
+ * Integer, for a Float that rounds to itself, and for a Rational whose
+ * denominator is one. A JS number is Ruby's Fixnum, Bignum and Float at once,
+ * so `Number.isInteger` is all three of those arms.
+ */
+function wholenumP(x: number | bigint | Rational): boolean {
+  if (typeof x === "number") return Number.isInteger(x);
+  if (typeof x === "bigint") return true;
+  return x.denominator === 1n;
+}
+
+/**
+ * @internal `rational.c` `rb_rational_canonicalize`, which every Rational
+ * arithmetic result passes through: a reduced denominator of one is an INTEGER
+ * to Ruby, not a Rational. `Rational(1,2) * 12` is `6`, and `Rational(9,3)` is
+ * `3` the moment it is built.
+ *
+ * TS cannot spell that in the constructor — a class constructor answers its
+ * class — so a {@link Rational} here stays one and the canonicalization is
+ * applied where Ruby's is observable: to the RESULT of the arithmetic a ported
+ * body then branches on with `FIXNUM_P` ({@link Date#rshift}'s `f_add3`).
+ * Without it that branch has to hand-roll `denominator === 1n`, which is the
+ * shape that made `Date.new(2000,1,31).next_year(Rational(1,2))` read as a
+ * trails-specific workaround rather than as the C's own test.
+ *
+ * A body that tests the ARGUMENT instead branches on {@link wholenumP}, the
+ * name the C uses there (`d_lite_plus`'s `T_RATIONAL` arm, `:6179-6182`).
+ *
+ * The Integer it answers goes through {@link bigNorm}: Ruby has one Integer,
+ * and a numerator past a JS number's exact range is a `bigint` here.
+ */
+function rbRationalCanonicalize(x: number | bigint | Rational): number | bigint | Rational {
+  if (x instanceof Rational && wholenumP(x)) return bigNorm(x.numerator);
+  return x;
 }
 
 /**
@@ -4114,8 +4154,18 @@ function validNthKdayP(
  * and only the conversion to the `Temporal` seat has nowhere to put it.
  *
  * Not exported: it is the seam between the C's Julian day and the substrate.
+ *
+ * The Julian day it takes is the WHOLE one — `encode_jd`'s
+ * (`date_core.c:1404-1412`), not the residue `m_jd` carries. `decode_jd`
+ * (`date_core.c:1393-1402`) splits it back, and a nonzero `nth` is a day at
+ * least one `CM_PERIOD` — `CM_PERIOD_GCY` (584388) Gregorian years — off the
+ * residue, so no `Temporal.PlainDate` (±271821) can hold it and it raises with
+ * the rest. Reading the residue instead silently answers a different,
+ * valid-looking date: `Date.civil(600000, 2, 29)` spelled `+015600-02-29`.
  */
-function plainDateFromJd(rjd: number, sg = DEFAULT_SG): Temporal.PlainDate {
+function plainDateFromJd(jd: number | bigint, sg = DEFAULT_SG): Temporal.PlainDate {
+  const [nth, rjd] = decodeJd(jd);
+  if (nth !== 0n) throw new DateError("invalid date");
   const [y, m, d] = cJdToCivil(rjd, sg);
   try {
     return Temporal.PlainDate.from({ year: y, month: m, day: d }, { overflow: "reject" });
@@ -6642,7 +6692,9 @@ export class Date {
         sf = sf.mul(-1);
       }
     } else {
-      if (other.denominator === 1n) return this.plus(Number(other.numerator));
+      // `wholenum_p(other)` / `rb_rational_num` / `goto again` (`:6179-6182`):
+      // a denominator of one is an Integer to Ruby before the switch ever runs.
+      if (wholenumP(other)) return this.plus(bigNorm(other.numerator));
 
       let s: number;
       if (other.numerator > 0n) s = +1;
@@ -6880,7 +6932,8 @@ export class Date {
    * `Date.new(2000,1,31) >> 1` is 2000-02-29.
    *
    * `other` is any Numeric, so `t` is carried as a {@link Rational}: Ruby
-   * canonicalizes a denominator of 1 back to an Integer, which is what puts
+   * canonicalizes a denominator of 1 back to an Integer
+   * ({@link rbRationalCanonicalize}), which is what puts
    * `Date.new(2000,1,31).next_year(Rational(1,2))` — `f_mul(n, 12)` is `(6/1)`,
    * so `t` is an Integer — on the C's `FIXNUM_P(t)` arm and answers 2000-07-31.
    * The `else` arm is the C's `f_idiv` / `f_mod` pair. Its `FIX2INT` is the
@@ -6893,13 +6946,15 @@ export class Date {
    * same integers off it that the C's Float arithmetic does.
    */
   rshift(other: number | bigint | Rational): this {
-    const t = new Rational(BigInt(this.year) * 12n + BigInt(this.mon - 1), 1).add(
-      typeof other === "number" && !Number.isInteger(other) ? fToR(other) : other,
+    const t = rbRationalCanonicalize(
+      new Rational(BigInt(this.year) * 12n + BigInt(this.mon - 1), 1).add(
+        typeof other === "number" && !Number.isInteger(other) ? fToR(other) : other,
+      ),
     );
     let y: number | bigint;
     let m: number;
-    if (t.denominator === 1n) {
-      const it = t.numerator;
+    if (!(t instanceof Rational)) {
+      const it = BigInt(t);
       y = bigNorm(div(it, 12));
       m = Number(mod(it, 12)) + 1;
     } else {
@@ -7182,7 +7237,7 @@ export class Date {
    * seat, not a seat.
    */
   toDate(): Temporal.PlainDate {
-    return plainDateFromJd(this.mLocalJd(), this.#sg);
+    return plainDateFromJd(encodeJd(this.nth, this.mLocalJd()), this.#sg);
   }
 
   /**

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -1134,11 +1134,13 @@ function iGcd(x: bigint, y: bigint): bigint {
  * fractional-hour offset needs: `rb_rational_new` canonicalizes to lowest terms
  * (`rational.c` `nurat_s_canonicalize_internal`), `+` adds an Integer
  * (`rational.c` `nurat_add`), and `numerator`/`denominator` read the parts back
- * out. Ruby DOES fold a Rational back to an Integer on its own — every result
- * passes through `rb_rational_canonicalize` and `Rational(1,2) * 12` is the
- * Integer `6` — but a TS constructor answers its own class, so the fold lives
- * in {@link rbRationalCanonicalize} / {@link wholenumP} instead and the ported
- * bodies that branch on it apply it where the C's `FIXNUM_P` sees it.
+ * out. A Rational stays a Rational under arithmetic in Ruby — on ruby 3.3.11
+ * `(Rational(1,2) * 12).class` is `Rational`, `(6/1)`, and so is `Rational(9,3)`
+ * — so a ported `FIXNUM_P` branch is NOT reached by a reducible Rational and
+ * this class matches by staying a Rational too. Only `rb_rational_new`, the C
+ * constructor `Date#day_fraction` and `#sec_fraction` answer through, folds a
+ * denominator of one to an Integer; where a body TESTS for that fold it uses
+ * `wholenum_p` ({@link wholenumP}), which is a predicate, not a conversion.
  *
  * @noRailsEquivalent PERMANENT — Ruby core, like the `::Date` below it. Rails
  * defines no Rational; it inherits Ruby's, and `Date._parse` answers one for a
@@ -1284,31 +1286,6 @@ function wholenumP(x: number | bigint | Rational): boolean {
 }
 
 /**
- * @internal `rational.c` `rb_rational_canonicalize`, which every Rational
- * arithmetic result passes through: a reduced denominator of one is an INTEGER
- * to Ruby, not a Rational. `Rational(1,2) * 12` is `6`, and `Rational(9,3)` is
- * `3` the moment it is built.
- *
- * TS cannot spell that in the constructor — a class constructor answers its
- * class — so a {@link Rational} here stays one and the canonicalization is
- * applied where Ruby's is observable: to the RESULT of the arithmetic a ported
- * body then branches on with `FIXNUM_P` ({@link Date#rshift}'s `f_add3`).
- * Without it that branch has to hand-roll `denominator === 1n`, which is the
- * shape that made `Date.new(2000,1,31).next_year(Rational(1,2))` read as a
- * trails-specific workaround rather than as the C's own test.
- *
- * A body that tests the ARGUMENT instead branches on {@link wholenumP}, the
- * name the C uses there (`d_lite_plus`'s `T_RATIONAL` arm, `:6179-6182`).
- *
- * The Integer it answers goes through {@link bigNorm}: Ruby has one Integer,
- * and a numerator past a JS number's exact range is a `bigint` here.
- */
-function rbRationalCanonicalize(x: number | bigint | Rational): number | bigint | Rational {
-  if (x instanceof Rational && wholenumP(x)) return bigNorm(x.numerator);
-  return x;
-}
-
-/**
  * @internal `date_parse.c` `date_zone_to_diff` (`date_parse.c:415-559`): the
  * `:offset` in seconds a `:zone` names. A trailing `standard`, `daylight` or
  * `dst` word comes off first (and `daylight`/`dst` add an hour), then the
@@ -1322,7 +1299,11 @@ function rbRationalCanonicalize(x: number | bigint | Rational): number | bigint 
  *
  * A fractional-hour offset of more than two decimal places is a `Rational`
  * (`date_parse.c:523-528`), and only an integer once its denominator reduces to
- * one — `+9.5555` is `(171999/5)` where `+9.555` is `34398`.
+ * one — `+9.5555` is `(171999/5)` where `+9.555` is `34398`. The C spells that
+ * fold out inline — `if (rb_rational_den(offset) == INT2FIX(1)) offset =
+ * rb_rational_num(offset);` (`date_parse.c:531-534`) — rather than sending
+ * `wholenum_p`, and the test below is that pair, not a missed helper: it is
+ * the only place the port converts rather than branches.
  */
 function dateZoneToDiff(str: string): number | Rational | null {
   let offset: number | Rational | null = null;
@@ -4893,6 +4874,12 @@ function dayToSec(d: Rational): Rational {
  * `DateTime.new(2000,1,1,0,0,0,Rational(2,1)).zone` is `"+48:00"` — two whole
  * days east — rather than the rejection `±DAY_IN_SECONDS` would suggest.
  *
+ * That arm is LIVE, not dead, and the `denominator === 1n` below is not a
+ * missed {@link wholenumP}: Rational arithmetic in Ruby keeps the Rational, so
+ * `day_to_sec(Rational(2,1))` is `(172800/1)` and `k_rational_p(vs)` holds.
+ * Folding it to an Integer here would route the value through `rounded:`
+ * instead and reject `Rational(2,1)` that MRI accepts.
+ *
  * C's `rb_warning("fraction of offset is ignored")` has no port analogue: it
  * writes to stderr under `$VERBOSE` only and is not part of the value.
  */
@@ -6930,32 +6917,39 @@ export class Date {
    * the last day of it is used — the `while` walking `d` down, which is why
    * `Date.new(2000,1,31) >> 1` is 2000-02-29.
    *
-   * `other` is any Numeric, so `t` is carried as a {@link Rational}: Ruby
-   * canonicalizes a denominator of 1 back to an Integer
-   * ({@link rbRationalCanonicalize}), which is what puts
-   * `Date.new(2000,1,31).next_year(Rational(1,2))` — `f_mul(n, 12)` is `(6/1)`,
-   * so `t` is an Integer — on the C's `FIXNUM_P(t)` arm and answers 2000-07-31.
-   * The `else` arm is the C's `f_idiv` / `f_mod` pair. Its `FIX2INT` is the
-   * non-Fixnum `rb_num2int`, which TRUNCATES: `f_mod` is a floor-mod, so the
-   * remainder is non-negative and the truncation is the bigint division below.
-   * That is what keeps `Date.new(2000,1,31) >> Rational(1,2)` on 2000-01-31 and
-   * puts `>> Rational(3,2)` on 2000-02-29 rather than walking into February by
-   * the fraction. A non-integral Float takes the same arm through
-   * {@link fToR}, since `Float#to_r` is exact and `f_idiv` / `f_mod` read the
-   * same integers off it that the C's Float arithmetic does.
+   * `other` is any Numeric, and `f_add3`'s result `t` is a Rational for every
+   * Rational and Float `other`: **Ruby's Rational arithmetic does NOT fold a
+   * denominator of one back to an Integer** — on ruby 3.3.11
+   * `(Rational(1,2) * 12).class` is `Rational`, `(6/1)`. So `FIXNUM_P(t)` is
+   * false for every one of them and the C's `else` arm — `f_idiv` / `f_mod` —
+   * is the only arm they take. `t` is an Integer here exactly when `other` was
+   * one, which is what the first branch tests.
+   *
+   * The `else` arm's `FIX2INT` is the non-Fixnum `rb_num2int`, which
+   * TRUNCATES: `f_mod` is a floor-mod, so the remainder is non-negative and the
+   * truncation is the bigint division below. That is what keeps
+   * `Date.new(2000,1,31) >> Rational(1,2)` on 2000-01-31, puts
+   * `>> Rational(3,2)` on 2000-02-29 rather than walking into February by the
+   * fraction, and `>> Rational(23,2)` on 2000-12-31 — and it is also how
+   * `next_year(Rational(1,2))` reaches 2000-07-31, through this arm rather than
+   * a Fixnum fast path. A non-integral Float takes it through {@link fToR},
+   * since `Float#to_r` is exact and `f_idiv` / `f_mod` read the same integers
+   * off it that the C's Float arithmetic does.
+   *
+   * The Integer arm covers the C's `FIXNUM_P(t)` and the Bignum `t` its `else`
+   * arm also takes: `f_idiv` / `f_mod` over two Integers is the same DIV/MOD
+   * pair, so JS having no Fixnum/Bignum split costs nothing here.
    */
   rshift(other: number | bigint | Rational): this {
-    const t = rbRationalCanonicalize(
-      new Rational(BigInt(this.year) * 12n + BigInt(this.mon - 1), 1).add(
-        typeof other === "number" && !Number.isInteger(other) ? fToR(other) : other,
-      ),
-    );
+    const o = typeof other === "number" && !Number.isInteger(other) ? fToR(other) : other;
+    const base = BigInt(this.year) * 12n + BigInt(this.mon - 1);
+    const t: bigint | Rational =
+      o instanceof Rational ? new Rational(base, 1).add(o) : base + BigInt(o);
     let y: number | bigint;
     let m: number;
     if (!(t instanceof Rational)) {
-      const it = BigInt(t);
-      y = bigNorm(div(it, 12));
-      m = Number(mod(it, 12)) + 1;
+      y = bigNorm(div(t, 12));
+      m = Number(mod(t, 12)) + 1;
     } else {
       const d12 = t.denominator * 12n;
       let q = t.numerator / d12;
@@ -7271,7 +7265,9 @@ export class Date {
    * denominator is a Rational and prints parenthesized, as MRI's
    * `((2451911j,0s,(1000000000/3)n),+0s,2299161j)` for `DateTime.new(2001,1,1) +
    * Rational(1, 86400*3)` shows. Storage here is uniformly a {@link Rational}
-   * where MRI's `sf` is an Integer until it isn't, so `denominator === 1n` is
+   * where MRI's `sf` is an Integer until it isn't — `rb_rational_new`, the C
+   * constructor `sf` is built through, folds a denominator of one where
+   * `Rational()` and Rational arithmetic do not — so `denominator === 1n` is
    * that Integer arm — `0n`, not `(0/1)n`.
    */
   inspect(): string {

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -6594,9 +6594,9 @@ export class Date {
    * the raise. The Rational arm keeps the C's `wholenum_p` / `rb_rational_num`
    * / `goto again` re-dispatch (`:6179-6182`) as {@link wholenumP} over
    * {@link bigNorm}, since a Rational whose denominator reduced to one is an
-   * Integer to Ruby before the switch ever runs. `modf` splits off a Float's fractional part and
-   * leaves the whole one in its out-parameter; JS has no `modf`, so the two
-   * halves are taken separately.
+   * Integer to Ruby before the switch ever runs. `modf` splits off a Float's
+   * fractional part and leaves the whole one in its out-parameter; JS has no
+   * `modf`, so the two halves are taken separately.
    *
    * Both fractional arms end at `d_simple_new_internal` rather than
    * `d_complex_new_internal` only when `!df && f_zero_p(sf) && !m_of(dat)`;

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -6591,9 +6591,10 @@ export class Date {
    * which sends `to_r` to anything else and re-dispatches, is reduced to its
    * `expect_numeric` head ({@link expectNumeric}): the parameter type spells the
    * numeric union, but it does not hold at a JS call site and the gem asserts
-   * the raise. The Rational arm keeps the
-   * C's `wholenum_p` re-dispatch, since a Rational whose denominator reduced to
-   * one is an Integer to Ruby. `modf` splits off a Float's fractional part and
+   * the raise. The Rational arm keeps the C's `wholenum_p` / `rb_rational_num`
+   * / `goto again` re-dispatch (`:6179-6182`) as {@link wholenumP} over
+   * {@link bigNorm}, since a Rational whose denominator reduced to one is an
+   * Integer to Ruby before the switch ever runs. `modf` splits off a Float's fractional part and
    * leaves the whole one in its out-parameter; JS has no `modf`, so the two
    * halves are taken separately.
    *
@@ -6692,8 +6693,6 @@ export class Date {
         sf = sf.mul(-1);
       }
     } else {
-      // `wholenum_p(other)` / `rb_rational_num` / `goto again` (`:6179-6182`):
-      // a denominator of one is an Integer to Ruby before the switch ever runs.
       if (wholenumP(other)) return this.plus(bigNorm(other.numerator));
 
       let s: number;

--- a/scripts/api-compare/lint-call-args.ts
+++ b/scripts/api-compare/lint-call-args.ts
@@ -2,7 +2,7 @@
 /**
  * Ratcheting gate for the call-ARGUMENT parity dimension (RFC 0095).
  *
- * `api:calls` compares the SET OF CALL NAMES a ported body makes, so a body can
+ * `parity:api:calls` compares the SET OF CALL NAMES a ported body makes, so a body can
  * call `where` where Rails calls `where`, hand it a completely different
  * argument list, and stay green. This gate ratchets
  * output/call-arg-mismatches.json — written by compare.ts under `--calls`.

--- a/scripts/parity/README.md
+++ b/scripts/parity/README.md
@@ -43,6 +43,16 @@ pre-split entry means deleting that one row by hand in the same commit.
   mark contract that `lint-assertion-mismatches.ts` enforces, and is not itself
   an entry point.
 
+## The legacy-spelling gate
+
+`lint-legacy-script-names.ts` (`pnpm parity:legacy-names`, and a step in the
+`Rails API/Test Comparison` job) fails on any retired compare-script spelling
+anywhere outside `vendor/rails/` and build output. The deprecated aliases in
+the root `package.json` keep out-of-repo callers working; they are not a
+licence to write the old names in a comment, a doc or a script. The fix for a
+hit is always the `parity:*` spelling — the three-entry allowlist in
+`legacy-script-names.ts` is closed.
+
 ## Baselines, marks and excludes
 
 Every file below records **known, unfixed divergence**. They are all

--- a/scripts/parity/legacy-script-names.test.ts
+++ b/scripts/parity/legacy-script-names.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "vitest";
+import * as fs from "fs/promises";
+import * as os from "os";
 import * as path from "path";
 import { fileURLToPath } from "url";
 import {
   ALLOWED_PATHS,
   LEGACY_SCRIPT_NAMES,
+  SKIPPED_DIRS,
   findLegacyScriptNames,
   isAliasDefinition,
   scanText,
@@ -48,6 +51,31 @@ describe("legacy compare-script name gate", () => {
     expect(isAliasDefinition("package.json", line)).toBe(true);
     expect(isAliasDefinition("packages/date/package.json", line)).toBe(false);
     expect(isAliasDefinition("package.json", `// see pnpm ${spell("api", "extra")}`)).toBe(false);
+  });
+
+  it("skips the sibling tasks repo and every symlink, so CI sees this population", async () => {
+    // `tasks/` is a symlink in a worktree and a real directory on the runner.
+    // Leaving that to chance is what let 3813 story-body references pass here
+    // and fail in CI.
+    expect(SKIPPED_DIRS).toContain("tasks");
+
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "trails-legacy-names-"));
+    try {
+      // A REAL tasks/ directory, which is what the runner has.
+      await fs.mkdir(path.join(root, "tasks"));
+      await fs.writeFile(path.join(root, "tasks", "story.md"), `pnpm ${spell("api", "compare")}\n`);
+      // A symlinked one, which is what a worktree has.
+      const outside = await fs.mkdtemp(path.join(os.tmpdir(), "trails-legacy-names-out-"));
+      await fs.writeFile(path.join(outside, "note.md"), `pnpm ${spell("api", "compare")}\n`);
+      await fs.symlink(outside, path.join(root, "linked"));
+
+      expect(await findLegacyScriptNames(root)).toEqual([]);
+      // ...and the same text IS a hit when it is genuinely in the population.
+      expect((await findLegacyScriptNames(outside)).map((h) => h.file)).toEqual(["note.md"]);
+      await fs.rm(outside, { recursive: true, force: true });
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
   });
 
   it("allowlists exactly the three intentional mentions", () => {

--- a/scripts/parity/legacy-script-names.test.ts
+++ b/scripts/parity/legacy-script-names.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import * as path from "path";
+import { fileURLToPath } from "url";
+import {
+  ALLOWED_PATHS,
+  LEGACY_SCRIPT_NAMES,
+  findLegacyScriptNames,
+  isAliasDefinition,
+  scanText,
+} from "./legacy-script-names.js";
+
+const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+// Assembled the same way the token list is, so this file is not itself a hit.
+const spell = (...parts: string[]): string => parts.join(":");
+
+describe("legacy compare-script name gate", () => {
+  it("flags a retired spelling in a comment", () => {
+    const token = spell("api", "compare");
+    const hits = scanText(`// run \`pnpm ${token}\` first\n`);
+    expect(hits).toEqual([{ line: 1, token, text: `// run \`pnpm ${token}\` first` }]);
+  });
+
+  it("flags each of the retired spellings", () => {
+    for (const token of LEGACY_SCRIPT_NAMES) {
+      expect(scanText(`pnpm ${token}`).map((h) => h.token)).toContain(token);
+    }
+  });
+
+  it("passes the parity:-prefixed forms, whose tails are the legacy names", () => {
+    const current = [
+      spell("parity", "api", "compare"),
+      spell("parity", "api", "calls"),
+      spell("parity", "api", "calls", "report"),
+      spell("parity", "test", "compare"),
+      spell("parity", "schema", "compare"),
+      spell("parity", "fixtures", "compare"),
+    ];
+    expect(scanText(current.join("\n"))).toEqual([]);
+  });
+
+  it("passes the compare directory names, which carry no colon", () => {
+    expect(scanText("scripts/api-compare/compare.ts scripts/test-compare/compare.ts")).toEqual([]);
+  });
+
+  it("passes an alias definition line in the root package.json only", () => {
+    const line = `    "${spell("api", "extra")}": "pnpm ${spell("parity", "api", "extra")}",`;
+    expect(isAliasDefinition("package.json", line)).toBe(true);
+    expect(isAliasDefinition("packages/date/package.json", line)).toBe(false);
+    expect(isAliasDefinition("package.json", `// see pnpm ${spell("api", "extra")}`)).toBe(false);
+  });
+
+  it("allowlists exactly the three intentional mentions", () => {
+    expect([...ALLOWED_PATHS.keys()]).toEqual([
+      "CLAUDE.md",
+      "scripts/parity/README.md",
+      "docs/infrastructure/prism-codegen-spike.md",
+    ]);
+  });
+
+  it("finds no reintroduced spelling in the tree", async () => {
+    const hits = await findLegacyScriptNames(ROOT_DIR);
+    expect(hits.map((h) => `${h.file}:${h.line} ${h.token}`)).toEqual([]);
+  }, 60_000);
+});

--- a/scripts/parity/legacy-script-names.ts
+++ b/scripts/parity/legacy-script-names.ts
@@ -1,0 +1,183 @@
+/**
+ * The legacy compare-script spellings RFC 0092 retired, and the scan that keeps
+ * them from coming back.
+ *
+ * `retire-legacy-compare-script-aliases` (#6305) moved every in-repo reference
+ * onto `parity:*`; the aliases left in the root `package.json` are a shim for
+ * out-of-repo callers and are deleted by `delete-legacy-compare-script-aliases`.
+ * Over the three days #6305 was open, sibling PRs merged SEVEN fresh references
+ * into `main` that only a hand grep after each rebase caught. Once the shim goes,
+ * a reintroduced spelling stops being a stale doc and becomes a broken command
+ * in a comment someone copy-pastes.
+ *
+ * The tokens are ASSEMBLED from their halves rather than written out, so this
+ * file and its test are not themselves matches and need no allowlist entry.
+ *
+ * Hard rules: no node:* imports, no process.* in the library surface (the CLI
+ * entry guard in the lint entry point is the sole exception), async fs only.
+ */
+
+import * as fs from "fs/promises";
+import * as path from "path";
+
+const SEP = ":";
+
+/**
+ * The retired spellings, halves joined so the literals never appear in this
+ * file. Only the STEMS are listed: a token is matched as a substring, so each
+ * one covers its own suffixed variants (the report, reseed, wide and all
+ * flavours) without a row of its own.
+ */
+export const LEGACY_SCRIPT_NAMES: readonly string[] = [
+  ["api", "compare"],
+  ["api", "drift"],
+  ["api", "extra"],
+  ["api", "build"],
+  ["api", "reasons"],
+  ["api", "detached"],
+  ["api", "calls"],
+  ["api", "arity"],
+  ["api", "inheritance"],
+  ["api", "pins"],
+  ["api", "moves"],
+  ["api", "conventions"],
+  ["lint", "deps"],
+  ["test", "compare"],
+  ["test", "assertions", "ratchet"],
+  ["test", "stubs"],
+  ["fixtures", "compare"],
+  ["schema", "compare"],
+].map((parts) => parts.join(SEP));
+
+/**
+ * The three intentional mentions, each a deprecation note or a historical
+ * reference with no `parity:*` counterpart. Nothing else may name a legacy
+ * spelling — this list is not where a new reference goes.
+ */
+export const ALLOWED_PATHS: ReadonlyMap<string, string> = new Map([
+  ["CLAUDE.md", "the deprecation notice that tells contributors to write parity:* instead"],
+  ["scripts/parity/README.md", "the same notice, in the tooling's own README (line 5)"],
+  [
+    "docs/infrastructure/prism-codegen-spike.md",
+    "historical mentions of the wide call gate — RFC 0084 deleted that script and it has no parity:* counterpart",
+  ],
+]);
+
+/** Directories the scan never descends into: upstream Ruby and build output. */
+export const SKIPPED_DIRS: readonly string[] = ["node_modules", "dist", ".git", "coverage"];
+
+/** `vendor/rails` is upstream Ruby; the rest of `vendor/` (README.md, fetch.ts,
+ *  sources.ts) IS in scope — excluding `vendor/` wholesale is the miss the #6305
+ *  review caught. */
+export const SKIPPED_PATHS: readonly string[] = [
+  path.join("vendor", "rails"),
+  // Gitignored compare artifacts — generated, gigantic, and rewritten by the
+  // steps that run before this gate in CI.
+  path.join("scripts", "api-compare", "output"),
+  path.join("scripts", "test-compare", "output"),
+  path.join("scripts", "fixtures-compare", "output"),
+  path.join("scripts", "schema-compare", "output"),
+];
+
+const TEXT_EXTENSIONS = new Set([
+  ".ts",
+  ".tsx",
+  ".js",
+  ".mjs",
+  ".cjs",
+  ".json",
+  ".md",
+  ".yml",
+  ".yaml",
+  ".sh",
+  ".rb",
+  ".txt",
+]);
+
+export interface LegacyNameHit {
+  /** Repo-relative path, POSIX-separated. */
+  file: string;
+  /** 1-indexed. */
+  line: number;
+  token: string;
+  text: string;
+}
+
+/**
+ * True for a root-`package.json` line that DEFINES an alias — a legacy key
+ * whose value is the `pnpm parity:*` it delegates to. The shim still exists, so
+ * its own keys are not violations; any other line of that file is.
+ */
+export function isAliasDefinition(file: string, text: string): boolean {
+  if (file !== "package.json") return false;
+  return /^\s*"[a-z:]+"\s*:\s*"pnpm parity:/.test(text);
+}
+
+/**
+ * Every legacy spelling in `text`. A token preceded by the `parity` prefix is
+ * the CURRENT name — every current name has a legacy one as its tail — and is
+ * not a hit.
+ */
+export function scanText(text: string): { line: number; token: string; text: string }[] {
+  const hits: { line: number; token: string; text: string }[] = [];
+  const lines = text.split("\n");
+  for (const [i, line] of lines.entries()) {
+    for (const token of LEGACY_SCRIPT_NAMES) {
+      let from = 0;
+      for (;;) {
+        const at = line.indexOf(token, from);
+        if (at === -1) break;
+        from = at + 1;
+        if (line.slice(0, at).endsWith(`parity${SEP}`)) continue;
+        hits.push({ line: i + 1, token, text: line.trim() });
+        break;
+      }
+    }
+  }
+  return hits;
+}
+
+async function walk(dir: string, root: string, out: string[]): Promise<void> {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    const rel = path.relative(root, full);
+    if (entry.isDirectory()) {
+      if (SKIPPED_DIRS.includes(entry.name)) continue;
+      if (SKIPPED_PATHS.includes(rel)) continue;
+      await walk(full, root, out);
+    } else if (entry.isFile() && TEXT_EXTENSIONS.has(path.extname(entry.name))) {
+      out.push(rel);
+    }
+  }
+}
+
+/** Every violation under `root`, allowlist and alias shim applied. */
+export async function findLegacyScriptNames(root: string): Promise<LegacyNameHit[]> {
+  const files: string[] = [];
+  await walk(root, root, files);
+  files.sort();
+
+  const hits: LegacyNameHit[] = [];
+  for (const file of files) {
+    const posix = file.split(path.sep).join("/");
+    if (ALLOWED_PATHS.has(posix)) continue;
+    const text = await fs.readFile(path.join(root, file), "utf8");
+    for (const hit of scanText(text)) {
+      if (isAliasDefinition(posix, hit.text)) continue;
+      hits.push({ file: posix, ...hit });
+    }
+  }
+  return hits;
+}
+
+export function reportHits(hits: readonly LegacyNameHit[]): string {
+  const lines = hits.map((h) => `  ${h.file}:${h.line}  ${h.token}\n      ${h.text}`);
+  return (
+    `\nlegacy compare-script spellings: ${hits.length} reference(s) reintroduced.\n\n` +
+    `${lines.join("\n")}\n\n` +
+    `Every one of these is retired (RFC 0092). Write the parity:* spelling ` +
+    `instead — parity:api, parity:api:calls, parity:test, parity:fixtures, ` +
+    `parity:schema and friends.\n`
+  );
+}

--- a/scripts/parity/legacy-script-names.ts
+++ b/scripts/parity/legacy-script-names.ts
@@ -63,8 +63,24 @@ export const ALLOWED_PATHS: ReadonlyMap<string, string> = new Map([
   ],
 ]);
 
-/** Directories the scan never descends into: upstream Ruby and build output. */
-export const SKIPPED_DIRS: readonly string[] = ["node_modules", "dist", ".git", "coverage"];
+/**
+ * Directories the scan never descends into: build output, and `tasks/` — the
+ * separate work-tracking repo `start-worktree.sh` places inside the worktree.
+ * Its several thousand story bodies are prose ABOUT past work, live in another
+ * repo's history, and are not references this repo can fix.
+ *
+ * `tasks/` is a symlink locally and a real directory in CI, so it has to be
+ * named rather than left to fall out of the symlink handling below — a
+ * population that differs between the two is how a gate passes locally and
+ * fails on the runner.
+ */
+export const SKIPPED_DIRS: readonly string[] = [
+  "node_modules",
+  "dist",
+  ".git",
+  "coverage",
+  "tasks",
+];
 
 /** `vendor/rails` is upstream Ruby; the rest of `vendor/` (README.md, fetch.ts,
  *  sources.ts) IS in scope — excluding `vendor/` wholesale is the miss the #6305
@@ -142,6 +158,9 @@ async function walk(dir: string, root: string, out: string[]): Promise<void> {
   for (const entry of entries) {
     const full = path.join(dir, entry.name);
     const rel = path.relative(root, full);
+    // A symlink is neither followed nor read: it resolves outside the tree as
+    // often as not, and following one would double-count or wander off it.
+    if (entry.isSymbolicLink()) continue;
     if (entry.isDirectory()) {
       if (SKIPPED_DIRS.includes(entry.name)) continue;
       if (SKIPPED_PATHS.includes(rel)) continue;

--- a/scripts/parity/legacy-script-names.ts
+++ b/scripts/parity/legacy-script-names.ts
@@ -68,11 +68,11 @@ export const SKIPPED_DIRS: readonly string[] = ["node_modules", "dist", ".git", 
 
 /** `vendor/rails` is upstream Ruby; the rest of `vendor/` (README.md, fetch.ts,
  *  sources.ts) IS in scope — excluding `vendor/` wholesale is the miss the #6305
- *  review caught. */
+ *  review caught. The `output/` dirs are gitignored compare artifacts —
+ *  generated, gigantic, and rewritten by the CI steps that run before this
+ *  gate. */
 export const SKIPPED_PATHS: readonly string[] = [
   path.join("vendor", "rails"),
-  // Gitignored compare artifacts — generated, gigantic, and rewritten by the
-  // steps that run before this gate in CI.
   path.join("scripts", "api-compare", "output"),
   path.join("scripts", "test-compare", "output"),
   path.join("scripts", "fixtures-compare", "output"),

--- a/scripts/parity/lint-legacy-script-names.ts
+++ b/scripts/parity/lint-legacy-script-names.ts
@@ -1,0 +1,43 @@
+#!/usr/bin/env npx tsx
+/**
+ * Gate against reintroduced legacy compare-script spellings (RFC 0092):
+ *
+ *   pnpm parity:legacy-names
+ *
+ * Population is the whole tree bar upstream Ruby and build output; the three
+ * intentional mentions are allowlisted in `legacy-script-names.ts`, which is
+ * also where the retired tokens live. There is no `--write`: the fix for a hit
+ * is the `parity:*` spelling, never a new allowlist row.
+ */
+
+import * as path from "path";
+import { fileURLToPath } from "url";
+import { findLegacyScriptNames, reportHits } from "./legacy-script-names.js";
+
+const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+async function main(): Promise<number> {
+  const hits = await findLegacyScriptNames(ROOT_DIR);
+  if (hits.length > 0) {
+    console.error(reportHits(hits));
+    return 1;
+  }
+  console.log("legacy compare-script spellings: OK (none reintroduced)");
+  return 0;
+}
+
+async function runAsScript(): Promise<void> {
+  const self = fileURLToPath(import.meta.url);
+  const invoked = process.argv[1] ? path.resolve(process.argv[1]) : "";
+  if (path.resolve(self) !== invoked) return;
+  let code: number;
+  try {
+    code = await main();
+  } catch (e) {
+    console.error(`\nlegacy compare-script spellings: ${(e as Error).message}\n`);
+    code = 1;
+  }
+  process.exit(code);
+}
+
+void runAsScript();


### PR DESCRIPTION
Four stories from one bundle. The fifth, `temporal-seat-loses-the-absolute-day-for-week-readers`, is **blocked** — see the bottom.

### `date-seat-drops-nth-and-spells-the-residue-year`

`Date#to_date` was `plainDateFromJd(this.mLocalJd(), sg)`, and `m_local_jd` is the RESIDUE Julian day: the `nth` `decode_jd` splits off (`date_core.c:1393-1402`) was dropped, so every static over the `Temporal.PlainDate` seat answered a different, valid-looking date for a year past one `CM_PERIOD` — `Date.civil(600000, 2, 29)` came back `+015600-02-29` where MRI has `600000-02-29`.

`plainDateFromJd` now takes `encode_jd`'s whole day (`date_core.c:1404-1412`) and raises `Date::Error, "invalid date"` for a nonzero `nth`: that is at least `CM_PERIOD_GCY` (584388) years off the residue and `Temporal.PlainDate` stops at ±271821, so no value exists. The gem-shaped path is untouched — `dNewByFrags({ year: 600000, yday: 60 })` still answers `600000-02-29` / jd 220866619.

### `rational-does-not-canonicalize-denominator-one-to-integer`

**The story's premise is false, and the convergence is the opposite of what it asked for.** The first review round asked about three untouched `denominator === 1n` sites; checking them sent me to `ruby 3.3.11` (it is on PATH here), which disproves the claim the story, my memory of #6321's review, and this PR's first commit were all built on:

```ruby
(Rational(1,2) * 12)      #=> (6/1)   -- class Rational, NOT Integer 6
Rational(9,3)             #=> (3/1)   -- class Rational
```

Ruby's Rational arithmetic does **not** fold a denominator of one back to an Integer. So `d_lite_rshift`'s `FIXNUM_P(t)` (`:6441-6478`) is false for every Rational `other`, and MRI always takes the `f_idiv` / `f_mod` **else** arm — its `FIX2INT` truncation is what produces the answers, verified end to end:

```ruby
Date.new(2000,1,31).next_year(Rational(1,2)).to_s  #=> "2000-07-31"
(Date.new(2000,1,31) >> Rational(1,2)).to_s        #=> "2000-01-31"
(Date.new(2000,1,31) >> Rational(3,2)).to_s        #=> "2000-02-29"
(Date.new(2000,1,31) >> Rational(23,2)).to_s       #=> "2000-12-31"   # 11.5 -> 11
```

Both the pre-PR code and my first commit routed a reducible Rational to the **Fixnum** arm — a branch MRI never takes. `rshift` now builds `t` as an Integer exactly when `other` was one, which is what `FIXNUM_P(t)` means, and `rbRationalCanonicalize` is **deleted**: the port must not perform a fold Ruby does not. `>> Rational(23,2)` is added as the case that separates the arms.

`wholenumP` stays. `wholenum_p` (`date_core.c:3183-3206`) is a real predicate the C sends at `d_lite_plus`'s `T_RATIONAL` arm before `rb_rational_num` + `goto again` (`:6179-6182`) — a test, not a conversion — and `Date#plus` branches on it.

**The three sites from the review** are each justified at their call site now; none is a missed helper:

| Site | Why it stays |
| --- | --- |
| `date_zone_to_diff` (`:1396`) | mirrors the C's own inline fold, spelled out at `date_parse.c:531-534` rather than sent as a helper |
| `offset_to_sec` (`:4706`) | the **live** `FIXNUM_P(vn) && vd == 1` arm (`:2421-2422`). Arithmetic keeps the Rational, so `day_to_sec(Rational(2,1))` is `(172800/1)` and this arm skips the ±`DAY_IN_SECONDS` bound — which is why MRI answers `"+48:00"`. Folding here would **reject an offset MRI accepts** |
| `inspect` (`:7046`) | reads `sf`, built through `rb_rational_new` — the one constructor that *does* fold — so the Integer arm is the display MRI produces |

That last distinction also retracts a follow-up I filed earlier in this PR: `day-fraction-reader-answers-a-number-on-the-whole-day-arm` is closed as invalid, because `(Date.new(2001,1,1) + Rational(2,1)).day_fraction` **is** the Integer `0` in MRI and trails already matches.

**Sibling audit.** `d_lite_cmp` / `cmp_gen` / `equal_gen` compare through `Rational#cmp`, which is fold-agnostic. `fixnumP`'s callers (`decode_year`, `guess_style`) take `number | bigint` only. Nothing else in `date.ts` branches on a Numeric's Rational-ness.

The `Rational` class doc claimed a Rational "never becomes an Integer on its own in Ruby". That was right about arithmetic and wrong about `rb_rational_new`; it now says which is which.

### `sqlite-add-index-expresses-schema-qualified-index-name`

SQLite puts an ATTACHed schema on the INDEX name, not the table it indexes, and qualifying the table is a syntax error. `SQLite3::SchemaCreation#visit_CreateIndexDefinition` now emits `CREATE INDEX "aux"."by_name" ON "widgets" (...)` for a qualified table and defers to the inherited body otherwise, so `copy_table_indexes` is one unconditional `add_index` call exactly as `sqlite3_adapter.rb:674` has it. The hand-built statement and its branch-local `MISSING RAILS CALL` comment are gone; no baseline row added, `parity:api:calls` green.

An ATTACHed-schema case pins the emission, in `sqlite3-introspection.test.ts` rather than `copy-table.trails.test.ts`: that suite already owns the qualified-name cases (including the sibling `alterTable` over `aux.widgets` with a custom index name) and runs on a throwaway file-backed adapter, so it needs no bespoke table next to canonical fixtures and no `usesTransaction` escape for the ATTACH/DETACH the savepoint wrapper refuses. `copy-table.trails.test.ts` is unchanged and green.

It also cannot pass an implicit index name: the DEFAULT name embeds the qualifier (`index_aux.customers_on_name`) and blows up on the dot — filed as `sqlite-default-index-name-embeds-the-schema-qualifier`.

### `guard-against-legacy-compare-script-spellings`

`pnpm parity:legacy-names` / `scripts/parity/lint-legacy-script-names.ts`, wired into the `Rails API/Test Comparison` job. Whole tree bar `vendor/rails/`, `node_modules/`, `dist/` and the gitignored compare artifacts; `vendor/{README.md,fetch.ts,sources.ts}` are in scope. A `parity:`-prefixed form is not a hit, the compare DIRECTORY names carry no colon so they never match, and an alias-definition line in the root `package.json` is exempt while the shim exists.

The token list is assembled from its halves at runtime, so the gate's own source and test are not matches and need no allowlist entry — the allowlist is exactly the three sanctioned mentions and the test pins that it stays three.

### Blocked: `temporal-seat-loses-the-absolute-day-for-week-readers`

Its two acceptance criteria are mutually exclusive, so it needs an RFC 0088 decision before any code:

1. Temporal has no `julian` calendar (`@js-temporal/polyfill` rejects it; CLDR ships `gregory`/`iso8601`), so every `PlainDate` reads as one absolute day `A(p)`.
2. `dayOfWeek(p) = A(p) mod 7` and MRI's `cwday` is `(jd+1) mod 7` under every `sg`, so criterion 1 — the commercial triple of `Date.commercial(-4712, 1, 1)` under ITALY, i.e. the Julian side — forces `A(p) = jd`.
3. Criterion 2 wants `Date.ordinal(1900, -2, Date::JULIAN)`'s `yday` = 365. With `A(p) = jd` the value is the Gregorian `1901-01-12`, whose `dayOfYear` is 12; the only `PlainDate` with `dayOfYear` 365 is the Julian SPELLING `1900-12-30`, 13 days off `jd`, whose `dayOfWeek` is 7 where MRI's is 6.

So the criteria demand `A(p) = jd` and `A(p) ≠ jd`. The story's cheapest option is (2) and fails (3); the remaining one is the gem-shaped return, which is the RFC's undecided Ruby opt-in and which the story itself forbids doing wholesale. Recommendation left on the story: generalize the existing `date-to-date-seat-raises-on-julian-only-spellings` precedent so `to_date` raises for any day the receiver's `sg` puts on the Julian side, and restate the criteria as "raises".

Closes-story: date-seat-drops-nth-and-spells-the-residue-year
Closes-story: rational-does-not-canonicalize-denominator-one-to-integer
Closes-story: sqlite-add-index-expresses-schema-qualified-index-name
Closes-story: guard-against-legacy-compare-script-spellings

