### PR TITLE
feat(activerecord,activesupport,date): port Relation#sum's block arm and Date#amjd; enroll XMLMiniEngineTest

### DIFF
--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1485,6 +1485,11 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   // treatment as pluck/pick/count. Without overriding, cp.sum('x') /
   // cp.whereBang({...}); cp.average('y') would both bypass the gate
   // and drop in-place mutations.
+  sum(block: SumBlock): Promise<number | bigint>;
+  sum(initialValue: number, block: SumBlock): Promise<number | bigint>;
+  sum(
+    initialValueOrColumn?: string | Nodes.Node | number,
+  ): Promise<number | bigint | Map<unknown, number | bigint>>;
   async sum(
     initialValueOrColumn?: string | Nodes.Node | number | SumBlock,
     block?: SumBlock,

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -35,6 +35,7 @@ import {
   findTakeWithLimit as baseFindTakeWithLimit,
 } from "../relation/finder-methods.js";
 import type { Nodes } from "@blazetrails/arel";
+import type { SumBlock } from "../relation/calculations.js";
 import { underscore, singularize, camelize, constantize } from "@blazetrails/activesupport";
 import {
   RecordNotSaved,
@@ -1485,25 +1486,28 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   // cp.whereBang({...}); cp.average('y') would both bypass the gate
   // and drop in-place mutations.
   async sum(
-    initialValueOrColumn?: string | Nodes.Node | number,
+    initialValueOrColumn?: string | Nodes.Node | number | SumBlock,
+    block?: SumBlock,
   ): Promise<number | bigint | Map<unknown, number | bigint>> {
     this._checkStrictLoading();
     const fn = (
       Relation.prototype as unknown as {
         sum: (
-          col?: string | Nodes.Node | number,
+          col?: string | Nodes.Node | number | SumBlock,
+          block?: SumBlock,
         ) => Promise<number | bigint | Map<unknown, number | bigint>>;
       }
     ).sum;
-    if (this._relationStateDiverged()) return fn.call(this, initialValueOrColumn);
+    if (this._relationStateDiverged()) return fn.call(this, initialValueOrColumn, block);
     const s = this.scope();
     return (
       s as unknown as {
         sum: (
-          col?: string | Nodes.Node | number,
+          col?: string | Nodes.Node | number | SumBlock,
+          block?: SumBlock,
         ) => Promise<number | bigint | Map<unknown, number | bigint>>;
       }
-    ).sum(initialValueOrColumn);
+    ).sum(initialValueOrColumn, block);
   }
 
   async average(column: string): Promise<unknown | null | Map<unknown, unknown>> {

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -6,6 +6,7 @@ import { sql as arelSql, star as arelStar } from "@blazetrails/arel";
 import { adapterType } from "./test-adapter.js";
 import { StatementInvalid } from "./errors.js";
 import { captureSql } from "./testing/sql-capture.js";
+import { assertNoQueries } from "./testing/query-assertions.js";
 import { fixtures } from "./test-fixtures.js";
 // Opt into the canonical-model autoload index so association targets resolve by
 // name on first reference — no manual `registerModel`.
@@ -1722,9 +1723,18 @@ describe("CalculationsTest", () => {
   });
 
   it("sum uses enumerable version when block is given", async () => {
-    const clients = await Client.all();
-    const total = clients.reduce((sum: number) => sum + 0, 0);
-    expect(total).toBe(0);
+    let blockCalled = false;
+    const relation = await Client.all().load();
+
+    await assertNoQueries(false, async () => {
+      expect(
+        await relation.sum(() => {
+          blockCalled = true;
+          return 0;
+        }),
+      ).toBe(0);
+    });
+    expect(blockCalled).toBe(true);
   });
 
   it("having with strong parameters", async () => {

--- a/packages/activerecord/src/calculations.trails.test.ts
+++ b/packages/activerecord/src/calculations.trails.test.ts
@@ -413,6 +413,16 @@ describe("empty-scope aggregate identities", () => {
     ).toBe(1000 + Number(creditLimits));
   });
 
+  // Ruby folds Integer and Bignum block results together (`Array#sum`), where
+  // JS `0 + 1n` is a TypeError — so the default `0` seed must still take a
+  // `bigint`-returning block.
+  it("sums bigint block return values onto the default identity", async () => {
+    const { Account } = await import("./test-helpers/models/account.js");
+    const rows = BigInt((await Account.count()) as number);
+    expect(await Account.sum(() => 1n)).toBe(rows);
+    expect(await Account.sum(1000, () => 1n)).toBe(1000n + rows);
+  });
+
   // `CollectionProxy < Relation` (collection_proxy.rb:31) inherits the same
   // `sum(initial_value_or_column = 0)`, so the strict-loading override must not
   // narrow it away.

--- a/packages/activerecord/src/calculations.trails.test.ts
+++ b/packages/activerecord/src/calculations.trails.test.ts
@@ -423,6 +423,20 @@ describe("empty-scope aggregate identities", () => {
     expect(await Account.sum(1000, () => 1n)).toBe(1000n + rows);
   });
 
+  // `[1].sum("age")` is a TypeError in Ruby, so a column name is not an initial
+  // value for the block arm — the overloads reject it at compile time and the
+  // fold raises for an untyped caller.
+  it("rejects a non-numeric initial value for the block arm", async () => {
+    const { Account } = await import("./test-helpers/models/account.js");
+    const sum = Account.sum as unknown as (
+      initialValueOrColumn: unknown,
+      block: () => number,
+    ) => Promise<number>;
+    await expect(sum.call(Account, "credit_limit", () => 1)).rejects.toThrow(
+      "no implicit conversion of Integer into String",
+    );
+  });
+
   // `CollectionProxy < Relation` (collection_proxy.rb:31) inherits the same
   // `sum(initial_value_or_column = 0)`, so the strict-loading override must not
   // narrow it away.

--- a/packages/activerecord/src/calculations.trails.test.ts
+++ b/packages/activerecord/src/calculations.trails.test.ts
@@ -400,10 +400,8 @@ describe("empty-scope aggregate identities", () => {
     expect(queries[1]).toMatch(/SELECT SUM\(\) AS ["`]?sum["`]?/);
   });
 
-  // The block arm of `sum(initial_value_or_column = 0, &block)`
-  // (calculations.rb:172-173), whose two doc examples are
-  // `Person.sum { |person| person.age }` and `Person.sum(1000) { |person| person.age }`
-  // (calculations.rb:167-168).
+  // `Person.sum { |person| person.age }` / `Person.sum(1000) { |person| person.age }`,
+  // the two doc examples of the block arm (calculations.rb:167-168, :172-173).
   it("sums the block return values onto the initial value", async () => {
     const { Account } = await import("./test-helpers/models/account.js");
     const creditLimits = await Account.sum("credit_limit");

--- a/packages/activerecord/src/calculations.trails.test.ts
+++ b/packages/activerecord/src/calculations.trails.test.ts
@@ -400,6 +400,21 @@ describe("empty-scope aggregate identities", () => {
     expect(queries[1]).toMatch(/SELECT SUM\(\) AS ["`]?sum["`]?/);
   });
 
+  // The block arm of `sum(initial_value_or_column = 0, &block)`
+  // (calculations.rb:172-173), whose two doc examples are
+  // `Person.sum { |person| person.age }` and `Person.sum(1000) { |person| person.age }`
+  // (calculations.rb:167-168).
+  it("sums the block return values onto the initial value", async () => {
+    const { Account } = await import("./test-helpers/models/account.js");
+    const creditLimits = await Account.sum("credit_limit");
+    expect(await Account.sum((account: { credit_limit: number }) => account.credit_limit)).toBe(
+      Number(creditLimits),
+    );
+    expect(
+      await Account.sum(1000, (account: { credit_limit: number }) => account.credit_limit),
+    ).toBe(1000 + Number(creditLimits));
+  });
+
   // `CollectionProxy < Relation` (collection_proxy.rb:31) inherits the same
   // `sum(initial_value_or_column = 0)`, so the strict-loading override must not
   // narrow it away.

--- a/packages/activerecord/src/calculations.trails.test.ts
+++ b/packages/activerecord/src/calculations.trails.test.ts
@@ -423,18 +423,23 @@ describe("empty-scope aggregate identities", () => {
     expect(await Account.sum(1000, () => 1n)).toBe(1000n + rows);
   });
 
-  // `[1].sum("age")` is a TypeError in Ruby, so a column name is not an initial
-  // value for the block arm — the overloads reject it at compile time and the
-  // fold raises for an untyped caller.
+  // A column name is not an initial value for the block arm: the overloads
+  // reject it at compile time, and for an untyped caller Ruby raises from
+  // `String#+` at the first addition — so `[1].sum("age")` raises while
+  // `[].sum("age")` answers `"age"`.
   it("rejects a non-numeric initial value for the block arm", async () => {
     const { Account } = await import("./test-helpers/models/account.js");
     const sum = Account.sum as unknown as (
       initialValueOrColumn: unknown,
       block: () => number,
-    ) => Promise<number>;
+    ) => Promise<unknown>;
     await expect(sum.call(Account, "credit_limit", () => 1)).rejects.toThrow(
       "no implicit conversion of Integer into String",
     );
+    const empty = Account.where({ id: [] }) as unknown as {
+      sum(initialValueOrColumn: unknown, block: () => number): Promise<unknown>;
+    };
+    expect(await empty.sum("credit_limit", () => 1)).toBe("credit_limit");
   });
 
   // `CollectionProxy < Relation` (collection_proxy.rb:31) inherits the same

--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -512,9 +512,10 @@ export function average<T extends typeof Base>(
 export function sum<T extends typeof Base>(
   this: T,
   column?: Parameters<ReturnType<T["all"]>["sum"]>[0],
+  block?: Parameters<ReturnType<T["all"]>["sum"]>[1],
 ): ReturnType<ReturnType<T["all"]>["sum"]> {
   const rel = this.all() as ReturnType<T["all"]>;
-  return rel.sum(column) as ReturnType<ReturnType<T["all"]>["sum"]>;
+  return rel.sum(column, block) as ReturnType<ReturnType<T["all"]>["sum"]>;
 }
 
 /**

--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -11,6 +11,7 @@ import { threadedConnectionFor, withQueryConnection } from "./connection-handlin
 import type { Relation } from "./relation.js";
 import type { Result } from "./result.js";
 import type { AssociationSpec, JoinSpec } from "./relation/query-methods.js";
+import type { SumBlock } from "./relation/calculations.js";
 
 /**
  * Rails: find_by_sql(sql, binds = [], preparable: nil, allow_retry: false, &block)
@@ -509,13 +510,28 @@ export function average<T extends typeof Base>(
 }
 
 /** Mirrors: ActiveRecord::Querying#sum — params/return derived from Relation#sum. */
+export function sum<T extends typeof Base>(this: T, block: SumBlock): Promise<number | bigint>;
 export function sum<T extends typeof Base>(
   this: T,
-  column?: Parameters<ReturnType<T["all"]>["sum"]>[0],
-  block?: Parameters<ReturnType<T["all"]>["sum"]>[1],
-): ReturnType<ReturnType<T["all"]>["sum"]> {
+  initialValue: number,
+  block: SumBlock,
+): Promise<number | bigint>;
+export function sum<T extends typeof Base>(
+  this: T,
+  column?: string | import("@blazetrails/arel").Nodes.Node | number,
+): Promise<number | bigint | Map<unknown, number | bigint>>;
+export function sum<T extends typeof Base>(
+  this: T,
+  column?: string | import("@blazetrails/arel").Nodes.Node | number | SumBlock,
+  block?: SumBlock,
+): Promise<number | bigint | Map<unknown, number | bigint>> {
   const rel = this.all() as ReturnType<T["all"]>;
-  return rel.sum(column, block) as ReturnType<ReturnType<T["all"]>["sum"]>;
+  return (
+    rel.sum as (
+      c?: unknown,
+      b?: unknown,
+    ) => Promise<number | bigint | Map<unknown, number | bigint>>
+  )(column, block);
 }
 
 /**

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -680,6 +680,22 @@ export async function calculate(
  * argument list: a function in the first position is the block with the default
  * identity, and `sum(1000, block)` is the explicit-initial-value form.
  */
+/**
+ * Ruby's `Integer#+` across the numeric tower, which is what `Array#sum` folds
+ * with: an Integer and a Bignum add exactly, and a Float operand takes the sum
+ * to Float. JS has no tower — `0 + 1n` is a TypeError — so a `bigint` operand
+ * pulls a whole-number partner up to `bigint`, and a fractional `number` pulls
+ * both down to `number`, which is where Ruby's Float arm lands too.
+ */
+function sumAdd(memo: number | bigint, value: number | bigint): number | bigint {
+  if (typeof memo === typeof value) {
+    return typeof memo === "bigint" ? memo + (value as bigint) : memo + (value as number);
+  }
+  const [n, b] = typeof memo === "bigint" ? [value as number, memo] : [memo, value];
+  if (!Number.isInteger(n)) return n + Number(b);
+  return BigInt(n) + (b as bigint);
+}
+
 export async function performSum(
   this: CalculationRelation,
   initialValueOrColumn: string | Nodes.Node | number | null | SumBlock = 0,
@@ -691,12 +707,7 @@ export async function performSum(
   }
   if (block !== undefined) {
     const records = await this.toArray();
-    return records
-      .map(block)
-      .reduce(
-        (memo, value) => (memo as number) + (value as number),
-        initialValueOrColumn as number | bigint,
-      );
+    return records.map(block).reduce(sumAdd, initialValueOrColumn as number | bigint);
   }
   const sum = await calculate.call(this, "sum", initialValueOrColumn);
   if (this._groupColumns.length > 0) return sum as Map<unknown, number | bigint>;

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -192,6 +192,18 @@ type AggFn = "count" | "sum" | "average" | "minimum" | "maximum";
 /** The `&block` of `Calculations#sum` (calculations.rb:172): one record in, a summable out. */
 export type SumBlock = (record: any) => number | bigint;
 
+/**
+ * Mirror of Ruby's `TypeError`, as `attribute-assignment.ts` and `cache/store.ts`
+ * carry it — what `Array#sum` raises when its initial value cannot be added to
+ * the block results.
+ */
+class TypeError extends globalThis.Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TypeError";
+  }
+}
+
 function isCoerceNumericTypeName(name: string | undefined): boolean {
   if (!name) return true;
   // Rails maps :integer + :decimal to value&.to_d. BigInteger inherits
@@ -706,6 +718,17 @@ export async function performSum(
     initialValueOrColumn = 0;
   }
   if (block !== undefined) {
+    // `Array#sum` folds a non-numeric seed with `String#+` (or the object's own
+    // `+`) and raises there — `[1].sum("age")` is a TypeError, not a
+    // concatenation.
+    if (typeof initialValueOrColumn !== "number") {
+      // eslint-disable-next-line blazetrails/rails-error-parity
+      throw new TypeError(
+        `no implicit conversion of Integer into ${
+          typeof initialValueOrColumn === "string" ? "String" : "Arel::Nodes::Node"
+        }`,
+      );
+    }
     const records = await this.toArray();
     return records.map(block).reduce(sumAdd, initialValueOrColumn as number | bigint);
   }
@@ -764,9 +787,12 @@ export interface CalculationMethods {
   ): Promise<unknown | null | Map<unknown, unknown>>;
   calculate(operation: string, column?: string | Nodes.Node | number | null): Promise<unknown>;
   count(column?: string | Nodes.Node): Promise<number | Map<unknown, number>>;
+  /** `sum { |record| … }` — the block arm on the default identity. */
+  sum(block: SumBlock): Promise<number | bigint>;
+  /** `sum(1000) { |record| … }` — the block arm on an explicit initial value. */
+  sum(initialValue: number, block: SumBlock): Promise<number | bigint>;
   sum(
-    initialValueOrColumn?: string | Nodes.Node | number | null | SumBlock,
-    block?: SumBlock,
+    initialValueOrColumn?: string | Nodes.Node | number | null,
   ): Promise<number | bigint | Map<unknown, number | bigint>>;
   average(column: string | Nodes.Node): Promise<unknown | null | Map<unknown, unknown>>;
   minimum(column: string | Nodes.Node): Promise<unknown | null | Map<unknown, unknown>>;

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -671,10 +671,14 @@ export async function calculate(
  *
  * The identity default falls through `aggregate_column` -> `arel_column`, whose
  * `field.to_s` (query_methods.rb:1993) makes it the SQL literal summed over, so
- * the no-argument answer comes out of `calculate` rather than a guard. The
- * Ruby's trailing `&block` has no TS slot, so it rides the argument list: a
- * function in the first position is the block with the default identity, and
- * `sum(1000, block)` is the explicit-initial-value form.
+ * the no-argument answer comes out of `calculate` rather than a guard.
+ *
+ * The block arm is `map(&block).sum(initial_value_or_column)`
+ * (calculations.rb:172-173): `Enumerable#map` loads the relation — a no-op when
+ * it is already loaded — and `Array#sum` seeds the accumulation with the
+ * initial value. Ruby's trailing `&block` has no TS slot, so it rides the
+ * argument list: a function in the first position is the block with the default
+ * identity, and `sum(1000, block)` is the explicit-initial-value form.
  */
 export async function performSum(
   this: CalculationRelation,
@@ -686,13 +690,13 @@ export async function performSum(
     initialValueOrColumn = 0;
   }
   if (block !== undefined) {
-    // Rails `map(&block).sum(initial_value_or_column)` (calculations.rb:172-173):
-    // Enumerable#map loads the relation (a no-op when already loaded) and
-    // Array#sum seeds the accumulation with the initial value.
     const records = await this.toArray();
     return records
       .map(block)
-      .reduce((memo: any, value: any) => memo + value, initialValueOrColumn as number | bigint);
+      .reduce(
+        (memo, value) => (memo as number) + (value as number),
+        initialValueOrColumn as number | bigint,
+      );
   }
   const sum = await calculate.call(this, "sum", initialValueOrColumn);
   if (this._groupColumns.length > 0) return sum as Map<unknown, number | bigint>;

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -698,8 +698,24 @@ export async function calculate(
  * to Float. JS has no tower — `0 + 1n` is a TypeError — so a `bigint` operand
  * pulls a whole-number partner up to `bigint`, and a fractional `number` pulls
  * both down to `number`, which is where Ruby's Float arm lands too.
+ *
+ * A non-numeric memo is the seed of a `sum(column) { … }` call, and Ruby raises
+ * it here rather than up front — from `String#+`, at the FIRST addition, so
+ * `[].sum("age")` still answers `"age"` and only `[1].sum("age")` raises. The
+ * `rails-error-parity` rule keys on the constructor name, so it flags this
+ * throw whether the class is the global `TypeError` or the ported mirror above;
+ * `attribute-assignment.ts` and `cache/store.ts` carry the same suppression for
+ * the same reason.
  */
 function sumAdd(memo: number | bigint, value: number | bigint): number | bigint {
+  if (typeof memo !== "number" && typeof memo !== "bigint") {
+    // eslint-disable-next-line blazetrails/rails-error-parity
+    throw new TypeError(
+      `no implicit conversion of ${
+        typeof value === "bigint" || Number.isInteger(value) ? "Integer" : "Float"
+      } into ${typeof memo === "string" ? "String" : (memo as object).constructor.name}`,
+    );
+  }
   if (typeof memo === typeof value) {
     return typeof memo === "bigint" ? memo + (value as bigint) : memo + (value as number);
   }
@@ -718,17 +734,6 @@ export async function performSum(
     initialValueOrColumn = 0;
   }
   if (block !== undefined) {
-    // `Array#sum` folds a non-numeric seed with `String#+` (or the object's own
-    // `+`) and raises there — `[1].sum("age")` is a TypeError, not a
-    // concatenation.
-    if (typeof initialValueOrColumn !== "number") {
-      // eslint-disable-next-line blazetrails/rails-error-parity
-      throw new TypeError(
-        `no implicit conversion of Integer into ${
-          typeof initialValueOrColumn === "string" ? "String" : "Arel::Nodes::Node"
-        }`,
-      );
-    }
     const records = await this.toArray();
     return records.map(block).reduce(sumAdd, initialValueOrColumn as number | bigint);
   }

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -189,6 +189,9 @@ interface CalculationRelation {
 
 type AggFn = "count" | "sum" | "average" | "minimum" | "maximum";
 
+/** The `&block` of `Calculations#sum` (calculations.rb:172): one record in, a summable out. */
+export type SumBlock = (record: any) => number | bigint;
+
 function isCoerceNumericTypeName(name: string | undefined): boolean {
   if (!name) return true;
   // Rails maps :integer + :decimal to value&.to_d. BigInteger inherits
@@ -669,13 +672,28 @@ export async function calculate(
  * The identity default falls through `aggregate_column` -> `arel_column`, whose
  * `field.to_s` (query_methods.rb:1993) makes it the SQL literal summed over, so
  * the no-argument answer comes out of `calculate` rather than a guard. The
- * block arm (`map(&block).sum(initial_value_or_column)`, calculations.rb:172-173)
- * is tracked by the `port-relation-sum-block-arm` story.
+ * Ruby's trailing `&block` has no TS slot, so it rides the argument list: a
+ * function in the first position is the block with the default identity, and
+ * `sum(1000, block)` is the explicit-initial-value form.
  */
 export async function performSum(
   this: CalculationRelation,
-  initialValueOrColumn: string | Nodes.Node | number | null = 0,
+  initialValueOrColumn: string | Nodes.Node | number | null | SumBlock = 0,
+  block?: SumBlock,
 ): Promise<number | bigint | Map<unknown, number | bigint>> {
+  if (typeof initialValueOrColumn === "function") {
+    block = initialValueOrColumn;
+    initialValueOrColumn = 0;
+  }
+  if (block !== undefined) {
+    // Rails `map(&block).sum(initial_value_or_column)` (calculations.rb:172-173):
+    // Enumerable#map loads the relation (a no-op when already loaded) and
+    // Array#sum seeds the accumulation with the initial value.
+    const records = await this.toArray();
+    return records
+      .map(block)
+      .reduce((memo: any, value: any) => memo + value, initialValueOrColumn as number | bigint);
+  }
   const sum = await calculate.call(this, "sum", initialValueOrColumn);
   if (this._groupColumns.length > 0) return sum as Map<unknown, number | bigint>;
   return (sum as number | bigint) ?? 0;
@@ -732,7 +750,8 @@ export interface CalculationMethods {
   calculate(operation: string, column?: string | Nodes.Node | number | null): Promise<unknown>;
   count(column?: string | Nodes.Node): Promise<number | Map<unknown, number>>;
   sum(
-    initialValueOrColumn?: string | Nodes.Node | number | null,
+    initialValueOrColumn?: string | Nodes.Node | number | null | SumBlock,
+    block?: SumBlock,
   ): Promise<number | bigint | Map<unknown, number | bigint>>;
   average(column: string | Nodes.Node): Promise<unknown | null | Map<unknown, unknown>>;
   minimum(column: string | Nodes.Node): Promise<unknown | null | Map<unknown, unknown>>;

--- a/packages/activesupport/src/xml-mini/xml-mini-engine.test.ts
+++ b/packages/activesupport/src/xml-mini/xml-mini-engine.test.ts
@@ -1,24 +1,243 @@
-import { describe, it } from "vitest";
+/**
+ * Mirrors: `activesupport/test/xml_mini/xml_mini_engine_test.rb` — the shared
+ * engine suite every backend test inherits (`XMLMiniEngineTest.inherited`
+ * mixes `EngineTests` into the subclass, `xml_mini_engine_test.rb:19-22`).
+ * Rails runs it once per backend; it runs here against `XmlMini_REXML`, whose
+ * own subclass cases live in `rexml-engine.test.ts` (`REXMLEngineTest <
+ * XMLMiniEngineTest`, `rexml_engine_test.rb:5`).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { RuntimeError } from "../rexml/document.js";
+import * as XmlMini from "../xml-mini.js";
+import * as XmlMini_REXML from "./rexml.js";
+
+/**
+ * `REXMLEngineTest#engine` (`rexml_engine_test.rb:20-22`), which Ruby uses
+ * both as the `XmlMini.backend=` argument and to name the constant. The
+ * backend module namespace object is what `cast_backend_name_to_module`
+ * (`xml_mini.rb:200-206`) resolves the name to, and the value passed here:
+ * under vitest the name arm's `import("./xml-mini/rexml.js")` has no `.js`
+ * file to glob, so the name is only spelled where it is compared.
+ */
+const engine = XmlMini_REXML;
+
+/** `REXMLEngineTest#expansion_attack_error` (`rexml_engine_test.rb:24-26`). */
+const expansionAttackError = RuntimeError;
+
+/**
+ * `XMLMiniEngineTest::EngineTests#assert_engine_class`
+ * (`xml_mini_engine_test.rb:212-214`): Ruby reads the
+ * `ActiveSupport::XmlMini_#{engine}` constant out of `ActiveSupport`, where a
+ * trails backend is the module namespace object of `xml-mini/<name>.js`.
+ */
+function assertEngineClass(actual: unknown): void {
+  expect(actual).toBe(XmlMini_REXML);
+}
+
+/**
+ * `XMLMiniEngineTest::EngineTests#assert_equal_rexml`
+ * (`xml_mini_engine_test.rb:216-221`) — the engine's own parse against the
+ * REXML one. `xml.rewind` has no analog: a trails backend takes a string
+ * (`XmlMiniBackend` in `xml-mini.ts`), so there is no IO to rewind.
+ */
+async function assertEqualRexml(xml: string): Promise<void> {
+  const parsedXml = await XmlMini.parse(xml);
+  const hash = await XmlMini.withBackend(XmlMini_REXML, () => XmlMini.parse(xml));
+  expect(hash).toEqual(parsedXml);
+}
 
 describe("XMLMiniEngineTest", () => {
+  let defaultBackend: XmlMini.XmlMiniBackend | null | undefined;
+
+  beforeEach(async () => {
+    defaultBackend = XmlMini.backend();
+    await XmlMini.setBackend(engine);
+  });
+
+  afterEach(async () => {
+    await XmlMini.setBackend(defaultBackend);
+  });
+
+  // `Hash.from_xml` — and with it `XmlMini::PARSING`, which `_parse_file`
+  // reaches through — is unported; tracked by the `port-xml-mini-parsing-table`
+  // story.
   it.skip("file from xml");
-  it.skip("exception thrown on expansion attack");
-  it.skip("setting backend");
-  it.skip("blank returns empty hash");
-  it.skip("parse from frozen string");
-  it.skip("array type makes an array");
-  it.skip("one node document as hash");
-  it.skip("one node with attributes document as hash");
-  it.skip("products node with book node as hash");
-  it.skip("products node with two book nodes as hash");
-  it.skip("single node with content as hash");
-  it.skip("children with children");
-  it.skip("children with text");
-  it.skip("children with non adjacent text");
-  it.skip("parse from io");
-  it.skip("children with simple cdata");
-  it.skip("children with multiple cdata");
-  it.skip("children with text and cdata");
-  it.skip("children with blank text");
-  it.skip("children with blank text and attribute");
+
+  it("exception thrown on expansion attack", async () => {
+    // Rails goes through `Hash.from_xml`, which is unported; the raise is
+    // `XmlMini.parse`'s either way (`xml_mini_engine_test.rb:51-68`).
+    await expect(
+      XmlMini.parse(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE member [
+  <!ENTITY a "&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;">
+  <!ENTITY b "&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;">
+  <!ENTITY c "&d;&d;&d;&d;&d;&d;&d;&d;&d;&d;">
+  <!ENTITY d "&e;&e;&e;&e;&e;&e;&e;&e;&e;&e;">
+  <!ENTITY e "&f;&f;&f;&f;&f;&f;&f;&f;&f;&f;">
+  <!ENTITY f "&g;&g;&g;&g;&g;&g;&g;&g;&g;&g;">
+  <!ENTITY g "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx">
+]>
+<member>
+  &a;
+</member>
+`),
+    ).rejects.toBeInstanceOf(expansionAttackError);
+  });
+
+  it("setting backend", () => {
+    assertEngineClass(XmlMini.backend());
+  });
+
+  it("blank returns empty hash", async () => {
+    expect(await XmlMini.parse(null)).toEqual({});
+    expect(await XmlMini.parse("")).toEqual({});
+  });
+
+  it("parse from frozen string", async () => {
+    const xmlString = "<root/>";
+    expect(await XmlMini.parse(xmlString)).toEqual({ root: {} });
+  });
+
+  it("array type makes an array", async () => {
+    await assertEqualRexml(`
+      <blog>
+        <posts type="array">
+          <post>a post</post>
+          <post>another post</post>
+        </posts>
+      </blog>
+    `);
+  });
+
+  it("one node document as hash", async () => {
+    await assertEqualRexml(`
+      <products/>
+    `);
+  });
+
+  it("one node with attributes document as hash", async () => {
+    await assertEqualRexml(`
+      <products foo="bar"/>
+    `);
+  });
+
+  it("products node with book node as hash", async () => {
+    await assertEqualRexml(`
+      <products>
+        <book name="awesome" id="12345" />
+      </products>
+    `);
+  });
+
+  it("products node with two book nodes as hash", async () => {
+    await assertEqualRexml(`
+      <products>
+        <book name="awesome" id="12345" />
+        <book name="america" id="67890" />
+      </products>
+    `);
+  });
+
+  it("single node with content as hash", async () => {
+    await assertEqualRexml(`
+      <products>
+        hello world
+      </products>
+    `);
+  });
+
+  it("children with children", async () => {
+    await assertEqualRexml(`
+      <root>
+        <products>
+          <book name="america" id="67890" />
+        </products>
+      </root>
+    `);
+  });
+
+  it("children with text", async () => {
+    await assertEqualRexml(`
+      <root>
+        <products>
+          hello everyone
+        </products>
+      </root>
+    `);
+  });
+
+  it("children with non adjacent text", async () => {
+    await assertEqualRexml(`
+      <root>
+        good
+        <products>
+          hello everyone
+        </products>
+        morning
+      </root>
+    `);
+  });
+
+  it("parse from io", async () => {
+    // Rails wraps the document in a `StringIO` (`xml_mini_engine_test.rb:154`);
+    // a trails backend's `parse` takes a string (`XmlMiniBackend` in
+    // `xml-mini.ts`), so the string arm is the trails analog.
+    await assertEqualRexml(`
+      <root>
+        good
+        <products>
+          hello everyone
+        </products>
+        morning
+      </root>
+    `);
+  });
+
+  it("children with simple cdata", async () => {
+    await assertEqualRexml(`
+      <root>
+        <products>
+           <![CDATA[cdatablock]]>
+        </products>
+      </root>
+    `);
+  });
+
+  it("children with multiple cdata", async () => {
+    await assertEqualRexml(`
+      <root>
+        <products>
+           <![CDATA[cdatablock1]]><![CDATA[cdatablock2]]>
+        </products>
+      </root>
+    `);
+  });
+
+  it("children with text and cdata", async () => {
+    await assertEqualRexml(`
+      <root>
+        <products>
+          hello <![CDATA[cdatablock]]>
+          morning
+        </products>
+      </root>
+    `);
+  });
+
+  it("children with blank text", async () => {
+    await assertEqualRexml(`
+      <root>
+        <products>   </products>
+      </root>
+    `);
+  });
+
+  it("children with blank text and attribute", async () => {
+    await assertEqualRexml(`
+      <root>
+        <products type="file">   </products>
+      </root>
+    `);
+  });
 });

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -2198,6 +2198,23 @@ describe("Date's second registration names", () => {
  * own tests pass Integers throughout and never pin which arm a Rational takes,
  * which is why these live here.
  */
+describe("Date#amjd", () => {
+  it("answers m_real_jd less 2400001 as a Rational", () => {
+    // ruby 3.3.11 -rdate:
+    //   Date.new(2001,2,3).amjd       #=> (51943/1)
+    //   Date.new(2001,2,3).amjd.class #=> Rational
+    expect(new RubyDate(2001, 2, 3).amjd.toString()).toBe("51943/1");
+  });
+
+  it("is not adjusted by the offset", () => {
+    // The C's own doc example (date_core.c:5224-5228):
+    //   DateTime.new(2001,2,3,4,5,6,'+7').amjd  #=> (249325817/4800)
+    //   DateTime.new(2001,2,2,14,5,6,'-7').amjd #=> (249325817/4800)
+    expect(new RubyDateTime(2001, 2, 3, 4, 5, 6, "+7").amjd.toString()).toBe("249325817/4800");
+    expect(new RubyDateTime(2001, 2, 2, 14, 5, 6, "-7").amjd.toString()).toBe("249325817/4800");
+  });
+});
+
 describe("a reducible Rational operand at the C's Integer branches", () => {
   it("takes d_lite_rshift's f_idiv/f_mod arm, never the FIXNUM_P one", () => {
     // ruby 3.3.11 -rdate:

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -1457,6 +1457,12 @@ function dateZoneToDiff(str: string): number | Rational | null {
           } else {
             const denom = 10 ** (n - 2);
             const rat = new Rational(sec, denom).add(hour * 3600);
+            // The C's OWN inline fold (`date_parse.c:531-534`:
+            // `if (rb_rational_den(offset) == INT2FIX(1)) offset = rb_rational_num(offset)`),
+            // not a canonicalization Rational arithmetic performs on its own —
+            // `f_add` leaves a `(n/1)` a Rational, which is why the C spells the
+            // fold out here and why a downstream `FIXNUM_P` test would be false
+            // without it.
             offset = rat.denominator === 1n ? Number(rat.numerator) : rat;
           }
           return offset;
@@ -6982,6 +6988,31 @@ export class Date {
     if (!sf.isZero()) ajd = ajd.add(nsToDay(sf));
 
     return ajd;
+  }
+
+  /**
+   * Ruby `Date#amjd` (ruby/date, `date_core.c` `d_lite_amjd`,
+   * `date_core.c:5231-5236`, over `m_amjd`, `date_core.c:1625-1651`), the
+   * astronomical modified Julian day: `m_real_jd` less 2400001 as a Rational,
+   * so `Date.new(2001,2,3).amjd` is `Rational(51943, 1)`. Unlike
+   * {@link Date#mjd} it is NOT adjusted by the offset — it reads `m_real_jd`
+   * and the stored UTC day fraction where `mjd` reads the local day.
+   *
+   * The C's two spellings of the subtraction — a `long` fast path and an
+   * `f_sub` one — build the same Rational, so there is one arm here, exactly
+   * as {@link Date#ajd} documents for its own pair.
+   */
+  get amjd(): Rational {
+    const r = new Rational(BigInt(this.mRealJd()) - 2400001n, 1);
+    if (simpleDatP(this)) return r;
+
+    let amjd = r;
+    const df = this.mDf();
+    if (df) amjd = amjd.add(isecToDay(df));
+    const sf = this.mSf();
+    if (!sf.isZero()) amjd = amjd.add(nsToDay(sf));
+
+    return amjd;
   }
 
   /**

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -1457,12 +1457,8 @@ function dateZoneToDiff(str: string): number | Rational | null {
           } else {
             const denom = 10 ** (n - 2);
             const rat = new Rational(sec, denom).add(hour * 3600);
-            // The C's OWN inline fold (`date_parse.c:531-534`:
-            // `if (rb_rational_den(offset) == INT2FIX(1)) offset = rb_rational_num(offset)`),
-            // not a canonicalization Rational arithmetic performs on its own —
-            // `f_add` leaves a `(n/1)` a Rational, which is why the C spells the
-            // fold out here and why a downstream `FIXNUM_P` test would be false
-            // without it.
+            // The C's OWN inline fold (`date_parse.c:531-534`), not one Rational
+            // arithmetic performs: `f_add` leaves a `(n/1)` a Rational.
             offset = rat.denominator === 1n ? Number(rat.numerator) : rat;
           }
           return offset;


### PR DESCRIPTION
Bundle of four stories.

## `Relation#sum`'s block arm (`port-relation-sum-block-arm`)

`sum(initial_value_or_column = 0, &block)` (`calculations.rb:171-177`) had only
the `calculate` arm. The `block_given?` arm is ported: `map(&block)` loads the
relation (a no-op when already loaded) and `Array#sum` seeds the accumulation
with `initial_value_or_column`. Ruby's trailing `&block` has no TS slot, so it
rides the argument list — a function in the first position is the block with the
default identity `0`, and `sum(1000, block)` is the explicit-initial-value form.
Threaded through `Querying#sum` and `CollectionProxy#sum`, which Rails reaches by
delegation/inheritance.

Rails' own coverage — `test_sum_uses_enumerable_version_when_block_is_given`
(`calculations_test.rb:1464-1472`) — was a stand-in that never called the block;
it now asserts the block runs and issues no query, as Rails does.

## `XMLMiniEngineTest` enrolled (`enroll-xml-mini-engine-test`)

`xml-mini-engine.test.ts` was a PERMANENT-SKIP stub of all 20 Rails test names;
it now runs against the REXML backend (19 pass, 1 skipped). `test_file_from_xml`
stays skipped with a pointer to `port-xml-mini-parsing-table`, which
`Hash.from_xml` → `XmlMini::PARSING` needs. `test_parse_from_io`'s trails analog
is the string arm — a trails backend's `parse` takes a string (`XmlMiniBackend`
in `xml-mini.ts`) — and the expansion-attack case asserts through `XmlMini.parse`,
which is where the `RuntimeError` is raised either way.

`XmlMini.backend=` is handed the backend module rather than the name `"REXML"`:
under vitest the name arm's `import("./xml-mini/rexml.js")` has no `.js` file to
glob. Noted at the call site.

## `Date#amjd` (`port-date-amjd`)

`d_lite_amjd` (`date_core.c:5231-5236`) over `m_amjd` (`:1625-1651`), next to
the already-ported `Date#ajd`: `m_real_jd` less 2400001 as a Rational, plus the
day fraction and sub-second on the complex arm. Unlike `Date#mjd` it is not
adjusted by the offset, which the C's own doc example
(`DateTime.new(2001,2,3,4,5,6,'+7').amjd == DateTime.new(2001,2,2,14,5,6,'-7').amjd
== (249325817/4800)`) pins.

## The disproven canonicalization premise (`audit-the-disproven-rational-canonicalization-premise`)

Ruby's Rational *arithmetic* does not fold a denominator of one to an Integer
(verified on ruby 3.3.11: `Rational(1,2) * 12` is `(6/1)`, class `Rational`).
Both RFC 0088 stories asserting otherwise now carry a correction note (pushed to
the tasks repo). In `date.ts` the four `denominator === 1n` sites were audited:
three already cite the C (`wholenum_p`, `offset_to_sec`'s live Rational arm, the
`inspect` display read), and the fourth — `date_zone_to_diff`'s fractional-hour
offset — now cites the C's own inline fold at `date_parse.c:531-534`. No ported
body routes a reducible Rational to a `FIXNUM_P` arm.

Closes-story: port-relation-sum-block-arm
Closes-story: enroll-xml-mini-engine-test
Closes-story: audit-the-disproven-rational-canonicalization-premise
Closes-story: port-date-amjd