### PR TITLE
fix(website): stub activesupport's relative yaml import in the service-worker bundle

### DIFF
--- a/packages/website/vite.config.ts
+++ b/packages/website/vite.config.ts
@@ -13,8 +13,21 @@ function pkgAlias(name: string, entry: string) {
   };
 }
 
+function stubActivesupportYaml() {
+  return {
+    name: "stub-activesupport-yaml",
+    enforce: "pre" as const,
+    resolveId(source: string, importer: string | undefined) {
+      if (source === "./yaml.js" && importer?.includes("/activesupport/src/")) {
+        return path.resolve(__dirname, "src/stubs/yaml-stub.ts");
+      }
+      return null;
+    },
+  };
+}
+
 export default defineConfig({
-  plugins: [tailwindcss(), sveltekit()],
+  plugins: [stubActivesupportYaml(), tailwindcss(), sveltekit()],
   resolve: {
     alias: [
       pkgAlias("@blazetrails/activesupport", "../activesupport/src/index.ts"),

--- a/packages/website/vite.sw.config.ts
+++ b/packages/website/vite.sw.config.ts
@@ -11,6 +11,24 @@ function pkgAlias(name: string, entry: string) {
   };
 }
 
+// `@blazetrails/activesupport/yaml` is also reached from inside activesupport
+// itself (`xml-mini.ts` resolves the optional `yaml` package through a
+// call-time `import("./yaml.js")`), and a relative specifier never hits the
+// subpath alias below. Redirect that one edge to the same stub so the
+// top-level await in `yaml.ts` stays out of the IIFE bundle.
+function stubActivesupportYaml() {
+  return {
+    name: "stub-activesupport-yaml",
+    enforce: "pre" as const,
+    resolveId(source: string, importer: string | undefined) {
+      if (source === "./yaml.js" && importer?.includes("/activesupport/src/")) {
+        return path.resolve(__dirname, "src/stubs/yaml-stub.ts");
+      }
+      return null;
+    },
+  };
+}
+
 function prependImportScripts() {
   return {
     name: "prepend-importscripts",
@@ -25,7 +43,7 @@ function prependImportScripts() {
 }
 
 export default defineConfig({
-  plugins: [prependImportScripts()],
+  plugins: [stubActivesupportYaml(), prependImportScripts()],
   resolve: {
     alias: [
       // Subpath imports must come before the base alias. The activerecord

--- a/packages/website/vite.sw.config.ts
+++ b/packages/website/vite.sw.config.ts
@@ -11,11 +11,6 @@ function pkgAlias(name: string, entry: string) {
   };
 }
 
-// `@blazetrails/activesupport/yaml` is also reached from inside activesupport
-// itself (`xml-mini.ts` resolves the optional `yaml` package through a
-// call-time `import("./yaml.js")`), and a relative specifier never hits the
-// subpath alias below. Redirect that one edge to the same stub so the
-// top-level await in `yaml.ts` stays out of the IIFE bundle.
 function stubActivesupportYaml() {
   return {
     name: "stub-activesupport-yaml",


### PR DESCRIPTION
`xml-mini.ts`'s `yaml:` parsing arm (`xml_mini.rb:83` — `YAML.load(yaml) rescue yaml`) resolves the optional `yaml` package via a call-time `import("./yaml.js")`. That relative specifier matches neither the `@blazetrails/activesupport/yaml` alias in `vite.sw.config.ts` nor the `@blazetrails/activesupport/` external rule in `vite.config.ts`, so both website bundles pulled in `yaml.ts` and choked on its top-level await:

- service worker (IIFE): `Module format "iife" does not support top-level await`
- SvelteKit browser build (es2020): `Top-level await is not available in the configured target environment`

Each config gets a pre-enforced `resolveId` plugin redirecting that one relative edge to the existing `src/stubs/yaml-stub.ts`.

Verified: `pnpm --filter @blazetrails/website build:sw` and `pnpm --filter @blazetrails/website exec vite build` both green.

Closes-story: red-b2d6aba4