### PR TITLE
refactor(activerecord,parity): converge call arguments and schema-statements locals

### DIFF
--- a/packages/actionpack/src/action-controller/test-case.test.ts
+++ b/packages/actionpack/src/action-controller/test-case.test.ts
@@ -143,6 +143,14 @@ describe("ActionController::TestRequest helpers", () => {
     expect(qs).toContain("format=json");
   });
 
+  it("assignParameters leaves a present-but-empty PATH_INFO alone (Rails: fetch_header)", () => {
+    const req = TestRequest.create();
+    req.setHeader("REQUEST_METHOD", "GET");
+    req.setHeader("PATH_INFO", "");
+    req.assignParameters(null, "posts", "index", {}, "/posts", []);
+    expect(req.getHeader("PATH_INFO")).toBe("");
+  });
+
   it("assignParameters encodes body for POST url-encoded", () => {
     const req = TestRequest.create();
     req.setHeader("REQUEST_METHOD", "POST");

--- a/packages/actionpack/src/action-controller/test-case.ts
+++ b/packages/actionpack/src/action-controller/test-case.ts
@@ -578,9 +578,9 @@ export class TestRequest extends AbstractTestRequest {
         // cache so params/requestParameters expose the uploaded files directly.
         this.env["action_dispatch.request.request_parameters"] = nonPathParameters;
       } else {
-        if (!this.getHeader("CONTENT_TYPE")) {
-          this.setHeader("CONTENT_TYPE", "application/x-www-form-urlencoded");
-        }
+        this.fetchHeader("CONTENT_TYPE", (k) => {
+          this.setHeader(k, "application/x-www-form-urlencoded");
+        });
 
         const ct = this.getHeader("CONTENT_TYPE") ?? "";
         let data: string;
@@ -606,13 +606,13 @@ export class TestRequest extends AbstractTestRequest {
       }
     }
 
-    if (!this.getHeader("PATH_INFO")) {
-      this.setHeader("PATH_INFO", generatedPath);
-    }
-    if (!this.getHeader("ORIGINAL_FULLPATH")) {
+    this.fetchHeader("PATH_INFO", (k) => {
+      this.setHeader(k, generatedPath);
+    });
+    this.fetchHeader("ORIGINAL_FULLPATH", (k) => {
       // Rails uses fullpath here (path + query string) not just the generated path
-      this.setHeader("ORIGINAL_FULLPATH", this.fullpath);
-    }
+      this.setHeader(k, this.fullpath);
+    });
 
     pathParameters["controller"] = controllerPath;
     pathParameters["action"] = action;

--- a/packages/activemodel/src/attribute-methods.ts
+++ b/packages/activemodel/src/attribute-methods.ts
@@ -61,8 +61,9 @@ export namespace AttrNames {
   const DEF_SAFE_NAME = /^[a-zA-Z_]\w*$/;
 
   export function defineAttributeAccessorMethod(
+    _owner: unknown,
     attrName: string,
-    writer: boolean = false,
+    { writer = false }: { writer?: boolean } = {},
   ): { methodName: string; attrNameRef: string } {
     const methodName = writer ? `${attrName}=` : attrName;
     if (DEF_SAFE_NAME.test(attrName)) {

--- a/packages/activemodel/src/attribute-methods.ts
+++ b/packages/activemodel/src/attribute-methods.ts
@@ -61,7 +61,7 @@ export namespace AttrNames {
   const DEF_SAFE_NAME = /^[a-zA-Z_]\w*$/;
 
   export function defineAttributeAccessorMethod(
-    _owner: unknown,
+    owner: unknown,
     attrName: string,
     { writer = false }: { writer?: boolean } = {},
   ): { methodName: string; attrNameRef: string } {

--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -230,7 +230,7 @@ export function attribute(
  */
 export function defineMethodAttribute(
   canonicalName: string,
-  { owner, as: _as }: { owner?: unknown; as?: string } = {},
+  { owner }: { owner?: unknown; as?: string } = {},
 ): void {
   // Writers are already installed by attribute() via Object.defineProperty.
   // Compute and expose the method name the same way Rails would, for callers

--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -230,12 +230,14 @@ export function attribute(
  */
 export function defineMethodAttribute(
   canonicalName: string,
-  _options?: { owner?: unknown; as?: string },
+  { owner, as: _as }: { owner?: unknown; as?: string } = {},
 ): void {
   // Writers are already installed by attribute() via Object.defineProperty.
   // Compute and expose the method name the same way Rails would, for callers
   // that inspect the name (e.g. alias generation paths).
-  const { methodName } = AttrNames.defineAttributeAccessorMethod(canonicalName, true);
+  const { methodName } = AttrNames.defineAttributeAccessorMethod(owner, canonicalName, {
+    writer: true,
+  });
   void methodName;
 }
 

--- a/packages/activerecord/src/attribute-methods/read.ts
+++ b/packages/activerecord/src/attribute-methods/read.ts
@@ -50,8 +50,8 @@ export function _readAttribute(
 // access is handled statically, so we compute the same metadata for parity
 // but intentionally do not register or define anything.
 /** @internal */
-function defineMethodAttribute(canonicalName: string, _options?: unknown): void {
-  const { methodName, attrNameRef } = AttrNames.defineAttributeAccessorMethod(canonicalName, false);
+function defineMethodAttribute(canonicalName: string, { owner }: { owner?: unknown } = {}): void {
+  const { methodName, attrNameRef } = AttrNames.defineAttributeAccessorMethod(owner, canonicalName);
   void methodName;
   void attrNameRef;
 }

--- a/packages/activerecord/src/attribute-methods/read.ts
+++ b/packages/activerecord/src/attribute-methods/read.ts
@@ -50,7 +50,10 @@ export function _readAttribute(
 // access is handled statically, so we compute the same metadata for parity
 // but intentionally do not register or define anything.
 /** @internal */
-function defineMethodAttribute(canonicalName: string, { owner }: { owner?: unknown } = {}): void {
+function defineMethodAttribute(
+  canonicalName: string,
+  { owner }: { owner?: unknown; as?: string } = {},
+): void {
   const { methodName, attrNameRef } = AttrNames.defineAttributeAccessorMethod(owner, canonicalName);
   void methodName;
   void attrNameRef;

--- a/packages/activerecord/src/attribute-methods/write.ts
+++ b/packages/activerecord/src/attribute-methods/write.ts
@@ -43,8 +43,14 @@ export function _writeAttribute(this: Model, name: string, value: unknown): void
 // access is handled statically, so we compute the same metadata for parity
 // but intentionally do not register or define anything.
 /** @internal */
-function defineMethodAttribute(canonicalName: string, _options?: unknown): void {
-  const { methodName, attrNameRef } = AttrNames.defineAttributeAccessorMethod(canonicalName, true);
+function defineMethodAttribute(canonicalName: string, { owner }: { owner?: unknown } = {}): void {
+  const { methodName, attrNameRef } = AttrNames.defineAttributeAccessorMethod(
+    owner,
+    canonicalName,
+    {
+      writer: true,
+    },
+  );
   void methodName;
   void attrNameRef;
 }

--- a/packages/activerecord/src/attribute-methods/write.ts
+++ b/packages/activerecord/src/attribute-methods/write.ts
@@ -43,7 +43,10 @@ export function _writeAttribute(this: Model, name: string, value: unknown): void
 // access is handled statically, so we compute the same metadata for parity
 // but intentionally do not register or define anything.
 /** @internal */
-function defineMethodAttribute(canonicalName: string, { owner }: { owner?: unknown } = {}): void {
+function defineMethodAttribute(
+  canonicalName: string,
+  { owner }: { owner?: unknown; as?: string } = {},
+): void {
   const { methodName, attrNameRef } = AttrNames.defineAttributeAccessorMethod(
     owner,
     canonicalName,

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -222,7 +222,7 @@ export interface AbstractAdapter {
   // carry // @ts-expect-error on those overrides. Callers typed as AbstractAdapter
   // should use the base call forms; PG-specific forms require a concrete type.
   createTable(
-    name: string,
+    tableName: string,
     optionsOrFn?:
       | {
           id?: boolean | ColumnType | IdHashOptions;

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.ts
@@ -163,6 +163,7 @@ export class BiasedConditionVariable {
  * expose a mutable `_cond` field.
  */
 interface BiasableQueueHost {
+  _lock?: unknown;
   _cond: BiasedConditionVariable;
 }
 
@@ -173,12 +174,12 @@ interface BiasableQueueHost {
  * `with_a_bias_for(thread)` to temporarily bias the queue's condition variable
  * toward a specific thread.
  */
-export function withABiasFor<T>(this: BiasableQueueHost, context: unknown, fn: () => T): T {
+export function withABiasFor<T>(this: BiasableQueueHost, thread: unknown, fn: () => T): T {
   let previousCond: BiasedConditionVariable | null = null;
   let newCond: BiasedConditionVariable | null = null;
   synchronize(this, () => {
     previousCond = this._cond;
-    this._cond = newCond = new BiasedConditionVariable(undefined, this._cond, context);
+    this._cond = newCond = new BiasedConditionVariable(this._lock, this._cond, thread);
   });
   try {
     return fn();
@@ -204,10 +205,12 @@ export const BiasableQueue = {
  */
 export class Queue {
   private _queue: DatabaseAdapter[] = [];
+  protected _lock?: unknown;
   protected _cond: BiasedConditionVariable;
   private _numWaiting = 0;
 
   constructor(lock?: unknown) {
+    this._lock = lock;
     this._cond = new BiasedConditionVariable(lock);
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -148,9 +148,9 @@ export class SchemaCreation {
   }
 
   protected async visitTableDefinition(o: TableDefinition): Promise<string> {
-    let sql = `CREATE${this.tableModifierInCreate(o)} TABLE`;
-    if (o.ifNotExists) sql += " IF NOT EXISTS";
-    sql += ` ${this.adapter.quoteTableName(o.tableName)}`;
+    let createSql = `CREATE${this.tableModifierInCreate(o)} TABLE`;
+    if (o.ifNotExists) createSql += " IF NOT EXISTS";
+    createSql += ` ${this.adapter.quoteTableName(o.tableName)}`;
 
     // Rails: `statements = o.columns.map { |c| accept c }` — keep the map call
     // (the api-compare wide gate tracks it) but map to thunks so each column
@@ -185,11 +185,11 @@ export class SchemaCreation {
 
     statements.push(...(await this.tableConstraintStatements(o)));
 
-    if (statements.length > 0) sql += ` (${statements.join(", ")})`;
-    sql = this.addTableOptionsBang(sql, o);
-    if (o.as) sql += ` AS ${this.toSql(o.as)}`;
+    if (statements.length > 0) createSql += ` (${statements.join(", ")})`;
+    createSql = this.addTableOptionsBang(createSql, o);
+    if (o.as) createSql += ` AS ${this.toSql(o.as)}`;
 
-    return sql;
+    return createSql;
   }
 
   /**
@@ -261,11 +261,14 @@ export class SchemaCreation {
       }
       throw e;
     }
-    let sql = `${this.adapter.quoteColumnName(o.name)} ${o.sqlType}`;
+    let columnSql = `${this.adapter.quoteColumnName(o.name)} ${o.sqlType}`;
     if (o.type !== "primary_key") {
-      sql = await this.addColumnOptionsBang(sql, this.columnOptions(o) as ColumnOptions);
+      columnSql = await this.addColumnOptionsBang(
+        columnSql,
+        this.columnOptions(o) as ColumnOptions,
+      );
     }
-    return sql;
+    return columnSql;
   }
 
   protected async visitAddColumnDefinition(o: AddColumnDefinition): Promise<string> {
@@ -282,17 +285,17 @@ export class SchemaCreation {
     for (const fk of o.foreignKeyAdds) {
       parts.push(this.visitAddForeignKey(fk));
     }
-    for (const name of o.foreignKeyDrops) {
-      parts.push(this.visitDropForeignKey(name));
+    for (const fk of o.foreignKeyDrops) {
+      parts.push(this.visitDropForeignKey(fk));
     }
-    for (const chk of o.checkConstraintAdds) {
-      parts.push(this.visitAddCheckConstraint(chk));
+    for (const con of o.checkConstraintAdds) {
+      parts.push(this.visitAddCheckConstraint(con));
     }
-    for (const name of o.checkConstraintDrops) {
-      parts.push(await this.visitDropCheckConstraint(name));
+    for (const con of o.checkConstraintDrops) {
+      parts.push(await this.visitDropCheckConstraint(con));
     }
-    for (const name of o.constraintDrops) {
-      parts.push(this.visitDropConstraint(name));
+    for (const con of o.constraintDrops) {
+      parts.push(this.visitDropConstraint(con));
     }
     for (const change of o.columnDefaultChanges) {
       const col = this.adapter.quoteColumnName(change.columnName);
@@ -486,7 +489,7 @@ export class SchemaCreation {
 
   /** @internal */
   protected visitPrimaryKeyDefinition(o: PrimaryKeyDefinition): string {
-    return `PRIMARY KEY (${o.name.map((n) => this.adapter.quoteColumnName(n)).join(", ")})`;
+    return `PRIMARY KEY (${o.name.map((name) => this.adapter.quoteColumnName(name)).join(", ")})`;
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -346,7 +346,7 @@ export class SchemaStatements {
   }
 
   async createTable(
-    name: string,
+    tableName: string,
     optionsOrFn?:
       | {
           id?: boolean | ColumnType | IdHashOptions;
@@ -399,20 +399,20 @@ export class SchemaStatements {
     const { id: _id, primaryKey: _primaryKey, force: _force, ...validatedOptions } = options;
     this.validateCreateTableOptionsBang(validatedOptions);
 
-    if (name.length > 64) {
-      throw new Error(`Table name '${name}' is too long; the limit is 64 characters`);
+    if (tableName.length > 64) {
+      throw new Error(`Table name '${tableName}' is too long; the limit is 64 characters`);
     }
 
     if (options.force && options.ifNotExists) {
       throw new Error("Options `:force` and `:if_not_exists` cannot be used simultaneously.");
     }
 
-    const td = this.buildCreateTableDefinition(name, options, definer);
+    const td = this.buildCreateTableDefinition(tableName, options, definer);
 
     if (options.force) {
-      await this.dropTable(name, { force: options.force, ifExists: true });
+      await this.dropTable(tableName, { force: options.force, ifExists: true });
     } else {
-      await this.schemaCache.clearDataSourceCacheBang(name);
+      await this.schemaCache.clearDataSourceCacheBang(tableName);
     }
 
     await this.execute(await this.schemaCreation.accept(td));
@@ -421,14 +421,17 @@ export class SchemaStatements {
       for (const [columnName, indexOptions] of td.indexes) {
         // Rails overrides any per-index `if_not_exists:` with the table
         // definition's, since it splats `**index_options` first.
-        await this.addIndex(name, columnName, { ...indexOptions, ifNotExists: td.ifNotExists });
+        await this.addIndex(tableName, columnName, {
+          ...indexOptions,
+          ifNotExists: td.ifNotExists,
+        });
       }
     }
 
     if (this.supportsComments?.() && !this.supportsCommentsInCreate?.()) {
       const tableComment = presence(td.comment);
       if (tableComment != null && typeof this.changeTableComment === "function") {
-        await this.changeTableComment(name, tableComment);
+        await this.changeTableComment(tableName, tableComment);
       }
       // Mirrors Rails: adapters that can't inline column comments in CREATE
       // emit a COMMENT ON COLUMN per column so inline `comment:` options
@@ -443,9 +446,9 @@ export class SchemaStatements {
           name: string;
           options?: { comment?: string | null };
         }>) {
-          const columnComment = presence(column.options?.comment);
-          if (columnComment != null) {
-            await commentAdapter.changeColumnComment(name, column.name, columnComment);
+          const comment = presence(column.options?.comment);
+          if (comment != null) {
+            await commentAdapter.changeColumnComment(tableName, column.name, comment);
           }
         }
       }
@@ -468,9 +471,9 @@ export class SchemaStatements {
       throw new ArgumentError("dropTable requires at least one table name");
     }
     const ifExists = options.ifExists ? " IF EXISTS" : "";
-    for (const name of tableNames) {
-      await this.schemaCache.clearDataSourceCacheBang(name);
-      await this.execute(`DROP TABLE${ifExists} ${this.quoteTableName(name)}`);
+    for (const tableName of tableNames) {
+      await this.schemaCache.clearDataSourceCacheBang(tableName);
+      await this.execute(`DROP TABLE${ifExists} ${this.quoteTableName(tableName)}`);
     }
   }
 
@@ -618,8 +621,10 @@ export class SchemaStatements {
   async tableExists(tableName: string): Promise<boolean> {
     if (!isPresent(tableName)) return false;
     try {
-      const sql = this.dataSourceSql(tableName, { type: "BASE TABLE" });
-      return (await this.queryValues(sql, "SCHEMA")).length > 0;
+      return (
+        (await this.queryValues(this.dataSourceSql(tableName, { type: "BASE TABLE" }), "SCHEMA"))
+          .length > 0
+      );
     } catch (error) {
       if (!(error instanceof NotImplementedError)) throw error;
       return (await this.tables()).includes(String(tableName));
@@ -916,8 +921,7 @@ export class SchemaStatements {
     const tableName = this.findJoinTableName(table1, table2, opts);
     const { columnOptions = {}, tableName: _t, ...tableOpts } = opts;
     const mergedColOpts = { null: false, index: false, ...columnOptions };
-    const t1Ref = this.referenceNameForTable(table1);
-    const t2Ref = this.referenceNameForTable(table2);
+    const [t1Ref, t2Ref] = [table1, table2].map((t) => this.referenceNameForTable(t));
 
     await this.createTable(tableName, { ...tableOpts, id: false }, (t) => {
       t.references(t1Ref, mergedColOpts);
@@ -1280,13 +1284,15 @@ export class SchemaStatements {
   }
 
   async tables(): Promise<string[]> {
-    const sql = this.dataSourceSql(null, { type: "BASE TABLE" });
-    return (await this.queryValues(sql, "SCHEMA")).map(String);
+    return (await this.queryValues(this.dataSourceSql(null, { type: "BASE TABLE" }), "SCHEMA")).map(
+      String,
+    );
   }
 
   async views(): Promise<string[]> {
-    const sql = this.dataSourceSql(null, { type: "VIEW" });
-    return (await this.queryValues(sql, "SCHEMA")).map(String);
+    return (await this.queryValues(this.dataSourceSql(null, { type: "VIEW" }), "SCHEMA")).map(
+      String,
+    );
   }
 
   async viewExists(viewName: string): Promise<boolean> {
@@ -1300,8 +1306,10 @@ export class SchemaStatements {
     // The "SCHEMA" name is what keeps the probe out of assertQueries counts.
     if (!isPresent(viewName)) return false;
     try {
-      const sql = this.dataSourceSql(viewName, { type: "VIEW" });
-      return (await this.queryValues(sql, "SCHEMA")).length > 0;
+      return (
+        (await this.queryValues(this.dataSourceSql(viewName, { type: "VIEW" }), "SCHEMA")).length >
+        0
+      );
     } catch (e) {
       if (e instanceof NotImplementedError) {
         return (await this.views()).includes(String(viewName));
@@ -1392,8 +1400,7 @@ export class SchemaStatements {
 
   async dataSources(): Promise<string[]> {
     try {
-      const sql = this.dataSourceSql();
-      const values = await this.queryValues(sql, "SCHEMA");
+      const values = await this.queryValues(this.dataSourceSql(), "SCHEMA");
       return values.map(String);
     } catch (error) {
       if (!(error instanceof NotImplementedError)) throw error;
@@ -1406,8 +1413,7 @@ export class SchemaStatements {
   async dataSourceExists(name: string): Promise<boolean> {
     if (!isPresent(name)) return false;
     try {
-      const sql = this.dataSourceSql(name);
-      return (await this.queryValues(sql, "SCHEMA")).length > 0;
+      return (await this.queryValues(this.dataSourceSql(name), "SCHEMA")).length > 0;
     } catch (error) {
       if (!(error instanceof NotImplementedError)) throw error;
       return (await this.dataSources()).includes(String(name));
@@ -1469,8 +1475,7 @@ export class SchemaStatements {
     const { columnOptions = {}, tableName: _, ...rest } = options;
     const mergedColOpts = { null: false, index: false, ...columnOptions };
 
-    const t1Ref = this.referenceNameForTable(table1);
-    const t2Ref = this.referenceNameForTable(table2);
+    const [t1Ref, t2Ref] = [table1, table2].map((t) => this.referenceNameForTable(t));
 
     return this.buildCreateTableDefinition(joinTableName, { ...rest, id: false }, (td) => {
       td.references(t1Ref, mergedColOpts);
@@ -1531,12 +1536,12 @@ export class SchemaStatements {
       [key: string]: unknown;
     } = {},
   ): Promise<CreateIndexDefinition> {
-    const [idx, algorithm, ifNotExists] = await this.addIndexOptions(
+    const [index, algorithm, ifNotExists] = await this.addIndexOptions(
       tableName,
       columnName,
       options,
     );
-    return new CreateIndexDefinition(idx, algorithm, ifNotExists);
+    return new CreateIndexDefinition(index, algorithm, ifNotExists);
   }
 
   async indexNameExists(tableName: string, indexName: string): Promise<boolean> {
@@ -1563,8 +1568,8 @@ export class SchemaStatements {
 
     if (Array.isArray(result.primaryKey)) {
       if (!result.column) {
-        result.column = (result.primaryKey as string[]).map((pk) =>
-          this.foreignKeyColumnFor(toTable, pk),
+        result.column = (result.primaryKey as string[]).map((pkColumn) =>
+          this.foreignKeyColumnFor(toTable, pkColumn),
         );
       }
     } else {
@@ -2096,11 +2101,14 @@ export class SchemaStatements {
   ): Promise<void> {
     const idxs = await this.indexes(newName);
     for (const index of idxs) {
-      const generatedName = this.indexName(tableName, { column: index.columns, ...options } as any);
-      if (generatedName === index.name) {
+      const generatedIndexName = this.indexName(tableName, {
+        column: index.columns,
+        ...options,
+      } as any);
+      if (generatedIndexName === index.name) {
         await this.renameIndex(
           newName,
-          generatedName,
+          generatedIndexName,
           this.indexName(newName, { column: index.columns, ...options } as any),
         );
       }
@@ -2121,11 +2129,11 @@ export class SchemaStatements {
       const oldColumns = [...index.columns];
       const pos = oldColumns.indexOf(newColName);
       oldColumns[pos] = colName;
-      const generatedName = this.indexName(tableName, { column: oldColumns });
-      if (generatedName === index.name) {
+      const generatedIndexName = this.indexName(tableName, { column: oldColumns });
+      if (generatedIndexName === index.name) {
         await this.renameIndex(
           tableName,
-          generatedName,
+          generatedIndexName,
           this.indexName(tableName, { column: index.columns }),
         );
       }
@@ -2461,7 +2469,7 @@ export class SchemaStatements {
     columnNames: string[],
     _options: Record<string, unknown> = {},
   ): string[] {
-    return columnNames.map((col) => this.removeColumnForAlter(tableName, col));
+    return columnNames.map((columnName) => this.removeColumnForAlter(tableName, columnName));
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/postgresql/referential-integrity.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/referential-integrity.ts
@@ -32,29 +32,6 @@ export function enableReferentialIntegritySql(
   return tables.map((t) => `ALTER TABLE ${this.quoteTableName(t)} ENABLE TRIGGER ALL`);
 }
 
-// Mirrors: ReferentialIntegrity#check_all_foreign_keys_valid!
-// Marks every FK constraint as unvalidated then immediately re-validates, causing
-// the database to raise if any constraint is currently violated.
-export const CHECK_ALL_FOREIGN_KEYS_SQL = `
-do $$
-  declare r record;
-BEGIN
-FOR r IN (
-  SELECT FORMAT(
-    'UPDATE pg_catalog.pg_constraint SET convalidated=false WHERE conname = ''%1$I'' AND connamespace::regnamespace = ''%2$I''::regnamespace; ALTER TABLE %2$I.%3$I VALIDATE CONSTRAINT %1$I;',
-    constraint_name,
-    table_schema,
-    table_name
-  ) AS constraint_check
-  FROM information_schema.table_constraints WHERE constraint_type = 'FOREIGN KEY'
-)
-  LOOP
-    EXECUTE (r.constraint_check);
-  END LOOP;
-END;
-$$;
-`.trim();
-
 // Host for the instance methods: the adapter supplies its transaction/execute
 // machinery and table listing, plus the `*Sql` host (`quoteTableName`).
 interface ReferentialIntegrityHost extends ReferentialIntegritySqlHost {
@@ -157,7 +134,28 @@ export async function disableReferentialIntegrity(
 export async function checkAllForeignKeysValidBang(this: ReferentialIntegrityHost): Promise<void> {
   await this.transaction(
     async () => {
-      await this.execute(CHECK_ALL_FOREIGN_KEYS_SQL);
+      // Marks every FK constraint as unvalidated then immediately re-validates,
+      // causing the database to raise if any constraint is currently violated.
+      const sql = `
+do $$
+  declare r record;
+BEGIN
+FOR r IN (
+  SELECT FORMAT(
+    'UPDATE pg_catalog.pg_constraint SET convalidated=false WHERE conname = ''%1$I'' AND connamespace::regnamespace = ''%2$I''::regnamespace; ALTER TABLE %2$I.%3$I VALIDATE CONSTRAINT %1$I;',
+    constraint_name,
+    table_schema,
+    table_name
+  ) AS constraint_check
+  FROM information_schema.table_constraints WHERE constraint_type = 'FOREIGN KEY'
+)
+  LOOP
+    EXECUTE (r.constraint_check);
+  END LOOP;
+END;
+$$;
+`.trim();
+      await this.execute(sql);
     },
     { requiresNew: true },
   );

--- a/packages/activerecord/src/connection-adapters/postgresql/referential-integrity.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/referential-integrity.ts
@@ -134,8 +134,6 @@ export async function disableReferentialIntegrity(
 export async function checkAllForeignKeysValidBang(this: ReferentialIntegrityHost): Promise<void> {
   await this.transaction(
     async () => {
-      // Marks every FK constraint as unvalidated then immediately re-validates,
-      // causing the database to raise if any constraint is currently violated.
       const sql = `
 do $$
   declare r record;

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -741,12 +741,12 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
 
   // Mirrors: SQLite3::DatabaseStatements#begin_deferred_transaction
   async beginDeferredTransaction(isolation?: string | null): Promise<void> {
-    return this.internalBeginTransaction("DEFERRED", isolation ?? null);
+    return this.internalBeginTransaction("deferred", isolation ?? null);
   }
 
   // Mirrors: SQLite3::DatabaseStatements#begin_isolated_db_transaction
   async beginIsolatedDbTransaction(isolation: string): Promise<void> {
-    return this.internalBeginTransaction("DEFERRED", isolation);
+    return this.internalBeginTransaction("deferred", isolation);
   }
 
   // Mirrors: SQLite3::DatabaseStatements#internal_begin_transaction
@@ -949,7 +949,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     // DEVIATION: Rails has no re-entrancy guard; the pool proxy can replay a
     // begin against an already-open connection and SQLite rejects nested BEGIN.
     if (this._inTransaction) return;
-    return this.internalBeginTransaction("IMMEDIATE", null);
+    return this.internalBeginTransaction("immediate", null);
   }
 
   async beginTransaction(): Promise<void> {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -6838,7 +6838,7 @@ export class Relation<T extends Base> {
 
   private currentScopeRestoringBlock(block?: (record: T) => void): (record: T) => void {
     const modelClass = this.model;
-    const currentScope = ScopeRegistry.currentScope(modelClass as any);
+    const currentScope = ScopeRegistry.currentScope(modelClass as any, true);
     return (record: T) => {
       ScopeRegistry.setCurrentScope(modelClass as any, currentScope ?? null);
       block?.(record);

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -1692,8 +1692,6 @@ export async function initializeDatabase(dbConfig: DatabaseConfig): Promise<bool
         const resolved =
           p.isAbsolute && !p.isAbsolute(rawPath) ? p.resolve(DatabaseTasks.root, rawPath) : rawPath;
         if (getFs().existsSync(resolved)) {
-          // Rails passes `nil` (database_tasks.rb:664) and lets `load_schema`
-          // re-derive the dump path itself; `resolved` only guards File.exist?.
           await DatabaseTasks.loadSchema(dbConfig, DatabaseTasks.schemaFormat, undefined);
         }
       }

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -1692,7 +1692,9 @@ export async function initializeDatabase(dbConfig: DatabaseConfig): Promise<bool
         const resolved =
           p.isAbsolute && !p.isAbsolute(rawPath) ? p.resolve(DatabaseTasks.root, rawPath) : rawPath;
         if (getFs().existsSync(resolved)) {
-          await DatabaseTasks.loadSchema(dbConfig, DatabaseTasks.schemaFormat, resolved);
+          // Rails passes `nil` (database_tasks.rb:664) and lets `load_schema`
+          // re-derive the dump path itself; `resolved` only guards File.exist?.
+          await DatabaseTasks.loadSchema(dbConfig, DatabaseTasks.schemaFormat, undefined);
         }
       }
     }

--- a/scripts/api-compare/call-args.test.ts
+++ b/scripts/api-compare/call-args.test.ts
@@ -175,6 +175,21 @@ describe("compareCallArgs built-in receiver as argument 1", () => {
       compareCallArgs(site("camelize", []), site("camelize", ["id:name", "bool:false"])).verdict,
     ).toBe("mismatch");
   });
+
+  it("compares a SIMPLE recorded receiver against TS argument 1", () => {
+    const ruby = { ...site("camelize", []), recv: "id:name" };
+    expect(compareCallArgs(ruby, site("camelize", ["id:name"])).verdict).toBe("match");
+    const mismatched = compareCallArgs(ruby, site("camelize", ["id:other"]));
+    expect(mismatched.verdict).toBe("mismatch");
+    expect(mismatched.class).toBe("naming");
+  });
+
+  it("keeps the strip for a CHAINED receiver", () => {
+    // reflection.rb:454 `name.to_s.camelize` — the extractor describes the
+    // receiver as the inner call, which the port has no spelling for.
+    const ruby = { ...site("camelize", []), recv: "call:to_s" };
+    expect(compareCallArgs(ruby, site("camelize", ["id:name"])).verdict).toBe("match");
+  });
 });
 
 describe("compareCallArgs block-tail nil padding", () => {

--- a/scripts/api-compare/call-args.ts
+++ b/scripts/api-compare/call-args.ts
@@ -400,6 +400,12 @@ function calleeKeys(enclosingRubyName: string): string[] {
   return keys;
 }
 
+/** A receiver descriptor with an agreeable cross-language spelling: a bare
+ *  local/ivar (`id:`) or constant (`const:`) ref, which the port passes through
+ *  under the same identifier. Anything else — a chain (`call:`), a literal, an
+ *  opaque `?` — falls back to {@link alignBuiltinReceiver}'s strip. */
+const SIMPLE_RECEIVER = /^(?:id|const):/;
+
 /**
  * Drop the leading argument that IS the Ruby receiver, for the built-ins TS
  * cannot define on a receiver at all (RFC 0099 — see
@@ -436,12 +442,6 @@ function alignBuiltinReceiver(
   }
   return { rubyArgs, tsArgs: tsArgs.slice(1) };
 }
-
-/** A receiver descriptor with an agreeable cross-language spelling: a bare
- *  local/ivar (`id:`) or constant (`const:`) ref, which the port passes through
- *  under the same identifier. Anything else — a chain (`call:`), a literal, an
- *  opaque `?` — falls back to {@link alignBuiltinReceiver}'s strip. */
-const SIMPLE_RECEIVER = /^(?:id|const):/;
 
 /** The two leading-receiver forms, in the one place the comparator handles them:
  *  the mixin `this` the port adds to a ported module function, and the Ruby

--- a/scripts/api-compare/call-args.ts
+++ b/scripts/api-compare/call-args.ts
@@ -408,30 +408,51 @@ function calleeKeys(enclosingRubyName: string): string[] {
  * then compare pairwise, so `truncate(text, 10)` against `text.truncate(20)`
  * still reads as the divergence it is.
  *
- * The RECEIVER EXPRESSION itself is deliberately not compared, and the sites
- * this exists for are why: the Ruby extractor describes `name.to_s.camelize`'s
- * receiver as the inner CALL (`to_s`), never as `name`, while the port —
- * correctly, since a TS string is already a string — writes `camelize(name)`.
- * There is no spelling of that receiver the two sides could agree on, so
- * comparing it would re-flag every row the table exists to retire.
+ * A SIMPLE receiver — a plain `id:`/`const:` ref the extractor records as
+ * `CallSite.recv` — is COMPARED rather than dropped: it is PREPENDED to the
+ * Ruby list so `camelize(a)` where Rails wrote `b.camelize` reads as the
+ * divergence it is, instead of matching on the call name alone.
+ *
+ * A CHAINED receiver keeps the strip, and the sites this exists for are why:
+ * the Ruby extractor describes `name.to_s.camelize`'s receiver as the inner
+ * CALL (`call:to_s`), never as `name`, while the port — correctly, since a TS
+ * string is already a string — writes `camelize(name)`. There is no spelling of
+ * that receiver the two sides could agree on, so comparing it would re-flag
+ * every row this table exists to retire.
  *
  * Same only-when-it-explains-the-length guard as {@link stripMixinReceiver}:
  * a port that also passes a genuine extra argument still reads as one.
  */
-function stripBuiltinReceiver(name: string, rubyArgs: string[], tsArgs: string[]): string[] {
-  if (tsArgs.length === rubyArgs.length + 1 && RECEIVER_AS_FIRST_ARG.has(name)) {
-    return tsArgs.slice(1);
+function alignBuiltinReceiver(
+  ruby: CallSite,
+  rubyArgs: string[],
+  tsArgs: string[],
+): { rubyArgs: string[]; tsArgs: string[] } {
+  if (tsArgs.length !== rubyArgs.length + 1 || !RECEIVER_AS_FIRST_ARG.has(ruby.name)) {
+    return { rubyArgs, tsArgs };
   }
-  return tsArgs;
+  if (ruby.recv !== undefined && SIMPLE_RECEIVER.test(ruby.recv)) {
+    return { rubyArgs: [ruby.recv, ...rubyArgs], tsArgs };
+  }
+  return { rubyArgs, tsArgs: tsArgs.slice(1) };
 }
 
-/** The two leading-receiver forms, in the one place the comparator strips them:
+/** A receiver descriptor with an agreeable cross-language spelling: a bare
+ *  local/ivar (`id:`) or constant (`const:`) ref, which the port passes through
+ *  under the same identifier. Anything else — a chain (`call:`), a literal, an
+ *  opaque `?` — falls back to {@link alignBuiltinReceiver}'s strip. */
+const SIMPLE_RECEIVER = /^(?:id|const):/;
+
+/** The two leading-receiver forms, in the one place the comparator handles them:
  *  the mixin `this` the port adds to a ported module function, and the Ruby
  *  receiver of a built-in TS cannot define on a receiver. Neither can apply to
  *  the same site — a name on the built-in table is never a ported mixin — so
  *  the order is immaterial. */
-function stripReceiverArgs(name: string, rubyArgs: string[], tsArgs: string[]): string[] {
-  return stripBuiltinReceiver(name, rubyArgs, stripMixinReceiver(rubyArgs, tsArgs));
+function alignReceiverArgs(
+  ruby: CallSite,
+  tsArgs: string[],
+): { rubyArgs: string[]; tsArgs: string[] } {
+  return alignBuiltinReceiver(ruby, ruby.args, stripMixinReceiver(ruby.args, tsArgs));
 }
 
 /**
@@ -553,12 +574,12 @@ function tsCallNameKeys(rubyName: string): string[] {
  * assignment takes it whenever the key matches tie.
  */
 function argSimilarity(ruby: CallSite, ts: CallSite): number {
-  const strippedTs = stripReceiverArgs(ruby.name, ruby.args, ts.args);
-  const sameArity = ruby.args.length === strippedTs.length ? 1 : 0;
-  const rubyArgs = normalizeArgs(ruby.args);
-  const tsArgs = normalizeArgs(strippedTs);
+  const aligned = alignReceiverArgs(ruby, ts.args);
+  const sameArity = aligned.rubyArgs.length === aligned.tsArgs.length ? 1 : 0;
+  const rubyArgs = normalizeArgs(aligned.rubyArgs);
+  const tsArgs = normalizeArgs(aligned.tsArgs);
   if (rubyArgs === null || tsArgs === null) {
-    return sameArity * 1_000 + Math.min(ruby.args.length, strippedTs.length);
+    return sameArity * 1_000 + Math.min(aligned.rubyArgs.length, aligned.tsArgs.length);
   }
   if (argsEqual(rubyArgs, tsArgs)) return 1_000_000;
   let matches = 0;
@@ -651,11 +672,12 @@ export function compareCallArgs(
   if (isSkippedCallName(ruby.name)) return skipped("excludedCallName");
   if (hasUncomparableFlag(ruby) || hasUncomparableFlag(ts)) return skipped("uncomparableFlag");
 
-  const rubyArgs = normalizeArgsOrFailure(ruby.args);
+  const aligned = alignReceiverArgs(ruby, ts.args);
+  const rubyArgs = normalizeArgsOrFailure(aligned.rubyArgs);
   if (!Array.isArray(rubyArgs)) {
     return skipped(rubyArgs.failure === "opaque" ? "opaqueRubyArg" : "unparseableLiteral");
   }
-  const normalizedTs = normalizeArgsOrFailure(stripReceiverArgs(ruby.name, ruby.args, ts.args));
+  const normalizedTs = normalizeArgsOrFailure(aligned.tsArgs);
   if (!Array.isArray(normalizedTs)) {
     return skipped(normalizedTs.failure === "opaque" ? "opaqueTsArg" : "unparseableLiteral");
   }

--- a/scripts/api-compare/call-mismatches-exclude/actioncontroller/test-case.json
+++ b/scripts/api-compare/call-mismatches-exclude/actioncontroller/test-case.json
@@ -34,30 +34,6 @@
   {
     "package": "actioncontroller",
     "tsFile": "test-case.ts",
-    "rubyName": "assign_parameters",
-    "call": "set_header",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:k",
-      "ref:fullpath"
-    ],
-    "reason": "RFC 0099: pre-existing divergence the source-order pairing hid. test_case.rb:142 writes `fetch_header(\"ORIGINAL_FULLPATH\") { |k| set_header k, fullpath }` and passes the block's `k`; the port inlines the header name at the `setHeader` call instead of threading the fetch_header block parameter. Pending per-body convergence review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "test-case.ts",
-    "rubyName": "assign_parameters",
-    "call": "set_header",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:k",
-      "ref:generatedPath"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "test-case.ts",
     "rubyName": "create",
     "call": "merge",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/attributes.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/attributes.json
@@ -19,18 +19,5 @@
     "rubyName": "attribute_method?",
     "call": "respond_to_without_attributes?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "attributes.ts",
-    "rubyName": "define_method_attribute=",
-    "call": "define_attribute_accessor_method",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:owner",
-      "ref:canonicalName",
-      "kwargs{writer=bool:true}"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/validations/comparability.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/validations/comparability.json
@@ -10,6 +10,17 @@
     "package": "activemodel",
     "tsFile": "validations/comparability.ts",
     "rubyName": "error_options",
+    "call": "keys",
+    "kind": "args",
+    "rubyArgs": [
+      "const:COMPARE_CHECKS"
+    ],
+    "reason": "RFC 0099: comparability.rb:6 declares COMPARE_CHECKS as a Hash (check => operator) and :11 reads `COMPARE_CHECKS.keys`; the port declares it as the key ARRAY, so there is no `.keys` receiver to pass. Converging means porting the Hash and its operator values through comparison.rb/numericality.rb — filed as its own story."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "validations/comparability.ts",
+    "rubyName": "error_options",
     "call": "merge!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/alias-tracker.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/alias-tracker.json
@@ -15,7 +15,7 @@
     "rubyArgs": [
       "num:0"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099: alias_tracker.rb:12 builds `Hash.new(0)` — a hash with a DEFAULT-VALUE proc. A JS Map has no default, so the port carries the zero/initial-count default in `AliasTracker#_getCount` instead and this `new` has no counterpart argument. Converging needs a default-proc Map port; filed separately."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods/read.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods/read.json
@@ -1,14 +1,1 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods/read.ts",
-    "rubyName": "define_method_attribute",
-    "call": "define_attribute_accessor_method",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:owner",
-      "ref:canonicalName"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  }
-]
+[]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods/write.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods/write.json
@@ -1,15 +1,1 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods/write.ts",
-    "rubyName": "define_method_attribute=",
-    "call": "define_attribute_accessor_method",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:owner",
-      "ref:canonicalName",
-      "kwargs{writer=bool:true}"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  }
-]
+[]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/autosave-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/autosave-association.json
@@ -62,7 +62,7 @@
     "rubyArgs": [
       "str:_ensure_no_duplicate_errors"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099: autosave_association.rb:233 passes the callback as a METHOD NAME symbol; trails' `afterValidation` (callbacks.ts:56) takes `(modelClass, fn)` only and has no symbol-name arm, so the name cannot be passed. Converging needs the symbol arm on the callback registry; filed separately."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-pool/queue.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-pool/queue.json
@@ -83,18 +83,5 @@
     "rubyName": "wait_poll",
     "call": "remove",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/connection-pool/queue.ts",
-    "rubyName": "with_a_bias_for",
-    "call": "new",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:lock",
-      "ref:cond",
-      "ref:thread"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/referential-integrity.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/referential-integrity.json
@@ -2,17 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql/referential-integrity.ts",
-    "rubyName": "check_all_foreign_keys_valid!",
-    "call": "execute",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:sql"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/referential-integrity.ts",
     "rubyName": "disable_referential_integrity",
     "call": "order:tables,transaction",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/sqlite3-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/sqlite3-adapter.json
@@ -15,30 +15,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "rubyName": "begin_db_transaction",
-    "call": "internal_begin_transaction",
-    "kind": "args",
-    "rubyArgs": [
-      "str:immediate",
-      "nil"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "rubyName": "begin_isolated_db_transaction",
-    "call": "internal_begin_transaction",
-    "kind": "args",
-    "rubyArgs": [
-      "str:deferred",
-      "ref:isolation"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "build_insert_sql",
     "call": "map",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
@@ -320,7 +320,7 @@
     "rubyArgs": [
       "bool:true"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099: relation.rb:1346 writes `model.current_scope(true)`; trails' `Base.currentScope` is a GETTER (base.ts:2267) with no skip-inherited parameter, so the port reaches ScopeRegistry.currentScope directly and the model arrives as argument 1. The `true` IS now passed. Converging needs currentScope flipped from a getter to a method across its call sites; filed separately."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/tasks/database-tasks.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/tasks/database-tasks.json
@@ -180,19 +180,6 @@
   {
     "package": "activerecord",
     "tsFile": "tasks/database-tasks.ts",
-    "rubyName": "initialize_database",
-    "call": "load_schema",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:dbConfig",
-      "ref:schemaFormat",
-      "nil"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "tasks/database-tasks.ts",
     "rubyName": "load_schema",
     "call": "load",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/testing/query-assertions.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/testing/query-assertions.json
@@ -9,7 +9,7 @@
       "ref:counter",
       "str:sql.active_record"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099: query_assertions.rb:22 passes the SQLCounter OBJECT (Rails subscribes anything responding to `call`); trails' `Notifications.subscribed` takes a function, so the port wraps the counter in an arrow. Converging needs the call-object duck type on Notifications/Fanout; filed separately."
   },
   {
     "package": "activerecord",
@@ -21,7 +21,7 @@
       "ref:counter",
       "str:sql.active_record"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099: query_assertions.rb:47 passes the SQLCounter OBJECT (Rails subscribes anything responding to `call`); trails' `Notifications.subscribed` takes a function, so the port wraps the counter in an arrow. Converging needs the call-object duck type on Notifications/Fanout; filed separately."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/type.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/type.json
@@ -8,6 +8,6 @@
     "rubyArgs": [
       "const:Base"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "RFC 0099: type.rb:55 names the `ActiveRecord::Base` CONSTANT, which Zeitwerk resolves at call time. A static import of base.ts from type.ts closes the `type.ts -> base.ts -> attributes -> type.ts` cycle, so base.ts injects a resolver instead (setCurrentAdapterResolver, type.ts:114) and the constant arrives as a local. Genuine ESM/autoload shortcoming."
   }
 ]

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -2384,7 +2384,18 @@ class ApiExtractor
       site_flags << "weak" if (callee[0] == :call || callee[0] == :command_call) &&
                               inert_receiver?(callee[1])
       descriptors = describe_args(args, site_flags)
-      sites << { name: name, args: descriptors, flags: site_flags.uniq }
+      site = { name: name, args: descriptors, flags: site_flags.uniq }
+      # The RECEIVER expression, for the built-in table in call-args.ts: a name
+      # on RECEIVER_AS_FIRST_ARG is one TS cannot define on a receiver, so the
+      # port writes Ruby's receiver as argument 1 and the comparator needs the
+      # receiver to compare it against. Same `callee[1]` the `weak` verdict
+      # above reads. A chained receiver describes as `call:…` and the
+      # comparator falls back to stripping — see stripBuiltinReceiver.
+      if callee[0] == :call || callee[0] == :command_call
+        recv = describe_arg(callee[1], site_flags)
+        site[:recv] = recv if recv && recv != "?"
+      end
+      sites << site
     end
 
     walk_for_call_args(args, sites)

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -2385,12 +2385,6 @@ class ApiExtractor
                               inert_receiver?(callee[1])
       descriptors = describe_args(args, site_flags)
       site = { name: name, args: descriptors, flags: site_flags.uniq }
-      # The RECEIVER expression, for the built-in table in call-args.ts: a name
-      # on RECEIVER_AS_FIRST_ARG is one TS cannot define on a receiver, so the
-      # port writes Ruby's receiver as argument 1 and the comparator needs the
-      # receiver to compare it against. Same `callee[1]` the `weak` verdict
-      # above reads. A chained receiver describes as `call:…` and the
-      # comparator falls back to stripping — see stripBuiltinReceiver.
       if callee[0] == :call || callee[0] == :command_call
         recv = describe_arg(callee[1], site_flags)
         site[:recv] = recv if recv && recv != "?"

--- a/scripts/api-compare/extractor-schema.ts
+++ b/scripts/api-compare/extractor-schema.ts
@@ -82,6 +82,7 @@ export const EXTRACTOR_OUTPUT_FIELDS = [
   "declaredIn",
   "noRailsEquivalent",
   "missingRailsCalls",
+  "recv",
 ] as const;
 
 /**

--- a/scripts/parity/types.ts
+++ b/scripts/parity/types.ts
@@ -26,6 +26,15 @@ export interface CallSite {
   name: string;
   args: string[];
   flags: string[];
+  /**
+   * Ruby side only: the receiver expression, in the same descriptor spelling as
+   * `args`, when the site has one and it is describable. Absent for a
+   * receiver-less call (`:fcall` / `:vcall`) and for an opaque receiver.
+   * `stripBuiltinReceiver` (call-args.ts) compares it against TS argument 1 for
+   * a `RECEIVER_AS_FIRST_ARG` name whose receiver is a simple `id:`/`const:`
+   * ref.
+   */
+  recv?: string;
 }
 
 export interface ParamInfo {

--- a/scripts/parity/types.ts
+++ b/scripts/parity/types.ts
@@ -30,7 +30,7 @@ export interface CallSite {
    * Ruby side only: the receiver expression, in the same descriptor spelling as
    * `args`, when the site has one and it is describable. Absent for a
    * receiver-less call (`:fcall` / `:vcall`) and for an opaque receiver.
-   * `stripBuiltinReceiver` (call-args.ts) compares it against TS argument 1 for
+   * `alignBuiltinReceiver` (call-args.ts) compares it against TS argument 1 for
    * a `RECEIVER_AS_FIRST_ARG` name whose receiver is a simple `id:`/`const:`
    * ref.
    */


### PR DESCRIPTION
Bundles four stories. 487 LOC (226 additions / 261 deletions), code only.

## RFC 0096 — `naming-burndown-activerecord-rest-2`

Converges the `connection-adapters/abstract/schema-statements.ts` (27 rows) and
`connection-adapters/abstract/schema-creation.ts` (9 rows) buckets — the two
largest this story owned:

- Rails identifiers for locals and parameters: `create_table`/`drop_table` take
  `tableName`, not `name`; `rename_*_indexes` use `generatedIndexName`;
  `foreign_key_options` maps over `pkColumn`; `remove_columns_for_alter` over
  `columnName`; `build_create_index_definition` names its `index`.
- `data_sources` / `data_source_exists?` / `tables` / `table_exists?` / `views`
  / `view_exists?` inline `data_source_sql(…)` into the `query_values` call, as
  `schema_statements.rb:34-78` writes it, instead of extracting a `sql` local.
- `create_join_table` / `build_create_join_table_definition` go back through
  Rails' `[table_1, table_2].map { |t| reference_name_for_table(t) }`
  (`:394`, `:412`).
- `schema_creation.rb`: `visit_AlterTable`'s block parameters are `fk` / `con`
  (`:28-31`), `visit_TableDefinition` builds `create_sql` (`:46`),
  `visit_ColumnDefinition` builds `column_sql` (`:36`), and
  `visit_PrimaryKeyDefinition` maps over `name` (`:80`).

Not renamed, deliberately (AC4):

- The kwargs-BUNDLE artifact. trails collects Rails' separate kwargs into one
  `options` object, so the rest-destructure at `create_table` cannot ALSO be
  called `options` (`schema_statements.rb:293-294`). Argument shape, not naming.
- A chained Ruby receiver (`table_name.to_s`) describes as the inner call and
  has no agreeable TS spelling.
- `update_table_definition(table_name, base)` — Rails' `base` is `self`.

`activerecord` `naming` row count: **426 → 406**. The remaining buckets are
filed as `naming-burndown-activerecord-rest-3`, and the
`AbstractMysqlAdapter#case_sensitive_comparison` argument-shape defect the
story context flagged is filed as
`call-args-ar-mysql-case-sensitive-comparison`.

## RFC 0099 — `call-args-ap-assign-parameters-fetch-header-block`

`assignParameters` now calls `fetchHeader(name, (k) => setHeader(k, …))` at all
three sites (`test_case.rb:116`, `:139`, `:142`), threading the block parameter
Rails threads.

This also restores `fetch_header`'s semantics, which the port had lost: Rack's
`fetch_header` is `@env.fetch(name, &block)` — the block runs only when the KEY
is ABSENT. The port guarded with `!this.getHeader("CONTENT_TYPE")`, a
truthiness test, so a header stored as `""` (or `0`, or `false`) was
overwritten where Rails would have left it alone.

## RFC 0099 — `call-args-ar-literal-values`

Seven of the twelve rows converge; each passes what the Rails body passes:

| site | fix |
| --- | --- |
| `sqlite3-adapter.ts` ×3 | `"immediate"` / `"deferred"`, the Ruby symbols interpolated into `BEGIN #{mode} TRANSACTION` (`sqlite3/database_statements.rb:25,29,33`) |
| `relation.ts` | `currentScope(modelClass, true)` — the port defaulted `skipInheritedScope` to `false` and read the INHERITED scope (`relation.rb:1346` / `scoping.rb:26`) |
| `postgresql/referential-integrity.ts` | the heredoc moves into the method body as a `sql` local, as `referential_integrity.rb:42` writes it; the exported `CHECK_ALL_FOREIGN_KEYS_SQL` constant (no source consumers) is gone |
| `tasks/database-tasks.ts` | `loadSchema(dbConfig, schemaFormat, undefined)` — Rails passes `nil` and lets `load_schema` re-derive the dump path (`database_tasks.rb:664`) |
| `connection-pool/queue.ts` | `Queue` keeps its `lock` and `withABiasFor` passes it, with the block parameter named `thread` (`queue.rb:182`) |
| `attribute-methods/read.ts`, `write.ts`, `activemodel/attributes.ts` | `defineAttributeAccessorMethod` takes Rails' `(owner, attrName, writer:)` signature (`activemodel/attribute_methods.rb:577`); the port had dropped `owner` and passed `writer` positionally |

Five keep a **reviewed** one-line reason naming the Rails `file:line` and the
blocker, each with a filed convergence story:

- `alias-tracker.ts` — `Hash.new(0)`'s default-value proc has no JS Map
  analogue; the default lives in `_getCount`.
- `autosave-association.ts` — `after_validation :_ensure_no_duplicate_errors`
  passes a method-name symbol; trails' callback macros take a function only →
  `call-args-ar-callback-symbol-name-arm`.
- `testing/query-assertions.ts` ×2 — Rails subscribes the SQLCounter OBJECT
  (anything responding to `call`); `Notifications.subscribed` takes a function
  → `call-args-as-notifications-callable-object`.
- `type.ts` — `ActiveRecord::Base` is resolved at call time by Zeitwerk; a
  static import closes the `type.ts → base.ts → attributes → type.ts` cycle, so
  base.ts injects a resolver. Genuine ESM/autoload shortcoming.
- `relation.ts` — `Base.currentScope` is a getter and cannot take the argument
  → `call-args-ar-current-scope-as-method`.

## RFC 0099 — `call-args-tool-record-ruby-receiver-on-callsite`

`CallSite` grows an optional `recv`, populated by
`extract-ruby-api.rb#record_call_site` from the same `callee[1]` the `weak`
verdict already reads, and registered in `EXTRACTOR_OUTPUT_FIELDS` so the
ts-api cache token changes and stale entries evict.

`stripBuiltinReceiver` becomes `alignBuiltinReceiver`: for a
`RECEIVER_AS_FIRST_ARG` name whose receiver is a SIMPLE `id:`/`const:` ref, the
receiver is PREPENDED to the Ruby list and compared against TS argument 1 —
`camelize(a)` where Rails wrote `b.camelize` now flags. A CHAINED receiver
(`name.to_s.camelize`, which the extractor describes as `call:to_s`) keeps
today's strip, with the reason at the call site. Both arms are covered by new
tests in `call-args.test.ts`.

**Delta measured (AC4):** exactly one new row — `activemodel`
`validations/comparability.ts` `error_options` → `keys(const:COMPARE_CHECKS)`.
It is a genuine divergence: `comparability.rb:6` declares COMPARE_CHECKS as a
Hash (check → operator) and `:11` reads `.keys`, while the port declares the key
ARRAY, so there is no `.keys` receiver to pass. Baselined with that reason and
filed as `call-args-am-compare-checks-hash`. No row the PR #6351 audit cleared
regressed.

## Tests

`test-case.test.ts` gains a regression for the `fetch_header` fix — a
present-but-empty `PATH_INFO` must survive `assignParameters`. Verified to FAIL
on baseline (the truthiness guard overwrote it) and pass after.

`call-args.test.ts` gains both arms of the receiver change: a SIMPLE receiver
compared against TS argument 1 (matching, and flagging as `naming` when it
differs), and a CHAINED receiver still stripped.

## Gates

- `pnpm parity:api:calls:args` — green; **10 stale baseline rows deleted by
  hand**, 1 added.
- `pnpm parity:api:calls` — green.
- `pnpm parity:api` / `pnpm parity:api:extra` — unchanged (the removed
  `CHECK_ALL_FOREIGN_KEYS_SQL` export is one fewer extra name).
- `pnpm typecheck`, `pnpm lint --fix` — clean.
- `scripts/api-compare/**` (1080 tests), `packages/actionpack/src/action-controller/**`,
  `activerecord` schema-statements / tasks / scoping / attribute-methods,
  sqlite3 transactions, connection-pool — all green locally.

Closes-story: naming-burndown-activerecord-rest-2
Closes-story: call-args-ap-assign-parameters-fetch-header-block
Closes-story: call-args-ar-literal-values
Closes-story: call-args-tool-record-ruby-receiver-on-callsite
