### PR TITLE
fix(scripts): pair a block-passing Ruby call site against the TS site that carries the block

### DIFF
--- a/scripts/api-compare/call-args.test.ts
+++ b/scripts/api-compare/call-args.test.ts
@@ -650,6 +650,40 @@ describe("pairCallSites", () => {
     expect(pairs.map((p) => p.ts.args)).toEqual([["id:name", "?", "id:seed_type"]]);
   });
 
+  it("pairs a block-passing Ruby site against the TS site that carries the block", () => {
+    // predicate_builder.rb:100 `associated_table(key, &block)` and :108
+    // `associated_table(key)` both describe as `(key)`, so only the block tells
+    // them apart — and the port mirrors both (predicate-builder.ts:79, :91).
+    const pairs = pairCallSites(
+      [
+        site("associated_table", ["id:key"], ["blockpass", "blockarg=id:block"]),
+        site("associated_table", ["id:key"]),
+      ],
+      [site("associatedTable", ["id:key", "id:block"]), site("associatedTable", ["id:key"])],
+    );
+    expect(pairs.map((p) => p.ts.args)).toEqual([["id:key", "id:block"], ["id:key"]]);
+  });
+
+  it("leaves a block-passing Ruby site alone when no TS site passes that block", () => {
+    // type_map_initializer.rb:98 `register_type(oid, &block)` against a port
+    // that pads the skipped optional parameter — the block is not simply the
+    // trailing argument, so the block-less :100 site keeps its own counterpart.
+    const pairs = pairCallSites(
+      [
+        site("register_type", ["id:oid"], ["blockpass", "blockarg=id:block"]),
+        site("register_type", ["id:oid", "id:oid_type"]),
+      ],
+      [
+        site("registerType", ["id:oid", "nil", "id:oidType"]),
+        site("registerType", ["id:oid", "id:oidType"]),
+      ],
+    );
+    expect(pairs.map((p) => p.ts.args)).toEqual([
+      ["id:oid", "nil", "id:oidType"],
+      ["id:oid", "id:oidType"],
+    ]);
+  });
+
   it("camelizes the Ruby call name to find its TS site", () => {
     const pairs = pairCallSites(
       [site("inject_join", ["id:list"])],

--- a/scripts/api-compare/call-args.ts
+++ b/scripts/api-compare/call-args.ts
@@ -664,6 +664,53 @@ function tsCallNameKeys(rubyName: string): string[] {
   return [snakeToCamel(rubyName)];
 }
 
+/** The descriptor of a `&blk` block-pass the Ruby site's argument list dropped
+ *  — `&block` is `blockarg=ref:block` (extract-ruby-api.rb#describe_args) —
+ *  or undefined at a site that passes no block. */
+function rubyBlockArg(ruby: CallSite): string | undefined {
+  return ruby.flags.find((flag) => flag.startsWith("blockarg="))?.slice("blockarg=".length);
+}
+
+/** Where the TS site passes the block the Ruby site block-passed, or -1 when it
+ *  passes no such argument.
+ *
+ *  TS has no `&`, so the port forwards the block as an ordinary argument —
+ *  `associatedTable(key, block)` (predicate-builder.ts:79) for
+ *  `predicate_builder.rb:100`'s `associated_table(key, &block)` — which the TS
+ *  extractor cannot tell from a value argument. The Ruby-side descriptor is
+ *  what names it. */
+function tsBlockArgIndex(ruby: CallSite, ts: CallSite): number {
+  const blockArg = rubyBlockArg(ruby);
+  return blockArg === undefined ? -1 : ts.args.lastIndexOf(blockArg);
+}
+
+/** The TS argument list with the forwarded block dropped, so that a
+ *  block-passing Ruby site scores against its block-carrying TS counterpart on
+ *  the arguments the two actually share ({@link tsBlockArgIndex}). */
+function stripForwardedBlockArg(ruby: CallSite, ts: CallSite): string[] {
+  const index = tsBlockArgIndex(ruby, ts);
+  return index === -1 ? ts.args : ts.args.filter((_, i) => i !== index);
+}
+
+/**
+ * Whether a candidate pairs a block-passing Ruby site with the TS site that
+ * carries the block, and a block-less Ruby site with one that does not — the
+ * {@link pairCallSites} tie-break that keeps two occurrences of a name
+ * differing only in a block from being interchangeable.
+ *
+ * `predicate_builder.rb:100` calls `associated_table(key, &block)` and `:108`
+ * calls `associated_table(key)`; both describe as `(key)`, because the
+ * block-pass is a flag rather than an argument, so both agree exactly with both
+ * of the port's two sites and source order strands the block-less Ruby site
+ * against the block-carrying TS one. The block is the only thing that
+ * distinguishes them, so it is what the tie is broken on.
+ */
+function blockAffinity(ruby: CallSite, ts: CallSite): number {
+  const rubyCarries = rubyBlockArg(ruby) !== undefined || ruby.flags.includes("block");
+  const tsCarries = tsBlockArgIndex(ruby, ts) !== -1 || ts.flags.includes("block");
+  return rubyCarries === tsCarries ? 1 : 0;
+}
+
 /**
  * How well two same-named call sites' argument lists agree, for
  * {@link pairCallSites}. Higher is a better pairing. Ordered so that an exact
@@ -687,7 +734,7 @@ function tsCallNameKeys(rubyName: string): string[] {
  * assignment takes it whenever the key matches tie.
  */
 function argSimilarity(ruby: CallSite, ts: CallSite): number {
-  const aligned = alignReceiverArgs(ruby, ts.args);
+  const aligned = alignReceiverArgs(ruby, stripForwardedBlockArg(ruby, ts));
   const sameArity = aligned.rubyArgs.length === aligned.tsArgs.length ? 1 : 0;
   const rubyArgs = normalizeArgs(aligned.rubyArgs);
   const tsArgs = normalizeArgs(aligned.tsArgs);
@@ -726,23 +773,30 @@ function argSimilarity(ruby: CallSite, ts: CallSite): number {
  * within one name it consumes exactly the min(Ruby, TS) sites the source-order
  * zip did, and nothing that used to be compared silently stops being compared.
  *
- * Greedy over the globally best-scoring candidate, ties broken by source order
- * on the Ruby then the TS side, so the verdict never depends on the order the
- * candidates were enumerated in.
+ * Greedy over the globally best-scoring candidate, ties broken by
+ * {@link blockAffinity} and then by source order on the Ruby then the TS side,
+ * so the verdict never depends on the order the candidates were enumerated in.
  */
 export function pairCallSites(
   rubySites: readonly CallSite[],
   tsSites: readonly CallSite[],
 ): { ruby: CallSite; ts: CallSite }[] {
-  const candidates: { rubyIdx: number; tsIdx: number; score: number }[] = [];
+  const candidates: { rubyIdx: number; tsIdx: number; score: number; block: number }[] = [];
   rubySites.forEach((ruby, rubyIdx) => {
     const keys = new Set(tsCallNameKeys(ruby.name));
     tsSites.forEach((ts, tsIdx) => {
       if (!keys.has(ts.name)) return;
-      candidates.push({ rubyIdx, tsIdx, score: argSimilarity(ruby, tsSites[tsIdx]) });
+      candidates.push({
+        rubyIdx,
+        tsIdx,
+        score: argSimilarity(ruby, ts),
+        block: blockAffinity(ruby, ts),
+      });
     });
   });
-  candidates.sort((a, b) => b.score - a.score || a.rubyIdx - b.rubyIdx || a.tsIdx - b.tsIdx);
+  candidates.sort(
+    (a, b) => b.score - a.score || b.block - a.block || a.rubyIdx - b.rubyIdx || a.tsIdx - b.tsIdx,
+  );
   const takenRuby = new Set<number>();
   const takenTs = new Set<number>();
   const matched = new Map<number, number>();

--- a/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal/request-forgery-protection.json
+++ b/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal/request-forgery-protection.json
@@ -146,17 +146,6 @@
   {
     "package": "actioncontroller",
     "tsFile": "metal/request-forgery-protection.ts",
-    "rubyName": "real_csrf_token",
-    "call": "fetch",
-    "kind": "args",
-    "rubyArgs": [
-      "const:CSRF_TOKEN"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/request-forgery-protection.ts",
     "rubyName": "request_authenticity_tokens",
     "call": "form_authenticity_param",
     "kind": "args",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/predicate-builder.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/predicate-builder.json
@@ -3,17 +3,6 @@
     "package": "activerecord",
     "tsFile": "relation/predicate-builder.ts",
     "rubyName": "expand_from_hash",
-    "call": "associated_table",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:key"
-    ],
-    "reason": "RFC 0099: residual site-pairing ambiguity surfaced by the similarity pairing, not a port divergence. predicate_builder.rb:100 calls `associated_table(key, &block)` and :108 calls `associated_table(key)`; the port mirrors both (predicate-builder.ts:121 passes `block`, :133 does not), but the two Ruby occurrences agree with the two TS sites equally well, so the assignment can strand the block-less Ruby site against the block-carrying TS one. Tracked as call-args-tool-pairing-ties-strand-blockpass-sites."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder.ts",
-    "rubyName": "expand_from_hash",
     "call": "wrap",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -2505,7 +2505,16 @@ class ApiExtractor
     case node[0]
     when :arg_paren then describe_args(node[1], flags)
     when :args_add_block
-      flags << "blockpass" if node[2].is_a?(Array)
+      if node[2].is_a?(Array)
+        flags << "blockpass"
+        # The block-pass is not an argument, but the port has no `&` so it
+        # forwards it as an ordinary trailing one. Record what was passed —
+        # `&block` is `blockarg=ref:block` — so the comparator can tell the TS
+        # site that carries the block from the one that does not (call-args.ts
+        # #tsCarriesBlock). Described against a scratch flag list: the block
+        # itself must not flag the call.
+        flags << "blockarg=#{describe_arg(node[2], [])}"
+      end
       describe_args(node[1], flags)
     when :args_add_star
       flags << "splat"

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -2507,12 +2507,9 @@ class ApiExtractor
     when :args_add_block
       if node[2].is_a?(Array)
         flags << "blockpass"
-        # The block-pass is not an argument, but the port has no `&` so it
-        # forwards it as an ordinary trailing one. Record what was passed —
-        # `&block` is `blockarg=ref:block` — so the comparator can tell the TS
-        # site that carries the block from the one that does not (call-args.ts
-        # #tsCarriesBlock). Described against a scratch flag list: the block
-        # itself must not flag the call.
+        # What was block-passed, so call-args.ts#tsBlockArgIndex can find it in
+        # the TS list the port forwards it through. Described against a scratch
+        # flag list: the block itself must not flag the call.
         flags << "blockarg=#{describe_arg(node[2], [])}"
       end
       describe_args(node[1], flags)

--- a/scripts/api-compare/extract-ruby-api.test.ts
+++ b/scripts/api-compare/extract-ruby-api.test.ts
@@ -1721,7 +1721,11 @@ describe("Ruby extractor call-argument capture", () => {
       flags: ["splat"],
     });
     // `xs` is a local, so both sites are also weak-receiver ones.
-    expect(sites.find((s) => s.name === "map")?.flags).toEqual(["weak", "blockpass"]);
+    expect(sites.find((s) => s.name === "map")?.flags).toEqual([
+      "weak",
+      "blockpass",
+      "blockarg=sym:to_s",
+    ]);
     expect(sites.find((s) => s.name === "each")?.flags).toEqual(["block", "weak"]);
     expect(argsOf(sites, "save")).toEqual(["id:x"]);
   });


### PR DESCRIPTION
`predicate_builder.rb:100` calls `associated_table(key, &block)` and `:108`
calls `associated_table(key)`. Ruby drops a `&block` from the argument list and
records a `blockpass` flag instead, so both occurrences describe as `(key)` and
agree equally with both of the port's two sites
(`predicate-builder.ts:79` passes `block`, `:91` does not) — the greedy
assignment could strand the block-less Ruby site against the block-carrying TS
one and report a `shape` row for a correct body.

extract-ruby-api.rb now records WHAT was block-passed alongside the flag
(`blockarg=ref:block`), which is what lets the comparator recognise the
forwarded block in the TS argument list — TS has no `&`, so the port passes it
as an ordinary argument the extractor cannot otherwise tell from a value. The
scorer drops that argument before comparing, and `pairCallSites` breaks the
remaining tie on block affinity.

Identifying the block by descriptor rather than by "one trailing argument"
matters: `type_map_initializer.rb:98`'s `register_type(oid, &block)` is ported
as `registerType(oid, undefined, oidType)`, padding the skipped optional
parameter, so a positional rule would mispair it.

Two baselined shape rows go stale and are deleted (278 -> 276): the
predicate-builder one this story tracks, and the `real_csrf_token` `fetch` row,
whose `request.env.fetch(CSRF_TOKEN) do … end` site now pairs against the
port's inline callback instead of the storage strategy's `fetch(request)`.

Closes-story: call-args-tool-pairing-ties-strand-blockpass-sites