### PR TITLE
refactor(activerecord): instance-call association callbacks, has_many counter helpers, and PoolConfig#serverVersion under the monitor

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -389,6 +389,58 @@ describeIfPg("PostgreSQLAdapter", () => {
       }
     });
 
+    // Regression for RFC 0061 pg-cancel-block-half-has-no-regression: nothing
+    // covered the `block` half of `cancel_any_running_query`
+    // (postgresql/database_statements.rb:131) — deleting the
+    // `await this._blockUntilCommandSettles(txClient)` line left the suite
+    // green. Its postcondition is libpq's own: once `block` returns, the
+    // cancelled command is off the wire, so `PQtransactionStatus` is no longer
+    // PQTRANS_ACTIVE. On an unloaded host the backend's ErrorResponse happens to
+    // land before the CancelRequest socket closes, so that byte alone does not
+    // discriminate; the deferred stand-in below reproduces the "command has not
+    // come back yet" state CI's loaded runner produces, and pins that the cancel
+    // does not resolve ahead of it.
+    it("cancelAnyRunningQuery waits for the cancelled command to come back", async () => {
+      const PQTRANS_ACTIVE = 1;
+      const other = new PostgreSQLAdapter(PG_TEST_URL);
+      try {
+        await other.beginDbTransaction();
+        const sleep = other.execute("SELECT pg_sleep(2)").catch(() => {});
+        await new Promise<void>((r) => setTimeout(r, 200));
+        expect(other.transactionStatus).toBe(PQTRANS_ACTIVE);
+
+        const internals = other as unknown as {
+          _cancelAnyRunningQuery(): Promise<void>;
+          _blockUntilCommandSettles(client: unknown): Promise<void>;
+        };
+        // Spy the INSTANCE, not the prototype: the adapter reads the method off
+        // `this`, and a prototype spy would be shadowed by nothing here but is
+        // shared with every other adapter in the worker.
+        const blockUntilCommandSettles = internals._blockUntilCommandSettles.bind(other);
+        let releaseBlock!: () => void;
+        const blocked = new Promise<void>((r) => (releaseBlock = r));
+        internals._blockUntilCommandSettles = async (client: unknown): Promise<void> => {
+          await blocked;
+          await blockUntilCommandSettles(client);
+        };
+
+        let cancelReturned = false;
+        const cancel = internals._cancelAnyRunningQuery().then(() => {
+          cancelReturned = true;
+        });
+        await new Promise<void>((r) => setTimeout(r, 50));
+        expect(cancelReturned).toBe(false);
+        releaseBlock();
+        await cancel;
+        expect(other.transactionStatus).not.toBe(PQTRANS_ACTIVE);
+
+        await sleep;
+        await other.rollbackDbTransaction();
+      } finally {
+        await other.close();
+      }
+    });
+
     // Rails' `cancel_any_running_query` has nothing to cancel once the lock
     // covers each query's whole life — `rollback_transaction` takes the same
     // lock (abstract/transaction.rb:611) and finds an idle transaction status.

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -187,6 +187,13 @@ export interface AssociationDefinition {
   isCounterMustBeUpdatedByHasMany?: () => boolean;
   /** Rails' `AbstractReflection#inverse_of` → `inverse_name`. See {@link macro}. */
   inverseName?: () => string | null;
+  /**
+   * Rails' `AbstractReflection#inverse_updates_counter_cache?` (reflection.rb:297,
+   * an alias of `inverse_which_updates_counter_cache`). See {@link macro}.
+   */
+  isInverseUpdatesCounterCache?: () => unknown;
+  /** Rails' `AbstractReflection#klass`. See {@link macro}. */
+  klass?: typeof Base;
 }
 
 /**

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -71,6 +71,20 @@ export class CollectionAssociation extends Association {
 
   private _sharedTargetEnabled = false;
 
+  /**
+   * Mirrors: `CollectionAssociation#callback` / `#callbacks_for`
+   * (collection_association.rb:492-505) — instance methods on the association,
+   * assigned as `this`-typed functions (CLAUDE.md's spelling for a body that
+   * lives at its Rails file position) so every call site is Rails'
+   * `callback(:before_add, record)` rather than a free function taking the
+   * receiver as its first argument.
+   *
+   * @internal
+   */
+  callback = callback;
+  /** @internal */
+  callbacksFor = callbacksFor;
+
   constructor(owner: Base, definition: AssociationDefinition) {
     super(owner, definition);
     this.target = [];
@@ -704,7 +718,7 @@ export class CollectionAssociation extends Association {
       const toRemove = this.difference(this.target, otherArray);
       let removable = true;
       for (const r of toRemove) {
-        if (!callback(this, "beforeRemove", r)) {
+        if (!this.callback("beforeRemove", r)) {
           removable = false;
           break;
         }
@@ -715,7 +729,7 @@ export class CollectionAssociation extends Association {
           if (idx !== -1) this.target.splice(idx, 1);
           this.removeInverseInstance(r);
         }
-        for (const r of toRemove) callback(this, "afterRemove", r);
+        for (const r of toRemove) this.callback("afterRemove", r);
       }
       // concat(difference(new_target, target)): add_to_target per record.
       // `added` is that difference — Rails' concat_records returns the full
@@ -1135,7 +1149,7 @@ export class CollectionAssociation extends Association {
     // Rails remove_records: catch(:abort) { each before_remove } || return —
     // an aborted before_remove halts removal (target untouched); returns false.
     for (const record of records) {
-      if (!callback(this, "beforeRemove", record)) {
+      if (!this.callback("beforeRemove", record)) {
         this._lastRemoveAborted = true;
         return false;
       }
@@ -1156,7 +1170,7 @@ export class CollectionAssociation extends Association {
       this.removeInverseInstance(record);
     }
     this._associationIds = null;
-    for (const record of records) callback(this, "afterRemove", record);
+    for (const record of records) this.callback("afterRemove", record);
     return true;
   }
 
@@ -1480,13 +1494,13 @@ function replaceOnTarget(
       (assoc as any)._associationIds = null;
       target.push(record);
     }
-    if (!skipCallbacks) callback(assoc, "afterAdd", record);
+    if (!skipCallbacks) assoc.callback("afterAdd", record);
     return record;
   };
 
   let yielded = false;
   try {
-    if (!skipCallbacks && !callback(assoc, "beforeAdd", record)) return null;
+    if (!skipCallbacks && !assoc.callback("beforeAdd", record)) return null;
     assoc.setInverseInstance(record);
     assoc._wasLoaded = true;
     if (block) {
@@ -1505,27 +1519,34 @@ function replaceOnTarget(
 }
 
 /**
- * The owner + reflection pair {@link callback} needs. Both the
- * `CollectionAssociation` and the `CollectionProxy` (which holds the same two
- * pieces under different field names) satisfy it.
+ * The receiver {@link callback} and {@link callbacksFor} run against — Rails'
+ * own `owner` / `reflection` readers plus the two methods themselves, so each
+ * calls the other as Rails does (`callbacks_for(method)`,
+ * collection_association.rb:493). Both the `CollectionAssociation` and the
+ * `CollectionProxy` (which holds the same two pieces under different field
+ * names) satisfy it.
  * @internal
  */
 export interface CallbackHost {
   owner: Base;
   reflection: { name: string; options: object };
+  /** @internal */
+  callback(method: string, record: Base): boolean;
+  /** @internal */
+  callbacksFor(callbackName: string): unknown[];
 }
 
 /**
  * Unified association-callback dispatch. Mirrors Rails'
  * `CollectionAssociation#callback` (collection_association.rb:492), whose
  * lookup half is `callbacks_for` (:498): looks up the registered callbacks for
- * `kind` (`beforeAdd`/`afterAdd`/`beforeRemove`/`afterRemove`) and invokes
+ * `method` (`beforeAdd`/`afterAdd`/`beforeRemove`/`afterRemove`) and invokes
  * each. Returns `false` if any callback aborts (Rails `throw :abort`,
  * modelled here as a callback returning `false`), so callers can halt the
  * add/remove like Rails' `catch(:abort) ... || return`.
  *
  * Arity note: like Rails, the stored procs take `(method, owner, record)` and
- * this dispatcher passes `kind` through as `method`. The symbol and proc arms
+ * this dispatcher passes the callback name straight through as `method`. The symbol and proc arms
  * ignore it, but the object arm needs it — Rails' `callback.send(method, owner,
  * record)` (builder/collection_association.rb:51) dispatches the callback kind
  * as a method ON the callback object, so binding it at registration time would
@@ -1534,43 +1555,47 @@ export interface CallbackHost {
  * `callback` is private in Rails, hence `@internal`.
  * @internal
  */
-export function callback(assoc: CallbackHost, kind: string, record: Base): boolean {
+export function callback(this: CallbackHost, method: string, record: Base): boolean {
   // Rails wraps only `before_add`/`before_remove` in `catch(:abort)`
   // (collection_association.rb:400-402, 462-464); after callbacks run outside
   // the catch (:408, :485), so a `throw :abort` from after_add/after_remove
   // propagates rather than being silently swallowed.
-  const catchAbort = kind.startsWith("before");
-  for (const cb of callbacksFor(assoc, kind)) {
+  const catchAbort = method.startsWith("before");
+  for (const cb of this.callbacksFor(method)) {
     if (typeof cb !== "function") continue;
     // A before callback halts the add/remove ONLY by throwing the abort sentinel
     // (faithful `throw :abort`); a `false` return no longer halts (Rails 5+).
     if (catchAbort) {
       try {
-        (cb as any)(kind, assoc.owner, record);
+        (cb as any)(method, this.owner, record);
       } catch (e) {
         if (!isAbortSignal(e)) throw e;
         return false;
       }
     } else {
       // after callbacks run outside the catch; their return value is ignored.
-      (cb as any)(kind, assoc.owner, record);
+      (cb as any)(method, this.owner, record);
     }
   }
   return true;
 }
 
-/** @internal */
-function callbacksFor(assoc: CallbackHost, callbackName: string): unknown[] {
+/**
+ * Mirrors: `CollectionAssociation#callbacks_for`
+ * (collection_association.rb:498-505), the lookup half of {@link callback}.
+ * @internal
+ */
+export function callbacksFor(this: CallbackHost, callbackName: string): unknown[] {
   // The builder stores normalized callbacks both as the
   // `<kind>For<Name>` class attribute (Rails parity) and on the reflection
   // options; either is the same array. Prefer the class attribute, matching
   // Rails' `owner.class.send("#{callback_name}_for_#{reflection.name}")`.
-  const fullName = `${callbackName}For${assoc.reflection.name.charAt(0).toUpperCase()}${assoc.reflection.name.slice(1)}`;
-  const owner = assoc.owner.constructor as any;
+  const fullName = `${callbackName}For${this.reflection.name.charAt(0).toUpperCase()}${this.reflection.name.slice(1)}`;
+  const owner = this.owner.constructor as any;
   const stored = owner[fullName];
   if (typeof stored === "function") return stored();
   if (Array.isArray(stored)) return stored;
-  const fromOptions = (assoc.reflection.options as Record<string, unknown>)[callbackName];
+  const fromOptions = (this.reflection.options as Record<string, unknown>)[callbackName];
   return Array.isArray(fromOptions) ? fromOptions : fromOptions != null ? [fromOptions] : [];
 }
 

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -3,6 +3,7 @@ import { Relation } from "../relation.js";
 import {
   CollectionAssociation,
   callback as assocCallback,
+  callbacksFor as assocCallbacksFor,
   type CallbackHost,
 } from "./collection-association.js";
 import type { PrettyPrinter } from "../pretty-print.js";
@@ -348,7 +349,12 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * @internal
    */
   private get _callbackHost(): CallbackHost {
-    return { owner: this._record, reflection: this._assocDef };
+    return {
+      owner: this._record,
+      reflection: this._assocDef,
+      callback: assocCallback,
+      callbacksFor: assocCallbacksFor,
+    };
   }
 
   /** @internal Association name — used by AssociationRelation. */
@@ -1440,13 +1446,13 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   ): Promise<T | null> {
     const { skipCallbacks = false, replace = false } = options;
     const index = this._targetReplaceIndex(record, replace);
-    if (!skipCallbacks && !assocCallback(this._callbackHost, "beforeAdd", record)) {
+    if (!skipCallbacks && !this._callbackHost.callback("beforeAdd", record)) {
       return null;
     }
     _setCollectionInverseInstance(this._record, this._assocName, this._assocDef.options, record);
     if (save) await save();
     this._commitToTarget(record, index);
-    if (!skipCallbacks) assocCallback(this._callbackHost, "afterAdd", record);
+    if (!skipCallbacks) this._callbackHost.callback("afterAdd", record);
     return record;
   }
 
@@ -1464,7 +1470,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   ): T | null {
     const { skipCallbacks = false, replace = false, inversing = false } = options;
     const index = this._targetReplaceIndex(record, replace);
-    if (!skipCallbacks && !assocCallback(this._callbackHost, "beforeAdd", record)) {
+    if (!skipCallbacks && !this._callbackHost.callback("beforeAdd", record)) {
       return null;
     }
     if (!inversing) {
@@ -1475,7 +1481,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       _setCollectionInverseInstance(this._record, this._assocName, this._assocDef.options, record);
     }
     this._commitToTarget(record, index, inversing);
-    if (!skipCallbacks) assocCallback(this._callbackHost, "afterAdd", record);
+    if (!skipCallbacks) this._callbackHost.callback("afterAdd", record);
     return record;
   }
 
@@ -2332,7 +2338,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       // return`: if any record's before_remove halts, the entire operation aborts
       // and nothing is deleted (the transaction commits with no work done).
       for (const record of modelRecords) {
-        if (!assocCallback(this._callbackHost, "beforeRemove", record)) {
+        if (!this._callbackHost.callback("beforeRemove", record)) {
           aborted = true;
           return;
         }
@@ -2401,7 +2407,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       // Remove from target first, then fire after_remove for all records.
       this._removeFromTarget(modelRecords as Base[]);
       for (const record of modelRecords) {
-        assocCallback(this._callbackHost, "afterRemove", record);
+        this._callbackHost.callback("afterRemove", record);
       }
     };
 
@@ -3625,7 +3631,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     if (this._isThrough) {
       const record = this._buildRecord(attrs) as T;
       if (block) block(record);
-      if (!assocCallback(this._callbackHost, "beforeAdd", record)) {
+      if (!this._callbackHost.callback("beforeAdd", record)) {
         throw new RecordNotSaved("Callback prevented record creation", record);
       }
       // Rails' `_create_record` runs the target save INSIDE the transaction —
@@ -3640,7 +3646,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       if (this._target.length === targetBefore) {
         throw new RecordNotSaved("Failed to create join record for through association", record);
       }
-      assocCallback(this._callbackHost, "afterAdd", record);
+      this._callbackHost.callback("afterAdd", record);
       return record;
     }
     // Rails: `@association.create!(...)` (collection_proxy.rb:319-321).

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -244,11 +244,7 @@ export class HasManyAssociation extends CollectionAssociation {
       // Rails: records.each(&:destroy!).
       for (const record of records) await (record as any).destroyBang();
       // Rails: update_counter(-records.length) unless reflection.inverse_updates_counter_cache?
-      // (has_many_association.rb:130). The destroy callbacks decrement the owner's
-      // counter through the child's belongs_to inverse (CounterCache#destroy_row)
-      // only when that inverse points at THIS reflection's counter column;
-      // otherwise (e.g. a has_many `counter_cache:` distinct from the inverse's)
-      // decrement here so we don't silently skip it.
+      // (has_many_association.rb:130).
       if (!this.reflection.isInverseUpdatesCounterCache?.()) {
         await this.updateCounter(-records.length);
       }
@@ -259,10 +255,9 @@ export class HasManyAssociation extends CollectionAssociation {
     // `delete` is intercepted by the CollectionProxy. Scope to the given records by
     // their query-constraint columns so we delete/nullify only those rows.
     // Rails: `reflection.klass.composite_query_constraints_list`
-    // (has_many_association.rb:132). An ad-hoc holder built from a macro
-    // definition (a through step's synthesised def) carries no `klass`, so fall
-    // back to the association's own resolved class — the same class the rich
-    // reflection resolves to.
+    // (has_many_association.rb:132). The `?? this.klass` arm covers an ad-hoc
+    // holder built from a macro definition, which carries no `klass`; it
+    // resolves to the same class.
     const queryConstraints = compositeQueryConstraintsList.call(
       (this.reflection.klass ?? this.klass) as any,
     );
@@ -327,10 +322,6 @@ export class HasManyAssociation extends CollectionAssociation {
    * @internal
    */
   async countRecords(): Promise<number> {
-    // Rails reads `reflection.has_active_cached_counter?` /
-    // `reflection.counter_cache_column` off its own reflection
-    // (has_many_association.rb:83-88); `association(name)` hands us the rich one
-    // (`associations.rb:290-296`), so there is nothing to re-resolve.
     const refl = this.reflection;
     return countRecords({
       hasActiveCachedCounter: () => refl.hasActiveCachedCounter?.() ?? false,

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -50,6 +50,10 @@ export class HasManyAssociation extends CollectionAssociation {
   declare updateCounterInMemory: (difference: number) => void;
   /** @internal */
   declare updateCounterIfSuccess: <T>(savedSuccessfully: T, difference: number) => T;
+  /** @internal */
+  declare updateCounter: (difference: number, reflection?: AssociationDefinition) => Promise<void>;
+  /** @internal */
+  declare deleteCount: (method: string, scope: any) => Promise<number>;
 
   /**
    * Set on an ad-hoc holder built by a CollectionProxy whose own Relation state
@@ -220,8 +224,8 @@ export class HasManyAssociation extends CollectionAssociation {
    * @internal
    */
   protected override async deleteOrNullifyAllRecords(method?: string): Promise<number> {
-    const count = await deleteCount(this, method ?? "", (this as any).scope());
-    await updateCounter(this, -count);
+    const count = await this.deleteCount(method ?? "", (this as any).scope());
+    await this.updateCounter(-count);
     return count;
   }
 
@@ -240,18 +244,13 @@ export class HasManyAssociation extends CollectionAssociation {
       // Rails: records.each(&:destroy!).
       for (const record of records) await (record as any).destroyBang();
       // Rails: update_counter(-records.length) unless reflection.inverse_updates_counter_cache?
-      // The destroy callbacks decrement the owner's counter through the child's
-      // belongs_to inverse (CounterCache#destroy_row) only when that inverse points
-      // at THIS reflection's counter column; otherwise (e.g. a has_many `counter_cache:`
-      // distinct from the inverse's) decrement here so we don't silently skip it.
-      const ctor = this.owner.constructor as typeof Base & {
-        _reflectOnAssociation?: (
-          n: string,
-        ) => { inverseWhichUpdatesCounterCache?: () => unknown } | undefined;
-      };
-      const refl = ctor._reflectOnAssociation?.(this.reflection.name) ?? this.reflection;
-      if (!(refl as any).inverseWhichUpdatesCounterCache?.()) {
-        await updateCounter(this, -records.length);
+      // (has_many_association.rb:130). The destroy callbacks decrement the owner's
+      // counter through the child's belongs_to inverse (CounterCache#destroy_row)
+      // only when that inverse points at THIS reflection's counter column;
+      // otherwise (e.g. a has_many `counter_cache:` distinct from the inverse's)
+      // decrement here so we don't silently skip it.
+      if (!this.reflection.isInverseUpdatesCounterCache?.()) {
+        await this.updateCounter(-records.length);
       }
       return records.length;
     }
@@ -259,7 +258,14 @@ export class HasManyAssociation extends CollectionAssociation {
     // association-layer `delete` with a dependent strategy; non-through has_many
     // `delete` is intercepted by the CollectionProxy. Scope to the given records by
     // their query-constraint columns so we delete/nullify only those rows.
-    const queryConstraints = compositeQueryConstraintsList.call(this.klass as any);
+    // Rails: `reflection.klass.composite_query_constraints_list`
+    // (has_many_association.rb:132). An ad-hoc holder built from a macro
+    // definition (a through step's synthesised def) carries no `klass`, so fall
+    // back to the association's own resolved class — the same class the rich
+    // reflection resolves to.
+    const queryConstraints = compositeQueryConstraintsList.call(
+      (this.reflection.klass ?? this.klass) as any,
+    );
     const values = records.map((r) =>
       queryConstraints.map((col) => (r as any)._readAttribute(col)),
     );
@@ -278,8 +284,8 @@ export class HasManyAssociation extends CollectionAssociation {
     // (collection-association.ts). Without this the per-record delete path falls
     // through to nullify, which fails for NOT-NULL composite-PK foreign keys.
     const strategy = method === "delete" ? "deleteAll" : method;
-    const count = await deleteCount(this, strategy, scope);
-    if (count > 0) await updateCounter(this, -count);
+    const count = await this.deleteCount(strategy, scope);
+    if (count > 0) await this.updateCounter(-count);
     return count;
   }
 
@@ -321,13 +327,11 @@ export class HasManyAssociation extends CollectionAssociation {
    * @internal
    */
   async countRecords(): Promise<number> {
-    const ctor = this.owner.constructor as typeof Base & {
-      _reflectOnAssociation?: (n: string) => unknown;
-    };
-    const refl = (ctor._reflectOnAssociation?.(this.reflection.name) ?? this.reflection) as {
-      hasActiveCachedCounter?: () => boolean;
-      counterCacheColumn?: () => string | null;
-    };
+    // Rails reads `reflection.has_active_cached_counter?` /
+    // `reflection.counter_cache_column` off its own reflection
+    // (has_many_association.rb:83-88); `association(name)` hands us the rich one
+    // (`associations.rb:290-296`), so there is nothing to re-resolve.
+    const refl = this.reflection;
     return countRecords({
       hasActiveCachedCounter: () => refl.hasActiveCachedCounter?.() ?? false,
       counterCacheColumn: () => refl.counterCacheColumn?.() ?? null,
@@ -402,12 +406,19 @@ function toI(value: unknown): number {
   return Number.isNaN(n) ? 0 : n;
 }
 
-/** @internal */
-async function updateCounter(assoc: HasManyAssociation, difference: number): Promise<void> {
-  const reflection = assoc.reflection;
+/**
+ * Mirrors: `HasManyAssociation#update_counter(difference, reflection =
+ * reflection())` (has_many_association.rb:98-102).
+ * @internal
+ */
+async function updateCounter(
+  this: HasManyAssociation,
+  difference: number,
+  reflection: AssociationDefinition = this.reflection,
+): Promise<void> {
   if (!reflection.hasCachedCounter?.()) return;
   const column = reflection.counterCacheColumn?.() as string;
-  const owner = assoc.owner as any;
+  const owner = this.owner as any;
   if (typeof owner.incrementBang === "function") {
     await owner.incrementBang(column, difference);
   } else if (typeof owner.updateCounters === "function") {
@@ -435,12 +446,16 @@ function updateCounterInMemory(this: HasManyAssociation, difference: number): vo
   owner.clearAttributeChange?.(column);
 }
 
-/** @internal */
-function deleteCount(assoc: HasManyAssociation, method: string, scope: any): Promise<number> {
+/**
+ * Mirrors: `HasManyAssociation#delete_count(method, scope)`
+ * (has_many_association.rb:112-118).
+ * @internal
+ */
+function deleteCount(this: HasManyAssociation, method: string, scope: any): Promise<number> {
   // Rails: delete_all → scope.delete_all; nullify → scope.update_all(nullified_owner_attributes).
   if (method === "deleteAll") return scope.deleteAll?.() ?? Promise.resolve(0);
   const nullAttrs = (
-    assoc as unknown as {
+    this as unknown as {
       computeNullifiedOwnerAttributes(): Record<string, null>;
     }
   ).computeNullifiedOwnerAttributes();
@@ -798,4 +813,9 @@ export function scope(record: Base, assocName: string, options: AssociationOptio
   return rel;
 }
 
-Object.assign(HasManyAssociation.prototype, { updateCounterInMemory, updateCounterIfSuccess });
+Object.assign(HasManyAssociation.prototype, {
+  updateCounterInMemory,
+  updateCounterIfSuccess,
+  updateCounter,
+  deleteCount,
+});

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -499,7 +499,7 @@ export class ConnectionPool implements ReapablePool {
     return this._boundSchemaCache;
   }
 
-  serverVersion(connection: DatabaseAdapter): unknown {
+  serverVersion(connection: DatabaseAdapter): Promise<unknown> {
     return this.poolConfig.serverVersion(connection);
   }
 

--- a/packages/activerecord/src/connection-adapters/pool-config.test.ts
+++ b/packages/activerecord/src/connection-adapters/pool-config.test.ts
@@ -192,23 +192,63 @@ describe("PoolConfig", () => {
   });
 
   describe("serverVersion", () => {
-    it("returns a function that caches the version from a connection", () => {
+    it("returns a function that caches the version from a connection", async () => {
       const mockConn = { getDatabaseVersion: vi.fn().mockReturnValue("3.39.0") };
-      const version = config.serverVersion(mockConn as any);
+      const version = await config.serverVersion(mockConn as any);
       expect(version).toBe("3.39.0");
       expect(mockConn.getDatabaseVersion).toHaveBeenCalledTimes(1);
 
-      config.serverVersion(mockConn as any);
+      await config.serverVersion(mockConn as any);
       expect(mockConn.getDatabaseVersion).toHaveBeenCalledTimes(1);
     });
 
-    it("can be set directly via the setter", () => {
+    it("can be set directly via the setter", async () => {
       config.setServerVersion("15.0");
       const mockConn = { getDatabaseVersion: vi.fn() };
-      const version = config.serverVersion(mockConn as any);
+      const version = await config.serverVersion(mockConn as any);
       expect(version).toBe("15.0");
       expect(mockConn.getDatabaseVersion).not.toHaveBeenCalled();
     });
+
+    // `@server_version || synchronize { @server_version ||= ... }`
+    // (`pool_config.rb:39-41`): the monitor is what makes the memo a memo under
+    // concurrency. Both callers arrive before either fetch resolves, so without
+    // the lock both issue the version query.
+    it("two concurrent first callers issue one fetch", async () => {
+      let fetches = 0;
+      const mockConn = {
+        async getDatabaseVersion() {
+          fetches += 1;
+          await new Promise<void>((r) => setTimeout(r, 10));
+          return "15.0";
+        },
+      };
+      const [a, b] = await Promise.all([
+        config.serverVersion(mockConn as any),
+        config.serverVersion(mockConn as any),
+      ]);
+      expect([a, b]).toEqual(["15.0", "15.0"]);
+      expect(fetches).toBe(1);
+    });
+
+    // Ruby's monitor is reentrant, which `configure_connection`
+    // (`abstract_adapter.rb:1212`) depends on: it reads the version back
+    // through this method from inside the fetch that opened the connection.
+    // The ported monitor is reentrant too, so the nested read runs straight
+    // through and recomputes rather than waiting on the lock it is inside.
+    it("a read re-entered from inside the fetch resolves rather than deadlocking", async () => {
+      let fetches = 0;
+      const mockConn = {
+        async getDatabaseVersion(): Promise<string> {
+          fetches += 1;
+          await Promise.resolve();
+          if (fetches === 1) await config.serverVersion(mockConn as any);
+          return "15.0";
+        },
+      };
+      expect(await config.serverVersion(mockConn as any)).toBe("15.0");
+      expect(fetches).toBe(2);
+    }, 5000);
   });
 
   describe("static discardPoolsBang", () => {

--- a/packages/activerecord/src/connection-adapters/pool-config.ts
+++ b/packages/activerecord/src/connection-adapters/pool-config.ts
@@ -147,28 +147,26 @@ export class PoolConfig {
    * adapter's `get_database_version` is fetched through; the adapters
    * themselves stay pure.
    *
-   * Reviewed against the monitor: Rails' `synchronize` here only prevents two
-   * threads both running `get_database_version`; it is a memoization guard,
-   * not a correctness one — either fetch yields the same version, and Ruby's
-   * monitor is reentrant precisely because `configure_connection` re-enters
-   * this method (see below). Locking it would mean the sync arm — which every
-   * caller of a version-gated adapter branch depends on — could no longer
-   * return a value. Left unlocked deliberately.
+   * The ported `synchronize` is async, so the reader is too — every consumer
+   * already awaits `AbstractAdapter#databaseVersion`, which is where the
+   * version-gated adapter branches read it.
+   *
+   * The reentry Ruby's Monitor tolerates is load-bearing here: the fetch opens
+   * the connection, whose `configureConnection` (`abstract_adapter.rb:1212`)
+   * reads the version back through this method from inside the fetch. Our
+   * monitor is reentrant too, so that nested call runs straight through and
+   * recomputes against a still-null `_serverVersion` exactly as Ruby's does.
    */
-  serverVersion(connection: DatabaseAdapter): unknown {
-    // trails-only: `getDatabaseVersion` is a real await on every adapter
-    // whose version comes off the wire, where Rails' is sync.
-    if (this._serverVersion != null) return this._serverVersion;
-    const version = connection.getDatabaseVersion?.();
-    // Only the resolved value is memoized, never the in-flight promise: the
-    // fetch opens the connection, whose `configureConnection`
-    // (`abstract_adapter.rb:1212`) reads back through here, and handing that
-    // nested call the promise it is itself inside would deadlock. Ruby's
-    // `synchronize` is a re-entrant Monitor, so it recomputes there too.
-    if (version instanceof Promise) {
-      return version.then((v) => (this._serverVersion = v));
-    }
-    return (this._serverVersion = version);
+  async serverVersion(connection: DatabaseAdapter): Promise<unknown> {
+    return (
+      this._serverVersion ??
+      (await this.synchronize(async () => {
+        // trails-only: `getDatabaseVersion` is a real await on every adapter
+        // whose version comes off the wire, where Rails' is sync.
+        this._serverVersion ??= await connection.getDatabaseVersion?.();
+        return this._serverVersion;
+      }))
+    );
   }
 
   /**

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-association.json
@@ -2,17 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/collection-association.ts",
-    "rubyName": "callback",
-    "call": "callbacks_for",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:method"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/collection-association.ts",
     "rubyName": "ids_writer",
     "call": "index_by",
     "kind": "args",
@@ -59,29 +48,5 @@
       "kwargs{replace=bool:true}"
     ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/collection-association.ts",
-    "rubyName": "replace_on_target",
-    "call": "callback",
-    "kind": "args",
-    "rubyArgs": [
-      "str:afterAdd",
-      "ref:record"
-    ],
-    "reason": "Receiver-as-first-argument shape, not an argument divergence: Rails' `callback(:before_add, record)` / `callback(:after_add, record)` (collection_association.rb:463, :485) are instance calls on the association, and the TS `callback` is a free function whose first parameter is that receiver (`assoc`), so the extractor reads it as an extra leading argument. Surfaced by this PR only because the begin/finish split collapsed into one `replaceOnTarget`, which the extractor can now match to `replace_on_target`; the calls themselves predate it. Converges with the file-wide receiver-as-first-argument burndown, not here."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/collection-association.ts",
-    "rubyName": "replace_on_target",
-    "call": "callback",
-    "kind": "args",
-    "rubyArgs": [
-      "str:beforeAdd",
-      "ref:record"
-    ],
-    "reason": "Receiver-as-first-argument shape, not an argument divergence: Rails' `callback(:before_add, record)` / `callback(:after_add, record)` (collection_association.rb:463, :485) are instance calls on the association, and the TS `callback` is a free function whose first parameter is that receiver (`assoc`), so the extractor reads it as an extra leading argument. Surfaced by this PR only because the begin/finish split collapsed into one `replaceOnTarget`, which the extractor can now match to `replace_on_target`; the calls themselves predate it. Converges with the file-wide receiver-as-first-argument burndown, not here."
   }
 ]


### PR DESCRIPTION
Four bundled stories.

**pg-cancel-block-half-has-no-regression** (RFC 0061) — test-only. Nothing
covered the `block` half of `cancel_any_running_query`
(`postgresql/database_statements.rb:131`): deleting
`await this._blockUntilCommandSettles(txClient)` left the PG suite green. The
new regression asserts the cancel does not return ahead of the settle, plus
libpq's own postcondition (`PQtransactionStatus` no longer `PQTRANS_ACTIVE`).
Verified red on a baseline with that `await` removed (`expected true to be
false`) and green with it in place. On an unloaded host the backend's
ErrorResponse happens to land before the CancelRequest socket closes — measured
5/5 — so the status byte alone does not discriminate; the deferred stand-in
reproduces the "command has not come back yet" state CI's loaded runner
produces. It spies the adapter INSTANCE, not the prototype.

**collection-association-callback-instance-call** (RFC 0099) —
`CollectionAssociation#callback` / `#callbacks_for` become instance methods
(`collection_association.rb:492-505`), assigned as `this`-typed functions per
CLAUDE.md's module-mixin idiom, so every call site is Rails'
`callback(:before_add, record)` instead of a free function taking the receiver
as argument 1. `CollectionProxy` reaches them through its `_callbackHost` the
same way. The three `kind: "args"` rows for `callback` / `callbacks_for` in
`call-mismatches-exclude/activerecord/associations/collection-association.json`
are deleted by hand (only-shrink, no reseed); the `--write` reseed is a no-op
against the result.

**converge-has-many-delete-records-rich-reflection** (RFC 0084) —
`delete_records` now reads `reflection.klass` and
`reflection.inverse_updates_counter_cache?` (`has_many_association.rb:130-132`)
with no `owner.constructor._reflectOnAssociation(...)` re-resolve; same
re-resolve removed from `count_records`. `association(name)` already hands the
association the rich reflection (`instance-methods.ts:163-166`, Rails
`associations.rb:290-296`), so there was nothing to re-resolve. `delete_count`
and `update_counter` become instance methods with Rails' parameter lists
(`has_many_association.rb:98-102, 112-118`), including the
`reflection = reflection()` default.

The same re-resolve shape survives ~18 times in `collection-proxy.ts`, which
holds only the thin `_assocDef` and has no rich `reflection` reader at all;
filed as `converge-collection-proxy-rich-reflection-re-resolve` (RFC 0084)
rather than reshaped here.

**converge-pool-config-pool-and-server-version-under-the-monitor** (RFC 0084) —
`#serverVersion` mirrors `pool_config.rb:39-41` including the `synchronize`
block; its "left unlocked deliberately" finding is deleted, and the reader is
now async (every consumer already awaited `AbstractAdapter#databaseVersion`).
New tests cover both halves the monitor buys: two concurrent first callers
issue one fetch, and the `configure_connection` reentry
(`abstract_adapter.rb:1212`) resolves rather than deadlocking on the lock it is
inside.

`#pool` is NOT converged here. The ported `synchronize` is async, so locking it
turns a Ruby attribute-shaped reader into a promise-returning method, and
`poolConfig.pool` is read synchronously from ~105 non-test call sites
(`Base.connectionPool()`, the whole `ConnectionHandler` surface). That flip is
its own PR under the LOC ceiling; filed as
`converge-pool-config-pool-under-the-monitor` (RFC 0084) with the blocking
caller shape named, and the existing finding on `get pool()` left untouched
rather than reworded.

Gates: `pnpm parity:api:calls`, `pnpm parity:api:calls:args`,
`pnpm parity:api:extra --package activerecord` clean; baseline reseed is a
no-op. Association, counter-cache, nested-attributes, collection-proxy and pool
suites green on SQLite and PostgreSQL locally.

Closes-story: pg-cancel-block-half-has-no-regression
Closes-story: collection-association-callback-instance-call
Closes-story: converge-has-many-delete-records-rich-reflection
Closes-story: converge-pool-config-pool-and-server-version-under-the-monitor
