### PR TITLE
fix(activerecord): stop resetBang canceling another chain's in-flight PG query

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -312,6 +312,48 @@ describeIfPg("PostgreSQLAdapter", () => {
       }
     });
 
+    // Same for `reset!`, which Rails runs under `@lock` and where it issues
+    // ROLLBACK / DISCARD ALL but never a CancelRequest — the two
+    // `cancel_any_running_query` callers are exec_rollback/restart
+    // (postgresql/database_statements.rb:79, :84), not `reset!`
+    // (postgresql_adapter.rb:371-381). The port cancelled here, killing a query
+    // another chain owned; with nothing left to observe that rejection it
+    // surfaced as vitest's run-end unhandled QueryCanceled.
+    it("reset does not cancel a query issued by another chain", async () => {
+      const other = new PostgreSQLAdapter(PG_TEST_URL);
+      try {
+        await other.beginDbTransaction();
+        const foreign = other.execute("SELECT pg_sleep(0.5) AS slept");
+        await new Promise<void>((r) => setTimeout(r, 100));
+        other.resetBang();
+        await expect(foreign).resolves.toHaveLength(1);
+      } finally {
+        await other.close();
+      }
+    });
+
+    // `resetBang` defers its body behind `_inFlightReset` and query paths wait
+    // on that barrier — several of them while already holding the connection
+    // lock. So the deferred body must NOT need that lock: a reset that waited
+    // for it would be queued behind a query that is waiting for the reset.
+    // Rails cannot reach the state (its `reset!` blocks under `@lock`), and
+    // this test is what proves the port doesn't either.
+    it("a query holding the lock does not wait on a reset queued behind it", async () => {
+      const other = new PostgreSQLAdapter(PG_TEST_URL);
+      try {
+        await other.execute("SELECT 1 AS n");
+        // Fired from OUTSIDE the lock, as a pool reap/checkin is.
+        setTimeout(() => other.resetBang(), 0);
+        await other.transactionManager.synchronize(async () => {
+          await new Promise<void>((r) => setTimeout(r, 50));
+          const rows = await other.execute("SELECT 1 AS n");
+          expect(rows).toHaveLength(1);
+        });
+      } finally {
+        await other.close();
+      }
+    });
+
     // Regression for RFC 0061 pg-query-canceled-unhandled-rejection-recurrence:
     // a CancelRequest is addressed to a backend, not to a statement, so firing
     // it without waiting for delivery (`cancel`) and for the cancelled command

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2783,9 +2783,15 @@ export class PostgreSQLAdapter
     const live = this._rawConnection;
     let work: Promise<unknown> = Promise.resolve();
     if (this._client) {
-      work = this._cancelAnyRunningQuery()
-        .then(() => live.query("ROLLBACK"))
-        .catch(() => {});
+      // No CancelRequest: `reset!` takes `@lock` (postgresql_adapter.rb:372)
+      // and so WAITS behind whatever query is on the wire; it never cancels
+      // one. `cancel_any_running_query` is reached only from
+      // `exec_rollback_db_transaction` / `exec_restart_db_transaction`
+      // (postgresql/database_statements.rb:79, :84). `resetBang` is sync and
+      // runs outside the lock, so a cancel fired here killed a query a
+      // DIFFERENT chain owned; node-pg queues this ROLLBACK behind that query
+      // on the same client, which is the ordering Rails gets from the lock.
+      work = live.query("ROLLBACK").catch(() => {});
       this._client = null;
       this._inTransaction = false;
     }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2783,14 +2783,14 @@ export class PostgreSQLAdapter
     const live = this._rawConnection;
     let work: Promise<unknown> = Promise.resolve();
     if (this._client) {
-      // No CancelRequest: `reset!` takes `@lock` (postgresql_adapter.rb:372)
-      // and so WAITS behind whatever query is on the wire; it never cancels
-      // one. `cancel_any_running_query` is reached only from
+      // No CancelRequest: `reset!` waits behind the query on the wire, it never
+      // cancels one — `cancel_any_running_query`'s only callers are
       // `exec_rollback_db_transaction` / `exec_restart_db_transaction`
-      // (postgresql/database_statements.rb:79, :84). `resetBang` is sync and
-      // runs outside the lock, so a cancel fired here killed a query a
-      // DIFFERENT chain owned; node-pg queues this ROLLBACK behind that query
-      // on the same client, which is the ordering Rails gets from the lock.
+      // (postgresql/database_statements.rb:79, :84). Cancelling here killed a
+      // query a DIFFERENT chain owned, since `resetBang` runs outside the lock
+      // Rails holds (postgresql_adapter.rb:372); node-pg queues this ROLLBACK
+      // behind that query on the same client, which is the ordering Rails gets
+      // from the lock.
       work = live.query("ROLLBACK").catch(() => {});
       this._client = null;
       this._inTransaction = false;


### PR DESCRIPTION
Fixes the recurring PG-shard red where **every test passes** and the job still
exits 1 on vitest's run-end `Unhandled Rejection: QueryCanceled: canceling
statement due to user request` (most recently main @0e79d1a4, run 31502791905
shard 2 — 325 files / 6967 tests passed, `Errors 1 error`, no test attribution).

## Root cause

`PostgreSQLAdapter#resetBang` fired `_cancelAnyRunningQuery()` before its
ROLLBACK. `resetBang` is sync and runs **outside** the connection lock (pool
checkin/reap), so the CancelRequest lands on a query a *different* async chain
still has on the wire. Once that chain has finished, nobody is left to observe
the rejection — the unattributed, run-end unhandled rejection vitest reports.

Rails does not do this. `reset!` (`postgresql_adapter.rb:371-381`) takes
`@lock`, then issues `ROLLBACK` (when the transaction status isn't idle) and
`DISCARD ALL`; it never cancels. `cancel_any_running_query` is reached only from
`exec_rollback_db_transaction` / `exec_restart_db_transaction`
(`postgresql/database_statements.rb:79, :84`).

## Fix

The cancel is gone. node-pg queues the ROLLBACK behind the in-flight query on
the same client, which is the ordering Rails gets from holding the lock.

Not #6363: that merged fix makes a cancel the adapter *owns* land on the right
statement (awaiting `PQcancel` + `block`). It does not touch `resetBang`, and I
verified on `origin/main` **with** it that the repro below still fails —
`expected 'QueryCanceled' to be 'none'`.

## Tests

- `reset does not cancel a query issued by another chain` — verified to FAIL on
  baseline (including on main with #6363) and pass after.
- `a query holding the lock does not wait on a reset queued behind it` — pins
  the invariant that the deferred reset body must not take the connection lock
  (see below). Fails as a 5s timeout against a lock-taking reset.

## Review round 1 — reset body under one lock

Reviewer was right that Rails holds `@lock` for the whole `reset!` body while
the port holds it for nothing (and, in the first revision of this PR, for the
ROLLBACK only). I implemented the single-`synchronize` version, and it
**deadlocks** — reverted on that evidence, with the follow-up filed as
`pg-reset-body-under-one-lock`.

Why: several query paths await `_inFlightReset` while **already holding** the
lock — `withRawConnection`'s in-lock `awaitRawConnectionReady()`,
`_acquireFreshClient`, and `verifyBang`. A reset that takes the lock is then
queued behind a query that is waiting for the reset. Two mitigations were tried
and measured, both insufficient: draining the barrier *before* the lock (TOCTOU
— `resetBang` can fire during `run()`'s `connectBang()` await, exactly as the
round-2 review predicted) and a "do I already hold the lock" guard on the
in-lock waits (still deadlocked in the test above). Collapsing the barrier and
the lock into one mechanism is the real fix and is bigger than this PR; the
story carries the evidence and the constraint that
`awaitRawConnectionReady`'s socket-reopen duty must survive (`disconnect and
recover on #configure_connection failure` reds otherwise).

This PR therefore leaves the lock scope exactly as `origin/main` has it and
changes only the cancel, so it introduces no new deadlock class.

## Review round 3 — story criteria and description

- **Description**: the version the round-3 review quotes (the `synchronize`
  wrap, the `awaitResetBarrier` hook, the 46→45 baseline row) was the round-2
  description; it was rewritten to match the branch at the same time the review
  ran. What you are reading now is the branch. Nothing was lost in the
  force-push: the lock-wrapping was deliberately abandoned, with the evidence
  above and below.
- **Story AC**: criteria 1 and 3 (ROLLBACK under `synchronize`; the converged
  `reset!` / `synchronize` baseline row) were written by me when that was the
  plan. Both have been **amended in the story file**, with the deadlock
  evidence, and moved to `pg-reset-body-under-one-lock`. The baseline row is
  therefore deliberately untouched here — it is still a real, unconverged
  deviation, and deleting it would have been the ratification this repo
  forbids.
- **On "solve it, don't drop it"**: agreed as the end state, which is why the
  follow-up story exists rather than a note in a comment. What I will not do is
  ship a lock design whose deadlock I reproduced and could not explain: the
  guard that should have suppressed the self-wait measured `_currentLockOwner`
  as null at the pre-lock check, which I cannot yet account for. Collapsing the
  barrier and the lock into one mechanism — the actual fix — is a different,
  larger change against `withRawConnection`, `_acquireFreshClient` and
  `verifyBang`, and it belongs in its own PR with its own review.

## Gates

- `pnpm parity:api:calls` (2055 baselined, tight), `pnpm parity:api:calls:args`
  (444 rows), `pnpm typecheck`, `pnpm lint` — clean. No baseline row added or
  removed: the `reset!` / `synchronize` row stays, and its convergence is what
  the follow-up story delivers.
- PG 17: `adapters/postgresql/**` + `connection-adapters/**` + `adapter.test.ts`
  + `transactions.test.ts` — 2889 passed, 1 failed (the known `pg_dump`
  newer-than-client environmental abort in `postgresql-rake.test.ts`).
- Rebased onto `origin/main` (post-#6363); the earlier conflict is gone.

Closes-story: pg-reset-bang-cancels-foreign-chain-query
