### PR TITLE
refactor(activerecord): converge the autosave has_one/belongs_to save bodies

### DIFF
--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -52,8 +52,20 @@ import { fixtures } from "./test-fixtures.js";
 import { assertNoQueries } from "./testing/query-assertions.js";
 import { resetI18n } from "./test-helpers/i18n.js";
 
+// Rails' assignment (`client.firm = apple`) routes through the association
+// WRITER, which for belongs_to is `replace` (belongs_to_association.rb:96) and
+// marks the association `updated?` — what the autosave FK propagation is gated
+// on (autosave_association.rb:560). `setTarget` is the LOADER path and leaves
+// `updated?` false, so a belongs_to assignment must not use it. The belongs_to
+// writer is synchronous, so it needs no await here.
+function setAssociationTarget(record: Base, name: string, value: unknown) {
+  const association = record.association(name) as any;
+  if (typeof association.isUpdated === "function") association.writer(value as any);
+  else association.setTarget(value as any);
+}
+
 function cacheAssoc(record: Base, name: string, value: unknown) {
-  record.association(name).setTarget(value as any);
+  setAssociationTarget(record, name, value);
 }
 
 fixtures([], { useTransactionalTests: false });
@@ -74,7 +86,7 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
   });
 
   function cacheAssoc(record: Base, name: string, value: unknown) {
-    record.association(name).setTarget(value as any);
+    setAssociationTarget(record, name, value);
   }
 
   function makePirateShip() {
@@ -497,7 +509,7 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
 
 describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
   function cacheAssoc(record: Base, name: string, value: unknown) {
-    record.association(name).setTarget(value as any);
+    setAssociationTarget(record, name, value);
   }
   const { companies, developers } = fixtures(["companies", "developers"]);
   beforeAll(() => {
@@ -988,7 +1000,7 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
 
 describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
   function cacheAssoc(record: Base, name: string, value: unknown) {
-    record.association(name).setTarget(value as any);
+    setAssociationTarget(record, name, value);
   }
   fixtures([]);
   beforeAll(() => {
@@ -1369,7 +1381,7 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
 describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
   fixtures([]);
   function cacheAssoc(record: Base, name: string, value: unknown) {
-    record.association(name).setTarget(value as any);
+    setAssociationTarget(record, name, value);
   }
 
   beforeAll(() => {
@@ -1713,7 +1725,7 @@ describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
 
 describe("TestDefaultAutosaveAssociationOnABelongsToAssociation", () => {
   function cacheAssoc(record: Base, name: string, value: unknown) {
-    record.association(name).setTarget(value as any);
+    setAssociationTarget(record, name, value);
   }
   fixtures([]);
 
@@ -2019,7 +2031,7 @@ describe("TestDefaultAutosaveAssociationOnABelongsToAssociation", () => {
 
 describe("TestAutosaveAssociationOnABelongsToAssociation", () => {
   function cacheAssoc(record: Base, name: string, value: unknown) {
-    record.association(name).setTarget(value as any);
+    setAssociationTarget(record, name, value);
   }
   fixtures([]);
 
@@ -2186,7 +2198,7 @@ describe("TestAutosaveAssociationOnABelongsToAssociation", () => {
 
 describe("TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAttributes", () => {
   function cacheAssoc(record: Base, name: string, value: unknown) {
-    record.association(name).setTarget(value as any);
+    setAssociationTarget(record, name, value);
   }
   fixtures([]);
 
@@ -2886,7 +2898,7 @@ describe("TestAutosaveAssociationsInGeneral", () => {
 
 describe("TestHasManyAutosaveAssociationWhichItselfHasAutosaveAssociations", () => {
   function cacheAssoc(record: Base, name: string, value: unknown) {
-    record.association(name).setTarget(value as any);
+    setAssociationTarget(record, name, value);
   }
   fixtures([]);
 
@@ -3229,7 +3241,7 @@ describe("TestAutosaveAssociationValidationMethodsGeneration", () => {
 
 describe("TestHasOneAutosaveAssociationWhichItselfHasAutosaveAssociations", () => {
   function cacheAssoc(record: Base, name: string, value: unknown) {
-    record.association(name).setTarget(value as any);
+    setAssociationTarget(record, name, value);
   }
   fixtures([]);
 

--- a/packages/activerecord/src/autosave-association.trails.test.ts
+++ b/packages/activerecord/src/autosave-association.trails.test.ts
@@ -16,8 +16,15 @@ import { Bird as CanonicalBird } from "./test-helpers/models/bird.js";
 import { Eye, Iris, IrisWithReadOnlyForeignKey } from "./test-helpers/models/eye.js";
 import { fixtures } from "./test-fixtures.js";
 
+// Rails' assignment (`client.firm = apple`) routes through the association
+// WRITER, which for belongs_to is `replace` (belongs_to_association.rb:96) and
+// marks the association `updated?` — what the autosave FK propagation is gated
+// on (autosave_association.rb:560). `setTarget` is the LOADER path and leaves
+// `updated?` false, so a belongs_to assignment must not use it.
 function cacheAssoc(record: Base, name: string, value: unknown) {
-  record.association(name).setTarget(value as any);
+  const association = record.association(name) as any;
+  if (typeof association.isUpdated === "function") association.writer(value as any);
+  else association.setTarget(value as any);
 }
 
 describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
@@ -187,8 +194,12 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     });
 
     const parent = new Parent({ name: "P" });
-    const child = new Child({ title: "c", group: "us-west" });
+    const child = new Child({ title: "c" });
     cacheAssoc(child, "parent", parent);
+    // Set the trailing FK column AFTER the assignment: Rails' `replace_keys`
+    // (belongs_to_association.rb:138-140) writes every array FK position from
+    // the target's PK values, so the assignment itself nulls "group".
+    child.group = "us-west";
     await child.save();
     expect(parent.isNewRecord()).toBe(false);
     expect(child.parent_id).toBe(parent.id);

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -6,8 +6,6 @@
  */
 import type { Base } from "./base.js";
 import { RecordInvalid } from "./validations.js";
-import { CompositePrimaryKeyMismatchError } from "./associations/errors.js";
-import { routeThroughCheckValidity } from "./associations/validate-through-reflection.js";
 import { NestedError as AssociationsNestedError } from "./associations/nested-error.js";
 import { associationInstanceGet, type AssociationDefinition } from "./associations.js";
 import { hasQueryConstraints, queryConstraintsList } from "./persistence.js";
@@ -287,13 +285,7 @@ export async function saveHasOneAssociation(
   reflection: any,
 ): Promise<boolean> {
   const owner = this as unknown as Base;
-  const assoc: AssociationDefinition = {
-    name: reflection.name,
-    type: "hasOne",
-    options: reflection.options ?? {},
-  } as AssociationDefinition;
   const association = associationInstanceGet.call(owner, reflection.name) as any;
-  const ctor = owner.constructor as typeof Base;
   // Rails `save_has_one_association` reads `reflection.through_reflection`
   // (autosave_association.rb:489).
   const isThrough = !!reflection?.throughReflection;
@@ -332,7 +324,11 @@ export async function saveHasOneAssociation(
     return true;
   }
 
-  const target = association?.target;
+  // Rails save_has_one_association:475 — `return unless association && association.loaded?`.
+  if (!association || !association.isLoaded()) return true;
+
+  // Rails save_has_one_association:477 — `record = association.load_target`.
+  const target = await association.loadTarget();
   if (!target || Array.isArray(target) || !(target instanceof Object)) return true;
   const record = target as Base;
 
@@ -351,7 +347,7 @@ export async function saveHasOneAssociation(
   // (autosave_association.rb:200) and `define_non_cyclic_method` guards
   // re-registration (:160 `return if method_defined?`), so a later
   // re-declaration is NOT picked up — Rails keeps the original reflection.
-  const autosave = assoc.options.autosave;
+  const autosave = reflection.options?.autosave;
 
   // NOTE: the join side of a has_one *through* was already persisted above by
   // `persistReplace` (which consumes the association's `_pendingReplace`),
@@ -387,16 +383,14 @@ export async function saveHasOneAssociation(
   // returned above), so a NEW child persists whether or not autosave is set.
   // Rails:485-486 — `primary_key = Array(compute_primary_key(reflection, self))`
   // then `primary_key_value = primary_key.map { _read_attribute(_1) }`.
-  const pkSpec = reflection ? computePrimaryKey(reflection, owner) : (ctor.primaryKey ?? "id");
-  const pkArr: string[] = Array.isArray(pkSpec) ? pkSpec : [pkSpec];
-  const pkForChangeCheck = pkArr.map((k) => owner._readAttribute(k));
+  const pkSpec = computePrimaryKey(reflection, owner);
+  const primaryKey: string[] = Array.isArray(pkSpec) ? pkSpec : [pkSpec];
+  const primaryKeyValue = primaryKey.map((key) => owner._readAttribute(key));
   const changedForSave =
     typeof (record as any).changedForAutosave === "function"
       ? (record as any).changedForAutosave()
       : !!(record as any).changed;
-  const recordChanged = reflection
-    ? is_recordChanged(reflection, record, pkForChangeCheck)
-    : record.isNewRecord();
+  const recordChanged = is_recordChanged(reflection, record, primaryKeyValue);
   if ((autosave && changedForSave) || recordChanged) {
     // Rails save_has_one_association:489 — `unless reflection.through_reflection`.
     // A has_one *through* never writes a foreign key onto the end record (its
@@ -406,74 +400,24 @@ export async function saveHasOneAssociation(
     // (gated by the same `(autosave && changed) || _record_changed?` condition),
     // so an `autosave: true` through re-saves a mutated end record.
     if (!reflection?.throughReflection) {
-      // reflection.foreignKey resolves queryConstraints-derived FK columns;
-      // fall back to the raw option or the default scalar FK.
-      const foreignKey: string | string[] =
-        (reflection && reflection.foreignKey != null ? reflection.foreignKey : null) ??
-        assoc.options.foreignKey ??
-        `${underscore(ctor.name)}_id`;
-      // Mirrors Rails compute_primary_key (autosave_association.rb:576-587).
-      // Use the reflection (when available) so the normalized queryConstraints option
-      // (array FKs are moved there by the reflection constructor) is visible to branch 2.
-      const explicitPk = assoc.options.primaryKey;
-      let primaryKey: string | string[];
-      if (explicitPk) {
-        primaryKey = explicitPk;
-      } else {
-        const candidatePk = computePrimaryKey(reflection ?? assoc, owner);
-        // computePrimaryKey may collapse a CPK to "id" when queryConstraintsList is null
-        // (our queryConstraintsList doesn't auto-return composite PK, unlike Rails).
-        // When that produces a scalar against a composite FK, fall back to ctor.primaryKey
-        // so CPK models with explicit composite FKs still pair correctly.
-        primaryKey =
-          !Array.isArray(candidatePk) && Array.isArray(foreignKey) ? ctor.primaryKey : candidatePk;
-      }
-      // Mirrors Rails composite_primary_key? collapse (autosave_association.rb:582-585):
-      // collapse only when the PK array IS the class composite primary key (not a QC-derived
-      // list). QC branch returns early before reaching composite_primary_key? in Rails,
-      // so we gate on Array.isArray(ctor.primaryKey) — QC models typically keep scalar PK.
-      if (
-        !explicitPk &&
-        Array.isArray(ctor.primaryKey) &&
-        Array.isArray(primaryKey) &&
-        !Array.isArray(foreignKey)
-      ) {
-        if (primaryKey.includes("id")) primaryKey = "id";
-      }
-      if (Array.isArray(primaryKey) && Array.isArray(foreignKey)) {
-        if (primaryKey.length !== foreignKey.length) {
-          // Route through the reflection's canonical checkValidityBang (Rails'
-          // single raise site) so the error carries the Rails-faithful message.
-          routeThroughCheckValidity(owner.constructor as typeof Base, assoc.name);
-          // No reflection resolvable — minimal trails-only fallback guard.
-          throw new CompositePrimaryKeyMismatchError({
-            activeRecord: (owner.constructor as typeof Base).name,
-            name: assoc.name,
-            primaryKey,
-            foreignKey,
-          });
+      // Rails save_has_one_association:490 — `foreign_key = Array(reflection.foreign_key)`.
+      const foreignKey: string[] = Array.isArray(reflection.foreignKey)
+        ? reflection.foreignKey
+        : [reflection.foreignKey];
+      // Rails save_has_one_association:491-495 — `primary_key.zip(foreign_key)`.
+      // Ruby's Array#zip pads with nil when the argument is shorter and drops
+      // the surplus when it is longer, so a shape mismatch writes fewer columns
+      // rather than raising.
+      for (let i = 0; i < primaryKey.length; i++) {
+        const fkCol = foreignKey[i];
+        if (fkCol == null) continue;
+        const associationId = owner._readAttribute(primaryKey[i]);
+        // Rails: `record[foreign_key] = association_id unless record[foreign_key] == association_id`.
+        if (record._readAttribute(fkCol) !== associationId) {
+          record._writeAttribute(fkCol, associationId);
         }
-        primaryKey.forEach((pk: string, i: number) => {
-          const pkValue = owner._readAttribute(pk);
-          if (pkValue != null) record._writeAttribute(foreignKey[i], pkValue);
-        });
-      } else if (!Array.isArray(primaryKey) && !Array.isArray(foreignKey)) {
-        const pkValue = owner._readAttribute(primaryKey);
-        if (pkValue != null) record._writeAttribute(foreignKey, pkValue);
-      } else {
-        // Route through the reflection's canonical checkValidityBang (Rails'
-        // single raise site) so the error carries the Rails-faithful message.
-        routeThroughCheckValidity(owner.constructor as typeof Base, assoc.name);
-        // No reflection resolvable — minimal trails-only fallback guard.
-        throw new CompositePrimaryKeyMismatchError({
-          activeRecord: (owner.constructor as typeof Base).name,
-          name: assoc.name,
-          primaryKey,
-          foreignKey,
-        });
       }
-      // Mirrors Rails save_has_one_association:496: set_inverse_instance fires
-      // after FK assignment, before save (autosave_association.rb:497).
+      // Rails save_has_one_association:496 — `association.set_inverse_instance(record)`.
       association?.setInverseInstance?.(record);
     }
 
@@ -519,10 +463,14 @@ export async function saveBelongsToAssociation(
     options: reflection.options ?? {},
   } as AssociationDefinition;
   const association = associationInstanceGet.call(owner, reflection.name) as any;
-  // Rails save_belongs_to_association:538 — skip when the loaded target is
-  // stale (FK changed since the target was cached).
-  if (association?.isStaleTarget?.()) return true;
-  const associated = association?.target;
+  // Rails save_belongs_to_association:533 — `return unless association &&
+  // association.loaded? && !association.stale_target?`: an unloaded association
+  // has nothing to save, and a loaded target is skipped once it is stale (the
+  // FK changed since the target was cached).
+  if (!association || !association.isLoaded() || association.isStaleTarget()) return true;
+
+  // Rails save_belongs_to_association:535 — `record = association.load_target`.
+  const associated = await association.loadTarget();
   if (!associated || Array.isArray(associated) || !(associated instanceof Object)) return true;
   const record = associated as Base;
   // Rails save_belongs_to_association:541 — `if record && !record.destroyed?`.
@@ -579,50 +527,22 @@ export async function saveBelongsToAssociation(
     }
   }
 
-  // Rails save_belongs_to_association:560 — the FK write is gated on
-  // `association.updated?`, independent of whether the target itself needed
-  // saving. This matters when two relations share one target (e.g. an order's
-  // billing and shipping pointing at the same customer): the second relation
-  // re-assigns an already-persisted, unchanged record, so the save above is
-  // skipped, but its FK must still be propagated. We keep `isNewOrChanged` in
-  // the guard so the `setTarget` test shortcut — which bypasses the writer and
-  // leaves `updated?` false — still propagates the FK as before.
-  if (isNewOrChanged || association?.isUpdated?.()) {
+  // Rails save_belongs_to_association:560 — `if association.updated?`. The FK
+  // write is gated on the association alone, independent of whether the target
+  // itself needed saving: when two relations share one target (an order's
+  // billing and shipping pointing at the same customer) the second re-assigns
+  // an already-persisted, unchanged record, so the save above is skipped but
+  // its FK must still be propagated.
+  if (association.isUpdated()) {
+    // Rails save_belongs_to_association:561 —
+    // `primary_key = Array(compute_primary_key(reflection, record)).map(&:to_s)`.
+    const pkSpec = computePrimaryKey(reflection, record);
+    const primaryKey: string[] = Array.isArray(pkSpec) ? pkSpec : [pkSpec];
     // Rails save_belongs_to_association:562 — `foreign_key = Array(reflection.foreign_key)`.
     const foreignKey: string[] = Array.isArray(reflection.foreignKey)
       ? reflection.foreignKey
       : [reflection.foreignKey];
-    // Pair against the target's PK columns in the same shape the writer
-    // (BelongsToAssociation#replaceKeys) used, so autosave FK
-    // propagation lands on the same columns the writer populated.
-    // Rails save_belongs_to_association:561 —
-    // `primary_key = Array(compute_primary_key(reflection, record)).map(&:to_s)`.
-    let primaryKey: string[] | null = null;
-    if (assoc.options.primaryKey == null) {
-      // Defer to computePrimaryKey when the target has *explicit* class-level
-      // query_constraints and Rails' compute_primary_key (steps 2/3 at
-      // autosave_association.rb:577-582) would pick that list.
-      const targetHasQc = hasQueryConstraints.call(record.constructor as any);
-      const targetQcWouldApply =
-        targetHasQc && (assoc.options.queryConstraints != null || assoc.options.foreignKey == null);
-      if (!targetQcWouldApply) {
-        // When the FK is explicitly composite, pair the full composite PK
-        // against the composite FK columns so the zip hits every column.
-        const explicitFk = assoc.options.foreignKey ?? assoc.options.queryConstraints;
-        const fkIsComposite = Array.isArray(explicitFk) && explicitFk.length > 1;
-        const reflFk = reflection?.foreignKey;
-        const reflFkIsComposite = Array.isArray(reflFk) && reflFk.length > 1;
-        if (fkIsComposite || reflFkIsComposite) {
-          const pk = (record.constructor as typeof Base).primaryKey;
-          if (Array.isArray(pk) && pk.length > 1) primaryKey = pk;
-        }
-      }
-    }
-    if (primaryKey === null) {
-      const rawPk = computePrimaryKey(reflection, record);
-      primaryKey = Array.isArray(rawPk) ? rawPk : [rawPk];
-    }
-    // Rails save_belongs_to_association:563: `primary_key.zip(foreign_key)`.
+    // Rails save_belongs_to_association:564: `primary_key.zip(foreign_key)`.
     // Ruby's Array#zip drops trailing args when the argument is longer than
     // the receiver, and pads with nil when the argument is shorter. Mirror
     // that here so shape mismatches don't raise — they just don't write FK
@@ -636,9 +556,8 @@ export async function saveBelongsToAssociation(
         owner._writeAttribute(fkCol, associationId);
       }
     }
-    // Rails save_belongs_to_association:568 — `association.loaded!` fires
-    // inside the `if association.updated?` branch after the FK write.
-    if (association?.isUpdated?.()) association.loadedBang?.();
+    // Rails save_belongs_to_association:568 — `association.loaded!`.
+    association.loadedBang?.();
   }
   return true;
 }

--- a/scripts/api-compare/call-args.test.ts
+++ b/scripts/api-compare/call-args.test.ts
@@ -136,6 +136,44 @@ describe("compareCallArgs colon-kept Symbol spelling", () => {
   });
 });
 
+describe("compareCallArgs to_s and reserved-word locals", () => {
+  // postgresql/schema_statements.rb:436-437 `clear_data_source_cache!(table_name.to_s)`.
+  it("reads a Ruby to_s argument as the TS toString call", () => {
+    expect(
+      compareCallArgs(
+        site("clear_data_source_cache!", ["call:to_s"]),
+        site("clearDataSourceCache", ["call:toString"]),
+      ).verdict,
+    ).toBe("match");
+  });
+
+  it("reads a Ruby to_s argument as a TS value already held as a string", () => {
+    expect(
+      compareCallArgs(site("remove_index", ["call:to_s"]), site("removeIndex", ["id:tableName"]))
+        .verdict,
+    ).toBe("match");
+  });
+
+  // abstract/schema_statements.rb#change_column_null(table_name, column_name, null, default).
+  it("reads a reserved Ruby name as the same name with a trailing underscore", () => {
+    expect(
+      compareCallArgs(
+        site("change_column_null", ["id:table_name", "id:null", "id:default"]),
+        site("changeColumnNull", ["id:tableName", "id:null_", "id:default_"]),
+      ).verdict,
+    ).toBe("match");
+  });
+
+  it("still reports a genuine rename of a non-reserved name", () => {
+    const result = compareCallArgs(
+      site("change_column_null", ["id:column_name"]),
+      site("changeColumnNull", ["id:columnName_"]),
+    );
+    expect(result.verdict).toBe("mismatch");
+    expect(result.class).toBe("naming");
+  });
+});
+
 describe("compareCallArgs built-in receiver as argument 1", () => {
   it("reads the TS first argument as the Ruby receiver for a core-ext", () => {
     // reflection.rb:454 `name.to_s.camelize` → `camelize(name)`.

--- a/scripts/api-compare/call-args.ts
+++ b/scripts/api-compare/call-args.ts
@@ -33,6 +33,51 @@ const IDENTIFIER_STRING = /^_?[a-z][A-Za-z0-9_]*$/;
  *  the whole site uncomparable. */
 const OPAQUE_DESCRIPTORS = new Set(["?", "array", "hash", "str-interp", "ternary"]);
 
+/** The words TS cannot spell as an identifier, so a port of a Ruby local or
+ *  parameter with one of these names has to add a trailing underscore
+ *  (`default` → `default_`, `null` → `null_`). Deliberately the reserved list
+ *  only: a `foo_` local is a rename and must keep reporting. */
+const JS_RESERVED_WORDS = new Set([
+  "await",
+  "break",
+  "case",
+  "catch",
+  "class",
+  "const",
+  "continue",
+  "debugger",
+  "default",
+  "delete",
+  "do",
+  "else",
+  "enum",
+  "export",
+  "extends",
+  "false",
+  "finally",
+  "for",
+  "function",
+  "if",
+  "import",
+  "in",
+  "instanceof",
+  "new",
+  "null",
+  "return",
+  "super",
+  "switch",
+  "this",
+  "throw",
+  "true",
+  "try",
+  "typeof",
+  "var",
+  "void",
+  "while",
+  "with",
+  "yield",
+]);
+
 /** Per-site flags that make the argument list's arity unknowable on that side. */
 const UNCOMPARABLE_FLAGS = new Set(["splat", "blockpass", "zsuper"]);
 
@@ -145,12 +190,30 @@ function normalizeRef(rawName: string): string {
  * both narrower and more accurate than folding the `is` prefix away on both
  * sides, which would read a plain `is_valid` local as `valid` and hide a
  * genuine rename to it.
+ *
+ * Two further families are TOOLING residue rather than port debt (RFC 0096):
+ *
+ * - `to_s`. The Ruby extractor describes `table_name.to_s`
+ *   (postgresql/schema_statements.rb:436-437, :439) as the CALL, dropping the
+ *   receiver, so the key is `ref:toS` and the receiver's name is not on the
+ *   Ruby side at all. The faithful port is either `toString()` or — because a
+ *   TS string is already a string — the bare local, and no rename is
+ *   detectable either way.
+ * - A Ruby name that is a JS reserved word. `default` and `null`
+ *   (postgresql/schema_statements.rb#extract_default_function,
+ *   abstract/schema_statements.rb#change_column_null) cannot be TS
+ *   identifiers, so the port spells them `default_` / `null_` and
+ *   {@link snakeToCamel} does not fold the trailing underscore back. Only the
+ *   reserved words qualify, so an unrelated `foo_` local still reports.
  */
 function refKeysEqual(rubyKey: string, tsKey: string): boolean {
   if (rubyKey === tsKey) return true;
   const rubyName = rubyKey.slice("ref:".length);
+  const tsName = tsKey.slice("ref:".length);
+  if (rubyName === "toS") return tsName === "toString" || IDENTIFIER_STRING.test(tsName);
+  if (JS_RESERVED_WORDS.has(rubyName) && tsName === `${rubyName}_`) return true;
   if (!/[?!=]$/.test(rubyName)) return false;
-  return (rubyMethodToTsIgnoringSkip(rubyName) ?? []).includes(tsKey.slice("ref:".length));
+  return (rubyMethodToTsIgnoringSkip(rubyName) ?? []).includes(tsName);
 }
 
 /**


### PR DESCRIPTION
Four bundled stories.

## `naming-comparator-to-s-and-reserved-word-residue`

`refKeysEqual` (scripts/api-compare/call-args.ts) now reads two tooling-shaped
families RFC 0096's `naming` class could only report:

- Ruby `to_s`. The Ruby extractor describes `table_name.to_s`
  (`postgresql/schema_statements.rb:436-437`, `:439`) as the CALL, dropping the
  receiver, so the key is `ref:toS` and the receiver's name is not on the Ruby
  side at all; the faithful port is `toString()` or the bare local, since a TS
  string is already a string.
- A Ruby name that is a JS reserved word — `default` / `null`
  (`postgresql/schema_statements.rb#extract_default_function`,
  `abstract/schema_statements.rb#change_column_null`) — spelled `default_` /
  `null_` in the port. Restricted to the reserved-word list, so an unrelated
  `foo_` local still reports (covered by a negative unit test).

Measured with `API_COMPARE_FORCE=1 pnpm parity:api --calls`:
`naming` 464 → 410 (−54), `shape` unchanged at 378.

## `converge-autosave-save-bodies-loaded-guard`

Both save bodies carry Rails' `association && association.loaded?` guard at
Rails' position (`autosave_association.rb:475`, `:533` conjoined with
`stale_target?`) and read the target through `loadTarget()` (`:477`, `:535`).

## `converge-autosave-belongs-to-updated-guard-and-pk-prepass`

The FK block is gated on `association.isUpdated()` alone (`:560`), and
`primaryKey` comes straight from `computePrimaryKey` (`:561`) — the ~20-line
composite-PK pre-pass is gone. The `isNewOrChanged` arm existed for the test-side
`setTarget` shortcut; the fix landed on the test side, where `cacheAssoc` now
routes a belongs_to through the association WRITER, as Rails' `client.firm =
apple` does (`belongs_to_association.rb:94-105`). `setTarget` is the loader path
and leaves `updated?` false.

One trails-only test (`belongs_to autosave with mismatched composite FK/PK uses
zip semantics`) now sets the trailing FK column after the assignment: Rails'
`replace_keys` (`belongs_to_association.rb:138-140`) writes every array FK
position from the target's PK values, so the assignment itself nulls it.

## `converge-autosave-has-one-fk-pairing`

`saveHasOneAssociation`'s FK write is `Array(reflection.foreignKey)` zipped
against the primary key already computed for the `_record_changed?` gate
(`:485`, `:490-495`). The three-way FK fallback chain, `explicitPk` case,
CPK collapse, and `CompositePrimaryKeyMismatchError` raise are gone — all
duplicates of `compute_primary_key` (`:576-587`). The synthetic `assoc` local
is gone; `reflection.options` is read directly, and the locals are Rails'
(`primaryKey`, `primaryKeyValue`, `foreignKey`, `associationId`).

## Verification

- `autosave-association.test.ts` (201) + `.trails.test.ts` (9): 210 passed.
- `packages/activerecord/src/associations`: 93 files, 2131 passed.
- `scripts/api-compare/call-args.test.ts`: 89 passed.
- `pnpm parity:api:calls` OK, `pnpm parity:api:calls:args` OK — no new baseline rows.

Closes-story: naming-comparator-to-s-and-reserved-word-residue
Closes-story: converge-autosave-belongs-to-updated-guard-and-pk-prepass
Closes-story: converge-autosave-has-one-fk-pairing
Closes-story: converge-autosave-save-bodies-loaded-guard