### PR TITLE
refactor(scripts,activerecord): drop `new` at a Proc receiver and replace the false constructor-idiom reasons

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -4085,11 +4085,6 @@ export class PostgreSQLAdapter
 
   /**
    * @internal postgresql/schema_statements.rb:1051-1056.
-   *
-   * @missingRailsCall new — Rails builds the deferred half of the ALTER with
-   *   `Proc.new { ... }` (postgresql/schema_statements.rb:1054, :1062); the TS
-   *   body uses an arrow function, the JS analogue, so there is no `new` to
-   *   match.
    */
   async changeColumnForAlter(
     tableName: string,
@@ -4108,11 +4103,6 @@ export class PostgreSQLAdapter
 
   /**
    * @internal
-   *
-   * @missingRailsCall new — Rails builds the deferred half of the ALTER with
-   *   `Proc.new { ... }` (postgresql/schema_statements.rb:1054, :1062); the TS
-   *   body uses an arrow function, the JS analogue, so there is no `new` to
-   *   match.
    */
   changeColumnNullForAlter(
     tableName: string,

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/request.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/request.json
@@ -25,7 +25,7 @@
     "tsFile": "http/request.ts",
     "rubyName": "GET",
     "call": "new",
-    "reason": "Constructor idiom: Ruby `X.new` ports to TS `new X()`, which extractCalls records as a construction/type reference rather than a named call. The construction is present in the port. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Unported body, not a constructor idiom: Rails' `GET` (actionpack/lib/action_dispatch/http/request.rb:395-406) memoizes through `fetch_header`/`set_header`, builds params via `ActionDispatch::ParamBuilder.from_query_string` and re-raises `ActionController::BadRequest.new(...)`. The port (http/request.ts:896) is `return this.queryParameters` — none of that body is present. Tracked by story `0084-wide-call-set-burndown/port-request-get-post-param-builder`."
   },
   {
     "package": "actiondispatch",
@@ -67,7 +67,7 @@
     "tsFile": "http/request.ts",
     "rubyName": "POST",
     "call": "new",
-    "reason": "Constructor idiom: Ruby `X.new` ports to TS `new X()`, which extractCalls records as a construction/type reference rather than a named call. The construction is present in the port. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Unported body, not a constructor idiom: Rails' `POST` (actionpack/lib/action_dispatch/http/request.rb:408-440) runs `parse_formatted_parameters` over `ParamBuilder.from_pairs`/`.from_hash` and re-raises `ActionController::BadRequest.new(...)`. The port (http/request.ts:901) is `return this.requestParameters` — none of that body is present. Tracked by story `0084-wide-call-set-burndown/port-request-get-post-param-builder`."
   },
   {
     "package": "actiondispatch",
@@ -95,7 +95,7 @@
     "tsFile": "http/request.ts",
     "rubyName": "initialize",
     "call": "new",
-    "reason": "Constructor idiom: Ruby `X.new` ports to TS `new X()`, which extractCalls records as a construction/type reference rather than a named call. The construction is present in the port. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Missing construction, not a constructor idiom: Rails' `initialize` (actionpack/lib/action_dispatch/http/request.rb:64-75) builds `@rack_request = Rack::Request.new(env)`. The port (http/request.ts:148-158) copies `env` and fills in Rack defaults instead, and never constructs a `Rack::Request`. Tracked by story `0084-wide-call-set-burndown/port-request-initialize-rack-request`."
   },
   {
     "package": "actiondispatch",

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/request.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/request.json
@@ -25,7 +25,7 @@
     "tsFile": "http/request.ts",
     "rubyName": "GET",
     "call": "new",
-    "reason": "Unported body, not a constructor idiom: Rails' `GET` (actionpack/lib/action_dispatch/http/request.rb:395-406) memoizes through `fetch_header`/`set_header`, builds params via `ActionDispatch::ParamBuilder.from_query_string` and re-raises `ActionController::BadRequest.new(...)`. The port (http/request.ts:896) is `return this.queryParameters` — none of that body is present. Tracked by story `0084-wide-call-set-burndown/port-request-get-post-param-builder`."
+    "reason": "Unported body, not a constructor idiom: Rails' `GET` (actionpack/lib/action_dispatch/http/request.rb:395-406) memoizes through `fetch_header`/`set_header`, builds params via `ActionDispatch::ParamBuilder.from_query_string` and re-raises `ActionController::BadRequest.new(...)`. The port (http/request.ts:896) is `return this.queryParameters` — none of that body is present. Not tracked by a story: actionpack is outside the project's stated focus (activerecord and its dependencies), which is why the convergence story filed for this row was closed as out of scope."
   },
   {
     "package": "actiondispatch",
@@ -67,7 +67,7 @@
     "tsFile": "http/request.ts",
     "rubyName": "POST",
     "call": "new",
-    "reason": "Unported body, not a constructor idiom: Rails' `POST` (actionpack/lib/action_dispatch/http/request.rb:408-440) runs `parse_formatted_parameters` over `ParamBuilder.from_pairs`/`.from_hash` and re-raises `ActionController::BadRequest.new(...)`. The port (http/request.ts:901) is `return this.requestParameters` — none of that body is present. Tracked by story `0084-wide-call-set-burndown/port-request-get-post-param-builder`."
+    "reason": "Unported body, not a constructor idiom: Rails' `POST` (actionpack/lib/action_dispatch/http/request.rb:408-440) runs `parse_formatted_parameters` over `ParamBuilder.from_pairs`/`.from_hash` and re-raises `ActionController::BadRequest.new(...)`. The port (http/request.ts:901) is `return this.requestParameters` — none of that body is present. Not tracked by a story: actionpack is outside the project's stated focus (activerecord and its dependencies), which is why the convergence story filed for this row was closed as out of scope."
   },
   {
     "package": "actiondispatch",
@@ -95,7 +95,7 @@
     "tsFile": "http/request.ts",
     "rubyName": "initialize",
     "call": "new",
-    "reason": "Missing construction, not a constructor idiom: Rails' `initialize` (actionpack/lib/action_dispatch/http/request.rb:64-75) builds `@rack_request = Rack::Request.new(env)`. The port (http/request.ts:148-158) copies `env` and fills in Rack defaults instead, and never constructs a `Rack::Request`. Tracked by story `0084-wide-call-set-burndown/port-request-initialize-rack-request`."
+    "reason": "Missing construction, not a constructor idiom: Rails' `initialize` (actionpack/lib/action_dispatch/http/request.rb:64-75) builds `@rack_request = Rack::Request.new(env)` and exposes it via `attr_reader :rack_request` (:77). The port (http/request.ts:148-158) copies `env` and fills in Rack defaults Rails does not set; the wrapper is built lazily by an invented `get rackRequest()` that caches it in `env[\"action_dispatch.rack_request\"]` (http/request.ts:925-931), so the constructor never constructs one. Not tracked by a story: actionpack is outside the project's stated focus (activerecord and its dependencies), which is why the convergence story filed for this row was closed as out of scope."
   },
   {
     "package": "actiondispatch",

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/exception-wrapper.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/exception-wrapper.json
@@ -4,7 +4,7 @@
     "tsFile": "middleware/exception-wrapper.ts",
     "rubyName": "build_backtrace",
     "call": "new",
-    "reason": "Missing construction, not a constructor idiom: Rails' `build_backtrace` (actionpack/lib/action_dispatch/middleware/exception_wrapper.rb:254-275) maps template frames onto `SourceMapLocation.new(...)`. The port (middleware/exception-wrapper.ts:297) is `return this.traces` — `ActionView::PathRegistry` and `SourceMapLocation` are unported, as the call-site comment already records. Tracked by story `0084-wide-call-set-burndown/port-exception-wrapper-build-backtrace`."
+    "reason": "Missing construction, not a constructor idiom: Rails' `build_backtrace` (actionpack/lib/action_dispatch/middleware/exception_wrapper.rb:254-275) maps template frames onto `SourceMapLocation.new(...)`. The port (middleware/exception-wrapper.ts:297) is `return this.traces` — `ActionView::PathRegistry` and `SourceMapLocation` are unported, as the call-site comment already records. Not tracked by a story: actionpack is outside the project's stated focus (activerecord and its dependencies), which is why the convergence story filed for this row was closed as out of scope."
   },
   {
     "package": "actiondispatch",

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/exception-wrapper.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/exception-wrapper.json
@@ -4,7 +4,7 @@
     "tsFile": "middleware/exception-wrapper.ts",
     "rubyName": "build_backtrace",
     "call": "new",
-    "reason": "Constructor idiom: Ruby `X.new` ports to TS `new X()`, which extractCalls records as a construction/type reference rather than a named call. The construction is present in the port. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Missing construction, not a constructor idiom: Rails' `build_backtrace` (actionpack/lib/action_dispatch/middleware/exception_wrapper.rb:254-275) maps template frames onto `SourceMapLocation.new(...)`. The port (middleware/exception-wrapper.ts:297) is `return this.traces` — `ActionView::PathRegistry` and `SourceMapLocation` are unported, as the call-site comment already records. Tracked by story `0084-wide-call-set-burndown/port-exception-wrapper-build-backtrace`."
   },
   {
     "package": "actiondispatch",

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/system-testing/driver.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/system-testing/driver.json
@@ -18,7 +18,7 @@
     "tsFile": "system-testing/driver.ts",
     "rubyName": "initialize",
     "call": "new",
-    "reason": "Missing construction, not a constructor idiom: Rails' `initialize` (actionpack/lib/action_dispatch/system_testing/driver.rb:10-25) builds `@browser = Browser.new(options[:using])` on the `:selenium` branch. The port (system-testing/driver.ts:47-55) stores `options.using` raw; `Browser` has no trails counterpart. Tracked by story `0084-wide-call-set-burndown/port-system-testing-driver-browser`."
+    "reason": "Missing construction, not a constructor idiom: Rails' `initialize` (actionpack/lib/action_dispatch/system_testing/driver.rb:10-25) builds `@browser = Browser.new(options[:using])` on the `:selenium` branch. The port (system-testing/driver.ts:47-55) stores `options.using` raw; `Browser` has no trails counterpart. Not tracked by a story: actionpack is outside the project's stated focus (activerecord and its dependencies), which is why the convergence story filed for this row was closed as out of scope."
   },
   {
     "package": "actiondispatch",

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/system-testing/driver.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/system-testing/driver.json
@@ -18,7 +18,7 @@
     "tsFile": "system-testing/driver.ts",
     "rubyName": "initialize",
     "call": "new",
-    "reason": "Constructor idiom: Ruby `X.new` ports to TS `new X()`, which extractCalls records as a construction/type reference rather than a named call. The construction is present in the port. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Missing construction, not a constructor idiom: Rails' `initialize` (actionpack/lib/action_dispatch/system_testing/driver.rb:10-25) builds `@browser = Browser.new(options[:using])` on the `:selenium` branch. The port (system-testing/driver.ts:47-55) stores `options.using` raw; `Browser` has no trails counterpart. Tracked by story `0084-wide-call-set-burndown/port-system-testing-driver-browser`."
   },
   {
     "package": "actiondispatch",

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/attribute-methods.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/attribute-methods.json
@@ -139,7 +139,7 @@
     "tsFile": "attribute-methods.ts",
     "rubyName": "generated_attribute_methods",
     "call": "new",
-    "reason": "Constructor idiom: Ruby `X.new` ports to TS `new X()`, which extractCalls records as a construction/type reference rather than a named call. The construction is present in the port. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Missing construction, not a constructor idiom: Rails builds and includes the module lazily — `@generated_attribute_methods ||= Module.new.tap { |mod| include mod }` (activemodel/lib/active_model/attribute_methods.rb:400-402). The port (attribute-methods.ts:467-469) is `return this._generatedMethods`, so neither the construction nor the include happens here. Tracked by story `0084-wide-call-set-burndown/converge-generated-attribute-methods-module`."
   },
   {
     "package": "activemodel",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/query-cache.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/query-cache.json
@@ -22,6 +22,6 @@
     "tsFile": "connection-adapters/abstract/query-cache.ts",
     "rubyName": "query_cache",
     "call": "new",
-    "reason": "Constructor idiom: Ruby `X.new` ports to TS `new X()`, which extractCalls records as a construction/type reference rather than a named call. The construction is present in the port. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Homonym match, not a constructor idiom: query_cache.rb declares `query_cache` twice — `ConnectionPoolConfiguration#query_cache` (:187-191, which does build `Store.new` inside `compute_if_absent`) and the adapter's `attr_accessor :query_cache` (:194). The class-less matcher pairs the :187 body against the TS attr-reader function `queryCache` (query-cache.ts:330), not against the getter at query-cache.ts:305-309 that carries both calls. Nothing in the port is missing; the row is a matcher artifact."
   }
 ]

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -2300,6 +2300,19 @@ class ApiExtractor
     inner.is_a?(Array) && inner[0] == :@ident
   end
 
+  # `Proc.new { ... }` ports to an arrow function, which names no callee at all,
+  # so the `new` recorded here could never be satisfied by any TS body. The
+  # discriminator is the RECEIVER, not the name: `Foo.new` is a real call the TS
+  # side already satisfies (extract-ts-api.ts records `constructor` for every
+  # `new X()`, and rubyMethodToTs("new") is ["constructor"]), so this verdict is
+  # per-SITE — a body with both `Proc.new` and `Foo.new` still records the second.
+  def proc_new_receiver?(recv)
+    return false unless recv.is_a?(Array) && recv[0] == :var_ref
+
+    inner = recv[1]
+    inner.is_a?(Array) && inner[0] == :@const && inner[1] == "Proc"
+  end
+
   # `weak` collects the occurrences whose receiver was inert; a name only
   # becomes a weak CALL when no non-inert occurrence exists (collect_method_calls).
   def walk_for_calls(node, calls, weak)
@@ -2315,7 +2328,8 @@ class ApiExtractor
       # matching extract-ts-api.ts#collectCalls; the two orders must agree.
       walk_for_calls(node[1], calls, weak)
       name = ident_name(node[3]) if node[3]
-      if name && !name.start_with?("_") && name =~ /\A[a-z]/
+      if name && !name.start_with?("_") && name =~ /\A[a-z]/ &&
+         !(name == "new" && proc_new_receiver?(node[1]))
         calls << name
         weak << name if inert_receiver?(node[1])
       end

--- a/scripts/api-compare/extract-ruby-api.test.ts
+++ b/scripts/api-compare/extract-ruby-api.test.ts
@@ -271,6 +271,39 @@ describe("Ruby extractor inert-receiver call suppression", () => {
     expect(c["Baz#c"].calls).toContain("save");
     expect(c["Baz#c"].weakCalls ?? []).not.toContain("save");
   });
+
+  it("drops new at a Proc receiver while keeping it at a constant receiver", () => {
+    const c = rubyWeakCalls({
+      "qux.rb": `
+        class Qux
+          def d
+            callback = Proc.new { |x| x.run }
+            Wrapper.new(callback)
+          end
+        end
+      `,
+    });
+    // `Proc.new { ... }` ports to an arrow function, which names no callee, so
+    // the site can never be satisfied; `Wrapper.new` is a real construction the
+    // TS side records as `constructor`.
+    expect(c["Qux#d"].calls).toContain("new");
+    expect(c["Qux#d"].calls?.filter((n) => n === "new")).toEqual(["new"]);
+    expect(c["Qux#d"].calls).toContain("run");
+  });
+
+  it("drops new entirely when Proc is the only receiver", () => {
+    const c = rubyWeakCalls({
+      "quux.rb": `
+        class Quux
+          def e
+            Proc.new { greet }
+          end
+        end
+      `,
+    });
+    expect(c["Quux#e"].calls ?? []).not.toContain("new");
+    expect(c["Quux#e"].calls).toContain("greet");
+  });
 });
 
 describe("Ruby extractor alias arity resolution", () => {


### PR DESCRIPTION
Two RFC 0084 stories, both about how the call extractor handles Ruby `new`.

## `drop-proc-new-at-the-receiver`

`Proc.new { ... }` ports to an arrow function, which names no callee at all, so
the `new` the Ruby extractor recorded could never be satisfied by any TS body.
The discriminator is the **receiver**, not the name — `Foo.new` is a real call
the TS side already satisfies (`extract-ts-api.ts:2919-2921` records
`constructor` for every `new X()`, and `rubyMethodToTs("new")` is
`["constructor"]`), so a name-level `NO_JS_CALL_FORM` entry would silence a
converged population.

`walk_for_calls` now drops `new` per-SITE when the receiver is the constant
`Proc`, at the same grain `inert_receiver?` already works at. Checked the
vendored source before adding: `Proc.new` occurs 50 times outside tests;
`proc.new` / `lambda.new` occur zero times, so only `Proc` is matched.

Unit test covers both halves — a `Proc.new` site dropped while a `Foo.new` site
in the same body is kept, and a body where `Proc` is the only receiver.

The rule replaces the two `@missingRailsCall new` tags PR #6372 minted on
`packages/activerecord/src/connection-adapters/postgresql-adapter.ts`
(`changeColumnForAlter` / `changeColumnNullForAlter`), which are deleted — left
behind they would red `parity:api:calls` as STALE. Verified: those two methods
no longer appear in `output/call-mismatches.json` at all, which is what proves
the extractor rule fires.

## `audit-constructor-idiom-cluster-reasons`

Seven `call-mismatches-exclude` rows carried this reason verbatim:

> Constructor idiom: Ruby `X.new` ports to TS `new X()`, which extractCalls
> records as a construction/type reference rather than a named call. The
> construction is present in the port. Cluster-vetted: …

**The mechanism it names does not exist** — see above; a TS body that constructs
what Rails constructs already satisfies the flag. The cluster was classified by
mechanism rather than line-diffed, so all seven were read against the vendored
Rails body individually. Not one was the claimed idiom:

| row | what it actually is |
| --- | --- |
| `http/request.ts` `GET` | `request.rb:395-406` memoizes via `fetch_header`/`set_header`, builds params through `ParamBuilder.from_query_string`, re-raises `BadRequest.new`. Port (`request.ts:896`) is `return this.queryParameters` — body unported. |
| `http/request.ts` `POST` | `request.rb:408-440`, same shape via `parse_formatted_parameters` / `from_pairs` / `from_hash`. Port (`:901`) is `return this.requestParameters`. |
| `http/request.ts` `initialize` | `request.rb:64-75` builds `@rack_request = Rack::Request.new(env)`. Port (`:148-158`) copies `env`, fills in Rack defaults Rails does not set, never constructs one. |
| `exception-wrapper.ts` `build_backtrace` | `exception_wrapper.rb:254-275` maps template frames onto `SourceMapLocation.new`. Port (`:297`) is `return this.traces`. |
| `system-testing/driver.ts` `initialize` | `driver.rb:10-25` builds `@browser = Browser.new(options[:using])`. Port (`:47-55`) stores `options.using` raw; `Browser` is unported. |
| `attribute-methods.ts` `generated_attribute_methods` | `attribute_methods.rb:400-402` is `@generated_attribute_methods ||= Module.new.tap { \|mod\| include mod }`. Port (`:467-469`) is `return this._generatedMethods` — neither construction nor include. |
| `query-cache.ts` `query_cache` | **Homonym match.** `query_cache.rb` declares `query_cache` twice: `ConnectionPoolConfiguration#query_cache` (`:187-191`, which *does* build `Store.new` inside `compute_if_absent`) and the adapter's `attr_accessor :query_cache` (`:194`). The class-less matcher pairs the `:187` body against the TS attr-reader function `queryCache` (`query-cache.ts:330`) instead of the getter at `:305-309` that carries both calls. Nothing is missing from the port. |

The first six are real convergeable work wearing a permanent-equivalent
justification. None fits under the LOC ceiling here (each needs an unported
collaborator — `ParamBuilder`, `Rack::Request`, `PathRegistry`/`SourceMapLocation`,
`Browser`, the module-mixin idiom), so each got a story of its own with the
Rails `file:line` already in hand, and its baseline reason now cites that story:

- `0084/port-request-get-post-param-builder`
- `0084/port-request-initialize-rack-request`
- `0084/port-exception-wrapper-build-backtrace`
- `0084/port-system-testing-driver-browser`
- `0084/converge-generated-attribute-methods-module`

The `query_cache` row survives with a reason naming the matcher artifact. The
false "extractCalls records a construction rather than a named call" sentence is
deleted repo-wide (`grep` returns 0).

## Scope

Claimed as an 11-story bundle. The other nine each need substantial independent
work — association body ports, a Queue waiter-protocol redesign (Rails' `add`
pushes then signals a thread that re-polls; trails hands the connection straight
to the waiter, so converging it reshapes `wait`/`waitPoll`/`internalPoll` and
needs interleaving tests on three lanes), and an arel visitor burndown the story
itself specifies as ~3 PRs. They are released, not attempted here.

## Verification — before/after (reviewer finding)

The finding is correct and my original Verification section was inadequate: it
reported post-change totals only. Measured properly, against `origin/main` after
rebasing onto #6373 (my base was stale, which is why a first measurement showed a
bogus +22 — that delta was #6373's convergences landing on main, not mine):

| register | origin/main | this PR |
| --- | ---: | ---: |
| `call-mismatches-exclude` baseline rows | 2247 | **2247** |
| `@missingRailsCall` tags in `packages/` | 19 | **17** |

**The baseline row count is flat, not shrinking.** Stated plainly rather than
defended: the acceptance criterion's premise was wrong. It assumed the `Proc.new`
sites were baselined rows, so retiring them would shrink the baseline. They were
never baselined — PR #6372 recorded them as two `@missingRailsCall` tags. The
extractor rule retires exactly those two, so the measurable shrink lands in the
tag register (19 → 17) and the baseline is untouched by construction.

The gate ends green with **zero STALE rows**, which is itself the proof the
extractor change took effect: the two tags are deleted, so if `walk_for_calls`
were still recording `new` at those `Proc.new` sites, both would surface as NEW
mismatches and red the gate. They do not appear in `output/call-mismatches.json`
at all.

Reproduce:

```
for REF in origin/main HEAD; do T=0
  for f in $(git ls-tree -r --name-only $REF -- scripts/api-compare/call-mismatches-exclude); do
    T=$((T + $(git show $REF:$f | python3 -c "import sys,json;print(len(json.load(sys.stdin)))"))); done
  echo "$REF: $T"; done
```

### Why no row converged in-PR

I tried to make the shrink real rather than argue the criterion. Two candidates:

- **`request.ts` `initialize`** — converged locally (a `rackRequest` field built
  once in the constructor, replacing the invented lazy `get rackRequest()` that
  cached the wrapper in `env["action_dispatch.rack_request"]`), which does delete
  the row. **Reverted**: four of the five follow-up stories I filed were
  auto-closed as *"out of scope: targets actionpack; project focus is
  activerecord and its dependencies"*. Converging actionpack here would push the
  PR into a package the project has descoped.
- **`attribute-methods.ts` `generated_attribute_methods`** — in scope, but
  `_generatedMethods` is a `Set<string>` of method *names*, whereas Rails builds
  an anonymous `Module` and `include`s it so generated methods sit below the
  class body in the ancestor chain. That is an architectural change across
  activemodel and activerecord, owned by
  `0084/converge-generated-attribute-methods-module` (in scope, `ready`).

Consequence of the scope closures, fixed in the follow-up commit: the four
actionpack reasons no longer cite a closed story (which would be a misleading
tracking destination). They name the scope decision directly. Only the
activemodel row still cites a story, and that story is open.

## Gates

- `pnpm parity:api:calls` — OK (1856 baselined, 0 STALE, 0 new)
- `pnpm parity:api:calls:args` — OK (410 baselined shape rows)
- `pnpm parity:api:reasons` — 3251 files, every tag carries a reason
- `pnpm parity:api:detached` — 3809 files, no detached tag blocks
- `pnpm vitest run scripts/stale-story-references.test.ts` — 17 passed
- `pnpm lint`, `pnpm typecheck` clean
- `extract-ruby-api.test.ts`, `baseline-json.test.ts`, `lint-call-mismatches.test.ts` — 110 passed

Closes-story: audit-constructor-idiom-cluster-reasons
Closes-story: drop-proc-new-at-the-receiver
