### PR TITLE
fix(scripts): parse the pre-rename --wide-calls step into the calls stats

### DIFF
--- a/scripts/sync-stats/classify-compare-step.test.ts
+++ b/scripts/sync-stats/classify-compare-step.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { classifyCompareStep } from "./classify-compare-step.js";
+
+describe("classifyCompareStep", () => {
+  it("separates the three api-compare runs", () => {
+    expect(
+      classifyCompareStep(
+        "pnpm exec tsx scripts/api-compare/extract-ts-api.ts && pnpm exec tsx scripts/api-compare/compare.ts",
+      ),
+    ).toBe("api_compare");
+    expect(classifyCompareStep("pnpm exec tsx scripts/api-compare/compare.ts --privates")).toBe(
+      "api_compare_privates",
+    );
+    expect(classifyCompareStep("pnpm exec tsx scripts/api-compare/compare.ts --calls")).toBe(
+      "api_calls",
+    );
+  });
+
+  // The calls run was `--wide-calls` before the rename. Its logs are still
+  // reparsed, and classifying them as api_compare overwrites the public-API
+  // step with full-surface numbers.
+  it("understands the pre-rename --wide-calls flag", () => {
+    expect(classifyCompareStep("pnpm exec tsx scripts/api-compare/compare.ts --wide-calls")).toBe(
+      "api_calls",
+    );
+  });
+
+  it("maps the current and historic test-compare entry points", () => {
+    for (const cmd of [
+      "pnpm exec tsx scripts/test-compare/compare.ts --gates",
+      "pnpm exec tsx scripts/test-compare/test-compare.ts --gates",
+      "pnpm exec tsx scripts/test-compare/convention-compare.ts",
+    ]) {
+      expect(classifyCompareStep(cmd)).toBe("test_compare");
+    }
+  });
+
+  it("ignores steps the sync does not parse", () => {
+    for (const cmd of [
+      "pnpm install --frozen-lockfile",
+      "pnpm exec tsx scripts/schema-compare/compare.ts",
+      "pnpm exec tsx scripts/fixtures-compare/compare.ts --models",
+      "pnpm exec tsx scripts/api-compare/lint-call-mismatches.ts",
+    ]) {
+      expect(classifyCompareStep(cmd)).toBeNull();
+    }
+  });
+});

--- a/scripts/sync-stats/classify-compare-step.ts
+++ b/scripts/sync-stats/classify-compare-step.ts
@@ -1,0 +1,33 @@
+/**
+ * Map a CI step's `##[group]Run <command>` line to the compare step it is, or
+ * null for a step the stats sync doesn't parse.
+ *
+ * Pulled out of extractStepLogs and covered by tests because getting it wrong
+ * is silent: two runs of `compare.ts` that classify the same overwrite each
+ * other in the step map (the later one in the job wins) and the losing step's
+ * stats table quietly fills with the wrong run's numbers.
+ *
+ * Historic flags and entry-point names are kept — the sync reparses job logs
+ * going back to the start of the repo, so a rename must stay understood here
+ * forever, not just until the next backfill.
+ */
+export function classifyCompareStep(command: string): string | null {
+  if (command.includes("api-compare/compare.ts")) {
+    if (command.includes("--privates")) return "api_compare_privates";
+    // `--wide-calls` is the pre-rename flag for the same run (CI step "API
+    // comparison (wide calls)"). Must be checked before falling through to
+    // api_compare: the calls run prints the same per-package table and appears
+    // later in the job, so misclassifying it overwrites the public-API step.
+    if (command.includes("--calls") || command.includes("--wide-calls")) return "api_calls";
+    return "api_compare";
+  }
+  if (
+    command.includes("test-compare/compare.ts") ||
+    // Pre-RFC-0092 entry-point names, kept so historic logs still parse.
+    command.includes("test-compare/test-compare.ts") ||
+    command.includes("test-compare/convention-compare.ts")
+  ) {
+    return "test_compare";
+  }
+  return null;
+}

--- a/scripts/sync-stats/sync.ts
+++ b/scripts/sync-stats/sync.ts
@@ -7,6 +7,7 @@ import type { SQLite3Adapter } from "@blazetrails/activerecord/connection-adapte
 import { BetterSQLite3Adapter } from "@blazetrails/activerecord/connection-adapters/better-sqlite3-adapter.js";
 import { parseTestCompareFromLogs } from "./parse-test-compare.js";
 import { parseCallSummariesFromLogs } from "./parse-call-summaries.js";
+import { classifyCompareStep } from "./classify-compare-step.js";
 
 const REPO = "blazetrailsdev/trails";
 const [REPO_OWNER, REPO_NAME] = REPO.split("/");
@@ -1783,27 +1784,7 @@ function extractStepLogs(rawLog: string): Map<string, string> {
   let m;
   while ((m = runPattern.exec(rawLog)) !== null) {
     const command = m[1].trim();
-    let stepName: string | null = null;
-
-    if (command.includes("api-compare/compare.ts")) {
-      // The --calls run prints the same per-package table as the plain run, so
-      // it must be classified BEFORE falling through to "api_compare" —
-      // otherwise it overwrites the public-API step's log (it appears later in
-      // the job) and the api_compare_stats feed silently becomes the
-      // full-surface numbers.
-      stepName = command.includes("--privates")
-        ? "api_compare_privates"
-        : command.includes("--calls")
-          ? "api_calls"
-          : "api_compare";
-    } else if (
-      command.includes("test-compare/compare.ts") ||
-      // Pre-RFC-0092 entry-point names, kept so historic logs still parse.
-      command.includes("test-compare/test-compare.ts") ||
-      command.includes("test-compare/convention-compare.ts")
-    ) {
-      stepName = "test_compare";
-    }
+    const stepName = classifyCompareStep(command);
 
     if (!stepName) continue;
 
@@ -2031,7 +2012,10 @@ const MISSING_STATS_PREDICATE = `
         -- Same shape as the privates gate: only expect calls stats from a job
         -- that actually ran the --calls step, so pre-RFC-0095 logs don't make
         -- --refresh reprocess the whole history on every run.
-        rjl.log_output LIKE '%compare.ts --calls%'
+        (
+          rjl.log_output LIKE '%compare.ts --calls%'
+          OR rjl.log_output LIKE '%compare.ts --wide-calls%'
+        )
         AND NOT EXISTS (
           SELECT 1 FROM api_calls_stats acls
           WHERE acls.merge_commit_sha = rjl.merge_commit_sha


### PR DESCRIPTION
Follow-up to #6339.

## The gap

The `--reparse-logs` backfill filled `api_calls_stats` for PRs **6128–6335** and stopped. Older logs invoke the same run under its pre-rename flag:

```
##[group]Run pnpm exec tsx scripts/api-compare/compare.ts --wide-calls
```

`"--wide-calls".includes("--calls")` is false, so those ~840 logs fell through to `"api_compare"` — overwriting the public-API step with the full-surface numbers, which is exactly the bug #6339's `--calls` case was added to fix. It just kept happening under the older flag.

## What changed

- `--wide-calls` classifies as `api_calls`, and the `MISSING_STATS_PREDICATE` gate matches it too, so `--refresh` picks those logs up.
- Step classification moves out of `extractStepLogs` into **`classify-compare-step.ts`**, with tests. This logic has now been wrong twice and fails silently — two `compare.ts` runs that classify the same overwrite each other in the step map, later one wins, and the loser's stats table quietly fills with the wrong run's numbers. It needed coverage, and it could not have it in place: importing `sync.ts` runs a full sync (it calls `main()` at module scope), so the testable part had to come out.

Tests cover the three api-compare runs, both test-compare entry-point names, the `--wide-calls` alias, and the steps the sync ignores.

After merge, `stats:sync --reparse-logs` extends the calls series back to the start of the wide-calls era.