### PR TITLE
refactor(arel): collector takes Rails' parameter position in the to_sql visitor helpers

### DIFF
--- a/packages/arel/src/visitors/mysql.ts
+++ b/packages/arel/src/visitors/mysql.ts
@@ -57,7 +57,7 @@ export class MySQL extends ToSql {
 
     if (node.orders.length > 0) {
       collector.append(" ORDER BY ");
-      this.injectJoin(node.orders, ", ", collector);
+      this.injectJoin(node.orders, collector, ", ");
     }
 
     if (node.limit) {

--- a/packages/arel/src/visitors/sqlite.ts
+++ b/packages/arel/src/visitors/sqlite.ts
@@ -30,7 +30,7 @@ export class SQLite extends ToSql {
 
     if (node.orders.length > 0) {
       collector.append(" ORDER BY ");
-      this.injectJoin(node.orders, ", ", collector);
+      this.injectJoin(node.orders, collector, ", ");
     }
 
     if (node.limit) {
@@ -88,9 +88,9 @@ export class SQLite extends ToSql {
    */
   protected override infixValueWithParen(
     o: Node & { left: Node; right: Node },
+    collector: SQLString,
     value: string,
     suppressParens = false,
-    collector: SQLString,
   ): SQLString {
     const sameClass = (child: Node): child is typeof o =>
       Object.getPrototypeOf(child) === Object.getPrototypeOf(o);
@@ -98,16 +98,16 @@ export class SQLite extends ToSql {
     if (!suppressParens) collector.append("( ");
     const left = this.unwrapGrouping(o.left);
     if (sameClass(left)) {
-      this.infixValueWithParen(left, value, true, collector);
+      this.infixValueWithParen(left, collector, value, true);
     } else {
-      this.groupingParentheses(left, false, collector);
+      this.groupingParentheses(left, collector, false);
     }
     collector.append(value);
     const right = this.unwrapGrouping(o.right);
     if (sameClass(right)) {
-      this.infixValueWithParen(right, value, true, collector);
+      this.infixValueWithParen(right, collector, value, true);
     } else {
-      this.groupingParentheses(right, false, collector);
+      this.groupingParentheses(right, collector, false);
     }
     if (!suppressParens) collector.append(" )");
     return collector;

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -240,7 +240,7 @@ export class ToSql extends Visitor {
 
     if (node.orders.length > 0) {
       collector.append(" ORDER BY ");
-      this.injectJoin(node.orders, ", ", collector);
+      this.injectJoin(node.orders, collector, ", ");
     }
 
     if (node.limit) {
@@ -262,7 +262,7 @@ export class ToSql extends Visitor {
 
     if (node.values.length > 0) {
       collector.append(" SET ");
-      this.injectJoin(node.values, ", ", collector);
+      this.injectJoin(node.values, collector, ", ");
     }
 
     if (node.wheres.length > 0) {
@@ -273,7 +273,7 @@ export class ToSql extends Visitor {
 
     if (node.orders.length > 0) {
       collector.append(" ORDER BY ");
-      this.injectJoin(node.orders, ", ", collector);
+      this.injectJoin(node.orders, collector, ", ");
     }
 
     if (node.limit) {
@@ -414,7 +414,7 @@ export class ToSql extends Visitor {
 
     if (node.orders.length > 0) {
       collector.append(" ORDER BY ");
-      this.injectJoin(node.orders, ", ", collector);
+      this.injectJoin(node.orders, collector, ", ");
     }
 
     if (node.limit) {
@@ -458,17 +458,17 @@ export class ToSql extends Visitor {
     this.collectOptimizerHints(node, collector);
     this.maybeVisit(node.setQuantifier ?? null, collector);
 
-    this.collectNodesFor(node.projections, " ", ", ", collector);
+    this.collectNodesFor(node.projections, collector, " ", ", ");
 
     if (node.source && !node.source.isEmpty()) {
       collector.append(" FROM ");
       this.visit(node.source, collector);
     }
 
-    this.collectNodesFor(node.wheres, " WHERE ", " AND ", collector);
-    this.collectNodesFor(node.groups, " GROUP BY ", ", ", collector);
-    this.collectNodesFor(node.havings, " HAVING ", " AND ", collector);
-    this.collectNodesFor(node.windows, " WINDOW ", ", ", collector);
+    this.collectNodesFor(node.wheres, collector, " WHERE ", " AND ");
+    this.collectNodesFor(node.groups, collector, " GROUP BY ", ", ");
+    this.collectNodesFor(node.havings, collector, " HAVING ", " AND ");
+    this.collectNodesFor(node.windows, collector, " WINDOW ", ", ");
 
     this.maybeVisit(node.comment ?? null, collector);
 
@@ -645,13 +645,13 @@ export class ToSql extends Visitor {
    */
   protected collectNodesFor(
     nodes: Node[],
+    collector: SQLString,
     spacer: string,
     connector = ", ",
-    collector: SQLString,
   ): SQLString {
     if (nodes.length === 0) return collector;
     collector.append(spacer);
-    this.injectJoin(nodes, connector, collector);
+    this.injectJoin(nodes, collector, connector);
     return collector;
   }
 
@@ -694,23 +694,23 @@ export class ToSql extends Visitor {
   // -- Set operations --
 
   protected visitArelNodesUnion(node: Nodes.Union, collector: SQLString): SQLString {
-    return this.infixValueWithParen(node, " UNION ", false, collector);
+    return this.infixValueWithParen(node, collector, " UNION ", false);
   }
 
   protected visitArelNodesUnionAll(node: Nodes.UnionAll, collector: SQLString): SQLString {
-    return this.infixValueWithParen(node, " UNION ALL ", false, collector);
+    return this.infixValueWithParen(node, collector, " UNION ALL ", false);
   }
 
   protected visitArelNodesIntersect(node: Nodes.Intersect, collector: SQLString): SQLString {
     collector.append("( ");
-    this.infixValue(node, " INTERSECT ", collector);
+    this.infixValue(node, collector, " INTERSECT ");
     collector.append(" )");
     return collector;
   }
 
   protected visitArelNodesExcept(node: Nodes.Except, collector: SQLString): SQLString {
     collector.append("( ");
-    this.infixValue(node, " EXCEPT ", collector);
+    this.infixValue(node, collector, " EXCEPT ");
     collector.append(" )");
     return collector;
   }
@@ -726,12 +726,12 @@ export class ToSql extends Visitor {
     collector.append("(");
     if (node.partitions.length > 0) {
       collector.append("PARTITION BY ");
-      this.injectJoin(node.partitions, ", ", collector);
+      this.injectJoin(node.partitions, collector, ", ");
     }
     if (node.orders.length > 0) {
       if (node.partitions.length > 0) collector.append(" ");
       collector.append("ORDER BY ");
-      this.injectJoin(node.orders, ", ", collector);
+      this.injectJoin(node.orders, collector, ", ");
     }
     if (node.framing) {
       if (node.partitions.length > 0 || node.orders.length > 0) collector.append(" ");
@@ -929,7 +929,7 @@ export class ToSql extends Visitor {
     collector.append(node.name);
     collector.append("(");
     if (node.distinct) collector.append("DISTINCT ");
-    this.injectJoin(node.expressions, ", ", collector);
+    this.injectJoin(node.expressions, collector, ", ");
     collector.append(")");
     if (node.alias) {
       collector.append(" AS ");
@@ -1059,7 +1059,7 @@ export class ToSql extends Visitor {
     if (node.left) this.visit(node.left, collector);
     if (node.right.length > 0) {
       if (node.left) collector.append(" ");
-      this.injectJoin(node.right, " ", collector);
+      this.injectJoin(node.right, collector, " ");
     }
     return collector;
   }
@@ -1653,7 +1653,7 @@ export class ToSql extends Visitor {
   }
 
   protected visitArelNodesFragments(node: Nodes.Fragments, collector: SQLString): SQLString {
-    return this.injectJoin(node.values, " ", collector);
+    return this.injectJoin(node.values, collector, " ");
   }
 
   /**
@@ -1718,7 +1718,7 @@ export class ToSql extends Visitor {
    * Mirrors `to_sql.rb#inject_join`: visits `list[0]`, then for each
    * subsequent node emits `joinStr` and visits.
    */
-  protected injectJoin(list: Node[], joinStr: string, collector: SQLString): SQLString {
+  protected injectJoin(list: Node[], collector: SQLString, joinStr: string): SQLString {
     list.forEach((n, i) => {
       if (i > 0) collector.append(joinStr);
       this.visit(n, collector);
@@ -1822,8 +1822,8 @@ export class ToSql extends Visitor {
   /** Mirrors `to_sql.rb#infix_value`. Visits left, emits literal, visits right. */
   protected infixValue(
     o: { left: Node; right: Node },
-    value: string,
     collector: SQLString,
+    value: string,
   ): SQLString {
     this.visit(o.left, collector);
     collector.append(value);
@@ -1838,24 +1838,24 @@ export class ToSql extends Visitor {
    */
   protected infixValueWithParen(
     o: Node & { left: Node; right: Node },
+    collector: SQLString,
     value: string,
     suppressParens = false,
-    collector: SQLString,
   ): SQLString {
     const sameClass = (child: Node): child is typeof o =>
       Object.getPrototypeOf(child) === Object.getPrototypeOf(o);
 
     if (!suppressParens) collector.append("( ");
     if (sameClass(o.left)) {
-      this.infixValueWithParen(o.left, value, true, collector);
+      this.infixValueWithParen(o.left, collector, value, true);
     } else {
-      this.groupingParentheses(o.left, false, collector);
+      this.groupingParentheses(o.left, collector, false);
     }
     collector.append(value);
     if (sameClass(o.right)) {
-      this.infixValueWithParen(o.right, value, true, collector);
+      this.infixValueWithParen(o.right, collector, value, true);
     } else {
-      this.groupingParentheses(o.right, false, collector);
+      this.groupingParentheses(o.right, collector, false);
     }
     if (!suppressParens) collector.append(" )");
     return collector;
@@ -1867,8 +1867,8 @@ export class ToSql extends Visitor {
    */
   protected groupingParentheses(
     o: Node,
-    alwaysWrapSelects = true,
     collector: SQLString,
+    alwaysWrapSelects = true,
   ): SQLString {
     if (o instanceof Nodes.SelectStatement && (alwaysWrapSelects || this.isRequireParentheses(o))) {
       collector.append("(");
@@ -1896,7 +1896,7 @@ export class ToSql extends Visitor {
     collector.retryable = false;
     collector.append(`${name}(`);
     if (o.distinct) collector.append("DISTINCT ");
-    this.injectJoin(o.expressions, ", ", collector);
+    this.injectJoin(o.expressions, collector, ", ");
     collector.append(")");
     if (o.alias) {
       collector.append(" AS ");
@@ -2111,7 +2111,7 @@ export class ToSql extends Visitor {
   protected visitArelNodesLateral(node: Nodes.Lateral, collector: SQLString): SQLString {
     // Mirrors Rails: `collector << "LATERAL "; grouping_parentheses(o.expr, ...)`.
     collector.append("LATERAL ");
-    return this.groupingParentheses(node.subquery, true, collector);
+    return this.groupingParentheses(node.subquery, collector, true);
   }
 
   protected appendEscape(escape: Node | null, collector: SQLString): void {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/association.json
@@ -59,7 +59,7 @@
     "call": "safe_constantize",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at associations/association.rb:341 `fresh_class = reflection.class_name.safe_constantize`: Rails invokes `safe_constantize` on a built-in receiver (a Ruby String/Hash/Object/Enumerable method or the ActiveSupport core-ext on one). TS cannot monkey-patch those prototypes, so the port calls the free function with that receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/association.json
@@ -59,7 +59,7 @@
     "call": "safe_constantize",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/builder/belongs-to.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/builder/belongs-to.json
@@ -6,7 +6,7 @@
     "call": "safe_constantize",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/builder/belongs-to.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/builder/belongs-to.json
@@ -6,7 +6,7 @@
     "call": "safe_constantize",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at associations/builder/belongs_to.rb:39 `klass = reflection.class_name.safe_constantize`: Rails invokes `safe_constantize` on a built-in receiver (a Ruby String/Hash/Object/Enumerable method or the ActiveSupport core-ext on one). TS cannot monkey-patch those prototypes, so the port calls the free function with that receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/builder/collection-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/builder/collection-association.json
@@ -13,6 +13,6 @@
     "call": "singularize",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/builder/collection-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/builder/collection-association.json
@@ -13,6 +13,6 @@
     "call": "singularize",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at associations/builder/collection_association.rb:62 `def #{name.to_s.singularize}_ids`: Rails invokes `singularize` on a built-in receiver (a Ruby String/Hash/Object/Enumerable method or the ActiveSupport core-ext on one). TS cannot monkey-patch those prototypes, so the port calls the free function with that receiver as argument 1; the remaining arguments match Rails exactly."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/builder/has-and-belongs-to-many.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/builder/has-and-belongs-to-many.json
@@ -20,7 +20,7 @@
     "call": "pluralize",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at associations/builder/has_and_belongs_to_many.rb:60 `middle_name = [lhs_model.name.downcase.pluralize,`: Rails invokes `pluralize` on a built-in receiver (a Ruby String/Hash/Object/Enumerable method or the ActiveSupport core-ext on one). TS cannot monkey-patch those prototypes, so the port calls the free function with that receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -50,7 +50,7 @@
     "call": "camelize",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at associations/builder/has_and_belongs_to_many.rb:50 `join_model.name                = \"HABTM_#{association_name.to_s.camelize}\"`: Rails invokes `camelize` on a built-in receiver (a Ruby String/Hash/Object/Enumerable method or the ActiveSupport core-ext on one). TS cannot monkey-patch those prototypes, so the port calls the free function with that receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -66,6 +66,6 @@
     "call": "singularize",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at associations/builder/has_and_belongs_to_many.rb:40 `rhs_name = name.to_s.singularize.to_sym`: Rails invokes `singularize` on a built-in receiver (a Ruby String/Hash/Object/Enumerable method or the ActiveSupport core-ext on one). TS cannot monkey-patch those prototypes, so the port calls the free function with that receiver as argument 1; the remaining arguments match Rails exactly."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/builder/has-and-belongs-to-many.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/builder/has-and-belongs-to-many.json
@@ -20,7 +20,7 @@
     "call": "pluralize",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -50,7 +50,7 @@
     "call": "camelize",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -66,6 +66,6 @@
     "call": "singularize",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-association.json
@@ -38,7 +38,7 @@
     "call": "all",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-association.json
@@ -38,7 +38,7 @@
     "call": "all",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (c) tooling noise, verified at associations/collection_association.rb:81 `klass.all.raise_record_not_found_exception!(...)`: Rails' `all` is the AR scoping method, while the TS occurrence the comparator matched is JS `Promise.all(...)` — a name collision, not the same call."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-many-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-many-association.json
@@ -17,7 +17,7 @@
       "str:restrict_dependent_destroy.has_many",
       "kwargs{record=ref:record}"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: the differing argument is a Ruby Symbol, spelled in trails as the colon-prefixed string the CLAUDE.md Symbol convention requires; same value, different rendering."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-many-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-many-association.json
@@ -17,7 +17,7 @@
       "str:restrict_dependent_destroy.has_many",
       "kwargs{record=ref:record}"
     ],
-    "reason": "RFC 0099 bucket (b) equivalent: the differing argument is a Ruby Symbol, spelled in trails as the colon-prefixed string the CLAUDE.md Symbol convention requires; same value, different rendering."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at associations/has_many_association.rb:22 `owner.errors.add(:base, :'restrict_dependent_destroy.has_many', record: record)`: the differing argument is a Ruby Symbol, spelled in trails as the colon-prefixed string the CLAUDE.md Symbol convention requires — same value, different rendering."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-one-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-one-association.json
@@ -80,7 +80,7 @@
       "str:restrict_dependent_destroy.has_one",
       "kwargs{record=ref:record}"
     ],
-    "reason": "RFC 0099 bucket (b) equivalent: the differing argument is a Ruby Symbol, spelled in trails as the colon-prefixed string the CLAUDE.md Symbol convention requires; same value, different rendering."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at associations/has_one_association.rb:17 `owner.errors.add(:base, :'restrict_dependent_destroy.has_one', record: record)`: the differing argument is a Ruby Symbol, spelled in trails as the colon-prefixed string the CLAUDE.md Symbol convention requires — same value, different rendering."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-one-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-one-association.json
@@ -80,7 +80,7 @@
       "str:restrict_dependent_destroy.has_one",
       "kwargs{record=ref:record}"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: the differing argument is a Ruby Symbol, spelled in trails as the colon-prefixed string the CLAUDE.md Symbol convention requires; same value, different rendering."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/preloader/through-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/preloader/through-association.json
@@ -20,7 +20,7 @@
     "call": "loaded?",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/preloader/through-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/preloader/through-association.json
@@ -20,7 +20,7 @@
     "call": "loaded?",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (c) tooling noise, verified at associations/preloader/through_association.rb:13 `if loaded?(owner)` and :20 `owners.first.association(through_reflection.name).loaded?`: the body calls `loaded?` twice — once with an owner argument, once on a receiver — and the comparator paired the port's single `loaded(owner)` against the receiverless occurrence."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
@@ -101,7 +101,7 @@
       "ref:expression",
       "ref:options"
     ],
-    "reason": "RFC 0099 bucket (c) tooling noise: the body contains several `new` calls and the comparator pairs the Ruby and TS occurrences positionally, so this row compares a TS error construction against an unrelated Ruby one rather than a matched call site."
+    "reason": "RFC 0099 bucket (c) tooling noise, verified at connection_adapters/abstract_mysql_adapter.rb:542 `CheckConstraintDefinition.new(table_name, expression, options)`: the two bodies each construct more than one object (or the port raises a guard Rails does not), and the comparator pairs the `new` occurrences positionally, so this row compares two unrelated constructions rather than a matched call site."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
@@ -101,7 +101,7 @@
       "ref:expression",
       "ref:options"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (c) tooling noise: the body contains several `new` calls and the comparator pairs the Ruby and TS occurrences positionally, so this row compares a TS error construction against an unrelated Ruby one rather than a matched call site."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-handler.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-handler.json
@@ -62,7 +62,7 @@
       "ref:role",
       "ref:shard"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (c) tooling noise: the body contains several `new` calls and the comparator pairs the Ruby and TS occurrences positionally, so this row compares a TS error construction against an unrelated Ruby one rather than a matched call site."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-handler.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-handler.json
@@ -62,7 +62,7 @@
       "ref:role",
       "ref:shard"
     ],
-    "reason": "RFC 0099 bucket (c) tooling noise: the body contains several `new` calls and the comparator pairs the Ruby and TS occurrences positionally, so this row compares a TS error construction against an unrelated Ruby one rather than a matched call site."
+    "reason": "RFC 0099 bucket (c) tooling noise, verified at connection_adapters/abstract/connection_handler.rb:279 `ConnectionAdapters::PoolConfig.new(connection_name, db_config, role, shard)`: the two bodies each construct more than one object (or the port raises a guard Rails does not), and the comparator pairs the `new` occurrences positionally, so this row compares two unrelated constructions rather than a matched call site."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/schema-definitions.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/schema-definitions.json
@@ -93,7 +93,7 @@
     "call": "pluralize",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -144,6 +144,6 @@
     "call": "singularize",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/schema-definitions.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/schema-definitions.json
@@ -93,7 +93,7 @@
     "call": "pluralize",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at connection_adapters/abstract/schema_definitions.rb:298 `Base.pluralize_table_names ? name.to_s.pluralize : name`: Rails invokes `pluralize` on a built-in receiver (a Ruby String/Hash/Object/Enumerable method or the ActiveSupport core-ext on one). TS cannot monkey-patch those prototypes, so the port calls the free function with that receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -144,6 +144,6 @@
     "call": "singularize",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at connection_adapters/abstract/schema_definitions.rb:397 `pk = primary_key || Base.get_primary_key(table_name.to_s.singularize)`: Rails invokes `singularize` on a built-in receiver (a Ruby String/Hash/Object/Enumerable method or the ActiveSupport core-ext on one). TS cannot monkey-patch those prototypes, so the port calls the free function with that receiver as argument 1; the remaining arguments match Rails exactly."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/schema-statements.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/schema-statements.json
@@ -27,7 +27,7 @@
     "call": "presence",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at connection_adapters/abstract/schema_statements.rb:318 `if table_comment = td.comment.presence`: Rails invokes `presence` on a built-in receiver (a Ruby String/Hash/Object/Enumerable method or the ActiveSupport core-ext on one). TS cannot monkey-patch those prototypes, so the port calls the free function with that receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -111,7 +111,7 @@
     "call": "keys",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at connection_adapters/abstract/schema_statements.rb:1506 `raise ArgumentError, \"Algorithm must be one of the following: #{index_algorithms.keys.map(&:inspect).join(', ')}\"`: Rails invokes `keys` on a built-in receiver (a Ruby String/Hash/Object/Enumerable method or the ActiveSupport core-ext on one). TS cannot monkey-patch those prototypes, so the port calls the free function with that receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -202,7 +202,7 @@
     "call": "pluralize",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at connection_adapters/abstract/schema_statements.rb:1086 `reference_name = Base.pluralize_table_names ? ref_name.to_s.pluralize : ref_name`: Rails invokes `pluralize` on a built-in receiver (a Ruby String/Hash/Object/Enumerable method or the ActiveSupport core-ext on one). TS cannot monkey-patch those prototypes, so the port calls the free function with that receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/schema-statements.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/schema-statements.json
@@ -27,7 +27,7 @@
     "call": "presence",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -111,7 +111,7 @@
     "call": "keys",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -202,7 +202,7 @@
     "call": "pluralize",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/transaction.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/transaction.json
@@ -9,7 +9,7 @@
       "str:afterRollback",
       "ref:block"
     ],
-    "reason": "RFC 0099 bucket (c) tooling noise: the body contains several `new` calls and the comparator pairs the Ruby and TS occurrences positionally, so this row compares a TS error construction against an unrelated Ruby one rather than a matched call site."
+    "reason": "RFC 0099 bucket (c) tooling noise, verified at connection_adapters/abstract/transaction.rb `after_rollback`: the two bodies each construct more than one object (or the port raises a guard Rails does not), and the comparator pairs the `new` occurrences positionally, so this row compares two unrelated constructions rather than a matched call site."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/transaction.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/transaction.json
@@ -9,7 +9,7 @@
       "str:afterRollback",
       "ref:block"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (c) tooling noise: the body contains several `new` calls and the comparator pairs the Ruby and TS occurrences positionally, so this row compares a TS error construction against an unrelated Ruby one rather than a matched call site."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/sqlite3-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/sqlite3-adapter.json
@@ -8,7 +8,7 @@
     "rubyArgs": [
       "ref:tableName"
     ],
-    "reason": "RFC 0099 bucket (b) equivalent: Rails passes a block to a method whose earlier parameters are defaulted (sqlite3_adapter.rb:561 `alter_table(table_name) do |definition|`). TS has no block syntax, so the callback is a trailing parameter and the intervening defaulted parameters are padded with nil, which the callee defaults exactly as Ruby's default expressions do."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at connection_adapters/sqlite3_adapter.rb `add_check_constraint`: Rails passes a block to a method whose earlier parameters are defaulted (sqlite3_adapter.rb:561 `def alter_table(table_name, foreign_keys = ..., check_constraints = ..., **options)`). TS has no block syntax, so the callback is a trailing parameter and the intervening defaulted parameters are padded with nil, which the callee defaults exactly as Ruby's default expressions do."
   },
   {
     "package": "activerecord",
@@ -19,7 +19,7 @@
     "rubyArgs": [
       "ref:tableName"
     ],
-    "reason": "RFC 0099 bucket (b) equivalent: Rails passes a block to a method whose earlier parameters are defaulted (sqlite3_adapter.rb:561 `alter_table(table_name) do |definition|`). TS has no block syntax, so the callback is a trailing parameter and the intervening defaulted parameters are padded with nil, which the callee defaults exactly as Ruby's default expressions do."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at connection_adapters/sqlite3_adapter.rb:341 `alter_table(table_name) do |definition|`: Rails passes a block to a method whose earlier parameters are defaulted (sqlite3_adapter.rb:561 `def alter_table(table_name, foreign_keys = ..., check_constraints = ..., **options)`). TS has no block syntax, so the callback is a trailing parameter and the intervening defaulted parameters are padded with nil, which the callee defaults exactly as Ruby's default expressions do."
   },
   {
     "package": "activerecord",
@@ -30,7 +30,7 @@
     "rubyArgs": [
       "ref:fromTable"
     ],
-    "reason": "RFC 0099 bucket (b) equivalent: Rails passes a block to a method whose earlier parameters are defaulted (sqlite3_adapter.rb:561 `alter_table(table_name) do |definition|`). TS has no block syntax, so the callback is a trailing parameter and the intervening defaulted parameters are padded with nil, which the callee defaults exactly as Ruby's default expressions do."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at connection_adapters/sqlite3_adapter.rb `add_foreign_key`: Rails passes a block to a method whose earlier parameters are defaulted (sqlite3_adapter.rb:561 `def alter_table(table_name, foreign_keys = ..., check_constraints = ..., **options)`). TS has no block syntax, so the callback is a trailing parameter and the intervening defaulted parameters are padded with nil, which the callee defaults exactly as Ruby's default expressions do."
   },
   {
     "package": "activerecord",
@@ -41,7 +41,7 @@
     "rubyArgs": [
       "ref:tableName"
     ],
-    "reason": "RFC 0099 bucket (b) equivalent: Rails passes a block to a method whose earlier parameters are defaulted (sqlite3_adapter.rb:561 `alter_table(table_name) do |definition|`). TS has no block syntax, so the callback is a trailing parameter and the intervening defaulted parameters are padded with nil, which the callee defaults exactly as Ruby's default expressions do."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at connection_adapters/sqlite3_adapter.rb:404 `alter_table(table_name) do |definition|`: Rails passes a block to a method whose earlier parameters are defaulted (sqlite3_adapter.rb:561 `def alter_table(table_name, foreign_keys = ..., check_constraints = ..., **options)`). TS has no block syntax, so the callback is a trailing parameter and the intervening defaulted parameters are padded with nil, which the callee defaults exactly as Ruby's default expressions do."
   },
   {
     "package": "activerecord",
@@ -96,7 +96,7 @@
     "rubyArgs": [
       "ref:tableName"
     ],
-    "reason": "RFC 0099 bucket (b) equivalent: Rails passes a block to a method whose earlier parameters are defaulted (sqlite3_adapter.rb:561 `alter_table(table_name) do |definition|`). TS has no block syntax, so the callback is a trailing parameter and the intervening defaulted parameters are padded with nil, which the callee defaults exactly as Ruby's default expressions do."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at connection_adapters/sqlite3_adapter.rb:386 `alter_table(table_name) do |definition|`: Rails passes a block to a method whose earlier parameters are defaulted (sqlite3_adapter.rb:561 `def alter_table(table_name, foreign_keys = ..., check_constraints = ..., **options)`). TS has no block syntax, so the callback is a trailing parameter and the intervening defaulted parameters are padded with nil, which the callee defaults exactly as Ruby's default expressions do."
   },
   {
     "package": "activerecord",
@@ -107,7 +107,7 @@
     "rubyArgs": [
       "ref:tableName"
     ],
-    "reason": "RFC 0099 bucket (b) equivalent: Rails passes a block to a method whose earlier parameters are defaulted (sqlite3_adapter.rb:561 `alter_table(table_name) do |definition|`). TS has no block syntax, so the callback is a trailing parameter and the intervening defaulted parameters are padded with nil, which the callee defaults exactly as Ruby's default expressions do."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at connection_adapters/sqlite3_adapter.rb:369 `alter_table(table_name) do |definition|`: Rails passes a block to a method whose earlier parameters are defaulted (sqlite3_adapter.rb:561 `def alter_table(table_name, foreign_keys = ..., check_constraints = ..., **options)`). TS has no block syntax, so the callback is a trailing parameter and the intervening defaulted parameters are padded with nil, which the callee defaults exactly as Ruby's default expressions do."
   },
   {
     "package": "activerecord",
@@ -118,7 +118,7 @@
     "rubyArgs": [
       "ref:tableName"
     ],
-    "reason": "RFC 0099 bucket (b) equivalent: Rails passes a block to a method whose earlier parameters are defaulted (sqlite3_adapter.rb:561 `alter_table(table_name) do |definition|`). TS has no block syntax, so the callback is a trailing parameter and the intervening defaulted parameters are padded with nil, which the callee defaults exactly as Ruby's default expressions do."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at connection_adapters/sqlite3_adapter.rb:380 `alter_table(table_name) do |definition|`: Rails passes a block to a method whose earlier parameters are defaulted (sqlite3_adapter.rb:561 `def alter_table(table_name, foreign_keys = ..., check_constraints = ..., **options)`). TS has no block syntax, so the callback is a trailing parameter and the intervening defaulted parameters are padded with nil, which the callee defaults exactly as Ruby's default expressions do."
   },
   {
     "package": "activerecord",
@@ -260,7 +260,7 @@
     "rubyArgs": [
       "ref:queryValue"
     ],
-    "reason": "RFC 0099 bucket (c) tooling noise: the body contains several `new` calls and the comparator pairs the Ruby and TS occurrences positionally, so this row compares a TS error construction against an unrelated Ruby one rather than a matched call site."
+    "reason": "RFC 0099 bucket (c) tooling noise, verified at connection_adapters/sqlite3_adapter.rb:477 `SQLite3Adapter::Version.new(query_value(\"SELECT sqlite_version(*)\", \"SCHEMA\"))`: the two bodies each construct more than one object (or the port raises a guard Rails does not), and the comparator pairs the `new` occurrences positionally, so this row compares two unrelated constructions rather than a matched call site."
   },
   {
     "package": "activerecord",
@@ -285,7 +285,7 @@
     "rubyArgs": [
       "kwargs{connectionPool=ref:pool}"
     ],
-    "reason": "RFC 0099 bucket (c) tooling noise: the body contains several `new` calls and the comparator pairs the Ruby and TS occurrences positionally, so this row compares a TS error construction against an unrelated Ruby one rather than a matched call site."
+    "reason": "RFC 0099 bucket (c) tooling noise, verified at connection_adapters/sqlite3_adapter.rb:120 `raise ActiveRecord::NoDatabaseError.new(connection_pool: @pool)`: the two bodies each construct more than one object (or the port raises a guard Rails does not), and the comparator pairs the `new` occurrences positionally, so this row compares two unrelated constructions rather than a matched call site."
   },
   {
     "package": "activerecord",
@@ -337,7 +337,7 @@
     "rubyArgs": [
       "ref:tableName"
     ],
-    "reason": "RFC 0099 bucket (b) equivalent: Rails passes a block to a method whose earlier parameters are defaulted (sqlite3_adapter.rb:561 `alter_table(table_name) do |definition|`). TS has no block syntax, so the callback is a trailing parameter and the intervening defaulted parameters are padded with nil, which the callee defaults exactly as Ruby's default expressions do."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at connection_adapters/sqlite3_adapter.rb:350 `alter_table(table_name) do |definition|`: Rails passes a block to a method whose earlier parameters are defaulted (sqlite3_adapter.rb:561 `def alter_table(table_name, foreign_keys = ..., check_constraints = ..., **options)`). TS has no block syntax, so the callback is a trailing parameter and the intervening defaulted parameters are padded with nil, which the callee defaults exactly as Ruby's default expressions do."
   },
   {
     "package": "activerecord",
@@ -348,7 +348,7 @@
     "rubyArgs": [
       "ref:tableName"
     ],
-    "reason": "RFC 0099 bucket (b) equivalent: Rails passes a block to a method whose earlier parameters are defaulted (sqlite3_adapter.rb:561 `alter_table(table_name) do |definition|`). TS has no block syntax, so the callback is a trailing parameter and the intervening defaulted parameters are padded with nil, which the callee defaults exactly as Ruby's default expressions do."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at connection_adapters/sqlite3_adapter.rb:357 `alter_table(table_name) do |definition|`: Rails passes a block to a method whose earlier parameters are defaulted (sqlite3_adapter.rb:561 `def alter_table(table_name, foreign_keys = ..., check_constraints = ..., **options)`). TS has no block syntax, so the callback is a trailing parameter and the intervening defaulted parameters are padded with nil, which the callee defaults exactly as Ruby's default expressions do."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/sqlite3-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/sqlite3-adapter.json
@@ -8,7 +8,7 @@
     "rubyArgs": [
       "ref:tableName"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: Rails passes a block to a method whose earlier parameters are defaulted (sqlite3_adapter.rb:561 `alter_table(table_name) do |definition|`). TS has no block syntax, so the callback is a trailing parameter and the intervening defaulted parameters are padded with nil, which the callee defaults exactly as Ruby's default expressions do."
   },
   {
     "package": "activerecord",
@@ -19,7 +19,7 @@
     "rubyArgs": [
       "ref:tableName"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: Rails passes a block to a method whose earlier parameters are defaulted (sqlite3_adapter.rb:561 `alter_table(table_name) do |definition|`). TS has no block syntax, so the callback is a trailing parameter and the intervening defaulted parameters are padded with nil, which the callee defaults exactly as Ruby's default expressions do."
   },
   {
     "package": "activerecord",
@@ -30,7 +30,7 @@
     "rubyArgs": [
       "ref:fromTable"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: Rails passes a block to a method whose earlier parameters are defaulted (sqlite3_adapter.rb:561 `alter_table(table_name) do |definition|`). TS has no block syntax, so the callback is a trailing parameter and the intervening defaulted parameters are padded with nil, which the callee defaults exactly as Ruby's default expressions do."
   },
   {
     "package": "activerecord",
@@ -41,7 +41,7 @@
     "rubyArgs": [
       "ref:tableName"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: Rails passes a block to a method whose earlier parameters are defaulted (sqlite3_adapter.rb:561 `alter_table(table_name) do |definition|`). TS has no block syntax, so the callback is a trailing parameter and the intervening defaulted parameters are padded with nil, which the callee defaults exactly as Ruby's default expressions do."
   },
   {
     "package": "activerecord",
@@ -96,7 +96,7 @@
     "rubyArgs": [
       "ref:tableName"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: Rails passes a block to a method whose earlier parameters are defaulted (sqlite3_adapter.rb:561 `alter_table(table_name) do |definition|`). TS has no block syntax, so the callback is a trailing parameter and the intervening defaulted parameters are padded with nil, which the callee defaults exactly as Ruby's default expressions do."
   },
   {
     "package": "activerecord",
@@ -107,7 +107,7 @@
     "rubyArgs": [
       "ref:tableName"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: Rails passes a block to a method whose earlier parameters are defaulted (sqlite3_adapter.rb:561 `alter_table(table_name) do |definition|`). TS has no block syntax, so the callback is a trailing parameter and the intervening defaulted parameters are padded with nil, which the callee defaults exactly as Ruby's default expressions do."
   },
   {
     "package": "activerecord",
@@ -118,7 +118,7 @@
     "rubyArgs": [
       "ref:tableName"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: Rails passes a block to a method whose earlier parameters are defaulted (sqlite3_adapter.rb:561 `alter_table(table_name) do |definition|`). TS has no block syntax, so the callback is a trailing parameter and the intervening defaulted parameters are padded with nil, which the callee defaults exactly as Ruby's default expressions do."
   },
   {
     "package": "activerecord",
@@ -260,7 +260,7 @@
     "rubyArgs": [
       "ref:queryValue"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (c) tooling noise: the body contains several `new` calls and the comparator pairs the Ruby and TS occurrences positionally, so this row compares a TS error construction against an unrelated Ruby one rather than a matched call site."
   },
   {
     "package": "activerecord",
@@ -285,7 +285,7 @@
     "rubyArgs": [
       "kwargs{connectionPool=ref:pool}"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (c) tooling noise: the body contains several `new` calls and the comparator pairs the Ruby and TS occurrences positionally, so this row compares a TS error construction against an unrelated Ruby one rather than a matched call site."
   },
   {
     "package": "activerecord",
@@ -337,7 +337,7 @@
     "rubyArgs": [
       "ref:tableName"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: Rails passes a block to a method whose earlier parameters are defaulted (sqlite3_adapter.rb:561 `alter_table(table_name) do |definition|`). TS has no block syntax, so the callback is a trailing parameter and the intervening defaulted parameters are padded with nil, which the callee defaults exactly as Ruby's default expressions do."
   },
   {
     "package": "activerecord",
@@ -348,7 +348,7 @@
     "rubyArgs": [
       "ref:tableName"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: Rails passes a block to a method whose earlier parameters are defaulted (sqlite3_adapter.rb:561 `alter_table(table_name) do |definition|`). TS has no block syntax, so the callback is a trailing parameter and the intervening defaulted parameters are padded with nil, which the callee defaults exactly as Ruby's default expressions do."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/core.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/core.json
@@ -74,7 +74,7 @@
     "call": "constantize",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at core.rb:29 `self._destroy_association_async_job = _destroy_association_async_job.constantize`: Rails invokes `constantize` on a built-in receiver (a Ruby String/Hash/Object/Enumerable method or the ActiveSupport core-ext on one). TS cannot monkey-patch those prototypes, so the port calls the free function with that receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/core.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/core.json
@@ -74,7 +74,7 @@
     "call": "constantize",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/database-configurations/database-config.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/database-configurations/database-config.json
@@ -15,6 +15,6 @@
     "rubyArgs": [
       "ref:configurationHash"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (c) tooling noise: the body contains several `new` calls and the comparator pairs the Ruby and TS occurrences positionally, so this row compares a TS error construction against an unrelated Ruby one rather than a matched call site."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/database-configurations/database-config.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/database-configurations/database-config.json
@@ -15,6 +15,6 @@
     "rubyArgs": [
       "ref:configurationHash"
     ],
-    "reason": "RFC 0099 bucket (c) tooling noise: the body contains several `new` calls and the comparator pairs the Ruby and TS occurrences positionally, so this row compares a TS error construction against an unrelated Ruby one rather than a matched call site."
+    "reason": "RFC 0099 bucket (c) tooling noise, verified at database_configurations/database_config.rb:25 `def new_connection`: the two bodies each construct more than one object (or the port raises a guard Rails does not), and the comparator pairs the `new` occurrences positionally, so this row compares two unrelated constructions rather than a matched call site."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/cipher/aes256-gcm.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/cipher/aes256-gcm.json
@@ -19,7 +19,7 @@
     "rubyArgs": [
       "const:CIPHER_TYPE"
     ],
-    "reason": "RFC 0099 bucket (c) tooling noise: the body contains several `new` calls and the comparator pairs the Ruby and TS occurrences positionally, so this row compares a TS error construction against an unrelated Ruby one rather than a matched call site."
+    "reason": "RFC 0099 bucket (c) tooling noise, verified at encryption/cipher/aes256_gcm.rb:39 `cipher = OpenSSL::Cipher.new(CIPHER_TYPE)`: the two bodies each construct more than one object (or the port raises a guard Rails does not), and the comparator pairs the `new` occurrences positionally, so this row compares two unrelated constructions rather than a matched call site."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/cipher/aes256-gcm.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/cipher/aes256-gcm.json
@@ -19,7 +19,7 @@
     "rubyArgs": [
       "const:CIPHER_TYPE"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (c) tooling noise: the body contains several `new` calls and the comparator pairs the Ruby and TS occurrences positionally, so this row compares a TS error construction against an unrelated Ruby one rather than a matched call site."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/config.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/config.json
@@ -8,6 +8,6 @@
     "rubyArgs": [
       "kwargs{hashDigestClass=const:SHA1}"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (c) tooling noise: the body contains several `new` calls and the comparator pairs the Ruby and TS occurrences positionally, so this row compares a TS error construction against an unrelated Ruby one rather than a matched call site."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/config.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/config.json
@@ -8,6 +8,6 @@
     "rubyArgs": [
       "kwargs{hashDigestClass=const:SHA1}"
     ],
-    "reason": "RFC 0099 bucket (c) tooling noise: the body contains several `new` calls and the comparator pairs the Ruby and TS occurrences positionally, so this row compares a TS error construction against an unrelated Ruby one rather than a matched call site."
+    "reason": "RFC 0099 bucket (c) tooling noise, verified at encryption/config.rb `support_sha1_for_non_deterministic_encryption=`: the two bodies each construct more than one object (or the port raises a guard Rails does not), and the comparator pairs the `new` occurrences positionally, so this row compares two unrelated constructions rather than a matched call site."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/inheritance.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/inheritance.json
@@ -90,7 +90,7 @@
     "call": "demodulize",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at inheritance.rb:212 `store_full_class_name ? base_class.name : base_class.name.demodulize`: Rails invokes `demodulize` on a built-in receiver (a Ruby String/Hash/Object/Enumerable method or the ActiveSupport core-ext on one). TS cannot monkey-patch those prototypes, so the port calls the free function with that receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -110,7 +110,7 @@
     "call": "demodulize",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at inheritance.rb:188 `store_full_sti_class && store_full_class_name ? name : name.demodulize`: Rails invokes `demodulize` on a built-in receiver (a Ruby String/Hash/Object/Enumerable method or the ActiveSupport core-ext on one). TS cannot monkey-patch those prototypes, so the port calls the free function with that receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/inheritance.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/inheritance.json
@@ -90,7 +90,7 @@
     "call": "demodulize",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -110,7 +110,7 @@
     "call": "demodulize",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/insert-all.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/insert-all.json
@@ -48,7 +48,7 @@
     "call": "keys",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at insert_all.rb:36 `@keys |= @scope_attributes.keys`: Rails invokes `keys` on a built-in receiver (a Ruby String/Hash/Object/Enumerable method or the ActiveSupport core-ext on one). TS cannot monkey-patch those prototypes, so the port calls the free function with that receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/insert-all.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/insert-all.json
@@ -48,7 +48,7 @@
     "call": "keys",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/migration.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/migration.json
@@ -63,7 +63,7 @@
     "call": "underscore",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/migration.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/migration.json
@@ -63,7 +63,7 @@
     "call": "underscore",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at migration.rb:1102 `new_path = File.join(destination, \"#{migration.version}_#{migration.name.underscore}.#{scope}.rb\")`: Rails invokes `underscore` on a built-in receiver (a Ruby String/Hash/Object/Enumerable method or the ActiveSupport core-ext on one). TS cannot monkey-patch those prototypes, so the port calls the free function with that receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/migration/command-recorder.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/migration/command-recorder.json
@@ -15,7 +15,7 @@
     "rubyArgs": [
       "ref:delegate"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (c) tooling noise: the body contains several `new` calls and the comparator pairs the Ruby and TS occurrences positionally, so this row compares a TS error construction against an unrelated Ruby one rather than a matched call site."
   },
   {
     "package": "activerecord",
@@ -40,7 +40,7 @@
     "rubyArgs": [
       "ref:delegate"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (c) tooling noise: the body contains several `new` calls and the comparator pairs the Ruby and TS occurrences positionally, so this row compares a TS error construction against an unrelated Ruby one rather than a matched call site."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/migration/command-recorder.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/migration/command-recorder.json
@@ -15,7 +15,7 @@
     "rubyArgs": [
       "ref:delegate"
     ],
-    "reason": "RFC 0099 bucket (c) tooling noise: the body contains several `new` calls and the comparator pairs the Ruby and TS occurrences positionally, so this row compares a TS error construction against an unrelated Ruby one rather than a matched call site."
+    "reason": "RFC 0099 bucket (c) tooling noise, verified at migration/command_recorder.rb:138 `recorder = self.class.new(self.delegate)`: the two bodies each construct more than one object (or the port raises a guard Rails does not), and the comparator pairs the `new` occurrences positionally, so this row compares two unrelated constructions rather than a matched call site."
   },
   {
     "package": "activerecord",
@@ -40,7 +40,7 @@
     "rubyArgs": [
       "ref:delegate"
     ],
-    "reason": "RFC 0099 bucket (c) tooling noise: the body contains several `new` calls and the comparator pairs the Ruby and TS occurrences positionally, so this row compares a TS error construction against an unrelated Ruby one rather than a matched call site."
+    "reason": "RFC 0099 bucket (c) tooling noise, verified at migration/command_recorder.rb:187 `sub_recorder = CommandRecorder.new(delegate)`: the two bodies each construct more than one object (or the port raises a guard Rails does not), and the comparator pairs the `new` occurrences positionally, so this row compares two unrelated constructions rather than a matched call site."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/model-schema.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/model-schema.json
@@ -20,7 +20,7 @@
     "call": "freeze",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -29,7 +29,7 @@
     "call": "values",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -119,6 +119,6 @@
     "call": "underscore",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/model-schema.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/model-schema.json
@@ -20,7 +20,7 @@
     "call": "freeze",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at model_schema.rb:479 `@column_names ||= columns.map(&:name).freeze`: Rails invokes `freeze` on a built-in receiver (a Ruby String/Hash/Object/Enumerable method or the ActiveSupport core-ext on one). TS cannot monkey-patch those prototypes, so the port calls the free function with that receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -29,7 +29,7 @@
     "call": "values",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at model_schema.rb:433 `@columns ||= columns_hash.values.freeze`: Rails invokes `values` on a built-in receiver (a Ruby String/Hash/Object/Enumerable method or the ActiveSupport core-ext on one). TS cannot monkey-patch those prototypes, so the port calls the free function with that receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -119,6 +119,6 @@
     "call": "underscore",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at model_schema.rb:601 `table_name = model_name.to_s.demodulize.underscore`: Rails invokes `underscore` on a built-in receiver (a Ruby String/Hash/Object/Enumerable method or the ActiveSupport core-ext on one). TS cannot monkey-patch those prototypes, so the port calls the free function with that receiver as argument 1; the remaining arguments match Rails exactly."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/reflection.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/reflection.json
@@ -34,7 +34,7 @@
     "call": "demodulize",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at reflection.rb:760 `inverse_name = ActiveSupport::Inflector.underscore(options[:as] || active_record.name.demodulize).to_sym`: Rails invokes `demodulize` on a built-in receiver (a Ruby String/Hash/Object/Enumerable method or the ActiveSupport core-ext on one). TS cannot monkey-patch those prototypes, so the port calls the free function with that receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -61,7 +61,7 @@
     "call": "underscore",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at reflection.rb:250 `counter_cache[:column] || -\"#{active_record.name.demodulize.underscore.pluralize}_count\"`: Rails invokes `underscore` on a built-in receiver (a Ruby String/Hash/Object/Enumerable method or the ActiveSupport core-ext on one). TS cannot monkey-patch those prototypes, so the port calls the free function with that receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -70,7 +70,7 @@
     "call": "camelize",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at reflection.rb:454 `name.to_s.camelize`: Rails invokes `camelize` on a built-in receiver (a Ruby String/Hash/Object/Enumerable method or the ActiveSupport core-ext on one). TS cannot monkey-patch those prototypes, so the port calls the free function with that receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -151,7 +151,7 @@
     "call": "singularize",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at reflection.rb:1114 `names = [name.to_s.singularize, name].collect(&:to_sym).uniq`: Rails invokes `singularize` on a built-in receiver (a Ruby String/Hash/Object/Enumerable method or the ActiveSupport core-ext on one). TS cannot monkey-patch those prototypes, so the port calls the free function with that receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -160,6 +160,6 @@
     "call": "singularize",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at reflection.rb:1109 `options[:source] ? [options[:source]] : [name.to_s.singularize, name].uniq`: Rails invokes `singularize` on a built-in receiver (a Ruby String/Hash/Object/Enumerable method or the ActiveSupport core-ext on one). TS cannot monkey-patch those prototypes, so the port calls the free function with that receiver as argument 1; the remaining arguments match Rails exactly."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/reflection.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/reflection.json
@@ -34,7 +34,7 @@
     "call": "demodulize",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -61,7 +61,7 @@
     "call": "underscore",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -70,7 +70,7 @@
     "call": "camelize",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -151,7 +151,7 @@
     "call": "singularize",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -160,6 +160,6 @@
     "call": "singularize",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
@@ -23,7 +23,7 @@
       "ref:__callee__",
       "ref:args"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: Ruby passes `__callee__` (query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`), which has no TS equivalent; the port passes the same value as a literal method-name string and the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -404,7 +404,7 @@
       "ref:__callee__",
       "ref:args"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: Ruby passes `__callee__` (query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`), which has no TS equivalent; the port passes the same value as a literal method-name string and the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -754,7 +754,7 @@
       "ref:__callee__",
       "ref:args"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: Ruby passes `__callee__` (query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`), which has no TS equivalent; the port passes the same value as a literal method-name string and the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -861,7 +861,7 @@
       "ref:__callee__",
       "ref:args"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: Ruby passes `__callee__` (query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`), which has no TS equivalent; the port passes the same value as a literal method-name string and the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -900,7 +900,7 @@
       "ref:__callee__",
       "ref:args"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: Ruby passes `__callee__` (query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`), which has no TS equivalent; the port passes the same value as a literal method-name string and the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -961,7 +961,7 @@
       "ref:__callee__",
       "ref:args"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: Ruby passes `__callee__` (query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`), which has no TS equivalent; the port passes the same value as a literal method-name string and the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -973,7 +973,7 @@
       "ref:__callee__",
       "ref:args"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: Ruby passes `__callee__` (query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`), which has no TS equivalent; the port passes the same value as a literal method-name string and the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -1013,7 +1013,7 @@
       "ref:__callee__",
       "ref:args"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: Ruby passes `__callee__` (query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`), which has no TS equivalent; the port passes the same value as a literal method-name string and the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -1053,7 +1053,7 @@
       "ref:__callee__",
       "ref:tableNames"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: Ruby passes `__callee__` (query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`), which has no TS equivalent; the port passes the same value as a literal method-name string and the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -1086,7 +1086,7 @@
       "ref:__callee__",
       "ref:args"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: Ruby passes `__callee__` (query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`), which has no TS equivalent; the port passes the same value as a literal method-name string and the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -1098,7 +1098,7 @@
       "ref:__callee__",
       "ref:args"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: Ruby passes `__callee__` (query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`), which has no TS equivalent; the port passes the same value as a literal method-name string and the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -1110,7 +1110,7 @@
       "ref:__callee__",
       "ref:args"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: Ruby passes `__callee__` (query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`), which has no TS equivalent; the port passes the same value as a literal method-name string and the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -1130,7 +1130,7 @@
       "ref:fields",
       "str:Call `select' with at least one field."
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: Ruby passes `__callee__` (query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`), which has no TS equivalent; the port passes the same value as a literal method-name string and the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -1244,7 +1244,7 @@
       "ref:__callee__",
       "ref:args"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: Ruby passes `__callee__` (query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`), which has no TS equivalent; the port passes the same value as a literal method-name string and the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -1350,7 +1350,7 @@
       "ref:__callee__",
       "ref:args"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: Ruby passes `__callee__` (query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`), which has no TS equivalent; the port passes the same value as a literal method-name string and the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -1362,6 +1362,6 @@
       "ref:__callee__",
       "ref:args"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: Ruby passes `__callee__` (query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`), which has no TS equivalent; the port passes the same value as a literal method-name string and the remaining arguments match Rails exactly."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
@@ -23,7 +23,7 @@
       "ref:__callee__",
       "ref:args"
     ],
-    "reason": "RFC 0099 bucket (b) equivalent: Ruby passes `__callee__` (query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`), which has no TS equivalent; the port passes the same value as a literal method-name string and the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at relation/query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`: Rails passes `__callee__`, which has no TS equivalent, and the port passes the same value as a literal method-name string; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -404,7 +404,7 @@
       "ref:__callee__",
       "ref:args"
     ],
-    "reason": "RFC 0099 bucket (b) equivalent: Ruby passes `__callee__` (query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`), which has no TS equivalent; the port passes the same value as a literal method-name string and the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at relation/query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`: Rails passes `__callee__`, which has no TS equivalent, and the port passes the same value as a literal method-name string; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -754,7 +754,7 @@
       "ref:__callee__",
       "ref:args"
     ],
-    "reason": "RFC 0099 bucket (b) equivalent: Ruby passes `__callee__` (query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`), which has no TS equivalent; the port passes the same value as a literal method-name string and the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at relation/query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`: Rails passes `__callee__`, which has no TS equivalent, and the port passes the same value as a literal method-name string; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -861,7 +861,7 @@
       "ref:__callee__",
       "ref:args"
     ],
-    "reason": "RFC 0099 bucket (b) equivalent: Ruby passes `__callee__` (query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`), which has no TS equivalent; the port passes the same value as a literal method-name string and the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at relation/query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`: Rails passes `__callee__`, which has no TS equivalent, and the port passes the same value as a literal method-name string; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -900,7 +900,7 @@
       "ref:__callee__",
       "ref:args"
     ],
-    "reason": "RFC 0099 bucket (b) equivalent: Ruby passes `__callee__` (query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`), which has no TS equivalent; the port passes the same value as a literal method-name string and the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at relation/query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`: Rails passes `__callee__`, which has no TS equivalent, and the port passes the same value as a literal method-name string; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -961,7 +961,7 @@
       "ref:__callee__",
       "ref:args"
     ],
-    "reason": "RFC 0099 bucket (b) equivalent: Ruby passes `__callee__` (query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`), which has no TS equivalent; the port passes the same value as a literal method-name string and the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at relation/query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`: Rails passes `__callee__`, which has no TS equivalent, and the port passes the same value as a literal method-name string; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -973,7 +973,7 @@
       "ref:__callee__",
       "ref:args"
     ],
-    "reason": "RFC 0099 bucket (b) equivalent: Ruby passes `__callee__` (query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`), which has no TS equivalent; the port passes the same value as a literal method-name string and the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at relation/query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`: Rails passes `__callee__`, which has no TS equivalent, and the port passes the same value as a literal method-name string; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -1013,7 +1013,7 @@
       "ref:__callee__",
       "ref:args"
     ],
-    "reason": "RFC 0099 bucket (b) equivalent: Ruby passes `__callee__` (query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`), which has no TS equivalent; the port passes the same value as a literal method-name string and the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at relation/query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`: Rails passes `__callee__`, which has no TS equivalent, and the port passes the same value as a literal method-name string; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -1053,7 +1053,7 @@
       "ref:__callee__",
       "ref:tableNames"
     ],
-    "reason": "RFC 0099 bucket (b) equivalent: Ruby passes `__callee__` (query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`), which has no TS equivalent; the port passes the same value as a literal method-name string and the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at relation/query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`: Rails passes `__callee__`, which has no TS equivalent, and the port passes the same value as a literal method-name string; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -1086,7 +1086,7 @@
       "ref:__callee__",
       "ref:args"
     ],
-    "reason": "RFC 0099 bucket (b) equivalent: Ruby passes `__callee__` (query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`), which has no TS equivalent; the port passes the same value as a literal method-name string and the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at relation/query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`: Rails passes `__callee__`, which has no TS equivalent, and the port passes the same value as a literal method-name string; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -1098,7 +1098,7 @@
       "ref:__callee__",
       "ref:args"
     ],
-    "reason": "RFC 0099 bucket (b) equivalent: Ruby passes `__callee__` (query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`), which has no TS equivalent; the port passes the same value as a literal method-name string and the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at relation/query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`: Rails passes `__callee__`, which has no TS equivalent, and the port passes the same value as a literal method-name string; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -1110,7 +1110,7 @@
       "ref:__callee__",
       "ref:args"
     ],
-    "reason": "RFC 0099 bucket (b) equivalent: Ruby passes `__callee__` (query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`), which has no TS equivalent; the port passes the same value as a literal method-name string and the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at relation/query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`: Rails passes `__callee__`, which has no TS equivalent, and the port passes the same value as a literal method-name string; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -1130,7 +1130,7 @@
       "ref:fields",
       "str:Call `select' with at least one field."
     ],
-    "reason": "RFC 0099 bucket (b) equivalent: Ruby passes `__callee__` (query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`), which has no TS equivalent; the port passes the same value as a literal method-name string and the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at relation/query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`: Rails passes `__callee__`, which has no TS equivalent, and the port passes the same value as a literal method-name string; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -1244,7 +1244,7 @@
       "ref:__callee__",
       "ref:args"
     ],
-    "reason": "RFC 0099 bucket (b) equivalent: Ruby passes `__callee__` (query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`), which has no TS equivalent; the port passes the same value as a literal method-name string and the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at relation/query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`: Rails passes `__callee__`, which has no TS equivalent, and the port passes the same value as a literal method-name string; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -1350,7 +1350,7 @@
       "ref:__callee__",
       "ref:args"
     ],
-    "reason": "RFC 0099 bucket (b) equivalent: Ruby passes `__callee__` (query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`), which has no TS equivalent; the port passes the same value as a literal method-name string and the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at relation/query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`: Rails passes `__callee__`, which has no TS equivalent, and the port passes the same value as a literal method-name string; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -1362,6 +1362,6 @@
       "ref:__callee__",
       "ref:args"
     ],
-    "reason": "RFC 0099 bucket (b) equivalent: Ruby passes `__callee__` (query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`), which has no TS equivalent; the port passes the same value as a literal method-name string and the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at relation/query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`: Rails passes `__callee__`, which has no TS equivalent, and the port passes the same value as a literal method-name string; the remaining arguments match Rails exactly."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/calculations.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/calculations.json
@@ -20,7 +20,7 @@
     "call": "many?",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/calculations.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/calculations.json
@@ -20,7 +20,7 @@
     "call": "many?",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at relation/calculations.rb:659 `(((column_name == :all || select_values.many?) && distinct) || has_limit_or_offset?)`: Rails invokes `many?` on a built-in receiver (a Ruby String/Hash/Object/Enumerable method or the ActiveSupport core-ext on one). TS cannot monkey-patch those prototypes, so the port calls the free function with that receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/query-methods.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/query-methods.json
@@ -288,7 +288,7 @@
     "rubyArgs": [
       "ref:subquery"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (c) tooling noise: the body contains several `new` calls and the comparator pairs the Ruby and TS occurrences positionally, so this row compares a TS error construction against an unrelated Ruby one rather than a matched call site."
   },
   {
     "package": "activerecord",
@@ -368,7 +368,7 @@
     "rubyArgs": [
       "ref:name"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (c) tooling noise: the body contains several `new` calls and the comparator pairs the Ruby and TS occurrences positionally, so this row compares a TS error construction against an unrelated Ruby one rather than a matched call site."
   },
   {
     "package": "activerecord",
@@ -414,7 +414,7 @@
     "rubyArgs": [
       "ref:predicates"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (c) tooling noise: the body contains several `new` calls and the comparator pairs the Ruby and TS occurrences positionally, so this row compares a TS error construction against an unrelated Ruby one rather than a matched call site."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/query-methods.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/query-methods.json
@@ -288,7 +288,7 @@
     "rubyArgs": [
       "ref:subquery"
     ],
-    "reason": "RFC 0099 bucket (c) tooling noise: the body contains several `new` calls and the comparator pairs the Ruby and TS occurrences positionally, so this row compares a TS error construction against an unrelated Ruby one rather than a matched call site."
+    "reason": "RFC 0099 bucket (c) tooling noise, verified at relation/query_methods.rb:1608 `Arel::SelectManager.new(subquery).project(select_value).tap do |arel|`: the two bodies each construct more than one object (or the port raises a guard Rails does not), and the comparator pairs the `new` occurrences positionally, so this row compares two unrelated constructions rather than a matched call site."
   },
   {
     "package": "activerecord",
@@ -368,7 +368,7 @@
     "rubyArgs": [
       "ref:name"
     ],
-    "reason": "RFC 0099 bucket (c) tooling noise: the body contains several `new` calls and the comparator pairs the Ruby and TS occurrences positionally, so this row compares a TS error construction against an unrelated Ruby one rather than a matched call site."
+    "reason": "RFC 0099 bucket (c) tooling noise, verified at relation/query_methods.rb:1955 `with_table = Arel::Table.new(name)`: the two bodies each construct more than one object (or the port raises a guard Rails does not), and the comparator pairs the `new` occurrences positionally, so this row compares two unrelated constructions rather than a matched call site."
   },
   {
     "package": "activerecord",
@@ -414,7 +414,7 @@
     "rubyArgs": [
       "ref:predicates"
     ],
-    "reason": "RFC 0099 bucket (c) tooling noise: the body contains several `new` calls and the comparator pairs the Ruby and TS occurrences positionally, so this row compares a TS error construction against an unrelated Ruby one rather than a matched call site."
+    "reason": "RFC 0099 bucket (c) tooling noise, verified at relation/query_methods.rb `excluding!`: the two bodies each construct more than one object (or the port raises a guard Rails does not), and the comparator pairs the `new` occurrences positionally, so this row compares two unrelated constructions rather than a matched call site."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/signed-id.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/signed-id.json
@@ -6,7 +6,7 @@
     "call": "underscore",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -75,6 +75,6 @@
       "ref:secret",
       "kwargs{digest=str:SHA256,serializer=const:JSON,urlSafe=bool:true}"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (c) tooling noise: the body contains several `new` calls and the comparator pairs the Ruby and TS occurrences positionally, so this row compares a TS error construction against an unrelated Ruby one rather than a matched call site."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/signed-id.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/signed-id.json
@@ -6,7 +6,7 @@
     "call": "underscore",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at signed_id.rb:104 `[ base_class.name.underscore, purpose.to_s ].compact_blank.join(\"/\")`: Rails invokes `underscore` on a built-in receiver (a Ruby String/Hash/Object/Enumerable method or the ActiveSupport core-ext on one). TS cannot monkey-patch those prototypes, so the port calls the free function with that receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -75,6 +75,6 @@
       "ref:secret",
       "kwargs{digest=str:SHA256,serializer=const:JSON,urlSafe=bool:true}"
     ],
-    "reason": "RFC 0099 bucket (c) tooling noise: the body contains several `new` calls and the comparator pairs the Ruby and TS occurrences positionally, so this row compares a TS error construction against an unrelated Ruby one rather than a matched call site."
+    "reason": "RFC 0099 bucket (c) tooling noise, verified at signed_id.rb:90 `ActiveSupport::MessageVerifier.new secret, digest: \"SHA256\", serializer: JSON, url_safe: true`: the two bodies each construct more than one object (or the port raises a guard Rails does not), and the comparator pairs the `new` occurrences positionally, so this row compares two unrelated constructions rather than a matched call site."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/token-for.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/token-for.json
@@ -31,7 +31,7 @@
     "call": "as_json",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at token_for.rb:24 `block ? [model.id, model.instance_eval(&block).as_json] : [model.id]`: Rails invokes `as_json` on a built-in receiver (a Ruby String/Hash/Object/Enumerable method or the ActiveSupport core-ext on one). TS cannot monkey-patch those prototypes, so the port calls the free function with that receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/token-for.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/token-for.json
@@ -31,7 +31,7 @@
     "call": "as_json",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: an ActiveSupport core-ext call on a built-in receiver (`name.singularize`). TS cannot monkey-patch the String/Array/Object prototypes, so the port calls the free function with the Ruby receiver as argument 1; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/type/hash-lookup-type-map.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/type/hash-lookup-type-map.json
@@ -8,7 +8,7 @@
     "rubyArgs": [
       "ref:type"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: Rails passes a block to a method whose earlier parameters are defaulted (sqlite3_adapter.rb:561 `alter_table(table_name) do |definition|`). TS has no block syntax, so the callback is a trailing parameter and the intervening defaulted parameters are padded with nil, which the callee defaults exactly as Ruby's default expressions do."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/type/hash-lookup-type-map.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/type/hash-lookup-type-map.json
@@ -8,7 +8,7 @@
     "rubyArgs": [
       "ref:type"
     ],
-    "reason": "RFC 0099 bucket (b) equivalent: Rails passes a block to a method whose earlier parameters are defaulted (sqlite3_adapter.rb:561 `alter_table(table_name) do |definition|`). TS has no block syntax, so the callback is a trailing parameter and the intervening defaulted parameters are padded with nil, which the callee defaults exactly as Ruby's default expressions do."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at type/hash_lookup_type_map.rb:40 `register_type(type) { |_, *args| lookup(alias_type, *args) }`: Rails passes a block to a method whose earlier parameters are defaulted (sqlite3_adapter.rb:561 `def alter_table(table_name, foreign_keys = ..., check_constraints = ..., **options)`). TS has no block syntax, so the callback is a trailing parameter and the intervening defaulted parameters are padded with nil, which the callee defaults exactly as Ruby's default expressions do."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/type/type-map.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/type/type-map.json
@@ -8,7 +8,7 @@
     "rubyArgs": [
       "ref:key"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099 bucket (b) equivalent: Rails passes a block to a method whose earlier parameters are defaulted (sqlite3_adapter.rb:561 `alter_table(table_name) do |definition|`). TS has no block syntax, so the callback is a trailing parameter and the intervening defaulted parameters are padded with nil, which the callee defaults exactly as Ruby's default expressions do."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/type/type-map.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/type/type-map.json
@@ -8,7 +8,7 @@
     "rubyArgs": [
       "ref:key"
     ],
-    "reason": "RFC 0099 bucket (b) equivalent: Rails passes a block to a method whose earlier parameters are defaulted (sqlite3_adapter.rb:561 `alter_table(table_name) do |definition|`). TS has no block syntax, so the callback is a trailing parameter and the intervening defaulted parameters are padded with nil, which the callee defaults exactly as Ruby's default expressions do."
+    "reason": "RFC 0099 bucket (b) equivalent, verified at type/type_map.rb:36 `register_type(key) do |sql_type|`: Rails passes a block to a method whose earlier parameters are defaulted (sqlite3_adapter.rb:561 `def alter_table(table_name, foreign_keys = ..., check_constraints = ..., **options)`). TS has no block syntax, so the callback is a trailing parameter and the intervening defaulted parameters are padded with nil, which the callee defaults exactly as Ruby's default expressions do."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/arel/visitors/sqlite.json
+++ b/scripts/api-compare/call-mismatches-exclude/arel/visitors/sqlite.json
@@ -2,60 +2,6 @@
   {
     "package": "arel",
     "tsFile": "visitors/sqlite.ts",
-    "rubyName": "infix_value_with_paren",
-    "call": "grouping_parentheses",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:left",
-      "ref:collector",
-      "bool:false"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/sqlite.ts",
-    "rubyName": "infix_value_with_paren",
-    "call": "grouping_parentheses",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:right",
-      "ref:collector",
-      "bool:false"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/sqlite.ts",
-    "rubyName": "infix_value_with_paren",
-    "call": "infix_value_with_paren",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:left",
-      "ref:collector",
-      "ref:value",
-      "bool:true"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/sqlite.ts",
-    "rubyName": "infix_value_with_paren",
-    "call": "infix_value_with_paren",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:right",
-      "ref:collector",
-      "ref:value",
-      "bool:true"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/sqlite.ts",
     "rubyName": "visit_Arel_Nodes_IsDistinctFrom",
     "call": "visit",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/arel/visitors/to-sql.json
+++ b/scripts/api-compare/call-mismatches-exclude/arel/visitors/to-sql.json
@@ -2,32 +2,6 @@
   {
     "package": "arel",
     "tsFile": "visitors/to-sql.ts",
-    "rubyName": "aggregate",
-    "call": "inject_join",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:expressions",
-      "ref:collector",
-      "str:, "
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "collect_nodes_for",
-    "call": "inject_join",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:nodes",
-      "ref:collector",
-      "ref:connector"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
     "rubyName": "collect_optimizer_hints",
     "call": "maybe_visit",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -38,60 +12,6 @@
     "rubyName": "compile",
     "call": "accept",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "infix_value_with_paren",
-    "call": "grouping_parentheses",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:left",
-      "ref:collector",
-      "bool:false"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "infix_value_with_paren",
-    "call": "grouping_parentheses",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:right",
-      "ref:collector",
-      "bool:false"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "infix_value_with_paren",
-    "call": "infix_value_with_paren",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:left",
-      "ref:collector",
-      "ref:value",
-      "bool:true"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "infix_value_with_paren",
-    "call": "infix_value_with_paren",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:right",
-      "ref:collector",
-      "ref:value",
-      "bool:true"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "arel",
@@ -124,74 +44,9 @@
   {
     "package": "arel",
     "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_Except",
-    "call": "infix_value",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:o",
-      "ref:collector",
-      "str: EXCEPT "
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_Fragments",
-    "call": "inject_join",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:values",
-      "ref:collector",
-      "str: "
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
     "rubyName": "visit_Arel_Nodes_InsertStatement",
     "call": "maybe_visit",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_Intersect",
-    "call": "infix_value",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:o",
-      "ref:collector",
-      "str: INTERSECT "
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_JoinSource",
-    "call": "inject_join",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:right",
-      "ref:collector",
-      "str: "
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_NamedFunction",
-    "call": "inject_join",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:expressions",
-      "ref:collector",
-      "str:, "
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "arel",
@@ -227,37 +82,9 @@
     "call": "collect_nodes_for",
     "kind": "args",
     "rubyArgs": [
-      "ref:havings",
-      "ref:collector",
-      "str: HAVING ",
-      "str: AND "
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_SelectCore",
-    "call": "collect_nodes_for",
-    "kind": "args",
-    "rubyArgs": [
       "ref:projections",
       "ref:collector",
       "str: "
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_SelectCore",
-    "call": "collect_nodes_for",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:wheres",
-      "ref:collector",
-      "str: WHERE ",
-      "str: AND "
     ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
@@ -334,19 +161,6 @@
     "rubyName": "visit_Arel_Nodes_Window",
     "call": "collect_nodes_for",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_Window",
-    "call": "inject_join",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:orders",
-      "ref:collector",
-      "str:, "
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "arel",


### PR DESCRIPTION
## What

Two of the three bundled stories; the third is blocked (below).

### 1. `arel-collector-argument-order-convergence`

The `to_sql` visitor-helper family took `collector` as its LAST parameter where
Rails passes it in the middle. Converged signatures, order and parameter names
to Rails, and updated all call sites in `to-sql.ts`, `sqlite.ts`, `mysql.ts`:

| Rails (`vendor/rails/activerecord/lib/arel/visitors/to_sql.rb`) | was |
| --- | --- |
| `inject_join(list, collector, join_str)` (`:897`) | `injectJoin(nodes, connector, collector)` |
| `collect_nodes_for(nodes, collector, spacer, connector = ", ")` (`:179`) | `(nodes, spacer, connector, collector)` |
| `infix_value(o, collector, value)` (`:957`) | `(o, value, collector)` |
| `infix_value_with_paren(o, collector, value, suppress_parens = false)` (`:963`) | `(o, value, suppressParens, collector)` |
| `grouping_parentheses(o, collector, always_wrap_selects = true)` (`:981`) | `(o, alwaysWrapSelects, collector)` |

No wrapper or overload retained. The 18 now-stale `kind: "args"` rows are
deleted from the `arel/visitors/{to-sql,sqlite}.json` shards by hand
(only-shrink, no reseed).

### 2. `call-args-activerecord-shape-classification`

All 410 `activerecord` `kind: "args"` shape rows classified against the
vendored Rails bodies into the RFC 0095 buckets:

- **bucket (b)/(c) — 88 rows** get a per-cluster reviewed `reason` replacing
  the seed: ActiveSupport core-ext on a built-in receiver (no prototype
  monkey-patching in TS), Ruby `__callee__` (`query_methods.rb:2213`), the
  block-as-last-arg nil padding (`sqlite3_adapter.rb:561`), the Symbol
  colon-prefix spelling, and the multi-`new` positional pairing noise in the
  extractor.
- **bucket (a) — the remainder** grouped by mechanism and filed as 11
  convergence stories under RFC 0099, each carrying every row with its Rails
  file and the converged argument list: host-param (×4, by area),
  dropped-argument, extra-argument, kwargs-vs-positional, kwarg-key-set,
  kwarg-values, join-separator, literal-values.

No row deleted without the call site actually converging; both ratchets green.


### Tooling follow-ups (filed, not in this PR)

Several bucket (b)/(c) clusters are patterns the comparator could encode instead
of baselining — each one will keep seeding new rows on every future port. Filed
under RFC 0099:

- `call-args-tool-pair-same-named-calls-by-similarity` — same-named calls are
  zipped positionally, so two `new`s in one body get cross-paired (15 rows).
- `call-args-tool-resolve-ruby-callee` — `__callee__` is statically knowable
  from the enclosing method the row is already keyed by (32 rows).
- `call-args-tool-ignore-block-tail-nil-padding` — the nils TS needs to reach a
  block-as-trailing-parameter (`sqlite3_adapter.rb:561`) carry no information
  (11 rows).
- `call-args-tool-builtin-receiver-as-first-arg` — the receiver of an
  unmonkey-patchable built-in becomes TS argument 1; scoped to a curated
  builtin/core-ext list, explicitly NOT the ~137 genuine host-param rows (29).
- `call-args-tool-symbol-colon-literals` — the colon-prefixed Symbol spelling
  reads as a value divergence (2 rows).

### 3. `naming-gate-flip` — blocked, not shipped

The story conditions the flip on the naming class having been drained to the
~6% tooling residue. It has not: `pnpm parity:api:calls:args:report` on `main`
today reports **886 naming rows** against 717 shape. Gating now would mean
seeding ~886 baseline rows, which is exactly the allowlist-widening the RFC
forbids, so the story is `tasks block`ed with that reason rather than ratified.

## Verification

- `pnpm parity:api:calls:args` — OK (671 baselined shape rows, down from 689)
- `pnpm parity:api:calls` — OK
- `pnpm vitest run packages/arel/src/visitors` — 501 passed
- `pnpm typecheck` — clean

Closes-story: arel-collector-argument-order-convergence
Closes-story: call-args-activerecord-shape-classification
