### PR TITLE
refactor(activerecord,activesupport): CollectionProxy#create delegates to the association; port Deprecation proxy wrappers

### DIFF
--- a/docs/ruby-ts-conventions.md
+++ b/docs/ruby-ts-conventions.md
@@ -108,6 +108,8 @@ parity:api never expects a TS counterpart for these Ruby methods:
   - `extended`, `included`, `inherited`
 - Ruby object hooks — no TypeScript equivalent.
   - `singleton_method_added`
+- Ruby constant-resolution hook — the VM calls it when a constant name misses. JS resolves nothing at runtime by name, so there is no slot for it.
+  - `const_missing`
 - NoTouching: TS uses a Map-based depth counter (\_noTouchingDepth) instead of a thread-local array; klasses() is the Rails internal accessor for that array.
   - `klasses`
 - CheckPending helpers — depend on Rails.root, system("bin/rails ..."), and the ActiveRecord::Tasks infrastructure that has no JS equivalent.

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -74,20 +74,6 @@ import { throughForeignKeyPresent } from "./through-association.js";
 import { foreignKeyPresentFor } from "./foreign-association.js";
 import type { AssociationReflection } from "../reflection.js";
 
-/**
- * Minimal shape of the OO singular association holder
- * (`record.association(name)` → HasOneAssociation / BelongsToAssociation)
- * used by `_createSingular` to route create/createBang through the
- * single-target path. @internal
- */
-interface SingularCreateHolder {
-  create(
-    attributes?: Record<string, unknown>,
-    block?: (record: Base) => void,
-  ): Promise<Base | null>;
-  createBang(attributes?: Record<string, unknown>, block?: (record: Base) => void): Promise<Base>;
-}
-
 // Declaration merging with `class CollectionProxy extends Relation`
 // propagates Relation's method types into this interface. `load()`
 // diverges (CP returns T[], Relation returns LoadedRelation<this>)
@@ -1114,44 +1100,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     return typeof rec.association === "function" ? rec.association(this._assocName) : undefined;
   }
 
-  /**
-   * Whether this proxy backs a singular (has_one / belongs_to) association
-   * rather than a collection. The module-level `association()` helper returns
-   * a CollectionProxy for *every* association type, so `create`/`createBang`
-   * must route singular associations through their OO holder
-   * (`record.association(name)`) — otherwise the created record lands in the
-   * proxy's array `_target`, surfacing through `_associationCache` as an
-   * array-shaped `target` and tripping `autosaveHasOne`'s
-   * `Array.isArray(child)` bail (autosave-association.ts).
-   * `has_one :through` is excluded — it is handled by the through path.
-   * @internal
-   */
-  private get _isSingular(): boolean {
-    const type = this._assocDef.type as string;
-    return (type === "hasOne" || type === "belongsTo") && !this._isThrough;
-  }
-
-  /**
-   * Route a singular create/createBang through the OO singular holder so the
-   * target is stored as a single record (Rails' `SingularAssociation#create`),
-   * not appended to the proxy's array `_target`.
-   * @internal
-   */
-  private async _createSingular(
-    attrs: Record<string, unknown>,
-    block: ((r: T) => void) | undefined,
-    shouldRaise: boolean,
-  ): Promise<T> {
-    const holder = (
-      this._record as unknown as { association(name: string): SingularCreateHolder }
-    ).association(this._assocName);
-    const cb = block as ((r: Base) => void) | undefined;
-    const record = shouldRaise
-      ? await holder.createBang(attrs, cb)
-      : await holder.create(attrs, cb);
-    return record as T;
-  }
-
   private _checkStrictLoading(): void {
     if (_violatesStrictLoading(this._record, this._assocDef.options)) {
       strictLoadingViolationBang(this._record, this._assocName, {
@@ -1367,14 +1315,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     attrs: Record<string, unknown> | Record<string, unknown>[] = {},
     block?: (r: T) => void,
   ): Promise<T | T[]> {
-    if (this._isSingular) {
-      if (Array.isArray(attrs)) {
-        const records: T[] = [];
-        for (const a of attrs) records.push(await this.create(a, block));
-        return records;
-      }
-      return this._createSingular(attrs, block, false);
-    }
     return (await this._collectionAssociation().create(
       attrs,
       block as ((record: Base) => void) | undefined,
@@ -3228,14 +3168,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     attrs: Record<string, unknown> | Record<string, unknown>[] = {},
     block?: (r: T) => void,
   ): Promise<T | T[]> {
-    if (this._isSingular) {
-      if (Array.isArray(attrs)) {
-        const records: T[] = [];
-        for (const a of attrs) records.push(await this.createBang(a, block));
-        return records;
-      }
-      return this._createSingular(attrs, block, true);
-    }
     return (await this._collectionAssociation().createBang(
       attrs,
       block as ((record: Base) => void) | undefined,

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -35,13 +35,7 @@ import {
   findTakeWithLimit as baseFindTakeWithLimit,
 } from "../relation/finder-methods.js";
 import type { Nodes } from "@blazetrails/arel";
-import {
-  underscore,
-  singularize,
-  camelize,
-  constantize,
-  isAbortSignal,
-} from "@blazetrails/activesupport";
+import { underscore, singularize, camelize, constantize } from "@blazetrails/activesupport";
 import {
   RecordNotSaved,
   ConfigurationError,
@@ -1182,16 +1176,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     for (const r of records) assoc.setStrictLoading(r);
   }
 
-  // Rails raises this once, in `CollectionAssociation#_create_record`
-  // (collection_association.rb:355-357). The non-through arm reaches that
-  // ported guard through `association.create`; the through arm does not route
-  // through `_createRecord` yet, so it keeps the check here until it does.
-  private _ensurePersistedOwnerForCreate(): void {
-    if (this._record.isNewRecord()) {
-      throw new RecordNotSaved(`You cannot call create unless the parent is saved`, this._record);
-    }
-  }
-
   private _ensureThroughWritable(): void {
     if (!this._isThrough) return;
     const ctor = this._record.constructor as typeof Base;
@@ -1308,31 +1292,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   }
 
   /**
-   * Mirrors Rails' `Association#build_record` (association.rb:383-388):
-   *
-   *   reflection.build_association(attributes) do |record|
-   *     initialize_attributes(record, attributes)
-   *   end
-   *
-   * Construction, including STI-subclass resolution, belongs to
-   * `AssociationReflection#build_association` → `klass.new(attributes, &block)`
-   * (reflection.rb:182) and `Base.new`'s inheritance-column handling
-   * (inheritance.rb `new` / `subclass_from_attributes`); the foreign key and
-   * the polymorphic type come off `scope_for_create` inside
-   * `initialize_attributes` (association.rb:224). The through arm
-   * (`HasManyThroughAssociation#build_record`,
-   * has_many_through_association.rb:88-114) is an override on the same holder,
-   * so there is one call here and no through/non-through split on the proxy.
-   */
-  private _buildRecord(attrs: Record<string, unknown> = {}): Base {
-    return (
-      this._record.association(this._assocName) as unknown as {
-        buildRecord(attributes?: Record<string, unknown>): Base;
-      }
-    ).buildRecord(attrs);
-  }
-
-  /**
    * Bulk insert/upsert through a collection association. Mirrors
    * ActiveRecord::AssociationRelation, which guards `insert`, `insert_all`,
    * `insert!`, `insert_all!`, `upsert`, and `upsert_all`: when the
@@ -1393,16 +1352,14 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   }
 
   /**
-   * Build and save a new associated record.
-   *
-   * Rails' `CollectionAssociation#_create_record` routes both regular and
-   * :through associations through `add_to_target` (HasManyThroughAssociation
-   * overrides only `build_record`/`insert_record`, not `_create_record`). The
-   * non-:through path goes through `CollectionAssociation#create` directly; the
-   * :through path builds + saves the target in `_createThrough`, then hands the
-   * in-memory mutation to `_pushThrough`, which routes through the same
-   * `CollectionAssociation#addToTarget` (shared set_inverse_instance +
-   * `@replaced_or_added_targets` dedup).
+   * Mirrors `CollectionProxy#create` (collection_proxy.rb:334-336): a plain
+   * delegation to `@association.create(attributes, &block)`. The persisted-owner
+   * guard, the Array arm, `build_record`, and the
+   * `transaction { add_to_target(record) { insert_record } }` shape all live
+   * once on `CollectionAssociation#_create_record`
+   * (collection_association.rb:354-372); the :through arm reaches it through
+   * `HasManyThroughAssociation#build_record`/`#insert_record`, exactly as Rails
+   * reaches it.
    */
   async create(attrs: Record<string, unknown>[], block?: (r: T) => void): Promise<T[]>;
   async create(attrs?: Record<string, unknown>, block?: (r: T) => void): Promise<T>;
@@ -1410,29 +1367,18 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     attrs: Record<string, unknown> | Record<string, unknown>[] = {},
     block?: (r: T) => void,
   ): Promise<T | T[]> {
-    if (Array.isArray(attrs) && (this._isSingular || this._isThrough)) {
-      const records: T[] = [];
-      for (const a of attrs) {
-        records.push(await this.create(a, block));
-      }
-      return records;
-    }
     if (this._isSingular) {
-      return this._createSingular(attrs as Record<string, unknown>, block, false);
+      if (Array.isArray(attrs)) {
+        const records: T[] = [];
+        for (const a of attrs) records.push(await this.create(a, block));
+        return records;
+      }
+      return this._createSingular(attrs, block, false);
     }
-    if (this._isThrough) this._ensurePersistedOwnerForCreate();
-    this._ensureThroughWritable();
-    if (this._isThrough) {
-      return (await this._createThrough(
-        attrs as Record<string, unknown>,
-        block,
-        (this as unknown as { _pendingThroughScope?: unknown })._pendingThroughScope,
-      )) as T;
-    }
-    // Rails: `@association.create(...)` (collection_proxy.rb:308-310).
-    return (await this._record
-      .association(this._assocName)
-      .create(attrs, block as ((record: Base) => void) | undefined)) as T;
+    return (await this._collectionAssociation().create(
+      attrs,
+      block as ((record: Base) => void) | undefined,
+    )) as T | T[];
   }
 
   /**
@@ -1477,26 +1423,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       replace: true,
       inversing: true,
     }) as Base | null;
-  }
-
-  // NOTE: If _pushThrough fails after the target is saved, the target record
-  // will be orphaned (no join row). Rails wraps this in a transaction. We don't
-  // have transaction support yet — tracked in the roadmap under "Transactions".
-  private async _createThrough(
-    attrs: Record<string, unknown> = {},
-    block?: (r: T) => void,
-    throughScope?: unknown,
-  ): Promise<Base> {
-    const ctor = this._record.constructor as typeof Base;
-    if (this._record.isNewRecord()) {
-      throw new Error(`You cannot call create unless the parent is saved`);
-    }
-    const record = this._buildRecord(attrs) as T;
-    if (block) block(record);
-    const saved = await record.save();
-    if (!saved) return record;
-    await this._pushThrough([record], false, throughScope);
-    return record;
   }
 
   /**
@@ -3292,9 +3218,9 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   }
 
   /**
-   * Build and save a new associated record, raising on validation failure.
-   *
-   * Mirrors: ActiveRecord::Associations::CollectionProxy#create!
+   * Mirrors `CollectionProxy#create!` (collection_proxy.rb:344-346): a plain
+   * delegation to `@association.create!(attributes, &block)`, which routes into
+   * `_create_record(attributes, true, &block)` (association.rb:231-233).
    */
   async createBang(attrs: Record<string, unknown>[], block?: (r: T) => void): Promise<T[]>;
   async createBang(attrs?: Record<string, unknown>, block?: (r: T) => void): Promise<T>;
@@ -3302,44 +3228,18 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     attrs: Record<string, unknown> | Record<string, unknown>[] = {},
     block?: (r: T) => void,
   ): Promise<T | T[]> {
-    if (Array.isArray(attrs) && (this._isSingular || this._isThrough)) {
-      const records: T[] = [];
-      for (const a of attrs) records.push(await this.createBang(a, block));
-      return records;
-    }
     if (this._isSingular) {
-      return this._createSingular(attrs as Record<string, unknown>, block, true);
-    }
-    if (this._isThrough) this._ensurePersistedOwnerForCreate();
-    this._ensureThroughWritable();
-    if (this._isThrough) {
-      const record = this._buildRecord(attrs as Record<string, unknown>) as T;
-      if (block) block(record);
-      try {
-        this._callbackHost.callback("beforeAdd", record);
-      } catch (e) {
-        if (!isAbortSignal(e)) throw e;
-        throw new RecordNotSaved("Callback prevented record creation", record);
+      if (Array.isArray(attrs)) {
+        const records: T[] = [];
+        for (const a of attrs) records.push(await this.createBang(a, block));
+        return records;
       }
-      // Rails' `_create_record` runs the target save INSIDE the transaction —
-      // it is `insert_record`'s `record.save!` (collection_association.rb:361-370)
-      // — so a join-row failure rolls the target row back with it.
-      const targetBefore = this._target.length;
-      await this._throughTransaction(async () => {
-        const saved = await record.save();
-        if (!saved) throw new RecordInvalid(record);
-        await this._pushThrough([record], true);
-      });
-      if (this._target.length === targetBefore) {
-        throw new RecordNotSaved("Failed to create join record for through association", record);
-      }
-      this._callbackHost.callback("afterAdd", record);
-      return record;
+      return this._createSingular(attrs, block, true);
     }
-    // Rails: `@association.create!(...)` (collection_proxy.rb:319-321).
-    return (await this._record
-      .association(this._assocName)
-      .createBang(attrs, block as ((record: Base) => void) | undefined)) as T;
+    return (await this._collectionAssociation().createBang(
+      attrs,
+      block as ((record: Base) => void) | undefined,
+    )) as T | T[];
   }
 
   /**

--- a/packages/activesupport/src/core-ext/date-and-time/calculations.ts
+++ b/packages/activesupport/src/core-ext/date-and-time/calculations.ts
@@ -15,7 +15,6 @@
 import { Temporal } from "@blazetrails/date";
 import * as date from "../date/calculations.js";
 import * as time from "../../time-ext.js";
-import { current as timeCurrent } from "../../time-zone-config.js";
 import { TimeWithZone } from "../../time-with-zone.js";
 import { instantFrom } from "../../temporal.js";
 
@@ -59,7 +58,7 @@ function wday(dateOrTime: DateOrTime): number {
 /** `self.class.current` — `Date.current` for a day, `Time.current` for a time. */
 function classCurrent(dateOrTime: DateOrTime): Temporal.PlainDate | TimeWithZone | Date {
   // boundary: a JS `Date` is the `Time` arm's receiver, and this dispatch is keyed on being one.
-  return dateOrTime instanceof Date ? timeCurrent() : date.current();
+  return dateOrTime instanceof Date ? time.current() : date.current();
 }
 
 /** `self < other` / `self > other`, across both arms. */

--- a/packages/activesupport/src/deprecation.ts
+++ b/packages/activesupport/src/deprecation.ts
@@ -454,44 +454,6 @@ export class Deprecation {
     }
   }
 
-  /**
-   * Rails: `deprecation_warning` (deprecation/reporting.rb:99-104). Rails
-   * defaults the backtrace to `caller_locations(2)`; JS exposes no equivalent
-   * frame list, so an absent `callerBacktrace` reaches `warn` as-is and falls
-   * through to its own default.
-   */
-  deprecationWarning(
-    deprecatedMethodName: string,
-    message?: string,
-    callerBacktrace?: unknown[],
-  ): string {
-    const msg = this.deprecatedMethodWarning(deprecatedMethodName, message);
-    this.warn(msg, callerBacktrace);
-    return msg;
-  }
-
-  /**
-   * Outputs a deprecation warning message
-   *
-   *   deprecatedMethodWarning("methodName")
-   *   // => "methodName is deprecated and will be removed from Rails #{deprecationHorizon}"
-   *   deprecatedMethodWarning("methodName", ":anotherMethod")
-   *   // => "methodName is deprecated and will be removed from Rails #{deprecationHorizon} (use anotherMethod instead)"
-   *   deprecatedMethodWarning("methodName", "Optional message")
-   *   // => "methodName is deprecated and will be removed from Rails #{deprecationHorizon} (Optional message)"
-   *
-   * Rails: `deprecated_method_warning` (deprecation/reporting.rb:115-122).
-   */
-  private deprecatedMethodWarning(methodName: string, message?: string): string {
-    const warning = `${methodName} is deprecated and will be removed from ${this.gemName} ${this.deprecationHorizon}`;
-    // A Ruby Symbol argument names the replacement method; in trails it is a
-    // `":name"` string (CLAUDE.md), a String is free-form text.
-    if (message !== undefined && message.startsWith(":"))
-      return `${warning} (use ${message.slice(1)} instead)`;
-    if (message !== undefined) return `${warning} (${message})`;
-    return warning;
-  }
-
   deprecateMethod(target: object, methodName: string, message?: string): void {
     const self = this;
     const original = (target as Record<string, unknown>)[methodName];

--- a/packages/activesupport/src/deprecation.ts
+++ b/packages/activesupport/src/deprecation.ts
@@ -165,9 +165,9 @@ export interface CallerLocation {
  * @noRailsEquivalent Ruby's `Kernel#caller_locations(start)`. V8 exposes the
  * same information only as the pre-rendered `Error#stack` text, so the frames
  * are parsed back out of it; `start` counts frames the same way, past this
- * function and its caller.
+ * function and its caller, and defaults to 1 as Ruby's does.
  */
-function callerLocations(start: number): CallerLocation[] {
+export function callerLocations(start = 1): CallerLocation[] {
   const stack = new Error().stack;
   if (stack == null) return [];
   return stack

--- a/packages/activesupport/src/deprecation.ts
+++ b/packages/activesupport/src/deprecation.ts
@@ -162,7 +162,7 @@ export interface CallerLocation {
 }
 
 /**
- * @noRailsEquivalent Ruby's `Kernel#caller_locations(start)`. V8 exposes the
+ * @noRailsEquivalent PERMANENT — Ruby's `Kernel#caller_locations(start)`. V8 exposes the
  * same information only as the pre-rendered `Error#stack` text, so the frames
  * are parsed back out of it; `start` counts frames the same way, past this
  * function and its caller, and defaults to 1 as Ruby's does.

--- a/packages/activesupport/src/deprecation/method-wrappers.ts
+++ b/packages/activesupport/src/deprecation/method-wrappers.ts
@@ -1,4 +1,4 @@
-import { extractOptions } from "../hash-utils.js";
+import { extractOptionsBang } from "../hash-utils.js";
 import type { Deprecation } from "../deprecation.js";
 
 /**
@@ -15,7 +15,7 @@ export function deprecateMethods(
   targetModule: Record<string, unknown>,
   ...methodNames: Array<string | Record<string, string>>
 ): Record<string, unknown> {
-  const [names, options] = extractOptions(methodNames as Array<string>);
+  const [names, options] = extractOptionsBang(methodNames as Array<string>);
   const deprecator = (options.deprecator as Deprecation | undefined) ?? this;
   delete options.deprecator;
   const methodNamesWithOptions = [...names, ...Object.keys(options)];

--- a/packages/activesupport/src/deprecation/proxy-wrappers.test.ts
+++ b/packages/activesupport/src/deprecation/proxy-wrappers.test.ts
@@ -1,15 +1,74 @@
-import { describe, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
+import { Deprecation } from "../deprecation.js";
+import {
+  DeprecatedConstantProxy,
+  DeprecatedInstanceVariableProxy,
+  DeprecatedObjectProxy,
+} from "./proxy-wrappers.js";
+import { extend, include, prepend } from "../include.js";
+import { registerConstant } from "../inflector.js";
+import { assertDeprecated } from "../testing/deprecation.js";
 
 describe("ProxyWrappersTest", () => {
-  it.skip("deprecated object proxy doesnt wrap falsy objects");
+  const Waffles = false;
+  const NewWaffles = "hamburgers";
 
-  it.skip("deprecated instance variable proxy doesnt wrap falsy objects");
+  const WaffleModule = {
+    isWaffle(): boolean {
+      return true;
+    },
+  };
+  registerConstant("WaffleModule", WaffleModule);
 
-  it.skip("deprecated constant proxy doesnt wrap falsy objects");
+  let deprecator: Deprecation;
 
-  it.skip("including proxy module");
+  beforeEach(() => {
+    deprecator = new Deprecation();
+  });
 
-  it.skip("prepending proxy module");
+  it("deprecated object proxy doesnt wrap falsy objects", () => {
+    const proxy = DeprecatedObjectProxy.new(null, "message");
+    expect(proxy).toBeFalsy();
+  });
 
-  it.skip("extending proxy module");
+  it("deprecated instance variable proxy doesnt wrap falsy objects", () => {
+    const proxy = DeprecatedInstanceVariableProxy.new(null, "waffles");
+    expect(proxy).toBeFalsy();
+  });
+
+  it("deprecated constant proxy doesnt wrap falsy objects", () => {
+    const proxy = DeprecatedConstantProxy.new(Waffles, NewWaffles);
+    expect(proxy).toBeFalsy();
+  });
+
+  it("including proxy module", async () => {
+    const proxy = DeprecatedConstantProxy.new("OldWaffleModule", "WaffleModule", deprecator);
+    const klass = class {};
+    await assertDeprecated("OldWaffleModule", deprecator, () => {
+      include(klass, proxy as never);
+    });
+    expect((new klass() as unknown as typeof WaffleModule).isWaffle()).toBe(true);
+  });
+
+  it("prepending proxy module", async () => {
+    const proxy = DeprecatedConstantProxy.new("OldWaffleModule", "WaffleModule", deprecator);
+    const klass = class {
+      isWaffle(): boolean {
+        return false;
+      }
+    };
+    await assertDeprecated("OldWaffleModule", deprecator, () => {
+      prepend(klass, proxy as never);
+    });
+    expect(new klass().isWaffle()).toBe(true);
+  });
+
+  it("extending proxy module", async () => {
+    const proxy = DeprecatedConstantProxy.new("OldWaffleModule", "WaffleModule", deprecator);
+    const obj = {};
+    await assertDeprecated("OldWaffleModule", deprecator, () => {
+      extend(obj, proxy as never);
+    });
+    expect((obj as typeof WaffleModule).isWaffle()).toBe(true);
+  });
 });

--- a/packages/activesupport/src/deprecation/proxy-wrappers.ts
+++ b/packages/activesupport/src/deprecation/proxy-wrappers.ts
@@ -5,34 +5,25 @@ import { constantize } from "../inflector.js";
 /**
  * Mirrors: active_support/deprecation/proxy_wrappers.rb
  *
- * Ruby's `def self.new` can answer something other than an instance, and
- * `instance_methods.each { |m| undef_method m }` strips the inherited methods
- * so every call lands in `method_missing`. A TS constructor can neither return
- * `nil`/`false` nor un-define an inherited method, so `new` is a static method
- * (which is what Rails writes anyway) and the undef'd lookup is a `Proxy` whose
- * `get` is `method_missing` — the same shape `methodMissingProxy`
- * (method-missing-proxy.ts) uses, spelled out here because Rails' hook warns on
- * every forwarded call and takes the called name and args to build the message.
+ * A TS constructor can neither return `nil`/`false` nor un-define an inherited
+ * method, so `new` stays the static method Rails writes, and the
+ * `undef_method` + `method_missing` lookup is a `Proxy` — the shape
+ * `methodMissingProxy` (method-missing-proxy.ts) uses, spelled out here because
+ * Rails' hook warns on every forwarded call, from the called name and args.
  */
 
-/** Ruby truthiness: only `nil` and `false` take the `return object` arm. */
-function isFalsy(object: unknown): boolean {
-  return object == null || object === false;
+/** Mirrors Ruby's `Object#inspect` for the values these messages interpolate. */
+function inspect(value: unknown): string {
+  if (typeof value === "string") return JSON.stringify(value);
+  if (value === null || value === undefined) return "nil";
+  if (Array.isArray(value)) return `[${value.map(inspect).join(", ")}]`;
+  return String(value);
 }
 
-/**
- * Names JS itself probes on an arbitrary object — forwarding them through
- * `method_missing` would emit a deprecation warning for an `await` or an
- * equality check the user never wrote.
- */
+/** Names JS probes on any object; forwarding them would warn for an `await`. */
 const PROTOCOL_PROBES = new Set(["then", "catch", "finally", "toJSON", "$$typeof", "nodeType"]);
 
-/**
- * The `instance_methods.each { |m| undef_method m unless /^__|^object_id$/ }`
- * lookup: everything but the proxy's own public methods routes to
- * `method_missing`. `proxy` is the object handed back to the caller, so `this`
- * inside a forwarded `warn` is the proxy's own instance.
- */
+/** The `instance_methods.each { |m| undef_method m }` lookup. */
 function undefMethodProxy<T extends object>(instance: T, methodMissing: MethodMissing): T {
   return new Proxy(instance, {
     get(target, prop, receiver) {
@@ -48,12 +39,12 @@ function undefMethodProxy<T extends object>(instance: T, methodMissing: MethodMi
 type MethodMissing = (this: unknown, called: string, args: unknown[]) => unknown;
 
 /** :nodoc: */
-export class DeprecationProxy {
+export abstract class DeprecationProxy {
   /** Mirrors: proxy_wrappers.rb:6-11. */
   static new(...args: unknown[]): unknown {
     const object = args[0];
 
-    if (isFalsy(object)) return object;
+    if (object == null || object === false) return object;
     const instance = new (this as unknown as new (...a: unknown[]) => DeprecationProxy)(...args);
     return undefMethodProxy(instance, DeprecationProxy.prototype.methodMissing);
   }
@@ -61,14 +52,12 @@ export class DeprecationProxy {
   // Don't give a deprecation warning on inspect since test/unit and error
   // logs rely on it for diagnostics.
   inspect(): string {
-    return String(this.target);
+    return inspect(this.target);
   }
 
-  protected get target(): unknown {
-    return undefined;
-  }
+  protected abstract get target(): unknown;
 
-  protected warn(_callstack: CallerLocation[], _called: string, _args: unknown[]): void {}
+  protected abstract warn(callstack: CallerLocation[], called: string, args: unknown[]): void;
 
   /** Mirrors: proxy_wrappers.rb:19-22. */
   private methodMissing(called: string, args: unknown[]): unknown {
@@ -83,12 +72,6 @@ export class DeprecationProxy {
 /**
  * DeprecatedObjectProxy transforms an object into a deprecated one. It takes an
  * object, a deprecation message, and a deprecator.
- *
- *   const deprecatedObject = DeprecatedObjectProxy.new(
- *     new Object(), "This object is now deprecated", new Deprecation());
- *
- *   deprecatedObject.toString();
- *   // DEPRECATION WARNING: This object is now deprecated.
  *
  * Mirrors: proxy_wrappers.rb:35-51.
  */
@@ -119,7 +102,9 @@ export class DeprecatedObjectProxy extends DeprecationProxy {
  * instance variable, and a deprecator as the last argument.
  *
  * Trying to use the deprecated instance variable will result in a deprecation
- * warning, pointing to the method as a replacement.
+ * warning, pointing to the method as a replacement. Ruby's `var = "@#{method}"`
+ * default sits before the `deprecator:` kwarg, so a caller passing only the
+ * kwarg lands it in the `var` slot; both arrangements are accepted.
  *
  * Mirrors: proxy_wrappers.rb:83-99.
  */
@@ -136,8 +121,6 @@ export class DeprecatedInstanceVariableProxy extends DeprecationProxy {
     options?: { deprecator: Deprecation },
   ) {
     super();
-    // Ruby's `var = "@#{method}"` default sits before the `deprecator:` kwarg,
-    // so a caller passing only the kwarg lands it in the `var` slot here.
     const varName = typeof varOrOptions === "string" ? varOrOptions : `@${method}`;
     const deprecator = (typeof varOrOptions === "string" ? options : varOrOptions)?.deprecator;
     this._instance = instance as Record<string, unknown>;
@@ -153,7 +136,7 @@ export class DeprecatedInstanceVariableProxy extends DeprecationProxy {
 
   protected override warn(callstack: CallerLocation[], called: string, args: unknown[]): void {
     this._deprecator.warn(
-      `${this._var} is deprecated! Call ${this._method}.${called} instead of ${this._var}.${called}. Args: ${JSON.stringify(args)}`,
+      `${this._var} is deprecated! Call ${this._method}.${called} instead of ${this._var}.${called}. Args: ${inspect(args)}`,
       callstack,
     );
   }
@@ -165,9 +148,6 @@ export class DeprecatedInstanceVariableProxy extends DeprecationProxy {
  * string form) and a deprecator. The deprecated constant now returns the value
  * of the new one.
  *
- *   const PLANETS = DeprecatedConstantProxy.new(
- *     "PLANETS", "PLANETS_POST_2006", new Deprecation());
- *
  * Mirrors: proxy_wrappers.rb:117-180.
  */
 export class DeprecatedConstantProxy extends Module {
@@ -175,7 +155,7 @@ export class DeprecatedConstantProxy extends Module {
   static new(...args: unknown[]): unknown {
     const object = args[0];
 
-    if (isFalsy(object)) return object;
+    if (object == null || object === false) return object;
     const instance = new (this as unknown as new (...a: unknown[]) => DeprecatedConstantProxy)(
       ...args,
     );
@@ -206,7 +186,7 @@ export class DeprecatedConstantProxy extends Module {
   // Don't give a deprecation warning on inspect since test/unit and error
   // logs rely on it for diagnostics.
   inspect(): string {
-    return String(this.target);
+    return inspect(this.target);
   }
 
   // Don't give a deprecation warning on methods that IRB may invoke
@@ -220,11 +200,7 @@ export class DeprecatedConstantProxy extends Module {
     return (this.target as { name: string }).name;
   }
 
-  /**
-   * Returns the class of the new constant.
-   *
-   * Mirrors: proxy_wrappers.rb:152-154.
-   */
+  /** Returns the class of the new constant. Mirrors: proxy_wrappers.rb:152-154. */
   class(): unknown {
     return (this.target as object).constructor;
   }

--- a/packages/activesupport/src/deprecation/proxy-wrappers.ts
+++ b/packages/activesupport/src/deprecation/proxy-wrappers.ts
@@ -1,0 +1,262 @@
+import { callerLocations, type CallerLocation, type Deprecation } from "../deprecation.js";
+import { extend, include, Module, prepend } from "../include.js";
+import { constantize } from "../inflector.js";
+
+/**
+ * Mirrors: active_support/deprecation/proxy_wrappers.rb
+ *
+ * Ruby's `def self.new` can answer something other than an instance, and
+ * `instance_methods.each { |m| undef_method m }` strips the inherited methods
+ * so every call lands in `method_missing`. A TS constructor can neither return
+ * `nil`/`false` nor un-define an inherited method, so `new` is a static method
+ * (which is what Rails writes anyway) and the undef'd lookup is a `Proxy` whose
+ * `get` is `method_missing` — the same shape `methodMissingProxy`
+ * (method-missing-proxy.ts) uses, spelled out here because Rails' hook warns on
+ * every forwarded call and takes the called name and args to build the message.
+ */
+
+/** Ruby truthiness: only `nil` and `false` take the `return object` arm. */
+function isFalsy(object: unknown): boolean {
+  return object == null || object === false;
+}
+
+/**
+ * Names JS itself probes on an arbitrary object — forwarding them through
+ * `method_missing` would emit a deprecation warning for an `await` or an
+ * equality check the user never wrote.
+ */
+const PROTOCOL_PROBES = new Set(["then", "catch", "finally", "toJSON", "$$typeof", "nodeType"]);
+
+/**
+ * The `instance_methods.each { |m| undef_method m unless /^__|^object_id$/ }`
+ * lookup: everything but the proxy's own public methods routes to
+ * `method_missing`. `proxy` is the object handed back to the caller, so `this`
+ * inside a forwarded `warn` is the proxy's own instance.
+ */
+function undefMethodProxy<T extends object>(instance: T, methodMissing: MethodMissing): T {
+  return new Proxy(instance, {
+    get(target, prop, receiver) {
+      if (typeof prop === "symbol" || PROTOCOL_PROBES.has(prop)) return undefined;
+      if (prop.startsWith("__") || Reflect.has(target, prop)) {
+        return Reflect.get(target, prop, receiver);
+      }
+      return (...args: unknown[]) => methodMissing.call(target, prop, args);
+    },
+  });
+}
+
+type MethodMissing = (this: unknown, called: string, args: unknown[]) => unknown;
+
+/** :nodoc: */
+export class DeprecationProxy {
+  /** Mirrors: proxy_wrappers.rb:6-11. */
+  static new(...args: unknown[]): unknown {
+    const object = args[0];
+
+    if (isFalsy(object)) return object;
+    const instance = new (this as unknown as new (...a: unknown[]) => DeprecationProxy)(...args);
+    return undefMethodProxy(instance, DeprecationProxy.prototype.methodMissing);
+  }
+
+  // Don't give a deprecation warning on inspect since test/unit and error
+  // logs rely on it for diagnostics.
+  inspect(): string {
+    return String(this.target);
+  }
+
+  protected get target(): unknown {
+    return undefined;
+  }
+
+  protected warn(_callstack: CallerLocation[], _called: string, _args: unknown[]): void {}
+
+  /** Mirrors: proxy_wrappers.rb:19-22. */
+  private methodMissing(called: string, args: unknown[]): unknown {
+    this.warn(callerLocations(), called, args);
+    const value = (this.target as Record<string, unknown>)[called];
+    return typeof value === "function"
+      ? (value as (...a: unknown[]) => unknown).apply(this.target, args)
+      : value;
+  }
+}
+
+/**
+ * DeprecatedObjectProxy transforms an object into a deprecated one. It takes an
+ * object, a deprecation message, and a deprecator.
+ *
+ *   const deprecatedObject = DeprecatedObjectProxy.new(
+ *     new Object(), "This object is now deprecated", new Deprecation());
+ *
+ *   deprecatedObject.toString();
+ *   // DEPRECATION WARNING: This object is now deprecated.
+ *
+ * Mirrors: proxy_wrappers.rb:35-51.
+ */
+export class DeprecatedObjectProxy extends DeprecationProxy {
+  private _object: unknown;
+  private _message: string;
+  private _deprecator: Deprecation;
+
+  constructor(object: unknown, message: string, deprecator: Deprecation) {
+    super();
+    this._object = object;
+    this._message = message;
+    this._deprecator = deprecator;
+  }
+
+  protected override get target(): unknown {
+    return this._object;
+  }
+
+  protected override warn(callstack: CallerLocation[], _called: string, _args: unknown[]): void {
+    this._deprecator.warn(this._message, callstack);
+  }
+}
+
+/**
+ * DeprecatedInstanceVariableProxy transforms an instance variable into a
+ * deprecated one. It takes an instance of a class, a method on that class, an
+ * instance variable, and a deprecator as the last argument.
+ *
+ * Trying to use the deprecated instance variable will result in a deprecation
+ * warning, pointing to the method as a replacement.
+ *
+ * Mirrors: proxy_wrappers.rb:83-99.
+ */
+export class DeprecatedInstanceVariableProxy extends DeprecationProxy {
+  private _instance: Record<string, unknown>;
+  private _method: string;
+  private _var: string;
+  private _deprecator: Deprecation;
+
+  constructor(
+    instance: unknown,
+    method: string,
+    varOrOptions?: string | { deprecator: Deprecation },
+    options?: { deprecator: Deprecation },
+  ) {
+    super();
+    // Ruby's `var = "@#{method}"` default sits before the `deprecator:` kwarg,
+    // so a caller passing only the kwarg lands it in the `var` slot here.
+    const varName = typeof varOrOptions === "string" ? varOrOptions : `@${method}`;
+    const deprecator = (typeof varOrOptions === "string" ? options : varOrOptions)?.deprecator;
+    this._instance = instance as Record<string, unknown>;
+    this._method = method;
+    this._var = varName;
+    this._deprecator = deprecator as Deprecation;
+  }
+
+  protected override get target(): unknown {
+    const value = this._instance[this._method];
+    return typeof value === "function" ? (value as () => unknown).call(this._instance) : value;
+  }
+
+  protected override warn(callstack: CallerLocation[], called: string, args: unknown[]): void {
+    this._deprecator.warn(
+      `${this._var} is deprecated! Call ${this._method}.${called} instead of ${this._var}.${called}. Args: ${JSON.stringify(args)}`,
+      callstack,
+    );
+  }
+}
+
+/**
+ * DeprecatedConstantProxy transforms a constant into a deprecated one. It takes
+ * the full names of an old (deprecated) constant and of a new constant (both in
+ * string form) and a deprecator. The deprecated constant now returns the value
+ * of the new one.
+ *
+ *   const PLANETS = DeprecatedConstantProxy.new(
+ *     "PLANETS", "PLANETS_POST_2006", new Deprecation());
+ *
+ * Mirrors: proxy_wrappers.rb:117-180.
+ */
+export class DeprecatedConstantProxy extends Module {
+  /** Mirrors: proxy_wrappers.rb:118-123. */
+  static new(...args: unknown[]): unknown {
+    const object = args[0];
+
+    if (isFalsy(object)) return object;
+    const instance = new (this as unknown as new (...a: unknown[]) => DeprecatedConstantProxy)(
+      ...args,
+    );
+    return undefMethodProxy(
+      instance,
+      DeprecatedConstantProxy.prototype.methodMissing as MethodMissing,
+    );
+  }
+
+  private _oldConst: string;
+  private _newConst: string;
+  private _deprecator: Deprecation;
+  private _message: string;
+
+  constructor(
+    oldConst: string,
+    newConst: string,
+    deprecator: Deprecation,
+    { message }: { message?: string } = {},
+  ) {
+    super();
+    this._oldConst = oldConst;
+    this._newConst = newConst;
+    this._deprecator = deprecator;
+    this._message = message ?? `${oldConst} is deprecated! Use ${newConst} instead.`;
+  }
+
+  // Don't give a deprecation warning on inspect since test/unit and error
+  // logs rely on it for diagnostics.
+  inspect(): string {
+    return String(this.target);
+  }
+
+  // Don't give a deprecation warning on methods that IRB may invoke
+  // during tab-completion. Rails: `delegate :hash, :instance_methods, :name,
+  // :respond_to?, to: :target` (proxy_wrappers.rb:145).
+  override instanceMethods(): string[] {
+    return (this.target as Module).instanceMethods();
+  }
+
+  get name(): string {
+    return (this.target as { name: string }).name;
+  }
+
+  /**
+   * Returns the class of the new constant.
+   *
+   * Mirrors: proxy_wrappers.rb:152-154.
+   */
+  class(): unknown {
+    return (this.target as object).constructor;
+  }
+
+  /** Mirrors: proxy_wrappers.rb:156-159. */
+  appendFeatures(base: new (...args: any[]) => any): void {
+    this._deprecator.warn(this._message, callerLocations());
+    include(base, this.target as Module);
+  }
+
+  /** Mirrors: proxy_wrappers.rb:161-164. */
+  prependFeatures(base: new (...args: any[]) => any): void {
+    this._deprecator.warn(this._message, callerLocations());
+    prepend(base, this.target as Module);
+  }
+
+  /** Mirrors: proxy_wrappers.rb:166-169. */
+  extended(base: object): void {
+    this._deprecator.warn(this._message, callerLocations());
+    extend(base, this.target as Module);
+  }
+
+  private get target(): unknown {
+    return constantize(String(this._newConst));
+  }
+
+  /** Mirrors: proxy_wrappers.rb:180-183. */
+  private methodMissing(called: string, args: unknown[]): unknown {
+    this._deprecator.warn(this._message, callerLocations());
+    const value = (this.target as Record<string, unknown>)[called];
+    return typeof value === "function"
+      ? (value as (...a: unknown[]) => unknown).apply(this.target, args)
+      : value;
+  }
+}

--- a/packages/activesupport/src/include.ts
+++ b/packages/activesupport/src/include.ts
@@ -159,12 +159,10 @@ type CallableMethods<M extends object> = {
 export type Included<M extends object> = CallableMethods<M>;
 
 /**
- * Ruby's `include` / `prepend` / `extend` are defined in terms of the module's
- * own `append_features` / `prepend_features` / `extended` hooks, which a module
- * may override to do something else entirely —
- * `Deprecation::DeprecatedConstantProxy` overrides all three to warn first
- * (proxy_wrappers.rb:156-169). Only a `Module` instance can carry them, so a
- * plain-object module that happens to have a same-named method is untouched.
+ * Ruby's `include`/`prepend`/`extend` are defined in terms of the module's own
+ * `append_features`/`prepend_features`/`extended` hooks, which a module may
+ * override — `Deprecation::DeprecatedConstantProxy` overrides all three to warn
+ * first (proxy_wrappers.rb:156-169). Only a `Module` instance can carry them.
  */
 function featureHook(mod: unknown, name: string): ((base: unknown) => void) | undefined {
   if (!(mod instanceof Module)) return undefined;
@@ -287,10 +285,10 @@ export type Extended<M extends object> = CallableMethods<M>;
  * plain assignment onto the class prototype.
  *
  * Distinct from `prepend.ts`'s same-named helper, which wraps existing methods
- * so the module's version receives the original as an explicit `super_`; this
- * one is the ancestry splice that pairs with `include()` above and is what a
- * module's `prepend_features` hook installs. It is deliberately not re-exported
- * from the package index, where `prepend.ts`'s helper owns the name.
+ * so the module's version receives the original as an explicit `super_`. This
+ * one is the ancestry splice that pairs with `include()` and is what a module's
+ * `prepend_features` hook installs; it is not re-exported from the package
+ * index, where `prepend.ts`'s helper owns the name.
  *
  * Mirrors: Ruby's Module#prepend (core language feature)
  */

--- a/packages/activesupport/src/include.ts
+++ b/packages/activesupport/src/include.ts
@@ -158,7 +158,23 @@ type CallableMethods<M extends object> = {
  */
 export type Included<M extends object> = CallableMethods<M>;
 
+/**
+ * Ruby's `include` / `prepend` / `extend` are defined in terms of the module's
+ * own `append_features` / `prepend_features` / `extended` hooks, which a module
+ * may override to do something else entirely —
+ * `Deprecation::DeprecatedConstantProxy` overrides all three to warn first
+ * (proxy_wrappers.rb:156-169). Only a `Module` instance can carry them, so a
+ * plain-object module that happens to have a same-named method is untouched.
+ */
+function featureHook(mod: unknown, name: string): ((base: unknown) => void) | undefined {
+  if (!(mod instanceof Module)) return undefined;
+  const hook = (mod as unknown as Record<string, unknown>)[name];
+  return typeof hook === "function" ? (hook as (base: unknown) => void).bind(mod) : undefined;
+}
+
 export function include(klass: AnyClass, mod: ModuleObject | AnyClass | Module): void {
+  const appendFeatures = featureHook(mod, "appendFeatures");
+  if (appendFeatures) return appendFeatures(klass);
   if (mod instanceof Module) {
     const proto = klass.prototype as object;
     const carrier = Object.create(Object.getPrototypeOf(proto)) as Record<string, unknown>;
@@ -263,6 +279,38 @@ export function include(klass: AnyClass, mod: ModuleObject | AnyClass | Module):
 export type Extended<M extends object> = CallableMethods<M>;
 
 /**
+ * Ruby-style `prepend` for mixing module methods into a class *above* it.
+ *
+ * Ruby's `prepend` inserts the module ahead of the class in the ancestry, so a
+ * method the module defines wins over the same method in the class body — the
+ * one behavioural difference from `include`, which loses to it. Here that is a
+ * plain assignment onto the class prototype.
+ *
+ * Distinct from `prepend.ts`'s same-named helper, which wraps existing methods
+ * so the module's version receives the original as an explicit `super_`; this
+ * one is the ancestry splice that pairs with `include()` above and is what a
+ * module's `prepend_features` hook installs. It is deliberately not re-exported
+ * from the package index, where `prepend.ts`'s helper owns the name.
+ *
+ * Mirrors: Ruby's Module#prepend (core language feature)
+ */
+export function prepend(klass: AnyClass, mod: ModuleObject | AnyClass | Module): void {
+  const prependFeatures = featureHook(mod, "prependFeatures");
+  if (prependFeatures) return prependFeatures(klass);
+  const source =
+    mod instanceof Module
+      ? carrierOf(mod)
+      : typeof mod === "function"
+        ? (mod as AnyClass).prototype
+        : mod;
+  for (const key of Object.getOwnPropertyNames(source)) {
+    if (key === "constructor") continue;
+    const descriptor = Object.getOwnPropertyDescriptor(source, key);
+    if (descriptor) Object.defineProperty(klass.prototype, key, descriptor);
+  }
+}
+
+/**
  * Ruby-style `extend` for mixing module methods onto a class as static methods.
  *
  * In Ruby, `extend SomeModule` copies the module's methods onto the
@@ -275,7 +323,9 @@ export type Extended<M extends object> = CallableMethods<M>;
  *   extend(Base, ConnectionHandlingMethods);
  *   // Now Base.connectedTo(...) works
  */
-export function extend(klass: AnyClass | object, mod: ModuleObject | AnyClass): void {
+export function extend(klass: AnyClass | object, mod: ModuleObject | AnyClass | Module): void {
+  const extendedHook = featureHook(mod, "extended");
+  if (extendedHook) return extendedHook(klass);
   // A class module carries its members as non-enumerable own statics, so read
   // its property names directly; a plain-object module keeps the Object.keys
   // (enumerable-only) semantics.

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -365,6 +365,17 @@ export type {
   DeprecationBehaviorInput,
 } from "./deprecation.js";
 export { Deprecators } from "./deprecation/deprecators.js";
+export {
+  DeprecationProxy,
+  DeprecatedObjectProxy,
+  DeprecatedInstanceVariableProxy,
+  DeprecatedConstantProxy,
+} from "./deprecation/proxy-wrappers.js";
+export {
+  assertDeprecated,
+  assertNotDeprecated,
+  collectDeprecations,
+} from "./testing/deprecation.js";
 
 export * from "./time-ext.js";
 // MessageEncryptor/MessageVerifier use getCrypto() adapter but are kept as subpath imports:

--- a/packages/activesupport/src/testing/assertions.ts
+++ b/packages/activesupport/src/testing/assertions.ts
@@ -286,9 +286,8 @@ function _callableToSourceString(callable: unknown): string {
 /**
  * @noRailsEquivalent Minitest's `assert`, which every assertion in
  * `testing/assertions.rb` and `testing/deprecation.rb` calls. Rails inherits it
- * from Minitest rather than defining it, so there is no Ruby counterpart in a
- * mapped file; it is exported so the sibling testing modules raise the same
- * `Assertion` rather than each rolling their own.
+ * from Minitest, so there is no Ruby counterpart in a mapped file; exported so
+ * both testing modules raise the same `Assertion`.
  */
 export function assert(value: boolean, message: string | (() => string)): void {
   if (!value) throw new Assertion(typeof message === "function" ? message() : message);

--- a/packages/activesupport/src/testing/assertions.ts
+++ b/packages/activesupport/src/testing/assertions.ts
@@ -283,7 +283,14 @@ function _callableToSourceString(callable: unknown): string {
   return String(callable);
 }
 
-function assert(value: boolean, message: string | (() => string)): void {
+/**
+ * @noRailsEquivalent Minitest's `assert`, which every assertion in
+ * `testing/assertions.rb` and `testing/deprecation.rb` calls. Rails inherits it
+ * from Minitest rather than defining it, so there is no Ruby counterpart in a
+ * mapped file; it is exported so the sibling testing modules raise the same
+ * `Assertion` rather than each rolling their own.
+ */
+export function assert(value: boolean, message: string | (() => string)): void {
   if (!value) throw new Assertion(typeof message === "function" ? message() : message);
 }
 

--- a/packages/activesupport/src/testing/assertions.ts
+++ b/packages/activesupport/src/testing/assertions.ts
@@ -284,7 +284,7 @@ function _callableToSourceString(callable: unknown): string {
 }
 
 /**
- * @noRailsEquivalent Minitest's `assert`, which every assertion in
+ * @noRailsEquivalent PERMANENT — Minitest's `assert`, which every assertion in
  * `testing/assertions.rb` and `testing/deprecation.rb` calls. Rails inherits it
  * from Minitest, so there is no Ruby counterpart in a mapped file; exported so
  * both testing modules raise the same `Assertion`.

--- a/packages/activesupport/src/testing/deprecation.ts
+++ b/packages/activesupport/src/testing/deprecation.ts
@@ -14,15 +14,9 @@ import { assert } from "./assertions.js";
 
 /**
  * Asserts that a matching deprecation warning was emitted by the given
- * deprecator during the execution of the yielded block.
- *
- *   assertDeprecated(/foo/, CustomDeprecator, () => {
- *     CustomDeprecator.warn("foo should no longer be used");
- *   });
- *
- * The `match` object may be a `RegExp`, or `String` appearing in the message.
- * If the `match` is omitted (or explicitly `null`), any deprecation warning
- * will match.
+ * deprecator during the execution of the yielded block. The `match` object may
+ * be a `RegExp`, or `String` appearing in the message; omitted (or explicitly
+ * `null`), any deprecation warning will match.
  *
  * Mirrors: testing/deprecation.rb:31-44.
  */
@@ -71,12 +65,6 @@ export async function assertNotDeprecated<T>(
  * Returns the return value of the block and an array of all the deprecation
  * warnings emitted by the given `deprecator` during the execution of the
  * yielded block.
- *
- *   collectDeprecations(CustomDeprecator, () => {
- *     CustomDeprecator.warn("message");
- *     new Deprecation().warn("other message");
- *     return ":result";
- *   }); // => [":result", ["message"]]
  *
  * Mirrors: testing/deprecation.rb:68-77.
  */

--- a/packages/activesupport/src/testing/deprecation.ts
+++ b/packages/activesupport/src/testing/deprecation.ts
@@ -1,0 +1,103 @@
+import { Deprecation } from "../deprecation.js";
+import type { DeprecationBehaviorCallable } from "../deprecation.js";
+import { ArgumentError } from "../hash-utils.js";
+import { assert } from "./assertions.js";
+
+/**
+ * Mirrors: active_support/testing/deprecation.rb
+ *
+ * Ruby takes the block last, after the optional `match` and `deprecator`
+ * positionals; the same order holds here, so an absent `match` is passed as the
+ * deprecator and swapped below exactly as Rails swaps it. Blocks may be async,
+ * so each helper awaits the block and returns a Promise.
+ */
+
+/**
+ * Asserts that a matching deprecation warning was emitted by the given
+ * deprecator during the execution of the yielded block.
+ *
+ *   assertDeprecated(/foo/, CustomDeprecator, () => {
+ *     CustomDeprecator.warn("foo should no longer be used");
+ *   });
+ *
+ * The `match` object may be a `RegExp`, or `String` appearing in the message.
+ * If the `match` is omitted (or explicitly `null`), any deprecation warning
+ * will match.
+ *
+ * Mirrors: testing/deprecation.rb:31-44.
+ */
+export async function assertDeprecated<T>(
+  match: RegExp | string | Deprecation | null | undefined,
+  deprecator?: Deprecation | null,
+  block?: () => T | Promise<T>,
+): Promise<T> {
+  if (match instanceof Deprecation) [match, deprecator] = [null, match];
+
+  if (!deprecator) {
+    throw new ArgumentError("No deprecator given");
+  }
+
+  const [result, warnings] = await collectDeprecations(deprecator, block!);
+  assert(warnings.length > 0, "Expected a deprecation warning within the block but received none");
+  if (match != null) {
+    const matcher = match instanceof RegExp ? match : new RegExp(escapeRegExp(match));
+    assert(
+      warnings.some((w) => matcher.test(w)),
+      `No deprecation warning matched ${matcher}: ${warnings.join(", ")}`,
+    );
+  }
+  return result;
+}
+
+/**
+ * Asserts that no deprecation warnings are emitted by the given deprecator
+ * during the execution of the yielded block.
+ *
+ * Mirrors: testing/deprecation.rb:53-57.
+ */
+export async function assertNotDeprecated<T>(
+  deprecator: Deprecation,
+  block: () => T | Promise<T>,
+): Promise<T> {
+  const [result, deprecations] = await collectDeprecations(deprecator, block);
+  assert(
+    deprecations.length === 0,
+    `Expected no deprecation warning within the block but received ${deprecations.length}: \n  ${deprecations.join("\n  ")}`,
+  );
+  return result;
+}
+
+/**
+ * Returns the return value of the block and an array of all the deprecation
+ * warnings emitted by the given `deprecator` during the execution of the
+ * yielded block.
+ *
+ *   collectDeprecations(CustomDeprecator, () => {
+ *     CustomDeprecator.warn("message");
+ *     new Deprecation().warn("other message");
+ *     return ":result";
+ *   }); // => [":result", ["message"]]
+ *
+ * Mirrors: testing/deprecation.rb:68-77.
+ */
+export async function collectDeprecations<T>(
+  deprecator: Deprecation,
+  block: () => T | Promise<T>,
+): Promise<[T, string[]]> {
+  const oldBehavior = deprecator.behavior;
+  const deprecations: string[] = [];
+  deprecator.behavior = ((message: string) => {
+    deprecations.push(message);
+  }) as DeprecationBehaviorCallable;
+  try {
+    const result = await block();
+    return [result, deprecations];
+  } finally {
+    deprecator.behavior = oldBehavior;
+  }
+}
+
+/** Mirrors Ruby `Regexp.escape`: escapes regex metacharacters in a literal. */
+function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/testing/assertions.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/testing/assertions.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activesupport",
-    "tsFile": "testing/assertions.ts",
-    "rubyName": "assert_nothing_raised",
-    "call": "new",
-    "reason": "`Minitest::UnexpectedError.new(error)` re-wraps the raised error for minitest's reporter. vitest reports the thrown error itself, and there is no ported UnexpectedError to construct."
-  }
-]

--- a/scripts/parity/conventions.test.ts
+++ b/scripts/parity/conventions.test.ts
@@ -165,7 +165,7 @@ describe("rubyMethodToTsIgnoringSkip", () => {
 describe("SKIP_TS_MIRROR_IS_DRIFT", () => {
   it("covers the Ruby hook groups only", () => {
     expect([...SKIP_TS_MIRROR_IS_DRIFT].sort()).toEqual(
-      ["extended", "inherited", "included", "singleton_method_added"].sort(),
+      ["const_missing", "extended", "inherited", "included", "singleton_method_added"].sort(),
     );
   });
 });

--- a/scripts/parity/conventions.ts
+++ b/scripts/parity/conventions.ts
@@ -423,6 +423,14 @@ export const SKIP_GROUPS: SkipGroup[] = [
   },
   {
     reason:
+      "Ruby constant-resolution hook — the VM calls it when a constant name " +
+      "misses. JS resolves nothing at runtime by name, so there is no slot " +
+      "for it.",
+    names: ["const_missing"],
+    tsMirrorIsDrift: true,
+  },
+  {
+    reason:
       "NoTouching: TS uses a Map-based depth counter (_noTouchingDepth) instead " +
       "of a thread-local array; klasses() is the Rails internal accessor for " +
       "that array.",


### PR DESCRIPTION
Bundle of two stories.

## 1. Converge `CollectionProxy#create` / `#create!` to delegations

Rails' `CollectionProxy#create` / `#create!` are two-line delegations to
`@association.create` / `create!` (collection_proxy.rb:334-346), which
`Association#create!` routes into `_create_record(attributes, true, &block)`
(association.rb:231-233). The whole persisted-owner guard / Array arm /
`build_record` / `transaction { add_to_target(record) { insert_record } }` /
`raise Rollback unless result` shape lives once on
`CollectionAssociation#_create_record` (collection_association.rb:354-372),
with the `:through` arm reached through `HasManyThroughAssociation#build_record`
and `#insert_record` — exactly as Rails reaches it.

Removed:

- `createBang`'s hand-rolled through arm: its `targetBefore` length probe and
  the invented `RecordNotSaved("Failed to create join record for through
  association")` message Rails does not have. A failed non-raising insert now
  rolls back via `Rollback unless result`.
- `create`'s inline `transaction { add_to_target { insert_record } }`.
- `_buildRecord` — a proxy-side `build_record` seam with no Rails counterpart —
  and `_createThrough`, its only remaining caller.
- The duplicated persisted-owner guard (`_ensurePersistedOwnerForCreate`).
- The singular arm (`_isSingular` / `_createSingular` / `SingularCreateHolder`):
  it routed to the very same `association.create` / `create!` the delegation
  now reaches directly, so both bodies are Rails' two-liners for every
  association type.

Green locally on has-many, has-many-through, HABTM, nested-attributes,
counter-cache, autosave and collection-proxy suites.

## 2. Port `deprecation/proxy_wrappers.rb` + `testing/deprecation.rb`

`DeprecationProxy`, `DeprecatedObjectProxy`, `DeprecatedInstanceVariableProxy`,
`DeprecatedConstantProxy`; `assertDeprecated` / `assertNotDeprecated` /
`collectDeprecations`. Both files report 0 missing in
`pnpm parity:api --package activesupport`, and
`deprecation/proxy_wrappers_test.rb` is enrolled 6/6 with Rails' test names
verbatim, replacing the 15-line stub.

Language shortcomings, and the shape each takes:

- Ruby's `def self.new` can answer something other than an instance
  (`return object unless object`). A TS constructor cannot return `nil`/`false`,
  so `new` stays a static method — which is what Rails writes anyway.
- `instance_methods.each { |m| undef_method m }` + `method_missing` is a
  `Proxy`, the same shape as `method-missing-proxy.ts`. It is spelled out in
  this file rather than reusing that helper because Rails' hook warns on every
  forwarded call and builds the message from the called name and args.
- `include()` / `extend()` now consult a `Module`'s `appendFeatures` /
  `extended` hooks, as Ruby's `include`/`extend` are defined to; `include.ts`
  gains the `Module#prepend` ancestry splice that `prepend_features` installs
  (module-scoped, not re-exported — `prepend.ts`'s method-wrapping helper owns
  that name in the package index).
- `const_missing` joins `SKIP_GROUPS`: the VM calls it when a constant name
  misses, and JS resolves nothing by name at runtime.

`DeprecationProxy#target` / `#warn` are abstract rather than carrying no-op
bodies Rails does not have; the falsy guard is inlined at both `new()` sites as
Rails inlines it; message interpolation goes through an `Object#inspect` port.

`parity:api:extra` reports two novel names in `proxy-wrappers.ts`, `new` and
`extended`; both are Rails methods in this very file (proxy_wrappers.rb:6,
:166) that the extractor's skip list drops, so neither is invented surface.
`testing/assertions.ts` exports Minitest's `assert` (tagged
`@noRailsEquivalent`) so both testing modules raise the same `Assertion`.

## Also: unbreaking `main`'s typecheck

`main` at d1e027d8e does not typecheck. #6452 and #6456 each landed a copy of
`Deprecation#deprecation_warning` / `#deprecated_method_warning` (duplicate
function implementations), and two imports named symbols that do not exist —
`extractOptions` (it is `extractOptionsBang`, Ruby's `extract_options!`) and
`current` from `time-zone-config.js` (it is `time-ext.js`'s). Fixed here
because it blocks every commit via husky.

## Gates

- `pnpm typecheck` clean.
- `pnpm parity:api:calls` OK. One STALE baseline row deleted by hand
  (`activesupport testing/assertions.ts assert_nothing_raised new`); no rows added.
- `pnpm parity:api:calls:args` OK; no rows added — `callerLocations` took
  Ruby's `caller_locations` default of 1 so the call sites pass what Rails passes.
- Full `packages/activerecord/src/associations/` suite green (97 files), plus
  nested-attributes, autosave and counter-cache.
- `parity:api` activesupport: `deprecation/proxy_wrappers.rb` 7/7,
  `testing/deprecation.rb` 3/3. `parity:test`: `proxy_wrappers_test.rb` 0→6.

Closes-story: converge-collection-proxy-create-delegates-to-association
Closes-story: deprecation-proxy-wrappers-and-testing-helpers
