### PR TITLE
refactor(activerecord): route collection-proxy construction through build_record and pass connection_pool inline

### DIFF
--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -718,10 +718,12 @@ export class Association {
     return record;
   }
 
-  protected buildRecord(
-    attributes?: Record<string, unknown>,
-    block?: (record: Base) => void,
-  ): Base | null {
+  /**
+   * Mirrors: ActiveRecord::Associations::Association#build_record
+   * (association.rb:383-388).
+   * @internal
+   */
+  buildRecord(attributes?: Record<string, unknown>, block?: (record: Base) => void): Base | null {
     const Klass = this.klass;
     if (!Klass) return null;
     // Rails' `build_record` passes `initialize_attributes` as the block to

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -54,11 +54,9 @@ import {
 } from "./errors.js";
 import { routeThroughCheckValidity } from "./validate-through-reflection.js";
 import { rebaseNewOwnerSeed } from "./new-owner-seed-rebase.js";
-import { findStiClass, stiEnabled } from "../inheritance.js";
 import { compositeQueryConstraintsList } from "../persistence.js";
 import type { AssociationDefinition } from "../associations.js";
 import {
-  association,
   autoloadModel,
   resolveAssocClass,
   _routeThroughViaAssociationScope,
@@ -67,11 +65,7 @@ import {
   _violatesStrictLoading,
 } from "../associations.js";
 import { _setCollectionProxyCtor } from "./collection-proxy-slot.js";
-import {
-  buildThroughInverseFor,
-  multisetDifference,
-  multisetIntersection,
-} from "./has-many-through-association.js";
+import { multisetDifference, multisetIntersection } from "./has-many-through-association.js";
 import {
   countRecords,
   scope as hasManyScope,
@@ -1277,124 +1271,43 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     return ctor._reflectOnAssociation?.(this._assocName)?.foreignKey ?? undefined;
   }
 
+  /**
+   * Mirrors Rails' `Association#build_record` (association.rb:383-388):
+   *
+   *   reflection.build_association(attributes) do |record|
+   *     initialize_attributes(record, attributes)
+   *   end
+   *
+   * Construction, including STI-subclass resolution, belongs to
+   * `AssociationReflection#build_association` → `klass.new(attributes, &block)`
+   * (reflection.rb:182) and `Base.new`'s inheritance-column handling
+   * (inheritance.rb `new` / `subclass_from_attributes`); the foreign key and
+   * the polymorphic type come off `scope_for_create` inside
+   * `initialize_attributes` (association.rb:224). So the proxy hands the whole
+   * job to the association holder rather than assembling them itself.
+   */
   private _buildRaw(attrs: Record<string, unknown> = {}): Base {
-    const ctor = this._record.constructor as typeof Base;
-    const primaryKey = this._assocDef.options.primaryKey ?? ctor.primaryKey;
-
-    // Polymorphic "as" option
-    const asName = this._assocDef.options.as;
-    const foreignKey = asName
-      ? (this._assocDef.options.foreignKey ??
-        this._reflectionForeignKey() ??
-        `${underscore(asName)}_id`)
-      : (this._assocDef.options.foreignKey ??
-        this._reflectionForeignKey() ??
-        `${underscore(ctor.name)}_id`);
-
-    const buildAttrs: Record<string, unknown> = { ...attrs };
-    // Composite key: spread each foreign-key column onto its owner primary-key
-    // column value. Coercing an array key to a string ("author_id,book_id")
-    // would produce an unknown attribute — tolerated only while construction
-    // silently swallowed it; the child's setter-dispatched assignment now
-    // raises, so map the real columns.
-    if (Array.isArray(foreignKey) || Array.isArray(primaryKey)) {
-      // Composite fk/pk: pair each foreign-key column with its owner primary-key
-      // column value. Fully parallel arrays (e.g. `foreign_key: [:author_id,
-      // :book_id]` / `primary_key: [:author_id, :id]`) pair by position; a mixed
-      // shape (scalar FK against a composite-PK target, or an array FK against a
-      // scalar PK) normalizes both to arrays and falls back to `pks[0]`, so a
-      // scalar side reads the leading key component. Coercing an array key to a
-      // string ("author_id,book_id") would produce an unknown attribute —
-      // tolerated only while construction swallowed it; the child's now
-      // setter-dispatched assignment raises, so map the real columns.
-      const fks = Array.isArray(foreignKey) ? foreignKey : [foreignKey];
-      const pks = Array.isArray(primaryKey) ? primaryKey : [primaryKey];
-      fks.forEach((fk, i) => {
-        buildAttrs[fk] = this._record._readAttribute(pks[i] ?? pks[0]);
-      });
-    } else {
-      buildAttrs[foreignKey] = this._record._readAttribute(primaryKey);
-    }
-    if (asName) {
-      const typeCol = this._assocDef.options.foreignType ?? `${underscore(asName)}_type`;
-      buildAttrs[typeCol] = ctor.polymorphicName();
-    }
-
-    let targetModel = this.model;
-
-    // STI: resolve subclass from the caller-supplied inheritance column,
-    // falling back to a value from scope_for_create (e.g.
-    // `has_many :posts, -> { where(type: "SpecialPost") }`). Rails resolves
-    // the subclass after scope-merge, so peek at scope here before
-    // instantiation; the full scope_for_create filter still runs below.
-    const sfcForSti = this._scopeForCreateRaw();
-    const inheritanceCol = targetModel.inheritanceColumn;
-    if (inheritanceCol !== null && stiEnabled(targetModel)) {
-      const typeName = (buildAttrs[inheritanceCol] ?? sfcForSti[inheritanceCol]) as
-        | string
-        | undefined;
-      if (typeName) targetModel = findStiClass(targetModel, typeName);
-    }
-
-    const record = new targetModel(buildAttrs);
-    this._record.association(this._assocName).initializeAttributes(record, attrs);
-    return record;
+    return (
+      this._record.association(this._assocName) as unknown as {
+        buildRecord(attributes?: Record<string, unknown>): Base;
+      }
+    ).buildRecord(attrs);
   }
 
+  /**
+   * Mirrors Rails' `HasManyThroughAssociation#build_record`
+   * (has_many_through_association.rb:88-100), which calls `super` —
+   * `Association#build_record` (association.rb:383-388) — for the
+   * construction and then wires the pre-built join row onto the target's
+   * inverse. Both halves live on the association holder, so the proxy hands
+   * the whole job to it.
+   */
   private _buildThrough(attrs: Record<string, unknown> = {}): Base {
-    let targetModel = this.model;
-
-    const sfcForSti = this._scopeForCreateRaw();
-    const inheritanceCol = targetModel.inheritanceColumn;
-    if (inheritanceCol !== null && stiEnabled(targetModel)) {
-      const typeName = (attrs[inheritanceCol] ?? sfcForSti[inheritanceCol]) as string | undefined;
-      if (typeName) targetModel = findStiClass(targetModel, typeName);
-    }
-
-    const record = new targetModel(attrs);
-    this._record.association(this._assocName).initializeAttributes(record, attrs);
-    // Mirrors the inverse half of Rails' HasManyThroughAssociation#build_record:
-    // pre-build the join row and wire it onto the target's inverse so the join
-    // is created alongside the target on save.
-    const built = buildThroughInverseFor(
-      this._record,
-      this._assocDef,
-      record,
-      (this as unknown as { _pendingThroughScope?: unknown })._pendingThroughScope ??
-        (this._isThrough ? this.scope() : this),
-    );
-    if (built?.isCollection) {
-      const invProxy = association(record, built.inverseName) as unknown as CollectionProxy;
-      invProxy._target.push(built.throughRecord);
-    } else if (built?.isHasOne) {
-      const inv = (record as unknown as { association?: (n: string) => any }).association?.(
-        built.inverseName,
-      );
-      if (inv) {
-        if (typeof inv.syncWrite === "function") {
-          inv.syncWrite(built.throughRecord);
-        } else {
-          inv.target = built.throughRecord;
-          inv.loadedBang?.();
-        }
-        inv.setInverseInstance?.(built.throughRecord);
+    return (
+      this._record.association(this._assocName) as unknown as {
+        buildRecord(attributes?: Record<string, unknown>): Base;
       }
-    } else if (built) {
-      // belongs_to inverse: call the writer to set FK on the new target record from the through record.
-      const inv = (record as unknown as { association?: (n: string) => any }).association?.(
-        built.inverseName,
-      );
-      if (inv && typeof inv.writer === "function") {
-        inv.writer(built.throughRecord);
-      }
-    }
-    return record;
-  }
-
-  private _scopeForCreateRaw(): Record<string, unknown> {
-    const fn = (this as unknown as { scopeForCreate?: () => Record<string, unknown> })
-      .scopeForCreate;
-    return typeof fn === "function" ? fn.call(this) : {};
+    ).buildRecord(attrs);
   }
 
   /**

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -296,19 +296,35 @@ export class HasManyThroughAssociation extends HasManyAssociation {
    * Builds the target via `super`, then — when the source reflection has an
    * inverse on the built record's class — pre-builds the through join row and
    * wires it onto that inverse so the join is created alongside the target.
+   *
+   * @internal
    */
-  protected override buildRecord(
+  override buildRecord(
     attributes?: Record<string, unknown>,
     block?: (record: Base) => void,
   ): Base | null {
     this.ensureNotNested();
-    (this as HasManyThroughAssociation & { _throughScope?: unknown })._throughScope = (
-      this as unknown as { scope?: () => unknown }
-    ).scope?.();
+    // Rails captures `scope` here inside the caller's `scoping` block, so a
+    // scoped build (`post.people.where(readers: { skimmer: true }).create`)
+    // sees the relation's values. trails carries that relation on the owner's
+    // proxy as `_pendingThroughScope` (association-relation.ts:153) instead of
+    // a current-scope stack, so prefer it when one is in flight.
+    const pendingThroughScope = (
+      this.owner._collectionProxies.get(this.reflection.name) as
+        | { _pendingThroughScope?: unknown }
+        | undefined
+    )?._pendingThroughScope;
+    (this as HasManyThroughAssociation & { _throughScope?: unknown })._throughScope =
+      pendingThroughScope ?? (this as unknown as { scope?: () => unknown }).scope?.();
     try {
       const record = super.buildRecord(attributes, block);
       if (!record) return record;
-      const built = buildThroughInverseFor(this.owner, this.reflection, record);
+      const built = buildThroughInverseFor(
+        this.owner,
+        this.reflection,
+        record,
+        (this as HasManyThroughAssociation & { _throughScope?: unknown })._throughScope,
+      );
       if (built) {
         const inverseAssoc = (
           record as unknown as { association?: (n: string) => any }
@@ -324,6 +340,13 @@ export class HasManyThroughAssociation extends HasManyAssociation {
               inverseAssoc.loadedBang?.();
             }
             inverseAssoc.setInverseInstance?.(built.throughRecord);
+          } else if (typeof inverseAssoc.writer === "function") {
+            // Rails' build_record covers only the collection and has_one
+            // inverses (has_many_through_association.rb:101-107); a belongs_to
+            // source inverse gets its foreign key from the through scope in
+            // `initialize_attributes`. trails' through scope does not carry it
+            // yet, so the writer stands in — tracked as through-scope debt.
+            inverseAssoc.writer(built.throughRecord);
           }
         }
       }

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -24,7 +24,6 @@ import { AbstractAdapter, Version } from "./abstract-adapter.js";
 import type { Column } from "./column.js";
 import {
   ActiveRecordError,
-  AdapterError,
   ConnectionFailed,
   ConnectionNotEstablished,
   DatabaseAlreadyExists,
@@ -1385,14 +1384,16 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     message: string,
     sql: string | null,
     binds: unknown[],
+    connectionPool: AbstractAdapter["pool"],
   ): MismatchedForeignKey {
     if (sql) {
       const details = this.mismatchedForeignKeyDetails(message, sql);
-      return new MismatchedForeignKey({ message, sql, binds, ...details });
+      return new MismatchedForeignKey({ message, sql, binds, connectionPool, ...details });
     }
     return new MismatchedForeignKey({
       message,
       binds,
+      connectionPool,
       queryParser: (parsedSql) => this.mismatchedForeignKeyDetails(message, parsedSql),
     });
   }
@@ -1482,7 +1483,8 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   protected _translateException(e: unknown, sql: string, binds: unknown[]): Error {
     if (e instanceof ActiveRecordError) return e;
     const build = (): Error => {
-      if (!(e instanceof Error)) return new StatementInvalid(String(e), { sql, binds });
+      if (!(e instanceof Error))
+        return new StatementInvalid(String(e), { sql, binds, connectionPool: this.pool });
       const errno = (e as { errno?: number }).errno;
       const msg = e.message;
       if (typeof errno !== "number") {
@@ -1496,44 +1498,44 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       }
       switch (errno) {
         case ER_DB_CREATE_EXISTS:
-          return new DatabaseAlreadyExists(msg, { sql, binds });
+          return new DatabaseAlreadyExists(msg, { sql, binds, connectionPool: this.pool });
         case ER_DUP_ENTRY:
-          return new RecordNotUnique(msg, { sql, binds });
+          return new RecordNotUnique(msg, { sql, binds, connectionPool: this.pool });
         case ER_NO_REFERENCED_ROW:
         case ER_ROW_IS_REFERENCED:
         case ER_ROW_IS_REFERENCED_2:
         case ER_NO_REFERENCED_ROW_2:
-          return new InvalidForeignKey(msg, { sql, binds });
+          return new InvalidForeignKey(msg, { sql, binds, connectionPool: this.pool });
         case ER_CANNOT_ADD_FOREIGN:
         case ER_FK_INCOMPATIBLE_COLUMNS:
-          return this.mismatchedForeignKey(msg, sql, binds);
+          return this.mismatchedForeignKey(msg, sql, binds, this.pool);
         case ER_CANNOT_CREATE_TABLE:
           if (msg.includes("errno: 150") || msg.includes("errno 150")) {
-            return this.mismatchedForeignKey(msg, sql, binds);
+            return this.mismatchedForeignKey(msg, sql, binds, this.pool);
           }
-          return new StatementInvalid(msg, { sql, binds });
+          return new StatementInvalid(msg, { sql, binds, connectionPool: this.pool });
         case ER_NOT_NULL_VIOLATION:
         case ER_DO_NOT_HAVE_DEFAULT:
-          return new NotNullViolation(msg, { sql, binds });
+          return new NotNullViolation(msg, { sql, binds, connectionPool: this.pool });
         case ER_DATA_TOO_LONG:
-          return new ValueTooLong(msg, { sql, binds });
+          return new ValueTooLong(msg, { sql, binds, connectionPool: this.pool });
         case ER_OUT_OF_RANGE:
-          return new ARRangeError(msg, { sql, binds });
+          return new ARRangeError(msg, { sql, binds, connectionPool: this.pool });
         case ER_LOCK_DEADLOCK:
-          return new Deadlocked(msg, { sql, binds });
+          return new Deadlocked(msg, { sql, binds, connectionPool: this.pool });
         case ER_LOCK_WAIT_TIMEOUT:
-          return new LockWaitTimeout(msg, { sql, binds });
+          return new LockWaitTimeout(msg, { sql, binds, connectionPool: this.pool });
         case ER_QUERY_TIMEOUT:
         case ER_FILSORT_ABORT:
-          return new StatementTimeout(msg, { sql, binds });
+          return new StatementTimeout(msg, { sql, binds, connectionPool: this.pool });
         case ER_QUERY_INTERRUPTED:
-          return new QueryCanceled(msg, { sql, binds });
+          return new QueryCanceled(msg, { sql, binds, connectionPool: this.pool });
         case ER_CONNECTION_KILLED:
         case ER_SERVER_SHUTDOWN:
         case CR_SERVER_GONE_ERROR:
         case CR_SERVER_LOST:
         case ER_CLIENT_INTERACTION_TIMEOUT:
-          return new ConnectionFailed(msg, { sql, binds });
+          return new ConnectionFailed(msg, { sql, binds, connectionPool: this.pool });
         default:
           // Driver errors expose a positive MySQL errno and usually a
           // sqlState. Node/system errors (ECONNREFUSED etc.) also carry
@@ -1541,7 +1543,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
           // errno to avoid re-tagging network failures as
           // StatementInvalid (which would attach misleading sql/binds).
           return typeof errno === "number" && errno > 0 && e instanceof StatementInvalid === false
-            ? new StatementInvalid(msg, { sql, binds })
+            ? new StatementInvalid(msg, { sql, binds, connectionPool: this.pool })
             : e;
       }
     };
@@ -1553,16 +1555,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     // as `translateExceptionClass` is for the public translator.
     if (translated !== e && (translated as { cause?: unknown }).cause === undefined) {
       (translated as { cause?: unknown }).cause = e;
-    }
-    // Mirrors Rails' AbstractMysqlAdapter#translate_exception, which builds
-    // every translated error with `connection_pool: @pool`
-    // (abstract_mysql_adapter.rb:815-856) — so the direct `_translateException`
-    // throw sites get a pool too, not just the public wrapper's callers. Both
-    // setters are guarded, so a pool passed at construction survives.
-    if (translated instanceof ConnectionNotEstablished) {
-      translated.setPool(this.pool);
-    } else if (translated instanceof AdapterError) {
-      translated.setConnectionPool(this.pool);
     }
     return translated;
   }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -41,7 +41,6 @@ import type { AdapterName } from "./abstract-adapter.js";
 import type { PostgreSQLAdapterOptions } from "./pool-config.js";
 import {
   ActiveRecordError,
-  AdapterError,
   ConnectionFailed,
   ConnectionNotEstablished,
   DatabaseAlreadyExists,
@@ -3807,30 +3806,31 @@ export class PostgreSQLAdapter
   private _translateException(e: unknown, sql: string, binds: unknown[]): Error {
     if (e instanceof ActiveRecordError) return e;
     const build = (): Error => {
-      if (!(e instanceof Error)) return new StatementInvalid(String(e), { sql, binds });
+      if (!(e instanceof Error))
+        return new StatementInvalid(String(e), { sql, binds, connectionPool: this.pool });
       const code = (e as { code?: string }).code;
       const msg = e.message;
       switch (code) {
         case "23505": // unique_violation
-          return new RecordNotUnique(msg, { sql, binds });
+          return new RecordNotUnique(msg, { sql, binds, connectionPool: this.pool });
         case "23503": // foreign_key_violation
-          return new InvalidForeignKey(msg, { sql, binds });
+          return new InvalidForeignKey(msg, { sql, binds, connectionPool: this.pool });
         case "23502": // not_null_violation
-          return new NotNullViolation(msg, { sql, binds });
+          return new NotNullViolation(msg, { sql, binds, connectionPool: this.pool });
         case "22001": // string_data_right_truncation
-          return new ValueTooLong(msg, { sql, binds });
+          return new ValueTooLong(msg, { sql, binds, connectionPool: this.pool });
         case "22003": // numeric_value_out_of_range
-          return new ActiveRecordRangeError(msg, { sql, binds });
+          return new ActiveRecordRangeError(msg, { sql, binds, connectionPool: this.pool });
         case "40001": // serialization_failure
-          return new SerializationFailure(msg, { sql, binds });
+          return new SerializationFailure(msg, { sql, binds, connectionPool: this.pool });
         case "40P01": // deadlock_detected
-          return new Deadlocked(msg, { sql, binds });
+          return new Deadlocked(msg, { sql, binds, connectionPool: this.pool });
         case "42P04": // duplicate_database
-          return new DatabaseAlreadyExists(msg, { sql, binds });
+          return new DatabaseAlreadyExists(msg, { sql, binds, connectionPool: this.pool });
         case "55P03": // lock_not_available
-          return new LockWaitTimeout(msg, { sql, binds });
+          return new LockWaitTimeout(msg, { sql, binds, connectionPool: this.pool });
         case "57014": // query_canceled
-          return new QueryCanceled(msg, { sql, binds });
+          return new QueryCanceled(msg, { sql, binds, connectionPool: this.pool });
         default:
           // A severed connection (08xxx, "Connection terminated", pg's
           // "Client has encountered a connection error", …) surfaces here as a
@@ -3873,7 +3873,7 @@ export class PostgreSQLAdapter
           // network failures as StatementInvalid with misleading
           // sql/binds attached.
           if (e instanceof pg.DatabaseError && e instanceof StatementInvalid === false) {
-            return new StatementInvalid(msg, { sql, binds });
+            return new StatementInvalid(msg, { sql, binds, connectionPool: this.pool });
           }
           return e;
       }
@@ -3887,15 +3887,6 @@ export class PostgreSQLAdapter
     // is for everything routed through the public translator.
     if (translated !== e && (translated as { cause?: unknown }).cause === undefined) {
       (translated as { cause?: unknown }).cause = e;
-    }
-    // Mirrors Rails' PostgreSQLAdapter#translate_exception, which builds every
-    // translated error with `connection_pool: @pool`. For a standalone adapter
-    // that pool is a NullPool. Use setPool/setConnectionPool (both guarded) so
-    // a pool attached at raise-time isn't overwritten.
-    if (translated instanceof ConnectionNotEstablished) {
-      translated.setPool(this.pool);
-    } else if (translated instanceof AdapterError) {
-      translated.setConnectionPool(this.pool);
     }
     return translated;
   }


### PR DESCRIPTION
## converge-collection-proxy-build-record

`CollectionProxy#_build` / `#_buildThrough` hand construction to the association holder's `buildRecord`, mirroring `Association#build_record` (`activerecord/lib/active_record/associations/association.rb:383-388`):

```ruby
def build_record(attributes)
  reflection.build_association(attributes) do |record|
    initialize_attributes(record, attributes)
    yield(record) if block_given?
  end
end
```

- Instantiation and STI resolution belong to `AssociationReflection#build_association` → `klass.new(attributes, &block)` (`reflection.rb:182`) and `Base.new`'s inheritance-column handling (`inheritance.rb` `new` / `subclass_from_attributes`) — the two hand-rolled `findStiClass` peeks are gone.
- The foreign key and polymorphic type come off `scope_for_create` inside `initialize_attributes` (`association.rb:224`) — the inline attribute hash is gone.
- `_scopeForCreateRaw` is deleted; it had no Rails counterpart and no other callers.
- The through half now lives entirely in `HasManyThroughAssociation#buildRecord` (`has_many_through_association.rb:89-107`): it forwards the captured through scope into `buildThroughInverseFor` (it previously built the join row with no scope at all), prefers the proxy's in-flight `_pendingThroughScope` where Rails reads the caller's `scoping` block, and carries the belongs_to source-inverse arm the proxy used to hold — flagged in place as through-scope debt, since Rails' `initialize_attributes` gets that FK from the through scope.

## translate-exception-branches-pass-connection-pool-inline

Every branch of PG's and abstract-mysql's `_translateException` now passes `connectionPool: this.pool` in its own options object, as Rails does (`postgresql_adapter.rb:801-844`, `abstract_mysql_adapter.rb:815-856`), and `mismatchedForeignKey` takes the pool like `mismatched_foreign_key(message, sql:, binds:, connection_pool:)` (`abstract_mysql_adapter.rb:1001`). The trailing `setPool` / `setConnectionPool` attachment blocks are deleted from both bodies. `AdapterError#setConnectionPool` stays — `mysql2-adapter.ts` still uses it, outside this story's scope.

## Verification

- `pnpm typecheck`, `pnpm lint` clean.
- `pnpm parity:api:calls` and `pnpm parity:api:calls:args` green, no new baseline rows.
- Green: has-many-associations, has-many-through-associations, has-one-through-associations, collection-proxy, association-relation, associations/callbacks, inverse-associations, habtm, build-record-block-ordering, nested-attributes, autosave-association, statement-invalid, errors.

Closes-story: converge-collection-proxy-build-record
Closes-story: translate-exception-branches-pass-connection-pool-inline