### PR TITLE
refactor(activerecord): raise Rollback from saveHasOneAssociation's failed save

### DIFF
--- a/packages/activerecord/src/autosave-association.trails.test.ts
+++ b/packages/activerecord/src/autosave-association.trails.test.ts
@@ -7,6 +7,7 @@
  * behavior belongs to, so a reader knows where each test's subject lives.
  */
 import type { AssociationProxy } from "./associations/collection-proxy.js";
+import { throwAbort } from "@blazetrails/activesupport";
 import { describe, it, expect, beforeAll } from "vitest";
 import { Base, registerModel, assignNestedAttributes } from "./index.js";
 import { Associations } from "./associations.js";
@@ -44,6 +45,56 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
 
     expect(eye.association("iris").isLoaded()).toBe(true);
     expect(eye.afterSaveCallbacksStack).toEqual([false, false]);
+  });
+
+  it("an autosaved has_one whose save is cancelled rolls the owner back", async () => {
+    // Covers `save_has_one_association`'s
+    // `raise ActiveRecord::Rollback if !saved && autosave`
+    // (autosave_association.rb:502). With `autosave: true` the child is saved
+    // with `validate: false`, so only a non-validation failure — here a
+    // `before_save` that throws abort — reaches the raise. The Rollback is
+    // swallowed by the owner's transaction, which leaves `save` falsy with no
+    // row written. `save!` is itself wrapped in `with_transaction_returning_status`
+    // (transactions.rb:366), so the same Rollback leaves its status unset and it
+    // returns nil rather than raising RecordNotSaved.
+    class CancellingFace extends Base {
+      declare description: string | null;
+      declare human_id: number | null;
+
+      static {
+        this._tableName = "faces";
+        this.beforeSave(function () {
+          throwAbort();
+        });
+      }
+    }
+    registerModel("CancellingFace", CancellingFace);
+
+    class HumanWithCancellingFace extends Base {
+      declare name: string | null;
+      declare cancellingFace: InstanceType<typeof CancellingFace> | null;
+
+      static {
+        this._tableName = "humans";
+        this.hasOne("cancellingFace", {
+          className: "CancellingFace",
+          autosave: true,
+          foreignKey: "human_id",
+        });
+      }
+    }
+    registerModel("HumanWithCancellingFace", HumanWithCancellingFace);
+
+    const human = new HumanWithCancellingFace({ name: "Steve" });
+    cacheAssoc(human, "cancellingFace", new CancellingFace({ description: "wide eyed" }));
+
+    expect(await human.save()).toBeFalsy();
+    expect(await HumanWithCancellingFace.where({ name: "Steve" }).count()).toBe(0);
+
+    const human2 = new HumanWithCancellingFace({ name: "Steve" });
+    cacheAssoc(human2, "cancellingFace", new CancellingFace({ description: "wide eyed" }));
+    expect(await human2.saveBang()).toBeUndefined();
+    expect(await HumanWithCancellingFace.where({ name: "Steve" }).count()).toBe(0);
   });
 });
 

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -6,6 +6,7 @@
  */
 import type { Base } from "./base.js";
 import { RecordInvalid } from "./validations.js";
+import { Rollback } from "./errors.js";
 import { NestedError as AssociationsNestedError } from "./associations/nested-error.js";
 import { associationInstanceGet, type AssociationDefinition } from "./associations.js";
 import { hasQueryConstraints, queryConstraintsList } from "./persistence.js";
@@ -435,15 +436,11 @@ export async function saveHasOneAssociation(
     // child was already validated in the owner's validation phase, so
     // validate: false; with autosave nil it is validated here at save time.
     const saved = await record.save({ validate: !autosave });
-    if (!saved) {
-      // Rails: `raise ActiveRecord::Rollback if !saved && autosave` — a failed
-      // save only rolls the owner back when the autosave option is enabled (and
-      // adds no owner error; child validation errors were already imported
-      // during the validation phase). trails surfaces that rollback by returning
-      // false, which makes the after_create/after_update callback throw
-      // RecordInvalid. With autosave nil there is no rollback, so return true.
-      return !autosave;
-    }
+    // autosave_association.rb:502 — a failed save only rolls the owner back
+    // when the autosave option is enabled (and adds no owner error; child
+    // validation errors were already imported during the validation phase).
+    if (!saved && autosave) throw new Rollback();
+    return saved !== false && saved != null;
   }
   return true;
 }
@@ -957,11 +954,14 @@ export function addAutosaveAssociationCallbacks(model: any, reflection: any): vo
     // unconditionally keeps a nil/true-autosave NEW/changed child's persistence
     // in-save (via the `_record_changed?` → `new_record?` leg) rather than
     // deferring it to the post-commit `flushPendingReplaces` net.
+    // The failure path is `save_has_one_association`'s own
+    // `raise ActiveRecord::Rollback` (autosave_association.rb:502), not a
+    // translation of the return value here.
     afterCreate(model, async (record: any) => {
-      if ((await record[saveMethod]()) === false) throw new RecordInvalid(record);
+      await record[saveMethod]();
     });
     afterUpdate(model, async (record: any) => {
-      if ((await record[saveMethod]()) === false) throw new RecordInvalid(record);
+      await record[saveMethod]();
     });
   } else {
     // belongs_to

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -440,7 +440,7 @@ export async function saveHasOneAssociation(
     // when the autosave option is enabled (and adds no owner error; child
     // validation errors were already imported during the validation phase).
     if (!saved && autosave) throw new Rollback();
-    return saved !== false && saved != null;
+    return saved ?? false;
   }
   return true;
 }
@@ -891,7 +891,8 @@ export function defineNonCyclicMethod(klass: any, name: string, fn: (this: any) 
  *   `_newRecordBeforeSave` tracking, then `afterCreate` + `afterUpdate` to
  *   persist children. Raises `RecordInvalid` on failure so `save()` returns
  *   false and the enclosing DB transaction is rolled back.
- * - HasOne: same as collection minus the around_save.
+ * - HasOne: `afterCreate` + `afterUpdate` that call the save method, which
+ *   raises `Rollback` itself when an autosaved child fails to save.
  * - BelongsTo: `beforeSave` that halts the chain on failure.
  *
  * @internal
@@ -954,9 +955,6 @@ export function addAutosaveAssociationCallbacks(model: any, reflection: any): vo
     // unconditionally keeps a nil/true-autosave NEW/changed child's persistence
     // in-save (via the `_record_changed?` → `new_record?` leg) rather than
     // deferring it to the post-commit `flushPendingReplaces` net.
-    // The failure path is `save_has_one_association`'s own
-    // `raise ActiveRecord::Rollback` (autosave_association.rb:502), not a
-    // translation of the return value here.
     afterCreate(model, async (record: any) => {
       await record[saveMethod]();
     });


### PR DESCRIPTION
Converges the has_one autosave arm to `autosave_association.rb:500-503`:

```ruby
saved = record.save(validate: !autosave)
raise ActiveRecord::Rollback if !saved && autosave
saved
```

- `saveHasOneAssociation` now raises `Rollback` at that position instead of returning `!autosave`, and returns `saved`.
- The has_one `afterCreate`/`afterUpdate` registrations no longer translate a `false` return into a `RecordInvalid` raised at the callback site (`autosave_association.rb:199-200` registers the save method plainly).

The raise reaches `withTransactionReturningStatus`, whose `transaction()` swallows `Rollback` and leaves the status unset, so `owner.save()` stays falsy and the enclosing transaction rolls back — same shape as Rails.

Verification: `autosave-association.test.ts` + `src/associations/**` — 93 files, 2186 passed. `pnpm parity:api:calls` and `:args` both OK, no new rows.

Closes-story: converge-autosave-has-one-rollback-raise