### PR TITLE
refactor(activerecord,activesupport): fold the where merge into mergeClauses; converge four activesupport surfaces

### DIFF
--- a/packages/activerecord/dx-tests/tsconfig.json
+++ b/packages/activerecord/dx-tests/tsconfig.json
@@ -18,6 +18,9 @@
       "@blazetrails/activesupport/core-ext/date/calculations": [
         "../../activesupport/src/core-ext/date/calculations.ts"
       ],
+      "@blazetrails/activesupport/core-ext/hash/slice": [
+        "../../activesupport/src/core-ext/hash/slice.ts"
+      ],
       "@blazetrails/activesupport/core-ext/string/inflections": [
         "../../activesupport/src/core-ext/string/inflections.ts"
       ],

--- a/packages/activerecord/src/cases/helper.ts
+++ b/packages/activerecord/src/cases/helper.ts
@@ -178,10 +178,8 @@ export function writingPoolsLeakedSinceBaseline(): string[] {
   return leaked;
 }
 
-// Mirror `ActiveSupport::Testing::TimeHelpers#after_teardown`
-// (activesupport/lib/active_support/testing/time_helpers.rb:70-73), which Rails
-// gets on every test case through the `super` chain: travel is unwound after
-// each test whether or not the case remembered to call `travel_back`.
+// Mirror `ActiveSupport::Testing::TimeHelpers#after_teardown` (time_helpers.rb:70-73),
+// which Rails gets on every test case through the `super` chain.
 afterEach(() => {
   afterTeardown();
 });

--- a/packages/activerecord/src/cases/helper.ts
+++ b/packages/activerecord/src/cases/helper.ts
@@ -10,10 +10,16 @@
 // in activerecord/index.ts) to keep better-sqlite3 a true optional peer for
 // non-test consumers.
 import "../sqlite/better-sqlite3.js";
-import { afterAll, expect } from "vitest";
+import { afterAll, afterEach, expect } from "vitest";
 import { Base } from "../base.js";
 import { I18n } from "@blazetrails/activemodel";
-import { getZone, setZone, resetZone, isZoneExplicit } from "@blazetrails/activesupport";
+import {
+  afterTeardown,
+  getZone,
+  setZone,
+  resetZone,
+  isZoneExplicit,
+} from "@blazetrails/activesupport";
 import { DelegateCache } from "../relation/delegation.js";
 import { ActiveRecord } from "../ar-config.js";
 import { registerFakeAdapter } from "../support/fake-adapter.js";
@@ -171,6 +177,14 @@ export function writingPoolsLeakedSinceBaseline(): string[] {
   }
   return leaked;
 }
+
+// Mirror `ActiveSupport::Testing::TimeHelpers#after_teardown`
+// (activesupport/lib/active_support/testing/time_helpers.rb:70-73), which Rails
+// gets on every test case through the `super` chain: travel is unwound after
+// each test whether or not the case remembered to call `travel_back`.
+afterEach(() => {
+  afterTeardown();
+});
 
 afterAll(() => {
   expect(

--- a/packages/activerecord/src/cases/time-helpers-teardown.trails.test.ts
+++ b/packages/activerecord/src/cases/time-helpers-teardown.trails.test.ts
@@ -1,11 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { currentTime, travelTo } from "@blazetrails/activesupport";
 
-// Rails gets `TimeHelpers#after_teardown` (time_helpers.rb:70-73) on every test
-// case through the `super` chain, so travel is unwound after each test even
-// when the case never calls `travel_back`. trails wires it into the AR suite's
-// shared harness (cases/helper.ts); this file proves the wiring, which no
-// single-test assertion can.
+// Proves the `afterTeardown` wiring in cases/helper.ts, the helper.rb port —
+// `TimeHelpers#after_teardown` (time_helpers.rb:70-73) unwinds travel after
+// every test. No single-test assertion can cover it.
 describe("TimeHelpers after_teardown", () => {
   it("travels without unwinding", () => {
     travelTo(new Date(Date.UTC(2004, 10, 24, 1, 4, 44)));

--- a/packages/activerecord/src/cases/time-helpers-teardown.trails.test.ts
+++ b/packages/activerecord/src/cases/time-helpers-teardown.trails.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { currentTime, travelTo } from "@blazetrails/activesupport";
+
+// Rails gets `TimeHelpers#after_teardown` (time_helpers.rb:70-73) on every test
+// case through the `super` chain, so travel is unwound after each test even
+// when the case never calls `travel_back`. trails wires it into the AR suite's
+// shared harness (cases/helper.ts); this file proves the wiring, which no
+// single-test assertion can.
+describe("TimeHelpers after_teardown", () => {
+  it("travels without unwinding", () => {
+    travelTo(new Date(Date.UTC(2004, 10, 24, 1, 4, 44)));
+    expect(currentTime().getUTCFullYear()).toBe(2004);
+  });
+
+  it("has the travel unwound by after_teardown", () => {
+    expect(currentTime().getUTCFullYear()).toBeGreaterThan(2004);
+  });
+});

--- a/packages/activerecord/src/relation/merger.ts
+++ b/packages/activerecord/src/relation/merger.ts
@@ -37,7 +37,6 @@ export class Merger {
     const rel = this.relation;
     this.mergeUnscope(rel);
     this.mergeExtending(rel);
-    this.mergeWhereClause(rel);
     this.mergeSelectValues(rel);
     this.mergeMultiValues(rel);
     this.mergeSingleValues(rel);
@@ -75,12 +74,6 @@ export class Merger {
   private mergeExtending(rel: any): void {
     const extendingValues = this.other._extending ?? [];
     if (extendingValues.length > 0) rel.extendingBang(...extendingValues);
-  }
-
-  private mergeWhereClause(rel: any): void {
-    if (!this.other._whereClause.isEmpty()) {
-      rel._whereClause = rel._whereClause.merge(this.other._whereClause);
-    }
   }
 
   private mergeSelectValues(rel: any): void {
@@ -280,12 +273,15 @@ export class Merger {
   }
 
   private mergeClauses(rel: any): void {
-    if (!this.other._havingClause.isEmpty()) {
-      rel._havingClause = rel._havingClause.merge(this.other._havingClause);
-    }
     if (this.isReplaceFromClause() && this.other._fromClause) {
       rel._fromClause = this.other._fromClause;
     }
+
+    const whereClause = rel._whereClause.merge(this.other._whereClause);
+    if (!whereClause.isEmpty()) rel._whereClause = whereClause;
+
+    const havingClause = rel._havingClause.merge(this.other._havingClause);
+    if (!havingClause.isEmpty()) rel._havingClause = havingClause;
   }
 
   private isReplaceFromClause(): boolean {

--- a/packages/activerecord/src/relation/merger.ts
+++ b/packages/activerecord/src/relation/merger.ts
@@ -37,16 +37,18 @@ export class Merger {
     const rel = this.relation;
     this.mergeUnscope(rel);
     this.mergeExtending(rel);
+    this.mergeCtes(rel);
+    this.mergeEagerLoad(rel);
+
+    if (this.other._isNone) rel._isNone = true;
+
     this.mergeSelectValues(rel);
     this.mergeMultiValues(rel);
     this.mergeSingleValues(rel);
     this.mergeClauses(rel);
-    this.mergeCtes(rel);
-    this.mergeEagerLoad(rel);
     this.mergePreloads(rel);
     this.mergeJoins(rel);
     this.mergeOuterJoins(rel);
-    if (this.other._isNone) rel._isNone = true;
     return rel;
   }
 

--- a/packages/activerecord/virtualized-dx-tests/tsconfig.json
+++ b/packages/activerecord/virtualized-dx-tests/tsconfig.json
@@ -18,6 +18,9 @@
       "@blazetrails/activesupport/core-ext/date/calculations": [
         "../../activesupport/src/core-ext/date/calculations.ts"
       ],
+      "@blazetrails/activesupport/core-ext/hash/slice": [
+        "../../activesupport/src/core-ext/hash/slice.ts"
+      ],
       "@blazetrails/activesupport/core-ext/string/inflections": [
         "../../activesupport/src/core-ext/string/inflections.ts"
       ],

--- a/packages/activesupport/package.json
+++ b/packages/activesupport/package.json
@@ -66,6 +66,10 @@
       "types": "./dist/core-ext/date/calculations.d.ts",
       "default": "./dist/core-ext/date/calculations.js"
     },
+    "./core-ext/hash/slice": {
+      "types": "./dist/core-ext/hash/slice.d.ts",
+      "default": "./dist/core-ext/hash/slice.js"
+    },
     "./core-ext/range/conversions": {
       "types": "./dist/core-ext/range/conversions.d.ts",
       "default": "./dist/core-ext/range/conversions.js"

--- a/packages/activesupport/src/cache/behaviors/cache-instrumentation-behavior.ts
+++ b/packages/activesupport/src/cache/behaviors/cache-instrumentation-behavior.ts
@@ -25,7 +25,16 @@ export function cacheInstrumentationBehavior(host: CacheInstrumentationBehaviorH
   });
 
   function withInstrumentation(method: string, block: () => void): Event[] {
-    return Notifications.collectEvents(`cache_${method}.active_support`, block);
+    const eventName = `cache_${method}.active_support`;
+
+    const events: Event[] = [];
+    try {
+      Notifications.subscribe(eventName, (event) => events.push(event));
+      block();
+      return events;
+    } finally {
+      Notifications.unsubscribe(eventName);
+    }
   }
 
   function normalizedKey(key: string, options?: StoreOptions): string {

--- a/packages/activesupport/src/cache/store-instrumentation.trails.test.ts
+++ b/packages/activesupport/src/cache/store-instrumentation.trails.test.ts
@@ -17,7 +17,16 @@ describe("Cache::Store instrumentation", () => {
   });
 
   function withInstrumentation(operation: string, block: () => void): Event[] {
-    return Notifications.collectEvents(`cache_${operation}.active_support`, block);
+    const eventName = `cache_${operation}.active_support`;
+
+    const events: Event[] = [];
+    try {
+      Notifications.subscribe(eventName, (event) => events.push(event));
+      block();
+      return events;
+    } finally {
+      Notifications.unsubscribe(eventName);
+    }
   }
 
   const normalizedKey = (key: string, options?: StoreOptions): string =>

--- a/packages/activesupport/src/cache/stores/memory-store.test.ts
+++ b/packages/activesupport/src/cache/stores/memory-store.test.ts
@@ -9,6 +9,7 @@ import { cacheStoreCompressionBehavior } from "../behaviors/cache-store-compress
 import { cacheStoreSerializerBehavior } from "../behaviors/cache-store-serializer-behavior.js";
 import type { StoreOptions } from "../store.js";
 import { Entry } from "../entry.js";
+import type { Event } from "../../notifications/instrumenter.js";
 import { Notifications } from "../../notifications.js";
 
 // Mirrors Rails' `MemoryStore.new.send(:cached_size, 1, Entry.new("aaaaaaaaaa"))`
@@ -157,14 +158,19 @@ describe("MemoryStore delete_matched namespacing", () => {
 });
 
 describe("MemoryStore increment instrumentation", () => {
-  it("instruments with the raw, unnormalized name under a namespace", () => {
+  it("instruments with the raw, unnormalized name under a namespace", async () => {
     // Rails MemoryStore#increment passes `name` (not the normalized key) to
     // instrument (memory_store.rb:149); FileStore passes the normalized key.
     const store = new MemoryStore({ namespace: "ns" });
     store.write("counter", 0);
-    const events = Notifications.collectEvents("cache_increment.active_support", () => {
-      store.increment("counter");
-    });
+    const events: Event[] = [];
+    await Notifications.subscribed(
+      (event: Event) => events.push(event),
+      "cache_increment.active_support",
+      () => {
+        store.increment("counter");
+      },
+    );
     expect(events[0].payload.key).toBe("counter");
     expect(store.read("counter")).toBe(1);
   });

--- a/packages/activesupport/src/collections.test.ts
+++ b/packages/activesupport/src/collections.test.ts
@@ -283,6 +283,15 @@ describe("extractBang", () => {
     expect(extracted).toEqual({ a: null });
     expect(original).toEqual({ b: null });
   });
+
+  it("ignores inherited keys", () => {
+    const proto: Record<string, unknown> = { inherited: 1 };
+    const original: Record<string, unknown> = Object.create(proto);
+    original.a = 2;
+    const extracted = extractBang(original, "a", "inherited");
+    expect(extracted).toEqual({ a: 2 });
+    expect(proto.inherited).toBe(1);
+  });
 });
 
 describe("extractOptionsBang", () => {

--- a/packages/activesupport/src/collections.test.ts
+++ b/packages/activesupport/src/collections.test.ts
@@ -30,7 +30,7 @@ import {
   compactBlank,
   HashWithIndifferentAccess,
 } from "./index.js";
-import { extractBang } from "./hash-utils.js";
+import { extractBang } from "./core-ext/hash/slice.js";
 
 // ── Hash utilities ──────────────────────────────────────────────────
 

--- a/packages/activesupport/src/core-ext/hash-ext.test.ts
+++ b/packages/activesupport/src/core-ext/hash-ext.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { extractBang } from "./hash/slice.js";
 
 import {
   deepMerge,
@@ -12,7 +13,6 @@ import {
   assertValidKeys,
   slice,
   except,
-  extractBang,
 } from "../hash-utils.js";
 
 describe("HashExtTest", () => {

--- a/packages/activesupport/src/core-ext/hash/slice.ts
+++ b/packages/activesupport/src/core-ext/hash/slice.ts
@@ -1,0 +1,16 @@
+type AnyObject = Record<string, unknown>;
+
+/**
+ * Removes and returns the key/value pairs matching the given keys, mutating
+ * the receiver — Ruby's `Hash#extract!` (core_ext/hash/slice.rb:24-26).
+ */
+export function extractBang<T extends AnyObject>(obj: T, ...keys: string[]): Partial<T> {
+  const result: Partial<T> = {};
+  for (const key of keys) {
+    if (key in obj) {
+      result[key as keyof T] = obj[key as keyof T];
+      delete obj[key as keyof T];
+    }
+  }
+  return result;
+}

--- a/packages/activesupport/src/core-ext/hash/slice.ts
+++ b/packages/activesupport/src/core-ext/hash/slice.ts
@@ -7,7 +7,7 @@ type AnyObject = Record<string, unknown>;
 export function extractBang<T extends AnyObject>(obj: T, ...keys: string[]): Partial<T> {
   const result: Partial<T> = {};
   for (const key of keys) {
-    if (key in obj) {
+    if (Object.hasOwn(obj, key)) {
       result[key as keyof T] = obj[key as keyof T];
       delete obj[key as keyof T];
     }

--- a/packages/activesupport/src/deprecation/proxy-wrappers.test.ts
+++ b/packages/activesupport/src/deprecation/proxy-wrappers.test.ts
@@ -7,7 +7,7 @@ import {
 } from "./proxy-wrappers.js";
 import { extend, include, prepend } from "../include.js";
 import { registerConstant } from "../inflector.js";
-import { assertDeprecated } from "../testing/deprecation.js";
+import { assertDeprecated, assertNotDeprecated } from "../testing/deprecation.js";
 
 describe("ProxyWrappersTest", () => {
   const Waffles = false;
@@ -61,6 +61,18 @@ describe("ProxyWrappersTest", () => {
       prepend(klass, proxy as never);
     });
     expect(new klass().isWaffle()).toBe(true);
+  });
+
+  it("proxy delegates respond_to? and hash to target without warning", async () => {
+    const proxy = DeprecatedConstantProxy.new("OldWaffleModule", "WaffleModule", deprecator) as {
+      respondTo(method: string): boolean;
+      hash(): unknown;
+    };
+    await assertNotDeprecated(deprecator, () => {
+      expect(proxy.respondTo("isWaffle")).toBe(true);
+      expect(proxy.respondTo("isPancake")).toBe(false);
+      proxy.hash();
+    });
   });
 
   it("extending proxy module", async () => {

--- a/packages/activesupport/src/deprecation/proxy-wrappers.ts
+++ b/packages/activesupport/src/deprecation/proxy-wrappers.ts
@@ -200,16 +200,20 @@ export class DeprecatedConstantProxy extends Module {
     return (this.target as { name: string }).name;
   }
 
-  // Ruby's `Object#hash` and `Object#respond_to?` are universal; TypeScript has
-  // no such members, so each delegation calls the target's own port when it has
-  // one and answers from the object itself otherwise. Either way the probe is
-  // answered here rather than falling through to `methodMissing`, which is the
-  // whole point of Rails' delegate line.
+  /**
+   * Ruby's `Object#hash` is universal and TypeScript's is not, so the delegation
+   * calls the target's own port when it has one.
+   */
   hash(): unknown {
     const target = this.target as { hash?: () => unknown };
     return typeof target.hash === "function" ? target.hash() : undefined;
   }
 
+  /**
+   * Ruby's `Object#respond_to?` is universal and TypeScript's is not, so the
+   * delegation calls the target's own port when it has one and reads the object
+   * itself otherwise.
+   */
   respondTo(method: string): boolean {
     const target = this.target as { respondTo?: (m: string) => boolean };
     return typeof target.respondTo === "function"

--- a/packages/activesupport/src/deprecation/proxy-wrappers.ts
+++ b/packages/activesupport/src/deprecation/proxy-wrappers.ts
@@ -200,6 +200,23 @@ export class DeprecatedConstantProxy extends Module {
     return (this.target as { name: string }).name;
   }
 
+  // Ruby's `Object#hash` and `Object#respond_to?` are universal; TypeScript has
+  // no such members, so each delegation calls the target's own port when it has
+  // one and answers from the object itself otherwise. Either way the probe is
+  // answered here rather than falling through to `methodMissing`, which is the
+  // whole point of Rails' delegate line.
+  hash(): unknown {
+    const target = this.target as { hash?: () => unknown };
+    return typeof target.hash === "function" ? target.hash() : undefined;
+  }
+
+  respondTo(method: string): boolean {
+    const target = this.target as { respondTo?: (m: string) => boolean };
+    return typeof target.respondTo === "function"
+      ? target.respondTo(method)
+      : method in (target as object);
+  }
+
   /** Returns the class of the new constant. Mirrors: proxy_wrappers.rb:152-154. */
   class(): unknown {
     return (this.target as object).constructor;

--- a/packages/activesupport/src/hash-ext.test.ts
+++ b/packages/activesupport/src/hash-ext.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { extractBang } from "./core-ext/hash/slice.js";
 import {
   deepMerge,
   deepTransformKeys,
@@ -12,7 +13,6 @@ import {
   ArgumentError,
   slice,
   except,
-  extractBang,
   sliceBang,
   exceptBang,
   reverseMergeBang,

--- a/packages/activesupport/src/hash-utils.ts
+++ b/packages/activesupport/src/hash-utils.ts
@@ -464,21 +464,6 @@ export function deepTransformValues(obj: unknown, fn: (value: unknown) => unknow
   return fn(obj);
 }
 
-/**
- * Removes and returns the key/value pairs matching the given keys, mutating
- * the receiver — Ruby's `Hash#extract!` (core_ext/hash/slice.rb:24-26).
- */
-export function extractBang<T extends AnyObject>(obj: T, ...keys: string[]): Partial<T> {
-  const result: Partial<T> = {};
-  for (const key of keys) {
-    if (key in obj) {
-      result[key as keyof T] = obj[key as keyof T];
-      delete obj[key as keyof T];
-    }
-  }
-  return result;
-}
-
 export function isPlainObject(value: unknown): value is AnyObject {
   if (value === null || value === undefined) return false;
   if (typeof value !== "object") return false;

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -310,8 +310,9 @@ export {
   presenceIn,
 } from "./enumerable-utils.js";
 
-// Note: hash-utils' `extractBang` is intentionally kept off this flat index and
-// reached from "./hash-utils.js" directly. `Hash#extract!`
+// Note: `Hash#extract!` is intentionally kept off this flat index and reached
+// through the "./core-ext/hash/slice" subpath, which mirrors its Rails require
+// path (`active_support/core_ext/hash/slice`). `Hash#extract!`
 // (core_ext/hash/slice.rb:24-26) and `Array#extract!` (core_ext/array/extract.rb)
 // are distinct Ruby methods on distinct receivers, so they never collide there;
 // in a flat ESM namespace they do, and array-utils' `extractBang` owns the

--- a/packages/activesupport/src/messages/rotation-coordinator.ts
+++ b/packages/activesupport/src/messages/rotation-coordinator.ts
@@ -1,4 +1,5 @@
-import { extractBang, isPlainObject } from "../hash-utils.js";
+import { extractBang } from "../core-ext/hash/slice.js";
+import { isPlainObject } from "../hash-utils.js";
 import type { OnRotation } from "./rotator.js";
 // The `messages/` ports raise through the Ruby builtins declared in
 // serializer-with-fallback.ts; activesupport has no separate errors module, and

--- a/packages/activesupport/src/notifications.test.ts
+++ b/packages/activesupport/src/notifications.test.ts
@@ -149,18 +149,28 @@ describe("SubscribedTest", () => {
     expect(innerFired).toBe(true);
   });
 
-  it("timed subscribed", () => {
-    const events = Notifications.collectEvents("timed.subscribed", () => {
-      Notifications.instrument("timed.subscribed", { x: 1 });
-    });
+  it("timed subscribed", async () => {
+    const events: Event[] = [];
+    await Notifications.subscribed(
+      (event: Event) => events.push(event),
+      "timed.subscribed",
+      () => {
+        Notifications.instrument("timed.subscribed", { x: 1 });
+      },
+    );
     expect(events).toHaveLength(1);
     expect(events[0].duration).toBeGreaterThanOrEqual(0);
   });
 
-  it("monotonic timed subscribed", () => {
-    const events = Notifications.collectEvents("monotonic.timed.subscribed", () => {
-      Notifications.instrument("monotonic.timed.subscribed");
-    });
+  it("monotonic timed subscribed", async () => {
+    const events: Event[] = [];
+    await Notifications.subscribed(
+      (event: Event) => events.push(event),
+      "monotonic.timed.subscribed",
+      () => {
+        Notifications.instrument("monotonic.timed.subscribed");
+      },
+    );
     expect(events.length).toBeGreaterThanOrEqual(1);
   });
 });
@@ -514,29 +524,6 @@ describe("ActiveSupport::Notifications", () => {
       Notifications.publish("cache.miss", { key: "users/1" });
       expect(events).toHaveLength(1);
       expect(events[0].payload).toEqual({ key: "users/1" });
-    });
-  });
-
-  describe("collectEvents", () => {
-    it("returns all matching events fired during block", () => {
-      const events = Notifications.collectEvents("sql", () => {
-        Notifications.instrument("sql", { sql: "SELECT 1" });
-        Notifications.instrument("sql", { sql: "SELECT 2" });
-        Notifications.instrument("other");
-      });
-      expect(events).toHaveLength(2);
-      expect(events[0].payload.sql).toBe("SELECT 1");
-      expect(events[1].payload.sql).toBe("SELECT 2");
-    });
-
-    it("does not include events outside the block", () => {
-      Notifications.instrument("sql", { sql: "before" });
-      const events = Notifications.collectEvents("sql", () => {
-        Notifications.instrument("sql", { sql: "during" });
-      });
-      Notifications.instrument("sql", { sql: "after" });
-      expect(events).toHaveLength(1);
-      expect(events[0].payload.sql).toBe("during");
     });
   });
 

--- a/packages/activesupport/src/notifications.ts
+++ b/packages/activesupport/src/notifications.ts
@@ -193,7 +193,7 @@ export class Notifications {
   }
 
   /** Remove a previously registered subscriber. */
-  static unsubscribe(subscriberOrName: NotificationSubscriber): void {
+  static unsubscribe(subscriberOrName: NotificationSubscriber | string): void {
     this._notifier.unsubscribe(subscriberOrName as unknown as FanoutSubscriber);
   }
 
@@ -288,38 +288,5 @@ export class Notifications {
   /** Mirrors `ActiveSupport::Notifications.instrumenter`. */
   static get instrumenter(): NotificationInstrumenter {
     return this._boundInstrumenter;
-  }
-
-  // -------------------------------------------------------------------------
-  // Monitoring helpers
-  // -------------------------------------------------------------------------
-
-  /**
-   * Collect all events matching pattern during the block, then return them.
-   * Useful in tests — mirrors Rails' AS::Notifications test helpers.
-   */
-  static collectEvents(pattern: string | RegExp | null | undefined, block: () => void): Event[] {
-    const events: Event[] = [];
-    const sub = this.subscribe(pattern, (e) => events.push(e));
-    try {
-      block();
-    } finally {
-      this.unsubscribe(sub);
-    }
-    return events;
-  }
-
-  static async collectEventsAsync(
-    pattern: string | RegExp | null | undefined,
-    block: () => Promise<void>,
-  ): Promise<Event[]> {
-    const events: Event[] = [];
-    const sub = this.subscribe(pattern, (e) => events.push(e));
-    try {
-      await block();
-    } finally {
-      this.unsubscribe(sub);
-    }
-    return events;
   }
 }

--- a/packages/activesupport/src/testing/time-helpers.ts
+++ b/packages/activesupport/src/testing/time-helpers.ts
@@ -171,9 +171,7 @@ export function travelTo(
 
   let now: Temporal.Instant;
   if (typeof dateOrTime === "string") {
-    // Rails' String arm is `Time.zone.parse(date_or_time)`; without a zone set
-    // there is no `Time.zone` to parse through, so the ISO string is read
-    // directly.
+    // Without a `Time.zone` set there is no zone to parse through.
     const zone = getZone();
     now = zone ? zone.parse(dateOrTime).toTime() : Temporal.Instant.from(dateOrTime);
   } else if (dateOrTime instanceof Date) {

--- a/packages/activesupport/src/testing/time-helpers.ts
+++ b/packages/activesupport/src/testing/time-helpers.ts
@@ -4,7 +4,8 @@
 import { Temporal } from "@blazetrails/date";
 
 import { Duration } from "../duration.js";
-import { currentTimeInstant, setFrozenInstant } from "../time-travel.js";
+import { clock, currentTimeInstant } from "../time-travel.js";
+import { getZone } from "../time-zone-config.js";
 
 /** Mirrors Ruby's `RuntimeError` — what a bare `raise "message"` raises. */
 class RuntimeError extends Error {
@@ -86,20 +87,6 @@ export class SimpleStubs {
     (stub.object as Record<string, unknown>)[stub.methodName] = stub.originalMethod;
   }
 }
-
-/**
- * The seam the trails clock is stubbed through. Rails redefines `Time.now`,
- * `Time.new`, `Date.today` and `DateTime.now` as singleton methods; trails
- * production code reads the clock through `time-travel.ts`'s module state
- * (`currentTimeInstant`), which no singleton-method stub can reach, so the one
- * stubbed method is this holder's `now` and `stubObject`/`unstubAllBang` push
- * its value into that module state.
- */
-const clock = {
-  now(): Temporal.Instant {
-    return currentTimeInstant();
-  },
-};
 
 let _simpleStubs: SimpleStubs | undefined;
 let _inBlock = false;
@@ -184,7 +171,11 @@ export function travelTo(
 
   let now: Temporal.Instant;
   if (typeof dateOrTime === "string") {
-    now = Temporal.Instant.from(dateOrTime);
+    // Rails' String arm is `Time.zone.parse(date_or_time)`; without a zone set
+    // there is no `Time.zone` to parse through, so the ISO string is read
+    // directly.
+    const zone = getZone();
+    now = zone ? zone.parse(dateOrTime).toTime() : Temporal.Instant.from(dateOrTime);
   } else if (dateOrTime instanceof Date) {
     now = Temporal.Instant.fromEpochMilliseconds(dateOrTime.getTime());
   } else {
@@ -198,7 +189,6 @@ export function travelTo(
   const stubs = simpleStubs();
   const stubbedTime = stubs.stubbing(clock, "now") ? currentTimeInstant() : undefined;
   stubs.stubObject(clock, "now", () => now);
-  setFrozenInstant(now);
 
   if (block) {
     try {
@@ -227,7 +217,6 @@ export function travelBack(block?: () => void): void {
 
   try {
     simpleStubs().unstubAllBang();
-    setFrozenInstant(null);
     if (block) block();
   } finally {
     if (stubbedTime) travelTo(stubbedTime);
@@ -268,7 +257,7 @@ function setInBlock(value: boolean): void {
 
 /**
  * Returns the current time, honouring any active travel. Rails reads
- * `Time.now`; the trails clock seam is the module-level `clock` holder above.
+ * `Time.now`; the trails clock method is `time-travel.ts`'s `clock.now`.
  */
 function currentTime(): Date {
   return new Date(clock.now().epochMilliseconds);

--- a/packages/activesupport/src/time-travel.ts
+++ b/packages/activesupport/src/time-travel.ts
@@ -18,6 +18,28 @@ import { Temporal } from "@blazetrails/date";
 let _frozenInstant: Temporal.Instant | null = null;
 let _timeOffsetNs: bigint = 0n;
 
+/**
+ * The named clock method `travel_to` stubs. Rails redefines the `Time.now`,
+ * `Time.new`, `Date.today` and `DateTime.now` singleton methods, so production
+ * code reading any of them sees the traveled time; trails production code reads
+ * the clock through `currentTimeInstant()`, so this holder's `now` is the
+ * method that plays that role and `SimpleStubs` (testing/time-helpers.ts)
+ * replaces it exactly the way Rails replaces `Time.now`.
+ *
+ * @noRailsEquivalent Ruby's stub target is the `Time.now` singleton method
+ * itself; TypeScript's clock seam is this module, so the method that plays that
+ * role has to live here.
+ */
+export const clock = {
+  now(): Temporal.Instant {
+    if (_frozenInstant) return _frozenInstant;
+    if (_timeOffsetNs === 0n) return Temporal.Now.instant();
+    return Temporal.Instant.fromEpochNanoseconds(
+      Temporal.Now.instant().epochNanoseconds + _timeOffsetNs,
+    );
+  },
+};
+
 export function setFrozenTime(time: Date | null): void {
   if (time === null) {
     _frozenInstant = null;
@@ -49,11 +71,7 @@ export function setTimeOffsetNs(offsetNs: bigint): void {
  * offset paths.
  */
 export function currentTimeInstant(): Temporal.Instant {
-  if (_frozenInstant) return _frozenInstant;
-  if (_timeOffsetNs === 0n) return Temporal.Now.instant();
-  return Temporal.Instant.fromEpochNanoseconds(
-    Temporal.Now.instant().epochNanoseconds + _timeOffsetNs,
-  );
+  return clock.now();
 }
 
 /**

--- a/packages/activesupport/src/time-travel.ts
+++ b/packages/activesupport/src/time-travel.ts
@@ -26,9 +26,11 @@ let _timeOffsetNs: bigint = 0n;
  * method that plays that role and `SimpleStubs` (testing/time-helpers.ts)
  * replaces it exactly the way Rails replaces `Time.now`.
  *
- * @noRailsEquivalent Ruby's stub target is the `Time.now` singleton method
- * itself; TypeScript's clock seam is this module, so the method that plays that
- * role has to live here.
+ * @noRailsEquivalent CONVERGEABLE — Ruby's stub target is the `Time.now`
+ * singleton method itself. Routing the trails clock through
+ * `@blazetrails/date`'s `Time.now` / `Date.today` / `DateTime.now`, which would
+ * retire this holder, is
+ * `0098-activesupport-ar-closure-port/time-helpers-stub-date-and-datetime-clock`.
  */
 export const clock = {
   now(): Temporal.Instant {

--- a/packages/trailties/src/rack/logger.test.ts
+++ b/packages/trailties/src/rack/logger.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { Logger } from "./logger.js";
 import { Notifications } from "@blazetrails/activesupport";
+import type { NotificationEvent as Event } from "@blazetrails/activesupport";
 import type { RackApp, RackBody, RackResponse } from "@blazetrails/rack";
 
 const emptyBody = (): RackBody => ({
@@ -17,11 +18,16 @@ const closeBody = (body: RackBody): void => {
 
 describe("Rack::Logger", () => {
   it("notification", async () => {
-    const events = await Notifications.collectEventsAsync("request.action_dispatch", async () => {
-      const middleware = new Logger(okApp);
-      const [, , body] = await middleware.call({ REQUEST_METHOD: "GET" });
-      closeBody(body);
-    });
+    const events: Event[] = [];
+    await Notifications.subscribed(
+      (event: Event) => events.push(event),
+      "request.action_dispatch",
+      async () => {
+        const middleware = new Logger(okApp);
+        const [, , body] = await middleware.call({ REQUEST_METHOD: "GET" });
+        closeBody(body);
+      },
+    );
     expect(events).toHaveLength(1);
   });
 
@@ -31,23 +37,28 @@ describe("Rack::Logger", () => {
     };
     const popped: number[] = [];
     let captured: unknown;
-    const events = await Notifications.collectEventsAsync("request.action_dispatch", async () => {
-      const middleware = new Logger(failingApp, {
-        logger: {
-          pushTags: (...tags) => tags,
-          popTags: (n = 1) => {
-            popped.push(n);
-            return [];
+    const events: Event[] = [];
+    await Notifications.subscribed(
+      (event: Event) => events.push(event),
+      "request.action_dispatch",
+      async () => {
+        const middleware = new Logger(failingApp, {
+          logger: {
+            pushTags: (...tags) => tags,
+            popTags: (n = 1) => {
+              popped.push(n);
+              return [];
+            },
           },
-        },
-        taggers: ["t"],
-      });
-      try {
-        await middleware.call({ REQUEST_METHOD: "GET" });
-      } catch (e) {
-        captured = e;
-      }
-    });
+          taggers: ["t"],
+        });
+        try {
+          await middleware.call({ REQUEST_METHOD: "GET" });
+        } catch (e) {
+          captured = e;
+        }
+      },
+    );
     expect((captured as Error).message).toBe("boom");
     expect(events).toHaveLength(1);
     expect(popped).toEqual([1]);

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/testing/time-helpers.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/testing/time-helpers.json
@@ -4,20 +4,13 @@
     "tsFile": "testing/time-helpers.ts",
     "rubyName": "travel_to",
     "call": "at",
-    "reason": "`Time.at(now)` builds the stubbed Time; the trails clock seam takes a `Temporal.Instant` directly, so there is no `at` constructor to call."
+    "reason": "`Time.at(now)` builds the stubbed Time; the trails clock method takes a `Temporal.Instant` directly, so there is no `at` constructor to call."
   },
   {
     "package": "activesupport",
     "tsFile": "testing/time-helpers.ts",
     "rubyName": "travel_to",
-    "call": "parse",
-    "reason": "`Time.zone.parse` handles the String arm; `Temporal.Instant.from` parses the ISO string instead."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "testing/time-helpers.ts",
-    "rubyName": "travel_to",
-    "call": "to_time",
-    "reason": "`to_time` normalizes a Date/DateTime receiver to a Time; the TS arm converts a `Date` to a `Temporal.Instant` via `fromEpochMilliseconds`."
+    "call": "order:parse,toTime",
+    "reason": "Rails' first `to_time` is the Ruby Date arm's `date_or_time.midnight.to_time`; trails' Date arm takes a JS `Date` (a Ruby Time, not a Ruby Date), so the only `toTime` left is the one after `Time.zone.parse`, which inverts the pair's order."
   }
 ]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -113,6 +113,10 @@ const alias = {
     __dirname,
     "packages/activesupport/src/core-ext/date/calculations.ts",
   ),
+  "@blazetrails/activesupport/core-ext/hash/slice": path.resolve(
+    __dirname,
+    "packages/activesupport/src/core-ext/hash/slice.ts",
+  ),
   "@blazetrails/activesupport/core-ext/string/inflections": path.resolve(
     __dirname,
     "packages/activesupport/src/core-ext/string/inflections.ts",


### PR DESCRIPTION
Bundle of five convergence stories.

### `Merger#mergeClauses` (merger.rb:176-184)

`mergeClauses` did the having merge first, the from-clause replacement second,
and omitted the where merge entirely (it ran as a separate `mergeWhereClause`
step earlier in `merge`). It now does all three in Rails' order, with Rails'
guards: the merged clause is assigned unless the *merged* clause is empty (the
old code guarded on `other`'s clause being empty, a different predicate). The
`unscope` pass still runs first, so `merge(unscope(:where))` is unchanged;
`relation/merging` is green.

### `DeprecatedConstantProxy` (proxy_wrappers.rb:145)

`delegate :hash, :instance_methods, :name, :respond_to?, to: :target` — the
first and last were missing, so a `respond_to?`-shaped probe fell into
`method_missing` and emitted a spurious deprecation warning, the exact bug the
delegate line prevents. Both are answered from `target` now (regression test
fails on the pre-fix baseline). Ruby's `Object#hash` / `respond_to?` are
universal and TypeScript's are not, so each delegation calls the target's own
port when it has one; that branch is justified at the call site.

### `Hash#extract!` (core_ext/hash/slice.rb:24-26)

Moved out of the `hash-utils.ts` aggregate into `core-ext/hash/slice.ts` at its
Rails path and given a `./core-ext/hash/slice` subpath export, so an
out-of-package consumer can reach it. Registered in all four places: package
`exports`, the vitest alias, and both dx-test tsconfigs. `Array#extract!` still
owns `extractBang` on the flat index.

### `TimeHelpers` (time_helpers.rb:70-73, 160-190)

`travel_to` had two stub mechanisms: a module-local `clock` holder *and* a push
into `time-travel.ts`'s `setFrozenInstant`. The clock method now lives in
`time-travel.ts` and is what `currentTimeInstant()` reads, so `SimpleStubs` is
the single mechanism and stubs the method production code actually reads — the
role Rails' `Time.now` singleton plays. The String arm goes through
`Time.zone.parse`. `afterTeardown` is wired into `cases/helper.ts` (the
helper.rb port), so travel unwinds after every AR test the way Rails' `super`
chain guarantees; the new AR test proves the wiring across two tests.

Two of the three baseline rows are gone (`parse` converged, `to_time`
converged). Converging `to_time` surfaced an ordering row: Rails' *first*
`to_time` is the Ruby `Date` arm's `midnight.to_time`, and trails' Date arm
takes a JS `Date` (a Ruby `Time`, not a Ruby `Date`). That row and `at` are
carried with reviewed reasons and filed as
`0098/time-helpers-stub-date-and-datetime-clock`, together with the
`Date.today` / `DateTime.now` stub targets — making `@blazetrails/date`'s clock
travel-aware is a dependency-direction question of its own, not something to
bolt onto this PR.

### `Notifications.collectEvents` (notifications.rb:258)

`collect_events` does not exist in Rails. Deleted both it and
`collectEventsAsync` in favour of `Notifications.subscribed`, which was already
ported at Rails' signature, and restated
`cache-instrumentation-behavior.ts`'s `withInstrumentation` the way
cache_instrumentation_behavior.rb's private method writes it
(subscribe, yield, unsubscribe in the `ensure`). `parity:api:extra --package
activesupport` loses both names.

Closes-story: merge-clauses-where-clause-structure
Closes-story: deprecated-constant-proxy-delegates-hash-and-respond-to
Closes-story: hash-extract-bang-reachable-under-its-rails-subpath
Closes-story: time-helpers-stub-real-clock-methods
Closes-story: converge-notifications-collect-events-onto-subscribed
