### PR TITLE
refactor(activerecord): thread save's block through create_or_update into _create_record

### DIFF
--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -456,24 +456,13 @@ export class CollectionAssociation extends Association {
     record: Base,
     validate = true,
     raise = false,
-    block?: () => void,
+    block?: (record: Base) => void,
   ): Promise<boolean> {
-    // Rails passes `&block` into `save`/`save!`, which yields it from
-    // `_create_record` after the INSERT but before the after_create callbacks
-    // (persistence.rb:940). trails' save stack takes no block yet — threading
-    // one through `save` → `createOrUpdate` → each `_createRecord` layer is
-    // filed as `plumb-save-block-through-create-record` — so the block runs
-    // here, right after the save, which is the same moment for every path that
-    // does not load the association from an after_create callback.
-    // @missingRailsCall save(&block)
-    if (raise && typeof (record as any).saveBang === "function") {
-      await (record as any).saveBang({ validate });
-      block?.();
-      return true;
+    if (raise) {
+      return !!(await (record as any).saveBang({ validate }, block));
+    } else {
+      return !!(await (record as any).save({ validate }, block));
     }
-    const result = !!(await (record as any).save?.({ validate }));
-    block?.();
-    return result;
   }
 
   /**

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -191,7 +191,12 @@ function assertValidLimit(n: number): void {
 interface ThroughAssociationHandle {
   _throughScope?: unknown;
   concat(...records: Base[]): Promise<Base[] | undefined>;
-  insertRecord(record: Base, validate?: boolean, raise?: boolean): Promise<boolean>;
+  insertRecord(
+    record: Base,
+    validate?: boolean,
+    raise?: boolean,
+    block?: (record: Base) => void,
+  ): Promise<boolean>;
   transaction<R>(block: () => Promise<R>): Promise<R | undefined>;
 }
 

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -158,7 +158,7 @@ export class HasManyAssociation extends CollectionAssociation {
     record: Base,
     validate = true,
     raise = false,
-    block?: () => void,
+    block?: (record: Base) => void,
   ): Promise<boolean> {
     this.setOwnerAttributes(record);
     return super.insertRecord(record, validate, raise, block);

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -266,7 +266,7 @@ export class HasManyThroughAssociation extends HasManyAssociation {
     record: Base,
     validate = true,
     raise = false,
-    block?: () => void,
+    block?: (record: Base) => void,
   ): Promise<boolean> {
     this.ensureNotNested();
     const needsTargetSave = record.isNewRecord() || record.hasChangesToSave;

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -3385,7 +3385,7 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Persistence#save (the super that Transactions#save calls)
    */
-  private async _createOrUpdate(): Promise<boolean> {
+  private async _createOrUpdate(block?: (record: this) => void): Promise<boolean> {
     const ctor = this.constructor as typeof Base;
     let saved = false;
     let wasNewRecord = false;
@@ -3396,11 +3396,11 @@ export class Base extends Model {
     const saveOk = await cbRunAll(ctor.prototype, "save", this, async () => {
       wasNewRecord = this._newRecord;
       if (wasNewRecord) {
-        const createOk = await this._createRecord();
+        const createOk = await this._createRecord(block);
         if (createOk) saved = true;
         else saved = false;
       } else {
-        const updateOk = await this._updateRecord();
+        const updateOk = await this._updateRecord(block);
         if (updateOk) saved = true;
         else saved = false;
       }
@@ -4648,8 +4648,14 @@ export interface Base extends Included<typeof AutosaveAssociation> {
     options?: { touch?: boolean | string | string[] },
   ): Promise<this>;
   toggleBang(attribute: string): Promise<boolean | undefined>;
-  save(options?: { validate?: boolean; touch?: boolean }): Promise<boolean | undefined>;
-  saveBang(options?: { validate?: boolean; touch?: boolean }): Promise<true | undefined>;
+  save(
+    options?: { validate?: boolean; touch?: boolean },
+    block?: (record: this) => void,
+  ): Promise<boolean | undefined>;
+  saveBang(
+    options?: { validate?: boolean; touch?: boolean },
+    block?: (record: this) => void,
+  ): Promise<true | undefined>;
   destroy(): Promise<this | false>;
   destroyBang(): Promise<this>;
   update(attrs: Record<string, unknown>): Promise<boolean | undefined>;
@@ -4673,9 +4679,9 @@ export interface Base extends Included<typeof AutosaveAssociation> {
   /** @internal */
   hasTransactionalCallbacks(): boolean;
   /** @internal */
-  _createRecord(): Promise<boolean>;
+  _createRecord(block?: (record: this) => void): Promise<boolean>;
   /** @internal */
-  _updateRecord(): Promise<boolean>;
+  _updateRecord(block?: (record: this) => void): Promise<boolean>;
   slice(...keys: string[]): Record<string, unknown>;
   valuesAt(...keys: string[]): unknown[];
   assignAttributes(attrs: Record<string, unknown>): Promise<void> | void;

--- a/packages/activerecord/src/callbacks.ts
+++ b/packages/activerecord/src/callbacks.ts
@@ -300,16 +300,19 @@ export function registerBaseTimestampCallbacks(baseProto: object): void {
 // ---------------------------------------------------------------------------
 
 /** @internal */
-export function createOrUpdate(this: any): Promise<boolean> {
+export function createOrUpdate(this: any, block?: (record: any) => void): Promise<boolean> {
   // Rails: Callbacks#create_or_update wraps super in _run_save_callbacks.
   // In trails, save's before/after callback chain runs inside _createOrUpdate
   // (base.ts: runBefore("save") → dispatch create/update → runAfter("save")),
   // so this wrapper just delegates and the callback ordering still matches.
-  return (this._createOrUpdate as () => Promise<boolean>).call(this);
+  return (this._createOrUpdate as (block?: (record: any) => void) => Promise<boolean>).call(
+    this,
+    block,
+  );
 }
 
 /** @internal */
-export async function _createRecord(this: any): Promise<boolean> {
+export async function _createRecord(this: any, block?: (record: any) => void): Promise<boolean> {
   // Rails: _run_create_callbacks { super }, whose value is the block's return
   // (run_callbacks returns env.value). Rails coerces one level up, in
   // create_or_update: `result != false` (persistence.rb:895) — so a nil/absent
@@ -349,6 +352,12 @@ export async function _createRecord(this: any): Promise<boolean> {
         }
         this._previouslyNewRecord = true;
         this._newRecord = false;
+        // Rails Persistence#_create_record yields here — after the INSERT and
+        // `@new_record = false`, before the after_create callbacks
+        // (persistence.rb:936-940). `changes_applied` runs above it, in
+        // AttributeMethods::Dirty#_create_record's `super` (dirty.rb:239-243),
+        // so the yield precedes it.
+        block?.(this);
         this.changesApplied();
         // Rails' block is `super`, whose truthy return becomes run_callbacks' value.
         return true;
@@ -358,7 +367,7 @@ export async function _createRecord(this: any): Promise<boolean> {
 }
 
 /** @internal */
-export async function _updateRecord(this: any): Promise<boolean> {
+export async function _updateRecord(this: any, block?: (record: any) => void): Promise<boolean> {
   // Rails: _run_update_callbacks { record_update_timestamps { super } }, whose
   // value is the block's return. As in _createRecord, Rails' `result != false`
   // (create_or_update, persistence.rb:895) is applied here to keep the
@@ -410,6 +419,10 @@ export async function _updateRecord(this: any): Promise<boolean> {
         this._pendingOperation = null;
       }
       this._previouslyNewRecord = false;
+      // Rails Persistence#_update_record yields here, after
+      // `@previously_new_record = false` and before the after_update callbacks
+      // (persistence.rb:912-916).
+      block?.(this);
       this.changesApplied();
       // Rails' block is `super`, whose truthy return becomes run_callbacks' value.
       return true;

--- a/packages/activerecord/src/callbacks.ts
+++ b/packages/activerecord/src/callbacks.ts
@@ -352,11 +352,8 @@ export async function _createRecord(this: any, block?: (record: any) => void): P
         }
         this._previouslyNewRecord = true;
         this._newRecord = false;
-        // Rails Persistence#_create_record yields here — after the INSERT and
-        // `@new_record = false`, before the after_create callbacks
-        // (persistence.rb:936-940). `changes_applied` runs above it, in
-        // AttributeMethods::Dirty#_create_record's `super` (dirty.rb:239-243),
-        // so the yield precedes it.
+        // Rails yields here (persistence.rb:936-940); `changes_applied` runs
+        // above it in Dirty#_create_record's `super` (dirty.rb:239-243).
         block?.(this);
         this.changesApplied();
         // Rails' block is `super`, whose truthy return becomes run_callbacks' value.
@@ -419,9 +416,7 @@ export async function _updateRecord(this: any, block?: (record: any) => void): P
         this._pendingOperation = null;
       }
       this._previouslyNewRecord = false;
-      // Rails Persistence#_update_record yields here, after
-      // `@previously_new_record = false` and before the after_update callbacks
-      // (persistence.rb:912-916).
+      // Rails yields here (persistence.rb:912-916).
       block?.(this);
       this.changesApplied();
       // Rails' block is `super`, whose truthy return becomes run_callbacks' value.

--- a/packages/activerecord/src/persistence-save-block.trails.test.ts
+++ b/packages/activerecord/src/persistence-save-block.trails.test.ts
@@ -114,4 +114,26 @@ describe("save block threading (trails)", () => {
 
     expect(seen).toEqual(["block", "after_create"]);
   });
+
+  // AC3: Rails' `@_was_loaded` guard. `concat_records` captures `loaded?` in the
+  // block it hands to `insert_record` (collection_association.rb:445), which
+  // `save` yields before the after_create callbacks (persistence.rb:940). A
+  // callback that loads the association therefore cannot make the capture read
+  // `true`, and `replace_on_target`'s `elsif @_was_loaded || !loaded?`
+  // (collection_association.rb:480) skips the append the load already made.
+  it("an after_create callback that loads the collection leaves no duplicate target entry", async () => {
+    const author = await Author.find(authors("david").id);
+
+    await resetCallbacks(Post, "create", async () => {
+      afterCreate(Post, async () => {
+        await author.posts.load();
+      });
+
+      const post = Post.new({ title: "dup", body: "check" });
+      await author.posts.push(post);
+
+      const target = await author.posts;
+      expect(target.filter((p) => p.id === post.id)).toHaveLength(1);
+    });
+  });
 });

--- a/packages/activerecord/src/persistence-save-block.trails.test.ts
+++ b/packages/activerecord/src/persistence-save-block.trails.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Trails-only: pins the `save(&block)` yield point.
+ *
+ * Rails threads the block from `save`/`save!` through `create_or_update` into
+ * `_create_record` / `_update_record`, which yield it after the write and
+ * *before* the after_create/after_update callbacks
+ * (persistence.rb:891-940). `CollectionAssociation#concat_records` depends on
+ * that exact moment to capture `@_was_loaded` before a callback can load the
+ * association (collection_association.rb:445). Rails covers the yield only
+ * indirectly, through the association behaviour it enables; these tests pin the
+ * plumbing itself because that is where the port had no block at all.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { registerModel } from "./index.js";
+import { fixtures } from "./test-fixtures.js";
+import { afterCreate, afterUpdate, resetCallbacks } from "./callbacks.js";
+import { Author } from "./test-helpers/models/author.js";
+import { Post } from "./test-helpers/models/post.js";
+
+interface CollectionAssociationLike {
+  insertRecord(
+    record: Post,
+    validate?: boolean,
+    raise?: boolean,
+    block?: (record: Post) => void,
+  ): Promise<boolean>;
+}
+
+const postsOf = (author: Author): CollectionAssociationLike =>
+  (author as unknown as { association(name: string): CollectionAssociationLike }).association(
+    "posts",
+  );
+
+describe("save block threading (trails)", () => {
+  const { authors } = fixtures(["authors", "posts"]);
+
+  beforeAll(() => {
+    registerModel(Author);
+    registerModel(Post);
+  });
+
+  it("save yields the block after the INSERT and before after_create", async () => {
+    const seen: string[] = [];
+    await resetCallbacks(Post, "create", async () => {
+      afterCreate(Post, () => {
+        seen.push("after_create");
+      });
+
+      const post = Post.new({ title: "yield", body: "after insert" });
+      const saved = await post.save({}, (record) => {
+        seen.push("block");
+        expect(record).toBe(post);
+        expect(record.isNewRecord()).toBe(false);
+        expect(record.id).not.toBeNull();
+      });
+
+      expect(saved).toBe(true);
+    });
+
+    expect(seen).toEqual(["block", "after_create"]);
+  });
+
+  it("save! yields the block after the INSERT and before after_create", async () => {
+    const seen: string[] = [];
+    await resetCallbacks(Post, "create", async () => {
+      afterCreate(Post, () => {
+        seen.push("after_create");
+      });
+
+      const post = Post.new({ title: "yield!", body: "after insert" });
+      await post.saveBang({}, () => {
+        seen.push("block");
+      });
+    });
+
+    expect(seen).toEqual(["block", "after_create"]);
+  });
+
+  it("save yields the block after the UPDATE and before after_update", async () => {
+    const seen: string[] = [];
+    const post = await Post.create({ title: "updatable", body: "body" });
+
+    await resetCallbacks(Post, "update", async () => {
+      afterUpdate(Post, () => {
+        seen.push("after_update");
+      });
+
+      post.title = "updated";
+      await post.save({}, (record) => {
+        seen.push("block");
+        expect(record).toBe(post);
+      });
+    });
+
+    expect(seen).toEqual(["block", "after_update"]);
+  });
+
+  it("insert_record hands its block to save, so it yields before after_create", async () => {
+    const seen: string[] = [];
+    const author = await Author.find(authors("david").id);
+
+    await resetCallbacks(Post, "create", async () => {
+      afterCreate(Post, () => {
+        seen.push("after_create");
+      });
+
+      const record = Post.new({ title: "insert_record", body: "block" });
+      const inserted = await postsOf(author).insertRecord(record, true, false, () => {
+        seen.push("block");
+      });
+
+      expect(inserted).toBe(true);
+    });
+
+    expect(seen).toEqual(["block", "after_create"]);
+  });
+});

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -695,6 +695,7 @@ interface SaveRecord {
 export async function save<T extends SaveRecord>(
   this: T,
   options?: { validate?: boolean; touch?: boolean },
+  block?: (record: T) => void,
 ): Promise<boolean | undefined> {
   // Mirrors ActiveRecord::Suppressor#save: a suppressed record returns `true`
   // immediately, before validations or the INSERT/UPDATE. This is why
@@ -779,7 +780,10 @@ export async function save<T extends SaveRecord>(
         }
       }
 
-      return self.createOrUpdate();
+      // Rails: `create_or_update(**options, &block)` — the block reaches
+      // `_create_record`/`_update_record`, which yield it after the write and
+      // before the after_create/after_update callbacks (persistence.rb:891-940).
+      return self.createOrUpdate(block);
     })) as boolean | undefined;
   } catch (e) {
     // Mirrors Rails' `rescue ActiveRecord::RecordInvalid` in save — autosave
@@ -795,10 +799,17 @@ export async function save<T extends SaveRecord>(
 /** Mirrors: ActiveRecord::Base#save! — `create_or_update(**options) || raise`. */
 export async function saveBang<
   T extends SaveRecord & {
-    save(o?: { validate?: boolean; touch?: boolean }): Promise<boolean | undefined>;
+    save(
+      o?: { validate?: boolean; touch?: boolean },
+      block?: (record: T) => void,
+    ): Promise<boolean | undefined>;
   },
->(this: T, options?: { validate?: boolean; touch?: boolean }): Promise<true | undefined> {
-  const result = await this.save(options);
+>(
+  this: T,
+  options?: { validate?: boolean; touch?: boolean },
+  block?: (record: T) => void,
+): Promise<true | undefined> {
+  const result = await this.save(options, block);
   if (result === false) {
     // Mirrors Rails' two save! layers: ActiveRecord::Validations#save! raises
     // RecordInvalid when validations failed (errors present); otherwise

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -780,9 +780,7 @@ export async function save<T extends SaveRecord>(
         }
       }
 
-      // Rails: `create_or_update(**options, &block)` — the block reaches
-      // `_create_record`/`_update_record`, which yield it after the write and
-      // before the after_create/after_update callbacks (persistence.rb:891-940).
+      // Rails: `create_or_update(**options, &block)` (persistence.rb:390-408).
       return self.createOrUpdate(block);
     })) as boolean | undefined;
   } catch (e) {

--- a/packages/activerecord/src/timestamp.ts
+++ b/packages/activerecord/src/timestamp.ts
@@ -280,7 +280,7 @@ interface TimestampHost {
 /** Minimal instance-side surface used by Timestamp private/internal helpers. */
 interface TimestampInstanceHost {
   _touchRecord: boolean | null;
-  _createOrUpdate: () => Promise<boolean>;
+  _createOrUpdate: (block?: (record: unknown) => void) => Promise<boolean>;
   readAttribute?(name: string): unknown;
   _readAttribute?(name: string): unknown;
   _writeAttribute?(name: string, val: unknown): void;
@@ -466,9 +466,13 @@ export async function _updateRecord(this: TimestampInstanceHost): Promise<boolea
 }
 
 /** @internal */
-export function createOrUpdate(this: TimestampInstanceHost, touch = true): Promise<boolean> {
+export function createOrUpdate(
+  this: TimestampInstanceHost,
+  touch = true,
+  block?: (record: unknown) => void,
+): Promise<boolean> {
   this._touchRecord = touch;
-  return this._createOrUpdate.call(this);
+  return this._createOrUpdate.call(this, block);
 }
 
 /** @internal */


### PR DESCRIPTION
Rails' `save`/`save!` take a trailing block and pass it to `create_or_update`,
which hands it to `_create_record`/`_update_record`
(`activerecord/lib/active_record/persistence.rb:390,423,891-895`). Those yield
it after the write and after `@new_record = false` / `@previously_new_record =
false`, and **before** the after_create/after_update callbacks
(`persistence.rb:920-940`, `:900-916`). `CollectionAssociation#insert_record`
passes `&block` straight into `record.save!(&block)` / `record.save(&block)`
(`collection_association.rb:377-383`), and that yield point is what lets
`concat_records` / `_create_record` capture `@_was_loaded = loaded?` before an
after_create callback can load the association
(`collection_association.rb:366,445,480`).

trails' save stack took no block at all. This threads it through:

- `Persistence#save` / `#save!` take the trailing block and forward it to
  `createOrUpdate` (`persistence.ts`).
- `Callbacks#create_or_update` → `Base#_createOrUpdate` →
  `_createRecord`/`_updateRecord` forward it (`callbacks.ts`, `base.ts`), and
  `Timestamp#create_or_update` forwards it past its `touch:` kwarg
  (`timestamp.ts`).
- `Callbacks#_create_record` yields it inside the innermost `super` body — after
  the INSERT and `@new_record = false`, before `changes_applied` (which lives
  above it in `AttributeMethods::Dirty#_create_record`, `dirty.rb:239-243`) and
  before the after_create callbacks. `_update_record` yields at the matching
  spot after `@previously_new_record = false`.
- `CollectionAssociation#insertRecord` is converged onto Rails' plain
  `if raise … save!(…, &block) else save(…, &block)`
  (`collection_association.rb:377-383`): the `typeof saveBang === "function"`
  guard, the unconditional `return true` from the raise arm, and the
  optional-call `save?.` are defensive control flow Rails does not have — and
  the `return true` swallowed a nil `save!` (rollback) that Rails propagates as
  a falsey `insert_record` result. (and the `HasMany` /
  `HasManyThrough` overrides, which forward it the way Ruby's `super` forwards a
  block) pass it to `save`/`saveBang` rather than invoking it themselves.

Since the block reaches the save stack, the counter-cache increments
(`CounterCache#_create_record`, `counter_cache.rb:200`) still run after the
yield, as in Rails.

### Coverage

`persistence-save-block.trails.test.ts` pins the yield point: `save`, `save!`
and the update path each yield before their after_create/after_update
callbacks, and `insert_record` hands its block down to `save` rather than
calling it after the fact. All four fail on baseline (the block argument was
simply ignored).

### Acceptance criterion 3 — now delivered (#6401 merged)

AC3 was blocked while #6401 was open; it merged, so this PR now carries the
composition and the regression test.

#6401 supplies `_wasLoaded` and `concat_records`' capture block plus
`replace_on_target`'s `elsif @_was_loaded || !loaded?`
(`collection_association.rb:480`); this PR delivers the yield point that makes
the capture run *before* the after_create callbacks (`persistence.rb:940`).
Neither half fixes the duplicate append alone — measured on both branches
separately, the target ended up holding the record twice.

The test pins the composition and is a true regression for this PR's change:
with the block invoked after the save (the pre-plumbing placement) it fails
with `expected [ …(2) ] to have a length of 1 but got 2`; at Rails' yield point
it passes.

Two traps worth knowing if you re-derive this: the association must start
unloaded (a prior `toArray()` lets `finishReplaceOnTarget`'s `Core#==` re-index
mask the duplicate), and the callback must `await` the load.

### Adjacent drift, filed not propagated

Review flagged that `HasManyAssociation#insertRecord` (untouched shape, but a
method this PR adds a parameter to) still does not match
`has_many_association.rb:61-64`, which is just `set_owner_attributes(record);
super`. trails never delegates to `super.insertRecord`, calls `save` regardless
of `raise` instead of taking `CollectionAssociation#insert_record`'s `save!`
arm, and folds `updateCounterIfSuccess` into `insert_record` rather than into
`concat_records` / `_create_record` (`has_many_association.rb:139-149`).
The raise-arm half of that drift lives in `CollectionAssociation#insertRecord`
and is converged above. The rest — `super` delegation, and moving the counter
bump — spans three methods, so it is filed as
`0084-wide-call-set-burndown/stories/converge-has-many-insert-record-to-super.md`
rather than absorbed here — the shape is not copied or extended by this diff.

This PR now implements the follow-up story that was filed for AC3 while #6401
was open, so it closes that one too rather than leaving already-done work
claimable. Rails has no test naming `@_was_loaded` (it covers the shape
indirectly), so the coverage is trails-only, as that story's third criterion
directs.

Closes-story: plumb-save-block-through-create-record
Closes-story: was-loaded-duplicate-append-regression
