### PR TITLE
feat(parity): seed the call-argument baseline, tally skip reasons, re-measure the arel population

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -15,3 +15,9 @@ vendor/*/
 # deliberately malformed YAML that prettier cannot parse, and reformatting the
 # rest would drift the fixtures away from the gem's.
 packages/i18n/src/test-data/locales/
+
+# Generated parity baselines with their own canonical serializer
+# (scripts/api-compare/baseline-json.ts#serializeBaseline, which the gates
+# verify byte-for-byte). Prettier collapses a short `rubyArgs` array onto one
+# line, which that serializer never emits, so the two formatters fight.
+scripts/api-compare/call-mismatches-exclude/

--- a/scripts/api-compare/call-args-baseline.ts
+++ b/scripts/api-compare/call-args-baseline.ts
@@ -33,6 +33,9 @@ export interface CallArgArtifact {
   packages?: string[];
   /** Sites compared — the report's denominator. */
   compared: number;
+  /** Sites the comparison could not reach, by reason (RFC 0095). Absent on an
+   *  artifact predating the tally. */
+  skipped?: Record<string, number>;
   mismatches: (CallArgKey & {
     rubyFile: string;
     tsName: string;

--- a/scripts/api-compare/call-args.test.ts
+++ b/scripts/api-compare/call-args.test.ts
@@ -253,6 +253,48 @@ describe("compareCallArgs", () => {
     expect(compareCallArgs(site("where", ["hash"]), site("where", ["hash"])).verdict).toBe("skip");
   });
 
+  it("reports the skip reason for an excluded call name", () => {
+    expect(compareCallArgs(site("super", ["id:x"]), site("super", ["id:y"])).reason).toBe(
+      "excludedCallName",
+    );
+    expect(compareCallArgs(site("to_s", ["id:x"]), site("to_s", ["id:y"])).reason).toBe(
+      "excludedCallName",
+    );
+  });
+
+  it("reports the skip reason for an uncomparable flag", () => {
+    expect(
+      compareCallArgs(site("build", ["*splat"], ["splat"]), site("build", ["id:x"])).reason,
+    ).toBe("uncomparableFlag");
+  });
+
+  it("reports the skip reason for an opaque Ruby argument", () => {
+    expect(compareCallArgs(site("where", ["hash"]), site("where", ["id:x"])).reason).toBe(
+      "opaqueRubyArg",
+    );
+  });
+
+  it("reports the skip reason for an opaque TS argument", () => {
+    expect(compareCallArgs(site("where", ["id:x"]), site("where", ["hash"])).reason).toBe(
+      "opaqueTsArg",
+    );
+  });
+
+  it("reports the skip reason for an unparseable literal", () => {
+    expect(compareCallArgs(site("limit", ["num:1"]), site("limit", ["num:123n"])).reason).toBe(
+      "unparseableLiteral",
+    );
+  });
+
+  it("carries no skip reason on a match or a mismatch", () => {
+    expect(
+      compareCallArgs(site("visit", ["id:o"]), site("visit", ["id:o"])).reason,
+    ).toBeUndefined();
+    expect(
+      compareCallArgs(site("visit", ["id:o"]), site("visit", ["id:o", "id:x"])).reason,
+    ).toBeUndefined();
+  });
+
   it("compares the non-block arguments of a block-flagged site", () => {
     expect(
       compareCallArgs(

--- a/scripts/api-compare/call-args.ts
+++ b/scripts/api-compare/call-args.ts
@@ -50,6 +50,28 @@ const LITERAL_KINDS: Record<string, LiteralValue["kind"]> = {
 
 export type CallArgVerdict = "match" | "mismatch" | "skip";
 
+/**
+ * WHY a site was skipped (RFC 0095). The first two are deliberate exclusions
+ * and should stay flat; the last three are population the dimension is LOSING,
+ * and a spike in any of them is the signature of the bug PR #6316 fixed — a
+ * grammar ambiguity that silently dropped whole call sites, invisible because
+ * nothing counted skips by reason.
+ */
+export type CallArgSkipReason =
+  | "excludedCallName"
+  | "uncomparableFlag"
+  | "opaqueRubyArg"
+  | "opaqueTsArg"
+  | "unparseableLiteral";
+
+export const CALL_ARG_SKIP_REASONS: readonly CallArgSkipReason[] = [
+  "excludedCallName",
+  "uncomparableFlag",
+  "opaqueRubyArg",
+  "opaqueTsArg",
+  "unparseableLiteral",
+];
+
 /** `shape` — argument count, order, literal values or kwarg keys differ; the
  *  class RFC 0095 §4 gates. `naming` — the two lists differ only in how a
  *  `ref:` identifier is spelled (Rails' `o` ported as `node`); reported only,
@@ -60,13 +82,28 @@ export type CallArgClass = "shape" | "naming";
  *  the verdict reads it without asserting it is there. */
 export type CallArgResult =
   | {
-      verdict: "skip" | "match";
+      verdict: "skip";
       class?: undefined;
+      /** Why the site is uncomparable — the tally's key (RFC 0095). */
+      reason: CallArgSkipReason;
       /** The normalized lists the verdict was reached on — what a row reports. */
       rubyArgs: string[];
       tsArgs: string[];
     }
-  | { verdict: "mismatch"; class: CallArgClass; rubyArgs: string[]; tsArgs: string[] };
+  | {
+      verdict: "match";
+      class?: undefined;
+      reason?: undefined;
+      rubyArgs: string[];
+      tsArgs: string[];
+    }
+  | {
+      verdict: "mismatch";
+      class: CallArgClass;
+      reason?: undefined;
+      rubyArgs: string[];
+      tsArgs: string[];
+    };
 
 /**
  * The comparison key for one identifier or nested call name.
@@ -121,13 +158,13 @@ function refKeysEqual(rubyKey: string, tsKey: string): boolean {
  * body's control flow turns on Symbol-vs-String — so `":dump"` and `"dump"` are
  * the same value here and must compare equal.
  */
-function normalizeLiteralArg(kind: LiteralValue["kind"], value: string): string | null {
+function normalizeLiteralArg(kind: LiteralValue["kind"], value: string): string | ArgFailure {
   const key = normalizeLiteral({ kind, value });
   // A token the numeric arm cannot parse is uncomparable, not the value NaN: the
   // TS extractor records a BigInt literal with its `n` suffix (`123n`), which no
   // Ruby token ever spells, so comparing it would manufacture a shape row.
-  if (key === "num:NaN") return null;
-  if (key === null || !key.startsWith("str:")) return key;
+  if (key === "num:NaN" || key === null) return UNPARSEABLE_LITERAL;
+  if (!key.startsWith("str:")) return key;
   const text = key.slice("str:".length);
   const bare = text.startsWith(":") ? text.slice(1) : text;
   return IDENTIFIER_STRING.test(bare) ? `str:${snakeToCamel(bare)}` : key;
@@ -184,18 +221,30 @@ function unescapeDescriptorText(text: string): string {
  *  significant — a Ruby hash literal and a TS object literal carry the same
  *  kwargs whatever order they are written in — so the pairs are sorted. A pair
  *  with no `=` is the `**splat` marker, which has no comparable arity. */
-function normalizeKwargs(descriptor: string): string | null {
+function normalizeKwargs(descriptor: string): string | ArgFailure {
   const body = descriptor.slice("kwargs{".length, -1);
   const pairs: string[] = [];
   for (const pair of splitPairs(body)) {
     const eq = pair.indexOf("=");
-    if (eq === -1) return null;
-    const value = normalizeArg(pair.slice(eq + 1));
-    if (value === null) return null;
+    if (eq === -1) return OPAQUE;
+    const value = normalizeArgOrFailure(pair.slice(eq + 1));
+    if (typeof value !== "string") return value;
     pairs.push(`${normalizeRubyKey(pair.slice(0, eq))}=${value}`);
   }
   return `kwargs{${pairs.sort().join(",")}}`;
 }
+
+/** Why a descriptor has no comparison key. `opaque` is the deliberate
+ *  exclusion of a form the two languages cannot agree on;
+ *  `unparseableLiteral` is a token {@link normalizeLiteralArg} could not read,
+ *  and the two are tallied apart so a normalization regression in the second is
+ *  visible rather than absorbed into the first (RFC 0095). */
+interface ArgFailure {
+  failure: "opaque" | "unparseableLiteral";
+}
+
+const OPAQUE: ArgFailure = { failure: "opaque" };
+const UNPARSEABLE_LITERAL: ArgFailure = { failure: "unparseableLiteral" };
 
 /**
  * The canonical comparison key for one argument descriptor, or null when the
@@ -205,33 +254,45 @@ function normalizeKwargs(descriptor: string): string | null {
  * tell a local read from a zero-arg self-send, the same information loss the
  * weak-call set already works around (extract-ruby-api.rb#inert_receiver?).
  */
-export function normalizeArg(descriptor: string): string | null {
-  if (OPAQUE_DESCRIPTORS.has(descriptor)) return null;
+function normalizeArgOrFailure(descriptor: string): string | ArgFailure {
+  if (OPAQUE_DESCRIPTORS.has(descriptor)) return OPAQUE;
   if (descriptor === "nil") return "nil";
   if (descriptor.startsWith("kwargs{")) return normalizeKwargs(descriptor);
-  if (descriptor.startsWith("binop:") || descriptor.startsWith("unary")) return null;
+  if (descriptor.startsWith("binop:") || descriptor.startsWith("unary")) return OPAQUE;
 
   const sep = descriptor.indexOf(":");
-  if (sep === -1) return null;
+  if (sep === -1) return OPAQUE;
   const kind = descriptor.slice(0, sep);
   const value = descriptor.slice(sep + 1);
   if (kind === "id" || kind === "call") return `ref:${normalizeRef(value)}`;
   if (kind === "const") return `const:${value}`;
   const literalKind = LITERAL_KINDS[kind];
   return literalKind === undefined
-    ? null
+    ? OPAQUE
     : normalizeLiteralArg(literalKind, unescapeDescriptorText(value));
+}
+
+export function normalizeArg(descriptor: string): string | null {
+  const key = normalizeArgOrFailure(descriptor);
+  return typeof key === "string" ? key : null;
+}
+
+/** Normalize a whole argument list, or the failure of its first uncomparable
+ *  member — which reason it was is the tally's key (RFC 0095). */
+function normalizeArgsOrFailure(args: string[]): string[] | ArgFailure {
+  const out: string[] = [];
+  for (const arg of args) {
+    const key = normalizeArgOrFailure(arg);
+    if (typeof key !== "string") return key;
+    out.push(key);
+  }
+  return out;
 }
 
 /** Normalize a whole argument list, or null when any member is opaque. */
 export function normalizeArgs(args: string[]): string[] | null {
-  const out: string[] = [];
-  for (const arg of args) {
-    const key = normalizeArg(arg);
-    if (key === null) return null;
-    out.push(key);
-  }
-  return out;
+  const keys = normalizeArgsOrFailure(args);
+  return Array.isArray(keys) ? keys : null;
 }
 
 /** Names excluded exactly as the call-set gate excludes them (compare.ts):
@@ -351,13 +412,23 @@ export function pairCallSites(
  *  skip: both extractors drop the block from the argument list and flag the
  *  site, so the remaining arguments still compare. */
 export function compareCallArgs(ruby: CallSite, ts: CallSite): CallArgResult {
-  const empty: CallArgResult = { verdict: "skip", rubyArgs: [], tsArgs: [] };
-  if (isSkippedCallName(ruby.name)) return empty;
-  if (hasUncomparableFlag(ruby) || hasUncomparableFlag(ts)) return empty;
+  const skipped = (reason: CallArgSkipReason): CallArgResult => ({
+    verdict: "skip",
+    reason,
+    rubyArgs: [],
+    tsArgs: [],
+  });
+  if (isSkippedCallName(ruby.name)) return skipped("excludedCallName");
+  if (hasUncomparableFlag(ruby) || hasUncomparableFlag(ts)) return skipped("uncomparableFlag");
 
-  const rubyArgs = normalizeArgs(ruby.args);
-  const tsArgs = normalizeArgs(stripMixinReceiver(ruby.args, ts.args));
-  if (rubyArgs === null || tsArgs === null) return empty;
+  const rubyArgs = normalizeArgsOrFailure(ruby.args);
+  if (!Array.isArray(rubyArgs)) {
+    return skipped(rubyArgs.failure === "opaque" ? "opaqueRubyArg" : "unparseableLiteral");
+  }
+  const tsArgs = normalizeArgsOrFailure(stripMixinReceiver(ruby.args, ts.args));
+  if (!Array.isArray(tsArgs)) {
+    return skipped(tsArgs.failure === "opaque" ? "opaqueTsArg" : "unparseableLiteral");
+  }
 
   if (argsEqual(rubyArgs, tsArgs)) return { verdict: "match", rubyArgs, tsArgs };
   return { verdict: "mismatch", class: classify(rubyArgs, tsArgs), rubyArgs, tsArgs };

--- a/scripts/api-compare/call-mismatches-exclude/abstractcontroller/caching/fragments.json
+++ b/scripts/api-compare/call-mismatches-exclude/abstractcontroller/caching/fragments.json
@@ -3,7 +3,34 @@
     "package": "abstractcontroller",
     "tsFile": "caching/fragments.ts",
     "rubyName": "expire_fragment",
+    "call": "delete",
+    "kind": "args",
+    "rubyArgs": ["ref:key", "ref:options"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "abstractcontroller",
+    "tsFile": "caching/fragments.ts",
+    "rubyName": "expire_fragment",
+    "call": "delete_matched",
+    "kind": "args",
+    "rubyArgs": ["ref:key", "ref:options"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "abstractcontroller",
+    "tsFile": "caching/fragments.ts",
+    "rubyName": "expire_fragment",
     "call": "order:instrumentFragmentCache,combinedFragmentCacheKey",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "abstractcontroller",
+    "tsFile": "caching/fragments.ts",
+    "rubyName": "fragment_exist?",
+    "call": "exist?",
+    "kind": "args",
+    "rubyArgs": ["ref:key", "ref:options"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/abstractcontroller/caching/fragments.json
+++ b/scripts/api-compare/call-mismatches-exclude/abstractcontroller/caching/fragments.json
@@ -5,7 +5,10 @@
     "rubyName": "expire_fragment",
     "call": "delete",
     "kind": "args",
-    "rubyArgs": ["ref:key", "ref:options"],
+    "rubyArgs": [
+      "ref:key",
+      "ref:options"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -14,7 +17,10 @@
     "rubyName": "expire_fragment",
     "call": "delete_matched",
     "kind": "args",
-    "rubyArgs": ["ref:key", "ref:options"],
+    "rubyArgs": [
+      "ref:key",
+      "ref:options"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -30,7 +36,10 @@
     "rubyName": "fragment_exist?",
     "call": "exist?",
     "kind": "args",
-    "rubyArgs": ["ref:key", "ref:options"],
+    "rubyArgs": [
+      "ref:key",
+      "ref:options"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/abstractcontroller/helpers.json
+++ b/scripts/api-compare/call-mismatches-exclude/abstractcontroller/helpers.json
@@ -19,7 +19,9 @@
     "rubyName": "default_helper_module!",
     "call": "helper",
     "kind": "args",
-    "rubyArgs": ["ref:helperPrefix"],
+    "rubyArgs": [
+      "ref:helperPrefix"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -35,7 +37,9 @@
     "rubyName": "helper_modules_from_paths",
     "call": "modules_for_helpers",
     "kind": "args",
-    "rubyArgs": ["ref:allHelpersFromPath"],
+    "rubyArgs": [
+      "ref:allHelpersFromPath"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/abstractcontroller/helpers.json
+++ b/scripts/api-compare/call-mismatches-exclude/abstractcontroller/helpers.json
@@ -16,9 +16,27 @@
   {
     "package": "abstractcontroller",
     "tsFile": "helpers.ts",
+    "rubyName": "default_helper_module!",
+    "call": "helper",
+    "kind": "args",
+    "rubyArgs": ["ref:helperPrefix"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "abstractcontroller",
+    "tsFile": "helpers.ts",
     "rubyName": "helper",
     "call": "modules_for_helpers",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "abstractcontroller",
+    "tsFile": "helpers.ts",
+    "rubyName": "helper_modules_from_paths",
+    "call": "modules_for_helpers",
+    "kind": "args",
+    "rubyArgs": ["ref:allHelpersFromPath"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "abstractcontroller",

--- a/scripts/api-compare/call-mismatches-exclude/actioncontroller/base.json
+++ b/scripts/api-compare/call-mismatches-exclude/actioncontroller/base.json
@@ -10,6 +10,15 @@
     "package": "actioncontroller",
     "tsFile": "base.ts",
     "rubyName": "allow_browser",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:request", "kwargs{versions=ref:versions}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "base.ts",
+    "rubyName": "allow_browser",
     "call": "require",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -54,6 +63,15 @@
     "rubyName": "fresh_when",
     "call": "fresh?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "base.ts",
+    "rubyName": "fresh_when",
+    "call": "head",
+    "kind": "args",
+    "rubyArgs": ["str:notModified"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "actioncontroller",
@@ -129,6 +147,15 @@
     "package": "actioncontroller",
     "tsFile": "base.ts",
     "rubyName": "redirect_to",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["str:Cannot redirect to nil!"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "base.ts",
+    "rubyName": "redirect_to",
     "call": "response_body",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -152,6 +179,15 @@
     "rubyName": "render",
     "call": "response_body",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "base.ts",
+    "rubyName": "respond_to",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:mimes", "ref:variant"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "actioncontroller",

--- a/scripts/api-compare/call-mismatches-exclude/actioncontroller/base.json
+++ b/scripts/api-compare/call-mismatches-exclude/actioncontroller/base.json
@@ -12,7 +12,10 @@
     "rubyName": "allow_browser",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:request", "kwargs{versions=ref:versions}"],
+    "rubyArgs": [
+      "ref:request",
+      "kwargs{versions=ref:versions}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -70,7 +73,9 @@
     "rubyName": "fresh_when",
     "call": "head",
     "kind": "args",
-    "rubyArgs": ["str:notModified"],
+    "rubyArgs": [
+      "str:notModified"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -149,7 +154,9 @@
     "rubyName": "redirect_to",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["str:Cannot redirect to nil!"],
+    "rubyArgs": [
+      "str:Cannot redirect to nil!"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -186,7 +193,10 @@
     "rubyName": "respond_to",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:mimes", "ref:variant"],
+    "rubyArgs": [
+      "ref:mimes",
+      "ref:variant"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/actioncontroller/log-subscriber.json
+++ b/scripts/api-compare/call-mismatches-exclude/actioncontroller/log-subscriber.json
@@ -12,7 +12,9 @@
     "rubyName": "process_action",
     "call": "round",
     "kind": "args",
-    "rubyArgs": ["num:1"],
+    "rubyArgs": [
+      "num:1"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/actioncontroller/log-subscriber.json
+++ b/scripts/api-compare/call-mismatches-exclude/actioncontroller/log-subscriber.json
@@ -9,6 +9,15 @@
   {
     "package": "actioncontroller",
     "tsFile": "log-subscriber.ts",
+    "rubyName": "process_action",
+    "call": "round",
+    "kind": "args",
+    "rubyArgs": ["num:1"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "log-subscriber.ts",
     "rubyName": "start_processing",
     "call": "each_pair",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal.json
+++ b/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal.json
@@ -19,7 +19,13 @@
     "rubyName": "build_middleware",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:klass", "ref:args", "ref:list", "ref:strategy", "ref:block"],
+    "rubyArgs": [
+      "ref:klass",
+      "ref:args",
+      "ref:list",
+      "ref:strategy",
+      "ref:block"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal.json
+++ b/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal.json
@@ -16,6 +16,15 @@
   {
     "package": "actioncontroller",
     "tsFile": "metal.ts",
+    "rubyName": "build_middleware",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:klass", "ref:args", "ref:list", "ref:strategy", "ref:block"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal.ts",
     "rubyName": "dispatch",
     "call": "process",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal/exceptions.json
+++ b/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal/exceptions.json
@@ -5,7 +5,9 @@
     "rubyName": "corrections",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["kwargs{dictionary=ref:maybeThese}"],
+    "rubyArgs": [
+      "kwargs{dictionary=ref:maybeThese}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal/exceptions.json
+++ b/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal/exceptions.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/exceptions.ts",
+    "rubyName": "corrections",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["kwargs{dictionary=ref:maybeThese}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal/live.json
+++ b/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal/live.json
@@ -9,6 +9,15 @@
   {
     "package": "actioncontroller",
     "tsFile": "metal/live.ts",
+    "rubyName": "new_controller_thread",
+    "call": "post",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/live.ts",
     "rubyName": "perform_write",
     "call": "merge",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal/mime-responds.json
+++ b/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal/mime-responds.json
@@ -17,6 +17,15 @@
     "package": "actioncontroller",
     "tsFile": "metal/mime-responds.ts",
     "rubyName": "respond_to",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:mimes", "ref:variant"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/mime-responds.ts",
+    "rubyName": "respond_to",
     "call": "variant",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }

--- a/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal/mime-responds.json
+++ b/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal/mime-responds.json
@@ -19,7 +19,10 @@
     "rubyName": "respond_to",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:mimes", "ref:variant"],
+    "rubyArgs": [
+      "ref:mimes",
+      "ref:variant"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal/params-wrapper.json
+++ b/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal/params-wrapper.json
@@ -3,6 +3,15 @@
     "package": "actioncontroller",
     "tsFile": "metal/params-wrapper.ts",
     "rubyName": "_perform_parameter_wrapping",
+    "call": "keys",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/params-wrapper.ts",
+    "rubyName": "_perform_parameter_wrapping",
     "call": "merge!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal/request-forgery-protection.json
+++ b/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal/request-forgery-protection.json
@@ -21,7 +21,10 @@
     "rubyName": "any_authenticity_token_valid?",
     "call": "valid_authenticity_token?",
     "kind": "args",
-    "rubyArgs": ["ref:session", "ref:token"],
+    "rubyArgs": [
+      "ref:session",
+      "ref:token"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -30,7 +33,9 @@
     "rubyName": "compare_with_global_token",
     "call": "global_csrf_token",
     "kind": "args",
-    "rubyArgs": ["ref:session"],
+    "rubyArgs": [
+      "ref:session"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -39,7 +44,9 @@
     "rubyName": "compare_with_real_token",
     "call": "real_csrf_token",
     "kind": "args",
-    "rubyArgs": ["ref:session"],
+    "rubyArgs": [
+      "ref:session"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -48,7 +55,11 @@
     "rubyName": "csrf_token_hmac",
     "call": "digest",
     "kind": "args",
-    "rubyArgs": ["ref:constructor", "ref:realCsrfToken", "ref:identifier"],
+    "rubyArgs": [
+      "ref:constructor",
+      "ref:realCsrfToken",
+      "ref:identifier"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -57,7 +68,9 @@
     "rubyName": "csrf_token_hmac",
     "call": "real_csrf_token",
     "kind": "args",
-    "rubyArgs": ["ref:session"],
+    "rubyArgs": [
+      "ref:session"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -66,7 +79,10 @@
     "rubyName": "global_csrf_token",
     "call": "csrf_token_hmac",
     "kind": "args",
-    "rubyArgs": ["ref:session", "const:GLOBAL_CSRF_TOKEN_IDENTIFIER"],
+    "rubyArgs": [
+      "ref:session",
+      "const:GLOBAL_CSRF_TOKEN_IDENTIFIER"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -105,7 +121,9 @@
     "rubyName": "masked_authenticity_token",
     "call": "normalize_action_path",
     "kind": "args",
-    "rubyArgs": ["ref:action"],
+    "rubyArgs": [
+      "ref:action"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -121,7 +139,11 @@
     "rubyName": "masked_authenticity_token",
     "call": "per_form_csrf_token",
     "kind": "args",
-    "rubyArgs": ["nil", "ref:actionPath", "ref:method"],
+    "rubyArgs": [
+      "nil",
+      "ref:actionPath",
+      "ref:method"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -130,7 +152,9 @@
     "rubyName": "normalize_action_path",
     "call": "normalize_relative_action_path",
     "kind": "args",
-    "rubyArgs": ["ref:path"],
+    "rubyArgs": [
+      "ref:path"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -139,7 +163,9 @@
     "rubyName": "real_csrf_token",
     "call": "fetch",
     "kind": "args",
-    "rubyArgs": ["const:CSRF_TOKEN"],
+    "rubyArgs": [
+      "const:CSRF_TOKEN"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -180,7 +206,9 @@
     "rubyName": "valid_authenticity_token?",
     "call": "compare_with_global_token",
     "kind": "args",
-    "rubyArgs": ["ref:csrfToken"],
+    "rubyArgs": [
+      "ref:csrfToken"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -189,7 +217,9 @@
     "rubyName": "valid_authenticity_token?",
     "call": "compare_with_real_token",
     "kind": "args",
-    "rubyArgs": ["ref:csrfToken"],
+    "rubyArgs": [
+      "ref:csrfToken"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -198,7 +228,9 @@
     "rubyName": "valid_authenticity_token?",
     "call": "compare_with_real_token",
     "kind": "args",
-    "rubyArgs": ["ref:maskedToken"],
+    "rubyArgs": [
+      "ref:maskedToken"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -207,7 +239,9 @@
     "rubyName": "valid_authenticity_token?",
     "call": "valid_per_form_csrf_token?",
     "kind": "args",
-    "rubyArgs": ["ref:csrfToken"],
+    "rubyArgs": [
+      "ref:csrfToken"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -216,7 +250,11 @@
     "rubyName": "valid_per_form_csrf_token?",
     "call": "per_form_csrf_token",
     "kind": "args",
-    "rubyArgs": ["ref:session", "ref:chomp", "ref:requestMethod"],
+    "rubyArgs": [
+      "ref:session",
+      "ref:chomp",
+      "ref:requestMethod"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal/request-forgery-protection.json
+++ b/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal/request-forgery-protection.json
@@ -9,6 +9,69 @@
   {
     "package": "actioncontroller",
     "tsFile": "metal/request-forgery-protection.ts",
+    "rubyName": "any_authenticity_token_valid?",
+    "call": "request_authenticity_tokens",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/request-forgery-protection.ts",
+    "rubyName": "any_authenticity_token_valid?",
+    "call": "valid_authenticity_token?",
+    "kind": "args",
+    "rubyArgs": ["ref:session", "ref:token"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/request-forgery-protection.ts",
+    "rubyName": "compare_with_global_token",
+    "call": "global_csrf_token",
+    "kind": "args",
+    "rubyArgs": ["ref:session"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/request-forgery-protection.ts",
+    "rubyName": "compare_with_real_token",
+    "call": "real_csrf_token",
+    "kind": "args",
+    "rubyArgs": ["ref:session"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/request-forgery-protection.ts",
+    "rubyName": "csrf_token_hmac",
+    "call": "digest",
+    "kind": "args",
+    "rubyArgs": ["ref:constructor", "ref:realCsrfToken", "ref:identifier"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/request-forgery-protection.ts",
+    "rubyName": "csrf_token_hmac",
+    "call": "real_csrf_token",
+    "kind": "args",
+    "rubyArgs": ["ref:session"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/request-forgery-protection.ts",
+    "rubyName": "global_csrf_token",
+    "call": "csrf_token_hmac",
+    "kind": "args",
+    "rubyArgs": ["ref:session", "const:GLOBAL_CSRF_TOKEN_IDENTIFIER"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/request-forgery-protection.ts",
     "rubyName": "handle_unverified_request",
     "call": "build",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -31,8 +94,62 @@
     "package": "actioncontroller",
     "tsFile": "metal/request-forgery-protection.ts",
     "rubyName": "masked_authenticity_token",
+    "call": "global_csrf_token",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/request-forgery-protection.ts",
+    "rubyName": "masked_authenticity_token",
+    "call": "normalize_action_path",
+    "kind": "args",
+    "rubyArgs": ["ref:action"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/request-forgery-protection.ts",
+    "rubyName": "masked_authenticity_token",
     "call": "order:perFormCsrfToken,normalizeActionPath",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/request-forgery-protection.ts",
+    "rubyName": "masked_authenticity_token",
+    "call": "per_form_csrf_token",
+    "kind": "args",
+    "rubyArgs": ["nil", "ref:actionPath", "ref:method"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/request-forgery-protection.ts",
+    "rubyName": "normalize_action_path",
+    "call": "normalize_relative_action_path",
+    "kind": "args",
+    "rubyArgs": ["ref:path"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/request-forgery-protection.ts",
+    "rubyName": "real_csrf_token",
+    "call": "fetch",
+    "kind": "args",
+    "rubyArgs": ["const:CSRF_TOKEN"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/request-forgery-protection.ts",
+    "rubyName": "request_authenticity_tokens",
+    "call": "form_authenticity_param",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "actioncontroller",
@@ -51,6 +168,60 @@
   {
     "package": "actioncontroller",
     "tsFile": "metal/request-forgery-protection.ts",
+    "rubyName": "unverified_request_warning_message",
+    "call": "valid_request_origin?",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/request-forgery-protection.ts",
+    "rubyName": "valid_authenticity_token?",
+    "call": "compare_with_global_token",
+    "kind": "args",
+    "rubyArgs": ["ref:csrfToken"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/request-forgery-protection.ts",
+    "rubyName": "valid_authenticity_token?",
+    "call": "compare_with_real_token",
+    "kind": "args",
+    "rubyArgs": ["ref:csrfToken"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/request-forgery-protection.ts",
+    "rubyName": "valid_authenticity_token?",
+    "call": "compare_with_real_token",
+    "kind": "args",
+    "rubyArgs": ["ref:maskedToken"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/request-forgery-protection.ts",
+    "rubyName": "valid_authenticity_token?",
+    "call": "valid_per_form_csrf_token?",
+    "kind": "args",
+    "rubyArgs": ["ref:csrfToken"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/request-forgery-protection.ts",
+    "rubyName": "valid_per_form_csrf_token?",
+    "call": "per_form_csrf_token",
+    "kind": "args",
+    "rubyArgs": ["ref:session", "ref:chomp", "ref:requestMethod"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/request-forgery-protection.ts",
     "rubyName": "verified_request?",
     "call": "get?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -61,5 +232,41 @@
     "rubyName": "verified_request?",
     "call": "head?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/request-forgery-protection.ts",
+    "rubyName": "verified_request?",
+    "call": "protect_against_forgery?",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/request-forgery-protection.ts",
+    "rubyName": "verified_request?",
+    "call": "valid_request_origin?",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/request-forgery-protection.ts",
+    "rubyName": "verify_same_origin_request",
+    "call": "marked_for_same_origin_verification?",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/request-forgery-protection.ts",
+    "rubyName": "verify_same_origin_request",
+    "call": "non_xhr_javascript_response?",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal/strong-parameters.json
+++ b/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal/strong-parameters.json
@@ -51,6 +51,15 @@
   {
     "package": "actioncontroller",
     "tsFile": "metal/strong-parameters.ts",
+    "rubyName": "deep_dup",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:deepDup", "ref:loggingContext"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/strong-parameters.ts",
     "rubyName": "deep_transform_keys",
     "call": "new_instance_with_inherited_permitted_status",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -198,6 +207,15 @@
   {
     "package": "actioncontroller",
     "tsFile": "metal/strong-parameters.ts",
+    "rubyName": "require",
+    "call": "keys",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/strong-parameters.ts",
     "rubyName": "reverse_merge",
     "call": "merge",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -264,6 +282,15 @@
     "rubyName": "transform_values!",
     "call": "convert_value_to_parameters",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/strong-parameters.ts",
+    "rubyName": "unpermitted_keys",
+    "call": "keys",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "actioncontroller",

--- a/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal/strong-parameters.json
+++ b/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal/strong-parameters.json
@@ -54,7 +54,10 @@
     "rubyName": "deep_dup",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:deepDup", "ref:loggingContext"],
+    "rubyArgs": [
+      "ref:deepDup",
+      "ref:loggingContext"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/actioncontroller/test-case.json
+++ b/scripts/api-compare/call-mismatches-exclude/actioncontroller/test-case.json
@@ -19,7 +19,9 @@
     "rubyName": "assign_parameters",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:b"],
+    "rubyArgs": [
+      "ref:b"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -35,7 +37,10 @@
     "rubyName": "assign_parameters",
     "call": "set_header",
     "kind": "args",
-    "rubyArgs": ["ref:k", "ref:generatedPath"],
+    "rubyArgs": [
+      "ref:k",
+      "ref:generatedPath"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -58,7 +63,9 @@
     "rubyName": "process",
     "call": "build_response",
     "kind": "args",
-    "rubyArgs": ["ref:responseKlass"],
+    "rubyArgs": [
+      "ref:responseKlass"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -74,7 +81,11 @@
     "rubyName": "process",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:scrub_env!", "ref:session", "ref:class"],
+    "rubyArgs": [
+      "ref:scrub_env!",
+      "ref:session",
+      "ref:class"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -83,7 +94,11 @@
     "rubyName": "process",
     "call": "process_controller_response",
     "kind": "args",
-    "rubyArgs": ["ref:action", "ref:cookies", "ref:xhr"],
+    "rubyArgs": [
+      "ref:action",
+      "ref:cookies",
+      "ref:xhr"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -141,7 +156,10 @@
     "rubyName": "query_string=",
     "call": "set_header",
     "kind": "args",
-    "rubyArgs": ["const:QUERY_STRING", "ref:string"],
+    "rubyArgs": [
+      "const:QUERY_STRING",
+      "ref:string"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/actioncontroller/test-case.json
+++ b/scripts/api-compare/call-mismatches-exclude/actioncontroller/test-case.json
@@ -17,8 +17,26 @@
     "package": "actioncontroller",
     "tsFile": "test-case.ts",
     "rubyName": "assign_parameters",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:b"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "test-case.ts",
+    "rubyName": "assign_parameters",
     "call": "query_string",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "test-case.ts",
+    "rubyName": "assign_parameters",
+    "call": "set_header",
+    "kind": "args",
+    "rubyArgs": ["ref:k", "ref:generatedPath"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "actioncontroller",
@@ -38,8 +56,35 @@
     "package": "actioncontroller",
     "tsFile": "test-case.ts",
     "rubyName": "process",
+    "call": "build_response",
+    "kind": "args",
+    "rubyArgs": ["ref:responseKlass"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "test-case.ts",
+    "rubyName": "process",
     "call": "clear_instance_variables_between_requests",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "test-case.ts",
+    "rubyName": "process",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:scrub_env!", "ref:session", "ref:class"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "test-case.ts",
+    "rubyName": "process",
+    "call": "process_controller_response",
+    "kind": "args",
+    "rubyArgs": ["ref:action", "ref:cookies", "ref:xhr"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "actioncontroller",
@@ -93,8 +138,26 @@
   {
     "package": "actioncontroller",
     "tsFile": "test-case.ts",
+    "rubyName": "query_string=",
+    "call": "set_header",
+    "kind": "args",
+    "rubyArgs": ["const:QUERY_STRING", "ref:string"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "test-case.ts",
     "rubyName": "scrub_env!",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "test-case.ts",
+    "rubyName": "tests",
+    "call": "camelize",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/cache.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/cache.json
@@ -9,6 +9,24 @@
   {
     "package": "actiondispatch",
     "tsFile": "http/cache.ts",
+    "rubyName": "strong_etag=",
+    "call": "set_header",
+    "kind": "args",
+    "rubyArgs": ["str:ETag", "ref:generateStrongEtag"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/cache.ts",
+    "rubyName": "weak_etag=",
+    "call": "set_header",
+    "kind": "args",
+    "rubyArgs": ["str:ETag", "ref:generateWeakEtag"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/cache.ts",
     "rubyName": "weak_etag?",
     "call": "etag",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/cache.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/cache.json
@@ -12,7 +12,10 @@
     "rubyName": "strong_etag=",
     "call": "set_header",
     "kind": "args",
-    "rubyArgs": ["str:ETag", "ref:generateStrongEtag"],
+    "rubyArgs": [
+      "str:ETag",
+      "ref:generateStrongEtag"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -21,7 +24,10 @@
     "rubyName": "weak_etag=",
     "call": "set_header",
     "kind": "args",
-    "rubyArgs": ["str:ETag", "ref:generateWeakEtag"],
+    "rubyArgs": [
+      "str:ETag",
+      "ref:generateWeakEtag"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/content-disposition.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/content-disposition.json
@@ -5,7 +5,9 @@
     "rubyName": "format",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["kwargs{disposition=ref:disposition,filename=ref:filename}"],
+    "rubyArgs": [
+      "kwargs{disposition=ref:disposition,filename=ref:filename}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/content-disposition.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/content-disposition.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/content-disposition.ts",
+    "rubyName": "format",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["kwargs{disposition=ref:disposition,filename=ref:filename}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/filter-parameters.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/filter-parameters.json
@@ -19,7 +19,9 @@
     "rubyName": "filtered_query_string",
     "call": "join",
     "kind": "args",
-    "rubyArgs": ["str:="],
+    "rubyArgs": [
+      "str:="
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/filter-parameters.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/filter-parameters.json
@@ -12,5 +12,14 @@
     "rubyName": "filtered_parameters",
     "call": "parameters",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/filter-parameters.ts",
+    "rubyName": "filtered_query_string",
+    "call": "join",
+    "kind": "args",
+    "rubyArgs": ["str:="],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/filter-redirect.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/filter-redirect.json
@@ -5,7 +5,9 @@
     "rubyName": "parameter_filtered_location",
     "call": "join",
     "kind": "args",
-    "rubyArgs": ["str:="],
+    "rubyArgs": [
+      "str:="
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/filter-redirect.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/filter-redirect.json
@@ -3,6 +3,15 @@
     "package": "actiondispatch",
     "tsFile": "http/filter-redirect.ts",
     "rubyName": "parameter_filtered_location",
+    "call": "join",
+    "kind": "args",
+    "rubyArgs": ["str:="],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/filter-redirect.ts",
+    "rubyName": "parameter_filtered_location",
     "call": "parse",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/mime-negotiation.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/mime-negotiation.json
@@ -9,9 +9,45 @@
   {
     "package": "actiondispatch",
     "tsFile": "http/mime-negotiation.ts",
+    "rubyName": "accepts",
+    "call": "get_header",
+    "kind": "args",
+    "rubyArgs": ["str:HTTP_ACCEPT"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/mime-negotiation.ts",
+    "rubyName": "accepts",
+    "call": "set_header",
+    "kind": "args",
+    "rubyArgs": ["ref:k", "ref:v"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/mime-negotiation.ts",
     "rubyName": "content_mime_type",
     "call": "fetch_header",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/mime-negotiation.ts",
+    "rubyName": "content_mime_type",
+    "call": "get_header",
+    "kind": "args",
+    "rubyArgs": ["str:CONTENT_TYPE"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/mime-negotiation.ts",
+    "rubyName": "content_mime_type",
+    "call": "set_header",
+    "kind": "args",
+    "rubyArgs": ["ref:k", "ref:v"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "actiondispatch",

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/mime-negotiation.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/mime-negotiation.json
@@ -12,7 +12,9 @@
     "rubyName": "accepts",
     "call": "get_header",
     "kind": "args",
-    "rubyArgs": ["str:HTTP_ACCEPT"],
+    "rubyArgs": [
+      "str:HTTP_ACCEPT"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -21,7 +23,10 @@
     "rubyName": "accepts",
     "call": "set_header",
     "kind": "args",
-    "rubyArgs": ["ref:k", "ref:v"],
+    "rubyArgs": [
+      "ref:k",
+      "ref:v"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -37,7 +42,9 @@
     "rubyName": "content_mime_type",
     "call": "get_header",
     "kind": "args",
-    "rubyArgs": ["str:CONTENT_TYPE"],
+    "rubyArgs": [
+      "str:CONTENT_TYPE"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -46,7 +53,10 @@
     "rubyName": "content_mime_type",
     "call": "set_header",
     "kind": "args",
-    "rubyArgs": ["ref:k", "ref:v"],
+    "rubyArgs": [
+      "ref:k",
+      "ref:v"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/mime-type.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/mime-type.json
@@ -9,6 +9,15 @@
   {
     "package": "actiondispatch",
     "tsFile": "http/mime-type.ts",
+    "rubyName": "lookup",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:string"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/mime-type.ts",
     "rubyName": "match?",
     "call": "any?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/mime-type.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/mime-type.json
@@ -12,7 +12,9 @@
     "rubyName": "lookup",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:string"],
+    "rubyArgs": [
+      "ref:string"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/param-builder.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/param-builder.json
@@ -19,7 +19,10 @@
     "rubyName": "new_depth_limit",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:paramsClass", "ref:paramDepthLimit"],
+    "rubyArgs": [
+      "ref:paramsClass",
+      "ref:paramDepthLimit"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/param-builder.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/param-builder.json
@@ -16,6 +16,15 @@
   {
     "package": "actiondispatch",
     "tsFile": "http/param-builder.ts",
+    "rubyName": "new_depth_limit",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:paramsClass", "ref:paramDepthLimit"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/param-builder.ts",
     "rubyName": "store_nested_param",
     "call": "params_hash_has_key?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/request.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/request.json
@@ -124,7 +124,9 @@
     "rubyName": "read_body_stream",
     "call": "has_header?",
     "kind": "args",
-    "rubyArgs": ["const:TRANSFER_ENCODING"],
+    "rubyArgs": [
+      "const:TRANSFER_ENCODING"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/request.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/request.json
@@ -121,6 +121,15 @@
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
+    "rubyName": "read_body_stream",
+    "call": "has_header?",
+    "kind": "args",
+    "rubyArgs": ["const:TRANSFER_ENCODING"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/request.ts",
     "rubyName": "request_parameters_list",
     "call": "get_header",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/journey/gtg/transition-table.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/journey/gtg/transition-table.json
@@ -5,7 +5,11 @@
     "rubyName": "visualizer",
     "call": "join",
     "kind": "args",
-    "rubyArgs": ["ref:__dir__", "str:..", "str:visualizer"],
+    "rubyArgs": [
+      "ref:__dir__",
+      "str:..",
+      "str:visualizer"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/journey/gtg/transition-table.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/journey/gtg/transition-table.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "actiondispatch",
+    "tsFile": "journey/gtg/transition-table.ts",
+    "rubyName": "visualizer",
+    "call": "join",
+    "kind": "args",
+    "rubyArgs": ["ref:__dir__", "str:..", "str:visualizer"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/journey/nfa/dot.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/journey/nfa/dot.json
@@ -5,7 +5,9 @@
     "rubyName": "to_dot",
     "call": "join",
     "kind": "args",
-    "rubyArgs": ["str: "],
+    "rubyArgs": [
+      "str: "
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/journey/nfa/dot.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/journey/nfa/dot.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "actiondispatch",
+    "tsFile": "journey/nfa/dot.ts",
+    "rubyName": "to_dot",
+    "call": "join",
+    "kind": "args",
+    "rubyArgs": ["str: "],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/journey/parser.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/journey/parser.json
@@ -5,7 +5,9 @@
     "rubyName": "parse_group",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:node"],
+    "rubyArgs": [
+      "ref:node"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -14,7 +16,9 @@
     "rubyName": "parse_star",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:constructor"],
+    "rubyArgs": [
+      "ref:constructor"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -23,7 +27,10 @@
     "rubyName": "parse_star",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:lastString", "const:GREEDY_EXP"],
+    "rubyArgs": [
+      "ref:lastString",
+      "const:GREEDY_EXP"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/journey/parser.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/journey/parser.json
@@ -1,0 +1,29 @@
+[
+  {
+    "package": "actiondispatch",
+    "tsFile": "journey/parser.ts",
+    "rubyName": "parse_group",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:node"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "journey/parser.ts",
+    "rubyName": "parse_star",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:constructor"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "journey/parser.ts",
+    "rubyName": "parse_star",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:lastString", "const:GREEDY_EXP"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/journey/path/pattern.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/journey/path/pattern.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "actiondispatch",
+    "tsFile": "journey/path/pattern.ts",
+    "rubyName": "to_regexp",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:separators", "ref:requirements"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/journey/path/pattern.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/journey/path/pattern.json
@@ -5,7 +5,10 @@
     "rubyName": "to_regexp",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:separators", "ref:requirements"],
+    "rubyArgs": [
+      "ref:separators",
+      "ref:requirements"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/journey/route.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/journey/route.json
@@ -9,6 +9,15 @@
   {
     "package": "actiondispatch",
     "tsFile": "journey/route.ts",
+    "rubyName": "required_keys",
+    "call": "keys",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "journey/route.ts",
     "rubyName": "verb_matcher",
     "call": "fetch",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/journey/router.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/journey/router.json
@@ -12,7 +12,9 @@
     "rubyName": "visualizer",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:ast"],
+    "rubyArgs": [
+      "ref:ast"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/journey/router.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/journey/router.json
@@ -5,5 +5,14 @@
     "rubyName": "recognize",
     "call": "merge",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "journey/router.ts",
+    "rubyName": "visualizer",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:ast"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/log-subscriber.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/log-subscriber.json
@@ -5,5 +5,14 @@
     "rubyName": "redirect",
     "call": "env",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "log-subscriber.ts",
+    "rubyName": "redirect",
+    "call": "round",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/cookies.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/cookies.json
@@ -26,7 +26,9 @@
     "rubyName": "encrypted",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:this"],
+    "rubyArgs": [
+      "ref:this"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -49,7 +51,9 @@
     "rubyName": "signed",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:this"],
+    "rubyArgs": [
+      "ref:this"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/cookies.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/cookies.json
@@ -23,6 +23,15 @@
   {
     "package": "actiondispatch",
     "tsFile": "middleware/cookies.ts",
+    "rubyName": "encrypted",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:this"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "middleware/cookies.ts",
     "rubyName": "have_cookie_jar?",
     "call": "has_header?",
     "reason": "Rack header accessor (`get_header`/`set_header`/`fetch_header`/`has_header?`). trails' request/response objects expose headers as direct property/map access instead of the Rack accessor pair, so the accessor call name is absent by design. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
@@ -33,5 +42,14 @@
     "rubyName": "parse",
     "call": "reserialize?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "middleware/cookies.ts",
+    "rubyName": "signed",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:this"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/debug-exceptions.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/debug-exceptions.json
@@ -2,6 +2,15 @@
   {
     "package": "actiondispatch",
     "tsFile": "middleware/debug-exceptions.ts",
+    "rubyName": "call",
+    "call": "render_exception",
+    "kind": "args",
+    "rubyArgs": ["ref:request", "ref:exception", "ref:wrapper"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "middleware/debug-exceptions.ts",
     "rubyName": "render",
     "call": "default_charset",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -9,9 +18,27 @@
   {
     "package": "actiondispatch",
     "tsFile": "middleware/debug-exceptions.ts",
+    "rubyName": "render_exception",
+    "call": "render_for_api_request",
+    "kind": "args",
+    "rubyArgs": ["ref:contentType", "ref:wrapper"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "middleware/debug-exceptions.ts",
     "rubyName": "render_for_api_request",
     "call": "fetch",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "middleware/debug-exceptions.ts",
+    "rubyName": "render_for_api_request",
+    "call": "render",
+    "kind": "args",
+    "rubyArgs": ["ref:statusCode", "ref:formattedBody", "ref:format"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "actiondispatch",

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/debug-exceptions.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/debug-exceptions.json
@@ -5,7 +5,11 @@
     "rubyName": "call",
     "call": "render_exception",
     "kind": "args",
-    "rubyArgs": ["ref:request", "ref:exception", "ref:wrapper"],
+    "rubyArgs": [
+      "ref:request",
+      "ref:exception",
+      "ref:wrapper"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -21,7 +25,10 @@
     "rubyName": "render_exception",
     "call": "render_for_api_request",
     "kind": "args",
-    "rubyArgs": ["ref:contentType", "ref:wrapper"],
+    "rubyArgs": [
+      "ref:contentType",
+      "ref:wrapper"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -37,7 +44,11 @@
     "rubyName": "render_for_api_request",
     "call": "render",
     "kind": "args",
-    "rubyArgs": ["ref:statusCode", "ref:formattedBody", "ref:format"],
+    "rubyArgs": [
+      "ref:statusCode",
+      "ref:formattedBody",
+      "ref:format"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/debug-locks.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/debug-locks.json
@@ -5,7 +5,9 @@
     "rubyName": "call",
     "call": "render_details",
     "kind": "args",
-    "rubyArgs": ["ref:req"],
+    "rubyArgs": [
+      "ref:req"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -14,7 +16,9 @@
     "rubyName": "render_details",
     "call": "join",
     "kind": "args",
-    "rubyArgs": ["str:<n>"],
+    "rubyArgs": [
+      "str:<n>"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -23,7 +27,9 @@
     "rubyName": "render_details",
     "call": "join",
     "kind": "args",
-    "rubyArgs": ["str:<n><n>---<n><n><n>"],
+    "rubyArgs": [
+      "str:<n><n>---<n><n><n>"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/debug-locks.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/debug-locks.json
@@ -1,0 +1,29 @@
+[
+  {
+    "package": "actiondispatch",
+    "tsFile": "middleware/debug-locks.ts",
+    "rubyName": "call",
+    "call": "render_details",
+    "kind": "args",
+    "rubyArgs": ["ref:req"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "middleware/debug-locks.ts",
+    "rubyName": "render_details",
+    "call": "join",
+    "kind": "args",
+    "rubyArgs": ["str:<n>"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "middleware/debug-locks.ts",
+    "rubyName": "render_details",
+    "call": "join",
+    "kind": "args",
+    "rubyArgs": ["str:<n><n>---<n><n><n>"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/executor.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/executor.json
@@ -5,7 +5,10 @@
     "rubyName": "call",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:backtraceCleaner", "ref:error"],
+    "rubyArgs": [
+      "ref:backtraceCleaner",
+      "ref:error"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/executor.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/executor.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "actiondispatch",
+    "tsFile": "middleware/executor.ts",
+    "rubyName": "call",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:backtraceCleaner", "ref:error"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/public-exceptions.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/public-exceptions.json
@@ -12,5 +12,14 @@
     "rubyName": "call",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "middleware/public-exceptions.ts",
+    "rubyName": "render_html",
+    "call": "render_format",
+    "kind": "args",
+    "rubyArgs": ["ref:status", "str:text/html", "ref:read"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/public-exceptions.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/public-exceptions.json
@@ -19,7 +19,11 @@
     "rubyName": "render_html",
     "call": "render_format",
     "kind": "args",
-    "rubyArgs": ["ref:status", "str:text/html", "ref:read"],
+    "rubyArgs": [
+      "ref:status",
+      "str:text/html",
+      "ref:read"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/remote-ip.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/remote-ip.json
@@ -5,7 +5,9 @@
     "rubyName": "call",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:env"],
+    "rubyArgs": [
+      "ref:env"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/remote-ip.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/remote-ip.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "actiondispatch",
+    "tsFile": "middleware/remote-ip.ts",
+    "rubyName": "call",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:env"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/show-exceptions.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/show-exceptions.json
@@ -2,6 +2,15 @@
   {
     "package": "actiondispatch",
     "tsFile": "middleware/show-exceptions.ts",
+    "rubyName": "call",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:backtraceCleaner", "ref:exception"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "middleware/show-exceptions.ts",
     "rubyName": "pass_response",
     "call": "default_charset",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/show-exceptions.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/show-exceptions.json
@@ -5,7 +5,10 @@
     "rubyName": "call",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:backtraceCleaner", "ref:exception"],
+    "rubyArgs": [
+      "ref:backtraceCleaner",
+      "ref:exception"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/stack.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/stack.json
@@ -149,6 +149,15 @@
   {
     "package": "actiondispatch",
     "tsFile": "middleware/stack.ts",
+    "rubyName": "unshift",
+    "call": "unshift",
+    "kind": "args",
+    "rubyArgs": ["ref:buildMiddleware"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "middleware/stack.ts",
     "rubyName": "use",
     "call": "build_middleware",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -159,5 +168,14 @@
     "rubyName": "use",
     "call": "middlewares",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "middleware/stack.ts",
+    "rubyName": "use",
+    "call": "push",
+    "kind": "args",
+    "rubyArgs": ["ref:buildMiddleware"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/stack.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/stack.json
@@ -152,7 +152,9 @@
     "rubyName": "unshift",
     "call": "unshift",
     "kind": "args",
-    "rubyArgs": ["ref:buildMiddleware"],
+    "rubyArgs": [
+      "ref:buildMiddleware"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -175,7 +177,9 @@
     "rubyName": "use",
     "call": "push",
     "kind": "args",
-    "rubyArgs": ["ref:buildMiddleware"],
+    "rubyArgs": [
+      "ref:buildMiddleware"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/static.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/static.json
@@ -5,7 +5,10 @@
     "rubyName": "attempt",
     "call": "find_file",
     "kind": "args",
-    "rubyArgs": ["ref:pathInfo", "kwargs{acceptEncoding=ref:acceptEncoding}"],
+    "rubyArgs": [
+      "ref:pathInfo",
+      "kwargs{acceptEncoding=ref:acceptEncoding}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -21,7 +24,9 @@
     "rubyName": "file_readable?",
     "call": "file?",
     "kind": "args",
-    "rubyArgs": ["ref:filePath"],
+    "rubyArgs": [
+      "ref:filePath"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -30,7 +35,11 @@
     "rubyName": "find_file",
     "call": "try_files",
     "kind": "args",
-    "rubyArgs": ["ref:filepath", "ref:contentType", "kwargs{acceptEncoding=ref:acceptEncoding}"],
+    "rubyArgs": [
+      "ref:filepath",
+      "ref:contentType",
+      "kwargs{acceptEncoding=ref:acceptEncoding}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -53,7 +62,11 @@
     "rubyName": "try_files",
     "call": "try_precompressed_files",
     "kind": "args",
-    "rubyArgs": ["ref:filepath", "ref:headers", "kwargs{acceptEncoding=ref:acceptEncoding}"],
+    "rubyArgs": [
+      "ref:filepath",
+      "ref:headers",
+      "kwargs{acceptEncoding=ref:acceptEncoding}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/static.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/static.json
@@ -2,9 +2,36 @@
   {
     "package": "actiondispatch",
     "tsFile": "middleware/static.ts",
+    "rubyName": "attempt",
+    "call": "find_file",
+    "kind": "args",
+    "rubyArgs": ["ref:pathInfo", "kwargs{acceptEncoding=ref:acceptEncoding}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "middleware/static.ts",
     "rubyName": "each_precompressed_filepath",
     "call": "fetch",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "middleware/static.ts",
+    "rubyName": "file_readable?",
+    "call": "file?",
+    "kind": "args",
+    "rubyArgs": ["ref:filePath"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "middleware/static.ts",
+    "rubyName": "find_file",
+    "call": "try_files",
+    "kind": "args",
+    "rubyArgs": ["ref:filepath", "ref:contentType", "kwargs{acceptEncoding=ref:acceptEncoding}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "actiondispatch",
@@ -19,5 +46,14 @@
     "rubyName": "serve",
     "call": "escape_path",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "middleware/static.ts",
+    "rubyName": "try_files",
+    "call": "try_precompressed_files",
+    "kind": "args",
+    "rubyArgs": ["ref:filepath", "ref:headers", "kwargs{acceptEncoding=ref:acceptEncoding}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/request/session.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/request/session.json
@@ -10,8 +10,26 @@
     "package": "actiondispatch",
     "tsFile": "request/session.ts",
     "rubyName": "create",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:store", "ref:req"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "request/session.ts",
+    "rubyName": "create",
     "call": "set",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "request/session.ts",
+    "rubyName": "disabled",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["nil", "ref:req", "kwargs{enabled=bool:false}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "actiondispatch",
@@ -23,8 +41,26 @@
   {
     "package": "actiondispatch",
     "tsFile": "request/session.ts",
+    "rubyName": "keys",
+    "call": "keys",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "request/session.ts",
     "rubyName": "load!",
     "call": "replace",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "request/session.ts",
+    "rubyName": "values",
+    "call": "values",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/request/session.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/request/session.json
@@ -12,7 +12,10 @@
     "rubyName": "create",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:store", "ref:req"],
+    "rubyArgs": [
+      "ref:store",
+      "ref:req"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -28,7 +31,11 @@
     "rubyName": "disabled",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["nil", "ref:req", "kwargs{enabled=bool:false}"],
+    "rubyArgs": [
+      "nil",
+      "ref:req",
+      "kwargs{enabled=bool:false}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/routing/inspector.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/routing/inspector.json
@@ -9,8 +9,26 @@
   {
     "package": "actiondispatch",
     "tsFile": "routing/inspector.ts",
+    "rubyName": "matches_filter?",
+    "call": "match",
+    "kind": "args",
+    "rubyArgs": ["ref:value"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "routing/inspector.ts",
     "rubyName": "normalize_filter",
     "call": "escape",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "routing/inspector.ts",
+    "rubyName": "normalize_filter",
+    "call": "underscore",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/routing/inspector.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/routing/inspector.json
@@ -12,7 +12,9 @@
     "rubyName": "matches_filter?",
     "call": "match",
     "kind": "args",
-    "rubyArgs": ["ref:value"],
+    "rubyArgs": [
+      "ref:value"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/routing/mapper.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/routing/mapper.json
@@ -175,7 +175,9 @@
     "rubyName": "initialize",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["kwargs{pathNames=ref:resourcesPathNames}"],
+    "rubyArgs": [
+      "kwargs{pathNames=ref:resourcesPathNames}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -240,7 +242,10 @@
     "rubyName": "mount",
     "call": "define_generate_prefix",
     "kind": "args",
-    "rubyArgs": ["ref:app", "ref:targetAs"],
+    "rubyArgs": [
+      "ref:app",
+      "ref:targetAs"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -389,7 +394,9 @@
     "rubyName": "resource",
     "call": "get",
     "kind": "args",
-    "rubyArgs": ["str:new"],
+    "rubyArgs": [
+      "str:new"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -470,7 +477,9 @@
     "rubyName": "resources",
     "call": "get",
     "kind": "args",
-    "rubyArgs": ["str:index"],
+    "rubyArgs": [
+      "str:index"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -614,7 +623,9 @@
     "rubyName": "with_default_scope",
     "call": "scope",
     "kind": "args",
-    "rubyArgs": ["ref:scope"],
+    "rubyArgs": [
+      "ref:scope"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/routing/mapper.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/routing/mapper.json
@@ -101,6 +101,15 @@
     "package": "actiondispatch",
     "tsFile": "routing/mapper.ts",
     "rubyName": "decomposed_match",
+    "call": "member",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "routing/mapper.ts",
+    "rubyName": "decomposed_match",
     "call": "nested",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -164,6 +173,15 @@
     "package": "actiondispatch",
     "tsFile": "routing/mapper.ts",
     "rubyName": "initialize",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["kwargs{pathNames=ref:resourcesPathNames}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "routing/mapper.ts",
+    "rubyName": "initialize",
     "call": "order:resourcesPathNames,constructor",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
@@ -215,6 +233,15 @@
     "rubyName": "member",
     "call": "with_scope_level",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "routing/mapper.ts",
+    "rubyName": "mount",
+    "call": "define_generate_prefix",
+    "kind": "args",
+    "rubyArgs": ["ref:app", "ref:targetAs"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "actiondispatch",
@@ -360,6 +387,24 @@
     "package": "actiondispatch",
     "tsFile": "routing/mapper.ts",
     "rubyName": "resource",
+    "call": "get",
+    "kind": "args",
+    "rubyArgs": ["str:new"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "routing/mapper.ts",
+    "rubyName": "resource",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "routing/mapper.ts",
+    "rubyName": "resource",
     "call": "order:get,constructor",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
@@ -418,6 +463,24 @@
     "rubyName": "resources",
     "call": "collection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "routing/mapper.ts",
+    "rubyName": "resources",
+    "call": "get",
+    "kind": "args",
+    "rubyArgs": ["str:index"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "routing/mapper.ts",
+    "rubyName": "resources",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "actiondispatch",
@@ -544,5 +607,14 @@
     "rubyName": "shallow",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "routing/mapper.ts",
+    "rubyName": "with_default_scope",
+    "call": "scope",
+    "kind": "args",
+    "rubyArgs": ["ref:scope"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/routing/polymorphic-routes.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/routing/polymorphic-routes.json
@@ -19,5 +19,14 @@
     "rubyName": "handle_list",
     "call": "call",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "routing/polymorphic-routes.ts",
+    "rubyName": "polymorphic_path",
+    "call": "polymorphic_method",
+    "kind": "args",
+    "rubyArgs": ["ref:this", "ref:recordOrHashOrArray", "ref:action", "ref:type", "ref:opts"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/routing/polymorphic-routes.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/routing/polymorphic-routes.json
@@ -26,7 +26,13 @@
     "rubyName": "polymorphic_path",
     "call": "polymorphic_method",
     "kind": "args",
-    "rubyArgs": ["ref:this", "ref:recordOrHashOrArray", "ref:action", "ref:type", "ref:opts"],
+    "rubyArgs": [
+      "ref:this",
+      "ref:recordOrHashOrArray",
+      "ref:action",
+      "ref:type",
+      "ref:opts"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/routing/redirection.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/routing/redirection.json
@@ -12,7 +12,9 @@
     "rubyName": "call",
     "call": "instrument",
     "kind": "args",
-    "rubyArgs": ["str:redirect.action_dispatch"],
+    "rubyArgs": [
+      "str:redirect.action_dispatch"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -28,7 +30,10 @@
     "rubyName": "redirect",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:status", "ref:block"],
+    "rubyArgs": [
+      "ref:status",
+      "ref:block"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/routing/redirection.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/routing/redirection.json
@@ -9,8 +9,26 @@
   {
     "package": "actiondispatch",
     "tsFile": "routing/redirection.ts",
+    "rubyName": "call",
+    "call": "instrument",
+    "kind": "args",
+    "rubyArgs": ["str:redirect.action_dispatch"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "routing/redirection.ts",
     "rubyName": "path",
     "call": "call",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "routing/redirection.ts",
+    "rubyName": "redirect",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:status", "ref:block"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/routing/route-set.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/routing/route-set.json
@@ -73,6 +73,15 @@
     "package": "actiondispatch",
     "tsFile": "routing/route-set.ts",
     "rubyName": "generate_extras",
+    "call": "keys",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "routing/route-set.ts",
+    "rubyName": "generate_extras",
     "call": "path",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -82,6 +91,15 @@
     "rubyName": "generate_url_helpers",
     "call": "full_url_for",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "routing/route-set.ts",
+    "rubyName": "generate_url_helpers",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "actiondispatch",
@@ -138,6 +156,15 @@
     "rubyName": "recognize_path",
     "call": "recognize_path_with_request",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "routing/route-set.ts",
+    "rubyName": "recognize_path_with_request",
+    "call": "recognize",
+    "kind": "args",
+    "rubyArgs": ["ref:req"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "actiondispatch",

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/routing/route-set.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/routing/route-set.json
@@ -163,7 +163,9 @@
     "rubyName": "recognize_path_with_request",
     "call": "recognize",
     "kind": "args",
-    "rubyArgs": ["ref:req"],
+    "rubyArgs": [
+      "ref:req"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/system-test-case.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/system-test-case.json
@@ -5,7 +5,9 @@
     "rubyName": "initialize",
     "call": "driven_by",
     "kind": "args",
-    "rubyArgs": ["str:selenium"],
+    "rubyArgs": [
+      "str:selenium"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/system-test-case.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/system-test-case.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "actiondispatch",
+    "tsFile": "system-test-case.ts",
+    "rubyName": "initialize",
+    "call": "driven_by",
+    "kind": "args",
+    "rubyArgs": ["str:selenium"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/system-testing/driver.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/system-testing/driver.json
@@ -23,9 +23,54 @@
   {
     "package": "actiondispatch",
     "tsFile": "system-testing/driver.ts",
+    "rubyName": "register",
+    "call": "register_cuprite",
+    "kind": "args",
+    "rubyArgs": ["ref:app"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "system-testing/driver.ts",
+    "rubyName": "register",
+    "call": "register_playwright",
+    "kind": "args",
+    "rubyArgs": ["ref:app"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "system-testing/driver.ts",
+    "rubyName": "register",
+    "call": "register_rack_test",
+    "kind": "args",
+    "rubyArgs": ["ref:app"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "system-testing/driver.ts",
+    "rubyName": "register",
+    "call": "register_selenium",
+    "kind": "args",
+    "rubyArgs": ["ref:app"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "system-testing/driver.ts",
     "rubyName": "register_cuprite",
     "call": "merge",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "system-testing/driver.ts",
+    "rubyName": "register_cuprite",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:app", "ref:merge"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "actiondispatch",

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/system-testing/driver.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/system-testing/driver.json
@@ -26,7 +26,9 @@
     "rubyName": "register",
     "call": "register_cuprite",
     "kind": "args",
-    "rubyArgs": ["ref:app"],
+    "rubyArgs": [
+      "ref:app"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -35,7 +37,9 @@
     "rubyName": "register",
     "call": "register_playwright",
     "kind": "args",
-    "rubyArgs": ["ref:app"],
+    "rubyArgs": [
+      "ref:app"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -44,7 +48,9 @@
     "rubyName": "register",
     "call": "register_rack_test",
     "kind": "args",
-    "rubyArgs": ["ref:app"],
+    "rubyArgs": [
+      "ref:app"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -53,7 +59,9 @@
     "rubyName": "register",
     "call": "register_selenium",
     "kind": "args",
-    "rubyArgs": ["ref:app"],
+    "rubyArgs": [
+      "ref:app"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -69,7 +77,10 @@
     "rubyName": "register_cuprite",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:app", "ref:merge"],
+    "rubyArgs": [
+      "ref:app",
+      "ref:merge"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/system-testing/server.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/system-testing/server.json
@@ -1,0 +1,20 @@
+[
+  {
+    "package": "actiondispatch",
+    "tsFile": "system-testing/server.ts",
+    "rubyName": "run",
+    "call": "setup",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "system-testing/server.ts",
+    "rubyName": "setup",
+    "call": "set_server",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/system-testing/test-helpers/screenshot-helper.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/system-testing/test-helpers/screenshot-helper.json
@@ -2,6 +2,15 @@
   {
     "package": "actiondispatch",
     "tsFile": "system-testing/test-helpers/screenshot-helper.ts",
+    "rubyName": "absolute_path",
+    "call": "join",
+    "kind": "args",
+    "rubyArgs": ["ref:screenshotsDir", "ref:imageName"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "system-testing/test-helpers/screenshot-helper.ts",
     "rubyName": "save_html",
     "call": "save_page",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/system-testing/test-helpers/screenshot-helper.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/system-testing/test-helpers/screenshot-helper.json
@@ -5,7 +5,10 @@
     "rubyName": "absolute_path",
     "call": "join",
     "kind": "args",
-    "rubyArgs": ["ref:screenshotsDir", "ref:imageName"],
+    "rubyArgs": [
+      "ref:screenshotsDir",
+      "ref:imageName"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/testing/assertions/response.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/testing/assertions/response.json
@@ -10,6 +10,15 @@
     "package": "actiondispatch",
     "tsFile": "testing/assertions/response.ts",
     "rubyName": "assert_response",
+    "call": "generate_response_message",
+    "kind": "args",
+    "rubyArgs": ["ref:type"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "testing/assertions/response.ts",
+    "rubyName": "assert_response",
     "call": "order:constructor,generateResponseMessage",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
@@ -19,6 +28,33 @@
     "rubyName": "exception_if_present",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "testing/assertions/response.ts",
+    "rubyName": "generate_response_message",
+    "call": "exception_if_present",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "testing/assertions/response.ts",
+    "rubyName": "generate_response_message",
+    "call": "location_if_redirected",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "testing/assertions/response.ts",
+    "rubyName": "generate_response_message",
+    "call": "response_body_if_short",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "actiondispatch",

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/testing/assertions/response.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/testing/assertions/response.json
@@ -12,7 +12,9 @@
     "rubyName": "assert_response",
     "call": "generate_response_message",
     "kind": "args",
-    "rubyArgs": ["ref:type"],
+    "rubyArgs": [
+      "ref:type"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/testing/assertions/routing.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/testing/assertions/routing.json
@@ -5,7 +5,10 @@
     "rubyName": "assert_generates",
     "call": "fail_on",
     "kind": "args",
-    "rubyArgs": ["const:InvalidURIError", "ref:message"],
+    "rubyArgs": [
+      "const:InvalidURIError",
+      "ref:message"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -35,7 +38,10 @@
     "rubyName": "recognized_request_for",
     "call": "fail_on",
     "kind": "args",
-    "rubyArgs": ["const:InvalidURIError", "ref:msg"],
+    "rubyArgs": [
+      "const:InvalidURIError",
+      "ref:msg"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/testing/assertions/routing.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/testing/assertions/routing.json
@@ -3,6 +3,15 @@
     "package": "actiondispatch",
     "tsFile": "testing/assertions/routing.ts",
     "rubyName": "assert_generates",
+    "call": "fail_on",
+    "kind": "args",
+    "rubyArgs": ["const:InvalidURIError", "ref:message"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "testing/assertions/routing.ts",
+    "rubyName": "assert_generates",
     "call": "parse",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -19,6 +28,15 @@
     "rubyName": "recognized_request_for",
     "call": "create",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "testing/assertions/routing.ts",
+    "rubyName": "recognized_request_for",
+    "call": "fail_on",
+    "kind": "args",
+    "rubyArgs": ["const:InvalidURIError", "ref:msg"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "actiondispatch",

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/testing/integration.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/testing/integration.json
@@ -31,6 +31,15 @@
     "package": "actiondispatch",
     "tsFile": "testing/integration.ts",
     "rubyName": "create_session",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["const:Session"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "testing/integration.ts",
+    "rubyName": "create_session",
     "call": "url_helpers",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/testing/integration.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/testing/integration.json
@@ -33,7 +33,9 @@
     "rubyName": "create_session",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["const:Session"],
+    "rubyArgs": [
+      "const:Session"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/testing/test-process.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/testing/test-process.json
@@ -3,6 +3,15 @@
     "package": "actiondispatch",
     "tsFile": "testing/test-process.ts",
     "rubyName": "file_fixture_upload",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:path", "ref:mimeType", "ref:binary"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "testing/test-process.ts",
+    "rubyName": "file_fixture_upload",
     "call": "order:constructor,fileFixture",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/testing/test-process.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/testing/test-process.json
@@ -5,7 +5,11 @@
     "rubyName": "file_fixture_upload",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:path", "ref:mimeType", "ref:binary"],
+    "rubyArgs": [
+      "ref:path",
+      "ref:mimeType",
+      "ref:binary"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/testing/test-response.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/testing/test-response.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "actiondispatch",
+    "tsFile": "testing/test-response.ts",
+    "rubyName": "parsed_body",
+    "call": "response_parser",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/actionview/buffers.json
+++ b/scripts/api-compare/call-mismatches-exclude/actionview/buffers.json
@@ -12,5 +12,14 @@
     "rubyName": "safe_concat",
     "call": "call",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actionview",
+    "tsFile": "buffers.ts",
+    "rubyName": "to_s",
+    "call": "html_safe",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actionview/helpers/number-helper.json
+++ b/scripts/api-compare/call-mismatches-exclude/actionview/helpers/number-helper.json
@@ -5,7 +5,11 @@
     "rubyName": "number_to_currency",
     "call": "delegate_number_helper_method",
     "kind": "args",
-    "rubyArgs": ["str:numberToCurrency", "ref:number", "ref:options"],
+    "rubyArgs": [
+      "str:numberToCurrency",
+      "ref:number",
+      "ref:options"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -14,7 +18,11 @@
     "rubyName": "number_to_human",
     "call": "delegate_number_helper_method",
     "kind": "args",
-    "rubyArgs": ["str:numberToHuman", "ref:number", "ref:options"],
+    "rubyArgs": [
+      "str:numberToHuman",
+      "ref:number",
+      "ref:options"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -23,7 +31,11 @@
     "rubyName": "number_to_human_size",
     "call": "delegate_number_helper_method",
     "kind": "args",
-    "rubyArgs": ["str:numberToHumanSize", "ref:number", "ref:options"],
+    "rubyArgs": [
+      "str:numberToHumanSize",
+      "ref:number",
+      "ref:options"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -32,7 +44,11 @@
     "rubyName": "number_to_percentage",
     "call": "delegate_number_helper_method",
     "kind": "args",
-    "rubyArgs": ["str:numberToPercentage", "ref:number", "ref:options"],
+    "rubyArgs": [
+      "str:numberToPercentage",
+      "ref:number",
+      "ref:options"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -41,7 +57,11 @@
     "rubyName": "number_with_delimiter",
     "call": "delegate_number_helper_method",
     "kind": "args",
-    "rubyArgs": ["str:numberToDelimited", "ref:number", "ref:options"],
+    "rubyArgs": [
+      "str:numberToDelimited",
+      "ref:number",
+      "ref:options"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -50,7 +70,11 @@
     "rubyName": "number_with_precision",
     "call": "delegate_number_helper_method",
     "kind": "args",
-    "rubyArgs": ["str:numberToRounded", "ref:number", "ref:options"],
+    "rubyArgs": [
+      "str:numberToRounded",
+      "ref:number",
+      "ref:options"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actionview/helpers/number-helper.json
+++ b/scripts/api-compare/call-mismatches-exclude/actionview/helpers/number-helper.json
@@ -1,0 +1,56 @@
+[
+  {
+    "package": "actionview",
+    "tsFile": "helpers/number-helper.ts",
+    "rubyName": "number_to_currency",
+    "call": "delegate_number_helper_method",
+    "kind": "args",
+    "rubyArgs": ["str:numberToCurrency", "ref:number", "ref:options"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actionview",
+    "tsFile": "helpers/number-helper.ts",
+    "rubyName": "number_to_human",
+    "call": "delegate_number_helper_method",
+    "kind": "args",
+    "rubyArgs": ["str:numberToHuman", "ref:number", "ref:options"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actionview",
+    "tsFile": "helpers/number-helper.ts",
+    "rubyName": "number_to_human_size",
+    "call": "delegate_number_helper_method",
+    "kind": "args",
+    "rubyArgs": ["str:numberToHumanSize", "ref:number", "ref:options"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actionview",
+    "tsFile": "helpers/number-helper.ts",
+    "rubyName": "number_to_percentage",
+    "call": "delegate_number_helper_method",
+    "kind": "args",
+    "rubyArgs": ["str:numberToPercentage", "ref:number", "ref:options"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actionview",
+    "tsFile": "helpers/number-helper.ts",
+    "rubyName": "number_with_delimiter",
+    "call": "delegate_number_helper_method",
+    "kind": "args",
+    "rubyArgs": ["str:numberToDelimited", "ref:number", "ref:options"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actionview",
+    "tsFile": "helpers/number-helper.ts",
+    "rubyName": "number_with_precision",
+    "call": "delegate_number_helper_method",
+    "kind": "args",
+    "rubyArgs": ["str:numberToRounded", "ref:number", "ref:options"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/actionview/helpers/output-safety-helper.json
+++ b/scripts/api-compare/call-mismatches-exclude/actionview/helpers/output-safety-helper.json
@@ -1,0 +1,20 @@
+[
+  {
+    "package": "actionview",
+    "tsFile": "helpers/output-safety-helper.ts",
+    "rubyName": "raw",
+    "call": "html_safe",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actionview",
+    "tsFile": "helpers/output-safety-helper.ts",
+    "rubyName": "safe_join",
+    "call": "html_safe",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/actionview/helpers/tag-helper.json
+++ b/scripts/api-compare/call-mismatches-exclude/actionview/helpers/tag-helper.json
@@ -2,6 +2,15 @@
   {
     "package": "actionview",
     "tsFile": "helpers/tag-helper.ts",
+    "rubyName": "attributes",
+    "call": "html_safe",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actionview",
+    "tsFile": "helpers/tag-helper.ts",
     "rubyName": "content_tag",
     "call": "capture",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/actionview/helpers/text-helper.json
+++ b/scripts/api-compare/call-mismatches-exclude/actionview/helpers/text-helper.json
@@ -9,9 +9,36 @@
   {
     "package": "actionview",
     "tsFile": "helpers/text-helper.ts",
+    "rubyName": "highlight",
+    "call": "html_safe",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actionview",
+    "tsFile": "helpers/text-helper.ts",
+    "rubyName": "highlight",
+    "call": "join",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actionview",
+    "tsFile": "helpers/text-helper.ts",
     "rubyName": "safe_concat",
     "call": "concat",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actionview",
+    "tsFile": "helpers/text-helper.ts",
+    "rubyName": "simple_format",
+    "call": "html_safe",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "actionview",

--- a/scripts/api-compare/call-mismatches-exclude/actionview/path-set.json
+++ b/scripts/api-compare/call-mismatches-exclude/actionview/path-set.json
@@ -5,5 +5,14 @@
     "rubyName": "exists?",
     "call": "any?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actionview",
+    "tsFile": "path-set.ts",
+    "rubyName": "initialize",
+    "call": "freeze",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actionview/renderer/renderer.json
+++ b/scripts/api-compare/call-mismatches-exclude/actionview/renderer/renderer.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "actionview",
+    "tsFile": "renderer/renderer.ts",
+    "rubyName": "render_body",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:lookupContext"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/actionview/renderer/renderer.json
+++ b/scripts/api-compare/call-mismatches-exclude/actionview/renderer/renderer.json
@@ -5,7 +5,9 @@
     "rubyName": "render_body",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:lookupContext"],
+    "rubyArgs": [
+      "ref:lookupContext"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actionview/renderer/template-renderer.json
+++ b/scripts/api-compare/call-mismatches-exclude/actionview/renderer/template-renderer.json
@@ -9,6 +9,15 @@
   {
     "package": "actionview",
     "tsFile": "renderer/template-renderer.ts",
+    "rubyName": "determine_template",
+    "call": "keys",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actionview",
+    "tsFile": "renderer/template-renderer.ts",
     "rubyName": "resolve_layout",
     "call": "find_template",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/attribute-methods.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/attribute-methods.json
@@ -37,6 +37,42 @@
   {
     "package": "activemodel",
     "tsFile": "attribute-methods.ts",
+    "rubyName": "attribute_method_patterns_cache",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["kwargs{initialCapacity=num:4}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "attribute-methods.ts",
+    "rubyName": "attribute_method_prefix",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["kwargs{parameters=ref:parameters,prefix=ref:prefix}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "attribute-methods.ts",
+    "rubyName": "attribute_method_suffix",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["kwargs{parameters=ref:parameters,suffix=ref:suffix}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "attribute-methods.ts",
+    "rubyName": "define_attribute_method",
+    "call": "define_attribute_method_pattern",
+    "kind": "args",
+    "rubyArgs": ["ref:pattern", "ref:attrName", "kwargs{as=ref:as,owner=ref:owner}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "attribute-methods.ts",
     "rubyName": "define_attribute_method_pattern",
     "call": "define_proxy_call",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -47,6 +83,15 @@
     "rubyName": "define_attribute_method_pattern",
     "call": "instance_method_already_implemented?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "attribute-methods.ts",
+    "rubyName": "define_attribute_methods",
+    "call": "define_attribute_method",
+    "kind": "args",
+    "rubyArgs": ["ref:attrName", "kwargs{_owner=ref:owner}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activemodel",

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/attribute-methods.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/attribute-methods.json
@@ -40,7 +40,9 @@
     "rubyName": "attribute_method_patterns_cache",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["kwargs{initialCapacity=num:4}"],
+    "rubyArgs": [
+      "kwargs{initialCapacity=num:4}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -49,7 +51,9 @@
     "rubyName": "attribute_method_prefix",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["kwargs{parameters=ref:parameters,prefix=ref:prefix}"],
+    "rubyArgs": [
+      "kwargs{parameters=ref:parameters,prefix=ref:prefix}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -58,7 +62,9 @@
     "rubyName": "attribute_method_suffix",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["kwargs{parameters=ref:parameters,suffix=ref:suffix}"],
+    "rubyArgs": [
+      "kwargs{parameters=ref:parameters,suffix=ref:suffix}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -67,7 +73,11 @@
     "rubyName": "define_attribute_method",
     "call": "define_attribute_method_pattern",
     "kind": "args",
-    "rubyArgs": ["ref:pattern", "ref:attrName", "kwargs{as=ref:as,owner=ref:owner}"],
+    "rubyArgs": [
+      "ref:pattern",
+      "ref:attrName",
+      "kwargs{as=ref:as,owner=ref:owner}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -90,7 +100,10 @@
     "rubyName": "define_attribute_methods",
     "call": "define_attribute_method",
     "kind": "args",
-    "rubyArgs": ["ref:attrName", "kwargs{_owner=ref:owner}"],
+    "rubyArgs": [
+      "ref:attrName",
+      "kwargs{_owner=ref:owner}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/attribute-registration.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/attribute-registration.json
@@ -3,8 +3,26 @@
     "package": "activemodel",
     "tsFile": "attribute-registration.ts",
     "rubyName": "decorate_attributes",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:names", "ref:decorator"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "attribute-registration.ts",
+    "rubyName": "decorate_attributes",
     "call": "resolve_attribute_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "attribute-registration.ts",
+    "rubyName": "reset_default_attributes",
+    "call": "subclasses",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activemodel",

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/attribute-registration.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/attribute-registration.json
@@ -5,7 +5,10 @@
     "rubyName": "decorate_attributes",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:names", "ref:decorator"],
+    "rubyArgs": [
+      "ref:names",
+      "ref:decorator"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/attribute-set.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/attribute-set.json
@@ -19,7 +19,9 @@
     "rubyName": "deep_dup",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:transformValues"],
+    "rubyArgs": [
+      "ref:transformValues"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -42,7 +44,9 @@
     "rubyName": "map",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:newAttributes"],
+    "rubyArgs": [
+      "ref:newAttributes"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -72,7 +76,9 @@
     "rubyName": "write_cast_value",
     "call": "with_cast_value",
     "kind": "args",
-    "rubyArgs": ["ref:value"],
+    "rubyArgs": [
+      "ref:value"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/attribute-set.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/attribute-set.json
@@ -17,6 +17,15 @@
     "package": "activemodel",
     "tsFile": "attribute-set.ts",
     "rubyName": "deep_dup",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:transformValues"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "attribute-set.ts",
+    "rubyName": "deep_dup",
     "call": "transform_values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -26,6 +35,15 @@
     "rubyName": "keys",
     "call": "each_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "attribute-set.ts",
+    "rubyName": "map",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:newAttributes"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activemodel",
@@ -47,5 +65,14 @@
     "rubyName": "values_for_database",
     "call": "transform_values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "attribute-set.ts",
+    "rubyName": "write_cast_value",
+    "call": "with_cast_value",
+    "kind": "args",
+    "rubyArgs": ["ref:value"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/attribute-set/builder.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/attribute-set/builder.json
@@ -12,7 +12,12 @@
     "rubyName": "build_from_database",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:values", "ref:types", "ref:additionalTypes", "ref:defaultAttributes"],
+    "rubyArgs": [
+      "ref:values",
+      "ref:types",
+      "ref:additionalTypes",
+      "ref:defaultAttributes"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/attribute-set/builder.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/attribute-set/builder.json
@@ -9,9 +9,36 @@
   {
     "package": "activemodel",
     "tsFile": "attribute-set/builder.ts",
+    "rubyName": "build_from_database",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:values", "ref:types", "ref:additionalTypes", "ref:defaultAttributes"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "attribute-set/builder.ts",
     "rubyName": "deep_dup",
     "call": "transform_values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "attribute-set/builder.ts",
+    "rubyName": "each_key",
+    "call": "keys",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "attribute-set/builder.ts",
+    "rubyName": "keys",
+    "call": "keys",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activemodel",

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/attributes.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/attributes.json
@@ -19,5 +19,14 @@
     "rubyName": "attribute_method?",
     "call": "respond_to_without_attributes?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "attributes.ts",
+    "rubyName": "define_method_attribute=",
+    "call": "define_attribute_accessor_method",
+    "kind": "args",
+    "rubyArgs": ["ref:owner", "ref:canonicalName", "kwargs{writer=bool:true}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/attributes.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/attributes.json
@@ -26,7 +26,11 @@
     "rubyName": "define_method_attribute=",
     "call": "define_attribute_accessor_method",
     "kind": "args",
-    "rubyArgs": ["ref:owner", "ref:canonicalName", "kwargs{writer=bool:true}"],
+    "rubyArgs": [
+      "ref:owner",
+      "ref:canonicalName",
+      "kwargs{writer=bool:true}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/dirty.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/dirty.json
@@ -37,6 +37,15 @@
   {
     "package": "activemodel",
     "tsFile": "dirty.ts",
+    "rubyName": "attribute_will_change!",
+    "call": "force_change",
+    "kind": "args",
+    "rubyArgs": ["ref:toS"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "dirty.ts",
     "rubyName": "changes_applied",
     "call": "forget_attribute_assignments",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/dirty.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/dirty.json
@@ -40,7 +40,9 @@
     "rubyName": "attribute_will_change!",
     "call": "force_change",
     "kind": "args",
-    "rubyArgs": ["ref:toS"],
+    "rubyArgs": [
+      "ref:toS"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/errors.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/errors.json
@@ -9,6 +9,15 @@
   {
     "package": "activemodel",
     "tsFile": "errors.ts",
+    "rubyName": "messages",
+    "call": "to_hash",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "errors.ts",
     "rubyName": "messages_for",
     "call": "where",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/model.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/model.json
@@ -9,6 +9,15 @@
   {
     "package": "activemodel",
     "tsFile": "model.ts",
+    "rubyName": "model_name",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:this", "ref:namespace"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "model.ts",
     "rubyName": "validates_each",
     "call": "validates_with",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/model.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/model.json
@@ -12,7 +12,10 @@
     "rubyName": "model_name",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:this", "ref:namespace"],
+    "rubyArgs": [
+      "ref:this",
+      "ref:namespace"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/secure-password.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/secure-password.json
@@ -3,8 +3,35 @@
     "package": "activemodel",
     "tsFile": "secure-password.ts",
     "rubyName": "has_secure_password",
+    "call": "add",
+    "kind": "args",
+    "rubyArgs": ["ref:attribute", "str:passwordTooLong"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "secure-password.ts",
+    "rubyName": "has_secure_password",
     "call": "include",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "secure-password.ts",
+    "rubyName": "has_secure_password",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:attribute", "kwargs{resetToken=ref:resetToken}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "secure-password.ts",
+    "rubyName": "has_secure_password",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:digestWas"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activemodel",

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/secure-password.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/secure-password.json
@@ -5,7 +5,10 @@
     "rubyName": "has_secure_password",
     "call": "add",
     "kind": "args",
-    "rubyArgs": ["ref:attribute", "str:passwordTooLong"],
+    "rubyArgs": [
+      "ref:attribute",
+      "str:passwordTooLong"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -21,7 +24,10 @@
     "rubyName": "has_secure_password",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:attribute", "kwargs{resetToken=ref:resetToken}"],
+    "rubyArgs": [
+      "ref:attribute",
+      "kwargs{resetToken=ref:resetToken}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -30,7 +36,9 @@
     "rubyName": "has_secure_password",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:digestWas"],
+    "rubyArgs": [
+      "ref:digestWas"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/serialization.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/serialization.json
@@ -5,7 +5,9 @@
     "rubyName": "serializable_attributes",
     "call": "read_attribute_for_serialization",
     "kind": "args",
-    "rubyArgs": ["ref:n"],
+    "rubyArgs": [
+      "ref:n"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -30,7 +32,9 @@
     "rubyName": "serializable_hash",
     "call": "serializable_add_includes",
     "kind": "args",
-    "rubyArgs": ["ref:options"],
+    "rubyArgs": [
+      "ref:options"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -39,7 +43,9 @@
     "rubyName": "serializable_hash",
     "call": "serializable_attributes",
     "kind": "args",
-    "rubyArgs": ["ref:attributeNames"],
+    "rubyArgs": [
+      "ref:attributeNames"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/serialization.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/serialization.json
@@ -2,8 +2,44 @@
   {
     "package": "activemodel",
     "tsFile": "serialization.ts",
+    "rubyName": "serializable_attributes",
+    "call": "read_attribute_for_serialization",
+    "kind": "args",
+    "rubyArgs": ["ref:n"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "serialization.ts",
+    "rubyName": "serializable_hash",
+    "call": "attribute_names_for_serialization",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "serialization.ts",
     "rubyName": "serializable_hash",
     "call": "order:serializableAddIncludes,map",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "serialization.ts",
+    "rubyName": "serializable_hash",
+    "call": "serializable_add_includes",
+    "kind": "args",
+    "rubyArgs": ["ref:options"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "serialization.ts",
+    "rubyName": "serializable_hash",
+    "call": "serializable_attributes",
+    "kind": "args",
+    "rubyArgs": ["ref:attributeNames"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/serializers/json.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/serializers/json.json
@@ -12,7 +12,10 @@
     "rubyName": "model_name",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:this", "ref:namespace"],
+    "rubyArgs": [
+      "ref:this",
+      "ref:namespace"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/serializers/json.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/serializers/json.json
@@ -5,5 +5,14 @@
     "rubyName": "from_json",
     "call": "decode",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "serializers/json.ts",
+    "rubyName": "model_name",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:this", "ref:namespace"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/type/immutable-string.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/type/immutable-string.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "activemodel",
+    "tsFile": "type/immutable-string.ts",
+    "rubyName": "cast_value",
+    "call": "freeze",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/type/string.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/type/string.json
@@ -1,0 +1,13 @@
+[
+  {
+    "package": "activemodel",
+    "tsFile": "type/string.ts",
+    "rubyName": "to_immutable_string",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": [
+      "kwargs{false=ref:false,limit=ref:limit,precision=ref:precision,scale=ref:scale,true=ref:true}"
+    ],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/validations/comparability.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/validations/comparability.json
@@ -10,6 +10,15 @@
     "package": "activemodel",
     "tsFile": "validations/comparability.ts",
     "rubyName": "error_options",
+    "call": "keys",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "validations/comparability.ts",
+    "rubyName": "error_options",
     "call": "merge!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/validations/length.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/validations/length.json
@@ -12,7 +12,9 @@
     "rubyName": "validate_each",
     "call": "skip_nil_check?",
     "kind": "args",
-    "rubyArgs": ["ref:key"],
+    "rubyArgs": [
+      "ref:key"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/validations/length.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/validations/length.json
@@ -5,5 +5,14 @@
     "rubyName": "validate_each",
     "call": "except",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "validations/length.ts",
+    "rubyName": "validate_each",
+    "call": "skip_nil_check?",
+    "kind": "args",
+    "rubyArgs": ["ref:key"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord-test-support/connection.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord-test-support/connection.json
@@ -1,0 +1,20 @@
+[
+  {
+    "package": "activerecord-test-support",
+    "tsFile": "connection.ts",
+    "rubyName": "connect",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["str:debug.log", "num:1", "ref:megabytes"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord-test-support",
+    "tsFile": "connection.ts",
+    "rubyName": "test_configuration_hashes",
+    "call": "keys",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord-test-support/connection.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord-test-support/connection.json
@@ -5,7 +5,11 @@
     "rubyName": "connect",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["str:debug.log", "num:1", "ref:megabytes"],
+    "rubyArgs": [
+      "str:debug.log",
+      "num:1",
+      "ref:megabytes"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations.json
@@ -23,6 +23,15 @@
   {
     "package": "activerecord",
     "tsFile": "associations.ts",
+    "rubyName": "belongs_to",
+    "call": "build",
+    "kind": "args",
+    "rubyArgs": ["ref:this", "ref:name", "ref:scope", "ref:options"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations.ts",
     "rubyName": "has_and_belongs_to_many",
     "call": "add_reflection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -68,5 +77,14 @@
     "rubyName": "has_one",
     "call": "add_reflection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations.ts",
+    "rubyName": "has_one",
+    "call": "build",
+    "kind": "args",
+    "rubyArgs": ["ref:this", "ref:name", "ref:scope", "ref:options"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations.json
@@ -26,7 +26,12 @@
     "rubyName": "belongs_to",
     "call": "build",
     "kind": "args",
-    "rubyArgs": ["ref:this", "ref:name", "ref:scope", "ref:options"],
+    "rubyArgs": [
+      "ref:this",
+      "ref:name",
+      "ref:scope",
+      "ref:options"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -84,7 +89,12 @@
     "rubyName": "has_one",
     "call": "build",
     "kind": "args",
-    "rubyArgs": ["ref:this", "ref:name", "ref:scope", "ref:options"],
+    "rubyArgs": [
+      "ref:this",
+      "ref:name",
+      "ref:scope",
+      "ref:options"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/alias-tracker.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/alias-tracker.json
@@ -9,6 +9,24 @@
   {
     "package": "activerecord",
     "tsFile": "associations/alias-tracker.ts",
+    "rubyName": "create",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["num:0"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/alias-tracker.ts",
+    "rubyName": "create",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:tableAliasLength", "ref:aliases"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/alias-tracker.ts",
     "rubyName": "initial_count_for",
     "call": "size",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/alias-tracker.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/alias-tracker.json
@@ -12,7 +12,9 @@
     "rubyName": "create",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["num:0"],
+    "rubyArgs": [
+      "num:0"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -21,7 +23,10 @@
     "rubyName": "create",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:tableAliasLength", "ref:aliases"],
+    "rubyArgs": [
+      "ref:tableAliasLength",
+      "ref:aliases"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/association-scope.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/association-scope.json
@@ -2,9 +2,36 @@
   {
     "package": "activerecord",
     "tsFile": "associations/association-scope.ts",
+    "rubyName": "add_constraints",
+    "call": "last_chain_scope",
+    "kind": "args",
+    "rubyArgs": ["ref:scope", "ref:last", "ref:owner"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/association-scope.ts",
+    "rubyName": "get_bind_values",
+    "call": "polymorphic_name",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/association-scope.ts",
     "rubyName": "get_chain",
     "call": "drop",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/association-scope.ts",
+    "rubyName": "last_chain_scope",
+    "call": "polymorphic_name",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -16,8 +43,26 @@
   {
     "package": "activerecord",
     "tsFile": "associations/association-scope.ts",
+    "rubyName": "next_chain_scope",
+    "call": "polymorphic_name",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/association-scope.ts",
     "rubyName": "transform_value",
     "call": "call",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/association-scope.ts",
+    "rubyName": "transform_value",
+    "call": "value_transformation",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/association-scope.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/association-scope.json
@@ -5,7 +5,11 @@
     "rubyName": "add_constraints",
     "call": "last_chain_scope",
     "kind": "args",
-    "rubyArgs": ["ref:scope", "ref:last", "ref:owner"],
+    "rubyArgs": [
+      "ref:scope",
+      "ref:last",
+      "ref:owner"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/association.json
@@ -2,6 +2,15 @@
   {
     "package": "activerecord",
     "tsFile": "associations/association.ts",
+    "rubyName": "association_scope",
+    "call": "scope",
+    "kind": "args",
+    "rubyArgs": ["ref:this"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/association.ts",
     "rubyName": "build_record",
     "call": "build_association",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -44,9 +53,27 @@
   {
     "package": "activerecord",
     "tsFile": "associations/association.ts",
+    "rubyName": "raise_on_type_mismatch!",
+    "call": "safe_constantize",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/association.ts",
     "rubyName": "scope",
     "call": "create",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/association.ts",
+    "rubyName": "scope",
+    "call": "global_current_scope",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/association.json
@@ -5,7 +5,9 @@
     "rubyName": "association_scope",
     "call": "scope",
     "kind": "args",
-    "rubyArgs": ["ref:this"],
+    "rubyArgs": [
+      "ref:this"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/belongs-to-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/belongs-to-association.json
@@ -54,7 +54,10 @@
     "rubyName": "replace",
     "call": "replace_keys",
     "kind": "args",
-    "rubyArgs": ["ref:record", "kwargs{force=bool:true}"],
+    "rubyArgs": [
+      "ref:record",
+      "kwargs{force=bool:true}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/belongs-to-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/belongs-to-association.json
@@ -51,6 +51,15 @@
   {
     "package": "activerecord",
     "tsFile": "associations/belongs-to-association.ts",
+    "rubyName": "replace",
+    "call": "replace_keys",
+    "kind": "args",
+    "rubyArgs": ["ref:record", "kwargs{force=bool:true}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/belongs-to-association.ts",
     "rubyName": "replace_keys",
     "call": "map",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/builder/belongs-to.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/builder/belongs-to.json
@@ -2,6 +2,15 @@
   {
     "package": "activerecord",
     "tsFile": "associations/builder/belongs-to.ts",
+    "rubyName": "add_counter_cache_callbacks",
+    "call": "safe_constantize",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/builder/belongs-to.ts",
     "rubyName": "define_validations",
     "call": "delete",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/builder/collection-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/builder/collection-association.json
@@ -5,5 +5,14 @@
     "rubyName": "define_extensions",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/builder/collection-association.ts",
+    "rubyName": "define_readers",
+    "call": "singularize",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/builder/has-and-belongs-to-many.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/builder/has-and-belongs-to-many.json
@@ -16,6 +16,15 @@
   {
     "package": "activerecord",
     "tsFile": "associations/builder/has-and-belongs-to-many.ts",
+    "rubyName": "middle_reflection",
+    "call": "pluralize",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/builder/has-and-belongs-to-many.ts",
     "rubyName": "through_model",
     "call": "belongs_to",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -38,7 +47,25 @@
     "package": "activerecord",
     "tsFile": "associations/builder/has-and-belongs-to-many.ts",
     "rubyName": "through_model",
+    "call": "camelize",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/builder/has-and-belongs-to-many.ts",
+    "rubyName": "through_model",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/builder/has-and-belongs-to-many.ts",
+    "rubyName": "through_model",
+    "call": "singularize",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-association.json
@@ -12,7 +12,9 @@
     "rubyName": "callback",
     "call": "callbacks_for",
     "kind": "args",
-    "rubyArgs": ["ref:method"],
+    "rubyArgs": [
+      "ref:method"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -121,7 +123,11 @@
     "rubyName": "replace_common_records_in_memory",
     "call": "replace_on_target",
     "kind": "args",
-    "rubyArgs": ["ref:record", "ref:skipCallbacks", "kwargs{replace=bool:true}"],
+    "rubyArgs": [
+      "ref:record",
+      "ref:skipCallbacks",
+      "kwargs{replace=bool:true}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-association.json
@@ -9,6 +9,15 @@
   {
     "package": "activerecord",
     "tsFile": "associations/collection-association.ts",
+    "rubyName": "callback",
+    "call": "callbacks_for",
+    "kind": "args",
+    "rubyArgs": ["ref:method"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/collection-association.ts",
     "rubyName": "concat_records",
     "call": "loaded?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -19,6 +28,15 @@
     "rubyName": "empty?",
     "call": "exists?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/collection-association.ts",
+    "rubyName": "ids_writer",
+    "call": "all",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -96,6 +114,15 @@
     "rubyName": "replace",
     "call": "transaction",
     "reason": "Confirmed equivalent (RFC 0044, transaction-wrapping-cluster): trails splits Rails' synchronous `CollectionAssociation#replace` (which wraps `replace_records` in `transaction` for a persisted owner — collection_association.rb:251) into a sync `replace` that records `_pendingReplace` plus an async `persistReplace`. The persisted-owner diff/save runs inside `transaction(this, ...)` in `persistReplace` (collection-association.ts:437), not literally inside `replace`, so the call-set extractor — which scopes to the Ruby-named `replace` body — flags it. The atomic wrap is present; false positive, no omission."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/collection-association.ts",
+    "rubyName": "replace_common_records_in_memory",
+    "call": "replace_on_target",
+    "kind": "args",
+    "rubyArgs": ["ref:record", "ref:skipCallbacks", "kwargs{replace=bool:true}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-proxy.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-proxy.json
@@ -5,7 +5,9 @@
     "rubyName": "delete_all",
     "call": "delete_all",
     "kind": "args",
-    "rubyArgs": ["ref:dependent"],
+    "rubyArgs": [
+      "ref:dependent"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-proxy.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-proxy.json
@@ -1,0 +1,20 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "associations/collection-proxy.ts",
+    "rubyName": "delete_all",
+    "call": "delete_all",
+    "kind": "args",
+    "rubyArgs": ["ref:dependent"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/collection-proxy.ts",
+    "rubyName": "scope",
+    "call": "scope",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-many-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-many-association.json
@@ -76,7 +76,9 @@
     "rubyName": "handle_dependency",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:name"],
+    "rubyArgs": [
+      "ref:name"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -106,7 +108,9 @@
     "rubyName": "update_counter_if_success",
     "call": "update_counter_in_memory",
     "kind": "args",
-    "rubyArgs": ["ref:difference"],
+    "rubyArgs": [
+      "ref:difference"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-many-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-many-association.json
@@ -10,8 +10,30 @@
     "package": "activerecord",
     "tsFile": "associations/has-many-association.ts",
     "rubyName": "handle_dependency",
+    "call": "add",
+    "kind": "args",
+    "rubyArgs": [
+      "str:base",
+      "str:restrict_dependent_destroy.has_many",
+      "kwargs{record=ref:record}"
+    ],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-many-association.ts",
+    "rubyName": "handle_dependency",
     "call": "collect",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-many-association.ts",
+    "rubyName": "handle_dependency",
+    "call": "delete_all",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -51,6 +73,15 @@
   {
     "package": "activerecord",
     "tsFile": "associations/has-many-association.ts",
+    "rubyName": "handle_dependency",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:name"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-many-association.ts",
     "rubyName": "set_owner_attributes",
     "call": "owner",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -68,5 +99,14 @@
     "rubyName": "set_owner_attributes",
     "call": "type",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-many-association.ts",
+    "rubyName": "update_counter_if_success",
+    "call": "update_counter_in_memory",
+    "kind": "args",
+    "rubyArgs": ["ref:difference"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-many-through-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-many-through-association.json
@@ -72,7 +72,9 @@
     "rubyName": "delete_through_records",
     "call": "through_records_for",
     "kind": "args",
-    "rubyArgs": ["ref:record"],
+    "rubyArgs": [
+      "ref:record"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -88,7 +90,9 @@
     "rubyName": "save_through_record",
     "call": "build_through_record",
     "kind": "args",
-    "rubyArgs": ["ref:record"],
+    "rubyArgs": [
+      "ref:record"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -148,7 +152,9 @@
     "rubyName": "through_records_for",
     "call": "construct_join_attributes",
     "kind": "args",
-    "rubyArgs": ["ref:record"],
+    "rubyArgs": [
+      "ref:record"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-many-through-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-many-through-association.json
@@ -16,6 +16,24 @@
   {
     "package": "activerecord",
     "tsFile": "associations/has-many-through-association.ts",
+    "rubyName": "build_through_record",
+    "call": "through_scope_attributes",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-many-through-association.ts",
+    "rubyName": "construct_join_attributes",
+    "call": "ensure_mutable",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-many-through-association.ts",
     "rubyName": "delete_records",
     "call": "count",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -51,9 +69,27 @@
   {
     "package": "activerecord",
     "tsFile": "associations/has-many-through-association.ts",
+    "rubyName": "delete_through_records",
+    "call": "through_records_for",
+    "kind": "args",
+    "rubyArgs": ["ref:record"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-many-through-association.ts",
     "rubyName": "find_target",
     "call": "scope",
     "reason": "Baseline (RFC 0084): `find_target` delegates to the module-private loader in the same file, which builds and runs the association scope; the body compared here is the delegating wrapper, so `scope` is called one frame down. Surfaced when the loader stopped being exported (RFC 0072)."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-many-through-association.ts",
+    "rubyName": "save_through_record",
+    "call": "build_through_record",
+    "kind": "args",
+    "rubyArgs": ["ref:record"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -96,5 +132,32 @@
     "rubyName": "target_scope",
     "call": "scope_for_association",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-many-through-association.ts",
+    "rubyName": "through_association",
+    "call": "through_reflection",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-many-through-association.ts",
+    "rubyName": "through_records_for",
+    "call": "construct_join_attributes",
+    "kind": "args",
+    "rubyArgs": ["ref:record"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-many-through-association.ts",
+    "rubyName": "through_scope_attributes",
+    "call": "through_scope",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-one-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-one-association.json
@@ -75,7 +75,11 @@
     "rubyName": "handle_dependency",
     "call": "add",
     "kind": "args",
-    "rubyArgs": ["str:base", "str:restrict_dependent_destroy.has_one", "kwargs{record=ref:record}"],
+    "rubyArgs": [
+      "str:base",
+      "str:restrict_dependent_destroy.has_one",
+      "kwargs{record=ref:record}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -84,7 +88,9 @@
     "rubyName": "handle_dependency",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:name"],
+    "rubyArgs": [
+      "ref:name"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-one-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-one-association.json
@@ -72,6 +72,24 @@
   {
     "package": "activerecord",
     "tsFile": "associations/has-one-association.ts",
+    "rubyName": "handle_dependency",
+    "call": "add",
+    "kind": "args",
+    "rubyArgs": ["str:base", "str:restrict_dependent_destroy.has_one", "kwargs{record=ref:record}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-one-association.ts",
+    "rubyName": "handle_dependency",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:name"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-one-association.ts",
     "rubyName": "nullify_owner_attributes",
     "call": "foreign_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -103,6 +121,15 @@
     "rubyName": "replace",
     "call": "transaction_if",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-one-association.ts",
+    "rubyName": "set_owner_attributes",
+    "call": "polymorphic_name",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-one-through-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-one-through-association.json
@@ -2,6 +2,42 @@
   {
     "package": "activerecord",
     "tsFile": "associations/has-one-through-association.ts",
+    "rubyName": "construct_join_attributes",
+    "call": "ensure_mutable",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-one-through-association.ts",
+    "rubyName": "create_through_record",
+    "call": "construct_join_attributes",
+    "kind": "args",
+    "rubyArgs": ["ref:record"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-one-through-association.ts",
+    "rubyName": "create_through_record",
+    "call": "ensure_not_nested",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-one-through-association.ts",
+    "rubyName": "create_through_record",
+    "call": "through_association",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-one-through-association.ts",
     "rubyName": "foreign_key_present?",
     "call": "all?",
     "reason": "Equivalent: foreignKeyPresent() delegates to ThroughAssociation#foreign_key_present? via the throughForeignKeyPresent mixin helper (through-association.ts), same delegation pattern as replace/stale_state/target_scope on this class."
@@ -82,5 +118,23 @@
     "rubyName": "target_scope",
     "call": "scope_for_association",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-one-through-association.ts",
+    "rubyName": "through_association",
+    "call": "through_reflection",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-one-through-association.ts",
+    "rubyName": "transaction",
+    "call": "through_reflection",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-one-through-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-one-through-association.json
@@ -14,7 +14,9 @@
     "rubyName": "create_through_record",
     "call": "construct_join_attributes",
     "kind": "args",
-    "rubyArgs": ["ref:record"],
+    "rubyArgs": [
+      "ref:record"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/join-dependency.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/join-dependency.json
@@ -9,6 +9,15 @@
   {
     "package": "activerecord",
     "tsFile": "associations/join-dependency.ts",
+    "rubyName": "build",
+    "call": "build",
+    "kind": "args",
+    "rubyArgs": ["ref:right", "ref:klass"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/join-dependency.ts",
     "rubyName": "instantiate",
     "call": "match?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/join-dependency.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/join-dependency.json
@@ -12,7 +12,10 @@
     "rubyName": "build",
     "call": "build",
     "kind": "args",
-    "rubyArgs": ["ref:right", "ref:klass"],
+    "rubyArgs": [
+      "ref:right",
+      "ref:klass"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/nested-error.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/nested-error.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "associations/nested-error.ts",
+    "rubyName": "initialize",
+    "call": "compute_attribute",
+    "kind": "args",
+    "rubyArgs": ["ref:innerError"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/nested-error.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/nested-error.json
@@ -5,7 +5,9 @@
     "rubyName": "initialize",
     "call": "compute_attribute",
     "kind": "args",
-    "rubyArgs": ["ref:innerError"],
+    "rubyArgs": [
+      "ref:innerError"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/preloader/branch.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/preloader/branch.json
@@ -2,9 +2,43 @@
   {
     "package": "activerecord",
     "tsFile": "associations/preloader/branch.ts",
+    "rubyName": "grouped_records",
+    "call": "association",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/preloader/branch.ts",
     "rubyName": "initialize",
     "call": "build_children",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/preloader/branch.ts",
+    "rubyName": "preloaders_for_reflection",
+    "call": "association",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/preloader/branch.ts",
+    "rubyName": "preloaders_for_reflection",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:rhsKlass",
+      "ref:rs",
+      "ref:reflection",
+      "ref:scope",
+      "ref:reflectionScope",
+      "ref:associateByDefault"
+    ],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/preloader/through-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/preloader/through-association.json
@@ -16,8 +16,35 @@
   {
     "package": "activerecord",
     "tsFile": "associations/preloader/through-association.ts",
+    "rubyName": "records_by_owner",
+    "call": "loaded?",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/preloader/through-association.ts",
     "rubyName": "source_preloaders",
     "call": "scope",
     "reason": "Deliberate: the source Preloader is handed a scope derived from `reflectionScope`/`preloadScope` rather than `scope`, because `throughScope` may already have eager-loaded the source (see the block comment at the call site)."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/preloader/through-association.ts",
+    "rubyName": "source_records_by_owner",
+    "call": "reduce",
+    "kind": "args",
+    "rubyArgs": ["str:merge"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/preloader/through-association.ts",
+    "rubyName": "through_records_by_owner",
+    "call": "reduce",
+    "kind": "args",
+    "rubyArgs": ["str:merge"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/preloader/through-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/preloader/through-association.json
@@ -35,7 +35,9 @@
     "rubyName": "source_records_by_owner",
     "call": "reduce",
     "kind": "args",
-    "rubyArgs": ["str:merge"],
+    "rubyArgs": [
+      "str:merge"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -44,7 +46,9 @@
     "rubyName": "through_records_by_owner",
     "call": "reduce",
     "kind": "args",
-    "rubyArgs": ["str:merge"],
+    "rubyArgs": [
+      "str:merge"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods.json
@@ -107,6 +107,15 @@
   {
     "package": "activerecord",
     "tsFile": "attribute-methods.ts",
+    "rubyName": "initialize_generated_modules",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "attribute-methods.ts",
     "rubyName": "instance_method_already_implemented?",
     "call": "dangerous_attribute_method?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods/read.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods/read.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "attribute-methods/read.ts",
+    "rubyName": "define_method_attribute",
+    "call": "define_attribute_accessor_method",
+    "kind": "args",
+    "rubyArgs": ["ref:owner", "ref:canonicalName"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods/read.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods/read.json
@@ -5,7 +5,10 @@
     "rubyName": "define_method_attribute",
     "call": "define_attribute_accessor_method",
     "kind": "args",
-    "rubyArgs": ["ref:owner", "ref:canonicalName"],
+    "rubyArgs": [
+      "ref:owner",
+      "ref:canonicalName"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods/serialization.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods/serialization.json
@@ -5,7 +5,11 @@
     "rubyName": "build_column_serializer",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:attrName", "ref:coder", "ref:type"],
+    "rubyArgs": [
+      "ref:attrName",
+      "ref:coder",
+      "ref:type"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods/serialization.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods/serialization.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "attribute-methods/serialization.ts",
+    "rubyName": "build_column_serializer",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:attrName", "ref:coder", "ref:type"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods/time-zone-conversion.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods/time-zone-conversion.json
@@ -5,5 +5,14 @@
     "rubyName": "cast",
     "call": "user_input_in_time_zone",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "attribute-methods/time-zone-conversion.ts",
+    "rubyName": "convert_time_to_time_zone",
+    "call": "map",
+    "kind": "args",
+    "rubyArgs": ["ref:value"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods/time-zone-conversion.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods/time-zone-conversion.json
@@ -12,7 +12,9 @@
     "rubyName": "convert_time_to_time_zone",
     "call": "map",
     "kind": "args",
-    "rubyArgs": ["ref:value"],
+    "rubyArgs": [
+      "ref:value"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods/write.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods/write.json
@@ -5,7 +5,11 @@
     "rubyName": "define_method_attribute=",
     "call": "define_attribute_accessor_method",
     "kind": "args",
-    "rubyArgs": ["ref:owner", "ref:canonicalName", "kwargs{writer=bool:true}"],
+    "rubyArgs": [
+      "ref:owner",
+      "ref:canonicalName",
+      "kwargs{writer=bool:true}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods/write.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods/write.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "attribute-methods/write.ts",
+    "rubyName": "define_method_attribute=",
+    "call": "define_attribute_accessor_method",
+    "kind": "args",
+    "rubyArgs": ["ref:owner", "ref:canonicalName", "kwargs{writer=bool:true}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/attributes.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/attributes.json
@@ -5,7 +5,9 @@
     "rubyName": "_default_attributes",
     "call": "apply_pending_attribute_modifications",
     "kind": "args",
-    "rubyArgs": ["ref:attributeSet"],
+    "rubyArgs": [
+      "ref:attributeSet"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -14,7 +16,9 @@
     "rubyName": "_default_attributes",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:attributesHash"],
+    "rubyArgs": [
+      "ref:attributesHash"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/attributes.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/attributes.json
@@ -3,6 +3,24 @@
     "package": "activerecord",
     "tsFile": "attributes.ts",
     "rubyName": "_default_attributes",
+    "call": "apply_pending_attribute_modifications",
+    "kind": "args",
+    "rubyArgs": ["ref:attributeSet"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "attributes.ts",
+    "rubyName": "_default_attributes",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:attributesHash"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "attributes.ts",
+    "rubyName": "_default_attributes",
     "call": "type_for_column",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/autosave-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/autosave-association.json
@@ -2,6 +2,33 @@
   {
     "package": "activerecord",
     "tsFile": "autosave-association.ts",
+    "rubyName": "add_autosave_association_callbacks",
+    "call": "around_save",
+    "kind": "args",
+    "rubyArgs": ["str:aroundSaveCollectionAssociation"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "autosave-association.ts",
+    "rubyName": "add_autosave_association_callbacks",
+    "call": "define_autosave_validation_callbacks",
+    "kind": "args",
+    "rubyArgs": ["ref:reflection"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "autosave-association.ts",
+    "rubyName": "add_autosave_association_callbacks",
+    "call": "define_non_cyclic_method",
+    "kind": "args",
+    "rubyArgs": ["ref:saveMethod"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "autosave-association.ts",
     "rubyName": "association_valid?",
     "call": "any?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -19,6 +46,24 @@
     "rubyName": "changed_for_autosave?",
     "call": "marked_for_destruction?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "autosave-association.ts",
+    "rubyName": "define_autosave_validation_callbacks",
+    "call": "after_validation",
+    "kind": "args",
+    "rubyArgs": ["str:_ensure_no_duplicate_errors"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "autosave-association.ts",
+    "rubyName": "define_autosave_validation_callbacks",
+    "call": "define_non_cyclic_method",
+    "kind": "args",
+    "rubyArgs": ["ref:validationMethod"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/autosave-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/autosave-association.json
@@ -5,7 +5,9 @@
     "rubyName": "add_autosave_association_callbacks",
     "call": "around_save",
     "kind": "args",
-    "rubyArgs": ["str:aroundSaveCollectionAssociation"],
+    "rubyArgs": [
+      "str:aroundSaveCollectionAssociation"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -14,7 +16,9 @@
     "rubyName": "add_autosave_association_callbacks",
     "call": "define_autosave_validation_callbacks",
     "kind": "args",
-    "rubyArgs": ["ref:reflection"],
+    "rubyArgs": [
+      "ref:reflection"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -23,7 +27,9 @@
     "rubyName": "add_autosave_association_callbacks",
     "call": "define_non_cyclic_method",
     "kind": "args",
-    "rubyArgs": ["ref:saveMethod"],
+    "rubyArgs": [
+      "ref:saveMethod"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -53,7 +59,9 @@
     "rubyName": "define_autosave_validation_callbacks",
     "call": "after_validation",
     "kind": "args",
-    "rubyArgs": ["str:_ensure_no_duplicate_errors"],
+    "rubyArgs": [
+      "str:_ensure_no_duplicate_errors"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -62,7 +70,9 @@
     "rubyName": "define_autosave_validation_callbacks",
     "call": "define_non_cyclic_method",
     "kind": "args",
-    "rubyArgs": ["ref:validationMethod"],
+    "rubyArgs": [
+      "ref:validationMethod"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/coders/column-serializer.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/coders/column-serializer.json
@@ -5,5 +5,23 @@
     "rubyName": "check_arity_of_constructor",
     "call": "load",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "coders/column-serializer.ts",
+    "rubyName": "dump",
+    "call": "assert_valid_value",
+    "kind": "args",
+    "rubyArgs": ["ref:object", "kwargs{action=str:dump}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "coders/column-serializer.ts",
+    "rubyName": "load",
+    "call": "assert_valid_value",
+    "kind": "args",
+    "rubyArgs": ["ref:object", "kwargs{action=str:load}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/coders/column-serializer.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/coders/column-serializer.json
@@ -12,7 +12,10 @@
     "rubyName": "dump",
     "call": "assert_valid_value",
     "kind": "args",
-    "rubyArgs": ["ref:object", "kwargs{action=str:dump}"],
+    "rubyArgs": [
+      "ref:object",
+      "kwargs{action=str:dump}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -21,7 +24,10 @@
     "rubyName": "load",
     "call": "assert_valid_value",
     "kind": "args",
-    "rubyArgs": ["ref:object", "kwargs{action=str:load}"],
+    "rubyArgs": [
+      "ref:object",
+      "kwargs{action=str:load}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-adapter.json
@@ -26,7 +26,9 @@
     "rubyName": "case_insensitive_comparison",
     "call": "lower",
     "kind": "args",
-    "rubyArgs": ["ref:value"],
+    "rubyArgs": [
+      "ref:value"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -35,7 +37,9 @@
     "rubyName": "column_for_attribute",
     "call": "columns_hash",
     "kind": "args",
-    "rubyArgs": ["ref:tableName"],
+    "rubyArgs": [
+      "ref:tableName"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -44,7 +48,9 @@
     "rubyName": "disconnect!",
     "call": "clear_cache!",
     "kind": "args",
-    "rubyArgs": ["kwargs{newConnection=bool:true}"],
+    "rubyArgs": [
+      "kwargs{newConnection=bool:true}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -151,7 +157,9 @@
     "rubyName": "reconnect!",
     "call": "clear_cache!",
     "kind": "args",
-    "rubyArgs": ["kwargs{newConnection=bool:true}"],
+    "rubyArgs": [
+      "kwargs{newConnection=bool:true}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -160,7 +168,9 @@
     "rubyName": "reset!",
     "call": "clear_cache!",
     "kind": "args",
-    "rubyArgs": ["kwargs{newConnection=bool:true}"],
+    "rubyArgs": [
+      "kwargs{newConnection=bool:true}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -169,7 +179,9 @@
     "rubyName": "select_all",
     "call": "empty",
     "kind": "args",
-    "rubyArgs": ["kwargs{async=ref:async}"],
+    "rubyArgs": [
+      "kwargs{async=ref:async}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -185,7 +197,12 @@
     "rubyName": "select_one",
     "call": "select_all",
     "kind": "args",
-    "rubyArgs": ["ref:arel", "ref:name", "ref:binds", "kwargs{async=ref:async}"],
+    "rubyArgs": [
+      "ref:arel",
+      "ref:name",
+      "ref:binds",
+      "kwargs{async=ref:async}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -194,7 +211,12 @@
     "rubyName": "select_rows",
     "call": "select_all",
     "kind": "args",
-    "rubyArgs": ["ref:arel", "ref:name", "ref:binds", "kwargs{async=ref:async}"],
+    "rubyArgs": [
+      "ref:arel",
+      "ref:name",
+      "ref:binds",
+      "kwargs{async=ref:async}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -203,7 +225,12 @@
     "rubyName": "select_value",
     "call": "select_rows",
     "kind": "args",
-    "rubyArgs": ["ref:arel", "ref:name", "ref:binds", "kwargs{async=ref:async}"],
+    "rubyArgs": [
+      "ref:arel",
+      "ref:name",
+      "ref:binds",
+      "kwargs{async=ref:async}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-adapter.json
@@ -23,6 +23,33 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-adapter.ts",
+    "rubyName": "case_insensitive_comparison",
+    "call": "lower",
+    "kind": "args",
+    "rubyArgs": ["ref:value"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
+    "rubyName": "column_for_attribute",
+    "call": "columns_hash",
+    "kind": "args",
+    "rubyArgs": ["ref:tableName"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
+    "rubyName": "disconnect!",
+    "call": "clear_cache!",
+    "kind": "args",
+    "rubyArgs": ["kwargs{newConnection=bool:true}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
     "rubyName": "disconnect!",
     "call": "synchronize",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -121,9 +148,63 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-adapter.ts",
+    "rubyName": "reconnect!",
+    "call": "clear_cache!",
+    "kind": "args",
+    "rubyArgs": ["kwargs{newConnection=bool:true}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
+    "rubyName": "reset!",
+    "call": "clear_cache!",
+    "kind": "args",
+    "rubyArgs": ["kwargs{newConnection=bool:true}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
+    "rubyName": "select_all",
+    "call": "empty",
+    "kind": "args",
+    "rubyArgs": ["kwargs{async=ref:async}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
     "rubyName": "select_all",
     "call": "select",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
+    "rubyName": "select_one",
+    "call": "select_all",
+    "kind": "args",
+    "rubyArgs": ["ref:arel", "ref:name", "ref:binds", "kwargs{async=ref:async}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
+    "rubyName": "select_rows",
+    "call": "select_all",
+    "kind": "args",
+    "rubyArgs": ["ref:arel", "ref:name", "ref:binds", "kwargs{async=ref:async}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
+    "rubyName": "select_value",
+    "call": "select_rows",
+    "kind": "args",
+    "rubyArgs": ["ref:arel", "ref:name", "ref:binds", "kwargs{async=ref:async}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -138,5 +219,14 @@
     "rubyName": "with_raw_connection",
     "call": "order:translateExceptionClass,synchronize",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
+    "rubyName": "with_raw_connection",
+    "call": "synchronize",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
@@ -68,7 +68,12 @@
     "rubyName": "change_column_null",
     "call": "change_column",
     "kind": "args",
-    "rubyArgs": ["ref:tableName", "ref:columnName", "nil", "kwargs{null=ref:null}"],
+    "rubyArgs": [
+      "ref:tableName",
+      "ref:columnName",
+      "nil",
+      "kwargs{null=ref:null}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -91,7 +96,11 @@
     "rubyName": "check_constraints",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:tableName", "ref:expression", "ref:options"],
+    "rubyArgs": [
+      "ref:tableName",
+      "ref:expression",
+      "ref:options"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -191,7 +200,9 @@
     "rubyName": "mismatched_foreign_key",
     "call": "mismatched_foreign_key_details",
     "kind": "args",
-    "rubyArgs": ["kwargs{message=ref:message,sql=ref:sql}"],
+    "rubyArgs": [
+      "kwargs{message=ref:message,sql=ref:sql}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
@@ -66,6 +66,15 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "change_column_null",
+    "call": "change_column",
+    "kind": "args",
+    "rubyArgs": ["ref:tableName", "ref:columnName", "nil", "kwargs{null=ref:null}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
+    "rubyName": "change_column_null",
     "call": "order:quoteColumnName,execute",
     "reason": "ORDER-only: Ruby evaluates the interpolated quote_table_name / *_for_alter arguments before `execute`; TS source order puts the `execute` call first, so the extractor's textual ordering can never match. Same body, same call set."
   },
@@ -75,6 +84,15 @@
     "rubyName": "check_constraints",
     "call": "internal_exec_query",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
+    "rubyName": "check_constraints",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:tableName", "ref:expression", "ref:options"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -166,6 +184,15 @@
     "rubyName": "handle_warnings",
     "call": "warning_ignored?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
+    "rubyName": "mismatched_foreign_key",
+    "call": "mismatched_foreign_key_details",
+    "kind": "args",
+    "rubyArgs": ["kwargs{message=ref:message,sql=ref:sql}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-handler.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-handler.json
@@ -19,7 +19,10 @@
     "rubyName": "establish_connection",
     "call": "instrument",
     "kind": "args",
-    "rubyArgs": ["str:!connection.active_record", "ref:payload"],
+    "rubyArgs": [
+      "str:!connection.active_record",
+      "ref:payload"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -28,7 +31,12 @@
     "rubyName": "establish_connection",
     "call": "resolve_pool_config",
     "kind": "args",
-    "rubyArgs": ["ref:config", "ref:ownerName", "ref:role", "ref:shard"],
+    "rubyArgs": [
+      "ref:config",
+      "ref:ownerName",
+      "ref:role",
+      "ref:shard"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -37,7 +45,9 @@
     "rubyName": "initialize",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["kwargs{initialCapacity=num:2}"],
+    "rubyArgs": [
+      "kwargs{initialCapacity=num:2}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -46,7 +56,12 @@
     "rubyName": "resolve_pool_config",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:connectionName", "ref:dbConfig", "ref:role", "ref:shard"],
+    "rubyArgs": [
+      "ref:connectionName",
+      "ref:dbConfig",
+      "ref:role",
+      "ref:shard"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-handler.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-handler.json
@@ -12,5 +12,53 @@
     "rubyName": "connection_pool_list",
     "call": "map",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/connection-handler.ts",
+    "rubyName": "establish_connection",
+    "call": "instrument",
+    "kind": "args",
+    "rubyArgs": ["str:!connection.active_record", "ref:payload"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/connection-handler.ts",
+    "rubyName": "establish_connection",
+    "call": "resolve_pool_config",
+    "kind": "args",
+    "rubyArgs": ["ref:config", "ref:ownerName", "ref:role", "ref:shard"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/connection-handler.ts",
+    "rubyName": "initialize",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["kwargs{initialCapacity=num:2}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/connection-handler.ts",
+    "rubyName": "resolve_pool_config",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:connectionName", "ref:dbConfig", "ref:role", "ref:shard"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/connection-handler.ts",
+    "rubyName": "retrieve_connection_pool",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:message",
+      "kwargs{connectionName=ref:connectionName,role=ref:role,shard=ref:shard}"
+    ],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-pool.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-pool.json
@@ -14,7 +14,9 @@
     "rubyName": "attempt_to_checkout_all_existing_connections",
     "call": "checkout_for_exclusive_access",
     "kind": "args",
-    "rubyArgs": ["ref:remainingTimeout"],
+    "rubyArgs": [
+      "ref:remainingTimeout"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -202,7 +204,9 @@
     "rubyName": "try_to_checkout_new_connection",
     "call": "adopt_connection",
     "kind": "args",
-    "rubyArgs": ["ref:conn"],
+    "rubyArgs": [
+      "ref:conn"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -243,7 +247,9 @@
     "rubyName": "with_connection",
     "call": "release_connection",
     "kind": "args",
-    "rubyArgs": ["ref:lease"],
+    "rubyArgs": [
+      "ref:lease"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -252,7 +258,9 @@
     "rubyName": "with_exclusively_acquired_all_connections",
     "call": "attempt_to_checkout_all_existing_connections",
     "kind": "args",
-    "rubyArgs": ["ref:raiseOnAcquisitionTimeout"],
+    "rubyArgs": [
+      "ref:raiseOnAcquisitionTimeout"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -270,7 +278,9 @@
     "rubyName": "with_new_connections_blocked",
     "call": "bulk_make_new_connections",
     "kind": "args",
-    "rubyArgs": ["ref:numNewConnsRequired"],
+    "rubyArgs": [
+      "ref:numNewConnsRequired"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-pool.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-pool.json
@@ -2,6 +2,33 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/connection-pool.ts",
+    "rubyName": "acquire_connection",
+    "call": "try_to_checkout_new_connection",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/connection-pool.ts",
+    "rubyName": "attempt_to_checkout_all_existing_connections",
+    "call": "checkout_for_exclusive_access",
+    "kind": "args",
+    "rubyArgs": ["ref:remainingTimeout"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/connection-pool.ts",
+    "rubyName": "bulk_make_new_connections",
+    "call": "try_to_checkout_new_connection",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/connection-pool.ts",
     "rubyName": "checkin",
     "call": "synchronize",
     "reason": "Ruby guards the body with Mutex#synchronize; the ported body is fully synchronous — it has no yield point, so run-to-completion supplies what the mutex supplies and the port has no analogue call."
@@ -40,6 +67,15 @@
     "rubyName": "clear_reloadable_connections",
     "call": "synchronize",
     "reason": "Ruby guards the body with Mutex#synchronize; the ported body mutates pool state in a fully synchronous core and only then awaits the drains that core returns, so no other body observes an intermediate state and the mutex has no analogue call. The invariant a later refactor must not break is that every state mutation precedes the first await."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/connection-pool.ts",
+    "rubyName": "complete",
+    "call": "each_connection_pool",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -163,6 +199,24 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/connection-pool.ts",
+    "rubyName": "try_to_checkout_new_connection",
+    "call": "adopt_connection",
+    "kind": "args",
+    "rubyArgs": ["ref:conn"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/connection-pool.ts",
+    "rubyName": "try_to_checkout_new_connection",
+    "call": "checkout_new_connection",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/connection-pool.ts",
     "rubyName": "unpin_connection!",
     "call": "lock",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -173,5 +227,50 @@
     "rubyName": "unpin_connection!",
     "call": "synchronize",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/connection-pool.ts",
+    "rubyName": "with_connection",
+    "call": "checkout",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/connection-pool.ts",
+    "rubyName": "with_connection",
+    "call": "release_connection",
+    "kind": "args",
+    "rubyArgs": ["ref:lease"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/connection-pool.ts",
+    "rubyName": "with_exclusively_acquired_all_connections",
+    "call": "attempt_to_checkout_all_existing_connections",
+    "kind": "args",
+    "rubyArgs": ["ref:raiseOnAcquisitionTimeout"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/connection-pool.ts",
+    "rubyName": "with_exclusively_acquired_all_connections",
+    "call": "with_new_connections_blocked",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/connection-pool.ts",
+    "rubyName": "with_new_connections_blocked",
+    "call": "bulk_make_new_connections",
+    "kind": "args",
+    "rubyArgs": ["ref:numNewConnsRequired"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-pool/queue.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-pool/queue.json
@@ -90,7 +90,11 @@
     "rubyName": "with_a_bias_for",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:lock", "ref:cond", "ref:thread"],
+    "rubyArgs": [
+      "ref:lock",
+      "ref:cond",
+      "ref:thread"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-pool/queue.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-pool/queue.json
@@ -9,6 +9,33 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/connection-pool/queue.ts",
+    "rubyName": "add",
+    "call": "signal",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/connection-pool/queue.ts",
+    "rubyName": "broadcast",
+    "call": "broadcast",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/connection-pool/queue.ts",
+    "rubyName": "broadcast",
+    "call": "broadcast_on_biased",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/connection-pool/queue.ts",
     "rubyName": "broadcast_on_biased",
     "call": "broadcast",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -30,6 +57,15 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/connection-pool/queue.ts",
+    "rubyName": "signal",
+    "call": "signal",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/connection-pool/queue.ts",
     "rubyName": "wait",
     "call": "current",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -47,5 +83,14 @@
     "rubyName": "wait_poll",
     "call": "remove",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/connection-pool/queue.ts",
+    "rubyName": "with_a_bias_for",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:lock", "ref:cond", "ref:thread"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/database-statements.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/database-statements.json
@@ -119,7 +119,9 @@
     "rubyName": "insert_fixtures_set",
     "call": "transaction",
     "kind": "args",
-    "rubyArgs": ["kwargs{requiresNew=bool:true}"],
+    "rubyArgs": [
+      "kwargs{requiresNew=bool:true}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/database-statements.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/database-statements.json
@@ -101,8 +101,26 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/database-statements.ts",
     "rubyName": "insert_fixtures_set",
+    "call": "disable_referential_integrity",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/database-statements.ts",
+    "rubyName": "insert_fixtures_set",
     "call": "order:disableReferentialIntegrity,transaction",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/database-statements.ts",
+    "rubyName": "insert_fixtures_set",
+    "call": "transaction",
+    "kind": "args",
+    "rubyArgs": ["kwargs{requiresNew=bool:true}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -159,6 +177,15 @@
     "rubyName": "truncate",
     "call": "order:buildTruncateStatement,execute",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/database-statements.ts",
+    "rubyName": "truncate_tables",
+    "call": "disable_referential_integrity",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/query-cache.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/query-cache.json
@@ -2,6 +2,15 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/query-cache.ts",
+    "rubyName": "cache_sql",
+    "call": "compute_if_absent",
+    "kind": "args",
+    "rubyArgs": ["ref:key"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/query-cache.ts",
     "rubyName": "query_cache",
     "call": "compute_if_absent",
     "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails query_cache.rb:187-191 calls `@thread_query_caches.compute_if_absent(IsolatedExecutionState.context)`; trails query-cache.ts:318-322 makes the same computeIfAbsent call with `executionContextId()` standing in for IsolatedExecutionState.context — the TS method is a getter, and the extractor records no calls for getters (its ts-api record carries no call set), so both reads go uncredited."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/query-cache.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/query-cache.json
@@ -5,7 +5,9 @@
     "rubyName": "cache_sql",
     "call": "compute_if_absent",
     "kind": "args",
-    "rubyArgs": ["ref:key"],
+    "rubyArgs": [
+      "ref:key"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/schema-creation.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/schema-creation.json
@@ -38,6 +38,15 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-creation.ts",
     "rubyName": "visit_AlterTable",
+    "call": "join",
+    "kind": "args",
+    "rubyArgs": ["str: "],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/schema-creation.ts",
+    "rubyName": "visit_AlterTable",
     "call": "order:visitAddForeignKey,join",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/schema-creation.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/schema-creation.json
@@ -40,7 +40,9 @@
     "rubyName": "visit_AlterTable",
     "call": "join",
     "kind": "args",
-    "rubyArgs": ["str: "],
+    "rubyArgs": [
+      "str: "
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/schema-definitions.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/schema-definitions.json
@@ -3,8 +3,26 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-definitions.ts",
     "rubyName": "add_column",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:newColumnDefinition"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/schema-definitions.ts",
+    "rubyName": "add_column",
     "call": "order:newColumnDefinition,constructor",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/schema-definitions.ts",
+    "rubyName": "add_to",
+    "call": "foreign_key",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -44,6 +62,15 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-definitions.ts",
+    "rubyName": "create_column_definition",
+    "call": "assert_valid_keys",
+    "kind": "args",
+    "rubyArgs": ["ref:validColumnDefinitionOptions"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/schema-definitions.ts",
     "rubyName": "foreign_key_options",
     "call": "merge",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -54,6 +81,15 @@
     "rubyName": "foreign_table_name",
     "call": "fetch",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/schema-definitions.ts",
+    "rubyName": "foreign_table_name",
+    "call": "pluralize",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -96,5 +132,14 @@
     "rubyName": "set_primary_key",
     "call": "get_primary_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/schema-definitions.ts",
+    "rubyName": "set_primary_key",
+    "call": "singularize",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/schema-definitions.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/schema-definitions.json
@@ -5,7 +5,9 @@
     "rubyName": "add_column",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:newColumnDefinition"],
+    "rubyArgs": [
+      "ref:newColumnDefinition"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -65,7 +67,9 @@
     "rubyName": "create_column_definition",
     "call": "assert_valid_keys",
     "kind": "args",
-    "rubyArgs": ["ref:validColumnDefinitionOptions"],
+    "rubyArgs": [
+      "ref:validColumnDefinitionOptions"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/schema-statements.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/schema-statements.json
@@ -24,6 +24,15 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "create_table",
+    "call": "presence",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/schema-statements.ts",
+    "rubyName": "create_table",
     "call": "validate_table_length!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -47,6 +56,15 @@
     "rubyName": "foreign_key_name",
     "call": "map",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/schema-statements.ts",
+    "rubyName": "foreign_key_options",
+    "call": "foreign_key_name",
+    "kind": "args",
+    "rubyArgs": ["ref:fromTable", "ref:options"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -86,6 +104,15 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
+    "rubyName": "index_algorithm",
+    "call": "keys",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "index_name",
     "call": "index_name_options",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -96,6 +123,33 @@
     "rubyName": "index_name_exists?",
     "call": "detect",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/schema-statements.ts",
+    "rubyName": "index_name_for_remove",
+    "call": "index_name",
+    "kind": "args",
+    "rubyArgs": ["ref:tableName", "ref:columnName"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/schema-statements.ts",
+    "rubyName": "index_name_for_remove",
+    "call": "index_name",
+    "kind": "args",
+    "rubyArgs": ["ref:tableName", "ref:columns"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/schema-statements.ts",
+    "rubyName": "index_name_for_remove",
+    "call": "join",
+    "kind": "args",
+    "rubyArgs": ["str:, "],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -121,6 +175,24 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
+    "rubyName": "remove_foreign_key",
+    "call": "foreign_key_exists?",
+    "kind": "args",
+    "rubyArgs": ["ref:fromTable", "ref:toTable"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/schema-statements.ts",
+    "rubyName": "remove_reference",
+    "call": "pluralize",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "table_exists?",
     "call": "any?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -128,8 +200,26 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
+    "rubyName": "tables",
+    "call": "data_source_sql",
+    "kind": "args",
+    "rubyArgs": ["kwargs{type=str:BASE TABLE}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "view_exists?",
     "call": "any?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/schema-statements.ts",
+    "rubyName": "views",
+    "call": "data_source_sql",
+    "kind": "args",
+    "rubyArgs": ["kwargs{type=str:VIEW}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/schema-statements.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/schema-statements.json
@@ -63,7 +63,10 @@
     "rubyName": "foreign_key_options",
     "call": "foreign_key_name",
     "kind": "args",
-    "rubyArgs": ["ref:fromTable", "ref:options"],
+    "rubyArgs": [
+      "ref:fromTable",
+      "ref:options"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -130,7 +133,10 @@
     "rubyName": "index_name_for_remove",
     "call": "index_name",
     "kind": "args",
-    "rubyArgs": ["ref:tableName", "ref:columnName"],
+    "rubyArgs": [
+      "ref:tableName",
+      "ref:columnName"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -139,7 +145,10 @@
     "rubyName": "index_name_for_remove",
     "call": "index_name",
     "kind": "args",
-    "rubyArgs": ["ref:tableName", "ref:columns"],
+    "rubyArgs": [
+      "ref:tableName",
+      "ref:columns"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -148,7 +157,9 @@
     "rubyName": "index_name_for_remove",
     "call": "join",
     "kind": "args",
-    "rubyArgs": ["str:, "],
+    "rubyArgs": [
+      "str:, "
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -178,7 +189,10 @@
     "rubyName": "remove_foreign_key",
     "call": "foreign_key_exists?",
     "kind": "args",
-    "rubyArgs": ["ref:fromTable", "ref:toTable"],
+    "rubyArgs": [
+      "ref:fromTable",
+      "ref:toTable"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -203,7 +217,9 @@
     "rubyName": "tables",
     "call": "data_source_sql",
     "kind": "args",
-    "rubyArgs": ["kwargs{type=str:BASE TABLE}"],
+    "rubyArgs": [
+      "kwargs{type=str:BASE TABLE}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -219,7 +235,9 @@
     "rubyName": "views",
     "call": "data_source_sql",
     "kind": "args",
-    "rubyArgs": ["kwargs{type=str:VIEW}"],
+    "rubyArgs": [
+      "kwargs{type=str:VIEW}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/transaction.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/transaction.json
@@ -2,6 +2,15 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/transaction.ts",
+    "rubyName": "after_rollback",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["str:afterRollback", "ref:block"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/transaction.ts",
     "rubyName": "before_commit_records",
     "call": "run_action_on_records",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/transaction.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/transaction.json
@@ -5,7 +5,10 @@
     "rubyName": "after_rollback",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["str:afterRollback", "ref:block"],
+    "rubyArgs": [
+      "str:afterRollback",
+      "ref:block"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/mysql2-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/mysql2-adapter.json
@@ -30,6 +30,24 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/mysql2-adapter.ts",
+    "rubyName": "initialize_type_map",
+    "call": "lookup",
+    "kind": "args",
+    "rubyArgs": ["str:string", "kwargs{adapter=str:mysql2,limit=ref:limit}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/mysql2-adapter.ts",
+    "rubyName": "initialize_type_map",
+    "call": "lookup",
+    "kind": "args",
+    "rubyArgs": ["str:string", "kwargs{adapter=str:mysql2}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/mysql2-adapter.ts",
     "rubyName": "new_client",
     "call": "db_error",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/mysql2-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/mysql2-adapter.json
@@ -33,7 +33,10 @@
     "rubyName": "initialize_type_map",
     "call": "lookup",
     "kind": "args",
-    "rubyArgs": ["str:string", "kwargs{adapter=str:mysql2,limit=ref:limit}"],
+    "rubyArgs": [
+      "str:string",
+      "kwargs{adapter=str:mysql2,limit=ref:limit}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -42,7 +45,10 @@
     "rubyName": "initialize_type_map",
     "call": "lookup",
     "kind": "args",
-    "rubyArgs": ["str:string", "kwargs{adapter=str:mysql2}"],
+    "rubyArgs": [
+      "str:string",
+      "kwargs{adapter=str:mysql2}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/mysql2/database-statements.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/mysql2/database-statements.json
@@ -5,7 +5,10 @@
     "rubyName": "cast_result",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:fields", "ref:toA"],
+    "rubyArgs": [
+      "ref:fields",
+      "ref:toA"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/mysql2/database-statements.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/mysql2/database-statements.json
@@ -3,6 +3,15 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/mysql2/database-statements.ts",
     "rubyName": "cast_result",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:fields", "ref:toA"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/mysql2/database-statements.ts",
+    "rubyName": "cast_result",
     "call": "order:freeRawResult,constructor",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql-adapter.json
@@ -79,6 +79,15 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "rubyName": "data_source_sql",
+    "call": "quoted_scope",
+    "kind": "args",
+    "rubyArgs": ["ref:name", "kwargs{type=ref:type}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "dbconsole",
     "call": "database_cli",
     "reason": "Rails reads the cli name only to pass it to `find_cmd_and_exec` (postgresql_adapter.rb); that PTY exec is Ruby-only and unported, so our `dbconsole` returns the arg list and never needs the lookup."
@@ -142,6 +151,32 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "rubyName": "exec_restart_db_transaction",
+    "call": "internal_execute",
+    "kind": "args",
+    "rubyArgs": [
+      "str:ROLLBACK AND CHAIN",
+      "str:TRANSACTION",
+      "kwargs{allowRetry=bool:false,materializeTransactions=bool:true}"
+    ],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "rubyName": "exec_rollback_db_transaction",
+    "call": "internal_execute",
+    "kind": "args",
+    "rubyArgs": [
+      "str:ROLLBACK",
+      "str:TRANSACTION",
+      "kwargs{allowRetry=bool:false,materializeTransactions=bool:true}"
+    ],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "explain",
     "call": "build_explain_clause",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -159,6 +194,15 @@
     "rubyName": "foreign_table_exists?",
     "call": "any?",
     "reason": "Ruby-ism: `query_values(...).any?` is `names.length > 0` in TS; `length` is a property access, not a call."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "rubyName": "foreign_tables",
+    "call": "data_source_sql",
+    "kind": "args",
+    "rubyArgs": ["kwargs{type=str:FOREIGN TABLE}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql-adapter.json
@@ -82,7 +82,10 @@
     "rubyName": "data_source_sql",
     "call": "quoted_scope",
     "kind": "args",
-    "rubyArgs": ["ref:name", "kwargs{type=ref:type}"],
+    "rubyArgs": [
+      "ref:name",
+      "kwargs{type=ref:type}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -201,7 +204,9 @@
     "rubyName": "foreign_tables",
     "call": "data_source_sql",
     "kind": "args",
-    "rubyArgs": ["kwargs{type=str:FOREIGN TABLE}"],
+    "rubyArgs": [
+      "kwargs{type=str:FOREIGN TABLE}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/database-statements.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/database-statements.json
@@ -26,7 +26,9 @@
     "rubyName": "handle_warnings",
     "call": "call",
     "kind": "args",
-    "rubyArgs": ["ref:warning"],
+    "rubyArgs": [
+      "ref:warning"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/database-statements.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/database-statements.json
@@ -23,6 +23,15 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql/database-statements.ts",
+    "rubyName": "handle_warnings",
+    "call": "call",
+    "kind": "args",
+    "rubyArgs": ["ref:warning"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql/database-statements.ts",
     "rubyName": "last_insert_id_result",
     "call": "internal_exec_query",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/oid/range.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/oid/range.json
@@ -12,7 +12,9 @@
     "rubyName": "infinity",
     "call": "infinity",
     "kind": "args",
-    "rubyArgs": ["kwargs{negative=ref:negative}"],
+    "rubyArgs": [
+      "kwargs{negative=ref:negative}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/oid/range.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/oid/range.json
@@ -9,6 +9,15 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql/oid/range.ts",
+    "rubyName": "infinity",
+    "call": "infinity",
+    "kind": "args",
+    "rubyArgs": ["kwargs{negative=ref:negative}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql/oid/range.ts",
     "rubyName": "serialize",
     "call": "order:constructor,typeCastSingleForDatabase",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/referential-integrity.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/referential-integrity.json
@@ -5,7 +5,9 @@
     "rubyName": "check_all_foreign_keys_valid!",
     "call": "execute",
     "kind": "args",
-    "rubyArgs": ["ref:sql"],
+    "rubyArgs": [
+      "ref:sql"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/referential-integrity.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/referential-integrity.json
@@ -2,6 +2,15 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql/referential-integrity.ts",
+    "rubyName": "check_all_foreign_keys_valid!",
+    "call": "execute",
+    "kind": "args",
+    "rubyArgs": ["ref:sql"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql/referential-integrity.ts",
     "rubyName": "disable_referential_integrity",
     "call": "order:tables,transaction",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/schema-creation.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/schema-creation.json
@@ -12,5 +12,14 @@
     "rubyName": "visit_AddUniqueConstraint",
     "call": "accept",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql/schema-creation.ts",
+    "rubyName": "visit_AlterTable",
+    "call": "join",
+    "kind": "args",
+    "rubyArgs": ["str: "],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/schema-creation.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/schema-creation.json
@@ -19,7 +19,9 @@
     "rubyName": "visit_AlterTable",
     "call": "join",
     "kind": "args",
-    "rubyArgs": ["str: "],
+    "rubyArgs": [
+      "str: "
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/schema-dumper.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/schema-dumper.json
@@ -12,7 +12,9 @@
     "rubyName": "exclusion_constraints_in_create",
     "call": "join",
     "kind": "args",
-    "rubyArgs": ["str:<n>"],
+    "rubyArgs": [
+      "str:<n>"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -28,7 +30,9 @@
     "rubyName": "unique_constraints_in_create",
     "call": "join",
     "kind": "args",
-    "rubyArgs": ["str:<n>"],
+    "rubyArgs": [
+      "str:<n>"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/schema-dumper.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/schema-dumper.json
@@ -9,8 +9,26 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql/schema-dumper.ts",
+    "rubyName": "exclusion_constraints_in_create",
+    "call": "join",
+    "kind": "args",
+    "rubyArgs": ["str:<n>"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql/schema-dumper.ts",
     "rubyName": "unique_constraints_in_create",
     "call": "any?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql/schema-dumper.ts",
+    "rubyName": "unique_constraints_in_create",
+    "call": "join",
+    "kind": "args",
+    "rubyArgs": ["str:<n>"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/sqlite3-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/sqlite3-adapter.json
@@ -2,9 +2,99 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
+    "rubyName": "add_check_constraint",
+    "call": "alter_table",
+    "kind": "args",
+    "rubyArgs": ["ref:tableName"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/sqlite3-adapter.ts",
+    "rubyName": "add_column",
+    "call": "alter_table",
+    "kind": "args",
+    "rubyArgs": ["ref:tableName"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/sqlite3-adapter.ts",
+    "rubyName": "add_foreign_key",
+    "call": "alter_table",
+    "kind": "args",
+    "rubyArgs": ["ref:fromTable"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/sqlite3-adapter.ts",
+    "rubyName": "add_timestamps",
+    "call": "alter_table",
+    "kind": "args",
+    "rubyArgs": ["ref:tableName"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/sqlite3-adapter.ts",
+    "rubyName": "alter_table",
+    "call": "move_table",
+    "kind": "args",
+    "rubyArgs": ["ref:tableName", "ref:alteredTableName", "ref:merge"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/sqlite3-adapter.ts",
+    "rubyName": "begin_db_transaction",
+    "call": "internal_begin_transaction",
+    "kind": "args",
+    "rubyArgs": ["str:immediate", "nil"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/sqlite3-adapter.ts",
+    "rubyName": "begin_isolated_db_transaction",
+    "call": "internal_begin_transaction",
+    "kind": "args",
+    "rubyArgs": ["str:deferred", "ref:isolation"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "build_insert_sql",
     "call": "map",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/sqlite3-adapter.ts",
+    "rubyName": "change_column",
+    "call": "alter_table",
+    "kind": "args",
+    "rubyArgs": ["ref:tableName"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/sqlite3-adapter.ts",
+    "rubyName": "change_column_default",
+    "call": "alter_table",
+    "kind": "args",
+    "rubyArgs": ["ref:tableName"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/sqlite3-adapter.ts",
+    "rubyName": "change_column_null",
+    "call": "alter_table",
+    "kind": "args",
+    "rubyArgs": ["ref:tableName"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -19,6 +109,28 @@
     "rubyName": "check_all_foreign_keys_valid!",
     "call": "execute",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/sqlite3-adapter.ts",
+    "rubyName": "check_constraints",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:tableName", "ref:expression", "kwargs{name=ref:name}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/sqlite3-adapter.ts",
+    "rubyName": "commit_db_transaction",
+    "call": "internal_execute",
+    "kind": "args",
+    "rubyArgs": [
+      "str:COMMIT TRANSACTION",
+      "str:TRANSACTION",
+      "kwargs{allowRetry=bool:true,materializeTransactions=bool:false}"
+    ],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -115,6 +227,15 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "get_database_version",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:queryValue"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/sqlite3-adapter.ts",
+    "rubyName": "get_database_version",
     "call": "query_value",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -129,8 +250,30 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "initialize",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["kwargs{connectionPool=ref:pool}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/sqlite3-adapter.ts",
+    "rubyName": "initialize",
     "call": "root",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/sqlite3-adapter.ts",
+    "rubyName": "internal_begin_transaction",
+    "call": "internal_execute",
+    "kind": "args",
+    "rubyArgs": [
+      "str:PRAGMA read_uncommitted=ON",
+      "str:TRANSACTION",
+      "kwargs{allowRetry=bool:true,materializeTransactions=bool:false}"
+    ],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -152,6 +295,24 @@
     "rubyName": "quote_string",
     "call": "quote",
     "reason": "Per-entry verified (RFC 0072 sqlite3 quoting cluster): Rails quoting.rb:66-68 delegates to the sqlite3 gem's C helper `::SQLite3::Database.quote`, which is exactly `'` -> `''`. There is no ported `SQLite3::Database` class (node:sqlite / better-sqlite3 expose no quote helper), so sqlite3-adapter.ts#quoteString spells that escape inline; it is the whole call's equivalent, not an omission."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/sqlite3-adapter.ts",
+    "rubyName": "remove_column",
+    "call": "alter_table",
+    "kind": "args",
+    "rubyArgs": ["ref:tableName"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/sqlite3-adapter.ts",
+    "rubyName": "remove_columns",
+    "call": "alter_table",
+    "kind": "args",
+    "rubyArgs": ["ref:tableName"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -229,6 +390,24 @@
     "rubyName": "table_structure_sql",
     "call": "union",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/sqlite3-adapter.ts",
+    "rubyName": "translate_exception",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:exception", "kwargs{connectionPool=ref:pool}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/sqlite3-adapter.ts",
+    "rubyName": "translate_exception",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:message", "kwargs{binds=ref:binds,connectionPool=ref:pool,sql=ref:sql}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/sqlite3-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/sqlite3-adapter.json
@@ -5,7 +5,9 @@
     "rubyName": "add_check_constraint",
     "call": "alter_table",
     "kind": "args",
-    "rubyArgs": ["ref:tableName"],
+    "rubyArgs": [
+      "ref:tableName"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -14,7 +16,9 @@
     "rubyName": "add_column",
     "call": "alter_table",
     "kind": "args",
-    "rubyArgs": ["ref:tableName"],
+    "rubyArgs": [
+      "ref:tableName"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -23,7 +27,9 @@
     "rubyName": "add_foreign_key",
     "call": "alter_table",
     "kind": "args",
-    "rubyArgs": ["ref:fromTable"],
+    "rubyArgs": [
+      "ref:fromTable"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -32,7 +38,9 @@
     "rubyName": "add_timestamps",
     "call": "alter_table",
     "kind": "args",
-    "rubyArgs": ["ref:tableName"],
+    "rubyArgs": [
+      "ref:tableName"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -41,7 +49,11 @@
     "rubyName": "alter_table",
     "call": "move_table",
     "kind": "args",
-    "rubyArgs": ["ref:tableName", "ref:alteredTableName", "ref:merge"],
+    "rubyArgs": [
+      "ref:tableName",
+      "ref:alteredTableName",
+      "ref:merge"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -50,7 +62,10 @@
     "rubyName": "begin_db_transaction",
     "call": "internal_begin_transaction",
     "kind": "args",
-    "rubyArgs": ["str:immediate", "nil"],
+    "rubyArgs": [
+      "str:immediate",
+      "nil"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -59,7 +74,10 @@
     "rubyName": "begin_isolated_db_transaction",
     "call": "internal_begin_transaction",
     "kind": "args",
-    "rubyArgs": ["str:deferred", "ref:isolation"],
+    "rubyArgs": [
+      "str:deferred",
+      "ref:isolation"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -75,7 +93,9 @@
     "rubyName": "change_column",
     "call": "alter_table",
     "kind": "args",
-    "rubyArgs": ["ref:tableName"],
+    "rubyArgs": [
+      "ref:tableName"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -84,7 +104,9 @@
     "rubyName": "change_column_default",
     "call": "alter_table",
     "kind": "args",
-    "rubyArgs": ["ref:tableName"],
+    "rubyArgs": [
+      "ref:tableName"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -93,7 +115,9 @@
     "rubyName": "change_column_null",
     "call": "alter_table",
     "kind": "args",
-    "rubyArgs": ["ref:tableName"],
+    "rubyArgs": [
+      "ref:tableName"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -116,7 +140,11 @@
     "rubyName": "check_constraints",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:tableName", "ref:expression", "kwargs{name=ref:name}"],
+    "rubyArgs": [
+      "ref:tableName",
+      "ref:expression",
+      "kwargs{name=ref:name}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -229,7 +257,9 @@
     "rubyName": "get_database_version",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:queryValue"],
+    "rubyArgs": [
+      "ref:queryValue"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -252,7 +282,9 @@
     "rubyName": "initialize",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["kwargs{connectionPool=ref:pool}"],
+    "rubyArgs": [
+      "kwargs{connectionPool=ref:pool}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -302,7 +334,9 @@
     "rubyName": "remove_column",
     "call": "alter_table",
     "kind": "args",
-    "rubyArgs": ["ref:tableName"],
+    "rubyArgs": [
+      "ref:tableName"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -311,7 +345,9 @@
     "rubyName": "remove_columns",
     "call": "alter_table",
     "kind": "args",
-    "rubyArgs": ["ref:tableName"],
+    "rubyArgs": [
+      "ref:tableName"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -397,7 +433,10 @@
     "rubyName": "translate_exception",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:exception", "kwargs{connectionPool=ref:pool}"],
+    "rubyArgs": [
+      "ref:exception",
+      "kwargs{connectionPool=ref:pool}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -406,7 +445,10 @@
     "rubyName": "translate_exception",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:message", "kwargs{binds=ref:binds,connectionPool=ref:pool,sql=ref:sql}"],
+    "rubyArgs": [
+      "ref:message",
+      "kwargs{binds=ref:binds,connectionPool=ref:pool,sql=ref:sql}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/sqlite3/explain-pretty-printer.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/sqlite3/explain-pretty-printer.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/sqlite3/explain-pretty-printer.ts",
+    "rubyName": "pp",
+    "call": "join",
+    "kind": "args",
+    "rubyArgs": ["str:<n>"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/sqlite3/explain-pretty-printer.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/sqlite3/explain-pretty-printer.json
@@ -5,7 +5,9 @@
     "rubyName": "pp",
     "call": "join",
     "kind": "args",
-    "rubyArgs": ["str:<n>"],
+    "rubyArgs": [
+      "str:<n>"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/sqlite3/schema-dumper.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/sqlite3/schema-dumper.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/sqlite3/schema-dumper.ts",
+    "rubyName": "virtual_tables",
+    "call": "virtual_tables",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-handling.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-handling.json
@@ -74,7 +74,10 @@
     "rubyName": "remove_connection",
     "call": "remove_connection_pool",
     "kind": "args",
-    "rubyArgs": ["ref:name", "kwargs{role=ref:currentRole,shard=ref:currentShard}"],
+    "rubyArgs": [
+      "ref:name",
+      "kwargs{role=ref:currentRole,shard=ref:currentShard}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -83,7 +86,10 @@
     "rubyName": "remove_connection",
     "call": "retrieve_connection_pool",
     "kind": "args",
-    "rubyArgs": ["ref:name", "kwargs{role=ref:currentRole,shard=ref:currentShard}"],
+    "rubyArgs": [
+      "ref:name",
+      "kwargs{role=ref:currentRole,shard=ref:currentShard}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-handling.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-handling.json
@@ -2,6 +2,15 @@
   {
     "package": "activerecord",
     "tsFile": "connection-handling.ts",
+    "rubyName": "clear_query_caches_for_current_thread",
+    "call": "each_connection_pool",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-handling.ts",
     "rubyName": "connected_to",
     "call": "connection_class?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -16,6 +25,29 @@
   {
     "package": "activerecord",
     "tsFile": "connection-handling.ts",
+    "rubyName": "connected_to_many",
+    "call": "append_to_connected_to_stack",
+    "kind": "args",
+    "rubyArgs": [
+      "kwargs{klasses=ref:classes,preventWrites=ref:preventWrites,role=ref:role,shard=ref:shard}"
+    ],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-handling.ts",
+    "rubyName": "connection_pool",
+    "call": "retrieve_connection_pool",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:connectionSpecificationName",
+      "kwargs{role=ref:currentRole,shard=ref:currentShard,strict=bool:true}"
+    ],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-handling.ts",
     "rubyName": "connects_to",
     "call": "first",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -24,8 +56,47 @@
     "package": "activerecord",
     "tsFile": "connection-handling.ts",
     "rubyName": "establish_connection",
+    "call": "call",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-handling.ts",
+    "rubyName": "establish_connection",
     "call": "connection_handler",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-handling.ts",
+    "rubyName": "remove_connection",
+    "call": "remove_connection_pool",
+    "kind": "args",
+    "rubyArgs": ["ref:name", "kwargs{role=ref:currentRole,shard=ref:currentShard}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-handling.ts",
+    "rubyName": "remove_connection",
+    "call": "retrieve_connection_pool",
+    "kind": "args",
+    "rubyArgs": ["ref:name", "kwargs{role=ref:currentRole,shard=ref:currentShard}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-handling.ts",
+    "rubyName": "retrieve_connection",
+    "call": "retrieve_connection",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:connectionSpecificationName",
+      "kwargs{role=ref:currentRole,shard=ref:currentShard}"
+    ],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/core.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/core.json
@@ -12,7 +12,10 @@
     "rubyName": "arel_table",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:tableName", "kwargs{klass=ref:this}"],
+    "rubyArgs": [
+      "ref:tableName",
+      "kwargs{klass=ref:this}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -142,7 +145,10 @@
     "rubyName": "predicate_builder",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:this", "ref:arelTable"],
+    "rubyArgs": [
+      "ref:this",
+      "ref:arelTable"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -165,7 +171,10 @@
     "rubyName": "strict_loading_violation!",
     "call": "instrument",
     "kind": "args",
-    "rubyArgs": ["ref:name", "kwargs{owner=ref:owner,reflection=ref:reflection}"],
+    "rubyArgs": [
+      "ref:name",
+      "kwargs{owner=ref:owner,reflection=ref:reflection}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/core.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/core.json
@@ -9,6 +9,15 @@
   {
     "package": "activerecord",
     "tsFile": "core.ts",
+    "rubyName": "arel_table",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:tableName", "kwargs{klass=ref:this}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "core.ts",
     "rubyName": "cached_find_by_statement",
     "call": "create",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -54,6 +63,15 @@
     "rubyName": "custom_inspect_method_defined?",
     "call": "owner",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "core.ts",
+    "rubyName": "destroy_association_async_job",
+    "call": "constantize",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -121,6 +139,15 @@
   {
     "package": "activerecord",
     "tsFile": "core.ts",
+    "rubyName": "predicate_builder",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:this", "ref:arelTable"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "core.ts",
     "rubyName": "preventing_writes?",
     "call": "any?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -131,6 +158,15 @@
     "rubyName": "preventing_writes?",
     "call": "include?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "core.ts",
+    "rubyName": "strict_loading_violation!",
+    "call": "instrument",
+    "kind": "args",
+    "rubyArgs": ["ref:name", "kwargs{owner=ref:owner,reflection=ref:reflection}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/counter-cache.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/counter-cache.json
@@ -2,6 +2,24 @@
   {
     "package": "activerecord",
     "tsFile": "counter-cache.ts",
+    "rubyName": "_create_record",
+    "call": "counter_cached_association_names",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "counter-cache.ts",
+    "rubyName": "destroy_row",
+    "call": "counter_cached_association_names",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "counter-cache.ts",
     "rubyName": "reset_counters",
     "call": "count",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -26,6 +44,15 @@
     "rubyName": "update_counters",
     "call": "primary_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "counter-cache.ts",
+    "rubyName": "update_counters",
+    "call": "update_counters",
+    "kind": "args",
+    "rubyArgs": ["ref:counters"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/counter-cache.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/counter-cache.json
@@ -51,7 +51,9 @@
     "rubyName": "update_counters",
     "call": "update_counters",
     "kind": "args",
-    "rubyArgs": ["ref:counters"],
+    "rubyArgs": [
+      "ref:counters"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/database-configurations.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/database-configurations.json
@@ -19,7 +19,9 @@
     "rubyName": "build_configuration_sentence",
     "call": "join",
     "kind": "args",
-    "rubyArgs": ["str:<n>"],
+    "rubyArgs": [
+      "str:<n>"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/database-configurations.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/database-configurations.json
@@ -16,6 +16,15 @@
   {
     "package": "activerecord",
     "tsFile": "database-configurations.ts",
+    "rubyName": "build_configuration_sentence",
+    "call": "join",
+    "kind": "args",
+    "rubyArgs": ["str:<n>"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "database-configurations.ts",
     "rubyName": "build_db_config_from_string",
     "call": "parse",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/database-configurations/database-config.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/database-configurations/database-config.json
@@ -12,7 +12,9 @@
     "rubyName": "new_connection",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:configurationHash"],
+    "rubyArgs": [
+      "ref:configurationHash"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/database-configurations/database-config.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/database-configurations/database-config.json
@@ -5,5 +5,14 @@
     "rubyName": "adapter_class",
     "call": "resolve",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "database-configurations/database-config.ts",
+    "rubyName": "new_connection",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:configurationHash"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/database-configurations/url-config.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/database-configurations/url-config.json
@@ -3,6 +3,15 @@
     "package": "activerecord",
     "tsFile": "database-configurations/url-config.ts",
     "rubyName": "initialize",
+    "call": "build_url_hash",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "database-configurations/url-config.ts",
+    "rubyName": "initialize",
     "call": "merge",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/cipher.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/cipher.json
@@ -1,0 +1,20 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/cipher.ts",
+    "rubyName": "decrypt",
+    "call": "try_to_decrypt_with_each",
+    "kind": "args",
+    "rubyArgs": ["ref:encryptedMessage", "kwargs{keys=ref:Array}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/cipher.ts",
+    "rubyName": "encrypt",
+    "call": "encrypt",
+    "kind": "args",
+    "rubyArgs": ["ref:cleanText"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/cipher.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/cipher.json
@@ -5,7 +5,10 @@
     "rubyName": "decrypt",
     "call": "try_to_decrypt_with_each",
     "kind": "args",
-    "rubyArgs": ["ref:encryptedMessage", "kwargs{keys=ref:Array}"],
+    "rubyArgs": [
+      "ref:encryptedMessage",
+      "kwargs{keys=ref:Array}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -14,7 +17,9 @@
     "rubyName": "encrypt",
     "call": "encrypt",
     "kind": "args",
-    "rubyArgs": ["ref:cleanText"],
+    "rubyArgs": [
+      "ref:cleanText"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/cipher/aes256-gcm.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/cipher/aes256-gcm.json
@@ -2,9 +2,45 @@
   {
     "package": "activerecord",
     "tsFile": "encryption/cipher/aes256-gcm.ts",
+    "rubyName": "decrypt",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["const:CIPHER_TYPE"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/cipher/aes256-gcm.ts",
+    "rubyName": "encrypt",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["const:CIPHER_TYPE"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/cipher/aes256-gcm.ts",
+    "rubyName": "encrypt",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["kwargs{payload=ref:encryptedData}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/cipher/aes256-gcm.ts",
     "rubyName": "encrypt",
     "call": "order:generateIv,constructor",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/cipher/aes256-gcm.ts",
+    "rubyName": "generate_deterministic_iv",
+    "call": "digest",
+    "kind": "args",
+    "rubyArgs": ["ref:constructor", "ref:secret", "ref:clearText"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/cipher/aes256-gcm.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/cipher/aes256-gcm.json
@@ -5,7 +5,9 @@
     "rubyName": "decrypt",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["const:CIPHER_TYPE"],
+    "rubyArgs": [
+      "const:CIPHER_TYPE"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -14,7 +16,9 @@
     "rubyName": "encrypt",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["const:CIPHER_TYPE"],
+    "rubyArgs": [
+      "const:CIPHER_TYPE"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -23,7 +27,9 @@
     "rubyName": "encrypt",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["kwargs{payload=ref:encryptedData}"],
+    "rubyArgs": [
+      "kwargs{payload=ref:encryptedData}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -39,7 +45,11 @@
     "rubyName": "generate_deterministic_iv",
     "call": "digest",
     "kind": "args",
-    "rubyArgs": ["ref:constructor", "ref:secret", "ref:clearText"],
+    "rubyArgs": [
+      "ref:constructor",
+      "ref:secret",
+      "ref:clearText"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/config.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/config.json
@@ -5,7 +5,9 @@
     "rubyName": "support_sha1_for_non_deterministic_encryption=",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["kwargs{hashDigestClass=const:SHA1}"],
+    "rubyArgs": [
+      "kwargs{hashDigestClass=const:SHA1}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/config.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/config.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/config.ts",
+    "rubyName": "support_sha1_for_non_deterministic_encryption=",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["kwargs{hashDigestClass=const:SHA1}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/derived-secret-key-provider.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/derived-secret-key-provider.json
@@ -5,7 +5,10 @@
     "rubyName": "initialize",
     "call": "derive_key_from",
     "kind": "args",
-    "rubyArgs": ["ref:password", "kwargs{using=ref:keyGenerator}"],
+    "rubyArgs": [
+      "ref:password",
+      "kwargs{using=ref:keyGenerator}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/derived-secret-key-provider.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/derived-secret-key-provider.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/derived-secret-key-provider.ts",
+    "rubyName": "initialize",
+    "call": "derive_key_from",
+    "kind": "args",
+    "rubyArgs": ["ref:password", "kwargs{using=ref:keyGenerator}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/encryptable-record.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/encryptable-record.json
@@ -30,6 +30,24 @@
   {
     "package": "activerecord",
     "tsFile": "encryption/encryptable-record.ts",
+    "rubyName": "add_length_validation_for_encrypted_columns",
+    "call": "validate_column_size",
+    "kind": "args",
+    "rubyArgs": ["ref:attributeName"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/encryptable-record.ts",
+    "rubyName": "build_decrypt_attribute_assignments",
+    "call": "ciphertext_for",
+    "kind": "args",
+    "rubyArgs": ["ref:attributeName"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/encryptable-record.ts",
     "rubyName": "build_encrypt_attribute_assignments",
     "call": "encrypted_attributes",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -45,8 +63,80 @@
     "package": "activerecord",
     "tsFile": "encryption/encryptable-record.ts",
     "rubyName": "ciphertext_for",
+    "call": "encrypted_attribute?",
+    "kind": "args",
+    "rubyArgs": ["ref:attributeName"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/encryptable-record.ts",
+    "rubyName": "ciphertext_for",
     "call": "read_attribute_for_database",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/encryptable-record.ts",
+    "rubyName": "decrypt",
+    "call": "decrypt_attributes",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/encryptable-record.ts",
+    "rubyName": "decrypt",
+    "call": "has_encrypted_attributes?",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/encryptable-record.ts",
+    "rubyName": "decrypt_attributes",
+    "call": "build_decrypt_attribute_assignments",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/encryptable-record.ts",
+    "rubyName": "decrypt_attributes",
+    "call": "validate_encryption_allowed",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/encryptable-record.ts",
+    "rubyName": "deterministic_encrypted_attributes",
+    "call": "encrypted_attributes",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/encryptable-record.ts",
+    "rubyName": "encrypt",
+    "call": "encrypt_attributes",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/encryptable-record.ts",
+    "rubyName": "encrypt",
+    "call": "has_encrypted_attributes?",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -68,6 +158,42 @@
     "rubyName": "encrypt_attribute",
     "call": "order:constructor,schemeFor",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/encryptable-record.ts",
+    "rubyName": "encrypt_attribute",
+    "call": "preserve_original_encrypted",
+    "kind": "args",
+    "rubyArgs": ["ref:name"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/encryptable-record.ts",
+    "rubyName": "encrypt_attributes",
+    "call": "build_encrypt_attribute_assignments",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/encryptable-record.ts",
+    "rubyName": "encrypt_attributes",
+    "call": "validate_encryption_allowed",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/encryptable-record.ts",
+    "rubyName": "encrypted_attribute?",
+    "call": "encrypted_attributes",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -110,6 +236,15 @@
     "rubyName": "preserve_original_encrypted",
     "call": "encrypts",
     "reason": "Rails' bare `encrypts original_attribute_name` is realized via `encryptAttribute(originalName, {}, buildScheme({}))` so the original_<name> scheme reuses buildScheme's legacy-encryptor shim + defaultEncryptor fallback; the declaration still happens, just not through the public `encrypts` entry."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/encryptable-record.ts",
+    "rubyName": "preserve_original_encrypted",
+    "call": "override_accessors_to_preserve_original",
+    "kind": "args",
+    "rubyArgs": ["ref:name", "ref:originalAttributeName"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/encryptable-record.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/encryptable-record.json
@@ -33,7 +33,9 @@
     "rubyName": "add_length_validation_for_encrypted_columns",
     "call": "validate_column_size",
     "kind": "args",
-    "rubyArgs": ["ref:attributeName"],
+    "rubyArgs": [
+      "ref:attributeName"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -42,7 +44,9 @@
     "rubyName": "build_decrypt_attribute_assignments",
     "call": "ciphertext_for",
     "kind": "args",
-    "rubyArgs": ["ref:attributeName"],
+    "rubyArgs": [
+      "ref:attributeName"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -65,7 +69,9 @@
     "rubyName": "ciphertext_for",
     "call": "encrypted_attribute?",
     "kind": "args",
-    "rubyArgs": ["ref:attributeName"],
+    "rubyArgs": [
+      "ref:attributeName"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -165,7 +171,9 @@
     "rubyName": "encrypt_attribute",
     "call": "preserve_original_encrypted",
     "kind": "args",
-    "rubyArgs": ["ref:name"],
+    "rubyArgs": [
+      "ref:name"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -243,7 +251,10 @@
     "rubyName": "preserve_original_encrypted",
     "call": "override_accessors_to_preserve_original",
     "kind": "args",
-    "rubyArgs": ["ref:name", "ref:originalAttributeName"],
+    "rubyArgs": [
+      "ref:name",
+      "ref:originalAttributeName"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/encrypted-attribute-type.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/encrypted-attribute-type.json
@@ -2,6 +2,15 @@
   {
     "package": "activerecord",
     "tsFile": "encryption/encrypted-attribute-type.ts",
+    "rubyName": "build_previous_types_for",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["kwargs{previousType=bool:true,scheme=ref:scheme}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/encrypted-attribute-type.ts",
     "rubyName": "serialize_with_oldest",
     "call": "first",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/encrypted-attribute-type.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/encrypted-attribute-type.json
@@ -5,7 +5,9 @@
     "rubyName": "build_previous_types_for",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["kwargs{previousType=bool:true,scheme=ref:scheme}"],
+    "rubyArgs": [
+      "kwargs{previousType=bool:true,scheme=ref:scheme}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/encryptor.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/encryptor.json
@@ -5,5 +5,14 @@
     "rubyName": "build_encrypted_message",
     "call": "add",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/encryptor.ts",
+    "rubyName": "compress_if_worth_it",
+    "call": "compress?",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/envelope-encryption-key-provider.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/envelope-encryption-key-provider.json
@@ -10,6 +10,15 @@
     "package": "activerecord",
     "tsFile": "encryption/envelope-encryption-key-provider.ts",
     "rubyName": "decrypt_data_key",
+    "call": "decrypt",
+    "kind": "args",
+    "rubyArgs": ["ref:encryptedDataKey", "kwargs{key=ref:key}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/envelope-encryption-key-provider.ts",
+    "rubyName": "decrypt_data_key",
     "call": "decryption_keys",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/envelope-encryption-key-provider.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/envelope-encryption-key-provider.json
@@ -12,7 +12,10 @@
     "rubyName": "decrypt_data_key",
     "call": "decrypt",
     "kind": "args",
-    "rubyArgs": ["ref:encryptedDataKey", "kwargs{key=ref:key}"],
+    "rubyArgs": [
+      "ref:encryptedDataKey",
+      "kwargs{key=ref:key}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/key-generator.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/key-generator.json
@@ -2,6 +2,15 @@
   {
     "package": "activerecord",
     "tsFile": "encryption/key-generator.ts",
+    "rubyName": "derive_key_from",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:password", "kwargs{hashDigestClass=ref:hashDigestClass}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/key-generator.ts",
     "rubyName": "generate_random_hex_key",
     "call": "generate_random_key",
     "reason": "Deferred (RFC 0072 activerecord-unrouted-privates-remaining-inventory): routing `generateRandomHexKey`/`generateRandomSecret` through `generateRandomKey` sits on top of a pre-existing return-type deviation (trails returns base64, Rails returns raw bytes). That deviation has to be settled first."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/key-generator.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/key-generator.json
@@ -5,7 +5,10 @@
     "rubyName": "derive_key_from",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:password", "kwargs{hashDigestClass=ref:hashDigestClass}"],
+    "rubyArgs": [
+      "ref:password",
+      "kwargs{hashDigestClass=ref:hashDigestClass}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/key.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/key.json
@@ -12,7 +12,9 @@
     "rubyName": "derive_from",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:secret"],
+    "rubyArgs": [
+      "ref:secret"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/key.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/key.json
@@ -5,5 +5,14 @@
     "rubyName": "derive_from",
     "call": "derive_key_from",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/key.ts",
+    "rubyName": "derive_from",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:secret"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/message.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/message.json
@@ -5,7 +5,9 @@
     "rubyName": "initialize",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:headers"],
+    "rubyArgs": [
+      "ref:headers"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/message.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/message.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/message.ts",
+    "rubyName": "initialize",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:headers"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/scheme.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/scheme.json
@@ -12,7 +12,9 @@
     "rubyName": "initialize",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["kwargs{compress=ref:compress}"],
+    "rubyArgs": [
+      "kwargs{compress=ref:compress}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -21,7 +23,9 @@
     "rubyName": "initialize",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["kwargs{compressor=ref:compressor}"],
+    "rubyArgs": [
+      "kwargs{compressor=ref:compressor}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/scheme.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/scheme.json
@@ -10,6 +10,24 @@
     "package": "activerecord",
     "tsFile": "encryption/scheme.ts",
     "rubyName": "initialize",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["kwargs{compress=ref:compress}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/scheme.ts",
+    "rubyName": "initialize",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["kwargs{compressor=ref:compressor}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/scheme.ts",
+    "rubyName": "initialize",
     "call": "wrap",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/inheritance.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/inheritance.json
@@ -19,7 +19,9 @@
     "rubyName": "discriminate_class_for_record",
     "call": "using_single_table_inheritance?",
     "kind": "args",
-    "rubyArgs": ["ref:record"],
+    "rubyArgs": [
+      "ref:record"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -49,7 +51,9 @@
     "rubyName": "find_sti_class",
     "call": "sti_class_for",
     "kind": "args",
-    "rubyArgs": ["ref:typeName"],
+    "rubyArgs": [
+      "ref:typeName"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -74,7 +78,9 @@
     "rubyName": "polymorphic_class_for",
     "call": "compute_type",
     "kind": "args",
-    "rubyArgs": ["ref:name"],
+    "rubyArgs": [
+      "ref:name"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -92,7 +98,9 @@
     "rubyName": "sti_class_for",
     "call": "compute_type",
     "kind": "args",
-    "rubyArgs": ["ref:typeName"],
+    "rubyArgs": [
+      "ref:typeName"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -110,7 +118,9 @@
     "rubyName": "subclass_from_attributes",
     "call": "find_sti_class",
     "kind": "args",
-    "rubyArgs": ["ref:subclassName"],
+    "rubyArgs": [
+      "ref:subclassName"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/inheritance.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/inheritance.json
@@ -16,6 +16,15 @@
   {
     "package": "activerecord",
     "tsFile": "inheritance.ts",
+    "rubyName": "discriminate_class_for_record",
+    "call": "using_single_table_inheritance?",
+    "kind": "args",
+    "rubyArgs": ["ref:record"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "inheritance.ts",
     "rubyName": "find_sti_class",
     "call": "cast",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -38,7 +47,79 @@
     "package": "activerecord",
     "tsFile": "inheritance.ts",
     "rubyName": "find_sti_class",
+    "call": "sti_class_for",
+    "kind": "args",
+    "rubyArgs": ["ref:typeName"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "inheritance.ts",
+    "rubyName": "find_sti_class",
     "call": "type_for_attribute",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "inheritance.ts",
+    "rubyName": "finder_needs_type_condition?",
+    "call": "descends_from_active_record?",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "inheritance.ts",
+    "rubyName": "polymorphic_class_for",
+    "call": "compute_type",
+    "kind": "args",
+    "rubyArgs": ["ref:name"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "inheritance.ts",
+    "rubyName": "polymorphic_name",
+    "call": "demodulize",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "inheritance.ts",
+    "rubyName": "sti_class_for",
+    "call": "compute_type",
+    "kind": "args",
+    "rubyArgs": ["ref:typeName"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "inheritance.ts",
+    "rubyName": "sti_name",
+    "call": "demodulize",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "inheritance.ts",
+    "rubyName": "subclass_from_attributes",
+    "call": "find_sti_class",
+    "kind": "args",
+    "rubyArgs": ["ref:subclassName"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "inheritance.ts",
+    "rubyName": "type_condition",
+    "call": "descendants",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/insert-all.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/insert-all.json
@@ -44,6 +44,15 @@
   {
     "package": "activerecord",
     "tsFile": "insert-all.ts",
+    "rubyName": "initialize",
+    "call": "keys",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "insert-all.ts",
     "rubyName": "primary_keys",
     "call": "schema_cache",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -89,6 +98,15 @@
     "rubyName": "resolve_sti",
     "call": "order:inheritanceColumn,stiName",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "insert-all.ts",
+    "rubyName": "resolve_sti",
+    "call": "sti_name",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/internal-metadata.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/internal-metadata.json
@@ -1,0 +1,20 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "internal-metadata.ts",
+    "rubyName": "delete_all_entries",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:arelTable"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "internal-metadata.ts",
+    "rubyName": "update_entry",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:arelTable"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/internal-metadata.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/internal-metadata.json
@@ -5,7 +5,9 @@
     "rubyName": "delete_all_entries",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:arelTable"],
+    "rubyArgs": [
+      "ref:arelTable"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -14,7 +16,9 @@
     "rubyName": "update_entry",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:arelTable"],
+    "rubyArgs": [
+      "ref:arelTable"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/locking/pessimistic.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/locking/pessimistic.json
@@ -5,5 +5,14 @@
     "rubyName": "lock!",
     "call": "has_changes_to_save?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "locking/pessimistic.ts",
+    "rubyName": "lock!",
+    "call": "reload",
+    "kind": "args",
+    "rubyArgs": ["kwargs{lock=ref:lock}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/locking/pessimistic.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/locking/pessimistic.json
@@ -12,7 +12,9 @@
     "rubyName": "lock!",
     "call": "reload",
     "kind": "args",
-    "rubyArgs": ["kwargs{lock=ref:lock}"],
+    "rubyArgs": [
+      "kwargs{lock=ref:lock}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/middleware/database-selector/resolver.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/middleware/database-selector/resolver.json
@@ -14,7 +14,9 @@
     "rubyName": "read_from_primary",
     "call": "connected_to",
     "kind": "args",
-    "rubyArgs": ["kwargs{preventWrites=bool:true,role=ref:writingRole}"],
+    "rubyArgs": [
+      "kwargs{preventWrites=bool:true,role=ref:writingRole}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -30,7 +32,9 @@
     "rubyName": "read_from_replica",
     "call": "connected_to",
     "kind": "args",
-    "rubyArgs": ["kwargs{preventWrites=bool:true,role=ref:readingRole}"],
+    "rubyArgs": [
+      "kwargs{preventWrites=bool:true,role=ref:readingRole}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -46,7 +50,9 @@
     "rubyName": "write_to_primary",
     "call": "connected_to",
     "kind": "args",
-    "rubyArgs": ["kwargs{preventWrites=bool:false,role=ref:writingRole}"],
+    "rubyArgs": [
+      "kwargs{preventWrites=bool:false,role=ref:writingRole}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/middleware/database-selector/resolver.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/middleware/database-selector/resolver.json
@@ -2,6 +2,24 @@
   {
     "package": "activerecord",
     "tsFile": "middleware/database-selector/resolver.ts",
+    "rubyName": "read",
+    "call": "read_from_primary?",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "middleware/database-selector/resolver.ts",
+    "rubyName": "read_from_primary",
+    "call": "connected_to",
+    "kind": "args",
+    "rubyArgs": ["kwargs{preventWrites=bool:true,role=ref:writingRole}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "middleware/database-selector/resolver.ts",
     "rubyName": "read_from_primary",
     "call": "instrument",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -10,8 +28,26 @@
     "package": "activerecord",
     "tsFile": "middleware/database-selector/resolver.ts",
     "rubyName": "read_from_replica",
+    "call": "connected_to",
+    "kind": "args",
+    "rubyArgs": ["kwargs{preventWrites=bool:true,role=ref:readingRole}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "middleware/database-selector/resolver.ts",
+    "rubyName": "read_from_replica",
     "call": "instrument",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "middleware/database-selector/resolver.ts",
+    "rubyName": "write_to_primary",
+    "call": "connected_to",
+    "kind": "args",
+    "rubyArgs": ["kwargs{preventWrites=bool:false,role=ref:writingRole}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/middleware/shard-selector.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/middleware/shard-selector.json
@@ -9,6 +9,24 @@
   {
     "package": "activerecord",
     "tsFile": "middleware/shard-selector.ts",
+    "rubyName": "selected_shard",
+    "call": "resolver",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "middleware/shard-selector.ts",
+    "rubyName": "set_shard",
+    "call": "connected_to",
+    "kind": "args",
+    "rubyArgs": ["kwargs{shard=ref:toSym}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "middleware/shard-selector.ts",
     "rubyName": "set_shard",
     "call": "fetch",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/middleware/shard-selector.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/middleware/shard-selector.json
@@ -21,7 +21,9 @@
     "rubyName": "set_shard",
     "call": "connected_to",
     "kind": "args",
-    "rubyArgs": ["kwargs{shard=ref:toSym}"],
+    "rubyArgs": [
+      "kwargs{shard=ref:toSym}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/migration.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/migration.json
@@ -30,9 +30,36 @@
   {
     "package": "activerecord",
     "tsFile": "migration.ts",
+    "rubyName": "check_all_pending!",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["kwargs{pendingMigrations=ref:migrations}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "migration.ts",
+    "rubyName": "check_pending_migrations",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["kwargs{pendingMigrations=ref:migrations}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "migration.ts",
     "rubyName": "copy",
     "call": "call",
     "reason": "Ruby's `options[:on_skip].call(scope, migration)` is a Proc invocation; TS calls the callback directly as `options.onSkip(scope, source)`, which has no `.call` token."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "migration.ts",
+    "rubyName": "copy",
+    "call": "underscore",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -110,6 +137,24 @@
     "rubyName": "validate",
     "call": "find",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "migration.ts",
+    "rubyName": "validate",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:name"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "migration.ts",
+    "rubyName": "with_advisory_lock",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["const:RELEASE_LOCK_FAILED_MESSAGE"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/migration.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/migration.json
@@ -33,7 +33,9 @@
     "rubyName": "check_all_pending!",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["kwargs{pendingMigrations=ref:migrations}"],
+    "rubyArgs": [
+      "kwargs{pendingMigrations=ref:migrations}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -42,7 +44,9 @@
     "rubyName": "check_pending_migrations",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["kwargs{pendingMigrations=ref:migrations}"],
+    "rubyArgs": [
+      "kwargs{pendingMigrations=ref:migrations}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -144,7 +148,9 @@
     "rubyName": "validate",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:name"],
+    "rubyArgs": [
+      "ref:name"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -153,7 +159,9 @@
     "rubyName": "with_advisory_lock",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["const:RELEASE_LOCK_FAILED_MESSAGE"],
+    "rubyArgs": [
+      "const:RELEASE_LOCK_FAILED_MESSAGE"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/migration/command-recorder.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/migration/command-recorder.json
@@ -12,7 +12,9 @@
     "rubyName": "change_table",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:delegate"],
+    "rubyArgs": [
+      "ref:delegate"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -35,7 +37,9 @@
     "rubyName": "invert_transaction",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:delegate"],
+    "rubyArgs": [
+      "ref:delegate"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/migration/command-recorder.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/migration/command-recorder.json
@@ -9,6 +9,15 @@
   {
     "package": "activerecord",
     "tsFile": "migration/command-recorder.ts",
+    "rubyName": "change_table",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:delegate"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "migration/command-recorder.ts",
     "rubyName": "invert_add_foreign_key",
     "call": "delete",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -19,6 +28,15 @@
     "rubyName": "invert_create_table",
     "call": "delete",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "migration/command-recorder.ts",
+    "rubyName": "invert_transaction",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:delegate"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/migration/pending-migration-connection.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/migration/pending-migration-connection.json
@@ -5,7 +5,10 @@
     "rubyName": "with_temporary_pool",
     "call": "establish_connection",
     "kind": "args",
-    "rubyArgs": ["ref:dbConfig", "kwargs{ownerName=ref:this}"],
+    "rubyArgs": [
+      "ref:dbConfig",
+      "kwargs{ownerName=ref:this}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/migration/pending-migration-connection.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/migration/pending-migration-connection.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "migration/pending-migration-connection.ts",
+    "rubyName": "with_temporary_pool",
+    "call": "establish_connection",
+    "kind": "args",
+    "rubyArgs": ["ref:dbConfig", "kwargs{ownerName=ref:this}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/model-schema.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/model-schema.json
@@ -16,6 +16,33 @@
   {
     "package": "activerecord",
     "tsFile": "model-schema.ts",
+    "rubyName": "column_names",
+    "call": "freeze",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "model-schema.ts",
+    "rubyName": "columns",
+    "call": "values",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "model-schema.ts",
+    "rubyName": "derive_join_table_name",
+    "call": "join",
+    "kind": "args",
+    "rubyArgs": ["str:\\0"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "model-schema.ts",
     "rubyName": "full_table_name_prefix",
     "call": "detect",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -82,5 +109,14 @@
     "rubyName": "table_name=",
     "call": "connected?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "model-schema.ts",
+    "rubyName": "undecorated_table_name",
+    "call": "underscore",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/model-schema.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/model-schema.json
@@ -37,7 +37,9 @@
     "rubyName": "derive_join_table_name",
     "call": "join",
     "kind": "args",
-    "rubyArgs": ["str:\\0"],
+    "rubyArgs": [
+      "str:\\0"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/nested-attributes.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/nested-attributes.json
@@ -2,6 +2,24 @@
   {
     "package": "activerecord",
     "tsFile": "nested-attributes.ts",
+    "rubyName": "accepts_nested_attributes_for",
+    "call": "define_autosave_validation_callbacks",
+    "kind": "args",
+    "rubyArgs": ["ref:reflection"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "nested-attributes.ts",
+    "rubyName": "accepts_nested_attributes_for",
+    "call": "generate_association_writer",
+    "kind": "args",
+    "rubyArgs": ["ref:associationName", "ref:type"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "nested-attributes.ts",
     "rubyName": "assign_nested_attributes_for_collection_association",
     "call": "order:isRejectNewRecord,association",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
@@ -17,6 +35,15 @@
     "package": "activerecord",
     "tsFile": "nested-attributes.ts",
     "rubyName": "assign_nested_attributes_for_collection_association",
+    "call": "reject_new_record?",
+    "kind": "args",
+    "rubyArgs": ["ref:associationName", "ref:attributes"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "nested-attributes.ts",
+    "rubyName": "assign_nested_attributes_for_collection_association",
     "call": "where",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -24,8 +51,35 @@
     "package": "activerecord",
     "tsFile": "nested-attributes.ts",
     "rubyName": "assign_nested_attributes_for_one_to_one_association",
+    "call": "call_reject_if",
+    "kind": "args",
+    "rubyArgs": ["ref:associationName", "ref:attributes"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "nested-attributes.ts",
+    "rubyName": "assign_nested_attributes_for_one_to_one_association",
     "call": "order:association,callRejectIf",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "nested-attributes.ts",
+    "rubyName": "assign_nested_attributes_for_one_to_one_association",
+    "call": "reject_new_record?",
+    "kind": "args",
+    "rubyArgs": ["ref:associationName", "ref:attributes"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "nested-attributes.ts",
+    "rubyName": "call_reject_if",
+    "call": "will_be_destroyed?",
+    "kind": "args",
+    "rubyArgs": ["ref:associationName", "ref:attributes"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -40,5 +94,32 @@
     "rubyName": "raise_nested_attributes_record_not_found!",
     "call": "klass",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "nested-attributes.ts",
+    "rubyName": "reject_new_record?",
+    "call": "call_reject_if",
+    "kind": "args",
+    "rubyArgs": ["ref:associationName", "ref:attributes"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "nested-attributes.ts",
+    "rubyName": "reject_new_record?",
+    "call": "will_be_destroyed?",
+    "kind": "args",
+    "rubyArgs": ["ref:associationName", "ref:attributes"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "nested-attributes.ts",
+    "rubyName": "will_be_destroyed?",
+    "call": "allow_destroy?",
+    "kind": "args",
+    "rubyArgs": ["ref:associationName"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/nested-attributes.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/nested-attributes.json
@@ -5,7 +5,9 @@
     "rubyName": "accepts_nested_attributes_for",
     "call": "define_autosave_validation_callbacks",
     "kind": "args",
-    "rubyArgs": ["ref:reflection"],
+    "rubyArgs": [
+      "ref:reflection"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -14,7 +16,10 @@
     "rubyName": "accepts_nested_attributes_for",
     "call": "generate_association_writer",
     "kind": "args",
-    "rubyArgs": ["ref:associationName", "ref:type"],
+    "rubyArgs": [
+      "ref:associationName",
+      "ref:type"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -37,7 +42,10 @@
     "rubyName": "assign_nested_attributes_for_collection_association",
     "call": "reject_new_record?",
     "kind": "args",
-    "rubyArgs": ["ref:associationName", "ref:attributes"],
+    "rubyArgs": [
+      "ref:associationName",
+      "ref:attributes"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -53,7 +61,10 @@
     "rubyName": "assign_nested_attributes_for_one_to_one_association",
     "call": "call_reject_if",
     "kind": "args",
-    "rubyArgs": ["ref:associationName", "ref:attributes"],
+    "rubyArgs": [
+      "ref:associationName",
+      "ref:attributes"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -69,7 +80,10 @@
     "rubyName": "assign_nested_attributes_for_one_to_one_association",
     "call": "reject_new_record?",
     "kind": "args",
-    "rubyArgs": ["ref:associationName", "ref:attributes"],
+    "rubyArgs": [
+      "ref:associationName",
+      "ref:attributes"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -78,7 +92,10 @@
     "rubyName": "call_reject_if",
     "call": "will_be_destroyed?",
     "kind": "args",
-    "rubyArgs": ["ref:associationName", "ref:attributes"],
+    "rubyArgs": [
+      "ref:associationName",
+      "ref:attributes"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -101,7 +118,10 @@
     "rubyName": "reject_new_record?",
     "call": "call_reject_if",
     "kind": "args",
-    "rubyArgs": ["ref:associationName", "ref:attributes"],
+    "rubyArgs": [
+      "ref:associationName",
+      "ref:attributes"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -110,7 +130,10 @@
     "rubyName": "reject_new_record?",
     "call": "will_be_destroyed?",
     "kind": "args",
-    "rubyArgs": ["ref:associationName", "ref:attributes"],
+    "rubyArgs": [
+      "ref:associationName",
+      "ref:attributes"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -119,7 +142,9 @@
     "rubyName": "will_be_destroyed?",
     "call": "allow_destroy?",
     "kind": "args",
-    "rubyArgs": ["ref:associationName"],
+    "rubyArgs": [
+      "ref:associationName"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/normalization.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/normalization.json
@@ -16,6 +16,15 @@
   {
     "package": "activerecord",
     "tsFile": "normalization.ts",
+    "rubyName": "normalize",
+    "call": "normalizer",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "normalization.ts",
     "rubyName": "serialize",
     "call": "order:cast,serializeCastValue",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/reflection.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/reflection.json
@@ -49,7 +49,9 @@
     "rubyName": "check_validity_of_inverse!",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:this"],
+    "rubyArgs": [
+      "ref:this"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -90,7 +92,9 @@
     "rubyName": "inverse_which_updates_counter_cache",
     "call": "reflect_on_all_associations",
     "kind": "args",
-    "rubyArgs": ["str:belongsTo"],
+    "rubyArgs": [
+      "str:belongsTo"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -108,7 +112,10 @@
     "rubyName": "join_scope",
     "call": "join_scopes",
     "kind": "args",
-    "rubyArgs": ["ref:table", "ref:predicateBuilder"],
+    "rubyArgs": [
+      "ref:table",
+      "ref:predicateBuilder"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -117,7 +124,10 @@
     "rubyName": "join_scope",
     "call": "klass_join_scope",
     "kind": "args",
-    "rubyArgs": ["ref:table", "ref:predicateBuilder"],
+    "rubyArgs": [
+      "ref:table",
+      "ref:predicateBuilder"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/reflection.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/reflection.json
@@ -30,9 +30,45 @@
   {
     "package": "activerecord",
     "tsFile": "reflection.ts",
+    "rubyName": "automatic_inverse_of",
+    "call": "demodulize",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "reflection.ts",
     "rubyName": "build_scope",
     "call": "create",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "reflection.ts",
+    "rubyName": "check_validity_of_inverse!",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:this"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "reflection.ts",
+    "rubyName": "counter_cache_column",
+    "call": "underscore",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "reflection.ts",
+    "rubyName": "derive_class_name",
+    "call": "camelize",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -51,6 +87,42 @@
   {
     "package": "activerecord",
     "tsFile": "reflection.ts",
+    "rubyName": "inverse_which_updates_counter_cache",
+    "call": "reflect_on_all_associations",
+    "kind": "args",
+    "rubyArgs": ["str:belongsTo"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "reflection.ts",
+    "rubyName": "join_scope",
+    "call": "finder_needs_type_condition?",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "reflection.ts",
+    "rubyName": "join_scope",
+    "call": "join_scopes",
+    "kind": "args",
+    "rubyArgs": ["ref:table", "ref:predicateBuilder"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "reflection.ts",
+    "rubyName": "join_scope",
+    "call": "klass_join_scope",
+    "kind": "args",
+    "rubyArgs": ["ref:table", "ref:predicateBuilder"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "reflection.ts",
     "rubyName": "join_scope",
     "call": "order:joinScopes,constructor",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
@@ -61,5 +133,23 @@
     "rubyName": "join_scope",
     "call": "with",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "reflection.ts",
+    "rubyName": "source_reflection_name",
+    "call": "singularize",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "reflection.ts",
+    "rubyName": "source_reflection_names",
+    "call": "singularize",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
@@ -19,7 +19,10 @@
     "rubyName": "annotate",
     "call": "check_if_method_has_arguments!",
     "kind": "args",
-    "rubyArgs": ["ref:__callee__", "ref:args"],
+    "rubyArgs": [
+      "ref:__callee__",
+      "ref:args"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -326,7 +329,9 @@
     "rubyName": "current_scope_restoring_block",
     "call": "current_scope",
     "kind": "args",
-    "rubyArgs": ["bool:true"],
+    "rubyArgs": [
+      "bool:true"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -384,7 +389,9 @@
     "rubyName": "distinct",
     "call": "distinct!",
     "kind": "args",
-    "rubyArgs": ["ref:value"],
+    "rubyArgs": [
+      "ref:value"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -393,7 +400,10 @@
     "rubyName": "eager_load",
     "call": "check_if_method_has_arguments!",
     "kind": "args",
-    "rubyArgs": ["ref:__callee__", "ref:args"],
+    "rubyArgs": [
+      "ref:__callee__",
+      "ref:args"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -409,7 +419,9 @@
     "rubyName": "exec_explain",
     "call": "join",
     "kind": "args",
-    "rubyArgs": ["str:<n>"],
+    "rubyArgs": [
+      "str:<n>"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -656,7 +668,9 @@
     "rubyName": "exists?",
     "call": "apply_join_dependency",
     "kind": "args",
-    "rubyArgs": ["kwargs{eagerLoading=bool:false}"],
+    "rubyArgs": [
+      "kwargs{eagerLoading=bool:false}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -736,7 +750,10 @@
     "rubyName": "group",
     "call": "check_if_method_has_arguments!",
     "kind": "args",
-    "rubyArgs": ["ref:__callee__", "ref:args"],
+    "rubyArgs": [
+      "ref:__callee__",
+      "ref:args"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -840,7 +857,10 @@
     "rubyName": "includes",
     "call": "check_if_method_has_arguments!",
     "kind": "args",
-    "rubyArgs": ["ref:__callee__", "ref:args"],
+    "rubyArgs": [
+      "ref:__callee__",
+      "ref:args"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -876,7 +896,10 @@
     "rubyName": "joins",
     "call": "check_if_method_has_arguments!",
     "kind": "args",
-    "rubyArgs": ["ref:__callee__", "ref:args"],
+    "rubyArgs": [
+      "ref:__callee__",
+      "ref:args"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -934,7 +957,10 @@
     "rubyName": "optimizer_hints",
     "call": "check_if_method_has_arguments!",
     "kind": "args",
-    "rubyArgs": ["ref:__callee__", "ref:args"],
+    "rubyArgs": [
+      "ref:__callee__",
+      "ref:args"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -943,7 +969,10 @@
     "rubyName": "order",
     "call": "check_if_method_has_arguments!",
     "kind": "args",
-    "rubyArgs": ["ref:__callee__", "ref:args"],
+    "rubyArgs": [
+      "ref:__callee__",
+      "ref:args"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -980,7 +1009,10 @@
     "rubyName": "preload",
     "call": "check_if_method_has_arguments!",
     "kind": "args",
-    "rubyArgs": ["ref:__callee__", "ref:args"],
+    "rubyArgs": [
+      "ref:__callee__",
+      "ref:args"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -1017,7 +1049,10 @@
     "rubyName": "references",
     "call": "check_if_method_has_arguments!",
     "kind": "args",
-    "rubyArgs": ["ref:__callee__", "ref:tableNames"],
+    "rubyArgs": [
+      "ref:__callee__",
+      "ref:tableNames"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -1047,7 +1082,10 @@
     "rubyName": "regroup",
     "call": "check_if_method_has_arguments!",
     "kind": "args",
-    "rubyArgs": ["ref:__callee__", "ref:args"],
+    "rubyArgs": [
+      "ref:__callee__",
+      "ref:args"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -1056,7 +1094,10 @@
     "rubyName": "reorder",
     "call": "check_if_method_has_arguments!",
     "kind": "args",
-    "rubyArgs": ["ref:__callee__", "ref:args"],
+    "rubyArgs": [
+      "ref:__callee__",
+      "ref:args"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -1065,7 +1106,10 @@
     "rubyName": "reselect",
     "call": "check_if_method_has_arguments!",
     "kind": "args",
-    "rubyArgs": ["ref:__callee__", "ref:args"],
+    "rubyArgs": [
+      "ref:__callee__",
+      "ref:args"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -1081,7 +1125,11 @@
     "rubyName": "select",
     "call": "check_if_method_has_arguments!",
     "kind": "args",
-    "rubyArgs": ["ref:__callee__", "ref:fields", "str:Call `select' with at least one field."],
+    "rubyArgs": [
+      "ref:__callee__",
+      "ref:fields",
+      "str:Call `select' with at least one field."
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -1104,7 +1152,9 @@
     "rubyName": "size",
     "call": "count",
     "kind": "args",
-    "rubyArgs": ["str:all"],
+    "rubyArgs": [
+      "str:all"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -1190,7 +1240,10 @@
     "rubyName": "unscope",
     "call": "check_if_method_has_arguments!",
     "kind": "args",
-    "rubyArgs": ["ref:__callee__", "ref:args"],
+    "rubyArgs": [
+      "ref:__callee__",
+      "ref:args"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -1199,7 +1252,10 @@
     "rubyName": "update",
     "call": "update",
     "kind": "args",
-    "rubyArgs": ["ref:id", "ref:attributes"],
+    "rubyArgs": [
+      "ref:id",
+      "ref:attributes"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -1208,7 +1264,10 @@
     "rubyName": "update!",
     "call": "update!",
     "kind": "args",
-    "rubyArgs": ["ref:id", "ref:attributes"],
+    "rubyArgs": [
+      "ref:id",
+      "ref:attributes"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -1287,7 +1346,10 @@
     "rubyName": "with",
     "call": "check_if_method_has_arguments!",
     "kind": "args",
-    "rubyArgs": ["ref:__callee__", "ref:args"],
+    "rubyArgs": [
+      "ref:__callee__",
+      "ref:args"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -1296,7 +1358,10 @@
     "rubyName": "with_recursive",
     "call": "check_if_method_has_arguments!",
     "kind": "args",
-    "rubyArgs": ["ref:__callee__", "ref:args"],
+    "rubyArgs": [
+      "ref:__callee__",
+      "ref:args"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
@@ -16,6 +16,15 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
+    "rubyName": "annotate",
+    "call": "check_if_method_has_arguments!",
+    "kind": "args",
+    "rubyArgs": ["ref:__callee__", "ref:args"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
     "rubyName": "apply_join_dependency",
     "call": "eager_load_values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -164,6 +173,24 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "cache_key_with_version",
+    "call": "cache_key",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "cache_key_with_version",
+    "call": "cache_version",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "cache_key_with_version",
     "call": "order:cacheKey,cacheVersion",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
@@ -296,6 +323,15 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
+    "rubyName": "current_scope_restoring_block",
+    "call": "current_scope",
+    "kind": "args",
+    "rubyArgs": ["bool:true"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
     "rubyName": "delete",
     "call": "order:primaryKey,where",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
@@ -345,9 +381,36 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
+    "rubyName": "distinct",
+    "call": "distinct!",
+    "kind": "args",
+    "rubyArgs": ["ref:value"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "eager_load",
+    "call": "check_if_method_has_arguments!",
+    "kind": "args",
+    "rubyArgs": ["ref:__callee__", "ref:args"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
     "rubyName": "except",
     "call": "relation_with",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "exec_explain",
+    "call": "join",
+    "kind": "args",
+    "rubyArgs": ["str:<n>"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -591,6 +654,15 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "exists?",
+    "call": "apply_join_dependency",
+    "kind": "args",
+    "rubyArgs": ["kwargs{eagerLoading=bool:false}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "exists?",
     "call": "skip_query_cache_if_necessary",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -611,6 +683,24 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
+    "rubyName": "find_by_token_for",
+    "call": "token_definitions",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "find_by_token_for!",
+    "call": "token_definitions",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
     "rubyName": "find_each",
     "call": "apply_limits",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -625,9 +715,29 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
+    "rubyName": "find_in_batches",
+    "call": "in_batches",
+    "kind": "args",
+    "rubyArgs": [
+      "kwargs{cursor=ref:cursor,errorOnIgnore=ref:errorOnIgnore,finish=ref:finish,load=bool:true,of=ref:batchSize,order=ref:order,start=ref:start}"
+    ],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
     "rubyName": "first_or_initialize",
     "call": "first",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "group",
+    "call": "check_if_method_has_arguments!",
+    "kind": "args",
+    "rubyArgs": ["ref:__callee__", "ref:args"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -663,6 +773,17 @@
     "rubyName": "in_batches",
     "call": "arel",
     "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "in_batches",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": [
+      "kwargs{cursor=ref:cursor,finish=ref:finish,of=ref:of,order=ref:order,relation=ref:this,start=ref:start,useRanges=ref:useRanges}"
+    ],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -716,6 +837,28 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
+    "rubyName": "includes",
+    "call": "check_if_method_has_arguments!",
+    "kind": "args",
+    "rubyArgs": ["ref:__callee__", "ref:args"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "insert_all!",
+    "call": "execute",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:this",
+      "ref:attributes",
+      "kwargs{onDuplicate=str:raise,recordTimestamps=ref:recordTimestamps,returning=ref:returning}"
+    ],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
     "rubyName": "instantiate_records",
     "call": "instantiate",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -726,6 +869,15 @@
     "rubyName": "instantiate_records",
     "call": "strict_loading_value",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "joins",
+    "call": "check_if_method_has_arguments!",
+    "kind": "args",
+    "rubyArgs": ["ref:__callee__", "ref:args"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -779,6 +931,24 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
+    "rubyName": "optimizer_hints",
+    "call": "check_if_method_has_arguments!",
+    "kind": "args",
+    "rubyArgs": ["ref:__callee__", "ref:args"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "order",
+    "call": "check_if_method_has_arguments!",
+    "kind": "args",
+    "rubyArgs": ["ref:__callee__", "ref:args"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
     "rubyName": "pick",
     "call": "all_attributes?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -803,6 +973,15 @@
     "rubyName": "pluck",
     "call": "with_connection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "preload",
+    "call": "check_if_method_has_arguments!",
+    "kind": "args",
+    "rubyArgs": ["ref:__callee__", "ref:args"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -835,6 +1014,15 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
+    "rubyName": "references",
+    "call": "check_if_method_has_arguments!",
+    "kind": "args",
+    "rubyArgs": ["ref:__callee__", "ref:tableNames"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
     "rubyName": "references_eager_loaded_tables?",
     "call": "build_joins",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -856,9 +1044,45 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
+    "rubyName": "regroup",
+    "call": "check_if_method_has_arguments!",
+    "kind": "args",
+    "rubyArgs": ["ref:__callee__", "ref:args"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "reorder",
+    "call": "check_if_method_has_arguments!",
+    "kind": "args",
+    "rubyArgs": ["ref:__callee__", "ref:args"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "reselect",
+    "call": "check_if_method_has_arguments!",
+    "kind": "args",
+    "rubyArgs": ["ref:__callee__", "ref:args"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
     "rubyName": "scope_for_create",
     "call": "create_with_value",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "select",
+    "call": "check_if_method_has_arguments!",
+    "kind": "args",
+    "rubyArgs": ["ref:__callee__", "ref:fields", "str:Call `select' with at least one field."],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -873,6 +1097,15 @@
     "rubyName": "select_for_count",
     "call": "with_connection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "size",
+    "call": "count",
+    "kind": "args",
+    "rubyArgs": ["str:all"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -954,6 +1187,33 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
+    "rubyName": "unscope",
+    "call": "check_if_method_has_arguments!",
+    "kind": "args",
+    "rubyArgs": ["ref:__callee__", "ref:args"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "update",
+    "call": "update",
+    "kind": "args",
+    "rubyArgs": ["ref:id", "ref:attributes"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "update!",
+    "call": "update!",
+    "kind": "args",
+    "rubyArgs": ["ref:id", "ref:attributes"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
     "rubyName": "update_all",
     "call": "arel",
     "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
@@ -1020,5 +1280,23 @@
     "rubyName": "values_for_queries",
     "call": "except",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "with",
+    "call": "check_if_method_has_arguments!",
+    "kind": "args",
+    "rubyArgs": ["ref:__callee__", "ref:args"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "with_recursive",
+    "call": "check_if_method_has_arguments!",
+    "kind": "args",
+    "rubyArgs": ["ref:__callee__", "ref:args"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/calculations.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/calculations.json
@@ -16,6 +16,15 @@
   {
     "package": "activerecord",
     "tsFile": "relation/calculations.ts",
+    "rubyName": "build_count_subquery?",
+    "call": "many?",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/calculations.ts",
     "rubyName": "execute_grouped_calculation",
     "call": "distinct!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -208,6 +217,51 @@
     "rubyName": "perform_calculation",
     "call": "any?",
     "reason": "Per-entry verified (RFC 0072 calculation cluster): Rails calculations.rb:447/453 uses `group_values.any?` / `select_values.empty?`; trails relation/calculations.ts performCalculation spells the same tests as `rel._groupColumns.length > 0` and `rel.selectValues.length === 0`, JS's spelling of `#any?`/`#empty?`. Equivalent, not an omission."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/calculations.ts",
+    "rubyName": "perform_calculation",
+    "call": "distinct_select?",
+    "kind": "args",
+    "rubyArgs": ["ref:columnName"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/calculations.ts",
+    "rubyName": "perform_calculation",
+    "call": "distinct_select?",
+    "kind": "args",
+    "rubyArgs": ["ref:selectForCount"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/calculations.ts",
+    "rubyName": "perform_calculation",
+    "call": "execute_grouped_calculation",
+    "kind": "args",
+    "rubyArgs": ["ref:operation", "ref:columnName", "ref:distinct"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/calculations.ts",
+    "rubyName": "perform_calculation",
+    "call": "execute_simple_calculation",
+    "kind": "args",
+    "rubyArgs": ["ref:operation", "ref:columnName", "ref:distinct"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/calculations.ts",
+    "rubyName": "perform_calculation",
+    "call": "select_for_count",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/calculations.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/calculations.json
@@ -224,7 +224,9 @@
     "rubyName": "perform_calculation",
     "call": "distinct_select?",
     "kind": "args",
-    "rubyArgs": ["ref:columnName"],
+    "rubyArgs": [
+      "ref:columnName"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -233,7 +235,9 @@
     "rubyName": "perform_calculation",
     "call": "distinct_select?",
     "kind": "args",
-    "rubyArgs": ["ref:selectForCount"],
+    "rubyArgs": [
+      "ref:selectForCount"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -242,7 +246,11 @@
     "rubyName": "perform_calculation",
     "call": "execute_grouped_calculation",
     "kind": "args",
-    "rubyArgs": ["ref:operation", "ref:columnName", "ref:distinct"],
+    "rubyArgs": [
+      "ref:operation",
+      "ref:columnName",
+      "ref:distinct"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -251,7 +259,11 @@
     "rubyName": "perform_calculation",
     "call": "execute_simple_calculation",
     "kind": "args",
-    "rubyArgs": ["ref:operation", "ref:columnName", "ref:distinct"],
+    "rubyArgs": [
+      "ref:operation",
+      "ref:columnName",
+      "ref:distinct"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/delegation.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/delegation.json
@@ -44,9 +44,27 @@
   {
     "package": "activerecord",
     "tsFile": "relation/delegation.ts",
+    "rubyName": "generate_relation_method",
+    "call": "generated_relation_methods",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/delegation.ts",
     "rubyName": "include_relation_methods",
     "call": "base_class?",
     "reason": "Mechanism divergence (story delegation-generated-methods-per-model-prototype-carrier): trails' per-model prototype-carrier port installs generated methods onto per-model Relation subclass prototypes (relationClassFor / GeneratedRelationMethods.includeInto) rather than replicating Rails' anonymous-module include, so the call-set differs by construction."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/delegation.ts",
+    "rubyName": "include_relation_methods",
+    "call": "generated_relation_methods",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/finder-methods.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/finder-methods.json
@@ -54,7 +54,9 @@
     "rubyName": "find_some",
     "call": "find_some_ordered",
     "kind": "args",
-    "rubyArgs": ["ref:ids"],
+    "rubyArgs": [
+      "ref:ids"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -70,7 +72,11 @@
     "rubyName": "find_some",
     "call": "raise_record_not_found_exception!",
     "kind": "args",
-    "rubyArgs": ["ref:ids", "ref:size", "ref:expectedSize"],
+    "rubyArgs": [
+      "ref:ids",
+      "ref:size",
+      "ref:expectedSize"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -86,7 +92,11 @@
     "rubyName": "find_some_ordered",
     "call": "raise_record_not_found_exception!",
     "kind": "args",
-    "rubyArgs": ["ref:ids", "ref:size", "ref:size"],
+    "rubyArgs": [
+      "ref:ids",
+      "ref:size",
+      "ref:size"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -123,7 +133,9 @@
     "rubyName": "find_with_ids",
     "call": "find_some",
     "kind": "args",
-    "rubyArgs": ["ref:ids"],
+    "rubyArgs": [
+      "ref:ids"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/finder-methods.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/finder-methods.json
@@ -52,8 +52,26 @@
     "package": "activerecord",
     "tsFile": "relation/finder-methods.ts",
     "rubyName": "find_some",
+    "call": "find_some_ordered",
+    "kind": "args",
+    "rubyArgs": ["ref:ids"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/finder-methods.ts",
+    "rubyName": "find_some",
     "call": "order:primaryKey,where",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/finder-methods.ts",
+    "rubyName": "find_some",
+    "call": "raise_record_not_found_exception!",
+    "kind": "args",
+    "rubyArgs": ["ref:ids", "ref:size", "ref:expectedSize"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -61,6 +79,15 @@
     "rubyName": "find_some_ordered",
     "call": "except",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/finder-methods.ts",
+    "rubyName": "find_some_ordered",
+    "call": "raise_record_not_found_exception!",
+    "kind": "args",
+    "rubyArgs": ["ref:ids", "ref:size", "ref:size"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -89,6 +116,15 @@
     "rubyName": "find_take_with_limit",
     "call": "take",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/finder-methods.ts",
+    "rubyName": "find_with_ids",
+    "call": "find_some",
+    "kind": "args",
+    "rubyArgs": ["ref:ids"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/predicate-builder.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/predicate-builder.json
@@ -31,6 +31,15 @@
     "package": "activerecord",
     "tsFile": "relation/predicate-builder.ts",
     "rubyName": "initialize",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:this"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/predicate-builder.ts",
+    "rubyName": "initialize",
     "call": "register_handler",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/predicate-builder.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/predicate-builder.json
@@ -33,7 +33,9 @@
     "rubyName": "initialize",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:this"],
+    "rubyArgs": [
+      "ref:this"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/predicate-builder/association-query-value.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/predicate-builder/association-query-value.json
@@ -1,0 +1,20 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "relation/predicate-builder/association-query-value.ts",
+    "rubyName": "ids",
+    "call": "polymorphic_clause?",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/predicate-builder/association-query-value.ts",
+    "rubyName": "ids",
+    "call": "select_clause?",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/predicate-builder/polymorphic-array-value.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/predicate-builder/polymorphic-array-value.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "relation/predicate-builder/polymorphic-array-value.ts",
+    "rubyName": "type_to_ids_mapping",
+    "call": "polymorphic_name",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/query-methods.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/query-methods.json
@@ -61,7 +61,10 @@
     "rubyName": "arel_column_with_table",
     "call": "resolve_arel_attribute",
     "kind": "args",
-    "rubyArgs": ["ref:tableName", "ref:columnName"],
+    "rubyArgs": [
+      "ref:tableName",
+      "ref:columnName"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -282,7 +285,9 @@
     "rubyName": "build_subquery",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:subquery"],
+    "rubyArgs": [
+      "ref:subquery"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -298,7 +303,9 @@
     "rubyName": "build_where_clause",
     "call": "build_from_hash",
     "kind": "args",
-    "rubyArgs": ["ref:opts"],
+    "rubyArgs": [
+      "ref:opts"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -358,7 +365,9 @@
     "rubyName": "build_with_join_node",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:name"],
+    "rubyArgs": [
+      "ref:name"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -402,7 +411,9 @@
     "rubyName": "excluding!",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:predicates"],
+    "rubyArgs": [
+      "ref:predicates"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -446,7 +457,10 @@
     "rubyName": "preprocess_order_args",
     "call": "disallow_raw_sql!",
     "kind": "args",
-    "rubyArgs": ["ref:flattenedArgs", "kwargs{permit=ref:columnNameWithOrderMatcher}"],
+    "rubyArgs": [
+      "ref:flattenedArgs",
+      "kwargs{permit=ref:columnNameWithOrderMatcher}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -490,7 +504,9 @@
     "rubyName": "unscope!",
     "call": "join",
     "kind": "args",
-    "rubyArgs": ["str:, :"],
+    "rubyArgs": [
+      "str:, :"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/query-methods.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/query-methods.json
@@ -59,6 +59,15 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "arel_column_with_table",
+    "call": "resolve_arel_attribute",
+    "kind": "args",
+    "rubyArgs": ["ref:tableName", "ref:columnName"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/query-methods.ts",
+    "rubyName": "arel_column_with_table",
     "call": "sql",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -152,6 +161,15 @@
     "rubyName": "build_from",
     "call": "from_clause",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/query-methods.ts",
+    "rubyName": "build_join_buckets",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -262,8 +280,26 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "build_subquery",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:subquery"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/query-methods.ts",
+    "rubyName": "build_subquery",
     "call": "optimizer_hints_values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/query-methods.ts",
+    "rubyName": "build_where_clause",
+    "call": "build_from_hash",
+    "kind": "args",
+    "rubyArgs": ["ref:opts"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -311,6 +347,24 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "build_with_join_node",
+    "call": "foreign_key",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/query-methods.ts",
+    "rubyName": "build_with_join_node",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:name"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/query-methods.ts",
+    "rubyName": "build_with_join_node",
     "call": "order:table,constructor",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
@@ -341,6 +395,15 @@
     "rubyName": "does_not_support_reverse?",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/query-methods.ts",
+    "rubyName": "excluding!",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:predicates"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -381,6 +444,15 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "preprocess_order_args",
+    "call": "disallow_raw_sql!",
+    "kind": "args",
+    "rubyArgs": ["ref:flattenedArgs", "kwargs{permit=ref:columnNameWithOrderMatcher}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/query-methods.ts",
+    "rubyName": "preprocess_order_args",
     "call": "flattened_args",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -411,5 +483,14 @@
     "rubyName": "table_name_matches?",
     "call": "quote_table_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/query-methods.ts",
+    "rubyName": "unscope!",
+    "call": "join",
+    "kind": "args",
+    "rubyArgs": ["str:, :"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/schema-dumper.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/schema-dumper.json
@@ -9,9 +9,27 @@
   {
     "package": "activerecord",
     "tsFile": "schema-dumper.ts",
+    "rubyName": "check_constraints_in_create",
+    "call": "join",
+    "kind": "args",
+    "rubyArgs": ["str:<n>"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "schema-dumper.ts",
     "rubyName": "foreign_keys",
     "call": "any?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "schema-dumper.ts",
+    "rubyName": "foreign_keys",
+    "call": "join",
+    "kind": "args",
+    "rubyArgs": ["str:<n>"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/schema-dumper.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/schema-dumper.json
@@ -12,7 +12,9 @@
     "rubyName": "check_constraints_in_create",
     "call": "join",
     "kind": "args",
-    "rubyArgs": ["str:<n>"],
+    "rubyArgs": [
+      "str:<n>"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -28,7 +30,9 @@
     "rubyName": "foreign_keys",
     "call": "join",
     "kind": "args",
-    "rubyArgs": ["str:<n>"],
+    "rubyArgs": [
+      "str:<n>"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/schema-migration.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/schema-migration.json
@@ -5,7 +5,9 @@
     "rubyName": "delete_version",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:arelTable"],
+    "rubyArgs": [
+      "ref:arelTable"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/schema-migration.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/schema-migration.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "schema-migration.ts",
+    "rubyName": "delete_version",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:arelTable"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/scoping/default.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/scoping/default.json
@@ -17,8 +17,44 @@
     "package": "activerecord",
     "tsFile": "scoping/default.ts",
     "rubyName": "build_default_scope",
+    "call": "default_scope_override",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "scoping/default.ts",
+    "rubyName": "build_default_scope",
+    "call": "evaluate_default_scope",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "scoping/default.ts",
+    "rubyName": "build_default_scope",
     "call": "owner",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "scoping/default.ts",
+    "rubyName": "evaluate_default_scope",
+    "call": "ignore_default_scope?",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "scoping/default.ts",
+    "rubyName": "ignore_default_scope?",
+    "call": "ignore_default_scope",
+    "kind": "args",
+    "rubyArgs": ["ref:baseClass"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/scoping/default.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/scoping/default.json
@@ -53,7 +53,9 @@
     "rubyName": "ignore_default_scope?",
     "call": "ignore_default_scope",
     "kind": "args",
-    "rubyArgs": ["ref:baseClass"],
+    "rubyArgs": [
+      "ref:baseClass"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/scoping/named.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/scoping/named.json
@@ -5,7 +5,10 @@
     "rubyName": "default_scoped",
     "call": "build_default_scope",
     "kind": "args",
-    "rubyArgs": ["ref:scope", "kwargs{allQueries=ref:allQueries}"],
+    "rubyArgs": [
+      "ref:scope",
+      "kwargs{allQueries=ref:allQueries}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/scoping/named.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/scoping/named.json
@@ -2,6 +2,15 @@
   {
     "package": "activerecord",
     "tsFile": "scoping/named.ts",
+    "rubyName": "default_scoped",
+    "call": "build_default_scope",
+    "kind": "args",
+    "rubyArgs": ["ref:scope", "kwargs{allQueries=ref:allQueries}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "scoping/named.ts",
     "rubyName": "scope",
     "call": "define_method",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/secure-token.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/secure-token.json
@@ -12,7 +12,9 @@
     "rubyName": "has_secure_token",
     "call": "generate_unique_secure_token",
     "kind": "args",
-    "rubyArgs": ["kwargs{length=ref:length}"],
+    "rubyArgs": [
+      "kwargs{length=ref:length}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/secure-token.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/secure-token.json
@@ -10,6 +10,15 @@
     "package": "activerecord",
     "tsFile": "secure-token.ts",
     "rubyName": "has_secure_token",
+    "call": "generate_unique_secure_token",
+    "kind": "args",
+    "rubyArgs": ["kwargs{length=ref:length}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "secure-token.ts",
+    "rubyName": "has_secure_token",
     "call": "set_callback",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/signed-id.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/signed-id.json
@@ -21,7 +21,10 @@
     "rubyName": "find_signed",
     "call": "verified",
     "kind": "args",
-    "rubyArgs": ["ref:signedId", "kwargs{purpose=ref:combineSignedIdPurposes}"],
+    "rubyArgs": [
+      "ref:signedId",
+      "kwargs{purpose=ref:combineSignedIdPurposes}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -37,7 +40,10 @@
     "rubyName": "find_signed!",
     "call": "verify",
     "kind": "args",
-    "rubyArgs": ["ref:signedId", "kwargs{purpose=ref:combineSignedIdPurposes}"],
+    "rubyArgs": [
+      "ref:signedId",
+      "kwargs{purpose=ref:combineSignedIdPurposes}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -65,7 +71,10 @@
     "rubyName": "signed_id_verifier",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:secret", "kwargs{digest=str:SHA256,serializer=const:JSON,urlSafe=bool:true}"],
+    "rubyArgs": [
+      "ref:secret",
+      "kwargs{digest=str:SHA256,serializer=const:JSON,urlSafe=bool:true}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/signed-id.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/signed-id.json
@@ -2,9 +2,27 @@
   {
     "package": "activerecord",
     "tsFile": "signed-id.ts",
+    "rubyName": "combine_signed_id_purposes",
+    "call": "underscore",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "signed-id.ts",
     "rubyName": "find_signed",
     "call": "combine_signed_id_purposes",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "signed-id.ts",
+    "rubyName": "find_signed",
+    "call": "verified",
+    "kind": "args",
+    "rubyArgs": ["ref:signedId", "kwargs{purpose=ref:combineSignedIdPurposes}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -16,8 +34,38 @@
   {
     "package": "activerecord",
     "tsFile": "signed-id.ts",
+    "rubyName": "find_signed!",
+    "call": "verify",
+    "kind": "args",
+    "rubyArgs": ["ref:signedId", "kwargs{purpose=ref:combineSignedIdPurposes}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "signed-id.ts",
     "rubyName": "signed_id",
     "call": "combine_signed_id_purposes",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "signed-id.ts",
+    "rubyName": "signed_id",
+    "call": "generate",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:id",
+      "kwargs{expiresAt=ref:expiresAt,expiresIn=ref:expiresIn,purpose=ref:combineSignedIdPurposes}"
+    ],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "signed-id.ts",
+    "rubyName": "signed_id_verifier",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:secret", "kwargs{digest=str:SHA256,serializer=const:JSON,urlSafe=bool:true}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/statement-cache.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/statement-cache.json
@@ -9,6 +9,15 @@
   {
     "package": "activerecord",
     "tsFile": "statement-cache.ts",
+    "rubyName": "create",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:queryBuilder", "ref:bindMap", "ref:model"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "statement-cache.ts",
     "rubyName": "execute",
     "call": "async_find_by_sql",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -19,5 +28,23 @@
     "rubyName": "execute",
     "call": "wrap",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "statement-cache.ts",
+    "rubyName": "partial_query",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:values"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "statement-cache.ts",
+    "rubyName": "query",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:sql"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/statement-cache.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/statement-cache.json
@@ -12,7 +12,11 @@
     "rubyName": "create",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:queryBuilder", "ref:bindMap", "ref:model"],
+    "rubyArgs": [
+      "ref:queryBuilder",
+      "ref:bindMap",
+      "ref:model"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -35,7 +39,9 @@
     "rubyName": "partial_query",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:values"],
+    "rubyArgs": [
+      "ref:values"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -44,7 +50,9 @@
     "rubyName": "query",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:sql"],
+    "rubyArgs": [
+      "ref:sql"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/store.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/store.json
@@ -2,9 +2,27 @@
   {
     "package": "activerecord",
     "tsFile": "store.ts",
+    "rubyName": "as_indifferent_hash",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "store.ts",
     "rubyName": "read",
     "call": "prepare",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "store.ts",
+    "rubyName": "read_store_attribute",
+    "call": "store_accessor_for",
+    "kind": "args",
+    "rubyArgs": ["ref:storeAttribute"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -45,6 +63,15 @@
     "package": "activerecord",
     "tsFile": "store.ts",
     "rubyName": "store_accessor",
+    "call": "read_store_attribute",
+    "kind": "args",
+    "rubyArgs": ["ref:storeAttribute", "ref:key"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "store.ts",
+    "rubyName": "store_accessor",
     "call": "saved_change_to_attribute?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -58,8 +85,35 @@
   {
     "package": "activerecord",
     "tsFile": "store.ts",
+    "rubyName": "store_accessor",
+    "call": "write_store_attribute",
+    "kind": "args",
+    "rubyArgs": ["ref:storeAttribute", "ref:key", "ref:value"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "store.ts",
     "rubyName": "stored_attributes",
     "call": "local_stored_attributes",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "store.ts",
+    "rubyName": "stored_attributes",
+    "call": "stored_attributes",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "store.ts",
+    "rubyName": "write_store_attribute",
+    "call": "store_accessor_for",
+    "kind": "args",
+    "rubyArgs": ["ref:storeAttribute"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/store.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/store.json
@@ -21,7 +21,9 @@
     "rubyName": "read_store_attribute",
     "call": "store_accessor_for",
     "kind": "args",
-    "rubyArgs": ["ref:storeAttribute"],
+    "rubyArgs": [
+      "ref:storeAttribute"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -65,7 +67,10 @@
     "rubyName": "store_accessor",
     "call": "read_store_attribute",
     "kind": "args",
-    "rubyArgs": ["ref:storeAttribute", "ref:key"],
+    "rubyArgs": [
+      "ref:storeAttribute",
+      "ref:key"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -88,7 +93,11 @@
     "rubyName": "store_accessor",
     "call": "write_store_attribute",
     "kind": "args",
-    "rubyArgs": ["ref:storeAttribute", "ref:key", "ref:value"],
+    "rubyArgs": [
+      "ref:storeAttribute",
+      "ref:key",
+      "ref:value"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -113,7 +122,9 @@
     "rubyName": "write_store_attribute",
     "call": "store_accessor_for",
     "kind": "args",
-    "rubyArgs": ["ref:storeAttribute"],
+    "rubyArgs": [
+      "ref:storeAttribute"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/table-metadata.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/table-metadata.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "table-metadata.ts",
+    "rubyName": "reflect_on_aggregation",
+    "call": "reflect_on_aggregation",
+    "kind": "args",
+    "rubyArgs": ["ref:aggregationName"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/table-metadata.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/table-metadata.json
@@ -5,7 +5,9 @@
     "rubyName": "reflect_on_aggregation",
     "call": "reflect_on_aggregation",
     "kind": "args",
-    "rubyArgs": ["ref:aggregationName"],
+    "rubyArgs": [
+      "ref:aggregationName"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/tasks/database-tasks.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/tasks/database-tasks.json
@@ -2,6 +2,42 @@
   {
     "package": "activerecord",
     "tsFile": "tasks/database-tasks.ts",
+    "rubyName": "charset",
+    "call": "charset",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "tasks/database-tasks.ts",
+    "rubyName": "charset_current",
+    "call": "configs_for",
+    "kind": "args",
+    "rubyArgs": ["kwargs{envName=ref:envName,name=ref:dbName}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "tasks/database-tasks.ts",
+    "rubyName": "check_current_protected_environment!",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["kwargs{current=ref:current,stored=ref:stored}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "tasks/database-tasks.ts",
+    "rubyName": "check_protected_environments!",
+    "call": "configs_for",
+    "kind": "args",
+    "rubyArgs": ["kwargs{envName=ref:environment}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "tasks/database-tasks.ts",
     "rubyName": "check_schema_file",
     "call": "root",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -23,6 +59,24 @@
   {
     "package": "activerecord",
     "tsFile": "tasks/database-tasks.ts",
+    "rubyName": "collation",
+    "call": "collation",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "tasks/database-tasks.ts",
+    "rubyName": "collation_current",
+    "call": "configs_for",
+    "kind": "args",
+    "rubyArgs": ["kwargs{envName=ref:envName,name=ref:dbName}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "tasks/database-tasks.ts",
     "rubyName": "configs_for",
     "call": "configurations",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -30,9 +84,36 @@
   {
     "package": "activerecord",
     "tsFile": "tasks/database-tasks.ts",
+    "rubyName": "create",
+    "call": "create",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "tasks/database-tasks.ts",
     "rubyName": "db_configs_with_versions",
     "call": "with_temporary_pool_for_each",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "tasks/database-tasks.ts",
+    "rubyName": "drop",
+    "call": "drop",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "tasks/database-tasks.ts",
+    "rubyName": "dump_schema",
+    "call": "dump",
+    "kind": "args",
+    "rubyArgs": ["ref:migrationConnectionPool", "ref:file"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -51,6 +132,24 @@
   {
     "package": "activerecord",
     "tsFile": "tasks/database-tasks.ts",
+    "rubyName": "dump_schema",
+    "call": "schema_dump_path",
+    "kind": "args",
+    "rubyArgs": ["ref:dbConfig", "ref:format"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "tasks/database-tasks.ts",
+    "rubyName": "each_current_configuration",
+    "call": "configs_for",
+    "kind": "args",
+    "rubyArgs": ["kwargs{envName=ref:env}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "tasks/database-tasks.ts",
     "rubyName": "for_each",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -61,6 +160,15 @@
     "rubyName": "for_each",
     "call": "order:env,configsFor",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "tasks/database-tasks.ts",
+    "rubyName": "initialize_database",
+    "call": "load_schema",
+    "kind": "args",
+    "rubyArgs": ["ref:dbConfig", "ref:schemaFormat", "nil"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -100,6 +208,33 @@
   {
     "package": "activerecord",
     "tsFile": "tasks/database-tasks.ts",
+    "rubyName": "migrate_all",
+    "call": "db_configs_with_versions",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "tasks/database-tasks.ts",
+    "rubyName": "migrate_all",
+    "call": "migrate",
+    "kind": "args",
+    "rubyArgs": ["kwargs{skipInitialize=bool:true}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "tasks/database-tasks.ts",
+    "rubyName": "migrate_status",
+    "call": "puts",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "tasks/database-tasks.ts",
     "rubyName": "migrate_status",
     "call": "table_exists?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -117,6 +252,33 @@
     "rubyName": "prepare_all",
     "call": "order:eachCurrentEnvironment,initializeDatabase",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "tasks/database-tasks.ts",
+    "rubyName": "purge",
+    "call": "purge",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "tasks/database-tasks.ts",
+    "rubyName": "raise_for_multi_db",
+    "call": "configs_for",
+    "kind": "args",
+    "rubyArgs": ["kwargs{envName=ref:environment}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "tasks/database-tasks.ts",
+    "rubyName": "reconstruct_from_schema",
+    "call": "with_temporary_pool",
+    "kind": "args",
+    "rubyArgs": ["ref:dbConfig", "kwargs{clobber=bool:true}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -145,5 +307,50 @@
     "rubyName": "schema_up_to_date?",
     "call": "with_temporary_pool",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "tasks/database-tasks.ts",
+    "rubyName": "structure_dump",
+    "call": "structure_dump",
+    "kind": "args",
+    "rubyArgs": ["ref:filename", "ref:flags"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "tasks/database-tasks.ts",
+    "rubyName": "structure_load",
+    "call": "structure_load",
+    "kind": "args",
+    "rubyArgs": ["ref:filename", "ref:flags"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "tasks/database-tasks.ts",
+    "rubyName": "truncate_all",
+    "call": "configs_for",
+    "kind": "args",
+    "rubyArgs": ["kwargs{envName=ref:environment}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "tasks/database-tasks.ts",
+    "rubyName": "with_temporary_pool",
+    "call": "establish_connection",
+    "kind": "args",
+    "rubyArgs": ["ref:dbConfig", "kwargs{clobber=ref:clobber}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "tasks/database-tasks.ts",
+    "rubyName": "with_temporary_pool",
+    "call": "establish_connection",
+    "kind": "args",
+    "rubyArgs": ["ref:originalDbConfig", "kwargs{clobber=ref:clobber}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/tasks/database-tasks.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/tasks/database-tasks.json
@@ -14,7 +14,9 @@
     "rubyName": "charset_current",
     "call": "configs_for",
     "kind": "args",
-    "rubyArgs": ["kwargs{envName=ref:envName,name=ref:dbName}"],
+    "rubyArgs": [
+      "kwargs{envName=ref:envName,name=ref:dbName}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -23,7 +25,9 @@
     "rubyName": "check_current_protected_environment!",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["kwargs{current=ref:current,stored=ref:stored}"],
+    "rubyArgs": [
+      "kwargs{current=ref:current,stored=ref:stored}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -32,7 +36,9 @@
     "rubyName": "check_protected_environments!",
     "call": "configs_for",
     "kind": "args",
-    "rubyArgs": ["kwargs{envName=ref:environment}"],
+    "rubyArgs": [
+      "kwargs{envName=ref:environment}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -71,7 +77,9 @@
     "rubyName": "collation_current",
     "call": "configs_for",
     "kind": "args",
-    "rubyArgs": ["kwargs{envName=ref:envName,name=ref:dbName}"],
+    "rubyArgs": [
+      "kwargs{envName=ref:envName,name=ref:dbName}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -112,7 +120,10 @@
     "rubyName": "dump_schema",
     "call": "dump",
     "kind": "args",
-    "rubyArgs": ["ref:migrationConnectionPool", "ref:file"],
+    "rubyArgs": [
+      "ref:migrationConnectionPool",
+      "ref:file"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -135,7 +146,10 @@
     "rubyName": "dump_schema",
     "call": "schema_dump_path",
     "kind": "args",
-    "rubyArgs": ["ref:dbConfig", "ref:format"],
+    "rubyArgs": [
+      "ref:dbConfig",
+      "ref:format"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -144,7 +158,9 @@
     "rubyName": "each_current_configuration",
     "call": "configs_for",
     "kind": "args",
-    "rubyArgs": ["kwargs{envName=ref:env}"],
+    "rubyArgs": [
+      "kwargs{envName=ref:env}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -167,7 +183,11 @@
     "rubyName": "initialize_database",
     "call": "load_schema",
     "kind": "args",
-    "rubyArgs": ["ref:dbConfig", "ref:schemaFormat", "nil"],
+    "rubyArgs": [
+      "ref:dbConfig",
+      "ref:schemaFormat",
+      "nil"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -220,7 +240,9 @@
     "rubyName": "migrate_all",
     "call": "migrate",
     "kind": "args",
-    "rubyArgs": ["kwargs{skipInitialize=bool:true}"],
+    "rubyArgs": [
+      "kwargs{skipInitialize=bool:true}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -268,7 +290,9 @@
     "rubyName": "raise_for_multi_db",
     "call": "configs_for",
     "kind": "args",
-    "rubyArgs": ["kwargs{envName=ref:environment}"],
+    "rubyArgs": [
+      "kwargs{envName=ref:environment}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -277,7 +301,10 @@
     "rubyName": "reconstruct_from_schema",
     "call": "with_temporary_pool",
     "kind": "args",
-    "rubyArgs": ["ref:dbConfig", "kwargs{clobber=bool:true}"],
+    "rubyArgs": [
+      "ref:dbConfig",
+      "kwargs{clobber=bool:true}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -314,7 +341,10 @@
     "rubyName": "structure_dump",
     "call": "structure_dump",
     "kind": "args",
-    "rubyArgs": ["ref:filename", "ref:flags"],
+    "rubyArgs": [
+      "ref:filename",
+      "ref:flags"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -323,7 +353,10 @@
     "rubyName": "structure_load",
     "call": "structure_load",
     "kind": "args",
-    "rubyArgs": ["ref:filename", "ref:flags"],
+    "rubyArgs": [
+      "ref:filename",
+      "ref:flags"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -332,7 +365,9 @@
     "rubyName": "truncate_all",
     "call": "configs_for",
     "kind": "args",
-    "rubyArgs": ["kwargs{envName=ref:environment}"],
+    "rubyArgs": [
+      "kwargs{envName=ref:environment}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -341,7 +376,10 @@
     "rubyName": "with_temporary_pool",
     "call": "establish_connection",
     "kind": "args",
-    "rubyArgs": ["ref:dbConfig", "kwargs{clobber=ref:clobber}"],
+    "rubyArgs": [
+      "ref:dbConfig",
+      "kwargs{clobber=ref:clobber}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -350,7 +388,10 @@
     "rubyName": "with_temporary_pool",
     "call": "establish_connection",
     "kind": "args",
-    "rubyArgs": ["ref:originalDbConfig", "kwargs{clobber=ref:clobber}"],
+    "rubyArgs": [
+      "ref:originalDbConfig",
+      "kwargs{clobber=ref:clobber}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/tasks/mysql-database-tasks.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/tasks/mysql-database-tasks.json
@@ -33,7 +33,11 @@
     "rubyName": "structure_load",
     "call": "run_cmd",
     "kind": "args",
-    "rubyArgs": ["str:mysql", "ref:args", "str:loading"],
+    "rubyArgs": [
+      "str:mysql",
+      "ref:args",
+      "str:loading"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/tasks/mysql-database-tasks.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/tasks/mysql-database-tasks.json
@@ -26,5 +26,14 @@
     "rubyName": "purge",
     "call": "recreate_database",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "tasks/mysql-database-tasks.ts",
+    "rubyName": "structure_load",
+    "call": "run_cmd",
+    "kind": "args",
+    "rubyArgs": ["str:mysql", "ref:args", "str:loading"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/testing/query-assertions.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/testing/query-assertions.json
@@ -5,7 +5,10 @@
     "rubyName": "assert_queries_count",
     "call": "subscribed",
     "kind": "args",
-    "rubyArgs": ["ref:counter", "str:sql.active_record"],
+    "rubyArgs": [
+      "ref:counter",
+      "str:sql.active_record"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -14,7 +17,10 @@
     "rubyName": "assert_queries_match",
     "call": "subscribed",
     "kind": "args",
-    "rubyArgs": ["ref:counter", "str:sql.active_record"],
+    "rubyArgs": [
+      "ref:counter",
+      "str:sql.active_record"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/testing/query-assertions.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/testing/query-assertions.json
@@ -2,6 +2,24 @@
   {
     "package": "activerecord",
     "tsFile": "testing/query-assertions.ts",
+    "rubyName": "assert_queries_count",
+    "call": "subscribed",
+    "kind": "args",
+    "rubyArgs": ["ref:counter", "str:sql.active_record"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "testing/query-assertions.ts",
+    "rubyName": "assert_queries_match",
+    "call": "subscribed",
+    "kind": "args",
+    "rubyArgs": ["ref:counter", "str:sql.active_record"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "testing/query-assertions.ts",
     "rubyName": "call",
     "call": "map",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/token-for.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/token-for.json
@@ -5,5 +5,41 @@
     "rubyName": "generate_token",
     "call": "order:payloadFor,generate",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "token-for.ts",
+    "rubyName": "generate_token_for",
+    "call": "token_definitions",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "token-for.ts",
+    "rubyName": "message_verifier",
+    "call": "generated_token_verifier",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "token-for.ts",
+    "rubyName": "payload_for",
+    "call": "as_json",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "token-for.ts",
+    "rubyName": "payload_for",
+    "call": "block",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/touch-later.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/touch-later.json
@@ -19,5 +19,14 @@
     "rubyName": "touch_later",
     "call": "add_to_transaction",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "touch-later.ts",
+    "rubyName": "touch_later",
+    "call": "reflect_on_all_associations",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/type.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/type.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "type.ts",
+    "rubyName": "current_adapter_name",
+    "call": "adapter_name_from",
+    "kind": "args",
+    "rubyArgs": ["const:Base"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/type.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/type.json
@@ -5,7 +5,9 @@
     "rubyName": "current_adapter_name",
     "call": "adapter_name_from",
     "kind": "args",
-    "rubyArgs": ["const:Base"],
+    "rubyArgs": [
+      "const:Base"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/type/hash-lookup-type-map.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/type/hash-lookup-type-map.json
@@ -2,6 +2,15 @@
   {
     "package": "activerecord",
     "tsFile": "type/hash-lookup-type-map.ts",
+    "rubyName": "alias_type",
+    "call": "register_type",
+    "kind": "args",
+    "rubyArgs": ["ref:type"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "type/hash-lookup-type-map.ts",
     "rubyName": "perform_fetch",
     "call": "call",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/type/hash-lookup-type-map.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/type/hash-lookup-type-map.json
@@ -5,7 +5,9 @@
     "rubyName": "alias_type",
     "call": "register_type",
     "kind": "args",
-    "rubyArgs": ["ref:type"],
+    "rubyArgs": [
+      "ref:type"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/type/serialized.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/type/serialized.json
@@ -2,6 +2,15 @@
   {
     "package": "activerecord",
     "tsFile": "type/serialized.ts",
+    "rubyName": "assert_valid_value",
+    "call": "assert_valid_value",
+    "kind": "args",
+    "rubyArgs": ["ref:value", "kwargs{action=str:serialize}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "type/serialized.ts",
     "rubyName": "default_value?",
     "call": "load",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/type/serialized.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/type/serialized.json
@@ -5,7 +5,10 @@
     "rubyName": "assert_valid_value",
     "call": "assert_valid_value",
     "kind": "args",
-    "rubyArgs": ["ref:value", "kwargs{action=str:serialize}"],
+    "rubyArgs": [
+      "ref:value",
+      "kwargs{action=str:serialize}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/type/type-map.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/type/type-map.json
@@ -5,7 +5,9 @@
     "rubyName": "alias_type",
     "call": "register_type",
     "kind": "args",
-    "rubyArgs": ["ref:key"],
+    "rubyArgs": [
+      "ref:key"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/type/type-map.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/type/type-map.json
@@ -2,6 +2,15 @@
   {
     "package": "activerecord",
     "tsFile": "type/type-map.ts",
+    "rubyName": "alias_type",
+    "call": "register_type",
+    "kind": "args",
+    "rubyArgs": ["ref:key"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "type/type-map.ts",
     "rubyName": "fetch",
     "call": "perform_fetch",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/validations/uniqueness.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/validations/uniqueness.json
@@ -10,8 +10,26 @@
     "package": "activerecord",
     "tsFile": "validations/uniqueness.ts",
     "rubyName": "validate_each",
+    "call": "build_relation",
+    "kind": "args",
+    "rubyArgs": ["ref:finderClass", "ref:attribute", "ref:value"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "validations/uniqueness.ts",
+    "rubyName": "validate_each",
     "call": "except",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "validations/uniqueness.ts",
+    "rubyName": "validate_each",
+    "call": "find_finder_class_for",
+    "kind": "args",
+    "rubyArgs": ["ref:record"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -26,5 +44,23 @@
     "rubyName": "validate_each",
     "call": "order:constructor,mapEnumAttribute",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "validations/uniqueness.ts",
+    "rubyName": "validate_each",
+    "call": "scope_relation",
+    "kind": "args",
+    "rubyArgs": ["ref:record", "ref:relation"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "validations/uniqueness.ts",
+    "rubyName": "validation_needed?",
+    "call": "covered_by_unique_index?",
+    "kind": "args",
+    "rubyArgs": ["ref:klass", "ref:record", "ref:attribute", "ref:scope"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/validations/uniqueness.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/validations/uniqueness.json
@@ -12,7 +12,11 @@
     "rubyName": "validate_each",
     "call": "build_relation",
     "kind": "args",
-    "rubyArgs": ["ref:finderClass", "ref:attribute", "ref:value"],
+    "rubyArgs": [
+      "ref:finderClass",
+      "ref:attribute",
+      "ref:value"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -28,7 +32,9 @@
     "rubyName": "validate_each",
     "call": "find_finder_class_for",
     "kind": "args",
-    "rubyArgs": ["ref:record"],
+    "rubyArgs": [
+      "ref:record"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -51,7 +57,10 @@
     "rubyName": "validate_each",
     "call": "scope_relation",
     "kind": "args",
-    "rubyArgs": ["ref:record", "ref:relation"],
+    "rubyArgs": [
+      "ref:record",
+      "ref:relation"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -60,7 +69,12 @@
     "rubyName": "validation_needed?",
     "call": "covered_by_unique_index?",
     "kind": "args",
-    "rubyArgs": ["ref:klass", "ref:record", "ref:attribute", "ref:scope"],
+    "rubyArgs": [
+      "ref:klass",
+      "ref:record",
+      "ref:attribute",
+      "ref:scope"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/cache.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/cache.json
@@ -2,6 +2,15 @@
   {
     "package": "activesupport",
     "tsFile": "cache.ts",
+    "rubyName": "exist?",
+    "call": "instrument",
+    "kind": "args",
+    "rubyArgs": ["str:exist?", "ref:key"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "cache.ts",
     "rubyName": "expanded_key",
     "call": "to_param",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/cache.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/cache.json
@@ -5,7 +5,10 @@
     "rubyName": "exist?",
     "call": "instrument",
     "kind": "args",
-    "rubyArgs": ["str:exist?", "ref:key"],
+    "rubyArgs": [
+      "str:exist?",
+      "ref:key"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/cache/file-store.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/cache/file-store.json
@@ -89,5 +89,23 @@
     "rubyName": "modify_value",
     "call": "order:writeEntry,constructor",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "cache/file-store.ts",
+    "rubyName": "modify_value",
+    "call": "to_i",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "cache/file-store.ts",
+    "rubyName": "modify_value",
+    "call": "write_entry",
+    "kind": "args",
+    "rubyArgs": ["ref:key", "ref:entry"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/cache/file-store.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/cache/file-store.json
@@ -105,7 +105,10 @@
     "rubyName": "modify_value",
     "call": "write_entry",
     "kind": "args",
-    "rubyArgs": ["ref:key", "ref:entry"],
+    "rubyArgs": [
+      "ref:key",
+      "ref:entry"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/cache/memory-store.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/cache/memory-store.json
@@ -51,6 +51,15 @@
   {
     "package": "activesupport",
     "tsFile": "cache/memory-store.ts",
+    "rubyName": "modify_value",
+    "call": "to_i",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "cache/memory-store.ts",
     "rubyName": "prune",
     "call": "synchronize",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/callbacks.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/callbacks.json
@@ -26,7 +26,11 @@
     "rubyName": "compiled",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:makeLambda", "ref:userConditions", "ref:chainConfig"],
+    "rubyArgs": [
+      "ref:makeLambda",
+      "ref:userConditions",
+      "ref:chainConfig"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -50,7 +54,10 @@
     "rubyName": "compiled",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:userCallback", "ref:userConditions"],
+    "rubyArgs": [
+      "ref:userCallback",
+      "ref:userConditions"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/callbacks.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/callbacks.json
@@ -23,6 +23,39 @@
   {
     "package": "activesupport",
     "tsFile": "callbacks.ts",
+    "rubyName": "compiled",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:makeLambda", "ref:userConditions", "ref:chainConfig"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "callbacks.ts",
+    "rubyName": "compiled",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:makeLambda",
+      "ref:userConditions",
+      "ref:chainConfig",
+      "ref:filter",
+      "ref:name"
+    ],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "callbacks.ts",
+    "rubyName": "compiled",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:userCallback", "ref:userConditions"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "callbacks.ts",
     "rubyName": "define_callbacks",
     "call": "descendants",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/string/output-safety.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/string/output-safety.json
@@ -9,6 +9,15 @@
   {
     "package": "activesupport",
     "tsFile": "core-ext/string/output-safety.ts",
+    "rubyName": "html_safe",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:this"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/string/output-safety.ts",
     "rubyName": "safe_concat",
     "call": "html_safe?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/string/output-safety.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/string/output-safety.json
@@ -12,7 +12,9 @@
     "rubyName": "html_safe",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:this"],
+    "rubyArgs": [
+      "ref:this"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/current-attributes.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/current-attributes.json
@@ -19,7 +19,9 @@
     "rubyName": "reset",
     "call": "run_callbacks",
     "kind": "args",
-    "rubyArgs": ["str:reset"],
+    "rubyArgs": [
+      "str:reset"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/current-attributes.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/current-attributes.json
@@ -16,6 +16,15 @@
   {
     "package": "activesupport",
     "tsFile": "current-attributes.ts",
+    "rubyName": "reset",
+    "call": "run_callbacks",
+    "kind": "args",
+    "rubyArgs": ["str:reset"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "current-attributes.ts",
     "rubyName": "set",
     "call": "with",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/encrypted-file.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/encrypted-file.json
@@ -32,7 +32,10 @@
     "rubyName": "encryptor",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:pack", "kwargs{cipher=const:CIPHER,serializer=const:Marshal}"],
+    "rubyArgs": [
+      "ref:pack",
+      "kwargs{cipher=const:CIPHER,serializer=const:Marshal}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -48,7 +51,9 @@
     "rubyName": "read",
     "call": "decrypt",
     "kind": "args",
-    "rubyArgs": ["ref:strip"],
+    "rubyArgs": [
+      "ref:strip"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -78,7 +83,9 @@
     "rubyName": "write",
     "call": "encrypt",
     "kind": "args",
-    "rubyArgs": ["ref:contents"],
+    "rubyArgs": [
+      "ref:contents"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/encrypted-file.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/encrypted-file.json
@@ -2,9 +2,54 @@
   {
     "package": "activesupport",
     "tsFile": "encrypted-file.ts",
+    "rubyName": "decrypt",
+    "call": "encryptor",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "encrypted-file.ts",
+    "rubyName": "encrypt",
+    "call": "check_key_length",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "encrypted-file.ts",
+    "rubyName": "encrypt",
+    "call": "encryptor",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "encrypted-file.ts",
+    "rubyName": "encryptor",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:pack", "kwargs{cipher=const:CIPHER,serializer=const:Marshal}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "encrypted-file.ts",
     "rubyName": "initialize",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "encrypted-file.ts",
+    "rubyName": "read",
+    "call": "decrypt",
+    "kind": "args",
+    "rubyArgs": ["ref:strip"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activesupport",
@@ -26,6 +71,24 @@
     "rubyName": "read_key_file",
     "call": "exist?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "encrypted-file.ts",
+    "rubyName": "write",
+    "call": "encrypt",
+    "kind": "args",
+    "rubyArgs": ["ref:contents"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "encrypted-file.ts",
+    "rubyName": "writing",
+    "call": "basename",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activesupport",

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/error-reporter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/error-reporter.json
@@ -5,5 +5,14 @@
     "rubyName": "report",
     "call": "merge",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "error-reporter.ts",
+    "rubyName": "unsubscribe",
+    "call": "delete_if",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/hash-utils.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/hash-utils.json
@@ -2,6 +2,15 @@
   {
     "package": "activesupport",
     "tsFile": "hash-utils.ts",
+    "rubyName": "deep_stringify_keys",
+    "call": "deep_transform_keys",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "hash-utils.ts",
     "rubyName": "stringify_keys",
     "call": "transform_keys",
     "reason": "Rails routes both key casts through `transform_keys` (keys.rb:11), the Hash primitive JS lacks: trails builds the result with an `Object.keys` loop (hash-utils.ts:145-148). Converging needs a ported `transformKeys` for plain objects to delegate to — filed as its own work, not resolvable inside the measurement fix that surfaced it."

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/hash-with-indifferent-access.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/hash-with-indifferent-access.json
@@ -5,5 +5,14 @@
     "rubyName": "replace",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "hash-with-indifferent-access.ts",
+    "rubyName": "with_indifferent_access",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:this"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/hash-with-indifferent-access.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/hash-with-indifferent-access.json
@@ -12,7 +12,9 @@
     "rubyName": "with_indifferent_access",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:this"],
+    "rubyArgs": [
+      "ref:this"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/message-pack/serializer.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/message-pack/serializer.json
@@ -2,6 +2,15 @@
   {
     "package": "activesupport",
     "tsFile": "message-pack/serializer.ts",
+    "rubyName": "load",
+    "call": "unpacker",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "message-pack/serializer.ts",
     "rubyName": "message_pack_pool",
     "call": "fetch",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/messages/metadata.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/messages/metadata.json
@@ -2,6 +2,15 @@
   {
     "package": "activesupport",
     "tsFile": "messages/metadata.ts",
+    "rubyName": "deserialize_from_json_safe_string",
+    "call": "decode",
+    "kind": "args",
+    "rubyArgs": ["ref:string", "kwargs{urlSafe=bool:false}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "messages/metadata.ts",
     "rubyName": "parse_expiry",
     "call": "iso8601",
     "reason": "Rails parses with `Time.iso8601`; trails parses the same ISO 8601 string with `Temporal.Instant.from`."
@@ -19,5 +28,14 @@
     "rubyName": "pick_expiry",
     "call": "advance",
     "reason": "Rails advances a `Time` with `Time.now.utc.advance(seconds:)`; trails' `Time` analogue is `Temporal.Instant`, whose equivalent is `add({ milliseconds })`."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "messages/metadata.ts",
+    "rubyName": "serialize_to_json_safe_string",
+    "call": "encode",
+    "kind": "args",
+    "rubyArgs": ["ref:serialize", "kwargs{urlSafe=bool:false}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/messages/metadata.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/messages/metadata.json
@@ -5,7 +5,10 @@
     "rubyName": "deserialize_from_json_safe_string",
     "call": "decode",
     "kind": "args",
-    "rubyArgs": ["ref:string", "kwargs{urlSafe=bool:false}"],
+    "rubyArgs": [
+      "ref:string",
+      "kwargs{urlSafe=bool:false}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -35,7 +38,10 @@
     "rubyName": "serialize_to_json_safe_string",
     "call": "encode",
     "kind": "args",
-    "rubyArgs": ["ref:serialize", "kwargs{urlSafe=bool:false}"],
+    "rubyArgs": [
+      "ref:serialize",
+      "kwargs{urlSafe=bool:false}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/messages/rotation-coordinator.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/messages/rotation-coordinator.json
@@ -2,6 +2,15 @@
   {
     "package": "activesupport",
     "tsFile": "messages/rotation-coordinator.ts",
+    "rubyName": "build_with_rotations",
+    "call": "uniq",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "messages/rotation-coordinator.ts",
     "rubyName": "changing_configuration!",
     "call": "any?",
     "reason": "Equivalent: `@codecs.any?` over a Hash is `this.#codecs.size > 0` on a Map, which has no `any?`."

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/notifications.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/notifications.json
@@ -5,7 +5,10 @@
     "rubyName": "instrument",
     "call": "instrument",
     "kind": "args",
-    "rubyArgs": ["ref:name", "ref:payload"],
+    "rubyArgs": [
+      "ref:name",
+      "ref:payload"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/notifications.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/notifications.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "activesupport",
+    "tsFile": "notifications.ts",
+    "rubyName": "instrument",
+    "call": "instrument",
+    "kind": "args",
+    "rubyArgs": ["ref:name", "ref:payload"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/number-helper/number-to-human-converter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/number-helper/number-to-human-converter.json
@@ -14,7 +14,9 @@
     "rubyName": "convert",
     "call": "calculate_exponent",
     "kind": "args",
-    "rubyArgs": ["ref:units"],
+    "rubyArgs": [
+      "ref:units"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -23,7 +25,10 @@
     "rubyName": "convert",
     "call": "determine_unit",
     "kind": "args",
-    "rubyArgs": ["ref:units", "ref:exponent"],
+    "rubyArgs": [
+      "ref:units",
+      "ref:exponent"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -32,7 +37,9 @@
     "rubyName": "convert",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:options"],
+    "rubyArgs": [
+      "ref:options"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/number-helper/number-to-human-converter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/number-helper/number-to-human-converter.json
@@ -1,0 +1,47 @@
+[
+  {
+    "package": "activesupport",
+    "tsFile": "number-helper/number-to-human-converter.ts",
+    "rubyName": "calculate_exponent",
+    "call": "floor",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "number-helper/number-to-human-converter.ts",
+    "rubyName": "convert",
+    "call": "calculate_exponent",
+    "kind": "args",
+    "rubyArgs": ["ref:units"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "number-helper/number-to-human-converter.ts",
+    "rubyName": "convert",
+    "call": "determine_unit",
+    "kind": "args",
+    "rubyArgs": ["ref:units", "ref:exponent"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "number-helper/number-to-human-converter.ts",
+    "rubyName": "convert",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:options"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "number-helper/number-to-human-converter.ts",
+    "rubyName": "unit_exponents",
+    "call": "keys",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/number-helper/number-to-human-size-converter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/number-helper/number-to-human-size-converter.json
@@ -10,7 +10,52 @@
     "package": "activesupport",
     "tsFile": "number-helper/number-to-human-size-converter.ts",
     "rubyName": "convert",
+    "call": "exponent",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "number-helper/number-to-human-size-converter.ts",
+    "rubyName": "convert",
     "call": "order:unit,exponent",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "number-helper/number-to-human-size-converter.ts",
+    "rubyName": "convert",
+    "call": "smaller_than_base?",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "number-helper/number-to-human-size-converter.ts",
+    "rubyName": "convert",
+    "call": "unit",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "number-helper/number-to-human-size-converter.ts",
+    "rubyName": "exponent",
+    "call": "log",
+    "kind": "args",
+    "rubyArgs": ["ref:base"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "number-helper/number-to-human-size-converter.ts",
+    "rubyName": "smaller_than_base?",
+    "call": "abs",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/number-helper/number-to-human-size-converter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/number-helper/number-to-human-size-converter.json
@@ -46,7 +46,9 @@
     "rubyName": "exponent",
     "call": "log",
     "kind": "args",
-    "rubyArgs": ["ref:base"],
+    "rubyArgs": [
+      "ref:base"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/number-helper/number-to-rounded-converter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/number-helper/number-to-rounded-converter.json
@@ -5,7 +5,10 @@
     "rubyName": "convert",
     "call": "convert",
     "kind": "args",
-    "rubyArgs": ["ref:formattedString", "ref:options"],
+    "rubyArgs": [
+      "ref:formattedString",
+      "ref:options"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -14,7 +17,9 @@
     "rubyName": "convert",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:options"],
+    "rubyArgs": [
+      "ref:options"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/number-helper/number-to-rounded-converter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/number-helper/number-to-rounded-converter.json
@@ -1,0 +1,20 @@
+[
+  {
+    "package": "activesupport",
+    "tsFile": "number-helper/number-to-rounded-converter.ts",
+    "rubyName": "convert",
+    "call": "convert",
+    "kind": "args",
+    "rubyArgs": ["ref:formattedString", "ref:options"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "number-helper/number-to-rounded-converter.ts",
+    "rubyName": "convert",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:options"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/time-with-zone.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/time-with-zone.json
@@ -77,7 +77,9 @@
     "rubyName": "strftime",
     "call": "strftime",
     "kind": "args",
-    "rubyArgs": ["ref:format"],
+    "rubyArgs": [
+      "ref:format"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -86,7 +88,9 @@
     "rubyName": "to_fs",
     "call": "strftime",
     "kind": "args",
-    "rubyArgs": ["ref:formatter"],
+    "rubyArgs": [
+      "ref:formatter"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -95,7 +99,10 @@
     "rubyName": "to_s",
     "call": "formatted_offset",
     "kind": "args",
-    "rubyArgs": ["bool:false", "str:UTC"],
+    "rubyArgs": [
+      "bool:false",
+      "str:UTC"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/time-with-zone.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/time-with-zone.json
@@ -44,6 +44,15 @@
   {
     "package": "activesupport",
     "tsFile": "time-with-zone.ts",
+    "rubyName": "dst?",
+    "call": "dst?",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-with-zone.ts",
     "rubyName": "localtime",
     "call": "getlocal",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -65,6 +74,33 @@
   {
     "package": "activesupport",
     "tsFile": "time-with-zone.ts",
+    "rubyName": "strftime",
+    "call": "strftime",
+    "kind": "args",
+    "rubyArgs": ["ref:format"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-with-zone.ts",
+    "rubyName": "to_fs",
+    "call": "strftime",
+    "kind": "args",
+    "rubyArgs": ["ref:formatter"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-with-zone.ts",
+    "rubyName": "to_s",
+    "call": "formatted_offset",
+    "kind": "args",
+    "rubyArgs": ["bool:false", "str:UTC"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-with-zone.ts",
     "rubyName": "to_s",
     "call": "strftime",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -82,5 +118,14 @@
     "rubyName": "xmlschema",
     "call": "strftime",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-with-zone.ts",
+    "rubyName": "zone",
+    "call": "abbreviation",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/values/time-zone.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/values/time-zone.json
@@ -10,8 +10,26 @@
     "package": "activesupport",
     "tsFile": "values/time-zone.ts",
     "rubyName": "iso8601",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:utc", "ref:this"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "values/time-zone.ts",
+    "rubyName": "iso8601",
     "call": "ordinal",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "values/time-zone.ts",
+    "rubyName": "local",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["nil", "ref:this", "ref:time"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activesupport",
@@ -19,6 +37,15 @@
     "rubyName": "now",
     "call": "in_time_zone",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "values/time-zone.ts",
+    "rubyName": "rfc3339",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:utc", "ref:this"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activesupport",

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/values/time-zone.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/values/time-zone.json
@@ -12,7 +12,10 @@
     "rubyName": "iso8601",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:utc", "ref:this"],
+    "rubyArgs": [
+      "ref:utc",
+      "ref:this"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -28,7 +31,11 @@
     "rubyName": "local",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["nil", "ref:this", "ref:time"],
+    "rubyArgs": [
+      "nil",
+      "ref:this",
+      "ref:time"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -44,7 +51,10 @@
     "rubyName": "rfc3339",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:utc", "ref:this"],
+    "rubyArgs": [
+      "ref:utc",
+      "ref:this"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/xml-mini.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/xml-mini.json
@@ -5,5 +5,14 @@
     "rubyName": "to_tag",
     "call": "call",
     "reason": "to_tag ports XmlMini.to_tag: Rails' Hash#delete(:type)/#merge/#call/#to_s are satisfied by different TS idioms (immutable `{ ...options }` spread instead of merge, destructured `options.type` instead of delete, direct function invocation, and String()/keyToString()) — no behavioral omission."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "xml-mini.ts",
+    "rubyName": "to_tag",
+    "call": "singularize",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/arel/nodes/binary.json
+++ b/scripts/api-compare/call-mismatches-exclude/arel/nodes/binary.json
@@ -5,7 +5,10 @@
     "rubyName": "to_cte",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:name", "ref:right"],
+    "rubyArgs": [
+      "ref:name",
+      "ref:right"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/arel/nodes/binary.json
+++ b/scripts/api-compare/call-mismatches-exclude/arel/nodes/binary.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "arel",
+    "tsFile": "nodes/binary.ts",
+    "rubyName": "to_cte",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:name", "ref:right"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/arel/nodes/casted.json
+++ b/scripts/api-compare/call-mismatches-exclude/arel/nodes/casted.json
@@ -5,7 +5,9 @@
     "rubyName": "build_quoted",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:other"],
+    "rubyArgs": [
+      "ref:other"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -14,7 +16,10 @@
     "rubyName": "build_quoted",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:other", "ref:attribute"],
+    "rubyArgs": [
+      "ref:other",
+      "ref:attribute"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/arel/nodes/casted.json
+++ b/scripts/api-compare/call-mismatches-exclude/arel/nodes/casted.json
@@ -1,0 +1,20 @@
+[
+  {
+    "package": "arel",
+    "tsFile": "nodes/casted.ts",
+    "rubyName": "build_quoted",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:other"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "arel",
+    "tsFile": "nodes/casted.ts",
+    "rubyName": "build_quoted",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:other", "ref:attribute"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/arel/select-manager.json
+++ b/scripts/api-compare/call-mismatches-exclude/arel/select-manager.json
@@ -9,6 +9,24 @@
   {
     "package": "arel",
     "tsFile": "select-manager.ts",
+    "rubyName": "initialize",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:table"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "arel",
+    "tsFile": "select-manager.ts",
+    "rubyName": "lock",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:locking"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "arel",
+    "tsFile": "select-manager.ts",
     "rubyName": "lock",
     "call": "sql",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/arel/select-manager.json
+++ b/scripts/api-compare/call-mismatches-exclude/arel/select-manager.json
@@ -12,7 +12,9 @@
     "rubyName": "initialize",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:table"],
+    "rubyArgs": [
+      "ref:table"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -21,7 +23,9 @@
     "rubyName": "lock",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:locking"],
+    "rubyArgs": [
+      "ref:locking"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/arel/update-manager.json
+++ b/scripts/api-compare/call-mismatches-exclude/arel/update-manager.json
@@ -5,7 +5,9 @@
     "rubyName": "set",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:column"],
+    "rubyArgs": [
+      "ref:column"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -14,7 +16,10 @@
     "rubyName": "set",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:constructor", "ref:value"],
+    "rubyArgs": [
+      "ref:constructor",
+      "ref:value"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/arel/update-manager.json
+++ b/scripts/api-compare/call-mismatches-exclude/arel/update-manager.json
@@ -1,0 +1,20 @@
+[
+  {
+    "package": "arel",
+    "tsFile": "update-manager.ts",
+    "rubyName": "set",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:column"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "arel",
+    "tsFile": "update-manager.ts",
+    "rubyName": "set",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:constructor", "ref:value"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/arel/visitors/sqlite.json
+++ b/scripts/api-compare/call-mismatches-exclude/arel/visitors/sqlite.json
@@ -2,6 +2,42 @@
   {
     "package": "arel",
     "tsFile": "visitors/sqlite.ts",
+    "rubyName": "infix_value_with_paren",
+    "call": "grouping_parentheses",
+    "kind": "args",
+    "rubyArgs": ["ref:left", "ref:collector", "bool:false"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "arel",
+    "tsFile": "visitors/sqlite.ts",
+    "rubyName": "infix_value_with_paren",
+    "call": "grouping_parentheses",
+    "kind": "args",
+    "rubyArgs": ["ref:right", "ref:collector", "bool:false"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "arel",
+    "tsFile": "visitors/sqlite.ts",
+    "rubyName": "infix_value_with_paren",
+    "call": "infix_value_with_paren",
+    "kind": "args",
+    "rubyArgs": ["ref:left", "ref:collector", "ref:value", "bool:true"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "arel",
+    "tsFile": "visitors/sqlite.ts",
+    "rubyName": "infix_value_with_paren",
+    "call": "infix_value_with_paren",
+    "kind": "args",
+    "rubyArgs": ["ref:right", "ref:collector", "ref:value", "bool:true"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "arel",
+    "tsFile": "visitors/sqlite.ts",
     "rubyName": "visit_Arel_Nodes_IsDistinctFrom",
     "call": "visit",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/arel/visitors/sqlite.json
+++ b/scripts/api-compare/call-mismatches-exclude/arel/visitors/sqlite.json
@@ -5,7 +5,11 @@
     "rubyName": "infix_value_with_paren",
     "call": "grouping_parentheses",
     "kind": "args",
-    "rubyArgs": ["ref:left", "ref:collector", "bool:false"],
+    "rubyArgs": [
+      "ref:left",
+      "ref:collector",
+      "bool:false"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -14,7 +18,11 @@
     "rubyName": "infix_value_with_paren",
     "call": "grouping_parentheses",
     "kind": "args",
-    "rubyArgs": ["ref:right", "ref:collector", "bool:false"],
+    "rubyArgs": [
+      "ref:right",
+      "ref:collector",
+      "bool:false"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -23,7 +31,12 @@
     "rubyName": "infix_value_with_paren",
     "call": "infix_value_with_paren",
     "kind": "args",
-    "rubyArgs": ["ref:left", "ref:collector", "ref:value", "bool:true"],
+    "rubyArgs": [
+      "ref:left",
+      "ref:collector",
+      "ref:value",
+      "bool:true"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -32,7 +45,12 @@
     "rubyName": "infix_value_with_paren",
     "call": "infix_value_with_paren",
     "kind": "args",
-    "rubyArgs": ["ref:right", "ref:collector", "ref:value", "bool:true"],
+    "rubyArgs": [
+      "ref:right",
+      "ref:collector",
+      "ref:value",
+      "bool:true"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/arel/visitors/to-sql.json
+++ b/scripts/api-compare/call-mismatches-exclude/arel/visitors/to-sql.json
@@ -2,6 +2,24 @@
   {
     "package": "arel",
     "tsFile": "visitors/to-sql.ts",
+    "rubyName": "aggregate",
+    "call": "inject_join",
+    "kind": "args",
+    "rubyArgs": ["ref:expressions", "ref:collector", "str:, "],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "arel",
+    "tsFile": "visitors/to-sql.ts",
+    "rubyName": "collect_nodes_for",
+    "call": "inject_join",
+    "kind": "args",
+    "rubyArgs": ["ref:nodes", "ref:collector", "ref:connector"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "arel",
+    "tsFile": "visitors/to-sql.ts",
     "rubyName": "collect_optimizer_hints",
     "call": "maybe_visit",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -12,6 +30,42 @@
     "rubyName": "compile",
     "call": "accept",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "arel",
+    "tsFile": "visitors/to-sql.ts",
+    "rubyName": "infix_value_with_paren",
+    "call": "grouping_parentheses",
+    "kind": "args",
+    "rubyArgs": ["ref:left", "ref:collector", "bool:false"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "arel",
+    "tsFile": "visitors/to-sql.ts",
+    "rubyName": "infix_value_with_paren",
+    "call": "grouping_parentheses",
+    "kind": "args",
+    "rubyArgs": ["ref:right", "ref:collector", "bool:false"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "arel",
+    "tsFile": "visitors/to-sql.ts",
+    "rubyName": "infix_value_with_paren",
+    "call": "infix_value_with_paren",
+    "kind": "args",
+    "rubyArgs": ["ref:left", "ref:collector", "ref:value", "bool:true"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "arel",
+    "tsFile": "visitors/to-sql.ts",
+    "rubyName": "infix_value_with_paren",
+    "call": "infix_value_with_paren",
+    "kind": "args",
+    "rubyArgs": ["ref:right", "ref:collector", "ref:value", "bool:true"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "arel",
@@ -44,9 +98,54 @@
   {
     "package": "arel",
     "tsFile": "visitors/to-sql.ts",
+    "rubyName": "visit_Arel_Nodes_Except",
+    "call": "infix_value",
+    "kind": "args",
+    "rubyArgs": ["ref:o", "ref:collector", "str: EXCEPT "],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "arel",
+    "tsFile": "visitors/to-sql.ts",
+    "rubyName": "visit_Arel_Nodes_Fragments",
+    "call": "inject_join",
+    "kind": "args",
+    "rubyArgs": ["ref:values", "ref:collector", "str: "],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "arel",
+    "tsFile": "visitors/to-sql.ts",
     "rubyName": "visit_Arel_Nodes_InsertStatement",
     "call": "maybe_visit",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "arel",
+    "tsFile": "visitors/to-sql.ts",
+    "rubyName": "visit_Arel_Nodes_Intersect",
+    "call": "infix_value",
+    "kind": "args",
+    "rubyArgs": ["ref:o", "ref:collector", "str: INTERSECT "],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "arel",
+    "tsFile": "visitors/to-sql.ts",
+    "rubyName": "visit_Arel_Nodes_JoinSource",
+    "call": "inject_join",
+    "kind": "args",
+    "rubyArgs": ["ref:right", "ref:collector", "str: "],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "arel",
+    "tsFile": "visitors/to-sql.ts",
+    "rubyName": "visit_Arel_Nodes_NamedFunction",
+    "call": "inject_join",
+    "kind": "args",
+    "rubyArgs": ["ref:expressions", "ref:collector", "str:, "],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "arel",
@@ -65,6 +164,51 @@
   {
     "package": "arel",
     "tsFile": "visitors/to-sql.ts",
+    "rubyName": "visit_Arel_Nodes_SelectCore",
+    "call": "collect_nodes_for",
+    "kind": "args",
+    "rubyArgs": ["ref:groups", "ref:collector", "str: GROUP BY "],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "arel",
+    "tsFile": "visitors/to-sql.ts",
+    "rubyName": "visit_Arel_Nodes_SelectCore",
+    "call": "collect_nodes_for",
+    "kind": "args",
+    "rubyArgs": ["ref:havings", "ref:collector", "str: HAVING ", "str: AND "],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "arel",
+    "tsFile": "visitors/to-sql.ts",
+    "rubyName": "visit_Arel_Nodes_SelectCore",
+    "call": "collect_nodes_for",
+    "kind": "args",
+    "rubyArgs": ["ref:projections", "ref:collector", "str: "],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "arel",
+    "tsFile": "visitors/to-sql.ts",
+    "rubyName": "visit_Arel_Nodes_SelectCore",
+    "call": "collect_nodes_for",
+    "kind": "args",
+    "rubyArgs": ["ref:wheres", "ref:collector", "str: WHERE ", "str: AND "],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "arel",
+    "tsFile": "visitors/to-sql.ts",
+    "rubyName": "visit_Arel_Nodes_SelectCore",
+    "call": "collect_nodes_for",
+    "kind": "args",
+    "rubyArgs": ["ref:windows", "ref:collector", "str: WINDOW "],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "arel",
+    "tsFile": "visitors/to-sql.ts",
     "rubyName": "visit_Arel_Nodes_SelectStatement",
     "call": "visit_Arel_Nodes_SelectCore",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -75,6 +219,24 @@
     "rubyName": "visit_Arel_Nodes_SelectStatement",
     "call": "visit_Arel_Nodes_SelectOptions",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "arel",
+    "tsFile": "visitors/to-sql.ts",
+    "rubyName": "visit_Arel_Nodes_Union",
+    "call": "infix_value_with_paren",
+    "kind": "args",
+    "rubyArgs": ["ref:o", "ref:collector", "str: UNION "],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "arel",
+    "tsFile": "visitors/to-sql.ts",
+    "rubyName": "visit_Arel_Nodes_UnionAll",
+    "call": "infix_value_with_paren",
+    "kind": "args",
+    "rubyArgs": ["ref:o", "ref:collector", "str: UNION ALL "],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "arel",
@@ -96,6 +258,15 @@
     "rubyName": "visit_Arel_Nodes_Window",
     "call": "collect_nodes_for",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "arel",
+    "tsFile": "visitors/to-sql.ts",
+    "rubyName": "visit_Arel_Nodes_Window",
+    "call": "inject_join",
+    "kind": "args",
+    "rubyArgs": ["ref:orders", "ref:collector", "str:, "],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "arel",

--- a/scripts/api-compare/call-mismatches-exclude/arel/visitors/to-sql.json
+++ b/scripts/api-compare/call-mismatches-exclude/arel/visitors/to-sql.json
@@ -5,7 +5,11 @@
     "rubyName": "aggregate",
     "call": "inject_join",
     "kind": "args",
-    "rubyArgs": ["ref:expressions", "ref:collector", "str:, "],
+    "rubyArgs": [
+      "ref:expressions",
+      "ref:collector",
+      "str:, "
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -14,7 +18,11 @@
     "rubyName": "collect_nodes_for",
     "call": "inject_join",
     "kind": "args",
-    "rubyArgs": ["ref:nodes", "ref:collector", "ref:connector"],
+    "rubyArgs": [
+      "ref:nodes",
+      "ref:collector",
+      "ref:connector"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -37,7 +45,11 @@
     "rubyName": "infix_value_with_paren",
     "call": "grouping_parentheses",
     "kind": "args",
-    "rubyArgs": ["ref:left", "ref:collector", "bool:false"],
+    "rubyArgs": [
+      "ref:left",
+      "ref:collector",
+      "bool:false"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -46,7 +58,11 @@
     "rubyName": "infix_value_with_paren",
     "call": "grouping_parentheses",
     "kind": "args",
-    "rubyArgs": ["ref:right", "ref:collector", "bool:false"],
+    "rubyArgs": [
+      "ref:right",
+      "ref:collector",
+      "bool:false"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -55,7 +71,12 @@
     "rubyName": "infix_value_with_paren",
     "call": "infix_value_with_paren",
     "kind": "args",
-    "rubyArgs": ["ref:left", "ref:collector", "ref:value", "bool:true"],
+    "rubyArgs": [
+      "ref:left",
+      "ref:collector",
+      "ref:value",
+      "bool:true"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -64,7 +85,12 @@
     "rubyName": "infix_value_with_paren",
     "call": "infix_value_with_paren",
     "kind": "args",
-    "rubyArgs": ["ref:right", "ref:collector", "ref:value", "bool:true"],
+    "rubyArgs": [
+      "ref:right",
+      "ref:collector",
+      "ref:value",
+      "bool:true"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -101,7 +127,11 @@
     "rubyName": "visit_Arel_Nodes_Except",
     "call": "infix_value",
     "kind": "args",
-    "rubyArgs": ["ref:o", "ref:collector", "str: EXCEPT "],
+    "rubyArgs": [
+      "ref:o",
+      "ref:collector",
+      "str: EXCEPT "
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -110,7 +140,11 @@
     "rubyName": "visit_Arel_Nodes_Fragments",
     "call": "inject_join",
     "kind": "args",
-    "rubyArgs": ["ref:values", "ref:collector", "str: "],
+    "rubyArgs": [
+      "ref:values",
+      "ref:collector",
+      "str: "
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -126,7 +160,11 @@
     "rubyName": "visit_Arel_Nodes_Intersect",
     "call": "infix_value",
     "kind": "args",
-    "rubyArgs": ["ref:o", "ref:collector", "str: INTERSECT "],
+    "rubyArgs": [
+      "ref:o",
+      "ref:collector",
+      "str: INTERSECT "
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -135,7 +173,11 @@
     "rubyName": "visit_Arel_Nodes_JoinSource",
     "call": "inject_join",
     "kind": "args",
-    "rubyArgs": ["ref:right", "ref:collector", "str: "],
+    "rubyArgs": [
+      "ref:right",
+      "ref:collector",
+      "str: "
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -144,7 +186,11 @@
     "rubyName": "visit_Arel_Nodes_NamedFunction",
     "call": "inject_join",
     "kind": "args",
-    "rubyArgs": ["ref:expressions", "ref:collector", "str:, "],
+    "rubyArgs": [
+      "ref:expressions",
+      "ref:collector",
+      "str:, "
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -167,7 +213,11 @@
     "rubyName": "visit_Arel_Nodes_SelectCore",
     "call": "collect_nodes_for",
     "kind": "args",
-    "rubyArgs": ["ref:groups", "ref:collector", "str: GROUP BY "],
+    "rubyArgs": [
+      "ref:groups",
+      "ref:collector",
+      "str: GROUP BY "
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -176,7 +226,12 @@
     "rubyName": "visit_Arel_Nodes_SelectCore",
     "call": "collect_nodes_for",
     "kind": "args",
-    "rubyArgs": ["ref:havings", "ref:collector", "str: HAVING ", "str: AND "],
+    "rubyArgs": [
+      "ref:havings",
+      "ref:collector",
+      "str: HAVING ",
+      "str: AND "
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -185,7 +240,11 @@
     "rubyName": "visit_Arel_Nodes_SelectCore",
     "call": "collect_nodes_for",
     "kind": "args",
-    "rubyArgs": ["ref:projections", "ref:collector", "str: "],
+    "rubyArgs": [
+      "ref:projections",
+      "ref:collector",
+      "str: "
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -194,7 +253,12 @@
     "rubyName": "visit_Arel_Nodes_SelectCore",
     "call": "collect_nodes_for",
     "kind": "args",
-    "rubyArgs": ["ref:wheres", "ref:collector", "str: WHERE ", "str: AND "],
+    "rubyArgs": [
+      "ref:wheres",
+      "ref:collector",
+      "str: WHERE ",
+      "str: AND "
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -203,7 +267,11 @@
     "rubyName": "visit_Arel_Nodes_SelectCore",
     "call": "collect_nodes_for",
     "kind": "args",
-    "rubyArgs": ["ref:windows", "ref:collector", "str: WINDOW "],
+    "rubyArgs": [
+      "ref:windows",
+      "ref:collector",
+      "str: WINDOW "
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -226,7 +294,11 @@
     "rubyName": "visit_Arel_Nodes_Union",
     "call": "infix_value_with_paren",
     "kind": "args",
-    "rubyArgs": ["ref:o", "ref:collector", "str: UNION "],
+    "rubyArgs": [
+      "ref:o",
+      "ref:collector",
+      "str: UNION "
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -235,7 +307,11 @@
     "rubyName": "visit_Arel_Nodes_UnionAll",
     "call": "infix_value_with_paren",
     "kind": "args",
-    "rubyArgs": ["ref:o", "ref:collector", "str: UNION ALL "],
+    "rubyArgs": [
+      "ref:o",
+      "ref:collector",
+      "str: UNION ALL "
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -265,7 +341,11 @@
     "rubyName": "visit_Arel_Nodes_Window",
     "call": "inject_join",
     "kind": "args",
-    "rubyArgs": ["ref:orders", "ref:collector", "str:, "],
+    "rubyArgs": [
+      "ref:orders",
+      "ref:collector",
+      "str:, "
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/arel/visitors/visitor.json
+++ b/scripts/api-compare/call-mismatches-exclude/arel/visitors/visitor.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "arel",
+    "tsFile": "visitors/visitor.ts",
+    "rubyName": "dispatch_cache",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/globalid/global-id.json
+++ b/scripts/api-compare/call-mismatches-exclude/globalid/global-id.json
@@ -1,0 +1,20 @@
+[
+  {
+    "package": "globalid",
+    "tsFile": "global-id.ts",
+    "rubyName": "create",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:create", "ref:options"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "globalid",
+    "tsFile": "global-id.ts",
+    "rubyName": "model_class",
+    "call": "constantize",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/globalid/global-id.json
+++ b/scripts/api-compare/call-mismatches-exclude/globalid/global-id.json
@@ -5,7 +5,10 @@
     "rubyName": "create",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:create", "ref:options"],
+    "rubyArgs": [
+      "ref:create",
+      "ref:options"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/globalid/uri/gid.json
+++ b/scripts/api-compare/call-mismatches-exclude/globalid/uri/gid.json
@@ -9,6 +9,15 @@
   {
     "package": "globalid",
     "tsFile": "uri/gid.ts",
+    "rubyName": "set_path",
+    "call": "set_model_components",
+    "kind": "args",
+    "rubyArgs": ["ref:path"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "globalid",
+    "tsFile": "uri/gid.ts",
     "rubyName": "to_s",
     "call": "query",
     "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails uri/gid.rb:104-107 reassembles from app/path/query; trails uri/gid.ts:222-224 toString returns the stored canonical `this.uri` string built at parse time — no query re-read needed."

--- a/scripts/api-compare/call-mismatches-exclude/globalid/uri/gid.json
+++ b/scripts/api-compare/call-mismatches-exclude/globalid/uri/gid.json
@@ -12,7 +12,9 @@
     "rubyName": "set_path",
     "call": "set_model_components",
     "kind": "args",
-    "rubyArgs": ["ref:path"],
+    "rubyArgs": [
+      "ref:path"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/i18n/backend/base.json
+++ b/scripts/api-compare/call-mismatches-exclude/i18n/backend/base.json
@@ -5,7 +5,10 @@
     "rubyName": "interpolate",
     "call": "interpolate",
     "kind": "args",
-    "rubyArgs": ["ref:subject", "ref:values"],
+    "rubyArgs": [
+      "ref:subject",
+      "ref:values"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -14,7 +17,10 @@
     "rubyName": "load_file",
     "call": "tr",
     "kind": "args",
-    "rubyArgs": ["str:.", "str:"],
+    "rubyArgs": [
+      "str:.",
+      "str:"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -23,7 +29,9 @@
     "rubyName": "translate",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:locale"],
+    "rubyArgs": [
+      "ref:locale"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -32,7 +40,11 @@
     "rubyName": "translate",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:locale", "ref:key", "ref:options"],
+    "rubyArgs": [
+      "ref:locale",
+      "ref:key",
+      "ref:options"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -41,7 +53,10 @@
     "rubyName": "translate",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:toSym", "ref:entry"],
+    "rubyArgs": [
+      "ref:toSym",
+      "ref:entry"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/i18n/backend/base.json
+++ b/scripts/api-compare/call-mismatches-exclude/i18n/backend/base.json
@@ -1,0 +1,56 @@
+[
+  {
+    "package": "i18n",
+    "tsFile": "backend/base.ts",
+    "rubyName": "interpolate",
+    "call": "interpolate",
+    "kind": "args",
+    "rubyArgs": ["ref:subject", "ref:values"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "i18n",
+    "tsFile": "backend/base.ts",
+    "rubyName": "load_file",
+    "call": "tr",
+    "kind": "args",
+    "rubyArgs": ["str:.", "str:"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "i18n",
+    "tsFile": "backend/base.ts",
+    "rubyName": "translate",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:locale"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "i18n",
+    "tsFile": "backend/base.ts",
+    "rubyName": "translate",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:locale", "ref:key", "ref:options"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "i18n",
+    "tsFile": "backend/base.ts",
+    "rubyName": "translate",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:toSym", "ref:entry"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "i18n",
+    "tsFile": "backend/base.ts",
+    "rubyName": "translate",
+    "call": "nil?",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/i18n/backend/flatten.json
+++ b/scripts/api-compare/call-mismatches-exclude/i18n/backend/flatten.json
@@ -14,7 +14,10 @@
     "rubyName": "flatten_translations",
     "call": "flatten_keys",
     "kind": "args",
-    "rubyArgs": ["ref:data", "ref:escape"],
+    "rubyArgs": [
+      "ref:data",
+      "ref:escape"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/i18n/backend/flatten.json
+++ b/scripts/api-compare/call-mismatches-exclude/i18n/backend/flatten.json
@@ -1,0 +1,20 @@
+[
+  {
+    "package": "i18n",
+    "tsFile": "backend/flatten.ts",
+    "rubyName": "flatten_keys",
+    "call": "to_sym",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "i18n",
+    "tsFile": "backend/flatten.ts",
+    "rubyName": "flatten_translations",
+    "call": "flatten_keys",
+    "kind": "args",
+    "rubyArgs": ["ref:data", "ref:escape"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/i18n/backend/simple.json
+++ b/scripts/api-compare/call-mismatches-exclude/i18n/backend/simple.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "i18n",
+    "tsFile": "backend/simple.ts",
+    "rubyName": "lookup",
+    "call": "to_sym",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/i18n/config.json
+++ b/scripts/api-compare/call-mismatches-exclude/i18n/config.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "i18n",
+    "tsFile": "config.ts",
+    "rubyName": "available_locales_set",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/rack/builder.json
+++ b/scripts/api-compare/call-mismatches-exclude/rack/builder.json
@@ -30,6 +30,15 @@
   {
     "package": "rack",
     "tsFile": "builder.ts",
+    "rubyName": "parse_file",
+    "call": "split",
+    "kind": "args",
+    "rubyArgs": ["str:_"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "rack",
+    "tsFile": "builder.ts",
     "rubyName": "to_app",
     "call": "fail",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/rack/builder.json
+++ b/scripts/api-compare/call-mismatches-exclude/rack/builder.json
@@ -33,7 +33,9 @@
     "rubyName": "parse_file",
     "call": "split",
     "kind": "args",
-    "rubyArgs": ["str:_"],
+    "rubyArgs": [
+      "str:_"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/rack/common-logger.json
+++ b/scripts/api-compare/call-mismatches-exclude/rack/common-logger.json
@@ -3,6 +3,15 @@
     "package": "rack",
     "tsFile": "common-logger.ts",
     "rubyName": "log",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:env"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "rack",
+    "tsFile": "common-logger.ts",
+    "rubyName": "log",
     "call": "order:extractContentLength,constructor",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }

--- a/scripts/api-compare/call-mismatches-exclude/rack/common-logger.json
+++ b/scripts/api-compare/call-mismatches-exclude/rack/common-logger.json
@@ -5,7 +5,9 @@
     "rubyName": "log",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:env"],
+    "rubyArgs": [
+      "ref:env"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/rack/deflater.json
+++ b/scripts/api-compare/call-mismatches-exclude/rack/deflater.json
@@ -12,7 +12,12 @@
     "rubyName": "should_deflate?",
     "call": "call",
     "kind": "args",
-    "rubyArgs": ["ref:env", "ref:status", "ref:headers", "ref:body"],
+    "rubyArgs": [
+      "ref:env",
+      "ref:status",
+      "ref:headers",
+      "ref:body"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/rack/deflater.json
+++ b/scripts/api-compare/call-mismatches-exclude/rack/deflater.json
@@ -5,5 +5,14 @@
     "rubyName": "call",
     "call": "select_best_encoding",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "rack",
+    "tsFile": "deflater.ts",
+    "rubyName": "should_deflate?",
+    "call": "call",
+    "kind": "args",
+    "rubyArgs": ["ref:env", "ref:status", "ref:headers", "ref:body"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/rack/directory.json
+++ b/scripts/api-compare/call-mismatches-exclude/rack/directory.json
@@ -10,6 +10,15 @@
     "package": "rack",
     "tsFile": "directory.ts",
     "rubyName": "get",
+    "call": "check_bad_request",
+    "kind": "args",
+    "rubyArgs": ["ref:pathInfo"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "rack",
+    "tsFile": "directory.ts",
+    "rubyName": "get",
     "call": "unescape_path",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -19,6 +28,15 @@
     "rubyName": "list_directory",
     "call": "escape_path",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "rack",
+    "tsFile": "directory.ts",
+    "rubyName": "list_directory",
+    "call": "mime_type",
+    "kind": "args",
+    "rubyArgs": ["ref:extname"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "rack",

--- a/scripts/api-compare/call-mismatches-exclude/rack/directory.json
+++ b/scripts/api-compare/call-mismatches-exclude/rack/directory.json
@@ -12,7 +12,9 @@
     "rubyName": "get",
     "call": "check_bad_request",
     "kind": "args",
-    "rubyArgs": ["ref:pathInfo"],
+    "rubyArgs": [
+      "ref:pathInfo"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -35,7 +37,9 @@
     "rubyName": "list_directory",
     "call": "mime_type",
     "kind": "args",
-    "rubyArgs": ["ref:extname"],
+    "rubyArgs": [
+      "ref:extname"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/rack/events.json
+++ b/scripts/api-compare/call-mismatches-exclude/rack/events.json
@@ -17,7 +17,34 @@
     "package": "rack",
     "tsFile": "events.ts",
     "rubyName": "call",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:body", "ref:request", "ref:response", "ref:handlers"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "rack",
+    "tsFile": "events.ts",
+    "rubyName": "call",
+    "call": "on_start",
+    "kind": "args",
+    "rubyArgs": ["ref:request", "nil"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "rack",
+    "tsFile": "events.ts",
+    "rubyName": "call",
     "call": "order:constructor,onStart",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+  },
+  {
+    "package": "rack",
+    "tsFile": "events.ts",
+    "rubyName": "make_response",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:status", "ref:headers", "ref:body"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/rack/events.json
+++ b/scripts/api-compare/call-mismatches-exclude/rack/events.json
@@ -19,7 +19,12 @@
     "rubyName": "call",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:body", "ref:request", "ref:response", "ref:handlers"],
+    "rubyArgs": [
+      "ref:body",
+      "ref:request",
+      "ref:response",
+      "ref:handlers"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -28,7 +33,10 @@
     "rubyName": "call",
     "call": "on_start",
     "kind": "args",
-    "rubyArgs": ["ref:request", "nil"],
+    "rubyArgs": [
+      "ref:request",
+      "nil"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -44,7 +52,11 @@
     "rubyName": "make_response",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:status", "ref:headers", "ref:body"],
+    "rubyArgs": [
+      "ref:status",
+      "ref:headers",
+      "ref:body"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/rack/files.json
+++ b/scripts/api-compare/call-mismatches-exclude/rack/files.json
@@ -19,7 +19,9 @@
     "rubyName": "get",
     "call": "file?",
     "kind": "args",
-    "rubyArgs": ["ref:path"],
+    "rubyArgs": [
+      "ref:path"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -49,7 +51,10 @@
     "rubyName": "serving",
     "call": "fail",
     "kind": "args",
-    "rubyArgs": ["num:416", "str:Byte range unsatisfiable"],
+    "rubyArgs": [
+      "num:416",
+      "str:Byte range unsatisfiable"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -65,7 +70,11 @@
     "rubyName": "serving",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:path", "ref:ranges", "kwargs{mimeType=ref:mimeType,size=ref:size}"],
+    "rubyArgs": [
+      "ref:path",
+      "ref:ranges",
+      "kwargs{mimeType=ref:mimeType,size=ref:size}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/rack/files.json
+++ b/scripts/api-compare/call-mismatches-exclude/rack/files.json
@@ -17,6 +17,15 @@
     "package": "rack",
     "tsFile": "files.ts",
     "rubyName": "get",
+    "call": "file?",
+    "kind": "args",
+    "rubyArgs": ["ref:path"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "rack",
+    "tsFile": "files.ts",
+    "rubyName": "get",
     "call": "unescape_path",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -38,8 +47,26 @@
     "package": "rack",
     "tsFile": "files.ts",
     "rubyName": "serving",
+    "call": "fail",
+    "kind": "args",
+    "rubyArgs": ["num:416", "str:Byte range unsatisfiable"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "rack",
+    "tsFile": "files.ts",
+    "rubyName": "serving",
     "call": "get_byte_ranges",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "rack",
+    "tsFile": "files.ts",
+    "rubyName": "serving",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:path", "ref:ranges", "kwargs{mimeType=ref:mimeType,size=ref:size}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "rack",

--- a/scripts/api-compare/call-mismatches-exclude/rack/lint.json
+++ b/scripts/api-compare/call-mismatches-exclude/rack/lint.json
@@ -5,7 +5,10 @@
     "rubyName": "call",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:app", "ref:env"],
+    "rubyArgs": [
+      "ref:app",
+      "ref:env"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/rack/lint.json
+++ b/scripts/api-compare/call-mismatches-exclude/rack/lint.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "rack",
+    "tsFile": "lint.ts",
+    "rubyName": "call",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:app", "ref:env"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/rack/method-override.json
+++ b/scripts/api-compare/call-mismatches-exclude/rack/method-override.json
@@ -5,5 +5,23 @@
     "rubyName": "method_override",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "rack",
+    "tsFile": "method-override.ts",
+    "rubyName": "method_override_param",
+    "call": "puts",
+    "kind": "args",
+    "rubyArgs": ["str:Bad request content body"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "rack",
+    "tsFile": "method-override.ts",
+    "rubyName": "method_override_param",
+    "call": "puts",
+    "kind": "args",
+    "rubyArgs": ["str:Invalid or incomplete POST params"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/rack/method-override.json
+++ b/scripts/api-compare/call-mismatches-exclude/rack/method-override.json
@@ -12,7 +12,9 @@
     "rubyName": "method_override_param",
     "call": "puts",
     "kind": "args",
-    "rubyArgs": ["str:Bad request content body"],
+    "rubyArgs": [
+      "str:Bad request content body"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -21,7 +23,9 @@
     "rubyName": "method_override_param",
     "call": "puts",
     "kind": "args",
-    "rubyArgs": ["str:Invalid or incomplete POST params"],
+    "rubyArgs": [
+      "str:Invalid or incomplete POST params"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/rack/mock-request.json
+++ b/scripts/api-compare/call-mismatches-exclude/rack/mock-request.json
@@ -10,6 +10,24 @@
     "package": "rack",
     "tsFile": "mock-request.ts",
     "rubyName": "env_for",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "rack",
+    "tsFile": "mock-request.ts",
+    "rubyName": "env_for",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:rackInput"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "rack",
+    "tsFile": "mock-request.ts",
+    "rubyName": "env_for",
     "call": "parse_uri_rfc2396",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -17,7 +35,25 @@
     "package": "rack",
     "tsFile": "mock-request.ts",
     "rubyName": "parse_uri_rfc2396",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "rack",
+    "tsFile": "mock-request.ts",
+    "rubyName": "parse_uri_rfc2396",
     "call": "parse",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "rack",
+    "tsFile": "mock-request.ts",
+    "rubyName": "request",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:app"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/rack/mock-request.json
+++ b/scripts/api-compare/call-mismatches-exclude/rack/mock-request.json
@@ -21,7 +21,9 @@
     "rubyName": "env_for",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:rackInput"],
+    "rubyArgs": [
+      "ref:rackInput"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -53,7 +55,9 @@
     "rubyName": "request",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:app"],
+    "rubyArgs": [
+      "ref:app"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/rack/multipart/generator.json
+++ b/scripts/api-compare/call-mismatches-exclude/rack/multipart/generator.json
@@ -19,5 +19,23 @@
     "rubyName": "flattened_params",
     "call": "build_multipart",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "rack",
+    "tsFile": "multipart/generator.ts",
+    "rubyName": "flattened_params",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "rack",
+    "tsFile": "multipart/generator.ts",
+    "rubyName": "multipart?",
+    "call": "values",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/rack/multipart/parser.json
+++ b/scripts/api-compare/call-mismatches-exclude/rack/multipart/parser.json
@@ -37,6 +37,15 @@
   {
     "package": "rack",
     "tsFile": "multipart/parser.ts",
+    "rubyName": "on_mime_head",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "rack",
+    "tsFile": "multipart/parser.ts",
     "rubyName": "result",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/rack/query-parser.json
+++ b/scripts/api-compare/call-mismatches-exclude/rack/query-parser.json
@@ -5,7 +5,10 @@
     "rubyName": "new_depth_limit",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:paramsClass", "ref:paramDepthLimit"],
+    "rubyArgs": [
+      "ref:paramsClass",
+      "ref:paramDepthLimit"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/rack/query-parser.json
+++ b/scripts/api-compare/call-mismatches-exclude/rack/query-parser.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "rack",
+    "tsFile": "query-parser.ts",
+    "rubyName": "new_depth_limit",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:paramsClass", "ref:paramDepthLimit"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/rack/request.json
+++ b/scripts/api-compare/call-mismatches-exclude/rack/request.json
@@ -5,7 +5,10 @@
     "rubyName": "POST",
     "call": "parse_multipart",
     "kind": "args",
-    "rubyArgs": ["ref:env", "const:ParamList"],
+    "rubyArgs": [
+      "ref:env",
+      "const:ParamList"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -14,7 +17,10 @@
     "rubyName": "POST",
     "call": "parse_query",
     "kind": "args",
-    "rubyArgs": ["ref:formVars", "str:&"],
+    "rubyArgs": [
+      "ref:formVars",
+      "str:&"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/rack/request.json
+++ b/scripts/api-compare/call-mismatches-exclude/rack/request.json
@@ -2,6 +2,24 @@
   {
     "package": "rack",
     "tsFile": "request.ts",
+    "rubyName": "POST",
+    "call": "parse_multipart",
+    "kind": "args",
+    "rubyArgs": ["ref:env", "const:ParamList"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "rack",
+    "tsFile": "request.ts",
+    "rubyName": "POST",
+    "call": "parse_query",
+    "kind": "args",
+    "rubyArgs": ["ref:formVars", "str:&"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "rack",
+    "tsFile": "request.ts",
     "rubyName": "add_header",
     "call": "get_header",
     "reason": "Rack header accessor (`get_header`/`set_header`/`fetch_header`/`has_header?`). trails' request/response objects expose headers as direct property/map access instead of the Rack accessor pair, so the accessor call name is absent by design. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."

--- a/scripts/api-compare/call-mismatches-exclude/rack/show-exceptions.json
+++ b/scripts/api-compare/call-mismatches-exclude/rack/show-exceptions.json
@@ -12,5 +12,14 @@
     "rubyName": "pretty",
     "call": "map",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "rack",
+    "tsFile": "show-exceptions.ts",
+    "rubyName": "pretty",
+    "call": "template",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/rack/utils.json
+++ b/scripts/api-compare/call-mismatches-exclude/rack/utils.json
@@ -44,6 +44,15 @@
   {
     "package": "rack",
     "tsFile": "utils.ts",
+    "rubyName": "status_code",
+    "call": "warn",
+    "kind": "args",
+    "rubyArgs": ["ref:message", "kwargs{uplevel=num:3}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "rack",
+    "tsFile": "utils.ts",
     "rubyName": "unescape_path",
     "call": "unescape",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/rack/utils.json
+++ b/scripts/api-compare/call-mismatches-exclude/rack/utils.json
@@ -47,7 +47,10 @@
     "rubyName": "status_code",
     "call": "warn",
     "kind": "args",
-    "rubyArgs": ["ref:message", "kwargs{uplevel=num:3}"],
+    "rubyArgs": [
+      "ref:message",
+      "kwargs{uplevel=num:3}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/trailties/application.json
+++ b/scripts/api-compare/call-mismatches-exclude/trailties/application.json
@@ -5,7 +5,9 @@
     "rubyName": "config",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:findRoot"],
+    "rubyArgs": [
+      "ref:findRoot"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -28,7 +30,11 @@
     "rubyName": "find_root",
     "call": "find_root_with_flag",
     "kind": "args",
-    "rubyArgs": ["str:config.ru", "ref:from", "ref:pwd"],
+    "rubyArgs": [
+      "str:config.ru",
+      "ref:from",
+      "ref:pwd"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -37,7 +43,9 @@
     "rubyName": "key_generator",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:constructor"],
+    "rubyArgs": [
+      "ref:constructor"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -46,7 +54,10 @@
     "rubyName": "key_generator",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:secretKeyBase", "kwargs{iterations=num:1000}"],
+    "rubyArgs": [
+      "ref:secretKeyBase",
+      "kwargs{iterations=num:1000}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/trailties/application.json
+++ b/scripts/api-compare/call-mismatches-exclude/trailties/application.json
@@ -2,6 +2,15 @@
   {
     "package": "trailties",
     "tsFile": "application.ts",
+    "rubyName": "config",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:findRoot"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "trailties",
+    "tsFile": "application.ts",
     "rubyName": "config_for",
     "call": "parse",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -12,5 +21,50 @@
     "rubyName": "config_for",
     "call": "update",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "trailties",
+    "tsFile": "application.ts",
+    "rubyName": "find_root",
+    "call": "find_root_with_flag",
+    "kind": "args",
+    "rubyArgs": ["str:config.ru", "ref:from", "ref:pwd"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "trailties",
+    "tsFile": "application.ts",
+    "rubyName": "key_generator",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:constructor"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "trailties",
+    "tsFile": "application.ts",
+    "rubyName": "key_generator",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:secretKeyBase", "kwargs{iterations=num:1000}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "trailties",
+    "tsFile": "application.ts",
+    "rubyName": "name",
+    "call": "dasherize",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "trailties",
+    "tsFile": "application.ts",
+    "rubyName": "name",
+    "call": "underscore",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/trailties/application/routes-reloader.json
+++ b/scripts/api-compare/call-mismatches-exclude/trailties/application/routes-reloader.json
@@ -5,5 +5,14 @@
     "rubyName": "execute_unless_loaded",
     "call": "application",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "trailties",
+    "tsFile": "application/routes-reloader.ts",
+    "rubyName": "execute_unless_loaded",
+    "call": "execute",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/trailties/engine.json
+++ b/scripts/api-compare/call-mismatches-exclude/trailties/engine.json
@@ -1,0 +1,20 @@
+[
+  {
+    "package": "trailties",
+    "tsFile": "engine.ts",
+    "rubyName": "config",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:findRoot"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "trailties",
+    "tsFile": "engine.ts",
+    "rubyName": "find_root_with_flag",
+    "call": "directory?",
+    "kind": "args",
+    "rubyArgs": ["ref:rootPath"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/trailties/engine.json
+++ b/scripts/api-compare/call-mismatches-exclude/trailties/engine.json
@@ -5,7 +5,9 @@
     "rubyName": "config",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:findRoot"],
+    "rubyArgs": [
+      "ref:findRoot"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -14,7 +16,9 @@
     "rubyName": "find_root_with_flag",
     "call": "directory?",
     "kind": "args",
-    "rubyArgs": ["ref:rootPath"],
+    "rubyArgs": [
+      "ref:rootPath"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/trailties/generators/migration.json
+++ b/scripts/api-compare/call-mismatches-exclude/trailties/generators/migration.json
@@ -5,7 +5,11 @@
     "rubyName": "migration_template",
     "call": "create_migration",
     "kind": "args",
-    "rubyArgs": ["ref:numberedDestination", "nil", "ref:config"],
+    "rubyArgs": [
+      "ref:numberedDestination",
+      "nil",
+      "ref:config"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/trailties/generators/migration.json
+++ b/scripts/api-compare/call-mismatches-exclude/trailties/generators/migration.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "trailties",
+    "tsFile": "generators/migration.ts",
+    "rubyName": "migration_template",
+    "call": "create_migration",
+    "kind": "args",
+    "rubyArgs": ["ref:numberedDestination", "nil", "ref:config"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/trailties/generators/model-helpers.json
+++ b/scripts/api-compare/call-mismatches-exclude/trailties/generators/model-helpers.json
@@ -1,0 +1,20 @@
+[
+  {
+    "package": "trailties",
+    "tsFile": "generators/model-helpers.ts",
+    "rubyName": "inflection_impossible?",
+    "call": "singularize",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "trailties",
+    "tsFile": "generators/model-helpers.ts",
+    "rubyName": "inflection_impossible?",
+    "call": "underscore",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/trailties/generators/rails/credentials/credentials-generator.json
+++ b/scripts/api-compare/call-mismatches-exclude/trailties/generators/rails/credentials/credentials-generator.json
@@ -1,0 +1,13 @@
+[
+  {
+    "package": "trailties",
+    "tsFile": "generators/rails/credentials/credentials-generator.ts",
+    "rubyName": "encrypted_file",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": [
+      "kwargs{configPath=ref:contentPath,envKey=str:RAILS_MASTER_KEY,keyPath=ref:keyPath,raiseIfMissingKey=bool:true}"
+    ],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/trailties/generators/rails/encrypted-file/encrypted-file-generator.json
+++ b/scripts/api-compare/call-mismatches-exclude/trailties/generators/rails/encrypted-file/encrypted-file-generator.json
@@ -1,0 +1,13 @@
+[
+  {
+    "package": "trailties",
+    "tsFile": "generators/rails/encrypted-file/encrypted-file-generator.ts",
+    "rubyName": "add_encrypted_file_silently",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": [
+      "kwargs{contentPath=ref:filePath,envKey=str:RAILS_MASTER_KEY,keyPath=ref:keyPath,raiseIfMissingKey=bool:true}"
+    ],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/trailties/generators/rails/generator/generator-generator.json
+++ b/scripts/api-compare/call-mismatches-exclude/trailties/generators/rails/generator/generator-generator.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "trailties",
+    "tsFile": "generators/rails/generator/generator-generator.ts",
+    "rubyName": "generator_dir",
+    "call": "join",
+    "kind": "args",
+    "rubyArgs": ["str:lib", "str:generators", "ref:regularClassPath", "ref:fileName"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/trailties/generators/rails/generator/generator-generator.json
+++ b/scripts/api-compare/call-mismatches-exclude/trailties/generators/rails/generator/generator-generator.json
@@ -5,7 +5,12 @@
     "rubyName": "generator_dir",
     "call": "join",
     "kind": "args",
-    "rubyArgs": ["str:lib", "str:generators", "ref:regularClassPath", "ref:fileName"],
+    "rubyArgs": [
+      "str:lib",
+      "str:generators",
+      "ref:regularClassPath",
+      "ref:fileName"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/trailties/generators/rails/master-key/master-key-generator.json
+++ b/scripts/api-compare/call-mismatches-exclude/trailties/generators/rails/master-key/master-key-generator.json
@@ -5,7 +5,10 @@
     "rubyName": "ignore_master_key_file",
     "call": "ignore_key_file",
     "kind": "args",
-    "rubyArgs": ["const:MASTER_KEY_PATH", "kwargs{ignore=ref:keyIgnore}"],
+    "rubyArgs": [
+      "const:MASTER_KEY_PATH",
+      "kwargs{ignore=ref:keyIgnore}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -14,7 +17,10 @@
     "rubyName": "ignore_master_key_file_silently",
     "call": "ignore_key_file_silently",
     "kind": "args",
-    "rubyArgs": ["const:MASTER_KEY_PATH", "kwargs{ignore=ref:keyIgnore}"],
+    "rubyArgs": [
+      "const:MASTER_KEY_PATH",
+      "kwargs{ignore=ref:keyIgnore}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/trailties/generators/rails/master-key/master-key-generator.json
+++ b/scripts/api-compare/call-mismatches-exclude/trailties/generators/rails/master-key/master-key-generator.json
@@ -1,0 +1,20 @@
+[
+  {
+    "package": "trailties",
+    "tsFile": "generators/rails/master-key/master-key-generator.ts",
+    "rubyName": "ignore_master_key_file",
+    "call": "ignore_key_file",
+    "kind": "args",
+    "rubyArgs": ["const:MASTER_KEY_PATH", "kwargs{ignore=ref:keyIgnore}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "trailties",
+    "tsFile": "generators/rails/master-key/master-key-generator.ts",
+    "rubyName": "ignore_master_key_file_silently",
+    "call": "ignore_key_file_silently",
+    "kind": "args",
+    "rubyArgs": ["const:MASTER_KEY_PATH", "kwargs{ignore=ref:keyIgnore}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/trailties/generators/rails/resource-route/resource-route-generator.json
+++ b/scripts/api-compare/call-mismatches-exclude/trailties/generators/rails/resource-route/resource-route-generator.json
@@ -3,6 +3,15 @@
     "package": "trailties",
     "tsFile": "generators/rails/resource-route/resource-route-generator.ts",
     "rubyName": "add_resource_route",
+    "call": "pluralize",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "trailties",
+    "tsFile": "generators/rails/resource-route/resource-route-generator.ts",
+    "rubyName": "add_resource_route",
     "call": "route",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }

--- a/scripts/api-compare/call-mismatches-exclude/trailties/generators/resource-helpers.json
+++ b/scripts/api-compare/call-mismatches-exclude/trailties/generators/resource-helpers.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "trailties",
+    "tsFile": "generators/resource-helpers.ts",
+    "rubyName": "controller_i18n_scope",
+    "call": "controller_file_path",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/trailties/health-controller.json
+++ b/scripts/api-compare/call-mismatches-exclude/trailties/health-controller.json
@@ -1,0 +1,20 @@
+[
+  {
+    "package": "trailties",
+    "tsFile": "health-controller.ts",
+    "rubyName": "render_down",
+    "call": "html_status",
+    "kind": "args",
+    "rubyArgs": ["kwargs{color=str:red}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "trailties",
+    "tsFile": "health-controller.ts",
+    "rubyName": "render_up",
+    "call": "html_status",
+    "kind": "args",
+    "rubyArgs": ["kwargs{color=str:green}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/trailties/health-controller.json
+++ b/scripts/api-compare/call-mismatches-exclude/trailties/health-controller.json
@@ -5,7 +5,9 @@
     "rubyName": "render_down",
     "call": "html_status",
     "kind": "args",
-    "rubyArgs": ["kwargs{color=str:red}"],
+    "rubyArgs": [
+      "kwargs{color=str:red}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -14,7 +16,9 @@
     "rubyName": "render_up",
     "call": "html_status",
     "kind": "args",
-    "rubyArgs": ["kwargs{color=str:green}"],
+    "rubyArgs": [
+      "kwargs{color=str:green}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/trailties/info-controller.json
+++ b/scripts/api-compare/call-mismatches-exclude/trailties/info-controller.json
@@ -2,6 +2,15 @@
   {
     "package": "trailties",
     "tsFile": "info-controller.ts",
+    "rubyName": "index",
+    "call": "redirect_to",
+    "kind": "args",
+    "rubyArgs": ["kwargs{action=str:routes}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "trailties",
+    "tsFile": "info-controller.ts",
     "rubyName": "notes",
     "call": "find",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -12,6 +21,24 @@
     "rubyName": "notes",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "trailties",
+    "tsFile": "info-controller.ts",
+    "rubyName": "routes",
+    "call": "matching_routes",
+    "kind": "args",
+    "rubyArgs": ["kwargs{exactMatch=bool:false,query=ref:query}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "trailties",
+    "tsFile": "info-controller.ts",
+    "rubyName": "routes",
+    "call": "matching_routes",
+    "kind": "args",
+    "rubyArgs": ["kwargs{exactMatch=bool:true,query=ref:query}"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "trailties",

--- a/scripts/api-compare/call-mismatches-exclude/trailties/info-controller.json
+++ b/scripts/api-compare/call-mismatches-exclude/trailties/info-controller.json
@@ -5,7 +5,9 @@
     "rubyName": "index",
     "call": "redirect_to",
     "kind": "args",
-    "rubyArgs": ["kwargs{action=str:routes}"],
+    "rubyArgs": [
+      "kwargs{action=str:routes}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -28,7 +30,9 @@
     "rubyName": "routes",
     "call": "matching_routes",
     "kind": "args",
-    "rubyArgs": ["kwargs{exactMatch=bool:false,query=ref:query}"],
+    "rubyArgs": [
+      "kwargs{exactMatch=bool:false,query=ref:query}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -37,7 +41,9 @@
     "rubyName": "routes",
     "call": "matching_routes",
     "kind": "args",
-    "rubyArgs": ["kwargs{exactMatch=bool:true,query=ref:query}"],
+    "rubyArgs": [
+      "kwargs{exactMatch=bool:true,query=ref:query}"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/trailties/info.json
+++ b/scripts/api-compare/call-mismatches-exclude/trailties/info.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "trailties",
+    "tsFile": "info.ts",
+    "rubyName": "to_html",
+    "call": "join",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/trailties/paths.json
+++ b/scripts/api-compare/call-mismatches-exclude/trailties/paths.json
@@ -2,6 +2,15 @@
   {
     "package": "trailties",
     "tsFile": "paths.ts",
+    "rubyName": "existent",
+    "call": "symlink?",
+    "kind": "args",
+    "rubyArgs": ["ref:f"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "trailties",
+    "tsFile": "paths.ts",
     "rubyName": "existent_directories",
     "call": "directory?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/trailties/paths.json
+++ b/scripts/api-compare/call-mismatches-exclude/trailties/paths.json
@@ -5,7 +5,9 @@
     "rubyName": "existent",
     "call": "symlink?",
     "kind": "args",
-    "rubyArgs": ["ref:f"],
+    "rubyArgs": [
+      "ref:f"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/trailties/rack/logger.json
+++ b/scripts/api-compare/call-mismatches-exclude/trailties/rack/logger.json
@@ -5,7 +5,9 @@
     "rubyName": "call",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:env"],
+    "rubyArgs": [
+      "ref:env"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/trailties/rack/logger.json
+++ b/scripts/api-compare/call-mismatches-exclude/trailties/rack/logger.json
@@ -3,6 +3,15 @@
     "package": "trailties",
     "tsFile": "rack/logger.ts",
     "rubyName": "call",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:env"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "trailties",
+    "tsFile": "rack/logger.ts",
+    "rubyName": "call",
     "call": "order:pushTags,constructor",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }

--- a/scripts/api-compare/call-mismatches-exclude/trailties/rack/silence-request.json
+++ b/scripts/api-compare/call-mismatches-exclude/trailties/rack/silence-request.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "trailties",
+    "tsFile": "rack/silence-request.ts",
+    "rubyName": "call",
+    "call": "silence",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/trailties/source-annotation-extractor.json
+++ b/scripts/api-compare/call-mismatches-exclude/trailties/source-annotation-extractor.json
@@ -12,7 +12,9 @@
     "rubyName": "find_in",
     "call": "directory?",
     "kind": "args",
-    "rubyArgs": ["ref:item"],
+    "rubyArgs": [
+      "ref:item"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
@@ -21,7 +23,9 @@
     "rubyName": "find_in",
     "call": "new",
     "kind": "args",
-    "rubyArgs": ["ref:pattern"],
+    "rubyArgs": [
+      "ref:pattern"
+    ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/trailties/source-annotation-extractor.json
+++ b/scripts/api-compare/call-mismatches-exclude/trailties/source-annotation-extractor.json
@@ -10,6 +10,24 @@
     "package": "trailties",
     "tsFile": "source-annotation-extractor.ts",
     "rubyName": "find_in",
+    "call": "directory?",
+    "kind": "args",
+    "rubyArgs": ["ref:item"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "trailties",
+    "tsFile": "source-annotation-extractor.ts",
+    "rubyName": "find_in",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": ["ref:pattern"],
+    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "trailties",
+    "tsFile": "source-annotation-extractor.ts",
+    "rubyName": "find_in",
     "call": "order:constructor,isDirectory",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -115,7 +115,13 @@ import { matchOptionKeysAgainst } from "./options-keys.js";
 // call-args.ts imports NO_JS_CALL_FORM back from this module and reads it at
 // CALL time for exactly that reason (see its isSkippedCallName): the pair is a
 // cycle, and only a module-evaluation-time read of either side would break.
-import { compareCallArgs, pairCallSites, type CallArgClass } from "./call-args.js";
+import {
+  CALL_ARG_SKIP_REASONS,
+  compareCallArgs,
+  pairCallSites,
+  type CallArgClass,
+  type CallArgSkipReason,
+} from "./call-args.js";
 import { callOf } from "./call-mismatch-baseline.js";
 import {
   compareDefaults,
@@ -864,7 +870,18 @@ interface CallArgMismatch {
 interface CallArgsResult {
   compared: number;
   mismatched: number;
+  /** Sites the comparison could not reach, by reason (RFC 0095). The last three
+   *  reasons are population the dimension is losing, so a normalization change
+   *  that shrinks the comparable set is countable rather than silent. */
+  skipped: Record<CallArgSkipReason, number>;
   mismatches: CallArgMismatch[];
+}
+
+function emptySkipTally(): Record<CallArgSkipReason, number> {
+  return Object.fromEntries(CALL_ARG_SKIP_REASONS.map((r) => [r, 0])) as Record<
+    CallArgSkipReason,
+    number
+  >;
 }
 
 // Advisory: a default's or constant's literal value differs for a matched pair.
@@ -2234,6 +2251,7 @@ export function main() {
     const suppressedCalls: SuppressedCall[] = [];
     const callSkeletons: CallSkeleton[] = [];
     let callArgsCompared = 0;
+    const callArgsSkipped = emptySkipTally();
     const callArgMismatches: CallArgMismatch[] = [];
     const bodyHashRecords: BodyHashRecord[] = [];
     const fileResults: FileResult[] = [];
@@ -2474,7 +2492,10 @@ export function main() {
         if (tsSites?.length !== 1) return;
         for (const { ruby, ts } of pairCallSites(rubySites, tsSites[0])) {
           const result = compareCallArgs(ruby, ts);
-          if (result.verdict === "skip") continue;
+          if (result.verdict === "skip") {
+            callArgsSkipped[result.reason]++;
+            continue;
+          }
           callArgsCompared++;
           if (result.verdict !== "mismatch") continue;
           callArgMismatches.push({
@@ -2936,6 +2957,7 @@ export function main() {
       callArgs: {
         compared: callArgsCompared,
         mismatched: callArgMismatches.length,
+        skipped: callArgsSkipped,
         mismatches: callArgMismatches,
       },
       bodyHashes: bodyHashRecords,
@@ -3092,6 +3114,12 @@ export function main() {
           packages: [...new Set(results.map((r) => r.package))].sort(),
           compared: results.reduce((n, r) => n + r.callArgs.compared, 0),
           mismatched: callArgsFlat.length,
+          skipped: Object.fromEntries(
+            CALL_ARG_SKIP_REASONS.map((reason) => [
+              reason,
+              results.reduce((n, r) => n + r.callArgs.skipped[reason], 0),
+            ]),
+          ),
           mismatches: callArgsFlat,
         },
         null,

--- a/scripts/api-compare/lint-call-mismatches.test.ts
+++ b/scripts/api-compare/lint-call-mismatches.test.ts
@@ -516,9 +516,12 @@ describe("--set-reason categories", () => {
 });
 
 describe("the shared shards", () => {
-  it("holds no args row today, so the call-set row count is what it was before RFC 0095", async () => {
+  it("partitions into exactly the call-set rows and the RFC 0095 args rows", async () => {
     const all = await loadSplitBaseline(BASELINE_DIR);
-    expect(await loadForeignRows()).toEqual([]);
-    expect((await loadBaseline()).length).toBe(all.length);
+    const args = await loadForeignRows();
+    expect(args.every((r) => r.kind === "args")).toBe(true);
+    // The seed of the argument dimension must not move RFC 0084's debt metric:
+    // every shard row is either a call-set row this gate loads or an args row.
+    expect((await loadBaseline()).length + args.length).toBe(all.length);
   });
 });

--- a/scripts/api-compare/lint-call-mismatches.test.ts
+++ b/scripts/api-compare/lint-call-mismatches.test.ts
@@ -520,8 +520,6 @@ describe("the shared shards", () => {
     const all = await loadSplitBaseline(BASELINE_DIR);
     const args = await loadForeignRows();
     expect(args.every((r) => r.kind === "args")).toBe(true);
-    // The seed of the argument dimension must not move RFC 0084's debt metric:
-    // every shard row is either a call-set row this gate loads or an args row.
     expect((await loadBaseline()).length + args.length).toBe(all.length);
   });
 });

--- a/scripts/api-compare/report-call-args.test.ts
+++ b/scripts/api-compare/report-call-args.test.ts
@@ -20,6 +20,7 @@ describe("renderReport", () => {
   const artifact = {
     compared: 302,
     mismatched: 3,
+    skipped: { excludedCallName: 41, opaqueRubyArg: 7, unparseableLiteral: 0 },
     mismatches: [
       row(),
       row({ class: "naming", call: "quote" }),
@@ -46,6 +47,13 @@ describe("renderReport", () => {
 
   it("reports the compared population", () => {
     expect(renderReport(artifact, 20)).toContain("3 row(s) across 2 file(s), 302 call site(s)");
+  });
+
+  it("groups the skipped population by reason", () => {
+    const out = renderReport(artifact, 20);
+    expect(out).toContain("Skipped (uncomparable) sites by reason (3)");
+    expect(out).toMatch(/excludedCallName\s+41/);
+    expect(out).toMatch(/opaqueRubyArg\s+7/);
   });
 
   it("truncates a grouping to --top", () => {

--- a/scripts/api-compare/report-call-args.ts
+++ b/scripts/api-compare/report-call-args.ts
@@ -38,6 +38,7 @@ export function renderReport(artifact: CallArgArtifact, top: number): string {
       tally(rows, (r) => `${r.package}/${r.tsFile}`),
       top,
     ),
+    section("Skipped (uncomparable) sites by reason", Object.entries(artifact.skipped ?? {})),
     section(
       "By class",
       tally(rows, (r) => r.class),


### PR DESCRIPTION
Bundle of three RFC 0095 stories: the arel population re-measurement, the
call-argument baseline seed, and the skip-reason tally.

## 1. arel population re-check (`call-args-arel-population-recheck`)

Measured on a clean tree with `API_COMPARE_FORCE=1 pnpm parity:api --calls --package arel`,
under the SHIPPED pairing (`pairCallSites` over the name-matched pairs `checkCalls` receives):

| metric   | shipped | spike (2026-08-08) |
| -------- | ------: | -----------------: |
| compared |     759 |                302 |
| flagged  |     140 |                ~70 |
| shape    |      31 |                  — |
| naming   |     109 |                  — |

Delta: ~2.5x the comparable sites, ~2x the flagged ones. The accounting is the
one the story states — the spike measured with its own throwaway Ripper/TS
walkers and no trails code, while the shipped streams come from
`extract-ruby-api.rb#describe_args` and `extract-ts-api.ts#describeArgs`, so it
is a different site population, not a comparator difference. The comparator
itself still reproduces every finding the RFC names. No comparator behaviour
changed here.

Full-scope numbers for reference: 5619 compared, 1618 flagged (735 shape / 883 naming).

## 2. Baseline seed (`call-args-baseline-seed`)

689 `kind: "args"` shape rows seeded from a forced full-scope run into the
EXISTING `call-mismatches-exclude/<package>/<path>.json` shards, written via
`serializeBaseline`, each carrying a reviewed RFC 0095 seed reason (not the
`TODO:` placeholder).

- call-set gate row count unchanged: **2115 before and after** — the seed does
  not move RFC 0084's debt metric. `pnpm parity:api:calls` is green.
- `naming` rows are NOT seeded (report-only, RFC 0096).
- `pnpm parity:api:calls:args` → `OK (689 baselined shape row(s))`.
- The burndown floor is 689; recorded in the RFC 0025 changelog.
- The three arel convergence targets (visitor-helper `collector` argument
  order, `appendEscape`, `UnaryOperation.operand`) are filed as their own
  stories, not fixed here.

The baseline diff is large and mechanical (generated); the code diff is ~180 LOC.

## 3. Skip-reason tally (`call-args-skip-reason-tally`)

`compareCallArgs` now returns `reason` on the `skip` arm — a discriminated
field, no second return channel — with five reasons. `compare.ts` tallies them
per package and `output/call-arg-mismatches.json` gains a flat `skipped` object
next to `compared` / `mismatched`, which `--report` renders. No verdict, flagged
row or parity % changes.

Full-scope tally: `excludedCallName` 179, `uncomparableFlag` 485,
`opaqueRubyArg` 445, `opaqueTsArg` 299, `unparseableLiteral` 0 — the last three
are the population the dimension is losing, now countable instead of silent
(the class of defect #6316 fixed). One test per reason.

Closes-story: call-args-arel-population-recheck
Closes-story: call-args-baseline-seed
Closes-story: call-args-skip-reason-tally
