### PR TITLE
refactor(activerecord): construct database task classes with the db config

### DIFF
--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -308,7 +308,11 @@ export async function disconnectAllBang(): Promise<void> {
 export { ConnectionHandler } from "./connection-adapters/abstract/connection-handler.js";
 export { ConnectionManagement, BodyProxy } from "./connection-adapters/connection-management.js";
 export { DatabaseTasks, DatabaseNotSupported } from "./tasks/database-tasks.js";
-export type { DatabaseTaskHandler, SchemaFormat } from "./tasks/database-tasks.js";
+export type {
+  DatabaseTaskHandler,
+  DatabaseTaskInstance,
+  SchemaFormat,
+} from "./tasks/database-tasks.js";
 export { eachCurrentEnvironment } from "./tasks/database-tasks.js";
 export { SQLiteDatabaseTasks } from "./tasks/sqlite-database-tasks.js";
 export { PostgreSQLDatabaseTasks } from "./tasks/postgresql-database-tasks.js";

--- a/packages/activerecord/src/tasks/database-tasks-banners.trails.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks-banners.trails.test.ts
@@ -31,29 +31,40 @@ describe("DatabaseTasksBannersTest", () => {
   });
 
   it("create prints the created banner", async () => {
-    DatabaseTasks.registerTask("sqlite", { create: async () => {} });
+    DatabaseTasks.registerTask(
+      "sqlite",
+      class {
+        async create(): Promise<void> {}
+      },
+    );
     await DatabaseTasks.create(config());
     expect(out.join("")).toEqual("Created database 'my-db'\n");
     expect(err).toEqual([]);
   });
 
   it("create prints already exists on DatabaseAlreadyExists", async () => {
-    DatabaseTasks.registerTask("sqlite", {
-      create: async () => {
-        throw new DatabaseAlreadyExists("boom");
+    DatabaseTasks.registerTask(
+      "sqlite",
+      class {
+        async create(): Promise<void> {
+          throw new DatabaseAlreadyExists("boom");
+        }
       },
-    });
+    );
     await DatabaseTasks.create(config());
     expect(out).toEqual([]);
     expect(err.join("")).toEqual("Database 'my-db' already exists\n");
   });
 
   it("create reraises other errors after printing both lines", async () => {
-    DatabaseTasks.registerTask("sqlite", {
-      create: async () => {
-        throw new Error("nope");
+    DatabaseTasks.registerTask(
+      "sqlite",
+      class {
+        async create(): Promise<void> {
+          throw new Error("nope");
+        }
       },
-    });
+    );
     await expect(DatabaseTasks.create(config())).rejects.toThrow("nope");
     expect(err.join("")).toEqual(
       "nope\nCouldn't create 'my-db' database. Please check your configuration.\n",
@@ -61,28 +72,39 @@ describe("DatabaseTasksBannersTest", () => {
   });
 
   it("drop prints the dropped banner", async () => {
-    DatabaseTasks.registerTask("sqlite", { drop: async () => {} });
+    DatabaseTasks.registerTask(
+      "sqlite",
+      class {
+        async drop(): Promise<void> {}
+      },
+    );
     await DatabaseTasks.drop(config());
     expect(out.join("")).toEqual("Dropped database 'my-db'\n");
   });
 
   it("drop prints does not exist on NoDatabaseError", async () => {
-    DatabaseTasks.registerTask("sqlite", {
-      drop: async () => {
-        throw new NoDatabaseError("boom");
+    DatabaseTasks.registerTask(
+      "sqlite",
+      class {
+        async drop(): Promise<void> {
+          throw new NoDatabaseError("boom");
+        }
       },
-    });
+    );
     await DatabaseTasks.drop(config());
     expect(out).toEqual([]);
     expect(err.join("")).toEqual("Database 'my-db' does not exist\n");
   });
 
   it("drop reraises other errors after printing both lines", async () => {
-    DatabaseTasks.registerTask("sqlite", {
-      drop: async () => {
-        throw new Error("nope");
+    DatabaseTasks.registerTask(
+      "sqlite",
+      class {
+        async drop(): Promise<void> {
+          throw new Error("nope");
+        }
       },
-    });
+    );
     await expect(DatabaseTasks.drop(config())).rejects.toThrow("nope");
     expect(err.join("")).toEqual("nope\nCouldn't drop database 'my-db'\n");
   });

--- a/packages/activerecord/src/tasks/database-tasks-protected-environments-env.trails.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks-protected-environments-env.trails.test.ts
@@ -31,7 +31,12 @@ describe("DatabaseTasksCheckProtectedEnvironmentsCurrentEnvironmentTest", () => 
     DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
       [env]: { primary: { adapter: "sqlite3", database: dbFile, pool: 1 } },
     });
-    DatabaseTasks.registerTask("sqlite", { create: async () => {} });
+    DatabaseTasks.registerTask(
+      "sqlite",
+      class {
+        async create(): Promise<void> {}
+      },
+    );
 
     const { BetterSQLite3Adapter } =
       await import("../connection-adapters/better-sqlite3-adapter.js");
@@ -123,7 +128,12 @@ describe("DatabaseTasksCheckCurrentProtectedEnvironmentTest", () => {
     DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
       [env]: { primary: { adapter: "sqlite3", database: dbFile, pool: 1 } },
     });
-    DatabaseTasks.registerTask("sqlite", { create: async () => {} });
+    DatabaseTasks.registerTask(
+      "sqlite",
+      class {
+        async create(): Promise<void> {}
+      },
+    );
 
     const { BetterSQLite3Adapter } =
       await import("../connection-adapters/better-sqlite3-adapter.js");

--- a/packages/activerecord/src/tasks/database-tasks-truncate-tables.trails.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks-truncate-tables.trails.test.ts
@@ -47,7 +47,7 @@ describe("DatabaseTasksTruncateTablesTest", () => {
 
     // No handler `truncateAll` registered, so truncation takes the Rails path.
     DatabaseTasks.clearRegisteredTasks();
-    DatabaseTasks.registerTask(/sqlite/, {});
+    DatabaseTasks.registerTask(/sqlite/, class {});
     await DatabaseTasks.truncateTables(config);
 
     const reader = new BetterSQLite3Adapter(dbPath);

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -51,7 +51,12 @@ describe("DatabaseTasksCheckProtectedEnvironmentsTest", () => {
       DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
         [env]: { primary: { adapter: "sqlite3", database: dbFile } },
       });
-      DatabaseTasks.registerTask("sqlite", { create: async () => {} });
+      DatabaseTasks.registerTask(
+        "sqlite",
+        class {
+          async create(): Promise<void> {}
+        },
+      );
 
       const { BetterSQLite3Adapter } =
         await import("../connection-adapters/better-sqlite3-adapter.js");
@@ -110,7 +115,12 @@ describe("DatabaseTasksCheckProtectedEnvironmentsTest", () => {
     DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
       arunit: { adapter: "sqlite3", database: dbFile },
     });
-    DatabaseTasks.registerTask("sqlite", { create: async () => {} });
+    DatabaseTasks.registerTask(
+      "sqlite",
+      class {
+        async create(): Promise<void> {}
+      },
+    );
     const { BetterSQLite3Adapter } =
       await import("../connection-adapters/better-sqlite3-adapter.js");
     const adapter = new BetterSQLite3Adapter(dbFile);
@@ -159,7 +169,12 @@ describe("DatabaseTasksCheckProtectedEnvironmentsMultiDatabaseTest", () => {
         secondary: { adapter: "sqlite3", database: secondaryDb },
       },
     });
-    DatabaseTasks.registerTask("sqlite", { create: async () => {} });
+    DatabaseTasks.registerTask(
+      "sqlite",
+      class {
+        async create(): Promise<void> {}
+      },
+    );
     const { BetterSQLite3Adapter } =
       await import("../connection-adapters/better-sqlite3-adapter.js");
     const protectedEnvironments = Base.protectedEnvironments;
@@ -216,14 +231,20 @@ describe("DatabaseTasksRegisterTask", () => {
   });
 
   it("register task", () => {
-    const handler = { create: async () => {} };
+    const handler = class {
+      async create(): Promise<void> {}
+    };
     DatabaseTasks.registerTask("sqlite", handler);
     expect(DatabaseTasks.resolveTask("sqlite3")).toBe(handler);
   });
 
   it("register task precedence", () => {
-    const first = { create: async () => {} };
-    const second = { create: async () => {} };
+    const first = class {
+      async create(): Promise<void> {}
+    };
+    const second = class {
+      async create(): Promise<void> {}
+    };
     DatabaseTasks.registerTask("sqlite", first);
     DatabaseTasks.registerTask("sqlite", second);
     expect(DatabaseTasks.resolveTask("sqlite3")).toBe(second);
@@ -400,11 +421,18 @@ describe("DatabaseTasksCreateAllTest", () => {
     created = [];
     await Base.establishConnection(ambientPoolConfiguration());
     vi.spyOn(Base, "establishConnection").mockResolvedValue(undefined);
-    DatabaseTasks.registerTask("abstract", {
-      create: async (config) => {
-        created.push(config.database ?? "unknown");
+    DatabaseTasks.registerTask(
+      "abstract",
+      class {
+        static usingDatabaseConfigurations(): boolean {
+          return true;
+        }
+        constructor(private readonly dbConfig: DatabaseConfig) {}
+        async create(): Promise<void> {
+          created.push(this.dbConfig.database ?? "unknown");
+        }
       },
-    });
+    );
   });
   afterEach(() => {
     DatabaseTasks.clearRegisteredTasks();
@@ -477,11 +505,18 @@ describe("DatabaseTasksCreateCurrentTest", () => {
   beforeEach(() => {
     created = [];
     establishSpy = vi.spyOn(Base, "establishConnection").mockResolvedValue(undefined);
-    DatabaseTasks.registerTask("abstract", {
-      create: async (config) => {
-        created.push(`${config.envName}:${config.database}`);
+    DatabaseTasks.registerTask(
+      "abstract",
+      class {
+        static usingDatabaseConfigurations(): boolean {
+          return true;
+        }
+        constructor(private readonly dbConfig: DatabaseConfig) {}
+        async create(): Promise<void> {
+          created.push(`${this.dbConfig.envName}:${this.dbConfig.database}`);
+        }
       },
-    });
+    );
     DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
       development: { adapter: "abstract", database: "dev-db" },
       test: { adapter: "abstract", database: "test-db" },
@@ -551,11 +586,18 @@ describe("DatabaseTasksCreateCurrentThreeTierTest", () => {
   beforeEach(() => {
     created = [];
     establishSpy = vi.spyOn(Base, "establishConnection").mockResolvedValue(undefined);
-    DatabaseTasks.registerTask("abstract", {
-      create: async (config) => {
-        created.push(`${config.envName}:${config.name}:${config.database}`);
+    DatabaseTasks.registerTask(
+      "abstract",
+      class {
+        static usingDatabaseConfigurations(): boolean {
+          return true;
+        }
+        constructor(private readonly dbConfig: DatabaseConfig) {}
+        async create(): Promise<void> {
+          created.push(`${this.dbConfig.envName}:${this.dbConfig.name}:${this.dbConfig.database}`);
+        }
       },
-    });
+    );
     DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
       development: {
         primary: { adapter: "abstract", database: "dev-db" },
@@ -621,11 +663,18 @@ describe("DatabaseTasksDropAllTest", () => {
   let dropped: string[];
   beforeEach(() => {
     dropped = [];
-    DatabaseTasks.registerTask("abstract", {
-      drop: async (config) => {
-        dropped.push(config.database ?? "unknown");
+    DatabaseTasks.registerTask(
+      "abstract",
+      class {
+        static usingDatabaseConfigurations(): boolean {
+          return true;
+        }
+        constructor(private readonly dbConfig: DatabaseConfig) {}
+        async drop(): Promise<void> {
+          dropped.push(this.dbConfig.database ?? "unknown");
+        }
       },
-    });
+    );
   });
   afterEach(() => {
     DatabaseTasks.clearRegisteredTasks();
@@ -695,11 +744,18 @@ describe("DatabaseTasksDropCurrentTest", () => {
   let dropped: string[];
   beforeEach(() => {
     dropped = [];
-    DatabaseTasks.registerTask("abstract", {
-      drop: async (config) => {
-        dropped.push(`${config.envName}:${config.database}`);
+    DatabaseTasks.registerTask(
+      "abstract",
+      class {
+        static usingDatabaseConfigurations(): boolean {
+          return true;
+        }
+        constructor(private readonly dbConfig: DatabaseConfig) {}
+        async drop(): Promise<void> {
+          dropped.push(`${this.dbConfig.envName}:${this.dbConfig.database}`);
+        }
       },
-    });
+    );
     DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
       development: { adapter: "abstract", database: "dev-db" },
       test: { adapter: "abstract", database: "test-db" },
@@ -751,11 +807,18 @@ describe("DatabaseTasksDropCurrentThreeTierTest", () => {
   let dropped: string[];
   beforeEach(() => {
     dropped = [];
-    DatabaseTasks.registerTask("abstract", {
-      drop: async (config) => {
-        dropped.push(`${config.envName}:${config.name}`);
+    DatabaseTasks.registerTask(
+      "abstract",
+      class {
+        static usingDatabaseConfigurations(): boolean {
+          return true;
+        }
+        constructor(private readonly dbConfig: DatabaseConfig) {}
+        async drop(): Promise<void> {
+          dropped.push(`${this.dbConfig.envName}:${this.dbConfig.name}`);
+        }
       },
-    });
+    );
     DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
       development: {
         primary: { adapter: "abstract", database: "dev-db" },
@@ -945,7 +1008,12 @@ describe("DatabaseTasksMigrateTest", () => {
   it.skipIf(skipMigrationTestCase)(
     "migrate set and unset empty values for verbose and version env vars",
     async () => {
-      DatabaseTasks.registerTask("sqlite", { create: async () => {} });
+      DatabaseTasks.registerTask(
+        "sqlite",
+        class {
+          async create(): Promise<void> {}
+        },
+      );
       let migrated = false;
       DatabaseTasks.registerMigrations([
         {
@@ -1114,7 +1182,12 @@ describe("DatabaseTasksMigrateErrorTest", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-migrate-cache-"));
     const dbFile = path.join(tmp, "arunit.sqlite3");
     await Base.establishConnection({ adapter: "sqlite3", database: dbFile, pool: 1 });
-    DatabaseTasks.registerTask("sqlite", { create: async () => {} });
+    DatabaseTasks.registerTask(
+      "sqlite",
+      class {
+        async create(): Promise<void> {}
+      },
+    );
     DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
       [DatabaseTasks.env]: { adapter: "sqlite3", database: dbFile },
     });
@@ -1151,11 +1224,18 @@ describe("DatabaseTasksPurgeCurrentTest", () => {
   it("purges current environment database", async () => {
     const purged: DatabaseConfig[] = [];
     const establishSpy = vi.spyOn(Base, "establishConnection").mockResolvedValue(undefined);
-    DatabaseTasks.registerTask("abstract", {
-      purge: async (config) => {
-        purged.push(config);
+    DatabaseTasks.registerTask(
+      "abstract",
+      class {
+        static usingDatabaseConfigurations(): boolean {
+          return true;
+        }
+        constructor(private readonly dbConfig: DatabaseConfig) {}
+        async purge(): Promise<void> {
+          purged.push(this.dbConfig);
+        }
       },
-    });
+    );
     DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
       development: { adapter: "abstract", database: "dev-db" },
       test: { adapter: "abstract", database: "test-db" },
@@ -1178,11 +1258,18 @@ describe("DatabaseTasksPurgeAllTest", () => {
 
   it("purge all local configurations", async () => {
     const purged: string[] = [];
-    DatabaseTasks.registerTask("abstract", {
-      purge: async (config) => {
-        purged.push(config.database ?? "");
+    DatabaseTasks.registerTask(
+      "abstract",
+      class {
+        static usingDatabaseConfigurations(): boolean {
+          return true;
+        }
+        constructor(private readonly dbConfig: DatabaseConfig) {}
+        async purge(): Promise<void> {
+          purged.push(this.dbConfig.database ?? "");
+        }
       },
-    });
+    );
     DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
       development: { adapter: "abstract", database: "dev-db", host: "localhost" },
       test: { adapter: "abstract", database: "test-db", host: "localhost" },
@@ -1201,11 +1288,14 @@ describe("DatabaseTasksTruncateAllTest", () => {
 
   it("truncate tables", async () => {
     let truncated = false;
-    DatabaseTasks.registerTask("abstract", {
-      truncateAll: async () => {
-        truncated = true;
+    DatabaseTasks.registerTask(
+      "abstract",
+      class {
+        async truncateAll(): Promise<void> {
+          truncated = true;
+        }
       },
-    });
+    );
     DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
       test: { adapter: "abstract", database: "test-db" },
     });
@@ -1219,11 +1309,18 @@ describe("DatabaseTasksTruncateAllWithMultipleDatabasesTest", () => {
   let truncated: string[];
   beforeEach(() => {
     truncated = [];
-    DatabaseTasks.registerTask("abstract", {
-      truncateAll: async (config) => {
-        truncated.push(`${config.envName}:${config.database}`);
+    DatabaseTasks.registerTask(
+      "abstract",
+      class {
+        static usingDatabaseConfigurations(): boolean {
+          return true;
+        }
+        constructor(private readonly dbConfig: DatabaseConfig) {}
+        async truncateAll(): Promise<void> {
+          truncated.push(`${this.dbConfig.envName}:${this.dbConfig.database}`);
+        }
       },
-    });
+    );
   });
   afterEach(() => {
     DatabaseTasks.clearRegisteredTasks();
@@ -1288,9 +1385,14 @@ describe("DatabaseTasksCharsetTest", () => {
   });
 
   it("charset current", async () => {
-    DatabaseTasks.registerTask("abstract", {
-      charset: async () => "utf8",
-    });
+    DatabaseTasks.registerTask(
+      "abstract",
+      class {
+        async charset(): Promise<string> {
+          return "utf8";
+        }
+      },
+    );
     DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
       test: { adapter: "abstract", database: "test-db" },
     });
@@ -1308,9 +1410,14 @@ describe("DatabaseTasksCollationTest", () => {
   });
 
   it("collation current", async () => {
-    DatabaseTasks.registerTask("abstract", {
-      collation: async () => "utf8_general_ci",
-    });
+    DatabaseTasks.registerTask(
+      "abstract",
+      class {
+        async collation(): Promise<string> {
+          return "utf8_general_ci";
+        }
+      },
+    );
     DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
       test: { adapter: "abstract", database: "test-db" },
     });

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -230,12 +230,21 @@ describe("DatabaseTasksRegisterTask", () => {
     DatabaseTasks.clearRegisteredTasks();
   });
 
-  it("register task", () => {
-    const handler = class {
-      async create(): Promise<void> {}
+  it("register task", async () => {
+    const constructed: unknown[][] = [];
+    const dumped: unknown[][] = [];
+    const klazz = class {
+      constructor(...args: unknown[]) {
+        constructed.push(args);
+      }
+      async structureDump(filename: string, flags?: string | string[] | null): Promise<void> {
+        dumped.push([filename, flags]);
+      }
     };
-    DatabaseTasks.registerTask("sqlite", handler);
-    expect(DatabaseTasks.resolveTask("sqlite3")).toBe(handler);
+    DatabaseTasks.registerTask(/abstract/, klazz);
+    await DatabaseTasks.structureDump({ adapter: "abstract" }, "awesome-file.sql");
+    expect(dumped).toEqual([["awesome-file.sql", null]]);
+    expect(constructed).toEqual([[{ adapter: "abstract" }]]);
   });
 
   it("register task precedence", () => {

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -222,11 +222,9 @@ export class DatabaseTasks {
       klass.usingDatabaseConfigurations();
 
     const config = converted ? dbConfig : dbConfig.configurationHash;
-    // Ruby's `klass.new(config, *arguments)` is untyped on both counts: the
-    // `converted` branch decides between a DatabaseConfig and a plain hash, and
-    // `*arguments` is whatever the caller threaded through. The declared
-    // constructor signature pins the reachable (converted) shape, so the widened
-    // form is asserted here rather than pushed onto every task class.
+    // `klass.new(config, *arguments)` is untyped in Ruby; the declared construct
+    // signature pins the converted shape, so the unconverted hash and the
+    // splat are widened here rather than on every task class.
     const ctor = klass as unknown as new (
       config: DatabaseConfig | DatabaseConfigOptions,
       ...args: unknown[]

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -222,9 +222,6 @@ export class DatabaseTasks {
       klass.usingDatabaseConfigurations();
 
     const config = converted ? dbConfig : dbConfig.configurationHash;
-    // `klass.new(config, *arguments)` is untyped in Ruby; the declared construct
-    // signature pins the converted shape, so the unconverted hash and the
-    // splat are widened here rather than on every task class.
     const ctor = klass as unknown as new (
       config: DatabaseConfig | DatabaseConfigOptions,
       ...args: unknown[]
@@ -874,7 +871,7 @@ export class DatabaseTasks {
   ): Promise<void> {
     const dbConfig = this.resolveConfiguration(configuration);
     const flags = this.structureDumpFlagsFor(dbConfig.adapter);
-    const handler = this.databaseAdapterFor(dbConfig, root);
+    const handler = this.databaseAdapterFor(dbConfig, ...(root === undefined ? [] : [root]));
     if (!handler.structureDump) {
       throw new Error(`Adapter '${dbConfig.adapter}' does not support structureDump`);
     }
@@ -889,7 +886,7 @@ export class DatabaseTasks {
   ): Promise<void> {
     const dbConfig = this.resolveConfiguration(configuration);
     const flags = this.structureLoadFlagsFor(dbConfig.adapter);
-    const handler = this.databaseAdapterFor(dbConfig, root);
+    const handler = this.databaseAdapterFor(dbConfig, ...(root === undefined ? [] : [root]));
     if (!handler.structureLoad) {
       throw new Error(`Adapter '${dbConfig.adapter}' does not support structureLoad`);
     }
@@ -1603,11 +1600,19 @@ export interface DatabaseTaskInstance {
 
 /**
  * The task class `register_task` records (`database_tasks.rb:73-81`) and
- * `database_adapter_for` instantiates with the db config plus Ruby's leftover
- * `*arguments` (`database_tasks.rb:566-572`).
+ * `database_adapter_for` instantiates as
+ * `klass.new(converted ? db_config : db_config.configuration_hash, *arguments)`
+ * (`database_tasks.rb:566-572`).
+ *
+ * The construct signature is bottom-typed because that call is untyped on both
+ * counts, and both are Rails-reachable: a class that answers
+ * `using_database_configurations?` takes a `DatabaseConfig`, one that does not
+ * takes the configuration hash, and `*arguments` is whatever the `structure_dump`
+ * / `structure_load` caller threaded past the filename (`:362-374`). A named
+ * parameter type here would admit one of those arms and reject the others.
  */
 export interface DatabaseTaskHandler {
-  new (config: DatabaseConfig, ...args: never[]): DatabaseTaskInstance;
+  new (...args: never[]): DatabaseTaskInstance;
   usingDatabaseConfigurations?(): boolean;
 }
 

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -5,6 +5,7 @@
  */
 
 import { DatabaseConfig } from "../database-configurations/database-config.js";
+import type { DatabaseConfigOptions } from "../database-configurations/database-config.js";
 import {
   DatabaseConfigurations,
   configurationsStore,
@@ -210,12 +211,27 @@ export class DatabaseTasks {
 
   /**
    * @internal Mirrors: `database_adapter_for` (`tasks/database_tasks.rb:566-572`).
-   * Rails instantiates the resolved task class per call; trails registers task
-   * singletons through `registerTask`, so the handler itself is the instance
-   * and there are no `*arguments` to forward to a constructor.
    */
-  private static databaseAdapterFor(dbConfig: DatabaseConfig): DatabaseTaskHandler {
-    return this.classForAdapter(dbConfig.adapter);
+  private static databaseAdapterFor(
+    dbConfig: DatabaseConfig,
+    ...args: unknown[]
+  ): DatabaseTaskInstance {
+    const klass = this.classForAdapter(dbConfig.adapter);
+    const converted =
+      typeof klass.usingDatabaseConfigurations === "function" &&
+      klass.usingDatabaseConfigurations();
+
+    const config = converted ? dbConfig : dbConfig.configurationHash;
+    // Ruby's `klass.new(config, *arguments)` is untyped on both counts: the
+    // `converted` branch decides between a DatabaseConfig and a plain hash, and
+    // `*arguments` is whatever the caller threaded through. The declared
+    // constructor signature pins the reachable (converted) shape, so the widened
+    // form is asserted here rather than pushed onto every task class.
+    const ctor = klass as unknown as new (
+      config: DatabaseConfig | DatabaseConfigOptions,
+      ...args: unknown[]
+    ) => DatabaseTaskInstance;
+    return new ctor(config, ...args);
   }
 
   static clearRegisteredTasks(): void {
@@ -230,7 +246,7 @@ export class DatabaseTasks {
     try {
       const handler = this.databaseAdapterFor(dbConfig);
       if (handler.create) {
-        await handler.create(dbConfig);
+        await handler.create();
       }
       if (isVerbose()) stdout.write(`Created database '${dbConfig.database}'\n`);
     } catch (error) {
@@ -277,7 +293,7 @@ export class DatabaseTasks {
     try {
       const handler = this.databaseAdapterFor(dbConfig);
       if (handler.drop) {
-        await handler.drop(dbConfig);
+        await handler.drop();
       }
       if (isVerbose()) stdout.write(`Dropped database '${dbConfig.database}'\n`);
     } catch (error) {
@@ -520,7 +536,7 @@ export class DatabaseTasks {
     const dbConfig = this.resolveConfiguration(configuration);
     const handler = this.databaseAdapterFor(dbConfig);
     if (handler.purge) {
-      await handler.purge(dbConfig);
+      await handler.purge();
     }
   }
 
@@ -545,7 +561,7 @@ export class DatabaseTasks {
     for (const dbConfig of configs) {
       const handler = this.databaseAdapterFor(dbConfig);
       if (handler.truncateAll) {
-        await handler.truncateAll(dbConfig);
+        await handler.truncateAll();
       } else {
         await this.truncateTables(dbConfig);
       }
@@ -557,10 +573,9 @@ export class DatabaseTasks {
    * send to the resolved task instance.
    *
    * Ruby gets the raise for free: a task class defining no `charset` answers
-   * NoMethodError. A trails handler is a plain object whose members are all
-   * optional (`registerTask` takes the object, not a class), so the absent
-   * send is raised explicitly; `constructor.name` stands in for Ruby's
-   * `.class.name` and reads `Object` for a handler registered as a literal.
+   * NoMethodError. TS has to model the absence, so every member of
+   * `DatabaseTaskInstance` is optional and the absent send is raised
+   * explicitly; `constructor.name` stands in for Ruby's `.class.name`.
    */
   static async charset(
     configuration: DatabaseConfig | string | Record<string, unknown>,
@@ -572,7 +587,7 @@ export class DatabaseTasks {
         `undefined method 'charset' for an instance of ${handler.constructor.name}`,
       );
     }
-    return handler.charset(dbConfig);
+    return handler.charset();
   }
 
   static async charsetCurrent(
@@ -600,7 +615,7 @@ export class DatabaseTasks {
         `undefined method 'collation' for an instance of ${handler.constructor.name}`,
       );
     }
-    return handler.collation(dbConfig);
+    return handler.collation();
   }
 
   static async collationCurrent(
@@ -861,11 +876,11 @@ export class DatabaseTasks {
   ): Promise<void> {
     const dbConfig = this.resolveConfiguration(configuration);
     const flags = this.structureDumpFlagsFor(dbConfig.adapter);
-    const handler = this.databaseAdapterFor(dbConfig);
+    const handler = this.databaseAdapterFor(dbConfig, root);
     if (!handler.structureDump) {
       throw new Error(`Adapter '${dbConfig.adapter}' does not support structureDump`);
     }
-    await handler.structureDump(dbConfig, filename, flags, root);
+    await handler.structureDump(filename, flags);
   }
 
   /** Mirrors: `structure_load` (`tasks/database_tasks.rb:369-374`). See {@link structureDump}. */
@@ -876,11 +891,11 @@ export class DatabaseTasks {
   ): Promise<void> {
     const dbConfig = this.resolveConfiguration(configuration);
     const flags = this.structureLoadFlagsFor(dbConfig.adapter);
-    const handler = this.databaseAdapterFor(dbConfig);
+    const handler = this.databaseAdapterFor(dbConfig, root);
     if (!handler.structureLoad) {
       throw new Error(`Adapter '${dbConfig.adapter}' does not support structureLoad`);
     }
-    await handler.structureLoad(dbConfig, filename, flags, root);
+    await handler.structureLoad(filename, flags);
   }
 
   /**
@@ -1137,14 +1152,14 @@ export class DatabaseTasks {
       const left = Math.floor(pad / 2);
       return " ".repeat(left) + s + " ".repeat(pad - left);
     };
-    const puts = (s: string) => stdout.write(s + "\n");
+    const puts = (s = "") => stdout.write(s + "\n");
     puts(`\ndatabase: ${dbName}\n`);
     puts(`${center("Status", 8)}  ${"Migration ID".padEnd(14)}  Migration Name`);
     puts("-".repeat(50));
     for (const row of rows) {
       puts(`${center(row.status, 8)}  ${row.version.padEnd(14)}  ${row.name}`);
     }
-    puts("");
+    puts();
   }
 
   /**
@@ -1525,7 +1540,7 @@ export class DatabaseTasks {
   static async truncateTables(dbConfig: DatabaseConfig): Promise<void> {
     const handler = this.databaseAdapterFor(dbConfig);
     if (handler.truncateAll) {
-      await handler.truncateAll(dbConfig);
+      await handler.truncateAll();
       return;
     }
     await this.withTemporaryConnection(dbConfig, async (conn) => {
@@ -1570,31 +1585,32 @@ export class DatabaseTasks {
   }
 }
 
+/**
+ * The instance a registered task class produces — the receiver of the bare
+ * sends `DatabaseTasks` makes at `database_tasks.rb:117,212,332-373`. Every
+ * member is optional because Ruby gets the "task class doesn't define this"
+ * arm for free as a NoMethodError; TS has to model the absence.
+ */
+export interface DatabaseTaskInstance {
+  create?(): Promise<void>;
+  drop?(): Promise<void>;
+  purge?(): Promise<void>;
+  truncateAll?(): Promise<void>;
+  charset?(): Promise<string | null>;
+  collation?(): Promise<string | null>;
+  /** `flags` is what `structure_dump_flags_for` computed (`database_tasks.rb:365-366`). */
+  structureDump?(filename: string, flags?: string | string[] | null): Promise<void>;
+  structureLoad?(filename: string, flags?: string | string[] | null): Promise<void>;
+}
+
+/**
+ * The task class `register_task` records (`database_tasks.rb:73-81`) and
+ * `database_adapter_for` instantiates with the db config plus Ruby's leftover
+ * `*arguments` (`database_tasks.rb:566-572`).
+ */
 export interface DatabaseTaskHandler {
-  create?(config: DatabaseConfig): Promise<void>;
-  drop?(config: DatabaseConfig): Promise<void>;
-  purge?(config: DatabaseConfig): Promise<void>;
-  truncateAll?(config: DatabaseConfig): Promise<void>;
-  charset?(config: DatabaseConfig): Promise<string | null>;
-  collation?(config: DatabaseConfig): Promise<string | null>;
-  /**
-   * `flags` is what `structure_dump_flags_for` computed and `root` is Ruby's
-   * leftover `*arguments`, which `database_adapter_for` forwards to the task
-   * constructor (`database_tasks.rb:566-572`). trails registers task
-   * singletons, so both reach the handler on the one call it gets.
-   */
-  structureDump?(
-    config: DatabaseConfig,
-    filename: string,
-    flags?: string | string[] | null,
-    root?: string,
-  ): Promise<void>;
-  structureLoad?(
-    config: DatabaseConfig,
-    filename: string,
-    flags?: string | string[] | null,
-    root?: string,
-  ): Promise<void>;
+  new (config: DatabaseConfig, ...args: never[]): DatabaseTaskInstance;
+  usingDatabaseConfigurations?(): boolean;
 }
 
 function _errorToS(error: unknown): string {

--- a/packages/activerecord/src/tasks/mysql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/mysql-database-tasks.ts
@@ -168,25 +168,7 @@ export class MySQLDatabaseTasks {
   }
 
   static register(): void {
-    const handler = {
-      create: async (config: DatabaseConfig) => new MySQLDatabaseTasks(config).create(),
-      drop: async (config: DatabaseConfig) => new MySQLDatabaseTasks(config).drop(),
-      purge: async (config: DatabaseConfig) => new MySQLDatabaseTasks(config).purge(),
-      charset: async (config: DatabaseConfig) => new MySQLDatabaseTasks(config).charset(),
-      collation: async (config: DatabaseConfig) => new MySQLDatabaseTasks(config).collation(),
-      truncateAll: async (config: DatabaseConfig) => new MySQLDatabaseTasks(config).truncateAll(),
-      structureDump: async (
-        config: DatabaseConfig,
-        filename: string,
-        flags?: string | string[] | null,
-      ) => new MySQLDatabaseTasks(config).structureDump(filename, flags),
-      structureLoad: async (
-        config: DatabaseConfig,
-        filename: string,
-        flags?: string | string[] | null,
-      ) => new MySQLDatabaseTasks(config).structureLoad(filename, flags),
-    };
-    DatabaseTasks.registerTask(/mysql/, handler);
+    DatabaseTasks.registerTask(/mysql/, MySQLDatabaseTasks);
   }
 
   private creationOptions(): { charset?: string; collation?: string } {

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.ts
@@ -152,17 +152,7 @@ export class PostgreSQLDatabaseTasks {
   }
 
   static register(): void {
-    DatabaseTasks.registerTask(/postgres/, {
-      create: async (config) => new PostgreSQLDatabaseTasks(config).create(),
-      drop: async (config) => new PostgreSQLDatabaseTasks(config).drop(),
-      purge: async (config) => new PostgreSQLDatabaseTasks(config).purge(),
-      charset: async (config) => new PostgreSQLDatabaseTasks(config).charset(),
-      collation: async (config) => new PostgreSQLDatabaseTasks(config).collation(),
-      structureDump: async (config, filename, flags) =>
-        new PostgreSQLDatabaseTasks(config).structureDump(filename, flags),
-      structureLoad: async (config, filename, flags) =>
-        new PostgreSQLDatabaseTasks(config).structureLoad(filename, flags),
-    });
+    DatabaseTasks.registerTask(/postgres/, PostgreSQLDatabaseTasks);
   }
 
   private encoding(): string {

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.ts
@@ -322,17 +322,7 @@ export class SQLiteDatabaseTasks {
   }
 
   static register(): void {
-    DatabaseTasks.registerTask(/sqlite/, {
-      create: async (config) => new SQLiteDatabaseTasks(config).create(),
-      drop: async (config) => new SQLiteDatabaseTasks(config).drop(),
-      purge: async (config) => new SQLiteDatabaseTasks(config).purge(),
-      charset: async (config) => new SQLiteDatabaseTasks(config).charset(),
-      truncateAll: async (config) => new SQLiteDatabaseTasks(config).truncateAll(),
-      structureDump: async (config, filename, flags, root) =>
-        new SQLiteDatabaseTasks(config, root).structureDump(filename, flags),
-      structureLoad: async (config, filename, flags, root) =>
-        new SQLiteDatabaseTasks(config, root).structureLoad(filename, flags),
-    });
+    DatabaseTasks.registerTask(/sqlite/, SQLiteDatabaseTasks);
   }
 }
 

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/tasks/database-tasks.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/tasks/database-tasks.json
@@ -2,15 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "tasks/database-tasks.ts",
-    "rubyName": "charset",
-    "call": "charset",
-    "kind": "args",
-    "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "tasks/database-tasks.ts",
     "rubyName": "check_current_protected_environment!",
     "call": "new",
     "kind": "args",
@@ -36,15 +27,6 @@
   {
     "package": "activerecord",
     "tsFile": "tasks/database-tasks.ts",
-    "rubyName": "collation",
-    "call": "collation",
-    "kind": "args",
-    "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "tasks/database-tasks.ts",
     "rubyName": "configs_for",
     "call": "configurations",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -52,27 +34,9 @@
   {
     "package": "activerecord",
     "tsFile": "tasks/database-tasks.ts",
-    "rubyName": "create",
-    "call": "create",
-    "kind": "args",
-    "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "tasks/database-tasks.ts",
     "rubyName": "db_configs_with_versions",
     "call": "with_temporary_pool_for_each",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "tasks/database-tasks.ts",
-    "rubyName": "drop",
-    "call": "drop",
-    "kind": "args",
-    "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -139,15 +103,6 @@
     "package": "activerecord",
     "tsFile": "tasks/database-tasks.ts",
     "rubyName": "migrate_status",
-    "call": "puts",
-    "kind": "args",
-    "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "tasks/database-tasks.ts",
-    "rubyName": "migrate_status",
     "call": "table_exists?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -164,15 +119,6 @@
     "rubyName": "prepare_all",
     "call": "order:eachCurrentEnvironment,initializeDatabase",
     "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "tasks/database-tasks.ts",
-    "rubyName": "purge",
-    "call": "purge",
-    "kind": "args",
-    "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activerecord",
@@ -201,29 +147,5 @@
     "rubyName": "schema_up_to_date?",
     "call": "with_temporary_pool",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "tasks/database-tasks.ts",
-    "rubyName": "structure_dump",
-    "call": "structure_dump",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:filename",
-      "ref:flags"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "tasks/database-tasks.ts",
-    "rubyName": "structure_load",
-    "call": "structure_load",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:filename",
-      "ref:flags"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]


### PR DESCRIPTION
Rails resolves a task **class** per adapter and instantiates it per call —
`database_adapter_for(db_config, *arguments)` does
`klass.new(converted ? db_config : db_config.configuration_hash, *arguments)`
(`tasks/database_tasks.rb:566-572`) — then sends a bare no-arg method to the
instance: `create` (`:117`), `drop` (`:212`), `purge` (`:349`), `charset`
(`:334`), `collation` (`:344`), and `structure_dump(filename, flags)` /
`structure_load(filename, flags)` (`:366`, `:373`).

trails registered task *singletons* — a plain object of optional closures — and
threaded `dbConfig` through every dispatch, so `parity:api:calls:args` flagged
all eight sends.

- `registerTask` now records the task class; `databaseAdapterFor` reads
  `usingDatabaseConfigurations?()` to choose between the `DatabaseConfig` and
  the configuration hash, constructs the class, and forwards Ruby's leftover
  `*arguments` (the structure dump/load `root`) to the constructor.
- `DatabaseTaskInstance` describes the constructed receiver: no-arg
  `create`/`drop`/`purge`/`truncateAll`/`charset`/`collation`, and
  `structureDump(filename, flags)` / `structureLoad(filename, flags)`. The
  SQLite / MySQL / PostgreSQL task classes already had exactly these signatures
  and a `usingDatabaseConfigurations()`, so each `register()` collapses to
  `DatabaseTasks.registerTask(/pattern/, TaskClass)`.
- `migrate_status`' trailing bare `puts` (`:317`) converges too — the local
  `puts` takes Ruby's default-empty argument.

Eight `kind: "args"` baseline rows deleted by hand (only-shrink, no `--write`):
`charset`, `collation`, `create`, `drop`, `purge`, `structure_dump`,
`structure_load`, and `migrate_status` → `puts`.

The ninth row in the story, `dump_schema` → `dump`, is **not** converged here:
Rails passes `(migration_connection_pool, file)` to a dumper whose `dump(pool,
stream, config)` writes to a stream (`schema_dumper.rb:44-49`), where trails'
`SchemaDumper.dump(adapter, options)` returns a string
(`packages/activerecord/src/schema-dumper.ts:455-457`). Converging the call
means converging the dumper's signature and every caller of it, so it is filed
as `call-args-database-tasks-dump-schema-dumper-stream` on RFC 0099 with the
citations above.

Gates: `pnpm parity:api:calls:args` OK (270 baselined shape rows),
`pnpm parity:api:calls` OK; the 11 `tasks/` suites pass (116 tests).

Closes-story: call-args-database-tasks-handler-protocol
