### PR TITLE
feat(scripts): record the advisory assertion counters in test-compare stats

### DIFF
--- a/scripts/sync-stats/parse-test-compare.test.ts
+++ b/scripts/sync-stats/parse-test-compare.test.ts
@@ -7,7 +7,7 @@ const currentFormatLog = `
 ==========================================================================================
 
 ==========================================================================================
-  did-you-mean  —  10/20 tests (50%) (3 skipped, 2 assertion-count-mismatch (see --assertions), 5 extra (TS only))  |  1/2 files  |  4 misplaced
+  did-you-mean  —  10/20 tests (50%) (3 skipped, 2 assertion-count-mismatch (see --assertions), 7 assertion-kind-mismatch (see --assertions), 5 extra (TS only))  |  1/2 files  |  4 misplaced
 ==========================================================================================
 
   Overall: 141/151 tests (93.4%) (53 extra (TS only))  |  7/8 files  |  4 misplaced
@@ -31,6 +31,8 @@ describe("parseTestCompareFromLogs", () => {
       filesMapped: 6,
       filesTotal: 6,
       misplaced: 0,
+      assertionCountMismatch: 0,
+      assertionKindMismatch: 0,
     });
     expect(results.get("did-you-mean")).toEqual({
       matched: 10,
@@ -40,6 +42,24 @@ describe("parseTestCompareFromLogs", () => {
       filesMapped: 1,
       filesTotal: 2,
       misplaced: 4,
+      assertionCountMismatch: 2,
+      assertionKindMismatch: 7,
+    });
+  });
+
+  // The counters are advisory: a mapped test whose body checks a different
+  // number (or different kinds) of things than the Ruby. They must not be
+  // confused with skipped, which the same parenthetical also carries.
+  it("reads both assertion counters off the real activerecord line", () => {
+    const log =
+      "  activerecord  —  8231/8407 tests (97.9%) (7 skipped, 6 wrong describe, " +
+      "1979 assertion-count-mismatch (see --assertions), 4067 assertion-kind-mismatch " +
+      "(see --assertions))  |  278/278 files  |  0 misplaced\n";
+
+    expect(parseTestCompareFromLogs(log).get("activerecord")).toMatchObject({
+      skipped: 7,
+      assertionCountMismatch: 1979,
+      assertionKindMismatch: 4067,
     });
   });
 
@@ -55,6 +75,9 @@ describe("parseTestCompareFromLogs", () => {
       filesMapped: 40,
       filesTotal: 50,
       misplaced: 7,
+      // The pre-#3825 format has no assertion counters at all.
+      assertionCountMismatch: 0,
+      assertionKindMismatch: 0,
     });
   });
 

--- a/scripts/sync-stats/parse-test-compare.ts
+++ b/scripts/sync-stats/parse-test-compare.ts
@@ -6,6 +6,12 @@ export interface TestComparePackageStats {
   filesMapped: number;
   filesTotal: number;
   misplaced: number;
+  // The two advisory assertion counters the summary carries: a ported test
+  // whose assertion COUNT differs from the Ruby, and one whose assertion KINDS
+  // differ. Both are "the test exists and is mapped, but its body does not
+  // check the same things", so they don't move the tests percent.
+  assertionCountMismatch: number;
+  assertionKindMismatch: number;
 }
 
 const SUMMARY_LINE =
@@ -16,7 +22,11 @@ export function parseTestCompareFromLogs(logs: string): Map<string, TestCompareP
 
   for (const m of logs.matchAll(SUMMARY_LINE)) {
     if (m[1] === "Overall") continue;
-    const skippedMatch = /(\d+)\s+skipped/.exec(m.groups?.details ?? "");
+    const details = m.groups?.details ?? "";
+    const skippedMatch = /(\d+)\s+skipped/.exec(details);
+    // "1979 assertion-count-mismatch (see --assertions), 4067 assertion-kind-mismatch (...)"
+    const countMatch = /(\d+)\s+assertion-count-mismatch/.exec(details);
+    const kindMatch = /(\d+)\s+assertion-kind-mismatch/.exec(details);
     results.set(m[1], {
       matched: parseInt(m[2]),
       total: parseInt(m[3]),
@@ -25,6 +35,8 @@ export function parseTestCompareFromLogs(logs: string): Map<string, TestCompareP
       filesMapped: parseInt(m[6]),
       filesTotal: parseInt(m[7]),
       misplaced: parseInt(m[8]),
+      assertionCountMismatch: countMatch ? parseInt(countMatch[1]) : 0,
+      assertionKindMismatch: kindMatch ? parseInt(kindMatch[1]) : 0,
     });
   }
   return results;

--- a/scripts/sync-stats/sync.ts
+++ b/scripts/sync-stats/sync.ts
@@ -346,6 +346,8 @@ class TestCompareStat extends Base {
     this.attribute("files_mapped", "integer", { default: 0 });
     this.attribute("files_total", "integer", { default: 0 });
     this.attribute("misplaced", "integer", { default: 0 });
+    this.attribute("assertion_count_mismatch", "integer", { default: 0 });
+    this.attribute("assertion_kind_mismatch", "integer", { default: 0 });
   }
 }
 
@@ -654,6 +656,13 @@ async function migrateDb(adapter: SQLite3Adapter) {
       });
     }
 
+    for (const col of ["assertion_count_mismatch", "assertion_kind_mismatch"]) {
+      if (await columnExists(adapter, "test_compare_stats", col)) continue;
+      await adapter.executeMutation(
+        `ALTER TABLE test_compare_stats ADD COLUMN ${col} INTEGER DEFAULT 0`,
+      );
+    }
+
     for (const table of ["api_calls_stats", "api_call_args_stats"]) {
       if (await tableExists(adapter, table)) continue;
       await adapter.createTable(table, {}, (t) => {
@@ -860,6 +869,8 @@ async function migrateDb(adapter: SQLite3Adapter) {
       t.integer("files_mapped", { default: 0 });
       t.integer("files_total", { default: 0 });
       t.integer("misplaced", { default: 0 });
+      t.integer("assertion_count_mismatch", { default: 0 });
+      t.integer("assertion_kind_mismatch", { default: 0 });
       t.index(["merge_commit_sha", "package"], { unique: true });
     });
 
@@ -2115,6 +2126,8 @@ async function syncCompareStats(
           files_mapped: s.filesMapped,
           files_total: s.filesTotal,
           misplaced: s.misplaced,
+          assertion_count_mismatch: s.assertionCountMismatch,
+          assertion_kind_mismatch: s.assertionKindMismatch,
         })),
         { uniqueBy: ["merge_commit_sha", "package"] },
       );


### PR DESCRIPTION
Same shape as #6339, for the test side.

## Why

The `test:compare` summary already carries two advisory counters per package:

```
activerecord — 8231/8407 tests (97.9%) (7 skipped, 6 wrong describe,
  1979 assertion-count-mismatch (see --assertions),
  4067 assertion-kind-mismatch (see --assertions))  |  278/278 files  |  0 misplaced
```

`parseTestCompareFromLogs` captured the whole parenthetical in its `details` group but only ever read `skipped` out of it, so both counters were discarded. They are the interesting burndown on the test side — the test exists and is mapped, but its body doesn't check the same things — and nothing could chart them.

## What

- `assertionCountMismatch` / `assertionKindMismatch` parsed off the same `details` group.
- Two counter columns on `test_compare_stats` beside `skipped` and `misplaced`, added to existing DBs with `ALTER TABLE ... ADD COLUMN ... DEFAULT 0`.
- Both default to 0, which is also the honest answer for the pre-#3825 summary format — it carries no counters at all.

Because these are columns on an existing table rather than a new table, `--reparse-logs` backfills the full history in one pass, and the counters are advisory so nothing about the tests percent changes.

## Tests

Extended fixtures plus a case pinned to the real activerecord line, which checks the counters are read without being confused for `skipped` — the same parenthetical carries all three.