### PR TITLE
refactor(activerecord): wire violates_strict_loading? into the find_target call sites

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -24,7 +24,6 @@ export { _setCollectionProxyCtor } from "./associations/collection-proxy-slot.js
 
 import { ConfigurationError } from "./errors.js";
 import { ArgumentError } from "@blazetrails/activemodel";
-import { strictLoadingViolationBang } from "./core.js";
 import { StatementCache } from "./statement-cache.js";
 import { HasManyThroughAssociationNotFoundError } from "./associations/errors.js";
 import {
@@ -1367,29 +1366,6 @@ export function syncToAssociationInstance(record: Base, assocName: string, resul
 }
 
 /**
- * Whether lazily loading an association on `record` is a strict-loading
- * violation. Mirrors Rails' `Association#violates_strict_loading?`:
- *
- *   return if @skip_strict_loading
- *   return unless owner.validation_context.nil?
- *   return reflection.strict_loading? if reflection.options.key?(:strict_loading)
- *   owner.strict_loading? && !owner.strict_loading_n_plus_one_only?
- *
- * A reflection-level `strictLoading` option wins over the owner's flag; the
- * `n_plus_one_only` clause lets the first level load lazily.
- *
- * @internal
- */
-export function _violatesStrictLoading(record: Base, options: AssociationOptions): boolean {
-  if (record._strictLoadingBypassCount) return false;
-  if (record._validationContext != null) return false;
-  if (Object.prototype.hasOwnProperty.call(options, "strictLoading")) {
-    return options.strictLoading === true;
-  }
-  return record._strictLoading && !record.isStrictLoadingNPlusOneOnly();
-}
-
-/**
  * Whether a lazy load would actually reach `find_target` — and therefore
  * `violates_strict_loading?`. Rails gates the strict-loading check inside
  * `find_target`, which `find_target?` only enters under macro-specific rules:
@@ -1917,11 +1893,7 @@ function wrapCollectionProxy<T extends Base = Base>(
         return target.target[Number(prop)];
       }
 
-      if (_violatesStrictLoading(target._record, target._assocDef.options)) {
-        strictLoadingViolationBang(target._record, target._assocName, {
-          className: target._assocDef.options.className ?? camelize(singularize(target._assocName)),
-        });
-      }
+      (target as unknown as { _checkStrictLoading(): void })._checkStrictLoading();
 
       // Class-method delegations resolve through the `Reflect.get(scope, prop,
       // scope)` fallback below: `target.scope()` returns an `AssociationRelation`

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -886,13 +886,29 @@ export class Association {
     return result;
   }
 
-  private isViolatesStrictLoading(): boolean {
+  /**
+   * Mirrors `Association#violates_strict_loading?` (association.rb:284-292),
+   * called from `findTarget` (association.rb:248-250) and from
+   * `CollectionProxy._checkStrictLoading`.
+   *
+   * The `@skip_strict_loading` guard reads two flags rather than one: the
+   * association-level ivar Rails has, plus the owner-level bypass counter the
+   * explicit loaders (`loadBelongsTo` / `loadHasOne` / `CollectionProxy`'s
+   * `_withoutStrictLoading`) raise. Those loaders are the trails spelling of a
+   * deliberate load, and they run where Ruby would have had an association
+   * handle to call `skip_strict_loading` on.
+   * @internal
+   */
+  protected isViolatesStrictLoading(): boolean {
     if (this._skipStrictLoading) return false;
+    if (this.owner._strictLoadingBypassCount) return false;
 
     if ((this.owner as { _validationContext?: unknown })._validationContext != null) return false;
 
-    if ("strictLoading" in (this.reflection.options as object)) {
-      return (this.reflection as { strictLoading?: boolean }).strictLoading ?? false;
+    if (Object.prototype.hasOwnProperty.call(this.reflection.options, "strictLoading")) {
+      // `AssociationReflection#strict_loading?` is `!!options[:strict_loading]`
+      // (reflection.rb:1344); the lightweight definition carries no getter.
+      return this.reflection.options.strictLoading === true;
     }
 
     return this.owner.isStrictLoading() && !this.owner.isStrictLoadingNPlusOneOnly();

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -60,7 +60,6 @@ import {
   resolveAssocClass,
   _routeThroughViaAssociationScope,
   ownerHasUnresolvedThroughKey,
-  _violatesStrictLoading,
 } from "../associations.js";
 import { _setCollectionProxyCtor } from "./collection-proxy-slot.js";
 import { multisetDifference, multisetIntersection } from "./has-many-through-association.js";
@@ -1101,7 +1100,13 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   }
 
   private _checkStrictLoading(): void {
-    if (_violatesStrictLoading(this._record, this._assocDef.options)) {
+    // Rails reaches `violates_strict_loading?` through the association the
+    // proxy delegates to (`find_target`, association.rb:248-250); trails' proxy
+    // loads on its own path, so it consults the same association instance.
+    const association = this._staleWrapper() as unknown as
+      | { isViolatesStrictLoading(): boolean }
+      | undefined;
+    if (association?.isViolatesStrictLoading()) {
       strictLoadingViolationBang(this._record, this._assocName, {
         className: this._assocDef.options.className ?? camelize(singularize(this._assocName)),
       });

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -12,7 +12,6 @@ import {
   _resolveInverseName,
   _routeThroughViaAssociationScope,
   _scopeForAssociation,
-  _violatesStrictLoading,
   _wireInverseAssociation,
   applyAssociationScope,
   resolveAssocClass,
@@ -190,7 +189,7 @@ export class HasManyAssociation extends CollectionAssociation {
         this.reflection.name,
         this.reflection.options,
         this._queryExecutor,
-        this._skipStrictLoading,
+        this.isViolatesStrictLoading(),
       );
       // Rails applies `set_strict_loading` per record inside `find_target`'s
       // instantiation block (association.rb:269-271), not in `load_target`.
@@ -548,9 +547,12 @@ export function setIntersection(a: Base[], b: Base[]): Base[] {
  * the model never declared that way; that triple shape is a trails-only
  * calling convention, not Rails surface, and it is module-private.
  *
- * `skipStrictLoading` carries the association's `@skip_strict_loading`
- * (association.rb) into this loader, since the strict-loading check Rails runs
- * inside `find_target` lives here rather than on the association instance.
+ * `violatesStrictLoading` carries the result of the association's
+ * `violates_strict_loading?` (association.rb:284-292) into this loader: Rails
+ * raises on it as `find_target`'s first statement, but trails only knows a
+ * query is actually needed after the cache/preload lookups below, which are
+ * Rails' `find_target?` guard (association.rb:190). The predicate reads only
+ * owner/reflection state, so evaluating it at the call site is the same answer.
  *
  * @internal
  */
@@ -559,7 +561,7 @@ async function findTarget(
   assocName: string,
   options: AssociationOptions,
   queryExecutor?: () => Promise<Base[]>,
-  skipStrictLoading = false,
+  violatesStrictLoading = false,
 ): Promise<Base[]> {
   if (options.through) {
     validateThroughReflection(record.constructor as typeof Base, assocName);
@@ -590,11 +592,7 @@ async function findTarget(
 
   // Strict loading check. Gated by `find_target?`: a new-record owner without
   // the FK present never reaches `find_target` and so never raises.
-  if (
-    !skipStrictLoading &&
-    _violatesStrictLoading(record, options) &&
-    _findTargetReachable(record, assocName, options, "foreign")
-  ) {
+  if (violatesStrictLoading && _findTargetReachable(record, assocName, options, "foreign")) {
     strictLoadingViolationBang(record, assocName, {
       className: options.className ?? camelize(singularize(assocName)),
     });

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -590,8 +590,21 @@ async function findTarget(
     }
   }
 
-  // Strict loading check. Gated by `find_target?`: a new-record owner without
-  // the FK present never reaches `find_target` and so never raises.
+  // `HasManyThroughAssociation#find_target` (has_many_through_association.rb
+  // :225-229) returns `scope.to_a if disable_joins` BEFORE `super`, so that
+  // route never reaches the base body's strict-loading raise. The scope-override
+  // executor below still wins, as it did when this branch sat under it.
+  const reflEarly =
+    options.through && !queryExecutor
+      ? (record.constructor as typeof Base)._reflectOnAssociation?.(assocName)
+      : undefined;
+  if (reflEarly && _canRouteThroughViaDisableJoinsAssociationScope(reflEarly, options)) {
+    return _loadThroughViaDisableJoinsScope(record, reflEarly, options);
+  }
+
+  // `Association#find_target`'s first statement (association.rb:248-250). Gated
+  // by `find_target?`: a new-record owner without the FK present never reaches
+  // `find_target` and so never raises.
   if (violatesStrictLoading && _findTargetReachable(record, assocName, options, "foreign")) {
     strictLoadingViolationBang(record, assocName, {
       className: options.className ?? camelize(singularize(assocName)),
@@ -609,17 +622,14 @@ async function findTarget(
   // 2-step loadHasManyThrough.
   if (options.through) {
     const ctorEarly = record.constructor as typeof Base;
-    const reflEarly = ctorEarly._reflectOnAssociation?.(assocName);
-    if (_canRouteThroughViaDisableJoinsAssociationScope(reflEarly, options)) {
-      return _loadThroughViaDisableJoinsScope(record, reflEarly, options);
-    }
+    const reflThrough = ctorEarly._reflectOnAssociation?.(assocName);
     // Nested-through shapes flatten their whole `reflection.chain` into the
     // JOIN-based AssociationScope path below, sharing its inverse-wiring and
     // null-FK short-circuit. An unsaved owner resolves its through step from
     // the in-memory association target (e.g. `post.author = mary` before save),
     // which the SQL JOIN cannot see — `_routeThroughViaAssociationScope` keeps
     // those on the 2-step loader.
-    if (!_routeThroughViaAssociationScope(record, reflEarly, options)) {
+    if (!_routeThroughViaAssociationScope(record, reflThrough, options)) {
       const { _buildAssociationInstance } = await import("./instance-methods.js");
       const through = _buildAssociationInstance.call(record, {
         name: assocName,

--- a/packages/activerecord/src/associations/singular-association.ts
+++ b/packages/activerecord/src/associations/singular-association.ts
@@ -11,7 +11,6 @@ import {
   _resolveInverseName,
   _scopeForAssociation,
   _skipSingularStatementCache,
-  _violatesStrictLoading,
   _wireInverseAssociation,
   applyAssociationScope,
   resolveAssocClass,
@@ -215,7 +214,7 @@ export class SingularAssociation extends Association {
 
     // A DB load would be required to answer.
     if (this.findTargetNeeded()) {
-      if (this._isStrictOnOwner()) {
+      if (this.isViolatesStrictLoading()) {
         strictLoadingViolationBang(this.owner, this.reflection.name, {
           polymorphic: this.reflection.options?.polymorphic,
           className: this.reflection.options?.className,
@@ -228,11 +227,6 @@ export class SingularAssociation extends Association {
       return this.loadTarget() as Promise<Base | null>;
     }
     return this.target;
-  }
-
-  private _isStrictOnOwner(): boolean {
-    const owner = this.owner as any;
-    return Boolean(owner._strictLoading) && !owner._strictLoadingBypassCount;
   }
 
   /**
@@ -318,7 +312,7 @@ export class SingularAssociation extends Association {
       // a new-record owner without the key present never reaches `find_target` and
       // so never raises.
       if (
-        _violatesStrictLoading(owner, options) &&
+        this.isViolatesStrictLoading() &&
         _findTargetReachable(owner, assocName, options, isBelongsTo ? "belongsTo" : "foreign")
       ) {
         strictLoadingViolationBang(owner, assocName, {

--- a/packages/activerecord/src/associations/singular-association.ts
+++ b/packages/activerecord/src/associations/singular-association.ts
@@ -308,9 +308,20 @@ export class SingularAssociation extends Association {
         validateThroughReflection(ctor, assocName);
       }
 
-      // Rails `Association#find_target`'s first statement. Gated by `find_target?`:
-      // a new-record owner without the key present never reaches `find_target` and
-      // so never raises.
+      // `SingularAssociation#find_target` (singular_association.rb:47-55) answers
+      // a `disable_joins` association from `scope.first` and never calls `super`,
+      // so that route never reaches the base body's strict-loading raise.
+      if (
+        !isBelongsTo &&
+        options.through &&
+        _canRouteThroughViaDisableJoinsAssociationScope(reflection, options)
+      ) {
+        return _loadSingularThroughViaDisableJoinsScope(owner, reflection, options);
+      }
+
+      // `Association#find_target`'s first statement (association.rb:248-250).
+      // Gated by `find_target?`: a new-record owner without the key present never
+      // reaches `find_target` and so never raises.
       if (
         this.isViolatesStrictLoading() &&
         _findTargetReachable(owner, assocName, options, isBelongsTo ? "belongsTo" : "foreign")
@@ -325,9 +336,6 @@ export class SingularAssociation extends Association {
       // still routes the shapes AssociationScope cannot build through the two-step
       // `HasOneThroughAssociation#findTarget`.
       if (!isBelongsTo && options.through) {
-        if (_canRouteThroughViaDisableJoinsAssociationScope(reflection, options)) {
-          return _loadSingularThroughViaDisableJoinsScope(owner, reflection, options);
-        }
         if (!_routeThroughViaAssociationScope(owner, reflection, options)) {
           return (
             this as unknown as { loadHasOneThrough(): Promise<Base | null> }

--- a/packages/activerecord/src/strict-loading-sync-reader.test.ts
+++ b/packages/activerecord/src/strict-loading-sync-reader.test.ts
@@ -36,6 +36,34 @@ describe("strict loading — sync singular reader (Phase R.3)", () => {
     expect(dev.id).toBe(developers("david").id);
   });
 
+  // `Association#violates_strict_loading?` (association.rb:284-292) ends at
+  // `owner.strict_loading? && !owner.strict_loading_n_plus_one_only?`, so the
+  // first level loads lazily under `:n_plus_one_only` — the sync reader has to
+  // consult the same predicate rather than the bare owner flag.
+  it("sync belongsTo access does not throw under n_plus_one_only mode", async () => {
+    const ship = await Ship.create({ name: "N+1 Ship", developer_id: developers("david").id });
+    ship.strictLoadingBang(true, { mode: "n_plus_one_only" });
+    expect(() => (ship as any).developer).not.toThrow();
+  });
+
+  // `return reflection.strict_loading? if reflection.options.key?(:strict_loading)`
+  // — the reflection-level option wins over the owner's flag, in both directions.
+  it("sync hasOne access does not throw when the reflection opts out of strict loading", async () => {
+    const developer = await Developer.find(developers("jamis").id);
+    developer.strictLoadingBang();
+    const options = (
+      Developer as unknown as {
+        _reflectOnAssociation(name: string): { options: Record<string, unknown> };
+      }
+    )._reflectOnAssociation("ship").options;
+    options.strictLoading = false;
+    try {
+      expect(() => (developer as any).ship).not.toThrow();
+    } finally {
+      delete options.strictLoading;
+    }
+  });
+
   it("strict loading stays off by default (Rails parity)", () => {
     expect(Ship.strictLoadingByDefault).toBe(false);
     expect(Developer.strictLoadingByDefault).toBe(false);

--- a/packages/activerecord/src/strict-loading.trails.test.ts
+++ b/packages/activerecord/src/strict-loading.trails.test.ts
@@ -16,6 +16,12 @@ import { Developer, AuditLog } from "./test-helpers/models/developer.js";
 import { Ship } from "./test-helpers/models/ship.js";
 import { Project } from "./test-helpers/models/project.js";
 import { Firm } from "./test-helpers/models/company.js";
+import { Author } from "./test-helpers/models/author.js";
+import { Post } from "./test-helpers/models/post.js";
+import { Comment } from "./test-helpers/models/comment.js";
+import { Member } from "./test-helpers/models/member.js";
+import { Membership, CurrentMembership } from "./test-helpers/models/membership.js";
+import { Club } from "./test-helpers/models/club.js";
 
 interface ReflectionHost {
   _reflectOnAssociation(name: string): { options: Record<string, unknown> };
@@ -45,7 +51,15 @@ interface ReflectionHost {
 describe("StrictLoadingNewRecordFindTargetTest", () => {
   // `fixtures` wires the handler suite internally; the `developers`
   // fixture gives a persisted owner for the unchanged-behavior assertion.
-  const { developers } = fixtures(["developers"]);
+  const { developers, authors, members } = fixtures([
+    "developers",
+    "authors",
+    "posts",
+    "comments",
+    "members",
+    "memberships",
+    "clubs",
+  ]);
   // The loaders resolve target classes by name from the registry; register the
   // canonical targets so `Developer`'s declared associations resolve.
   registerModel(Developer);
@@ -53,6 +67,7 @@ describe("StrictLoadingNewRecordFindTargetTest", () => {
   registerModel(Ship);
   registerModel(Project);
   registerModel(Firm);
+  registerModel([Author, Post, Comment, Member, Membership, CurrentMembership, Club]);
 
   const optionsFor = (name: string) =>
     (Developer as unknown as ReflectionHost)._reflectOnAssociation(name).options;
@@ -111,6 +126,29 @@ describe("StrictLoadingNewRecordFindTargetTest", () => {
     await expect(
       findHasManyTarget(developer, "auditLogs", optionsFor("auditLogs")),
     ).rejects.toThrow(StrictLoadingViolationError);
+  });
+
+  // `SingularAssociation#find_target` (singular_association.rb:47-55) answers a
+  // `disable_joins` association from `scope.first`, and
+  // `HasManyThroughAssociation#find_target` (has_many_through_association.rb
+  // :225-229) returns `scope.to_a if disable_joins` — both BEFORE `super`, so
+  // neither route reaches the strict-loading raise in the base body.
+  it("does not raise on lazy loading a disable_joins has_many :through on a strict-loading owner", async () => {
+    const author = await Author.find(authors("david").id);
+    author.strictLoadingBang();
+    await expect(
+      findHasManyTarget(
+        author,
+        "noJoinsComments",
+        (Author as unknown as ReflectionHost)._reflectOnAssociation("noJoinsComments").options,
+      ),
+    ).resolves.toBeInstanceOf(Array);
+  });
+
+  it("does not raise on lazy loading a disable_joins has_one :through on a strict-loading owner", async () => {
+    const member = await Member.find(members("groucho").id);
+    member.strictLoadingBang();
+    await expect(loadSingularTarget(member, "clubWithoutJoins")).resolves.not.toBeUndefined();
   });
 
   it("still raises on lazy loading a strict-loading has_many on a persisted owner", async () => {


### PR DESCRIPTION
## What

`Association#violates_strict_loading?` (vendor/rails/activerecord/lib/active_record/associations/association.rb:284-292) had a faithful body in trails (`associations/association.ts`) but **nothing called it** — every strict-loading raise was gated instead by an ad-hoc `_violatesStrictLoading(record, options)` duplicate in `associations.ts`.

This wires the ported predicate into the Rails call sites and deletes the duplicate.

- `HasManyAssociation#findTarget` evaluates `this.isViolatesStrictLoading()` and hands the result to the module-private loader, which raises after the cache/preload lookups — those lookups are Rails' `find_target?` guard (association.rb:190), so the check cannot be hoisted above them. The predicate reads only owner/reflection state, so evaluating it at the call site is the same answer.
- `SingularAssociation#findTarget` calls it directly, as `find_target`'s first statement does (association.rb:248-250).
- `SingularAssociation#reader` calls it in place of the ad-hoc `_isStrictOnOwner()`, now deleted. That helper read only `owner._strictLoading && !bypass`, so the sync reader raised under `:n_plus_one_only` and ignored a reflection-level `strictLoading: false`.
- `CollectionProxy#_checkStrictLoading` consults the owner's association instance; the proxy `get` trap in `associations.ts` now routes through that one method rather than re-implementing the raise.

The `@skip_strict_loading` guard in the ported body reads two flags: the association ivar Rails has, plus the owner-level bypass counter trails' explicit loaders (`loadBelongsTo` / `loadHasOne` / `CollectionProxy#_withoutStrictLoading`) raise — those run where Ruby would have had an association handle to call `skip_strict_loading` on. The reflection branch now uses `hasOwnProperty` (Rails' `options.key?`) rather than `in`.

## Tests

`strict_loading_test.rb` is enrolled 54/54 and covers all four branches — `skip_strict_loading` (`strict loading on concat is ignored`, `strict loading with new record on concat is ignored`), validation context (2 tests), reflection-level `strict_loading:`, and `n_plus_one_only` (4 tests). All pass, as do the 99 `associations/` test files (2146 tests).

Two trails-only sync-reader tests added for the branches `_isStrictOnOwner` was blind to (both fail on baseline): `:n_plus_one_only` mode, and a reflection opting out of strict loading.

Gates: `parity:api:calls` OK, `parity:api:calls:args` OK, no novel extra surface (this only removes a function).

Closes-story: wire-violates-strict-loading-call-site