### PR TITLE
fix(activesupport): retarget the xml-mini file-from-xml skip note at the open Hash.fromXml story

### DIFF
--- a/packages/activesupport/src/xml-mini/xml-mini-engine.test.ts
+++ b/packages/activesupport/src/xml-mini/xml-mini-engine.test.ts
@@ -59,9 +59,9 @@ describe("XMLMiniEngineTest", () => {
     await XmlMini.setBackend(defaultBackend);
   });
 
-  // `Hash.from_xml` — and with it `XmlMini::PARSING`, which `_parse_file`
-  // reaches through — is unported; tracked by the `port-xml-mini-parsing-table`
-  // story.
+  // `Hash.from_xml`, which this test reaches `_parse_file` through, is
+  // unported; tracked by the `port-hash-from-xml` story. (`XmlMini::PARSING`
+  // itself landed in #6465.)
   it.skip("file from xml");
 
   it("exception thrown on expansion attack", async () => {


### PR DESCRIPTION
Unit Tests went red on main at 4cfa5159:

```
FAIL scripts/stale-story-references.test.ts > no comment or markdown paragraph
     in the tree names a story that has already landed
+ "packages/activesupport/src/xml-mini/xml-mini-engine.test.ts:62 port-xml-mini-parsing-table"
```

`port-xml-mini-parsing-table` landed as #6465, so the skip note above
`it.skip("file from xml")` was citing a done story.

The skipped test is still correctly skipped: it needs `Hash.from_xml`
(`activesupport/lib/active_support/core_ext/hash/conversions.rb:141-155`,
`xml_mini_engine_test.rb:35-47`), which is unported — `XmlMini::PARSING` was
only half of what it was waiting on. So this retargets the note at a newly
filed story, `0101-activesupport-out-of-closure-surface/port-hash-from-xml`,
which carries the porting context and both affected tests.

`pnpm vitest run scripts/stale-story-references.test.ts` — 17 passed.

Closes-story: red-4cfa5159
