### PR TITLE
refactor(activerecord): converge arelColumnWithTable's colStr local to Rails' columnName

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -5544,7 +5544,7 @@ export class Relation<T extends Base> {
    * resolution.
    * @internal
    */
-  arelColumnWithTable(tableName: string, columnName: string | symbol): unknown {
+  arelColumnWithTable(tableName: string, columnName: string): unknown {
     return _arelColumnWithTable.call(this as any, tableName, columnName);
   }
 
@@ -5552,7 +5552,7 @@ export class Relation<T extends Base> {
    * Rails `Relation#arel_column`. Delegates to the canonical helper.
    * @internal
    */
-  arelColumn(field: string | symbol | Nodes.Node, fallback?: (attr: string) => unknown): unknown {
+  arelColumn(field: string | Nodes.Node, fallback?: (attr: string) => unknown): unknown {
     if (field instanceof Nodes.Node) return field;
     return _arelColumn.call(this as any, field, fallback);
   }

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -5544,7 +5544,7 @@ export class Relation<T extends Base> {
    * resolution.
    * @internal
    */
-  arelColumnWithTable(tableName: string, columnName: string): unknown {
+  arelColumnWithTable(tableName: string, columnName: string | symbol): unknown {
     return _arelColumnWithTable.call(this as any, tableName, columnName);
   }
 
@@ -5552,7 +5552,7 @@ export class Relation<T extends Base> {
    * Rails `Relation#arel_column`. Delegates to the canonical helper.
    * @internal
    */
-  arelColumn(field: string | Nodes.Node, fallback?: (attr: string) => unknown): unknown {
+  arelColumn(field: string | symbol | Nodes.Node, fallback?: (attr: string) => unknown): unknown {
     if (field instanceof Nodes.Node) return field;
     return _arelColumn.call(this as any, field, fallback);
   }

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2221,8 +2221,8 @@ export function arelColumnAliasesFromHash(
       });
     }
     if (Array.isArray(columnsAliases)) {
-      return (columnsAliases as unknown[]).map((col) =>
-        arelColumnWithTable.call(this, tableName, String(col)),
+      return (columnsAliases as string[]).map((col) =>
+        arelColumnWithTable.call(this, tableName, col),
       );
     }
     if (typeof columnsAliases === "string" || typeof columnsAliases === "symbol") {

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2079,7 +2079,7 @@ export function isTableNameMatches(this: QueryMethodsHost, from: unknown): boole
 /** @internal */
 export function arelColumn(
   this: QueryMethodsHost,
-  field: string | symbol | number | Nodes.Node | null,
+  field: string | number | Nodes.Node | null,
   fallback?: (attr: string) => unknown,
 ): unknown {
   const modelClass: any = this.model;
@@ -2087,12 +2087,11 @@ export function arelColumn(
   // Rails: a raw Arel node has no columns_hash/table.column form; it falls to
   // the block, else passes through unchanged (query_methods.rb:1996-2003).
   if (field instanceof Nodes.Node) return fallback ? fallback(field as any) : field;
-  const isSymbol = typeof field === "symbol";
-  // Ruby `field = field.name if is_symbol` then `field.to_s`
-  // (query_methods.rb:1991-1993) — which is what carries `sum`'s Integer
-  // identity default through as the literal it sums over, and `async_sum`'s nil
-  // one (calculations.rb:182) as `""`, the empty `SUM()`.
-  let fieldStr = isSymbol ? symbolToName(field) : field == null ? "" : String(field);
+  // Ruby `field.to_s` (query_methods.rb:1992) — which is what carries `sum`'s
+  // Integer identity default through as the literal it sums over, and
+  // `async_sum`'s nil one (calculations.rb:182) as `""`, the empty `SUM()`.
+  // A Ruby Symbol is a JS string here, so `is_symbol` is always false.
+  let fieldStr = field == null ? "" : String(field);
   fieldStr = modelClass?._attributeAliases?.[fieldStr] ?? fieldStr;
 
   const fromClause = (this as any)._fromClause;
@@ -2106,16 +2105,14 @@ export function arelColumn(
     return arelColumnWithTable.call(this, dotMatch.groups!.tbl, dotMatch.groups!.col);
   }
   if (fallback) return fallback(fieldStr);
-  const quoted = isSymbol ? safeQuoteColumnName(modelClass, fieldStr) : fieldStr;
-  return arelSql(quoted);
+  return arelSql(fieldStr);
 }
 
 /** @internal */
 export function arelColumns(this: QueryMethodsHost, columns: unknown[]): unknown[] {
   return columns.flatMap((field) => {
     if (field instanceof Nodes.Node) return [field]; // Arel nodes pass through directly
-    if (typeof field === "string" || typeof field === "symbol")
-      return [arelColumn.call(this, field as any)];
+    if (typeof field === "string") return [arelColumn.call(this, field)];
     if (typeof field === "function") return [field()];
     if (isPlainObject(field)) return arelColumnsFromHash.call(this, field);
     return [field];
@@ -2126,33 +2123,34 @@ export function arelColumns(this: QueryMethodsHost, columns: unknown[]): unknown
 export function arelColumnWithTable(
   this: QueryMethodsHost,
   tableName: string,
-  columnName: string | symbol,
+  columnName: string,
 ): unknown {
   const existing = (this as any)._referencesValues ?? [];
   if (!existing.includes(tableName)) (this as any)._referencesValues = [...existing, tableName];
-  const colStr = typeof columnName === "symbol" ? symbolToName(columnName) : columnName;
   const modelClass: any = this.model;
   // Schema-qualified table names (e.g. "schema.table") must not be passed to
   // ArelTable — the visitor quotes the whole string as one identifier, producing
   // "schema.table"."col" instead of "schema"."table"."col".
   if (tableName.includes(".")) {
     const quotedTable = safeQuoteTableName(modelClass, tableName);
-    const quotedCol = safeQuoteColumnName(modelClass, colStr);
+    const quotedCol = safeQuoteColumnName(modelClass, columnName);
     return arelSql(`${quotedTable}.${quotedCol}`);
   }
-  if (typeof columnName === "symbol" || !/\W/.test(colStr)) {
+  // Rails' `column_name.is_a?(Symbol) ||` arm (query_methods.rb:1980) collapses
+  // here: a Ruby Symbol is a JS string in trails, so only the `\W` test remains.
+  if (!/\W/.test(columnName)) {
     const builder = (this as any).predicateBuilder;
     // Rails passes `lookup_table_klass_from_join_dependencies` as the block
     // (query_methods.rb:1982-1984), so a table name that only resolves through a
     // join dependency still finds its model — and its type caster.
     return (
-      builder?.resolveArelAttribute?.(tableName, colStr, (name: string) =>
+      builder?.resolveArelAttribute?.(tableName, columnName, (name: string) =>
         lookupTableKlassFromJoinDependencies.call(this, name),
-      ) ?? new ArelTable(tableName).get(colStr)
+      ) ?? new ArelTable(tableName).get(columnName)
     );
   }
   const quotedTable = safeQuoteTableName(modelClass, tableName);
-  return arelSql(`${quotedTable}.${colStr}`);
+  return arelSql(`${quotedTable}.${columnName}`);
 }
 
 /** @internal */
@@ -2223,8 +2221,8 @@ export function arelColumnAliasesFromHash(
       });
     }
     if (Array.isArray(columnsAliases)) {
-      return (columnsAliases as (string | symbol)[]).map((col) =>
-        arelColumnWithTable.call(this, tableName, col),
+      return (columnsAliases as unknown[]).map((col) =>
+        arelColumnWithTable.call(this, tableName, String(col)),
       );
     }
     if (typeof columnsAliases === "string" || typeof columnsAliases === "symbol") {

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2079,7 +2079,7 @@ export function isTableNameMatches(this: QueryMethodsHost, from: unknown): boole
 /** @internal */
 export function arelColumn(
   this: QueryMethodsHost,
-  field: string | number | Nodes.Node | null,
+  field: string | symbol | number | Nodes.Node | null,
   fallback?: (attr: string) => unknown,
 ): unknown {
   const modelClass: any = this.model;
@@ -2087,11 +2087,13 @@ export function arelColumn(
   // Rails: a raw Arel node has no columns_hash/table.column form; it falls to
   // the block, else passes through unchanged (query_methods.rb:1996-2003).
   if (field instanceof Nodes.Node) return fallback ? fallback(field as any) : field;
-  // Ruby `field.to_s` (query_methods.rb:1992) — which is what carries `sum`'s
-  // Integer identity default through as the literal it sums over, and
-  // `async_sum`'s nil one (calculations.rb:182) as `""`, the empty `SUM()`.
-  // A Ruby Symbol is a JS string here, so `is_symbol` is always false.
-  let fieldStr = field == null ? "" : String(field);
+  // Ruby `field = field.name if is_symbol = field.is_a?(Symbol)` then `field.to_s`
+  // (query_methods.rb:1991-1992) — which is what carries `sum`'s Integer identity
+  // default through as the literal it sums over, and `async_sum`'s nil one
+  // (calculations.rb:182) as `""`, the empty `SUM()`.
+  const isSymbol = typeof field === "symbol";
+  let fieldStr =
+    typeof field === "symbol" ? symbolToName(field) : field == null ? "" : String(field);
   fieldStr = modelClass?._attributeAliases?.[fieldStr] ?? fieldStr;
 
   const fromClause = (this as any)._fromClause;
@@ -2105,14 +2107,20 @@ export function arelColumn(
     return arelColumnWithTable.call(this, dotMatch.groups!.tbl, dotMatch.groups!.col);
   }
   if (fallback) return fallback(fieldStr);
-  return arelSql(fieldStr);
+  // Ruby `Arel.sql(is_symbol ? quote_table_name(field) : field)`
+  // (query_methods.rb:2003): a Symbol names a column and is quoted; a String is
+  // raw SQL and is not. TS has no way to recover that distinction from a bare
+  // string, so the JS-`Symbol` modelling is retained here (RFC 0096 debt).
+  const quoted = isSymbol ? safeQuoteColumnName(modelClass, fieldStr) : fieldStr;
+  return arelSql(quoted);
 }
 
 /** @internal */
 export function arelColumns(this: QueryMethodsHost, columns: unknown[]): unknown[] {
   return columns.flatMap((field) => {
     if (field instanceof Nodes.Node) return [field]; // Arel nodes pass through directly
-    if (typeof field === "string") return [arelColumn.call(this, field)];
+    if (typeof field === "string" || typeof field === "symbol")
+      return [arelColumn.call(this, field)];
     if (typeof field === "function") return [field()];
     if (isPlainObject(field)) return arelColumnsFromHash.call(this, field);
     return [field];
@@ -2123,10 +2131,16 @@ export function arelColumns(this: QueryMethodsHost, columns: unknown[]): unknown
 export function arelColumnWithTable(
   this: QueryMethodsHost,
   tableName: string,
-  columnName: string,
+  columnName: string | symbol,
 ): unknown {
   const existing = (this as any)._referencesValues ?? [];
   if (!existing.includes(tableName)) (this as any)._referencesValues = [...existing, tableName];
+  // Ruby discriminates `column_name.is_a?(Symbol)` (query_methods.rb:1980): a
+  // Symbol names a column, a String may be an expression. TS cannot recover that
+  // from a bare string, so the JS-`Symbol` modelling is retained (RFC 0096 debt);
+  // the name itself is Rails' `columnName` from here down.
+  const isSymbol = typeof columnName === "symbol";
+  if (typeof columnName === "symbol") columnName = symbolToName(columnName);
   const modelClass: any = this.model;
   // Schema-qualified table names (e.g. "schema.table") must not be passed to
   // ArelTable — the visitor quotes the whole string as one identifier, producing
@@ -2136,9 +2150,7 @@ export function arelColumnWithTable(
     const quotedCol = safeQuoteColumnName(modelClass, columnName);
     return arelSql(`${quotedTable}.${quotedCol}`);
   }
-  // Rails' `column_name.is_a?(Symbol) ||` arm (query_methods.rb:1980) collapses
-  // here: a Ruby Symbol is a JS string in trails, so only the `\W` test remains.
-  if (!/\W/.test(columnName)) {
+  if (isSymbol || !/\W/.test(columnName)) {
     const builder = (this as any).predicateBuilder;
     // Rails passes `lookup_table_klass_from_join_dependencies` as the block
     // (query_methods.rb:1982-1984), so a table name that only resolves through a
@@ -2221,7 +2233,7 @@ export function arelColumnAliasesFromHash(
       });
     }
     if (Array.isArray(columnsAliases)) {
-      return (columnsAliases as string[]).map((col) =>
+      return (columnsAliases as (string | symbol)[]).map((col) =>
         arelColumnWithTable.call(this, tableName, col),
       );
     }


### PR DESCRIPTION
`arelColumnWithTable` could not spell its local Rails' `column_name` because the parameter is `string | symbol` and the later `typeof columnName === "symbol"` branch needed the un-narrowed value. This takes Rails' own shape instead — `field = field.name if is_symbol` (`vendor/rails/activerecord/lib/active_record/relation/query_methods.rb:1991`) — reassigning the parameter after capturing the discriminator, so `colStr` disappears and the local is `columnName` from the top of the body down.

## On the story's premise

The story proposed deleting the JS-`Symbol` arms outright as dead modelling. They are not dead — that first attempt red four SQLite tests in `relation/select.test.ts`. Rails discriminates on the Ruby type at two live sites:

- `query_methods.rb:2003` — `Arel.sql(is_symbol ? quote_table_name(field) : field)`. `Post.select("1", "foo()", :bar)` emits `SELECT 1, foo(), "bar"` (`test/cases/relation/select_test.rb:16-19`): the Symbol names a column and is quoted, the Strings are raw SQL and are not.
- `query_methods.rb:1980` — `column_name.is_a?(Symbol) || !column_name.match?(/\W/)`, pinned by `select_test.rb:71-78` (`Post.select(posts: [:bar, :id])`).

So this PR ships the rename and justifies each retained arm at its call site with the Rails cite, which is the story's stated escape hatch. The JS-`Symbol` modelling itself is a real CLAUDE.md violation, but converging it means adopting the leading-colon string idiom (`:bar` → `":bar"`) across the `select` / `order` / `group` / `where` argument surface and all 15 `symbolToName` sites in `query-methods.ts` — a campaign, not a rename. Filed as `0096-naming-identifier-burndown/arel-symbol-modelling-colon-string-campaign` with the citations above.

Verified: `pnpm typecheck`, `pnpm parity:api:calls` (OK), `pnpm parity:api:calls:args` (OK), `pnpm parity:api:extra --package activerecord` (no new surface), and `select.test.ts` / `relations.test.ts` / `calculations.test.ts` / `build-arel-helpers.test.ts` green locally.

Closes-story: arel-column-with-table-symbol-arm
