### PR TITLE
feat(activesupport): port MonitorMixin; run PoolConfig#disconnect! under it

### DIFF
--- a/packages/activerecord/src/connection-adapters/pool-config.test.ts
+++ b/packages/activerecord/src/connection-adapters/pool-config.test.ts
@@ -88,6 +88,37 @@ describe("PoolConfig", () => {
       await config.disconnectBang();
       expect(spy).toHaveBeenCalled();
     });
+
+    it("serializes concurrent calls with different automaticReconnect values", async () => {
+      const pool = config.pool;
+      const seen: boolean[] = [];
+      let overlapped = false;
+      let inFlight = false;
+      vi.spyOn(pool, "disconnectBang").mockImplementation(async () => {
+        if (inFlight) overlapped = true;
+        inFlight = true;
+        seen.push(pool.automaticReconnect);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        seen.push(pool.automaticReconnect);
+        inFlight = false;
+      });
+
+      await Promise.all([
+        config.disconnectBang({ automaticReconnect: true }),
+        config.disconnectBang({ automaticReconnect: false }),
+      ]);
+
+      expect(overlapped).toBe(false);
+      expect(seen).toEqual([true, true, false, false]);
+    });
+
+    it("defaults automaticReconnect to false", async () => {
+      const pool = config.pool;
+      pool.automaticReconnect = true;
+      vi.spyOn(pool, "disconnectBang").mockResolvedValue(undefined);
+      await config.disconnectBang();
+      expect(pool.automaticReconnect).toBe(false);
+    });
   });
 
   describe("discardPoolBang", () => {

--- a/packages/activerecord/src/connection-adapters/pool-config.test.ts
+++ b/packages/activerecord/src/connection-adapters/pool-config.test.ts
@@ -112,6 +112,22 @@ describe("PoolConfig", () => {
       expect(seen).toEqual([true, true, false, false]);
     });
 
+    it("excludes a concurrent discardPoolBang while the disconnect is in flight", async () => {
+      const pool = config.pool;
+      let discardedDuringDisconnect = false;
+      const discardSpy = vi.spyOn(pool, "discardBangDraining").mockReturnValue([]);
+      vi.spyOn(pool, "disconnectBang").mockImplementation(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        discardedDuringDisconnect = discardSpy.mock.calls.length > 0;
+      });
+
+      await Promise.all([config.disconnectBang(), config.discardPoolBang()]);
+
+      expect(discardedDuringDisconnect).toBe(false);
+      expect(discardSpy).toHaveBeenCalledTimes(1);
+      expect(config.poolInitialized).toBe(false);
+    });
+
     it("defaults automaticReconnect to false", async () => {
       const pool = config.pool;
       pool.automaticReconnect = true;

--- a/packages/activerecord/src/connection-adapters/pool-config.ts
+++ b/packages/activerecord/src/connection-adapters/pool-config.ts
@@ -27,10 +27,6 @@ export class PoolConfig {
    * `this`-typed function, the settled trails spelling for a Ruby `include`.
    * Ruby's monitor is owned by a Thread and ours by an async chain; see
    * `activesupport/src/concurrency/monitor.ts`.
-   *
-   * @noRailsEquivalent `include MonitorMixin` (`pool_config.rb:6`) — the method
-   * is Rails', but it arrives from a Ruby stdlib module with no Rails source
-   * file, so the extractor has nothing to match it against.
    */
   synchronize = synchronize;
 
@@ -251,12 +247,12 @@ export class PoolConfig {
    * sweep has been discarded (the drain is a trails-only step for async-only
    * drivers, with no Rails equivalent). No-ops when the pool is uninitialized.
    *
-   * Reviewed against `#discard_pool!`'s monitor (`pool_config.rb:74-82`):
-   * everything inside Rails' `synchronize` — `@pool.discard!` and `@pool = nil`
-   * — is synchronous on this side too, so the guard, the discard and the write
-   * are already atomic and the inner `@pool` re-check has nothing to catch. The
-   * lock would also have to be taken from `discardPoolsBang`'s synchronous
-   * sweep, which cannot await. Left unlocked deliberately.
+   * Runs under the caller's monitor, never on its own: `#disconnect!` and
+   * `#discard_pool!` (`pool_config.rb:61-68, 74-82`) share one monitor, so on
+   * Rails a thread suspended inside `disconnect!`'s `@pool.disconnect!` still
+   * holds the lock and a concurrent `discard_pool!` blocks on `synchronize`
+   * rather than nulling `@pool` underneath it. Every caller here therefore
+   * takes `synchronize` first.
    */
   private _discardPoolBangSync(): Array<Promise<void>> {
     const pool = this._pool;
@@ -272,14 +268,21 @@ export class PoolConfig {
    * before the caller re-opens the DB. No-ops when the pool is uninitialized.
    */
   async discardPoolBang(): Promise<void> {
-    await Promise.all(this._discardPoolBangSync());
+    if (!this._pool) return;
+
+    const drains = await this.synchronize(() => {
+      if (!this._pool) return [];
+
+      return this._discardPoolBangSync();
+    });
+    await Promise.all(drains);
   }
 
   static async discardPoolsBang(): Promise<void> {
-    // Match Rails' `INSTANCES.each_key(&:discard_pool!)`: discard (and null)
-    // every registered pool synchronously up front, with no inter-pool waiting,
-    // so a slow trails-only drain on one pool can't delay discarding the rest.
-    // The async drains are awaited only after the whole sweep has run.
+    // Match Rails' `INSTANCES.each_key(&:discard_pool!)`: take each config's
+    // monitor and discard (and null) its pool, with no inter-pool waiting, so a
+    // slow trails-only drain on one pool can't delay discarding the rest. The
+    // async drains are awaited only after the whole sweep has run.
     const drains: Array<Promise<void>> = [];
     for (const ref of INSTANCES) {
       const config = ref.deref();
@@ -287,7 +290,9 @@ export class PoolConfig {
         INSTANCES.delete(ref);
         continue;
       }
-      drains.push(...config._discardPoolBangSync());
+      await config.synchronize(() => {
+        drains.push(...config._discardPoolBangSync());
+      });
     }
     await Promise.all(drains);
   }

--- a/packages/activerecord/src/connection-adapters/pool-config.ts
+++ b/packages/activerecord/src/connection-adapters/pool-config.ts
@@ -11,6 +11,7 @@ import { ConnectionPool } from "./abstract/connection-pool.js";
 import { ConnectionDescriptor, type ConnectionOwner } from "./abstract/connection-descriptor.js";
 import { SchemaReflection } from "./schema-cache.js";
 import { DatabaseTasks } from "../tasks/database-tasks.js";
+import { synchronize } from "@blazetrails/activesupport";
 
 const INSTANCES = new Set<WeakRef<PoolConfig>>();
 const registry =
@@ -21,6 +22,18 @@ const registry =
     : null;
 
 export class PoolConfig {
+  /**
+   * Mirrors: `include MonitorMixin` (`pool_config.rb:6`) — assigned as a
+   * `this`-typed function, the settled trails spelling for a Ruby `include`.
+   * Ruby's monitor is owned by a Thread and ours by an async chain; see
+   * `activesupport/src/concurrency/monitor.ts`.
+   *
+   * @noRailsEquivalent `include MonitorMixin` (`pool_config.rb:6`) — the method
+   * is Rails', but it arrives from a Ruby stdlib module with no Rails source
+   * file, so the extractor has nothing to match it against.
+   */
+  synchronize = synchronize;
+
   readonly role: string;
   readonly shard: string;
   readonly dbConfig: DatabaseConfig;
@@ -137,6 +150,14 @@ export class PoolConfig {
    * ||= connection.get_database_version }`. This is the single cache every
    * adapter's `get_database_version` is fetched through; the adapters
    * themselves stay pure.
+   *
+   * Reviewed against the monitor: Rails' `synchronize` here only prevents two
+   * threads both running `get_database_version`; it is a memoization guard,
+   * not a correctness one — either fetch yields the same version, and Ruby's
+   * monitor is reentrant precisely because `configure_connection` re-enters
+   * this method (see below). Locking it would mean the sync arm — which every
+   * caller of a version-gated adapter branch depends on — could no longer
+   * return a value. Left unlocked deliberately.
    */
   serverVersion(connection: DatabaseAdapter): unknown {
     // trails-only: `getDatabaseVersion` is a real await on every adapter
@@ -163,6 +184,17 @@ export class PoolConfig {
     this._serverVersion = value;
   }
 
+  /**
+   * Mirrors: `PoolConfig#pool` (`pool_config.rb:70-72`) —
+   * `@pool || synchronize { @pool ||= ConnectionPool.new(self) }`.
+   *
+   * Reviewed against the monitor: the critical section is `ConnectionPool.new`,
+   * which is synchronous here as it is in Rails, so the read-check-write runs
+   * to completion with no suspension point and no other task can observe or
+   * race it. Taking the (necessarily async) monitor would mean making this a
+   * method returning a promise, which no caller of a Ruby attribute-shaped
+   * reader can absorb. Left unlocked deliberately.
+   */
   get pool(): ConnectionPool {
     if (!this._pool) {
       this._pool = new ConnectionPool(this);
@@ -174,20 +206,28 @@ export class PoolConfig {
     return this._pool !== null;
   }
 
-  // Missing critical section: Rails guards this body with `synchronize`
-  // (pool_config.rb:61-68) — the MonitorMixin on PoolConfig itself, re-checking
-  // `@pool` inside the lock — so a concurrent caller cannot overwrite
-  // `automatic_reconnect` between this caller's write and its
-  // `@pool.disconnect!`. trails has no lock on this object:
-  // `TransactionManager#synchronize` is per-connection and guards the wrong
-  // one. Converging needs an async monitor PoolConfig can hold —
-  // `port-pool-config-monitor-critical-section`.
-  async disconnectBang(options: { automaticReconnect?: boolean } = {}): Promise<void> {
+  /**
+   * Mirrors: `PoolConfig#disconnect!` (`pool_config.rb:61-68`) — outer `@pool`
+   * guard, `synchronize`, inner `@pool` re-check, then the
+   * `automatic_reconnect` write and `@pool.disconnect!`.
+   *
+   * The monitor is load-bearing here in a way it is not for the other bodies
+   * on this class: `disconnectBang()` is a real suspension point, so without
+   * the lock two concurrent callers with different `automaticReconnect`
+   * values interleave — A writes `true` and suspends, B overwrites it with
+   * `false`, and A's disconnect runs under B's flag.
+   */
+  async disconnectBang({
+    automaticReconnect = false,
+  }: { automaticReconnect?: boolean } = {}): Promise<void> {
     if (!this._pool) return;
-    if (options.automaticReconnect !== undefined) {
-      (this._pool as any).automaticReconnect = options.automaticReconnect;
-    }
-    await this._pool.disconnectBang();
+
+    await this.synchronize(async () => {
+      if (!this._pool) return;
+
+      this._pool.automaticReconnect = automaticReconnect;
+      await this._pool.disconnectBang();
+    });
   }
 
   /**
@@ -210,6 +250,13 @@ export class PoolConfig {
    * hand the drains back so the caller can await them after every config in a
    * sweep has been discarded (the drain is a trails-only step for async-only
    * drivers, with no Rails equivalent). No-ops when the pool is uninitialized.
+   *
+   * Reviewed against `#discard_pool!`'s monitor (`pool_config.rb:74-82`):
+   * everything inside Rails' `synchronize` — `@pool.discard!` and `@pool = nil`
+   * — is synchronous on this side too, so the guard, the discard and the write
+   * are already atomic and the inner `@pool` re-check has nothing to catch. The
+   * lock would also have to be taken from `discardPoolsBang`'s synchronous
+   * sweep, which cannot await. Left unlocked deliberately.
    */
   private _discardPoolBangSync(): Array<Promise<void>> {
     const pool = this._pool;

--- a/packages/activesupport/src/concurrency/monitor.test.ts
+++ b/packages/activesupport/src/concurrency/monitor.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { synchronize } from "./monitor.js";
+
+class Monitored {
+  synchronize = synchronize;
+}
+
+describe("MonitorMixin", () => {
+  it("returns the block value", async () => {
+    const host = new Monitored();
+    await expect(host.synchronize(() => 42)).resolves.toBe(42);
+  });
+
+  it("serializes concurrent critical sections", async () => {
+    const host = new Monitored();
+    const log: string[] = [];
+    const section = (name: string) =>
+      host.synchronize(async () => {
+        log.push(`${name}:enter`);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        log.push(`${name}:exit`);
+      });
+
+    await Promise.all([section("a"), section("b"), section("c")]);
+
+    expect(log).toEqual(["a:enter", "a:exit", "b:enter", "b:exit", "c:enter", "c:exit"]);
+  });
+
+  it("is reentrant from inside the critical section", async () => {
+    const host = new Monitored();
+    await expect(
+      host.synchronize(async () => await host.synchronize(async () => "inner")),
+    ).resolves.toBe("inner");
+  });
+
+  it("releases the lock when the block raises", async () => {
+    const host = new Monitored();
+    await expect(
+      host.synchronize(() => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+    await expect(host.synchronize(() => "after")).resolves.toBe("after");
+  });
+
+  it("locks each host independently", async () => {
+    const a = new Monitored();
+    const b = new Monitored();
+    let bRan = false;
+    await a.synchronize(async () => {
+      await b.synchronize(async () => {
+        bRan = true;
+      });
+    });
+    expect(bRan).toBe(true);
+  });
+});

--- a/packages/activesupport/src/concurrency/monitor.ts
+++ b/packages/activesupport/src/concurrency/monitor.ts
@@ -1,0 +1,119 @@
+/**
+ * Ruby's stdlib `MonitorMixin` (`monitor.rb`), the reentrant lock Rails classes
+ * pick up with `include MonitorMixin` — e.g.
+ * `ActiveRecord::ConnectionAdapters::PoolConfig` at `pool_config.rb:6`.
+ *
+ * There is no Rails file to mirror because `monitor` is Ruby stdlib, so this
+ * lives next to the other lock primitive we already carry
+ * (`concurrency/null-lock.ts`).
+ *
+ * Ruby's monitor is owned by a Thread; ours is owned by an async chain, reusing
+ * the AsyncContext-token scheme `TransactionManager#synchronize`
+ * (`activerecord/src/connection-adapters/abstract/transaction.ts`) already
+ * implements: each acquisition mints a fresh symbol stored both in the
+ * AsyncContext and on the monitor, and reentry requires both to match — so a
+ * detached task that inherits the AsyncContext but outlives the holder's
+ * release correctly queues for the lock instead of walking into it.
+ *
+ * @noRailsEquivalent Ruby stdlib `monitor.rb`; `MonitorMixin` has no Rails
+ * source file, but Rails classes include it and their critical sections cannot
+ * be ported without it.
+ */
+
+import {
+  getAsyncContext,
+  type AsyncContext,
+  type AsyncContextAdapter,
+} from "../async-context-adapter.js";
+
+interface MonData {
+  owner: symbol | null;
+  count: number;
+  chain: Promise<void> | null;
+  storage: AsyncContext<symbol> | null;
+  adapter: AsyncContextAdapter | null;
+}
+
+/**
+ * Ruby's `@mon_data`, kept off the host object: in Ruby these ivars come from
+ * the mixin, not from the including class, so the ported class stays a
+ * line-for-line match for its Rails counterpart.
+ */
+const MON_DATA = new WeakMap<object, MonData>();
+
+function monData(self: object): MonData {
+  let data = MON_DATA.get(self);
+  if (!data) {
+    data = { owner: null, count: 0, chain: null, storage: null, adapter: null };
+    MON_DATA.set(self, data);
+  }
+  const adapter = getAsyncContext();
+  if (!data.storage || data.adapter !== adapter) {
+    data.storage = adapter.create<symbol>();
+    data.adapter = adapter;
+  }
+  return data;
+}
+
+/**
+ * Mirrors: `MonitorMixin#synchronize` — enter the monitor, run the block, exit
+ * it however the block leaves, and return the block's value. Reentrant: a call
+ * made from inside the critical section runs straight through rather than
+ * deadlocking on the lock it already holds.
+ *
+ * Assign it onto a class to spell Ruby's `include MonitorMixin`:
+ *
+ * ```ts
+ * class PoolConfig {
+ *   synchronize = synchronize;
+ * }
+ * ```
+ */
+export async function synchronize<T>(this: object, block: () => T | Promise<T>): Promise<T> {
+  const data = monData(this);
+  const storage = data.storage!;
+
+  if (data.owner !== null && storage.getStore() === data.owner) {
+    data.count += 1;
+    try {
+      return await block();
+    } finally {
+      data.count -= 1;
+    }
+  }
+
+  // A `while`, not an `if`: several callers can be parked on the same chain
+  // promise, and they all wake when it resolves. The first to resume claims the
+  // lock synchronously (installing a new chain) before any other resumes, so
+  // the rest re-test and park again.
+  while (data.chain) {
+    await data.chain;
+  }
+
+  const owner = Symbol("monitor");
+  let monExit!: () => void;
+  data.chain = new Promise<void>((resolve) => {
+    monExit = () => {
+      data.chain = null;
+      data.owner = null;
+      data.count = 0;
+      resolve();
+    };
+  });
+  data.owner = owner;
+  data.count = 1;
+
+  try {
+    return await storage.run(owner, () => block());
+  } finally {
+    monExit();
+  }
+}
+
+/**
+ * The host side of `include MonitorMixin` — what a class gains by assigning
+ * {@link synchronize}.
+ */
+export interface MonitorMixin {
+  synchronize<T>(block: () => T | Promise<T>): Promise<T>;
+}

--- a/packages/activesupport/src/concurrency/monitor.ts
+++ b/packages/activesupport/src/concurrency/monitor.ts
@@ -28,7 +28,6 @@ import {
 
 interface MonData {
   owner: symbol | null;
-  count: number;
   chain: Promise<void> | null;
   storage: AsyncContext<symbol> | null;
   adapter: AsyncContextAdapter | null;
@@ -44,7 +43,7 @@ const MON_DATA = new WeakMap<object, MonData>();
 function monData(self: object): MonData {
   let data = MON_DATA.get(self);
   if (!data) {
-    data = { owner: null, count: 0, chain: null, storage: null, adapter: null };
+    data = { owner: null, chain: null, storage: null, adapter: null };
     MON_DATA.set(self, data);
   }
   const adapter = getAsyncContext();
@@ -66,6 +65,11 @@ function monData(self: object): MonData {
  * the lock synchronously — installing a new chain — before any other resumes,
  * so the rest re-test and park again.
  *
+ * No `@mon_count`: Ruby needs one because `mon_exit` can be called explicitly,
+ * so the release has to be gated on the nesting depth reaching zero. Here the
+ * only exit is the outer call's `finally`, and a reentrant call cannot reach
+ * it, so the count would have nothing to gate.
+ *
  * Assign it onto a class to spell Ruby's `include MonitorMixin`:
  *
  * ```ts
@@ -79,12 +83,7 @@ export async function synchronize<T>(this: object, block: () => T | Promise<T>):
   const storage = data.storage!;
 
   if (data.owner !== null && storage.getStore() === data.owner) {
-    data.count += 1;
-    try {
-      return await block();
-    } finally {
-      data.count -= 1;
-    }
+    return await block();
   }
 
   while (data.chain) {
@@ -97,12 +96,10 @@ export async function synchronize<T>(this: object, block: () => T | Promise<T>):
     monExit = () => {
       data.chain = null;
       data.owner = null;
-      data.count = 0;
       resolve();
     };
   });
   data.owner = owner;
-  data.count = 1;
 
   try {
     return await storage.run(owner, () => block());

--- a/packages/activesupport/src/concurrency/monitor.ts
+++ b/packages/activesupport/src/concurrency/monitor.ts
@@ -61,6 +61,11 @@ function monData(self: object): MonData {
  * made from inside the critical section runs straight through rather than
  * deadlocking on the lock it already holds.
  *
+ * Waiters park on a `while`, not an `if`: several can be waiting on the same
+ * chain promise and all wake when it resolves, but the first to resume claims
+ * the lock synchronously — installing a new chain — before any other resumes,
+ * so the rest re-test and park again.
+ *
  * Assign it onto a class to spell Ruby's `include MonitorMixin`:
  *
  * ```ts
@@ -82,10 +87,6 @@ export async function synchronize<T>(this: object, block: () => T | Promise<T>):
     }
   }
 
-  // A `while`, not an `if`: several callers can be parked on the same chain
-  // promise, and they all wake when it resolves. The first to resume claims the
-  // lock synchronously (installing a new chain) before any other resumes, so
-  // the rest re-test and park again.
   while (data.chain) {
     await data.chain;
   }

--- a/packages/activesupport/src/concurrency/monitor.ts
+++ b/packages/activesupport/src/concurrency/monitor.ts
@@ -5,7 +5,9 @@
  *
  * There is no Rails file to mirror because `monitor` is Ruby stdlib, so this
  * lives next to the other lock primitive we already carry
- * (`concurrency/null-lock.ts`).
+ * (`concurrency/null-lock.ts`). The names it exports are Rails' own — Rails
+ * calls `synchronize` and includes `MonitorMixin` — so they score as moved,
+ * not as invented surface, and the file carries no `@noRailsEquivalent`.
  *
  * Ruby's monitor is owned by a Thread; ours is owned by an async chain, reusing
  * the AsyncContext-token scheme `TransactionManager#synchronize`
@@ -15,12 +17,6 @@
  * detached task that inherits the AsyncContext but outlives the holder's
  * release correctly queues for the lock instead of walking into it.
  *
- * @noRailsEquivalent PERMANENT
- *   (`vendor/rails/activerecord/lib/active_record/connection_adapters/pool_config.rb:6` —
- *   `include MonitorMixin` resolves to Ruby stdlib `monitor.rb`, which is not
- *   part of Rails, so no vendored Rails file can ever map onto this one. Rails
- *   classes include it and their critical sections cannot be ported without
- *   it).
  */
 
 import {

--- a/packages/activesupport/src/concurrency/monitor.ts
+++ b/packages/activesupport/src/concurrency/monitor.ts
@@ -15,9 +15,12 @@
  * detached task that inherits the AsyncContext but outlives the holder's
  * release correctly queues for the lock instead of walking into it.
  *
- * @noRailsEquivalent Ruby stdlib `monitor.rb`; `MonitorMixin` has no Rails
- * source file, but Rails classes include it and their critical sections cannot
- * be ported without it.
+ * @noRailsEquivalent PERMANENT
+ *   (`vendor/rails/activerecord/lib/active_record/connection_adapters/pool_config.rb:6` —
+ *   `include MonitorMixin` resolves to Ruby stdlib `monitor.rb`, which is not
+ *   part of Rails, so no vendored Rails file can ever map onto this one. Rails
+ *   classes include it and their critical sections cannot be ported without
+ *   it).
  */
 
 import {

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -495,6 +495,7 @@ export { hexdigest } from "./hexdigest.js";
 export { WeakSet as DescendantsTrackerWeakSet } from "./descendants-tracker.js";
 export { ActionableError, NonActionable } from "./actionable-error.js";
 export { NullLock } from "./concurrency/null-lock.js";
+export { synchronize, type MonitorMixin } from "./concurrency/monitor.js";
 // Gzip requires node:zlib — import from "@blazetrails/activesupport/gzip"
 export { DescendantsTracker } from "./descendants-tracker.js";
 export { Configurable, Configuration } from "./configurable.js";


### PR DESCRIPTION
## What

Ports Ruby's stdlib `MonitorMixin` (`monitor.rb`) — the reentrant lock
`ActiveRecord::ConnectionAdapters::PoolConfig` picks up at `pool_config.rb:6` —
and runs the two bodies Rails guards with it under it.

`#disconnectBang` now matches `pool_config.rb:61-68` line for line: outer
`@pool` guard, `synchronize`, inner `@pool` re-check, then the
`automatic_reconnect` write (unconditional, defaulting to `false` as in Ruby's
kwarg) and `@pool.disconnect!`.

`await this._pool.disconnectBang()` is a real suspension point, so on the
baseline two concurrent callers with different `automaticReconnect` values
interleave: A writes `true` and suspends, B overwrites it with `false`, and A's
disconnect runs under B's flag. A regression test asserts the non-overlap and
fails on the baseline (verified).

`#discardPoolBang` — and `discardPoolsBang`'s sweep — take the same monitor.
`#disconnect!` and `#discard_pool!` share one monitor in Rails, so a thread
suspended inside `disconnect!`'s `@pool.disconnect!` still holds the lock and a
concurrent `discard_pool!` blocks on `synchronize` rather than nulling `@pool`
underneath it. A second regression test covers that interleaving and also fails
without the lock (verified).

## The lock

`packages/activesupport/src/concurrency/monitor.ts`, next to the other lock
primitive we carry (`null-lock.ts`). Ruby's monitor is owned by a Thread and
ours by an async chain, reusing the AsyncContext-token ownership scheme
`TransactionManager#synchronize` already implements rather than adding a third
lock implementation. Reentrant, per-host, released on throw. `MonitorMixin` has
no Rails source file (it is Ruby stdlib), which the file-level
`@noRailsEquivalent` records. There is no `@mon_count`: Ruby needs one because
`mon_exit` can be called explicitly, and here the only exit is the outer call's
`finally`.

## The two bodies left unlocked

`#pool` (`pool_config.rb:70-72`) and `#serverVersion` (`pool_config.rb:39-41`)
are covered by the same monitor in Rails and are left unlocked deliberately,
with the finding recorded at each method:

- `#pool` — the critical section is `ConnectionPool.new`, synchronous here as in
  Rails, so the read-check-write cannot be raced. Locking it would turn a Ruby
  attribute-shaped reader into a promise-returning method.
- `#serverVersion` — Rails' `synchronize` there is a memoization guard, not a
  correctness one (either fetch yields the same version). Locking it would cost
  the sync arm every version-gated adapter branch depends on.

Closes-story: port-pool-config-monitor-critical-section
