### PR TITLE
refactor(parity): converge 26 call-argument naming rows in activesupport, encryption, relation and the mysql adapters

### DIFF
--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
@@ -202,8 +202,11 @@ export class SchemaCreation extends AbstractSchemaCreation {
 
   /** @internal */
   protected async visitChangeColumnDefinition(o: ChangeColumnDefinition): Promise<string> {
-    const sql = `CHANGE ${this.adapter.quoteColumnName(o.name)} ${await this.accept(o.column)}`;
-    return this.addColumnPositionBang(sql, this.columnOptions(o.column) as MysqlColumnOptions);
+    const changeColumnSql = `CHANGE ${this.adapter.quoteColumnName(o.name)} ${await this.accept(o.column)}`;
+    return this.addColumnPositionBang(
+      changeColumnSql,
+      this.columnOptions(o.column) as MysqlColumnOptions,
+    );
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -140,7 +140,7 @@ export class MysqlSchemaStatements extends BaseSchemaStatements {
           // The separate lengths/orders Records are consumed here and dropped.
           if (Object.keys(expressions).length > 0) {
             const quotedColumns = new Map<string, string>(
-              columns.map((c) => [c, expressions[c] ?? quoteColumnName(c)]),
+              columns.map((name) => [name, expressions[name] ?? quoteColumnName(name)]),
             );
             await this.addOptionsForIndexColumns(quotedColumns, { order: orders, length: lengths });
             return new IndexDefinition(
@@ -496,11 +496,12 @@ export function quotedScope(
   name?: string | null,
   options: { type?: string } = {},
 ): { schema: string; name?: string; type?: string } {
-  const [schema, tableName] = extractSchemaQualifiedName(name);
+  let schema: string | null;
+  [schema, name] = extractSchemaQualifiedName(name);
   const scope: { schema: string; name?: string; type?: string } = {
     schema: schema ? this.quote(schema) : "database()",
   };
-  if (tableName) scope.name = this.quote(tableName);
+  if (name) scope.name = this.quote(name);
   if (options.type) scope.type = this.quote(options.type);
   return scope;
 }

--- a/packages/activerecord/src/encryption/auto-filtered-parameters.ts
+++ b/packages/activerecord/src/encryption/auto-filtered-parameters.ts
@@ -73,8 +73,8 @@ export class AutoFilteredParameters {
 
   private applyCollectedAttributes(): void {
     for (const [klass, attributes] of this._attributesByClass) {
-      for (const attr of attributes) {
-        this.applyFilter(klass, attr);
+      for (const attribute of attributes) {
+        this.applyFilter(klass, attribute);
       }
     }
   }

--- a/packages/activerecord/src/encryption/cipher.ts
+++ b/packages/activerecord/src/encryption/cipher.ts
@@ -13,8 +13,8 @@ import { Decryption } from "./errors.js";
 import { Message } from "./message.js";
 
 export class Cipher {
-  encrypt(clearText: string | Buffer, options: { key: string; deterministic?: boolean }): Message {
-    return this.cipherFor(options.key, options.deterministic ?? false).encrypt(clearText);
+  encrypt(cleanText: string | Buffer, options: { key: string; deterministic?: boolean }): Message {
+    return this.cipherFor(options.key, options.deterministic ?? false).encrypt(cleanText);
   }
 
   decrypt(
@@ -33,12 +33,12 @@ export class Cipher {
   }
 
   /** @internal */
-  private tryToDecryptWithEach(encryptedMessage: Message, { keys }: { keys: string[] }): Buffer {
+  private tryToDecryptWithEach(encryptedText: Message, { keys }: { keys: string[] }): Buffer {
     if (keys.length === 0) throw new Decryption("No decryption keys provided");
     let lastError: unknown;
     for (let i = 0; i < keys.length; i++) {
       try {
-        return this.cipherFor(keys[i]).decrypt(encryptedMessage);
+        return this.cipherFor(keys[i]).decrypt(encryptedText);
       } catch (e) {
         if (!(e instanceof Decryption)) throw e; // integrity/config errors propagate immediately
         lastError = e;

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -633,7 +633,7 @@ export function encryptAttribute(this: any, name: string, options: SchemeOptions
     preserveOriginalEncrypted.call(this, name);
   }
 
-  Configurable.encryptedAttributeWasDeclared(modelClass, name);
+  Configurable.encryptedAttributeWasDeclared(this, name);
 }
 
 /**
@@ -644,7 +644,7 @@ export function encryptAttribute(this: any, name: string, options: SchemeOptions
  */
 export function preserveOriginalEncrypted(this: any, name: string): void {
   const modelClass = this;
-  const originalName = `${ORIGINAL_ATTRIBUTE_PREFIX}${name}`;
+  const originalAttributeName = `${ORIGINAL_ATTRIBUTE_PREFIX}${name}`;
   // Record the source attribute so the post-reflection hook
   // (`requireOriginalColumnsAfterReflection`, driven from schema reflection)
   // can re-run the missing-column check against the authoritative DB column
@@ -669,8 +669,8 @@ export function preserveOriginalEncrypted(this: any, name: string): void {
   // `encrypts original_attribute_name` (encryptable_record.rb:105 — no kwargs).
   // encryptAttribute's durable branch buffers this in _pendingEncryptions so
   // the original column rides the same replay-safe machinery as its source.
-  encryptAttribute.call(this, originalName, {});
-  EncryptableRecord.overrideAccessorsToPreserveOriginal(this, name, originalName);
+  encryptAttribute.call(this, originalAttributeName, {});
+  EncryptableRecord.overrideAccessorsToPreserveOriginal(this, name, originalAttributeName);
 }
 
 /**

--- a/packages/activerecord/src/encryption/encryptor.ts
+++ b/packages/activerecord/src/encryption/encryptor.ts
@@ -246,10 +246,10 @@ export class Encryptor {
   }
 
   /** @internal */
-  private deserializeMessage(encryptedText: string): Message {
+  private deserializeMessage(message: string): Message {
     // Mirrors Rails: rescue ArgumentError, TypeError, Errors::ForbiddenClass => Errors::Encoding
     try {
-      return this.serializer().load(encryptedText);
+      return this.serializer().load(message);
     } catch (e) {
       if (e instanceof ForbiddenClass || e instanceof TypeError) throw new Encoding();
       throw e;

--- a/packages/activerecord/src/encryption/envelope-encryption-key-provider.ts
+++ b/packages/activerecord/src/encryption/envelope-encryption-key-provider.ts
@@ -34,8 +34,8 @@ export class EnvelopeEncryptionKeyProvider {
     return key;
   }
 
-  decryptionKeys(message: Message): Key[] {
-    const secret = this.decryptDataKey(message);
+  decryptionKeys(encryptedMessage: Message): Key[] {
+    const secret = this.decryptDataKey(encryptedMessage);
     return secret ? [new Key(secret)] : [];
   }
 

--- a/packages/activerecord/src/encryption/message-pack-message-serializer.ts
+++ b/packages/activerecord/src/encryption/message-pack-message-serializer.ts
@@ -25,13 +25,13 @@ export class MessagePackMessageSerializer implements MessageSerializerLike {
     return MessagePack.dump(this.messageToHash(message)).toString("latin1");
   }
 
-  load(serialized: string): Message {
-    if (typeof serialized !== "string") {
-      throw new TypeError(`Expected string, got ${typeof serialized}`);
+  load(serializedContent: string): Message {
+    if (typeof serializedContent !== "string") {
+      throw new TypeError(`Expected string, got ${typeof serializedContent}`);
     }
     let data: unknown;
     try {
-      data = MessagePack.load(Buffer.from(serialized, "latin1"));
+      data = MessagePack.load(Buffer.from(serializedContent, "latin1"));
     } catch (e) {
       // ActiveSupport::MessagePack raises MessagePackError on a missing/wrong
       // signature or malformed bytes — both mean an undecodable message.

--- a/packages/activerecord/src/encryption/message-serializer.ts
+++ b/packages/activerecord/src/encryption/message-serializer.ts
@@ -10,7 +10,7 @@ import { Decryption, ForbiddenClass } from "./errors.js";
 
 export interface MessageSerializerLike {
   dump(message: Message): string;
-  load(serialized: string): Message;
+  load(serializedContent: string): Message;
   isBinary(): boolean;
 }
 
@@ -22,13 +22,13 @@ export class MessageSerializer implements MessageSerializerLike {
     return JSON.stringify(this.messageToJson(message));
   }
 
-  load(serialized: string): Message {
-    if (typeof serialized !== "string") {
-      throw new TypeError(`Expected string, got ${typeof serialized}`);
+  load(serializedContent: string): Message {
+    if (typeof serializedContent !== "string") {
+      throw new TypeError(`Expected string, got ${typeof serializedContent}`);
     }
     let data: unknown;
     try {
-      data = JSON.parse(serialized);
+      data = JSON.parse(serializedContent);
     } catch {
       throw new Decryption("Failed to deserialize encrypted message");
     }

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -54,7 +54,7 @@ export class InsertAll {
   updateOnly: string | string[] | undefined;
   updateSql: Nodes.SqlLiteral | undefined;
 
-  private _scopeAttributes: Record<string, unknown>;
+  private scopeAttributes: Record<string, unknown>;
   private _recordTimestamps: boolean;
   private _updatableColumns: string[] | undefined;
   private _uniqueByResolved = false;
@@ -117,8 +117,8 @@ export class InsertAll {
     // handled by resolveSti (reverse_merge) so it must not be re-injected here.
     const rawScopeAttrs: Record<string, unknown> = (relation as any).scopeForCreate();
     delete rawScopeAttrs[this.model.inheritanceColumn as string];
-    this._scopeAttributes = rawScopeAttrs;
-    for (const key of Object.keys(this._scopeAttributes)) {
+    this.scopeAttributes = rawScopeAttrs;
+    for (const key of Object.keys(this.scopeAttributes)) {
       this.keys.add(key);
     }
 
@@ -242,10 +242,10 @@ export class InsertAll {
     const timestamps = this.recordTimestamps() ? this.timestampsForCreate() : undefined;
     const keysList = [...this.keysIncludingTimestamps()];
     return this.inserts.map((row) => {
-      const merged = { ...row, ...this._scopeAttributes };
+      const attributes = { ...row, ...this.scopeAttributes };
       if (timestamps) {
         for (const [col, val] of Object.entries(timestamps)) {
-          if (!(col in merged)) merged[col] = val;
+          if (!(col in attributes)) attributes[col] = val;
         }
       }
       // Rails calls verify_attributes here (insert_all.rb:79), after the
@@ -253,8 +253,8 @@ export class InsertAll {
       // not in the constructor: `keysIncludingTimestamps` reads the model's
       // timestamp attributes off the reflected schema, which is not loaded yet
       // at construction time.
-      this.verifyAttributes(merged);
-      return keysList.map((key) => fn(key, merged[key]));
+      this.verifyAttributes(attributes);
+      return keysList.map((key) => fn(key, attributes[key]));
     });
   }
 
@@ -398,8 +398,8 @@ export class InsertAll {
     if (!this.inserts[0] || !this.hasAttributeAliases(this.inserts[0])) return;
     for (let i = 0; i < this.inserts.length; i++) {
       const resolved: Record<string, unknown> = {};
-      for (const [key, val] of Object.entries(this.inserts[i])) {
-        resolved[this.resolveAttributeAlias(key)] = val;
+      for (const [attribute, val] of Object.entries(this.inserts[i])) {
+        resolved[this.resolveAttributeAlias(attribute)] = val;
       }
       this.inserts[i] = resolved;
     }
@@ -408,12 +408,12 @@ export class InsertAll {
     // target reference physical column names.
     if (this.updateOnly !== undefined) {
       const cols = Array.isArray(this.updateOnly) ? this.updateOnly : [this.updateOnly];
-      this.updateOnly = cols.map((c) => this.resolveAttributeAlias(c));
+      this.updateOnly = cols.map((attribute) => this.resolveAttributeAlias(attribute));
     }
     if (typeof this.uniqueBy === "string") {
       this.uniqueBy = this.resolveAttributeAlias(this.uniqueBy);
     } else if (Array.isArray(this.uniqueBy)) {
-      this.uniqueBy = this.uniqueBy.map((c) => this.resolveAttributeAlias(c));
+      this.uniqueBy = this.uniqueBy.map((attribute) => this.resolveAttributeAlias(attribute));
     }
   }
 

--- a/packages/activerecord/src/query-logs.ts
+++ b/packages/activerecord/src/query-logs.ts
@@ -270,7 +270,8 @@ export class QueryLogs implements QueryTransformer {
     // ASCII key order — `<` compares UTF-16 code units, which matches Ruby's
     // String#<=> (UTF-8 bytewise) for the ASCII keys QueryLogs tags use.
     entries.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
-    return this._formatter.join(entries.map(([key, value]) => this._formatter.format(key, value)));
+    const pairs = entries.map(([key, val]) => this._formatter.format(key, val));
+    return this._formatter.join(pairs);
   }
 
   /**

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1155,9 +1155,9 @@ export class Relation<T extends Base> {
     // through to ValueType (no-op cast).
     const typeCaster = new TypeCasterMap(this.model);
     // Normalize undefined → null so eq(null) emits IS NULL (not the invalid = NULL).
-    const normalized = values.map((v) => {
-      if (v === undefined || v === null) return null;
-      return typeCaster.typeCastForDatabase(column, v);
+    const normalized = values.map((value) => {
+      if (value === undefined || value === null) return null;
+      return typeCaster.typeCastForDatabase(column, value);
     });
 
     // Mirrors Rails: `column.is_a?(Arel::Nodes::SqlLiteral) ? column : order_column(column.to_s)`.

--- a/packages/activerecord/src/tasks/mysql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/mysql-database-tasks.ts
@@ -310,8 +310,8 @@ export class MySQLDatabaseTasks {
 
   /** @internal */
   private async establishConnection(configHash?: Record<string, unknown>): Promise<void> {
-    const hash: Record<string, unknown> = { ...(configHash ?? this.dbConfig.configuration) };
-    await Base.establishConnection(hash as { adapter?: string; [key: string]: unknown });
+    const config: Record<string, unknown> = { ...(configHash ?? this.dbConfig.configuration) };
+    await Base.establishConnection(config as { adapter?: string; [key: string]: unknown });
   }
 
   /** @internal */

--- a/packages/activesupport/src/cache/coder.ts
+++ b/packages/activesupport/src/cache/coder.ts
@@ -308,10 +308,10 @@ export class Coder {
     return dumpedVersion;
   }
 
-  private tryCompress(payload: string, threshold: number): string | undefined {
-    if (this.compressor && Buffer.byteLength(payload) >= threshold) {
-      const compressed = this.compressor.deflate(payload);
-      if (compressed.length < Buffer.byteLength(payload)) return compressed;
+  private tryCompress(string: string, threshold: number): string | undefined {
+    if (this.compressor && Buffer.byteLength(string) >= threshold) {
+      const compressed = this.compressor.deflate(string);
+      if (compressed.length < Buffer.byteLength(string)) return compressed;
     }
     return undefined;
   }

--- a/packages/activesupport/src/cache/store.ts
+++ b/packages/activesupport/src/cache/store.ts
@@ -102,14 +102,7 @@ export abstract class Store {
     }
   }
 
-  /**
-   * Mirrors Rails `Cache::Store#fetch` (cache.rb:443). Rails reassigns
-   * `options = merged_options(options)`; TypeScript cannot, because the
-   * pre-merge value here is a `let` local (the overload split), and TS drops
-   * narrowing for a `let` assigned on more than one branch — so the merged
-   * value is a block-scoped `options` and the pre-merge one keeps Rails' other
-   * name for it, `call_options` (cache.rb:861, 948).
-   */
+  /** Mirrors Rails `Cache::Store#fetch` (cache.rb:443). */
   fetch(
     name: string,
     options?: StoreOptions,
@@ -121,23 +114,25 @@ export abstract class Store {
     optionsOrBlock?: StoreOptions | ((key: string, opts: WriteOptions) => unknown),
     maybeBlock?: (key: string, opts: WriteOptions) => unknown,
   ): unknown {
-    let callOptions: StoreOptions | undefined;
+    let options: StoreOptions | undefined;
     let block: ((key: string, opts: WriteOptions) => unknown) | undefined;
     if (typeof optionsOrBlock === "function") {
       block = optionsOrBlock;
     } else {
-      callOptions = optionsOrBlock;
+      options = optionsOrBlock;
       block = maybeBlock;
     }
 
     if (block) {
-      const options = this.mergedOptions(callOptions);
+      options = this.mergedOptions(options);
       const key = this.normalizeKey(name, options);
       let entry: Entry | null = null;
       if (!options.force) {
         this.instrument("read", key, options, (payload) => {
-          const cachedEntry = this.readEntry(key, options);
-          entry = this.handleExpiredEntry(cachedEntry, key, options);
+          // `options` is the merged value assigned just above; TS drops the
+          // narrowing across the closure boundary because it is a `let`.
+          const cachedEntry = this.readEntry(key, options!);
+          entry = this.handleExpiredEntry(cachedEntry, key, options!);
           if (entry) {
             if (entry.isMismatched(this.normalizeVersion(name, options) ?? null)) {
               entry = null;
@@ -156,12 +151,12 @@ export abstract class Store {
       }
       if (entry) return this.getEntryValue(entry, name, options);
       return this.saveBlockResultToCache(name, key, options, block);
-    } else if (callOptions?.force) {
+    } else if (options?.force) {
       throw new ArgumentError(
         "Missing block: Calling `Cache#fetch` with `force: true` requires a block.",
       );
     } else {
-      return this.read(name, callOptions);
+      return this.read(name, options);
     }
   }
 

--- a/packages/activesupport/src/cache/store.ts
+++ b/packages/activesupport/src/cache/store.ts
@@ -129,8 +129,6 @@ export abstract class Store {
       let entry: Entry | null = null;
       if (!options.force) {
         this.instrument("read", key, options, (payload) => {
-          // `options` is the merged value assigned just above; TS drops the
-          // narrowing across the closure boundary because it is a `let`.
           const cachedEntry = this.readEntry(key, options!);
           entry = this.handleExpiredEntry(cachedEntry, key, options!);
           if (entry) {

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -657,10 +657,10 @@ export class Callback {
     // Mirrors ActiveSupport::Callbacks::CallTemplate.build: a Proc/block filter
     // compiles to InstanceExec{0,1,2} (run via instance_exec, so `self` is the
     // record) selected by arity; a method-name filter compiles to MethodCall.
-    let callTemplate: CallTemplate;
+    let userCallback: CallTemplate;
     if (typeof this.filter === "function") {
       const arity = this.filter.length;
-      callTemplate =
+      userCallback =
         arity > 1
           ? new InstanceExec2(
               this.filter as (target: object, block: (() => unknown) | null) => unknown,
@@ -680,27 +680,27 @@ export class Callback {
       // ObjectCall.new(filter, current_scopes.join("_").to_sym) — the dispatched
       // method is the callback's scope-join, so the default `[:kind]` scope calls
       // `around`/`before`/`after` and `scope: [:kind, :name]` calls `aroundSave`.
-      callTemplate = new ObjectCall(this.filter, this.objectCallMethodName());
+      userCallback = new ObjectCall(this.filter, this.objectCallMethodName());
     } else {
-      callTemplate = new MethodCall(
+      userCallback = new MethodCall(
         typeof this.filter === "string" ? this.filter.slice(1) : (this.filter as PropertyKey),
       );
     }
 
     if (this.kind === "before") {
       this._compiled = new Before(
-        callTemplate.makeLambda(),
+        userCallback.makeLambda(),
         userConditions,
         this.chainConfig,
         this.filter,
         this.name,
       );
     } else if (this.kind === "after") {
-      this._compiled = new After(callTemplate.makeLambda(), userConditions, {
+      this._compiled = new After(userCallback.makeLambda(), userConditions, {
         skipAfterCallbacksIfTerminated: this.chainConfig.skipAfterCallbacksIfTerminated,
       });
     } else {
-      this._compiled = new Around(callTemplate, userConditions);
+      this._compiled = new Around(userCallback, userConditions);
     }
     return this._compiled;
   }

--- a/packages/activesupport/src/hash-with-indifferent-access.ts
+++ b/packages/activesupport/src/hash-with-indifferent-access.ts
@@ -14,17 +14,17 @@ type AnyObject = Record<string, unknown>;
 export class HashWithIndifferentAccess<V = unknown> {
   private data: Map<string, V>;
 
-  constructor(obj?: AnyObject | Map<string, V>) {
+  constructor(constructor?: AnyObject | Map<string, V>) {
     this.data = new Map();
-    if (obj) {
-      if (obj instanceof Map) {
-        for (const [key, value] of obj) {
+    if (constructor) {
+      if (constructor instanceof Map) {
+        for (const [key, value] of constructor) {
           this.data.set(String(key), value);
         }
       } else {
         // Mirrors Rails HashWithIndifferentAccess#initialize, which populates
         // via `update(constructor)` rather than inlining the copy.
-        this.update(obj);
+        this.update(constructor);
       }
     }
   }


### PR DESCRIPTION
RFC 0096 wave 2. Renames body-local identifiers to their Rails counterparts
across the four bundled story file sets. No behaviour change, no public API
change beyond parameter names.

`pnpm parity:api:calls:args:report`: **naming 368 → 342** (26 rows converged),
**shape unchanged at 285** — no new rows. `pnpm parity:api:calls` and
`pnpm parity:api:calls:args` both green; `pnpm parity:api` / `pnpm parity:test`
deltas unchanged.

## What changed

**activesupport**

- `cache/store.ts#fetch` reassigns `options = mergedOptions(options)` the way
  `cache.rb:443` does, retiring the separate `callOptions` local and the JSDoc
  that ratified it. The two closure-captured reads keep a `!` (TS drops `let`
  narrowing across a closure) with a note.
- `cache/coder.ts#tryCompress` takes `string` (`coder.rb:129`).
- `callbacks.ts#compiled` names the CallTemplate `userCallback`
  (`callbacks.rb:285`).
- `hash-with-indifferent-access.ts` constructor takes `constructor`
  (`hash_with_indifferent_access.rb:70`).

**activerecord encryption / tasks / query logs**

- `cipher.ts`: `cleanText` (`cipher.rb:15`), `encryptedText` (`cipher.rb:39`).
- `encryptor.ts#deserializeMessage`: `message` (`encryptor.rb:125`).
- `envelope-encryption-key-provider.ts#decryptionKeys`: `encryptedMessage`
  (`envelope_encryption_key_provider.rb:26`).
- `message-serializer.ts` / `message-pack-message-serializer.ts#load`:
  `serializedContent` (`message_serializer.rb:24`,
  `message_pack_message_serializer.rb:27`).
- `auto-filtered-parameters.ts`: `attribute`
  (`auto_filtered_parameters.rb:38`).
- `encryptable-record.ts`: `encryptedAttributeWasDeclared` receives `this`
  (`encryptable_record.rb:95`); `preserveOriginalEncrypted` uses
  `originalAttributeName` (`encryptable_record.rb:99`).
- `query-logs.ts#tagContent` extracts Rails' `pairs` local and its `val` block
  variable (`query_logs.rb:230-234`).
- `tasks/mysql-database-tasks.ts#establishConnection` passes `config`.

**relation / insert-all**

- `insert-all.ts`: field `scopeAttributes` (`insert_all.rb:35`), `attributes`
  in `mapKeyWithValue` (`insert_all.rb:74`), `attribute` at all three
  `resolveAttributeAlias` sites (`insert_all.rb:118,121,122`).
- `relation.ts#inOrderOf`: `value` (`query_methods.rb:724`).

**mysql adapters**

- `mysql/schema-creation.ts#visitChangeColumnDefinition`: `changeColumnSql`
  (`mysql/schema_creation.rb:23`).
- `mysql/schema-statements.ts#indexes`: `name` block variable
  (`mysql/schema_statements.rb:61`).
- `mysql/schema-statements.ts#quotedScope` reassigns `name` from
  `extractSchemaQualifiedName` (`mysql/schema_statements.rb:257`).

## Rows deliberately left standing

Each is an a1/a3 finding, not a rename — converging it changes behaviour or
shape, so it is out of scope per the story's instruction. Filed:

- `0023-surfaced-deviations/inflections-irregular-arms-and-uncountables-class`
  — the seven `inflector/inflections.ts` rows all come from inlining
  `Uncountables`' case-folding `delete`/`add` at the call site; the same story
  also captures `irregular` emitting four fewer `singular` rules than
  `inflections.rb`.
- `0023-surfaced-deviations/merger-merge-clauses-drops-where-merge` — the
  `merger.ts` row is a dropped statement plus reordered branches.
- `0023-surfaced-deviations/build-with-value-from-hash-node-and-arg-order` —
  `Nodes.Cte(name, expr)` vs `Arel::Nodes::TableAlias.new(expr, name)`: a
  different node class and reversed argument order.
- `0023-surfaced-deviations/unknown-primary-key-receives-model-not-relation` —
  `token_for.rb:42` raises `UnknownPrimaryKey.new(self)` (the relation);
  trails passes `this.model`, which changes the rendered message. The error's
  constructor type has to widen before the call site can converge.

The remainder are structural and belong to their own RFCs: helper-standing-in-
for-a-Ruby-method rows (`classOf` for `object.class`, `integer()` for
`Integer()`, `keyToPath`, `defaultType(createTableInfo, …)`), the `.call(this)`
mixin idiom (`touchAll`, `encryptAttributes`), the prepend-emulation receiver
parameters in `extended-deterministic-queries.ts`, splat-arity differences
(`callbacks.ts#append`/`#prepend`), the restructured number-helper converters,
and inline-expression rows (`ref:toA`, `ref:strip`, `ref:decode`) where Ruby
has no local to rename to.

One more, worth calling out because it looks fixable and is not:
`insert-all.ts#uniqueIndexes` passing `arelTable.name` where Rails passes
`model.table_name`. Switching to `this.model.tableName` retires that naming row
and two `call-mismatches` rows, but the extractor visits Ruby callees before
arguments and TS arguments before callees, so it immediately raises a NEW
`order:indexes,tableName` call-set row that no arrangement of the statement
avoids. Left as-is rather than widening a baseline for new work.

Closes-story: naming-burndown-2-activesupport
Closes-story: naming-burndown-2-ar-encryption-and-tasks
Closes-story: naming-burndown-2-ar-relation-insert-all
Closes-story: naming-burndown-2-ar-mysql-sqlite-adapters
