### PR TITLE
refactor(activerecord): converge HasManyAssociation#insertRecord to set owner attributes + super

### DIFF
--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -448,9 +448,13 @@ export class CollectionAssociation extends Association {
     throw new Error("intersection is implemented by CollectionAssociation subclasses");
   }
 
-  /** @internal */
+  /**
+   * Mirrors: ActiveRecord::Associations::CollectionAssociation#insert_record
+   * (collection_association.rb:377-383) — `raise` picks `save!`, which raises
+   * from inside the save, over `save`, which returns false.
+   * @internal
+   */
   async insertRecord(record: Base, validate = true, raise = false): Promise<boolean> {
-    this.setOwnerAttributes(record);
     if (raise && typeof (record as any).saveBang === "function") {
       await (record as any).saveBang({ validate });
       return true;

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -25,7 +25,6 @@ import {
   routeThroughCheckValidity,
 } from "./validate-through-reflection.js";
 import { CompositePrimaryKeyMismatchError, DeleteRestrictionError } from "./errors.js";
-import { RecordInvalid } from "../validations.js";
 import { CollectionAssociation, includesRecord } from "./collection-association.js";
 import { ForeignAssociation, ownerForeignKeyColumns } from "./foreign-association.js";
 import { compositeQueryConstraintsList } from "../persistence.js";
@@ -50,7 +49,7 @@ export class HasManyAssociation extends CollectionAssociation {
    */
   declare updateCounterInMemory: (difference: number) => void;
   /** @internal */
-  declare updateCounterIfSuccess: (savedSuccessfully: boolean, difference: number) => boolean;
+  declare updateCounterIfSuccess: <T>(savedSuccessfully: T, difference: number) => T;
 
   /**
    * Set on an ad-hoc holder built by a CollectionProxy whose own Relation state
@@ -150,20 +149,14 @@ export class HasManyAssociation extends CollectionAssociation {
   }
 
   /**
-   * Insert a record into the collection. Sets the FK and type
-   * columns on the record to point to the owner, then saves.
-   * Rails: if raise is true, uses save! (raises on failure);
-   * otherwise uses save (returns boolean).
+   * Mirrors: ActiveRecord::Associations::HasManyAssociation#insert_record
+   * (has_many_association.rb:61-64) — point the record's FK/type columns at the
+   * owner, then delegate to `CollectionAssociation#insert_record`, which picks
+   * the `save!` / `save` arm from `raise`.
    */
-  async insertRecord(record: Base, validate = true, raise = false): Promise<boolean> {
+  override async insertRecord(record: Base, validate = true, raise = false): Promise<boolean> {
     this.setOwnerAttributes(record);
-    let saved = false;
-    if (typeof (record as any).save === "function") {
-      saved = !!(await (record as any).save({ validate }));
-      if (!saved && raise) throw new RecordInvalid(record);
-    }
-    // Rails: update_counter_if_success(super, 1) — sync counter on successful insert
-    return this.updateCounterIfSuccess(saved, 1);
+    return super.insertRecord(record, validate, raise);
   }
 
   /**
@@ -270,6 +263,37 @@ export class HasManyAssociation extends CollectionAssociation {
     const count = await deleteCount(this, strategy, scope);
     if (count > 0) await updateCounter(this, -count);
     return count;
+  }
+
+  /**
+   * Mirrors: ActiveRecord::Associations::HasManyAssociation#concat_records
+   * (has_many_association.rb:139-141) — `update_counter_if_success(super,
+   * records.length)`.
+   * @internal
+   */
+  protected override async concatRecords(records: Base[], raise = false): Promise<Base[]> {
+    return this.updateCounterIfSuccess(await super.concatRecords(records, raise), records.length);
+  }
+
+  /**
+   * Mirrors: ActiveRecord::Associations::HasManyAssociation#_create_record
+   * (has_many_association.rb:143-149) — the array arm creates each record
+   * through `super` (which bumps the counter per record), the scalar arm bumps
+   * by one.
+   * @internal
+   */
+  protected override async _createRecord(
+    attributes?: Record<string, unknown>,
+    shouldRaise = false,
+    block?: (record: Base) => void,
+  ): Promise<Base | null> {
+    if (Array.isArray(attributes)) {
+      return super._createRecord(attributes, shouldRaise, block);
+    }
+    return this.updateCounterIfSuccess(
+      await super._createRecord(attributes, shouldRaise, block),
+      1,
+    );
   }
 
   /**
@@ -429,11 +453,11 @@ function scopeForRecords(scope: any, queryConstraints: string[], records: Base[]
 }
 
 /** @internal */
-function updateCounterIfSuccess(
+function updateCounterIfSuccess<T>(
   this: HasManyAssociation,
-  savedSuccessfully: boolean,
+  savedSuccessfully: T,
   difference: number,
-): boolean {
+): T {
   if (savedSuccessfully) this.updateCounterInMemory(difference);
   return savedSuccessfully;
 }

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -277,9 +277,11 @@ export class HasManyAssociation extends CollectionAssociation {
 
   /**
    * Mirrors: ActiveRecord::Associations::HasManyAssociation#_create_record
-   * (has_many_association.rb:143-149) — the array arm creates each record
-   * through `super` (which bumps the counter per record), the scalar arm bumps
-   * by one.
+   * (has_many_association.rb:143-149). Rails' array arm — `_create_record`
+   * recursing over an Array of attribute hashes, each recursion bumping the
+   * counter by one — has no counterpart here: `Association#_createRecord`
+   * takes a single attribute hash, and the multi-record form is the loop in
+   * `CollectionProxy#create`, which reaches this method once per element.
    * @internal
    */
   protected override async _createRecord(
@@ -287,9 +289,6 @@ export class HasManyAssociation extends CollectionAssociation {
     shouldRaise = false,
     block?: (record: Base) => void,
   ): Promise<Base | null> {
-    if (Array.isArray(attributes)) {
-      return super._createRecord(attributes, shouldRaise, block);
-    }
     return this.updateCounterIfSuccess(
       await super._createRecord(attributes, shouldRaise, block),
       1,


### PR DESCRIPTION
Rails' `HasManyAssociation#insert_record` is two lines
(`has_many_association.rb:61-64`):

```ruby
def insert_record(record, validate = true, raise = false)
  set_owner_attributes(record)
  super
end
```

`super` is `CollectionAssociation#insert_record`
(`collection_association.rb:377-383`), which picks `save!` when `raise` and
`save` otherwise. trails diverged on three points: it never delegated to
`super`, it called `record.save({ validate })` regardless of `raise` and threw
`RecordInvalid` after the fact (so the whole save completed before the throw,
instead of the error being raised from inside the save), and it folded
`updateCounterIfSuccess(saved, 1)` into `insert_record`.

Changes:

- `HasManyAssociation#insertRecord` is now `setOwnerAttributes(record)` +
  `super.insertRecord(record, validate, raise)`.
- The in-memory counter bump moves to `concatRecords` and `_createRecord`,
  each wrapping its `super` in `updateCounterIfSuccess`, as in
  `has_many_association.rb:139-149`. `updateCounterIfSuccess` becomes generic
  so it returns whatever `super` returned (records array / record / boolean),
  matching Ruby's truthiness pass-through.
- `CollectionAssociation#insertRecord` drops its `setOwnerAttributes` call:
  Rails' base has none, and for a through association it set FKs that the
  has_many override deliberately skips.

`pnpm parity:api:calls` and `pnpm parity:api:calls:args` are both OK with no
new rows. has-many, has-many-through, collection-proxy, callbacks,
counter-cache, inverse, habtm, autosave and nested-attributes suites pass
locally.

Closes-story: converge-has-many-insert-record-to-super