### PR TITLE
fix(scripts): accept the pre-rename ', WIDE' call-summary label

### DIFF
--- a/scripts/sync-stats/parse-call-summaries.test.ts
+++ b/scripts/sync-stats/parse-call-summaries.test.ts
@@ -30,6 +30,21 @@ describe("parseCallSummariesFromLogs", () => {
     expect(callArgs).toBeNull();
   });
 
+  // Pre-rename logs label the same measurement "advisory, WIDE". The numbers
+  // run continuously across the rename, so they belong in the same series.
+  it("accepts the pre-rename WIDE qualifier", () => {
+    const wideLog = `
+  Calls (advisory, WIDE): 6041 matched pairs checked, 1517 omit a ported-method call Rails makes — see output/call-mismatches-wide.json
+`;
+
+    expect(parseCallSummariesFromLogs(wideLog).calls).toEqual({
+      matched: 4524,
+      total: 6041,
+      percent: 74.9,
+      mismatched: 1517,
+    });
+  });
+
   it("returns null for both when the step never ran", () => {
     expect(parseCallSummariesFromLogs("")).toEqual({ calls: null, callArgs: null });
   });

--- a/scripts/sync-stats/parse-call-summaries.ts
+++ b/scripts/sync-stats/parse-call-summaries.ts
@@ -11,6 +11,11 @@
  * matched/total/percent shape as every other stats table, and the parity page
  * can chart them without a special case.
  *
+ * Before the step was renamed from --wide-calls, both lines carried a ", WIDE"
+ * qualifier ("Calls (advisory, WIDE): ..."). It is the same measurement over the
+ * same full surface — the numbers run continuously across the rename — so the
+ * qualifier is simply optional here, and ~850 pre-rename logs parse.
+ *
  * Returns null for a summary the log doesn't carry: `Call args` only prints
  * when the call-arg artifact exists, so an older log has calls but no args.
  */
@@ -21,11 +26,11 @@ export function parseCallSummariesFromLogs(logs: string): {
   return {
     calls: matchCallSummary(
       logs,
-      /Calls \(advisory\): (\d+) matched pairs checked, (\d+) omit a ported-method call/,
+      /Calls \(advisory(?:, WIDE)?\): (\d+) matched pairs checked, (\d+) omit a ported-method call/,
     ),
     callArgs: matchCallSummary(
       logs,
-      /Call args \(advisory\): (\d+) call sites compared, (\d+) pass different arguments/,
+      /Call args \(advisory(?:, WIDE)?\): (\d+) call sites compared, (\d+) pass different arguments/,
     ),
   };
 }


### PR DESCRIPTION
Follow-up to #6342 — third and last piece of the calls-stats backfill.

## What was still wrong

#6342 got the `--wide-calls` step classified as `api_calls`, but `--reparse-logs` still produced rows only back to PR #6128. The step was being extracted; the parser then found nothing in it, because that era labels the summary differently:

```
Calls (advisory, WIDE): 6041 matched pairs checked, 1517 omit a ported-method call Rails makes
```

The regex required the exact `Calls (advisory):`.

## Why these belong in one series

Same measurement over the same full surface — **6041/1517 (74.9%)** at the end of the wide era runs continuously into **6217/1487 (76.1%)** today. The qualifier is now optional, and ~850 pre-rename logs join the series.

Worth being explicit about the trap, since it is the reason this looked wrong at first glance: in that era the **plain** `api_compare` run prints its *own* `Calls (advisory)` line — `2946 matched pairs checked, 12 omit` — measured over the public-only surface. Charting that alongside the wide numbers would show a fake cliff from ~99.6% to ~75% at the cutover. It is never picked up, because the parser only reads the `api_calls` step's slice, and #6342 is what makes that slice correct.

`Call args` gets the same optional qualifier for symmetry, though no stored log carries `Call args (advisory, WIDE)` — that check postdates the rename.