### PR TITLE
fix(activesupport): keep control characters raw in the cache coder payload

### DIFF
--- a/packages/activesupport/src/cache/behaviors/cache-store-compression-behavior.ts
+++ b/packages/activesupport/src/cache/behaviors/cache-store-compression-behavior.ts
@@ -1,4 +1,4 @@
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
 import { Entry } from "../entry.js";
 import type { Store, StoreOptions } from "../store.js";
 
@@ -27,6 +27,13 @@ export interface CompressionBehaviorHost {
 export function cacheStoreCompressionBehavior(host: CompressionBehaviorHost): void {
   let cache: Store;
 
+  // Stands in for the including test class's `setup` (`@cache = lookup_store`,
+  // e.g. file_store_test.rb:30-32), which the cases that never call
+  // `lookup_store` themselves rely on.
+  beforeEach(() => {
+    cache = host.lookupStore();
+  });
+
   function computeEntrySizeReduction(value: unknown, withOptions: StoreOptions = {}): number {
     const entry = new Entry(value);
 
@@ -39,12 +46,20 @@ export function cacheStoreCompressionBehavior(host: CompressionBehaviorHost): vo
     const uncompressed = send.serializeEntry(entry, { ...withOptions, compress: false });
     const actual = send.serializeEntry(entry, withOptions);
 
-    const sizeOf = (payload: unknown): number =>
+    // Ruby's payload is a String either way, so `#bytesize` is unambiguous. A JS
+    // string carries no encoding, and the two shapes count differently (see
+    // Entry#bytesize, entry.rb:60-69): a serializer dump is UTF-8, while a
+    // deflated payload is the binary string `gzip.ts` returns, one char per
+    // byte. A payload that differs from the uncompressed one is the compressed
+    // shape.
+    const sizeOf = (payload: unknown, compressed = false): number =>
       payload instanceof Entry
         ? payload.bytesize()
-        : new TextEncoder().encode(String(payload)).length;
+        : compressed
+          ? String(payload).length
+          : new TextEncoder().encode(String(payload)).length;
 
-    return sizeOf(uncompressed) - sizeOf(actual);
+    return sizeOf(uncompressed) - sizeOf(actual, actual !== uncompressed);
   }
 
   function assertCompress(value: unknown, withOptions?: StoreOptions): void {
@@ -107,5 +122,14 @@ export function cacheStoreCompressionBehavior(host: CompressionBehaviorHost): vo
 
     cache = host.lookupStore({ compress: true, compressThreshold: 1024 * 1024 });
     assertCompression(":all", { compressThreshold: 1 });
+  });
+
+  it("compression ignores incompressible data", () => {
+    assertNotCompress("", { compress: true, compressThreshold: 1 });
+    // Ruby's `[*0..127].pack("C*")`.
+    assertNotCompress(Array.from({ length: 128 }, (_, i) => String.fromCharCode(i)).join(""), {
+      compress: true,
+      compressThreshold: 1,
+    });
   });
 }

--- a/packages/activesupport/src/cache/coder.test.ts
+++ b/packages/activesupport/src/cache/coder.test.ts
@@ -75,4 +75,17 @@ describe("cache coder fidelity", () => {
     const value = { name: "test", count: 42, on: true, tags: ["a", "b"] };
     expect(roundtrip(value)).toEqual(value);
   });
+
+  it("dumps control characters raw so a binary-ish payload keeps its byte size", () => {
+    // Ruby's `[*0..127].pack("C*")`, whose Marshal payload tracks its 128 bytes.
+    const value = Array.from({ length: 128 }, (_, i) => String.fromCharCode(i)).join("");
+    expect(coder.dump(value).length).toBeLessThan(value.length + 16);
+    expect(roundtrip(value)).toBe(value);
+  });
+
+  it("round-trips strings that spell a control-character escape", () => {
+    for (const value of ["\\u0001", "\\" + String.fromCharCode(1), String.fromCharCode(1) + "\\"]) {
+      expect(roundtrip(value)).toBe(value);
+    }
+  });
 });

--- a/packages/activesupport/src/cache/coder.ts
+++ b/packages/activesupport/src/cache/coder.ts
@@ -116,6 +116,31 @@ function decode(node: unknown): unknown {
   return decoded;
 }
 
+// `Marshal.dump` writes a String's bytes verbatim, so a binary-ish value keeps
+// its byte size in the payload and deflating it is a loss — which is what
+// `compression ignores incompressible data`
+// (cache_store_compression_behavior.rb:71-74) asserts. `JSON.stringify` instead
+// emits every control character as a six-byte `\uXXXX` escape, more than
+// doubling such a payload and making it deflate well. So the escapes are undone
+// on the way out and redone on the way in; the two passes are exact inverses,
+// since a dump carries no raw control character it did not itself unescape.
+const CONTROL_CHAR_ESCAPE = /\\u00[01][0-9a-f]/g;
+
+function unescapeControlChars(json: string): string {
+  return json.replace(CONTROL_CHAR_ESCAPE, (escape) =>
+    String.fromCharCode(parseInt(escape.slice(2), 16)),
+  );
+}
+
+function escapeControlChars(dumped: string): string {
+  let escaped = "";
+  for (const char of dumped) {
+    const code = char.charCodeAt(0);
+    escaped += code < 0x20 ? `\\u${code.toString(16).padStart(4, "0")}` : char;
+  }
+  return escaped;
+}
+
 /**
  * The trails Marshal-equivalent cache serializer. Mirrors the `dump`/`load`
  * surface of Rails' `Cache::Coder` while preserving JS type fidelity (Date,
@@ -125,10 +150,10 @@ function decode(node: unknown): unknown {
  */
 export const coder = {
   dump(value: unknown): string {
-    return JSON.stringify(encode(value));
+    return unescapeControlChars(JSON.stringify(encode(value)));
   },
   load(dumped: string): unknown {
-    return decode(JSON.parse(dumped));
+    return decode(JSON.parse(escapeControlChars(dumped)));
   },
 };
 


### PR DESCRIPTION
Ruby's `Marshal.dump` writes a String's bytes verbatim, so a binary-ish value keeps its byte size in the payload and deflating it is a loss — which is what `compression ignores incompressible data` (activesupport/test/cache/behaviors/cache_store_compression_behavior.rb:71-74) asserts. trails' fidelity coder is JSON-based, and `JSON.stringify` escapes every control character as a six-byte `\uXXXX` sequence: `[*0..127].pack("C*")` dumped to 275 bytes that deflate to 191, so compression kicked in where Rails reads a reduction of 0.

- `cache/coder.ts` now undoes those escapes on `dump` and redoes them on `load`. The two passes are exact inverses (a dump carries no raw control character it did not itself unescape), and the 128-byte value now dumps to 140 bytes that do not deflate.
- The behavior helper's `sizeOf` counts bytes the way `Entry#bytesize` (entry.rb:60-69) does for each payload shape: UTF-8 for a serializer dump, one char per byte for the binary string `gzip.ts`' `deflate` returns — it previously reported 291 for a 191-byte compressed payload.
- `compression ignores incompressible data` is enrolled verbatim and green for FileStore and MemoryStore.

Overlaps `cache-store-compression-behavior.ts` with the still-open #6444, which enrolls the other cases of the same mixin (including the `beforeEach` standing in for the Ruby `setup`); whichever lands second rebases.

Closes-story: converge-fidelity-coder-binary-string-payload