### PR TITLE
refactor(activesupport,arel): rename locals to Rails identifiers; drop arel default args

### DIFF
--- a/packages/activesupport/src/cache/file-store.ts
+++ b/packages/activesupport/src/cache/file-store.ts
@@ -215,18 +215,18 @@ export class FileStore extends Store implements CacheStore {
   // Rails FileStore instruments increment/decrement with the normalized key
   // (file_store.rb:62-64), unlike MemoryStore which uses the raw name.
   override increment(name: string, amount = 1, options?: StoreOptions): number | null {
-    const merged = this.mergedOptions(options);
-    const key = this.normalizeKey(name, merged);
+    options = this.mergedOptions(options);
+    const key = this.normalizeKey(name, options);
     return this.instrument("increment", key, { amount }, () =>
-      this.modifyValue(name, amount, merged),
+      this.modifyValue(name, amount, options),
     );
   }
 
   override decrement(name: string, amount = 1, options?: StoreOptions): number | null {
-    const merged = this.mergedOptions(options);
-    const key = this.normalizeKey(name, merged);
+    options = this.mergedOptions(options);
+    const key = this.normalizeKey(name, options);
     return this.instrument("decrement", key, { amount }, () =>
-      this.modifyValue(name, -amount, merged),
+      this.modifyValue(name, -amount, options),
     );
   }
 
@@ -241,13 +241,13 @@ export class FileStore extends Store implements CacheStore {
     // Rails coerces `amount = Integer(amount)` once (file_store.rb:226) and uses
     // it uniformly for the seed write, the return, and the hit-path addition;
     // `Integer()` raises on NaN/Infinity rather than silently truncating.
-    const amt = integer(amount);
+    amount = integer(amount);
     const entry = this.readEntry(key, options);
     if (!entry || entry.isExpired() || entry.isMismatched(version)) {
-      this.write(name, amt, options);
-      return amt;
+      this.write(name, amount, options);
+      return amount;
     }
-    const num = toI(entry.value) + amt;
+    const num = toI(entry.value) + amount;
     this.writeEntry(
       key,
       new Entry(num, { expiresAt: entry.expiresAt, version: entry.version }),

--- a/packages/activesupport/src/cache/memory-store.ts
+++ b/packages/activesupport/src/cache/memory-store.ts
@@ -83,10 +83,10 @@ export class MemoryStore extends Store implements CacheStore {
   // Mirrors Rails MemoryStore#cleanup (memory_store.rb): instrumented, deletes
   // every expired entry.
   override cleanup(options?: CacheOptions): void {
-    const merged = this.mergedOptions(options);
+    options = this.mergedOptions(options);
     this.instrument("cleanup", null, { size: this.data.size }, () => {
       for (const [key, rec] of this.data) {
-        if (this.recordExpired(rec)) this.deleteEntry(key, merged);
+        if (this.recordExpired(rec)) this.deleteEntry(key, options);
       }
     });
   }
@@ -94,13 +94,13 @@ export class MemoryStore extends Store implements CacheStore {
   // Mirrors Rails MemoryStore#delete_matched (memory_store.rb): instrumented with
   // the matcher, which is run through keyMatcher so a namespaced store scopes the
   // deletion to its own (namespace-prefixed) keys.
-  override deleteMatched(pattern: string | RegExp, options?: CacheOptions): void {
-    const merged = this.mergedOptions(options);
-    const raw = typeof pattern === "string" ? new RegExp(pattern) : pattern;
-    const matcher = this.keyMatcher(raw, merged);
+  override deleteMatched(matcher: string | RegExp, options?: CacheOptions): void {
+    options = this.mergedOptions(options);
+    if (typeof matcher === "string") matcher = new RegExp(matcher);
+    matcher = this.keyMatcher(matcher, options);
     this.instrument("delete_matched", String(matcher), undefined, () => {
       for (const key of this.data.keys()) {
-        if (key.match(matcher) !== null) this.deleteEntry(key, merged);
+        if (key.match(matcher) !== null) this.deleteEntry(key, options);
       }
     });
   }
@@ -126,10 +126,10 @@ export class MemoryStore extends Store implements CacheStore {
   // `increment("foo") # => 1`); on a hit it adds to entry.value.to_i, preserving
   // the entry's expiresAt/version.
   private modifyValue(name: string, amount: number, options?: CacheOptions): number {
-    const merged = this.mergedOptions(options);
-    const key = this.normalizeKey(name, merged);
-    const version = this.normalizeVersion(name, merged) ?? null;
-    const entry = this.readEntry(key, merged);
+    options = this.mergedOptions(options);
+    const key = this.normalizeKey(name, options);
+    const version = this.normalizeVersion(name, options) ?? null;
+    const entry = this.readEntry(key, options);
     if (!entry || entry.isExpired() || entry.isMismatched(version)) {
       // Rails seeds with `Integer(amount)` (raises on NaN/Infinity) but returns
       // the raw `amount` (memory_store.rb:248-249), so `increment("foo", 1.5)`

--- a/packages/activesupport/src/cache/store.ts
+++ b/packages/activesupport/src/cache/store.ts
@@ -112,25 +112,25 @@ export abstract class Store {
     optionsOrBlock?: StoreOptions | ((key: string, opts: WriteOptions) => unknown),
     maybeBlock?: (key: string, opts: WriteOptions) => unknown,
   ): unknown {
-    let opts: StoreOptions | undefined;
+    let callOptions: StoreOptions | undefined;
     let block: ((key: string, opts: WriteOptions) => unknown) | undefined;
     if (typeof optionsOrBlock === "function") {
       block = optionsOrBlock;
     } else {
-      opts = optionsOrBlock;
+      callOptions = optionsOrBlock;
       block = maybeBlock;
     }
 
     if (block) {
-      const merged = this.mergedOptions(opts);
-      const key = this.normalizeKey(name, merged);
+      const options = this.mergedOptions(callOptions);
+      const key = this.normalizeKey(name, options);
       let entry: Entry | null = null;
-      if (!merged.force) {
-        this.instrument("read", key, merged, (payload) => {
-          const cached = this.readEntry(key, merged);
-          entry = this.handleExpiredEntry(cached, key, merged);
+      if (!options.force) {
+        this.instrument("read", key, options, (payload) => {
+          const cachedEntry = this.readEntry(key, options);
+          entry = this.handleExpiredEntry(cachedEntry, key, options);
           if (entry) {
-            if (entry.isMismatched(this.normalizeVersion(name, merged) ?? null)) {
+            if (entry.isMismatched(this.normalizeVersion(name, options) ?? null)) {
               entry = null;
             } else {
               try {
@@ -145,29 +145,29 @@ export abstract class Store {
           payload.hit = !!entry;
         });
       }
-      if (entry) return this.getEntryValue(entry, name, merged);
-      return this.saveBlockResultToCache(name, key, merged, block);
-    } else if (opts?.force) {
+      if (entry) return this.getEntryValue(entry, name, options);
+      return this.saveBlockResultToCache(name, key, options, block);
+    } else if (callOptions?.force) {
       throw new ArgumentError(
         "Missing block: Calling `Cache#fetch` with `force: true` requires a block.",
       );
     } else {
-      return this.read(name, opts);
+      return this.read(name, callOptions);
     }
   }
 
   read(name: string, options?: StoreOptions): unknown {
-    const merged = this.mergedOptions(options);
-    const key = this.normalizeKey(name, merged);
-    const version = this.normalizeVersion(name, merged);
-    return this.instrument("read", key, merged, (payload) => {
-      const entry = this.readEntry(key, merged);
+    options = this.mergedOptions(options);
+    const key = this.normalizeKey(name, options);
+    const version = this.normalizeVersion(name, options);
+    return this.instrument("read", key, options, (payload) => {
+      const entry = this.readEntry(key, options);
       if (!entry) {
         payload.hit = false;
         return null;
       }
       if (entry.isExpired()) {
-        this.deleteEntry(key, merged);
+        this.deleteEntry(key, options);
         payload.hit = false;
         return null;
       }
@@ -190,33 +190,33 @@ export abstract class Store {
 
   readMulti(...names: [...string[], StoreOptions] | string[]): Record<string, unknown> {
     if (names.length === 0) return {};
-    const options = extractOptions(names as unknown[]);
+    let options = extractOptions(names as unknown[]);
     const nameList = names as string[];
-    const merged = this.mergedOptions(options);
-    const keys = nameList.map((n) => this.normalizeKey(n, merged));
-    return this.instrumentMulti("read_multi", keys, merged, (payload) => {
-      const results = this.readMultiEntries(nameList, merged);
-      payload.hits = Object.keys(results).map((n) => this.normalizeKey(n, merged));
+    options = this.mergedOptions(options);
+    const keys = nameList.map((name) => this.normalizeKey(name, options));
+    return this.instrumentMulti("read_multi", keys, options, (payload) => {
+      const results = this.readMultiEntries(nameList, options);
+      payload.hits = Object.keys(results).map((name) => this.normalizeKey(name, options));
       return results;
     });
   }
 
   writeMulti(hash: Record<string, unknown>, options?: StoreOptions): Record<string, unknown> {
     if (Object.keys(hash).length === 0) return hash;
-    const merged = this.mergedOptions(options);
+    options = this.mergedOptions(options);
     const normalizedHash: Record<string, unknown> = {};
-    for (const [name, value] of Object.entries(hash)) {
-      normalizedHash[this.normalizeKey(name, merged)] = value;
+    for (const [key, value] of Object.entries(hash)) {
+      normalizedHash[this.normalizeKey(key, options)] = value;
     }
-    return this.instrumentMulti("write_multi", normalizedHash, merged, () => {
+    return this.instrumentMulti("write_multi", normalizedHash, options, () => {
       const entries: Record<string, Entry> = {};
       for (const [name, value] of Object.entries(hash)) {
-        entries[this.normalizeKey(name, merged)] = new Entry(value, {
-          expiresIn: typeof merged.expiresIn === "number" ? merged.expiresIn : null,
-          version: this.normalizeVersion(name, merged) ?? undefined,
+        entries[this.normalizeKey(name, options)] = new Entry(value, {
+          expiresIn: typeof options.expiresIn === "number" ? options.expiresIn : null,
+          version: this.normalizeVersion(name, options) ?? undefined,
         });
       }
-      return this.writeMultiEntries(entries, merged);
+      return this.writeMultiEntries(entries, options);
     });
   }
 
@@ -229,80 +229,80 @@ export abstract class Store {
     if (typeof block !== "function")
       throw new ArgumentError("Missing block: `Cache#fetch_multi` requires a block.");
     if (namesAndBlock.length === 0) return {};
-    const options = extractOptions(namesAndBlock as unknown[]);
+    let options = extractOptions(namesAndBlock as unknown[]);
     const names = namesAndBlock as string[];
-    const merged = this.mergedOptions(options);
-    const keys = names.map((n) => this.normalizeKey(n, merged));
+    options = this.mergedOptions(options);
+    const keys = names.map((name) => this.normalizeKey(name, options));
     const writes: Record<string, unknown> = {};
-    const ordered = this.instrumentMulti("read_multi", keys, merged, (payload) => {
-      const reads = merged.force ? {} : this.readMultiEntries(names, merged);
+    const ordered = this.instrumentMulti("read_multi", keys, options, (payload) => {
+      const reads = options.force ? {} : this.readMultiEntries(names, options);
       const result: Record<string, unknown> = {};
       for (const name of names) {
         result[name] = Object.prototype.hasOwnProperty.call(reads, name)
           ? reads[name]
           : (writes[name] = block(name));
       }
-      if (merged.skipNil) {
+      if (options.skipNil) {
         for (const k of Object.keys(writes)) {
           if (writes[k] == null) delete writes[k];
         }
       }
-      payload.hits = Object.keys(reads).map((n) => this.normalizeKey(n, merged));
+      payload.hits = Object.keys(reads).map((name) => this.normalizeKey(name, options));
       payload.super_operation = "fetch_multi";
       return result;
     });
-    this.writeMulti(writes, merged);
+    this.writeMulti(writes, options);
     return ordered;
   }
 
   write(name: string, value: unknown, options?: StoreOptions): boolean {
-    const merged = this.mergedOptions(options);
-    const key = this.normalizeKey(name, merged);
-    return this.instrument("write", key, merged, () =>
+    options = this.mergedOptions(options);
+    const key = this.normalizeKey(name, options);
+    return this.instrument("write", key, options, () =>
       this.writeEntry(
         key,
         new Entry(value, {
-          expiresIn: typeof merged.expiresIn === "number" ? merged.expiresIn : null,
-          version: this.normalizeVersion(name, merged) ?? undefined,
+          expiresIn: typeof options.expiresIn === "number" ? options.expiresIn : null,
+          version: this.normalizeVersion(name, options) ?? undefined,
         }),
-        merged,
+        options,
       ),
     );
   }
 
   delete(name: string, options?: StoreOptions): boolean {
-    const merged = this.mergedOptions(options);
-    const key = this.normalizeKey(name, merged);
-    return this.instrument("delete", key, merged, () => this.deleteEntry(key, merged));
+    options = this.mergedOptions(options);
+    const key = this.normalizeKey(name, options);
+    return this.instrument("delete", key, options, () => this.deleteEntry(key, options));
   }
 
   deleteMulti(names: string[], options?: StoreOptions): number {
     if (names.length === 0) return 0;
-    const merged = this.mergedOptions(options);
-    const keys = names.map((n) => this.normalizeKey(n, merged));
-    return this.instrumentMulti("delete_multi", keys, merged, () =>
-      this.deleteMultiEntries(keys, merged),
+    options = this.mergedOptions(options);
+    names = names.map((key) => this.normalizeKey(key, options));
+    return this.instrumentMulti("delete_multi", names, options, () =>
+      this.deleteMultiEntries(names, options),
     );
   }
 
   exist(name: string, options?: StoreOptions): boolean {
-    const merged = this.mergedOptions(options);
-    const key = this.normalizeKey(name, merged);
+    options = this.mergedOptions(options);
+    const key = this.normalizeKey(name, options);
     return this.instrument("exist?", key, undefined, () => {
-      const entry = this.readEntry(key, merged);
+      const entry = this.readEntry(key, options);
       return !!(
         entry &&
         !entry.isExpired() &&
-        !entry.isMismatched(this.normalizeVersion(name, merged) ?? null)
+        !entry.isMismatched(this.normalizeVersion(name, options) ?? null)
       );
     });
   }
 
   newEntry(value: unknown, options?: StoreOptions): Entry {
-    const merged = this.mergedOptions(options);
+    options = this.mergedOptions(options);
     return new Entry(value, {
-      expiresIn: typeof merged.expiresIn === "number" ? merged.expiresIn : null,
-      version: merged.version != null ? String(merged.version) : undefined,
+      expiresIn: typeof options.expiresIn === "number" ? options.expiresIn : null,
+      version: options.version != null ? String(options.version) : undefined,
     });
   }
 
@@ -472,9 +472,9 @@ export abstract class Store {
   }
 
   protected normalizeKey(key: unknown, options?: StoreOptions): string {
-    const str = this.expandedKey(key);
-    if (!str) throw new ArgumentError("key cannot be blank");
-    return this.namespaceKey(str, options);
+    const strKey = this.expandedKey(key);
+    if (!strKey) throw new ArgumentError("key cannot be blank");
+    return this.namespaceKey(strKey, options);
   }
 
   /**
@@ -515,7 +515,7 @@ export abstract class Store {
   protected expandedKey(key: unknown): string {
     if (key != null && typeof key === "object") {
       if ("cacheKey" in key) return String((key as { cacheKey(): string }).cacheKey());
-      if (Array.isArray(key)) return key.map((k) => this.expandedKey(k)).join("/");
+      if (Array.isArray(key)) return key.map((element) => this.expandedKey(element)).join("/");
       return Object.entries(key as Record<string, unknown>)
         .map(([k, v]) => `${k}=${v}`)
         .sort()
@@ -564,11 +564,11 @@ export abstract class Store {
     options: StoreOptions,
     block: (key: string, opts: WriteOptions) => unknown,
   ): unknown {
-    const mutableOptions = { ...options };
-    const result = this.instrument("generate", key, mutableOptions, () =>
-      block(name, new WriteOptions(mutableOptions)),
+    options = { ...options };
+    const result = this.instrument("generate", key, options, () =>
+      block(name, new WriteOptions(options)),
     );
-    if (result != null || !options.skipNil) this.write(name, result, mutableOptions);
+    if (result != null || !options.skipNil) this.write(name, result, options);
     return result;
   }
 }

--- a/packages/activesupport/src/cache/store.ts
+++ b/packages/activesupport/src/cache/store.ts
@@ -101,6 +101,14 @@ export abstract class Store {
     }
   }
 
+  /**
+   * Mirrors Rails `Cache::Store#fetch` (cache.rb:443). Rails reassigns
+   * `options = merged_options(options)`; TypeScript cannot, because the
+   * pre-merge value here is a `let` local (the overload split), and TS drops
+   * narrowing for a `let` assigned on more than one branch — so the merged
+   * value is a block-scoped `options` and the pre-merge one keeps Rails' other
+   * name for it, `call_options` (cache.rb:861, 948).
+   */
   fetch(
     name: string,
     options?: StoreOptions,

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -745,13 +745,13 @@ export class CallbackSequence {
     this.userConditions = userConditions;
   }
 
-  before(b: Before): this {
-    (this.beforeList ??= []).unshift(b);
+  before(before: Before): this {
+    (this.beforeList ??= []).unshift(before);
     return this;
   }
 
-  after(a: After): this {
-    (this.afterList ??= []).push(a);
+  after(after: After): this {
+    (this.afterList ??= []).push(after);
     return this;
   }
 

--- a/packages/activesupport/src/encrypted-file.ts
+++ b/packages/activesupport/src/encrypted-file.ts
@@ -149,8 +149,8 @@ export class EncryptedFile {
       // the re-encrypt step, so it must not be world-readable.
       await fs.writeFile!(tmpPath, contents, { mode: 0o600 });
       await block(tmpPath);
-      const updated = await fs.readFile!(tmpPath, "utf8");
-      if (updated !== contents) await this.write(updated);
+      const updatedContents = await fs.readFile!(tmpPath, "utf8");
+      if (updatedContents !== contents) await this.write(updatedContents);
     } finally {
       try {
         await fs.unlink!(tmpPath);
@@ -167,13 +167,13 @@ export class EncryptedFile {
     }
   }
 
-  private encrypt(key: string, plaintext: string): string {
+  private encrypt(key: string, contents: string): string {
     this.checkKeyLength(key);
-    return this.encryptor(key).encryptAndSign(plaintext);
+    return this.encryptor(key).encryptAndSign(contents);
   }
 
-  private decrypt(key: string, ciphertext: string): string {
-    return this.encryptor(key).decryptAndVerify(ciphertext) as string;
+  private decrypt(key: string, contents: string): string {
+    return this.encryptor(key).decryptAndVerify(contents) as string;
   }
 
   private encryptor(key: string): MessageEncryptor {

--- a/packages/activesupport/src/notifications.ts
+++ b/packages/activesupport/src/notifications.ts
@@ -154,7 +154,7 @@ export class Notifications {
       block = blockOrOptions as () => T | Promise<T>;
       options = maybeOptions ?? {};
     }
-    const sub = this._notifier.subscribe(
+    const subscriber = this._notifier.subscribe(
       pattern,
       callback as FanoutListener,
       options.monotonic ?? false,
@@ -162,7 +162,7 @@ export class Notifications {
     try {
       return await block();
     } finally {
-      this._notifier.unsubscribe(sub);
+      this._notifier.unsubscribe(subscriber);
     }
   }
 
@@ -179,8 +179,8 @@ export class Notifications {
   }
 
   /** Remove a previously registered subscriber. */
-  static unsubscribe(subscriber: NotificationSubscriber): void {
-    this._notifier.unsubscribe(subscriber as unknown as FanoutSubscriber);
+  static unsubscribe(subscriberOrName: NotificationSubscriber): void {
+    this._notifier.unsubscribe(subscriberOrName as unknown as FanoutSubscriber);
   }
 
   /** Remove all subscribers. Useful in tests. */

--- a/packages/activesupport/src/number-helper/number-to-human-converter.ts
+++ b/packages/activesupport/src/number-helper/number-to-human-converter.ts
@@ -35,25 +35,25 @@ export class NumberToHumanConverter extends NumberConverter<NumberToHumanOptions
   }
 
   protected convert(): string {
-    const opts = this.options;
-    if (!("stripInsignificantZeros" in opts)) {
-      opts.stripInsignificantZeros = true;
+    const options = this.options;
+    if (!("stripInsignificantZeros" in options)) {
+      options.stripInsignificantZeros = true;
     }
 
-    const precision = (opts.precision ?? 3) as number;
-    const significant = (opts.significant ?? true) as boolean;
+    const precision = (options.precision ?? 3) as number;
+    const significant = (options.significant ?? true) as boolean;
 
-    const roundMode = opts.roundMode as string | undefined;
+    const roundMode = options.roundMode as string | undefined;
 
-    let num = this.numberAsFloat();
-    num = new RoundingHelper({ precision, significant, roundMode }).round(num);
+    let number = this.numberAsFloat();
+    number = new RoundingHelper({ precision, significant, roundMode }).round(number);
 
     const units = this.opts.units;
-    const exponent = this.calculateExponent(units, Math.abs(num));
-    num = num / Math.pow(10, exponent);
+    const exponent = this.calculateExponent(units, Math.abs(number));
+    number = number / Math.pow(10, exponent);
 
-    const roundedNumber = NumberToRoundedConverter.convert(num, opts);
-    const unit = this.determineUnit(units, exponent, Math.trunc(num));
+    const roundedNumber = NumberToRoundedConverter.convert(number, options);
+    const unit = this.determineUnit(units, exponent, Math.trunc(number));
     const format = this.getFormat();
     return format.replaceAll("%n", roundedNumber).replaceAll("%u", String(unit)).trim();
   }

--- a/packages/activesupport/src/number-helper/number-to-human-size-converter.ts
+++ b/packages/activesupport/src/number-helper/number-to-human-size-converter.ts
@@ -13,9 +13,9 @@ export class NumberToHumanSizeConverter extends NumberConverter<NumberToHumanSiz
   }
 
   protected convert(): string {
-    const opts = this.options;
-    if (!("stripInsignificantZeros" in opts)) {
-      opts.stripInsignificantZeros = true;
+    const options = this.options;
+    if (!("stripInsignificantZeros" in options)) {
+      options.stripInsignificantZeros = true;
     }
 
     const num = this.numberAsFloat();
@@ -30,7 +30,7 @@ export class NumberToHumanSizeConverter extends NumberConverter<NumberToHumanSiz
 
     const exp = this.exponent(Math.abs(num));
     const humanSize = num / Math.pow(BASE, exp);
-    const numberToFormat = NumberToRoundedConverter.convert(humanSize, opts);
+    const numberToFormat = NumberToRoundedConverter.convert(humanSize, options);
     const unit = this.unit(num, STORAGE_UNITS[exp]);
     return this.conversionFormat().replaceAll("%n", numberToFormat).replaceAll("%u", String(unit));
   }

--- a/packages/activesupport/src/number-helper/number-to-human-size-converter.ts
+++ b/packages/activesupport/src/number-helper/number-to-human-size-converter.ts
@@ -18,20 +18,20 @@ export class NumberToHumanSizeConverter extends NumberConverter<NumberToHumanSiz
       options.stripInsignificantZeros = true;
     }
 
-    const num = this.numberAsFloat();
+    const number = this.numberAsFloat();
 
-    if (this.smallerThanBase(num)) {
-      const numberToFormat = String(Math.trunc(num));
-      const unit = this.unit(num, "byte");
+    if (this.smallerThanBase(number)) {
+      const numberToFormat = String(Math.trunc(number));
+      const unit = this.unit(number, "byte");
       return this.conversionFormat()
         .replaceAll("%n", numberToFormat)
         .replaceAll("%u", String(unit));
     }
 
-    const exp = this.exponent(Math.abs(num));
-    const humanSize = num / Math.pow(BASE, exp);
+    const exp = this.exponent(Math.abs(number));
+    const humanSize = number / Math.pow(BASE, exp);
     const numberToFormat = NumberToRoundedConverter.convert(humanSize, options);
-    const unit = this.unit(num, STORAGE_UNITS[exp]);
+    const unit = this.unit(number, STORAGE_UNITS[exp]);
     return this.conversionFormat().replaceAll("%n", numberToFormat).replaceAll("%u", String(unit));
   }
 
@@ -53,7 +53,7 @@ export class NumberToHumanSizeConverter extends NumberConverter<NumberToHumanSiz
     return Math.max(0, Math.min(exp, max));
   }
 
-  private smallerThanBase(num: number): boolean {
-    return Math.abs(Math.trunc(num)) < BASE;
+  private smallerThanBase(number: number): boolean {
+    return Math.abs(Math.trunc(number)) < BASE;
   }
 }

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -458,7 +458,7 @@ export class ToSql extends Visitor {
     this.collectOptimizerHints(node, collector);
     this.maybeVisit(node.setQuantifier ?? null, collector);
 
-    this.collectNodesFor(node.projections, collector, " ", ", ");
+    this.collectNodesFor(node.projections, collector, " ");
 
     if (node.source && !node.source.isEmpty()) {
       collector.append(" FROM ");
@@ -466,9 +466,9 @@ export class ToSql extends Visitor {
     }
 
     this.collectNodesFor(node.wheres, collector, " WHERE ", " AND ");
-    this.collectNodesFor(node.groups, collector, " GROUP BY ", ", ");
+    this.collectNodesFor(node.groups, collector, " GROUP BY ");
     this.collectNodesFor(node.havings, collector, " HAVING ", " AND ");
-    this.collectNodesFor(node.windows, collector, " WINDOW ", ", ");
+    this.collectNodesFor(node.windows, collector, " WINDOW ");
 
     this.maybeVisit(node.comment ?? null, collector);
 
@@ -694,11 +694,11 @@ export class ToSql extends Visitor {
   // -- Set operations --
 
   protected visitArelNodesUnion(node: Nodes.Union, collector: SQLString): SQLString {
-    return this.infixValueWithParen(node, collector, " UNION ", false);
+    return this.infixValueWithParen(node, collector, " UNION ");
   }
 
   protected visitArelNodesUnionAll(node: Nodes.UnionAll, collector: SQLString): SQLString {
-    return this.infixValueWithParen(node, collector, " UNION ALL ", false);
+    return this.infixValueWithParen(node, collector, " UNION ALL ");
   }
 
   protected visitArelNodesIntersect(node: Nodes.Intersect, collector: SQLString): SQLString {
@@ -2119,7 +2119,7 @@ export class ToSql extends Visitor {
   protected visitArelNodesLateral(node: Nodes.Lateral, collector: SQLString): SQLString {
     // Mirrors Rails: `collector << "LATERAL "; grouping_parentheses(o.expr, ...)`.
     collector.append("LATERAL ");
-    return this.groupingParentheses(node.subquery, collector, true);
+    return this.groupingParentheses(node.subquery, collector);
   }
 
   protected appendEscape(escape: Node | null, collector: SQLString): void {

--- a/scripts/api-compare/call-mismatches-exclude/arel/visitors/to-sql.json
+++ b/scripts/api-compare/call-mismatches-exclude/arel/visitors/to-sql.json
@@ -65,45 +65,6 @@
   {
     "package": "arel",
     "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_SelectCore",
-    "call": "collect_nodes_for",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:groups",
-      "ref:collector",
-      "str: GROUP BY "
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_SelectCore",
-    "call": "collect_nodes_for",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:projections",
-      "ref:collector",
-      "str: "
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_SelectCore",
-    "call": "collect_nodes_for",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:windows",
-      "ref:collector",
-      "str: WINDOW "
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
     "rubyName": "visit_Arel_Nodes_SelectStatement",
     "call": "visit_Arel_Nodes_SelectCore",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -114,32 +75,6 @@
     "rubyName": "visit_Arel_Nodes_SelectStatement",
     "call": "visit_Arel_Nodes_SelectOptions",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_Union",
-    "call": "infix_value_with_paren",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:o",
-      "ref:collector",
-      "str: UNION "
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_UnionAll",
-    "call": "infix_value_with_paren",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:o",
-      "ref:collector",
-      "str: UNION ALL "
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "arel",


### PR DESCRIPTION
Two bundled stories.

## 1. `naming-burndown-activesupport` (RFC 0096)

Renames body-local identifiers in `packages/activesupport/src/` back to their
Rails spellings. No public surface or behaviour changes except where the Rails
identifier restored a value Rails actually uses (see below).

`naming` call-argument rows for `activesupport`: **85 → 35** (50 converged).

Converged, with the Rails source that names each identifier:

- `cache/store.ts` (35 rows) — Rails reassigns `options = merged_options(options)`
  in `fetch`/`read`/`read_multi`/`write_multi`/`fetch_multi`/`write`/`delete`/
  `delete_multi`/`exist?`/`new_entry` (cache.rb:443, 498, 540, 550, 600, 660,
  675, 689, 700, 707); trails had a second local `merged`. Also
  `cached_entry` (cache.rb:449), `str_key` (cache.rb:933), `element`
  (cache.rb:978), `key` in `write_multi`'s `transform_keys` (cache.rb:551),
  `names` in `delete_multi`'s `map!` (cache.rb:690), and
  `options = options.dup` in `save_block_result_to_cache` (cache.rb:1053).
- `cache/file-store.ts` — `options` (file_store.rb:61, 81) and
  `amount = Integer(amount)` (file_store.rb:226).
- `cache/memory-store.ts` — `options` (memory_store.rb:90, 223) and
  `matcher = key_matcher(matcher, options)` (memory_store.rb:91).
- `callbacks.ts` — `before` / `after` (callbacks.rb:528, 534).
- `encrypted-file.ts` — `updated_contents`, `contents` (encrypted_file.rb).
- `notifications.ts` — `subscriber` (notifications.rb:259),
  `subscriber_or_name` (notifications.rb:265).
- `number-helper/number-to-human-converter.ts`,
  `number-to-human-size-converter.ts` — `options` / `number`
  (number_to_human_converter.rb:15-28, number_to_human_size_converter.rb:14-26).

One deviation, cited at the call site (JSDoc on `Store#fetch`): Rails reassigns
`options = merged_options(options)` in every one of these bodies, and trails
does the same wherever the pre-merge value is a **parameter** — TypeScript
keeps the assignment narrowing across the instrumentation closures there.
`fetch` is the exception: its pre-merge value is a `let` local (the overload
split writes it on one branch only), and TS drops narrowing for a `let` written
on more than one branch, so `this.readEntry(key, options)` inside the `:read`
closure stops typechecking. There the merged value is a block-scoped `options`
and the pre-merge one takes Rails' other name for exactly this value,
`call_options` (cache.rb:861 `merged_options(call_options)`, cache.rb:948
`namespace_key(key, call_options)`).

Two behavioural corrections fall out of restoring the Rails identifier, both
toward Rails: `MemoryStore#modify_value` now seeds through `write` with the
**merged** options (memory_store.rb:232, previously the raw call options), and
`FileStore#modify_value` returns the `Integer()`-coerced amount consistently
(file_store.rb:226).

Left in place per acceptance criterion 4 — these rows are structural, not
identifier renames — and filed:

- `inflector/inflections.ts` (7 rows): trails has no `Inflections::Uncountables`
  collection (inflections.rb:22-63), so the downcasing Rails does inside
  `add`/`delete` is spelled at every call site → filed
  `0023-surfaced-deviations/port-inflections-uncountables-collection`.
- `number-to-percentage-converter.ts`, `number-to-currency-converter.ts`
  (3 rows): body reshaped vs number_to_currency_converter.rb:10-25 (no
  `valid_bigdecimal` arm, no rounding-aware negative-format guard) → filed
  `0023-surfaced-deviations/converge-number-helper-percentage-currency-converters`.
- `cache/entry.ts` (5 rows), `deprecation.ts` (2), `cache/coder.ts`,
  `message-pack/extensions.ts`, `messages/metadata.ts`, `notifications/fanout.ts`,
  `hash-with-indifferent-access.ts`, `string-inquirer.ts`, `values/time-zone.ts`,
  `xml-mini.ts`, `cache/file-store.ts#delete_entry`: the Rails side is `@value`,
  `self`, or a method-call result, not a local a TS body can spell the same way.

## 2. `converge-arel-visitor-helper-collector-parameter-position` (RFC 0084)

All six declarations already took Rails' parameter order and names as of #6348,
which landed while this bundle was claimed, so acceptance criteria 1, 2 and the
defaulted-before-required TS defect are already satisfied on `main`. What remained is acceptance
criterion 3: call sites that Rails leaves to a default must stop passing it.
Dropped six explicit defaults so the trailing defaults Rails relies on are the
ones in force:

- `collect_nodes_for(o.projections, collector, " ")` (to_sql.rb:155),
  `o.groups, " GROUP BY "` (:163), `o.windows, " WINDOW "` (:165) — the
  `connector = ", "` default.
- `infix_value_with_paren(o, collector, " UNION ")` (to_sql.rb:209) and
  `" UNION ALL "` (:213) — the `suppress_parens = false` default.
- `grouping_parentheses(o.expr, collector)` (postgresql.rb:66) — the
  `always_wrap_selects = true` default.

Pure signature-default work: generated SQL is unchanged and
`pnpm vitest run packages/arel` is green (76 files, 1463 tests).

## Gates

- `pnpm parity:api:calls` — OK (2114 baselined).
- `pnpm parity:api:calls:args` — OK. The six dropped defaults converged **5**
  baseline rows in `call-mismatches-exclude/arel/visitors/to-sql.json`, deleted
  by hand (only-shrink; no reseed).
- `pnpm parity:api:extra --package arel` / `--package activesupport` unchanged.
- `pnpm vitest run packages/arel`, `packages/activesupport/src/cache`,
  `src/number-helper`, `callbacks`, `notifications`, `encrypted-file` green.

Closes-story: naming-burndown-activesupport
Closes-story: converge-arel-visitor-helper-collector-parameter-position
