### PR TITLE
refactor(activerecord): model Ruby Symbols as leading-colon strings in query methods

### DIFF
--- a/packages/activerecord/src/associations/cascaded-eager-loading.test.ts
+++ b/packages/activerecord/src/associations/cascaded-eager-loading.test.ts
@@ -105,7 +105,7 @@ describe("CascadedEagerLoadingTest", () => {
     const authors = await Author.joins("posts")
       .eagerLoad("comments")
       .where({ posts: { tags_count: 1 } })
-      .order(Symbol.for("id"));
+      .order(":id");
     await assertQueriesCount(0, false, () => {
       expect(authors).toHaveLength(3);
     });

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -923,13 +923,15 @@ export class JoinDependency {
   }
 
   static walkTree(associations: any, hash: Record<PropertyKey, any>): void {
-    if (typeof associations === "symbol") {
-      if (!hash[associations]) hash[associations] = Object.create(null);
-    } else if (typeof associations === "string") {
+    if (typeof associations === "string") {
+      // Ruby `when Symbol, String then hash[associations.to_sym] ||= {}`
+      // (join_dependency.rb:55-56): a Symbol and the equivalent String key the
+      // same node, so a Symbol — spelled `":comments"` — drops its colon here.
+      const name = associations.startsWith(":") ? associations.slice(1) : associations;
       // Dotted strings ("comments.author") are a trails affordance: split them
       // into nested levels so the builder joins each segment in turn.
       let cur = hash;
-      for (const part of associations.split(".")) {
+      for (const part of name.split(".")) {
         cur = cur[part] ??= Object.create(null);
       }
     } else if (Array.isArray(associations)) {

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -941,8 +941,15 @@ export class JoinDependency {
     } else if (associations && typeof associations === "object") {
       for (const key of Reflect.ownKeys(associations)) {
         const value = associations[key];
-        if (!hash[key]) hash[key] = Object.create(null);
-        if (value != null) JoinDependency.walkTree(value, hash[key]);
+        // Ruby `cache = hash[k] ||= {}` (join_dependency.rb:61-64) stores the key
+        // object as-is, and `find_reflection` resolves a Symbol or a String alike
+        // (`_reflect_on_association(name)`). `build` looks the stored key up by
+        // its string form, so a Symbol key — `{ ":agents": ":agents" }` — drops
+        // its colon here instead.
+        const k =
+          typeof key === "string" && key.startsWith(":") ? key.slice(1) : (key as PropertyKey);
+        if (!hash[k]) hash[k] = Object.create(null);
+        if (value != null) JoinDependency.walkTree(value, hash[k]);
       }
     } else {
       let desc: string;

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -1295,9 +1295,7 @@ describe("CalculationsTest", () => {
 
   it("ids with includes and non primary key order", async () => {
     const all = (await Company.all().order("id")).map((c) => Number(c.id));
-    const ids = (await Company.all().includes("contracts").order(Symbol.for("id")).ids()).map(
-      Number,
-    );
+    const ids = (await Company.all().includes("contracts").order(":id").ids()).map(Number);
     expect(ids).toEqual(all);
   });
 
@@ -1336,10 +1334,8 @@ describe("CalculationsTest", () => {
   });
 
   it("ids with includes offset", async () => {
-    expect(
-      (await Topic.includes("replies").order(Symbol.for("id")).offset(4).ids()).map(Number),
-    ).toEqual([5]);
-    expect(await Topic.includes("replies").order(Symbol.for("id")).offset(5).ids()).toEqual([]);
+    expect((await Topic.includes("replies").order(":id").offset(4).ids()).map(Number)).toEqual([5]);
+    expect(await Topic.includes("replies").order(":id").offset(5).ids()).toEqual([]);
   });
 
   it("pluck with includes limit and empty result", async () => {
@@ -1349,11 +1345,9 @@ describe("CalculationsTest", () => {
 
   it("pluck with includes offset", async () => {
     expect(
-      (await Topic.includes("replies").order(Symbol.for("id")).offset(4).pluck("id")).map(Number),
+      (await Topic.includes("replies").order(":id").offset(4).pluck("id")).map(Number),
     ).toEqual([5]);
-    expect(await Topic.includes("replies").order(Symbol.for("id")).offset(5).pluck("id")).toEqual(
-      [],
-    );
+    expect(await Topic.includes("replies").order(":id").offset(5).pluck("id")).toEqual([]);
   });
 
   it("pluck with join", async () => {
@@ -1388,7 +1382,7 @@ describe("CalculationsTest", () => {
       // Rails `order(:count)`: the Symbol qualifies to `"posts"."count"`, which PG
       // resolves via functional notation as `count(posts.*)` — the "virtual count
       // attribute". A bare string would stay raw SQL and fail to parse.
-      const actual = await (Post.group("type").order(Symbol.for("count") as any) as any)
+      const actual = await (Post.group("type").order(":count" as any) as any)
         .limit(2)
         .maximum("comments_count");
       expect(actual).toEqual(expected);

--- a/packages/activerecord/src/finder.test.ts
+++ b/packages/activerecord/src/finder.test.ts
@@ -326,7 +326,7 @@ describe("FinderTest", () => {
       undefined,
       false,
       async () => {
-        await Topic.order(Symbol.for("updated_at")).secondToLast();
+        await Topic.order(":updated_at").secondToLast();
       },
     );
   });

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -365,7 +365,7 @@ export class Relation<T extends Base> {
   private _reverseOrderValue: boolean | undefined = undefined;
   private _limitValue: number | null = null;
   private _offsetValue: number | null = null;
-  private _selectColumns: (string | symbol | Nodes.Node)[] | null = null;
+  private _selectColumns: (string | Nodes.Node)[] | null = null;
   private _isDistinct = false;
   private _distinctOnColumns: string[] = [];
   private _groupColumns: string[] = [];
@@ -412,19 +412,19 @@ export class Relation<T extends Base> {
   private _joinsValues: (AssociationSpec | string | Nodes.Join)[] = [];
   private _leftOuterJoinsValues: AssociationSpec[] = [];
   // A `joins_values` entry is a "named" inner association join (resolved through
-  // JoinDependency) when it is a nested-association hash, a genuine Symbol
-  // (trails' signal for an association/CTE name, e.g. `joins(:name)`), or a
-  // string naming an association; everything else (Arel join nodes, raw SQL
-  // strings) is a raw join value. The two derived getters below partition
-  // `_joinsValues` by this rule — the same rule `joins` uses at insert time. A
-  // raw Symbol misrouted to `_joinValues` would reach the arel visitor and raise
-  // "Unknown node type: Symbol", so Symbols must land in `_namedInnerJoins`.
+  // JoinDependency) when it is a nested-association hash, a Symbol — spelled as
+  // a leading-colon string, trails' signal for an association/CTE name, e.g.
+  // `joins(":name")` — or a string naming an association; everything else (Arel
+  // join nodes, raw SQL strings) is a raw join value. The two derived getters
+  // below partition `_joinsValues` by this rule — the same rule `joins` uses at
+  // insert time. A raw Symbol misrouted to `_joinValues` would reach the arel
+  // visitor and raise "Unknown node type: Symbol", so Symbols must land in
+  // `_namedInnerJoins`.
   private _isNamedJoinValue(v: unknown): boolean {
     return (
       _isPlainObject(v) ||
-      typeof v === "symbol" ||
       v instanceof JoinDependency ||
-      (typeof v === "string" && this._isAssociationName(v))
+      (typeof v === "string" && (v.startsWith(":") || this._isAssociationName(v)))
     );
   }
   // INNER `joins(:assoc)` association names (and nested hash/through specs),
@@ -4052,10 +4052,8 @@ export class Relation<T extends Base> {
    * fresh allocation, matching the stored-reference semantics of the other
    * value readers.
    */
-  get selectValues(): (string | symbol | Nodes.Node)[] {
-    return (
-      this._selectColumns ?? (EMPTY_VALUE_ARRAY as unknown as (string | symbol | Nodes.Node)[])
-    );
+  get selectValues(): (string | Nodes.Node)[] {
+    return this._selectColumns ?? (EMPTY_VALUE_ARRAY as unknown as (string | Nodes.Node)[]);
   }
 
   /**
@@ -5544,7 +5542,7 @@ export class Relation<T extends Base> {
    * resolution.
    * @internal
    */
-  arelColumnWithTable(tableName: string, columnName: string | symbol): unknown {
+  arelColumnWithTable(tableName: string, columnName: string): unknown {
     return _arelColumnWithTable.call(this as any, tableName, columnName);
   }
 
@@ -5552,7 +5550,7 @@ export class Relation<T extends Base> {
    * Rails `Relation#arel_column`. Delegates to the canonical helper.
    * @internal
    */
-  arelColumn(field: string | symbol | Nodes.Node, fallback?: (attr: string) => unknown): unknown {
+  arelColumn(field: string | Nodes.Node, fallback?: (attr: string) => unknown): unknown {
     if (field instanceof Nodes.Node) return field;
     return _arelColumn.call(this as any, field, fallback);
   }
@@ -7005,7 +7003,7 @@ export class Relation<T extends Base> {
   }
 
   /** @internal */
-  private arelColumnAliasesFromHash(fields: Record<string | symbol, unknown>): unknown[] {
+  private arelColumnAliasesFromHash(fields: Record<string, unknown>): unknown[] {
     return _qm.arelColumnAliasesFromHash.call(this as any, fields);
   }
 

--- a/packages/activerecord/src/relation/order-string-arg-stays-bare.trails.test.ts
+++ b/packages/activerecord/src/relation/order-string-arg-stays-bare.trails.test.ts
@@ -35,9 +35,7 @@ describe("order string arg stays bare", () => {
     // Rails' order! runs `order_values |= args`, deduping repeated terms.
     const dupString = Customer.order("name", "name").toSql();
     expect(dupString.match(/ORDER BY name/g)).toHaveLength(1);
-    const dupSymbol = (Customer as unknown as { order(...a: symbol[]): { toSql(): string } })
-      .order(Symbol.for("name"), Symbol.for("name"))
-      .toSql();
+    const dupSymbol = Customer.order(":name", ":name").toSql();
     expect(dupSymbol.match(new RegExp(qualifiedName, "g"))).toHaveLength(1);
   });
 
@@ -48,9 +46,7 @@ describe("order string arg stays bare", () => {
   });
 
   it("qualifies a Symbol order arg to the table, like Rails order(:name)", () => {
-    const sql = (Customer as unknown as { order(arg: symbol): { toSql(): string } })
-      .order(Symbol.for("name"))
-      .toSql();
+    const sql = Customer.order(":name").toSql();
     expect(sql).toMatch(new RegExp(`ORDER BY ${qualifiedName} ASC`));
   });
 

--- a/packages/activerecord/src/relation/order.test.ts
+++ b/packages/activerecord/src/relation/order.test.ts
@@ -89,9 +89,7 @@ describe("OrderTest", () => {
     // Rails' final arg is the symbol `:name`, which qualifies to `books.name`.
     // A bare string `"name"` would stay an unqualified SqlLiteral (matching
     // Rails string semantics) and be ambiguous across the joined tables.
-    expect(await incOrder({ authors: { name: "desc" } }, Symbol.for("name"))).toEqual(
-      authorDescThenBookName,
-    );
+    expect(await incOrder({ authors: { name: "desc" } }, ":name")).toEqual(authorDescThenBookName);
   });
 
   it("order with association alias", async () => {
@@ -107,13 +105,11 @@ describe("OrderTest", () => {
       authorThenBookName,
     );
     expect(await incOrder("author.name", { books: { name: "asc" } })).toEqual(authorThenBookName);
-    // Trailing `Symbol.for("name")` mirrors Rails' `:name` symbol (qualifies to
+    // Trailing `":name"` mirrors Rails' `:name` symbol (qualifies to
     // `books.name`); a bare `"name"` string stays an unqualified SqlLiteral and
     // would be ambiguous across the joined tables.
-    expect(await incOrder({ author: { name: "asc" } }, Symbol.for("name"))).toEqual(
-      authorThenBookName,
-    );
-    expect(await incOrder(authorName, Symbol.for("name"))).toEqual(authorThenBookName);
+    expect(await incOrder({ author: { name: "asc" } }, ":name")).toEqual(authorThenBookName);
+    expect(await incOrder(authorName, ":name")).toEqual(authorThenBookName);
 
     const authorDescThenBookName = [y.id, x.id, z.id];
 
@@ -123,9 +119,7 @@ describe("OrderTest", () => {
     expect(await incOrder("author.name desc", { books: { name: "asc" } })).toEqual(
       authorDescThenBookName,
     );
-    expect(await incOrder({ author: { name: "desc" } }, Symbol.for("name"))).toEqual(
-      authorDescThenBookName,
-    );
-    expect(await incOrder(authorName.desc(), Symbol.for("name"))).toEqual(authorDescThenBookName);
+    expect(await incOrder({ author: { name: "desc" } }, ":name")).toEqual(authorDescThenBookName);
+    expect(await incOrder(authorName.desc(), ":name")).toEqual(authorDescThenBookName);
   });
 });

--- a/packages/activerecord/src/relation/preprocess-order-args-order-column.trails.test.ts
+++ b/packages/activerecord/src/relation/preprocess-order-args-order-column.trails.test.ts
@@ -26,7 +26,7 @@ describe("preprocessOrderArgs routes through orderColumn", () => {
     );
 
   it("falls back to a bare quoted literal for an unknown column in the Symbol arm", () => {
-    const [node] = preprocess(Topic.all(), [Symbol.for("nonexistent")]);
+    const [node] = preprocess(Topic.all(), [":nonexistent"]);
     expect(node).toBeInstanceOf(Nodes.Ascending);
     expect(sqlOf(node)).not.toMatch(/topics/i);
     expect(sqlOf(node)).toMatch(/nonexistent.*ASC/i);
@@ -40,7 +40,7 @@ describe("preprocessOrderArgs routes through orderColumn", () => {
   });
 
   it("keeps a known column qualified against the relation's table", () => {
-    const [node] = preprocess(Topic.all(), [Symbol.for("title")]);
+    const [node] = preprocess(Topic.all(), [":title"]);
     expect(sqlOf(node)).toMatch(/"topics"\."title" ASC|`topics`\.`title` ASC/);
   });
 
@@ -64,7 +64,7 @@ describe("preprocessOrderArgs routes through orderColumn", () => {
     const quoteTableName = vi.spyOn(connection as never, "quoteTableName");
     const quoteColumnName = vi.spyOn(connection as never, "quoteColumnName");
     try {
-      preprocess(Topic.all(), [Symbol.for("nonexistent")]);
+      preprocess(Topic.all(), [":nonexistent"]);
       expect(quoteTableName).toHaveBeenCalledWith("nonexistent");
       expect(quoteColumnName).not.toHaveBeenCalledWith("nonexistent");
     } finally {

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -150,7 +150,6 @@ type OrderDirection = "asc" | "desc" | "ASC" | "DESC";
  */
 export type OrderArg =
   | string
-  | symbol
   | Record<string, OrderDirection | Record<string, OrderDirection>>
   | Nodes.Node
   | string[]
@@ -483,7 +482,6 @@ function _selectBang(this: QueryMethodsHost, ...columns: any[]): any {
   const flat = columns.flat(Infinity);
   const normalized = flat.map((c: any) => {
     if (c instanceof Nodes.Node) return c;
-    if (typeof c === "symbol") return c;
     // Rails' `_select!(-> { aliases.columns })` (join_dependency.rb:155) stores
     // the Proc itself; `arel_columns` calls it at build_select time.
     if (typeof c === "function") return c;
@@ -509,17 +507,15 @@ function _selectBang(this: QueryMethodsHost, ...columns: any[]): any {
   const seenThunks = new Set<unknown>();
   for (const existing of this._selectColumns) {
     if (typeof existing === "string") seenStrings.add(existing);
-    else if (typeof existing === "symbol") seenStrings.add(symbolToName(existing));
     else if (existing instanceof Nodes.Node) addNodeToSeen(existing);
     else if (typeof existing === "function") seenThunks.add(existing);
     else seenStrings.add((existing as { value: string }).value);
   }
   for (const col of normalized) {
-    if (typeof col === "string" || typeof col === "symbol") {
-      const key = typeof col === "symbol" ? symbolToName(col) : col;
-      if (!seenStrings.has(key)) {
+    if (typeof col === "string") {
+      if (!seenStrings.has(col)) {
         this._selectColumns.push(col);
-        seenStrings.add(key);
+        seenStrings.add(col);
       }
     } else if (col instanceof Nodes.Node) {
       if (!nodeIsDuplicate(col)) {
@@ -1537,12 +1533,7 @@ export function isBlankArgument(value: unknown): boolean {
   if (value === null || value === undefined || value === false) return true;
   if (typeof value === "string") return value.trim() === "";
   if (Array.isArray(value)) return value.length === 0;
-  if (isPlainObject(value)) {
-    // A hash is blank only with no keys. trails represents Ruby symbol hash keys
-    // (e.g. `select(foo: :post_title)`) as Symbol-keyed objects, which
-    // Object.keys omits — count those too so a symbol-keyed hash isn't compacted.
-    return Object.keys(value).length === 0 && Object.getOwnPropertySymbols(value).length === 0;
-  }
+  if (isPlainObject(value)) return Object.keys(value).length === 0;
   return false;
 }
 
@@ -1784,9 +1775,21 @@ export function extractTableNameFrom(orderTerm: string): string | null {
   return match ? match[1] : null;
 }
 
-function symbolToName(s: symbol): string {
-  const name = Symbol.keyFor(s) ?? s.description;
-  if (name === undefined || name.trim() === "") {
+/**
+ * Ruby `x.is_a?(Symbol)`. A Ruby Symbol is a JS string carrying its leading
+ * colon (CLAUDE.md) — `:bar` is `":bar"` — so the colon is the discriminator
+ * the Ruby side gets from the type. Rails turns on it at
+ * query_methods.rb:1980 (`column_name.is_a?(Symbol) || !column_name.match?(/\W/)`)
+ * and :2003 (`Arel.sql(is_symbol ? quote_table_name(field) : field)`).
+ */
+function isRubySymbol(value: unknown): value is string {
+  return typeof value === "string" && value.startsWith(":");
+}
+
+/** Ruby `Symbol#name`. */
+function symbolToName(s: string): string {
+  const name = s.slice(1);
+  if (name.trim() === "") {
     throw argumentError("Order symbols must have a non-blank name");
   }
   return name;
@@ -1802,8 +1805,8 @@ export function columnReferences(orderArgs: unknown[]): string[] {
       // `order(["comments.body", ...])`) never registers its table reference and
       // an `includes` it names is not promoted to `eager_load`.
       refs.push(...columnReferences(arg));
-    } else if (typeof arg === "string" || typeof arg === "symbol") {
-      const term = typeof arg === "symbol" ? symbolToName(arg) : arg;
+    } else if (typeof arg === "string") {
+      const term = isRubySymbol(arg) ? symbolToName(arg) : arg;
       const t = extractTableNameFrom(term);
       if (t) refs.push(t);
     } else if (arg instanceof Nodes.Attribute) {
@@ -1820,8 +1823,8 @@ export function columnReferences(orderArgs: unknown[]): string[] {
       for (const [key, value] of arg) {
         if (isPlainObject(value)) {
           refs.push(String(key));
-        } else if (typeof key === "string" || typeof key === "symbol") {
-          const t = extractTableNameFrom(typeof key === "symbol" ? symbolToName(key) : key);
+        } else if (typeof key === "string") {
+          const t = extractTableNameFrom(isRubySymbol(key) ? symbolToName(key) : key);
           if (t) refs.push(t);
         }
       }
@@ -1848,18 +1851,18 @@ export function sanitizeOrderArguments(this: QueryMethodsHost, orderArgs: unknow
   return orderArgs;
 }
 
-function flattenedOrderKeysForRawSqlCheck(orderArgs: unknown[]): (string | symbol)[] {
-  const result: (string | symbol)[] = [];
+function flattenedOrderKeysForRawSqlCheck(orderArgs: unknown[]): string[] {
+  const result: string[] = [];
   for (const arg of orderArgs) {
     if (Array.isArray(arg)) {
       result.push(...flattenedOrderKeysForRawSqlCheck(arg));
-    } else if (typeof arg === "string" || typeof arg === "symbol") {
+    } else if (typeof arg === "string") {
       result.push(arg);
     } else if (arg instanceof Nodes.Node) {
       // Arel nodes (SqlLiteral, Attribute, Ordering, …) are pre-sanitized; skip them.
     } else if (arg instanceof Map) {
       for (const key of arg.keys()) {
-        if (typeof key === "string" || typeof key === "symbol") result.push(key);
+        if (typeof key === "string") result.push(key);
       }
     } else if (isPlainObject(arg)) {
       for (const [key, value] of Object.entries(arg)) {
@@ -1882,7 +1885,7 @@ export function preprocessOrderArgs(this: QueryMethodsHost, orderArgs: unknown[]
   // disallowRawSqlBang skips symbols — resolve symbol names to strings first
   // so their descriptions are validated against the column-name matcher.
   const flattenedArgs = flattenedOrderKeysForRawSqlCheck(orderArgs).map((k) =>
-    typeof k === "symbol" ? symbolToName(k) : k,
+    isRubySymbol(k) ? symbolToName(k) : k,
   );
   disallowRawSqlBang(flattenedArgs, {
     permit: (
@@ -1897,7 +1900,7 @@ export function preprocessOrderArgs(this: QueryMethodsHost, orderArgs: unknown[]
   }
   const mapped: unknown[] = [];
   for (const arg of orderArgs) {
-    if (typeof arg === "symbol") {
+    if (isRubySymbol(arg)) {
       mapped.push(new Nodes.Ascending(orderColumn.call(this, symbolToName(arg))));
     } else if (arg instanceof Map) {
       // JS object keys can't be Arel nodes, so a Map is the analogue of Rails'
@@ -1911,8 +1914,8 @@ export function preprocessOrderArgs(this: QueryMethodsHost, orderArgs: unknown[]
         );
       }
     } else if (isPlainObject(arg)) {
-      for (const rawKey of Reflect.ownKeys(arg)) {
-        const key = typeof rawKey === "symbol" ? symbolToName(rawKey) : rawKey;
+      for (const rawKey of Object.keys(arg)) {
+        const key = isRubySymbol(rawKey) ? symbolToName(rawKey) : rawKey;
         const value = (arg as Record<PropertyKey, unknown>)[rawKey];
         if (isPlainObject(value)) {
           for (const [field, dir] of Object.entries(value)) {
@@ -2079,7 +2082,7 @@ export function isTableNameMatches(this: QueryMethodsHost, from: unknown): boole
 /** @internal */
 export function arelColumn(
   this: QueryMethodsHost,
-  field: string | symbol | number | Nodes.Node | null,
+  field: string | number | Nodes.Node | null,
   fallback?: (attr: string) => unknown,
 ): unknown {
   const modelClass: any = this.model;
@@ -2091,9 +2094,8 @@ export function arelColumn(
   // (query_methods.rb:1991-1992) — which is what carries `sum`'s Integer identity
   // default through as the literal it sums over, and `async_sum`'s nil one
   // (calculations.rb:182) as `""`, the empty `SUM()`.
-  const isSymbol = typeof field === "symbol";
-  let fieldStr =
-    typeof field === "symbol" ? symbolToName(field) : field == null ? "" : String(field);
+  const isSymbol = isRubySymbol(field);
+  let fieldStr = isSymbol ? symbolToName(field) : field == null ? "" : String(field);
   fieldStr = modelClass?._attributeAliases?.[fieldStr] ?? fieldStr;
 
   const fromClause = (this as any)._fromClause;
@@ -2109,8 +2111,7 @@ export function arelColumn(
   if (fallback) return fallback(fieldStr);
   // Ruby `Arel.sql(is_symbol ? quote_table_name(field) : field)`
   // (query_methods.rb:2003): a Symbol names a column and is quoted; a String is
-  // raw SQL and is not. TS has no way to recover that distinction from a bare
-  // string, so the JS-`Symbol` modelling is retained here (RFC 0096 debt).
+  // raw SQL and is not.
   const quoted = isSymbol ? safeQuoteColumnName(modelClass, fieldStr) : fieldStr;
   return arelSql(quoted);
 }
@@ -2119,8 +2120,7 @@ export function arelColumn(
 export function arelColumns(this: QueryMethodsHost, columns: unknown[]): unknown[] {
   return columns.flatMap((field) => {
     if (field instanceof Nodes.Node) return [field]; // Arel nodes pass through directly
-    if (typeof field === "string" || typeof field === "symbol")
-      return [arelColumn.call(this, field)];
+    if (typeof field === "string") return [arelColumn.call(this, field)];
     if (typeof field === "function") return [field()];
     if (isPlainObject(field)) return arelColumnsFromHash.call(this, field);
     return [field];
@@ -2131,16 +2131,14 @@ export function arelColumns(this: QueryMethodsHost, columns: unknown[]): unknown
 export function arelColumnWithTable(
   this: QueryMethodsHost,
   tableName: string,
-  columnName: string | symbol,
+  columnName: string,
 ): unknown {
   const existing = (this as any)._referencesValues ?? [];
   if (!existing.includes(tableName)) (this as any)._referencesValues = [...existing, tableName];
   // Ruby discriminates `column_name.is_a?(Symbol)` (query_methods.rb:1980): a
-  // Symbol names a column, a String may be an expression. TS cannot recover that
-  // from a bare string, so the JS-`Symbol` modelling is retained (RFC 0096 debt);
-  // the name itself is Rails' `columnName` from here down.
-  const isSymbol = typeof columnName === "symbol";
-  if (typeof columnName === "symbol") columnName = symbolToName(columnName);
+  // Symbol names a column, a String may be an expression.
+  const isSymbol = isRubySymbol(columnName);
+  if (isSymbol) columnName = symbolToName(columnName);
   const modelClass: any = this.model;
   // Schema-qualified table names (e.g. "schema.table") must not be passed to
   // ArelTable — the visitor quotes the whole string as one identifier, producing
@@ -2168,13 +2166,13 @@ export function arelColumnWithTable(
 /** @internal */
 export function arelColumnsFromHash(
   this: QueryMethodsHost,
-  fields: Record<PropertyKey, unknown>,
+  fields: Record<string, unknown>,
 ): unknown[] {
-  return Reflect.ownKeys(fields).flatMap((key) => {
-    const columns = (fields as Record<string | symbol, unknown>)[key];
-    const tbl = typeof key === "symbol" ? symbolToName(key) : key;
-    if (typeof columns === "string" || typeof columns === "symbol") {
-      return [arelColumnWithTable.call(this, tbl, columns as any)];
+  return Object.keys(fields).flatMap((key) => {
+    const columns = fields[key];
+    const tbl = isRubySymbol(key) ? symbolToName(key) : key;
+    if (typeof columns === "string") {
+      return [arelColumnWithTable.call(this, tbl, columns)];
     }
     if (Array.isArray(columns)) {
       return columns.map((col) => arelColumnWithTable.call(this, tbl, col));
@@ -2217,28 +2215,28 @@ function nodeAs(attr: unknown, quotedAlias: string): unknown {
 /** @internal */
 export function arelColumnAliasesFromHash(
   this: QueryMethodsHost,
-  fields: Record<string | symbol, unknown>,
+  fields: Record<string, unknown>,
 ): unknown[] {
-  return Reflect.ownKeys(fields).flatMap((key) => {
-    const columnsAliases = fields[key as any];
-    const tableName = typeof key === "symbol" ? symbolToName(key) : key;
+  return Object.keys(fields).flatMap((key) => {
+    const columnsAliases = fields[key];
+    const tableName = isRubySymbol(key) ? symbolToName(key) : key;
     const modelClass: any = this.model;
     const quoteAlias = (a: unknown): string =>
-      safeQuoteColumnName(modelClass, typeof a === "symbol" ? symbolToName(a) : String(a));
+      safeQuoteColumnName(modelClass, isRubySymbol(a) ? symbolToName(a) : String(a));
     if (isPlainObject(columnsAliases)) {
-      return Reflect.ownKeys(columnsAliases as object).map((col) => {
+      return Object.keys(columnsAliases as object).map((col) => {
         const alias = (columnsAliases as any)[col];
-        const attr = arelColumnWithTable.call(this, tableName, col as any);
+        const attr = arelColumnWithTable.call(this, tableName, col);
         return nodeAs(attr instanceof Nodes.Node ? attr : arelSql(String(col)), quoteAlias(alias));
       });
     }
     if (Array.isArray(columnsAliases)) {
-      return (columnsAliases as (string | symbol)[]).map((col) =>
+      return (columnsAliases as string[]).map((col) =>
         arelColumnWithTable.call(this, tableName, col),
       );
     }
-    if (typeof columnsAliases === "string" || typeof columnsAliases === "symbol") {
-      return [nodeAs(arelColumn.call(this, key as any), quoteAlias(columnsAliases))];
+    if (typeof columnsAliases === "string") {
+      return [nodeAs(arelColumn.call(this, key), quoteAlias(columnsAliases))];
     }
     return [];
   });
@@ -2394,8 +2392,8 @@ export function buildWithValueFromHash(
   this: QueryMethodsHost,
   hash: Record<string, unknown>,
 ): unknown[] {
-  return Reflect.ownKeys(hash).map((key) => {
-    const name = typeof key === "symbol" ? symbolToName(key) : key;
+  return Object.keys(hash).map((key) => {
+    const name = isRubySymbol(key) ? symbolToName(key) : key;
     if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
       throw argumentError(
         `Invalid CTE name "${name}": must be a valid SQL identifier (letters, digits, underscores, not starting with a digit).`,
@@ -2515,7 +2513,7 @@ export function selectNamedJoins(
   const associations: unknown[] = [];
 
   for (const joinName of joinNames) {
-    if (typeof joinName === "symbol" && cteNames.has(symbolToName(joinName))) {
+    if (isRubySymbol(joinName) && cteNames.has(symbolToName(joinName))) {
       cteJoins.push(symbolToName(joinName));
     } else {
       associations.push(joinName);
@@ -2540,7 +2538,6 @@ export function selectAssociationList(
   for (const association of associations) {
     if (
       typeof association === "string" ||
-      typeof association === "symbol" ||
       Array.isArray(association) ||
       isPlainObject(association)
     ) {
@@ -2573,12 +2570,7 @@ export function assertValidLeftOuterJoinsBang(values: unknown[]): void {
   for (const v of values) {
     if (typeof v === "string") {
       if (/\s/.test(v)) throw argumentError("only Hash, Symbol and Array are allowed");
-    } else if (
-      typeof v !== "symbol" &&
-      !Array.isArray(v) &&
-      !isPlainObject(v) &&
-      !(v instanceof JoinDependency)
-    ) {
+    } else if (!Array.isArray(v) && !isPlainObject(v) && !(v instanceof JoinDependency)) {
       throw argumentError("only Hash, Symbol and Array are allowed");
     }
   }

--- a/packages/activerecord/src/relation/select.test.ts
+++ b/packages/activerecord/src/relation/select.test.ts
@@ -17,8 +17,6 @@ import { quoteTableName, escapeRegExp } from "../support/quote-regex.js";
 registerModel(Post);
 registerModel(Comment);
 
-const sym = (name: string) => Symbol(name) as unknown as string;
-
 // ==========================================================================
 // SelectTest — targets relation/select_test.rb
 // ==========================================================================
@@ -48,22 +46,22 @@ describe("SelectTest", () => {
 
   it("select with non field values", () => {
     const expected = new RegExp(`^SELECT 1, foo\\(\\), ${q("bar")} FROM`);
-    expect(Post.select("1", "foo()", sym("bar")).toSql()).toMatch(expected);
+    expect(Post.select("1", "foo()", ":bar").toSql()).toMatch(expected);
   });
 
   it("select with non field hash values", () => {
     const expected = new RegExp(
       `^SELECT 1 AS ${q("a")}, foo\\(\\) AS ${q("b")}, ${q("bar")} AS ${q("c")} FROM`,
     );
-    expect(
-      Post.select({ "1": sym("a"), "foo()": sym("b"), [sym("bar")]: sym("c") } as never).toSql(),
-    ).toMatch(expected);
+    expect(Post.select({ "1": ":a", "foo()": ":b", ":bar": ":c" } as never).toSql()).toMatch(
+      expected,
+    );
   });
 
   it("select with hash argument", async () => {
     const post = (await Post.select({
-      "UPPER(title)": sym("title"),
-      posts: { title: sym("post_title") },
+      "UPPER(title)": ":title",
+      posts: { title: ":post_title" },
     }).first()) as never as { title: string; readAttribute(n: string): unknown };
 
     expect(post.title).toBe("WELCOME TO THE WEBLOG");
@@ -72,8 +70,8 @@ describe("SelectTest", () => {
 
   it("select with reserved words aliases", async () => {
     const post = (await Post.select({
-      "UPPER(title)": sym("from"),
-      title: sym("group"),
+      "UPPER(title)": ":from",
+      title: ":group",
     }).first()) as never as { readAttribute(n: string): unknown };
 
     expect(post.readAttribute("from")).toBe("WELCOME TO THE WEBLOG");
@@ -82,8 +80,8 @@ describe("SelectTest", () => {
 
   it("select with one level hash argument", async () => {
     const post = (await Post.select({
-      "UPPER(title)": sym("title"),
-      title: sym("post_title"),
+      "UPPER(title)": ":title",
+      title: ":post_title",
     }).first()) as never as { title: string; readAttribute(n: string): unknown };
 
     expect(post.title).toBe("WELCOME TO THE WEBLOG");
@@ -92,7 +90,7 @@ describe("SelectTest", () => {
 
   it("select with not exists field", async () => {
     const expected = new RegExp(`^SELECT ${q("foo")} AS ${q("post_title")} FROM`);
-    expect(Post.select({ [sym("foo")]: sym("post_title") } as never).toSql()).toMatch(expected);
+    expect(Post.select({ [":foo"]: ":post_title" } as never).toSql()).toMatch(expected);
 
     // Rails guards the raise with `skip if sqlite3_adapter_strict_strings_disabled?`
     // (select_test.rb:53). That guard only matters when the SQLite adapter is
@@ -100,35 +98,33 @@ describe("SelectTest", () => {
     // identifier (`"foo"`) parse as a string literal instead of raising. Our
     // SQLite test adapter always runs with DQS off, so `"foo"` always errors;
     // PG/MySQL raise too. The guard condition is therefore always false here.
-    await expect(Post.select({ [sym("foo")]: sym("post_title") } as never).take()).rejects.toThrow(
+    await expect(Post.select({ [":foo"]: ":post_title" } as never).take()).rejects.toThrow(
       StatementInvalid,
     );
   });
 
   it("select with hash with not exists field", async () => {
     const expected = new RegExp(`^SELECT ${q("posts.bar")} AS ${q("post_title")} FROM`);
-    expect(Post.select({ posts: { bar: sym("post_title") } }).toSql()).toMatch(expected);
+    expect(Post.select({ posts: { bar: ":post_title" } }).toSql()).toMatch(expected);
 
-    await expect(Post.select({ posts: { boo: sym("post_title") } }).take()).rejects.toThrow(
+    await expect(Post.select({ posts: { boo: ":post_title" } }).take()).rejects.toThrow(
       StatementInvalid,
     );
   });
 
   it("select with hash array value with not exists field", async () => {
     const expected = new RegExp(`^SELECT ${q("posts.bar")}, ${q("posts.id")} FROM`);
-    expect(Post.select({ posts: [sym("bar"), sym("id")] }).toSql()).toMatch(expected);
+    expect(Post.select({ posts: [":bar", ":id"] }).toSql()).toMatch(expected);
 
-    await expect(Post.select({ posts: [sym("bar"), sym("id")] }).take()).rejects.toThrow(
-      StatementInvalid,
-    );
+    await expect(Post.select({ posts: [":bar", ":id"] }).take()).rejects.toThrow(StatementInvalid);
   });
 
   it("select with hash and table alias", async () => {
     const post = (await Post.joins("comments", "commentsWithExtend")
       .select("title", {
-        posts: { title: sym("post_title") },
-        comments: { body: sym("comment_body") },
-        commentsWithExtend: { body: sym("comment_body_2") },
+        posts: { title: ":post_title" },
+        comments: { body: ":comment_body" },
+        commentsWithExtend: { body: ":comment_body_2" },
       } as never)
       .take()) as never as { title: string; readAttribute(n: string): unknown };
 
@@ -138,15 +134,15 @@ describe("SelectTest", () => {
   });
 
   it("select with invalid nested field", async () => {
-    await expect(
-      Post.select({ posts: { "UPPER(title)": sym("post_title") } }).take(),
-    ).rejects.toThrow(StatementInvalid);
+    await expect(Post.select({ posts: { "UPPER(title)": ":post_title" } }).take()).rejects.toThrow(
+      StatementInvalid,
+    );
     await expect(Post.select({ posts: ["UPPER(title)"] }).take()).rejects.toThrow(StatementInvalid);
   });
 
   it("select with hash argument without aliases", async () => {
     const post = (await Post.select({
-      posts: [sym("title"), "title as post_title"],
+      posts: [":title", "title as post_title"],
     }).first()) as never as { title: string; readAttribute(n: string): unknown };
 
     expect(post.title).toBe("Welcome to the weblog");
@@ -156,8 +152,8 @@ describe("SelectTest", () => {
   it("select with hash argument with few tables", async () => {
     const post = (await Post.joins("comments")
       .select("title", {
-        posts: { title: sym("post_title") },
-        comments: { body: sym("comment_body") },
+        posts: { title: ":post_title" },
+        comments: { body: ":comment_body" },
       } as never)
       .take()) as never as { title: string; readAttribute(n: string): unknown };
 
@@ -178,18 +174,16 @@ describe("SelectTest", () => {
   });
 
   it("reselect with hash argument", () => {
-    const expected = Post.select("title", { posts: { title: sym("post_title") } }).toSql();
+    const expected = Post.select("title", { posts: { title: ":post_title" } }).toSql();
     const actual = Post.select("title", "body")
-      .reselect("title", { posts: { title: sym("post_title") } })
+      .reselect("title", { posts: { title: ":post_title" } })
       .toSql();
     expect(actual).toBe(expected);
   });
 
   it("reselect with one level hash argument", () => {
-    const expected = Post.select("title", { title: sym("post_title") }).toSql();
-    const actual = Post.select("title", "body")
-      .reselect("title", { title: sym("post_title") })
-      .toSql();
+    const expected = Post.select("title", { title: ":post_title" }).toSql();
+    const actual = Post.select("title", "body").reselect("title", { title: ":post_title" }).toSql();
     expect(actual).toBe(expected);
   });
 

--- a/packages/activerecord/src/relation/symbol-association-join-spec.trails.test.ts
+++ b/packages/activerecord/src/relation/symbol-association-join-spec.trails.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Rails' `joins(:comments)` passes a Symbol; `JoinDependency.walk_tree` keys the
+ * tree by `associations.to_sym` (join_dependency.rb:55-56), so the Symbol and
+ * the equivalent String name the same association. trails spells a Ruby Symbol
+ * as a leading-colon string, so `joins(":comments")` must resolve the
+ * `comments` association exactly as `joins("comments")` does — the colon is
+ * modelling, not part of the name.
+ *
+ * trails-only (hence `.trails.test.ts`): Rails cannot write this test, because
+ * on the Ruby side the two spellings are different types rather than two
+ * strings.
+ */
+import { describe, it, expect } from "vitest";
+import "../index.js";
+import { Post } from "../test-helpers/models/post.js";
+import { fixtures } from "../test-fixtures.js";
+
+describe("a leading-colon association spec", () => {
+  fixtures(["posts", "comments"]);
+
+  it("joins the same association as the bare string", async () => {
+    expect(Post.joins(":comments").toSql()).toBe(Post.joins("comments").toSql());
+    expect(await Post.joins(":comments").count()).toBe(await Post.joins("comments").count());
+  });
+
+  it("left outer joins the same association as the bare string", async () => {
+    expect(Post.leftOuterJoins(":comments").toSql()).toBe(Post.leftOuterJoins("comments").toSql());
+    expect(await Post.leftOuterJoins(":comments").count()).toBe(
+      await Post.leftOuterJoins("comments").count(),
+    );
+  });
+
+  it("joins a nested spec given as a colon string", () => {
+    expect(Post.joins({ comments: ":post" }).toSql()).toBe(
+      Post.joins({ comments: "post" }).toSql(),
+    );
+  });
+});

--- a/packages/activerecord/src/relation/symbol-association-join-spec.trails.test.ts
+++ b/packages/activerecord/src/relation/symbol-association-join-spec.trails.test.ts
@@ -35,4 +35,14 @@ describe("a leading-colon association spec", () => {
       Post.joins({ comments: "post" }).toSql(),
     );
   });
+
+  it("joins a nested spec whose key is a colon string", async () => {
+    // Rails `joins(comments: :post)` — both halves of the hash are Symbols.
+    expect(Post.joins({ ":comments": ":post" }).toSql()).toBe(
+      Post.joins({ comments: "post" }).toSql(),
+    );
+    expect(await Post.joins({ ":comments": ":post" }).count()).toBe(
+      await Post.joins({ comments: "post" }).count(),
+    );
+  });
 });

--- a/packages/activerecord/src/relation/with.test.ts
+++ b/packages/activerecord/src/relation/with.test.ts
@@ -34,8 +34,6 @@ function toIds(ids: any[]): number[] {
 // trails collapses Ruby Symbol and String to one JS string type; a genuine
 // Symbol is how a caller signals "association/CTE name" (vs a raw SQL fragment)
 // to the join partitioner (query_methods.ts `selectNamedJoins`).
-const cteSym = (name: string) => Symbol(name) as unknown as string;
-
 // ==========================================================================
 // WithTest — targets relation/with_test.rb
 // ==========================================================================
@@ -188,7 +186,7 @@ describeIfSupports("common_table_expressions", "WithTest", () => {
     // joins() to build_with_join_node(name, InnerJoin) — an
     // `INNER JOIN commented_posts ON commented_posts.post_id = posts.id`.
     const relation = Post.with({ commented_posts: Comment.select("post_id").distinct() }).joins(
-      cteSym("commented_posts"),
+      ":commented_posts",
     );
 
     expect(toIds(await relation.order("id").pluck("id"))).toEqual(POSTS_WITH_COMMENTS);
@@ -206,7 +204,7 @@ describeIfSupports("common_table_expressions", "WithTest", () => {
     const sql = (
       Post.with({
         commented_posts: Comment.select("post_id").distinct(),
-      }).joins(cteSym("commented_posts")) as unknown as { toSql(): string }
+      }).joins(":commented_posts") as unknown as { toSql(): string }
     ).toSql();
 
     // Identifier quoting is dialect-specific (`"` on sqlite/pg, backticks on
@@ -247,11 +245,11 @@ describeIfSupports("common_table_expressions", "WithTest", () => {
     // the LEFT OUTER JOIN directly (no `from(...)` subquery wrapper). Lock the
     // OuterJoin routing: the CTE symbol must emit a LEFT OUTER JOIN to the CTE
     // (`commented_posts.post_id = posts.id`), not an INNER JOIN. (trails Symbol
-    // is `Symbol("name")`.)
+    // is `":name"`.)
     const relation = Post.with({
       commented_posts: Comment.select("post_id").distinct(),
     })
-      .leftOuterJoins(cteSym("commented_posts"))
+      .leftOuterJoins(":commented_posts")
       .select("posts.id");
 
     const sql = (relation as unknown as { toSql(): string }).toSql();
@@ -277,7 +275,7 @@ describeIfSupports("common_table_expressions", "WithTest", () => {
       commented_posts: Comment.select("post_id").distinct(),
     })
       .joins("INNER JOIN authors ON authors.id = posts.author_id")
-      .leftOuterJoins(cteSym("commented_posts"))
+      .leftOuterJoins(":commented_posts")
       .select("posts.id");
 
     const sql = (relation as unknown as { toSql(): string }).toSql();

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -406,9 +406,7 @@ describe("RelationTest", () => {
   });
 
   it("finding with subquery with eager loading in from", async () => {
-    const relation = Comment.includes("post")
-      .where({ "posts.type": "Post" })
-      .order(Symbol.for("id"));
+    const relation = Comment.includes("post").where({ "posts.type": "Post" }).order(":id");
     const expected = (await relation).map((c) => c.id);
     expect((await Comment.select("*").from(relation)).map((c) => c.id)).toEqual(expected);
     expect((await Comment.select("subquery.*").from(relation)).map((c) => c.id)).toEqual(expected);
@@ -425,9 +423,7 @@ describe("RelationTest", () => {
   // `toSql()` emits. This is Rails-correct, and shared with the where-subquery
   // path (`relation-handler`); converging to `t0_r*` here would diverge.
   it("eager from() subquery projects the table star, not column aliases", async () => {
-    const relation = Comment.includes("post")
-      .where({ "posts.type": "Post" })
-      .order(Symbol.for("id"));
+    const relation = Comment.includes("post").where({ "posts.type": "Post" }).order(":id");
     const sql = await (Comment.select("*").from(relation) as any).toSql();
     // Adapter-agnostic: strip identifier quoting (`"` on sqlite/postgres,
     // backticks on mysql) so the shape assertion holds on every CI adapter.
@@ -574,7 +570,7 @@ describe("RelationTest", () => {
   });
 
   it("order with hash and symbol generates the same sql", () => {
-    expect(Topic.order(Symbol.for("id")).toSql()).toBe(Topic.order({ id: "asc" }).toSql());
+    expect(Topic.order(":id").toSql()).toBe(Topic.order({ id: "asc" }).toSql());
   });
 
   it("finding with desc order with string", async () => {
@@ -628,7 +624,7 @@ describe("RelationTest", () => {
   });
 
   it("finding with order by aliased attributes", async () => {
-    const topicsRel = Topic.order(Symbol.for("heading"));
+    const topicsRel = Topic.order(":heading");
     expect(await topicsRel.size()).toBe(5);
     expect((await topicsRel.first())!.title).toBe(topics("fifth").title);
   });
@@ -657,7 +653,7 @@ describe("RelationTest", () => {
   });
 
   it("finding with reorder by aliased attributes", async () => {
-    const topicsRel = Topic.order("author_name").reorder(Symbol.for("heading"));
+    const topicsRel = Topic.order("author_name").reorder(":heading");
     expect(await topicsRel.size()).toBe(5);
     expect((await topicsRel.first())!.title).toBe(topics("fifth").title);
   });

--- a/packages/activerecord/src/reserved-word.test.ts
+++ b/packages/activerecord/src/reserved-word.test.ts
@@ -172,7 +172,7 @@ describe("ReservedWordTest", () => {
 
   it("delete all with subselect", async () => {
     await createTestFixtures("values");
-    expect(await Values.order(Symbol.for("as")).limit(1).offset(1).deleteAll()).toBe(1);
+    expect(await Values.order(":as").limit(1).offset(1).deleteAll()).toBe(1);
     await expect(Values.find(2)).rejects.toThrow(RecordNotFound);
     expect(await Values.find(1)).not.toBeNull();
   });

--- a/scripts/parity/pipeline/fixtures/ar-79/query.ts
+++ b/scripts/parity/pipeline/fixtures/ar-79/query.ts
@@ -1,3 +1,3 @@
 import { Book } from "./models.js";
 
-export default Book.where({ active: true }).unscoped().order(Symbol.for("title"));
+export default Book.where({ active: true }).unscoped().order(":title");


### PR DESCRIPTION
## What

`arelColumn` / `arelColumns` / `arelColumnWithTable` / `arelColumnsFromHash` /
`arelColumnAliasesFromHash` (and the `order` / `group` / `joins` / `with` paths
alongside them) discriminated on `typeof x === "symbol"` — a JS `Symbol` used as
a Ruby-Symbol stand-in, which CLAUDE.md forbids ("a Ruby Symbol is a JS string,
never a JS `Symbol`").

The arms themselves are load-bearing, not dead modelling. Rails turns on the
Ruby type at two live sites:

- `query_methods.rb:2003` — `Arel.sql(is_symbol ? model.adapter_class.quote_table_name(field) : field)`.
  `Post.select("1", "foo()", :bar)` emits `SELECT 1, foo(), "bar"`
  (`activerecord/test/cases/relation/select_test.rb:16-19`): the Symbol names a
  column and is quoted, the Strings are raw SQL and are not.
- `query_methods.rb:1980` — `column_name.is_a?(Symbol) || !column_name.match?(/\W/)`,
  exercised by `select_test.rb:71-78` (`Post.select(posts: [:bar, :id])`).

So this converts the modelling rather than deleting the arms: a Ruby Symbol is
now the settled leading-colon string — `:bar` is `":bar"`, `.slice(1)` for the
name — matched by a private `isRubySymbol` predicate. The quoting behavior at
both Rails sites is preserved exactly.

## Changes

- `relation/query-methods.ts`: `symbolToName` takes a colon-string; new private
  `isRubySymbol`; all 15 call sites flipped. `Reflect.ownKeys` → `Object.keys`
  now that no hash key is a JS Symbol, and the symbol-key arms of
  `isBlankArgument` / `_selectBang` / `selectAssociationList` /
  `assertValidLeftOuterJoinsBang` collapse into their existing string arms.
  Dropping `_selectBang`'s symbol→name dedup key also converges Ruby's
  `select_values |= args`, where `:bar` and `"bar"` are not `eql?` and both
  survive.
- `relation.ts`: `_isNamedJoinValue` routes a leading-colon string to
  `_namedInnerJoins` (where the JS Symbol used to land); `selectValues` /
  `arelColumn` / `arelColumnWithTable` / `arelColumnAliasesFromHash` signatures
  lose `symbol`.
- Tests: `select.test.ts`'s `sym()` and `with.test.ts`'s `cteSym()` helpers are
  gone — the call sites now read `":bar"`, matching `select_test.rb` verbatim —
  and `Symbol.for("x")` order args across `relations` / `calculations` /
  `finder` / `reserved-word` / `order` / `cascaded-eager-loading` become `":x"`.
  The `ar-79` parity fixture now mirrors its `query.rb` `.order(:title)`.

## Verification

`relation/**` (51 files), `relations.test.ts`, `calculations.test.ts`,
`finder.test.ts`, `reserved-word.test.ts`, `cascaded-eager-loading.test.ts`,
`scripts/parity` — 1749 passed locally on SQLite. `pnpm typecheck`,
`pnpm lint`, `parity:api:calls` (OK), `parity:api:calls:args` (OK) all clean;
no new public surface.

Closes-story: arel-symbol-modelling-colon-string-campaign
