### PR TITLE
refactor(parity): port MemoryStore::DupCoder + pruning guard, delegate CollectionProxy removal to the association

### DIFF
--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -1157,9 +1157,12 @@ export class CollectionAssociation extends Association {
     if (existingRecords.length > 0) {
       await this.deleteRecords(existingRecords, method);
     }
+    // Rails `@target -= records` (collection_association.rb:404) is an Array
+    // difference by `==` — class + id — not by object identity, so a record the
+    // id-coercing `find` in `delete_or_destroy` re-materialized still prunes the
+    // instance already sitting in the loaded target.
+    this.target = this.target.filter((r) => !includesRecord(records, r));
     for (const record of records) {
-      const idx = this.target.indexOf(record);
-      if (idx !== -1) this.target.splice(idx, 1);
       // A `dependent: :destroy` record is frozen once destroyed, so clearing its
       // inverse foreign key would raise FrozenError. Rails leaves the destroyed
       // record's attributes untouched here (remove_records only prunes @target),

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -1136,6 +1136,11 @@ export class CollectionAssociation extends Association {
   /**
    * Mirrors: ActiveRecord::Associations::CollectionAssociation#remove_records —
    * before/after-remove callbacks, `deleteRecords`, in-memory target prune.
+   *
+   * The prune is Rails' `@target -= records` (collection_association.rb:404):
+   * an Array difference by `==` — class + id — not by object identity, so a
+   * record the id-coercing `find` in `delete_or_destroy` re-materialized still
+   * prunes the instance already sitting in the loaded target.
    * @internal
    */
   protected async removeRecords(
@@ -1157,10 +1162,6 @@ export class CollectionAssociation extends Association {
     if (existingRecords.length > 0) {
       await this.deleteRecords(existingRecords, method);
     }
-    // Rails `@target -= records` (collection_association.rb:404) is an Array
-    // difference by `==` — class + id — not by object identity, so a record the
-    // id-coercing `find` in `delete_or_destroy` re-materialized still prunes the
-    // instance already sitting in the loaded target.
     this.target = this.target.filter((r) => !includesRecord(records, r));
     for (const record of records) {
       // A `dependent: :destroy` record is frozen once destroyed, so clearing its

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -60,7 +60,6 @@ import {
 } from "./errors.js";
 import { routeThroughCheckValidity } from "./validate-through-reflection.js";
 import { rebaseNewOwnerSeed } from "./new-owner-seed-rebase.js";
-import { compositeQueryConstraintsList } from "../persistence.js";
 import type { AssociationDefinition } from "../associations.js";
 import {
   autoloadModel,
@@ -2163,160 +2162,19 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   //   divergence — renaming either would break the Rails API surface.
   //   Accepts Integer/String keys too, mirroring Rails' delete_or_destroy.
   async delete(...records: Array<T | number | string | bigint>): Promise<Base[] | undefined> {
-    // Rails CollectionAssociation#delete opens with `return if records.empty?`
-    // (collection_association.rb:385) BEFORE flatten, so a no-arg delete returns
-    // nil — not []. An explicit `delete([])` is `[[]]` (size 1) and falls through.
-    if (records.length === 0) return undefined;
     this._ensureThroughWritable();
-    // Through (incl. HABTM): delegate to the association-layer delete_records.
-    if (this._assocDef.options.through) {
-      const assoc = this._record.association(this._assocName) as unknown as {
-        delete: (...r: Array<Base | number | string | bigint>) => Promise<Base[] | undefined>;
-        _lastRemoveAborted?: boolean;
-      };
-      // Rails' CollectionProxy just delegates; the source @target is pruned
-      // INSIDE the association's remove_records (`@target -= records`) and ONLY
-      // when no before_remove aborts — an abort exits first
-      // (collection_association.rb:399-405), and HMT#remove_records prunes only
-      // the through/join targets while still returning the records
-      // (has_many_through_association.rb:116-118, 209-222). So propagate the
-      // returned records verbatim, but skip the proxy-target prune on abort so
-      // an aborted through delete doesn't make the collection look emptied.
-      const removed = await assoc.delete(...records);
-      if (removed && !assoc._lastRemoveAborted) this._removeFromTarget(removed);
-      return removed;
-    }
-    // Mirror Rails CollectionAssociation#delete → delete_or_destroy
-    // (collection_association.rb): coerce Integer/String args via the scoped
-    // `find` *first*, then flatten. Rails only treats a bare Integer/String
-    // top-level arg as an id (`records.any? { |r| r.is_a?(Integer) || r.is_a?(String) }`),
-    // never one nested in an array — so an id passed as an array (`delete([1, 2])`)
-    // skips `find` and is left to the type check, exactly as Rails does. Flattening
-    // only after `find` makes `delete([a, b])` and `delete(a, b)` behave identically
-    // for the model-object form the proxy callers use; `flat(Infinity)` matches
-    // Ruby's deep `Array#flatten`.
-    const coerced = records.some((r) => typeof r !== "object")
-      ? ([await this.find(...(records as unknown[]))].flat().filter(Boolean) as T[])
-      : records;
-    const modelRecords = (coerced as unknown[]).flat(Infinity) as T[];
-
-    // Rails CollectionProxy#delete resolves the strategy from the reflection's
-    // `:dependent` (delete_or_destroy(records, options[:dependent])). Share the
-    // remove_records path with `destroy`, which forces `:destroy`.
-    const aborted = await this._removeRecords(modelRecords, this._deleteStrategy());
-    // Rails remove_records aborts via `catch(:abort) { ... } || return` → nil
-    // (collection_association.rb:399-405), so a halted before_remove returns nil.
-    if (aborted) return undefined;
-    return modelRecords as Base[];
-  }
-
-  /**
-   * Shared implementation of Rails `CollectionAssociation#remove_records`
-   * (collection_association.rb:399-409): fire the abortable `before_remove`
-   * loop, run `delete_records` for the given strategy on the persisted subset,
-   * prune the in-memory target, then fire `after_remove`. Wrapped in a
-   * transaction when any record is persisted, mirroring `delete_or_destroy`.
-   * Both `delete` (strategy from `:dependent`) and `destroy` (forced `:destroy`)
-   * route through here so the two never drift. Returns whether a `before_remove`
-   * callback aborted the operation.
-   */
-  private async _removeRecords(
-    modelRecords: T[],
-    method: "delete_all" | "destroy" | "nullify",
-  ): Promise<boolean> {
-    // Rails delete_or_destroy (collection_association.rb:385-390) type-checks
-    // every record — after id-coercion/flatten, before any DB write — for both
-    // `delete` and `destroy`. Run it here so the two share the guard.
-    this._raiseOnTypeMismatch(modelRecords);
-    // Persisted children are deleted/nullified via the DB; new-record children
-    // have no row — they only participate in the callbacks and target pruning.
-    const persistedRecords = modelRecords.filter((r) => !r.isNewRecord());
-
-    let aborted = false;
-    const removeRecords = async () => {
-      // Rails wraps the whole `before_remove` loop in one `catch(:abort) ... ||
-      // return`: if any record's before_remove halts, the entire operation aborts
-      // and nothing is deleted (the transaction commits with no work done).
-      try {
-        for (const record of modelRecords) this._callbackHost.callback("beforeRemove", record);
-      } catch (e) {
-        if (!isAbortSignal(e)) throw e;
-        aborted = true;
-        return;
-      }
-      if (persistedRecords.length > 0) {
-        // Mirror Rails HasManyAssociation#delete_records: `:destroy` destroys
-        // each record (callbacks run); `:delete_all` bulk-DELETEs the scoped
-        // rows; otherwise (incl. nil → the has_many default) nullify the FK.
-        if (method === "destroy") {
-          // Rails: records.each(&:destroy!) — bang so a failed destroy raises
-          // RecordNotDestroyed and rolls back the wrapping transaction.
-          for (const record of persistedRecords) {
-            await (record as any).destroyBang();
-          }
-          // Rails: update_counter(-records.length) unless reflection.inverse_updates_counter_cache?
-          // The destroy callbacks decrement the owner's counter through the child's
-          // belongs_to inverse only when that inverse points at THIS reflection's
-          // counter column; otherwise (e.g. a has_many `counter_cache:` distinct from
-          // the inverse's) decrement here so we don't silently skip it.
-          const reflection = this.reflection as {
-            inverseWhichUpdatesCounterCache?: () => unknown;
-          };
-          if (!reflection.inverseWhichUpdatesCounterCache?.()) {
-            await this._decrementCounterCache(persistedRecords.length);
-          }
-        } else {
-          // Scope to the specific records via composite_query_constraints_list
-          // (persistence.rb:234). Single-column: `where({col: ids})`; composite:
-          // `where(cols, tuples)` (OR-of-AND) to avoid the cartesian-product that
-          // `AND col1 IN (...) AND col2 IN (...)` would produce.
-          const queryCols = compositeQueryConstraintsList.call((this as any)._model as typeof Base);
-          const readCol = (r: Base, col: string) => (r as any)._readAttribute(col);
-          let scope = this.scope();
-          if (queryCols.length === 1) {
-            scope = scope.where({
-              [queryCols[0]]: persistedRecords.map((r) => readCol(r, queryCols[0])),
-            });
-          } else {
-            const tuples = persistedRecords.map((r) => queryCols.map((col) => readCol(r, col)));
-            scope = scope.where(queryCols, tuples);
-          }
-          let count: number;
-          if (method === "delete_all") {
-            count = await scope.deleteAll();
-          } else {
-            const nullUpdates = this._buildNullifyUpdates();
-            count = await scope.updateAll(nullUpdates);
-            for (const record of persistedRecords) {
-              for (const [col, val] of Object.entries(nullUpdates)) {
-                record._writeAttribute(col, val);
-              }
-            }
-          }
-          // Rails delete_records else-branch: update_counter(-delete_count). The
-          // bulk DELETE/UPDATE bypasses callbacks (and thus the belongs_to inverse),
-          // so Rails always decrements the owner's counter cache by the affected
-          // count here — unlike the :destroy branch, which is gated on
-          // inverse_updates_counter_cache?.
-          if (count > 0) await this._decrementCounterCache(count);
-        }
-      }
-      // Remove from target first, then fire after_remove for all records.
-      this._removeFromTarget(modelRecords as Base[]);
-      for (const record of modelRecords) {
-        this._callbackHost.callback("afterRemove", record);
-      }
-    };
-
-    // Rails delete_or_destroy wraps remove_records in a transaction only when
-    // there are existing (persisted) records; new-record-only deletes run outside
-    // any transaction.
-    if (persistedRecords.length > 0) {
-      await this.transaction(removeRecords);
-    } else {
-      await removeRecords();
-    }
-    return aborted;
+    // Rails: `@association.delete(*records).tap { reset_scope }`
+    // (collection_proxy.rb:620-622). The whole removal body — the id coercion,
+    // `raise_on_type_mismatch!`, the single `catch(:abort)` around the
+    // `before_remove` loop, `delete_records`, the `@target` prune and
+    // `after_remove` — lives once on `CollectionAssociation#delete_or_destroy` /
+    // `#remove_records` (collection_association.rb:385-408), which writes the
+    // same in-memory target this proxy reads (the shared target store).
+    const removed = await this._collectionAssociation().delete(
+      ...(records as Array<Base | number | string | bigint>),
+    );
+    this.resetScope();
+    return removed;
   }
 
   private _removeFromTarget(records: Base[]): void {
@@ -2337,27 +2195,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       return !nullPkRecords.has(r);
     });
     this._invalidateAssociationIds();
-  }
-
-  /**
-   * Resolve the effective `:dependent` strategy for a record-level `delete`,
-   * mirroring Rails `HasManyAssociation#delete_records`: `:destroy` destroys each
-   * record, `:delete_all` (or the `delete`/camelCase aliases) bulk-DELETEs, and
-   * everything else — including the nil default for a plain has_many — nullifies
-   * the FK. Unlike `deleteAll`, `delete` does NOT collapse `:destroy` to
-   * `:delete_all`, so destroy callbacks run.
-   */
-  private _deleteStrategy(): "delete_all" | "destroy" | "nullify" {
-    switch (this._assocDef.options.dependent as string | undefined) {
-      case "destroy":
-        return "destroy";
-      case "delete_all":
-      case "deleteAll":
-      case "delete":
-        return "delete_all";
-      default:
-        return "nullify";
-    }
   }
 
   /**
@@ -2421,62 +2258,15 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   //   destroys by record reference (association semantics). Intentional
   //   permanent divergence — same rationale as CP#delete above.
   async destroy(...records: Array<T | number | string | bigint>): Promise<Base[] | undefined> {
-    // Mirror `delete`: Rails delete_or_destroy opens with `return if
-    // records.empty?` (collection_association.rb:385), so a no-arg destroy
-    // returns nil — not []. Keep the two in lockstep on the empty/abort contract.
-    if (records.length === 0) return undefined;
-    // Through (incl. HABTM): delegate to the association-layer destroy, exactly
-    // as Rails CollectionProxy#destroy → `@association.destroy(*records)`. For
-    // has_many :through that runs HasManyThroughAssociation#delete_records
-    // (has_many_through_association.rb:148-163): `scope.destroy_all` on the
-    // THROUGH (join) scope only — built via `construct_join_attributes(*records)`
-    // so duplicate join rows for the same target are all destroyed — then
-    // `remove_records` prunes the in-memory target and fires after_remove (in
-    // that order), wrapped in a transaction when any record is persisted. The
-    // source records themselves are never destroyed. Mirror `delete`'s through
-    // branch and sync the proxy's own target from the returned removed records.
-    if (this._isThrough) {
-      const assoc = this._record.association(this._assocName) as unknown as {
-        destroy: (...r: Array<Base | number | string | bigint>) => Promise<Base[] | undefined>;
-        _lastRemoveAborted?: boolean;
-      };
-      // As in the `delete` through-branch: propagate the returned records, but
-      // skip the proxy-target prune on a before_remove abort so an aborted
-      // through destroy doesn't make the collection look emptied in memory
-      // (collection_association.rb:399-405; has_many_through_association.rb:
-      // 116-118, 209-222).
-      const removed = await assoc.destroy(...(records as Base[]));
-      if (removed && !assoc._lastRemoveAborted) this._removeFromTarget(removed);
-      return removed;
-    }
-    // Mirror Rails CollectionAssociation#destroy → delete_or_destroy
-    // (collection_association.rb:387-389): coerce Integer/String args to records
-    // via the scoped `find` first (so a bare id finds+destroys the row rather
-    // than throwing `record.destroy is not a function`), flatten, then run
-    // raise_on_type_mismatch! before any DB write — exactly as the through
-    // branch does via the association layer. Only a top-level bare id is
-    // coerced; an id nested in an array is left to the type check, matching
-    // Rails and the `delete` branch above. The `filter(Boolean)` is
-    // defensive-only: on a genuine missing id `find` raises RecordNotFound
-    // (Relation#find, collection-proxy.ts non-cache path) exactly as Rails
-    // does — it never returns a falsy element — so the filter only guards the
-    // theoretical null return and never silently drops a real record.
-    const coerced = records.some((r) => typeof r !== "object")
-      ? ([await this.find(...(records as unknown[]))].flat().filter(Boolean) as T[])
-      : (records as T[]);
-    const modelRecords = (coerced as unknown[]).flat(Infinity) as T[];
-
-    // Rails CollectionProxy#destroy → delete_or_destroy(records, :destroy):
-    // the same remove_records path as `delete`, with the strategy forced to
-    // `:destroy`. Share `_removeRecords` so type-check, before_remove/after_remove
-    // callbacks, the counter-cache decrement, and the bang-destroy-in-transaction
-    // behavior stay in lockstep with `delete`. Rails returns the removed records
-    // (collection_association.rb:385-396, via remove_records' `records`); an
-    // aborted before_remove returns none, mirroring `delete`.
-    const aborted = await this._removeRecords(modelRecords, "destroy");
-    // Rails remove_records returns nil on a before_remove abort
-    // (collection_association.rb:399-405); mirror `delete` with undefined.
-    return aborted ? undefined : (modelRecords as Base[]);
+    this._ensureThroughWritable();
+    // Rails: `@association.destroy(*records).tap { reset_scope }`
+    // (collection_proxy.rb:692-694) — `delete_or_destroy(records, :destroy)`,
+    // sharing every step with `delete` above.
+    const removed = await this._collectionAssociation().destroy(
+      ...(records as Array<Base | number | string | bigint>),
+    );
+    this.resetScope();
+    return removed;
   }
 
   /**

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -2152,9 +2152,17 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   }
 
   /**
-   * Delete associated records by nullifying the FK (or removing join record for through).
+   * Deletes the `records` supplied according to the `:dependent` option, and
+   * removes them from the collection.
    *
    * Mirrors: ActiveRecord::Associations::CollectionProxy#delete
+   * (collection_proxy.rb:620-622) — `@association.delete(*records).tap {
+   * reset_scope }`. The removal body itself (id coercion,
+   * `raise_on_type_mismatch!`, the `catch(:abort)` around `before_remove`,
+   * `delete_records`, the `@target` prune, `after_remove`) lives once on
+   * `CollectionAssociation#delete_or_destroy` / `#remove_records`
+   * (collection_association.rb:385-408), which writes the same in-memory target
+   * this proxy reads.
    */
   // @ts-expect-error CP and Relation share the method name for genuinely
   //   different operations: Relation#delete removes by PK; CP#delete removes
@@ -2162,14 +2170,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   //   divergence — renaming either would break the Rails API surface.
   //   Accepts Integer/String keys too, mirroring Rails' delete_or_destroy.
   async delete(...records: Array<T | number | string | bigint>): Promise<Base[] | undefined> {
-    this._ensureThroughWritable();
-    // Rails: `@association.delete(*records).tap { reset_scope }`
-    // (collection_proxy.rb:620-622). The whole removal body — the id coercion,
-    // `raise_on_type_mismatch!`, the single `catch(:abort)` around the
-    // `before_remove` loop, `delete_records`, the `@target` prune and
-    // `after_remove` — lives once on `CollectionAssociation#delete_or_destroy` /
-    // `#remove_records` (collection_association.rb:385-408), which writes the
-    // same in-memory target this proxy reads (the shared target store).
     const removed = await this._collectionAssociation().delete(
       ...(records as Array<Base | number | string | bigint>),
     );
@@ -2249,19 +2249,19 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   }
 
   /**
-   * Destroy associated records (runs callbacks and deletes from DB).
+   * Destroys the `records` supplied and removes them from the collection,
+   * always removing the row from the database regardless of `:dependent`.
    *
    * Mirrors: ActiveRecord::Associations::CollectionProxy#destroy
+   * (collection_proxy.rb:692-694) — `@association.destroy(*records).tap {
+   * reset_scope }`, which is `delete_or_destroy(records, :destroy)` and so
+   * shares every step with {@link delete}.
    */
   // @ts-expect-error CP and Relation share the method name for genuinely
   //   different operations: Relation#destroy removes by PK; CP#destroy
   //   destroys by record reference (association semantics). Intentional
   //   permanent divergence — same rationale as CP#delete above.
   async destroy(...records: Array<T | number | string | bigint>): Promise<Base[] | undefined> {
-    this._ensureThroughWritable();
-    // Rails: `@association.destroy(*records).tap { reset_scope }`
-    // (collection_proxy.rb:692-694) — `delete_or_destroy(records, :destroy)`,
-    // sharing every step with `delete` above.
     const removed = await this._collectionAssociation().destroy(
       ...(records as Array<Base | number | string | bigint>),
     );

--- a/packages/activesupport/src/cache.test.ts
+++ b/packages/activesupport/src/cache.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { MemoryStore, DupCoder } from "./cache/memory-store.js";
-import { Entry } from "./cache/entry.js";
+import { MemoryStore } from "./cache/memory-store.js";
 import { NullStore } from "./cache/null-store.js";
 import { FileStore } from "./cache/file-store.js";
 import { mkdtempSync, rmSync } from "node:fs";
@@ -370,54 +369,5 @@ describe("FileStoreTest", () => {
     store.write("tmp", "value", { expiresIn: 0.01 });
     await new Promise((r) => setTimeout(r, 20));
     expect(store.read("tmp")).toBeNull();
-  });
-});
-
-describe("DupCoder", () => {
-  it("deep-clones plain objects", () => {
-    const obj = { a: { b: 1 }, c: [2, 3] };
-    const dup = DupCoder.load(DupCoder.dump(new Entry(obj))).value as typeof obj;
-    expect(dup).toEqual(obj);
-    expect(dup).not.toBe(obj);
-    expect(dup.a).not.toBe(obj.a);
-  });
-
-  it("deep-clones arrays", () => {
-    const arr = [{ x: 1 }, { y: 2 }];
-    const dup = DupCoder.load(DupCoder.dump(new Entry(arr))).value as typeof arr;
-    expect(dup).toEqual(arr);
-    expect(dup[0]).not.toBe(arr[0]);
-  });
-
-  it("returns primitives unchanged", () => {
-    for (const value of [42, true, null]) {
-      const entry = new Entry(value);
-      expect(DupCoder.dump(entry)).toBe(entry);
-    }
-  });
-
-  it("preserves expiresAt and version", () => {
-    const entry = new Entry({ a: 1 }, { expiresAt: 1234, version: "v1" });
-    const loaded = DupCoder.load(DupCoder.dump(entry));
-    expect(loaded.expiresAt).toBe(1234);
-    expect(loaded.version).toBe("v1");
-    expect(loaded.value).toEqual({ a: 1 });
-  });
-
-  it("round-trips a string without wrapping it", () => {
-    const entry = new Entry("hello");
-    expect(DupCoder.load(DupCoder.dump(entry)).value).toBe("hello");
-  });
-
-  it("dumpCompressed compresses past the threshold", () => {
-    const entry = new Entry("a".repeat(2000));
-    expect(DupCoder.dumpCompressed(entry, 1).isCompressed()).toBe(true);
-    expect(DupCoder.dumpCompressed(entry, 1).value).toBe("a".repeat(2000));
-    expect(DupCoder.dumpCompressed(entry, Infinity).isCompressed()).toBe(false);
-  });
-
-  it("load leaves a compressed entry alone", () => {
-    const compressed = DupCoder.dumpCompressed(new Entry("a".repeat(2000)), 1);
-    expect(DupCoder.load(compressed)).toBe(compressed);
   });
 });

--- a/packages/activesupport/src/cache.test.ts
+++ b/packages/activesupport/src/cache.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { MemoryStore, DupCoder } from "./cache/memory-store.js";
+import { Entry } from "./cache/entry.js";
 import { NullStore } from "./cache/null-store.js";
 import { FileStore } from "./cache/file-store.js";
 import { mkdtempSync, rmSync } from "node:fs";
@@ -375,7 +376,7 @@ describe("FileStoreTest", () => {
 describe("DupCoder", () => {
   it("deep-clones plain objects", () => {
     const obj = { a: { b: 1 }, c: [2, 3] };
-    const dup = DupCoder.dump(obj) as typeof obj;
+    const dup = DupCoder.load(DupCoder.dump(new Entry(obj))).value as typeof obj;
     expect(dup).toEqual(obj);
     expect(dup).not.toBe(obj);
     expect(dup.a).not.toBe(obj.a);
@@ -383,21 +384,40 @@ describe("DupCoder", () => {
 
   it("deep-clones arrays", () => {
     const arr = [{ x: 1 }, { y: 2 }];
-    const dup = DupCoder.dump(arr) as typeof arr;
+    const dup = DupCoder.load(DupCoder.dump(new Entry(arr))).value as typeof arr;
     expect(dup).toEqual(arr);
     expect(dup[0]).not.toBe(arr[0]);
   });
 
   it("returns primitives unchanged", () => {
-    expect(DupCoder.dump(42)).toBe(42);
-    expect(DupCoder.dump("hello")).toBe("hello");
-    expect(DupCoder.dump(true)).toBe(true);
-    expect(DupCoder.dump(null)).toBe(null);
-    expect(DupCoder.dump(undefined)).toBe(undefined);
+    for (const value of [42, true, null]) {
+      const entry = new Entry(value);
+      expect(DupCoder.dump(entry)).toBe(entry);
+    }
   });
 
-  it("load is symmetric with dump", () => {
-    const obj = { a: 1 };
-    expect(DupCoder.load(DupCoder.dump(obj))).toEqual(obj);
+  it("preserves expiresAt and version", () => {
+    const entry = new Entry({ a: 1 }, { expiresAt: 1234, version: "v1" });
+    const loaded = DupCoder.load(DupCoder.dump(entry));
+    expect(loaded.expiresAt).toBe(1234);
+    expect(loaded.version).toBe("v1");
+    expect(loaded.value).toEqual({ a: 1 });
+  });
+
+  it("round-trips a string without wrapping it", () => {
+    const entry = new Entry("hello");
+    expect(DupCoder.load(DupCoder.dump(entry)).value).toBe("hello");
+  });
+
+  it("dumpCompressed compresses past the threshold", () => {
+    const entry = new Entry("a".repeat(2000));
+    expect(DupCoder.dumpCompressed(entry, 1).isCompressed()).toBe(true);
+    expect(DupCoder.dumpCompressed(entry, 1).value).toBe("a".repeat(2000));
+    expect(DupCoder.dumpCompressed(entry, Infinity).isCompressed()).toBe(false);
+  });
+
+  it("load leaves a compressed entry alone", () => {
+    const compressed = DupCoder.dumpCompressed(new Entry("a".repeat(2000)), 1);
+    expect(DupCoder.load(compressed)).toBe(compressed);
   });
 });

--- a/packages/activesupport/src/cache/cache-store-namespace.test.ts
+++ b/packages/activesupport/src/cache/cache-store-namespace.test.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect } from "vitest";
 import { MemoryStore } from "./memory-store.js";
-import { coder } from "./coder.js";
+import type { Entry } from "./entry.js";
 
 // Mirrors Rails' `cache.instance_variable_get(:@data)["tester:foo"].value`
 // peek at the raw namespaced key.
 function rawValue(cache: MemoryStore, key: string): unknown {
-  const data = (cache as unknown as { data: Map<string, { encodedValue: string }> }).data;
+  const data = (cache as unknown as { data: Map<string, { payload: Entry }> }).data;
   const rec = data.get(key);
   if (!rec) return undefined;
-  return coder.load(rec.encodedValue);
+  return rec.payload.value;
 }
 
 describe("CacheStoreNamespaceTest", () => {

--- a/packages/activesupport/src/cache/file-store-compression.trails.test.ts
+++ b/packages/activesupport/src/cache/file-store-compression.trails.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { FileStore } from "./file-store.js";
+import type { CacheEntry } from "./entry-record.js";
+
+// trails-only coverage for FileStore's `serialize_entry` compression branch
+// (cache.rb:806-813). Rails covers it through the shared
+// `CacheStoreCompressionBehavior` suite, which trails has not enrolled yet.
+describe("FileStore compression", () => {
+  function withStore(options: Record<string, unknown>, fn: (store: FileStore) => void): void {
+    const dir = mkdtempSync(join(tmpdir(), "trails-file-store-"));
+    try {
+      fn(new FileStore(dir, options));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  function storedPayload(store: FileStore, key: string): string {
+    const path = (store as unknown as { keyToPath(k: string): string }).keyToPath(key);
+    const record = (store as unknown as { readFile(p: string): CacheEntry }).readFile(path);
+    return record.encodedValue;
+  }
+
+  it("compresses a large value by default and reads it back intact", () => {
+    withStore({}, (store) => {
+      const value = "a".repeat(4096);
+      store.write("foo", value);
+      expect(storedPayload(store, "foo").length).toBeLessThan(value.length);
+      expect(store.read("foo")).toBe(value);
+    });
+  });
+
+  it("stores the value uncompressed when compress is false", () => {
+    withStore({ compress: false }, (store) => {
+      const value = "a".repeat(4096);
+      store.write("foo", value);
+      expect(storedPayload(store, "foo").length).toBeGreaterThan(value.length);
+      expect(store.read("foo")).toBe(value);
+    });
+  });
+});

--- a/packages/activesupport/src/cache/file-store.ts
+++ b/packages/activesupport/src/cache/file-store.ts
@@ -1,6 +1,7 @@
 import { getFs, getPath } from "../fs-adapter.js";
 import type { CacheOptions, CacheStore } from "./index.js";
-import { coder } from "./coder.js";
+import { Coder, coder } from "./coder.js";
+import { deflate, inflate } from "../gzip.js";
 import { DeserializationError } from "./deserialization-error.js";
 import { Entry } from "./entry.js";
 import { Store, type StoreOptions } from "./store.js";
@@ -9,6 +10,13 @@ import { type CacheEntry, isExpired } from "./entry-record.js";
 import { registerStoreClass } from "./store-registry.js";
 
 const FILENAME_MAX_SIZE = 228;
+
+// Rails `Cache::DEFAULT_COMPRESS_LIMIT` (cache.rb:45).
+const DEFAULT_COMPRESS_LIMIT = 1024;
+
+// The coder Rails' `Store#initialize` builds when none is given:
+// `Cache::Coder.new(serializer, compressor)` (cache.rb:301-309).
+const fileCoder = new Coder(coder, { deflate, inflate });
 
 export class FileStore extends Store implements CacheStore {
   /** Advertise cache versioning support (file_store.rb:25-28). */
@@ -52,14 +60,26 @@ export class FileStore extends Store implements CacheStore {
   }
 
   /**
-   * Mirrors Rails `Store#serialize_entry` (cache.rb:806-813). Rails' default
-   * coder returns a String payload; the trails FileStore's on-disk payload is
-   * the {@link CacheEntry} record, so the Coder round-trip that stands in for
-   * Marshal happens on its `encodedValue`.
+   * Mirrors Rails `Store#serialize_entry` (cache.rb:806-813): dispatch to the
+   * coder's `dump_compressed` under `:compress` — Rails' default
+   * (`@options[:compress] = true unless @options.key?(:compress)`, cache.rb:298)
+   * — and to `dump` otherwise. The coder is `Cache::Coder` over the default
+   * serializer and Zlib (cache.rb:301-309), which `Store#initialize` builds and
+   * holds in `@coder`; trails' `Store` has no such seam yet (RFC 0101 story
+   * `converge-store-serialized-entry-hooks-and-file-store-paths`), so this
+   * store builds the same coder meanwhile. The framed payload carries the
+   * value, the compression flag, `expires_at` and `version`; the surrounding
+   * record keeps `expiresAt` beside it for the directory scans `cleanup` and
+   * `deleteMatched` do without deserializing.
    */
-  private serializeEntry(entry: Entry, _options: StoreOptions): CacheEntry {
+  private serializeEntry(entry: Entry, options: StoreOptions): CacheEntry {
+    const compress = (options.compress as boolean | undefined) ?? true;
+    const compressThreshold =
+      (options.compressThreshold as number | undefined) ?? DEFAULT_COMPRESS_LIMIT;
     return {
-      encodedValue: coder.dump(entry.value),
+      encodedValue: compress
+        ? fileCoder.dumpCompressed(entry, compressThreshold)
+        : fileCoder.dump(entry),
       expiresAt: entry.expiresAt,
       version: entry.version,
       accessedAt: Date.now(),
@@ -72,14 +92,12 @@ export class FileStore extends Store implements CacheStore {
    */
   private deserializeEntry(payload: CacheEntry | null): Entry | null {
     if (payload === null || payload.encodedValue === undefined) return null;
-    let value: unknown;
     try {
-      value = coder.load(payload.encodedValue);
+      return fileCoder.load(payload.encodedValue) as Entry;
     } catch (e) {
       if (e instanceof DeserializationError) return null;
       throw e;
     }
-    return new Entry(value, { expiresAt: payload.expiresAt, version: payload.version ?? null });
   }
 
   protected deleteEntry(key: string, _options: StoreOptions): boolean {

--- a/packages/activesupport/src/cache/file-store.ts
+++ b/packages/activesupport/src/cache/file-store.ts
@@ -34,29 +34,52 @@ export class FileStore extends Store implements CacheStore {
   // isExpired()/isMismatched() like Rails read_entry. A malformed payload
   // degrades to a miss, mirroring Rails deserialize_entry's rescue (cache.rb).
   protected readEntry(key: string, _options: StoreOptions): Entry | null {
-    const stored = this.readFile(this.keyToPath(key));
-    if (!stored || stored.encodedValue === undefined) return null;
-    let value: unknown;
-    try {
-      value = coder.load(stored.encodedValue);
-    } catch (e) {
-      if (e instanceof DeserializationError) return null;
-      throw e;
+    const payload = this.readFile(this.keyToPath(key));
+    if (payload) {
+      const entry = this.deserializeEntry(payload);
+      return entry instanceof Entry ? entry : null;
     }
-    return new Entry(value, { expiresAt: stored.expiresAt, version: stored.version ?? null });
+    return null;
   }
 
+  // The `unless_exist` refusal is Rails' `write_serialized_entry`
+  // (file_store.rb:123-129), whose own port belongs with the FileStore path
+  // helpers; `write_entry` itself is Rails' `serialize_entry` call.
   protected writeEntry(key: string, entry: Entry, options: StoreOptions): boolean {
-    // Mirrors Rails write_serialized_entry (file_store.rb:124-129): unless_exist
-    // refuses the write when the file merely exists, regardless of expiry.
     if (options.unlessExist && getFs().existsSync(this.keyToPath(key))) return false;
-    this.writeFile(this.keyToPath(key), {
+    this.writeFile(this.keyToPath(key), this.serializeEntry(entry, options));
+    return true;
+  }
+
+  /**
+   * Mirrors Rails `Store#serialize_entry` (cache.rb:806-813). Rails' default
+   * coder returns a String payload; the trails FileStore's on-disk payload is
+   * the {@link CacheEntry} record, so the Coder round-trip that stands in for
+   * Marshal happens on its `encodedValue`.
+   */
+  private serializeEntry(entry: Entry, _options: StoreOptions): CacheEntry {
+    return {
       encodedValue: coder.dump(entry.value),
       expiresAt: entry.expiresAt,
       version: entry.version,
       accessedAt: Date.now(),
-    });
-    return true;
+    };
+  }
+
+  /**
+   * Mirrors Rails `Store#deserialize_entry` (cache.rb:815-819), including the
+   * `rescue DeserializationError` that degrades a malformed payload to a miss.
+   */
+  private deserializeEntry(payload: CacheEntry | null): Entry | null {
+    if (payload === null || payload.encodedValue === undefined) return null;
+    let value: unknown;
+    try {
+      value = coder.load(payload.encodedValue);
+    } catch (e) {
+      if (e instanceof DeserializationError) return null;
+      throw e;
+    }
+    return new Entry(value, { expiresAt: payload.expiresAt, version: payload.version ?? null });
   }
 
   protected deleteEntry(key: string, _options: StoreOptions): boolean {

--- a/packages/activesupport/src/cache/memory-store-dup-coder.trails.test.ts
+++ b/packages/activesupport/src/cache/memory-store-dup-coder.trails.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { DupCoder } from "./memory-store.js";
+import { Entry } from "./entry.js";
+
+// trails-only coverage for `ActiveSupport::Cache::MemoryStore::DupCoder`
+// (memory_store.rb:29-70), which Rails exercises only indirectly through the
+// shared cache-store behaviour suites.
+describe("DupCoder", () => {
+  it("deep-clones plain objects", () => {
+    const obj = { a: { b: 1 }, c: [2, 3] };
+    const dup = DupCoder.load(DupCoder.dump(new Entry(obj))).value as typeof obj;
+    expect(dup).toEqual(obj);
+    expect(dup).not.toBe(obj);
+    expect(dup.a).not.toBe(obj.a);
+  });
+
+  it("deep-clones arrays", () => {
+    const arr = [{ x: 1 }, { y: 2 }];
+    const dup = DupCoder.load(DupCoder.dump(new Entry(arr))).value as typeof arr;
+    expect(dup).toEqual(arr);
+    expect(dup[0]).not.toBe(arr[0]);
+  });
+
+  it("returns primitives unchanged", () => {
+    for (const value of [42, true, null]) {
+      const entry = new Entry(value);
+      expect(DupCoder.dump(entry)).toBe(entry);
+    }
+  });
+
+  it("preserves expiresAt and version", () => {
+    const entry = new Entry({ a: 1 }, { expiresAt: 1234, version: "v1" });
+    const loaded = DupCoder.load(DupCoder.dump(entry));
+    expect(loaded.expiresAt).toBe(1234);
+    expect(loaded.version).toBe("v1");
+    expect(loaded.value).toEqual({ a: 1 });
+  });
+
+  it("round-trips a string without wrapping it", () => {
+    const entry = new Entry("hello");
+    expect(DupCoder.load(DupCoder.dump(entry)).value).toBe("hello");
+  });
+
+  it("dumpCompressed compresses past the threshold", () => {
+    const entry = new Entry("a".repeat(2000));
+    expect(DupCoder.dumpCompressed(entry, 1).isCompressed()).toBe(true);
+    expect(DupCoder.dumpCompressed(entry, 1).value).toBe("a".repeat(2000));
+    expect(DupCoder.dumpCompressed(entry, Infinity).isCompressed()).toBe(false);
+  });
+
+  it("load leaves a compressed entry alone", () => {
+    const compressed = DupCoder.dumpCompressed(new Entry("a".repeat(2000)), 1);
+    expect(DupCoder.load(compressed)).toBe(compressed);
+  });
+});

--- a/packages/activesupport/src/cache/memory-store-dup-coder.trails.test.ts
+++ b/packages/activesupport/src/cache/memory-store-dup-coder.trails.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { DupCoder } from "./memory-store.js";
+import { DupCoder, MemoryStore } from "./memory-store.js";
 import { Entry } from "./entry.js";
 
 // trails-only coverage for `ActiveSupport::Cache::MemoryStore::DupCoder`
@@ -51,5 +51,31 @@ describe("DupCoder", () => {
   it("load leaves a compressed entry alone", () => {
     const compressed = DupCoder.dumpCompressed(new Entry("a".repeat(2000)), 1);
     expect(DupCoder.load(compressed)).toBe(compressed);
+  });
+});
+
+describe("MemoryStore serialization", () => {
+  it("routes writes through DupCoder so a stored value cannot alias the caller's", () => {
+    const store = new MemoryStore();
+    const value = { a: { b: 1 } };
+    store.write("foo", value);
+    value.a.b = 2;
+    expect(store.read("foo")).toEqual({ a: { b: 1 } });
+  });
+
+  it("compresses past the threshold when compress is set", () => {
+    const store = new MemoryStore({ compress: true, compressThreshold: 1 });
+    const value = "a".repeat(2000);
+    store.write("foo", value);
+    const data = (store as unknown as { data: Map<string, { payload: Entry }> }).data;
+    expect(data.get("foo")!.payload.isCompressed()).toBe(true);
+    expect(store.read("foo")).toBe(value);
+  });
+
+  it("stores uncompressed by default", () => {
+    const store = new MemoryStore();
+    store.write("foo", "a".repeat(2000));
+    const data = (store as unknown as { data: Map<string, { payload: Entry }> }).data;
+    expect(data.get("foo")!.payload.isCompressed()).toBe(false);
   });
 });

--- a/packages/activesupport/src/cache/memory-store.ts
+++ b/packages/activesupport/src/cache/memory-store.ts
@@ -5,15 +5,13 @@ import { Store } from "./store.js";
 import { integer } from "./integer.js";
 import { registerStoreClass } from "./store-registry.js";
 
-// In-memory record backing a single key. We store the coder-serialized value
-// (so Date/undefined/bigint/non-finite numbers and deep-clone isolation survive
-// the round-trip) alongside the Rails Entry metadata (absolute `expiresAt` in ms,
-// `version`). `accessedAt` drives LRU pruning. readEntry/writeEntry rebuild the
-// Rails second-unit `Entry` so the instrumented Store base owns read/write/fetch.
+// In-memory record backing a single key. Rails stores the `serialize_entry`
+// payload itself (`@data[key] = payload`, memory_store.rb:213-227), which for
+// this store is a DupCoder-dumped `Entry`; `expiresAt` mirrors it for the
+// `unless_exist` check and `accessedAt` drives LRU pruning.
 interface MemoryRecord {
-  encodedValue: string;
+  payload: Entry;
   expiresAt: number | null;
-  version: string | null;
   accessedAt: number;
 }
 
@@ -43,6 +41,8 @@ export class MemoryStore extends Store implements CacheStore {
     sizeLimit?: number;
     namespace?: string | (() => string);
     expiresIn?: number;
+    compress?: boolean;
+    compressThreshold?: number;
   }) {
     super(options ?? {});
     this.sizeLimit = options?.sizeLimit ?? Infinity;
@@ -54,25 +54,45 @@ export class MemoryStore extends Store implements CacheStore {
     const rec = this.data.get(key);
     if (!rec) return null;
     rec.accessedAt = Date.now();
-    return new Entry(coder.load(rec.encodedValue), {
-      expiresAt: rec.expiresAt,
-      version: rec.version,
-    });
+    return this.deserializeEntry(rec.payload);
   }
 
   protected writeEntry(key: string, entry: Entry, options: Record<string, unknown>): boolean {
+    const payload = this.serializeEntry(entry, options);
     if (options.unlessExist) {
       const existing = this.data.get(key);
       if (existing && !this.recordExpired(existing)) return false;
     }
     this.data.set(key, {
-      encodedValue: coder.dump(entry.value),
+      payload,
       expiresAt: entry.expiresAt,
-      version: entry.version,
       accessedAt: Date.now(),
     });
     if (this.data.size > this.sizeLimit) this.evictLRU();
     return true;
+  }
+
+  /**
+   * Mirrors Rails `Store#serialize_entry` (cache.rb:806-813): dispatch to the
+   * coder's `dump_compressed` under `compress`, else `dump`. Rails installs the
+   * coder in `MemoryStore#initialize` (`options[:coder] = DupCoder`,
+   * memory_store.rb:73-75) and holds it in `@coder` on the base; trails' `Store`
+   * has no `@coder` seam yet (RFC 0101 story
+   * `converge-store-serialized-entry-hooks-and-file-store-paths` ports it), so
+   * this store names the coder Rails installs for it directly until that lands.
+   */
+  private serializeEntry(entry: Entry, options: Record<string, unknown>): Entry {
+    options = this.mergedOptions(options as CacheOptions) as Record<string, unknown>;
+    if (options.compress) {
+      return DupCoder.dumpCompressed(entry, (options.compressThreshold as number) ?? 1024);
+    } else {
+      return DupCoder.dump(entry);
+    }
+  }
+
+  /** Mirrors Rails `Store#deserialize_entry` (cache.rb:815-819). */
+  private deserializeEntry(payload: Entry | null): Entry | null {
+    return payload === null ? null : DupCoder.load(payload);
   }
 
   protected deleteEntry(key: string, _options: Record<string, unknown>): boolean {

--- a/packages/activesupport/src/cache/memory-store.ts
+++ b/packages/activesupport/src/cache/memory-store.ts
@@ -157,9 +157,11 @@ export class MemoryStore extends Store implements CacheStore {
     return num;
   }
 
-  // Rails guards `prune` against re-entry with the `@pruning` flag
-  // (memory_store.rb:110-127): `cleanup` and the per-key `delete_entry` below can
-  // both re-enter through a write, and the inner call must not prune again.
+  /**
+   * Rails guards `prune` against re-entry with the `@pruning` flag
+   * (memory_store.rb:110-127): `cleanup` and the per-key deletion below can both
+   * re-enter through a write, and the inner call must not prune again.
+   */
   prune(targetSize: number, maxTime?: number): void {
     if (this.isPruning()) return;
     this._pruning = true;
@@ -196,10 +198,12 @@ export class MemoryStore extends Store implements CacheStore {
 }
 
 export namespace DupCoder {
-  // Mirrors Rails MemoryStore::DupCoder#dump (memory_store.rb:32-38): rebuild the
-  // Entry around a dumped value so the stored value can't alias the caller's,
-  // preserving expires_at/version. Ruby's `entry.value && … != true &&
-  // !Numeric` leaves nil/false/true/Numeric entries untouched.
+  /**
+   * Mirrors Rails MemoryStore::DupCoder#dump (memory_store.rb:32-38): rebuild
+   * the Entry around a dumped value so the stored value can't alias the
+   * caller's, preserving expires_at/version. Ruby's `entry.value && … != true
+   * && !Numeric` leaves nil/false/true/Numeric entries untouched.
+   */
   export function dump(entry: Entry): Entry {
     const value = entry.value;
     if (
@@ -215,13 +219,13 @@ export namespace DupCoder {
     }
   }
 
-  // Mirrors Rails MemoryStore::DupCoder#dump_compressed (memory_store.rb:40-43).
+  /** Mirrors Rails MemoryStore::DupCoder#dump_compressed (memory_store.rb:40-43). */
   export function dumpCompressed(entry: Entry, threshold: number): Entry {
     const compressedEntry = entry.compressed(threshold);
     return compressedEntry.isCompressed() ? compressedEntry : dump(entry);
   }
 
-  // Mirrors Rails MemoryStore::DupCoder#load (memory_store.rb:45-51).
+  /** Mirrors Rails MemoryStore::DupCoder#load (memory_store.rb:45-51). */
   export function load(entry: Entry): Entry {
     if (!entry.isCompressed() && typeof entry.value === "string") {
       return new Entry(loadValue(entry.value), {
@@ -233,17 +237,21 @@ export namespace DupCoder {
     }
   }
 
-  // Rails' `MARSHAL_SIGNATURE` (memory_store.rb:54) is the two leading bytes
-  // every `Marshal.dump` payload carries, which is how `load_value` tells a
-  // serialized value from a String stored verbatim. The trails Marshal
-  // equivalent is the fidelity Coder (coder.ts), whose JSON output carries no
-  // such self-identifying prefix, so dump_value prepends the same signature and
-  // load_value strips it — same discriminator, same two arms.
+  /**
+   * Rails' `MARSHAL_SIGNATURE` (memory_store.rb:54) is the two leading bytes
+   * every `Marshal.dump` payload carries, which is how `load_value` tells a
+   * serialized value from a String stored verbatim. The trails Marshal
+   * equivalent is the fidelity Coder (coder.ts), whose JSON output carries no
+   * such self-identifying prefix, so `dump_value` prepends the same signature
+   * and `load_value` strips it — same discriminator, same two arms.
+   */
   const MARSHAL_SIGNATURE = "\x04\x08";
 
-  // Mirrors Rails MemoryStore::DupCoder#dump_value (memory_store.rb:56-62).
-  // Ruby's `value.dup` guards against the caller mutating the stored String;
-  // JS strings are immutable, so the String arm returns it as-is.
+  /**
+   * Mirrors Rails MemoryStore::DupCoder#dump_value (memory_store.rb:56-62).
+   * Ruby's `value.dup` guards against the caller mutating the stored String;
+   * JS strings are immutable, so the String arm returns it as-is.
+   */
   function dumpValue(value: unknown): string {
     if (typeof value === "string" && !value.startsWith(MARSHAL_SIGNATURE)) {
       return value;
@@ -252,7 +260,7 @@ export namespace DupCoder {
     }
   }
 
-  // Mirrors Rails MemoryStore::DupCoder#load_value (memory_store.rb:64-70).
+  /** Mirrors Rails MemoryStore::DupCoder#load_value (memory_store.rb:64-70). */
   function loadValue(string: string): unknown {
     if (string.startsWith(MARSHAL_SIGNATURE)) {
       return coder.load(string.slice(MARSHAL_SIGNATURE.length));

--- a/packages/activesupport/src/cache/memory-store.ts
+++ b/packages/activesupport/src/cache/memory-store.ts
@@ -37,6 +37,7 @@ export class MemoryStore extends Store implements CacheStore {
 
   private data: Map<string, MemoryRecord> = new Map();
   private sizeLimit: number;
+  private _pruning = false;
 
   constructor(options?: {
     sizeLimit?: number;
@@ -156,17 +157,31 @@ export class MemoryStore extends Store implements CacheStore {
     return num;
   }
 
+  // Rails guards `prune` against re-entry with the `@pruning` flag
+  // (memory_store.rb:110-127): `cleanup` and the per-key `delete_entry` below can
+  // both re-enter through a write, and the inner call must not prune again.
   prune(targetSize: number, maxTime?: number): void {
-    const start = Date.now();
-    this.cleanup();
-    const sorted = [...this.data.entries()].sort((a, b) => a[1].accessedAt - b[1].accessedAt);
-    let freed = 0;
-    for (const [key] of sorted) {
-      if (freed >= targetSize) break;
-      if (maxTime != null && Date.now() - start > maxTime * 1000) break;
-      this.data.delete(key);
-      freed++;
+    if (this.isPruning()) return;
+    this._pruning = true;
+    try {
+      const startTime = Date.now();
+      this.cleanup();
+      const sorted = [...this.data.entries()].sort((a, b) => a[1].accessedAt - b[1].accessedAt);
+      let freed = 0;
+      for (const [key] of sorted) {
+        if (freed >= targetSize) break;
+        if (maxTime != null && Date.now() - startTime > maxTime * 1000) break;
+        this.data.delete(key);
+        freed++;
+      }
+    } finally {
+      this._pruning = false;
     }
+  }
+
+  /** Returns true if the cache is currently being pruned (memory_store.rb:129-131). */
+  isPruning(): boolean {
+    return this._pruning;
   }
 
   private evictLRU(): void {
@@ -181,18 +196,69 @@ export class MemoryStore extends Store implements CacheStore {
 }
 
 export namespace DupCoder {
-  export function dump(entry: unknown): unknown {
-    if (entry === null || entry === undefined) return entry;
-    if (typeof entry !== "object") return entry;
-    try {
-      return structuredClone(entry);
-    } catch {
+  // Mirrors Rails MemoryStore::DupCoder#dump (memory_store.rb:32-38): rebuild the
+  // Entry around a dumped value so the stored value can't alias the caller's,
+  // preserving expires_at/version. Ruby's `entry.value && … != true &&
+  // !Numeric` leaves nil/false/true/Numeric entries untouched.
+  export function dump(entry: Entry): Entry {
+    const value = entry.value;
+    if (
+      value != null &&
+      value !== false &&
+      value !== true &&
+      typeof value !== "number" &&
+      typeof value !== "bigint"
+    ) {
+      return new Entry(dumpValue(value), { expiresAt: entry.expiresAt, version: entry.version });
+    } else {
       return entry;
     }
   }
 
-  export function load(entry: unknown): unknown {
-    return dump(entry);
+  // Mirrors Rails MemoryStore::DupCoder#dump_compressed (memory_store.rb:40-43).
+  export function dumpCompressed(entry: Entry, threshold: number): Entry {
+    const compressedEntry = entry.compressed(threshold);
+    return compressedEntry.isCompressed() ? compressedEntry : dump(entry);
+  }
+
+  // Mirrors Rails MemoryStore::DupCoder#load (memory_store.rb:45-51).
+  export function load(entry: Entry): Entry {
+    if (!entry.isCompressed() && typeof entry.value === "string") {
+      return new Entry(loadValue(entry.value), {
+        expiresAt: entry.expiresAt,
+        version: entry.version,
+      });
+    } else {
+      return entry;
+    }
+  }
+
+  // Rails' `MARSHAL_SIGNATURE` (memory_store.rb:54) is the two leading bytes
+  // every `Marshal.dump` payload carries, which is how `load_value` tells a
+  // serialized value from a String stored verbatim. The trails Marshal
+  // equivalent is the fidelity Coder (coder.ts), whose JSON output carries no
+  // such self-identifying prefix, so dump_value prepends the same signature and
+  // load_value strips it — same discriminator, same two arms.
+  const MARSHAL_SIGNATURE = "\x04\x08";
+
+  // Mirrors Rails MemoryStore::DupCoder#dump_value (memory_store.rb:56-62).
+  // Ruby's `value.dup` guards against the caller mutating the stored String;
+  // JS strings are immutable, so the String arm returns it as-is.
+  function dumpValue(value: unknown): string {
+    if (typeof value === "string" && !value.startsWith(MARSHAL_SIGNATURE)) {
+      return value;
+    } else {
+      return MARSHAL_SIGNATURE + coder.dump(value);
+    }
+  }
+
+  // Mirrors Rails MemoryStore::DupCoder#load_value (memory_store.rb:64-70).
+  function loadValue(string: string): unknown {
+    if (string.startsWith(MARSHAL_SIGNATURE)) {
+      return coder.load(string.slice(MARSHAL_SIGNATURE.length));
+    } else {
+      return string;
+    }
   }
 }
 

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/cache/file-store.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/cache/file-store.json
@@ -94,19 +94,5 @@
       "ref:entry"
     ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "cache/file-store.ts",
-    "rubyName": "read_entry",
-    "call": "deserialize_entry",
-    "reason": "Pre-existing FileStore divergence, newly visible: `read_entry`/`write_entry` in file-store.ts serialize with the fidelity Coder directly (file-store.ts:38-54) instead of Rails' `Store#deserialize_entry`/`#serialize_entry` (cache.rb:806-819), which trails' `Store` has no `@coder` seam for yet. The two call names only entered the compare population when MemoryStore ported them (PR #6435), so this row records existing debt rather than new; RFC 0101 story `converge-store-serialized-entry-hooks-and-file-store-paths` ports the Store-level seam and converges these two call sites with it."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "cache/file-store.ts",
-    "rubyName": "write_entry",
-    "call": "serialize_entry",
-    "reason": "Pre-existing FileStore divergence, newly visible: `read_entry`/`write_entry` in file-store.ts serialize with the fidelity Coder directly (file-store.ts:38-54) instead of Rails' `Store#deserialize_entry`/`#serialize_entry` (cache.rb:806-819), which trails' `Store` has no `@coder` seam for yet. The two call names only entered the compare population when MemoryStore ported them (PR #6435), so this row records existing debt rather than new; RFC 0101 story `converge-store-serialized-entry-hooks-and-file-store-paths` ports the Store-level seam and converges these two call sites with it."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/cache/file-store.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/cache/file-store.json
@@ -94,5 +94,19 @@
       "ref:entry"
     ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "cache/file-store.ts",
+    "rubyName": "read_entry",
+    "call": "deserialize_entry",
+    "reason": "Pre-existing FileStore divergence, newly visible: `read_entry`/`write_entry` in file-store.ts serialize with the fidelity Coder directly (file-store.ts:38-54) instead of Rails' `Store#deserialize_entry`/`#serialize_entry` (cache.rb:806-819), which trails' `Store` has no `@coder` seam for yet. The two call names only entered the compare population when MemoryStore ported them (PR #6435), so this row records existing debt rather than new; RFC 0101 story `converge-store-serialized-entry-hooks-and-file-store-paths` ports the Store-level seam and converges these two call sites with it."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "cache/file-store.ts",
+    "rubyName": "write_entry",
+    "call": "serialize_entry",
+    "reason": "Pre-existing FileStore divergence, newly visible: `read_entry`/`write_entry` in file-store.ts serialize with the fidelity Coder directly (file-store.ts:38-54) instead of Rails' `Store#deserialize_entry`/`#serialize_entry` (cache.rb:806-819), which trails' `Store` has no `@coder` seam for yet. The two call names only entered the compare population when MemoryStore ported them (PR #6435), so this row records existing debt rather than new; RFC 0101 story `converge-store-serialized-entry-hooks-and-file-store-paths` ports the Store-level seam and converges these two call sites with it."
   }
 ]


### PR DESCRIPTION
`ActiveSupport::Cache::MemoryStore::DupCoder` carried a `structuredClone` shim
in place of the Rails bodies. Port `dump`/`load` (memory_store.rb:32-51) so they
rebuild a `Cache::Entry` with `expires_at`/`version` preserved, and add
`dump_compressed` (:40-43) plus the private `dump_value`/`load_value` Marshal
round-trip (:56-70). The trails Marshal equivalent (the fidelity Coder) emits
JSON with no self-identifying prefix, so `dump_value` prepends Rails'
`MARSHAL_SIGNATURE` and `load_value` strips it — same discriminator, same arms.

`MemoryStore#prune` had no reentrancy guard; add the `@pruning` flag and
`pruning?` (memory_store.rb:110-131).

`CollectionProxy#delete`/`#destroy` re-spelled `remove_records` against the
proxy's own target — the type check, a third `catch(:abort)` around the
`before_remove` loop, the destroy/delete_all/nullify dispatch of
`HasManyAssociation#delete_records`, the counter-cache decrement, the target
prune and `after_remove`. Rails is a one-line delegation
(collection_proxy.rb:620-622, :692-694), so make it one: the body now lives
once on `CollectionAssociation#delete_or_destroy`/`#remove_records`, which
writes the same shared in-memory target the proxy reads. With the proxy copy
gone, `remove_records`' prune converges to Rails' `@target -= records`
(:404) — Array difference by `==`, i.e. class + id, not object identity, so a
record the id-coercing `find` re-materialized still prunes the loaded instance.

Closes-story: converge-memory-store-dupcoder-and-pruning-guard
Closes-story: converge-collection-proxy-delete-delegates-to-association

Story `converge-new-owner-replace-to-replace-records` is **blocked**, not shipped: `CollectionAssociation#replace` is reached synchronously from the constructor's mass-assignment dispatch (`base.ts` `_dispatchAssociationAttrs` → `syncWrite` → `replace`), while Rails' new-owner arm `replace_records` runs through `delete`/`concat`, every link of which is `async` here — an await on a non-promise still defers a microtask past the caller's next read. Converging needs that chain restated as `Promise<T> | T` hybrids first, filed as `convert-collection-removal-chain-to-sync-hybrid` (RFC 0084).

Verified: `packages/activerecord/src/associations/` (97 files, 1995 tests) green, activesupport cache suites green, `pnpm parity:api:calls` and `parity:api:calls:args` OK with no baseline row added, `pnpm typecheck` and `pnpm lint` clean.