### PR TITLE
refactor(activerecord): converge Association#matches_foreign_key? to a single Rails-shaped port

### DIFF
--- a/packages/activerecord/src/associations/association-matches-foreign-key.trails.test.ts
+++ b/packages/activerecord/src/associations/association-matches-foreign-key.trails.test.ts
@@ -1,0 +1,53 @@
+/**
+ * `Association#matches_foreign_key?` (association.rb:411-418) — the inverse-wiring
+ * FK match used by `inversable?`. Rails has ONE body:
+ *
+ *   if foreign_key_for?(record)
+ *     record.read_attribute(reflection.foreign_key) == owner.id ||
+ *       (foreign_key_for?(owner) && owner.read_attribute(reflection.foreign_key) == record.id)
+ *   else
+ *     owner.read_attribute(reflection.foreign_key) == record.id
+ *   end
+ *
+ * trails carried two ports of it; the surviving one is pinned here on the two
+ * cases the bodies disagreed on — a composite foreign key (`Array(foreign_key)`
+ * against a composite `owner.id`) and the `foreign_key_for?(owner)` arm, which
+ * only fires when owner and record share the FK column (the self-referential
+ * `companies` table).
+ */
+import { describe, it, expect } from "vitest";
+
+import { Base } from "../base.js";
+import { fixtures } from "../test-fixtures.js";
+import "../support/canonical-model-index.js";
+import { Client, Firm } from "../test-helpers/models/company.js";
+import { CpkBook, CpkOrder } from "../test-helpers/models/cpk.js";
+
+type AssociationLike = { matchesForeignKey(record: Base): boolean };
+
+const association = (record: Base, name: string): AssociationLike =>
+  (record as unknown as { association(name: string): AssociationLike }).association(name);
+
+describe("Association#matches_foreign_key?", () => {
+  const { companies } = fixtures(["companies"]);
+
+  it("matches a composite foreign key against the composite owner id", () => {
+    const order = new CpkOrder({ id: [1, 2] });
+    const book = new CpkBook({ id: [5, 7], shop_id: 1, order_id: 2 });
+    const otherShopBook = new CpkBook({ id: [5, 8], shop_id: 3, order_id: 2 });
+
+    expect(association(order, "books").matchesForeignKey(book)).toBe(true);
+    expect(association(order, "books").matchesForeignKey(otherShopBook)).toBe(false);
+  });
+
+  it("matches through the owner's own foreign key when both records carry it", async () => {
+    const firm = (await Firm.find(companies("first_firm").id)) as Base;
+    const client = (await Client.find(companies("second_client").id)) as Base;
+
+    // owner = client, record = firm: both live in `companies`, so
+    // `foreign_key_for?(record)` is true but the firm's own `client_of` is not
+    // the client's id — only the `foreign_key_for?(owner)` arm can match.
+    expect(association(client, "firm").matchesForeignKey(firm)).toBe(true);
+    expect(association(firm, "clientsOfFirm").matchesForeignKey(client)).toBe(true);
+  });
+});

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -814,12 +814,21 @@ export class Association {
   matchesForeignKey(record: Base): boolean {
     if (this.isForeignKeyFor(record)) {
       return (
-        this.keyValuesEqual(this.foreignKeyValues(record), this.idValues(this.owner)) ||
+        this.keyValuesEqual(
+          this.resolveForeignKey().map((key) => record.readAttribute(key)),
+          this.owner.id,
+        ) ||
         (this.isForeignKeyFor(this.owner) &&
-          this.keyValuesEqual(this.foreignKeyValues(this.owner), this.idValues(record)))
+          this.keyValuesEqual(
+            this.resolveForeignKey().map((key) => this.owner.readAttribute(key)),
+            record.id,
+          ))
       );
     }
-    return this.keyValuesEqual(this.foreignKeyValues(this.owner), this.idValues(record));
+    return this.keyValuesEqual(
+      this.resolveForeignKey().map((key) => this.owner.readAttribute(key)),
+      record.id,
+    );
   }
 
   private resolveForeignKey(): string[] {
@@ -850,18 +859,17 @@ export class Association {
     return as ? `${underscore(as)}_type` : null;
   }
 
-  private foreignKeyValues(record: Base): unknown[] {
-    return this.resolveForeignKey().map((key) => (record as any)._readAttribute(key));
-  }
-
-  private idValues(record: Base): unknown[] {
-    const pk = (record.constructor as typeof Base).primaryKey;
-    return (Array.isArray(pk) ? pk : [pk]).map((key) => (record as any)._readAttribute(key));
-  }
-
-  private keyValuesEqual(a: unknown[], b: unknown[]): boolean {
-    if (a.length === 0 || a.length !== b.length) return false;
-    return a.every((value, i) => associationKeysEqual(value, b[i]));
+  /**
+   * Ruby compares `read_attribute(reflection.foreign_key) == owner.id` directly;
+   * with a composite key both sides are arrays, and `associationKeysEqual`
+   * bridges a child FK (int4 number) and an owner PK (int8 BigInt under PG
+   * bigserial) as Ruby's `Integer ==` does.
+   */
+  private keyValuesEqual(a: unknown, b: unknown): boolean {
+    const left = Array.isArray(a) ? a : [a];
+    const right = Array.isArray(b) ? b : [b];
+    if (left.length === 0 || left.length !== right.length) return false;
+    return left.every((value, i) => associationKeysEqual(value, right[i]));
   }
 
   private ensureKlassExistsBang(): typeof Base {
@@ -1034,19 +1042,6 @@ export class Association {
       ownerAny._afterCommitJobs ??= [];
       ownerAny._afterCommitJobs.push([jobClass, options]);
     }
-  }
-
-  private isMatchesForeignKey(record: Base): boolean {
-    const fk = (this.reflection.options as any).foreignKey;
-    const fkArr: string[] = Array.isArray(fk) ? fk : [String(fk)];
-    if (this.isForeignKeyFor(record)) {
-      return (
-        fkArr.every((key) => (record as any).readAttribute(key) === (this.owner as any).id) ||
-        (this.isForeignKeyFor(this.owner) &&
-          fkArr.every((key) => (this.owner as any).readAttribute(key) === (record as any).id))
-      );
-    }
-    return fkArr.every((key) => (this.owner as any).readAttribute(key) === (record as any).id);
   }
 }
 

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/association.json
@@ -9,13 +9,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/association.ts",
-    "rubyName": "matches_foreign_key?",
-    "call": "order:foreignKey,isForeignKeyFor",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
     "rubyName": "scope",
     "call": "create",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
## What

`associations/association.ts` carried **two** ports of Rails'
`Association#matches_foreign_key?` (`associations/association.rb:411-418`): the
public `matchesForeignKey` and a dead private `isMatchesForeignKey`. One Rails
method is one TS method, so the duplicate is deleted.

The surviving body now makes Rails' calls in Rails' order — `foreign_key_for?`
first, then `read_attribute(reflection.foreign_key)` against `owner.id` /
`record.id` — instead of routing through the `foreignKeyValues` / `idValues`
helpers (both removed; they read `_readAttribute` and re-derived the PK by hand).
`keyValuesEqual` stays as the value-equality bridge Ruby gets free from
`Integer ==` across a number FK and a BigInt PG bigserial PK, and now normalizes
the scalar/composite shapes Rails compares directly.

`api-compare` name-matched Rails against the private duplicate, so the baseline
row `matches_foreign_key? | order:foreignKey,isForeignKeyFor` is deleted by hand
(only-shrink). The re-measure reports `matches_foreign_key?` with **no** missing
calls — the row is retired, none added; `parity:api:calls`, `parity:api:calls:args`
and the `--write` drift check are all clean.

## Tests

New `association-matches-foreign-key.trails.test.ts` pins the two cases the
duplicate bodies disagreed on: a composite foreign key against a composite
`owner.id`, and the `foreign_key_for?(owner)` arm (owner and record sharing the
FK column on the self-referential `companies` table). Substituting the deleted
body makes the composite case red — it compared each FK column against the whole
`owner.id`, which is an array under a composite PK. Note the deleted body was
unreachable, so a literal "fails on pre-fix `HEAD`" run is not possible.

Closes-story: converge-association-duplicate-matches-foreign-key