### PR TITLE
refactor(activemodel,arel): rename locals and params to their Rails identifiers

### DIFF
--- a/packages/activemodel/src/attribute-assignment.ts
+++ b/packages/activemodel/src/attribute-assignment.ts
@@ -10,11 +10,9 @@ interface PermittedAttributes {
 export function assignAttributes(model: AttributeAssignment, newAttributes: unknown): void {
   assertHashAttributes(newAttributes);
 
-  const attrs = newAttributes;
-  if (isMassAssignmentEmpty(attrs)) return;
+  if (isMassAssignmentEmpty(newAttributes)) return;
 
-  const sanitized = sanitizeForMassAssignment(attrs);
-  _assignAttributes(model, sanitized);
+  _assignAttributes(model, sanitizeForMassAssignment(newAttributes));
 }
 
 export function attributeWriterMissing(
@@ -36,14 +34,14 @@ export function _assignAttributes(
 }
 
 /** @internal Rails-private helper. */
-export function _assignAttribute(model: AttributeAssignment, key: string, value: unknown): void {
-  const setter = findSetter(model, key);
+export function _assignAttribute(model: AttributeAssignment, k: string, v: unknown): void {
+  const setter = findSetter(model, k);
   if (setter) {
-    setter.call(model, value);
+    setter.call(model, v);
     return;
   }
   try {
-    model.writeAttribute(key, value);
+    model.writeAttribute(k, v);
   } catch (error) {
     // Rails `_assign_attribute` only writes through a setter; a key with no
     // setter goes straight to `attribute_writer_missing` → UnknownAttributeError.
@@ -53,9 +51,9 @@ export function _assignAttribute(model: AttributeAssignment, key: string, value:
     // MissingAttributeError with no setter — surface it as Rails does.
     if (error instanceof UnknownAttributeError || error instanceof MissingAttributeError) {
       if (typeof model.attributeWriterMissing === "function") {
-        model.attributeWriterMissing(key, value);
+        model.attributeWriterMissing(k, v);
       } else {
-        attributeWriterMissing(model, key, value);
+        attributeWriterMissing(model, k, v);
       }
     } else {
       throw error;

--- a/packages/activemodel/src/attribute-mutation-tracker.ts
+++ b/packages/activemodel/src/attribute-mutation-tracker.ts
@@ -49,14 +49,14 @@ export class AttributeMutationTracker {
   }
 
   changedAttributeNames(): string[] {
-    return this.attrNames().filter((name) => this.isChanged(name));
+    return this.attrNames().filter((attrName) => this.isChanged(attrName));
   }
 
   changedValues(): Record<string, unknown> {
     const result: Record<string, unknown> = {};
-    for (const name of this.attrNames()) {
-      if (this.isChanged(name)) {
-        result[name] = this.originalValue(name);
+    for (const attrName of this.attrNames()) {
+      if (this.isChanged(attrName)) {
+        result[attrName] = this.originalValue(attrName);
       }
     }
     return result;
@@ -64,81 +64,81 @@ export class AttributeMutationTracker {
 
   changes(): Record<string, [unknown, unknown]> {
     const result: Record<string, [unknown, unknown]> = {};
-    for (const name of this.attrNames()) {
-      const change = this.changeToAttribute(name);
-      if (change) result[name] = change;
+    for (const attrName of this.attrNames()) {
+      const change = this.changeToAttribute(attrName);
+      if (change) result[attrName] = change;
     }
     return result;
   }
 
-  changeToAttribute(name: string): [unknown, unknown] | null {
-    if (this.isChanged(name)) {
-      return [this.originalValue(name), this.fetchValue(name)];
+  changeToAttribute(attrName: string): [unknown, unknown] | null {
+    if (this.isChanged(attrName)) {
+      return [this.originalValue(attrName), this.fetchValue(attrName)];
     }
     return null;
   }
 
   anyChanges(): boolean {
-    return this.attrNames().some((name) => this.isChanged(name));
+    return this.attrNames().some((attr) => this.isChanged(attr));
   }
 
-  isChanged(name: string, options?: { from?: unknown; to?: unknown }): boolean {
-    if (!this.attributeChanged(name)) return false;
+  isChanged(attrName: string, options?: { from?: unknown; to?: unknown }): boolean {
+    if (!this.attributeChanged(attrName)) return false;
     if (
       options &&
       "from" in options &&
-      !valuesEqual(this.originalValue(name), this.typeCast(name, options.from))
+      !valuesEqual(this.originalValue(attrName), this.typeCast(attrName, options.from))
     )
       return false;
     if (
       options &&
       "to" in options &&
-      !valuesEqual(this.fetchValue(name), this.typeCast(name, options.to))
+      !valuesEqual(this.fetchValue(attrName), this.typeCast(attrName, options.to))
     )
       return false;
     return true;
   }
 
-  changedInPlace(name: string): boolean {
-    return this.attributes.getAttribute(name).changedInPlace();
+  changedInPlace(attrName: string): boolean {
+    return this.attributes.getAttribute(attrName).changedInPlace();
   }
 
-  forgetChange(name: string): void {
-    this.forcedChanges.delete(name);
-    if (this.attributes.has(name)) {
-      const attr = this.attributes.getAttribute(name);
-      this.attributes.set(name, attr.forgettingAssignment());
+  forgetChange(attrName: string): void {
+    this.forcedChanges.delete(attrName);
+    if (this.attributes.has(attrName)) {
+      const attr = this.attributes.getAttribute(attrName);
+      this.attributes.set(attrName, attr.forgettingAssignment());
     }
   }
 
-  originalValue(name: string): unknown {
-    return this.attributes.getAttribute(name).originalValue;
+  originalValue(attrName: string): unknown {
+    return this.attributes.getAttribute(attrName).originalValue;
   }
 
-  forceChange(name: string): void {
+  forceChange(attrName: string): void {
     // Intentionally store the live value (no clone) to match Rails:
     // in-place mutations after forceChange must surface via dirty tracking.
-    this.forcedChanges.set(name, this.fetchValue(name));
+    this.forcedChanges.set(attrName, this.fetchValue(attrName));
   }
 
   protected attrNames(): string[] {
     const keys = new Set(this.attributes.keys());
-    for (const name of this.forcedChanges.keys()) keys.add(name);
+    for (const attrName of this.forcedChanges.keys()) keys.add(attrName);
     return [...keys];
   }
 
-  protected attributeChanged(name: string): boolean {
-    return this.forcedChanges.has(name) || this.attributes.getAttribute(name).isChanged();
+  protected attributeChanged(attrName: string): boolean {
+    return this.forcedChanges.has(attrName) || this.attributes.getAttribute(attrName).isChanged();
   }
 
   /** @internal */
-  protected fetchValue(name: string): unknown {
-    return this.attributes.fetchValue(name);
+  protected fetchValue(attrName: string): unknown {
+    return this.attributes.fetchValue(attrName);
   }
 
   /** @internal */
-  protected typeCast(name: string, value: unknown): unknown {
-    return this.attributes.getAttribute(name).typeCast(value);
+  protected typeCast(attrName: string, value: unknown): unknown {
+    return this.attributes.getAttribute(attrName).typeCast(value);
   }
 }
 
@@ -150,35 +150,35 @@ export class AttributeMutationTracker {
 export class ForcedMutationTracker extends AttributeMutationTracker {
   private finalizedChanges: Record<string, [unknown, unknown]> | null = null;
 
-  changedInPlace(_name: string): boolean {
+  changedInPlace(_attrName: string): boolean {
     return false;
   }
 
-  changeToAttribute(name: string): [unknown, unknown] | null {
+  changeToAttribute(attrName: string): [unknown, unknown] | null {
     if (
       this.finalizedChanges &&
-      Object.prototype.hasOwnProperty.call(this.finalizedChanges, name)
+      Object.prototype.hasOwnProperty.call(this.finalizedChanges, attrName)
     ) {
-      return [...this.finalizedChanges[name]];
+      return [...this.finalizedChanges[attrName]];
     }
-    return super.changeToAttribute(name);
+    return super.changeToAttribute(attrName);
   }
 
-  forgetChange(name: string): void {
-    this.forcedChanges.delete(name);
+  forgetChange(attrName: string): void {
+    this.forcedChanges.delete(attrName);
   }
 
-  originalValue(name: string): unknown {
-    if (this.isChanged(name)) {
-      return this.forcedChanges.get(name);
+  originalValue(attrName: string): unknown {
+    if (this.isChanged(attrName)) {
+      return this.forcedChanges.get(attrName);
     }
-    return this.fetchValue(name);
+    return this.fetchValue(attrName);
   }
 
-  forceChange(name: string): void {
-    if (this.forcedChanges.has(name)) return;
-    const value = this.fetchValue(name);
-    this.forcedChanges.set(name, cloneValue(value));
+  forceChange(attrName: string): void {
+    if (this.forcedChanges.has(attrName)) return;
+    const value = this.fetchValue(attrName);
+    this.forcedChanges.set(attrName, cloneValue(value));
   }
 
   finalizeChanges(): void {
@@ -189,12 +189,12 @@ export class ForcedMutationTracker extends AttributeMutationTracker {
     return Array.from(this.forcedChanges.keys());
   }
 
-  protected override attributeChanged(name: string): boolean {
-    return this.forcedChanges.has(name);
+  protected override attributeChanged(attrName: string): boolean {
+    return this.forcedChanges.has(attrName);
   }
 
   /** @internal */
-  protected override typeCast(_name: string, value: unknown): unknown {
+  protected override typeCast(_attrName: string, value: unknown): unknown {
     return value;
   }
 }
@@ -217,7 +217,7 @@ export class NullMutationTracker {
     return {};
   }
 
-  changeToAttribute(_name: string): [unknown, unknown] | null {
+  changeToAttribute(_attrName: string): [unknown, unknown] | null {
     return null;
   }
 
@@ -225,19 +225,19 @@ export class NullMutationTracker {
     return false;
   }
 
-  isChanged(_name: string, _options?: { from?: unknown; to?: unknown }): boolean {
+  isChanged(_attrName: string, _options?: { from?: unknown; to?: unknown }): boolean {
     return false;
   }
 
-  changedInPlace(_name: string): boolean {
+  changedInPlace(_attrName: string): boolean {
     return false;
   }
 
-  originalValue(_name: string): unknown {
+  originalValue(_attrName: string): unknown {
     return undefined;
   }
 
-  forgetChange(_name: string): void {}
-  forceChange(_name: string): void {}
+  forgetChange(_attrName: string): void {}
+  forceChange(_attrName: string): void {}
   finalizeChanges(): void {}
 }

--- a/packages/activemodel/src/attribute-set.ts
+++ b/packages/activemodel/src/attribute-set.ts
@@ -190,9 +190,9 @@ export class AttributeSet {
     return new AttributeSet(newAttrs);
   }
 
-  reset(name: string): void {
-    if (this.has(name)) {
-      this.writeFromDatabase(name, null);
+  reset(key: string): void {
+    if (this.has(key)) {
+      this.writeFromDatabase(key, null);
     }
   }
 

--- a/packages/activemodel/src/attribute.ts
+++ b/packages/activemodel/src/attribute.ts
@@ -36,20 +36,25 @@ export abstract class Attribute {
 
   // --- Factory methods ---
 
-  static fromDatabase(name: string, value: unknown, type: Type, castValue?: unknown): FromDatabase {
+  static fromDatabase(
+    name: string,
+    valueBeforeTypeCast: unknown,
+    type: Type,
+    value?: unknown,
+  ): FromDatabase {
     if (arguments.length >= 4) {
-      return new FromDatabase(name, value, type, null, castValue);
+      return new FromDatabase(name, valueBeforeTypeCast, type, null, value);
     }
-    return new FromDatabase(name, value, type, null);
+    return new FromDatabase(name, valueBeforeTypeCast, type, null);
   }
 
   static fromUser(
     name: string,
-    value: unknown,
+    valueBeforeTypeCast: unknown,
     type: Type,
     originalAttribute: Attribute | null = null,
   ): FromUser {
-    return new FromUser(name, value, type, originalAttribute);
+    return new FromUser(name, valueBeforeTypeCast, type, originalAttribute);
   }
 
   static withCastValue(name: string, value: unknown, type: Type): WithCastValue {

--- a/packages/activemodel/src/errors.ts
+++ b/packages/activemodel/src/errors.ts
@@ -88,8 +88,8 @@ export class Errors<TBase extends object = object> {
    *     @errors.append(NestedError.new(@base, error, override_options))
    *   end
    */
-  import(error: ActiveModelError, options?: { attribute?: string; type?: string }): void {
-    this._errors.push(new NestedError(this._base, error, options));
+  import(error: ActiveModelError, overrideOptions?: { attribute?: string; type?: string }): void {
+    this._errors.push(new NestedError(this.base, error, overrideOptions));
   }
 
   /**
@@ -251,7 +251,7 @@ export class Errors<TBase extends object = object> {
     } & Record<string, unknown>,
   ): ActiveModelError {
     const [normAttr, normType, normOpts] = this.normalizeArguments(attribute, type, options);
-    const error = new ActiveModelError(this._base, normAttr, normType, normOpts);
+    const error = new ActiveModelError(this.base, normAttr, normType, normOpts);
     const strict = normOpts.strict;
     if (strict) {
       const ExceptionClass: new (message?: string) => globalThis.Error =
@@ -281,13 +281,14 @@ export class Errors<TBase extends object = object> {
       | ((record: TBase | null, options: Record<string, unknown>) => string) = ":invalid",
     options?: Record<string, unknown>,
   ): boolean {
-    const [normAttr, normType, normOpts] = this.normalizeArguments(attribute, type, options);
+    let normType: string;
+    [attribute, normType, options] = this.normalizeArguments(attribute, type, options);
     if (normType.startsWith(":")) {
       // Symbol branch: strict attribute/type/options match.
-      return this._errors.some((e) => e.strictMatch(normAttr, normType, normOpts));
+      return this._errors.some((e) => e.strictMatch(attribute, normType, options));
     }
     // String branch: full-message lookup (Rails else clause in added?).
-    return this.messagesFor(normAttr).includes(normType);
+    return this.messagesFor(attribute).includes(normType);
   }
 
   /**
@@ -304,13 +305,14 @@ export class Errors<TBase extends object = object> {
       | string
       | ((record: TBase | null, options: Record<string, unknown>) => string) = ":invalid",
   ): boolean {
-    const [normAttr, normType] = this.normalizeArguments(attribute, type);
+    let normType: string;
+    [attribute, normType] = this.normalizeArguments(attribute, type);
     if (normType.startsWith(":")) {
       // Symbol branch: check for errors of this exact type.
-      return this.where(normAttr, normType).length > 0;
+      return this.where(attribute, normType).length > 0;
     }
     // String branch: full-message lookup (Rails else clause).
-    return this.messagesFor(normAttr).includes(normType);
+    return this.messagesFor(attribute).includes(normType);
   }
 
   get fullMessages(): string[] {
@@ -326,7 +328,7 @@ export class Errors<TBase extends object = object> {
   }
 
   fullMessage(attribute: string, message: string): string {
-    return ActiveModelError.fullMessage(attribute, message, this._base);
+    return ActiveModelError.fullMessage(attribute, message, this.base);
   }
 
   generateMessage(
@@ -334,7 +336,7 @@ export class Errors<TBase extends object = object> {
     type: string = ":invalid",
     options?: Record<string, unknown>,
   ): string {
-    return ActiveModelError.generateMessage(attribute, type, this._base, options);
+    return ActiveModelError.generateMessage(attribute, type, this.base, options);
   }
 
   /**

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -2417,9 +2417,8 @@ export class Model {
    */
   assignAttributes(newAttributes: unknown): void {
     assertHashAttributes(newAttributes);
-    const attrs = newAttributes;
-    if (isMassAssignmentEmpty(attrs)) return;
-    this._assignAttributes(this.sanitizeForMassAssignment(attrs));
+    if (isMassAssignmentEmpty(newAttributes)) return;
+    this._assignAttributes(this.sanitizeForMassAssignment(newAttributes));
   }
 
   /**

--- a/packages/activemodel/src/type/integer.ts
+++ b/packages/activemodel/src/type/integer.ts
@@ -58,7 +58,8 @@ export class IntegerType extends NumericValueType {
     // `castValue` (`to_i rescue nil`, integer.rb:90), and `in_range?(nil)` is
     // `!value` => true. Casting here rather than trusting the caller keeps this
     // predicate correct for a raw value, whether or not the caller pre-cast.
-    return this.isInRange(this.cast(value) as number | bigint | null);
+    const castValue = this.cast(value) as number | bigint | null;
+    return this.isInRange(castValue);
   }
 
   /**

--- a/packages/activemodel/src/validations/comparison.ts
+++ b/packages/activemodel/src/validations/comparison.ts
@@ -30,14 +30,14 @@ export class ComparisonValidator extends EachValidator {
   resolveValue = resolveValue;
   errorOptions = errorOptions;
 
-  validateEach(record: ValidatableRecord, attribute: string, value: unknown): void {
+  validateEach(record: ValidatableRecord, attrName: string, value: unknown): void {
     for (const optKey of COMPARE_CHECKS) {
-      const raw = this.options[optKey];
-      if (raw === undefined) continue;
-      const optionValue = this.resolveValue(record, raw);
+      const rawOptionValue = this.options[optKey];
+      if (rawOptionValue === undefined) continue;
+      const optionValue = this.resolveValue(record, rawOptionValue);
 
       if (value === null || value === undefined || (typeof value === "string" && isBlank(value))) {
-        record.errors.add(attribute, ":blank", this.errorOptions(value, optionValue));
+        record.errors.add(attrName, ":blank", this.errorOptions(value, optionValue));
         return;
       }
 
@@ -45,7 +45,7 @@ export class ComparisonValidator extends EachValidator {
         const cmp = this.compare(value, optionValue);
         if (!COMPARE_OPS[optKey](cmp)) {
           record.errors.add(
-            attribute,
+            attrName,
             COMPARE_KEYS_TO_RAILS[optKey],
             this.errorOptions(value, optionValue),
           );
@@ -54,7 +54,7 @@ export class ComparisonValidator extends EachValidator {
         if (!(e instanceof ArgumentError)) throw e;
         // Rails comparison.rb:30 — uses the ArgumentError message as the
         // error key/message and continues to the next compare option.
-        record.errors.add(attribute, e.message);
+        record.errors.add(attrName, e.message);
       }
     }
   }

--- a/packages/activemodel/src/validations/confirmation.ts
+++ b/packages/activemodel/src/validations/confirmation.ts
@@ -32,11 +32,11 @@ export class ConfirmationValidator extends EachValidator {
   validateEach(record: ValidatableRecord, attribute: string, value: unknown): void {
     const confirmationAttr = `${attribute}Confirmation`;
     const rec = record as unknown as Record<string, unknown>;
-    const confirmation =
+    const confirmed =
       (rec.readAttribute as ((a: string) => unknown) | undefined)?.(confirmationAttr) ??
       rec[confirmationAttr];
-    if (confirmation == null) return;
-    if (!this.isConfirmationValueEqual(record, attribute, value, confirmation)) {
+    if (confirmed == null) return;
+    if (!this.isConfirmationValueEqual(record, attribute, value, confirmed)) {
       const modelClass = rec.constructor as
         | { humanAttributeName?: (a: string) => string }
         | undefined;

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -93,8 +93,8 @@ export class Attribute extends Node {
    *
    * @internal
    */
-  quotedNode(value: unknown): Node {
-    return buildQuoted(value, this);
+  quotedNode(other: unknown): Node {
+    return buildQuoted(other, this);
   }
 
   // -- Ordering --
@@ -156,8 +156,8 @@ export class Attribute extends Node {
 
   // -- Aliasing --
 
-  as(aliasName: string): As {
-    return new As(this, new SqlLiteral(aliasName, { retryable: true }));
+  as(other: string): As {
+    return new As(this, new SqlLiteral(other, { retryable: true }));
   }
 
   // -- Aggregate functions --

--- a/packages/arel/src/delete-manager.ts
+++ b/packages/arel/src/delete-manager.ts
@@ -42,13 +42,12 @@ export class DeleteManager extends TreeManager {
    *
    * Mirrors: Arel::DeleteManager#group
    */
-  group(column: Node | string, ...rest: (Node | string)[]): this {
-    const columns = [column, ...rest];
-    for (const c of columns) {
-      if (typeof c === "string") {
-        this.ast.groups.push(new Group(new SqlLiteral(c)));
+  group(...columns: (Node | string)[]): this {
+    for (const column of columns) {
+      if (typeof column === "string") {
+        this.ast.groups.push(new Group(new SqlLiteral(column)));
       } else {
-        this.ast.groups.push(new Group(c));
+        this.ast.groups.push(new Group(column));
       }
     }
     return this;

--- a/packages/arel/src/delete-manager.ts
+++ b/packages/arel/src/delete-manager.ts
@@ -42,7 +42,7 @@ export class DeleteManager extends TreeManager {
    *
    * Mirrors: Arel::DeleteManager#group
    */
-  group(...columns: (Node | string)[]): this {
+  group(columns: (Node | string)[]): this {
     for (const column of columns) {
       if (typeof column === "string") {
         this.ast.groups.push(new Group(new SqlLiteral(column)));

--- a/packages/arel/src/insert-manager.ts
+++ b/packages/arel/src/insert-manager.ts
@@ -82,12 +82,12 @@ export class InsertManager extends TreeManager {
       if (first?.relation) this.ast.relation = first.relation;
     }
 
-    const row: unknown[] = [];
-    for (const [col, val] of fields) {
-      this.ast.columns.push(col);
-      row.push(val);
+    const values: unknown[] = [];
+    for (const [column, value] of fields) {
+      this.ast.columns.push(column);
+      values.push(value);
     }
-    this.ast.values = this.createValues(row);
+    this.ast.values = this.createValues(values);
     return this;
   }
 

--- a/packages/arel/src/nodes/infix-operation.ts
+++ b/packages/arel/src/nodes/infix-operation.ts
@@ -35,8 +35,8 @@ export class InfixOperation extends Binary {
     return buildQuoted(other, this);
   }
 
-  as(aliasName: string): As {
-    return new As(this, new SqlLiteral(aliasName, { retryable: true }));
+  as(other: string): As {
+    return new As(this, new SqlLiteral(other, { retryable: true }));
   }
 
   asc(): Ascending {

--- a/packages/arel/src/predications.ts
+++ b/packages/arel/src/predications.ts
@@ -163,17 +163,17 @@ export const Predications = {
   notEq(this: Node & PredicationHost, other: unknown): NotEqual {
     return new NotEqual(this, this.quotedNode(other));
   },
-  gt(this: Node & PredicationHost, other: unknown): GreaterThan {
-    return new GreaterThan(this, this.quotedNode(other));
+  gt(this: Node & PredicationHost, right: unknown): GreaterThan {
+    return new GreaterThan(this, this.quotedNode(right));
   },
-  gteq(this: Node & PredicationHost, other: unknown): GreaterThanOrEqual {
-    return new GreaterThanOrEqual(this, this.quotedNode(other));
+  gteq(this: Node & PredicationHost, right: unknown): GreaterThanOrEqual {
+    return new GreaterThanOrEqual(this, this.quotedNode(right));
   },
-  lt(this: Node & PredicationHost, other: unknown): LessThan {
-    return new LessThan(this, this.quotedNode(other));
+  lt(this: Node & PredicationHost, right: unknown): LessThan {
+    return new LessThan(this, this.quotedNode(right));
   },
-  lteq(this: Node & PredicationHost, other: unknown): LessThanOrEqual {
-    return new LessThanOrEqual(this, this.quotedNode(other));
+  lteq(this: Node & PredicationHost, right: unknown): LessThanOrEqual {
+    return new LessThanOrEqual(this, this.quotedNode(right));
   },
 
   isDistinctFrom(this: Node & PredicationHost, other: unknown): IsDistinctFrom {
@@ -185,7 +185,7 @@ export const Predications = {
 
   matches(
     this: Node & PredicationHost,
-    pattern: unknown,
+    other: unknown,
     escape: string | Node | null = null,
     caseSensitive = false,
   ): Matches {
@@ -193,25 +193,21 @@ export const Predications = {
     // `quotedNode` (→ buildQuoted) already unwraps SelectManager/TreeManager
     // `.ast` and passes Nodes through untouched, so we don't need a
     // separate branch for AST-bearing inputs here.
-    return new Matches(this, this.quotedNode(pattern), escape, caseSensitive);
+    return new Matches(this, this.quotedNode(other), escape, caseSensitive);
   },
   doesNotMatch(
     this: Node & PredicationHost,
-    pattern: unknown,
+    other: unknown,
     escape: string | Node | null = null,
     caseSensitive = false,
   ): DoesNotMatch {
-    return new DoesNotMatch(this, this.quotedNode(pattern), escape, caseSensitive);
+    return new DoesNotMatch(this, this.quotedNode(other), escape, caseSensitive);
   },
-  matchesRegexp(this: Node & PredicationHost, pattern: string, caseSensitive = true): RegexpNode {
-    return new RegexpNode(this, this.quotedNode(pattern), caseSensitive);
+  matchesRegexp(this: Node & PredicationHost, other: string, caseSensitive = true): RegexpNode {
+    return new RegexpNode(this, this.quotedNode(other), caseSensitive);
   },
-  doesNotMatchRegexp(
-    this: Node & PredicationHost,
-    pattern: string,
-    caseSensitive = true,
-  ): NotRegexp {
-    return new NotRegexp(this, this.quotedNode(pattern), caseSensitive);
+  doesNotMatchRegexp(this: Node & PredicationHost, other: string, caseSensitive = true): NotRegexp {
+    return new NotRegexp(this, this.quotedNode(other), caseSensitive);
   },
 
   in(this: Node & PredicationHost, other: unknown): In {

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -560,10 +560,7 @@ export class SelectManager extends TreeManager {
     um.order(...this.orders);
     um.wheres = this.constraints;
     um.key = key;
-    if (groupValuesColumns.length > 0) {
-      const [first, ...rest] = groupValuesColumns;
-      um.group(first, ...rest);
-    }
+    if (groupValuesColumns.length > 0) um.group(groupValuesColumns);
     if (havingClause !== null) um.having(havingClause);
     return um;
   }
@@ -591,10 +588,7 @@ export class SelectManager extends TreeManager {
     dm.order(...this.orders);
     dm.wheres = this.constraints;
     dm.key = key;
-    if (groupValuesColumns.length > 0) {
-      const [first, ...rest] = groupValuesColumns;
-      dm.group(first, ...rest);
-    }
+    if (groupValuesColumns.length > 0) dm.group(groupValuesColumns);
     if (havingClause !== null) dm.having(havingClause);
     return dm;
   }

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -115,10 +115,10 @@ export class SelectManager extends TreeManager {
    *
    * Mirrors: Arel::SelectManager#as
    */
-  as(alias: string): TableAlias {
+  as(other: string): TableAlias {
     return this.createTableAlias(
       this.grouping(this.ast),
-      new SqlLiteral(alias, { retryable: true }),
+      new SqlLiteral(other, { retryable: true }),
     );
   }
 
@@ -172,12 +172,12 @@ export class SelectManager extends TreeManager {
   /**
    * Add GROUP BY.
    */
-  group(...exprs: (Node | string)[]): this {
-    for (const e of exprs) {
-      if (typeof e === "string") {
-        this.core.groups.push(new Group(new SqlLiteral(e)));
+  group(...columns: (Node | string)[]): this {
+    for (const column of columns) {
+      if (typeof column === "string") {
+        this.core.groups.push(new Group(new SqlLiteral(column)));
       } else {
-        this.core.groups.push(new Group(e));
+        this.core.groups.push(new Group(column));
       }
     }
     return this;
@@ -211,23 +211,23 @@ export class SelectManager extends TreeManager {
    * Mirrors: Arel::SelectManager#join (select_manager.rb:102-113).
    */
   join(
-    table: Node | string | null | undefined,
+    relation: Node | string | null | undefined,
     klass: new (left: Node, right: Node | null) => Join = InnerJoin,
   ): this {
-    if (table == null) return this;
-
-    const tableNode = typeof table === "string" ? new SqlLiteral(table) : table;
+    if (relation == null) return this;
 
     // Rails: `case relation when String, Nodes::SqlLiteral` (select_manager.rb:105-109).
     // SqlLiteral subclasses String in Ruby, so both arms share the emptiness
     // check and the StringJoin promotion.
-    if (typeof table === "string" || table instanceof SqlLiteral) {
-      const text = typeof table === "string" ? table : table.value;
+    if (typeof relation === "string" || relation instanceof SqlLiteral) {
+      const text = typeof relation === "string" ? relation : relation.value;
       if (text.length === 0) throw new EmptyJoinError();
       klass = StringJoin as unknown as new (left: Node, right: Node | null) => Join;
     }
 
-    this.core.source.right.push(this.createJoin(tableNode, null, klass));
+    if (typeof relation === "string") relation = new SqlLiteral(relation);
+
+    this.core.source.right.push(this.createJoin(relation, null, klass));
     return this;
   }
 
@@ -236,8 +236,8 @@ export class SelectManager extends TreeManager {
    *
    * Mirrors: Arel::SelectManager#outer_join (select_manager.rb:115-117).
    */
-  outerJoin(table: Node | string | null | undefined): this {
-    return this.join(table, OuterJoin);
+  outerJoin(relation: Node | string | null | undefined): this {
+    return this.join(relation, OuterJoin);
   }
 
   /**
@@ -252,20 +252,20 @@ export class SelectManager extends TreeManager {
    * Define a named window.
    */
   window(name: string): NamedWindow {
-    const win = new NamedWindow(name);
-    this.core.windows.push(win);
-    return win;
+    const window = new NamedWindow(name);
+    this.core.windows.push(window);
+    return window;
   }
 
   /**
    * Add projections (columns to SELECT).
    */
   project(...projections: (Node | string)[]): this {
-    for (const p of projections) {
-      if (typeof p === "string") {
-        this.core.projections.push(new SqlLiteral(p));
+    for (const x of projections) {
+      if (typeof x === "string") {
+        this.core.projections.push(new SqlLiteral(x));
       } else {
-        this.core.projections.push(p);
+        this.core.projections.push(x);
       }
     }
     return this;
@@ -404,12 +404,12 @@ export class SelectManager extends TreeManager {
    *
    * Mirrors: Arel::SelectManager#lateral
    */
-  lateral(alias?: string): Lateral {
+  lateral(tableName?: string): Lateral {
     // Mirrors Rails: `lateral(table_name = nil)` builds the base — either the
     // raw AST or `as(table_name)` (a TableAlias wrapping a Grouping) — and
     // wraps it in a Lateral. The TableAlias lives inside the Lateral, not
     // outside (select_manager.rb).
-    const base = alias === undefined ? this.ast : this.as(alias);
+    const base = tableName === undefined ? this.ast : this.as(tableName);
     return new Lateral(base);
   }
 
@@ -427,8 +427,8 @@ export class SelectManager extends TreeManager {
    * Mirrors: Arel::SelectManager#take (select_manager.rb). Pass `null`
    * to clear; raw amounts flow through `new Limit(amount)` unwrapped.
    */
-  take(amount: number | Node | null): this {
-    this.ast.limit = amount == null ? null : new Limit(amount);
+  take(limit: number | Node | null): this {
+    this.ast.limit = limit == null ? null : new Limit(limit);
     return this;
   }
 
@@ -465,11 +465,11 @@ export class SelectManager extends TreeManager {
 
   // Mirrors Arel::SelectManager#collapse (select_manager.rb:256-268).
   protected collapse(exprs: unknown[]): Node {
-    const filtered = exprs
-      .filter((e) => e !== null && e !== undefined)
-      .map((e) => (typeof e === "string" ? new SqlLiteral(e) : (e as Node)));
-    if (filtered.length === 1) return filtered[0];
-    return this.createAnd(filtered);
+    exprs = exprs
+      .filter((expr) => expr !== null && expr !== undefined)
+      .map((expr) => (typeof expr === "string" ? new SqlLiteral(expr) : (expr as Node)));
+    if (exprs.length === 1) return exprs[0] as Node;
+    return this.createAnd(exprs as Node[]);
   }
 
   private get core(): SelectCore {

--- a/packages/arel/src/update-manager.test.ts
+++ b/packages/arel/src/update-manager.test.ts
@@ -25,14 +25,14 @@ describe("UpdateManagerTest", () => {
     it("adds columns to the AST when group value is a String", () => {
       const um = new UpdateManager();
       um.table(users);
-      um.group("name");
+      um.group(["name"]);
       expect(um.ast.groups.length).toBe(1);
     });
 
     it("adds columns to the AST when group value is a Symbol", () => {
       const um = new UpdateManager();
       um.table(users);
-      um.group(users.get("name"));
+      um.group([users.get("name")]);
       expect(um.ast.groups.length).toBe(1);
     });
   });

--- a/packages/arel/src/update-manager.ts
+++ b/packages/arel/src/update-manager.ts
@@ -82,7 +82,7 @@ export class UpdateManager extends TreeManager {
    *
    * Mirrors: Arel::UpdateManager#group
    */
-  group(...columns: (Node | string)[]): this {
+  group(columns: (Node | string)[]): this {
     for (const column of columns) {
       if (typeof column === "string") {
         this.ast.groups.push(new Group(new SqlLiteral(column)));

--- a/packages/arel/src/update-manager.ts
+++ b/packages/arel/src/update-manager.ts
@@ -82,13 +82,12 @@ export class UpdateManager extends TreeManager {
    *
    * Mirrors: Arel::UpdateManager#group
    */
-  group(column: Node | string, ...rest: (Node | string)[]): this {
-    const columns = [column, ...rest];
-    for (const c of columns) {
-      if (typeof c === "string") {
-        this.ast.groups.push(new Group(new SqlLiteral(c)));
+  group(...columns: (Node | string)[]): this {
+    for (const column of columns) {
+      if (typeof column === "string") {
+        this.ast.groups.push(new Group(new SqlLiteral(column)));
       } else {
-        this.ast.groups.push(new Group(c));
+        this.ast.groups.push(new Group(column));
       }
     }
     return this;

--- a/packages/arel/src/visitors/dot.test.ts
+++ b/packages/arel/src/visitors/dot.test.ts
@@ -344,7 +344,7 @@ describe("TestDot", () => {
       const stmt = new UpdateManager()
         .table(users)
         .set([[users.get("name"), "x"]])
-        .group(users.get("dept"))
+        .group([users.get("dept")])
         .having(users.get("active").eq(true)).ast;
       const out = dot.compile(stmt);
       expect(out).toContain("UpdateStatement");
@@ -357,7 +357,7 @@ describe("TestDot", () => {
     it("DeleteStatement emits Rails' six edges and no groups/havings", () => {
       const stmt = new DeleteManager()
         .from(users)
-        .group(users.get("dept"))
+        .group([users.get("dept")])
         .having(users.get("active").eq(true)).ast;
       const out = dot.compile(stmt);
       expect(out).toContain("DeleteStatement");

--- a/packages/arel/src/visitors/dot.ts
+++ b/packages/arel/src/visitors/dot.ts
@@ -503,10 +503,9 @@ export class Dot extends Visitor {
 
   /** Mirrors Rails' Dot#edge — push edge, run block, pop. */
   protected edge(name: string, block: () => void): void {
-    const from = this.nodeStack[this.nodeStack.length - 1];
-    const e = new DotEdge(name, from);
-    this.edgeStack.push(e);
-    this.edges.push(e);
+    const edge = new DotEdge(name, this.nodeStack[this.nodeStack.length - 1]);
+    this.edgeStack.push(edge);
+    this.edges.push(edge);
     try {
       block();
     } finally {

--- a/packages/arel/src/visitors/mysql.ts
+++ b/packages/arel/src/visitors/mysql.ts
@@ -13,12 +13,12 @@ export class MySQL extends ToSql {
   // cast form) rather than the prefix-`BINARY ` operator the previous
   // Trails impl used. Both force binary comparison; this matches Rails'
   // emitted SQL.
-  protected override visitArelNodesBin(node: Nodes.Bin, collector: SQLString): SQLString {
+  protected override visitArelNodesBin(o: Nodes.Bin, collector: SQLString): SQLString {
     collector.append("CAST(");
-    if (node.expr instanceof Node) {
-      this.visit(node.expr, collector);
-    } else if (node.expr !== null) {
-      collector.append(String(node.expr));
+    if (o.expr instanceof Node) {
+      this.visit(o.expr, collector);
+    } else if (o.expr !== null) {
+      collector.append(String(o.expr));
     }
     collector.append(" AS BINARY)");
     return collector;
@@ -30,70 +30,70 @@ export class MySQL extends ToSql {
   // relation prefix this leaves on for an Attribute is fine: MySQL's
   // `UPDATE t SET x = t.x + 1` is valid.
   protected override visitArelNodesUnqualifiedColumn(
-    node: Nodes.UnqualifiedColumn,
+    o: Nodes.UnqualifiedColumn,
     collector: SQLString,
   ): SQLString {
-    if (node.expr instanceof Node) {
-      this.visit(node.expr, collector);
-    } else if (node.expr !== null) {
-      collector.append(String(node.expr));
+    if (o.expr instanceof Node) {
+      this.visit(o.expr, collector);
+    } else if (o.expr !== null) {
+      collector.append(String(o.expr));
     }
     return collector;
   }
 
   protected override visitArelNodesSelectStatement(
-    node: Nodes.SelectStatement,
+    o: Nodes.SelectStatement,
     collector: SQLString,
   ): SQLString {
-    if (node.with) {
-      this.visit(node.with, collector);
+    if (o.with) {
+      this.visit(o.with, collector);
       collector.append(" ");
     }
 
-    for (let i = 0; i < node.cores.length; i++) {
+    for (let i = 0; i < o.cores.length; i++) {
       if (i > 0) collector.append(" ");
-      this.visit(node.cores[i], collector);
+      this.visit(o.cores[i], collector);
     }
 
-    if (node.orders.length > 0) {
+    if (o.orders.length > 0) {
       collector.append(" ORDER BY ");
-      this.injectJoin(node.orders, collector, ", ");
+      this.injectJoin(o.orders, collector, ", ");
     }
 
-    if (node.limit) {
+    if (o.limit) {
       collector.append(" ");
-      this.visit(node.limit, collector);
-    } else if (node.offset) {
+      this.visit(o.limit, collector);
+    } else if (o.offset) {
       // MySQL requires a LIMIT when using OFFSET; use the max unsigned 64-bit value.
       collector.append(" LIMIT 18446744073709551615");
     }
 
-    if (node.offset) {
+    if (o.offset) {
       collector.append(" ");
-      this.visit(node.offset, collector);
+      this.visit(o.offset, collector);
     }
 
-    if (node.lock) {
+    if (o.lock) {
       collector.append(" ");
-      this.visit(node.lock, collector);
+      this.visit(o.lock, collector);
     }
 
     return collector;
   }
 
   protected override visitArelNodesSelectCore(
-    node: Nodes.SelectCore,
+    o: Nodes.SelectCore,
     collector: SQLString,
   ): SQLString {
-    node.froms ??= new Nodes.SqlLiteral("DUAL", { retryable: true });
-    return super.visitArelNodesSelectCore(node, collector);
+    o.froms ??= new Nodes.SqlLiteral("DUAL", { retryable: true });
+    return super.visitArelNodesSelectCore(o, collector);
   }
 
-  protected override visitArelNodesConcat(node: Nodes.Concat, collector: SQLString): SQLString {
+  protected override visitArelNodesConcat(o: Nodes.Concat, collector: SQLString): SQLString {
     collector.append(" CONCAT(");
-    this.visit(node.left, collector);
+    this.visit(o.left, collector);
     collector.append(", ");
-    this.visit(node.right, collector);
+    this.visit(o.right, collector);
     collector.append(") ");
     return collector;
   }
@@ -102,68 +102,62 @@ export class MySQL extends ToSql {
   // FROM` is supported only on MySQL 8.0.14+; the operator form works
   // on every MySQL version.
   protected override visitArelNodesIsNotDistinctFrom(
-    node: Nodes.IsNotDistinctFrom,
+    o: Nodes.IsNotDistinctFrom,
     collector: SQLString,
   ): SQLString {
-    this.visit(node.left, collector);
+    this.visit(o.left, collector);
     collector.append(" <=> ");
-    this.visit(node.right, collector);
+    this.visit(o.right, collector);
     return collector;
   }
 
   protected override visitArelNodesIsDistinctFrom(
-    node: Nodes.IsDistinctFrom,
+    o: Nodes.IsDistinctFrom,
     collector: SQLString,
   ): SQLString {
     collector.append("NOT ");
-    return this.visitArelNodesIsNotDistinctFrom(node, collector);
+    return this.visitArelNodesIsNotDistinctFrom(o, collector);
   }
 
   // MySQL uses `REGEXP` / `NOT REGEXP`, not the SQL-standard `~` /
   // `!~` (which is Postgres). Mirrors Rails MySQL's `infix_value`
   // helper — same shape as visitArelNodesMatches.
-  protected override visitArelNodesRegexp(node: Nodes.Regexp, collector: SQLString): SQLString {
-    this.visit(node.left, collector);
+  protected override visitArelNodesRegexp(o: Nodes.Regexp, collector: SQLString): SQLString {
+    this.visit(o.left, collector);
     collector.append(" REGEXP ");
-    this.visit(node.right, collector);
+    this.visit(o.right, collector);
     return collector;
   }
 
-  protected override visitArelNodesNotRegexp(
-    node: Nodes.NotRegexp,
-    collector: SQLString,
-  ): SQLString {
-    this.visit(node.left, collector);
+  protected override visitArelNodesNotRegexp(o: Nodes.NotRegexp, collector: SQLString): SQLString {
+    this.visit(o.left, collector);
     collector.append(" NOT REGEXP ");
-    this.visit(node.right, collector);
+    this.visit(o.right, collector);
     return collector;
   }
 
   protected override visitArelNodesNullsFirst(
-    node: Nodes.NullsFirst,
+    o: Nodes.NullsFirst,
     collector: SQLString,
   ): SQLString {
     // MySQL has no NULLS FIRST; emulate: col IS NOT NULL, col ASC/DESC
-    const ordering = node.expr as Nodes.Ascending | Nodes.Descending;
-    this.visit(ordering.expr as Nodes.NodeOrValue, collector);
+    const expr = o.expr as Nodes.Ascending | Nodes.Descending;
+    this.visit(expr.expr as Nodes.NodeOrValue, collector);
     collector.append(" IS NOT NULL, ");
-    this.visit(ordering, collector);
+    this.visit(expr, collector);
     return collector;
   }
 
-  protected override visitArelNodesNullsLast(
-    node: Nodes.NullsLast,
-    collector: SQLString,
-  ): SQLString {
+  protected override visitArelNodesNullsLast(o: Nodes.NullsLast, collector: SQLString): SQLString {
     // MySQL has no NULLS LAST; emulate: col IS NULL, col ASC/DESC
-    const ordering = node.expr as Nodes.Ascending | Nodes.Descending;
-    this.visit(ordering.expr as Nodes.NodeOrValue, collector);
+    const expr = o.expr as Nodes.Ascending | Nodes.Descending;
+    this.visit(expr.expr as Nodes.NodeOrValue, collector);
     collector.append(" IS NULL, ");
-    this.visit(ordering, collector);
+    this.visit(expr, collector);
     return collector;
   }
 
-  protected override visitArelNodesCte(node: Nodes.Cte, collector: SQLString): SQLString {
+  protected override visitArelNodesCte(o: Nodes.Cte, collector: SQLString): SQLString {
     // MySQL identifiers are backtick-quoted, not double-quoted, and the
     // MATERIALIZED / NOT MATERIALIZED modifiers Postgres supports are
     // ignored. Mirrors Rails' MySQL visit_Arel_Nodes_Cte which calls
@@ -172,12 +166,12 @@ export class MySQL extends ToSql {
     // SelectManager as Rails does), so we add them explicitly. But a
     // Grouping (SqlLiteral path) or a set-operation node (array CTE → UnionAll)
     // visits with its own parens — skip the explicit wrap in that case.
-    collector.append(`${this.quoteTableName(node.name)} AS `);
-    if (cteRelationSelfWraps(node.relation)) {
-      this.visit(node.relation, collector);
+    collector.append(`${this.quoteTableName(o.name)} AS `);
+    if (cteRelationSelfWraps(o.relation)) {
+      this.visit(o.relation, collector);
     } else {
       collector.append("(");
-      this.visit(node.relation, collector);
+      this.visit(o.relation, collector);
       collector.append(")");
     }
     return collector;
@@ -240,9 +234,12 @@ export class MySQL extends ToSql {
 
     const stmt = new Nodes.SelectStatement();
     const core = stmt.cores[stmt.cores.length - 1];
-    const keyName = (key as unknown as { name: string }).name;
     core.source = new Nodes.JoinSource(new Nodes.Grouping(subselect).as("__active_record_temp"));
-    core.projections = [new Nodes.SqlLiteral(this.quoteColumnName(keyName), { retryable: true })];
+    core.projections = [
+      new Nodes.SqlLiteral(this.quoteColumnName((key as unknown as { name: string }).name), {
+        retryable: true,
+      }),
+    ];
     return stmt;
   }
 }

--- a/packages/arel/src/visitors/postgresql.ts
+++ b/packages/arel/src/visitors/postgresql.ts
@@ -9,45 +9,42 @@ import { ToSql } from "./to-sql.js";
  * Mirrors: Arel::Visitors::PostgreSQL
  */
 export class PostgreSQL extends ToSql {
-  protected override visitArelNodesMatches(node: Nodes.Matches, collector: SQLString): SQLString {
-    this.visit(node.left, collector);
-    collector.append(node.caseSensitive ? " LIKE " : " ILIKE ");
-    this.visit(node.right, collector);
-    this.appendEscape(node.escape, collector);
+  protected override visitArelNodesMatches(o: Nodes.Matches, collector: SQLString): SQLString {
+    this.visit(o.left, collector);
+    collector.append(o.caseSensitive ? " LIKE " : " ILIKE ");
+    this.visit(o.right, collector);
+    this.appendEscape(o.escape, collector);
     return collector;
   }
 
   protected override visitArelNodesDoesNotMatch(
-    node: Nodes.DoesNotMatch,
+    o: Nodes.DoesNotMatch,
     collector: SQLString,
   ): SQLString {
-    this.visit(node.left, collector);
-    collector.append(node.caseSensitive ? " NOT LIKE " : " NOT ILIKE ");
-    this.visit(node.right, collector);
-    this.appendEscape(node.escape, collector);
+    this.visit(o.left, collector);
+    collector.append(o.caseSensitive ? " NOT LIKE " : " NOT ILIKE ");
+    this.visit(o.right, collector);
+    this.appendEscape(o.escape, collector);
     return collector;
   }
 
-  protected override visitArelNodesRegexp(node: Nodes.Regexp, collector: SQLString): SQLString {
-    return this.visitBinaryOp(node, node.caseSensitive ? "~" : "~*", collector);
+  protected override visitArelNodesRegexp(o: Nodes.Regexp, collector: SQLString): SQLString {
+    return this.visitBinaryOp(o, o.caseSensitive ? "~" : "~*", collector);
   }
 
-  protected override visitArelNodesNotRegexp(
-    node: Nodes.NotRegexp,
-    collector: SQLString,
-  ): SQLString {
-    return this.visitBinaryOp(node, node.caseSensitive ? "!~" : "!~*", collector);
+  protected override visitArelNodesNotRegexp(o: Nodes.NotRegexp, collector: SQLString): SQLString {
+    return this.visitBinaryOp(o, o.caseSensitive ? "!~" : "!~*", collector);
   }
 
   protected override visitArelNodesDistinctOn(
-    node: Nodes.DistinctOn,
+    o: Nodes.DistinctOn,
     collector: SQLString,
   ): SQLString {
     collector.append("DISTINCT ON ( ");
-    if (node.expr instanceof Node) {
-      this.visit(node.expr, collector);
-    } else if (node.expr !== null) {
-      collector.append(String(node.expr));
+    if (o.expr instanceof Node) {
+      this.visit(o.expr, collector);
+    } else if (o.expr !== null) {
+      collector.append(String(o.expr));
     }
     collector.append(" )");
     return collector;
@@ -57,53 +54,53 @@ export class PostgreSQL extends ToSql {
   // the parens. The base ToSql renders `(expr)` without spaces, so
   // override to match Rails' `visit_Arel_Nodes_GroupingElement`.
   protected override visitArelNodesGroupingElement(
-    node: Nodes.GroupingElement,
+    o: Nodes.GroupingElement,
     collector: SQLString,
   ): SQLString {
-    return this.groupingArrayOrGroupingElement(node, collector);
+    return this.groupingArrayOrGroupingElement(o, collector);
   }
 
   // Cube/Rollup/GroupingSet: emit `CUBE` / `ROLLUP` / `GROUPING SETS`
   // followed by `grouping_array_or_grouping_element` formatting. Mirrors
   // Rails Postgres ([postgresql.rb](https://github.com/rails/rails/blob/v8.0.2/activerecord/lib/arel/visitors/postgresql.rb)).
-  protected override visitArelNodesCube(node: Nodes.Cube, collector: SQLString): SQLString {
+  protected override visitArelNodesCube(o: Nodes.Cube, collector: SQLString): SQLString {
     collector.append("CUBE");
-    return this.groupingArrayOrGroupingElement(node, collector);
+    return this.groupingArrayOrGroupingElement(o, collector);
   }
 
-  protected override visitArelNodesRollUp(node: Nodes.RollUp, collector: SQLString): SQLString {
+  protected override visitArelNodesRollUp(o: Nodes.RollUp, collector: SQLString): SQLString {
     collector.append("ROLLUP");
-    return this.groupingArrayOrGroupingElement(node, collector);
+    return this.groupingArrayOrGroupingElement(o, collector);
   }
 
   protected override visitArelNodesGroupingSet(
-    node: Nodes.GroupingSet,
+    o: Nodes.GroupingSet,
     collector: SQLString,
   ): SQLString {
     collector.append("GROUPING SETS");
-    return this.groupingArrayOrGroupingElement(node, collector);
+    return this.groupingArrayOrGroupingElement(o, collector);
   }
 
   // Postgres natively supports `IS [NOT] DISTINCT FROM`. Behaviorally
   // identical to the base ToSql visitor; the explicit override mirrors
   // Rails' Postgres visitor for fidelity (no behavior change).
   protected override visitArelNodesIsNotDistinctFrom(
-    node: Nodes.IsNotDistinctFrom,
+    o: Nodes.IsNotDistinctFrom,
     collector: SQLString,
   ): SQLString {
-    this.visit(node.left, collector);
+    this.visit(o.left, collector);
     collector.append(" IS NOT DISTINCT FROM ");
-    this.visit(node.right, collector);
+    this.visit(o.right, collector);
     return collector;
   }
 
   protected override visitArelNodesIsDistinctFrom(
-    node: Nodes.IsDistinctFrom,
+    o: Nodes.IsDistinctFrom,
     collector: SQLString,
   ): SQLString {
-    this.visit(node.left, collector);
+    this.visit(o.left, collector);
     collector.append(" IS DISTINCT FROM ");
-    this.visit(node.right, collector);
+    this.visit(o.right, collector);
     return collector;
   }
 

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -335,8 +335,8 @@ export class ToSql extends Visitor {
     // collector << quote(o.value_for_database).to_s — the quoted literal is
     // appended directly (visit_Arel_Nodes_Quoted is an alias). Only BindParam
     // uses add_bind. Inlines exactly like visitQuoted.
-    const value = resolveValueForDatabase(node.valueForDatabase());
-    collector.append(this.quote(value));
+    const valueForDatabase = resolveValueForDatabase(node.valueForDatabase());
+    collector.append(this.quote(valueForDatabase));
     return collector;
   }
 
@@ -621,7 +621,7 @@ export class ToSql extends Visitor {
     // empty filter, so hints that sanitize to empty still emit the comment. The
     // node only exists when `optimizer_hints(*hints)` got a non-empty splat
     // (select_manager.rb:147-149), which is the only emptiness Rails guards.
-    const hints = node.hints.map((h) => this.sanitizeAsSqlComment(h)).join(" ");
+    const hints = node.hints.map((v) => this.sanitizeAsSqlComment(v)).join(" ");
     collector.append(` /*+ ${hints} */`);
     return collector;
   }
@@ -1152,6 +1152,7 @@ export class ToSql extends Visitor {
   }
 
   private visitArelNodesIn(node: Nodes.In, collector: SQLString): SQLString {
+    const attr = node.left;
     let values = node.right;
     if (Array.isArray(values)) {
       collector.preparable = false;
@@ -1164,7 +1165,7 @@ export class ToSql extends Visitor {
         return collector;
       }
     }
-    this.visit(node.left, collector);
+    this.visit(attr, collector);
     // Duck-type check for SelectManager subquery - visit wraps it in parens
     if (
       values &&
@@ -1191,6 +1192,7 @@ export class ToSql extends Visitor {
   }
 
   private visitArelNodesNotIn(node: Nodes.NotIn, collector: SQLString): SQLString {
+    const attr = node.left;
     let values = node.right;
     if (Array.isArray(values)) {
       collector.preparable = false;
@@ -1203,7 +1205,7 @@ export class ToSql extends Visitor {
         return collector;
       }
     }
-    this.visit(node.left, collector);
+    this.visit(attr, collector);
     if (Array.isArray(values)) {
       collector.append(" NOT IN (");
       for (let i = 0; i < values.length; i++) {
@@ -1257,17 +1259,20 @@ export class ToSql extends Visitor {
   // -- Predicates --
 
   private visitArelNodesEquality(node: Nodes.Equality, collector: SQLString): SQLString {
-    if (this.unboundableSign(node.right) !== 0) {
+    const right = node.right;
+
+    if (this.unboundableSign(right) !== 0) {
       return collector.append("1=0");
     }
-    if (this.rightIsNull(node.right)) {
-      this.visit(node.left, collector);
-      collector.append(" IS NULL");
-      return collector;
-    }
+
     this.visit(node.left, collector);
-    collector.append(" = ");
-    this.visit(node.right, collector);
+
+    if (this.rightIsNull(right)) {
+      collector.append(" IS NULL");
+    } else {
+      collector.append(" = ");
+      this.visit(right, collector);
+    }
     return collector;
   }
 
@@ -1300,17 +1305,20 @@ export class ToSql extends Visitor {
   }
 
   private visitArelNodesNotEqual(node: Nodes.NotEqual, collector: SQLString): SQLString {
-    if (this.unboundableSign(node.right) !== 0) {
+    const right = node.right;
+
+    if (this.unboundableSign(right) !== 0) {
       return collector.append("1=1");
     }
-    if (this.rightIsNull(node.right)) {
-      this.visit(node.left, collector);
-      collector.append(" IS NOT NULL");
-      return collector;
-    }
+
     this.visit(node.left, collector);
-    collector.append(" != ");
-    this.visit(node.right, collector);
+
+    if (this.rightIsNull(right)) {
+      collector.append(" IS NOT NULL");
+    } else {
+      collector.append(" != ");
+      this.visit(right, collector);
+    }
     return collector;
   }
 
@@ -1719,9 +1727,9 @@ export class ToSql extends Visitor {
    * subsequent node emits `joinStr` and visits.
    */
   protected injectJoin(list: Node[], collector: SQLString, joinStr: string): SQLString {
-    list.forEach((n, i) => {
+    list.forEach((x, i) => {
       if (i > 0) collector.append(joinStr);
-      this.visit(n, collector);
+      this.visit(x, collector);
     });
     return collector;
   }

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/type/integer.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/type/integer.json
@@ -2,13 +2,6 @@
   {
     "package": "activemodel",
     "tsFile": "type/integer.ts",
-    "rubyName": "serializable?",
-    "call": "order:isInRange,cast",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "type/integer.ts",
     "rubyName": "serialize",
     "call": "non_numeric_string?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Burns down the `naming` class of the RFC 0095 call-argument report
(`output/call-arg-mismatches.json`) in `packages/activemodel/src/` and
`packages/arel/src/`: body-local identifiers that had drifted from the Rails
names are renamed back to what the Ruby calls them.

No public surface changes, no behavior changes. `pnpm parity:api` is unchanged
(Overall 13312/17761, arity 7942/8033), `pnpm parity:api:extra` unchanged,
`pnpm parity:api:calls` and `pnpm parity:api:calls:args` both green, and the
full `arel` + `activemodel` vitest suites pass (151 files / 3433 tests).

## `naming` row counts (`pnpm parity:api:calls:args:report`)

| package | before | after |
| --- | --- | --- |
| activemodel | 49 | 23 |
| arel | 112 | 42 |
| **total (repo-wide)** | **886** | **790** |

(Measured against this branch's rebase base. The arel figure moved by 3 versus
the pre-rebase measurement because `injectJoin`'s argument order was flipped to
Rails' `inject_join(list, collector, joiner)` on main in the meantime; this
branch takes main's order and keeps the `x` rename.)

## What changed

**activemodel**
- `attribute-mutation-tracker.ts` — `name` → `attrName` throughout, `anyChanges`'
  block var → `attr` (attribute_mutation_tracker.rb:14-84).
- `attribute-assignment.ts` — `_assignAttribute(k, v)`; `assignAttributes` drops
  the `attrs` alias and passes `newAttributes` (attribute_assignment.rb:28-72).
- `attribute.ts` — `Attribute.fromDatabase` / `.fromUser` take
  `valueBeforeTypeCast`, and `fromDatabase`'s 4th arg is `value`
  (attribute.rb:8-14).
- `errors.ts` — `import`'s 2nd param is `overrideOptions` (errors.rb:154);
  `added` / `ofKind` reassign `attribute` / `options` from `normalizeArguments`
  as Rails does (errors.rb:388, :396); `@base` reads go through the `base`
  reader.
- `attribute-set.ts` `reset(key)` (attribute_set.rb:87); `model.ts`
  `assignAttributes` drops the `attrs` alias; `type/integer.ts` restores the
  `cast_value` local (integer.rb:75).
- `validations/comparison.ts` — `attrName`, `rawOptionValue` (comparison.rb:19-20);
  `validations/confirmation.ts` — `confirmed` (confirmation.rb:12).

**arel**
- `predications.ts` — `gt`/`gteq`/`lt`/`lteq` take `right`, the four
  `matches`/`does_not_match` forms take `other` (predications.rb:131-208). This
  single mixin fix clears the mirrored rows on `attributes/attribute.ts`,
  `nodes/node-expression.ts`, `nodes/sql-literal.ts` and
  `nodes/infix-operation.ts` too.
- `as(other)` on `attributes/attribute.ts`, `nodes/infix-operation.ts` and
  `select-manager.ts` (alias_predication.rb:5, select_manager.rb:48);
  `Attribute#quotedNode(other)`.
- `select-manager.ts` — `join(relation, …)` / `outerJoin(relation)`
  (select_manager.rb:102-117), `group(...columns)`, `project`'s `x`,
  `window`'s `window`, `take(limit)`, and `collapse` reassigning `exprs`
  (select_manager.rb:74, :130, :124, :257).
- `delete-manager.ts` / `update-manager.ts` — `group(columns)` now takes the
  single enumerable Rails takes (`delete_manager.rb:16`, `update_manager.rb:33`
  — only `SelectManager#group` splats, `select_manager.rb:74`), replacing the
  `(column, ...rest)` split, which matched neither. Its two call sites in
  `SelectManager#compileUpdate` / `#compileDelete` converge to Rails'
  `um.group(group_values_columns)` (`crud.rb:31`, `crud.rb:49`), dropping the
  first/rest destructuring the old signature forced.
- `insert-manager.ts` — `values` / `column` / `value` (insert_manager.rb).
- `visitors/mysql.ts`, `visitors/postgresql.ts` — every visitor param `node` → `o`,
  plus `expr` in `NullsFirst`/`NullsLast` and the inlined `key.name` in
  `buildSubselect` (mysql.rb:62-70, :106).
- `visitors/dot.ts` — `edge` local, `@node_stack.last` inlined (dot.rb:262).
- `visitors/to-sql.ts` — targeted rows only: `injectJoin`'s `x`,
  `OptimizerHints`' `v`, `Casted`'s `valueForDatabase`, `In`/`NotIn`'s `attr`,
  and `Equality`/`NotEqual` restructured to Rails' `right = o.right` +
  if/else shape (to_sql.rb:588, :643, :678).

## Baseline

One call-set baseline row went stale and is deleted by hand (no reseed):
`activemodel type/integer.ts serializable? order:isInRange,cast` — restoring the
Rails `cast_value` local also restored Rails' call ORDER.

## Left in place deliberately (AC #4)

These rows are argument-ORDER defects or invented conversions/structural gaps at
the call site, not renames, so they are NOT renamed away:

- `activemodel/attribute-methods.ts` (3) — Rails passes a
  `ActiveSupport::CodeGenerator`; trails passes the host class. No CodeGenerator
  port exists.
- `activemodel/type/date.ts`, `type/date-time.ts` — `String(value).trim()`
  coercion where Rails branches on `value.is_a?(::String)`.
- `activemodel/type/helpers/numeric.ts`, `helpers/mutable.ts` — documented
  BigDecimal / pre-serialized normalization locals.
- `activemodel/naming.ts` — the constructor is restructured around pre-segmented
  input.
- `activemodel/errors.ts` `added` / `ofKind` keep one non-Rails local,
  `normType`. Rails reassigns `type` in place; TS cannot narrow a reassigned
  union-typed parameter, so spelling it `type` would cost an `as string` at each
  of its three uses. `attribute` and `options` are reassigned as Rails does.
- `arel/visitors/to-sql.ts` — the bulk `node` → `o` rename across ~100 visitor
  methods is ~800 LOC on its own and does not fit under this PR's ceiling; the
  remaining rows there are that rename. Filed as
  `0096-naming-identifier-burndown/naming-burndown-arel-to-sql`.
- Rows whose Ruby side is a method-chain result (`ref:toS`, `ref:send`,
  `ref:except`, `ref:parseInt`) have no identifier to rename to.

Closes-story: naming-burndown-activemodel
Closes-story: naming-burndown-arel
