### PR TITLE
refactor(activerecord,activesupport): this-typed module mixin receivers; Rails-named cache behavior helpers

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -813,7 +813,7 @@ export class Associations {
     // here so `validate: false` is observable (`treasure.valid?` must not
     // run child validations) regardless of an explicit `autosave:` option.
     const habtmReflection = Reflection._reflectOnAssociation(this as any, name);
-    if (habtmReflection) addAutosaveAssociationCallbacks(this, habtmReflection);
+    if (habtmReflection) addAutosaveAssociationCallbacks.call(this, habtmReflection);
   }
 }
 

--- a/packages/activerecord/src/associations/builder/belongs-to.ts
+++ b/packages/activerecord/src/associations/builder/belongs-to.ts
@@ -69,7 +69,7 @@ export class BelongsTo extends SingularAssociation {
     // gated on the `autosave` option. The option only steers behavior inside
     // save_belongs_to_association (validate flag, destroy of marked-for-
     // destruction targets, save of changed-but-persisted records).
-    addAutosaveAssociationCallbacks(model, reflection);
+    addAutosaveAssociationCallbacks.call(model, reflection);
   }
 
   static addCounterCacheCallbacks(model: any, reflection: any): void {

--- a/packages/activerecord/src/associations/builder/collection-association.ts
+++ b/packages/activerecord/src/associations/builder/collection-association.ts
@@ -35,7 +35,7 @@ export class CollectionAssociation extends Association {
     // association regardless of the `autosave:` option. The option only
     // gates extra behavior inside save_collection_association; insert-of-new
     // children must always propagate so failures surface on owner.save.
-    addAutosaveAssociationCallbacks(model, reflection);
+    addAutosaveAssociationCallbacks.call(model, reflection);
   }
 
   static override defineExtensions(model: any, name: string, block?: (...args: any[]) => any): any {

--- a/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
+++ b/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
@@ -227,7 +227,7 @@ export class HasAndBelongsToMany {
     const middleReflection = Reflection.create("hasMany", middleName, null, middleOptions, model);
     // Rails: `Builder::HasMany.define_callbacks self, middle_reflection`
     // (associations.rb:1878); AutosaveAssociation is one of its extensions.
-    addAutosaveAssociationCallbacks(model, middleReflection);
+    addAutosaveAssociationCallbacks.call(model, middleReflection);
     Reflection.addReflection(model, middleName, middleReflection as any);
 
     // Mirrors Rails associations.rb:1886-1894 — instead of registering a

--- a/packages/activerecord/src/associations/builder/has-one.ts
+++ b/packages/activerecord/src/associations/builder/has-one.ts
@@ -140,7 +140,7 @@ export class HasOne extends SingularAssociation {
     // persisted) before the after_create/after_update touch fires — mirrors
     // Rails, where has_one.rb's `define_callbacks` runs `super` (which wires
     // autosave) before `add_touch_callbacks`.
-    addAutosaveAssociationCallbacks(model, reflection);
+    addAutosaveAssociationCallbacks.call(model, reflection);
     if (options.touch) {
       this.addTouchCallbacks(model, reflection);
     }

--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -2701,7 +2701,7 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     registerModel("DuplicateCallbackProfileUser", DuplicateCallbackProfileUser);
     // Calling addAutosaveAssociationCallbacks a second time must not duplicate callbacks
     const reflection = (DuplicateCallbackProfileUser as any)._reflectOnAssociation("profile");
-    addAutosaveAssociationCallbacks(DuplicateCallbackProfileUser, reflection);
+    addAutosaveAssociationCallbacks.call(DuplicateCallbackProfileUser, reflection);
 
     const user = await DuplicateCallbackProfileUser.create({ name: "Test" });
     const profile = new Profile({ name: "Hello" });
@@ -2743,7 +2743,7 @@ describe("TestAutosaveAssociationsInGeneral", () => {
       className: "DuplicateCallbacksBelongsToAuthor",
     });
     const reflection = (Post as any)._reflectOnAssociation("author");
-    addAutosaveAssociationCallbacks(Post, reflection);
+    addAutosaveAssociationCallbacks.call(Post, reflection);
 
     const author = new Author({ name: "New" });
     const post = await Post.create({ name: "Test" });
@@ -2784,7 +2784,7 @@ describe("TestAutosaveAssociationsInGeneral", () => {
       className: "DuplicateCallbacksHasManyBook",
     });
     const reflection = (Author as any)._reflectOnAssociation("books");
-    addAutosaveAssociationCallbacks(Author, reflection);
+    addAutosaveAssociationCallbacks.call(Author, reflection);
 
     const author = await Author.create({ name: "Test" });
     const book = new Book({ name: "My Book" });
@@ -2828,7 +2828,7 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     // Calling addAutosaveAssociationCallbacks a second time must not duplicate callbacks
     const reflection = (DupCbPirate as any)._reflectOnAssociation("parrots");
     expect(reflection).toBeDefined();
-    addAutosaveAssociationCallbacks(DupCbPirate, reflection);
+    addAutosaveAssociationCallbacks.call(DupCbPirate, reflection);
 
     const pirate = await DupCbPirate.create({ catchphrase: "Arrr" });
     const parrot = await DupCbParrot.create({ name: "Polly" });
@@ -2878,7 +2878,7 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     // Wire _ensureNoDuplicateErrors as after_validation on ShipCyclic (mirrors Rails'
     // AssociationBuilderExtension.build → add_autosave_association_callbacks).
     const prisonersRef = ShipCyclic.reflectOnAssociation("prisoners");
-    addAutosaveAssociationCallbacks(ShipCyclic, prisonersRef);
+    addAutosaveAssociationCallbacks.call(ShipCyclic, prisonersRef);
 
     const ship = new ShipCyclic({ name: "" });
     const prisoner = new PrisonerCyclic({});

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -11,7 +11,6 @@ import { NestedError as AssociationsNestedError } from "./associations/nested-er
 import { associationInstanceGet, type AssociationDefinition } from "./associations.js";
 import { hasQueryConstraints, queryConstraintsList } from "./persistence.js";
 import { throwAbort, underscore } from "@blazetrails/activesupport";
-import { afterCreate, afterUpdate, beforeSave } from "./callbacks.js";
 
 const MARKED_FOR_DESTRUCTION = Symbol.for("blazetrails.markedForDestruction");
 const VALIDATING_BELONGS_TO_FOR = Symbol.for("blazetrails.validatingBelongsToFor");
@@ -817,6 +816,10 @@ export function _ensureNoDuplicateErrors(this: AutosaveAssociationHost): void {
 /** @internal */
 export function defineNonCyclicMethod(this: any, name: string, fn: (this: any) => any): void {
   const klass = this;
+  // Rails passes a Symbol here and `define_method` names the method after it;
+  // a Ruby Symbol is a colon-prefixed string in trails, so drop the colon to
+  // get the method name.
+  if (name.startsWith(":")) name = name.slice(1);
   if (!klass.prototype) return;
   // Mirrors Ruby method_defined?(name, false) — check only the immediate class prototype.
   if (Object.prototype.hasOwnProperty.call(klass.prototype, name)) return;
@@ -867,13 +870,8 @@ export function defineNonCyclicMethod(this: any, name: string, fn: (this: any) =
  *
  * @internal
  */
-export function addAutosaveAssociationCallbacks(model: any, reflection: any): void {
-  const saveMethod = `autosaveAssociatedRecordsFor_${reflection.name}`;
-  // Mirrors Rails' `define_non_cyclic_method` early-return: if the method is
-  // already defined on the model's own prototype, all callbacks for this
-  // association are already registered — calling again would duplicate the
-  // after_create/after_update/before_save lambdas.
-  if (Object.prototype.hasOwnProperty.call(model.prototype ?? {}, saveMethod)) return;
+export function addAutosaveAssociationCallbacks(this: any, reflection: any): void {
+  const saveMethod = `:autosaveAssociatedRecordsFor_${reflection.name}`;
   const isCollection: boolean =
     typeof reflection.isCollection === "function"
       ? reflection.isCollection()
@@ -888,22 +886,18 @@ export function addAutosaveAssociationCallbacks(model: any, reflection: any): vo
       : reflection.hasOne === true || reflection.macro === "hasOne" || reflection.type === "hasOne";
 
   if (isCollection) {
-    model.aroundSave(":aroundSaveCollectionAssociation");
-    defineNonCyclicMethod.call(model, saveMethod, async function (this: any) {
+    this.aroundSave(":aroundSaveCollectionAssociation");
+    defineNonCyclicMethod.call(this, saveMethod, async function (this: any) {
       return saveCollectionAssociation.call(this, reflection);
     });
     // Doesn't use after_save as that would save associations added in
     // after_create/after_update twice (autosave_association.rb:196-198). The
     // registration is unconditional: the `autosave != false` decision lives
     // INSIDE `save_collection_association` (autosave_association.rb:429-431).
-    afterCreate(model, async (record: any) => {
-      await record[saveMethod]();
-    });
-    afterUpdate(model, async (record: any) => {
-      await record[saveMethod]();
-    });
+    this.afterCreate(saveMethod);
+    this.afterUpdate(saveMethod);
   } else if (isHasOne) {
-    defineNonCyclicMethod.call(model, saveMethod, async function (this: any) {
+    defineNonCyclicMethod.call(this, saveMethod, async function (this: any) {
       return saveHasOneAssociation.call(this, reflection);
     });
     // Mirrors Rails: `save_has_one_association` is registered for after_create
@@ -914,12 +908,8 @@ export function addAutosaveAssociationCallbacks(model: any, reflection: any): vo
     // unconditionally keeps a nil/true-autosave NEW/changed child's persistence
     // in-save (via the `_record_changed?` → `new_record?` leg) rather than
     // deferring it to the post-commit `flushPendingReplaces` net.
-    afterCreate(model, async (record: any) => {
-      await record[saveMethod]();
-    });
-    afterUpdate(model, async (record: any) => {
-      await record[saveMethod]();
-    });
+    this.afterCreate(saveMethod);
+    this.afterUpdate(saveMethod);
   } else {
     // belongs_to
     // Mirrors autosave_association.rb:213 — the `== false` check and the
@@ -927,15 +917,15 @@ export function addAutosaveAssociationCallbacks(model: any, reflection: any): vo
     // takes the bare method reference. `Promise.resolve` covers the re-entrant
     // branch of `defineNonCyclicMethod`, which returns a sync `true` to mirror
     // Rails' cyclic-guard early return.
-    defineNonCyclicMethod.call(model, saveMethod, async function (this: any) {
+    defineNonCyclicMethod.call(this, saveMethod, async function (this: any) {
       if ((await Promise.resolve(saveBelongsToAssociation.call(this, reflection))) === false) {
         throwAbort();
       }
     });
-    beforeSave(model, (record: any) => record[saveMethod]());
+    this.beforeSave(saveMethod);
   }
 
-  defineAutosaveValidationCallbacks.call(model, reflection);
+  defineAutosaveValidationCallbacks.call(this, reflection);
 }
 
 /** @internal */

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2210,7 +2210,8 @@ export class Base extends Model {
       const r = new (_relationCtorFor(this))(this);
       return wrapWithScopeProxy(r);
     };
-    const rel = DefaultScoping.buildDefaultScope(this, buildBase, { allQueries }) ?? buildBase();
+    const rel =
+      DefaultScoping.buildDefaultScope.call(this, buildBase(), { allQueries }) ?? buildBase();
     return this._applyStiTypeCondition(rel);
   }
 
@@ -4106,7 +4107,11 @@ export class Base extends Model {
     signedId: string,
     options?: { purpose?: string },
   ): Promise<InstanceType<T> | null> {
-    return _findSigned(this, signedId, options);
+    return _findSigned.call<
+      T,
+      [string, { purpose?: string } | undefined],
+      Promise<InstanceType<T> | null>
+    >(this, signedId, options);
   }
 
   /**
@@ -4120,7 +4125,11 @@ export class Base extends Model {
     signedId: string,
     options?: { purpose?: string },
   ): Promise<InstanceType<T>> {
-    return _findSignedBang(this, signedId, options);
+    return _findSignedBang.call<
+      T,
+      [string, { purpose?: string } | undefined],
+      Promise<InstanceType<T>>
+    >(this, signedId, options);
   }
 
   /**
@@ -4313,7 +4322,7 @@ export class Base extends Model {
    * Mirrors: ActiveRecord::TokenFor#generate_token_for (token_for.rb:118).
    */
   generateTokenFor(purpose: string): string {
-    return _generateTokenFor(this, purpose);
+    return _generateTokenFor.call(this, purpose);
   }
 }
 

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
@@ -366,7 +366,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries::RelationQuerie
       whereValuesHash: () => ({ email: [avCurrent, avPrev] }),
     };
 
-    const result = RelationQueries.scopeForCreate(() => ({}), relation);
+    const result = RelationQueries.scopeForCreate.call(relation, () => ({}));
     // scope_for_create keeps the AV reference so serialize unwraps to
     // ciphertext on save without re-encrypting (our cast->toString
     // path would otherwise double-encrypt a plaintext-unwrapped value).
@@ -381,7 +381,9 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries::RelationQuerie
     };
     const relation = { model, whereValuesHash: () => ({}) };
 
-    const result = RelationQueries.scopeForCreate(() => ({ email: "plain@example.com" }), relation);
+    const result = RelationQueries.scopeForCreate.call(relation, () => ({
+      email: "plain@example.com",
+    }));
     expect(result.email).toBe("plain@example.com");
   });
 
@@ -394,7 +396,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries::RelationQuerie
     };
     const relation = { model, whereValuesHash: () => ({ body: [av] }) };
 
-    const result = RelationQueries.scopeForCreate(() => ({}), relation);
+    const result = RelationQueries.scopeForCreate.call(relation, () => ({}));
     expect(result.body).toBeUndefined();
   });
 
@@ -408,7 +410,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries::RelationQuerie
       model,
       whereValuesHash: () => ({ email: "plain@example.com" }),
     };
-    const result = RelationQueries.scopeForCreate(() => ({}), relation);
+    const result = RelationQueries.scopeForCreate.call(relation, () => ({}));
     expect(result.email).toBeUndefined();
   });
 
@@ -449,7 +451,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries::RelationQuerie
     expect((hash.email as unknown[])[0]).toBeInstanceOf(AdditionalValue);
     expect((hash.email as AdditionalValue[])[0].value).toBe(avCurrent.value);
 
-    const scope = RelationQueries.scopeForCreate(() => ({}), rel);
+    const scope = RelationQueries.scopeForCreate.call(rel, () => ({}));
     expect(scope.email).toBeInstanceOf(AdditionalValue);
     expect((scope.email as AdditionalValue).value).toBe(avCurrent.value);
   });

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.ts
@@ -219,14 +219,12 @@ export class RelationQueries {
     this: any,
     originalScopeForCreate: (...args: any[]) => unknown,
   ): Record<string, unknown> {
-    const relation = this;
-    const model = relation.model ?? relation;
+    const model = this.model ?? this;
     const encryptedAttrs = model._encryptedAttributes as Set<string> | undefined;
-    if (!encryptedAttrs?.size)
-      return originalScopeForCreate.call(relation) as Record<string, unknown>;
+    if (!encryptedAttrs?.size) return originalScopeForCreate.call(this) as Record<string, unknown>;
 
-    const scopeAttrs = originalScopeForCreate.call(relation) as Record<string, unknown>;
-    const wheres = relation.whereValuesHash();
+    const scopeAttrs = originalScopeForCreate.call(this) as Record<string, unknown>;
+    const wheres = this.whereValuesHash();
     for (const attrName of encryptedAttrs) {
       const type = encryptedTypeOf(getAttributeType(model, attrName));
       if (!type?.deterministic) continue;

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.ts
@@ -77,18 +77,18 @@ export class ExtendedDeterministicQueries {
 
     prepend(relProto, {
       where(super_, ...args) {
-        return RelationQueries.where(super_ as (...args: any[]) => unknown, this, args);
+        return RelationQueries.where.call(this, super_ as (...args: any[]) => unknown, args);
       },
       exists(super_, ...args) {
-        return RelationQueries.isExists(super_ as (...args: any[]) => unknown, this, args);
+        return RelationQueries.isExists.call(this, super_ as (...args: any[]) => unknown, args);
       },
       scopeForCreate(super_) {
-        return RelationQueries.scopeForCreate(super_ as (...args: any[]) => unknown, this);
+        return RelationQueries.scopeForCreate.call(this, super_ as (...args: any[]) => unknown);
       },
     });
     prepend(baseTarget, {
       findBy(super_, ...args) {
-        return CoreQueries.findBy(super_ as (...args: any[]) => unknown, this, args);
+        return CoreQueries.findBy.call(this, super_ as (...args: any[]) => unknown, args);
       },
     });
     prepend(eatProto, {
@@ -203,26 +203,23 @@ export class EncryptedQuery {
  * Mirrors: ActiveRecord::Encryption::ExtendedDeterministicQueries::RelationQueries
  */
 export class RelationQueries {
-  static where(
-    originalWhere: (...args: any[]) => unknown,
-    relation: any,
-    args: unknown[],
-  ): unknown {
-    return originalWhere.call(relation, ...EncryptedQuery.processArguments(relation, args, true));
+  static where(this: any, originalWhere: (...args: any[]) => unknown, args: unknown[]): unknown {
+    return originalWhere.call(this, ...EncryptedQuery.processArguments(this, args, true));
   }
 
   static isExists(
+    this: any,
     originalExists: (...args: any[]) => unknown,
-    relation: any,
     args: unknown[],
   ): unknown {
-    return originalExists.call(relation, ...EncryptedQuery.processArguments(relation, args, true));
+    return originalExists.call(this, ...EncryptedQuery.processArguments(this, args, true));
   }
 
   static scopeForCreate(
+    this: any,
     originalScopeForCreate: (...args: any[]) => unknown,
-    relation: any,
   ): Record<string, unknown> {
+    const relation = this;
     const model = relation.model ?? relation;
     const encryptedAttrs = model._encryptedAttributes as Set<string> | undefined;
     if (!encryptedAttrs?.size)
@@ -259,8 +256,8 @@ export class RelationQueries {
  * Mirrors: ActiveRecord::Encryption::ExtendedDeterministicQueries::CoreQueries
  */
 export class CoreQueries {
-  static findBy(originalFindBy: (...args: any[]) => unknown, klass: any, args: unknown[]): unknown {
-    return originalFindBy.call(klass, ...EncryptedQuery.processArguments(klass, args, false));
+  static findBy(this: any, originalFindBy: (...args: any[]) => unknown, args: unknown[]): unknown {
+    return originalFindBy.call(this, ...EncryptedQuery.processArguments(this, args, false));
   }
 }
 

--- a/packages/activerecord/src/scoping/default.ts
+++ b/packages/activerecord/src/scoping/default.ts
@@ -35,46 +35,45 @@ export class Default {
    * @internal
    */
   static buildDefaultScope(
-    modelClass: any,
-    buildRelation: () => any,
+    this: any,
+    relation: any,
     { allQueries }: { allQueries?: boolean | null } = {},
   ): any {
-    if (modelClass.abstractClass) return undefined;
+    if (this.abstractClass) return undefined;
 
     // Rails default.rb:145-152 — memoize the `default_scope_override` boolean on
     // first build (the class_attribute starts nil): does this class own a
     // `default_scope` method override rather than only inheriting the macro?
     // Written through the class-attribute setter (`self.default_scope_override = `).
-    if (modelClass.defaultScopeOverride == null) {
-      modelClass.defaultScopeOverride = hasDefaultScopeOverride(modelClass);
+    if (this.defaultScopeOverride == null) {
+      this.defaultScopeOverride = hasDefaultScopeOverride(this);
     }
 
     // Rails: when the model defines its own `default_scope` method (the
     // proc/method form, `def self.default_scope`) rather than registering via
     // the `default_scope { }` macro, call that method with the base relation
     // installed as the current scope (`relation.scoping { default_scope }`).
-    const override = modelClass.defaultScopeOverride ? defaultScopeMethod(modelClass) : undefined;
+    const override = this.defaultScopeOverride ? defaultScopeMethod(this) : undefined;
     if (override) {
-      return evaluateDefaultScope.call(modelClass, () => {
-        const base = buildRelation();
-        const prev = ScopeRegistry.currentScope(modelClass);
-        modelClass.setCurrentScope(base);
+      return evaluateDefaultScope.call(this, () => {
+        const prev = ScopeRegistry.currentScope(this);
+        this.setCurrentScope(relation);
         try {
           // Return the override's value unchanged (nullish included), mirroring
           // Rails' `relation.scoping { default_scope }`; the `|| scope` fallback
           // lives at the call site (`?? buildBase()` / `?? rel`).
-          return override.call(modelClass);
+          return override.call(this);
         } finally {
-          modelClass.setCurrentScope(prev);
+          this.setCurrentScope(prev);
         }
       });
     }
 
-    const scopes: DefaultScope[] = modelClass.defaultScopes ?? [];
+    const scopes: DefaultScope[] = this.defaultScopes ?? [];
     if (scopes.length === 0) return undefined;
 
-    return evaluateDefaultScope.call(modelClass, () => {
-      let rel = buildRelation();
+    return evaluateDefaultScope.call(this, () => {
+      let rel = relation;
       for (const scopeObj of scopes) {
         if (isExecuteScope(allQueries, scopeObj)) {
           const result = scopeObj.scope(rel);

--- a/packages/activerecord/src/scoping/named.ts
+++ b/packages/activerecord/src/scoping/named.ts
@@ -183,10 +183,9 @@ export function defaultScoped(
   // Relation instance.
   const kwargsOnly =
     scopeOrOptions != null && Object.getPrototypeOf(scopeOrOptions) === Object.prototype;
-  const scope = kwargsOnly ? undefined : scopeOrOptions;
+  const scope = (kwargsOnly ? undefined : scopeOrOptions) ?? this._buildUnscopedRelation?.();
   const opts = kwargsOnly ? (scopeOrOptions as { allQueries?: boolean | null }) : options;
-  const rel = scope ?? this._buildUnscopedRelation?.();
-  return Default.buildDefaultScope(this as any, () => rel, { allQueries: opts?.allQueries }) ?? rel;
+  return Default.buildDefaultScope.call(this, scope, { allQueries: opts?.allQueries }) ?? scope;
 }
 
 /**

--- a/packages/activerecord/src/signed-id.ts
+++ b/packages/activerecord/src/signed-id.ts
@@ -103,17 +103,17 @@ export function signedId(
  * Mirrors: ActiveRecord::SignedId::ClassMethods#find_signed
  */
 export async function findSigned<T extends typeof Base>(
-  modelClass: T,
+  this: T,
   signedId: string,
   options?: { purpose?: string },
 ): Promise<InstanceType<T> | null> {
-  const pk = modelClass.primaryKey;
+  const pk = this.primaryKey;
   if (!_hasPrimaryKey(pk)) {
-    throw new UnknownPrimaryKey(modelClass);
+    throw new UnknownPrimaryKey(this);
   }
-  const verifier = modelClass.signedIdVerifier;
+  const verifier = this.signedIdVerifier;
   const id = verifier.verified(signedId, {
-    purpose: modelClass.combineSignedIdPurposes(options?.purpose) || undefined,
+    purpose: this.combineSignedIdPurposes(options?.purpose) || undefined,
   });
   if (id === null) return null;
   if (Array.isArray(pk)) {
@@ -121,9 +121,9 @@ export async function findSigned<T extends typeof Base>(
     pk.forEach((col, i) => {
       conditions[col] = (id as unknown[])[i];
     });
-    return modelClass.findBy(conditions);
+    return this.findBy(conditions);
   }
-  return modelClass.findBy({ [pk]: id });
+  return this.findBy({ [pk]: id });
 }
 
 /**
@@ -133,15 +133,15 @@ export async function findSigned<T extends typeof Base>(
  * Mirrors: ActiveRecord::SignedId::ClassMethods#find_signed!
  */
 export async function findSignedBang<T extends typeof Base>(
-  modelClass: T,
+  this: T,
   signedId: string,
   options?: { purpose?: string },
 ): Promise<InstanceType<T>> {
-  const verifier = modelClass.signedIdVerifier;
+  const verifier = this.signedIdVerifier;
   const id = verifier.verify(signedId, {
-    purpose: modelClass.combineSignedIdPurposes(options?.purpose) || undefined,
+    purpose: this.combineSignedIdPurposes(options?.purpose) || undefined,
   });
-  return modelClass.find(id);
+  return this.find(id);
 }
 
 /**

--- a/packages/activerecord/src/token-for.ts
+++ b/packages/activerecord/src/token-for.ts
@@ -303,8 +303,8 @@ export function generatesTokenFor(
  *
  * Mirrors: ActiveRecord::TokenFor#generate_token_for
  */
-export function generateTokenFor(record: Base, purpose: string): string {
-  return (record.constructor as typeof Base).tokenDefinitions.fetch(purpose).generateToken(record);
+export function generateTokenFor(this: Base, purpose: string): string {
+  return (this.constructor as typeof Base).tokenDefinitions.fetch(purpose).generateToken(this);
 }
 
 /**

--- a/packages/activesupport/src/cache/behaviors/cache-delete-matched-behavior.ts
+++ b/packages/activesupport/src/cache/behaviors/cache-delete-matched-behavior.ts
@@ -1,0 +1,29 @@
+import { expect, it } from "vitest";
+import type { Store, StoreOptions } from "../store.js";
+
+// Mirrors Rails `CacheDeleteMatchedBehavior`
+// (activesupport/test/cache/behaviors/cache_delete_matched_behavior.rb).
+// Ruby's `include CacheDeleteMatchedBehavior` is spelled here as a function
+// the store test file calls inside its own describe, which is the trails
+// spelling of a test-behavior mixin.
+
+/** @internal */
+export interface CacheDeleteMatchedBehaviorHost {
+  lookupStore(options?: StoreOptions): Store;
+}
+
+/** @internal */
+export function cacheDeleteMatchedBehavior(host: CacheDeleteMatchedBehaviorHost): void {
+  it("delete matched", () => {
+    const cache = host.lookupStore();
+    cache.write("foo", "bar");
+    cache.write("fu", "baz");
+    cache.write("foo/bar", "baz");
+    cache.write("fu/baz", "bar");
+    cache.deleteMatched(/oo/);
+    expect(cache.exist("foo")).toBe(false);
+    expect(cache.exist("fu")).toBe(true);
+    expect(cache.exist("foo/bar")).toBe(false);
+    expect(cache.exist("fu/baz")).toBe(true);
+  });
+}

--- a/packages/activesupport/src/cache/behaviors/cache-increment-decrement-behavior.ts
+++ b/packages/activesupport/src/cache/behaviors/cache-increment-decrement-behavior.ts
@@ -1,0 +1,73 @@
+import { expect, it } from "vitest";
+import type { Store, StoreOptions } from "../store.js";
+
+// Mirrors Rails `CacheIncrementDecrementBehavior`
+// (activesupport/test/cache/behaviors/cache_increment_decrement_behavior.rb).
+// Ruby's `include CacheIncrementDecrementBehavior` is spelled here as a
+// function the store test file calls inside its own describe, which is the
+// trails spelling of a test-behavior mixin.
+
+// Ruby seeds each test with `SecureRandom.uuid` / `SecureRandom.alphanumeric`
+// so the keys can't collide across a shared backend; SecureRandom is not
+// ported, and `cache_store_serializer_behavior` already spells this as a
+// random suffix.
+function uniqueKey(): string {
+  return `key${Math.random()}`;
+}
+
+/** @internal */
+export interface CacheIncrementDecrementBehaviorHost {
+  lookupStore(options?: StoreOptions): Store;
+}
+
+/** @internal */
+export function cacheIncrementDecrementBehavior(host: CacheIncrementDecrementBehaviorHost): void {
+  it("increment", () => {
+    const cache = host.lookupStore();
+    const key = uniqueKey();
+    cache.write(key, 1, { raw: true });
+    expect(Number(cache.read(key, { raw: true }))).toBe(1);
+    expect(cache.increment(key)).toBe(2);
+    expect(Number(cache.read(key, { raw: true }))).toBe(2);
+    expect(cache.increment(key)).toBe(3);
+    expect(Number(cache.read(key, { raw: true }))).toBe(3);
+
+    let missing = cache.increment(uniqueKey());
+    expect(missing).toBe(1);
+    missing = cache.increment(uniqueKey(), 100);
+    expect(missing).toBe(100);
+  });
+
+  it("decrement", () => {
+    const cache = host.lookupStore();
+    const key = uniqueKey();
+    cache.write(key, 3, { raw: true });
+    expect(Number(cache.read(key, { raw: true }))).toBe(3);
+    expect(cache.decrement(key)).toBe(2);
+    expect(Number(cache.read(key, { raw: true }))).toBe(2);
+    expect(cache.decrement(key)).toBe(1);
+    expect(Number(cache.read(key, { raw: true }))).toBe(1);
+
+    // Ruby branches on `@cache.is_a?(ActiveSupport::Cache::MemCacheStore)`;
+    // MemCacheStore is not ported, so only the non-MemCacheStore arm exists.
+    let missing = cache.decrement(uniqueKey());
+    expect(missing).toBe(-1);
+    missing = cache.decrement(uniqueKey(), 100);
+    expect(missing).toBe(-100);
+  });
+
+  it("ttl isnt updated", async () => {
+    const cache = host.lookupStore();
+    const key = uniqueKey();
+
+    expect(cache.increment(key, 1, { expiresIn: 0.1 })).toBe(1);
+    expect(cache.increment(key, 1, { expiresIn: 5000 })).toBe(2);
+
+    // Ruby sleeps 2s because it covers backends without subsecond TTL
+    // granularity; every ported store expires on a float clock, so the
+    // 0.1s TTL above only needs to elapse.
+    await new Promise((r) => setTimeout(r, 150));
+
+    expect(cache.read(key, { raw: true })).toBeNull();
+  });
+}

--- a/packages/activesupport/src/cache/behaviors/cache-store-coder-behavior.ts
+++ b/packages/activesupport/src/cache/behaviors/cache-store-coder-behavior.ts
@@ -1,0 +1,141 @@
+import { expect, it } from "vitest";
+import { Entry } from "../entry.js";
+import { coder } from "../coder.js";
+import type { Store, StoreOptions } from "../store.js";
+
+// Mirrors Rails `CacheStoreCoderBehavior`
+// (activesupport/test/cache/behaviors/cache_store_coder_behavior.rb).
+// Ruby's `include CacheStoreCoderBehavior` is spelled here as a function the
+// store test file calls inside its own describe, which is the trails spelling
+// of a test-behavior mixin.
+
+// Ruby names `Marshal` directly; trails' equivalent is the fidelity coder
+// (cache/coder.ts), so a dumped entry is its packed members.
+class SpyCoder {
+  dumpedEntries: Entry[] = [];
+  loadedEntries: Entry[] = [];
+  dumpCompressedEntries: Entry[] = [];
+
+  dump(entry: Entry): string {
+    this.dumpedEntries.push(entry);
+    return coder.dump(entry.pack());
+  }
+
+  load(payload: string): Entry {
+    const entry = Entry.unpack(coder.load(payload) as unknown[]);
+    this.loadedEntries.push(entry);
+    return entry;
+  }
+
+  dumpCompressed(entry: Entry, threshold: number): string {
+    if (threshold === 0) {
+      this.dumpCompressedEntries.push(entry);
+      return coder.dump(entry.pack());
+    } else {
+      return this.dump(entry);
+    }
+  }
+}
+
+// Rails calls the private `serialize_entry` through `send`
+// (cache_store_coder_behavior.rb:90).
+function serializeEntry(store: Store, entry: Entry): unknown {
+  return (store as unknown as { serializeEntry(entry: Entry): unknown }).serializeEntry(entry);
+}
+
+/** @internal */
+export interface CacheStoreCoderBehaviorHost {
+  lookupStore(options?: StoreOptions): Store;
+}
+
+/** @internal */
+export function cacheStoreCoderBehavior(host: CacheStoreCoderBehaviorHost): void {
+  it("coder receive the entry on write", () => {
+    const coder = new SpyCoder();
+    const store = host.lookupStore({ coder });
+    store.write("foo", "bar");
+    expect(coder.dumpedEntries.length).toBe(1);
+    const entry = coder.dumpedEntries[0];
+    expect(entry).toBeInstanceOf(Entry);
+    expect(entry.value).toBe("bar");
+  });
+
+  it("coder receive the entry on read", () => {
+    const coder = new SpyCoder();
+    const store = host.lookupStore({ coder });
+    store.write("foo", "bar");
+    store.read("foo");
+    expect(coder.loadedEntries.length).toBe(1);
+    const entry = coder.loadedEntries[0];
+    expect(entry).toBeInstanceOf(Entry);
+    expect(entry.value).toBe("bar");
+  });
+
+  it("coder receive the entry on read multi", () => {
+    const coder = new SpyCoder();
+    const store = host.lookupStore({ coder });
+    store.writeMulti({ foo: "bar", egg: "spam" });
+    store.readMulti("foo", "egg");
+    expect(coder.loadedEntries.length).toBe(2);
+    let entry = coder.loadedEntries[0];
+    expect(entry).toBeInstanceOf(Entry);
+    expect(entry.value).toBe("bar");
+
+    entry = coder.loadedEntries[1];
+    expect(entry).toBeInstanceOf(Entry);
+    expect(entry.value).toBe("spam");
+  });
+
+  it("coder receive the entry on write multi", () => {
+    const coder = new SpyCoder();
+    const store = host.lookupStore({ coder });
+    store.writeMulti({ foo: "bar", egg: "spam" });
+    expect(coder.dumpedEntries.length).toBe(2);
+    let entry = coder.dumpedEntries[0];
+    expect(entry).toBeInstanceOf(Entry);
+    expect(entry.value).toBe("bar");
+
+    entry = coder.dumpedEntries[1];
+    expect(entry).toBeInstanceOf(Entry);
+    expect(entry.value).toBe("spam");
+  });
+
+  it("coder does not receive the entry on read miss", () => {
+    const coder = new SpyCoder();
+    const store = host.lookupStore({ coder });
+    store.read("foo");
+    expect(coder.loadedEntries.length).toBe(0);
+  });
+
+  it("nil coder bypasses serialization", () => {
+    const store = host.lookupStore({ coder: null });
+    const entry = new Entry("value");
+    expect(serializeEntry(store, entry)).toBe(entry);
+  });
+
+  it("coder is used during handle expired entry when expired", async () => {
+    const coder = new SpyCoder();
+    const store = host.lookupStore({ coder });
+    // Ruby writes a 1-second entry and `travel_to(2.seconds.from_now)`; there
+    // is no time-travel helper here, so the entry expires on the real clock.
+    store.write("foo", "bar", { expiresIn: 0.05 });
+    expect(coder.loadedEntries.length).toBe(0);
+    expect(coder.dumpedEntries.length).toBe(1);
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    const val = store.fetch(
+      "foo",
+      { raceConditionTtl: 5, compress: true, compressThreshold: 0 },
+      () => "baz",
+    );
+    expect(val).toBe("baz");
+    expect(coder.loadedEntries.length).toBe(1); // 1 read in fetch
+    expect(coder.loadedEntries[0].value).toBe("bar");
+    expect(coder.dumpedEntries.length).toBe(1); // did not change from original write
+    // 1 write the expired entry handler, 1 in fetch
+    expect(coder.dumpCompressedEntries.length).toBe(2);
+    expect(coder.dumpCompressedEntries[0].value).toBe("bar");
+    expect(coder.dumpCompressedEntries[coder.dumpCompressedEntries.length - 1].value).toBe("baz");
+  });
+}

--- a/packages/activesupport/src/cache/stores/file-store.test.ts
+++ b/packages/activesupport/src/cache/stores/file-store.test.ts
@@ -5,6 +5,9 @@ import { dirname, join } from "node:path";
 import { FileStore } from "../file-store.js";
 import { cacheInstrumentationBehavior } from "../behaviors/cache-instrumentation-behavior.js";
 import { cacheStoreBehavior } from "../behaviors/cache-store-behavior.js";
+import { cacheDeleteMatchedBehavior } from "../behaviors/cache-delete-matched-behavior.js";
+import { cacheIncrementDecrementBehavior } from "../behaviors/cache-increment-decrement-behavior.js";
+import { cacheStoreCoderBehavior } from "../behaviors/cache-store-coder-behavior.js";
 import { cacheStoreCompressionBehavior } from "../behaviors/cache-store-compression-behavior.js";
 import { cacheStoreSerializerBehavior } from "../behaviors/cache-store-serializer-behavior.js";
 import type { StoreOptions } from "../store.js";
@@ -171,6 +174,11 @@ describe("FileStoreTest", () => {
   // Mirrors `include CacheStoreBehavior` (file_store_test.rb:32).
   cacheStoreBehavior({ lookupStore: (options?: StoreOptions) => new FileStore(cacheDir, options) });
 
+  // Mirrors `include CacheStoreCoderBehavior` (file_store_test.rb:34).
+  cacheStoreCoderBehavior({
+    lookupStore: (options?: StoreOptions) => new FileStore(cacheDir, options),
+  });
+
   // Mirrors `include CacheStoreCompressionBehavior` (file_store_test.rb:35).
   cacheStoreCompressionBehavior({
     lookupStore: (options?: StoreOptions) => new FileStore(cacheDir, options),
@@ -178,6 +186,16 @@ describe("FileStoreTest", () => {
 
   // Mirrors `include CacheStoreSerializerBehavior` (file_store_test.rb:36).
   cacheStoreSerializerBehavior({
+    lookupStore: (options?: StoreOptions) => new FileStore(cacheDir, options),
+  });
+
+  // Mirrors `include CacheDeleteMatchedBehavior` (file_store_test.rb:38).
+  cacheDeleteMatchedBehavior({
+    lookupStore: (options?: StoreOptions) => new FileStore(cacheDir, options),
+  });
+
+  // Mirrors `include CacheIncrementDecrementBehavior` (file_store_test.rb:39).
+  cacheIncrementDecrementBehavior({
     lookupStore: (options?: StoreOptions) => new FileStore(cacheDir, options),
   });
 
@@ -231,7 +249,7 @@ describe("FileStore coder fidelity", () => {
   });
 });
 
-describe("CacheIncrementDecrementBehavior", () => {
+describe("FileStore increment/decrement amount coercion", () => {
   let cacheDir: string;
   let cache: FileStore;
 
@@ -244,32 +262,6 @@ describe("CacheIncrementDecrementBehavior", () => {
     try {
       rmSync(cacheDir, { recursive: true, force: true });
     } catch {}
-  });
-
-  it("test_increment", () => {
-    cache.write("foo", 1, { raw: true });
-    expect(Number(cache.read("foo"))).toBe(1);
-    expect(cache.increment("foo")).toBe(2);
-    expect(Number(cache.read("foo"))).toBe(2);
-    expect(cache.increment("foo")).toBe(3);
-    expect(Number(cache.read("foo"))).toBe(3);
-
-    // Rails: a missing key is created set to `amount` (file_store.rb:230-231).
-    expect(cache.increment("bar")).toBe(1);
-    expect(cache.increment("baz", 100)).toBe(100);
-  });
-
-  it("test_decrement", () => {
-    cache.write("foo", 3, { raw: true });
-    expect(Number(cache.read("foo"))).toBe(3);
-    expect(cache.decrement("foo")).toBe(2);
-    expect(Number(cache.read("foo"))).toBe(2);
-    expect(cache.decrement("foo")).toBe(1);
-    expect(Number(cache.read("foo"))).toBe(1);
-
-    // Non-MemCacheStore backends return -amount on a missing key.
-    expect(cache.decrement("qux")).toBe(-1);
-    expect(cache.decrement("quux", 100)).toBe(-100);
   });
 
   // Rails coerces `amount = Integer(amount)` (file_store.rb:226), which raises
@@ -294,13 +286,5 @@ describe("CacheIncrementDecrementBehavior", () => {
     expect(Number(cache.read("frac"))).toBe(1);
     expect(cache.increment("frac", 2.9)).toBe(3);
     expect(Number(cache.read("frac"))).toBe(3);
-  });
-
-  it("test_ttl_isnt_updated", async () => {
-    expect(cache.increment("foo", 1, { expiresIn: 0.1 })).toBe(1);
-    // A second increment with a longer TTL must not reset the original expiry.
-    expect(cache.increment("foo", 1, { expiresIn: 5000 })).toBe(2);
-    await new Promise((r) => setTimeout(r, 150));
-    expect(cache.read("foo")).toBeNull();
   });
 });

--- a/packages/activesupport/src/cache/stores/memory-store.test.ts
+++ b/packages/activesupport/src/cache/stores/memory-store.test.ts
@@ -2,17 +2,14 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { MemoryStore } from "../memory-store.js";
 import { cacheInstrumentationBehavior } from "../behaviors/cache-instrumentation-behavior.js";
 import { cacheStoreBehavior } from "../behaviors/cache-store-behavior.js";
+import { cacheDeleteMatchedBehavior } from "../behaviors/cache-delete-matched-behavior.js";
+import { cacheIncrementDecrementBehavior } from "../behaviors/cache-increment-decrement-behavior.js";
+import { cacheStoreCoderBehavior } from "../behaviors/cache-store-coder-behavior.js";
 import { cacheStoreCompressionBehavior } from "../behaviors/cache-store-compression-behavior.js";
 import { cacheStoreSerializerBehavior } from "../behaviors/cache-store-serializer-behavior.js";
 import type { StoreOptions } from "../store.js";
 import { Entry } from "../entry.js";
-import { coder } from "../coder.js";
 import { Notifications } from "../../notifications.js";
-
-// Rails calls the private `serialize_entry` through `send` (cache_store_coder_behavior.rb:90).
-function serializeEntry(store: MemoryStore, entry: Entry): unknown {
-  return (store as unknown as { serializeEntry(entry: Entry): unknown }).serializeEntry(entry);
-}
 
 // Mirrors Rails' `MemoryStore.new.send(:cached_size, 1, Entry.new("aaaaaaaaaa"))`
 // (memory_store_test.rb:101-104), the record size the pruning budget is sized in.
@@ -78,6 +75,9 @@ describe("MemoryStoreTest", () => {
   // Mirrors `include CacheStoreBehavior` (memory_store_test.rb:16).
   cacheStoreBehavior({ lookupStore: (options?: StoreOptions) => new MemoryStore(options) });
 
+  // Mirrors `include CacheStoreCoderBehavior` (memory_store_test.rb:18).
+  cacheStoreCoderBehavior({ lookupStore: (options?: StoreOptions) => new MemoryStore(options) });
+
   // Mirrors `include CacheStoreCompressionBehavior` (memory_store_test.rb:19);
   // MemoryStore overrides `compression_always_disabled_by_default?`
   // (memory_store_test.rb:93-96).
@@ -91,6 +91,14 @@ describe("MemoryStoreTest", () => {
     lookupStore: (options?: StoreOptions) => new MemoryStore(options),
   });
 
+  // Mirrors `include CacheDeleteMatchedBehavior` (memory_store_test.rb:21).
+  cacheDeleteMatchedBehavior({ lookupStore: (options?: StoreOptions) => new MemoryStore(options) });
+
+  // Mirrors `include CacheIncrementDecrementBehavior` (memory_store_test.rb:22).
+  cacheIncrementDecrementBehavior({
+    lookupStore: (options?: StoreOptions) => new MemoryStore(options),
+  });
+
   // Mirrors `include CacheInstrumentationBehavior` (memory_store_test.rb:23).
   cacheInstrumentationBehavior({
     lookupStore: (options?: StoreOptions) => new MemoryStore(options),
@@ -98,37 +106,11 @@ describe("MemoryStoreTest", () => {
   });
 });
 
-describe("CacheIncrementDecrementBehavior", () => {
+describe("MemoryStore increment/decrement amount coercion", () => {
   let cache: MemoryStore;
 
   beforeEach(() => {
     cache = new MemoryStore();
-  });
-
-  it("test_increment", () => {
-    cache.write("foo", 1, { raw: true });
-    expect(Number(cache.read("foo"))).toBe(1);
-    expect(cache.increment("foo")).toBe(2);
-    expect(Number(cache.read("foo"))).toBe(2);
-    expect(cache.increment("foo")).toBe(3);
-    expect(Number(cache.read("foo"))).toBe(3);
-
-    // Rails: a missing key is created set to `amount` (memory_store.rb:136).
-    expect(cache.increment("bar")).toBe(1);
-    expect(cache.increment("baz", 100)).toBe(100);
-  });
-
-  it("test_decrement", () => {
-    cache.write("foo", 3, { raw: true });
-    expect(Number(cache.read("foo"))).toBe(3);
-    expect(cache.decrement("foo")).toBe(2);
-    expect(Number(cache.read("foo"))).toBe(2);
-    expect(cache.decrement("foo")).toBe(1);
-    expect(Number(cache.read("foo"))).toBe(1);
-
-    // Non-MemCacheStore backends return -amount on a missing key.
-    expect(cache.decrement("qux")).toBe(-1);
-    expect(cache.decrement("quux", 100)).toBe(-100);
   });
 
   // The seed path writes `Integer(amount)` (memory_store.rb:248), which raises
@@ -159,30 +141,9 @@ describe("CacheIncrementDecrementBehavior", () => {
     cache.write("frac", 1, { raw: true });
     expect(cache.increment("frac", 2.5)).toBe(3.5);
   });
-
-  it("test_ttl_isnt_updated", async () => {
-    expect(cache.increment("foo", 1, { expiresIn: 0.1 })).toBe(1);
-    // A second increment with a longer TTL must not reset the original expiry.
-    expect(cache.increment("foo", 1, { expiresIn: 5000 })).toBe(2);
-    await new Promise((r) => setTimeout(r, 150));
-    expect(cache.read("foo")).toBeNull();
-  });
 });
 
-describe("CacheDeleteMatchedBehavior", () => {
-  it("test_delete_matched", () => {
-    const cache = new MemoryStore();
-    cache.write("foo", "bar");
-    cache.write("fu", "baz");
-    cache.write("foo/bar", "baz");
-    cache.write("fu/baz", "bar");
-    cache.deleteMatched(/oo/);
-    expect(cache.exist("foo")).toBe(false);
-    expect(cache.exist("fu")).toBe(true);
-    expect(cache.exist("foo/bar")).toBe(false);
-    expect(cache.exist("fu/baz")).toBe(true);
-  });
-
+describe("MemoryStore delete_matched namespacing", () => {
   it("scopes delete_matched to the configured namespace", () => {
     // keyMatcher prefixes the namespace into the regex source, so an unanchored
     // pattern only deletes this store's namespaced keys.
@@ -439,79 +400,5 @@ describe("MemoryStore coder fidelity", () => {
     expect(r1).not.toBe(r2);
     r1.nested.count = 42;
     expect(r2.nested.count).toBe(1);
-  });
-});
-
-// Port of Rails' CacheStoreCoderBehavior (test/cache/behaviors/cache_store_coder_behavior.rb).
-// SpyCoder mirrors the Rails double; the fidelity `coder` (cache/coder.ts) stands
-// in for Marshal, so a dumped entry is its packed members.
-class SpyCoder {
-  dumpedEntries: Entry[] = [];
-  loadedEntries: Entry[] = [];
-  dumpCompressedEntries: Entry[] = [];
-
-  dump(entry: Entry): string {
-    this.dumpedEntries.push(entry);
-    return coder.dump(entry.pack());
-  }
-
-  load(payload: string): Entry {
-    const entry = Entry.unpack(coder.load(payload) as unknown[]);
-    this.loadedEntries.push(entry);
-    return entry;
-  }
-
-  dumpCompressed(entry: Entry, threshold: number): string {
-    if (threshold === 0) {
-      this.dumpCompressedEntries.push(entry);
-      return coder.dump(entry.pack());
-    } else {
-      return this.dump(entry);
-    }
-  }
-}
-
-describe("CacheStoreCoderBehavior", () => {
-  it("test_coder_receive_the_entry_on_write", () => {
-    const spy = new SpyCoder();
-    const store = new MemoryStore({ coder: spy });
-    store.write("foo", "bar");
-    expect(spy.dumpedEntries.length).toBe(1);
-    const entry = spy.dumpedEntries[0];
-    expect(entry).toBeInstanceOf(Entry);
-    expect(entry.value).toBe("bar");
-  });
-
-  it("test_coder_receive_the_entry_on_read", () => {
-    const spy = new SpyCoder();
-    const store = new MemoryStore({ coder: spy });
-    store.write("foo", "bar");
-    store.read("foo");
-    expect(spy.loadedEntries.length).toBe(1);
-    const entry = spy.loadedEntries[0];
-    expect(entry).toBeInstanceOf(Entry);
-    expect(entry.value).toBe("bar");
-  });
-
-  it("test_coder_receive_the_entry_on_write_multi", () => {
-    const spy = new SpyCoder();
-    const store = new MemoryStore({ coder: spy });
-    store.writeMulti({ foo: "bar", egg: "spam" });
-    expect(spy.dumpedEntries.length).toBe(2);
-    expect(spy.dumpedEntries[0].value).toBe("bar");
-    expect(spy.dumpedEntries[1].value).toBe("spam");
-  });
-
-  it("test_coder_does_not_receive_the_entry_on_read_miss", () => {
-    const spy = new SpyCoder();
-    const store = new MemoryStore({ coder: spy });
-    store.read("foo");
-    expect(spy.loadedEntries.length).toBe(0);
-  });
-
-  it("test_nil_coder_bypasses_serialization", () => {
-    const store = new MemoryStore({ coder: null });
-    const entry = new Entry("value");
-    expect(serializeEntry(store, entry)).toBe(entry);
   });
 });


### PR DESCRIPTION
Two bundled stories.

## 1. `module-mixin-receiver-this-typed` (RFC 0096)

Converts the ported module functions that took the receiver as an explicit
leading parameter to the settled `this`-typed idiom (CLAUDE.md "Module
mixins"), so the body says `this` exactly where Rails says `self`.

- `autosave-association.ts#addAutosaveAssociationCallbacks` — `this`-typed, and
  the callback registrations are now `this.afterCreate(saveMethod)` /
  `this.afterUpdate(saveMethod)` / `this.beforeSave(saveMethod)`, i.e. the
  Symbol method-name filter Rails passes (`after_create save_method`,
  `autosave_association.rb:196-214`), not a wrapping arrow. `saveMethod` is
  therefore a Ruby Symbol (`":autosaveAssociatedRecordsFor_…"`) and
  `defineNonCyclicMethod` drops the colon to name the method, mirroring
  `define_method(:sym)`. Because a string filter is `Callback#isDuplicates`-
  comparable, ActiveSupport's own `set_callback` dedup now covers repeat
  registration and the bespoke "already defined on the prototype" early return
  — which Rails does not have — is gone.
- `encryption/extended-deterministic-queries.ts` — `RelationQueries#where`,
  `#isExists`, `#scopeForCreate` and `CoreQueries#findBy` are `this`-typed, so
  `EncryptedQuery.processArguments(this, args, …)` matches
  `process_arguments(self, args, …)` (`extended_deterministic_queries.rb:99-136`).
- `scoping/default.ts#buildDefaultScope` — `this`-typed, and takes the built
  `relation` rather than a trails-only thunk; Ruby's `relation = relation()`
  default arg is evaluated at call time too (`scoping/default.rb:145`).
  `scoping/named.ts#defaultScoped` now names its local `scope`, as Rails does.
- `signed-id.ts#findSigned` / `#findSignedBang` — `this`-typed, so
  `new UnknownPrimaryKey(this)` matches `UnknownPrimaryKey.new(self)`
  (`signed_id.rb:53`).
- `token-for.ts#generateTokenFor` — `this`-typed, so
  `…generateToken(this)` matches `generate_token(self)` (`token_for.rb:120`).

Callers pass the receiver with `.call(model, …)`, mirroring Rails'
`model.send(:add_autosave_association_callbacks, reflection)`
(`autosave_association.rb:145`).

`parity:api:calls:args:report` `naming` class: **318 → 307** (-11), `shape`
unchanged at 292; no baseline row added or widened. `pnpm parity:api:calls` and
`pnpm parity:api:calls:args` both green.

## 2. `wire-the-remaining-cache-behavior-modules-into-helpers` (RFC 0101) — partial, NOT closed by this PR

Three of the modules, under the LOC ceiling:

- New `cache/behaviors/cache-store-coder-behavior.ts` — all 7 cases of
  `cache_store_coder_behavior.rb`, relocating the 5 already ported into
  `memory-store.test.ts` and adding `read_multi` and
  `coder_is_used_during_handle_expired_entry_when_expired`.
- New `cache/behaviors/cache-delete-matched-behavior.ts` and
  `cache-increment-decrement-behavior.ts` — the misplaced file-level describes
  in `memory-store.test.ts` / `file-store.test.ts` move into helpers. The
  store-specific extras (MemoryStore does not truncate a float amount, FileStore
  does) stay in their store test files under their own describes.

All three are called from `memory-store.test.ts` and `file-store.test.ts` in
Rails `include` order (`memory_store_test.rb:16-24`, `file_store_test.rb:32-41`).

`pnpm parity:test --package activesupport`: matched **2465 → 2473**, TS-only
extras **494 → 483**, misplaced stays **0**; all three files report ✓.

The story's acceptance criterion covers all six modules, so **this PR does not
carry a closing trailer for it** — it stays in-progress. The three modules
that did not fit under the LOC ceiling are split into their own RFC 0101
stories, each carrying the Rails `file:line` include sites:

- `wire-cache-store-version-behavior-into-helpers` (12 cases; both stores)
- `wire-cache-store-format-version-behavior-into-helpers` (8 cases;
  `file_store_test.rb:37` only — `memory_store_test.rb` does not include it)
- `wire-cache-logging-behavior-into-helpers` (8 cases; both stores)

The parent story body records this split and what landed here, so it closes
once those three land.

Closes-story: module-mixin-receiver-this-typed
