### PR TITLE
refactor(parity): converge markForDestruction writes, the proxy create guard, the cache store lookup and unported-file scope

### DIFF
--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -40,7 +40,6 @@ import "./test-helpers/models/bird.js";
 import "./test-helpers/models/treasure.js";
 import "./test-helpers/models/price-estimate.js";
 
-import { markForDestruction } from "./autosave-association.js";
 import { Preloader } from "./associations/preloader.js";
 import { LoaderQuery } from "./associations/preloader/association.js";
 
@@ -1780,7 +1779,7 @@ describe("AssociationsTest", () => {
   it("loading the association target should keep child records marked for destruction", async () => {
     const ship = await Ship.create({ name: "The good ship Dollypop" });
     const part = await (ship as any).parts.create({ name: "Mast" });
-    markForDestruction(part);
+    part.markForDestruction();
     // Rails `ship.parts[0]` routes through load_target → merge_target_lists,
     // preserving in-memory records (marked-for-destruction kept); trails'
     // `toArray()` merges in-memory over DB rows the same way.
@@ -1791,7 +1790,7 @@ describe("AssociationsTest", () => {
   it("loading the association target should load most recent attributes for child records marked for destruction", async () => {
     const ship = await Ship.create({ name: "The good ship Dollypop" });
     const part = await (ship as any).parts.create({ name: "Mast" });
-    markForDestruction(part);
+    part.markForDestruction();
     const reloaded = await ShipPart.find(part.id as number);
     await reloaded.updateColumn("name", "Deck");
     const parts = await (ship as any).parts.toArray();

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1159,8 +1159,10 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     for (const r of records) assoc.setStrictLoading(r);
   }
 
-  // Rails' `_create_record` raises before building the record or opening a
-  // transaction when the owner is unsaved (collection_association.rb:354-357).
+  // Rails raises this once, in `CollectionAssociation#_create_record`
+  // (collection_association.rb:355-357). The non-through arm reaches that
+  // ported guard through `association.create`; the through arm does not route
+  // through `_createRecord` yet, so it keeps the check here until it does.
   private _ensurePersistedOwnerForCreate(): void {
     if (this._record.isNewRecord()) {
       throw new RecordNotSaved(`You cannot call create unless the parent is saved`, this._record);
@@ -1397,7 +1399,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     if (this._isSingular) {
       return this._createSingular(attrs, block, false);
     }
-    this._ensurePersistedOwnerForCreate();
+    if (this._isThrough) this._ensurePersistedOwnerForCreate();
     this._ensureThroughWritable();
     if (this._isThrough) {
       return (await this._createThrough(
@@ -3629,7 +3631,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     if (this._isSingular) {
       return this._createSingular(attrs, block, true);
     }
-    this._ensurePersistedOwnerForCreate();
+    if (this._isThrough) this._ensurePersistedOwnerForCreate();
     this._ensureThroughWritable();
     if (this._isThrough) {
       const record = this._buildRecord(attrs) as T;

--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -42,11 +42,7 @@ import { Customer as CanonicalCustomer } from "./test-helpers/models/customer.js
 import { Order as CanonicalOrder } from "./test-helpers/models/order.js";
 import { Invoice } from "./test-helpers/models/invoice.js";
 import { LineItem } from "./test-helpers/models/line-item.js";
-import {
-  markForDestruction,
-  computePrimaryKey,
-  addAutosaveAssociationCallbacks,
-} from "./autosave-association.js";
+import { computePrimaryKey, addAutosaveAssociationCallbacks } from "./autosave-association.js";
 import { fixtures } from "./test-fixtures.js";
 import { assertNoQueries } from "./testing/query-assertions.js";
 import { resetI18n } from "./test-helpers/i18n.js";
@@ -98,8 +94,8 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
     const ship = await Ship.create({ name: "Nights Dirty Lightning", pirate_id: pirate.id });
     cacheAssoc(pirate, "ship", ship);
 
-    markForDestruction(pirate);
-    markForDestruction(ship);
+    pirate.markForDestruction();
+    ship.markForDestruction();
 
     expect((await pirate.reload()).markedForDestruction()).toBe(false);
     expect((await ship.reload()).markedForDestruction()).toBe(false);
@@ -109,7 +105,7 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
     const { Pirate, Ship } = makePirateShip();
     const pirate = await Pirate.create({ catchphrase: "Yarr" });
     const ship = await Ship.create({ name: "Black Pearl", pirate_id: pirate.id });
-    markForDestruction(ship);
+    ship.markForDestruction();
     cacheAssoc(pirate, "ship", ship);
     await pirate.save();
     expect(ship.isDestroyed()).toBe(true);
@@ -120,7 +116,7 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
     const ship = await Ship.create({ name: "Titanic" });
     const part = await Part.create({ name: "Mast", ship_id: ship.id });
     part.name = "";
-    markForDestruction(part);
+    part.markForDestruction();
     cacheAssoc(ship, "parts", [part]);
     const saved = await ship.save();
     expect(saved).toBe(true);
@@ -131,7 +127,7 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
     const { Pirate, Ship } = makePirateShip();
     const pirate = await Pirate.create({ catchphrase: "Yarr" });
     const ship = await Ship.create({ name: "Pearl", pirate_id: pirate.id });
-    markForDestruction(ship);
+    ship.markForDestruction();
     cacheAssoc(pirate, "ship", ship);
     await pirate.save();
     expect(ship.isDestroyed()).toBe(true);
@@ -184,7 +180,7 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
     const { Pirate, Ship } = makePirateShip();
     const pirate = await Pirate.create({ catchphrase: "Yarr" });
     const ship = await Ship.create({ name: "Pearl", pirate_id: pirate.id });
-    markForDestruction(pirate);
+    pirate.markForDestruction();
     cacheAssoc(ship, "pirate", pirate);
     await ship.save();
     expect(pirate.isDestroyed()).toBe(true);
@@ -194,7 +190,7 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
     const { Pirate, Ship } = makePirateShip();
     const pirate = await Pirate.create({ catchphrase: "Ahoy" });
     const ship = await Ship.create({ name: "Queen Anne", pirate_id: pirate.id });
-    markForDestruction(pirate);
+    pirate.markForDestruction();
     cacheAssoc(ship, "pirate", pirate);
     await ship.save();
     expect(pirate.isDestroyed()).toBe(true);
@@ -204,7 +200,7 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
     const { Pirate, Ship } = makePirateShip();
     const pirate = await Pirate.create({ catchphrase: "Yarr" });
     const ship = await Ship.create({ name: "Pearl", pirate_id: pirate.id });
-    markForDestruction(pirate);
+    pirate.markForDestruction();
     cacheAssoc(ship, "pirate", pirate);
     const saved = await ship.save();
     expect(saved).toBe(true);
@@ -215,7 +211,7 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
     const { Pirate, Ship } = makePirateShip();
     const pirate = await Pirate.create({ catchphrase: "Yarr" });
     const ship = await Ship.create({ name: "Pearl", pirate_id: pirate.id });
-    markForDestruction(pirate);
+    pirate.markForDestruction();
     cacheAssoc(ship, "pirate", pirate);
     await ship.save();
     expect(pirate.isDestroyed()).toBe(true);
@@ -260,7 +256,7 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
     const pirate = await Pirate.create({ catchphrase: "Yarr" });
     const b1 = await Bird.create({ name: "Polly", pirate_id: pirate.id });
     const b2 = await Bird.create({ name: "Crackers", pirate_id: pirate.id });
-    markForDestruction(b1);
+    b1.markForDestruction();
     cacheAssoc(pirate, "birds", [b1, b2]);
     await pirate.save();
     expect(b1.isDestroyed()).toBe(true);
@@ -282,7 +278,7 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
     const pirate = await Pirate.create({ catchphrase: "Yarr" });
     const bird = await Bird.create({ name: "Polly", pirate_id: pirate.id });
     bird.name = "";
-    markForDestruction(bird);
+    bird.markForDestruction();
     cacheAssoc(pirate, "birds", [bird]);
     const saved = await pirate.save();
     expect(saved).toBe(true);
@@ -303,7 +299,7 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
     const { Pirate, Bird } = makePirateShip();
     const pirate = await Pirate.create({ catchphrase: "Yarr" });
     const bird = await Bird.create({ name: "Polly", pirate_id: pirate.id });
-    markForDestruction(bird);
+    bird.markForDestruction();
     cacheAssoc(pirate, "birds", [bird]);
     await pirate.save();
     expect(bird.isDestroyed()).toBe(true);
@@ -317,8 +313,8 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
     const pirate = await Pirate.create({ catchphrase: "Yarr" });
     const b1 = await Bird.create({ name: "birds_0", pirate_id: pirate.id });
     const b2 = await Bird.create({ name: "birds_1", pirate_id: pirate.id });
-    markForDestruction(b1);
-    markForDestruction(b2);
+    b1.markForDestruction();
+    b2.markForDestruction();
     // Override the second bird's destroy to raise after super
     const origDestroy = b2.destroy.bind(b2);
     (b2 as any).destroy = async () => {
@@ -336,7 +332,7 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
     const { Pirate, Bird } = makePirateShip();
     const pirate = await Pirate.create({ catchphrase: "Yarr" });
     const b1 = new Bird({ name: "Polly" });
-    markForDestruction(b1);
+    b1.markForDestruction();
     const b2 = new Bird({ name: "Crackers" });
     cacheAssoc(pirate, "birds", [b1, b2]);
     const saved = await pirate.save();
@@ -348,7 +344,7 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
     const { Pirate, Bird } = makePirateShip();
     const pirate = await Pirate.create({ catchphrase: "Yarr" });
     const b1 = await Bird.create({ name: "Polly", pirate_id: pirate.id });
-    markForDestruction(b1);
+    b1.markForDestruction();
     const b2 = new Bird({ name: "Polly" });
     cacheAssoc(pirate, "birds", [b1, b2]);
     const saved = await pirate.save();
@@ -370,7 +366,7 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
 
     const parrots = await proxy;
     expect(parrots.some((p) => p.markedForDestruction())).toBe(false);
-    for (const p of parrots) markForDestruction(p);
+    for (const p of parrots) p.markForDestruction();
 
     // Rails `assert_no_difference "Parrot.count"`: HABTM mark_for_destruction
     // removes the join row, it does NOT destroy the associated record.
@@ -393,7 +389,7 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
     for (const p of parrots) p.name = "";
     expect(await pirate.isValid()).toBe(false);
 
-    for (const p of parrots) markForDestruction(p);
+    for (const p of parrots) p.markForDestruction();
 
     // Rails `assert_not_called(parrot, :valid?)`: a marked-for-destruction child
     // is skipped by `association_valid?` before validation runs, so `valid?`
@@ -472,7 +468,7 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
     const proxy = association(pirate, "parrots");
     await proxy.create({ name: "parrots_1" });
 
-    for (const p of await proxy) markForDestruction(p);
+    for (const p of await proxy) p.markForDestruction();
     expect(await pirate.save()).toBe(true);
 
     // The join record is already gone — saving again issues no queries.
@@ -488,7 +484,7 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
     await proxy.create({ name: "parrots_1" });
 
     const before = (await proxy).map((p) => p.id).sort();
-    for (const p of await proxy) markForDestruction(p);
+    for (const p of await proxy) p.markForDestruction();
 
     // Mirror Rails: override the parrots association's `destroy` to raise after
     // running the real destroy, so the whole save transaction rolls back.
@@ -1645,7 +1641,7 @@ describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
     // ship. Only an autosave association skips validating a marked child.
     const ship = new ShipWithoutNestedAttributes({ name: "The Black Flag" });
     const part = ship.parts.build();
-    markForDestruction(part);
+    part.markForDestruction();
 
     expect(await ship.isValid()).toBe(false);
   });
@@ -2956,7 +2952,7 @@ describe("TestHasManyAutosaveAssociationWhichItselfHasAutosaveAssociations", () 
     const pirate = await Pirate.create({ catchphrase: "Yarr" });
     const ship = await Ship.create({ name: "Pearl", pirate_id: pirate.id });
     const part = await Part.create({ name: "Mast", ship_id: ship.id });
-    markForDestruction(part);
+    part.markForDestruction();
     cacheAssoc(ship, "parts", [part]);
     ship.name = "Pearl-touched";
     cacheAssoc(pirate, "ships", [ship]);
@@ -3289,7 +3285,7 @@ describe("TestHasOneAutosaveAssociationWhichItselfHasAutosaveAssociations", () =
     const pirate = await Pirate.create({ catchphrase: "Yarr" });
     const ship = await Ship.create({ name: "Pearl", pirate_id: pirate.id });
     const part = await Part.create({ name: "Mast", ship_id: ship.id });
-    markForDestruction(part);
+    part.markForDestruction();
     cacheAssoc(ship, "part", part);
     ship.name = "Pearl-touched";
     cacheAssoc(pirate, "ship", ship);
@@ -4830,7 +4826,7 @@ describe("TestAutosaveAssociationOnACollectionRemoveCallbacks", () => {
       const assocName = `birdsWith${callbackType === "method" ? "Method" : "Proc"}Callbacks`;
       const pirate = await CanonicalPirate.create({ catchphrase: "Arr" });
       const child = await association(pirate, assocName).create({ name: "Crowe the One-Eyed" });
-      markForDestruction(child);
+      child.markForDestruction();
       const childId = child.id;
 
       pirate.shipLog.splice(0);

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -158,10 +158,6 @@ function _setAutosavingBelongsToFor(record: any, association: unknown, value: bo
 // Standalone exports (used by other modules, called via dynamic import)
 // ---------------------------------------------------------------------------
 
-export function markForDestruction(record: Base): void {
-  (record as any)[MARKED_FOR_DESTRUCTION] = true;
-}
-
 export function isDestroyable(record: Base): boolean {
   return !record.isNewRecord() && record.markedForDestruction();
 }

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -332,7 +332,7 @@ export { SchemaMigration, NullSchemaMigration } from "./schema-migration.js";
 export type { MigrationProxy } from "./migration.js";
 export type { DelegatedTypeOptions } from "./delegated-type.js";
 
-export { markForDestruction, isDestroyable } from "./autosave-association.js";
+export { isDestroyable } from "./autosave-association.js";
 export { Connection as TypeCasterConnection } from "./type-caster/connection.js";
 export { Map as TypeCasterMap } from "./type-caster/map.js";
 

--- a/packages/activerecord/src/nested-attributes.test.ts
+++ b/packages/activerecord/src/nested-attributes.test.ts
@@ -18,7 +18,6 @@ import {
   REJECT_ALL_BLANK_PROC,
   TooManyRecords,
 } from "./index.js";
-import { markForDestruction } from "./autosave-association.js";
 import { fixtures } from "./test-fixtures.js";
 import type { AssociationProxy } from "./associations/collection-proxy.js";
 import { Human } from "./test-helpers/models/human.js";
@@ -171,7 +170,7 @@ describe("TestNestedAttributesInGeneral", () => {
   it("a model should respond to underscore destroy and return if it is marked for destruction", async () => {
     const ship = await Ship.createBang({ name: "Nights Dirty Lightning" });
     expect(ship.markedForDestruction()).toBe(false);
-    markForDestruction(ship);
+    ship.markForDestruction();
     expect(ship.markedForDestruction()).toBe(true);
   });
 

--- a/packages/activerecord/src/nested-attributes.trails.test.ts
+++ b/packages/activerecord/src/nested-attributes.trails.test.ts
@@ -16,6 +16,7 @@ import { Categorization } from "./test-helpers/models/categorization.js";
 import { Pirate } from "./test-helpers/models/pirate.js";
 import { Parrot } from "./test-helpers/models/parrot.js";
 import { Ship } from "./test-helpers/models/ship.js";
+import { Developer } from "./test-helpers/models/developer.js";
 
 // Dynamic column reads/writes (FK/counter-cache columns and the generated
 // `*Attributes=` setters vary per model and are not statically declared), kept
@@ -143,6 +144,7 @@ describe("nested attributes save wrapper argument forwarding (trails-only)", () 
   fixtures({
     pirates: [Pirate, {}],
     ships: [Ship, {}],
+    developers: [Developer, {}],
   });
 
   // `acceptsNestedAttributesFor` wraps `save` to flush pending nested
@@ -405,5 +407,41 @@ describe("nested attributes assignment ordering (trails-only)", () => {
     });
 
     expect(events.slice(0, 3)).toEqual(["remove_target!:start", "remove_target!:end", "parrots"]);
+  });
+});
+
+describe("nested attributes destroy dispatch (trails-only)", () => {
+  fixtures({
+    pirates: [Pirate, {}],
+    ships: [Ship, {}],
+    developers: [Developer, {}],
+  });
+
+  // Rails' `assign_to_or_mark_for_destruction` calls `record.mark_for_destruction`
+  // (nested_attributes.rb:578), so an override on the record is honoured. A
+  // trails port that wrote the private flag directly instead would bypass it.
+  it("dispatches the _destroy flag through the record's markForDestruction", async () => {
+    Pirate.acceptsNestedAttributesFor("ship", { allowDestroy: true });
+    const pirate = await Pirate.createBang({ catchphrase: "Arr" });
+    const ship = await (
+      pirate as unknown as { createShip(a: Record<string, unknown>): Promise<Ship> }
+    ).createShip({ name: "Nights Dirty Lightning" });
+
+    const original = Ship.prototype.markForDestruction;
+    let calls = 0;
+    Ship.prototype.markForDestruction = function (this: Ship): void {
+      calls += 1;
+      original.call(this);
+    };
+    try {
+      await (pirate as unknown as { update(a: Record<string, unknown>): Promise<unknown> }).update({
+        shipAttributes: { id: ship.id, _destroy: "1" },
+      });
+    } finally {
+      Ship.prototype.markForDestruction = original;
+    }
+
+    expect(calls).toBe(1);
+    expect(await Ship.findBy({ id: ship.id })).toBeNull();
   });
 });

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -8,7 +8,7 @@ import {
 import { ActiveRecordError, UnknownAttributeError, RecordNotFound } from "./errors.js";
 import { singularize, camelize, underscore, isBlank } from "@blazetrails/activesupport";
 import { Table, UpdateManager } from "@blazetrails/arel";
-import { markForDestruction, defineAutosaveValidationCallbacks } from "./autosave-association.js";
+import { defineAutosaveValidationCallbacks } from "./autosave-association.js";
 import { BooleanType } from "@blazetrails/activemodel";
 
 /**
@@ -482,7 +482,7 @@ export function assignToOrMarkForDestruction(
   const pending = childRecord.assignAttributes(assignable);
   const markIfRequested = (): void => {
     if (hasDestroyFlag(attributes) && allowDestroy) {
-      markForDestruction(childRecord);
+      childRecord.markForDestruction();
     }
   };
   return pending ? pending.then(markIfRequested) : markIfRequested();
@@ -957,7 +957,7 @@ export function assignNestedAttributesForCollectionAssociation(
           const id = a.id;
           if (id != null && id !== "" && hasDestroyFlag(a)) {
             const existing = findRecordById(targetModel, loaded, id);
-            if (existing) markForDestruction(existing);
+            if (existing) existing.markForDestruction();
           }
         }
       }

--- a/packages/activesupport/src/cache.ts
+++ b/packages/activesupport/src/cache.ts
@@ -1,8 +1,11 @@
 import { extractOptions, toParam } from "./hash-utils.js";
 import { env } from "./process-adapter.js";
 import { MemoryStore } from "./cache/memory-store.js";
-import { NullStore } from "./cache/null-store.js";
-import { FileStore } from "./cache/file-store.js";
+// Imported for the registration side effect: each store module registers its
+// class under its symbol name, which is what requiring the file does in Ruby.
+import "./cache/null-store.js";
+import "./cache/file-store.js";
+import { lookupStoreClass } from "./cache/store-registry.js";
 import type { CacheStore } from "./cache/index.js";
 
 export { Store, ArgumentError, NotImplementedError, WriteOptions } from "./cache/store.js";
@@ -106,28 +109,24 @@ function retrieveCacheKey(key: unknown): string {
  * Ruby resolves the class by `require "active_support/cache/#{store}"` plus a
  * `const_get` on the camelized name, so a store shipped by another gem
  * resolves too. ESM has no such call-time autoload — an import is eager and
- * cannot be built from a runtime name — so the stores this package ships are
- * named directly, and any other name raises with the message Ruby's rescued
- * LoadError produces.
+ * cannot be built from a runtime name — so the store modules register
+ * themselves under their symbol name (the way requiring the file defines the
+ * constant) and the lookup reads that registry, which stands in for the
+ * `ActiveSupport::Cache` namespace `const_get` reads. A name nothing has
+ * registered raises with the message Ruby's rescued LoadError produces.
  *
  * Mirrors: ActiveSupport::Cache.retrieve_store_class (cache.rb:135-144)
  *
  * @internal
  */
 function retrieveStoreClass(store: string): new (...args: any[]) => CacheStore {
-  switch (store) {
-    case ":memory_store":
-      return MemoryStore as unknown as new (...args: any[]) => CacheStore;
-    case ":null_store":
-      return NullStore as unknown as new (...args: any[]) => CacheStore;
-    case ":file_store":
-      return FileStore as unknown as new (...args: any[]) => CacheStore;
-    default: {
-      const name = store.slice(1);
-      throw new RuntimeError(
-        `Could not find cache store adapter for ${name} ` +
-          `(cannot load such file -- active_support/cache/${name})`,
-      );
-    }
+  const klass = lookupStoreClass(store);
+  if (klass === undefined) {
+    const name = store.slice(1);
+    throw new RuntimeError(
+      `Could not find cache store adapter for ${name} ` +
+        `(cannot load such file -- active_support/cache/${name})`,
+    );
   }
+  return klass;
 }

--- a/packages/activesupport/src/cache/file-store.ts
+++ b/packages/activesupport/src/cache/file-store.ts
@@ -6,6 +6,7 @@ import { Entry } from "./entry.js";
 import { Store, type StoreOptions } from "./store.js";
 import { integer } from "./integer.js";
 import { type CacheEntry, isExpired } from "./entry-record.js";
+import { registerStoreClass } from "./store-registry.js";
 
 const FILENAME_MAX_SIZE = 228;
 
@@ -273,3 +274,5 @@ function toI(value: unknown): number {
   }
   return 0;
 }
+
+registerStoreClass(":file_store", FileStore);

--- a/packages/activesupport/src/cache/memory-store.ts
+++ b/packages/activesupport/src/cache/memory-store.ts
@@ -3,6 +3,7 @@ import { coder } from "./coder.js";
 import { Entry } from "./entry.js";
 import { Store } from "./store.js";
 import { integer } from "./integer.js";
+import { registerStoreClass } from "./store-registry.js";
 
 // In-memory record backing a single key. We store the coder-serialized value
 // (so Date/undefined/bigint/non-finite numbers and deep-clone isolation survive
@@ -194,3 +195,5 @@ export namespace DupCoder {
     return dump(entry);
   }
 }
+
+registerStoreClass(":memory_store", MemoryStore);

--- a/packages/activesupport/src/cache/null-store.ts
+++ b/packages/activesupport/src/cache/null-store.ts
@@ -1,6 +1,7 @@
 import type { CacheOptions, CacheStore } from "./index.js";
 import { Entry } from "./entry.js";
 import { Store } from "./store.js";
+import { registerStoreClass } from "./store-registry.js";
 
 // Mirrors Rails `Cache::NullStore` (null_store.rb): a store that persists
 // nothing. read/write/delete/exist?/fetch/read_multi/write_multi/delete_multi
@@ -39,3 +40,5 @@ export class NullStore extends Store implements CacheStore {
     return false;
   }
 }
+
+registerStoreClass(":null_store", NullStore);

--- a/packages/activesupport/src/cache/store-registry.trails.test.ts
+++ b/packages/activesupport/src/cache/store-registry.trails.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Trails-only: Ruby resolves a cache store class by requiring
+ * `active_support/cache/#{store}` at call time (cache.rb:135-144), so a store
+ * shipped by another gem resolves with no change to Rails. ESM cannot build an
+ * import specifier from a runtime name, so trails keeps a registry that stands
+ * in for the `ActiveSupport::Cache` namespace `const_get` reads. Rails has no
+ * counterpart test because Ruby needs none.
+ */
+import { describe, it, expect } from "vitest";
+import { lookupStore } from "../cache.js";
+import { registerStoreClass } from "./store-registry.js";
+import { MemoryStore } from "./memory-store.js";
+import { NullStore } from "./null-store.js";
+import { FileStore } from "./file-store.js";
+
+describe("cache store registry (trails-only)", () => {
+  it("resolves the stores this package ships", () => {
+    expect(lookupStore(":memory_store")).toBeInstanceOf(MemoryStore);
+    expect(lookupStore(":null_store")).toBeInstanceOf(NullStore);
+    expect(lookupStore(":file_store", "tmp/cache")).toBeInstanceOf(FileStore);
+  });
+
+  it("resolves a store registered from outside this package", () => {
+    class MyOwnStore extends NullStore {}
+    registerStoreClass(":my_own_store", MyOwnStore);
+
+    expect(lookupStore(":my_own_store")).toBeInstanceOf(MyOwnStore);
+  });
+
+  it("raises Ruby's rescued LoadError message for an unregistered store", () => {
+    expect(() => lookupStore(":no_such_store")).toThrow(
+      "Could not find cache store adapter for no_such_store " +
+        "(cannot load such file -- active_support/cache/no_such_store)",
+    );
+  });
+});

--- a/packages/activesupport/src/cache/store-registry.ts
+++ b/packages/activesupport/src/cache/store-registry.ts
@@ -1,0 +1,41 @@
+import type { CacheStore } from "./index.js";
+
+/**
+ * Ruby resolves a cache store class at call time:
+ * `require "active_support/cache/#{store}"` then `const_get(store.camelize)`
+ * (cache.rb:135-144), so a store shipped by another gem — `redis-activesupport`,
+ * `dalli` — resolves with no change to Rails. ESM has no call-time autoload: an
+ * `import` is eager and its specifier cannot be built from a runtime name. This
+ * registry stands in for the `ActiveSupport::Cache` constant namespace that
+ * `const_get` reads, so a store module registers itself the way requiring its
+ * file defines its constant, and `retrieve_store_class` looks names up rather
+ * than switching over a closed set.
+ *
+ * @noRailsEquivalent PERMANENT: stands in for Ruby's `const_get` over an
+ * autoloaded namespace. ESM imports are eager and their specifier cannot be
+ * built from a runtime name, so no port can resolve a store class by name
+ * without a registry.
+ */
+const STORE_CLASSES = new Map<string, new (...args: any[]) => any>();
+
+/**
+ * Registers `klass` under the Ruby-symbol name of its store (`":memory_store"`),
+ * the trails analogue of `require`-ing `active_support/cache/memory_store`.
+ *
+ * @noRailsEquivalent PERMANENT: half of the constant-namespace stand-in
+ * described on STORE_CLASSES; ESM has no call-time autoload to define it.
+ */
+export function registerStoreClass(store: string, klass: new (...args: any[]) => any): void {
+  STORE_CLASSES.set(store, klass);
+}
+
+/**
+ * Looks a registered store class up, or returns `undefined` where Ruby's
+ * `require` would raise `LoadError`.
+ *
+ * @noRailsEquivalent PERMANENT: half of the constant-namespace stand-in
+ * described on STORE_CLASSES; ESM has no call-time autoload to read it.
+ */
+export function lookupStoreClass(store: string): (new (...args: any[]) => CacheStore) | undefined {
+  return STORE_CLASSES.get(store);
+}

--- a/scripts/parity/conventions.ts
+++ b/scripts/parity/conventions.ts
@@ -123,6 +123,23 @@ export const PATH_SEGMENT_ALIASES: Record<string, string> = {
  */
 export const RUBY_FILE_TS_OVERRIDES: Record<string, string> = {
   "activesupport:inflector/methods.rb": "inflector.ts",
+  // Real ports that live under a different file name than the Ruby one, found
+  // by triaging the buckets #6414 un-hid (RFC 0072). Without these the members
+  // read as missing while the TS file next door defines them.
+  //
+  // `Rescuable`'s class methods are mixed onto a class by `rescueFrom` and
+  // friends in `module-ext.ts`, alongside the other `include`-shaped helpers.
+  "activesupport:rescuable.rb": "module-ext.ts",
+  // `LoggerSilence` and `LoggerThreadSafeLevel` are both mixed into
+  // `ActiveSupport::Logger`; trails carries `silence` and `localLevel` on the
+  // Logger class itself rather than in two mixin files.
+  "activesupport:logger_silence.rb": "logger.ts",
+  "activesupport:logger_thread_safe_level.rb": "logger.ts",
+  // `Deprecation::Disallowed` is one of the modules `Deprecation` includes;
+  // trails carries `disallowedWarnings` / `disallowedBehavior` on Deprecation.
+  "activesupport:deprecation/disallowed.rb": "deprecation.ts",
+  // `Array#extract_options!` is ported next to the other options-hash helpers.
+  "activesupport:core_ext/array/extract_options.rb": "hash-utils.ts",
   "activesupport:core_ext/string/inflections.rb": "inflector.ts",
   // Same reopening shape: this file reopens `class Integer` first, so its
   // bucket owns all of Integer's core_ext surface — `ordinalize`/`ordinal` here

--- a/scripts/parity/unported-files/actionview.ts
+++ b/scripts/parity/unported-files/actionview.ts
@@ -1,0 +1,91 @@
+/**
+ * Entries scoped to `package: "actionview"`. The `package` field, not this file's
+ * name, is what scopes the match. Schema: ./types.ts.
+ *
+ * These are view-layer buckets with no trails counterpart at all — every one is
+ * outside the ActiveRecord/ActiveModel require closure, which is what this
+ * register exists to declare. They read as partly ported until PR #6414 stopped
+ * crediting `matched` to Ruby files with no TS file; scoping them keeps the
+ * `percent` metric measuring porting debt rather than a scope decision.
+ */
+
+import type { UnportedFile } from "./types.js";
+
+const FORM_HELPER_REASON =
+  "Form-builder HTML generation (tag/label/input rendering, `FormBuilder` object binding). " +
+  "Pre-1.0 scope: trails ports no view layer and the AR/AM closure never reaches it.";
+
+export const ACTIONVIEW_UNPORTED_FILES: UnportedFile[] = [
+  {
+    pattern: "/helpers.rb",
+    package: "actionview",
+    reason:
+      "The `ActionView::Helpers` umbrella that includes every helper module; " +
+      "nothing under it is ported, so the barrel has no trails counterpart.",
+  },
+  {
+    pattern: "/test_case.rb",
+    package: "actionview",
+    reason:
+      "Minitest harness for rendering views (`ActionView::TestCase`) — a Rails test-suite " +
+      "support class for a layer trails does not port.",
+  },
+  { pattern: "helpers/form_helper.rb", package: "actionview", reason: FORM_HELPER_REASON },
+  { pattern: "helpers/form_tag_helper.rb", package: "actionview", reason: FORM_HELPER_REASON },
+  { pattern: "helpers/form_options_helper.rb", package: "actionview", reason: FORM_HELPER_REASON },
+  { pattern: "helpers/tags/base.rb", package: "actionview", reason: FORM_HELPER_REASON },
+  {
+    pattern: "helpers/tags/collection_check_boxes.rb",
+    package: "actionview",
+    reason: FORM_HELPER_REASON,
+  },
+  {
+    pattern: "helpers/tags/collection_radio_buttons.rb",
+    package: "actionview",
+    reason: FORM_HELPER_REASON,
+  },
+  {
+    pattern: "helpers/tags/collection_select.rb",
+    package: "actionview",
+    reason: FORM_HELPER_REASON,
+  },
+  {
+    pattern: "helpers/tags/grouped_collection_select.rb",
+    package: "actionview",
+    reason: FORM_HELPER_REASON,
+  },
+  { pattern: "helpers/tags/select.rb", package: "actionview", reason: FORM_HELPER_REASON },
+  {
+    pattern: "helpers/tags/time_zone_select.rb",
+    package: "actionview",
+    reason: FORM_HELPER_REASON,
+  },
+  { pattern: "helpers/tags/weekday_select.rb", package: "actionview", reason: FORM_HELPER_REASON },
+  {
+    pattern: "helpers/asset_tag_helper.rb",
+    package: "actionview",
+    reason: "Emits asset `<script>`/`<img>` tags off the asset pipeline; no trails view layer.",
+  },
+  {
+    pattern: "helpers/translation_helper.rb",
+    package: "actionview",
+    reason:
+      "View-side `translate`/`localize` wrappers that add HTML-safety and lazy `.key` lookup " +
+      "on top of I18n; trails ports the I18n gem itself, not the view wrappers.",
+  },
+  {
+    pattern: "helpers/url_helper.rb",
+    package: "actionview",
+    reason: "`link_to`/`button_to` HTML generation over the routing layer; no trails view layer.",
+  },
+  {
+    pattern: "/layouts.rb",
+    package: "actionview",
+    reason: "Layout resolution for rendered templates; no trails template renderer.",
+  },
+  {
+    pattern: "renderer/collection_renderer.rb",
+    package: "actionview",
+    reason: "Renders a partial per collection element; no trails template renderer.",
+  },
+];

--- a/scripts/parity/unported-files/index.ts
+++ b/scripts/parity/unported-files/index.ts
@@ -9,22 +9,26 @@
 
 import type { UnportedFile } from "./types.js";
 import { ACTIVERECORD_TEST_SUPPORT_UNPORTED_FILES } from "./activerecord-test-support.js";
+import { ACTIONVIEW_UNPORTED_FILES } from "./actionview.js";
 import { ACTIVESUPPORT_UNPORTED_FILES } from "./activesupport.js";
 import { DATE_UNPORTED_FILES } from "./date.js";
 import { DID_YOU_MEAN_UNPORTED_FILES } from "./did-you-mean.js";
 import { GLOBALID_UNPORTED_FILES } from "./globalid.js";
 import { I18N_UNPORTED_FILES } from "./i18n.js";
+import { TRAILTIES_UNPORTED_FILES } from "./trailties.js";
 import { UNSCOPED_UNPORTED_FILES } from "./unscoped.js";
 
 export type { UnportedFile } from "./types.js";
 
 export const UNPORTED_FILES: UnportedFile[] = [
+  ...ACTIONVIEW_UNPORTED_FILES,
   ...ACTIVERECORD_TEST_SUPPORT_UNPORTED_FILES,
   ...ACTIVESUPPORT_UNPORTED_FILES,
   ...DATE_UNPORTED_FILES,
   ...DID_YOU_MEAN_UNPORTED_FILES,
   ...GLOBALID_UNPORTED_FILES,
   ...I18N_UNPORTED_FILES,
+  ...TRAILTIES_UNPORTED_FILES,
   ...UNSCOPED_UNPORTED_FILES,
 ];
 

--- a/scripts/parity/unported-files/trailties.ts
+++ b/scripts/parity/unported-files/trailties.ts
@@ -1,0 +1,35 @@
+/**
+ * Entries scoped to `package: "trailties"`. The `package` field, not this file's
+ * name, is what scopes the match. Schema: ./types.ts.
+ */
+
+import type { UnportedFile } from "./types.js";
+
+const SCAFFOLD_REASON =
+  "Rails scaffold generator: writes controller/view/test templates into a generated app. " +
+  "Pre-1.0 scope — trailties ports no generator layer, and it is outside the AR/AM closure.";
+
+export const TRAILTIES_UNPORTED_FILES: UnportedFile[] = [
+  {
+    pattern: "generators/app_name.rb",
+    package: "trailties",
+    reason:
+      "Validates and camelizes the application name for `rails new`; part of the generator " +
+      "layer trails does not port.",
+  },
+  {
+    pattern: "generators/erb/scaffold/scaffold_generator.rb",
+    package: "trailties",
+    reason: SCAFFOLD_REASON,
+  },
+  {
+    pattern: "generators/rails/scaffold_controller/scaffold_controller_generator.rb",
+    package: "trailties",
+    reason: SCAFFOLD_REASON,
+  },
+  {
+    pattern: "generators/test_unit/scaffold/scaffold_generator.rb",
+    package: "trailties",
+    reason: SCAFFOLD_REASON,
+  },
+];


### PR DESCRIPTION
Four bundled convergence stories.

## 1. `mark_for_destruction` slot writes

Rails' `mark_for_destruction` is `@marked_for_destruction = true`
(`autosave_association.rb:321-323`) and every caller reaches it through the
method — `assign_to_or_mark_for_destruction` calls
`record.mark_for_destruction` (`nested_attributes.rb:578`). trails still had a
standalone `markForDestruction(record)` writing the private slot directly, so
an override on the record was bypassed. Every call site now dispatches through
`record.markForDestruction()`; the standalone export and its `index.ts`
re-export are deleted (public surface `parity:api:extra` scores).

Regression: `dispatches the _destroy flag through the record's markForDestruction`
in `nested-attributes.trails.test.ts` counts the dispatches through an override
— it reads 0 on the pre-change code.

## 2. Duplicate persisted-owner guard on `CollectionProxy#create`

Rails raises `RecordNotSaved("You cannot call create unless the parent is
saved")` once, in `CollectionAssociation#_create_record`
(`collection_association.rb:355-357`); `CollectionProxy#create`/`create!` are
one-liners (`collection_proxy.rb:298-321`). trails ran the proxy's own copy
first, leaving the ported guard dead on the non-through arm. The proxy guard
now runs only on the through arm, which does not route through `_createRecord`
yet (`route-through-create-via-create-record` retires it entirely), with the
reason at the call site. Error class, message and `record` payload unchanged;
the has-many and has-many-through suites are green.

## 3. `Cache.retrieve_store_class`

Ruby builds the require path from the runtime value
(`cache.rb:135-144`), so a store from another gem resolves. The port was a
closed `switch`, which cannot. It now reads a registry standing in for the
`ActiveSupport::Cache` constant namespace `const_get` reads: each shipped store
module registers its class under its symbol name at the bottom of its own body,
the way requiring the file defines the constant. The raise is unchanged, and no
new eager import was added (`cache.ts` already loaded all three store modules).

## 4. Buckets un-hidden by #6414

Triaged the 31 zero-port buckets:

- **actionview (18)** and **trailties (4)** — scoped in new
  `scripts/parity/unported-files/{actionview,trailties}.ts`. All are view-layer
  or generator files outside the AR/AM closure, with no trails counterpart.
- **activesupport (5)** — not scoped: their port is real and lives under
  another file name, so they got `RUBY_FILE_TS_OVERRIDES` entries instead —
  `rescuable.rb` → `module-ext.ts`, `logger_silence.rb` /
  `logger_thread_safe_level.rb` → `logger.ts`, `deprecation/disallowed.rb` →
  `deprecation.ts`, `core_ext/array/extract_options.rb` → `hash-utils.ts`.
  Together they credit 22 previously-missing members.
- **activesupport (4)** — `core_ext/object/acts_like.rb`,
  `core_ext/array/access.rb`, `core_ext/numeric/bytes.rb` and
  `testing/constant_lookup.rb` are left **unscoped**: they are in-closure and
  genuinely unported (each already has a trails test file), so they must keep
  reading as missing.

No bucket regains cross-file `matched` credit; #6414's gate is untouched.

`percent` movement: Overall **72.5% → 82.3%** (12693/17505 → 12656/15369; the
scoping removes 2136 in-scope members and the 59 matches they held, the
overrides add 22). AR closure **92.8% → 93.1%** (8371 → 8390 matched).

Gates: `parity:api:calls` OK, `parity:api:calls:args` OK, `parity:api:extra` clean
(the two registry helpers carry PERMANENT `@noRailsEquivalent` reasons), lint and
typecheck green.

Closes-story: converge-mark-for-destruction-slot-writes
Closes-story: drop-duplicate-persisted-owner-guard-on-proxy-create
Closes-story: converge-retrieve-store-class-to-a-registry
Closes-story: scope-buckets-unhidden-by-phantom-credit-fix
