### PR TITLE
fix(parity): count Rails' test/**/behaviors mixin cases; enroll the rest of CacheStoreCompressionBehavior

### DIFF
--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1618,20 +1618,26 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   // treatment as pluck/pick/count. Without overriding, cp.sum('x') /
   // cp.whereBang({...}); cp.average('y') would both bypass the gate
   // and drop in-place mutations.
-  async sum(column?: string): Promise<number | bigint | Map<unknown, number | bigint>> {
+  async sum(
+    initialValueOrColumn?: string | Nodes.Node | number,
+  ): Promise<number | bigint | Map<unknown, number | bigint>> {
     this._checkStrictLoading();
     const fn = (
       Relation.prototype as unknown as {
-        sum: (col?: string) => Promise<number | bigint | Map<unknown, number | bigint>>;
+        sum: (
+          col?: string | Nodes.Node | number,
+        ) => Promise<number | bigint | Map<unknown, number | bigint>>;
       }
     ).sum;
-    if (this._relationStateDiverged()) return fn.call(this, column);
+    if (this._relationStateDiverged()) return fn.call(this, initialValueOrColumn);
     const s = this.scope();
     return (
       s as unknown as {
-        sum: (col?: string) => Promise<number | bigint | Map<unknown, number | bigint>>;
+        sum: (
+          col?: string | Nodes.Node | number,
+        ) => Promise<number | bigint | Map<unknown, number | bigint>>;
       }
-    ).sum(column);
+    ).sum(initialValueOrColumn);
   }
 
   async average(column: string): Promise<unknown | null | Map<unknown, unknown>> {

--- a/packages/activerecord/src/calculations.trails.test.ts
+++ b/packages/activerecord/src/calculations.trails.test.ts
@@ -373,6 +373,32 @@ describe("empty-scope aggregate identities", () => {
     expect(await Account.none().sum("firm_id")).toBe(0);
   });
 
+  // Rails' `sum(initial_value_or_column = 0)` (calculations.rb:171-177) sends the
+  // identity through `calculate`, where `arel_column`'s `field.to_s`
+  // (query_methods.rb:1993) turns it into the literal summed over.
+  it("sums the identity value when no column is given", async () => {
+    const { Account } = await import("./test-helpers/models/account.js");
+    const rows = (await Account.count()) as number;
+    expect(await Account.sum()).toBe(0);
+    expect(await Account.sum(1000)).toBe(1000 * rows);
+    expect(await Account.calculate("sum", 1000)).toBe(1000 * rows);
+    expect(await Account.all().calculate("sum", 1000)).toBe(1000 * rows);
+    expect(await Account.asyncSum(1000)).toBe(1000 * rows);
+  });
+
+  // `CollectionProxy < Relation` (collection_proxy.rb:31) inherits the same
+  // `sum(initial_value_or_column = 0)`, so the strict-loading override must not
+  // narrow it away.
+  it("sums the identity value through a collection proxy", async () => {
+    const { Firm } = await import("./test-helpers/models/company.js");
+    const firm = (await Firm.firstBang()) as unknown as {
+      accounts: { sum(v?: string | number): Promise<number | bigint> };
+    };
+    const rows = Number(await firm.accounts.sum(1));
+    expect(rows).toBeGreaterThan(0);
+    expect(await firm.accounts.sum(1000)).toBe(1000 * rows);
+  });
+
   it("keeps the empty identity for every aggregate on a contradictory scope", async () => {
     const { Account } = await import("./test-helpers/models/account.js");
     const empty = Account.where({ id: [] });

--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -1004,12 +1004,10 @@ export function except<T extends typeof Base>(
 export function calculate<T extends typeof Base>(
   this: T,
   operation: "count" | "sum" | "average" | "minimum" | "maximum",
-  column?: string,
+  column?: Parameters<Relation<InstanceType<T>>["calculate"]>[1],
 ): ReturnType<Relation<InstanceType<T>>["calculate"]> {
   const rel = this.all();
-  return rel.calculate(operation as "count", column) as ReturnType<
-    Relation<InstanceType<T>>["calculate"]
-  >;
+  return rel.calculate(operation, column);
 }
 
 /** Mirrors: ActiveRecord::Querying#async_count — params/return derived from Relation#asyncCount. */
@@ -1048,9 +1046,9 @@ export function asyncMaximum<T extends typeof Base>(
 /** Mirrors: ActiveRecord::Querying#async_sum — delegates through all(). */
 export function asyncSum<T extends typeof Base>(
   this: T,
-  column?: string,
+  identityOrColumn?: Parameters<Relation<InstanceType<T>>["asyncSum"]>[0],
 ): ReturnType<Relation<InstanceType<T>>["asyncSum"]> {
-  return this.all().asyncSum(column);
+  return this.all().asyncSum(identityOrColumn);
 }
 
 /** Mirrors: ActiveRecord::Querying#async_pluck — params/return derived from Relation#asyncPluck. */

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3422,7 +3422,7 @@ export class Relation<T extends Base> {
   /**
    * Mirrors: ActiveRecord::Relation#async_sum
    */
-  asyncSum(identityOrColumn?: string) {
+  asyncSum(identityOrColumn?: Parameters<Relation<T>["sum"]>[0]) {
     return this.sum(identityOrColumn);
   }
 
@@ -7144,7 +7144,7 @@ export class Relation<T extends Base> {
   /** @internal */
   private async executeSimpleCalculation(
     operation: string,
-    columnName: string,
+    columnName: Parameters<typeof _executeSimpleCalculation>[2],
     distinct: boolean,
   ): Promise<unknown> {
     return _executeSimpleCalculation(this as any, operation, columnName, distinct);
@@ -7153,7 +7153,7 @@ export class Relation<T extends Base> {
   /** @internal */
   private async executeGroupedCalculation(
     operation: string,
-    columnName: string,
+    columnName: Parameters<typeof _executeGroupedCalculation>[2],
     distinct: boolean,
   ): Promise<Record<string, unknown> | Map<unknown, unknown>> {
     return _executeGroupedCalculation(this as any, operation, columnName, distinct);

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -9,7 +9,7 @@
  */
 
 import { Nodes, Table, SelectManager } from "@blazetrails/arel";
-import { BigIntegerType } from "@blazetrails/activemodel";
+import { ArgumentError, BigIntegerType } from "@blazetrails/activemodel";
 import { any, many, tryCall } from "@blazetrails/activesupport";
 import type { AdapterName } from "../connection-adapters/abstract-adapter.js";
 import type { Base } from "../base.js";
@@ -149,7 +149,7 @@ function isCoerceNumericTypeName(name: string | undefined): boolean {
 function buildAggNode(
   rel: CalculationRelation,
   fn: AggFn,
-  column: string | Nodes.Node,
+  column: string | Nodes.Node | number,
   distinct: boolean,
 ): any {
   const sqlName = SQL_FN_NAMES[fn];
@@ -337,13 +337,17 @@ function applyFromToManager(rel: CalculationRelation, manager: any): void {
   if (fromNode !== undefined && fromNode !== null) manager.from(fromNode);
 }
 
-function isBigintColumn(rel: CalculationRelation, fn: AggFn, column: string | Nodes.Node): boolean {
+function isBigintColumn(
+  rel: CalculationRelation,
+  fn: AggFn,
+  column: string | Nodes.Node | number,
+): boolean {
   if (fn === "count" || fn === "average" || column === "*") return false;
   if (column instanceof Nodes.Node) return false;
   const table = rel._model.arelTable as {
     typeForAttribute?(col: string): unknown;
   };
-  return table.typeForAttribute?.(column) instanceof BigIntegerType;
+  return table.typeForAttribute?.(String(column)) instanceof BigIntegerType;
 }
 
 /**
@@ -423,7 +427,7 @@ function foldSelectValuesForHaving(rel: CalculationRelation, manager: any): void
 async function groupedAggregate(
   rel: CalculationRelation,
   fn: AggFn,
-  column: string | Nodes.Node,
+  column: string | Nodes.Node | number,
   distinct: boolean | null = rel._isDistinct,
 ): Promise<Map<unknown, unknown>> {
   rel._checkEagerLoadable();
@@ -591,7 +595,7 @@ async function groupedCompositeAssoc(
   rel: CalculationRelation,
   association: any,
   fn: AggFn,
-  column: string | Nodes.Node,
+  column: string | Nodes.Node | number,
 ): Promise<Map<unknown, unknown>> {
   const table = rel._model.arelTable;
   const fkCols = association.foreignKey as string[];
@@ -675,7 +679,13 @@ async function groupedCompositeAssoc(
 export async function performCount(
   this: CalculationRelation,
   columnName?: string | Nodes.Node,
+  ...rest: unknown[]
 ): Promise<number | Map<unknown, number>> {
+  // Ruby's `def count(column_name = nil)` arity check; JS silently drops the
+  // extra arguments, so the ArgumentError has to be raised explicitly.
+  if (rest.length > 0) {
+    throw new ArgumentError(`wrong number of arguments (given ${rest.length + 1}, expected 0..1)`);
+  }
   return calculate.call(this, "count", columnName) as Promise<number | Map<unknown, number>>;
 }
 
@@ -735,7 +745,7 @@ export async function calculate(
 /**
  * Mirrors: ActiveRecord::Calculations#sum (calculations.rb:171-177).
  *
- * The identity default falls through `aggregate_column` → `arel_column`, whose
+ * The identity default falls through `aggregate_column` -> `arel_column`, whose
  * `field.to_s` (query_methods.rb:1993) makes it the SQL literal summed over, so
  * the no-argument answer comes out of `calculate` rather than a guard. The
  * block arm (`map(&block).sum(initial_value_or_column)`, calculations.rb:172-173)
@@ -792,15 +802,17 @@ export interface CalculationMethods {
   calculate(operation: "count", column?: string): Promise<number | Map<unknown, number>>;
   calculate(
     operation: "sum",
-    column: string,
+    column: string | Nodes.Node | number,
   ): Promise<number | bigint | Map<unknown, number | bigint>>;
   calculate(
     operation: "average" | "minimum" | "maximum",
     column: string,
   ): Promise<unknown | null | Map<unknown, unknown>>;
-  calculate(operation: string, column?: string | Nodes.Node): Promise<unknown>;
+  calculate(operation: string, column?: string | Nodes.Node | number): Promise<unknown>;
   count(column?: string | Nodes.Node): Promise<number | Map<unknown, number>>;
-  sum(column?: string | Nodes.Node): Promise<number | bigint | Map<unknown, number | bigint>>;
+  sum(
+    initialValueOrColumn?: string | Nodes.Node | number,
+  ): Promise<number | bigint | Map<unknown, number | bigint>>;
   average(column: string | Nodes.Node): Promise<unknown | null | Map<unknown, unknown>>;
   minimum(column: string | Nodes.Node): Promise<unknown | null | Map<unknown, unknown>>;
   maximum(column: string | Nodes.Node): Promise<unknown | null | Map<unknown, unknown>>;
@@ -869,7 +881,7 @@ export class ColumnAliasTracker {
  * has no name to build an alias from and keeps the internal "val".
  * @internal
  */
-function aggregateAliasFor(fn: AggFn, column: string | Nodes.Node): string {
+function aggregateAliasFor(fn: AggFn, column: string | Nodes.Node | number): string {
   if (typeof column !== "string") return "val";
   return columnAliasFor(`${fn} ${column.toLowerCase()}`.replace(/\*/g, "all"));
 }
@@ -893,9 +905,6 @@ export function aggregateColumn(
   columnName: string | Nodes.Node | number,
 ): unknown {
   if (columnName instanceof Nodes.Node) return columnName;
-  // Ruby `arel_column`'s `field.to_s` (query_methods.rb:1993), which is what
-  // turns `sum`'s Integer identity default into the literal it sums over.
-  columnName = String(columnName);
   const table = rel._model.arelTable;
   // Ruby `when :all then Arel.star` (calculations.rb:418-419) — ":all" is
   // spelled "*"/"all" here. "1" is the count-subquery's literal projection.
@@ -951,7 +960,9 @@ export function hasInclude(
  * than pretending trails supports it.
  * @internal
  */
-function aggregateTarget(columnName: string | string[] | Nodes.Node | null): string | Nodes.Node {
+function aggregateTarget(
+  columnName: string | string[] | Nodes.Node | number | null,
+): string | Nodes.Node | number {
   if (columnName == null) return "*";
   return Array.isArray(columnName) ? columnName.join(",") : columnName;
 }
@@ -987,9 +998,29 @@ export function performCalculation(
   }
 
   if (any(rel.groupValues)) {
-    return (rel as any).executeGroupedCalculation(operation, columnName, distinct);
+    return dispatchTarget(rel).executeGroupedCalculation(operation, columnName, distinct);
   }
-  return (rel as any).executeSimpleCalculation(operation, columnName, distinct);
+  return dispatchTarget(rel).executeSimpleCalculation(operation, columnName, distinct);
+}
+
+// Rails' `perform_calculation` calls its two private siblings directly
+// (calculations.rb:455-457). They are `private` on `Relation` too, and a TS
+// `private` member cannot satisfy a public interface member, so the dispatch
+// reaches them through this structural view rather than `any` — the column name
+// keeps the type `perform_calculation` resolved it to.
+function dispatchTarget(rel: CalculationRelation): {
+  executeSimpleCalculation(
+    operation: string,
+    columnName: string | string[] | Nodes.Node | number | null,
+    distinct: boolean | null,
+  ): Promise<unknown>;
+  executeGroupedCalculation(
+    operation: string,
+    columnName: string | string[] | Nodes.Node | number | null,
+    distinct: boolean | null,
+  ): Promise<unknown>;
+} {
+  return rel as never;
 }
 
 /** @internal */
@@ -1021,7 +1052,7 @@ export function operationOverAggregateColumn(
  */
 function buildCountSubquery(
   relation: CalculationRelation,
-  columnName: string | Nodes.Node | null,
+  columnName: string | Nodes.Node | number | null,
   distinct: boolean,
 ): [SelectManager, unknown[]] {
   const table = relationTable(relation);
@@ -1083,7 +1114,7 @@ function buildCountSubquery(
 export async function executeSimpleCalculation(
   rel: CalculationRelation,
   operation: string,
-  columnName: string | string[] | Nodes.Node | null,
+  columnName: string | string[] | Nodes.Node | number | null,
   distinct: boolean | null,
 ): Promise<unknown> {
   // DIVERGENCE (calculations.rb:469-511): each arm compiles to SQL + binds
@@ -1201,7 +1232,7 @@ function typeCasterFor(column: unknown): unknown {
 export async function executeGroupedCalculation(
   rel: CalculationRelation,
   operation: string,
-  columnName: string | string[] | Nodes.Node | null,
+  columnName: string | string[] | Nodes.Node | number | null,
   distinct: boolean | null,
 ): Promise<Map<unknown, unknown>> {
   const fn = operation.toLowerCase() as AggFn;
@@ -1215,7 +1246,7 @@ export async function executeGroupedCalculation(
 }
 
 /** @internal */
-export function typeFor(rel: CalculationRelation, field: string | Nodes.Node): unknown {
+export function typeFor(rel: CalculationRelation, field: string | Nodes.Node | number): unknown {
   const fieldName =
     field instanceof Nodes.Node
       ? String((field as unknown as { name?: string }).name ?? "")
@@ -1373,7 +1404,7 @@ export function selectForCount(rel: CalculationRelation): string {
 export function isBuildCountSubquery(
   rel: CalculationRelation,
   operation: string,
-  columnName: string | string[] | Nodes.Node | null,
+  columnName: string | string[] | Nodes.Node | number | null,
   distinct: boolean,
 ): boolean {
   const isAll = columnName == null || columnName === "*" || columnName === "all";

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -113,7 +113,7 @@ interface CalculationRelation {
   /** @internal Awaitable `apply_join_dependency`; see Relation. */
   _applyJoinDependencyAsync<R>(run: (relation: CalculationRelation) => Promise<R>): Promise<R>;
   /** Mirrors `Relation#calculate`; `calculate` recurses through it. */
-  calculate(operation: string, columnName?: string | Nodes.Node): Promise<unknown>;
+  calculate(operation: string, columnName?: string | Nodes.Node | number): Promise<unknown>;
   _applyWheresToManager(manager: any, table: any): void;
   _applyOrderToManager(manager: any): void;
   _buildFromNode(): Nodes.Node | string | undefined;
@@ -685,7 +685,7 @@ export async function performCount(
 export async function calculate(
   this: CalculationRelation,
   operation: string,
-  columnName?: string | Nodes.Node,
+  columnName?: string | Nodes.Node | number,
 ): Promise<unknown> {
   operation = operation.toLowerCase();
 
@@ -732,12 +732,20 @@ export async function calculate(
   }
 }
 
+/**
+ * Mirrors: ActiveRecord::Calculations#sum (calculations.rb:171-177).
+ *
+ * The identity default falls through `aggregate_column` → `arel_column`, whose
+ * `field.to_s` (query_methods.rb:1993) makes it the SQL literal summed over, so
+ * the no-argument answer comes out of `calculate` rather than a guard. The
+ * block arm (`map(&block).sum(initial_value_or_column)`, calculations.rb:172-173)
+ * is tracked by the `port-relation-sum-block-arm` story.
+ */
 export async function performSum(
   this: CalculationRelation,
-  column?: string | Nodes.Node,
+  initialValueOrColumn: string | Nodes.Node | number = 0,
 ): Promise<number | bigint | Map<unknown, number | bigint>> {
-  if (!column) return 0;
-  const sum = await calculate.call(this, "sum", column);
+  const sum = await calculate.call(this, "sum", initialValueOrColumn);
   if (this._groupColumns.length > 0) return sum as Map<unknown, number | bigint>;
   return (sum as number | bigint) ?? 0;
 }
@@ -882,9 +890,12 @@ function truncate(name: string): string {
 /** @internal */
 export function aggregateColumn(
   rel: CalculationRelation,
-  columnName: string | Nodes.Node,
+  columnName: string | Nodes.Node | number,
 ): unknown {
   if (columnName instanceof Nodes.Node) return columnName;
+  // Ruby `arel_column`'s `field.to_s` (query_methods.rb:1993), which is what
+  // turns `sum`'s Integer identity default into the literal it sums over.
+  columnName = String(columnName);
   const table = rel._model.arelTable;
   // Ruby `when :all then Arel.star` (calculations.rb:418-419) — ":all" is
   // spelled "*"/"all" here. "1" is the count-subquery's literal projection.
@@ -916,7 +927,7 @@ export function isAllAttributes(rel: CalculationRelation, columnNames: string[])
 /** @internal */
 export function hasInclude(
   rel: CalculationRelation,
-  columnName: string | Nodes.Node | null,
+  columnName: string | Nodes.Node | number | null,
 ): boolean {
   const anyRel = rel as any;
   // eager_load_values.any? → always triggers (part of eager_loading?)
@@ -949,7 +960,7 @@ function aggregateTarget(columnName: string | string[] | Nodes.Node | null): str
 export function performCalculation(
   rel: CalculationRelation,
   operation: string,
-  columnName: string | string[] | Nodes.Node | null,
+  columnName: string | string[] | Nodes.Node | number | null,
 ): Promise<unknown> {
   operation = operation.toLowerCase();
 
@@ -984,7 +995,7 @@ export function performCalculation(
 /** @internal */
 export function isDistinctSelect(
   _rel: CalculationRelation,
-  columnName: string | string[] | Nodes.Node,
+  columnName: string | string[] | Nodes.Node | number,
 ): boolean {
   return typeof columnName === "string" && /\bDISTINCT[\s(]/i.test(columnName);
 }

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2080,7 +2080,7 @@ export function isTableNameMatches(this: QueryMethodsHost, from: unknown): boole
 /** @internal */
 export function arelColumn(
   this: QueryMethodsHost,
-  field: string | symbol | Nodes.Node,
+  field: string | symbol | number | Nodes.Node,
   fallback?: (attr: string) => unknown,
 ): unknown {
   const modelClass: any = this.model;
@@ -2089,7 +2089,10 @@ export function arelColumn(
   // the block, else passes through unchanged (query_methods.rb:1996-2003).
   if (field instanceof Nodes.Node) return fallback ? fallback(field as any) : field;
   const isSymbol = typeof field === "symbol";
-  let fieldStr = isSymbol ? symbolToName(field) : field;
+  // Ruby `field = field.name if is_symbol` then `field.to_s`
+  // (query_methods.rb:1991-1993) — which is what carries `sum`'s Integer
+  // identity default through as the literal it sums over.
+  let fieldStr = isSymbol ? symbolToName(field) : String(field);
   fieldStr = modelClass?._attributeAliases?.[fieldStr] ?? fieldStr;
 
   const fromClause = (this as any)._fromClause;

--- a/packages/activesupport/src/cache/behaviors/cache-store-compression-behavior.ts
+++ b/packages/activesupport/src/cache/behaviors/cache-store-compression-behavior.ts
@@ -1,5 +1,8 @@
-import { beforeEach, expect, it } from "vitest";
+import { afterEach, beforeEach, expect, it } from "vitest";
 import { Entry } from "../entry.js";
+import { coder } from "../coder.js";
+import { getFormatVersion, setFormatVersion } from "../format-version-slot.js";
+import { deflate, inflate } from "../../gzip.js";
 import type { Store, StoreOptions } from "../store.js";
 
 // Mirrors Rails `CacheStoreCompressionBehavior`
@@ -15,6 +18,15 @@ const LARGE_STRING = "0".repeat(2 * 1024);
 
 const SMALL_OBJECT = { data: SMALL_STRING };
 const LARGE_OBJECT = { data: LARGE_STRING };
+
+// Ruby names `Marshal` and `Zlib` directly; trails' equivalents are the
+// fidelity coder (cache/coder.ts) framed as a cache coder, and the gzip pair
+// `Store#initialize` itself installs as the default `:compressor`.
+const MARSHAL_CODER = {
+  dump: (entry: Entry): string => coder.dump(entry.pack()),
+  load: (payload: string): Entry => Entry.unpack(coder.load(payload) as unknown[]),
+};
+const ZLIB = { deflate, inflate };
 
 /** @internal */
 export interface CompressionBehaviorHost {
@@ -33,6 +45,22 @@ export function cacheStoreCompressionBehavior(host: CompressionBehaviorHost): vo
   beforeEach(() => {
     cache = host.lookupStore();
   });
+
+  afterEach(() => {
+    setFormatVersion(7.0);
+  });
+
+  // Ruby `ActiveSupport::Cache.with(format_version:)` (Object#with), which
+  // restores the previous value once the block returns.
+  function withFormat<T>(formatVersion: number, block: () => T): T {
+    const previous = getFormatVersion();
+    setFormatVersion(formatVersion);
+    try {
+      return block();
+    } finally {
+      setFormatVersion(previous);
+    }
+  }
 
   function computeEntrySizeReduction(value: unknown, withOptions: StoreOptions = {}): number {
     const entry = new Entry(value);
@@ -88,6 +116,26 @@ export function cacheStoreCompressionBehavior(host: CompressionBehaviorHost): vo
     }
   }
 
+  it("compression works with cache format version 7.0 (using Marshal70WithFallback)", () => {
+    cache = withFormat(7.0, () => host.lookupStore({ compress: true }));
+    assertCompression(true);
+  });
+
+  it("compression works with cache format version >= 7.1 (using Cache::Coder)", () => {
+    cache = withFormat(7.1, () => host.lookupStore({ compress: true }));
+    assertCompression(true);
+  });
+
+  it("compression is disabled with custom coder", () => {
+    cache = withFormat(7.1, () => host.lookupStore({ coder: MARSHAL_CODER }));
+    assertCompression(false);
+  });
+
+  it("compression works with custom serializer", () => {
+    cache = withFormat(7.1, () => host.lookupStore({ compress: true, serializer: coder }));
+    assertCompression(true);
+  });
+
   it("compression by default", () => {
     cache = host.lookupStore();
     assertCompression(!host.compressionAlwaysDisabledByDefault);
@@ -124,12 +172,55 @@ export function cacheStoreCompressionBehavior(host: CompressionBehaviorHost): vo
     assertCompression(":all", { compressThreshold: 1 });
   });
 
+  it("compression ignores nil", () => {
+    assertNotCompress(null);
+    assertNotCompress(null, { compress: true, compressThreshold: 1 });
+  });
+
   it("compression ignores incompressible data", () => {
     assertNotCompress("", { compress: true, compressThreshold: 1 });
     // Ruby's `[*0..127].pack("C*")`.
     assertNotCompress(Array.from({ length: 128 }, (_, i) => String.fromCharCode(i)).join(""), {
       compress: true,
       compressThreshold: 1,
+    });
+  });
+
+  it("compressor can be specified", () => {
+    const lossyCompressor = {
+      deflate(_dumped: string): string {
+        return "yolo";
+      },
+      inflate(compressed: string): string | undefined {
+        return compressed === "yolo" ? coder.dump("lossy!") : undefined;
+      },
+    };
+
+    cache = withFormat(7.1, () =>
+      host.lookupStore({ compress: true, compressor: lossyCompressor, serializer: coder }),
+    );
+    const key = crypto.randomUUID();
+
+    cache.write(key, LARGE_OBJECT);
+    expect(cache.read(key)).toBe("lossy!");
+  });
+
+  it("compressor can be nil", () => {
+    cache = withFormat(7.1, () => host.lookupStore({ compressor: null }));
+    assertCompression(false);
+  });
+
+  it("specifying a compressor raises when cache format version < 7.1", () => {
+    withFormat(7.0, () => {
+      expect(() => host.lookupStore({ compressor: ZLIB })).toThrow(/compressor/i);
+    });
+  });
+
+  it("specifying a compressor raises when also specifying a coder", () => {
+    withFormat(7.1, () => {
+      expect(() => host.lookupStore({ compressor: ZLIB, coder: MARSHAL_CODER })).toThrow(
+        /compressor/i,
+      );
     });
   });
 }

--- a/scripts/test-compare/compare.ts
+++ b/scripts/test-compare/compare.ts
@@ -117,6 +117,11 @@ function enforceGateZero(results: { package: string; totalGateMismatch: number }
  * i18n gem's lib root is `lib/i18n` while its test root is `test`, so a test
  * mirroring `lib/i18n/<x>.rb` sits at `test/i18n/<x>_test.rb`; that leading
  * segment is dropped so both sides land on `packages/i18n/src/<x>`.
+ *
+ * A shared test-behavior mixin (a `_behavior.rb` file under a `behaviors`
+ * directory) is not a test file on either side — ours is a plain module the
+ * including store test calls — so it maps onto `-behavior.ts`, not
+ * `-behavior.test.ts`.
  */
 export function rubyToConventionTs(rubyFile: string, pkg: string): string {
   if (pkg === "rack") {
@@ -139,7 +144,7 @@ export function rubyToConventionTs(rubyFile: string, pkg: string): string {
   // are credited, not counted as unmapped.
   const base = PATH_SEGMENT_ALIASES[rawBase] ?? rawBase;
   const kebab = base.replace(/_/g, "-");
-  const tsFile = kebab + ".test.ts";
+  const tsFile = /_behavior$/.test(rawBase) ? kebab + ".ts" : kebab + ".test.ts";
 
   let tsDir =
     dir === "."

--- a/scripts/test-compare/extract-ruby-tests.rb
+++ b/scripts/test-compare/extract-ruby-tests.rb
@@ -1544,9 +1544,13 @@ def run
 
     # Find test files, excluding arel tests from the activerecord package
     # (they belong to the arel package)
+    # Shared test-behavior mixins define their `test` blocks in a module and
+    # match none of the three name patterns above; process_module /
+    # flush_collected_modules materialize them once the file is scanned.
     test_files = Dir.glob(File.join(pkg_dir, "**", "*_test.rb")) +
                  Dir.glob(File.join(pkg_dir, "**", "test_*.rb")) +
-                 Dir.glob(File.join(pkg_dir, "**", "spec_*.rb"))
+                 Dir.glob(File.join(pkg_dir, "**", "spec_*.rb")) +
+                 Dir.glob(File.join(pkg_dir, "**", "behaviors", "*_behavior.rb"))
     test_files.uniq!
 
     # For activerecord, exclude arel test files (handled by arel package)

--- a/scripts/test-compare/extract-ts-tests.ts
+++ b/scripts/test-compare/extract-ts-tests.ts
@@ -29,7 +29,12 @@ function getPackageTestFiles(): Record<string, string[]> {
 
   for (const pkg of packages) {
     const pattern = `packages/${pkg}/src/**/*.test.ts`;
-    const files = globSync(pattern, { cwd: ROOT_DIR }).sort();
+    // Twin of the Ruby side's `test/**/behaviors/*_behavior.rb` glob.
+    const behaviorPattern = `packages/${pkg}/src/**/behaviors/*-behavior.ts`;
+    const files = [
+      ...globSync(pattern, { cwd: ROOT_DIR }),
+      ...globSync(behaviorPattern, { cwd: ROOT_DIR }),
+    ].sort();
 
     result[pkg] = files;
   }


### PR DESCRIPTION
Bundle of three stories. The fourth,
`converge-memory-store-coder-install-guards`, turned out to be already
implemented on `main` by **#6440**, which landed while this branch was open —
it is marked done against that PR and is not part of this diff.

## 1. `parity:test` counts Rails' `test/**/behaviors/` mixin cases

`scripts/test-compare/extract-ruby-tests.rb` collected the Ruby denominator from
`*_test.rb` / `test_*.rb` / `spec_*.rb` only. Rails' shared test-behavior mixins
match none of those — they live at `activesupport/test/cache/behaviors/*_behavior.rb`
— so their cases were absent from the denominator even though `process_module` /
`flush_collected_modules` already know how to materialize a mixin module's `test`
blocks at the including class's gate. Three changes:

- Ruby extractor also globs `**/behaviors/*_behavior.rb`.
- TS extractor also globs `packages/<pkg>/src/**/behaviors/*-behavior.ts` (our
  behavior helpers are plain modules the store test calls, not `*.test.ts`).
- `rubyToConventionTs` maps `*_behavior.rb` onto `*-behavior.ts`, not
  `*-behavior.test.ts`.

Only `activesupport` has a `behaviors/` tree in vendored Rails, so the blast
radius is that package alone.

**One-time denominator movement** (`pnpm parity:test --package activesupport`):

| | before | after |
|---|---|---|
| matched / total | 2393 / 2758 (86.8%) | 2417 / 2952 (81.9%) |
| files | 148 / 148 | 149 / 163 |
| misplaced | 0 | 10 |

The +194 denominator is the 15 previously-unscanned Rails behavior files. The
+23 matched are #6439's six `CacheStoreCompressionBehavior` cases (which
previously credited as nothing), the eight enrolled below, and cases in
`cache_increment_decrement_behavior.rb` / `cache_delete_matched_behavior.rb`
that were already ported. The 10 misplaced are pre-existing behavior-suite tests
living in `cache-store-base.test.ts` / `mem-cache-store.test.ts` / the store test
files rather than in a behavior helper; they were invisible before and are
report-only now (`misplaced` has no CI gate). `parity:test`,
`parity:test:assertions` and the gate-mismatch check all exit 0.

## 2. The remaining `CacheStoreCompressionBehavior` cases

#6440 landed `Store#initialize`'s serializer/compressor arms, `default_serializer`
and `validate_options`, which is what the remaining cases needed. These nine are
enrolled here verbatim, in Rails' order, for FileStore and MemoryStore:

- `compression works with cache format version 7.0 (using Marshal70WithFallback)`
- `compression works with cache format version >= 7.1 (using Cache::Coder)`
- `compression is disabled with custom coder`
- `compression works with custom serializer`
- `compression ignores nil`
- `compressor can be specified`
- `compressor can be nil`
- `specifying a compressor raises when cache format version < 7.1`
- `specifying a compressor raises when also specifying a coder`

`with_format` is ported as `withFormat` over the `format-version-slot` accessors
#6440 introduced. Ruby names `Marshal` and `Zlib` directly; the trails stands-in
are the fidelity coder framed as a cache coder, and the `gzip.ts` deflate/inflate
pair `Store#initialize` itself installs as the default `:compressor`. The helper
also gains the `beforeEach` standing in for the including class's `setup`
(`@cache = lookup_store`), which the cases that never call `lookup_store`
themselves rely on.

`compression ignores incompressible data` (:71-74) was the one case that could
not hold when this PR was written — trails' JSON fidelity coder escaped the
control bytes of `[*0..127].pack("C*")` into a compressible payload. That was
filed with the measurement as
`0101/converge-fidelity-coder-binary-string-payload` and **#6446 has since
landed it**, so all fourteen names are now present verbatim and green for both
stores — `parity:test` reads the file **16/16 ✓**, fully complete. This PR
rebases onto #6446, keeping its `beforeEach` (the stand-in for the including
class's `setup`, which the cases that never call `lookup_store` rely on), its
`sizeOf` byte-counting fix and its incompressible-data case, and adding the nine
above.

## 3. `sum`'s identity default converges through `calculate` / `arel_column`

`calculations.rb:171-177` is `sum(initial_value_or_column = 0, &block)` with no
pre-`calculate` branch, so `performSum`'s trails-only `if (!column) return 0` is
gone. The identity reaches SQL the way Rails sends it: `calculate` →
`aggregate_column` → `arel_column`, whose `field.to_s`
(query_methods.rb:1990-1994) makes it the literal summed over. `Model.sum()`
still answers 0, now through `calculate` like its three
`performAverage`/`Minimum`/`Maximum` siblings after #6438.

The conversion lives at Rails' site — `arelColumn` — rather than at one caller,
because `buildAggNode` reaches it without passing through `aggregateColumn`.
Every signature the identity threads through carries the type unnarrowed: the
public `calculate` overloads and `Querying#calculate`'s delegate, `asyncSum`,
`CollectionProxy#sum` (`CollectionProxy < Relation`, collection_proxy.rb:31),
and `perform_calculation`'s two private siblings, whose dispatch now goes
through a structural view instead of `as any`. Regression coverage in
`calculations.trails.test.ts` pins `sum(1000)`, `calculate("sum", 1000)` on both
the static and relation paths, `asyncSum(1000)`, and a collection-proxy
`sum(1000)` against row count.

One thing this surfaced: `count with too many parameters raises` was passing off
the *TypeError* the missing `to_s` produced, not an arity check. `performCount`
now raises Ruby's `count(column_name = nil)` `ArgumentError` explicitly.

The block arm (`map(&block).sum(...)`) is registered as
`0084/port-relation-sum-block-arm`, cited at the call site.

## Gates

`pnpm typecheck`, `pnpm lint`, `pnpm parity:api`, `pnpm parity:api:calls`,
`pnpm parity:api:calls:args`, `pnpm parity:api:extra` all green with no new
baseline rows. `packages/activesupport/src/cache/**`,
`packages/activerecord/src/calculations*.test.ts` and `scripts/test-compare/**`
pass, as do `packages/activerecord/src/relation/**` (1079) and the
collection-proxy suites. 242 additions / 48 deletions.

Closes-story: test-compare-scans-rails-behavior-mixin-files
Closes-story: enroll-remaining-cache-store-compression-cases
Closes-story: drop-perform-sum-nil-column-short-circuit



