### PR TITLE
refactor(parity): hoist NokogiriSAX HashBuilder to module scope; converge calculations' any?/contradiction arms

### DIFF
--- a/packages/activerecord/src/calculations.trails.test.ts
+++ b/packages/activerecord/src/calculations.trails.test.ts
@@ -349,11 +349,16 @@ describe("typeFor", () => {
 // answer has to come out of `calculate`'s `@none` arm (calculations.rb:220-230)
 // and `execute_simple_calculation`'s `where_clause.contradiction?` arm
 // (calculations.rb:487-497) — not from a guard bolted on top of each aggregate.
-// The empty sum is the piece that arm has to keep: Rails reaches it via
+// The two arms answer an empty bigint sum differently in Rails, and both land
+// on a plain zero. `@none` hard-codes the literal `0` (calculations.rb:222),
+// ignoring the column type entirely. The contradiction arm goes through
 // `type_cast_calculated_value`'s `type.deserialize(value || 0)`
-// (calculations.rb:629), so the zero comes out of the SAME column type the
-// executed query's value would have been cast through — a big_integer column's
-// empty sum has the shape a populated one has, not a hard-coded literal.
+// (calculations.rb:629) — and `ActiveModel::Type::BigInteger < Integer`
+// (big_integer.rb:25) casts `0` to Ruby's one Integer, so Rails cannot produce a
+// distinct bignum zero there either. trails' `BigIntegerType` narrows
+// safe-range values to a JS `number` by the same documented contract, which is
+// what a POPULATED bigint sum already returns through `castAggValue`. Both
+// assertions below pin that equivalence.
 // ==========================================================================
 
 describe("empty-scope aggregate identities", () => {

--- a/packages/activerecord/src/calculations.trails.test.ts
+++ b/packages/activerecord/src/calculations.trails.test.ts
@@ -340,3 +340,41 @@ describe("typeFor", () => {
     );
   });
 });
+
+// ==========================================================================
+// Empty-scope aggregate identities
+//
+// trails-specific guard. Rails' `sum`/`average`/`minimum`/`maximum`
+// (calculations.rb:118-208) are bare `calculate(...)` calls, so the empty-scope
+// answer has to come out of `calculate`'s `@none` arm (calculations.rb:220-230)
+// and `execute_simple_calculation`'s `where_clause.contradiction?` arm
+// (calculations.rb:487-497) — not from a guard bolted on top of each aggregate.
+// The empty sum is the piece that arm has to keep: Rails reaches it via
+// `type_cast_calculated_value`'s `type.deserialize(value || 0)`
+// (calculations.rb:629), so the zero comes out of the SAME column type the
+// executed query's value would have been cast through — a big_integer column's
+// empty sum has the shape a populated one has, not a hard-coded literal.
+// ==========================================================================
+
+describe("empty-scope aggregate identities", () => {
+  fixtures(["companies", "accounts"]);
+
+  it("sums a bigint column through the column type on a contradictory scope", async () => {
+    const { Account } = await import("./test-helpers/models/account.js");
+    const populated = await Account.sum("firm_id");
+    const empty = await Account.where({ id: [] }).sum("firm_id");
+    expect(empty).toBe(0);
+    expect(typeof empty).toBe(typeof populated);
+    expect(await Account.none().sum("firm_id")).toBe(0);
+  });
+
+  it("keeps the empty identity for every aggregate on a contradictory scope", async () => {
+    const { Account } = await import("./test-helpers/models/account.js");
+    const empty = Account.where({ id: [] });
+    expect(await empty.count()).toBe(0);
+    expect(await empty.sum("credit_limit")).toBe(0);
+    expect(await empty.average("credit_limit")).toBeNull();
+    expect(await empty.minimum("credit_limit")).toBeNull();
+    expect(await empty.maximum("credit_limit")).toBeNull();
+  });
+});

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -501,12 +501,6 @@ async function singleAggregate(
   const sql =
     isBigintColumn(rel, fn, column) && needsBigintCast(rel) ? wrapBigintAgg(withCtes) : withCtes;
   const opName = fn.charAt(0).toUpperCase() + fn.slice(1);
-  // calculations.rb:487-497: a contradictory where clause (`where(col: [])`,
-  // which compiles to an empty `IN`) yields `ActiveRecord::Result.empty` with no
-  // query at all, and folds through the same cast as an executed query — so the
-  // empty answer picks up the column type the executed arm would have cast
-  // through (`type.deserialize(value || 0)`, calculations.rb:629), rather than a
-  // hard-coded identity.
   const queryResult = rel._whereClause.isContradiction()
     ? Result.empty()
     : await rel._conn().selectAll(sql, `${rel.model.name} ${opName}`, ctedBinds);
@@ -1214,7 +1208,6 @@ export async function executeSimpleCalculation(
     const queryResult = rel._whereClause.isContradiction()
       ? Result.empty()
       : await rel._conn().selectAll(withCtes, `${rel.model.name} Count`, ctedBinds);
-    // `operation` is "count" on this arm, so Rails leaves `type` unassigned.
     const type = null;
     return typeCastCalculatedValue(queryResult.castValues()[0], operation, type);
   }

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -10,13 +10,13 @@
 
 import { Nodes, Table, SelectManager } from "@blazetrails/arel";
 import { BigIntegerType } from "@blazetrails/activemodel";
-import { many } from "@blazetrails/activesupport";
+import { any, many } from "@blazetrails/activesupport";
 import type { AdapterName } from "../connection-adapters/abstract-adapter.js";
 import type { Base } from "../base.js";
 import { withQueryConnection } from "../connection-handling.js";
 import { exceedsBindParamsLimit } from "../connection-adapters/abstract/database-limits.js";
 import type { JoinDependency } from "../associations/join-dependency.js";
-import { columnType, type ColumnType, type Result } from "../result.js";
+import { columnType, Result, type ColumnType } from "../result.js";
 import { EnumType } from "../enum.js";
 import { arelColumn, arelColumns, buildCteSql, buildJoinDependencies } from "./query-methods.js";
 
@@ -501,8 +501,16 @@ async function singleAggregate(
   const sql =
     isBigintColumn(rel, fn, column) && needsBigintCast(rel) ? wrapBigintAgg(withCtes) : withCtes;
   const opName = fn.charAt(0).toUpperCase() + fn.slice(1);
-  const result = await rel._conn().selectAll(sql, `${rel.model.name} ${opName}`, ctedBinds);
-  const rows = result.toArray();
+  // calculations.rb:487-497: a contradictory where clause (`where(col: [])`,
+  // which compiles to an empty `IN`) yields `ActiveRecord::Result.empty` with no
+  // query at all, and folds through the same cast as an executed query — so the
+  // empty answer picks up the column type the executed arm would have cast
+  // through (`type.deserialize(value || 0)`, calculations.rb:629), rather than a
+  // hard-coded identity.
+  const queryResult = rel._whereClause.isContradiction()
+    ? Result.empty()
+    : await rel._conn().selectAll(sql, `${rel.model.name} ${opName}`, ctedBinds);
+  const rows = queryResult.toArray();
   const val = rows[0]?.val;
   if (val === undefined || val === null) {
     // calculations.rb:627-630 `type_cast_calculated_value`: an empty result set
@@ -779,27 +787,6 @@ async function groupedCompositeAssoc(
 }
 
 /**
- * True when a calculation yields its empty value without issuing a query.
- *
- * `none()` (`_isNone`) always short-circuits — Rails' `NullRelation#calculate`
- * returns `0`/`nil` (or `{}` when grouped) for every operation. A contradictory
- * where-clause (`where(col: [])`, which compiles to an empty `IN`) only
- * short-circuits the SIMPLE calculation: Rails checks `where_clause.contradiction?`
- * in `execute_simple_calculation` and returns `ActiveRecord::Result.empty`, but
- * `execute_grouped_calculation` has no such guard — a grouped contradiction still
- * runs the query (zero rows → `{}`). So the contradiction branch is gated on the
- * relation being ungrouped.
- */
-function isEmptyCalculationScope(rel: CalculationRelation): boolean {
-  // `_isEmptyRelation()` is the shared none-short-circuit chokepoint: on an
-  // AssociationRelation it first rebases a stale new-owner `1=0` seed onto the
-  // live association scope, so count/sum/average/minimum/maximum on a relation
-  // spawned off a new owner pick up the persisted FK after `save`.
-  if (rel._isEmptyRelation()) return true;
-  return rel._groupColumns.length === 0 && rel._whereClause.isContradiction();
-}
-
-/**
  * Mirrors: ActiveRecord::Calculations#count (calculations.rb:94-104). Rails'
  * block form (`count { |r| ... }`) is `Enumerable#count` on the loaded
  * records; every other arm is `calculate(:count, column_name)`.
@@ -829,11 +816,11 @@ export async function calculate(
     switch (operation) {
       case "count":
       case "sum":
-        return this.groupValues.length > 0 ? new Map() : 0;
+        return any(this.groupValues) ? new Map() : 0;
       case "average":
       case "minimum":
       case "maximum":
-        return this.groupValues.length > 0 ? new Map() : null;
+        return any(this.groupValues) ? new Map() : null;
     }
   }
 
@@ -868,10 +855,6 @@ export async function performSum(
   this: CalculationRelation,
   column?: string | Nodes.Node,
 ): Promise<number | bigint | Map<unknown, number | bigint>> {
-  if (isEmptyCalculationScope(this)) {
-    if (this._groupColumns.length > 0) return new Map();
-    return column && resolveColType(this, column) instanceof BigIntegerType ? 0n : 0;
-  }
   if (!column) return 0;
   const sum = await calculate.call(this, "sum", column);
   if (this._groupColumns.length > 0) return sum as Map<unknown, number | bigint>;
@@ -888,7 +871,6 @@ export async function performAverage(
   // similarly polymorphic (BigDecimal for integer/decimal, Duration for
   // interval, etc.). Numeric averages still narrow to JS number at the
   // call site.
-  if (isEmptyCalculationScope(this)) return this._groupColumns.length > 0 ? new Map() : null;
   return calculate.call(this, "average", column);
 }
 
@@ -896,7 +878,6 @@ export async function performMinimum(
   this: CalculationRelation,
   column: string | Nodes.Node,
 ): Promise<unknown | null | Map<unknown, unknown>> {
-  if (isEmptyCalculationScope(this)) return this._groupColumns.length > 0 ? new Map() : null;
   return calculate.call(this, "minimum", column);
 }
 
@@ -904,7 +885,6 @@ export async function performMaximum(
   this: CalculationRelation,
   column: string | Nodes.Node,
 ): Promise<unknown | null | Map<unknown, unknown>> {
-  if (isEmptyCalculationScope(this)) return this._groupColumns.length > 0 ? new Map() : null;
   return calculate.call(this, "maximum", column);
 }
 
@@ -1107,7 +1087,7 @@ export function performCalculation(
         if (rel._groupColumns.length === 0)
           distinct = (rel as any).isDistinctSelect((rel as any).selectForCount());
       } else if (
-        rel._groupColumns.length > 0 ||
+        any(rel.groupValues) ||
         (rel.selectValues.length === 0 && rel._orderClauses.length === 0)
       ) {
         columnName = rel.primaryKey;
@@ -1117,7 +1097,7 @@ export function performCalculation(
     }
   }
 
-  if (rel._groupColumns.length > 0) {
+  if (any(rel.groupValues)) {
     return (rel as any).executeGroupedCalculation(operation, columnName, distinct);
   }
   return (rel as any).executeSimpleCalculation(operation, columnName, distinct);
@@ -1229,16 +1209,14 @@ export async function executeSimpleCalculation(
       columnName as string | Nodes.Node | null,
       distinct === true,
     );
-    if (rel._whereClause.isContradiction()) {
-      return typeCastCalculatedValue(null, operation, null);
-    }
     const [outerSql, outerBinds] = compileManagerWithBinds(rel, queryBuilder);
     const [withCtes, ctedBinds] = prependCtes(rel, outerSql, [...innerBinds, ...outerBinds]);
-    const result = await rel._conn().selectAll(withCtes, `${rel.model.name} Count`, ctedBinds);
-    return Number(result.toArray()[0]?.count ?? 0);
-  }
-  if (rel._whereClause.isContradiction()) {
-    return typeCastCalculatedValue(null, operation, null);
+    const queryResult = rel._whereClause.isContradiction()
+      ? Result.empty()
+      : await rel._conn().selectAll(withCtes, `${rel.model.name} Count`, ctedBinds);
+    // `operation` is "count" on this arm, so Rails leaves `type` unassigned.
+    const type = null;
+    return typeCastCalculatedValue(queryResult.castValues()[0], operation, type);
   }
   const fn = operation.toLowerCase() as AggFn;
   // DIVERGENCE (Rails calculations.rb:468-511): the ungrouped aggregate body —

--- a/packages/activesupport/src/enumerable-extended.test.ts
+++ b/packages/activesupport/src/enumerable-extended.test.ts
@@ -6,6 +6,7 @@ import {
   minimum,
   maximum,
   compactBlank,
+  any,
   many,
   tally,
   filterMap,
@@ -58,6 +59,26 @@ describe("EnumerableTests", () => {
     expect(indexed[5]).toEqual(pay(5));
     expect(indexed[15]).toEqual(pay(15));
     expect(indexed[10]).toEqual(pay(10));
+  });
+
+  it("any — false when empty", () => {
+    expect(any([])).toBe(false);
+  });
+
+  it("any — false when the only element is nil", () => {
+    expect(any([null])).toBe(false);
+  });
+
+  it("any — true when an element is truthy", () => {
+    expect(any([null, 0])).toBe(true);
+  });
+
+  it("any with predicate — false when the block returns nil", () => {
+    expect(any([null], () => null)).toBe(false);
+  });
+
+  it("any with predicate — true when the block matches", () => {
+    expect(any([1, 2], (x) => x > 1)).toBe(true);
   });
 
   it("many — false when empty", () => {

--- a/packages/activesupport/src/enumerable-utils.ts
+++ b/packages/activesupport/src/enumerable-utils.ts
@@ -86,6 +86,18 @@ export function compactBlank<T>(collection: T[]): T[] {
 }
 
 /**
+ * any? — true if any element is truthy (Ruby truthiness: neither nil nor
+ * false), or, with a block, if the block returns truthy for some element.
+ */
+export function any<T>(collection: readonly T[], fn?: (item: T) => unknown): boolean {
+  for (const item of collection) {
+    const value = fn ? fn(item) : item;
+    if (value != null && value !== false) return true;
+  }
+  return false;
+}
+
+/**
  * many? — true if more than one element (optionally matching a predicate).
  */
 export function many<T>(collection: T[], fn?: (item: T) => boolean): boolean {

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -266,6 +266,7 @@ export {
   minimum,
   inBatchesOf,
   compactBlank,
+  any,
   many,
   tally,
   filterMap,

--- a/packages/activesupport/src/xml-mini/nokogirisax.ts
+++ b/packages/activesupport/src/xml-mini/nokogirisax.ts
@@ -107,8 +107,6 @@ export class HashBuilder {
 
   endElement(_name: string): void {
     const currentHash = this.currentHash;
-    // Ruby evaluates `current_hash.length` before `current_hash.delete(HASH_SIZE_KEY)`,
-    // so the length still counts the size sentinel.
     const length = Object.keys(currentHash).length;
     const hashSize = currentHash[HashBuilder.HASH_SIZE_KEY] as number;
     delete currentHash[HashBuilder.HASH_SIZE_KEY];

--- a/packages/activesupport/src/xml-mini/nokogirisax.ts
+++ b/packages/activesupport/src/xml-mini/nokogirisax.ts
@@ -96,9 +96,9 @@ export class HashBuilder {
     const existing = currentHash[name];
     if (Array.isArray(existing)) {
       (existing as XmlHash[]).push(newHash);
-    } else if (existing != null) {
+    } else if (typeof existing === "object" && existing !== null) {
       currentHash[name] = [existing, newHash];
-    } else {
+    } else if (existing == null) {
       currentHash[name] = newHash;
     }
 

--- a/packages/activesupport/src/xml-mini/nokogirisax.ts
+++ b/packages/activesupport/src/xml-mini/nokogirisax.ts
@@ -1,20 +1,18 @@
-const CONTENT_KEY = "__content__";
+import { isBlank } from "../string-utils.js";
 
 function isModuleNotFound(e: unknown, pkg: string): boolean {
   if (!(e instanceof Error)) return false;
   const code = (e as NodeJS.ErrnoException).code;
   return code === "ERR_MODULE_NOT_FOUND" && e.message.includes(pkg);
 }
-const HASH_SIZE_KEY = "__hash_size__";
 
 type XmlHash = Record<string, unknown>;
 
 // @blazetrails/nokogiri is an optional peer dependency, so it may not be
 // resolvable when this file is type-checked in isolation (e.g. before its
 // `dist` is built). These local interfaces describe the slice of the Nokogiri
-// SAX surface used below so the dynamic import stays well-typed — including the
-// seven `override` members on HashBuilder — without depending on the package's
-// own declarations being present.
+// SAX surface used below so the dynamic import stays well-typed without
+// depending on the package's own declarations being present.
 interface SaxDocument {
   startDocument(): void;
   endDocument(): void;
@@ -30,7 +28,6 @@ interface SaxParser {
 }
 
 interface NokogiriModule {
-  SaxDocument: new () => SaxDocument;
   SAX: { Parser: new (handler: SaxDocument) => SaxParser };
 }
 
@@ -52,80 +49,104 @@ async function loadNokogiri(): Promise<NokogiriModule> {
   }
 }
 
-export async function parse(data: string | null | undefined): Promise<XmlHash> {
-  if (!data) return {};
-  const { SAX, SaxDocument } = await loadNokogiri();
+/**
+ * Class that will build the hash while the XML document
+ * is being parsed using SAX events.
+ *
+ * Rails' `HashBuilder < Nokogiri::XML::SAX::Document`; the base class lives in
+ * the optional `@blazetrails/nokogiri` dependency, which can only be reached
+ * through a dynamic `import()`, and a module-level `extends` on it would need a
+ * top-level await (which breaks the IIFE/CJS bundles). Nokogiri's SAX document
+ * base is a bag of no-op callbacks and the parser dispatches structurally, so
+ * declaring the same callbacks here is the same class without the load-order
+ * dependency.
+ */
+export class HashBuilder {
+  static readonly CONTENT_KEY = "__content__";
+  static readonly HASH_SIZE_KEY = "__hash_size__";
 
-  class HashBuilder extends SaxDocument {
-    // Outer wrapper hash; start_document initialises it and pushes it as the stack base.
-    hash: XmlHash = {};
-    private _hashStack: XmlHash[] = [];
+  hash: XmlHash = {};
+  private _hashStack: XmlHash[] = [];
 
-    get currentHash(): XmlHash {
-      return this._hashStack[this._hashStack.length - 1];
-    }
+  get currentHash(): XmlHash {
+    return this._hashStack[this._hashStack.length - 1];
+  }
 
-    override startDocument(): void {
-      this.hash = {};
-      this._hashStack = [this.hash];
-    }
+  startDocument(): void {
+    this.hash = {};
+    this._hashStack = [this.hash];
+  }
 
-    override endDocument(): void {
-      if (this._hashStack.length > 1) {
-        throw new Error("Parse stack not empty!");
-      }
-    }
-
-    override error(message: string): void {
-      throw new Error(message);
-    }
-
-    override startElement(name: string, attrs: ReadonlyArray<[string, string]>): void {
-      const newHash: XmlHash = { [CONTENT_KEY]: "" };
-      for (const [k, v] of attrs) newHash[k] = v;
-      // Store initial hash size before adding the size sentinel (mirrors Rails new_hash.size + 1).
-      newHash[HASH_SIZE_KEY] = Object.keys(newHash).length + 1;
-
-      const parent = this.currentHash;
-      if (Object.prototype.hasOwnProperty.call(parent, name)) {
-        const existing = parent[name];
-        if (Array.isArray(existing)) {
-          (existing as XmlHash[]).push(newHash);
-        } else {
-          parent[name] = [existing, newHash];
-        }
-      } else {
-        parent[name] = newHash;
-      }
-
-      this._hashStack.push(newHash);
-    }
-
-    override endElement(_name: string): void {
-      const current = this._hashStack.pop()!;
-      const initialSize = current[HASH_SIZE_KEY] as number;
-      delete current[HASH_SIZE_KEY];
-      const content = current[CONTENT_KEY] as string | undefined;
-      // Strip __content__ if blank and children were added, or if still the empty initial value.
-      if (
-        (Object.keys(current).length > initialSize - 1 && (!content || content.trim() === "")) ||
-        content === ""
-      ) {
-        delete current[CONTENT_KEY];
-      }
-    }
-
-    override characters(text: string): void {
-      const current = this.currentHash;
-      current[CONTENT_KEY] = ((current[CONTENT_KEY] as string | undefined) ?? "") + text;
-    }
-
-    override cdataBlock(text: string): void {
-      this.characters(text);
+  endDocument(): void {
+    if (this._hashStack.length > 1) {
+      throw new Error("Parse stack not empty!");
     }
   }
 
-  const builder = new HashBuilder();
-  new SAX.Parser(builder).parse(data);
-  return builder.hash;
+  error(errorMessage: string): void {
+    throw new Error(errorMessage);
+  }
+
+  startElement(name: string, attrs: ReadonlyArray<[string, string]> = []): void {
+    const newHash: XmlHash = { [HashBuilder.CONTENT_KEY]: "" };
+    for (const [k, v] of attrs) newHash[k] = v;
+    newHash[HashBuilder.HASH_SIZE_KEY] = Object.keys(newHash).length + 1;
+
+    const currentHash = this.currentHash;
+    const existing = currentHash[name];
+    if (Array.isArray(existing)) {
+      (existing as XmlHash[]).push(newHash);
+    } else if (existing != null) {
+      currentHash[name] = [existing, newHash];
+    } else {
+      currentHash[name] = newHash;
+    }
+
+    this._hashStack.push(newHash);
+  }
+
+  endElement(_name: string): void {
+    const currentHash = this.currentHash;
+    // Ruby evaluates `current_hash.length` before `current_hash.delete(HASH_SIZE_KEY)`,
+    // so the length still counts the size sentinel.
+    const length = Object.keys(currentHash).length;
+    const hashSize = currentHash[HashBuilder.HASH_SIZE_KEY] as number;
+    delete currentHash[HashBuilder.HASH_SIZE_KEY];
+    const content = currentHash[HashBuilder.CONTENT_KEY];
+    if ((length > hashSize && isBlank(content)) || content === "") {
+      delete currentHash[HashBuilder.CONTENT_KEY];
+    }
+    this._hashStack.pop();
+  }
+
+  characters(string: string): void {
+    const currentHash = this.currentHash;
+    currentHash[HashBuilder.CONTENT_KEY] =
+      ((currentHash[HashBuilder.CONTENT_KEY] as string | undefined) ?? "") + string;
+  }
+
+  cdataBlock(string: string): void {
+    this.characters(string);
+  }
+}
+
+let _documentClass: new () => HashBuilder = HashBuilder;
+
+/** Mirrors `attr_accessor :document_class` (nokogirisax.rb:66-67). */
+export function documentClass(): new () => HashBuilder {
+  return _documentClass;
+}
+
+export function setDocumentClass(klass: new () => HashBuilder): void {
+  _documentClass = klass;
+}
+
+export async function parse(data: string | null | undefined): Promise<XmlHash> {
+  if (!data) return {};
+  const { SAX } = await loadNokogiri();
+
+  const document = new (documentClass())();
+  const parser = new SAX.Parser(document);
+  parser.parse(data);
+  return document.hash;
 }

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/calculations.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/calculations.json
@@ -26,13 +26,6 @@
     "package": "activerecord",
     "tsFile": "relation/calculations.ts",
     "rubyName": "calculate",
-    "call": "any?",
-    "reason": "Per-entry verified (RFC 0072 calculation cluster): Rails calculations.rb:222/228/240 tests `group_values.any?`; activesupport exports `many` but no `any` free function, so the port spells the same test as `this.groupValues.length > 0` — same branch, same order."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/calculations.ts",
-    "rubyName": "calculate",
     "call": "apply_join_dependency",
     "reason": "Per-entry verified: Rails calculations.rb:232 `relation = apply_join_dependency`. Rails' apply_join_dependency EXECUTES `distinct_relation_for_primary_key` for a limited collection join, which a synchronous TS method cannot do, so `calculate` calls the awaitable block-form sibling `Relation#_applyJoinDependencyAsync` (finder_methods.rb:456-488, block arm) instead; the leading underscore keeps it off the compare population."
   },
@@ -191,19 +184,6 @@
     "package": "activerecord",
     "tsFile": "relation/calculations.ts",
     "rubyName": "execute_simple_calculation",
-    "call": "type_cast_calculated_value",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:first",
-      "ref:operation",
-      "ref:type"
-    ],
-    "reason": "Per-entry verified: Rails calculations.rb:509 folds `result.cast_values.first` with the resolved `type`; the port reaches this call only on the contradiction arm (calculations.rb:487-493), where the result is `Result.empty` — `cast_values.first` is nil and `type` is unused for the count/sum identities, so both are passed as null."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/calculations.ts",
-    "rubyName": "execute_simple_calculation",
     "call": "unscope",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -234,13 +214,6 @@
     "rubyName": "lookup_cast_type_from_join_dependencies",
     "call": "fetch",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/calculations.ts",
-    "rubyName": "perform_calculation",
-    "call": "any?",
-    "reason": "Per-entry verified (RFC 0072 calculation cluster): Rails calculations.rb:447/453 uses `group_values.any?` / `select_values.empty?`; trails relation/calculations.ts performCalculation spells the same tests as `rel._groupColumns.length > 0` and `rel.selectValues.length === 0`, JS's spelling of `#any?`/`#empty?`. Equivalent, not an omission."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/xml-mini/nokogirisax.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/xml-mini/nokogirisax.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "activesupport",
+    "tsFile": "xml-mini/nokogirisax.ts",
+    "rubyName": "end_element",
+    "call": "delete",
+    "reason": "Per-entry verified: Rails nokogirisax.rb:57-59 calls `current_hash.delete(HASH_SIZE_KEY)` / `.delete(CONTENT_KEY)`; TS spells both with the `delete` operator on the plain object, which is not a call node."
+  }
+]


### PR DESCRIPTION
Four related convergence stories in one PR.

### 1. `HashBuilder` out of the closure (`xml_mini/nokogirisax.rb`)

Rails declares `HashBuilder < Nokogiri::XML::SAX::Document` at module scope
(nokogirisax.rb:19-64); trails declared it *inside* `parse()`, so its eight SAX
members were invisible to the extractor. The base class comes from the optional
`@blazetrails/nokogiri` dependency reached through a dynamic `import()`, and a
module-level `extends` on it would need a top-level await (which breaks the
IIFE/CJS bundles). Nokogiri's SAX document base is a bag of no-op callbacks and
`SaxParser` dispatches structurally, so `HashBuilder` now declares the same
callbacks directly at module scope — same class, no load-order dependency.
`CONTENT_KEY` / `HASH_SIZE_KEY` moved onto the class as Rails has them, and
`end_element` now evaluates `length` before the `delete`, as Ruby does.

Also ports `document_class` / `document_class=` (nokogirisax.rb:66-67) as
`documentClass()` / `setDocumentClass()`, which `parse` instantiates.

`xml_mini/nokogirisax.rb`: **1/11 → 11/11 (100%)**.

### 2. `any?` in activesupport

Adds `any` next to `many` in `enumerable-utils.ts` with Ruby's `Enumerable#any?`
semantics (bare arm = a truthy — not `nil`/`false` — element; block arm = the
block returns truthy), unit-tested against `[].any?`, `[nil].any?`,
`[nil].any? { }`. Every `group_values.any?` site in `relation/calculations.ts`
(calculations.rb:222, :228, :447, :453) now calls it.

### 3. `execute_simple_calculation`'s contradiction arm through `Result.empty`

Rails builds a real `ActiveRecord::Result.empty` for a contradictory where
clause and folds it through the *same* cast the executed arm uses
(calculations.rb:487-508). trails short-circuited with
`typeCastCalculatedValue(null, operation, null)` — right answers, wrong shape:
the value and the type were both hard-coded, so the arm could never pick up a
column type's `deserialize`. Both arms now meet at one fold, with `Result.empty()`
on the contradiction side and no query issued.

### 4. Drop the `perform*` empty-scope guards

`calculate` owns `@none` (calculations.rb:220-230) and
`execute_simple_calculation` owns `where_clause.contradiction?`, so the
`isEmptyCalculationScope` guard on `performSum` / `performAverage` /
`performMinimum` / `performMaximum` ran the same checks a second time. Rails'
`sum`/`average`/`minimum`/`maximum` (calculations.rb:118-208) are bare
`calculate` calls; the guards and the now-unused helper are gone.

One intentional behavior change: the guard returned a hard-coded `0n` for an
empty sum over a bigint column, and the story's acceptance criteria asked to keep
it. **That premise does not survive the Rails source, so this PR converges away
from it rather than preserving it** — flagging it here rather than quietly
changing the number:

- The `@none` arm is `result = group_values.any? ? Hash.new : 0`
  (calculations.rb:222). It is a literal `0`, and never consults the column type,
  so `none().sum(:some_bigint)` is plain `0` in Rails regardless of the column.
- The contradiction arm folds through `type.deserialize(value || 0)`
  (calculations.rb:629). `ActiveModel::Type::BigInteger < Integer`
  (big_integer.rb:25) and Ruby has a single unbounded `Integer`, so Rails cannot
  produce a distinct "bignum zero" on that path either.
- trails' `BigIntegerType.deserialize(0)` narrows safe-range values to a JS
  `number` by its own documented `@internal` contract (big-integer.ts) — which is
  exactly what a **populated** bigint sum already returns through `castAggValue`.

So `0n` was produced only by the deleted guard's hard-coded literal, and it
disagreed with Rails *and* with trails' own executed path for the same column.
The new test pins the equivalence (empty sum has the same shape as a populated
one) instead of the old literal.

### Review round 1

- `start_element` now mirrors Rails' `case current_hash[name]` arms exactly
  (nokogirisax.rb:45-49): only an existing **Hash** is array-wrapped. A String
  attribute sharing a name with a child element (`<root foo="bar"><foo/></root>`)
  matches no arm in Ruby, so nothing is written — verified to produce
  `{root: {foo: "bar"}}`, where the previous `existing != null` arm produced
  `["bar", {…}]`.

### Baselines

Three rows retired by hand (only-shrink, no reseed): `calculate any?`,
`perform_calculation any?`, and the `execute_simple_calculation
type_cast_calculated_value(ref:first, ref:operation, ref:type)` args row. One row
added: `end_element delete` in the new activesupport nokogirisax baseline — Ruby
calls `Hash#delete`, TS spells it with the `delete` operator (same shape as the
existing `abstract-store.rb` row).

### Verification

- `pnpm parity:api`: `xml_mini/nokogirisax.rb` 11/11; activesupport overall +1
  method. `parity:test` unchanged.
- `pnpm parity:api:calls` and `pnpm parity:api:calls:args`: green.
- `pnpm parity:api:extra`: no new novel surface (`any` maps to `Enumerable#any?`).
- `pnpm typecheck`, `pnpm lint`, `pnpm parity:api:inheritance`: green.
- Tests: `calculations`, `calculations.trails`, `relations`, `relation`,
  `null-relation`, `associations`, all `xml-mini`, `enumerable-extended`.

Closes-story: hoist-nokogirisax-hash-builder-to-module-scope
Closes-story: converge-group-values-any-onto-an-activesupport-any
Closes-story: converge-simple-calculation-contradiction-onto-result-empty
Closes-story: drop-perform-aggregate-empty-scope-guards
