### PR TITLE
feat(scripts): record the advisory call + call-arg parity numbers in stats

### DIFF
--- a/scripts/sync-stats/parse-call-summaries.test.ts
+++ b/scripts/sync-stats/parse-call-summaries.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { parseCallSummariesFromLogs } from "./parse-call-summaries.js";
+
+// The tail of a `compare.ts --calls` run: the grand-total block, where both
+// advisory summaries are printed once for the whole repo.
+const callsLog = `
+  Overall: 12345/12345 methods (100%)  |  files: 500/500
+  Option keys (advisory): 112 pairs compared, 17 with keys missing in TS (likely-real), 72 differ total — see output/options-key-mismatches.json
+  Calls (advisory): 6213 matched pairs checked, 1494 omit a ported-method call Rails makes — see output/call-mismatches.json
+  Call args (advisory): 812 call sites compared, 96 pass different arguments — see output/call-arg-mismatches.json
+`;
+
+// Every log stored before the call-arg artifact existed: calls, no call args.
+const callsOnlyLog = `
+  Calls (advisory): 6213 matched pairs checked, 1494 omit a ported-method call Rails makes — see output/call-mismatches.json
+`;
+
+describe("parseCallSummariesFromLogs", () => {
+  it("derives matched/total/percent from both advisory summaries", () => {
+    const { calls, callArgs } = parseCallSummariesFromLogs(callsLog);
+
+    expect(calls).toEqual({ matched: 4719, total: 6213, percent: 76, mismatched: 1494 });
+    expect(callArgs).toEqual({ matched: 716, total: 812, percent: 88.2, mismatched: 96 });
+  });
+
+  it("returns null for a summary the log does not carry", () => {
+    const { calls, callArgs } = parseCallSummariesFromLogs(callsOnlyLog);
+
+    expect(calls?.total).toBe(6213);
+    expect(callArgs).toBeNull();
+  });
+
+  it("returns null for both when the step never ran", () => {
+    expect(parseCallSummariesFromLogs("")).toEqual({ calls: null, callArgs: null });
+  });
+
+  // A zero denominator would make percent NaN and poison the chart.
+  it("ignores a summary with nothing compared", () => {
+    const log =
+      "  Calls (advisory): 0 matched pairs checked, 0 omit a ported-method call Rails makes\n";
+
+    expect(parseCallSummariesFromLogs(log).calls).toBeNull();
+  });
+});

--- a/scripts/sync-stats/parse-call-summaries.ts
+++ b/scripts/sync-stats/parse-call-summaries.ts
@@ -1,0 +1,53 @@
+/**
+ * Parse the two advisory call summaries the `--calls` run prints at the end of
+ * its output (compare.ts, grand-total block):
+ *
+ *   Calls (advisory): 6213 matched pairs checked, 1494 omit a ported-method call Rails makes
+ *   Call args (advisory): 812 call sites compared, 96 pass different arguments
+ *
+ * Both are whole-repo totals — compare.ts tallies them across packages and
+ * prints them once — so each yields a single row rather than one per package.
+ * `matched` is derived (compared - mismatched) so the rows carry the same
+ * matched/total/percent shape as every other stats table, and the parity page
+ * can chart them without a special case.
+ *
+ * Returns null for a summary the log doesn't carry: `Call args` only prints
+ * when the call-arg artifact exists, so an older log has calls but no args.
+ */
+export function parseCallSummariesFromLogs(logs: string): {
+  calls: CallSummary | null;
+  callArgs: CallSummary | null;
+} {
+  return {
+    calls: matchCallSummary(
+      logs,
+      /Calls \(advisory\): (\d+) matched pairs checked, (\d+) omit a ported-method call/,
+    ),
+    callArgs: matchCallSummary(
+      logs,
+      /Call args \(advisory\): (\d+) call sites compared, (\d+) pass different arguments/,
+    ),
+  };
+}
+
+export interface CallSummary {
+  matched: number;
+  total: number;
+  percent: number;
+  mismatched: number;
+}
+
+function matchCallSummary(logs: string, re: RegExp): CallSummary | null {
+  const m = re.exec(logs);
+  if (!m) return null;
+  const total = parseInt(m[1]);
+  const mismatched = parseInt(m[2]);
+  if (total <= 0) return null;
+  const matched = total - mismatched;
+  return {
+    matched,
+    total,
+    percent: Math.round((matched / total) * 1000) / 10,
+    mismatched,
+  };
+}

--- a/scripts/sync-stats/sync.ts
+++ b/scripts/sync-stats/sync.ts
@@ -6,6 +6,7 @@ import { Base } from "@blazetrails/activerecord";
 import type { SQLite3Adapter } from "@blazetrails/activerecord/connection-adapters/sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "@blazetrails/activerecord/connection-adapters/better-sqlite3-adapter.js";
 import { parseTestCompareFromLogs } from "./parse-test-compare.js";
+import { parseCallSummariesFromLogs } from "./parse-call-summaries.js";
 
 const REPO = "blazetrailsdev/trails";
 const [REPO_OWNER, REPO_NAME] = REPO.split("/");
@@ -376,6 +377,38 @@ class ApiComparePrivatesStat extends Base {
   }
 }
 
+// The two advisory call summaries the --calls run prints. Whole-repo totals, so
+// every row is package "all" — kept as a column anyway so these tables have the
+// same shape as the other stats tables (and so a future per-package breakdown
+// slots in without a migration).
+class ApiCallsStat extends Base {
+  static {
+    this.tableName = "api_calls_stats";
+    this.attribute("id", "big_integer");
+    this.attribute("merge_commit_sha", "string");
+    this.attribute("pr_number", "integer");
+    this.attribute("package", "string");
+    this.attribute("matched", "integer");
+    this.attribute("total", "integer");
+    this.attribute("percent", "float");
+    this.attribute("mismatched", "integer", { default: 0 });
+  }
+}
+
+class ApiCallArgsStat extends Base {
+  static {
+    this.tableName = "api_call_args_stats";
+    this.attribute("id", "big_integer");
+    this.attribute("merge_commit_sha", "string");
+    this.attribute("pr_number", "integer");
+    this.attribute("package", "string");
+    this.attribute("matched", "integer");
+    this.attribute("total", "integer");
+    this.attribute("percent", "float");
+    this.attribute("mismatched", "integer", { default: 0 });
+  }
+}
+
 class CompareLog extends Base {
   static {
     this.tableName = "compare_logs";
@@ -620,6 +653,20 @@ async function migrateDb(adapter: SQLite3Adapter) {
       });
     }
 
+    for (const table of ["api_calls_stats", "api_call_args_stats"]) {
+      if (await tableExists(adapter, table)) continue;
+      await adapter.createTable(table, {}, (t) => {
+        t.string("merge_commit_sha");
+        t.integer("pr_number");
+        t.string("package");
+        t.integer("matched");
+        t.integer("total");
+        t.float("percent");
+        t.integer("mismatched", { default: 0 });
+        t.index(["merge_commit_sha", "package"], { unique: true });
+      });
+    }
+
     if (!(await tableExists(adapter, "api_compare_privates_stats"))) {
       await adapter.createTable("api_compare_privates_stats", {}, (t) => {
         t.string("merge_commit_sha");
@@ -835,6 +882,28 @@ async function migrateDb(adapter: SQLite3Adapter) {
       t.integer("total");
       t.float("percent");
       t.integer("missing", { default: 0 });
+      t.index(["merge_commit_sha", "package"], { unique: true });
+    });
+
+    await adapter.createTable("api_calls_stats", {}, (t) => {
+      t.string("merge_commit_sha");
+      t.integer("pr_number");
+      t.string("package");
+      t.integer("matched");
+      t.integer("total");
+      t.float("percent");
+      t.integer("mismatched", { default: 0 });
+      t.index(["merge_commit_sha", "package"], { unique: true });
+    });
+
+    await adapter.createTable("api_call_args_stats", {}, (t) => {
+      t.string("merge_commit_sha");
+      t.integer("pr_number");
+      t.string("package");
+      t.integer("matched");
+      t.integer("total");
+      t.float("percent");
+      t.integer("mismatched", { default: 0 });
       t.index(["merge_commit_sha", "package"], { unique: true });
     });
 
@@ -1717,7 +1786,16 @@ function extractStepLogs(rawLog: string): Map<string, string> {
     let stepName: string | null = null;
 
     if (command.includes("api-compare/compare.ts")) {
-      stepName = command.includes("--privates") ? "api_compare_privates" : "api_compare";
+      // The --calls run prints the same per-package table as the plain run, so
+      // it must be classified BEFORE falling through to "api_compare" —
+      // otherwise it overwrites the public-API step's log (it appears later in
+      // the job) and the api_compare_stats feed silently becomes the
+      // full-surface numbers.
+      stepName = command.includes("--privates")
+        ? "api_compare_privates"
+        : command.includes("--calls")
+          ? "api_calls"
+          : "api_compare";
     } else if (
       command.includes("test-compare/compare.ts") ||
       // Pre-RFC-0092 entry-point names, kept so historic logs still parse.
@@ -1949,6 +2027,16 @@ const MISSING_STATS_PREDICATE = `
           WHERE acps.merge_commit_sha = rjl.merge_commit_sha
         )
       )
+      OR (
+        -- Same shape as the privates gate: only expect calls stats from a job
+        -- that actually ran the --calls step, so pre-RFC-0095 logs don't make
+        -- --refresh reprocess the whole history on every run.
+        rjl.log_output LIKE '%compare.ts --calls%'
+        AND NOT EXISTS (
+          SELECT 1 FROM api_calls_stats acls
+          WHERE acls.merge_commit_sha = rjl.merge_commit_sha
+        )
+      )
       OR EXISTS (
         WITH expected(step_name, required) AS (
           VALUES
@@ -2089,6 +2177,43 @@ async function syncCompareStats(
       );
     }
 
+    // Advisory call summaries. Whole-repo totals printed once by the --calls
+    // run, so one row each, under package "all".
+    const callsStepLog = stepLogs.get("api_calls") ?? "";
+    const { calls, callArgs } = parseCallSummariesFromLogs(callsStepLog);
+    if (calls) {
+      await ApiCallsStat.upsertAll(
+        [
+          {
+            merge_commit_sha: headSha,
+            pr_number: prNumber,
+            package: "all",
+            matched: calls.matched,
+            total: calls.total,
+            percent: calls.percent,
+            mismatched: calls.mismatched,
+          },
+        ],
+        { uniqueBy: ["merge_commit_sha", "package"] },
+      );
+    }
+    if (callArgs) {
+      await ApiCallArgsStat.upsertAll(
+        [
+          {
+            merge_commit_sha: headSha,
+            pr_number: prNumber,
+            package: "all",
+            matched: callArgs.matched,
+            total: callArgs.total,
+            percent: callArgs.percent,
+            mismatched: callArgs.mismatched,
+          },
+        ],
+        { uniqueBy: ["merge_commit_sha", "package"] },
+      );
+    }
+
     if (stepLogs.size > 0 || testStats.size > 0 || apiStats.size > 0 || apiPrivatesStats.size > 0) {
       parsed++;
       const totalTests = [...testStats.values()].reduce((sum, s) => sum + s.matched, 0);
@@ -2098,8 +2223,10 @@ async function syncCompareStats(
         0,
       );
       const logSteps = [...stepLogs.keys()].join(", ");
+      const callsNote = calls ? `, calls ${calls.matched}/${calls.total}` : "";
+      const argsNote = callArgs ? `, call args ${callArgs.matched}/${callArgs.total}` : "";
       console.log(
-        `  PR #${prNumber}: ${testStats.size} test packages (${totalTests} matched), ${apiStats.size} api packages (${totalApi} matched), ${apiPrivatesStats.size} api-privates packages (${totalApiPrivates} matched), logs: [${logSteps}]`,
+        `  PR #${prNumber}: ${testStats.size} test packages (${totalTests} matched), ${apiStats.size} api packages (${totalApi} matched), ${apiPrivatesStats.size} api-privates packages (${totalApiPrivates} matched)${callsNote}${argsNote}, logs: [${logSteps}]`,
       );
     }
   }


### PR DESCRIPTION
## Why

The `compare.ts --calls` run prints two advisory summaries at the end of its output:

```
Calls (advisory): 6213 matched pairs checked, 1494 omit a ported-method call Rails makes
Call args (advisory): 812 call sites compared, 96 pass different arguments
```

The stats sync threw both away, so there is no way to chart call parity over time — the numbers exist only inside `raw_job_logs`, which is too coarse to query per day. ringo's parity page charts tables, so it needs these as rows.

## What

- **`extractStepLogs` classifies `compare.ts --calls` as its own `api_calls` step.** It was falling through to `"api_compare"` and, since the calls step appears later in the job than the public run, overwriting that step's log — so `api_compare_stats` has been parsed from the full-surface (public + private) numbers since the calls step landed. Currently invisible, because every package the run covers is at 100% in all three variants, but it is a real mislabeling and it blocks parsing the calls step at all.
- **`parse-call-summaries.ts`** turns each summary line into a `matched` / `total` / `percent` / `mismatched` row, deriving `matched = compared - mismatched` so the rows carry the same shape as every other stats table and consumers need no special case. Both are whole-repo totals (compare.ts tallies them across packages and prints them once), so each is a single row under package `"all"` — the column stays so a future per-package breakdown slots in without a migration.
- **`api_calls_stats` / `api_call_args_stats`**, created on both the fresh-DB and existing-DB paths, and gated in `MISSING_STATS_PREDICATE` the same way the `--privates` step is, so pre-RFC-0095 logs don't make `--refresh` reprocess the whole history every run.

`Call args` is parsed independently of `Calls` and returns null when absent — older logs carry the first line but not the second.

## Verification

`parse-call-summaries.test.ts` covers both summaries, a log with calls but no args, an absent step, and a zero denominator (which would otherwise make `percent` NaN and poison the chart).

Run against the real DB, the sync produces sane numbers: calls at **4730/6217 (76.1%)** and call args at **4038/5660 (71.3%)** for the most recent PRs.

Backfill the ~970 stored logs with `stats:sync --reparse-logs`.