### PR TITLE
feat(activesupport,activerecord): port DateAndTime::Calculations week/month/quarter/year; converge two naming/arg-order divergences

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -816,7 +816,7 @@ export class ReferenceDefinition {
   }
 
   async add(tableName: string, connection: ReferenceDefinitionConnection): Promise<void> {
-    for (const [colName, colType, colOpts] of this._columns()) {
+    for (const [colName, colType, colOpts] of this.columns()) {
       await connection.addColumn(tableName, colName, colType, colOpts);
     }
     if (this.index) {
@@ -832,7 +832,7 @@ export class ReferenceDefinition {
   }
 
   addTo(table: TableDefinition): void {
-    for (const [colName, colType, colOpts] of this._columns()) {
+    for (const [colName, colType, colOpts] of this.columns()) {
       table.column(colName, colType, colOpts);
     }
     if (this.index) {
@@ -900,7 +900,7 @@ export class ReferenceDefinition {
 
   /** @internal */
   private columnNames(): string[] {
-    return this._columns().map(([n]) => n);
+    return this.columns().map(([n]) => n);
   }
 
   /** @internal */
@@ -910,7 +910,7 @@ export class ReferenceDefinition {
   }
 
   /** @internal */
-  private _columns(): [string, ColumnType, ColumnOptions][] {
+  private columns(): [string, ColumnType, ColumnOptions][] {
     const result: [string, ColumnType, ColumnOptions][] = [
       [this.columnName(), this.type, this.options],
     ];

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2389,7 +2389,7 @@ export function buildWithValueFromHash(
       );
     }
     const expr = buildWithExpressionFromValue.call(this, (hash as any)[key]);
-    return new Nodes.Cte(name, expr as any);
+    return new Nodes.TableAlias(expr as any, name);
   });
 }
 

--- a/packages/activesupport/src/core-ext/date-and-time/calculations.test.ts
+++ b/packages/activesupport/src/core-ext/date-and-time/calculations.test.ts
@@ -9,7 +9,39 @@ import {
   isOnWeekday,
   isBefore,
   isAfter,
+  weeksAgo,
+  weeksSince,
+  monthsAgo,
+  monthsSince,
+  yearsAgo,
+  yearsSince,
+  beginningOfMonth,
+  beginningOfQuarter,
+  endOfQuarter,
+  quarter,
+  beginningOfYear,
+  nextWeek,
+  nextWeekday,
+  nextQuarter,
+  prevWeek,
+  prevWeekday,
+  prevQuarter,
+  lastMonth,
+  lastYear,
+  daysToWeekStart,
+  beginningOfWeek,
+  monday,
+  endOfWeek,
+  sunday,
+  endOfMonth,
+  endOfYear,
+  nextOccurring,
+  prevOccurring,
 } from "./calculations.js";
+import {
+  beginningOfWeek as dateBeginningOfWeek,
+  setBeginningOfWeek,
+} from "../date/calculations.js";
 
 /**
  * Mirrors `DateAndTimeBehavior`'s `date_time_init` hook
@@ -24,11 +56,29 @@ function dateTimeInit(
   hour: number,
   minute: number,
   second: number,
+  usec: number = 0,
 ): { date: Temporal.PlainDate; time: Date } {
   return {
     date: new Temporal.PlainDate(year, month, day),
-    time: new Date(year, month - 1, day, hour, minute, second),
+    time: new Date(year, month - 1, day, hour, minute, second, Math.floor(usec / 1000)),
   };
+}
+
+/** Rails' `Rational(999999999, 1000)` usec — the last instant of a second. */
+const LAST_USEC = 999999999 / 1000;
+
+/**
+ * Mirrors `DateAndTimeBehavior`'s `with_bw_default`
+ * (`date_and_time_behavior.rb:355-361`).
+ */
+function withBwDefault(bw: string, block: () => void): void {
+  const oldBw = dateBeginningOfWeek();
+  setBeginningOfWeek(bw);
+  try {
+    block();
+  } finally {
+    setBeginningOfWeek(oldBw);
+  }
 }
 
 function expectSame(
@@ -97,6 +147,586 @@ describe("DateAndTimeBehavior", () => {
       { date: daysSince(yearEnd.date, 1), time: daysSince(yearEnd.time, 1) },
       dateTimeInit(2005, 1, 1, 10, 10, 10),
     );
+  });
+
+  it("weeks_ago", () => {
+    const from = dateTimeInit(2005, 6, 5, 10, 10, 10);
+    for (const [weeks, y, m, d] of [
+      [1, 2005, 5, 29],
+      [5, 2005, 5, 1],
+      [6, 2005, 4, 24],
+      [14, 2005, 2, 27],
+    ]) {
+      expectSame(
+        { date: weeksAgo(from.date, weeks), time: weeksAgo(from.time, weeks) },
+        dateTimeInit(y, m, d, 10, 10, 10),
+      );
+    }
+    const newYear = dateTimeInit(2005, 1, 1, 10, 10, 10);
+    expectSame(
+      { date: weeksAgo(newYear.date, 1), time: weeksAgo(newYear.time, 1) },
+      dateTimeInit(2004, 12, 25, 10, 10, 10),
+    );
+  });
+
+  it("weeks_since", () => {
+    for (const [fy, fm, fd, y, m, d] of [
+      [2005, 7, 7, 2005, 7, 14],
+      [2005, 6, 27, 2005, 7, 4],
+      [2004, 12, 28, 2005, 1, 4],
+    ]) {
+      const from = dateTimeInit(fy, fm, fd, 10, 10, 10);
+      expectSame(
+        { date: weeksSince(from.date, 1), time: weeksSince(from.time, 1) },
+        dateTimeInit(y, m, d, 10, 10, 10),
+      );
+    }
+  });
+
+  it("months_ago", () => {
+    const from = dateTimeInit(2005, 6, 5, 10, 10, 10);
+    for (const [months, y, m] of [
+      [1, 2005, 5],
+      [7, 2004, 11],
+      [6, 2004, 12],
+      [12, 2004, 6],
+      [24, 2003, 6],
+    ]) {
+      expectSame(
+        { date: monthsAgo(from.date, months), time: monthsAgo(from.time, months) },
+        dateTimeInit(y, m, 5, 10, 10, 10),
+      );
+    }
+  });
+
+  it("months_since", () => {
+    for (const [fy, fm, fd, months, y, m, d] of [
+      [2005, 6, 5, 1, 2005, 7, 5],
+      [2005, 12, 5, 1, 2006, 1, 5],
+      [2005, 6, 5, 6, 2005, 12, 5],
+      [2005, 12, 5, 6, 2006, 6, 5],
+      [2005, 6, 5, 7, 2006, 1, 5],
+      [2005, 6, 5, 12, 2006, 6, 5],
+      [2005, 6, 5, 24, 2007, 6, 5],
+      [2005, 3, 31, 1, 2005, 4, 30],
+      [2005, 1, 29, 1, 2005, 2, 28],
+      [2005, 1, 30, 1, 2005, 2, 28],
+      [2005, 1, 31, 1, 2005, 2, 28],
+    ]) {
+      const from = dateTimeInit(fy, fm, fd, 10, 10, 10);
+      expectSame(
+        { date: monthsSince(from.date, months), time: monthsSince(from.time, months) },
+        dateTimeInit(y, m, d, 10, 10, 10),
+      );
+    }
+  });
+
+  it("years_ago", () => {
+    for (const [fy, fm, fd, years, y, m, d] of [
+      [2005, 6, 5, 1, 2004, 6, 5],
+      [2005, 6, 5, 7, 1998, 6, 5],
+      [2004, 2, 29, 1, 2003, 2, 28], // 1 year ago from leap day
+    ]) {
+      const from = dateTimeInit(fy, fm, fd, 10, 10, 10);
+      expectSame(
+        { date: yearsAgo(from.date, years), time: yearsAgo(from.time, years) },
+        dateTimeInit(y, m, d, 10, 10, 10),
+      );
+    }
+  });
+
+  it("years_since", () => {
+    for (const [fy, fm, fd, years, y, m, d] of [
+      [2005, 6, 5, 1, 2006, 6, 5],
+      [2005, 6, 5, 7, 2012, 6, 5],
+      [2004, 2, 29, 1, 2005, 2, 28], // 1 year since leap day
+      [2005, 6, 5, 177, 2182, 6, 5],
+    ]) {
+      const from = dateTimeInit(fy, fm, fd, 10, 10, 10);
+      expectSame(
+        { date: yearsSince(from.date, years), time: yearsSince(from.time, years) },
+        dateTimeInit(y, m, d, 10, 10, 10),
+      );
+    }
+  });
+
+  it("beginning_of_month", () => {
+    const from = dateTimeInit(2005, 2, 22, 10, 10, 10);
+    expectSame(
+      { date: beginningOfMonth(from.date), time: beginningOfMonth(from.time) },
+      dateTimeInit(2005, 2, 1, 0, 0, 0),
+    );
+  });
+
+  it("beginning_of_quarter", () => {
+    for (const [fy, fm, fd, fh, fmin, fs, y, m] of [
+      [2005, 2, 15, 10, 10, 10, 2005, 1],
+      [2005, 1, 1, 0, 0, 0, 2005, 1],
+      [2005, 12, 31, 10, 10, 10, 2005, 10],
+      [2005, 6, 30, 23, 59, 59, 2005, 4],
+    ]) {
+      const from = dateTimeInit(fy, fm, fd, fh, fmin, fs);
+      expectSame(
+        { date: beginningOfQuarter(from.date), time: beginningOfQuarter(from.time) },
+        dateTimeInit(y, m, 1, 0, 0, 0),
+      );
+    }
+  });
+
+  it("end_of_quarter", () => {
+    for (const [fy, fm, fd, fh, fmin, fs, y, m, d] of [
+      [2007, 2, 15, 10, 10, 10, 2007, 3, 31],
+      [2007, 3, 31, 0, 0, 0, 2007, 3, 31],
+      [2007, 12, 21, 10, 10, 10, 2007, 12, 31],
+      [2007, 4, 1, 0, 0, 0, 2007, 6, 30],
+      [2008, 5, 31, 0, 0, 0, 2008, 6, 30],
+    ]) {
+      const from = dateTimeInit(fy, fm, fd, fh, fmin, fs);
+      expectSame(
+        { date: endOfQuarter(from.date), time: endOfQuarter(from.time) },
+        dateTimeInit(y, m, d, 23, 59, 59, LAST_USEC),
+      );
+    }
+  });
+
+  it("quarter", () => {
+    for (const [m, d, h, min, s, expected] of [
+      [1, 1, 0, 0, 0, 1],
+      [2, 15, 12, 0, 0, 1],
+      [3, 31, 23, 59, 59, 1],
+      [4, 1, 0, 0, 0, 2],
+      [5, 15, 12, 0, 0, 2],
+      [6, 30, 23, 59, 59, 2],
+      [7, 1, 0, 0, 0, 3],
+      [8, 15, 12, 0, 0, 3],
+      [9, 30, 23, 59, 59, 3],
+      [10, 1, 0, 0, 0, 4],
+      [11, 15, 12, 0, 0, 4],
+      [12, 31, 23, 59, 59, 4],
+    ]) {
+      const at = dateTimeInit(2005, m, d, h, min, s);
+      expect(quarter(at.date)).toBe(expected);
+      expect(quarter(at.time)).toBe(expected);
+    }
+  });
+
+  it("beginning_of_year", () => {
+    const from = dateTimeInit(2005, 2, 22, 10, 10, 10);
+    expectSame(
+      { date: beginningOfYear(from.date), time: beginningOfYear(from.time) },
+      dateTimeInit(2005, 1, 1, 0, 0, 0),
+    );
+  });
+
+  it("next_week", () => {
+    const feb = dateTimeInit(2005, 2, 22, 15, 15, 10);
+    expectSame(
+      { date: nextWeek(feb.date), time: nextWeek(feb.time) },
+      dateTimeInit(2005, 2, 28, 0, 0, 0),
+    );
+    expectSame(
+      { date: nextWeek(feb.date, "friday"), time: nextWeek(feb.time, "friday") },
+      dateTimeInit(2005, 3, 4, 0, 0, 0),
+    );
+    const oct = dateTimeInit(2006, 10, 23, 0, 0, 0);
+    expectSame(
+      { date: nextWeek(oct.date), time: nextWeek(oct.time) },
+      dateTimeInit(2006, 10, 30, 0, 0, 0),
+    );
+    expectSame(
+      { date: nextWeek(oct.date, "wednesday"), time: nextWeek(oct.time, "wednesday") },
+      dateTimeInit(2006, 11, 1, 0, 0, 0),
+    );
+  });
+
+  it("next_week_with_default_beginning_of_week_set", () => {
+    withBwDefault("tuesday", () => {
+      const from = new Date(2012, 2, 21);
+      for (const [day, y, m, d] of [
+        ["wednesday", 2012, 3, 28],
+        ["saturday", 2012, 3, 31],
+        ["tuesday", 2012, 3, 27],
+        ["monday", 2012, 4, 2],
+      ] as [string, number, number, number][]) {
+        expect(nextWeek(from, day).epochMilliseconds).toBe(new Date(y, m - 1, d).getTime());
+      }
+    });
+  });
+
+  it("next_week_at_same_time", () => {
+    const feb = dateTimeInit(2005, 2, 22, 15, 15, 10);
+    expectSame(
+      {
+        date: nextWeek(feb.date, "monday", { sameTime: true }),
+        time: nextWeek(feb.time, "monday", { sameTime: true }),
+      },
+      dateTimeInit(2005, 2, 28, 15, 15, 10),
+    );
+    expectSame(
+      {
+        date: nextWeek(feb.date, "friday", { sameTime: true }),
+        time: nextWeek(feb.time, "friday", { sameTime: true }),
+      },
+      dateTimeInit(2005, 3, 4, 15, 15, 10),
+    );
+    const oct = dateTimeInit(2006, 10, 23, 0, 0, 0);
+    expectSame(
+      {
+        date: nextWeek(oct.date, "monday", { sameTime: true }),
+        time: nextWeek(oct.time, "monday", { sameTime: true }),
+      },
+      dateTimeInit(2006, 10, 30, 0, 0, 0),
+    );
+    expectSame(
+      {
+        date: nextWeek(oct.date, "wednesday", { sameTime: true }),
+        time: nextWeek(oct.time, "wednesday", { sameTime: true }),
+      },
+      dateTimeInit(2006, 11, 1, 0, 0, 0),
+    );
+  });
+
+  it("next_weekday_on_wednesday", () => {
+    for (const [h, min, s] of [
+      [0, 0, 0],
+      [15, 15, 10],
+    ]) {
+      const from = dateTimeInit(2015, 1, 7, h, min, s);
+      expectSame(
+        { date: nextWeekday(from.date), time: nextWeekday(from.time) },
+        dateTimeInit(2015, 1, 8, h, min, s),
+      );
+    }
+  });
+
+  it("next_weekday_on_friday", () => {
+    for (const [h, min, s] of [
+      [0, 0, 0],
+      [15, 15, 10],
+    ]) {
+      const from = dateTimeInit(2015, 1, 2, h, min, s);
+      expectSame(
+        { date: nextWeekday(from.date), time: nextWeekday(from.time) },
+        dateTimeInit(2015, 1, 5, h, min, s),
+      );
+    }
+  });
+
+  it("next_weekday_on_saturday", () => {
+    for (const [h, min, s] of [
+      [0, 0, 0],
+      [15, 15, 10],
+    ]) {
+      const from = dateTimeInit(2015, 1, 3, h, min, s);
+      expectSame(
+        { date: nextWeekday(from.date), time: nextWeekday(from.time) },
+        dateTimeInit(2015, 1, 5, h, min, s),
+      );
+    }
+  });
+
+  it("next_quarter_on_31st", () => {
+    const from = dateTimeInit(2005, 8, 31, 15, 15, 10);
+    expectSame(
+      { date: nextQuarter(from.date), time: nextQuarter(from.time) },
+      dateTimeInit(2005, 11, 30, 15, 15, 10),
+    );
+  });
+
+  it("prev_week", () => {
+    const march = dateTimeInit(2005, 3, 1, 15, 15, 10);
+    expectSame(
+      { date: prevWeek(march.date), time: prevWeek(march.time) },
+      dateTimeInit(2005, 2, 21, 0, 0, 0),
+    );
+    expectSame(
+      { date: prevWeek(march.date, "tuesday"), time: prevWeek(march.time, "tuesday") },
+      dateTimeInit(2005, 2, 22, 0, 0, 0),
+    );
+    expectSame(
+      { date: prevWeek(march.date, "friday"), time: prevWeek(march.time, "friday") },
+      dateTimeInit(2005, 2, 25, 0, 0, 0),
+    );
+    const nov = dateTimeInit(2006, 11, 6, 0, 0, 0);
+    expectSame(
+      { date: prevWeek(nov.date), time: prevWeek(nov.time) },
+      dateTimeInit(2006, 10, 30, 0, 0, 0),
+    );
+    const nov23 = dateTimeInit(2006, 11, 23, 0, 0, 0);
+    expectSame(
+      { date: prevWeek(nov23.date, "wednesday"), time: prevWeek(nov23.time, "wednesday") },
+      dateTimeInit(2006, 11, 15, 0, 0, 0),
+    );
+  });
+
+  it("prev_week_with_default_beginning_of_week", () => {
+    withBwDefault("tuesday", () => {
+      const from = new Date(2012, 2, 21);
+      for (const [day, y, m, d] of [
+        ["wednesday", 2012, 3, 14],
+        ["saturday", 2012, 3, 17],
+        ["tuesday", 2012, 3, 13],
+        ["monday", 2012, 3, 19],
+      ] as [string, number, number, number][]) {
+        expect(prevWeek(from, day).epochMilliseconds).toBe(new Date(y, m - 1, d).getTime());
+      }
+    });
+  });
+
+  it("prev_week_at_same_time", () => {
+    const march = dateTimeInit(2005, 3, 1, 15, 15, 10);
+    for (const [day, y, m, d] of [
+      ["monday", 2005, 2, 21],
+      ["tuesday", 2005, 2, 22],
+      ["friday", 2005, 2, 25],
+    ] as [string, number, number, number][]) {
+      expectSame(
+        {
+          date: prevWeek(march.date, day, { sameTime: true }),
+          time: prevWeek(march.time, day, { sameTime: true }),
+        },
+        dateTimeInit(y, m, d, 15, 15, 10),
+      );
+    }
+  });
+
+  it("prev_weekday_on_wednesday", () => {
+    for (const [h, min, s] of [
+      [0, 0, 0],
+      [15, 15, 10],
+    ]) {
+      const from = dateTimeInit(2015, 1, 7, h, min, s);
+      expectSame(
+        { date: prevWeekday(from.date), time: prevWeekday(from.time) },
+        dateTimeInit(2015, 1, 6, h, min, s),
+      );
+    }
+  });
+
+  it("prev_weekday_on_monday", () => {
+    for (const [h, min, s] of [
+      [0, 0, 0],
+      [15, 15, 10],
+    ]) {
+      const from = dateTimeInit(2015, 1, 5, h, min, s);
+      expectSame(
+        { date: prevWeekday(from.date), time: prevWeekday(from.time) },
+        dateTimeInit(2015, 1, 2, h, min, s),
+      );
+    }
+  });
+
+  it("prev_weekday_on_sunday", () => {
+    for (const [h, min, s] of [
+      [0, 0, 0],
+      [15, 15, 10],
+    ]) {
+      const from = dateTimeInit(2015, 1, 4, h, min, s);
+      expectSame(
+        { date: prevWeekday(from.date), time: prevWeekday(from.time) },
+        dateTimeInit(2015, 1, 2, h, min, s),
+      );
+    }
+  });
+
+  it("prev_quarter_on_31st", () => {
+    const from = dateTimeInit(2004, 5, 31, 10, 10, 10);
+    expectSame(
+      { date: prevQuarter(from.date), time: prevQuarter(from.time) },
+      dateTimeInit(2004, 2, 29, 10, 10, 10),
+    );
+  });
+
+  it("last_month_on_31st", () => {
+    const from = dateTimeInit(2004, 3, 31, 0, 0, 0);
+    expectSame(
+      { date: lastMonth(from.date), time: lastMonth(from.time) },
+      dateTimeInit(2004, 2, 29, 0, 0, 0),
+    );
+  });
+
+  it("last_year", () => {
+    const from = dateTimeInit(2005, 6, 5, 10, 0, 0);
+    expectSame(
+      { date: lastYear(from.date), time: lastYear(from.time) },
+      dateTimeInit(2004, 6, 5, 10, 0, 0),
+    );
+  });
+
+  it("days_to_week_start", () => {
+    for (const [d, expected] of [
+      [1, 0],
+      [2, 1],
+      [3, 2],
+      [4, 3],
+      [5, 4],
+      [6, 5],
+      [7, 6],
+    ]) {
+      const at = dateTimeInit(2011, 11, d, 0, 0, 0);
+      expect(daysToWeekStart(at.date, "tuesday")).toBe(expected);
+      expect(daysToWeekStart(at.time, "tuesday")).toBe(expected);
+    }
+
+    for (const [d, startDay] of [
+      [3, "monday"],
+      [4, "tuesday"],
+      [5, "wednesday"],
+      [6, "thursday"],
+      [7, "friday"],
+      [8, "saturday"],
+      [9, "sunday"],
+    ] as [number, string][]) {
+      const at = dateTimeInit(2011, 11, d, 0, 0, 0);
+      expect(daysToWeekStart(at.date, startDay)).toBe(3);
+      expect(daysToWeekStart(at.time, startDay)).toBe(3);
+    }
+  });
+
+  it("days_to_week_start_with_default_set", () => {
+    withBwDefault("friday", () => {
+      for (const [d, expected] of [
+        [8, 6],
+        [7, 5],
+        [6, 4],
+        [5, 3],
+        [4, 2],
+        [3, 1],
+        [2, 0],
+      ]) {
+        expect(daysToWeekStart(new Date(2012, 2, d, 0, 0, 0))).toBe(expected);
+      }
+    });
+  });
+
+  it("beginning_of_week", () => {
+    const feb = dateTimeInit(2005, 2, 4, 10, 10, 10);
+    expectSame(
+      { date: beginningOfWeek(feb.date), time: beginningOfWeek(feb.time) },
+      dateTimeInit(2005, 1, 31, 0, 0, 0),
+    );
+    // monday through sunday all answer the same monday
+    for (const [m, d] of [
+      [11, 28],
+      [11, 29],
+      [11, 30],
+      [12, 1],
+      [12, 2],
+      [12, 3],
+      [12, 4],
+    ]) {
+      const at = dateTimeInit(2005, m, d, 0, 0, 0);
+      expectSame(
+        { date: beginningOfWeek(at.date), time: beginningOfWeek(at.time) },
+        dateTimeInit(2005, 11, 28, 0, 0, 0),
+      );
+    }
+  });
+
+  it("end_of_week", () => {
+    const dec = dateTimeInit(2007, 12, 31, 10, 10, 10);
+    expectSame(
+      { date: endOfWeek(dec.date), time: endOfWeek(dec.time) },
+      dateTimeInit(2008, 1, 6, 23, 59, 59, LAST_USEC),
+    );
+    for (const [m, d] of [
+      [8, 27],
+      [8, 28],
+      [8, 29],
+      [8, 30],
+      [8, 31],
+      [9, 1],
+      [9, 2],
+    ]) {
+      const at = dateTimeInit(2007, m, d, 0, 0, 0);
+      expectSame(
+        { date: endOfWeek(at.date), time: endOfWeek(at.time) },
+        dateTimeInit(2007, 9, 2, 23, 59, 59, LAST_USEC),
+      );
+    }
+  });
+
+  it("end_of_month", () => {
+    for (const [m, d] of [
+      [3, 31],
+      [2, 28],
+      [4, 30],
+    ]) {
+      const at = dateTimeInit(2005, m, 20, 10, 10, 10);
+      expectSame(
+        { date: endOfMonth(at.date), time: endOfMonth(at.time) },
+        dateTimeInit(2005, m, d, 23, 59, 59, LAST_USEC),
+      );
+    }
+  });
+
+  it("end_of_year", () => {
+    for (const [m, d] of [
+      [2, 22],
+      [12, 31],
+    ]) {
+      const at = dateTimeInit(2007, m, d, 10, 10, 10);
+      expectSame(
+        { date: endOfYear(at.date), time: endOfYear(at.time) },
+        dateTimeInit(2007, 12, 31, 23, 59, 59, LAST_USEC),
+      );
+    }
+  });
+
+  it("next_occurring", () => {
+    const from = dateTimeInit(2017, 12, 14, 3, 14, 15);
+    for (const [day, d] of [
+      ["monday", 18],
+      ["tuesday", 19],
+      ["wednesday", 20],
+      ["thursday", 21],
+      ["friday", 15],
+      ["saturday", 16],
+      ["sunday", 17],
+    ] as [string, number][]) {
+      expectSame(
+        { date: nextOccurring(from.date, day), time: nextOccurring(from.time, day) },
+        dateTimeInit(2017, 12, d, 3, 14, 15),
+      );
+    }
+  });
+
+  it("prev_occurring", () => {
+    const from = dateTimeInit(2017, 12, 14, 3, 14, 15);
+    for (const [day, d] of [
+      ["monday", 11],
+      ["tuesday", 12],
+      ["wednesday", 13],
+      ["thursday", 7],
+      ["friday", 8],
+      ["saturday", 9],
+      ["sunday", 10],
+    ] as [string, number][]) {
+      expectSame(
+        { date: prevOccurring(from.date, day), time: prevOccurring(from.time, day) },
+        dateTimeInit(2017, 12, d, 3, 14, 15),
+      );
+    }
+  });
+
+  it("monday_with_default_beginning_of_week_set", () => {
+    withBwDefault("saturday", () => {
+      const from = dateTimeInit(2012, 9, 18, 0, 0, 0);
+      expectSame(
+        { date: monday(from.date), time: monday(from.time) },
+        dateTimeInit(2012, 9, 17, 0, 0, 0),
+      );
+    });
+  });
+
+  it("sunday_with_default_beginning_of_week_set", () => {
+    withBwDefault("wednesday", () => {
+      const from = dateTimeInit(2012, 9, 19, 0, 0, 0);
+      expectSame(
+        { date: sunday(from.date), time: sunday(from.time) },
+        dateTimeInit(2012, 9, 23, 23, 59, 59, LAST_USEC),
+      );
+    });
   });
 
   it("on_weekend_on_saturday", () => {

--- a/packages/activesupport/src/core-ext/date-and-time/calculations.trails.test.ts
+++ b/packages/activesupport/src/core-ext/date-and-time/calculations.trails.test.ts
@@ -1,6 +1,17 @@
 import { describe, it, expect } from "vitest";
 import { Temporal } from "@blazetrails/date";
-import { isToday, isTomorrow, isYesterday, isPast, isFuture } from "./calculations.js";
+import {
+  isToday,
+  isTomorrow,
+  isYesterday,
+  isPast,
+  isFuture,
+  allDay,
+  allWeek,
+  allMonth,
+  allQuarter,
+  allYear,
+} from "./calculations.js";
 
 /**
  * Rails covers `today?` / `tomorrow?` / `yesterday?` / `past?` / `future?`
@@ -32,5 +43,23 @@ describe("DateAndTime::Calculations predicates (trails)", () => {
     expect(isFuture(today.subtract({ days: 1 }))).toBe(false);
     expect(isPast(new Date(Date.now() - 1000))).toBe(true);
     expect(isFuture(new Date(Date.now() + 60_000))).toBe(true);
+  });
+
+  it("all_day, all_week, all_month, all_quarter and all_year span their period", () => {
+    const at = new Temporal.PlainDate(2005, 2, 22);
+    for (const [range, from, to] of [
+      [allWeek(at), "2005-02-21", "2005-02-27"],
+      [allMonth(at), "2005-02-01", "2005-02-28"],
+      [allQuarter(at), "2005-01-01", "2005-03-31"],
+      [allYear(at), "2005-01-01", "2005-12-31"],
+    ] as [{ begin: unknown; end: unknown; excludeEnd: boolean }, string, string][]) {
+      expect(String(range.begin)).toBe(from);
+      expect(String(range.end)).toBe(to);
+      expect(range.excludeEnd).toBe(false);
+    }
+
+    const day = allDay(at);
+    expect(day.begin).not.toBeNull();
+    expect(day.end).not.toBeNull();
   });
 });

--- a/packages/activesupport/src/core-ext/date-and-time/calculations.ts
+++ b/packages/activesupport/src/core-ext/date-and-time/calculations.ts
@@ -17,6 +17,8 @@ import * as date from "../date/calculations.js";
 import * as time from "../../time-ext.js";
 import { TimeWithZone } from "../../time-with-zone.js";
 import { instantFrom } from "../../temporal.js";
+import { Range } from "../../range-ext.js";
+import { KeyError } from "../key-error.js";
 
 /** A receiver of the mixin: the `Date` arm or the `Time` arm. */
 export type DateOrTime = Temporal.PlainDate | Date;
@@ -29,6 +31,17 @@ export type Comparable = DateOrTime | TimeWithZone | Temporal.Instant;
 
 /** What a receiver-returning member answers: a day for a day, an instant for a time. */
 export type DateOrInstant = Temporal.PlainDate | Temporal.Instant;
+
+/** Mirrors: `DateAndTime::Calculations::DAYS_INTO_WEEK` (`:8-16`) */
+export const DAYS_INTO_WEEK: Record<string, number> = {
+  sunday: 0,
+  monday: 1,
+  tuesday: 2,
+  wednesday: 3,
+  thursday: 4,
+  friday: 5,
+  saturday: 6,
+};
 
 /** Mirrors: `DateAndTime::Calculations::WEEKEND_DAYS` (`:17`) */
 export const WEEKEND_DAYS = [6, 0];
@@ -75,6 +88,123 @@ function toInstant(dateOrTime: Comparable): Temporal.Instant {
   if (dateOrTime instanceof TimeWithZone) return dateOrTime.utc();
   if (dateOrTime instanceof Temporal.Instant) return dateOrTime;
   return dateOrTime.toZonedDateTime("UTC").toInstant();
+}
+
+/**
+ * `self.change(...)` — the `Date` arm ignores the time-of-day keys, exactly as
+ * `Date#change` (`date/calculations.rb:143-149`) does.
+ */
+function change(
+  dateOrTime: DateOrTime,
+  options: {
+    year?: number;
+    month?: number;
+    day?: number;
+    hour?: number;
+    min?: number;
+    sec?: number;
+    nsec?: number;
+  },
+): DateOrInstant {
+  // boundary: a JS `Date` is the `Time` arm's receiver, and this dispatch is keyed on being one.
+  return dateOrTime instanceof Date
+    ? time.change(dateOrTime, options)
+    : date.change(dateOrTime, options);
+}
+
+/**
+ * Re-enters the mixin with a value one of its members answered. Ruby's members
+ * return the receiver's own class, so a chained call needs no conversion; the
+ * `Time` arm here answers a `Temporal.Instant` while its receiver is a JS
+ * `Date`, so the chain converts back.
+ */
+function receiver(dateOrTime: DateOrInstant): DateOrTime {
+  // boundary: the `Time` arm's receiver is a JS `Date`, which is what this rebuilds.
+  return dateOrTime instanceof Temporal.Instant
+    ? new Date(dateOrTime.epochMilliseconds)
+    : dateOrTime;
+}
+
+/** `self.year` / `self.month` / `self.day`, across both arms. */
+function year(dateOrTime: DateOrTime): number {
+  // boundary: a JS `Date` is the `Time` arm's receiver, and this dispatch is keyed on being one.
+  return dateOrTime instanceof Date ? dateOrTime.getFullYear() : dateOrTime.year;
+}
+
+function month(dateOrTime: DateOrTime): number {
+  // boundary: as `year` above.
+  return dateOrTime instanceof Date ? dateOrTime.getMonth() + 1 : dateOrTime.month;
+}
+
+function day(dateOrTime: DateOrTime): number {
+  // boundary: as `year` above.
+  return dateOrTime instanceof Date ? dateOrTime.getDate() : dateOrTime.day;
+}
+
+/**
+ * `self.hour` / `min` / `sec` / `try(:nsec)`. Ruby's `Date` answers 0 for the
+ * three time-of-day readers (they are `Date`'s private `hour`/`min`/`sec`,
+ * reachable through `copy_time_to`'s implicit receiver) and does not respond to
+ * `nsec` at all, which is why Rails guards that one with `try`.
+ */
+function hour(dateOrTime: DateOrTime): number {
+  // boundary: as `year` above.
+  return dateOrTime instanceof Date ? dateOrTime.getHours() : 0;
+}
+
+function min(dateOrTime: DateOrTime): number {
+  // boundary: as `year` above.
+  return dateOrTime instanceof Date ? dateOrTime.getMinutes() : 0;
+}
+
+function sec(dateOrTime: DateOrTime): number {
+  // boundary: as `year` above.
+  return dateOrTime instanceof Date ? dateOrTime.getSeconds() : 0;
+}
+
+function nsec(dateOrTime: DateOrTime): number | undefined {
+  // boundary: as `year` above.
+  return dateOrTime instanceof Date ? dateOrTime.getMilliseconds() * 1_000_000 : undefined;
+}
+
+/** `self.next_day` / `self.prev_day` — `advance` on either receiver. */
+function nextDay(dateOrTime: DateOrTime): DateOrInstant {
+  return advance(dateOrTime, { days: 1 });
+}
+
+function prevDay(dateOrTime: DateOrTime): DateOrInstant {
+  return advance(dateOrTime, { days: -1 });
+}
+
+/** `self.beginning_of_day` / `self.end_of_day` — a moment on either arm. */
+function beginningOfDay(dateOrTime: DateOrTime): TimeWithZone | Temporal.Instant {
+  // boundary: as `year` above.
+  return dateOrTime instanceof Date
+    ? time.beginningOfDay(dateOrTime)
+    : date.beginningOfDay(dateOrTime);
+}
+
+function endOfDay(dateOrTime: DateOrTime): TimeWithZone | Temporal.Instant {
+  // boundary: as `year` above.
+  return dateOrTime instanceof Date ? time.endOfDay(dateOrTime) : date.endOfDay(dateOrTime);
+}
+
+/** `Hash#fetch` — raises on an unknown key, where `hash[key]` answers `nil`. */
+function fetch(hash: Record<string, number>, key: string): number {
+  const value = hash[key];
+  if (value === undefined) throw new KeyError(`key not found: :${key}`);
+  return value;
+}
+
+/**
+ * `self.acts_like?(:time)`. Rails asks the receiver for the marker method;
+ * neither of trails' two receivers carries one, so the arm itself is the
+ * answer — a JS `Date` is a moment, a `Temporal.PlainDate` a calendar day.
+ */
+function actsLike(dateOrTime: DateOrTime | DateOrInstant, duck: string): boolean {
+  // boundary: a JS `Date` is the `Time` arm's receiver, and this dispatch is keyed on being one.
+  const isTime = dateOrTime instanceof Date || dateOrTime instanceof Temporal.Instant;
+  return duck === "time" ? isTime : !isTime;
 }
 
 /**
@@ -206,4 +336,364 @@ export function daysSince(dateOrTime: Temporal.PlainDate, days: number): Tempora
 export function daysSince(dateOrTime: Date, days: number): Temporal.Instant;
 export function daysSince(dateOrTime: DateOrTime, days: number): DateOrInstant {
   return advance(dateOrTime, { days: days });
+}
+
+/** Mirrors: `DateAndTime::Calculations#weeks_ago` (`:87-89`) */
+export function weeksAgo(dateOrTime: Temporal.PlainDate, weeks: number): Temporal.PlainDate;
+export function weeksAgo(dateOrTime: Date, weeks: number): Temporal.Instant;
+export function weeksAgo(dateOrTime: DateOrTime, weeks: number): DateOrInstant {
+  return advance(dateOrTime, { weeks: -weeks });
+}
+
+/** Mirrors: `DateAndTime::Calculations#weeks_since` (`:92-94`) */
+export function weeksSince(dateOrTime: Temporal.PlainDate, weeks: number): Temporal.PlainDate;
+export function weeksSince(dateOrTime: Date, weeks: number): Temporal.Instant;
+export function weeksSince(dateOrTime: DateOrTime, weeks: number): DateOrInstant {
+  return advance(dateOrTime, { weeks: weeks });
+}
+
+/** Mirrors: `DateAndTime::Calculations#months_ago` (`:97-99`) */
+export function monthsAgo(dateOrTime: Temporal.PlainDate, months: number): Temporal.PlainDate;
+export function monthsAgo(dateOrTime: Date, months: number): Temporal.Instant;
+export function monthsAgo(dateOrTime: DateOrTime, months: number): DateOrInstant {
+  return advance(dateOrTime, { months: -months });
+}
+
+/** Mirrors: `DateAndTime::Calculations#months_since` (`:102-104`) */
+export function monthsSince(dateOrTime: Temporal.PlainDate, months: number): Temporal.PlainDate;
+export function monthsSince(dateOrTime: Date, months: number): Temporal.Instant;
+export function monthsSince(dateOrTime: DateOrTime, months: number): DateOrInstant {
+  return advance(dateOrTime, { months: months });
+}
+
+/** Mirrors: `DateAndTime::Calculations#years_ago` (`:107-109`) */
+export function yearsAgo(dateOrTime: Temporal.PlainDate, years: number): Temporal.PlainDate;
+export function yearsAgo(dateOrTime: Date, years: number): Temporal.Instant;
+export function yearsAgo(dateOrTime: DateOrTime, years: number): DateOrInstant {
+  return advance(dateOrTime, { years: -years });
+}
+
+/** Mirrors: `DateAndTime::Calculations#years_since` (`:112-114`) */
+export function yearsSince(dateOrTime: Temporal.PlainDate, years: number): Temporal.PlainDate;
+export function yearsSince(dateOrTime: Date, years: number): Temporal.Instant;
+export function yearsSince(dateOrTime: DateOrTime, years: number): DateOrInstant {
+  return advance(dateOrTime, { years: years });
+}
+
+/** Mirrors: `DateAndTime::Calculations#beginning_of_month` (`:125-127`) */
+export function beginningOfMonth(dateOrTime: Temporal.PlainDate): Temporal.PlainDate;
+export function beginningOfMonth(dateOrTime: Date): Temporal.Instant;
+export function beginningOfMonth(dateOrTime: DateOrTime): DateOrInstant {
+  return firstHour(change(dateOrTime, { day: 1 }));
+}
+
+/** Mirrors: `alias :at_beginning_of_month :beginning_of_month` (`:128`) */
+export const atBeginningOfMonth = beginningOfMonth;
+
+/** Mirrors: `DateAndTime::Calculations#beginning_of_quarter` (`:139-142`) */
+export function beginningOfQuarter(dateOrTime: Temporal.PlainDate): Temporal.PlainDate;
+export function beginningOfQuarter(dateOrTime: Date): Temporal.Instant;
+export function beginningOfQuarter(dateOrTime: DateOrTime): DateOrInstant {
+  const firstQuarterMonth = month(dateOrTime) - ((2 + month(dateOrTime)) % 3);
+  return change(receiver(beginningOfMonth(dateOrTime as Date)), { month: firstQuarterMonth });
+}
+
+/** Mirrors: `alias :at_beginning_of_quarter :beginning_of_quarter` (`:143`) */
+export const atBeginningOfQuarter = beginningOfQuarter;
+
+/** Mirrors: `DateAndTime::Calculations#end_of_quarter` (`:154-157`) */
+export function endOfQuarter(dateOrTime: Temporal.PlainDate): Temporal.PlainDate;
+export function endOfQuarter(dateOrTime: Date): Temporal.Instant;
+export function endOfQuarter(dateOrTime: DateOrTime): DateOrInstant {
+  const lastQuarterMonth = month(dateOrTime) + ((12 - month(dateOrTime)) % 3);
+  return endOfMonth(
+    receiver(
+      change(receiver(beginningOfMonth(dateOrTime as Date)), { month: lastQuarterMonth }),
+    ) as Date,
+  );
+}
+
+/** Mirrors: `alias :at_end_of_quarter :end_of_quarter` (`:158`) */
+export const atEndOfQuarter = endOfQuarter;
+
+/** Mirrors: `DateAndTime::Calculations#quarter` (`:166-168`) */
+export function quarter(dateOrTime: DateOrTime): number {
+  return Math.ceil(month(dateOrTime) / 3.0);
+}
+
+/** Mirrors: `DateAndTime::Calculations#beginning_of_year` (`:179-181`) */
+export function beginningOfYear(dateOrTime: Temporal.PlainDate): Temporal.PlainDate;
+export function beginningOfYear(dateOrTime: Date): Temporal.Instant;
+export function beginningOfYear(dateOrTime: DateOrTime): DateOrInstant {
+  return beginningOfMonth(receiver(change(dateOrTime, { month: 1 })) as Date);
+}
+
+/** Mirrors: `alias :at_beginning_of_year :beginning_of_year` (`:182`) */
+export const atBeginningOfYear = beginningOfYear;
+
+/** Mirrors: `DateAndTime::Calculations#next_week` (`:200-203`) */
+export function nextWeek(
+  dateOrTime: Temporal.PlainDate,
+  givenDayInNextWeek?: string,
+  options?: { sameTime?: boolean },
+): Temporal.PlainDate;
+export function nextWeek(
+  dateOrTime: Date,
+  givenDayInNextWeek?: string,
+  options?: { sameTime?: boolean },
+): Temporal.Instant;
+export function nextWeek(
+  dateOrTime: DateOrTime,
+  givenDayInNextWeek: string = date.beginningOfWeek(),
+  { sameTime = false }: { sameTime?: boolean } = {},
+): DateOrInstant {
+  const result = firstHour(
+    daysSince(
+      receiver(beginningOfWeek(receiver(weeksSince(dateOrTime as Date, 1)) as Date)) as Date,
+      daysSpan(givenDayInNextWeek),
+    ),
+  );
+  return sameTime ? copyTimeTo(dateOrTime, result) : result;
+}
+
+/** Mirrors: `DateAndTime::Calculations#next_weekday` (`:206-212`) */
+export function nextWeekday(dateOrTime: Temporal.PlainDate): Temporal.PlainDate;
+export function nextWeekday(dateOrTime: Date): Temporal.Instant;
+export function nextWeekday(dateOrTime: DateOrTime): DateOrInstant {
+  if (isOnWeekend(receiver(nextDay(dateOrTime)))) {
+    return nextWeek(dateOrTime as Date, "monday", { sameTime: true });
+  } else {
+    return nextDay(dateOrTime);
+  }
+}
+
+/** Mirrors: `DateAndTime::Calculations#next_quarter` (`:215-217`) */
+export function nextQuarter(dateOrTime: Temporal.PlainDate): Temporal.PlainDate;
+export function nextQuarter(dateOrTime: Date): Temporal.Instant;
+export function nextQuarter(dateOrTime: DateOrTime): DateOrInstant {
+  return monthsSince(dateOrTime as Date, 3);
+}
+
+/** Mirrors: `DateAndTime::Calculations#prev_week` (`:223-226`) */
+export function prevWeek(
+  dateOrTime: Temporal.PlainDate,
+  startDay?: string,
+  options?: { sameTime?: boolean },
+): Temporal.PlainDate;
+export function prevWeek(
+  dateOrTime: Date,
+  startDay?: string,
+  options?: { sameTime?: boolean },
+): Temporal.Instant;
+export function prevWeek(
+  dateOrTime: DateOrTime,
+  startDay: string = date.beginningOfWeek(),
+  { sameTime = false }: { sameTime?: boolean } = {},
+): DateOrInstant {
+  const result = firstHour(
+    daysSince(
+      receiver(beginningOfWeek(receiver(weeksAgo(dateOrTime as Date, 1)) as Date)) as Date,
+      daysSpan(startDay),
+    ),
+  );
+  return sameTime ? copyTimeTo(dateOrTime, result) : result;
+}
+
+/** Mirrors: `alias_method :last_week, :prev_week` (`:227`) */
+export const lastWeek = prevWeek;
+
+/** Mirrors: `DateAndTime::Calculations#prev_weekday` (`:230-236`) */
+export function prevWeekday(dateOrTime: Temporal.PlainDate): Temporal.PlainDate;
+export function prevWeekday(dateOrTime: Date): Temporal.Instant;
+export function prevWeekday(dateOrTime: DateOrTime): DateOrInstant {
+  if (isOnWeekend(receiver(prevDay(dateOrTime)))) {
+    return copyTimeTo(dateOrTime, beginningOfWeek(dateOrTime as Date, "friday"));
+  } else {
+    return prevDay(dateOrTime);
+  }
+}
+
+/** Mirrors: `alias_method :last_weekday, :prev_weekday` (`:237`) */
+export const lastWeekday = prevWeekday;
+
+/** Mirrors: `DateAndTime::Calculations#last_month` (`:240-242`) */
+export function lastMonth(dateOrTime: Temporal.PlainDate): Temporal.PlainDate;
+export function lastMonth(dateOrTime: Date): Temporal.Instant;
+export function lastMonth(dateOrTime: DateOrTime): DateOrInstant {
+  return monthsAgo(dateOrTime as Date, 1);
+}
+
+/** Mirrors: `DateAndTime::Calculations#prev_quarter` (`:245-247`) */
+export function prevQuarter(dateOrTime: Temporal.PlainDate): Temporal.PlainDate;
+export function prevQuarter(dateOrTime: Date): Temporal.Instant;
+export function prevQuarter(dateOrTime: DateOrTime): DateOrInstant {
+  return monthsAgo(dateOrTime as Date, 3);
+}
+
+/** Mirrors: `alias_method :last_quarter, :prev_quarter` (`:248`) */
+export const lastQuarter = prevQuarter;
+
+/** Mirrors: `DateAndTime::Calculations#last_year` (`:251-253`) */
+export function lastYear(dateOrTime: Temporal.PlainDate): Temporal.PlainDate;
+export function lastYear(dateOrTime: Date): Temporal.Instant;
+export function lastYear(dateOrTime: DateOrTime): DateOrInstant {
+  return yearsAgo(dateOrTime as Date, 1);
+}
+
+/** Mirrors: `DateAndTime::Calculations#days_to_week_start` (`:258-261`) */
+export function daysToWeekStart(
+  dateOrTime: DateOrTime,
+  startDay: string = date.beginningOfWeek(),
+): number {
+  const startDayNumber = fetch(DAYS_INTO_WEEK, startDay);
+  return (((wday(dateOrTime) - startDayNumber) % 7) + 7) % 7;
+}
+
+/** Mirrors: `DateAndTime::Calculations#beginning_of_week` (`:267-270`) */
+export function beginningOfWeek(
+  dateOrTime: Temporal.PlainDate,
+  startDay?: string,
+): Temporal.PlainDate;
+export function beginningOfWeek(dateOrTime: Date, startDay?: string): Temporal.Instant;
+export function beginningOfWeek(
+  dateOrTime: DateOrTime,
+  startDay: string = date.beginningOfWeek(),
+): DateOrInstant {
+  const result = daysAgo(dateOrTime as Date, daysToWeekStart(dateOrTime, startDay));
+  return actsLike(dateOrTime, "time") ? time.midnight(receiver(result) as Date) : result;
+}
+
+/** Mirrors: `alias :at_beginning_of_week :beginning_of_week` (`:271`) */
+export const atBeginningOfWeek = beginningOfWeek;
+
+/** Mirrors: `DateAndTime::Calculations#monday` (`:275-277`) */
+export function monday(dateOrTime: Temporal.PlainDate): Temporal.PlainDate;
+export function monday(dateOrTime: Date): Temporal.Instant;
+export function monday(dateOrTime: DateOrTime): DateOrInstant {
+  return beginningOfWeek(dateOrTime as Date, "monday");
+}
+
+/** Mirrors: `DateAndTime::Calculations#end_of_week` (`:283-285`) */
+export function endOfWeek(dateOrTime: Temporal.PlainDate, startDay?: string): Temporal.PlainDate;
+export function endOfWeek(dateOrTime: Date, startDay?: string): Temporal.Instant;
+export function endOfWeek(
+  dateOrTime: DateOrTime,
+  startDay: string = date.beginningOfWeek(),
+): DateOrInstant {
+  return lastHour(daysSince(dateOrTime as Date, 6 - daysToWeekStart(dateOrTime, startDay)));
+}
+
+/** Mirrors: `alias :at_end_of_week :end_of_week` (`:286`) */
+export const atEndOfWeek = endOfWeek;
+
+/** Mirrors: `DateAndTime::Calculations#sunday` (`:290-292`) */
+export function sunday(dateOrTime: Temporal.PlainDate): Temporal.PlainDate;
+export function sunday(dateOrTime: Date): Temporal.Instant;
+export function sunday(dateOrTime: DateOrTime): DateOrInstant {
+  return endOfWeek(dateOrTime as Date, "monday");
+}
+
+/** Mirrors: `DateAndTime::Calculations#end_of_month` (`:296-299`) */
+export function endOfMonth(dateOrTime: Temporal.PlainDate): Temporal.PlainDate;
+export function endOfMonth(dateOrTime: Date): Temporal.Instant;
+export function endOfMonth(dateOrTime: DateOrTime): DateOrInstant {
+  const lastDay = time.daysInMonth(month(dateOrTime), year(dateOrTime));
+  return lastHour(daysSince(dateOrTime as Date, lastDay - day(dateOrTime)));
+}
+
+/** Mirrors: `alias :at_end_of_month :end_of_month` (`:300`) */
+export const atEndOfMonth = endOfMonth;
+
+/** Mirrors: `DateAndTime::Calculations#end_of_year` (`:304-306`) */
+export function endOfYear(dateOrTime: Temporal.PlainDate): Temporal.PlainDate;
+export function endOfYear(dateOrTime: Date): Temporal.Instant;
+export function endOfYear(dateOrTime: DateOrTime): DateOrInstant {
+  return endOfMonth(receiver(change(dateOrTime, { month: 12 })) as Date);
+}
+
+/** Mirrors: `alias :at_end_of_year :end_of_year` (`:307`) */
+export const atEndOfYear = endOfYear;
+
+/** Mirrors: `DateAndTime::Calculations#all_day` (`:310-312`) */
+export function allDay(dateOrTime: DateOrTime): Range<unknown> {
+  return new Range(beginningOfDay(dateOrTime), endOfDay(dateOrTime));
+}
+
+/** Mirrors: `DateAndTime::Calculations#all_week` (`:316-318`) */
+export function allWeek(
+  dateOrTime: DateOrTime,
+  startDay: string = date.beginningOfWeek(),
+): Range<DateOrInstant> {
+  return new Range(
+    beginningOfWeek(dateOrTime as Date, startDay),
+    endOfWeek(dateOrTime as Date, startDay),
+  );
+}
+
+/** Mirrors: `DateAndTime::Calculations#all_month` (`:321-323`) */
+export function allMonth(dateOrTime: DateOrTime): Range<DateOrInstant> {
+  return new Range(beginningOfMonth(dateOrTime as Date), endOfMonth(dateOrTime as Date));
+}
+
+/** Mirrors: `DateAndTime::Calculations#all_quarter` (`:326-328`) */
+export function allQuarter(dateOrTime: DateOrTime): Range<DateOrInstant> {
+  return new Range(beginningOfQuarter(dateOrTime as Date), endOfQuarter(dateOrTime as Date));
+}
+
+/** Mirrors: `DateAndTime::Calculations#all_year` (`:331-333`) */
+export function allYear(dateOrTime: DateOrTime): Range<DateOrInstant> {
+  return new Range(beginningOfYear(dateOrTime as Date), endOfYear(dateOrTime as Date));
+}
+
+/** Mirrors: `DateAndTime::Calculations#next_occurring` (`:340-344`) */
+export function nextOccurring(
+  dateOrTime: Temporal.PlainDate,
+  dayOfWeek: string,
+): Temporal.PlainDate;
+export function nextOccurring(dateOrTime: Date, dayOfWeek: string): Temporal.Instant;
+export function nextOccurring(dateOrTime: DateOrTime, dayOfWeek: string): DateOrInstant {
+  let fromNow = fetch(DAYS_INTO_WEEK, dayOfWeek) - wday(dateOrTime);
+  if (!(fromNow > 0)) fromNow += 7;
+  return advance(dateOrTime, { days: fromNow });
+}
+
+/** Mirrors: `DateAndTime::Calculations#prev_occurring` (`:351-355`) */
+export function prevOccurring(
+  dateOrTime: Temporal.PlainDate,
+  dayOfWeek: string,
+): Temporal.PlainDate;
+export function prevOccurring(dateOrTime: Date, dayOfWeek: string): Temporal.Instant;
+export function prevOccurring(dateOrTime: DateOrTime, dayOfWeek: string): DateOrInstant {
+  let ago = wday(dateOrTime) - fetch(DAYS_INTO_WEEK, dayOfWeek);
+  if (!(ago > 0)) ago += 7;
+  return advance(dateOrTime, { days: -ago });
+}
+
+/** Mirrors: `DateAndTime::Calculations#first_hour` (`:358-360`) @internal */
+function firstHour(dateOrTime: DateOrInstant): DateOrInstant {
+  return actsLike(dateOrTime, "time")
+    ? time.beginningOfDay(receiver(dateOrTime) as Date)
+    : dateOrTime;
+}
+
+/** Mirrors: `DateAndTime::Calculations#last_hour` (`:362-364`) @internal */
+function lastHour(dateOrTime: DateOrInstant): DateOrInstant {
+  return actsLike(dateOrTime, "time") ? time.endOfDay(receiver(dateOrTime) as Date) : dateOrTime;
+}
+
+/** Mirrors: `DateAndTime::Calculations#days_span` (`:366-368`) @internal */
+function daysSpan(day: string): number {
+  return (
+    (((fetch(DAYS_INTO_WEEK, day) - fetch(DAYS_INTO_WEEK, date.beginningOfWeek())) % 7) + 7) % 7
+  );
+}
+
+/** Mirrors: `DateAndTime::Calculations#copy_time_to` (`:370-372`) @internal */
+function copyTimeTo(self: DateOrTime, other: DateOrInstant): DateOrInstant {
+  return change(receiver(other), {
+    hour: hour(self),
+    min: min(self),
+    sec: sec(self),
+    nsec: nsec(self),
+  });
 }

--- a/packages/activesupport/src/core-ext/date-and-time/calculations.ts
+++ b/packages/activesupport/src/core-ext/date-and-time/calculations.ts
@@ -19,6 +19,7 @@ import { TimeWithZone } from "../../time-with-zone.js";
 import { instantFrom } from "../../temporal.js";
 import { Range } from "../../range-ext.js";
 import { KeyError } from "../key-error.js";
+import { Object } from "../object/acts-like.js";
 
 /** A receiver of the mixin: the `Date` arm or the `Time` arm. */
 export type DateOrTime = Temporal.PlainDate | Date;
@@ -132,12 +133,12 @@ function year(dateOrTime: DateOrTime): number {
 }
 
 function month(dateOrTime: DateOrTime): number {
-  // boundary: as `year` above.
+  // boundary: a JS `Date` is the `Time` arm's receiver, and this dispatch is keyed on being one.
   return dateOrTime instanceof Date ? dateOrTime.getMonth() + 1 : dateOrTime.month;
 }
 
 function day(dateOrTime: DateOrTime): number {
-  // boundary: as `year` above.
+  // boundary: a JS `Date` is the `Time` arm's receiver, and this dispatch is keyed on being one.
   return dateOrTime instanceof Date ? dateOrTime.getDate() : dateOrTime.day;
 }
 
@@ -148,22 +149,22 @@ function day(dateOrTime: DateOrTime): number {
  * `nsec` at all, which is why Rails guards that one with `try`.
  */
 function hour(dateOrTime: DateOrTime): number {
-  // boundary: as `year` above.
+  // boundary: a JS `Date` is the `Time` arm's receiver, and this dispatch is keyed on being one.
   return dateOrTime instanceof Date ? dateOrTime.getHours() : 0;
 }
 
 function min(dateOrTime: DateOrTime): number {
-  // boundary: as `year` above.
+  // boundary: a JS `Date` is the `Time` arm's receiver, and this dispatch is keyed on being one.
   return dateOrTime instanceof Date ? dateOrTime.getMinutes() : 0;
 }
 
 function sec(dateOrTime: DateOrTime): number {
-  // boundary: as `year` above.
+  // boundary: a JS `Date` is the `Time` arm's receiver, and this dispatch is keyed on being one.
   return dateOrTime instanceof Date ? dateOrTime.getSeconds() : 0;
 }
 
 function nsec(dateOrTime: DateOrTime): number | undefined {
-  // boundary: as `year` above.
+  // boundary: a JS `Date` is the `Time` arm's receiver, and this dispatch is keyed on being one.
   return dateOrTime instanceof Date ? dateOrTime.getMilliseconds() * 1_000_000 : undefined;
 }
 
@@ -178,14 +179,14 @@ function prevDay(dateOrTime: DateOrTime): DateOrInstant {
 
 /** `self.beginning_of_day` / `self.end_of_day` — a moment on either arm. */
 function beginningOfDay(dateOrTime: DateOrTime): TimeWithZone | Temporal.Instant {
-  // boundary: as `year` above.
+  // boundary: a JS `Date` is the `Time` arm's receiver, and this dispatch is keyed on being one.
   return dateOrTime instanceof Date
     ? time.beginningOfDay(dateOrTime)
     : date.beginningOfDay(dateOrTime);
 }
 
 function endOfDay(dateOrTime: DateOrTime): TimeWithZone | Temporal.Instant {
-  // boundary: as `year` above.
+  // boundary: a JS `Date` is the `Time` arm's receiver, and this dispatch is keyed on being one.
   return dateOrTime instanceof Date ? time.endOfDay(dateOrTime) : date.endOfDay(dateOrTime);
 }
 
@@ -197,14 +198,15 @@ function fetch(hash: Record<string, number>, key: string): number {
 }
 
 /**
- * `self.acts_like?(:time)`. Rails asks the receiver for the marker method;
- * neither of trails' two receivers carries one, so the arm itself is the
- * answer — a JS `Date` is a moment, a `Temporal.PlainDate` a calendar day.
+ * `self.acts_like?(:time)`. `Object.actsLike` asks the receiver for the marker
+ * method, and neither of trails' two receivers carries one, so for `:time` the
+ * arm itself is the answer — a JS `Date` and the `Temporal.Instant` its members
+ * answer are moments, a `Temporal.PlainDate` is a calendar day.
  */
 function actsLike(dateOrTime: DateOrTime | DateOrInstant, duck: string): boolean {
-  // boundary: a JS `Date` is the `Time` arm's receiver, and this dispatch is keyed on being one.
-  const isTime = dateOrTime instanceof Date || dateOrTime instanceof Temporal.Instant;
-  return duck === "time" ? isTime : !isTime;
+  if (duck !== "time") return Object.actsLike(dateOrTime, duck);
+  // boundary: a JS `Date` is the `Time` arm's receiver, and this arm is keyed on being one.
+  return dateOrTime instanceof Date || dateOrTime instanceof Temporal.Instant;
 }
 
 /**
@@ -615,7 +617,7 @@ export function endOfYear(dateOrTime: DateOrTime): DateOrInstant {
 export const atEndOfYear = endOfYear;
 
 /** Mirrors: `DateAndTime::Calculations#all_day` (`:310-312`) */
-export function allDay(dateOrTime: DateOrTime): Range<unknown> {
+export function allDay(dateOrTime: DateOrTime): Range<TimeWithZone | Temporal.Instant> {
   return new Range(beginningOfDay(dateOrTime), endOfDay(dateOrTime));
 }
 

--- a/packages/activesupport/src/core-ext/name-error.ts
+++ b/packages/activesupport/src/core-ext/name-error.ts
@@ -36,6 +36,9 @@ export class NameError extends ReferenceError {
    * branch — the message regex — which yields the same qualified path Ruby's
    * receiver branch builds. Deliberately not {@link constantName}, which is the
    * unqualified `name`.
+   *
+   * @missingRailsCall receiver — a JS `Error` carries no receiver, so the
+   * branches guarded by `receiver` (`name_error.rb:29-38`) are unreachable.
    */
   missingName(): string | undefined {
     if (!this.message.startsWith("uninitialized constant ")) return undefined;


### PR DESCRIPTION
Three bundled stories.

## `DateAndTime::Calculations` — week/month/quarter/year (slot B)

Ports the rest of the mixin (`calculations.rb:87-372`) onto Slot A's two-arm
dispatcher file: `weeks_ago`/`weeks_since`, `months_ago`/`months_since`,
`years_ago`/`years_since`, `beginning_of_month`, `beginning_of_quarter`/
`end_of_quarter`/`quarter`, `beginning_of_year`/`end_of_year`, `end_of_month`,
`days_to_week_start`, `beginning_of_week`/`end_of_week` (+ `monday`/`sunday`),
`next_week`/`next_weekday`/`next_quarter`, `prev_week`/`prev_weekday`/
`prev_quarter`/`last_month`/`last_year` (+ the `last_*` aliases), `all_day`/
`all_week`/`all_month`/`all_quarter`/`all_year` (returning trails' `Range`), and
`next_occurring`/`prev_occurring` — plus the mixin's own `DAYS_INTO_WEEK`
constant and its four private helpers (`first_hour`, `last_hour`, `days_span`,
`copy_time_to`).

`beginning_of_week` / `next_week` / `prev_week` / `days_to_week_start` /
`all_week` default their start day to `Date.beginning_of_week`, read at call
time, so the `with_bw_default` cases pass on both receivers.

The receiver-polymorphism helpers follow Slot A's existing pattern: `change`,
`year`/`month`/`day`/`hour`/`min`/`sec`/`nsec`, `next_day`/`prev_day`,
`beginning_of_day`/`end_of_day`, `acts_like?` and `Hash#fetch` are
module-private dispatchers keyed on which arm the receiver is. `receiver()` is
the one addition Ruby has no analogue for: the `Time` arm answers a
`Temporal.Instant` while its receiver is a JS `Date`, so a chained mixin call
converts back.

Tests are `DateAndTimeBehavior`'s cases, run against both receivers as Rails
runs them from `date_ext_test.rb` and `time_ext_test.rb`.

## `build_with_value_from_hash` argument order (RFC 0096)

`query_methods.rb:1925` builds `Arel::Nodes::TableAlias.new(expression, name)`;
trails built `Cte.new(name, expression)`. Now the Rails node in the Rails order
— `collect_ctes` calls `to_cte` on each child (`to_sql.rb:1023-1030`), and
`TableAlias#to_cte` produces the same `Cte`, so the SQL is unchanged. The
`buildWithValueFromHash` row is gone from `parity:api:calls:args:report`.

## `ReferenceDefinition#_columns` → `columns` (RFC 0084)

Rails names it `columns` (`schema_definitions.rb:280-286`); the underscore was
avoiding a collision with `TableDefinition#columns` that does not exist —
different class. Call sites `add`, `addTo` and `columnNames` updated. As the
story's sweep note records, the two baseline rows it cited were already gone
with the `call-mismatches-wide-exclude/` tree, so this is a pure fidelity
rename.

## Drive-by

`NameError#missingName` carries a `@missingRailsCall receiver` tag — the
`receiver`-guarded branches of `name_error.rb` have no JS analogue (an `Error`
carries no receiver), which the method's JSDoc already explained; the call-set
ratchet surfaced it as a new row on the forced recompute.

## Size

Over the 700-LOC ceiling at ~1130. The mixin's second half is 30 members × two
receivers plus `DateAndTimeBehavior`'s full case list; splitting it would either
land members without their tests or leave the mixin half-ported across two PRs.
The fourth story of the bundle (`time-helpers-stub-real-clock-methods`) was
released back to the queue rather than piled on.

## Verification

- `parity:api:calls` and `parity:api:calls:args` ratchets both OK.
- `parity:api:extra --package activesupport` reports no new surface.
- `parity:test --gates --check` exits 0.
- `calculations.test.ts` (48), `calculations.trails.test.ts`, `relation/with.test.ts`,
  `arel` cte tests and `schema-definitions.trails.test.ts` green locally.

Closes-story: build-with-value-from-hash-arg-order
Closes-story: reference-definition-columns-rename-from-underscore-columns
Closes-story: date-and-time-calculations-week-month-quarter-year
