### PR TITLE
refactor(activerecord): make ShardSelector's shard a plain string

### DIFF
--- a/packages/activerecord/src/middleware/shard-selector.ts
+++ b/packages/activerecord/src/middleware/shard-selector.ts
@@ -6,14 +6,13 @@
 
 import { Base } from "../base.js";
 import { Notifications } from "@blazetrails/activesupport";
-import { ArgumentError } from "@blazetrails/activemodel";
 
 export interface ShardRequest {
   method: string;
   [key: string]: unknown;
 }
 
-type ShardResolverFn = (request: ShardRequest) => string | symbol;
+type ShardResolverFn = (request: ShardRequest) => string;
 
 export class ShardSelector {
   /** @internal */
@@ -33,6 +32,11 @@ export class ShardSelector {
     this.options = options;
   }
 
+  /**
+   * @missingRailsCall new — shard_selector.rb:41 wraps env in
+   * ActionDispatch::Request.new(env); trails has no ActionDispatch, so call()
+   * receives the request itself and constructs nothing.
+   */
   async call(request: ShardRequest): Promise<unknown> {
     const shard = this.selectedShard(request);
     return this.setShard(shard, () => this.app(request));
@@ -54,20 +58,12 @@ export class ShardSelector {
   }
 
   /** @internal */
-  selectedShard(request: ShardRequest): string | symbol {
+  selectedShard(request: ShardRequest): string {
     return this.resolver(request);
   }
 
-  private async setShard<T>(shard: string | symbol, block: () => T | Promise<T>): Promise<T> {
-    let shardKey: string;
-    if (typeof shard === "string") {
-      shardKey = shard;
-    } else {
-      const name = Symbol.keyFor(shard) ?? shard.description;
-      if (!name) throw new ArgumentError(`Cannot convert symbol to shard key: ${String(shard)}`);
-      shardKey = name;
-    }
-    return Base.connectedTo({ shard: shardKey }, () =>
+  private async setShard<T>(shard: string, block: () => T | Promise<T>): Promise<T> {
+    return Base.connectedTo({ shard }, () =>
       Base.prohibitShardSwapping(() => block(), this.options.lock ?? true),
     ) as Promise<T>;
   }


### PR DESCRIPTION
CLAUDE.md: a Ruby Symbol is a JS string, never a JS `Symbol`. `ShardSelector`
typed its shard as `string | symbol` and converted a JS `Symbol` back with
`Symbol.keyFor` / `.description`, raising `ArgumentError` when neither yielded
a name. With `shard` a plain string, Rails' `shard.to_sym`
(`activerecord/lib/active_record/middleware/shard_selector.rb:56`) is a no-op
and the call site is just `connectedTo({ shard })`.

- `selectedShard` / `setShard` / the resolver type take and return `string`.
- Conversion block and its `ArgumentError` deleted.
- The dropped `new ArgumentError` was the only `new` in the file, so the
  call-set gate surfaced the pre-existing omission of `ActionDispatch::Request.new(env)`
  (shard_selector.rb:41) — trails has no ActionDispatch and `call()` receives the
  request directly. Recorded as a `@missingRailsCall` at the call site rather
  than a baseline row.

`pnpm vitest run packages/activerecord/src/shard-selector.test.ts` green;
`parity:api:calls` and `parity:api:calls:args` both OK.

Closes-story: converge-shard-selector-symbol-to-string