### PR TITLE
refactor(activerecord): converge receiver-as-first-argument helper call sites

### DIFF
--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -980,12 +980,11 @@ export function addAutosaveAssociationCallbacks(model: any, reflection: any): vo
 
 /** @internal */
 export function defineAutosaveValidationCallbacks(this: any, reflection: any): void {
-  const klass = this;
   if (!reflection.validate) return;
   const validationName = `validateAssociatedRecordsFor_${reflection.name}`;
-  if (!klass.prototype) return;
+  if (!this.prototype) return;
   // Mirrors method_defined?(name, false) — only skip if defined on this exact class.
-  if (Object.prototype.hasOwnProperty.call(klass.prototype, validationName)) return;
+  if (Object.prototype.hasOwnProperty.call(this.prototype, validationName)) return;
   const isCol =
     typeof reflection.isCollection === "function"
       ? reflection.isCollection()
@@ -993,15 +992,15 @@ export function defineAutosaveValidationCallbacks(this: any, reflection: any): v
   const isHasOne =
     typeof reflection.hasOne === "function" ? reflection.hasOne() : !!reflection.hasOne;
   if (isCol) {
-    defineNonCyclicMethod.call(klass, validationName, function (this: any) {
+    defineNonCyclicMethod.call(this, validationName, function (this: any) {
       return validateCollectionAssociation.call(this, reflection);
     });
   } else if (isHasOne) {
-    defineNonCyclicMethod.call(klass, validationName, function (this: any) {
+    defineNonCyclicMethod.call(this, validationName, function (this: any) {
       return validateHasOneAssociation.call(this, reflection);
     });
   } else {
-    defineNonCyclicMethod.call(klass, validationName, function (this: any) {
+    defineNonCyclicMethod.call(this, validationName, function (this: any) {
       return validateBelongsToAssociation.call(this, reflection);
     });
   }
@@ -1010,8 +1009,8 @@ export function defineAutosaveValidationCallbacks(this: any, reflection: any): v
   // Cycle-breaking is handled per-record by `defineNonCyclicMethod`'s
   // `_alreadyCalled` guard, so co-recursive owner/child chains terminate
   // even though each validator runs independently.
-  if (typeof klass.validate === "function") {
-    klass.validate(validationName);
+  if (typeof this.validate === "function") {
+    this.validate(validationName);
   }
-  klass.afterValidation(":_ensureNoDuplicateErrors");
+  this.afterValidation(":_ensureNoDuplicateErrors");
 }

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -840,7 +840,8 @@ export function _ensureNoDuplicateErrors(this: AutosaveAssociationHost): void {
 }
 
 /** @internal */
-export function defineNonCyclicMethod(klass: any, name: string, fn: (this: any) => any): void {
+export function defineNonCyclicMethod(this: any, name: string, fn: (this: any) => any): void {
+  const klass = this;
   if (!klass.prototype) return;
   // Mirrors Ruby method_defined?(name, false) — check only the immediate class prototype.
   if (Object.prototype.hasOwnProperty.call(klass.prototype, name)) return;
@@ -913,7 +914,7 @@ export function addAutosaveAssociationCallbacks(model: any, reflection: any): vo
 
   if (isCollection) {
     model.aroundSave(":aroundSaveCollectionAssociation");
-    defineNonCyclicMethod(model, saveMethod, async function (this: any) {
+    defineNonCyclicMethod.call(model, saveMethod, async function (this: any) {
       return saveCollectionAssociation.call(this, reflection);
     });
     // Mirrors Rails: save_collection_association runs for every collection
@@ -938,7 +939,7 @@ export function addAutosaveAssociationCallbacks(model: any, reflection: any): vo
       await record[saveMethod]();
     });
   } else if (isHasOne) {
-    defineNonCyclicMethod(model, saveMethod, async function (this: any) {
+    defineNonCyclicMethod.call(model, saveMethod, async function (this: any) {
       return saveHasOneAssociation.call(this, reflection);
     });
     // Mirrors Rails: `save_has_one_association` is registered for after_create
@@ -957,7 +958,7 @@ export function addAutosaveAssociationCallbacks(model: any, reflection: any): vo
     });
   } else {
     // belongs_to
-    defineNonCyclicMethod(model, saveMethod, function (this: any) {
+    defineNonCyclicMethod.call(model, saveMethod, function (this: any) {
       return saveBelongsToAssociation.call(this, reflection);
     });
     beforeSave(
@@ -974,11 +975,12 @@ export function addAutosaveAssociationCallbacks(model: any, reflection: any): vo
     );
   }
 
-  defineAutosaveValidationCallbacks(model, reflection);
+  defineAutosaveValidationCallbacks.call(model, reflection);
 }
 
 /** @internal */
-export function defineAutosaveValidationCallbacks(klass: any, reflection: any): void {
+export function defineAutosaveValidationCallbacks(this: any, reflection: any): void {
+  const klass = this;
   if (!reflection.validate) return;
   const validationName = `validateAssociatedRecordsFor_${reflection.name}`;
   if (!klass.prototype) return;
@@ -991,15 +993,15 @@ export function defineAutosaveValidationCallbacks(klass: any, reflection: any): 
   const isHasOne =
     typeof reflection.hasOne === "function" ? reflection.hasOne() : !!reflection.hasOne;
   if (isCol) {
-    defineNonCyclicMethod(klass, validationName, function (this: any) {
+    defineNonCyclicMethod.call(klass, validationName, function (this: any) {
       return validateCollectionAssociation.call(this, reflection);
     });
   } else if (isHasOne) {
-    defineNonCyclicMethod(klass, validationName, function (this: any) {
+    defineNonCyclicMethod.call(klass, validationName, function (this: any) {
       return validateHasOneAssociation.call(this, reflection);
     });
   } else {
-    defineNonCyclicMethod(klass, validationName, function (this: any) {
+    defineNonCyclicMethod.call(klass, validationName, function (this: any) {
       return validateBelongsToAssociation.call(this, reflection);
     });
   }

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -32,6 +32,7 @@ import {
   encryptAttribute,
   encryptedAttribute,
   encryptedTypeOf,
+  validateColumnSize,
 } from "./encryption/encryptable-record.js";
 import { Configurable } from "./encryption/configurable.js";
 import { Contexts } from "./encryption/contexts.js";
@@ -117,7 +118,7 @@ export function applyPendingEncryptions(klass: any): void {
   // registering the same LengthValidator twice.
   if (Configurable.config.validateColumnSize) {
     for (const { name } of pending) {
-      EncryptableRecord.validateColumnSize(klass, name);
+      validateColumnSize.call(klass, name);
     }
   }
 

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -73,23 +73,6 @@ const NOT_CACHED = Symbol("encryption.columnDefault.notCached");
  *   EncryptableRecord.encrypts(User, "email", { deterministic: true })
  */
 export class EncryptableRecord {
-  /** @internal */
-  static validateColumnSize(modelClass: any, attribute: string): void {
-    if (typeof modelClass.validatesLengthOf !== "function") return;
-    const limit = modelClass._attributeDefinitions?.get(attribute)?.limit;
-    if (limit == null) return;
-    // Guard against double registration (called at encrypts() time and again
-    // after schema reflection). Check whether a LengthValidator with this
-    // exact maximum already exists for the attribute.
-    const existing: unknown[] = modelClass._validators?.get(attribute) ?? [];
-    const alreadyRegistered = existing.some(
-      (v: unknown) => v instanceof LengthValidator && (v as any).options?.maximum === limit,
-    );
-    if (!alreadyRegistered) {
-      modelClass.validatesLengthOf(attribute, { maximum: limit });
-    }
-  }
-
   /**
    * `class_attribute :encrypted_attributes` (encryptable_record.rb:11) also
    * generates the predicate, whose body is `!!encrypted_attributes` — true once
@@ -348,7 +331,7 @@ export class EncryptableRecord {
   static addLengthValidationForEncryptedColumns(modelClass: any): void {
     const attrs: Set<string> = modelClass._encryptedAttributes ?? new Set<string>();
     for (const name of attrs) {
-      this.validateColumnSize(modelClass, name);
+      validateColumnSize.call(modelClass, name);
     }
   }
 
@@ -379,6 +362,28 @@ export class EncryptableRecord {
         record.errors?.add?.(attr, "can't be modified because it is encrypted");
       }
     }
+  }
+}
+
+/**
+ * Mirrors: ...EncryptableRecord::ClassMethods#validate_column_size
+ * (encryptable_record.rb:138-142). `this` is the model class.
+ *
+ * @internal
+ */
+export function validateColumnSize(this: any, attributeName: string): void {
+  if (typeof this.validatesLengthOf !== "function") return;
+  const limit = this._attributeDefinitions?.get(attributeName)?.limit;
+  if (limit == null) return;
+  // Guard against double registration (called at encrypts() time and again
+  // after schema reflection). Check whether a LengthValidator with this
+  // exact maximum already exists for the attribute.
+  const existing: unknown[] = this._validators?.get(attributeName) ?? [];
+  const alreadyRegistered = existing.some(
+    (v: unknown) => v instanceof LengthValidator && (v as any).options?.maximum === limit,
+  );
+  if (!alreadyRegistered) {
+    this.validatesLengthOf(attributeName, { maximum: limit });
   }
 }
 
@@ -617,7 +622,7 @@ export function encryptAttribute(this: any, name: string, options: SchemeOptions
   }
 
   if (Configurable.config.validateColumnSize) {
-    EncryptableRecord.validateColumnSize(this, name);
+    validateColumnSize.call(this, name);
   }
 
   // Mirrors Rails encryptable_record.rb:94 —

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -137,7 +137,7 @@ export function acceptsNestedAttributesFor(
     // (not just the `_associations` entry the save path reads) so
     // `reflection.validate?` sees it and the validation callback is wired.
     reflection.autosave = true;
-    defineAutosaveValidationCallbacks(modelClass, reflection);
+    defineAutosaveValidationCallbacks.call(modelClass, reflection);
   }
 
   // Rails does NOT reject polymorphic belongs_to at declaration time — the
@@ -433,45 +433,43 @@ export function hasDestroyFlag(hash: Record<string, unknown>): boolean {
 }
 
 /** @internal */
-export function isAllowDestroy(record: Base, associationName: string): boolean {
-  const configs: NestedAttributeConfig[] =
-    (record.constructor as any)._nestedAttributeConfigs ?? [];
+export function isAllowDestroy(this: Base, associationName: string): boolean {
+  const configs: NestedAttributeConfig[] = (this.constructor as any)._nestedAttributeConfigs ?? [];
   return configs.find((c) => c.associationName === associationName)?.options.allowDestroy ?? false;
 }
 
 /** @internal */
 export function isWillBeDestroyed(
-  record: Base,
+  this: Base,
   associationName: string,
   attributes: Record<string, unknown>,
 ): boolean {
-  return isAllowDestroy(record, associationName) && hasDestroyFlag(attributes);
+  return isAllowDestroy.call(this, associationName) && hasDestroyFlag(attributes);
 }
 
 /** @internal */
 export function callRejectIf(
-  record: Base,
+  this: Base,
   associationName: string,
   attributes: Record<string, unknown>,
 ): boolean {
-  if (isWillBeDestroyed(record, associationName, attributes)) return false;
-  const configs: NestedAttributeConfig[] =
-    (record.constructor as any)._nestedAttributeConfigs ?? [];
+  if (isWillBeDestroyed.call(this, associationName, attributes)) return false;
+  const configs: NestedAttributeConfig[] = (this.constructor as any)._nestedAttributeConfigs ?? [];
   const rejectIf = configs.find((c) => c.associationName === associationName)?.options.rejectIf;
   // `"all_blank"` is resolved to a proc in acceptsNestedAttributesFor, so a
   // stored rejectIf is always a function here.
-  return typeof rejectIf === "function" ? rejectIf(attributes, record) : false;
+  return typeof rejectIf === "function" ? rejectIf(attributes, this) : false;
 }
 
 /** @internal */
 export function isRejectNewRecord(
-  record: Base,
+  this: Base,
   associationName: string,
   attributes: Record<string, unknown>,
 ): boolean {
   return (
-    isWillBeDestroyed(record, associationName, attributes) ||
-    callRejectIf(record, associationName, attributes)
+    isWillBeDestroyed.call(this, associationName, attributes) ||
+    callRejectIf.call(this, associationName, attributes)
   );
 }
 
@@ -836,7 +834,7 @@ export function assignNestedAttributesForOneToOneAssociation(
     existing &&
     (updateOnly || String(existing.id) === String((attributes as any).id))
   ) {
-    if (!callRejectIf(record, associationName, attributes)) {
+    if (!callRejectIf.call(record, associationName, attributes)) {
       return assignToOrMarkForDestruction(existing, attributes, options.allowDestroy ?? false);
     }
     return;
@@ -848,7 +846,7 @@ export function assignNestedAttributesForOneToOneAssociation(
   }
 
   // Rails nested_attributes.rb:443 — build a new record (no matching id).
-  if (!isRejectNewRecord(record, associationName, attributes)) {
+  if (!isRejectNewRecord.call(record, associationName, attributes)) {
     const assignable = assignableNestedAttributes(attributes);
     const targetModel = resolveCollectionTargetModel(record, associationName);
     if (targetModel) assertNestedAttributesAreKnown(targetModel, assignable);
@@ -1017,7 +1015,7 @@ export function assignNestedAttributesForCollectionAssociation(
   let pending: Promise<void> | undefined;
   for (const a of attrs) {
     if (!hasNestedId(a)) {
-      if (!isRejectNewRecord(record, associationName, a)) {
+      if (!isRejectNewRecord.call(record, associationName, a)) {
         const assignable = assignableNestedAttributes(a);
         if (collectionTargetModel)
           assertNestedAttributesAreKnown(collectionTargetModel, assignable);
@@ -1029,7 +1027,7 @@ export function assignNestedAttributesForCollectionAssociation(
       const existing = populateInMemoryExistingRecord(record, associationName, a);
       nestedTarget.push(existing);
       if (existing) {
-        const allowDestroy = isAllowDestroy(record, associationName);
+        const allowDestroy = isAllowDestroy.call(record, associationName);
         pending = (
           pending
             ? pending.then(() => assignToOrMarkForDestruction(existing, a, allowDestroy))
@@ -1119,7 +1117,7 @@ function populateInMemoryExistingRecord(
   // rejected existing record never enters `@target`. Defer the stub's
   // `add_to_target` until after the reject check to avoid leaving a partial
   // (PK-only) stub in the in-memory collection.
-  if (callRejectIf(record, associationName, attrs)) return null;
+  if (callRejectIf.call(record, associationName, attrs)) return null;
   if (isNewStub) (proxy as any).addExistingRecord(existing);
   return existing ?? null;
 }

--- a/packages/activerecord/src/scoping/default.ts
+++ b/packages/activerecord/src/scoping/default.ts
@@ -55,7 +55,7 @@ export class Default {
     // installed as the current scope (`relation.scoping { default_scope }`).
     const override = modelClass.defaultScopeOverride ? defaultScopeOverride(modelClass) : undefined;
     if (override) {
-      return evaluateDefaultScope(modelClass, () => {
+      return evaluateDefaultScope.call(modelClass, () => {
         const base = buildRelation();
         const prev = ScopeRegistry.currentScope(modelClass);
         modelClass.setCurrentScope(base);
@@ -73,7 +73,7 @@ export class Default {
     const scopes: DefaultScope[] = modelClass.defaultScopes ?? [];
     if (scopes.length === 0) return undefined;
 
-    return evaluateDefaultScope(modelClass, () => {
+    return evaluateDefaultScope.call(modelClass, () => {
       let rel = buildRelation();
       for (const scopeObj of scopes) {
         if (isExecuteScope(allQueries, scopeObj)) {
@@ -238,32 +238,39 @@ function isExecuteScope(
   return allQueries == null || (!!allQueries && defaultScopeObj.allQueries);
 }
 
-/** @internal */
-function isIgnoreDefaultScope(modelClass: any): boolean {
-  return !!ScopeRegistry.ignoreDefaultScope(modelClass, true);
+/**
+ * Mirrors: Scoping::Default::ClassMethods#ignore_default_scope?
+ * (default.rb:181-183) — keyed off `base_class`, so an STI subtree shares the
+ * one recursion guard, and WITHOUT `skip_inherited_scope`.
+ * @internal
+ */
+function isIgnoreDefaultScope(this: any): boolean {
+  return !!ScopeRegistry.ignoreDefaultScope(this.baseClass);
 }
 
-/** @internal */
-function setIgnoreDefaultScope(baseClass: any, ignore: boolean | null): void {
-  ScopeRegistry.setIgnoreDefaultScope(baseClass, ignore);
+/**
+ * Mirrors: Scoping::Default::ClassMethods#ignore_default_scope=
+ * (default.rb:185-187).
+ * @internal
+ */
+function setIgnoreDefaultScope(this: any, ignore: boolean | null): void {
+  ScopeRegistry.setIgnoreDefaultScope(this.baseClass, ignore);
 }
 
 /**
  * Mirrors: Scoping::Default#evaluate_default_scope. Temporarily sets
  * ignore_default_scope to true while yielding so nested calls don't re-apply
  * the default scope recursively. Returns undefined when already ignoring
- * (matches Rails' nil return from evaluate_default_scope). Saves and restores
- * the prior ScopeRegistry value so nested calls from different classes compose
- * correctly.
+ * (matches Rails' nil return from evaluate_default_scope, default.rb:192-201).
  * @internal
  */
-function evaluateDefaultScope(modelClass: any, fn: () => unknown): unknown {
-  if (isIgnoreDefaultScope(modelClass)) return undefined;
-  const prior = ScopeRegistry.ignoreDefaultScope(modelClass, true);
+function evaluateDefaultScope(this: any, fn: () => unknown): unknown {
+  if (isIgnoreDefaultScope.call(this)) return undefined;
+
   try {
-    setIgnoreDefaultScope(modelClass, true);
+    setIgnoreDefaultScope.call(this, true);
     return fn();
   } finally {
-    setIgnoreDefaultScope(modelClass, prior);
+    setIgnoreDefaultScope.call(this, false);
   }
 }

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/autosave-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/autosave-association.json
@@ -2,20 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "autosave-association.ts",
-    "rubyName": "changed_for_autosave?",
-    "call": "marked_for_destruction?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "autosave-association.ts",
-    "rubyName": "define_autosave_validation_callbacks",
-    "call": "order:validate,defineNonCyclicMethod",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "autosave-association.ts",
     "rubyName": "define_non_cyclic_method",
     "call": "define_method",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/autosave-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/autosave-association.json
@@ -2,35 +2,16 @@
   {
     "package": "activerecord",
     "tsFile": "autosave-association.ts",
-    "rubyName": "add_autosave_association_callbacks",
-    "call": "define_autosave_validation_callbacks",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:reflection"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "autosave-association.ts",
-    "rubyName": "add_autosave_association_callbacks",
-    "call": "define_non_cyclic_method",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:saveMethod"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "rubyName": "changed_for_autosave?",
+    "call": "marked_for_destruction?",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "autosave-association.ts",
     "rubyName": "define_autosave_validation_callbacks",
-    "call": "define_non_cyclic_method",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:validationMethod"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "call": "order:validate,defineNonCyclicMethod",
+    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/encryptable-record.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/encryptable-record.json
@@ -9,17 +9,6 @@
   {
     "package": "activerecord",
     "tsFile": "encryption/encryptable-record.ts",
-    "rubyName": "add_length_validation_for_encrypted_columns",
-    "call": "validate_column_size",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:attributeName"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "encryption/encryptable-record.ts",
     "rubyName": "ciphertext_for",
     "call": "read_attribute_for_database",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/nested-attributes.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/nested-attributes.json
@@ -3,17 +3,6 @@
     "package": "activerecord",
     "tsFile": "nested-attributes.ts",
     "rubyName": "accepts_nested_attributes_for",
-    "call": "define_autosave_validation_callbacks",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:reflection"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "nested-attributes.ts",
-    "rubyName": "accepts_nested_attributes_for",
     "call": "generate_association_writer",
     "kind": "args",
     "rubyArgs": [
@@ -40,18 +29,6 @@
     "package": "activerecord",
     "tsFile": "nested-attributes.ts",
     "rubyName": "assign_nested_attributes_for_collection_association",
-    "call": "reject_new_record?",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:associationName",
-      "ref:attributes"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "nested-attributes.ts",
-    "rubyName": "assign_nested_attributes_for_collection_association",
     "call": "where",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -59,44 +36,8 @@
     "package": "activerecord",
     "tsFile": "nested-attributes.ts",
     "rubyName": "assign_nested_attributes_for_one_to_one_association",
-    "call": "call_reject_if",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:associationName",
-      "ref:attributes"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "nested-attributes.ts",
-    "rubyName": "assign_nested_attributes_for_one_to_one_association",
     "call": "order:association,callRejectIf",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "nested-attributes.ts",
-    "rubyName": "assign_nested_attributes_for_one_to_one_association",
-    "call": "reject_new_record?",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:associationName",
-      "ref:attributes"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "nested-attributes.ts",
-    "rubyName": "call_reject_if",
-    "call": "will_be_destroyed?",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:associationName",
-      "ref:attributes"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -118,40 +59,5 @@
     "rubyName": "raise_nested_attributes_record_not_found!",
     "call": "order:constructor,id",
     "reason": "Order artifact of a TS-only class reach: `record.constructor` (nested-attributes.ts:515) is credited as `constructor` before `record.id`, where Rails evaluates the id interpolation before RecordNotFound.new."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "nested-attributes.ts",
-    "rubyName": "reject_new_record?",
-    "call": "call_reject_if",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:associationName",
-      "ref:attributes"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "nested-attributes.ts",
-    "rubyName": "reject_new_record?",
-    "call": "will_be_destroyed?",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:associationName",
-      "ref:attributes"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "nested-attributes.ts",
-    "rubyName": "will_be_destroyed?",
-    "call": "allow_destroy?",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:associationName"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/scoping/default.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/scoping/default.json
@@ -25,35 +25,6 @@
   {
     "package": "activerecord",
     "tsFile": "scoping/default.ts",
-    "rubyName": "build_default_scope",
-    "call": "evaluate_default_scope",
-    "kind": "args",
-    "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "scoping/default.ts",
-    "rubyName": "evaluate_default_scope",
-    "call": "ignore_default_scope?",
-    "kind": "args",
-    "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "scoping/default.ts",
-    "rubyName": "ignore_default_scope?",
-    "call": "ignore_default_scope",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:baseClass"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "scoping/default.ts",
     "rubyName": "scope_attributes?",
     "call": "any?",
     "reason": "Ruby Array#any? has no ported counterpart: `default_scopes.any?` (scoping/default.rb:56) ports to the `defaultScopes.length` check in isScopeAttributes."


### PR DESCRIPTION
Continues RFC 0099 bucket (a) (`call-args-ar-extra-argument-rest`). Rails passes
no receiver argument to these bodies — the receiver is `self`. The port carried
it as parameter 1, so `parity:api:calls:args` flagged 15 sites.

Each helper becomes a `this`-typed function (CLAUDE.md "Module mixins") and is
dispatched through `.call(receiver, …)`, so its parameter list is now exactly
the Rails one:

| file | Rails methods | rows |
| --- | --- | --- |
| `nested-attributes.ts` | `allow_destroy?`, `will_be_destroyed?`, `call_reject_if`, `reject_new_record?` (`nested_attributes.rb:598-616`) | 8 |
| `autosave-association.ts` | `define_non_cyclic_method`, `define_autosave_validation_callbacks` (`autosave_association.rb:200-231`) | 3 |
| `scoping/default.ts` | `ignore_default_scope?`, `ignore_default_scope=`, `evaluate_default_scope` (`default.rb:181-201`) | 3 |
| `encryption/encryptable-record.ts` | `validate_column_size` (`encryptable_record.rb:138-142`) | 1 |

The `scoping/default.ts` conversion also carries the behavioural converge Rails
specifies and the port had drifted from: the recursion guard is keyed off
`base_class` with **no** `skip_inherited_scope` (`default.rb:181-187`, so an STI
subtree shares one guard as in Rails), and the `ensure` arm restores `false`
(`default.rb:192-201`) rather than the previously-read value. The prior value is
always falsy at that point — `evaluate_default_scope` returns early when the
flag is set — so the two are equivalent; Rails' spelling wins.

The 15 now-stale `kind: "args"` baseline rows are deleted by hand (only-shrink,
no `--write`). Baseline goes 357 → 342 shape rows.

The remaining rows from the story (alias-tracker / reflection / database-tasks
constructors, `inheritance.ts`, `store.ts`, `relation/calculations.ts`,
`collection-association.ts`, `association-scope.ts`, `join-dependency.ts`,
`connection-pool.ts`, `through-association.ts`) each need a structural change of
their own and are filed as `call-args-ar-extra-argument-rest-2`.

Review also flagged that `nested-attributes.ts` declares these four helpers in
the reverse of Rails' order (`nested_attributes.rb:589/598/610/614`). That
predates this PR and this diff does not touch member order, so it is filed as
`nested-attributes-reject-helper-member-order` (RFC 0023) rather than mixed in
here.

Verified: `pnpm parity:api:calls:args` OK (342 baselined), `pnpm parity:api:calls`
OK, `pnpm typecheck`, `pnpm lint`, and the nested-attributes / autosave /
encryption / scoping suites (1000+ tests) green.

Closes-story: call-args-ar-extra-argument-rest
