### PR TITLE
refactor(activerecord,activesupport,date): route _update_record through _update_row; port transform_keys, rb_warning, m_real_cwyear and ::Time's range checks

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -4833,6 +4833,24 @@ for (const [name, fn] of [
     },
   ],
   [
+    // Rails' MRO for `_update_row` is Persistence ← Locking::Optimistic
+    // (base.rb includes Locking::Optimistic after Persistence), so the locking
+    // body runs first and reaches Persistence's through `super`
+    // (optimistic.rb:92-118 over persistence.rb:884-889). Without this wiring
+    // the override was never installed and neither the save path nor `touch`
+    // enforced the lock-version WHERE.
+    "_updateRow",
+    function (this: Base, attributeNames: string[], attemptedAction = "update"): Promise<number> {
+      return LockingOptimistic._updateRow.call(
+        this as any,
+        attributeNames,
+        attemptedAction,
+        (names: string[], action: string) =>
+          _Persistence._updateRow.call(this as any, names, action),
+      );
+    },
+  ],
+  [
     "_updateRecord",
     function (this: Base, block?: (record: Base) => void): Promise<boolean> {
       return Timestamp._updateRecord.call(this as any, () =>

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -4833,12 +4833,6 @@ for (const [name, fn] of [
     },
   ],
   [
-    // Rails' MRO for `_update_row` is Persistence ← Locking::Optimistic
-    // (base.rb includes Locking::Optimistic after Persistence), so the locking
-    // body runs first and reaches Persistence's through `super`
-    // (optimistic.rb:92-118 over persistence.rb:884-889). Without this wiring
-    // the override was never installed and neither the save path nor `touch`
-    // enforced the lock-version WHERE.
     "_updateRow",
     function (this: Base, attributeNames: string[], attemptedAction = "update"): Promise<number> {
       return LockingOptimistic._updateRow.call(

--- a/packages/activerecord/src/connection-adapters/abstract/sql-datetime.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/sql-datetime.ts
@@ -23,7 +23,7 @@
  * address and calls into this file.
  */
 
-import { Rational, Temporal, strftime, type StrftimeSubject } from "@blazetrails/date";
+import { Rational, Temporal, cCivilToJd, strftime, type StrftimeSubject } from "@blazetrails/date";
 import { ActiveRecord } from "../../ar-config.js";
 
 /**
@@ -56,6 +56,9 @@ function strftimeSubject(v: {
 }): StrftimeSubject {
   return {
     year: v.year,
+    jd: cCivilToJd(v.year, v.month, v.day),
+    nth: 0n,
+    gregorianP: true,
     mon: v.month,
     day: v.day,
     wday: v.dayOfWeek % 7,

--- a/packages/activerecord/src/locking/optimistic.ts
+++ b/packages/activerecord/src/locking/optimistic.ts
@@ -171,9 +171,16 @@ type InstanceLockingHost = {
   constructor: typeof Base & LockingHost;
   _attributes: {
     getAttribute(name: string): {
+      value: unknown;
+      valueBeforeTypeCast: unknown;
+      type: unknown;
       valueForDatabase: unknown;
       originalValueForDatabase(): unknown;
     };
+    set(name: string, attribute: unknown): void;
+  };
+  _dirty: {
+    attributeWritten(name: string, value: unknown, before: unknown, type: unknown): void;
   };
   readAttribute(name: string): unknown;
   writeAttribute(name: string, value: unknown): void;
@@ -229,11 +236,12 @@ export async function _updateRow(
   if (!ctor.lockingEnabled) return superFn(attributeNames, attemptedAction);
 
   const col = ctor.lockingColumn;
-  const lockVersionWas = this.readAttribute(col);
-  const baseConstraints = buildBaseConstraints(this, ctor);
-  const updateConstraints = { ...baseConstraints, [col]: _lockValueForDatabase.call(this, col) };
+  const lockAttributeWas = this._attributes.getAttribute(col);
 
-  attributeNames = [...attributeNames.filter((n) => n !== col), col];
+  const updateConstraints = _queryConstraintsHash.call(this, buildBaseConstraints(this, ctor));
+
+  attributeNames = [...attributeNames, col];
+
   this.writeAttribute(col, (Number(this.readAttribute(col)) || 0) + 1);
 
   try {
@@ -242,10 +250,18 @@ export async function _updateRow(
       attributesWithValues.call(this as any, attributeNames),
       updateConstraints,
     );
+
     if (affectedRows !== 1) throw new StaleObjectError(this, attemptedAction);
+
     return affectedRows;
   } catch (e) {
-    this.writeAttribute(col, lockVersionWas);
+    this._attributes.set(col, lockAttributeWas);
+    this._dirty.attributeWritten(
+      col,
+      lockAttributeWas.value,
+      lockAttributeWas.valueBeforeTypeCast,
+      lockAttributeWas.type,
+    );
     throw e;
   }
 }
@@ -269,15 +285,15 @@ export function destroyRow(
 /**
  * @internal
  * Mirrors: ActiveRecord::Locking::Optimistic#_lock_value_for_database
+ *
+ * `Attribute::FromDatabase#_original_value_for_database` is the raw
+ * `value_before_type_cast`, so a lock column that is NULL in the row constrains
+ * on NULL: `LockingType#deserialize`'s `nil.to_i` 0 never reaches the WHERE.
  */
 export function _lockValueForDatabase(this: InstanceLockingHost, lockingColumn: string): unknown {
   if (isWillSaveChangeToAttribute(this as any, lockingColumn)) {
     return this._attributes.getAttribute(lockingColumn).valueForDatabase;
   }
-  // `Attribute::FromDatabase#_original_value_for_database` is the raw
-  // `value_before_type_cast`, so a lock column that is NULL in the row
-  // constrains on NULL — `LockingType#deserialize`'s `nil.to_i` 0 never reaches
-  // the WHERE (locking/optimistic.rb:134-139, activemodel attribute.rb).
   return this._attributes.getAttribute(lockingColumn).originalValueForDatabase();
 }
 

--- a/packages/activerecord/src/locking/optimistic.ts
+++ b/packages/activerecord/src/locking/optimistic.ts
@@ -1,7 +1,7 @@
 import type { Base } from "../base.js";
 import { StaleObjectError } from "../errors.js";
 import { Type, ValueType } from "@blazetrails/activemodel";
-import { isWillSaveChangeToAttribute, attributeInDatabase } from "../attribute-methods/dirty.js";
+import { isWillSaveChangeToAttribute } from "../attribute-methods/dirty.js";
 import { queryConstraintsList, _updateRecord as persistenceUpdateRecord } from "../persistence.js";
 import { attributesWithValues } from "../attribute-methods.js";
 import { reloadSchemaFromCache } from "../model-schema.js";
@@ -169,6 +169,12 @@ export async function updateCounters(
 
 type InstanceLockingHost = {
   constructor: typeof Base & LockingHost;
+  _attributes: {
+    getAttribute(name: string): {
+      valueForDatabase: unknown;
+      originalValueForDatabase(): unknown;
+    };
+  };
   readAttribute(name: string): unknown;
   writeAttribute(name: string, value: unknown): void;
   clearAttributeChange(name: string): void;
@@ -266,9 +272,13 @@ export function destroyRow(
  */
 export function _lockValueForDatabase(this: InstanceLockingHost, lockingColumn: string): unknown {
   if (isWillSaveChangeToAttribute(this as any, lockingColumn)) {
-    return this.readAttribute(lockingColumn) ?? 0;
+    return this._attributes.getAttribute(lockingColumn).valueForDatabase;
   }
-  return attributeInDatabase(this as any, lockingColumn) ?? 0;
+  // `Attribute::FromDatabase#_original_value_for_database` is the raw
+  // `value_before_type_cast`, so a lock column that is NULL in the row
+  // constrains on NULL — `LockingType#deserialize`'s `nil.to_i` 0 never reaches
+  // the WHERE (locking/optimistic.rb:134-139, activemodel attribute.rb).
+  return this._attributes.getAttribute(lockingColumn).originalValueForDatabase();
 }
 
 /**

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -339,7 +339,7 @@ export async function _updateRecord(
 
   const adapter = threadedConnectionFor((this as any).constructor) ?? (this as any).connection;
   if (typeof adapter.update === "function") {
-    return adapter.update(um);
+    return adapter.update(um, `${(this as any).name} Update`);
   }
   const sql = adapter.toSql(um);
   return adapter.executeMutation(sql);

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -29,7 +29,6 @@ import {
 import {
   ActiveRecordError,
   ReadOnlyRecord,
-  StaleObjectError,
   RecordNotDestroyed,
   RecordNotSaved,
   UnknownAttributeError,
@@ -1943,7 +1942,9 @@ export function _touchRow(
   for (const attr of attributeNames) {
     this._writeAttribute(attr, t);
   }
-  return _updateRow.call(this, attributeNames, "touch");
+  // Rails calls the METHOD (persistence.rb:874-882), so a locking-enabled
+  // model reaches `Locking::Optimistic#_update_row` here too.
+  return (this as any)._updateRow(attributeNames, "touch");
 }
 
 /** @internal */
@@ -1959,36 +1960,6 @@ export function _updateRow(
   );
 }
 
-// Build the Arel value node for one write-path column (INSERT VALUES / UPDATE
-// SET). Mirrors Rails' `_insert_record`/`_update_record`, which hand every
-// column to the Arel visitor as an `ActiveModel::Attribute` so
-// `visit_ActiveModel_Attribute → collector.add_bind(o)` binds it as a typed
-// prepared-statement parameter (`type_casted_binds`) — null bytes round-trip
-// and intermediate database values (BinaryData, Temporal, BigDecimal) are
-// finished off by each adapter's bind normalization instead of being inlined
-// via `quote()`.
-//
-// Deviation: the bind carries the pre-extracted `valuesForDatabase()` primitive
-// where Rails' AST carries the Attribute object itself (attribute_methods.rb
-// `attributes_with_values` → persistence.rb `_insert_record`/`_update_record`),
-// keeping type metadata until the adapter's `type_casted_binds`. In trails the
-// Attribute would be resolved to the very same primitive one step later anyway:
-// `toSqlAndBinds` (abstract/database-statements.ts) unwraps every ModelAttribute
-// bind to `valueForDatabase` at compile time — a trails-wide seam shared with
-// the read path and relied on by query-cache keying
-// (`JSON.stringify([sql, binds])`), so threading the Attribute through here is
-// inert. The only driver dispatch keyed off attribute type (SQLite's
-// FloatType → SQLITE_FLOAT for whole-valued floats) is not observable for
-// table writes: a float column's REAL affinity converts an INTEGER-typed bind
-// on storage (verified: `typeof(col)` is 'real' either way).
-// Array columns bind like every other column: `value_for_database` yields the
-// PG `OID::Array::Data` wrapper, which `type_casted_binds` routes through
-// `encode_array` (postgresql/quoting.rb) so the driver receives the encoded
-// `{…}` literal as one bound parameter typed by the column.
-function writePathValueNode(raw: unknown): InstanceType<typeof Nodes.Node> {
-  return new Nodes.BindParam(raw);
-}
-
 /**
  * The bottom of the update super chain: the UPDATE, `@previously_new_record =
  * false`, then the `save(&block)` yield.
@@ -2000,120 +1971,18 @@ async function instanceUpdateRecord(
   this: PersistenceInstanceChainHost,
   block?: (record: any) => void,
 ): Promise<boolean> {
-  const ctor = this.constructor;
-
-  // Rails resolves no connection here: `_update_record` delegates the write to
-  // `_update_row` → the class-level `_update_record`, which does the
-  // `with_connection` (persistence.rb:906, 944-946). While that delegation is
-  // deferred (see below), thread the connection the enclosing
-  // `withQueryConnection` already leased rather than the deprecated
-  // `.connection` getter, so the UPDATE does not flip the lease permanent.
-  const adapter = threadedConnectionFor(ctor) ?? ctor.connection;
-
-  const table = ctor.arelTable;
-
   // Rails AttributeMethods::Dirty#_update_record's default argument
   // (dirty.rb:233) — with partial_updates off it is every attribute name.
   let attributeNames = attributeNamesForPartialUpdates.call(this as any);
   attributeNames = attributesForUpdate.call(this as any, attributeNames);
 
-  // Mirrors Rails _update_record's `if attribute_names.empty?` branch: no
-  // columns to write ⇒ affected_rows = 0 but @_trigger_update_callback = true.
   if (attributeNames.length === 0) {
     (this as any)._triggerUpdateCallback = true;
   } else {
-    // Deviation: Rails delegates the row write to `_update_row(attribute_names)`
-    // (persistence.rb:906), which `Locking::Optimistic#_update_row`
-    // (optimistic.rb:92-118) overrides for the lock bump and the
-    // `affected_rows != 1` raise. trails has both halves — `_updateRow` below
-    // and `LockingOptimistic._updateRow` — but they build their values from
-    // `attributes_with_values` (cast values) where this path binds
-    // `valuesForDatabase()` write-path primitives, so routing through them
-    // changes what reaches the adapter for every column type. Converged by
-    // story `route-update-record-through-update-row` (RFC 0084), which owns
-    // that bind-path change and the missing `LockingOptimistic._updateRow`
-    // install.
-    const dbValues = this._attributes.valuesForDatabase();
-    const updateValues: [InstanceType<typeof Nodes.Node>, unknown][] = attributeNames.map(
-      (key: string) => [table.get(key), writePathValueNode(dbValues[key])],
-    );
-
-    // Optimistic locking: include lock column in WHERE and increment it.
-    // Remove any user-supplied lock column entry from the SET list first —
-    // it will be replaced with the auto-incremented value to avoid a
-    // "multiple assignments to same column" error on PostgreSQL.
-    const lockCol = ctor.lockingColumn;
-    let lockAttributeWas: import("@blazetrails/activemodel").Attribute | null = null;
-    let lockWhereValue: unknown;
-    if (ctor.lockingEnabled) {
-      const rawVersion = this.readAttribute(lockCol);
-      const currentVersion = rawVersion == null ? 0 : Number(rawVersion);
-      // Mirrors Rails _lock_value_for_database:
-      // - User explicitly changed lock_version (e.g. person.lock_version = 42):
-      //   use valueForDatabase so WHERE = 42. DB has 0 → StaleObjectError.
-      // - Normal auto-increment path: use originalValueForDatabase() so
-      //   NULL-in-DB records generate IS NULL, freshly-created records generate = 0.
-      // Must be read BEFORE mutating _attributes below.
-      const lockAttr = this._attributes.getAttribute(lockCol);
-      lockAttributeWas = lockAttr; // snapshot for stale restore (mirrors Rails lock_attribute_was)
-      if (this.willSaveChangeToAttribute(lockCol)) {
-        lockWhereValue = lockAttr.valueForDatabase;
-      } else {
-        lockWhereValue = lockAttr.originalValueForDatabase();
-      }
-      const lockIdx = attributeNames.indexOf(lockCol);
-      if (lockIdx !== -1) updateValues.splice(lockIdx, 1);
-      this._writeAttribute(lockCol, currentVersion + 1);
-      // Rails increments `self[locking_column]` and lets `_update_record` pass
-      // the attribute to Arel like every other SET column (optimistic.rb:
-      // 101-108 → persistence.rb attributes_with_values), so the bumped lock
-      // value is bound, not inlined — route through the same write-path node.
-      updateValues.push([table.get(lockCol), writePathValueNode(currentVersion + 1)]);
-    }
-
-    const um = new UpdateManager()
-      .table(table)
-      .set(updateValues)
-      // Mirrors Rails _update_record(_query_constraints_hash): WHERE targets
-      // each query-constraint column's `*_in_database` value (just the primary
-      // key keyed to `id_in_database` when no query_constraints are declared),
-      // so a dirty primary key updates the original row (and can write a new PK
-      // value into it).
-      .where(ctor._buildQueryConstraintsWhereNode(_queryConstraintsHash.call(this as any)));
-    if (ctor.lockingEnabled) {
-      if (lockWhereValue == null) {
-        um.where(table.get(lockCol).eq(null));
-      } else {
-        um.where(table.get(lockCol).eq(lockWhereValue));
-      }
-    }
-    applyDefaultAndGlobalConstraints(um as any, ctor);
-
-    const [updateSql, updateBinds] = adapter.toSqlAndBinds(um);
-    const affectedRows = await adapter.execUpdate(updateSql, `${ctor.name} Update`, updateBinds);
-    // Mirrors Rails Locking::Optimistic#_update_row (optimistic.rb:110):
-    // `raise StaleObjectError if affected_rows != 1` — not just `=== 0`.
-    if (ctor.lockingEnabled && affectedRows !== 1) {
-      // Mirrors Rails _update_row rescue: `@attributes[locking_column] =
-      // lock_attribute_was` restores the attribute snapshot so NULL-in-DB
-      // records don't lose their original null valueBeforeTypeCast.
-      if (lockAttributeWas !== null) {
-        this._attributes.set(lockCol, lockAttributeWas);
-        // Rails derives dirty state from @attributes, so restoring
-        // lock_attribute_was also reverts the auto-increment bump's dirty
-        // entry. Our DirtyTracker is a separate map, so recompute lockCol
-        // against the snapshot baseline: this drops the auto-bump (clean →
-        // clean) while preserving any user-set lock_version change.
-        (this._dirty as any).attributeWritten(
-          lockCol,
-          lockAttributeWas.value,
-          lockAttributeWas.valueBeforeTypeCast,
-          lockAttributeWas.type,
-        );
-      }
-      throw new StaleObjectError(this, "update");
-    }
-    // Mirrors Rails _update_record: `@_trigger_update_callback = affected_rows == 1`.
+    // Rails calls the METHOD (persistence.rb:906), so
+    // `Locking::Optimistic#_update_row` (optimistic.rb:92-118) — wired over
+    // `_Persistence._updateRow` in base.ts — takes it when locking is enabled.
+    const affectedRows: number = await (this as any)._updateRow(attributeNames);
     // A stale update whose WHERE matched no row (row deleted by another
     // instance earlier in the transaction) leaves the flag false, so
     // after_update_commit / after_rollback(on: :update) don't fire.

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -1942,8 +1942,6 @@ export function _touchRow(
   for (const attr of attributeNames) {
     this._writeAttribute(attr, t);
   }
-  // Rails calls the METHOD (persistence.rb:874-882), so a locking-enabled
-  // model reaches `Locking::Optimistic#_update_row` here too.
   return (this as any)._updateRow(attributeNames, "touch");
 }
 
@@ -1979,9 +1977,6 @@ async function instanceUpdateRecord(
   if (attributeNames.length === 0) {
     (this as any)._triggerUpdateCallback = true;
   } else {
-    // Rails calls the METHOD (persistence.rb:906), so
-    // `Locking::Optimistic#_update_row` (optimistic.rb:92-118) — wired over
-    // `_Persistence._updateRow` in base.ts — takes it when locking is enabled.
     const affectedRows: number = await (this as any)._updateRow(attributeNames);
     // A stale update whose WHERE matched no row (row deleted by another
     // instance earlier in the transaction) leaves the flag false, so

--- a/packages/activesupport/src/hash-utils.ts
+++ b/packages/activesupport/src/hash-utils.ts
@@ -189,11 +189,7 @@ export function extractOptionsBang<T>(args: T[]): [T[], AnyObject] {
  * Convert all keys to strings (Rails' stringify_keys).
  */
 export function stringifyKeys<T extends AnyObject>(obj: T): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
-  for (const key of Object.keys(obj)) {
-    result[String(key)] = obj[key];
-  }
-  return result;
+  return transformKeys(obj, (k) => String(k));
 }
 
 /**
@@ -216,7 +212,7 @@ export function deepStringifyKeys(obj: unknown): unknown {
  * equivalent to stringifyKeys but mirrors Rails' symbolize_keys semantics.
  */
 export function symbolizeKeys<T extends AnyObject>(obj: T): Record<string, unknown> {
-  return stringifyKeys(obj);
+  return transformKeys(obj, (key) => key);
 }
 
 /**
@@ -226,7 +222,7 @@ export function symbolizeKeys<T extends AnyObject>(obj: T): Record<string, unkno
  * `stringify_keys`'s here.
  */
 export function symbolizeKeysBang<T extends AnyObject>(hash: T): T {
-  return stringifyKeysBang(hash);
+  return transformKeysBang(hash, (key) => key);
 }
 
 /**
@@ -319,11 +315,32 @@ export function _deepTransformKeysInObjectBang(
 }
 
 /**
+ * Ruby's `Hash#transform_keys` — a new hash with each key replaced by the
+ * block's result. The primitive the `keys.rb` key casts are written on top of.
+ *
+ * @noRailsEquivalent PERMANENT — Ruby core `Hash`, not Rails. `keys.rb` writes
+ * every key cast on top of it (keys.rb:11, :22) but never defines it, so there
+ * is no Rails method for the port to converge on; JS objects have no such
+ * primitive, so it is spelled here in the file that consumes it.
+ */
+export function transformKeys<T extends AnyObject>(
+  hash: T,
+  block: (key: string) => string,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const key of Object.keys(hash)) {
+    result[block(key)] = hash[key];
+  }
+  return result;
+}
+
+/**
  * Ruby's `Hash#transform_keys!`, the in-place primitive the `keys.rb` bang
  * forms are written on top of.
- * @internal
+ *
+ * @noRailsEquivalent PERMANENT — Ruby core `Hash`, as {@link transformKeys} is.
  */
-function transformKeysBang<T extends AnyObject>(hash: T, block: (key: string) => string): T {
+export function transformKeysBang<T extends AnyObject>(hash: T, block: (key: string) => string): T {
   for (const key of Object.keys(hash)) {
     const value = hash[key];
     delete hash[key];

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -11,7 +11,7 @@ import { currentTime } from "./time-travel.js";
 import { getZone, findZoneBang } from "./time-zone-config.js";
 import { Temporal } from "@blazetrails/date";
 import { instantFrom } from "./temporal.js";
-import { Rational, strftime } from "@blazetrails/date";
+import { Rational, cCivilToJd, strftime } from "@blazetrails/date";
 import { Encoding } from "./json/encoding.js";
 
 /**
@@ -397,6 +397,9 @@ export class TimeWithZone {
     return strftime(
       {
         year: l.year,
+        jd: cCivilToJd(l.year, l.month, l.day),
+        nth: 0n,
+        gregorianP: true,
         mon: l.month,
         day: l.day,
         wday: this.wday,

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -1055,11 +1055,6 @@ describe("Date", () => {
   });
 
   it("reads strftime's week numbers off the residue day, as the C's int readers do", () => {
-    // ruby 3.3.11 -rdate:
-    //   Date.jd(2**70).strftime("%G|%V|%U") #=> "3232350070754114273|02|01"
-    // `%G` is `m_real_cwyear` (date_core.c:1858-1873) — `m_cwyear`'s `int` over
-    // the residue day with `nth` encoded back in — while `%V`/`%U`/`%W` read
-    // `m_cweek`/`m_wnum0`/`m_wnum1`, which stay `int`s and never see `nth`.
     const d = dNewByFrags({ jd: 2n ** 70n });
     expect(d.strftime("%G|%V|%U")).toBe("3232350070754114273|02|01");
     expect(d.strftime("%W|%g")).toBe("01|73");

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -1054,6 +1054,17 @@ describe("Date", () => {
     expect(dt.jd).toBe(1180591620717411303424n);
   });
 
+  it("reads strftime's week numbers off the residue day, as the C's int readers do", () => {
+    // ruby 3.3.11 -rdate:
+    //   Date.jd(2**70).strftime("%G|%V|%U") #=> "3232350070754114273|02|01"
+    // `%G` is `m_real_cwyear` (date_core.c:1858-1873) — `m_cwyear`'s `int` over
+    // the residue day with `nth` encoded back in — while `%V`/`%U`/`%W` read
+    // `m_cweek`/`m_wnum0`/`m_wnum1`, which stay `int`s and never see `nth`.
+    const d = dNewByFrags({ jd: 2n ** 70n });
+    expect(d.strftime("%G|%V|%U")).toBe("3232350070754114273|02|01");
+    expect(d.strftime("%W|%g")).toBe("01|73");
+  });
+
   it("truncates a fractional year through valid_civil_p, as decode_year does", () => {
     // ruby 3.3.11 -rdate — valid_civil_p (date_core.c:2246-2277) runs
     // decode_year before c_valid_civil_p's `int y`, and the truncation is of

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -21,6 +21,7 @@
  */
 
 import { Temporal } from "@js-temporal/polyfill";
+import { rbWarning } from "./rb-warning.js";
 
 const DAY_NAMES = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
 const ABBR_DAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
@@ -70,6 +71,18 @@ function pad2(n: number): string {
  */
 export interface StrftimeSubject {
   year: number | bigint;
+  /**
+   * `m_local_jd` (`date_core.c:1485-1497`), the residue Julian day the
+   * week-number readers below are defined over. It is carried rather than
+   * rebuilt from {@link StrftimeSubject.year}, which is the REAL year
+   * (`m_real_year`, `date_core.c:1746-1762`) and has no `int` to rebuild from
+   * once `nth` is nonzero.
+   */
+  jd: number;
+  /** `m_nth` (`date_core.c:1478-1483`), the period count `year` encodes. */
+  nth: bigint;
+  /** `m_gregorian_p` (`date_core.c:1965-1973`), which picks `encode_year`'s period. */
+  gregorianP: boolean;
   mon: number;
   day: number;
   wday: number;
@@ -118,6 +131,9 @@ function temporalSubject(
 
   return {
     year: plain.year,
+    jd: cCivilToJd(plain.year, plain.month, plain.day),
+    nth: 0n,
+    gregorianP: true,
     mon: plain.month,
     day: plain.day,
     wday: cJdToWday(cCivilToJd(plain.year, plain.month, plain.day)),
@@ -150,7 +166,7 @@ function temporalSubject(
  */
 function epochSeconds(subject: StrftimeSubject): number {
   return (
-    (mLocalJd(subject) - UNIX_EPOCH_IN_CJD) * DAY_IN_SECONDS +
+    (subject.jd - UNIX_EPOCH_IN_CJD) * DAY_IN_SECONDS +
     timeToDf(subject.hour, subject.min, subject.sec) -
     subject.utcOffset
   );
@@ -169,27 +185,18 @@ function msecs(subject: StrftimeSubject): number {
 }
 
 /**
- * @internal `m_local_jd` (`date_core.c:1485-1497`), the Julian day the
- * week-number readers below work off. The subject carries the civil date and no
- * `df`, so the `complex_dat_p` arm's `local_jd` shift has no bearer and the
- * conversion is {@link cCivilToJd} over it. The subject carries the REAL year,
- * `nth` and all, where the C's `c_civil_to_jd` takes the residue `int`, so the
- * conversion back is where the magnitude drops — as it does in the C's own
- * `int` day, which is what these week readers are defined over.
- */
-function mLocalJd(subject: StrftimeSubject): number {
-  return cCivilToJd(Number(subject.year), subject.mon, subject.day);
-}
-
-/**
- * @internal `m_cwyear` (`date_core.c:1848-1856`), which reaches `%G`
+ * @internal `m_real_cwyear` (`date_core.c:1858-1873`) over `m_cwyear`
+ * (`date_core.c:1848-1856`), which reaches `%G`
  * (`date_strftime.c:238`) and `%g` (`date_strftime.c:251`) as the `cwyear` slot
  * of the `tmx_funcs` table (`date_core.c:7153`, through `m_real_cwyear`) that
- * `tmx_cwyear` (`date_tmx.h:35`) reads.
+ * `tmx_cwyear` (`date_tmx.h:35`) reads. `m_cwyear` is an `int` over the residue
+ * day; `m_real_cwyear` puts `nth` back afterwards, exactly as `m_real_year`
+ * does, so `%G` past a Fixnum answers a `bigint`.
  */
-function cwyear(subject: StrftimeSubject): number {
-  const [ry] = cJdToCommercial(mLocalJd(subject));
-  return ry;
+function cwyear(subject: StrftimeSubject): number | bigint {
+  const [ry] = cJdToCommercial(subject.jd);
+  if (subject.nth === 0n) return ry;
+  return encodeYear(subject.nth, ry, subject.gregorianP ? -1 : +1);
 }
 
 /**
@@ -198,7 +205,7 @@ function cwyear(subject: StrftimeSubject): number {
  * (`date_core.c:7154`) that `tmx_cweek` (`date_tmx.h:36`) reads.
  */
 function cweek(subject: StrftimeSubject): number {
-  const [, rw] = cJdToCommercial(mLocalJd(subject));
+  const [, rw] = cJdToCommercial(subject.jd);
   return rw;
 }
 
@@ -209,7 +216,7 @@ function cweek(subject: StrftimeSubject): number {
  * between the two.
  */
 function wnumx(subject: StrftimeSubject, f: number): number {
-  const [, rw] = cJdToWeeknum(mLocalJd(subject), f);
+  const [, rw] = cJdToWeeknum(subject.jd, f);
   return rw;
 }
 
@@ -3486,11 +3493,13 @@ function cValidStartP(sg: number): boolean {
  * @internal `date_core.c`'s `val2sg` macro (`date_core.c:3320-3327`), the macro
  * every user-facing `start` argument is read through — the `start` counterpart
  * of {@link val2off}: whatever {@link cValidStartP} rejects becomes
- * {@link DEFAULT_SG}. The C's `rb_warning("invalid start is ignored")` is a
- * `$VERBOSE`-only warning with no analogue here, as `val2off`'s is.
+ * {@link DEFAULT_SG}.
  */
 function val2sg(vsg: number): number {
-  if (!cValidStartP(vsg)) return DEFAULT_SG;
+  if (!cValidStartP(vsg)) {
+    rbWarning("invalid start is ignored");
+    return DEFAULT_SG;
+  }
   return vsg;
 }
 
@@ -4842,7 +4851,10 @@ export function dtNewByFrags(hash: DateParts | null, sg = DEFAULT_SG): DateTime 
   // `Rational` offset truncates toward zero before the bound below — not
   // `round()`: 34399.8 becomes 34399.
   let of = to == null ? 0 : to instanceof Rational ? to.toI() : Math.trunc(to);
-  if (of < -DAY_IN_SECONDS || of > DAY_IN_SECONDS) of = 0;
+  if (of < -DAY_IN_SECONDS || of > DAY_IN_SECONDS) {
+    of = 0;
+    rbWarning("invalid offset is ignored");
+  }
 
   const [nth, rjd] = decodeJd(jd);
   return new DateTime(SEAT, nth, jdLocalToUtc(rjd, df, of), dfLocalToUtc(df, of), sf, of, sg);
@@ -4930,9 +4942,6 @@ function dayToSec(d: Rational): Rational {
  * `day_to_sec(Rational(2,1))` is `(172800/1)` and `k_rational_p(vs)` holds.
  * Folding it to an Integer here would route the value through `rounded:`
  * instead and reject `Rational(2,1)` that MRI accepts.
- *
- * C's `rb_warning("fraction of offset is ignored")` has no port analogue: it
- * writes to stderr under `$VERBOSE` only and is not part of the value.
  */
 function offsetToSec(vof: number | bigint | Rational | string): number | null {
   // `default:` (`:2398-2405`) — `expect_numeric` then `f_to_r`, so a Bignum
@@ -4950,7 +4959,9 @@ function offsetToSec(vof: number | bigint | Rational | string): number | null {
     }
     const n = vof * DAY_IN_SECONDS;
     if (n < -DAY_IN_SECONDS || n > DAY_IN_SECONDS) return null;
-    return round(n);
+    const rof = round(n);
+    if (rof !== n) rbWarning("fraction of offset is ignored");
+    return rof;
   }
   if (vof instanceof Rational) {
     const vs = dayToSec(vof);
@@ -4959,6 +4970,7 @@ function offsetToSec(vof: number | bigint | Rational | string): number | null {
       n = Number(vs.numerator);
     } else {
       n = vs.round();
+      if (vs.cmp(n) !== 0) rbWarning("fraction of offset is ignored");
       if (n < -DAY_IN_SECONDS || n > DAY_IN_SECONDS) return null;
     }
     return n;
@@ -7470,6 +7482,9 @@ export class Date {
     return strftime(
       {
         year: this.year,
+        jd: this.mLocalJd(),
+        nth: this.nth,
+        gregorianP: this.isGregorian,
         mon: this.mon,
         day: this.day,
         wday: this.wday,
@@ -8272,9 +8287,7 @@ export class DateTime extends DateWithoutParseStatics {
    * does not screen its `start` (`date_core.c:8147-8150`, against
    * `date_s_today`'s `val2sg` at `:3799-3802`).
    *
-   * An offset past a day is dropped to `0` (`date_core.c:8217-8220`); the
-   * `rb_warning("invalid offset is ignored")` beside it has no port analogue,
-   * as `val2sg`'s and `val2off`'s do not.
+   * An offset past a day is dropped to `0` (`date_core.c:8217-8220`).
    */
   static now(start = DEFAULT_SG): Temporal.PlainDateTime | Temporal.ZonedDateTime {
     const sg = start;
@@ -8293,6 +8306,7 @@ export class DateTime extends DateWithoutParseStatics {
 
     if (of < -DAY_IN_SECONDS || of > DAY_IN_SECONDS) {
       of = 0;
+      rbWarning("invalid offset is ignored");
     }
 
     const [nth, ry] = decodeYear(y, -1);
@@ -8734,6 +8748,9 @@ export class DateTime extends DateWithoutParseStatics {
     return strftime(
       {
         year: this.year,
+        jd: this.mLocalJd(),
+        nth: this.nth,
+        gregorianP: this.isGregorian,
         mon: this.mon,
         day: this.day,
         wday: this.wday,

--- a/packages/date/src/index.ts
+++ b/packages/date/src/index.ts
@@ -15,6 +15,7 @@ export {
   Date,
   DateTime,
   Rational,
+  cCivilToJd,
   dNewByFrags,
   dtNewByFrags,
   strftime,

--- a/packages/date/src/rb-warning.ts
+++ b/packages/date/src/rb-warning.ts
@@ -1,0 +1,41 @@
+/**
+ * MRI's `rb_warning` and the `$VERBOSE` global it reads, the seam ruby/date
+ * emits from at the twelve sites where it silently drops an argument it cannot
+ * use (`date_core.c`, e.g. `:8304` `"invalid offset is ignored"`).
+ *
+ * @noRailsEquivalent PERMANENT — Ruby core, not Rails. `date_core.c` calls
+ * `rb_warning` (`error.c`) directly and there is no Rails counterpart for a
+ * port to converge on.
+ */
+
+/**
+ * MRI's `ruby_verbose`, the storage behind Ruby's `$VERBOSE`. `nil` and `false`
+ * both silence {@link rbWarning}; only `true` lets one through, which is why a
+ * normal run never sees these.
+ */
+let rubyVerbose: boolean | null = false;
+
+/**
+ * Assigns `$VERBOSE`. A `set`-prefixed method rather than a setter because
+ * `$VERBOSE` is a global variable, not a member of any object.
+ */
+export function setRubyVerbose(value: boolean | null): void {
+  rubyVerbose = value;
+}
+
+/** Reads `$VERBOSE`. */
+export function getRubyVerbose(): boolean | null {
+  return rubyVerbose;
+}
+
+/**
+ * MRI's `rb_warning` (`error.c`): writes to `$stderr` under `RTEST(ruby_verbose)`
+ * only — `$VERBOSE == true` — so it is silent both by default and under
+ * `$VERBOSE = nil`. MRI prefixes the message with the source position it was
+ * raised from; there is none to carry here, so the `"warning: "` prefix stands
+ * alone.
+ */
+export function rbWarning(mesg: string): void {
+  if (rubyVerbose !== true) return;
+  console.warn(`warning: ${mesg}`);
+}

--- a/packages/date/src/test-date-strftime.test.ts
+++ b/packages/date/src/test-date-strftime.test.ts
@@ -13,15 +13,13 @@
  * through the exported `dtNewByFrags`/`dNewByFrags` builders those statics
  * themselves call — the gem-shaped object that carries `strftime`.
  *
- * `test_strftime__offset`'s `assert_warning(/invalid offset/)` arm asserts the
- * *effect* rather than the warning: `rb_warning("invalid offset is ignored")`
- * (`date_core.c:8304`) is `$VERBOSE`-only and has no port analogue — the same
- * position `date.ts` already records for `val2sg` and `val2off`. The offset
- * itself is still dropped to `0` (`date_core.c:8301-8305`), which is what the
- * assertion reads.
+ * `test_strftime__offset`'s `assert_warning(/invalid offset/)` arm goes through
+ * {@link assertWarning}, which sets `$VERBOSE` for the block the way Ruby's
+ * does — `rb_warning("invalid offset is ignored")` (`date_core.c:8304`) is
+ * emitted only under it.
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   ArgumentError,
   Errno,
@@ -31,6 +29,27 @@ import {
   dtNewByFrags,
 } from "./date.js";
 import { Time as RubyTime } from "./time.js";
+import { setRubyVerbose } from "./rb-warning.js";
+
+/**
+ * Ruby's `assert_warning` (`test/lib/core_assertions.rb`): runs the block with
+ * `$VERBOSE` set, capturing what `rb_warning` writes, and matches it against
+ * the pattern. `$VERBOSE` is restored in a `finally` so it cannot leak past the
+ * block, let alone past this file.
+ */
+function assertWarning(pattern: RegExp, block: () => void): void {
+  const stderr = vi.spyOn(console, "warn").mockImplementation(() => {});
+  let output: string;
+  setRubyVerbose(true);
+  try {
+    block();
+  } finally {
+    setRubyVerbose(false);
+    output = stderr.mock.calls.map((call) => String(call[0])).join("\n");
+    stderr.mockRestore();
+  }
+  expect(output).toMatch(pattern);
+}
 
 const gemDateTimeParse = (str: string) => dtNewByFrags(RubyDate._parse(str));
 const gemDateTimeStrptime = (str: string, fmt: string) =>
@@ -251,7 +270,9 @@ describe("TestDateStrftime", () => {
       }
     }
     for (const r of ["+2430", "-2430"]) {
-      expect(gemDateTimeParse(s + r).zone).toEqual("+00:00");
+      assertWarning(/invalid offset/, () => {
+        gemDateTimeParse(s + r);
+      });
     }
   });
 

--- a/packages/date/src/time.trails.test.ts
+++ b/packages/date/src/time.trails.test.ts
@@ -166,6 +166,13 @@ describe("Time", () => {
     expect(() => Time.utc(2015, 6, -1)).toThrow(new ArgumentError("argument out of range"));
   });
 
+  it("normalizes a day past the month's length, as MRI's timegmw does", () => {
+    expect(Time.utc(2015, 2, 29).strftime("%Y-%m-%d %H:%M:%S")).toBe("2015-03-01 00:00:00");
+    expect(Time.utc(2015, 2, 31).strftime("%Y-%m-%d")).toBe("2015-03-03");
+    expect(Time.utc(2015, 6, 31).strftime("%Y-%m-%d")).toBe("2015-07-01");
+    expect(Time.utc(2016, 2, 29).strftime("%Y-%m-%d")).toBe("2016-02-29");
+  });
+
   it("admits a 24th hour and rolls it into the next day, as MRI does", () => {
     expect(Time.utc(2015, 6, 30, 24).strftime("%Y-%m-%d %H:%M:%S")).toBe("2015-07-01 00:00:00");
     expect(() => Time.utc(2015, 6, 30, 24, 1)).toThrow(new ArgumentError("min out of range"));

--- a/packages/date/src/time.trails.test.ts
+++ b/packages/date/src/time.trails.test.ts
@@ -147,6 +147,31 @@ describe("Time", () => {
     expect(time.strftime("%L")).toBe("000");
   });
 
+  it("raises MRI's ArgumentError, naming the field, for an out-of-range positional", () => {
+    expect(() => Time.utc(2015, 6, 30, 23, 60, 0)).toThrow(new ArgumentError("min out of range"));
+    expect(() => Time.utc(2015, 13, 1)).toThrow(new ArgumentError("mon out of range"));
+    expect(() => Time.utc(2015, 6, 0)).toThrow(new ArgumentError("mday out of range"));
+    expect(() => Time.utc(2015, 6, 1, 25)).toThrow(new ArgumentError("hour out of range"));
+    expect(() => Time.utc(2015, 6, 1, 0, 0, 61)).toThrow(new ArgumentError("sec out of range"));
+  });
+
+  it("raises MRI's unnamed ArgumentError for a positional wider than its bit field", () => {
+    expect(() => Time.utc(2015, 6, 32)).toThrow(new ArgumentError("argument out of range"));
+    expect(() => Time.utc(2015, 16, 1)).toThrow(new ArgumentError("argument out of range"));
+    expect(() => Time.utc(2015, 6, 1, 32)).toThrow(new ArgumentError("argument out of range"));
+    expect(() => Time.utc(2015, 6, 1, 0, 64)).toThrow(new ArgumentError("argument out of range"));
+    expect(() => Time.utc(2015, 6, 1, 0, 0, 64)).toThrow(
+      new ArgumentError("argument out of range"),
+    );
+    expect(() => Time.utc(2015, 6, -1)).toThrow(new ArgumentError("argument out of range"));
+  });
+
+  it("admits a 24th hour and rolls it into the next day, as MRI does", () => {
+    expect(Time.utc(2015, 6, 30, 24).strftime("%Y-%m-%d %H:%M:%S")).toBe("2015-07-01 00:00:00");
+    expect(() => Time.utc(2015, 6, 30, 24, 1)).toThrow(new ArgumentError("min out of range"));
+    expect(() => Time.utc(2015, 6, 30, 24, 0, 1)).toThrow(new ArgumentError("sec out of range"));
+  });
+
   describe("in a local zone `Intl` has no abbreviation for", () => {
     afterEach(() => {
       vi.restoreAllMocks();

--- a/packages/date/src/time.ts
+++ b/packages/date/src/time.ts
@@ -202,6 +202,27 @@ function subsecNanoseconds(sec: number | Rational): number {
 }
 
 /**
+ * MRI's `obj2ubits` (`time.c`), which every `::Time` constructor positional
+ * goes through before `validate_vtm` sees it: the value has to fit in `bits`
+ * unsigned bits or the argument is rejected outright, with a message that names
+ * no field. That is why `Time.utc(2015, 6, 32)` is `"argument out of range"`
+ * while `Time.utc(2015, 6, 0)` — inside 5 bits — is `"mday out of range"`.
+ */
+function obj2ubits(obj: number, bits: number): number {
+  const usableMask = (1 << bits) - 1;
+  if ((obj & usableMask) !== obj) throw new ArgumentError("argument out of range");
+  return obj;
+}
+
+/**
+ * MRI's `validate_vtm_range` macro (`time.c`), which interpolates the struct
+ * member's own name into the message.
+ */
+function validateVtmRange(mem: string, value: number, b: number, e: number): void {
+  if (value < b || value > e) throw new ArgumentError(`${mem} out of range`);
+}
+
+/**
  * @noRailsEquivalent PERMANENT — Ruby core `::Time`. Rails never defines the
  * class, only reopens it in `core_ext/time/*.rb`, so there is no Rails
  * counterpart for a port to converge on. trails carries only the members a
@@ -291,6 +312,13 @@ export class Time {
    * `2015-07-01 00:00:00 UTC` and its `#sec` is `0`. `Temporal` rejects the
    * value outright (`RejectTime`: `0 <= 60 <= 59`), so the roll is spelled here
    * rather than in the slot. A 61st second is `ArgumentError` there and here.
+   * Every other positional is range-checked here too, ahead of the
+   * `Temporal.PlainDateTime` construction, because `Temporal` raises its own
+   * `RangeError` with its own wording where MRI raises `ArgumentError` naming
+   * the field (`time.c` `obj2ubits` / `validate_vtm`). MRI's `hour` upper bound
+   * is 24, not 23 — `Time.utc(2015, 6, 30, 24)` is `2015-07-01 00:00:00 UTC`,
+   * the same roll `sec == 60` takes, and it admits only a zero `min`/`sec`.
+   *
    * That MRI reading is why `Time#toDatetime`'s `s == 60` fold
    * (`date_core.c:8913-8915`) is unreachable through the constructor on both
    * runtimes; the C carries it for a `right/`-zoneinfo build, which is not a
@@ -307,19 +335,29 @@ export class Time {
   ) {
     const nsec = subsecNanoseconds(sec);
     const wholeSec = sec instanceof Rational ? sec.div(1) : Math.floor(sec);
-    if (wholeSec > 60) throw new ArgumentError("sec out of range");
+    obj2ubits(month, 4);
+    obj2ubits(day, 5);
+    obj2ubits(hour, 5);
+    obj2ubits(min, 6);
+    obj2ubits(wholeSec, 6);
+    validateVtmRange("mon", month, 1, 12);
+    validateVtmRange("mday", day, 1, 31);
+    validateVtmRange("hour", hour, 0, 24);
+    validateVtmRange("min", min, 0, hour === 24 ? 0 : 59);
+    validateVtmRange("sec", wholeSec, 0, hour === 24 ? 0 : 60);
     const plain = new Temporal.PlainDateTime(
       year,
       month,
       day,
-      hour,
+      hour === 24 ? 23 : hour,
       min,
       wholeSec === 60 ? 59 : wholeSec,
       Math.floor(nsec / 1_000_000),
       Math.floor(nsec / 1_000) % 1_000,
       nsec % 1_000,
     );
-    this.#plain = wholeSec === 60 ? plain.add({ seconds: 1 }) : plain;
+    this.#plain =
+      hour === 24 ? plain.add({ hours: 1 }) : wholeSec === 60 ? plain.add({ seconds: 1 }) : plain;
     const utcOffset = zone == null ? Temporal.Now.timeZoneId() : utcOffsetArgument(zone);
     this.#timeZoneId = typeof utcOffset === "number" ? null : utcOffset;
     this.#utcOffset =
@@ -524,6 +562,9 @@ export class Time {
     return strftime(
       {
         year: this.year,
+        jd: cCivilToJd(this.year, this.mon, this.day),
+        nth: 0n,
+        gregorianP: true,
         mon: this.mon,
         day: this.day,
         wday: this.wday,

--- a/packages/date/src/time.ts
+++ b/packages/date/src/time.ts
@@ -318,6 +318,11 @@ export class Time {
    * the field (`time.c` `obj2ubits` / `validate_vtm`). MRI's `hour` upper bound
    * is 24, not 23 — `Time.utc(2015, 6, 30, 24)` is `2015-07-01 00:00:00 UTC`,
    * the same roll `sec == 60` takes, and it admits only a zero `min`/`sec`.
+   * `mday` is bounded at 31 and nothing narrower: the month's own length is
+   * never checked, and `timegmw` normalizes the overflow, so
+   * `Time.utc(2015, 2, 29)` is `2015-03-01 00:00:00 UTC` and
+   * `Time.utc(2015, 2, 31)` is the 3rd of March. `Temporal.PlainDateTime`
+   * rejects both outright, so the day is carried in as `1` and added back.
    *
    * That MRI reading is why `Time#toDatetime`'s `s == 60` fold
    * (`date_core.c:8913-8915`) is unreachable through the constructor on both
@@ -348,14 +353,14 @@ export class Time {
     const plain = new Temporal.PlainDateTime(
       year,
       month,
-      day,
+      1,
       hour === 24 ? 23 : hour,
       min,
       wholeSec === 60 ? 59 : wholeSec,
       Math.floor(nsec / 1_000_000),
       Math.floor(nsec / 1_000) % 1_000,
       nsec % 1_000,
-    );
+    ).add({ days: day - 1 });
     this.#plain =
       hour === 24 ? plain.add({ hours: 1 }) : wholeSec === 60 ? plain.add({ seconds: 1 }) : plain;
     const utcOffset = zone == null ? Temporal.Now.timeZoneId() : utcOffsetArgument(zone);

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/hash-utils.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/hash-utils.json
@@ -87,41 +87,5 @@
     "rubyName": "slice!",
     "call": "replace",
     "reason": "Ruby's `Hash#replace` swaps a hash's contents in place; JS objects have no such method, so the port clears the own keys and `Object.assign`s the sliced result — the same in-place replacement."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "hash-utils.ts",
-    "rubyName": "stringify_keys",
-    "call": "transform_keys",
-    "kind": "args",
-    "rubyArgs": [],
-    "reason": "Ruby passes the key transform as a BLOCK, which contributes no positional argument; TypeScript has no block syntax, so the port passes it as a trailing function parameter (and the receiver as the leading one, the settled trails core_ext convention). Same call, same order, one extra positional."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "hash-utils.ts",
-    "rubyName": "stringify_keys!",
-    "call": "transform_keys!",
-    "kind": "args",
-    "rubyArgs": [],
-    "reason": "Ruby passes the key transform as a BLOCK, which contributes no positional argument; TypeScript has no block syntax, so the port passes it as a trailing function parameter (and the receiver as the leading one, the settled trails core_ext convention). Same call, same order, one extra positional."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "hash-utils.ts",
-    "rubyName": "symbolize_keys",
-    "call": "transform_keys",
-    "kind": "args",
-    "rubyArgs": [],
-    "reason": "Ruby passes the key transform as a BLOCK, which contributes no positional argument; TypeScript has no block syntax, so the port passes it as a trailing function parameter (and the receiver as the leading one, the settled trails core_ext convention). Same call, same order, one extra positional."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "hash-utils.ts",
-    "rubyName": "symbolize_keys!",
-    "call": "transform_keys!",
-    "kind": "args",
-    "rubyArgs": [],
-    "reason": "Ruby passes the key transform as a BLOCK, which contributes no positional argument; TypeScript has no block syntax, so the port passes it as a trailing function parameter (and the receiver as the leading one, the settled trails core_ext convention). Same call, same order, one extra positional."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/hash-utils.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/hash-utils.json
@@ -93,7 +93,9 @@
     "tsFile": "hash-utils.ts",
     "rubyName": "stringify_keys",
     "call": "transform_keys",
-    "reason": "Rails routes both key casts through `transform_keys` (keys.rb:11), the Hash primitive JS lacks: trails builds the result with an `Object.keys` loop (hash-utils.ts:145-148). Converging needs a ported `transformKeys` for plain objects to delegate to — filed as its own work, not resolvable inside the measurement fix that surfaced it."
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Ruby passes the key transform as a BLOCK, which contributes no positional argument; TypeScript has no block syntax, so the port passes it as a trailing function parameter (and the receiver as the leading one, the settled trails core_ext convention). Same call, same order, one extra positional."
   },
   {
     "package": "activesupport",
@@ -109,6 +111,17 @@
     "tsFile": "hash-utils.ts",
     "rubyName": "symbolize_keys",
     "call": "transform_keys",
-    "reason": "Same as `stringify_keys` above: Rails' `transform_keys` (keys.rb:22) has no JS Hash counterpart, so trails inlines the key loop."
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Ruby passes the key transform as a BLOCK, which contributes no positional argument; TypeScript has no block syntax, so the port passes it as a trailing function parameter (and the receiver as the leading one, the settled trails core_ext convention). Same call, same order, one extra positional."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "hash-utils.ts",
+    "rubyName": "symbolize_keys!",
+    "call": "transform_keys!",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Ruby passes the key transform as a BLOCK, which contributes no positional argument; TypeScript has no block syntax, so the port passes it as a trailing function parameter (and the receiver as the leading one, the settled trails core_ext convention). Same call, same order, one extra positional."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/time-with-zone.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/time-with-zone.json
@@ -74,17 +74,6 @@
   {
     "package": "activesupport",
     "tsFile": "time-with-zone.ts",
-    "rubyName": "strftime",
-    "call": "strftime",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:format"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-with-zone.ts",
     "rubyName": "to_fs",
     "call": "strftime",
     "kind": "args",

--- a/scripts/api-compare/receiver-as-first-arg.ts
+++ b/scripts/api-compare/receiver-as-first-arg.ts
@@ -72,6 +72,11 @@ export const RECEIVER_AS_FIRST_ARG = new Set([
   "assert_valid_keys",
   "to_param",
   "as_json",
+  // Ruby core `Hash#transform_keys(!)` — `hash.transform_keys { … }`, exported
+  // by @blazetrails/activesupport as `transformKeys(hash, block)` because JS
+  // objects have no such primitive to hang it on.
+  "transform_keys",
+  "transform_keys!",
   // active_support/core_ext/hash/indifferent_access.rb — `hash.with_indifferent_access`,
   // exported by @blazetrails/activesupport as `withIndifferentAccess(obj)`.
   "with_indifferent_access",


### PR DESCRIPTION
Five bundled stories.

### 1. `_update_record` routes through `_update_row` (RFC 0084)

`Persistence#_update_record` built its own `UpdateManager`, with its own
lock-column SET/WHERE handling and its own `StaleObjectError` throw/restore,
while trails' two correctly-shaped halves of Rails' decomposition sat unused.
Now `instanceUpdateRecord` is persistence.rb:900-916 — `attributes_for_update`,
the empty-names branch, `_update_row(attribute_names)`, `@_trigger_update_callback
= affected_rows == 1` — and nothing else.

`Locking::Optimistic#_update_row` (optimistic.rb:92-118) is wired over
`_Persistence._updateRow` in base.ts's explicit-super loop, next to
`_updateRecord`/`_createRecord`. It had **zero** call sites before this, so a
`touch` on a locking-enabled model enforced no lock-version WHERE and raised no
`StaleObjectError`; `Persistence#_touchRow` now calls the method rather than the
module function, so it reaches the override the way persistence.rb:874-882 does.

The value path converged rather than being ratified: the save path's
`valuesForDatabase()` write-path primitives are gone, and the write goes through
`attributes_with_values` → the class-level `_update_record`, whose `BindParam`s
carry the `ModelAttribute`s themselves — `toSqlAndBinds` unwraps them to
`valueForDatabase` at compile time, so the same primitive reaches the adapter.
`write-path-binds.trails.test.ts` (binary, temporal, serialized, array) stays
green, as do locking, custom-locking, touch-later, timestamp, persistence,
dirty and autosave.

One real bug fell out on the way: `_lockValueForDatabase` answered
`readAttribute(col) ?? 0` / `attributeInDatabase(col) ?? 0` where
optimistic.rb:134-139 reads `@attributes[locking_column].value_for_database` /
`.original_value_for_database`. `Attribute::FromDatabase#_original_value_for_database`
is the raw `value_before_type_cast`, so a lock column that is NULL in the row
must constrain on NULL — the `?? 0` turned that into `= 0`, which matches no
row. It now reads the attribute, and the three "should work with null in the
database" tests pass through the shared path.

Not in scope, still owned by `wire-locking-touch-update-row-into-persistence-path`:
installing `LockingOptimistic._touchRow` / `Dirty._touchRow` in the `_touch_row`
chain.

### 2. `Hash#transform_keys(!)` ported, the four key casts delegate (RFC 0098)

keys.rb:10-35 writes every shallow key cast on `transform_keys` /
`transform_keys!`; trails inlined an `Object.keys` loop and had the bang
primitive private. Both are public and Rails-shaped now, and
`stringifyKeys(!)` / `symbolizeKeys(!)` delegate.

The two `transform_keys` **set** rows are deleted from
`call-mismatches-exclude/activesupport/hash-utils.json`. Three **args** rows
replace them, carrying verbatim the reviewed reason already on the sibling
`stringify_keys! → transform_keys!` row: Ruby passes the transform as a block
(no positional), TypeScript has no block syntax, so it is a trailing function
parameter. That is the same TS language shortcoming, not a new one — the shape
is unreachable while `transform_keys` takes a block.

### 3. `rb_warning` / `$VERBOSE` (RFC 0088)

`packages/date/src/rb-warning.ts` — a zero-dependency seam mirroring MRI's
`rb_warning` (`error.c`), emitting only under `$VERBOSE == true`. The three
sites that recorded "no analogue here" in prose now call it with the C's message
verbatim, at the C's point in the body: `val2sg` (`date_core.c:3325`),
`offsetToSec`'s two `fraction of offset` arms (`:2395`, `:2426`), `dtNewByFrags`
(`:8304`) and `DateTime.now` (`:8219`). The three JSDoc comments are gone.

`test_strftime__offset` asserts the warning now, through an `assertWarning`
helper shaped like Ruby's — it sets `$VERBOSE` for the block and restores it in
a `finally`, so the flag cannot leak past the block, let alone the file.

### 4. strftime's week readers read the residue day (RFC 0088)

`mLocalJd(subject)`'s `cCivilToJd(Number(subject.year), …)` rebuild — a
trails-only seam — is gone. `StrftimeSubject` carries the `m_local_jd` the
receiver already has, plus `nth` and `gregorianP`, so `cwyear` is
`m_real_cwyear` (`date_core.c:1858-1873`: `c_jd_to_commercial` over the residue
day, then `encode_year`) and `cweek` / `wnum0` / `wnum1` take the residue day
straight, as the C's `int` readers do.

    ruby -rdate -e 'p Date.jd(2**70).strftime("%G|%V|%U")'
    #=> "3232350070754114273|02|01"     # trails: was "…|168655945816773030000|…"

### 5. `::Time`'s range checks raise `ArgumentError` (RFC 0088)

Only `sec` was checked; every other positional fell through to Temporal's
`RejectTime`/`RejectISODate` and raised a `RangeError` a caller rescuing
`ArgumentError` does not catch. `obj2ubits` and `validateVtmRange` mirror the C
(`time.c` `time_arg` / `validate_vtm`), which is a two-stage check verified
against ruby 3.3.11 — the bit-field width first (`Time.utc(2015, 6, 32)` is
`"argument out of range"`, naming no field) and the field's own range after
(`Time.utc(2015, 6, 0)` is `"mday out of range"`). MRI's `hour` bound is 24 and
rolls, admitting only a zero `min`/`sec`; that arm is ported and covered.

Closes-story: route-update-record-through-update-row
Closes-story: hash-transform-keys-port-and-delegate
Closes-story: port-rb-warning-verbose-seam
Closes-story: strftime-week-readers-rebuild-a-day-from-the-real-year
Closes-story: time-range-checks-raise-rangeerror-not-argumenterror
