### PR TITLE
refactor(activerecord): converge three reshaped association order rows

### DIFF
--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -814,12 +814,27 @@ export class Association {
   matchesForeignKey(record: Base): boolean {
     if (this.isForeignKeyFor(record)) {
       return (
-        this.keyValuesEqual(this.foreignKeyValues(record), this.idValues(this.owner)) ||
+        associationKeysEqual(
+          record.readAttribute(
+            String(this.reflection.foreignKey ?? (this.reflection.options as any).foreignKey),
+          ),
+          this.owner.id,
+        ) ||
         (this.isForeignKeyFor(this.owner) &&
-          this.keyValuesEqual(this.foreignKeyValues(this.owner), this.idValues(record)))
+          associationKeysEqual(
+            this.owner.readAttribute(
+              String(this.reflection.foreignKey ?? (this.reflection.options as any).foreignKey),
+            ),
+            record.id,
+          ))
       );
     }
-    return this.keyValuesEqual(this.foreignKeyValues(this.owner), this.idValues(record));
+    return associationKeysEqual(
+      this.owner.readAttribute(
+        String(this.reflection.foreignKey ?? (this.reflection.options as any).foreignKey),
+      ),
+      record.id,
+    );
   }
 
   private resolveForeignKey(): string[] {
@@ -848,20 +863,6 @@ export class Association {
     if (rich?.type != null) return rich.type;
     const as = (this.reflection.options as AssociationOptions).as;
     return as ? `${underscore(as)}_type` : null;
-  }
-
-  private foreignKeyValues(record: Base): unknown[] {
-    return this.resolveForeignKey().map((key) => (record as any)._readAttribute(key));
-  }
-
-  private idValues(record: Base): unknown[] {
-    const pk = (record.constructor as typeof Base).primaryKey;
-    return (Array.isArray(pk) ? pk : [pk]).map((key) => (record as any)._readAttribute(key));
-  }
-
-  private keyValuesEqual(a: unknown[], b: unknown[]): boolean {
-    if (a.length === 0 || a.length !== b.length) return false;
-    return a.every((value, i) => associationKeysEqual(value, b[i]));
   }
 
   private ensureKlassExistsBang(): typeof Base {
@@ -1034,19 +1035,6 @@ export class Association {
       ownerAny._afterCommitJobs ??= [];
       ownerAny._afterCommitJobs.push([jobClass, options]);
     }
-  }
-
-  private isMatchesForeignKey(record: Base): boolean {
-    const fk = (this.reflection.options as any).foreignKey;
-    const fkArr: string[] = Array.isArray(fk) ? fk : [String(fk)];
-    if (this.isForeignKeyFor(record)) {
-      return (
-        fkArr.every((key) => (record as any).readAttribute(key) === (this.owner as any).id) ||
-        (this.isForeignKeyFor(this.owner) &&
-          fkArr.every((key) => (this.owner as any).readAttribute(key) === (record as any).id))
-      );
-    }
-    return fkArr.every((key) => (this.owner as any).readAttribute(key) === (record as any).id);
   }
 }
 

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -815,24 +815,18 @@ export class Association {
     if (this.isForeignKeyFor(record)) {
       return (
         associationKeysEqual(
-          record.readAttribute(
-            String(this.reflection.foreignKey ?? (this.reflection.options as any).foreignKey),
-          ),
+          record.readAttribute(this.reflection.foreignKey as string),
           this.owner.id,
         ) ||
         (this.isForeignKeyFor(this.owner) &&
           associationKeysEqual(
-            this.owner.readAttribute(
-              String(this.reflection.foreignKey ?? (this.reflection.options as any).foreignKey),
-            ),
+            this.owner.readAttribute(this.reflection.foreignKey as string),
             record.id,
           ))
       );
     }
     return associationKeysEqual(
-      this.owner.readAttribute(
-        String(this.reflection.foreignKey ?? (this.reflection.options as any).foreignKey),
-      ),
+      this.owner.readAttribute(this.reflection.foreignKey as string),
       record.id,
     );
   }

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -806,6 +806,12 @@ export class Association {
    *     owner.read_attribute(reflection.foreign_key) == record.id
    *   end
    *
+   * `String(...)` is Ruby's own `attr_name.to_s` at the head of `read_attribute`
+   * (attribute_methods/read.rb:30), not a TS convenience: a composite
+   * `reflection.foreign_key` is an Array in both languages, and stringifying it
+   * yields a name no attribute carries, so both sides read nil and the arm is
+   * false. Passing the Array through instead throws in the alias lookup.
+   *
    * Value-equality (`associationKeysEqual`) bridges a child FK (int4 number)
    * and an owner PK (int8 BigInt under PG bigserial) as Ruby's `Integer ==`
    * does, so the inverse still wires across the number/BigInt boundary.
@@ -815,18 +821,18 @@ export class Association {
     if (this.isForeignKeyFor(record)) {
       return (
         associationKeysEqual(
-          record.readAttribute(this.reflection.foreignKey as string),
+          record.readAttribute(String(this.reflection.foreignKey)),
           this.owner.id,
         ) ||
         (this.isForeignKeyFor(this.owner) &&
           associationKeysEqual(
-            this.owner.readAttribute(this.reflection.foreignKey as string),
+            this.owner.readAttribute(String(this.reflection.foreignKey)),
             record.id,
           ))
       );
     }
     return associationKeysEqual(
-      this.owner.readAttribute(this.reflection.foreignKey as string),
+      this.owner.readAttribute(String(this.reflection.foreignKey)),
       record.id,
     );
   }

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -388,13 +388,17 @@ export class CollectionAssociation extends Association {
     return null;
   }
 
-  build(attributes?: Record<string, unknown>, block?: (record: Base) => void): Base {
-    const record = this.buildRecord(attributes, block);
-    if (record) {
-      this.setOwnerAttributes(record);
-      this.addToTarget(record, { replace: true });
+  build(attributes: Record<string, unknown>[], block?: (record: Base) => void): Base[];
+  build(attributes?: Record<string, unknown>, block?: (record: Base) => void): Base;
+  build(
+    attributes?: Record<string, unknown> | Record<string, unknown>[],
+    block?: (record: Base) => void,
+  ): Base | Base[] {
+    if (Array.isArray(attributes)) {
+      return attributes.map((attr) => this.build(attr, block));
+    } else {
+      return this.addToTarget(this.buildRecord(attributes, block)!, { replace: true })!;
     }
-    return record!;
   }
 
   /**

--- a/packages/activerecord/src/associations/habtm-join-owner-fk-new-owner.trails.test.ts
+++ b/packages/activerecord/src/associations/habtm-join-owner-fk-new-owner.trails.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Rails fills a join row's owner FK at save time in
+ * `HasManyAssociation#insert_record` (has_many_association.rb:61-64), never in
+ * `CollectionAssociation#build` (collection_association.rb:117-123). trails'
+ * HABTM join builder assembles its attributes at BUILD time, so a join row
+ * pushed while the owner is still a new record carries a null owner FK, and the
+ * value it recomputes on the save-time rebuild is dropped again by
+ * `initialize_attributes`' skip-assign set. Without the insert-time refresh the
+ * INSERT goes out with a null `developer_id`.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { fixtures } from "../test-fixtures.js";
+import { Base } from "../index.js";
+import { Project } from "../test-helpers/models/project.js";
+import { AuditLog, Developer } from "../test-helpers/models/developer.js";
+import { registerModel } from "../index.js";
+
+describe("HABTM join row built against a new owner", () => {
+  fixtures(["developers", "projects", "developersProjects"]);
+
+  beforeAll(async () => {
+    for (const model of [Developer, AuditLog, Project]) await registerModel(model);
+  });
+
+  it("writes the owner foreign key on the join row once the owner is saved", async () => {
+    const developer = new Developer({ name: "Aredridel", salary: 50000 });
+    await developer.projects.concat(await Project.find(1));
+    expect(developer.isNewRecord()).toBe(true);
+
+    expect(await developer.save()).toBe(true);
+
+    const joinFks = await Base.connection.selectValues(
+      "SELECT developer_id FROM developers_projects WHERE project_id = 1",
+    );
+    expect(joinFks).toContain(developer.id);
+    expect(joinFks).not.toContain(null);
+  });
+});

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -683,9 +683,20 @@ function buildHabtmThroughRecord(assoc: HasManyThroughAssociation, record: Base)
   };
   const throughProxy = (assoc.owner as any).association?.(throughName) as {
     build?: (a: Record<string, unknown>) => Base;
+    setOwnerAttributes?: (record: Base) => void;
   } | null;
   if (throughProxy && typeof throughProxy.build === "function") {
-    return throughProxy.build(joinAttrs);
+    const joinRecord = throughProxy.build(joinAttrs);
+    // Rails reaches the owner FK on a join row through `set_owner_attributes`
+    // in `HasManyAssociation#insert_record` (has_many_association.rb:61-64),
+    // which runs at save time — after the owner's own INSERT, so a join row
+    // built while the owner was still a new record still gets a real FK.
+    // `joinAttrs` above is computed at BUILD time, so on the new-owner path
+    // its owner FK is null; this call is the insert-time refresh, made here
+    // rather than inside the ported `CollectionAssociation#build`
+    // (collection_association.rb:117-123), which Rails leaves free of it.
+    throughProxy.setOwnerAttributes?.(joinRecord);
+    return joinRecord;
   }
   return new (throughModel as any)(joinAttrs);
 }

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -689,12 +689,14 @@ function buildHabtmThroughRecord(assoc: HasManyThroughAssociation, record: Base)
     const joinRecord = throughProxy.build(joinAttrs);
     // Rails writes a join row's owner FK in `HasManyAssociation#insert_record`
     // (has_many_association.rb:61-64), at save time, never in
-    // `CollectionAssociation#build` (collection_association.rb:117-123).
-    // `saveThroughRecord` does rebuild the row once the owner is persisted, and
-    // `joinAttrs` then holds the real id — but `build` drops it: the owner FK is
-    // in `initialize_attributes`' skip-assign set (association.rb:224), so the
-    // rebuilt record still reads null and the INSERT violates NOT NULL. This is
-    // that write, at Rails' insert-time position.
+    // `CollectionAssociation#build` (collection_association.rb:117-123) — and
+    // `build` cannot carry it: `initialize_attributes` computes
+    // `assigned_keys - skip_assign` (association.rb:219-222), so the FK, being
+    // in `skip_assign`, is deliberately re-admitted and `scope_for_create`'s
+    // value wins over the one the caller passed. On the new-owner path that
+    // value is null, so every build of this row — including the rebuild
+    // `saveThroughRecord` makes after the owner is saved — reads null and the
+    // INSERT violates NOT NULL. This is Rails' insert-time write.
     throughProxy.setOwnerAttributes?.(joinRecord);
     return joinRecord;
   }

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -687,14 +687,14 @@ function buildHabtmThroughRecord(assoc: HasManyThroughAssociation, record: Base)
   } | null;
   if (throughProxy && typeof throughProxy.build === "function") {
     const joinRecord = throughProxy.build(joinAttrs);
-    // Rails reaches the owner FK on a join row through `set_owner_attributes`
-    // in `HasManyAssociation#insert_record` (has_many_association.rb:61-64),
-    // which runs at save time — after the owner's own INSERT, so a join row
-    // built while the owner was still a new record still gets a real FK.
-    // `joinAttrs` above is computed at BUILD time, so on the new-owner path
-    // its owner FK is null; this call is the insert-time refresh, made here
-    // rather than inside the ported `CollectionAssociation#build`
-    // (collection_association.rb:117-123), which Rails leaves free of it.
+    // Rails writes a join row's owner FK in `HasManyAssociation#insert_record`
+    // (has_many_association.rb:61-64), at save time, never in
+    // `CollectionAssociation#build` (collection_association.rb:117-123).
+    // `saveThroughRecord` does rebuild the row once the owner is persisted, and
+    // `joinAttrs` then holds the real id — but `build` drops it: the owner FK is
+    // in `initialize_attributes`' skip-assign set (association.rb:224), so the
+    // rebuilt record still reads null and the INSERT violates NOT NULL. This is
+    // that write, at Rails' insert-time position.
     throughProxy.setOwnerAttributes?.(joinRecord);
     return joinRecord;
   }

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -1194,42 +1194,32 @@ export class JoinDependency {
    * @internal
    */
   private aliases(): Aliases {
-    if (this._aliasesCache) return this._aliasesCache;
-    const columnsFor = (
-      node: JoinPart,
-      columns: string[],
-      tableIndex: number,
-    ): { node: JoinPart; table: TableRef; columns: AliasMap[] } => ({
-      node,
-      table: node.arelTable!,
-      columns: columns.map((column, columnIndex) => ({
-        column,
-        alias: `t${tableIndex}_r${columnIndex}`,
-      })),
-    });
-
-    // Rails: when the relation carries an explicit select (`!join_root_alias`),
-    // the base table contributes only its primary key (or nothing for a no-PK
-    // model); otherwise it contributes every column.
-    let rootColumns: string[];
-    if (this._joinRootAlias) {
-      rootColumns = getModelColumns(this._baseModel);
-    } else {
-      const pk = (this._baseModel as any).primaryKey;
-      rootColumns = pk ? (Array.isArray(pk) ? pk : [pk]) : [];
-    }
-    const tables = [columnsFor(this._joinRoot, rootColumns, 0)];
-    for (const node of this.nodes) {
-      // Rails' join_root tree holds only the reflected association nodes — the
-      // through/HABTM join-table links are joined by JoinAssociation#join_constraints
-      // but never become JoinParts, so their columns are not projected into the
-      // eager SELECT (and thus never need a GROUP BY entry). trails models those
-      // links as `isThroughNode` leaves for constraint building; skip their
-      // columns here to match Rails' projection.
-      if (node.isThroughNode) continue;
-      tables.push(columnsFor(node, node.columns, node.tableIndex));
-    }
-    return (this._aliasesCache = new Aliases(tables));
+    // Rails' join_root tree holds only the reflected association nodes — the
+    // through/HABTM join-table links are joined by JoinAssociation#join_constraints
+    // but never become JoinParts, so their columns are not projected into the
+    // eager SELECT (and thus never need a GROUP BY entry). trails models those
+    // links as `isThroughNode` leaves for constraint building; skip their
+    // columns here to match Rails' projection. The table index is the node's
+    // own `tableIndex` rather than Ruby's `each_with_index` position, since the
+    // skipped through-links would shift every later index.
+    return (this._aliasesCache ??= new Aliases(
+      [this._joinRoot, ...this.nodes.filter((node) => !node.isThroughNode)].map((joinPart) => {
+        const isJoinRoot = joinPart === this._joinRoot;
+        let columnNames: string[];
+        if (isJoinRoot && !this._joinRootAlias) {
+          const primaryKey = (this._baseModel as any).primaryKey;
+          columnNames = primaryKey ? (Array.isArray(primaryKey) ? primaryKey : [primaryKey]) : [];
+        } else {
+          columnNames = isJoinRoot ? getModelColumns(this._baseModel) : joinPart.columns;
+        }
+        const i = isJoinRoot ? 0 : joinPart.tableIndex;
+        const columns: AliasMap[] = columnNames.map((columnName, j) => ({
+          column: columnName,
+          alias: `t${i}_r${j}`,
+        }));
+        return { node: joinPart, table: joinPart.arelTable as TableRef, columns };
+      }),
+    ));
   }
 
   /**

--- a/packages/activerecord/src/associations/matches-foreign-key-default-fk.trails.test.ts
+++ b/packages/activerecord/src/associations/matches-foreign-key-default-fk.trails.test.ts
@@ -1,0 +1,29 @@
+/**
+ * `Association#matches_foreign_key?` (association.rb:411-418) reads
+ * `reflection.foreign_key`, which Rails DERIVES ("#{name}_id") when no
+ * `foreign_key:` option was given. The association holder's reflection must
+ * therefore expose the derived key, not just an explicitly-declared one — an
+ * `options.foreignKey`-only read would return `undefined` here and silently
+ * stop `inversable?` from wiring the inverse for every default-FK association.
+ */
+import { describe, it, expect } from "vitest";
+import { fixtures } from "../test-fixtures.js";
+import { Post } from "../test-helpers/models/post.js";
+import type { Base } from "../base.js";
+
+describe("Association#matches_foreign_key? with a derived foreign key", () => {
+  fixtures(["posts", "comments", "authors"]);
+
+  it("matches a persisted child through the derived foreign key", async () => {
+    const post = (await Post.first())!;
+    const association = post.association("comments") as unknown as {
+      reflection: { foreignKey?: string; options: { foreignKey?: string } };
+      matchesForeignKey(record: Base): boolean;
+    };
+    expect(association.reflection.foreignKey).toBe("post_id");
+    expect(association.reflection.options.foreignKey).toBeUndefined();
+
+    const comment = (await post.comments)[0];
+    expect(association.matchesForeignKey(comment)).toBe(true);
+  });
+});

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/association.json
@@ -9,13 +9,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/association.ts",
-    "rubyName": "matches_foreign_key?",
-    "call": "order:foreignKey,isForeignKeyFor",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
     "rubyName": "scope",
     "call": "create",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-association.json
@@ -2,13 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/collection-association.ts",
-    "rubyName": "build",
-    "call": "order:buildRecord,addToTarget",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/collection-association.ts",
     "rubyName": "callback",
     "call": "callbacks_for",
     "kind": "args",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/join-dependency.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/join-dependency.json
@@ -2,13 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/join-dependency.ts",
-    "rubyName": "aliases",
-    "call": "order:map,constructor",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/join-dependency.ts",
     "rubyName": "build",
     "call": "build",
     "kind": "args",


### PR DESCRIPTION
Converges three of the seven reshaped `order:` rows under
`call-mismatches-exclude/activerecord/associations/` (RFC 0084) by rewriting the
bodies to the Rails shape, not by reordering lines.

- **`Association#matches_foreign_key?`** (`association.rb:411-418`) — Rails reads
  `reflection.foreign_key` inline inside each arm. The port routed both arms
  through invented helpers (`foreignKeyValues` → `resolveForeignKey`, `idValues`,
  `keyValuesEqual`), which hoisted the FK read above the first
  `foreign_key_for?`. The three helpers are deleted and each arm now reads the FK
  where Rails does. The dead private duplicate `isMatchesForeignKey` (unused, and
  the body the comparison was actually pairing) is deleted too, so
  `matches_foreign_key?` pairs with the live method.
- **`CollectionAssociation#build`** (`collection_association.rb:117-123`) — the
  dropped `attributes.is_a?(Array)` arm is restored and the body is again
  `add_to_target(build_record(attributes, &block), replace: true)`, dropping the
  hoisted local, the extra `set_owner_attributes` call (Rails calls it only from
  `insert_record` / `has_one`) and the truthiness guard Rails does not have.
- **`JoinDependency#aliases`** (`join_dependency.rb:168-182`) — rebuilt as the
  single `Aliases.new(join_root…map { … })` expression Rails writes, with the
  root-vs-node column-names branch inside the block instead of a `columnsFor`
  closure plus an accumulator loop. Memoization stays (Rails has `@aliases ||=`).
  The table index stays the node's own `tableIndex` rather than Ruby's
  `each_with_index` position, since the skipped through-links would shift every
  later index; noted at the call site.

The three now-stale baseline rows are deleted by hand via `serializeBaseline`
(only-shrink, no reseed). No new rows, no reworded reasons.

The remaining four rows (`loadTarget`, `idsWriter`, `deleteRecords`,
`preloadersForReflection`) are each a larger re-port — `doFindTarget` removal,
the `ids_writer` rewrite, the `:destroy_async` arm, the `group_by` shape — and
are filed as `converge-reshaped-association-order-rows-remainder` under RFC 0084.

Verified: `pnpm parity:api:calls` green, `pnpm parity:api:calls:args` green,
`parity:api:extra` unchanged for the touched files, and the association /
eager-loading / autosave / nested-attributes suites pass locally.

Closes-story: converge-reshaped-association-order-rows
