### PR TITLE
refactor(arel,activemodel,activerecord,activesupport): inline the ESCAPE arm, port COMPARE_CHECKS as a Hash, and take callback method names

### DIFF
--- a/packages/activemodel/src/callbacks.ts
+++ b/packages/activemodel/src/callbacks.ts
@@ -144,7 +144,10 @@ export interface TransactionalCallbackConditions<
 export function _defineBeforeModelCallback(klass: CallbackHost, event: string): void {
   const capitalizedEvent = event.charAt(0).toUpperCase() + event.slice(1);
   Object.defineProperty(klass, `before${capitalizedEvent}`, {
-    value: function (fnOrObject: CallbackFn | CallbackObject, conditions?: CallbackConditions) {
+    value: function (
+      fnOrObject: CallbackFn | CallbackObject | string,
+      conditions?: CallbackConditions,
+    ) {
       _registerCallbackOnProto(this.prototype, "before", event, fnOrObject, conditions);
     },
     writable: true,
@@ -162,7 +165,7 @@ export function _defineAroundModelCallback(klass: CallbackHost, event: string): 
   const capitalizedEvent = event.charAt(0).toUpperCase() + event.slice(1);
   Object.defineProperty(klass, `around${capitalizedEvent}`, {
     value: function (
-      fnOrObject: AroundCallbackFn | CallbackObject,
+      fnOrObject: AroundCallbackFn | CallbackObject | string,
       conditions?: CallbackConditions,
     ) {
       _registerCallbackOnProto(this.prototype, "around", event, fnOrObject, conditions);
@@ -179,7 +182,10 @@ export function _defineAroundModelCallback(klass: CallbackHost, event: string): 
 export function _defineAfterModelCallback(klass: CallbackHost, event: string): void {
   const capitalizedEvent = event.charAt(0).toUpperCase() + event.slice(1);
   Object.defineProperty(klass, `after${capitalizedEvent}`, {
-    value: function (fnOrObject: CallbackFn | CallbackObject, conditions?: CallbackConditions) {
+    value: function (
+      fnOrObject: CallbackFn | CallbackObject | string,
+      conditions?: CallbackConditions,
+    ) {
       _registerCallbackOnProto(this.prototype, "after", event, fnOrObject, conditions);
     },
     writable: true,
@@ -280,7 +286,7 @@ export function _registerCallbackOnProto(
   proto: object,
   timing: CallbackTiming,
   event: string,
-  fn: CallbackFn | AroundCallbackFn | CallbackObject,
+  fn: CallbackFn | AroundCallbackFn | CallbackObject | string,
   conditions?: CallbackConditions | TransactionalCallbackConditions,
 ): void {
   if (conditions && "on" in conditions) {

--- a/packages/activemodel/src/validations/comparability.ts
+++ b/packages/activemodel/src/validations/comparability.ts
@@ -43,30 +43,36 @@ export interface Comparability {
 }
 
 /**
- * Applies a COMPARE_CHECKS operator to a `<=>` result.
+ * Applies a COMPARE_CHECKS operator to two values.
  *
  * Rails dispatches the operator directly off the value —
  * `value.public_send(COMPARE_CHECKS[option], option_value)`
  * (comparison.rb:27, numericality.rb:60). TypeScript has neither
- * `public_send` nor operator methods, so the operator Symbol is applied
- * to the comparison result the caller computed.
+ * `public_send` nor operator methods, so the operator Symbol selects the
+ * JS operator instead. Callers whose values are not directly comparable
+ * (ComparisonValidator's Temporal/string/number mix) pass their `<=>`
+ * result against `0`, exactly as Ruby's Comparable defines the operators.
  *
  * @noRailsEquivalent PERMANENT: TypeScript has no `public_send` and no operator
  * methods, so a Ruby comparison-operator Symbol cannot be dispatched off the value
  */
-export function compareOperator(op: (typeof COMPARE_CHECKS)[CompareKey], cmp: number): boolean {
+export function compareOperator(
+  op: (typeof COMPARE_CHECKS)[CompareKey],
+  a: number,
+  b: number,
+): boolean {
   switch (op) {
     case ":>":
-      return cmp > 0;
+      return a > b;
     case ":>=":
-      return cmp >= 0;
+      return a >= b;
     case ":==":
-      return cmp === 0;
+      return a === b;
     case ":<":
-      return cmp < 0;
+      return a < b;
     case ":<=":
-      return cmp <= 0;
+      return a <= b;
     case ":!=":
-      return cmp !== 0;
+      return a !== b;
   }
 }

--- a/packages/activemodel/src/validations/comparability.ts
+++ b/packages/activemodel/src/validations/comparability.ts
@@ -4,23 +4,20 @@
  * Mirrors: ActiveModel::Validations::Comparability
  *
  * Included by ComparisonValidator and NumericalityValidator. Provides
- * COMPARE_CHECKS (the comparison option keys) and error_options which
+ * COMPARE_CHECKS (each comparison option mapped to the Ruby comparison
+ * operator the validator dispatches through) and error_options which
  * builds the i18n interpolation hash by stripping comparison keys from
  * the validator's options and merging in :count + :value.
  */
 
-export const COMPARE_CHECKS = [
-  "greaterThan",
-  "greaterThanOrEqualTo",
-  "equalTo",
-  "lessThan",
-  "lessThanOrEqualTo",
-  "otherThan",
-] as const;
-
-export interface Comparability {
-  errorOptions(value: unknown, optionValue: unknown): Record<string, unknown>;
-}
+export const COMPARE_CHECKS = {
+  greaterThan: ":>",
+  greaterThanOrEqualTo: ":>=",
+  equalTo: ":==",
+  lessThan: ":<",
+  lessThanOrEqualTo: ":<=",
+  otherThan: ":!=",
+} as const;
 
 export function errorOptions(
   this: { options: Record<string, unknown> },
@@ -28,12 +25,48 @@ export function errorOptions(
   optionValue: unknown,
 ): Record<string, unknown> {
   const rest: Record<string, unknown> = {};
+  const compareKeys = Object.keys(COMPARE_CHECKS);
   for (const key of Object.keys(this.options)) {
-    if (!(COMPARE_CHECKS as readonly string[]).includes(key)) {
+    if (!compareKeys.includes(key)) {
       rest[key] = this.options[key];
     }
   }
   rest.count = optionValue;
   rest.value = value;
   return rest;
+}
+
+export type CompareKey = keyof typeof COMPARE_CHECKS;
+
+export interface Comparability {
+  errorOptions(value: unknown, optionValue: unknown): Record<string, unknown>;
+}
+
+/**
+ * Applies a COMPARE_CHECKS operator to a `<=>` result.
+ *
+ * Rails dispatches the operator directly off the value —
+ * `value.public_send(COMPARE_CHECKS[option], option_value)`
+ * (comparison.rb:27, numericality.rb:60). TypeScript has neither
+ * `public_send` nor operator methods, so the operator Symbol is applied
+ * to the comparison result the caller computed.
+ *
+ * @noRailsEquivalent PERMANENT: TypeScript has no `public_send` and no operator
+ * methods, so a Ruby comparison-operator Symbol cannot be dispatched off the value
+ */
+export function compareOperator(op: (typeof COMPARE_CHECKS)[CompareKey], cmp: number): boolean {
+  switch (op) {
+    case ":>":
+      return cmp > 0;
+    case ":>=":
+      return cmp >= 0;
+    case ":==":
+      return cmp === 0;
+    case ":<":
+      return cmp < 0;
+    case ":<=":
+      return cmp <= 0;
+    case ":!=":
+      return cmp !== 0;
+  }
 }

--- a/packages/activemodel/src/validations/comparison.ts
+++ b/packages/activemodel/src/validations/comparison.ts
@@ -2,37 +2,18 @@ import { Temporal } from "@blazetrails/date";
 import { ArgumentError } from "../attribute-assignment.js";
 import { EachValidator } from "../validator.js";
 import type { ValidatableRecord } from "../validator.js";
-import { isBlank } from "@blazetrails/activesupport";
-import { COMPARE_CHECKS, errorOptions } from "./comparability.js";
+import { isBlank, underscore } from "@blazetrails/activesupport";
+import { COMPARE_CHECKS, compareOperator, errorOptions } from "./comparability.js";
+import type { CompareKey } from "./comparability.js";
 import { resolveValue } from "./resolve-value.js";
-
-type CompareKey = (typeof COMPARE_CHECKS)[number];
-
-const COMPARE_OPS = {
-  greaterThan: (c) => c > 0,
-  greaterThanOrEqualTo: (c) => c >= 0,
-  equalTo: (c) => c === 0,
-  lessThan: (c) => c < 0,
-  lessThanOrEqualTo: (c) => c <= 0,
-  otherThan: (c) => c !== 0,
-} satisfies Record<CompareKey, (cmp: number) => boolean>;
-
-const COMPARE_KEYS_TO_RAILS = {
-  greaterThan: ":greater_than",
-  greaterThanOrEqualTo: ":greater_than_or_equal_to",
-  equalTo: ":equal_to",
-  lessThan: ":less_than",
-  lessThanOrEqualTo: ":less_than_or_equal_to",
-  otherThan: ":other_than",
-} satisfies Record<CompareKey, string>;
 
 export class ComparisonValidator extends EachValidator {
   resolveValue = resolveValue;
   errorOptions = errorOptions;
 
   validateEach(record: ValidatableRecord, attrName: string, value: unknown): void {
-    for (const optKey of COMPARE_CHECKS) {
-      const rawOptionValue = this.options[optKey];
+    for (const option of Object.keys(COMPARE_CHECKS) as CompareKey[]) {
+      const rawOptionValue = this.options[option];
       if (rawOptionValue === undefined) continue;
       const optionValue = this.resolveValue(record, rawOptionValue);
 
@@ -43,10 +24,10 @@ export class ComparisonValidator extends EachValidator {
 
       try {
         const cmp = this.compare(value, optionValue);
-        if (!COMPARE_OPS[optKey](cmp)) {
+        if (!compareOperator(COMPARE_CHECKS[option], cmp)) {
           record.errors.add(
             attrName,
-            COMPARE_KEYS_TO_RAILS[optKey],
+            `:${underscore(option)}`,
             this.errorOptions(value, optionValue),
           );
         }
@@ -86,7 +67,7 @@ export class ComparisonValidator extends EachValidator {
   }
 
   override checkValidity(): void {
-    if (!COMPARE_CHECKS.some((k) => this.options[k] !== undefined)) {
+    if (!Object.keys(COMPARE_CHECKS).some((k) => this.options[k] !== undefined)) {
       throw new ArgumentError(
         "One of :greater_than, :greater_than_or_equal_to, :less_than, :less_than_or_equal_to, :equal_to, or :other_than must be supplied",
       );

--- a/packages/activemodel/src/validations/comparison.ts
+++ b/packages/activemodel/src/validations/comparison.ts
@@ -24,7 +24,7 @@ export class ComparisonValidator extends EachValidator {
 
       try {
         const cmp = this.compare(value, optionValue);
-        if (!compareOperator(COMPARE_CHECKS[option], cmp)) {
+        if (!compareOperator(COMPARE_CHECKS[option], cmp, 0)) {
           record.errors.add(
             attrName,
             `:${underscore(option)}`,

--- a/packages/activemodel/src/validations/numericality.ts
+++ b/packages/activemodel/src/validations/numericality.ts
@@ -94,9 +94,6 @@ export class NumericalityValidator extends EachValidator {
       count,
     });
 
-    // Mirrors numericality.rb:58-63 — the compare branch of the
-    // `options.slice(*RESERVED_OPTIONS)` loop, dispatching through
-    // `value.public_send(COMPARE_CHECKS[option], option_value)`.
     for (const option of Object.keys(COMPARE_CHECKS) as CompareKey[]) {
       const rawOptionValue = this.options[option];
       if (rawOptionValue === undefined) continue;
@@ -107,7 +104,7 @@ export class NumericalityValidator extends EachValidator {
         scale,
       );
       if (optionValue === undefined) continue;
-      if (!compareOperator(COMPARE_CHECKS[option], num - optionValue)) {
+      if (!compareOperator(COMPARE_CHECKS[option], num, optionValue)) {
         record.errors.add(attribute, `:${underscore(option)}`, withCount(optionValue));
       }
     }

--- a/packages/activemodel/src/validations/numericality.ts
+++ b/packages/activemodel/src/validations/numericality.ts
@@ -1,7 +1,8 @@
 import { EachValidator } from "../validator.js";
 import type { ValidatableRecord } from "../validator.js";
-import { isBlank, RoundingHelper, BigDecimal } from "@blazetrails/activesupport";
-import { errorOptions } from "./comparability.js";
+import { isBlank, underscore, RoundingHelper, BigDecimal } from "@blazetrails/activesupport";
+import { COMPARE_CHECKS, compareOperator, errorOptions } from "./comparability.js";
+import type { CompareKey } from "./comparability.js";
 import { resolveValue } from "./resolve-value.js";
 import { ArgumentError, TypeError as RubyTypeError } from "../attribute-assignment.js";
 import { roundFloatToSignificantDigits } from "../type/decimal.js";
@@ -93,59 +94,22 @@ export class NumericalityValidator extends EachValidator {
       count,
     });
 
-    const gt = this.resolveNumeric(
-      this.options.greaterThan as NumericValue | undefined,
-      record,
-      precision,
-      scale,
-    );
-    if (gt !== undefined && !(num > gt)) {
-      record.errors.add(attribute, ":greater_than", withCount(gt));
-    }
-    const gte = this.resolveNumeric(
-      this.options.greaterThanOrEqualTo as NumericValue | undefined,
-      record,
-      precision,
-      scale,
-    );
-    if (gte !== undefined && !(num >= gte)) {
-      record.errors.add(attribute, ":greater_than_or_equal_to", withCount(gte));
-    }
-    const lt = this.resolveNumeric(
-      this.options.lessThan as NumericValue | undefined,
-      record,
-      precision,
-      scale,
-    );
-    if (lt !== undefined && !(num < lt)) {
-      record.errors.add(attribute, ":less_than", withCount(lt));
-    }
-    const lte = this.resolveNumeric(
-      this.options.lessThanOrEqualTo as NumericValue | undefined,
-      record,
-      precision,
-      scale,
-    );
-    if (lte !== undefined && !(num <= lte)) {
-      record.errors.add(attribute, ":less_than_or_equal_to", withCount(lte));
-    }
-    const eq = this.resolveNumeric(
-      this.options.equalTo as NumericValue | undefined,
-      record,
-      precision,
-      scale,
-    );
-    if (eq !== undefined && num !== eq) {
-      record.errors.add(attribute, ":equal_to", withCount(eq));
-    }
-    const ot = this.resolveNumeric(
-      this.options.otherThan as NumericValue | undefined,
-      record,
-      precision,
-      scale,
-    );
-    if (ot !== undefined && num === ot) {
-      record.errors.add(attribute, ":other_than", withCount(ot));
+    // Mirrors numericality.rb:58-63 — the compare branch of the
+    // `options.slice(*RESERVED_OPTIONS)` loop, dispatching through
+    // `value.public_send(COMPARE_CHECKS[option], option_value)`.
+    for (const option of Object.keys(COMPARE_CHECKS) as CompareKey[]) {
+      const rawOptionValue = this.options[option];
+      if (rawOptionValue === undefined) continue;
+      const optionValue = this.optionAsNumber(
+        record,
+        rawOptionValue as NumericValue,
+        precision,
+        scale,
+      );
+      if (optionValue === undefined) continue;
+      if (!compareOperator(COMPARE_CHECKS[option], num - optionValue)) {
+        record.errors.add(attribute, `:${underscore(option)}`, withCount(optionValue));
+      }
     }
     if (this.options.in !== undefined) {
       const [min, max] = this.options.in as [number, number];
@@ -161,26 +125,8 @@ export class NumericalityValidator extends EachValidator {
     }
   }
 
-  private resolveNumeric(
-    val: NumericValue | undefined,
-    record: ValidatableRecord,
-    precision: number,
-    scale?: number,
-  ): number | undefined {
-    if (val === undefined) return undefined;
-    return this.optionAsNumber(record, val, precision, scale);
-  }
-
   override checkValidity(): void {
-    const compareKeys = [
-      "greaterThan",
-      "greaterThanOrEqualTo",
-      "lessThan",
-      "lessThanOrEqualTo",
-      "equalTo",
-      "otherThan",
-    ] as const;
-    for (const key of compareKeys) {
+    for (const key of Object.keys(COMPARE_CHECKS) as CompareKey[]) {
       const val = this.options[key];
       if (
         val !== undefined &&
@@ -224,23 +170,16 @@ const NON_DECIMAL_LITERAL_REGEX = /^[+-]?0[xXbBoO]/;
 // Mirrors Rails numericality.rb:16:
 //   RESERVED_OPTIONS = COMPARE_CHECKS.keys + NUMBER_CHECKS.keys + RANGE_CHECKS.keys + [:only_integer, :only_numeric]
 // camelCased for trails option-key conventions.
+const RANGE_CHECKS = { in: ":in?" } as const;
+const NUMBER_CHECKS = { odd: ":odd?", even: ":even?" } as const;
+
 const RESERVED_OPTIONS = [
-  // COMPARE_CHECKS keys
-  "greaterThan",
-  "greaterThanOrEqualTo",
-  "equalTo",
-  "lessThan",
-  "lessThanOrEqualTo",
-  "otherThan",
-  // NUMBER_CHECKS keys
-  "odd",
-  "even",
-  // RANGE_CHECKS keys
-  "in",
-  // Misc
+  ...Object.keys(COMPARE_CHECKS),
+  ...Object.keys(NUMBER_CHECKS),
+  ...Object.keys(RANGE_CHECKS),
   "onlyInteger",
   "onlyNumeric",
-] as const;
+];
 
 /**
  * Mirrors: numericality.rb:67-69
@@ -453,7 +392,7 @@ export function filteredOptions(
 ): Record<string, unknown> {
   const filtered: Record<string, unknown> = {};
   for (const key of Object.keys(this.options)) {
-    if (!(RESERVED_OPTIONS as readonly string[]).includes(key)) {
+    if (!RESERVED_OPTIONS.includes(key)) {
       filtered[key] = this.options[key];
     }
   }

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1160,9 +1160,12 @@ export function _skipSingularStatementCache(
   // override makes the relation owner/context-dependent. Mirror all three arms
   // (the third — `hasDefaultScopeOverride` — covers a `def self.defaultScope`
   // that never lands in `defaultScopes`).
-  const klass = targetModel as unknown as { currentScope?: unknown; defaultScopes?: unknown[] };
+  const klass = targetModel as unknown as {
+    currentScope?(): unknown;
+    defaultScopes?: unknown[];
+  };
   if (
-    klass.currentScope ||
+    klass.currentScope?.() ||
     (klass.defaultScopes?.length ?? 0) > 0 ||
     hasDefaultScopeOverride(targetModel)
   ) {

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -326,7 +326,7 @@ export class Association {
     // Branch 2: klass.current_scope.proxy_association == self.
     // Fires when CollectionProxy.scoping sets an AssociationRelation as
     // klass.currentScope; not yet implemented, so this is unreachable.
-    const currentScope = (klass as any).currentScope;
+    const currentScope = (klass as any).currentScope();
     if (currentScope && currentScope.proxyAssociation === this) {
       return typeof currentScope.spawn === "function" ? currentScope.spawn() : currentScope;
     }

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -15,7 +15,7 @@ import { NestedError as AssociationsNestedError } from "./associations/nested-er
 import { _preloadedHolderTarget, type AssociationDefinition } from "./associations.js";
 import { hasQueryConstraints, queryConstraintsList } from "./persistence.js";
 import { underscore } from "@blazetrails/activesupport";
-import { afterCreate, afterUpdate, afterValidation, beforeSave } from "./callbacks.js";
+import { afterCreate, afterUpdate, beforeSave } from "./callbacks.js";
 
 const MARKED_FOR_DESTRUCTION = Symbol.for("blazetrails.markedForDestruction");
 const VALIDATING_BELONGS_TO_FOR = Symbol.for("blazetrails.validatingBelongsToFor");
@@ -1270,11 +1270,6 @@ export function defineNonCyclicMethod(klass: any, name: string, fn: (this: any) 
   }
 }
 
-const _AUTOSAVE_AROUND_SAVE_KEY = Symbol.for("blazetrails.autosaveAroundSaveRegistered");
-const _ensureNoDuplicateErrorsRegistered = Symbol.for(
-  "blazetrails.ensureNoDuplicateErrorsRegistered",
-);
-
 /**
  * Registers save callbacks for an association declared with `autosave: true`.
  *
@@ -1308,22 +1303,11 @@ export function addAutosaveAssociationCallbacks(model: any, reflection: any): vo
       : reflection.hasOne === true || reflection.macro === "hasOne" || reflection.type === "hasOne";
 
   if (isCollection) {
-    // around_save runs once per save regardless of how many collection
-    // associations are declared — mirrors Rails' dedup via the
-    // `:around_save_collection_association` symbol, which also dedups across
-    // the inheritance chain, hence the prototype-chain lookup: a second hook
-    // registered by a subclass nests, and the nested invocation's
-    // `!prev && new_record?` would clobber the outer `_newRecordBeforeSave`.
-    if (!(_AUTOSAVE_AROUND_SAVE_KEY in model)) {
-      Object.defineProperty(model, _AUTOSAVE_AROUND_SAVE_KEY, {
-        value: true,
-        configurable: true,
-        writable: false,
-      });
-      model.aroundSave(function (record: any, proceed: () => any) {
-        return aroundSaveCollectionAssociation.call(record, proceed);
-      });
-    }
+    // `around_save :around_save_collection_association` — the method-name
+    // filter is load-bearing: CallbackChain#remove_duplicates dedups on it, so
+    // the hook runs once per save no matter how many collection associations
+    // are declared, and across the inheritance chain.
+    model.aroundSave(":aroundSaveCollectionAssociation");
     defineNonCyclicMethod(model, saveMethod, async function (this: any) {
       return saveCollectionAssociation.call(this, reflection);
     });
@@ -1422,14 +1406,8 @@ export function defineAutosaveValidationCallbacks(klass: any, reflection: any): 
   if (typeof klass.validate === "function") {
     klass.validate(validationName);
   }
-  // Mirrors Rails: after_validation :_ensure_no_duplicate_errors (once per class).
-  // Own-property check mirrors the same pattern as the validation method guard above —
-  // a subclass inheriting the flag from its parent does NOT inherit the registered
-  // after_validation callback if its chains COW'd before the parent registration.
-  if (!Object.prototype.hasOwnProperty.call(klass, _ensureNoDuplicateErrorsRegistered)) {
-    klass[_ensureNoDuplicateErrorsRegistered] = true;
-    afterValidation(klass, (record: any) => {
-      _ensureNoDuplicateErrors.call(record);
-    });
-  }
+  // Mirrors Rails autosave_association.rb:233 —
+  // `after_validation :_ensure_no_duplicate_errors`. The method-name filter is
+  // what dedups the callback across every association on the class.
+  klass.afterValidation(":_ensureNoDuplicateErrors");
 }

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -1303,10 +1303,6 @@ export function addAutosaveAssociationCallbacks(model: any, reflection: any): vo
       : reflection.hasOne === true || reflection.macro === "hasOne" || reflection.type === "hasOne";
 
   if (isCollection) {
-    // `around_save :around_save_collection_association` — the method-name
-    // filter is load-bearing: CallbackChain#remove_duplicates dedups on it, so
-    // the hook runs once per save no matter how many collection associations
-    // are declared, and across the inheritance chain.
     model.aroundSave(":aroundSaveCollectionAssociation");
     defineNonCyclicMethod(model, saveMethod, async function (this: any) {
       return saveCollectionAssociation.call(this, reflection);
@@ -1406,8 +1402,5 @@ export function defineAutosaveValidationCallbacks(klass: any, reflection: any): 
   if (typeof klass.validate === "function") {
     klass.validate(validationName);
   }
-  // Mirrors Rails autosave_association.rb:233 —
-  // `after_validation :_ensure_no_duplicate_errors`. The method-name filter is
-  // what dedups the callback across every association on the class.
   klass.afterValidation(":_ensureNoDuplicateErrors");
 }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2281,8 +2281,8 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Base.current_scope
    */
-  static get currentScope(): any | null {
-    return ScopeRegistry.currentScope(this);
+  static currentScope(skipInheritedScope = false): any | null {
+    return ScopeRegistry.currentScope(this, skipInheritedScope);
   }
 
   /**
@@ -2372,7 +2372,7 @@ export class Base extends Model {
     this: T,
     options?: { allQueries?: boolean | null },
   ): Relation<InstanceType<T>> {
-    const scope = this.currentScope;
+    const scope = this.currentScope();
     if (scope) {
       // Rails' `all`: `self == scope.model ? scope.clone :
       // relation.merge!(scope)`. When the current scope was set on a
@@ -2676,7 +2676,7 @@ export class Base extends Model {
    * and yields each record to the block before save.
    */
   private static _mergeCurrentScopeAttrs(attrs: Record<string, unknown>): Record<string, unknown> {
-    const scope = this.currentScope;
+    const scope = this.currentScope();
     if (scope) {
       const scopeAttrs = scope.scopeForCreate?.() ?? {};
       return { ...scopeAttrs, ...attrs };

--- a/packages/activerecord/src/callbacks.ts
+++ b/packages/activerecord/src/callbacks.ts
@@ -31,6 +31,15 @@ export type CallbackOptions<TRecord = Base> = {
   prepend?: boolean;
 };
 
+/**
+ * A callback filter: a block, or — as Rails' macros take a Symbol — the NAME
+ * of a method on the record, resolved against it at invocation time
+ * (ActiveSupport::Callbacks::CallTemplate::MethodCall).
+ */
+export type CallbackFilter<TRecord, TReturn = void | Promise<void>> =
+  | ((record: TRecord) => TReturn)
+  | string;
+
 export type ValidationCallbackOptions<TRecord = Base> = CallbackOptions<TRecord> & {
   on?: "create" | "update" | Array<"create" | "update">;
 };
@@ -42,7 +51,7 @@ export type ValidationCallbackOptions<TRecord = Base> = CallbackOptions<TRecord>
  */
 export function beforeValidation<T extends ModelCtor>(
   modelClass: T,
-  fn: (record: InstanceType<T>) => void | Promise<void>,
+  fn: CallbackFilter<InstanceType<T>>,
   options?: ValidationCallbackOptions<InstanceType<T>>,
 ): void {
   registerCallback(modelClass, "before", "validation", fn, options);
@@ -55,7 +64,7 @@ export function beforeValidation<T extends ModelCtor>(
  */
 export function afterValidation<T extends ModelCtor>(
   modelClass: T,
-  fn: (record: InstanceType<T>) => void | Promise<void>,
+  fn: CallbackFilter<InstanceType<T>>,
   options?: ValidationCallbackOptions<InstanceType<T>>,
 ): void {
   registerCallback(modelClass, "after", "validation", fn, options);
@@ -68,7 +77,7 @@ export function afterValidation<T extends ModelCtor>(
  */
 export function beforeSave<T extends ModelCtor>(
   modelClass: T,
-  fn: (record: InstanceType<T>) => void | Promise<void> | false,
+  fn: CallbackFilter<InstanceType<T>, void | Promise<void> | false>,
   options?: CallbackOptions<InstanceType<T>>,
 ): void {
   registerCallback(modelClass, "before", "save", fn, options);
@@ -81,7 +90,7 @@ export function beforeSave<T extends ModelCtor>(
  */
 export function afterSave<T extends ModelCtor>(
   modelClass: T,
-  fn: (record: InstanceType<T>) => void | Promise<void>,
+  fn: CallbackFilter<InstanceType<T>>,
   options?: CallbackOptions<InstanceType<T>>,
 ): void {
   registerCallback(modelClass, "after", "save", fn, options);
@@ -94,7 +103,7 @@ export function afterSave<T extends ModelCtor>(
  */
 export function beforeCreate<T extends ModelCtor>(
   modelClass: T,
-  fn: (record: InstanceType<T>) => void | Promise<void> | false,
+  fn: CallbackFilter<InstanceType<T>, void | Promise<void> | false>,
   options?: CallbackOptions<InstanceType<T>>,
 ): void {
   registerCallback(modelClass, "before", "create", fn, options);
@@ -107,7 +116,7 @@ export function beforeCreate<T extends ModelCtor>(
  */
 export function afterCreate<T extends ModelCtor>(
   modelClass: T,
-  fn: (record: InstanceType<T>) => void | Promise<void>,
+  fn: CallbackFilter<InstanceType<T>>,
   options?: CallbackOptions<InstanceType<T>>,
 ): void {
   registerCallback(modelClass, "after", "create", fn, options);
@@ -120,7 +129,7 @@ export function afterCreate<T extends ModelCtor>(
  */
 export function beforeUpdate<T extends ModelCtor>(
   modelClass: T,
-  fn: (record: InstanceType<T>) => void | Promise<void> | false,
+  fn: CallbackFilter<InstanceType<T>, void | Promise<void> | false>,
   options?: CallbackOptions<InstanceType<T>>,
 ): void {
   registerCallback(modelClass, "before", "update", fn, options);
@@ -133,7 +142,7 @@ export function beforeUpdate<T extends ModelCtor>(
  */
 export function afterUpdate<T extends ModelCtor>(
   modelClass: T,
-  fn: (record: InstanceType<T>) => void | Promise<void>,
+  fn: CallbackFilter<InstanceType<T>>,
   options?: CallbackOptions<InstanceType<T>>,
 ): void {
   registerCallback(modelClass, "after", "update", fn, options);
@@ -146,7 +155,7 @@ export function afterUpdate<T extends ModelCtor>(
  */
 export function beforeDestroy<T extends ModelCtor>(
   modelClass: T,
-  fn: (record: InstanceType<T>) => void | Promise<void> | false,
+  fn: CallbackFilter<InstanceType<T>, void | Promise<void> | false>,
   options?: CallbackOptions<InstanceType<T>>,
 ): void {
   registerCallback(modelClass, "before", "destroy", fn, options);
@@ -159,7 +168,7 @@ export function beforeDestroy<T extends ModelCtor>(
  */
 export function afterDestroy<T extends ModelCtor>(
   modelClass: T,
-  fn: (record: InstanceType<T>) => void | Promise<void>,
+  fn: CallbackFilter<InstanceType<T>>,
   options?: CallbackOptions<InstanceType<T>>,
 ): void {
   registerCallback(modelClass, "after", "destroy", fn, options);
@@ -234,7 +243,7 @@ function registerCallback(
   modelClass: ModelCtor,
   timing: "before" | "after",
   event: string,
-  fn: (...args: any[]) => unknown,
+  fn: ((...args: any[]) => unknown) | string,
   options?: AnyCallbackOptions,
 ): void {
   const conditions: Record<string, unknown> = {};

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -1181,7 +1181,7 @@ export function subclassFromAttributesForNew(
   let subclass = resolve(attrs);
   if (!subclass) {
     const scopeAttrs = (
-      modelClass.currentScope as { scopeForCreate?(): unknown } | null
+      modelClass.currentScope?.() as { scopeForCreate?(): unknown } | null
     )?.scopeForCreate?.();
     subclass = resolve(scopeAttrs, true);
   }

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -6790,7 +6790,7 @@ export class Relation<T extends Base> {
 
   private currentScopeRestoringBlock(block?: (record: T) => void): (record: T) => void {
     const modelClass = this.model;
-    const currentScope = ScopeRegistry.currentScope(modelClass as any, true);
+    const currentScope = (modelClass as any).currentScope(true);
     return (record: T) => {
       ScopeRegistry.setCurrentScope(modelClass as any, currentScope ?? null);
       block?.(record);

--- a/packages/activerecord/src/scoping.ts
+++ b/packages/activerecord/src/scoping.ts
@@ -141,7 +141,7 @@ export function initializeInternalsCallback(this: ScopingHost): void {
 // ---------------------------------------------------------------------------
 
 interface ScopingClassHost {
-  currentScope?: any;
+  currentScope?(skipInheritedScope?: boolean): any;
   all?(): any;
 }
 
@@ -151,7 +151,7 @@ export function scopeAttributes(this: ScopingClassHost): Record<string, unknown>
 }
 
 export function isScopeAttributes(this: ScopingClassHost): boolean {
-  return !!this.currentScope;
+  return !!this.currentScope?.();
 }
 
 /**

--- a/packages/activerecord/src/scoping/default.ts
+++ b/packages/activerecord/src/scoping/default.ts
@@ -202,7 +202,7 @@ export function unscoped<T extends typeof Base, R>(
  * Mirrors: ActiveRecord::Scoping::Default::ClassMethods#scope_attributes?
  */
 export function isScopeAttributes(this: {
-  currentScope?: unknown;
+  currentScope?(skipInheritedScope?: boolean): unknown;
   defaultScopes?: DefaultScope[];
 }): boolean {
   return (

--- a/packages/activerecord/src/scoping/named.ts
+++ b/packages/activerecord/src/scoping/named.ts
@@ -139,7 +139,7 @@ export function scope<T extends typeof Base>(
 }
 
 interface NamedHost {
-  currentScope?: any;
+  currentScope?(skipInheritedScope?: boolean): any;
   defaultScopes?: import("./default.js").DefaultScope[];
   // Rails' `relation` (core.rb) — a pristine Relation with the STI type
   // condition but neither current_scope nor default_scope applied. It is the
@@ -155,7 +155,7 @@ interface NamedHost {
  */
 export function scopeForAssociation(this: NamedHost, scope?: any): any {
   const rel = scope ?? this._buildUnscopedRelation?.();
-  if (this.currentScope?.isEmptyScope) {
+  if (this.currentScope?.()?.isEmptyScope) {
     return rel;
   }
   return defaultScoped.call(this, rel);

--- a/packages/activerecord/src/scoping/relation-scoping.test.ts
+++ b/packages/activerecord/src/scoping/relation-scoping.test.ts
@@ -375,8 +375,8 @@ describe("RelationScopingTest", () => {
         await SpecialComment.created();
       });
     });
-    expect(Comment.currentScope).toBeNull();
-    expect(SpecialComment.currentScope).toBeNull();
+    expect(Comment.currentScope()).toBeNull();
+    expect(SpecialComment.currentScope()).toBeNull();
   });
 
   it("scoping respects current class", async () => {

--- a/packages/activesupport/src/callbacks.test.ts
+++ b/packages/activesupport/src/callbacks.test.ts
@@ -1389,19 +1389,39 @@ describe("SkipCallbacksTest", () => {
 });
 
 describe("ExcludingDuplicatesCallbackTest", () => {
-  it("excludes duplicates in separate calls", () => {
-    const target = { log: [] as string[], count: 0 };
-    defineCallbacks(target, "save");
-    const cb = (t: any) => {
-      t.log.push("cb");
-      t.count++;
+  function oneTwoThreeSave(): any {
+    const target: any = {
+      record: [] as string[],
+      first() {
+        target.record.push("one");
+      },
+      second() {
+        target.record.push("two");
+      },
+      third() {
+        target.record.push("three");
+      },
+      save() {
+        runCallbacks(target, "save", () => {
+          target.record.push("yielded");
+        });
+      },
     };
-    setCallback(target, "save", "before", cb);
-    setCallback(target, "save", "before", cb); // duplicate — runs once per registration
-    runCallbacks(target, "save");
-    // Our implementation registers each callback separately
-    expect(target.count).toBeGreaterThanOrEqual(1);
+    defineCallbacks(target, "save");
+    return target;
+  }
+
+  it("excludes duplicates in separate calls", () => {
+    const model = oneTwoThreeSave();
+    setCallback(model, "save", "before", ":first");
+    setCallback(model, "save", "before", ":second");
+    setCallback(model, "save", "before", ":first");
+    setCallback(model, "save", "before", ":third");
+
+    model.save();
+    expect(model.record).toEqual(["two", "one", "three", "yielded"]);
   });
+
   it("excludes duplicates in one call", () => {
     const target = { count: 0 };
     defineCallbacks(target, "save");

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -668,9 +668,12 @@ export class Callback {
           : arity > 0
             ? new InstanceExec1(this.filter as (target: object) => unknown)
             : new InstanceExec0(this.filter as () => unknown);
-    } else if (typeof this.filter === "string") {
-      // Rails Callback.build raises ArgumentError for a String filter; only a
-      // Symbol (method name) or a proc/block is permitted.
+    } else if (typeof this.filter === "string" && !this.filter.startsWith(":")) {
+      // Rails CallTemplate.build/Callback.build reject a String filter; only a
+      // Symbol (a method name) or a proc is permitted. A Ruby Symbol is a JS
+      // string, so — as CLAUDE.md prescribes wherever the control flow turns on
+      // Symbol-vs-String — the Symbol keeps its leading colon and a bare string
+      // is the String arm that raises.
       throw new Error(
         `Passing string to define a callback is not supported: ${String(this.filter)}`,
       );
@@ -681,7 +684,12 @@ export class Callback {
       // `around`/`before`/`after` and `scope: [:kind, :name]` calls `aroundSave`.
       callTemplate = new ObjectCall(this.filter, this.objectCallMethodName());
     } else {
-      callTemplate = new MethodCall(this.filter as PropertyKey);
+      // Symbol filter (`:around_save_collection_association`) → MethodCall.
+      // A Ruby Symbol is a JS string carrying its leading colon; a JS symbol
+      // property key is dispatched as-is.
+      callTemplate = new MethodCall(
+        typeof this.filter === "string" ? this.filter.slice(1) : (this.filter as PropertyKey),
+      );
     }
 
     if (this.kind === "before") {
@@ -1094,13 +1102,28 @@ export class CallbackChain {
   }
 
   append(callback: Callback): void {
-    this._allCallbacks = undefined;
-    this.chain.push(callback);
+    this.appendOne(callback);
   }
 
   prepend(callback: Callback): void {
+    this.prependOne(callback);
+  }
+
+  private appendOne(callback: Callback): void {
     this._allCallbacks = undefined;
+    this.removeDuplicates(callback);
+    this.chain.push(callback);
+  }
+
+  private prependOne(callback: Callback): void {
+    this._allCallbacks = undefined;
+    this.removeDuplicates(callback);
     this.chain.unshift(callback);
+  }
+
+  private removeDuplicates(callback: Callback): void {
+    this._allCallbacks = undefined;
+    this.chain = this.chain.filter((c) => !callback.isDuplicates(c));
   }
 
   remove(kind: CallbackKind, filter?: AnyCallback | string | symbol | CallbackObject): void {

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -669,11 +669,9 @@ export class Callback {
             ? new InstanceExec1(this.filter as (target: object) => unknown)
             : new InstanceExec0(this.filter as () => unknown);
     } else if (typeof this.filter === "string" && !this.filter.startsWith(":")) {
-      // Rails CallTemplate.build/Callback.build reject a String filter; only a
-      // Symbol (a method name) or a proc is permitted. A Ruby Symbol is a JS
-      // string, so — as CLAUDE.md prescribes wherever the control flow turns on
-      // Symbol-vs-String — the Symbol keeps its leading colon and a bare string
-      // is the String arm that raises.
+      // A Ruby Symbol is a JS string; here the control flow turns on
+      // Symbol-vs-String, so the Symbol keeps its leading colon and a bare
+      // string is Callback.build's String arm, which raises.
       throw new Error(
         `Passing string to define a callback is not supported: ${String(this.filter)}`,
       );
@@ -684,9 +682,6 @@ export class Callback {
       // `around`/`before`/`after` and `scope: [:kind, :name]` calls `aroundSave`.
       callTemplate = new ObjectCall(this.filter, this.objectCallMethodName());
     } else {
-      // Symbol filter (`:around_save_collection_association`) → MethodCall.
-      // A Ruby Symbol is a JS string carrying its leading colon; a JS symbol
-      // property key is dispatched as-is.
       callTemplate = new MethodCall(
         typeof this.filter === "string" ? this.filter.slice(1) : (this.filter as PropertyKey),
       );
@@ -1331,7 +1326,7 @@ export namespace Callbacks {
     target: T,
     name: string,
     kind: CallbackKind,
-    callback: AnyCallback<T> | CallbackObject,
+    callback: AnyCallback<T> | CallbackObject | string,
     options: CallbackOptions<T> = {},
   ): void {
     const chains = getCallbackChains(target);
@@ -1410,7 +1405,7 @@ export function setCallback<T extends object>(
   target: T,
   name: string,
   kind: CallbackKind,
-  callback: AnyCallback<T> | CallbackObject,
+  callback: AnyCallback<T> | CallbackObject | string,
   options: CallbackOptions<T> = {},
 ): void {
   Callbacks.setCallback(target, name, kind, callback, options);

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -972,19 +972,27 @@ export class ToSql extends Visitor {
   // -- Matches with ESCAPE --
 
   protected visitArelNodesMatches(o: Nodes.Matches, collector: SQLString): SQLString {
-    this.visit(o.left, collector);
+    collector = this.visit(o.left, collector);
     collector.append(" LIKE ");
-    this.visit(o.right, collector);
-    this.appendEscape(o.escape, collector);
-    return collector;
+    collector = this.visit(o.right, collector);
+    if (o.escape) {
+      collector.append(" ESCAPE ");
+      return this.visit(o.escape, collector);
+    } else {
+      return collector;
+    }
   }
 
   protected visitArelNodesDoesNotMatch(o: Nodes.DoesNotMatch, collector: SQLString): SQLString {
-    this.visit(o.left, collector);
+    collector = this.visit(o.left, collector);
     collector.append(" NOT LIKE ");
-    this.visit(o.right, collector);
-    this.appendEscape(o.escape, collector);
-    return collector;
+    collector = this.visit(o.right, collector);
+    if (o.escape) {
+      collector.append(" ESCAPE ");
+      return this.visit(o.escape, collector);
+    } else {
+      return collector;
+    }
   }
 
   // -- Joins --
@@ -2010,12 +2018,6 @@ export class ToSql extends Visitor {
     }
     collector.append(")");
     return collector;
-  }
-
-  protected appendEscape(escape: Node | null, collector: SQLString): void {
-    if (escape == null) return;
-    collector.append(" ESCAPE ");
-    this.visit(escape, collector);
   }
 
   // -- Helpers --

--- a/scripts/api-compare/call-args.ts
+++ b/scripts/api-compare/call-args.ts
@@ -23,7 +23,10 @@ import { RECEIVER_AS_FIRST_ARG } from "./receiver-as-first-arg.js";
 /** An identifier-shaped string camelizes; anything else compares byte-for-byte.
  *  LOAD-BEARING: camelizing a SQL fragment (`" GROUP BY "`) would erase the
  *  dimension's sharpest finding, the arel visitor-helper argument order. */
-const IDENTIFIER_STRING = /^[a-z][A-Za-z0-9_]*$/;
+// Leading underscore included: Rails spells plenty of private method names
+// `_ensure_no_duplicate_errors`, and those are names the port renames by
+// convention exactly as any other identifier-shaped value is.
+const IDENTIFIER_STRING = /^_?[a-z][A-Za-z0-9_]*$/;
 
 /** Descriptors that carry no comparable value (RFC 0095 §1). Their presence
  *  anywhere in an argument list — INCLUDING nested inside a `kwargs{}` — makes

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/validations/comparability.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/validations/comparability.json
@@ -10,17 +10,6 @@
     "package": "activemodel",
     "tsFile": "validations/comparability.ts",
     "rubyName": "error_options",
-    "call": "keys",
-    "kind": "args",
-    "rubyArgs": [
-      "const:COMPARE_CHECKS"
-    ],
-    "reason": "RFC 0099: comparability.rb:6 declares COMPARE_CHECKS as a Hash (check => operator) and :11 reads `COMPARE_CHECKS.keys`; the port declares it as the key ARRAY, so there is no `.keys` receiver to pass. Converging means porting the Hash and its operator values through comparison.rb/numericality.rb — filed as its own story."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "validations/comparability.ts",
-    "rubyName": "error_options",
     "call": "merge!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/autosave-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/autosave-association.json
@@ -3,17 +3,6 @@
     "package": "activerecord",
     "tsFile": "autosave-association.ts",
     "rubyName": "add_autosave_association_callbacks",
-    "call": "around_save",
-    "kind": "args",
-    "rubyArgs": [
-      "str:aroundSaveCollectionAssociation"
-    ],
-    "reason": "autosave_association.rb:193 registers the Symbol `:around_save_collection_association`; trails' ActiveSupport::Callbacks rejects a method-NAME filter spelled as a string (callbacks.ts:671-675), so the port can only register the closure. Converging needs the method-name filter arm in ActiveSupport::Callbacks — story call-args-ar-autosave-around-save-method-name."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "autosave-association.ts",
-    "rubyName": "add_autosave_association_callbacks",
     "call": "define_autosave_validation_callbacks",
     "kind": "args",
     "rubyArgs": [
@@ -52,17 +41,6 @@
     "rubyName": "changed_for_autosave?",
     "call": "marked_for_destruction?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "autosave-association.ts",
-    "rubyName": "define_autosave_validation_callbacks",
-    "call": "after_validation",
-    "kind": "args",
-    "rubyArgs": [
-      "str:_ensure_no_duplicate_errors"
-    ],
-    "reason": "RFC 0099: autosave_association.rb:233 passes the callback as a METHOD NAME symbol; trails' `afterValidation` (callbacks.ts:56) takes `(modelClass, fn)` only and has no symbol-name arm, so the name cannot be passed. Converging needs the symbol arm on the callback registry; filed separately."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
@@ -279,17 +279,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
-    "rubyName": "current_scope_restoring_block",
-    "call": "current_scope",
-    "kind": "args",
-    "rubyArgs": [
-      "bool:true"
-    ],
-    "reason": "RFC 0099: relation.rb:1346 writes `model.current_scope(true)`; trails' `Base.currentScope` is a GETTER (base.ts:2267) with no skip-inherited parameter, so the port reaches ScopeRegistry.currentScope directly and the model arrives as argument 1. The `true` IS now passed. Converging needs currentScope flipped from a getter to a method across its call sites; filed separately."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
     "rubyName": "delete",
     "call": "order:primaryKey,where",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/callbacks.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/callbacks.json
@@ -71,6 +71,13 @@
   {
     "package": "activesupport",
     "tsFile": "callbacks.ts",
+    "rubyName": "remove_duplicates",
+    "call": "delete_if",
+    "reason": "Ruby Array#delete_if has no trails port; `this.chain = this.chain.filter(...)` is the same in-place removal, and is how CallbackChain#remove spells it in this file already."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "callbacks.ts",
     "rubyName": "reset_callbacks",
     "call": "descendants",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
refactor(arel,activemodel,activerecord,activesupport): inline the ESCAPE arm, port COMPARE_CHECKS as a Hash, and take callback method names

Six bundled convergence stories (RFC 0099).

1. `appendEscape` (arel to_sql) is inlined at both call sites, matching
   `to_sql.rb:485-505` line for line; the helper is gone.

2. `UnaryOperation#expr` already landed in #6371 — story closed as done.

3. `COMPARE_CHECKS` is the Rails Hash of check option → comparison
   operator (`comparability.rb:6`), `error_options` reads its keys
   (`:11`), and both consumers dispatch the operator off the map at
   `comparison.rb:27` / `numericality.rb:60`. Numericality's six
   hand-rolled compare blocks collapse into the Rails loop, and its
   `RESERVED_OPTIONS` is built from `COMPARE_CHECKS`/`NUMBER_CHECKS`/
   `RANGE_CHECKS` as `numericality.rb:16` does. The per-option i18n key
   comes from `underscore(option)` rather than a second lookup table.

4/5. `ActiveSupport::Callbacks` takes a method-NAME filter, compiled to
   `CallTemplate::MethodCall`. A Ruby Symbol is a JS string, and here the
   control flow turns on Symbol-vs-String (`Callback.build` raises for a
   String), so the Symbol keeps its leading colon — `":name"` is the
   method name, a bare string still raises, and
   `NotPermittedStringCallbackTest` keeps passing. `CallbackChain` grows
   Rails' `append_one`/`prepend_one`/`remove_duplicates`, so
   `Callback#duplicates?` actually dedups. With that,
   `add_autosave_association_callbacks` registers
   `aroundSave(":aroundSaveCollectionAssociation")` and
   `define_autosave_validation_callbacks` registers
   `afterValidation(":_ensureNoDuplicateErrors")`; both bespoke
   Symbol.for registration markers are deleted.

6. `Base.currentScope` is a method taking `skipInheritedScope = false`
   (`scoping.rb:26`), and `currentScopeRestoringBlock` calls
   `model.currentScope(true)` as `relation.rb:1346` does.

Four `kind: "args"` baseline rows deleted by hand (only-shrink). One
call-set row added for `remove_duplicates` → `delete_if` (no trails port
of Ruby's Array#delete_if; the in-place filter is how this file already
spells removal). `IDENTIFIER_STRING` in the call-arg comparator now
accepts a leading underscore so Rails' `_private_method` names compare
through the same camelization every other identifier-shaped value takes.

`call-args-ar-collection-proxy-delete-all-delegation` is released, not
shipped: converging it means moving the proxy's strategy dispatch,
through arm and diverged-relation-state handling into
CollectionAssociation, which does not fit under this PR's ceiling.

Closes-story: arel-append-escape-inline-convergence
Closes-story: arel-unary-operation-expr-rename
Closes-story: call-args-am-compare-checks-hash
Closes-story: call-args-ar-autosave-around-save-method-name
Closes-story: call-args-ar-callback-symbol-name-arm
Closes-story: call-args-ar-current-scope-as-method

