### PR TITLE
fix(api-compare): stop crediting matched members to Ruby files with no TS counterpart

### DIFF
--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -1484,10 +1484,7 @@ describe("rubyFileHasTsCounterpart", () => {
     expect(rubyFileHasTsCounterpart(false, "core-ext/object/blank.ts")).toBe(true);
   });
 
-  it("is false for a Ruby file with no port anywhere", () => {
-    // `active_support/execution_wrapper.rb`: `execution-wrapper.ts` does not
-    // exist and no TS file maps to it, yet it read as `matched: 2` off the
-    // cross-file credit for TS names that merely equal `run` / `complete`.
+  it("is false for a Ruby file with no port anywhere, so its members cannot be credited cross-file", () => {
     expect(rubyFileHasTsCounterpart(false, null)).toBe(false);
   });
 });

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -14,6 +14,7 @@ import {
   dedupeRubyMethodInto,
   NAME_COLLISION_CLUSTERS,
   selectMisplacedFile,
+  rubyFileHasTsCounterpart,
   MISPLACED_MIN_HITS,
   blazetrailsDepKeys,
   buildEntitiesByName,
@@ -1471,6 +1472,23 @@ describe("dedupeRubyMethodInto", () => {
       rubyModule: "Foo::A",
       definedInFile: "x.rb",
     });
+  });
+});
+
+describe("rubyFileHasTsCounterpart", () => {
+  it("is true when the mirrored TS file exists", () => {
+    expect(rubyFileHasTsCounterpart(true, null)).toBe(true);
+  });
+
+  it("is true when the port landed in the sibling file the misplaced vote found", () => {
+    expect(rubyFileHasTsCounterpart(false, "core-ext/object/blank.ts")).toBe(true);
+  });
+
+  it("is false for a Ruby file with no port anywhere", () => {
+    // `active_support/execution_wrapper.rb`: `execution-wrapper.ts` does not
+    // exist and no TS file maps to it, yet it read as `matched: 2` off the
+    // cross-file credit for TS names that merely equal `run` / `complete`.
+    expect(rubyFileHasTsCounterpart(false, null)).toBe(false);
   });
 });
 

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -1817,6 +1817,29 @@ function isPackageBarrel(file: string): boolean {
  */
 export const NAME_COLLISION_CLUSTERS: ReadonlySet<string> = new Set([]);
 
+/**
+ * Whether a Ruby file has SOME real TS counterpart the compare can point at:
+ * either its mirrored `expectedTsFile` exists, or the misplaced-cluster vote
+ * found the sibling file its port actually landed in.
+ *
+ * Cross-file credit — the include chain, the mixin/reopening arms, the umbrella
+ * config arm — is gated on this. Those arms all say "the member is ported, just
+ * in another file", which is only meaningful when this Ruby file is ported at
+ * all. Without the gate a Ruby file with a 0-line port accumulates `matched`
+ * from unrelated files that happen to define a TS name equal to one of its Ruby
+ * member names — `active_support/execution_wrapper.rb` read as `matched: 2`
+ * with no `ExecutionWrapper` anywhere in the tree, and every `helpers/tags/*.rb`
+ * bucket read as ~36 matched off the ActionView helper modules. `matched` must
+ * mean "a TS member the compare can point at in a file that maps to this Ruby
+ * file"; an unmapped file's members are missing, and read as missing.
+ */
+export function rubyFileHasTsCounterpart(
+  tsFileExists: boolean,
+  misplacedActualFile: string | null,
+): boolean {
+  return tsFileExists || misplacedActualFile !== null;
+}
+
 export function selectMisplacedFile(
   fileHits: Map<string, number>,
   rubyMethodCount: number,
@@ -2903,6 +2926,9 @@ export function main() {
       const actualMethods = misplacedActualFile
         ? tsMethodsByFile.get(misplacedActualFile) || new Set<string>()
         : null;
+      // Cross-file credit is only meaningful for a Ruby file that has a TS
+      // counterpart at all — see `rubyFileHasTsCounterpart`.
+      const hasTsCounterpart = rubyFileHasTsCounterpart(tsFileExists, misplacedActualFile);
 
       for (const [
         _dedupeKey,
@@ -2915,6 +2941,18 @@ export function main() {
         if (directMatch) {
           fileMatched++;
           checkArity(rubyName, directMatch, expectedTs, rubyModule);
+          continue;
+        }
+
+        // Every arm below this point is cross-file credit — the include chain,
+        // the mixin/reopening arms, the misplaced-cluster fallback, the
+        // umbrella-config arm. None of them applies to a Ruby file with no TS
+        // counterpart of its own (`rubyFileHasTsCounterpart`): there is nothing
+        // for the member to have moved OUT of, so a same-named TS method in an
+        // unrelated file is a name collision, not a port.
+        if (!hasTsCounterpart) {
+          fileMissing++;
+          missingMethods.push({ rubyName, tsName: tsCandidates[0], rubyModule });
           continue;
         }
 

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -1832,6 +1832,11 @@ export const NAME_COLLISION_CLUSTERS: ReadonlySet<string> = new Set([]);
  * bucket read as ~36 matched off the ActionView helper modules. `matched` must
  * mean "a TS member the compare can point at in a file that maps to this Ruby
  * file"; an unmapped file's members are missing, and read as missing.
+ *
+ * Every credit arm after the same-file direct match is cross-file — the include
+ * chain, the mixin/reopening arms, the misplaced-cluster fallback and the
+ * umbrella-config arm — so `main` short-circuits all of them to `missing` when
+ * this returns false.
  */
 export function rubyFileHasTsCounterpart(
   tsFileExists: boolean,
@@ -2926,8 +2931,6 @@ export function main() {
       const actualMethods = misplacedActualFile
         ? tsMethodsByFile.get(misplacedActualFile) || new Set<string>()
         : null;
-      // Cross-file credit is only meaningful for a Ruby file that has a TS
-      // counterpart at all — see `rubyFileHasTsCounterpart`.
       const hasTsCounterpart = rubyFileHasTsCounterpart(tsFileExists, misplacedActualFile);
 
       for (const [
@@ -2944,12 +2947,6 @@ export function main() {
           continue;
         }
 
-        // Every arm below this point is cross-file credit — the include chain,
-        // the mixin/reopening arms, the misplaced-cluster fallback, the
-        // umbrella-config arm. None of them applies to a Ruby file with no TS
-        // counterpart of its own (`rubyFileHasTsCounterpart`): there is nothing
-        // for the member to have moved OUT of, so a same-named TS method in an
-        // unrelated file is a name collision, not a port.
         if (!hasTsCounterpart) {
           fileMissing++;
           missingMethods.push({ rubyName, tsName: tsCandidates[0], rubyModule });


### PR DESCRIPTION
## What

`scripts/api-compare/compare.ts` credited `matched` to a Ruby file through the
cross-file arms (include chain, mixin/reopening credit, umbrella config) even
when that Ruby file has **no TS counterpart at all** — its `expectedTsFile` does
not exist and the misplaced-cluster vote found no sibling file either. The
credit then came purely from a TS name in an unrelated file that happens to
equal one of the Ruby member names, so a file with a 0-line port read as partly
ported.

The instance that surfaced this (PR #6411):
`activesupport/lib/active_support/execution_wrapper.rb` reported `matched: 2`
with no `ExecutionWrapper` anywhere in `packages/activesupport/src`.

## Fix

New `rubyFileHasTsCounterpart(tsFileExists, misplacedActualFile)` — true when
the mirrored TS file exists, or the misplaced vote found the sibling file the
port landed in. Every cross-file credit arm is gated on it; members of an
unmapped Ruby file fall through to `missing`, which is what they are. `matched`
now means "a TS member the compare can point at in a file that maps to this Ruby
file".

## Totals

The stats DB reads `percent`, so stating the movement explicitly. Sweep of the
artifact before/after: **630 phantom members across 31 files**, all in packages
outside the AR closure:

| package | files | members |
| --- | ---: | ---: |
| actionview | 18 | −574 |
| activesupport | 9 | −37 |
| trailties | 4 | −19 |

Overall: `13313/17569 (75.78%)` → `12683/17569 (72.19%)`. AR closure is
unchanged (`8371/9071`, 92.3%); activerecord and activemodel move by zero
members, so the umbrella-config arm is unaffected. Largest single buckets were
`actionview helpers/tags/*.rb` (~36 each, off the ActionView helper modules) and
`helpers.rb` / `test_case.rb` (58 each).

Denominators are untouched — this only removes numerator credit that was never
backed by a port.

## Verification

- `pnpm parity:api`, `parity:api:calls`, `parity:api:calls:args`,
  `parity:api:arity`, `parity:api:inheritance`, `parity:api:pins`,
  `parity:api:reasons`, `parity:api:detached`, `parity:api:extra` — all OK, no
  baseline row went stale.
- `npx vitest run scripts/api-compare/` — 37 files, 1127 tests green, including
  the new `rubyFileHasTsCounterpart` regression covering the
  `execution_wrapper.rb` shape.

## Not in this PR

`converge-collection-proxy-create-delegates-to-association` was claimed in the
same bundle and is **blocked**, not shipped: both of its sequenced deps are
unmet — `port-collection-association-create-record` is in flight in open PR
#6410 (`CollectionAssociation#_createRecord` does not exist on `main`), and
`route-through-create-via-create-record` is itself blocked on that. Building the
proxy-side half now would duplicate #6410's body in the same two files.

Closes-story: no-matched-credit-for-files-with-no-ts-counterpart