### PR TITLE
refactor(activerecord): route TimeZoneConverter through the subtype's map hook

### DIFF
--- a/packages/activemodel/src/type/value.ts
+++ b/packages/activemodel/src/type/value.ts
@@ -91,7 +91,9 @@ export abstract class Type<T = unknown> {
     return false;
   }
 
-  map(value: T | null): T | null {
+  // Rails: `def map(value, &) = value` (value.rb:117-119). The block is the
+  // subtype's hook — the default drops it, OID::Range/OID::Array apply it.
+  map(value: T | null, _block?: (value: unknown) => unknown): T | null {
     return value;
   }
 

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -178,6 +178,14 @@ export class TimeZoneConverter extends ValueType<unknown> {
     return extractUtc(value);
   }
 
+  override equals(other: Type): boolean {
+    if (!(other instanceof TimeZoneConverter)) return false;
+    const sub = this._subtype as ValueTypeInstance;
+    return typeof sub.equals === "function"
+      ? sub.equals(other._subtype)
+      : this._subtype === other._subtype;
+  }
+
   /**
    * Rails' `DelegateClass(Type::Value)` forwards `map` to the wrapped subtype,
    * so `map` is the SUBTYPE's hook: `Type::Value#map` returns the value
@@ -202,14 +210,6 @@ export class TimeZoneConverter extends ValueType<unknown> {
     if (typeof value === "number" && !Number.isFinite(value)) return value;
 
     return this.map(value, (v) => this.convertTimeToTimeZone(v));
-  }
-
-  override equals(other: Type): boolean {
-    if (!(other instanceof TimeZoneConverter)) return false;
-    const sub = this._subtype as ValueTypeInstance;
-    return typeof sub.equals === "function"
-      ? sub.equals(other._subtype)
-      : this._subtype === other._subtype;
   }
 }
 

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -55,11 +55,17 @@ export class TimeZoneConverter extends ValueType<unknown> {
     }
     // TimeWithZone: move to current zone.
     if (value instanceof TimeWithZone) {
-      return convertTimeToTimeZone(value);
+      return this.convertTimeToTimeZone(value);
     }
     // ZonedDateTime: extract instant, wrap in current zone.
     if (value instanceof Temporal.ZonedDateTime) {
-      return convertTimeToTimeZone(value.toInstant());
+      return this.convertTimeToTimeZone(value.toInstant());
+    }
+    // Instant: Ruby's Time responds to in_time_zone, so it takes the
+    // `super(user_input_in_time_zone(value)) || super` arm rather than the
+    // `map` else-branch (time_zone_conversion.rb:21-27).
+    if (value instanceof Temporal.Instant) {
+      return this.convertTimeToTimeZone(this._subtype.cast(value));
     }
     // PlainDateTime: wall-clock components from multiparameter assembly (no timezone).
     // Mirrors Rails' Hash branch: set_time_zone_without_conversion(super).
@@ -82,43 +88,17 @@ export class TimeZoneConverter extends ValueType<unknown> {
         // doesn't handle, e.g. non-standard strings the subtype accepts).
         const parsed = parseStringInZone(value, zone);
         if (parsed !== null) return parsed;
-        return convertTimeToTimeZone(this._subtype.cast(value));
+        return this.convertTimeToTimeZone(this._subtype.cast(value));
       }
     }
-    // Temporal.Instant, etc.: cast via subtype then wrap in zone.
-    // For array-like results (e.g. Range types), recurse cast() on each element
-    // to mirror Rails' `map(super) { |v| cast(v) }`.
-    const casted = this._subtype.cast(value);
-    if (Array.isArray(casted)) {
-      // Elements may themselves be Range-like (tsrange[] columns): apply TZ
-      // conversion to each bound. Bounds may be strings (when the user assigns
-      // Range objects with string bounds) or Instants (when cast by the subtype).
-      // Scalar elements (datetime[] columns) arrive here as Temporal.Instants
-      // after ArrayType pre-casts them through the DateTime subtype; this.cast(v)
-      // reaches convertTimeToTimeZone via the fallback path rather than through
-      // ArrayType.cast again (which would be a no-op second pass).
-      return casted.map((v) =>
-        isRangeLike(v) ? mapRange(v, (b) => castBoundInZone(b, this._subtypeIsUtc)) : this.cast(v),
-      );
-    }
-    if (isRangeLike(casted)) {
-      // Range-typed columns (tsrange/tstzrange): cast each bound through the
-      // dedicated bound helper so string bounds are parsed in the current zone
-      // and Instants are zone-wrapped — without routing through _subtype.cast
-      // (which is RangeType and would misparse a timestamp string as a range literal).
-      return mapRange(casted, (b) => castBoundInZone(b, this._subtypeIsUtc));
-    }
-    return convertTimeToTimeZone(casted);
+    // Rails: `map(super) { |v| cast(v) }` (time_zone_conversion.rb:31) — the
+    // DelegateClass hop to the subtype's own `map` hook, which rebuilds an
+    // Array or a Range from its cast elements (oid/array.rb:67, oid/range.rb:50).
+    return this.map(this._subtype.cast(value), (v) => this.cast(v));
   }
 
   override deserialize(value: unknown): unknown {
-    const d = this._subtype.deserialize(value);
-    if (Array.isArray(d))
-      return (d as unknown[]).map((v) =>
-        isRangeLike(v) ? mapRange(v, convertTimeToTimeZone) : convertTimeToTimeZone(v),
-      );
-    if (isRangeLike(d)) return mapRange(d, convertTimeToTimeZone);
-    return convertTimeToTimeZone(d);
+    return this.convertTimeToTimeZone(this._subtype.deserialize(value));
   }
 
   override serialize(value: unknown): unknown {
@@ -198,6 +178,32 @@ export class TimeZoneConverter extends ValueType<unknown> {
     return extractUtc(value);
   }
 
+  /**
+   * Rails' `DelegateClass(Type::Value)` forwards `map` to the wrapped subtype,
+   * so `map` is the SUBTYPE's hook: `Type::Value#map` returns the value
+   * untouched (value.rb:117-119), while OID::Range and OID::Array rebuild
+   * their value from the mapped elements (oid/range.rb:50-54, oid/array.rb:67-69).
+   */
+  override map(value: unknown, block?: (value: unknown) => unknown): unknown {
+    return (this._subtype as ValueTypeInstance).map(value as never, block);
+  }
+
+  /** Mirrors: TimeZoneConverter#convert_time_to_time_zone (time_zone_conversion.rb:38-48) */
+  private convertTimeToTimeZone(value: unknown): unknown {
+    if (value == null) return null;
+
+    // acts_like?(:time)
+    if (value instanceof TimeWithZone || value instanceof Temporal.Instant) {
+      const zone = getZone();
+      if (!zone) return value;
+      return value instanceof TimeWithZone ? value.inTimeZone(zone) : new TimeWithZone(value, zone);
+    }
+    // value.respond_to?(:infinite?) && value.infinite?
+    if (typeof value === "number" && !Number.isFinite(value)) return value;
+
+    return this.map(value, (v) => this.convertTimeToTimeZone(v));
+  }
+
   override equals(other: Type): boolean {
     if (!(other instanceof TimeZoneConverter)) return false;
     const sub = this._subtype as ValueTypeInstance;
@@ -229,23 +235,6 @@ function resolveIsUtc(type: unknown): boolean | undefined {
     current = current.subtype as { isUtc?: unknown; subtype?: unknown } | undefined;
   }
   return undefined;
-}
-
-/** @internal */
-function convertTimeToTimeZone(value: unknown): unknown {
-  if (value == null) return value;
-  if (Array.isArray(value)) {
-    return value.map((v) => convertTimeToTimeZone(v));
-  }
-  const zone = getZone();
-  if (!zone) return value;
-  if (value instanceof TimeWithZone) {
-    return value.inTimeZone(zone);
-  }
-  if (value instanceof Temporal.Instant) {
-    return new TimeWithZone(value, zone);
-  }
-  return value;
 }
 
 /** @internal */
@@ -334,26 +323,6 @@ function isPlainObject(v: unknown): v is Record<string, unknown> {
   if (v === null || typeof v !== "object" || Array.isArray(v)) return false;
   const proto = Object.getPrototypeOf(v);
   return proto === Object.prototype || proto === null;
-}
-
-/** @internal */
-function castBoundInZone(value: unknown, subtypeIsUtc?: boolean): unknown {
-  if (value == null) return null;
-  if (value instanceof TimeWithZone) return convertTimeToTimeZone(value);
-  if (value instanceof Temporal.Instant) return convertTimeToTimeZone(value);
-  if (value instanceof Temporal.ZonedDateTime) return convertTimeToTimeZone(value.toInstant());
-  if (value instanceof Temporal.PlainDateTime) {
-    const instant = value.toZonedDateTime(zoneForIsUtc(subtypeIsUtc)).toInstant();
-    return setTimeZoneWithoutConversion(instant, subtypeIsUtc);
-  }
-  if (typeof value === "string") {
-    const zone = getZone();
-    if (zone) {
-      const parsed = parseStringInZone(value, zone);
-      if (parsed !== null) return parsed;
-    }
-  }
-  return convertTimeToTimeZone(value);
 }
 
 interface RangeLike {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods/time-zone-conversion.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods/time-zone-conversion.json
@@ -5,16 +5,5 @@
     "rubyName": "cast",
     "call": "user_input_in_time_zone",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods/time-zone-conversion.ts",
-    "rubyName": "convert_time_to_time_zone",
-    "call": "map",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:value"
-    ],
-    "reason": "time_zone_conversion.rb:48 `map(value) { ... }` is the DelegateClass hop to the SUBTYPE's own `map` hook (postgresql/oid/range.rb:50-54); the port maps arrays inline with `Array#map` and never reaches a subtype hook, so the `value` argument has no receiver. Converging needs the subtype `map` hook ported — story call-args-ar-time-zone-converter-subtype-map."
   }
 ]


### PR DESCRIPTION
`TimeZoneConverter#convert_time_to_time_zone` ends in `map(value) { |v| convert_time_to_time_zone(v) }` and `cast` in `map(super) { |v| cast(v) }` (`time_zone_conversion.rb:31,48`). Because `TimeZoneConverter` is a `DelegateClass(Type::Value)`, `map` is the **subtype's** hook: `Type::Value#map` returns the value untouched (`value.rb:117-119`), `OID::Range#map` rebuilds a Range from the mapped ends (`oid/range.rb:50-54`) and `OID::Array#map` maps an Array or delegates to its own subtype (`oid/array.rb:67-69`).

trails mapped arrays inline with `Array#map` and rebuilt ranges through a local `mapRange`/`isRangeLike`/`castBoundInZone` trio, so no subtype hook was ever reached and the `value` argument had no receiver.

- `Type#map` takes the block (`_block`), matching Rails' `map(value, &)`. The `OID::Range` / `OID::Array` overrides already existed.
- `TimeZoneConverter` gets the DelegateClass `map` forward to its subtype, and `convert_time_to_time_zone` becomes the private method Rails has, ending in `this.map(value, (v) => this.convertTimeToTimeZone(v))`; `cast`'s else-branch is now `this.map(this._subtype.cast(value), (v) => this.cast(v))`.
- An `Instant` arm joins the `respond_to?(:in_time_zone)` group in `cast` (Ruby's `Time` responds to it, so it never reaches the `map` else-branch).
- `castBoundInZone` / the inline range+array walks in `cast`/`deserialize` are deleted — the subtype hook does that work now.
- The `convert_time_to_time_zone` → `map` `kind: "args"` baseline row is deleted (by hand, no `--write`).

Verified against PostgreSQL locally: `adapters/postgresql/{range,array,infinity,timestamp}.test.ts`, plus `attribute-methods/*`, `attributes`, `multiparameter-attributes`, `date-time-precision`. `pnpm parity:api:calls` and `pnpm parity:api:calls:args` both green.

Closes-story: call-args-ar-time-zone-converter-subtype-map
