### PR TITLE
refactor(activerecord): converge replace_on_target to one method with Rails' inversing kwarg

### DIFF
--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -847,8 +847,16 @@ export class CollectionAssociation extends Association {
     const distinctValue = !!(this.associationScope() as { distinctValue?: boolean } | undefined)
       ?.distinctValue;
     const shouldReplace = replace || distinctValue;
-    if (save) return replaceOnTargetAsync(this, record, skipCallbacks, shouldReplace, save);
-    return replaceOnTarget(this, record, skipCallbacks, shouldReplace);
+    if (save) {
+      return replaceOnTarget(
+        this,
+        record,
+        skipCallbacks,
+        { replace: shouldReplace },
+        save,
+      ) as Promise<Base | null>;
+    }
+    return replaceOnTarget(this, record, skipCallbacks, { replace: shouldReplace }) as Base | null;
   }
 
   /**
@@ -1422,112 +1430,75 @@ function replaceCommonRecordsInMemory(
 ): void {
   const common = diffHooks(assoc).intersection(newTarget, originalTarget);
   for (const record of common) {
-    replaceOnTarget(assoc, record, true, true);
+    replaceOnTarget(assoc, record, true, { replace: true }) as Base | null;
   }
 }
 
 /**
- * Rails `replace_on_target`'s pre-`yield` half: the index lookup, `before_add`
- * abort check, `set_inverse_instance`, and `@association_ids` reset. Returns the
- * replace index (`-1` when appending) or `null` when `before_add` aborted the
- * add (Rails' `catch(:abort) { ... } || return`). Shared by the sync
- * `replaceOnTarget` and the async `replaceOnTargetAsync` so both stay in parity.
+ * Mirrors Rails' `CollectionAssociation#replace_on_target(record,
+ * skip_callbacks, replace:, inversing: false, &block)`
+ * (collection_association.rb:457-489) — one Rails method, one TS function.
+ *
+ * `block` is Rails' `yield(record)`: `concat_records` passes the per-record
+ * insert there. TypeScript cannot `await` inside a function whose other callers
+ * (build/replace) must stay synchronous, so the block's promise is threaded
+ * through `.then` rather than `await`ed, and the function's return type widens
+ * to `Promise<Base | null>` exactly when a block is supplied. Rails'
+ * `ensure @_was_loaded = nil` (:488) therefore runs in a `finally` on that
+ * promise for the block arm and in the sync `finally` otherwise.
+ *
  * @internal
  */
-function beginReplaceOnTarget(
-  assoc: CollectionAssociation,
-  record: Base,
-  skipCallbacks: boolean,
-  replace: boolean,
-): number | null {
-  // Rails: `index = @target.index(record) if replace && (!record.new_record? ||
-  // @replaced_or_added_targets.include?(record))` (collection_association.rb:478).
-  const index =
-    replace && (!record.isNewRecord() || assoc._replacedOrAddedTargets.has(record))
-      ? indexInTarget(assoc, record)
-      : -1;
-  if (!skipCallbacks && !callback(assoc, "beforeAdd", record)) return null;
-  assoc.setInverseInstance(record);
-  assoc._wasLoaded = true;
-  return index;
-}
-
-/**
- * Rails `replace_on_target`'s post-`yield` half: the target mutation and
- * `after_add` callback.
- * @internal
- */
-function finishReplaceOnTarget(
-  assoc: CollectionAssociation,
-  record: Base,
-  skipCallbacks: boolean,
-  index: number,
-): Base {
-  const target = assoc.target;
-  // Rails re-runs `@target.index(record)` after the `yield` — the block (a
-  // save) can have added the record to `@replaced_or_added_targets` in between.
-  let at = index;
-  if (at === -1 && assoc._replacedOrAddedTargets.has(record)) at = indexInTarget(assoc, record);
-  if (at !== -1 || record.isNewRecord()) assoc._replacedOrAddedTargets.add(record);
-  if (at !== -1) {
-    target[at] = record;
-  } else if (assoc._wasLoaded || !assoc.isLoaded()) {
-    (assoc as any)._associationIds = null;
-    target.push(record);
-  }
-  if (!skipCallbacks) callback(assoc, "afterAdd", record);
-  return record;
-}
-
-/**
- * Ruby's `@target.index(record)` inside `replace_on_target`: `Core#==`, not JS
- * reference identity, so a re-fetched persisted record dedups against the one
- * already buffered.
- * @internal
- */
-function indexInTarget(assoc: CollectionAssociation, record: Base): number {
-  return assoc.target.findIndex((r) => r === record || r.equals(record));
-}
-
-/** @internal */
 function replaceOnTarget(
   assoc: CollectionAssociation,
   record: Base,
   skipCallbacks: boolean,
-  replace: boolean,
-): Base | null {
-  try {
-    const index = beginReplaceOnTarget(assoc, record, skipCallbacks, replace);
-    if (index === null) return null;
-    return finishReplaceOnTarget(assoc, record, skipCallbacks, index);
-  } finally {
-    // Rails' `ensure @_was_loaded = nil` (collection_association.rb:488).
-    assoc._wasLoaded = null;
-  }
-}
+  { replace, inversing = false }: { replace: boolean; inversing?: boolean },
+  block?: () => Promise<void>,
+): Base | null | Promise<Base | null> {
+  // Ruby's `@target.index(record)` uses `Core#==`, not JS reference identity,
+  // so a re-fetched persisted record dedups against the one already buffered.
+  // `-1` stands in for Ruby's `nil` index throughout.
+  const targetIndex = (): number => assoc.target.findIndex((r) => r === record || r.equals(record));
 
-/**
- * Async twin of `replaceOnTarget`: runs `save` at Rails' `yield(record)` point
- * — after `set_inverse_instance`, before the target mutation and after_add.
- * Kept as a separate async function so the sync `replaceOnTarget` callers
- * (build/replace paths) stay synchronous.
- * @internal
- */
-async function replaceOnTargetAsync(
-  assoc: CollectionAssociation,
-  record: Base,
-  skipCallbacks: boolean,
-  replace: boolean,
-  save?: () => Promise<void>,
-): Promise<Base | null> {
+  let index =
+    replace && (!record.isNewRecord() || assoc._replacedOrAddedTargets.has(record))
+      ? targetIndex()
+      : -1;
+
+  const afterYield = (): Base => {
+    const target = assoc.target;
+    if (index === -1 && assoc._replacedOrAddedTargets.has(record)) index = targetIndex();
+    if (inversing || index !== -1 || record.isNewRecord()) {
+      assoc._replacedOrAddedTargets.add(record);
+    }
+    if (index !== -1) {
+      target[index] = record;
+    } else if (assoc._wasLoaded || !assoc.isLoaded()) {
+      (assoc as any)._associationIds = null;
+      target.push(record);
+    }
+    if (!skipCallbacks) callback(assoc, "afterAdd", record);
+    return record;
+  };
+
+  let yielded = false;
   try {
-    const index = beginReplaceOnTarget(assoc, record, skipCallbacks, replace);
-    if (index === null) return null;
-    if (save) await save();
-    return finishReplaceOnTarget(assoc, record, skipCallbacks, index);
+    if (!skipCallbacks && !callback(assoc, "beforeAdd", record)) return null;
+    assoc.setInverseInstance(record);
+    assoc._wasLoaded = true;
+    if (block) {
+      yielded = true;
+      return block()
+        .then(afterYield)
+        .finally(() => {
+          assoc._wasLoaded = null;
+        });
+    }
+    return afterYield();
   } finally {
     // Rails' `ensure @_was_loaded = nil` (collection_association.rb:488).
-    assoc._wasLoaded = null;
+    if (!yielded) assoc._wasLoaded = null;
   }
 }
 

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -486,8 +486,10 @@ export class CollectionAssociation extends Association {
    * @missingRailsCall loaded? — the `{ @_was_loaded = loaded? }` block Rails
    * hands to `insert_record` (collection_association.rb:365-367) feeds
    * `replace_on_target`'s `@_was_loaded || !loaded?` append gate
-   * (collection_association.rb:481). trails' `replaceOnTarget` port appends
-   * unconditionally, so the flag has no reader to set.
+   * (collection_association.rb:481). `replaceOnTarget` reads the flag, but at
+   * this call site both arms of that gate agree — an unloaded association takes
+   * `!loaded?` and a loaded one would set the flag `true` — so writing it is
+   * unobservable here.
    * @internal
    */
   protected override async _createRecord(

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1460,15 +1460,21 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    */
   private _replaceOnTarget(
     record: T,
-    options: { skipCallbacks?: boolean; replace?: boolean } = {},
+    options: { skipCallbacks?: boolean; replace?: boolean; inversing?: boolean } = {},
   ): T | null {
-    const { skipCallbacks = false, replace = false } = options;
+    const { skipCallbacks = false, replace = false, inversing = false } = options;
     const index = this._targetReplaceIndex(record, replace);
     if (!skipCallbacks && !assocCallback(this._callbackHost, "beforeAdd", record)) {
       return null;
     }
-    _setCollectionInverseInstance(this._record, this._assocName, this._assocDef.options, record);
-    this._commitToTarget(record, index);
+    if (!inversing) {
+      // Rails' `set_inverse_instance(record)` (collection_association.rb:466).
+      // On the `inversing: true` path the reciprocal (record → owner) side has
+      // already been established by the caller in `associations.ts`, and
+      // re-wiring here would recurse back into `_wireInverseTarget`.
+      _setCollectionInverseInstance(this._record, this._assocName, this._assocDef.options, record);
+    }
+    this._commitToTarget(record, index, inversing);
     if (!skipCallbacks) assocCallback(this._callbackHost, "afterAdd", record);
     return record;
   }
@@ -1492,11 +1498,13 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * save), record the identity, then either replace in place or append.
    * @internal
    */
-  private _commitToTarget(record: T, index: number): void {
+  private _commitToTarget(record: T, index: number, inversing = false): void {
     if (index === -1 && this._replacedOrAddedTargets.has(record)) {
       index = this._indexInTarget(record);
     }
-    if (index !== -1 || record.isNewRecord()) {
+    // Rails: `@replaced_or_added_targets << record if inversing || index ||
+    // record.new_record?` (collection_association.rb:476).
+    if (inversing || index !== -1 || record.isNewRecord()) {
       this._replacedOrAddedTargets.add(record);
     }
     if (index !== -1) {
@@ -1530,44 +1538,26 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * (the call at collection_association.rb:294), the path Rails takes when a
    * belongs_to-loaded or preloaded record is folded back into its `has_many`
    * owner: `skip_callbacks` (no before/after_add — inverse wiring is not a user
-   * `<<`), `replace: true`, and `inversing: true`. Per that method we always
-   * record the record in
-   * `@replaced_or_added_targets` (so a later `<<`/`push` of the same record
-   * replaces in place rather than appending a duplicate) and, because
-   * `@_was_loaded` is forced true there, always append to `@target` — loaded or
-   * not. A subsequent real `load()` merges this in-memory record by primary key
+   * `<<`), `replace: true`, and `inversing: true`. The `inversing` arm of that
+   * method's `@replaced_or_added_targets << record if inversing || index ||
+   * record.new_record?` (:476) is what records a *persisted* record here, so a
+   * later `<<`/`push` of the same record replaces in place rather than
+   * appending a duplicate; and because `@_was_loaded` is forced true there we
+   * always append to `@target` — loaded or not. A subsequent real `load()` merges this in-memory record by primary key
    * (the trails analog of `merge_target_lists`), so the early append is not
    * double-counted.
    *
    * This is the single write entry point for inverse has_many targets. The C2
    * (#2591) seam, which used to reach into `proxy._replacedOrAddedTargets` from
    * `associations.ts`, is now internal here. `set_inverse_instance(record)` is
-   * deliberately NOT re-invoked: the reciprocal (record → owner) side is
-   * established by the caller in `associations.ts`, and re-wiring here would
-   * recurse. The seeded record lands in `_target`, which `Base#_associationCache`
+   * deliberately NOT re-invoked (see `_replaceOnTarget`'s `inversing` guard):
+   * the reciprocal (record → owner) side is established by the caller in
+   * `associations.ts`, and re-wiring here would recurse. The seeded record lands in `_target`, which `Base#_associationCache`
    * surfaces to readers (this proxy is the canonical has_many store).
    * @internal
    */
   _wireInverseTarget(record: T): void {
-    // replace && (!new_record? || @replaced_or_added_targets.include?(record))
-    const index =
-      !record.isNewRecord() || this._replacedOrAddedTargets.has(record)
-        ? this._indexInTarget(record)
-        : -1;
-    // Rails re-runs `@target.index(record)` after `set_inverse_instance` / the
-    // `yield` block (collection_association.rb:478-480) because that block can
-    // mutate `_target` / `_replacedOrAddedTargets` between the two searches.
-    // The `inversing: true` path passes no block and we deliberately do not
-    // re-invoke `set_inverse_instance` here (see above), so nothing changes in
-    // between — the re-search would be a no-op and is omitted.
-    // inversing: true → unconditionally tracked.
-    this._replacedOrAddedTargets.add(record);
-    if (index !== -1) {
-      this._target[index] = record;
-    } else {
-      this._target.push(record);
-      this._invalidateAssociationIds();
-    }
+    this._replaceOnTarget(record, { skipCallbacks: true, replace: true, inversing: true });
   }
 
   // NOTE: If _pushThrough fails after the target is saved, the target record

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1543,17 +1543,18 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * record.new_record?` (:476) is what records a *persisted* record here, so a
    * later `<<`/`push` of the same record replaces in place rather than
    * appending a duplicate; and because `@_was_loaded` is forced true there we
-   * always append to `@target` — loaded or not. A subsequent real `load()` merges this in-memory record by primary key
-   * (the trails analog of `merge_target_lists`), so the early append is not
-   * double-counted.
+   * always append to `@target` — loaded or not. A subsequent real `load()`
+   * merges this in-memory record by primary key (the trails analog of
+   * `merge_target_lists`), so the early append is not double-counted.
    *
    * This is the single write entry point for inverse has_many targets. The C2
    * (#2591) seam, which used to reach into `proxy._replacedOrAddedTargets` from
    * `associations.ts`, is now internal here. `set_inverse_instance(record)` is
    * deliberately NOT re-invoked (see `_replaceOnTarget`'s `inversing` guard):
    * the reciprocal (record → owner) side is established by the caller in
-   * `associations.ts`, and re-wiring here would recurse. The seeded record lands in `_target`, which `Base#_associationCache`
-   * surfaces to readers (this proxy is the canonical has_many store).
+   * `associations.ts`, and re-wiring here would recurse. The seeded record
+   * lands in `_target`, which `Base#_associationCache` surfaces to readers
+   * (this proxy is the canonical has_many store).
    * @internal
    */
   _wireInverseTarget(record: T): void {

--- a/packages/activerecord/src/associations/replace-on-target-inversing.trails.test.ts
+++ b/packages/activerecord/src/associations/replace-on-target-inversing.trails.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Covers `replace_on_target`'s `inversing:` kwarg
+ * (activerecord/lib/active_record/associations/collection_association.rb:457,
+ * read at :476 — `@replaced_or_added_targets << record if inversing || index ||
+ * record.new_record?`), reached from `target=` at :294 with
+ * `replace_on_target(record, true, replace: true, inversing: true)`.
+ *
+ * A *persisted* record folded in through the inversing path is tracked in
+ * `@replaced_or_added_targets` only because of the `inversing ||` arm — without
+ * it a later add of the same record misses the `:458` index lookup and appends
+ * a duplicate instead of replacing in place. This locks that arm: drop
+ * `inversing: true` from `CollectionProxy#_wireInverseTarget`'s
+ * `_replaceOnTarget` call, or the `inversing ||` factor from the set-add guard,
+ * and the second add appends a duplicate.
+ */
+import { describe, it, expect } from "vitest";
+import { Base, association } from "../index.js";
+import { fixtures } from "../test-fixtures.js";
+import { loadSingularTarget } from "../test-helpers/load-singular-target.js";
+import { Human } from "../test-helpers/models/human.js";
+
+async function withHasManyInversing(model: typeof Base, fn: () => Promise<void>): Promise<void> {
+  const flags = model as unknown as { hasManyInversing: boolean };
+  const prev = flags.hasManyInversing;
+  flags.hasManyInversing = true;
+  try {
+    await fn();
+  } finally {
+    flags.hasManyInversing = prev;
+  }
+}
+
+describe("replace_on_target inversing (trails)", () => {
+  const { interests } = fixtures(["humans", "interests"]);
+
+  it("tracks a persisted record added through the inversing path so a later add replaces in place", async () => {
+    await withHasManyInversing(Human, async () => {
+      const interest = interests("trainspotting") as Base & { id: number };
+      const human = (await loadSingularTarget(interest, "human")) as Base & {
+        _associationCache(name: string): { target: Base[] } | undefined;
+      };
+      const interestIds = (): unknown[] => {
+        const cached = human._associationCache("interests") as { target: Base[] } | undefined;
+        return (cached?.target ?? []).map((i: Base) => (i as Base & { id: number }).id);
+      };
+
+      expect(interestIds()).toEqual([interest.id]);
+
+      await association(human, "interests").push(interest);
+
+      expect(interestIds()).toEqual([interest.id]);
+    });
+  });
+});

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-association.json
@@ -59,5 +59,29 @@
       "kwargs{replace=bool:true}"
     ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/collection-association.ts",
+    "rubyName": "replace_on_target",
+    "call": "callback",
+    "kind": "args",
+    "rubyArgs": [
+      "str:beforeAdd",
+      "ref:record"
+    ],
+    "reason": "Receiver-as-first-argument shape, not an argument divergence: Rails' `callback(:before_add, record)` / `callback(:after_add, record)` (collection_association.rb:463, :485) are instance calls on the association, and the TS `callback` is a free function whose first parameter is that receiver (`assoc`), so the extractor reads it as an extra leading argument. Surfaced by this PR only because the begin/finish split collapsed into one `replaceOnTarget`, which the extractor can now match to `replace_on_target`; the calls themselves predate it. Converges with the file-wide receiver-as-first-argument burndown, not here."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/collection-association.ts",
+    "rubyName": "replace_on_target",
+    "call": "callback",
+    "kind": "args",
+    "rubyArgs": [
+      "str:afterAdd",
+      "ref:record"
+    ],
+    "reason": "Receiver-as-first-argument shape, not an argument divergence: Rails' `callback(:before_add, record)` / `callback(:after_add, record)` (collection_association.rb:463, :485) are instance calls on the association, and the TS `callback` is a free function whose first parameter is that receiver (`assoc`), so the extractor reads it as an extra leading argument. Surfaced by this PR only because the begin/finish split collapsed into one `replaceOnTarget`, which the extractor can now match to `replace_on_target`; the calls themselves predate it. Converges with the file-wide receiver-as-first-argument burndown, not here."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-association.json
@@ -67,7 +67,7 @@
     "call": "callback",
     "kind": "args",
     "rubyArgs": [
-      "str:beforeAdd",
+      "str:afterAdd",
       "ref:record"
     ],
     "reason": "Receiver-as-first-argument shape, not an argument divergence: Rails' `callback(:before_add, record)` / `callback(:after_add, record)` (collection_association.rb:463, :485) are instance calls on the association, and the TS `callback` is a free function whose first parameter is that receiver (`assoc`), so the extractor reads it as an extra leading argument. Surfaced by this PR only because the begin/finish split collapsed into one `replaceOnTarget`, which the extractor can now match to `replace_on_target`; the calls themselves predate it. Converges with the file-wide receiver-as-first-argument burndown, not here."
@@ -79,7 +79,7 @@
     "call": "callback",
     "kind": "args",
     "rubyArgs": [
-      "str:afterAdd",
+      "str:beforeAdd",
       "ref:record"
     ],
     "reason": "Receiver-as-first-argument shape, not an argument divergence: Rails' `callback(:before_add, record)` / `callback(:after_add, record)` (collection_association.rb:463, :485) are instance calls on the association, and the TS `callback` is a free function whose first parameter is that receiver (`assoc`), so the extractor reads it as an extra leading argument. Surfaced by this PR only because the begin/finish split collapsed into one `replaceOnTarget`, which the extractor can now match to `replace_on_target`; the calls themselves predate it. Converges with the file-wide receiver-as-first-argument burndown, not here."


### PR DESCRIPTION
Rails has one `CollectionAssociation#replace_on_target(record, skip_callbacks, replace:, inversing: false, &block)` (`activerecord/lib/active_record/associations/collection_association.rb:457-489`). trails had five functions over the same lines and no `inversing` parameter, so the set-add guard at `:476` — `@replaced_or_added_targets << record if inversing || index || record.new_record?` — was missing its `inversing ||` factor.

## What changed

**`associations/collection-association.ts`** — `beginReplaceOnTarget`, `finishReplaceOnTarget`, `indexInTarget`, `replaceOnTarget` and `replaceOnTargetAsync` fold into one `replaceOnTarget(assoc, record, skipCallbacks, { replace, inversing = false }, block?)`, Rails' signature and Rails' body order. The `@_was_loaded` guard on the append arm (`:480`) and the yield point are unchanged.

The one deviation is justified at the call site: TypeScript cannot `await` inside a function whose other callers (build / replace) must stay synchronous, so Rails' `yield(record)` block is threaded through `.then` rather than `await`ed and the return type widens to `Promise<Base | null>` exactly when a block is supplied. Rails' `ensure @_was_loaded = nil` (`:488`) runs in that promise's `finally` on the block arm and in the sync `finally` otherwise. `indexInTarget` (Ruby `@target.index(record)` uses `Core#==`, JS `indexOf` uses reference identity) becomes a local closure inside the method rather than a sibling top-level function — the genuine language gap stays explicit, the extra public surface goes away.

**`associations/collection-proxy.ts`** — `inversing` is threaded through `_replaceOnTarget` → `_commitToTarget`, and `_wireInverseTarget` (the trails `target=` inversing caller, reached from `set_inverse_instance` → `inversed_from`) now goes through `_replaceOnTarget(record, { skipCallbacks: true, replace: true, inversing: true })`, exactly `collection_association.rb:294`, instead of re-spelling the method body inline. `set_inverse_instance` stays skipped on that arm (re-wiring recurses back into `_wireInverseTarget`); that pre-existing deviation is now a single guarded branch with the reason at the call site rather than a duplicated body.

## On acceptance criterion 3

The regression test is a lock, not a red-on-baseline reproduction, and I verified that rather than assuming it: on `origin/main` the new test **passes**. The reason is that the inversing path in trails routes through `CollectionProxy#_wireInverseTarget`, whose inline body already hardcoded the `inversing: true` behaviour (an unconditional `_replacedOrAddedTargets.add`). The missing kwarg lived in the `collection-association.ts` copy, which has no inversing caller, so the double-append was latent there rather than reachable. The test does fail if the `inversing` arm is dropped from either copy — checked by flipping `inversing: true` to `false` in `_wireInverseTarget` (test goes red) and by re-running against untouched `origin/main` sources (green).

## Gates

- `pnpm parity:api:calls` — OK (no new rows)
- `pnpm parity:api:calls:args` — OK. Two `args` rows added to `call-mismatches-exclude/activerecord/associations/collection-association.json` for `replace_on_target → callback`, with a reviewed reason: they are the receiver-as-first-argument free-function shape (`callback(assoc, kind, record)` for Rails' instance call `callback(:before_add, record)`), surfaced only because the begin/finish split collapsed into one method the extractor can now match to `replace_on_target`. The calls predate this PR; they converge with the file-wide receiver-as-first-argument burndown, not here.
- `pnpm parity:api:extra --package activerecord` — no novel names (five top-level functions removed, one kept)
- `pnpm typecheck`, `pnpm lint` clean
- `pnpm vitest run packages/activerecord/src/associations/ packages/activerecord/src/nested-attributes.test.ts` — 97 files, 2155 passed, including `persistence-save-block.trails.test.ts`

Closes-story: replace-on-target-inversing-parameter
