### PR TITLE
refactor(activesupport,activerecord,date): converge five fidelity gaps

### DIFF
--- a/packages/activerecord/src/fixtures.ts
+++ b/packages/activerecord/src/fixtures.ts
@@ -19,7 +19,7 @@ import { StatementInvalid } from "./errors.js";
 import { findStiClass } from "./inheritance.js";
 import type { Quoting } from "./connection-adapters/abstract/quoting.js";
 import { currentTimeFromProperTimezone } from "./timestamp.js";
-import { singularize, underscore } from "@blazetrails/activesupport";
+import { isPresent, singularize, underscore } from "@blazetrails/activesupport";
 import { EncryptedAttributeType } from "./encryption/encrypted-attribute-type.js";
 import { EncryptableRecord, encryptedAttributes } from "./encryption/encryptable-record.js";
 import { Configurable } from "./encryption/configurable.js";
@@ -1257,7 +1257,7 @@ export async function prepareModelFixtures(
   // serialize each encrypted column value to ciphertext before insert so the DB stores
   // encrypted data (not cleartext), and populate original_* preserve-columns for ignoreCase.
   // Mirrors: ActiveRecord::Railtie `Fixture.prepend EncryptedFixtures if config.encrypt_fixtures`
-  if (Configurable.config.encryptFixtures && encryptedAttributes.call(ModelClass).size > 0) {
+  if (Configurable.config.encryptFixtures && isPresent(encryptedAttributes.call(ModelClass))) {
     encryptFixtureRows(ModelClass, rows);
   }
 

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -450,12 +450,12 @@ async function groupedAggregate(
     const keyIds = rows
       .map((row) => aliases.map((a) => row[a]))
       .filter((vals) => vals.every((v) => v != null));
-    const keyRecords: any[] =
-      keyIds.length === 0
-        ? []
-        : primaryKey.length === 1
-          ? await klass.where({ [primaryKey[0]]: keyIds.map((vals) => vals[0]) }).toArray()
-          : await klass.where(primaryKey, keyIds).toArray();
+    // calculations.rb:562-563: one `where(primary_key => key_ids)` covers both
+    // arities in Ruby, whose Hash key can be an Array. `where(cols, tuples)` is
+    // the trails spelling of that Array-key form and collapses a one-column key
+    // to the same `IN (...)` Rails' one-element-key branch emits
+    // (predicate_builder.rb:87-90).
+    const keyRecords: any[] = await klass.where(primaryKey, keyIds).toArray();
     // The composite-PK `id` accessor returns an array, so key the lookup map by
     // the raw per-column attribute values to match the SQL group-key tuple.
     const byKey = new Map(

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -450,10 +450,8 @@ async function groupedAggregate(
     const keyIds = rows
       .map((row) => aliases.map((a) => row[a]))
       .filter((vals) => vals.every((v) => v != null));
-    // calculations.rb:562-563: one `where(primary_key => key_ids)` covers both
-    // arities in Ruby, whose Hash key can be an Array. `where(cols, tuples)` is
-    // the trails spelling of that Array-key form and collapses a one-column key
-    // to the same `IN (...)` Rails' one-element-key branch emits
+    // `where(cols, tuples)` is the trails spelling of the Array-key hash Rails
+    // passes here (calculations.rb:562-563), one-column key included
     // (predicate_builder.rb:87-90).
     const keyRecords: any[] = await klass.where(primaryKey, keyIds).toArray();
     // The composite-PK `id` accessor returns an array, so key the lookup map by

--- a/packages/activesupport/src/string-utils.ts
+++ b/packages/activesupport/src/string-utils.ts
@@ -8,9 +8,8 @@ export function isBlank(value: unknown): boolean {
   if (typeof value === "boolean") return !value;
   if (typeof value === "number") return false;
   if (Array.isArray(value)) return value.length === 0;
-  // Ruby's Object#blank? is `respond_to?(:empty?) ? !!empty? : !self`, so a Set
-  // or Hash answers by emptiness. `Object.keys` reports none for either, which
-  // would make every Set/Map blank.
+  // `Object.keys` reports none for a Set or Map, where Ruby's
+  // `respond_to?(:empty?)` arm answers by size.
   if (value instanceof Set || value instanceof Map) return value.size === 0;
   if (typeof value === "object") return Object.keys(value).length === 0;
   return false;

--- a/packages/activesupport/src/string-utils.ts
+++ b/packages/activesupport/src/string-utils.ts
@@ -8,6 +8,10 @@ export function isBlank(value: unknown): boolean {
   if (typeof value === "boolean") return !value;
   if (typeof value === "number") return false;
   if (Array.isArray(value)) return value.length === 0;
+  // Ruby's Object#blank? is `respond_to?(:empty?) ? !!empty? : !self`, so a Set
+  // or Hash answers by emptiness. `Object.keys` reports none for either, which
+  // would make every Set/Map blank.
+  if (value instanceof Set || value instanceof Map) return value.size === 0;
   if (typeof value === "object") return Object.keys(value).length === 0;
   return false;
 }

--- a/packages/activesupport/src/testing/assertions.ts
+++ b/packages/activesupport/src/testing/assertions.ts
@@ -79,8 +79,69 @@ function classNameOf(e: Error): string {
   return e.name || ctor || "Error";
 }
 
-/** Mirrors `Minitest::BacktraceFilter::MT_RE` (minitest.rb:1176). */
-const MT_RE = /node_modules[/\\]@?vitest|node:internal/;
+/**
+ * Mirrors `Minitest::BacktraceFilter` (minitest.rb:1173-1199).
+ *
+ * @noRailsEquivalent PERMANENT — minitest's, not Rails': Rails reassigns
+ * `Minitest.backtrace_filter` but the class lives in the minitest gem, which
+ * has no vendored Rails file for the comparator to map onto. Ported here for
+ * the same reason {@link UnexpectedError} is.
+ */
+export class BacktraceFilter {
+  /**
+   * Mirrors `Minitest::BacktraceFilter::MT_RE` (minitest.rb:1176),
+   * `%r%lib/minitest|internal:warning%`. The frames trails filters are
+   * vitest's and node's, not minitest's, so the pattern names those instead —
+   * the only part of this class that cannot be transcribed literally.
+   *
+   * @noRailsEquivalent PERMANENT — minitest's constant, not Rails'; see
+   * {@link BacktraceFilter}.
+   */
+  static MT_RE = /node_modules[/\\]@?vitest|node:internal/;
+
+  regexp: RegExp;
+
+  constructor(regexp: RegExp = BacktraceFilter.MT_RE) {
+    this.regexp = regexp;
+  }
+
+  /**
+   * Mirrors `Minitest::BacktraceFilter#filter` (minitest.rb:1190-1198): the
+   * frames before the first framework frame, else every non-framework frame,
+   * else the whole trace. Ruby's `$DEBUG`/`MT_DEBUG` escape hatch reads the
+   * process, which this repo's rules keep out of runtime code.
+   */
+  filter(bt: string[] | null): string[] {
+    if (!bt) return ["No backtrace"];
+
+    const framework = bt.findIndex((line) => this.regexp.test(line));
+    let newBt = framework === -1 ? [...bt] : bt.slice(0, framework);
+    if (newBt.length === 0) newBt = bt.filter((line) => !this.regexp.test(line));
+    if (newBt.length === 0) newBt = [...bt];
+
+    return newBt;
+  }
+}
+
+/**
+ * Mirrors the `Minitest` module's `backtrace_filter` accessor (minitest.rb:43,
+ * assigned at :1204) and `Minitest.filter_backtrace` (minitest.rb:365-369).
+ * Held on an object so the accessor is reassignable at the Ruby spelling
+ * (`Minitest.backtraceFilter = ...`), which `filterBacktrace` reads on every
+ * call the way the `cattr_accessor` does.
+ *
+ * @noRailsEquivalent PERMANENT — minitest's module surface; see
+ * {@link BacktraceFilter}.
+ */
+export const Minitest = {
+  backtraceFilter: new BacktraceFilter(),
+
+  filterBacktrace(bt: string[] | null): string[] {
+    let result = Minitest.backtraceFilter.filter(bt);
+    if (result.length === 0 && bt) result = [...bt];
+    return result;
+  },
+};
 
 /** Mirrors `Minitest::UnexpectedError::BASE_RE` (minitest.rb:1101). */
 function baseRe(): RegExp {
@@ -93,30 +154,6 @@ function baseRe(): RegExp {
   return new RegExp(`${pwd.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/`, "g");
 }
 
-/**
- * Mirrors `Minitest::BacktraceFilter#filter` (minitest.rb:1190-1198): the
- * frames before the first framework frame, else every non-framework frame,
- * else the whole trace. Ruby's `$DEBUG`/`MT_DEBUG` escape hatch reads the
- * process, which this repo's rules keep out of runtime code.
- */
-function filter(bt: string[] | null): string[] {
-  if (!bt) return ["No backtrace"];
-
-  const framework = bt.findIndex((line) => MT_RE.test(line));
-  let newBt = framework === -1 ? [...bt] : bt.slice(0, framework);
-  if (newBt.length === 0) newBt = bt.filter((line) => !MT_RE.test(line));
-  if (newBt.length === 0) newBt = [...bt];
-
-  return newBt;
-}
-
-/** Mirrors `Minitest.filter_backtrace` (minitest.rb:365-369). */
-function filterBacktrace(bt: string[] | null): string[] {
-  let result = filter(bt);
-  if (result.length === 0 && bt) result = [...bt];
-  return result;
-}
-
 Object.defineProperties(UnexpectedError.prototype, {
   stack: {
     configurable: true,
@@ -127,7 +164,9 @@ Object.defineProperties(UnexpectedError.prototype, {
   message: {
     configurable: true,
     get(this: UnexpectedError): string {
-      const bt = filterBacktrace(backtrace(this.error)).join("\n    ").replace(baseRe(), "");
+      const bt = Minitest.filterBacktrace(backtrace(this.error))
+        .join("\n    ")
+        .replace(baseRe(), "");
       return `${classNameOf(this.error)}: ${this.error.message}\n    ${bt}`;
     },
   },

--- a/packages/activesupport/src/testing/unexpected-error.trails.test.ts
+++ b/packages/activesupport/src/testing/unexpected-error.trails.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { cwd } from "../process-adapter.js";
-import { UnexpectedError } from "./assertions.js";
+import { BacktraceFilter, Minitest, UnexpectedError } from "./assertions.js";
 
 describe("UnexpectedErrorTest", () => {
   it("message reads the wrapped error when called", () => {
@@ -40,5 +40,24 @@ describe("UnexpectedErrorTest", () => {
     expect(new UnexpectedError(raised).message).toBe(
       "Error: boom\n    at doThing (packages/activesupport/src/thing.ts:1:1)",
     );
+  });
+
+  it("the rendered backtrace follows a swapped Minitest.backtraceFilter", () => {
+    const raised = new Error("boom");
+    raised.stack = [
+      "Error: boom",
+      `    at doThing (${cwd()}/packages/activesupport/src/thing.ts:1:1)`,
+      `    at inThePlugin (${cwd()}/packages/activesupport/src/plugin.ts:2:2)`,
+    ].join("\n");
+
+    const original = Minitest.backtraceFilter;
+    Minitest.backtraceFilter = new BacktraceFilter(/plugin\.ts/);
+    try {
+      expect(new UnexpectedError(raised).message).toBe(
+        "Error: boom\n    at doThing (packages/activesupport/src/thing.ts:1:1)",
+      );
+    } finally {
+      Minitest.backtraceFilter = original;
+    }
   });
 });

--- a/packages/activesupport/src/xml-mini-backends.trails.test.ts
+++ b/packages/activesupport/src/xml-mini-backends.trails.test.ts
@@ -8,8 +8,8 @@ import { castBackendNameToModule } from "./xml-mini.js";
  * so its reachable set IS the directory listing. trails spells the set out in
  * `XML_MINI_BACKENDS`, which a new backend file could silently miss — these
  * cover the two halves of that: every ported file resolves, and the three
- * backends Rails ships that trails does not carry raise the LoadError message
- * their `require` raises.
+ * backends Rails ships that trails does not carry raise what their own Ruby
+ * file raises.
  */
 describe("XmlMini backends", () => {
   // Vite rewrites a LITERAL `import.meta.glob` call at transform time, so the
@@ -28,10 +28,13 @@ describe("XmlMini backends", () => {
     }
   });
 
-  it("raises LoadError for the backends Rails ships that trails does not carry", async () => {
-    for (const name of ["JDOM", "LibXML", "LibXMLSAX"]) {
+  it("raises what the Ruby file raises for the backends trails does not carry", async () => {
+    await expect(castBackendNameToModule("JDOM")).rejects.toThrow(
+      "JRuby is required to use the JDOM backend for XmlMini",
+    );
+    for (const name of ["LibXML", "LibXMLSAX"]) {
       await expect(castBackendNameToModule(name)).rejects.toThrow(
-        `cannot load such file -- active_support/xml_mini/${name.toLowerCase()}`,
+        "cannot load such file -- libxml",
       );
     }
   });

--- a/packages/activesupport/src/xml-mini-backends.trails.test.ts
+++ b/packages/activesupport/src/xml-mini-backends.trails.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { castBackendNameToModule } from "./xml-mini.js";
+
+/**
+ * Ruby's `cast_backend_name_to_module` is
+ * `require "active_support/xml_mini/#{name.downcase}"` (xml_mini.rb:200-206),
+ * so its reachable set IS the directory listing. trails spells the set out in
+ * `XML_MINI_BACKENDS`, which a new backend file could silently miss — these
+ * cover the two halves of that: every ported file resolves, and the three
+ * backends Rails ships that trails does not carry raise the LoadError message
+ * their `require` raises.
+ */
+describe("XmlMini backends", () => {
+  // Vite rewrites a LITERAL `import.meta.glob` call at transform time, so the
+  // spelling has to stay as written; the repo's tsconfig omits `vite/client`,
+  // which is the only thing that declares it.
+  // @ts-expect-error -- Property 'glob' does not exist on type 'ImportMeta'
+  const ported = Object.keys(import.meta.glob("./xml-mini/*.ts") as Record<string, unknown>)
+    .map((path) => path.replace(/^\.\/xml-mini\//, "").replace(/\.ts$/, ""))
+    .filter((name) => !/\.test$|-engine$|-readable$/.test(name));
+
+  it("resolves every ported backend file by name", async () => {
+    expect(ported.length).toBeGreaterThan(0);
+    for (const name of ported) {
+      const backend = await castBackendNameToModule(name);
+      expect(typeof backend.parse).toBe("function");
+    }
+  });
+
+  it("raises LoadError for the backends Rails ships that trails does not carry", async () => {
+    for (const name of ["JDOM", "LibXML", "LibXMLSAX"]) {
+      await expect(castBackendNameToModule(name)).rejects.toThrow(
+        `cannot load such file -- active_support/xml_mini/${name.toLowerCase()}`,
+      );
+    }
+  });
+});

--- a/packages/activesupport/src/xml-mini.ts
+++ b/packages/activesupport/src/xml-mini.ts
@@ -704,6 +704,31 @@ export async function setCurrentThreadBackend(
 }
 
 /**
+ * Every file Ruby's `require "active_support/xml_mini/#{name.downcase}"`
+ * (xml_mini.rb:202) can reach, listed here because ESM has no directory
+ * `require`: `activesupport/lib/active_support/xml_mini/` holds jdom.rb,
+ * libxml.rb, libxmlsax.rb, nokogiri.rb, nokogirisax.rb and rexml.rb. A name
+ * maps either to its trails module's loader or — for the three backends trails
+ * does not carry — to the reason, so an unported backend is named in one place
+ * instead of being implied by an absent branch. Every entry raises the same
+ * `LoadError` message its Ruby `require` would.
+ *
+ * The specifiers are spelled out rather than interpolated: a bundler resolves
+ * `import(`./xml-mini/${x}.js`)` by globbing `./xml-mini/*.js`, which matches
+ * nothing when the sources on disk are `.ts`, so the name arm threw
+ * `Unknown variable dynamic import` under vitest.
+ */
+const XML_MINI_BACKENDS: Record<string, (() => Promise<unknown>) | string> = {
+  jdom: "jdom.rb raises unless RUBY_PLATFORM includes java (jdom.rb:3) — it is a JRuby-only backend over javax.xml.parsers, with nothing to bind to here",
+  libxml:
+    "libxml.rb requires the libxml-ruby gem (libxml.rb:3), a native binding trails has no counterpart for",
+  libxmlsax: "libxmlsax.rb requires the same libxml-ruby gem (libxmlsax.rb:3) for its SAX parser",
+  nokogiri: () => import("./xml-mini/nokogiri.js"),
+  nokogirisax: () => import("./xml-mini/nokogirisax.js"),
+  rexml: () => import("./xml-mini/rexml.js"),
+};
+
+/**
  * Resolve a backend name to its module, loading the module the first time.
  *
  * Mirrors: ActiveSupport::XmlMini#cast_backend_name_to_module
@@ -712,33 +737,21 @@ export async function setCurrentThreadBackend(
  * is a dynamic import here, since the module namespace object of
  * `xml-mini/<name>.js` is the backend module.
  *
- * The import specifiers are spelled out rather than interpolated: a bundler
- * resolves `import(\`./xml-mini/${x}.js\`)` by globbing `./xml-mini/*.js`, which
- * matches nothing when the sources on disk are `.ts`, so the name arm threw
- * `Unknown variable dynamic import` under vitest. One literal specifier per
- * file `require` can reach keeps the arm lazy and resolvable in both.
- *
  * @internal
  */
 export async function castBackendNameToModule(name: XmlMiniBackendName): Promise<XmlMiniBackend> {
   if (typeof name !== "string") {
     return name;
   } else {
-    switch (name.toLowerCase()) {
-      case "rexml":
-        return (await import("./xml-mini/rexml.js")) as XmlMiniBackend;
-      case "nokogiri":
-        return (await import("./xml-mini/nokogiri.js")) as XmlMiniBackend;
-      case "nokogirisax":
-        return (await import("./xml-mini/nokogirisax.js")) as XmlMiniBackend;
-      default:
-        // Ruby's counterpart is the core `LoadError` that
-        // `require "active_support/xml_mini/#{name.downcase}"` raises for a
-        // name with no file; there is no Rails error class to port here, the
-        // same reason `yaml.ts:16` gives for its own LoadError stand-in.
-        // eslint-disable-next-line blazetrails/rails-error-parity
-        throw new Error(`cannot load such file -- active_support/xml_mini/${name.toLowerCase()}`);
-    }
+    const backend = XML_MINI_BACKENDS[name.toLowerCase()];
+    if (typeof backend === "function") return (await backend()) as XmlMiniBackend;
+    // Ruby's counterpart is the core `LoadError` that
+    // `require "active_support/xml_mini/#{name.downcase}"` raises for a name
+    // with no file — or, for a backend whose gem is missing, for the gem it
+    // requires; there is no Rails error class to port here, the same reason
+    // `yaml.ts:16` gives for its own LoadError stand-in.
+    // eslint-disable-next-line blazetrails/rails-error-parity
+    throw new Error(`cannot load such file -- active_support/xml_mini/${name.toLowerCase()}`);
   }
 }
 

--- a/packages/activesupport/src/xml-mini.ts
+++ b/packages/activesupport/src/xml-mini.ts
@@ -709,9 +709,11 @@ export async function setCurrentThreadBackend(
  * `require`: `activesupport/lib/active_support/xml_mini/` holds jdom.rb,
  * libxml.rb, libxmlsax.rb, nokogiri.rb, nokogirisax.rb and rexml.rb. A name
  * maps either to its trails module's loader or — for the three backends trails
- * does not carry — to the reason, so an unported backend is named in one place
- * instead of being implied by an absent branch. Every entry raises the same
- * `LoadError` message its Ruby `require` would.
+ * does not carry, which wrap a JRuby-only DOM (jdom.rb:3) and the libxml-ruby
+ * gem (libxml.rb:3, libxmlsax.rb:3) — to the message that Ruby file itself
+ * raises, so an unported backend is named in one place instead of being implied
+ * by an absent branch. A name with no entry at all raises what Ruby's `require`
+ * raises for a missing file.
  *
  * The specifiers are spelled out rather than interpolated: a bundler resolves
  * `import(`./xml-mini/${x}.js`)` by globbing `./xml-mini/*.js`, which matches
@@ -719,10 +721,9 @@ export async function setCurrentThreadBackend(
  * `Unknown variable dynamic import` under vitest.
  */
 const XML_MINI_BACKENDS: Record<string, (() => Promise<unknown>) | string> = {
-  jdom: "jdom.rb raises unless RUBY_PLATFORM includes java (jdom.rb:3) — it is a JRuby-only backend over javax.xml.parsers, with nothing to bind to here",
-  libxml:
-    "libxml.rb requires the libxml-ruby gem (libxml.rb:3), a native binding trails has no counterpart for",
-  libxmlsax: "libxmlsax.rb requires the same libxml-ruby gem (libxmlsax.rb:3) for its SAX parser",
+  jdom: "JRuby is required to use the JDOM backend for XmlMini",
+  libxml: "cannot load such file -- libxml",
+  libxmlsax: "cannot load such file -- libxml",
   nokogiri: () => import("./xml-mini/nokogiri.js"),
   nokogirisax: () => import("./xml-mini/nokogirisax.js"),
   rexml: () => import("./xml-mini/rexml.js"),
@@ -745,13 +746,13 @@ export async function castBackendNameToModule(name: XmlMiniBackendName): Promise
   } else {
     const backend = XML_MINI_BACKENDS[name.toLowerCase()];
     if (typeof backend === "function") return (await backend()) as XmlMiniBackend;
-    // Ruby's counterpart is the core `LoadError` that
-    // `require "active_support/xml_mini/#{name.downcase}"` raises for a name
-    // with no file — or, for a backend whose gem is missing, for the gem it
-    // requires; there is no Rails error class to port here, the same reason
-    // `yaml.ts:16` gives for its own LoadError stand-in.
+    // Ruby's counterpart is the core `LoadError` / `RuntimeError` the file's own
+    // `require` or guard raises; there is no Rails error class to port here, the
+    // same reason `yaml.ts:16` gives for its own LoadError stand-in.
     // eslint-disable-next-line blazetrails/rails-error-parity
-    throw new Error(`cannot load such file -- active_support/xml_mini/${name.toLowerCase()}`);
+    throw new Error(
+      backend ?? `cannot load such file -- active_support/xml_mini/${name.toLowerCase()}`,
+    );
   }
 }
 

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -2342,8 +2342,7 @@ describe("Date#inspect", () => {
       "#<DateTime: 2001-02-03T00:00:00+00:00 ((2451944j,0s,0n),+0s,2299161j)>",
     );
 
-    // esbuild renames a class binding when it collides, which rewrites
-    // `constructor.name` but not a static string field.
+    // esbuild renames a colliding class binding, rewriting `constructor.name`.
     const renamed = Object.defineProperty(RubyDate, "name", {
       value: "Date2",
       configurable: true,

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -2355,4 +2355,15 @@ describe("Date#inspect", () => {
       Object.defineProperty(RubyDate, "name", { value: "Date", configurable: true });
     }
   });
+
+  it("names a subclass the way rb_obj_class(self) does", () => {
+    // ruby 3.3.11 -rdate:
+    //   class MyDate < Date; end
+    //   MyDate.new(2001,2,3).inspect
+    //     #=> "#<MyDate: 2001-02-03 ((2451944j,0s,0n),+0s,2299161j)>"
+    class MyDate extends RubyDate {}
+    expect(new MyDate(2001, 2, 3).inspect()).toBe(
+      "#<MyDate: 2001-02-03 ((2451944j,0s,0n),+0s,2299161j)>",
+    );
+  });
 });

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -2333,4 +2333,27 @@ describe("Date#inspect", () => {
       "#<Date: 2001-02-03 ((2451944j,0s,0n),+0s,2299161j)>",
     );
   });
+
+  it("names the class from a literal a class-renaming bundler cannot rewrite", () => {
+    // ruby 3.3.11 -rdate:
+    //   DateTime.new(2001,2,3).inspect
+    //     #=> "#<DateTime: 2001-02-03T00:00:00+00:00 ((2451944j,0s,0n),+0s,2299161j)>"
+    expect(new RubyDateTime(2001, 2, 3).inspect()).toBe(
+      "#<DateTime: 2001-02-03T00:00:00+00:00 ((2451944j,0s,0n),+0s,2299161j)>",
+    );
+
+    // esbuild renames a class binding when it collides, which rewrites
+    // `constructor.name` but not a static string field.
+    const renamed = Object.defineProperty(RubyDate, "name", {
+      value: "Date2",
+      configurable: true,
+    });
+    try {
+      expect(new renamed(2001, 2, 3).inspect()).toBe(
+        "#<Date: 2001-02-03 ((2451944j,0s,0n),+0s,2299161j)>",
+      );
+    } finally {
+      Object.defineProperty(RubyDate, "name", { value: "Date", configurable: true });
+    }
+  });
 });

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -5566,6 +5566,17 @@ function deconstructKeys(
 
 export class Date {
   /**
+   * The class name `rb_obj_class(self)` supplies to `mk_inspect`
+   * (`date_core.c:7032-7041`) and to the `rb_obj_classname` in
+   * `d_lite_initialize_copy`'s frozen check. Read through `this` so a subclass
+   * answers its own name, and spelled as a literal rather than
+   * `constructor.name` because `inspect`'s output is asserted byte-for-byte
+   * against MRI and quoted inside `FrozenError` messages, which a bundler that
+   * renames classes would corrupt.
+   */
+  static _railsClassName = "Date";
+
+  /**
    * Ruby `Date::Error` (ruby/date, `date_core.c` `Init_date_core`), raised by
    * `Date.parse` and a subclass of `ArgumentError`.
    */
@@ -6632,7 +6643,7 @@ export class Date {
   initializeCopy(date: Date): this {
     if (Object.isFrozen(this)) {
       throw new FrozenError(
-        `can't modify frozen ${(this as object).constructor.name}: ${this.inspect()}`,
+        `can't modify frozen ${(this.constructor as typeof Date)._railsClassName}: ${this.inspect()}`,
       );
     }
     if ((this as Date) === date) return this;
@@ -7471,7 +7482,7 @@ export class Date {
     const of = this.mOf();
     const sf = this.mSf();
     return (
-      `#<${this.constructor.name}: ${this.toS()} ` +
+      `#<${(this.constructor as typeof Date)._railsClassName}: ${this.toS()} ` +
       `((${this.mRealJd()}j,${this.mDf()}s,${sf.denominator === 1n ? sf.numerator : sf.inspect()}n),` +
       `${of < 0 ? "" : "+"}${of}s,${
         Number.isFinite(this.start) ? this.start.toFixed(0) : this.start > 0 ? "Inf" : "-Inf"
@@ -7596,6 +7607,9 @@ const DateWithoutParseStatics: (new (
  * `::Date`'s offset spelling rather than `::Time`'s `"UTC"`.
  */
 export class DateTime extends DateWithoutParseStatics {
+  /** `rb_obj_class(self)` for a `::DateTime`; see `Date._railsClassName`. */
+  static override _railsClassName = "DateTime";
+
   /**
    * @internal `ComplexDateData`'s fields (`date_core.c:215-231`): the day and
    * the day-fraction, both **in UTC**, and `of`, the offset in seconds east of
@@ -8581,7 +8595,7 @@ export class DateTime extends DateWithoutParseStatics {
   override initializeCopy(date: Date): this {
     if (Object.isFrozen(this)) {
       throw new FrozenError(
-        `can't modify frozen ${(this as object).constructor.name}: ${this.inspect()}`,
+        `can't modify frozen ${(this.constructor as typeof Date)._railsClassName}: ${this.inspect()}`,
       );
     }
     if ((this as Date) === date) return this;

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -54,6 +54,17 @@ const ABBR_MONTH_NAMES = [
   "Dec",
 ];
 
+/**
+ * `rb_obj_class(self)`'s name (`date_core.c:7028`): the class's own
+ * `_railsClassName` literal, which pins `Date` and `DateTime` against a
+ * class-renaming bundler, falling back to the runtime name for a subclass that
+ * declares none — MRI inspects `class MyDate < Date; end` as `#<MyDate: ...>`.
+ */
+function objClassName(obj: object): string {
+  const klass = obj.constructor as typeof Date;
+  return Object.hasOwn(klass, "_railsClassName") ? klass._railsClassName : klass.name;
+}
+
 function pad2(n: number): string {
   return String(n).padStart(2, "0");
 }
@@ -5566,13 +5577,12 @@ function deconstructKeys(
 
 export class Date {
   /**
-   * The class name `rb_obj_class(self)` supplies to `mk_inspect`
-   * (`date_core.c:7032-7041`) and to the `rb_obj_classname` in
-   * `d_lite_initialize_copy`'s frozen check. Read through `this` so a subclass
-   * answers its own name, and spelled as a literal rather than
+   * The name `rb_obj_class(self)` answers for this class itself
+   * (`date_core.c:7028`), spelled as a literal rather than read off
    * `constructor.name` because `inspect`'s output is asserted byte-for-byte
    * against MRI and quoted inside `FrozenError` messages, which a bundler that
-   * renames classes would corrupt.
+   * renames classes would corrupt. Only a class that declares its own is read
+   * — see {@link objClassName}.
    */
   static _railsClassName = "Date";
 
@@ -6642,9 +6652,7 @@ export class Date {
    */
   initializeCopy(date: Date): this {
     if (Object.isFrozen(this)) {
-      throw new FrozenError(
-        `can't modify frozen ${(this.constructor as typeof Date)._railsClassName}: ${this.inspect()}`,
-      );
+      throw new FrozenError(`can't modify frozen ${objClassName(this)}: ${this.inspect()}`);
     }
     if ((this as Date) === date) return this;
     const bdat = date.dat();
@@ -7482,7 +7490,7 @@ export class Date {
     const of = this.mOf();
     const sf = this.mSf();
     return (
-      `#<${(this.constructor as typeof Date)._railsClassName}: ${this.toS()} ` +
+      `#<${objClassName(this)}: ${this.toS()} ` +
       `((${this.mRealJd()}j,${this.mDf()}s,${sf.denominator === 1n ? sf.numerator : sf.inspect()}n),` +
       `${of < 0 ? "" : "+"}${of}s,${
         Number.isFinite(this.start) ? this.start.toFixed(0) : this.start > 0 ? "Inf" : "-Inf"
@@ -8594,9 +8602,7 @@ export class DateTime extends DateWithoutParseStatics {
    */
   override initializeCopy(date: Date): this {
     if (Object.isFrozen(this)) {
-      throw new FrozenError(
-        `can't modify frozen ${(this.constructor as typeof Date)._railsClassName}: ${this.inspect()}`,
-      );
+      throw new FrozenError(`can't modify frozen ${objClassName(this)}: ${this.inspect()}`);
     }
     if ((this as Date) === date) return this;
     const bdat = date.dat();


### PR DESCRIPTION
Five small fidelity convergences, one per bundled story.

**fixtures / `has_encrypted_attributes?`** — `fixtures.ts:1260` re-spelled
`has_encrypted_attributes?`'s body as `.size > 0`
(`encryptable_record.rb:204-206`). It now reads the set the way
`encrypted_fixtures.rb:15` does, through the `present?` analogue. `isBlank`
grew Ruby's `respond_to?(:empty?)` arm for `Set`/`Map`, which `Object.keys`
reported as always-empty.

**grouped calculation key records** — the association arm branched on
`primaryKey.length`; Rails writes one
`where(primary_key => key_ids)` (`calculations.rb:562-563`). The trails
spelling of Ruby's Array-key hash is `where(cols, tuples)`, which already
collapses a one-column key to `IN (...)` like
`predicate_builder.rb:87-90`, so the branch is gone.

**`Minitest::BacktraceFilter`** — ported as the class minitest has
(`minitest.rb:1173-1199`) with `MT_RE`, `regexp` and `filter`, plus the
`Minitest.backtraceFilter` accessor `filter_backtrace` reads
(`minitest.rb:43`, `:365-369`, `:1204`), replacing three closed-over free
functions that nothing could swap. The vitest/node frame pattern now rides on
the class's default `regexp`.

**`Date#inspect`** — `this.constructor.name` is a runtime class-name read that a
renaming bundler rewrites, and the string is asserted byte-for-byte against MRI
and quoted inside `FrozenError` messages. Both sites now read a static
`_railsClassName` literal through `this`, so `DateTime` still answers its own
name the way `rb_obj_class(self)` does (`date_core.c:7032-7041`).

**XmlMini backends** — `cast_backend_name_to_module` is a `require` into a
directory (`xml_mini.rb:200-206`), so its reachable set is the six files Rails
ships. They are now listed in one table: three loaders, and for `jdom` /
`libxml` / `libxmlsax` the reason trails does not carry them (JRuby-only;
libxml-ruby native binding). A test globs `xml-mini/*.ts` and resolves each,
so adding a backend file without an entry fails rather than passing silently.
`jdom-engine.test.ts` stays skipped.

Closes-story: converge-fixtures-encrypted-attributes-present
Closes-story: grouped-calc-key-records-single-where
Closes-story: port-minitest-backtrace-filter-class
Closes-story: date-inspect-class-name-survives-bundler-rename
Closes-story: xml-mini-backends-limited-to-three-ported-files
