### PR TITLE
refactor(activerecord): delegate CollectionProxy#deleteAll to the association

### DIFF
--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -505,19 +505,32 @@ export class CollectionAssociation extends Association {
    * option. If :dependent is :destroy, uses :delete_all strategy instead.
    */
   async deleteAll(dependent?: string): Promise<number> {
-    if (dependent && dependent !== "nullify" && dependent !== "deleteAll") {
+    // Rails' `[:nullify, :delete_all].include?(dependent)`. `:delete_all` is
+    // spelled both ways in trails: `"delete_all"` (the literal Symbol name, what
+    // the proxy has always accepted from callers) and `"deleteAll"` (the
+    // camelCased form the internal `method` dispatch below runs on).
+    if (
+      dependent &&
+      dependent !== "nullify" &&
+      dependent !== "delete_all" &&
+      dependent !== "deleteAll"
+    ) {
       throw new ArgumentError("Valid values are :nullify or :delete_all");
     }
 
     const optionDep = this.options.dependent;
-    dependent = dependent
-      ? dependent
-      : // Rails' `options[:dependent] == :destroy` arm. Canonical trails models
-        // spell `:delete_all` as `"delete"`, which is the same delete strategy,
-        // so it collapses here too rather than falling through to nullify.
-        optionDep === "destroy" || optionDep === "delete"
+    dependent =
+      dependent === "delete_all"
         ? "deleteAll"
-        : optionDep;
+        : dependent
+          ? dependent
+          : // Rails' `options[:dependent] == :destroy` arm. Canonical trails
+            // models spell `:delete_all` as `"delete"`, which is the same delete
+            // strategy, so it collapses here too rather than falling through to
+            // nullify.
+            optionDep === "destroy" || optionDep === "delete"
+            ? "deleteAll"
+            : optionDep;
 
     const count = await this.deleteOrNullifyAllRecords(dependent);
 

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -2,6 +2,7 @@ import type { Base } from "../base.js";
 import type { AssociationDefinition } from "../associations.js";
 import { association as associationProxy } from "../associations.js";
 import { underscore, isAbortSignal } from "@blazetrails/activesupport";
+import { ArgumentError } from "@blazetrails/activemodel";
 import { Association } from "./association.js";
 import { foreignKeyPresentFor, ownerForeignKeyColumns } from "./foreign-association.js";
 import { throughForeignKeyPresent } from "./through-association.js";
@@ -503,25 +504,26 @@ export class CollectionAssociation extends Association {
    * Removes all records from the association. Honors the :dependent
    * option. If :dependent is :destroy, uses :delete_all strategy instead.
    */
-  async deleteAll(dependent?: string): Promise<void> {
-    if (
-      dependent &&
-      dependent !== "nullify" &&
-      dependent !== "deleteAll" &&
-      dependent !== "delete"
-    ) {
-      throw new Error("Valid values are 'nullify', 'delete', or 'deleteAll'");
+  async deleteAll(dependent?: string): Promise<number> {
+    if (dependent && dependent !== "nullify" && dependent !== "deleteAll") {
+      throw new ArgumentError("Valid values are :nullify or :delete_all");
     }
 
-    const normalized = dependent === "delete" ? "deleteAll" : dependent;
     const optionDep = this.options.dependent;
-    dependent =
-      normalized ?? (optionDep === "destroy" || optionDep === "delete" ? "deleteAll" : optionDep);
+    dependent = dependent
+      ? dependent
+      : // Rails' `options[:dependent] == :destroy` arm. Canonical trails models
+        // spell `:delete_all` as `"delete"`, which is the same delete strategy,
+        // so it collapses here too rather than falling through to nullify.
+        optionDep === "destroy" || optionDep === "delete"
+        ? "deleteAll"
+        : optionDep;
 
-    await this.deleteOrNullifyAllRecords(dependent);
+    const count = await this.deleteOrNullifyAllRecords(dependent);
 
     this.reset();
     this.loadedBang();
+    return count;
   }
 
   /**
@@ -533,12 +535,11 @@ export class CollectionAssociation extends Association {
    * deletes the rows; every other method (including the `nil`/`undefined`
    * default from `delete_all` with no `:dependent`) nullifies the FK.
    */
-  protected async deleteOrNullifyAllRecords(method?: string): Promise<void> {
+  protected async deleteOrNullifyAllRecords(method?: string): Promise<number> {
     if (method === "deleteAll") {
-      await this.deleteAllRecords();
-    } else {
-      await this.nullifyAllRecords();
+      return this.deleteAllRecords();
     }
+    return this.nullifyAllRecords();
   }
 
   /**
@@ -1129,14 +1130,13 @@ export class CollectionAssociation extends Association {
     return nullAttrs;
   }
 
-  protected async nullifyAllRecords(): Promise<void> {
+  protected async nullifyAllRecords(): Promise<number> {
     const nullAttrs = this.computeNullifiedOwnerAttributes();
 
     // Prefer scope-based bulk update (hits DB even if target isn't loaded)
     const rel = this.scope();
     if (rel && typeof rel.updateAll === "function") {
-      await rel.updateAll(nullAttrs);
-      return;
+      return rel.updateAll(nullAttrs);
     }
 
     // Fallback: load and update individually
@@ -1153,6 +1153,7 @@ export class CollectionAssociation extends Association {
         await (record as any).save();
       }
     }
+    return this.target.length;
   }
 
   /**
@@ -1191,11 +1192,12 @@ export class CollectionAssociation extends Association {
       : (record as any)[pk];
   }
 
-  private async deleteAllRecords(): Promise<void> {
+  private async deleteAllRecords(): Promise<number> {
     const rel = this.scope();
     if (rel && typeof rel.deleteAll === "function") {
-      await rel.deleteAll();
+      return rel.deleteAll();
     }
+    return 0;
   }
 
   /**

--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -864,8 +864,7 @@ describe("CollectionProxy — mutated finder requery on stale new-owner seed", (
 });
 
 // The mutation terminals invoked on the PROXY itself (not a spawned relation)
-// route through `Relation`'s implementations with `this` = the proxy — and
-// `deleteAll`'s diverged branch calls `super.deleteAll()` on the proxy — so
+// route through `Relation`'s implementations with `this` = the proxy, so
 // they hit the base `_isEmptyRelation()` chokepoint on the proxy. The
 // `CollectionProxy#_isEmptyRelation` override rebases the stale new-owner
 // `1=0` seed there, giving the mutation side the same rebase reads already
@@ -897,18 +896,30 @@ describe("CollectionProxy — mutation terminals invoked on the proxy itself on 
   it("resolves the persisted FK on the diverged deleteAll branch invoked on the proxy after save", async () => {
     const author = new Author({ name: "Proxy Mutation Two" });
     const posts = association<Post>(author, "posts") as any;
-    // Diverge the proxy in place while the owner is new so its base is the
-    // stale `1=0` seed and `deleteAll` takes the `super.deleteAll()` branch.
+    // Diverge the proxy in place while the owner is new, so its own relation
+    // state sits on the stale `1=0` seed.
     posts.whereBang({ title: "drop" });
 
     await author.save();
     const authorId = author.id as number;
     const dropped = await Post.create({ title: "drop", body: "1", author_id: authorId });
     const kept = await Post.create({ title: "keep", body: "2", author_id: authorId });
+    // A post belonging to a DIFFERENT author proves the association scope still
+    // constrains to this owner's FK, not a bare `deleteAll` over the table.
+    const otherAuthor = await Author.create({ name: "Someone Else Two" });
+    const theirs = await Post.create({ title: "drop", body: "3", author_id: otherAuthor.id });
 
-    expect(await posts.deleteAll()).toBe(1);
-    expect(await Post.where({ author_id: authorId }).pluck("id")).toEqual([kept.id]);
-    expect(await Post.exists(dropped.id)).toBe(false);
+    // Rails' `CollectionProxy#delete_all` is `@association.delete_all(dependent)`
+    // (collection_proxy.rb:474-476): it runs against the association scope, so
+    // the proxy's in-place `where!` does NOT narrow it — both of this author's
+    // posts leave the collection. `Author has_many :posts` declares no
+    // `:dependent`, so Rails' `delete_count(nil, scope)`
+    // (has_many_association.rb:112-118) nullifies the FK rather than deleting.
+    expect(await posts.deleteAll()).toBe(2);
+    expect(await Post.where({ author_id: authorId }).pluck("id")).toEqual([]);
+    expect((await Post.find(dropped.id)).author_id).toBeNull();
+    expect((await Post.find(kept.id)).author_id).toBeNull();
+    expect((await Post.find(theirs.id)).author_id).toBe(otherAuthor.id);
   });
 
   it("resolves the persisted FK on touchAll invoked on the proxy after save", async () => {

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -2546,42 +2546,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     this._invalidateAssociationIds();
   }
 
-  private async _deleteThroughAllSql(): Promise<number> {
-    const ctor = this._record.constructor as typeof Base;
-    const associations: AssociationDefinition[] = (ctor as any)._associations ?? [];
-    const throughAssoc = associations.find((a: any) => a.name === this._assocDef.options.through);
-    if (!throughAssoc) return 0;
-
-    const throughClassName =
-      throughAssoc.options.className ?? camelize(singularize(throughAssoc.name));
-    const throughModel = resolveAssocClass(this._record, throughAssoc.name, throughClassName);
-    const throughAs = throughAssoc.options.as;
-    let conditions: Record<string, unknown>;
-    if (throughAs) {
-      const poly = this._throughOwnerPolymorphic(throughAssoc, ctor, throughAs);
-      if (poly.idValue == null) return 0;
-      conditions = { [poly.idCol]: poly.idValue, [poly.typeCol]: poly.typeValue };
-    } else {
-      conditions = this._throughOwnerAttrs(throughAssoc, ctor);
-      if (Object.values(conditions).some((v) => v == null)) return 0;
-    }
-    if (this._assocDef.options.sourceType) {
-      const sourceName = this._assocDef.options.source ?? singularize(this._assocName);
-      conditions[`${underscore(sourceName)}_type`] = this._assocDef.options.sourceType;
-    }
-    return (throughModel as any).where(conditions).deleteAll();
-  }
-
-  private async _nullifyThroughAll(): Promise<number> {
-    const assoc = this._record.association(this._assocName) as unknown as {
-      loadTarget: () => Promise<Base[]>;
-      deleteRecords: (records: Base[], method: string) => Promise<number>;
-    };
-    const target = await assoc.loadTarget();
-    if (target.length === 0) return 0;
-    return assoc.deleteRecords(target, "nullify");
-  }
-
   /**
    * Resolve the effective `:dependent` strategy for a record-level `delete`,
    * mirroring Rails `HasManyAssociation#delete_records`: `:destroy` destroys each
@@ -3806,83 +3770,22 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * Delete all records from the collection according to the dependent strategy.
    *
    * Mirrors: ActiveRecord::Associations::CollectionProxy#delete_all
+   * (collection_proxy.rb:474-476): `@association.delete_all(dependent).tap {
+   * reset_scope }`. The argument validation, the `:destroy` → `:delete_all`
+   * normalization and the delete/nullify dispatch all live in
+   * `CollectionAssociation#deleteAll` / `deleteOrNullifyAllRecords`, exactly as
+   * in Rails.
    */
   async deleteAll(dependent?: string): Promise<number> {
-    this._ensureThroughWritable();
-    // Rails' `delete_all(dependent = nil)` only permits an explicit `:nullify`
-    // or `:delete_all` from a caller; any other symbol raises ArgumentError
-    // (collection_association.rb:151-153). The camelCase `"deleteAll"` and the
-    // `:destroy`/`:delete` mappings below apply only to the internal *option*
-    // default (`options.dependent`), never to a user-passed argument.
-    if (dependent !== undefined && dependent !== "nullify" && dependent !== "delete_all") {
-      throw new ArgumentError("Valid values are :nullify or :delete_all");
-    }
-    // Rails normalizes dependent: :destroy → :delete_all for deleteAll,
-    // because deleteAll should never run destroy callbacks (use destroyAll for that).
-    const raw = dependent ?? (this._assocDef.options.dependent as string | undefined);
-    let strategy: "delete_all" | "nullify";
-    switch (raw) {
-      case undefined:
-      case "delete_all":
-      case "deleteAll":
-      case "delete":
-      case "destroy":
-        strategy = "delete_all";
-        break;
-      case "nullify":
-        strategy = "nullify";
-        break;
-      default:
-        throw new Error(
-          `deleteAll only accepts "nullify", "delete_all", "deleteAll", "delete", or "destroy". Received: "${raw}"`,
-        );
-    }
-
-    // If the proxy's inherited Relation state has been mutated in place
-    // (e.g. cp.whereBang(...)), go through super.deleteAll() /
-    // super.updateAll() directly — scope() would rebuild the
-    // unmutated association scope and delete/nullify MORE rows than
-    // the caller constrained. NOT `this.deleteAll()` / `this.updateAll()`
-    // here: those resolve back to CollectionProxy's own methods and
-    // would recurse.
-    const diverged = this._relationStateDiverged();
-    // Through and diverged paths bypass scope(), which is where AR
-    // gates strict-loading. Enforce directly so deleteAll is
-    // consistent regardless of through/diverged state. The
-    // non-diverged non-through branch goes through scope() which
-    // produces an AR and enforces the same gate on its own.
-    if (this._isThrough || diverged) {
-      this._checkStrictLoading();
-    }
-    let count: number;
-    if (strategy === "delete_all") {
-      if (this._isThrough) {
-        // For through associations, delete join rows via SQL — not the target records
-        count = await this._deleteThroughAllSql();
-      } else if (diverged) {
-        count = await super.deleteAll();
-      } else {
-        count = await this.scope().deleteAll();
+    const count = await (
+      this._record.association(this._assocName) as unknown as {
+        deleteAll(dependent?: string): Promise<number>;
       }
-    } else {
-      // Nullify: set-based SQL update to null FKs (no per-record callbacks)
-      if (this._isThrough) {
-        // Rails `delete_or_nullify_all_records(:nullify)` → `delete_records`
-        // (has_many_through_association.rb:136-175) UPDATEs the source FK on the
-        // join rows to NULL — it does NOT delete them — and decrements the
-        // owner's counter caches. Delegate to the association layer (as `clear`
-        // does) so nullify semantics and counters are handled in one place,
-        // rather than `_deleteThroughAllSql`, which would DELETE the join rows.
-        count = await this._nullifyThroughAll();
-      } else {
-        const nullUpdates = this._buildNullifyUpdates();
-        if (diverged) {
-          count = await super.updateAll(nullUpdates);
-        } else {
-          count = await this.scope().updateAll(nullUpdates);
-        }
-      }
-    }
+    ).deleteAll(dependent);
+    // In Rails the proxy reads the association's `@target`, so the `reset` /
+    // `loaded!` inside `delete_all` is what empties the collection the proxy
+    // shows. The trails CollectionProxy keeps its own copy of the target, so
+    // the same reset has to be replayed on it here.
     this._target = [];
     this._targetLoaded = true;
     this._invalidateAssociationIds();

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -217,9 +217,10 @@ export class HasManyAssociation extends CollectionAssociation {
    * then decrements the counter cache by the affected count.
    * @internal
    */
-  protected override async deleteOrNullifyAllRecords(method?: string): Promise<void> {
+  protected override async deleteOrNullifyAllRecords(method?: string): Promise<number> {
     const count = await deleteCount(this, method ?? "", (this as any).scope());
     await updateCounter(this, -count);
+    return count;
   }
 
   /**

--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -593,6 +593,14 @@ describe("HasManyAssociationsTest", () => {
     expect((await Client.where(`firm_id=${firm.id}`)).length).toBe(0);
   });
 
+  it("delete all with option delete all", async () => {
+    const firm = companies("first_firm") as any;
+    const clientId = (await firm.dependentClientsOfFirm.first()).id;
+    const count = await firm.dependentClientsOfFirm.count();
+    expect(await firm.dependentClientsOfFirm.deleteAll("delete_all")).toBe(count);
+    expect(await Client.findBy({ id: clientId })).toBeNull();
+  });
+
   it("delete all with option nullify", async () => {
     const firm = companies("first_firm") as any;
     const clientId = (await firm.dependentClientsOfFirm.first()).id;

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -477,8 +477,8 @@ export class HasManyThroughAssociation extends HasManyAssociation {
    * bulk `scope.deleteAll`, which can't reach the join table.
    * @internal
    */
-  protected override async deleteOrNullifyAllRecords(method?: string): Promise<void> {
-    await this.deleteRecords(await this.loadTarget(), method ?? "");
+  protected override async deleteOrNullifyAllRecords(method?: string): Promise<number> {
+    return this.deleteRecords(await this.loadTarget(), method ?? "");
   }
 }
 

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-proxy.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-proxy.json
@@ -2,17 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/collection-proxy.ts",
-    "rubyName": "delete_all",
-    "call": "delete_all",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:dependent"
-    ],
-    "reason": "collection_proxy.rb:474-476 is `@association.delete_all(dependent).tap { reset_scope }`; the port reimplements the dependent dispatch, the through-join delete and the nullify arms inside the proxy rather than delegating, so there is no association-level `deleteAll(dependent)` call to forward the argument to. Converging is the delegation rewrite tracked by story call-args-ar-collection-proxy-delete-all-delegation."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/collection-proxy.ts",
     "rubyName": "scope",
     "call": "scope",
     "kind": "args",


### PR DESCRIPTION
Rails' `CollectionProxy#delete_all` (`collection_proxy.rb:474-476`) is a
one-liner: `@association.delete_all(dependent).tap { reset_scope }`. The port
reimplemented all of it inside the proxy — argument validation, the
`:destroy`/`:delete`/`"deleteAll"` mapping, a `_isThrough` /
`_relationStateDiverged()` branch, and direct calls to `_deleteThroughAllSql()`
/ `_nullifyThroughAll()` / `super.deleteAll()`.

## What moved

- `CollectionProxy#deleteAll` is now the Rails one-liner: delegate to the
  association's `deleteAll(dependent)`, then `resetScope()`. (The proxy keeps
  its own copy of the target where Rails shares the association's `@target`, so
  the association's `reset` is replayed on it — commented at the call site.)
- `CollectionAssociation#deleteAll` (`collection_association.rb:150-166`) does
  the validation (`ArgumentError`, "Valid values are :nullify or :delete_all"),
  the `dependent: :destroy` → `:delete_all` collapse, and routes through
  `deleteOrNullifyAllRecords`, returning the affected count as Rails does.
- The through arm and the nullify arm were already in
  `HasManyAssociation#deleteOrNullifyAllRecords`
  (`has_many_association.rb:112-118`) and
  `HasManyThroughAssociation#deleteOrNullifyAllRecords`
  (`has_many_through_association.rb:136-138`); they now return the count.
- Removed the proxy-only `_deleteThroughAllSql` / `_nullifyThroughAll` helpers.

## Behavior note

Delegating restores two Rails semantics the proxy body diverged from:

1. A plain `has_many` with no `:dependent` **nullifies** on `delete_all`
   (`delete_count(nil, scope)` → `update_all(nullified_owner_attributes)`), it
   does not DELETE. The proxy collapsed a `nil` dependent to `delete_all`.
2. In-place proxy mutation (`posts.whereBang(...)`) does not narrow
   `delete_all` — Rails runs it against the association scope.

`collection-proxy.test.ts`'s stale-new-owner-seed case for the diverged
`deleteAll` branch is updated to assert the Rails behavior (and now also pins
that the association scope still constrains to the owner's FK); its name is
unchanged.

## Gates

- `pnpm parity:api:calls` OK, `pnpm parity:api:calls:args` OK — the
  `associations/collection-proxy.ts` `delete_all` → `delete_all` `kind: "args"`
  baseline row is deleted by hand (only-shrink, no `--write`).
- `pnpm typecheck`, and the full `packages/activerecord/src/associations` suite
  (95 files, 2349 tests) plus `strict-loading`, `counter-cache`, `persistence`
  green locally.

Closes-story: call-args-ar-collection-proxy-delete-all-delegation
