### PR TITLE
ci: temporarily disable the Website job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1949,9 +1949,11 @@ jobs:
                   ;;
                 website)
                   # Temporarily disabled (if: false) — its skip is always
-                  # legitimate until the job is re-enabled. The original
-                  # condition (website_affected false AND no website/release
-                  # label) is restored by deleting this `continue`.
+                  # legitimate until the job is re-enabled. On re-enable,
+                  # replace this `continue` with the original guard:
+                  #   if [ "$WEBSITE_AFFECTED" = "false" ] && [ "$WEBSITE_LABEL" != "true" ]; then
+                  #     continue
+                  #   fi
                   continue
                   ;;
                 trails-tsc-tests)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1309,7 +1309,14 @@ jobs:
   website:
     name: Website
     needs: changes
+    # TEMPORARILY DISABLED. The build has been failing on main and the job
+    # doesn't run on ordinary PRs, so nothing catches the breakage before it
+    # lands; the site being stale is acceptable for now. To re-enable, delete
+    # the leading `false &&` from the `if:` below. The aggregate `ci` job
+    # already treats this job's skip as always-legitimate (see the website
+    # case there).
     if: >-
+      false &&
       needs.changes.outputs.docs_only != 'true' &&
       (needs.changes.outputs.website_affected == 'true' ||
       needs.changes.outputs.website_label == 'true')
@@ -1941,11 +1948,11 @@ jobs:
                   fi
                   ;;
                 website)
-                  # Legitimate skip when website_affected is false AND no
-                  # website/release label opted the job in.
-                  if [ "$WEBSITE_AFFECTED" = "false" ] && [ "$WEBSITE_LABEL" != "true" ]; then
-                    continue
-                  fi
+                  # Temporarily disabled (if: false) — its skip is always
+                  # legitimate until the job is re-enabled. The original
+                  # condition (website_affected false AND no website/release
+                  # label) is restored by deleting this `continue`.
+                  continue
                   ;;
                 trails-tsc-tests)
                   # Legitimate skip when neither trails-tsc nor tse-compiler changed.


### PR DESCRIPTION
The `Website` build has been failing on `main`. It doesn't run on ordinary PRs
(it's gated on `packages/website/**` changes or a `website`/`release` label), so
nothing catches the breakage before it lands, and every `main` push goes red. A
stale site is acceptable for now, so the job is switched off rather than fixed.

**Disabled, not deleted.** The job definition, its steps, and the whole
`website_affected` / `website_label` filter wiring stay exactly as they were.

Two edits, following the pattern `mysql-tests` already uses in this file:

- `website:` — a leading `false &&` on the `if:`, with the original condition
  left intact beneath it, plus a comment saying why it's off and that
  re-enabling means deleting that one clause.
- the `ci` aggregate's `website)` skip case — made an unconditional `continue`.
  Without this, `if: false` would just move the red from `Website` to `CI`: the
  case only tolerated a skip when `website_affected` was false **and** no
  `website`/`release` label opted in, so a `main` push (which forces
  `website_affected=true`) or a labelled PR would fall through to
  "Unexpectedly skipped job: website".

### Verified against the actual conditions

The job is now unconditionally skipped, and the aggregate's `website)` case
`continue`s unconditionally, so all four cases are green:

| Case | `Website` | aggregate |
| --- | --- | --- |
| PR touching `packages/website/` (`website_affected=true`) | skipped | `continue` — green |
| PR with the `website` / `release` label (`website_label=true`) | skipped | `continue` — green |
| `main` push (`force_all_affected` ⇒ `website_affected=true`) — the currently-failing case | skipped | `continue` — green |
| docs-only PR | skipped | `docs_only=true` short-circuits the whole loop before the `case`, unchanged |

`scripts/ci-suite-coverage.test.ts` passes (18/18); it pins the gate regexes and
the draft/guides opt-ins, none of which move here. `actionlint` isn't part of
this repo's tooling. Nothing else under `.github/` and no required-checks or
branch-protection config references the `Website` check by name — `ci.yml` is
the only file that mentions it.

### Why it's broken

Not fixed here (out of scope), filed as
**`0061-ci-failures/website-build-top-level-await`** with the failing step and
error. Short version: the `Build SvelteKit` step's `build:sw` bundle is `iife`,
and `packages/activesupport/src/yaml.ts` has a top-level `await` —
`Module format "iife" does not support top-level await`. The docs build never
ran, so there may be more behind it.