### PR TITLE
refactor(activerecord): restate the collection removal/append chain as `Promise<T> | T`

### DIFF
--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -527,7 +527,7 @@ export class Association {
     // unsaved build. The stale and find-target branches stay mutually exclusive
     // (`stale_target?` requires loaded, `find_target?` requires not-loaded).
     // The find is the only I/O here, so the body runs inline and answers a
-    // promise only when it actually ran — the sync-hybrid shape callers reached
+    // promise only when it actually ran — the `Promise<T> | T` shape callers reached
     // from a synchronous writer (`CollectionAssociation#concat`) depend on.
     const loaded = (): Base | Base[] | null => {
       this.loadedBang();

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -508,7 +508,7 @@ export class Association {
    *
    * Mirrors: ActiveRecord::Associations::Association#load_target
    */
-  async loadTarget(): Promise<Base | Base[] | null> {
+  loadTarget(): Promise<Base | Base[] | null> | Base | Base[] | null {
     // Corresponds to Rails' guard `(@stale_state && stale_target?) ||
     // find_target?` (association.rb:190). Rails relies on
     // `SingularAssociation#reader` resetting a stale association *before*
@@ -526,21 +526,27 @@ export class Association {
     // record assigned before its owner FK was set): that would clobber the
     // unsaved build. The stale and find-target branches stay mutually exclusive
     // (`stale_target?` requires loaded, `find_target?` requires not-loaded).
+    // The find is the only I/O here, so the body runs inline and answers a
+    // promise only when it actually ran — the sync-hybrid shape callers reached
+    // from a synchronous writer (`CollectionAssociation#concat`) depend on.
+    const loaded = (): Base | Base[] | null => {
+      this.loadedBang();
+      return this.target;
+    };
     if (this.isStaleTarget() && (this._staleState != null || this.target == null)) {
       // Rails `find_target` always issues a query; skip the in-memory
       // `doFindTarget` cache so a stale target is actually re-fetched.
-      await this._findTarget();
+      return this._findTarget().then(loaded);
     } else if (this.findTargetNeeded()) {
       const cached = this.doFindTarget();
       if (cached !== undefined) {
         this.target = cached;
       } else {
-        await this._findTarget();
+        return this._findTarget().then(loaded);
       }
     }
 
-    this.loadedBang();
-    return this.target;
+    return loaded();
   }
 
   /**

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -427,11 +427,13 @@ export class CollectionAssociation extends Association {
    * persisted-owner transaction (collection_association.rb:127-135) — the
    * nil that makes `CollectionProxy#<<` falsy.
    */
-  async concat(...records: Base[]): Promise<Base[] | undefined> {
+  concat(...records: Base[]): Promise<Base[] | undefined> | Base[] | undefined {
     records = records.flat();
     if (this.owner.isNewRecord()) {
-      await this.skipStrictLoading(() => this.loadTarget());
-      return this.concatRecords(records);
+      const loaded = this.skipStrictLoading(() => this.loadTarget());
+      return isThenable(loaded)
+        ? loaded.then(() => this.concatRecords(records))
+        : this.concatRecords(records);
     }
     return this.transaction(() => this.concatRecords(records));
   }
@@ -444,13 +446,13 @@ export class CollectionAssociation extends Association {
    * `HasManyThroughAssociation` picks up.
    * @internal
    */
-  protected transaction<R>(block: () => Promise<R>): Promise<R | undefined> {
+  protected transaction<R>(block: () => Promise<R> | R): Promise<R | undefined> {
     // Rails: reflection.klass.transaction(&block) — uses the reflection's klass, not assoc.klass
     const klass = (this.reflection as any).klass ?? this.klass;
     if (klass && typeof klass.transaction === "function") {
-      return klass.transaction(block);
+      return klass.transaction(() => Promise.resolve(block()));
     }
-    return block();
+    return Promise.resolve(block());
   }
 
   /**
@@ -537,8 +539,8 @@ export class CollectionAssociation extends Association {
    *
    * @internal
    */
-  protected async concatRecords(records: Base[], raise = false): Promise<Base[]> {
-    await concatRecordsLoop(records, async (record, resultStillTrue) => {
+  protected concatRecords(records: Base[], raise = false): Promise<Base[]> | Base[] {
+    const looped = concatRecordsLoop(records, (record, resultStillTrue) => {
       (this as any).raiseOnTypeMismatchBang(record);
       // Mirror Rails' `add_to_target(record) { insert_record }`
       // (collection_association.rb:440-446): the insert runs *inside* the
@@ -547,17 +549,19 @@ export class CollectionAssociation extends Association {
       // before_add abort (`added == null`) skips the yield, so `inserted`
       // stays true and the fold leaves `result` unchanged.
       let inserted = true;
-      await this.addToTarget(record, {}, async () => {
+      const added = this.addToTarget(record, {}, () => {
         // `resultStillTrue === false` → a prior record failed, so Rails'
         // `result &&= insert_record` short-circuits the save.
         if (this.owner.isNewRecord() || !resultStillTrue) return;
-        inserted = await this.insertRecord(record, true, raise, () => {
+        return this.insertRecord(record, true, raise, () => {
           this._wasLoaded = this.isLoaded();
+        }).then((result) => {
+          inserted = result;
         });
       });
-      return inserted;
+      return isThenable(added) ? added.then(() => inserted) : inserted;
     });
-    return records;
+    return isThenable(looped) ? looped.then(() => records) : records;
   }
 
   /**
@@ -643,7 +647,9 @@ export class CollectionAssociation extends Association {
    * Remove specific records from the association using the :dependent
    * strategy. Calls before_remove/after_remove callbacks.
    */
-  async delete(...records: Array<Base | number | string | bigint>): Promise<Base[] | undefined> {
+  delete(
+    ...records: Array<Base | number | string | bigint>
+  ): Promise<Base[] | undefined> | Base[] | undefined {
     // Pass the raw splat (do NOT pre-flatten) so deleteOrDestroy's
     // `records.empty?` check sees the un-flattened arg list, matching Rails:
     // `delete()` → [] → nil, but `delete([])` → [[]] (size 1) → [] → [].
@@ -816,16 +822,21 @@ export class CollectionAssociation extends Association {
   /**
    * Load target from database and merge with in-memory records.
    */
-  override async loadTarget(): Promise<Base[]> {
+  override loadTarget(): Promise<Base[]> | Base[] {
+    const loaded = (): Base[] => {
+      this.loadedBang();
+      return this.target;
+    };
     if (this.findTargetNeeded()) {
       // Every collection subclass overrides `findTarget` to return `Base[]`;
       // the cast only narrows the singular-shaped base signature.
-      const findTarget = (await this.findTarget()) as Base[];
-      this.target = this.mergeTargetLists(findTarget, this.target);
+      return Promise.resolve(this.findTarget()).then((findTarget) => {
+        this.target = this.mergeTargetLists(findTarget as Base[], this.target);
+        return loaded();
+      });
     }
 
-    this.loadedBang();
-    return this.target;
+    return loaded();
   }
 
   /**
@@ -850,24 +861,19 @@ export class CollectionAssociation extends Association {
   addToTarget(
     record: Base,
     options: { skipCallbacks?: boolean; replace?: boolean },
-    save: () => Promise<void>,
-  ): Promise<Base | null>;
+    save: () => Promise<void> | void,
+  ): Promise<Base | null> | Base | null;
   addToTarget(
     record: Base,
     options: { skipCallbacks?: boolean; replace?: boolean } = {},
-    save?: () => Promise<void>,
+    save?: () => Promise<void> | void,
   ): Base | null | Promise<Base | null> {
     const { skipCallbacks = false, replace = false } = options;
     const distinctValue = !!(this.associationScope() as { distinctValue?: boolean } | undefined)
       ?.distinctValue;
     const shouldReplace = replace || distinctValue;
     if (save) {
-      return this.replaceOnTarget(
-        record,
-        skipCallbacks,
-        { replace: shouldReplace },
-        save,
-      ) as Promise<Base | null>;
+      return this.replaceOnTarget(record, skipCallbacks, { replace: shouldReplace }, save);
     }
     return this.replaceOnTarget(record, skipCallbacks, { replace: shouldReplace }) as Base | null;
   }
@@ -1070,10 +1076,10 @@ export class CollectionAssociation extends Association {
     return opts.foreignType ?? `${underscore(opts.as)}_type`;
   }
 
-  protected async deleteOrDestroy(
+  protected deleteOrDestroy(
     records: Array<Base | number | string | bigint>,
     method?: string,
-  ): Promise<Base[] | undefined> {
+  ): Promise<Base[] | undefined> | Base[] | undefined {
     // Rails delete_or_destroy opens with `return if records.empty?`
     // (collection_association.rb:385) BEFORE the flatten on the next line, so
     // the check is against the raw splat: `delete()` → [] → nil, but an
@@ -1089,23 +1095,29 @@ export class CollectionAssociation extends Association {
     // `raise_on_type_mismatch!` after `records.flatten` and raises. So run the
     // id-check on the raw splat, then flatten, then type-check the flattened
     // values — the order the non-through proxy path already follows.
-    const coerced = await this.coerceToRecords(records);
-    const resolved = (coerced as unknown[]).flat(Infinity) as Base[];
-    for (const record of resolved) (this as any).raiseOnTypeMismatchBang(record);
-    const existingRecords = resolved.filter((r) => !r.isNewRecord());
-    // A `before_remove` abort halts removal (removeRecords returns false); like
-    // Rails, leave the target untouched and report no removed records.
-    let removed = false;
-    if (existingRecords.length === 0) {
-      removed = await this.removeRecords(existingRecords, resolved, method ?? "");
-    } else {
-      await this.transaction(async () => {
-        removed = await this.removeRecords(existingRecords, resolved, method ?? "");
-      });
-    }
+    const coerced = this.coerceToRecords(records);
     // Rails remove_records aborts via `catch(:abort) { ... } || return` → nil
     // (collection_association.rb:399-402), so a halted before_remove returns nil.
-    return removed ? resolved : undefined;
+    const remove = (coerced: Base[]): Promise<Base[] | undefined> | Base[] | undefined => {
+      const resolved = (coerced as unknown[]).flat(Infinity) as Base[];
+      for (const record of resolved) (this as any).raiseOnTypeMismatchBang(record);
+      const existingRecords = resolved.filter((r) => !r.isNewRecord());
+      // A `before_remove` abort halts removal (removeRecords returns false); like
+      // Rails, leave the target untouched and report no removed records.
+      if (existingRecords.length === 0) {
+        const removed = this.removeRecords(existingRecords, resolved, method ?? "");
+        return isThenable(removed)
+          ? removed.then((r) => (r ? resolved : undefined))
+          : removed
+            ? resolved
+            : undefined;
+      }
+      let removed = false;
+      return this.transaction(async () => {
+        removed = await this.removeRecords(existingRecords, resolved, method ?? "");
+      }).then(() => (removed ? resolved : undefined));
+    };
+    return isThenable(coerced) ? coerced.then(remove) : remove(coerced);
   }
 
   /**
@@ -1116,21 +1128,25 @@ export class CollectionAssociation extends Association {
    * join (see HMT `idsReader`).
    * @internal
    */
-  private async coerceToRecords(records: Array<Base | number | string | bigint>): Promise<Base[]> {
+  private coerceToRecords(
+    records: Array<Base | number | string | bigint>,
+  ): Promise<Base[]> | Base[] {
     const isId = (r: Base | number | string | bigint): r is number | string | bigint =>
       typeof r === "number" || typeof r === "string" || typeof r === "bigint";
+    // Records passed as records need no lookup at all, so this stays inline —
+    // the arm `delete_or_destroy` takes for a new owner.
     if (!records.some(isId)) return records as Base[];
     const ids = records.map((r) => (isId(r) ? r : this.primaryKeyValue(r)));
     if (this.reflection.options.through) {
-      const target = await this.loadTarget();
-      return ids.map((id) => {
-        const found = target.find((r) => String(this.primaryKeyValue(r)) === String(id));
-        if (!found) throw new Error(`Couldn't find ${this.klass.name} with ID ${String(id)}`);
-        return found;
-      });
+      return Promise.resolve(this.loadTarget()).then((target) =>
+        ids.map((id) => {
+          const found = target.find((r) => String(this.primaryKeyValue(r)) === String(id));
+          if (!found) throw new Error(`Couldn't find ${this.klass.name} with ID ${String(id)}`);
+          return found;
+        }),
+      );
     }
-    const found = await this.find(...ids);
-    return Array.isArray(found) ? found : found ? [found] : [];
+    return this.find(...ids).then((found) => (Array.isArray(found) ? found : found ? [found] : []));
   }
 
   /**
@@ -1143,11 +1159,11 @@ export class CollectionAssociation extends Association {
    * prunes the instance already sitting in the loaded target.
    * @internal
    */
-  protected async removeRecords(
+  protected removeRecords(
     existingRecords: Base[],
     records: Base[],
     method: string,
-  ): Promise<boolean> {
+  ): Promise<boolean> | boolean {
     // Rails remove_records: catch(:abort) { each before_remove } || return
     // (collection_association.rb:399-402) — an aborted before_remove halts
     // removal (target untouched); returns false.
@@ -1159,22 +1175,30 @@ export class CollectionAssociation extends Association {
       return false;
     }
     this._lastRemoveAborted = false;
+    // Rails' tail after `delete_records` (collection_association.rb:404-409).
+    const pruned = (): boolean => {
+      this.target = this.target.filter((r) => !includesRecord(records, r));
+      for (const record of records) {
+        // A `dependent: :destroy` record is frozen once destroyed, so clearing its
+        // inverse foreign key would raise FrozenError. Rails leaves the destroyed
+        // record's attributes untouched here (remove_records only prunes @target),
+        // so skip inverse removal for already-destroyed records.
+        if (typeof (record as any).isDestroyed === "function" && (record as any).isDestroyed())
+          continue;
+        this.removeInverseInstance(record);
+      }
+      this._associationIds = null;
+      for (const record of records) this.callback("afterRemove", record);
+      return true;
+    };
+    // `delete_records` is the only I/O in this body and Rails skips it outright
+    // when nothing persisted is being removed, so a new-owner removal runs
+    // start to finish inline.
     if (existingRecords.length > 0) {
-      await this.deleteRecords(existingRecords, method);
+      const deleted = this.deleteRecords(existingRecords, method);
+      if (isThenable(deleted)) return deleted.then(pruned);
     }
-    this.target = this.target.filter((r) => !includesRecord(records, r));
-    for (const record of records) {
-      // A `dependent: :destroy` record is frozen once destroyed, so clearing its
-      // inverse foreign key would raise FrozenError. Rails leaves the destroyed
-      // record's attributes untouched here (remove_records only prunes @target),
-      // so skip inverse removal for already-destroyed records.
-      if (typeof (record as any).isDestroyed === "function" && (record as any).isDestroyed())
-        continue;
-      this.removeInverseInstance(record);
-    }
-    this._associationIds = null;
-    for (const record of records) this.callback("afterRemove", record);
-    return true;
+    return pruned();
   }
 
   /**
@@ -1182,7 +1206,7 @@ export class CollectionAssociation extends Association {
    * `CollectionAssociation#delete_records` (raises NotImplementedError).
    * @internal
    */
-  protected async deleteRecords(_records: Base[], _method: string): Promise<number> {
+  protected deleteRecords(_records: Base[], _method: string): Promise<number> | number {
     throw new Error(`deleteRecords must be implemented by ${this.constructor.name}`);
   }
 
@@ -1371,7 +1395,7 @@ export class CollectionAssociation extends Association {
     record: Base,
     skipCallbacks: boolean,
     { replace, inversing = false }: { replace: boolean; inversing?: boolean },
-    block?: () => Promise<void>,
+    block?: () => Promise<void> | void,
   ): Base | null | Promise<Base | null> {
     // Ruby's `@target.index(record)` uses `Core#==`, not JS reference identity,
     // so a re-fetched persisted record dedups against the one already buffered.
@@ -1413,12 +1437,17 @@ export class CollectionAssociation extends Association {
       this.setInverseInstance(record);
       this._wasLoaded = true;
       if (block) {
-        yielded = true;
-        return block()
-          .then(afterYield)
-          .finally(() => {
+        const yield_ = block();
+        // Only a block that actually owes I/O defers the rest; a synchronous
+        // yield (a new-record owner's `concat_records`, whose `insert_record`
+        // never runs) finishes inline, under the sync `ensure` below.
+        if (isThenable(yield_)) {
+          yielded = true;
+          return yield_.then(afterYield).finally(() => {
             this._wasLoaded = null;
           });
+        }
+        return afterYield();
       }
       return afterYield();
     } finally {
@@ -1455,19 +1484,42 @@ export class CollectionAssociation extends Association {
  *
  * @internal
  */
-export async function concatRecordsLoop(
+export function concatRecordsLoop(
   records: Base[],
-  addRecord: (record: Base, resultStillTrue: boolean) => Promise<boolean>,
-): Promise<void> {
+  addRecord: (record: Base, resultStillTrue: boolean) => Promise<boolean> | boolean,
+): Promise<void> | void {
   let result = true;
-  for (const record of records) {
+  for (let i = 0; i < records.length; i++) {
     // `add_to_target` always runs (so the record is type-checked and buffered),
     // but the insert inside `addRecord` is gated on the current `result` to match
     // Ruby's `result &&= insert_record(...)` short-circuit.
-    const inserted = await addRecord(record, result);
+    const inserted = addRecord(records[i], result);
+    // The first record whose add owes I/O turns the whole loop asynchronous;
+    // everything before it has already run inline (a new-record owner never
+    // reaches `insert_record`, so the loop stays synchronous end to end).
+    if (isThenable(inserted)) {
+      const rest = records.slice(i + 1);
+      return inserted.then(async (first) => {
+        result = result && first;
+        for (const record of rest) {
+          result = result && (await addRecord(record, result));
+        }
+        if (!result) throw new Rollback();
+      });
+    }
     result = result && inserted;
   }
   if (!result) throw new Rollback();
+}
+
+/**
+ * A value the sync-hybrid chain must chain behind rather than use directly —
+ * the port's stand-in for Ruby, where every one of these bodies has already
+ * finished by the time it returns.
+ * @internal
+ */
+export function isThenable<T>(value: Promise<T> | T): value is Promise<T> {
+  return typeof (value as { then?: unknown } | null | undefined)?.then === "function";
 }
 
 /**

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -1502,7 +1502,8 @@ export function concatRecordsLoop(
       return inserted.then(async (first) => {
         result = result && first;
         for (const record of rest) {
-          result = result && (await addRecord(record, result));
+          const inserted = await addRecord(record, result);
+          result = result && inserted;
         }
         if (!result) throw new Rollback();
       });

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -1514,7 +1514,7 @@ export function concatRecordsLoop(
 }
 
 /**
- * A value the sync-hybrid chain must chain behind rather than use directly —
+ * A value a `Promise<T> | T` body must chain behind rather than use directly —
  * the port's stand-in for Ruby, where every one of these bodies has already
  * finished by the time it returns.
  * @internal

--- a/packages/activerecord/src/associations/collection-sync-removal-chain.trails.test.ts
+++ b/packages/activerecord/src/associations/collection-sync-removal-chain.trails.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Trails-only: Rails' `CollectionAssociation#concat` / `#delete` have finished
+ * mutating the target by the time they return
+ * (vendor/rails/activerecord/lib/active_record/associations/collection_association.rb:123-135,
+ * :186-197), and for a NEW owner neither does any I/O — `concat_records` skips
+ * `insert_record` under `unless owner.new_record?` (:434-448) and
+ * `remove_records` skips `delete_records` when `existing_records` is empty
+ * (:404-405). The chain is therefore restated as the sync-hybrid shape
+ * (`Promise<T> | T`): it runs inline and answers a promise only when a call
+ * actually owed I/O, so `replace`'s new-owner arm — reached synchronously from
+ * the constructor's mass-assignment dispatch — can drive it. There is no Rails
+ * test for this deviation.
+ */
+import { describe, it, expect } from "vitest";
+import { Author } from "../test-helpers/models/author.js";
+import { Post } from "../test-helpers/models/post.js";
+import { fixtures } from "../test-fixtures.js";
+
+interface PostsAssociation {
+  target: Post[];
+  concat(...records: Post[]): Promise<Post[] | undefined> | Post[] | undefined;
+  delete(...records: Post[]): Promise<Post[] | undefined> | Post[] | undefined;
+}
+
+const postsAssociation = (owner: Author): PostsAssociation =>
+  (owner as unknown as { association(n: string): PostsAssociation }).association("posts");
+
+describe("CollectionSyncRemovalChain", () => {
+  fixtures(["authors", "posts"]);
+
+  it("concat on a new owner buffers the record before the next statement", () => {
+    const author = Author.new({ name: "Kelly" });
+    const post = Post.new({ title: "Welcome", body: "hi" });
+    const assoc = postsAssociation(author);
+
+    const result = assoc.concat(post);
+
+    expect(result).not.toBeInstanceOf(Promise);
+    expect(assoc.target).toEqual([post]);
+  });
+
+  it("delete on a new owner prunes the record before the next statement", () => {
+    const author = Author.new({ name: "Kelly" });
+    const post = Post.new({ title: "Welcome", body: "hi" });
+    const assoc = postsAssociation(author);
+    void assoc.concat(post);
+
+    const result = assoc.delete(post);
+
+    expect(result).not.toBeInstanceOf(Promise);
+    expect(assoc.target).toEqual([]);
+  });
+
+  it("delete on a persisted owner still answers a promise", async () => {
+    const author = await Author.create({ name: "Kelly" });
+    const post = await (
+      author as unknown as { posts: { create(a: object): Promise<Post> } }
+    ).posts.create({ title: "Welcome", body: "hi" });
+    const assoc = postsAssociation(author);
+
+    const result = assoc.delete(post);
+
+    expect(result).toBeInstanceOf(Promise);
+    expect(await result).toEqual([post]);
+    expect(assoc.target).toEqual([]);
+  });
+});

--- a/packages/activerecord/src/associations/collection-sync-removal-chain.trails.test.ts
+++ b/packages/activerecord/src/associations/collection-sync-removal-chain.trails.test.ts
@@ -51,6 +51,22 @@ describe("CollectionSyncRemovalChain", () => {
     expect(assoc.target).toEqual([]);
   });
 
+  it("buffers every record after an async insert fails", async () => {
+    const author = await Author.create({ name: "Kelly" });
+    const first = Post.new({ title: "First", body: "hi" });
+    const second = Post.new({ title: "Second", body: "hi" });
+    const assoc = postsAssociation(author);
+    // Rails short-circuits only `insert_record` once `result` is false
+    // (collection_association.rb:441-449); `add_to_target` still runs for every
+    // remaining record, so both stay buffered.
+    (assoc as unknown as { insertRecord(): Promise<boolean> }).insertRecord = () =>
+      Promise.resolve(false);
+
+    await assoc.concat(first, second);
+
+    expect(assoc.target).toEqual([first, second]);
+  });
+
   it("delete on a persisted owner still answers a promise", async () => {
     const author = await Author.create({ name: "Kelly" });
     const post = await (

--- a/packages/activerecord/src/associations/collection-sync-removal-chain.trails.test.ts
+++ b/packages/activerecord/src/associations/collection-sync-removal-chain.trails.test.ts
@@ -5,10 +5,10 @@
  * :186-197), and for a NEW owner neither does any I/O — `concat_records` skips
  * `insert_record` under `unless owner.new_record?` (:434-448) and
  * `remove_records` skips `delete_records` when `existing_records` is empty
- * (:404-405). The chain is therefore restated as the sync-hybrid shape
- * (`Promise<T> | T`): it runs inline and answers a promise only when a call
- * actually owed I/O, so `replace`'s new-owner arm — reached synchronously from
- * the constructor's mass-assignment dispatch — can drive it. There is no Rails
+ * (:404-405). The chain is therefore restated as `Promise<T> | T` bodies: they
+ * run inline and answer a promise only when a call actually owed I/O, so
+ * `replace`'s new-owner arm — reached synchronously from the constructor's
+ * mass-assignment dispatch — can drive it. There is no Rails
  * test for this deviation.
  */
 import { describe, it, expect } from "vitest";

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -25,7 +25,7 @@ import {
   routeThroughCheckValidity,
 } from "./validate-through-reflection.js";
 import { CompositePrimaryKeyMismatchError, DeleteRestrictionError } from "./errors.js";
-import { CollectionAssociation, includesRecord } from "./collection-association.js";
+import { CollectionAssociation, includesRecord, isThenable } from "./collection-association.js";
 import { ForeignAssociation, ownerForeignKeyColumns } from "./foreign-association.js";
 import { compositeQueryConstraintsList } from "../persistence.js";
 import { camelize, singularize, underscore } from "@blazetrails/activesupport";
@@ -289,8 +289,11 @@ export class HasManyAssociation extends CollectionAssociation {
    * records.length)`.
    * @internal
    */
-  protected override async concatRecords(records: Base[], raise = false): Promise<Base[]> {
-    return this.updateCounterIfSuccess(await super.concatRecords(records, raise), records.length);
+  protected override concatRecords(records: Base[], raise = false): Promise<Base[]> | Base[] {
+    const concatenated = super.concatRecords(records, raise);
+    return isThenable(concatenated)
+      ? concatenated.then((saved) => this.updateCounterIfSuccess(saved, records.length))
+      : this.updateCounterIfSuccess(concatenated, records.length);
   }
 
   /**

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -22,6 +22,7 @@ import {
   throughTargetScope,
 } from "./through-association.js";
 import { associationKeysEqual } from "./key-normalization.js";
+import { isThenable } from "./collection-association.js";
 import { runAllCallbacks } from "@blazetrails/activemodel";
 
 function safeKlass(refl: { klass?: unknown } | null | undefined): any {
@@ -57,7 +58,7 @@ export class HasManyThroughAssociation extends HasManyAssociation {
   /** @internal */
   declare throughRecordsFor: (record: Base) => Base[];
   /** @internal */
-  declare deleteThroughRecords: (records: Base[]) => Promise<void>;
+  declare deleteThroughRecords: (records: Base[]) => void;
   /** @internal */
   declare throughReflection: () => unknown;
   /** @internal */
@@ -189,15 +190,20 @@ export class HasManyThroughAssociation extends HasManyAssociation {
    * the join rows alongside the owner.
    * @internal
    */
-  protected override async concatRecords(records: Base[], _raise = false): Promise<Base[]> {
+  protected override concatRecords(records: Base[], _raise = false): Promise<Base[]> | Base[] {
     this.ensureNotNested();
-    const added = await super.concatRecords(records, true);
-    if (this.owner.isNewRecord() && added) {
-      for (const record of added.flat()) {
-        this.buildThroughRecord(record);
+    const concatenated = super.concatRecords(records, true);
+    const buildThroughRecords = (added: Base[]): Base[] => {
+      if (this.owner.isNewRecord() && added) {
+        for (const record of added.flat()) {
+          this.buildThroughRecord(record);
+        }
       }
-    }
-    return added;
+      return added;
+    };
+    return isThenable(concatenated)
+      ? concatenated.then(buildThroughRecords)
+      : buildThroughRecords(concatenated);
   }
 
   /**
@@ -379,11 +385,11 @@ export class HasManyThroughAssociation extends HasManyAssociation {
    * then drop the matching join rows from the through target.
    * @internal
    */
-  protected override async removeRecords(
+  protected override removeRecords(
     existingRecords: Base[],
     records: Base[],
     method: string,
-  ): Promise<boolean> {
+  ): Promise<boolean> | boolean {
     // Rails HMT#remove_records (has_many_through_association.rb:116-118) is
     // `super; delete_through_records(records)` — the method result is
     // `delete_through_records`'s `records.each` (a truthy array), NOT super's
@@ -393,8 +399,14 @@ export class HasManyThroughAssociation extends HasManyAssociation {
     // returns the records on abort, not nil. Discard super's boolean and report
     // truthy so deleteOrDestroy hands back `resolved`; the empty-args guard is
     // the only through path that yields nil.
-    await super.removeRecords(existingRecords, records, method);
-    await this.deleteThroughRecords(records);
+    const removed = super.removeRecords(existingRecords, records, method);
+    if (isThenable(removed)) {
+      return removed.then(() => {
+        this.deleteThroughRecords(records);
+        return true;
+      });
+    }
+    this.deleteThroughRecords(records);
     return true;
   }
 
@@ -446,7 +458,7 @@ export class HasManyThroughAssociation extends HasManyAssociation {
       count = await scope.deleteAll();
     }
 
-    await this.deleteThroughRecords(records);
+    this.deleteThroughRecords(records);
 
     // Rails' counter-cache tail (has_many_through_association.rb:159-173). Kept
     // inline (rather than in a helper) so the ported `delete_records` body makes
@@ -833,15 +845,15 @@ function throughRecordsFor(this: HasManyThroughAssociation, record: Base): Base[
 }
 
 /** @internal */
-function deleteThroughRecords(this: HasManyThroughAssociation, records: Base[]): Promise<void> {
+function deleteThroughRecords(this: HasManyThroughAssociation, records: Base[]): void {
   // Mirrors Rails `delete_through_records`: prune the matching join rows from
   // the through target, then evict the per-record `@through_records` cache so a
   // built-then-removed target is not re-associated when the owner is saved.
   const throughName = this.reflection.options.through;
-  if (!throughName) return Promise.resolve();
+  if (!throughName) return;
   const proxy = throughProxy(this);
   const cache = throughRecordsCache(this);
-  if (!proxy) return Promise.resolve();
+  if (!proxy) return;
   for (const record of records) {
     const toDelete = this.throughRecordsFor(record);
     if (Array.isArray(proxy.target)) {
@@ -854,7 +866,6 @@ function deleteThroughRecords(this: HasManyThroughAssociation, records: Base[]):
     }
     cache.delete(record);
   }
-  return Promise.resolve();
 }
 
 /**

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -268,7 +268,7 @@ export class HasOneAssociation extends SingularAssociation {
    * @internal
    */
   protected loadTargetForBuild(): Promise<unknown> {
-    return this.loadTarget();
+    return Promise.resolve(this.loadTarget());
   }
 
   /**

--- a/packages/activerecord/src/associations/instance-methods.ts
+++ b/packages/activerecord/src/associations/instance-methods.ts
@@ -183,7 +183,7 @@ export function association(this: Base, name: string): AssociationInstance {
 export async function loadBelongsTo(this: Base, name: string): Promise<Base | null> {
   assertSingularAssociation.call(this, name, "belongsTo");
   const result = await bypassStrictLoading.call(this, () =>
-    association.call(this, name).loadTarget(),
+    Promise.resolve(association.call(this, name).loadTarget()),
   );
   return result as Base | null;
 }
@@ -199,7 +199,7 @@ export async function loadBelongsTo(this: Base, name: string): Promise<Base | nu
 export async function loadHasOne(this: Base, name: string): Promise<Base | null> {
   assertSingularAssociation.call(this, name, "hasOne");
   const result = await bypassStrictLoading.call(this, () =>
-    association.call(this, name).loadTarget(),
+    Promise.resolve(association.call(this, name).loadTarget()),
   );
   return result as Base | null;
 }


### PR DESCRIPTION
`CollectionAssociation#delete`/`#concat` and everything under them
(`deleteOrDestroy`, `coerceToRecords`, `removeRecords`, `deleteRecords`,
`concatRecords`, `concatRecordsLoop`, `addToTarget`/`replaceOnTarget`'s yield
arm, `loadTarget`) were `async`, so each hop deferred a microtask even when it
did no I/O. Rails' bodies have finished by the time they return, and for a NEW
owner none of them touch the database: `concat_records` skips `insert_record`
under `unless owner.new_record?` (collection_association.rb:434-448) and
`remove_records` skips `delete_records` when `existing_records` is empty
(:404-405).

Restate the chain as `Promise<T> | T` bodies — the shape `assignAttributes` /
`_assignAttributes` and `set#{Name}Attributes` already use: run inline, answer a
promise only when a call actually owed I/O, and chain the tail behind it.
Existing `await` call sites are unchanged. This unblocks `replace`'s new-owner
arm delegating to `replace_records` (collection_association.rb:246-254,
:414-424), which is reached synchronously from the constructor's
mass-assignment dispatch.

`HasManyAssociation#concatRecords` and the `HasManyThroughAssociation`
overrides of `concatRecords` / `removeRecords` follow; HMT's
`deleteThroughRecords` is pure in-memory work and drops its `Promise.resolve()`
wrapper.

Closes-story: convert-collection-removal-chain-to-sync-hybrid
