### PR TITLE
refactor(scripts,activerecord,date): qualify parity:api:build expectations by class, migrate the verified-equivalents rows, port d_lite_initialize_copy

### DIFF
--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -267,6 +267,11 @@ export function dangerousAttributeMethods(): Set<string> {
  * wires this attribute-methods entry point as the single static (see base.ts),
  * so the super call reaches `generatedAssociationMethods` just as Rails' method
  * ancestry does.
+ *
+ * @missingRailsCall include — Per-entry verified (RFC 0032 wide-entry
+ *   verification): Rails attribute_methods.rb:42-50 does `include @generated_attribute_methods`;
+ *   trails attribute-methods.ts:257-259 assigns a GeneratedAttributeMethods
+ *   holder instance — no Module#include in TS, the holder is consulted directly.
  */
 export function initializeGeneratedModules(this: AttributeMethodsHost): void {
   this._generatedAttributeMethods = new GeneratedAttributeMethods(this.name);
@@ -519,6 +524,14 @@ export function isDangerousAttributeMethod(this: AttributeMethodsHost, name: str
   return dangerousAttributeMethods().has(name);
 }
 
+/**
+ * @missingRailsCall owner — Per-entry verified (RFC 0032 wide-entry
+ *   verification): Rails attribute_methods.rb:187-197 compares
+ *   `instance_method(name).owner` across class and superclass; trails
+ *   attribute-methods.ts:508-517 uses `name in klass.prototype` vs `name in
+ *   superklass.prototype` — the prototype chain check replaces Method#owner
+ *   introspection.
+ */
 export function isMethodDefinedWithin(
   this: AttributeMethodsHost,
   name: string,

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -823,6 +823,13 @@ export class AbstractAdapter implements Quoting {
    */
   static dbWarningsIgnore: (string | RegExp)[] = [];
 
+  /**
+   * @missingRailsCall disable_prepared_statements — Bucket (b): Rails reads
+   *   `ActiveRecord.disable_prepared_statements` inline in `initialize`
+   *   (abstract_adapter.rb:159); the port applies it in the `preparedStatements`
+   *   setter (abstract-adapter.ts:1058), the chokepoint the constructor and
+   *   every (re-)establishConnection flow through.
+   */
   constructor() {
     // The module-level `include(...)` / callback / query-cache wiring is applied
     // lazily on first construction rather than at module-evaluation time. This

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3286,6 +3286,12 @@ export class PostgreSQLAdapter
    * (XmlData, BitData, Range, ArrayData) fall through to the base dispatch.
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::Quoting#quote
+   *
+   * @missingRailsCall check_int_in_range — Equivalent (RFC 0072
+   *   activerecord-unrouted-privates-remaining-inventory): `checkIntInRange` is
+   *   a bare alias — `export const checkIntInRange = checkIntegerRange` — so the
+   *   routed call is the alias target and the extractor never sees the alias
+   *   name. Nothing to converge.
    */
   override quote(value: unknown): string {
     // `.call(this)` so the inherited date/time dispatch resolves to this
@@ -3297,6 +3303,15 @@ export class PostgreSQLAdapter
    * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::Quoting#quote_string
    * (postgresql/quoting.rb:127-131) — escape-only, so the inherited `quote`
    * dispatches here instead of the abstract backslash-doubling escape.
+   *
+   * @missingRailsCall with_raw_connection — Language shortcoming: Rails'
+   *   quote_string escapes through the live connection (`with_raw_connection {
+   *   |c| c.escape(s) }`, postgresql/quoting.rb:127-131), but node-postgres
+   *   exposes no escape entry point at all — sync or async — and `quote_string`
+   *   is a sync method every `quote` call site depends on. The override
+   *   reproduces libpq's standard_conforming_strings escaping inline in
+   *   postgresql/quoting.ts (same divergence already baselined for that module's
+   *   quote_string).
    */
   override quoteString(s: string): string {
     return pgQuoteString(s);
@@ -3447,6 +3462,14 @@ export class PostgreSQLAdapter
     );
   }
 
+  /**
+   * @missingRailsCall values_at — Per-entry verified (RFC 0072
+   *   converge-pg-extension-cluster-onto-internal-exec-query): Ruby's
+   *   `split(".").values_at(-2, -1)` has no JS analogue;
+   *   postgresql-adapter.ts#enableExtension expresses the identical
+   *   destructuring as `[parts.at(-2) ?? null, parts.at(-1)]`, giving nil-schema
+   *   for a bare name.
+   */
   async enableExtension(name: string, _options?: Record<string, unknown>): Promise<void> {
     const parts = String(name).split(".");
     const [schema, extName] = [parts.at(-2) ?? null, parts.at(-1)!];
@@ -3456,6 +3479,13 @@ export class PostgreSQLAdapter
     await this.reloadTypeMap();
   }
 
+  /**
+   * @missingRailsCall values_at — Per-entry verified (RFC 0072
+   *   converge-pg-extension-cluster-onto-internal-exec-query): Ruby's
+   *   `split(".").values_at(-2, -1)` discards the schema half;
+   *   postgresql-adapter.ts#disableExtension takes `parts.at(-1)` directly,
+   *   which is the same value.
+   */
   async disableExtension(name: string, options: { force?: "cascade" } = {}): Promise<void> {
     const parts = String(name).split(".");
     const extName = parts.at(-1)!;
@@ -3484,6 +3514,10 @@ export class PostgreSQLAdapter
     return names as string[];
   }
 
+  /**
+   * @missingRailsCall any? — Ruby-ism: `query_values(...).any?` is `names.length
+   *   > 0` in TS; `length` is a property access, not a call.
+   */
   async foreignTableExists(tableName: string): Promise<boolean> {
     if (!tableName) return false;
     const names = await this.queryValues(
@@ -4033,7 +4067,14 @@ export class PostgreSQLAdapter
     ];
   }
 
-  /** @internal postgresql/schema_statements.rb:1051-1056. */
+  /**
+   * @internal postgresql/schema_statements.rb:1051-1056.
+   *
+   * @missingRailsCall new — Rails builds the deferred half of the ALTER with
+   *   `Proc.new { ... }` (postgresql/schema_statements.rb:1054, :1062); the TS
+   *   body uses an arrow function, the JS analogue, so there is no `new` to
+   *   match.
+   */
   async changeColumnForAlter(
     tableName: string,
     columnName: string,
@@ -4049,7 +4090,14 @@ export class PostgreSQLAdapter
     return sqls;
   }
 
-  /** @internal */
+  /**
+   * @internal
+   *
+   * @missingRailsCall new — Rails builds the deferred half of the ALTER with
+   *   `Proc.new { ... }` (postgresql/schema_statements.rb:1054, :1062); the TS
+   *   body uses an arrow function, the JS analogue, so there is no `new` to
+   *   match.
+   */
   changeColumnNullForAlter(
     tableName: string,
     columnName: string,

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -2252,12 +2252,4 @@ describe("initialize_copy", () => {
     const d = new RubyDate(2001, 2, 3);
     expect(d.initializeCopy(d)).toBe(d);
   });
-
-  it("carries a DateTime's day-fraction, sub-second and offset across", () => {
-    // ruby 3.3.11 -rdate:
-    //   DateTime.new(2001,2,3,4,5,6,"+09:00").dup.offset #=> (3/8)
-    const dt = new RubyDateTime(2001, 2, 3, 4, 5, 6, "+09:00").dup();
-    expect(dt.toS()).toBe("2001-02-03T04:05:06+09:00");
-    expect(dt.offset.toString()).toBe("3/8");
-  });
 });

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -2256,6 +2256,15 @@ describe("initialize_copy", () => {
     expect(() => d.initializeCopy(new RubyDate(2002, 1, 1))).toThrow("can't modify frozen Date");
   });
 
+  it("carries a DateTime's day-fraction, sub-second and offset across", () => {
+    // The complex arm's `adat->c = bdat->c` (date_core.c:5176) with values the
+    // gem's own test_dup cannot distinguish from zero. ruby 3.3.11 -rdate:
+    //   DateTime.new(2001,2,3,4,5,6,"+09:00").dup.offset #=> (3/8)
+    const dt = new RubyDateTime(2001, 2, 3, 4, 5, 6, "+09:00").dup();
+    expect(dt.toS()).toBe("2001-02-03T04:05:06+09:00");
+    expect(dt.offset.toString()).toBe("3/8");
+  });
+
   it("returns the receiver when it is its own source", () => {
     // The C's `copy == date` early return (date_core.c:5144-5145).
     const d = new RubyDate(2001, 2, 3);

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -2247,6 +2247,15 @@ describe("initialize_copy", () => {
     expect(() => d.dup()).toThrow("cannot load complex into simple");
   });
 
+  it("refuses a frozen receiver", () => {
+    // ruby 3.3.11 -rdate: rb_check_frozen(copy) (date_core.c:5142) —
+    //   Date.new(2001,2,3).freeze.send(:initialize_copy, Date.new(2002,1,1))
+    //   #=> FrozenError: can't modify frozen Date
+    const d = Object.freeze(new RubyDate(2001, 2, 3));
+    expect(() => d.initializeCopy(new RubyDate(2002, 1, 1))).toThrow(TypeError);
+    expect(() => d.initializeCopy(new RubyDate(2002, 1, 1))).toThrow("can't modify frozen Date");
+  });
+
   it("returns the receiver when it is its own source", () => {
     // The C's `copy == date` early return (date_core.c:5144-5145).
     const d = new RubyDate(2001, 2, 3);

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -2230,3 +2230,34 @@ describe("check_limit measures bytes, not UTF-16 code units", () => {
     expect(() => RubyDate._parse(str, false, { limit: 120 })).not.toThrow();
   });
 });
+
+/**
+ * Trails-only: `test_dup` (`test/date/test_switch_hitter.rb:611-623`) only ever
+ * dups a `Date` and a `DateTime`, so the arm `d_lite_initialize_copy` raises on
+ * (`date_core.c:5172-5175`) has no gem test at all.
+ */
+describe("initialize_copy", () => {
+  it("cannot load complex into simple", () => {
+    // ruby 3.3.11 -rdate: ::Date allocates simple (date_core.c:9636), so a
+    // fractional Date — which d_lite_plus made complex — has nowhere to go.
+    //   (Date.new(2001,1,1) + Rational(1,2)).dup
+    //   #=> ArgumentError: cannot load complex into simple
+    const d = new RubyDate(2001, 1, 1).plus(new Rational(1, 2));
+    expect(() => d.dup()).toThrow(ArgumentError);
+    expect(() => d.dup()).toThrow("cannot load complex into simple");
+  });
+
+  it("returns the receiver when it is its own source", () => {
+    // The C's `copy == date` early return (date_core.c:5144-5145).
+    const d = new RubyDate(2001, 2, 3);
+    expect(d.initializeCopy(d)).toBe(d);
+  });
+
+  it("carries a DateTime's day-fraction, sub-second and offset across", () => {
+    // ruby 3.3.11 -rdate:
+    //   DateTime.new(2001,2,3,4,5,6,"+09:00").dup.offset #=> (3/8)
+    const dt = new RubyDateTime(2001, 2, 3, 4, 5, 6, "+09:00").dup();
+    expect(dt.toS()).toBe("2001-02-03T04:05:06+09:00");
+    expect(dt.offset.toString()).toBe("3/8");
+  });
+});

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -5185,6 +5185,26 @@ function simpleDatP(dat: Date): boolean {
 }
 
 /**
+ * @internal `union DateData` (`date_core.c:233-236`) read out as one record —
+ * `SimpleDateData`'s fields (`date_core.c:203-213`) with
+ * `ComplexDateData`'s `df`/`sf`/`of`/time (`date_core.c:215-231`) present
+ * exactly on the complex arm, which is what {@link simpleDatP} reads. The C
+ * gets at the struct through `get_d2` (`date_core.c:1109-1114`) and copies it
+ * whole; TS class fields are private per class, so the read is a method
+ * ({@link Date#dat}) and the write stays in the class that owns the fields.
+ */
+interface DateData {
+  nth: bigint;
+  jd?: number;
+  df?: number;
+  sf?: Rational;
+  of?: number;
+  sg: number;
+  civil?: [ry: number, rm: number, rdom: number];
+  time?: [rh: number, rmin: number, rs: number];
+}
+
+/**
  * @internal `date_core.c` `k_numeric_p` (`date_core.c:1073`), true for the
  * Numeric operands `cmp_gen` and `equal_gen` admit. Ruby's Numeric covers
  * Integer, Float and Rational; JS's covers `number` and `bigint`, and the
@@ -5557,7 +5577,7 @@ export class Date {
    * reform's readings rather than proleptic ones, and `Date.new(1500, 2, 29)`
    * builds, as MRI's does.
    *
-   * The `start` ARGUMENT is {@link #sg} below: every conversion is read under
+   * The `start` ARGUMENT is {@link Date#sg} below: every conversion is read under
    * it, and {@link Date#start}, {@link Date#isJulian} and
    * {@link Date#newStart} answer off it.
    *
@@ -5604,8 +5624,11 @@ export class Date {
    * @internal `SimpleDateData`'s `sg` (`date_core.c:203-213`), the
    * calendar-reform start the date is read under — the `start` argument every
    * constructor takes, {@link DEFAULT_SG} when none is passed.
+   *
+   * Not `#`-private, for the reason {@link nth} is not: `ComplexDateData`
+   * carries the same field, and {@link DateTime#initializeCopy} writes it.
    */
-  readonly #sg: number;
+  sg: number;
 
   /**
    * @internal `SimpleDateData`'s civil fields (`date_core.c:203-213`), which
@@ -5693,13 +5716,13 @@ export class Date {
       const [nth, ry] = decodeYear(year.year, -1);
       this.nth = nth;
       this.#jd = cCivilToJd(ry, year.month, year.day, virtualSg(nth, sg));
-      this.#sg = sg;
+      this.sg = sg;
       return;
     }
     if (typeof year === "symbol") {
       this.nth = month as bigint;
       this.#jd = day as number;
-      this.#sg = start;
+      this.sg = start;
       this.#df = df;
       this.#sf = sf;
       this.#of = of;
@@ -5717,7 +5740,7 @@ export class Date {
       if (r === null) throw new DateError("invalid date");
       const [nth, ry, rm, rd] = r;
       this.nth = nth;
-      this.#sg = sg;
+      this.sg = sg;
       this.#civil = [ry, rm, rd];
     } else {
       const r = validCivilP(year, month as number, d, sg);
@@ -5725,7 +5748,7 @@ export class Date {
       const [nth, rjd] = r;
       this.nth = nth;
       this.#jd = rjd;
-      this.#sg = sg;
+      this.sg = sg;
     }
   }
 
@@ -5738,7 +5761,7 @@ export class Date {
   #getSJd(): number {
     if (this.#jd === undefined) {
       const [year, mon, mday] = this.#civil as [number, number, number];
-      this.#jd = cCivilToJd(year, mon, mday, virtualSg(this.nth, this.#sg));
+      this.#jd = cCivilToJd(year, mon, mday, virtualSg(this.nth, this.sg));
     }
     return this.#jd;
   }
@@ -5800,7 +5823,7 @@ export class Date {
    * receiver.
    */
   #getCCivil(): [ry: number, rm: number, rdom: number] {
-    return (this.#civil ??= cJdToCivil(this.mLocalJd(), virtualSg(this.nth, this.#sg)));
+    return (this.#civil ??= cJdToCivil(this.mLocalJd(), virtualSg(this.nth, this.sg)));
   }
 
   /**
@@ -6451,7 +6474,7 @@ export class Date {
    * year, as the Julian leap day before it makes it in MRI.
    */
   get yday(): number {
-    const [, rd] = cJdToOrdinal(this.mLocalJd(), virtualSg(this.nth, this.#sg));
+    const [, rd] = cJdToOrdinal(this.mLocalJd(), virtualSg(this.nth, this.sg));
     return rd;
   }
 
@@ -6466,7 +6489,7 @@ export class Date {
    * one on `DateTime` — hence the override there.
    */
   get isJulian(): boolean {
-    return mJulianP(this.#getSJd(), virtualSg(this.nth, this.#sg));
+    return mJulianP(this.#getSJd(), virtualSg(this.nth, this.sg));
   }
 
   /**
@@ -6502,22 +6525,91 @@ export class Date {
    * a Double, which is a JS number.
    */
   get start(): number {
-    return this.#sg;
+    return this.sg;
   }
 
   /**
-   * Ruby `Date#dup`, which is `Object#dup` over the `initialize_copy` the C
-   * defines for it (`d_lite_initialize_copy`, `date_core.c:5140-5182`,
-   * registered at `:9714`): a new object of the receiver's own class carrying
-   * the receiver's `SimpleDateData`/`ComplexDateData` verbatim, reform
-   * included. TS has no `dup_obj`, so this runs through the same
-   * {@link Date#newStart} seam the C's `dup_obj_with_new_start` is, with the
-   * receiver's OWN reform — which is why `DateTime#dup` keeps its
-   * day-fraction, sub-second and offset (the C's complex arm, `:5171`) without
-   * a second override.
+   * @internal `date_core.c` `get_d1` (`date_core.c:1103-1107`) — the receiver's
+   * live `DateData` read straight out, lazy fields and all: a `jd` the
+   * proleptic-Gregorian arm has not filled in yet stays `undefined` here,
+   * exactly as the C copies a struct whose `HAVE_JD` bit is clear rather than
+   * forcing `get_s_jd`. {@link DateTime} overrides it for its own fields.
+   */
+  dat(): DateData {
+    return {
+      nth: this.nth,
+      jd: this.#jd,
+      df: this.#df,
+      sf: this.#sf,
+      of: this.#of,
+      sg: this.sg,
+      civil: this.#civil,
+    };
+  }
+
+  /**
+   * Ruby `Date#initialize_copy(date)` (ruby/date, `date_core.c`
+   * `d_lite_initialize_copy`, `date_core.c:5140-5182`, registered at `:9714`),
+   * the body `Object#dup` and `Object#clone` run over the freshly allocated
+   * receiver: the source's `DateData` written into it verbatim, reform
+   * included.
+   *
+   * `rb_check_frozen(copy)` is `Object.isFrozen` — the same `TypeError` JS
+   * raises on a write to a frozen object — and the `copy == date` early return
+   * (`:5144-5145`) comes before the copy, as it does there. The last arm is the
+   * one the C raises on (`:5172-5175`): a complex source cannot be loaded into
+   * a simple receiver, which is why `(Date.new(2001, 1, 1) + Rational(1, 2)).dup`
+   * is an `ArgumentError` in MRI too — `Date`'s allocator is
+   * `d_lite_s_alloc_simple` (`:9636`).
+   */
+  initializeCopy(date: Date): this {
+    if (Object.isFrozen(this)) {
+      throw new TypeError(`can't modify frozen ${(this as object).constructor.name}`);
+    }
+    if ((this as Date) === date) return this;
+    const bdat = date.dat();
+    if (simpleDatP(date)) {
+      if (simpleDatP(this)) {
+        this.nth = bdat.nth;
+        this.#jd = bdat.jd;
+        this.sg = bdat.sg;
+        this.#civil = bdat.civil;
+      } else {
+        // `:5150-5169`, the simple half widened into the complex arm: no day
+        // fraction, sub-second or offset to carry, so all three are zero.
+        this.nth = bdat.nth;
+        this.#jd = bdat.jd;
+        this.#df = 0;
+        this.#sf = new Rational(0, 1);
+        this.#of = 0;
+        this.sg = bdat.sg;
+        this.#civil = bdat.civil;
+      }
+    } else {
+      if (!this.complexDatP()) throw new ArgumentError("cannot load complex into simple");
+      this.nth = bdat.nth;
+      this.#jd = bdat.jd;
+      this.#df = bdat.df;
+      this.#sf = bdat.sf;
+      this.#of = bdat.of;
+      this.sg = bdat.sg;
+      this.#civil = bdat.civil;
+    }
+    return this;
+  }
+
+  /**
+   * Ruby has no `Date#dup` of its own: `Object#dup` allocates through the
+   * class's own allocator — `d_lite_s_alloc_simple` for `::Date` (`:9636`),
+   * `d_lite_s_alloc_complex` for `::DateTime` (`:9969`) — and calls
+   * {@link Date#initializeCopy} on it. TS cannot allocate an instance whose
+   * private fields exist without running a constructor, so the two allocators
+   * are the {@link SEAT} construction each class already has, and the copy is
+   * `initialize_copy`'s, not `dup_obj_with_new_start`'s: no `set_sg`, so
+   * nothing forces `get_c_jd`/`get_c_df` or clears the civil seat.
    */
   dup(): this {
-    return this.newStart(this.start);
+    return (new Date(SEAT, 0n, 0, DEFAULT_SG) as this).initializeCopy(this);
   }
 
   /**
@@ -7246,7 +7338,7 @@ export class Date {
    * seat, not a seat.
    */
   toDate(): Temporal.PlainDate {
-    return plainDateFromJd(encodeJd(this.nth, this.mLocalJd()), this.#sg);
+    return plainDateFromJd(encodeJd(this.nth, this.mLocalJd()), this.sg);
   }
 
   /**
@@ -7258,15 +7350,7 @@ export class Date {
    * `bdat->s = adat->s`; the seat below is that copy.
    */
   toDatetime(): Temporal.PlainDateTime | Temporal.ZonedDateTime {
-    return new DateTime(
-      SEAT,
-      this.nth,
-      this.mJd(),
-      0,
-      new Rational(0, 1),
-      0,
-      this.#sg,
-    ).toDatetime();
+    return new DateTime(SEAT, this.nth, this.mJd(), 0, new Rational(0, 1), 0, this.sg).toDatetime();
   }
 
   /**
@@ -7438,7 +7522,7 @@ export class DateTime extends DateWithoutParseStatics {
    * `d_complex_new_internal` seat, which stores `HAVE_JD | HAVE_DF` and leaves
    * `get_c_time` (`date_core.c:1227-1244`) to decode the time from `df`.
    */
-  readonly #time?: [rh: number, rmin: number, rs: number];
+  #time?: [rh: number, rmin: number, rs: number];
 
   /**
    * @internal `ComplexDateData`'s civil fields (`date_core.c:215-231`), which
@@ -7447,7 +7531,7 @@ export class DateTime extends DateWithoutParseStatics {
    * other arm keeps {@link Date}'s, which a `DateTime` never reads because it
    * overrides {@link mLocalJd}.
    */
-  readonly #civil?: [ry: number, rm: number, rdom: number];
+  #civil?: [ry: number, rm: number, rdom: number];
   /**
    * @internal `ComplexDateData`'s `sf`, the sub-second part in **nanoseconds**
    * (`date_core.c:215-231`). `jd_local_to_utc` / `df_local_to_utc` do not touch
@@ -7460,8 +7544,8 @@ export class DateTime extends DateWithoutParseStatics {
    * Rational either way (`:993-998`) — so the storage is uniformly a Rational,
    * exact at any denominator, and the two arms differ only in their rounding.
    */
-  readonly #sf: Rational;
-  readonly #of: number;
+  #sf: Rational;
+  #of: number;
 
   /**
    * Ruby `DateTime.new(y = -4712, m = 1, d = 1, h = 0, min = 0, s = 0, offset = 0)`
@@ -8363,6 +8447,72 @@ export class DateTime extends DateWithoutParseStatics {
       this.#of,
       val2sg(start),
     ) as this;
+  }
+
+  /**
+   * The `ComplexDateData` half of {@link Date#dat} — `df`, `sf` and `of` are
+   * always live on a `DateTime`, and the time of day the proleptic-Gregorian
+   * arm of `datetime_initialize` stores instead of a day-fraction rides along
+   * with the civil triple it goes with.
+   */
+  override dat(): DateData {
+    return {
+      nth: this.nth,
+      jd: this.#jd,
+      df: this.#df,
+      sf: this.#sf,
+      of: this.#of,
+      sg: this.start,
+      civil: this.#civil,
+      time: this.#time,
+    };
+  }
+
+  /**
+   * The complex receiver's half of `d_lite_initialize_copy`
+   * (`date_core.c:5140-5182`): one C function, but its two arms WRITE
+   * different data, and TS class fields are private to the class that declares
+   * them — so `adat->c = bdat->c` (`:5176`) is spelled where `c` lives. A
+   * `DateTime` is always complex, so the raise at `:5173-5175` cannot be
+   * reached from here; the simple-source arm is the C's `:5150-5169`.
+   */
+  override initializeCopy(date: Date): this {
+    if (Object.isFrozen(this)) {
+      throw new TypeError(`can't modify frozen ${(this as object).constructor.name}`);
+    }
+    if ((this as Date) === date) return this;
+    const bdat = date.dat();
+    this.nth = bdat.nth;
+    if (simpleDatP(date)) {
+      // A simple source has no day-fraction, sub-second or offset, and keeps
+      // its civil triple with no time of day beside it — so the day is taken
+      // whole rather than left to a `get_c_jd` that would find no time.
+      this.#jd = bdat.jd ?? date.mLocalJd();
+      this.#df = 0;
+      this.#sf = new Rational(0, 1);
+      this.#of = 0;
+      this.#civil = bdat.civil;
+      this.#time = undefined;
+    } else {
+      this.#jd = bdat.jd;
+      this.#df = bdat.df;
+      this.#sf = bdat.sf!;
+      this.#of = bdat.of!;
+      this.#civil = bdat.civil;
+      this.#time = bdat.time;
+    }
+    this.sg = bdat.sg;
+    return this;
+  }
+
+  /**
+   * `::DateTime`'s allocator is `d_lite_s_alloc_complex` (`date_core.c:9969`),
+   * where `::Date`'s is the simple one; see {@link Date#dup}.
+   */
+  override dup(): this {
+    return (new DateTime(SEAT, 0n, 0, 0, new Rational(0, 1), 0, DEFAULT_SG) as this).initializeCopy(
+      this,
+    );
   }
 
   /**

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -6529,11 +6529,11 @@ export class Date {
   }
 
   /**
-   * @internal `date_core.c` `get_d1` (`date_core.c:1103-1107`) — the receiver's
-   * live `DateData` read straight out, lazy fields and all: a `jd` the
-   * proleptic-Gregorian arm has not filled in yet stays `undefined` here,
-   * exactly as the C copies a struct whose `HAVE_JD` bit is clear rather than
-   * forcing `get_s_jd`. {@link DateTime} overrides it for its own fields.
+   * @internal `date_core.c` `get_d1` (`:1103-1107`) — the receiver's live
+   * `DateData` read straight out, lazy fields and all: a `jd` the
+   * proleptic-Gregorian arm has not filled in stays `undefined`, as the C
+   * copies a struct whose `HAVE_JD` bit is clear rather than forcing
+   * `get_s_jd`. {@link DateTime} overrides it for its own fields.
    */
   dat(): DateData {
     return {
@@ -6556,7 +6556,9 @@ export class Date {
    *
    * `rb_check_frozen(copy)` is `Object.isFrozen` — the same `TypeError` JS
    * raises on a write to a frozen object — and the `copy == date` early return
-   * (`:5144-5145`) comes before the copy, as it does there. The last arm is the
+   * (`:5144-5145`) comes before the copy, as it does there. The middle arm
+   * (`:5150-5169`) widens a simple source into a complex receiver, which is why
+   * its day fraction, sub-second and offset are all zero. The last arm is the
    * one the C raises on (`:5172-5175`): a complex source cannot be loaded into
    * a simple receiver, which is why `(Date.new(2001, 1, 1) + Rational(1, 2)).dup`
    * is an `ArgumentError` in MRI too — `Date`'s allocator is
@@ -6575,8 +6577,6 @@ export class Date {
         this.sg = bdat.sg;
         this.#civil = bdat.civil;
       } else {
-        // `:5150-5169`, the simple half widened into the complex arm: no day
-        // fraction, sub-second or offset to carry, so all three are zero.
         this.nth = bdat.nth;
         this.#jd = bdat.jd;
         this.#df = 0;
@@ -8450,10 +8450,9 @@ export class DateTime extends DateWithoutParseStatics {
   }
 
   /**
-   * The `ComplexDateData` half of {@link Date#dat} — `df`, `sf` and `of` are
+   * The `ComplexDateData` half of {@link Date#dat}: `df`, `sf` and `of` are
    * always live on a `DateTime`, and the time of day the proleptic-Gregorian
-   * arm of `datetime_initialize` stores instead of a day-fraction rides along
-   * with the civil triple it goes with.
+   * arm of `datetime_initialize` stores rides along with its civil triple.
    */
   override dat(): DateData {
     return {
@@ -8474,7 +8473,9 @@ export class DateTime extends DateWithoutParseStatics {
    * different data, and TS class fields are private to the class that declares
    * them — so `adat->c = bdat->c` (`:5176`) is spelled where `c` lives. A
    * `DateTime` is always complex, so the raise at `:5173-5175` cannot be
-   * reached from here; the simple-source arm is the C's `:5150-5169`.
+   * reached from here. On the simple-source arm (`:5150-5169`) the day is taken
+   * whole rather than left to a `get_c_jd` that would find no time of day
+   * beside the civil triple it copied.
    */
   override initializeCopy(date: Date): this {
     if (Object.isFrozen(this)) {
@@ -8484,9 +8485,6 @@ export class DateTime extends DateWithoutParseStatics {
     const bdat = date.dat();
     this.nth = bdat.nth;
     if (simpleDatP(date)) {
-      // A simple source has no day-fraction, sub-second or offset, and keeps
-      // its civil triple with no time of day beside it — so the day is taken
-      // whole rather than left to a `get_c_jd` that would find no time.
       this.#jd = bdat.jd ?? date.mLocalJd();
       this.#df = 0;
       this.#sf = new Rational(0, 1);

--- a/scripts/api-compare/build.test.ts
+++ b/scripts/api-compare/build.test.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import { afterAll, describe, expect, it } from "vitest";
 import {
   ANY_CLASS,
+  type MethodExpectation,
   DEFAULT_TAG_REASON,
   expectationKey,
   parseJsdoc,
@@ -15,6 +16,14 @@ import {
 } from "./build.js";
 import { serializeBaseline } from "./baseline-json.js";
 import { NARROW_DEFAULT_REASON } from "./missing-rails-call-tags.js";
+
+/** One expectation under {@link ANY_CLASS} — the key a `tsClass`-less artifact
+ *  row produces, which reconciles every declaration of the name in the file. */
+const anyClass = (
+  tsName: string,
+  rubyNames: string[],
+  calls: Set<string>,
+): [string, MethodExpectation] => [expectationKey(ANY_CLASS, tsName), { rubyNames, tsName, calls }];
 
 const reasonFor = () => DEFAULT_TAG_REASON;
 
@@ -143,14 +152,8 @@ const FILE = [
 describe("reconcileFileText", () => {
   it("reconciles: drops satisfied tags, adds tags, creates missing JSDoc", () => {
     const expectations = new Map([
-      [
-        expectationKey(ANY_CLASS, "bar"),
-        { rubyNames: ["bar"], tsName: "bar", calls: new Set(["save"]) },
-      ],
-      [
-        expectationKey(ANY_CLASS, "baz"),
-        { rubyNames: ["baz"], tsName: "baz", calls: new Set(["reload"]) },
-      ],
+      anyClass("bar", ["bar"], new Set(["save"])),
+      anyClass("baz", ["baz"], new Set(["reload"])),
     ]);
     const { text, harvested } = reconcileFileText("foo.ts", FILE, expectations, () => "why");
     expect(text).not.toBeNull();
@@ -166,12 +169,7 @@ describe("reconcileFileText", () => {
 
   it("produces zero edits when every missing call is still baselined by placeholder", () => {
     const src = ["export class Foo {", "  bar(): void {}", "}"].join("\n");
-    const expectations = new Map([
-      [
-        expectationKey(ANY_CLASS, "bar"),
-        { rubyNames: ["bar"], tsName: "bar", calls: new Set(["save"]) },
-      ],
-    ]);
+    const expectations = new Map([anyClass("bar", ["bar"], new Set(["save"]))]);
     const r = reconcileFileText("foo.ts", src, expectations, () => DEFAULT_TAG_REASON);
     expect(r.text).toBeNull();
     expect(r.skipped).toEqual(["save"]);
@@ -185,12 +183,7 @@ describe("reconcileFileText", () => {
       "  bar(): void {}",
       "}",
     ].join("\n");
-    const expectations = new Map([
-      [
-        expectationKey(ANY_CLASS, "bar"),
-        { rubyNames: ["bar"], tsName: "bar", calls: new Set(["save"]) },
-      ],
-    ]);
+    const expectations = new Map([anyClass("bar", ["bar"], new Set(["save"]))]);
     const r = reconcileFileText("foo.ts", src, expectations, () => DEFAULT_TAG_REASON);
     expect(r.text).toBeNull();
   });
@@ -202,14 +195,8 @@ describe("reconcileFileText", () => {
 
   it("is idempotent: a second run produces zero edits", () => {
     const expectations = new Map([
-      [
-        expectationKey(ANY_CLASS, "bar"),
-        { rubyNames: ["bar"], tsName: "bar", calls: new Set(["save"]) },
-      ],
-      [
-        expectationKey(ANY_CLASS, "baz"),
-        { rubyNames: ["baz"], tsName: "baz", calls: new Set(["reload"]) },
-      ],
+      anyClass("bar", ["bar"], new Set(["save"])),
+      anyClass("baz", ["baz"], new Set(["reload"])),
     ]);
     const first = reconcileFileText("foo.ts", FILE, expectations, () => "why").text!;
     const second = reconcileFileText("foo.ts", first, expectations, () => "why");
@@ -218,12 +205,7 @@ describe("reconcileFileText", () => {
 
   it("reconciles set accessors (extract-ts-api extracts them into the artifact)", () => {
     const src = ["export class Foo {", "  set name(v: string) {}", "}"].join("\n");
-    const expectations = new Map([
-      [
-        expectationKey(ANY_CLASS, "name"),
-        { rubyNames: ["name="], tsName: "name", calls: new Set(["write_attribute"]) },
-      ],
-    ]);
+    const expectations = new Map([anyClass("name", ["name="], new Set(["write_attribute"]))]);
     const { text } = reconcileFileText("foo.ts", src, expectations, () => "why");
     expect(text!).toContain("@missingRailsCall write_attribute — why");
   });
@@ -234,12 +216,7 @@ describe("reconcileFileText", () => {
     const reason =
       "Per-entry verified (RFC 0032): Rails core.rb caches `klass.primary_key` into " +
       "@primary_key and calls `klass.define_attribute_methods`; neither call appears here.";
-    const expectations = new Map([
-      [
-        expectationKey(ANY_CLASS, "bar"),
-        { rubyNames: ["bar"], tsName: "bar", calls: new Set(["primary_key"]) },
-      ],
-    ]);
+    const expectations = new Map([anyClass("bar", ["bar"], new Set(["primary_key"]))]);
     const first = reconcileFileText("foo.ts", src, expectations, () => reason).text!;
     const second = reconcileFileText("foo.ts", first, expectations, () => reason);
     expect(second.text).toBeNull();
@@ -251,14 +228,8 @@ describe("reconcileFileText", () => {
   it("tags constructors (Ruby initialize) and reports unmatched expectations", () => {
     const src = ["export class Foo {", "  constructor() {}", "}"].join("\n");
     const expectations = new Map([
-      [
-        expectationKey(ANY_CLASS, "constructor"),
-        { rubyNames: ["initialize"], tsName: "constructor", calls: new Set(["super"]) },
-      ],
-      [
-        expectationKey(ANY_CLASS, "prototypePatched"),
-        { rubyNames: ["patched"], tsName: "prototypePatched", calls: new Set(["save"]) },
-      ],
+      anyClass("constructor", ["initialize"], new Set(["super"])),
+      anyClass("prototypePatched", ["patched"], new Set(["save"])),
     ]);
     const { text, unmatched } = reconcileFileText("foo.ts", src, expectations, () => "why");
     expect(text!).toContain("@missingRailsCall super — why");
@@ -312,14 +283,8 @@ describe("reconcileFileText", () => {
 describe("reconcileFileText baseline migration", () => {
   it("reports every justified (rubyName, call) so the baseline row can be dropped", () => {
     const expectations = new Map([
-      [
-        expectationKey(ANY_CLASS, "bar"),
-        { rubyNames: ["bar"], tsName: "bar", calls: new Set(["save"]) },
-      ],
-      [
-        expectationKey(ANY_CLASS, "baz"),
-        { rubyNames: ["baz"], tsName: "baz", calls: new Set(["reload"]) },
-      ],
+      anyClass("bar", ["bar"], new Set(["save"])),
+      anyClass("baz", ["baz"], new Set(["reload"])),
     ]);
     const { tagged } = reconcileFileText("foo.ts", FILE, expectations, () => "why");
     expect(tagged).toEqual([
@@ -329,12 +294,7 @@ describe("reconcileFileText baseline migration", () => {
   });
 
   it("reports a KEPT tag too — an already-tagged call owes no baseline row", () => {
-    const expectations = new Map([
-      [
-        expectationKey(ANY_CLASS, "bar"),
-        { rubyNames: ["bar"], tsName: "bar", calls: new Set(["save"]) },
-      ],
-    ]);
+    const expectations = new Map([anyClass("bar", ["bar"], new Set(["save"]))]);
     const first = reconcileFileText("foo.ts", FILE, expectations, () => "why").text!;
     const { tagged } = reconcileFileText("foo.ts", first, expectations, () => "why");
     expect(tagged).toEqual([{ rubyName: "bar", call: "save" }]);
@@ -430,23 +390,13 @@ describe("buildExpectations", () => {
   });
 
   it("leaves a placeholder-reasoned row in the baseline — it justifies nothing", () => {
-    const expectations = new Map([
-      [
-        expectationKey(ANY_CLASS, "bar"),
-        { rubyNames: ["bar"], tsName: "bar", calls: new Set(["save"]) },
-      ],
-    ]);
+    const expectations = new Map([anyClass("bar", ["bar"], new Set(["save"]))]);
     const { tagged } = reconcileFileText("foo.ts", FILE, expectations, () => DEFAULT_TAG_REASON);
     expect(tagged).toEqual([]);
   });
 
   it("mints no tag for a narrow-seeded row either, matching the wide policy", () => {
-    const expectations = new Map([
-      [
-        expectationKey(ANY_CLASS, "bar"),
-        { rubyNames: ["bar"], tsName: "bar", calls: new Set(["save"]) },
-      ],
-    ]);
+    const expectations = new Map([anyClass("bar", ["bar"], new Set(["save"]))]);
     const { text, tagged, skipped } = reconcileFileText(
       "foo.ts",
       FILE,
@@ -487,12 +437,7 @@ describe("buildExpectations", () => {
 
 describe("reconcileFileText with two Ruby names on one TS method", () => {
   it("drops the baseline row of each Ruby name a justified tag covers", () => {
-    const expectations = new Map([
-      [
-        expectationKey(ANY_CLASS, "bar"),
-        { rubyNames: ["bar", "bar_all"], tsName: "bar", calls: new Set(["save"]) },
-      ],
-    ]);
+    const expectations = new Map([anyClass("bar", ["bar", "bar_all"], new Set(["save"]))]);
     const { tagged } = reconcileFileText("foo.ts", FILE, expectations, () => "why");
     expect(tagged).toEqual([
       { rubyName: "bar", call: "save" },
@@ -501,12 +446,7 @@ describe("reconcileFileText with two Ruby names on one TS method", () => {
   });
 
   it("seeds a new tag from whichever Ruby name has curated prose", () => {
-    const expectations = new Map([
-      [
-        expectationKey(ANY_CLASS, "bar"),
-        { rubyNames: ["bar", "bar_all"], tsName: "bar", calls: new Set(["save"]) },
-      ],
-    ]);
+    const expectations = new Map([anyClass("bar", ["bar", "bar_all"], new Set(["save"]))]);
     const { text } = reconcileFileText("foo.ts", FILE, expectations, (rubyName) =>
       rubyName === "bar_all" ? "curated" : DEFAULT_TAG_REASON,
     );

--- a/scripts/api-compare/build.test.ts
+++ b/scripts/api-compare/build.test.ts
@@ -3,7 +3,9 @@ import * as os from "os";
 import * as path from "path";
 import { afterAll, describe, expect, it } from "vitest";
 import {
+  ANY_CLASS,
   DEFAULT_TAG_REASON,
+  expectationKey,
   parseJsdoc,
   reconcile,
   reconcileFileText,
@@ -141,8 +143,14 @@ const FILE = [
 describe("reconcileFileText", () => {
   it("reconciles: drops satisfied tags, adds tags, creates missing JSDoc", () => {
     const expectations = new Map([
-      ["bar", { rubyNames: ["bar"], calls: new Set(["save"]) }],
-      ["baz", { rubyNames: ["baz"], calls: new Set(["reload"]) }],
+      [
+        expectationKey(ANY_CLASS, "bar"),
+        { rubyNames: ["bar"], tsName: "bar", calls: new Set(["save"]) },
+      ],
+      [
+        expectationKey(ANY_CLASS, "baz"),
+        { rubyNames: ["baz"], tsName: "baz", calls: new Set(["reload"]) },
+      ],
     ]);
     const { text, harvested } = reconcileFileText("foo.ts", FILE, expectations, () => "why");
     expect(text).not.toBeNull();
@@ -158,7 +166,12 @@ describe("reconcileFileText", () => {
 
   it("produces zero edits when every missing call is still baselined by placeholder", () => {
     const src = ["export class Foo {", "  bar(): void {}", "}"].join("\n");
-    const expectations = new Map([["bar", { rubyNames: ["bar"], calls: new Set(["save"]) }]]);
+    const expectations = new Map([
+      [
+        expectationKey(ANY_CLASS, "bar"),
+        { rubyNames: ["bar"], tsName: "bar", calls: new Set(["save"]) },
+      ],
+    ]);
     const r = reconcileFileText("foo.ts", src, expectations, () => DEFAULT_TAG_REASON);
     expect(r.text).toBeNull();
     expect(r.skipped).toEqual(["save"]);
@@ -172,7 +185,12 @@ describe("reconcileFileText", () => {
       "  bar(): void {}",
       "}",
     ].join("\n");
-    const expectations = new Map([["bar", { rubyNames: ["bar"], calls: new Set(["save"]) }]]);
+    const expectations = new Map([
+      [
+        expectationKey(ANY_CLASS, "bar"),
+        { rubyNames: ["bar"], tsName: "bar", calls: new Set(["save"]) },
+      ],
+    ]);
     const r = reconcileFileText("foo.ts", src, expectations, () => DEFAULT_TAG_REASON);
     expect(r.text).toBeNull();
   });
@@ -184,8 +202,14 @@ describe("reconcileFileText", () => {
 
   it("is idempotent: a second run produces zero edits", () => {
     const expectations = new Map([
-      ["bar", { rubyNames: ["bar"], calls: new Set(["save"]) }],
-      ["baz", { rubyNames: ["baz"], calls: new Set(["reload"]) }],
+      [
+        expectationKey(ANY_CLASS, "bar"),
+        { rubyNames: ["bar"], tsName: "bar", calls: new Set(["save"]) },
+      ],
+      [
+        expectationKey(ANY_CLASS, "baz"),
+        { rubyNames: ["baz"], tsName: "baz", calls: new Set(["reload"]) },
+      ],
     ]);
     const first = reconcileFileText("foo.ts", FILE, expectations, () => "why").text!;
     const second = reconcileFileText("foo.ts", first, expectations, () => "why");
@@ -195,7 +219,10 @@ describe("reconcileFileText", () => {
   it("reconciles set accessors (extract-ts-api extracts them into the artifact)", () => {
     const src = ["export class Foo {", "  set name(v: string) {}", "}"].join("\n");
     const expectations = new Map([
-      ["name", { rubyNames: ["name="], calls: new Set(["write_attribute"]) }],
+      [
+        expectationKey(ANY_CLASS, "name"),
+        { rubyNames: ["name="], tsName: "name", calls: new Set(["write_attribute"]) },
+      ],
     ]);
     const { text } = reconcileFileText("foo.ts", src, expectations, () => "why");
     expect(text!).toContain("@missingRailsCall write_attribute — why");
@@ -208,7 +235,10 @@ describe("reconcileFileText", () => {
       "Per-entry verified (RFC 0032): Rails core.rb caches `klass.primary_key` into " +
       "@primary_key and calls `klass.define_attribute_methods`; neither call appears here.";
     const expectations = new Map([
-      ["bar", { rubyNames: ["bar"], calls: new Set(["primary_key"]) }],
+      [
+        expectationKey(ANY_CLASS, "bar"),
+        { rubyNames: ["bar"], tsName: "bar", calls: new Set(["primary_key"]) },
+      ],
     ]);
     const first = reconcileFileText("foo.ts", src, expectations, () => reason).text!;
     const second = reconcileFileText("foo.ts", first, expectations, () => reason);
@@ -221,8 +251,14 @@ describe("reconcileFileText", () => {
   it("tags constructors (Ruby initialize) and reports unmatched expectations", () => {
     const src = ["export class Foo {", "  constructor() {}", "}"].join("\n");
     const expectations = new Map([
-      ["constructor", { rubyNames: ["initialize"], calls: new Set(["super"]) }],
-      ["prototypePatched", { rubyNames: ["patched"], calls: new Set(["save"]) }],
+      [
+        expectationKey(ANY_CLASS, "constructor"),
+        { rubyNames: ["initialize"], tsName: "constructor", calls: new Set(["super"]) },
+      ],
+      [
+        expectationKey(ANY_CLASS, "prototypePatched"),
+        { rubyNames: ["patched"], tsName: "prototypePatched", calls: new Set(["save"]) },
+      ],
     ]);
     const { text, unmatched } = reconcileFileText("foo.ts", src, expectations, () => "why");
     expect(text!).toContain("@missingRailsCall super — why");
@@ -235,7 +271,9 @@ describe("reconcileFileText", () => {
       "export function f(a: number): void;",
       "export function f(a: unknown): void {}",
     ].join("\n");
-    const expectations = new Map([["f", { rubyNames: ["f"], calls: new Set(["save"]) }]]);
+    const expectations = new Map([
+      [expectationKey(ANY_CLASS, "f"), { rubyNames: ["f"], tsName: "f", calls: new Set(["save"]) }],
+    ]);
     const { text } = reconcileFileText("foo.ts", src, expectations, () => "why");
     expect(text!.match(/@missingRailsCall save/g)).toHaveLength(1);
     expect(text!.indexOf("@missingRailsCall")).toBeGreaterThan(text!.indexOf("f(a: number)"));
@@ -274,8 +312,14 @@ describe("reconcileFileText", () => {
 describe("reconcileFileText baseline migration", () => {
   it("reports every justified (rubyName, call) so the baseline row can be dropped", () => {
     const expectations = new Map([
-      ["bar", { rubyNames: ["bar"], calls: new Set(["save"]) }],
-      ["baz", { rubyNames: ["baz"], calls: new Set(["reload"]) }],
+      [
+        expectationKey(ANY_CLASS, "bar"),
+        { rubyNames: ["bar"], tsName: "bar", calls: new Set(["save"]) },
+      ],
+      [
+        expectationKey(ANY_CLASS, "baz"),
+        { rubyNames: ["baz"], tsName: "baz", calls: new Set(["reload"]) },
+      ],
     ]);
     const { tagged } = reconcileFileText("foo.ts", FILE, expectations, () => "why");
     expect(tagged).toEqual([
@@ -285,10 +329,67 @@ describe("reconcileFileText baseline migration", () => {
   });
 
   it("reports a KEPT tag too — an already-tagged call owes no baseline row", () => {
-    const expectations = new Map([["bar", { rubyNames: ["bar"], calls: new Set(["save"]) }]]);
+    const expectations = new Map([
+      [
+        expectationKey(ANY_CLASS, "bar"),
+        { rubyNames: ["bar"], tsName: "bar", calls: new Set(["save"]) },
+      ],
+    ]);
     const first = reconcileFileText("foo.ts", FILE, expectations, () => "why").text!;
     const { tagged } = reconcileFileText("foo.ts", first, expectations, () => "why");
     expect(tagged).toEqual([{ rubyName: "bar", call: "save" }]);
+  });
+});
+
+describe("class-qualified expectations", () => {
+  // Two same-named methods in one file, as `connection-pool.ts` has:
+  // Rails' NullPool takes no mutex and defines no `checkout` at all
+  // (connection_adapters/abstract/connection_pool.rb:14-42), so only
+  // ConnectionPool's copy is the artifact's match.
+  const src = [
+    "export class ConnectionPool {",
+    "  checkout(): void {}",
+    "}",
+    "",
+    "export class NullPool {",
+    "  checkout(): void {}",
+    "}",
+  ].join("\n");
+  const artifact = {
+    packages: ["activerecord"],
+    mismatches: [
+      {
+        package: "activerecord",
+        tsFile: "connection-pool.ts",
+        rubyName: "checkout",
+        tsName: "checkout",
+        tsClass: "ConnectionPool",
+        missing: ["synchronize → synchronize"],
+      },
+    ],
+  };
+
+  it("mints the tag only on the class the artifact matched", () => {
+    const expectations = buildExpectations(artifact, "activerecord").get("connection-pool.ts")!;
+    const { text } = reconcileFileText("connection-pool.ts", src, expectations, () => "why");
+    expect(text).not.toBeNull();
+    expect(text!.match(/@missingRailsCall synchronize/g)).toHaveLength(1);
+    expect(text!).toContain(
+      ["export class ConnectionPool {", "  /**", "   * @missingRailsCall synchronize — why"].join(
+        "\n",
+      ),
+    );
+    expect(text!).toContain(["export class NullPool {", "  checkout(): void {}"].join("\n"));
+  });
+
+  it("reconciles every declaration of the name when the artifact resolved no class", () => {
+    const unqualified = {
+      ...artifact,
+      mismatches: [{ ...artifact.mismatches[0], tsClass: undefined }],
+    };
+    const expectations = buildExpectations(unqualified, "activerecord").get("connection-pool.ts")!;
+    const { text } = reconcileFileText("connection-pool.ts", src, expectations, () => "why");
+    expect(text!.match(/@missingRailsCall synchronize/g)).toHaveLength(2);
   });
 });
 
@@ -319,7 +420,7 @@ describe("buildExpectations", () => {
   it("keeps a suppressed call expected, so the tag that earned it survives", () => {
     const calls = buildExpectations(artifact, "arel")
       .get("insert-manager.ts")!
-      .get("insert")!.calls;
+      .get(expectationKey(ANY_CLASS, "insert"))!.calls;
     expect([...calls].sort()).toEqual(["each", "first"]);
   });
 
@@ -329,13 +430,23 @@ describe("buildExpectations", () => {
   });
 
   it("leaves a placeholder-reasoned row in the baseline — it justifies nothing", () => {
-    const expectations = new Map([["bar", { rubyNames: ["bar"], calls: new Set(["save"]) }]]);
+    const expectations = new Map([
+      [
+        expectationKey(ANY_CLASS, "bar"),
+        { rubyNames: ["bar"], tsName: "bar", calls: new Set(["save"]) },
+      ],
+    ]);
     const { tagged } = reconcileFileText("foo.ts", FILE, expectations, () => DEFAULT_TAG_REASON);
     expect(tagged).toEqual([]);
   });
 
   it("mints no tag for a narrow-seeded row either, matching the wide policy", () => {
-    const expectations = new Map([["bar", { rubyNames: ["bar"], calls: new Set(["save"]) }]]);
+    const expectations = new Map([
+      [
+        expectationKey(ANY_CLASS, "bar"),
+        { rubyNames: ["bar"], tsName: "bar", calls: new Set(["save"]) },
+      ],
+    ]);
     const { text, tagged, skipped } = reconcileFileText(
       "foo.ts",
       FILE,
@@ -367,7 +478,9 @@ describe("buildExpectations", () => {
         },
       ],
     };
-    const exp = buildExpectations(twoNames, "arel").get("insert-manager.ts")!.get("insert")!;
+    const exp = buildExpectations(twoNames, "arel")
+      .get("insert-manager.ts")!
+      .get(expectationKey(ANY_CLASS, "insert"))!;
     expect(exp.rubyNames).toEqual(["insert", "insert_all"]);
   });
 });
@@ -375,7 +488,10 @@ describe("buildExpectations", () => {
 describe("reconcileFileText with two Ruby names on one TS method", () => {
   it("drops the baseline row of each Ruby name a justified tag covers", () => {
     const expectations = new Map([
-      ["bar", { rubyNames: ["bar", "bar_all"], calls: new Set(["save"]) }],
+      [
+        expectationKey(ANY_CLASS, "bar"),
+        { rubyNames: ["bar", "bar_all"], tsName: "bar", calls: new Set(["save"]) },
+      ],
     ]);
     const { tagged } = reconcileFileText("foo.ts", FILE, expectations, () => "why");
     expect(tagged).toEqual([
@@ -386,7 +502,10 @@ describe("reconcileFileText with two Ruby names on one TS method", () => {
 
   it("seeds a new tag from whichever Ruby name has curated prose", () => {
     const expectations = new Map([
-      ["bar", { rubyNames: ["bar", "bar_all"], calls: new Set(["save"]) }],
+      [
+        expectationKey(ANY_CLASS, "bar"),
+        { rubyNames: ["bar", "bar_all"], tsName: "bar", calls: new Set(["save"]) },
+      ],
     ]);
     const { text } = reconcileFileText("foo.ts", FILE, expectations, (rubyName) =>
       rubyName === "bar_all" ? "curated" : DEFAULT_TAG_REASON,

--- a/scripts/api-compare/build.ts
+++ b/scripts/api-compare/build.ts
@@ -90,6 +90,11 @@ export interface ArtifactMismatch {
   tsFile: string;
   rubyName: string;
   tsName: string;
+  /** The class declaring `tsName`, when compare.ts could resolve one for the
+   *  matched pair (see `resolveTsOwner`). A tag is minted on THAT declaration
+   *  alone; absent, every declaration of the name in the file is reconciled,
+   *  as before this was keyed. */
+  tsClass?: string;
   missing: string[];
 }
 
@@ -98,6 +103,8 @@ export interface SuppressedCall {
   tsFile: string;
   rubyName: string;
   tsName: string;
+  /** See `ArtifactMismatch.tsClass`. */
+  tsClass?: string;
   call: string;
 }
 
@@ -202,9 +209,12 @@ export function renderJsdoc(rest: string[], entries: TagEntry[], indent: string)
     return oneLineProse(body[0]) === "" ? null : body[0];
   }
   // Normalize a one-line `/** ... */` comment to block form when tags exist.
+  // Its opener replaces the existing comment IN PLACE, after the declaration
+  // line's own indent — so, unlike the synthesized block above, it must not
+  // carry one of its own.
   if (ordered.length > 0 && body.length === 1) {
     const inner = oneLineProse(body[0]);
-    body = [`${indent}/**`, ...(inner ? [`${indent} * ${inner}`] : []), `${indent} */`];
+    body = ["/**", ...(inner ? [`${indent} * ${inner}`] : []), `${indent} */`];
   }
   const closeIdx = body.findIndex((l) => l.trim().endsWith("*/"));
   const head = body.slice(0, closeIdx);
@@ -228,6 +238,18 @@ interface Edit {
   text: string;
 }
 
+/** Key for one expectation: the declaration a tag belongs on. `tsClass` is the
+ *  declaring class, `""` for a top-level function, and `ANY_CLASS` when
+ *  compare.ts could not resolve one — the last matching any declaration of the
+ *  name in the file. */
+export function expectationKey(tsClass: string, tsName: string): string {
+  return `${tsClass}\u0000${tsName}`;
+}
+
+/** Stands in for a class in {@link expectationKey} when the artifact carries
+ *  none. */
+export const ANY_CLASS = "*";
+
 export interface MethodExpectation {
   /** Every Ruby method name matched onto this TS name, in artifact order. Two
    *  Ruby names can land on one TS method, and each keys its own baseline rows
@@ -235,6 +257,8 @@ export interface MethodExpectation {
    *  row of each, so a second Ruby name's deviation is not attributed to the
    *  first. */
   rubyNames: string[];
+  /** The declaration's TS name, since the map key is class-qualified. */
+  tsName: string;
   calls: Set<string>;
 }
 
@@ -285,14 +309,20 @@ export function reconcileFileText(
   const seen = new Set<string>();
   const skipped: string[] = [];
 
+  // The class a declaration is written in, `""` at the top level. Expectations
+  // are keyed by it, so a tag is minted only on the declaration whose Ruby
+  // counterpart actually makes the call — never on a same-named sibling in
+  // another class of the same file (`NullPool#checkout`, which Rails does not
+  // even define, next to `ConnectionPool#checkout`).
+  const enclosingClassName = (node: ts.Node): string => {
+    for (let p = node.parent; p; p = p.parent) {
+      if (ts.isClassDeclaration(p) || ts.isClassExpression(p)) return p.name?.text ?? "";
+    }
+    return "";
+  };
+
   const visit = (node: ts.Node): void => {
     let name: string | null = null;
-    // KNOWN LIMITATION: expectations are keyed by bare identifier name per
-    // file (mirroring compare.ts's tsCallsByFileName), so two same-named
-    // methods in one file (STI siblings, mixin + host, get/set accessor
-    // pairs) are reconciled against the SAME expected-call set. Unlike the
-    // lints this tool writes to source, so a shared name can stamp tags onto
-    // a sibling they don't belong to — qualify by class if this ever bites.
     // Only body-bearing declarations: overload SIGNATURES (and interface /
     // ambient members) must not be stamped — tagging each overload duplicates
     // the block once per signature (found by the activerecord-wide run).
@@ -312,8 +342,11 @@ export function reconcileFileText(
       name = "constructor";
     }
     if (name !== null) {
-      seen.add(name);
-      const exp = expectations.get(name);
+      const key = expectationKey(enclosingClassName(node), name);
+      const anyKey = expectationKey(ANY_CLASS, name);
+      seen.add(key);
+      if (expectations.has(anyKey)) seen.add(anyKey);
+      const exp = expectations.get(key) ?? expectations.get(anyKey);
       const ranges = ts.getLeadingCommentRanges(text, node.getFullStart()) ?? [];
       const jsdocRange = ranges.filter((r) => text.slice(r.pos, r.pos + 3) === "/**").at(-1);
       const comment = jsdocRange ? text.slice(jsdocRange.pos, jsdocRange.end) : null;
@@ -367,7 +400,10 @@ export function reconcileFileText(
   };
   visit(sf);
 
-  const unmatched = [...expectations.keys()].filter((n) => !seen.has(n)).sort();
+  const unmatched = [...expectations.entries()]
+    .filter(([k]) => !seen.has(k))
+    .map(([, e]) => e.tsName)
+    .sort();
   if (edits.length === 0) return { text: null, harvested, tagged, unmatched, skipped };
   let out = text;
   for (const e of edits.sort((a, b) => b.start - a.start)) {
@@ -387,23 +423,29 @@ export function buildExpectations(
   onlyFile?: string,
 ): Map<string, Map<string, MethodExpectation>> {
   const byFile = new Map<string, Map<string, MethodExpectation>>();
-  const expectationFor = (tsFile: string, tsName: string, rubyName: string) => {
+  const expectationFor = (
+    tsFile: string,
+    tsName: string,
+    tsClass: string | undefined,
+    rubyName: string,
+  ) => {
     const fileMap = byFile.get(tsFile) ?? byFile.set(tsFile, new Map()).get(tsFile)!;
+    const key = expectationKey(tsClass ?? ANY_CLASS, tsName);
     const exp =
-      fileMap.get(tsName) ?? fileMap.set(tsName, { rubyNames: [], calls: new Set() }).get(tsName)!;
+      fileMap.get(key) ?? fileMap.set(key, { rubyNames: [], tsName, calls: new Set() }).get(key)!;
     if (!exp.rubyNames.includes(rubyName)) exp.rubyNames.push(rubyName);
     return exp;
   };
   for (const m of artifact.mismatches) {
     if (m.package !== pkg) continue;
     if (onlyFile && m.tsFile !== onlyFile) continue;
-    const exp = expectationFor(m.tsFile, m.tsName, m.rubyName);
+    const exp = expectationFor(m.tsFile, m.tsName, m.tsClass, m.rubyName);
     for (const missing of m.missing) exp.calls.add(callOf(missing));
   }
   for (const c of artifact.suppressed ?? []) {
     if (c.package !== pkg) continue;
     if (onlyFile && c.tsFile !== onlyFile) continue;
-    expectationFor(c.tsFile, c.tsName, c.rubyName).calls.add(c.call);
+    expectationFor(c.tsFile, c.tsName, c.tsClass, c.rubyName).calls.add(c.call);
   }
   return byFile;
 }

--- a/scripts/api-compare/build.ts
+++ b/scripts/api-compare/build.ts
@@ -209,9 +209,8 @@ export function renderJsdoc(rest: string[], entries: TagEntry[], indent: string)
     return oneLineProse(body[0]) === "" ? null : body[0];
   }
   // Normalize a one-line `/** ... */` comment to block form when tags exist.
-  // Its opener replaces the existing comment IN PLACE, after the declaration
-  // line's own indent — so, unlike the synthesized block above, it must not
-  // carry one of its own.
+  // Its opener replaces the comment IN PLACE, after the declaration line's own
+  // indent, so — unlike the synthesized block above — it carries none itself.
   if (ordered.length > 0 && body.length === 1) {
     const inner = oneLineProse(body[0]);
     body = ["/**", ...(inner ? [`${indent} * ${inner}`] : []), `${indent} */`];
@@ -309,11 +308,8 @@ export function reconcileFileText(
   const seen = new Set<string>();
   const skipped: string[] = [];
 
-  // The class a declaration is written in, `""` at the top level. Expectations
-  // are keyed by it, so a tag is minted only on the declaration whose Ruby
-  // counterpart actually makes the call — never on a same-named sibling in
-  // another class of the same file (`NullPool#checkout`, which Rails does not
-  // even define, next to `ConnectionPool#checkout`).
+  // The class a declaration is written in — `""` at the top level — which is
+  // half of the {@link expectationKey} a tag is minted under.
   const enclosingClassName = (node: ts.Node): string => {
     for (let p = node.parent; p; p = p.parent) {
       if (ts.isClassDeclaration(p) || ts.isClassExpression(p)) return p.name?.text ?? "";

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods.json
@@ -94,13 +94,6 @@
     "package": "activerecord",
     "tsFile": "attribute-methods.ts",
     "rubyName": "initialize_generated_modules",
-    "call": "include",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails attribute_methods.rb:42-50 does `include @generated_attribute_methods`; trails attribute-methods.ts:257-259 assigns a GeneratedAttributeMethods holder instance — no Module#include in TS, the holder is consulted directly."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods.ts",
-    "rubyName": "initialize_generated_modules",
     "call": "new",
     "kind": "args",
     "rubyArgs": [],
@@ -126,13 +119,6 @@
     "rubyName": "instance_method_already_implemented?",
     "call": "owner",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods.ts",
-    "rubyName": "method_defined_within?",
-    "call": "owner",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails attribute_methods.rb:187-197 compares `instance_method(name).owner` across class and superclass; trails attribute-methods.ts:508-517 uses `name in klass.prototype` vs `name in superklass.prototype` — the prototype chain check replaces Method#owner introspection."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-adapter.json
@@ -91,13 +91,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-adapter.ts",
     "rubyName": "initialize",
-    "call": "disable_prepared_statements",
-    "reason": "Bucket (b): Rails reads `ActiveRecord.disable_prepared_statements` inline in `initialize` (abstract_adapter.rb:159); the port applies it in the `preparedStatements` setter (abstract-adapter.ts:1058), the chokepoint the constructor and every (re-)establishConnection flow through."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-adapter.ts",
-    "rubyName": "initialize",
     "call": "fetch",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql-adapter.json
@@ -30,20 +30,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "change_column_for_alter",
-    "call": "new",
-    "reason": "Rails builds the deferred half of the ALTER with `Proc.new { ... }` (postgresql/schema_statements.rb:1054, :1062); the TS body uses an arrow function, the JS analogue, so there is no `new` to match."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "change_column_null_for_alter",
-    "call": "new",
-    "reason": "Rails builds the deferred half of the ALTER with `Proc.new { ... }` (postgresql/schema_statements.rb:1054, :1062); the TS body uses an arrow function, the JS analogue, so there is no `new` to match."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "configure_connection",
     "call": "fetch",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -86,13 +72,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "disable_extension",
-    "call": "values_at",
-    "reason": "Per-entry verified (RFC 0072 converge-pg-extension-cluster-onto-internal-exec-query): Ruby's `split(\".\").values_at(-2, -1)` discards the schema half; postgresql-adapter.ts#disableExtension takes `parts.at(-1)` directly, which is the same value."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "disable_referential_integrity",
     "call": "collect",
     "reason": "The body lives in postgresql/referential-integrity.ts — Rails houses it in the ReferentialIntegrity module too (postgresql/referential_integrity.rb:5-36) — and makes both calls there; the adapter member is the include seam."
@@ -103,13 +82,6 @@
     "rubyName": "disable_referential_integrity",
     "call": "quote_table_name",
     "reason": "The body lives in postgresql/referential-integrity.ts — Rails houses it in the ReferentialIntegrity module too (postgresql/referential_integrity.rb:5-36) — and makes both calls there; the adapter member is the include seam."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "enable_extension",
-    "call": "values_at",
-    "reason": "Per-entry verified (RFC 0072 converge-pg-extension-cluster-onto-internal-exec-query): Ruby's `split(\".\").values_at(-2, -1)` has no JS analogue; postgresql-adapter.ts#enableExtension expresses the identical destructuring as `[parts.at(-2) ?? null, parts.at(-1)]`, giving nil-schema for a bare name."
   },
   {
     "package": "activerecord",
@@ -168,13 +140,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "foreign_table_exists?",
-    "call": "any?",
-    "reason": "Ruby-ism: `query_values(...).any?` is `names.length > 0` in TS; `length` is a property access, not a call."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "foreign_tables",
     "call": "data_source_sql",
     "kind": "args",
@@ -224,20 +189,6 @@
     "rubyName": "prepare_statement",
     "call": "translate_exception_class",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "quote",
-    "call": "check_int_in_range",
-    "reason": "Equivalent (RFC 0072 activerecord-unrouted-privates-remaining-inventory): `checkIntInRange` is a bare alias — `export const checkIntInRange = checkIntegerRange` — so the routed call is the alias target and the extractor never sees the alias name. Nothing to converge."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "quote_string",
-    "call": "with_raw_connection",
-    "reason": "Language shortcoming: Rails' quote_string escapes through the live connection (`with_raw_connection { |c| c.escape(s) }`, postgresql/quoting.rb:127-131), but node-postgres exposes no escape entry point at all — sync or async — and `quote_string` is a sync method every `quote` call site depends on. The override reproduces libpq's standard_conforming_strings escaping inline in postgresql/quoting.ts (same divergence already baselined for that module's quote_string)."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -34,8 +34,10 @@ import {
   reachedSameFileMethods,
   callTagKey,
   splitOverriddenFileBuckets,
+  resolveTsOwner,
   staleCallTags,
   suppressTaggedCalls,
+  tagsForOwner,
 } from "./compare.js";
 import { rubyMethodToTs } from "@blazetrails/parity/conventions";
 import type {
@@ -1656,17 +1658,26 @@ describe("suppressTaggedCalls", () => {
 });
 
 describe("staleCallTags", () => {
-  const tags = new Map([["relation.ts", new Map([["load", new Set(["synchronize", "reload"])]])]]);
+  const tags = new Map([
+    [
+      "relation.ts",
+      new Map([["load", new Map([["Relation", new Set(["synchronize", "reload"])]])]]),
+    ],
+  ]);
 
   it("reports a tag whose call no longer flags on a compared method", () => {
-    const used = new Map([[callTagKey("relation.ts", "load"), new Set(["synchronize"])]]);
+    const used = new Map([
+      [callTagKey("relation.ts", "Relation", "load"), new Set(["synchronize"])],
+    ]);
     expect(staleCallTags(tags, used)).toEqual([
       { tsFile: "relation.ts", tsName: "load", call: "reload" },
     ]);
   });
 
   it("reports nothing while every tag still suppresses", () => {
-    const used = new Map([[callTagKey("relation.ts", "load"), new Set(["synchronize", "reload"])]]);
+    const used = new Map([
+      [callTagKey("relation.ts", "Relation", "load"), new Set(["synchronize", "reload"])],
+    ]);
     expect(staleCallTags(tags, used)).toEqual([]);
   });
 
@@ -1676,13 +1687,73 @@ describe("staleCallTags", () => {
 
   it("keys tags to their own file, so a same-named method elsewhere is untouched", () => {
     const twoFiles = new Map([
-      ["relation.ts", new Map([["load", new Set(["synchronize"])]])],
-      ["core.ts", new Map([["load", new Set(["synchronize"])]])],
+      ["relation.ts", new Map([["load", new Map([["Relation", new Set(["synchronize"])]])]])],
+      ["core.ts", new Map([["load", new Map([["Core", new Set(["synchronize"])]])]])],
     ]);
-    const used = new Map([[callTagKey("core.ts", "load"), new Set<string>()]]);
+    const used = new Map([[callTagKey("core.ts", "Core", "load"), new Set<string>()]]);
     expect(staleCallTags(twoFiles, used)).toEqual([
       { tsFile: "core.ts", tsName: "load", call: "synchronize" },
     ]);
+  });
+
+  it("keys tags to their own class, so a sibling in the same file is untouched", () => {
+    const twoClasses = new Map([
+      [
+        "connection-pool.ts",
+        new Map([
+          [
+            "checkout",
+            new Map([
+              ["ConnectionPool", new Set(["synchronize"])],
+              ["NullPool", new Set(["synchronize"])],
+            ]),
+          ],
+        ]),
+      ],
+    ]);
+    const used = new Map([
+      [callTagKey("connection-pool.ts", "ConnectionPool", "checkout"), new Set(["synchronize"])],
+    ]);
+    expect(staleCallTags(twoClasses, used)).toEqual([]);
+  });
+});
+
+describe("resolveTsOwner", () => {
+  it("takes the sole declaring class without consulting the Ruby name", () => {
+    expect(resolveTsOwner(new Set(["ConnectionPool"]), "ActiveRecord::Base")).toBe(
+      "ConnectionPool",
+    );
+  });
+
+  it("picks the class named after the Ruby entity when a file declares several", () => {
+    const owners = new Set(["ConnectionPool", "NullPool"]);
+    expect(resolveTsOwner(owners, "ActiveRecord::ConnectionAdapters::NullPool")).toBe("NullPool");
+  });
+
+  it("resolves nothing when no declaring class carries the Ruby name", () => {
+    const owners = new Set(["ConnectionPool", "NullPool"]);
+    expect(resolveTsOwner(owners, "ActiveRecord::ConnectionAdapters::PoolConfig")).toBeUndefined();
+  });
+});
+
+describe("tagsForOwner", () => {
+  const byClass = new Map([
+    ["ConnectionPool", new Set(["synchronize"])],
+    ["NullPool", new Set(["reload"])],
+  ]);
+
+  it("reads only the resolved owner's tags", () => {
+    expect([...tagsForOwner(byClass, "ConnectionPool")!]).toEqual(["synchronize"]);
+  });
+
+  it("gives an owner with no tags of its own nothing from its siblings", () => {
+    expect(tagsForOwner(new Map([["NullPool", new Set(["synchronize"])]]), "ConnectionPool")).toBe(
+      undefined,
+    );
+  });
+
+  it("falls back to the union when the owner is unresolved", () => {
+    expect([...tagsForOwner(byClass, undefined)!].sort()).toEqual(["reload", "synchronize"]);
   });
 });
 

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -1950,12 +1950,10 @@ export function main() {
     const tsCallSeqByFileName = new Map<string, Map<string, string[][]>>();
     const tsSkeletonByFileName = new Map<string, Map<string, string[][]>>();
     const tsCallArgsByFileName = new Map<string, Map<string, CallSite[][]>>();
-    // (file → name → declaring class → tagged calls). Qualified by class so a
-    // tag on one class never speaks for a same-named sibling in the same file;
-    // a top-level function declares under `""`.
+    // (file → name → declaring class → tagged calls), so a tag on one class
+    // never speaks for a same-named sibling; a top-level function is `""`.
     const tsMissingCallTagsByFileName = new Map<string, Map<string, Map<string, Set<string>>>>();
-    // (file → name → every class in that file declaring it), the population
-    // `resolveTsOwner` disambiguates a matched pair against.
+    // (file → name → every class declaring it), `resolveTsOwner`'s population.
     const tsOwnersByFileName = new Map<string, Map<string, Set<string>>>();
     // Same call-sets unioned by NAME across this package and its deps (the same
     // scope tsParamsByName uses). Consulted ONLY by the delegation-transparency

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -751,14 +751,51 @@ export interface SuppressedCall {
   tsFile: string;
   rubyName: string;
   tsName: string;
+  /** See `CallMismatch.tsClass`. */
+  tsClass?: string;
   call: string;
 }
 
 /** Identity of the declaration a `@missingRailsCall` tag is written on. Keyed
- *  by (tsFile, tsName), so a tag justifies the deviation for exactly the method
- *  that carries it and never for a same-named method in another file. */
-export function callTagKey(tsFile: string, tsName: string): string {
-  return `${tsFile}\u0000${tsName}`;
+ *  by (tsFile, tsClass, tsName), so a tag justifies the deviation for exactly
+ *  the method that carries it — never for a same-named method in another file,
+ *  and never for a sibling class's method in the SAME file (`NullPool#checkout`
+ *  next to `ConnectionPool#checkout`). `tsClass` is `""` for a top-level
+ *  function and `"*"` when the owning class could not be resolved. */
+export function callTagKey(tsFile: string, tsClass: string, tsName: string): string {
+  return `${tsFile}\u0000${tsClass}\u0000${tsName}`;
+}
+
+/** The TS class that owns `tsName` in the file a pair matched, given every
+ *  class in that file declaring the name and the Ruby entity the pair came
+ *  from. One declaration needs no disambiguation; several are resolved by the
+ *  Ruby class's own short name (`ActiveRecord::ConnectionAdapters::NullPool` →
+ *  `NullPool`), which the naming rules make the TS class name too. Unresolved
+ *  (`undefined`) keeps the whole-file behaviour it replaced. */
+export function resolveTsOwner(
+  owners: ReadonlySet<string> | undefined,
+  rubyModule: string,
+): string | undefined {
+  if (!owners || owners.size === 0) return undefined;
+  if (owners.size === 1) return [...owners][0];
+  const short = rubyModule.split("::").at(-1) ?? rubyModule;
+  return owners.has(short) ? short : undefined;
+}
+
+/** The tags that justify deviations for `owner`'s copy of a method. A resolved
+ *  owner reads ONLY its own class's tags, so a tag on a sibling class cannot
+ *  silence a flag raised against this one. With no owner resolved the tags of
+ *  the file's single tagged class — or, ambiguously, their union — apply. */
+export function tagsForOwner(
+  byClass: ReadonlyMap<string, ReadonlySet<string>> | undefined,
+  owner: string | undefined,
+): ReadonlySet<string> | undefined {
+  if (!byClass || byClass.size === 0) return undefined;
+  if (owner !== undefined) return byClass.get(owner);
+  if (byClass.size === 1) return [...byClass.values()][0];
+  const union = new Set<string>();
+  for (const calls of byClass.values()) for (const c of calls) union.add(c);
+  return union;
 }
 
 /** Drop the flagged calls a tag on this declaration justifies, recording each
@@ -778,19 +815,25 @@ export function suppressTaggedCalls(
   });
 }
 
-/** Every tagged call on a COMPARED (tsFile, tsName) that never suppressed a
- *  flag — the tag's stale half. Sorted for a deterministic artifact. */
+/** Every tagged call on a COMPARED (tsFile, tsClass, tsName) that never
+ *  suppressed a flag — the tag's stale half. Sorted for a deterministic
+ *  artifact. A pair whose owning class stayed unresolved recorded its
+ *  suppressions under the `"*"` class, so both keys are consulted. */
 export function staleCallTags(
-  tagsByFileName: Map<string, Map<string, Set<string>>>,
+  tagsByFileName: Map<string, Map<string, Map<string, Set<string>>>>,
   used: Map<string, Set<string>>,
 ): StaleCallTag[] {
   const out: StaleCallTag[] = [];
   for (const [tsFile, byName] of tagsByFileName) {
-    for (const [tsName, calls] of byName) {
-      const hit = used.get(callTagKey(tsFile, tsName));
-      if (hit === undefined) continue;
-      for (const call of calls) {
-        if (!hit.has(call)) out.push({ tsFile, tsName, call });
+    for (const [tsName, byClass] of byName) {
+      for (const [tsClass, calls] of byClass) {
+        const hit =
+          used.get(callTagKey(tsFile, tsClass, tsName)) ??
+          used.get(callTagKey(tsFile, "*", tsName));
+        if (hit === undefined) continue;
+        for (const call of calls) {
+          if (!hit.has(call)) out.push({ tsFile, tsName, call });
+        }
       }
     }
   }
@@ -861,6 +904,10 @@ interface CallMismatch {
   tsFile: string;
   rubyName: string;
   tsName: string;
+  /** The class declaring `tsName` in `tsFile`, when the file's declarations of
+   *  that name resolve to one (see `resolveTsOwner`). `parity:api:build` mints
+   *  the tag on that declaration alone. */
+  tsClass?: string;
   missing: string[];
 }
 
@@ -1903,7 +1950,13 @@ export function main() {
     const tsCallSeqByFileName = new Map<string, Map<string, string[][]>>();
     const tsSkeletonByFileName = new Map<string, Map<string, string[][]>>();
     const tsCallArgsByFileName = new Map<string, Map<string, CallSite[][]>>();
-    const tsMissingCallTagsByFileName = new Map<string, Map<string, Set<string>>>();
+    // (file → name → declaring class → tagged calls). Qualified by class so a
+    // tag on one class never speaks for a same-named sibling in the same file;
+    // a top-level function declares under `""`.
+    const tsMissingCallTagsByFileName = new Map<string, Map<string, Map<string, Set<string>>>>();
+    // (file → name → every class in that file declaring it), the population
+    // `resolveTsOwner` disambiguates a matched pair against.
+    const tsOwnersByFileName = new Map<string, Map<string, Set<string>>>();
     // Same call-sets unioned by NAME across this package and its deps (the same
     // scope tsParamsByName uses). Consulted ONLY by the delegation-transparency
     // gate (see effectiveTsCalls), never as the primary population — the
@@ -1946,7 +1999,13 @@ export function main() {
       m: MethodInfo,
       file = m.file ?? "",
       scope: "package" | "dep" = "package",
+      owner = "",
     ) => {
+      if (scope === "package") {
+        const owners = tsOwnersByFileName.get(file) ?? new Map<string, Set<string>>();
+        owners.set(m.name, (owners.get(m.name) ?? new Set<string>()).add(owner));
+        tsOwnersByFileName.set(file, owners);
+      }
       const sigs = tsParamsByName.get(m.name) ?? [];
       sigs.push(m.params);
       tsParamsByName.set(m.name, sigs);
@@ -1964,10 +2023,13 @@ export function main() {
         }
       }
       if (m.missingRailsCalls !== undefined) {
-        const byName = tsMissingCallTagsByFileName.get(file) ?? new Map<string, Set<string>>();
-        const tagged = byName.get(m.name) ?? new Set<string>();
+        const byName =
+          tsMissingCallTagsByFileName.get(file) ?? new Map<string, Map<string, Set<string>>>();
+        const byClass = byName.get(m.name) ?? new Map<string, Set<string>>();
+        const tagged = byClass.get(owner) ?? new Set<string>();
         for (const c of m.missingRailsCalls) tagged.add(c);
-        byName.set(m.name, tagged);
+        byClass.set(owner, tagged);
+        byName.set(m.name, byClass);
         tsMissingCallTagsByFileName.set(file, byName);
       }
       if (m.callSeq !== undefined) {
@@ -2006,7 +2068,7 @@ export function main() {
         for (const m of [...cls.instanceMethods, ...cls.classMethods]) {
           if (tsShouldInclude(m)) {
             methods.add(m.name);
-            recordTsParams(m, file);
+            recordTsParams(m, file, "package", cls.name);
           }
         }
         tsMethodsByFile.set(file, methods);
@@ -2039,7 +2101,7 @@ export function main() {
       if (!depPkg) continue;
       for (const ent of [...Object.values(depPkg.classes), ...Object.values(depPkg.modules)]) {
         for (const m of [...ent.instanceMethods, ...ent.classMethods]) {
-          if (tsShouldInclude(m)) recordTsParams(m, m.file ?? "", "dep");
+          if (tsShouldInclude(m)) recordTsParams(m, m.file ?? "", "dep", ent.name);
         }
       }
       for (const fns of Object.values(depPkg.fileFunctions ?? {})) {
@@ -2392,7 +2454,7 @@ export function main() {
       // (b) are absent from the TS body's call-set. A coarse body-fidelity
       // signal — never affects the parity %. Lossy: legitimate restructuring
       // (extracted helper, inlined call) shows up here, so it's advisory.
-      const checkCalls = (rubyName: string, tsName: string, tsFile: string) => {
+      const checkCalls = (rubyName: string, tsName: string, tsFile: string, rubyModule: string) => {
         // The call set is computed only under `--calls`, the mode that
         // writes and gates the artifact (see the artifact write below).
         if (!callsGate) return;
@@ -2445,15 +2507,16 @@ export function main() {
           jsEnumerableAliases,
           negatedTsCalls,
         );
-        const tags = tsMissingCallTagsByFileName.get(tsFile)?.get(tsName);
+        const tsClass = resolveTsOwner(tsOwnersByFileName.get(tsFile)?.get(tsName), rubyModule);
+        const tags = tagsForOwner(tsMissingCallTagsByFileName.get(tsFile)?.get(tsName), tsClass);
         let kept = missing;
         if (tags !== undefined && tags.size > 0) {
-          const tagKey = callTagKey(tsFile, tsName);
+          const tagKey = callTagKey(tsFile, tsClass ?? "*", tsName);
           const used = callTagsUsed.get(tagKey) ?? callTagsUsed.set(tagKey, new Set()).get(tagKey)!;
           kept = suppressTaggedCalls(missing, tags, used);
           for (const m of missing) {
             const call = callOf(m);
-            if (tags.has(call)) suppressedCalls.push({ tsFile, rubyName, tsName, call });
+            if (tags.has(call)) suppressedCalls.push({ tsFile, rubyName, tsName, tsClass, call });
           }
         }
         const rubySkeleton = rubySkeletonByName.get(rubyName);
@@ -2484,7 +2547,7 @@ export function main() {
         }
         const flagged = [...kept, ...ordered];
         if (flagged.length === 0) return;
-        callMismatches.push({ rubyFile, tsFile, rubyName, tsName, missing: flagged });
+        callMismatches.push({ rubyFile, tsFile, rubyName, tsName, tsClass, missing: flagged });
       };
 
       // Advisory call-argument check (RFC 0095), on the pair checkCalls
@@ -2547,10 +2610,10 @@ export function main() {
         bodyHashRecords.push({ rubyFile, rubyName, tsFile, tsName, digest });
       };
 
-      const checkArity = (rubyName: string, tsName: string, tsFile: string) => {
+      const checkArity = (rubyName: string, tsName: string, tsFile: string, rubyModule = "") => {
         checkOptionKeys(rubyName, tsName, tsFile);
         checkLiterals(rubyName, tsName, tsFile);
-        checkCalls(rubyName, tsName, tsFile);
+        checkCalls(rubyName, tsName, tsFile, rubyModule);
         checkCallArgs(rubyName, tsName, tsFile);
         checkBody(rubyName, tsName, tsFile);
         if (isArityOverridden(rubyName, rubyFile)) return;
@@ -2633,7 +2696,7 @@ export function main() {
         const directMatch = tsCandidates.find((c) => tsMethods.has(c));
         if (directMatch) {
           fileMatched++;
-          checkArity(rubyName, directMatch, expectedTs);
+          checkArity(rubyName, directMatch, expectedTs, rubyModule);
           continue;
         }
 
@@ -2653,7 +2716,7 @@ export function main() {
 
         if (foundViaInclude) {
           fileMatched++;
-          checkArity(rubyName, matchedCandidate!, foundViaInclude);
+          checkArity(rubyName, matchedCandidate!, foundViaInclude, rubyModule);
           moves.push({
             tsName: matchedCandidate!,
             rubyName,
@@ -2697,7 +2760,7 @@ export function main() {
         );
         if (creditedToReopening) {
           fileMatched++;
-          checkArity(rubyName, creditedToReopening.tsName, creditedToReopening.tsFile);
+          checkArity(rubyName, creditedToReopening.tsName, creditedToReopening.tsFile, rubyModule);
           moves.push({
             tsName: creditedToReopening.tsName,
             rubyName,
@@ -2714,7 +2777,7 @@ export function main() {
           const misplacedMatch = tsCandidates.find((c) => actualMethods.has(c));
           if (misplacedMatch) {
             fileMatched++;
-            checkArity(rubyName, misplacedMatch, misplacedActualFile!);
+            checkArity(rubyName, misplacedMatch, misplacedActualFile!, rubyModule);
             moves.push({
               tsName: misplacedMatch,
               rubyName,
@@ -2754,7 +2817,7 @@ export function main() {
             // Only an arity-meaningful direct match (`writingRole`) is checked;
             // a `setX` setter has an extra `value` param vs the Ruby reader, so
             // comparing their arities manufactures a spurious mismatch.
-            if (directPort) checkArity(rubyName, directPort, actualFile);
+            if (directPort) checkArity(rubyName, directPort, actualFile, rubyModule);
             moves.push({
               tsName: port,
               rubyName,

--- a/scripts/api-compare/missing-rails-call-tags.test.ts
+++ b/scripts/api-compare/missing-rails-call-tags.test.ts
@@ -4,7 +4,7 @@ import {
   NARROW_DEFAULT_REASON,
   suppressedCallsIn,
 } from "./missing-rails-call-tags.js";
-import { reconcileFileText } from "./build.js";
+import { ANY_CLASS, expectationKey, reconcileFileText } from "./build.js";
 
 const block = (...lines: string[]): string =>
   ["/**", ...lines.map((l) => ` * ${l}`), " */"].join("\n");
@@ -142,7 +142,12 @@ describe("suppressedCallsIn", () => {
 });
 
 describe("parity:api:build over a hand-written one-line tag", () => {
-  const expectations = new Map([["bar", { rubyNames: ["bar"], calls: new Set(["first"]) }]]);
+  const expectations = new Map([
+    [
+      expectationKey(ANY_CLASS, "bar"),
+      { rubyNames: ["bar"], tsName: "bar", calls: new Set(["first"]) },
+    ],
+  ]);
   const reason = "the caller already ordered.";
   const src = [
     "export class Foo {",


### PR DESCRIPTION
Bundle of three stories.

## qualify-build-expectations-by-class (RFC 0084)

`parity:api:build` keyed its expectations by bare identifier per file, so two
same-named declarations in one file shared ONE expected-call set — which is how
#6364's `ConnectionPool#checkout` tags got stamped onto `NullPool#checkout`,
whose Rails counterpart (`connection_adapters/abstract/connection_pool.rb:14-42`)
takes no mutex and defines no `checkout` at all, and how one stray copy then
suppressed the flag file-wide.

- compare.ts records the declaring class of every method (`tsOwnersByFileName`,
  and `tsMissingCallTagsByFileName` gains a class level), resolves a matched
  pair's owner from the Ruby entity's short name (`resolveTsOwner`), and emits
  it as `tsClass` on the artifact's `mismatches` / `suppressed` rows.
- `callTagKey` is `(tsFile, tsClass, tsName)`, and `tagsForOwner` gives a
  resolved owner ONLY its own class's tags — so a tag on one class can neither
  be minted for nor suppress a flag raised against a sibling. An unresolved
  owner keeps the previous whole-file behaviour.
- `buildExpectations` keys by `expectationKey(class, name)`; top-level functions
  keep their bare-name key (`""`).
- Regression test: a two-class fixture where only one class is the artifact's
  match mints exactly one tag; the unqualified artifact still reconciles both.
- The KNOWN LIMITATION comment in `reconcileFileText` goes away with the
  limitation. Also fixes the stray indent the one-line-JSDoc normalization
  emitted.

## burndown-annotate-verified-equivalents (RFC 0084)

10 curated rows migrated out of `call-mismatches-exclude/` to
`@missingRailsCall` tags at their call sites, all through
`parity:api:build --call` (never by hand-editing both sides):

- `attribute-methods.ts` — the RFC 0032 `include` and `owner` rows.
- `connection-adapters/postgresql-adapter.ts` — `values_at` on
  enable/disable_extension (RFC 0072), the two `Proc.new` → arrow-function rows
  (`postgresql/schema_statements.rb:1054,1062`), `quote_string`'s
  `with_raw_connection` language shortcoming (`postgresql/quoting.rb:127`),
  `foreign_table_exists?`'s `any?`, and `quote`'s `check_int_in_range` alias row.
- `connection-adapters/abstract-adapter.ts` — the bucket-(b)
  `disable_prepared_statements` row (`abstract_adapter.rb:159`).

Audited and deliberately NOT tagged, being real convergeable gaps rather than
verified equivalents: `attributes_for_update`'s `readonly_attribute?` (already
tracked), `lookup_cast_type`'s `query_value` (tracked by
`pg-lookup-cast-type-async-divergence`), `dbconsole`'s `database_cli`, and the
`disable_referential_integrity` include-seam pair.

`parity:api:calls` is green with 2000 baselined rows (down 10);
`parity:api:reasons`, `parity:api:detached` and `parity:api:calls:args` green.

## port-initialize-copy-under-its-ruby-name (RFC 0088)

`Date#dup` routed through `newStart`, i.e. through `set_sg`, which forces
`get_c_jd`/`get_c_df` and clears the civil seat. Ruby has no `Date#dup`:
`Object#dup` allocates and runs `d_lite_initialize_copy`
(`date_core.c:5140-5182`, registered at `:9714`).

- `initializeCopy` is ported under its Ruby name with the C's three arms
  (`simple_dat_p(bdat)` / `simple_dat_p(adat)` / `complex_dat_p(adat)`), its
  frozen guard, its `copy == date` early return (`:5144-5145`) and its
  `ArgumentError("cannot load complex into simple")` (`:5173-5175`) — which MRI
  really does raise for `(Date.new(2001,1,1) + Rational(1,2)).dup` and the port
  could not produce at all. Verified against `ruby 3.3.11 -rdate`.
- `dup` allocates through each class's own allocator (`d_lite_s_alloc_simple`
  for `::Date`, `:9636`; `d_lite_s_alloc_complex` for `::DateTime`, `:9969`) and
  copies — no `set_sg`.
- `dat()` is `get_d1`/`get_d2`'s struct read: TS class fields are private per
  class, so the read is a method and the write stays in the class owning the
  fields (the same reason `newStart`/`newOffset` are already per-class here).
- `test_dup` passes unchanged; `parity:test --package date` holds at 124/137
  with `test_switch_hitter.rb` 18/18. Three trails-only tests cover the arms the
  gem's suite never reaches.

## Size

786 LOC against the 700 ceiling. The bundle is fixed by the prompt (one PR for
three stories) so it cannot be split. ~90 of it is mechanical: the `#sg` → `sg`
rename `DateTime#initializeCopy` needs, the re-keying of every existing
`build.test.ts` expectation, and the baseline-JSON row deletions.

Closes-story: burndown-annotate-verified-equivalents
Closes-story: qualify-build-expectations-by-class
Closes-story: port-initialize-copy-under-its-ruby-name
