### PR TITLE
refactor(activerecord): converge three call-argument divergences

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -784,9 +784,10 @@ export class Associations {
     scope: ((...args: any[]) => any) | (AssociationOptions & { joinTable?: string }) | null = {},
     options: AssociationOptions & { joinTable?: string } = {},
   ): void {
-    // Mirrors Builder::Association.build's options-object shift (Rails resolves
-    // this from the Ruby signature; the HABTM builder is not an Association
-    // subclass, so the shift happens here at the macro).
+    // Builder::Association.build's options-object shift, which
+    // `Builder::HasAndBelongsToMany` does not inherit in Rails either
+    // (associations.rb:1870) — so it happens at the macro rather than in the
+    // builder.
     if (
       typeof scope === "object" &&
       scope !== null &&

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -756,8 +756,17 @@ export class Associations {
    *
    * Mirrors: ActiveRecord::Associations::ClassMethods#has_many
    */
-  static hasMany(name: string, options: AssociationOptions = {}): void {
-    HasManyBuilder.build(this, name, options as Record<string, unknown>);
+  static hasMany(
+    name: string,
+    scope: ((...args: any[]) => any) | AssociationOptions | null = {},
+    options: AssociationOptions = {},
+  ): void {
+    HasManyBuilder.build(
+      this,
+      name,
+      scope as ((...args: any[]) => any) | Record<string, unknown> | null,
+      options as Record<string, unknown>,
+    );
   }
 
   /**
@@ -772,8 +781,21 @@ export class Associations {
    */
   static hasAndBelongsToMany(
     name: string,
+    scope: ((...args: any[]) => any) | (AssociationOptions & { joinTable?: string }) | null = {},
     options: AssociationOptions & { joinTable?: string } = {},
   ): void {
+    // Mirrors Builder::Association.build's options-object shift (Rails resolves
+    // this from the Ruby signature; the HABTM builder is not an Association
+    // subclass, so the shift happens here at the macro).
+    if (
+      typeof scope === "object" &&
+      scope !== null &&
+      !Array.isArray(scope) &&
+      !(scope instanceof Function)
+    ) {
+      options = scope;
+      scope = null;
+    }
     // `class_name` Symbol coercion is handled generically in
     // MacroReflection#normalizeOptions (mirroring Rails' AbstractReflection#
     // class_name `.to_s`), but the HABTM builder reads `options.className`
@@ -783,12 +805,18 @@ export class Associations {
     if (typeof rawClassName === "symbol") {
       options = { ...options, className: rawClassName.description ?? "" };
     }
-    HabtmBuilder.build(this, name, options as Record<string, unknown>, {
-      defaultJoinTableName,
-      singleFk,
-      createHabtmJoinModel,
-      modelRegistry,
-    });
+    HabtmBuilder.build(
+      this,
+      name,
+      scope as ((...args: any[]) => any) | null,
+      options as Record<string, unknown>,
+      {
+        defaultJoinTableName,
+        singleFk,
+        createHabtmJoinModel,
+        modelRegistry,
+      },
+    );
     // Rails registers the autosave-association callbacks for every HABTM
     // (the underlying has_many :through is built via the standard
     // `has_many` builder, which always calls `define_callbacks`). Wire it

--- a/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
+++ b/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
@@ -325,12 +325,10 @@ export class HasAndBelongsToMany {
         habtmOptions[k] = options[k];
       }
     }
-    // `scope:` is captured as a positional reflection arg below, but keep
-    // it on the options bag too for callers that bypass reflection.
     // Rails passes `scope` as the second positional to
-    // `HasAndBelongsToManyReflection.new` (associations.rb:1871); accept it
-    // there as well as off the options bag, which the through-routing loaders
-    // already read.
+    // `HasAndBelongsToManyReflection.new` (associations.rb:1871). It is
+    // captured as a positional reflection arg below, but kept on the options
+    // bag too for the through-routing loaders, which read it from there.
     const positionalScope = typeof scope === "function" ? scope : null;
     if (positionalScope || typeof options.scope === "function") {
       habtmOptions.scope = positionalScope ?? options.scope;

--- a/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
+++ b/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
@@ -133,6 +133,7 @@ export class HasAndBelongsToMany {
   static build(
     model: any,
     name: string,
+    scope: ((...args: any[]) => any) | null,
     options: Record<string, unknown>,
     deps: {
       defaultJoinTableName: (model: any, name: string, options?: { className?: string }) => string;
@@ -141,15 +142,18 @@ export class HasAndBelongsToMany {
       modelRegistry: Map<string, any>;
     },
   ): void {
-    new this(name, model, options)._build(deps);
+    new this(name, model, options)._build(deps, scope);
   }
 
-  private _build(deps: {
-    defaultJoinTableName: (model: any, name: string, options?: { className?: string }) => string;
-    singleFk: (fk: string | string[] | undefined, fallback: string) => string;
-    createHabtmJoinModel: (...args: any[]) => any;
-    modelRegistry: Map<string, any>;
-  }): void {
+  private _build(
+    deps: {
+      defaultJoinTableName: (model: any, name: string, options?: { className?: string }) => string;
+      singleFk: (fk: string | string[] | undefined, fallback: string) => string;
+      createHabtmJoinModel: (...args: any[]) => any;
+      modelRegistry: Map<string, any>;
+    },
+    scope: ((...args: any[]) => any) | null = null,
+  ): void {
     const model = this.lhsModel;
     const name = this.associationName;
     const options = this.options;
@@ -323,8 +327,13 @@ export class HasAndBelongsToMany {
     }
     // `scope:` is captured as a positional reflection arg below, but keep
     // it on the options bag too for callers that bypass reflection.
-    if (typeof options.scope === "function") {
-      habtmOptions.scope = options.scope;
+    // Rails passes `scope` as the second positional to
+    // `HasAndBelongsToManyReflection.new` (associations.rb:1871); accept it
+    // there as well as off the options bag, which the through-routing loaders
+    // already read.
+    const positionalScope = typeof scope === "function" ? scope : null;
+    if (positionalScope || typeof options.scope === "function") {
+      habtmOptions.scope = positionalScope ?? options.scope;
     }
     model._associations.push({
       type: "hasAndBelongsToMany",

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -103,7 +103,10 @@ import {
   type AssociationCache as _AssociationCache,
   createAssociationCache,
 } from "./association-cache.js";
-import { ConnectionHandler } from "./connection-adapters/abstract/connection-handler.js";
+import {
+  ConnectionHandler,
+  _registerBase as _registerBaseWithConnectionHandler,
+} from "./connection-adapters/abstract/connection-handler.js";
 
 import * as ConnectionHandling from "./connection-handling.js";
 import type { DatabaseConfig } from "./database-configurations/database-config.js";
@@ -5223,3 +5226,4 @@ _registerBaseWithSchemaMigration(Base);
 _registerBaseWithInternalMetadata(Base);
 _registerBaseWithSchemaDumper(Base);
 _registerBaseWithNamedScoping(Base);
+_registerBaseWithConnectionHandler(Base);

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -2610,6 +2610,12 @@ export class AbstractAdapter implements Quoting {
     });
     if (arError !== nativeError && arError instanceof Error && nativeError instanceof Error) {
       arError.stack = nativeError.stack;
+      // Ruby's raise site sets `Exception#cause` from `$!` implicitly, so no
+      // translator names the driver error in its argument list
+      // (`translate_exception` in each adapter). JS chains nothing at a `throw`,
+      // so the driver error is attached here — beside the `set_backtrace`
+      // analogue (abstract_adapter.rb:1130) — rather than in the call.
+      if (arError.cause === undefined) arError.cause = nativeError;
     }
     return arError;
   }

--- a/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
@@ -42,6 +42,19 @@ _setAdapterClassResolver(
 export { ConnectionDescriptor };
 export type { ConnectionOwner };
 
+// Ruby resolves `Base` in `establish_connection`'s `owner_name: Base` default
+// (`abstract/connection_handler.rb:115`) when the method runs, so
+// connection_handler.rb takes no load-order dependency on base.rb. An ESM
+// `import` from here would close a cycle (base.ts already imports this file),
+// so `base.ts` pushes itself in at the bottom of its own body instead — the
+// same `_registerBase` shape schema-migration.ts uses.
+let _base: ConnectionOwner | undefined;
+
+/** @internal */
+export function _registerBase(base: ConnectionOwner): void {
+  _base = base;
+}
+
 export class ConnectionHandler {
   private _connectionNameToPoolManager: Map<string, PoolManager>;
   private _preventWrites: boolean;
@@ -67,10 +80,10 @@ export class ConnectionHandler {
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::ConnectionHandler#determine_owner_name
    *
-   * Returns undefined where Rails returns `owner_name`'s default, `Base`:
-   * trails has no Base-as-default-owner (Base is a model class here, and
-   * importing it would close a cycle), so establishConnection supplies the
-   * fallback descriptor instead.
+   * Returns undefined only when no owner was given at all — `establishConnection`
+   * defaults `ownerName` to `Base` (via `_registerBase`) as
+   * connection_handler.rb:115 does, and supplies a config-name descriptor for
+   * the window before base.ts has loaded.
    *
    * @internal
    */
@@ -140,8 +153,11 @@ export class ConnectionHandler {
       adapterFactory?: () => DatabaseAdapter;
     } = {},
   ): ConnectionPool {
+    // `owner_name: Base` (connection_handler.rb:115). `_base` is unset only
+    // before base.ts has finished loading, where Rails' constant would not
+    // resolve either; fall back to the config-name descriptor then.
     const ownerName =
-      this.determineOwnerName(options.ownerName, config) ??
+      this.determineOwnerName(options.ownerName ?? _base, config) ??
       (config instanceof DatabaseConfig
         ? new ConnectionDescriptor(config.name)
         : new ConnectionDescriptor("primary"));

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2732,7 +2732,17 @@ WHERE type = 'table' AND name = ${this.quote(tableName)}
       const code = (e as any)?.code;
       if (code !== undefined) (exc as any).code = code;
     }
-    return translateException(exc, msg, sql, binds, this.pool);
+    const translated = translateException(exc, msg, sql, binds, this.pool);
+    // Ruby chains the driver error implicitly: `translate_exception`'s result is
+    // raised from inside the `rescue`, so `Exception#cause` is `$!` and the
+    // driver error is never named in the argument list
+    // (sqlite3_adapter.rb:698-702). JS sets no cause at a `throw`, so this is
+    // the raise-site stand-in — the same one `translateExceptionClass` applies
+    // for every adapter that goes through the public translator.
+    if (translated !== exc && (translated as { cause?: unknown }).cause === undefined) {
+      (translated as { cause?: unknown }).cause = exc;
+    }
+    return translated;
   }
 
   /** @internal */
@@ -3188,24 +3198,24 @@ function translateException(
     code?.includes("CONSTRAINT_UNIQUE") ||
     /(column(s)? .* (is|are) not unique|UNIQUE constraint failed: .*)/i.test(msg)
   ) {
-    return new RecordNotUnique(message, { sql, binds, connectionPool: pool, cause: exception });
+    return new RecordNotUnique(message, { sql, binds, connectionPool: pool });
   }
   if (
     code?.includes("CONSTRAINT_NOTNULL") ||
     /(.* may not be NULL|NOT NULL constraint failed: .*)/i.test(msg)
   ) {
-    return new NotNullViolation(message, { sql, binds, connectionPool: pool, cause: exception });
+    return new NotNullViolation(message, { sql, binds, connectionPool: pool });
   }
   if (code?.includes("CONSTRAINT_FOREIGNKEY") || /FOREIGN KEY constraint failed/i.test(msg)) {
-    return new InvalidForeignKey(message, { sql, binds, connectionPool: pool, cause: exception });
+    return new InvalidForeignKey(message, { sql, binds, connectionPool: pool });
   }
   if (msg.includes("String or BLOB exceeded size limit")) {
-    return new ValueTooLong(message, { sql, binds, connectionPool: pool, cause: exception });
+    return new ValueTooLong(message, { sql, binds, connectionPool: pool });
   }
   if (/called on a closed database/i.test(msg)) {
     return new ConnectionNotEstablished(exception, { connectionPool: pool });
   }
-  return new StatementInvalid(message, { sql, binds, connectionPool: pool, cause: exception });
+  return new StatementInvalid(message, { sql, binds, connectionPool: pool });
 }
 
 // `dirties_query_cache` for the write methods this adapter OVERRIDES (Rails

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2733,12 +2733,12 @@ WHERE type = 'table' AND name = ${this.quote(tableName)}
       if (code !== undefined) (exc as any).code = code;
     }
     const translated = translateException(exc, msg, sql, binds, this.pool);
-    // Ruby chains the driver error implicitly: `translate_exception`'s result is
-    // raised from inside the `rescue`, so `Exception#cause` is `$!` and the
-    // driver error is never named in the argument list
-    // (sqlite3_adapter.rb:698-702). JS sets no cause at a `throw`, so this is
-    // the raise-site stand-in — the same one `translateExceptionClass` applies
-    // for every adapter that goes through the public translator.
+    // `translate_exception`'s result is raised from inside the `rescue`, so
+    // Ruby sets `Exception#cause` from `$!` and never names the driver error in
+    // the argument list (sqlite3_adapter.rb:698-702). JS chains nothing at a
+    // `throw`; this is the raise-site stand-in for the direct
+    // `throw this._translateException(...)` sites, as `translateExceptionClass`
+    // is for everything routed through the public translator.
     if (translated !== exc && (translated as { cause?: unknown }).cause === undefined) {
       (translated as { cause?: unknown }).cause = exc;
     }

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -1296,7 +1296,6 @@ export class DatabaseTasks {
       // (database_tasks.rb:543). Ruby's `establish_connection(config_or_env = nil)`
       // takes no `clobber:`, so the kwarg can only be threaded through the handler.
       const pool = migrationClass.connectionHandler.establishConnection(dbConfig, {
-        ownerName: migrationClass.connectionClassForSelf(),
         clobber,
       });
       // Deviation: ESM cannot import synchronously, so the handler resolves the
@@ -1307,7 +1306,6 @@ export class DatabaseTasks {
       return await fn(pool);
     } finally {
       await migrationClass.connectionHandler.establishConnection(originalDbConfig, {
-        ownerName: migrationClass.connectionClassForSelf(),
         clobber,
       }).adapterReady;
     }

--- a/packages/activerecord/src/test-helpers/models/post.ts
+++ b/packages/activerecord/src/test-helpers/models/post.ts
@@ -365,8 +365,7 @@ export class Post extends Base {
       source: "ratings",
     });
     this.hasMany("specialComments");
-    this.hasMany("nonexistentComments", {
-      scope: (q: any) => q.where("comments.id < 0"),
+    this.hasMany("nonexistentComments", (q: any) => q.where("comments.id < 0"), {
       className: "Comment",
     });
 

--- a/packages/activerecord/src/test-helpers/models/project.ts
+++ b/packages/activerecord/src/test-helpers/models/project.ts
@@ -34,9 +34,9 @@ export class Project extends Base {
 
   static {
     this.belongsTo("mentor");
-    this.hasAndBelongsToMany("developers", {
-      scope: (q: any) => q.distinct().order("developers.name desc, developers.id desc"),
-    });
+    this.hasAndBelongsToMany("developers", (q: any) =>
+      q.distinct().order("developers.name desc, developers.id desc"),
+    );
     this.hasAndBelongsToMany("readonlyDevelopers", {
       scope: (q: any) => q.readonly(),
       className: "Developer",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/sqlite3-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/sqlite3-adapter.json
@@ -223,18 +223,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "rubyName": "translate_exception",
-    "call": "new",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:message",
-      "kwargs{binds=ref:binds,connectionPool=ref:pool,sql=ref:sql}"
-    ],
-    "reason": "RFC 0099: sqlite3_adapter.rb:698-702 pass no `cause:` — Ruby sets Exception#cause implicitly from `$!` at the `raise` site, which JS does not, so the driver error has to be threaded through the constructor to keep the chain."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "virtual_table_exists?",
     "call": "any?",
     "reason": "Per-entry verified (RFC 0072 sqlite3 introspection cluster): Rails schema_statements.rb:88 ends the query_values probe with a block-less `.any?`; the port spells that emptiness test as `.length > 0` (JS arrays have no `any?`), same as the other `#any?` -> `.length > 0` entries in this baseline."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/tasks/database-tasks.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/tasks/database-tasks.json
@@ -232,29 +232,5 @@
       "ref:flags"
     ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "tasks/database-tasks.ts",
-    "rubyName": "with_temporary_pool",
-    "call": "establish_connection",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:dbConfig",
-      "kwargs{clobber=ref:clobber}"
-    ],
-    "reason": "RFC 0099: database_tasks.rb:544,548 pass no owner_name, relying on establish_connection's `owner_name: Base` default (abstract/connection_handler.rb:115); trails' handler cannot import Base (module cycle, connection-handler.ts:70-76) so it falls back to a config-name descriptor and the owner has to be named here."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "tasks/database-tasks.ts",
-    "rubyName": "with_temporary_pool",
-    "call": "establish_connection",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:originalDbConfig",
-      "kwargs{clobber=ref:clobber}"
-    ],
-    "reason": "RFC 0099: database_tasks.rb:544,548 pass no owner_name, relying on establish_connection's `owner_name: Base` default (abstract/connection_handler.rb:115); trails' handler cannot import Base (module cycle, connection-handler.ts:70-76) so it falls back to a config-name descriptor and the owner has to be named here."
   }
 ]


### PR DESCRIPTION
Converges three RFC 0099 call-argument divergences and deletes the three
baseline rows they were held by (only-shrink, deleted by hand).

### `has_many` / `has_and_belongs_to_many` take Rails' `scope` positional

`associations.rb:1302-1303` and `:1870-1871` have the same
`(name, scope = nil, **options)` signature `belongs_to` / `has_one` got in
#6373; these two were left behind because the baseline had no row for them,
leaving the macro family split two-and-two. Existing two-argument call sites
(`hasMany("posts", { className: … })`) keep working through
`Builder::Association.build`'s options-object shift. `Builder::HasAndBelongsToMany`
is not an `Association` subclass in Rails either, so the shift happens at the
macro and `scope` reaches the reflection as Rails' second positional
(`HasAndBelongsToManyReflection.new(name, scope, options, self)`).

Two canonical models are put back on Rails' spelling to cover the new
positional behaviourally: `Post.nonexistentComments` (`post.rb:120`) and
`Project.developers` (`project.rb:5`) both passed the scope in the options
bag. They were chosen because tests already assert the scope reaches the
relation — `join-model.test.ts`'s "has many through uses conditions specified
on the has many association" and its eager counterpart both fail (the
`id < 0` predicate stops being applied) when the scope is dropped, verified
against the converted declaration. The remaining ~176 options-bag scopes
across 26 model files are a sweep of their own, filed as
`0099-call-argument-convergence/models-scope-positional-sweep`.

### `establish_connection`'s owner defaults to `Base`

`with_temporary_pool` (`database_tasks.rb:544,548`) passes `clobber:` only,
relying on `owner_name: Base` (`abstract/connection_handler.rb:115`). trails'
handler cannot `import` Base — the cycle is real — so Base is pushed in from
`base.ts` through the same `_registerBase` shape `schema-migration.ts` already
uses, and both call sites drop the `ownerName:` kwarg. The pre-Base-load window
keeps the config-name descriptor fallback, where Ruby's constant would not
resolve either.

### `translate_exception` drops `cause:`

`sqlite3_adapter.rb:698-702` builds each error with `sql:`, `binds:` and
`connection_pool:` only; Ruby sets `Exception#cause` implicitly from `$!` at the
`raise` site. JS chains nothing at a `throw`, so the driver error is attached
after construction instead of appearing in the argument list — in
`translateExceptionClass`, beside the `set_backtrace` analogue
(`abstract_adapter.rb:1130`), which is the shared funnel every adapter's public
translator routes through, and in the sqlite3 translator's own raise-site proxy
for its direct `throw this._translateException(...)` sites. `error.cause` still
resolves to the driver error; the assertions in `adapter.test.ts` and
`adapters/mysql2/mysql2-adapter.test.ts` are untouched and green.

### Baseline row counts

The story text says four `kind: "args"` rows for `translate_exception`; only
one existed. The gate keys a row on `package + tsFile + rubyName + call +
rubyArgs`, so the five `new` call sites in `translate_exception` that share an
argument signature dedup into a single row. One row removed, not four —
`database-tasks.json` loses its two, for three deletions total.

### Not in this PR

Two stories from the bundle are **released back to the queue**, unstarted:

- `pg-reset-body-under-one-lock` — an architectural change already attempted and
  reverted once with measured deadlock evidence (#6365). Landing it means
  removing the in-lock `_inFlightReset` waits in `withRawConnection`,
  `_acquireFreshClient` and `verifyBang` while preserving
  `awaitRawConnectionReady`'s socket-reopen duty, and verifying against a live
  PG. It needs a session of its own, not the tail of a five-story bundle.
- `call-args-ar-host-param-encryption` — converging the 13 rows means moving the
  instance-side half of `EncryptableRecord` to the `this`-typed mixin idiom,
  which crosses the deliberate `encryptionHooks` registry (it exists to keep
  zlib/crypto out of browser bundles) and ~24 call sites. Too large to bolt on
  here without doing it badly.

### Verification

`pnpm parity:api:calls:args` OK (388 baselined shape rows), `pnpm parity:api:calls`
OK, `pnpm lint`, `pnpm typecheck`. Locally green:
`associations/**` (91 files), `adapter.test.ts`,
`abstract-adapter.query-logging.test.ts`, `tasks/database-tasks.test.ts`,
`connection-handling.test.ts`, `multi-db-migrator*.test.ts`, `multiple-db.test.ts`.

Closes-story: call-args-ar-has-many-habtm-scope-positional
Closes-story: converge-establish-connection-owner-name-default
Closes-story: converge-translate-exception-cause-kwarg
