### PR TITLE
fix(activerecord,activesupport,rack): read the PG version memo, drop the DEFAULT_GENERATED ON UPDATE fold, port StringIO

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -188,7 +188,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       const extra = ((f["Extra"] as string | null) ?? "").trim();
       const sqlType = ((f["Type"] as string | null) ?? "").toLowerCase();
       if (def == null || /^\d/.test(def) || def.startsWith("'")) return false;
-      if (extra.toUpperCase().startsWith("DEFAULT_GENERATED")) return false;
+      if (extra === "DEFAULT_GENERATED") return false;
       // newColumnFromField's datetime+CURRENT_TIMESTAMP short-circuit only fires when the
       // semantic type is "datetime" (sqlType startsWith "datetime"/"timestamp"); for
       // non-datetime columns with a CURRENT_TIMESTAMP default we still need SHOW CREATE TABLE

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -373,10 +373,8 @@ export function newColumnFromField(
   let def: string | null = field["Default"] ?? null;
   let defFn: string | null = null;
 
-  const extraRaw = field["Extra"] ?? "";
-
   if (meta.type === "datetime" && /^CURRENT_TIMESTAMP(\([0-6]?\))?$/i.test(def ?? "")) {
-    if (/on update CURRENT_TIMESTAMP/i.test(extraRaw)) def = `${def} ON UPDATE ${def}`;
+    if (/on update CURRENT_TIMESTAMP/i.test(field["Extra"] ?? "")) def = `${def} ON UPDATE ${def}`;
     [def, defFn] = [null, def];
   } else if (meta.extra === "DEFAULT_GENERATED") {
     if (def != null && !def.startsWith("(")) def = `(${def})`;
@@ -397,7 +395,7 @@ export function newColumnFromField(
     unsigned: /\bunsigned(?: zerofill)?$/.test(field["Type"] ?? ""),
     autoIncrement: /auto_increment/i.test(field["Extra"] ?? ""),
     virtual: /(virtual|stored|persistent)\s+generated/i.test(field["Extra"] ?? ""),
-    extra: extraRaw,
+    extra: field["Extra"] ?? "",
     comment: presence(field["Comment"] as string | undefined) ?? null,
   });
 }

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -374,20 +374,13 @@ export function newColumnFromField(
   let defFn: string | null = null;
 
   const extraRaw = field["Extra"] ?? "";
-  const onUpdateMatch = extraRaw.match(/on update (.+)$/i);
 
   if (meta.type === "datetime" && /^CURRENT_TIMESTAMP(\([0-6]?\))?$/i.test(def ?? "")) {
     if (/on update CURRENT_TIMESTAMP/i.test(extraRaw)) def = `${def} ON UPDATE ${def}`;
     [def, defFn] = [null, def];
-  } else if (meta.extra.toUpperCase().startsWith("DEFAULT_GENERATED")) {
-    // MySQL 8 emits "DEFAULT_GENERATED" alone (function default) or compound
-    // "DEFAULT_GENERATED on update CURRENT_TIMESTAMP". Both flow through the
-    // function-default path; fold on_update into the function expression so
-    // renameColumnForAlter can rebuild the column from defaultFunction alone.
+  } else if (meta.extra === "DEFAULT_GENERATED") {
     if (def != null && !def.startsWith("(")) def = `(${def})`;
-    let folded = def?.replace(/\\'/g, "'") ?? null;
-    if (folded != null && onUpdateMatch) folded = `${folded} ON UPDATE ${onUpdateMatch[1]}`;
-    [def, defFn] = [null, folded];
+    [def, defFn] = [null, def?.replace(/\\'/g, "'") ?? null];
   } else if (meta.type === "text" && def?.startsWith("'")) {
     def = def.slice(1, -1).replace(/\\'/g, "'");
   } else if (def != null && !/^\d/.test(def)) {

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
@@ -64,6 +64,12 @@ function makeAdapter(options: FakeOptions = {}) {
       return options.queryValue ? await options.queryValue(text) : null;
     }),
     getDatabaseVersion: vi.fn(async () => 160000),
+    // `database_version` is `pool.server_version(self)` (`abstract_adapter.rb:854-856`),
+    // so the shim carries the pool that memo lives on.
+    pool: {
+      serverVersion: (connection: { getDatabaseVersion(): Promise<number> }) =>
+        connection.getDatabaseVersion(),
+    },
     maxIdentifierLength: () => options.maxIdentifierLength ?? 63,
   };
   return { adapter: adapter as unknown as DatabaseAdapter, sql };

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -63,12 +63,10 @@ function toS(value: unknown): string {
  * declaration for them would collide with it — `PostgreSQLAdapter` narrows many
  * (`adapterName` to `AdapterName`, `createAlterTable` to `PgAlterTable`), which is
  * legal on a class and is what Ruby's untyped override translates to, but
- * declaration merging demands identical types. `getDatabaseVersion` is the one
- * exception: a declaration-only `declare` field in the class body does outrank
- * the inherited method (see the class), which is what removed
- * `resetPkSequenceBang`'s cast.
+ * declaration merging demands identical types.
  *
- * The same trick cannot reach `typeMap`: `AbstractAdapter` declares it as an
+ * A declaration-only `declare` field in the class body outranks an inherited
+ * method, but that trick cannot reach `typeMap`: `AbstractAdapter` declares it as an
  * accessor (`abstract-adapter.ts:2543`), and TypeScript refuses to narrow an
  * inherited accessor from either a merged-interface member or a `declare` field
  * (TS2610). A real accessor override here would shadow `PostgreSQLAdapter`'s own
@@ -110,11 +108,6 @@ export interface SchemaStatements
 
 export class SchemaStatements extends AbstractSchemaStatements {
   /* eslint-enable @typescript-eslint/no-unsafe-declaration-merging */
-
-  // Rails gets PostgreSQLAdapter's `get_database_version` (`server_version_num`)
-  // by ordinary method lookup; TS picks the inherited generic-adapter method
-  // ahead of a merged-interface one, so restate it declaration-only.
-  declare getDatabaseVersion: () => Promise<number>;
 
   /** Mirrors: PostgreSQL::SchemaStatements#update_table_definition */
   override updateTableDefinition(tableName: string, base?: unknown): PgTable {
@@ -1857,7 +1850,10 @@ export class SchemaStatements extends AbstractSchemaStatements {
     );
     let minvalue: unknown = null;
     if (maxPk == null) {
-      const dbVersion = await this.getDatabaseVersion();
+      // Rails reads `database_version` (`postgresql/schema_statements.rb:347`),
+      // the pool memo; the inherited accessor is typed for every adapter, so PG
+      // narrows it here the same way `columns` does.
+      const dbVersion = (await this.databaseVersion) as number;
       minvalue =
         dbVersion >= 100000
           ? await this.queryValue(

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -1850,9 +1850,6 @@ export class SchemaStatements extends AbstractSchemaStatements {
     );
     let minvalue: unknown = null;
     if (maxPk == null) {
-      // Rails reads `database_version` (`postgresql/schema_statements.rb:347`),
-      // the pool memo; the inherited accessor is typed for every adapter, so PG
-      // narrows it here the same way `columns` does.
       const dbVersion = (await this.databaseVersion) as number;
       minvalue =
         dbVersion >= 100000

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -477,6 +477,7 @@ export {
 } from "./core-ext/object/duplicable.js";
 export { CurrentAttributes } from "./current-attributes.js";
 export { StringInquirer, inquiry } from "./string-inquirer.js";
+export { StringIO } from "./string-io.js";
 export { EnvironmentInquirer } from "./environment-inquirer.js";
 export { getEnv } from "./environment.js";
 export { ExecutionContext } from "./execution-context.js";

--- a/packages/activesupport/src/string-io.trails.test.ts
+++ b/packages/activesupport/src/string-io.trails.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { StringIO } from "./string-io.js";
+
+// Ruby stdlib shim, so there is no Rails test to mirror; the expectations below
+// are MRI's (`ruby -rstringio`).
+describe("StringIO", () => {
+  it("reads the buffer forward and reports eof", () => {
+    const io = new StringIO("abc");
+    expect(io.read(2)).toBe("ab");
+    expect(io.read()).toBe("c");
+    expect(io.isEof()).toBe(true);
+    expect(io.read()).toBe("");
+    expect(io.read(1)).toBe(null);
+  });
+
+  it("rewinds to the start", () => {
+    const io = new StringIO("abc");
+    io.read();
+    io.rewind();
+    expect(io.read()).toBe("abc");
+  });
+
+  it("answers string and size regardless of position", () => {
+    const io = new StringIO("abc");
+    io.read();
+    expect(io.string()).toBe("abc");
+    expect(io.size).toBe(3);
+  });
+
+  it("appends written characters", () => {
+    const io = new StringIO("ab");
+    expect(io.write("cd")).toBe(2);
+    expect(io.string()).toBe("abcd");
+  });
+
+  it("closes", () => {
+    const io = new StringIO();
+    expect(io.closed).toBe(false);
+    io.close();
+    expect(io.closed).toBe(true);
+  });
+});

--- a/packages/activesupport/src/string-io.trails.test.ts
+++ b/packages/activesupport/src/string-io.trails.test.ts
@@ -27,6 +27,13 @@ describe("StringIO", () => {
     expect(io.size).toBe(3);
   });
 
+  it("counts bytes, not code points, in a binary string", () => {
+    // MRI: StringIO.new("\xFF".b).size == 1
+    const io = new StringIO("\xff");
+    expect(io.size).toBe(1);
+    expect(io.read()).toBe("\xff");
+  });
+
   it("writes from the current position", () => {
     const io = new StringIO("ab");
     expect(io.write("cd")).toBe(2);

--- a/packages/activesupport/src/string-io.trails.test.ts
+++ b/packages/activesupport/src/string-io.trails.test.ts
@@ -27,10 +27,20 @@ describe("StringIO", () => {
     expect(io.size).toBe(3);
   });
 
-  it("appends written characters", () => {
+  it("writes from the current position", () => {
     const io = new StringIO("ab");
     expect(io.write("cd")).toBe(2);
-    expect(io.string()).toBe("abcd");
+    expect(io.string()).toBe("cd");
+
+    const io2 = new StringIO("abcdef");
+    io2.read(2);
+    io2.write("XY");
+    expect(io2.string()).toBe("abXYef");
+
+    const io3 = new StringIO("ab");
+    io3.read();
+    io3.write("Z");
+    expect(io3.string()).toBe("abZ");
   });
 
   it("closes", () => {

--- a/packages/activesupport/src/string-io.ts
+++ b/packages/activesupport/src/string-io.ts
@@ -48,10 +48,14 @@ export class StringIO {
     return chunk;
   }
 
-  /** Ruby: `StringIO#write` — appends and returns the characters written. */
+  /**
+   * Ruby: `StringIO#write` — overwrites from the current position, advances it
+   * past what was written, and returns the number of characters written.
+   */
   write(string: string): number {
-    this._string += string;
-    this._pos = this._string.length;
+    this._string =
+      this._string.slice(0, this._pos) + string + this._string.slice(this._pos + string.length);
+    this._pos += string.length;
     return string.length;
   }
 

--- a/packages/activesupport/src/string-io.ts
+++ b/packages/activesupport/src/string-io.ts
@@ -4,9 +4,10 @@
  * and `Rack::MockRequest` hand to their callers. Only the members Ruby code in
  * this repo sends are ported.
  *
- * Positions are counted in characters: a trails string is the port of a Ruby
- * String, and the payloads that reach here (`Base64.decode64`'s binary string,
- * a request body) are already one character per byte.
+ * Read positions are counted in characters, where Ruby counts bytes: the
+ * payloads that reach here (`Base64.decode64`'s binary string, a request body)
+ * are one character per byte. `size` is Ruby's bytesize, which callers send to
+ * fill a `CONTENT_LENGTH`.
  *
  * @noRailsEquivalent PERMANENT — Ruby stdlib, not Rails: `StringIO` ships with
  * the interpreter, so no Rails file defines it and no port can remove the need
@@ -26,9 +27,9 @@ export class StringIO {
     return this._string;
   }
 
-  /** Ruby: `StringIO#size` (aliased `length`). */
+  /** Ruby: `StringIO#size` (aliased `length`) — the buffer's bytesize. */
   get size(): number {
-    return this._string.length;
+    return new TextEncoder().encode(this._string).length;
   }
 
   /**

--- a/packages/activesupport/src/string-io.ts
+++ b/packages/activesupport/src/string-io.ts
@@ -1,0 +1,77 @@
+/**
+ * Ruby's `StringIO` (stdlib), the readable/writable in-memory IO that
+ * `XmlMini._parse_file` (`activesupport/lib/active_support/xml_mini.rb:180-186`)
+ * and `Rack::MockRequest` hand to their callers. Only the members Ruby code in
+ * this repo sends are ported.
+ *
+ * Positions are counted in characters: a trails string is the port of a Ruby
+ * String, and the payloads that reach here (`Base64.decode64`'s binary string,
+ * a request body) are already one character per byte.
+ *
+ * @noRailsEquivalent PERMANENT — Ruby stdlib, not Rails: `StringIO` ships with
+ * the interpreter, so no Rails file defines it and no port can remove the need
+ * for it while `_parse_file` and `Rack::MockRequest` hand callers an IO.
+ */
+export class StringIO {
+  private _string: string;
+  private _pos = 0;
+  private _closed = false;
+
+  constructor(string = "") {
+    this._string = string;
+  }
+
+  /** Ruby: `StringIO#string` — the whole buffer, regardless of position. */
+  string(): string {
+    return this._string;
+  }
+
+  /** Ruby: `StringIO#size` (aliased `length`). */
+  get size(): number {
+    return this._string.length;
+  }
+
+  /**
+   * Ruby: `StringIO#read` — with no length, the rest of the buffer (`""` at
+   * eof); with a length, at most that many characters, or `nil` at eof.
+   */
+  read(length?: number): string | null {
+    if (length == null) {
+      const rest = this._string.slice(this._pos);
+      this._pos = this._string.length;
+      return rest;
+    }
+    if (this.isEof()) return length === 0 ? "" : null;
+    const chunk = this._string.slice(this._pos, this._pos + length);
+    this._pos += chunk.length;
+    return chunk;
+  }
+
+  /** Ruby: `StringIO#write` — appends and returns the characters written. */
+  write(string: string): number {
+    this._string += string;
+    this._pos = this._string.length;
+    return string.length;
+  }
+
+  /** Ruby: `StringIO#rewind`. */
+  rewind(): number {
+    this._pos = 0;
+    return 0;
+  }
+
+  /** Ruby: `StringIO#eof?` (aliased `eof`). */
+  isEof(): boolean {
+    return this._pos >= this._string.length;
+  }
+
+  /** Ruby: `StringIO#close`. */
+  close(): void {
+    this._closed = true;
+  }
+
+  /** Ruby: `StringIO#closed?`. */
+  get closed(): boolean {
+    return this._closed;
+  }
+}

--- a/packages/activesupport/src/string-io.ts
+++ b/packages/activesupport/src/string-io.ts
@@ -4,10 +4,11 @@
  * and `Rack::MockRequest` hand to their callers. Only the members Ruby code in
  * this repo sends are ported.
  *
- * Read positions are counted in characters, where Ruby counts bytes: the
- * payloads that reach here (`Base64.decode64`'s binary string, a request body)
- * are one character per byte. `size` is Ruby's bytesize, which callers send to
- * fill a `CONTENT_LENGTH`.
+ * The buffer is a Ruby binary String — one character per byte — which is what
+ * `Base64.decode64` returns (`xml_mini.rb:180-181`) and what a request body
+ * already is, so `size`, `read`'s length and `write`'s return value count bytes
+ * exactly as Ruby's do. A caller holding text encodes it before writing, as
+ * Ruby does.
  *
  * @noRailsEquivalent PERMANENT — Ruby stdlib, not Rails: `StringIO` ships with
  * the interpreter, so no Rails file defines it and no port can remove the need
@@ -29,7 +30,7 @@ export class StringIO {
 
   /** Ruby: `StringIO#size` (aliased `length`) — the buffer's bytesize. */
   get size(): number {
-    return new TextEncoder().encode(this._string).length;
+    return this._string.length;
   }
 
   /**

--- a/packages/activesupport/src/xml-mini.trails.test.ts
+++ b/packages/activesupport/src/xml-mini.trails.test.ts
@@ -16,9 +16,11 @@ describe("XmlMini", () => {
     expect(_parseBinary("IGNORED INPUT", {})).toBe("IGNORED INPUT");
   });
 
-  it("_parse_file returns the decoded content decorated with FileLike", async () => {
+  it("_parse_file returns the decoded content decorated with FileLike", () => {
     const file = _parseFile("SGVsbG8=", { name: "logo.png", content_type: "image/png" });
-    expect(await file.text()).toBe("Hello");
+    expect(file.read()).toBe("Hello");
+    file.rewind();
+    expect(file.string()).toBe("Hello");
     expect(file.originalFilename).toBe("logo.png");
     expect(file.contentType).toBe("image/png");
   });

--- a/packages/activesupport/src/xml-mini.ts
+++ b/packages/activesupport/src/xml-mini.ts
@@ -2,6 +2,7 @@ import { camelize, singularize, underscore } from "./inflector.js";
 import { htmlEscape } from "./core-ext/tse/util.js";
 import { BigDecimal } from "./core-ext/big-decimal/conversions.js";
 import { IsolatedExecutionState } from "./isolated-execution-state.js";
+import { StringIO } from "./string-io.js";
 import { Temporal } from "@blazetrails/date";
 
 /**
@@ -480,21 +481,19 @@ export function _parseBinary(bin: string, entity: Record<string, string | undefi
  * Decode a `type="file"` value into an IO decorated with the element's `name`
  * and `content_type` attributes.
  *
- * Mirrors: ActiveSupport::XmlMini._parse_file (xml_mini.rb:180-186) — `Blob` is
- * the platform's in-memory, readable byte container, so it stands in for
- * `StringIO.new`; the Latin-1 round-trip hands it {@link decode64}'s bytes
- * unchanged rather than re-encoding them as UTF-8. Copying {@link FileLike}'s
- * descriptors onto it is `f.extend(FileLike)`.
+ * Mirrors: ActiveSupport::XmlMini._parse_file (xml_mini.rb:180-186). Copying
+ * {@link FileLike}'s descriptors onto the instance is `f.extend(FileLike)` —
+ * Ruby's `extend` decorates the object, not its class.
  *
  * @internal
  */
 export function _parseFile(
   file: string,
   entity: Record<string, string | undefined>,
-): Blob & typeof FileLike {
-  const f = new Blob([Uint8Array.from(decode64(file), (c) => c.charCodeAt(0))]);
+): StringIO & typeof FileLike {
+  const f = new StringIO(decode64(file));
   Object.defineProperties(f, Object.getOwnPropertyDescriptors(FileLike));
-  const fileLike = f as Blob & typeof FileLike;
+  const fileLike = f as StringIO & typeof FileLike;
   fileLike.originalFilename = entity["name"];
   fileLike.contentType = entity["content_type"];
   return fileLike;

--- a/packages/rack/src/mock-request.ts
+++ b/packages/rack/src/mock-request.ts
@@ -18,6 +18,7 @@ import {
   HEAD,
   OPTIONS,
 } from "./constants.js";
+import { StringIO } from "@blazetrails/activesupport";
 import { MockResponse } from "./mock-response.js";
 import { buildNestedQuery, parseNestedQuery } from "./utils.js";
 
@@ -38,32 +39,6 @@ class FatalWarner {
   flush(): void {}
   string(): string {
     return "";
-  }
-}
-
-class StringIO {
-  private _data: string;
-  private _closed = false;
-  constructor(data = "") {
-    this._data = data;
-  }
-  read(): string {
-    return this._data;
-  }
-  write(s: string): void {
-    this._data += s;
-  }
-  string(): string {
-    return this._data;
-  }
-  get size(): number {
-    return Buffer.byteLength(this._data);
-  }
-  close(): void {
-    this._closed = true;
-  }
-  get closed(): boolean {
-    return this._closed;
   }
 }
 


### PR DESCRIPTION
Bundle of three convergences.

**`database-version-sync-getter-forces-hand-warms`.** The bulk of this story
landed in #6226 (`databaseVersion` fetches on demand; the version-gated
predicates went async), so all five hand-warms the story lists are already gone
from `main` — the only surviving `databaseVersion` warm is
`Mysql2Adapter#configureConnection`'s, which the story itself calls justified
and which is cited at the call site. The residue this PR closes is the last
caller reaching around the pool memo: PG's `reset_pk_sequence!` reads
`database_version` (`postgresql/schema_statements.rb:347`), while the port
called `getDatabaseVersion()` directly — a second round-trip past
`pool.server_version`'s cache. The declaration-only `getDatabaseVersion` field
that existed solely for that call site goes with it.

**`mysql-new-column-from-field-folds-on-update-into-default-generated`.** Rails
folds `ON UPDATE` only in the datetime/`CURRENT_TIMESTAMP` branch and matches
`type_metadata.extra == "DEFAULT_GENERATED"` exactly
(`mysql/schema_statements.rb:189-201`). The port folded `ON UPDATE <expr>` into
the function default in the `DEFAULT_GENERATED` branch as well and widened the
guard to `startsWith`. The in-code justification for the fold — feeding
`renameColumnForAlter`'s rebuild through `Column#onUpdate` — expired with #6228,
which deleted that attribute and its only consumer, so both inventions are
removed. `AbstractMysqlAdapter#columns`' `SHOW CREATE TABLE` prefetch heuristic
tracks the same exact guard, so a compound
`"DEFAULT_GENERATED on update CURRENT_TIMESTAMP"` extra now falls through to the
later branches on both sides.

**`converge-parse-file-onto-a-stringio-shim`.** `_parse_file` returns
`StringIO.new(Base64.decode64(file))` extended with `FileLike`
(`xml_mini.rb:180-186`); the port returned a `Blob`, which offers no synchronous
`read` and forced a Latin-1 re-widening to stop it re-encoding the decoded bytes
as UTF-8. Ports Ruby's `StringIO` as a shared stdlib shim
(`activesupport/src/string-io.ts`, tagged `@noRailsEquivalent PERMANENT` — Ruby
stdlib, no Rails file defines it), hands it `decode64`'s binary string as-is,
and collapses `Rack::MockRequest`'s private `class StringIO` onto it. Only the
members Ruby code in this repo sends are ported; the expectations in
`string-io.trails.test.ts` are MRI's.

Gates: `parity:api:calls` OK, `parity:api:calls:args` OK, `parity:api:extra`
0 novel, typecheck and lint clean.

Closes-story: database-version-sync-getter-forces-hand-warms
Closes-story: mysql-new-column-from-field-folds-on-update-into-default-generated
Closes-story: converge-parse-file-onto-a-stringio-shim
