### PR TITLE
refactor(arel,globalid,i18n,trailties,actionpack): converge visitor call order and 13 renamed call arguments

### DIFF
--- a/packages/actionpack/src/abstract-controller/caching/fragments.ts
+++ b/packages/actionpack/src/abstract-controller/caching/fragments.ts
@@ -106,18 +106,18 @@ export function writeFragment(
   options?: CacheOptions,
 ): string {
   if (!cacheConfigured(this)) return content;
-  const combined = stringifyKey(combinedFragmentCacheKey.call(this, key));
-  return instrumentFragmentCache(this, "write_fragment", combined, () => {
-    this.constructor.cacheStore!.write(combined, content, options);
+  key = stringifyKey(combinedFragmentCacheKey.call(this, key));
+  return instrumentFragmentCache(this, "write_fragment", key, () => {
+    this.constructor.cacheStore!.write(key as string, content, options);
     return content;
   });
 }
 
 export function readFragment(this: FragmentsHost, key: unknown, options?: CacheOptions): unknown {
   if (!cacheConfigured(this)) return undefined;
-  const combined = stringifyKey(combinedFragmentCacheKey.call(this, key));
-  return instrumentFragmentCache(this, "read_fragment", combined, () =>
-    this.constructor.cacheStore!.read(combined, options),
+  key = stringifyKey(combinedFragmentCacheKey.call(this, key));
+  return instrumentFragmentCache(this, "read_fragment", key, () =>
+    this.constructor.cacheStore!.read(key as string, options),
   );
 }
 
@@ -132,9 +132,9 @@ export function fragmentExist(
   _options?: CacheOptions,
 ): boolean | undefined {
   if (!cacheConfigured(this)) return undefined;
-  const combined = stringifyKey(combinedFragmentCacheKey.call(this, key));
-  return instrumentFragmentCache(this, "exist_fragment?", combined, () =>
-    this.constructor.cacheStore!.exist(combined),
+  key = stringifyKey(combinedFragmentCacheKey.call(this, key));
+  return instrumentFragmentCache(this, "exist_fragment?", key, () =>
+    this.constructor.cacheStore!.exist(key as string),
   );
 }
 
@@ -144,12 +144,15 @@ export function expireFragment(
   _options?: CacheOptions,
 ): unknown {
   if (!cacheConfigured(this)) return undefined;
-  const store = this.constructor.cacheStore!;
-  if (key instanceof RegExp) {
-    return instrumentFragmentCache(this, "expire_fragment", key, () => store.deleteMatched(key));
-  }
-  const combined = stringifyKey(combinedFragmentCacheKey.call(this, key));
-  return instrumentFragmentCache(this, "expire_fragment", combined, () => store.delete(combined));
+  if (!(key instanceof RegExp)) key = stringifyKey(combinedFragmentCacheKey.call(this, key));
+
+  return instrumentFragmentCache(this, "expire_fragment", key, () => {
+    if (key instanceof RegExp) {
+      return this.constructor.cacheStore!.deleteMatched(key);
+    } else {
+      return this.constructor.cacheStore!.delete(key as string);
+    }
+  });
 }
 
 export function instrumentFragmentCache<T>(

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1326,11 +1326,12 @@ export class ToSql extends Visitor {
 
   private visitArelAttributesAttribute(o: Nodes.Attribute, collector: SQLString): SQLString {
     const joinName = o.relation.tableAlias || o.relation.name;
+    collector.append(this.quoteTableName(joinName));
+    collector.append(".");
     // Rails: `quote_column_name(Arel.star)` returns the `SqlLiteral("*")`
     // unchanged. We model `Arel.star` as the string sentinel `"*"` on the
     // Attribute, so short-circuit identifier quoting here.
-    const col = o.name === "*" ? "*" : this.quoteColumnName(o.name);
-    collector.append(`${this.quoteTableName(joinName)}.${col}`);
+    collector.append(o.name === "*" ? "*" : this.quoteColumnName(o.name));
     return collector;
   }
 

--- a/packages/globalid/src/global-id.ts
+++ b/packages/globalid/src/global-id.ts
@@ -97,19 +97,17 @@ export class GlobalID {
     for (const [k, v] of Object.entries(rest)) {
       if (v != null) filteredParams[k] = String(v);
     }
-    const modelName = model.constructor.name;
     const params = Object.keys(filteredParams).length ? filteredParams : null;
-    return new this(GID.build({ app, modelName, modelId: model.id, params }), options);
+    return new this(GID.create(app, model, params), options);
   }
 
   /** Mirrors: GlobalID.parse — falls back to base64-decoded form. */
   static parse(gid: string | GlobalID, options: GlobalIDOptions = {}): GlobalID | null {
     if (gid instanceof this) return gid;
-    const str = String(gid);
     try {
-      return new this(GID.parse(str), options);
+      return new this(gid, options);
     } catch {
-      return this.parseEncodedGid(str, options);
+      return this.parseEncodedGid(gid, options);
     }
   }
 
@@ -120,8 +118,8 @@ export class GlobalID {
   private static parseEncodedGid(gid: string, options: GlobalIDOptions): GlobalID | null {
     try {
       const b64 = gid.replace(/-/g, "+").replace(/_/g, "/");
-      const decoded = atob(b64 + "=".repeat((4 - (b64.length % 4)) % 4));
-      return new this(GID.parse(decoded), options);
+      const urlsafeDecode64 = atob(b64 + "=".repeat((4 - (b64.length % 4)) % 4));
+      return new this(urlsafeDecode64, options);
     } catch {
       return null;
     }

--- a/packages/globalid/src/locator.ts
+++ b/packages/globalid/src/locator.ts
@@ -338,8 +338,6 @@ export class Locator {
    */
   static use(app: string, locator: LocatorLike | LocatorBlock): void {
     validateApp(app);
-    // Ruby splits the two arms across a positional `locator` and a `&locator_block`;
-    // TypeScript has no block parameter, so the single argument is discriminated here.
     const locatorBlock = typeof locator === "function" ? locator : undefined;
     _appLocators.set(
       Locator.normalizeApp(app),

--- a/packages/globalid/src/locator.ts
+++ b/packages/globalid/src/locator.ts
@@ -338,8 +338,13 @@ export class Locator {
    */
   static use(app: string, locator: LocatorLike | LocatorBlock): void {
     validateApp(app);
-    const wrapped = typeof locator === "function" ? new BlockLocator(locator) : locator;
-    _appLocators.set(Locator.normalizeApp(app), wrapped);
+    // Ruby splits the two arms across a positional `locator` and a `&locator_block`;
+    // TypeScript has no block parameter, so the single argument is discriminated here.
+    const locatorBlock = typeof locator === "function" ? locator : undefined;
+    _appLocators.set(
+      Locator.normalizeApp(app),
+      locatorBlock === undefined ? (locator as LocatorLike) : new BlockLocator(locatorBlock),
+    );
   }
 
   // ─── Private helpers (Rails class << self private) ───────────────────────

--- a/packages/i18n/src/backend/flatten.ts
+++ b/packages/i18n/src/backend/flatten.ts
@@ -28,7 +28,7 @@ export interface FlattenHost {
     prevKey?: string | null,
     block?: (currKey: string, value: unknown) => void,
   ): void;
-  storeLink(locale: string, key: string, link: unknown): void;
+  storeLink(locale: string, key: string, link: unknown): string;
   resolveLink(locale: string, key: string): string;
   findLink(locale: string, key: string): [string, string] | null;
   escapeDefaultSeparator(key: unknown): string;
@@ -176,11 +176,13 @@ export function flattenTranslations(
   return hash;
 }
 
-export function storeLink(this: FlattenHost, locale: string, key: string, link: unknown): void {
+export function storeLink(this: FlattenHost, locale: string, key: string, link: unknown): string {
   locale = toSym(locale).slice(1);
   const byLocale = this.links().get(locale) ?? new Map<string, string>();
   this.links().set(locale, byLocale);
-  byLocale.set(String(key), toS(link));
+  const value = toS(link);
+  byLocale.set(String(key), value);
+  return value;
 }
 
 export function resolveLink(this: FlattenHost, locale: string, key: string): string {
@@ -193,9 +195,7 @@ export function resolveLink(this: FlattenHost, locale: string, key: string): str
 
   const link = this.findLink(locale, key);
   if (link) {
-    const resolved = key.replaceAll(link[0], link[1]);
-    this.storeLink(locale, key, resolved);
-    return resolved;
+    return this.storeLink(locale, key, key.replaceAll(link[0], link[1]));
   }
   return key;
 }

--- a/packages/i18n/src/backend/key-value.ts
+++ b/packages/i18n/src/backend/key-value.ts
@@ -195,11 +195,12 @@ export class KeyValue {
         .reverse()
         .reduce<unknown>((value, key) => ({ [key]: value }), mainValue) as TranslationData;
     });
-    const injected = nested.reduce<TranslationData | undefined>(
-      (hash, elem) => (hash === undefined ? elem : deepMergeBang(hash, elem)),
-      undefined,
-    );
-    return (this.translationsStore = deepSymbolizeKeys(injected!));
+    return (this.translationsStore = deepSymbolizeKeys(
+      nested.reduce<TranslationData | undefined>(
+        (hash, elem) => (hash === undefined ? elem : deepMergeBang(hash, elem)),
+        undefined,
+      )!,
+    ));
   }
 
   protected initTranslations(): void {

--- a/packages/trailties/src/application.ts
+++ b/packages/trailties/src/application.ts
@@ -131,12 +131,12 @@ export class Application extends Engine {
   }
 
   /** 1000 iterations match Rails for cookie compatibility. */
-  keyGenerator(secret: string | null = this.secretKeyBase()): CachingKeyGenerator {
-    if (secret === null) throw new Error("Missing secret_key_base.");
-    let gen = this._keyGenerators.get(secret);
+  keyGenerator(secretKeyBase: string | null = this.secretKeyBase()): CachingKeyGenerator {
+    if (secretKeyBase === null) throw new Error("Missing secret_key_base.");
+    let gen = this._keyGenerators.get(secretKeyBase);
     if (!gen) {
-      gen = new CachingKeyGenerator(new KeyGenerator(secret, { iterations: 1000 }));
-      this._keyGenerators.set(secret, gen);
+      gen = new CachingKeyGenerator(new KeyGenerator(secretKeyBase, { iterations: 1000 }));
+      this._keyGenerators.set(secretKeyBase, gen);
     }
     return gen;
   }

--- a/packages/trailties/src/application/routes-reloader.ts
+++ b/packages/trailties/src/application/routes-reloader.ts
@@ -42,12 +42,12 @@ export class RoutesReloader {
   }
 
   async executeUnlessLoaded(
-    app: unknown,
+    application: unknown,
     loader?: (p: string) => void | Promise<void>,
   ): Promise<boolean> {
     if (this.loaded) return false;
     await this.execute(loader);
-    runLoadHooks("after_routes_loaded", app);
+    runLoadHooks("after_routes_loaded", application);
     return true;
   }
 }

--- a/scripts/api-compare/call-mismatches-exclude/abstractcontroller/caching/fragments.json
+++ b/scripts/api-compare/call-mismatches-exclude/abstractcontroller/caching/fragments.json
@@ -26,13 +26,6 @@
   {
     "package": "abstractcontroller",
     "tsFile": "caching/fragments.ts",
-    "rubyName": "expire_fragment",
-    "call": "order:instrumentFragmentCache,combinedFragmentCacheKey",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "abstractcontroller",
-    "tsFile": "caching/fragments.ts",
     "rubyName": "fragment_exist?",
     "call": "exist?",
     "kind": "args",

--- a/scripts/api-compare/call-mismatches-exclude/arel/visitors/to-sql.json
+++ b/scripts/api-compare/call-mismatches-exclude/arel/visitors/to-sql.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Attributes_Attribute",
-    "call": "order:quoteColumnName,quoteTableName",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/globalid/locator.json
+++ b/scripts/api-compare/call-mismatches-exclude/globalid/locator.json
@@ -5,12 +5,5 @@
     "rubyName": "locate_many_signed",
     "call": "order:parse,locateMany",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "globalid",
-    "tsFile": "locator.ts",
-    "rubyName": "use",
-    "call": "order:constructor,normalizeApp",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]


### PR DESCRIPTION
Two bundled burndown stories.

## B1 — arel visitor helper calls (RFC 0084)

Re-measured first, as the story asked: the ~90-row projection from the 2026-07-30
probe no longer holds. The `collect_nodes_for` / `maybe_visit` / `infix_value`
convergences the story enumerated (`DeleteStatement`, `UpdateStatement`,
`InsertStatement`, `SelectCore`, `SelectOptions`, `Window`, and the mysql /
postgresql / sqlite dialect visitors) all landed in the sibling PRs #6370, #6371
and #6374. A full `API_COMPARE_FORCE=1 pnpm parity:api --calls` on `main` at
322fba948 reports exactly **one** remaining `arel` call-set row, which this PR
converges — so no slice-out follow-up stories are needed.

- `visitors/to-sql.ts#visitArelAttributesAttribute` — Rails
  (`arel/visitors/to_sql.rb:746-749`) is
  `collector << quote_table_name(join_name) << "." << quote_column_name(o.name)`:
  table quoting first, then column. The port built the column fragment first and
  interpolated. Restructured into Rails' three appends in Rails' order.
  `call-mismatches-exclude/arel/visitors/to-sql.json` deleted (the file's only row).

`arel` is now at zero call-set rows.

## B2 — naming call-argument residue in the small packages (RFC 0096)

25 `naming` rows across globalid / i18n / trailties / abstractcontroller /
did-you-mean at the start; **13 converged**, 12 left standing (all classified
below). No public API change, no new `shape` rows.

Converged:

- `actionpack/.../caching/fragments.ts` (5 rows) — Rails reassigns the parameter
  (`key = combined_fragment_cache_key(key)`, `fragments.rb:83,96,107,133`); the port
  bound a separate `combined` local. Reassign `key` as Rails does, in
  `writeFragment` / `readFragment` / `fragmentExist` / `expireFragment`.
  `expireFragment` additionally regained Rails' single `instrument_fragment_cache`
  block with the Regexp branch *inside* it (`fragments.rb:131-142`) instead of two
  branch-local instrument calls — that retired the file's
  `order:instrumentFragmentCache,combinedFragmentCacheKey` baseline row too.
- `globalid/global-id.ts` (4 rows) —
  `create` now calls `GID.create(app, model, params)`, the ported
  `URI::GID.create` (`global_id/global_id.rb:14`), instead of re-deriving
  `modelName` and calling `GID.build`;
  `parse` passes the raw gid to the constructor and to `parseEncodedGid`, as Rails
  does (`global_id.rb:25-28`) — the constructor already parses, so the `URI::Error`
  rescue arm behaves identically;
  `parseEncodedGid` passes the decoded string straight to `new`, matching
  `new(Base64.urlsafe_decode64(gid), options)` (`global_id.rb:39`).
- `globalid/locator.ts` (1 row) — `use` now names the block arm `locatorBlock`,
  Rails' `&locator_block` (`locator.rb:130-135`), and evaluates the two arms in
  Rails' `locator || BlockLocator.new(locator_block)` order. That also retired the
  file's `order:constructor,normalizeApp` baseline row.
- `i18n/backend/flatten.ts` (1 row) — `resolveLink` now returns
  `storeLink(locale, key, key.replaceAll(...))` directly, as Rails does
  (`flatten.rb:100`); `storeLink` returns the stored string, matching Ruby's
  assignment-expression return (`flatten.rb:89-91`).
- `i18n/backend/key-value.ts` (1 row) — `translations` inlines the `reduce` into the
  `deepSymbolizeKeys` argument rather than binding an `injected` local
  (`key_value.rb:116-121`).
- `trailties/application.ts` (1 row) — `keyGenerator`'s parameter is `secretKeyBase`,
  Rails' name (`rails/application.rb:172`).
- `trailties/application/routes-reloader.ts` (1 row) — `executeUnlessLoaded`'s
  parameter is `application`, matching the `Rails.application` Rails passes to
  `run_load_hooks` (`routes_reloader.rb:40`).

Left standing, with the class each belongs to:

**Ruby-core method names with no TS counterpart** (the extractor names the receiver's
last call, so these can never match — not renamable, not a divergence):

- `i18n/backend/base.ts` ×2 — `e.inspect` vs `inspectError(e)` (`base.rb:269,285`).
  JS errors have no `#inspect`.
- `i18n/backend/base.ts` ×1 — `File.read` vs `readFile` (`base.rb:282`).
- `i18n/backend/flatten.ts` ×1 — `String#gsub` vs `String.replaceAll` (`flatten.rb:100`).
- `i18n/backend/key-value.ts` ×1 — `Enumerable#inject` vs `Array.reduce` (`key_value.rb:121`).
- `globalid/signed-global-id.ts` ×1 — `sgid.to_s` on an already-`string` parameter
  (`signed_global_id.rb:11`).

**Ruby ivar / method-name collision** — the ivar and a same-named predicate coexist in
Ruby but not on a TS class, so the ivar keeps a backing-field spelling:

- `trailties/engine/configuration.ts` — `@root` vs `root=` → `_root`
  (`engine/configuration.rb:75,115`).
- `i18n/backend/key-value.ts` — `@subtrees` vs `subtrees?` → `subtreesFlag`
  (`key_value.rb:85` / `key_value.rb` predicate).

**JS reserved word**:

- `trailties/paths.ts` — Rails' local is `with` (`paths.rb:65`), which is a reserved
  word in ES modules; the port uses `with_`.

**a3 (structural) findings, filed rather than renamed** — these are not identifier
renames and converging them changes body structure, so per the story they stay:

- `trailties/rack/logger.ts#call` passes `env` where Rails passes an
  `ActionDispatch::Request` built from it (`rails/rack/logger.rb:21-24`) — belongs to
  the ActionDispatch request-object port, not to a naming burndown.
- `did-you-mean/spell-checker.ts#correct` iterates `{word, index, score}` candidate
  objects rather than Ruby's bare word array (`spell_checker.rb:23`).
- `globalid/locator.ts#locateManySigned` collects URI strings where Rails passes the
  parsed `SignedGlobalID` objects to `locate_many` (`locator.rb:107`).

## Verification

- `pnpm parity:api:calls` — OK; two baseline rows deleted by hand (no reseed),
  arel call-set rows now 0.
- `pnpm parity:api:calls:args` — OK, 391 baselined `shape` rows unchanged.
- `pnpm parity:api:calls:args:report`: `naming` 532 → 519 total; small-package
  `naming` 25 → 12.
- `pnpm parity:api:extra --package globalid`: 0 novel.
- `pnpm lint` clean; `tsc --build --force` clean; 198 test files / 3134 tests pass
  across arel, globalid, i18n, trailties and abstract-controller.

Closes-story: burndown-arel-visitors
Closes-story: naming-burndown-2-tail
