### PR TITLE
refactor(activerecord,activemodel): converge db_config.database, YAMLEncoder(attribute_types) and the migration proxy call args

### DIFF
--- a/packages/activemodel/src/attribute-set/coder.test.ts
+++ b/packages/activemodel/src/attribute-set/coder.test.ts
@@ -9,16 +9,22 @@ function makeSet(attrs: Map<string, Attribute>): AttributeSet {
   return new AttributeSet(attrs);
 }
 
+const stringType = typeRegistry.lookup("string");
+const integerType = typeRegistry.lookup("integer");
+
 function stringAttr(name: string, value: string): Attribute {
-  return Attribute.fromUser(name, value, typeRegistry.lookup("string"));
+  return Attribute.fromUser(name, value, stringType);
 }
 
 function intAttr(name: string, value: number): Attribute {
-  return Attribute.fromUser(name, value, typeRegistry.lookup("integer"));
+  return Attribute.fromUser(name, value, integerType);
 }
 
 describe("AttributeSetCoder", () => {
-  const coder = new AttributeSetCoder(typeRegistry);
+  // `default_types` is the model's `attribute_types`, whose values are the very
+  // Type instances its attributes carry — Rails' `equal?` check depends on that.
+  const defaultTypes = { name: stringType, age: integerType };
+  const coder = new AttributeSetCoder(defaultTypes);
 
   afterEach(() => {
     vi.restoreAllMocks();
@@ -35,25 +41,41 @@ describe("AttributeSetCoder", () => {
     expect(decoded.fetchValue("age")).toBe(30);
   });
 
-  it("uninitialized attributes round-trip via defaultAttributes", () => {
-    const intType = typeRegistry.lookup("integer");
-    const uninit = Attribute.uninitialized("score", intType);
-    const schemaAttr = Attribute.fromUser("score", 99, intType);
-    const schema = new Map<string, Attribute>([["score", schemaAttr]]);
-    const set = makeSet(new Map([["score", uninit]]));
+  it("omits the type of an attribute whose type is the default type", () => {
+    const set = makeSet(new Map([["name", stringAttr("name", "Alice")]]));
+    expect(JSON.parse(coder.encode(set)).types.name).toBeNull();
+  });
 
-    const encoded = coder.encode(set);
+  it("writes the type of an attribute whose type is not the default type", () => {
+    const set = makeSet(new Map([["name", intAttr("name", 7)]]));
+    expect(JSON.parse(coder.encode(set)).types.name).toBe("integer");
+  });
+
+  it("restores the default type for an attribute encoded without one", () => {
+    const custom = integerType;
+    const localCoder = new AttributeSetCoder({ qty: custom });
+    const json = JSON.stringify({ v: 1, types: { qty: null }, values: { qty: 5 } });
+    const decoded = localCoder.decode(json);
+    expect(decoded.fetchValue("qty")).toBe(5);
+    expect(decoded.castTypes().qty).toBe(custom);
+  });
+
+  it("uninitialized attributes round-trip as uninitialized", () => {
+    const intType = integerType;
+    const localCoder = new AttributeSetCoder({ score: intType });
+    const set = makeSet(new Map([["score", Attribute.uninitialized("score", intType)]]));
+
+    const encoded = localCoder.encode(set);
     expect(JSON.parse(encoded).defaultAttributes).toContain("score");
 
-    // decode with schema: score should be restored from the schema default (99)
-    const decoded = coder.decode(encoded, schema);
-    expect(decoded.has("score")).toBe(true);
-    expect(decoded.fetchValue("score")).toBe(99);
+    const decoded = localCoder.decode(encoded);
+    expect(decoded.has("score")).toBe(false);
+    expect(decoded.castTypes().score).toBe(intType);
   });
 
   it("unknown type key falls back to value type and warns once", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const localCoder = new AttributeSetCoder(typeRegistry);
+    const localCoder = new AttributeSetCoder({});
     const json = JSON.stringify({
       v: 1,
       types: { x: "unknown_type_xyz" },
@@ -69,9 +91,7 @@ describe("AttributeSetCoder", () => {
 
   it("silenceDriftWarnings suppresses the console.warn", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const silentCoder = new AttributeSetCoder(typeRegistry, {
-      silenceDriftWarnings: true,
-    });
+    const silentCoder = new AttributeSetCoder({}, { silenceDriftWarnings: true });
     const json = JSON.stringify({
       v: 1,
       types: { y: "completely_unknown_type_abc" },
@@ -87,35 +107,15 @@ describe("AttributeSetCoder", () => {
     expect(() => coder.decode(json)).toThrow("v=2 not supported");
   });
 
-  it("attr in envelope but not in schema is kept as additional", () => {
-    const schema = new Map<string, Attribute>([["name", stringAttr("name", "Bob")]]);
+  it("attr not among the default types is kept with its own type", () => {
     const json = JSON.stringify({
       v: 1,
-      types: { name: "string", extra: "string" },
+      types: { name: null, extra: "string" },
       values: { name: "Bob", extra: "bonus" },
     });
-    const decoded = coder.decode(json, schema);
+    const decoded = coder.decode(json);
     expect(decoded.fetchValue("extra")).toBe("bonus");
-  });
-
-  it("prefers schema attr type over registry lookup when names match", () => {
-    // Simulates an AR-specific type (e.g. uuid, jsonb) that isn't in AM's registry.
-    // When schemaAttributes provides the type, decode should use it directly.
-    const customType = typeRegistry.lookup("integer");
-    const schemaAttr = Attribute.fromUser("qty", 0, customType);
-    const schema = new Map<string, Attribute>([["qty", schemaAttr]]);
-    const json = JSON.stringify({
-      v: 1,
-      types: { qty: "integer" },
-      values: { qty: 5 },
-    });
-    const decoded = coder.decode(json, schema);
-    // type instance should come from the schema, not a fresh registry.lookup()
-    expect(decoded.fetchValue("qty")).toBe(5);
-    // Confirm the schema type object is reused (same reference)
-    const decodedType = (decoded as unknown as { castTypes(): Record<string, unknown> }).castTypes()
-      .qty;
-    expect(decodedType).toBe(customType);
+    expect(decoded.fetchValue("name")).toBe("Bob");
   });
 
   it("uses attr.type.name (registry key) not type() for type storage", () => {
@@ -140,31 +140,11 @@ describe("AttributeSetCoder", () => {
       }),
       decode: vi.fn((input: string) => JSON.parse(input) as AttributeSetEnvelope),
     };
-    const customCoder = new AttributeSetCoder(typeRegistry, { codec: customCodec });
+    const customCoder = new AttributeSetCoder({}, { codec: customCodec });
     const set = makeSet(new Map([["x", stringAttr("x", "hi")]]));
     customCoder.decode(customCoder.encode(set));
     expect(customCodec.encode).toHaveBeenCalledOnce();
     expect(customCodec.decode).toHaveBeenCalledOnce();
     expect(encoded[0].types.x).toBe("string");
-  });
-
-  it("schema attr not in envelope resolves to Uninitialized (retained in map, not initialized)", () => {
-    const stringType = typeRegistry.lookup("string");
-    const schema = new Map<string, Attribute>([
-      ["name", stringAttr("name", "Bob")],
-      ["missing", Attribute.uninitialized("missing", stringType)],
-    ]);
-    const json = JSON.stringify({
-      v: 1,
-      types: { name: "string" },
-      values: { name: "Bob" },
-    });
-    const decoded = coder.decode(json, schema);
-    // has() returns false for Uninitialized (not initialized)
-    expect(decoded.has("missing")).toBe(false);
-    // but the attr IS retained in the map — castTypes() iterates all attrs including Uninitialized
-    const types = decoded.castTypes();
-    expect(types["missing"]).toBeDefined();
-    expect(types["missing"].name).toBe("string");
   });
 });

--- a/packages/activemodel/src/attribute-set/coder.ts
+++ b/packages/activemodel/src/attribute-set/coder.ts
@@ -35,9 +35,10 @@ const warnedKeys = new Set<string>();
 /**
  * Mirrors: ActiveModel::AttributeSet::YAMLEncoder
  *
- * Rails takes the model's `attribute_types` as `default_types` and drops the
- * type from any attribute whose type is that default (`yaml_encoder.rb:13-19`),
- * restoring it on the way back in (`:23-33`). trails keeps that contract.
+ * Rails takes the model's `attribute_types` as `default_types` and encodes an
+ * attribute whose type is that default as `attr.with_type(nil)`
+ * (`yaml_encoder.rb:14-18`), restoring the default type on the way back in
+ * (`:27-29`). trails writes that missing type as a `null` envelope key.
  *
  * Two things Rails gets from Psych and trails has to carry itself, both
  * consequences of the wire format rather than choices:
@@ -80,8 +81,6 @@ export class AttributeSetCoder {
         defaultAttributes.push(name);
         return;
       }
-      // `attr.type.equal?(default_types[attr.name]) ? attr.with_type(nil) : attr`
-      // (`yaml_encoder.rb:14-18`).
       types[name] = attr.type === this.defaultTypes[name] ? null : attr.type.name;
       values[name] = attr.valueBeforeTypeCast;
     });
@@ -101,9 +100,22 @@ export class AttributeSetCoder {
     const attributesHash = new Map<string, Attribute>();
 
     for (const [name, typeKey] of Object.entries(envelope.types)) {
-      // `attr = attr.with_type(default_types[attr.name]) if attr.type.nil?`
-      // (`yaml_encoder.rb:27-29`).
-      const type = typeKey == null ? this.defaultTypes[name] : this.lookupType(typeKey);
+      let type: Type;
+      if (typeKey == null) {
+        type = this.defaultTypes[name];
+      } else {
+        try {
+          type = this.registry.lookup(typeKey);
+        } catch {
+          if (!this.silenceDriftWarnings && !warnedKeys.has(typeKey)) {
+            warnedKeys.add(typeKey);
+            console.warn(
+              `AttributeSetCoder: unknown type key "${typeKey}" — falling back to "value" type`,
+            );
+          }
+          type = this.registry.lookup("value");
+        }
+      }
       attributesHash.set(name, Attribute.fromUser(name, envelope.values[name], type));
     }
 
@@ -112,19 +124,5 @@ export class AttributeSetCoder {
     }
 
     return new AttributeSet(attributesHash);
-  }
-
-  private lookupType(typeKey: string): Type {
-    try {
-      return this.registry.lookup(typeKey);
-    } catch {
-      if (!this.silenceDriftWarnings && !warnedKeys.has(typeKey)) {
-        warnedKeys.add(typeKey);
-        console.warn(
-          `AttributeSetCoder: unknown type key "${typeKey}" — falling back to "value" type`,
-        );
-      }
-      return this.registry.lookup("value");
-    }
   }
 }

--- a/packages/activemodel/src/attribute-set/coder.ts
+++ b/packages/activemodel/src/attribute-set/coder.ts
@@ -1,22 +1,20 @@
 import { Attribute, Uninitialized } from "../attribute.js";
 import { AttributeSet } from "../attribute-set.js";
-import type { TypeRegistry } from "../type/registry.js";
+import { typeRegistry, type TypeRegistry } from "../type/registry.js";
+import type { Type } from "../type/value.js";
 import { jsonCodec } from "./codecs/json.js";
 
 export interface AttributeSetEnvelope {
   v: 1;
-  /** attr → registry type key (e.g. "string", "integer", "decimal") */
-  types: Record<string, string>;
+  /**
+   * attr → registry type key (e.g. "string", "integer", "decimal"), or `null`
+   * for `attr.with_type(nil)` (`yaml_encoder.rb:15`) — the attribute's type is
+   * the model's default type for that name, so it is not written out.
+   */
+  types: Record<string, string | null>;
   /** attr → raw value before type-cast (valueBeforeTypeCast) */
   values: Record<string, unknown>;
-  /**
-   * Reserved for future use: type keys for attrs that existed in the envelope
-   * but were absent from the schema at decode time. Not written by encode() in
-   * this release — such attrs are stored in `types` alongside schema-matched
-   * ones and kept as additional attributes on the decoded set.
-   */
-  additionalTypes?: Record<string, string>;
-  /** attrs that should resolve to the schema default on decode */
+  /** attrs that were Uninitialized when encoded */
   defaultAttributes?: string[];
 }
 
@@ -35,48 +33,56 @@ export class AttributeSetCoderError extends Error {
 const warnedKeys = new Set<string>();
 
 /**
- * Format-agnostic encoder/decoder for AttributeSet.
- * Delegates wire format to an injected codec (default: JSON).
- *
- * Schema-drift policy on decode:
- * - Unknown type key: falls back to "value" type + one-time console.warn per key (opt-out via silenceDriftWarnings).
- * - v mismatch: throws AttributeSetCoderError.
- * - Attr in envelope but not in schemaAttributes: kept as an additional attribute with the envelope type.
- * - Attr in schemaAttributes but not in envelope AND in defaultAttributes: restored from schema (preserves schema default).
- * - Attr in schemaAttributes but not in envelope AND not in defaultAttributes: set to Uninitialized.
- *
- * Type reconstruction on decode:
- * - When schemaAttributes is provided and the schema type name matches the envelope type key,
- *   the schema attr's type is used directly (preserving precision/scale/limit and AR-specific types).
- * - Otherwise the registry is queried by the envelope type key.
- *
  * Mirrors: ActiveModel::AttributeSet::YAMLEncoder
+ *
+ * Rails takes the model's `attribute_types` as `default_types` and drops the
+ * type from any attribute whose type is that default (`yaml_encoder.rb:13-19`),
+ * restoring it on the way back in (`:23-33`). trails keeps that contract.
+ *
+ * Two things Rails gets from Psych and trails has to carry itself, both
+ * consequences of the wire format rather than choices:
+ *
+ * - Psych dumps a non-default `Type` object inline; JSON cannot, so a
+ *   non-default type travels as its registry key and comes back through
+ *   `registry`. An unknown key falls back to the "value" type with a one-time
+ *   warning per key (opt out with `silenceDriftWarnings`).
+ * - Psych round-trips an `Attribute::Uninitialized` as itself; a JSON envelope
+ *   has no value to carry for one, so those names are listed in
+ *   `defaultAttributes` and rebuilt as `Uninitialized` on decode.
  */
 export class AttributeSetCoder {
+  private defaultTypes: Record<string, Type>;
   private registry: TypeRegistry;
   private codec: AttributeSetCodec;
   private silenceDriftWarnings: boolean;
 
   constructor(
-    registry: TypeRegistry,
-    opts: { codec?: AttributeSetCodec; silenceDriftWarnings?: boolean } = {},
+    defaultTypes: Record<string, Type>,
+    opts: {
+      registry?: TypeRegistry;
+      codec?: AttributeSetCodec;
+      silenceDriftWarnings?: boolean;
+    } = {},
   ) {
-    this.registry = registry;
+    this.defaultTypes = defaultTypes;
+    this.registry = opts.registry ?? typeRegistry;
     this.codec = opts.codec ?? jsonCodec;
     this.silenceDriftWarnings = opts.silenceDriftWarnings ?? false;
   }
 
-  encode(set: AttributeSet): string {
-    const types: Record<string, string> = {};
+  encode(attributeSet: AttributeSet): string {
+    const types: Record<string, string | null> = {};
     const values: Record<string, unknown> = {};
     const defaultAttributes: string[] = [];
 
-    set.forEach((attr, name) => {
+    attributeSet.forEach((attr, name) => {
       if (attr instanceof Uninitialized) {
         defaultAttributes.push(name);
         return;
       }
-      types[name] = attr.type.name;
+      // `attr.type.equal?(default_types[attr.name]) ? attr.with_type(nil) : attr`
+      // (`yaml_encoder.rb:14-18`).
+      types[name] = attr.type === this.defaultTypes[name] ? null : attr.type.name;
       values[name] = attr.valueBeforeTypeCast;
     });
 
@@ -85,62 +91,40 @@ export class AttributeSetCoder {
     return this.codec.encode(envelope);
   }
 
-  decode(input: string, schemaAttributes?: Map<string, Attribute>): AttributeSet {
+  decode(input: string): AttributeSet {
     const envelope = this.codec.decode(input);
 
     if (envelope.v !== 1) {
       throw new AttributeSetCoderError(`envelope version v=${envelope.v} not supported`);
     }
 
-    const attrs = new Map<string, Attribute>();
+    const attributesHash = new Map<string, Attribute>();
 
     for (const [name, typeKey] of Object.entries(envelope.types)) {
-      const schemaAttr = schemaAttributes?.get(name);
-      const schemaType =
-        schemaAttr && !(schemaAttr instanceof Uninitialized) ? schemaAttr.type : undefined;
-
-      let type;
-      if (schemaType && schemaType.name === typeKey) {
-        // Schema type matches envelope key — use the schema instance directly so
-        // precision/scale/limit and AR-specific types (uuid, jsonb, etc.) are preserved.
-        type = schemaType;
-      } else {
-        try {
-          type = this.registry.lookup(typeKey);
-        } catch {
-          if (!this.silenceDriftWarnings && !warnedKeys.has(typeKey)) {
-            warnedKeys.add(typeKey);
-            console.warn(
-              `AttributeSetCoder: unknown type key "${typeKey}" — falling back to "value" type`,
-            );
-          }
-          type = this.registry.lookup("value");
-        }
-      }
-      const rawValue = envelope.values[name];
-      attrs.set(name, Attribute.fromUser(name, rawValue, type));
+      // `attr = attr.with_type(default_types[attr.name]) if attr.type.nil?`
+      // (`yaml_encoder.rb:27-29`).
+      const type = typeKey == null ? this.defaultTypes[name] : this.lookupType(typeKey);
+      attributesHash.set(name, Attribute.fromUser(name, envelope.values[name], type));
     }
 
-    if (schemaAttributes) {
-      const defaultAttrSet = new Set(envelope.defaultAttributes ?? []);
-      for (const [name, schemaAttr] of schemaAttributes) {
-        if (attrs.has(name)) continue;
-        if (defaultAttrSet.has(name)) {
-          attrs.set(
-            name,
-            schemaAttr instanceof Uninitialized ? schemaAttr : schemaAttr.withType(schemaAttr.type),
-          );
-        } else {
-          attrs.set(
-            name,
-            schemaAttr instanceof Uninitialized
-              ? schemaAttr
-              : new Uninitialized(name, schemaAttr.type),
-          );
-        }
-      }
+    for (const name of envelope.defaultAttributes ?? []) {
+      attributesHash.set(name, Attribute.uninitialized(name, this.defaultTypes[name]));
     }
 
-    return new AttributeSet(attrs);
+    return new AttributeSet(attributesHash);
+  }
+
+  private lookupType(typeKey: string): Type {
+    try {
+      return this.registry.lookup(typeKey);
+    } catch {
+      if (!this.silenceDriftWarnings && !warnedKeys.has(typeKey)) {
+        warnedKeys.add(typeKey);
+        console.warn(
+          `AttributeSetCoder: unknown type key "${typeKey}" — falling back to "value" type`,
+        );
+      }
+      return this.registry.lookup("value");
+    }
   }
 }

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1573,15 +1573,21 @@ export class Migration {
         // Build a fresh migration factory that imports the NEW path — spreading
         // `source` would carry over a closure pinned to the old engine file.
         const proxyName = source.name;
+        // `@migration ||= load_migration` (`migration.rb:1191`) — the proxy loads
+        // once and every delegated call sees the same instance.
+        let loaded: Promise<Migration> | undefined;
         const copy: MigrationProxy = {
           name: source.name,
           version: newVersion,
           scope,
           filename: newPath,
           migration: async () => {
-            const { pathToFileURL } = await import("node:url");
-            const mod = (await import(pathToFileURL(newPath).href)) as Record<string, unknown>;
-            return loadMigrationFrom(mod, proxyName, newVersion);
+            loaded ??= (async () => {
+              const { pathToFileURL } = await import("node:url");
+              const mod = (await import(pathToFileURL(newPath).href)) as Record<string, unknown>;
+              return loadMigrationFrom(mod, proxyName, newVersion);
+            })();
+            return loaded;
           },
         };
         last = copy;
@@ -2210,15 +2216,21 @@ export class MigrationContext<
       }
       const version = toInteger(rawVersion);
       const name = camelize(rawName);
+      // `@migration ||= load_migration` (`migration.rb:1191`) — the proxy loads
+      // once and every delegated call sees the same instance.
+      let loaded: Promise<Migration> | undefined;
       return {
         version,
         name,
         filename: file,
         scope: scope || undefined,
         migration: async (): Promise<Migration> => {
-          const { pathToFileURL } = await import("node:url");
-          const mod = await import(pathToFileURL(file).href);
-          return loadMigrationFrom(mod, name, version);
+          loaded ??= (async () => {
+            const { pathToFileURL } = await import("node:url");
+            const mod = await import(pathToFileURL(file).href);
+            return loadMigrationFrom(mod, name, version);
+          })();
+          return loaded;
         },
       } satisfies MigrationProxy;
     });
@@ -2540,37 +2552,40 @@ export class Migrator {
    * migration actually ran, which is what `run_without_lock` hands back to
    * `MigrationContext#run`.
    */
-  async executeMigrationInTransaction(proxy: MigrationProxy): Promise<number | undefined> {
-    let migration: Migration | undefined;
+  async executeMigrationInTransaction(migration: MigrationProxy): Promise<number | undefined> {
     // Ruby's method-level `rescue` (`migration.rb:1538`) covers the guards and
     // the log line too, not just the ddl_transaction.
     try {
       const applied = await this.migrated();
-      if (this.isDown() && !applied.has(proxy.version)) return undefined;
-      if (this.isUp() && applied.has(proxy.version)) return undefined;
+      if (this.isDown() && !applied.has(migration.version)) return undefined;
+      if (this.isUp() && applied.has(migration.version)) return undefined;
 
       // Rails' guard is just `if Base.logger`; the `?.` on `info` is forced by
       // trails' `Base.logger` type, which declares every level optional
       // (base.ts:1717-1723) because the logger is app-supplied, where Ruby's is
       // an ActiveSupport::Logger that always responds to `info`.
-      if (_base?.logger) _base.logger.info?.(`Migrating to ${proxy.name} (${proxy.version})`);
+      if (_base?.logger)
+        _base.logger.info?.(`Migrating to ${migration.name} (${migration.version})`);
 
-      const loaded = (migration = await proxy.migration());
-      await this.ddlTransaction(loaded, async () => {
-        await loaded.migrate(this._direction);
-        await this.recordVersionStateAfterMigrating(proxy.version);
+      await this.ddlTransaction(migration, async () => {
+        // `delegate :migrate, ..., to: :migration` (`migration.rb:1187`). The
+        // proxy's own `migration()` is async — an ESM `import()` where Ruby's
+        // `load` is synchronous — so the delegating members cannot be plain
+        // methods on the proxy and the await lands here instead.
+        await (await migration.migration()).migrate(this._direction);
+        await this.recordVersionStateAfterMigrating(migration.version);
       });
     } catch (e) {
       // Rails re-resolves the proxy here (`migration.rb:1540` → `use_transaction?`
       // → `MigrationProxy#disable_ddl_transaction`), so a migration that failed to
       // load raises again from inside the rescue and escapes unwrapped.
-      const useTx = this.isUseTransaction(migration ?? (await proxy.migration()));
+      const useTx = await this.isUseTransaction(migration);
       // Ruby's `#{e}` interpolates Exception#to_s — the bare message, without
       // the `Error: ` prefix JS String(e) would add.
       const msg = `An error has occurred, ${useTx ? "this and " : ""}all later migrations canceled:\n\n${e instanceof Error ? e.message : e}`;
       throw Object.assign(new Error(msg), { cause: e });
     }
-    return proxy.version;
+    return migration.version;
   }
 
   /** @internal Mirrors: ActiveRecord::Migrator#target */
@@ -2860,8 +2875,8 @@ export class Migrator {
    *
    * @internal
    */
-  async ddlTransaction(migration: Migration, fn: () => Promise<void>): Promise<void> {
-    if (this.isUseTransaction(migration)) {
+  async ddlTransaction(migration: MigrationProxy, fn: () => Promise<void>): Promise<void> {
+    if (await this.isUseTransaction(migration)) {
       await this.connection.transaction(fn);
     } else {
       await fn();
@@ -2874,8 +2889,11 @@ export class Migrator {
    *
    * @internal
    */
-  isUseTransaction(migration: Migration): boolean {
-    if (migration.disableDdlTransaction) return false;
+  async isUseTransaction(migration: MigrationProxy): Promise<boolean> {
+    // `migration.disable_ddl_transaction` is delegated through the proxy
+    // (`migration.rb:1187`); trails resolves it here because the proxy's loader
+    // is an async ESM `import()` where Ruby's `load` is synchronous.
+    if ((await migration.migration()).disableDdlTransaction) return false;
     // Check adapter support via the DatabaseAdapter interface.
     // SQLite returns true, PG returns true, MySQL returns false.
     // Absent (undefined) defaults to false.

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1573,8 +1573,6 @@ export class Migration {
         // Build a fresh migration factory that imports the NEW path — spreading
         // `source` would carry over a closure pinned to the old engine file.
         const proxyName = source.name;
-        // `@migration ||= load_migration` (`migration.rb:1191`) — the proxy loads
-        // once and every delegated call sees the same instance.
         let loaded: Promise<Migration> | undefined;
         const copy: MigrationProxy = {
           name: source.name,
@@ -1856,6 +1854,11 @@ export interface MigrationProxy {
   filename?: string;
   /** Mirrors: ActiveRecord::MigrationProxy#scope — engine name for copied engine migrations */
   scope?: string;
+  /**
+   * Mirrors: ActiveRecord::MigrationProxy#migration — `@migration ||=
+   * load_migration` (`migration.rb:1190-1192`). Memoized by the implementer, so
+   * every member Rails delegates through the proxy sees the same instance.
+   */
   migration: () => Migration | Promise<Migration>;
   /** @internal Mirrors: ActiveRecord::MigrationProxy#basename */
   basename?(): string;
@@ -2216,8 +2219,6 @@ export class MigrationContext<
       }
       const version = toInteger(rawVersion);
       const name = camelize(rawName);
-      // `@migration ||= load_migration` (`migration.rb:1191`) — the proxy loads
-      // once and every delegated call sees the same instance.
       let loaded: Promise<Migration> | undefined;
       return {
         version,
@@ -2568,10 +2569,9 @@ export class Migrator {
         _base.logger.info?.(`Migrating to ${migration.name} (${migration.version})`);
 
       await this.ddlTransaction(migration, async () => {
-        // `delegate :migrate, ..., to: :migration` (`migration.rb:1187`). The
-        // proxy's own `migration()` is async — an ESM `import()` where Ruby's
-        // `load` is synchronous — so the delegating members cannot be plain
-        // methods on the proxy and the await lands here instead.
+        // Rails delegates `migrate` through the proxy (`migration.rb:1187`);
+        // trails resolves it here because the proxy's loader is an async ESM
+        // `import()` where Ruby's `load` is synchronous.
         await (await migration.migration()).migrate(this._direction);
         await this.recordVersionStateAfterMigrating(migration.version);
       });

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -594,6 +594,8 @@ interface SchemaHost {
   _columns?: any[];
   _returningColumnsForInsertCache?: string[];
   _attributesBuilder?: any;
+  _yamlEncoder?: AttributeSetCoder;
+  attributeTypes(): Record<string, any>;
   _schemaLoaded?: boolean;
   _virtualAttributesReconciled?: boolean;
   /** Global epoch stamped on reflect/invalidate; see {@link schemaEpoch}. @internal */
@@ -776,13 +778,18 @@ export function columns(this: SchemaHost): any[] {
 
 /**
  * Rails: `@yaml_encoder ||= ActiveModel::AttributeSet::YAMLEncoder.new(attribute_types)`
- * (model_schema.rb:446). trails' coder is codec-agnostic (JSON by default) rather
- * than YAML-only, but the accessor keeps the Rails name.
+ * (model_schema.rb:446-448). trails' coder is codec-agnostic (JSON by default)
+ * rather than YAML-only, but the accessor keeps the Rails name and passes the
+ * model's own attribute types, so a declared `attribute :x, :my_type` override
+ * round-trips through that type rather than through a global registry lookup.
  *
  * @internal
  */
 export function yamlEncoder(this: SchemaHost): AttributeSetCoder {
-  return new AttributeSetCoder(typeRegistry);
+  const own = ownSchemaMemo(this, "_yamlEncoder");
+  if (own) return own;
+  this._yamlEncoder = new AttributeSetCoder(this.attributeTypes());
+  return this._yamlEncoder;
 }
 
 /**
@@ -1206,12 +1213,14 @@ function applyColumnsHash(
 
   type CacheBag = {
     _attributesBuilder?: unknown;
+    _yamlEncoder?: unknown;
     _cachedDefaultAttributes?: unknown;
     _columnsHash?: unknown;
     _columns?: unknown;
   };
   const bag = host as CacheBag;
   bag._attributesBuilder = undefined;
+  bag._yamlEncoder = undefined;
   bag._cachedDefaultAttributes = null;
   bag._columns = undefined;
   host._columnsHash = filteredHash;

--- a/packages/activerecord/src/tasks/mysql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/mysql-database-tasks.ts
@@ -58,13 +58,13 @@ export class MySQLDatabaseTasks {
     await this.establishConnection(this.configurationHashWithoutDatabase());
     await (
       await this.connection()
-    ).createDatabase(this.requireDatabaseName(), this.creationOptions());
+    ).createDatabase(this.dbConfig.database as string, this.creationOptions());
     await this.establishConnection();
   }
 
   async drop(): Promise<void> {
     await this.establishConnection();
-    await (await this.connection()).dropDatabase(this.requireDatabaseName());
+    await (await this.connection()).dropDatabase(this.dbConfig.database as string);
   }
 
   async purge(): Promise<void> {
@@ -84,7 +84,7 @@ export class MySQLDatabaseTasks {
     await this.establishConnection(this.configurationHashWithoutDatabase());
     await (
       await this.connection()
-    ).createDatabase(this.requireDatabaseName(), { ...this.creationOptions(), ...saved });
+    ).createDatabase(this.dbConfig.database as string, { ...this.creationOptions(), ...saved });
     await this.establishConnection();
   }
 
@@ -115,11 +115,11 @@ export class MySQLDatabaseTasks {
         }),
       );
       for (const table of ignoreTables) {
-        args.push(`--ignore-table=${this.requireDatabaseName()}.${table as string}`);
+        args.push(`--ignore-table=${this.dbConfig.database as string}.${table as string}`);
       }
     }
 
-    args.push(this.requireDatabaseName());
+    args.push(this.dbConfig.database as string);
     if (extraFlags) {
       args.unshift(...(Array.isArray(extraFlags) ? extraFlags : [extraFlags]));
     }
@@ -128,7 +128,7 @@ export class MySQLDatabaseTasks {
 
   async structureLoad(filename: string, extraFlags?: string | string[] | null): Promise<void> {
     const args = this.prepareCommandOptions();
-    args.push("--database", this.requireDatabaseName());
+    args.push("--database", this.dbConfig.database as string);
     if (extraFlags) {
       args.unshift(...(Array.isArray(extraFlags) ? extraFlags : [extraFlags]));
     }
@@ -144,7 +144,7 @@ export class MySQLDatabaseTasks {
    * Mysql2Adapter#truncate_tables behavior).
    */
   async truncateAll(): Promise<void> {
-    const dbName = this.requireDatabaseName();
+    const dbName = this.dbConfig.database as string;
     await this.establishConnection();
     const adapter = await this.connection();
     const bookkeeping = metadataTableNames();
@@ -201,7 +201,7 @@ export class MySQLDatabaseTasks {
   }
 
   private async savedCharset(): Promise<{ charset?: string; collation?: string }> {
-    const dbName = this.requireDatabaseName();
+    const dbName = this.dbConfig.database as string;
     // Connect without selecting a database: information_schema.SCHEMATA is
     // server-global, and connecting to the target DB would fail with error 1049
     // if it doesn't exist yet (e.g. purge() called before create() on a clean env).
@@ -300,12 +300,6 @@ export class MySQLDatabaseTasks {
           (details.length ? `${details.join("\n\n")}\n` : ""),
       );
     }
-  }
-
-  private requireDatabaseName(): string {
-    const name = this.dbConfig.database ?? this.urlParts.database;
-    if (!name) throw new Error("MySQL configuration missing 'database'");
-    return name;
   }
 
   /** @internal */


### PR DESCRIPTION
RFC 0096 wave 3, items 4/6/7 — split out of `naming-burndown-3-ar-structural-residue` because each needs a structural change, not a rename.

### 1. `MySQLDatabaseTasks` — `db_config.database`

`create` / `drop` (and the six other sites) passed `this.requireDatabaseName()`, a trails-only guard that fell back to re-parsing the config URL, where Rails passes `db_config.database` (`mysql_database_tasks.rb:15-23`). `UrlConfig#database` already resolves a URL config the way Rails' does, so the fallback was dead code — deleted, and every site now reads `this.dbConfig.database`, matching the already-converged `PostgreSQLDatabaseTasks`.

### 2. `yamlEncoder` — `YAMLEncoder.new(attribute_types)`

`model_schema.rb:446-448` passes the model's own `attribute_types`; trails passed the global `typeRegistry`. That is a latent wrong-type bug for any model with a declared attribute override. `AttributeSetCoder` is reshaped to Rails' `YAMLEncoder(default_types)`:

- `encode` drops the type of an attribute whose type *is* the default type — `attr.with_type(nil)` (`yaml_encoder.rb:14-18`) — writing `null` for it.
- `decode` restores it from `default_types` (`:27-29`).
- `yamlEncoder` passes `this.attributeTypes()` and memoizes like Rails' `||=`, invalidated with the rest of the schema cache bag.

Two things Rails gets from Psych and trails carries explicitly, both consequences of the wire format: a non-default type travels as its registry key (JSON can't dump a `Type`), and an `Uninitialized` travels in `defaultAttributes`. Both are documented on the class. The invented `decode(input, schemaAttributes)` parameter is gone — Rails' `decode` takes one argument.

### 3. `executeMigrationInTransaction` — the `MigrationProxy`

`migration.rb:1529-1543` passes the proxy straight to `ddl_transaction`, which reads `disable_ddl_transaction` back through the proxy's delegation (`:1187`). trails resolved the migration first and passed the loaded object. Now `ddlTransaction` and `isUseTransaction` take the `MigrationProxy` and the parameter is named `migration`, as in Rails. The one remaining deviation — the `await` on the delegated read — is forced by the loader being an async ESM `import()` where Ruby's `load` is synchronous; it is justified at both call sites. Both proxy literals now memoize their load, mirroring `@migration ||= load_migration` (`:1191`), so the delegated calls all see one instance.

### Verification

- `pnpm parity:api:calls` and `pnpm parity:api:calls:args` — OK, no baseline row added or widened.
- `pnpm parity:api:extra --package activemodel` — no new public name (`additionalTypes` removed).
- `pnpm typecheck`, targeted eslint, and the migrator / migration / model-schema / attributes / tasks / attribute-set suites pass.

Closes-story: ar-tasks-yaml-encoder-migration-proxy-args

### Filed, not done here

`AttributeSetCoder` still carries a trails name for `yaml_encoder.rb`, so `parity:api` buckets the file as having no Rails counterpart. Renaming it is what makes the file Rails-matched — and then every remaining trails-only name in it becomes measured extra surface — so it is registered as `0096-naming-identifier-burndown/attribute-set-coder-rename-to-yaml-encoder` rather than folded in here.
