### PR TITLE
feat(activesupport): port File.probe_stat_in and atomic_write's permission copy

### DIFF
--- a/packages/activesupport/src/core-ext/file.test.ts
+++ b/packages/activesupport/src/core-ext/file.test.ts
@@ -1,60 +1,93 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { atomicWrite, probeStatIn } from "./file/atomic.js";
 
 describe("AtomicWriteTest", () => {
-  // Simulated atomic write: write to temp, then rename
-  function atomicWrite(path: string, fn: () => string): string | undefined {
-    let content: string;
-    try {
-      content = fn();
-    } catch {
-      return undefined; // don't write if block raises
-    }
-    return content;
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "trails-atomic-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function fileName(): string {
+    return join(dir, "atomic.file");
+  }
+
+  function fileMode(): number {
+    return statSync(fileName()).mode;
   }
 
   it("atomic write without errors", () => {
-    const result = atomicWrite("/tmp/test.txt", () => "content");
-    expect(result).toBe("content");
+    const contents = "Atomic Text";
+    atomicWrite(fileName(), dir, (file) => {
+      file.write(contents);
+      expect(existsSync(fileName())).toBe(false);
+    });
+    expect(existsSync(fileName())).toBe(true);
+    expect(readFileSync(fileName(), "utf-8")).toBe(contents);
   });
 
   it("atomic write doesnt write when block raises", () => {
-    const result = atomicWrite("/tmp/test.txt", () => {
-      throw new Error("fail");
-    });
-    expect(result).toBeUndefined();
+    expect(() =>
+      atomicWrite(fileName(), undefined, (file) => {
+        file.write("testing");
+        throw new Error("something bad");
+      }),
+    ).toThrow("something bad");
+    expect(existsSync(fileName())).toBe(false);
   });
 
   it("atomic write preserves file permissions", () => {
-    // In JS we can't easily test filesystem permissions; just verify write succeeds
-    const result = atomicWrite("/tmp/test.txt", () => "data");
-    expect(result).toBe("data");
+    const contents = "Atomic Text";
+    atomicWrite(fileName(), dir, (file) => file.write(contents));
+    chmodSync(fileName(), 0o755);
+    expect(fileMode() & 0o777).toBe(0o755);
+
+    atomicWrite(fileName(), dir, (file) => {
+      file.write(contents);
+      expect(existsSync(fileName())).toBe(true);
+    });
+    expect(existsSync(fileName())).toBe(true);
+    expect(fileMode() & 0o777).toBe(0o755);
+    expect(readFileSync(fileName(), "utf-8")).toBe(contents);
   });
 
   it("atomic write preserves default file permissions", () => {
-    const result = atomicWrite("/tmp/default.txt", () => "default");
-    expect(result).toBe("default");
+    const contents = "Atomic Text";
+    atomicWrite(fileName(), dir, (file) => {
+      file.write(contents);
+      expect(existsSync(fileName())).toBe(false);
+    });
+    expect(existsSync(fileName())).toBe(true);
+    expect(probeStatIn(dir)!.mode).toBe(fileMode());
+    expect(readFileSync(fileName(), "utf-8")).toBe(contents);
   });
 
   it("atomic write preserves file permissions same directory", () => {
-    const result = atomicWrite("/tmp/same-dir.txt", () => "same-dir");
-    expect(result).toBe("same-dir");
+    chmodSync(dir, 0o700);
+
+    const probedPermissions = probeStatIn(dir)!.mode!.toString(8);
+
+    atomicWrite(join(dir, "atomic.file"), undefined, () => undefined);
+
+    const actualPermissions = statSync(join(dir, "atomic.file")).mode.toString(8);
+
+    expect(actualPermissions).toBe(probedPermissions);
   });
 
   it("atomic write returns result from yielded block", () => {
-    const result = atomicWrite("/tmp/result.txt", () => "returned value");
-    expect(result).toBe("returned value");
+    const blockReturnValue = atomicWrite(fileName(), dir, () => "Hello world!");
+
+    expect(blockReturnValue).toBe("Hello world!");
   });
 
   it("probe stat in when no dir", () => {
-    // When directory doesn't exist, we simulate error handling
-    let error: Error | null = null;
-    try {
-      // A real implementation would throw if directory doesn't exist
-      const r = atomicWrite("/nonexistent/dir/file.txt", () => "data");
-    } catch (e) {
-      error = e as Error;
-    }
-    // Since our test impl doesn't check fs, just verify the concept
-    expect(true).toBe(true);
+    expect(probeStatIn("/dir/does/not/exist")).toBeNull();
   });
 });

--- a/packages/activesupport/src/core-ext/file/atomic.ts
+++ b/packages/activesupport/src/core-ext/file/atomic.ts
@@ -1,4 +1,4 @@
-import { getFs, getPath } from "../../fs-adapter.js";
+import { getFs, getPath, type FsStatResult } from "../../fs-adapter.js";
 
 /**
  * Write to a file atomically. Useful for situations where you don't
@@ -21,10 +21,10 @@ import { getFs, getPath } from "../../fs-adapter.js";
  * yielded object stands in for the `Tempfile` the Ruby block writes to; only
  * `write` is used by callers, and `binmode`/`close` are the adapter's job.
  *
- * @missingRailsCall exist? — the fs adapter models no uid/gid/mode, so the
- * `exist?`/`probe_stat_in` permission probe (atomic.rb:28-34) has nothing to
- * probe and the `chown`/`chmod` copy is unrepresentable.
- * @missingRailsCall stat — same permission probe (atomic.rb:30).
+ * @missingRailsCall exist? — spelled `existsSync`, the fs adapter's name for
+ * the sync existence check (atomic.rb:28).
+ * @missingRailsCall stat — spelled `statSync`, the fs adapter's name for the
+ * sync stat (atomic.rb:30).
  * @missingRailsCall rename — spelled `renameSync`, the fs adapter's name for
  * the sync rename every other trails caller uses (atomic.rb:48).
  */
@@ -51,6 +51,28 @@ export function atomicWrite<T>(
   const returnVal = block(tempFile);
   getFs().writeFileSync(tempPath, payload, "utf-8");
 
+  const oldStat = getFs().existsSync(fileName)
+    ? // Get original file permissions
+      getFs().statSync(fileName)
+    : // If not possible, probe which are the default permissions in the
+      // destination directory.
+      probeStatIn(getPath().dirname(fileName));
+
+  if (oldStat) {
+    // Set correct permissions on new file
+    try {
+      if (oldStat.uid != null && oldStat.gid != null) {
+        getFs().chownSync?.(tempPath, oldStat.uid, oldStat.gid);
+      }
+      // This operation will affect filesystem ACL's
+      if (oldStat.mode != null) getFs().chmodSync?.(tempPath, oldStat.mode);
+    } catch (error) {
+      // Changing file ownership failed, moving on.
+      const code = (error as { code?: string }).code;
+      if (code !== "EPERM" && code !== "EACCES") throw error;
+    }
+  }
+
   // Overwrite original file with temp file (atomic.rb:48).
   try {
     getFs().renameSync(tempPath, fileName);
@@ -61,4 +83,40 @@ export function atomicWrite<T>(
     throw error;
   }
   return returnVal;
+}
+
+/**
+ * Private utility method.
+ *
+ * Mirrors Ruby `File.probe_stat_in` (core_ext/file/atomic.rb:55-70).
+ *
+ * The basename's uniqueness components in Rails are the thread id and pid
+ * (atomic.rb:59-60); neither exists here (single thread, no `process.*`), so
+ * two random draws stand in for them.
+ *
+ * @missingRailsCall stat — spelled `statSync`, the fs adapter's name for the
+ * sync stat (atomic.rb:66).
+ */
+export function probeStatIn(dir: string): FsStatResult | null {
+  const basename = [
+    ".permissions_check",
+    Math.floor(Math.random() * 1000000),
+    Math.floor(Math.random() * 1000000),
+  ].join(".");
+
+  let fileName: string | null = getPath().join(dir, basename);
+  try {
+    getFs().appendFileSync(fileName, "");
+    return getFs().statSync(fileName);
+  } catch (error) {
+    if ((error as { code?: string }).code !== "ENOENT") throw error;
+    fileName = null;
+    return null;
+  } finally {
+    if (fileName) {
+      try {
+        getFs().unlinkSync(fileName);
+      } catch {}
+    }
+  }
 }

--- a/packages/activesupport/src/core-ext/file/atomic.ts
+++ b/packages/activesupport/src/core-ext/file/atomic.ts
@@ -20,13 +20,6 @@ import { getFs, getPath, type FsStatResult } from "../../fs-adapter.js";
  * Mirrors Ruby `File.atomic_write` (core_ext/file/atomic.rb:20-52). The
  * yielded object stands in for the `Tempfile` the Ruby block writes to; only
  * `write` is used by callers, and `binmode`/`close` are the adapter's job.
- *
- * @missingRailsCall exist? — spelled `existsSync`, the fs adapter's name for
- * the sync existence check (atomic.rb:28).
- * @missingRailsCall stat — spelled `statSync`, the fs adapter's name for the
- * sync stat (atomic.rb:30).
- * @missingRailsCall rename — spelled `renameSync`, the fs adapter's name for
- * the sync rename every other trails caller uses (atomic.rb:48).
  */
 export function atomicWrite<T>(
   fileName: string,
@@ -93,9 +86,6 @@ export function atomicWrite<T>(
  * The basename's uniqueness components in Rails are the thread id and pid
  * (atomic.rb:59-60); neither exists here (single thread, no `process.*`), so
  * two random draws stand in for them.
- *
- * @missingRailsCall stat — spelled `statSync`, the fs adapter's name for the
- * sync stat (atomic.rb:66).
  */
 export function probeStatIn(dir: string): FsStatResult | null {
   const basename = [

--- a/packages/activesupport/src/core-ext/file/atomic.ts
+++ b/packages/activesupport/src/core-ext/file/atomic.ts
@@ -83,13 +83,15 @@ export function atomicWrite<T>(
  *
  * Mirrors Ruby `File.probe_stat_in` (core_ext/file/atomic.rb:55-70).
  *
- * The basename's uniqueness components in Rails are the thread id and pid
- * (atomic.rb:59-60); neither exists here (single thread, no `process.*`), so
- * two random draws stand in for them.
+ * The basename keeps Rails' three uniqueness components after the prefix
+ * (atomic.rb:57-62). The third is Rails' own `rand(1000000)`; the first two
+ * stand in for `Thread.current.object_id` and `Process.pid`, neither of which
+ * exists here (single thread, no `process.*`).
  */
 export function probeStatIn(dir: string): FsStatResult | null {
   const basename = [
     ".permissions_check",
+    Math.floor(Math.random() * 1000000),
     Math.floor(Math.random() * 1000000),
     Math.floor(Math.random() * 1000000),
   ].join(".");

--- a/packages/activesupport/src/fs-adapter.ts
+++ b/packages/activesupport/src/fs-adapter.ts
@@ -9,6 +9,12 @@ export interface FsStatResult {
   isSymbolicLink?(): boolean;
   size: number;
   mtime: Date;
+  /** File mode, including the type bits (e.g. 0o100644). Optional: not every adapter models permissions. */
+  mode?: number;
+  /** Owner user id. Optional: not every adapter models ownership. */
+  uid?: number;
+  /** Owner group id. Optional: not every adapter models ownership. */
+  gid?: number;
 }
 
 export interface FsDirent {
@@ -42,6 +48,17 @@ export interface FsAdapter {
    */
   flockSync?(fd: number, operation: "ex" | "un"): void;
   statSync(path: string): FsStatResult;
+  /**
+   * Sync chmod, mirroring Ruby `File.chmod`. Optional: adapters that model no
+   * permissions (an in-memory VFS) may omit it, and callers skip the copy.
+   */
+  chmodSync?(path: string, mode: number): void;
+  /**
+   * Sync chown, mirroring Ruby `File.chown`. Optional for the same reason as
+   * {@link FsAdapter.chmodSync}. Argument order follows the adapter's Node
+   * shape (path first), not Ruby's.
+   */
+  chownSync?(path: string, uid: number, gid: number): void;
   /**
    * Sync realpath — resolves symlinks, mirroring Ruby File.realpath. Optional;
    * adapters without symlink support may omit it (callers fall back to a

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/file/atomic.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/file/atomic.json
@@ -10,15 +10,15 @@
     "package": "activesupport",
     "tsFile": "core-ext/file/atomic.ts",
     "rubyName": "atomic_write",
-    "call": "stat",
-    "reason": "trails has no Ruby File: the fs-adapter's statSync is the File.stat analogue and carries no matching Ruby name."
+    "call": "rename",
+    "reason": "trails has no Ruby File: the fs-adapter's renameSync is the File.rename analogue and carries no matching Ruby name."
   },
   {
     "package": "activesupport",
     "tsFile": "core-ext/file/atomic.ts",
     "rubyName": "atomic_write",
-    "call": "rename",
-    "reason": "trails has no Ruby File: the fs-adapter's renameSync is the File.rename analogue and carries no matching Ruby name."
+    "call": "stat",
+    "reason": "trails has no Ruby File: the fs-adapter's statSync is the File.stat analogue and carries no matching Ruby name."
   },
   {
     "package": "activesupport",

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/file/atomic.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/file/atomic.json
@@ -1,0 +1,30 @@
+[
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/file/atomic.ts",
+    "rubyName": "atomic_write",
+    "call": "exist?",
+    "reason": "trails has no Ruby File: the fs-adapter's existsSync is the File.exist? analogue and carries no matching Ruby name."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/file/atomic.ts",
+    "rubyName": "atomic_write",
+    "call": "stat",
+    "reason": "trails has no Ruby File: the fs-adapter's statSync is the File.stat analogue and carries no matching Ruby name."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/file/atomic.ts",
+    "rubyName": "atomic_write",
+    "call": "rename",
+    "reason": "trails has no Ruby File: the fs-adapter's renameSync is the File.rename analogue and carries no matching Ruby name."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/file/atomic.ts",
+    "rubyName": "probe_stat_in",
+    "call": "stat",
+    "reason": "trails has no Ruby File: the fs-adapter's statSync is the File.stat analogue and carries no matching Ruby name."
+  }
+]


### PR DESCRIPTION
Ports `File.probe_stat_in` (`activesupport/lib/active_support/core_ext/file/atomic.rb:55-70`) and the permission copy `File.atomic_write` does before the rename (`atomic.rb:28-46`).

- `FsStatResult` gains optional `mode`/`uid`/`gid`; `FsAdapter` gains optional `chmodSync`/`chownSync` (the Node adapter picks both up for free).
- `atomicWrite` stats the destination when it exists, otherwise probes the directory's defaults via `probeStatIn`, then chowns/chmods the temp file, swallowing `EPERM`/`EACCES` as Rails does (`atomic.rb:36-46`).
- `probeStatIn` mirrors Rails' decomposition; the thread-id/pid components of the probe basename (`atomic.rb:59-60`) are two random draws here (single thread, no `process.*`).
- The two "unrepresentable permission copy" `@missingRailsCall` tags are gone; what remains are the adapter's `existsSync`/`statSync`/`renameSync` spellings.
- `core-ext/file.test.ts` now exercises the real implementation instead of a local stub, with Rails' test names unchanged; the permission tests fail on the baseline.

Closes-story: port-atomic-write-probe-stat-in-permissions