### PR TITLE
feat(activesupport): port XmlMini's backend registry, parse delegation and PARSING typecast helpers

### DIFF
--- a/packages/activesupport/src/xml-mini.test.ts
+++ b/packages/activesupport/src/xml-mini.test.ts
@@ -216,9 +216,9 @@ describe("ToTagTest", () => {
 
 // Rails' `module REXML end` stand-ins: a backend is anything answering #parse,
 // and these are only ever compared by identity.
-const REXML: XmlMiniBackend = { parse: () => ({}) };
-const LibXML: XmlMiniBackend = { parse: () => ({}) };
-const Nokogiri: XmlMiniBackend = { parse: () => ({}) };
+const REXML: XmlMiniBackend = { parse: async () => ({}) };
+const LibXML: XmlMiniBackend = { parse: async () => ({}) };
+const Nokogiri: XmlMiniBackend = { parse: async () => ({}) };
 
 describe("WithBackendTest", () => {
   let defaultBackend: XmlMiniBackend | null | undefined;

--- a/packages/activesupport/src/xml-mini.test.ts
+++ b/packages/activesupport/src/xml-mini.test.ts
@@ -1,5 +1,15 @@
-import { describe, it, expect, beforeEach } from "vitest";
-import { renameKey, toTag, XmlStringBuilder, type ToTagOptions } from "./xml-mini.js";
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import {
+  backend,
+  renameKey,
+  setBackend,
+  toTag,
+  withBackend,
+  XmlStringBuilder,
+  type ToTagOptions,
+  type XmlMiniBackend,
+} from "./xml-mini.js";
+import { IsolatedExecutionState } from "./isolated-execution-state.js";
 import { BigDecimal } from "./core-ext/big-decimal/conversions.js";
 import { Temporal } from "@blazetrails/date";
 
@@ -201,5 +211,102 @@ describe("ToTagTest", () => {
   it("#to_tag emits an empty array as a self-closing tag", () => {
     toTag("b", [], options);
     expect(builder.target()).toBe('<b type="array"/>');
+  });
+});
+
+// Rails' `module REXML end` stand-ins: a backend is anything answering #parse,
+// and these are only ever compared by identity.
+const REXML: XmlMiniBackend = { parse: () => ({}) };
+const LibXML: XmlMiniBackend = { parse: () => ({}) };
+const Nokogiri: XmlMiniBackend = { parse: () => ({}) };
+
+describe("WithBackendTest", () => {
+  let defaultBackend: XmlMiniBackend | null | undefined;
+
+  beforeEach(() => {
+    defaultBackend = backend();
+  });
+
+  afterEach(async () => {
+    await setBackend(defaultBackend);
+  });
+
+  it("#with_backend should switch backend and then switch back", async () => {
+    await setBackend(REXML);
+    await withBackend(LibXML, async () => {
+      expect(backend()).toBe(LibXML);
+      await withBackend(Nokogiri, () => {
+        expect(backend()).toBe(Nokogiri);
+      });
+      expect(backend()).toBe(LibXML);
+    });
+    expect(backend()).toBe(REXML);
+  });
+
+  it("backend switch inside #with_backend block", async () => {
+    await withBackend(LibXML, async () => {
+      await setBackend(REXML);
+      expect(backend()).toBe(REXML);
+    });
+    expect(backend()).toBe(REXML);
+  });
+});
+
+describe("ThreadSafetyTest", () => {
+  let defaultBackend: XmlMiniBackend | null | undefined;
+
+  beforeEach(() => {
+    defaultBackend = backend();
+  });
+
+  afterEach(async () => {
+    await setBackend(defaultBackend);
+  });
+
+  /**
+   * The Rails tests spawn a Thread and `sleep 0.1 while t.status != "sleep"`.
+   * The trails analog of a thread is an isolated execution state
+   * (AsyncLocalStorage), and the analog of waiting for it to park is awaiting
+   * the signal it sends from inside the block.
+   */
+  function spawn(name: XmlMiniBackend): { entered: Promise<void>; join: () => Promise<void> } {
+    let signalEntered!: () => void;
+    let release!: () => void;
+    const entered = new Promise<void>((resolve) => (signalEntered = resolve));
+    const sleep = new Promise<void>((resolve) => (release = resolve));
+    const thread = IsolatedExecutionState.run(() =>
+      withBackend(name, () => {
+        signalEntered();
+        return sleep;
+      }),
+    );
+    return {
+      entered,
+      join: async () => {
+        release();
+        await thread;
+      },
+    };
+  }
+
+  it("#with_backend should be thread-safe", async () => {
+    await setBackend(REXML);
+    const t = spawn(LibXML);
+    await t.entered;
+
+    // We should get `old_backend` here even while another
+    // execution state is using `new_backend`.
+    expect(backend()).toBe(REXML);
+    await t.join();
+  });
+
+  it("nested #with_backend should be thread-safe", async () => {
+    await withBackend(REXML, async () => {
+      const t = spawn(LibXML);
+      await t.entered;
+
+      expect(backend()).toBe(REXML);
+      await t.join();
+    });
   });
 });

--- a/packages/activesupport/src/xml-mini.trails.test.ts
+++ b/packages/activesupport/src/xml-mini.trails.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { _parseBinary, _parseFile, _parseHexBinary, FileLike } from "./xml-mini.js";
+
+// Rails exercises these through `XmlMini::PARSING` (xml_mini_test.rb:248) and
+// `Hash.from_xml` (xml_mini_engine_test.rb:36), neither of which is ported yet,
+// so the helpers are covered directly here.
+describe("XmlMini", () => {
+  it("_parse_hex_binary decodes hex to bytes", () => {
+    expect(_parseHexBinary("48656C6C6F2C20576F726C6421")).toBe("Hello, World!");
+  });
+
+  it("_parse_binary decodes according to the entity encoding", () => {
+    expect(_parseBinary("SGVsbG8=", { encoding: "base64" })).toBe("Hello");
+    expect(_parseBinary("48656C6C6F", { encoding: "hex" })).toBe("Hello");
+    expect(_parseBinary("48656C6C6F", { encoding: "hexBinary" })).toBe("Hello");
+    expect(_parseBinary("IGNORED INPUT", {})).toBe("IGNORED INPUT");
+  });
+
+  it("_parse_file returns the decoded content decorated with FileLike", async () => {
+    const file = _parseFile("SGVsbG8=", { name: "logo.png", content_type: "image/png" });
+    expect(await file.text()).toBe("Hello");
+    expect(file.originalFilename).toBe("logo.png");
+    expect(file.contentType).toBe("image/png");
+  });
+
+  it("_parse_file falls back to the FileLike defaults", () => {
+    const file = _parseFile("SGVsbG8=", {});
+    expect(file.originalFilename).toBe("untitled");
+    expect(file.contentType).toBe("application/octet-stream");
+  });
+
+  it("FileLike readers default until written", () => {
+    const f = Object.defineProperties(
+      {},
+      Object.getOwnPropertyDescriptors(FileLike),
+    ) as typeof FileLike;
+    expect(f.originalFilename).toBe("untitled");
+    f.originalFilename = "avatar.gif";
+    expect(f.originalFilename).toBe("avatar.gif");
+  });
+});

--- a/packages/activesupport/src/xml-mini.ts
+++ b/packages/activesupport/src/xml-mini.ts
@@ -41,9 +41,13 @@ export const FileLike = {
  * `require`s `active_support/xml_mini/<name>` and reads the constant out of
  * `ActiveSupport`; here the module namespace object of
  * `./xml-mini/<name>.js` *is* that module.
+ *
+ * Rails' backends return the parsed Hash synchronously; ours are async because
+ * each loads its optional parser package (`@blazetrails/nokogiri`) through a
+ * dynamic import — see `xml-mini/nokogirisax.ts:55` and `xml-mini/nokogiri.ts:99`.
  */
 export interface XmlMiniBackend {
-  parse(data: string | null | undefined): unknown;
+  parse(data: string | null | undefined): Promise<Record<string, unknown>>;
 }
 
 /** The name of a backend, or the backend module itself. */
@@ -54,6 +58,143 @@ export interface RenameKeyOptions {
   dasherize?: boolean;
   /** Camelize the key first: `true`/`"upper"` for UpperCamel, `"lower"` for lowerCamel. */
   camelize?: boolean | "lower" | "upper";
+}
+
+/**
+ * The backend `parse` delegates to (Ruby's `@backend`). Rails'
+ * `XmlMini.backend = "REXML"` (xml_mini.rb:210) has no counterpart yet:
+ * `XmlMini_REXML` is unported, so there is no default and `parse` raises until
+ * a backend is set.
+ *
+ * @internal
+ */
+let _backend: XmlMiniBackend | null | undefined;
+
+/**
+ * Parse an XML document into a hash through the current backend.
+ *
+ * Mirrors: `delegate :parse, to: :backend` (xml_mini.rb:99) — awaitable because
+ * every backend's `parse` is (see {@link XmlMiniBackend}); the delegation itself
+ * still forwards straight to the selected backend.
+ */
+export function parse(data: string | null | undefined): Promise<Record<string, unknown>> {
+  return backend()!.parse(data);
+}
+
+/**
+ * The backend in effect: the execution-state-scoped override set by
+ * {@link withBackend} if there is one, else the process-wide backend.
+ *
+ * Mirrors: ActiveSupport::XmlMini.backend (xml_mini.rb:101-103).
+ *
+ * @missingRailsCall cast_backend_name_to_module — belongs to `backend=`, which
+ * the call gate pairs with this reader (the bare-camel candidate wins over
+ * `setBackend`); {@link setBackend} makes the call.
+ */
+export function backend(): XmlMiniBackend | null | undefined {
+  return currentThreadBackend() ?? _backend;
+}
+
+/**
+ * Set the process-wide backend, by name or module.
+ *
+ * Mirrors: ActiveSupport::XmlMini#backend= (xml_mini.rb:105-109) — awaitable
+ * because resolving a name imports the backend module, which Ruby does
+ * synchronously via `require`.
+ */
+export async function setBackend(name: XmlMiniBackendName | null | undefined): Promise<void> {
+  const backend = name != null ? await castBackendNameToModule(name) : name;
+  if (currentThreadBackend() != null) await setCurrentThreadBackend(backend);
+  _backend = backend;
+}
+
+/**
+ * Run `fn` with `name` as the backend, restoring the previous
+ * execution-state-scoped backend afterwards.
+ *
+ * Mirrors: ActiveSupport::XmlMini#with_backend (xml_mini.rb:111-117).
+ */
+export async function withBackend<T>(
+  name: XmlMiniBackendName | null | undefined,
+  fn: () => T | Promise<T>,
+): Promise<T> {
+  const oldBackend = currentThreadBackend();
+  try {
+    await setCurrentThreadBackend(name != null ? await castBackendNameToModule(name) : name);
+    return await fn();
+  } finally {
+    await setCurrentThreadBackend(oldBackend);
+  }
+}
+
+/**
+ * The execution-state-scoped backend override.
+ *
+ * Mirrors: ActiveSupport::XmlMini#current_thread_backend (xml_mini.rb:192-194).
+ *
+ * @missingRailsCall cast_backend_name_to_module — belongs to
+ * `current_thread_backend=`, which the call gate pairs with this reader (the
+ * bare-camel candidate wins over `setCurrentThreadBackend`);
+ * {@link setCurrentThreadBackend} makes the call.
+ *
+ * @internal
+ */
+export function currentThreadBackend(): XmlMiniBackend | null | undefined {
+  return IsolatedExecutionState.get("xml_mini_backend");
+}
+
+/**
+ * Mirrors: ActiveSupport::XmlMini#current_thread_backend= (xml_mini.rb:196-198).
+ *
+ * @internal
+ */
+export async function setCurrentThreadBackend(
+  name: XmlMiniBackendName | null | undefined,
+): Promise<void> {
+  IsolatedExecutionState.set(
+    "xml_mini_backend",
+    name != null ? await castBackendNameToModule(name) : name,
+  );
+}
+
+/**
+ * Resolve a backend name to its module, loading the module the first time.
+ *
+ * Mirrors: ActiveSupport::XmlMini#cast_backend_name_to_module
+ * (xml_mini.rb:200-206) — Ruby's `require
+ * "active_support/xml_mini/#{name.downcase}"` plus `const_get "XmlMini_#{name}"`
+ * is one dynamic import here, since the module namespace object of
+ * `xml-mini/<name>.js` is the backend module.
+ *
+ * @internal
+ */
+export async function castBackendNameToModule(name: XmlMiniBackendName): Promise<XmlMiniBackend> {
+  if (typeof name !== "string") {
+    return name;
+  } else {
+    return (await import(`./xml-mini/${name.toLowerCase()}.js`)) as XmlMiniBackend;
+  }
+}
+
+/**
+ * Apply the `camelize`/`dasherize` key transforms to a single XML tag name.
+ *
+ * Mirrors: ActiveSupport::XmlMini.rename_key (xml_mini.rb:154-161) — camelize (when requested) runs
+ * first, then dasherize (default `true`) runs on the result. Both transforms
+ * compose exactly as in Rails, so `camelize: true` still passes through
+ * `_dasherize` (a no-op on an already-camelized, underscore-free key).
+ */
+export function renameKey(key: string, options: RenameKeyOptions = {}): string {
+  const { camelize: camelizeOpt } = options;
+  const dasherize = options.dasherize === undefined || options.dasherize;
+  let result = key;
+  if (camelizeOpt) {
+    result = camelizeOpt === true ? camelize(result) : camelize(result, camelizeOpt);
+  }
+  if (dasherize) {
+    result = _dasherize(result);
+  }
+  return result;
 }
 
 /**
@@ -126,27 +267,6 @@ export function _parseFile(
  */
 export function _parseHexBinary(bin: string): string {
   return Buffer.from(bin, "hex").toString("binary");
-}
-
-/**
- * Apply the `camelize`/`dasherize` key transforms to a single XML tag name.
- *
- * Mirrors: ActiveSupport::XmlMini.rename_key (xml_mini.rb:154-161) — camelize (when requested) runs
- * first, then dasherize (default `true`) runs on the result. Both transforms
- * compose exactly as in Rails, so `camelize: true` still passes through
- * `_dasherize` (a no-op on an already-camelized, underscore-free key).
- */
-export function renameKey(key: string, options: RenameKeyOptions = {}): string {
-  const { camelize: camelizeOpt } = options;
-  const dasherize = options.dasherize === undefined || options.dasherize;
-  let result = key;
-  if (camelizeOpt) {
-    result = camelizeOpt === true ? camelize(result) : camelize(result, camelizeOpt);
-  }
-  if (dasherize) {
-    result = _dasherize(result);
-  }
-  return result;
 }
 
 /**
@@ -253,120 +373,6 @@ function encode64(value: unknown): string {
  */
 function decode64(value: string): string {
   return Buffer.from(value, "base64").toString("binary");
-}
-
-/**
- * The backend `parse` delegates to (Ruby's `@backend`). Rails'
- * `XmlMini.backend = "REXML"` (xml_mini.rb:210) has no counterpart yet:
- * `XmlMini_REXML` is unported, so there is no default and `parse` raises until
- * a backend is set.
- *
- * @internal
- */
-let _backend: XmlMiniBackend | null | undefined;
-
-/**
- * Parse an XML document into a hash through the current backend.
- *
- * Mirrors: `delegate :parse, to: :backend` (xml_mini.rb:99).
- */
-export function parse(data: string | null | undefined): unknown {
-  return backend()!.parse(data);
-}
-
-/**
- * The backend in effect: the execution-state-scoped override set by
- * {@link withBackend} if there is one, else the process-wide backend.
- *
- * Mirrors: ActiveSupport::XmlMini.backend (xml_mini.rb:101-103).
- *
- * @missingRailsCall cast_backend_name_to_module — belongs to `backend=`, which
- * the call gate pairs with this reader (the bare-camel candidate wins over
- * `setBackend`); {@link setBackend} makes the call.
- */
-export function backend(): XmlMiniBackend | null | undefined {
-  return currentThreadBackend() ?? _backend;
-}
-
-/**
- * Set the process-wide backend, by name or module.
- *
- * Mirrors: ActiveSupport::XmlMini#backend= (xml_mini.rb:105-109) — awaitable
- * because resolving a name imports the backend module, which Ruby does
- * synchronously via `require`.
- */
-export async function setBackend(name: XmlMiniBackendName | null | undefined): Promise<void> {
-  const backend = name != null ? await castBackendNameToModule(name) : name;
-  if (currentThreadBackend() != null) await setCurrentThreadBackend(backend);
-  _backend = backend;
-}
-
-/**
- * Run `fn` with `name` as the backend, restoring the previous
- * execution-state-scoped backend afterwards.
- *
- * Mirrors: ActiveSupport::XmlMini#with_backend (xml_mini.rb:111-117).
- */
-export async function withBackend<T>(
-  name: XmlMiniBackendName | null | undefined,
-  fn: () => T | Promise<T>,
-): Promise<T> {
-  const oldBackend = currentThreadBackend();
-  try {
-    await setCurrentThreadBackend(name != null ? await castBackendNameToModule(name) : name);
-    return await fn();
-  } finally {
-    await setCurrentThreadBackend(oldBackend);
-  }
-}
-
-/**
- * The execution-state-scoped backend override.
- *
- * Mirrors: ActiveSupport::XmlMini#current_thread_backend (xml_mini.rb:192-194).
- *
- * @missingRailsCall cast_backend_name_to_module — belongs to
- * `current_thread_backend=`, which the call gate pairs with this reader (the
- * bare-camel candidate wins over `setCurrentThreadBackend`);
- * {@link setCurrentThreadBackend} makes the call.
- *
- * @internal
- */
-export function currentThreadBackend(): XmlMiniBackend | null | undefined {
-  return IsolatedExecutionState.get("xml_mini_backend");
-}
-
-/**
- * Mirrors: ActiveSupport::XmlMini#current_thread_backend= (xml_mini.rb:196-198).
- *
- * @internal
- */
-export async function setCurrentThreadBackend(
-  name: XmlMiniBackendName | null | undefined,
-): Promise<void> {
-  IsolatedExecutionState.set(
-    "xml_mini_backend",
-    name != null ? await castBackendNameToModule(name) : name,
-  );
-}
-
-/**
- * Resolve a backend name to its module, loading the module the first time.
- *
- * Mirrors: ActiveSupport::XmlMini#cast_backend_name_to_module
- * (xml_mini.rb:200-206) — Ruby's `require
- * "active_support/xml_mini/#{name.downcase}"` plus `const_get "XmlMini_#{name}"`
- * is one dynamic import here, since the module namespace object of
- * `xml-mini/<name>.js` is the backend module.
- *
- * @internal
- */
-export async function castBackendNameToModule(name: XmlMiniBackendName): Promise<XmlMiniBackend> {
-  if (typeof name !== "string") {
-    return name;
-  } else {
-    return (await import(`./xml-mini/${name.toLowerCase()}.js`)) as XmlMiniBackend;
-  }
 }
 
 function formatDateTime(value: unknown): string {

--- a/packages/activesupport/src/xml-mini.ts
+++ b/packages/activesupport/src/xml-mini.ts
@@ -1,7 +1,53 @@
 import { camelize, singularize, underscore } from "./inflector.js";
 import { htmlEscape } from "./core-ext/tse/util.js";
 import { BigDecimal } from "./core-ext/big-decimal/conversions.js";
+import { IsolatedExecutionState } from "./isolated-execution-state.js";
 import { Temporal } from "@blazetrails/date";
+
+/**
+ * This object decorates files deserialized using `Hash.fromXml` with the
+ * `originalFilename` and `contentType` methods.
+ *
+ * Mirrors: ActiveSupport::XmlMini::FileLike (xml_mini.rb:22-31) — a Ruby module
+ * `_parseFile` `extend`s onto the StringIO it returns, so the descriptors are
+ * copied onto that object rather than inherited from a class.
+ */
+export const FileLike = {
+  /** @internal `@original_filename` */
+  _originalFilename: undefined as string | undefined,
+  /** @internal `@content_type` */
+  _contentType: undefined as string | undefined,
+
+  set originalFilename(value: string | undefined) {
+    this._originalFilename = value;
+  },
+
+  set contentType(value: string | undefined) {
+    this._contentType = value;
+  },
+
+  get originalFilename(): string {
+    return this._originalFilename ?? "untitled";
+  },
+
+  get contentType(): string {
+    return this._contentType ?? "application/octet-stream";
+  },
+};
+
+/**
+ * A pluggable parse backend — the trails analog of the `XmlMini_REXML`,
+ * `XmlMini_Nokogiri`, … modules `backend` holds (xml_mini.rb:101-109). Rails
+ * `require`s `active_support/xml_mini/<name>` and reads the constant out of
+ * `ActiveSupport`; here the module namespace object of
+ * `./xml-mini/<name>.js` *is* that module.
+ */
+export interface XmlMiniBackend {
+  parse(data: string | null | undefined): unknown;
+}
+
+/** The name of a backend, or the backend module itself. */
+export type XmlMiniBackendName = XmlMiniBackend | string;
 
 export interface RenameKeyOptions {
   /** Convert `snake_case` keys to `dashed-keys`. Defaults to `true`. */
@@ -13,21 +59,79 @@ export interface RenameKeyOptions {
 /**
  * Dasherize an `underscore_key`, preserving any leading/trailing underscores.
  *
- * Mirrors: ActiveSupport::XmlMini._dasherize — the `$2` (interior) capture is
+ * Mirrors: ActiveSupport::XmlMini._dasherize (xml_mini.rb:163-167) — the `$2` (interior) capture is
  * non-greedy so surrounding runs of underscores are left untouched and only the
  * interior `_`/space characters become `-`.
+ *
+ * @internal
  */
-function underscoreToDash(key: string): string {
-  const match = /^(_*)([\s\S]*?)(_*)$/.exec(key.trim());
+export function _dasherize(key: string): string {
+  const match = key.trim().match(/^(_*)([\s\S]*?)(_*)$/);
   if (!match) return key;
   const [, left, middle, right] = match;
   return `${left}${middle.replace(/[_ ]/g, "-")}${right}`;
 }
 
 /**
+ * Decode a `type="binary"` value according to its element's `encoding`
+ * attribute, leaving an unrecognized encoding untouched.
+ *
+ * Mirrors: ActiveSupport::XmlMini._parse_binary (xml_mini.rb:169-178).
+ *
+ * @internal
+ */
+export function _parseBinary(bin: string, entity: Record<string, string | undefined>): string {
+  switch (entity["encoding"]) {
+    case "base64":
+      return decode64(bin);
+    case "hex":
+    case "hexBinary":
+      return _parseHexBinary(bin);
+    default:
+      return bin;
+  }
+}
+
+/**
+ * Decode a `type="file"` value into an IO decorated with the element's `name`
+ * and `content_type` attributes.
+ *
+ * Mirrors: ActiveSupport::XmlMini._parse_file (xml_mini.rb:180-186) — `Blob` is
+ * the platform's in-memory, readable byte container, so it stands in for
+ * `StringIO.new`; the Latin-1 round-trip hands it {@link decode64}'s bytes
+ * unchanged rather than re-encoding them as UTF-8. Copying {@link FileLike}'s
+ * descriptors onto it is `f.extend(FileLike)`.
+ *
+ * @internal
+ */
+export function _parseFile(
+  file: string,
+  entity: Record<string, string | undefined>,
+): Blob & typeof FileLike {
+  const f = new Blob([Uint8Array.from(decode64(file), (c) => c.charCodeAt(0))]);
+  Object.defineProperties(f, Object.getOwnPropertyDescriptors(FileLike));
+  const fileLike = f as Blob & typeof FileLike;
+  fileLike.originalFilename = entity["name"];
+  fileLike.contentType = entity["content_type"];
+  return fileLike;
+}
+
+/**
+ * Decode a hex-encoded value to its bytes.
+ *
+ * Mirrors: ActiveSupport::XmlMini._parse_hex_binary (xml_mini.rb:188-190) —
+ * Ruby's `[bin].pack("H*")`.
+ *
+ * @internal
+ */
+export function _parseHexBinary(bin: string): string {
+  return Buffer.from(bin, "hex").toString("binary");
+}
+
+/**
  * Apply the `camelize`/`dasherize` key transforms to a single XML tag name.
  *
- * Mirrors: ActiveSupport::XmlMini.rename_key — camelize (when requested) runs
+ * Mirrors: ActiveSupport::XmlMini.rename_key (xml_mini.rb:154-161) — camelize (when requested) runs
  * first, then dasherize (default `true`) runs on the result. Both transforms
  * compose exactly as in Rails, so `camelize: true` still passes through
  * `_dasherize` (a no-op on an already-camelized, underscore-free key).
@@ -40,7 +144,7 @@ export function renameKey(key: string, options: RenameKeyOptions = {}): string {
     result = camelizeOpt === true ? camelize(result) : camelize(result, camelizeOpt);
   }
   if (dasherize) {
-    result = underscoreToDash(result);
+    result = _dasherize(result);
   }
   return result;
 }
@@ -139,6 +243,125 @@ function encode64(value: unknown): string {
   // Base64.encode64 exactly, including when the length is a multiple of 60.
   if (b64 === "") return "";
   return (b64.match(/.{1,60}/g) ?? []).join("\n") + "\n";
+}
+
+/**
+ * Decode Base64 content, mirroring Ruby's `Base64.decode64`: any character
+ * outside the Base64 alphabet (the line breaks `encode64` inserts included) is
+ * ignored. The decoded bytes come back as a binary (Latin-1) string, the same
+ * shape {@link encode64} accepts.
+ */
+function decode64(value: string): string {
+  return Buffer.from(value, "base64").toString("binary");
+}
+
+// The backend `parse` delegates to. Rails' `XmlMini.backend = "REXML"`
+// (xml_mini.rb:210) has no counterpart yet: `XmlMini_REXML` is unported, so
+// there is no default and `parse` raises until a backend is set.
+let _backend: XmlMiniBackend | null | undefined;
+
+/**
+ * Parse an XML document into a hash through the current backend.
+ *
+ * Mirrors: `delegate :parse, to: :backend` (xml_mini.rb:99).
+ */
+export function parse(data: string | null | undefined): unknown {
+  return backend()!.parse(data);
+}
+
+/**
+ * The backend in effect: the execution-state-scoped override set by
+ * {@link withBackend} if there is one, else the process-wide backend.
+ *
+ * Mirrors: ActiveSupport::XmlMini.backend (xml_mini.rb:101-103).
+ *
+ * @missingRailsCall cast_backend_name_to_module — belongs to `backend=`, which
+ * the call gate pairs with this reader (the bare-camel candidate wins over
+ * `setBackend`); {@link setBackend} makes the call.
+ */
+export function backend(): XmlMiniBackend | null | undefined {
+  return currentThreadBackend() ?? _backend;
+}
+
+/**
+ * Set the process-wide backend, by name or module.
+ *
+ * Mirrors: ActiveSupport::XmlMini#backend= (xml_mini.rb:105-109) — awaitable
+ * because resolving a name imports the backend module, which Ruby does
+ * synchronously via `require`.
+ */
+export async function setBackend(name: XmlMiniBackendName | null | undefined): Promise<void> {
+  const backend = name != null ? await castBackendNameToModule(name) : name;
+  if (currentThreadBackend() != null) await setCurrentThreadBackend(backend);
+  _backend = backend;
+}
+
+/**
+ * Run `fn` with `name` as the backend, restoring the previous
+ * execution-state-scoped backend afterwards.
+ *
+ * Mirrors: ActiveSupport::XmlMini#with_backend (xml_mini.rb:111-117).
+ */
+export async function withBackend<T>(
+  name: XmlMiniBackendName | null | undefined,
+  fn: () => T | Promise<T>,
+): Promise<T> {
+  const oldBackend = currentThreadBackend();
+  try {
+    await setCurrentThreadBackend(name != null ? await castBackendNameToModule(name) : name);
+    return await fn();
+  } finally {
+    await setCurrentThreadBackend(oldBackend);
+  }
+}
+
+/**
+ * The execution-state-scoped backend override.
+ *
+ * Mirrors: ActiveSupport::XmlMini#current_thread_backend (xml_mini.rb:192-194).
+ *
+ * @missingRailsCall cast_backend_name_to_module — belongs to
+ * `current_thread_backend=`, which the call gate pairs with this reader (the
+ * bare-camel candidate wins over `setCurrentThreadBackend`);
+ * {@link setCurrentThreadBackend} makes the call.
+ *
+ * @internal
+ */
+export function currentThreadBackend(): XmlMiniBackend | null | undefined {
+  return IsolatedExecutionState.get("xml_mini_backend");
+}
+
+/**
+ * Mirrors: ActiveSupport::XmlMini#current_thread_backend= (xml_mini.rb:196-198).
+ *
+ * @internal
+ */
+export async function setCurrentThreadBackend(
+  name: XmlMiniBackendName | null | undefined,
+): Promise<void> {
+  IsolatedExecutionState.set(
+    "xml_mini_backend",
+    name != null ? await castBackendNameToModule(name) : name,
+  );
+}
+
+/**
+ * Resolve a backend name to its module, loading the module the first time.
+ *
+ * Mirrors: ActiveSupport::XmlMini#cast_backend_name_to_module
+ * (xml_mini.rb:200-206) — Ruby's `require
+ * "active_support/xml_mini/#{name.downcase}"` plus `const_get "XmlMini_#{name}"`
+ * is one dynamic import here, since the module namespace object of
+ * `xml-mini/<name>.js` is the backend module.
+ *
+ * @internal
+ */
+export async function castBackendNameToModule(name: XmlMiniBackendName): Promise<XmlMiniBackend> {
+  if (typeof name !== "string") {
+    return name;
+  } else {
+    return (await import(`./xml-mini/${name.toLowerCase()}.js`)) as XmlMiniBackend;
+  }
 }
 
 function formatDateTime(value: unknown): string {

--- a/packages/activesupport/src/xml-mini.ts
+++ b/packages/activesupport/src/xml-mini.ts
@@ -53,11 +53,72 @@ export interface XmlMiniBackend {
 /** The name of a backend, or the backend module itself. */
 export type XmlMiniBackendName = XmlMiniBackend | string;
 
-export interface RenameKeyOptions {
-  /** Convert `snake_case` keys to `dashed-keys`. Defaults to `true`. */
-  dasherize?: boolean;
-  /** Camelize the key first: `true`/`"upper"` for UpperCamel, `"lower"` for lowerCamel. */
-  camelize?: boolean | "lower" | "upper";
+/** Mirrors: ActiveSupport::XmlMini::DEFAULT_ENCODINGS. */
+const DEFAULT_ENCODINGS: Record<string, string> = {
+  binary: "base64",
+};
+
+/**
+ * Per-type value formatters. Mirrors: ActiveSupport::XmlMini::FORMATTING —
+ * the JS type each entry receives is the trails analog of the Ruby class that
+ * `TYPE_NAMES` maps to the same tag name (e.g. `Temporal.Duration` ↔
+ * `ActiveSupport::Duration`).
+ */
+const FORMATTING: Record<string, (value: unknown) => string> = {
+  symbol: (value) => (typeof value === "symbol" ? (value.description ?? "") : String(value)),
+  date: (value) => (value instanceof Temporal.PlainDate ? value.toString() : String(value)),
+  time: (value) => (value instanceof Temporal.PlainTime ? value.toString() : String(value)),
+  dateTime: formatDateTime,
+  duration: (value) => (value instanceof Temporal.Duration ? value.toString() : String(value)),
+  binary: encode64,
+};
+
+/**
+ * Base64-encode binary content, mirroring Ruby's `Base64.encode64`: MIME line
+ * wrapping at 60 characters, each line (including the last) terminated by `\n`.
+ * Accepts a byte array or a binary (Latin-1) string, matching how Rails' binary
+ * columns arrive.
+ */
+function encode64(value: unknown): string {
+  const bytes =
+    typeof value === "string" ? Buffer.from(value, "binary") : Buffer.from(value as Uint8Array);
+  const b64 = bytes.toString("base64");
+  // Empty input encodes to "" (no trailing newline); otherwise chunk into
+  // 60-char lines joined by "\n" with a single trailing "\n" — matching
+  // Base64.encode64 exactly, including when the length is a multiple of 60.
+  if (b64 === "") return "";
+  return (b64.match(/.{1,60}/g) ?? []).join("\n") + "\n";
+}
+
+/**
+ * Decode Base64 content, mirroring Ruby's `Base64.decode64`: any character
+ * outside the Base64 alphabet (the line breaks `encode64` inserts included) is
+ * ignored. The decoded bytes come back as a binary (Latin-1) string, the same
+ * shape {@link encode64} accepts.
+ */
+function decode64(value: string): string {
+  return Buffer.from(value, "base64").toString("binary");
+}
+
+function formatDateTime(value: unknown): string {
+  // boundary: legacy JS Date values serialize as ISO 8601 dateTime.
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? "" : value.toISOString();
+  }
+  // ActiveSupport::TimeWithZone (and any zoned wall-clock) exposes #xmlschema,
+  // which keeps the local offset — Rails' `time.xmlschema`.
+  if (typeof (value as { xmlschema?: unknown })?.xmlschema === "function") {
+    return (value as { xmlschema(): string }).xmlschema();
+  }
+  if (value instanceof Temporal.ZonedDateTime) {
+    // Drop the IANA `[Zone]` annotation so the lexical form is a valid XML
+    // Schema dateTime while keeping the numeric offset (unlike a UTC recast).
+    return value.toString({ timeZoneName: "never" });
+  }
+  if (value instanceof Temporal.Instant || value instanceof Temporal.PlainDateTime) {
+    return value.toString();
+  }
+  return String(value);
 }
 
 /**
@@ -128,148 +189,6 @@ export async function withBackend<T>(
 }
 
 /**
- * The execution-state-scoped backend override.
- *
- * Mirrors: ActiveSupport::XmlMini#current_thread_backend (xml_mini.rb:192-194).
- *
- * @missingRailsCall cast_backend_name_to_module — belongs to
- * `current_thread_backend=`, which the call gate pairs with this reader (the
- * bare-camel candidate wins over `setCurrentThreadBackend`);
- * {@link setCurrentThreadBackend} makes the call.
- *
- * @internal
- */
-export function currentThreadBackend(): XmlMiniBackend | null | undefined {
-  return IsolatedExecutionState.get("xml_mini_backend");
-}
-
-/**
- * Mirrors: ActiveSupport::XmlMini#current_thread_backend= (xml_mini.rb:196-198).
- *
- * @internal
- */
-export async function setCurrentThreadBackend(
-  name: XmlMiniBackendName | null | undefined,
-): Promise<void> {
-  IsolatedExecutionState.set(
-    "xml_mini_backend",
-    name != null ? await castBackendNameToModule(name) : name,
-  );
-}
-
-/**
- * Resolve a backend name to its module, loading the module the first time.
- *
- * Mirrors: ActiveSupport::XmlMini#cast_backend_name_to_module
- * (xml_mini.rb:200-206) — Ruby's `require
- * "active_support/xml_mini/#{name.downcase}"` plus `const_get "XmlMini_#{name}"`
- * is one dynamic import here, since the module namespace object of
- * `xml-mini/<name>.js` is the backend module.
- *
- * @internal
- */
-export async function castBackendNameToModule(name: XmlMiniBackendName): Promise<XmlMiniBackend> {
-  if (typeof name !== "string") {
-    return name;
-  } else {
-    return (await import(`./xml-mini/${name.toLowerCase()}.js`)) as XmlMiniBackend;
-  }
-}
-
-/**
- * Apply the `camelize`/`dasherize` key transforms to a single XML tag name.
- *
- * Mirrors: ActiveSupport::XmlMini.rename_key (xml_mini.rb:154-161) — camelize (when requested) runs
- * first, then dasherize (default `true`) runs on the result. Both transforms
- * compose exactly as in Rails, so `camelize: true` still passes through
- * `_dasherize` (a no-op on an already-camelized, underscore-free key).
- */
-export function renameKey(key: string, options: RenameKeyOptions = {}): string {
-  const { camelize: camelizeOpt } = options;
-  const dasherize = options.dasherize === undefined || options.dasherize;
-  let result = key;
-  if (camelizeOpt) {
-    result = camelizeOpt === true ? camelize(result) : camelize(result, camelizeOpt);
-  }
-  if (dasherize) {
-    result = _dasherize(result);
-  }
-  return result;
-}
-
-/**
- * Dasherize an `underscore_key`, preserving any leading/trailing underscores.
- *
- * Mirrors: ActiveSupport::XmlMini._dasherize (xml_mini.rb:163-167) — the `$2` (interior) capture is
- * non-greedy so surrounding runs of underscores are left untouched and only the
- * interior `_`/space characters become `-`.
- *
- * @internal
- */
-export function _dasherize(key: string): string {
-  const match = key.trim().match(/^(_*)([\s\S]*?)(_*)$/);
-  if (!match) return key;
-  const [, left, middle, right] = match;
-  return `${left}${middle.replace(/[_ ]/g, "-")}${right}`;
-}
-
-/**
- * Decode a `type="binary"` value according to its element's `encoding`
- * attribute, leaving an unrecognized encoding untouched.
- *
- * Mirrors: ActiveSupport::XmlMini._parse_binary (xml_mini.rb:169-178).
- *
- * @internal
- */
-export function _parseBinary(bin: string, entity: Record<string, string | undefined>): string {
-  switch (entity["encoding"]) {
-    case "base64":
-      return decode64(bin);
-    case "hex":
-    case "hexBinary":
-      return _parseHexBinary(bin);
-    default:
-      return bin;
-  }
-}
-
-/**
- * Decode a `type="file"` value into an IO decorated with the element's `name`
- * and `content_type` attributes.
- *
- * Mirrors: ActiveSupport::XmlMini._parse_file (xml_mini.rb:180-186) — `Blob` is
- * the platform's in-memory, readable byte container, so it stands in for
- * `StringIO.new`; the Latin-1 round-trip hands it {@link decode64}'s bytes
- * unchanged rather than re-encoding them as UTF-8. Copying {@link FileLike}'s
- * descriptors onto it is `f.extend(FileLike)`.
- *
- * @internal
- */
-export function _parseFile(
-  file: string,
-  entity: Record<string, string | undefined>,
-): Blob & typeof FileLike {
-  const f = new Blob([Uint8Array.from(decode64(file), (c) => c.charCodeAt(0))]);
-  Object.defineProperties(f, Object.getOwnPropertyDescriptors(FileLike));
-  const fileLike = f as Blob & typeof FileLike;
-  fileLike.originalFilename = entity["name"];
-  fileLike.contentType = entity["content_type"];
-  return fileLike;
-}
-
-/**
- * Decode a hex-encoded value to its bytes.
- *
- * Mirrors: ActiveSupport::XmlMini._parse_hex_binary (xml_mini.rb:188-190) —
- * Ruby's `[bin].pack("H*")`.
- *
- * @internal
- */
-export function _parseHexBinary(bin: string): string {
-  return Buffer.from(bin, "hex").toString("binary");
-}
-
-/**
  * A sink for XML fragments. `toTag` writes one value's tag(s) into it, so the
  * same per-value logic can target either a compact string (the parity default,
  * {@link XmlStringBuilder}) or an indentation-aware sink (ActiveModel's
@@ -300,6 +219,13 @@ export interface XmlTypeInfo {
   nested: Record<string, XmlTypeInfo>;
 }
 
+export interface RenameKeyOptions {
+  /** Convert `snake_case` keys to `dashed-keys`. Defaults to `true`. */
+  dasherize?: boolean;
+  /** Camelize the key first: `true`/`"upper"` for UpperCamel, `"lower"` for lowerCamel. */
+  camelize?: boolean | "lower" | "upper";
+}
+
 export interface ToTagOptions extends RenameKeyOptions {
   /** The sink the emitted tag(s) are written to. */
   builder: XmlBuilder;
@@ -326,74 +252,6 @@ export interface ToTagOptions extends RenameKeyOptions {
   root?: unknown;
   /** Always true once inside `to_tag` (no XML instruction on nested docs). */
   skipInstruct?: boolean;
-}
-
-/** Mirrors: ActiveSupport::XmlMini::DEFAULT_ENCODINGS. */
-const DEFAULT_ENCODINGS: Record<string, string> = {
-  binary: "base64",
-};
-
-/**
- * Per-type value formatters. Mirrors: ActiveSupport::XmlMini::FORMATTING —
- * the JS type each entry receives is the trails analog of the Ruby class that
- * `TYPE_NAMES` maps to the same tag name (e.g. `Temporal.Duration` ↔
- * `ActiveSupport::Duration`).
- */
-const FORMATTING: Record<string, (value: unknown) => string> = {
-  symbol: (value) => (typeof value === "symbol" ? (value.description ?? "") : String(value)),
-  date: (value) => (value instanceof Temporal.PlainDate ? value.toString() : String(value)),
-  time: (value) => (value instanceof Temporal.PlainTime ? value.toString() : String(value)),
-  dateTime: formatDateTime,
-  duration: (value) => (value instanceof Temporal.Duration ? value.toString() : String(value)),
-  binary: encode64,
-};
-
-/**
- * Base64-encode binary content, mirroring Ruby's `Base64.encode64`: MIME line
- * wrapping at 60 characters, each line (including the last) terminated by `\n`.
- * Accepts a byte array or a binary (Latin-1) string, matching how Rails' binary
- * columns arrive.
- */
-function encode64(value: unknown): string {
-  const bytes =
-    typeof value === "string" ? Buffer.from(value, "binary") : Buffer.from(value as Uint8Array);
-  const b64 = bytes.toString("base64");
-  // Empty input encodes to "" (no trailing newline); otherwise chunk into
-  // 60-char lines joined by "\n" with a single trailing "\n" — matching
-  // Base64.encode64 exactly, including when the length is a multiple of 60.
-  if (b64 === "") return "";
-  return (b64.match(/.{1,60}/g) ?? []).join("\n") + "\n";
-}
-
-/**
- * Decode Base64 content, mirroring Ruby's `Base64.decode64`: any character
- * outside the Base64 alphabet (the line breaks `encode64` inserts included) is
- * ignored. The decoded bytes come back as a binary (Latin-1) string, the same
- * shape {@link encode64} accepts.
- */
-function decode64(value: string): string {
-  return Buffer.from(value, "base64").toString("binary");
-}
-
-function formatDateTime(value: unknown): string {
-  // boundary: legacy JS Date values serialize as ISO 8601 dateTime.
-  if (value instanceof Date) {
-    return Number.isNaN(value.getTime()) ? "" : value.toISOString();
-  }
-  // ActiveSupport::TimeWithZone (and any zoned wall-clock) exposes #xmlschema,
-  // which keeps the local offset — Rails' `time.xmlschema`.
-  if (typeof (value as { xmlschema?: unknown })?.xmlschema === "function") {
-    return (value as { xmlschema(): string }).xmlschema();
-  }
-  if (value instanceof Temporal.ZonedDateTime) {
-    // Drop the IANA `[Zone]` annotation so the lexical form is a valid XML
-    // Schema dateTime while keeping the numeric offset (unlike a UTC recast).
-    return value.toString({ timeZoneName: "never" });
-  }
-  if (value instanceof Temporal.Instant || value instanceof Temporal.PlainDateTime) {
-    return value.toString();
-  }
-  return String(value);
 }
 
 /**
@@ -559,6 +417,148 @@ function emitHash(key: unknown, hash: Record<string, unknown>, options: ToTagOpt
     toTag(k, v, { ...options, type: info?.types[k], typeInfo: info?.nested[k], root: k });
   }
   options.builder.closeTag(root);
+}
+
+/**
+ * Apply the `camelize`/`dasherize` key transforms to a single XML tag name.
+ *
+ * Mirrors: ActiveSupport::XmlMini.rename_key (xml_mini.rb:154-161) — camelize (when requested) runs
+ * first, then dasherize (default `true`) runs on the result. Both transforms
+ * compose exactly as in Rails, so `camelize: true` still passes through
+ * `_dasherize` (a no-op on an already-camelized, underscore-free key).
+ */
+export function renameKey(key: string, options: RenameKeyOptions = {}): string {
+  const { camelize: camelizeOpt } = options;
+  const dasherize = options.dasherize === undefined || options.dasherize;
+  let result = key;
+  if (camelizeOpt) {
+    result = camelizeOpt === true ? camelize(result) : camelize(result, camelizeOpt);
+  }
+  if (dasherize) {
+    result = _dasherize(result);
+  }
+  return result;
+}
+
+/**
+ * Dasherize an `underscore_key`, preserving any leading/trailing underscores.
+ *
+ * Mirrors: ActiveSupport::XmlMini._dasherize (xml_mini.rb:163-167) — the `$2` (interior) capture is
+ * non-greedy so surrounding runs of underscores are left untouched and only the
+ * interior `_`/space characters become `-`.
+ *
+ * @internal
+ */
+export function _dasherize(key: string): string {
+  const match = key.trim().match(/^(_*)([\s\S]*?)(_*)$/);
+  if (!match) return key;
+  const [, left, middle, right] = match;
+  return `${left}${middle.replace(/[_ ]/g, "-")}${right}`;
+}
+
+/**
+ * Decode a `type="binary"` value according to its element's `encoding`
+ * attribute, leaving an unrecognized encoding untouched.
+ *
+ * Mirrors: ActiveSupport::XmlMini._parse_binary (xml_mini.rb:169-178).
+ *
+ * @internal
+ */
+export function _parseBinary(bin: string, entity: Record<string, string | undefined>): string {
+  switch (entity["encoding"]) {
+    case "base64":
+      return decode64(bin);
+    case "hex":
+    case "hexBinary":
+      return _parseHexBinary(bin);
+    default:
+      return bin;
+  }
+}
+
+/**
+ * Decode a `type="file"` value into an IO decorated with the element's `name`
+ * and `content_type` attributes.
+ *
+ * Mirrors: ActiveSupport::XmlMini._parse_file (xml_mini.rb:180-186) — `Blob` is
+ * the platform's in-memory, readable byte container, so it stands in for
+ * `StringIO.new`; the Latin-1 round-trip hands it {@link decode64}'s bytes
+ * unchanged rather than re-encoding them as UTF-8. Copying {@link FileLike}'s
+ * descriptors onto it is `f.extend(FileLike)`.
+ *
+ * @internal
+ */
+export function _parseFile(
+  file: string,
+  entity: Record<string, string | undefined>,
+): Blob & typeof FileLike {
+  const f = new Blob([Uint8Array.from(decode64(file), (c) => c.charCodeAt(0))]);
+  Object.defineProperties(f, Object.getOwnPropertyDescriptors(FileLike));
+  const fileLike = f as Blob & typeof FileLike;
+  fileLike.originalFilename = entity["name"];
+  fileLike.contentType = entity["content_type"];
+  return fileLike;
+}
+
+/**
+ * Decode a hex-encoded value to its bytes.
+ *
+ * Mirrors: ActiveSupport::XmlMini._parse_hex_binary (xml_mini.rb:188-190) —
+ * Ruby's `[bin].pack("H*")`.
+ *
+ * @internal
+ */
+export function _parseHexBinary(bin: string): string {
+  return Buffer.from(bin, "hex").toString("binary");
+}
+
+/**
+ * The execution-state-scoped backend override.
+ *
+ * Mirrors: ActiveSupport::XmlMini#current_thread_backend (xml_mini.rb:192-194).
+ *
+ * @missingRailsCall cast_backend_name_to_module — belongs to
+ * `current_thread_backend=`, which the call gate pairs with this reader (the
+ * bare-camel candidate wins over `setCurrentThreadBackend`);
+ * {@link setCurrentThreadBackend} makes the call.
+ *
+ * @internal
+ */
+export function currentThreadBackend(): XmlMiniBackend | null | undefined {
+  return IsolatedExecutionState.get("xml_mini_backend");
+}
+
+/**
+ * Mirrors: ActiveSupport::XmlMini#current_thread_backend= (xml_mini.rb:196-198).
+ *
+ * @internal
+ */
+export async function setCurrentThreadBackend(
+  name: XmlMiniBackendName | null | undefined,
+): Promise<void> {
+  IsolatedExecutionState.set(
+    "xml_mini_backend",
+    name != null ? await castBackendNameToModule(name) : name,
+  );
+}
+
+/**
+ * Resolve a backend name to its module, loading the module the first time.
+ *
+ * Mirrors: ActiveSupport::XmlMini#cast_backend_name_to_module
+ * (xml_mini.rb:200-206) — Ruby's `require
+ * "active_support/xml_mini/#{name.downcase}"` plus `const_get "XmlMini_#{name}"`
+ * is one dynamic import here, since the module namespace object of
+ * `xml-mini/<name>.js` is the backend module.
+ *
+ * @internal
+ */
+export async function castBackendNameToModule(name: XmlMiniBackendName): Promise<XmlMiniBackend> {
+  if (typeof name !== "string") {
+    return name;
+  } else {
+    return (await import(`./xml-mini/${name.toLowerCase()}.js`)) as XmlMiniBackend;
+  }
 }
 
 /** Render `attrs` as ` k="v"` pairs with escaped values, in insertion order. */

--- a/packages/activesupport/src/xml-mini.ts
+++ b/packages/activesupport/src/xml-mini.ts
@@ -255,9 +255,14 @@ function decode64(value: string): string {
   return Buffer.from(value, "base64").toString("binary");
 }
 
-// The backend `parse` delegates to. Rails' `XmlMini.backend = "REXML"`
-// (xml_mini.rb:210) has no counterpart yet: `XmlMini_REXML` is unported, so
-// there is no default and `parse` raises until a backend is set.
+/**
+ * The backend `parse` delegates to (Ruby's `@backend`). Rails'
+ * `XmlMini.backend = "REXML"` (xml_mini.rb:210) has no counterpart yet:
+ * `XmlMini_REXML` is unported, so there is no default and `parse` raises until
+ * a backend is set.
+ *
+ * @internal
+ */
 let _backend: XmlMiniBackend | null | undefined;
 
 /**


### PR DESCRIPTION
Ports the half of `xml_mini.rb` that `packages/activesupport/src/xml-mini.ts`
was missing — everything past the serialize path. `parity:api` for
`xml_mini.rb` goes **4/19 → 19/19** (activesupport +15 methods, overall
12704 → 12719).

## What landed

**Backend registry + parse delegation** (`xml_mini.rb:99-117, 192-206`)

`backend`/`setBackend`, `withBackend`, `currentThreadBackend`/
`setCurrentThreadBackend`, `castBackendNameToModule`, and `parse`
(`delegate :parse, to: :backend`). The execution-state-scoped override goes
through `IsolatedExecutionState["xml_mini_backend"]`, the trails analog of
Rails' thread-local, so `withBackend` set/restore is the Rails body verbatim
including the `ensure`-restore.

Ruby resolves a backend name with `require
"active_support/xml_mini/#{name.downcase}"` + `const_get "XmlMini_#{name}"`;
here the module namespace object of `./xml-mini/<name>.js` **is** that module,
so one dynamic import does both. That import is async, so `backend=` and
`current_thread_backend=` are the sanctioned `setX()` form.

`XmlMiniBackend.parse` is typed `Promise<Record<string, unknown>>`, and so is
the top-level `parse` delegate: both shipped backends are async because each
loads `@blazetrails/nokogiri` through a dynamic import
(`xml-mini/nokogirisax.ts:55`, `xml-mini/nokogiri.ts:99`). The delegation itself
still forwards straight to the selected backend, as Rails' `delegate` does.

New members sit where Rails declares them: the backend accessors ahead of
`renameKey` (`xml_mini.rb:99-117` precedes `:152`), and `_dasherize` +
`_parse_binary`/`_parse_file`/`_parse_hex_binary` together after it, in Rails'
`private`-section order (`:163-190`).

**PARSING typecast helpers** (`xml_mini.rb:169-190`) — `_parseBinary`,
`_parseFile`, `_parseHexBinary`, plus `FileLike` (`xml_mini.rb:22-31`), the
accessor module `_parse_file` `extend`s onto the IO it returns (copied on as
descriptors, since Ruby `extend` decorates an instance). `_parseFile` returns a
`Blob` — the platform's in-memory readable byte container — where Ruby returns
`StringIO.new`, with a Latin-1 round-trip so `decode64`'s bytes are not
re-encoded as UTF-8.

**`_dasherize`** now carries its Rails name (was `underscoreToDash`) and calls
`String#match` where Rails calls `Regexp#match`.

## Deliberately not here

No default backend. Rails ends the file with `XmlMini.backend = "REXML"`
(`xml_mini.rb:210`), but `XmlMini_REXML` is unported — there is no
`xml-mini/rexml.ts` and `rexml-engine.test.ts` is still a skip stub — so
`_backend` starts unset and `parse` raises until a caller sets one. Cited at
the declaration and filed as
`0101-activesupport-out-of-closure-surface/stories/port-xml-mini-rexml-backend-and-default`,
which also records the still-unported `PARSING` table and `depth`.

## Tests

`WithBackendTest` and `ThreadSafetyTest` are enrolled with the Rails test names
verbatim; the Rails `Thread` + `sleep 0.1 while t.status != "sleep"` pattern
becomes an `IsolatedExecutionState.run` task that signals from inside the
block, so the assertion is deterministic rather than timing-dependent. The four
`_parse*`/`FileLike` unit tests go in `xml-mini.trails.test.ts` — Rails covers
those through `XmlMini::PARSING` and `Hash.from_xml`, neither of which is
ported, so they match no Rails test.

## Gates

`parity:api` **requires a built tree** — it exits before measuring when package
`dist/*.d.ts` declarations are missing and tells you to run `pnpm build` first
(`scripts/api-compare/extract-ts-api.ts:284`; `API_COMPARE_FORCE=1` does not
help, build state is not a cache). Measured after `pnpm build`:

| gate | result |
| --- | --- |
| `parity:api` — `xml_mini.rb` | **4/19 → 19/19 methods, 0 missing** |
| `parity:api` — activesupport | 1120 → **1135**/2026 methods |
| `parity:api` — overall | 12704 → **12719**/15359 (82.7% → 82.8%) |
| `parity:test` — `xml_mini_test.rb` | 31 → **35**/47 matched, extras unchanged at 2 (both pre-existing) |
| `pnpm api:calls` | OK (no new rows; 1675 baselined, unchanged) |
| `pnpm api:calls:args` | OK (275 baselined shape rows, unchanged) |
| `pnpm api:extra --package activesupport` | `xml-mini.ts` unchanged at 8 novel — all pre-existing builder/option-key surface, none of it added here |

`pnpm api:calls:wide` no longer exists: RFC 0084 folded the wide ratchet into
`api:calls` (one artifact, one baseline — see CLAUDE.md "Before you open the
PR"), and the sibling gate over the same shards is `api:calls:args`, which is in
the table.

No baseline rows added. Of the four call flags this diff raised, two converged
(`_dasherize` now calls `String#match` as Rails calls `Regexp#match`;
`_parseFile` constructs with `new`), and two are `@missingRailsCall` receipts on
the readers the gate pairs Ruby's `backend=` / `current_thread_backend=` with —
the bare-camel candidate wins over `setBackend`
(`scripts/parity/conventions.ts:1210-1223`), so the cast is flagged against the
reader while `setBackend` is the body that makes it.

typecheck, lint and the touched test files are green.

Closes-story: port-xml-mini-backend-and-parsing-half
