### PR TITLE
fix(website): escape prose braces so markdown-it-attrs cannot emit a Vue binding

### DIFF
--- a/packages/website/scripts/escape-typedoc.mjs
+++ b/packages/website/scripts/escape-typedoc.mjs
@@ -11,7 +11,10 @@
  *    take effect. TypeScript generics (Array<T>), JSDoc HTML examples (<script>,
  *    <br>), and type signatures all produce angle brackets that break parsing.
  *    Fix: escape all `<` outside fenced code blocks to `&lt;`, so nothing looks
- *    like an HTML tag to the Vue parser.
+ *    like an HTML tag to the Vue parser, and all `{` outside fenced blocks and
+ *    inline code spans to `&#123;`, so no prose brace group is picked up as a
+ *    markdown-it-attrs attribute list (which renders as a Vue binding) or as a
+ *    `{{ }}` interpolation.
  *
  * 2. Repoint dead relative links in generated pages at working GitHub URLs.
  *    typedoc copies package READMEs and every locally-linked markdown file
@@ -247,7 +250,16 @@ export function escapeForVue(content) {
       continue;
     }
 
-    result.push(line.replace(/</g, "&lt;"));
+    // markdown-it-attrs consumes a trailing `{...}` as an attribute list, so a
+    // Ruby example like `# => {:a=>:b}` becomes `<p :a="&gt;:b">` — a Vue
+    // binding whose value is not a JS expression, which kills the SFC parse.
+    // `{{ }}` in prose is the same hazard as an interpolation. Escaping `{`
+    // outside inline code spans defuses both; inside a code span the entity
+    // would render literally, and attrs/interpolation do not apply there.
+    const escaped = line.replace(/</g, "&lt;");
+    const spans = codeSpanRanges(escaped);
+    const inCode = (idx) => spans.some(([s, e]) => idx >= s && idx < e);
+    result.push(escaped.replace(/\{/g, (brace, offset) => (inCode(offset) ? brace : "&#123;")));
   }
 
   return result.join("\n");

--- a/packages/website/scripts/escape-typedoc.mjs
+++ b/packages/website/scripts/escape-typedoc.mjs
@@ -5,7 +5,7 @@
  * docs (guides/, root index, …) are never touched, so genuine dead links there
  * still fail the build.
  *
- * 1. Escape angle brackets for the Vue SFC parser.
+ * 1. Escape angle brackets and braces for the Vue SFC parser.
  *    VitePress compiles markdown as Vue SFC templates. The Vue SFC parser must
  *    successfully parse the entire template before any directives (like v-pre)
  *    take effect. TypeScript generics (Array<T>), JSDoc HTML examples (<script>,
@@ -250,12 +250,6 @@ export function escapeForVue(content) {
       continue;
     }
 
-    // markdown-it-attrs consumes a trailing `{...}` as an attribute list, so a
-    // Ruby example like `# => {:a=>:b}` becomes `<p :a="&gt;:b">` — a Vue
-    // binding whose value is not a JS expression, which kills the SFC parse.
-    // `{{ }}` in prose is the same hazard as an interpolation. Escaping `{`
-    // outside inline code spans defuses both; inside a code span the entity
-    // would render literally, and attrs/interpolation do not apply there.
     const escaped = line.replace(/</g, "&lt;");
     const spans = codeSpanRanges(escaped);
     const inCode = (idx) => spans.some(([s, e]) => idx >= s && idx < e);

--- a/packages/website/scripts/escape-typedoc.test.ts
+++ b/packages/website/scripts/escape-typedoc.test.ts
@@ -280,4 +280,21 @@ describe("escapeForVue", () => {
     const src = ["```ts", "const x: Array<T> = [];", "```"].join("\n");
     expect(escapeForVue(src)).toBe(src);
   });
+
+  it("escapes braces outside fenced code", () => {
+    expect(escapeForVue("  options(1, 2, a: :b) # => {:a=>:b}")).toBe(
+      "  options(1, 2, a: :b) # => &#123;:a=>:b}",
+    );
+    expect(escapeForVue("renders {{ value }}")).toBe("renders &#123;&#123; value }}");
+  });
+
+  it("leaves braces inside inline code spans alone", () => {
+    expect(escapeForVue("returns `{}` always")).toBe("returns `{}` always");
+    expect(escapeForVue("`{a}` and {b}")).toBe("`{a}` and &#123;b}");
+  });
+
+  it("leaves braces in fenced code blocks alone", () => {
+    const src = ["```ts", "const x = { a: 1 };", "```"].join("\n");
+    expect(escapeForVue(src)).toBe(src);
+  });
 });


### PR DESCRIPTION
The Website job has been red on main since `extractOptionsBang`'s JSDoc landed:

```
[vite:vue] docs/api/@blazetrails/activesupport/functions/extractOptionsBang.md (14:8):
Error parsing JavaScript expression: Unexpected token (1:1)
```

The doc comment carries the Rails example `options(1, 2, a: :b) # => {:a=>:b}`.
VitePress's markdown-it-attrs plugin consumes a trailing `{...}` as an attribute
list, so that paragraph renders as `<p :a="&gt;:b">` — a Vue binding whose value
is not a JS expression, which kills the SFC parse before any `v-pre` applies.
Same class of hazard as the `<` escaping `escape-typedoc.mjs` already does.

Fix: `escapeForVue` now also escapes `{` to `&#123;` outside fenced blocks and
outside inline code spans (inside a code span the entity would render literally,
and neither attrs nor `{{ }}` interpolation applies there). This defuses both the
attrs pickup and stray interpolation in prose.

Verified locally: `pnpm --filter @blazetrails/website run docs:build` fails on
`origin/main` with the error above and completes (`build complete in 76.57s`)
with this change. `vitest run scripts/` passes with three new cases.

Closes-story: red-614e5b8e
