### PR TITLE
refactor(activerecord): converge call-argument locals to the Rails identifiers

### DIFF
--- a/packages/activerecord/src/attribute-methods/primary-key.ts
+++ b/packages/activerecord/src/attribute-methods/primary-key.ts
@@ -299,12 +299,12 @@ export function isDangerousAttributeMethod(_this: PrimaryKeyHost, name: string):
  * Rails: adapter_class.quote_column_name(primary_key)
  */
 export function quotedPrimaryKey(this: PrimaryKeyHost & { connection?: DatabaseAdapter }): string {
-  const pk = this.primaryKey;
+  const primaryKey = this.primaryKey;
   const quoter = this.connection;
   const fallback = (k: string) => `"${k.replace(/"/g, '""')}"`;
-  if (Array.isArray(pk))
-    return pk.map((k) => (quoter ? quoter.quoteColumnName(k) : fallback(k))).join(", ");
-  return quoter ? quoter.quoteColumnName(pk) : fallback(pk);
+  if (Array.isArray(primaryKey))
+    return primaryKey.map((k) => (quoter ? quoter.quoteColumnName(k) : fallback(k))).join(", ");
+  return quoter ? quoter.quoteColumnName(primaryKey) : fallback(primaryKey);
 }
 
 export function resetPrimaryKey(this: PrimaryKeyHost): void {

--- a/packages/activerecord/src/attribute-methods/serialization.ts
+++ b/packages/activerecord/src/attribute-methods/serialization.ts
@@ -103,22 +103,25 @@ export function buildColumnSerializer(
   type: unknown,
   yaml?: YamlColumnOptions,
 ): unknown {
-  const resolvedCoder = coder === globalThis.JSON ? CodersJSON : coder;
+  // When ::JSON is used, force it to go through the Active Support JSON encoder
+  // to ensure special objects (e.g. Active Record models) are dumped correctly
+  // using the #as_json hook.
+  if (coder === globalThis.JSON) coder = CodersJSON;
 
   // Mirrors Rails' `coder == ::YAML || coder == Coders::YAMLColumn`. The string
   // "YAML" is the trails analog of Ruby's `::YAML` module constant. Rails forwards
   // `**(yaml || {})` (permitted_classes/unsafe_load) into the YAMLColumn ctor.
-  if (resolvedCoder === "YAML" || resolvedCoder === YAMLColumn) {
+  if (coder === "YAML" || coder === YAMLColumn) {
     return new YAMLColumn(attrName, type as new (...args: unknown[]) => unknown, yaml ?? {});
   }
 
-  if (typeof resolvedCoder === "function" && !("load" in resolvedCoder)) {
-    return new (resolvedCoder as any)(attrName, type);
+  if (typeof coder === "function" && !("load" in coder)) {
+    return new (coder as any)(attrName, type);
   }
 
   if (type && type !== Object) {
-    return new CodersColumnSerializer(attrName, resolvedCoder as any, type as any);
+    return new CodersColumnSerializer(attrName, coder as any, type as any);
   }
 
-  return resolvedCoder;
+  return coder;
 }

--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -189,7 +189,7 @@ export function _defaultAttributes(this: AnyClass): AttributeSet {
     // matters for LockingType, where deserialize(null) → 0.
     const columns = cachedColumnsHash(cacheHost);
     const defs: Map<string, AttributeDefinition> = cacheHost._attributeDefinitions;
-    const attrMap = new Map<string, Attribute>();
+    const attributesHash = new Map<string, Attribute>();
     for (const [name, def] of defs) {
       const source = def.source ?? (def.userProvided === false ? "schema" : "user");
       const column = columns[name];
@@ -199,7 +199,7 @@ export function _defaultAttributes(this: AnyClass): AttributeSet {
         // Rails lacks), and phase 2 replays those same decorators, so seeding
         // from `def.type` applies each one twice.
         const seedType = def.reflectedColumnType ?? def.type;
-        attrMap.set(name, Attribute.fromDatabase(name, def.defaultValue ?? null, seedType));
+        attributesHash.set(name, Attribute.fromDatabase(name, def.defaultValue ?? null, seedType));
       } else if (column !== undefined) {
         // User type-override on a real DB column (e.g. enum, serialize,
         // normalizes, encryption): seed with the REFLECTED column type, not the
@@ -213,19 +213,19 @@ export function _defaultAttributes(this: AnyClass): AttributeSet {
         // where the adapter is in hand; fall back to the def's own type before
         // the schema has reflected.
         const seedType = def.reflectedColumnType ?? def.type;
-        attrMap.set(name, Attribute.fromDatabase(name, column.default ?? null, seedType));
+        attributesHash.set(name, Attribute.fromDatabase(name, column.default ?? null, seedType));
       } else if (def.defaultValue != null) {
         const base = Attribute.withCastValue(name, null, def.type);
-        attrMap.set(name, base.withUserDefault(def.defaultValue));
+        attributesHash.set(name, base.withUserDefault(def.defaultValue));
       } else {
-        attrMap.set(name, Attribute.fromDatabase(name, null, def.type));
+        attributesHash.set(name, Attribute.fromDatabase(name, null, def.type));
       }
     }
 
     // Phase 2: replay user-declared attribute() calls from the pending queue.
     // These always win over schema columns, matching Rails' ordering guarantee.
     // Mirrors: apply_pending_attribute_modifications(attribute_set)
-    const attributeSet = new AttributeSet(attrMap);
+    const attributeSet = new AttributeSet(attributesHash);
     applyPendingAttributeModifications(cacheHost, attributeSet);
 
     cacheHost._cachedDefaultAttributes = attributeSet;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3373,7 +3373,7 @@ export class PostgreSQLAdapter
     const rawSqlType = col?.sqlType ?? col?.type ?? null;
     const self = this;
     const lookup = {
-      lookupCastTypeFromColumn(c: {
+      lookupCastTypeFromColumn(column: {
         sqlType?: string | null;
         oid?: number | null;
         fmod?: number | null;
@@ -3386,8 +3386,8 @@ export class PostgreSQLAdapter
         // an array column that OID resolves to OID::Array(subtype) — an
         // array-aware type whose serialize returns ArrayData, which
         // quoteDefaultExpression handles directly.
-        if (c.oid != null) {
-          return self.lookupCastTypeFromColumn(c) as {
+        if (column.oid != null) {
+          return self.lookupCastTypeFromColumn(column) as {
             serialize?(v: unknown): unknown;
           } | null;
         }
@@ -3395,7 +3395,7 @@ export class PostgreSQLAdapter
         // sql_type with the live regtype query (postgresql/quoting.rb:195),
         // which handles typmods and `[]` array suffixes server-side — an
         // array sql_type resolves to the array type's OID directly.
-        return self.lookupCastType(c.sqlType ?? "");
+        return self.lookupCastType(column.sqlType ?? "");
       },
     };
     return pgQuoteDefaultExpression.call(
@@ -3564,15 +3564,15 @@ export class PostgreSQLAdapter
     return singularize(table);
   }
 
-  async renameTable(oldName: string, newName: string): Promise<void> {
+  async renameTable(tableName: string, newName: string): Promise<void> {
     this.validateTableLengthBang(newName);
     await this.clearCacheBang();
-    const [oldSchema, unqualifiedOld] = this.extractSchemaQualifiedName(oldName);
+    const [oldSchema, unqualifiedOld] = this.extractSchemaQualifiedName(tableName);
     const [, unqualifiedNew] = this.extractSchemaQualifiedName(newName);
-    await this.schemaCache.clearDataSourceCacheBang(oldName);
+    await this.schemaCache.clearDataSourceCacheBang(tableName);
     await this.schemaCache.clearDataSourceCacheBang(newName);
     await this.execute(
-      `ALTER TABLE ${this.quoteTableName(oldName)} RENAME TO ${this.quoteColumnName(unqualifiedNew)}`,
+      `ALTER TABLE ${this.quoteTableName(tableName)} RENAME TO ${this.quoteColumnName(unqualifiedNew)}`,
     );
     // Rails reads max_identifier_length here, which lazily runs the SHOW query
     // on first use; warm the memo so the truncation limit is the real server
@@ -3609,7 +3609,7 @@ export class PostgreSQLAdapter
         }
       }
     }
-    await this.renameTableIndexes(oldName, newName);
+    await this.renameTableIndexes(tableName, newName);
   }
 
   async addIndex(

--- a/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
@@ -303,7 +303,9 @@ export function buildTruncateStatements(
   this: BuildTruncateStatementsHost,
   tableNames: string[],
 ): string[] {
-  return [`TRUNCATE TABLE ${tableNames.map((t) => this.quoteTableName(t)).join(", ")}`];
+  return [
+    `TRUNCATE TABLE ${tableNames.map((tableName) => this.quoteTableName(tableName)).join(", ")}`,
+  ];
 }
 
 /** @internal */

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/point.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/point.ts
@@ -65,9 +65,8 @@ export class Point extends ValueType<PointValue> {
       return this.buildPoint(value[0], value[1]);
     }
     if (typeof value === "object") {
-      const hash = value as Record<string, unknown>;
-      if (Object.keys(hash).length === 0) return null;
-      const [x, y] = valuesArrayFromHash(hash);
+      if (Object.keys(value as Record<string, unknown>).length === 0) return null;
+      const [x, y] = valuesArrayFromHash(value as Record<string, unknown>);
       return this.buildPoint(x, y);
     }
     return null;

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/uuid.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/uuid.ts
@@ -55,9 +55,9 @@ export class Uuid extends ValueType<string> {
 
   /** @internal Rails-private helper. */
   protected override castValue(value: unknown): string | null {
-    const str = String(value);
-    if (!ACCEPTABLE_UUID.test(str)) return null;
-    return this.formatUuid(str);
+    value = String(value);
+    if (!ACCEPTABLE_UUID.test(value as string)) return null;
+    return this.formatUuid(value as string);
   }
 
   private formatUuid(uuid: string): string {

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-creation.ts
@@ -180,7 +180,7 @@ export class SchemaCreation extends AbstractSchemaCreation {
       // and PostgreSQL owns the rejection — `[null]` would throw in the quoter
       // first (add_unique_constraint has no pre-raise for the empty case).
       const cols = wrap(o.column)
-        .map((c) => this.adapter.quoteColumnName(c))
+        .map((column) => this.adapter.quoteColumnName(column))
         .join(", ");
       p.push(`(${cols})`);
     }

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -715,7 +715,8 @@ export function strictLoadingViolationBang(
     });
     return;
   }
-  throw new StrictLoadingViolationError(reflectionLike.strictLoadingViolationMessage(ownerClass));
+  const message = reflectionLike.strictLoadingViolationMessage(ownerClass);
+  throw new StrictLoadingViolationError(message);
 }
 
 export function initializeFindByCache(this: CoreHost): void {
@@ -776,9 +777,7 @@ export function filterAttributes(
 export function predicateBuilder(this: CoreHost): PredicateBuilder {
   if (Object.prototype.hasOwnProperty.call(this, "_predicateBuilder") && this._predicateBuilder)
     return this._predicateBuilder;
-  const table = this.arelTable;
-  const metadata = new TableMetadata(this as any, table);
-  this._predicateBuilder = new PredicateBuilder(metadata);
+  this._predicateBuilder = new PredicateBuilder(new TableMetadata(this as any, this.arelTable));
   return this._predicateBuilder;
 }
 

--- a/packages/activerecord/src/counter-cache.ts
+++ b/packages/activerecord/src/counter-cache.ts
@@ -364,8 +364,8 @@ export async function _createRecord(
   superFn: () => Promise<unknown>,
 ): Promise<unknown> {
   const id = await superFn();
-  for (const name of counterCachedAssociationNames(this.constructor)) {
-    await this.association(name).incrementCounters();
+  for (const associationName of counterCachedAssociationNames(this.constructor)) {
+    await this.association(associationName).incrementCounters();
   }
   return id;
 }
@@ -380,8 +380,8 @@ export async function destroyRow(
 ): Promise<number> {
   const affectedRows = await superFn();
   if (affectedRows > 0) {
-    for (const name of counterCachedAssociationNames(this.constructor)) {
-      const assoc = this.association(name);
+    for (const associationName of counterCachedAssociationNames(this.constructor)) {
+      const association = this.association(associationName);
       const dba = this.destroyedByAssociation as {
         foreignKey?: unknown;
         options?: Record<string, unknown>;
@@ -389,9 +389,10 @@ export async function destroyRow(
       const destroyedByForeignKey =
         dba?.foreignKey ?? derivedForeignKey(dba, this.constructor.name);
       const reflectionForeignKey =
-        assoc.reflection?.foreignKey ?? derivedForeignKey(assoc.reflection, name);
+        association.reflection?.foreignKey ??
+        derivedForeignKey(association.reflection, associationName);
       if (!dba || !_foreignKeysEqual(destroyedByForeignKey, reflectionForeignKey)) {
-        await assoc.decrementCounters();
+        await association.decrementCounters();
       }
     }
   }

--- a/packages/activerecord/src/locking/optimistic.ts
+++ b/packages/activerecord/src/locking/optimistic.ts
@@ -268,11 +268,11 @@ export function destroyRow(
  * @internal
  * Mirrors: ActiveRecord::Locking::Optimistic#_lock_value_for_database
  */
-export function _lockValueForDatabase(this: InstanceLockingHost, col: string): unknown {
-  if (isWillSaveChangeToAttribute(this as any, col)) {
-    return this.readAttribute(col) ?? 0;
+export function _lockValueForDatabase(this: InstanceLockingHost, lockingColumn: string): unknown {
+  if (isWillSaveChangeToAttribute(this as any, lockingColumn)) {
+    return this.readAttribute(lockingColumn) ?? 0;
   }
-  return attributeInDatabase(this as any, col) ?? 0;
+  return attributeInDatabase(this as any, lockingColumn) ?? 0;
 }
 
 /**
@@ -281,9 +281,9 @@ export function _lockValueForDatabase(this: InstanceLockingHost, col: string): u
  */
 export function _clearLockingColumn(this: InstanceLockingHost): void {
   const ctor = this.constructor;
-  const col = ctor.lockingColumn;
-  this.writeAttribute(col, null);
-  this.clearAttributeChange(col);
+  const lockingColumn = ctor.lockingColumn;
+  this.writeAttribute(lockingColumn, null);
+  this.clearAttributeChange(lockingColumn);
 }
 
 /**

--- a/packages/activerecord/src/migration/command-recorder.ts
+++ b/packages/activerecord/src/migration/command-recorder.ts
@@ -132,10 +132,10 @@ export class CommandRecorder {
       typeof delegate?.supportsBulkAlter === "function" && delegate.supportsBulkAlter() === true;
 
     if (options["bulk"] && supportsBulk) {
-      const sub = new CommandRecorder(this._delegate);
-      sub.reverting = this._reverting;
-      await callback(delegate.updateTableDefinition(tableName, sub));
-      this._commands.push({ cmd: "changeTable", args: [tableName, sub.commands] });
+      const recorder = new CommandRecorder(this._delegate);
+      recorder.reverting = this._reverting;
+      await callback(delegate.updateTableDefinition(tableName, recorder));
+      this._commands.push({ cmd: "changeTable", args: [tableName, recorder.commands] });
     } else {
       await callback(delegate.updateTableDefinition(tableName, this));
     }

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -749,18 +749,18 @@ export function attributesBuilder(this: SchemaHost): AttributeSetBuilder {
 
   const pk = this.primaryKey;
   const pkSet = new Set(Array.isArray(pk) ? pk : [pk]);
-  const types = new Map<string, any>();
+  const attributeTypes = new Map<string, any>();
   const defaults = new Map<string, Attribute>();
   for (const [name, def] of this._attributeDefinitions) {
     const type = def.type ?? { cast: (v: unknown) => v, serialize: (v: unknown) => v };
-    types.set(name, type);
+    attributeTypes.set(name, type);
     if (!pkSet.has(name) && def.defaultValue !== undefined) {
       const val = typeof def.defaultValue === "function" ? def.defaultValue() : def.defaultValue;
       defaults.set(name, Attribute.withCastValue(name, val, type));
     }
   }
 
-  this._attributesBuilder = new AttributeSetBuilder(types, defaults);
+  this._attributesBuilder = new AttributeSetBuilder(attributeTypes, defaults);
   return this._attributesBuilder;
 }
 

--- a/packages/activerecord/src/result.ts
+++ b/packages/activerecord/src/result.ts
@@ -239,8 +239,8 @@ export class Result {
 
   get indexedRows(): IndexedRow[] {
     if (this.#indexedRows) return this.#indexedRows;
-    const idx = this.columnIndexes;
-    this.#indexedRows = this.rows.map((row) => new IndexedRow(idx, row));
+    const columns = this.columnIndexes;
+    this.#indexedRows = this.rows.map((row) => new IndexedRow(columns, row));
     return this.#indexedRows;
   }
 

--- a/packages/activerecord/src/sanitization.ts
+++ b/packages/activerecord/src/sanitization.ts
@@ -345,11 +345,11 @@ export const ClassMethods = {
  *
  * @internal
  */
-function replaceBindVariables(quoter: Quoter, statement: string, values: unknown[]): string {
+function replaceBindVariables(connection: Quoter, statement: string, values: unknown[]): string {
   raiseIfBindArityMismatch(statement, statement.match(/\?/g)?.length ?? 0, values.length);
   const bound = [...values];
   let result = statement;
-  result = result.replace(/\?/g, () => replaceBindVariable(quoter, bound.shift()));
+  result = result.replace(/\?/g, () => replaceBindVariable(connection, bound.shift()));
   return result;
 }
 
@@ -361,7 +361,7 @@ function replaceBindVariables(quoter: Quoter, statement: string, values: unknown
  *
  * @internal
  */
-function replaceBindVariable(quoter: Quoter, value: unknown): string {
+function replaceBindVariable(connection: Quoter, value: unknown): string {
   // Rails checks `ActiveRecord::Relation === value` first and inlines the
   // relation's SQL as a subquery. Duck-typed here to avoid importing Relation
   // (circular): a Relation exposes both `toSql` and `toArray`, which a record
@@ -369,7 +369,7 @@ function replaceBindVariable(quoter: Quoter, value: unknown): string {
   if (isRelationLike(value)) {
     return (value as { toSql(): string }).toSql();
   }
-  return quoteBoundValue(quoter, value);
+  return quoteBoundValue(connection, value);
 }
 
 function isRelationLike(value: unknown): value is { toSql(): string } {
@@ -389,7 +389,7 @@ function isRelationLike(value: unknown): value is { toSql(): string } {
  * @internal
  */
 function replaceNamedBindVariables(
-  quoter: Quoter,
+  connection: Quoter,
   statement: string,
   bindVars: Record<string, unknown>,
 ): string {
@@ -408,7 +408,7 @@ function replaceNamedBindVariables(
         if (!Object.prototype.hasOwnProperty.call(bindVars, name)) {
           throw new PreparedStatementInvalid(`missing value for :${name} in ${statement}`);
         }
-        return replaceBindVariable(quoter, bindVars[name]);
+        return replaceBindVariable(connection, bindVars[name]);
       }
     },
   );
@@ -424,10 +424,10 @@ function replaceNamedBindVariables(
  *
  * @internal
  */
-function quoteBoundValue(quoter: Quoter, value: unknown): string {
+function quoteBoundValue(connection: Quoter, value: unknown): string {
   if (hasIdForDatabase(value)) {
-    const cast = quoter.castBoundValue(value.idForDatabase());
-    return quoter.quote(cast);
+    const cast = connection.castBoundValue(value.idForDatabase());
+    return connection.quote(cast);
   }
 
   // Handle collections recognized by isEnumerable (Array and Set only).
@@ -437,20 +437,20 @@ function quoteBoundValue(quoter: Quoter, value: unknown): string {
   if (isEnumerable(value)) {
     const values = Array.from(value);
     if (values.length === 0) {
-      const cast = quoter.castBoundValue(null);
-      return quoter.quote(cast);
+      const cast = connection.castBoundValue(null);
+      return connection.quote(cast);
     }
     return values
       .map((v) => {
         const idVal = hasIdForDatabase(v) ? v.idForDatabase() : v;
-        const cast = quoter.castBoundValue(idVal);
-        return quoter.quote(cast);
+        const cast = connection.castBoundValue(idVal);
+        return connection.quote(cast);
       })
       .join(",");
   }
 
-  const cast = quoter.castBoundValue(value);
-  return quoter.quote(cast);
+  const cast = connection.castBoundValue(value);
+  return connection.quote(cast);
 }
 
 function hasIdForDatabase(value: unknown): value is { idForDatabase(): unknown } {

--- a/packages/activerecord/src/schema.ts
+++ b/packages/activerecord/src/schema.ts
@@ -90,13 +90,13 @@ export class Schema extends Current {
     // trailties boot). Using defaultEnv over a hard-coded literal
     // keeps Schema.define consistent with how Migrator and other
     // migration-stack pieces resolve the current environment.
-    const environment =
+    const currentEnvironment =
       info.environment ??
       getEnv("TRAILS_ENV") ??
       getEnv("NODE_ENV") ??
       DatabaseConfigurations.defaultEnv;
     const internalMetadata = new InternalMetadata(adapter.pool);
-    await internalMetadata.createTableAndSetFlags(environment);
+    await internalMetadata.createTableAndSetFlags(currentEnvironment);
   }
 
   constructor(adapter: DatabaseAdapter) {

--- a/packages/activerecord/src/scoping/default.ts
+++ b/packages/activerecord/src/scoping/default.ts
@@ -131,23 +131,23 @@ export function hasDefaultScopeOverride(modelClass: any): boolean {
  */
 export function defaultScope<T extends typeof Base>(
   this: T,
-  fn: (rel: Relation<InstanceType<T>>) => Relation<any>,
+  scope: (rel: Relation<InstanceType<T>>) => Relation<any>,
   options?: { allQueries?: boolean },
 ): void;
 export function defaultScope<T extends typeof Base>(
   this: T,
-  fn: (rel: Relation<InstanceType<T>>) => Relation<any>,
+  scope: (rel: Relation<InstanceType<T>>) => Relation<any>,
   allQueries?: boolean,
 ): void;
 export function defaultScope<T extends typeof Base>(
   this: T,
-  fn: (rel: Relation<InstanceType<T>>) => Relation<any>,
+  scope: (rel: Relation<InstanceType<T>>) => Relation<any>,
   optionsOrAllQueries?: { allQueries?: boolean } | boolean,
 ): void {
   // Rails: `scope.is_a?(Relation) || !scope.respond_to?(:call)`. A trails
   // Relation is a non-callable object, so the callable check alone covers both
   // (an eager `Model.where(...)` relation included).
-  if (typeof fn !== "function") {
+  if (typeof scope !== "function") {
     throw new ArgumentError(
       "Support for calling #default_scope without a block is removed. For " +
         "example instead of `default_scope where(color: 'red')`, please use " +
@@ -161,7 +161,7 @@ export function defaultScope<T extends typeof Base>(
       ? optionsOrAllQueries
       : (optionsOrAllQueries?.allQueries ?? false);
 
-  const scopeObj = new DefaultScope(fn as (rel: any) => any, allQueries);
+  const scopeObj = new DefaultScope(scope as (rel: any) => any, allQueries);
   const existing: DefaultScope[] = (this as any).defaultScopes ?? [];
   (this as any).defaultScopes = [...existing, scopeObj];
 }
@@ -244,8 +244,8 @@ function isIgnoreDefaultScope(modelClass: any): boolean {
 }
 
 /** @internal */
-function setIgnoreDefaultScope(modelClass: any, value: boolean | null): void {
-  ScopeRegistry.setIgnoreDefaultScope(modelClass, value);
+function setIgnoreDefaultScope(baseClass: any, ignore: boolean | null): void {
+  ScopeRegistry.setIgnoreDefaultScope(baseClass, ignore);
 }
 
 /**

--- a/packages/activerecord/src/store.ts
+++ b/packages/activerecord/src/store.ts
@@ -469,26 +469,30 @@ function defineStoreAccessorDirtyMethods(
  *   store(User, 'settings', { accessors: ['theme'], prefix: true })
  *   store(User, 'settings', { accessors: ['theme'], coder: JSON })
  */
-export function store(modelClass: typeof Base, attribute: string, options: StoreOptions): void {
+export function store(
+  modelClass: typeof Base,
+  storeAttribute: string,
+  options: StoreOptions,
+): void {
   // Mirror Rails three-step: build_column_serializer → IndifferentCoder → serialize
-  const baseCoder = buildColumnSerializer(attribute, options.coder, Object, options.yaml);
+  const coder = buildColumnSerializer(storeAttribute, options.coder, Object, options.yaml);
   // Validate: if a coder was resolved, it must implement dump/load. Strings, numbers,
   // and arbitrary objects without these methods would crash silently later.
   if (
-    baseCoder != null &&
-    (typeof (baseCoder as any).dump !== "function" || typeof (baseCoder as any).load !== "function")
+    coder != null &&
+    (typeof (coder as any).dump !== "function" || typeof (coder as any).load !== "function")
   ) {
     throw new ConfigurationError(
-      `store coder for '${attribute}' must implement dump() and load(), ` +
-        `but got ${typeof baseCoder}.`,
+      `store coder for '${storeAttribute}' must implement dump() and load(), ` +
+        `but got ${typeof coder}.`,
     );
   }
-  const indifferentCoder = new IndifferentCoder(attribute, baseCoder as CoderLike | null);
-  setStoreCoder(modelClass, attribute, indifferentCoder);
+  const indifferentCoder = new IndifferentCoder(storeAttribute, coder as CoderLike | null);
+  setStoreCoder(modelClass, storeAttribute, indifferentCoder);
   // Structured column types (json/jsonb/hstore) have a type-level accessor and
   // handle their own cast/serialize. Only patch readAttribute for plain text/string
   // columns that have no type-level accessor.
-  const colType = (modelClass as any).typeForAttribute?.(attribute);
+  const colType = (modelClass as any).typeForAttribute?.(storeAttribute);
   if (!colType || typeof colType.accessor !== "function") {
     if (!_serializeAttr) {
       throw new ConfigurationError(
@@ -496,18 +500,18 @@ export function store(modelClass: typeof Base, attribute: string, options: Store
           `Ensure base.ts (or the activerecord index) is imported before calling store().`,
       );
     }
-    _serializeAttr(modelClass, attribute, { coder: indifferentCoder as any });
+    _serializeAttr(modelClass, storeAttribute, { coder: indifferentCoder as any });
   }
 
   if (options.accessors !== undefined) {
-    storeAccessor(modelClass, attribute, {
+    storeAccessor(modelClass, storeAttribute, {
       accessors: options.accessors,
       prefix: options.prefix,
       suffix: options.suffix,
     });
   } else {
     // Still register the column in storedAttributes even with no accessors.
-    addLocalStoredAttribute(modelClass, attribute, []);
+    addLocalStoredAttribute(modelClass, storeAttribute, []);
   }
 }
 

--- a/packages/activerecord/src/table-metadata.ts
+++ b/packages/activerecord/src/table-metadata.ts
@@ -81,7 +81,7 @@ export class TableMetadata {
       return new TableMetadata(associationKlass, arelTable, reflection);
     }
 
-    const typeCaster = new TypeCasterConnection(this._klass as any, tableName);
+    const typeCaster = new TypeCasterConnection(this.klass as any, tableName);
     const arelTable = new Table(tableName, { typeCaster });
     return new TableMetadata(null, arelTable, reflection);
   }

--- a/packages/activerecord/src/timestamp.ts
+++ b/packages/activerecord/src/timestamp.ts
@@ -474,10 +474,10 @@ export function createOrUpdate(this: TimestampInstanceHost, touch = true): Promi
 /** @internal */
 export async function recordUpdateTimestamps(this: TimestampInstanceHost): Promise<void> {
   if (this._touchRecord && shouldRecordTimestamps.call(this)) {
-    const time = currentTimeFromProperTimezone();
-    for (const col of timestampAttributesForUpdateInModel.call(this.constructor)) {
-      if (!this.willSaveChangeToAttribute?.(col)) {
-        this._writeAttribute?.(col, time);
+    const currentTime = currentTimeFromProperTimezone();
+    for (const column of timestampAttributesForUpdateInModel.call(this.constructor)) {
+      if (!this.willSaveChangeToAttribute?.(column)) {
+        this._writeAttribute?.(column, currentTime);
       }
     }
   }
@@ -509,9 +509,9 @@ export function maxUpdatedColumnTimestamp(this: TimestampInstanceHost): Temporal
 
 /** @internal */
 export function clearTimestampAttributes(this: TimestampInstanceHost): void {
-  for (const attr of allTimestampAttributesInModel.call(this.constructor)) {
-    (this as unknown as Record<string, unknown>)[attr] = null;
-    this.clearAttributeChange?.(attr);
+  for (const attributeName of allTimestampAttributesInModel.call(this.constructor)) {
+    (this as unknown as Record<string, unknown>)[attributeName] = null;
+    this.clearAttributeChange?.(attributeName);
   }
 }
 

--- a/packages/activerecord/src/token-for.ts
+++ b/packages/activerecord/src/token-for.ts
@@ -145,8 +145,7 @@ export class TokenDefinition {
   }
 
   generateToken(model: Base): string {
-    const data = this.payloadFor(model);
-    return this.messageVerifier().generate(data, {
+    return this.messageVerifier().generate(this.payloadFor(model), {
       purpose: this.fullPurpose(),
       expiresIn: this.expiresIn,
     });
@@ -160,9 +159,9 @@ export class TokenDefinition {
   ): Promise<Base | null> {
     const verified = this.messageVerifier().verified(token, { purpose: this.fullPurpose() });
     const payload = Array.isArray(verified) && verified.length > 0 ? verified : null;
-    const record = payload ? await block(payload[0]) : null;
-    return record && JSON.stringify(this.payloadFor(record)) === JSON.stringify(payload)
-      ? record
+    const model = payload ? await block(payload[0]) : null;
+    return model && JSON.stringify(this.payloadFor(model)) === JSON.stringify(payload)
+      ? model
       : null;
   }
 }

--- a/packages/activerecord/src/touch-later.ts
+++ b/packages/activerecord/src/touch-later.ts
@@ -150,14 +150,14 @@ export async function beforeCommittedBang(this: Base): Promise<void> {
 /** @internal */
 export function surreptitiouslyTouch(this: Base, attrNames: string[]): void {
   const time = (this as any)._touchTime;
-  for (const attr of attrNames) {
-    (this as any).writeAttribute(attr, time);
+  for (const attrName of attrNames) {
+    (this as any).writeAttribute(attrName, time);
     // Per-attribute clear so the baseline rebinds to the touched value;
     // otherwise a later write would diff against the pre-touch original.
     if (typeof (this as any).clearAttributeChange === "function") {
-      (this as any).clearAttributeChange(attr);
+      (this as any).clearAttributeChange(attrName);
     } else if (typeof (this as any).clearAttributeChanges === "function") {
-      (this as any).clearAttributeChanges([attr]);
+      (this as any).clearAttributeChanges([attrName]);
     }
   }
 }

--- a/packages/activerecord/src/validations/associated.ts
+++ b/packages/activerecord/src/validations/associated.ts
@@ -40,8 +40,8 @@ export class AssociatedValidator extends EachValidator {
     // would race on a repeated/shared associated record and reorder
     // callbacks. Await each in order to preserve that observable behavior.
     let anyInvalid = false;
-    for (const assoc of values) {
-      if (!(await isValidObject(assoc, context))) anyInvalid = true;
+    for (const association of values) {
+      if (!(await isValidObject(association, context))) anyInvalid = true;
     }
     if (anyInvalid) {
       const { attributes: _, ...errorOpts } = this.options;

--- a/packages/activerecord/src/validations/uniqueness.ts
+++ b/packages/activerecord/src/validations/uniqueness.ts
@@ -167,15 +167,14 @@ export class UniquenessValidator extends EachValidator {
     if (value == null && o.allowNil === true) return;
     if (isBlank(value) && o.allowBlank === true) return;
 
-    const finderClass = findFinderClassFor(record, this._klass);
-    const modelClass = finderClass ?? record.constructor;
-    if (!modelClass.where) return;
+    const finderClass = findFinderClassFor(record, this._klass) ?? record.constructor;
+    if (!finderClass.where) return;
 
-    const mapped = mapEnumAttribute(modelClass, attribute, value);
+    const mapped = mapEnumAttribute(finderClass, attribute, value);
 
     if (
       record.isPersisted?.() &&
-      !(await isValidationNeeded(this, modelClass, record, attribute))
+      !(await isValidationNeeded(this, finderClass, record, attribute))
     ) {
       return;
     }
@@ -190,16 +189,16 @@ export class UniquenessValidator extends EachValidator {
     // that constructs the validator directly with a strict option.
     if (opts?.strict != null) errorOpts.strict = opts.strict;
 
-    let [relation] = await buildRelation(modelClass, attribute, mapped, this.options);
+    let [relation] = await buildRelation(finderClass, attribute, mapped, this.options);
 
     if (record.isPersisted?.()) {
-      const pk = modelClass.primaryKey;
+      const pk = finderClass.primaryKey;
       // Rails raises UnknownPrimaryKey rather than excluding the record by id
       // when a persisted record's finder class has no primary key — there is
       // no way to exclude the row itself from the existence check.
       if (pk == null) {
         throw new UnknownPrimaryKey(
-          modelClass,
+          finderClass,
           "Cannot validate uniqueness for persisted record without primary key.",
         );
       }

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/token-for.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/token-for.json
@@ -2,13 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "token-for.ts",
-    "rubyName": "generate_token",
-    "call": "order:payloadFor,generate",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "token-for.ts",
     "rubyName": "generate_token_for",
     "call": "token_definitions",
     "kind": "args",


### PR DESCRIPTION
RFC 0096 wave 2, two bundled stories. Renames body-local variables and
parameters to the identifiers the Rails bodies use, camelCased per
`docs/ruby-ts-conventions.md`. No behavior change, no public-surface change.

Measured with `API_COMPARE_FORCE=1 pnpm parity:api --calls` on a fresh build,
before and after:

| class | before | after |
| --- | ---: | ---: |
| `naming` | 498 | 464 |
| `shape` | 378 | 378 |

34 `naming` rows converged; no new `shape` rows (the one `shape` row that
changes key — `validations/uniqueness.ts#validateEach` → `build_relation` —
is the same pre-existing row re-keyed from `modelClass` to `finderClass`).

Inlining `payload_for` at `token-for.ts#generateToken` also converged a
`call-mismatches` baseline row (`order:payloadFor,generate`); that row is
deleted by hand, per the only-shrink contract. `pnpm parity:api:calls` and
`pnpm parity:api:calls:args` are both green.

### Renames

PostgreSQL adapter / OID:

- `postgresql-adapter.ts#renameTable` — `oldName` → `tableName` (`schema_statements.rb:436`)
- `postgresql-adapter.ts#quoteDefaultExpression` — `c` → `column` (`quoting.rb:162`)
- `postgresql/schema-creation.ts#visitUniqueConstraintDefinition` — `c` → `column` (`schema_creation.rb:50`)
- `postgresql/oid/point.ts#cast` — drops the `hash` local, passing `value` as Rails does (`oid/point.rb:31`)
- `postgresql/oid/uuid.ts#castValue` — reassigns `value` instead of a `str` local (`oid/uuid.rb:29-30`)
- `postgresql/database-statements.ts#buildTruncateStatements` — `t` → `tableName`. Rails writes `table_names.map(&method(:quote_table_name))` (`postgresql/database_statements.rb:200`) with no block variable at all; TS has no method-reference form, so the arrow parameter is forced, and it takes the singular of the collection name like every other such block in this PR.

Model core:

- `attributes.ts#_defaultAttributes` — `attrMap` → `attributesHash` (`attributes.rb:243,249`)
- `attribute-methods/primary-key.ts#quotedPrimaryKey` — `pk` → `primaryKey` (`primary_key.rb:92`)
- `attribute-methods/serialization.ts#buildColumnSerializer` — `resolvedCoder` → reassigned `coder` param (`serialization.rb:212`)
- `core.ts#strictLoadingViolationBang` — extracts Rails' `message` local (`core.rb:256-257`)
- `core.ts#predicateBuilder` — inlines `TableMetadata.new(self, arel_table)` (`core.rb:396`)
- `counter-cache.ts#_createRecord`/`#destroyRow` — `name` → `associationName`, `assoc` → `association` (`counter_cache.rb:203-215`)
- `locking/optimistic.ts#_lockValueForDatabase`/`#_clearLockingColumn` — `col` → `lockingColumn` (`locking/optimistic.rb:134-145`)
- `migration/command-recorder.ts#changeTable` — `sub` → `recorder` (`command_recorder.rb:138`)
- `model-schema.ts#attributesBuilder` — `types` → `attributeTypes` (`model_schema.rb:423`)
- `result.ts#indexedRows` — `idx` → `columns` (`result.rb:218`)
- `sanitization.ts` bind-variable helpers — `quoter` → `connection` (`sanitization.rb:203-216`)
- `schema.ts#define` — `environment` → `currentEnvironment` (`schema.rb:63`)
- `scoping/default.ts#defaultScope` — `fn` → `scope`; `#setIgnoreDefaultScope` — `modelClass`/`value` → `baseClass`/`ignore` (`scoping/default.rb:129,186`)
- `store.ts#store` — `attribute` → `storeAttribute`, `baseCoder` → `coder` (`store.rb:106-108`)
- `table-metadata.ts#associatedTable` — reads `this.klass` rather than the `_klass` field (`table_metadata.rb`)
- `timestamp.ts#recordUpdateTimestamps` — `col`/`time` → `column`/`currentTime`; `#clearTimestampAttributes` — `attr` → `attributeName` (`timestamp.rb:130-174`)
- `token-for.ts#generateToken` — inlines `payloadFor`; `#resolveToken` — `record` → `model` (`token_for.rb:27-34`)
- `touch-later.ts#surreptitiouslyTouch` — `attr` → `attrName` (`touch_later.rb:55`)
- `validations/associated.ts#validateEach` — `assoc` → `association` (`validations/associated.rb:9`)
- `validations/uniqueness.ts#validateEach` — collapses `finderClass`/`modelClass` onto Rails' single `finder_class` local (`validations/uniqueness.rb:21`)

`attributes.ts#_defaultAttributes` is renamed for fidelity but does not move
the counts: the comparator does not currently emit a row for that call site on
either side of the change, so the story table's snapshot row for `attributes.ts`
is stale rather than converged. The rename stands on `attributes.rb:243,249`
regardless.

### Rows deliberately left standing

Not renames — each is an a1/a3-class finding, or a comparator artifact a
rename cannot reach. None of these are new; all remain reported.

**Comparator artifacts (no rename converges them).** Ruby `x.to_s` is recorded
as `ref:toS`, which never equals TS `ref:toString` (or a bare string local),
and Ruby `default`/`null` cannot be spelled as TS identifiers so the port uses
`default_`/`null_`. Affects ~11 rows across `postgresql-adapter.ts`
(`renameTable`, `removeIndex`, `indexName`, `referenceNameForTable`,
`extractSchemaQualifiedName`, `newColumnFromField`, `changeColumnNullForAlter`),
`postgresql/quoting.ts` (`quote`, `quotedBinary`), and
`connection-handling.ts` (`connectionSpecificationName` is a method call in
trails, an attribute in Rails). This is a gap in the `naming` dimension itself,
not port debt — worth a tooling story against RFC 0096 rather than a code change.

**a3 (structure the port does not share):**

- `postgresql-adapter.ts#buildStatementPool` — trails' StatementPool takes the
  `client`, Rails' takes `self`.
- `postgresql-adapter.ts#renameTable` → `pkAndSequenceFor(renamedName)` — trails
  rebuilds the schema-qualified post-rename name; Rails passes `new_name`.
- `postgresql/database-statements.ts#castResult` → `Result.new` — Rails passes
  `fields` (an array of column-name Strings), `result.values` and `types.freeze`;
  node-postgres' `fields` are field *objects*, so the port binds `fields` to
  those and passes the derived `columnNames`. Renaming the local would put the
  Rails name on a different value (`database_statements.rb:178-184`).
- `postgresql/oid/array.ts`, `point.ts#buildPoint`, `range.ts`,
  `type-map-initializer.ts` — no `PG::TextEncoder`/`TextDecoder` in trails, and
  `buildPoint` needs null-guarded coordinate conversion where Rails uses `Float()`.
- `activemodel/attribute-methods.ts#generateAliasAttributeMethods` — Rails' first
  argument is a `CodeGenerator`; trails' `host` is the receiver, so renaming it
  would mislabel it.
- `enum.ts#_enum` → `defineEnumMethods` — trails passes the alias-resolved
  `attrName` where Rails passes `name`; `scopesEnabled`/`instanceMethodsEnabled`
  cannot take the Rails names without shadowing the `options.scopes` /
  `options.instanceMethods` reads in the same body.
- `migration.ts#executeMigrationInTransaction` — trails threads a migration
  `proxy`; `loaded` cannot take Rails' `migration` name, which is already bound.
- `token-for.ts#generatesTokenFor`, `signed-id.ts#findSigned`,
  `statement-cache.ts#create`, `internal-metadata.ts#selectEntry`,
  `database-configurations.ts`, `normalization.ts`, `scoping/named.ts`,
  `middleware/.../session.ts` — the differing argument is a public option key,
  an imported binding, or an expression, not a body-local.

Closes-story: naming-burndown-2-pg-adapter
Closes-story: naming-burndown-2-ar-model-core
