### PR TITLE
fix(parity): converge four call-order and country-zone divergences

### DIFF
--- a/packages/activemodel/src/validations/numericality.ts
+++ b/packages/activemodel/src/validations/numericality.ts
@@ -56,14 +56,6 @@ export class NumericalityValidator extends EachValidator {
     precision = 15,
     scale?: number,
   ): void {
-    // Mirrors Rails `is_number?(nil) => false`: a nil/undefined value that
-    // reaches validate_each (i.e. `allow_nil: true` did NOT short-circuit it in
-    // EachValidator#validate) is always :not_a_number. The default is to reject
-    // nil — matching `test_default_validates_numericality_of`.
-    if (value === null || value === undefined) {
-      record.errors.add(attribute, ":not_a_number", this.filteredOptions(value));
-      return;
-    }
     // A cast/raw decimal is a BigDecimal (Numeric in Rails — Kernel.Float
     // accepts it). Normalize to its fixed-form string so the string-based
     // checks below (isNumber, Number(), isInteger) treat it as numeric.
@@ -75,8 +67,6 @@ export class NumericalityValidator extends EachValidator {
       return;
     }
 
-    const num = parseAsNumber(Number(value), precision, scale) as number;
-
     // Rails dispatches through allow_only_integer?(record), not the
     // raw options[:only_integer] read, so a Proc / method-name option
     // is honored per-record.
@@ -84,6 +74,8 @@ export class NumericalityValidator extends EachValidator {
       record.errors.add(attribute, ":not_an_integer", this.filteredOptions(value));
       return;
     }
+
+    const num = parseAsNumber(Number(value), precision, scale) as number;
 
     // Rails uses filtered_options(value).merge!(count: option_value)
     // for compare/range branches and filtered_options(value) (no count)

--- a/packages/activerecord/src/base.trails.test.ts
+++ b/packages/activerecord/src/base.trails.test.ts
@@ -3,15 +3,13 @@
  *
  * These guard trails-internal behavior with no Rails counterpart in
  * base_test.rb: the _applyScopeAttributes
- * scoping mechanism, the UnknownPrimaryKey error message, and the internalSchemaCache-less
- * tableExists fallback.
+ * scoping mechanism and the UnknownPrimaryKey error message.
  */
 import { describe, it, expect } from "vitest";
 import { Base, UnknownPrimaryKey } from "./index.js";
 import { registerSubclass } from "./inheritance.js";
 import { Type } from "@blazetrails/activemodel";
 import { fixtures } from "./test-fixtures.js";
-import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import { reconcileVirtualAttributes, loadSchema } from "./model-schema.js";
 
 describe("_applyScopeAttributes — scoping initializeInternalsCallback", () => {
@@ -211,18 +209,6 @@ describe("instantiate override types for absent keys (trails)", () => {
 });
 
 describe("BasicsTest (trails)", () => {
-  it("tableExists returns true when adapter has no internalSchemaCache", async () => {
-    class Ghost extends Base {
-      static tableName = "ghosts_that_do_not_exist";
-      static {
-        this.attribute("name", "string");
-        this.adapter = { adapterName: "sqlite" } as DatabaseAdapter;
-      }
-    }
-    const exists = await Ghost.tableExists();
-    expect(exists).toBe(true);
-  });
-
   it("columnNames raises TableNotSpecified on an abstract class", () => {
     // Rails column_names has no abstract-class fallback — load_schema! raises
     // TableNotSpecified. Guards against reintroducing the attribute-walk branch.

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -705,12 +705,13 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     columnName: string,
     defaultOrChanges: unknown,
   ): Promise<void> {
+    const quotedTableName = this.quoteTableName(tableName);
     const fragment = await this.changeColumnDefaultForAlter(
       tableName,
       columnName,
       defaultOrChanges,
     );
-    await this.execute(`ALTER TABLE ${this.quoteTableName(tableName)} ${fragment}`);
+    await this.execute(`ALTER TABLE ${quotedTableName} ${fragment}`);
   }
 
   /**
@@ -779,9 +780,8 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   ): Promise<void> {
     this.validateChangeColumnNullArgumentBang(null_);
     if (!null_ && default_ != null) {
-      const colId = this.quoteColumnName(columnName);
       await this.execute(
-        `UPDATE ${this.quoteTableName(tableName)} SET ${colId}=${this.quote(default_)} WHERE ${colId} IS NULL`,
+        `UPDATE ${this.quoteTableName(tableName)} SET ${this.quoteColumnName(columnName)}=${this.quote(default_)} WHERE ${this.quoteColumnName(columnName)} IS NULL`,
       );
     }
     await this.changeColumn(tableName, columnName, null, { null: null_ });
@@ -848,8 +848,9 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   }
 
   async renameColumn(tableName: string, columnName: string, newColumnName: string): Promise<void> {
+    const quotedTableName = this.quoteTableName(tableName);
     const fragment = await this.renameColumnForAlter(tableName, columnName, newColumnName);
-    await this.execute(`ALTER TABLE ${this.quoteTableName(tableName)} ${fragment}`);
+    await this.execute(`ALTER TABLE ${quotedTableName} ${fragment}`);
     await this.renameColumnIndexes(tableName, columnName, newColumnName);
   }
 

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1569,10 +1569,7 @@ export function cachedTableExists(this: SchemaHost): boolean | undefined {
 }
 
 export async function tableExists(this: SchemaHost): Promise<boolean> {
-  const exists = await reflectionAdapter(this).schemaCache.dataSourceExists(this.tableName);
-  // BoundSchemaReflection answers `undefined` when the pool can't be probed;
-  // Rails' schema_cache always answers a boolean, so treat unknown as present.
-  return exists !== false;
+  return (await reflectionAdapter(this).schemaCache.dataSourceExists(this.tableName)) ?? false;
 }
 
 /**

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1569,10 +1569,9 @@ export function cachedTableExists(this: SchemaHost): boolean | undefined {
 }
 
 export async function tableExists(this: SchemaHost): Promise<boolean> {
-  const conn = reflectionAdapter(this);
-  const cache = conn.schemaCache;
-  if (!cache || typeof cache.dataSourceExists !== "function") return true;
-  const exists = await cache.dataSourceExists(this.tableName);
+  const exists = await reflectionAdapter(this).schemaCache.dataSourceExists(this.tableName);
+  // BoundSchemaReflection answers `undefined` when the pool can't be probed;
+  // Rails' schema_cache always answers a boolean, so treat unknown as present.
   return exists !== false;
 }
 

--- a/packages/activesupport/src/core-ext/date/calculations.ts
+++ b/packages/activesupport/src/core-ext/date/calculations.ts
@@ -16,6 +16,7 @@ import { IsolatedExecutionState } from "../../isolated-execution-state.js";
 import { TimeWithZone } from "../../time-with-zone.js";
 import { TimeZone } from "../../values/time-zone.js";
 import { ArgumentError, findZoneBang, getZone } from "../../time-zone-config.js";
+import { toTime } from "./conversions.js";
 
 /**
  * Mirrors: `DateAndTime::Calculations::DAYS_INTO_WEEK`
@@ -100,18 +101,15 @@ export function current(): Temporal.PlainDate {
  * `time_with_zone` takes its `TimeWithZone.new(nil, zone, to_time(:utc))` arm —
  * the day's midnight read in `zone`.
  *
- * The `else` arm is Ruby's `to_time`, a bare `Time` at local midnight. trails
- * has no bare-Time receiver carrying the `since`/`middle_of_day`/`end_of_day`
- * this method's five callers delegate to (`time-ext.ts` is a free-function
- * module over JS `Date`), so the fallback is the same instant expressed in the
- * system zone — `to_time`'s value under a TimeWithZone receiver.
+ * Rails' `time` local is `nil` for a `Date` receiver, so the `else` arm is
+ * `to_time` — see `core-ext/date/conversions.ts` for the receiver equivalence.
  */
 export function inTimeZone(date: Temporal.PlainDate, zone: unknown = getZone()): TimeWithZone {
   const timeZone = findZoneBang(zone);
   if (timeZone) {
     return timeWithZone(date, timeZone);
   }
-  return timeWithZone(date, TimeZone.find(Temporal.Now.timeZoneId())!);
+  return toTime(date);
 }
 
 /** Mirrors: `DateAndTime::Zones#time_with_zone` (`date_and_time/zones.rb:32-38`) */

--- a/packages/activesupport/src/core-ext/date/conversions.ts
+++ b/packages/activesupport/src/core-ext/date/conversions.ts
@@ -1,0 +1,34 @@
+/**
+ * The `Date` arm of ActiveSupport's conversions reopenings
+ * (`core_ext/date/conversions.rb`), keyed on `Temporal.PlainDate` the way
+ * `core-ext/date/calculations.ts` is.
+ *
+ * Mirrors: `class Date` (`core_ext/date/conversions.rb`)
+ */
+
+import { Temporal } from "@blazetrails/date";
+import { TimeWithZone } from "../../time-with-zone.js";
+import { TimeZone } from "../../values/time-zone.js";
+import { ArgumentError } from "../../time-zone-config.js";
+
+/**
+ * Mirrors: `Date#to_time` (`core_ext/date/conversions.rb:83-86`) —
+ * `::Time.public_send(form, year, month, day)`.
+ *
+ * **The bare-`Time` equivalence, recorded once.** Ruby answers a bare `Time`:
+ * the day's midnight read in the system zone (`:local`) or in UTC. trails has
+ * no bare-`Time` receiver — `time-ext.ts` is a free-function module over JS
+ * `Date`, not a class — so the value is carried by a `TimeWithZone` on that
+ * same zone. `TimeZone#local` builds exactly `Time.local`'s wall clock in the
+ * zone it names, so this answers Ruby's instant with Ruby's components; the
+ * receiver's class is the only difference. Callers that delegate to `to_time`
+ * (`Date#in_time_zone`'s `else` arm, `date/calculations.rb:55-87`) therefore
+ * keep Rails' single delegating expression instead of a two-arm dispatch.
+ */
+export function toTime(date: Temporal.PlainDate, form: string = "local"): TimeWithZone {
+  if (form !== "local" && form !== "utc") {
+    throw new ArgumentError(`Expected :local or :utc, got :${form}.`);
+  }
+  const zone = TimeZone.find(form === "utc" ? "UTC" : Temporal.Now.timeZoneId())!;
+  return zone.local(date.year, date.month, date.day);
+}

--- a/packages/activesupport/src/core-ext/date/conversions.ts
+++ b/packages/activesupport/src/core-ext/date/conversions.ts
@@ -26,7 +26,7 @@ import { ArgumentError } from "../../time-zone-config.js";
  * keep Rails' single delegating expression instead of a two-arm dispatch.
  */
 export function toTime(date: Temporal.PlainDate, form: string = "local"): TimeWithZone {
-  if (form !== "local" && form !== "utc") {
+  if (!["local", "utc"].includes(form)) {
     throw new ArgumentError(`Expected :local or :utc, got :${form}.`);
   }
   const zone = TimeZone.find(form === "utc" ? "UTC" : Temporal.Now.timeZoneId())!;

--- a/packages/activesupport/src/time-zone.trails.test.ts
+++ b/packages/activesupport/src/time-zone.trails.test.ts
@@ -38,3 +38,82 @@ describe("TimeZoneTest", () => {
     expect(TimeZone.countryZones("ua").map((z) => z.name)).not.toContain("Europe/Kiev");
   });
 });
+
+describe("TimeZone country zone membership", () => {
+  /**
+   * `TZInfo::Country#zone_identifiers` reads tzdata's `zone1970.tab`, which
+   * files a zone under every country that observes it; ECMA-402's CLDR table
+   * names one country per zone. Pinned by FULL membership rather than
+   * `toContain`, because the gap this covers is a MISSING member —
+   * `Asia/Tokyo` under `au`, `Europe/Simferopol` under `ru` — which every
+   * `assert_includes`-style assertion in `time_zone.test.ts` is blind to.
+   * Both lists are `TZInfo::Country.get(code).zone_identifiers` run through
+   * Rails' MAPPING, in Rails' `<=>` order.
+   */
+  it("country zones agree with TZInfo zone_identifiers for au", () => {
+    expect(TimeZone.countryZones("au").map((z) => z.name)).toEqual([
+      "Perth",
+      "Australia/Eucla",
+      "Osaka",
+      "Sapporo",
+      "Tokyo",
+      "Adelaide",
+      "Australia/Broken_Hill",
+      "Darwin",
+      "Antarctica/Macquarie",
+      "Australia/Lindeman",
+      "Brisbane",
+      "Hobart",
+      "Melbourne",
+      "Sydney",
+      "Australia/Lord_Howe",
+    ]);
+  });
+
+  it("country zones agree with TZInfo zone_identifiers for ru", () => {
+    expect(TimeZone.countryZones("ru").map((z) => z.name)).toEqual([
+      "Kaliningrad",
+      "Europe/Kirov",
+      "Europe/Simferopol",
+      "Moscow",
+      "St. Petersburg",
+      "Volgograd",
+      "Europe/Astrakhan",
+      "Europe/Saratov",
+      "Europe/Ulyanovsk",
+      "Samara",
+      "Ekaterinburg",
+      "Asia/Omsk",
+      "Asia/Barnaul",
+      "Asia/Novokuznetsk",
+      "Asia/Tomsk",
+      "Krasnoyarsk",
+      "Novosibirsk",
+      "Irkutsk",
+      "Asia/Chita",
+      "Asia/Khandyga",
+      "Yakutsk",
+      "Asia/Ust-Nera",
+      "Vladivostok",
+      "Asia/Sakhalin",
+      "Magadan",
+      "Srednekolymsk",
+      "Asia/Anadyr",
+      "Kamchatka",
+    ]);
+  });
+
+  /**
+   * `zone1970.tab` knows `bv`/`hm` and files no zone under either, so
+   * `TZInfo::Country.get("bv").zone_identifiers` is `[]` and Rails answers an
+   * empty list rather than raising `InvalidCountryCode`.
+   */
+  it("country zones for a known zoneless country answer an empty list", () => {
+    expect(TimeZone.countryZones("bv")).toEqual([]);
+    expect(TimeZone.countryZones("hm")).toEqual([]);
+  });
+
+  it("country zones for an unknown country code raise", () => {
+    expect(() => TimeZone.countryZones("zz")).toThrow(/Invalid country code/);
+  });
+});

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -49,6 +49,7 @@ const MAPPING: Record<string, string> = {
   "Buenos Aires": "America/Argentina/Buenos_Aires",
   Montevideo: "America/Montevideo",
   Georgetown: "America/Guyana",
+  "Puerto Rico": "America/Puerto_Rico",
   Greenland: "America/Godthab",
   "Mid-Atlantic": "Atlantic/South_Georgia",
   Azores: "Atlantic/Azores",
@@ -120,10 +121,10 @@ const MAPPING: Record<string, string> = {
   Mumbai: "Asia/Kolkata",
   "New Delhi": "Asia/Kolkata",
   Kathmandu: "Asia/Kathmandu",
-  Astana: "Asia/Dhaka",
   Dhaka: "Asia/Dhaka",
   "Sri Jayawardenepura": "Asia/Colombo",
   Almaty: "Asia/Almaty",
+  Astana: "Asia/Almaty",
   Novosibirsk: "Asia/Novosibirsk",
   Rangoon: "Asia/Rangoon",
   Bangkok: "Asia/Bangkok",
@@ -147,7 +148,7 @@ const MAPPING: Record<string, string> = {
   Yakutsk: "Asia/Yakutsk",
   Darwin: "Australia/Darwin",
   Adelaide: "Australia/Adelaide",
-  Canberra: "Australia/Melbourne",
+  Canberra: "Australia/Canberra",
   Melbourne: "Australia/Melbourne",
   Sydney: "Australia/Sydney",
   Brisbane: "Australia/Brisbane",
@@ -157,7 +158,7 @@ const MAPPING: Record<string, string> = {
   "Port Moresby": "Pacific/Port_Moresby",
   Magadan: "Asia/Magadan",
   Srednekolymsk: "Asia/Srednekolymsk",
-  Solomon: "Pacific/Guadalcanal",
+  "Solomon Is.": "Pacific/Guadalcanal",
   "New Caledonia": "Pacific/Noumea",
   Fiji: "Pacific/Fiji",
   Kamchatka: "Asia/Kamchatka",
@@ -186,6 +187,7 @@ const MAPPING: Record<string, string> = {
  * `Intl.DateTimeFormat#resolvedOptions().timeZone` echoes the link name back
  * unchanged on node 24 — so it is carried here rather than derived.
  */
+
 const CANONICAL_ZONE_IDENTIFIERS: Record<string, string> = {
   "Africa/Accra": "Africa/Abidjan",
   "Africa/Addis_Ababa": "Africa/Nairobi",
@@ -308,6 +310,38 @@ const CANONICAL_ZONE_IDENTIFIERS: Record<string, string> = {
   "Pacific/Truk": "Pacific/Port_Moresby",
   "Pacific/Wake": "Pacific/Tarawa",
   "Pacific/Wallis": "Pacific/Tarawa",
+};
+
+/**
+ * Per-country membership tzdata's `zone1970.tab` records and ECMA-402's
+ * country table does not, keyed by Alpha2 code.
+ *
+ * `TZInfo::Country#zone_identifiers` — what `load_country_zones`
+ * (time_zone.rb:275) reads — is `zone1970.tab`, which lists a zone under every
+ * country that observes it: `Asia/Singapore` is Antarctica's summer zone,
+ * `Asia/Tokyo` covers Australia's Antarctic bases, `Asia/Bangkok` covers
+ * northwestern Vietnam. CLDR's table names one country per zone, so
+ * `Intl.Locale#getTimeZones` omits these five and `countryZones` would answer a
+ * SHORTER list than Rails for `aq`/`au`/`ru`/`tf`/`vn`. Unlike
+ * {@link CANONICAL_ZONE_IDENTIFIERS} this is not a link-resolution gap — the
+ * two tables genuinely disagree about membership — so no runtime lookup can
+ * reconcile it and the rows are carried here, each confirmed against
+ * `TZInfo::Country.get(code).zone_identifiers` on tzinfo 2.x.
+ *
+ * `BV` and `HM` carry an EMPTY list: `zone1970.tab` knows both codes and files
+ * no zone under either, so `TZInfo::Country.get("bv").zone_identifiers` is `[]`
+ * and Rails answers `[]`. `getTimeZones` reports them the same way it reports a
+ * code it does not know, so a row here is also what separates "known, zoneless"
+ * from the `Country.get` raise.
+ */
+const COUNTRY_ZONE_IDENTIFIER_ADDITIONS: Record<string, string[]> = {
+  AQ: ["Asia/Singapore"],
+  AU: ["Asia/Tokyo"],
+  BV: [],
+  HM: [],
+  RU: ["Europe/Simferopol"],
+  TF: ["Asia/Dubai"],
+  VN: ["Asia/Bangkok"],
 };
 
 /**
@@ -1127,11 +1161,15 @@ export class TimeZone {
     } catch {
       country = undefined;
     }
-    if (country === undefined || country.length === 0) {
+    const additions = COUNTRY_ZONE_IDENTIFIER_ADDITIONS[code];
+    if (country === undefined || (country.length === 0 && additions === undefined)) {
       throw new Error(`Invalid country code: ${code}`);
     }
-    return country
-      .map((tzId) => CANONICAL_ZONE_IDENTIFIERS[tzId] ?? tzId)
+    const identifiers = country.map((tzId) => CANONICAL_ZONE_IDENTIFIERS[tzId] ?? tzId);
+    for (const tzId of additions ?? []) {
+      if (!identifiers.includes(tzId)) identifiers.push(tzId);
+    }
+    return identifiers
       .flatMap((tzId) => {
         if (Object.values(MAPPING).includes(tzId)) {
           const memo: TimeZone[] = [];

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/validations/numericality.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/validations/numericality.json
@@ -24,13 +24,6 @@
     "package": "activemodel",
     "tsFile": "validations/numericality.ts",
     "rubyName": "validate_each",
-    "call": "order:add,isNumber",
-    "reason": "The pre-existing order divergence previously keyed as order:filteredOptions,isNumber; the first inversion moved when the order stream stopped positioning hoisted-closure calls (RFC 0084)."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "validations/numericality.ts",
-    "rubyName": "validate_each",
     "call": "slice",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
@@ -51,20 +51,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
-    "rubyName": "change_column_default",
-    "call": "order:changeColumnDefaultForAlter,quoteTableName",
-    "reason": "Order artifact of an await-forced hoist: the port lifts the awaited changeColumnDefaultForAlter above the quoteTableName Rails evaluates first in the same interpolation (abstract-mysql-adapter.ts:692); both are pure."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
-    "rubyName": "change_column_null",
-    "call": "order:quoteColumnName,quoteTableName",
-    "reason": "Order artifact of a hoisted local: the port lifts the twice-used quoteColumnName above the quoteTableName Rails evaluates first in the same interpolation (abstract-mysql-adapter.ts:766); both are pure."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "check_constraints",
     "call": "internal_exec_query",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -194,13 +180,6 @@
     "rubyName": "remove_index_for_alter",
     "call": "index_name_for_remove",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
-    "rubyName": "rename_column",
-    "call": "order:renameColumnForAlter,quoteTableName",
-    "reason": "Order artifact of an await-forced hoist: the port lifts the awaited renameColumnForAlter above the quoteTableName Rails evaluates first in the same interpolation (abstract-mysql-adapter.ts:835); both are pure."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/model-schema.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/model-schema.json
@@ -51,13 +51,6 @@
   {
     "package": "activerecord",
     "tsFile": "model-schema.ts",
-    "rubyName": "table_exists?",
-    "call": "order:dataSourceExists,tableName",
-    "reason": "Order artifact of a TS-only capability guard: `typeof cache.dataSourceExists !== \"function\"` (model-schema.ts:1574) credits dataSourceExists before the tableName argument Rails evaluates first."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "model-schema.ts",
     "rubyName": "table_name=",
     "call": "connected?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Converges four evaluation-order / membership divergences surfaced by RFC 0084 and RFC 0098, and deletes the five baseline rows they were carried under (only-shrink, by hand — no `--write` reseed; the reseed was run afterwards and is a no-op).

## `abstract-mysql-adapter` interpolation hoists

`abstract_mysql_adapter.rb:369,381,396` evaluate `quote_table_name` first in each interpolated `execute` string.

- `changeColumnNull` repeats `quoteColumnName(columnName)` inline, as Rails does, instead of hoisting it into `colId`.
- `changeColumnDefault` / `renameColumn` keep the `await` hoist the language forces, but now bind `quoteTableName(tableName)` into its own local *first*, so the recorded order matches Rails.

## trails-only guards that reordered Rails' calls

- `validateEach` (`numericality.rb:24`): drops the `value === null || value === undefined` pre-arm. Rails' `is_number?` already answers false for nil (`numericality.rb:105`, `Kernel.Float`), and the trails `isNumber` already has that arm — so the pre-arm was pure divergence that also bypassed `allow_blank`. Converging it surfaced a second order row, so `parseAsNumber` now runs *after* the `only_integer` check, where Rails runs it.
- `tableExists` (`model_schema.rb:416-418`): drops the `typeof cache.dataSourceExists !== "function"` capability guard. `conn.schemaCache` is always a `BoundSchemaReflection`, which always has the method, so the guard was unreachable and only served to credit `dataSourceExists` ahead of the `tableName` argument. Dropping it exposed a second divergence in the same line and it is converged too: `data_source_exists?` returns **nil** for an ignored table (`schema_cache.rb:309-310`) and `table_exists?` passes that through, so consumers read it as falsy (`core.rb:382`) — the port's `exists !== false` inverted it and answered `true`. The one trails test that pinned the removed guard (a hand-built adapter object with no `schemaCache`, which Rails has no analogue for) is deleted with it.

## `countryZones` vs `TZInfo::Country#zone_identifiers`

Measured all 249 codes against `TZInfo::Country#zone_identifiers` run through the **vendored** Rails `MAPPING`. Started at 28 mismatched codes; now **0**.

Two mechanisms were involved:

1. **`MAPPING` had drifted from vendored Rails.** It now matches key-for-key, value-for-value, and in Rails' order: adds the missing `"Puerto Rico" => "America/Puerto_Rico"` (which alone accounted for 19 codes), renames `Solomon` → `"Solomon Is."`, fixes `Astana` (`Asia/Dhaka` → `Asia/Almaty`, at Rails' slot after `Almaty`), and fixes `Canberra` (`Australia/Melbourne` → `Australia/Canberra`). A parity check over the vendored `MAPPING = {` block now reports an exact ordered match.
2. **CLDR vs `zone1970.tab` membership**, the story's subject. `Intl.Locale#getTimeZones` names one country per zone; `zone1970.tab` files a zone under every country that observes it. `COUNTRY_ZONE_IDENTIFIER_ADDITIONS` carries the five rows that differ (`AQ`/`AU`/`RU`/`TF`/`VN`), each confirmed against `TZInfo::Country.get(code).zone_identifiers`. `BV`/`HM` carry an empty list: tzdata knows both and files no zone under either, so Rails answers `[]` where trails was raising — `getTimeZones` reports a known-zoneless code identically to an unknown one, so the row is what separates them.

Pinned by **full membership** for `au` and `ru` (the two codes Rails tests, whose `assert_includes` assertions are blind to a missing member), plus the `bv`/`hm` empty list and the `zz` raise.

## `Date#in_time_zone`'s else arm

Ports `Date#to_time` (`date/conversions.rb:83-86`, `::Time.public_send(form, year, month, day)`) into `core-ext/date/conversions.ts`, and `inTimeZone`'s `else` arm now answers it — Rails' `time || to_time`, where `time` is always nil for a `Date` receiver.

The bare-`Time` receiver equivalence is recorded **once**, on `toTime`: trails has no bare-`Time` class (`time-ext.ts` is a free-function module over JS `Date`), and `TimeZone#local` builds exactly `Time.local`'s wall clock in the zone it names, so the value is Ruby's instant with Ruby's components under a `TimeWithZone` receiver. The five callers keep their single delegating expression. The per-call-site deviation note is deleted, not reworded.

## Not in this PR

`call-args-ar-select-async-kwarg` was **released back to the queue**, not shipped. Its acceptance criteria require porting `FutureResult`, `async_enabled?`, the async executor and the `AsynchronousQueryInsideTransactionError` guard before the four `async:` kwarg rows can converge — a multi-file infrastructure port that is its own epic and does not fit alongside this work. The deferral note at `database-statements.ts:2099-2112` is unchanged.

## Verification

- `pnpm parity:api:calls` — OK (baseline shrank by 5 rows)
- `pnpm parity:api:calls:args` — OK
- `lint-call-mismatches.ts --write` — no drift beyond the 5 deletions
- `pnpm lint`, `pnpm typecheck` — clean
- `pnpm parity:api` activesupport methods/files unchanged
- Test files run: `time-zone.test.ts`, `time-zone.trails.test.ts`, `date-ext.test.ts`, `date-ext.trails.test.ts`, `numericality-validation.test.ts` (activemodel + activerecord), `model-schema.test.ts`, `validations/**`, `abstract-mysql-adapter.test.ts`

Closes-story: converge-mysql-adapter-interpolation-hoist-order
Closes-story: converge-trails-only-guards-that-reorder-calls
Closes-story: country-zones-cldr-tzdata-membership-differs-for-five-codes
Closes-story: date-in-time-zone-else-arm-answers-a-bare-time
