### PR TITLE
refactor(activerecord): drop extra arguments from 13 ported call sites

### DIFF
--- a/packages/activerecord/src/associations/belongs-to-association.ts
+++ b/packages/activerecord/src/associations/belongs-to-association.ts
@@ -165,8 +165,7 @@ export class BelongsToAssociation extends SingularAssociation {
     const scope = klass.where(conditions);
     if (typeof scope.updateCounters === "function") {
       const touch = (this.reflection.options as any).touch;
-      const opts = touch != null ? { touch } : undefined;
-      await scope.updateCounters({ [counterCol]: by }, opts);
+      await scope.updateCounters({ [counterCol]: by, touch });
     }
   }
 
@@ -446,11 +445,10 @@ export class BelongsToAssociation extends SingularAssociation {
     }
 
     const Klass = this.klass;
-    const opts = touch != null ? { touch } : undefined;
     if (Klass && typeof (Klass as any).where === "function") {
       const scope = (Klass as any).where(conditions);
       if (typeof scope.updateCounters === "function") {
-        await scope.updateCounters({ [counterCol]: by }, opts);
+        await scope.updateCounters({ [counterCol]: by, touch });
       }
     }
   }

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1387,14 +1387,14 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     connectionPool: AbstractAdapter["pool"],
   ): MismatchedForeignKey {
     if (sql) {
-      const details = this.mismatchedForeignKeyDetails(message, sql);
+      const details = this.mismatchedForeignKeyDetails({ message, sql });
       return new MismatchedForeignKey({ message, sql, binds, connectionPool, ...details });
     }
     return new MismatchedForeignKey({
       message,
       binds,
       connectionPool,
-      queryParser: (parsedSql) => this.mismatchedForeignKeyDetails(message, parsedSql),
+      queryParser: (sql) => this.mismatchedForeignKeyDetails({ message, sql }),
     });
   }
 
@@ -1405,10 +1405,13 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    *
    * Mirrors: AbstractMysqlAdapter#mismatched_foreign_key_details (abstract_mysql_adapter.rb:978)
    */
-  protected mismatchedForeignKeyDetails(
-    message: string,
-    sql: string,
-  ): Partial<MismatchedForeignKeyOptions> {
+  protected mismatchedForeignKeyDetails({
+    message,
+    sql,
+  }: {
+    message: string;
+    sql: string;
+  }): Partial<MismatchedForeignKeyOptions> {
     // Extract the referencing column name from MySQL's error message when
     // available (MySQL 8+ includes it: "Referencing column 'x' and referenced")
     const fkFromMsg = /Referencing column '(\w+)' and referenced/i.exec(message)?.[1];

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -346,8 +346,8 @@ export function toSqlAndBinds(
 export function cacheableQuery(
   this: DatabaseStatementsHost | void,
   klass: {
-    query?(sql: string, options?: { retryable?: boolean }): unknown;
-    partialQuery?(parts: unknown, options?: { retryable?: boolean }): unknown;
+    query?(sql: string): unknown;
+    partialQuery?(parts: unknown): unknown;
     partialQueryCollector?(): unknown;
   },
   arel: unknown,
@@ -363,21 +363,18 @@ export function cacheableQuery(
 
   // Prepared path: compile with bind extraction, return Query + raw binds
   if (host?.preparedStatements && klass.query && visitor && node instanceof Nodes.Node) {
-    const [sql, binds, retryable] = visitor.compileWithBinds(node);
-    return [klass.query(sql, { retryable }), binds];
+    const [sql, binds] = visitor.compileWithBinds(node);
+    return [klass.query(sql), binds];
   }
 
   // Unprepared path: compile through PartialQueryCollector to produce
   // parts with Substitute slots, matching Rails' cacheable_query when
   // prepared_statements is false.
   if (klass.partialQueryCollector && klass.partialQuery && visitor && node instanceof Nodes.Node) {
-    const collector = klass.partialQueryCollector() as {
-      value: [unknown[], unknown[]];
-      retryable?: boolean;
-    };
+    const collector = klass.partialQueryCollector() as { value: [unknown[], unknown[]] };
     visitor.compileWithCollector(node, collector);
     const [parts, collectedBinds] = collector.value;
-    return [klass.partialQuery(parts, { retryable: collector.retryable ?? false }), collectedBinds];
+    return [klass.partialQuery(parts), collectedBinds];
   }
 
   // Fallback: compile to SQL string

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -652,7 +652,7 @@ function cacheSql(
   const qc = this._queryCache;
   if (!qc) return block();
   const key = sqlCacheKey(sql, binds);
-  return qc.computeIfAbsent(key, block);
+  return qc.computeIfAbsent(key, () => block());
 }
 
 /**

--- a/packages/activerecord/src/counter-cache.ts
+++ b/packages/activerecord/src/counter-cache.ts
@@ -69,7 +69,9 @@ export async function updateCounters(
   options?: { touch?: CounterCacheTouchOption },
 ): Promise<number> {
   const relation = this.unscoped().where(buildPkPredicate(this, id));
-  return relation.updateCounters(counters, options);
+  // Rails threads `:touch` through the counters hash itself, which
+  // `Relation#update_counters` shifts back off (`relation.rb:927`).
+  return relation.updateCounters({ ...counters, touch: options?.touch });
 }
 
 /**

--- a/packages/activerecord/src/counter-cache.ts
+++ b/packages/activerecord/src/counter-cache.ts
@@ -69,8 +69,6 @@ export async function updateCounters(
   options?: { touch?: CounterCacheTouchOption },
 ): Promise<number> {
   const relation = this.unscoped().where(buildPkPredicate(this, id));
-  // Rails threads `:touch` through the counters hash itself, which
-  // `Relation#update_counters` shifts back off (`relation.rb:927`).
   return relation.updateCounters({ ...counters, touch: options?.touch });
 }
 

--- a/packages/activerecord/src/encryption/cipher.ts
+++ b/packages/activerecord/src/encryption/cipher.ts
@@ -14,7 +14,7 @@ import { Message } from "./message.js";
 
 export class Cipher {
   encrypt(clearText: string | Buffer, options: { key: string; deterministic?: boolean }): Message {
-    return this.cipherFor(options.key, options.deterministic ?? false).encrypt(clearText, options);
+    return this.cipherFor(options.key, options.deterministic ?? false).encrypt(clearText);
   }
 
   decrypt(

--- a/packages/activerecord/src/encryption/cipher/aes256-gcm.ts
+++ b/packages/activerecord/src/encryption/cipher/aes256-gcm.ts
@@ -64,11 +64,11 @@ export class Aes256Gcm {
     return { deterministic: this.deterministic };
   }
 
-  encrypt(clearText: string | Buffer, options?: { deterministic?: boolean }): Message {
+  encrypt(clearText: string | Buffer): Message {
     this._validateKeyLength(this.secret);
     const keyBuf = Buffer.from(this.secret, "base64").subarray(0, KEY_LENGTH);
     const inputBuf = Buffer.isBuffer(clearText) ? clearText : Buffer.from(clearText, "utf-8");
-    const iv = this.generateIv(inputBuf, options?.deterministic ?? this.deterministic);
+    const iv = this.generateIv(inputBuf, this.deterministic);
     const cipher = getCrypto().createCipheriv(Aes256Gcm.CIPHER_TYPE, keyBuf, iv, {
       authTagLength: AUTH_TAG_LENGTH,
     });
@@ -144,9 +144,8 @@ export class Aes256Gcm {
   /**
    * Rails' first parameter is the live `OpenSSL::Cipher` (only so the random
    * branch can call `cipher.random_iv`). WebCrypto has no such object before
-   * the IV exists, so the slot carries the deterministic flag instead — which
-   * Rails reads off `@deterministic`, and this port also lets `encrypt`
-   * override per call.
+   * the IV exists, so the slot carries the deterministic flag instead, which
+   * Rails reads off `@deterministic`.
    *
    * @internal
    */

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -5871,8 +5871,10 @@ export class Relation<T extends Base> {
    * wrapper keeps NULL counters from propagating through the arithmetic.
    */
   async updateCounters(
-    counters: Record<string, number | { time?: Temporal.Instant }>,
-    options?: { touch?: CounterCacheTouchOption },
+    counters: Record<
+      string,
+      number | { time?: Temporal.Instant } | CounterCacheTouchOption | undefined
+    >,
   ): Promise<number> {
     // No `none?` guard here: Rails' update_counters (relation.rb:926-944) ends
     // in `update_all updates` and inherits the `return 0 if @none` from there
@@ -5896,9 +5898,7 @@ export class Relation<T extends Base> {
       updates[attr.name] = this._incrementAttribute(attr, value);
     }
 
-    const touchOption = (touchFromCounters ?? options?.touch) as
-      | CounterCacheTouchOption
-      | undefined;
+    const touchOption = touchFromCounters as CounterCacheTouchOption | undefined;
     if (touchOption) {
       // Mirror Rails relation.rb: parse touch into names + time (`{ time: }`
       // hash form; `touch: []` → no names), then touch the update-timestamp

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -905,7 +905,7 @@ export async function findSome(rel: FinderRelation, ids: unknown[]): Promise<any
 
   if (records.length !== expectedSize) {
     // Rails find_some: raise_record_not_found_exception!(ids, result.size, expected_size)
-    (rel as any).raiseRecordNotFoundExceptionBang(ids, records.length, expectedSize, pk);
+    (rel as any).raiseRecordNotFoundExceptionBang(ids, records.length, expectedSize);
   }
   return records;
 }
@@ -930,7 +930,7 @@ export async function findSomeOrdered(rel: FinderRelation, ids: unknown[]): Prom
 
   if (records.length !== ids.length) {
     // Rails find_some_ordered: raise_record_not_found_exception!(ids, result.size, ids.size)
-    (rel as any).raiseRecordNotFoundExceptionBang(ids, records.length, ids.length, primaryKey);
+    (rel as any).raiseRecordNotFoundExceptionBang(ids, records.length, ids.length);
   }
   const idIndex = new Map(ids.map((id, i) => [castKey(id), i]));
   return records.sort((a: any, b: any) => {

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -916,8 +916,9 @@ export function buildWhereClause(
       const resolved = aliases[key] ?? key;
       normalized[resolved] = value;
     }
-    const block = (tableName: string) => lookupTableKlassFromJoinDependencies.call(this, tableName);
-    const parts = this.predicateBuilder.buildFromHash(normalized, block);
+    const parts = this.predicateBuilder.buildFromHash(normalized, (tableName: string) =>
+      lookupTableKlassFromJoinDependencies.call(this, tableName),
+    );
     return new WhereClause(parts);
   }
 
@@ -2141,10 +2142,10 @@ export function arelColumnWithTable(
     // Rails passes `lookup_table_klass_from_join_dependencies` as the block
     // (query_methods.rb:1982-1984), so a table name that only resolves through a
     // join dependency still finds its model — and its type caster.
-    const block = (name: string) => lookupTableKlassFromJoinDependencies.call(this, name);
     return (
-      builder?.resolveArelAttribute?.(tableName, colStr, block) ??
-      new ArelTable(tableName).get(colStr)
+      builder?.resolveArelAttribute?.(tableName, colStr, (name: string) =>
+        lookupTableKlassFromJoinDependencies.call(this, name),
+      ) ?? new ArelTable(tableName).get(colStr)
     );
   }
   const quotedTable = safeQuoteTableName(modelClass, tableName);

--- a/packages/activerecord/src/relation/update-all.trails.test.ts
+++ b/packages/activerecord/src/relation/update-all.trails.test.ts
@@ -159,7 +159,7 @@ describe("touch_all / update_counters with empty updates", () => {
     // `touch: []` is truthy in Ruby too, so Rails calls
     // touch_attributes_with_time with no names; on a model without
     // updated_at/updated_on that yields {} and update_all raises.
-    await expect(Post.all().updateCounters({}, { touch: [] })).rejects.toThrow(
+    await expect(Post.all().updateCounters({ touch: [] })).rejects.toThrow(
       new ArgumentError("Empty list of attributes to change"),
     );
   });
@@ -167,7 +167,7 @@ describe("touch_all / update_counters with empty updates", () => {
   it("update_counters still updates when only the touch option contributes columns", async () => {
     const first = topics("first");
     const before = await Topic.find(first.id);
-    const count = await Topic.where({ id: first.id }).updateCounters({}, { touch: true });
+    const count = await Topic.where({ id: first.id }).updateCounters({ touch: true });
 
     expect(count).toBe(1);
     const after = await Topic.find(first.id);

--- a/packages/activerecord/src/statement-cache.ts
+++ b/packages/activerecord/src/statement-cache.ts
@@ -26,12 +26,10 @@ export class Substitute {}
  * Mirrors: ActiveRecord::StatementCache::Query
  */
 export class Query {
-  readonly retryable: boolean;
   private _sql: string;
 
-  constructor(sql: string, options: { retryable?: boolean } = {}) {
+  constructor(sql: string) {
     this._sql = sql;
-    this.retryable = options.retryable ?? false;
   }
 
   sqlFor(_binds: unknown[], _connection: unknown): string {
@@ -47,8 +45,8 @@ export class PartialQuery extends Query {
   private _values: unknown[];
   private _indexes: number[];
 
-  constructor(values: unknown[], options: { retryable?: boolean } = {}) {
-    super("", options);
+  constructor(values: unknown[]) {
+    super("");
     this._values = values;
     this._indexes = [];
     for (let i = 0; i < values.length; i++) {
@@ -177,12 +175,12 @@ export class StatementCache {
     this._model = model;
   }
 
-  static query(sql: string, options: { retryable?: boolean } = {}): Query {
-    return new Query(sql, options);
+  static query(sql: string): Query {
+    return new Query(sql);
   }
 
-  static partialQuery(values: unknown[], options: { retryable?: boolean } = {}): PartialQuery {
-    return new PartialQuery(values, options);
+  static partialQuery(values: unknown[]): PartialQuery {
+    return new PartialQuery(values);
   }
 
   static partialQueryCollector(): PartialQueryCollector {
@@ -244,7 +242,7 @@ export class StatementCache {
     try {
       const bindValues = this._bindMap.bind(params);
       const sql = this._queryBuilder.sqlFor(bindValues, connection);
-      const allowRetry = opts.allowRetry ?? this._queryBuilder.retryable;
+      const allowRetry = opts.allowRetry ?? false;
       // PartialQuery inlines values into the SQL string — pass empty binds
       // to avoid findBySql trying to re-substitute them. This matches Rails:
       // PartialQuery#sql_for drains the bind_values array in place via

--- a/packages/activerecord/src/validations/uniqueness.ts
+++ b/packages/activerecord/src/validations/uniqueness.ts
@@ -167,7 +167,7 @@ export class UniquenessValidator extends EachValidator {
     if (value == null && o.allowNil === true) return;
     if (isBlank(value) && o.allowBlank === true) return;
 
-    const finderClass = findFinderClassFor(record, this._klass) ?? record.constructor;
+    const finderClass = this.findFinderClassFor(record) ?? record.constructor;
     if (!finderClass.where) return;
 
     const mapped = mapEnumAttribute(finderClass, attribute, value);
@@ -189,7 +189,7 @@ export class UniquenessValidator extends EachValidator {
     // that constructs the validator directly with a strict option.
     if (opts?.strict != null) errorOpts.strict = opts.strict;
 
-    let [relation] = await buildRelation(finderClass, attribute, mapped, this.options);
+    let [relation] = await this.buildRelation(finderClass, attribute, mapped);
 
     if (record.isPersisted?.()) {
       const pk = finderClass.primaryKey;
@@ -217,7 +217,7 @@ export class UniquenessValidator extends EachValidator {
       }
     }
 
-    relation = scopeRelation(record, relation, this.options);
+    relation = this.scopeRelation(record, relation);
 
     if (opts?.conditions && typeof opts.conditions === "function") {
       const conditioned =
@@ -232,37 +232,185 @@ export class UniquenessValidator extends EachValidator {
       record.errors.add(attribute, ":taken", errorOpts);
     }
   }
-}
 
-/**
- * Walks up the inheritance chain from `record.class` to the validator's
- * configured `:class` option, returning the first non-abstract class —
- * mirrors Rails' rule that the existence check must run from a concrete
- * (non-abstract) class.
- *
- * Mirrors: ActiveRecord::Validations::UniquenessValidator#find_finder_class_for
- *
- * @internal
- */
-function findFinderClassFor(record: any, klassOption: any): any {
-  // Rails walks from record.class up to @klass, tracking the most-recent
-  // non-abstract class; STI uses this so the existence query targets the
-  // class where the validation was declared (and its scope/table). When
-  // @klass is unset in Trails, bound the walk at the AR/AM boundary
-  // (parent class without `.where`) so we don't leak into ActiveModel.
-  let current = record.constructor;
-  let lastConcrete: any = null;
-  while (current) {
-    if (!current.abstractClass && typeof current.where === "function") {
-      lastConcrete = current;
+  /**
+   * Walks up the inheritance chain from `record.class` to the validator's
+   * configured `:class` option, returning the first non-abstract class —
+   * mirrors Rails' rule that the existence check must run from a concrete
+   * (non-abstract) class.
+   *
+   * Mirrors: ActiveRecord::Validations::UniquenessValidator#find_finder_class_for
+   *
+   * @internal
+   */
+  private findFinderClassFor(record: any): any {
+    // Rails walks from record.class up to @klass, tracking the most-recent
+    // non-abstract class; STI uses this so the existence query targets the
+    // class where the validation was declared (and its scope/table). When
+    // @klass is unset in Trails, bound the walk at the AR/AM boundary
+    // (parent class without `.where`) so we don't leak into ActiveModel.
+    let current = record.constructor;
+    let lastConcrete: any = null;
+    while (current) {
+      if (!current.abstractClass && typeof current.where === "function") {
+        lastConcrete = current;
+      }
+      if (current === this._klass) break;
+      const parent = Object.getPrototypeOf(current);
+      if (!parent || parent === Function.prototype || parent === Object) break;
+      if (typeof parent.where !== "function") break;
+      current = parent;
     }
-    if (current === klassOption) break;
-    const parent = Object.getPrototypeOf(current);
-    if (!parent || parent === Function.prototype || parent === Object) break;
-    if (typeof parent.where !== "function") break;
-    current = parent;
+    return lastConcrete ?? record.constructor;
   }
-  return lastConcrete ?? record.constructor;
+
+  /**
+   * Builds the base existence-check relation: `klass.unscoped.where(attr = value)`,
+   * with case-sensitivity honoring the `:case_sensitive` option (and the
+   * adapter's default collation when unspecified).
+   *
+   * Mirrors: ActiveRecord::Validations::UniquenessValidator#build_relation
+   *
+   * @internal
+   */
+  protected async buildRelation(klass: any, attribute: string, value: unknown): Promise<[any]> {
+    // Wrapped in a tuple because Relation is thenable — a bare `await` would
+    // execute the query and resolve to the row array.
+    const base = typeof klass.unscoped === "function" ? klass.unscoped() : klass.where({});
+
+    // Resolve an attribute alias (`alias_attribute :new_content, :content`) to its
+    // underlying column before building the comparison — Rails routes the bind
+    // through the predicate builder, which resolves aliases.
+    attribute = (klass._attributeAliases?.[attribute] as string) ?? attribute;
+
+    // Resolve an association attribute (`validates :event`) to its foreign-key
+    // column for the comparison. `value` already arrives as the FK scalar; if a
+    // record is passed (Rails routes the association object through), read its
+    // primary key. Mirrors build_relation's reflection branch.
+    const refl = klass._reflectOnAssociation?.(attribute);
+    if (refl) {
+      const fk = Array.isArray(refl.foreignKey) ? refl.foreignKey[0] : refl.foreignKey;
+      if (
+        value != null &&
+        typeof value === "object" &&
+        typeof (value as any).readAttribute === "function"
+      ) {
+        const pk = refl.klass?.primaryKey ?? "id";
+        value = (value as any).readAttribute(Array.isArray(pk) ? pk[0] : pk);
+      }
+      attribute = fk;
+    }
+
+    // A nil value must compare as `IS NULL`, not `= NULL` (which never matches).
+    // `where({ col: null })` emits the IS NULL form; Rails routes nil through the
+    // predicate builder for the same effect.
+    if (value == null) {
+      return [base.where({ [attribute]: null })];
+    }
+
+    const arel = klass.arelTable as { get?: (n: string) => any } | null;
+    const pb = (
+      base as { predicateBuilder?: { buildBindAttribute(c: string, v: unknown): unknown } }
+    ).predicateBuilder;
+    const adapter = klass.connection ?? null;
+    const hasCsKey = Object.prototype.hasOwnProperty.call(this.options, "caseSensitive");
+    const typeObj =
+      typeof klass.typeForAttribute === "function" ? klass.typeForAttribute(attribute) : null;
+
+    // Serialized columns (`serialize :content`) store the coder-dumped form, but
+    // the value is NOT serialized here: the bind path below runs it through the
+    // attribute's (decorated, coder-wrapping) type, which the arel table resolves
+    // via `typeForAttribute` — so `buildBindAttribute` / `where` already emit the
+    // coder-dumped form. Serializing here too would double-dump (`"x\n"` →
+    // `"x\n\n"`) and never match the stored row. Mirrors Rails' `build_relation`,
+    // which hands the raw value to `bind_attribute` and lets the type serialize.
+
+    // When the attribute supports unencrypted data alongside encrypted values, the
+    // patched Relation#where (ExtendedDeterministicQueries) must receive a hash-style
+    // arg so processArguments can expand the IN list to include the plain-text variant.
+    // The Arel node path below bypasses processArguments entirely and would miss rows
+    // stored without encryption.
+    if (typeObj?.supportUnencryptedData) {
+      return [base.where({ [attribute]: value })];
+    }
+
+    // Rails routes the comparison through the adapter (defaultUniquenessComparison
+    // / caseSensitiveComparison / caseInsensitiveComparison) so adapters with
+    // CI collations / native ILIKE / case-insensitive types can pick the right
+    // SQL form without wrapping the column in LOWER() and defeating indexes.
+    if (arel && typeof arel.get === "function" && pb?.buildBindAttribute) {
+      const attr = arel.get(attribute);
+      const bind = pb.buildBindAttribute(attribute, value);
+      let comparison: any = null;
+      if (!hasCsKey || value == null) {
+        comparison = adapter?.defaultUniquenessComparison?.(attr, bind) ?? null;
+      } else if (this.options.caseSensitive) {
+        comparison = (await adapter?.caseSensitiveComparison?.(attr, bind)) ?? null;
+      } else {
+        // UUID columns are already canonical lowercase — skip LOWER() to match Rails,
+        // which returns false from can_perform_case_insensitive_comparison_for? for uuid
+        // (PG has no lower(uuid) function). Use plain equality instead.
+        const colType =
+          typeObj == null
+            ? null
+            : typeof typeObj.type === "function"
+              ? typeObj.type()
+              : typeObj.type;
+        if (colType !== "uuid") {
+          comparison = (await adapter?.caseInsensitiveComparison?.(attr, bind)) ?? null;
+          if (comparison == null && typeof value === "string") {
+            // No native CI form — fall back to LOWER() with a lowercased bind.
+            // Keeps the bind parameterized so the prepared-statement cache
+            // stays effective.
+            const lowerBind = pb.buildBindAttribute(attribute, value.toLowerCase());
+            comparison = attr.lower().eq(lowerBind);
+          }
+        }
+      }
+      if (comparison != null && typeof base.where === "function") {
+        return [base.where(comparison)];
+      }
+    }
+    return [base.where({ [attribute]: value })];
+  }
+
+  /**
+   * Adds `WHERE scope = record.scope` clauses for each `:scope` option,
+   * resolving association-name scopes to their underlying FK value.
+   *
+   * Mirrors: ActiveRecord::Validations::UniquenessValidator#scope_relation
+   *
+   * @internal
+   */
+  private scopeRelation(record: any, relation: any): any {
+    const scope = this.options.scope;
+    if (scope == null) return relation;
+    const scopes = Array.isArray(scope) ? (scope as string[]) : [scope as string];
+    let r = relation;
+    for (const rawItem of scopes) {
+      const ctor = record.constructor;
+      // Resolve an alias scope (`scope: :new_parent_id`) to the real column.
+      const item = (ctor._attributeAliases?.[rawItem] as string) ?? rawItem;
+      const refl = ctor._reflectOnAssociation?.(item);
+      if (refl) {
+        // Read FK (and foreignType for polymorphic) directly off the record —
+        // do NOT load the association (Rails routes through the proxy reader,
+        // but in TS this can trigger lazy-load and strict-loading violations).
+        const isPoly =
+          typeof refl.isPolymorphic === "function" ? refl.isPolymorphic() : refl.polymorphic;
+        const fks = Array.isArray(refl.foreignKey) ? refl.foreignKey : [refl.foreignKey];
+        for (const fk of fks) {
+          r = r.where({ [fk]: record.readAttribute?.(fk) });
+        }
+        if (isPoly && refl.foreignType) {
+          r = r.where({ [refl.foreignType]: record.readAttribute?.(refl.foreignType) });
+        }
+      } else {
+        r = r.where({ [item]: record.readAttribute?.(item) });
+      }
+    }
+    return r;
+  }
 }
 
 /**
@@ -386,154 +534,6 @@ function resolveAttributes(record: any, attributes: string[]): string[] {
     if (isPoly && refl.foreignType) out.push(refl.foreignType);
   }
   return out.filter((x) => x != null);
-}
-
-/**
- * Builds the base existence-check relation: `klass.unscoped.where(attr = value)`,
- * with case-sensitivity honoring the `:case_sensitive` option (and the
- * adapter's default collation when unspecified).
- *
- * Mirrors: ActiveRecord::Validations::UniquenessValidator#build_relation
- *
- * @internal
- */
-async function buildRelation(
-  klass: any,
-  attribute: string,
-  value: unknown,
-  options: Record<string, unknown>,
-): Promise<[any]> {
-  // Wrapped in a tuple because Relation is thenable — a bare `await` would
-  // execute the query and resolve to the row array.
-  const base = typeof klass.unscoped === "function" ? klass.unscoped() : klass.where({});
-
-  // Resolve an attribute alias (`alias_attribute :new_content, :content`) to its
-  // underlying column before building the comparison — Rails routes the bind
-  // through the predicate builder, which resolves aliases.
-  attribute = (klass._attributeAliases?.[attribute] as string) ?? attribute;
-
-  // Resolve an association attribute (`validates :event`) to its foreign-key
-  // column for the comparison. `value` already arrives as the FK scalar; if a
-  // record is passed (Rails routes the association object through), read its
-  // primary key. Mirrors build_relation's reflection branch.
-  const refl = klass._reflectOnAssociation?.(attribute);
-  if (refl) {
-    const fk = Array.isArray(refl.foreignKey) ? refl.foreignKey[0] : refl.foreignKey;
-    if (
-      value != null &&
-      typeof value === "object" &&
-      typeof (value as any).readAttribute === "function"
-    ) {
-      const pk = refl.klass?.primaryKey ?? "id";
-      value = (value as any).readAttribute(Array.isArray(pk) ? pk[0] : pk);
-    }
-    attribute = fk;
-  }
-
-  // A nil value must compare as `IS NULL`, not `= NULL` (which never matches).
-  // `where({ col: null })` emits the IS NULL form; Rails routes nil through the
-  // predicate builder for the same effect.
-  if (value == null) {
-    return [base.where({ [attribute]: null })];
-  }
-
-  const arel = klass.arelTable as { get?: (n: string) => any } | null;
-  const pb = (base as { predicateBuilder?: { buildBindAttribute(c: string, v: unknown): unknown } })
-    .predicateBuilder;
-  const adapter = klass.connection ?? null;
-  const hasCsKey = Object.prototype.hasOwnProperty.call(options, "caseSensitive");
-  const typeObj =
-    typeof klass.typeForAttribute === "function" ? klass.typeForAttribute(attribute) : null;
-
-  // Serialized columns (`serialize :content`) store the coder-dumped form, but
-  // the value is NOT serialized here: the bind path below runs it through the
-  // attribute's (decorated, coder-wrapping) type, which the arel table resolves
-  // via `typeForAttribute` — so `buildBindAttribute` / `where` already emit the
-  // coder-dumped form. Serializing here too would double-dump (`"x\n"` →
-  // `"x\n\n"`) and never match the stored row. Mirrors Rails' `build_relation`,
-  // which hands the raw value to `bind_attribute` and lets the type serialize.
-
-  // When the attribute supports unencrypted data alongside encrypted values, the
-  // patched Relation#where (ExtendedDeterministicQueries) must receive a hash-style
-  // arg so processArguments can expand the IN list to include the plain-text variant.
-  // The Arel node path below bypasses processArguments entirely and would miss rows
-  // stored without encryption.
-  if (typeObj?.supportUnencryptedData) {
-    return [base.where({ [attribute]: value })];
-  }
-
-  // Rails routes the comparison through the adapter (defaultUniquenessComparison
-  // / caseSensitiveComparison / caseInsensitiveComparison) so adapters with
-  // CI collations / native ILIKE / case-insensitive types can pick the right
-  // SQL form without wrapping the column in LOWER() and defeating indexes.
-  if (arel && typeof arel.get === "function" && pb?.buildBindAttribute) {
-    const attr = arel.get(attribute);
-    const bind = pb.buildBindAttribute(attribute, value);
-    let comparison: any = null;
-    if (!hasCsKey || value == null) {
-      comparison = adapter?.defaultUniquenessComparison?.(attr, bind) ?? null;
-    } else if (options.caseSensitive) {
-      comparison = (await adapter?.caseSensitiveComparison?.(attr, bind)) ?? null;
-    } else {
-      // UUID columns are already canonical lowercase — skip LOWER() to match Rails,
-      // which returns false from can_perform_case_insensitive_comparison_for? for uuid
-      // (PG has no lower(uuid) function). Use plain equality instead.
-      const colType =
-        typeObj == null ? null : typeof typeObj.type === "function" ? typeObj.type() : typeObj.type;
-      if (colType !== "uuid") {
-        comparison = (await adapter?.caseInsensitiveComparison?.(attr, bind)) ?? null;
-        if (comparison == null && typeof value === "string") {
-          // No native CI form — fall back to LOWER() with a lowercased bind.
-          // Keeps the bind parameterized so the prepared-statement cache
-          // stays effective.
-          const lowerBind = pb.buildBindAttribute(attribute, value.toLowerCase());
-          comparison = attr.lower().eq(lowerBind);
-        }
-      }
-    }
-    if (comparison != null && typeof base.where === "function") {
-      return [base.where(comparison)];
-    }
-  }
-  return [base.where({ [attribute]: value })];
-}
-
-/**
- * Adds `WHERE scope = record.scope` clauses for each `:scope` option,
- * resolving association-name scopes to their underlying FK value.
- *
- * Mirrors: ActiveRecord::Validations::UniquenessValidator#scope_relation
- *
- * @internal
- */
-function scopeRelation(record: any, relation: any, options: Record<string, unknown>): any {
-  const scope = options.scope;
-  if (scope == null) return relation;
-  const scopes = Array.isArray(scope) ? (scope as string[]) : [scope as string];
-  let r = relation;
-  for (const rawItem of scopes) {
-    const ctor = record.constructor;
-    // Resolve an alias scope (`scope: :new_parent_id`) to the real column.
-    const item = (ctor._attributeAliases?.[rawItem] as string) ?? rawItem;
-    const refl = ctor._reflectOnAssociation?.(item);
-    if (refl) {
-      // Read FK (and foreignType for polymorphic) directly off the record —
-      // do NOT load the association (Rails routes through the proxy reader,
-      // but in TS this can trigger lazy-load and strict-loading violations).
-      const isPoly =
-        typeof refl.isPolymorphic === "function" ? refl.isPolymorphic() : refl.polymorphic;
-      const fks = Array.isArray(refl.foreignKey) ? refl.foreignKey : [refl.foreignKey];
-      for (const fk of fks) {
-        r = r.where({ [fk]: record.readAttribute?.(fk) });
-      }
-      if (isPoly && refl.foreignType) {
-        r = r.where({ [refl.foreignType]: record.readAttribute?.(refl.foreignType) });
-      }
-    } else {
-      r = r.where({ [item]: record.readAttribute?.(item) });
-    }
-  }
-  return r;
 }
 
 /**

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
@@ -170,17 +170,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
-    "rubyName": "mismatched_foreign_key",
-    "call": "mismatched_foreign_key_details",
-    "kind": "args",
-    "rubyArgs": [
-      "kwargs{message=ref:message,sql=ref:sql}"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "mismatched_foreign_key_details",
     "call": "column_for",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/counter-cache.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/counter-cache.json
@@ -49,17 +49,6 @@
     "package": "activerecord",
     "tsFile": "counter-cache.ts",
     "rubyName": "update_counters",
-    "call": "update_counters",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:counters"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "counter-cache.ts",
-    "rubyName": "update_counters",
     "call": "where!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/cipher.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/cipher.json
@@ -1,13 +1,1 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "encryption/cipher.ts",
-    "rubyName": "encrypt",
-    "call": "encrypt",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:cleanText"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  }
-]
+[]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/finder-methods.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/finder-methods.json
@@ -69,35 +69,9 @@
   {
     "package": "activerecord",
     "tsFile": "relation/finder-methods.ts",
-    "rubyName": "find_some",
-    "call": "raise_record_not_found_exception!",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:ids",
-      "ref:size",
-      "ref:expectedSize"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
     "rubyName": "find_some_ordered",
     "call": "except",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "find_some_ordered",
-    "call": "raise_record_not_found_exception!",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:ids",
-      "ref:size",
-      "ref:size"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/query-methods.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/query-methods.json
@@ -38,27 +38,8 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "arel_column_with_table",
-    "call": "order:lookupTableKlassFromJoinDependencies,resolveArelAttribute",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "arel_column_with_table",
     "call": "quote_table_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "arel_column_with_table",
-    "call": "resolve_arel_attribute",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:tableName",
-      "ref:columnName"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -203,17 +184,6 @@
       "ref:subquery"
     ],
     "reason": "RFC 0099 bucket (c) tooling noise, verified at relation/query_methods.rb:1608 `Arel::SelectManager.new(subquery).project(select_value).tap do |arel|`: the two bodies each construct more than one object (or the port raises a guard Rails does not), and the comparator pairs the `new` occurrences positionally, so this row compares two unrelated constructions rather than a matched call site."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "build_where_clause",
-    "call": "build_from_hash",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:opts"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/statement-cache.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/statement-cache.json
@@ -19,27 +19,5 @@
     "rubyName": "execute",
     "call": "wrap",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "statement-cache.ts",
-    "rubyName": "partial_query",
-    "call": "new",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:values"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "statement-cache.ts",
-    "rubyName": "query",
-    "call": "new",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:sql"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/validations/uniqueness.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/validations/uniqueness.json
@@ -10,32 +10,8 @@
     "package": "activerecord",
     "tsFile": "validations/uniqueness.ts",
     "rubyName": "validate_each",
-    "call": "build_relation",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:finderClass",
-      "ref:attribute",
-      "ref:value"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "validations/uniqueness.ts",
-    "rubyName": "validate_each",
     "call": "except",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "validations/uniqueness.ts",
-    "rubyName": "validate_each",
-    "call": "find_finder_class_for",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:record"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -50,18 +26,6 @@
     "rubyName": "validate_each",
     "call": "order:constructor,mapEnumAttribute",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "validations/uniqueness.ts",
-    "rubyName": "validate_each",
-    "call": "scope_relation",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:record",
-      "ref:relation"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",


### PR DESCRIPTION
Converges 13 of the 47 RFC 0099 bucket-(a) `kind: "args"` rows for
`activerecord` — call sites where the port passes MORE arguments than the Rails
body does — and deletes their (only-shrink) baseline rows by hand.

## What converged

| file | Rails call | was |
| --- | --- | --- |
| `statement-cache.ts` | `Query.new(sql)` / `PartialQuery.new(values)` (`statement_cache.rb:34,45`) | `(sql, { retryable })` / `(values, { retryable })` |
| `encryption/cipher.ts` | `cipher_for(...).encrypt(clean_text)` (`encryption/cipher.rb:15`) | `.encrypt(clearText, options)` |
| `relation/finder-methods.ts` ×2 | `raise_record_not_found_exception!(ids, size, expected_size)` (`relation/finder_methods.rb:398,409`) | trailing `pk` argument |
| `validations/uniqueness.ts` ×3 | `find_finder_class_for(record)`, `build_relation(klass, attribute, value)`, `scope_relation(record, relation)` (`validations/uniqueness.rb:59,110,214`) | free functions taking `@klass` / `options` as extra parameters |
| `connection-adapters/abstract-mysql-adapter.ts` ×2 | `mismatched_foreign_key_details(message:, sql:)` (`abstract_mysql_adapter.rb:978`) | positional `(message, sql)` |
| `connection-adapters/abstract/query-cache.ts` | `compute_if_absent(key) { … }` (`query_cache.rb:284`) | `(key, block)` |
| `relation/query-methods.ts` ×2 | `build_from_hash(opts) { … }`, `resolve_arel_attribute(table_name, column_name) { … }` (`query_methods.rb:1643,1982`) | `(…, block)` |
| `counter-cache.ts` | `update_counters(counters)` with `:touch` inside the hash (`counter_cache.rb:117`, `relation.rb:926-927`) | `(counters, options)` |

Notable details:

- **`retryable` was invented surface.** Rails' `StatementCache::Query` carries
  no such field; `allow_retry` is passed by the caller
  (`core.rb#find_by_statement_cache` → `execute(..., allow_retry: true)`,
  which trails already does). `cacheable_query` now mirrors
  `database_statements.rb:56-66` exactly.
- **Uniqueness helpers became private instance methods**, which is what Rails
  has — `this.options` / `this._klass` replace the threaded parameters.
- **Blocks are now passed inline.** Ruby drops a block from the argument list
  and flags the site instead, and so does the extractor for an inline
  arrow — so passing the callback inline is both the faithful shape and what
  clears the row.
- `Relation#updateCounters` lost its `options` parameter; `:touch` travels
  inside the counters hash exactly as in `relation.rb:927`. The class-level
  `Model.updateCounters(id, counters, { touch })` surface is unchanged.

## Scope

The other 34 rows each need a structural change (converting a whole file's
record-first free functions to `this`-typed methods, giving an error class the
Rails constructor, having `database_adapter_for` return a constructed task
object) that does not fit alongside this diff under the LOC ceiling. They are
filed as a follow-up story with the per-row breakdown and the convergence each
one needs, grouped by shape.

## Verification

- `pnpm parity:api:calls:args` — OK (345 baselined shape rows, down 12)
- `pnpm parity:api:calls` — OK (one stale ORDER row also retired)
- `pnpm typecheck`, `pnpm lint` — clean
- `pnpm vitest run` over counter-cache, statement-cache, cipher, aes256-gcm,
  uniqueness-validation (+trails), extended-deterministic-uniqueness-validator,
  finder-methods, query-methods/predicate-builder, query-cache,
  update-all.trails, connection-pool.trails, postgresql exec-query — all green

Closes-story: call-args-ar-extra-argument
