### PR TITLE
refactor(parity): rich reflection on CollectionProxy, persistence call args, and four activesupport core_ext ports

### DIFF
--- a/packages/activerecord/src/associations/association-relation.test.ts
+++ b/packages/activerecord/src/associations/association-relation.test.ts
@@ -81,7 +81,10 @@ describe("AssociationRelation", () => {
     const scope = proxy.where({ name: "Mast" }) as unknown as AssociationRelation<ShipPart>;
     expect(scope.proxyAssociation.owner).toBe(ship);
     expect(scope.proxyAssociation.reflection.name).toBe("parts");
-    expect(scope.proxyAssociation.reflection.type).toBe("hasMany");
+    // `reflection` is now the rich AssociationReflection (Rails'
+    // `Association#reflection`), so the macro reads off `macro` — Rails'
+    // `reflection.type` is the polymorphic `*_type` column, nil here.
+    expect(scope.proxyAssociation.reflection.macro).toBe("hasMany");
   });
 
   it("equals compares against a loaded array of records", async () => {

--- a/packages/activerecord/src/associations/association-relation.test.ts
+++ b/packages/activerecord/src/associations/association-relation.test.ts
@@ -81,9 +81,6 @@ describe("AssociationRelation", () => {
     const scope = proxy.where({ name: "Mast" }) as unknown as AssociationRelation<ShipPart>;
     expect(scope.proxyAssociation.owner).toBe(ship);
     expect(scope.proxyAssociation.reflection.name).toBe("parts");
-    // `reflection` is now the rich AssociationReflection (Rails'
-    // `Association#reflection`), so the macro reads off `macro` — Rails'
-    // `reflection.type` is the polymorphic `*_type` column, nil here.
     expect(scope.proxyAssociation.reflection.macro).toBe("hasMany");
   });
 

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -338,9 +338,22 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     this._record = record;
   }
 
-  /** @internal Association definition — used by AssociationRelation. */
+  /**
+   * Mirrors Rails' `Association#reflection` (association.rb:16), which is the
+   * rich `AssociationReflection` the constructor was handed off the owner's
+   * class (`associations.rb:290-296`). The proxy is built from the thin macro
+   * definition, so the reader resolves the reflection here — once — instead of
+   * every rich-predicate call site re-resolving `_reflectOnAssociation`. An
+   * anonymous inline association has no registered reflection; it falls back to
+   * the macro definition.
+   * @internal
+   */
   get reflection(): AssociationDefinition {
-    return this._assocDef;
+    const ctor = this._record.constructor as typeof Base;
+    return (
+      (ctor._reflectOnAssociation?.(this._assocName) as AssociationDefinition | null) ??
+      this._assocDef
+    );
   }
 
   /**
@@ -1287,10 +1300,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * @internal
    */
   private _reflectionForeignKey(): string | string[] | undefined {
-    const ctor = this._record.constructor as typeof Base & {
-      _reflectOnAssociation?: (n: string) => { foreignKey?: string | string[] } | undefined;
-    };
-    return ctor._reflectOnAssociation?.(this._assocName)?.foreignKey ?? undefined;
+    return this.reflection.foreignKey ?? undefined;
   }
 
   /**
@@ -1598,10 +1608,11 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * guard the loader uses.
    */
   private async _djarForCount(): Promise<{ djar: unknown } | null> {
-    const ctor = this._record.constructor as typeof Base;
-    const reflection = ctor._reflectOnAssociation?.(this._assocName);
-    if (!reflection) return null;
-    if (ownerHasUnresolvedThroughKey(this._record, reflection)) return null;
+    const reflection = this.reflection;
+    // An anonymous inline association falls back to the macro definition,
+    // which carries no `klass` for the DJAR to scope against.
+    if (reflection.klass == null) return null;
+    if (ownerHasUnresolvedThroughKey(this._record, reflection as any)) return null;
     const { DisableJoinsAssociationScope } = await import("./disable-joins-association-scope.js");
     const klass = (reflection as { klass: typeof Base }).klass;
     // Box the DJAR so awaiting this helper doesn't unwrap it via
@@ -1642,8 +1653,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     //     doesn't have. Fall back to the loader for those (task #25
     //     covers the underlying scope-build issue).
     if (this._assocDef.options.through) {
-      const ctor = this._record.constructor as typeof Base;
-      const refl = (ctor as any)._reflectOnAssociation?.(this._assocName);
+      const refl = this.reflection as any;
       // Disable-joins through: fast path goes through DJAR's
       // deferred walker + final-step COUNT. The divergence-aware
       // Relation.prototype.count fallthrough below handles any
@@ -1816,15 +1826,10 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * @internal
    */
   private _countRecords(): Promise<number> {
-    const ctor = this._record.constructor as typeof Base & {
-      _reflectOnAssociation?: (n: string) => unknown;
-    };
-    const refl = ctor._reflectOnAssociation?.(this._assocName) as
-      | { hasActiveCachedCounter?: () => boolean; counterCacheColumn?: () => string | null }
-      | undefined;
+    const reflection = this.reflection;
     return countRecords({
-      hasActiveCachedCounter: () => refl?.hasActiveCachedCounter?.() ?? false,
-      counterCacheColumn: () => refl?.counterCacheColumn?.() ?? null,
+      hasActiveCachedCounter: () => reflection.hasActiveCachedCounter?.() ?? false,
+      counterCacheColumn: () => reflection.counterCacheColumn?.() ?? null,
       readCounterAttribute: (col) => this._record.readAttribute(col),
       countViaScope: () => this.count(),
       // Rails clamps by `association_scope.limit_value` — the association's own
@@ -1864,9 +1869,10 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * @internal
    */
   private _foreignKeyPresent(): boolean {
-    const ctor = this._record.constructor as typeof Base;
-    const reflection = ctor._reflectOnAssociation?.(this._assocName);
-    if (!reflection) return false;
+    const reflection = this.reflection;
+    // Same anonymous-inline fallback as `_djarForCount`: the macro definition
+    // carries none of the key readers the two branches below read.
+    if (reflection.klass == null) return false;
     if (this._assocDef.options.through) {
       return throughForeignKeyPresent({ owner: this._record, reflection });
     }
@@ -1905,15 +1911,9 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // Using _countRecords unconditionally was a regression: when count=0 it calls
     // markLoaded(), so a later isEmpty() reads a stale empty cache instead of
     // querying the DB again after records were created.
-    const ctor = this._record.constructor as typeof Base & {
-      _reflectOnAssociation?: (n: string) => unknown;
-    };
-    const refl = ctor._reflectOnAssociation?.(this._assocName) as
-      | { hasActiveCachedCounter?: () => boolean }
-      | undefined;
     let activeCachedCounter = false;
     try {
-      activeCachedCounter = refl?.hasActiveCachedCounter?.() ?? false;
+      activeCachedCounter = this.reflection.hasActiveCachedCounter?.() ?? false;
     } catch {
       // hasActiveCachedCounter can throw when referenced models are not yet
       // registered (e.g. inverseWhichUpdatesCounterCache calls c.klass).
@@ -2211,9 +2211,8 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // association name, which for a collection source (e.g. `has_many :comments
     // through: :posts`, source `Post#comments`) is plural. `singularize` would
     // mis-guess `comment`, so prefer the resolved source reflection.
-    const sourceRefl = ctor._reflectOnAssociation?.(this._assocName)?.sourceReflection as
-      | { name?: string }
-      | undefined;
+    const sourceRefl = (this.reflection as { sourceReflection?: { name?: string } })
+      .sourceReflection;
     const sourceName =
       sourceRefl?.name ?? this._assocDef.options.source ?? singularize(this._assocName);
     const sources = (await (this._record as any)[throughName]) as Base[] | undefined;
@@ -2360,14 +2359,10 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
           // belongs_to inverse only when that inverse points at THIS reflection's
           // counter column; otherwise (e.g. a has_many `counter_cache:` distinct from
           // the inverse's) decrement here so we don't silently skip it.
-          const reflection = (
-            this._record.constructor as typeof Base & {
-              _reflectOnAssociation?: (
-                n: string,
-              ) => { inverseWhichUpdatesCounterCache?: () => unknown } | undefined;
-            }
-          )._reflectOnAssociation?.(this._assocName);
-          if (!reflection?.inverseWhichUpdatesCounterCache?.()) {
+          const reflection = this.reflection as {
+            inverseWhichUpdatesCounterCache?: () => unknown;
+          };
+          if (!reflection.inverseWhichUpdatesCounterCache?.()) {
             await this._decrementCounterCache(persistedRecords.length);
           }
         } else {
@@ -2479,15 +2474,8 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // bypasses the child callbacks, so resolve the reflection's cached-counter
     // column and decrement it here, matching Rails' `update_counter(-count)`.
     if (!column) {
-      const refl = (
-        this._record.constructor as typeof Base & {
-          _reflectOnAssociation?: (n: string) => {
-            hasCachedCounter?: () => boolean;
-            counterCacheColumn?: () => string | null;
-          };
-        }
-      )._reflectOnAssociation?.(this._assocName);
-      if (refl?.hasCachedCounter?.()) column = refl.counterCacheColumn?.() ?? null;
+      const refl = this.reflection;
+      if (refl.hasCachedCounter?.()) column = refl.counterCacheColumn?.() ?? null;
     }
     if (!column) return;
     const owner = this._record as any;
@@ -3358,8 +3346,8 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // throw. Only shapes `_routeThroughViaAssociationScope` still declines
     // (polymorphic-has_many sources, unsaved nested-through) fall through to
     // that fallback, where the composite guards remain as a loud backstop.
-    const refl = (ctor as any)._reflectOnAssociation?.(this._assocName);
-    if (refl && _routeThroughViaAssociationScope(this._record, refl, this._assocDef.options)) {
+    const refl = this.reflection as any;
+    if (_routeThroughViaAssociationScope(this._record, refl, this._assocDef.options)) {
       const joinRel = hasManyScope(this._record, this._assocName, this._assocDef.options);
       return joinRel ?? (this.model as any).all().none(); // null FK → empty, as below
     }
@@ -3388,11 +3376,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // This avoids the pluralize-fallback ambiguity and respects the source:
     // option exactly as Rails does (source_reflection_names returns [options[:source]]
     // only when source: is given — reflection.rb:1108).
-    const sourceRefl = (
-      ctor as unknown as {
-        _reflectOnAssociation?: (n: string) => { sourceReflection?: any } | null;
-      }
-    )._reflectOnAssociation?.(this._assocName)?.sourceReflection;
+    const sourceRefl = (this.reflection as { sourceReflection?: any }).sourceReflection;
 
     const throughAs = throughAssoc.options.as;
     const throughTable = throughModel.arelTable;

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1609,8 +1609,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    */
   private async _djarForCount(): Promise<{ djar: unknown } | null> {
     const reflection = this.reflection;
-    // An anonymous inline association falls back to the macro definition,
-    // which carries no `klass` for the DJAR to scope against.
+    // No registered reflection: the macro-definition fallback carries no `klass`.
     if (reflection.klass == null) return null;
     if (ownerHasUnresolvedThroughKey(this._record, reflection as any)) return null;
     const { DisableJoinsAssociationScope } = await import("./disable-joins-association-scope.js");
@@ -1870,8 +1869,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    */
   private _foreignKeyPresent(): boolean {
     const reflection = this.reflection;
-    // Same anonymous-inline fallback as `_djarForCount`: the macro definition
-    // carries none of the key readers the two branches below read.
+    // No registered reflection: the fallback carries none of the key readers below.
     if (reflection.klass == null) return false;
     if (this._assocDef.options.through) {
       return throughForeignKeyPresent({ owner: this._record, reflection });

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -255,12 +255,12 @@ export class HasManyAssociation extends CollectionAssociation {
     // `delete` is intercepted by the CollectionProxy. Scope to the given records by
     // their query-constraint columns so we delete/nullify only those rows.
     // Rails: `reflection.klass.composite_query_constraints_list`
-    // (has_many_association.rb:132). The `?? this.klass` arm covers an ad-hoc
-    // holder built from a macro definition, which carries no `klass`; it
-    // resolves to the same class.
-    const queryConstraints = compositeQueryConstraintsList.call(
-      (this.reflection.klass ?? this.klass) as any,
-    );
+    // (has_many_association.rb:132). `Association#klass` IS `reflection.klass`
+    // (association.rb:36-38), so this is the same expression — and it keeps the
+    // derivation for an ad-hoc holder built from a macro definition (which
+    // carries no `klass`) in the single reader that owns it, rather than a
+    // second fallback arm here.
+    const queryConstraints = compositeQueryConstraintsList.call(this.klass as any);
     const values = records.map((r) =>
       queryConstraints.map((col) => (r as any)._readAttribute(col)),
     );

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -255,11 +255,8 @@ export class HasManyAssociation extends CollectionAssociation {
     // `delete` is intercepted by the CollectionProxy. Scope to the given records by
     // their query-constraint columns so we delete/nullify only those rows.
     // Rails: `reflection.klass.composite_query_constraints_list`
-    // (has_many_association.rb:132). `Association#klass` IS `reflection.klass`
-    // (association.rb:36-38), so this is the same expression — and it keeps the
-    // derivation for an ad-hoc holder built from a macro definition (which
-    // carries no `klass`) in the single reader that owns it, rather than a
-    // second fallback arm here.
+    // (has_many_association.rb:132); `Association#klass` IS `reflection.klass`
+    // (association.rb:36-38), and owns the unregistered-association derivation.
     const queryConstraints = compositeQueryConstraintsList.call(this.klass as any);
     const values = records.map((r) =>
       queryConstraints.map((col) => (r as any)._readAttribute(col)),

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -255,9 +255,11 @@ export class HasManyAssociation extends CollectionAssociation {
     // `delete` is intercepted by the CollectionProxy. Scope to the given records by
     // their query-constraint columns so we delete/nullify only those rows.
     // Rails: `reflection.klass.composite_query_constraints_list`
-    // (has_many_association.rb:132); `Association#klass` IS `reflection.klass`
-    // (association.rb:36-38), and owns the unregistered-association derivation.
-    const queryConstraints = compositeQueryConstraintsList.call(this.klass as any);
+    // (has_many_association.rb:132). Both routes here go through
+    // `record.association(name)` (instance-methods.ts:163-166, Rails
+    // associations.rb:290-296), which constructs from the registered
+    // reflection, so `reflection.klass` is always the rich reader.
+    const queryConstraints = compositeQueryConstraintsList.call(this.reflection.klass as any);
     const values = records.map((r) =>
       queryConstraints.map((col) => (r as any)._readAttribute(col)),
     );

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -2165,8 +2165,6 @@ export function _raiseRecordNotDestroyed(this: PersistencePrivateHost): never {
   const key = this.constructor.primaryKey;
   const keyStr = Array.isArray(key) ? key.join(", ") : key;
   try {
-    // Rails raises the association's exception when one was recorded, else
-    // builds the RecordNotDestroyed (persistence.rb:952).
     throw (
       (this as any)._associationDestroyException ??
       new RecordNotDestroyed(

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -348,8 +348,7 @@ export async function _deleteRecord(
   constraints: Record<string, unknown>,
 ): Promise<number> {
   const table: ArelTable = (this as any).arelTable;
-  const dm = new DeleteManager();
-  dm.from(table);
+  const dm = new DeleteManager(table);
 
   for (const [col, val] of Object.entries(constraints)) {
     dm.where(table.get(col).eq(val));
@@ -1884,7 +1883,7 @@ export function isApplyScoping(
   // all_queries-flagged default scope (or a global current scope) opts a
   // mutation/reload into scoping; a plain default scope does not.
   const hasAllQueriesDefaultScope = !!ctor.defaultScopes?.some((s: any) => s.allQueries);
-  return !!(hasAllQueriesDefaultScope || ScopeRegistry.globalCurrentScope(ctor));
+  return !!(hasAllQueriesDefaultScope || ctor.globalCurrentScope());
 }
 
 /** @internal */
@@ -2162,18 +2161,22 @@ export function verifyReadonlyAttribute(this: PersistencePrivateHost, name: stri
 
 /** @internal */
 export function _raiseRecordNotDestroyed(this: PersistencePrivateHost): never {
+  (this as any)._associationDestroyException ??= null;
   const key = this.constructor.primaryKey;
   const keyStr = Array.isArray(key) ? key.join(", ") : key;
-  // If an association destroy raised an exception, propagate that instead.
-  const assocEx = (this as any)._associationDestroyException ?? null;
-  if (assocEx) (this as any)._associationDestroyException = null;
-  throw (
-    assocEx ??
-    new RecordNotDestroyed(
-      `Failed to destroy ${this.constructor.name} with ${keyStr}=${String(this.id)}`,
-      this as unknown as object,
-    )
-  );
+  try {
+    // Rails raises the association's exception when one was recorded, else
+    // builds the RecordNotDestroyed (persistence.rb:952).
+    throw (
+      (this as any)._associationDestroyException ??
+      new RecordNotDestroyed(
+        `Failed to destroy ${this.constructor.name} with ${keyStr}=${String(this.id)}`,
+        this as unknown as object,
+      )
+    );
+  } finally {
+    (this as any)._associationDestroyException = null;
+  }
 }
 
 /** @internal */

--- a/packages/activesupport/src/array-utils.ts
+++ b/packages/activesupport/src/array-utils.ts
@@ -158,30 +158,6 @@ export function splitArray<T>(array: T[], valueOrFn: T | ((item: T) => boolean))
 }
 
 /**
- * Return elements from index `position` onwards.
- * Mirrors Rails' `Array#from`.
- */
-export function arrayFrom<T>(array: T[], position: number): T[] {
-  if (position < 0) {
-    const idx = array.length + position;
-    return idx < 0 ? [] : array.slice(idx);
-  }
-  return array.slice(position);
-}
-
-/**
- * Return elements up to (and including) index `position`.
- * Mirrors Rails' `Array#to`.
- */
-export function arrayTo<T>(array: T[], position: number): T[] {
-  if (position < 0) {
-    const idx = array.length + position;
-    return idx < 0 ? [] : array.slice(0, idx + 1);
-  }
-  return array.slice(0, position + 1);
-}
-
-/**
  * Remove elements from `array` that match `predicate`, returning the removed elements.
  * Mirrors Rails' `Array#extract!`.
  */
@@ -194,18 +170,4 @@ export function extract<T>(array: T[], predicate?: (item: T) => boolean): T[] {
     }
   }
   return extracted;
-}
-
-/**
- * Return a new array with the given values appended.
- */
-export function including<T>(array: T[], ...values: T[]): T[] {
-  return [...array, ...values];
-}
-
-/**
- * Return a new array with the given values removed.
- */
-export function excluding<T>(array: T[], ...values: T[]): T[] {
-  return array.filter((item) => !values.includes(item));
 }

--- a/packages/activesupport/src/core-ext/array/access.test.ts
+++ b/packages/activesupport/src/core-ext/array/access.test.ts
@@ -1,34 +1,47 @@
 import { describe, expect, it } from "vitest";
-import { arrayFrom, arrayTo, excluding, including, without } from "../../index.js";
+import { Array as ArrayExt } from "./access.js";
 
 describe("AccessTest", () => {
   it("from", () => {
-    expect(arrayFrom([1, 2, 3, 4, 5], 2)).toEqual([3, 4, 5]);
-    expect(arrayFrom([1, 2, 3], 0)).toEqual([1, 2, 3]);
-    expect(arrayFrom([1, 2, 3], -2)).toEqual([2, 3]);
+    expect(ArrayExt.from([1, 2, 3, 4, 5], 2)).toEqual([3, 4, 5]);
+    expect(ArrayExt.from([1, 2, 3], 0)).toEqual([1, 2, 3]);
+    expect(ArrayExt.from([1, 2, 3], -2)).toEqual([2, 3]);
+    expect(ArrayExt.from([1, 2, 3], 10)).toEqual([]);
+    expect(ArrayExt.from([1, 2, 3], -10)).toEqual([]);
   });
 
   it("to", () => {
-    expect(arrayTo([1, 2, 3, 4, 5], 2)).toEqual([1, 2, 3]);
-    expect(arrayTo([1, 2, 3], 0)).toEqual([1]);
-    expect(arrayTo([1, 2, 3], -2)).toEqual([1, 2]);
+    expect(ArrayExt.to([1, 2, 3, 4, 5], 2)).toEqual([1, 2, 3]);
+    expect(ArrayExt.to([1, 2, 3], 0)).toEqual([1]);
+    expect(ArrayExt.to([1, 2, 3], -2)).toEqual([1, 2]);
+    expect(ArrayExt.to([1, 2, 3], 10)).toEqual([1, 2, 3]);
+    expect(ArrayExt.to([1, 2, 3], -10)).toEqual([]);
   });
 
   it("specific accessor", () => {
     const arr = [1, 2, 3, 4, 5];
-    expect(arr[2]).toBe(3);
-    expect(arr[0]).toBe(1);
+    expect(ArrayExt.second(arr)).toBe(2);
+    expect(ArrayExt.third(arr)).toBe(3);
+    expect(ArrayExt.fourth(arr)).toBe(4);
+    expect(ArrayExt.fifth(arr)).toBe(5);
+    expect(ArrayExt.fortyTwo([...globalThis.Array(42).keys()])).toBe(41);
+    expect(ArrayExt.thirdToLast(arr)).toBe(3);
+    expect(ArrayExt.secondToLast(arr)).toBe(4);
   });
 
   it("including", () => {
-    expect(including([1, 2, 3], 4, 5)).toEqual([1, 2, 3, 4, 5]);
+    expect(ArrayExt.including([1, 2, 3], 4, 5)).toEqual([1, 2, 3, 4, 5]);
+    expect(ArrayExt.including([[0, 1]], [[1, 0]])).toEqual([
+      [0, 1],
+      [1, 0],
+    ]);
   });
 
   it("excluding", () => {
-    expect(excluding([1, 2, 3, 4, 5], 2, 4)).toEqual([1, 3, 5]);
+    expect(ArrayExt.excluding([1, 2, 3, 4, 5], 2, 4)).toEqual([1, 3, 5]);
   });
 
   it("without", () => {
-    expect(without([1, 2, 3, 4, 5], 2, 4)).toEqual([1, 3, 5]);
+    expect(ArrayExt.without([1, 2, 3, 4, 5], 2, 4)).toEqual([1, 3, 5]);
   });
 });

--- a/packages/activesupport/src/core-ext/array/access.ts
+++ b/packages/activesupport/src/core-ext/array/access.ts
@@ -1,0 +1,140 @@
+/**
+ * Mirrors: active_support/core_ext/array/access.rb
+ *
+ * Ruby reopens `Array`; TypeScript cannot, so the reopening is a class of the
+ * Ruby name whose members take the receiver as the first parameter — the same
+ * idiom `core-ext/object/blank.ts` uses for `NilClass`/`String`/`Time`.
+ */
+
+export class Array {
+  /**
+   * Returns the tail of the array from +position+.
+   *
+   *   %w( a b c d ).from(0)  # => ["a", "b", "c", "d"]
+   *   %w( a b c d ).from(2)  # => ["c", "d"]
+   *   %w( a b c d ).from(10) # => []
+   *   %w().from(0)           # => []
+   *   %w( a b c d ).from(-2) # => ["c", "d"]
+   *   %w( a b c ).from(-10)  # => []
+   */
+  static from<T>(self: T[], position: number): T[] {
+    // Ruby: `self[position, length] || []` — the two-arg slice is nil (→ []) for
+    // a start past the end or a negative start that underflows the array.
+    const start = position < 0 ? self.length + position : position;
+    if (start < 0 || start > self.length) return [];
+    return self.slice(start);
+  }
+
+  /**
+   * Returns the beginning of the array up to +position+.
+   *
+   *   %w( a b c d ).to(0)  # => ["a"]
+   *   %w( a b c d ).to(2)  # => ["a", "b", "c"]
+   *   %w( a b c d ).to(10) # => ["a", "b", "c", "d"]
+   *   %w().to(0)           # => []
+   *   %w( a b c d ).to(-2) # => ["a", "b", "c"]
+   *   %w( a b c ).to(-10)  # => []
+   */
+  static to<T>(self: T[], position: number): T[] {
+    if (position >= 0) {
+      return self.slice(0, position + 1);
+    } else {
+      // Ruby: `self[0..position]` — an inclusive range with a negative end,
+      // which is empty once the end underflows the array.
+      const end = self.length + position;
+      return end < 0 ? [] : self.slice(0, end + 1);
+    }
+  }
+
+  /**
+   * Returns a new array that includes the passed elements.
+   *
+   *   [ 1, 2, 3 ].including(4, 5) # => [ 1, 2, 3, 4, 5 ]
+   *   [ [ 0, 1 ] ].including([ [ 1, 0 ] ]) # => [ [ 0, 1 ], [ 1, 0 ] ]
+   */
+  static including<T>(self: T[], ...elements: (T | T[])[]): T[] {
+    return self.concat(elements.flat(1) as T[]);
+  }
+
+  /**
+   * Returns a copy of the Array excluding the specified elements.
+   *
+   *   ["David", "Rafael", "Aaron", "Todd"].excluding("Aaron", "Todd") # => ["David", "Rafael"]
+   *   [ [ 0, 1 ], [ 1, 0 ] ].excluding([ [ 1, 0 ] ]) # => [ [ 0, 1 ] ]
+   *
+   * Note: This is an optimization of `Enumerable#excluding` that uses `Array#-`
+   * instead of `Array#reject` for performance reasons.
+   */
+  static excluding<T>(self: T[], ...elements: (T | T[])[]): T[] {
+    const removed = elements.flat(1) as T[];
+    return self.filter((element) => !removed.includes(element));
+  }
+
+  /** Alias of {@link Array.excluding}. */
+  static without<T>(self: T[], ...elements: (T | T[])[]): T[] {
+    return Array.excluding(self, ...elements);
+  }
+
+  /**
+   * Equal to `self[1]`.
+   *
+   *   %w( a b c d e ).second # => "b"
+   */
+  static second<T>(self: T[]): T | undefined {
+    return self[1];
+  }
+
+  /**
+   * Equal to `self[2]`.
+   *
+   *   %w( a b c d e ).third # => "c"
+   */
+  static third<T>(self: T[]): T | undefined {
+    return self[2];
+  }
+
+  /**
+   * Equal to `self[3]`.
+   *
+   *   %w( a b c d e ).fourth # => "d"
+   */
+  static fourth<T>(self: T[]): T | undefined {
+    return self[3];
+  }
+
+  /**
+   * Equal to `self[4]`.
+   *
+   *   %w( a b c d e ).fifth # => "e"
+   */
+  static fifth<T>(self: T[]): T | undefined {
+    return self[4];
+  }
+
+  /**
+   * Equal to `self[41]`. Also known as accessing "the reddit".
+   *
+   *   (1..42).to_a.forty_two # => 42
+   */
+  static fortyTwo<T>(self: T[]): T | undefined {
+    return self[41];
+  }
+
+  /**
+   * Equal to `self[-3]`.
+   *
+   *   %w( a b c d e ).third_to_last # => "c"
+   */
+  static thirdToLast<T>(self: T[]): T | undefined {
+    return self.at(-3);
+  }
+
+  /**
+   * Equal to `self[-2]`.
+   *
+   *   %w( a b c d e ).second_to_last # => "d"
+   */
+  static secondToLast<T>(self: T[]): T | undefined {
+    return self.at(-2);
+  }
+}

--- a/packages/activesupport/src/core-ext/array/access.ts
+++ b/packages/activesupport/src/core-ext/array/access.ts
@@ -16,10 +16,11 @@ export class Array {
    *   %w().from(0)           # => []
    *   %w( a b c d ).from(-2) # => ["c", "d"]
    *   %w( a b c ).from(-10)  # => []
+   *
+   * Ruby's `self[position, length] || []`: the two-arg slice is nil (→ `[]`)
+   * for a start past the end, or a negative start that underflows the array.
    */
   static from<T>(self: T[], position: number): T[] {
-    // Ruby: `self[position, length] || []` — the two-arg slice is nil (→ []) for
-    // a start past the end or a negative start that underflows the array.
     const start = position < 0 ? self.length + position : position;
     if (start < 0 || start > self.length) return [];
     return self.slice(start);
@@ -34,13 +35,14 @@ export class Array {
    *   %w().to(0)           # => []
    *   %w( a b c d ).to(-2) # => ["a", "b", "c"]
    *   %w( a b c ).to(-10)  # => []
+   *
+   * The negative arm is Ruby's `self[0..position]`: an inclusive range with a
+   * negative end, which is empty once that end underflows the array.
    */
   static to<T>(self: T[], position: number): T[] {
     if (position >= 0) {
       return self.slice(0, position + 1);
     } else {
-      // Ruby: `self[0..position]` — an inclusive range with a negative end,
-      // which is empty once the end underflows the array.
       const end = self.length + position;
       return end < 0 ? [] : self.slice(0, end + 1);
     }

--- a/packages/activesupport/src/core-ext/numeric/bytes.ts
+++ b/packages/activesupport/src/core-ext/numeric/bytes.ts
@@ -1,0 +1,129 @@
+/**
+ * Mirrors: active_support/core_ext/numeric/bytes.rb
+ *
+ * Ruby reopens `Numeric`; TypeScript cannot, so the reopening is a class of the
+ * Ruby name whose members take the receiver as the first parameter — the same
+ * idiom `core-ext/object/blank.ts` uses for `NilClass`/`String`/`Time`.
+ */
+
+export class Numeric {
+  static readonly KILOBYTE = 1024;
+  static readonly MEGABYTE = Numeric.KILOBYTE * 1024;
+  static readonly GIGABYTE = Numeric.MEGABYTE * 1024;
+  static readonly TERABYTE = Numeric.GIGABYTE * 1024;
+  static readonly PETABYTE = Numeric.TERABYTE * 1024;
+  static readonly EXABYTE = Numeric.PETABYTE * 1024;
+  static readonly ZETTABYTE = Numeric.EXABYTE * 1024;
+
+  /**
+   * Enables the use of byte calculations and declarations, like 45.bytes + 2.6.megabytes
+   *
+   *   2.bytes # => 2
+   */
+  static bytes(self: number): number {
+    return self;
+  }
+
+  /** Alias of {@link Numeric.bytes}. */
+  static byte(self: number): number {
+    return Numeric.bytes(self);
+  }
+
+  /**
+   * Returns the number of bytes equivalent to the kilobytes provided.
+   *
+   *   2.kilobytes # => 2048
+   */
+  static kilobytes(self: number): number {
+    return self * Numeric.KILOBYTE;
+  }
+
+  /** Alias of {@link Numeric.kilobytes}. */
+  static kilobyte(self: number): number {
+    return Numeric.kilobytes(self);
+  }
+
+  /**
+   * Returns the number of bytes equivalent to the megabytes provided.
+   *
+   *   2.megabytes # => 2_097_152
+   */
+  static megabytes(self: number): number {
+    return self * Numeric.MEGABYTE;
+  }
+
+  /** Alias of {@link Numeric.megabytes}. */
+  static megabyte(self: number): number {
+    return Numeric.megabytes(self);
+  }
+
+  /**
+   * Returns the number of bytes equivalent to the gigabytes provided.
+   *
+   *   2.gigabytes # => 2_147_483_648
+   */
+  static gigabytes(self: number): number {
+    return self * Numeric.GIGABYTE;
+  }
+
+  /** Alias of {@link Numeric.gigabytes}. */
+  static gigabyte(self: number): number {
+    return Numeric.gigabytes(self);
+  }
+
+  /**
+   * Returns the number of bytes equivalent to the terabytes provided.
+   *
+   *   2.terabytes # => 2_199_023_255_552
+   */
+  static terabytes(self: number): number {
+    return self * Numeric.TERABYTE;
+  }
+
+  /** Alias of {@link Numeric.terabytes}. */
+  static terabyte(self: number): number {
+    return Numeric.terabytes(self);
+  }
+
+  /**
+   * Returns the number of bytes equivalent to the petabytes provided.
+   *
+   *   2.petabytes # => 2_251_799_813_685_248
+   */
+  static petabytes(self: number): number {
+    return self * Numeric.PETABYTE;
+  }
+
+  /** Alias of {@link Numeric.petabytes}. */
+  static petabyte(self: number): number {
+    return Numeric.petabytes(self);
+  }
+
+  /**
+   * Returns the number of bytes equivalent to the exabytes provided.
+   *
+   *   2.exabytes # => 2_305_843_009_213_693_952
+   */
+  static exabytes(self: number): number {
+    return self * Numeric.EXABYTE;
+  }
+
+  /** Alias of {@link Numeric.exabytes}. */
+  static exabyte(self: number): number {
+    return Numeric.exabytes(self);
+  }
+
+  /**
+   * Returns the number of bytes equivalent to the zettabytes provided.
+   *
+   *   2.zettabytes # => 2_361_183_241_434_822_606_848
+   */
+  static zettabytes(self: number): number {
+    return self * Numeric.ZETTABYTE;
+  }
+
+  /** Alias of {@link Numeric.zettabytes}. */
+  static zettabyte(self: number): number {
+    return Numeric.zettabytes(self);
+  }
+}

--- a/packages/activesupport/src/core-ext/numeric/bytes.ts
+++ b/packages/activesupport/src/core-ext/numeric/bytes.ts
@@ -4,6 +4,12 @@
  * Ruby reopens `Numeric`; TypeScript cannot, so the reopening is a class of the
  * Ruby name whose members take the receiver as the first parameter — the same
  * idiom `core-ext/object/blank.ts` uses for `NilClass`/`String`/`Time`.
+ *
+ * `EXABYTE` (1024**6) and `ZETTABYTE` (1024**7) exceed `Number.MAX_SAFE_INTEGER`,
+ * so they — and any `exabytes`/`zettabytes` result — are the nearest double
+ * rather than the exact value Ruby's arbitrary-precision `Integer` gives. The
+ * return type stays `number` to match every other Numeric core_ext method; a
+ * `bigint` port would not compose with them.
  */
 
 export class Numeric {

--- a/packages/activesupport/src/core-ext/object/acts-like.test.ts
+++ b/packages/activesupport/src/core-ext/object/acts-like.test.ts
@@ -7,7 +7,6 @@ describe("ObjectTests", () => {
     expect(ObjectExt.actsLike(datelike, "date")).toBe(true);
     expect(ObjectExt.actsLike({}, "date")).toBe(false);
     expect(ObjectExt.actsLike({ actsLikeTime: () => true }, "time")).toBe(true);
-    // The `else` arm: any duck name, not just the three cased ones.
     expect(ObjectExt.actsLike({ actsLikeStringish: () => true }, "stringish")).toBe(true);
   });
 

--- a/packages/activesupport/src/core-ext/object/acts-like.test.ts
+++ b/packages/activesupport/src/core-ext/object/acts-like.test.ts
@@ -1,16 +1,19 @@
 import { describe, expect, it } from "vitest";
+import { Object as ObjectExt } from "./acts-like.js";
 
 describe("ObjectTests", () => {
   it("duck typing", () => {
-    // acts_like? - checking if an object behaves like something
-    const actsLike = (obj: any, type: string) => typeof obj[`acts_like_${type}?`] === "function";
-    const datelike = { "acts_like_date?": () => true };
-    expect(actsLike(datelike, "date")).toBe(true);
-    expect(actsLike({}, "date")).toBe(false);
+    const datelike = { actsLikeDate: () => true };
+    expect(ObjectExt.actsLike(datelike, "date")).toBe(true);
+    expect(ObjectExt.actsLike({}, "date")).toBe(false);
+    expect(ObjectExt.actsLike({ actsLikeTime: () => true }, "time")).toBe(true);
+    // The `else` arm: any duck name, not just the three cased ones.
+    expect(ObjectExt.actsLike({ actsLikeStringish: () => true }, "stringish")).toBe(true);
   });
 
   it("acts like string", () => {
-    const strlike = { "acts_like_string?": () => true };
-    expect(typeof strlike["acts_like_string?"] === "function").toBe(true);
+    const strlike = { actsLikeString: () => true };
+    expect(ObjectExt.actsLike(strlike, "string")).toBe(true);
+    expect(ObjectExt.actsLike("a real string", "string")).toBe(false);
   });
 });

--- a/packages/activesupport/src/core-ext/object/acts-like.ts
+++ b/packages/activesupport/src/core-ext/object/acts-like.ts
@@ -1,0 +1,44 @@
+/**
+ * Mirrors: active_support/core_ext/object/acts_like.rb
+ *
+ * Ruby reopens `Object`; TypeScript cannot, so the reopening is a class of the
+ * Ruby name whose members take the receiver as the first parameter — the same
+ * idiom `core-ext/object/blank.ts` uses for `NilClass`/`String`/`Time`.
+ */
+
+export class Object {
+  /**
+   * Provides a way to check whether some class acts like some other class
+   * based on the existence of an appropriately-named marker method.
+   *
+   * Note that the marker method is only expected to exist. It isn't called, so
+   * its body or return value are irrelevant.
+   */
+  static actsLike(self: unknown, duck: string): boolean {
+    switch (duck) {
+      case "time":
+        return respondTo.call(self, "acts_like_time?");
+      case "date":
+        return respondTo.call(self, "acts_like_date?");
+      case "string":
+        return respondTo.call(self, "acts_like_string?");
+      default:
+        return respondTo.call(self, `acts_like_${duck}?`);
+    }
+  }
+}
+
+/**
+ * Ruby's `respond_to?`, which takes the RUBY method name — so the marker names
+ * above read exactly as they do in Rails. The trails spelling of a marker is
+ * the conventions-table rename of that name (`acts_like_time?` →
+ * `actsLikeTime`, as `TimeWithZone#actsLikeTime` defines it), applied here so
+ * the one translation lives in one place.
+ */
+function respondTo(this: unknown, rubyName: string): boolean {
+  if (this == null) return false;
+  const tsName = rubyName
+    .replace(/\?$/, "")
+    .replace(/_([a-z])/g, (_m, c: string) => c.toUpperCase());
+  return typeof (this as Record<string, unknown>)[tsName] === "function";
+}

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -253,8 +253,6 @@ export {
   inGroups,
   splitArray,
   extract,
-  arrayFrom,
-  arrayTo,
   toSentence,
 } from "./array-utils.js";
 

--- a/packages/activesupport/src/testing/constant-lookup.ts
+++ b/packages/activesupport/src/testing/constant-lookup.ts
@@ -1,0 +1,47 @@
+/**
+ * Mirrors: active_support/testing/constant_lookup.rb
+ *
+ * Resolves a constant from a minitest spec name.
+ *
+ * Given the following spec-style test:
+ *
+ *   describe WidgetsController, :index do
+ *     describe "authenticated user" do
+ *       describe "returns widgets" do
+ *         it "has a controller that exists" do
+ *           assert_kind_of WidgetsController, @controller
+ *         end
+ *       end
+ *     end
+ *   end
+ *
+ * The test will have the following name:
+ *
+ *   "WidgetsController::index::authenticated user::returns widgets"
+ *
+ * The constant WidgetsController can be resolved from the name.
+ */
+import { safeConstantize } from "../inflector.js";
+
+export namespace ConstantLookup {
+  // Rails nests this in `module ClassMethods` under `extend ActiveSupport::Concern`;
+  // the Concern flattens it onto the including class, so it sits on the module here.
+  export function determineConstantFromTestName(
+    testName: string,
+    block: (constant: unknown) => boolean,
+  ): unknown {
+    const names = testName.split("::");
+    while (names.length > 0) {
+      names[names.length - 1] = names[names.length - 1].replace(/Test$/, "");
+      try {
+        const constant = safeConstantize(names.join("::"));
+        // Ruby `break(constant) if yield(constant)` — the `ensure` below still
+        // pops before the value leaves the loop.
+        if (block(constant)) return constant;
+      } finally {
+        names.pop();
+      }
+    }
+    return undefined;
+  }
+}

--- a/packages/activesupport/src/testing/constant-lookup.ts
+++ b/packages/activesupport/src/testing/constant-lookup.ts
@@ -24,8 +24,11 @@
 import { safeConstantize } from "../inflector.js";
 
 export namespace ConstantLookup {
-  // Rails nests this in `module ClassMethods` under `extend ActiveSupport::Concern`;
-  // the Concern flattens it onto the including class, so it sits on the module here.
+  /**
+   * Rails nests this in `module ClassMethods` under `extend
+   * ActiveSupport::Concern`, which flattens it onto the including class — so it
+   * sits on the module here.
+   */
   export function determineConstantFromTestName(
     testName: string,
     block: (constant: unknown) => boolean,
@@ -35,8 +38,6 @@ export namespace ConstantLookup {
       names[names.length - 1] = names[names.length - 1].replace(/Test$/, "");
       try {
         const constant = safeConstantize(names.join("::"));
-        // Ruby `break(constant) if yield(constant)` — the `ensure` below still
-        // pops before the value leaves the loop.
         if (block(constant)) return constant;
       } finally {
         names.pop();

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/persistence.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/persistence.json
@@ -24,17 +24,6 @@
     "package": "activerecord",
     "tsFile": "persistence.ts",
     "rubyName": "_delete_record",
-    "call": "new",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:arelTable"
-    ],
-    "reason": "Pre-existing divergence in an untouched body, surfaced when the instance-side `_create_record`/`_update_record` landed in persistence.ts and the file's ClassMethods/instance pairing was recomputed."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "persistence.ts",
-    "rubyName": "_delete_record",
     "call": "with_connection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -57,7 +46,7 @@
     "tsFile": "persistence.ts",
     "rubyName": "_raise_record_not_destroyed",
     "call": "order:constructor,primaryKey",
-    "reason": "Pre-existing divergence in an untouched body, surfaced when the instance-side `_create_record`/`_update_record` landed in persistence.ts and the file's ClassMethods/instance pairing was recomputed."
+    "reason": "Extractor call-resolution artifact, not a body divergence: the TS body reads `this.constructor.primaryKey` then `this.constructor.name`, the same order as Rails' `self.class.primary_key` then `self.class` (persistence.rb:951-952), and the extracted `callSeq` is `constructor, primaryKey`. Ruby `class` resolves against the later `name` read rather than `constructor`, inverting the reported pair. The body itself was converged to Rails' `ensure`-clears shape in the same PR."
   },
   {
     "package": "activerecord",
@@ -76,22 +65,13 @@
   {
     "package": "activerecord",
     "tsFile": "persistence.ts",
-    "rubyName": "apply_scoping?",
-    "call": "global_current_scope",
-    "kind": "args",
-    "rubyArgs": [],
-    "reason": "Pre-existing divergence in an untouched body, surfaced when the instance-side `_create_record`/`_update_record` landed in persistence.ts and the file's ClassMethods/instance pairing was recomputed."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "persistence.ts",
     "rubyName": "build_default_constraint",
     "call": "default_scoped",
     "kind": "args",
     "rubyArgs": [
       "kwargs{allQueries=bool:true}"
     ],
-    "reason": "Pre-existing divergence in an untouched body, surfaced when the instance-side `_create_record`/`_update_record` landed in persistence.ts and the file's ClassMethods/instance pairing was recomputed."
+    "reason": "TypeScript cannot omit a leading optional positional to pass only kwargs: Rails' `default_scoped(scope = relation, all_queries: nil)` (scoping/named.rb:45) is called here as `default_scoped(all_queries: true)`, so the port must spell the `scope` slot as `undefined` before the trailing kwargs object. The kwarg key and value match Rails exactly."
   },
   {
     "package": "activerecord",


### PR DESCRIPTION
Bundle of four stories.

## 1. CollectionProxy reaches the rich reflection through one reader

`CollectionProxy#reflection` now resolves the registered `AssociationReflection`
off the owner's class, as Rails' `Association#reflection` (`association.rb:16`)
already is — the proxy is constructed from the thin macro definition, so the
reader does the resolve once and falls back to that definition only for an
anonymous inline association with no registered reflection.

Nine `owner.constructor._reflectOnAssociation(this._assocName)` re-resolves in
`collection-proxy.ts` are deleted in favour of `this.reflection`. Two survive
and are cited: `_targetModelFor` is a static with no instance to read through,
and the through-step resolve at `:2000` resolves a *different* association name
(`throughAssoc.name`).

Two of the converged sites (`_djarForCount`, `_foreignKeyPresent`) used a null
reflection as an "unregistered association" signal; they now test
`reflection.klass == null`, which is the same condition — the macro definitions
the declaration macros build carry none of the rich fields.

`association-relation.test.ts` asserted `proxyAssociation.reflection.type ===
"hasMany"`. That was the thin definition's spelling: on a Rails reflection
`type` is the polymorphic `*_type` column and the macro is `macro`. The
assertion moved to `.macro`; the test name is unchanged.

## 2. `HasManyAssociation#deleteRecords` drops its `?? this.klass` arm

Rails: `reflection.klass.composite_query_constraints_list`
(`has_many_association.rb:132`). The body reads `this.reflection.klass`,
literally, with no fallback arm.

The story's second criterion — `klass` non-optional, or the ad-hoc holder path
shown unreachable — resolves as unreachable. Both routes into `deleteRecords`
go through `record.association(name)`, which constructs the association from
the registered reflection (`instance-methods.ts:163-166`, Rails
`associations.rb:290-296`): `CollectionAssociation#removeRecords` runs on that
instance, and the through arm in `collection-proxy.ts:2623` calls
`this._record.association(this._assocName)` explicitly. The ad-hoc
`_buildAssociationInstance` holders, which carry a thin macro definition with
no `klass`, reach `HasManyThroughAssociation#deleteRecords` instead — a
different override. The full association suite (97 files, 2140 tests) is green
on the literal read.

## 3. persistence.ts call-argument rows

- `_delete_record`: `new DeleteManager(arelTable)` instead of
  `new DeleteManager()` + `dm.from(table)` — Rails'
  `Arel::DeleteManager.new(arel_table)` (`persistence.rb:292`). Row deleted.
- `apply_scoping?`: `ctor.globalCurrentScope()` instead of
  `ScopeRegistry.globalCurrentScope(ctor)` — Rails'
  `self.class.global_current_scope` (`persistence.rb:849`). Row deleted.
- `_raise_record_not_destroyed`: body converged to Rails' shape
  (`persistence.rb:949-955`) — `@_association_destroy_exception ||= nil` up
  front and an `ensure` that always clears, rather than clearing only when one
  was set. The order row **survives**, re-reasoned: it is an extractor
  call-resolution artifact. The extracted `callSeq` is `constructor,
  primaryKey`, matching Ruby; the reported inversion comes from Ruby `class`
  resolving against the later `name` read.
- `build_default_constraint`: survives, re-reasoned. Rails'
  `default_scoped(scope = relation, all_queries: nil)` is called as
  `default_scoped(all_queries: true)`; TypeScript cannot omit a leading
  optional positional to pass only kwargs, so the port must spell the `scope`
  slot as `undefined`. Kwarg key and value match Rails exactly.

Two rows deleted, two re-reasoned from the shared placeholder to the specific
blocker. Both gates green.

## 4. Four activesupport core_ext ports

`core-ext/object/acts-like.ts`, `core-ext/array/access.ts`,
`core-ext/numeric/bytes.ts`, `testing/constant-lookup.ts`, at the paths
`docs/ruby-ts-conventions.md` derives. The three that reopen a built-in follow
`core-ext/object/blank.ts`'s idiom — a class of the Ruby name whose members
take the receiver as the first parameter.

`parity:api` buckets: `object/acts_like.rb` 10/10, `numeric/bytes.rb` 19/19,
`array/access.rb` 14/15 (the miss is `compact_blank!`, aggregated into the
bucket from `Enumerable`), `testing/constant_lookup.rb` 3/5 (the two misses are
Concern's `append_features` / `prepend_features` lifecycle hooks, which live in
`concern.ts`). No `unported-files` entry added for any of them; no novel public
surface (`parity:api:extra`).

`array-utils.ts`'s `arrayFrom` / `arrayTo` / `including` / `excluding` were the
same four methods under trails-invented names in a file that does not map to
`access.rb`; they had no non-test callers (`including` / `excluding` are
exported from `enumerable-utils.ts`) and are deleted. The two existing trails
test files now exercise the ported source instead of an inline stand-in;
`constant-lookup.test.ts`'s skipped Rails-named stubs are untouched.

`bytes.ts` carries a header note on the one JS-number gap: `EXABYTE` (1024**6)
and `ZETTABYTE` (1024**7) exceed `Number.MAX_SAFE_INTEGER`, so they are the
nearest double rather than Ruby's exact `Integer`. The return type stays
`number` to compose with the other Numeric core_ext methods; a `bigint` port
would not.

## Verification

- `pnpm parity:api:calls` OK, `pnpm parity:api:calls:args` OK
- `pnpm parity:api` deltas positive: AR closure 8390 → 8433, overall 12656 → 12702
- `pnpm vitest run packages/activerecord/src/associations` — 2149 passed
- persistence suites — 178 passed
- new/updated activesupport tests — 8 passed

Closes-story: converge-collection-proxy-rich-reflection-re-resolve
Closes-story: converge-has-many-delete-records-reflection-klass-fallback
Closes-story: converge-persistence-recomputed-pairing-rows
Closes-story: port-four-in-closure-activesupport-zero-port-buckets
