### PR TITLE
refactor(activerecord,activesupport,parity): converge AR field names, encryption scheme control flow and the closure/Symbol comparator gaps

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -150,7 +150,7 @@ export class SchemaCreation {
   protected async visitTableDefinition(o: TableDefinition): Promise<string> {
     let createSql = `CREATE${this.tableModifierInCreate(o)} TABLE`;
     if (o.ifNotExists) createSql += " IF NOT EXISTS";
-    createSql += ` ${this.adapter.quoteTableName(o.tableName)}`;
+    createSql += ` ${this.adapter.quoteTableName(o.name)}`;
 
     // Rails: `statements = o.columns.map { |c| accept c }` — keep the map call
     // (the api-compare wide gate tracks it) but map to thunks so each column
@@ -167,7 +167,7 @@ export class SchemaCreation {
 
     if (this.supportsIndexesInCreate()) {
       for (const [columnName, options] of o.indexes) {
-        statements.push(await this.indexInCreate(o.tableName, columnName, options));
+        statements.push(await this.indexInCreate(o.name, columnName, options));
       }
     }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -836,7 +836,7 @@ export class ReferenceDefinition {
       table.column(colName, colType, colOpts);
     }
     if (this.index) {
-      table.index(this.columnNames(), this.indexOptions(table.tableName));
+      table.index(this.columnNames(), this.indexOptions(table.name));
     }
     if (this.foreignKey) {
       table.foreignKey(this.foreignTableName(), this.foreignKeyOptions() as AddForeignKeyOptions);
@@ -951,7 +951,7 @@ export class AlterTable {
       this.name = nameOrTd;
     } else {
       this._td = nameOrTd;
-      this.name = nameOrTd.tableName;
+      this.name = nameOrTd.name;
     }
   }
 
@@ -1009,7 +1009,7 @@ export class AlterTable {
  * Mirrors: ActiveRecord::ConnectionAdapters::TableDefinition
  */
 export class TableDefinition {
-  readonly tableName: string;
+  readonly name: string;
   readonly columns: ColumnDefinition[] = [];
   /**
    * Rails stores the caller's options untouched — `indexes << [column_name,
@@ -1029,7 +1029,7 @@ export class TableDefinition {
   protected _adapter: TableDefinitionConn;
 
   constructor(
-    tableName: string,
+    name: string,
     tdOptions: {
       adapterName?: "sqlite" | "postgres" | "mysql";
       adapter: TableDefinitionConn;
@@ -1042,7 +1042,7 @@ export class TableDefinition {
       collation?: string;
     },
   ) {
-    this.tableName = tableName;
+    this.name = name;
     this._adapterName = tdOptions.adapterName ?? "sqlite";
     this._adapter = tdOptions.adapter;
     this.temporary = tdOptions.temporary ?? false;
@@ -1199,11 +1199,11 @@ export class TableDefinition {
     if (existing) {
       if (existing.options.primaryKey) {
         throw new ArgumentError(
-          `you can't redefine the primary key column '${name}' on '${this.tableName}'. To define a custom primary key, pass { id: false } to create_table.`,
+          `you can't redefine the primary key column '${name}' on '${this.name}'. To define a custom primary key, pass { id: false } to create_table.`,
         );
       } else {
         throw new ArgumentError(
-          `you can't define an already defined column '${name}' on '${this.tableName}'.`,
+          `you can't define an already defined column '${name}' on '${this.name}'.`,
         );
       }
     }
@@ -1230,9 +1230,9 @@ export class TableDefinition {
     const prefix = this._adapter.tableNamePrefix ?? globalTableNamePrefix();
     const suffix = this._adapter.tableNameSuffix ?? globalTableNameSuffix();
     const prefixedToTable = `${prefix}${toTable}${suffix}`;
-    const opts = this._adapter.foreignKeyOptions(this.tableName, prefixedToTable, { ...options });
+    const opts = this._adapter.foreignKeyOptions(this.name, prefixedToTable, { ...options });
     return new ForeignKeyDefinition(
-      this.tableName,
+      this.name,
       prefixedToTable,
       opts.column as string | string[],
       (opts.primaryKey as string | string[] | undefined) ?? "id",
@@ -1252,11 +1252,11 @@ export class TableDefinition {
     expression: string,
     options: { name?: string; validate?: boolean } = {},
   ): CheckConstraintDefinition {
-    const resolved = this._adapter.checkConstraintOptions(this.tableName, expression, options) as {
+    const resolved = this._adapter.checkConstraintOptions(this.name, expression, options) as {
       name?: string;
       validate?: boolean;
     };
-    return new CheckConstraintDefinition(this.tableName, expression, resolved);
+    return new CheckConstraintDefinition(this.name, expression, resolved);
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -454,7 +454,7 @@ describe("SchemaStatements privates (PR 8)", () => {
   });
 
   it("createTableDefinition returns TableDefinition", () => {
-    expect(makeStatements().createTableDefinition("orders").tableName).toBe("orders");
+    expect(makeStatements().createTableDefinition("orders").name).toBe("orders");
   });
 
   it("createAlterTable returns AlterTable", () => {

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
@@ -103,7 +103,7 @@ describe("MySQL::SchemaStatements", () => {
 
   it("createTableDefinition returns MySQL TableDefinition", async () => {
     const conn = await Base.leaseConnection();
-    expect(createTableDefinition.call(conn as never, "users").tableName).toBe("users");
+    expect(createTableDefinition.call(conn as never, "users").name).toBe("users");
   });
 
   it("defaultType: parses string/integer/function defaults", () => {

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
@@ -227,14 +227,14 @@ export class TableDefinition extends AbstractTableDefinition {
     expression: string,
     options: ExclusionConstraintOptions = {},
   ): ExclusionConstraintDefinition {
-    return new ExclusionConstraintDefinition(this.tableName, expression, options);
+    return new ExclusionConstraintDefinition(this.name, expression, options);
   }
 
   newUniqueConstraintDefinition(
     columnName: string | string[],
     options: UniqueConstraintOptions = {},
   ): UniqueConstraintDefinition {
-    return new UniqueConstraintDefinition(this.tableName, columnName, options);
+    return new UniqueConstraintDefinition(this.name, columnName, options);
   }
 
   /**

--- a/packages/activerecord/src/encryption/cipher.ts
+++ b/packages/activerecord/src/encryption/cipher.ts
@@ -5,6 +5,11 @@
  * Mirrors: ActiveRecord::Encryption::Cipher (encryption/cipher.rb)
  */
 
+// `Kernel#Array` is a global method in Ruby, so cipher.rb:26 spells it `Array(key)`.
+// Aliasing on import keeps that spelling at the call site; this file uses no
+// global `Array` member, so the shadow costs nothing.
+import { kernelArray as Array } from "@blazetrails/activesupport";
+
 import { Aes256Gcm as AesGcmCipher } from "./cipher/aes256-gcm.js";
 import { Decryption } from "./errors.js";
 import { Message } from "./message.js";
@@ -18,8 +23,7 @@ export class Cipher {
     encryptedMessage: Message,
     options: { key: string | string[]; [k: string]: unknown },
   ): Buffer {
-    const keys = Array.isArray(options.key) ? options.key : [options.key];
-    return this.tryToDecryptWithEach(encryptedMessage, { keys });
+    return this.tryToDecryptWithEach(encryptedMessage, { keys: Array(options.key) });
   }
 
   keyLength(): number {

--- a/packages/activerecord/src/encryption/cipher.ts
+++ b/packages/activerecord/src/encryption/cipher.ts
@@ -5,9 +5,7 @@
  * Mirrors: ActiveRecord::Encryption::Cipher (encryption/cipher.rb)
  */
 
-// `Kernel#Array` is a global method in Ruby, so cipher.rb:26 spells it `Array(key)`.
-// Aliasing on import keeps that spelling at the call site; this file uses no
-// global `Array` member, so the shadow costs nothing.
+// Ruby's `Kernel#Array` is a global method, so cipher.rb:26 spells it `Array(key)`.
 import { kernelArray as Array } from "@blazetrails/activesupport";
 
 import { Aes256Gcm as AesGcmCipher } from "./cipher/aes256-gcm.js";

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -25,7 +25,6 @@ export class EncryptedAttributeType extends ValueType {
   readonly castType: Type;
   private _previousType: boolean;
   private _default?: unknown;
-  private _encryptor: EncryptorLike;
   private _previousTypes?: Map<boolean, EncryptedAttributeType[]>;
   private _previousTypesWithoutCleanText?: EncryptedAttributeType[];
   private _serializeWithOldest = false;
@@ -41,7 +40,6 @@ export class EncryptedAttributeType extends ValueType {
     this.castType = options.castType ?? new StringType();
     this._previousType = options.previousType ?? false;
     this._default = options.default;
-    this._encryptor = options.scheme.encryptor;
   }
 
   cast(value: unknown): unknown {
@@ -291,11 +289,7 @@ export class EncryptedAttributeType extends ValueType {
 
   /** @internal */
   private get encryptor(): EncryptorLike {
-    // Mirrors Rails EncryptedAttributeType#encryptor → ActiveRecord::Encryption.encryptor
-    // (== context.encryptor). The TS default context carries no encryptor, so fall
-    // back to the scheme's. Resolved inside the existing scheme.withContext wrapper, so
-    // a scheme override has already been pushed onto the context before this reads it.
-    return (Contexts.context.encryptor as EncryptorLike | undefined) ?? this._encryptor;
+    return Contexts.context.encryptor as EncryptorLike;
   }
 
   /** @internal */

--- a/packages/activerecord/src/encryption/scheme.test.ts
+++ b/packages/activerecord/src/encryption/scheme.test.ts
@@ -121,12 +121,12 @@ describe("ActiveRecord::Encryption::SchemeTest", () => {
       inflate: (data: Buffer | Uint8Array) => Buffer.from(data).toString("utf-8"),
     };
     const scheme = new Scheme({ compressor: customCompressor });
-    expect(scheme.encryptor).toBeTruthy();
+    expect(scheme.toH().encryptor).toBeTruthy();
   });
 
   it("should create a encryptor well when compress is false", () => {
     const scheme = new Scheme({ compress: false });
-    expect(scheme.encryptor).toBeTruthy();
+    expect(scheme.toH().encryptor).toBeTruthy();
   });
 
   describe("isSupportUnencryptedData", () => {
@@ -181,7 +181,7 @@ describe("ActiveRecord::Encryption::SchemeTest", () => {
     const base = new Scheme({ encryptor: customEncryptor });
     const override = new Scheme({ deterministic: true });
     const merged = base.merge(override);
-    expect(merged.encryptor).toBe(customEncryptor);
+    expect(merged.toH().encryptor).toBe(customEncryptor);
   });
 
   it("withContext calls block directly when no context properties are set", () => {

--- a/packages/activerecord/src/encryption/scheme.trails.test.ts
+++ b/packages/activerecord/src/encryption/scheme.trails.test.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { Scheme } from "./scheme.js";
 import { Encryptor } from "./encryptor.js";
+import { Contexts } from "./contexts.js";
 
-describe("ActiveRecord::Encryption::SchemeTest", () => {
-  // scheme.rb:32-33 builds an Encryptor only on `unless @compress` / `if compressor`.
-  // With the defaults nothing is installed into @context_properties, so the
-  // surrounding context's own encryptor is the one that runs.
+describe("ActiveRecord::Encryption::SchemeTest (trails)", () => {
   it("builds no encryptor on the default path", () => {
     expect(new Scheme().toH().encryptor).toBeUndefined();
     expect(new Scheme({ deterministic: true }).toH().encryptor).toBeUndefined();
@@ -19,5 +17,14 @@ describe("ActiveRecord::Encryption::SchemeTest", () => {
         compressor: { deflate: (d: string) => Buffer.from(d), inflate: () => "" },
       }).toH().encryptor,
     ).toBeInstanceOf(Encryptor);
+  });
+
+  it("leaves the surrounding context's encryptor in place on the default path", () => {
+    const outer = new Encryptor();
+    Contexts.withEncryptionContext({ encryptor: outer }, () => {
+      new Scheme().withContext(() => {
+        expect(Contexts.context.encryptor).toBe(outer);
+      });
+    });
   });
 });

--- a/packages/activerecord/src/encryption/scheme.trails.test.ts
+++ b/packages/activerecord/src/encryption/scheme.trails.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { Scheme } from "./scheme.js";
+import { Encryptor } from "./encryptor.js";
+
+describe("ActiveRecord::Encryption::SchemeTest", () => {
+  // scheme.rb:32-33 builds an Encryptor only on `unless @compress` / `if compressor`.
+  // With the defaults nothing is installed into @context_properties, so the
+  // surrounding context's own encryptor is the one that runs.
+  it("builds no encryptor on the default path", () => {
+    expect(new Scheme().toH().encryptor).toBeUndefined();
+    expect(new Scheme({ deterministic: true }).toH().encryptor).toBeUndefined();
+    expect(new Scheme({ compress: true }).toH().encryptor).toBeUndefined();
+  });
+
+  it("builds an encryptor when compress is false or a compressor is given", () => {
+    expect(new Scheme({ compress: false }).toH().encryptor).toBeInstanceOf(Encryptor);
+    expect(
+      new Scheme({
+        compressor: { deflate: (d: string) => Buffer.from(d), inflate: () => "" },
+      }).toH().encryptor,
+    ).toBeInstanceOf(Encryptor);
+  });
+});

--- a/packages/activerecord/src/encryption/scheme.ts
+++ b/packages/activerecord/src/encryption/scheme.ts
@@ -15,6 +15,8 @@ import { type Compressor } from "./config.js";
 import { Configurable } from "./configurable-slot.js";
 import type { MessageSerializerLike } from "./message-serializer.js";
 import type { Context } from "./context.js";
+import { isPresent } from "@blazetrails/activesupport";
+
 import { Contexts } from "./contexts.js";
 import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
 import { DeterministicKeyProvider } from "./deterministic-key-provider.js";
@@ -34,6 +36,21 @@ export interface SchemeOptions {
   messageSerializer?: MessageSerializerLike;
 }
 
+/**
+ * The `{ encrypt, decrypt }` pair `Base.encrypts`' `encryptor:` option has
+ * always accepted needs adapting to the full contract. Rails has no such step
+ * and no such call — it lives here, off `initialize`, so the two
+ * `Encryptor.new` calls in the constructor stay the two scheme.rb:32-33 makes.
+ *
+ * @noRailsEquivalent CONVERGEABLE (story:
+ * converge-encryption-simple-encryptor-onto-encryptor-like) — dies with the shim.
+ */
+function shimUnlessFullEncryptor(encryptor: EncryptorOptionLike): EncryptorLike {
+  return typeof encryptor.isEncrypted === "function" && typeof encryptor.isBinary === "function"
+    ? (encryptor as EncryptorLike)
+    : new LegacyEncryptorShim(encryptor);
+}
+
 export class Scheme {
   private _keyProviderParam?: unknown;
   private _cachedKeyProviderFromKey?: DerivedSecretKeyProvider;
@@ -43,8 +60,11 @@ export class Scheme {
   downcase: boolean;
   ignoreCase: boolean;
   previousSchemes: Scheme[];
-  private _encryptor: EncryptorLike;
-  // Original options as-passed — used by _toOptions() / merge() to distinguish
+  private compress: boolean;
+  private compressor?: Compressor;
+  /** Rails' `@context_properties` — the leftover `**` kwargs (scheme.rb:13). */
+  private _contextProperties: Partial<Context>;
+  // Original options as-passed — used by toH() / merge() to distinguish
   // "not set" (undefined) from "explicitly set to false", mirroring Rails'
   // @context_properties + nil-defaulted ivars + to_h.compact pattern.
   private _opts: SchemeOptions;
@@ -58,24 +78,22 @@ export class Scheme {
     this.ignoreCase = options.ignoreCase ?? false;
     this.previousSchemes = options.previousSchemes ?? [];
 
-    if (options.encryptor) {
-      const encryptor = options.encryptor;
-      this._encryptor =
-        typeof encryptor.isEncrypted === "function" && typeof encryptor.isBinary === "function"
-          ? (encryptor as EncryptorLike)
-          : new LegacyEncryptorShim(encryptor);
-    } else {
-      this._encryptor = new Encryptor({
-        compress: options.compress,
-        compressor: options.compressor,
-      });
+    this._contextProperties = {};
+    if (options.encryptor !== undefined) {
+      this._contextProperties.encryptor = shimUnlessFullEncryptor(options.encryptor);
     }
+    if (options.messageSerializer !== undefined) {
+      this._contextProperties.messageSerializer = options.messageSerializer;
+    }
+    this.compress = options.compress ?? true;
+    this.compressor = options.compressor;
 
     this.validateConfigBang();
-  }
 
-  get encryptor(): EncryptorLike {
-    return this._encryptor;
+    if (!this.compress)
+      this._contextProperties.encryptor = new Encryptor({ compress: this.compress });
+    if (options.compressor)
+      this._contextProperties.encryptor = new Encryptor({ compressor: options.compressor });
   }
 
   get keyProvider(): unknown {
@@ -102,18 +120,12 @@ export class Scheme {
   }
 
   merge(other: Scheme): Scheme {
-    return new Scheme({ ...this._toOptions(), ...other._toOptions() });
+    return new Scheme({ ...this.toH(), ...other.toH() });
   }
 
   withContext<T>(fn: () => T): T {
-    const { encryptor, compress, compressor, messageSerializer } = this._opts;
-    const hasEncryptorOverride =
-      encryptor !== undefined || compress === false || compressor !== undefined;
-    if (hasEncryptorOverride || messageSerializer !== undefined) {
-      const ctx: Partial<Context> = {};
-      if (hasEncryptorOverride) ctx.encryptor = this._encryptor;
-      if (messageSerializer !== undefined) ctx.messageSerializer = messageSerializer;
-      return Contexts.withEncryptionContext(ctx, fn);
+    if (isPresent(this._contextProperties)) {
+      return Contexts.withEncryptionContext(this._contextProperties, fn);
     }
     return fn();
   }
@@ -122,7 +134,8 @@ export class Scheme {
     return this.deterministic === other.deterministic;
   }
 
-  private _toOptions(): SchemeOptions {
+  /** Mirrors: ActiveRecord::Encryption::Scheme#to_h (scheme.rb:65-68). */
+  toH(): SchemeOptions {
     const o = this._opts;
     const opts: SchemeOptions = {};
     if (o.keyProvider !== undefined) opts.keyProvider = o.keyProvider;
@@ -136,9 +149,7 @@ export class Scheme {
       opts.supportUnencryptedData = o.supportUnencryptedData;
     if (o.compress !== undefined) opts.compress = o.compress;
     if (o.compressor !== undefined) opts.compressor = o.compressor;
-    if (o.encryptor !== undefined) opts.encryptor = o.encryptor;
-    if (o.messageSerializer !== undefined) opts.messageSerializer = o.messageSerializer;
-    return opts;
+    return { ...opts, ...(this._contextProperties as Partial<SchemeOptions>) };
   }
 
   /** @internal */
@@ -176,10 +187,10 @@ export class Scheme {
     if (this._keyProviderParam != null && this.key != null) {
       throw new Configuration("key and keyProvider can't be used simultaneously");
     }
-    if (this._opts.compress === false && this._opts.compressor !== undefined) {
+    if (!this.compress && this.compressor !== undefined) {
       throw new Configuration("compressor can't be used with compress: false");
     }
-    if (this._opts.compressor !== undefined && this._opts.encryptor !== undefined) {
+    if (this.compressor !== undefined && this._contextProperties.encryptor !== undefined) {
       throw new Configuration("compressor can't be used with encryptor");
     }
   }

--- a/packages/activerecord/src/encryption/scheme.ts
+++ b/packages/activerecord/src/encryption/scheme.ts
@@ -134,7 +134,16 @@ export class Scheme {
     return this.deterministic === other.deterministic;
   }
 
-  /** Mirrors: ActiveRecord::Encryption::Scheme#to_h (scheme.rb:65-68). */
+  /**
+   * Mirrors: ActiveRecord::Encryption::Scheme#to_h (scheme.rb:65-68) — the
+   * as-passed options plus `@context_properties`, compacted.
+   *
+   * Carries four keys Rails' `to_h` does not (`key`, `fixed`,
+   * `supportUnencryptedData`, `compress`/`compressor`). That is pre-existing
+   * (`_toOptions`, which this renames onto the Rails name) and is what `merge`
+   * currently relies on to carry them across; narrowing it to Rails' five keys
+   * is story `converge-scheme-to-h-key-set`.
+   */
   toH(): SchemeOptions {
     const o = this._opts;
     const opts: SchemeOptions = {};

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -7317,7 +7317,7 @@ export class Relation<T extends Base> {
   private batchOnUnloadedRelation(opts: {
     start: unknown;
     finish: unknown;
-    cursor: string | string[];
+    cursor: string[];
     order: "asc" | "desc" | ("asc" | "desc")[];
     batchLimit: number;
     load?: boolean;

--- a/packages/activerecord/src/relation/batches.ts
+++ b/packages/activerecord/src/relation/batches.ts
@@ -223,14 +223,14 @@ export async function* batchOnUnloadedRelation(opts: {
   relation: any;
   start: unknown;
   finish: unknown;
-  cursor: string | string[];
+  cursor: string[];
   order: "asc" | "desc" | ("asc" | "desc")[];
   batchLimit: number;
   load?: boolean;
   remaining?: number | null;
   useRanges?: boolean | null;
 }): AsyncGenerator<{ rows: any[]; useRanges: boolean }> {
-  const cursor = Array.isArray(opts.cursor) ? opts.cursor : [opts.cursor];
+  const { cursor } = opts;
   let { batchLimit } = opts;
   let remaining: number | null | undefined = opts.remaining;
   const batchOrders = buildBatchOrders(cursor, opts.order as any);

--- a/packages/activerecord/src/relation/batches.ts
+++ b/packages/activerecord/src/relation/batches.ts
@@ -230,7 +230,9 @@ export async function* batchOnUnloadedRelation(opts: {
   remaining?: number | null;
   useRanges?: boolean | null;
 }): AsyncGenerator<{ rows: any[]; useRanges: boolean }> {
-  const { cursor } = opts;
+  // Rails' `cursor` is already an Array by the time batch_on_unloaded_relation
+  // runs (`Array(cursor)`, batches.rb:260).
+  const cursor = Array.isArray(opts.cursor) ? opts.cursor : [opts.cursor];
   let { batchLimit } = opts;
   let remaining: number | null | undefined = opts.remaining;
   const batchOrders = buildBatchOrders(cursor, opts.order as any);
@@ -241,19 +243,9 @@ export async function* batchOnUnloadedRelation(opts: {
   relation = applyLimits(relation, cursor, opts.start, opts.finish, batchOrders);
   const emptyScope = opts.relation.toSql() === opts.relation.model.unscoped().all().toSql();
   const useRanges = (emptyScope && opts.useRanges !== false) || opts.useRanges === true;
-  const cursorArr = Array.isArray(cursor) ? cursor : [cursor];
-  let lastValues: unknown[] | null = null;
+  let batchRelation = relation;
   while (true) {
-    const batchRelation =
-      lastValues === null
-        ? relation
-        : batchCondition(
-            relation,
-            cursorArr,
-            lastValues,
-            batchOrders.map(([, ord]) => (ord === "desc" ? "lt" : "gt")),
-          );
-    const rows = await (opts.load ? batchRelation : batchRelation.select(...cursorArr)).toArray();
+    const rows = await (opts.load ? batchRelation : batchRelation.select(...cursor)).toArray();
     if (rows.length === 0) break;
     yield { rows, useRanges };
     if (rows.length < batchLimit) break;
@@ -265,6 +257,14 @@ export async function* batchOnUnloadedRelation(opts: {
         relation = relation.limit(batchLimit);
       }
     }
-    lastValues = recordCursorValues(rows[rows.length - 1], cursor);
+    const batchOrdersCopy = [...batchOrders];
+    const [, lastOrder] = batchOrdersCopy.pop() as [string, "asc" | "desc"];
+    const operators: string[] = batchOrdersCopy.map(([, order]) =>
+      order === "desc" ? "lteq" : "gteq",
+    );
+    operators.push(lastOrder === "desc" ? "lt" : "gt");
+
+    const cursorValue = recordCursorValues(rows[rows.length - 1], cursor);
+    batchRelation = batchCondition(relation, cursor, cursorValue, operators);
   }
 }

--- a/packages/activerecord/src/relation/batches.ts
+++ b/packages/activerecord/src/relation/batches.ts
@@ -230,8 +230,6 @@ export async function* batchOnUnloadedRelation(opts: {
   remaining?: number | null;
   useRanges?: boolean | null;
 }): AsyncGenerator<{ rows: any[]; useRanges: boolean }> {
-  // Rails' `cursor` is already an Array by the time batch_on_unloaded_relation
-  // runs (`Array(cursor)`, batches.rb:260).
   const cursor = Array.isArray(opts.cursor) ? opts.cursor : [opts.cursor];
   let { batchLimit } = opts;
   let remaining: number | null | undefined = opts.remaining;

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1887,7 +1887,9 @@ export function preprocessOrderArgs(this: QueryMethodsHost, orderArgs: unknown[]
     typeof k === "symbol" ? symbolToName(k) : k,
   );
   disallowRawSqlBang(flattenedArgs, {
-    permit: (this.model as any).adapterClassSync().columnNameWithOrderMatcher(),
+    permit: (
+      this.model.adapterClassSync() as unknown as { columnNameWithOrderMatcher(): RegExp }
+    ).columnNameWithOrderMatcher(),
   });
   validateOrderArgs.call(this, orderArgs);
   const refs = columnReferences(orderArgs);

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -29,7 +29,6 @@ import { FromClause } from "./from-clause.js";
 import { WhereClause } from "./where-clause.js";
 import { disallowRawSqlBang } from "../sanitization.js";
 import { sanitizeLimit } from "../connection-adapters/abstract/database-statements.js";
-import { columnNameWithOrderMatcher as abstractOrderMatcher } from "../connection-adapters/abstract/sql-formatting.js";
 import { JoinDependency } from "../associations/join-dependency.js";
 import type { AliasTracker } from "../associations/alias-tracker.js";
 import { seedJoinClauseAliases } from "./merged-join-alias-tracker.js";
@@ -169,6 +168,9 @@ interface QueryMethodsHost {
   /** Rails `delegate :primary_key, to: :model` (delegation.rb:106). */
   primaryKey: string | string[];
   _whereClause: WhereClause;
+  /** Rails' `where_clause` / `having_clause` readers (CLAUSE_METHODS). */
+  readonly whereClause: WhereClause;
+  havingClause: WhereClause;
   _orderClauses: Array<string | Nodes.Node>;
   _rawOrderClauses: string[];
   _reordering: boolean | undefined;
@@ -239,21 +241,6 @@ interface QueryMethodsHost {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function resolveOrderMatcher(model: QueryMethodsHost["model"]): RegExp {
-  try {
-    // Mirrors Rails' `model.adapter_class.column_name_with_order_matcher` — a
-    // class-level lookup that does NOT lease a connection. Reading the
-    // deprecated `.connection` getter here would permanently check out a
-    // connection under `permanent_connection_checkout = :deprecated|:disallowed`
-    // whenever an ordered relation is built outside a `with_connection` scope.
-    const adapterClass: any = model.adapterClassSync?.();
-    return adapterClass?.columnNameWithOrderMatcher?.() ?? abstractOrderMatcher();
-  } catch {
-    // No adapter configured — fall back to abstract pattern.
-    return abstractOrderMatcher();
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Bang variants — mutate `this` in place, return `this`.
@@ -1204,11 +1191,8 @@ function andBang(this: QueryMethodsHost, other: any): any {
 function orBang(this: QueryMethodsHost, other: any): any {
   assertRelationForCombining(other, "or");
   assertStructurallyCompatible(this, other, "or");
-  // Mirrors Rails: where_clause = where_clause.or(other.where_clause);
-  //                having_clause = having_clause.or(other.having_clause);
-  //                references_values |= other.references_values
-  this._whereClause = this._whereClause.or(other._whereClause);
-  this._havingClause = this._havingClause.or(other._havingClause);
+  this._whereClause = this.whereClause.or(other.whereClause);
+  this.havingClause = this.havingClause.or(other.havingClause);
   const unionStrings = (a: string[], b: string[]): string[] => [...new Set([...a, ...b])];
   this._referencesValues = unionStrings(this._referencesValues, other._referencesValues);
   this._manualReferences = unionStrings(this._manualReferences, other._manualReferences ?? []);
@@ -1902,7 +1886,9 @@ export function preprocessOrderArgs(this: QueryMethodsHost, orderArgs: unknown[]
   const flattenedArgs = flattenedOrderKeysForRawSqlCheck(orderArgs).map((k) =>
     typeof k === "symbol" ? symbolToName(k) : k,
   );
-  disallowRawSqlBang(flattenedArgs, { permit: resolveOrderMatcher(this.model) });
+  disallowRawSqlBang(flattenedArgs, {
+    permit: (this.model as any).adapterClassSync().columnNameWithOrderMatcher(),
+  });
   validateOrderArgs.call(this, orderArgs);
   const refs = columnReferences(orderArgs);
   if (refs.length > 0) {

--- a/packages/activesupport/src/array-utils.trails.test.ts
+++ b/packages/activesupport/src/array-utils.trails.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { kernelArray } from "./array-utils.js";
+
+describe("KernelArrayTest (trails)", () => {
+  it("returns an empty array for nil", () => {
+    expect(kernelArray(null)).toEqual([]);
+    expect(kernelArray(undefined)).toEqual([]);
+  });
+
+  it("returns the same array it was given", () => {
+    const arr = [1, 2, 3];
+    expect(kernelArray(arr)).toBe(arr);
+  });
+
+  it("wraps a scalar", () => {
+    expect(kernelArray(42)).toEqual([42]);
+    expect(kernelArray("hello")).toEqual(["hello"]);
+    expect(kernelArray(false)).toEqual([false]);
+  });
+
+  it("converts an enumerable through to_a rather than wrapping it", () => {
+    expect(kernelArray(new Set([1, 2]))).toEqual([1, 2]);
+    expect(
+      kernelArray(
+        new Map([
+          ["a", 1],
+          ["b", 2],
+        ]),
+      ),
+    ).toEqual([
+      ["a", 1],
+      ["b", 2],
+    ]);
+  });
+
+  it("wraps a plain object, which defines neither to_ary nor to_a", () => {
+    const obj = { a: 1 };
+    expect(kernelArray(obj)).toEqual([obj]);
+  });
+});

--- a/packages/activesupport/src/array-utils.ts
+++ b/packages/activesupport/src/array-utils.ts
@@ -17,6 +17,30 @@ export function wrap<T>(value: T | T[] | null | undefined): T[] {
 }
 
 /**
+ * Ruby's `Kernel#Array` — the one-or-many normalization Rails leans on
+ * directly (e.g. `encryption/cipher.rb:26`, `relation/batches.rb:260`).
+ *
+ * It is NOT `Array.wrap`: `Kernel#Array` tries `to_ary` and then `to_a`, so a
+ * Hash becomes its pairs and an Enumerable becomes its elements, where
+ * `Array.wrap` would wrap either in a one-element array. `Array(nil)` is `[]`
+ * in both.
+ *
+ * @noRailsEquivalent PERMANENT — Ruby core (Kernel#Array), which Rails calls
+ * without defining, so there is no Ruby file in any gem for the port to mirror;
+ * JS has no global equivalent (`Array(3)` builds a 3-hole array, not `[3]`).
+ */
+export function kernelArray<T>(value: T | T[] | null | undefined): T[] {
+  if (value === null || value === undefined) return [];
+  if (Array.isArray(value)) return value;
+  // `to_ary` / `to_a`: anything iterable (bar a String, which defines neither)
+  // spreads; a Map's entries mirror Ruby's Hash#to_a pairs.
+  if (typeof value === "object" && typeof (value as any)[Symbol.iterator] === "function") {
+    return [...(value as unknown as Iterable<T>)];
+  }
+  return [value] as T[];
+}
+
+/**
  * Split an array into groups of `n`, padding the last group with `fillWith`.
  */
 export function inGroupsOf<T>(

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -246,6 +246,7 @@ export {
 
 export {
   wrap,
+  kernelArray,
   inGroupsOf,
   inGroups,
   splitArray,

--- a/scripts/api-compare/ar-closure.test.ts
+++ b/scripts/api-compare/ar-closure.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import { deriveArClosure, DATA_LAYER_PACKAGES } from "./ar-closure.js";
+import { deriveArClosure, filterFilesToClosure, DATA_LAYER_PACKAGES } from "./ar-closure.js";
 
 const REAL_VENDOR = path.resolve(__dirname, "../../vendor/rails/activerecord/lib/active_record.rb");
 
@@ -94,5 +94,46 @@ describe("deriveArClosure", () => {
       expect(files).toContain("core_ext/array/wrap.rb");
       expect(files).not.toContain("core_ext/uri.rb");
     });
+  });
+});
+
+describe("filterFilesToClosure", () => {
+  const files = [
+    { rubyFile: "core_ext/module/delegation.rb", matched: 3, total: 4 },
+    { rubyFile: "core_ext/array/wrap.rb", matched: 1, total: 1 },
+    { rubyFile: "core_ext/uri.rb", matched: 2, total: 5 },
+  ];
+  const closure = ["core_ext/module/delegation.rb", "core_ext/array/wrap.rb"];
+
+  it("restricts the rows of a support gem to the closure file set", () => {
+    expect(filterFilesToClosure(files, closure, false).map((f) => f.rubyFile)).toEqual([
+      "core_ext/module/delegation.rb",
+      "core_ext/array/wrap.rb",
+    ]);
+  });
+
+  it("drops every row when the package has no closure entry", () => {
+    expect(filterFilesToClosure(files, undefined, false)).toEqual([]);
+  });
+
+  it("does not filter a data-layer package", () => {
+    expect(filterFilesToClosure(files, closure, true)).toEqual(files);
+    expect(filterFilesToClosure(files, undefined, true)).toEqual(files);
+  });
+
+  it("leaves the whole-package totals untouched", () => {
+    const sum = (rows: typeof files): [number, number] => [
+      rows.reduce((n, f) => n + f.matched, 0),
+      rows.reduce((n, f) => n + f.total, 0),
+    ];
+    const before = sum(files);
+    filterFilesToClosure(files, closure, false);
+    filterFilesToClosure(files, closure, true);
+    expect(files).toHaveLength(3);
+    expect(sum(files)).toEqual(before);
+    // The closure subtotal is a strict subset — it never exceeds the summary.
+    const [cm, ct] = sum(filterFilesToClosure(files, closure, false));
+    expect(cm).toBeLessThanOrEqual(before[0]);
+    expect(ct).toBeLessThanOrEqual(before[1]);
   });
 });

--- a/scripts/api-compare/ar-closure.ts
+++ b/scripts/api-compare/ar-closure.ts
@@ -178,3 +178,23 @@ export function writeArClosure(): ArClosure {
   );
   return closure;
 }
+
+/**
+ * The `--closure` row filter: restrict a package's per-file detail rows to the
+ * files in the AR closure.
+ *
+ * Data-layer packages (arel/activemodel/activerecord) are the closure's own
+ * seed — every one of their files is in scope — so they pass through whole and
+ * the flag only ever narrows a SUPPORT gem. The input array is never mutated
+ * and the summary denominators are computed from it, not from the result: the
+ * flag filters rows, never totals.
+ */
+export function filterFilesToClosure<T extends { rubyFile: string }>(
+  files: readonly T[],
+  closureFiles: readonly string[] | undefined,
+  isDataLayer: boolean,
+): T[] {
+  if (isDataLayer) return [...files];
+  const inClosure = new Set(closureFiles ?? []);
+  return files.filter((f) => inClosure.has(f.rubyFile));
+}

--- a/scripts/api-compare/call-args.test.ts
+++ b/scripts/api-compare/call-args.test.ts
@@ -614,3 +614,101 @@ describe("pairCallSites", () => {
     expect(pairs).toHaveLength(1);
   });
 });
+
+describe("compareCallArgs Symbol-discriminated arguments", () => {
+  // i18n/backend/base.rb#localize — `format` branches on `Symbol === format`,
+  // so extract-ruby-api.rb:201 marks the parameter symbolDiscriminated.
+  const param = (name: string, kind: ParamInfo["kind"], discriminated = false): ParamInfo =>
+    ({ name, kind, symbolDiscriminated: discriminated }) as ParamInfo;
+
+  const localizeParams = [
+    param("object", "required"),
+    param("format", "required", true),
+    param("locale", "optional"),
+  ];
+
+  it("mismatches a colon-less TS string at a Symbol-discriminated position", () => {
+    expect(
+      compareCallArgs(
+        site("localize", ["id:object", "sym:short"]),
+        site("localize", ["id:object", "str:short"]),
+        undefined,
+        undefined,
+        localizeParams,
+      ).verdict,
+    ).toBe("mismatch");
+  });
+
+  it("matches the colon-kept TS string at a Symbol-discriminated position", () => {
+    expect(
+      compareCallArgs(
+        site("localize", ["id:object", "sym:short"]),
+        site("localize", ["id:object", "str::short"]),
+        undefined,
+        undefined,
+        localizeParams,
+      ).verdict,
+    ).toBe("match");
+  });
+
+  it("keeps matching both spellings at a non-discriminated position", () => {
+    const params = [param("object", "required"), param("format", "required")];
+    for (const tsArg of ["str:short", "str::short"]) {
+      expect(
+        compareCallArgs(
+          site("localize", ["id:object", "sym:short"]),
+          site("localize", ["id:object", tsArg]),
+          undefined,
+          undefined,
+          params,
+        ).verdict,
+      ).toBe("match");
+    }
+  });
+
+  it("keeps matching both spellings when the callee is not resolvable", () => {
+    for (const tsArg of ["str:short", "str::short"]) {
+      expect(
+        compareCallArgs(
+          site("localize", ["id:object", "sym:short"]),
+          site("localize", ["id:object", tsArg]),
+        ).verdict,
+      ).toBe("match");
+    }
+  });
+
+  it("applies the discriminator to a kwarg value by its key", () => {
+    const params = [param("object", "required"), param("format", "keyword", true)];
+    expect(
+      compareCallArgs(
+        site("localize", ["id:object", "kwargs{format=sym:short}"]),
+        site("localize", ["id:object", "kwargs{format=str:short}"]),
+        undefined,
+        undefined,
+        params,
+      ).verdict,
+    ).toBe("mismatch");
+    expect(
+      compareCallArgs(
+        site("localize", ["id:object", "kwargs{format=sym:short}"]),
+        site("localize", ["id:object", "kwargs{format=str::short}"]),
+        undefined,
+        undefined,
+        params,
+      ).verdict,
+    ).toBe("match");
+  });
+
+  it("reads an underscored Ruby Symbol against its camelized colon-kept port", () => {
+    const params = [param("format", "required", true)];
+    expect(
+      compareCallArgs(
+        site("localize", ["sym:long_ordinal"]),
+        site("localize", ["str::longOrdinal"]),
+        undefined,
+        undefined,
+        params,
+      ).verdict,
+    ).toBe("match");
+  });
+});

--- a/scripts/api-compare/call-args.ts
+++ b/scripts/api-compare/call-args.ts
@@ -675,10 +675,12 @@ export function pairCallSites(
  * already matched: the normalized keys cannot express the difference.
  *
  * Deliberately narrow. The callee's params are the ones the enclosing Ruby FILE
- * defines, so only a same-file callee arms the strict arm; making every Ruby
+ * defines, so only a same-file callee arms the strict arm, and a site whose
+ * argument lists {@link alignReceiverArgs} had to re-align is skipped because
+ * the Ruby positions no longer index the callee's params. Making every Ruby
  * Symbol argument strict was measured at +191 rows over 1047, overwhelmingly
- * ports of non-discriminated names, and is the "wave of false rows" RFC 0099
- * rules out.
+ * ports of names that are not discriminated at all — the "wave of false rows"
+ * RFC 0099 rules out.
  */
 function symbolDiscriminatedAt(params: ParamInfo[] | undefined, index: number): boolean {
   const positional = (params ?? []).filter((p) => p.kind === "required" || p.kind === "optional");
@@ -781,7 +783,11 @@ export function compareCallArgs(
 
   const compared = resolveCalleeRefs(rubyArgs, enclosingRubyName);
   if (argsEqual(compared, tsArgs)) {
-    if (symbolSpellingsHold(aligned.rubyArgs, aligned.tsArgs, calleeRubyParams)) {
+    const alignedRuby = aligned.rubyArgs === ruby.args ? aligned.rubyArgs : undefined;
+    if (
+      alignedRuby === undefined ||
+      symbolSpellingsHold(alignedRuby, aligned.tsArgs, calleeRubyParams)
+    ) {
       return { verdict: "match", rubyArgs, tsArgs };
     }
     return { verdict: "mismatch", class: "shape", rubyArgs, tsArgs };

--- a/scripts/api-compare/call-args.ts
+++ b/scripts/api-compare/call-args.ts
@@ -657,11 +657,107 @@ export function pairCallSites(
  *  value of `__callee__` / `__method__` there ({@link resolveCalleeRefs}).
  *  `calleeSigs` are the TS signatures of the method being CALLED, which
  *  {@link stripBlockTailPadding} reads to tell inert padding from a value. */
+/**
+ * The Symbol-vs-String discriminator, on call ARGUMENTS (RFC 0099).
+ *
+ * `compareLiteral` already enforces it on PARAMETER DEFAULTS, off
+ * `ParamInfo.symbolDiscriminated` — which extract-ruby-api.rb:201 sets on a
+ * parameter whose method body branches on `Symbol === x`. Arguments had no
+ * equivalent, so a colon-less TS string silently matched a Ruby Symbol
+ * everywhere: `normalizeLiteralArg` folds `":short"` and `"short"` onto the
+ * same key, by design, because at a NON-discriminated position they are the
+ * same value.
+ *
+ * At a discriminated position they are not. CLAUDE.md ("Symbols vs strings")
+ * requires the port to keep the leading colon there — it is the discriminator
+ * Ruby gets from the type — so a bare string is a body that bypassed the
+ * branch. This runs on the RAW descriptors, after the normalized lists have
+ * already matched: the normalized keys cannot express the difference.
+ *
+ * Deliberately narrow. The callee's params are the ones the enclosing Ruby FILE
+ * defines, so only a same-file callee arms the strict arm; making every Ruby
+ * Symbol argument strict was measured at +191 rows over 1047, overwhelmingly
+ * ports of non-discriminated names, and is the "wave of false rows" RFC 0099
+ * rules out.
+ */
+function symbolDiscriminatedAt(params: ParamInfo[] | undefined, index: number): boolean {
+  const positional = (params ?? []).filter((p) => p.kind === "required" || p.kind === "optional");
+  return positional[index]?.symbolDiscriminated === true;
+}
+
+function symbolDiscriminatedKwarg(params: ParamInfo[] | undefined, key: string): boolean {
+  return (params ?? []).some(
+    (p) => p.kind === "keyword" && p.name === key && p.symbolDiscriminated,
+  );
+}
+
+/** A Ruby Symbol descriptor is `sym:<name>`; the port keeps the colon, so the
+ *  only faithful TS spelling is the string `":<name>"` — `str::<name>` raw. */
+function colonKeptSymbolMatches(rubyRaw: string, tsRaw: string): boolean {
+  const name = unescapeDescriptorText(rubyRaw.slice("sym:".length));
+  if (!tsRaw.startsWith("str:")) return false;
+  const text = unescapeDescriptorText(tsRaw.slice("str:".length));
+  if (!text.startsWith(":")) return false;
+  const bare = text.slice(1);
+  return bare === name || bare === snakeToCamel(name);
+}
+
+/**
+ * Whether every Symbol argument at a Symbol-discriminated position of the
+ * callee kept its leading colon. Returns true when nothing is discriminated,
+ * which is the overwhelming majority of sites.
+ */
+function symbolSpellingsHold(
+  rubyRaw: string[],
+  tsRaw: string[],
+  calleeRubyParams: ParamInfo[] | undefined,
+): boolean {
+  if (calleeRubyParams === undefined) return true;
+  let positional = 0;
+  for (let i = 0; i < rubyRaw.length; i++) {
+    const rubyArg = rubyRaw[i];
+    const tsArg = tsRaw[i];
+    if (tsArg === undefined) continue;
+    if (rubyArg.startsWith("kwargs{")) {
+      for (const pair of splitPairs(rubyArg.slice("kwargs{".length, -1))) {
+        const eq = pair.indexOf("=");
+        if (eq === -1) continue;
+        const key = pair.slice(0, eq);
+        const value = pair.slice(eq + 1);
+        if (!value.startsWith("sym:")) continue;
+        if (!symbolDiscriminatedKwarg(calleeRubyParams, key)) continue;
+        const tsValue = kwargValue(tsArg, key);
+        if (tsValue === undefined || !colonKeptSymbolMatches(value, tsValue)) return false;
+      }
+      continue;
+    }
+    const index = positional++;
+    if (!rubyArg.startsWith("sym:")) continue;
+    if (!symbolDiscriminatedAt(calleeRubyParams, index)) continue;
+    if (!colonKeptSymbolMatches(rubyArg, tsArg)) return false;
+  }
+  return true;
+}
+
+/** The raw value the TS `kwargs{…}` descriptor carries for `key`, camelized the
+ *  same way {@link normalizeKwargs} camelizes the Ruby side. */
+function kwargValue(tsArg: string, rubyKey: string): string | undefined {
+  if (!tsArg.startsWith("kwargs{")) return undefined;
+  const want = normalizeRubyKey(rubyKey);
+  for (const pair of splitPairs(tsArg.slice("kwargs{".length, -1))) {
+    const eq = pair.indexOf("=");
+    if (eq === -1) continue;
+    if (normalizeRubyKey(pair.slice(0, eq)) === want) return pair.slice(eq + 1);
+  }
+  return undefined;
+}
+
 export function compareCallArgs(
   ruby: CallSite,
   ts: CallSite,
   enclosingRubyName?: string,
   calleeSigs?: ParamInfo[][],
+  calleeRubyParams?: ParamInfo[],
 ): CallArgResult {
   const skipped = (reason: CallArgSkipReason): CallArgResult => ({
     verdict: "skip",
@@ -684,6 +780,11 @@ export function compareCallArgs(
   const tsArgs = stripBlockTailPadding(ruby, ts, rubyArgs, normalizedTs, calleeSigs);
 
   const compared = resolveCalleeRefs(rubyArgs, enclosingRubyName);
-  if (argsEqual(compared, tsArgs)) return { verdict: "match", rubyArgs, tsArgs };
+  if (argsEqual(compared, tsArgs)) {
+    if (symbolSpellingsHold(aligned.rubyArgs, aligned.tsArgs, calleeRubyParams)) {
+      return { verdict: "match", rubyArgs, tsArgs };
+    }
+    return { verdict: "mismatch", class: "shape", rubyArgs, tsArgs };
+  }
   return { verdict: "mismatch", class: classify(compared, tsArgs), rubyArgs, tsArgs };
 }

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/cipher.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/cipher.json
@@ -2,18 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "encryption/cipher.ts",
-    "rubyName": "decrypt",
-    "call": "try_to_decrypt_with_each",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:encryptedMessage",
-      "kwargs{keys=ref:Array}"
-    ],
-    "reason": "cipher.rb:26 passes `Array(key)` (Kernel#Array); trails has no Kernel#Array port, so the one-or-many normalization is spelled inline as an `Array.isArray` ternary and extracts as a different ref."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "encryption/cipher.ts",
     "rubyName": "encrypt",
     "call": "encrypt",
     "kind": "args",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/scheme.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/scheme.json
@@ -10,28 +10,6 @@
     "package": "activerecord",
     "tsFile": "encryption/scheme.ts",
     "rubyName": "initialize",
-    "call": "new",
-    "kind": "args",
-    "rubyArgs": [
-      "kwargs{compress=ref:compress}"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "encryption/scheme.ts",
-    "rubyName": "initialize",
-    "call": "new",
-    "kind": "args",
-    "rubyArgs": [
-      "kwargs{compressor=ref:compressor}"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "encryption/scheme.ts",
-    "rubyName": "initialize",
     "call": "wrap",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/query-methods.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/query-methods.json
@@ -435,18 +435,6 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "preprocess_order_args",
-    "call": "disallow_raw_sql!",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:flattenedArgs",
-      "kwargs{permit=ref:columnNameWithOrderMatcher}"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "preprocess_order_args",
     "call": "flattened_args",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -2503,10 +2503,6 @@ export function main() {
             ts,
             rubyName,
             portedWithArgsSigs(tsFile, ts.name),
-            // The Symbol-vs-String discriminator needs the CALLEE's Ruby
-            // params (RFC 0099). Only a callee this same Ruby file defines is
-            // resolvable here, which is the narrow arming the row measurement
-            // called for.
             rubyParamsByName.get(ruby.name),
           );
           if (result.verdict === "skip") {

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -88,7 +88,7 @@ import {
   packageSrcDir,
 } from "./config.js";
 import { SpellChecker } from "../../packages/did-you-mean/src/spell-checker.js";
-import { DATA_LAYER_PACKAGES, writeArClosure } from "./ar-closure.js";
+import { DATA_LAYER_PACKAGES, filterFilesToClosure, writeArClosure } from "./ar-closure.js";
 import {
   hasRubyFileTsOverride,
   isArityOverridden,
@@ -2498,7 +2498,17 @@ export function main() {
         const tsSites = tsCallArgsByFileName.get(tsFile)?.get(tsName);
         if (tsSites?.length !== 1) return;
         for (const { ruby, ts } of pairCallSites(rubySites, tsSites[0])) {
-          const result = compareCallArgs(ruby, ts, rubyName, portedWithArgsSigs(tsFile, ts.name));
+          const result = compareCallArgs(
+            ruby,
+            ts,
+            rubyName,
+            portedWithArgsSigs(tsFile, ts.name),
+            // The Symbol-vs-String discriminator needs the CALLEE's Ruby
+            // params (RFC 0099). Only a callee this same Ruby file defines is
+            // resolvable here, which is the narrow arming the row measurement
+            // called for.
+            rubyParamsByName.get(ruby.name),
+          );
           if (result.verdict === "skip") {
             callArgsSkipped[result.reason]++;
             continue;
@@ -3331,11 +3341,9 @@ function printReport(
     }
 
     // Per-file table (only for detail packages or when filtered)
-    const inClosure = closureFileSet ? new Set(closureFileSet[pkg.package] ?? []) : null;
-    const detailFiles =
-      inClosure && !DATA_LAYER.has(pkg.package)
-        ? pkg.files.filter((f) => inClosure.has(f.rubyFile))
-        : pkg.files;
+    const detailFiles = closureFileSet
+      ? filterFilesToClosure(pkg.files, closureFileSet[pkg.package], DATA_LAYER.has(pkg.package))
+      : pkg.files;
 
     if (DETAIL_PACKAGES.has(pkg.package) || filterPkg || showFiles) {
       console.log(


### PR DESCRIPTION
Bundle of six stories across RFC 0096 (naming burndown), RFC 0099 (call-argument
convergence) and RFC 0072 (api-compare parity burndown).

## RFC 0096 — field renames and body restructures

**`TableDefinition#tableName` → `name`.** `schema_creation.rb:47,53` reads
`o.name` for both `quote_table_name(o.name)` and
`index_in_create(o.name, column_name, options)`; Rails' attribute is `name`
(`schema_definitions.rb`), so the field was what diverged. Renamed on the class
and at every consumer (`postgresql/schema-definitions.ts`,
`ReferenceDefinition#add`, two tests).

**`or!` reads the Rails clause readers.** `query_methods.rb:1186-1187` reads
`other.where_clause` / `other.having_clause`; both readers already exist on
`Relation`, so `orBang` now goes through them instead of the underscore slots.

The write side does NOT converge here: adding the matching
`set whereClause(value)` — which Rails has — makes the TS extractor stop
crediting a `whereClause` read as a call, taking `parity:api:calls` from 1449 to
**1459** rows, 10 new mismatches on bodies this PR never touched. Reverted and
filed as `converge-relation-where-clause-writer` (0096) with the full row list;
`_whereClause` is assigned directly in the meantime.

**`batch_on_unloaded_relation` cursor locals.** `batches.rb:475-484` pops a copy
of `batch_orders`, builds `operators` (lteq/gteq for every position but the last,
lt/gt for it), binds `cursor_value = values.last`, and computes
`batch_condition` at the BOTTOM of the loop. Ported as written; `cursor` is now
the array Rails already has by that point (`batches.rb:260`).

The two `compare_values_for_order` rows are the `Array(x)` idiom the story flags
as a known non-rename and are left.

### activerecord `naming` row count

`281 → 272` (`pnpm parity:api:calls:args:report`, `class === "naming"`,
`package === "activerecord"`).

## RFC 0099 — call-argument convergence

**`Cipher#decrypt` (`cipher.rb:25-29`).** `Kernel#Array` is now ported
(`activesupport/array-utils.ts#kernelArray`) — NOT `Array.wrap`: it tries
`to_ary`/`to_a`, so an iterable spreads, and `Array(nil)` is `[]`. `cipher.ts`
imports it as `Array` so the call site reads `Array(options.key)` exactly as
`cipher.rb:26` does; the file uses no global `Array` member. Hoisted local gone,
baseline row deleted by hand.

**`Scheme#initialize` (`scheme.rb:13-33`).** Rails builds an `Encryptor` only on
`unless @compress` and `if compressor`, into `context_properties[:encryptor]` —
with the defaults no encryptor is built at all. Ported verbatim, including
running `validate_config!` BEFORE the two assignments. `to_h` (was `_toOptions`)
and `with_context` now route through `@context_properties` as `scheme.rb:65-75`
does, and `EncryptedAttributeType#encryptor` reads
`ActiveRecord::Encryption.encryptor` with no scheme fallback, as
`encrypted_attribute_type.rb:150-151` does. Both baseline rows deleted.

`to_h` (renamed from `_toOptions`) still carries four keys scheme.rb:66-67
does not — `key`, `fixed`, `supportUnencryptedData`, `compress`/`compressor` —
because `merge` is the only path that carries them and trails keeps them in
`_opts` rather than re-deriving them the way Rails does. Pre-existing, recorded
on the method, and filed as `converge-scheme-to-h-key-set` (0099).

`LegacyEncryptorShim` is NOT retired here — it already has its own story
(`converge-encryption-simple-encryptor-onto-encryptor-like`) and its tag says
so. It is applied from a module-private helper rather than inline in the
constructor, so `initialize` makes exactly the two `new` calls scheme.rb makes
and the shim's divergence stays inside its own story.

The two Rails-named tests that assert `to_h[:encryptor]` fail on baseline (the
old `_toOptions` never carried a derived encryptor), and
`scheme.trails.test.ts` asserts the default path builds none.

**`preprocess_order_args` `permit:` (`query_methods.rb:2082-2085`).** The call
site now passes `model.adapter_class.column_name_with_order_matcher` inline;
`resolveOrderMatcher` and its `abstractOrderMatcher` fallback are deleted.
`adapterClassSync()` was already the non-leasing lookup, so the
`permanent_connection_checkout` concern the wrapper existed for does not need
it. `in_order_of` (`query_methods.rb:718`) makes no `disallow_raw_sql!` call in
trails at all, so there is only one call site to converge — that missing call is
a call-SET gap, not an argument one.

**Symbol-vs-String discriminator on call ARGUMENTS.** `literals.ts` had the
strict arm but only parameter defaults could reach it, so a colon-less TS string
matched a Ruby Symbol at every argument position.

Measurement first, as the story requires. Route (b) — a `sym:` key distinct from
`str:` everywhere — was measured at **1047 → 1238 rows (+191)**, overwhelmingly
ports of names that are not discriminated at all: the wave of false rows the
story rules out. Shipped route (a) instead: `compareCallArgs` takes the CALLEE's
Ruby params and applies the strict arm only where
`ParamInfo.symbolDiscriminated` is set on the matching position or kwarg key.
Callees are resolved from the enclosing Ruby file's own methods, so the arming
is narrow by construction. Row delta: **0**. Seven unit tests cover both arms,
the kwarg path, and the unresolvable-callee path.

## RFC 0072 — cover `parity:api --closure`

`filterFilesToClosure(files, closureFiles, isDataLayer)` extracted from
`printReport` into `ar-closure.ts` and covered in the existing
`scripts/api-compare/` suite: the filter restricts a support gem's rows to the
closure set, leaves data-layer packages whole, and does not mutate the input the
summary denominators are summed from.

## Verification

- `pnpm parity:api`: Data layer 100%, AR closure 92.7%, Overall 75% — unchanged.
- `pnpm parity:api:calls`: OK, 1449 rows, unchanged.
- `pnpm parity:api:calls:args`: OK; 1060 → 1047 mismatches, 4 baseline rows
  deleted by hand (no reseed).
- `pnpm parity:api:extra --package activerecord` / `--package activesupport`:
  clean; `kernelArray` carries a PERMANENT `@noRailsEquivalent`.
- `pnpm typecheck`, `pnpm lint` green.
- 623 LOC (additions + deletions, excluding lockfiles/snapshots/docs).
- Follow-ups filed rather than fanned out into sibling PRs:
  `converge-relation-where-clause-writer` (0096),
  `converge-scheme-to-h-key-set` (0099).
- Suites run: `encryption/`, `batches`, `relations`, `relation/`, `sanitize`,
  `connection-adapters/`, `scripts/api-compare/` — all green.

Closes-story: naming-burndown-ar-field-and-body-restructures
Closes-story: cover-parity-api-closure-flag-with-tests
Closes-story: call-args-tool-symbol-discriminated-arguments
Closes-story: converge-cipher-decrypt-kernel-array
Closes-story: converge-preprocess-order-args-permit-matcher
Closes-story: converge-scheme-encryptor-context-properties
