### PR TITLE
fix(activerecord): restore the pinned-connection lock around unpinConnectionBang

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -822,11 +822,9 @@ export class ConnectionPool implements ReapablePool {
     let clean = true;
 
     // The block Rails runs under `@pinned_connection.lock.synchronize`
-    // (connection_pool.rb:344-362). `rollbackTransaction` is a real await in
-    // trails, so without the lock a second `unpinConnectionBang` — or a
-    // concurrent `pinConnectionBang` — enters while the pin is half torn down:
-    // it sees the not-yet-decremented `pin.depth`, rolls the same transaction
-    // back a second time, or checks the connection in twice.
+    // (connection_pool.rb:344-362). trails' `rollbackTransaction` is a real
+    // await, so without the lock a second unpin enters while the pin is half
+    // torn down and rolls the same transaction back again.
     const block = async () => {
       try {
         if (isTransactionAware(connection)) {
@@ -851,11 +849,10 @@ export class ConnectionPool implements ReapablePool {
       }
     };
 
-    // `TransactionManager#synchronize` is the trails-native spelling of the
-    // per-connection lock, and it is re-entrant on the same async chain, so the
-    // nested `rollbackTransaction` (which takes the same lock) cannot
-    // self-deadlock. A connection with no transaction manager has no lock to
-    // take and no transaction to roll back.
+    // `TransactionManager#synchronize` is the trails spelling of Rails'
+    // per-connection lock; it is re-entrant on the async chain, so the nested
+    // `rollbackTransaction` (same lock) cannot self-deadlock. A connection with
+    // no transaction manager has neither a lock to take nor a transaction.
     if (isTransactionAware(connection)) {
       await connection.transactionManager.synchronize(block);
     } else {

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -821,26 +821,45 @@ export class ConnectionPool implements ReapablePool {
     const connection = pin.connection;
     let clean = true;
 
-    try {
-      if (isTransactionAware(connection)) {
-        if (connection.transactionManager.currentTransaction.open) {
-          await connection.transactionManager.rollbackTransaction();
-        } else {
-          clean = false;
-          connection.resetBang();
+    // The block Rails runs under `@pinned_connection.lock.synchronize`
+    // (connection_pool.rb:344-362). `rollbackTransaction` is a real await in
+    // trails, so without the lock a second `unpinConnectionBang` — or a
+    // concurrent `pinConnectionBang` — enters while the pin is half torn down:
+    // it sees the not-yet-decremented `pin.depth`, rolls the same transaction
+    // back a second time, or checks the connection in twice.
+    const block = async () => {
+      try {
+        if (isTransactionAware(connection)) {
+          if (connection.transactionManager.currentTransaction.open) {
+            await connection.transactionManager.rollbackTransaction();
+          } else {
+            clean = false;
+            connection.resetBang();
+          }
+        }
+      } finally {
+        pin.depth--;
+        if (pin.depth === 0) {
+          if (fromFixture) {
+            this._fixturePin = null;
+          } else {
+            this._pinnedConnections.delete(ctxId);
+          }
+          this._cacheConfig.decrementPinnedCount();
+          this.checkin(connection);
         }
       }
-    } finally {
-      pin.depth--;
-      if (pin.depth === 0) {
-        if (fromFixture) {
-          this._fixturePin = null;
-        } else {
-          this._pinnedConnections.delete(ctxId);
-        }
-        this._cacheConfig.decrementPinnedCount();
-        this.checkin(connection);
-      }
+    };
+
+    // `TransactionManager#synchronize` is the trails-native spelling of the
+    // per-connection lock, and it is re-entrant on the same async chain, so the
+    // nested `rollbackTransaction` (which takes the same lock) cannot
+    // self-deadlock. A connection with no transaction manager has no lock to
+    // take and no transaction to roll back.
+    if (isTransactionAware(connection)) {
+      await connection.transactionManager.synchronize(block);
+    } else {
+      await block();
     }
 
     return clean;

--- a/packages/activerecord/src/connection-adapters/pool-config.ts
+++ b/packages/activerecord/src/connection-adapters/pool-config.ts
@@ -174,13 +174,13 @@ export class PoolConfig {
     return this._pool !== null;
   }
 
-  // Rails guards this body with `synchronize` (pool_config.rb:61-68) — the
-  // MonitorMixin on PoolConfig itself, re-checking `@pool` inside the lock —
-  // so a concurrent caller cannot overwrite `automatic_reconnect` between this
-  // caller's write and its `@pool.disconnect!`. That lock has no counterpart
-  // here: the only async mutex in trails is `TransactionManager#synchronize`,
-  // which is a *per-connection* lock and guards the wrong object, and adding a
-  // second lock shape is out of scope for this story. Tracked as
+  // Missing critical section: Rails guards this body with `synchronize`
+  // (pool_config.rb:61-68) — the MonitorMixin on PoolConfig itself, re-checking
+  // `@pool` inside the lock — so a concurrent caller cannot overwrite
+  // `automatic_reconnect` between this caller's write and its
+  // `@pool.disconnect!`. trails has no lock on this object:
+  // `TransactionManager#synchronize` is per-connection and guards the wrong
+  // one. Converging needs an async monitor PoolConfig can hold —
   // `port-pool-config-monitor-critical-section`.
   async disconnectBang(options: { automaticReconnect?: boolean } = {}): Promise<void> {
     if (!this._pool) return;

--- a/packages/activerecord/src/connection-adapters/pool-config.ts
+++ b/packages/activerecord/src/connection-adapters/pool-config.ts
@@ -174,6 +174,14 @@ export class PoolConfig {
     return this._pool !== null;
   }
 
+  // Rails guards this body with `synchronize` (pool_config.rb:61-68) — the
+  // MonitorMixin on PoolConfig itself, re-checking `@pool` inside the lock —
+  // so a concurrent caller cannot overwrite `automatic_reconnect` between this
+  // caller's write and its `@pool.disconnect!`. That lock has no counterpart
+  // here: the only async mutex in trails is `TransactionManager#synchronize`,
+  // which is a *per-connection* lock and guards the wrong object, and adding a
+  // second lock shape is out of scope for this story. Tracked as
+  // `port-pool-config-monitor-critical-section`.
   async disconnectBang(options: { automaticReconnect?: boolean } = {}): Promise<void> {
     if (!this._pool) return;
     if (options.automaticReconnect !== undefined) {

--- a/packages/activerecord/src/connection-pool.trails.test.ts
+++ b/packages/activerecord/src/connection-pool.trails.test.ts
@@ -427,6 +427,57 @@ it("context pin takes priority over fixture pin in unpin", async () => {
   }
 });
 
+it("concurrent unpinConnectionBang calls do not interleave inside the pin tear-down", async () => {
+  // Rails runs the whole of `unpin_connection!` under
+  // `@pinned_connection.lock.synchronize` (connection_pool.rb:344-362). trails'
+  // `rollbackTransaction` is a real await, so without that lock a second unpin
+  // enters the critical section while the first is still mid-rollback and the
+  // pin bookkeeping is half torn down. Assert the *interleaving*, not just the
+  // end state: the two tear-downs must be strictly sequential.
+  const pool = makeAmbientPool({ pool: 5 });
+  try {
+    await pool.pinConnectionBang();
+    const pinned = (await pool.checkout()) as LeasedTestAdapter;
+
+    const tm = pinned.transactionManager as unknown as {
+      rollbackTransaction: (...args: unknown[]) => Promise<unknown>;
+    };
+    const original = tm.rollbackTransaction.bind(tm);
+    const events: string[] = [];
+    let inFlight = 0;
+    let maxInFlight = 0;
+    tm.rollbackTransaction = async (...args: unknown[]) => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      events.push("rollback:begin");
+      try {
+        // Yield the microtask queue so a second unpin gets a real chance to
+        // enter the tear-down while this one is suspended.
+        await Promise.resolve();
+        return await original(...args);
+      } finally {
+        events.push("rollback:end");
+        inFlight--;
+      }
+    };
+
+    const [first, second] = await Promise.all([
+      pool.unpinConnectionBang(),
+      pool.unpinConnectionBang(),
+    ]);
+
+    // Baseline (no lock) records ["rollback:begin", "rollback:begin", …] and a
+    // maxInFlight of 2, and both callers report a clean unpin because both see
+    // the transaction still open.
+    expect(maxInFlight).toBe(1);
+    expect(events).toEqual(["rollback:begin", "rollback:end"]);
+    expect([first, second]).toEqual([true, false]);
+    expect(pinned.transactionManager.openTransactions).toBe(0);
+  } finally {
+    await closePoolConnections(pool);
+  }
+});
+
 describe("ConnectionPool schema cache", () => {
   // Rails' ConnectionPoolTests declares `fixtures` and sets
   // `use_transactional_tests = false` (connection_pool_test.rb:11); its

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2975,12 +2975,10 @@ export class CheckPending {
     this._migrations = options.migrations ?? [];
   }
 
-  // Rails wraps this body in `@mutex.synchronize` (migration.rb:657) to guard
-  // the `@watcher ||= build_watcher` memo and the `@needs_check` flag it flips.
-  // Neither piece of state exists in the port — trails registers migrations
-  // programmatically, so there is no FileUpdateChecker to memoize and no
-  // needs-check flag — and nothing else on `this` is written across the awaits
-  // below. There is no critical section here to restore.
+  // Rails' `@mutex.synchronize` (migration.rb:657) guards the
+  // `@watcher ||= build_watcher` memo and the `@needs_check` flag. trails
+  // registers migrations programmatically, so it has neither, and nothing else
+  // on `this` is written across the awaits below — no critical section to hold.
   async call(env: Record<string, unknown>): Promise<unknown> {
     if (this._migrator) {
       await this._migrator.loadMigrated();

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2975,6 +2975,12 @@ export class CheckPending {
     this._migrations = options.migrations ?? [];
   }
 
+  // Rails wraps this body in `@mutex.synchronize` (migration.rb:657) to guard
+  // the `@watcher ||= build_watcher` memo and the `@needs_check` flag it flips.
+  // Neither piece of state exists in the port — trails registers migrations
+  // programmatically, so there is no FileUpdateChecker to memoize and no
+  // needs-check flag — and nothing else on `this` is written across the awaits
+  // below. There is no critical section here to restore.
   async call(env: Record<string, unknown>): Promise<unknown> {
     if (this._migrator) {
       await this._migrator.loadMigrated();


### PR DESCRIPTION
Ports the async critical sections for the pool-lifecycle half of
`port-async-critical-sections-for-mutex-guarded-lifecycle`, whose adapter half
(`reconnectBang` / `verifyBang` / `reloadTypeMap` / mysql2 `reconnect`) already
shipped.

Each of the three candidates was confirmed or excluded by reading the Rails body
against the TS body.

## Converged — `ConnectionPool#unpinConnectionBang`

Rails runs the entire tear-down under the pinned connection's own lock
(`connection_pool.rb:344-362`, `@pinned_connection.lock.synchronize`). trails'
`rollbackTransaction` is a real await, so the unlocked port let a second
`unpinConnectionBang` enter while the pin was half torn down: it saw the
not-yet-decremented `pin.depth`, found the transaction still open, and rolled the
same transaction back a second time.

Restored with `TransactionManager#synchronize`
(`connection-adapters/abstract/transaction.ts:1194`) — the same trails-native
per-connection lock the adapter half used, no second lock shape. It is re-entrant
on the async chain, so the nested `rollbackTransaction` (which takes the same
lock) cannot self-deadlock.

Regression test asserts the **interleaving**, not the end state: it instruments
`rollbackTransaction` to record begin/end events and track max in-flight depth,
fires two concurrent unpins, and requires strictly sequential tear-downs.
Verified red on the baseline (`expected 2 to be 1`) and green with the fix.

## Excluded — `CheckPending#call`

Rails' `@mutex.synchronize` (`migration.rb:657`) guards the
`@watcher ||= build_watcher` memo and the `@needs_check` flag. Neither exists in
the port — trails registers migrations programmatically, so there is no
FileUpdateChecker to memoize — and nothing else on `this` is written across the
awaits. No critical section to restore; finding recorded at the call site.

## Deferred — `PoolConfig#disconnectBang`

Confirmed as a **real** hazard, not a false positive: Rails' `synchronize`
(`pool_config.rb:61-68`) is the `MonitorMixin` on PoolConfig itself, with an
inner `@pool` re-check, so a concurrent caller cannot overwrite
`automatic_reconnect` between this caller's write and its `@pool.disconnect!`.
The port has no lock and a real suspension point, so that interleaving is
reachable.

It is not converged here because the only async mutex in trails is
`TransactionManager#synchronize`, a *per-connection* lock that guards the wrong
object; `NullLock` is a sync pass-through. Converging needs an async-chain-aware
monitor PoolConfig can hold — a lock-shape decision that deserves its own review
rather than being smuggled in here, and one that should cover `#pool`,
`#discardPoolBang` and `#serverVersion` in the same pass. Filed as
`0084-wide-call-set-burndown/port-pool-config-monitor-critical-section` with the
Rails citations and acceptance criteria; the finding is also recorded at the call
site.

## Gates

- `pnpm parity:api:calls` — OK (1746 baselined, 331 marks, zero slack). No row
  became stale, so none was deleted: the `unpin_connection!` / `lock` row tracks
  the literal `.lock` token, which the trails spelling
  (`connection.transactionManager.synchronize`) does not produce.
- `pnpm parity:api:calls:args` — OK (357 baselined shape rows).
- `pnpm parity:api:extra --package activerecord` — no novel surface.
- `pnpm typecheck` clean; eslint clean on the touched files.
- `pnpm parity:api` and `pnpm parity:test` totals unchanged (delta 0, non-negative):
  AR closure 8404/9071, tests 15557/22726 on both main and this branch.
- 113 LOC (ceiling 700).

Closes-story: port-async-critical-sections-for-pool-lifecycle
