### PR TITLE
feat(date): check_limit measures UTF-8 bytes, TestSH tail port; fix(activerecord): sqlite active() drains a deferred disconnect

### DIFF
--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-perform-query.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-perform-query.trails.test.ts
@@ -208,6 +208,33 @@ describeIfSqlite("SQLite3AdapterPerformQueryTest (trails)", () => {
     expect(closing.isOpen).toBe(false);
   });
 
+  it("reports itself inactive once the disconnect a caller awaited has returned", async () => {
+    // Ruby's `@lock.synchronize` blocks (abstract_adapter.rb:696-701), so
+    // `active?` is already false the moment `disconnect!` returns. JS cannot
+    // block, so the close lands on `_statementLock`'s tail — and `active()`,
+    // the awaitable surface, drains it rather than reporting the open handle
+    // Rails never exposes.
+    const closing = new BetterSQLite3Adapter(":memory:");
+    // eslint-disable-next-line blazetrails/require-table-teardown
+    await closing.exec(`CREATE TABLE "dc2" ("id" INTEGER PRIMARY KEY)`);
+    const release = await acquireStatementLock(closing);
+    const held = closing._statementLock;
+
+    const queued = closing.executeMutation(`INSERT INTO "dc2" DEFAULT VALUES`);
+    for (let i = 0; i < 100 && closing._statementLock === held; i++) await Promise.resolve();
+
+    closing.disconnectBang();
+    // Asked WHILE the close is still queued behind the statement — the window
+    // Rails does not have. It must not answer until the handle is closed.
+    const answered = closing.active();
+
+    release();
+    await expect(queued).resolves.toBe(1);
+
+    expect(await answered).toBe(false);
+    expect(closing.isOpen).toBe(false);
+  });
+
   it("returns the rowid of each of two RETURNING inserts issued together", async () => {
     const ids = await Promise.all([
       adapter.executeMutation(`INSERT INTO "pq" ("nick") VALUES ('a') RETURNING "id"`),

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-perform-query.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-perform-query.trails.test.ts
@@ -224,8 +224,7 @@ describeIfSqlite("SQLite3AdapterPerformQueryTest (trails)", () => {
     for (let i = 0; i < 100 && closing._statementLock === held; i++) await Promise.resolve();
 
     closing.disconnectBang();
-    // Asked WHILE the close is still queued behind the statement — the window
-    // Rails does not have. It must not answer until the handle is closed.
+    // Asked while the close is still queued behind the statement.
     const answered = closing.active();
 
     release();

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -301,7 +301,18 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
    * the handle is fully torn down. Sync drivers (better-sqlite3) leave this null.
    */
   private _closingDriver: Promise<void> | null = null;
+  /**
+   * Mirrors: SQLite3Adapter#active? (sqlite3_adapter.rb:216-218).
+   *
+   * Ruby's `disconnect!` takes `@lock.synchronize`
+   * (`abstract_adapter.rb:696-701`), which BLOCKS, so `active?` never observes
+   * an open handle once `disconnect!` has returned. `disconnectBang` below
+   * cannot block on `_statementLock` and defers the close instead, so this —
+   * the async surface — drains that deferred close before it answers, and no
+   * caller awaiting it sees a handle Rails would already have closed.
+   */
   override async active(): Promise<boolean> {
+    await this.whenClosed();
     return this.driver?.isOpen() ?? false;
   }
   /**
@@ -1451,7 +1462,14 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     // between a statement's preparation and its execution. `_statementLock` is
     // that lock here, and it cannot be awaited from a sync body — so when it is
     // held, chain the close onto its tail rather than closing the handle out
-    // from under a queued statement. `close()` / `whenClosed()` drain it.
+    // from under a queued statement. `close()` / `whenClosed()` drain it, and
+    // `active()` drains it before it answers — so the deferral is invisible on
+    // every surface a caller can await, which is the whole of what Ruby's
+    // blocking `@lock.synchronize` buys. The two helpers below exist only to
+    // express that deferral: Rails needs neither, because `disconnect!`
+    // (sqlite3_adapter.rb:221) is one straight-line body under a lock that
+    // blocks. They go away with `_statementLock` itself once `perform_query`
+    // runs under `with_raw_connection`'s adapter-level lock (RFC 0076).
     const ahead = this._statementLock;
     if (ahead) {
       this._chainClose(ahead.then(() => this._disconnect()));

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -2210,3 +2210,23 @@ describe("a reducible Rational operand at the C's Integer branches", () => {
     expect(d.jd).toBe(2451913);
   });
 });
+
+/**
+ * Trails-only: `check_limit` measures `RSTRING_LEN(str)` — bytes
+ * (`date_core.c:4468-4479`) — and the gem's own tests are all ASCII, where a
+ * byte count and a JS UTF-16 code-unit count agree. They diverge on any
+ * multi-byte string, both in whether the raise fires and in the number the
+ * message reports.
+ */
+describe("check_limit measures bytes, not UTF-16 code units", () => {
+  it("raises for a string whose byte length crosses the limit its length does not", () => {
+    // 40 code units, 120 UTF-8 bytes.
+    const str = "日".repeat(40);
+    expect(str.length).toBe(40);
+    expect(() => RubyDate._parse(str, false, { limit: 100 })).toThrow(ArgumentError);
+    expect(() => RubyDate._parse(str, false, { limit: 100 })).toThrow(
+      "string length (120) exceeds the limit 100",
+    );
+    expect(() => RubyDate._parse(str, false, { limit: 120 })).not.toThrow();
+  });
+});

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -4833,13 +4833,14 @@ function getLimit(opt: ParseOpt | undefined): number {
  * @internal `date_core.c` `check_limit` (`date_core.c:4467-4479`), which runs
  * BEFORE any sub-parser so a pathological string is rejected rather than
  * walked. A `nil` string is let through to the sub-parser that answers `{}` for
- * it (`NIL_P(str)`, `date_core.c:4471`). The C measures `RSTRING_LEN` — bytes —
- * where a JS string measures UTF-16 code units; the gem's own tests are ASCII,
- * where the two agree.
+ * it (`NIL_P(str)`, `date_core.c:4471`). `RSTRING_LEN` is a byte count over the
+ * ASCII-compatible encoding `date_s__parse_internal` has already checked for
+ * (`rb_enc_str_asciicompat_p`, `date_core.c:4490-4492`), so `slen` is the
+ * string's UTF-8 byte length, not its UTF-16 code-unit length.
  */
 function checkLimit(str: string | null | undefined, opt: ParseOpt | undefined): void {
   if (str == null) return;
-  const slen = str.length;
+  const slen = new TextEncoder().encode(str).length;
   const limit = getLimit(opt);
   if (slen > limit) {
     throw new ArgumentError(`string length (${slen}) exceeds the limit ${limit}`);
@@ -6502,6 +6503,21 @@ export class Date {
    */
   get start(): number {
     return this.#sg;
+  }
+
+  /**
+   * Ruby `Date#dup`, which is `Object#dup` over the `initialize_copy` the C
+   * defines for it (`d_lite_initialize_copy`, `date_core.c:5140-5182`,
+   * registered at `:9714`): a new object of the receiver's own class carrying
+   * the receiver's `SimpleDateData`/`ComplexDateData` verbatim, reform
+   * included. TS has no `dup_obj`, so this runs through the same
+   * {@link Date#newStart} seam the C's `dup_obj_with_new_start` is, with the
+   * receiver's OWN reform — which is why `DateTime#dup` keeps its
+   * day-fraction, sub-second and offset (the C's complex arm, `:5171`) without
+   * a second override.
+   */
+  dup(): this {
+    return this.newStart(this.start);
   }
 
   /**

--- a/packages/date/src/test-switch-hitter.test.ts
+++ b/packages/date/src/test-switch-hitter.test.ts
@@ -16,7 +16,15 @@
  * Ruby's `Encoding::US_ASCII` assertions in `test_zone` / `test_to_s` /
  * `test_inspect` have no JS analogue — a JS string carries no encoding tag —
  * so the ported assertion is the property the Ruby one is checking for: the
- * answer is ASCII-only.
+ * answer is ASCII-only. `test_enc` is the same conversion: its `euc-jp` and
+ * `ascii-8bit` arms differ only in the tag `force_encoding` puts on an
+ * identical string, so each pair ports to one assertion on the value.
+ *
+ * `test_base` is `def test_base ... end if defined?(Date.test_all)`, and
+ * `Date.test_all` is registered only under `#ifndef NDEBUG`
+ * (`date_core.c:10045-10057`) — so a released gem never defines the method and
+ * never defines the test. trails has no debug build either, which is what the
+ * ported body asserts.
  *
  * `test_canon24oc`'s three static spellings answer the `Temporal` seat, which
  * has no `#hour`/`#offset`, so each is asserted through the seat's own
@@ -49,7 +57,9 @@ function isUsAscii(s: string): boolean {
  * -5,000,000 or `test_period2`'s Bignum Julian days, and `#mon`/`#wday`/
  * `#gregorian` are gem-object members. These are the same `d_new_by_frags`
  * (`date_core.c:4110-4147`) the statics themselves run over, given the `:jd`
- * the C's `date_s_jd` sets.
+ * the C's `date_s_jd` sets. `gemDateTimeJd`'s `offset` is the `:offset` frag,
+ * seconds east of UTC — what `DateTime.jd`'s own `'+12:00'` argument reaches
+ * `d_new_by_frags` as (`val2off`, `date_core.c:5071-5077`).
  */
 const gemJd = (jd: number | bigint, sg?: number) => dNewByFrags({ jd }, sg);
 const gemDateTimeJd = (
@@ -57,9 +67,6 @@ const gemDateTimeJd = (
   hour: number,
   min: number,
   sec: number,
-  // The `:offset` frag is seconds east of UTC, which is what `DateTime.jd`'s
-  // own `'+12:00'` argument reaches `d_new_by_frags` as (`val2off`,
-  // `date_core.c:5071-5077`).
   offset: number,
   sg?: number,
 ) => dtNewByFrags({ jd, hour, min, sec, offset }, sg);

--- a/packages/date/src/test-switch-hitter.test.ts
+++ b/packages/date/src/test-switch-hitter.test.ts
@@ -27,13 +27,66 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { Date as RubyDate, DateTime as RubyDateTime, ERANGE, Rational } from "./date.js";
+import {
+  Date as RubyDate,
+  DateTime as RubyDateTime,
+  ERANGE,
+  Rational,
+  dNewByFrags,
+  dtNewByFrags,
+} from "./date.js";
 
 /* eslint-disable no-control-regex */
 
 /** Ruby `String#encoding == Encoding::US_ASCII`; see the file comment. */
 function isUsAscii(s: string): boolean {
   return /^[\x00-\x7f]*$/.test(s);
+}
+
+/**
+ * `Date.jd` / `DateTime.jd` on the gem-shaped object. The statics answer the
+ * `Temporal` seat, whose year range (±271821) cannot hold `test_period`'s
+ * -5,000,000 or `test_period2`'s Bignum Julian days, and `#mon`/`#wday`/
+ * `#gregorian` are gem-object members. These are the same `d_new_by_frags`
+ * (`date_core.c:4110-4147`) the statics themselves run over, given the `:jd`
+ * the C's `date_s_jd` sets.
+ */
+const gemJd = (jd: number | bigint, sg?: number) => dNewByFrags({ jd }, sg);
+const gemDateTimeJd = (
+  jd: number | bigint,
+  hour: number,
+  min: number,
+  sec: number,
+  // The `:offset` frag is seconds east of UTC, which is what `DateTime.jd`'s
+  // own `'+12:00'` argument reaches `d_new_by_frags` as (`val2off`,
+  // `date_core.c:5071-5077`).
+  offset: number,
+  sg?: number,
+) => dtNewByFrags({ jd, hour, min, sec, offset }, sg);
+
+/** `TestSH#period2_iter2`, the private helper `test_period2` drives. */
+function period2Iter2(from: bigint, to: bigint, sg: number): void {
+  for (let j = from; j <= to; j++) {
+    const d = gemJd(j, sg);
+    const d2 = new RubyDate(d.year, d.mon, d.mday, sg);
+    expect(BigInt(d2.jd)).toBe(j);
+    expect(String(d2.ajd)).toBe(String(d.ajd));
+    expect(String(d2.year)).toBe(String(d.year));
+
+    const t = gemDateTimeJd(j, 12, 0, 0, 12 * 3600, sg);
+    const t2 = new RubyDateTime(t.year, t.mon, t.mday, t.hour, t.min, t.sec, t.offset, sg);
+    expect(BigInt(t2.jd)).toBe(j);
+    expect(String(t2.ajd)).toBe(String(t.ajd));
+    expect(String(t2.year)).toBe(String(t.year));
+  }
+}
+
+/** `TestSH#period2_iter`, the private helper `test_period2` drives. */
+function period2Iter(from: bigint, to: bigint): void {
+  period2Iter2(from, to, RubyDate.GREGORIAN);
+  period2Iter2(from, to, RubyDate.ITALY);
+  period2Iter2(from, to, RubyDate.ENGLAND);
+  period2Iter2(from, to, RubyDate.JULIAN);
 }
 
 describe("TestSH", () => {
@@ -329,5 +382,282 @@ describe("TestSH", () => {
     expect(isUsAscii(d.inspect())).toBe(true);
     d = new RubyDateTime(2001, 2, 3);
     expect(isUsAscii(d.inspect())).toBe(true);
+  });
+
+  it("cmp", () => {
+    expect(new RubyDate(2001, 2, 3).cmp(new RubyDate(2001, 2, 4))).toBe(-1);
+    expect(new RubyDate(2001, 2, 3).cmp(new RubyDate(2001, 2, 3))).toBe(0);
+    expect(new RubyDate(2001, 2, 3).cmp(new RubyDate(2001, 2, 2))).toBe(1);
+
+    expect(new RubyDate(2001, 2, 3).cmp(2451944.0)).toBe(-1);
+    expect(new RubyDate(2001, 2, 3).cmp(2451944)).toBe(-1);
+    expect(new RubyDate(2001, 2, 3).cmp(2451943.5)).toBe(0);
+    expect(new RubyDate(2001, 2, 3).cmp(2451943.0)).toBe(1);
+    expect(new RubyDate(2001, 2, 3).cmp(2451943)).toBe(1);
+
+    expect(new RubyDate(2001, 2, 3).cmp(new Rational(4903888, 2))).toBe(-1);
+    expect(new RubyDate(2001, 2, 3).cmp(new Rational(4903887, 2))).toBe(0);
+    expect(new RubyDate(2001, 2, 3).cmp(new Rational(4903886, 2))).toBe(1);
+
+    expect(
+      new RubyDate(-4713, 11, 1, RubyDate.GREGORIAN).cmp(
+        new RubyDate(-4713, 12, 1, RubyDate.GREGORIAN),
+      ),
+    ).toBe(-1);
+  });
+
+  it("eqeqeq", () => {
+    expect(new RubyDate(2001, 2, 3).caseEquals(new RubyDate(2001, 2, 4))).toBe(false);
+    expect(new RubyDate(2001, 2, 3).caseEquals(new RubyDate(2001, 2, 3))).toBe(true);
+    expect(new RubyDate(2001, 2, 3).caseEquals(new RubyDate(2001, 2, 2))).toBe(false);
+
+    expect(new RubyDate(2001, 2, 3).caseEquals(2451944.0)).toBe(true);
+    expect(new RubyDate(2001, 2, 3).caseEquals(2451944)).toBe(true);
+    expect(new RubyDate(2001, 2, 3).caseEquals(2451943.5)).toBe(false);
+    expect(new RubyDate(2001, 2, 3).caseEquals(2451943.0)).toBe(false);
+    expect(new RubyDate(2001, 2, 3).caseEquals(2451943)).toBe(false);
+
+    expect(new RubyDate(2001, 2, 3).caseEquals(new Rational(4903888, 2))).toBe(true);
+    expect(new RubyDate(2001, 2, 3).caseEquals(new Rational(4903887, 2))).toBe(false);
+    expect(new RubyDate(2001, 2, 3).caseEquals(new Rational(4903886, 2))).toBe(false);
+  });
+
+  it("period", () => {
+    // -5000
+    let d = new RubyDate(-5000, 1, 1);
+    expect([d.year, d.mon, d.mday, d.wday]).toEqual([-5000, 1, 1, 5]);
+    let d2 = d.gregorian();
+    expect([d2.year, d2.mon, d2.mday, d.wday]).toEqual([-5001, 11, 22, 5]);
+
+    d = new RubyDate(-5000, 1, 1, RubyDate.JULIAN);
+    expect([d.year, d.mon, d.mday, d.wday]).toEqual([-5000, 1, 1, 5]);
+    d2 = d.gregorian();
+    expect([d2.year, d2.mon, d2.mday, d.wday]).toEqual([-5001, 11, 22, 5]);
+
+    d = new RubyDate(-5000, 1, 1, RubyDate.GREGORIAN);
+    expect([d.year, d.mon, d.mday, d.wday]).toEqual([-5000, 1, 1, 3]);
+    d2 = d.julian();
+    expect([d2.year, d2.mon, d2.mday, d.wday]).toEqual([-5000, 2, 10, 3]);
+
+    d = gemJd(-105192);
+    expect([d.year, d.mon, d.mday, d.wday]).toEqual([-5000, 1, 1, 5]);
+    d2 = d.gregorian();
+    expect([d2.year, d2.mon, d2.mday, d.wday]).toEqual([-5001, 11, 22, 5]);
+
+    d = gemJd(-105192, RubyDate.JULIAN);
+    expect([d.year, d.mon, d.mday, d.wday]).toEqual([-5000, 1, 1, 5]);
+    d2 = d.gregorian();
+    expect([d2.year, d2.mon, d2.mday, d.wday]).toEqual([-5001, 11, 22, 5]);
+
+    d = gemJd(-105152, RubyDate.GREGORIAN);
+    expect([d.year, d.mon, d.mday, d.wday]).toEqual([-5000, 1, 1, 3]);
+    d2 = d.julian();
+    expect([d2.year, d2.mon, d2.mday, d.wday]).toEqual([-5000, 2, 10, 3]);
+
+    // -5000000
+    d = new RubyDate(-5_000_000, 1, 1);
+    expect([d.year, d.mon, d.mday, d.wday]).toEqual([-5_000_000, 1, 1, 3]);
+    d2 = d.gregorian();
+    expect([d2.year, d2.mon, d2.mday, d.wday]).toEqual([-5_000_103, 4, 28, 3]);
+
+    d = new RubyDate(-5_000_000, 1, 1, RubyDate.JULIAN);
+    expect([d.year, d.mon, d.mday, d.wday]).toEqual([-5_000_000, 1, 1, 3]);
+    d2 = d.gregorian();
+    expect([d2.year, d2.mon, d2.mday, d.wday]).toEqual([-5_000_103, 4, 28, 3]);
+
+    d = new RubyDate(-5_000_000, 1, 1, RubyDate.GREGORIAN);
+    expect([d.year, d.mon, d.mday, d.wday]).toEqual([-5_000_000, 1, 1, 6]);
+    d2 = d.julian();
+    expect([d2.year, d2.mon, d2.mday, d.wday]).toEqual([-4_999_898, 9, 4, 6]);
+
+    d = gemJd(-1824528942);
+    expect([d.year, d.mon, d.mday, d.wday]).toEqual([-5_000_000, 1, 1, 3]);
+    d2 = d.gregorian();
+    expect([d2.year, d2.mon, d2.mday, d.wday]).toEqual([-5_000_103, 4, 28, 3]);
+
+    d = gemJd(-1824528942, RubyDate.JULIAN);
+    expect([d.year, d.mon, d.mday, d.wday]).toEqual([-5_000_000, 1, 1, 3]);
+    d2 = d.gregorian();
+    expect([d2.year, d2.mon, d2.mday, d.wday]).toEqual([-5_000_103, 4, 28, 3]);
+
+    d = gemJd(-1824491440, RubyDate.GREGORIAN);
+    expect([d.year, d.mon, d.mday, d.wday]).toEqual([-5_000_000, 1, 1, 6]);
+    d2 = d.julian();
+    expect([d2.year, d2.mon, d2.mday, d.wday]).toEqual([-4_999_898, 9, 4, 6]);
+
+    // 5000000
+    d = new RubyDate(5_000_000, 1, 1);
+    expect([d.year, d.mon, d.mday, d.wday]).toEqual([5_000_000, 1, 1, 6]);
+    d2 = d.julian();
+    expect([d2.year, d2.mon, d2.mday, d.wday]).toEqual([4_999_897, 5, 3, 6]);
+
+    d = new RubyDate(5_000_000, 1, 1, RubyDate.JULIAN);
+    expect([d.year, d.mon, d.mday, d.wday]).toEqual([5_000_000, 1, 1, 5]);
+    d2 = d.gregorian();
+    expect([d2.year, d2.mon, d2.mday, d.wday]).toEqual([5_000_102, 9, 1, 5]);
+
+    d = new RubyDate(5_000_000, 1, 1, RubyDate.GREGORIAN);
+    expect([d.year, d.mon, d.mday, d.wday]).toEqual([5_000_000, 1, 1, 6]);
+    d2 = d.julian();
+    expect([d2.year, d2.mon, d2.mday, d.wday]).toEqual([4_999_897, 5, 3, 6]);
+
+    d = gemJd(1827933560);
+    expect([d.year, d.mon, d.mday, d.wday]).toEqual([5_000_000, 1, 1, 6]);
+    d2 = d.julian();
+    expect([d2.year, d2.mon, d2.mday, d.wday]).toEqual([4_999_897, 5, 3, 6]);
+
+    d = gemJd(1827971058, RubyDate.JULIAN);
+    expect([d.year, d.mon, d.mday, d.wday]).toEqual([5_000_000, 1, 1, 5]);
+    d2 = d.gregorian();
+    expect([d2.year, d2.mon, d2.mday, d.wday]).toEqual([5_000_102, 9, 1, 5]);
+
+    d = gemJd(1827933560, RubyDate.GREGORIAN);
+    expect([d.year, d.mon, d.mday, d.wday]).toEqual([5_000_000, 1, 1, 6]);
+    d2 = d.julian();
+    expect([d2.year, d2.mon, d2.mday, d.wday]).toEqual([4_999_897, 5, 3, 6]);
+
+    // dt
+    let dt = new RubyDateTime(-123456789, 2, 3, 4, 5, 6, 0);
+    expect([dt.year, dt.mon, dt.mday, dt.hour, dt.min, dt.sec, dt.wday]).toEqual([
+      -123456789, 2, 3, 4, 5, 6, 1,
+    ]);
+    let dt2 = dt.gregorian();
+    expect([dt2.year, dt2.mon, dt2.mday, dt2.hour, dt2.min, dt2.sec, dt.wday]).toEqual([
+      -123459325, 12, 27, 4, 5, 6, 1,
+    ]);
+
+    dt = new RubyDateTime(123456789, 2, 3, 4, 5, 6, 0);
+    expect([dt.year, dt.mon, dt.mday, dt.hour, dt.min, dt.sec, dt.wday]).toEqual([
+      123456789, 2, 3, 4, 5, 6, 5,
+    ]);
+    dt2 = dt.julian();
+    expect([dt2.year, dt2.mon, dt2.mday, dt2.hour, dt2.min, dt2.sec, dt.wday]).toEqual([
+      123454254, 1, 19, 4, 5, 6, 5,
+    ]);
+  });
+
+  it("period2", () => {
+    const cmPeriod0 = 71149239n;
+    const cmPeriod = (0xfffffffn / cmPeriod0) * cmPeriod0;
+    period2Iter(-cmPeriod * (1n << 64n) - 3n, -cmPeriod * (1n << 64n) + 3n);
+    period2Iter(-cmPeriod - 3n, -cmPeriod + 3n);
+    period2Iter(0n - 3n, 0n + 3n);
+    period2Iter(cmPeriod - 3n, cmPeriod + 3n);
+    period2Iter(cmPeriod * (1n << 64n) - 3n, cmPeriod * (1n << 64n) + 3n);
+  });
+
+  it("different alignments", () => {
+    expect(gemJd(0).cmp(new RubyDate(-4713, 11, 24, RubyDate.GREGORIAN))).toBe(0);
+    expect(gemJd(213447717).cmp(new RubyDate(579687, 11, 24))).toBe(0);
+    expect(gemJd(-213447717).cmp(new RubyDate(-589113, 11, 24, RubyDate.GREGORIAN))).toBe(0);
+
+    expect(gemJd(0).cmp(new RubyDateTime(-4713, 11, 24, 0, 0, 0, 0, RubyDate.GREGORIAN))).toBe(0);
+    expect(gemJd(213447717).cmp(new RubyDateTime(579687, 11, 24))).toBe(0);
+    expect(
+      gemJd(-213447717).cmp(new RubyDateTime(-589113, 11, 24, 0, 0, 0, 0, RubyDate.GREGORIAN)),
+    ).toBe(0);
+
+    expect(gemJd(0).equals(new RubyDate(-4713, 11, 24, RubyDate.GREGORIAN))).toBe(true);
+    expect(gemJd(213447717).equals(new RubyDate(579687, 11, 24))).toBe(true);
+    expect(gemJd(-213447717).equals(new RubyDate(-589113, 11, 24, RubyDate.GREGORIAN))).toBe(true);
+
+    expect(gemJd(0).equals(new RubyDateTime(-4713, 11, 24, 0, 0, 0, 0, RubyDate.GREGORIAN))).toBe(
+      true,
+    );
+    expect(gemJd(213447717).equals(new RubyDateTime(579687, 11, 24))).toBe(true);
+    expect(
+      gemJd(-213447717).equals(new RubyDateTime(-589113, 11, 24, 0, 0, 0, 0, RubyDate.GREGORIAN)),
+    ).toBe(true);
+
+    expect(gemJd(0).caseEquals(new RubyDate(-4713, 11, 24, RubyDate.GREGORIAN))).toBe(true);
+    expect(gemJd(213447717).caseEquals(new RubyDate(579687, 11, 24))).toBe(true);
+    expect(gemJd(-213447717).caseEquals(new RubyDate(-589113, 11, 24, RubyDate.GREGORIAN))).toBe(
+      true,
+    );
+
+    expect(
+      gemJd(0).caseEquals(new RubyDateTime(-4713, 11, 24, 12, 0, 0, 0, RubyDate.GREGORIAN)),
+    ).toBe(true);
+    expect(gemJd(213447717).caseEquals(new RubyDateTime(579687, 11, 24, 12))).toBe(true);
+    expect(
+      gemJd(-213447717).caseEquals(
+        new RubyDateTime(-589113, 11, 24, 12, 0, 0, 0, RubyDate.GREGORIAN),
+      ),
+    ).toBe(true);
+
+    let a = gemJd(0);
+    let b = new RubyDate(-4713, 11, 24, RubyDate.GREGORIAN);
+    expect(a.cmp(b)).toBe(0);
+
+    a = new RubyDate(-4712, 1, 1, RubyDate.JULIAN);
+    b = new RubyDate(-4713, 11, 24, RubyDate.GREGORIAN);
+    void a.jd;
+    void b.jd;
+    expect(a.cmp(b)).toBe(0);
+
+    a = gemJd(0);
+    b = new RubyDate(-4713, 11, 24, RubyDate.GREGORIAN);
+    expect(a.equals(b)).toBe(true);
+
+    a = new RubyDate(-4712, 1, 1, RubyDate.JULIAN);
+    b = new RubyDate(-4713, 11, 24, RubyDate.GREGORIAN);
+    void a.jd;
+    void b.jd;
+    expect(a.equals(b)).toBe(true);
+
+    a = gemJd(0);
+    b = new RubyDate(-4713, 11, 24, RubyDate.GREGORIAN);
+    expect(a.caseEquals(b)).toBe(true);
+
+    a = new RubyDate(-4712, 1, 1, RubyDate.JULIAN);
+    b = new RubyDate(-4713, 11, 24, RubyDate.GREGORIAN);
+    void a.jd;
+    void b.jd;
+    expect(a.caseEquals(b)).toBe(true);
+  });
+
+  it("enc", () => {
+    RubyDate.MONTHNAMES.filter((s) => s !== null).forEach((s) => {
+      expect(isUsAscii(s)).toBe(true);
+    });
+    RubyDate.DAYNAMES.filter((s) => s !== null).forEach((s) => {
+      expect(isUsAscii(s)).toBe(true);
+    });
+    RubyDate.ABBR_MONTHNAMES.filter((s) => s !== null).forEach((s) => {
+      expect(isUsAscii(s)).toBe(true);
+    });
+    RubyDate.ABBR_DAYNAMES.filter((s) => s !== null).forEach((s) => {
+      expect(isUsAscii(s)).toBe(true);
+    });
+
+    let h = RubyDate._strptime("15:43+09:00", "%R%z");
+    expect(h?.zone).toBe("+09:00");
+    h = RubyDate._strptime("1;1/0", "%d");
+    expect(h?.leftover).toBe(";1/0");
+
+    const p = RubyDate._parse("15:43+09:00");
+    expect(p.zone).toBe("+09:00");
+
+    const today = RubyDate.today();
+    expect(new RubyDate(today.year, today.month, today.day).strftime("new 105")).toBe("new 105");
+    expect(new RubyDateTime(2001, 2, 3).strftime("super $record")).toBe("super $record");
+  });
+
+  it("dup", () => {
+    let d: RubyDate = new RubyDate(2001, 2, 3);
+    let d2 = d.dup();
+    expect(d2).not.toBe(d);
+    expect(d2).toBeInstanceOf(RubyDate);
+    expect(d.equals(d2)).toBe(true);
+
+    d = new RubyDateTime(2001, 2, 3);
+    d2 = d.dup();
+    expect(d2).not.toBe(d);
+    expect(d2).toBeInstanceOf(RubyDateTime);
+    expect(d.equals(d2)).toBe(true);
+  });
+
+  it("base", () => {
+    expect("testAll" in RubyDate).toBe(false);
   });
 });

--- a/packages/date/src/test-switch-hitter.test.ts
+++ b/packages/date/src/test-switch-hitter.test.ts
@@ -647,7 +647,12 @@ describe("TestSH", () => {
 
     const today = RubyDate.today();
     expect(new RubyDate(today.year, today.month, today.day).strftime("new 105")).toBe("new 105");
-    expect(new RubyDateTime(2001, 2, 3).strftime("super $record")).toBe("super $record");
+    const now = RubyDateTime.now();
+    expect(
+      new RubyDateTime(now.year, now.month, now.day, now.hour, now.minute, now.second).strftime(
+        "super $record",
+      ),
+    ).toBe("super $record");
   });
 
   it("dup", () => {


### PR DESCRIPTION
Three bundled stories.

### `check_limit` measures bytes, not UTF-16 code units

`check_limit`'s `slen` is `RSTRING_LEN(str)` (`date_core.c:4468-4479`) — a byte
count over the ASCII-compatible encoding `date_s__parse_internal` has already
checked for (`rb_enc_str_asciicompat_p`, `:4490-4492`). `checkLimit` measured
`str.length`, which agrees only on ASCII; on any multi-byte string both the
raise and the number the message reports were wrong. `TextEncoder` is a global,
so no `node:*` import. Covered by a trails-only test with a 40-code-unit,
120-byte string against `limit: 100`.

### Port `test_switch_hitter.rb`'s tail (8 tests)

`test_cmp`, `test_eqeqeq`, `test_period`, `test_period2`,
`test_different_alignments`, `test_enc`, `test_dup`, `test_base`.
`test_switch_hitter.rb` now reads **18/18 ✓** on `parity:test --package date`
(date overall 124/137). The four `marshal*` tests stay excluded and unwritten;
their `UNPORTED_FILES` entries are untouched.

Two notes:

- `Date#dup` did not exist. It is `Object#dup` over the `initialize_copy` the C
  defines for it (`d_lite_initialize_copy`, `date_core.c:5140-5182`, registered
  at `:9714`), implemented through the same `newStart` seam that already stands
  in for the C's `dup_obj` — which is why `DateTime#dup` keeps its
  day-fraction, sub-second and offset without a second override.
- `test_period` / `test_period2` run on the gem-shaped objects: the `Temporal`
  seat's year range cannot hold -5,000,000 or a Bignum Julian day, and
  `#mon`/`#wday`/`#gregorian` are gem-object members. No `Temporal` return is
  converged back to a Ruby-shaped one.

### sqlite `active()` drains a disconnect deferred behind the statement lock

Ruby's `disconnect!` takes the same `@lock.synchronize` as
`with_raw_connection` (`abstract_adapter.rb:696-701`, `:983-984`), and it
BLOCKS — so `active?` never observes an open handle once `disconnect!` has
returned. JS cannot block, so `disconnectBang` chains the close onto
`_statementLock`'s tail; `active()`, the awaitable surface, now drains that
close before it answers. `close()` / `whenClosed()` already did, so the
deferral is invisible on every surface a caller can await.

`_disconnect` / `_chainClose` stay, with the justification sharpened at the
call site: they exist only to express that deferral, and they go away with
`_statementLock` itself once `perform_query` runs under `with_raw_connection`'s
adapter-level lock (`retire-sqlite-statement-lock-onto-with-raw-connection`).

The new test fails on baseline (`active()` answered `true` while the handle was
still open) and passes here.

### `wire-raw-execute-through-log` released, not shipped

Its remaining work is the adapter routing: rerouting `execute` /
`executeMutation` on all three adapters through `rawExecute`, re-deriving where
`preprocessQuery` / `materializeTransactions` run on each, renaming PG's
private `_performQuery` (6+ call sites) to the Rails name, plus the
`ddl-profile.ts` leaf-primitive update and the savepoint / `BEGIN`
`name: "TRANSACTION"` decision. That does not fit in this PR's remaining budget
with the care the hottest query path needs, and it is untestable locally on the
PG/MySQL lanes. Released back to the queue for an agent with a full budget.

One finding for whoever takes it: sqlite3 and mysql2 **already** expose
`performQuery` at the Rails name on the prototype (`sqlite3-adapter.ts:3233`,
`mysql2-adapter.ts:2041`); only PG still keeps a private `_performQuery`
(`postgresql-adapter.ts:1629`). What is missing everywhere is the layering —
each adapter still calls `this.performQuery` inside its OWN `log`, so
`rawExecute` has no callers.

Closes-story: check-limit-measures-utf16-units-not-bytes
Closes-story: port-test-switch-hitter-compare-marshal
Closes-story: sqlite-disconnect-returns-before-the-handle-closes
