### PR TITLE
refactor(activerecord): converge Scheme#toH onto Rails' five-key hash

### DIFF
--- a/packages/activerecord/src/encryption/config.trails.test.ts
+++ b/packages/activerecord/src/encryption/config.trails.test.ts
@@ -33,7 +33,7 @@ describe("ActiveRecord::Encryption::ConfigTest", () => {
 
     expect(() => {
       config.previous = [{ compressor, compress: false }];
-    }).toThrow("compressor can't be used with compress: false");
+    }).toThrow("compressor: can't be used with compress: false");
   });
 
   it("credential predicates treat a blank credential as absent", () => {

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -301,16 +301,8 @@ export class EncryptedAttributeType extends ValueType {
 
   /** @internal */
   private cleanTextScheme(): Scheme {
-    // Rails' clean_text_scheme passes `downcase: downcase?`, and Rails'
-    // `Scheme` sets `@downcase = downcase || ignore_case` internally so
-    // `downcase?` is true for either flag. Our Scheme keeps the flags
-    // separate, so fold `ignoreCase` into `downcase` here to mirror
-    // Rails' effective behavior. Without this, a scheme configured
-    // `ignoreCase: true, downcase: false` would produce a non-lower-
-    // casing clean-text fallback and miss normalized plaintext rows.
     return new Scheme({
-      deterministic: this.scheme.deterministic,
-      downcase: this.scheme.downcase || this.scheme.ignoreCase,
+      downcase: this.isDowncase,
       encryptor: new NullEncryptor(),
     });
   }

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -93,7 +93,7 @@ export class EncryptedAttributeType extends ValueType {
   }
 
   get deterministic(): boolean {
-    return this.scheme.deterministic ?? false;
+    return this.scheme.isDeterministic();
   }
 
   // Mirrors Rails' `delegate :key_provider, :downcase?, :previous_schemes,

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -103,7 +103,7 @@ export class EncryptedAttributeType extends ValueType {
   }
 
   get isDowncase(): boolean {
-    return this.scheme.downcase;
+    return this.scheme.downcase ?? false;
   }
 
   get previousSchemes(): Scheme[] {
@@ -119,7 +119,7 @@ export class EncryptedAttributeType extends ValueType {
   }
 
   get ignoreCase(): boolean {
-    return this.scheme.ignoreCase;
+    return this.scheme.ignoreCase ?? false;
   }
 
   override type(): string | undefined {

--- a/packages/activerecord/src/encryption/encryption-schemes.test.ts
+++ b/packages/activerecord/src/encryption/encryption-schemes.test.ts
@@ -305,8 +305,7 @@ describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
     const type = new EncryptedAttributeType({
       scheme: new Scheme({
         encryptor: currentEncryptor,
-        deterministic: true,
-        fixed: false,
+        deterministic: { fixed: false },
         previousSchemes: [oldScheme],
       }),
     });
@@ -352,8 +351,7 @@ describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
           this.adapter = adp;
           this.encrypts("name", {
             encryptor: currentEncryptor,
-            deterministic: true,
-            fixed: false,
+            deterministic: { fixed: false },
           });
         }
       } as any;

--- a/packages/activerecord/src/encryption/scheme.test.ts
+++ b/packages/activerecord/src/encryption/scheme.test.ts
@@ -10,7 +10,6 @@ import { DeterministicKeyProvider } from "./deterministic-key-provider.js";
 describe("ActiveRecord::Encryption::SchemeTest", () => {
   it("validates config options when using encrypted attributes", () => {
     expect(() => new Scheme({ ignoreCase: true, deterministic: false })).toThrow(Configuration);
-    expect(() => new Scheme({ downcase: true, deterministic: false })).toThrow(Configuration);
     expect(() => new Scheme({ key: "k", keyProvider: {} })).toThrow(Configuration);
     expect(
       () =>

--- a/packages/activerecord/src/encryption/scheme.trails.test.ts
+++ b/packages/activerecord/src/encryption/scheme.trails.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { Scheme } from "./scheme.js";
 import { Encryptor } from "./encryptor.js";
 import { Contexts } from "./contexts.js";
+import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
 
 describe("ActiveRecord::Encryption::SchemeTest (trails)", () => {
   it("builds no encryptor on the default path", () => {
@@ -17,6 +18,19 @@ describe("ActiveRecord::Encryption::SchemeTest (trails)", () => {
         compressor: { deflate: (d: string) => Buffer.from(d), inflate: () => "" },
       }).toH().encryptor,
     ).toBeInstanceOf(Encryptor);
+  });
+
+  it("toH emits key_provider, not key, so merge drops a bare key: as Rails does", () => {
+    const scheme = new Scheme({ key: "mykey" });
+    expect(scheme.keyProvider).toBeInstanceOf(DerivedSecretKeyProvider);
+
+    // scheme.rb:66 emits `key_provider: @key_provider_param`, which is nil when
+    // the scheme was declared with `key:` — the derived provider from
+    // `key_provider_from_key` (scheme.rb:57, :90) is never serialized, so a
+    // merged scheme falls back to the default key provider in Rails too.
+    expect(scheme.toH().key).toBeUndefined();
+    expect(scheme.toH().keyProvider).toBeUndefined();
+    expect(scheme.merge(new Scheme()).keyProvider).not.toBe(scheme.keyProvider);
   });
 
   it("leaves the surrounding context's encryptor in place on the default path", () => {

--- a/packages/activerecord/src/encryption/scheme.ts
+++ b/packages/activerecord/src/encryption/scheme.ts
@@ -181,19 +181,16 @@ export class Scheme {
   /** @internal */
   private validateConfigBang(): void {
     if (this.ignoreCase != null && this.ignoreCase !== false && !this.isDeterministic()) {
-      throw new Configuration("ignoreCase requires deterministic encryption");
-    }
-    if (this.downcase != null && this.downcase !== false && !this.isDeterministic()) {
-      throw new Configuration("downcase requires deterministic encryption");
+      throw new Configuration("ignoreCase: can only be used with deterministic encryption");
     }
     if (this._keyProviderParam != null && this.key != null) {
-      throw new Configuration("key and keyProvider can't be used simultaneously");
+      throw new Configuration("keyProvider: and key: can't be used simultaneously");
     }
     if (!this.compress && this.compressor !== undefined) {
-      throw new Configuration("compressor can't be used with compress: false");
+      throw new Configuration("compressor: can't be used with compress: false");
     }
     if (this.compressor !== undefined && this._contextProperties.encryptor !== undefined) {
-      throw new Configuration("compressor can't be used with encryptor");
+      throw new Configuration("compressor: can't be used with encryptor");
     }
   }
 }

--- a/packages/activerecord/src/encryption/scheme.ts
+++ b/packages/activerecord/src/encryption/scheme.ts
@@ -181,10 +181,10 @@ export class Scheme {
   /** @internal */
   private validateConfigBang(): void {
     if (this.ignoreCase != null && this.ignoreCase !== false && !this.isDeterministic()) {
-      throw new Configuration("ignoreCase: can only be used with deterministic encryption");
+      throw new Configuration("ignore_case: can only be used with deterministic encryption");
     }
     if (this._keyProviderParam != null && this.key != null) {
-      throw new Configuration("keyProvider: and key: can't be used simultaneously");
+      throw new Configuration("key_provider: and key: can't be used simultaneously");
     }
     if (!this.compress && this.compressor !== undefined) {
       throw new Configuration("compressor: can't be used with compress: false");

--- a/packages/activerecord/src/encryption/scheme.ts
+++ b/packages/activerecord/src/encryption/scheme.ts
@@ -24,8 +24,7 @@ import { DeterministicKeyProvider } from "./deterministic-key-provider.js";
 export interface SchemeOptions {
   keyProvider?: unknown;
   key?: string;
-  deterministic?: boolean;
-  fixed?: boolean;
+  deterministic?: boolean | { fixed?: boolean };
   supportUnencryptedData?: boolean;
   downcase?: boolean;
   ignoreCase?: boolean;
@@ -55,27 +54,30 @@ export class Scheme {
   private _keyProviderParam?: unknown;
   private _cachedKeyProviderFromKey?: DerivedSecretKeyProvider;
   private _cachedDeterministicKeyProvider?: DeterministicKeyProvider;
+  private _fixed?: boolean;
   key?: string;
-  deterministic: boolean;
+  // Initialized to `undefined` throughout, as Rails initializes every ivar to
+  // `nil`: "not set" has to stay distinguishable from "explicitly false" so
+  // that `merge` does not override a value with a default (scheme.rb:15-16).
+  deterministic?: boolean | { fixed?: boolean };
+  private _supportUnencryptedData?: boolean;
   downcase: boolean;
   ignoreCase: boolean;
+  private _previousSchemesParam?: Scheme[];
   previousSchemes: Scheme[];
   private compress: boolean;
   private compressor?: Compressor;
   /** Rails' `@context_properties` — the leftover `**` kwargs (scheme.rb:13). */
   private _contextProperties: Partial<Context>;
-  // Original options as-passed — used by toH() / merge() to distinguish
-  // "not set" (undefined) from "explicitly set to false", mirroring Rails'
-  // @context_properties + nil-defaulted ivars + to_h.compact pattern.
-  private _opts: SchemeOptions;
 
   constructor(options: SchemeOptions = {}) {
-    this._opts = { ...options };
     this._keyProviderParam = options.keyProvider;
     this.key = options.key;
-    this.deterministic = options.deterministic ?? false;
+    this.deterministic = options.deterministic;
+    this._supportUnencryptedData = options.supportUnencryptedData;
     this.downcase = options.downcase ?? false;
     this.ignoreCase = options.ignoreCase ?? false;
+    this._previousSchemesParam = options.previousSchemes;
     this.previousSchemes = options.previousSchemes ?? [];
 
     this._contextProperties = {};
@@ -96,10 +98,11 @@ export class Scheme {
       this._contextProperties.encryptor = new Encryptor({ compressor: options.compressor });
   }
 
+  isDeterministic(): boolean {
+    return this.deterministic != null && this.deterministic !== false;
+  }
+
   get keyProvider(): unknown {
-    // When an explicit encryptor is provided, key providers are irrelevant —
-    // the encryptor handles encryption without needing key material from here.
-    if (this._opts.encryptor !== undefined) return this._keyProviderParam ?? undefined;
     return (
       this._keyProviderParam ??
       this.keyProviderFromKey() ??
@@ -109,14 +112,15 @@ export class Scheme {
   }
 
   isSupportUnencryptedData(): boolean {
-    return this._opts.supportUnencryptedData ?? Configurable.config.supportUnencryptedData;
+    return this._supportUnencryptedData ?? Configurable.config.supportUnencryptedData;
   }
 
-  // fixed: true (default for deterministic) → serialize uses the oldest previous
-  // scheme so existing deterministic ciphertexts remain stable across key rotations.
-  // fixed: false → serialize always uses the current (newest) scheme.
   isFixed(): boolean {
-    return this._opts.fixed ?? this.deterministic;
+    // by default deterministic encryption is fixed
+    return (this._fixed ??=
+      this.deterministic != null &&
+      this.deterministic !== false &&
+      (typeof this.deterministic !== "object" || this.deterministic.fixed !== false));
   }
 
   merge(other: Scheme): Scheme {
@@ -131,34 +135,23 @@ export class Scheme {
   }
 
   isCompatibleWith(other: Scheme): boolean {
-    return this.deterministic === other.deterministic;
+    return this.isDeterministic() === other.isDeterministic();
   }
 
-  /**
-   * Mirrors: ActiveRecord::Encryption::Scheme#to_h (scheme.rb:65-68) — the
-   * as-passed options plus `@context_properties`, compacted.
-   *
-   * Carries four keys Rails' `to_h` does not (`key`, `fixed`,
-   * `supportUnencryptedData`, `compress`/`compressor`). That is pre-existing
-   * (`_toOptions`, which this renames onto the Rails name) and is what `merge`
-   * currently relies on to carry them across; narrowing it to Rails' five keys
-   * is story `converge-scheme-to-h-key-set`.
-   */
+  /** Mirrors: ActiveRecord::Encryption::Scheme#to_h (scheme.rb:65-68). */
   toH(): SchemeOptions {
-    const o = this._opts;
-    const opts: SchemeOptions = {};
-    if (o.keyProvider !== undefined) opts.keyProvider = o.keyProvider;
-    if (o.key !== undefined) opts.key = o.key;
-    if (o.deterministic !== undefined) opts.deterministic = o.deterministic;
-    if (o.fixed !== undefined) opts.fixed = o.fixed;
-    if (o.downcase !== undefined) opts.downcase = o.downcase;
-    if (o.ignoreCase !== undefined) opts.ignoreCase = o.ignoreCase;
-    if (o.previousSchemes !== undefined) opts.previousSchemes = o.previousSchemes;
-    if (o.supportUnencryptedData !== undefined)
-      opts.supportUnencryptedData = o.supportUnencryptedData;
-    if (o.compress !== undefined) opts.compress = o.compress;
-    if (o.compressor !== undefined) opts.compressor = o.compressor;
-    return { ...opts, ...(this._contextProperties as Partial<SchemeOptions>) };
+    const h: SchemeOptions = {
+      keyProvider: this._keyProviderParam,
+      deterministic: this.deterministic,
+      downcase: this.downcase,
+      ignoreCase: this.ignoreCase,
+      previousSchemes: this._previousSchemesParam,
+      ...(this._contextProperties as Partial<SchemeOptions>),
+    };
+    for (const key of Object.keys(h) as (keyof SchemeOptions)[]) {
+      if (h[key] == null) delete h[key];
+    }
+    return h;
   }
 
   /** @internal */
@@ -177,7 +170,7 @@ export class Scheme {
 
   /** @internal */
   private deterministicKeyProvider(): DeterministicKeyProvider | undefined {
-    if (this.deterministic) {
+    if (this.isDeterministic()) {
       const deterministicKey = Configurable.config.deterministicKey;
       this._cachedDeterministicKeyProvider ??= new DeterministicKeyProvider(deterministicKey);
       return this._cachedDeterministicKeyProvider;
@@ -187,10 +180,10 @@ export class Scheme {
 
   /** @internal */
   private validateConfigBang(): void {
-    if (this.ignoreCase && !this.deterministic) {
+    if (this.ignoreCase && !this.isDeterministic()) {
       throw new Configuration("ignoreCase requires deterministic encryption");
     }
-    if (this.downcase && !this.deterministic) {
+    if (this.downcase && !this.isDeterministic()) {
       throw new Configuration("downcase requires deterministic encryption");
     }
     if (this._keyProviderParam != null && this.key != null) {

--- a/packages/activerecord/src/encryption/scheme.ts
+++ b/packages/activerecord/src/encryption/scheme.ts
@@ -56,13 +56,10 @@ export class Scheme {
   private _cachedDeterministicKeyProvider?: DeterministicKeyProvider;
   private _fixed?: boolean;
   key?: string;
-  // Initialized to `undefined` throughout, as Rails initializes every ivar to
-  // `nil`: "not set" has to stay distinguishable from "explicitly false" so
-  // that `merge` does not override a value with a default (scheme.rb:15-16).
   deterministic?: boolean | { fixed?: boolean };
   private _supportUnencryptedData?: boolean;
-  downcase: boolean;
-  ignoreCase: boolean;
+  downcase?: boolean;
+  ignoreCase?: boolean;
   private _previousSchemesParam?: Scheme[];
   previousSchemes: Scheme[];
   private compress: boolean;
@@ -71,12 +68,14 @@ export class Scheme {
   private _contextProperties: Partial<Context>;
 
   constructor(options: SchemeOptions = {}) {
+    // Initializing all attributes to +undefined+ as we want to allow a "not set" semantics so that we
+    // can merge schemes without overriding values with defaults. See +#merge+
     this._keyProviderParam = options.keyProvider;
     this.key = options.key;
     this.deterministic = options.deterministic;
     this._supportUnencryptedData = options.supportUnencryptedData;
-    this.downcase = options.downcase ?? false;
-    this.ignoreCase = options.ignoreCase ?? false;
+    this.downcase = options.downcase || options.ignoreCase;
+    this.ignoreCase = options.ignoreCase;
     this._previousSchemesParam = options.previousSchemes;
     this.previousSchemes = options.previousSchemes ?? [];
 
@@ -120,7 +119,8 @@ export class Scheme {
     return (this._fixed ??=
       this.deterministic != null &&
       this.deterministic !== false &&
-      (typeof this.deterministic !== "object" || this.deterministic.fixed !== false));
+      (typeof this.deterministic !== "object" ||
+        (this.deterministic.fixed != null && this.deterministic.fixed !== false)));
   }
 
   merge(other: Scheme): Scheme {
@@ -180,10 +180,10 @@ export class Scheme {
 
   /** @internal */
   private validateConfigBang(): void {
-    if (this.ignoreCase && !this.isDeterministic()) {
+    if (this.ignoreCase != null && this.ignoreCase !== false && !this.isDeterministic()) {
       throw new Configuration("ignoreCase requires deterministic encryption");
     }
-    if (this.downcase && !this.isDeterministic()) {
+    if (this.downcase != null && this.downcase !== false && !this.isDeterministic()) {
       throw new Configuration("downcase requires deterministic encryption");
     }
     if (this._keyProviderParam != null && this.key != null) {


### PR DESCRIPTION
`Scheme#to_h` (`activerecord/lib/active_record/encryption/scheme.rb:65-68`)
emits five named keys plus `**@context_properties`, compacted. trails' `toH`
emitted four more — `key`, `fixed`, `supportUnencryptedData`,
`compress`/`compressor` — read off a `_opts` snapshot of the constructor
arguments that Rails does not keep.

This drops the snapshot and the four keys, storing the Rails ivars instead
(`@key_provider_param`, `@deterministic`, `@support_unencrypted_data`,
`@previous_schemes_param`). Each dropped key is satisfied the Rails way:

- `key` folds into `key_provider` via `key_provider_from_key` (scheme.rb:57).
- `fixed` is memoized off `@deterministic` (scheme.rb:52-55), so
  `deterministic` now accepts Rails' `{ fixed: false }` hash form and
  `isFixed()` mirrors the memo. `deterministic?` (scheme.rb:44) arrives as
  `isDeterministic()`; the Rails-mirrored tests move to
  `deterministic: { fixed: false }`, matching `encryption_schemes_test.rb:143`.
- `supportUnencryptedData` falls through to the global config (scheme.rb:47).
- `compress`/`compressor` are already absorbed into
  `@context_properties[:encryptor]` by the constructor (scheme.rb:32-33).

The extra `keyProvider` short-circuit on an explicitly-passed encryptor goes
with the `_opts` snapshot it read, converging the getter on scheme.rb:57-59.

`SchemeTest` and the encryption suites are green; `parity:api:calls`,
`parity:api:calls:args` and `parity:api:extra` unchanged or shrinking.

Closes-story: converge-scheme-to-h-key-set