### PR TITLE
fix(parity,activerecord,date): score reopened Ruby files, drop raise-position new from call order, route through-create via _create_record, spell Inf in Date#inspect

### DIFF
--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1913,11 +1913,13 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * the association keeps membership, loaded-ness, `@replaced_or_added_targets`
    * dedup, and the before/after_add callbacks coherent across both handles.
    *
-   * `skipCallbacks` is the `create!` path, whose caller already fires
-   * before/after_add around the whole build+save; it mirrors Rails'
-   * `_create_record` — `add_to_target(record) { insert_record(record, true,
-   * true) }` (collection_association.rb:363-371) — rather than going through
-   * `concat`, which would fire the callbacks a second time.
+   * The `create!` path does NOT come through here: it is
+   * `@association.create!(...)` (collection_proxy.rb:319-321) onto
+   * `CollectionAssociation#_create_record` (collection_association.rb:354-372),
+   * which owns the `transaction`, the `add_to_target { insert_record }` funnel,
+   * the `raise ActiveRecord::Rollback unless result` guard and — through
+   * `HasManyAssociation#_create_record` (has_many_association.rb:143-149) — the
+   * in-memory counter bump.
    *
    * `throughScope` is Rails' `@through_scope`
    * (has_many_through_association.rb:93), which `construct_join_attributes`
@@ -1929,37 +1931,12 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     return this._record.association(this._assocName) as unknown as ThroughAssociationHandle;
   }
 
-  /**
-   * @internal Rails' `CollectionAssociation#transaction`, which
-   * `ThroughAssociation` overrides to the *through* model's — the join-row
-   * writes are what has to be atomic, not the target model's.
-   */
-  private _throughTransaction<R>(block: () => Promise<R>): Promise<R | undefined> {
-    return this._throughAssociation().transaction(block);
-  }
-
-  private async _pushThrough(
-    records: T[],
-    skipCallbacks = false,
-    throughScope?: unknown,
-  ): Promise<void> {
+  private async _pushThrough(records: T[], throughScope?: unknown): Promise<void> {
     const assoc = this._throughAssociation();
     const previousThroughScope = assoc._throughScope;
     if (throughScope != null) assoc._throughScope = throughScope;
     try {
-      if (skipCallbacks) {
-        await this._throughTransaction(async () => {
-          for (const record of records) {
-            await (assoc as unknown as CollectionAssociation).addToTarget(
-              record,
-              { skipCallbacks: true, replace: this.distinctValue },
-              () => assoc.insertRecord(record, true, true) as unknown as Promise<void>,
-            );
-          }
-        });
-      } else {
-        await assoc.concat(...records);
-      }
+      await assoc.concat(...records);
     } finally {
       assoc._throughScope = previousThroughScope;
     }

--- a/packages/activerecord/src/associations/through-push-routes-to-insert-record.trails.test.ts
+++ b/packages/activerecord/src/associations/through-push-routes-to-insert-record.trails.test.ts
@@ -93,6 +93,22 @@ describe("through-collection writes route onto the association's insertRecord", 
     expect(await Category.count()).toBe(before);
   });
 
+  it("createBang rolls the target row back when the join insert returns false", async () => {
+    // `_create_record`'s `raise ActiveRecord::Rollback unless result`
+    // (collection_association.rb:368) — the NON-raising failure arm, whose
+    // return value the proxy's own `insert_record` call used to discard.
+    // `Rollback` is swallowed by the transaction, so `create!` still returns
+    // the (now unpersisted) record.
+    const author = (await Author.find(authors("david").id)) as unknown as AuthorWithCategories;
+    const assoc = author.association("categories");
+    assoc.insertRecord = () => Promise.resolve(false);
+    const before = await Category.count();
+
+    await author.categories.createBang({ name: "Rolled back" });
+
+    expect(await Category.count()).toBe(before);
+  });
+
   it("the pushed record lands in the one shared target", async () => {
     const author = (await Author.find(authors("david").id)) as unknown as AuthorWithCategories;
     const category = (await Category.find(categories("technology").id)) as unknown as Base;

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -895,43 +895,48 @@ export class ConnectionPool implements ReapablePool {
   // 0023-surfaced-deviations / converge-connection-pool-checkout-lease-async.
   async checkout(timeout?: number): Promise<DatabaseAdapter> {
     const pinned = this._resolvePinnedConnection();
-    if (pinned) {
-      // Mirrors Rails' pinned branch (connection_pool.rb:553-559): verify!
-      // unconditionally, ensure membership in @connections, and return — no
-      // checkout_and_verify / QueryCache wiring on the pinned connection.
-      // verifyBang is async in trails (Rails' verify! is sync); await it on the
-      // async path so verification completes before the connection is handed out
-      // and a rejection surfaces here rather than as an unhandled rejection.
-      await (pinned as unknown as { verifyBang(): void | Promise<void> }).verifyBang();
-      if (this._connections && !this._connections.includes(pinned)) {
-        this._connections.push(pinned);
+    // Rails' guard clause: `return checkout_and_verify(acquire_connection(
+    // checkout_timeout)) unless @pinned_connection` (connection_pool.rb:551).
+    // The acquire is inlined here rather than living on `acquire_connection`,
+    // which in trails does not block on the queue.
+    if (!pinned) {
+      const conn = this._tryAcquire();
+      if (conn) {
+        return checkoutAndVerify(this, conn);
       }
-      return pinned;
-    }
-    const conn = this._tryAcquire();
-    if (conn) {
-      return checkoutAndVerify(this, conn);
+
+      const t = timeout ?? this.checkoutTimeout;
+      if (!this._available) {
+        throw new ConnectionNotEstablished("Connection pool has been discarded");
+      }
+      let c: DatabaseAdapter;
+      try {
+        const result = this._available.poll(t);
+        c = result instanceof Promise ? await result : result;
+      } catch (err) {
+        if (err instanceof ConnectionTimeoutError) {
+          err.setPool(this);
+        }
+        throw err;
+      }
+      if (this.isDiscarded()) {
+        throw new ConnectionNotEstablished("Connection pool has been discarded");
+      }
+      this._checkedOut.add(c);
+      return checkoutAndVerify(this, c);
     }
 
-    const t = timeout ?? this.checkoutTimeout;
-    if (!this._available) {
-      throw new ConnectionNotEstablished("Connection pool has been discarded");
+    // Mirrors Rails' pinned branch (connection_pool.rb:553-559): verify!
+    // unconditionally, ensure membership in @connections, and return — no
+    // checkout_and_verify / QueryCache wiring on the pinned connection.
+    // verifyBang is async in trails (Rails' verify! is sync); await it on the
+    // async path so verification completes before the connection is handed out
+    // and a rejection surfaces here rather than as an unhandled rejection.
+    await (pinned as unknown as { verifyBang(): void | Promise<void> }).verifyBang();
+    if (this._connections && !this._connections.includes(pinned)) {
+      this._connections.push(pinned);
     }
-    let c: DatabaseAdapter;
-    try {
-      const result = this._available.poll(t);
-      c = result instanceof Promise ? await result : result;
-    } catch (err) {
-      if (err instanceof ConnectionTimeoutError) {
-        err.setPool(this);
-      }
-      throw err;
-    }
-    if (this.isDiscarded()) {
-      throw new ConnectionNotEstablished("Connection pool has been discarded");
-    }
-    this._checkedOut.add(c);
-    return checkoutAndVerify(this, c);
+    return pinned;
   }
 
   private _acquireConnection(): DatabaseAdapter {

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -529,16 +529,6 @@ export function _enum(
   assertValidEnumDefinitionValues(values);
   assertValidEnumOptions(options ?? {});
 
-  // Rails guards the enum *name* itself against reserved Active Record methods
-  // before generating any value methods: the pluralized mapping accessor
-  // (`name.pluralize`, e.g. `column` → `columns`) as a class method, and the
-  // reader/writer (`name`, `name=`) as instance methods.
-  // Mirrors enum.rb `detect_enum_conflict!(name, name.pluralize, true)` and the
-  // two `detect_enum_conflict!(name, name)` / `detect_enum_conflict!(name, "#{name}=")` calls.
-  detectEnumConflictBang.call(this, name, pluralize(name), true);
-  detectEnumConflictBang.call(this, name, name);
-  detectEnumConflictBang.call(this, name, `${name}=`);
-
   const attribute = name;
   const mapping = Array.isArray(values)
     ? Object.fromEntries(values.map((v, i) => [v, i]))
@@ -569,10 +559,24 @@ export function _enum(
       attribute
     ] ?? attribute;
 
+  // Rails guards the enum *name* itself against reserved Active Record methods
+  // before generating any value methods: the pluralized mapping accessor
+  // (`name.pluralize`, e.g. `column` → `columns`) as a class method, and the
+  // reader/writer (`name`, `name=`) as instance methods. The store the mapping
+  // lands in is built first (`enum_values = HashWithIndifferentAccess.new`,
+  // enum.rb:227) and `defined_enums[name] = enum_values` lands between the
+  // guards (enum.rb:231-236), so a conflict on the reader/writer leaves the
+  // mapping registered, as it does in Rails.
   if (!Object.prototype.hasOwnProperty.call(this, "_enums")) {
     this._enums = new Map(this._enums);
   }
+
+  detectEnumConflictBang.call(this, name, pluralize(name), true);
+
   this._enums.set(attrName, mapping);
+
+  detectEnumConflictBang.call(this, name, name);
+  detectEnumConflictBang.call(this, name, `${name}=`);
 
   const prefixStr =
     options?.prefix === true

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -679,8 +679,10 @@ export function _enum(
   // another enum" when a *different* enum on the same class already generated a
   // value method with this name. `dangerousAttributeMethods()` covers only
   // framework methods, so we track enum-generated predicate/bang names and
-  // consult them here; the set is populated during the generation pass below, so
-  // the conflict pass only sees names from prior `enum()` declarations.
+  // consult them here. Within one `_enum` an intra-enum collision is caught by
+  // `definedNames` first, which raises the same "already defined by another
+  // enum" error, so recording into this set as each label is generated —
+  // Rails' own interleaving — changes no message.
   //
   // Crucially the set is per-class and NOT inherited: Rails' `_enum_methods_module`
   // is a class-instance variable (enum.rb:326-332) that Ruby does not inherit, so
@@ -696,8 +698,11 @@ export function _enum(
   const enumMethodNames = enumMethodsHost._enumMethodsModuleNames!;
   const definedNames = new Set<string>();
   const valueMethodNames: string[] = [];
-  const aliasedLabels = new Set<string>();
-  for (const [n] of Object.entries(mapping)) {
+  // Rails generates the per-value methods inside `_enum_methods_module`
+  // (enum.rb:252); route trails' generation through the same module so
+  // `EnumMethods.defineEnumMethods` is the single generator.
+  const methodsModule = this._enumMethodsModule();
+  for (const [n, value] of Object.entries(mapping)) {
     const fullName = toCamel(methodName(n));
     const { predicateName, bangName, notScopeName } = enumMethodNamesFor(fullName);
     const friendlyName = toCamel(methodName(n).replace(/[^\w\x80-\uffff]+/g, "_"));
@@ -708,13 +713,12 @@ export function _enum(
     // same guard also gates the alias's define_enum_methods call (enum.rb:273):
     // two labels mangling to one alias (e.g. "Etc/GMT+1" / "Etc/GMT-1") is NOT
     // a conflict — the alias sticks to the first label and the second label
-    // simply doesn't get one. Record the decision in `aliasedLabels` so the
-    // generation pass below skips the alias for later same-mangling labels too.
+    // simply doesn't get one, and its `define_enum_methods` call is skipped
+    // with it.
     valueMethodNames.push(fullName);
     const aliasIsNew = friendlyName !== fullName && !valueMethodNames.includes(friendlyName);
     if (aliasIsNew) {
       valueMethodNames.push(friendlyName);
-      aliasedLabels.add(n);
     }
 
     // Rails runs `detect_enum_conflict!` for the `?`/`!` methods *only* inside
@@ -797,23 +801,6 @@ export function _enum(
         detectEnumConflictBang.call(this, attribute, notFriendlyName, true);
       }
     }
-  }
-
-  // Rails only warns (never raises) when an enum element's auto-generated
-  // negative scope (`not*`) would clash with a positively-named element, and
-  // skips the check entirely when scopes are disabled.
-  // Mirrors: `detect_negative_enum_conditions!(value_method_names) if scopes`.
-  if (scopesEnabled) {
-    detectNegativeEnumConditionsBang(valueMethodNames);
-  }
-
-  // Rails generates the per-value methods inside `_enum_methods_module`
-  // (enum.rb:251); route trails' generation through the same module so
-  // `EnumMethods.defineEnumMethods` is the single generator.
-  const methodsModule = this._enumMethodsModule();
-  for (const [n, value] of Object.entries(mapping)) {
-    const fullName = toCamel(methodName(n));
-    const friendlyName = toCamel(methodName(n).replace(/[^\w\x80-\uffff]+/g, "_"));
 
     // Route the value method name — and, when it differs, its special-char
     // friendly alias — through the single generator, mirroring Rails' two
@@ -827,7 +814,7 @@ export function _enum(
       scopesEnabled,
       instanceMethodsEnabled,
     );
-    if (aliasedLabels.has(n)) {
+    if (aliasIsNew) {
       methodsModule.defineEnumMethods(
         attrName,
         friendlyName,
@@ -869,12 +856,21 @@ export function _enum(
       const names = enumMethodNamesFor(fullName);
       enumMethodNames.add(names.predicateName);
       enumMethodNames.add(names.bangName);
-      if (aliasedLabels.has(n)) {
+      if (aliasIsNew) {
         const friendlyNames = enumMethodNamesFor(friendlyName);
         enumMethodNames.add(friendlyNames.predicateName);
         enumMethodNames.add(friendlyNames.bangName);
       }
     }
+  }
+
+  // Rails only warns (never raises) when an enum element's auto-generated
+  // negative scope (`not*`) would clash with a positively-named element, and
+  // skips the check entirely when scopes are disabled.
+  // Mirrors: `detect_negative_enum_conditions!(value_method_names) if scopes`
+  // (enum.rb:262), after the generation loop.
+  if (scopesEnabled) {
+    detectNegativeEnumConditionsBang(valueMethodNames);
   }
 
   // Mirrors Rails:

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -2315,3 +2315,22 @@ describe("initialize_copy", () => {
     expect(d.initializeCopy(d)).toBe(d);
   });
 });
+
+describe("Date#inspect", () => {
+  it("spells a non-finite reform start Inf/-Inf, as mk_inspect's %.0f does", () => {
+    // ruby 3.3.11 -rdate:
+    //   Date.new(2001,2,3,Date::JULIAN).inspect
+    //     #=> "#<Date: 2001-02-03 ((2451957j,0s,0n),+0s,Infj)>"
+    //   Date.new(2001,2,3,Date::GREGORIAN).inspect
+    //     #=> "#<Date: 2001-02-03 ((2451944j,0s,0n),+0s,-Infj)>"
+    expect(new RubyDate(2001, 2, 3, RubyDate.JULIAN).inspect()).toBe(
+      "#<Date: 2001-02-03 ((2451957j,0s,0n),+0s,Infj)>",
+    );
+    expect(new RubyDate(2001, 2, 3, RubyDate.GREGORIAN).inspect()).toBe(
+      "#<Date: 2001-02-03 ((2451944j,0s,0n),+0s,-Infj)>",
+    );
+    expect(new RubyDate(2001, 2, 3).inspect()).toBe(
+      "#<Date: 2001-02-03 ((2451944j,0s,0n),+0s,2299161j)>",
+    );
+  });
+});

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -7468,7 +7468,12 @@ export class Date {
     return (
       `#<${this.constructor.name}: ${this.toS()} ` +
       `((${this.mRealJd()}j,${this.mDf()}s,${sf.denominator === 1n ? sf.numerator : sf.inspect()}n),` +
-      `${of < 0 ? "" : "+"}${of}s,${this.start.toFixed(0)}j)>`
+      `${of < 0 ? "" : "+"}${of}s,${
+        // `%.0f` over a non-finite double prints `inf`/`-inf` in C; MRI's
+        // capitalised spelling is what `Date::JULIAN` / `Date::GREGORIAN`
+        // inspect as. JS `toFixed` would answer "Infinity"/"-Infinity".
+        Number.isFinite(this.start) ? this.start.toFixed(0) : this.start > 0 ? "Inf" : "-Inf"
+      }j)>`
     );
   }
 

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -7461,6 +7461,11 @@ export class Date {
    * constructor `sf` is built through, folds a denominator of one where
    * `Rational()` and Rational arithmetic do not — so `denominator === 1n` is
    * that Integer arm — `0n`, not `(0/1)n`.
+   *
+   * The reform start goes through `%.0f`, which C spells `inf` / `-inf` for a
+   * non-finite double and MRI capitalises — `Date::JULIAN` inspects as `Infj`
+   * and `Date::GREGORIAN` as `-Infj`, where `toFixed` would answer
+   * `"Infinity"`.
    */
   inspect(): string {
     const of = this.mOf();
@@ -7469,9 +7474,6 @@ export class Date {
       `#<${this.constructor.name}: ${this.toS()} ` +
       `((${this.mRealJd()}j,${this.mDf()}s,${sf.denominator === 1n ? sf.numerator : sf.inspect()}n),` +
       `${of < 0 ? "" : "+"}${of}s,${
-        // `%.0f` over a non-finite double prints `inf`/`-inf` in C; MRI's
-        // capitalised spelling is what `Date::JULIAN` / `Date::GREGORIAN`
-        // inspect as. JS `toFixed` would answer "Infinity"/"-Infinity".
         Number.isFinite(this.start) ? this.start.toFixed(0) : this.start > 0 ? "Inf" : "-Inf"
       }j)>`
     );

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/request.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/request.json
@@ -24,13 +24,6 @@
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "GET",
-    "call": "new",
-    "reason": "Unported body, not a constructor idiom: Rails' `GET` (actionpack/lib/action_dispatch/http/request.rb:395-406) memoizes through `fetch_header`/`set_header`, builds params via `ActionDispatch::ParamBuilder.from_query_string` and re-raises `ActionController::BadRequest.new(...)`. The port (http/request.ts:896) is `return this.queryParameters` — none of that body is present. Not tracked by a story: actionpack is outside the project's stated focus (activerecord and its dependencies), which is why the convergence story filed for this row was closed as out of scope."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/request.ts",
-    "rubyName": "GET",
     "call": "set_header",
     "reason": "Rack header accessor (`get_header`/`set_header`/`fetch_header`/`has_header?`). trails' request/response objects expose headers as direct property/map access instead of the Rack accessor pair, so the accessor call name is absent by design. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
   },
@@ -61,13 +54,6 @@
     "rubyName": "POST",
     "call": "from_pairs",
     "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails request.rb:408-434 runs the body through parse_formatted_parameters/params_parsers and ParamBuilder.from_pairs/from_hash with encoding templates; trails request.ts:949-951 returns `this.requestParameters` — body parsing happens in that accessor without the encoding-template/ParamBuilder machinery (unported by design)."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/request.ts",
-    "rubyName": "POST",
-    "call": "new",
-    "reason": "Unported body, not a constructor idiom: Rails' `POST` (actionpack/lib/action_dispatch/http/request.rb:408-440) runs `parse_formatted_parameters` over `ParamBuilder.from_pairs`/`.from_hash` and re-raises `ActionController::BadRequest.new(...)`. The port (http/request.ts:901) is `return this.requestParameters` — none of that body is present. Not tracked by a story: actionpack is outside the project's stated focus (activerecord and its dependencies), which is why the convergence story filed for this row was closed as out of scope."
   },
   {
     "package": "actiondispatch",

--- a/scripts/api-compare/call-mismatches-exclude/actionview/helpers/text-helper.json
+++ b/scripts/api-compare/call-mismatches-exclude/actionview/helpers/text-helper.json
@@ -2,13 +2,6 @@
   {
     "package": "actionview",
     "tsFile": "helpers/text-helper.ts",
-    "rubyName": "cycle",
-    "call": "order:constructor,getCycle",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "actionview",
-    "tsFile": "helpers/text-helper.ts",
     "rubyName": "highlight",
     "call": "join",
     "kind": "args",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
@@ -58,13 +58,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
-    "rubyName": "check_constraints",
-    "call": "order:constructor,quotedScope",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "column_definitions",
     "call": "internal_exec_query",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-pool.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-pool.json
@@ -68,12 +68,5 @@
     "rubyName": "stat",
     "call": "count",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/connection-pool.ts",
-    "rubyName": "checkout",
-    "call": "order:includes,checkoutAndVerify",
-    "reason": "ORDER-only divergence, un-hidden (not introduced) by the raise-position `new` filter (RFC 0084 extractor-throw-new-constructor-credit-order): connection_pool.rb:551 makes the unpinned `checkout_and_verify` its guard clause, ahead of the pinned branch's `@connections.include?`; the port tests the pinned connection first."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-pool.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-pool.json
@@ -68,5 +68,12 @@
     "rubyName": "stat",
     "call": "count",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/connection-pool.ts",
+    "rubyName": "checkout",
+    "call": "order:includes,checkoutAndVerify",
+    "reason": "ORDER-only divergence, un-hidden (not introduced) by the raise-position `new` filter (RFC 0084 extractor-throw-new-constructor-credit-order): connection_pool.rb:551 makes the unpinned `checkout_and_verify` its guard clause, ahead of the pinned branch's `@connections.include?`; the port tests the pinned connection first."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/oid/range.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/oid/range.json
@@ -2,13 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql/oid/range.ts",
-    "rubyName": "cast_value",
-    "call": "order:constructor,sanitizeBounds",
-    "reason": "Order artifact of the raise idiom: Rails' `raise ArgumentError, msg` ports to `throw new Error(...)` (range.ts:109), whose `constructor` is credited before the ::Range.new(*sanitize_bounds(...)) at the end of the body."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/oid/range.ts",
     "rubyName": "extract_bounds",
     "call": "split",
     "reason": "Name-collision false positive (story relation-delegation-rails-named-methods): exposing the `delegate ... to: :records` set under Rails names made `split`/`reverse`/`rindex` recognized ported method names, so this unrelated call to String#split / Array#reverse / String#rindex on a non-Relation receiver is flagged by the name-based wide call-set check."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/core.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/core.json
@@ -44,13 +44,6 @@
   {
     "package": "activerecord",
     "tsFile": "core.ts",
-    "rubyName": "find",
-    "call": "order:constructor,unsupportedValue",
-    "reason": "Order artifact: the port constructs before it reaches StatementCache.unsupportedValue (core.ts:975), where Rails checks unsupported_value? before RecordNotFound.new."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "core.ts",
     "rubyName": "find_by",
     "call": "cached_find_by",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/enum.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/enum.json
@@ -59,7 +59,7 @@
     "package": "activerecord",
     "tsFile": "enum.ts",
     "rubyName": "_enum",
-    "call": "order:detectEnumConflictBang,constructor",
-    "reason": "ORDER-only divergence, un-hidden (not introduced) by the raise-position `new` filter (RFC 0084 extractor-throw-new-constructor-credit-order): the port runs its conflict detection before the value hash Rails builds first. Converge by restoring enum.rb:225-247's statement order."
+    "call": "order:detectNegativeEnumConditionsBang,defineEnumMethods",
+    "reason": "Un-masked (not introduced) by converging the `constructor` inversion ahead of it in the same body: enum.rb:249-262 detects and defines in ONE loop and runs detect_negative_enum_conditions! after it, where the port uses a conflict pass then a generation pass. Convergence has to preserve the enum.ts:663-676 `notActive` warn-not-raise invariant — tracked by 0084 converge-enum-two-pass-method-generation."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/enum.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/enum.json
@@ -54,12 +54,5 @@
     "rubyName": "serialize",
     "call": "fetch",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "enum.ts",
-    "rubyName": "_enum",
-    "call": "order:detectNegativeEnumConditionsBang,defineEnumMethods",
-    "reason": "Un-masked (not introduced) by converging the `constructor` inversion ahead of it in the same body: enum.rb:249-262 detects and defines in ONE loop and runs detect_negative_enum_conditions! after it, where the port uses a conflict pass then a generation pass. Convergence has to preserve the enum.ts:663-676 `notActive` warn-not-raise invariant — tracked by 0084 converge-enum-two-pass-method-generation."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/enum.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/enum.json
@@ -9,13 +9,6 @@
   {
     "package": "activerecord",
     "tsFile": "enum.ts",
-    "rubyName": "_enum",
-    "call": "order:constructor,assertValidEnumDefinitionValues",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "enum.ts",
     "rubyName": "_enum_methods_module",
     "call": "include",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -61,5 +54,12 @@
     "rubyName": "serialize",
     "call": "fetch",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "enum.ts",
+    "rubyName": "_enum",
+    "call": "order:detectEnumConflictBang,constructor",
+    "reason": "ORDER-only divergence, un-hidden (not introduced) by the raise-position `new` filter (RFC 0084 extractor-throw-new-constructor-credit-order): the port runs its conflict detection before the value hash Rails builds first. Converge by restoring enum.rb:225-247's statement order."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/insert-all.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/insert-all.json
@@ -9,13 +9,6 @@
   {
     "package": "activerecord",
     "tsFile": "insert-all.ts",
-    "rubyName": "find_unique_index_for",
-    "call": "order:constructor,primaryKey",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "insert-all.ts",
     "rubyName": "initialize",
     "call": "except",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/migration.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/migration.json
@@ -96,12 +96,5 @@
     "rubyName": "validate",
     "call": "find",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
-    "rubyName": "with_advisory_lock",
-    "call": "order:constructor,releaseAdvisoryLock",
-    "reason": "Ruby `raise ConcurrentMigrationError` names the class without constructing it (migration.rb:1604), so Rails' only `.new` is the RELEASE_LOCK_FAILED one after `release_advisory_lock`; TypeScript has no `throw SomeError` spelling, so the port's first `throw new` necessarily precedes it."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/schema-dumper.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/schema-dumper.json
@@ -131,12 +131,5 @@
     "rubyName": "table",
     "call": "valid_type?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "schema-dumper.ts",
-    "rubyName": "tables",
-    "call": "order:foreignKeys,constructor",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/scoping/named.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/scoping/named.json
@@ -19,12 +19,5 @@
     "rubyName": "scope",
     "call": "method_defined_within?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "scoping/named.ts",
-    "rubyName": "scope",
-    "call": "order:constructor,isDangerousClassMethod",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/enumerable-utils.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/enumerable-utils.json
@@ -2,13 +2,6 @@
   {
     "package": "activesupport",
     "tsFile": "enumerable-utils.ts",
-    "rubyName": "in?",
-    "call": "new",
-    "reason": "`new` here is `ArgumentError.new` in Rails' `rescue NoMethodError` arm (object/inclusion.rb:22). `isIn` type-switches on the collection instead of rescuing, so no argument can reach a receiver without `include?` and the arm has nothing to raise from."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "enumerable-utils.ts",
     "rubyName": "in_order_of",
     "call": "compact",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/hash-utils.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/hash-utils.json
@@ -9,13 +9,6 @@
   {
     "package": "activesupport",
     "tsFile": "hash-utils.ts",
-    "rubyName": "assert_valid_keys",
-    "call": "order:constructor,join",
-    "reason": "Order artifact of a TS-only `new Set(validKeys)` (hash-utils.ts:192), credited as `constructor` before the join Rails evaluates inside the ArgumentError.new message."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "hash-utils.ts",
     "rubyName": "deep_stringify_keys",
     "call": "deep_transform_keys",
     "kind": "args",

--- a/scripts/api-compare/call-mismatches-exclude/trailties/generators/generated-attribute.json
+++ b/scripts/api-compare/call-mismatches-exclude/trailties/generators/generated-attribute.json
@@ -1,9 +1,1 @@
-[
-  {
-    "package": "trailties",
-    "tsFile": "generators/generated-attribute.ts",
-    "rubyName": "parse",
-    "call": "order:constructor,reference",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  }
-]
+[]

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -1393,14 +1393,11 @@ function buildPackageReport(
   for (const rubyFile of rubyFileNames) coveredTsFiles.add(rubyFileToTs(rubyFile, pkg));
 
   // A reopened class is stamped with whichever reopening the extractor read
-  // first — `Date` with `core_ext/date/acts_like.rb`, never with
-  // `core_ext/date/conversions.rb` — so every other file that reopens it is
-  // absent from `rubyFiles` and its TS target falls into the
-  // `uncoveredTsFiles(...)` arm, scored against an EMPTY allowed set and tagged
-  // `[no Rails counterpart]`. The methods themselves ARE stamped per-file, so
-  // recover the file list from them: every `.rb` any method is declared in is a
-  // Rails counterpart, whether or not it also has a `RUBY_FILE_TS_OVERRIDES`
-  // row (the overrides are the subset of this population found by hand).
+  // first (`Date` with `core_ext/date/acts_like.rb`), so every other file that
+  // reopens it is absent from `rubyFiles` and its TS target falls into the
+  // `uncoveredTsFiles(...)` arm below — scored against an EMPTY allowed set.
+  // The methods ARE stamped per-file, so recover the file list from them; the
+  // `RUBY_FILE_TS_OVERRIDES` rows are the subset of it found by hand.
   const methodDeclarationFiles = new Set<string>();
   for (const info of [...Object.values(rubyPkg.classes), ...Object.values(rubyPkg.modules)]) {
     for (const m of [...info.instanceMethods, ...info.classMethods]) {

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -1392,7 +1392,22 @@ function buildPackageReport(
   const coveredTsFiles = new Set<string>();
   for (const rubyFile of rubyFileNames) coveredTsFiles.add(rubyFileToTs(rubyFile, pkg));
 
-  for (const rubyFile of overriddenRubyFiles(pkg)) {
+  // A reopened class is stamped with whichever reopening the extractor read
+  // first — `Date` with `core_ext/date/acts_like.rb`, never with
+  // `core_ext/date/conversions.rb` — so every other file that reopens it is
+  // absent from `rubyFiles` and its TS target falls into the
+  // `uncoveredTsFiles(...)` arm, scored against an EMPTY allowed set and tagged
+  // `[no Rails counterpart]`. The methods themselves ARE stamped per-file, so
+  // recover the file list from them: every `.rb` any method is declared in is a
+  // Rails counterpart, whether or not it also has a `RUBY_FILE_TS_OVERRIDES`
+  // row (the overrides are the subset of this population found by hand).
+  const methodDeclarationFiles = new Set<string>();
+  for (const info of [...Object.values(rubyPkg.classes), ...Object.values(rubyPkg.modules)]) {
+    for (const m of [...info.instanceMethods, ...info.classMethods]) {
+      if (m.file) methodDeclarationFiles.add(m.file);
+    }
+  }
+  for (const rubyFile of [...overriddenRubyFiles(pkg), ...[...methodDeclarationFiles].sort()]) {
     if (rubyFiles.has(rubyFile)) continue;
     const tsFile = rubyFileToTs(rubyFile, pkg);
     if (coveredTsFiles.has(tsFile)) continue;

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -2040,12 +2040,26 @@ class ApiExtractor
     { deps: deps, depRefs: dep_refs }
   end
 
+  # `raise Foo.new(msg)` and `raise Foo, msg` are the same raise written two
+  # ways, and the port spells BOTH `throw new Foo(msg)` — so the `new` is a
+  # position the two spellings disagree on. Evaluation order puts the
+  # argument's `new` immediately before the `raise` that consumes it, which is
+  # exactly this occurrence; drop it, as extract-ts-api.ts#isThrownConstruction
+  # drops the TS half. Any OTHER `new` in the body still counts, and the two
+  # extractors have to agree here or a raise pins `new` at the front of one
+  # sequence and nowhere in the other.
+  def drop_raised_new(calls)
+    calls.each_with_index.reject { |name, i| name == "new" && calls[i + 1] == "raise" }
+         .map(&:first)
+  end
+
   # Returns [calls, weak_calls]: the de-duplicated call names, and the subset
   # whose EVERY occurrence had an inert receiver (see walk_for_calls).
   def collect_method_calls(body_node)
     calls = []
     weak = []
     walk_for_calls(body_node, calls, weak)
+    calls = drop_raised_new(calls)
     total = calls.tally
     weak_calls = weak.tally.select { |name, n| total[name] == n }.keys
     [calls.uniq, weak_calls]

--- a/scripts/api-compare/extract-ruby-api.test.ts
+++ b/scripts/api-compare/extract-ruby-api.test.ts
@@ -320,6 +320,24 @@ describe("Ruby extractor inert-receiver call suppression", () => {
     expect(c["Qux#d"].calls).toContain("run");
   });
 
+  it("drops the new a raise builds its error with, keeping any other new", () => {
+    const c = rubyWeakCalls({
+      "raiser.rb": `
+        class Raiser
+          def f
+            raise ArgumentError.new("bad") unless ok?
+            Wrapper.new(build)
+          end
+        end
+      `,
+    });
+    // `raise Foo.new(msg)` and `raise Foo, msg` are one raise written two ways,
+    // and the port spells both `throw new Foo(msg)` — so the raise's own `new`
+    // carries no position (extract-ts-api.ts#isThrownConstruction drops the TS
+    // half). `Wrapper.new` still does, and lands after `ok?`.
+    expect(c["Raiser#f"].calls).toEqual(["ok?", "raise", "build", "new"]);
+  });
+
   it("drops new entirely when Proc is the only receiver", () => {
     const c = rubyWeakCalls({
       "quux.rb": `

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -260,7 +260,10 @@ describe("body call capture", () => {
 
   it("records `constructor` for an instantiation but not for a class reference", () => {
     // Shape from persistence.rb:949-955: `self.class.primary_key` first,
-    // `RecordNotDestroyed.new` last — the sequence must not invert.
+    // `RecordNotDestroyed.new` last. The instantiation is the operand of a
+    // `throw`, which Rails spells either `raise Foo, msg` (no `new` at all) or
+    // `raise Foo.new(msg)` — an ambiguous position both extractors drop from
+    // the ORDER stream, keeping it in the call SET.
     const cls = extractFromSource(
       `class Foo {
         raiseNotDestroyed() {
@@ -270,8 +273,24 @@ describe("body call capture", () => {
       }`,
     );
     const m = cls.instanceMethods.find((x) => x.name === "raiseNotDestroyed")!;
-    expect(m.callSeq).toEqual(["primaryKey", "name", "constructor"]);
+    expect(m.callSeq).toEqual(["primaryKey", "name"]);
+    expect(m.calls).toContain("constructor");
     expect(m.calls).not.toContain("class");
+  });
+
+  it("keeps a non-thrown instantiation's position in the sequence", () => {
+    // Only the `throw` operand is ambiguous: a plain `new` has one spelling in
+    // Ruby (`Foo.new`) and one position.
+    const cls = extractFromSource(
+      `class Foo {
+        build() {
+          const scope = this.scope();
+          return new Preloader(scope);
+        }
+      }`,
+    );
+    const m = cls.instanceMethods.find((x) => x.name === "build")!;
+    expect(m.callSeq).toEqual(["scope", "constructor"]);
   });
 
   it("records a callback argument after the call it is passed to, as Ruby records a block", () => {
@@ -345,7 +364,7 @@ describe("body call capture", () => {
       }`,
     );
     const create = cls.instanceMethods.find((m) => m.name === "create")!;
-    expect(create.callSeq).toEqual(["dirty", "constructor", "save", "rollback"]);
+    expect(create.callSeq).toEqual(["dirty", "save", "rollback"]);
     expect(create.skeleton).toEqual([
       "if",
       "ref:dirty",

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -2785,6 +2785,26 @@ function recordCallSite(
 }
 
 /**
+ * `throw new Foo(msg)` — the operand of a `throw`, which Rails spells EITHER
+ * `raise Foo, msg` (no `.new` call, and `raise` itself is filtered as noise on
+ * the Ruby side) or `raise Foo.new(msg)` (a `new` call in that position). The
+ * position is therefore ambiguous, exactly as a hoisted closure's calls are:
+ * the ORDER stream drops the name rather than picking a side, since a
+ * `throw` in an early guard would otherwise pin `constructor` at the front of
+ * the sequence — deduplicated at first occurrence — ahead of the real `X.new`
+ * the Rails body makes later, which is what the `order:constructor,…` rows
+ * #6404 baselined actually were. The call SET is unaffected: whichever way
+ * Rails spells the raise, an instantiation happens.
+ *
+ * Only the throw's own operand is ambiguous: a `new` nested inside one
+ * (`throw wrap(new Foo())`) has an unambiguous position.
+ */
+function isThrownConstruction(call: ts.NewExpression): boolean {
+  const parent = call.parent;
+  return parent !== undefined && ts.isThrowStatement(parent) && parent.expression === call;
+}
+
+/**
  * The site name, under the SAME filter extract-ruby-api.rb#call_site_name
  * applies (`:2385-2396`): a name starting with `_`, or with anything other than
  * a lowercase letter, is dropped. Ruby never emits such a site, so recording one
@@ -2951,7 +2971,7 @@ function collectCalls(
       // constructor arguments (`new Foo(typeCast(x))`) are credited regardless
       // of body shape.
       ts.forEachChild(n, visit);
-      names.add("constructor");
+      if (!(skipHoistedClosures && isThrownConstruction(n))) names.add("constructor");
       return;
     } else if (ts.isCallExpression(n)) {
       // Receiver, then the ARGUMENTS, then the call itself — Ruby's EVALUATION


### PR DESCRIPTION
Bundle of four RFC-tracked stories.

### 1. extra-surface scores a reopened Ruby file against an empty allowed set

`extra-surface.ts` built its scoring targets from `rubyFiles.keys()` — the files
the extractor *stamped* each entity with, which for a reopened class is
whichever reopening came first. `core_ext/date/acts_like.rb` stamps `class Date`,
so `core_ext/date/conversions.rb` never appeared and its TS target fell into the
`uncoveredTsFiles(...)` arm with `rubyFile: null`, scored against an empty
allowed set and tagged `[no Rails counterpart]`.

The methods themselves *are* stamped per-file, so the file list is recovered
from them. This generalises the existing `overriddenRubyFiles(pkg)` loop, whose
population (the hand-found `RUBY_FILE_TS_OVERRIDES` rows) is a subset of the
same thing. The story cited `date-ext.ts`, which has since been split into
`core-ext/date/{calculations,conversions}.ts`; the same defect was live on
`conversions.ts`, `core-ext/string/inflections.ts` and `actionpackversion`.

`activesupport` Total 1139 → 1134, NoCntrp 315 → 310; `actionpackversion` 2 → 0.
No package's Novel/Moved totals regress; the stale-tag gate stays green.

### 2. `throw new X()` credited as a constructor call ahead of the real one

Rails writes a raise two ways — `raise Foo, msg` (no `new` call at all) and
`raise Foo.new(msg)` (a `new` in that position) — and the port spells **both**
`throw new Foo(msg)`. The position is therefore ambiguous, exactly as a hoisted
closure's calls are, so both extractors now drop it from the **ORDER** stream
and keep it in the call **SET**:

- `extract-ts-api.ts#isThrownConstruction` — the operand of a `ThrowStatement`,
  applied only when `skipHoistedClosures` is on (the `callSeq` stream).
- `extract-ruby-api.rb#drop_raised_new` — the `new` immediately preceding the
  `raise` that consumes it, which evaluation order makes exactly this occurrence.

Dropping it on the TS side alone was measured first and cost 71 new
missing-call rows (every `raise Foo.new(...)` in Rails); the symmetric pair is
what converges.

**Rows retired (15, deleted by hand — only-shrink):** `http/request.ts GET/POST`,
`text-helper.ts cycle`, `abstract-mysql-adapter.ts check_constraints`,
`oid/range.ts cast_value`, `core.ts find`, `enum.ts _enum`,
`insert-all.ts find_unique_index_for`, `migration.ts with_advisory_lock`,
`schema-dumper.ts tables`, `scoping/named.ts scope`, `enumerable-utils.ts in?`,
`hash-utils.ts assert_valid_keys`, `testing/assertions.ts assert_nothing_raised`,
`generated-attribute.ts parse`.

**Rows added: none.** Two pre-existing order divergences the noise was masking
surfaced, and both are converged in the port rather than baselined:

- `ConnectionPool#checkout` takes Rails' guard clause — `return
  checkout_and_verify(acquire_connection(checkout_timeout)) unless
  @pinned_connection` (connection_pool.rb:551) — with the pinned branch after it.
- `_enum` builds the store the mapping lands in before the name guards
  (enum.rb:227) and registers it between them (enum.rb:231-236). Converging that
  un-masked the next inversion in the same body, so the conflict pass and the
  generation pass are merged into Rails' single loop (enum.rb:249-262), with
  `detect_negative_enum_conditions!` after it. `aliasedLabels`, the set that only
  existed to carry the alias decision between the two passes, is gone.

Net −14 rows against the current base (1672 → 1658).

Of the six rows the story attributed to this cause, three retire here
(`oid/range.ts cast_value`, `core.ts find`, `hash-utils.ts assert_valid_keys`)
and `nested-attributes.ts raise_nested_attributes_record_not_found!` is already
gone from the baseline. The remaining two —
`message-pack-message-serializer.ts hash_to_message` and `rack/logger.ts call` —
survive the re-measure, so their cause is not the throw credit but a genuinely
differently-ordered port body; they stay baselined for their own convergence.

The story's second item (`record.constructor` credited as an instantiation) is
already handled: `collectCalls` skips a `constructor` property read.

### 3. through-`create!` routed through `_create_record`

`CollectionProxy#createBang`'s `_isThrough` arm hand-rolled Rails'
`CollectionAssociation#_create_record` (collection_association.rb:354-372) —
build, save, then `_pushThrough(records, /* skipCallbacks */ true)` calling
`insertRecord` directly. Since #6407 moved the in-memory counter bump into
`#_create_record` (has_many_association.rb:143-149) that arm stopped bumping it,
and `insert_record`'s return value was discarded, so the
`raise ActiveRecord::Rollback unless result` guard (collection_association.rb:368)
was missing.

Rails has no through special case here: `CollectionProxy#create!` is
`@association.create!(...)` (collection_proxy.rb:319-321). **A sibling PR landed
that same delegation on `main` while this was in review**, so after the rebase
what remains from this PR is the other half: `_pushThrough`'s `skipCallbacks`
branch, now dead with no caller passing `true`, is deleted along with the
`_throughTransaction` helper that existed only to serve it. `_pushThrough` is
what it always should have been — `proxy_association.concat(records)`.

New cover in `through-push-routes-to-insert-record.trails.test.ts` for the
non-raising failure arm (`insert_record` returning `false` rolls the target row
back and `create!` still returns the record, as the swallowed `Rollback` does),
which pins the behaviour the delegation buys on either side of the rebase.
All 97 `associations/` files and both counter-cache suites are green.

### 4. `Date#inspect` spells a non-finite start `Inf` / `-Inf`

`mk_inspect` (`date_core.c:7032-7041`) renders the reform start with `%.0f`,
which C spells `inf` / `-inf` and MRI capitalises. `toFixed(0)` answers
`"Infinity"`. Verified against `ruby -rdate` on this machine:

```
#<Date: 2001-02-03 ((2451957j,0s,0n),+0s,Infj)>     # Date::JULIAN
#<Date: 2001-02-03 ((2451944j,0s,0n),+0s,-Infj)>    # Date::GREGORIAN
#<Date: 2001-02-03 ((2451944j,0s,0n),+0s,2299161j)> # finite, unchanged
```

Covered in `packages/date/src/date.trails.test.ts`. `this.constructor.name` is
left alone: changing it is a separate, wider question than this one spelling.

### Verification

`pnpm parity:api:calls`, `pnpm parity:api:calls:args`, `pnpm parity:api:extra`,
`pnpm lint`, `pnpm typecheck` green. `pnpm parity:test --package date` 124/137,
unchanged. `pnpm vitest run` over `scripts/api-compare`,
`packages/date/src`, `packages/activerecord/src/associations`, and the
counter-cache suites all pass.

Closes-story: extra-surface-scores-overridden-ruby-files
Closes-story: extractor-throw-new-constructor-credit-order
Closes-story: route-through-create-via-create-record
Closes-story: date-inspect-spells-infinite-start-as-inf
Closes-story: converge-enum-two-pass-method-generation
