### PR TITLE
test(postgresql): read the cancelled query's error after awaiting it

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -374,10 +374,14 @@ describeIfPg("PostgreSQLAdapter", () => {
         await (
           other as unknown as { _cancelAnyRunningQuery(): Promise<void> }
         )._cancelAnyRunningQuery();
-        // The `block` half: the cancelled command has already settled by the
-        // time the cancel returns, so nothing of it is left in flight.
-        expect(sleepError).toBeInstanceOf(QueryCanceled);
+        // The `block` half: the cancelled command has already come back by the
+        // time the cancel returns, so nothing of it is left in flight. Its
+        // error reaching this `catch` is a further microtask hop behind the
+        // wire, so `await` the query before reading what it rejected with —
+        // whether that hop has run yet is a scheduling detail, not the
+        // invariant under test.
         await sleep;
+        expect(sleepError).toBeInstanceOf(QueryCanceled);
         // The cancel aborted the transaction, so end it before probing — a
         // leaked cancel shows up as QueryCanceled on one of these two, not as
         // the 25P02 an aborted transaction block answers with.

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -374,12 +374,9 @@ describeIfPg("PostgreSQLAdapter", () => {
         await (
           other as unknown as { _cancelAnyRunningQuery(): Promise<void> }
         )._cancelAnyRunningQuery();
-        // The `block` half: the cancelled command has already come back by the
-        // time the cancel returns, so nothing of it is left in flight. Its
-        // error reaching this `catch` is a further microtask hop behind the
-        // wire, so `await` the query before reading what it rejected with —
-        // whether that hop has run yet is a scheduling detail, not the
-        // invariant under test.
+        // `block` puts the cancelled command back off the wire before the
+        // cancel returns; its error reaching this `catch` is a further
+        // microtask hop behind that, so await the query before reading it.
         await sleep;
         expect(sleepError).toBeInstanceOf(QueryCanceled);
         // The cancel aborted the transaction, so end it before probing — a


### PR DESCRIPTION
The `Active Record PostgreSQL Tests (2)` red on main @6780b137 was the
`cancelAnyRunningQuery does not leak its cancel onto a later query`
regression failing with `expected undefined to be an instance of
QueryCanceled`.

`_cancelAnyRunningQuery` was fine. The test asserted `sleepError` before
awaiting the cancelled query. `block`
(postgresql/database_statements.rb:131) guarantees the command has come back
off the wire by the time the cancel returns — not that its rejection has
already walked the `execute` await chain into the test's `catch`, which is a
further microtask hop. Which of the two chains drains first is a scheduling
detail; on a loaded runner the cancel path won and the assertion read
`undefined`.

The fix awaits the query first, then asserts what it rejected with. The leak
the test is named for is still asserted by the rollback and the follow-up
SELECT below it — that is where a cancel landing on a later query actually
surfaces, and it is how this regression failed before #6363.

Verified against a local PG 17: the target test passes repeatedly, before
and after.

Closes-story: red-6780b137