### PR TITLE
refactor(activerecord): converge autosave collection validate/save arms with Rails

### DIFF
--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -3477,7 +3477,7 @@ describe("TestDefaultAutosaveAssociationOnNewRecord", () => {
 });
 
 describe("TestAutosaveAssociationValidationsOnAHasManyAssociation", () => {
-  fixtures([]);
+  fixtures(["pirates", "ships"]);
   it("should automatically validate associations", async () => {
     class Item extends Base {
       declare name: string | null;
@@ -3492,17 +3492,16 @@ describe("TestAutosaveAssociationValidationsOnAHasManyAssociation", () => {
     expect(valid).toBe(false);
   });
   it("validations still fire on unchanged association with custom validation context", async () => {
-    class Post extends Base {
-      declare title: string | null;
+    const { FamousPirate } = await import("./test-helpers/models/pirate.js");
+    const { FamousShip } = await import("./test-helpers/models/ship.js");
+    registerModel("FamousPirate", FamousPirate as never);
+    registerModel("FamousShip", FamousShip as never);
 
-      static {
-        this.attribute("title", "string");
-        this.validates("title", { presence: true, on: "create" });
-      }
-    }
-    const p = new Post({});
-    expect(await p.isValid("create")).toBe(false);
-    expect(await p.isValid("update")).toBe(true);
+    const pirate = (await FamousPirate.createBang({ catchphrase: "Avast Ye!" })) as any;
+    await pirate.famousShips.createBang({});
+
+    expect(await pirate.isValid()).toBe(true);
+    expect(await pirate.isValid("conference")).toBe(false);
   });
 });
 

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -224,9 +224,9 @@ export async function flushPendingReplaces(record: Base): Promise<void> {
 export async function saveCollectionAssociation(
   this: AutosaveAssociationHost,
   reflection: any,
-): Promise<boolean> {
+): Promise<void> {
   const association = associationInstanceGet.call(this as unknown as Base, reflection.name) as any;
-  if (!association) return true;
+  if (!association) return;
   const autosave = reflection.options?.autosave;
 
   // By saving the instance variable in a local variable,
@@ -236,7 +236,8 @@ export async function saveCollectionAssociation(
   // reconstruct the scope now that we know the owner's id
   association.resetScope();
 
-  let records: Base[] | null = associatedRecordsToValidateOrSave(
+  let records: Base[] | null = associatedRecordsToValidateOrSave.call(
+    this,
     association,
     newRecordBeforeSave,
     autosave,
@@ -272,13 +273,9 @@ export async function saveCollectionAssociation(
         saved = !!(await record.save({ validate: false }));
       }
 
-      // Rails raises `RecordInvalid.new(association.owner)`; trails surfaces the
-      // failure by returning false, which makes the registered
-      // after_create/after_update callback raise it instead.
-      if (!saved) return false;
+      if (!saved) throw new RecordInvalid(association.owner);
     }
   }
-  return true;
 }
 
 /** @internal */
@@ -665,6 +662,7 @@ function initInternals(this: AutosaveAssociationHost): void {
 
 /** @internal */
 export function associatedRecordsToValidateOrSave(
+  this: AutosaveAssociationHost,
   association: any,
   newRecord: boolean,
   autosave: boolean,
@@ -672,7 +670,11 @@ export function associatedRecordsToValidateOrSave(
   const raw = association?.target;
   if (raw == null) return null;
   const target: any[] = Array.isArray(raw) ? raw : [raw];
-  if (newRecord) return target;
+  // Rails autosave_association.rb:299 — `if new_record || custom_validation_context?`.
+  const customValidationContext =
+    typeof (this as any)?.customValidationContext === "function" &&
+    (this as any).customValidationContext();
+  if (newRecord || customValidationContext) return target;
   if (autosave) return target.filter((r: any) => r.changedForAutosave?.() ?? false);
   return target.filter((r: any) => r.isNewRecord?.() ?? false);
 }
@@ -766,23 +768,12 @@ export async function validateCollectionAssociation(
   // Pass the real Association instance so downstream readers can reach
   // subclass methods (`isUpdated`, `setInverseInstance`, etc.) — Slot A.
   const association = associationInstanceGet.call(this as unknown as Base, reflection.name) as any;
-  // Mirrors Rails autosave_association.rb:298-305 — a custom validation context
-  // bypasses the changed/new filter so unchanged persisted children still run
-  // their context-specific validators (the `|| custom_validation_context?` arm).
-  const customCtx =
-    typeof (this as any).customValidationContext === "function" &&
-    (this as any).customValidationContext();
-  const records = customCtx
-    ? association?.target == null
-      ? null
-      : Array.isArray(association.target)
-        ? (association.target as any[])
-        : [association.target]
-    : associatedRecordsToValidateOrSave(
-        association,
-        typeof this.isNewRecord === "function" ? this.isNewRecord() : false,
-        !!reflection.options?.autosave,
-      );
+  const records = associatedRecordsToValidateOrSave.call(
+    this,
+    association,
+    typeof this.isNewRecord === "function" ? this.isNewRecord() : false,
+    !!reflection.options?.autosave,
+  );
   if (!records) return;
   for (const record of records) {
     await isAssociationValid.call(this, association, record);
@@ -1026,14 +1017,17 @@ export function addAutosaveAssociationCallbacks(model: any, reflection: any): vo
         (a: any) => a.name === collectionName,
       );
       if (assocDef?.options?.autosave === false) return;
-      if ((await record[saveMethod]()) === false) throw new RecordInvalid(record);
+      // Rails registers `save_collection_association` directly
+      // (autosave_association.rb:196-197); the RecordInvalid raise lives inside
+      // it, at `:460`, so there is nothing to translate here.
+      await record[saveMethod]();
     });
     afterUpdate(model, async (record: any) => {
       const assocDef = record.constructor._associations?.find(
         (a: any) => a.name === collectionName,
       );
       if (assocDef?.options?.autosave === false) return;
-      if ((await record[saveMethod]()) === false) throw new RecordInvalid(record);
+      await record[saveMethod]();
     });
   } else if (isHasOne) {
     defineNonCyclicMethod(model, saveMethod, async function (this: any) {

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -1017,9 +1017,6 @@ export function addAutosaveAssociationCallbacks(model: any, reflection: any): vo
         (a: any) => a.name === collectionName,
       );
       if (assocDef?.options?.autosave === false) return;
-      // Rails registers `save_collection_association` directly
-      // (autosave_association.rb:196-197); the RecordInvalid raise lives inside
-      // it, at `:460`, so there is nothing to translate here.
       await record[saveMethod]();
     });
     afterUpdate(model, async (record: any) => {


### PR DESCRIPTION
Two `0084-wide-call-set-burndown` convergences in `autosave-association.ts`.

**`custom_validation_context?` arm** — `associatedRecordsToValidateOrSave` now
implements all three Rails branches
(`activerecord/lib/active_record/autosave_association.rb:298-305`), including
`new_record || custom_validation_context?`. `validateCollectionAssociation`'s
compensating inline `Array.wrap`-shaped ternary is gone, so both it and
`saveCollectionAssociation` (`:437`) go through one implementation — the latter
previously diverged silently on the same input.

**`RecordInvalid` raise site** — `saveCollectionAssociation`'s per-record loop
raises `RecordInvalid(association.owner)` at `:460` instead of `return false`,
and the collection `afterCreate`/`afterUpdate` registrations no longer translate
a `false` return into a raise (Rails registers `save_collection_association`
directly, `:196-197`). The belongs_to arm is untouched: Rails wraps it as
`throw(:abort) if save_belongs_to_association(reflection) == false` (`:194`), so
its boolean return is load-bearing.

The `saveHasOneAssociation` audit called for in the second story is out of scope
here: Rails raises `ActiveRecord::Rollback` there (`:502`), not `RecordInvalid`,
so converging it needs Rollback semantics settled first. Filed as
`0084-wide-call-set-burndown/converge-autosave-has-one-rollback-raise`.

## Tests

`TestAutosaveAssociationValidationsOnAHasManyAssociation > validations still
fire on unchanged association with custom validation context` is converged from
a bespoke stand-in to the Rails body
(`autosave_association_test.rb:2238`, `FamousPirate` / `famous_ships`); it fails
on baseline with the new arm removed.

`autosave-association.test.ts` (201), `nested-attributes*` and
`src/associations/**` (2295) green. `pnpm parity:api:calls` and
`parity:api:calls:args` both OK, no new rows.

Closes-story: converge-associated-records-custom-validation-context
Closes-story: converge-autosave-collection-raise-record-invalid