### PR TITLE
feat(activesupport): port Cache::Store's coder and serializer layer

### DIFF
--- a/packages/activesupport/src/cache.ts
+++ b/packages/activesupport/src/cache.ts
@@ -7,6 +7,7 @@ import "./cache/null-store.js";
 import "./cache/file-store.js";
 import { lookupStoreClass } from "./cache/store-registry.js";
 import type { CacheStore } from "./cache/index.js";
+import { getFormatVersion } from "./cache/format-version-slot.js";
 
 export { Store, ArgumentError, NotImplementedError, WriteOptions } from "./cache/store.js";
 export type { CacheLogger, StoreOptions } from "./cache/store.js";
@@ -23,18 +24,13 @@ class RuntimeError extends Error {
   }
 }
 
-/** Mirrors Rails `@format_version = 7.0` (cache.rb:55). */
-let _formatVersion = 7.0;
-
 /** Mirrors Rails `ActiveSupport::Cache.format_version` (cache.rb:58). */
 export function formatVersion(): number {
-  return _formatVersion;
+  return getFormatVersion();
 }
 
 /** Mirrors Rails `ActiveSupport::Cache.format_version=` (cache.rb:58). */
-export function setFormatVersion(value: number): void {
-  _formatVersion = value;
-}
+export { setFormatVersion } from "./cache/format-version-slot.js";
 
 /**
  * Creates a new Store object according to the given options. A Ruby Symbol is

--- a/packages/activesupport/src/cache/format-version-slot.ts
+++ b/packages/activesupport/src/cache/format-version-slot.ts
@@ -1,0 +1,23 @@
+// Zero-import slot for `ActiveSupport::Cache.format_version` (cache.rb:55-58).
+//
+// Ruby resolves `Cache.format_version` when `Store#default_serializer` /
+// `#validate_options` run (cache.rb:765, 921), so cache.rb can hold the state
+// and store.rb can read it without a load-order dependency. In ESM the import
+// is eager: `store.ts` importing `cache.ts` closes a cycle whose participants
+// include `class MemoryStore extends Store`, so entering the graph at
+// `store.ts` evaluates MemoryStore with Store still in TDZ. This module has no
+// runtime imports, so it cannot join that cycle; `cache.ts` exports the
+// Rails-named `formatVersion` / `setFormatVersion` over it.
+
+/** Mirrors Rails `@format_version = 7.0` (cache.rb:55). @internal */
+let _formatVersion = 7.0;
+
+/** @internal */
+export function getFormatVersion(): number {
+  return _formatVersion;
+}
+
+/** @internal */
+export function setFormatVersion(value: number): void {
+  _formatVersion = value;
+}

--- a/packages/activesupport/src/cache/memory-store.ts
+++ b/packages/activesupport/src/cache/memory-store.ts
@@ -1,7 +1,7 @@
 import type { CacheOptions, CacheStore } from "./index.js";
 import { coder } from "./coder.js";
 import { Entry } from "./entry.js";
-import { Store } from "./store.js";
+import { Store, type StoreOptions } from "./store.js";
 import { integer } from "./integer.js";
 import { registerStoreClass } from "./store-registry.js";
 
@@ -29,9 +29,10 @@ export class MemoryStore extends Store implements CacheStore {
   }
 
   // Rails stores the `serialize_entry` payload itself (`@data[key] = payload`,
-  // memory_store.rb:213-227), which for this store is a DupCoder-dumped `Entry`,
-  // and keeps the LRU order in the Hash — re-inserted on read (:204-208).
-  private data: Map<string, Entry> = new Map();
+  // memory_store.rb:213-227), which is a DupCoder-dumped `Entry` by default and
+  // a serializer's dumped string when the caller names one, and keeps the LRU
+  // order in the Hash — re-inserted on read (:204-208).
+  private data: Map<string, Entry | string> = new Map();
   private maxSize: number;
   private maxPruneTime: number;
   private cacheSize: number;
@@ -45,18 +46,29 @@ export class MemoryStore extends Store implements CacheStore {
     compress?: boolean;
     compressThreshold?: number;
     coder?: unknown;
+    serializer?: unknown;
   }) {
     // Rails installs DupCoder and disables compression by default
-    // (memory_store.rb:73-77).
-    super({ coder: DupCoder, compress: false, ...(options ?? {}) });
+    // (memory_store.rb:73-77); the coder is skipped when the caller named a
+    // `:coder` or a `:serializer` of their own.
+    const opts: StoreOptions = { ...(options ?? {}) };
+    if (!("coder" in opts) && !("serializer" in opts)) opts.coder = DupCoder;
+    if (!opts.compress) opts.compress = false;
+    super(opts);
     this.maxSize = options?.size ?? 32 * 1024 * 1024;
     this.maxPruneTime = options?.maxPruneTime ?? 2;
     this.cacheSize = 0;
   }
 
-  // Mirrors Rails MemoryStore#cached_size (memory_store.rb:198-200).
-  private cachedSize(key: string, payload: Entry): number {
-    return UTF8.encode(String(key)).length + payload.bytesize() + PER_ENTRY_OVERHEAD;
+  // Mirrors Rails MemoryStore#cached_size (memory_store.rb:198-200). Ruby's
+  // `payload.bytesize` reads the same on a Marshal/serializer String as on a
+  // DupCoder `Entry`; TS has to branch because JS strings have no such method.
+  private cachedSize(key: string, payload: Entry | string): number {
+    return (
+      UTF8.encode(String(key)).length +
+      (typeof payload === "string" ? UTF8.encode(payload).length : payload.bytesize()) +
+      PER_ENTRY_OVERHEAD
+    );
   }
 
   // Abstract entry hooks of the instrumented Store base, backed by the Map. The
@@ -73,12 +85,16 @@ export class MemoryStore extends Store implements CacheStore {
   }
 
   protected writeEntry(key: string, entry: Entry, options: Record<string, unknown>): boolean {
-    const payload = this.serializeEntry(entry, options) as Entry;
+    const payload = this.serializeEntry(entry, options) as Entry | string;
     if (options.unlessExist && this.exist(key, { namespace: null })) return false;
 
     const oldPayload = this.data.get(key);
     if (oldPayload !== undefined) {
-      this.cacheSize -= oldPayload.bytesize() - payload.bytesize();
+      // Ruby `old_payload.bytesize - payload.bytesize` (memory_store.rb:216)
+      // duck-types over String and Entry; JS strings have no `bytesize`.
+      this.cacheSize -=
+        (typeof oldPayload === "string" ? UTF8.encode(oldPayload).length : oldPayload.bytesize()) -
+        (typeof payload === "string" ? UTF8.encode(payload).length : payload.bytesize());
     } else {
       this.cacheSize += this.cachedSize(key, payload);
     }

--- a/packages/activesupport/src/cache/store.ts
+++ b/packages/activesupport/src/cache/store.ts
@@ -1,6 +1,7 @@
 import { Entry } from "./entry.js";
-import { Coder, coder as fidelityCoder } from "./coder.js";
-import { SerializerWithFallback } from "./serializer-with-fallback.js";
+import { Coder, type CoderCompressor, type CoderSerializer } from "./coder.js";
+import { SerializerWithFallback, type Serializer } from "./serializer-with-fallback.js";
+import { getFormatVersion } from "./format-version-slot.js";
 import { deflate, inflate } from "../gzip.js";
 import { DeserializationError } from "./deserialization-error.js";
 import { Notifications } from "../notifications.js";
@@ -9,6 +10,9 @@ import type { EventPayload } from "../notifications/instrumenter.js";
 
 /** Mirrors Rails `Cache::DEFAULT_COMPRESS_LIMIT` (cache.rb:45). */
 const DEFAULT_COMPRESS_LIMIT = 1024;
+
+/** Mirrors Ruby's `Zlib`, the default `:compressor` (cache.rb:305). */
+const Zlib: CoderCompressor = { deflate, inflate };
 
 /** Mirrors Ruby ArgumentError. @internal */
 export class ArgumentError extends Error {
@@ -111,8 +115,8 @@ export abstract class Store {
   protected coder: CacheCoder;
   protected coderSupportsCompression: boolean;
 
-  constructor(options: StoreOptions = {}) {
-    this.options = Store.normalizeOptions({ ...options });
+  constructor(options?: StoreOptions) {
+    this.options = options ? this.validateOptions(Store.normalizeOptions({ ...options })) : {};
 
     if (!("compress" in this.options)) this.options.compress = true;
     // Ruby `||=` replaces only nil/false, so an explicit `compress_threshold: 0`
@@ -127,7 +131,24 @@ export abstract class Store {
     const hadCoder = "coder" in this.options;
     let coder = this.options.coder as CacheCoder | null | undefined;
     delete this.options.coder;
-    if (!hadCoder) coder = new Coder(fidelityCoder, { deflate, inflate });
+    if (!hadCoder) {
+      const legacySerializer = getFormatVersion() < 7.1 && !this.options.serializer;
+      let serializer = this.options.serializer as Serializer | string | undefined;
+      delete this.options.serializer;
+      serializer ||= this.defaultSerializer();
+      // A Ruby Symbol is a colon-prefixed string in trails, which is what
+      // `serializer.is_a?(Symbol)` discriminates on (cache.rb:303).
+      if (typeof serializer === "string") {
+        serializer = SerializerWithFallback.get(serializer.slice(1));
+      }
+      const compressor =
+        "compressor" in this.options ? (this.options.compressor as CoderCompressor) : Zlib;
+      delete this.options.compressor;
+
+      coder = new Coder(serializer as unknown as CoderSerializer, compressor, {
+        legacySerializer,
+      });
+    }
     this.coder =
       coder == null || (coder as unknown) === false
         ? (SerializerWithFallback.get("passthrough") as CacheCoder)
@@ -428,6 +449,20 @@ export abstract class Store {
     ) as T;
   }
 
+  /** Mirrors Rails `Cache::Store#default_serializer` (cache.rb:764-773). */
+  private defaultSerializer(): Serializer {
+    switch (getFormatVersion()) {
+      case 7.0:
+        return SerializerWithFallback.get("marshal_7_0");
+      case 7.1:
+        return SerializerWithFallback.get("marshal_7_1");
+      default:
+        throw new ArgumentError(
+          `Unrecognized ActiveSupport::Cache.format_version: ${getFormatVersion()}`,
+        );
+    }
+  }
+
   protected abstract readEntry(key: string, options: StoreOptions): Entry | null;
   protected abstract writeEntry(key: string, entry: Entry, options: StoreOptions): boolean;
   protected abstract deleteEntry(key: string, options: StoreOptions): boolean;
@@ -531,6 +566,26 @@ export abstract class Store {
       delete opts.expired_in;
     }
     return opts;
+  }
+
+  /** Mirrors Rails `Cache::Store#validate_options` (cache.rb:912-925). */
+  private validateOptions(options: StoreOptions): StoreOptions {
+    if ("coder" in options && options.serializer) {
+      throw new ArgumentError("Cannot specify :serializer and :coder options together");
+    }
+
+    if ("coder" in options && options.compressor) {
+      throw new ArgumentError("Cannot specify :compressor and :coder options together");
+    }
+
+    if (getFormatVersion() < 7.1 && !options.serializer && options.compressor) {
+      throw new ArgumentError(
+        "Cannot specify :compressor option when using" +
+          " default serializer and cache format version is < 7.1",
+      );
+    }
+
+    return options;
   }
 
   /** Mirrors Rails `Cache::Store#handle_invalid_expires_in` (cache.rb:892–898). */

--- a/packages/activesupport/src/cache/stores/memory-store.test.ts
+++ b/packages/activesupport/src/cache/stores/memory-store.test.ts
@@ -1,7 +1,14 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { MemoryStore } from "../memory-store.js";
 import { Entry } from "../entry.js";
+import { coder } from "../coder.js";
+import { setFormatVersion } from "../format-version-slot.js";
 import { Notifications } from "../../notifications.js";
+
+// Rails calls the private `serialize_entry` through `send` (cache_store_coder_behavior.rb:90).
+function serializeEntry(store: MemoryStore, entry: Entry): unknown {
+  return (store as unknown as { serializeEntry(entry: Entry): unknown }).serializeEntry(entry);
+}
 
 // Mirrors Rails' `MemoryStore.new.send(:cached_size, 1, Entry.new("aaaaaaaaaa"))`
 // (memory_store_test.rb:101-104), the record size the pruning budget is sized in.
@@ -406,5 +413,117 @@ describe("MemoryStore coder fidelity", () => {
     expect(r1).not.toBe(r2);
     r1.nested.count = 42;
     expect(r2.nested.count).toBe(1);
+  });
+});
+
+// Port of Rails' CacheStoreCoderBehavior (test/cache/behaviors/cache_store_coder_behavior.rb).
+// SpyCoder mirrors the Rails double; the fidelity `coder` (cache/coder.ts) stands
+// in for Marshal, so a dumped entry is its packed members.
+class SpyCoder {
+  dumpedEntries: Entry[] = [];
+  loadedEntries: Entry[] = [];
+  dumpCompressedEntries: Entry[] = [];
+
+  dump(entry: Entry): string {
+    this.dumpedEntries.push(entry);
+    return coder.dump(entry.pack());
+  }
+
+  load(payload: string): Entry {
+    const entry = Entry.unpack(coder.load(payload) as unknown[]);
+    this.loadedEntries.push(entry);
+    return entry;
+  }
+
+  dumpCompressed(entry: Entry, threshold: number): string {
+    if (threshold === 0) {
+      this.dumpCompressedEntries.push(entry);
+      return coder.dump(entry.pack());
+    } else {
+      return this.dump(entry);
+    }
+  }
+}
+
+describe("CacheStoreCoderBehavior", () => {
+  it("test_coder_receive_the_entry_on_write", () => {
+    const spy = new SpyCoder();
+    const store = new MemoryStore({ coder: spy });
+    store.write("foo", "bar");
+    expect(spy.dumpedEntries.length).toBe(1);
+    const entry = spy.dumpedEntries[0];
+    expect(entry).toBeInstanceOf(Entry);
+    expect(entry.value).toBe("bar");
+  });
+
+  it("test_coder_receive_the_entry_on_read", () => {
+    const spy = new SpyCoder();
+    const store = new MemoryStore({ coder: spy });
+    store.write("foo", "bar");
+    store.read("foo");
+    expect(spy.loadedEntries.length).toBe(1);
+    const entry = spy.loadedEntries[0];
+    expect(entry).toBeInstanceOf(Entry);
+    expect(entry.value).toBe("bar");
+  });
+
+  it("test_coder_receive_the_entry_on_write_multi", () => {
+    const spy = new SpyCoder();
+    const store = new MemoryStore({ coder: spy });
+    store.writeMulti({ foo: "bar", egg: "spam" });
+    expect(spy.dumpedEntries.length).toBe(2);
+    expect(spy.dumpedEntries[0].value).toBe("bar");
+    expect(spy.dumpedEntries[1].value).toBe("spam");
+  });
+
+  it("test_coder_does_not_receive_the_entry_on_read_miss", () => {
+    const spy = new SpyCoder();
+    const store = new MemoryStore({ coder: spy });
+    store.read("foo");
+    expect(spy.loadedEntries.length).toBe(0);
+  });
+
+  it("test_nil_coder_bypasses_serialization", () => {
+    const store = new MemoryStore({ coder: null });
+    const entry = new Entry("value");
+    expect(serializeEntry(store, entry)).toBe(entry);
+  });
+});
+
+// Port of Rails' CacheStoreSerializerBehavior
+// (test/cache/behaviors/cache_store_serializer_behavior.rb).
+describe("CacheStoreSerializerBehavior", () => {
+  afterEach(() => {
+    setFormatVersion(7.0);
+  });
+
+  it("serializer can be specified", () => {
+    const serializer = {
+      dump(value: unknown): string {
+        return (value as object).constructor.name;
+      },
+      load(dumped: string): unknown {
+        return dumped;
+      },
+    };
+
+    setFormatVersion(7.1);
+    const cache = new MemoryStore({ serializer });
+    cache.write("key", 123);
+    expect(cache.read("key")).toBe("Number");
+  });
+
+  it("serializer can be :message_pack", () => {
+    setFormatVersion(7.1);
+    const cache = new MemoryStore({ serializer: ":message_pack" });
+    cache.write("key", 123);
+    expect(cache.read("key")).toBe(123);
+  });
+
+  it("specifying a serializer raises when also specifying a coder", () => {
+    setFormatVersion(7.1);
+    expect(() => new MemoryStore({ serializer: ":marshal_7_1", coder: null })).toThrow(
+      /serializer/i,
+    );
   });
 });

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/cache.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/cache.json
@@ -23,19 +23,6 @@
   {
     "package": "activesupport",
     "tsFile": "cache.ts",
-    "rubyName": "initialize",
-    "call": "new",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:serializer",
-      "ref:compressor",
-      "kwargs{legacySerializer=ref:legacySerializer}"
-    ],
-    "reason": "`legacy_serializer` rides Cache.format_version and the :serializer option (cache.rb:302-307), neither of which the Store options seam carries yet; the compressor is the trails deflate/inflate pair standing in for Zlib."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "cache.ts",
     "rubyName": "key_matcher",
     "call": "call",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Completes the `Cache::Store` coder layer. #6437 landed the `@coder` seam with a
hardcoded `Cache::Coder` over the fidelity coder; this PR builds that coder the
way Rails does and adds the two methods it needs.

## What landed

- **`Store#initialize`** (cache.rb:294-311) builds `@coder` from
  `@options.delete(:serializer) || default_serializer` (Symbol arm included),
  `@options.delete(:compressor) { Zlib }`, and `legacy_serializer`, and runs
  `validate_options(normalize_options(options))`.
- **`default_serializer`** (cache.rb:764-773) — `marshal_7_0` / `marshal_7_1`
  keyed off `Cache.format_version`, `ArgumentError` otherwise.
- **`validate_options`** (cache.rb:912-925) — all three `ArgumentError` arms.
- **`MemoryStore#initialize`** installs `DupCoder` only `unless options.key?(:coder) || options.key?(:serializer)`
  (memory_store.rb:73-75) — the previous unconditional install would now collide
  with `validate_options` when a caller names a serializer.
- `MemoryStore`'s payload can therefore be a serializer's dumped string, so
  `cached_size` / `write_entry` size it the way Ruby's duck-typed
  `payload.bytesize` does over String and Entry (memory_store.rb:199, 216).

## Notes

- `Cache.format_version` state moves into a zero-import slot
  (`cache/format-version-slot.ts`). `store.ts` reads it at call time, where Ruby
  resolves the constant; importing `cache.ts` directly would close a module cycle
  whose participants include `class MemoryStore extends Store`.
- Ports Rails' `CacheStoreCoderBehavior` and `CacheStoreSerializerBehavior`
  against `MemoryStore`.
- Retires the now-converged `Coder.new(serializer, compressor, legacy_serializer:)`
  call-argument baseline row — the body passes what Rails passes.
- `parity:api` activesupport: `cache.rb` 62/63, `memory_store.rb` 17/19.

Closes-story: port-cache-store-coder-and-serializer-layer
