### PR TITLE
refactor(activerecord): converge PoolConfig descriptor naming; collapse the duplicate replace_on_target store

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -657,26 +657,6 @@ export function _preloadedHolderTarget(
 }
 
 /**
- * Set the inverse association instance on a freshly built/created collection
- * member, caching the owner on the child under the resolved inverse name.
- * Mirrors `ActiveRecord::Associations::Association#set_inverse_instance`, called
- * from `initialize_attributes` (so the inverse is wired before any build/create
- * block runs) and from `replace_on_target`.
- *
- * @internal
- */
-export function _setCollectionInverseInstance(
-  owner: Base,
-  assocName: string,
-  options: AssociationOptions,
-  record: Base,
-): void {
-  const ownerCtor = owner.constructor as typeof Base;
-  const inverseName = _resolveInverseName(ownerCtor, assocName, options);
-  if (inverseName) _wireInverseAssociation(owner, record, inverseName);
-}
-
-/**
  * @internal
  * Builds a HasManyThroughAssociationNotFoundError with DidYouMean-style
  * `corrections` derived from the owner's existing association names —

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -862,15 +862,14 @@ export class CollectionAssociation extends Association {
       ?.distinctValue;
     const shouldReplace = replace || distinctValue;
     if (save) {
-      return replaceOnTarget(
-        this,
+      return this.replaceOnTarget(
         record,
         skipCallbacks,
         { replace: shouldReplace },
         save,
       ) as Promise<Base | null>;
     }
-    return replaceOnTarget(this, record, skipCallbacks, { replace: shouldReplace }) as Base | null;
+    return this.replaceOnTarget(record, skipCallbacks, { replace: shouldReplace }) as Base | null;
   }
 
   /**
@@ -1343,6 +1342,77 @@ export class CollectionAssociation extends Association {
     const idSet = new Set(normalizedIds);
     return this.target.filter((r) => idSet.has(normalize(this.primaryKeyValue(r))));
   }
+
+  /**
+   * Mirrors Rails' `CollectionAssociation#replace_on_target(record,
+   * skip_callbacks, replace:, inversing: false, &block)`
+   * (collection_association.rb:457-489) — one Rails method, one TS method, and
+   * the ONLY implementation of it: `CollectionProxy` reaches this one rather
+   * than re-spelling the body over its own target array.
+   *
+   * `block` is Rails' `yield(record)`: `concat_records` passes the per-record
+   * insert there. TypeScript cannot `await` inside a method whose other callers
+   * (build/replace) must stay synchronous, so the block's promise is threaded
+   * through `.then` rather than `await`ed, and the return type widens to
+   * `Promise<Base | null>` exactly when a block is supplied. Rails'
+   * `ensure @_was_loaded = nil` (:488) therefore runs in a `finally` on that
+   * promise for the block arm and in the sync `finally` otherwise.
+   *
+   * `replace_on_target` is private in Rails, hence `@internal`.
+   * @internal
+   */
+  replaceOnTarget(
+    record: Base,
+    skipCallbacks: boolean,
+    { replace, inversing = false }: { replace: boolean; inversing?: boolean },
+    block?: () => Promise<void>,
+  ): Base | null | Promise<Base | null> {
+    // Ruby's `@target.index(record)` uses `Core#==`, not JS reference identity,
+    // so a re-fetched persisted record dedups against the one already buffered.
+    // `-1` stands in for Ruby's `nil` index throughout.
+    const targetIndex = (): number =>
+      this.target.findIndex((r) => r === record || r.equals(record));
+
+    let index =
+      replace && (!record.isNewRecord() || this._replacedOrAddedTargets.has(record))
+        ? targetIndex()
+        : -1;
+
+    const afterYield = (): Base => {
+      const target = this.target;
+      if (index === -1 && this._replacedOrAddedTargets.has(record)) index = targetIndex();
+      if (inversing || index !== -1 || record.isNewRecord()) {
+        this._replacedOrAddedTargets.add(record);
+      }
+      if (index !== -1) {
+        target[index] = record;
+      } else if (this._wasLoaded || !this.isLoaded()) {
+        (this as any)._associationIds = null;
+        target.push(record);
+      }
+      if (!skipCallbacks) this.callback("afterAdd", record);
+      return record;
+    };
+
+    let yielded = false;
+    try {
+      if (!skipCallbacks && !this.callback("beforeAdd", record)) return null;
+      this.setInverseInstance(record);
+      this._wasLoaded = true;
+      if (block) {
+        yielded = true;
+        return block()
+          .then(afterYield)
+          .finally(() => {
+            this._wasLoaded = null;
+          });
+      }
+      return afterYield();
+    } finally {
+      // Rails' `ensure @_was_loaded = nil` (collection_association.rb:488).
+      if (!yielded) this._wasLoaded = null;
+    }
+  }
 }
 
 /**
@@ -1444,75 +1514,7 @@ function replaceCommonRecordsInMemory(
 ): void {
   const common = diffHooks(assoc).intersection(newTarget, originalTarget);
   for (const record of common) {
-    replaceOnTarget(assoc, record, true, { replace: true }) as Base | null;
-  }
-}
-
-/**
- * Mirrors Rails' `CollectionAssociation#replace_on_target(record,
- * skip_callbacks, replace:, inversing: false, &block)`
- * (collection_association.rb:457-489) — one Rails method, one TS function.
- *
- * `block` is Rails' `yield(record)`: `concat_records` passes the per-record
- * insert there. TypeScript cannot `await` inside a function whose other callers
- * (build/replace) must stay synchronous, so the block's promise is threaded
- * through `.then` rather than `await`ed, and the function's return type widens
- * to `Promise<Base | null>` exactly when a block is supplied. Rails'
- * `ensure @_was_loaded = nil` (:488) therefore runs in a `finally` on that
- * promise for the block arm and in the sync `finally` otherwise.
- *
- * @internal
- */
-function replaceOnTarget(
-  assoc: CollectionAssociation,
-  record: Base,
-  skipCallbacks: boolean,
-  { replace, inversing = false }: { replace: boolean; inversing?: boolean },
-  block?: () => Promise<void>,
-): Base | null | Promise<Base | null> {
-  // Ruby's `@target.index(record)` uses `Core#==`, not JS reference identity,
-  // so a re-fetched persisted record dedups against the one already buffered.
-  // `-1` stands in for Ruby's `nil` index throughout.
-  const targetIndex = (): number => assoc.target.findIndex((r) => r === record || r.equals(record));
-
-  let index =
-    replace && (!record.isNewRecord() || assoc._replacedOrAddedTargets.has(record))
-      ? targetIndex()
-      : -1;
-
-  const afterYield = (): Base => {
-    const target = assoc.target;
-    if (index === -1 && assoc._replacedOrAddedTargets.has(record)) index = targetIndex();
-    if (inversing || index !== -1 || record.isNewRecord()) {
-      assoc._replacedOrAddedTargets.add(record);
-    }
-    if (index !== -1) {
-      target[index] = record;
-    } else if (assoc._wasLoaded || !assoc.isLoaded()) {
-      (assoc as any)._associationIds = null;
-      target.push(record);
-    }
-    if (!skipCallbacks) assoc.callback("afterAdd", record);
-    return record;
-  };
-
-  let yielded = false;
-  try {
-    if (!skipCallbacks && !assoc.callback("beforeAdd", record)) return null;
-    assoc.setInverseInstance(record);
-    assoc._wasLoaded = true;
-    if (block) {
-      yielded = true;
-      return block()
-        .then(afterYield)
-        .finally(() => {
-          assoc._wasLoaded = null;
-        });
-    }
-    return afterYield();
-  } finally {
-    // Rails' `ensure @_was_loaded = nil` (collection_association.rb:488).
-    if (!yielded) assoc._wasLoaded = null;
+    assoc.replaceOnTarget(record, true, { replace: true }) as Base | null;
   }
 }
 

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -61,7 +61,6 @@ import {
   resolveAssocClass,
   _routeThroughViaAssociationScope,
   ownerHasUnresolvedThroughKey,
-  _setCollectionInverseInstance,
   _violatesStrictLoading,
 } from "../associations.js";
 import { _setCollectionProxyCtor } from "./collection-proxy-slot.js";
@@ -1286,7 +1285,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * @internal
    */
   addExistingRecord(record: T): void {
-    this._replaceOnTarget(record, { skipCallbacks: true });
+    this._collectionAssociation().addToTarget(record, { skipCallbacks: true });
   }
 
   /**
@@ -1394,10 +1393,11 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * Rails' `CollectionAssociation#_create_record` routes both regular and
    * :through associations through `add_to_target` (HasManyThroughAssociation
    * overrides only `build_record`/`insert_record`, not `_create_record`). The
-   * non-:through path goes through `_addToTarget` directly; the :through path
-   * builds + saves the target in `_createThrough`, then hands the in-memory
-   * mutation to `_pushThrough`, which now also routes through `_addToTarget`
-   * (shared set_inverse_instance + `@replaced_or_added_targets` dedup).
+   * non-:through path goes through `CollectionAssociation#create` directly; the
+   * :through path builds + saves the target in `_createThrough`, then hands the
+   * in-memory mutation to `_pushThrough`, which routes through the same
+   * `CollectionAssociation#addToTarget` (shared set_inverse_instance +
+   * `@replaced_or_added_targets` dedup).
    */
   async create(attrs: Record<string, unknown>[], block?: (r: T) => void): Promise<T[]>;
   async create(attrs?: Record<string, unknown>, block?: (r: T) => void): Promise<T>;
@@ -1431,119 +1431,14 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   }
 
   /**
-   * Add `record` to the in-memory target, firing add callbacks, wiring the
-   * inverse instance, and deduping by identity via `_replacedOrAddedTargets`.
-   * Mirrors `ActiveRecord::Associations::CollectionAssociation#replace_on_target`.
-   *
-   * `save`, when supplied, runs between `set_inverse_instance` and the target
-   * mutation (Rails' `yield(record)` inside `replace_on_target`, used by
-   * `create`/`concat` to `insert_record`). Its return value is ignored: the
-   * record is committed to the target and `after_add` fires regardless of the
-   * save result, matching Rails' `replace_on_target` (the `yield(record)` at
-   * collection_association.rb:470 is unused). A non-raising save failure that
-   * needs to be undone is rolled back by the surrounding `transaction { ... } /
-   * raise Rollback` — the `create` and persisted-`concat` paths both wrap the
-   * insert in a transaction (see `create` and the `concat` funnel below).
-   *
-   * Rails' append branch is gated on `@_was_loaded || !loaded?`. On the create
-   * path `@_was_loaded` is set true before the save and reset to `loaded?`
-   * after, so that gate is always true; with `create` the sole caller it is
-   * collapsed to an unconditional push here.
+   * Rails' `@association` ivar (collection_proxy.rb:33), which every mutation
+   * on the proxy delegates to. trails resolves it off the owner instead of
+   * holding it, because the proxy is built from the reflection, not handed the
+   * association object.
    * @internal
    */
-  private async _addToTarget(
-    record: T,
-    options: { skipCallbacks?: boolean; replace?: boolean } = {},
-    save?: () => Promise<unknown>,
-  ): Promise<T | null> {
-    const { skipCallbacks = false, replace = false } = options;
-    const index = this._targetReplaceIndex(record, replace);
-    if (!skipCallbacks && !this._callbackHost.callback("beforeAdd", record)) {
-      return null;
-    }
-    _setCollectionInverseInstance(this._record, this._assocName, this._assocDef.options, record);
-    if (save) await save();
-    this._commitToTarget(record, index);
-    if (!skipCallbacks) this._callbackHost.callback("afterAdd", record);
-    return record;
-  }
-
-  /**
-   * Synchronous sibling of `_addToTarget` for callers with no DB write to
-   * interleave (Rails' `add_to_target` with no block — e.g. `build`, which
-   * calls `add_to_target(build_record(...), replace: true)`). Same
-   * set_inverse_instance + `@replaced_or_added_targets` dedup + before/after_add
-   * funnel as `_addToTarget`, minus the `yield(record)` save step.
-   * @internal
-   */
-  private _replaceOnTarget(
-    record: T,
-    options: { skipCallbacks?: boolean; replace?: boolean; inversing?: boolean } = {},
-  ): T | null {
-    const { skipCallbacks = false, replace = false, inversing = false } = options;
-    const index = this._targetReplaceIndex(record, replace);
-    if (!skipCallbacks && !this._callbackHost.callback("beforeAdd", record)) {
-      return null;
-    }
-    if (!inversing) {
-      // Rails' `set_inverse_instance(record)` (collection_association.rb:466).
-      // On the `inversing: true` path the reciprocal (record → owner) side has
-      // already been established by the caller in `associations.ts`, and
-      // re-wiring here would recurse back into `_wireInverseTarget`.
-      _setCollectionInverseInstance(this._record, this._assocName, this._assocDef.options, record);
-    }
-    this._commitToTarget(record, index, inversing);
-    if (!skipCallbacks) this._callbackHost.callback("afterAdd", record);
-    return record;
-  }
-
-  /**
-   * Pre-callback `@target.index(record)` computation from Rails'
-   * `replace_on_target`: only meaningful when replacing a persisted record or
-   * one already tracked in `@replaced_or_added_targets`.
-   * @internal
-   */
-  private _targetReplaceIndex(record: T, replace: boolean): number {
-    if (replace && (!record.isNewRecord() || this._replacedOrAddedTargets.has(record))) {
-      return this._indexInTarget(record);
-    }
-    return -1;
-  }
-
-  /**
-   * Post-callback target mutation from Rails' `replace_on_target`: recompute
-   * the index (the record may have joined `@replaced_or_added_targets` during a
-   * save), record the identity, then either replace in place or append.
-   * @internal
-   */
-  private _commitToTarget(record: T, index: number, inversing = false): void {
-    if (index === -1 && this._replacedOrAddedTargets.has(record)) {
-      index = this._indexInTarget(record);
-    }
-    // Rails: `@replaced_or_added_targets << record if inversing || index ||
-    // record.new_record?` (collection_association.rb:476).
-    if (inversing || index !== -1 || record.isNewRecord()) {
-      this._replacedOrAddedTargets.add(record);
-    }
-    if (index !== -1) {
-      this._target[index] = record;
-    } else {
-      this._target.push(record);
-      this._invalidateAssociationIds();
-    }
-  }
-
-  /**
-   * Locate `record` in `_target` using ActiveRecord equality (`Core#==`) rather
-   * than JS reference identity, mirroring Ruby's `@target.index(record)` inside
-   * `replace_on_target`. Two distinct object instances of the same class with
-   * the same present primary key compare equal, so a re-fetched persisted record
-   * dedups against the buffered target under a `distinct` scope; new records,
-   * whose `==` falls back to identity, only match the same instance.
-   * @internal
-   */
-  private _indexInTarget(record: T): number {
-    return this._target.findIndex((r) => r === record || r.equals(record));
+  private _collectionAssociation(): CollectionAssociation {
+    return this._record.association(this._assocName) as unknown as CollectionAssociation;
   }
 
   /**
@@ -1567,16 +1462,16 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    *
    * This is the single write entry point for inverse has_many targets. The C2
    * (#2591) seam, which used to reach into `proxy._replacedOrAddedTargets` from
-   * `associations.ts`, is now internal here. `set_inverse_instance(record)` is
-   * deliberately NOT re-invoked (see `_replaceOnTarget`'s `inversing` guard):
-   * the reciprocal (record → owner) side is established by the caller in
-   * `associations.ts`, and re-wiring here would recurse. The seeded record
-   * lands in `_target`, which `Base#_associationCache` surfaces to readers
-   * (this proxy is the canonical has_many store).
+   * `associations.ts`, is now internal here. The seeded record lands in
+   * `_target`, which `Base#_associationCache` surfaces to readers (this proxy
+   * is the canonical has_many store).
    * @internal
    */
   _wireInverseTarget(record: T): void {
-    this._replaceOnTarget(record, { skipCallbacks: true, replace: true, inversing: true });
+    this._collectionAssociation().replaceOnTarget(record, true, {
+      replace: true,
+      inversing: true,
+    }) as Base | null;
   }
 
   // NOTE: If _pushThrough fails after the target is saved, the target record
@@ -2162,10 +2057,10 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       if (skipCallbacks) {
         await this._throughTransaction(async () => {
           for (const record of records) {
-            await this._addToTarget(
+            await (assoc as unknown as CollectionAssociation).addToTarget(
               record,
               { skipCallbacks: true, replace: this.distinctValue },
-              () => assoc.insertRecord(record, true, true),
+              () => assoc.insertRecord(record, true, true) as unknown as Promise<void>,
             );
           }
         });
@@ -3058,7 +2953,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    */
   private _replaceCommonRecordsInMemory(newTarget: T[], originalTarget: T[]): void {
     for (const record of this._intersection(newTarget, originalTarget)) {
-      this._replaceOnTarget(record, { skipCallbacks: true, replace: true });
+      this._collectionAssociation().replaceOnTarget(record, true, { replace: true }) as Base | null;
     }
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/connection-descriptor.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-descriptor.ts
@@ -12,17 +12,31 @@ export interface ConnectionOwner {
 }
 
 export class ConnectionDescriptor {
-  readonly name: string;
-  readonly isPrimary: boolean;
+  private readonly _name: string;
+  private readonly _primary: boolean;
 
-  constructor(name: string, isPrimary: boolean = false) {
-    this.name = name;
-    this.isPrimary = isPrimary;
+  constructor(name: string, primary: boolean = false) {
+    this._name = name;
+    this._primary = primary;
+  }
+
+  /** Mirrors: ConnectionHandler::ConnectionDescriptor#name
+   *  (`abstract/connection_handler.rb:63`) — `primary_class? ? "ActiveRecord::Base" : @name`;
+   *  trails spells `ActiveRecord::Base` as `Base`. */
+  get name(): string {
+    return this.primaryClassQ() ? "Base" : this._name;
+  }
+
+  /** Mirrors: ConnectionHandler::ConnectionDescriptor#primary_class?
+   *  (`abstract/connection_handler.rb:67`). */
+  primaryClassQ(): boolean {
+    return this._primary;
   }
 
   /** Mirrors: ConnectionHandler::ConnectionDescriptor#current_preventing_writes
-   *  (`abstract/connection_handler.rb:71`) — `Base.preventing_writes?(@name)`. */
+   *  (`abstract/connection_handler.rb:71`) — `Base.preventing_writes?(@name)`,
+   *  the raw name, not the primary-normalized `#name`. */
   currentPreventingWrites(): boolean {
-    return isPreventingWrites(this.name);
+    return isPreventingWrites(this._name);
   }
 }

--- a/packages/activerecord/src/connection-adapters/pool-config.test.ts
+++ b/packages/activerecord/src/connection-adapters/pool-config.test.ts
@@ -57,7 +57,7 @@ describe("PoolConfig", () => {
 
     it("wraps primary class owners correctly", () => {
       config.connectionDescriptor = { name: "Base", primaryClassQ: () => true };
-      expect(config.connectionDescriptor.isPrimary).toBe(true);
+      expect(config.connectionDescriptor.primaryClassQ()).toBe(true);
       expect(config.connectionDescriptor.name).toBe("Base");
     });
   });

--- a/packages/activerecord/src/connection-adapters/pool-config.ts
+++ b/packages/activerecord/src/connection-adapters/pool-config.ts
@@ -344,16 +344,7 @@ export class PoolConfig {
     if (value instanceof ConnectionDescriptor) {
       this._connectionDescriptor = value;
     } else {
-      // DEVIATION (RFC 0096): Rails passes `connection_descriptor.name`
-      // verbatim (pool_config.rb:43-50). trails normalizes the primary class's
-      // name to "Base" because the connected-to stack matches pool names
-      // through the same normalization (core.ts `isPreventingWrites`), so an
-      // `ApplicationRecord` pool has to be registered under "Base" for the
-      // stack lookup to find it. Converging means retiring that normalization
-      // on BOTH sides at once — tracked as its own story.
-      const isPrimary = value.primaryClassQ();
-      const name = isPrimary ? "Base" : value.name;
-      this._connectionDescriptor = new ConnectionDescriptor(name, isPrimary);
+      this._connectionDescriptor = new ConnectionDescriptor(value.name, value.primaryClassQ());
     }
   }
 

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -597,7 +597,7 @@ export function connectionSpecificationName(this: typeof Base): string {
 
   // Branch 3: no own property — derive from class shape.
   // Base is always its own terminal; primary classes (ApplicationRecord) store
-  // their pool under "Base" per PoolConfig#connectionDescriptor's normalization.
+  // their pool under "Base" per ConnectionDescriptor#name (connection_handler.rb:63).
   if (this.name === "Base") return "Base";
   if (typeof (this as any).primaryClassQ === "function" && (this as any).primaryClassQ()) {
     return "Base";
@@ -1125,7 +1125,7 @@ export function resolveConfigForConnection(
   // Mirrors Rails: connection_name = primary_class? ? Base.name : name, then
   // self.connection_specification_name = connection_name. The primary class
   // (Base/ApplicationRecord) stores its pool under "Base" — matching
-  // PoolConfig#connectionDescriptor's primary-class normalization — so
+  // ConnectionDescriptor#name's primary-class normalization — so
   // subsequent connectionPool() lookups hit the right key. The reader uses
   // an own-property check so writing here doesn't bleed through JS static
   // inheritance into unrelated subclasses.

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -611,10 +611,6 @@ export function currentPreventingWrites(this: CoreHost): boolean {
 /**
  * Mirrors: ActiveRecord::Core.preventing_writes? (`core.rb:205-213`).
  *
- * Rails compares `klass.name == class_name` against a descriptor whose `name`
- * is "ActiveRecord::Base" for a primary class
- * (`abstract/connection_handler.rb:63`); trails' PoolConfig normalizes that
- * name to "Base", so the klass side is normalized to match.
  */
 export function isPreventingWrites(className?: string): boolean {
   const stack = connectedToStack();
@@ -625,9 +621,7 @@ export function isPreventingWrites(className?: string): boolean {
     if (className) {
       for (const klass of entry.klasses) {
         if (typeof klass !== "function") continue;
-        const targetName =
-          typeof klass.primaryClassQ === "function" && klass.primaryClassQ() ? "Base" : klass.name;
-        if (targetName === className) return entry.preventWrites;
+        if (klass.name === className) return entry.preventWrites;
       }
     }
   }

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -610,7 +610,6 @@ export function currentPreventingWrites(this: CoreHost): boolean {
 
 /**
  * Mirrors: ActiveRecord::Core.preventing_writes? (`core.rb:205-213`).
- *
  */
 export function isPreventingWrites(className?: string): boolean {
   const stack = connectedToStack();

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-association.json
@@ -48,5 +48,19 @@
       "kwargs{replace=bool:true}"
     ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/collection-association.ts",
+    "rubyName": "replace_on_target",
+    "call": "catch",
+    "reason": "Ruby `catch(:abort) { callback(:before_add, record) }` (collection_association.rb:463-465): the abort catch lives inside trails' shared `callback` dispatcher, which converts the thrown abort sentinel into a `false` return — the same split already baselined for `remove_records`."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/collection-association.ts",
+    "rubyName": "replace_on_target",
+    "call": "order:isLoaded,callback",
+    "reason": "TS language shortcoming: the post-`yield(record)` half of the Rails body (collection_association.rb:471-486) has to be a closure so the block arm can run it from `.then`, and a closure must be declared before the `try` that uses it — so `loaded?` and `after_add` read earlier in source order than the `before_add` call that precedes them at runtime."
   }
 ]


### PR DESCRIPTION
Two related convergences: one identifier substitution in the pool-config /
connected-to pair, and the duplicated `replace_on_target` store between
`CollectionProxy` and `CollectionAssociation`.

## 1. `PoolConfig#connectionDescriptor=` passes the class's own name

`PoolConfig#connection_descriptor=` builds
`ConnectionDescriptor.new(connection_descriptor.name, connection_descriptor.primary_class?)`
(`pool_config.rb:43-50`) — the class's own name, verbatim. trails substituted
the literal `"Base"` for the name whenever `primaryClassQ()` was true, and
`Core.preventing_writes?` normalized the klass side the same way to compensate.

The normalization Rails actually has lives one level down, on the descriptor:
`ConnectionDescriptor#name` returns `"ActiveRecord::Base"` when `primary_class?`
while `@name` keeps the real class name, and `#current_preventing_writes` passes
that *raw* `@name` to `Base.preventing_writes?`
(`abstract/connection_handler.rb:57-73`).

So:

- `ConnectionDescriptor` stores the raw name and gains `#name` (primary →
  `"Base"`, trails' spelling of `ActiveRecord::Base`) and `#primaryClassQ()`,
  replacing the plain `isPrimary` field.
- `PoolConfig#connectionDescriptor=` now passes `value.name` and
  `value.primaryClassQ()`.
- `Core.preventing_writes?` compares `klass.name === className` with no
  normalization, matching `hash[:klasses].any? { |klass| klass.name == class_name }`
  (`core.rb:207-213`).

Pool keys are unchanged: `establishConnection` keys on
`poolConfig.connectionDescriptor.name`, which is still `"Base"` for a primary
class — Rails keys the same way, via the getter.

## 2. One `replace_on_target` / `add_to_target` store

Rails has one `replace_on_target` (`collection_association.rb:457-489`), on
`CollectionAssociation`. trails had two: the association's, and a structurally
duplicated `_addToTarget` / `_replaceOnTarget` / `_targetReplaceIndex` /
`_commitToTarget` / `_indexInTarget` set on `CollectionProxy` re-spelling the
same lines. None of those last three exists in Rails; they were the proxy's
private split of `replace_on_target`'s body, the split
`collection-association.ts` removed in #6417.

- The module-level `replaceOnTarget(assoc, …)` helper becomes
  `CollectionAssociation#replaceOnTarget` — one Rails method, one TS method, on
  the Rails class.
- The proxy's five methods are deleted. `addExistingRecord`,
  `_wireInverseTarget`, `_replaceCommonRecordsInMemory` and `_pushThrough` reach
  the association's `addToTarget` / `replaceOnTarget` through a
  `_collectionAssociation()` reader — trails' spelling of Rails' `@association`
  ivar (`collection_proxy.rb:33`), which `CollectionProxy` delegates every
  mutation to.
- The stores were already one: `CollectionAssociation#target` /
  `_replacedOrAddedTargets` forward to the proxy's `_sharedTarget` /
  `_sharedReplacedOrAddedTargets` when a proxy exists, so the surviving method
  mutates the same array either way.
- `set_inverse_instance(record)` is now called unconditionally
  (`collection_association.rb:466`), retiring the proxy's `inversing` guard
  around it; `inversing` survives only where Rails uses it, in the
  `@replaced_or_added_targets << record if inversing || index || record.new_record?`
  arm (`:476`).

Baselines: two `kind: "args"` rows for `replace_on_target` converged and are
deleted, and one stale `@missingRailsCall loaded?` tag on `_createRecord` is
removed. Two new call-set rows are added for the collapsed method — Ruby's
`catch(:abort)`, which lives in trails' shared `callback` dispatcher (the same
split already baselined for `remove_records`), and a source-order row forced by
the `afterYield` closure the async block arm requires.

`packages/activerecord/src/associations/` (97 files, 2139 tests),
`connection-handling`, `pool-config` and `connection-pool` are green locally.

Closes-story: converge-pool-config-primary-class-name-substitution
Closes-story: collapse-collection-proxy-duplicate-add-to-target-store
