### PR TITLE
refactor(parity): scope out-of-closure activesupport files; converge association_valid? and CollectionProxy#build

### DIFF
--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1206,10 +1206,11 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   }
 
   /**
-   * Build a new associated record (unsaved).
-   * For direct has_many, sets the FK on the target.
-   * For through associations, builds the target without FK — the join
-   * record is created later via create() or push().
+   * Mirrors `CollectionProxy#build` (collection_proxy.rb:315-317): a plain
+   * delegation to `@association.build(attributes, &block)`. The Array arm and
+   * the `add_to_target(build_record(...), replace: true)` shape live on
+   * `CollectionAssociation#build` (collection_association.rb:117-123), which
+   * writes the same in-memory target this proxy reads.
    */
   build(attrs: Record<string, unknown>[], block?: (r: T) => void): T[];
   build(attrs?: Record<string, unknown>, block?: (r: T) => void): T;
@@ -1217,14 +1218,14 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     attrs: Record<string, unknown> | Record<string, unknown>[] = {},
     block?: (r: T) => void,
   ): T | T[] {
-    if (Array.isArray(attrs)) {
-      return attrs.map((a) => this.build(a, block));
-    }
-    // Rails' build calls add_to_target(build_record(...), replace: true).
-    const record = (this._isThrough ? this._buildThrough(attrs) : this._buildRaw(attrs)) as T;
-    if (block) block(record);
-    this._replaceOnTarget(record, { replace: true });
-    return record;
+    const association = this._record.association(
+      this._assocName,
+    ) as unknown as CollectionAssociation;
+    return (
+      Array.isArray(attrs)
+        ? association.build(attrs, block as (record: Base) => void)
+        : association.build(attrs, block as (record: Base) => void)
+    ) as T | T[];
   }
 
   /** Rails `CollectionProxy#new` — `alias_method :new, :build`. */
@@ -1234,12 +1235,11 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     attrs: Record<string, unknown> | Record<string, unknown>[] = {},
     block?: (r: T) => void,
   ): T | T[] {
-    // The two branches read identically but are NOT redundant: each narrows
-    // `attrs` (array vs single record) so overload resolution selects the
-    // matching `build` overload. A bare `this.build(attrs, block)` on the union
-    // type fails (TS2769 — no overload accepts `T | T[]`), and casting would
-    // mis-type the return. This is the cast-free delegation Rails expresses as
-    // `alias_method :new, :build` (collection_proxy.rb:321).
+    // Each branch narrows `attrs` (array vs single) so overload resolution
+    // selects the matching `build` overload: a bare `this.build(attrs, block)`
+    // on the union fails (TS2769 — no overload accepts `T | T[]`). This is the
+    // cast-free delegation Rails expresses as `alias_method :new, :build`
+    // (collection_proxy.rb:321).
     return Array.isArray(attrs) ? this.build(attrs, block) : this.build(attrs, block);
   }
 
@@ -1287,26 +1287,12 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * (reflection.rb:182) and `Base.new`'s inheritance-column handling
    * (inheritance.rb `new` / `subclass_from_attributes`); the foreign key and
    * the polymorphic type come off `scope_for_create` inside
-   * `initialize_attributes` (association.rb:224). So the proxy hands the whole
-   * job to the association holder rather than assembling them itself.
+   * `initialize_attributes` (association.rb:224). The through arm
+   * (`HasManyThroughAssociation#build_record`,
+   * has_many_through_association.rb:88-114) is an override on the same holder,
+   * so there is one call here and no through/non-through split on the proxy.
    */
-  private _buildRaw(attrs: Record<string, unknown> = {}): Base {
-    return (
-      this._record.association(this._assocName) as unknown as {
-        buildRecord(attributes?: Record<string, unknown>): Base;
-      }
-    ).buildRecord(attrs);
-  }
-
-  /**
-   * Mirrors Rails' `HasManyThroughAssociation#build_record`
-   * (has_many_through_association.rb:88-100), which calls `super` —
-   * `Association#build_record` (association.rb:383-388) — for the
-   * construction and then wires the pre-built join row onto the target's
-   * inverse. Both halves live on the association holder, so the proxy hands
-   * the whole job to it.
-   */
-  private _buildThrough(attrs: Record<string, unknown> = {}): Base {
+  private _buildRecord(attrs: Record<string, unknown> = {}): Base {
     return (
       this._record.association(this._assocName) as unknown as {
         buildRecord(attributes?: Record<string, unknown>): Base;
@@ -1410,7 +1396,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
         (this as unknown as { _pendingThroughScope?: unknown })._pendingThroughScope,
       )) as T;
     }
-    const record = this._buildRaw(attrs) as T;
+    const record = this._buildRecord(attrs) as T;
     if (block) block(record);
     // Rails' `_create_record` wraps the insert in a transaction and re-raises
     // `Rollback unless result` (collection_association.rb:363-371) so a
@@ -1600,7 +1586,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     if (this._record.isNewRecord()) {
       throw new Error(`You cannot call create unless the parent is saved`);
     }
-    const record = this._buildThrough(attrs) as T;
+    const record = this._buildRecord(attrs) as T;
     if (block) block(record);
     const saved = await record.save();
     if (!saved) return record;
@@ -3650,7 +3636,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     this._ensurePersistedOwnerForCreate();
     this._ensureThroughWritable();
     if (this._isThrough) {
-      const record = this._buildThrough(attrs) as T;
+      const record = this._buildRecord(attrs) as T;
       if (block) block(record);
       if (!assocCallback(this._callbackHost, "beforeAdd", record)) {
         throw new RecordNotSaved("Callback prevented record creation", record);
@@ -3670,7 +3656,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       assocCallback(this._callbackHost, "afterAdd", record);
       return record;
     }
-    const record = this._buildRaw(attrs) as T;
+    const record = this._buildRecord(attrs) as T;
     if (block) block(record);
     // Mirror Rails' _create_record(raise: true): add_to_target(record) { save! }.
     // The save (insert_record) runs inside the add_to_target funnel, between

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1211,6 +1211,12 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * the `add_to_target(build_record(...), replace: true)` shape live on
    * `CollectionAssociation#build` (collection_association.rb:117-123), which
    * writes the same in-memory target this proxy reads.
+   *
+   * The two textually identical ternary arms are not dead code: each narrows
+   * `attrs` (array vs single) so overload resolution picks the matching
+   * `CollectionAssociation#build` overload. A bare
+   * `association.build(attrs, block)` on the union fails with TS2769 — the same
+   * language necessity `new()` carries below.
    */
   build(attrs: Record<string, unknown>[], block?: (r: T) => void): T[];
   build(attrs?: Record<string, unknown>, block?: (r: T) => void): T;

--- a/packages/activerecord/src/autosave-association.trails.test.ts
+++ b/packages/activerecord/src/autosave-association.trails.test.ts
@@ -402,3 +402,29 @@ describe("TestAutosaveAssociationsInGeneral changed_for_autosave?", () => {
     expect(gadget.changedForAutosave()).toBe(true);
   });
 });
+
+describe("TestAutosaveAssociationsInGeneral association_valid?", () => {
+  fixtures([]);
+
+  it("association_valid? dispatches through marked_for_destruction?", async () => {
+    // autosave_association.rb:372 —
+    // `return true if record.destroyed? || (association.options[:autosave] &&
+    // record.marked_for_destruction?)`. `marked_for_destruction?` is a method
+    // call, so an override decides the skip; reading the in-memory flag
+    // directly instead would validate a record Rails skips.
+    registerModel(CanonicalPirate);
+    registerModel(CanonicalBird);
+    class DoomedBird extends CanonicalBird {
+      override markedForDestruction = (): boolean => true;
+    }
+    registerModel("AssociationValidDoomedBird", DoomedBird);
+
+    const pirate = await CanonicalPirate.create({ catchphrase: "Yarr" });
+    // `name` is `validates presence` on Bird, so this child is invalid — and
+    // `birds` is autosave through `accepts_nested_attributes_for`.
+    const doomed = new DoomedBird({ name: "" });
+    pirate.association("birds").setTarget([doomed] as any);
+
+    expect(await pirate.save()).toBe(true);
+  });
+});

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -701,25 +701,25 @@ export async function isAssociationValid(
   // neither rides in as an extra param.
   const owner = this as any;
   const reflection = association.reflection;
-  if (typeof record.isDestroyed === "function" && record.isDestroyed()) return true;
-  if (reflection.options?.autosave && isMarkedForDestruction(record)) return true;
+  if (record.isDestroyed() || (association.options.autosave && record.markedForDestruction()))
+    return true;
   const context =
     typeof owner?.customValidationContext === "function" && owner.customValidationContext()
       ? owner._validationContext
       : undefined;
-  const isChildValid = typeof record.isValid === "function" ? await record.isValid(context) : true;
+  const isChildValid = await record.isValid(context);
   if (isChildValid) return true;
 
   const childErrors: any[] = record.errors?.objects ?? [];
   const associatedErrors =
-    record.isNewRecord?.() || record.changed || context
+    record.changed || record.isNewRecord() || context
       ? childErrors
       : childErrors.filter((e: any) => e instanceof AssociationsNestedError);
 
   const parentErrors = owner?.errors;
   if (!parentErrors) return isChildValid;
 
-  if (reflection.options?.autosave) {
+  if (association.options.autosave) {
     if (owner === record) return isChildValid; // Rails: `return if equal?(record)`
     for (const error of associatedErrors) {
       parentErrors.objects.push(new AssociationsNestedError(association, error));

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -696,38 +696,36 @@ export async function isAssociationValid(
   association: any,
   record: any,
 ): Promise<boolean> {
-  // Mirrors Rails `association_valid?` (autosave_association.rb:371-398), which
-  // reads the reflection off the association and the errors off `self` — so
-  // neither rides in as an extra param.
+  // Rails reads the reflection off the association and the errors off `self`,
+  // so neither rides in as an extra param.
   const owner = this as any;
-  const reflection = association.reflection;
   if (record.isDestroyed() || (association.options.autosave && record.markedForDestruction()))
     return true;
-  const context =
-    typeof owner?.customValidationContext === "function" && owner.customValidationContext()
-      ? owner._validationContext
-      : undefined;
-  const isChildValid = await record.isValid(context);
-  if (isChildValid) return true;
 
-  const childErrors: any[] = record.errors?.objects ?? [];
-  const associatedErrors =
-    record.changed || record.isNewRecord() || context
-      ? childErrors
-      : childErrors.filter((e: any) => e instanceof AssociationsNestedError);
+  const context = owner.customValidationContext() ? owner._validationContext : undefined;
+  if (await record.isValid(context)) return true;
 
-  const parentErrors = owner?.errors;
-  if (!parentErrors) return isChildValid;
+  let associatedErrors: any[];
+  if (record.changed || record.isNewRecord() || context) {
+    associatedErrors = record.errors.objects;
+  } else {
+    associatedErrors = record.errors.objects.filter(
+      (error: any) => error instanceof AssociationsNestedError,
+    );
+  }
 
   if (association.options.autosave) {
-    if (owner === record) return isChildValid; // Rails: `return if equal?(record)`
+    // Ruby's `return if equal?(record)` returns nil, which every caller here
+    // discards; `false` is its truthiness in TS.
+    if (owner === record) return false;
     for (const error of associatedErrors) {
-      parentErrors.objects.push(new AssociationsNestedError(association, error));
+      owner.errors.objects.push(new AssociationsNestedError(association, error));
     }
   } else if (associatedErrors.length > 0) {
-    parentErrors.add(reflection.name);
+    owner.errors.add(association.reflection.name);
   }
-  return isChildValid;
+
+  return owner.errors.any;
 }
 
 /** @internal */

--- a/scripts/parity/unported-files/activesupport.ts
+++ b/scripts/parity/unported-files/activesupport.ts
@@ -83,4 +83,136 @@ export const ACTIVESUPPORT_UNPORTED_FILES: UnportedFile[] = [
     package: "activesupport",
     reason: "Pre-1.0: one arm of `acts_like?`; trails ports the Time/Date arms only.",
   },
+  // Out-of-closure activesupport families (RFC 0072). trails' scope for the
+  // support gems is the `require "active_support/…"` closure of
+  // activerecord/lib + activemodel/lib — the set `scripts/api-compare/ar-closure.ts`
+  // walks out of vendor/rails and prints as the "AR closure" rollup. Every file
+  // below sits OUTSIDE that closure and has no trails counterpart, so it is
+  // denominator-only. Files that are out of closure but partially ported
+  // (`cache.rb`, `cache/file_store.rb`, `cache/memory_store.rb`,
+  // `cache/null_store.rb`, `xml_mini.rb`, `xml_mini/nokogiri*.rb`) stay counted,
+  // as do in-closure files the walk reaches (`concurrency/share_lock.rb`,
+  // `dependencies/interlock.rb`, `testing/parallelization*.rb`) and
+  // `log_subscriber/test_helper.rb`, which AR's own log_subscriber and enum
+  // tests include.
+  {
+    pattern: "cache/redis_cache_store.rb",
+    testFile: "redis_cache_store_test.rb",
+    package: "activesupport",
+    reason:
+      "outside the AR/AM require closure; deferred until an actionpack/railties port needs it.",
+  },
+  {
+    pattern: "cache/mem_cache_store.rb",
+    testFile: "mem_cache_store_test.rb",
+    package: "activesupport",
+    reason:
+      "outside the AR/AM require closure; deferred until an actionpack/railties port needs it.",
+  },
+  {
+    pattern: "cache/strategy/local_cache.rb",
+    package: "activesupport",
+    reason:
+      "outside the AR/AM require closure; deferred until an actionpack/railties port needs it.",
+  },
+  {
+    pattern: "cache/strategy/local_cache_middleware.rb",
+    testFile: "local_cache_middleware_test.rb",
+    package: "activesupport",
+    reason:
+      "outside the AR/AM require closure; deferred until an actionpack/railties port needs it.",
+  },
+  {
+    pattern: "reloader.rb",
+    testFile: "reloader_test.rb",
+    package: "activesupport",
+    reason:
+      "outside the AR/AM require closure; deferred until an actionpack/railties port needs it.",
+  },
+  {
+    pattern: "execution_wrapper.rb",
+    package: "activesupport",
+    reason:
+      "outside the AR/AM require closure; deferred until an actionpack/railties port needs it.",
+  },
+  {
+    pattern: "/file_update_checker.rb",
+    testFile: "/file_update_checker_test.rb",
+    package: "activesupport",
+    reason:
+      "outside the AR/AM require closure; deferred until an actionpack/railties port needs it.",
+  },
+  {
+    pattern: "evented_file_update_checker.rb",
+    testFile: "evented_file_update_checker_test.rb",
+    package: "activesupport",
+    reason:
+      "outside the AR/AM require closure; deferred until an actionpack/railties port needs it.",
+  },
+  {
+    pattern: "xml_mini/jdom.rb",
+    testFile: "jdom_engine_test.rb",
+    package: "activesupport",
+    reason:
+      "outside the AR/AM require closure; deferred until an actionpack/railties port needs it.",
+  },
+  {
+    pattern: "xml_mini/libxml.rb",
+    testFile: "libxml_engine_test.rb",
+    package: "activesupport",
+    reason:
+      "outside the AR/AM require closure; deferred until an actionpack/railties port needs it.",
+  },
+  {
+    pattern: "xml_mini/libxmlsax.rb",
+    testFile: "libxmlsax_engine_test.rb",
+    package: "activesupport",
+    reason:
+      "outside the AR/AM require closure; deferred until an actionpack/railties port needs it.",
+  },
+  {
+    pattern: "xml_mini/rexml.rb",
+    testFile: "rexml_engine_test.rb",
+    package: "activesupport",
+    reason:
+      "outside the AR/AM require closure; deferred until an actionpack/railties port needs it.",
+  },
+  {
+    pattern: "testing/parallelize_executor.rb",
+    package: "activesupport",
+    reason:
+      "outside the AR/AM require closure; deferred until an actionpack/railties port needs it.",
+  },
+  {
+    pattern: "encrypted_configuration.rb",
+    testFile: "encrypted_configuration_test.rb",
+    package: "activesupport",
+    reason:
+      "outside the AR/AM require closure; deferred until an actionpack/railties port needs it.",
+  },
+  {
+    pattern: "code_generator.rb",
+    package: "activesupport",
+    reason:
+      "outside the AR/AM require closure; deferred until an actionpack/railties port needs it.",
+  },
+  {
+    pattern: "fork_tracker.rb",
+    testFile: "fork_tracker_test.rb",
+    package: "activesupport",
+    reason:
+      "outside the AR/AM require closure; deferred until an actionpack/railties port needs it.",
+  },
+  {
+    pattern: "/railtie.rb",
+    package: "activesupport",
+    reason:
+      "outside the AR/AM require closure; deferred until an actionpack/railties port needs it.",
+  },
+  {
+    pattern: "syntax_error_proxy.rb",
+    package: "activesupport",
+    reason:
+      "outside the AR/AM require closure; deferred until an actionpack/railties port needs it.",
+  },
 ];


### PR DESCRIPTION
Bundle of three stories (a fourth is blocked, see below).

## 1. `activesupport-out-of-closure-unported-entries` (RFC 0072)

trails' scope for the support gems is the `require "active_support/…"` closure of
`activerecord/lib` + `activemodel/lib` — the set `scripts/api-compare/ar-closure.ts`
walks out of `vendor/rails` and prints as the "AR closure" rollup. This adds
`UNPORTED_FILES` entries for the out-of-closure activesupport families that have
**no trails counterpart at all**: `cache/{redis_cache_store,mem_cache_store,strategy/local_cache,strategy/local_cache_middleware}.rb`,
`reloader.rb`, `execution_wrapper.rb`, `file_update_checker.rb`,
`evented_file_update_checker.rb`, `xml_mini/{jdom,libxml,libxmlsax,rexml}.rb`,
`testing/parallelize_executor.rb`, `encrypted_configuration.rb`,
`code_generator.rb`, `fork_tracker.rb`, `railtie.rb`, `syntax_error_proxy.rb`.

Deliberately **not** excluded, against the story's candidate list:

- **In the computed closure**, so out of bounds for this register:
  `concurrency/share_lock.rb`, `dependencies/interlock.rb`,
  `testing/parallelization{,/server,/worker}.rb`.
- **AR's own tests need it**: `log_subscriber/test_helper.rb` —
  `activerecord/test/cases/{log_subscriber_test,enum_test}.rb` both
  `require "active_support/log_subscriber/test_helper"`.
- **Out of closure but partially ported**, so excluding would forfeit real
  credit: `cache.rb` (51 matched), `cache/file_store.rb`, `cache/memory_store.rb`,
  `cache/null_store.rb`, `xml_mini.rb`, `xml_mini/nokogiri*.rb`.

Every excluded Rails test file is a permanent-skip stub on the trails side, so
no test credit moves.

### Stats-DB side effect (2026-08-12)

`api_compare_stats.percent` for activesupport jumps discontinuously on this
commit — dashboard trends across this date are not comparable:

| | before | after |
|---|---|---|
| activesupport total | 2292 | 2100 |
| activesupport matched | 1079 | **1077** |
| activesupport percent | 47.1% | 51.3% |
| overall | 13315/17761 (75%) | 13313/17569 (75.8%) |
| test parity | 15557/22726 (68.5%) | 15557/22623 (68.8%) |

The matched count drops by 2: both came from `execution_wrapper.rb`, which has
no TS file and no `ExecutionWrapper` port anywhere in
`packages/activesupport/src` — they were cross-file name collisions credited
through `moves`, not a real port.

## 2. `converge-association-valid-marked-for-destruction-and-branch-order` (RFC 0084)

`isAssociationValid` vs `association_valid?`
(`activerecord/lib/active_record/autosave_association.rb:371-383`):

- the marked-for-destruction term now calls `record.markedForDestruction()`
  instead of reading the private `Symbol.for("blazetrails.markedForDestruction")`
  slot — the same bypass #6403 removed from `changedForAutosave`;
- the autosave option is read off `association.options` (Rails
  `association.options[:autosave]`), not `reflection.options`;
- the error-selection guard is back in Rails' order — `record.changed ||
  record.isNewRecord() || context`;
- the defensive `typeof record.isDestroyed === "function"` /
  `record.isValid === "function"` / `record.isNewRecord?.()` guards are gone:
  every record reaching here is a `Base`.

The tail converges with it: `context = custom_validation_context? ? … : nil`,
the `if/else` error selection, `errors.add(association.reflection.name)`, the
`return if equal?(record)` early exit and the `errors.any?` return are now the
Rails shapes rather than `parentErrors`-guarded variants.

No `call-mismatches-exclude/` row exists for `association_valid?` on main, so
none was deleted and none was added; both ratchets stay green.

Regression: `autosave-association.trails.test.ts` —
"association_valid? dispatches through marked_for_destruction?" — an invalid
child of the autosave `birds` association overriding `markedForDestruction()`.
Verified failing on the pre-fix body (slot read) and passing after.

## 3. `converge-collection-proxy-build-delegates-to-association` (RFC 0084)

`CollectionProxy#build` becomes the Rails two-line delegation to
`@association.build(attributes, &block)` (collection_proxy.rb:315-317). The Array
arm and the `add_to_target(build_record(...), replace: true)` shape now live only
on `CollectionAssociation#build` (collection_association.rb:117-123), which
writes the *same* in-memory target the proxy reads (`_sharedTarget`,
collection-association.ts:96). `_buildRaw` and `_buildThrough` had identical
bodies — both just called `association.buildRecord` — and collapse into one
private `_buildRecord`, so the through/non-through split lives only where Rails
puts it (`HasManyThroughAssociation#build_record`). The TS overload pair on
`new` stays: it is pure union narrowing for overload resolution, with the
comment trimmed to that.

## Not in this PR: `route-through-create-via-create-record` — BLOCKED

`CollectionAssociation#_create_record` (collection_association.rb:354-372) is not
ported yet; the sibling story `port-collection-association-create-record` that
ports it is currently claimed and in flight by another agent, on these same two
files. Routing `_pushThrough`'s `skipCallbacks` arm through `_createRecord`
requires that body to exist first, and porting it here would duplicate and
conflict with that PR. Story marked blocked with that reason.

## Verification

- `pnpm parity:api` / `pnpm parity:test` — deltas above; percent up on both.
- `pnpm parity:api:calls` — OK (1707 baselined). `pnpm parity:api:calls:args` — OK (343 rows).
- `pnpm parity:api:extra --package activerecord` — no new public surface (only
  private methods removed).
- `pnpm vitest run` on autosave-association{,.trails}, nested-attributes,
  collection-proxy, habtm, has-many-associations, has-many-through-associations,
  has-one-through-build, counter-cache, and the two `scripts/parity` unported-files
  suites — all green.

Closes-story: activesupport-out-of-closure-unported-entries
Closes-story: converge-association-valid-marked-for-destruction-and-branch-order
Closes-story: converge-collection-proxy-build-delegates-to-association
