### PR TITLE
refactor(activerecord): key adapter-scoped types on Rails' :mysql2

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.test.ts
@@ -384,7 +384,7 @@ describe("per-adapter visitor isolation", () => {
       return "MySQL" as const;
     }
     override get adapterName() {
-      return "mysql" as const;
+      return "mysql2" as const;
     }
     override arelVisitor() {
       return new Visitors.MySQL(this);

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -136,7 +136,7 @@ import { DecimalWithoutScale } from "../type/decimal-without-scale.js";
  * Mirrors: the three families Rails branches on throughout
  * ActiveRecord (sqlite3, postgresql, mysql2).
  */
-export type AdapterName = "sqlite" | "postgres" | "mysql";
+export type AdapterName = "sqlite" | "postgres" | "mysql2";
 
 /**
  * Map a database.yml `adapter:` config string to the normalized `AdapterName` family.
@@ -152,7 +152,7 @@ export function adapterNameFromConfig(configAdapter: string | undefined): Adapte
     case "mysql":
     case "mysql2":
     case "mariadb":
-      return "mysql";
+      return "mysql2";
     default:
       return "sqlite";
   }
@@ -1300,7 +1300,7 @@ export class AbstractAdapter implements Quoting {
   // which is NOT a member of the normalized `AdapterName` family). The deleted
   // `DatabaseAdapter` interface typed this `AdapterName`; rather than force that
   // infidelitous narrow type onto the base, concrete adapters already override
-  // the getter to return `AdapterName` (sqlite3/postgresql/mysql), and the few
+  // the getter to return `AdapterName` (sqlite3/postgresql/mysql2), and the few
   // downstream sites that need the narrow family narrow/guard at the call site.
   get adapterName(): string {
     return "Abstract";

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -249,7 +249,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   protected _statementLimit = 1000;
 
   get adapterName(): AdapterName {
-    return "mysql";
+    return "mysql2";
   }
 
   // Rails maps MySQL::SchemaStatements#table_alias_length (256, not the

--- a/packages/activerecord/src/connection-adapters/abstract/native-database-types.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/native-database-types.ts
@@ -111,10 +111,10 @@ export function postgresqlNativeDatabaseTypes(
 }
 
 export const NATIVE_DATABASE_TYPES_BY_ADAPTER: Record<
-  "sqlite" | "postgres" | "mysql",
+  "sqlite" | "postgres" | "mysql2",
   NativeDatabaseTypes
 > = {
   sqlite: SQLITE3_NATIVE_DATABASE_TYPES,
   postgres: POSTGRESQL_NATIVE_DATABASE_TYPES,
-  mysql: MYSQL_NATIVE_DATABASE_TYPES,
+  mysql2: MYSQL_NATIVE_DATABASE_TYPES,
 };

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.test.ts
@@ -492,7 +492,7 @@ describe("Table#aliasedTypes", () => {
 
 describe("TableDefinition id hash form", () => {
   it("extracts type and merges remaining keys as pk column options", () => {
-    const td = new TableDefinition("t", { adapterName: "mysql", adapter: conn });
+    const td = new TableDefinition("t", { adapterName: "mysql2", adapter: conn });
     td.setPrimaryKey("t", { type: "string", collation: "utf8mb4_bin" });
     const id = td.columns.find((c) => c.name === "id")!;
     expect(id.type).toBe("string");
@@ -501,7 +501,7 @@ describe("TableDefinition id hash form", () => {
   });
 
   it("defaults type to primary_key when hash omits type", () => {
-    const td = new TableDefinition("t", { adapterName: "mysql", adapter: conn });
+    const td = new TableDefinition("t", { adapterName: "mysql2", adapter: conn });
     td.setPrimaryKey("t", { collation: "utf8mb4_bin" });
     const id = td.columns.find((c) => c.name === "id")!;
     expect(id.type).toBe("primary_key");
@@ -509,7 +509,7 @@ describe("TableDefinition id hash form", () => {
   });
 
   it("outer default is merged first, hash content overrides", () => {
-    const td = new TableDefinition("t", { adapterName: "mysql", adapter: conn });
+    const td = new TableDefinition("t", { adapterName: "mysql2", adapter: conn });
     td.setPrimaryKey("t", { type: "string", default: "generated" }, undefined, {
       default: "outer",
     });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1003,13 +1003,13 @@ export class TableDefinition {
   readonly options?: string;
   readonly comment?: string;
   private _primaryKeys?: PrimaryKeyDefinition;
-  private _adapterName: "sqlite" | "postgres" | "mysql";
+  private _adapterName: "sqlite" | "postgres" | "mysql2";
   protected _adapter: TableDefinitionConn;
 
   constructor(
     name: string,
     tdOptions: {
-      adapterName?: "sqlite" | "postgres" | "mysql";
+      adapterName?: "sqlite" | "postgres" | "mysql2";
       adapter: TableDefinitionConn;
       temporary?: boolean;
       ifNotExists?: boolean;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
@@ -55,7 +55,7 @@ class StubAdapter extends AbstractAdapter {
 class CapturingAdapter extends AbstractAdapter {
   lastSql = "";
   lastParams: unknown[] = [];
-  constructor(private readonly dialect: "sqlite" | "postgres" | "mysql") {
+  constructor(private readonly dialect: "sqlite" | "postgres" | "mysql2") {
     super();
   }
   get adapterName() {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -559,7 +559,7 @@ export class SchemaStatements {
     // then drops by that real name — never a silent DROP ... IF EXISTS.
     const indexName = await this.indexNameForRemove(tableName, columnName, options);
 
-    if (this.adapterName === "mysql") {
+    if (this.adapterName === "mysql2") {
       await this.execute(
         `DROP INDEX ${this.quoteColumnName(indexName)} ON ${this.quoteColumnName(tableName)}`,
       );
@@ -578,7 +578,7 @@ export class SchemaStatements {
     const table = this.quoteColumnName(tableName);
     const col = this.quoteColumnName(columnName);
 
-    if (this.adapterName === "mysql") {
+    if (this.adapterName === "mysql2") {
       const nullable = options.null === false ? " NOT NULL" : "";
       const defaultClause =
         options.default === undefined
@@ -1120,7 +1120,7 @@ export class SchemaStatements {
           });
         });
       }
-      case "mysql": {
+      case "mysql2": {
         const rows = await this.schemaQuery(
           `SELECT column_name, column_key, data_type, character_maximum_length, numeric_precision, numeric_scale, is_nullable, column_default FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = ? ORDER BY ordinal_position`,
           [tableName],
@@ -1227,7 +1227,7 @@ export class SchemaStatements {
           });
         });
       }
-      case "mysql": {
+      case "mysql2": {
         const rows = await this.schemaQuery(
           `SHOW INDEX FROM ${this.quoteTableName(tableName)} WHERE Key_name != 'PRIMARY'`,
         );
@@ -1282,7 +1282,7 @@ export class SchemaStatements {
         );
         return rows.length > 0 ? (rows[0] as any).attname : null;
       }
-      case "mysql": {
+      case "mysql2": {
         const rows = await this.schemaQuery(
           `SHOW KEYS FROM \`${tableName}\` WHERE Key_name = 'PRIMARY'`,
         );

--- a/packages/activerecord/src/connection-adapters/adapter-scoped-string-registration.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/adapter-scoped-string-registration.trails.test.ts
@@ -2,7 +2,7 @@
  * trails-only: importing the mysql2 adapter registers the adapter-scoped
  * `:string`/`:immutable_string`/`:unsigned_integer` cast types via
  * `Type.register(name, adapter: :mysql2)` (mysql2_adapter.rb:190-198), keyed by
- * the normalized `AdapterName` family (`"mysql"`) that `Type.lookup` defaults
+ * the normalized `AdapterName` family (`"mysql2"`) that `Type.lookup` defaults
  * to under a mysql2 configuration. These assert the registrations resolve
  * through that lookup — the path `Mysql2Adapter.initializeTypeMap` uses for
  * char/varchar/enum/set — without a live MySQL connection. Rails covers the
@@ -10,14 +10,14 @@
  */
 import { it, expect } from "vitest";
 // Side-effect import: loading the concrete adapter runs its module-level
-// `Type.register(..., adapter: "mysql")` calls.
+// `Type.register(..., adapter: "mysql2")` calls.
 import "./mysql2-adapter.js";
 import { StringType, ImmutableStringType as ImmutableString } from "@blazetrails/activemodel";
 import { lookup } from "../type.js";
 import { UnsignedInteger } from "../type/unsigned-integer.js";
 
 it("mysql2 :string coerces booleans to 1/0 and threads limit", () => {
-  const type = lookup("string", { adapter: "mysql", limit: 255 }) as StringType;
+  const type = lookup("string", { adapter: "mysql2", limit: 255 }) as StringType;
   expect(type).toBeInstanceOf(StringType);
   expect(type.limit).toBe(255);
   expect(type.trueString).toBe("1");
@@ -25,13 +25,13 @@ it("mysql2 :string coerces booleans to 1/0 and threads limit", () => {
 });
 
 it("mysql2 :immutable_string coerces booleans to 1/0", () => {
-  const type = lookup("immutable_string", { adapter: "mysql" }) as ImmutableString;
+  const type = lookup("immutable_string", { adapter: "mysql2" }) as ImmutableString;
   expect(type).toBeInstanceOf(ImmutableString);
   expect(type.trueString).toBe("1");
   expect(type.falseString).toBe("0");
 });
 
 it("mysql2 :unsigned_integer resolves to UnsignedInteger", () => {
-  const type = lookup("unsigned_integer", { adapter: "mysql" });
+  const type = lookup("unsigned_integer", { adapter: "mysql2" });
   expect(type).toBeInstanceOf(UnsignedInteger);
 });

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.test.ts
@@ -135,7 +135,7 @@ describeIfMysqlAdapter("MySQL::SchemaCreation", () => {
   });
 
   it("addTableOptionsBang appends charset and collation", async () => {
-    const td = new TableDefinition("users", { adapter: mysqlConn(), adapterName: "mysql" });
+    const td = new TableDefinition("users", { adapter: mysqlConn(), adapterName: "mysql2" });
     (td as any).charset = "utf8mb4";
     (td as any).collation = "utf8mb4_unicode_ci";
     const result = (sc as any).addTableOptionsBang("CREATE TABLE `users` ()", td);

--- a/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
@@ -83,13 +83,13 @@ export class TableDefinition extends AbstractTableDefinition {
       options?: string;
       comment?: string;
       adapter: VisitorHostAdapter;
-      adapterName?: "sqlite" | "postgres" | "mysql";
+      adapterName?: "sqlite" | "postgres" | "mysql2";
     },
   ) {
     const { adapter, adapterName: _ignoredAdapterName, charset, collation, ...rest } = options;
     super(tableName, {
       ...rest,
-      adapterName: "mysql",
+      adapterName: "mysql2",
       adapter,
     });
     this.charset = charset ?? undefined;

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.trails.test.ts
@@ -5,7 +5,7 @@ import { Table as MysqlTable } from "./schema-definitions.js";
 describe("MysqlSchemaStatements#changeTable", () => {
   it("yields the MySQL Table subclass", async () => {
     const ss = Object.setPrototypeOf(
-      { adapterName: "mysql" },
+      { adapterName: "mysql2" },
       MysqlSchemaStatements.prototype,
     ) as MysqlSchemaStatements;
     let yielded: unknown;

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -121,10 +121,10 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     super.initializeTypeMap(m);
     m.registerType(/char/i, undefined, (sqlType) => {
       const limit = this.extractLimit(sqlType);
-      return Type.lookup("string", { adapter: "mysql", limit });
+      return Type.lookup("string", { adapter: "mysql2", limit });
     });
-    m.registerType(/^enum/i, Type.lookup("string", { adapter: "mysql" }));
-    m.registerType(/^set/i, Type.lookup("string", { adapter: "mysql" }));
+    m.registerType(/^enum/i, Type.lookup("string", { adapter: "mysql2" }));
+    m.registerType(/^set/i, Type.lookup("string", { adapter: "mysql2" }));
   }
 
   // Mirrors Rails' Mysql2Adapter#active? (mysql2_adapter.rb:108), whose body is
@@ -2071,18 +2071,18 @@ Mysql2Adapter.prototype.performQuery = mysql2PerformQuery;
 // (not the ActiveModel default `"t"`/`"f"`) so a boolean assigned to a string
 // column round-trips as 1/0; `initializeTypeMap` resolves char/varchar/enum/set
 // through `Type.lookup(:string, adapter: :mysql2)`.
-Type.register("immutable_string", null, { adapter: "mysql" }, (_symbol, args?) => {
+Type.register("immutable_string", null, { adapter: "mysql2" }, (_symbol, args?) => {
   return new ImmutableStringType({
     trueString: "1",
     falseString: "0",
     ...((args as Record<string, unknown>) ?? {}),
   });
 });
-Type.register("string", null, { adapter: "mysql" }, (_symbol, args?) => {
+Type.register("string", null, { adapter: "mysql2" }, (_symbol, args?) => {
   return new StringType({
     trueString: "1",
     falseString: "0",
     ...((args as Record<string, unknown>) ?? {}),
   });
 });
-Type.register("unsigned_integer", UnsignedInteger, { adapter: "mysql" });
+Type.register("unsigned_integer", UnsignedInteger, { adapter: "mysql2" });

--- a/packages/activerecord/src/connection-pool.trails.test.ts
+++ b/packages/activerecord/src/connection-pool.trails.test.ts
@@ -833,9 +833,9 @@ describe("adapterNameFromConfig", () => {
   });
 
   it("maps mysql variants to mysql", async () => {
-    expect(adapterNameFromConfig("mysql2")).toBe("mysql");
-    expect(adapterNameFromConfig("mysql")).toBe("mysql");
-    expect(adapterNameFromConfig("mariadb")).toBe("mysql");
+    expect(adapterNameFromConfig("mysql2")).toBe("mysql2");
+    expect(adapterNameFromConfig("mysql")).toBe("mysql2");
+    expect(adapterNameFromConfig("mariadb")).toBe("mysql2");
   });
 
   it("maps sqlite variants to sqlite", async () => {

--- a/packages/activerecord/src/connection-pool.trails.test.ts
+++ b/packages/activerecord/src/connection-pool.trails.test.ts
@@ -1156,7 +1156,7 @@ describe("checkout/checkin callbacks", () => {
     const pool = makeAmbientPool({ pool: 1 });
     try {
       await pool.checkout();
-      expect(calls).toEqual([adapterType]);
+      expect(calls).toEqual([adapterNameFromConfig(adapterType)]);
     } finally {
       await closePoolConnections(pool);
       // Drop the test-registered callback so it can't leak into sibling tests.

--- a/packages/activerecord/src/fixtures.ts
+++ b/packages/activerecord/src/fixtures.ts
@@ -293,15 +293,15 @@ export function resolveCompositeRefColumn(
 }
 
 /**
- * Returns the adapter's normalized name (`"postgres"` / `"mysql"` / `"sqlite"`).
+ * Returns the adapter's normalized name (`"postgres"` / `"mysql2"` / `"sqlite"`).
  * Lets ERB-style adapter-conditional fixture data translate to TS:
  *
  * ```ts
  * { data: adapterName(adapter) === "postgres" ? a : b }
  * ```
  */
-export function adapterName(adapter: DatabaseAdapter): "postgres" | "mysql" | "sqlite" {
-  return adapter.adapterName as "postgres" | "mysql" | "sqlite";
+export function adapterName(adapter: DatabaseAdapter): "postgres" | "mysql2" | "sqlite" {
+  return adapter.adapterName as "postgres" | "mysql2" | "sqlite";
 }
 
 // --- Phase 1b: tableName → ModelClass registry (scoped per adapter) ---

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -665,7 +665,7 @@ export class Builder implements InsertBuilder {
       if (this._insertAll.inserts.length > 1) {
         throw new Error("Bulk insert with no explicit columns is not supported");
       }
-      if (this._dialect === "mysql") {
+      if (this._dialect === "mysql2") {
         return `INTO ${tableName} () VALUES ()`;
       }
       return `INTO ${tableName} DEFAULT VALUES`;
@@ -778,7 +778,7 @@ export class Builder implements InsertBuilder {
     const v = this._insertAll.connection.visitor;
     if (v) return v;
     const q = this._insertAll.connection as unknown as Visitors.ArelConnection;
-    if (this._dialect === "mysql") return new Visitors.MySQL(q);
+    if (this._dialect === "mysql2") return new Visitors.MySQL(q);
     if (this._dialect === "postgres") return new Visitors.PostgreSQL(q);
     return new Visitors.SQLite(q);
   }

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -30,7 +30,7 @@ function emitTableSql(td: TableDefinition): Promise<string> {
   // the `supports*` / isMariadb() flags), so thread the table definition's through —
   // matching the real adapter call sites and the production `*.toSql()` overrides.
   if (adapterName === "postgres") return new PgSchemaCreation(adapter).accept(td);
-  if (adapterName === "mysql") return new MysqlSchemaCreation(adapter).accept(td);
+  if (adapterName === "mysql2") return new MysqlSchemaCreation(adapter).accept(td);
   return new SQLite3SchemaCreation(adapter).accept(td);
 }
 import { Person } from "./test-helpers/models/person.js";

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -405,8 +405,8 @@ export class Migration {
   private static _disableDdlTransaction = false;
 
   /** Return the normalized adapter name from the configured adapter. */
-  protected get _adapterName(): "sqlite" | "postgres" | "mysql" {
-    return this.connection.adapterName as "sqlite" | "postgres" | "mysql";
+  protected get _adapterName(): "sqlite" | "postgres" | "mysql2" {
+    return this.connection.adapterName as "sqlite" | "postgres" | "mysql2";
   }
 
   /**

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -461,7 +461,7 @@ function sqlTypeFor(typeName: string, adapterName?: string): string {
         return "varchar";
     }
   }
-  if (adapterName === "mysql") {
+  if (adapterName === "mysql2") {
     switch (typeName) {
       case "integer":
         return "int";
@@ -518,7 +518,7 @@ export async function createTable(this: typeof Base): Promise<void> {
   const table = resolveTableName.call(this);
   const pks = Array.isArray(this.primaryKey) ? this.primaryKey : [this.primaryKey];
   const adapterName = this.connection.adapterName;
-  const isMysql = adapterName === "mysql";
+  const isMysql = adapterName === "mysql2";
   const isPg = adapterName === "postgres";
   const pkSet = new Set(pks);
   const a = this.connection;

--- a/packages/activerecord/src/relation/select.test.ts
+++ b/packages/activerecord/src/relation/select.test.ts
@@ -243,7 +243,7 @@ describe("SelectTest", () => {
     // the bare `Number(...)` coercion above would otherwise mask (the raw mysql2
     // driver string "1.1" also numeric-equals 1.1).
     const adapterName = (Post.connection as unknown as { adapterName: string }).adapterName;
-    const expectsBigDecimal = adapterName === "postgres" || adapterName === "mysql";
+    const expectsBigDecimal = adapterName === "postgres" || adapterName === "mysql2";
     expect(foo instanceof BigDecimal).toBe(expectsBigDecimal);
   });
 

--- a/packages/activerecord/src/support/canonical-schema.ts
+++ b/packages/activerecord/src/support/canonical-schema.ts
@@ -116,7 +116,7 @@ class TableBuilder {
     // MySQL DATETIME without precision = DATETIME(0); upgrade to DATETIME(6)
     // unless an explicit precision (incl. null) opted out.
     if (
-      this.adapterName === "mysql" &&
+      this.adapterName === "mysql2" &&
       primitive === "datetime" &&
       options["precision"] === undefined
     ) {
@@ -273,7 +273,7 @@ export async function prepareSchema(
   const typeMap =
     adapter.adapterName === "postgres"
       ? COLUMN_TYPE_MAP_PG
-      : adapter.adapterName === "mysql"
+      : adapter.adapterName === "mysql2"
         ? COLUMN_TYPE_MAP_MYSQL
         : COLUMN_TYPE_MAP_SQLITE;
   return { ss, typeMap };
@@ -766,7 +766,7 @@ export async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
     // schema.rb:426 — MySQL-only functional index (current_adapter?(:Mysql2, :Trilogy)).
     t.index("(CONCAT_WS(`firm_name`, `name`, _utf8mb4' '))", {
       name: "full_name_index",
-      adapters: ["mysql"],
+      adapters: ["mysql2"],
     });
   });
 

--- a/packages/activerecord/src/support/canonical-table-rebuild.test.ts
+++ b/packages/activerecord/src/support/canonical-table-rebuild.test.ts
@@ -284,7 +284,7 @@ describe("bulkInboundFkHost", () => {
       name: "fk_rails_13f362e4f5",
     };
     // MySQL's key_column_usage reports one row per constrained column.
-    const { adapter } = fakeAdapter("mysql", [row, { ...row }]);
+    const { adapter } = fakeAdapter("mysql2", [row, { ...row }]);
     const blockers = await bulkInboundFkHost(adapter, base).foreignKeysReferencing!(["authors"]);
     expect(blockers).toEqual([
       { fromTable: "lessons_students", toTable: "authors", name: "fk_rails_13f362e4f5" },
@@ -292,7 +292,7 @@ describe("bulkInboundFkHost", () => {
   });
 
   test("skips the catalog query when nothing is being dropped", async () => {
-    const { adapter, queries } = fakeAdapter("mysql");
+    const { adapter, queries } = fakeAdapter("mysql2");
     expect(await bulkInboundFkHost(adapter, base).foreignKeysReferencing!([])).toEqual([]);
     expect(queries).toEqual([]);
   });

--- a/packages/activerecord/src/support/canonical-table-rebuild.ts
+++ b/packages/activerecord/src/support/canonical-table-rebuild.ts
@@ -194,7 +194,7 @@ export function bulkInboundFkHost(
   ss: FkSafeDropPlanHost,
 ): FkSafeDropPlanHost {
   const name = adapter.adapterName;
-  if (name !== "postgres" && name !== "mysql") return ss;
+  if (name !== "postgres" && name !== "mysql2") return ss;
   const foreignKeysReferencing = async (
     toTables: readonly string[],
   ): Promise<readonly FkDropBlocker[]> => {

--- a/packages/activerecord/src/support/drop-all-tables.test.ts
+++ b/packages/activerecord/src/support/drop-all-tables.test.ts
@@ -173,7 +173,7 @@ describe("dropAllTables", () => {
   });
 
   it("drops 3-table FK chain without error", async () => {
-    const int = dropAdapter.adapterName === "mysql" ? "INT" : "INTEGER";
+    const int = dropAdapter.adapterName === "mysql2" ? "INT" : "INTEGER";
     await dropAdapter.executeMutation(`CREATE TABLE fk_parent (id ${int} PRIMARY KEY)`);
     await dropAdapter.executeMutation(
       `CREATE TABLE fk_child (id ${int} PRIMARY KEY, parent_id ${int}, FOREIGN KEY (parent_id) REFERENCES fk_parent(id))`,

--- a/packages/activerecord/src/support/drop-all-tables.ts
+++ b/packages/activerecord/src/support/drop-all-tables.ts
@@ -165,7 +165,7 @@ async function resetTables(
     case "postgres":
       await resetPgTables(adapter, mode, bootLaid);
       break;
-    case "mysql":
+    case "mysql2":
       await resetMysqlTables(adapter, mode, bootLaid);
       break;
     case "sqlite":

--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -489,7 +489,7 @@ async function loadSqliteSpecificSchema(adapter: DatabaseAdapter): Promise<void>
  */
 const ADAPTER_SPECIFIC_SCHEMAS: Record<string, (adapter: DatabaseAdapter) => Promise<void>> = {
   postgres: (adapter) => loadPostgresqlSpecificSchema(adapter as unknown as PostgreSQLAdapter),
-  mysql: (adapter) => loadMysql2SpecificSchema(adapter as unknown as AbstractMysqlAdapter),
+  mysql2: (adapter) => loadMysql2SpecificSchema(adapter as unknown as AbstractMysqlAdapter),
   sqlite: loadSqliteSpecificSchema,
 };
 

--- a/packages/activerecord/src/support/schema-file-generator.test.ts
+++ b/packages/activerecord/src/support/schema-file-generator.test.ts
@@ -136,7 +136,7 @@ describe("generateSchemaFile (MySQL adapter)", () => {
   let filePath: string;
 
   beforeAll(async () => {
-    filePath = await generateSchemaFile(MYSQL_SCHEMA, "mysql");
+    filePath = await generateSchemaFile(MYSQL_SCHEMA, "mysql2");
     const fs = await getFsAsync();
     content = fs.readFileSync(filePath, "utf-8");
   });
@@ -244,7 +244,7 @@ describe("generateSchemaFile single-column integer PK id type per adapter", () =
   });
 
   it("uses integer (INT auto-increment) on mysql, not bigint", async () => {
-    const filePath = await generateSchemaFile(SCHEMA, "mysql");
+    const filePath = await generateSchemaFile(SCHEMA, "mysql2");
     const fs = await getFsAsync();
     const content = fs.readFileSync(filePath, "utf-8");
     expect(content).toContain('"gadget_id", "integer", { primaryKey: true }');
@@ -266,7 +266,7 @@ describe("generateSchemaFile single-column big_integer PK id type per adapter", 
   });
 
   it("uses bigint (BIGINT auto-increment) on mysql", async () => {
-    const filePath = await generateSchemaFile(SCHEMA, "mysql");
+    const filePath = await generateSchemaFile(SCHEMA, "mysql2");
     const fs = await getFsAsync();
     const content = fs.readFileSync(filePath, "utf-8");
     expect(content).toContain('"widget_id", "bigint", { primaryKey: true }');
@@ -328,7 +328,7 @@ describe("generateSchemaFile / define-schema.ts type-map parity", () => {
     map: Record<string, string>;
   }> = [
     { adapter: "postgres", map: COLUMN_TYPE_MAP_PG },
-    { adapter: "mysql", map: COLUMN_TYPE_MAP_MYSQL },
+    { adapter: "mysql2", map: COLUMN_TYPE_MAP_MYSQL },
     { adapter: "sqlite", map: COLUMN_TYPE_MAP_SQLITE },
   ];
 
@@ -347,14 +347,16 @@ describe("generateSchemaFile / define-schema.ts type-map parity", () => {
   // The exact #4461 regression, pinned: the generator's stale map remapped
   // date/time/json → string on MySQL, so these must stay native, not VARCHAR.
   it("emits native date/time/json (not string) on MySQL — the PR #4461 regression", async () => {
-    const emitted = emittedTypes(await readGenerated(schemaFor(["date", "time", "json"]), "mysql"));
+    const emitted = emittedTypes(
+      await readGenerated(schemaFor(["date", "time", "json"]), "mysql2"),
+    );
     expect(emitted["c_date"]).toBe("date");
     expect(emitted["c_time"]).toBe("time");
     expect(emitted["c_json"]).toBe("json");
   });
 
   it("injects precision:6 on MySQL bare datetime columns (mirrors define-schema.ts)", async () => {
-    const content = await readGenerated({ parity_probe: { at: "datetime" } }, "mysql");
+    const content = await readGenerated({ parity_probe: { at: "datetime" } }, "mysql2");
     expect(content).toContain('t.column("at", "datetime", { precision: 6 })');
   });
 
@@ -366,7 +368,7 @@ describe("generateSchemaFile / define-schema.ts type-map parity", () => {
   });
 
   it("emits serial-PK width matching serialIdType for every adapter", async () => {
-    for (const adapter of ["postgres", "mysql", "sqlite"]) {
+    for (const adapter of ["postgres", "mysql2", "sqlite"]) {
       for (const type of ["integer", "big_integer"] as PrimitiveColumnSpec[]) {
         const schema: Schema = {
           parity_probe: { columns: { pk: type }, primaryKey: ["pk"] },
@@ -499,7 +501,7 @@ const PARITY_INDEXES: Parameters<typeof emitTableIndexes>[3] = [
   { columns: "(lower(external_id))", opts: {} },
   // Adapter-restricted index (schema.rb's inline current_adapter? gate, e.g.
   // the MySQL-only full_name_index) — both emitters must apply the same skip.
-  { columns: "body", opts: { name: "idx_probe_mysql_only", adapters: ["mysql"] } },
+  { columns: "body", opts: { name: "idx_probe_mysql_only", adapters: ["mysql2"] } },
 ];
 const PARITY_EXPRESSION_INDEX = "(lower(external_id))";
 const GENERATOR_INDEXES: IndexSpec[] = PARITY_INDEXES.map((i) => ({
@@ -543,8 +545,8 @@ describe("generateSchemaFile / canonical-schema.ts index-gating parity", () => {
   // in lockstep. (The MySQL-8 divergence is the tracked residual below.)
   it("emits the same addIndex calls as canonical-schema.ts on mysql (MariaDB, no expression index)", async () => {
     const [gen, canon] = await Promise.all([
-      generatorIndexes(GENERATOR_SCHEMA, "mysql"),
-      canonicalIndexes(PARITY_INDEXES, "mysql", false),
+      generatorIndexes(GENERATOR_SCHEMA, "mysql2"),
+      canonicalIndexes(PARITY_INDEXES, "mysql2", false),
     ]);
     // Only the expression index is dropped (the adapters-gated MySQL-only
     // index survives here), so the rest come through — pin the count so the
@@ -574,7 +576,7 @@ describe("generateSchemaFile / canonical-schema.ts index-gating parity", () => {
 
   // Expression-index gating parity on MySQL 8. The generator now threads the
   // caller-resolved `supportsExpressionIndex` capability (MySQL >= 8.0.13,
-  // SQLite >= 3.9, never MariaDB) instead of the coarse `adapterName === "mysql"`
+  // SQLite >= 3.9, never MariaDB) instead of the coarse `adapterName === "mysql2"`
   // skip, so on a live MySQL 8 (supportsExpressionIndex true) it keeps the
   // expression index — matching canonical-schema.ts's `emitTableIndexes`, which
   // uses the same runtime check. (Previously the PR #4471 tracked residual: the
@@ -582,8 +584,8 @@ describe("generateSchemaFile / canonical-schema.ts index-gating parity", () => {
   // the capability flag from the caller into `generateSchemaFile`.)
   it("emits the same addIndex calls as canonical-schema.ts on mysql 8 (expression index kept)", async () => {
     const [gen, canonMysql8] = await Promise.all([
-      generatorIndexes(GENERATOR_SCHEMA, "mysql", true),
-      canonicalIndexes(PARITY_INDEXES, "mysql", true),
+      generatorIndexes(GENERATOR_SCHEMA, "mysql2", true),
+      canonicalIndexes(PARITY_INDEXES, "mysql2", true),
     ]);
     // All four indexes survive on MySQL 8 (expression kept). Pin the count so
     // the equality below can't pass vacuously.

--- a/packages/activerecord/src/support/schema-file-generator.ts
+++ b/packages/activerecord/src/support/schema-file-generator.ts
@@ -91,7 +91,7 @@ function colOpts(spec: ColumnSpec, primitive: string, adapterName?: string): str
   // Mirrors schema-types.ts: MySQL DATETIME without precision defaults to
   // DATETIME(0), which rejects fractional seconds. Inject precision:6 unless
   // the spec sets precision explicitly (even precision:null opts out).
-  if (adapterName === "mysql" && primitive === "datetime" && !hasPrecision) {
+  if (adapterName === "mysql2" && primitive === "datetime" && !hasPrecision) {
     parts.push(`precision: 6`);
   }
   return parts.length === 0 ? "{}" : `{ ${parts.join(", ")} }`;
@@ -120,7 +120,7 @@ function generateCode(
   // PG/MySQL: loadSchema runs on a shared database that other workers may already
   // have connected to, so we can't DROP DATABASE. Use force:"cascade" per-table
   // drop+recreate instead — safe for concurrent workers on a shared DB.
-  const needsForce = adapterName === "postgres" || adapterName === "mysql";
+  const needsForce = adapterName === "postgres" || adapterName === "mysql2";
 
   // A referencing table must go before the table it points at: PG/MySQL below
   // drop+recreate each table in declaration order, and a live child FK blocks
@@ -205,12 +205,12 @@ function generateCode(
       // threads in `supportsExpressionIndex` (resolved from the DB version) to
       // match `emitTableIndexes`' runtime `supportsExpressionIndex(adapter)`
       // check (MySQL >= 8.0.13, SQLite >= 3.9, never MariaDB). When the flag is
-      // omitted, fall back to the coarse `adapterName === "mysql"` skip — a
+      // omitted, fall back to the coarse `adapterName === "mysql2"` skip — a
       // last resort for a caller with no live connection. Live callers
       // (test-setup-dy.ts, template-global-setup.ts) must thread the flag, or
       // a MySQL-8 worker rebuild strips the canonical expression indexes.
       const dropExpression =
-        supportsExpressionIndex !== undefined ? !supportsExpressionIndex : adapterName === "mysql";
+        supportsExpressionIndex !== undefined ? !supportsExpressionIndex : adapterName === "mysql2";
       if (isExpression && dropExpression) continue;
       // schema.rb's inline current_adapter? gate (e.g. the MySQL-only
       // full_name_index) — mirrors emitTableIndexes' `opts.adapters` skip.
@@ -250,7 +250,7 @@ function generateCode(
  * Pass `supportsExpressionIndex` (resolved from the caller's live DB version)
  * to gate expression indexes with `supportsExpressionIndex` semantics
  * (MySQL >= 8.0.13, SQLite >= 3.9, never MariaDB) instead of the coarse
- * `adapterName === "mysql"` skip. Omitted for the PG-only template caller,
+ * `adapterName === "mysql2"` skip. Omitted for the PG-only template caller,
  * where PG always supports expression indexes.
  */
 export async function generateSchemaFile(

--- a/packages/activerecord/src/test-helpers/test-schema.ts
+++ b/packages/activerecord/src/test-helpers/test-schema.ts
@@ -568,7 +568,7 @@ export const TEST_SCHEMA: Schema = {
       {
         columns: "(CONCAT_WS(`firm_name`, `name`, _utf8mb4' '))",
         name: "full_name_index",
-        adapters: ["mysql"],
+        adapters: ["mysql2"],
       },
     ],
   },

--- a/packages/activerecord/src/type.trails.test.ts
+++ b/packages/activerecord/src/type.trails.test.ts
@@ -42,7 +42,7 @@ describe("Type.currentAdapterName", () => {
 
   it("normalizes the configured adapter to the registration namespace", () => {
     expect(adapterNameFrom(modelWith("postgresql"))).toBe("postgres");
-    expect(adapterNameFrom(modelWith("mysql2"))).toBe("mysql");
+    expect(adapterNameFrom(modelWith("mysql2"))).toBe("mysql2");
     expect(adapterNameFrom(modelWith("sqlite3"))).toBe("sqlite");
   });
 
@@ -98,7 +98,7 @@ describe("Type.lookup under a non-sqlite configuration", () => {
 
   it("picks the mysql registration for a mysql2 configuration", () => {
     register("foo", GenericType, { override: false });
-    register("foo", AdapterType, { adapter: "mysql" });
+    register("foo", AdapterType, { adapter: "mysql2" });
 
     stubAdapter("mysql2");
     expect(lookup("foo")).toBeInstanceOf(AdapterType);
@@ -131,7 +131,7 @@ describe("the PostgreSQL OID registrations", () => {
     expect(lookup("uuid", { adapter: "postgres" })).toBeInstanceOf(Uuid);
 
     expect(() => lookup("money", { adapter: "sqlite" })).toThrow("Unknown type :money");
-    expect(() => lookup("interval", { adapter: "mysql" })).toThrow("Unknown type :interval");
+    expect(() => lookup("interval", { adapter: "mysql2" })).toThrow("Unknown type :interval");
   });
 
   it("shadow the generic registrations of the same name under postgres", () => {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/mysql2-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/mysql2-adapter.json
@@ -9,30 +9,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/mysql2-adapter.ts",
-    "rubyName": "initialize_type_map",
-    "call": "lookup",
-    "kind": "args",
-    "rubyArgs": [
-      "str:string",
-      "kwargs{adapter=str:mysql2,limit=ref:limit}"
-    ],
-    "reason": "mysql2_adapter.rb:45-49 scopes these to `adapter: :mysql2`; trails' `adapterNameFromConfig` (abstract-adapter.ts:142-155) normalizes every MySQL config to `\"mysql\"`, so the registration and the lookup must move together — tracked by story `converge-mysql2-type-registration-adapter-key`."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql2-adapter.ts",
-    "rubyName": "initialize_type_map",
-    "call": "lookup",
-    "kind": "args",
-    "rubyArgs": [
-      "str:string",
-      "kwargs{adapter=str:mysql2}"
-    ],
-    "reason": "mysql2_adapter.rb:45-49 scopes these to `adapter: :mysql2`; trails' `adapterNameFromConfig` (abstract-adapter.ts:142-155) normalizes every MySQL config to `\"mysql\"`, so the registration and the lookup must move together — tracked by story `converge-mysql2-type-registration-adapter-key`."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql2-adapter.ts",
     "rubyName": "new_client",
     "call": "db_error",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Rails' `ActiveRecord::Type.adapter_name_from` is `db_config.adapter.to_sym`
(`type.rb:49-51`), so `Mysql2Adapter` both **registers** and **looks up** its
adapter-scoped `:string` / `:immutable_string` / `:unsigned_integer` types under
`:mysql2` (`mysql2_adapter.rb:45-49`, `:190-198`).

trails normalized every MySQL config string (`mysql` / `mysql2` / `mariadb`) to
`"mysql"` in `adapterNameFromConfig`, and spelled all six registration/lookup
sites `adapter: "mysql"` to match. Flipping only the two flagged lookups would
have broken the registry — the generic model-attribute path routes through
`adapterNameFrom` and would miss the mysql2-scoped `StringType` (the one that
coerces booleans to `"1"`/`"0"`), silently falling back to ActiveModel's
`"t"`/`"f"`. So the normalizer, the registrations and the lookups move together.

- `AdapterName`'s MySQL member is now Rails' `"mysql2"`; `adapterNameFromConfig`
  and `AbstractMysqlAdapter#adapterName` return it.
- Every `adapterName === "mysql"` / `case "mysql"` comparison on that family
  value in `packages/activerecord/src` is audited and updated: `insert-all.ts`,
  `abstract/schema-statements.ts`, `model-schema.ts`, `migration.ts`,
  `fixtures.ts`, `abstract/schema-definitions.ts`, `mysql/schema-definitions.ts`,
  `abstract/native-database-types.ts`, `support/{schema-file-generator,
  canonical-schema,canonical-table-rebuild,drop-all-tables,load-schema-helper}.ts`,
  `test-helpers/test-schema.ts` and the adapter-conditional test arms.
  Lane names (`adapterType`, `TestAdapterName`, `CONNECTION_LANES`) and
  config-string normalization (`normalizeAdapterName`, the adapter registry key)
  are a different concept and stay `"mysql"`.
- The two RFC 0095 `initialize_type_map` → `lookup` `kind: "args"` rows are
  deleted by hand from `call-mismatches-exclude/.../mysql2-adapter.json`
  (only-shrink; no reseed).

`pnpm parity:api:calls` and `pnpm parity:api:calls:args` both green.

Closes-story: converge-mysql2-type-registration-adapter-key
