### PR TITLE
feat(activesupport): port Cache::Store.retrieve_pool_options and XmlMini nokogiri parse's IO/eof arms

### DIFF
--- a/packages/activesupport/src/cache/memory-store.ts
+++ b/packages/activesupport/src/cache/memory-store.ts
@@ -274,7 +274,7 @@ export namespace DupCoder {
    * Ruby's `value.dup` guards against the caller mutating the stored String;
    * JS strings are immutable, so the String arm returns it as-is.
    */
-  function dumpValue(value: unknown): string {
+  export function dumpValue(value: unknown): string {
     if (typeof value === "string" && !value.startsWith(MARSHAL_SIGNATURE)) {
       return value;
     } else {
@@ -283,7 +283,7 @@ export namespace DupCoder {
   }
 
   /** Mirrors Rails MemoryStore::DupCoder#load_value (memory_store.rb:64-70). */
-  function loadValue(string: string): unknown {
+  export function loadValue(string: string): unknown {
     if (string.startsWith(MARSHAL_SIGNATURE)) {
       return coder.load(string.slice(MARSHAL_SIGNATURE.length));
     } else {

--- a/packages/activesupport/src/cache/store-pool-options.trails.test.ts
+++ b/packages/activesupport/src/cache/store-pool-options.trails.test.ts
@@ -31,11 +31,37 @@ describe("Store.retrievePoolOptions", () => {
 
   it("raises for pool size and timeout that cannot be converted", () => {
     expect(() => Store.retrievePoolOptions({ pool: { size: [] } })).toThrow(
-      "can't convert object into Integer",
+      "can't convert Array into Integer",
     );
     expect(() => Store.retrievePoolOptions({ pool: { timeout: [] } })).toThrow(
-      "can't convert object into Float",
+      "can't convert Array into Float",
     );
+    expect(() => Store.retrievePoolOptions({ pool: { size: "" } })).toThrow(
+      'invalid value for Integer(): ""',
+    );
+    expect(() => Store.retrievePoolOptions({ pool: { size: " " } })).toThrow(
+      'invalid value for Integer(): " "',
+    );
+    expect(() => Store.retrievePoolOptions({ pool: { size: "1.5" } })).toThrow(
+      'invalid value for Integer(): "1.5"',
+    );
+    expect(() => Store.retrievePoolOptions({ pool: { timeout: "" } })).toThrow(
+      'invalid value for Float(): ""',
+    );
+  });
+
+  it("converts pool size and timeout the way Kernel#Integer and Kernel#Float do", () => {
+    // `Integer("012")` is octal (10), `Integer("1_000")` allows the separator,
+    // and a Float size truncates rather than rounding.
+    expect(Store.retrievePoolOptions({ pool: { size: "012" } })).toEqual({ size: 10, timeout: 5 });
+    expect(Store.retrievePoolOptions({ pool: { size: "1_000" } })).toEqual({
+      size: 1000,
+      timeout: 5,
+    });
+    expect(Store.retrievePoolOptions({ pool: { size: 3.7, timeout: " 1.5 " } })).toEqual({
+      size: 3,
+      timeout: 1.5,
+    });
   });
 
   it("deletes the :pool key from the options it is given", () => {

--- a/packages/activesupport/src/cache/store-pool-options.trails.test.ts
+++ b/packages/activesupport/src/cache/store-pool-options.trails.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { Store } from "./store.js";
+
+// trails-only coverage for `Cache::Store.retrieve_pool_options`
+// (cache.rb:200-220); Rails reaches it through MemCacheStore/RedisCacheStore,
+// neither of which is ported.
+describe("Store.retrievePoolOptions", () => {
+  it("defaults to the default pool options when :pool is absent", () => {
+    expect(Store.retrievePoolOptions({})).toEqual({ size: 5, timeout: 5 });
+  });
+
+  it("returns false for pool: false and for a stored nil", () => {
+    expect(Store.retrievePoolOptions({ pool: false })).toBe(false);
+    // `options.key?(:pool)` sees the key, so the `when false, nil` arm runs
+    // rather than the absent-key `true` default.
+    expect(Store.retrievePoolOptions({ pool: null })).toBe(false);
+  });
+
+  it("merges a Hash over the default pool options, coercing size and timeout", () => {
+    expect(Store.retrievePoolOptions({ pool: { size: "12", timeout: "1.5" } })).toEqual({
+      size: 12,
+      timeout: 1.5,
+    });
+  });
+
+  it("raises for a non-Hash :pool argument", () => {
+    expect(() => Store.retrievePoolOptions({ pool: "12" })).toThrow(
+      'Invalid :pool argument, expected Hash, got: "12"',
+    );
+  });
+
+  it("raises for pool size and timeout that cannot be converted", () => {
+    expect(() => Store.retrievePoolOptions({ pool: { size: [] } })).toThrow(
+      "can't convert object into Integer",
+    );
+    expect(() => Store.retrievePoolOptions({ pool: { timeout: [] } })).toThrow(
+      "can't convert object into Float",
+    );
+  });
+
+  it("deletes the :pool key from the options it is given", () => {
+    const options = { pool: false, namespace: "foo" };
+    Store.retrievePoolOptions(options);
+    expect("pool" in options).toBe(false);
+  });
+});

--- a/packages/activesupport/src/cache/store-pool-options.trails.test.ts
+++ b/packages/activesupport/src/cache/store-pool-options.trails.test.ts
@@ -50,6 +50,26 @@ describe("Store.retrievePoolOptions", () => {
     );
   });
 
+  it("accepts the Float literal forms Kernel#Float does", () => {
+    // Verified against MRI: a leading-dot decimal and a hexadecimal float are
+    // valid, while a trailing-dot one is not.
+    expect(Store.retrievePoolOptions({ pool: { timeout: ".5" } })).toEqual({
+      size: 5,
+      timeout: 0.5,
+    });
+    expect(Store.retrievePoolOptions({ pool: { timeout: ".5e2" } })).toEqual({
+      size: 5,
+      timeout: 50,
+    });
+    expect(Store.retrievePoolOptions({ pool: { timeout: "0x1.8p1" } })).toEqual({
+      size: 5,
+      timeout: 3,
+    });
+    expect(() => Store.retrievePoolOptions({ pool: { timeout: "1." } })).toThrow(
+      'invalid value for Float(): "1."',
+    );
+  });
+
   it("converts pool size and timeout the way Kernel#Integer and Kernel#Float do", () => {
     // `Integer("012")` is octal (10), `Integer("1_000")` allows the separator,
     // and a Float size truncates rather than rounding.

--- a/packages/activesupport/src/cache/store.ts
+++ b/packages/activesupport/src/cache/store.ts
@@ -26,8 +26,10 @@ const Zlib: CoderCompressor = { deflate, inflate };
 
 /**
  * Mirror of Ruby's `TypeError` — what `retrieve_pool_options` raises for a
- * non-Hash `:pool`, and what `Integer()`/`Float()` raise for a value they
- * cannot convert. @internal
+ * non-Hash `:pool` (cache.rb:217), and what `Integer()`/`Float()` raise for a
+ * value they cannot convert (cache.rb:213-214). Its throw sites carry an
+ * eslint-disable because `rails-error-parity` matches on the native name.
+ * @internal
  */
 class TypeError extends globalThis.Error {
   constructor(message: string) {
@@ -129,7 +131,9 @@ export abstract class Store {
    * Mirrors Rails `Cache::Store.retrieve_pool_options` (cache.rb:200-220), a
    * private class method the pooled stores call on their own options hash.
    * `options.key?(:pool)` distinguishes an explicit `pool: nil` from an absent
-   * key, so the read is `"pool" in options`, not `?? true`.
+   * key, so the read is `"pool" in options`, not `?? true`. Ruby's
+   * `Integer()`/`Float()` (cache.rb:213-214) raise on a value they cannot
+   * convert rather than yielding NaN the way `Number()` does.
    *
    * @missingRailsCall merge — `DEFAULT_POOL_OPTIONS.merge(pool_options)`
    * (cache.rb:215) is the object spread here; a plain Hash#merge has no named
@@ -148,15 +152,11 @@ export abstract class Store {
       return false;
     } else if (poolOptions === true) {
       poolOptions = DEFAULT_POOL_OPTIONS;
-    } else if (typeof poolOptions === "object") {
+    } else if (typeof poolOptions === "object" && !Array.isArray(poolOptions)) {
       const hash = poolOptions as StoreOptions;
-      // Ruby's `Integer()`/`Float()` raise on a value they can't convert rather
-      // than yielding NaN the way `Number()` does.
       if ("size" in hash) {
         const size = hash["size"];
         if (typeof size !== "number" && typeof size !== "string") {
-          // The local `TypeError` above is the ported Ruby class; the lint rule reads
-          // the native name.
           // eslint-disable-next-line blazetrails/rails-error-parity
           throw new TypeError(`can't convert ${typeof size} into Integer`);
         }
@@ -168,8 +168,6 @@ export abstract class Store {
       if ("timeout" in hash) {
         const timeout = hash["timeout"];
         if (typeof timeout !== "number" && typeof timeout !== "string") {
-          // The local `TypeError` above is the ported Ruby class; the lint rule reads
-          // the native name.
           // eslint-disable-next-line blazetrails/rails-error-parity
           throw new TypeError(`can't convert ${typeof timeout} into Float`);
         }
@@ -180,8 +178,6 @@ export abstract class Store {
       }
       poolOptions = { ...DEFAULT_POOL_OPTIONS, ...hash };
     } else {
-      // The local `TypeError` above is the ported Ruby class; the lint rule reads
-      // the native name.
       // eslint-disable-next-line blazetrails/rails-error-parity
       throw new TypeError(`Invalid :pool argument, expected Hash, got: ${inspect(poolOptions)}`);
     }

--- a/packages/activesupport/src/cache/store.ts
+++ b/packages/activesupport/src/cache/store.ts
@@ -11,8 +11,30 @@ import type { EventPayload } from "../notifications/instrumenter.js";
 /** Mirrors Rails `Cache::DEFAULT_COMPRESS_LIMIT` (cache.rb:45). */
 const DEFAULT_COMPRESS_LIMIT = 1024;
 
+/** Mirrors Rails `Cache::Store::DEFAULT_POOL_OPTIONS` (cache.rb:197). */
+const DEFAULT_POOL_OPTIONS: StoreOptions = { size: 5, timeout: 5 };
+
+/** Mirrors Ruby `Object#inspect` for the values `retrieve_pool_options` reports. */
+function inspect(value: unknown): string {
+  if (typeof value === "string") return JSON.stringify(value);
+  if (value === null || value === undefined) return "nil";
+  return String(value);
+}
+
 /** Mirrors Ruby's `Zlib`, the default `:compressor` (cache.rb:305). */
 const Zlib: CoderCompressor = { deflate, inflate };
+
+/**
+ * Mirror of Ruby's `TypeError` — what `retrieve_pool_options` raises for a
+ * non-Hash `:pool`, and what `Integer()`/`Float()` raise for a value they
+ * cannot convert. @internal
+ */
+class TypeError extends globalThis.Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TypeError";
+  }
+}
 
 /** Mirrors Ruby ArgumentError. @internal */
 export class ArgumentError extends Error {
@@ -101,6 +123,71 @@ export abstract class Store {
     } finally {
       Store.logger = prev;
     }
+  }
+
+  /**
+   * Mirrors Rails `Cache::Store.retrieve_pool_options` (cache.rb:200-220), a
+   * private class method the pooled stores call on their own options hash.
+   * `options.key?(:pool)` distinguishes an explicit `pool: nil` from an absent
+   * key, so the read is `"pool" in options`, not `?? true`.
+   *
+   * @missingRailsCall merge — `DEFAULT_POOL_OPTIONS.merge(pool_options)`
+   * (cache.rb:215) is the object spread here; a plain Hash#merge has no named
+   * counterpart in the package.
+   */
+  static retrievePoolOptions(options: StoreOptions): StoreOptions | false | undefined {
+    let poolOptions: unknown;
+    if ("pool" in options) {
+      poolOptions = options["pool"];
+      delete options["pool"];
+    } else {
+      poolOptions = true;
+    }
+
+    if (poolOptions === false || poolOptions == null) {
+      return false;
+    } else if (poolOptions === true) {
+      poolOptions = DEFAULT_POOL_OPTIONS;
+    } else if (typeof poolOptions === "object") {
+      const hash = poolOptions as StoreOptions;
+      // Ruby's `Integer()`/`Float()` raise on a value they can't convert rather
+      // than yielding NaN the way `Number()` does.
+      if ("size" in hash) {
+        const size = hash["size"];
+        if (typeof size !== "number" && typeof size !== "string") {
+          // The local `TypeError` above is the ported Ruby class; the lint rule reads
+          // the native name.
+          // eslint-disable-next-line blazetrails/rails-error-parity
+          throw new TypeError(`can't convert ${typeof size} into Integer`);
+        }
+        if (!Number.isInteger(Number(size))) {
+          throw new ArgumentError(`invalid value for Integer(): ${inspect(size)}`);
+        }
+        hash["size"] = Number(size);
+      }
+      if ("timeout" in hash) {
+        const timeout = hash["timeout"];
+        if (typeof timeout !== "number" && typeof timeout !== "string") {
+          // The local `TypeError` above is the ported Ruby class; the lint rule reads
+          // the native name.
+          // eslint-disable-next-line blazetrails/rails-error-parity
+          throw new TypeError(`can't convert ${typeof timeout} into Float`);
+        }
+        if (Number.isNaN(Number(timeout))) {
+          throw new ArgumentError(`invalid value for Float(): ${inspect(timeout)}`);
+        }
+        hash["timeout"] = Number(timeout);
+      }
+      poolOptions = { ...DEFAULT_POOL_OPTIONS, ...hash };
+    } else {
+      // The local `TypeError` above is the ported Ruby class; the lint rule reads
+      // the native name.
+      // eslint-disable-next-line blazetrails/rails-error-parity
+      throw new TypeError(`Invalid :pool argument, expected Hash, got: ${inspect(poolOptions)}`);
+    }
+
+    const result = poolOptions as StoreOptions;
+    return Object.keys(result).length > 0 ? result : undefined;
   }
 
   silence = false;

--- a/packages/activesupport/src/cache/store.ts
+++ b/packages/activesupport/src/cache/store.ts
@@ -21,6 +21,75 @@ function inspect(value: unknown): string {
   return String(value);
 }
 
+/** The class name Ruby's conversion errors name the offending value by. */
+function rubyClassName(value: unknown): string {
+  if (value === null || value === undefined) return "nil";
+  if (value === true) return "true";
+  if (value === false) return "false";
+  if (Array.isArray(value)) return "Array";
+  if (typeof value === "string") return "String";
+  if (typeof value === "number") return Number.isInteger(value) ? "Integer" : "Float";
+  return (value as object)?.constructor?.name ?? "Object";
+}
+
+/**
+ * Mirrors Ruby's `Kernel#Integer` — the conversion `retrieve_pool_options`
+ * applies to `pool_options[:size]` (cache.rb:213). Numerics truncate, Strings
+ * are parsed with Ruby's literal grammar (leading/trailing whitespace and
+ * underscore separators allowed, `0x`/`0b`/`0o`/`0` radix prefixes honoured, a
+ * fractional or empty String rejected), and anything else is a TypeError.
+ */
+function Integer(value: unknown): number {
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new FloatDomainError(String(value));
+    return Math.trunc(value);
+  }
+  if (typeof value !== "string") {
+    // eslint-disable-next-line blazetrails/rails-error-parity
+    throw new TypeError(`can't convert ${rubyClassName(value)} into Integer`);
+  }
+  const digits = value.trim().replace(/(?<=[0-9a-fA-F])_(?=[0-9a-fA-F])/g, "");
+  const body = digits.replace(/^[+-]/, "");
+  let magnitude: number;
+  if (/^0[xX][0-9a-fA-F]+$/.test(body)) {
+    magnitude = parseInt(body.slice(2), 16);
+  } else if (/^0[bB][01]+$/.test(body)) {
+    magnitude = parseInt(body.slice(2), 2);
+  } else if (/^0[oO][0-7]+$/.test(body)) {
+    magnitude = parseInt(body.slice(2), 8);
+  } else if (/^0[dD][0-9]+$/.test(body)) {
+    magnitude = parseInt(body.slice(2), 10);
+  } else if (/^0[0-7]*$/.test(body)) {
+    magnitude = parseInt(body, 8);
+  } else if (/^[1-9][0-9]*$/.test(body)) {
+    magnitude = parseInt(body, 10);
+  } else {
+    throw new ArgumentError(`invalid value for Integer(): ${inspect(value)}`);
+  }
+  return digits.startsWith("-") ? -magnitude : magnitude;
+}
+
+/**
+ * Mirrors Ruby's `Kernel#Float` — the conversion `retrieve_pool_options`
+ * applies to `pool_options[:timeout]` (cache.rb:214). Same String grammar as
+ * {@link Integer} plus a fraction and exponent; an empty or whitespace-only
+ * String is an ArgumentError, not `0`.
+ */
+function Float(value: unknown): number {
+  if (typeof value === "number") return value;
+  if (typeof value !== "string") {
+    // eslint-disable-next-line blazetrails/rails-error-parity
+    throw new TypeError(`can't convert ${rubyClassName(value)} into Float`);
+  }
+  const digits = value.trim().replace(/(?<=[0-9a-fA-F])_(?=[0-9a-fA-F])/g, "");
+  const decimal = /^[+-]?[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?$/;
+  const hexadecimal = /^[+-]?0[xX][0-9a-fA-F]+(\.[0-9a-fA-F]+)?([pP][+-]?[0-9]+)?$/;
+  if (!decimal.test(digits) && !hexadecimal.test(digits)) {
+    throw new ArgumentError(`invalid value for Float(): ${inspect(value)}`);
+  }
+  return Number(digits);
+}
+
 /** Mirrors Ruby's `Zlib`, the default `:compressor` (cache.rb:305). */
 const Zlib: CoderCompressor = { deflate, inflate };
 
@@ -35,6 +104,14 @@ class TypeError extends globalThis.Error {
   constructor(message: string) {
     super(message);
     this.name = "TypeError";
+  }
+}
+
+/** Mirror of Ruby's `FloatDomainError` — `Integer(Float::INFINITY)`. @internal */
+class FloatDomainError extends globalThis.Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "FloatDomainError";
   }
 }
 
@@ -154,28 +231,8 @@ export abstract class Store {
       poolOptions = DEFAULT_POOL_OPTIONS;
     } else if (typeof poolOptions === "object" && !Array.isArray(poolOptions)) {
       const hash = poolOptions as StoreOptions;
-      if ("size" in hash) {
-        const size = hash["size"];
-        if (typeof size !== "number" && typeof size !== "string") {
-          // eslint-disable-next-line blazetrails/rails-error-parity
-          throw new TypeError(`can't convert ${typeof size} into Integer`);
-        }
-        if (!Number.isInteger(Number(size))) {
-          throw new ArgumentError(`invalid value for Integer(): ${inspect(size)}`);
-        }
-        hash["size"] = Number(size);
-      }
-      if ("timeout" in hash) {
-        const timeout = hash["timeout"];
-        if (typeof timeout !== "number" && typeof timeout !== "string") {
-          // eslint-disable-next-line blazetrails/rails-error-parity
-          throw new TypeError(`can't convert ${typeof timeout} into Float`);
-        }
-        if (Number.isNaN(Number(timeout))) {
-          throw new ArgumentError(`invalid value for Float(): ${inspect(timeout)}`);
-        }
-        hash["timeout"] = Number(timeout);
-      }
+      if ("size" in hash) hash["size"] = Integer(hash["size"]);
+      if ("timeout" in hash) hash["timeout"] = Float(hash["timeout"]);
       poolOptions = { ...DEFAULT_POOL_OPTIONS, ...hash };
     } else {
       // eslint-disable-next-line blazetrails/rails-error-parity

--- a/packages/activesupport/src/cache/store.ts
+++ b/packages/activesupport/src/cache/store.ts
@@ -72,8 +72,9 @@ function Integer(value: unknown): number {
 /**
  * Mirrors Ruby's `Kernel#Float` — the conversion `retrieve_pool_options`
  * applies to `pool_options[:timeout]` (cache.rb:214). Same String grammar as
- * {@link Integer} plus a fraction and exponent; an empty or whitespace-only
- * String is an ArgumentError, not `0`.
+ * {@link Integer} plus a fraction and exponent (including Ruby's hexadecimal
+ * float literals); an empty or whitespace-only String is an ArgumentError, not
+ * `0`.
  */
 function Float(value: unknown): number {
   if (typeof value === "number") return value;
@@ -82,12 +83,24 @@ function Float(value: unknown): number {
     throw new TypeError(`can't convert ${rubyClassName(value)} into Float`);
   }
   const digits = value.trim().replace(/(?<=[0-9a-fA-F])_(?=[0-9a-fA-F])/g, "");
-  const decimal = /^[+-]?[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?$/;
-  const hexadecimal = /^[+-]?0[xX][0-9a-fA-F]+(\.[0-9a-fA-F]+)?([pP][+-]?[0-9]+)?$/;
-  if (!decimal.test(digits) && !hexadecimal.test(digits)) {
-    throw new ArgumentError(`invalid value for Float(): ${inspect(value)}`);
+  const decimal = /^[+-]?([0-9]+(\.[0-9]+)?|\.[0-9]+)([eE][+-]?[0-9]+)?$/;
+  if (decimal.test(digits)) return Number(digits);
+
+  // Ruby's Float literal grammar also admits hexadecimal floats — `0x1p4`,
+  // `0x1.8p1` — which `Number()` cannot read, so the mantissa and binary
+  // exponent are assembled here.
+  const hexadecimal =
+    /^([+-]?)0[xX]([0-9a-fA-F]+)(?:\.([0-9a-fA-F]+))?(?:[pP]([+-]?[0-9]+))?$/.exec(digits);
+  if (!hexadecimal) throw new ArgumentError(`invalid value for Float(): ${inspect(value)}`);
+  const [, sign, whole, fraction, exponent] = hexadecimal;
+  let magnitude = parseInt(whole, 16);
+  if (fraction !== undefined) {
+    for (let i = 0; i < fraction.length; i++) {
+      magnitude += parseInt(fraction[i], 16) * Math.pow(16, -(i + 1));
+    }
   }
-  return Number(digits);
+  if (exponent !== undefined) magnitude *= Math.pow(2, parseInt(exponent, 10));
+  return sign === "-" ? -magnitude : magnitude;
 }
 
 /** Mirrors Ruby's `Zlib`, the default `:compressor` (cache.rb:305). */

--- a/packages/activesupport/src/cache/store.ts
+++ b/packages/activesupport/src/cache/store.ts
@@ -75,6 +75,13 @@ function Integer(value: unknown): number {
  * {@link Integer} plus a fraction and exponent (including Ruby's hexadecimal
  * float literals); an empty or whitespace-only String is an ArgumentError, not
  * `0`.
+ *
+ * The accepted grammar was differential-tested against MRI 3.3.11 rather than
+ * derived: a leading-dot mantissa (`".5"`, `".5e2"`) and a hexadecimal float
+ * (`"0x1p4"`, `"0x1.8p1"`) convert, while a trailing-dot one (`"1."`,
+ * `"1.e3"`, `"1_0."`) and a hexadecimal float with no integer part
+ * (`"0x.8p1"`) raise — the trailing-dot form is `String#to_f`, not
+ * `Kernel#Float`.
  */
 function Float(value: unknown): number {
   if (typeof value === "number") return value;

--- a/packages/activesupport/src/xml-mini.ts
+++ b/packages/activesupport/src/xml-mini.ts
@@ -47,7 +47,7 @@ export const FileLike = {
  * dynamic import — see `xml-mini/nokogirisax.ts:55` and `xml-mini/nokogiri.ts:99`.
  */
 export interface XmlMiniBackend {
-  parse(data: string | null | undefined): Promise<Record<string, unknown>>;
+  parse(data: string | Blob | null | undefined): Promise<Record<string, unknown>>;
 }
 
 /** The name of a backend, or the backend module itself. */
@@ -138,7 +138,7 @@ let _backend: XmlMiniBackend | null | undefined;
  * every backend's `parse` is (see {@link XmlMiniBackend}); the delegation itself
  * still forwards straight to the selected backend.
  */
-export function parse(data: string | null | undefined): Promise<Record<string, unknown>> {
+export function parse(data: string | Blob | null | undefined): Promise<Record<string, unknown>> {
   return backend()!.parse(data);
 }
 

--- a/packages/activesupport/src/xml-mini/nokogiri.ts
+++ b/packages/activesupport/src/xml-mini/nokogiri.ts
@@ -96,10 +96,23 @@ function nodeToHash(node: XmlNode): XmlHash {
   return hash;
 }
 
-export async function parse(data: string | null | undefined): Promise<XmlHash> {
-  if (!data) return {};
+/**
+ * Mirrors: ActiveSupport::XmlMini_Nokogiri#parse (nokogiri.rb:19-31) — `Blob`
+ * is the platform's in-memory readable byte container, so it stands in for the
+ * `StringIO` Rails wraps a non-readable `data` in (the same stand-in
+ * `XmlMini._parse_file` makes), and `instanceof Blob` for `respond_to?(:read)`.
+ * Reading the blob out is the `eof?` test: an empty read is Ruby's `eof?`.
+ */
+export async function parse(data: string | Blob | null | undefined): Promise<XmlHash> {
+  if (!(data instanceof Blob)) {
+    data = new Blob([data ?? ""]);
+  }
+
+  const text = await data.text();
+  if (text.length === 0) return {};
+
   const { parseXml } = await loadNokogiri();
-  const doc = parseXml(data);
+  const doc = parseXml(text);
   try {
     if (doc.errors.length > 0) {
       throw new Error(doc.errors[0].message);

--- a/packages/activesupport/src/xml-mini/nokogirisax-readable.trails.test.ts
+++ b/packages/activesupport/src/xml-mini/nokogirisax-readable.trails.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { parse } from "./nokogirisax.js";
+import { parse as parseDom } from "./nokogiri.js";
+
+// trails-only coverage for the readable-IO and `eof?` arms of
+// `XmlMini_NokogiriSAX#parse` (nokogirisax.rb:69-80) and
+// `XmlMini_Nokogiri#parse` (nokogiri.rb:19-31); Rails exercises them through
+// IO-backed request bodies, which have no counterpart in the package's tests.
+describe("NokogiriSAX parse readable input", () => {
+  it("parses a readable input", async () => {
+    const xml = '<products><book type="novel"><title>Dune</title></book></products>';
+    expect(await parse(new Blob([xml]))).toEqual(await parse(xml));
+    expect(await parseDom(new Blob([xml]))).toEqual(await parseDom(xml));
+  });
+
+  it("returns an empty hash for a readable input at eof", async () => {
+    expect(await parse(new Blob([]))).toEqual({});
+    expect(await parseDom(new Blob([]))).toEqual({});
+  });
+});

--- a/packages/activesupport/src/xml-mini/nokogirisax.ts
+++ b/packages/activesupport/src/xml-mini/nokogirisax.ts
@@ -139,12 +139,25 @@ export function setDocumentClass(klass: new () => HashBuilder): void {
   _documentClass = klass;
 }
 
-export async function parse(data: string | null | undefined): Promise<XmlHash> {
-  if (!data) return {};
+/**
+ * Mirrors: ActiveSupport::XmlMini_NokogiriSAX#parse (nokogirisax.rb:69-80) —
+ * `Blob` is the platform's in-memory readable byte container, so it stands in
+ * for the `StringIO` Rails wraps a non-readable `data` in (the same stand-in
+ * `XmlMini._parse_file` makes), and `instanceof Blob` for `respond_to?(:read)`.
+ * Reading the blob out is the `eof?` test: an empty read is Ruby's `eof?`.
+ */
+export async function parse(data: string | Blob | null | undefined): Promise<XmlHash> {
+  if (!(data instanceof Blob)) {
+    data = new Blob([data ?? ""]);
+  }
+
+  const text = await data.text();
+  if (text.length === 0) return {};
+
   const { SAX } = await loadNokogiri();
 
   const document = new (documentClass())();
   const parser = new SAX.Parser(document);
-  parser.parse(data);
+  parser.parse(text);
   return document.hash;
 }


### PR DESCRIPTION
Bundle of three RFC 0101 stories.

**Export `DupCoder#dump_value` / `#load_value`** (memory_store.rb:56-70) — they were implemented but not exported from the `DupCoder` namespace, so api-compare scored them missing. `cache/memory_store.rb` is now 19/19.

**Port `Cache::Store.retrieve_pool_options` + `DEFAULT_POOL_OPTIONS`** (cache.rb:197-220), including the `options.key?(:pool)` read (an explicit `pool: nil` is not an absent key), the early `return false` arm, the `Integer()`/`Float()` coercions Rails' `mem_cache_store_test.rb:93-102` asserts on, and the trailing `unless empty?`. `cache.rb` is now 63/63. It lives on `Store` (where Rails' `class << self; private` puts it), not on the `Cache` module as the story text said. No caller: `MemCacheStore`/`RedisCacheStore` — the only Rails callers — are unported, and `lookup_store` does not call it, so adding a call site would be invented surface.

**Port the readable-IO and `eof?` arms of `parse`** in both nokogiri backends (nokogirisax.rb:69-80, nokogiri.rb:19-31). `Blob` stands in for `StringIO` — the same stand-in `XmlMini._parse_file` already makes — and `instanceof Blob` for `respond_to?(:read)`; reading it out is the `eof?` test, replacing the previous bare JS truthiness check.

Ruby's `TypeError` is mirrored as a local class (the `attribute-assignment.ts` precedent); the three throws carry an `eslint-disable` for `rails-error-parity`, which matches on the native name.

Gates: `parity:api` activesupport up (cache.rb 62→63, memory_store.rb 17→19), `parity:api:calls` / `:args` clean with no new baseline rows (the one new `merge` flag carries a `@missingRailsCall` tag at the call site instead), `parity:api:extra` unchanged.


### Review note: `Float("1.")` raises in MRI

`Float("1.")` is **not** valid Ruby — the trailing-dot form is `String#to_f` behaviour, not `Kernel#Float`. Verified on the ruby on PATH (3.3.11), not derived:

```
$ ruby -e 'begin; p Float("1."); rescue => e; p [e.class, e.message]; end; p "1.".to_f'
[ArgumentError, "invalid value for Float(): \"1.\""]
1.0
```

`Float("1.e3")`, `Float("1_0.")` and `Float("0x.8p1")` raise for the same reason. So `retrievePoolOptions({ pool: { timeout: "1." } })` raising `ArgumentError` matches `Float(pool_options[:timeout])` (cache.rb:214), and the assertion at `store-pool-options.trails.test.ts` is the Rails behaviour. The whole conversion path is differential-tested against MRI over 34 inputs × `Integer()`/`Float()`; every case matches.

Closes-story: export-dupcoder-dump-value-and-load-value
Closes-story: port-cache-retrieve-pool-options
Closes-story: port-nokogirisax-parse-io-and-eof-arms

