### PR TITLE
feat(parity): resolve Ruby __callee__ to the enclosing method in the call-arg comparator

### DIFF
--- a/scripts/api-compare/call-args.test.ts
+++ b/scripts/api-compare/call-args.test.ts
@@ -322,6 +322,60 @@ describe("compareCallArgs", () => {
     expect(result.class).toBe("shape");
   });
 
+  it("resolves __callee__ to the enclosing method name the port passes", () => {
+    expect(
+      compareCallArgs(
+        site("check_if_method_has_arguments!", ["id:__callee__", "id:args"]),
+        site("checkIfMethodHasArgumentsBang", ["str:eager_load", "id:args"]),
+        "eager_load",
+      ).verdict,
+    ).toBe("match");
+    expect(
+      compareCallArgs(
+        site("check_if_method_has_arguments!", ["id:__callee__", "id:args"]),
+        site("checkIfMethodHasArgumentsBang", ["str:eagerLoad", "id:args"]),
+        "eager_load",
+      ).verdict,
+    ).toBe("match");
+  });
+
+  it("resolves __method__ the same way, and accepts a symbol or identifier spelling", () => {
+    expect(
+      compareCallArgs(
+        site("send", ["id:__method__"]),
+        site("send", ["sym:optimizer_hints"]),
+        "optimizer_hints",
+      ).verdict,
+    ).toBe("match");
+    expect(
+      compareCallArgs(
+        site("send", ["id:__method__"]),
+        site("send", ["id:optimizerHints"]),
+        "optimizer_hints",
+      ).verdict,
+    ).toBe("match");
+  });
+
+  it("still flags a port that passes some OTHER method's name", () => {
+    const result = compareCallArgs(
+      site("check_if_method_has_arguments!", ["id:__callee__", "id:args"]),
+      site("checkIfMethodHasArgumentsBang", ["str:preload", "id:args"]),
+      "eager_load",
+    );
+    expect(result.verdict).toBe("mismatch");
+    expect(result.class).toBe("shape");
+    expect(result.rubyArgs).toEqual(["ref:__callee__", "ref:args"]);
+  });
+
+  it("leaves __callee__ unresolved when the enclosing method is unknown", () => {
+    expect(
+      compareCallArgs(
+        site("check_if_method_has_arguments!", ["id:__callee__"]),
+        site("checkIfMethodHasArgumentsBang", ["str:eager_load"]),
+      ).verdict,
+    ).toBe("mismatch");
+  });
+
   it("reports the normalized lists on a mismatch", () => {
     const result = compareCallArgs(site("visit", ["id:o"]), site("visit", ["id:node"]));
     expect(result.rubyArgs).toEqual(["ref:o"]);

--- a/scripts/api-compare/call-args.ts
+++ b/scripts/api-compare/call-args.ts
@@ -353,9 +353,57 @@ function stripMixinReceiver(rubyArgs: string[], tsArgs: string[]): string[] {
   return tsArgs;
 }
 
+/** Ruby's reflective self-name pseudo-variables, which Ripper hands the
+ *  extractor as a plain identifier read. Both denote the name of the enclosing
+ *  method — `__callee__` the name it was CALLED through (so an alias reports the
+ *  alias), `__method__` the name it was defined as — and neither has a TS
+ *  spelling, so the port passes the name as a literal. */
+const CALLEE_REFS = new Set(["ref:__callee__", "ref:__method__"]);
+
+/** The resolved-`__callee__` key: the enclosing Ruby method's own name, which
+ *  the extractor already knows because it keys every row by it. */
+const CALLEE_PREFIX = "callee:";
+
+/** Rewrite a normalized Ruby argument list's `__callee__` / `__method__` reads
+ *  to the enclosing method's name (RFC 0099).
+ *
+ * `check_if_method_has_arguments!(__callee__, args)` is the single largest
+ * same-shape block in the argument dimension: the value is statically knowable
+ * and the port passes it as `checkIfMethodHasArgumentsBang("eager_load", …)`,
+ * which is the faithful port and not a shape divergence.
+ *
+ * Applied to the VERDICT's lists only — a row still REPORTS the raw
+ * `ref:__callee__` it always did, so resolving the value does not re-key the
+ * baseline rows of the sites that still diverge for an unrelated reason and make
+ * them read as new ones.
+ */
+function resolveCalleeRefs(args: string[], enclosingRubyName: string | undefined): string[] {
+  if (enclosingRubyName === undefined) return args;
+  return args.map((arg) => (CALLEE_REFS.has(arg) ? CALLEE_PREFIX + enclosingRubyName : arg));
+}
+
+/** Every key a faithful port of `__callee__` can spell: the enclosing method's
+ *  name as an identifier read, or — the shape the port actually uses, since TS
+ *  has no `__callee__` — as a string/symbol literal of the same name. Both go
+ *  through the Ruby→TS name conventions, so `eager_load` also matches
+ *  `"eagerLoad"`, and a `?`/`!`/`=` name matches each spelling the table
+ *  sanctions. */
+function calleeKeys(enclosingRubyName: string): string[] {
+  const names = [enclosingRubyName, ...tsCallNameKeys(enclosingRubyName)];
+  const keys = names.map((name) => `ref:${name}`);
+  for (const name of names) {
+    const literal = normalizeLiteralArg("string", name);
+    if (typeof literal === "string") keys.push(literal);
+  }
+  return keys;
+}
+
 /** Two argument keys naming the same value. Only `ref:` keys have more than one
  *  spelling; a literal key is already canonical. */
 function argKeysEqual(rubyKey: string, tsKey: string): boolean {
+  if (rubyKey.startsWith(CALLEE_PREFIX)) {
+    return calleeKeys(rubyKey.slice(CALLEE_PREFIX.length)).includes(tsKey);
+  }
   if (rubyKey.startsWith("ref:") && tsKey.startsWith("ref:")) return refKeysEqual(rubyKey, tsKey);
   return rubyKey === tsKey;
 }
@@ -410,8 +458,15 @@ export function pairCallSites(
  *  block-pass on either side, an opaque descriptor anywhere in either list, or
  *  a call name the call-set gate already excludes. A `block` flag is NOT a
  *  skip: both extractors drop the block from the argument list and flag the
- *  site, so the remaining arguments still compare. */
-export function compareCallArgs(ruby: CallSite, ts: CallSite): CallArgResult {
+ *  site, so the remaining arguments still compare.
+ *
+ *  `enclosingRubyName` is the Ruby method whose body both sites are in — the
+ *  value of `__callee__` / `__method__` there ({@link resolveCalleeRefs}). */
+export function compareCallArgs(
+  ruby: CallSite,
+  ts: CallSite,
+  enclosingRubyName?: string,
+): CallArgResult {
   const skipped = (reason: CallArgSkipReason): CallArgResult => ({
     verdict: "skip",
     reason,
@@ -430,6 +485,7 @@ export function compareCallArgs(ruby: CallSite, ts: CallSite): CallArgResult {
     return skipped(tsArgs.failure === "opaque" ? "opaqueTsArg" : "unparseableLiteral");
   }
 
-  if (argsEqual(rubyArgs, tsArgs)) return { verdict: "match", rubyArgs, tsArgs };
-  return { verdict: "mismatch", class: classify(rubyArgs, tsArgs), rubyArgs, tsArgs };
+  const compared = resolveCalleeRefs(rubyArgs, enclosingRubyName);
+  if (argsEqual(compared, tsArgs)) return { verdict: "match", rubyArgs, tsArgs };
+  return { verdict: "mismatch", class: classify(compared, tsArgs), rubyArgs, tsArgs };
 }

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
@@ -16,18 +16,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
-    "rubyName": "annotate",
-    "call": "check_if_method_has_arguments!",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:__callee__",
-      "ref:args"
-    ],
-    "reason": "RFC 0099 bucket (b) equivalent, verified at relation/query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`: Rails passes `__callee__`, which has no TS equivalent, and the port passes the same value as a literal method-name string; the remaining arguments match Rails exactly."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
     "rubyName": "apply_join_dependency",
     "call": "eager_load_values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -397,18 +385,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
-    "rubyName": "eager_load",
-    "call": "check_if_method_has_arguments!",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:__callee__",
-      "ref:args"
-    ],
-    "reason": "RFC 0099 bucket (b) equivalent, verified at relation/query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`: Rails passes `__callee__`, which has no TS equivalent, and the port passes the same value as a literal method-name string; the remaining arguments match Rails exactly."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
     "rubyName": "except",
     "call": "relation_with",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -747,18 +723,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
-    "rubyName": "group",
-    "call": "check_if_method_has_arguments!",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:__callee__",
-      "ref:args"
-    ],
-    "reason": "RFC 0099 bucket (b) equivalent, verified at relation/query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`: Rails passes `__callee__`, which has no TS equivalent, and the port passes the same value as a literal method-name string; the remaining arguments match Rails exactly."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
     "rubyName": "has_include?",
     "call": "includes_values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -854,18 +818,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
-    "rubyName": "includes",
-    "call": "check_if_method_has_arguments!",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:__callee__",
-      "ref:args"
-    ],
-    "reason": "RFC 0099 bucket (b) equivalent, verified at relation/query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`: Rails passes `__callee__`, which has no TS equivalent, and the port passes the same value as a literal method-name string; the remaining arguments match Rails exactly."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
     "rubyName": "insert_all!",
     "call": "execute",
     "kind": "args",
@@ -954,18 +906,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
-    "rubyName": "optimizer_hints",
-    "call": "check_if_method_has_arguments!",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:__callee__",
-      "ref:args"
-    ],
-    "reason": "RFC 0099 bucket (b) equivalent, verified at relation/query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`: Rails passes `__callee__`, which has no TS equivalent, and the port passes the same value as a literal method-name string; the remaining arguments match Rails exactly."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
     "rubyName": "order",
     "call": "check_if_method_has_arguments!",
     "kind": "args",
@@ -1006,18 +946,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
-    "rubyName": "preload",
-    "call": "check_if_method_has_arguments!",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:__callee__",
-      "ref:args"
-    ],
-    "reason": "RFC 0099 bucket (b) equivalent, verified at relation/query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`: Rails passes `__callee__`, which has no TS equivalent, and the port passes the same value as a literal method-name string; the remaining arguments match Rails exactly."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
     "rubyName": "preload_associations",
     "call": "includes_values",
     "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails relation.rb:1321-1328 concatenates preload_values/includes_values and runs Preloader.new(...).call per spec under the strict_loading_value scope; trails relation.ts:6473-6475 returns the merged `[..._preloadAssociations, ..._includesAssociations]` list and the load path consuming it invokes the preloader — the value reads are direct field spreads."
@@ -1046,18 +974,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
-    "rubyName": "references",
-    "call": "check_if_method_has_arguments!",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:__callee__",
-      "ref:tableNames"
-    ],
-    "reason": "RFC 0099 bucket (b) equivalent, verified at relation/query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`: Rails passes `__callee__`, which has no TS equivalent, and the port passes the same value as a literal method-name string; the remaining arguments match Rails exactly."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
     "rubyName": "references_eager_loaded_tables?",
     "call": "build_joins",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -1079,31 +995,7 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
-    "rubyName": "regroup",
-    "call": "check_if_method_has_arguments!",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:__callee__",
-      "ref:args"
-    ],
-    "reason": "RFC 0099 bucket (b) equivalent, verified at relation/query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`: Rails passes `__callee__`, which has no TS equivalent, and the port passes the same value as a literal method-name string; the remaining arguments match Rails exactly."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
     "rubyName": "reorder",
-    "call": "check_if_method_has_arguments!",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:__callee__",
-      "ref:args"
-    ],
-    "reason": "RFC 0099 bucket (b) equivalent, verified at relation/query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`: Rails passes `__callee__`, which has no TS equivalent, and the port passes the same value as a literal method-name string; the remaining arguments match Rails exactly."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "reselect",
     "call": "check_if_method_has_arguments!",
     "kind": "args",
     "rubyArgs": [
@@ -1118,19 +1010,6 @@
     "rubyName": "scope_for_create",
     "call": "create_with_value",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "select",
-    "call": "check_if_method_has_arguments!",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:__callee__",
-      "ref:fields",
-      "str:Call `select' with at least one field."
-    ],
-    "reason": "RFC 0099 bucket (b) equivalent, verified at relation/query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`: Rails passes `__callee__`, which has no TS equivalent, and the port passes the same value as a literal method-name string; the remaining arguments match Rails exactly."
   },
   {
     "package": "activerecord",
@@ -1237,18 +1116,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
-    "rubyName": "unscope",
-    "call": "check_if_method_has_arguments!",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:__callee__",
-      "ref:args"
-    ],
-    "reason": "RFC 0099 bucket (b) equivalent, verified at relation/query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`: Rails passes `__callee__`, which has no TS equivalent, and the port passes the same value as a literal method-name string; the remaining arguments match Rails exactly."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
     "rubyName": "update",
     "call": "update",
     "kind": "args",
@@ -1339,29 +1206,5 @@
     "rubyName": "values_for_queries",
     "call": "except",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "with",
-    "call": "check_if_method_has_arguments!",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:__callee__",
-      "ref:args"
-    ],
-    "reason": "RFC 0099 bucket (b) equivalent, verified at relation/query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`: Rails passes `__callee__`, which has no TS equivalent, and the port passes the same value as a literal method-name string; the remaining arguments match Rails exactly."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "with_recursive",
-    "call": "check_if_method_has_arguments!",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:__callee__",
-      "ref:args"
-    ],
-    "reason": "RFC 0099 bucket (b) equivalent, verified at relation/query_methods.rb:2213 `check_if_method_has_arguments!(method_name, args, message = nil)`: Rails passes `__callee__`, which has no TS equivalent, and the port passes the same value as a literal method-name string; the remaining arguments match Rails exactly."
   }
 ]

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -2492,7 +2492,7 @@ export function main() {
         const tsSites = tsCallArgsByFileName.get(tsFile)?.get(tsName);
         if (tsSites?.length !== 1) return;
         for (const { ruby, ts } of pairCallSites(rubySites, tsSites[0])) {
-          const result = compareCallArgs(ruby, ts);
+          const result = compareCallArgs(ruby, ts, rubyName);
           if (result.verdict === "skip") {
             callArgsSkipped[result.reason]++;
             continue;


### PR DESCRIPTION
Story: `call-args-tool-resolve-ruby-callee` (RFC 0099) — a bucket-(b) block: the
ports are correct and the comparator was mis-flagging them.

Ruby's `__callee__` has no TS spelling, so
`check_if_method_has_arguments!(__callee__, args)` (`relation/query_methods.rb:2206`)
is ported as `checkIfMethodHasArgumentsBang("eager_load", …)`. The comparator saw
`ref:__callee__` vs `str:eagerLoad` and flagged a shape divergence at all 32 call
sites (16 baseline rows × the two Ruby files `relation.rb` / `relation/query_methods.rb`
that both match `relation.ts`).

## Change

`compareCallArgs` now takes the enclosing Ruby method name — which `compare.ts`
already has, since it keys every row by it — and resolves a `__callee__` /
`__method__` argument to it before the verdict. The resolved key matches either an
identifier read or a string/symbol literal of that name, both through the existing
Ruby→TS conventions (`scripts/parity/conventions.ts`), so `__callee__` inside
`eager_load` matches `"eager_load"`, `"eagerLoad"`, `:eager_load` and `eagerLoad`.

Resolution feeds the **verdict only**; a row still reports the raw `ref:__callee__`
it always did. That keeps baseline keys stable, so the three sites that still
diverge for an unrelated reason (`joins` / `order` / `reorder`, whose TS side passes
a trailing `nil, {orderArgs: true}` — the block-tail padding story
`call-args-tool-ignore-block-tail-nil-padding` covers) keep their existing rows
rather than appearing as new ones.

A port passing some *other* method's name is still a `shape` mismatch (covered by a
test).

## Row count

`call-mismatches-exclude`: **2786 → 2773 (−13)** (counts as of the rebase onto current `main`), deleted by hand via
`serializeBaseline`; no reseed, no rows added.

13, not 16: `joins` / `order` / `reorder` still diverge on the trailing block-tail
arguments and keep their rows. Of the 13 retired sites, 10 remain visible as
report-only `naming` mismatches (Rails' `args` ported as `associations` / `columns` /
`ctes`) — the callee argument itself now matches; nothing beyond this story's block
was suppressed.

## Acceptance criteria

1. ✅ `__callee__` normalizes to the enclosing method's name, compared through the
   Ruby→TS conventions.
2. ✅ `__method__` handled identically.
3. ✅ The bucket-(b) rows deleted from the baseline.
4. ✅ `pnpm parity:api:calls:args` green (`OK (676 baselined shape row(s))`),
   `pnpm parity:api:calls` green, total row count strictly decreases.

