### PR TITLE
fix(activerecord): run the PostgreSQL reset! body under one lock

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -332,12 +332,12 @@ describeIfPg("PostgreSQLAdapter", () => {
       }
     });
 
-    // `resetBang` defers its body behind `_inFlightReset` and query paths wait
-    // on that barrier — several of them while already holding the connection
-    // lock. So the deferred body must NOT need that lock: a reset that waited
-    // for it would be queued behind a query that is waiting for the reset.
-    // Rails cannot reach the state (its `reset!` blocks under `@lock`), and
-    // this test is what proves the port doesn't either.
+    // `resetBang` is sync and cannot block, so it schedules its body onto the
+    // connection lock (Rails takes that lock inline, postgresql_adapter.rb:372)
+    // and returns. A query already holding the lock must therefore never wait
+    // on the queued reset — it would be waiting on work queued behind itself.
+    // This is what pins the one-mechanism arrangement: query paths serialize
+    // against the reset on the lock alone, never on a second barrier.
     it("a query holding the lock does not wait on a reset queued behind it", async () => {
       const other = new PostgreSQLAdapter(PG_TEST_URL);
       try {

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -2429,12 +2429,10 @@ export class AbstractAdapter implements Quoting {
       // Rails: `connect! if @raw_connection.nil? && reconnect_can_restore_state?`
       // (abstract_adapter.rb:985), and `connect!` is `verify!` (rb:778-781).
       if (this._connection === null && this.isReconnectCanRestoreState()) await this.connectBang();
-      // Drain any deferred connection-readiness work (PostgreSQLAdapter's
-      // async reset barrier: ROLLBACK + DISCARD ALL + reconfigure) ONCE here,
-      // before any query runs. Rails' `reset!` blocks, so the connection is
-      // already scrubbed by the time the loop yields it; trails' `resetBang`
-      // can't block, so it defers behind a promise this hook awaits. Pre-loop
-      // (not per-iteration) — a no-op for adapters with no deferred work.
+      // Drain any deferred connection-readiness work (PostgreSQLAdapter
+      // re-opens a socket a failed reconfigure tore down, and drains orphaned
+      // prepared statements) ONCE here, before any query runs. Pre-loop (not
+      // per-iteration) — a no-op for adapters with no deferred work.
       await this.awaitRawConnectionReady();
       if (materializeTransactions) await this.materializeTransactions();
 
@@ -2501,7 +2499,7 @@ export class AbstractAdapter implements Quoting {
    * on retry. Mysql2Adapter overrides this to re-await its driver-level
    * connect so reconnectBang() + continue picks up a fresh handle. PG no
    * longer overrides it: connectBang()/reconnect() populate _connection
-   * eagerly and awaitRawConnectionReady() drains the reset barrier pre-loop.
+   * eagerly and awaitRawConnectionReady() re-opens a torn-down socket pre-loop.
    *
    * Mirrors: AbstractAdapter#with_raw_connection (yield @raw_connection)
    */
@@ -2513,10 +2511,11 @@ export class AbstractAdapter implements Quoting {
    * @internal
    * Overridable readiness barrier awaited once per `withRawConnection` call,
    * after the eager `connectBang()` and before any query. Default no-op.
-   * PostgreSQLAdapter overrides it to drain its async reset barrier
-   * (`_inFlightReset`: ROLLBACK → DISCARD ALL → reconfigure) so the connection
-   * yielded by the loop is guaranteed scrubbed + reconfigured, matching Rails
-   * where `reset!` blocks before `with_raw_connection` ever yields.
+   * PostgreSQLAdapter overrides it to re-open a socket a failed reconfigure
+   * tore down and to drain orphaned prepared statements, so the connection
+   * yielded by the loop is guaranteed live and configured. Serializing against
+   * `reset!` is not its job — that runs under the same lock this call is
+   * already inside (postgresql_adapter.rb:372).
    */
   protected async awaitRawConnectionReady(): Promise<void> {}
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.get-client.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.get-client.test.ts
@@ -21,10 +21,10 @@ import { PostgreSQLAdapter } from "./postgresql-adapter.js";
 interface PrivatePgAdapter {
   _rawConnection: unknown;
   _client: unknown;
-  _inFlightReset: Promise<void> | null;
   _acquireFreshClient: () => Promise<unknown>;
   reconnect: () => void;
   resetBang: () => void;
+  transactionManager: { synchronize: <T>(fn: () => Promise<T> | T) => Promise<T> };
   close: () => Promise<void>;
   isConnected: () => boolean;
 }
@@ -98,7 +98,7 @@ describe("PostgreSQLAdapter#getClient (single persistent connection)", () => {
     expect(adapter.isConnected()).toBe(false);
   });
 
-  it("resetBang barrier: real _acquireFreshClient waits until DISCARD ALL resolves", async () => {
+  it("resetBang runs ROLLBACK + DISCARD ALL + reconfigure under one lock", async () => {
     adapter = new PostgreSQLAdapter({ host: "localhost", port: 1 }) as unknown as PrivatePgAdapter;
 
     const order: string[] = [];
@@ -109,8 +109,8 @@ describe("PostgreSQLAdapter#getClient (single persistent connection)", () => {
 
     const fakeClient = {
       query: vi.fn(async (sql: string) => {
+        order.push(sql);
         if (sql === "DISCARD ALL") {
-          order.push("discard-start");
           await discardGate;
           order.push("discard-end");
         }
@@ -119,40 +119,36 @@ describe("PostgreSQLAdapter#getClient (single persistent connection)", () => {
       end: async () => {},
       on: () => fakeClient,
     };
-    // Pre-seed the connection so _doAcquire reuses it rather than
-    // opening a new socket (avoids real network I/O).
+    // Pre-seed the connection so nothing opens a real socket, and mark the
+    // adapter mid-transaction so the conditional ROLLBACK arm runs (Rails'
+    // `transaction_status != PQTRANS_IDLE`, postgresql_adapter.rb:375).
     adapter._rawConnection = fakeClient;
+    adapter._client = fakeClient;
 
-    // resetBang() clears _connectionConfigured, so _acquireFreshClient
-    // will call _maybeConfigureConnection via _doAcquire after the
-    // barrier clears. Stub it to avoid real SET queries on the fake client.
+    // resetBang() clears _connectionConfigured, so the body reconfigures.
+    // Stub it to avoid real SET queries on the fake client.
     vi.spyOn(
       adapter as unknown as { _maybeConfigureConnection: () => Promise<void> },
       "_maybeConfigureConnection",
     ).mockResolvedValue(undefined);
 
-    // Fire resetBang (sync) — sets _inFlightReset before returning.
+    // Fired from outside the lock, as a pool reap/checkin is.
     adapter.resetBang();
-    expect(adapter._inFlightReset).not.toBeNull();
 
-    // Concurrent acquire using the REAL _acquireFreshClient — must queue
-    // behind the in-flight reset.
-    const acquirePromise = adapter._acquireFreshClient().then((c) => {
-      order.push("acquire-done");
-      return c;
+    // A foreign chain taking the same lock — Rails' `@lock.synchronize`
+    // (postgresql_adapter.rb:372) is what keeps it out of the reset body.
+    const foreign = adapter.transactionManager.synchronize(() => {
+      order.push("foreign");
     });
 
-    // Yield several microtask ticks; DISCARD ALL gate holds everything up.
-    for (let i = 0; i < 5; i++) await Promise.resolve();
-    expect(order).toEqual(["discard-start"]);
+    // Yield several microtask ticks; the DISCARD ALL gate holds the lock.
+    for (let i = 0; i < 8; i++) await Promise.resolve();
+    expect(order).toEqual(["ROLLBACK", "DISCARD ALL"]);
 
-    // Release DISCARD ALL — the acquire should now proceed.
     resolveDiscard();
-    await acquirePromise;
+    await foreign;
 
-    expect(order).toEqual(["discard-start", "discard-end", "acquire-done"]);
-    // Barrier is cleared after reset completes.
-    expect(adapter._inFlightReset).toBeNull();
+    expect(order).toEqual(["ROLLBACK", "DISCARD ALL", "discard-end", "foreign"]);
   });
 
   it("serializes the initial connect so concurrent callers share one pg.Client", async () => {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -502,8 +502,9 @@ export class PostgreSQLAdapter
   // Whether the eager load_additional_types pass has run for the current
   // physical connection. Reset on disconnect/discard (a brand-new socket needs
   // it) but NOT on resetBang: DISCARD ALL leaves the in-memory type map intact,
-  // and the reset reconfigure runs inside the _inFlightReset barrier — issuing
-  // the pg_type queries there would deadlock awaitRawConnectionReady.
+  // and the reset reconfigure runs while the reset holds the connection lock —
+  // routing the pg_type queries back through withRawConnection would re-enter
+  // it needlessly.
   private _typeMapEagerLoaded = false;
   // The single StatementPool attached to _rawConnection. PG prepared
   // statements are session-scoped; lifetime tracks _rawConnection.
@@ -534,10 +535,6 @@ export class PostgreSQLAdapter
   // parallel — mirrors Rails' @lock.synchronize around connect (Rails
   // postgresql_adapter.rb:349, abstract_adapter.rb:984).
   private _acquiring: Promise<pg.Client> | null = null;
-  // In-flight reset promise (ROLLBACK + DISCARD ALL). Query paths await
-  // this before proceeding so no query can interleave between the two
-  // SQL commands that resetBang fires asynchronously.
-  private _inFlightReset: Promise<void> | null = null;
   // Accumulates PG NOTICE/WARNING messages fired during the current query.
   // Cleared before each query; processed by handleWarnings after.
   _noticeReceiverSqlWarnings: SQLWarning[] = [];
@@ -831,10 +828,10 @@ export class PostgreSQLAdapter
     //
     // The pg_type queries run DIRECTLY on `client` (like the SET statements
     // above), NOT through schemaQuery/withRawConnection. configure runs while
-    // the acquire machinery still holds `_acquiring` (and, on resetBang, inside
-    // the `_inFlightReset` barrier); routing these queries back through the
-    // connection-readiness stack would re-enter connectBang/verify or block on
-    // that barrier and deadlock. Issuing them on the raw socket sidesteps all
+    // the acquire machinery still holds `_acquiring` (and, on resetBang, while
+    // the reset holds the connection lock); routing these queries back through
+    // the connection-readiness stack would re-enter connectBang/verify and
+    // deadlock. Issuing them on the raw socket sidesteps all
     // of it, exactly as Rails runs them inline on the raw connection.
     //
     // Gated per physical socket: resetBang's DISCARD ALL leaves the in-memory
@@ -1299,14 +1296,6 @@ export class PostgreSQLAdapter
     if (this._closed || this._pgClientOptions == null) {
       throw new Error("PostgreSQLAdapter: connection is closed");
     }
-    // Serialize behind any in-flight reset (ROLLBACK + DISCARD ALL) so no
-    // query can interleave between the two commands resetBang fires.
-    while (this._inFlightReset) await this._inFlightReset;
-    // Re-check after the yield: a concurrent close/disconnect/discard
-    // may have run while we were waiting for the reset to complete.
-    if (this._closed || this._pgClientOptions == null) {
-      throw new Error("PostgreSQLAdapter: connection is closed");
-    }
     // Fast path: connection already opened and configured, no drain pending.
     if (this._rawConnection && this._connectionConfigured && !this._needsDeallocateAll) {
       return this._rawConnection;
@@ -1469,19 +1458,18 @@ export class PostgreSQLAdapter
   }
 
   /**
-   * Drain the async reset barrier before the base `withRawConnection` loop
-   * yields `this._connection`. `resetBang` defers ROLLBACK + DISCARD ALL +
-   * reconfigure behind `_inFlightReset` (it can't block the way Rails'
-   * `reset!` does); awaiting it here — once per call, pre-loop — guarantees
-   * the yielded socket is scrubbed and reconfigured, with no per-iteration
-   * re-acquire. The connection itself is opened eagerly by `connectBang()`
-   * (initial use) or `reconnect()` (post-failure), so there is nothing left
-   * to acquire here. Replaces the deleted `rawConnectionForBlock` seam.
+   * Re-open / drain the connection before the base `withRawConnection` loop
+   * yields `this._connection`. Serialization against `resetBang` is NOT this
+   * hook's job: the reset body runs under the same `@lock` the loop already
+   * holds (postgresql_adapter.rb:372), so it can only run before or after this
+   * call, never between two of the statements it fires. The connection itself
+   * is opened eagerly by `connectBang()` (initial use) or `reconnect()`
+   * (post-failure), so there is nothing left to acquire here. Replaces the
+   * deleted `rawConnectionForBlock` seam.
    *
    * @internal
    */
   protected override async awaitRawConnectionReady(): Promise<void> {
-    while (this._inFlightReset) await this._inFlightReset;
     // If the reset's reconfigure step failed it tore down the socket; re-open
     // a fresh, configured connection so the loop never yields an unconfigured
     // (or null) one. connect() throws here only if the server is truly down —
@@ -2750,9 +2738,6 @@ export class PostgreSQLAdapter
       this.verifiedBang();
       return;
     }
-    while (this._inFlightReset) await this._inFlightReset;
-    // Re-check after the yield: a concurrent disconnect/close/discard
-    // may have nulled _rawConnection while we were waiting.
     const conn = this._rawConnection;
     if (this._closed || !conn) {
       await this.reconnectBang({ restoreTransactions: true });
@@ -2760,7 +2745,10 @@ export class PostgreSQLAdapter
       return;
     }
     try {
-      await conn.query(";");
+      // Rails' `active?` sends its `;` ping under `@lock`
+      // (postgresql_adapter.rb:348-352), so it can never land between the
+      // statements `reset!` fires under the same lock.
+      await this._transactionManager.synchronize(() => conn.query(";"));
     } catch {
       await this.reconnectBang({ restoreTransactions: true });
     }
@@ -2781,58 +2769,51 @@ export class PostgreSQLAdapter
       super.resetBang();
       return;
     }
-    // Capture the live connection so subsequent DISCARD ALL chains
-    // onto it even if a concurrent reconnect later nulls
-    // _rawConnection. resetBang is sync per AbstractAdapter, so we
-    // can't truly await — chain via .then so DISCARD ALL is sent
-    // only AFTER ROLLBACK's response is processed (matching the
-    // sequence in Rails' reset!, postgresql_adapter.rb:371-382).
+    // Capture the live connection so DISCARD ALL still chains onto it even if
+    // a concurrent reconnect later nulls _rawConnection.
     const live = this._rawConnection;
-    let work: Promise<unknown> = Promise.resolve();
-    if (this._client) {
-      // No CancelRequest: `reset!` waits behind the query on the wire, it never
-      // cancels one — `cancel_any_running_query`'s only callers are
-      // `exec_rollback_db_transaction` / `exec_restart_db_transaction`
-      // (postgresql/database_statements.rb:79, :84). Cancelling here killed a
-      // query a DIFFERENT chain owned, since `resetBang` runs outside the lock
-      // Rails holds (postgresql_adapter.rb:372); node-pg queues this ROLLBACK
-      // behind that query on the same client, which is the ordering Rails gets
-      // from the lock.
-      work = live.query("ROLLBACK").catch(() => {});
-      this._client = null;
-      this._inTransaction = false;
-    }
-    // Gate all query paths behind this promise so no query can interleave
-    // between ROLLBACK and DISCARD ALL. _acquireFreshClient awaits it.
-    // Capture in a local so the .finally() only clears the barrier when
-    // this specific reset is still the active one — prevents a second
-    // concurrent resetBang() from having its barrier cleared prematurely
-    // by the first reset's .finally().
     // DISCARD ALL also resets session-level GUCs (standard_conforming_
     // strings, intervalstyle, client_min_messages, custom variables) —
-    // mark the connection unconfigured so the chain below (and any racing
+    // mark the connection unconfigured so the body below (and any racing
     // acquire) re-runs _maybeConfigureConnection. Matches Rails' reset!,
     // which calls attempt_configure_connection via super
-    // (abstract_adapter.rb:729). Set BEFORE building the chain so the
-    // chained _maybeConfigureConnection sees it false and reconfigures.
+    // (abstract_adapter.rb:729). Set BEFORE scheduling the body so a racing
+    // _maybeConfigureConnection sees it false and reconfigures.
     this._connectionConfigured = false;
-    const reset: Promise<void> = work
-      .then(() => live.query("DISCARD ALL"))
-      // Re-run configure_connection on the SAME socket once DISCARD ALL has
-      // landed, so a connection yielded by withRawConnection (which drains
-      // this barrier via awaitRawConnectionReady) is already reconfigured —
-      // mirroring Rails' blocking reset! → super → configure_connection.
-      // Guard on socket identity: a concurrent reconnect may have swapped in
-      // a new client, in which case its own acquire handles configuration.
-      // On configure failure, tear down the socket (mirroring _doAcquire's
-      // catch) so awaitRawConnectionReady re-opens a fresh, configured
-      // connection rather than yielding an unconfigured one.
-      .then(() => {
+    // Rails wraps the whole body — the conditional ROLLBACK, DISCARD ALL and
+    // super — in ONE @lock.synchronize (postgresql_adapter.rb:372-381), so no
+    // foreign query can interleave between those statements. resetBang is sync
+    // per AbstractAdapter and cannot block for the lock, so the body is
+    // scheduled onto it instead: it runs to completion once, uninterrupted,
+    // and every query path serializes on the same lock rather than on a
+    // separate reset barrier.
+    // The lock lives on the TransactionManager, and `super.resetBang()` swaps
+    // that manager out (`reset_transaction`, database-statements.ts), so hold
+    // the one that is current now: a foreign query entering while the body
+    // runs reads the same manager and queues on the same lock.
+    const lock = this._transactionManager;
+    void lock
+      .synchronize(async () => {
+        if (this._client) {
+          // No CancelRequest: `reset!` waits behind the query on the wire, it
+          // never cancels one — `cancel_any_running_query`'s only callers are
+          // `exec_rollback_db_transaction` / `exec_restart_db_transaction`
+          // (postgresql/database_statements.rb:79, :84).
+          await live.query("ROLLBACK").catch(() => {});
+          this._client = null;
+          this._inTransaction = false;
+        }
+        await live.query("DISCARD ALL");
+        // Guard on socket identity: a concurrent reconnect may have swapped in
+        // a new client, in which case its own acquire handles configuration.
+        // On configure failure, tear down the socket (mirroring _doAcquire's
+        // catch) so awaitRawConnectionReady re-opens a fresh, configured
+        // connection rather than yielding an unconfigured one.
         if (this._rawConnection === live && !this._closed) {
-          // Rails' reset! ends in configure_connection
-          // (postgresql_adapter.rb:371), so the dispatch goes through the
+          // Rails' reset! ends in configure_connection via super
+          // (postgresql_adapter.rb:380), so the dispatch goes through the
           // public, overridable hook.
-          return this.configureConnection().catch((error: unknown) => {
+          await this.configureConnection().catch((error: unknown) => {
             if (this._rawConnection === live) {
               this._rawConnection = null;
               this._connectionConfigured = false;
@@ -2844,17 +2825,15 @@ export class PostgreSQLAdapter
             throw error;
           });
         }
+        // DISCARD ALL drops server-side prepared statements — reset the
+        // local pool so a later PREPARE name (a1, a2, ...) doesn't collide.
+        this._statementPool?.reset();
+        // Rails' `super` — clear_cache!(new_connection: true) + reset_transaction
+        // (abstract_adapter.rb:728-731) — runs inside the same lock, last
+        // (postgresql_adapter.rb:380).
+        super.resetBang();
       })
-      .then(() => {})
-      .catch(() => {})
-      .finally(() => {
-        if (this._inFlightReset === reset) this._inFlightReset = null;
-      });
-    this._inFlightReset = reset;
-    // DISCARD ALL drops server-side prepared statements — reset the
-    // local pool so a later PREPARE name (a1, a2, ...) doesn't collide.
-    this._statementPool?.reset();
-    super.resetBang();
+      .catch(() => {});
   }
 
   /**


### PR DESCRIPTION
Rails wraps the whole `reset!` body — the conditional `ROLLBACK`, `DISCARD ALL` and `super` — in one `@lock.synchronize` (`postgresql_adapter.rb:372-381`), so no foreign query can interleave between those statements. trails' `resetBang` is sync and cannot block, so it deferred the body behind an `_inFlightReset` barrier and took no lock at all: a query could land between ROLLBACK and DISCARD ALL, and DISCARD ALL could clobber session state a foreign chain had just set up.

## What changed

Two serialization mechanisms collapse into one. `resetBang` schedules its body onto the connection lock; every query path then serializes on that lock alone, so the in-lock `_inFlightReset` waits — `awaitRawConnectionReady` (inside `withRawConnection`'s `synchronize`), `_acquireFreshClient` and `verifyBang` — go away with the field. Those waits are exactly what deadlocked the lock-taking attempt in #6365: a lock-taking reset queued behind a query that was waiting on the reset.

`awaitRawConnectionReady` keeps its second duty (re-open a socket a failed reconfigure tore down, drain orphaned prepared statements), which `disconnect and recover on #configure_connection failure` in `adapter.test.ts` covers.

Two details the lock scope depends on:

- `super.resetBang()` swaps the `TransactionManager` (`reset_transaction`), and in trails the lock lives on that manager. So the body holds the manager that was current when the reset fired and calls `super` **last, inside the lock** — the position Rails' `super` occupies (`postgresql_adapter.rb:380`). Without this the manager swap released the lock mid-body and a foreign query interleaved (caught by the rewritten unit test).
- `verifyBang`'s `;` ping now runs under the lock, as Rails' `active?` does (`postgresql_adapter.rb:348-352`); it no longer needs a barrier wait to stay out of the reset body.

## Verification

- `a query holding the lock does not wait on a reset queued behind it` and `reset does not cancel a query issued by another chain` both stay green against the real server (`postgresql-adapter.trails.test.ts`, 121 passed).
- The `resetBang` unit test in `postgresql-adapter.get-client.test.ts` now pins the lock scope instead of the deleted barrier: ROLLBACK → DISCARD ALL → reconfigure complete before a foreign `synchronize` caller runs.
- PG lane: `adapters/postgresql/**` (988 passed; the one failure is the local box missing `pg_dump`), `connection-adapters/**` + `adapter.test.ts` + `transactions.test.ts` (1906 passed). SQLite lane: same set, 1825 passed.
- `parity:api:calls` and `parity:api:calls:args` both OK; the `reset!` / `synchronize` call mismatch is gone from `output/call-mismatches.json` (`connection-adapters/postgresql-adapter.ts` drops from 26 to 25 rows). It had no row in `call-mismatches-exclude/`, so there is none to delete.

Closes-story: pg-reset-body-under-one-lock