### PR TITLE
feat(activesupport): port XmlMini's REXML backend and make it the default

### DIFF
--- a/packages/activesupport/src/rexml/document.trails.test.ts
+++ b/packages/activesupport/src/rexml/document.trails.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { Document, Element, ParseException, Text } from "./document.js";
+
+// REXML is Ruby stdlib, so there is no Rails test file to mirror: these cover
+// the slice of the parser `XmlMini_REXML` drives.
+describe("REXML::Document", () => {
+  it("exposes the root element", () => {
+    const doc = new Document("<?xml version='1.0'?><root/>");
+    expect(doc.root?.name).toBe("root");
+    expect(doc.root?.hasElements()).toBe(false);
+  });
+
+  it("has no root for an XML declaration only", () => {
+    expect(new Document("<?xml version='1.0'?>").root).toBeUndefined();
+  });
+
+  it("reads attributes and unescapes entities", () => {
+    const doc = new Document(`<root a="1" b='&lt;&amp;&#65;'/>`);
+    const attrs: Array<[string, string]> = [];
+    doc.root!.attributes.each((n, v) => attrs.push([n, v]));
+    expect(attrs).toEqual([
+      ["a", "1"],
+      ["b", "<&A"],
+    ]);
+  });
+
+  it("nests child elements and text", () => {
+    const doc = new Document("<products><book>Ruby</book><!-- c --><book/></products>");
+    const root = doc.root!;
+    expect(root.hasElements()).toBe(true);
+    const names: string[] = [];
+    root.eachElement((child) => names.push(child.name));
+    expect(names).toEqual(["book", "book"]);
+    const book = root.children[0] as Element;
+    expect(book.hasText()).toBe(true);
+    expect(book.texts.map((t: Text) => t.value)).toEqual(["Ruby"]);
+  });
+
+  it("reads CDATA as text", () => {
+    const doc = new Document("<root><![CDATA[<b>hi</b>]]></root>");
+    expect(doc.root!.texts.map((t) => t.value)).toEqual(["<b>hi</b>"]);
+  });
+
+  it("skips a DOCTYPE with an internal subset without expanding its entities", () => {
+    const doc = new Document(`<!DOCTYPE root [<!ENTITY a "aaa">]><root>&a;</root>`);
+    expect(doc.root!.texts.map((t) => t.value)).toEqual(["&a;"]);
+  });
+
+  it("raises ParseException on an unclosed tag", () => {
+    expect(() => new Document("<root><a></root>")).toThrow(ParseException);
+  });
+
+  it("serializes back to XML", () => {
+    expect(new Document(`<root a="1"><b>x</b></root>`).toString()).toBe(
+      "<root a='1'><b>x</b></root>",
+    );
+  });
+});

--- a/packages/activesupport/src/rexml/document.trails.test.ts
+++ b/packages/activesupport/src/rexml/document.trails.test.ts
@@ -46,6 +46,13 @@ describe("REXML::Document", () => {
     expect(doc.root!.texts.map((t) => t.value)).toEqual(["aaa"]);
   });
 
+  it("expands the internal DTD subset entities in attribute values", () => {
+    const doc = new Document(`<!DOCTYPE root [<!ENTITY a "aaa">]><root attr="&a;"/>`);
+    const attrs: Array<[string, string]> = [];
+    doc.root!.attributes.each((n, v) => attrs.push([n, v]));
+    expect(attrs).toEqual([["attr", "aaa"]]);
+  });
+
   it("raises RuntimeError when an entity expands past REXML's text limit", () => {
     const doc = new Document(`<?xml version="1.0" encoding="UTF-8"?>
       <!DOCTYPE member [

--- a/packages/activesupport/src/rexml/document.trails.test.ts
+++ b/packages/activesupport/src/rexml/document.trails.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Document, Element, ParseException, Text } from "./document.js";
+import { Document, Element, ParseException, RuntimeError, Text } from "./document.js";
 
 // REXML is Ruby stdlib, so there is no Rails test file to mirror: these cover
 // the slice of the parser `XmlMini_REXML` drives.
@@ -41,9 +41,25 @@ describe("REXML::Document", () => {
     expect(doc.root!.texts.map((t) => t.value)).toEqual(["<b>hi</b>"]);
   });
 
-  it("skips a DOCTYPE with an internal subset without expanding its entities", () => {
+  it("expands the internal DTD subset entities", () => {
     const doc = new Document(`<!DOCTYPE root [<!ENTITY a "aaa">]><root>&a;</root>`);
-    expect(doc.root!.texts.map((t) => t.value)).toEqual(["&a;"]);
+    expect(doc.root!.texts.map((t) => t.value)).toEqual(["aaa"]);
+  });
+
+  it("raises RuntimeError when an entity expands past REXML's text limit", () => {
+    const doc = new Document(`<?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE member [
+        <!ENTITY a "&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;">
+        <!ENTITY b "&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;">
+        <!ENTITY c "&d;&d;&d;&d;&d;&d;&d;&d;&d;&d;">
+        <!ENTITY d "&e;&e;&e;&e;&e;&e;&e;&e;&e;&e;">
+        <!ENTITY e "&f;&f;&f;&f;&f;&f;&f;&f;&f;&f;">
+        <!ENTITY f "&g;&g;&g;&g;&g;&g;&g;&g;&g;&g;">
+        <!ENTITY g "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx">
+      ]>
+      <member>&a;</member>`);
+    // REXML expands lazily: the document parses, #value raises.
+    expect(() => doc.root!.texts.map((t) => t.value)).toThrow(RuntimeError);
   });
 
   it("raises ParseException on an unclosed tag", () => {

--- a/packages/activesupport/src/rexml/document.ts
+++ b/packages/activesupport/src/rexml/document.ts
@@ -1,0 +1,284 @@
+/**
+ * The slice of Ruby's REXML that `XmlMini_REXML` uses (`require
+ * "rexml/document"`, rexml.rb:3): `REXML::Document`, the `Element`/`Text`
+ * nodes it exposes, and `REXML::ParseException`.
+ *
+ * REXML is Ruby stdlib, not Rails, so it has no `vendor/rails` counterpart and
+ * no parity population — this file stands in for the gem the way
+ * `@blazetrails/date` stands in for `date`. The names and semantics are REXML's
+ * (`Document#root`, `Element#has_elements?`, `#each_element`, `#has_text?`,
+ * `#texts`, `#attributes`, `Text#value`), so the ported `xml-mini/rexml.ts`
+ * bodies read as the Ruby ones.
+ */
+
+/**
+ * Mirrors: REXML::ParseException.
+ *
+ * @noRailsEquivalent PERMANENT — `REXML::ParseException` is Ruby stdlib (rexml/document.rb),
+ * not Rails; `XmlMini_REXML` `require`s it.
+ */
+export class ParseException extends Error {
+  /** The Ruby class name, which is what `rescue`/message formatting shows. */
+  override name = "REXML::ParseException";
+}
+
+/**
+ * Mirrors: REXML::Text — a text (or CDATA) node.
+ *
+ * @noRailsEquivalent PERMANENT — `REXML::Text` is Ruby stdlib (rexml/document.rb),
+ * not Rails; `XmlMini_REXML` `require`s it.
+ */
+export class Text {
+  constructor(public readonly value: string) {}
+}
+
+/**
+ * Mirrors: REXML::Attributes — the attribute table of an element, iterated by
+ * `attributes.each { |n, v| ... }`.
+ *
+ * @noRailsEquivalent PERMANENT — `REXML::Attributes` is Ruby stdlib (rexml/document.rb),
+ * not Rails; `XmlMini_REXML` `require`s it.
+ */
+export class Attributes {
+  private readonly entries = new Map<string, string>();
+
+  set(name: string, value: string): void {
+    this.entries.set(name, value);
+  }
+
+  each(fn: (name: string, value: string) => void): void {
+    for (const [name, value] of this.entries) fn(name, value);
+  }
+}
+
+/**
+ * Mirrors: REXML::Element.
+ *
+ * @noRailsEquivalent PERMANENT — `REXML::Element` is Ruby stdlib (rexml/document.rb),
+ * not Rails; `XmlMini_REXML` `require`s it.
+ */
+export class Element {
+  readonly attributes = new Attributes();
+  readonly children: Array<Element | Text> = [];
+
+  constructor(public readonly name: string) {}
+
+  /**
+   * Mirrors: REXML::Element#has_elements?.
+   *
+   * @noRailsEquivalent PERMANENT — a `REXML::` member (Ruby stdlib rexml/document.rb),
+   * not Rails.
+   */
+  hasElements(): boolean {
+    return this.children.some((child) => child instanceof Element);
+  }
+
+  /**
+   * Mirrors: REXML::Element#each_element.
+   *
+   * @noRailsEquivalent PERMANENT — a `REXML::` member (Ruby stdlib rexml/document.rb),
+   * not Rails.
+   */
+  eachElement(fn: (child: Element) => void): void {
+    for (const child of this.children) if (child instanceof Element) fn(child);
+  }
+
+  /**
+   * Mirrors: REXML::Element#has_text?.
+   *
+   * @noRailsEquivalent PERMANENT — a `REXML::` member (Ruby stdlib rexml/document.rb),
+   * not Rails.
+   */
+  hasText(): boolean {
+    return this.children.some((child) => child instanceof Text);
+  }
+
+  /**
+   * Mirrors: REXML::Element#texts — the element's direct text children.
+   *
+   * @noRailsEquivalent PERMANENT — a `REXML::` member (Ruby stdlib rexml/document.rb),
+   * not Rails.
+   */
+  get texts(): Text[] {
+    return this.children.filter((child): child is Text => child instanceof Text);
+  }
+
+  /**
+   * Mirrors: REXML::Element#to_s — serializes the element back to XML.
+   *
+   * @noRailsEquivalent PERMANENT — a `REXML::` member (Ruby stdlib rexml/document.rb),
+   * not Rails.
+   */
+  toString(): string {
+    let attrs = "";
+    this.attributes.each((name, value) => {
+      attrs += ` ${name}='${escapeXml(value)}'`;
+    });
+    if (this.children.length === 0) return `<${this.name}${attrs}/>`;
+    const body = this.children
+      .map((child) => (child instanceof Element ? child.toString() : escapeXml(child.value)))
+      .join("");
+    return `<${this.name}${attrs}>${body}</${this.name}>`;
+  }
+}
+
+const ENTITIES: Record<string, string> = {
+  lt: "<",
+  gt: ">",
+  amp: "&",
+  quot: '"',
+  apos: "'",
+};
+
+function escapeXml(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/**
+ * Resolve the standard entities and numeric character references. Entities
+ * declared in an internal DTD subset are deliberately NOT expanded: that is the
+ * billion-laughs vector, and REXML caps expansion for the same reason.
+ */
+function unescapeXml(text: string): string {
+  return text.replace(/&(#x?[0-9a-fA-F]+|[^;\s&]+);/g, (match, ref: string) => {
+    if (ref.startsWith("#")) {
+      const code = ref.startsWith("#x") ? parseInt(ref.slice(2), 16) : parseInt(ref.slice(1), 10);
+      return Number.isNaN(code) ? match : String.fromCodePoint(code);
+    }
+    return ENTITIES[ref] ?? match;
+  });
+}
+
+const NAME = /[^\s/>]+/y;
+
+/**
+ * Mirrors: REXML::Document — parses an XML document string into a node tree.
+ *
+ * @noRailsEquivalent PERMANENT — `REXML::Document` is Ruby stdlib (rexml/document.rb),
+ * not Rails; `XmlMini_REXML` `require`s it.
+ */
+export class Document {
+  /**
+   * Mirrors: REXML::Document#root — the root element, or `undefined`.
+   *
+   * @noRailsEquivalent PERMANENT — a `REXML::` member (Ruby stdlib rexml/document.rb),
+   * not Rails.
+   */
+  root: Element | undefined;
+
+  constructor(source: string) {
+    this.parse(source);
+  }
+
+  /**
+   * Mirrors: REXML::Document#to_s.
+   *
+   * @noRailsEquivalent PERMANENT — a `REXML::` member (Ruby stdlib rexml/document.rb),
+   * not Rails.
+   */
+  toString(): string {
+    return this.root ? this.root.toString() : "";
+  }
+
+  private parse(source: string): void {
+    const stack: Element[] = [];
+    let pos = 0;
+
+    const fail = (message: string): never => {
+      throw new ParseException(message);
+    };
+
+    const skipTo = (marker: string): void => {
+      const end = source.indexOf(marker, pos);
+      if (end === -1) fail(`Missing end of ${marker} at ${pos}`);
+      pos = end + marker.length;
+    };
+
+    while (pos < source.length) {
+      const next = source.indexOf("<", pos);
+      if (next === -1) break;
+
+      if (next > pos) {
+        const text = source.slice(pos, next);
+        const parent = stack[stack.length - 1];
+        if (parent) parent.children.push(new Text(unescapeXml(text)));
+        pos = next;
+      }
+
+      if (source.startsWith("<?", pos)) {
+        skipTo("?>");
+      } else if (source.startsWith("<!--", pos)) {
+        skipTo("-->");
+      } else if (source.startsWith("<![CDATA[", pos)) {
+        const end = source.indexOf("]]>", pos);
+        if (end === -1) fail(`Missing end of CDATA at ${pos}`);
+        const parent = stack[stack.length - 1];
+        if (parent) parent.children.push(new Text(source.slice(pos + 9, end)));
+        pos = end + 3;
+      } else if (source.startsWith("<!", pos)) {
+        // A DOCTYPE, with or without an internal subset.
+        const subset = source.indexOf("[", pos);
+        const close = source.indexOf(">", pos);
+        if (close === -1) fail(`Missing end of declaration at ${pos}`);
+        if (subset !== -1 && subset < close) {
+          skipTo("]");
+          skipTo(">");
+        } else {
+          pos = close + 1;
+        }
+      } else if (source.startsWith("</", pos)) {
+        pos += 2;
+        NAME.lastIndex = pos;
+        const match = NAME.exec(source);
+        if (!match) fail(`Malformed closing tag at ${pos}`);
+        const open = stack.pop();
+        if (!open || open.name !== match![0]) {
+          fail(`Missing end tag for '${open ? open.name : match![0]}'`);
+        }
+        pos = NAME.lastIndex;
+        const close = source.indexOf(">", pos);
+        if (close === -1) fail(`Missing end of closing tag at ${pos}`);
+        pos = close + 1;
+      } else {
+        pos += 1;
+        NAME.lastIndex = pos;
+        const match = NAME.exec(source);
+        if (!match) fail(`Malformed element at ${pos}`);
+        pos = NAME.lastIndex;
+        const element = new Element(match![0]);
+        pos = this.parseAttributes(source, pos, element, fail);
+        const selfClosing = source.startsWith("/>", pos);
+        pos += selfClosing ? 2 : 1;
+
+        const parent = stack[stack.length - 1];
+        if (parent) parent.children.push(element);
+        else if (this.root) fail("Malformed XML: Extra tag at the end of the document");
+        else this.root = element;
+
+        if (!selfClosing) stack.push(element);
+      }
+    }
+
+    if (stack.length > 0) fail(`Missing end tag for '${stack[stack.length - 1].name}'`);
+  }
+
+  private parseAttributes(
+    source: string,
+    start: number,
+    element: Element,
+    fail: (message: string) => never,
+  ): number {
+    let pos = start;
+    const attribute = /\s*([^\s=/>]+)\s*=\s*("([^"]*)"|'([^']*)')/y;
+    for (;;) {
+      while (pos < source.length && /\s/.test(source[pos])) pos += 1;
+      if (pos >= source.length) fail("Missing end of start tag");
+      if (source.startsWith("/>", pos) || source[pos] === ">") return pos;
+      attribute.lastIndex = pos;
+      const match = attribute.exec(source);
+      if (!match) fail(`Malformed attribute at ${pos}`);
+      element.attributes.set(match[1], unescapeXml(match[3] ?? match[4]));
+      pos = attribute.lastIndex;
+    }
+  }
+}

--- a/packages/activesupport/src/rexml/document.ts
+++ b/packages/activesupport/src/rexml/document.ts
@@ -348,7 +348,7 @@ export class Document {
       attribute.lastIndex = pos;
       const match = attribute.exec(source);
       if (!match) fail(`Malformed attribute at ${pos}`);
-      element.attributes.set(match[1], unescapeXml(match[3] ?? match[4]));
+      element.attributes.set(match[1], unescapeXml(match[3] ?? match[4], this.entities));
       pos = attribute.lastIndex;
     }
   }

--- a/packages/activesupport/src/rexml/document.ts
+++ b/packages/activesupport/src/rexml/document.ts
@@ -29,7 +29,24 @@ export class ParseException extends Error {
  * not Rails; `XmlMini_REXML` `require`s it.
  */
 export class Text {
-  constructor(public readonly value: string) {}
+  constructor(
+    private readonly raw: string,
+    private readonly entities: Record<string, string> = {},
+  ) {}
+
+  /**
+   * Mirrors: REXML::Text#value — the unescaped text, with the DOCTYPE's
+   * internal-subset entities expanded. REXML expands lazily, here as there:
+   * `Document.new` on a billion-laughs payload succeeds and the
+   * `entity expansion has grown too large` RuntimeError is raised at the first
+   * `#value`, which is where `XmlMini_REXML#merge_texts!` reads it.
+   *
+   * @noRailsEquivalent PERMANENT — a `REXML::` member (Ruby stdlib rexml/document.rb),
+   * not Rails.
+   */
+  get value(): string {
+    return unescapeXml(this.raw, this.entities);
+  }
 }
 
 /**
@@ -135,18 +152,66 @@ function escapeXml(text: string): string {
 }
 
 /**
- * Resolve the standard entities and numeric character references. Entities
- * declared in an internal DTD subset are deliberately NOT expanded: that is the
- * billion-laughs vector, and REXML caps expansion for the same reason.
+ * Mirrors: RuntimeError — what REXML raises when an entity expands past
+ * `REXML::Security.entity_expansion_text_limit` / `entity_expansion_limit`, and
+ * what `XMLMiniEngineTest#test_exception_thrown_on_expansion_attack` asserts
+ * through `REXMLEngineTest#expansion_attack_error`
+ * (activesupport/test/xml_mini/rexml_engine_test.rb:24-25).
+ *
+ * @noRailsEquivalent PERMANENT — Ruby core `RuntimeError`, not Rails.
  */
-function unescapeXml(text: string): string {
-  return text.replace(/&(#x?[0-9a-fA-F]+|[^;\s&]+);/g, (match, ref: string) => {
-    if (ref.startsWith("#")) {
-      const code = ref.startsWith("#x") ? parseInt(ref.slice(2), 16) : parseInt(ref.slice(1), 10);
-      return Number.isNaN(code) ? match : String.fromCodePoint(code);
-    }
-    return ENTITIES[ref] ?? match;
-  });
+export class RuntimeError extends Error {
+  override name = "RuntimeError";
+}
+
+/** REXML::Security.entity_expansion_limit. */
+const ENTITY_EXPANSION_LIMIT = 10000;
+
+/** REXML::Security.entity_expansion_text_limit. */
+const ENTITY_EXPANSION_TEXT_LIMIT = 10240;
+
+/**
+ * Resolve the standard entities, numeric character references and the
+ * DOCTYPE's internal-subset entities, under REXML's expansion caps: a
+ * billion-laughs payload raises `RuntimeError: entity expansion has grown too
+ * large` rather than expanding, which is verified against MRI REXML 3.4.
+ */
+function unescapeXml(text: string, entities: Record<string, string> = {}): string {
+  let expansions = 0;
+
+  const expand = (source: string): string =>
+    source.replace(/&(#x?[0-9a-fA-F]+|[^;\s&]+);/g, (match, ref: string) => {
+      if (ref.startsWith("#")) {
+        const code = ref.startsWith("#x") ? parseInt(ref.slice(2), 16) : parseInt(ref.slice(1), 10);
+        return Number.isNaN(code) ? match : String.fromCodePoint(code);
+      }
+      if (ENTITIES[ref] !== undefined) return ENTITIES[ref];
+      const value = entities[ref];
+      if (value === undefined) return match;
+      expansions += 1;
+      if (expansions > ENTITY_EXPANSION_LIMIT) {
+        throw new RuntimeError("number of entity expansions exceeded, processing aborted");
+      }
+      const expanded = expand(value);
+      if (expanded.length > ENTITY_EXPANSION_TEXT_LIMIT) {
+        throw new RuntimeError("entity expansion has grown too large");
+      }
+      return expanded;
+    });
+
+  const result = expand(text);
+  if (result.length > ENTITY_EXPANSION_TEXT_LIMIT) {
+    throw new RuntimeError("entity expansion has grown too large");
+  }
+  return result;
+}
+
+/** Read the `<!ENTITY name "value">` declarations out of an internal DTD subset. */
+function parseEntityDeclarations(subset: string): Record<string, string> {
+  const entities: Record<string, string> = {};
+  const declaration = /<!ENTITY\s+([^\s%]+)\s+("([^"]*)"|'([^']*)')\s*>/g;
+  for (const m of subset.matchAll(declaration)) entities[m[1]] = m[3] ?? m[4];
+  return entities;
 }
 
 const NAME = /[^\s/>]+/y;
@@ -165,6 +230,9 @@ export class Document {
    * not Rails.
    */
   root: Element | undefined;
+
+  /** The DOCTYPE internal-subset entities, expanded lazily by {@link Text#value}. */
+  private entities: Record<string, string> = {};
 
   constructor(source: string) {
     this.parse(source);
@@ -201,7 +269,7 @@ export class Document {
       if (next > pos) {
         const text = source.slice(pos, next);
         const parent = stack[stack.length - 1];
-        if (parent) parent.children.push(new Text(unescapeXml(text)));
+        if (parent) parent.children.push(new Text(text, this.entities));
         pos = next;
       }
 
@@ -213,7 +281,7 @@ export class Document {
         const end = source.indexOf("]]>", pos);
         if (end === -1) fail(`Missing end of CDATA at ${pos}`);
         const parent = stack[stack.length - 1];
-        if (parent) parent.children.push(new Text(source.slice(pos + 9, end)));
+        if (parent) parent.children.push(new Text(escapeXml(source.slice(pos + 9, end))));
         pos = end + 3;
       } else if (source.startsWith("<!", pos)) {
         // A DOCTYPE, with or without an internal subset.
@@ -221,6 +289,9 @@ export class Document {
         const close = source.indexOf(">", pos);
         if (close === -1) fail(`Missing end of declaration at ${pos}`);
         if (subset !== -1 && subset < close) {
+          const subsetEnd = source.indexOf("]", subset);
+          if (subsetEnd === -1) fail(`Missing end of declaration at ${pos}`);
+          this.entities = parseEntityDeclarations(source.slice(subset + 1, subsetEnd));
           skipTo("]");
           skipTo(">");
         } else {

--- a/packages/activesupport/src/xml-mini.ts
+++ b/packages/activesupport/src/xml-mini.ts
@@ -3,6 +3,7 @@ import { htmlEscape } from "./core-ext/tse/util.js";
 import { BigDecimal } from "./core-ext/big-decimal/conversions.js";
 import { IsolatedExecutionState } from "./isolated-execution-state.js";
 import { Temporal } from "@blazetrails/date";
+import * as XmlMini_REXML from "./xml-mini/rexml.js";
 
 /**
  * This object decorates files deserialized using `Hash.fromXml` with the
@@ -122,10 +123,26 @@ function formatDateTime(value: unknown): string {
 }
 
 /**
- * The backend `parse` delegates to (Ruby's `@backend`). Rails'
- * `XmlMini.backend = "REXML"` (xml_mini.rb:210) has no counterpart yet:
- * `XmlMini_REXML` is unported, so there is no default and `parse` raises until
- * a backend is set.
+ * The maximum element nesting a backend will descend before raising.
+ *
+ * Mirrors: `attr_accessor :depth` / `self.depth = 100` (xml_mini.rb:97-98).
+ *
+ * @internal
+ */
+let _depth = 100;
+
+/** Mirrors: ActiveSupport::XmlMini.depth (xml_mini.rb:97). */
+export function depth(): number {
+  return _depth;
+}
+
+/** Mirrors: ActiveSupport::XmlMini.depth= (xml_mini.rb:97). */
+export function setDepth(value: number): void {
+  _depth = value;
+}
+
+/**
+ * The backend `parse` delegates to (Ruby's `@backend`).
  *
  * @internal
  */
@@ -639,3 +656,12 @@ export class IndentedXmlStringBuilder implements XmlBuilder {
     return this.buffer;
   }
 }
+
+/**
+ * Mirrors: `XmlMini.backend = "REXML"` (xml_mini.rb:210) — the module-bottom
+ * default. {@link setBackend} resolves a name through a dynamic import, which
+ * cannot be awaited at module scope, so the default is assigned from the
+ * statically-imported module: the same value `castBackendNameToModule("REXML")`
+ * returns for `"REXML"`.
+ */
+_backend = XmlMini_REXML;

--- a/packages/activesupport/src/xml-mini/rexml-engine.test.ts
+++ b/packages/activesupport/src/xml-mini/rexml-engine.test.ts
@@ -1,9 +1,18 @@
-import { describe, it } from "vitest";
+import { describe, it, expect } from "vitest";
+import { backend, parse } from "../xml-mini.js";
+import * as XmlMini_REXML from "./rexml.js";
 
 describe("REXMLEngineTest", () => {
-  it.skip("default is rexml");
+  it("default is rexml", () => {
+    expect(backend()).toBe(XmlMini_REXML);
+  });
 
-  it.skip("parse from empty string");
+  it("parse from empty string", async () => {
+    expect(await parse("")).toEqual({});
+  });
 
-  it.skip("parse from frozen string");
+  it("parse from frozen string", async () => {
+    const xmlString = "<root></root>";
+    expect(await parse(xmlString)).toEqual({ root: {} });
+  });
 });

--- a/packages/activesupport/src/xml-mini/rexml.ts
+++ b/packages/activesupport/src/xml-mini/rexml.ts
@@ -1,0 +1,175 @@
+import * as XmlMini from "../xml-mini.js";
+import { Document, Element, ParseException } from "../rexml/document.js";
+import { isBlank } from "../string-utils.js";
+
+/**
+ * Mirrors: ActiveSupport::XmlMini_REXML (xml_mini/rexml.rb) — the default
+ * backend.
+ */
+
+/** Mirrors: ActiveSupport::XmlMini_REXML::CONTENT_KEY (rexml.rb:11). */
+export const CONTENT_KEY = "__content__";
+
+/**
+ * Parse an XML Document string or IO into a simple hash.
+ *
+ * Same as XmlSimple::xml_in but doesn't shoot itself in the foot,
+ * and uses the defaults from Active Support.
+ *
+ * data::
+ *   XML Document string or IO to parse
+ *
+ * Mirrors: ActiveSupport::XmlMini_REXML#parse (rexml.rb:20-36) — `data` is a
+ * string here (see {@link XmlMini.XmlMiniBackend}), so Rails' wrap in a
+ * `StringIO` and its `eof?` check are the empty-string check.
+ */
+export async function parse(data: string | null | undefined): Promise<Record<string, unknown>> {
+  const io = data ?? "";
+
+  if (io === "") {
+    return {};
+  } else {
+    const doc = new Document(io);
+
+    if (doc.root) {
+      return mergeElementBang({}, doc.root, XmlMini.depth());
+    } else {
+      throw new ParseException(
+        `The document ${JSON.stringify(String(doc))} does not have a valid root`,
+      );
+    }
+  }
+}
+
+/**
+ * Convert an XML element and merge into the hash
+ *
+ * hash::
+ *   Hash to merge the converted element into.
+ * element::
+ *   XML element to merge into hash
+ *
+ * Mirrors: ActiveSupport::XmlMini_REXML#merge_element! (rexml.rb:47-50).
+ *
+ * @internal
+ */
+function mergeElementBang(
+  hash: Record<string, unknown>,
+  element: Element,
+  depth: number,
+): Record<string, unknown> {
+  if (depth === 0) throw new ParseException("The document is too deep");
+  return mergeBang(hash, element.name, collapse(element, depth));
+}
+
+/**
+ * Actually converts an XML document element into a data structure.
+ *
+ * element::
+ *   The document element to be collapsed.
+ *
+ * Mirrors: ActiveSupport::XmlMini_REXML#collapse (rexml.rb:56-66).
+ *
+ * @internal
+ */
+function collapse(element: Element, depth: number): Record<string, unknown> {
+  const hash = getAttributes(element);
+
+  if (element.hasElements()) {
+    element.eachElement((child) => mergeElementBang(hash, child, depth - 1));
+    if (!isEmptyContent(element)) mergeTextsBang(hash, element);
+    return hash;
+  } else {
+    return mergeTextsBang(hash, element);
+  }
+}
+
+/**
+ * Merge all the texts of an element into the hash
+ *
+ * hash::
+ *   Hash to add the converted element to.
+ * element::
+ *   XML element whose texts are to me merged into the hash
+ *
+ * Mirrors: ActiveSupport::XmlMini_REXML#merge_texts! (rexml.rb:73-82).
+ *
+ * @internal
+ */
+function mergeTextsBang(hash: Record<string, unknown>, element: Element): Record<string, unknown> {
+  if (!element.hasText()) {
+    return hash;
+  } else {
+    // must use value to prevent double-escaping
+    let texts = "";
+    for (const t of element.texts) texts += t.value;
+    return mergeBang(hash, CONTENT_KEY, texts);
+  }
+}
+
+/**
+ * Adds a new key/value pair to an existing Hash. If the key to be added
+ * already exists and the existing value associated with key is not
+ * an Array, it will be wrapped in an Array. Then the new value is
+ * appended to that Array.
+ *
+ * hash::
+ *   Hash to add key/value pair to.
+ * key::
+ *   Key to be added.
+ * value::
+ *   Value to be associated with key.
+ *
+ * Mirrors: ActiveSupport::XmlMini_REXML#merge! (rexml.rb:94-106).
+ *
+ * @internal
+ */
+function mergeBang(
+  hash: Record<string, unknown>,
+  key: string,
+  value: unknown,
+): Record<string, unknown> {
+  if (Object.prototype.hasOwnProperty.call(hash, key)) {
+    if (Array.isArray(hash[key])) {
+      (hash[key] as unknown[]).push(value);
+    } else {
+      hash[key] = [hash[key], value];
+    }
+  } else if (Array.isArray(value)) {
+    hash[key] = [value];
+  } else {
+    hash[key] = value;
+  }
+  return hash;
+}
+
+/**
+ * Converts the attributes array of an XML element into a hash.
+ * Returns an empty Hash if node has no attributes.
+ *
+ * element::
+ *   XML element to extract attributes from.
+ *
+ * Mirrors: ActiveSupport::XmlMini_REXML#get_attributes (rexml.rb:113-117).
+ *
+ * @internal
+ */
+function getAttributes(element: Element): Record<string, unknown> {
+  const attributes: Record<string, unknown> = {};
+  element.attributes.each((n, v) => (attributes[n] = v));
+  return attributes;
+}
+
+/**
+ * Determines if a document element has text content
+ *
+ * element::
+ *   XML element to be checked.
+ *
+ * Mirrors: ActiveSupport::XmlMini_REXML#empty_content? (rexml.rb:123-125).
+ *
+ * @internal
+ */
+function isEmptyContent(element: Element): boolean {
+  return isBlank(element.texts.map((t) => t.value).join(""));
+}

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/number-helper/number-converter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/number-helper/number-converter.json
@@ -4,6 +4,6 @@
     "tsFile": "number-helper/number-converter.ts",
     "rubyName": "format_options",
     "call": "merge!",
-    "reason": "Per-entry verified: surfaced by porting XmlMini_REXML#merge! (which puts `merge!` in the gate's population). Rails number_converter.rb:146 spells `default_format_options.merge!(i18n_format_options)`; the TS body merges both with an object spread, which is not a call node."
+    "reason": "Per-entry verified: Rails number_converter.rb:146 spells `default_format_options.merge!(i18n_format_options)`; the TS body merges both with an object spread, which is not a call node — Ruby's `Hash#merge!` is core, not Rails, so there is no ported name for the gate to match. Pre-existing; only became visible when porting XmlMini_REXML#merge! put `merge!` in the gate's ported-name population. Convergence of the surrounding decomposition is tracked by story 0101-activesupport-out-of-closure-surface/converge-number-converter-format-options."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/number-helper/number-converter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/number-helper/number-converter.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "activesupport",
+    "tsFile": "number-helper/number-converter.ts",
+    "rubyName": "format_options",
+    "call": "merge!",
+    "reason": "Per-entry verified: surfaced by porting XmlMini_REXML#merge! (which puts `merge!` in the gate's population). Rails number_converter.rb:146 spells `default_format_options.merge!(i18n_format_options)`; the TS body merges both with an object spread, which is not a call node."
+  }
+]

--- a/scripts/parity/unported-files/activesupport.ts
+++ b/scripts/parity/unported-files/activesupport.ts
@@ -171,13 +171,6 @@ export const ACTIVESUPPORT_UNPORTED_FILES: UnportedFile[] = [
       "outside the AR/AM require closure; deferred until an actionpack/railties port needs it.",
   },
   {
-    pattern: "xml_mini/rexml.rb",
-    testFile: "rexml_engine_test.rb",
-    package: "activesupport",
-    reason:
-      "outside the AR/AM require closure; deferred until an actionpack/railties port needs it.",
-  },
-  {
     pattern: "testing/parallelize_executor.rb",
     package: "activesupport",
     reason:


### PR DESCRIPTION
Ports the two pieces `port-xml-mini-backend-and-parsing-half` left behind.

- `packages/activesupport/src/xml-mini/rexml.ts` — `ActiveSupport::XmlMini_REXML`
  (`xml_mini/rexml.rb`): `parse`, `merge_element!`, `collapse`, `merge_texts!`,
  `merge!`, `get_attributes`, `empty_content?`, `CONTENT_KEY`, with the Rails
  bodies, branch order and messages. `require_rexml` has no counterpart (ESM
  imports are static), which is the file's one unmatched method.
- `xml-mini.ts` — the module-bottom `XmlMini.backend = "REXML"`
  (`xml_mini.rb:210`), replacing the "no default backend" comment, plus the
  `depth` accessor (`xml_mini.rb:97-98`) `merge_element!` reads. `setBackend`
  resolves a name through a dynamic import and cannot be awaited at module
  scope, so the default is assigned from the statically-imported module — the
  same value `castBackendNameToModule("REXML")` returns.
- `packages/activesupport/src/rexml/document.ts` — the slice of REXML the
  backend drives (`Document`, `Element`, `Text`, `Attributes`,
  `ParseException`). REXML is Ruby stdlib, not Rails, so it has no vendor/rails
  counterpart; it stands in for the gem the way `@blazetrails/date` does for
  `date`, and every member carries a `@noRailsEquivalent PERMANENT` tag. No
  `node:*` imports, no new dependencies. Entities declared in an internal DTD
  subset are deliberately not expanded (billion-laughs).
- `xml-mini/rexml-engine.test.ts` enrolled: the three Rails test names, verbatim.
  `xml_mini/rexml.rb` is removed from `unported-files/activesupport.ts`.

Gates: `parity:api` activesupport 1159→1166 methods, files 159→160
(`xml_mini/rexml.rb` 7/8); `parity:test` `rexml_engine_test.rb` 3/3 ✓;
`parity:api:calls` and `:calls:args` green. Porting `merge!` puts that name in
the call gate's population, which surfaced one PRE-EXISTING divergence in
`number-helper/number-converter.ts` (`format_options` spreads where Rails calls
`merge!`); baselined with a per-entry reason, not introduced here.

Closes-story: port-xml-mini-rexml-backend-and-default

## Review round 1

**Expansion attack (document.ts).** Fixed. The internal DTD subset is parsed
into an entity table and expanded lazily in `Text#value` under
`REXML::Security.entity_expansion_limit` (10000) and
`entity_expansion_text_limit` (10240), raising `RuntimeError:
entity expansion has grown too large`. Verified against MRI REXML 3.4: the
Rails payload parses fine at `Document.new` and raises at the first `#value`,
which is exactly where `merge_texts!` reads it — so `XmlMini.parse` on the
`xml_mini_engine_test.rb:51-68` payload now rejects with that RuntimeError,
matching `REXMLEngineTest#expansion_attack_error`
(`rexml_engine_test.rb:24-25`).

**number-converter baseline row.** Kept, with the reason narrowed. It is not a
divergence this PR introduces: `format_options` has folded `opts` in with an
object spread since it landed, and Ruby's `Hash#merge!` is *core*, not Rails, so
there is no ported TS name for the gate to match — a spread is not a call node
(the same fact the neighbouring `xml-mini/nokogirisax.json` row records for
`delete`). Porting `XmlMini_REXML#merge!` — required by the story — is what put
`merge!` into the gate's ported-name population and made the pre-existing shape
visible; deleting the row reds `parity:api:calls` with nothing in this PR to
fix. Converging the surrounding decomposition (Rails merges `opts` in `options`,
not in `format_options` — `number_converter.rb:141-147`) is filed as story
`0101-activesupport-out-of-closure-surface/converge-number-converter-format-options`.

Gates after the fix: `parity:api` activesupport 1166 methods / 160 files
(`xml_mini/rexml.rb` 7/8), `parity:api:calls` OK, `parity:api:calls:args` OK,
`parity:api:extra` `rexml/document.ts` 0 novel.
