### PR TITLE
refactor(activerecord): restore Rails local/parameter names in the abstract adapter cluster

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
@@ -185,8 +185,7 @@ export class ConnectionHandler {
       adapterFactory: options.adapterFactory,
     });
 
-    const poolKey = poolConfig.connectionDescriptor.name;
-    const poolManager = this.setPoolManager(poolKey);
+    const poolManager = this.setPoolManager(poolConfig.connectionDescriptor);
 
     const existingPoolConfig = poolManager.getPoolConfig(role, shard);
 
@@ -210,7 +209,7 @@ export class ConnectionHandler {
     poolManager.setPoolConfig(role, shard, poolConfig);
 
     const payload = {
-      connection_name: poolKey,
+      connection_name: poolConfig.connectionDescriptor.name,
       role,
       shard,
       config: poolConfig.dbConfig.configuration,
@@ -363,11 +362,11 @@ export class ConnectionHandler {
   }
 
   /** @internal */
-  private setPoolManager(connectionName: string): PoolManager {
-    let manager = this._connectionNameToPoolManager.get(connectionName);
+  private setPoolManager(connectionDescriptor: ConnectionDescriptor): PoolManager {
+    let manager = this._connectionNameToPoolManager.get(connectionDescriptor.name);
     if (!manager) {
       manager = new PoolManager();
-      this._connectionNameToPoolManager.set(connectionName, manager);
+      this._connectionNameToPoolManager.set(connectionDescriptor.name, manager);
     }
     return manager;
   }

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/reaper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/reaper.ts
@@ -36,8 +36,8 @@ export class Reaper {
   }
 
   run(): void {
-    if (!this._frequency || this._frequency <= 0) return;
-    Reaper.registerPool(this._pool, this._frequency);
+    if (!this.frequency || this.frequency <= 0) return;
+    Reaper.registerPool(this.pool, this.frequency);
   }
 
   // --- Class-level registry (mirrors Rails @mutex/@pools/@threads) ---

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -526,7 +526,7 @@ export function quotedTime(this: QuotingDispatchHost, value: QuotedTimeValue): s
   if (value instanceof TimeValue) {
     value = value.getobj().toZonedDateTimeISO(defaultSqlTimezone()).toPlainDateTime();
   }
-  const dt =
+  value =
     value instanceof Temporal.PlainTime
       ? new Temporal.PlainDateTime(
           2000,
@@ -540,7 +540,7 @@ export function quotedTime(this: QuotingDispatchHost, value: QuotedTimeValue): s
           value.nanosecond,
         )
       : value.with({ year: 2000, month: 1, day: 1 });
-  return this.quotedDate(dt).replace(/^\d{4}-\d{2}-\d{2} /, "");
+  return this.quotedDate(value).replace(/^\d{4}-\d{2}-\d{2} /, "");
 }
 
 /** @internal */

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1252,11 +1252,11 @@ export class TableDefinition {
     expression: string,
     options: { name?: string; validate?: boolean } = {},
   ): CheckConstraintDefinition {
-    const resolved = this._adapter.checkConstraintOptions(this.name, expression, options) as {
+    options = this._adapter.checkConstraintOptions(this.name, expression, options) as {
       name?: string;
       validate?: boolean;
     };
-    return new CheckConstraintDefinition(this.name, expression, resolved);
+    return new CheckConstraintDefinition(this.name, expression, options);
   }
 
   /** @internal */
@@ -1584,17 +1584,17 @@ export class Table {
     const options = (typeof last === "object" && last !== null ? rest.pop() : {}) as ColumnOptions;
     this.raiseOnIfExistOptions(options as Record<string, unknown>);
     await this._schema.removeColumns(
-      this._tableName,
+      this.name,
       ...(rest as string[]),
       ...(Object.keys(options).length > 0 ? [options] : []),
     );
   }
-  async rename(oldName: string, newName: string): Promise<void> {
-    await this._schema.renameColumn(this._tableName, oldName, newName);
+  async rename(columnName: string, newColumnName: string): Promise<void> {
+    await this._schema.renameColumn(this.name, columnName, newColumnName);
   }
   async index(columns: string | string[], options: AddIndexOptions = {}): Promise<void> {
     this.raiseOnIfExistOptions(options as Record<string, unknown>);
-    await this._schema.addIndex(this._tableName, columns, options);
+    await this._schema.addIndex(this.name, columns, options);
   }
   // Rails: `Table#remove_index(column_name = nil, **options)` forwards to
   // `@base.remove_index(table_name, column_name, **options)`.
@@ -1608,9 +1608,9 @@ export class Table {
     const columnName = isColumn ? columnOrOptions : undefined;
     // Ruby's `**options` collects the hash from either position, so an explicit
     // nil column with the options behind it keeps them.
-    const optionHash = isColumn ? options : { ...columnOrOptions, ...options };
-    this.raiseOnIfExistOptions(optionHash as Record<string, unknown>);
-    await this._schema.removeIndex(this._tableName, columnName, optionHash);
+    options = isColumn ? options : { ...columnOrOptions, ...options };
+    this.raiseOnIfExistOptions(options as Record<string, unknown>);
+    await this._schema.removeIndex(this.name, columnName, options);
   }
   async references(...refNames: string[]): Promise<void>;
   async references(...args: [...refNames: string[], options: AddReferenceOptions]): Promise<void>;
@@ -1618,7 +1618,7 @@ export class Table {
     const { names, options } = this._splitRefNames(args);
     this.raiseOnIfExistOptions(options as Record<string, unknown>);
     for (const refName of names) {
-      await this._schema.addReference(this._tableName, refName, options);
+      await this._schema.addReference(this.name, refName, options);
     }
   }
   async belongsTo(...refNames: string[]): Promise<void>;
@@ -1628,7 +1628,7 @@ export class Table {
   }
   async timestamps(options: ColumnOptions = {}): Promise<void> {
     this.raiseOnIfExistOptions(options as Record<string, unknown>);
-    await this._schema.addTimestamps(this._tableName, options);
+    await this._schema.addTimestamps(this.name, options);
   }
 
   get name(): string {
@@ -1645,18 +1645,18 @@ export class Table {
     // `@base.add_column(name, column_name, type, **options)` passes no fourth
     // argument when `options` is empty, and CommandRecorder records args verbatim.
     if (Object.keys(colOpts).length === 0) {
-      await this._schema.addColumn(this._tableName, columnName, type);
+      await this._schema.addColumn(this.name, columnName, type);
     } else {
-      await this._schema.addColumn(this._tableName, columnName, type, colOpts as ColumnOptions);
+      await this._schema.addColumn(this.name, columnName, type, colOpts as ColumnOptions);
     }
     if (indexOpt) {
       const opts: AddIndexOptions = typeof indexOpt === "object" ? indexOpt : {};
-      await this._schema.addIndex(this._tableName, columnName, opts);
+      await this._schema.addIndex(this.name, columnName, opts);
     }
   }
 
   async columnExists(columnName: string, type?: ColumnType): Promise<boolean> {
-    return this._require("columnExists").call(this._schema, this._tableName, columnName, type);
+    return this._require("columnExists").call(this._schema, this.name, columnName, type);
   }
 
   private _require<K extends keyof SchemaStatementsLike>(
@@ -1671,28 +1671,22 @@ export class Table {
     columnName: string | string[],
     options: Record<string, unknown> = {},
   ): Promise<boolean> {
-    return this._require("indexExists").call(this._schema, this._tableName, columnName, options);
+    return this._require("indexExists").call(this._schema, this.name, columnName, options);
   }
 
   async renameIndex(oldName: string, newName: string): Promise<void> {
-    return this._require("renameIndex").call(this._schema, this._tableName, oldName, newName);
+    return this._require("renameIndex").call(this._schema, this.name, oldName, newName);
   }
 
   async change(columnName: string, type: ColumnType, options: ColumnOptions = {}): Promise<void> {
     this.raiseOnIfExistOptions(options as Record<string, unknown>);
-    return this._require("changeColumn").call(
-      this._schema,
-      this._tableName,
-      columnName,
-      type,
-      options,
-    );
+    return this._require("changeColumn").call(this._schema, this.name, columnName, type, options);
   }
 
   async changeDefault(columnName: string, defaultOrChanges: unknown): Promise<void> {
     return this._require("changeColumnDefault").call(
       this._schema,
-      this._tableName,
+      this.name,
       columnName,
       defaultOrChanges,
     );
@@ -1701,7 +1695,7 @@ export class Table {
   async changeNull(columnName: string, isNull: boolean, defaultValue?: unknown): Promise<void> {
     return this._require("changeColumnNull").call(
       this._schema,
-      this._tableName,
+      this.name,
       columnName,
       isNull,
       defaultValue,
@@ -1709,7 +1703,7 @@ export class Table {
   }
 
   async removeTimestamps(options?: ColumnOptions): Promise<void> {
-    return this._require("removeTimestamps").call(this._schema, this._tableName, options);
+    return this._require("removeTimestamps").call(this._schema, this.name, options);
   }
 
   async removeReferences(...refNames: string[]): Promise<void>;
@@ -1720,7 +1714,7 @@ export class Table {
     const { names, options } = this._splitRefNames(args);
     this.raiseOnIfExistOptions(options as Record<string, unknown>);
     for (const refName of names) {
-      await this._require("removeReference").call(this._schema, this._tableName, refName, options);
+      await this._require("removeReference").call(this._schema, this.name, refName, options);
     }
   }
   async removeBelongsTo(...refNames: string[]): Promise<void>;
@@ -1742,7 +1736,7 @@ export class Table {
 
   async foreignKey(toTable: string, options: Partial<AddForeignKeyOptions> = {}): Promise<void> {
     this.raiseOnIfExistOptions(options as Record<string, unknown>);
-    return this._require("addForeignKey").call(this._schema, this._tableName, toTable, options);
+    return this._require("addForeignKey").call(this._schema, this.name, toTable, options);
   }
 
   async removeForeignKey(
@@ -1751,20 +1745,15 @@ export class Table {
     this.raiseOnIfExistOptions(
       (typeof toTableOrOptions === "object" ? toTableOrOptions : {}) as Record<string, unknown>,
     );
-    return this._require("removeForeignKey").call(this._schema, this._tableName, toTableOrOptions);
+    return this._require("removeForeignKey").call(this._schema, this.name, toTableOrOptions);
   }
 
   async foreignKeyExists(toTableOrOptions?: string | Record<string, unknown>): Promise<boolean> {
-    return this._require("foreignKeyExists").call(this._schema, this._tableName, toTableOrOptions);
+    return this._require("foreignKeyExists").call(this._schema, this.name, toTableOrOptions);
   }
 
   async checkConstraint(expression: string, options?: Record<string, unknown>): Promise<void> {
-    return this._require("addCheckConstraint").call(
-      this._schema,
-      this._tableName,
-      expression,
-      options,
-    );
+    return this._require("addCheckConstraint").call(this._schema, this.name, expression, options);
   }
 
   async removeCheckConstraint(
@@ -1774,13 +1763,13 @@ export class Table {
     if (typeof expressionOrOptions === "string") {
       return this._require("removeCheckConstraint").call(
         this._schema,
-        this._tableName,
+        this.name,
         options?.name ? options : expressionOrOptions,
       );
     }
     return this._require("removeCheckConstraint").call(
       this._schema,
-      this._tableName,
+      this.name,
       expressionOrOptions,
     );
   }
@@ -1788,7 +1777,7 @@ export class Table {
   async checkConstraintExists(
     options: { name?: string; expression?: string } = {},
   ): Promise<boolean> {
-    return this._require("checkConstraintExists").call(this._schema, this._tableName, options);
+    return this._require("checkConstraintExists").call(this._schema, this.name, options);
   }
 
   async primaryKey(
@@ -1800,7 +1789,7 @@ export class Table {
   }
 
   async add(columnName: string, type: ColumnType, options?: ColumnOptions): Promise<void> {
-    return this._schema.addColumn(this._tableName, columnName, type, options);
+    return this._schema.addColumn(this.name, columnName, type, options);
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -535,27 +535,25 @@ export class SchemaStatements {
     // Rails: `remove_index(table_name, column_name = nil, **options)` — the column
     // can be passed positionally or via the options hash.
     let columnName: string | string[] | undefined;
-    let opts: { column?: string | string[]; name?: string; ifExists?: boolean };
     if (typeof columnOrOptions === "string" || Array.isArray(columnOrOptions)) {
       columnName = columnOrOptions;
-      opts = options;
     } else {
       columnName = undefined;
       // Ruby's `**options` collects the hash whether it arrived as the sole
       // argument or behind an explicit nil column.
-      opts = { ...columnOrOptions, ...options };
+      options = { ...columnOrOptions, ...options };
     }
 
     // Rails: `return if options[:if_exists] && !index_exists?(table_name,
     // column_name, **options)` (schema_statements.rb:967) — one probe, because
     // `Index#defined_for?` (schema_definitions.rb:54) reads `options[:column]`
     // when no columns are given and then matches on `name` alone.
-    if (opts.ifExists && !(await this.indexExists(tableName, columnName, opts))) return;
+    if (options.ifExists && !(await this.indexExists(tableName, columnName, options))) return;
 
     // Rails resolves the concrete index name via `index_name_for_remove`, which
     // raises ArgumentError when the spec matches no index (or is ambiguous), and
     // then drops by that real name — never a silent DROP ... IF EXISTS.
-    const indexName = await this.indexNameForRemove(tableName, columnName, opts);
+    const indexName = await this.indexNameForRemove(tableName, columnName, options);
 
     if (this.adapterName === "mysql") {
       await this.execute(
@@ -1830,21 +1828,21 @@ export class SchemaStatements {
     if (!algorithm) return undefined;
     const normalized = algorithm.toLowerCase();
 
-    const adapterAlgorithms =
+    const indexAlgorithms =
       typeof (this as any).indexAlgorithms === "function"
         ? ((this as any).indexAlgorithms() as Record<string, string>)
         : null;
 
-    if (adapterAlgorithms) {
-      if (normalized in adapterAlgorithms) {
-        const result = adapterAlgorithms[normalized];
+    if (indexAlgorithms) {
+      if (normalized in indexAlgorithms) {
+        const result = indexAlgorithms[normalized];
         return result || undefined;
       }
     } else if (normalized === "concurrently") {
       return "CONCURRENTLY";
     }
 
-    const valid = adapterAlgorithms ? Object.keys(adapterAlgorithms) : ["concurrently"];
+    const valid = indexAlgorithms ? Object.keys(indexAlgorithms) : ["concurrently"];
     throw new ArgumentError(
       `Algorithm must be one of the following: ${valid.map((a) => `'${a}'`).join(", ")}`,
     );

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -456,17 +456,21 @@ export class Transaction {
     const recs = this.records;
     if (recs) {
       const ite = this.uniqueRecords();
-      const instanceMap = this.prepareInstancesToRunCallbacksOn(ite);
+      const instancesToRunCallbacksOn = this.prepareInstancesToRunCallbacksOn(ite);
 
       try {
-        await this.runActionOnRecords(ite, instanceMap, async (record, shouldRunCallbacks) => {
-          if (typeof (record as any).rolledbackBang === "function") {
-            await (record as any).rolledbackBang({
-              forceRestoreState: this.isFullRollback(),
-              shouldRunCallbacks,
-            });
-          }
-        });
+        await this.runActionOnRecords(
+          ite,
+          instancesToRunCallbacksOn,
+          async (record, shouldRunCallbacks) => {
+            if (typeof (record as any).rolledbackBang === "function") {
+              await (record as any).rolledbackBang({
+                forceRestoreState: this.isFullRollback(),
+                shouldRunCallbacks,
+              });
+            }
+          },
+        );
       } finally {
         for (const i of ite) {
           if (typeof (i as any).rolledbackBang === "function") {
@@ -518,14 +522,18 @@ export class Transaction {
       const ite = this.uniqueRecords();
 
       if (this._runCommitCallbacks) {
-        const instanceMap = this.prepareInstancesToRunCallbacksOn(ite);
+        const instancesToRunCallbacksOn = this.prepareInstancesToRunCallbacksOn(ite);
 
         try {
-          await this.runActionOnRecords(ite, instanceMap, async (record, shouldRunCallbacks) => {
-            if (typeof (record as any).committedBang === "function") {
-              await (record as any).committedBang({ shouldRunCallbacks });
-            }
-          });
+          await this.runActionOnRecords(
+            ite,
+            instancesToRunCallbacksOn,
+            async (record, shouldRunCallbacks) => {
+              if (typeof (record as any).committedBang === "function") {
+                await (record as any).committedBang({ shouldRunCallbacks });
+              }
+            },
+          );
         } finally {
           for (const i of ite) {
             if (typeof (i as any).committedBang === "function") {

--- a/packages/activerecord/src/connection-adapters/pool-config.ts
+++ b/packages/activerecord/src/connection-adapters/pool-config.ts
@@ -60,8 +60,8 @@ export class PoolConfig {
       // missing config leaves the cache path null, which is what
       // SchemaReflection treats as "no persistent cache on disk"
       // (possibleCacheAvailable → false).
-      const cachePath = this._lazySchemaCachePath();
-      this._schemaReflection = new SchemaReflection(cachePath);
+      const lazySchemaCachePath = this._lazySchemaCachePath();
+      this._schemaReflection = new SchemaReflection(lazySchemaCachePath);
     }
     return this._schemaReflection;
   }

--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -947,8 +947,8 @@ export class BoundSchemaReflection {
     return new BoundSchemaReflection(abstractSchemaReflection, new FakePool(connection));
   }
 
-  constructor(schemaReflection: SchemaReflection, pool: unknown) {
-    this._schemaReflection = schemaReflection;
+  constructor(abstractSchemaReflection: SchemaReflection, pool: unknown) {
+    this._schemaReflection = abstractSchemaReflection;
     this._pool = pool;
   }
 

--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -540,12 +540,12 @@ export class SchemaCache {
   }
 
   async addAll(pool: unknown): Promise<void> {
-    await withConnection(pool, async (connection) => {
-      const tables = await this.tablesToCache(connection);
+    await withConnection(pool, async () => {
+      const tables = await this.tablesToCache(pool);
       for (const table of tables) {
-        await this.add(connection, table);
+        await this.add(pool, table);
       }
-      await this.version(connection);
+      await this.version(pool);
     });
   }
 
@@ -651,7 +651,7 @@ export class SchemaCache {
     return withConnection(pool, async (connection) => {
       if (typeof connection.dataSources === "function") {
         const tables = (await connection.dataSources()) as string[];
-        return tables.filter((t) => !this.isIgnoredTable(t));
+        return tables.filter((table) => !this.isIgnoredTable(table));
       }
       return [];
     });
@@ -941,10 +941,10 @@ export class BoundSchemaReflection {
   private _pool: unknown;
 
   static forLoneConnection(
-    schemaReflection: SchemaReflection,
+    abstractSchemaReflection: SchemaReflection,
     connection: unknown,
   ): BoundSchemaReflection {
-    return new BoundSchemaReflection(schemaReflection, new FakePool(connection));
+    return new BoundSchemaReflection(abstractSchemaReflection, new FakePool(connection));
   }
 
   constructor(schemaReflection: SchemaReflection, pool: unknown) {
@@ -1053,7 +1053,7 @@ export class FakePool {
  * @internal
  */
 export function deepDeduplicate<T>(value: T): T {
-  if (Array.isArray(value)) return value.map((v) => deepDeduplicate(v)) as unknown as T;
+  if (Array.isArray(value)) return value.map((i) => deepDeduplicate(i)) as unknown as T;
   if (value !== null && typeof value === "object") {
     const out: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(value as Record<string, unknown>)) {


### PR DESCRIPTION
RFC 0096 wave 2 — burns down the `naming` call-argument rows in the abstract
connection adapter, schema statements/definitions, transaction, pool-config and
schema cache. Body-local identifiers only: no behavior change, no public API
change.

Measured on `origin/main` at 6780b1379 the file set carried **26** `naming` rows
(the story's 45 predates several sibling wave-2 merges). This PR converges **17**
of them — `pnpm parity:api --calls` goes 736 → 719 total call-arg rows, i.e. the
delta is exactly the converged rows, so **no new `shape` rows**. Both ratchets
are green (`parity:api:calls`, `parity:api:calls:args`), as is `pnpm lint`.

### Converged

| File | Was → Rails |
| --- | --- |
| `abstract/connection-pool/reaper.ts` | `this._pool`/`this._frequency` → the `pool`/`frequency` readers (`abstract/connection_pool/reaper.rb:71-74`) |
| `abstract/quoting.ts` | `dt` → reassigns `value`, as `quoted_time` does (`abstract/quoting.rb:201-204`) |
| `abstract/connection-handler.ts` | drops the `poolKey` local; `setPoolManager` takes the ConnectionDescriptor and indexes by `.name` itself (`abstract/connection_handler.rb:121,248-250`) |
| `abstract/schema-definitions.ts` | `resolved` → reassigns `options` (`:583-586`); `optionHash` → `options` (`:842-845`); `Table#rename(oldName,newName)` → `(columnName,newColumnName)` (`:861-863`) |
| `abstract/schema-definitions.ts` | `Table` reads `this.name` at every forwarding site instead of the private `_tableName` field, matching Rails' `attr_reader :name` |
| `abstract/schema-statements.ts` | `opts` → reassigns `options` in `removeIndex` (`:966-972`); `adapterAlgorithms` → `indexAlgorithms` (`:1504-1508`) |
| `abstract/transaction.ts` | `instanceMap` → `instancesToRunCallbacksOn` (`abstract/transaction.rb:259-261,304-306,340`) |
| `pool-config.ts` | `cachePath` → `lazySchemaCachePath` (`pool_config.rb:11-13`) |
| `schema-cache.ts` | `forLoneConnection` param → `abstractSchemaReflection` (`:155-157`); `addAll` threads `pool` through `tablesToCache`/`add`/`version` inside the `withConnection` block rather than the leased connection (`:396-404`); `t` → `table` (`:428-434`); `v` → `i` (`:448-459`) |

### Left standing — a1/a3, not renames

9 rows remain. None is an identifier rename: each is a missing/extra parameter
(a1) or an invented helper/conversion (a3) that needs a real convergence. Filed
as **`0096-naming-identifier-burndown/naming-burndown-2-ar-abstract-adapters-a1a3-residue`**
with the Rails `file:line` for each. Summary:

- `registerClassWithLimit` / `registerClassWithPrecision` — Rails' block is
  `|*args|` reading `args.last`; our `TypeMap#registerType` block takes a single
  `lookupKey`, so the arg can't be spelled Rails' way until that signature moves.
- `unpreparedStatement` — Ruby keys the Set by `object_id`; JS has none, so the
  adapter instance is the identity.
- `AlterTable#addColumn` — hoists `colDef` because our AlterTable carries an
  *optional* `_td` with a fallback branch Rails does not have.
- `createTable` — `validatedOptions` is the rest-object left after splitting
  `id:`/`primaryKey:`/`force:` back out of the bundled kwargs object.
- `changeTable` — Rails takes `base = self`; we have no `base` parameter (a1).
- `foreignKeyColumnFor` — passes `tableName.replace(/^.*\./, "")`, a trails-added
  PG schema-qualifier strip (a3).
- `commitRecords` → `appendCallbacks(this._callbacks)` — the repo's `_`-prefixed
  ivar spelling, which the args comparator does not normalize.
- `PoolConfig#connectionDescriptor=` — substitutes `"Base"` for the name when
  `primaryClassQ()` (a3).

Closes-story: naming-burndown-2-ar-abstract-adapters
