### PR TITLE
refactor(activerecord): rename locals to Rails identifiers in the naming burndown files

### DIFF
--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -412,12 +412,12 @@ export class CollectionAssociation extends Association {
    * nil that makes `CollectionProxy#<<` falsy.
    */
   async concat(...records: Base[]): Promise<Base[] | undefined> {
-    const flattened = records.flat();
+    records = records.flat();
     if (this.owner.isNewRecord()) {
       await this.skipStrictLoading(() => this.loadTarget());
-      return this.concatRecords(flattened);
+      return this.concatRecords(records);
     }
-    return this.transaction(() => this.concatRecords(flattened));
+    return this.transaction(() => this.concatRecords(records));
   }
 
   /**
@@ -475,7 +475,7 @@ export class CollectionAssociation extends Association {
    *
    * @internal
    */
-  protected async concatRecords(records: Base[], shouldRaise = false): Promise<Base[]> {
+  protected async concatRecords(records: Base[], raise = false): Promise<Base[]> {
     await concatRecordsLoop(records, async (record, resultStillTrue) => {
       (this as any).raiseOnTypeMismatchBang(record);
       // Mirror Rails' `add_to_target(record) { insert_record }`
@@ -489,7 +489,7 @@ export class CollectionAssociation extends Association {
         // `resultStillTrue === false` → a prior record failed, so Rails'
         // `result &&= insert_record` short-circuits the save.
         if (this.owner.isNewRecord() || !resultStillTrue) return;
-        inserted = await this.insertRecord(record, true, shouldRaise);
+        inserted = await this.insertRecord(record, true, raise);
       });
       return inserted;
     });
@@ -521,10 +521,10 @@ export class CollectionAssociation extends Association {
 
     const normalized = dependent === "delete" ? "deleteAll" : dependent;
     const optionDep = this.options.dependent;
-    const effectiveDependent =
+    dependent =
       normalized ?? (optionDep === "destroy" || optionDep === "delete" ? "deleteAll" : optionDep);
 
-    await this.deleteOrNullifyAllRecords(effectiveDependent);
+    await this.deleteOrNullifyAllRecords(dependent);
 
     this.reset();
     this.loadedBang();
@@ -753,9 +753,9 @@ export class CollectionAssociation extends Association {
    */
   override async loadTarget(): Promise<Base[]> {
     if (this.findTargetNeeded()) {
-      const cached = this.doFindTarget();
-      if (cached !== undefined && Array.isArray(cached)) {
-        this.target = this.mergeTargetLists(cached, this.target);
+      const findTarget = this.doFindTarget();
+      if (findTarget !== undefined && Array.isArray(findTarget)) {
+        this.target = this.mergeTargetLists(findTarget, this.target);
       } else {
         const found = await this.findTarget();
         if (found !== undefined && found !== null && Array.isArray(found)) {
@@ -1562,9 +1562,9 @@ function isIncludeInMemory(assoc: CollectionAssociation, record: Base): boolean 
   // For through reflections, also check through the source chain.
   const refl = assoc.reflection as any;
   if (refl.isThroughReflection?.()) {
-    const throughName = refl.options?.through;
-    if (throughName) {
-      const throughAssoc = (assoc.owner as any).association?.(throughName);
+    const name = refl.options?.through;
+    if (name) {
+      const throughAssoc = (assoc.owner as any).association?.(name);
       const sourceRefl = refl.sourceReflection?.();
       if (throughAssoc && sourceRefl) {
         const sourceName = sourceRefl.name;

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -189,7 +189,7 @@ export class HasManyThroughAssociation extends HasManyAssociation {
    * the join rows alongside the owner.
    * @internal
    */
-  protected override async concatRecords(records: Base[], _shouldRaise = false): Promise<Base[]> {
+  protected override async concatRecords(records: Base[], _raise = false): Promise<Base[]> {
     this.ensureNotNested();
     const added = await super.concatRecords(records, true);
     if (this.owner.isNewRecord() && added) {

--- a/packages/activerecord/src/relation/batches.ts
+++ b/packages/activerecord/src/relation/batches.ts
@@ -124,16 +124,16 @@ export function batchCondition(
   // where STRICT_OP is the strict variant of OP (lteq→lt, gteq→gt).
   const positions = cursorArr.map((col, i) => [col, valArr[i], operators[i]] as const);
   const [firstCol, firstVal, firstOp] = positions[positions.length - 1];
-  let clause: any = table.get(firstCol)[firstOp](firstVal);
+  let whereClause: any = table.get(firstCol)[firstOp](firstVal);
 
   for (let i = positions.length - 2; i >= 0; i--) {
     const [col, val, op] = positions[i];
     const attr = table.get(col);
     const strictOp = op === "lteq" ? "lt" : op === "gteq" ? "gt" : op;
-    clause = attr[strictOp](val).or(attr.eq(val).and(clause));
+    whereClause = attr[strictOp](val).or(attr.eq(val).and(whereClause));
   }
 
-  return relation.where(clause);
+  return relation.where(whereClause);
 }
 
 /** @internal */

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2381,9 +2381,9 @@ export function buildWithExpressionFromValue(this: QueryMethodsHost, value: unkn
     if (value.length === 0)
       throw argumentError("Empty array passed to buildWithExpressionFromValue");
     if (value.length === 1) return buildWithExpressionFromValue.call(this, value[0]);
-    const parts = value.map((part) => buildWithExpressionFromValue.call(this, part));
+    const parts = value.map((query) => buildWithExpressionFromValue.call(this, query));
     return parts.reduce(
-      (result: unknown, part: unknown) => new Nodes.UnionAll(result as any, part as any),
+      (result: unknown, value: unknown) => new Nodes.UnionAll(result as any, value as any),
     );
   }
   throw argumentError(`Unsupported argument type: \`${String(value)}\` ${typeof value}`);

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -717,27 +717,27 @@ export abstract class SchemaDumper {
   }
 
   /** @internal */
-  async table(tableName: string, lines: string[]): Promise<void> {
+  async table(table: string, lines: string[]): Promise<void> {
     // Mirrors Rails' reliance on `@connection.primary_key(table)`: capture the
     // authoritative PK column order before iterating columns so `emitTable` /
     // `resolvePrimaryKeyColumns` render composite/promoted keys in key order.
     const adapter = this._adapter();
     if (adapter && typeof adapter.primaryKeys === "function") {
       try {
-        this.primaryKeyOrderCache[tableName] = await adapter.primaryKeys(tableName);
+        this.primaryKeyOrderCache[table] = await adapter.primaryKeys(table);
       } catch {
         // Live introspection is best-effort; fall through to declaration order.
       }
     }
-    this.tableName = tableName;
+    this.tableName = table;
     try {
-      const columns = await this._source.columns(tableName);
-      const rawIndexes = await this._source.indexes(tableName);
-      const indexes = await this.filterIndexesForDump(tableName, rawIndexes);
-      const adapterTableOpts = await this.fetchTableOptions(tableName);
+      const columns = await this._source.columns(table);
+      const rawIndexes = await this._source.indexes(table);
+      const indexes = await this.filterIndexesForDump(table, rawIndexes);
+      const adapterTableOpts = await this.fetchTableOptions(table);
       const inlineLines: string[] = [];
-      const remaining = await this.gatherInlineConstraints(tableName, inlineLines);
-      this.emitTable(lines, tableName, columns, indexes, adapterTableOpts, inlineLines);
+      const remaining = await this.gatherInlineConstraints(table, inlineLines);
+      this.emitTable(lines, table, columns, indexes, adapterTableOpts, inlineLines);
       if (remaining && remaining.length > 0) lines.push("", ...remaining);
       lines.push("");
     } finally {
@@ -767,7 +767,7 @@ export abstract class SchemaDumper {
    * @internal
    */
   protected async checkConstraintsInCreate(
-    tableName: string,
+    table: string,
     lines: string[],
   ): Promise<string[] | undefined> {
     const host = this._hookHost("checkConstraints") as
@@ -782,7 +782,7 @@ export abstract class SchemaDumper {
     // raises NotImplementedError when unsupported (e.g. MySQL <8.0.16, MariaDB
     // <10.2.1) must not be queried.
     if (host.supportsCheckConstraints && !(await host.supportsCheckConstraints())) return undefined;
-    const checkConstraints = ((await host.checkConstraints(tableName)) ?? []) as {
+    const checkConstraints = ((await host.checkConstraints(table)) ?? []) as {
       expression: string;
       name?: string;
       validate?: boolean;
@@ -801,7 +801,7 @@ export abstract class SchemaDumper {
     }
 
     if (checkInvalid.length > 0) {
-      const tableNameStr = JSON.stringify(this.removePrefixAndSuffix(tableName));
+      const tableNameStr = JSON.stringify(this.removePrefixAndSuffix(table));
       const addCheckConstraintStatements = checkInvalid.map((check) => {
         const [expr, ...opts] = this.checkParts(check);
         const optStr = opts.length > 0 ? `, { ${opts.join(", ")} }` : "";
@@ -985,8 +985,8 @@ export abstract class SchemaDumper {
   /** @internal */
   indexesInCreate(tableName: string, lines: string[], indexes: IndexInfo[] = []): void {
     const stripped = this.removePrefixAndSuffix(tableName);
-    for (const idx of indexes) {
-      const [cols, ...opts] = this.indexParts(idx);
+    for (const index of indexes) {
+      const [cols, ...opts] = this.indexParts(index);
       const optStr = opts.length > 0 ? `, { ${opts.join(", ")} }` : "";
       lines.push(`  await ctx.addIndex(${JSON.stringify(stripped)}, ${cols}${optStr});`);
     }
@@ -1116,12 +1116,12 @@ export abstract class SchemaDumper {
    */
   formatColspec(colspec: Record<string, unknown>): string {
     return Object.entries(colspec)
-      .map(([k, v]) => {
-        const value =
-          v && typeof v === "object" && !Array.isArray(v)
-            ? `{ ${this.formatColspec(v as Record<string, unknown>)} }`
-            : String(v);
-        return `${k}: ${value}`;
+      .map(([key, value]) => {
+        return `${key}: ${
+          value && typeof value === "object" && !Array.isArray(value)
+            ? `{ ${this.formatColspec(value as Record<string, unknown>)} }`
+            : String(value)
+        }`;
       })
       .join(", ");
   }

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -260,13 +260,13 @@ export class DatabaseTasks {
   }
 
   static async createCurrent(environment?: string, name?: string): Promise<void> {
-    for (const dbConfig of this.eachCurrentConfiguration(this._normalizeEnv(environment), name)) {
+    environment = this._normalizeEnv(environment);
+    for (const dbConfig of this.eachCurrentConfiguration(environment, name)) {
       await this.create(dbConfig);
     }
     // database_tasks.rb:173 — `migration_class.establish_connection(environment.to_sym)`,
     // which resolves the bare env name through `Base.configurations`.
-    const envName = this._normalizeEnv(environment);
-    await this.migrationClass().establishConnection(envName);
+    await this.migrationClass().establishConnection(environment);
   }
 
   static async drop(
@@ -519,13 +519,13 @@ export class DatabaseTasks {
   }
 
   static async purgeCurrent(environment?: string): Promise<void> {
-    const env = this._normalizeEnv(environment);
-    for (const dbConfig of this.eachCurrentConfiguration(env)) {
+    environment = this._normalizeEnv(environment);
+    for (const dbConfig of this.eachCurrentConfiguration(environment)) {
       await this.purge(dbConfig);
     }
     // database_tasks.rb:359 — `migration_class.establish_connection(environment.to_sym)`,
     // which resolves the bare env name through `Base.configurations`.
-    await this.migrationClass().establishConnection(env);
+    await this.migrationClass().establishConnection(environment);
   }
 
   static async purgeAll(): Promise<void> {


### PR DESCRIPTION
Continues the RFC 0096 naming burndown over the buckets listed in
`naming-burndown-activerecord-rest-3`. Every change is a local/parameter rename
or a Rails-shaped reassignment — no behaviour change, no public surface change.

## Renames (Rails `file:line` for each)

**`associations/collection-association.ts`**
- `concat` reassigns `records` instead of binding `flattened` — `collection_association.rb:125` `records = records.flatten`.
- `concat_records`' second parameter is `raise`, not `shouldRaise` — `:438` `def concat_records(records, raise = false)`.
- `delete_all` reassigns `dependent` instead of binding `effectiveDependent` — `:155-163`.
- `load_target` binds `findTarget` — `:274` `merge_target_lists(find_target, target)`.
- `include_in_memory?` binds `name` — `:509` `owner.association(reflection.through_reflection.name)`.

**`associations/has-many-through-association.ts`**
- the `concat_records` override's unused second slot is spelled `_raise`, matching the base signature `collection_association.rb:438`.

**`schema-dumper.ts`**
- `table(table, …)` — `schema_dumper.rb:158` `def table(table, stream)`.
- `check_constraints_in_create(table, …)` — `:283`.
- `index_parts(index)` in the `indexes_in_create` loop — `:258`.
- `format_colspec` binds `key` / `value` and inlines the ternary as Rails writes it — `:348-352`.

**`relation/batches.ts`**
- `batch_condition` builds `whereClause` — `batches.rb:352-357`.

**`relation/query-methods.ts`**
- `build_with_expression_from_value` binds `query` in the map and `value` in the reduce — `query_methods.rb:1942-1948` (Rails' reduce block deliberately shadows `value`).

**`tasks/database-tasks.ts`**
- `create_current` / `purge_current` reassign `environment` rather than binding `envName` / `env` — `database_tasks.rb:170-174`, `:356-360`.

## Row count

activerecord `naming` rows (`output/call-arg-mismatches.json`, `class === "naming"`): **281 → 267**.

Gates: `pnpm parity:api:calls` OK, `pnpm parity:api:extra --package activerecord` unchanged (258 novel / 558 moved), `pnpm parity:api:calls:args` OK, `pnpm parity:api` AR closure unchanged at 8405/9071, `pnpm lint` clean, `pnpm typecheck` clean. No baseline row was added or edited.

## Left alone / filed, not renamed away

Known non-renames carried from the parent story (Ruby `null`/`default` are JS
reserved words; a chained `x.to_s` receiver describes as the inner call and has
no TS spelling; `Array(x)` coercion locals) account for most of the residue in
these files. The rest was filed rather than papered over:

- `naming-burndown-ar-schema-dumper-stream` (RFC 0096) — the dumper's
  `lines: string[]` is Rails' `stream`, a file-wide parameter rename, plus
  `tables`' missing second foreign-key loop (`schema_dumper.rb:144-155`).
- `naming-burndown-ar-field-and-body-restructures` (RFC 0096) — rows that need
  a FIELD rename or a body restructure: `_whereClause` / `_havingClause` vs
  Rails' `where_clause` / `having_clause`, `TableDefinition#tableName` vs
  Rails' `name`, and `batch_on_unloaded_relation`'s inlined `operators` /
  `cursorValue`.
- `ar-query-methods-mysql-call-site-defects` (RFC 0023) — three genuine
  divergences, per this story's acceptance criterion 4: the swapped
  `build_with_value_from_hash` argument order (`query_methods.rb:1921-1927`),
  the invented `attribute.quotedNode(value)` in `case_sensitive_comparison`
  (`abstract_mysql_adapter.rb:604`), and `flattened_args` dropping Rails' Hash
  `.to_a` arm (`query_methods.rb:2077-2079`).

## Bundle disposition

- `call-args-ar-assume-migrated-upto-version-local` was **already implemented on
  `main`** — #6353 removed the `verNum` local, so `assumeMigratedUptoVersion`
  already reads `version` throughout and no baseline row remains. Marked done
  against #6353; nothing in this PR.
- `call-args-ar-host-param-connection-adapters` was **released back to the
  queue**. It is a ~432-LOC structural refactor (making file-private module
  functions real methods across `connection-pool.ts`, `queue.ts`,
  `database-tasks.ts`' handler instantiation, and the `data_source_sql` /
  `each_connection_pool` optional-leading-argument signatures) that shares no
  files with this rename pass and cannot be closed partially — it deserves its
  own PR rather than being half-done inside this one.

Closes-story: naming-burndown-activerecord-rest-3
Closes-story: call-args-ar-assume-migrated-upto-version-local
