### PR TITLE
fix(activerecord): pass the bind to Arel::Nodes::Bin in caseSensitiveComparison

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1054,7 +1054,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   ): Promise<Nodes.Node> {
     const column = (await this.columnForAttribute(attribute)) as MysqlColumn | undefined;
     if (column?.collation && !column.isCaseSensitive()) {
-      return attribute.eq(new Nodes.Bin(attribute.quotedNode(value)));
+      return attribute.eq(new Nodes.Bin(value));
     }
     return super.caseSensitiveComparison(attribute, value);
   }

--- a/packages/arel/src/visitors/mysql.test.ts
+++ b/packages/arel/src/visitors/mysql.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { testConnection, mysqlTestConnection } from "../test-helpers/connection.js";
+import { Attribute as AMAttribute, StringType } from "@blazetrails/activemodel";
 import { Table, star, SelectManager, Nodes, Visitors } from "../index.js";
 
 describe("MysqlTest", () => {
@@ -228,6 +229,14 @@ describe("MySQL dialect overrides (audit follow-up)", () => {
 
   it("Bin uses CAST(... AS BINARY) (mirrors Rails)", () => {
     expect(compile(new Nodes.Bin(users.get("name")))).toBe("CAST(`users`.`name` AS BINARY)");
+  });
+
+  // AbstractMysqlAdapter#case_sensitive_comparison wraps the *bind* in
+  // Arel::Nodes::Bin, so the visitor has to dispatch on an
+  // ActiveModel::Attribute the same way `visit` does everywhere else.
+  it("Bin visits a bind attribute rather than stringifying it", () => {
+    const bind = AMAttribute.fromDatabase("name", "x", new StringType());
+    expect(compile(new Nodes.Bin(bind))).toBe("CAST(? AS BINARY)");
   });
 
   it("UnqualifiedColumn delegates to its inner expression", () => {

--- a/packages/arel/src/visitors/mysql.ts
+++ b/packages/arel/src/visitors/mysql.ts
@@ -16,11 +16,7 @@ export class MySQL extends ToSql {
   // emitted SQL.
   protected override visitArelNodesBin(o: Nodes.Bin, collector: SQLString): SQLString {
     collector.append("CAST(");
-    if (o.expr instanceof Node) {
-      this.visit(o.expr, collector);
-    } else if (o.expr !== null) {
-      collector.append(String(o.expr));
-    }
+    this.visit(o.expr, collector);
     collector.append(" AS BINARY)");
     return collector;
   }


### PR DESCRIPTION
`AbstractMysqlAdapter#case_sensitive_comparison` passes `value` straight into `Arel::Nodes::Bin` (`vendor/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:600-606`). The port passed `attribute.quotedNode(value)` — an invented call-site conversion.

The wrap was load-bearing only because our MySQL visitor's `visitArelNodesBin` stringified any non-`Node` expr instead of visiting it, and the value here is the `ActiveModel::Attribute` bind built by `buildBindAttribute` (`uniqueness.rb:117-123`) — so an unwrapped bind rendered as `[object Object]`. Rails' visitor is a bare `visit o.expr` (`vendor/rails/activerecord/lib/arel/visitors/mysql.rb:7-11`), and `visit` already dispatches `ActiveModel::Attribute` via the registry. Converged the node, then the call site.

Regression test in `packages/arel/src/visitors/mysql.test.ts` renders `CAST(? AS BINARY)` for a bind; it produced `CAST([object Object] AS BINARY)` on baseline.

`pnpm parity:api:calls:args` and `pnpm parity:api:calls` green; no baseline row to delete.

Closes-story: call-args-ar-mysql-case-sensitive-comparison