### PR TITLE
refactor(activerecord): converge SchemaDumper.dump onto Rails' pool/stream/config signature

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/enum.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/enum.test.ts
@@ -316,7 +316,7 @@ describeIfPg("PostgreSQLAdapter", () => {
             )
           `);
 
-          const output = await SchemaDumper.dump(adapter);
+          const output = (await SchemaDumper.dump(adapter)).join("\n");
 
           expect(output).toContain('await ctx.createEnum("public.mood", ["sad","ok","happy"]);');
           expect(output).toContain(

--- a/packages/activerecord/src/adapters/postgresql/extension-migration.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/extension-migration.test.ts
@@ -67,7 +67,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       }
       await new EnableCitext().run(adapter, "up");
       expect(await adapter.extensionEnabled("citext")).toBe(true);
-      const dump = await adapter.createSchemaDumper(adapter).dump();
+      const dump = (await adapter.createSchemaDumper(adapter).dump()).join("\n");
       expect(dump).toContain(`await ctx.enableExtension("citext");`);
       // A full PG schema dump under 6-fork parallel load legitimately exceeds
       // vitest's 5s default (I/O contention, not a logic bug). Bump to 60s,

--- a/packages/activerecord/src/adapters/sqlite3/collation.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/collation.test.ts
@@ -71,7 +71,7 @@ describeIfSqlite("SQLite3CollationTest", () => {
   });
 
   it("schema dump includes collation", async () => {
-    const output = await SchemaDumper.dump(adapter);
+    const output = (await SchemaDumper.dump(adapter)).join("\n");
     expect(output).toMatch(/t\.string\("string_nocase",[^)]*collation: "NOCASE"/);
     expect(output).toMatch(/t\.text\("text_rtrim",[^)]*collation: "RTRIM"/);
   });

--- a/packages/activerecord/src/adapters/sqlite3/virtual-table.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/virtual-table.test.ts
@@ -28,7 +28,7 @@ describeIfSqlite("SQLite3VirtualTableTest", () => {
   });
 
   it("schema dump", async () => {
-    const output = await SchemaDumper.dump(adapter);
+    const output = (await SchemaDumper.dump(adapter)).join("\n");
 
     // Internal FTS5 shadow tables (e.g. searchables_docsize) must not appear
     expect(output).not.toMatch(/searchables_docsize/);

--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.test.ts
@@ -147,7 +147,7 @@ describe("SchemaDumper raises on a column whose type is not a valid native type"
   };
 
   it("emits the Could-not-dump comment instead of a fabricated t.column line", async () => {
-    const output = await SchemaDumper.dump(source as any);
+    const output = (await SchemaDumper.dump(source as any)).join("\n");
     expect(output).toContain(`# Could not dump table "widgets" because of following StandardError`);
     expect(output).toContain(`#   Unknown type 'composite_type' for column 'kind'`);
     expect(output).not.toContain("createTable");
@@ -166,7 +166,7 @@ describe("SchemaDumper raises on a column whose type is not a valid native type"
       indexes: (_t: string) => [],
       isValidType: (type: string | null | undefined) => type === "integer" || type === "string",
     };
-    const output = await SchemaDumper.dump(validSource as any);
+    const output = (await SchemaDumper.dump(validSource as any)).join("\n");
     expect(output).not.toContain("# Could not dump table");
     expect(output).toContain(`await ctx.createTable("widgets"`);
     expect(output).toContain(`t.string("name"`);

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -431,7 +431,7 @@ describe("SchemaDumperTest", () => {
       indexes: async () => [],
     };
     SchemaDumper.ignoreTables = [/^temp_/];
-    const output = await SchemaDumper.dump(source as any);
+    const output = (await SchemaDumper.dump(source as any)).join("\n");
     expect(output).toContain("users");
     expect(output).not.toContain("temp_cache");
   });
@@ -697,7 +697,7 @@ describe("SchemaDumperTest", () => {
               ]
             : [],
       };
-      const output = await SchemaDumper.dump(source as any);
+      const output = (await SchemaDumper.dump(source as any)).join("\n");
       const authorsIdx = output.indexOf('createTable("authors"');
       const booksIdx = output.indexOf('createTable("books"');
       const fkIdx = output.indexOf("addForeignKey");
@@ -726,7 +726,7 @@ describe("SchemaDumperTest", () => {
             ]
           : [],
     };
-    const output = await SchemaDumper.dump(source as any);
+    const output = (await SchemaDumper.dump(source as any)).join("\n");
     expect(output).not.toContain("addForeignKey");
     expect(output).not.toContain('"books"');
   });
@@ -737,7 +737,7 @@ describe("SchemaDumperTest", () => {
       columns: async (_t: string) => [{ name: "id", type: "integer", primaryKey: true }],
       indexes: async () => [],
     };
-    const output = await SchemaDumper.dump(source as any);
+    const output = (await SchemaDumper.dump(source as any)).join("\n");
     expect(output).not.toContain("addForeignKey");
   });
 
@@ -747,10 +747,12 @@ describe("SchemaDumperTest", () => {
       columns: async (_t: string) => [{ name: "id", type: "integer", primaryKey: true }],
       indexes: async () => [],
     };
-    const output = await SchemaDumper.dump(source as any, {
-      tableNamePrefix: "myapp_",
-      tableNameSuffix: "_v1",
-    });
+    const output = (
+      await SchemaDumper.dump(source as any, [], {
+        tableNamePrefix: "myapp_",
+        tableNameSuffix: "_v1",
+      })
+    ).join("\n");
     expect(output).toContain('"users"');
     expect(output).not.toContain("myapp_users_v1");
   });
@@ -761,7 +763,9 @@ describe("SchemaDumperTest", () => {
       columns: async (_t: string) => [{ name: "id", type: "integer", primaryKey: true }],
       indexes: async () => [],
     };
-    const output = await SchemaDumper.dump(source as any, { tableNamePrefix: "app.prefix_" });
+    const output = (
+      await SchemaDumper.dump(source as any, [], { tableNamePrefix: "app.prefix_" })
+    ).join("\n");
     expect(output).toContain('"users"');
     expect(output).not.toContain("app.prefix_users");
   });
@@ -772,7 +776,9 @@ describe("SchemaDumperTest", () => {
       indexes: async () => [],
     };
     SchemaDumper.ignoreTables = ["posts"];
-    const output = await SchemaDumper.dump(source as any, { tableNamePrefix: "myapp_" });
+    const output = (await SchemaDumper.dump(source as any, [], { tableNamePrefix: "myapp_" })).join(
+      "\n",
+    );
     expect(output).toContain('"users"');
     expect(output).not.toContain('"posts"');
     expect(output).not.toContain("myapp_");

--- a/packages/activerecord/src/schema-dumper.trails.test.ts
+++ b/packages/activerecord/src/schema-dumper.trails.test.ts
@@ -25,7 +25,7 @@ describe("SchemaDumper trails-only cases", () => {
       ],
       indexes: () => [],
     };
-    const output = TopLevelDumper.dump(source) as string;
+    const output = (TopLevelDumper.dump(source) as string[]).join("\n");
     expect(output).toContain(`() => "gen_random_uuid()"`);
   });
 
@@ -55,7 +55,7 @@ describe("SchemaDumper trails-only cases", () => {
       ],
       indexes: () => [],
     };
-    const output = TopLevelDumper.dump(source) as string;
+    const output = (TopLevelDumper.dump(source) as string[]).join("\n");
     for (const helper of [
       "int4range",
       "int8range",
@@ -91,7 +91,7 @@ describe("SchemaDumper trails-only cases", () => {
       ],
       indexes: () => [],
     };
-    const output = TopLevelDumper.dump(source) as string;
+    const output = (TopLevelDumper.dump(source) as string[]).join("\n");
     // Regression guard against collapsing to the `enum` fallback. timestamptz/
     // interval/oid resolve to their TableDefinition helpers (`t.timestamptz`/
     // `t.interval`/`t.oid`); uuid has no helper and round-trips through the
@@ -183,12 +183,12 @@ describe("SchemaDumper trails-only cases", () => {
     });
     // auto-generated Rails name → name: omitted (export_name_on_schema_dump? == false)
     const autoName = "fk_rails_abc123def4";
-    const autoOutput = await SchemaDumper.dump(mkSource(autoName) as any);
+    const autoOutput = (await SchemaDumper.dump(mkSource(autoName) as any)).join("\n");
     expect(autoOutput).toContain("addForeignKey");
     expect(autoOutput).not.toContain(`"${autoName}"`);
     // custom name → name: included
     const customName = "fk_books_author_id";
-    const customOutput = await SchemaDumper.dump(mkSource(customName) as any);
+    const customOutput = (await SchemaDumper.dump(mkSource(customName) as any)).join("\n");
     expect(customOutput).toContain(`name: "${customName}"`);
   });
 
@@ -200,11 +200,11 @@ describe("SchemaDumper trails-only cases", () => {
       checkConstraints: async () => [{ expression: "price > 0", name: chkName }],
     });
     const autoName = "chk_rails_abc123def4";
-    const autoOutput = await SchemaDumper.dump(mkSource(autoName) as any);
+    const autoOutput = (await SchemaDumper.dump(mkSource(autoName) as any)).join("\n");
     expect(autoOutput).toContain("t.checkConstraint");
     expect(autoOutput).not.toContain(`"${autoName}"`);
     const customChkName = "products_price_check";
-    const customOutput = await SchemaDumper.dump(mkSource(customChkName) as any);
+    const customOutput = (await SchemaDumper.dump(mkSource(customChkName) as any)).join("\n");
     expect(customOutput).toContain(`name: "${customChkName}"`);
   });
 });
@@ -279,7 +279,7 @@ describe("SchemaDumperAdapterTest", () => {
     await adapter.createTable("reminders", {}, (t) => {
       t.string("name");
     });
-    const result = await TopLevelDumper.dump(adapter);
+    const result = (await TopLevelDumper.dump(adapter)).join("\n");
     expect(result).toContain("reminders");
     expect(result).not.toContain("schema_migrations");
     expect(result).not.toContain("ar_internal_metadata");
@@ -414,7 +414,7 @@ describe("SchemaDumper async header ordering", () => {
     }
     const source = { tables: () => [], columns: () => [], indexes: () => [] };
     const dumper = new (OrderedDumper as any)(source);
-    const result = await (dumper.dump() as Promise<string>);
+    const result = (await (dumper.dump() as Promise<string[]>)).join("\n");
     expect(log).toEqual(["schemas", "extensions", "types"]);
     const schemasIdx = result.indexOf("SCHEMAS");
     const extensionsIdx = result.indexOf("EXTENSIONS");

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -493,7 +493,6 @@ export abstract class SchemaDumper {
     // into dumps.
     if (isDatabaseAdapter(pool)) {
       const source = new AdapterSchemaSource(pool);
-      const dumperOptions = options;
       // Instantiate the adapter-specific subclass when the adapter exposes
       // createSchemaDumper() (MySQL/PG/SQLite) so dialect overrides like
       // MySQL's schemaPrecision (datetime precision 0 → `precision: nil`)
@@ -504,11 +503,8 @@ export abstract class SchemaDumper {
       const createDialectDumper = (pool as { createSchemaDumper?: unknown }).createSchemaDumper;
       const dumper =
         (typeof createDialectDumper === "function"
-          ? (createDialectDumper.call(pool, source, dumperOptions) as
-              | SchemaDumper
-              | undefined
-              | null)
-          : undefined) ?? this.create(source, dumperOptions);
+          ? (createDialectDumper.call(pool, source, options) as SchemaDumper | undefined | null)
+          : undefined) ?? this.create(source, options);
       return dumper.dump(stream) as Promise<string[]>;
     }
     if (isConnectionPool(pool)) {
@@ -1165,15 +1161,6 @@ export abstract class SchemaDumper {
 }
 
 /**
- * Duck-type check so `dump()` can branch on adapter vs SchemaSource.
- * `DatabaseAdapter` IS a SchemaSource at the duck level (it has
- * `tables`/`columns`/`indexes`), so we identify adapters by their
- * adapter-specific surface (`execute`/`executeMutation`/
- * `adapterName`). If that matches, we route through
- * `AdapterSchemaSource` even though the raw adapter would duck-type
- * as a SchemaSource.
- */
-/**
  * `pool.with_connection` is all `SchemaDumper.dump` asks of its pool
  * (`schema_dumper.rb:44`); typing the parameter structurally keeps
  * schema-dumper.ts off connection-pool.ts's import graph, exactly as the
@@ -1191,6 +1178,15 @@ function isConnectionPool(v: unknown): v is ConnectionPoolLike {
   );
 }
 
+/**
+ * Duck-type check so `dump()` can branch on adapter vs SchemaSource.
+ * `DatabaseAdapter` IS a SchemaSource at the duck level (it has
+ * `tables`/`columns`/`indexes`), so we identify adapters by their
+ * adapter-specific surface (`execute`/`executeMutation`/
+ * `adapterName`). If that matches, we route through
+ * `AdapterSchemaSource` even though the raw adapter would duck-type
+ * as a SchemaSource.
+ */
 function isDatabaseAdapter(v: unknown): v is DatabaseAdapter {
   if (v === null || typeof v !== "object") return false;
   const obj = v as {

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -163,6 +163,16 @@ export interface SchemaDumperOptions {
 }
 
 /**
+ * The `config` argument of `SchemaDumper.dump(pool, stream, config)` — Rails
+ * passes `ActiveRecord::Base` and reads `table_name_prefix` /
+ * `table_name_suffix` off it (`schema_dumper.rb:43,51-56`).
+ */
+export interface SchemaDumperConfig extends SchemaDumperOptions {
+  tableNamePrefix?: string;
+  tableNameSuffix?: string;
+}
+
+/**
  * DSL methods that actually exist as helpers on TableDefinition —
  * either the abstract base (connection-adapters/abstract/schema-definitions.ts)
  * or adapter-specific subclasses (e.g. PG range helpers in
@@ -350,6 +360,15 @@ export function statelessTest(pattern: RegExp, value: string): boolean {
  */
 export abstract class SchemaDumper {
   static ignoreTables: (string | RegExp)[] = [];
+  /**
+   * Output language for a dump that names none explicitly. Rails' dumper only
+   * ever emits Ruby, so `dump(pool, stream, config)` has no slot for this;
+   * trails emits TS or JS, and `DatabaseTasks.dumpSchema` sets it from
+   * `schema_format` — the same global that decides `:ruby` vs `:sql` in Rails.
+   * @noRailsEquivalent PERMANENT: trails' dumper emits TS or JS where Rails
+   * only ever emits Ruby, so Rails has no slot to converge this onto.
+   */
+  static language: SchemaDumpLanguage = "ts";
   /** @internal Mirrors Rails' `SchemaDumper.fk_ignore_pattern`. */
   static fkIgnorePattern: RegExp = /^fk_rails_[0-9a-f]{10}$/;
   /** @internal Mirrors Rails' `SchemaDumper.chk_ignore_pattern`. */
@@ -380,7 +399,9 @@ export abstract class SchemaDumper {
   constructor(source: SchemaSource, options: Record<string, unknown> = {}) {
     this._source = source;
     this._options = options;
-    const lang = (options.language as SchemaDumpLanguage | undefined) ?? "ts";
+    const lang =
+      (options.language as SchemaDumpLanguage | undefined) ??
+      (this.constructor as typeof SchemaDumper).language;
     this._language = lang;
     this._version = typeof options.version === "string" ? options.version : undefined;
     const subclassIgnore = (this.constructor as typeof SchemaDumper).ignoreTables ?? [];
@@ -417,12 +438,15 @@ export abstract class SchemaDumper {
   }
 
   /** @internal */
-  static generateOptions(
-    config: { tableNamePrefix?: string; tableNameSuffix?: string } = {},
-  ): Record<string, unknown> {
+  static generateOptions(config: SchemaDumperConfig = {}): Record<string, unknown> {
     return {
       tableNamePrefix: config.tableNamePrefix ?? "",
       tableNameSuffix: config.tableNameSuffix ?? "",
+      // Rails' dumper reads the version off the connection in `initialize`
+      // (`schema_dumper.rb:73`); trails resolves it in `dumpWithVersion` and
+      // hands it down here, and emits TS or JS rather than only Ruby.
+      language: config.language,
+      version: config.version,
     };
   }
 
@@ -448,16 +472,18 @@ export abstract class SchemaDumper {
   }
 
   /**
-   * Dump from a SchemaSource (matches Rails) OR directly from a
-   * DatabaseAdapter (convenience overload — bridges through
-   * AdapterSchemaSource).
+   * Mirrors: `ActiveRecord::SchemaDumper.dump` (`schema_dumper.rb:43-48`) —
+   * dumps through the pool's connection into `stream` and returns `stream`.
+   * A `DatabaseAdapter` or a bare `SchemaSource` is also accepted in the
+   * `pool` slot: Rails' pool always yields a connection that is itself the
+   * dump source, while trails' mock sources are not adapters.
    */
-  static dump(source: SchemaSource, options?: Record<string, unknown>): string | Promise<string>;
-  static dump(adapter: DatabaseAdapter, options?: SchemaDumperOptions): Promise<string>;
   static dump(
-    sourceOrAdapter: SchemaSource | DatabaseAdapter,
-    options: Record<string, unknown> = {},
-  ): string | Promise<string> {
+    pool: ConnectionPoolLike | SchemaSource | DatabaseAdapter = baseClass().connectionPool(),
+    stream: string[] = [],
+    config: SchemaDumperConfig = baseClass(),
+  ): string[] | Promise<string[]> {
+    const options = this.generateOptions(config);
     // Adapter check runs FIRST because concrete DatabaseAdapters
     // (PostgreSQLAdapter, SQLite3Adapter) implement `tables()` /
     // `columns()` / `indexes()` and so also satisfy the SchemaSource
@@ -465,10 +491,9 @@ export abstract class SchemaDumper {
     // does the column normalization expected by emitTable — skipping
     // it would leak raw adapter column shapes (e.g. `scale: null`)
     // into dumps.
-    if (isDatabaseAdapter(sourceOrAdapter)) {
-      const source = new AdapterSchemaSource(sourceOrAdapter);
-      const lang = (options.language as SchemaDumpLanguage) ?? "ts";
-      const dumperOptions = { ...options, language: lang };
+    if (isDatabaseAdapter(pool)) {
+      const source = new AdapterSchemaSource(pool);
+      const dumperOptions = options;
       // Instantiate the adapter-specific subclass when the adapter exposes
       // createSchemaDumper() (MySQL/PG/SQLite) so dialect overrides like
       // MySQL's schemaPrecision (datetime precision 0 → `precision: nil`)
@@ -476,18 +501,24 @@ export abstract class SchemaDumper {
       // the adapter's SchemaDumper module into the dumper. Without the hook,
       // `create` still resolves to the ConnectionAdapters subclass (see its
       // redirect) — never the bare base.
-      const createDialectDumper = (sourceOrAdapter as { createSchemaDumper?: unknown })
-        .createSchemaDumper;
+      const createDialectDumper = (pool as { createSchemaDumper?: unknown }).createSchemaDumper;
       const dumper =
         (typeof createDialectDumper === "function"
-          ? (createDialectDumper.call(sourceOrAdapter, source, dumperOptions) as
+          ? (createDialectDumper.call(pool, source, dumperOptions) as
               | SchemaDumper
               | undefined
               | null)
           : undefined) ?? this.create(source, dumperOptions);
-      return dumper.dump() as Promise<string>;
+      return dumper.dump(stream) as Promise<string[]>;
     }
-    return this.create(sourceOrAdapter, options).dump();
+    if (isConnectionPool(pool)) {
+      return pool
+        .withConnection(async (connection) => {
+          await this.dump(connection, stream, config);
+        })
+        .then(() => stream);
+    }
+    return this.create(pool, options).dump(stream);
   }
 
   static dumpTableSchema(adapter: DatabaseAdapter, tableName: string): Promise<string>;
@@ -533,12 +564,11 @@ export abstract class SchemaDumper {
         version = versions[versions.length - 1];
       }
     }
-    const schema = await this.dump(adapter, { ...options, version });
-    return `// Schema version: ${version}\n${schema}`;
+    const schema = await this.dump(adapter, [], { ...options, version });
+    return `// Schema version: ${version}\n${schema.join("\n")}`;
   }
 
-  dump(): string | Promise<string> {
-    const stream: string[] = [];
+  dump(stream: string[] = []): string[] | Promise<string[]> {
     this.header(stream);
     const schemasResult = this.schemas(stream);
     // Run header sections sequentially to preserve deterministic output order
@@ -561,24 +591,24 @@ export abstract class SchemaDumper {
   }
 
   /** @internal */
-  private _finalizeDump(stream: string[]): string | Promise<string> {
+  private _finalizeDump(stream: string[]): string[] | Promise<string[]> {
     const result = this.tables(stream);
     if (result instanceof Promise) {
       return result.then(async () => {
         await this.virtualTables(stream);
         this.trailer(stream);
-        return stream.join("\n");
+        return stream;
       });
     }
     const vtResult = this.virtualTables(stream);
     if (vtResult instanceof Promise) {
       return vtResult.then(() => {
         this.trailer(stream);
-        return stream.join("\n");
+        return stream;
       });
     }
     this.trailer(stream);
-    return stream.join("\n");
+    return stream;
   }
 
   /** @internal */
@@ -1143,6 +1173,24 @@ export abstract class SchemaDumper {
  * `AdapterSchemaSource` even though the raw adapter would duck-type
  * as a SchemaSource.
  */
+/**
+ * `pool.with_connection` is all `SchemaDumper.dump` asks of its pool
+ * (`schema_dumper.rb:44`); typing the parameter structurally keeps
+ * schema-dumper.ts off connection-pool.ts's import graph, exactly as the
+ * `baseClass()` slot above keeps it off base.ts's.
+ */
+interface ConnectionPoolLike {
+  withConnection<T>(fn: (conn: DatabaseAdapter) => T | Promise<T>): Promise<T>;
+}
+
+function isConnectionPool(v: unknown): v is ConnectionPoolLike {
+  return (
+    v !== null &&
+    typeof v === "object" &&
+    typeof (v as { withConnection?: unknown }).withConnection === "function"
+  );
+}
+
 function isDatabaseAdapter(v: unknown): v is DatabaseAdapter {
   if (v === null || typeof v !== "object") return false;
   const obj = v as {

--- a/packages/activerecord/src/support/schema-dumping-helper.ts
+++ b/packages/activerecord/src/support/schema-dumping-helper.ts
@@ -11,8 +11,8 @@ import { SchemaDumper } from "../connection-adapters/abstract/schema-dumper.js";
  * Test-only schema-dump helpers. Mirrors Rails'
  * `ActiveRecord::SchemaDumpingHelper` (test/support/schema_dumping_helper.rb).
  *
- * Rails captures `SchemaDumper.dump(pool)` stdout; our dumper returns the
- * generated DSL string directly, so there is no `capture_io`. The
+ * Rails captures `SchemaDumper.dump(pool)` stdout; our dump stream is the
+ * array of generated DSL lines, so there is no `capture_io`. The
  * `SchemaDumper.ignore_tables` save/restore dance is faithful — both helpers
  * scope the global filter to a single dump and always restore it (even on
  * throw), so concurrent suites don't observe a mutated baseline.
@@ -45,7 +45,7 @@ export async function dumpTableSchema(source: SchemaSource, ...tables: string[])
     : await source.tables();
   BaseSchemaDumper.ignoreTables = dataSources.filter((name) => !tables.includes(name));
   try {
-    return await SchemaDumper.dump(source);
+    return (await SchemaDumper.dump(source)).join("\n");
   } finally {
     BaseSchemaDumper.ignoreTables = oldIgnoreTables;
   }
@@ -63,7 +63,7 @@ export async function dumpAllTableSchema(
   const oldIgnoreTables = BaseSchemaDumper.ignoreTables;
   BaseSchemaDumper.ignoreTables = ignoreTables;
   try {
-    return await SchemaDumper.dump(source);
+    return (await SchemaDumper.dump(source)).join("\n");
   } finally {
     BaseSchemaDumper.ignoreTables = oldIgnoreTables;
   }

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -1017,15 +1017,21 @@ export class DatabaseTasks {
     const dir = path.dirname(filename);
     fs.mkdirSync(dir, { recursive: true });
     // Rails' dumper only ever emits Ruby, so its `dump` has no language slot;
-    // ours reads the class default, which `schema_format` decides here.
+    // ours reads the class default, scoped to this dump the way `load_schema`
+    // scopes `Migration.verbose` (`database_tasks.rb:380,394`).
+    const languageWas = SchemaDumper.language;
     SchemaDumper.language = format === "js" ? "js" : "ts";
-    const migrationConnectionPool = this.migrationConnectionPool();
-    // Rails: `File.open(filename, "w:utf-8") { |file| SchemaDumper.dump(pool, file) }`
-    // (`database_tasks.rb:439-442`). `file` is the dump stream — ours collects
-    // the lines, then writes them, because the fs port has no open-file handle.
-    const file: string[] = [];
-    await SchemaDumper.dump(migrationConnectionPool, file);
-    fs.writeFileSync(filename, file.join("\n"));
+    try {
+      const migrationConnectionPool = this.migrationConnectionPool();
+      // Rails: `File.open(filename, "w:utf-8") { |file| SchemaDumper.dump(pool, file) }`
+      // (`database_tasks.rb:439-442`). `file` is the dump stream — ours collects
+      // the lines, then writes them, because the fs port has no open-file handle.
+      const file: string[] = [];
+      await SchemaDumper.dump(migrationConnectionPool, file);
+      fs.writeFileSync(filename, file.join("\n"));
+    } finally {
+      SchemaDumper.language = languageWas;
+    }
   }
 
   static async loadSchema(

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -1012,14 +1012,20 @@ export class DatabaseTasks {
       return;
     }
     const { SchemaDumper } = await import("../connection-adapters/abstract/schema-dumper.js");
-    const adapter = await this._migrationAdapter();
     const fs = getFs();
     const path = getPath();
     const dir = path.dirname(filename);
     fs.mkdirSync(dir, { recursive: true });
-    const language = format === "js" ? "js" : "ts";
-    const output = await SchemaDumper.dump(adapter, { language });
-    fs.writeFileSync(filename, output);
+    // Rails' dumper only ever emits Ruby, so its `dump` has no language slot;
+    // ours reads the class default, which `schema_format` decides here.
+    SchemaDumper.language = format === "js" ? "js" : "ts";
+    const migrationConnectionPool = this.migrationConnectionPool();
+    // Rails: `File.open(filename, "w:utf-8") { |file| SchemaDumper.dump(pool, file) }`
+    // (`database_tasks.rb:439-442`). `file` is the dump stream — ours collects
+    // the lines, then writes them, because the fs port has no open-file handle.
+    const file: string[] = [];
+    await SchemaDumper.dump(migrationConnectionPool, file);
+    fs.writeFileSync(filename, file.join("\n"));
   }
 
   static async loadSchema(

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -974,7 +974,7 @@ describe("schema dump and load", () => {
       const source = new AdapterSchemaSource(sourceAdapter);
       // Dump as JS so the JSDoc-annotated output is valid input to
       // `new Function` below (no TS `import type` / annotation syntax).
-      const schema = await SchemaDumper.dump(source, { language: "js" });
+      const schema = (await SchemaDumper.dump(source, [], { language: "js" })).join("\n");
       expect(schema).toContain("users");
       expect(schema).toContain("createTable");
 

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/tasks/database-tasks.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/tasks/database-tasks.json
@@ -78,18 +78,6 @@
     "package": "activerecord",
     "tsFile": "tasks/database-tasks.ts",
     "rubyName": "dump_schema",
-    "call": "dump",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:migrationConnectionPool",
-      "ref:file"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "tasks/database-tasks.ts",
-    "rubyName": "dump_schema",
     "call": "open",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },


### PR DESCRIPTION
Converges `SchemaDumper.dump` onto Rails' signature so `DatabaseTasks.dumpSchema`
can make Rails' call.

Rails `SchemaDumper.dump(pool = Base.connection_pool, stream = $stdout, config = Base)`
dumps through the pool's connection into `stream` and returns the stream
(`schema_dumper.rb:43-48`), and `dump_schema` calls it as
`SchemaDumper.dump(migration_connection_pool, file)` inside the file open
(`database_tasks.rb:439-442`). trails took `(adapter, options)` and returned the
joined string.

- static `dump(pool, stream, config)` with Rails' order/defaults, returning the
  stream. A pool routes through `withConnection`; a `DatabaseAdapter` or bare
  `SchemaSource` is still accepted in the pool slot (Rails' pool always yields a
  connection that *is* the dump source; our mock sources are not adapters).
- instance `dump(stream)` takes and returns the stream (`schema_dumper.rb:60-69`).
- `dumpSchema` builds the `file` stream and calls
  `dump(migrationConnectionPool, file)`, then writes it (the fs port has no
  open-file handle, so the lines are collected and written).
- Output language has no slot in Rails' signature (its dumper only ever emits
  Ruby), so it moves to a `SchemaDumper.language` class default, tagged
  `@noRailsEquivalent`; `dumpSchema` sets it from `schema_format`, the same
  global that picks `:ruby` vs `:sql` in Rails.
- Callers updated to join the returned stream.

Deletes the `dump_schema` → `dump` `kind: "args"` baseline row by hand
(only-shrink). `pnpm parity:api:calls:args` and `pnpm parity:api:calls` are green.

Closes-story: call-args-database-tasks-dump-schema-dumper-stream
