### PR TITLE
refactor(parity): drop the UNSEEDED bootstrap arm from the call-args ratchet

### DIFF
--- a/scripts/api-compare/call-args-baseline.test.ts
+++ b/scripts/api-compare/call-args-baseline.test.ts
@@ -59,6 +59,12 @@ describe("diffAgainstBaseline", () => {
     expect(stale).toHaveLength(1);
   });
 
+  it("reports nothing when neither side has a row, so a converged dimension is a real green", () => {
+    const { added, stale } = diffAgainstBaseline([], []);
+    expect(added).toHaveLength(0);
+    expect(stale).toHaveLength(0);
+  });
+
   it("matches a baselined row on its argument list", () => {
     expect(diffAgainstBaseline([key()], [entry()]).added).toHaveLength(0);
     expect(diffAgainstBaseline([key({ rubyArgs: ["ref:o"] })], [entry()]).added).toHaveLength(1);

--- a/scripts/api-compare/lint-call-args.test.ts
+++ b/scripts/api-compare/lint-call-args.test.ts
@@ -3,7 +3,7 @@ import * as fs from "fs/promises";
 import * as os from "os";
 import * as path from "path";
 import type { CallArgExcludeEntry } from "./call-args-baseline.js";
-import { loadBaseline, renderKey, renderUnseeded } from "./lint-call-args.js";
+import { loadBaseline, renderKey } from "./lint-call-args.js";
 import { writeSplitBaseline } from "./lint-call-mismatches.js";
 import { rowsOfKind } from "./call-mismatch-baseline.js";
 
@@ -83,9 +83,6 @@ describe("the split call-argument baseline", () => {
   });
 });
 
-it("prints the argument list that makes a row its own key, and names the seeding story", () => {
+it("prints the argument list that makes a row its own key", () => {
   expect(renderKey(entry())).toContain("visit(ref:o, ref:collector)");
-  const out = renderUnseeded([entry()]);
-  expect(out).toContain("UNSEEDED");
-  expect(out).toContain("call-args-baseline-seed");
 });

--- a/scripts/api-compare/lint-call-args.ts
+++ b/scripts/api-compare/lint-call-args.ts
@@ -23,17 +23,6 @@
  * through the argument comparison rather than an argument defect; they stay
  * report-only, reachable through `--report`, until RFC 0096 drains them.
  *
- * ── Before the seed ─────────────────────────────────────────────────────────
- * The baseline is seeded by its own `main`-only PR (RFC 0095
- * `call-args-baseline-seed`) AFTER this gate lands, because a seed generated on
- * a branch drifts from what CI measures. Until then the shards carry no `args`
- * row at all while the artifact flags hundreds, and that combination — zero
- * baselined AND some flagged — is reported as UNSEEDED and exits 0 rather than
- * failing every PR on the merge train with the whole population. It self-closes
- * the moment the seed lands, and it cannot swallow a converged dimension: zero
- * baselined with zero flagged takes the normal path and passes as a real
- * green.
- *
  * A plain gating run first regenerates the artifact itself by shelling out to
  * `pnpm parity:api --calls` (see gate-regen.ts): gating a stale artifact is
  * what makes a sibling PR's deleted method surface as a STALE row on a branch
@@ -111,15 +100,6 @@ export function renderKey(k: CallArgKey): string {
   return `${k.package}  ${k.tsFile}  ${k.rubyName}  ${k.call}(${k.rubyArgs.join(", ")})`;
 }
 
-export function renderUnseeded(rows: CallArgKey[]): string {
-  return (
-    "call-args ratchet: UNSEEDED — no `args` row is baselined yet, so the " +
-    `${rows.length} flagged shape row(s) are reported, not gated. The baseline is seeded on ` +
-    "`main` by its own PR (RFC 0095 call-args-baseline-seed); this arm disappears the " +
-    "moment the first row lands."
-  );
-}
-
 export async function main(write: boolean): Promise<number> {
   const artifact = await loadArtifact();
   const current: CallArgKey[] = gatedRows(artifact);
@@ -152,10 +132,6 @@ export async function main(write: boolean): Promise<number> {
   }
 
   const baseline = await loadBaseline();
-  if (baseline.length === 0 && current.length > 0) {
-    console.log(renderUnseeded(current));
-    return 0;
-  }
 
   const dups = findDuplicateKeys(baseline);
   if (dups.length > 0) {


### PR DESCRIPTION
The call-args ratchet carried a bootstrap arm: with no `kind: "args"` row baselined and rows flagged, it printed UNSEEDED and exited 0 instead of failing. It existed only because the gate (#6334) had to land before the seed (#6343). The seed has landed, so the arm is now unreachable except by hand-deleting every args row — precisely the case that should fail loudly.

- `renderUnseeded` and its call site deleted; an empty args population with flagged rows now fails as NEW rows like any other ratchet.
- The test for the arm goes with it; "nothing baselined AND nothing flagged is a real green" is now covered directly on `diffAgainstBaseline`.
- UNSEEDED paragraph removed from the `lint-call-args.ts` header (CLAUDE.md / CONTRIBUTING.md never mentioned it).

`pnpm parity:api:calls:args` → OK (689 baselined shape rows).

Closes-story: call-args-remove-unseeded-bootstrap-arm