### PR TITLE
refactor(scripts): teach the call-arg comparator Ruby to_sym, including inside kwargs

### DIFF
--- a/scripts/api-compare/call-args.test.ts
+++ b/scripts/api-compare/call-args.test.ts
@@ -164,6 +164,34 @@ describe("compareCallArgs to_s and reserved-word locals", () => {
     ).toBe("match");
   });
 
+  // connection_handling.rb:254 `current_role == role.to_sym`.
+  it("reads a Ruby to_sym argument as a TS value already held as a string", () => {
+    expect(
+      compareCallArgs(
+        site("establish_connection", ["call:to_sym"]),
+        site("establishConnection", ["id:environment"]),
+      ).verdict,
+    ).toBe("match");
+  });
+
+  // connection_handling.rb:103 `establish_connection(db_config, …, shard: shard.to_sym)`.
+  it("reads a Ruby to_sym nested inside kwargs the same way", () => {
+    expect(
+      compareCallArgs(
+        site("connected_to", ["kwargs{shard=call:to_sym}"]),
+        site("connectedTo", ["kwargs{shard=id:shardKey}"]),
+      ).verdict,
+    ).toBe("match");
+  });
+
+  it("still reports a genuine rename of a kwargs value", () => {
+    const result = compareCallArgs(
+      site("connected_to", ["kwargs{shard=id:shard}"]),
+      site("connectedTo", ["kwargs{shard=id:shardKey}"]),
+    );
+    expect(result.verdict).toBe("mismatch");
+  });
+
   it("still reports a genuine rename of a non-reserved name", () => {
     const result = compareCallArgs(
       site("change_column_null", ["id:column_name"]),

--- a/scripts/api-compare/call-args.test.ts
+++ b/scripts/api-compare/call-args.test.ts
@@ -164,7 +164,7 @@ describe("compareCallArgs to_s and reserved-word locals", () => {
     ).toBe("match");
   });
 
-  // connection_handling.rb:254 `current_role == role.to_sym`.
+  // connection_handling.rb:51 `config_or_env ||= DEFAULT_ENV.call.to_sym`.
   it("reads a Ruby to_sym argument as a TS value already held as a string", () => {
     expect(
       compareCallArgs(

--- a/scripts/api-compare/call-args.ts
+++ b/scripts/api-compare/call-args.ts
@@ -28,6 +28,11 @@ import { RECEIVER_AS_FIRST_ARG } from "./receiver-as-first-arg.js";
 // convention exactly as any other identifier-shaped value is.
 const IDENTIFIER_STRING = /^_?[a-z][A-Za-z0-9_]*$/;
 
+/** Ruby conversions the extractor records as the CALL with the receiver
+ *  dropped, leaving no rename signal on the Ruby side at all — see
+ *  {@link refKeysEqual}. */
+const RECEIVER_DROPPING_CONVERSIONS = new Set(["toS", "toSym"]);
+
 /** Descriptors that carry no comparable value (RFC 0095 §1). Their presence
  *  anywhere in an argument list — INCLUDING nested inside a `kwargs{}` — makes
  *  the whole site uncomparable. */
@@ -193,12 +198,17 @@ function normalizeRef(rawName: string): string {
  *
  * Two further families are TOOLING residue rather than port debt (RFC 0096):
  *
- * - `to_s`. The Ruby extractor describes `table_name.to_s`
+ * - `to_s` and `to_sym`. The Ruby extractor describes `table_name.to_s`
  *   (postgresql/schema_statements.rb:436-437, :439) as the CALL, dropping the
  *   receiver, so the key is `ref:toS` and the receiver's name is not on the
  *   Ruby side at all. The faithful port is either `toString()` or — because a
  *   TS string is already a string — the bare local, and no rename is
- *   detectable either way.
+ *   detectable either way. `shard.to_sym`
+ *   (connection_handling.rb:103, :254) records the same way as `ref:toSym`,
+ *   and a Ruby Symbol IS a JS string (CLAUDE.md, "Symbols vs strings"), so the
+ *   port is the bare local and the receiver is again unrecoverable. The list is
+ *   named rather than "any `ref:` matches any `ref:`": a genuine rename between
+ *   two ordinary identifiers still reports.
  * - A Ruby name that is a JS reserved word. `default` and `null`
  *   (postgresql/schema_statements.rb#extract_default_function,
  *   abstract/schema_statements.rb#change_column_null) cannot be TS
@@ -210,7 +220,9 @@ function refKeysEqual(rubyKey: string, tsKey: string): boolean {
   if (rubyKey === tsKey) return true;
   const rubyName = rubyKey.slice("ref:".length);
   const tsName = tsKey.slice("ref:".length);
-  if (rubyName === "toS") return tsName === "toString" || IDENTIFIER_STRING.test(tsName);
+  if (RECEIVER_DROPPING_CONVERSIONS.has(rubyName)) {
+    return tsName === "toString" || IDENTIFIER_STRING.test(tsName);
+  }
   if (JS_RESERVED_WORDS.has(rubyName) && tsName === `${rubyName}_`) return true;
   if (!/[?!=]$/.test(rubyName)) return false;
   return (rubyMethodToTsIgnoringSkip(rubyName) ?? []).includes(tsName);
@@ -579,7 +591,43 @@ function argKeysEqual(rubyKey: string, tsKey: string): boolean {
     return calleeKeys(rubyKey.slice(CALLEE_PREFIX.length)).includes(tsKey);
   }
   if (rubyKey.startsWith("ref:") && tsKey.startsWith("ref:")) return refKeysEqual(rubyKey, tsKey);
+  if (rubyKey.startsWith("kwargs{") && tsKey.startsWith("kwargs{")) {
+    return kwargsKeysEqual(rubyKey, tsKey);
+  }
   return rubyKey === tsKey || keptSymbolColon(rubyKey, tsKey);
+}
+
+/**
+ * Two `kwargs{…}` descriptors carrying the same keys with equal values.
+ *
+ * A kwargs value is an argument key like any other — `shard: shard.to_sym`
+ * (connection_handling.rb:103) is the same `ref:toSym` residue whether it sits
+ * at a positional slot or inside the hash — so the values compare through
+ * {@link argKeysEqual} rather than by the raw string equality that would class
+ * a nested-only difference as a `shape` row.
+ */
+function kwargsKeysEqual(rubyKey: string, tsKey: string): boolean {
+  const ruby = kwargPairs(rubyKey);
+  const ts = kwargPairs(tsKey);
+  if (ruby.size !== ts.size) return false;
+  for (const [key, rubyValue] of ruby) {
+    const tsValue = ts.get(key);
+    if (tsValue === undefined || !argKeysEqual(rubyValue, tsValue)) return false;
+  }
+  return true;
+}
+
+/** The key→value pairs of an already-normalized `kwargs{…}` descriptor. A
+ *  fragment with no `=` is a double-splat or a shorthand the normalizer left
+ *  whole; it keys itself so two of them still have to match. */
+function kwargPairs(descriptor: string): Map<string, string> {
+  const pairs = new Map<string, string>();
+  for (const pair of splitPairs(descriptor.slice("kwargs{".length, -1))) {
+    const eq = pair.indexOf("=");
+    if (eq === -1) pairs.set(pair, pair);
+    else pairs.set(pair.slice(0, eq), pair.slice(eq + 1));
+  }
+  return pairs;
 }
 
 /**

--- a/scripts/api-compare/call-args.ts
+++ b/scripts/api-compare/call-args.ts
@@ -203,7 +203,8 @@ function normalizeRef(rawName: string): string {
  *   receiver, so the key is `ref:toS` and the receiver's name is not on the
  *   Ruby side at all. The faithful port is either `toString()` or — because a
  *   TS string is already a string — the bare local, and no rename is
- *   detectable either way. `shard.to_sym`
+ *   detectable either way — and `toString` is itself identifier-shaped, so the
+ *   one test covers both spellings. `shard.to_sym`
  *   (connection_handling.rb:103, :254) records the same way as `ref:toSym`,
  *   and a Ruby Symbol IS a JS string (CLAUDE.md, "Symbols vs strings"), so the
  *   port is the bare local and the receiver is again unrecoverable. The list is
@@ -220,9 +221,7 @@ function refKeysEqual(rubyKey: string, tsKey: string): boolean {
   if (rubyKey === tsKey) return true;
   const rubyName = rubyKey.slice("ref:".length);
   const tsName = tsKey.slice("ref:".length);
-  if (RECEIVER_DROPPING_CONVERSIONS.has(rubyName)) {
-    return tsName === "toString" || IDENTIFIER_STRING.test(tsName);
-  }
+  if (RECEIVER_DROPPING_CONVERSIONS.has(rubyName)) return IDENTIFIER_STRING.test(tsName);
   if (JS_RESERVED_WORDS.has(rubyName) && tsName === `${rubyName}_`) return true;
   if (!/[?!=]$/.test(rubyName)) return false;
   return (rubyMethodToTsIgnoringSkip(rubyName) ?? []).includes(tsName);
@@ -618,8 +617,8 @@ function kwargsKeysEqual(rubyKey: string, tsKey: string): boolean {
 }
 
 /** The key→value pairs of an already-normalized `kwargs{…}` descriptor. A
- *  fragment with no `=` is a double-splat or a shorthand the normalizer left
- *  whole; it keys itself so two of them still have to match. */
+ *  fragment carrying no `=` keys itself, so it can only ever match the
+ *  identical fragment. */
 function kwargPairs(descriptor: string): Map<string, string> {
   const pairs = new Map<string, string>();
   for (const pair of splitPairs(descriptor.slice("kwargs{".length, -1))) {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
@@ -66,20 +66,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "change_column_null",
-    "call": "change_column",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:tableName",
-      "ref:columnName",
-      "nil",
-      "kwargs{null=ref:null}"
-    ],
-    "reason": "TS language shortcoming: `null` is a reserved word and cannot name a parameter, so Rails' `null` (abstract_mysql_adapter.rb:381-388) is spelled `null_`; the kwarg KEY still matches."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
-    "rubyName": "change_column_null",
     "call": "order:quoteColumnName,execute",
     "reason": "ORDER-only: Ruby evaluates the interpolated quote_table_name / *_for_alter arguments before `execute`; TS source order puts the `execute` call first, so the extractor's textual ordering can never match. Same body, same call set."
   },

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/middleware/shard-selector.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/middleware/shard-selector.json
@@ -19,17 +19,6 @@
     "package": "activerecord",
     "tsFile": "middleware/shard-selector.ts",
     "rubyName": "set_shard",
-    "call": "connected_to",
-    "kind": "args",
-    "rubyArgs": [
-      "kwargs{shard=ref:toSym}"
-    ],
-    "reason": "shard_selector.rb:56 passes `shard.to_sym`; trails models the Ruby Symbol as a JS `Symbol`, which CLAUDE.md forbids — converging the value means making `shard` a plain string, tracked by story `converge-shard-selector-symbol-to-string`."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "middleware/shard-selector.ts",
-    "rubyName": "set_shard",
     "call": "fetch",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }


### PR DESCRIPTION
## What

The call-arg comparator's `to_s` arm (PR #6391) extended to the sibling
built-in the residue measurement showed next: Ruby `to_sym`.

The Ruby extractor describes `shard.to_sym`
(`connection_handling.rb:103`, `:254`; `shard_selector.rb:56`) as the CALL and
drops the receiver, so the key is `ref:toSym` with the receiver's name absent
from the Ruby side entirely. A Ruby Symbol is a JS string (CLAUDE.md, "Symbols
vs strings"), so the faithful port is the bare local — no rename is detectable
either way. Kept as a named list (`to_s`, `to_sym`), not a blanket
"any `ref:` matches any `ref:`": a rename between two ordinary identifiers
still reports.

The `connected_to(shard: shard.to_sym)` instance sits INSIDE a `kwargs{}`
value, which previously compared by raw string equality and so classed as
`shape`. `argKeysEqual` now recurses into two `kwargs{…}` descriptors and
compares each value by the same rules as a positional argument.

## Measurement

`API_COMPARE_FORCE=1 pnpm parity:api --calls`, against the post-#6391 numbers:

| class | before | after |
| --- | --- | --- |
| naming | 410 | 406 |
| shape | 378 | 371 |

`shape` is non-increasing as required; the extra movement past the one
`connected_to` row is other nested-kwargs values that now get the reserved-word
and `?`/`!`/`=` rules they already got positionally.

Two baseline rows converged and were deleted by hand (no `--write`):
`middleware/shard-selector.json` `set_shard`/`connected_to` and
`abstract-mysql-adapter.json` `change_column_null`/`change_column` (the
`kwargs{null=ref:null}` reserved-word row, now handled nested).

Note the shard-selector row's reason also described a real port deviation —
`shard-selector.ts` models the Ruby Symbol as a JS `Symbol`. That deviation is
not visible at the argument-key level either way (`ref:toSym` vs `ref:shardKey`
is unfalsifiable), and it stays tracked by the existing
`converge-shard-selector-symbol-to-string` story.

## Gates

- `pnpm parity:api:calls` — OK
- `pnpm parity:api:calls:args` — OK (355 baselined shape rows)
- `pnpm vitest run scripts/api-compare/call-args.test.ts` — 92 passed

Closes-story: naming-comparator-to-sym-residue
