### PR TITLE
fix(api-compare): stop crediting a Ruby predicate with the plain call's TS position

### DIFF
--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-association.json
@@ -85,13 +85,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/collection-association.ts",
-    "rubyName": "load_target",
-    "call": "order:mergeTargetLists,findTarget",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/collection-association.ts",
     "rubyName": "remove_records",
     "call": "catch",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/autosave-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/autosave-association.json
@@ -42,13 +42,6 @@
   {
     "package": "activerecord",
     "tsFile": "autosave-association.ts",
-    "rubyName": "define_autosave_validation_callbacks",
-    "call": "order:validate,defineNonCyclicMethod",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "autosave-association.ts",
     "rubyName": "define_non_cyclic_method",
     "call": "define_method",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -1999,8 +1999,6 @@ describe("narrowPredicateCandidates", () => {
   });
 
   it("keeps the whole list rather than narrowing to nothing", () => {
-    // A predicate whose ONLY candidate is the plain call's must still be
-    // checkable — narrowing to [] would silence a genuinely dropped call.
     expect(narrowPredicateCandidates("save?", ["save"], ["save?", "save"], () => ["save"])).toEqual(
       ["save"],
     );
@@ -2075,11 +2073,6 @@ describe("reorderedCalls (RFC 0084 order-only call parity)", () => {
   });
 
   it("does not credit a predicate with the plain call's TS position", () => {
-    // CollectionAssociation#load_target (collection_association.rb:37-42) calls
-    // `find_target?`, `merge_target_lists`, then `find_target`; trails calls
-    // `findTargetNeeded`, `mergeTargetLists`, then `findTarget`. `find_target?`
-    // maps to ["isFindTarget", "findTarget"], and letting it claim `findTarget`
-    // reported an inversion against a body whose order matches Rails.
     expect(
       reorderedCalls(
         "load_target",
@@ -2093,11 +2086,6 @@ describe("reorderedCalls (RFC 0084 order-only call parity)", () => {
   });
 
   it("drops a TS name two of the body's Ruby calls could both be ported as", () => {
-    // define_autosave_validation_callbacks (autosave_association.rb:219-234)
-    // calls `reflection.validate?` and then `validate validation_method`; trails
-    // spells the first `reflection.validate`, so the TS name `validate` carries
-    // no position for either. The weak call (`reflection.validate?` sits on an
-    // inert receiver) still disambiguates, so it is passed as bodyRubyCalls.
     expect(
       reorderedCalls(
         "define_autosave_validation_callbacks",
@@ -2109,7 +2097,6 @@ describe("reorderedCalls (RFC 0084 order-only call parity)", () => {
         ["validate?", "define_non_cyclic_method", "validate"],
       ),
     ).toEqual([]);
-    // Without the ambiguity, the same sequences ARE an inversion.
     expect(
       reorderedCalls(
         "define_autosave_validation_callbacks",

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -19,6 +19,8 @@ import {
   buildEntitiesByName,
   resolveEntityByDeclaringFile,
   significantMissingCalls,
+  narrowPredicateCandidates,
+  ambiguousTsNames,
   reorderedCalls,
   ORDER_PREFIX,
   resolvePortedWithArgsSigs,
@@ -1965,6 +1967,58 @@ describe("reopeningMethodCreditedToOwnFile", () => {
   });
 });
 
+describe("narrowPredicateCandidates", () => {
+  const map = (c: string) => rubyMethodToTs(c);
+
+  it("drops the bare spelling when the body also makes the plain call", () => {
+    expect(
+      narrowPredicateCandidates(
+        "find_target?",
+        ["isFindTarget", "findTarget"],
+        ["find_target?", "find_target"],
+        map,
+      ),
+    ).toEqual(["isFindTarget"]);
+  });
+
+  it("keeps both spellings when the plain call is absent", () => {
+    expect(
+      narrowPredicateCandidates(
+        "find_target?",
+        ["isFindTarget", "findTarget"],
+        ["find_target?"],
+        map,
+      ),
+    ).toEqual(["isFindTarget", "findTarget"]);
+  });
+
+  it("leaves a non-predicate call alone", () => {
+    expect(narrowPredicateCandidates("find_target", ["findTarget"], ["find_target"], map)).toEqual([
+      "findTarget",
+    ]);
+  });
+
+  it("keeps the whole list rather than narrowing to nothing", () => {
+    // A predicate whose ONLY candidate is the plain call's must still be
+    // checkable — narrowing to [] would silence a genuinely dropped call.
+    expect(narrowPredicateCandidates("save?", ["save"], ["save?", "save"], () => ["save"])).toEqual(
+      ["save"],
+    );
+  });
+});
+
+describe("ambiguousTsNames", () => {
+  const map = (c: string) => rubyMethodToTs(c);
+
+  it("names the TS spelling a predicate and its plain sibling share", () => {
+    expect([...ambiguousTsNames(["validate?", "validate", "name"], map)]).toEqual(["validate"]);
+  });
+
+  it("is empty when every Ruby call maps to its own TS names", () => {
+    expect([...ambiguousTsNames(["build_record", "add_to_target"], map)]).toEqual([]);
+  });
+});
+
 describe("reorderedCalls (RFC 0084 order-only call parity)", () => {
   const map = (c: string) => rubyMethodToTs(c);
   const wide = { has: (k: string) => k !== "super" };
@@ -2018,6 +2072,54 @@ describe("reorderedCalls (RFC 0084 order-only call parity)", () => {
     expect(
       reorderedCalls("save", ["super", "touch", "build"], ["touch", "build"], ported, map, wide),
     ).toEqual([]);
+  });
+
+  it("does not credit a predicate with the plain call's TS position", () => {
+    // CollectionAssociation#load_target (collection_association.rb:37-42) calls
+    // `find_target?`, `merge_target_lists`, then `find_target`; trails calls
+    // `findTargetNeeded`, `mergeTargetLists`, then `findTarget`. `find_target?`
+    // maps to ["isFindTarget", "findTarget"], and letting it claim `findTarget`
+    // reported an inversion against a body whose order matches Rails.
+    expect(
+      reorderedCalls(
+        "load_target",
+        ["find_target?", "merge_target_lists", "find_target"],
+        ["findTargetNeeded", "mergeTargetLists", "findTarget"],
+        ported,
+        map,
+        wide,
+      ),
+    ).toEqual([]);
+  });
+
+  it("drops a TS name two of the body's Ruby calls could both be ported as", () => {
+    // define_autosave_validation_callbacks (autosave_association.rb:219-234)
+    // calls `reflection.validate?` and then `validate validation_method`; trails
+    // spells the first `reflection.validate`, so the TS name `validate` carries
+    // no position for either. The weak call (`reflection.validate?` sits on an
+    // inert receiver) still disambiguates, so it is passed as bodyRubyCalls.
+    expect(
+      reorderedCalls(
+        "define_autosave_validation_callbacks",
+        ["define_non_cyclic_method", "validate"],
+        ["validate", "defineNonCyclicMethod"],
+        ported,
+        map,
+        wide,
+        ["validate?", "define_non_cyclic_method", "validate"],
+      ),
+    ).toEqual([]);
+    // Without the ambiguity, the same sequences ARE an inversion.
+    expect(
+      reorderedCalls(
+        "define_autosave_validation_callbacks",
+        ["define_non_cyclic_method", "validate"],
+        ["validate", "defineNonCyclicMethod"],
+        ported,
+        map,
+        wide,
+      ),
+    ).toEqual([`${ORDER_PREFIX}validate,defineNonCyclicMethod → defineNonCyclicMethod,validate`]);
   });
 
   it("respects the ported-with-args gate the missing-call check uses", () => {

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -326,6 +326,43 @@ export function dropWeakCalls(
 export { JS_ENUMERABLE_ALIASES, jsEnumerableAliases, NEGATED_ALIASES, partitionNegatedCalls };
 
 /**
+ * Narrow a Ruby PREDICATE's candidate list against the rest of the body it was
+ * read from (RFC 0084 `extractor-predicate-and-closure-order-artifacts`).
+ *
+ * `rubyMethodToTs` maps `find_target?` to BOTH spellings a port may use —
+ * `["isFindTarget", "findTarget"]` — because trails prefixes some ported
+ * predicates with `is` and leaves others bare, and the conventions table cannot
+ * know which. That either-spelling candidate is safe on its own and wrong the
+ * moment the SAME body also calls the plain `find_target`: the bare spelling is
+ * then the plain call's port, and letting the predicate claim it makes the two
+ * distinct Ruby calls resolve to one TS name. `CollectionAssociation#load_target`
+ * is the worked case — Rails calls `find_target?` then `merge_target_lists` then
+ * `find_target` (collection_association.rb:37-42), trails calls
+ * `findTargetNeeded` then `mergeTargetLists` then `findTarget`
+ * (collection-association.ts), and the predicate claiming `findTarget` reported
+ * a call-ORDER inversion in a body whose order matches Rails exactly.
+ *
+ * So: when the body makes the plain call too, drop from the predicate's
+ * candidates every name the plain call also maps to. The `is`-prefixed spelling
+ * always survives (the plain call never produces it), so a genuinely dropped
+ * predicate is still flagged — this only stops one Ruby call from being
+ * credited to another's port.
+ */
+export function narrowPredicateCandidates(
+  rubyCall: string,
+  mapped: readonly string[],
+  rubyCalls: readonly string[],
+  mapCall: (rubyCall: string) => string[] | null = rubyMethodToTs,
+): string[] {
+  if (!rubyCall.endsWith("?")) return [...mapped];
+  const plain = rubyCall.slice(0, -1);
+  if (!rubyCalls.includes(plain)) return [...mapped];
+  const claimed = new Set(mapCall(plain) ?? []);
+  const narrowed = mapped.filter((c) => !claimed.has(c));
+  return narrowed.length === 0 ? [...mapped] : narrowed;
+}
+
+/**
  * Core of the advisory calls-parity check (pure, exported for tests). For a
  * name-matched pair, returns the fidelity-critical Ruby body calls that are
  * absent from the TS body's call-set, formatted as `ruby_call → tsCand|tsCand`.
@@ -340,6 +377,11 @@ export { JS_ENUMERABLE_ALIASES, jsEnumerableAliases, NEGATED_ALIASES, partitionN
  *   3. flagged only when the TS body makes NONE of the mapped candidates, nor
  *      any JS-native analogue of the Ruby call (`aliasCall`, e.g. `some` for
  *      `any?`).
+ *
+ * `bodyRubyCalls` is the body's call list BEFORE `dropWeakCalls` — the
+ * disambiguation above is about what the Ruby body NAMES, and a call the weak
+ * filter drops (an inert receiver, `reflection.validate?`) still names a TS
+ * spelling that another call would otherwise be credited with.
  */
 export function significantMissingCalls(
   rubyName: string,
@@ -350,6 +392,7 @@ export function significantMissingCalls(
   significant: { has(value: string): boolean } = SIGNIFICANT_CALLS,
   aliasCall: (rubyCall: string) => string[] = jsEnumerableAliases,
   negatedTsCalls: Set<string> = new Set(),
+  bodyRubyCalls: readonly string[] = rubyCalls,
 ): string[] {
   const missing: string[] = [];
   for (const rc of rubyCalls) {
@@ -369,8 +412,9 @@ export function significantMissingCalls(
       if (!chained) missing.push(`super → super|${[...selfTs].join("|")}`);
       continue;
     }
-    const mapped = mapCall(rc);
-    if (!mapped || mapped.length === 0) continue;
+    const raw = mapCall(rc);
+    if (!raw || raw.length === 0) continue;
+    const mapped = narrowPredicateCandidates(rc, raw, bodyRubyCalls, mapCall);
     if (!mapped.some(isPortedWithArgs)) continue;
     if (mapped.some((c) => tsCalls.has(c))) continue;
     // A NEGATED alias (`exclude? → includes`) is matched against the negated
@@ -385,6 +429,38 @@ export function significantMissingCalls(
     missing.push(`${rc} → ${mapped.join("|")}`);
   }
   return missing;
+}
+
+/**
+ * The TS names that TWO OR MORE of a body's Ruby calls could be ported as, so
+ * no position in the TS sequence can be attributed to either of them (RFC 0084
+ * `extractor-predicate-and-closure-order-artifacts`).
+ *
+ * The class is a predicate and its plain sibling in one body:
+ * `define_autosave_validation_callbacks` calls `reflection.validate?`
+ * (autosave_association.rb:221) and then `validate validation_method` (:231),
+ * and trails spells the first `reflection.validate` — so the TS name `validate`
+ * occurs twice with two different meanings, and `callSeq` (deduplicated at
+ * first occurrence, like Ruby's `calls.uniq`) keeps only the predicate's
+ * position. Charging the plain call with that position reported an inversion
+ * against a body whose order matches Rails.
+ *
+ * Order needs identity, so an ambiguous name is dropped from the ORDER
+ * comparison only. Membership does not: {@link significantMissingCalls} still
+ * sees the name in the TS call-set, so a genuinely dropped call is still
+ * flagged either way.
+ */
+export function ambiguousTsNames(
+  rubyCalls: readonly string[],
+  mapCall: (rubyCall: string) => string[] | null = rubyMethodToTs,
+): Set<string> {
+  const owners = new Map<string, Set<string>>();
+  for (const rc of new Set(rubyCalls)) {
+    for (const c of mapCall(rc) ?? []) {
+      (owners.get(c) ?? owners.set(c, new Set()).get(c)!).add(rc);
+    }
+  }
+  return new Set([...owners].filter(([, rcs]) => rcs.size > 1).map(([c]) => c));
 }
 
 /**
@@ -422,6 +498,30 @@ export const ORDER_PREFIX = "order:";
  * At most one flag per body, naming the first inversion — `order:b,a → a,b`
  * reads "TS calls b before a; Rails calls a before b" — so the row is a stable
  * baseline key rather than a whole-sequence string that churns on every edit.
+ *
+ * A TS name two of the body's Ruby calls could both be ported as carries no
+ * position for either ({@link ambiguousTsNames}), so it is skipped here; the
+ * membership check still sees it.
+ *
+ * ONE class of order flag is a known extractor artifact and is NOT handled
+ * here, recorded once rather than re-derived per file (RFC 0084
+ * `extractor-predicate-and-closure-order-artifacts`): a call nested in ANOTHER
+ * call's ARGUMENTS. Both extractors emit lexical order — receiver, then the
+ * call, then its arguments (extract-ruby-api.rb#walk_for_calls,
+ * extract-ts-api.ts#collectCalls, whose comments pin the two to each other) —
+ * so Rails' `add_to_target(build_record(attributes, &block), replace: true)`
+ * (collection_association.rb:121) records `add_to_target` BEFORE `build_record`
+ * even though `build_record` is what runs first. A port that hoists the nested
+ * call into a local — which an `await` forces — then reads as an inversion.
+ * Ruby EVALUATION order (arguments before the enclosing call) is the sequence
+ * both sides should record; changing it is a matched change to two extractors
+ * with its own whole-artifact re-measure, so it is its own story rather than a
+ * special case here.
+ *
+ * `bodyRubyCalls` is the body's call list BEFORE `dropWeakCalls` — the
+ * disambiguation above is about what the Ruby body NAMES, and a call the weak
+ * filter drops (an inert receiver, `reflection.validate?`) still names a TS
+ * spelling that another call would otherwise be credited with.
  */
 export function reorderedCalls(
   rubyName: string,
@@ -430,16 +530,19 @@ export function reorderedCalls(
   isPortedWithArgs: (tsName: string) => boolean,
   mapCall: (rubyCall: string) => string[] | null = rubyMethodToTs,
   significant: { has(value: string): boolean } = SIGNIFICANT_CALLS,
+  bodyRubyCalls: readonly string[] = rubyCalls,
 ): string[] {
+  const ambiguous = ambiguousTsNames(bodyRubyCalls, mapCall);
   const rubySeq: string[] = [];
   for (const rc of rubyCalls) {
     if (rc === rubyName) continue;
     if (rc === "super") continue;
     if (!significant.has(rc)) continue;
-    const mapped = mapCall(rc);
-    if (!mapped || mapped.length === 0) continue;
+    const raw = mapCall(rc);
+    if (!raw || raw.length === 0) continue;
+    const mapped = narrowPredicateCandidates(rc, raw, bodyRubyCalls, mapCall);
     if (!mapped.some(isPortedWithArgs)) continue;
-    const hit = mapped.find((c) => tsCalls.includes(c));
+    const hit = mapped.find((c) => tsCalls.includes(c) && !ambiguous.has(c));
     if (hit === undefined) continue;
     if (rubySeq.includes(hit)) continue;
     rubySeq.push(hit);
@@ -2589,6 +2692,7 @@ export function main() {
           callsSignificant,
           jsEnumerableAliases,
           negatedTsCalls,
+          rubyOwned?.calls ?? rubyCalls,
         );
         const tags = tagsForOwner(tsMissingCallTagsByFileName.get(tsFile)?.get(tsName), tsClass);
         let kept = missing;
@@ -2624,6 +2728,7 @@ export function main() {
               (c) => portedWithArgsSigs(tsFile, c).some((sig) => stripThis(sig).length > 0),
               rubyMethodToTs,
               callsSignificant,
+              rubyOwned?.calls ?? rubyCalls,
             ),
           );
         }

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -337,7 +337,7 @@ export { JS_ENUMERABLE_ALIASES, jsEnumerableAliases, NEGATED_ALIASES, partitionN
  * then the plain call's port, and letting the predicate claim it makes the two
  * distinct Ruby calls resolve to one TS name. `CollectionAssociation#load_target`
  * is the worked case — Rails calls `find_target?` then `merge_target_lists` then
- * `find_target` (collection_association.rb:37-42), trails calls
+ * `find_target` (collection_association.rb:272-279), trails calls
  * `findTargetNeeded` then `mergeTargetLists` then `findTarget`
  * (collection-association.ts), and the predicate claiming `findTarget` reported
  * a call-ORDER inversion in a body whose order matches Rails exactly.

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -344,9 +344,16 @@ export { JS_ENUMERABLE_ALIASES, jsEnumerableAliases, NEGATED_ALIASES, partitionN
  *
  * So: when the body makes the plain call too, drop from the predicate's
  * candidates every name the plain call also maps to. The `is`-prefixed spelling
- * always survives (the plain call never produces it), so a genuinely dropped
- * predicate is still flagged — this only stops one Ruby call from being
- * credited to another's port.
+ * always survives — conventions.ts emits one only for a `?`-suffixed name, and
+ * `plain` never ends in `?` — so a genuinely dropped predicate is still
+ * flagged; this only stops one Ruby call from being credited to another's port.
+ *
+ * Deliberately narrow: the pairing is a predicate against its OWN bare sibling,
+ * exact-string. Two DIFFERENT Ruby predicates whose candidate lists overlap are
+ * not disambiguated here, because nothing says which of them owns the shared
+ * spelling — there is no `plain` to reserve it for. That case is handled where
+ * it actually costs something, the order check, by dropping the shared name
+ * from both ({@link ambiguousTsNames}).
  */
 export function narrowPredicateCandidates(
   rubyCall: string,
@@ -445,10 +452,15 @@ export function significantMissingCalls(
  * position. Charging the plain call with that position reported an inversion
  * against a body whose order matches Rails.
  *
- * Order needs identity, so an ambiguous name is dropped from the ORDER
- * comparison only. Membership does not: {@link significantMissingCalls} still
- * sees the name in the TS call-set, so a genuinely dropped call is still
- * flagged either way.
+ * Wired into the ORDER comparison ONLY, and the asymmetry with the membership
+ * check is the semantics of the two, not an oversight. A position is one
+ * indivisible fact that has to be attributed to exactly one call, so an
+ * ambiguous name carries no usable position. Membership is a SET comparison on
+ * both sides — Ruby's `calls.uniq` against the TS `Set` — and neither side
+ * records multiplicity, so it cannot demand that two Ruby calls be satisfied by
+ * two distinct TS names even in principle: a body calling one method twice is
+ * already indistinguishable from one calling it once. Narrowing there would
+ * only manufacture rows for a demand the artifact cannot express.
  */
 export function ambiguousTsNames(
   rubyCalls: readonly string[],


### PR DESCRIPTION
## What

`rubyMethodToTs` maps a Ruby predicate to **both** spellings a port may use —
`find_target?` → `["isFindTarget", "findTarget"]` — because trails prefixes some
ported predicates with `is` and leaves others bare, and the conventions table
cannot know which. That is safe on its own and wrong the moment the same body
also calls the plain `find_target`: the two distinct Ruby calls resolve to one TS
name, and the call-ORDER comparison reports an inversion against a body whose
order matches Rails exactly.

Two fixes, both in the comparator, where the Ruby↔TS conventions live:

- **`narrowPredicateCandidates`** — when the body also makes the plain call,
  drop from the predicate's candidates every name the plain call maps to. The
  `is` spelling always survives, so a genuinely dropped predicate is still
  flagged; this only stops one Ruby call being credited to another's port.
- **`ambiguousTsNames`** — drop from the ORDER comparison any TS name two of the
  body's Ruby calls could both be ported as. Order needs identity, and `callSeq`
  is deduplicated at first occurrence, so that position belongs to neither.
  Membership is unaffected: `significantMissingCalls` still sees the name.
  Computed over the body's calls **before** `dropWeakCalls`, since an
  inert-receiver call (`reflection.validate?`) still names a TS spelling another
  call would otherwise be credited with.

## Measured

`API_COMPARE_FORCE=1 pnpm parity:api --calls`, whole artifact, vs `main`:
**4 rows gone, 0 added** (two of the four are the same row with a shorter
candidate list — same baseline key).

| gone | why it was an artifact |
| --- | --- |
| `associations/collection-association.ts \| load_target \| order:mergeTargetLists,findTarget` | Rails calls `find_target?`, `merge_target_lists`, `find_target` (collection_association.rb:272-279); trails calls `findTargetNeeded`, `mergeTargetLists`, `findTarget` — same order, but `find_target?` claimed `findTarget` |
| `autosave-association.ts \| define_autosave_validation_callbacks \| order:validate,defineNonCyclicMethod` | Rails calls `reflection.validate?` then `validate validation_method` (autosave_association.rb:219-234); trails spells the first `reflection.validate`, so the TS name `validate` carries no position |
| `attribute-methods/primary-key.ts \| reset_primary_key \| base_class? → isBaseClass\|baseClass` | narrowed to `→ isBaseClass` (same baseline key) |
| `persistence.ts \| query_constraints_list \| base_class? → isBaseClass\|baseClass` | narrowed to `→ isBaseClass` (same baseline key) |

The two real rows are deleted from `call-mismatches-exclude/` by hand
(only-shrink, no reseed).

## Every row the story lists, accounted for

The story's bullets are `rubyMethod | rubyCall → candidates` — so
`skip_statement_cache? | any?` is the call `any?` inside the method
`skip_statement_cache?`, not two colliding predicates. Its twelve rows against
the current re-measure (`API_COMPARE_FORCE=1 pnpm parity:api --calls`), each
either fixed here, filed, or gone:

| story row | disposition |
| --- | --- |
| `load_target \| order:mergeTargetLists,findTarget` | **fixed here** (predicate collision) |
| `define_autosave_validation_callbacks \| order:validate,defineNonCyclicMethod` | **fixed here** (ambiguous TS name) |
| `build \| order:buildRecord,addToTarget` | artifact, argument-nesting class — documented once at `reorderedCalls`, filed as `0084/extractor-argument-nesting-call-order` |
| `matches_foreign_key? \| order:foreignKey,isForeignKeyFor` | real: a duplicate private `isMatchesForeignKey` body reads `reflection.foreignKey` before calling `isForeignKeyFor`, inverting association.rb:411-418 — filed as `0084/converge-association-duplicate-matches-foreign-key` |
| `reset \| new → constructor` | real: drops `@replaced_or_added_targets = Set.new.compare_by_identity` (collection_association.rb:87-92) — filed |
| `concat_records \| loaded?` | real: drops the `insert_record` block `@_was_loaded = loaded?` (collection_association.rb:438-454) — filed |
| `empty? \| exists?` | real: `isEmpty` / `isEmptyAsync` split, query arm only in the async one (collection_association.rb:232-238) — filed |
| `skip_statement_cache? \| any?` | `default_scopes.any?` → `.length`, the positional/property-analogue class **already decided and cited** at `enumerable-idioms.ts` (RFC 0092 `positional-idiom-analogues`) |
| `marshal_dump \| map` | already carries a per-entry verified reason in the baseline (RFC 0032): Marshal ivar introspection has no JS analogue |
| `changed_for_autosave? \| marked_for_destruction?` | real, and the one row this review surfaced as unaccounted: the body reads the private `Symbol.for("blazetrails.markedForDestruction")` slot instead of the ported `isMarkedForDestruction` (autosave_association.rb:275-277), adds a `!!this.changed` term Rails has no counterpart for, and is duplicated as `isChangedForAutosave` — filed as `0084/converge-changed-for-autosave-marked-for-destruction`, covering the `base.ts` twin too |
| `violates_strict_loading? \| strict_loading?` | **no longer live** — absent from the current artifact |
| `association_valid? \| any?`, `save_collection_association \| new`, `initialize_attributes \| map`, `save_has_one_association \| map`, `save_belongs_to_association \| map`, `inverse_association_for \| order:inverseReflectionFor,isInvertibleFor` | **no longer live** — absent from the current artifact (the story text predates the post-0083 convergence in those files) |

Verified by name against `output/call-mismatches.json` from the run in this
branch, not by grepping the baseline: a row can be live and unbaselined.

This story may not edit association source, so the real ones are filed rather
than dropped — four follow-up stories, each carrying the Rails `file:line` above
and the baseline row it retires:
`0084/extractor-argument-nesting-call-order`,
`0084/converge-collection-association-reset-concat-empty`,
`0084/converge-association-duplicate-matches-foreign-key`,
`0084/converge-changed-for-autosave-marked-for-destruction`.

## On the narrowing asymmetry (review question 1)

Intentional, and now stated at `ambiguousTsNames`. A call POSITION is one
indivisible fact that must be attributed to exactly one call, so a name two
Ruby calls could both be ported as carries no usable position — the order check
has to drop it. Membership is a SET comparison on both sides (Ruby's
`calls.uniq` against the TS `Set`); neither side records multiplicity, so it
cannot demand that two Ruby calls be satisfied by two DISTINCT TS names even in
principle — a body calling one method twice is already indistinguishable from
one calling it once. Narrowing there would manufacture rows for a demand the
artifact cannot express.

`narrowPredicateCandidates` stays deliberately narrow for the same reason: it
pairs a predicate with its OWN bare sibling, where there is a `plain` call to
reserve the shared spelling FOR. Two different predicates with overlapping
candidate lists have no such owner, so there is nothing to narrow to — that case
is handled where it costs something, in the order check, by dropping the shared
name from both.

## Checks

- `pnpm parity:api:calls` — OK; `pnpm parity:api:calls:args` — OK.
- `npx vitest run scripts/api-compare/` — 37 files, 1118 tests passing, including
  new coverage for both helpers and for the two retired rows as regressions
  (each asserts the artifact is gone *and* that the same sequences without the
  ambiguity still flag).
- No package source file is touched.

Closes-story: extractor-predicate-and-closure-order-artifacts
