### PR TITLE
refactor(activerecord): converge preloader reflection-scope arity guard and lazy memo

### DIFF
--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -590,10 +590,7 @@ describe("PreloaderTest", () => {
     expect(loaded.length).toBe(Number(await Comment.where({ post_id: post.id }).count()));
   });
 
-  // TODO(preload-hmt-with-conditions-remaining-sti-gap): remove it.fails when
-  // that story fixes the gap. `store-full-sti-class-name` landed (#3874)
-  // without closing it.
-  it.fails("preload for hmt with conditions", async () => {
+  it("preload for hmt with conditions", async () => {
     const post = posts("welcome");
     await CategoryPost.create({
       category_id: (await Category.create({ name: "Normal" })).id,

--- a/packages/activerecord/src/associations/preloader/association.ts
+++ b/packages/activerecord/src/associations/preloader/association.ts
@@ -23,8 +23,7 @@ export class Association {
   readonly reflection: AssociationLikeReflection;
   /** @internal */
   protected preloadScope: any;
-  /** @internal */
-  protected reflectionScope: any;
+  private _reflectionScope: any;
   private _associate: boolean;
   private _model: typeof Base | null;
   private _run: boolean;
@@ -47,7 +46,7 @@ export class Association {
     this.owners = this._uniqueOwners(owners);
     this.reflection = reflection;
     this.preloadScope = preloadScope ?? null;
-    this.reflectionScope = reflectionScope ?? null;
+    this._reflectionScope = reflectionScope ?? null;
     this._associate = associateByDefault || preloadScope == null;
     this._model = owners.length > 0 ? (owners[0].constructor as typeof Base) : null;
     this._run = false;
@@ -203,8 +202,8 @@ export class Association {
 
   associateRecordsFromUnscoped(unscopedRecords: Base[] | undefined): void {
     if (!unscopedRecords || unscopedRecords.length === 0) return;
-    if (this.reflectionScope != null) return;
-    if (this.preloadScope != null) return;
+    if (!this.reflectionScope.isEmptyScope) return;
+    if (this.preloadScope && !this.preloadScope.isEmptyScope) return;
     if ((this.reflection as any).isCollection?.()) return;
 
     for (const record of unscopedRecords) {
@@ -347,6 +346,20 @@ export class Association {
     return this.model.typeForAttribute(key).type();
   }
 
+  /**
+   * Mirrors: ActiveRecord::Associations::Preloader::Association#reflection_scope
+   * (`preloader/association.rb:290-292`). Branch only passes a scope down for an
+   * instance-dependent reflection scope; every other reflection recomputes it
+   * lazily here, off the record.
+   * @internal
+   */
+  protected get reflectionScope(): any {
+    this._reflectionScope ??= (this.reflection as any)
+      .joinScopes((this.klass as any).arelTable, (this.klass as any).predicateBuilder, this.klass)
+      .reduce((acc: any, s: any) => acc.merge(s), (this.klass as any).unscoped());
+    return this._reflectionScope;
+  }
+
   private buildScope(): any {
     // Mirror Rails' build_scope `scope = klass.scope_for_association`. It bases
     // on the pristine relation (ignoring any enclosing current_scope) and
@@ -361,13 +374,8 @@ export class Association {
       });
     }
 
-    // Merge reflection scope: use the pre-computed scope from Branch if available,
-    // otherwise apply the raw scope function directly
-    if (this.reflectionScope != null) {
+    if (!this.reflectionScope.isEmptyScope) {
       scope = scope.merge(this.reflectionScope);
-    } else if (this.reflection.scope) {
-      const scopeResult = this.reflection.scope(scope);
-      if (scopeResult) scope = scopeResult;
     }
 
     if (this.preloadScope && !this.preloadScope.isEmptyScope) {

--- a/packages/activerecord/src/associations/preloader/branch.ts
+++ b/packages/activerecord/src/associations/preloader/branch.ts
@@ -187,7 +187,14 @@ export class Branch {
       const klass: typeof Base = (record as any).association(this.association!).klass;
 
       let reflectionScope: any = undefined;
-      if (reflection.scope) {
+      // Rails: `if reflection.scope && reflection.scope.arity != 0`
+      // (`preloader/branch.rb:95`). A trails scope lambda takes the relation as
+      // its first parameter where Ruby's takes none (`invokeScopeLambda`,
+      // `associations/association-scope.ts:20-49`), so Ruby's `arity != 0` is
+      // `length > 1` here. Only an instance-dependent scope is grouped per
+      // record; every other one is recomputed lazily by
+      // `Preloader::Association#reflectionScope`.
+      if (reflection.scope && reflection.scope.length > 1) {
         const scopes = (reflection as any).joinScopes(
           klass.arelTable,
           (klass as any).predicateBuilder,

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -247,7 +247,7 @@ export class ThroughAssociation extends Association {
     let sourceScope = null;
     const sourceIsNested = (sourceRefl as any).isThroughReflection?.() ?? false;
     const hasSourceType = !!(this.reflection as any).options?.sourceType;
-    if (!sourceIsNested && this.reflectionScope != null) {
+    if (!sourceIsNested && !this.reflectionScope.isEmptyScope) {
       sourceScope = this.reflectionScope._clone();
       if (!hasSourceType) {
         sourceScope._whereClause = new WhereClause([]);


### PR DESCRIPTION
Converges the two halves of Rails's preloader reflection-scope handling, which only work together.

- `Preloader::Branch#preloadersForReflection` restores the `arity != 0` half of the guard (`preloader/branch.rb:95`), so only an *instance-dependent* scope is grouped per record. Trails' scope lambda takes the relation as its first parameter where Ruby's takes none (`associations/association-scope.ts:20-49`), so Ruby `arity != 0` is `scope.length > 1`; the offset is cited at the call site.
- `Preloader::Association` grows Rails' lazy `reflectionScope` memo (`preloader/association.rb:290-292`) — `joinScopes(...).inject(klass.unscoped, &:merge!)` — so an arity-0 reflection scope still reaches the preload query.
- `buildScope` and `associateRecordsFromUnscoped` now key on `empty_scope?` as Rails does (`association.rb:220,301`), replacing the `!= null` checks and the raw-lambda fallback in `buildScope`.
- `ThroughAssociation#sourcePreloaders` follows the same predicate, keeping its behaviour unchanged now that `reflectionScope` is never null.

Side effect: `PreloaderTest > preload for hmt with conditions` was an `it.fails` (STI-through gap) and now passes — the `it.fails` and its TODO are removed.

No new `call-mismatches-exclude` rows (`parity:api:calls` and `parity:api:calls:args` both OK); no new extra surface.

Closes-story: converge-preloader-reflection-scope-arity-and-lazy-memo
Closes-story: preload-hmt-with-conditions-remaining-sti-gap