### PR TITLE
refactor(activerecord): layer the create/update super chain onto Rails' modules

### DIFF
--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -844,8 +844,6 @@ import {
   changedAttributeNamesToSave as _changedAttributeNamesToSave,
   attributesInDatabase as _attributesInDatabase,
   _touchRow as __touchRow,
-  _updateRecord as __updateRecord,
-  _createRecord as __createRecord,
   attributeNamesForPartialUpdates as _attributeNamesForPartialUpdates,
   attributeNamesForPartialInserts as _attributeNamesForPartialInserts,
 } from "./attribute-methods/dirty.js";
@@ -1001,20 +999,6 @@ export function _touchRow(
   time?: any,
 ): Promise<number> {
   return __touchRow.call(this as any, attributeNames, time);
-}
-/** @internal */
-export function _updateRecord(
-  this: InstanceMethodHost,
-  superFn: () => Promise<unknown>,
-): Promise<unknown> {
-  return __updateRecord.call(this as any, superFn);
-}
-/** @internal */
-export function _createRecord(
-  this: InstanceMethodHost,
-  superFn: () => Promise<unknown>,
-): Promise<unknown> {
-  return __createRecord.call(this as any, superFn);
 }
 /** @internal */
 export function attributeNamesForPartialUpdates(this: InstanceMethodHost): string[] {

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -1005,16 +1005,16 @@ export function _touchRow(
 /** @internal */
 export function _updateRecord(
   this: InstanceMethodHost,
-  attributeNames?: string[],
-): Promise<number> {
-  return __updateRecord.call(this as any, attributeNames);
+  superFn: () => Promise<unknown>,
+): Promise<unknown> {
+  return __updateRecord.call(this as any, superFn);
 }
 /** @internal */
 export function _createRecord(
   this: InstanceMethodHost,
-  attributeNames?: string[],
+  superFn: () => Promise<unknown>,
 ): Promise<unknown> {
-  return __createRecord.call(this as any, attributeNames);
+  return __createRecord.call(this as any, superFn);
 }
 /** @internal */
 export function attributeNamesForPartialUpdates(this: InstanceMethodHost): string[] {

--- a/packages/activerecord/src/attribute-methods/dirty.ts
+++ b/packages/activerecord/src/attribute-methods/dirty.ts
@@ -211,22 +211,23 @@ export function _touchRow(
 }
 
 /** @internal */
-export function _updateRecord(this: DirtyPrivateHost, _attributeNames?: string[]): Promise<number> {
-  return this._performUpdate().then((rows) => {
-    this.changesApplied();
-    return rows;
-  });
+export async function _updateRecord(
+  this: DirtyPrivateHost,
+  superFn: () => Promise<unknown>,
+): Promise<unknown> {
+  const affectedRows = await superFn();
+  this.changesApplied();
+  return affectedRows;
 }
 
 /** @internal */
-export function _createRecord(
+export async function _createRecord(
   this: DirtyPrivateHost,
-  _attributeNames?: string[],
+  superFn: () => Promise<unknown>,
 ): Promise<unknown> {
-  return this._performInsert().then((id) => {
-    this.changesApplied();
-    return id;
-  });
+  const id = await superFn();
+  this.changesApplied();
+  return id;
 }
 
 /** @internal */

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -116,7 +116,6 @@ import {
   createOrUpdate as callbacksCreateOrUpdate,
   _createRecord as callbacksCreateRecord,
   _updateRecord as callbacksUpdateRecord,
-  registerBaseTimestampCallbacks,
 } from "./callbacks.js";
 import {
   runAllCallbacks as cbRunAll,
@@ -3423,7 +3422,6 @@ export class Base extends Model {
       return saved;
     });
 
-    this._skipTouch = false;
     if (!saveOk) return false;
 
     if (saved) {
@@ -3434,7 +3432,9 @@ export class Base extends Model {
   }
 
   private _pendingOperation: Promise<void> | null = null;
-  private _skipTouch = false;
+  // Mirrors ActiveRecord::Timestamp's @_touch_record ivar (timestamp.rb:104),
+  // set by Timestamp#create_or_update and read by record_update_timestamps.
+  private _touchRecord: boolean | null = null;
   private _instanceRecordTimestamps: boolean | null = null;
 
   // Mirrors: ActiveRecord class_attribute :record_timestamps instance-level override
@@ -3455,16 +3455,6 @@ export class Base extends Model {
     // Resolved after the suppression guard so a suppressed write on a
     // connectionless model never touches `.connection` (Rails resolves lazily).
     const adapter = ConnectionHandling.threadedConnectionFor(ctor) ?? ctor.connection;
-
-    // Auto-populate timestamps (unless touch: false or recordTimestamps disabled)
-    if (!this._skipTouch && this.recordTimestamps !== false) {
-      const now = Timestamp.currentTimeFromProperTimezone();
-      for (const col of Timestamp.allTimestampAttributesInModel.call(ctor)) {
-        if (ctor._attributeDefinitions.has(col) && this._readAttribute(col) == null) {
-          this._writeAttribute(col, now);
-        }
-      }
-    }
 
     // Initialize the locking column from its schema default so a new record's
     // lock value is never nil at insert time. Rails reflects the column
@@ -3610,16 +3600,6 @@ export class Base extends Model {
     const adapter = ConnectionHandling.threadedConnectionFor(ctor) ?? ctor.connection;
 
     const table = ctor.arelTable;
-
-    // Auto-populate update timestamps (unless touch: false or recordTimestamps disabled)
-    if (!this._skipTouch && this.recordTimestamps !== false) {
-      const now = Timestamp.currentTimeFromProperTimezone();
-      for (const col of Timestamp.timestampAttributesForUpdateInModel.call(ctor)) {
-        if (ctor._attributeDefinitions.has(col) && !this.willSaveChangeToAttribute(col)) {
-          this._writeAttribute(col, now);
-        }
-      }
-    }
 
     const changedAttrs = { ...this.changes };
 
@@ -5099,10 +5079,35 @@ include(Base, {
   touchDeferredAttributes: TouchLater.touchDeferredAttributes,
 });
 
+// Rails layers create_or_update / _create_record / _update_record by include
+// order (base.rb:299-316): Timestamp sits above Callbacks, so its body runs
+// first and reaches Callbacks' through `super`. Each layer takes that `super`
+// as an explicit continuation.
 for (const [name, fn] of [
-  ["createOrUpdate", callbacksCreateOrUpdate],
-  ["_createRecord", callbacksCreateRecord],
-  ["_updateRecord", callbacksUpdateRecord],
+  [
+    "createOrUpdate",
+    function (this: Base, touch = true, block?: (record: Base) => void): Promise<boolean> {
+      return Timestamp.createOrUpdate.call(this as any, touch, () =>
+        callbacksCreateOrUpdate.call(this, block),
+      );
+    },
+  ],
+  [
+    "_createRecord",
+    function (this: Base, block?: (record: Base) => void): Promise<boolean> {
+      return Timestamp._createRecord.call(this as any, () =>
+        callbacksCreateRecord.call(this, block),
+      ) as Promise<boolean>;
+    },
+  ],
+  [
+    "_updateRecord",
+    function (this: Base, block?: (record: Base) => void): Promise<boolean> {
+      return Timestamp._updateRecord.call(this as any, () =>
+        callbacksUpdateRecord.call(this, block),
+      ) as Promise<boolean>;
+    },
+  ],
 ] as const) {
   Object.defineProperty(Base.prototype, name, {
     value: fn,
@@ -5111,12 +5116,6 @@ for (const [name, fn] of [
     enumerable: false,
   });
 }
-
-// Register Timestamp's internal before_create callback on Base.prototype so
-// timestamps are available to user-defined before_create callbacks (Rails parity:
-// ActiveRecord::Timestamp registers before_create :_assign_timestamps_on_create
-// at include-time, before any subclass callbacks).
-registerBaseTimestampCallbacks(Base.prototype);
 
 // Register Model's super methods for the Validations module.
 // Breaks the recursion on isValid (Base.isValid → validations.isValid → Model.isValid)

--- a/packages/activerecord/src/callbacks.ts
+++ b/packages/activerecord/src/callbacks.ts
@@ -17,11 +17,11 @@ import {
 } from "@blazetrails/activemodel";
 import { subclasses as _subclasses } from "./inheritance.js";
 import { _createRecord as counterCacheCreateRecord } from "./counter-cache.js";
+import { recordUpdateTimestamps } from "./timestamp.js";
 import {
-  allTimestampAttributesInModel,
-  currentTimeFromProperTimezone,
-  timestampAttributesForUpdateInModel,
-} from "./timestamp.js";
+  _createRecord as dirtyCreateRecord,
+  _updateRecord as dirtyUpdateRecord,
+} from "./attribute-methods/dirty.js";
 
 type ModelCtor = typeof Base;
 
@@ -262,35 +262,6 @@ function registerCallback(
   );
 }
 
-/**
- * Mirrors Rails' ActiveRecord::Timestamp#_assign_timestamps_on_create, registered
- * as an early before_create callback on Base so timestamps are available to user-defined
- * before_create callbacks (which run after this one in the inherited chain).
- *
- * @internal
- */
-function _assignTimestampsOnCreate(this: any): void {
-  const ctor = this.constructor;
-  if ((this.recordTimestamps ?? ctor.recordTimestamps) !== false) {
-    const time = currentTimeFromProperTimezone();
-    for (const col of allTimestampAttributesInModel.call(ctor)) {
-      if (ctor._attributeDefinitions?.has(col) && !this._readAttribute?.(col)) {
-        this._writeAttribute?.(col, time);
-      }
-    }
-  }
-}
-
-/**
- * Register the internal timestamp before_create callback on Base.prototype.
- * Must be called once after Base is defined, before any subclass registers callbacks.
- *
- * @internal
- */
-export function registerBaseTimestampCallbacks(baseProto: object): void {
-  _registerCallbackOnProto(baseProto, "before", "create", _assignTimestampsOnCreate, {});
-}
-
 // ---------------------------------------------------------------------------
 // Private instance helpers — mirrors ActiveRecord::Callbacks private block.
 // Rails overrides persistence methods to wrap each in _run_*_callbacks { super }.
@@ -311,6 +282,61 @@ export function createOrUpdate(this: any, block?: (record: any) => void): Promis
   );
 }
 
+/**
+ * The Persistence#_create_record body (persistence.rb:920-940) — the bottom of
+ * the create super chain: the INSERT, `@new_record = false`, then the yield.
+ */
+async function persistenceCreateRecord(this: any, block?: (record: any) => void): Promise<boolean> {
+  const ctor = this.constructor;
+  if (!this._performInsert) throw new Error("_performInsert not implemented");
+  // Reinstate constructor-assigned attrs as dirty vs schema defaults BEFORE the
+  // insert. Rails new records are dirty from construction, so partial_inserts'
+  // `attribute_names & changed_attribute_names_to_save` (attributesForCreate)
+  // correctly includes attrs the user set to a non-default value — e.g. an
+  // hstore column with a DB default of "" that was assigned {key: null}.
+  // Running this after the insert would leave the dirty set empty at column-
+  // selection time and wrongly drop such columns. Only a *null* PK column is
+  // skipped: that's the auto-populated key, tracked via
+  // _writeAttribute(pk, insertedId) in _performInsert. A user-assigned
+  // (non-null) PK column — e.g. a composite key — must stay dirty so it's
+  // inserted; otherwise the row is written with a missing key and
+  // find/destroy by that key raises RecordNotFound.
+  const _pk = ctor.primaryKey;
+  const _pkSet = new Set(
+    (Array.isArray(_pk) ? _pk : [_pk]).filter((n: string) => this._readAttribute?.(n) == null),
+  );
+  this._dirty.reinstateNewRecordChanges(this._attributes, _pkSet);
+  await this._performInsert();
+  if (this._pendingOperation) {
+    await this._pendingOperation;
+    this._pendingOperation = null;
+  }
+  this._previouslyNewRecord = true;
+  this._newRecord = false;
+  // Rails yields here (persistence.rb:936-940).
+  block?.(this);
+  // Rails returns `id`; the trails chain carries a truthy value that becomes
+  // run_callbacks' value in Callbacks#_create_record.
+  return true;
+}
+
+/**
+ * The Persistence#_update_record body (persistence.rb:900-916) — the bottom of
+ * the update super chain: the UPDATE, then the yield.
+ */
+async function persistenceUpdateRecord(this: any, block?: (record: any) => void): Promise<boolean> {
+  if (!this._performUpdate) throw new Error("_performUpdate not implemented");
+  await this._performUpdate();
+  if (this._pendingOperation) {
+    await this._pendingOperation;
+    this._pendingOperation = null;
+  }
+  this._previouslyNewRecord = false;
+  // Rails yields here (persistence.rb:912-916).
+  block?.(this);
+  return true;
+}
+
 /** @internal */
 export async function _createRecord(this: any, block?: (record: any) => void): Promise<boolean> {
   // Rails: _run_create_callbacks { super }, whose value is the block's return
@@ -318,47 +344,16 @@ export async function _createRecord(this: any, block?: (record: any) => void): P
   // create_or_update: `result != false` (persistence.rb:895) — so a nil/absent
   // value is truthy and only an explicit `false` (a halted chain) is falsey.
   // Our signature is Promise<boolean>, so that predicate is applied here.
+  //
+  // `super` walks base.rb's include order below Callbacks (base.rb:299-316):
+  // AttributeMethods::Dirty (changes_applied, dirty.rb:239-243) → CounterCache
+  // (increment_counters, counter_cache.rb:200-207) → Persistence (the INSERT).
   const ctor = this.constructor;
   return (
-    (await runAllCallbacks(ctor.prototype, "create", this, async () =>
-      // Rails includes CounterCache BEFORE Callbacks (base.rb:309 vs :315), so
-      // Callbacks#_create_record's `super` reaches CounterCache#_create_record,
-      // which increments the belongs_to counter caches after the INSERT and
-      // before the after_create callbacks run. Threading the insert body as its
-      // `super` reproduces that ordering.
-      counterCacheCreateRecord.call(this, async () => {
-        if (!this._performInsert) throw new Error("_performInsert not implemented");
-        // Reinstate constructor-assigned attrs as dirty vs schema defaults BEFORE the
-        // insert. Rails new records are dirty from construction, so partial_inserts'
-        // `attribute_names & changed_attribute_names_to_save` (attributesForCreate)
-        // correctly includes attrs the user set to a non-default value — e.g. an
-        // hstore column with a DB default of "" that was assigned {key: null}.
-        // Running this after the insert would leave the dirty set empty at column-
-        // selection time and wrongly drop such columns. Only a *null* PK column is
-        // skipped: that's the auto-populated key, tracked via
-        // _writeAttribute(pk, insertedId) in _performInsert. A user-assigned
-        // (non-null) PK column — e.g. a composite key — must stay dirty so it's
-        // inserted; otherwise the row is written with a missing key and
-        // find/destroy by that key raises RecordNotFound.
-        const _pk = ctor.primaryKey;
-        const _pkSet = new Set(
-          (Array.isArray(_pk) ? _pk : [_pk]).filter((n) => this._readAttribute?.(n) == null),
-        );
-        this._dirty.reinstateNewRecordChanges(this._attributes, _pkSet);
-        await this._performInsert();
-        if (this._pendingOperation) {
-          await this._pendingOperation;
-          this._pendingOperation = null;
-        }
-        this._previouslyNewRecord = true;
-        this._newRecord = false;
-        // Rails yields here (persistence.rb:936-940); `changes_applied` runs
-        // above it in Dirty#_create_record's `super` (dirty.rb:239-243).
-        block?.(this);
-        this.changesApplied();
-        // Rails' block is `super`, whose truthy return becomes run_callbacks' value.
-        return true;
-      }),
+    (await runAllCallbacks(ctor.prototype, "create", this, () =>
+      dirtyCreateRecord.call(this, () =>
+        counterCacheCreateRecord.call(this, () => persistenceCreateRecord.call(this, block)),
+      ),
     )) !== false
   );
 }
@@ -368,59 +363,14 @@ export async function _updateRecord(this: any, block?: (record: any) => void): P
   // Rails: _run_update_callbacks { record_update_timestamps { super } }, whose
   // value is the block's return. As in _createRecord, Rails' `result != false`
   // (create_or_update, persistence.rb:895) is applied here to keep the
-  // Promise<boolean> signature.
-  // record_update_timestamps writes updated_at/updated_on when @_touch_record
-  // and should_record_timestamps? are true, then yields to the actual update.
+  // Promise<boolean> signature. `super` reaches AttributeMethods::Dirty
+  // (dirty.rb:233-237) and then Persistence (the UPDATE).
   const ctor = this.constructor;
   return (
-    (await runAllCallbacks(ctor.prototype, "update", this, async () => {
-      // Mirror record_update_timestamps: write timestamp columns before the update
-      // when the model has record_timestamps enabled and has changes to save.
-      // Mirror record_update_timestamps: use _skipTouch (Rails' @_touch_record flag)
-      // and the shared currentTimeFromProperTimezone() helper (Temporal.Instant).
-      // With partial_writes=false Rails always issues an UPDATE; treat it as having changes.
-      const hasChanges =
-        !ctor.partialUpdates ||
-        ("hasChangesToSave" in this
-          ? !!(this.hasChangesToSave as boolean)
-          : Object.keys(this.changes ?? {}).length > 0);
-      const instanceRecordTs = this.recordTimestamps ?? ctor.recordTimestamps;
-      const wroteTimestamps = !this._skipTouch && instanceRecordTs !== false && hasChanges;
-      if (wroteTimestamps) {
-        const time = currentTimeFromProperTimezone();
-        const updateAttrs = timestampAttributesForUpdateInModel.call(ctor);
-        for (const col of updateAttrs) {
-          if (ctor._attributeDefinitions?.has(col) && !this.willSaveChangeToAttribute?.(col)) {
-            this.writeAttribute?.(col, time);
-          }
-        }
-      }
-      if (!this._performUpdate) throw new Error("_performUpdate not implemented");
-      // _performUpdate also auto-touches updated_at; skip its inner write when:
-      //   - the outer wrapper just handled timestamps, OR
-      //   - recordTimestamps is disabled, OR
-      //   - there are no dirty changes (Rails no-op — don't auto-touch and don't
-      //     desync updated_at vs updated_on by writing inside the inner layer).
-      // Rails: Timestamp#_update_record writes once via record_update_timestamps;
-      // super does not.
-      const previousSkipTouch = this._skipTouch;
-      const skipInnerTouch = wroteTimestamps || instanceRecordTs === false || !hasChanges;
-      if (skipInnerTouch) this._skipTouch = true;
-      try {
-        await this._performUpdate();
-      } finally {
-        this._skipTouch = previousSkipTouch;
-      }
-      if (this._pendingOperation) {
-        await this._pendingOperation;
-        this._pendingOperation = null;
-      }
-      this._previouslyNewRecord = false;
-      // Rails yields here (persistence.rb:912-916).
-      block?.(this);
-      this.changesApplied();
-      // Rails' block is `super`, whose truthy return becomes run_callbacks' value.
-      return true;
-    })) !== false
+    (await runAllCallbacks(ctor.prototype, "update", this, () =>
+      recordUpdateTimestamps.call(this, () =>
+        dirtyUpdateRecord.call(this, () => persistenceUpdateRecord.call(this, block)),
+      ),
+    )) !== false
   );
 }

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -529,7 +529,7 @@ export function findStiClass(baseClass: typeof Base, typeName: string): typeof B
   // candidate is found via the model's own module nesting rather than the bare
   // (unregistered) demodulized name. With the default flags on, sti_class_for
   // falls back to the bare registry lookup, preserving the prior behavior.
-  return stiClassFor(baseClass, typeName);
+  return baseClass.stiClassFor(typeName);
 }
 
 /**
@@ -777,7 +777,7 @@ export function stiClassFor(modelClass: typeof Base, typeName: string): typeof B
     if (klass.storeFullStiClass && klass.storeFullClassName) {
       subclass = constantize(typeName) as typeof Base;
     } else {
-      subclass = computeType(modelClass, typeName);
+      subclass = modelClass.computeType(typeName);
     }
   } catch (cause) {
     if (!(cause instanceof NameError)) throw cause;
@@ -808,7 +808,7 @@ export function polymorphicClassFor(modelClass: typeof Base, name: string): type
   if (klass.storeFullClassName) {
     return constantize(name) as typeof Base;
   }
-  return computeType(modelClass, name);
+  return modelClass.computeType(name);
 }
 
 /**
@@ -944,7 +944,7 @@ export function typeCondition(modelClass: typeof Base, arelTable?: any): any {
 
   const stiColumn = typeof table.get === "function" ? table.get(inheritCol) : table[inheritCol];
   const stiNames = ([modelClass] as (typeof Base)[])
-    .concat(descendants(modelClass))
+    .concat(modelClass.descendants)
     .map((klass) => stiName(klass));
 
   // Use predicate builder to create an IN clause

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -661,7 +661,7 @@ export async function deleteRow<T extends DeleteRecord>(this: T): Promise<T> {
 // save / save! / destroy / destroy! — the callback- and transaction-wrapped
 // entry points. They rely on Base-provided internal helpers/state
 // (_createOrUpdate, _destroyRow, _performInsert, _performUpdate,
-// _skipTouch, _pendingOperation) which remain `private` on Base; the
+// _touchRecord, _pendingOperation) which remain `private` on Base; the
 // extracted functions reach them through `(this as any)` since those
 // members intentionally aren't part of the public Persistence API.
 // Mirrors ActiveRecord::Persistence#save, #save!, #destroy, #destroy!
@@ -767,8 +767,6 @@ export async function save<T extends SaveRecord>(
         return false;
       }
 
-      self._skipTouch = options?.touch === false;
-
       // Auto-set STI type column on new records
       if (this._newRecord && isStiSubclass(ctor)) {
         const col = getStiBase(ctor).inheritanceColumn;
@@ -778,7 +776,8 @@ export async function save<T extends SaveRecord>(
       }
 
       // Rails: `create_or_update(**options, &block)` (persistence.rb:390-408).
-      return self.createOrUpdate(block);
+      // `touch:` is consumed by Timestamp#create_or_update (timestamp.rb:125-128).
+      return self.createOrUpdate(options?.touch ?? true, block);
     })) as boolean | undefined;
   } catch (e) {
     // Mirrors Rails' `rescue ActiveRecord::RecordInvalid` in save — autosave
@@ -786,8 +785,6 @@ export async function save<T extends SaveRecord>(
     // has already rolled back at this point.
     if (e instanceof RecordInvalid) return false;
     throw e;
-  } finally {
-    self._skipTouch = false;
   }
 }
 

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -44,7 +44,7 @@ import {
   InverseOfAssociationRecursiveError,
   CompositePrimaryKeyMismatchError,
 } from "./associations/errors.js";
-import { isFinderNeedsTypeCondition, polymorphicName, typeCondition } from "./inheritance.js";
+import { polymorphicName, typeCondition } from "./inheritance.js";
 
 type MacroType = "belongsTo" | "hasOne" | "hasMany" | "hasAndBelongsToMany" | "composedOf";
 
@@ -315,7 +315,7 @@ export class AbstractReflection {
     // an alias) rather than baked into `klassJoinScope`, so a self-referential
     // STI join filters on the aliased table instead of the model's base table.
     const targetKlass = this.klass as any;
-    if (isFinderNeedsTypeCondition(targetKlass)) {
+    if (targetKlass.isFinderNeedsTypeCondition()) {
       scope = scope.where(typeCondition(targetKlass, table));
     }
 
@@ -463,7 +463,7 @@ export class AbstractReflection {
     const col = this.counterCacheColumn();
     if (!col) return null;
     const inv = this.inverseOf();
-    const candidates: any[] = inv ? [inv] : reflectOnAllAssociations(this.klass, "belongsTo");
+    const candidates: any[] = inv ? [inv] : this.klass.reflectOnAllAssociations("belongsTo");
     return (
       candidates.find((c: any) => {
         try {

--- a/packages/activerecord/src/timestamp.ts
+++ b/packages/activerecord/src/timestamp.ts
@@ -280,7 +280,6 @@ interface TimestampHost {
 /** Minimal instance-side surface used by Timestamp private/internal helpers. */
 interface TimestampInstanceHost {
   _touchRecord: boolean | null;
-  _createOrUpdate: (block?: (record: unknown) => void) => Promise<boolean>;
   readAttribute?(name: string): unknown;
   _readAttribute?(name: string): unknown;
   _writeAttribute?(name: string, val: unknown): void;
@@ -442,41 +441,48 @@ export function initInternals(this: TimestampInstanceHost): void {
 }
 
 /** @internal */
-export async function _createRecord(this: TimestampInstanceHost): Promise<unknown> {
-  if (this.constructor.recordTimestamps !== false) {
-    const time = currentTimeFromProperTimezone();
-    for (const col of allTimestampAttributesInModel.call(this.constructor)) {
-      if (this._readAttribute?.(col) == null) {
-        this._writeAttribute?.(col, time);
+export async function _createRecord(
+  this: TimestampInstanceHost,
+  superFn: () => Promise<unknown>,
+): Promise<unknown> {
+  if ((this.recordTimestamps ?? this.constructor.recordTimestamps) !== false) {
+    const currentTime = currentTimeFromProperTimezone();
+
+    for (const column of allTimestampAttributesInModel.call(this.constructor)) {
+      if (this._readAttribute?.(column) == null) {
+        this._writeAttribute?.(column, currentTime);
       }
     }
   }
-  // Rails calls super here (the persistence layer). In trails the persistence
-  // layer is wired separately via callbacks.ts; this method provides the
-  // timestamp-writing half only.
-  return this.id;
+
+  return superFn();
 }
 
 /** @internal */
-export async function _updateRecord(this: TimestampInstanceHost): Promise<boolean> {
+export async function _updateRecord(
+  this: TimestampInstanceHost,
+  superFn: () => Promise<unknown>,
+): Promise<unknown> {
   await recordUpdateTimestamps.call(this);
-  // Rails yields to super (persistence layer) inside record_update_timestamps.
-  // In trails the persistence layer is wired separately via callbacks.ts.
-  return true;
+
+  return superFn();
 }
 
 /** @internal */
 export function createOrUpdate(
   this: TimestampInstanceHost,
   touch = true,
-  block?: (record: unknown) => void,
+  superFn: () => Promise<boolean>,
 ): Promise<boolean> {
   this._touchRecord = touch;
-  return this._createOrUpdate.call(this, block);
+  return superFn();
 }
 
 /** @internal */
-export async function recordUpdateTimestamps(this: TimestampInstanceHost): Promise<void> {
+export async function recordUpdateTimestamps<T>(
+  this: TimestampInstanceHost,
+  block?: () => Promise<T>,
+): Promise<T | undefined> {
   if (this._touchRecord && shouldRecordTimestamps.call(this)) {
     const currentTime = currentTimeFromProperTimezone();
     for (const column of timestampAttributesForUpdateInModel.call(this.constructor)) {
@@ -485,6 +491,8 @@ export async function recordUpdateTimestamps(this: TimestampInstanceHost): Promi
       }
     }
   }
+
+  return block?.();
 }
 
 /** @internal */

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/inheritance.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/inheritance.json
@@ -49,17 +49,6 @@
     "package": "activerecord",
     "tsFile": "inheritance.ts",
     "rubyName": "find_sti_class",
-    "call": "sti_class_for",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:typeName"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "inheritance.ts",
-    "rubyName": "find_sti_class",
     "call": "type_for_attribute",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -75,43 +64,12 @@
   {
     "package": "activerecord",
     "tsFile": "inheritance.ts",
-    "rubyName": "polymorphic_class_for",
-    "call": "compute_type",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:name"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "inheritance.ts",
-    "rubyName": "sti_class_for",
-    "call": "compute_type",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:typeName"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "inheritance.ts",
     "rubyName": "subclass_from_attributes",
     "call": "find_sti_class",
     "kind": "args",
     "rubyArgs": [
       "ref:subclassName"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "inheritance.ts",
-    "rubyName": "type_condition",
-    "call": "descendants",
-    "kind": "args",
-    "rubyArgs": [],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/reflection.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/reflection.json
@@ -58,25 +58,5 @@
     "rubyName": "inverse_name",
     "call": "fetch",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "reflection.ts",
-    "rubyName": "inverse_which_updates_counter_cache",
-    "call": "reflect_on_all_associations",
-    "kind": "args",
-    "rubyArgs": [
-      "str:belongsTo"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "reflection.ts",
-    "rubyName": "join_scope",
-    "call": "finder_needs_type_condition?",
-    "kind": "args",
-    "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]


### PR DESCRIPTION
Converges the create/update write path onto Rails' module layering, and
converges eight RFC 0099 bucket (a) call-argument rows.

## The super chain

`base.rb:299-316` layers `create_or_update` / `_create_record` /
`_update_record` by include order: `Timestamp` → `Callbacks` →
`AttributeMethods::Dirty` → `CounterCache` → `Persistence`. trails flattened
that into `callbacks.ts#_createRecord` plus `base.ts#_performInsert`, which
left `timestamp.ts`' `createOrUpdate`, `_createRecord` and `_updateRecord`
exported, scoring for `parity:api`, and unreachable (surfaced twice in review
on #6405).

Each layer now takes the next as an explicit `super` continuation — the shape
`counter-cache.ts#_createRecord(superFn)` already used:

- `timestamp.ts#_createRecord` writes the create timestamps then calls super
  (`timestamp.rb:107-117`); `#_updateRecord` runs `record_update_timestamps`
  then super (`timestamp.rb:119-123`); `#createOrUpdate` sets `@_touch_record`
  then super (`timestamp.rb:125-128`). `record_update_timestamps` takes Rails'
  optional block (`timestamp.rb:140`).
- `attribute-methods/dirty.ts#_createRecord` / `#_updateRecord` call super then
  `changes_applied` (`dirty.rb:233-243`), replacing the inline
  `changesApplied()` in `callbacks.ts`.
- `callbacks.ts#_updateRecord` is `_run_update_callbacks {
  record_update_timestamps { super } }` (`callbacks.rb:446-448`).

Because only one layer writes timestamps now, the `wroteTimestamps` /
`skipInnerTouch` double-write guards, the inline timestamp blocks in
`_performInsert` / `_performUpdate`, the `_assignTimestampsOnCreate`
`before_create` shim and the `_skipTouch` flag all come out; `save` passes
`touch:` through to `create_or_update` as Rails does
(`persistence.rb:390-408`).

The `save(&block)` yield stays where #6405 put it — after the INSERT and
`@new_record = false`, before the after_create callbacks
(`persistence.rb:936-940`); `persistence-save-block.trails.test.ts` is green.

## Call-argument rows

Six `shape` rows converged onto the class-level surface the Ruby receiver
resolves to — Rails' bare, implicit-`self` class-method calls at
`inheritance.rb:196,220,313` and `reflection.rb:220,288`, which the port was
routing through an inheritance-blind module function — and their baseline rows
deleted by hand (only-shrink, no `--write`): `inheritance.ts`' `sti_class_for`,
`compute_type` (×2) and `descendants`; `reflection.ts`'
`finder_needs_type_condition?` and `reflect_on_all_associations`.

(An earlier revision of this branch also converged `counter-cache.ts`'
`counter_cached_association_names` ×2; #6409 landed the same fix first, so the
rebase dropped both the code change and the baseline rows. They are not part of
this diff.)

`attribute-methods.ts`' `_createRecord` / `_updateRecord` re-export shims are
deleted rather than re-signatured: `attribute_methods.rb` defines neither method
— both live in `attribute_methods/dirty.rb` (`dirty.rb:233-243`), ported at
`attribute-methods/dirty.ts`, which is what the chain wires. Nothing called the
wrappers, and `parity:api` totals are unchanged by their removal.

## Verification

`pnpm parity:api:calls` and `pnpm parity:api:calls:args` green. Timestamp,
dirty, counter-cache, callbacks, persistence, autosave, locking, touch-later,
transaction-callbacks, inheritance, reflection, relations, nested-attributes,
has_many and belongs_to suites all pass locally.

Closes-story: call-args-ar-extra-argument-rest-3
Closes-story: converge-create-record-super-chain-layers
