### PR TITLE
feat(parity): AR closure rollup; test:stubs read-only by default

### DIFF
--- a/scripts/api-compare/ar-closure.test.ts
+++ b/scripts/api-compare/ar-closure.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { deriveArClosure, DATA_LAYER_PACKAGES } from "./ar-closure.js";
+
+describe("deriveArClosure", () => {
+  const closure = deriveArClosure();
+
+  it("includes activesupport files ActiveRecord requires directly", () => {
+    // active_record/base.rb requires "active_support/core_ext/module/attribute_accessors".
+    expect(closure.files.activesupport).toContain("core_ext/module/attribute_accessors.rb");
+  });
+
+  it("expands umbrella require-lists transitively", () => {
+    // active_support/rails.rb → core_ext/module/delegation; core_ext/array.rb →
+    // core_ext/array/*.rb. Neither is named anywhere in this repo.
+    expect(closure.files.activesupport).toContain("core_ext/module/delegation.rb");
+    expect(closure.files.activesupport).toContain("core_ext/array/wrap.rb");
+  });
+
+  it("omits activesupport files outside the closure", () => {
+    // Required by actionpack/actionview, never by ActiveRecord or ActiveModel.
+    expect(closure.files.activesupport).not.toContain("core_ext/uri.rb");
+  });
+
+  it("does not report the data-layer packages, which are rolled up whole", () => {
+    for (const pkg of DATA_LAYER_PACKAGES) {
+      expect(closure.files[pkg]).toBeUndefined();
+    }
+  });
+
+  it("reports paths relative to the package root, not the gem lib dir", () => {
+    for (const file of closure.files.activesupport ?? []) {
+      expect(file.startsWith("active_support/")).toBe(false);
+      expect(file.endsWith(".rb")).toBe(true);
+    }
+  });
+});

--- a/scripts/api-compare/ar-closure.test.ts
+++ b/scripts/api-compare/ar-closure.test.ts
@@ -1,36 +1,98 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
 import { deriveArClosure, DATA_LAYER_PACKAGES } from "./ar-closure.js";
 
+const REAL_VENDOR = path.resolve(__dirname, "../../vendor/rails/activerecord/lib/active_record.rb");
+
+function write(root: string, rel: string, body: string): void {
+  const full = path.join(root, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, body);
+}
+
 describe("deriveArClosure", () => {
-  const closure = deriveArClosure();
+  let root: string;
+
+  beforeAll(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "ar-closure-"));
+    write(
+      root,
+      "vendor/rails/activerecord/lib/active_record/base.rb",
+      'require "active_support/core_ext/module/attribute_accessors"\nrequire "active_support/core_ext/array"\n',
+    );
+    write(
+      root,
+      "vendor/rails/activemodel/lib/active_model/naming.rb",
+      'require "i18n"\nrequire "action_dispatch/http/response"\n',
+    );
+    write(
+      root,
+      "vendor/rails/activesupport/lib/active_support/core_ext/module/attribute_accessors.rb",
+      "",
+    );
+    // An umbrella: a file whose whole body is a require list.
+    write(
+      root,
+      "vendor/rails/activesupport/lib/active_support/core_ext/array.rb",
+      'require "active_support/core_ext/array/wrap"\n',
+    );
+    write(root, "vendor/rails/activesupport/lib/active_support/core_ext/array/wrap.rb", "");
+    // Vendored but never required by AR/AM.
+    write(root, "vendor/rails/activesupport/lib/active_support/core_ext/uri.rb", "");
+    write(root, "vendor/i18n/lib/i18n.rb", 'require "i18n/backend"\n');
+    write(root, "vendor/i18n/lib/i18n/backend.rb", "");
+  });
+
+  afterAll(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
 
   it("includes activesupport files ActiveRecord requires directly", () => {
-    // active_record/base.rb requires "active_support/core_ext/module/attribute_accessors".
-    expect(closure.files.activesupport).toContain("core_ext/module/attribute_accessors.rb");
+    expect(deriveArClosure(root).files.activesupport).toContain(
+      "core_ext/module/attribute_accessors.rb",
+    );
   });
 
   it("expands umbrella require-lists transitively", () => {
-    // active_support/rails.rb → core_ext/module/delegation; core_ext/array.rb →
-    // core_ext/array/*.rb. Neither is named anywhere in this repo.
-    expect(closure.files.activesupport).toContain("core_ext/module/delegation.rb");
-    expect(closure.files.activesupport).toContain("core_ext/array/wrap.rb");
+    expect(deriveArClosure(root).files.activesupport).toContain("core_ext/array/wrap.rb");
   });
 
-  it("omits activesupport files outside the closure", () => {
-    // Required by actionpack/actionview, never by ActiveRecord or ActiveModel.
-    expect(closure.files.activesupport).not.toContain("core_ext/uri.rb");
+  it("omits vendored files nothing in the data layer requires", () => {
+    expect(deriveArClosure(root).files.activesupport).not.toContain("core_ext/uri.rb");
+  });
+
+  it("follows requires into the other support gems", () => {
+    // i18n.rb is the gem entrypoint, above the package root, so only what it
+    // pulls in lands in the closure.
+    expect(deriveArClosure(root).files.i18n).toEqual(["backend.rb"]);
+  });
+
+  it("stops at a require reaching a package outside the closure", () => {
+    expect(deriveArClosure(root).files.actiondispatch).toBeUndefined();
   });
 
   it("does not report the data-layer packages, which are rolled up whole", () => {
     for (const pkg of DATA_LAYER_PACKAGES) {
-      expect(closure.files[pkg]).toBeUndefined();
+      expect(deriveArClosure(root).files[pkg]).toBeUndefined();
     }
   });
 
   it("reports paths relative to the package root, not the gem lib dir", () => {
-    for (const file of closure.files.activesupport ?? []) {
+    for (const file of deriveArClosure(root).files.activesupport ?? []) {
       expect(file.startsWith("active_support/")).toBe(false);
       expect(file.endsWith(".rb")).toBe(true);
     }
+  });
+
+  // The vendored gems are fetched for the compare jobs, not for Unit Tests.
+  describe.skipIf(!fs.existsSync(REAL_VENDOR))("against the vendored Rails source", () => {
+    it("derives the real activesupport closure", () => {
+      const files = deriveArClosure().files.activesupport ?? [];
+      expect(files).toContain("core_ext/module/delegation.rb");
+      expect(files).toContain("core_ext/array/wrap.rb");
+      expect(files).not.toContain("core_ext/uri.rb");
+    });
   });
 });

--- a/scripts/api-compare/ar-closure.ts
+++ b/scripts/api-compare/ar-closure.ts
@@ -63,16 +63,16 @@ interface GemRoot {
  */
 const CLOSURE_PACKAGES = ["activesupport", "date", "i18n", "globalid", "did-you-mean"];
 
-function gemRoots(): GemRoot[] {
+function gemRoots(rootDir: string): GemRoot[] {
   const roots: GemRoot[] = [];
   for (const source of SOURCES) {
     for (const pkg of source.packages) {
       if (!CLOSURE_PACKAGES.includes(pkg.name)) continue;
-      const packageRoot = path.join(ROOT_DIR, "vendor", source.name, pkg.libPath);
+      const packageRoot = path.join(rootDir, "vendor", source.name, pkg.libPath);
       const segments = pkg.libPath.split("/");
       const libIndex = segments.lastIndexOf("lib");
       if (libIndex === -1) continue;
-      const libDir = path.join(ROOT_DIR, "vendor", source.name, ...segments.slice(0, libIndex + 1));
+      const libDir = path.join(rootDir, "vendor", source.name, ...segments.slice(0, libIndex + 1));
       roots.push({ package: pkg.name, libDir, packageRoot });
     }
   }
@@ -112,14 +112,20 @@ export interface ArClosure {
   files: Record<string, string[]>;
 }
 
-/** Walk the AR/AM requires transitively and return the support-gem file set. */
-export function deriveArClosure(): ArClosure {
-  const roots = gemRoots();
-  const seeds: string[] = SEED_FILES.map((f) => path.join(ROOT_DIR, "vendor/rails", f)).filter(
-    (f) => fs.existsSync(f),
+/**
+ * Walk the AR/AM requires transitively and return the support-gem file set.
+ *
+ * `rootDir` is the repo root the vendored gems hang off; the tests point it at
+ * a synthetic vendor tree so the derivation is asserted without a populated
+ * `vendor/rails` (the Unit Tests job does not fetch one).
+ */
+export function deriveArClosure(rootDir: string = ROOT_DIR): ArClosure {
+  const roots = gemRoots(rootDir);
+  const seeds: string[] = SEED_FILES.map((f) => path.join(rootDir, "vendor/rails", f)).filter((f) =>
+    fs.existsSync(f),
   );
   for (const dir of SEED_DIRS) {
-    seeds.push(...walkRubyFiles(path.join(ROOT_DIR, "vendor/rails", dir)));
+    seeds.push(...walkRubyFiles(path.join(rootDir, "vendor/rails", dir)));
   }
 
   const visited = new Set<string>();

--- a/scripts/api-compare/ar-closure.ts
+++ b/scripts/api-compare/ar-closure.ts
@@ -1,0 +1,174 @@
+/**
+ * AR/AM require closure.
+ *
+ * The project's scope for the support gems (activesupport, i18n, globalid,
+ * date, did-you-mean) is not the whole gem — it is the set of files
+ * ActiveRecord and ActiveModel actually `require`. Rolling up whole packages
+ * mixes in hundreds of out-of-scope members (actionpack's share of
+ * activesupport, i18n's backends, …) and understates parity for the code the
+ * data layer depends on.
+ *
+ * This module derives that set by walking `require "…"` lines from
+ * `vendor/rails/{activerecord,activemodel}/lib` transitively. Umbrella files
+ * (`active_support.rb`, `active_support/rails.rb`,
+ * `active_support/core_ext/array.rb`, …) are require-lists themselves, so the
+ * transitive walk expands them without a hand-written list.
+ *
+ * The result is written to `output/ar-closure.json` and read by compare.ts to
+ * print the "AR closure" rollup. Regenerating from vendor/rails means a moved
+ * `require` changes the scope with no code change.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { SOURCES } from "../../vendor/sources.js";
+import { OUTPUT_DIR, ROOT_DIR } from "./config.js";
+
+/** Packages measured whole — the data layer itself. */
+export const DATA_LAYER_PACKAGES = ["arel", "activemodel", "activerecord"];
+
+/** `require "x"` / `require "x"` with a trailing comment; not require_relative. */
+const REQUIRE_RE = /^\s*require\s+["']([^"']+)["']/;
+
+/**
+ * Entry points whose requires seed the closure — the data layer's own lib
+ * trees. `activerecord/lib/rails` (the generators) is deliberately left out:
+ * it pulls railties and actionpack in behind it, which are not data-layer
+ * scope.
+ */
+const SEED_DIRS = [
+  "activerecord/lib/active_record",
+  "activerecord/lib/arel",
+  "activemodel/lib/active_model",
+];
+const SEED_FILES = [
+  "activerecord/lib/active_record.rb",
+  "activerecord/lib/arel.rb",
+  "activemodel/lib/active_model.rb",
+];
+
+interface GemRoot {
+  /** api-compare package key, e.g. "activesupport". */
+  package: string;
+  /** Absolute path of the gem's `lib` dir — what a `require` resolves against. */
+  libDir: string;
+  /** Absolute path of the package root — what a rubyFile is relative to. */
+  packageRoot: string;
+}
+
+/**
+ * Support gems whose files enter the closure one at a time. The data-layer
+ * packages are rolled up whole, and the web-layer gems are out of scope, so a
+ * require reaching either resolves to nothing and stops the walk there.
+ */
+const CLOSURE_PACKAGES = ["activesupport", "date", "i18n", "globalid", "did-you-mean"];
+
+function gemRoots(): GemRoot[] {
+  const roots: GemRoot[] = [];
+  for (const source of SOURCES) {
+    for (const pkg of source.packages) {
+      if (!CLOSURE_PACKAGES.includes(pkg.name)) continue;
+      const packageRoot = path.join(ROOT_DIR, "vendor", source.name, pkg.libPath);
+      const segments = pkg.libPath.split("/");
+      const libIndex = segments.lastIndexOf("lib");
+      if (libIndex === -1) continue;
+      const libDir = path.join(ROOT_DIR, "vendor", source.name, ...segments.slice(0, libIndex + 1));
+      roots.push({ package: pkg.name, libDir, packageRoot });
+    }
+  }
+  return roots;
+}
+
+function walkRubyFiles(dir: string, out: string[] = []): string[] {
+  if (!fs.existsSync(dir)) return out;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walkRubyFiles(full, out);
+    else if (entry.name.endsWith(".rb")) out.push(full);
+  }
+  return out;
+}
+
+function requiresIn(filePath: string): string[] {
+  const out: string[] = [];
+  for (const line of fs.readFileSync(filePath, "utf-8").split("\n")) {
+    const m = REQUIRE_RE.exec(line);
+    if (m) out.push(m[1]);
+  }
+  return out;
+}
+
+/** Resolve a Ruby require path to a vendored .rb file, or null if unvendored. */
+function resolveRequire(req: string, roots: GemRoot[]): string | null {
+  for (const root of roots) {
+    const candidate = path.join(root.libDir, `${req}.rb`);
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+export interface ArClosure {
+  /** package → sorted rubyFile paths (relative to the package root). */
+  files: Record<string, string[]>;
+}
+
+/** Walk the AR/AM requires transitively and return the support-gem file set. */
+export function deriveArClosure(): ArClosure {
+  const roots = gemRoots();
+  const seeds: string[] = SEED_FILES.map((f) => path.join(ROOT_DIR, "vendor/rails", f)).filter(
+    (f) => fs.existsSync(f),
+  );
+  for (const dir of SEED_DIRS) {
+    seeds.push(...walkRubyFiles(path.join(ROOT_DIR, "vendor/rails", dir)));
+  }
+
+  const visited = new Set<string>();
+  const queue: string[] = [];
+  for (const seed of seeds) {
+    for (const req of requiresIn(seed)) {
+      const resolved = resolveRequire(req, roots);
+      if (resolved && !visited.has(resolved)) {
+        visited.add(resolved);
+        queue.push(resolved);
+      }
+    }
+  }
+
+  while (queue.length > 0) {
+    const file = queue.pop()!;
+    for (const req of requiresIn(file)) {
+      const resolved = resolveRequire(req, roots);
+      if (resolved && !visited.has(resolved)) {
+        visited.add(resolved);
+        queue.push(resolved);
+      }
+    }
+  }
+
+  const files: Record<string, string[]> = {};
+  for (const file of visited) {
+    for (const root of roots) {
+      const rel = path.relative(root.packageRoot, file);
+      // An umbrella entrypoint like lib/active_support.rb sits above the
+      // package root, so it escapes with "..": it seeds the walk but is not
+      // itself part of the compared population.
+      if (rel.startsWith("..") || path.isAbsolute(rel)) continue;
+      (files[root.package] ??= []).push(rel);
+      break;
+    }
+  }
+  for (const list of Object.values(files)) list.sort();
+
+  return { files };
+}
+
+/** Regenerate the artifact from vendor/rails and return it. */
+export function writeArClosure(): ArClosure {
+  const closure = deriveArClosure();
+  fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+  fs.writeFileSync(
+    path.join(OUTPUT_DIR, "ar-closure.json"),
+    `${JSON.stringify(closure, null, 2)}\n`,
+  );
+  return closure;
+}

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -83,6 +83,7 @@ import {
   packageSrcDir,
 } from "./config.js";
 import { SpellChecker } from "../../packages/did-you-mean/src/spell-checker.js";
+import { DATA_LAYER_PACKAGES, writeArClosure } from "./ar-closure.js";
 import {
   hasRubyFileTsOverride,
   isArityOverridden,
@@ -3355,7 +3356,7 @@ function printReport(
   }
 
   // Data layer summary (arel + activemodel + activerecord)
-  const DATA_LAYER = new Set(["arel", "activemodel", "activerecord"]);
+  const DATA_LAYER = new Set(DATA_LAYER_PACKAGES);
   let dataTotal = 0;
   let dataMatched = 0;
   let dataFiles = 0;
@@ -3369,12 +3370,40 @@ function printReport(
     }
   }
 
+  // AR closure summary: the data layer plus only the support-gem files that
+  // ActiveRecord/ActiveModel actually require (RFC 0092). The file set is
+  // regenerated from vendor/rails on every run, so a moved `require` moves the
+  // scope without a code change here.
+  const closure = writeArClosure();
+  let closureTotal = dataTotal;
+  let closureMatched = dataMatched;
+  let closureFiles = dataFiles;
+  let closureFilesExist = dataFilesExist;
+  for (const pkg of results) {
+    const inScope = closure.files[pkg.package];
+    if (!inScope || DATA_LAYER.has(pkg.package)) continue;
+    const inScopeSet = new Set(inScope);
+    for (const f of pkg.files) {
+      if (!inScopeSet.has(f.rubyFile)) continue;
+      closureTotal += f.total;
+      closureMatched += f.matched;
+      closureFiles += 1;
+      if (f.tsFileExists) closureFilesExist += 1;
+    }
+  }
+
   const grandPct = grandTotal > 0 ? Math.round((grandMatched / grandTotal) * 1000) / 10 : 0;
   const dataPct = dataTotal > 0 ? Math.round((dataMatched / dataTotal) * 1000) / 10 : 0;
+  const closurePct = closureTotal > 0 ? Math.round((closureMatched / closureTotal) * 1000) / 10 : 0;
   console.log(`\n${"=".repeat(100)}`);
   if (dataTotal > 0 && dataTotal !== grandTotal) {
     console.log(
       `  Data layer: ${dataMatched}/${dataTotal} methods (${dataPct}%)  |  files: ${dataFilesExist}/${dataFiles}`,
+    );
+  }
+  if (closureTotal > dataTotal) {
+    console.log(
+      `  AR closure: ${closureMatched}/${closureTotal} methods (${closurePct}%)  |  files: ${closureFilesExist}/${closureFiles}`,
     );
   }
   const inhPct =

--- a/scripts/parity/README.md
+++ b/scripts/parity/README.md
@@ -53,6 +53,24 @@ licence to write the old names in a comment, a doc or a script. The fix for a
 hit is always the `parity:*` spelling — the three-entry allowlist in
 `legacy-script-names.ts` is closed.
 
+## Everything in the namespace is read-only unless asked to write
+
+A bare `parity:*` invocation reports and exits; writing is always an explicit
+flag (`--write` on the ratchets, `--reseed` on the baselines). That includes
+`parity:test:stubs`, which lists the stub files it _would_ generate and creates
+none until you pass `--write` — it used to write by default, and a single
+verification run once produced 200 files that a `git add -A` swept into a
+commit.
+
+## The AR closure rollup
+
+`parity:api` prints an `AR closure` line beside `Data layer`: the data-layer
+packages plus only those support-gem files ActiveRecord/ActiveModel actually
+`require`. `api-compare/ar-closure.ts` derives that file set by walking
+`require` lines from `vendor/rails/{activerecord,activemodel}/lib`
+transitively and writes `api-compare/output/ar-closure.json` on every run, so a
+moved `require` changes the scope with no code change.
+
 ## Baselines, marks and excludes
 
 Every file below records **known, unfixed divergence**. They are all

--- a/scripts/test-compare/generate-stubs.ts
+++ b/scripts/test-compare/generate-stubs.ts
@@ -211,7 +211,7 @@ function main() {
       const content = generateStubContent(testsToStub);
 
       if (!write) {
-        console.log(`  [dry-run] ${tsFullPath} (${testsToStub.length} tests)`);
+        console.log(`  [report] ${tsFullPath} (${testsToStub.length} tests)`);
       } else {
         const dir = path.dirname(tsFullPath);
         fs.mkdirSync(dir, { recursive: true });

--- a/scripts/test-compare/generate-stubs.ts
+++ b/scripts/test-compare/generate-stubs.ts
@@ -7,7 +7,11 @@
  * with properly nested describe blocks matching the Ruby test hierarchy.
  *
  * Usage:
- *   npx tsx scripts/test-compare/generate-stubs.ts [--package activerecord] [--dry-run] [--missing-files-only]
+ * Read-only by default: reports what it would generate and writes nothing.
+ * Pass --write to actually create the stub files.
+ *
+ * Usage:
+ *   npx tsx scripts/test-compare/generate-stubs.ts [--package activerecord] [--write] [--missing-files-only]
  */
 
 import * as fs from "fs";
@@ -118,7 +122,7 @@ function generateStubContent(testCases: TestCaseInfo[]): string {
 function main() {
   const args = process.argv.slice(2);
   const filterPkg = args.includes("--package") ? args[args.indexOf("--package") + 1] : null;
-  const dryRun = args.includes("--dry-run");
+  const write = args.includes("--write");
   const missingFilesOnly = args.includes("--missing-files-only");
 
   const railsPath = path.join(OUTPUT_DIR, "rails-tests.json");
@@ -206,7 +210,7 @@ function main() {
 
       const content = generateStubContent(testsToStub);
 
-      if (dryRun) {
+      if (!write) {
         console.log(`  [dry-run] ${tsFullPath} (${testsToStub.length} tests)`);
       } else {
         const dir = path.dirname(tsFullPath);
@@ -231,7 +235,13 @@ function main() {
     }
   }
 
-  console.log(`\n  Total: ${totalGenerated} test stubs across ${totalFiles} files`);
+  const verb = write ? "written" : "would be generated";
+  console.log(`\n  Total: ${totalGenerated} test stubs across ${totalFiles} files ${verb}`);
+  if (!write && totalFiles > 0) {
+    console.log(
+      `  No files written (read-only by default) — re-run with --write to generate them.`,
+    );
+  }
 }
 
 main();


### PR DESCRIPTION
Three RFC 0092 stories.

**AR closure rollup** — `parity:api` now prints an `AR closure` line next to
`Data layer`: the data-layer packages plus only the activesupport / i18n / date
files that ActiveRecord and ActiveModel actually `require`.
`scripts/api-compare/ar-closure.ts` derives that set by walking `require "…"`
lines from `vendor/rails/{activerecord,activemodel}/lib` transitively (umbrella
files like `active_support/rails.rb` and `core_ext/array.rb` are require-lists,
so they expand without a hand list) and writes
`scripts/api-compare/output/ar-closure.json`, which the rollup reads. A moved
`require` moves the scope with no code change.

Measured: `AR closure: 8404/9071 methods (92.6%) | files: 497/532` — activesupport
143 files, i18n 5, date 1. globalid and did-you-mean are named as in-scope gems by
the story context but the real closure never reaches them (neither is `require`d
anywhere under `vendor/rails/{activerecord,activemodel,activesupport}/lib`), so
they contribute nothing; that is the derivation working, not a gap. Whole-package
summaries and the Data layer line are unchanged.

*Correction to the story context:* it says to reuse `lint-deps.ts`'s require
parsing. `lint-deps.ts` has no require-line parser — its dep data comes from
`extract-ruby-api.rb`'s `detect_deps`, a method-*body* scanner unrelated to
`require` statements. There was nothing to reuse, so `REQUIRE_RE` in
`ar-closure.ts` is the first and only such parser.

**`test:stubs` is read-only by default** — `generate-stubs.ts` wrote 200 files on
a bare run (see the story: PR #6263 swept them into a commit). The default is now
the report; generation moved behind `--write`, matching the ratchets. No in-repo
caller relied on the old default (`package.json` is the only reference).

**Legacy spellings swept out of the tasks repo** — 4149 hits across 1917 story
bodies rewritten onto their `parity:*` names, so
`delete-legacy-compare-script-aliases` cannot turn a copy-pasted story body into
a broken command. Landed in `blazetrailsdev/tasks@6583e818b`; the four
meta-stories *about* the rename were reworded to point at `LEGACY_SCRIPT_NAMES`
rather than re-listing the retired names, and
`delete-legacy-compare-script-aliases` now records this sweep as a prerequisite.
The gate's population is unchanged — `tasks/` stays in `SKIPPED_DIRS`.

Closes-story: ar-closure-rollup-in-parity-summaries
Closes-story: sweep-legacy-script-spellings-in-the-tasks-repo
Closes-story: test-stubs-writes-files-by-default
