### PR TITLE
refactor(parity): record call sequences in evaluation order in both extractors

### DIFF
--- a/scripts/api-compare/call-mismatches-exclude/abstractcontroller/helpers.json
+++ b/scripts/api-compare/call-mismatches-exclude/abstractcontroller/helpers.json
@@ -41,12 +41,5 @@
       "ref:allHelpersFromPath"
     ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "abstractcontroller",
-    "tsFile": "helpers.ts",
-    "rubyName": "helper_modules_from_paths",
-    "call": "order:allHelpersFromPath,modulesForHelpers",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal/request-forgery-protection.json
+++ b/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal/request-forgery-protection.json
@@ -102,13 +102,6 @@
   {
     "package": "actioncontroller",
     "tsFile": "metal/request-forgery-protection.ts",
-    "rubyName": "mask_token",
-    "call": "order:encodeCsrfToken,xorByteStrings",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/request-forgery-protection.ts",
     "rubyName": "masked_authenticity_token",
     "call": "global_csrf_token",
     "kind": "args",
@@ -125,13 +118,6 @@
       "ref:action"
     ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/request-forgery-protection.ts",
-    "rubyName": "masked_authenticity_token",
-    "call": "order:perFormCsrfToken,normalizeActionPath",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "actioncontroller",

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/routing/inspector.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/routing/inspector.json
@@ -2,13 +2,6 @@
   {
     "package": "actiondispatch",
     "tsFile": "routing/inspector.ts",
-    "rubyName": "format",
-    "call": "order:collectRoutes,filterRoutes",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "routing/inspector.ts",
     "rubyName": "matches_filter?",
     "call": "match",
     "kind": "args",

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/routing/mapper.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/routing/mapper.json
@@ -183,13 +183,6 @@
   {
     "package": "actiondispatch",
     "tsFile": "routing/mapper.ts",
-    "rubyName": "initialize",
-    "call": "order:resourcesPathNames,constructor",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "routing/mapper.ts",
     "rubyName": "map_match",
     "call": "warn",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/testing/assertions/response.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/testing/assertions/response.json
@@ -13,13 +13,6 @@
   {
     "package": "actiondispatch",
     "tsFile": "testing/assertions/response.ts",
-    "rubyName": "assert_response",
-    "call": "order:constructor,generateResponseMessage",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "testing/assertions/response.ts",
     "rubyName": "exception_if_present",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/validations/numericality.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/validations/numericality.json
@@ -24,8 +24,8 @@
     "package": "activemodel",
     "tsFile": "validations/numericality.ts",
     "rubyName": "validate_each",
-    "call": "order:add,isNumber",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+    "call": "order:filteredOptions,isNumber",
+    "reason": "Order artifact of a TS-only pre-guard: the port adds a nil/undefined arm that calls filteredOptions before is_number? is ever reached (numericality.ts:63); Rails calls is_number? first."
   },
   {
     "package": "activemodel",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-assignment.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-assignment.json
@@ -2,13 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "attribute-assignment.ts",
-    "rubyName": "assign_multiparameter_attributes",
-    "call": "order:extractCallstackForMultiparameterAttributes,executeCallstackForMultiparameterAttributes",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-assignment.ts",
     "rubyName": "execute_callstack_for_multiparameter_attributes",
     "call": "all?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods/primary-key.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods/primary-key.json
@@ -65,13 +65,6 @@
   {
     "package": "activerecord",
     "tsFile": "attribute-methods/primary-key.ts",
-    "rubyName": "quoted_primary_key",
-    "call": "order:primaryKey,quoteColumnName",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods/primary-key.ts",
     "rubyName": "reset_primary_key",
     "call": "base_class?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
@@ -51,23 +51,16 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
-    "rubyName": "change_column",
-    "call": "order:quoteTableName,execute",
-    "reason": "ORDER-only: Ruby evaluates the interpolated quote_table_name / *_for_alter arguments before `execute`; TS source order puts the `execute` call first, so the extractor's textual ordering can never match. Same body, same call set."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "change_column_default",
-    "call": "order:changeColumnDefaultForAlter,execute",
-    "reason": "ORDER-only: Ruby evaluates the interpolated quote_table_name / *_for_alter arguments before `execute`; TS source order puts the `execute` call first, so the extractor's textual ordering can never match. Same body, same call set."
+    "call": "order:changeColumnDefaultForAlter,quoteTableName",
+    "reason": "Order artifact of an await-forced hoist: the port lifts the awaited changeColumnDefaultForAlter above the quoteTableName Rails evaluates first in the same interpolation (abstract-mysql-adapter.ts:692); both are pure."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "change_column_null",
-    "call": "order:quoteColumnName,execute",
-    "reason": "ORDER-only: Ruby evaluates the interpolated quote_table_name / *_for_alter arguments before `execute`; TS source order puts the `execute` call first, so the extractor's textual ordering can never match. Same body, same call set."
+    "call": "order:quoteColumnName,quoteTableName",
+    "reason": "Order artifact of a hoisted local: the port lifts the twice-used quoteColumnName above the quoteTableName Rails evaluates first in the same interpolation (abstract-mysql-adapter.ts:766); both are pure."
   },
   {
     "package": "activerecord",
@@ -206,8 +199,8 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "rename_column",
-    "call": "order:renameColumnForAlter,execute",
-    "reason": "ORDER-only: Ruby evaluates the interpolated quote_table_name / *_for_alter arguments before `execute`; TS source order puts the `execute` call first, so the extractor's textual ordering can never match. Same body, same call set."
+    "call": "order:renameColumnForAlter,quoteTableName",
+    "reason": "Order artifact of an await-forced hoist: the port lifts the awaited renameColumnForAlter above the quoteTableName Rails evaluates first in the same interpolation (abstract-mysql-adapter.ts:835); both are pure."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/schema-definitions.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/schema-definitions.json
@@ -2,13 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-definitions.ts",
-    "rubyName": "add_column",
-    "call": "order:newColumnDefinition,constructor",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-definitions.ts",
     "rubyName": "add_to",
     "call": "foreign_key",
     "kind": "args",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql-adapter.json
@@ -195,13 +195,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "rename_index",
-    "call": "order:quoteTableName,execute",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "returning_column_values",
     "call": "first",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/oid/array.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/oid/array.json
@@ -19,12 +19,5 @@
     "rubyName": "initialize",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/oid/array.ts",
-    "rubyName": "serialize",
-    "call": "order:constructor,typeCastArray",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/oid/range.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/oid/range.json
@@ -2,15 +2,15 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql/oid/range.ts",
-    "rubyName": "extract_bounds",
-    "call": "split",
-    "reason": "Name-collision false positive (story relation-delegation-rails-named-methods): exposing the `delegate ... to: :records` set under Rails names made `split`/`reverse`/`rindex` recognized ported method names, so this unrelated call to String#split / Array#reverse / String#rindex on a non-Relation receiver is flagged by the name-based wide call-set check."
+    "rubyName": "cast_value",
+    "call": "order:constructor,sanitizeBounds",
+    "reason": "Order artifact of the raise idiom: Rails' `raise ArgumentError, msg` ports to `throw new Error(...)` (range.ts:109), whose `constructor` is credited before the ::Range.new(*sanitize_bounds(...)) at the end of the body."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql/oid/range.ts",
-    "rubyName": "serialize",
-    "call": "order:constructor,typeCastSingleForDatabase",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+    "rubyName": "extract_bounds",
+    "call": "split",
+    "reason": "Name-collision false positive (story relation-delegation-rails-named-methods): exposing the `delegate ... to: :records` set under Rails names made `split`/`reverse`/`rindex` recognized ported method names, so this unrelated call to String#split / Array#reverse / String#rindex on a non-Relation receiver is flagged by the name-based wide call-set check."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/core.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/core.json
@@ -45,8 +45,8 @@
     "package": "activerecord",
     "tsFile": "core.ts",
     "rubyName": "find",
-    "call": "order:constructor,primaryKey",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+    "call": "order:constructor,unsupportedValue",
+    "reason": "Order artifact: the port constructs before it reaches StatementCache.unsupportedValue (core.ts:975), where Rails checks unsupported_value? before RecordNotFound.new."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/message-pack-message-serializer.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/message-pack-message-serializer.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/message-pack-message-serializer.ts",
+    "rubyName": "hash_to_message",
+    "call": "order:constructor,parseProperties",
+    "reason": "Order artifact: the port's earlier construction is credited before parseProperties, where Rails evaluates the parse_properties argument before Message.new."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/message-serializer.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/message-serializer.json
@@ -1,9 +1,1 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "encryption/message-serializer.ts",
-    "rubyName": "parse_message",
-    "call": "order:decodeIfNeeded,constructor",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  }
-]
+[]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/model-schema.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/model-schema.json
@@ -51,6 +51,13 @@
   {
     "package": "activerecord",
     "tsFile": "model-schema.ts",
+    "rubyName": "table_exists?",
+    "call": "order:dataSourceExists,tableName",
+    "reason": "Order artifact of a TS-only capability guard: `typeof cache.dataSourceExists !== \"function\"` (model-schema.ts:1574) credits dataSourceExists before the tableName argument Rails evaluates first."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "model-schema.ts",
     "rubyName": "table_name=",
     "call": "connected?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/nested-attributes.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/nested-attributes.json
@@ -115,6 +115,13 @@
   {
     "package": "activerecord",
     "tsFile": "nested-attributes.ts",
+    "rubyName": "raise_nested_attributes_record_not_found!",
+    "call": "order:constructor,id",
+    "reason": "Order artifact of a TS-only class reach: `record.constructor` (nested-attributes.ts:515) is credited as `constructor` before `record.id`, where Rails evaluates the id interpolation before RecordNotFound.new."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "nested-attributes.ts",
     "rubyName": "reject_new_record?",
     "call": "call_reject_if",
     "kind": "args",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/normalization.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/normalization.json
@@ -21,12 +21,5 @@
     "kind": "args",
     "rubyArgs": [],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "normalization.ts",
-    "rubyName": "serialize",
-    "call": "order:cast,serializeCastValue",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/query-logs.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/query-logs.json
@@ -1,9 +1,1 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "query-logs.ts",
-    "rubyName": "tag_content",
-    "call": "order:join,format",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  }
-]
+[]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
@@ -279,13 +279,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
-    "rubyName": "delete",
-    "call": "order:primaryKey,where",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
     "rubyName": "delete_all",
     "call": "arel",
     "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/finder-methods.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/finder-methods.json
@@ -62,13 +62,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation/finder-methods.ts",
-    "rubyName": "find_some",
-    "call": "order:primaryKey,where",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
     "rubyName": "find_some_ordered",
     "call": "except",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/query-methods.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/query-methods.json
@@ -79,13 +79,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
-    "rubyName": "build_arel",
-    "call": "order:table,constructor",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
     "rubyName": "build_bound_sql_literal",
     "call": "sql",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -103,13 +96,6 @@
     "rubyName": "build_join_buckets",
     "call": "sql",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "build_join_dependencies",
-    "call": "order:selectNamedJoins,constructJoinDependency",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activerecord",
@@ -234,13 +220,6 @@
     "tsFile": "relation/query-methods.ts",
     "rubyName": "build_with_join_node",
     "call": "order:table,constructor",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "build_with_value_from_hash",
-    "call": "order:buildWithExpressionFromValue,constructor",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/where-clause.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/where-clause.json
@@ -24,13 +24,6 @@
     "package": "activerecord",
     "tsFile": "relation/where-clause.ts",
     "rubyName": "invert",
-    "call": "order:constructor,invertPredicate",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/where-clause.ts",
-    "rubyName": "invert",
     "call": "size",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/cache.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/cache.json
@@ -30,13 +30,6 @@
   {
     "package": "activesupport",
     "tsFile": "cache.ts",
-    "rubyName": "new_entry",
-    "call": "order:mergedOptions,constructor",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "cache.ts",
     "rubyName": "normalize_version",
     "call": "try",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -46,13 +39,6 @@
     "tsFile": "cache.ts",
     "rubyName": "read_multi_entries",
     "call": "order:deleteEntry,normalizeVersion",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "cache.ts",
-    "rubyName": "write",
-    "call": "order:writeEntry,constructor",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/cache/file-store.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/cache/file-store.json
@@ -87,13 +87,6 @@
     "package": "activesupport",
     "tsFile": "cache/file-store.ts",
     "rubyName": "modify_value",
-    "call": "order:writeEntry,constructor",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "cache/file-store.ts",
-    "rubyName": "modify_value",
     "call": "write_entry",
     "kind": "args",
     "rubyArgs": [

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/cache/memory-store.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/cache/memory-store.json
@@ -9,13 +9,6 @@
   {
     "package": "activesupport",
     "tsFile": "cache/memory-store.ts",
-    "rubyName": "modify_value",
-    "call": "order:writeEntry,constructor",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "cache/memory-store.ts",
     "rubyName": "read_entry",
     "call": "delete",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/hash-utils.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/hash-utils.json
@@ -2,6 +2,13 @@
   {
     "package": "activesupport",
     "tsFile": "hash-utils.ts",
+    "rubyName": "assert_valid_keys",
+    "call": "order:constructor,join",
+    "reason": "Order artifact of a TS-only `new Set(validKeys)` (hash-utils.ts:192), credited as `constructor` before the join Rails evaluates inside the ArgumentError.new message."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "hash-utils.ts",
     "rubyName": "deep_stringify_keys",
     "call": "deep_transform_keys",
     "kind": "args",

--- a/scripts/api-compare/call-mismatches-exclude/globalid/locator.json
+++ b/scripts/api-compare/call-mismatches-exclude/globalid/locator.json
@@ -1,9 +1,1 @@
-[
-  {
-    "package": "globalid",
-    "tsFile": "locator.ts",
-    "rubyName": "locate_many_signed",
-    "call": "order:parse,locateMany",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  }
-]
+[]

--- a/scripts/api-compare/call-mismatches-exclude/i18n/backend/key-value.json
+++ b/scripts/api-compare/call-mismatches-exclude/i18n/backend/key-value.json
@@ -1,9 +1,1 @@
-[
-  {
-    "package": "i18n",
-    "tsFile": "backend/key-value.ts",
-    "rubyName": "translations",
-    "call": "order:map,deepSymbolizeKeys",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  }
-]
+[]

--- a/scripts/api-compare/call-mismatches-exclude/trailties/rack/logger.json
+++ b/scripts/api-compare/call-mismatches-exclude/trailties/rack/logger.json
@@ -14,7 +14,7 @@
     "package": "trailties",
     "tsFile": "rack/logger.ts",
     "rubyName": "call",
-    "call": "order:pushTags,constructor",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
+    "call": "order:computeTags,constructor",
+    "reason": "Order artifact: the port computes the tags before constructing the request, where Rails builds ActionDispatch::Request.new(env) first and computes compute_tags(request) after."
   }
 ]

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -507,6 +507,13 @@ export const ORDER_PREFIX = "order:";
  * `tsCalls` sequences must both be deduplicated at first occurrence, since a
  * name's position is its first one.
  *
+ * Both sequences are recorded in EVALUATION order by the extractors
+ * (extract-ruby-api.rb#walk_call_in_order, extract-ts-api.ts#collectCalls):
+ * a call's arguments come before the call itself, so a body that hoists a
+ * nested argument into a local — which an `await` forces on the TS side —
+ * reads as the same sequence as the nested spelling, and only a real
+ * reordering flags here.
+ *
  * At most one flag per body, naming the first inversion — `order:b,a → a,b`
  * reads "TS calls b before a; Rails calls a before b" — so the row is a stable
  * baseline key rather than a whole-sequence string that churns on every edit.

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -2326,8 +2326,13 @@ class ApiExtractor
     when :super, :zsuper
       # super(args) is [:super, ...]; bare super is [:zsuper]. Both chain to
       # the parent method; record as "super" so calls-parity can flag a ported
-      # override that drops the super call.
+      # override that drops the super call. Its arguments precede it, as every
+      # other call's do — the TS `super(...)` is an ordinary CallExpression.
+      lambdas = []
+      node.drop(1).each { |child| walk_arg_node(child, calls, weak, lambdas) }
       calls << "super"
+      lambdas.each { |lambda_node| walk_for_calls(lambda_node, calls, weak) }
+      return
     end
 
     node.each { |child| walk_for_calls(child, calls, weak) if child.is_a?(Array) }

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -2319,25 +2319,10 @@ class ApiExtractor
     return unless node.is_a?(Array)
 
     case node[0]
-    when :fcall, :vcall
-      # Unqualified method call: foo() or foo
-      name = ident_name(node[1])
-      calls << name if name && !name.start_with?("_") && name =~ /\A[a-z]/
-    when :call, :command_call
-      # Qualified method call: obj.foo. Receiver before the call it receives,
-      # matching extract-ts-api.ts#collectCalls; the two orders must agree.
-      walk_for_calls(node[1], calls, weak)
-      name = ident_name(node[3]) if node[3]
-      if name && !name.start_with?("_") && name =~ /\A[a-z]/ &&
-         !(name == "new" && proc_new_receiver?(node[1]))
-        calls << name
-        weak << name if inert_receiver?(node[1])
-      end
-      node.drop(4).each { |child| walk_for_calls(child, calls, weak) if child.is_a?(Array) }
+    when :method_add_arg, :fcall, :vcall, :call, :command, :command_call
+      callee, args = split_call_node(node)
+      walk_call_in_order(callee, args, calls, weak)
       return
-    when :command
-      name = ident_name(node[1])
-      calls << name if name && !name.start_with?("_") && name =~ /\A[a-z]/
     when :super, :zsuper
       # super(args) is [:super, ...]; bare super is [:zsuper]. Both chain to
       # the parent method; record as "super" so calls-parity can flag a ported
@@ -2346,6 +2331,86 @@ class ApiExtractor
     end
 
     node.each { |child| walk_for_calls(child, calls, weak) if child.is_a?(Array) }
+  end
+
+  # Decompose a call-ish Ripper node into [callee_node, argument_nodes] — the
+  # argument list hangs off a different slot in each of Ripper's five call
+  # shapes. nil when the node is not a call.
+  def split_call_node(node)
+    return nil unless node.is_a?(Array)
+
+    case node[0]
+    when :method_add_arg then [node[1], node.drop(2)]
+    when :command then [[:fcall, node[1]], node.drop(2)]
+    when :command_call then [node[0, 4], node.drop(4)]
+    when :fcall, :vcall, :call then [node, []]
+    end
+  end
+
+  # Receiver, then the ARGUMENTS, then the call itself — Ruby's EVALUATION
+  # order, matching extract-ts-api.ts#collectCalls; the two orders must agree.
+  # Recording evaluation rather than lexical order makes the sequence invariant
+  # to hoisting: `add_to_target(build_record(x))` and the port's
+  # `const r = await buildRecord(x); addToTarget(r)` — the hoist an `await`
+  # forces — record the same two names in the same order.
+  #
+  # A BLOCK is not walked here: `:method_add_block` falls through to the plain
+  # child walk, so a block body lands AFTER the name of the call it hangs off.
+  # That is the port's order too — Rails' `xs.each do … end` is normally a
+  # `for` loop, whose body follows the iterated expression — and the TS side
+  # defers function-expression arguments for exactly this reason.
+  def walk_call_in_order(callee, args, calls, weak)
+    name = nil
+    recv = nil
+    case callee[0]
+    when :fcall, :vcall
+      # Unqualified method call: foo() or foo
+      name = ident_name(callee[1])
+    when :call, :command_call
+      # Qualified method call: obj.foo
+      recv = callee[1]
+      walk_for_calls(recv, calls, weak)
+      name = ident_name(callee[3]) if callee[3]
+    else
+      # Not a plain call node (`foo[1](2)`, a chained `method_add_arg`, …) —
+      # walk it whole; its arguments still follow.
+      walk_for_calls(callee, calls, weak)
+    end
+
+    lambdas = []
+    args.each { |child| walk_arg_node(child, calls, weak, lambdas) }
+
+    if name && !name.start_with?("_") && name =~ /\A[a-z]/ &&
+       !(name == "new" && recv && proc_new_receiver?(recv))
+      calls << name
+      weak << name if recv && inert_receiver?(recv)
+    end
+
+    lambdas.each { |lambda_node| walk_for_calls(lambda_node, calls, weak) }
+  end
+
+  # Ripper's argument wrappers — structure, never a call of their own.
+  ARG_WRAPPER_NODES = %i[
+    arg_paren args args_new args_add args_add_star args_add_block
+    bare_assoc_hash assoc_new assoc_splat
+  ].freeze
+
+  # An argument subtree, with lambda literals collected rather than walked: a
+  # `-> { … }` argument (`scope :active, -> { where(…) }`) is a block in
+  # everything but Ripper's node name, and the port spells it as the callback
+  # argument extract-ts-api.ts#collectCalls defers — so its body follows the
+  # call name there, and must here.
+  def walk_arg_node(node, calls, weak, lambdas)
+    return unless node.is_a?(Array)
+
+    kind = node[0]
+    if kind == :lambda
+      lambdas << node
+    elsif kind.is_a?(Array) || ARG_WRAPPER_NODES.include?(kind)
+      node.each { |child| walk_arg_node(child, calls, weak, lambdas) if child.is_a?(Array) }
+    else
+      walk_for_calls(node, calls, weak)
+    end
   end
 
   # The argument half of walk_for_calls (RFC 0025 §1). Every syntactic call

--- a/scripts/api-compare/extract-ruby-api.test.ts
+++ b/scripts/api-compare/extract-ruby-api.test.ts
@@ -124,6 +124,35 @@ describe("Ruby extractor body call capture", () => {
     ]);
   });
 
+  it("emits a nested argument before the call it is passed to", () => {
+    // Ruby EVALUATION order (collection_association.rb:121): the argument runs
+    // first, so the port's `await`-forced hoist into a local records the same
+    // sequence as the nested spelling. extract-ts-api.ts#collectCalls agrees.
+    const c = rubyCalls({
+      "foo.rb": `
+        class Foo
+          def build(attributes)
+            add_to_target(build_record(attributes), replace: true)
+          end
+
+          def block_body(xs)
+            xs.each { |x| save(x) }
+          end
+
+          def lambda_arg
+            scope :active, -> { where(status: 0) }
+          end
+        end
+      `,
+    });
+    expect(c["Foo#build"]).toEqual(["build_record", "add_to_target"]);
+    // A block, and the lambda literal that is a block in all but name, still
+    // follow the call they hang off — the port spells both as the callback
+    // argument the TS side defers, or as a `for` body.
+    expect(c["Foo#block_body"]).toEqual(["each", "save"]);
+    expect(c["Foo#lambda_arg"]).toEqual(["scope", "where"]);
+  });
+
   it('records super(args) and bare super as a "super" call', () => {
     const c = rubyCalls({
       "foo.rb": `

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -227,6 +227,51 @@ describe("body call capture", () => {
     expect(swapped.callSeq).toEqual(["save", "build"]);
   });
 
+  it("records a nested argument before the call it is passed to", () => {
+    // Ruby's EVALUATION order (collection_association.rb:121 records
+    // build_record before add_to_target), which extract-ruby-api.rb now
+    // mirrors: recording it makes the sequence invariant to the hoist an
+    // `await` forces, so both spellings below read the same.
+    const nested = extractFromSource(
+      `class Foo {
+        build(attributes) {
+          this.addToTarget(this.buildRecord(attributes), true);
+        }
+      }`,
+    );
+    expect(nested.instanceMethods.find((m) => m.name === "build")!.callSeq).toEqual([
+      "buildRecord",
+      "addToTarget",
+    ]);
+
+    const hoisted = extractFromSource(
+      `class Foo {
+        async build(attributes) {
+          const record = await this.buildRecord(attributes);
+          this.addToTarget(record, true);
+        }
+      }`,
+    );
+    expect(hoisted.instanceMethods.find((m) => m.name === "build")!.callSeq).toEqual([
+      "buildRecord",
+      "addToTarget",
+    ]);
+  });
+
+  it("records a callback argument after the call it is passed to, as Ruby records a block", () => {
+    const cls = extractFromSource(
+      `class Foo {
+        blockBody(xs) {
+          xs.forEach((x) => this.save(x));
+        }
+      }`,
+    );
+    expect(cls.instanceMethods.find((m) => m.name === "blockBody")!.callSeq).toEqual([
+      "forEach",
+      "save",
+    ]);
+  });
+
   it("also records callSeq for an object-literal member and an arrow-function export", () => {
     // The two populations RFC 0084's order-only check was silently skipping:
     // `export const X = { method() {...} }` (arel's visitor tables, the

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -2910,6 +2910,11 @@ function describeObjectLiteral(node: ts.ObjectLiteralExpression, flags: string[]
   return `kwargs{${pairs.join(",")}}`;
 }
 
+/** The port's spelling of a Ruby block: an inline callback argument. */
+function isFunctionArgument(node: ts.Node): boolean {
+  return ts.isArrowFunction(node) || ts.isFunctionExpression(node);
+}
+
 function collectCalls(node: ts.Node | undefined): string[] | undefined {
   if (!node) return undefined;
   const aliases = currentImportAliases;
@@ -2924,24 +2929,35 @@ function collectCalls(node: ts.Node | undefined): string[] | undefined {
       // `new Foo(...)` is Ruby's `Foo.new(...)`. The Ruby extractor records the
       // call as `new`, which conventions.ts maps to the TS `constructor`; record
       // `constructor` here so an instantiation counts toward the call set. Args
-      // are still walked below, so calls nested in constructor arguments
-      // (`new Foo(typeCast(x))`) are credited regardless of body shape.
+      // are walked FIRST (see the call branch below), so calls nested in
+      // constructor arguments (`new Foo(typeCast(x))`) are credited regardless
+      // of body shape.
+      ts.forEachChild(n, visit);
       names.add("constructor");
+      return;
     } else if (ts.isCallExpression(n)) {
+      // Receiver, then the ARGUMENTS, then the call itself — Ruby's EVALUATION
+      // order, matching extract-ruby-api.rb#walk_call_in_order; the two orders
+      // must agree. Recording evaluation rather than lexical order makes the
+      // sequence invariant to hoisting: `addToTarget(buildRecord(x))` and the
+      // `const r = await buildRecord(x); addToTarget(r)` an `await` forces
+      // record the same two names in the same order.
       const callee = n.expression;
+      const called: string[] = [];
+      // The names the `!x()` negation prefix applies to — the call's own, not
+      // the extra identifier a `X.call(...)` dispatch credits below.
+      const negated: string[] = [];
       if (ts.isIdentifier(callee)) {
-        names.add(callee.text);
+        called.push(callee.text);
         // Renamed-import call (`import { a as b }; b()`): also credit the
         // original imported name so it matches the ported call set.
-        names.add(resolve(callee.text));
-        addNegated(n, callee.text, resolve(callee.text));
+        called.push(resolve(callee.text));
+        negated.push(callee.text, resolve(callee.text));
       } else if (ts.isPropertyAccessExpression(callee)) {
-        // Receiver before the call it receives, matching
-        // extract-ruby-api.rb#walk_for_calls; the two orders must agree.
         visit(callee.expression);
         const prop = callee.name.text;
-        names.add(prop);
-        addNegated(n, prop);
+        called.push(prop);
+        negated.push(prop);
         // `X.call(...)` / `X.apply(...)` also dispatch the function bound to
         // `X` (the project's `this`-typed mixin convention, plus Ruby's
         // `meth.call`/`send` indirection). Additionally credit the dispatched
@@ -2949,14 +2965,27 @@ function collectCalls(node: ts.Node | undefined): string[] | undefined {
         // invocation of a ported method counts toward its call set. Additive:
         // the literal `call`/`apply` name is retained, so no prior match is lost.
         if ((prop === "call" || prop === "apply") && ts.isIdentifier(callee.expression)) {
-          names.add(resolve(callee.expression.text));
+          called.push(resolve(callee.expression.text));
         }
       } else if (callee.kind === ts.SyntaxKind.SuperKeyword) {
         // Bare `super(...)` (constructor chain) — `super.foo()` is already
         // captured as `foo` by the property-access branch. Record as "super"
         // so calls-parity can flag a ported override that drops the super call.
-        names.add("super");
+        called.push("super");
+      } else {
+        visit(callee);
       }
+      // A function-expression argument is the port's spelling of a Ruby BLOCK,
+      // which extract-ruby-api.rb walks AFTER the call it hangs off (the block
+      // of `xs.each do … end` is normally a `for` body here, following the
+      // iterated expression). So it is deferred, and only the value arguments
+      // are evaluated before the call.
+      const blocks = n.arguments.filter(isFunctionArgument);
+      for (const arg of n.arguments) if (!isFunctionArgument(arg)) visit(arg);
+      for (const name of called) names.add(name);
+      for (const block of blocks) visit(block);
+      addNegated(n, ...negated);
+      return;
     } else if (ts.isPropertyAccessExpression(n)) {
       // A property READ (`this.joinsValues`, `obj.nested`) is the faithful TS
       // mirror of a Ruby method send: Ruby has no public field access on ANY


### PR DESCRIPTION
Both call-sequence extractors recorded a body's calls in LEXICAL order —
receiver, the call, then its arguments — and each comment pinned the other
("the two orders must agree"). Both disagreed with Ruby's EVALUATION order, in
which an argument runs before the call it is passed to
(`collection_association.rb:121`: `add_to_target(build_record(attributes), …)`
evaluates `build_record` first). The port's `await`-forced hoist into a local
then read as an inversion to `compare.ts#reorderedCalls`.

## What changed (extractors only — no package source is touched)

- `extract-ruby-api.rb`: `walk_for_calls` now decomposes each of Ripper's five
  call shapes (`split_call_node`) and walks them through `walk_call_in_order` —
  receiver, arguments, then the call name.
- `extract-ts-api.ts#collectCalls`: the same order for `CallExpression` /
  `NewExpression`; the `X.call(...)` dispatched-identifier credit moved with
  the call name (the `!x()` negation credit still applies only to the call's own
  names, as before).
- `super(args)` chains through the same order on the Ruby side (its arguments
  precede it), since the TS `super(...)` is an ordinary `CallExpression`.
- **Blocks stay after the call they hang off**, on both sides. Rails'
  `xs.each do … end` is normally a `for` body in the port, so `:method_add_block`
  is left to the plain child walk and the TS side defers function-expression
  arguments. A Ruby lambda literal (`scope :active, -> { where(…) }`) is a block
  in all but Ripper's node name and is deferred with them (`walk_arg_node`) —
  the port spells it as the deferred callback argument.

### Acceptance criterion 2 — the other streams, considered

`extractSkeleton` / `walk_for_skeleton` and the call-ARGUMENT site streams
(`walk_for_call_args` / `walkForCallArgs`) are deliberately **left alone**. They
are already a matched pair recording SITES in source order, and neither
comparator does order-inversion detection: the skeleton is signal-only, and the
argument gate matches sites by name and position. Reordering them would churn
the 357 baselined `kind: "args"` rows for no new signal.

## Re-measure (criterion 3) — `API_COMPARE_FORCE=1 pnpm parity:api --calls`

**36 rows retired, 11 added — net −25.** Both gates green
(`parity:api:calls`, `parity:api:calls:args`).

The 11 additions were each checked against the Rails body first; all are real
order divergences in the ported body that the lexical order happened to hide,
and each is baselined with its own reviewed one-line reason:

- **TS-only guard or pre-arm evaluates a call earlier than Rails** —
  `numericality.ts#validateEach` (added nil arm calls `filteredOptions` first),
  `model-schema.ts#tableExists` (`typeof cache.dataSourceExists !== "function"`).
- **`await`-forced hoist crossing a pure sibling call in the same
  interpolation** — mysql `changeColumnDefault`, `changeColumnNull`,
  `renameColumn` (Rails evaluates `quote_table_name` first).
- **An earlier `constructor` credit the Rails body has no counterpart for** —
  `range.ts#castValue` and `hash-utils.ts#assertValidKeys` (`throw new Error` /
  `new Set`), `nested-attributes.ts` (`record.constructor` as a class reach),
  `core.ts#find`, `message-pack-message-serializer.ts`, `trailties` rack logger.

`associations/collection-association.ts | build | order:buildRecord,addToTarget`
— the row the story names — is among the 36 deleted by hand (only-shrink; no
`--write` reseed).

## Tests

Regression tests on both extractors: a nested argument records before its
enclosing call, the hoisted spelling records identically, and a block / lambda
argument still records after.

Closes-story: extractor-argument-nesting-call-order
