### PR TITLE
fix(activesupport): repair merge collisions in Deprecation reporting and DateAndTime current

### DIFF
--- a/packages/activesupport/src/core-ext/date-and-time/calculations.ts
+++ b/packages/activesupport/src/core-ext/date-and-time/calculations.ts
@@ -15,7 +15,6 @@
 import { Temporal } from "@blazetrails/date";
 import * as date from "../date/calculations.js";
 import * as time from "../../time-ext.js";
-import { current as timeCurrent } from "../../time-zone-config.js";
 import { TimeWithZone } from "../../time-with-zone.js";
 import { instantFrom } from "../../temporal.js";
 
@@ -59,7 +58,7 @@ function wday(dateOrTime: DateOrTime): number {
 /** `self.class.current` — `Date.current` for a day, `Time.current` for a time. */
 function classCurrent(dateOrTime: DateOrTime): Temporal.PlainDate | TimeWithZone | Date {
   // boundary: a JS `Date` is the `Time` arm's receiver, and this dispatch is keyed on being one.
-  return dateOrTime instanceof Date ? timeCurrent() : date.current();
+  return dateOrTime instanceof Date ? time.current() : date.current();
 }
 
 /** `self < other` / `self > other`, across both arms. */

--- a/packages/activesupport/src/deprecation.ts
+++ b/packages/activesupport/src/deprecation.ts
@@ -454,44 +454,6 @@ export class Deprecation {
     }
   }
 
-  /**
-   * Rails: `deprecation_warning` (deprecation/reporting.rb:99-104). Rails
-   * defaults the backtrace to `caller_locations(2)`; JS exposes no equivalent
-   * frame list, so an absent `callerBacktrace` reaches `warn` as-is and falls
-   * through to its own default.
-   */
-  deprecationWarning(
-    deprecatedMethodName: string,
-    message?: string,
-    callerBacktrace?: unknown[],
-  ): string {
-    const msg = this.deprecatedMethodWarning(deprecatedMethodName, message);
-    this.warn(msg, callerBacktrace);
-    return msg;
-  }
-
-  /**
-   * Outputs a deprecation warning message
-   *
-   *   deprecatedMethodWarning("methodName")
-   *   // => "methodName is deprecated and will be removed from Rails #{deprecationHorizon}"
-   *   deprecatedMethodWarning("methodName", ":anotherMethod")
-   *   // => "methodName is deprecated and will be removed from Rails #{deprecationHorizon} (use anotherMethod instead)"
-   *   deprecatedMethodWarning("methodName", "Optional message")
-   *   // => "methodName is deprecated and will be removed from Rails #{deprecationHorizon} (Optional message)"
-   *
-   * Rails: `deprecated_method_warning` (deprecation/reporting.rb:115-122).
-   */
-  private deprecatedMethodWarning(methodName: string, message?: string): string {
-    const warning = `${methodName} is deprecated and will be removed from ${this.gemName} ${this.deprecationHorizon}`;
-    // A Ruby Symbol argument names the replacement method; in trails it is a
-    // `":name"` string (CLAUDE.md), a String is free-form text.
-    if (message !== undefined && message.startsWith(":"))
-      return `${warning} (use ${message.slice(1)} instead)`;
-    if (message !== undefined) return `${warning} (${message})`;
-    return warning;
-  }
-
   deprecateMethod(target: object, methodName: string, message?: string): void {
     const self = this;
     const original = (target as Record<string, unknown>)[methodName];

--- a/packages/activesupport/src/deprecation/method-wrappers.ts
+++ b/packages/activesupport/src/deprecation/method-wrappers.ts
@@ -1,4 +1,4 @@
-import { extractOptions } from "../hash-utils.js";
+import { extractOptionsBang } from "../hash-utils.js";
 import type { Deprecation } from "../deprecation.js";
 
 /**
@@ -15,7 +15,7 @@ export function deprecateMethods(
   targetModule: Record<string, unknown>,
   ...methodNames: Array<string | Record<string, string>>
 ): Record<string, unknown> {
-  const [names, options] = extractOptions(methodNames as Array<string>);
+  const [names, options] = extractOptionsBang(methodNames as Array<string>);
   const deprecator = (options.deprecator as Deprecation | undefined) ?? this;
   delete options.deprecator;
   const methodNamesWithOptions = [...names, ...Object.keys(options)];


### PR DESCRIPTION
Main is red on every build/type-check job (Website, Build & Type Check, Unit Tests, Guides Code Type Check, Virtualized DX Type Tests, and the AR lanes) at d1e027d8. Three sibling PRs landed colliding changes:

- **Duplicate class members.** #6452 and #6456 each added `Deprecation#deprecationWarning` and `#deprecatedMethodWarning`. Kept the copy that defaults `callerBacktrace` to `callerLocations(2)` and types it `CallerLocation[]` (`deprecation/reporting.rb:96-101`, `112-119`); deleted the second.
- **`extractOptions` no longer exported.** #6456's `deprecation/method-wrappers.ts` imports it; #6454 renamed it to `extractOptionsBang` (Ruby `Array#extract_options!`). Same signature, so this is an import/callsite rename.
- **`Time.current` moved.** `core-ext/date-and-time/calculations.ts` imported `current` from `time-zone-config.js`; it now lives in `time-ext.ts` (`time/calculations.rb:39-41`). `classCurrent` dispatches through the `time` module the file already imports, so the extra import goes away.

`pnpm typecheck` is clean and the website sw bundle builds. Deprecation, method-wrappers, date-and-time calculations and time-ext suites pass locally.

Closes-story: red-d1e027d8
