### PR TITLE
refactor(activerecord): rename locals to Rails' across tasks and adapters

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -1029,13 +1029,12 @@ export class AbstractAdapter implements Quoting {
     // Rails: `value = lookup_cast_type(column.sql_type).serialize(value)`
     // (abstract/quoting.rb:161) before quoting. Returns a bare literal — the
     // ` DEFAULT ` keyword is owned by the caller (add_column_options!).
-    let serialized: unknown = value;
     const sqlType = (column as { sqlType?: string | null } | undefined)?.sqlType;
     if (sqlType) {
       const castType = this.lookupCastType(sqlType) as { serialize?(v: unknown): unknown };
-      if (typeof castType?.serialize === "function") serialized = castType.serialize(value);
+      if (typeof castType?.serialize === "function") value = castType.serialize(value);
     }
-    return this.quote(serialized);
+    return this.quote(value);
   }
 
   quotedTrue(): string {
@@ -1328,13 +1327,17 @@ export class AbstractAdapter implements Quoting {
             await this.attemptConfigureConnection();
           });
           return;
-        } catch (error) {
-          const translated = this.translateExceptionClass(error, undefined, undefined);
+        } catch (originalException) {
+          const translatedException = this.translateExceptionClass(
+            originalException,
+            undefined,
+            undefined,
+          );
           const retryDeadlineExceeded = deadline !== null && deadline < Date.now();
 
           if (!retryDeadlineExceeded && retriesAvailable > 0) {
             retriesAvailable -= 1;
-            if (this.isRetryableConnectionError(translated)) {
+            if (this.isRetryableConnectionError(translatedException)) {
               await this.backoff(this.connectionRetries - retriesAvailable);
               continue;
             }
@@ -1344,7 +1347,7 @@ export class AbstractAdapter implements Quoting {
           // translated exception (Rails' `raise translated_exception`).
           this._lastActivity = 0;
           this._verified = false;
-          throw translated;
+          throw translatedException;
         }
       }
     });
@@ -2442,27 +2445,31 @@ export class AbstractAdapter implements Quoting {
       for (;;) {
         try {
           return await block(await this.rawConnectionForBlock());
-        } catch (e) {
-          const translated = this.translateExceptionClass(e, null, null) as Error;
-          this.invalidateTransaction(translated);
+        } catch (originalException) {
+          const translatedException = this.translateExceptionClass(
+            originalException,
+            null,
+            null,
+          ) as Error;
+          this.invalidateTransaction(translatedException);
           const expired = deadline !== null && deadline < Date.now();
           if (!expired && retriesAvailable > 0) {
             retriesAvailable -= 1;
-            if (this.isRetryableQueryError(translated)) {
+            if (this.isRetryableQueryError(translatedException)) {
               await this.backoff(this.connectionRetries - retriesAvailable);
               continue;
             }
-            if (reconnectable && this.isRetryableConnectionError(translated)) {
+            if (reconnectable && this.isRetryableConnectionError(translatedException)) {
               await this.reconnectBang({ restoreTransactions: true });
               reconnectable = false;
               continue;
             }
           }
-          if (!this.isRetryableQueryError(translated)) {
+          if (!this.isRetryableQueryError(translatedException)) {
             this._lastActivity = 0;
             this._verified = false;
           }
-          throw translated;
+          throw translatedException;
         } finally {
           if (materializeTransactions) this.dirtyCurrentTransaction();
         }

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -651,8 +651,10 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   async changeTableComment(tableName: string, commentOrChanges: CommentOrChanges): Promise<void> {
     const raw = this.extractNewCommentValue(commentOrChanges);
     // Mirrors Rails: `comment = "" if comment.nil?` then `COMMENT #{quote(comment)}`.
-    const c = raw == null ? "" : String(raw);
-    await this.execute(`ALTER TABLE ${this.quoteTableName(tableName)} COMMENT ${this.quote(c)}`);
+    const comment = raw == null ? "" : String(raw);
+    await this.execute(
+      `ALTER TABLE ${this.quoteTableName(tableName)} COMMENT ${this.quote(comment)}`,
+    );
   }
 
   async renameTable(tableName: string, newName: string): Promise<void> {
@@ -801,7 +803,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     options: ColumnOptions = {},
   ): Promise<ChangeColumnDefinition> {
     const column = await this.columnFor(tableName, columnName);
-    const resolvedType = type ?? column.sqlType ?? "";
+    type ??= column.sqlType ?? "";
 
     const opts: Record<string, unknown> = { ...options };
 
@@ -817,10 +819,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
 
     if (opts["collation"] === null) {
       delete opts["collation"];
-    } else if (
-      !Object.prototype.hasOwnProperty.call(opts, "collation") &&
-      this.isTextType(resolvedType)
-    ) {
+    } else if (!Object.prototype.hasOwnProperty.call(opts, "collation") && this.isTextType(type)) {
       opts["collation"] = column.collation ?? undefined;
     }
 
@@ -829,8 +828,8 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     }
 
     const td = this.createTableDefinition(tableName);
-    const colDef = td.newColumnDefinition(column.name, resolvedType as any, opts as any);
-    return new ChangeColumnDefinition(colDef, column.name);
+    const cd = td.newColumnDefinition(column.name, type as any, opts as any);
+    return new ChangeColumnDefinition(cd, column.name);
   }
 
   async renameColumn(tableName: string, columnName: string, newColumnName: string): Promise<void> {
@@ -865,15 +864,15 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     columnName: string | string[],
     options: Record<string, unknown> = {},
   ): Promise<CreateIndexDefinition | undefined> {
-    const [idx, algorithmClause, ifNotExists] = await this.addIndexOptions(
+    const [index, algorithm, ifNotExists] = await this.addIndexOptions(
       tableName,
       columnName,
       options,
     );
-    if (ifNotExists && (await this.indexExists(tableName, idx.columns, { name: idx.name }))) {
+    if (ifNotExists && (await this.indexExists(tableName, columnName, { name: index.name }))) {
       return undefined;
     }
-    return new CreateIndexDefinition(idx, algorithmClause);
+    return new CreateIndexDefinition(index, algorithm);
   }
 
   addSqlCommentBang(sql: string, comment: string): string {
@@ -1076,9 +1075,9 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     // stripping so an order that becomes empty after stripping doesn't consume
     // an alias index slot.
     const orderColumns = (orders ?? [])
-      .map((o) => (typeof o === "string" ? o : visitor.compile(o)))
-      .filter((o) => o.trim().length > 0)
-      .map((o) => o.replace(/\s+(?:ASC|DESC)\b/gi, "").trim())
+      .map((s) => (typeof s === "string" ? s : visitor.compile(s)))
+      .filter((s) => s.trim().length > 0)
+      .map((s) => s.replace(/\s+(?:ASC|DESC)\b/gi, "").trim())
       .filter((col) => col.length > 0)
       .map((col, i) => `${col} AS alias_${i}`);
     if (orderColumns.length === 0) return columns;

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -703,8 +703,9 @@ export async function insert(
   binds: unknown[] = [],
 ): Promise<unknown> {
   const host = this as DatabaseStatementsHost;
-  const [sql, resolvedBinds] = toSqlAndBinds(arel, binds);
-  const result = await execInsert.call(this, sql, name, resolvedBinds, pk, sequenceName);
+  let sql: string;
+  [sql, binds] = toSqlAndBinds(arel, binds);
+  const result = await execInsert.call(this, sql, name, binds, pk, sequenceName);
   if (idValue !== undefined && idValue !== null) return idValue;
   return host.lastInsertedId!(result);
 }
@@ -720,8 +721,9 @@ export async function update(
   name: string | null = null,
   binds: unknown[] = [],
 ): Promise<number> {
-  const [sql, resolvedBinds] = toSqlAndBinds(arel, binds);
-  return execUpdate.call(this, sql, name, resolvedBinds);
+  let sql: string;
+  [sql, binds] = toSqlAndBinds(arel, binds);
+  return execUpdate.call(this, sql, name, binds);
 }
 
 /**
@@ -735,8 +737,9 @@ export async function deleteStatement(
   name: string | null = null,
   binds: unknown[] = [],
 ): Promise<number> {
-  const [sql, resolvedBinds] = toSqlAndBinds(arel, binds);
-  return execDelete.call(this, sql, name, resolvedBinds);
+  let sql: string;
+  [sql, binds] = toSqlAndBinds(arel, binds);
+  return execDelete.call(this, sql, name, binds);
 }
 // Rails name: delete — aliased to avoid JS reserved word conflict.
 // Consumers can import as: import { delete as delete_ } from "..."
@@ -1503,15 +1506,9 @@ async function insertStatement(
   binds: unknown[] = [],
   opts?: { returning?: string[] | null },
 ): Promise<unknown> {
-  const [sql, resolvedBinds] = toSqlAndBinds.call(this, arel, binds);
-  const result = await this.execInsert(
-    sql,
-    name,
-    resolvedBinds,
-    pk,
-    sequenceName,
-    opts?.returning ?? null,
-  );
+  let sql: string;
+  [sql, binds] = toSqlAndBinds.call(this, arel, binds);
+  const result = await this.execInsert(sql, name, binds, pk, sequenceName, opts?.returning ?? null);
   // execInsert may return a Result (PG/adapter with RETURNING support) or a
   // number/insertId (MySQL/SQLite via executeMutation). Delegate to the
   // adapter's lastInsertedId when available; fall back to treating the
@@ -1711,8 +1708,9 @@ export const DatabaseStatements = {
     name: string | null = null,
     binds: unknown[] = [],
   ): Promise<number> {
-    const [sql, resolvedBinds] = toSqlAndBinds.call(this, arel, binds);
-    return this.execUpdate(sql, name, resolvedBinds);
+    let sql: string;
+    [sql, binds] = toSqlAndBinds.call(this, arel, binds);
+    return this.execUpdate(sql, name, binds);
   },
 
   async delete(
@@ -1721,8 +1719,9 @@ export const DatabaseStatements = {
     name: string | null = null,
     binds: unknown[] = [],
   ): Promise<number> {
-    const [sql, resolvedBinds] = toSqlAndBinds.call(this, arel, binds);
-    return this.execDelete(sql, name, resolvedBinds);
+    let sql: string;
+    [sql, binds] = toSqlAndBinds.call(this, arel, binds);
+    return this.execDelete(sql, name, binds);
   },
 
   rawExecute,

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1859,22 +1859,22 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   async changeColumnNull(
     tableName: string,
     columnName: string,
-    allowNull: boolean,
-    defaultValue?: unknown,
+    null_: boolean,
+    default_?: unknown,
   ): Promise<void> {
-    this.validateChangeColumnNullArgumentBang(allowNull);
-    if (!allowNull && defaultValue !== undefined) {
+    this.validateChangeColumnNullArgumentBang(null_);
+    if (!null_ && default_ !== undefined) {
       // Rails backfills NULLs via quote_default_expression, which serializes the
       // value through the column's cast type (abstract/schema_statements.rb).
       const existing = (await this.columns(tableName)).find((c) => c.name === columnName);
-      const serialized = this.serializeDefaultForColumn(defaultValue, existing?.sqlType ?? null);
+      const serialized = this.serializeDefaultForColumn(default_, existing?.sqlType ?? null);
       const quotedDefault = this.quoteDefault(serialized);
       await this.execute(
         `UPDATE ${quoteTableName(tableName)} SET ${quoteColumnName(columnName)} = ${quotedDefault} WHERE ${quoteColumnName(columnName)} IS NULL`,
       );
     }
     await this.alterTable(tableName, undefined, undefined, undefined, (definition) => {
-      definition.get(columnName)!.options.null = allowNull;
+      definition.get(columnName)!.options.null = null_;
     });
   }
 
@@ -2296,7 +2296,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     toTableOrOptions?: string | RemoveForeignKeyOptions,
     options: RemoveForeignKeyOptions = {},
   ): Promise<void> {
-    const positionalToTable = typeof toTableOrOptions === "string" ? toTableOrOptions : undefined;
+    let toTable = typeof toTableOrOptions === "string" ? toTableOrOptions : undefined;
     const opts: RemoveForeignKeyOptions =
       typeof toTableOrOptions === "object" && toTableOrOptions !== null
         ? { ...toTableOrOptions, ...options }
@@ -2304,9 +2304,9 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     const ifExists = opts.ifExists === true;
     delete opts.ifExists;
 
-    if (ifExists && !(await this.foreignKeyExists(fromTable, positionalToTable))) return;
+    if (ifExists && !(await this.foreignKeyExists(fromTable, toTable))) return;
 
-    const toTable = positionalToTable ?? opts.toTable;
+    toTable ??= opts.toTable;
     const matchOptions: ForeignKeyLookupOptions = { ...opts };
     delete matchOptions.name;
     delete matchOptions.toTable;
@@ -2317,7 +2317,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
       toTable ?? (Base.pluralizeTableNames ? pluralize(inferred) : inferred),
     );
 
-    const existingFks = await this.foreignKeys(fromTable);
+    const foreignKeys = await this.foreignKeys(fromTable);
     // Rails' SQLite override hand-rolls `options.slice(*fk.options.keys)` +
     // `fk.options[k].to_s == v.to_s` (sqlite3/schema_statements.rb:79-80) rather
     // than calling defined_for?. isDefinedFor is that same slice-and-compare,
@@ -2325,19 +2325,19 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     // the `["a", "b"]` inspect form. Reproducing that would mean porting Ruby
     // inspect formatting, and it is unreachable here: SQLite add_foreign_key is
     // single-column.
-    const fkToRemove = existingFks.find(
+    const fkey = foreignKeys.find(
       (fk) =>
         this.stripTableNamePrefixAndSuffix(fk.toTable) === table && fk.isDefinedFor(matchOptions),
     );
 
-    if (!fkToRemove) {
+    if (!fkey) {
       throw new ArgumentError(
         `Table '${fromTable}' has no foreign key for ${toTable ?? JSON.stringify(matchOptions)}`,
       );
     }
 
-    const remainingFks = existingFks.filter((fk) => fk !== fkToRemove);
-    await this.alterTable(fromTable, remainingFks);
+    foreignKeys.splice(foreignKeys.indexOf(fkey), 1);
+    await this.alterTable(fromTable, foreignKeys);
   }
 
   /**
@@ -2383,12 +2383,12 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
 
     if (ifExists === true && !(await this.checkConstraintExists(tableName, lookupOptions))) return;
 
-    const checkConstraints = await this.checkConstraints(tableName);
+    let checkConstraints = await this.checkConstraints(tableName);
     const chkNameToDelete = (
       await this.checkConstraintForBang(tableName, { expression, ...lookupOptions })
     ).name;
-    const remainingChecks = checkConstraints.filter((chk) => chk.name !== chkNameToDelete);
-    await this.alterTable(tableName, await this.foreignKeys(tableName), remainingChecks);
+    checkConstraints = checkConstraints.filter((chk) => chk.name !== chkNameToDelete);
+    await this.alterTable(tableName, await this.foreignKeys(tableName), checkConstraints);
   }
 
   // --- Private: alter_table copy strategy (Rails: SQLite3Adapter#alter_table) ---
@@ -2507,8 +2507,10 @@ WHERE type = 'table' AND name = ${this.quote(tableName)}
     const COLLATE_REGEX = /.*"(\w+)".*collate\s+"(\w+)".*/i;
     const AI_REGEX = /.*"(\w+)".+PRIMARY KEY AUTOINCREMENT/i;
     const GENERATED_REGEX = /.*"(\w+)".+GENERATED ALWAYS AS \((.+)\) (?:STORED|VIRTUAL)/i;
-    const colNames = basicStructure.map((c) => String(c["name"]));
-    const strings = await this.tableStructureSql(tableName, colNames);
+    const strings = await this.tableStructureSql(
+      tableName,
+      basicStructure.map((column) => String(column["name"])),
+    );
     if (!strings.length) return basicStructure.map((c) => ({ ...c }));
     const collations: Record<string, string> = {};
     const autoIncrements: Record<string, boolean> = {};

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -142,7 +142,7 @@ export class DatabaseTasks {
    * Gating flag for automatic schema dumps after a migration-writing task.
    * DatabaseTasks itself only exposes `migrate()`; trailties' CLI layer
    * reads this flag and chooses whether to call back into
-   * `DatabaseTasks.dumpSchema(config)` after its `db migrate`,
+   * `DatabaseTasks.dumpSchema(dbConfig)` after its `db migrate`,
    * `db rollback`, `db forward`, `db migrate:up`, `db migrate:down`, and
    * `db migrate:redo` subcommands.
    *
@@ -225,22 +225,22 @@ export class DatabaseTasks {
   static async create(
     configuration: DatabaseConfig | string | Record<string, unknown>,
   ): Promise<void> {
-    const config = this.resolveConfiguration(configuration);
+    const dbConfig = this.resolveConfiguration(configuration);
     const { DatabaseAlreadyExists } = await import("../errors.js");
     try {
-      const handler = this.databaseAdapterFor(config);
+      const handler = this.databaseAdapterFor(dbConfig);
       if (handler.create) {
-        await handler.create(config);
+        await handler.create(dbConfig);
       }
-      if (isVerbose()) stdout.write(`Created database '${config.database}'\n`);
+      if (isVerbose()) stdout.write(`Created database '${dbConfig.database}'\n`);
     } catch (error) {
       if (error instanceof DatabaseAlreadyExists) {
-        if (isVerbose()) stderr.write(`Database '${config.database}' already exists\n`);
+        if (isVerbose()) stderr.write(`Database '${dbConfig.database}' already exists\n`);
         return;
       }
       stderr.write(_errorToS(error) + "\n");
       stderr.write(
-        `Couldn't create '${config.database}' database. Please check your configuration.\n`,
+        `Couldn't create '${dbConfig.database}' database. Please check your configuration.\n`,
       );
       throw error;
     }
@@ -272,28 +272,28 @@ export class DatabaseTasks {
   static async drop(
     configuration: DatabaseConfig | string | Record<string, unknown>,
   ): Promise<void> {
-    const config = this.resolveConfiguration(configuration);
+    const dbConfig = this.resolveConfiguration(configuration);
     const { NoDatabaseError } = await import("../errors.js");
     try {
-      const handler = this.databaseAdapterFor(config);
+      const handler = this.databaseAdapterFor(dbConfig);
       if (handler.drop) {
-        await handler.drop(config);
+        await handler.drop(dbConfig);
       }
-      if (isVerbose()) stdout.write(`Dropped database '${config.database}'\n`);
+      if (isVerbose()) stdout.write(`Dropped database '${dbConfig.database}'\n`);
     } catch (error) {
       if (error instanceof NoDatabaseError) {
-        stderr.write(`Database '${config.database}' does not exist\n`);
+        stderr.write(`Database '${dbConfig.database}' does not exist\n`);
         return;
       }
       stderr.write(_errorToS(error) + "\n");
-      stderr.write(`Couldn't drop database '${config.database}'\n`);
+      stderr.write(`Couldn't drop database '${dbConfig.database}'\n`);
       throw error;
     }
   }
 
   static async dropAll(): Promise<void> {
-    for (const config of this.eachLocalConfiguration()) {
-      await this.drop(config);
+    for (const dbConfig of this.eachLocalConfiguration()) {
+      await this.drop(dbConfig);
     }
   }
 
@@ -511,10 +511,10 @@ export class DatabaseTasks {
   static async purge(
     configuration: DatabaseConfig | string | Record<string, unknown>,
   ): Promise<void> {
-    const config = this.resolveConfiguration(configuration);
-    const handler = this.databaseAdapterFor(config);
+    const dbConfig = this.resolveConfiguration(configuration);
+    const handler = this.databaseAdapterFor(dbConfig);
     if (handler.purge) {
-      await handler.purge(config);
+      await handler.purge(dbConfig);
     }
   }
 
@@ -529,20 +529,20 @@ export class DatabaseTasks {
   }
 
   static async purgeAll(): Promise<void> {
-    for (const config of this.eachLocalConfiguration()) {
-      await this.purge(config);
+    for (const dbConfig of this.eachLocalConfiguration()) {
+      await this.purge(dbConfig);
     }
   }
 
   static async truncateAll(environment?: string): Promise<void> {
     const env = this._normalizeEnv(environment);
     const configs = this.configsFor(env);
-    for (const config of configs) {
-      const handler = this.databaseAdapterFor(config);
+    for (const dbConfig of configs) {
+      const handler = this.databaseAdapterFor(dbConfig);
       if (handler.truncateAll) {
-        await handler.truncateAll(config);
+        await handler.truncateAll(dbConfig);
       } else {
-        await this.truncateTables(config);
+        await this.truncateTables(dbConfig);
       }
     }
   }
@@ -560,22 +560,22 @@ export class DatabaseTasks {
   static async charset(
     configuration: DatabaseConfig | string | Record<string, unknown>,
   ): Promise<string | null> {
-    const config = this.resolveConfiguration(configuration);
-    const handler = this.databaseAdapterFor(config);
+    const dbConfig = this.resolveConfiguration(configuration);
+    const handler = this.databaseAdapterFor(dbConfig);
     if (!handler.charset) {
       throw new NoMethodError(
         `undefined method 'charset' for an instance of ${handler.constructor.name}`,
       );
     }
-    return handler.charset(config);
+    return handler.charset(dbConfig);
   }
 
   static async charsetCurrent(environment?: string): Promise<string | null> {
     const env = this._normalizeEnv(environment);
     const configs = this.configsFor(env);
     if (configs.length === 0) return null;
-    const primary = configs.find((c) => c.name === "primary") ?? configs[0];
-    return this.charset(primary);
+    const dbConfig = configs.find((c) => c.name === "primary") ?? configs[0];
+    return this.charset(dbConfig);
   }
 
   /**
@@ -587,22 +587,22 @@ export class DatabaseTasks {
   static async collation(
     configuration: DatabaseConfig | string | Record<string, unknown>,
   ): Promise<string | null> {
-    const config = this.resolveConfiguration(configuration);
-    const handler = this.databaseAdapterFor(config);
+    const dbConfig = this.resolveConfiguration(configuration);
+    const handler = this.databaseAdapterFor(dbConfig);
     if (!handler.collation) {
       throw new NoMethodError(
         `undefined method 'collation' for an instance of ${handler.constructor.name}`,
       );
     }
-    return handler.collation(config);
+    return handler.collation(dbConfig);
   }
 
   static async collationCurrent(environment?: string): Promise<string | null> {
     const env = this._normalizeEnv(environment);
     const configs = this.configsFor(env);
     if (configs.length === 0) return null;
-    const primary = configs.find((c) => c.name === "primary") ?? configs[0];
-    return this.collation(primary);
+    const dbConfig = configs.find((c) => c.name === "primary") ?? configs[0];
+    return this.collation(dbConfig);
   }
 
   static targetVersion(): number | null {
@@ -625,14 +625,14 @@ export class DatabaseTasks {
     }
   }
 
-  static dumpSchemaFilename(config?: DatabaseConfig, format?: SchemaFormat): string {
+  static dumpSchemaFilename(dbConfig?: DatabaseConfig, format?: SchemaFormat): string {
     const envSchema = getEnv("SCHEMA");
     if (envSchema !== undefined) return envSchema;
     const fmt = format ?? this.schemaFormat;
     const ext = fmt === "sql" ? "sql" : fmt;
     const base = fmt === "sql" ? "structure" : "schema";
-    if (config && config.name !== "primary") {
-      return `${this.dbDir}/${config.name}_${base}.${ext}`;
+    if (dbConfig && dbConfig.name !== "primary") {
+      return `${this.dbDir}/${dbConfig.name}_${base}.${ext}`;
     }
     return `${this.dbDir}/${base}.${ext}`;
   }
@@ -666,8 +666,8 @@ export class DatabaseTasks {
     if (getEnv("DISABLE_DATABASE_ENVIRONMENT_CHECK") !== undefined) return;
 
     const envName = this._normalizeEnv(environment);
-    for (const config of this.configsFor(envName)) {
-      await checkCurrentProtectedEnvironmentBang(config);
+    for (const dbConfig of this.configsFor(envName)) {
+      await checkCurrentProtectedEnvironmentBang(dbConfig);
     }
   }
 
@@ -710,13 +710,13 @@ export class DatabaseTasks {
   static eachLocalConfiguration(): DatabaseConfig[] {
     const result: DatabaseConfig[] = [];
     // database_tasks.rb:599 — `configs_for.each`, i.e. Base.configurations.
-    for (const c of configurationsStore().configsFor()) {
-      if (!c.database) continue;
-      if (this.isLocalDatabase(c)) {
-        result.push(c);
+    for (const dbConfig of configurationsStore().configsFor()) {
+      if (!dbConfig.database) continue;
+      if (this.isLocalDatabase(dbConfig)) {
+        result.push(dbConfig);
       } else {
         stderr.write(
-          `This task only modifies local databases. ${c.database} is on a remote host.\n`,
+          `This task only modifies local databases. ${dbConfig.database} is on a remote host.\n`,
         );
       }
     }
@@ -849,13 +849,13 @@ export class DatabaseTasks {
     filename: string,
     root?: string,
   ): Promise<void> {
-    const config = this.resolveConfiguration(configuration);
-    const flags = this.structureDumpFlagsFor(config.adapter);
-    const handler = this.databaseAdapterFor(config);
+    const dbConfig = this.resolveConfiguration(configuration);
+    const flags = this.structureDumpFlagsFor(dbConfig.adapter);
+    const handler = this.databaseAdapterFor(dbConfig);
     if (!handler.structureDump) {
-      throw new Error(`Adapter '${config.adapter}' does not support structureDump`);
+      throw new Error(`Adapter '${dbConfig.adapter}' does not support structureDump`);
     }
-    await handler.structureDump(config, filename, flags, root);
+    await handler.structureDump(dbConfig, filename, flags, root);
   }
 
   /** Mirrors: `structure_load` (`tasks/database_tasks.rb:369-374`). See {@link structureDump}. */
@@ -864,13 +864,13 @@ export class DatabaseTasks {
     filename: string,
     root?: string,
   ): Promise<void> {
-    const config = this.resolveConfiguration(configuration);
-    const flags = this.structureLoadFlagsFor(config.adapter);
-    const handler = this.databaseAdapterFor(config);
+    const dbConfig = this.resolveConfiguration(configuration);
+    const flags = this.structureLoadFlagsFor(dbConfig.adapter);
+    const handler = this.databaseAdapterFor(dbConfig);
     if (!handler.structureLoad) {
-      throw new Error(`Adapter '${config.adapter}' does not support structureLoad`);
+      throw new Error(`Adapter '${dbConfig.adapter}' does not support structureLoad`);
     }
-    await handler.structureLoad(config, filename, flags, root);
+    await handler.structureLoad(dbConfig, filename, flags, root);
   }
 
   /**
@@ -917,7 +917,7 @@ export class DatabaseTasks {
    * Mirrors Rails' `DatabaseTasks.schema_dump_path`:
    * 1. Returns `ENV["SCHEMA"]` when set.
    * 2. When `schemaDump` is explicitly set in the config hash, consults
-   *    `config.schemaDump(format)` — returns `null` for `false`/null (disabled),
+   *    `dbConfig.schemaDump(format)` — returns `null` for `false`/null (disabled),
    *    or the custom path string. Applies Rails' db_dir prefix rule:
    *    dirname == dbDir → return as-is; otherwise prepend dbDir.
    * 3. For configs with no explicit `schemaDump` key, falls back to
@@ -926,30 +926,30 @@ export class DatabaseTasks {
    *
    * Returns `null` when the config disables schema dumping (`schemaDump: false`).
    */
-  static schemaDumpPath(config?: DatabaseConfig, format?: SchemaFormat): string | null {
+  static schemaDumpPath(dbConfig?: DatabaseConfig, format?: SchemaFormat): string | null {
     const envSchema = getEnv("SCHEMA");
     if (envSchema !== undefined) return envSchema;
 
-    // Only consult config.schemaDump() when the key is explicitly present.
+    // Only consult dbConfig.schemaDump() when the key is explicitly present.
     // When absent, dumpSchemaFilename() is the authoritative path — it handles
     // all formats (including the Trails-only "js") with the dbDir prefix.
     // Calling schemaDump() unconditionally for "js" would return "schema.ts"
     // (after "js"→"ts" normalization) giving the wrong extension.
-    const rawCfg = (config as unknown as { configuration?: Record<string, unknown> })
+    const rawCfg = (dbConfig as unknown as { configuration?: Record<string, unknown> })
       ?.configuration;
     const hasExplicitSchemaDump =
       rawCfg != null && Object.hasOwn(rawCfg, "schemaDump") && rawCfg["schemaDump"] !== undefined;
 
     if (!hasExplicitSchemaDump) {
-      return this.dumpSchemaFilename(config, format);
+      return this.dumpSchemaFilename(dbConfig, format);
     }
 
     // Explicit key: call schemaDump() for the value.
     // Normalize "js" → "ts": HashConfig.schemaDump() has no "js" case and
     // returns null for unknown formats, which would incorrectly gate the dump.
-    const cfgWithDump = config as unknown as { schemaDump?: (format?: string) => string | null };
+    const cfgWithDump = dbConfig as unknown as { schemaDump?: (format?: string) => string | null };
     if (typeof cfgWithDump?.schemaDump !== "function") {
-      return this.dumpSchemaFilename(config, format);
+      return this.dumpSchemaFilename(dbConfig, format);
     }
     const fmt = (format ?? this.schemaFormat) === "js" ? "ts" : (format ?? this.schemaFormat);
     const filename = cfgWithDump.schemaDump(fmt);
@@ -975,11 +975,11 @@ export class DatabaseTasks {
     return path.isAbsolute(filename) ? filename : (path.resolve?.(this.root, filename) ?? filename);
   }
 
-  static async dumpSchema(config: DatabaseConfig): Promise<void> {
+  static async dumpSchema(dbConfig: DatabaseConfig): Promise<void> {
     // Rails: `return unless db_config.schema_dump` — lets per-config
     // `schemaDump: false` (or null) suppress dumping.
     // schemaDumpPath() returns null when schemaDump is disabled.
-    const rawFilename = this.schemaDumpPath(config);
+    const rawFilename = this.schemaDumpPath(dbConfig);
     if (rawFilename == null) return;
     // Resolve relative paths against `root` so the dump lands in the app's
     // db/ dir regardless of process cwd — mirrors loadSchema's resolution.
@@ -988,7 +988,7 @@ export class DatabaseTasks {
       const fs = getFs();
       const path = getPath();
       fs.mkdirSync(path.dirname(filename), { recursive: true });
-      await this.structureDump(config, filename);
+      await this.structureDump(dbConfig, filename);
       // Rails' dump_schema appends `dump_schema_information` after a
       // structure_dump so schema_migrations' version rows round-trip
       // through load. Without this, loading structure.sql into a
@@ -1010,15 +1010,15 @@ export class DatabaseTasks {
   }
 
   static async loadSchema(
-    config: DatabaseConfig,
+    dbConfig: DatabaseConfig,
     format: SchemaFormat = DatabaseTasks.schemaFormat,
     file?: string,
   ): Promise<void> {
     // Rails: file ||= schema_dump_path(db_config, format); return unless file
     // Ruby `unless file` is nil/false only — "" is truthy there, so blank strings
     // reach check_schema_file. Use == null (nullish) to match that.
-    const filename = file ?? this.schemaDumpPath(config, format);
-    if (filename == null) return;
+    file ??= this.schemaDumpPath(dbConfig, format) ?? undefined;
+    if (file == null) return;
 
     // Rails: `verbose_was, Migration.verbose = Migration.verbose, verbose? && ENV["VERBOSE"]`
     // (`database_tasks.rb:380`) — the extra ENV["VERBOSE"] term keeps a schema
@@ -1027,11 +1027,11 @@ export class DatabaseTasks {
     const verboseWas = Migration.verbose;
     Migration.verbose = isVerbose() && getEnv("VERBOSE") !== undefined;
     try {
-      this.checkSchemaFile(filename);
+      this.checkSchemaFile(file);
 
       if (format === "sql") {
-        await this.structureLoad(config, filename);
-        await this._stampSchemaSha1(config, filename);
+        await this.structureLoad(dbConfig, file);
+        await this._stampSchemaSha1(dbConfig, file);
         return;
       }
 
@@ -1043,9 +1043,9 @@ export class DatabaseTasks {
         );
       }
       // Missing isAbsolute means the PathAdapter doesn't model relative vs.
-      // absolute (e.g. a VFS) — treat the incoming filename as already
+      // absolute (e.g. a VFS) — treat the incoming file as already
       // absolute in that case.
-      const absolute = this._resolveSchemaPath(filename);
+      const absolute = this._resolveSchemaPath(file);
       const href = path.pathToFileURL(absolute).href;
       const mod = (await import(href)) as {
         default?: (ctx: unknown) => Promise<void> | void;
@@ -1057,10 +1057,10 @@ export class DatabaseTasks {
       }
       const adapter = await this._migrationAdapter();
       await defineSchema(adapter);
-      // Stamp using the resolved absolute path — `filename` may be
+      // Stamp using the resolved absolute path — `file` may be
       // relative and `schemaSha1` reads the file via getFs(), so the
       // path must match what was actually imported.
-      await this._stampSchemaSha1(config, absolute);
+      await this._stampSchemaSha1(dbConfig, absolute);
     } finally {
       Migration.verbose = verboseWas;
     }
@@ -1073,17 +1073,17 @@ export class DatabaseTasks {
    * path). Mirrors Rails' `load_schema` which calls
    * `internal_metadata.create_table_and_set_flags(env, schema_sha1(file))`.
    */
-  private static async _stampSchemaSha1(config: DatabaseConfig, filename: string): Promise<void> {
-    if (!config.useMetadataTable) return;
+  private static async _stampSchemaSha1(dbConfig: DatabaseConfig, filename: string): Promise<void> {
+    if (!dbConfig.useMetadataTable) return;
     try {
       const adapter = await this._migrationAdapter();
       const { InternalMetadata } = await import("../internal-metadata.js");
       const metadata = new InternalMetadata(adapter.pool);
       const sha1 = await this.schemaSha1(filename);
-      await metadata.createTableAndSetFlags(config.envName, sha1);
+      await metadata.createTableAndSetFlags(dbConfig.envName, sha1);
     } catch (error) {
       console.debug?.(
-        `[trails] _stampSchemaSha1 failed for ${config.envName} (${filename})`,
+        `[trails] _stampSchemaSha1 failed for ${dbConfig.envName} (${filename})`,
         error,
       );
     }
@@ -1159,8 +1159,8 @@ export class DatabaseTasks {
     const configs = this.configsFor(this._normalizeEnv());
 
     // Rails: initialize_database for every config before the single-primary fast path or version loop.
-    for (const config of configs) {
-      await initializeDatabase(config);
+    for (const dbConfig of configs) {
+      await initializeDatabase(dbConfig);
     }
 
     // Rails: a single primary database short-circuits the per-config loop and
@@ -1195,16 +1195,16 @@ export class DatabaseTasks {
     const dumpDbConfigs: DatabaseConfig[] = [];
 
     // Rails: each_current_configuration { |db_config| initialize_database(db_config) }
-    for (const envName of eachCurrentEnvironment(env)) {
-      for (const dbConfig of this.configsFor(envName)) {
+    for (const environment of eachCurrentEnvironment(env)) {
+      for (const dbConfig of this.configsFor(environment)) {
         const databaseInitialized = await initializeDatabase(dbConfig);
         if (databaseInitialized && dbConfig.seeds) seed = true;
       }
     }
 
     // Rails: db_configs_with_versions per environment, sort, migrate each.
-    for (const envName of eachCurrentEnvironment(env)) {
-      const mappedVersions = await this.dbConfigsWithVersions(envName);
+    for (const environment of eachCurrentEnvironment(env)) {
+      const mappedVersions = await this.dbConfigsWithVersions(environment);
       const sorted = Array.from(mappedVersions.entries()).sort(([a], [b]) =>
         BigInt(String(a)) < BigInt(String(b)) ? -1 : BigInt(String(a)) > BigInt(String(b)) ? 1 : 0,
       );
@@ -1220,9 +1220,9 @@ export class DatabaseTasks {
     }
 
     if (this.dumpSchemaAfterMigration) {
-      for (const config of dumpDbConfigs) {
-        await this.withTemporaryPool(config, async () => {
-          await this.dumpSchema(config);
+      for (const dbConfig of dumpDbConfigs) {
+        await this.withTemporaryPool(dbConfig, async () => {
+          await this.dumpSchema(dbConfig);
         });
       }
     }
@@ -1246,14 +1246,14 @@ export class DatabaseTasks {
         ? targetVersionOverride.trim() || null
         : (targetVersionOverride ?? null);
     const targetVersion = explicit === null ? this.targetVersion() : Number(explicit);
-    for (const config of this.configsFor(env)) {
-      await this.withTemporaryPool(config, async (pool) => {
-        const context = await this._migrationContextFor(await pool.leaseConnection(), config);
+    for (const dbConfig of this.configsFor(env)) {
+      await this.withTemporaryPool(dbConfig, async (pool) => {
+        const context = await this._migrationContextFor(await pool.leaseConnection(), dbConfig);
         const versionsToRun = await context.pendingMigrationVersions();
         for (const version of versionsToRun) {
           if (targetVersion !== null && targetVersion !== Number(version)) continue;
           const list = dbConfigsWithVersions.get(version) ?? [];
-          list.push(config);
+          list.push(dbConfig);
           dbConfigsWithVersions.set(version, list);
         }
       });
@@ -1263,7 +1263,7 @@ export class DatabaseTasks {
 
   /**
    * Mirrors Rails' `DatabaseTasks.with_temporary_pool`
-   * (`tasks/database_tasks.rb:541-548`): establishes a pool for `config`
+   * (`tasks/database_tasks.rb:541-548`): establishes a pool for `dbConfig`
    * (clobber defaults to false, so an existing pool for the same config object
    * is reused), yields it, then re-establishes the original config
    * unconditionally in the `ensure` (`:547`).
@@ -1291,7 +1291,7 @@ export class DatabaseTasks {
    * @internal
    */
   static async withTemporaryPool<T>(
-    config: DatabaseConfig,
+    dbConfig: DatabaseConfig,
     fn: (pool: ConnectionPool) => Promise<T>,
     { clobber = false }: { clobber?: boolean } = {},
   ): Promise<T> {
@@ -1301,7 +1301,7 @@ export class DatabaseTasks {
       // Rails: `connection_handler.establish_connection(db_config, clobber:)`
       // (database_tasks.rb:543). Ruby's `establish_connection(config_or_env = nil)`
       // takes no `clobber:`, so the kwarg can only be threaded through the handler.
-      const pool = migrationClass.connectionHandler.establishConnection(config, {
+      const pool = migrationClass.connectionHandler.establishConnection(dbConfig, {
         owner: migrationClass.connectionClassForSelf(),
         clobber,
       });
@@ -1320,13 +1320,13 @@ export class DatabaseTasks {
   }
 
   static async withTemporaryConnection<T>(
-    config: DatabaseConfig,
+    dbConfig: DatabaseConfig,
     fn: (
       adapter: import("../connection-adapters/abstract-adapter.js").AbstractAdapter,
     ) => Promise<T>,
     { clobber = false }: { clobber?: boolean } = {},
   ): Promise<T> {
-    return this.withTemporaryPool(config, async (pool) => fn(await pool.leaseConnection()), {
+    return this.withTemporaryPool(dbConfig, async (pool) => fn(await pool.leaseConnection()), {
       clobber,
     });
   }
@@ -1396,15 +1396,15 @@ export class DatabaseTasks {
   }
 
   static async schemaUpToDate(
-    config: DatabaseConfig,
+    dbConfig: DatabaseConfig,
     format: SchemaFormat = DatabaseTasks.schemaFormat,
     file?: string,
   ): Promise<boolean> {
     void format;
-    const filename = file ?? this.schemaDumpPath(config);
-    if (!filename) return true;
+    file ??= this.schemaDumpPath(dbConfig) ?? undefined;
+    if (!file) return true;
     const fs = getFs();
-    if (!fs.existsSync(filename)) return true;
+    if (!fs.existsSync(file)) return true;
 
     let adapter: import("../connection-adapters/abstract-adapter.js").AbstractAdapter;
     try {
@@ -1421,7 +1421,7 @@ export class DatabaseTasks {
     const storedSha1 = await metadata.get("schema_sha1");
     if (!storedSha1) return false;
 
-    const fileSha1 = await this.schemaSha1(filename);
+    const fileSha1 = await this.schemaSha1(file);
     return storedSha1 === fileSha1;
   }
 
@@ -1527,45 +1527,45 @@ export class DatabaseTasks {
    * is a trails invention the remaining mysql/sqlite tasks still ride on.
    * @internal
    */
-  static async truncateTables(config: DatabaseConfig): Promise<void> {
-    const handler = this.databaseAdapterFor(config);
+  static async truncateTables(dbConfig: DatabaseConfig): Promise<void> {
+    const handler = this.databaseAdapterFor(dbConfig);
     if (handler.truncateAll) {
-      await handler.truncateAll(config);
+      await handler.truncateAll(dbConfig);
       return;
     }
-    await this.withTemporaryConnection(config, async (conn) => {
+    await this.withTemporaryConnection(dbConfig, async (conn) => {
       await conn.truncateTables(...(await conn.tables()));
     });
   }
 
   static async reconstructFromSchema(
-    config: DatabaseConfig,
+    dbConfig: DatabaseConfig,
     format: SchemaFormat = DatabaseTasks.schemaFormat,
     file?: string,
   ): Promise<void> {
     // Rails: file ||= schema_dump_path(db_config, format)
-    const resolvedFile = file ?? this.schemaDumpPath(config, format) ?? undefined;
+    file ??= this.schemaDumpPath(dbConfig, format) ?? undefined;
     // Rails: check_schema_file(file) if file
-    if (resolvedFile !== undefined) this.checkSchemaFile(resolvedFile);
+    if (file !== undefined) this.checkSchemaFile(file);
 
     const { NoDatabaseError } = await import("../errors.js");
     // Mirrors Rails' `with_temporary_pool(db_config, clobber: true)` wrapper:
     // establishes a fresh connection so schemaUpToDate can query ar_internal_metadata,
     // then restores the prior connection when done.
-    await this.withTemporaryPool(config, async () => {
+    await this.withTemporaryPool(dbConfig, async () => {
       try {
-        if (await this.schemaUpToDate(config, format, resolvedFile)) {
+        if (await this.schemaUpToDate(dbConfig, format, file)) {
           if (getEnv("SKIP_TEST_DATABASE_TRUNCATE") === undefined) {
-            await this.truncateTables(config);
+            await this.truncateTables(dbConfig);
           }
         } else {
-          await this.purge(config);
-          await this.loadSchema(config, format, resolvedFile);
+          await this.purge(dbConfig);
+          await this.loadSchema(dbConfig, format, file);
         }
       } catch (error) {
         if (!(error instanceof NoDatabaseError)) throw error;
-        await this.create(config);
-        await this.loadSchema(config, format, resolvedFile);
+        await this.create(dbConfig);
+        await this.loadSchema(dbConfig, format, file);
       }
     });
   }

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -256,6 +256,19 @@ describe("body call capture", () => {
     expect(quote.callSeq).toEqual(["typeCast", "quoteString"]);
   });
 
+  it("credits an expression-bodied arrow's outermost call", () => {
+    // The body IS the CallExpression, so a walk that starts at the body's
+    // CHILDREN never sees `where` — Ruby's walk_for_calls is handed the whole
+    // body node and credits the equivalent one-expression body (RFC 0084).
+    const info = extractFromFiles("/p", {
+      "quoting.ts": `export const f = (x: unknown) => where(x);`,
+    });
+    const f = fileFunctionsOf(info, "quoting.ts").find((fn) => fn.name === "f")!;
+    expect(f.calls).toEqual(["where"]);
+    expect(f.callSeq).toEqual(["where"]);
+    expect(f.skeleton).toEqual(["ref:where"]);
+  });
+
   it("emits an ordered control + call skeleton, with duplicates, alongside calls", () => {
     const cls = extractFromSource(
       `class Foo {

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -922,6 +922,7 @@ export function extractFromProgram(
             const calls = extractCalls(body);
             const callSeq = extractCallSeq(body);
             const callArgs = extractCallArgs(body);
+            const skeleton = extractSkeleton(body);
             const internal = hasInternalJsDocTag(decl);
             // A renamed export (`export { withRoutesHelpers as with }`) is its
             // own surface entry: the declaration's tag justifies the DECLARED
@@ -956,6 +957,7 @@ export function extractFromProgram(
               ...(calls !== undefined ? { calls } : {}),
               ...(callSeq !== undefined ? { callSeq } : {}),
               ...(callArgs !== undefined ? { callArgs } : {}),
+              ...(skeleton !== undefined ? { skeleton } : {}),
               ...(exportedMissingRailsCalls !== undefined
                 ? { missingRailsCalls: exportedMissingRailsCalls }
                 : {}),
@@ -2708,7 +2710,9 @@ function extractSkeleton(node: ts.Node | undefined): string[] | undefined {
     }
     ts.forEachChild(n, visit);
   };
-  ts.forEachChild(node, visit);
+  // The body ITSELF, not just its children: an expression-bodied arrow
+  // (`= (x) => where(x)`) IS the call site, and Ruby's walk_for_skeleton covers it.
+  visit(node);
   return tokens.length === 0 ? undefined : tokens;
 }
 
@@ -2974,7 +2978,9 @@ function collectCalls(node: ts.Node | undefined): string[] | undefined {
     }
     ts.forEachChild(n, visit);
   };
-  ts.forEachChild(node, visit);
+  // The body ITSELF, not just its children: an expression-bodied arrow
+  // (`= (x) => where(x)`) IS the call site, and Ruby's walk_for_calls covers it.
+  visit(node);
   if (names.size === 0) return undefined;
   return [...names];
 }


### PR DESCRIPTION
Two bundled stories.

## 1. Rename locals/params to Rails' (RFC 0096)

`naming` call-argument rows converged by renaming body-local identifiers to the
Rails identifier, camelCased. No public surface or behavior change.

- `tasks/database-tasks.ts` — `config` → `dbConfig` throughout (Rails' `db_config`,
  `tasks/database_tasks.rb:116,171,211,230,376,413,566,599,635,652`); the extra
  `filename` / `resolvedFile` locals in `load_schema`, `schema_up_to_date?` and
  `reconstruct_from_schema` are gone in favour of Rails' `file ||= schema_dump_path(...)`
  (`database_tasks.rb:377,400,414`); `primary` → `dbConfig` in `charset_current` /
  `collation_current` (`:328,338`); `c` → `dbConfig` in `each_local_configuration`
  (`:599`); `envName` → `environment` in `prepare_all` (`:186`).
- `connection-adapters/abstract-adapter.ts` — `translated` → `translatedException`,
  the rescued error → `originalException` in `reconnect!` and `with_raw_connection`
  (`abstract_adapter.rb:678-694,1016-1036`); the `serialized` local dropped for
  Rails' `value = ...serialize(value)` (`abstract/quoting.rb:161`).
- `connection-adapters/abstract/database-statements.ts` — `resolvedBinds` → `binds`,
  matching Rails' `sql, binds = to_sql_and_binds(arel, binds)`
  (`abstract/database_statements.rb:207,213`).
- `connection-adapters/sqlite3-adapter.ts` — `existingFks`/`fkToRemove` →
  `foreignKeys`/`fkey`, `positionalToTable` folded into `toTable`
  (`sqlite3/schema_statements.rb:65-84`); `remainingChecks` → `checkConstraints`
  (`:113-119`); the `colNames` local inlined as Rails inlines it (`:721`);
  `allowNull`/`defaultValue` → `null_`/`default_` (`sqlite3_adapter.rb:374`).
- `connection-adapters/abstract-mysql-adapter.ts` — `c` → `comment` (`:322`),
  `resolvedType` → `type` (`:407`), `colDef` → `cd` (`:405-`), `idx`/`algorithmClause`
  → `index`/`algorithm` and `index_exists?` now gets `columnName` as Rails passes it
  (`:452-457`), `o` → `s` in `columns_for_distinct` (`:620`).

Not renamed (AC4): Ruby `null`/`default` are JS reserved words (`null_`/`default_`
is the settled spelling); `args.last` in a `register_type` block has no local;
`case_sensitive_comparison` passing `attribute.quotedNode(value)` is an
argument-shape defect, not a naming one.

**Row movement** (`pnpm parity:api:calls:args:report`): `naming` 912 → 864 overall,
activerecord 434 → 386 (48 converged). `shape` rows unchanged. Both ratchets green:
`call-mismatches ratchet: OK (2115 baselined)`, `call-args ratchet: OK (658 baselined shape row(s))`.

The remaining 386 activerecord rows are filed as
`0096-naming-identifier-burndown/naming-burndown-activerecord-rest-2`.

## 2. Credit an expression-bodied arrow's outermost call (RFC 0084)

`collectCalls` and `extractSkeleton` started their walk at `ts.forEachChild(body, visit)`,
so for `const f = (x) => where(x)` — where the body IS the `CallExpression` — `where`
was never credited. Both now start at the body node, matching `walkForCallArgs` and
Ruby's `walk_for_calls` / `walk_for_skeleton`, which are handed the whole body node.
`skeleton` is also now emitted for the exported-const function population (it already
carried `calls`, `callSeq` and `callArgs`), so the fix is observable there.

Artifact regenerated: `Calls (advisory): 6217 matched pairs checked, 1485 omit a
ported-method call Rails makes` — no baseline row went stale and no new row surfaced,
so the exclude tree is untouched.

A test pins `const f = (x) => where(x)` crediting `where` in `calls`, `callSeq` and
`skeleton`.

Closes-story: naming-burndown-activerecord-rest
Closes-story: ts-extractor-credit-expression-bodied-arrow-calls
