### PR TITLE
refactor(activerecord): PG and MySQL connection-error branches pass the driver exception

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1556,10 +1556,9 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     }
     // Mirrors Rails' AbstractMysqlAdapter#translate_exception, which builds
     // every translated error with `connection_pool: @pool`
-    // (abstract_mysql_adapter.rb:815-856). Attaching it here rather than in the
-    // public wrapper is what gives the direct `_translateException` throw sites
-    // a pool too. Use setPool/setConnectionPool (both guarded) so a pool
-    // attached at construction isn't overwritten.
+    // (abstract_mysql_adapter.rb:815-856) — so the direct `_translateException`
+    // throw sites get a pool too, not just the public wrapper's callers. Both
+    // setters are guarded, so a pool passed at construction survives.
     if (translated instanceof ConnectionNotEstablished) {
       translated.setPool(this.pool);
     } else if (translated instanceof AdapterError) {

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1491,7 +1491,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
         // generic Error) get promoted to ConnectionNotEstablished when the
         // message indicates the client lost the server handshake.
         if (/MySQL client is not connected/i.test(msg)) {
-          return new ConnectionNotEstablished(msg);
+          return new ConnectionNotEstablished(e, { connectionPool: this.pool });
         }
       }
       switch (errno) {
@@ -1554,16 +1554,23 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     if (translated !== e && (translated as { cause?: unknown }).cause === undefined) {
       (translated as { cause?: unknown }).cause = e;
     }
+    // Mirrors Rails' AbstractMysqlAdapter#translate_exception, which builds
+    // every translated error with `connection_pool: @pool`
+    // (abstract_mysql_adapter.rb:815-856). Attaching it here rather than in the
+    // public wrapper is what gives the direct `_translateException` throw sites
+    // a pool too. Use setPool/setConnectionPool (both guarded) so a pool
+    // attached at construction isn't overwritten.
+    if (translated instanceof ConnectionNotEstablished) {
+      translated.setPool(this.pool);
+    } else if (translated instanceof AdapterError) {
+      translated.setConnectionPool(this.pool);
+    }
     return translated;
   }
 
   /** @internal */
   translateException(exception: unknown, opts: { sql: string; binds: unknown[] }): Error {
-    const translated = this._translateException(exception, opts.sql, opts.binds);
-    // Mirrors Rails' AbstractAdapter#translate_exception, which attaches the
-    // originating pool (`connection_pool`) to every exception it builds.
-    if (translated instanceof AdapterError) translated.setConnectionPool(this.pool);
-    return translated;
+    return this._translateException(exception, opts.sql, opts.binds);
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -255,7 +255,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     const build = (): Error => {
       if (isMysql2DriverTimeout(e)) {
         const msg = e instanceof Error ? e.message : String(e);
-        return new AdapterTimeout(msg, { sql, binds });
+        return new AdapterTimeout(msg, { sql, binds, connectionPool: this.pool });
       }
       if (isMysql2ConnectionError(e)) {
         // Mirrors `Mysql2Adapter#translate_exception`'s
@@ -264,9 +264,11 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         // everything else in this family is ConnectionFailed.
         const msg = (e as Error).message;
         if (/MySQL client is not connected/i.test(msg)) {
-          return new ConnectionNotEstablished(msg);
+          // mysql2_adapter.rb:177 passes the driver exception itself here, while
+          // :179 below passes the message — the asymmetry is Rails'.
+          return new ConnectionNotEstablished(e as Error, { connectionPool: this.pool });
         }
-        return new ConnectionFailed(msg, { sql, binds });
+        return new ConnectionFailed(msg, { sql, binds, connectionPool: this.pool });
       }
       return super._translateException(e, sql, binds);
     };

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3831,8 +3831,6 @@ export class PostgreSQLAdapter
           return new LockWaitTimeout(msg, { sql, binds });
         case "57014": // query_canceled
           return new QueryCanceled(msg, { sql, binds });
-        case "57P01": // admin_shutdown (pg_terminate_backend or server restart)
-          return new ConnectionNotEstablished(msg);
         default:
           // A severed connection (08xxx, "Connection terminated", pg's
           // "Client has encountered a connection error", …) surfaces here as a
@@ -3863,10 +3861,10 @@ export class PostgreSQLAdapter
           // takes ConnectionFailed. (Connect-path failures still surface as
           // ConnectionNotEstablished — see newClient.)
           if (PostgreSQLAdapter._isConnectionClosedBeforeSend(e)) {
-            return new ConnectionNotEstablished(msg);
+            return new ConnectionNotEstablished(e, { connectionPool: this.pool });
           }
           if (PostgreSQLAdapter._isConnectionError(e)) {
-            return new ConnectionFailed(msg, { sql, binds });
+            return new ConnectionFailed(e, { connectionPool: this.pool });
           }
           // Only wrap node-postgres `DatabaseError`s. The SQLSTATE
           // 5-char shape alone isn't enough — Node system errors like

--- a/packages/activerecord/src/errors.ts
+++ b/packages/activerecord/src/errors.ts
@@ -294,11 +294,18 @@ export class QueryAborted extends StatementInvalid {
 
 /** Mirrors `ActiveRecord::ConnectionFailed`. */
 export class ConnectionFailed extends QueryAborted {
+  /**
+   * Rails' PG translator builds this one from the driver exception rather than a
+   * message string (`postgresql_adapter.rb:815`); Ruby's `Exception.new` takes
+   * any object and `to_s`es it, so an Error is accepted here and kept as the
+   * cause.
+   */
   constructor(
-    message?: string,
+    message?: string | Error,
     options?: { sql?: string; binds?: unknown[]; connectionPool?: unknown; cause?: unknown },
   ) {
-    super(message, options);
+    const cause = options?.cause ?? (message instanceof Error ? message : undefined);
+    super(message instanceof Error ? message.message : message, { ...options, cause });
     this.name = "ConnectionFailed";
   }
 }


### PR DESCRIPTION
Rails' connection-error branches build the error from the driver **exception**, not from its message, and `ConnectionFailed` gets no `sql:`/`binds:` at all.

- **PG** (`postgresql_adapter.rb:806-818`): `_translateException` now passes `e` to `ConnectionNotEstablished` / `ConnectionFailed` with `connectionPool: this.pool`.
- `ConnectionFailed` accepts an `Error` first argument (keeping it as the cause), as `ConnectionNotEstablished` already did for `sqlite3_adapter.rb:704`.
- Dropped PG's trails-only `case "57P01"` branch: Rails' `translate_exception` has no admin_shutdown case, so a `57P01` SQLSTATE falls through to `super` and lands on `StatementInvalid` — which is exactly what the default arm now does.
- **MySQL** (`abstract_mysql_adapter.rb:817-819`, `mysql2_adapter.rb:172-184`): the `MySQL client is not connected` branches pass the exception. `mysql2_adapter.rb:179` keeps passing the *message* to `ConnectionFailed` — that asymmetry with `:177` is Rails' own and is noted at the call site.
- The `connectionPool` attachment moved out of the public `translateException` wrapper into `_translateException`, where Rails attaches it, so MySQL's direct `throw this._translateException(...)` sites carry a pool too.

Gates: `pnpm parity:api:calls:args` OK (362 baselined shape rows), `pnpm parity:api:calls` OK, typecheck + lint clean. `adapter.test.ts`, `errors.test.ts`, `adapter-connection.trails.test.ts`, `abstract-adapter.lifecycle.test.ts` green locally; PG/MySQL lanes run in CI.

### Bundled story already done in main

`converge-association-instance-get-to-rails-one-liner` needed no code: `associationInstanceGet` (`associations.ts`) is already the Rails one-liner (`associations.rb:81-83`) with no proxy/holder consultation and no `AssociationNotFoundError` catch, and the 7 autosave tests the story names are green (210/210 in `autosave-association{,.trails}.test.ts`). Marked done against #4074.

Closes-story: pg-mysql-connection-error-branches-pass-the-exception