### PR TITLE
fix(activerecord): block on the PG cancel request, and converge two call sites

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -312,6 +312,40 @@ describeIfPg("PostgreSQLAdapter", () => {
       }
     });
 
+    // Regression for RFC 0061 pg-query-canceled-unhandled-rejection-recurrence:
+    // a CancelRequest is addressed to a backend, not to a statement, so firing
+    // it without waiting for delivery (`cancel`) and for the cancelled command
+    // to come back (`block` — postgresql/database_statements.rb:130-131) lets
+    // it land on whatever query is on the wire milliseconds later. Before the
+    // fix the sleep below was still running when cancelAnyRunningQuery
+    // resolved, and the follow-up SELECT died with "canceling statement due to
+    // user request".
+    it("cancelAnyRunningQuery does not leak its cancel onto a later query", async () => {
+      const other = new PostgreSQLAdapter(PG_TEST_URL);
+      try {
+        await other.beginDbTransaction();
+        let sleepError: unknown;
+        const sleep = other.execute("SELECT pg_sleep(2)").catch((e) => {
+          sleepError = e;
+        });
+        await new Promise<void>((r) => setTimeout(r, 200));
+        await (
+          other as unknown as { _cancelAnyRunningQuery(): Promise<void> }
+        )._cancelAnyRunningQuery();
+        // The `block` half: the cancelled command has already settled by the
+        // time the cancel returns, so nothing of it is left in flight.
+        expect(sleepError).toBeInstanceOf(QueryCanceled);
+        await sleep;
+        // The cancel aborted the transaction, so end it before probing — a
+        // leaked cancel shows up as QueryCanceled on one of these two, not as
+        // the 25P02 an aborted transaction block answers with.
+        await other.rollbackDbTransaction();
+        await expect(other.execute("SELECT 1 AS n")).resolves.toHaveLength(1);
+      } finally {
+        await other.close();
+      }
+    });
+
     // Rails' `cancel_any_running_query` has nothing to cancel once the lock
     // covers each query's whole life — `rollback_transaction` takes the same
     // lock (abstract/transaction.rb:611) and finds an idle transaction status.

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -635,6 +635,11 @@ describe("indexNameForRemoveFrom early return", () => {
 });
 
 describe("distinctRelationForPrimaryKey", () => {
+  // Rails hands `select_rows` the ARel node (schema_statements.rb:1440) so the
+  // adapter compiles and binds it; a node with no `toSql` would flatten to
+  // "[object Object]" on the way through a string-compiling port.
+  const arelNode = { __arel: true };
+
   function makeRelation(over: Record<string, unknown> = {}) {
     const calls = { reselect: [] as unknown[], where: [] as Record<string, unknown>[] };
     const rel: any = {
@@ -650,7 +655,7 @@ describe("distinctRelationForPrimaryKey", () => {
         // distinctBang on the original would be observable.
         return { ...this, distinctBang: () => {}, arel: this.arel };
       },
-      arel: () => ({ toSql: () => "SELECT DISTINCT ..." }),
+      arel: () => arelNode,
       // Rails uses where! (in-place); mirror that with whereBang.
       whereBang(c: Record<string, unknown>) {
         calls.where.push(c);
@@ -675,7 +680,7 @@ describe("distinctRelationForPrimaryKey", () => {
     const result = await ss.distinctRelationForPrimaryKey(rel);
 
     expect(rel._calls.reselect).toEqual(['"posts"."id"']);
-    expect(selectRows).toHaveBeenCalledWith("SELECT DISTINCT ...", "SQL");
+    expect(selectRows).toHaveBeenCalledWith(arelNode, "SQL");
     expect(rel._calls.where).toEqual([{ id: [10, 20] }]);
     expect(rel._limitValue).toBeNull();
     expect(rel._offsetValue).toBeNull();

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1695,7 +1695,7 @@ export class SchemaStatements {
     where?: (conditions: Record<string, unknown>) => unknown;
     limitValue?: number | null;
     offsetValue?: number | null;
-    arel?: unknown;
+    arel?: () => unknown;
   }): Promise<unknown> {
     const pk = relation.primaryKey;
     if (!pk) return relation;
@@ -1724,16 +1724,13 @@ export class SchemaStatements {
     }
 
     // Rails: select_rows(limited.arel, "SQL").map { |r| r.last(primary_key.length) }
-    // — selectRows yields positional column arrays, so the trailing pk values
-    // survive the leading order columns PG/MySQL prepend in columns_for_distinct.
-    const arel = typeof limited.arel === "function" ? limited.arel() : limited;
-    const sql = typeof arel === "string" ? arel : (arel?.toSql?.() ?? String(arel));
+    // — the ARel node goes to the adapter, which compiles and binds it
+    // (schema_statements.rb:1440); flattening to SQL here would strand the
+    // binds. selectRows yields positional column arrays, so the trailing pk
+    // values survive the leading order columns PG/MySQL prepend in
+    // columns_for_distinct.
     const pkLen = pkNames.length;
-    const adapter = this as any;
-    const rows: unknown[][] =
-      typeof adapter.selectRows === "function"
-        ? ((await adapter.selectRows(sql, "SQL")) as unknown[][])
-        : (await adapter.execute(sql)).map((row: Record<string, unknown>) => Object.values(row));
+    const rows = (await (this as any).selectRows(limited.arel(), "SQL")) as unknown[][];
     const limitedIds: unknown[][] = rows.map((row) => row.slice(-pkLen));
 
     if (limitedIds.length === 0) {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2018,13 +2018,26 @@ export class PostgreSQLAdapter
     });
   }
 
-  // Mirrors: PostgreSQL::DatabaseStatements#cancel_any_running_query (database_statements.rb private)
+  // Mirrors: PostgreSQL::DatabaseStatements#cancel_any_running_query (database_statements.rb:127-133)
   // Sends a CancelRequest to abort any in-flight query on the transaction connection
   // before issuing ROLLBACK / ROLLBACK AND CHAIN. Best-effort: errors are
-  // swallowed. There is no `@raw_connection.block` half
-  // (postgresql/database_statements.rb:128) to reproduce: the connection lock
-  // covers each query's whole life, so a caller that reaches here holds the
-  // lock and nothing this adapter issued is still on the wire.
+  // swallowed, as Ruby's `rescue PG::Error` swallows them.
+  //
+  // Both of Ruby's two lines are BLOCKING, and both halves matter: `cancel` is
+  // PQcancel, which returns only once the request socket has been sent and
+  // closed, and `block` waits for the cancelled command to come back before
+  // the method returns. Together they mean the cancel is delivered, and its
+  // effect consumed, entirely inside the chain that owns the query.
+  //
+  // A CancelRequest is addressed to a BACKEND, not to a statement: whatever
+  // that backend is running when the packet lands is what dies. So dropping
+  // either half turns the cancel into a delayed round that fires at whatever
+  // query happens to be on the wire milliseconds later — measured at 25/25
+  // against PG 17 when the request is fired without awaiting delivery, which
+  // is the RFC 0061 run-end `QueryCanceled` unhandled rejection (a query whose
+  // awaiter is already gone rejecting long after its chain ended). Awaiting
+  // both halves is the ownership proof; the pre-2026-08-11 shape sampled
+  // `transactionStatus` and then fired blind.
   private async _cancelAnyRunningQuery(): Promise<void> {
     type PgClientWithPid = pg.Client & {
       processID?: number | null;
@@ -2041,25 +2054,64 @@ export class PostgreSQLAdapter
     }
     if (txClient?.processID == null) return;
     try {
-      // Open a FRESH TCP connection to send a CancelRequest — mirrors
-      // libpq PQcancel / Ruby PG::Connection#cancel: new socket, send
-      // the 16-byte cancel message, close. Leaves the original
-      // transaction socket untouched; does NOT consume a pool slot.
-      const cancelCon = new pg.Connection() as PgConnectionWithCancel;
-      cancelCon.on("error", () => {});
-      cancelCon.once("connect", () => {
-        cancelCon.cancel(txClient.processID!, txClient.secretKey ?? 0);
+      // `@raw_connection.cancel` — open a FRESH TCP connection, send the
+      // 16-byte CancelRequest, and wait for the server to close it, exactly as
+      // libpq PQcancel does. Leaves the original transaction socket untouched;
+      // does NOT consume a pool slot.
+      await new Promise<void>((resolve) => {
+        const cancelCon = new pg.Connection() as PgConnectionWithCancel;
+        cancelCon.on("error", () => resolve());
+        cancelCon.on("end", () => resolve());
+        cancelCon.once("connect", () => {
+          cancelCon.cancel(txClient.processID!, txClient.secretKey ?? 0);
+        });
+        const { host, port } = txClient;
+        if (host?.startsWith("/")) {
+          cancelCon.connect(`${host}/.s.PGSQL.${port}`);
+        } else {
+          cancelCon.connect(port, host);
+        }
       });
-      const { host, port } = txClient;
-      if (host?.startsWith("/")) {
-        cancelCon.connect(`${host}/.s.PGSQL.${port}`);
-      } else {
-        cancelCon.connect(port, host);
-      }
+      // `@raw_connection.block` — the cancelled command still has to come back.
+      // Returning before it does would leave the cancel's effect (and the
+      // command's own rejection) to land after this chain is gone.
+      await this._blockUntilCommandSettles(txClient);
     } catch {
       // cancel is best-effort — a drain failure must not mask the rollback,
       // as Rails' `rescue PG::Error` on cancel_any_running_query does not.
     }
+  }
+
+  /**
+   * Mirrors `PG::Connection#block` as `cancel_any_running_query` uses it
+   * (postgresql/database_statements.rb:131): wait until the command on the
+   * wire has produced its terminating message. libpq blocks on the socket;
+   * node-pg is event-driven, so the wait is on the same terminating-message
+   * events `_attachReadyForQueryListener` tracks `_commandSettled` from, plus
+   * the socket's own end/error so a connection that dies under the cancel
+   * cannot hang the rollback. Like Ruby's, it has no timeout of its own.
+   *
+   * @internal
+   */
+  private _blockUntilCommandSettles(client: pg.Client): Promise<void> {
+    if (this._commandSettled) return Promise.resolve();
+    const connection = (client as pg.Client & { connection?: pg.Connection }).connection;
+    if (connection == null) return Promise.resolve();
+    return new Promise<void>((resolve) => {
+      const settle = (): void => {
+        connection.off("readyForQuery", settle);
+        connection.off("commandComplete", settle);
+        connection.off("errorMessage", settle);
+        connection.off("end", settle);
+        connection.off("error", settle);
+        resolve();
+      };
+      connection.on("readyForQuery", settle);
+      connection.on("commandComplete", settle);
+      connection.on("errorMessage", settle);
+      connection.on("end", settle);
+      connection.on("error", settle);
+    });
   }
 
   // Mirrors: DatabaseStatements#begin_isolated_db_transaction (database_statements.rb:68)

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2023,21 +2023,14 @@ export class PostgreSQLAdapter
   // before issuing ROLLBACK / ROLLBACK AND CHAIN. Best-effort: errors are
   // swallowed, as Ruby's `rescue PG::Error` swallows them.
   //
-  // Both of Ruby's two lines are BLOCKING, and both halves matter: `cancel` is
-  // PQcancel, which returns only once the request socket has been sent and
-  // closed, and `block` waits for the cancelled command to come back before
-  // the method returns. Together they mean the cancel is delivered, and its
-  // effect consumed, entirely inside the chain that owns the query.
-  //
-  // A CancelRequest is addressed to a BACKEND, not to a statement: whatever
-  // that backend is running when the packet lands is what dies. So dropping
-  // either half turns the cancel into a delayed round that fires at whatever
-  // query happens to be on the wire milliseconds later — measured at 25/25
-  // against PG 17 when the request is fired without awaiting delivery, which
-  // is the RFC 0061 run-end `QueryCanceled` unhandled rejection (a query whose
-  // awaiter is already gone rejecting long after its chain ended). Awaiting
-  // both halves is the ownership proof; the pre-2026-08-11 shape sampled
-  // `transactionStatus` and then fired blind.
+  // The invariant both of Ruby's lines buy, and neither buys alone: a
+  // CancelRequest is addressed to a BACKEND, not to a statement, so whatever
+  // that backend is running when the packet lands is what dies. `cancel` is
+  // PQcancel and returns only once the request has been sent and the socket
+  // closed; `block` waits for the cancelled command to come back. Both block,
+  // so the cancel is delivered — and its effect consumed — inside the chain
+  // that owns the query, rather than firing at whatever is on the wire
+  // milliseconds later.
   private async _cancelAnyRunningQuery(): Promise<void> {
     type PgClientWithPid = pg.Client & {
       processID?: number | null;
@@ -2058,9 +2051,10 @@ export class PostgreSQLAdapter
       // 16-byte CancelRequest, and wait for the server to close it, exactly as
       // libpq PQcancel does. Leaves the original transaction socket untouched;
       // does NOT consume a pool slot.
-      await new Promise<void>((resolve) => {
+      await new Promise<void>((resolve, reject) => {
         const cancelCon = new pg.Connection() as PgConnectionWithCancel;
-        cancelCon.on("error", () => resolve());
+        // A failed PQcancel raises PG::Error in Ruby, so `block` never runs.
+        cancelCon.on("error", (error: unknown) => reject(error));
         cancelCon.on("end", () => resolve());
         cancelCon.once("connect", () => {
           cancelCon.cancel(txClient.processID!, txClient.secretKey ?? 0);

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -6181,21 +6181,21 @@ export class Relation<T extends Base> {
       const records = await this.toArray();
       return records.some((r) => r.equals(record));
     }
-    // Unloaded fast path: probe existence by primary key. Composite-PK models
-    // (Rails `record.class.composite_primary_key?`) carry a tuple id, which
-    // exists()'s array branch reads as `[sql, ...binds]`; route those through a
-    // PK-column hash instead so each component is bound to its column.
+    // Unloaded fast path: probe existence by primary key. The composite-PK arm
+    // (Rails `record.class.composite_primary_key?`) is a `primary_key.zip(id)`
+    // hash rather than the tuple, which exists()'s array branch would read as
+    // `[sql, ...binds]`.
     const recordClass = record.constructor as typeof Base;
-    if (recordClass.compositePrimaryKey) {
-      const pk = recordClass.primaryKey as string[];
-      const id = record.id as unknown[];
-      const conditions: Record<string, unknown> = {};
-      pk.forEach((col, i) => {
-        conditions[col] = id[i];
-      });
-      return this.exists(conditions);
-    }
-    return this.exists(record.id);
+    const id = recordClass.compositePrimaryKey
+      ? Object.fromEntries(
+          (recordClass.primaryKey as string[]).map((column, index) => [
+            column,
+            (record.id as unknown[])[index],
+          ]),
+        )
+      : record.id;
+
+    return this.exists(id);
   }
 
   /**


### PR DESCRIPTION
## What

Three of the five bundled stories; the other two are released (see below).

### `pg-query-canceled-unhandled-rejection-recurrence` — root cause + fix

`_cancelAnyRunningQuery` opened a fresh socket, sent the libpq CancelRequest,
and returned **without awaiting anything**. Rails' two lines are both blocking:
`@raw_connection.cancel` is PQcancel (returns once the request socket is sent
and closed) and `@raw_connection.block` waits for the cancelled command to come
back (`postgresql/database_statements.rb:130-131`). The port had the first half
fire-and-forget and an explicit comment claiming the `block` half was
unnecessary. It is not.

A CancelRequest is addressed to a **backend**, not to a statement: whatever that
backend is running when the packet lands is what dies. Measured against PG 17
with a probe that fires the same fire-and-forget cancel and then runs a fresh
query:

| case | leaked onto the *next* query |
| --- | --- |
| cancel fired, short query settles first | 24/25 |
| cancel fired while the backend is idle | 25/25 |

So the gate (`transactionStatus` sampling) is irrelevant to the outcome — even a
correctly-sampled ACTIVE status only says the query was on the wire at *send*
time, not at *arrival* time. That is the run-end `QueryCanceled` unhandled
rejection: a query whose awaiter is already gone rejecting long after its chain
ended, with `PostgreSQLAdapter.log` as the outermost frame.

Fix: await the cancel socket, then `_blockUntilCommandSettles` — the `block`
half, on the same terminating-message events `_commandSettled` is tracked from,
plus socket end/error so a connection that dies under the cancel can't hang the
rollback. Invariant documented at the call site.

Verified: the new regression test fails on baseline (`expected undefined to be
an instance of QueryCanceled` — the sleep was still running when the cancel
returned) and passes after; 20 consecutive runs of both PG adapter/transaction
files, 125/125 each, zero unhandled rejections.

### `call-args-ar-distinct-relation-select-rows-arel`

`distinctRelationForPrimaryKey` now passes `limited.arel()` to `selectRows`, as
`schema_statements.rb:1440` does, instead of flattening to a SQL string first
(which stranded the bind path). The `toSql()` flattening and the
`typeof selectRows === "function"` / `execute` fallback are gone. The test now
uses an ARel node with no `toSql`, which the old body would have flattened to
`"[object Object]"`.

### `relation-include-id-local-shape`

`Relation#include?` binds Rails' single `id` local via a conditional
expression and calls `exists(id)` from both arms, with the composite arm as a
`primary_key.zip(record.id).to_h`-shaped map rather than an imperative
`pk.forEach` loop (`finder_methods.rb:389-403`). No behaviour change; covered
by the existing composite-PK `include?` tests in `finder.test.ts`.

## Released, not shipped here

`call-args-ar-host-param-encryption` and `call-args-ar-kwarg-key-set` are
released back to the queue rather than squeezed in. Neither is mechanical:

- the encryption rows want `EncryptableRecord`'s static-with-explicit-host
  methods converted to the `this`-typed mixin idiom, which reaches
  `encryption-hooks.ts`, `base.ts` and every plain-object test model;
- the kwarg rows include `in_batches(of:)` (renaming a live public kwarg),
  `insert_all!`'s `on_duplicate:`, and error-constructor `cause:` semantics —
  each needing its own Rails read and lane run.

Together they are ~360 LOC of cross-cutting change on top of this diff, which
would put the PR well past the point where review cycles blow up.

### On `relation-include-id-local-shape` AC 3 (row retirement)

There is nothing left to retire, confirmed two ways. A scan of every
`call-mismatches-exclude/` **and** `call-mismatches-unreviewed/` shard for
`tsFile: relation.ts` with `rubyName: "include?"` or `call: "exists?"` returns
exactly one row — `relation.ts | include? | having_clause`, a call-SET row from
RFC 0047 that is unrelated to this shape and out of scope here. The row the
story describes was a `naming` row, and naming rows are report-only (they are
never written to the baseline — CLAUDE.md, RFC 0095); `pnpm
parity:api:calls:args:report --package activerecord` now emits no
`relation.ts` row mentioning `include?` or `exists?`, so the shape convergence
retired it from the report by itself. Both gates are green with no stale row.

### Sibling PR overlap

**#6365** ("stop resetBang canceling another chain's in-flight PG query") edits
the same two files. It is the *second* site of this flake: `resetBang` runs sync
and outside the connection lock, so a cancel it fires targets a query a
different chain owns, and blocking the cancel — what this PR does — does not
help there. The two fixes are complementary, not alternatives: this one makes
the cancel land only on a query the cancelling chain owns; #6365 stops
`resetBang` from cancelling at all (Rails' `reset!`, postgresql_adapter.rb:371-381,
never calls `cancel_any_running_query` — only exec_rollback/restart do,
database_statements.rb:79,84). Whichever merges second will need a trivial
rebase in `_cancelAnyRunningQuery`'s neighbourhood.

## Gates

- `pnpm parity:api:calls` — OK (2105 baselined)
- `pnpm parity:api:calls:args` — OK (487 baselined shape rows); no row went
  stale, so nothing to retire by hand
- `pnpm typecheck`, eslint/prettier clean
- `finder.test.ts` 268/268, `primary-keys.test.ts`, the schema-statements
  privates file, and both PG adapter files green

Closes-story: pg-query-canceled-unhandled-rejection-recurrence
Closes-story: call-args-ar-distinct-relation-select-rows-arel
Closes-story: relation-include-id-local-shape

