### PR TITLE
refactor(activerecord): fold _performUpdate into Persistence#_updateRecord

### DIFF
--- a/packages/activerecord/src/attribute-methods/dirty.ts
+++ b/packages/activerecord/src/attribute-methods/dirty.ts
@@ -151,7 +151,6 @@ interface DirtyPrivateHost {
   /** @internal */
   _readAttribute(name: string): unknown;
   _writeAttribute(name: string, value: unknown): void;
-  _performUpdate(): Promise<number>;
   changedAttributeNamesToSave: string[];
   constructor: {
     attributeNames(): string[];

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -38,7 +38,7 @@ import {
   type TransactionalCallbackConditions,
 } from "@blazetrails/activemodel";
 import { setCurrentAdapterResolver } from "./type.js";
-import { Table, UpdateManager, DeleteManager, Nodes } from "@blazetrails/arel";
+import { Table, DeleteManager, Nodes } from "@blazetrails/arel";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import type { ExplainOption } from "./connection-adapters/abstract/database-statements.js";
 import type { Relation } from "./relation.js";
@@ -868,36 +868,6 @@ interface _ConstructorAssociationWriter {
   writer?: (v: unknown) => void;
   syncWrite?: (v: unknown) => void;
   syncIdsWrite?: (v: unknown[]) => void;
-}
-
-// Build the Arel value node for one write-path column (INSERT VALUES / UPDATE
-// SET). Mirrors Rails' `_insert_record`/`_update_record`, which hand every
-// column to the Arel visitor as an `ActiveModel::Attribute` so
-// `visit_ActiveModel_Attribute → collector.add_bind(o)` binds it as a typed
-// prepared-statement parameter (`type_casted_binds`) — null bytes round-trip
-// and intermediate database values (BinaryData, Temporal, BigDecimal) are
-// finished off by each adapter's bind normalization instead of being inlined
-// via `quote()`.
-//
-// Deviation: the bind carries the pre-extracted `valuesForDatabase()` primitive
-// where Rails' AST carries the Attribute object itself (attribute_methods.rb
-// `attributes_with_values` → persistence.rb `_insert_record`/`_update_record`),
-// keeping type metadata until the adapter's `type_casted_binds`. In trails the
-// Attribute would be resolved to the very same primitive one step later anyway:
-// `toSqlAndBinds` (abstract/database-statements.ts) unwraps every ModelAttribute
-// bind to `valueForDatabase` at compile time — a trails-wide seam shared with
-// the read path and relied on by query-cache keying
-// (`JSON.stringify([sql, binds])`), so threading the Attribute through here is
-// inert. The only driver dispatch keyed off attribute type (SQLite's
-// FloatType → SQLITE_FLOAT for whole-valued floats) is not observable for
-// table writes: a float column's REAL affinity converts an INTEGER-typed bind
-// on storage (verified: `typeof(col)` is 'real' either way).
-// Array columns bind like every other column: `value_for_database` yields the
-// PG `OID::Array::Data` wrapper, which `type_casted_binds` routes through
-// `encode_array` (postgresql/quoting.rb) so the driver receives the encoded
-// `{…}` literal as one bound parameter typed by the column.
-function writePathValueNode(raw: unknown): InstanceType<typeof Nodes.Node> {
-  return new Nodes.BindParam(raw);
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -3416,7 +3386,7 @@ export class Base extends Model {
       if (saved) {
         this._transactionAction = wasNewRecord ? "create" : "update";
         (this as any)._newRecordBeforeLastCommit = wasNewRecord;
-        // `@_trigger_update_callback` is set inside `_performUpdate` from the
+        // `@_trigger_update_callback` is set inside `_updateRecord` from the
         // UPDATE's affected-row count (Rails persistence.rb:900-909), so it is
         // NOT forced here: a real update whose WHERE matched zero rows (e.g. a
         // separate instance deleted the row earlier in the transaction) must
@@ -3440,7 +3410,6 @@ export class Base extends Model {
     return saved;
   }
 
-  private _pendingOperation: Promise<void> | null = null;
   // Mirrors ActiveRecord::Timestamp's @_touch_record ivar (timestamp.rb:104),
   // set by Timestamp#create_or_update and read by record_update_timestamps.
   private _touchRecord: boolean | null = null;
@@ -3453,130 +3422,6 @@ export class Base extends Model {
 
   set recordTimestamps(value: boolean) {
     this._instanceRecordTimestamps = value;
-  }
-
-  private _performUpdate(): void {
-    const ctor = this.constructor as typeof Base;
-
-    // Thread the `withQueryConnection` connection rather than the deprecated
-    // `.connection` getter (see `_createRecord` in persistence.ts); resolved after the suppression
-    // guard so a suppressed write never touches `.connection`.
-    const adapter = ConnectionHandling.threadedConnectionFor(ctor) ?? ctor.connection;
-
-    const table = ctor.arelTable;
-
-    const changedAttrs = { ...this.changes };
-
-    // With partial_writes=false Rails uses all columns and never short-circuits on clean attrs.
-    // Mirrors Rails _update_record's `if attribute_names.empty?` branch: no
-    // columns to write ⇒ affected_rows = 0 but @_trigger_update_callback = true.
-    if (ctor.partialUpdates && Object.keys(changedAttrs).length === 0) {
-      (this as any)._triggerUpdateCallback = true;
-      return;
-    }
-
-    const dbValues = this._attributes.valuesForDatabase();
-    // With partial_writes=false Rails includes all columns; with it on, only dirty ones.
-    const candidateNames = ctor.partialUpdates
-      ? Object.keys(changedAttrs).filter((key) => ctor._attributeDefinitions.has(key))
-      : ctor.attributeNames().filter((key) => ctor._attributeDefinitions.has(key));
-    const declaredChanges = _attributesForUpdate.call(this, candidateNames);
-
-    // Same empty-attribute_names branch as above (Rails persistence.rb:903-905).
-    if (declaredChanges.length === 0) {
-      (this as any)._triggerUpdateCallback = true;
-      return;
-    }
-
-    const updateValues: [InstanceType<typeof Nodes.Node>, unknown][] = declaredChanges.map(
-      (key) => [table.get(key), writePathValueNode(dbValues[key])],
-    );
-
-    // Optimistic locking: include lock column in WHERE and increment it.
-    // Remove any user-supplied lock column entry from the SET list first —
-    // it will be replaced with the auto-incremented value to avoid a
-    // "multiple assignments to same column" error on PostgreSQL.
-    const lockCol = ctor.lockingColumn;
-    let lockAttributeWas: import("@blazetrails/activemodel").Attribute | null = null;
-    let lockWhereValue: unknown;
-    if (ctor.lockingEnabled) {
-      const rawVersion = this.readAttribute(lockCol);
-      const currentVersion = rawVersion == null ? 0 : Number(rawVersion) || 0;
-      // Mirrors Rails _lock_value_for_database:
-      // - User explicitly changed lock_version (e.g. person.lock_version = 42):
-      //   use valueForDatabase so WHERE = 42. DB has 0 → StaleObjectError.
-      // - Normal auto-increment path: use originalValueForDatabase() so
-      //   NULL-in-DB records generate IS NULL, freshly-created records generate = 0.
-      // Must be read BEFORE mutating _attributes below.
-      const lockAttr = this._attributes.getAttribute(lockCol);
-      lockAttributeWas = lockAttr; // snapshot for stale restore (mirrors Rails lock_attribute_was)
-      if (this.willSaveChangeToAttribute(lockCol)) {
-        lockWhereValue = lockAttr.valueForDatabase;
-      } else {
-        lockWhereValue = lockAttr.originalValueForDatabase();
-      }
-      const lockIdx = declaredChanges.indexOf(lockCol);
-      if (lockIdx !== -1) updateValues.splice(lockIdx, 1);
-      this._writeAttribute(lockCol, currentVersion + 1);
-      // Rails increments `self[locking_column]` and lets `_update_record` pass
-      // the attribute to Arel like every other SET column (optimistic.rb:
-      // 101-108 → persistence.rb attributes_with_values), so the bumped lock
-      // value is bound, not inlined — route through the same write-path node.
-      updateValues.push([table.get(lockCol), writePathValueNode(currentVersion + 1)]);
-    }
-
-    const um = new UpdateManager()
-      .table(table)
-      .set(updateValues)
-      // Mirrors Rails _update_record(_query_constraints_hash): WHERE targets
-      // each query-constraint column's `*_in_database` value (just the primary
-      // key keyed to `id_in_database` when no query_constraints are declared),
-      // so a dirty primary key updates the original row (and can write a new PK
-      // value into it).
-      .where(
-        ctor._buildQueryConstraintsWhereNode(_Persistence._queryConstraintsHash.call(this as any)),
-      );
-    if (ctor.lockingEnabled) {
-      if (lockWhereValue == null) {
-        um.where(table.get(lockCol).eq(null));
-      } else {
-        um.where(table.get(lockCol).eq(Number(lockWhereValue) || 0));
-      }
-    }
-    _Persistence.applyDefaultAndGlobalConstraints(um as any, ctor);
-
-    const [updateSql, updateBinds] = adapter.toSqlAndBinds(um);
-    this._pendingOperation = adapter
-      .execUpdate(updateSql, `${ctor.name} Update`, updateBinds)
-      .then((affected) => {
-        // Mirrors Rails Locking::Optimistic#_update_row (optimistic.rb:110):
-        // `raise StaleObjectError if affected_rows != 1` — not just `=== 0`.
-        if (ctor.lockingEnabled && affected !== 1) {
-          // Mirrors Rails _update_row rescue: `@attributes[locking_column] =
-          // lock_attribute_was` restores the attribute snapshot so NULL-in-DB
-          // records don't lose their original null valueBeforeTypeCast.
-          if (lockAttributeWas !== null) {
-            this._attributes.set(lockCol, lockAttributeWas);
-            // Rails derives dirty state from @attributes, so restoring
-            // lock_attribute_was also reverts the auto-increment bump's dirty
-            // entry. Our DirtyTracker is a separate map, so recompute lockCol
-            // against the snapshot baseline: this drops the auto-bump (clean →
-            // clean) while preserving any user-set lock_version change.
-            (this as any)._dirty.attributeWritten(
-              lockCol,
-              lockAttributeWas.value,
-              lockAttributeWas.valueBeforeTypeCast,
-              lockAttributeWas.type,
-            );
-          }
-          throw new StaleObjectError(this, "update");
-        }
-        // Mirrors Rails _update_record: `@_trigger_update_callback = affected_rows == 1`.
-        // A stale update whose WHERE matched no row (row deleted by another
-        // instance earlier in the transaction) leaves the flag false, so
-        // after_update_commit / after_rollback(on: :update) don't fire.
-        (this as any)._triggerUpdateCallback = affected === 1;
-      });
   }
 
   // update / updateBang extracted to persistence.ts; wired via include() below.

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -2886,9 +2886,11 @@ function ensureAbstractAdapterMixinsApplied(): void {
   // `update`/`delete`/`insert`/`create`; trails wires one layer lower, on
   // `execUpdate`/`execDelete`/`execInsert`/`execInsertAll`, because that is the
   // single funnel every logical write shares. Two distinct update paths converge
-  // there: the model save path (`_performUpdate`/`_destroyRow` in base.ts) calls
+  // there: the model save path (`_updateRecord` in persistence.ts, `_destroyRow`
+  // in base.ts) calls
   // `execUpdate`/`execDelete` DIRECTLY, bypassing the public `update`/`delete`
-  // entirely, while `update_all`/`updateColumns` (persistence.ts `_updateRecord`)
+  // entirely, while `update_all`/`updateColumns` (the ClassMethods
+  // `_updateRecord` in persistence.ts)
   // go through the public `update`/`delete` — which themselves call
   // `execUpdate`/`execDelete`. Wiring the public methods would miss the direct
   // save path; wiring the low-level method catches both, exactly once each. The

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -1797,7 +1797,6 @@ type PersistenceInstanceChainHost = {
   _previouslyNewRecord: boolean;
   _attributes: any;
   _dirty: { reinstateNewRecordChanges(attributes: unknown, skip: Set<string>): void };
-  changes: Record<string, [unknown, unknown]>;
   readAttribute(name: string): unknown;
   willSaveChangeToAttribute(name: string): boolean;
   _readAttribute(name: string): unknown;
@@ -2019,6 +2018,17 @@ async function instanceUpdateRecord(
   if (attributeNames.length === 0) {
     (this as any)._triggerUpdateCallback = true;
   } else {
+    // Deviation: Rails delegates the row write to `_update_row(attribute_names)`
+    // (persistence.rb:906), which `Locking::Optimistic#_update_row`
+    // (optimistic.rb:92-118) overrides for the lock bump and the
+    // `affected_rows != 1` raise. trails has both halves — `_updateRow` below
+    // and `LockingOptimistic._updateRow` — but they build their values from
+    // `attributes_with_values` (cast values) where this path binds
+    // `valuesForDatabase()` write-path primitives, so routing through them
+    // changes what reaches the adapter for every column type. Converged by
+    // story `route-update-record-through-update-row` (RFC 0084), which owns
+    // that bind-path change and the missing `LockingOptimistic._updateRow`
+    // install.
     const dbValues = this._attributes.valuesForDatabase();
     const updateValues: [InstanceType<typeof Nodes.Node>, unknown][] = attributeNames.map(
       (key: string) => [table.get(key), writePathValueNode(dbValues[key])],

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -29,6 +29,7 @@ import {
 import {
   ActiveRecordError,
   ReadOnlyRecord,
+  StaleObjectError,
   RecordNotDestroyed,
   RecordNotSaved,
   UnknownAttributeError,
@@ -39,7 +40,7 @@ import {
 } from "./multiparameter-attribute-assignment.js";
 import { threadedConnectionFor, withConnection } from "./connection-handling.js";
 import * as LockingOptimistic from "./locking/optimistic.js";
-import { attributesForCreate, attributesWithValues } from "./attribute-methods.js";
+import { attributesForCreate, attributesForUpdate, attributesWithValues } from "./attribute-methods.js";
 import { getStiBase, isStiSubclass, stiName, defineDynamicSelectReaders } from "./inheritance.js";
 import { withTransactionReturningStatus } from "./transactions.js";
 import { isSuppressed } from "./suppressor.js";
@@ -677,8 +678,7 @@ export async function deleteRow<T extends DeleteRecord>(this: T): Promise<T> {
 // ---------------------------------------------------------------------------
 // save / save! / destroy / destroy! — the callback- and transaction-wrapped
 // entry points. They rely on Base-provided internal helpers/state
-// (_createOrUpdate, _destroyRow, _performUpdate,
-// _touchRecord, _pendingOperation) which remain `private` on Base; the
+// (_createOrUpdate, _destroyRow, _touchRecord) which remain `private` on Base; the
 // extracted functions reach them through `(this as any)` since those
 // members intentionally aren't part of the public Persistence API.
 // Mirrors ActiveRecord::Persistence#save, #save!, #destroy, #destroy!
@@ -1785,22 +1785,16 @@ type PersistenceInternalHost = PersistencePrivateHost & {
   };
 };
 
-/**
- * Host surface for the Persistence layer of the create/update super chain.
- * `_performUpdate` is the remaining trails-only decomposition living on
- * base.ts (`_performUpdate` reaches private record state); `_pendingOperation`
- * is the promise slot it parks the statement in.
- */
+/** Host surface for the Persistence layer of the create/update super chain. */
 type PersistenceInstanceChainHost = {
   constructor: any;
   _newRecord: boolean;
   _previouslyNewRecord: boolean;
-  _pendingOperation?: Promise<unknown> | null;
   _attributes: any;
   _dirty: { reinstateNewRecordChanges(attributes: unknown, skip: Set<string>): void };
+  changes: Record<string, [unknown, unknown]>;
   _readAttribute(name: string): unknown;
   _writeAttribute(name: string, value: unknown): void;
-  _performUpdate?(): Promise<unknown> | void;
 };
 
 /** @internal */
@@ -1958,12 +1952,39 @@ export function _updateRow(
   );
 }
 
+// Build the Arel value node for one write-path column (INSERT VALUES / UPDATE
+// SET). Mirrors Rails' `_insert_record`/`_update_record`, which hand every
+// column to the Arel visitor as an `ActiveModel::Attribute` so
+// `visit_ActiveModel_Attribute → collector.add_bind(o)` binds it as a typed
+// prepared-statement parameter (`type_casted_binds`) — null bytes round-trip
+// and intermediate database values (BinaryData, Temporal, BigDecimal) are
+// finished off by each adapter's bind normalization instead of being inlined
+// via `quote()`.
+//
+// Deviation: the bind carries the pre-extracted `valuesForDatabase()` primitive
+// where Rails' AST carries the Attribute object itself (attribute_methods.rb
+// `attributes_with_values` → persistence.rb `_insert_record`/`_update_record`),
+// keeping type metadata until the adapter's `type_casted_binds`. In trails the
+// Attribute would be resolved to the very same primitive one step later anyway:
+// `toSqlAndBinds` (abstract/database-statements.ts) unwraps every ModelAttribute
+// bind to `valueForDatabase` at compile time — a trails-wide seam shared with
+// the read path and relied on by query-cache keying
+// (`JSON.stringify([sql, binds])`), so threading the Attribute through here is
+// inert. The only driver dispatch keyed off attribute type (SQLite's
+// FloatType → SQLITE_FLOAT for whole-valued floats) is not observable for
+// table writes: a float column's REAL affinity converts an INTEGER-typed bind
+// on storage (verified: `typeof(col)` is 'real' either way).
+// Array columns bind like every other column: `value_for_database` yields the
+// PG `OID::Array::Data` wrapper, which `type_casted_binds` routes through
+// `encode_array` (postgresql/quoting.rb) so the driver receives the encoded
+// `{…}` literal as one bound parameter typed by the column.
+function writePathValueNode(raw: unknown): InstanceType<typeof Nodes.Node> {
+  return new Nodes.BindParam(raw);
+}
+
 /**
  * The bottom of the update super chain: the UPDATE, `@previously_new_record =
  * false`, then the `save(&block)` yield.
- *
- * The `_pendingOperation` await has no Rails counterpart — trails' `_performUpdate`
- * parks the statement promise there so the sync half of the chain can start it.
  *
  * Mirrors: ActiveRecord::Persistence#_update_record (persistence.rb:900-916)
  * @internal
@@ -1972,12 +1993,116 @@ async function instanceUpdateRecord(
   this: PersistenceInstanceChainHost,
   block?: (record: any) => void,
 ): Promise<boolean> {
-  if (!this._performUpdate) throw new Error("_performUpdate not implemented");
-  await this._performUpdate();
-  if (this._pendingOperation) {
-    await this._pendingOperation;
-    this._pendingOperation = null;
+  const ctor = this.constructor;
+
+  // Thread the `withQueryConnection` connection rather than the deprecated
+  // `.connection` getter (see `_createRecord` below); resolved after the
+  // suppression guard so a suppressed write never touches `.connection`.
+  const adapter = threadedConnectionFor(ctor) ?? ctor.connection;
+
+  const table = ctor.arelTable;
+
+  const changedAttrs = { ...this.changes };
+
+  // With partial_writes=false Rails includes all columns; with it on, only dirty ones.
+  const candidateNames = ctor.partialUpdates
+    ? Object.keys(changedAttrs).filter((key: string) => ctor._attributeDefinitions.has(key))
+    : ctor.attributeNames().filter((key: string) => ctor._attributeDefinitions.has(key));
+  // Rails: `attribute_names = attributes_for_update(attribute_names)`.
+  const declaredChanges = attributesForUpdate.call(this as any, candidateNames);
+
+  // Mirrors Rails _update_record's `if attribute_names.empty?` branch: no
+  // columns to write ⇒ affected_rows = 0 but @_trigger_update_callback = true.
+  if (declaredChanges.length === 0) {
+    (this as any)._triggerUpdateCallback = true;
+  } else {
+    const dbValues = this._attributes.valuesForDatabase();
+    const updateValues: [InstanceType<typeof Nodes.Node>, unknown][] = declaredChanges.map(
+      (key: string) => [table.get(key), writePathValueNode(dbValues[key])],
+    );
+
+    // Optimistic locking: include lock column in WHERE and increment it.
+    // Remove any user-supplied lock column entry from the SET list first —
+    // it will be replaced with the auto-incremented value to avoid a
+    // "multiple assignments to same column" error on PostgreSQL.
+    const lockCol = ctor.lockingColumn;
+    let lockAttributeWas: import("@blazetrails/activemodel").Attribute | null = null;
+    let lockWhereValue: unknown;
+    if (ctor.lockingEnabled) {
+      const rawVersion = this._readAttribute(lockCol);
+      const currentVersion = rawVersion == null ? 0 : Number(rawVersion) || 0;
+      // Mirrors Rails _lock_value_for_database:
+      // - User explicitly changed lock_version (e.g. person.lock_version = 42):
+      //   use valueForDatabase so WHERE = 42. DB has 0 → StaleObjectError.
+      // - Normal auto-increment path: use originalValueForDatabase() so
+      //   NULL-in-DB records generate IS NULL, freshly-created records generate = 0.
+      // Must be read BEFORE mutating _attributes below.
+      const lockAttr = this._attributes.getAttribute(lockCol);
+      lockAttributeWas = lockAttr; // snapshot for stale restore (mirrors Rails lock_attribute_was)
+      if ((this as any).willSaveChangeToAttribute(lockCol)) {
+        lockWhereValue = lockAttr.valueForDatabase;
+      } else {
+        lockWhereValue = lockAttr.originalValueForDatabase();
+      }
+      const lockIdx = declaredChanges.indexOf(lockCol);
+      if (lockIdx !== -1) updateValues.splice(lockIdx, 1);
+      this._writeAttribute(lockCol, currentVersion + 1);
+      // Rails increments `self[locking_column]` and lets `_update_record` pass
+      // the attribute to Arel like every other SET column (optimistic.rb:
+      // 101-108 → persistence.rb attributes_with_values), so the bumped lock
+      // value is bound, not inlined — route through the same write-path node.
+      updateValues.push([table.get(lockCol), writePathValueNode(currentVersion + 1)]);
+    }
+
+    const um = new UpdateManager()
+      .table(table)
+      .set(updateValues)
+      // Mirrors Rails _update_record(_query_constraints_hash): WHERE targets
+      // each query-constraint column's `*_in_database` value (just the primary
+      // key keyed to `id_in_database` when no query_constraints are declared),
+      // so a dirty primary key updates the original row (and can write a new PK
+      // value into it).
+      .where(ctor._buildQueryConstraintsWhereNode(_queryConstraintsHash.call(this as any)));
+    if (ctor.lockingEnabled) {
+      if (lockWhereValue == null) {
+        um.where(table.get(lockCol).eq(null));
+      } else {
+        um.where(table.get(lockCol).eq(Number(lockWhereValue) || 0));
+      }
+    }
+    applyDefaultAndGlobalConstraints(um as any, ctor);
+
+    const [updateSql, updateBinds] = adapter.toSqlAndBinds(um);
+    const affected = await adapter.execUpdate(updateSql, `${ctor.name} Update`, updateBinds);
+    // Mirrors Rails Locking::Optimistic#_update_row (optimistic.rb:110):
+    // `raise StaleObjectError if affected_rows != 1` — not just `=== 0`.
+    if (ctor.lockingEnabled && affected !== 1) {
+      // Mirrors Rails _update_row rescue: `@attributes[locking_column] =
+      // lock_attribute_was` restores the attribute snapshot so NULL-in-DB
+      // records don't lose their original null valueBeforeTypeCast.
+      if (lockAttributeWas !== null) {
+        this._attributes.set(lockCol, lockAttributeWas);
+        // Rails derives dirty state from @attributes, so restoring
+        // lock_attribute_was also reverts the auto-increment bump's dirty
+        // entry. Our DirtyTracker is a separate map, so recompute lockCol
+        // against the snapshot baseline: this drops the auto-bump (clean →
+        // clean) while preserving any user-set lock_version change.
+        (this._dirty as any).attributeWritten(
+          lockCol,
+          lockAttributeWas.value,
+          lockAttributeWas.valueBeforeTypeCast,
+          lockAttributeWas.type,
+        );
+      }
+      throw new StaleObjectError(this, "update");
+    }
+    // Mirrors Rails _update_record: `@_trigger_update_callback = affected_rows == 1`.
+    // A stale update whose WHERE matched no row (row deleted by another
+    // instance earlier in the transaction) leaves the flag false, so
+    // after_update_commit / after_rollback(on: :update) don't fire.
+    (this as any)._triggerUpdateCallback = affected === 1;
   }
+
   this._previouslyNewRecord = false;
   // Rails yields here (persistence.rb:912-916).
   block?.(this);

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -1793,6 +1793,8 @@ type PersistenceInstanceChainHost = {
   _attributes: any;
   _dirty: { reinstateNewRecordChanges(attributes: unknown, skip: Set<string>): void };
   changes: Record<string, [unknown, unknown]>;
+  readAttribute(name: string): unknown;
+  willSaveChangeToAttribute(name: string): boolean;
   _readAttribute(name: string): unknown;
   _writeAttribute(name: string, value: unknown): void;
 };
@@ -2002,22 +2004,19 @@ async function instanceUpdateRecord(
 
   const table = ctor.arelTable;
 
-  const changedAttrs = { ...this.changes };
-
   // With partial_writes=false Rails includes all columns; with it on, only dirty ones.
-  const candidateNames = ctor.partialUpdates
-    ? Object.keys(changedAttrs).filter((key: string) => ctor._attributeDefinitions.has(key))
+  let attributeNames = ctor.partialUpdates
+    ? Object.keys(this.changes).filter((key: string) => ctor._attributeDefinitions.has(key))
     : ctor.attributeNames().filter((key: string) => ctor._attributeDefinitions.has(key));
-  // Rails: `attribute_names = attributes_for_update(attribute_names)`.
-  const declaredChanges = attributesForUpdate.call(this as any, candidateNames);
+  attributeNames = attributesForUpdate.call(this as any, attributeNames);
 
   // Mirrors Rails _update_record's `if attribute_names.empty?` branch: no
   // columns to write ⇒ affected_rows = 0 but @_trigger_update_callback = true.
-  if (declaredChanges.length === 0) {
+  if (attributeNames.length === 0) {
     (this as any)._triggerUpdateCallback = true;
   } else {
     const dbValues = this._attributes.valuesForDatabase();
-    const updateValues: [InstanceType<typeof Nodes.Node>, unknown][] = declaredChanges.map(
+    const updateValues: [InstanceType<typeof Nodes.Node>, unknown][] = attributeNames.map(
       (key: string) => [table.get(key), writePathValueNode(dbValues[key])],
     );
 
@@ -2029,7 +2028,7 @@ async function instanceUpdateRecord(
     let lockAttributeWas: import("@blazetrails/activemodel").Attribute | null = null;
     let lockWhereValue: unknown;
     if (ctor.lockingEnabled) {
-      const rawVersion = this._readAttribute(lockCol);
+      const rawVersion = this.readAttribute(lockCol);
       const currentVersion = rawVersion == null ? 0 : Number(rawVersion) || 0;
       // Mirrors Rails _lock_value_for_database:
       // - User explicitly changed lock_version (e.g. person.lock_version = 42):
@@ -2039,12 +2038,12 @@ async function instanceUpdateRecord(
       // Must be read BEFORE mutating _attributes below.
       const lockAttr = this._attributes.getAttribute(lockCol);
       lockAttributeWas = lockAttr; // snapshot for stale restore (mirrors Rails lock_attribute_was)
-      if ((this as any).willSaveChangeToAttribute(lockCol)) {
+      if (this.willSaveChangeToAttribute(lockCol)) {
         lockWhereValue = lockAttr.valueForDatabase;
       } else {
         lockWhereValue = lockAttr.originalValueForDatabase();
       }
-      const lockIdx = declaredChanges.indexOf(lockCol);
+      const lockIdx = attributeNames.indexOf(lockCol);
       if (lockIdx !== -1) updateValues.splice(lockIdx, 1);
       this._writeAttribute(lockCol, currentVersion + 1);
       // Rails increments `self[locking_column]` and lets `_update_record` pass
@@ -2073,10 +2072,10 @@ async function instanceUpdateRecord(
     applyDefaultAndGlobalConstraints(um as any, ctor);
 
     const [updateSql, updateBinds] = adapter.toSqlAndBinds(um);
-    const affected = await adapter.execUpdate(updateSql, `${ctor.name} Update`, updateBinds);
+    const affectedRows = await adapter.execUpdate(updateSql, `${ctor.name} Update`, updateBinds);
     // Mirrors Rails Locking::Optimistic#_update_row (optimistic.rb:110):
     // `raise StaleObjectError if affected_rows != 1` — not just `=== 0`.
-    if (ctor.lockingEnabled && affected !== 1) {
+    if (ctor.lockingEnabled && affectedRows !== 1) {
       // Mirrors Rails _update_row rescue: `@attributes[locking_column] =
       // lock_attribute_was` restores the attribute snapshot so NULL-in-DB
       // records don't lose their original null valueBeforeTypeCast.
@@ -2100,7 +2099,7 @@ async function instanceUpdateRecord(
     // A stale update whose WHERE matched no row (row deleted by another
     // instance earlier in the transaction) leaves the flag false, so
     // after_update_commit / after_rollback(on: :update) don't fire.
-    (this as any)._triggerUpdateCallback = affected === 1;
+    (this as any)._triggerUpdateCallback = affectedRows === 1;
   }
 
   this._previouslyNewRecord = false;

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -40,7 +40,12 @@ import {
 } from "./multiparameter-attribute-assignment.js";
 import { threadedConnectionFor, withConnection } from "./connection-handling.js";
 import * as LockingOptimistic from "./locking/optimistic.js";
-import { attributesForCreate, attributesForUpdate, attributesWithValues } from "./attribute-methods.js";
+import {
+  attributesForCreate,
+  attributesForUpdate,
+  attributesWithValues,
+} from "./attribute-methods.js";
+import { attributeNamesForPartialUpdates } from "./attribute-methods/dirty.js";
 import { getStiBase, isStiSubclass, stiName, defineDynamicSelectReaders } from "./inheritance.js";
 import { withTransactionReturningStatus } from "./transactions.js";
 import { isSuppressed } from "./suppressor.js";
@@ -2004,10 +2009,9 @@ async function instanceUpdateRecord(
 
   const table = ctor.arelTable;
 
-  // With partial_writes=false Rails includes all columns; with it on, only dirty ones.
-  let attributeNames = ctor.partialUpdates
-    ? Object.keys(this.changes).filter((key: string) => ctor._attributeDefinitions.has(key))
-    : ctor.attributeNames().filter((key: string) => ctor._attributeDefinitions.has(key));
+  // Rails AttributeMethods::Dirty#_update_record's default argument
+  // (dirty.rb:233) — with partial_updates off it is every attribute name.
+  let attributeNames = attributeNamesForPartialUpdates.call(this as any);
   attributeNames = attributesForUpdate.call(this as any, attributeNames);
 
   // Mirrors Rails _update_record's `if attribute_names.empty?` branch: no
@@ -2029,7 +2033,7 @@ async function instanceUpdateRecord(
     let lockWhereValue: unknown;
     if (ctor.lockingEnabled) {
       const rawVersion = this.readAttribute(lockCol);
-      const currentVersion = rawVersion == null ? 0 : Number(rawVersion) || 0;
+      const currentVersion = rawVersion == null ? 0 : Number(rawVersion);
       // Mirrors Rails _lock_value_for_database:
       // - User explicitly changed lock_version (e.g. person.lock_version = 42):
       //   use valueForDatabase so WHERE = 42. DB has 0 → StaleObjectError.
@@ -2066,7 +2070,7 @@ async function instanceUpdateRecord(
       if (lockWhereValue == null) {
         um.where(table.get(lockCol).eq(null));
       } else {
-        um.where(table.get(lockCol).eq(Number(lockWhereValue) || 0));
+        um.where(table.get(lockCol).eq(lockWhereValue));
       }
     }
     applyDefaultAndGlobalConstraints(um as any, ctor);

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -2001,9 +2001,12 @@ async function instanceUpdateRecord(
 ): Promise<boolean> {
   const ctor = this.constructor;
 
-  // Thread the `withQueryConnection` connection rather than the deprecated
-  // `.connection` getter (see `_createRecord` below); resolved after the
-  // suppression guard so a suppressed write never touches `.connection`.
+  // Rails resolves no connection here: `_update_record` delegates the write to
+  // `_update_row` → the class-level `_update_record`, which does the
+  // `with_connection` (persistence.rb:906, 944-946). While that delegation is
+  // deferred (see below), thread the connection the enclosing
+  // `withQueryConnection` already leased rather than the deprecated
+  // `.connection` getter, so the UPDATE does not flip the lease permanent.
   const adapter = threadedConnectionFor(ctor) ?? ctor.connection;
 
   const table = ctor.arelTable;


### PR DESCRIPTION
Folds the trails-only `_performUpdate` decomposition on `base.ts` into
`persistence.ts#_updateRecord`, matching the way Rails writes
`Persistence#_update_record` (`persistence.rb:900-916`).

**This is a partial delivery of the story's first acceptance criterion.** The
UPDATE body now lives in `persistence.ts#_updateRecord` and `base.ts` defines no
`_performUpdate` — but `_update_row` is NOT yet the extraction the row write goes
through; the inline UPDATE build is carried forward verbatim. That half is
deferred to `route-update-record-through-update-row` (same RFC), for the reasons
below. The story file has been updated so its acceptance criteria say what
actually shipped rather than reading as if the fold were complete.

- `base.ts` no longer defines `_performUpdate`; the UPDATE build, optimistic-lock
  WHERE/SET handling and `@_trigger_update_callback` write all live in the
  `_updateRecord` body.
- The two trails early returns collapse into Rails' single
  `if attribute_names.empty?` branch (`persistence.rb:903-905`), so
  `@previously_new_record = false` and the `save(&block)` yield run on that arm
  as well — which is what the caller already did.
- `_pendingOperation` had exactly one writer (`_performUpdate`) and one reader
  (`_updateRecord`); with the body inlined the UPDATE is awaited directly and the
  slot is gone, along with the now-unused `_performUpdate` entry in `dirty.ts`'
  host interface.
- The default argument now routes through `attributeNamesForPartialUpdates`
  (`dirty.rb:233,245-246`) then `attributesForUpdate` (`persistence.rb:901` →
  `attribute_methods.rb:508-509`), replacing a hand-inlined `partialUpdates ? …`
  branch and a redundant `_attributeDefinitions` pre-filter.
- Dropped the `Number(…) || 0` clamps on the lock version and the lock WHERE
  value: Rails does `self[locking_column] += 1` (`optimistic.rb:107`) and passes
  `_lock_value_for_database` straight to the predicate builder, with no numeric
  coercion.
- The write-path bind helper `writePathValueNode` (module-local, not exported)
  moves to `persistence.ts` with the body it serves.

No behavioral change intended: the same statements run in the same order.

### `_update_row` is not routed through — deliberately, and now tracked

Rails delegates the row write to `_update_row` (`persistence.rb:906`), which
`Locking::Optimistic#_update_row` (`optimistic.rb:92-118`) overrides. trails has
both halves (`persistence.ts#_updateRow`, `locking/optimistic.ts#_updateRow`) and
this body calls neither — a bypass that predates this PR, carried over verbatim
from `base.ts#_performUpdate`.

It is not converged here because it is not a move: this path binds
`_attributes.valuesForDatabase()` (write-path DB-serialized primitives, see the
`writePathValueNode` note), while `_updateRow` builds its values from
`attributes_with_values` (cast values), so routing through it changes what
reaches the adapter for every column type — binary, temporal, array, serialized,
decimal. `LockingOptimistic._updateRow` is also not installed over
`_Persistence._updateRow` at all (`InstanceMethods`, `optimistic.ts:310`, exports
only `_lockValueForDatabase` / `_clearLockingColumn` / `_queryConstraintsHash`),
so it has zero call sites today and the `touch` path gets no lock enforcement —
a pre-existing gap, not one this PR creates.

Deleting the unreachable `LockingOptimistic._updateRow` would be the wrong
answer: `Locking::Optimistic#_update_row` is a real Rails method, so removing its
mirror shrinks parity instead of growing it. Filed as story
`route-update-record-through-update-row` (RFC 0084), which owns the bind-path
change, the missing install and the touch-path lock enforcement. The deviation is
cited at the call site in `instanceUpdateRecord`.

### Gates

`parity:api:calls` OK (1703 baselined, unchanged), `parity:api:calls:args` OK
(311, unchanged), `parity:api:extra --package activerecord` unchanged. No
baseline rows added or retired: the `_update_record` / `attributes_for_update`
row survives because the extractor pairs `_update_record` with the ClassMethods
`_updateRecord` homonym, not the instance body this PR touches, and the three
remaining `_create_record` rows (`attributes_with_values`, `with_connection`,
`id`) are behaviour changes explicitly out of this story's scope.

Suites green locally: persistence (+trails, +save-block), locking (+trails),
custom-locking, callbacks, timestamp, dirty, counter-cache, autosave,
nested-attributes, transactions, transaction-callbacks, attribute-methods,
readonly, serialized-attribute, touch-later, base.

Closes-story: fold-perform-insert-update-into-persistence-record-bodies
