### PR TITLE
refactor(activerecord,activesupport): drop the MySQL tasks URL re-parse, fold the Date zones copy into the mixin, resolve XmlMini backends by name

### DIFF
--- a/packages/activerecord/src/support/config.ts
+++ b/packages/activerecord/src/support/config.ts
@@ -97,8 +97,8 @@ export type EnvReader = (key: string) => string | undefined;
  * CI routinely sets a variable to `""` to mean "no value" (an empty password,
  * an unused socket path), and `??` alone would take that literally — an empty
  * `MYSQL_USER` becomes `user: ""` and the server answers
- * `Access denied for user ''`. This matches the convention already used by
- * `MySQLDatabaseTasks#resolvedField`, which likewise rejects `""`.
+ * `Access denied for user ''`. This mirrors ActiveSupport's `presence`, which
+ * likewise treats `""` as absent.
  */
 function present(read: EnvReader, key: string): string | undefined {
   const value = read(key);

--- a/packages/activerecord/src/tasks/mysql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/mysql-database-tasks.ts
@@ -195,12 +195,15 @@ export class MySQLDatabaseTasks {
    * hash into it (`database_configurations/url_config.rb:41-43`), so there is
    * nothing left to re-parse here.
    *
+   * Ruby's `filter_map` guard is `if configuration_hash[opt]`, so only nil/false
+   * are dropped — an empty string still emits its flag.
+   *
    * The one deviation is `password: "--password"`, deliberately NOT placed in
    * argv (it would otherwise be visible in `ps` to other local users); it is
    * passed via MYSQL_PWD in {@link commandEnv} instead.
    */
   private prepareCommandOptions(): string[] {
-    const args: Record<string, string> = {
+    const args = Object.entries({
       host: "--host",
       port: "--port",
       socket: "--socket",
@@ -212,12 +215,12 @@ export class MySQLDatabaseTasks {
       sslcipher: "--ssl-cipher",
       sslkey: "--ssl-key",
       ssl_mode: "--ssl-mode",
-    };
-    return Object.entries(args).flatMap(([opt, arg]) => {
+    }).flatMap(([opt, arg]) => {
       const value = this.configurationHash[opt];
-      // Ruby's `if configuration_hash[opt]` — only nil/false are skipped.
       return value != null && value !== false ? [`${arg}=${String(value)}`] : [];
     });
+
+    return args;
   }
 
   private commandEnv(): NodeJS.ProcessEnv {

--- a/packages/activerecord/src/tasks/mysql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/mysql-database-tasks.ts
@@ -197,10 +197,6 @@ export class MySQLDatabaseTasks {
    *
    * Ruby's `filter_map` guard is `if configuration_hash[opt]`, so only nil/false
    * are dropped — an empty string still emits its flag.
-   *
-   * The one deviation is `password: "--password"`, deliberately NOT placed in
-   * argv (it would otherwise be visible in `ps` to other local users); it is
-   * passed via MYSQL_PWD in {@link commandEnv} instead.
    */
   private prepareCommandOptions(): string[] {
     const args = Object.entries({
@@ -208,6 +204,7 @@ export class MySQLDatabaseTasks {
       port: "--port",
       socket: "--socket",
       username: "--user",
+      password: "--password",
       encoding: "--default-character-set",
       sslca: "--ssl-ca",
       sslcert: "--ssl-cert",
@@ -223,15 +220,6 @@ export class MySQLDatabaseTasks {
     return args;
   }
 
-  private commandEnv(): NodeJS.ProcessEnv {
-    const env: NodeJS.ProcessEnv = {
-      ...((globalThis as { process?: { env?: NodeJS.ProcessEnv } }).process?.env ?? {}),
-    };
-    const password = this.configurationHash.password;
-    if (password != null && password !== false) env.MYSQL_PWD = String(password);
-    return env;
-  }
-
   private async connection(): Promise<Mysql2Adapter> {
     return (await Base.connectionPool().leaseConnection()) as Mysql2Adapter;
   }
@@ -241,7 +229,6 @@ export class MySQLDatabaseTasks {
     const result: SpawnSyncResult = childProcess.spawnSync(cmd, args, {
       encoding: "utf8",
       input: stdin,
-      env: this.commandEnv(),
     });
     if (result.error || result.status !== 0 || result.signal) {
       const details: string[] = [];

--- a/packages/activerecord/src/tasks/mysql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/mysql-database-tasks.ts
@@ -12,37 +12,9 @@ import { DatabaseTasks, metadataTableNames } from "./database-tasks.js";
 
 type ConfigHash = Record<string, unknown>;
 
-interface UrlParts {
-  host?: string;
-  port?: string;
-  username?: string;
-  password?: string;
-  database?: string;
-  socket?: string;
-}
-
-function parseDbUrl(url: string | undefined): UrlParts {
-  if (!url) return {};
-  try {
-    const parsed = new URL(url);
-    const database = decodeURIComponent(parsed.pathname.replace(/^\/+/, ""));
-    return {
-      host: parsed.hostname || undefined,
-      port: parsed.port || undefined,
-      username: parsed.username ? decodeURIComponent(parsed.username) : undefined,
-      password: parsed.password ? decodeURIComponent(parsed.password) : undefined,
-      database: database || undefined,
-      socket: parsed.searchParams.get("socket") ?? undefined,
-    };
-  } catch {
-    return {};
-  }
-}
-
 export class MySQLDatabaseTasks {
   private readonly dbConfig: DatabaseConfig;
   private readonly configurationHash: ConfigHash;
-  private readonly urlParts: UrlParts;
 
   static usingDatabaseConfigurations(): boolean {
     return true;
@@ -51,7 +23,6 @@ export class MySQLDatabaseTasks {
   constructor(dbConfig: DatabaseConfig) {
     this.dbConfig = dbConfig;
     this.configurationHash = { ...dbConfig.configuration };
-    this.urlParts = parseDbUrl(this.configurationHash.url as string | undefined);
   }
 
   async create(): Promise<void> {
@@ -218,54 +189,43 @@ export class MySQLDatabaseTasks {
     return { charset: row.DEFAULT_CHARACTER_SET_NAME, collation: row.DEFAULT_COLLATION_NAME };
   }
 
-  private resolvedField(name: keyof UrlParts): string | undefined {
-    const c = this.configurationHash;
-    const fromConfig = c[name as string];
-    if (fromConfig !== undefined && fromConfig !== null && fromConfig !== "") {
-      return String(fromConfig);
-    }
-    const fromUrl = this.urlParts[name];
-    return fromUrl !== undefined ? String(fromUrl) : undefined;
-  }
-
   /**
-   * Build argv for mysql/mysqldump. The password is deliberately NOT placed
-   * in argv (it would otherwise be visible in `ps` to other local users);
-   * callers should read the password via env (MYSQL_PWD) — set in
-   * {@link commandEnv}.
+   * `prepare_command_options` (`mysql_database_tasks.rb:76-93`). Reads
+   * `configuration_hash` only: `UrlConfig` has already merged the resolved URL
+   * hash into it (`database_configurations/url_config.rb:41-43`), so there is
+   * nothing left to re-parse here.
+   *
+   * The one deviation is `password: "--password"`, deliberately NOT placed in
+   * argv (it would otherwise be visible in `ps` to other local users); it is
+   * passed via MYSQL_PWD in {@link commandEnv} instead.
    */
   private prepareCommandOptions(): string[] {
-    const args: string[] = [];
-    const flagMap: Array<{ flag: string; key: string; fromUrl?: boolean }> = [
-      { flag: "--host", key: "host", fromUrl: true },
-      { flag: "--port", key: "port", fromUrl: true },
-      { flag: "--socket", key: "socket", fromUrl: true },
-      { flag: "--user", key: "username", fromUrl: true },
-      { flag: "--default-character-set", key: "encoding" },
-      { flag: "--ssl-ca", key: "sslca" },
-      { flag: "--ssl-cert", key: "sslcert" },
-      { flag: "--ssl-capath", key: "sslcapath" },
-      { flag: "--ssl-cipher", key: "sslcipher" },
-      { flag: "--ssl-key", key: "sslkey" },
-      { flag: "--ssl-mode", key: "ssl_mode" },
-    ];
-    for (const { flag, key, fromUrl } of flagMap) {
-      const value = fromUrl
-        ? this.resolvedField(key as keyof UrlParts)
-        : (this.configurationHash[key] as string | number | undefined);
-      if (value !== undefined && value !== null && value !== "") {
-        args.push(`${flag}=${String(value)}`);
-      }
-    }
-    return args;
+    const args: Record<string, string> = {
+      host: "--host",
+      port: "--port",
+      socket: "--socket",
+      username: "--user",
+      encoding: "--default-character-set",
+      sslca: "--ssl-ca",
+      sslcert: "--ssl-cert",
+      sslcapath: "--ssl-capath",
+      sslcipher: "--ssl-cipher",
+      sslkey: "--ssl-key",
+      ssl_mode: "--ssl-mode",
+    };
+    return Object.entries(args).flatMap(([opt, arg]) => {
+      const value = this.configurationHash[opt];
+      // Ruby's `if configuration_hash[opt]` — only nil/false are skipped.
+      return value != null && value !== false ? [`${arg}=${String(value)}`] : [];
+    });
   }
 
   private commandEnv(): NodeJS.ProcessEnv {
     const env: NodeJS.ProcessEnv = {
       ...((globalThis as { process?: { env?: NodeJS.ProcessEnv } }).process?.env ?? {}),
     };
-    const password = this.resolvedField("password");
-    if (password !== undefined) env.MYSQL_PWD = password;
+    const password = this.configurationHash.password;
+    if (password != null && password !== false) env.MYSQL_PWD = String(password);
     return env;
   }
 

--- a/packages/activesupport/src/core-ext/date-and-time/zones.ts
+++ b/packages/activesupport/src/core-ext/date-and-time/zones.ts
@@ -37,6 +37,11 @@ export type DateOrTime = Temporal.PlainDate | Date | Temporal.Instant;
  * parameter takes both arms Rails accepts — a `TimeZone` object and a String
  * identifying one — because `Time.find_zone!` dispatches on both.
  */
+export function inTimeZone(dateOrTime: Temporal.PlainDate, zone?: unknown): TimeWithZone;
+export function inTimeZone(
+  dateOrTime: Date | Temporal.Instant,
+  zone?: unknown,
+): TimeWithZone | Temporal.Instant;
 export function inTimeZone(
   dateOrTime: DateOrTime,
   zone: unknown = getZone(),

--- a/packages/activesupport/src/core-ext/date-and-time/zones.ts
+++ b/packages/activesupport/src/core-ext/date-and-time/zones.ts
@@ -37,6 +37,13 @@ export type DateOrTime = Temporal.PlainDate | Date | Temporal.Instant;
  * parameter takes both arms Rails accepts — a `TimeZone` object and a String
  * identifying one — because `Time.find_zone!` dispatches on both.
  */
+/**
+ * The `Date` arm. Ruby's `time || to_time` is `to_time` here (a Date is never
+ * `acts_like?(:time)`), and trails' `Date#to_time` answers a `TimeWithZone`
+ * (`core-ext/date/conversions.ts`, `date/conversions.rb:83-86`), so both arms
+ * of this receiver return one — `Temporal.Instant` is reachable only from the
+ * `Time` arm's `time`.
+ */
 export function inTimeZone(dateOrTime: Temporal.PlainDate, zone?: unknown): TimeWithZone;
 export function inTimeZone(
   dateOrTime: Date | Temporal.Instant,

--- a/packages/activesupport/src/core-ext/date/calculations.ts
+++ b/packages/activesupport/src/core-ext/date/calculations.ts
@@ -7,6 +7,9 @@
  * `Date` — always an instant — and is that `Time` arm; this file is the `Date`
  * one, keyed on `Temporal.PlainDate`, the calendar-day analogue.
  *
+ * `in_time_zone` comes from `DateAndTime::Zones`, which `core_ext/date/zones.rb`
+ * mixes into `Date`, so it is imported rather than redefined here.
+ *
  * Mirrors: `class Date` (`core_ext/date/calculations.rb`)
  */
 
@@ -15,8 +18,6 @@ import { Duration } from "../../duration.js";
 import { IsolatedExecutionState } from "../../isolated-execution-state.js";
 import { TimeWithZone } from "../../time-with-zone.js";
 import { ArgumentError, getZone } from "../../time-zone-config.js";
-// `core_ext/date/zones.rb` — `Date.include DateAndTime::Zones`; the Date arm's
-// `in_time_zone` is that mixin's, not a Date-local method.
 import { inTimeZone } from "../date-and-time/zones.js";
 
 /**

--- a/packages/activesupport/src/core-ext/date/calculations.ts
+++ b/packages/activesupport/src/core-ext/date/calculations.ts
@@ -14,9 +14,10 @@ import { Temporal } from "@blazetrails/date";
 import { Duration } from "../../duration.js";
 import { IsolatedExecutionState } from "../../isolated-execution-state.js";
 import { TimeWithZone } from "../../time-with-zone.js";
-import { TimeZone } from "../../values/time-zone.js";
-import { ArgumentError, findZoneBang, getZone } from "../../time-zone-config.js";
-import { toTime } from "./conversions.js";
+import { ArgumentError, getZone } from "../../time-zone-config.js";
+// `core_ext/date/zones.rb` — `Date.include DateAndTime::Zones`; the Date arm's
+// `in_time_zone` is that mixin's, not a Date-local method.
+import { inTimeZone } from "../date-and-time/zones.js";
 
 /**
  * Mirrors: `DateAndTime::Calculations::DAYS_INTO_WEEK`
@@ -85,36 +86,6 @@ export function current(): Temporal.PlainDate {
     return new Temporal.PlainDate(today.year, today.month, today.day);
   }
   return Temporal.Now.plainDateISO();
-}
-
-/**
- * TODO(converge-time-zone-reader-names): the mixin this specialises now lives
- * at its Rails path, `core-ext/date-and-time/zones.ts`. This Date-only copy
- * stays only because its `else` arm returns a `TimeWithZone` where the mixin
- * returns the `Temporal.Instant` Ruby's `to_time` gives, so folding the two
- * changes the return type of every caller (`ago`, `since`, …). Route them
- * through the mixin and delete this pair; do not add a third copy.
- *
- * Mirrors: `DateAndTime::Zones#in_time_zone` (`date_and_time/zones.rb:20-28`)
- * for the `Date` receiver (`core_ext/date/zones.rb` mixes it in). A Date never
- * `acts_like?(:time)`, so Rails' `time` local is always nil here and
- * `time_with_zone` takes its `TimeWithZone.new(nil, zone, to_time(:utc))` arm —
- * the day's midnight read in `zone`.
- *
- * Rails' `time` local is `nil` for a `Date` receiver, so the `else` arm is
- * `to_time` — see `core-ext/date/conversions.ts` for the receiver equivalence.
- */
-export function inTimeZone(date: Temporal.PlainDate, zone: unknown = getZone()): TimeWithZone {
-  const timeZone = findZoneBang(zone);
-  if (timeZone) {
-    return timeWithZone(date, timeZone);
-  }
-  return toTime(date);
-}
-
-/** Mirrors: `DateAndTime::Zones#time_with_zone` (`date_and_time/zones.rb:32-38`) */
-function timeWithZone(date: Temporal.PlainDate, zone: TimeZone): TimeWithZone {
-  return zone.local(date.year, date.month, date.day);
 }
 
 /** Mirrors: `Date#ago` (`date/calculations.rb:55-57`) */

--- a/packages/activesupport/src/xml-mini.trails.test.ts
+++ b/packages/activesupport/src/xml-mini.trails.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { _parseBinary, _parseFile, _parseHexBinary, FileLike } from "./xml-mini.js";
+import {
+  _parseBinary,
+  _parseFile,
+  _parseHexBinary,
+  castBackendNameToModule,
+  FileLike,
+} from "./xml-mini.js";
+import * as XmlMini_REXML from "./xml-mini/rexml.js";
+import * as XmlMini_Nokogiri from "./xml-mini/nokogiri.js";
 
 // Rails exercises these through `XmlMini::PARSING` (xml_mini_test.rb:248) and
 // `Hash.from_xml` (xml_mini_engine_test.rb:36), neither of which is ported yet,
@@ -39,5 +47,25 @@ describe("XmlMini", () => {
     expect(f.originalFilename).toBe("untitled");
     f.originalFilename = "avatar.gif";
     expect(f.originalFilename).toBe("avatar.gif");
+  });
+
+  // Rails' own engine suites set the backend by NAME
+  // (`XmlMini.backend = engine`, `xml_mini_engine_test.rb:25-27`), so the name
+  // arm of `cast_backend_name_to_module` (`xml_mini.rb:200-206`) is the one
+  // Rails exercises; it is covered directly here because it must resolve both
+  // under vitest and in the built package.
+  it("cast_backend_name_to_module resolves a backend by name", async () => {
+    expect(await castBackendNameToModule("REXML")).toBe(XmlMini_REXML);
+    expect(await castBackendNameToModule("Nokogiri")).toBe(XmlMini_Nokogiri);
+  });
+
+  it("cast_backend_name_to_module returns a module unchanged", async () => {
+    expect(await castBackendNameToModule(XmlMini_REXML)).toBe(XmlMini_REXML);
+  });
+
+  it("cast_backend_name_to_module raises for an unknown backend name", async () => {
+    await expect(castBackendNameToModule("NoSuchEngine")).rejects.toThrow(
+      "cannot load such file -- active_support/xml_mini/nosuchengine",
+    );
   });
 });

--- a/packages/activesupport/src/xml-mini.ts
+++ b/packages/activesupport/src/xml-mini.ts
@@ -709,8 +709,14 @@ export async function setCurrentThreadBackend(
  * Mirrors: ActiveSupport::XmlMini#cast_backend_name_to_module
  * (xml_mini.rb:200-206) — Ruby's `require
  * "active_support/xml_mini/#{name.downcase}"` plus `const_get "XmlMini_#{name}"`
- * is one dynamic import here, since the module namespace object of
+ * is a dynamic import here, since the module namespace object of
  * `xml-mini/<name>.js` is the backend module.
+ *
+ * The import specifiers are spelled out rather than interpolated: a bundler
+ * resolves `import(\`./xml-mini/${x}.js\`)` by globbing `./xml-mini/*.js`, which
+ * matches nothing when the sources on disk are `.ts`, so the name arm threw
+ * `Unknown variable dynamic import` under vitest. One literal specifier per
+ * file `require` can reach keeps the arm lazy and resolvable in both.
  *
  * @internal
  */
@@ -718,7 +724,21 @@ export async function castBackendNameToModule(name: XmlMiniBackendName): Promise
   if (typeof name !== "string") {
     return name;
   } else {
-    return (await import(`./xml-mini/${name.toLowerCase()}.js`)) as XmlMiniBackend;
+    switch (name.toLowerCase()) {
+      case "rexml":
+        return (await import("./xml-mini/rexml.js")) as XmlMiniBackend;
+      case "nokogiri":
+        return (await import("./xml-mini/nokogiri.js")) as XmlMiniBackend;
+      case "nokogirisax":
+        return (await import("./xml-mini/nokogirisax.js")) as XmlMiniBackend;
+      default:
+        // Ruby's counterpart is the core `LoadError` that
+        // `require "active_support/xml_mini/#{name.downcase}"` raises for a
+        // name with no file; there is no Rails error class to port here, the
+        // same reason `yaml.ts:16` gives for its own LoadError stand-in.
+        // eslint-disable-next-line blazetrails/rails-error-parity
+        throw new Error(`cannot load such file -- active_support/xml_mini/${name.toLowerCase()}`);
+    }
   }
 }
 

--- a/packages/activesupport/src/xml-mini/xml-mini-engine.test.ts
+++ b/packages/activesupport/src/xml-mini/xml-mini-engine.test.ts
@@ -14,13 +14,9 @@ import * as XmlMini_REXML from "./rexml.js";
 
 /**
  * `REXMLEngineTest#engine` (`rexml_engine_test.rb:20-22`), which Ruby uses
- * both as the `XmlMini.backend=` argument and to name the constant. The
- * backend module namespace object is what `cast_backend_name_to_module`
- * (`xml_mini.rb:200-206`) resolves the name to, and the value passed here:
- * under vitest the name arm's `import("./xml-mini/rexml.js")` has no `.js`
- * file to glob, so the name is only spelled where it is compared.
+ * both as the `XmlMini.backend=` argument and to name the constant.
  */
-const engine = XmlMini_REXML;
+const engine = "REXML";
 
 /** `REXMLEngineTest#expansion_attack_error` (`rexml_engine_test.rb:24-26`). */
 const expansionAttackError = RuntimeError;


### PR DESCRIPTION
Three convergence stories, one PR.

**`MySQLDatabaseTasks` reads `configuration_hash` only.** `prepare_command_options`
(`mysql_database_tasks.rb:76-93`) is a `filter_map` over `configuration_hash`; trails
additionally parsed the config's `url` itself and fell back to the parsed parts for
`host`/`port`/`username`/`password`/`socket`. `UrlConfig` has already merged the
resolved URL hash into `configuration_hash` (`url_config.rb:41-43`) — and trails'
`ConnectionUrlResolver#toHash` resolves all five — so `parseDbUrl`, the `UrlParts`
type, the `urlParts` field and `resolvedField` are deleted. The body is now Rails'
opt→flag map, with Ruby's truthiness (`nil`/`false` only) rather than a `""` test.
The single remaining deviation, `password` going through `MYSQL_PWD` instead of argv,
keeps its call-site note.

**One `in_time_zone`, at the Rails path.** `core-ext/date/calculations.ts` carried a
Date-only copy of `DateAndTime::Zones#in_time_zone` / `#time_with_zone`
(`date_and_time/zones.rb:20-38`) alongside the mixin PR #6465 ported to
`core-ext/date-and-time/zones.ts`. The copy and its `TODO` are gone; `ago`, `since`,
`beginningOfDay`, `middleOfDay` and `endOfDay` route through the mixin. Caller return
types are unchanged after all: the story expected the mixin's no-zone arm to yield a
`Temporal.Instant`, but trails' `Date#to_time` (`core-ext/date/conversions.ts:28`,
`date/conversions.rb:83-86`) returns a `TimeWithZone` — the `Instant` only ever comes
from the `Time` arm. Overloads on the mixin state that per receiver.

**Review round 1.** `prepare_command_options` now carries `password: "--password"`
in the option map, exactly as `mysql_database_tasks.rb:90-104` does; the MYSQL_PWD
rewrite and the `commandEnv` helper that existed only to hold it are deleted, and
`run_cmd` spawns with no env override, matching `Kernel.system(cmd, *args)`.

On the `Date#since` no-zone path: it resolves, and `date-ext.test.ts`'s `since` /
`ago` cases (no `Time.zone` set) cover it. Ruby's `time || to_time` is `to_time`
for a Date receiver, and trails' `Date#to_time` (`core-ext/date/conversions.ts`,
`date/conversions.rb:83-86`) answers a `TimeWithZone`, which has `.since`;
`Temporal.Instant` is reachable only from the mixin's `Time` arm, via `asInstant`
(`zones.ts:55`). That is now stated on the `Date`-arm overload rather than left to
the union type — the union is what the story's premise, and the review, read as the
Date arm's return.

**`XmlMini.backend = "REXML"` resolves.** `cast_backend_name_to_module`
(`xml_mini.rb:200-206`) was one interpolated dynamic import; a bundler resolves that
by globbing `./xml-mini/*.js`, which matches nothing when the sources are `.ts`, so
the name arm — the one Rails' own suites use — threw `Unknown variable dynamic
import` under vitest. It is now one literal specifier per file `require` can reach,
still lazy, with an unknown name raising the message Ruby's `LoadError` carries.
`xml-mini-engine.test.ts` sets the backend by name as `xml_mini_engine_test.rb:25-27`
does, and its workaround note is gone; the name arm is covered directly in
`xml-mini.trails.test.ts`.

Gates: `parity:api:calls`, `parity:api:calls:args` OK (no rows added); `parity:api:extra`
does not grow for either package; `parity:api` / `parity:test` deltas non-negative.
MySQL-lane tests were not run locally (no server here) — CI covers that lane.

Closes-story: mysql-tasks-drop-url-reparse-fallbacks
Closes-story: fold-date-only-zones-mixin-copy-into-rails-path
Closes-story: xml-mini-backend-name-arm-unresolvable
