### PR TITLE
feat(activesupport,activerecord): subscribe callable objects, as Rails' Fanout does

### DIFF
--- a/packages/activerecord/src/testing/query-assertions.ts
+++ b/packages/activerecord/src/testing/query-assertions.ts
@@ -38,9 +38,12 @@ export class SQLCounter {
     return this.logFull.map(([sql]) => sql);
   }
 
-  /** @internal */
-  // Rails' `def call(*, payload)` (query_assertions.rb:103) takes the payload
-  // as the LAST positional, whatever the subscriber arity handed it.
+  /**
+   * Mirrors Ruby's `def call(*, payload)` — the payload is the last positional,
+   * whatever arity the notifier's subscriber hands it.
+   *
+   * @internal
+   */
   call(...args: unknown[]): void {
     const payload = args[args.length - 1] as SqlPayload;
     if (payload.cached) return;

--- a/packages/activerecord/src/testing/query-assertions.ts
+++ b/packages/activerecord/src/testing/query-assertions.ts
@@ -4,7 +4,7 @@
  * Mirrors: ActiveRecord::Assertions::QueryAssertions
  */
 
-import { Notifications, NotificationEvent } from "@blazetrails/activesupport";
+import { Notifications } from "@blazetrails/activesupport";
 
 /** @internal */
 export interface SqlPayload {
@@ -39,7 +39,10 @@ export class SQLCounter {
   }
 
   /** @internal */
-  call(_name: unknown, _id: unknown, payload: SqlPayload): void {
+  // Rails' `def call(*, payload)` (query_assertions.rb:103) takes the payload
+  // as the LAST positional, whatever the subscriber arity handed it.
+  call(...args: unknown[]): void {
+    const payload = args[args.length - 1] as SqlPayload;
     if (payload.cached) return;
 
     const sql = payload.sql ?? "";
@@ -64,25 +67,21 @@ export async function assertQueriesCount(
   fn: () => void | Promise<void>,
 ): Promise<void> {
   const counter = new SQLCounter();
-  await Notifications.subscribed(
-    (event: NotificationEvent) => {
-      counter.call(event.name, event.transactionId, event.payload as SqlPayload);
-    },
-    "sql.active_record",
-    fn,
-  );
-  const queries = includeSchema ? counter.logAll : counter.log;
-  if (count !== undefined) {
-    if (queries.length !== count) {
-      throw new Error(
-        `${queries.length} instead of ${count} queries were executed. Queries: ${queries.join("\n\n")}`,
-      );
+  await Notifications.subscribed(counter, "sql.active_record", async () => {
+    await fn();
+    const queries = includeSchema ? counter.logAll : counter.log;
+    if (count !== undefined) {
+      if (queries.length !== count) {
+        throw new Error(
+          `${queries.length} instead of ${count} queries were executed. Queries: ${queries.join("\n\n")}`,
+        );
+      }
+    } else {
+      if (queries.length < 1) {
+        throw new Error("1 or more queries expected, but none were executed.");
+      }
     }
-  } else {
-    if (queries.length < 1) {
-      throw new Error("1 or more queries expected, but none were executed.");
-    }
-  }
+  });
 }
 
 /**
@@ -110,34 +109,30 @@ export async function assertQueriesMatch(
   fn: () => void | Promise<void>,
 ): Promise<void> {
   const counter = new SQLCounter();
-  await Notifications.subscribed(
-    (event: NotificationEvent) => {
-      counter.call(event.name, event.transactionId, event.payload as SqlPayload);
-    },
-    "sql.active_record",
-    fn,
-  );
-  const queries = includeSchema ? counter.logAll : counter.log;
-  // Reset lastIndex before each test (and after) to mirror Ruby Regexp#=== (always stateless).
-  const matched = queries.filter((q) => {
+  await Notifications.subscribed(counter, "sql.active_record", async () => {
+    await fn();
+    const queries = includeSchema ? counter.logAll : counter.log;
+    // Reset lastIndex before each test (and after) to mirror Ruby Regexp#=== (always stateless).
+    const matchedQueries = queries.filter((query) => {
+      match.lastIndex = 0;
+      return match.test(query);
+    });
     match.lastIndex = 0;
-    return match.test(q);
-  });
-  match.lastIndex = 0;
 
-  if (count !== undefined) {
-    if (matched.length !== count) {
-      throw new Error(
-        `${matched.length} instead of ${count} queries were executed.${queries.length === 0 ? "" : `\nQueries:\n${queries.join("\n")}`}`,
-      );
+    if (count !== undefined) {
+      if (matchedQueries.length !== count) {
+        throw new Error(
+          `${matchedQueries.length} instead of ${count} queries were executed.${queries.length === 0 ? "" : `\nQueries:\n${queries.join("\n")}`}`,
+        );
+      }
+    } else {
+      if (matchedQueries.length < 1) {
+        throw new Error(
+          `1 or more queries expected, but none were executed.${queries.length === 0 ? "" : `\nQueries:\n${queries.join("\n")}`}`,
+        );
+      }
     }
-  } else {
-    if (matched.length < 1) {
-      throw new Error(
-        `1 or more queries expected, but none were executed.${queries.length === 0 ? "" : `\nQueries:\n${queries.join("\n")}`}`,
-      );
-    }
-  }
+  });
 }
 
 /**

--- a/packages/activesupport/src/notifications.test.ts
+++ b/packages/activesupport/src/notifications.test.ts
@@ -59,7 +59,7 @@ describe("SubscribeEventObjectsTest", () => {
   it("subscribe with a single arity callable listener", () => {
     const received: Event[] = [];
     const handler = { call: (e: Event) => received.push(e) };
-    Notifications.subscribe("qux", (e) => handler.call(e));
+    Notifications.subscribe("qux", handler);
     Notifications.instrument("qux");
     expect(received).toHaveLength(1);
   });

--- a/packages/activesupport/src/notifications.trails.test.ts
+++ b/packages/activesupport/src/notifications.trails.test.ts
@@ -254,6 +254,22 @@ describe("Notifications (trails)", () => {
       expect(events[0].payload).toBe(payload);
     });
 
+    it("a multi-argument callable object is subscribed as a timed listener", () => {
+      const calls: unknown[][] = [];
+      const listener = {
+        call(name: string, start: unknown, finish: unknown, id: unknown, payload: unknown) {
+          calls.push([name, start, finish, id, payload]);
+        },
+      };
+      Notifications.subscribe("callable.timed", listener);
+
+      Notifications.instrument("callable.timed", { a: 1 });
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0][0]).toBe("callable.timed");
+      expect((calls[0][4] as Record<string, unknown>).a).toBe(1);
+    });
+
     it("publishEvent routes a prebuilt event to matching subscribers", () => {
       const received: Event[] = [];
       Notifications.subscribe("prebuilt", (e) => received.push(e));

--- a/packages/activesupport/src/notifications.ts
+++ b/packages/activesupport/src/notifications.ts
@@ -80,17 +80,21 @@ export class Notifications {
    * - RegExp: regex match against name
    * - null/omitted: all events
    *
-   * The callback is wrapped so it presents to the `Fanout` as an event-object
-   * (single-arity) subscriber, which always receives the built `Event` — trails'
-   * public API always yields the Event, regardless of the callback's arity.
+   * A function callback is wrapped so it presents to the `Fanout` as an
+   * event-object (single-arity) subscriber, which always receives the built
+   * `Event` — trails' public API always yields the Event, regardless of the
+   * callback's arity. A callable object is forwarded to the notifier untouched,
+   * as `notifications.rb:244-245` forwards `callback`, so `Subscribers.new`
+   * classifies it by its own `call` (fanout.rb:328-331).
    */
   static subscribe(
     pattern: string | RegExp | null | undefined,
-    callback: ((event: Event) => void) | { call(event: Event): void },
+    callback: ((event: Event) => void) | CallableListener,
   ): NotificationSubscriber {
-    const sub = this._notifier.subscribe(pattern ?? null, (event: Event) =>
-      typeof callback === "function" ? callback(event) : callback.call(event),
-    );
+    const sub =
+      typeof callback === "function"
+        ? this._notifier.subscribe(pattern ?? null, (event: Event) => callback(event))
+        : this._notifier.subscribe(pattern ?? null, callback);
     return sub as unknown as NotificationSubscriber;
   }
 

--- a/packages/activesupport/src/notifications.ts
+++ b/packages/activesupport/src/notifications.ts
@@ -11,6 +11,7 @@ import { Temporal } from "@blazetrails/date";
 import { Event, Instrumenter } from "./notifications/instrumenter.js";
 import type { EventPayload, NotificationHandle } from "./notifications/instrumenter.js";
 import { Fanout } from "./notifications/fanout.js";
+import type { CallableListener } from "./notifications/fanout.js";
 
 // The concrete subscriber handle the notifier hands back. Kept internal (not the
 // public `NotificationSubscriber`) so the `Fanout` subscriber's members don't
@@ -31,9 +32,12 @@ export type { NotificationHandle };
  * `ActiveSupport::Notifications.subscribe`): a single-arity block receives the
  * built `Event`, while the five-arity block receives `(name, start, finish, id,
  * payload)`. The notifier classifies by arity, so `monotonic` subscribers must
- * be the five-arity form to see monotonic (`number`) start/finish times.
+ * be the five-arity form to see monotonic (`number`) start/finish times. Rails
+ * also accepts any object responding to `call` (`Fanout::Subscribers.new`,
+ * notifications/fanout.rb:328), so a callable object is a subscriber too.
  */
 export type NotificationCallback =
+  | CallableListener
   | ((event: Event) => void)
   | ((
       name: string,
@@ -82,9 +86,11 @@ export class Notifications {
    */
   static subscribe(
     pattern: string | RegExp | null | undefined,
-    callback: (event: Event) => void,
+    callback: ((event: Event) => void) | { call(event: Event): void },
   ): NotificationSubscriber {
-    const sub = this._notifier.subscribe(pattern ?? null, (event: Event) => callback(event));
+    const sub = this._notifier.subscribe(pattern ?? null, (event: Event) =>
+      typeof callback === "function" ? callback(event) : callback.call(event),
+    );
     return sub as unknown as NotificationSubscriber;
   }
 
@@ -107,12 +113,16 @@ export class Notifications {
   ): NotificationSubscriber {
     let pattern: string | RegExp | null;
     let callback: NotificationCallback;
-    if (typeof patternOrCallback === "function") {
-      pattern = null;
-      callback = patternOrCallback;
-    } else {
+    if (
+      typeof patternOrCallback === "string" ||
+      patternOrCallback instanceof RegExp ||
+      patternOrCallback == null
+    ) {
       pattern = patternOrCallback ?? null;
       callback = maybeCallback!;
+    } else {
+      pattern = null;
+      callback = patternOrCallback;
     }
     const sub = this._notifier.subscribe(pattern, callback as FanoutListener, true);
     return sub as unknown as NotificationSubscriber;

--- a/packages/activesupport/src/notifications/fanout.ts
+++ b/packages/activesupport/src/notifications/fanout.ts
@@ -73,6 +73,13 @@ type EventObjectCallback = (event: Event) => void;
  * (fanout.rb:437, 452); JS has no such uniform invocation, so `createSubscriber`
  * binds the object's `call` to its receiver and the groups keep calling a
  * function.
+ *
+ * Rails classifies a listener as EventObject on `procish.arity == 1 &&
+ * procish.parameters.length == 1` (fanout.rb:330). JS exposes only
+ * `Function.length`, which counts the parameters before the first defaulted or
+ * rest one and has no `parameters` analogue — so `(event, ...rest)`, which Ruby
+ * keeps timed, reads as single-arity here. There is no runtime reflection that
+ * closes that gap short of parsing `Function.prototype.toString`.
  */
 export type CallableListener = { call(...args: never[]): void };
 

--- a/packages/activesupport/src/notifications/fanout.ts
+++ b/packages/activesupport/src/notifications/fanout.ts
@@ -65,6 +65,13 @@ type TimedCallback = (
 
 type EventObjectCallback = (event: Event) => void;
 
+/**
+ * Any object responding to `call` — Rails' `Subscribers.new` reaches for
+ * `listener.method(:call)` whenever the listener is not itself procish
+ * (fanout.rb:328), so a plain object with a `call` method subscribes.
+ */
+export type CallableListener = { call(...args: never[]): void };
+
 export interface Matcher {
   matches(name: string): boolean;
   unsubscribe(name: string): void;
@@ -123,11 +130,15 @@ interface Subscriber {
 
 function createSubscriber(
   pattern: string | RegExp | null,
-  listener: EventedListener | TimedCallback | EventObjectCallback,
+  listener: EventedListener | TimedCallback | EventObjectCallback | CallableListener,
   monotonic: boolean,
 ): Subscriber {
   const matcher = wrapMatcher(pattern);
   let kind: SubscriberKind;
+  // Rails calls `@delegate.call` uniformly for procs and callable objects
+  // (fanout.rb:437, 452); JS has no such uniform invocation, so bind the
+  // object's `call` to its receiver here.
+  let delegate = listener as EventedListener | TimedCallback | EventObjectCallback;
 
   if (
     typeof listener === "object" &&
@@ -138,8 +149,13 @@ function createSubscriber(
     kind = "evented";
   } else {
     kind = monotonic ? "monotonic" : "timed";
-    if (typeof listener === "function" && listener.length === 1) {
+    // Doing this to detect a single argument block or callable (fanout.rb:325-332).
+    const procish = typeof listener === "function" ? listener : listener.call;
+    if (procish.length === 1) {
       kind = "event_object";
+    }
+    if (typeof listener !== "function") {
+      delegate = procish.bind(listener) as TimedCallback;
     }
   }
 
@@ -149,7 +165,7 @@ function createSubscriber(
   return {
     matcher,
     kind,
-    delegate: listener,
+    delegate,
     silenceable,
     subscribed(name: string) {
       return matcher.matches(name);
@@ -312,7 +328,7 @@ export class Fanout {
 
   subscribe(
     pattern: string | RegExp | null,
-    listener: EventedListener | TimedCallback | EventObjectCallback,
+    listener: EventedListener | TimedCallback | EventObjectCallback | CallableListener,
     monotonic = false,
   ): Subscriber {
     const sub = createSubscriber(pattern, listener, monotonic);

--- a/packages/activesupport/src/notifications/fanout.ts
+++ b/packages/activesupport/src/notifications/fanout.ts
@@ -68,7 +68,11 @@ type EventObjectCallback = (event: Event) => void;
 /**
  * Any object responding to `call` — Rails' `Subscribers.new` reaches for
  * `listener.method(:call)` whenever the listener is not itself procish
- * (fanout.rb:328), so a plain object with a `call` method subscribes.
+ * (fanout.rb:328), so a plain object with a `call` method subscribes. Ruby then
+ * invokes `@delegate.call` uniformly for procs and callable objects
+ * (fanout.rb:437, 452); JS has no such uniform invocation, so `createSubscriber`
+ * binds the object's `call` to its receiver and the groups keep calling a
+ * function.
  */
 export type CallableListener = { call(...args: never[]): void };
 
@@ -135,9 +139,6 @@ function createSubscriber(
 ): Subscriber {
   const matcher = wrapMatcher(pattern);
   let kind: SubscriberKind;
-  // Rails calls `@delegate.call` uniformly for procs and callable objects
-  // (fanout.rb:437, 452); JS has no such uniform invocation, so bind the
-  // object's `call` to its receiver here.
   let delegate = listener as EventedListener | TimedCallback | EventObjectCallback;
 
   if (
@@ -149,7 +150,6 @@ function createSubscriber(
     kind = "evented";
   } else {
     kind = monotonic ? "monotonic" : "timed";
-    // Doing this to detect a single argument block or callable (fanout.rb:325-332).
     const procish = typeof listener === "function" ? listener : listener.call;
     if (procish.length === 1) {
       kind = "event_object";

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/testing/query-assertions.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/testing/query-assertions.json
@@ -2,30 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "testing/query-assertions.ts",
-    "rubyName": "assert_queries_count",
-    "call": "subscribed",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:counter",
-      "str:sql.active_record"
-    ],
-    "reason": "RFC 0099: query_assertions.rb:22 passes the SQLCounter OBJECT (Rails subscribes anything responding to `call`); trails' `Notifications.subscribed` takes a function, so the port wraps the counter in an arrow. Converging needs the call-object duck type on Notifications/Fanout; filed separately."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "testing/query-assertions.ts",
-    "rubyName": "assert_queries_match",
-    "call": "subscribed",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:counter",
-      "str:sql.active_record"
-    ],
-    "reason": "RFC 0099: query_assertions.rb:47 passes the SQLCounter OBJECT (Rails subscribes anything responding to `call`); trails' `Notifications.subscribed` takes a function, so the port wraps the counter in an arrow. Converging needs the call-object duck type on Notifications/Fanout; filed separately."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "testing/query-assertions.ts",
     "rubyName": "call",
     "call": "map",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
`Fanout::Subscribers.new` (`activesupport/lib/active_support/notifications/fanout.rb:322-333`)
reaches for `listener.method(:call)` whenever the listener isn't procish, so any
object responding to `call` is a valid subscriber. trails' `Fanout#subscribe`
took a function only, so the `query_assertions` port had to wrap its counter in
an arrow.

- `Fanout#subscribe` / `Notifications.subscribe` / `subscribed` /
  `monotonicSubscribe` admit a callable object. Kind classification uses the
  `call` method's arity (fanout.rb:325-332), and `call` is bound to its receiver
  so the groups keep invoking the delegate uniformly, as Ruby's
  `@delegate.call` does.
- `assertQueriesCount` / `assertQueriesMatch` pass `counter` directly and run
  their assertions inside the subscribed block, mirroring
  `query_assertions.rb:22` / `:47`. `SQLCounter#call` now takes the payload as
  the last positional, mirroring `def call(*, payload)`
  (`query_assertions.rb:103`).
- `notifications.test.ts` "subscribe with a single arity callable listener" now
  passes the object, as `notifications_test.rb:96` does.

Both `subscribed(ref:counter, str:sql.active_record)` rows deleted from
`call-mismatches-exclude/activerecord/testing/query-assertions.json`;
`pnpm parity:api:calls:args` green at 276 shape rows (was 278).
`pnpm parity:api:calls` green.

Closes-story: call-args-as-notifications-callable-object