### PR TITLE
refactor(activerecord): converge association/reflection call-argument identifiers to Rails

### DIFF
--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -410,18 +410,18 @@ export class AssociationScope {
       | { name?: string }
       | null
       | undefined;
-    let table: string | null;
+    let tableName: string | null;
     if (typeof aliased === "string") {
-      table = aliased;
+      tableName = aliased;
     } else if (aliased && typeof aliased === "object" && typeof aliased.name === "string") {
-      table = aliased.name;
+      tableName = aliased.name;
     } else if (klass && typeof klass.tableName === "string") {
-      table = klass.tableName;
+      tableName = klass.tableName;
     } else {
       try {
-        table = (reflection as { klass?: { tableName?: string } }).klass?.tableName ?? null;
+        tableName = (reflection as { klass?: { tableName?: string } }).klass?.tableName ?? null;
       } catch {
-        table = null;
+        tableName = null;
       }
     }
     // For polymorphic belongsTo, `joinPrimaryKey` is hard-coded to "id"
@@ -459,17 +459,18 @@ export class AssociationScope {
     // Rails passes `reflection.aliased_table` (an Arel node) to apply_scope;
     // resolve it the same way `nextChainScope` does so the identity check
     // sees the alias node, not a bare name.
-    const tableNode = table ? this._arelTableFor(reflection, table) : null;
+    const table = tableName ? this._arelTableFor(reflection, tableName) : null;
     for (let i = 0; i < joinPks.length; i++) {
-      const rawValue = owner._readAttribute(joinFks[i]);
-      const value = this.transformValue(rawValue);
-      scope = this.applyScope(scope, tableNode, joinPks[i], value);
+      const value = this.transformValue(owner._readAttribute(joinFks[i]));
+      scope = this.applyScope(scope, table, joinPks[i], value);
     }
     if (r.type) {
       // Rails: `owner.class.polymorphic_name` (returns base_class.name
       // for STI subclasses) routed through `transform_value`.
-      const polyName = this.transformValue((owner.constructor as typeof Base).polymorphicName());
-      scope = this.applyScope(scope, tableNode, r.type, polyName);
+      const polymorphicType = this.transformValue(
+        (owner.constructor as typeof Base).polymorphicName(),
+      );
+      scope = this.applyScope(scope, table, r.type, polymorphicType);
     }
     return scope;
   }
@@ -503,23 +504,23 @@ export class AssociationScope {
     const name = reflection.name;
     for (const refl of tail) {
       const klass = (refl as unknown as { klass?: typeof Base }).klass;
-      let aliased: unknown;
+      let aliasedTable: unknown;
       if (tracker && klass) {
         // Rails: `tracker.aliased_table_for(refl.klass.arel_table) {
         // refl.alias_candidate(name) }`. Pass a thunk so
         // `aliasCandidate` is only invoked on repeat visits — first
         // visits return the base arel table without ever building
         // the candidate string.
-        aliased = tracker.aliasedTableFor(klass.arelTable, () => {
+        aliasedTable = tracker.aliasedTableFor(klass.arelTable, () => {
           const fn = (refl as unknown as { aliasCandidate?: (n: string) => string }).aliasCandidate;
           return typeof fn === "function" ? fn.call(refl, name) : klass.tableName;
         });
       } else {
         // Fallback for the legacy single-call path where no tracker
         // is provided — bare table name, same behavior as before.
-        aliased = klass?.tableName ?? "";
+        aliasedTable = klass?.tableName ?? "";
       }
-      chain.push(new ReflectionProxy(refl, aliased));
+      chain.push(new ReflectionProxy(refl, aliasedTable));
     }
     return chain;
   }
@@ -606,16 +607,16 @@ export class AssociationScope {
         : aliased && typeof aliased === "object" && typeof aliased.name === "string"
           ? aliased.name
           : (nr.klass?.tableName ?? "");
-    // Build the ON condition as Arel constraint nodes —
+    // Build the ON condition as Arel constraints nodes —
     // `table[join_primary_key].eq(foreign_table[foreign_key])` folded with
     // `.and` — exactly as Rails' next_chain_scope (association_scope.rb:88-91).
     // Identifier quoting and value escaping flow through the Arel visitor,
     // so no manual interpolation or quoter is needed.
-    const tableNode = this._arelTableFor(reflection, tableName);
-    const foreignTableNode = this._arelTableFor(nextReflection, foreignTableName);
-    let constraint: Nodes.Node = tableNode.get(joinPks[0]).eq(foreignTableNode.get(joinFks[0]));
+    const table = this._arelTableFor(reflection, tableName);
+    const foreignTable = this._arelTableFor(nextReflection, foreignTableName);
+    let constraints: Nodes.Node = table.get(joinPks[0]).eq(foreignTable.get(joinFks[0]));
     for (let i = 1; i < joinPks.length; i++) {
-      constraint = constraint.and(tableNode.get(joinPks[i]).eq(foreignTableNode.get(joinFks[i])));
+      constraints = constraints.and(table.get(joinPks[i]).eq(foreignTable.get(joinFks[i])));
     }
     if (r.type) {
       // Polymorphic through: filter by the next reflection's klass
@@ -630,13 +631,13 @@ export class AssociationScope {
       // table, ...)` where `table` is `reflection.aliased_table` (so
       // `table.name` is the alias). Keeps the `_type` WHERE on the same
       // identifier the JOIN uses.
-      scope = this.applyScope(scope, tableNode, r.type, value);
+      scope = this.applyScope(scope, table, r.type, value);
     }
-    // Wrap the join target + constraint in Arel's LeadingJoin/On nodes via
+    // Wrap the join target + constraints in Arel's LeadingJoin/On nodes via
     // `join()` and push it through Relation#joins, which stores Arel join
     // nodes in joins_values (mirrors Rails' `scope.joins!(join(...))`).
     return (scope as { joins: (node: Nodes.Join) => unknown }).joins(
-      this.join(foreignTableNode, constraint) as Nodes.Join,
+      this.join(foreignTable, constraints) as Nodes.Join,
     );
   }
 

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -607,7 +607,7 @@ export class AssociationScope {
         : aliased && typeof aliased === "object" && typeof aliased.name === "string"
           ? aliased.name
           : (nr.klass?.tableName ?? "");
-    // Build the ON condition as Arel constraints nodes —
+    // Build the ON condition as Arel constraint nodes —
     // `table[join_primary_key].eq(foreign_table[foreign_key])` folded with
     // `.and` — exactly as Rails' next_chain_scope (association_scope.rb:88-91).
     // Identifier quoting and value escaping flow through the Arel visitor,

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -702,7 +702,7 @@ export class Association {
 
   protected async _createRecord(
     attributes?: Record<string, unknown>,
-    shouldRaise = false,
+    raise = false,
     block?: (record: Base) => void,
   ): Promise<Base | null> {
     // Rails yields the record inside `build_record` (association.rb:383-388),
@@ -711,7 +711,7 @@ export class Association {
     if (!record) return null;
     if (typeof (record as any).save === "function") {
       const saved = await (record as any).save();
-      if (!saved && shouldRaise) {
+      if (!saved && raise) {
         throw new Error(`Failed to save the new associated ${this.reflection.name}.`);
       }
     }

--- a/packages/activerecord/src/associations/belongs-to-association.ts
+++ b/packages/activerecord/src/associations/belongs-to-association.ts
@@ -130,9 +130,9 @@ export class BelongsToAssociation extends SingularAssociation {
     }
 
     const fkNames = this.foreignKeyNames();
-    const foreignKeyWas = fkNames.map((fk) =>
+    const foreignKeyWas = fkNames.map((foreignKey) =>
       typeof this.owner.attributeBeforeLastSave === "function"
-        ? this.owner.attributeBeforeLastSave(fk)
+        ? this.owner.attributeBeforeLastSave(foreignKey)
         : undefined,
     );
 

--- a/packages/activerecord/src/associations/builder/belongs-to.ts
+++ b/packages/activerecord/src/associations/builder/belongs-to.ts
@@ -180,7 +180,7 @@ export class BelongsTo extends SingularAssociation {
             reflection?.foreignType ??
             reflection?.options?.foreignType ??
             `${underscore(name)}_type`;
-          const typeName =
+          klass =
             (changes[foreignType] as [unknown, unknown] | undefined)?.[0] ??
             (typeof record._readAttribute === "function"
               ? record._readAttribute(foreignType)
@@ -189,10 +189,10 @@ export class BelongsTo extends SingularAssociation {
             // Rails: `o.class.polymorphic_class_for(klass)` — a model may
             // override the hook to map a custom polymorphic_name back to its
             // class (builder/belongs_to.rb:53).
-            klass = typeName
+            klass = klass
               ? (
                   record.constructor as { polymorphicClassFor(name: string): any }
-                ).polymorphicClassFor(typeName)
+                ).polymorphicClassFor(klass)
               : null;
           } catch {
             klass = null;

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -501,7 +501,7 @@ export class CollectionAssociation extends Association {
    */
   protected override async _createRecord(
     attributes?: Record<string, unknown>,
-    shouldRaise = false,
+    raise = false,
     block?: (record: Base) => void,
   ): Promise<Base | null> {
     if (!this.owner.isPersisted()) {
@@ -513,7 +513,7 @@ export class CollectionAssociation extends Association {
     await this.transaction(async () => {
       let result: boolean | undefined = undefined;
       await this.addToTarget(record, {}, async () => {
-        result = await this.insertRecord(record, true, shouldRaise, () => {
+        result = await this.insertRecord(record, true, raise, () => {
           this._wasLoaded = this.isLoaded();
         });
       });

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -3703,7 +3703,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     column: string,
   ): Promise<unknown | null | Map<unknown, unknown>>;
   async calculate(operation: string, columnName?: string): Promise<unknown> {
-    const op =
+    operation =
       operation === "avg"
         ? "average"
         : operation === "min"
@@ -3712,8 +3712,8 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
             ? "maximum"
             : operation;
 
-    if (op !== "count" && columnName == null) {
-      throw new Error(`Column name is required for calculation operation: ${op}`);
+    if (operation !== "count" && columnName == null) {
+      throw new Error(`Column name is required for calculation operation: ${operation}`);
     }
     const s = this.scope();
     // Rails: `null_scope? ? scope.calculate(operation, column_name) : super`
@@ -3722,23 +3722,23 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // in-memory fallback at the bottom of this method, which counts loaded
     // records with no rows behind them and must stay unreachable for a null
     // scope no matter what `scope()` grows the ability to answer.
-    if (this.isNullScope()) return s.calculate(op, columnName);
-    if (op === "count" && columnName == null && typeof s.count === "function") {
+    if (this.isNullScope()) return s.calculate(operation, columnName);
+    if (operation === "count" && columnName == null && typeof s.count === "function") {
       return s.count();
     }
     if (typeof s.calculate === "function") {
-      return s.calculate(op, columnName);
+      return s.calculate(operation, columnName);
     }
     // Fallback: compute in-memory from loaded records
     const records = await this.loadTarget();
-    if (op === "count") return records.length;
+    if (operation === "count") return records.length;
     if (columnName == null) {
-      throw new Error(`Column name is required for calculation operation: ${op}`);
+      throw new Error(`Column name is required for calculation operation: ${operation}`);
     }
     const values = records
       .map((r) => r.readAttribute(columnName))
       .filter((v) => v != null) as number[];
-    switch (op) {
+    switch (operation) {
       case "sum":
         return values.reduce((a, b) => Number(a) + Number(b), 0);
       case "average":
@@ -3750,7 +3750,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       case "maximum":
         return values.length > 0 ? Math.max(...values.map(Number)) : null;
       default:
-        throw new Error(`Unknown calculation operation: ${op}`);
+        throw new Error(`Unknown calculation operation: ${operation}`);
     }
   }
 

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -278,8 +278,8 @@ export class HasManyAssociation extends CollectionAssociation {
     // it to the delete_all strategy here the same way `deleteAll()` does
     // (collection-association.ts). Without this the per-record delete path falls
     // through to nullify, which fails for NOT-NULL composite-PK foreign keys.
-    const strategy = method === "delete" ? "deleteAll" : method;
-    const count = await this.deleteCount(strategy, scope);
+    method = method === "delete" ? "deleteAll" : method;
+    const count = await this.deleteCount(method, scope);
     if (count > 0) await this.updateCounter(-count);
     return count;
   }
@@ -305,13 +305,10 @@ export class HasManyAssociation extends CollectionAssociation {
    */
   protected override async _createRecord(
     attributes?: Record<string, unknown>,
-    shouldRaise = false,
+    raise = false,
     block?: (record: Base) => void,
   ): Promise<Base | null> {
-    return this.updateCounterIfSuccess(
-      await super._createRecord(attributes, shouldRaise, block),
-      1,
-    );
+    return this.updateCounterIfSuccess(await super._createRecord(attributes, raise, block), 1);
   }
 
   /**
@@ -408,14 +405,14 @@ async function updateCounter(
   reflection: AssociationDefinition = this.reflection,
 ): Promise<void> {
   if (!reflection.hasCachedCounter?.()) return;
-  const column = reflection.counterCacheColumn?.() as string;
+  const counterCacheColumn = reflection.counterCacheColumn?.() as string;
   const owner = this.owner as any;
   if (typeof owner.incrementBang === "function") {
-    await owner.incrementBang(column, difference);
+    await owner.incrementBang(counterCacheColumn, difference);
   } else if (typeof owner.updateCounters === "function") {
-    await owner.updateCounters({ [column]: difference });
+    await owner.updateCounters({ [counterCacheColumn]: difference });
   } else if (typeof owner.increment === "function") {
-    owner.increment(column, difference);
+    owner.increment(counterCacheColumn, difference);
   }
 }
 

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -380,7 +380,7 @@ export class HasOneAssociation extends SingularAssociation {
    */
   protected override async _createRecord(
     attributes?: Record<string, unknown>,
-    shouldRaise = false,
+    raise = false,
     block?: (record: Base) => void,
   ): Promise<Base | null> {
     if (!(this.owner as { isPersisted?: () => boolean }).isPersisted?.()) {
@@ -401,7 +401,7 @@ export class HasOneAssociation extends SingularAssociation {
     // `loadDisplacedTargetForCreate`, which caches the row as `this.target`;
     // `super._createRecord` removes it via `detachDisplacedOnBuild`.
     const loadError = await this.loadDisplacedTargetForCreate();
-    const record = await super._createRecord(attributes, shouldRaise, block);
+    const record = await super._createRecord(attributes, raise, block);
     // Every exception but `RecordNotFound` propagates out of `load_target`
     // (association.rb:189-195). Re-raise at the point Rails raises: after
     // `build_record` and `record.save`. A failed load cached nothing, so the

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -174,12 +174,12 @@ export class HasOneThroughAssociation extends HasOneAssociation {
    */
   protected override async _createRecord(
     attributes?: Record<string, unknown>,
-    shouldRaise = false,
+    raise = false,
     block?: (record: Base) => void,
   ): Promise<Base | null> {
     let record: Base | null;
     try {
-      record = await super._createRecord(attributes, shouldRaise, block);
+      record = await super._createRecord(attributes, raise, block);
     } catch (error) {
       if (error instanceof RecordInvalid && this._pendingReplace) {
         await this.persistReplace(false);

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -502,13 +502,13 @@ export class JoinDependency {
     if (references) {
       for (const tableName of references) this._references.set(tableName, tableName);
     }
-    const joins = this.makeJoinConstraints(this._joinRoot, this._joinType);
+    const joins = this.makeJoinConstraints(this.joinRoot, this.joinType);
 
     for (const oj of joinsToAdd) {
-      if (this._joinRoot.isMatch(oj._joinRoot)) {
-        joins.push(...this.walk(this._joinRoot, oj._joinRoot, oj._joinType));
+      if (this.joinRoot.isMatch(oj.joinRoot)) {
+        joins.push(...this.walk(this.joinRoot, oj.joinRoot, oj.joinType));
       } else {
-        joins.push(...this.makeJoinConstraints(oj._joinRoot, oj._joinType));
+        joins.push(...this.makeJoinConstraints(oj.joinRoot, oj.joinType));
       }
     }
     return joins;

--- a/packages/activerecord/src/associations/join-dependency/join-part.ts
+++ b/packages/activerecord/src/associations/join-dependency/join-part.ts
@@ -115,12 +115,12 @@ export abstract class JoinPart {
     }
   }
 
-  extractRecord(row: Record<string, unknown>, columnAlias: string): Record<string, unknown> {
+  extractRecord(row: Record<string, unknown>, aliases: string): Record<string, unknown> {
     const record: Record<string, unknown> = {};
 
     // Check for JoinDependency-style aliases (t{n}_r{n}) first, since
     // the prefix `t1_` would falsely match generic prefix matching
-    const indexMatch = columnAlias.match(/^t(\d+)$/);
+    const indexMatch = aliases.match(/^t(\d+)$/);
     if (indexMatch) {
       const pattern = new RegExp(`^t${indexMatch[1]}_r(\\d+)$`);
       const baseColumns = this.baseKlass.columnNames();
@@ -139,8 +139,8 @@ export abstract class JoinPart {
       if (matched) return record;
     }
 
-    // Generic prefix matching: keys in the form `${columnAlias}_<attr>`
-    const prefix = `${columnAlias}_`;
+    // Generic prefix matching: keys in the form `${aliases}_<attr>`
+    const prefix = `${aliases}_`;
     for (const [key, value] of Object.entries(row)) {
       if (key.startsWith(prefix)) {
         record[key.slice(prefix.length)] = value;
@@ -150,8 +150,8 @@ export abstract class JoinPart {
     return record;
   }
 
-  instantiate(row: Record<string, unknown>, columnAlias: string): Base | null {
-    const attrs = this.extractRecord(row, columnAlias);
+  instantiate(row: Record<string, unknown>, aliases: string): Base | null {
+    const attrs = this.extractRecord(row, aliases);
     const hasData = Object.values(attrs).some((v) => v !== null && v !== undefined);
     if (!hasData) return null;
     return this.baseKlass._instantiate(attrs);

--- a/packages/activerecord/src/associations/preloader/association.ts
+++ b/packages/activerecord/src/associations/preloader/association.ts
@@ -330,9 +330,9 @@ export class Association {
    * reproduces. ActiveRecord does not override `type_for_attribute`.
    */
   private associationKeyType(): string | undefined {
-    const key = this.associationKeyName;
-    if (Array.isArray(key)) return undefined;
-    return this.klass.typeForAttribute(key).type();
+    const associationKeyName = this.associationKeyName;
+    if (Array.isArray(associationKeyName)) return undefined;
+    return this.klass.typeForAttribute(associationKeyName).type();
   }
 
   /** Mirrors: Preloader::Association#owner_key_type
@@ -341,9 +341,9 @@ export class Association {
    *  loader, where Rails' `@model` would be nil and `type_for_attribute`
    *  unreachable. */
   private ownerKeyType(): string | undefined {
-    const key = this.ownerKeyName;
-    if (this.model == null || Array.isArray(key)) return undefined;
-    return this.model.typeForAttribute(key).type();
+    const ownerKeyName = this.ownerKeyName;
+    if (this.model == null || Array.isArray(ownerKeyName)) return undefined;
+    return this.model.typeForAttribute(ownerKeyName).type();
   }
 
   /**

--- a/packages/activerecord/src/associations/preloader/branch.ts
+++ b/packages/activerecord/src/associations/preloader/branch.ts
@@ -257,8 +257,8 @@ export class Branch {
   get loaders(): Association[] {
     if (this._loaders !== null) return this._loaders;
     this._loaders = [];
-    for (const [reflection, records] of this.groupedRecords()) {
-      this._loaders.push(...this.preloadersForReflection(reflection, records));
+    for (const [reflection, reflectionRecords] of this.groupedRecords()) {
+      this._loaders.push(...this.preloadersForReflection(reflection, reflectionRecords));
     }
     return this._loaders;
   }

--- a/packages/activerecord/src/associations/singular-association.ts
+++ b/packages/activerecord/src/associations/singular-association.ts
@@ -409,7 +409,7 @@ export class SingularAssociation extends Association {
 
   protected override async _createRecord(
     attributes?: Record<string, unknown>,
-    shouldRaise = false,
+    raise = false,
     block?: (record: Base) => void,
   ): Promise<Base | null> {
     // Rails yields the record in `build_record` before the save (block can
@@ -432,7 +432,7 @@ export class SingularAssociation extends Association {
     const removal = this.detachDisplacedOnBuild(record);
     if (removal) await removal;
     this.setNewRecord(record);
-    if (!saved && shouldRaise) {
+    if (!saved && raise) {
       throw new RecordInvalid(record);
     }
     return record;

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -941,10 +941,10 @@ export function addAutosaveAssociationCallbacks(model: any, reflection: any): vo
 /** @internal */
 export function defineAutosaveValidationCallbacks(this: any, reflection: any): void {
   if (!reflection.validate) return;
-  const validationName = `validateAssociatedRecordsFor_${reflection.name}`;
+  const validationMethod = `validateAssociatedRecordsFor_${reflection.name}`;
   if (!this.prototype) return;
   // Mirrors method_defined?(name, false) — only skip if defined on this exact class.
-  if (Object.prototype.hasOwnProperty.call(this.prototype, validationName)) return;
+  if (Object.prototype.hasOwnProperty.call(this.prototype, validationMethod)) return;
   const isCol =
     typeof reflection.isCollection === "function"
       ? reflection.isCollection()
@@ -952,15 +952,15 @@ export function defineAutosaveValidationCallbacks(this: any, reflection: any): v
   const isHasOne =
     typeof reflection.hasOne === "function" ? reflection.hasOne() : !!reflection.hasOne;
   if (isCol) {
-    defineNonCyclicMethod.call(this, validationName, function (this: any) {
+    defineNonCyclicMethod.call(this, validationMethod, function (this: any) {
       return validateCollectionAssociation.call(this, reflection);
     });
   } else if (isHasOne) {
-    defineNonCyclicMethod.call(this, validationName, function (this: any) {
+    defineNonCyclicMethod.call(this, validationMethod, function (this: any) {
       return validateHasOneAssociation.call(this, reflection);
     });
   } else {
-    defineNonCyclicMethod.call(this, validationName, function (this: any) {
+    defineNonCyclicMethod.call(this, validationMethod, function (this: any) {
       return validateBelongsToAssociation.call(this, reflection);
     });
   }
@@ -970,7 +970,7 @@ export function defineAutosaveValidationCallbacks(this: any, reflection: any): v
   // `_alreadyCalled` guard, so co-recursive owner/child chains terminate
   // even though each validator runs independently.
   if (typeof this.validate === "function") {
-    this.validate(validationName);
+    this.validate(validationMethod);
   }
   this.afterValidation(":_ensureNoDuplicateErrors");
 }

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -820,18 +820,22 @@ export function assignNestedAttributesForOneToOneAssociation(
       );
     }
   }
-  const existing = assoc.target ?? null;
+  const existingRecord = assoc.target ?? null;
 
   // Rails nested_attributes.rb:436 — update (or mark for destruction) the
   // existing record in place when `update_only` is set, or when a matching
   // `id` was supplied and the in-memory target carries that id.
   if (
     (updateOnly || hasId) &&
-    existing &&
-    (updateOnly || String(existing.id) === String((attributes as any).id))
+    existingRecord &&
+    (updateOnly || String(existingRecord.id) === String((attributes as any).id))
   ) {
     if (!callRejectIf.call(record, associationName, attributes)) {
-      return assignToOrMarkForDestruction(existing, attributes, options.allowDestroy ?? false);
+      return assignToOrMarkForDestruction(
+        existingRecord,
+        attributes,
+        options.allowDestroy ?? false,
+      );
     }
     return;
   }
@@ -846,15 +850,15 @@ export function assignNestedAttributesForOneToOneAssociation(
     const assignable = assignableNestedAttributes(attributes);
     const targetModel = resolveCollectionTargetModel(record, associationName);
     if (targetModel) assertNestedAttributesAreKnown(targetModel, assignable);
-    if (existing && existing.isNewRecord()) {
+    if (existingRecord && existingRecord.isNewRecord()) {
       // Rails reuses an already-built unsaved target (e.g. after `buildShip`)
       // rather than replacing it: assign into it, then re-anchor FK/scope/
       // inverse via `initialize_attributes`.
-      const pending = existing.assignAttributes(assignable);
+      const pending = existingRecord.assignAttributes(assignable);
       if (pending) {
-        return pending.then(() => assoc.initializeAttributes(existing));
+        return pending.then(() => assoc.initializeAttributes(existingRecord));
       }
-      assoc.initializeAttributes(existing);
+      assoc.initializeAttributes(existingRecord);
     } else {
       // Rails nested_attributes.rb:451 — `method = :"build_#{association_name}";
       // respond_to?(method) ? public_send(method, ...) : raise`. A plain

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -336,8 +336,8 @@ export class AbstractReflection {
     // `build_scope` is a bare relation (no default scope, no STI); the STI
     // `type_condition` is added by `joinScope`, qualified by the join's table.
     const klass = this.klass as any;
-    const bare = this.buildScope(table, predicateBuilder);
-    return klass.scopeForAssociation ? klass.scopeForAssociation(bare) : bare;
+    const relation = this.buildScope(table, predicateBuilder);
+    return klass.scopeForAssociation ? klass.scopeForAssociation(relation) : relation;
   }
 
   constraints(): Array<(...args: any[]) => any> {
@@ -500,9 +500,9 @@ export class AbstractReflection {
     if (opts.counterCache) return true;
     const iwucc = this.inverseWhichUpdatesCounterCache();
     if (iwucc && asConcrete(iwucc).options?.counterCache) {
-      const col = this.counterCacheColumn();
+      const counterCacheColumn = this.counterCacheColumn();
       const owner = this._concrete().activeRecord as any;
-      if (col && owner?.hasAttribute?.(col)) return true;
+      if (counterCacheColumn && owner?.hasAttribute?.(counterCacheColumn)) return true;
     }
     return false;
   }
@@ -1010,7 +1010,7 @@ export class AssociationReflection extends MacroReflection {
     try {
       const lookupNames: string[] = [...candidateNames];
       if (this.activeRecord.automaticallyInvertPluralAssociations) {
-        for (const n of candidateNames) lookupNames.push(pluralize(n));
+        for (const inverseName of candidateNames) lookupNames.push(pluralize(inverseName));
       }
       // Pick the first candidate whose reflection is a valid inverse. A
       // hit on an invalid candidate (e.g. inverseOf:false, mismatched FK,
@@ -2327,10 +2327,10 @@ export function create(
   name: string | null,
   scope: ((...args: any[]) => any) | null,
   options: Record<string, unknown>,
-  activeRecord: typeof Base,
+  ar: typeof Base,
 ): AssociationReflection | ThroughReflection | AggregateReflection {
   const ReflectionClass = reflectionClassFor(macro);
-  const reflection = new ReflectionClass(name, scope, options, activeRecord);
+  const reflection = new ReflectionClass(name, scope, options, ar);
   return options.through
     ? new ThroughReflection(reflection as AssociationReflection)
     : (reflection as AssociationReflection | AggregateReflection);


### PR DESCRIPTION
RFC 0096 wave 2: burn down the `naming` call-argument rows in the associations,
reflection, autosave and nested-attributes ports by renaming body-local
identifiers to the Rails names, camelCased. No behavior change, no public
surface change — every rename is a local or parameter.

## Measurement

`API_COMPARE_FORCE=1 pnpm parity:api --calls` on a fresh build:

| | before | after |
| --- | ---: | ---: |
| `naming` rows in this file set | 38 | 14 |
| `call-arg-mismatches` total | 735 | 711 |
| `shape` rows | 326 | 326 |

`pnpm parity:api:calls` and `pnpm parity:api:calls:args` both green; no
baseline rows added.

`pnpm parity:api` Overall is unchanged at 12693/17505 and `pnpm parity:test` at
15557/22623 — no test files touched, so both deltas are 0.

(The story's snapshot said 47 rows across 18 files; a re-measure on current
`origin/main` reports 38 across 14 — sibling wave-2 work moved the totals, as
the story anticipated. In particular #6395 landed the
`preloaders_for_reflection` `rhsKlass`/`rs` rename mid-flight, so this branch
was rebased onto it and that hunk is now main's.)

## Converged

- `associations/association-scope.ts` (association_scope.rb:58-99, 112-122) —
  `tableNode` → `table`, `polyName` → `polymorphicType`, `foreignTableNode` →
  `foreignTable`, `constraint` → `constraints`, `aliased` → `aliasedTable` in
  `getChain`; the `owner._readAttribute(...)` read inlines into
  `transformValue(...)` as Rails writes it (line 65).
- `associations/belongs-to-association.ts` (belongs_to_association.rb:75) —
  `fk` → `foreignKey`.
- `associations/builder/belongs-to.ts` (builder/belongs_to.rb:52-53) — the
  `typeName` intermediate folds into `klass`, matching Rails' reuse of the
  same local across the read and the `polymorphic_class_for` call.
- `associations/{association,collection-association,has-many,has-one,
  has-one-through,singular}-association.ts` (collection_association.rb:354,366)
  — `shouldRaise` → `raise` across the `_create_record` / `insert_record` chain.
- `associations/collection-proxy.ts` (collection_proxy.rb:724) — `op` →
  `operation` (the alias normalisation now reassigns the parameter).
- `associations/has-many-association.ts` (has_many_association.rb:100,135) —
  `column` → `counterCacheColumn`; `strategy` → reassigned `method`.
- `associations/join-dependency.ts` (join_dependency.rb:94-101) —
  `joinConstraints` now reads through the `joinRoot` / `joinType` getters
  Rails' body uses instead of the private `_joinRoot` / `_joinType` fields.
- `associations/join-dependency/join-part.ts` (join_part.rb:65-66) —
  `columnAlias` → `aliases`.
- `associations/preloader/association.ts` — `key` →
  `associationKeyName` / `ownerKeyName`.
- `associations/preloader/branch.ts` (preloader/branch.rb:121) — `records` →
  `reflectionRecords` in `loaders`. (The `rhsKlass`/`rs` destructure rename
  landed in #6395 while this was in flight; taken from main on rebase.)
- `autosave-association.ts` (autosave_association.rb:220-231) —
  `validationName` → `validationMethod`.
- `nested-attributes.ts` (nested_attributes.rb:434-448) — `existing` →
  `existingRecord`.
- `reflection.ts` (reflection.rb:18-19, 235-237, 307-311, 765) — `bare` →
  `relation`, `col` → `counterCacheColumn`, `n` → `inverseName`,
  `activeRecord` → `ar` on `create`.

## Left standing (14 rows)

None of these is a rename; each is either a Ruby/JS builtin difference or an
a3 (extra trails local/helper) finding, so per the story they stay:

- **Ruby/JS builtin, not an identifier** (6): `ref:size` → `ref:length` in
  `collection-association.ts#idsWriter` and `#find`; `ref:class` →
  `ref:constructor` in `belongs-to-polymorphic-association.ts`;
  `ref:instanceExec` → `ref:block` in `belongs-to-association.ts#default`
  (`instance_exec` has no TS analogue — the port calls the block directly).
- **TS shadowing shortcoming** (2): `has-many-through-association.ts#difference`
  / `#intersection` want the Rails local `distribution`, but
  `const distribution = distribution(b)` is a TDZ error in TS where Ruby's
  `distribution = distribution(b)` is legal. The module-level helper cannot be
  qualified, so the local stays `dist`.
- **a3 — extra trails local/helper** (7): `has-many-through-association.ts`
  `decrement_counter` (`ref:map` → `ref:ids`, a defensive null-filtered id
  list Rails inlines); `join-dependency/join-association.ts#appendConstraints`
  (`ref:unshift` → `ref:allExprs`, an extra length-1 branch Arel's readonly
  join nodes force); `nested-attributes.ts` collection `build`
  (`ref:except` → `ref:assignable`, the trails-only
  `assignableNestedAttributes` helper); `autosave-association.ts`'s five
  `after_create` / `after_update` / `before_save` rows, where the trails
  callback macros take `(model, callback)` rather than Ruby's bare
  `after_create save_method` — an argument-shape difference from the
  mixin idiom, not a rename.

The a3 residue belongs to the file's owning RFC (0023-surfaced-deviations for
the autosave callback-macro shape); no new rows or allowlist entries were
added here.

## Filed, not fixed here

`JoinPart#extract_record` is a structural deviation, not a naming one: Rails
takes an array of column objects and index-loops `row[column.alias]` →
`hash[column.name]` (join_part.rb:47-62), while the port takes a single alias
string and reconstructs the record by regex + `startsWith` prefix scan
(join-part.ts:118-151). It predates this PR and converging it is
behavior-bearing, so it is filed as
`0023-surfaced-deviations/converge-join-part-extract-record-alias-columns`
rather than done here.

One consequence is visible in this diff: the rename to `aliases` is right for
`instantiate`'s argument (join_part.rb:65) and an improvement on the previous
`columnAlias`, but `extract_record`'s own Rails parameter is
`column_names_with_alias` — a name the TS parameter cannot honestly carry
while it holds a bare string. That last rename is an acceptance criterion on
the filed story, where it lands together with the structure it describes.

## Verification

- `pnpm typecheck`, `pnpm lint` clean.
- `pnpm parity:api:calls` → OK; `pnpm parity:api:calls:args` → OK
  (313 baselined shape rows, unchanged).
- Tests: `packages/activerecord/src/associations/**` + `associations.test.ts`,
  `autosave-association*.test.ts`, `reflection*.test.ts` → 105 files, 2631
  passed; `nested-attributes*` → 5 files, 197 passed; `relation/**` +
  `join-dependency` → 55 files, 1335 passed.

Closes-story: naming-burndown-2-ar-associations
