### PR TITLE
refactor(activerecord,activesupport,actionpack): converge four Rails surfaces

### DIFF
--- a/packages/actionpack/src/action-controller/metal/strong-parameters.ts
+++ b/packages/actionpack/src/action-controller/metal/strong-parameters.ts
@@ -1,6 +1,7 @@
 /** ActionController::StrongParameters Provides ActionController::Parameters, a hash-like object that controls which parameters are permitted for mass assignment. @see https://api.rubyonrails.org/classes/ActionController/StrongParameters.html @internal */
 
 import { SpellChecker } from "@blazetrails/did-you-mean";
+import { isBlank } from "@blazetrails/activesupport";
 
 // --- Error classes ---
 
@@ -72,15 +73,6 @@ function isPermittedScalar(value: unknown): boolean {
   if (value === null || value === undefined) return true;
   const t = typeof value;
   return t === "string" || t === "number" || t === "boolean";
-}
-
-function isBlank(value: unknown): boolean {
-  if (value === null || value === undefined || value === false) return true;
-  if (typeof value === "string" && value.trim() === "") return true;
-  if (Array.isArray(value) && value.length === 0) return true;
-  if (value instanceof Parameters) return value.empty;
-  if (isPlainObject(value) && Object.keys(value).length === 0) return true;
-  return false;
 }
 
 // --- Parameters ---

--- a/packages/actionpack/src/action-dispatch/http/url.ts
+++ b/packages/actionpack/src/action-dispatch/http/url.ts
@@ -8,7 +8,7 @@
  * instance methods (url, host, port, ...) live on {@link Request}.
  */
 
-import { toParam, toQuery } from "@blazetrails/activesupport";
+import { isBlank, toParam, toQuery } from "@blazetrails/activesupport";
 import { escapeFragment, rackEscape } from "../journey/router/utils.js";
 
 const IP_HOST_REGEXP = /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/;
@@ -39,10 +39,6 @@ export interface UrlOptions {
   tldLength?: number;
   subdomain?: string | boolean | { toParam(): string };
   domain?: string;
-}
-
-function isBlank(s: string): boolean {
-  return s.length === 0 || /^\s*$/.test(s);
 }
 
 function namedHost(host: string): boolean {

--- a/packages/actionpack/src/action-dispatch/journey/formatter.ts
+++ b/packages/actionpack/src/action-dispatch/journey/formatter.ts
@@ -1,4 +1,4 @@
-import { isPlainObject, toParam } from "@blazetrails/activesupport";
+import { isPlainObject, isPresent, toParam } from "@blazetrails/activesupport";
 import { UrlGenerationError } from "../../action-controller/metal/exceptions.js";
 import type { Route } from "./route.js";
 
@@ -310,15 +310,6 @@ interface CacheNode {
 
 function pairKey(k: string, v: unknown): string {
   return JSON.stringify([k, v ?? null]);
-}
-
-function isPresent(v: unknown): boolean {
-  if (v == null) return false;
-  if (v === false) return false;
-  if (typeof v === "string") return v.length > 0;
-  if (Array.isArray(v)) return v.length > 0;
-  if (typeof v === "object") return Object.keys(v).length > 0;
-  return true;
 }
 
 function toS(v: unknown): string {

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -48,6 +48,7 @@ import {
   HasOneThroughNestedAssociationsAreReadonly,
   HasManyThroughOrderError,
   CompositePrimaryKeyMismatchError,
+  AssociationNotFoundError,
 } from "./errors.js";
 import { routeThroughCheckValidity } from "./validate-through-reflection.js";
 import { rebaseNewOwnerSeed } from "./new-owner-seed-rebase.js";
@@ -1109,7 +1110,8 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     if (association?.isViolatesStrictLoading()) {
       const ctor = this._record.constructor as typeof Base;
       const reflection = ctor._reflectOnAssociation?.(this._assocName);
-      if (reflection) strictLoadingViolationBang({ owner: ctor, reflection });
+      if (!reflection) throw new AssociationNotFoundError(this._record, this._assocName);
+      strictLoadingViolationBang({ owner: ctor, reflection });
     }
   }
 

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1107,9 +1107,9 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       | { isViolatesStrictLoading(): boolean }
       | undefined;
     if (association?.isViolatesStrictLoading()) {
-      strictLoadingViolationBang(this._record, this._assocName, {
-        className: this._assocDef.options.className ?? camelize(singularize(this._assocName)),
-      });
+      const ctor = this._record.constructor as typeof Base;
+      const reflection = ctor._reflectOnAssociation?.(this._assocName);
+      if (reflection) strictLoadingViolationBang({ owner: ctor, reflection });
     }
   }
 

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -23,7 +23,11 @@ import {
   validateThroughReflection,
   routeThroughCheckValidity,
 } from "./validate-through-reflection.js";
-import { CompositePrimaryKeyMismatchError, DeleteRestrictionError } from "./errors.js";
+import {
+  AssociationNotFoundError,
+  CompositePrimaryKeyMismatchError,
+  DeleteRestrictionError,
+} from "./errors.js";
 import { CollectionAssociation, includesRecord, isThenable } from "./collection-association.js";
 import { ForeignAssociation, ownerForeignKeyColumns } from "./foreign-association.js";
 import { compositeQueryConstraintsList } from "../persistence.js";
@@ -608,7 +612,8 @@ async function findTarget(
   if (violatesStrictLoading && _findTargetReachable(record, assocName, options, "foreign")) {
     const ctor = record.constructor as typeof Base;
     const reflection = ctor._reflectOnAssociation?.(assocName);
-    if (reflection) strictLoadingViolationBang({ owner: ctor, reflection });
+    if (!reflection) throw new AssociationNotFoundError(record, assocName);
+    strictLoadingViolationBang({ owner: ctor, reflection });
   }
 
   // Scope-override path: CollectionProxy passes this when its Relation state

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -606,9 +606,9 @@ async function findTarget(
   // by `find_target?`: a new-record owner without the FK present never reaches
   // `find_target` and so never raises.
   if (violatesStrictLoading && _findTargetReachable(record, assocName, options, "foreign")) {
-    strictLoadingViolationBang(record, assocName, {
-      className: options.className ?? camelize(singularize(assocName)),
-    });
+    const ctor = record.constructor as typeof Base;
+    const reflection = ctor._reflectOnAssociation?.(assocName);
+    if (reflection) strictLoadingViolationBang({ owner: ctor, reflection });
   }
 
   // Scope-override path: CollectionProxy passes this when its Relation state

--- a/packages/activerecord/src/associations/singular-association.ts
+++ b/packages/activerecord/src/associations/singular-association.ts
@@ -215,10 +215,10 @@ export class SingularAssociation extends Association {
     // A DB load would be required to answer.
     if (this.findTargetNeeded()) {
       if (this.isViolatesStrictLoading()) {
-        strictLoadingViolationBang(this.owner, this.reflection.name, {
-          polymorphic: this.reflection.options?.polymorphic,
-          className: this.reflection.options?.className,
-        });
+        const ctor = this.owner.constructor as typeof Base;
+        const reflection = ctor._reflectOnAssociation?.(this.reflection.name);
+        if (!reflection) throw new AssociationNotFoundError(this.owner, this.reflection.name);
+        strictLoadingViolationBang({ owner: ctor, reflection });
       }
       // Rails loads synchronously; Node.js requires async I/O. The union
       // return type now forces callers to `await` — TypeScript enforces it
@@ -326,10 +326,7 @@ export class SingularAssociation extends Association {
         this.isViolatesStrictLoading() &&
         _findTargetReachable(owner, assocName, options, isBelongsTo ? "belongsTo" : "foreign")
       ) {
-        strictLoadingViolationBang(owner, assocName, {
-          polymorphic: isBelongsTo ? options.polymorphic : undefined,
-          className: options.className,
-        });
+        strictLoadingViolationBang({ owner: owner.constructor, reflection });
       }
 
       // has_one :through. Rails expresses `:through` inside the scope chain; trails

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -682,7 +682,7 @@ export function strictLoadingViolationBang({
   owner,
   reflection,
 }: {
-  owner: any;
+  owner: unknown;
   reflection: { name: string; strictLoadingViolationMessage(owner: unknown): string };
 }): void {
   switch (ActiveRecord.actionOnStrictLoadingViolation) {

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -24,15 +24,10 @@ import {
   Notifications,
   IsolatedExecutionState,
   ParameterFilter,
-  camelize,
   constantize,
   pluralize,
 } from "@blazetrails/activesupport";
-import {
-  strictLoadingViolationMessage,
-  _reflectOnAssociation,
-  reflectOnAggregation,
-} from "./reflection.js";
+import { _reflectOnAssociation, reflectOnAggregation } from "./reflection.js";
 import { compactUniqIds, compactUniqTuples } from "./relation/compact-uniq-ids.js";
 import { PredicateBuilder } from "./relation/predicate-builder.js";
 import { TableMetadata } from "./table-metadata.js";
@@ -678,37 +673,26 @@ export function asynchronousQueriesSession(): any {
  * `action_on_strict_loading_violation = "raise"` this throws
  * `StrictLoadingViolationError`; under `"log"` it instruments
  * `strict_loading_violation.active_record` and returns so the caller can
- * continue the (now warned-about) lazy load. `owner` is the violating
- * record (or its class); `reflection` is the association name.
+ * continue the (now warned-about) lazy load. Rails' callers pass
+ * `owner: owner.class` (association.rb:250).
  *
  * Mirrors: ActiveRecord::Core.strict_loading_violation!
  */
-export function strictLoadingViolationBang(
-  owner: any,
-  reflection: string,
-  options: { polymorphic?: boolean; className?: string } = {},
-): void {
-  const reflectionLike = {
-    name: reflection,
-    strictLoadingViolationMessage(ownerArg: unknown): string {
-      return strictLoadingViolationMessage(ownerArg, {
-        name: reflection,
-        polymorphic: options.polymorphic === true,
-        className: options.className ?? camelize(reflection),
-      });
-    },
-  };
-  // Rails passes `owner.class` (Notifications payload + message subject); the
-  // message builder stringifies it to the class name, matching Ruby's `#{owner}`.
-  const ownerClass = typeof owner === "function" ? owner : owner?.constructor;
+export function strictLoadingViolationBang({
+  owner,
+  reflection,
+}: {
+  owner: any;
+  reflection: { name: string; strictLoadingViolationMessage(owner: unknown): string };
+}): void {
   switch (ActiveRecord.actionOnStrictLoadingViolation) {
     case "raise": {
-      const message = reflectionLike.strictLoadingViolationMessage(ownerClass);
+      const message = reflection.strictLoadingViolationMessage(owner);
       throw new StrictLoadingViolationError(message);
     }
     case "log": {
       const name = "strict_loading_violation.active_record";
-      Notifications.instrument(name, { owner: ownerClass, reflection: reflectionLike });
+      Notifications.instrument(name, { owner, reflection });
     }
   }
 }

--- a/packages/activesupport/src/backtrace-cleaner.ts
+++ b/packages/activesupport/src/backtrace-cleaner.ts
@@ -49,6 +49,11 @@ export class BacktraceCleaner {
     }
   }
 
+  /** filter — `alias :filter :clean` (backtrace_cleaner.rb:57). */
+  filter(backtrace: string[], kind: CleanKind = "silent"): string[] {
+    return this.clean(backtrace, kind);
+  }
+
   /** cleanFrame — clean a single frame; returns undefined when excluded by the selected kind. */
   cleanFrame(frame: string, kind: CleanKind = "silent"): string | undefined {
     for (const f of this._filters) frame = f(frame);

--- a/packages/activesupport/src/core-ext/hash/slice.ts
+++ b/packages/activesupport/src/core-ext/hash/slice.ts
@@ -1,4 +1,22 @@
+import { slice } from "../../hash-utils.js";
+
 type AnyObject = Record<string, unknown>;
+
+/**
+ * Replaces the hash with only the given keys, returning the removed
+ * key/value pairs — Ruby's `Hash#slice!` (core_ext/hash/slice.rb:10-17).
+ *
+ * `hash.default` / `hash.default_proc` have no JS analogue: a plain object has
+ * no default-value seat, so slice.rb:13-14 has nothing to copy over.
+ */
+export function sliceBang<T extends AnyObject>(hash: T, ...keys: string[]): Partial<T> {
+  const omit = slice(hash, ...(Object.keys(hash).filter((k) => !keys.includes(k)) as (keyof T)[]));
+  const result = slice(hash, ...(keys as (keyof T)[]));
+  // `replace(hash)`: empty the receiver, then take the sliced pairs.
+  for (const key of Object.keys(hash)) delete hash[key];
+  Object.assign(hash, result);
+  return omit as Partial<T>;
+}
 
 /**
  * Removes and returns the key/value pairs matching the given keys, mutating

--- a/packages/activesupport/src/core-ext/hash/slice.ts
+++ b/packages/activesupport/src/core-ext/hash/slice.ts
@@ -8,11 +8,12 @@ type AnyObject = Record<string, unknown>;
  *
  * `hash.default` / `hash.default_proc` have no JS analogue: a plain object has
  * no default-value seat, so slice.rb:13-14 has nothing to copy over.
+ * `replace(hash)` (slice.rb:15) is the own-key clear plus `Object.assign` —
+ * JS objects carry no `replace`.
  */
 export function sliceBang<T extends AnyObject>(hash: T, ...keys: string[]): Partial<T> {
   const omit = slice(hash, ...(Object.keys(hash).filter((k) => !keys.includes(k)) as (keyof T)[]));
   const result = slice(hash, ...(keys as (keyof T)[]));
-  // `replace(hash)`: empty the receiver, then take the sliced pairs.
   for (const key of Object.keys(hash)) delete hash[key];
   Object.assign(hash, result);
   return omit as Partial<T>;

--- a/packages/activesupport/src/core-ext/object/blank.ts
+++ b/packages/activesupport/src/core-ext/object/blank.ts
@@ -4,9 +4,14 @@
  * In Ruby, these are monkey-patches on built-in classes. In TypeScript,
  * `presence` is a standalone function and the per-class `blank?`/`present?`
  * arms are statics on type-specific classes, one per Ruby reopening.
+ *
+ * `isBlank` below is `Object#blank?` (blank.rb:18-20) — the entry point Ruby
+ * reaches by dynamic dispatch. TypeScript has no per-class dispatch on a
+ * built-in, so it switches on the value class in blank.rb's own order and
+ * routes to that class's arm. `Array`, `Hash` and `Numeric` have no class here:
+ * their arms (`alias_method :blank?, :empty?` at blank.rb:96/111, and
+ * blank.rb:167-169) are one expression each, applied inline at the switch.
  */
-
-import { isBlank, isPresent } from "../../string-utils.js";
 
 const BLANK_RE = /^\s*$/;
 
@@ -68,6 +73,51 @@ export class Time {
 }
 
 /**
+ * `Object#blank?` (`core_ext/object/blank.rb:18-20`) plus the per-class
+ * overrides, dispatched on the value class.
+ */
+export function isBlank(value: unknown): boolean {
+  // blank.rb:56 — NilClass#blank?
+  if (value === null || value === undefined) return NilClass.isBlank(value);
+  // blank.rb:69 / :82 — FalseClass#blank? and TrueClass#blank?
+  if (typeof value === "boolean")
+    return value ? TrueClass.isBlank(value) : FalseClass.isBlank(value);
+  // blank.rb:96 — `alias_method :blank?, :empty?` on Array.
+  if (Array.isArray(value)) return value.length === 0;
+  // blank.rb:120 — Symbol#blank?. A Ruby Symbol is a JS string, so this arm is
+  // only reached by a genuine JS `symbol`; the string spelling falls to String.
+  if (typeof value === "symbol") return Symbol.isBlank(value);
+  // blank.rb:145-153 — String#blank?
+  if (typeof value === "string") return String.isBlank(value);
+  // blank.rb:167-169 — Numeric#blank? is always false, including for 0.
+  if (typeof value === "number" || typeof value === "bigint") return false;
+  // blank.rb:182-184 — Time#blank?
+  // boundary: the `Time` arm below is typed on the JS `Date` this dispatches to.
+  if (value instanceof Date) return Time.isBlank(value);
+  // `Object#blank?`'s `respond_to?(:empty?)` arm: `Object.keys` reports none
+  // for a Set or Map, which answer by size.
+  if (value instanceof Set || value instanceof Map) return value.size === 0;
+  // The same arm for any other object that answers `empty?`. Ruby probes one
+  // spelling; trails has two — `isEmpty` from the conventions table, and the
+  // `empty` getter actionpack's Hash-like wrappers (`Parameters`, `FlashHash`)
+  // carry — so both are probed. Only a boolean-valued reader answers here: a
+  // method-shaped `isEmpty()` is not invoked, because trails has async ones
+  // (`Relation#isEmpty` runs a query) and Ruby's `blank?` issues no I/O.
+  const empty = (value as { isEmpty?: unknown }).isEmpty ?? (value as { empty?: unknown }).empty;
+  if (typeof empty === "boolean") return empty;
+  // blank.rb:111 — `alias_method :blank?, :empty?` on Hash.
+  if (typeof value === "object") return Object.keys(value).length === 0;
+  return false;
+}
+
+/**
+ * `Object#present?` (`core_ext/object/blank.rb:25-27`): `!blank?`.
+ */
+export function isPresent(value: unknown): boolean {
+  return !isBlank(value);
+}
+
+/**
  * `Object#presence` (`core_ext/object/blank.rb:44-46`): `self if present?`.
  * Ruby's `nil` return for a blank receiver is `undefined` here, so the
  * `presence ?? default` idiom reads the way `presence || default` does in Ruby.
@@ -75,5 +125,3 @@ export class Time {
 export function presence<T>(value: T): T | undefined {
   return isPresent(value) ? value : undefined;
 }
-
-export { isBlank, isPresent };

--- a/packages/activesupport/src/core-ext/object/blank.ts
+++ b/packages/activesupport/src/core-ext/object/blank.ts
@@ -74,38 +74,36 @@ export class Time {
 
 /**
  * `Object#blank?` (`core_ext/object/blank.rb:18-20`) plus the per-class
- * overrides, dispatched on the value class.
+ * overrides, dispatched on the value class in blank.rb's own order: `NilClass`
+ * (:56), `FalseClass` (:69), `TrueClass` (:82), `Array` (:96), `Hash` (:111),
+ * `Symbol` (:120), `String` (:145-153), `Numeric` (:167-169), `Time`
+ * (:182-184). `Array`, `Hash` and `Numeric` get no class of their own here:
+ * their arms are `alias_method :blank?, :empty?` and a bare `false`, applied at
+ * the switch.
+ *
+ * A Ruby Symbol is a JS string, so the `Symbol` arm is reached only by a
+ * genuine JS `symbol`; the string spelling falls through to `String`.
+ *
+ * `Object#blank?`'s `respond_to?(:empty?)` arm answers for `Set` and `Map`,
+ * which `Object.keys` reports as empty, and for any other object carrying a
+ * boolean `isEmpty` (the conventions-table spelling of `empty?`) or `empty`
+ * (the getter actionpack's Hash-like wrappers carry). A method-shaped
+ * `isEmpty()` is deliberately not invoked: trails has async ones
+ * (`Relation#isEmpty` runs a query) and Ruby's `blank?` issues no I/O.
  */
 export function isBlank(value: unknown): boolean {
-  // blank.rb:56 — NilClass#blank?
   if (value === null || value === undefined) return NilClass.isBlank(value);
-  // blank.rb:69 / :82 — FalseClass#blank? and TrueClass#blank?
   if (typeof value === "boolean")
     return value ? TrueClass.isBlank(value) : FalseClass.isBlank(value);
-  // blank.rb:96 — `alias_method :blank?, :empty?` on Array.
   if (Array.isArray(value)) return value.length === 0;
-  // blank.rb:120 — Symbol#blank?. A Ruby Symbol is a JS string, so this arm is
-  // only reached by a genuine JS `symbol`; the string spelling falls to String.
   if (typeof value === "symbol") return Symbol.isBlank(value);
-  // blank.rb:145-153 — String#blank?
   if (typeof value === "string") return String.isBlank(value);
-  // blank.rb:167-169 — Numeric#blank? is always false, including for 0.
   if (typeof value === "number" || typeof value === "bigint") return false;
-  // blank.rb:182-184 — Time#blank?
-  // boundary: the `Time` arm below is typed on the JS `Date` this dispatches to.
+  // boundary: the `Time` arm is typed on the JS `Date` this dispatches to.
   if (value instanceof Date) return Time.isBlank(value);
-  // `Object#blank?`'s `respond_to?(:empty?)` arm: `Object.keys` reports none
-  // for a Set or Map, which answer by size.
   if (value instanceof Set || value instanceof Map) return value.size === 0;
-  // The same arm for any other object that answers `empty?`. Ruby probes one
-  // spelling; trails has two — `isEmpty` from the conventions table, and the
-  // `empty` getter actionpack's Hash-like wrappers (`Parameters`, `FlashHash`)
-  // carry — so both are probed. Only a boolean-valued reader answers here: a
-  // method-shaped `isEmpty()` is not invoked, because trails has async ones
-  // (`Relation#isEmpty` runs a query) and Ruby's `blank?` issues no I/O.
   const empty = (value as { isEmpty?: unknown }).isEmpty ?? (value as { empty?: unknown }).empty;
   if (typeof empty === "boolean") return empty;
-  // blank.rb:111 — `alias_method :blank?, :empty?` on Hash.
   if (typeof value === "object") return Object.keys(value).length === 0;
   return false;
 }

--- a/packages/activesupport/src/hash-ext.test.ts
+++ b/packages/activesupport/src/hash-ext.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { extractBang } from "./core-ext/hash/slice.js";
+import { extractBang, sliceBang } from "./core-ext/hash/slice.js";
 import {
   deepMerge,
   deepTransformKeys,
@@ -13,7 +13,6 @@ import {
   ArgumentError,
   slice,
   except,
-  sliceBang,
   exceptBang,
   reverseMergeBang,
   reverseUpdate,

--- a/packages/activesupport/src/hash-utils.ts
+++ b/packages/activesupport/src/hash-utils.ts
@@ -92,7 +92,7 @@ export function deepDup<T>(obj: T): T {
 export function slice<T extends AnyObject, K extends keyof T>(obj: T, ...keys: K[]): Pick<T, K> {
   const result = {} as Pick<T, K>;
   for (const key of keys) {
-    if (key in obj) {
+    if (Object.hasOwn(obj, key as string)) {
       result[key] = obj[key];
     }
   }
@@ -387,18 +387,6 @@ export const reverseUpdate = reverseMergeBang;
  * (core_ext/hash/reverse_merge.rb:23).
  */
 export const withDefaultsBang = reverseMergeBang;
-
-/**
- * Replaces the hash with only the given keys, returning the removed
- * key/value pairs — Ruby's `Hash#slice!` (core_ext/hash/slice.rb:10-17).
- */
-export function sliceBang<T extends AnyObject>(hash: T, ...keys: string[]): Partial<T> {
-  const omit = slice(hash, ...(Object.keys(hash).filter((k) => !keys.includes(k)) as (keyof T)[]));
-  const result = slice(hash, ...(keys as (keyof T)[]));
-  for (const key of Object.keys(hash)) delete hash[key];
-  Object.assign(hash, result);
-  return omit as Partial<T>;
-}
 
 /**
  * Removes the given keys from the hash and returns it — Ruby's `Hash#except!`

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -254,7 +254,6 @@ export {
   reverseMergeBang,
   reverseUpdate,
   withDefaultsBang,
-  sliceBang,
   exceptBang,
   nestedUnderIndifferentAccess,
   toParam,
@@ -309,6 +308,8 @@ export {
   isIn,
   presenceIn,
 } from "./enumerable-utils.js";
+
+export { sliceBang } from "./core-ext/hash/slice.js";
 
 // Note: `Hash#extract!` is intentionally kept off this flat index and reached
 // through the "./core-ext/hash/slice" subpath, which mirrors its Rails require

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -603,6 +603,8 @@ export {
   assertNoChanges,
   UnexpectedError,
   UNTRACKED,
+  BacktraceFilter,
+  Minitest,
 } from "./testing/assertions.js";
 export { currentTime } from "./time-travel.js";
 export { currentTimeInstant } from "./time-travel.js";

--- a/packages/activesupport/src/string-utils.ts
+++ b/packages/activesupport/src/string-utils.ts
@@ -2,22 +2,10 @@
  * String utilities mirroring Rails ActiveSupport string extensions.
  */
 
-export function isBlank(value: unknown): boolean {
-  if (value === null || value === undefined) return true;
-  if (typeof value === "string") return /^\s*$/.test(value);
-  if (typeof value === "boolean") return !value;
-  if (typeof value === "number") return false;
-  if (Array.isArray(value)) return value.length === 0;
-  // `Object.keys` reports none for a Set or Map, where Ruby's
-  // `respond_to?(:empty?)` arm answers by size.
-  if (value instanceof Set || value instanceof Map) return value.size === 0;
-  if (typeof value === "object") return Object.keys(value).length === 0;
-  return false;
-}
-
-export function isPresent(value: unknown): boolean {
-  return !isBlank(value);
-}
+// `blank?` / `present?` are `core_ext/object/blank.rb`'s, not a string
+// extension — they live at the Rails path and are re-exported here so this
+// file's long-standing importers keep reaching them.
+export { isBlank, isPresent } from "./core-ext/object/blank.js";
 
 export function squish(str: string): string {
   return str.trim().replace(/\s+/g, " ");

--- a/packages/activesupport/src/testing/assertions.ts
+++ b/packages/activesupport/src/testing/assertions.ts
@@ -135,12 +135,17 @@ export class BacktraceFilter {
  * assigned at :1204) and `Minitest.filter_backtrace` (minitest.rb:365-369).
  * Held on an object so the accessor is reassignable at the Ruby spelling
  * (`Minitest.backtraceFilter = ...`), which `filterBacktrace` reads on every
- * call the way the `cattr_accessor` does.
+ * call the way the `cattr_accessor` does. The seat is typed by the `filter`
+ * method alone because Ruby's is duck-typed: `rails_plugin.rb:118` assigns a
+ * `BacktraceFilterWithFallback`, which is not a `BacktraceFilter`.
  *
  * @noRailsEquivalent PERMANENT — minitest's module surface; see
  * {@link BacktraceFilter}.
  */
-export const Minitest = {
+export const Minitest: {
+  backtraceFilter: { filter(bt: string[] | null): string[] };
+  filterBacktrace(bt: string[] | null): string[];
+} = {
   backtraceFilter: new BacktraceFilter(),
 
   filterBacktrace(bt: string[] | null): string[] {

--- a/packages/activesupport/src/testing/assertions.ts
+++ b/packages/activesupport/src/testing/assertions.ts
@@ -23,7 +23,7 @@
  */
 import { indexWith } from "../enumerable-utils.js";
 
-import { cwd } from "../process-adapter.js";
+import { cwd, env } from "../process-adapter.js";
 import { _testCaseIdentity, taggedLogger } from "./tagged-logging.js";
 
 /** Mirrors `Minitest::Assertion` — the error a failed assertion raises. */
@@ -106,13 +106,20 @@ export class BacktraceFilter {
   }
 
   /**
-   * Mirrors `Minitest::BacktraceFilter#filter` (minitest.rb:1190-1198): the
-   * frames before the first framework frame, else every non-framework frame,
-   * else the whole trace. Ruby's `$DEBUG`/`MT_DEBUG` escape hatch reads the
-   * process, which this repo's rules keep out of runtime code.
+   * Mirrors `Minitest::BacktraceFilter#filter` (minitest.rb:1191-1201): the
+   * whole trace under debug, else the frames before the first framework frame,
+   * else every non-framework frame, else the whole trace.
+   *
+   * Ruby's `$DEBUG` half of the minitest.rb:1194 guard has no JS analogue —
+   * there is no interpreter-wide debug global to read — so only the
+   * `ENV["MT_DEBUG"]` half is ported, through `process-adapter`. Ruby
+   * truthiness makes a set-but-empty `MT_DEBUG` count, hence the `!= null`
+   * rather than a bare truthiness test.
    */
   filter(bt: string[] | null): string[] {
     if (!bt) return ["No backtrace"];
+
+    if (env.MT_DEBUG != null) return [...bt];
 
     const framework = bt.findIndex((line) => this.regexp.test(line));
     let newBt = framework === -1 ? [...bt] : bt.slice(0, framework);

--- a/packages/activesupport/src/testing/unexpected-error.trails.test.ts
+++ b/packages/activesupport/src/testing/unexpected-error.trails.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { cwd } from "../process-adapter.js";
+import { cwd, env, setEnv } from "../process-adapter.js";
 import { BacktraceFilter, Minitest, UnexpectedError } from "./assertions.js";
 
 describe("UnexpectedErrorTest", () => {
@@ -40,6 +40,23 @@ describe("UnexpectedErrorTest", () => {
     expect(new UnexpectedError(raised).message).toBe(
       "Error: boom\n    at doThing (packages/activesupport/src/thing.ts:1:1)",
     );
+  });
+
+  it("filter returns the whole trace under MT_DEBUG", () => {
+    const bt = [
+      "at doThing (thing.ts:1:1)",
+      "at runTest (/node_modules/vitest/dist/runner.js:2:2)",
+    ];
+    const filter = new BacktraceFilter();
+    expect(filter.filter(bt)).toEqual(["at doThing (thing.ts:1:1)"]);
+
+    const original = env.MT_DEBUG;
+    setEnv("MT_DEBUG", "1");
+    try {
+      expect(filter.filter(bt)).toEqual(bt);
+    } finally {
+      setEnv("MT_DEBUG", original);
+    }
   });
 
   it("the rendered backtrace follows a swapped Minitest.backtraceFilter", () => {

--- a/packages/trailties/src/minitest/rails-plugin.test.ts
+++ b/packages/trailties/src/minitest/rails-plugin.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { BacktraceFilter, Minitest, env, setEnv } from "@blazetrails/activesupport";
+import { pluginRailsInit } from "./rails-plugin.js";
+
+/**
+ * `backtrace_gem_line` (rails_plugin_test.rb:96-98) builds a frame inside a
+ * gem's `lib`. trails' gems are packages under `node_modules`, which is what
+ * `Rails::BacktraceCleaner`'s `APP_DIRS_PATTERN` silences.
+ */
+function backtraceGemLine(gemName: string): string {
+  return `node_modules/${gemName}/lib/${gemName}.js:1:1`;
+}
+
+/** Mirrors `with_plugin` (rails_plugin_test.rb:83-94). */
+function withPlugin(
+  options: { fullBacktrace?: boolean },
+  initialBacktraceFilter: BacktraceFilter,
+  block: () => void,
+): void {
+  const originalBacktraceFilter = Minitest.backtraceFilter;
+  const originalRailsEnv = env.RAILS_ENV;
+  Minitest.backtraceFilter = initialBacktraceFilter;
+  setEnv("RAILS_ENV", "test");
+  try {
+    pluginRailsInit(options);
+    block();
+  } finally {
+    Minitest.backtraceFilter = originalBacktraceFilter;
+    setEnv("RAILS_ENV", originalRailsEnv);
+  }
+}
+
+describe("Minitest::RailsPluginTest", () => {
+  it("replaces backtrace filter with one that silences gem lines", () => {
+    const backtrace = ["lib/my_code.rb", backtraceGemLine("rails")];
+
+    withPlugin({}, new BacktraceFilter(), () => {
+      expect(Minitest.backtraceFilter.filter(backtrace)).toEqual(backtrace.slice(0, 1));
+    });
+  });
+
+  it("replacement backtrace filter never returns an empty backtrace", () => {
+    const backtrace = [backtraceGemLine("rails")];
+
+    withPlugin({}, new BacktraceFilter(), () => {
+      expect(Minitest.backtraceFilter.filter(backtrace)).toEqual(backtrace);
+    });
+  });
+
+  it("does not replace backtrace filter when using --backtrace option", () => {
+    const backtraceFilter = new BacktraceFilter();
+
+    withPlugin({ fullBacktrace: true }, backtraceFilter, () => {
+      expect(Minitest.backtraceFilter).toBe(backtraceFilter);
+    });
+  });
+});

--- a/packages/trailties/src/minitest/rails-plugin.ts
+++ b/packages/trailties/src/minitest/rails-plugin.ts
@@ -3,12 +3,8 @@
  * `railties/lib/minitest/rails_plugin.rb`.
  */
 
-import { env, Minitest, type BacktraceFilter } from "@blazetrails/activesupport";
+import { env, Minitest } from "@blazetrails/activesupport";
 import { Trails } from "../rails.js";
-
-interface BacktraceFilterLike {
-  filter(backtrace: string[]): string[];
-}
 
 /**
  * Mirrors `Minitest::BacktraceFilterWithFallback` (rails_plugin.rb:8-19) — runs
@@ -23,10 +19,13 @@ interface BacktraceFilterLike {
  * `widen-trailties-libpath-to-cover-lib-minitest`.
  */
 export class BacktraceFilterWithFallback {
-  private preferred: BacktraceFilterLike;
-  private fallback: BacktraceFilterLike;
+  private preferred: { filter(backtrace: string[]): string[] };
+  private fallback: { filter(backtrace: string[]): string[] };
 
-  constructor(preferred: BacktraceFilterLike, fallback: BacktraceFilterLike) {
+  constructor(
+    preferred: { filter(backtrace: string[]): string[] },
+    fallback: { filter(backtrace: string[]): string[] },
+  ) {
     this.preferred = preferred;
     this.fallback = fallback;
   }
@@ -40,7 +39,9 @@ export class BacktraceFilterWithFallback {
 
 /**
  * Mirrors `Minitest.plugin_rails_init` (rails_plugin.rb:111-136) — replaces
- * `Minitest.backtrace_filter` with one that silences gem lines.
+ * `Minitest.backtrace_filter` with one that silences gem lines. Rails guards the
+ * assignment with `::Rails.respond_to?(:backtrace_cleaner)` because the plugin
+ * can run without Rails loaded; `Trails.backtraceCleaner` is the trails seat.
  *
  * @missingRailsCall rails_plugin.rb:122-135 swaps three Minitest reporters
  * (`SummaryReporter`, `ProgressReporter`, `ProfileReporter`). trails has no
@@ -50,17 +51,15 @@ export class BacktraceFilterWithFallback {
  * @noRailsEquivalent Ports `Minitest.plugin_rails_init`, which the comparator
  * cannot see for the libPath reason on {@link BacktraceFilterWithFallback}.
  */
-export function pluginRailsInit(options: { fullBacktrace?: boolean } = {}): void {
+export function pluginRailsInit(options: { fullBacktrace?: boolean }): void {
   if (env.RAILS_ENV == null && env.RAILS_MINITEST_PLUGIN == null) return;
 
   if (options.fullBacktrace !== true) {
-    // Rails guards with `::Rails.respond_to?(:backtrace_cleaner)` because the
-    // plugin can run without Rails loaded.
     if (Trails.backtraceCleaner != null) {
       Minitest.backtraceFilter = new BacktraceFilterWithFallback(
         Trails.backtraceCleaner,
         Minitest.backtraceFilter,
-      ) as unknown as BacktraceFilter;
+      );
     }
   }
 }

--- a/packages/trailties/src/minitest/rails-plugin.ts
+++ b/packages/trailties/src/minitest/rails-plugin.ts
@@ -1,0 +1,66 @@
+/**
+ * Port of minitest's Rails plugin from
+ * `railties/lib/minitest/rails_plugin.rb`.
+ */
+
+import { env, Minitest, type BacktraceFilter } from "@blazetrails/activesupport";
+import { Trails } from "../rails.js";
+
+interface BacktraceFilterLike {
+  filter(backtrace: string[]): string[];
+}
+
+/**
+ * Mirrors `Minitest::BacktraceFilterWithFallback` (rails_plugin.rb:8-19) — runs
+ * the preferred filter and falls back to the previous one when it silences
+ * everything.
+ *
+ * @noRailsEquivalent Ports a real Rails class, but `railties/lib/minitest/` sits
+ * outside the trailties libPath the API comparator scans
+ * (`railties/lib/rails`, vendor/sources.ts:128), so it cannot be matched —
+ * the same reason `Minitest::BacktraceFilter` carries one in
+ * `activesupport/src/testing/assertions.ts`. Tracked by
+ * `widen-trailties-libpath-to-cover-lib-minitest`.
+ */
+export class BacktraceFilterWithFallback {
+  private preferred: BacktraceFilterLike;
+  private fallback: BacktraceFilterLike;
+
+  constructor(preferred: BacktraceFilterLike, fallback: BacktraceFilterLike) {
+    this.preferred = preferred;
+    this.fallback = fallback;
+  }
+
+  filter(backtrace: string[]): string[] {
+    let filtered = this.preferred.filter(backtrace);
+    if (filtered.length === 0) filtered = this.fallback.filter(backtrace);
+    return filtered;
+  }
+}
+
+/**
+ * Mirrors `Minitest.plugin_rails_init` (rails_plugin.rb:111-136) — replaces
+ * `Minitest.backtrace_filter` with one that silences gem lines.
+ *
+ * @missingRailsCall rails_plugin.rb:122-135 swaps three Minitest reporters
+ * (`SummaryReporter`, `ProgressReporter`, `ProfileReporter`). trails has no
+ * Minitest reporter surface to swap — vitest owns reporting — so only the
+ * backtrace-filter arm (:115-120) is ported.
+ *
+ * @noRailsEquivalent Ports `Minitest.plugin_rails_init`, which the comparator
+ * cannot see for the libPath reason on {@link BacktraceFilterWithFallback}.
+ */
+export function pluginRailsInit(options: { fullBacktrace?: boolean } = {}): void {
+  if (env.RAILS_ENV == null && env.RAILS_MINITEST_PLUGIN == null) return;
+
+  if (options.fullBacktrace !== true) {
+    // Rails guards with `::Rails.respond_to?(:backtrace_cleaner)` because the
+    // plugin can run without Rails loaded.
+    if (Trails.backtraceCleaner != null) {
+      Minitest.backtraceFilter = new BacktraceFilterWithFallback(
+        Trails.backtraceCleaner,
+        Minitest.backtraceFilter,
+      ) as unknown as BacktraceFilter;
+    }
+  }
+}

--- a/packages/trailties/src/minitest/rails-plugin.ts
+++ b/packages/trailties/src/minitest/rails-plugin.ts
@@ -11,7 +11,8 @@ import { Trails } from "../rails.js";
  * the preferred filter and falls back to the previous one when it silences
  * everything.
  *
- * @noRailsEquivalent Ports a real Rails class, but `railties/lib/minitest/` sits
+ * @noRailsEquivalent CONVERGEABLE — comparator gap, not a deviation. Ports a
+ * real Rails class, but `railties/lib/minitest/` sits
  * outside the trailties libPath the API comparator scans
  * (`railties/lib/rails`, vendor/sources.ts:128), so it cannot be matched —
  * the same reason `Minitest::BacktraceFilter` carries one in
@@ -48,8 +49,10 @@ export class BacktraceFilterWithFallback {
  * Minitest reporter surface to swap — vitest owns reporting — so only the
  * backtrace-filter arm (:115-120) is ported.
  *
- * @noRailsEquivalent Ports `Minitest.plugin_rails_init`, which the comparator
- * cannot see for the libPath reason on {@link BacktraceFilterWithFallback}.
+ * @noRailsEquivalent CONVERGEABLE — comparator gap, not a deviation. Ports
+ * `Minitest.plugin_rails_init`, which the comparator cannot see for the libPath
+ * reason on {@link BacktraceFilterWithFallback}; same story,
+ * `widen-trailties-libpath-to-cover-lib-minitest`.
  */
 export function pluginRailsInit(options: { fullBacktrace?: boolean }): void {
   if (env.RAILS_ENV == null && env.RAILS_MINITEST_PLUGIN == null) return;

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/core.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/core.json
@@ -110,17 +110,5 @@
     "rubyName": "preventing_writes?",
     "call": "include?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "core.ts",
-    "rubyName": "strict_loading_violation!",
-    "call": "instrument",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:name",
-      "kwargs{owner=ref:owner,reflection=ref:reflection}"
-    ],
-    "reason": "core.rb:253-262 takes `owner:`/`reflection:` kwargs and instruments them verbatim; trails takes positional `(owner, reflection: string)` and synthesizes `ownerClass`/`reflectionLike`, so the values converge only with the signature — tracked by story `converge-strict-loading-violation-signature`."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/hash-utils.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/hash-utils.json
@@ -73,12 +73,5 @@
       "ref:otherHash"
     ],
     "reason": "Ruby's `reverse_merge(other_hash)` is called on the receiver; trails' core_ext functions take the receiver as the leading positional, so the same call carries one extra argument."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "hash-utils.ts",
-    "rubyName": "slice!",
-    "call": "replace",
-    "reason": "Ruby's `Hash#replace` swaps a hash's contents in place; JS objects have no such method, so the port clears the own keys and `Object.assign`s the sliced result — the same in-place replacement."
   }
 ]


### PR DESCRIPTION
Four bundled convergence stories.

### 1. `strict_loading_violation!` takes Rails' kwargs

`core.rb:253-262` is `def self.strict_loading_violation!(owner:, reflection:)`,
cases on `:raise` first, and instruments the pair verbatim. trails took
positional `(owner, reflection: string, options)` and synthesized a
`reflectionLike` object and an `ownerClass`, so the kwarg VALUES could not
converge without the signature. It now takes `{ owner, reflection }` with a real
reflection (the one `_reflectOnAssociation` returns, which already carries
`strictLoadingViolationMessage` — reflection.rb:344), in Rails' branch order
with the `name` local. All four call sites pass `owner.class` and the registered
reflection, the way `association.rb:250` does.

The RFC 0095 `args` baseline row for it is deleted (only-shrink).

### 2. `Hash#slice!` joins `extract!` at its Rails path

`core_ext/hash/slice.rb` defines two methods; #6468 moved only `extract!` to
`core-ext/hash/slice.ts`, leaving `slice!` in the invented `hash-utils.ts`
aggregate — one Rails file split across two TS files, with the invented one
holding half. `sliceBang` now lives beside `extractBang` and is re-exported from
the flat index unchanged. It already returned `omit` per slice.rb:16; the
`default` / `default_proc` lines have no JS seat and are cited as such.
`Hash#slice` now probes own keys (`Object.hasOwn`), matching Ruby's `has_key?`
basis and the guard `extractBang` uses. Its stale call-mismatch row is deleted.

### 3. `BacktraceFilter#filter` gains the `MT_DEBUG` arm

minitest-6.0.6 `lib/minitest.rb:1194` is
`return bt.dup if $DEBUG || ENV["MT_DEBUG"]`. The `ENV` half is now ported
through `process-adapter` (no `process.*` in runtime code); Ruby truthiness makes
a set-but-empty `MT_DEBUG` count, hence `!= null`. `$DEBUG` has no JS analogue —
there is no interpreter-wide debug global — and is cited at the call site as the
unportable half.

Story 3's second half is now ported too, not deferred. `Rails.backtrace_cleaner`
turned out to already exist in trails as `Trails.backtraceCleaner`
(`packages/trailties/src/rails.ts:116`, over the `Rails::BacktraceCleaner` port
at `trailties/src/backtrace-cleaner.ts`), so the dependency the first pass filed
a story for was in fact available. `packages/trailties/src/minitest/rails-plugin.ts`
now carries `BacktraceFilterWithFallback` (rails_plugin.rb:8-19) verbatim and
`pluginRailsInit`'s backtrace-filter arm (rails_plugin.rb:112-120), including the
`RAILS_ENV` / `RAILS_MINITEST_PLUGIN` guard, the `full_backtrace` option, and the
`respond_to?(:backtrace_cleaner)` check. `BacktraceCleaner#filter` gains Ruby's
`alias :filter :clean` (backtrace_cleaner.rb:57), which is the method
`BacktraceFilterWithFallback` calls on it.

`plugin_rails_init`'s other three blocks (rails_plugin.rb:122-135) swap Minitest
reporters, which trails has no surface for — vitest owns reporting — so they
carry a `@missingRailsCall` at the call site.

`packages/trailties/src/minitest/rails-plugin.test.ts` ports
`railties/test/minitest/rails_plugin_test.rb`'s three backtrace-filter tests
under their Rails names verbatim; `parity:test` credits them (the trailties
`testPath` already covers `railties/test/minitest/`). The remaining tests in that
Rails file assert reporter replacement, which is the unported arm above.

The API comparator cannot match the new file: trailties' scanned libPath is
`railties/lib/rails` (`vendor/sources.ts:128`), and `rails_plugin.rb` lives in
`railties/lib/minitest`. The two public names therefore carry
`@noRailsEquivalent` receipts naming that tooling gap — the same reason
`Minitest::BacktraceFilter` carries one in `assertions.ts` — and
`widen-trailties-libpath-to-cover-lib-minitest` is filed to close it and delete
both tags.

### 4. `blank?` / `present?` at the Rails path

`core-ext/object/blank.ts` already held blank.rb's per-class arms but imported
the actual answer from `string-utils.ts`, a file with no Rails counterpart. The
`Object#blank?` entry point (blank.rb:18-20) now lives in blank.ts, switching on
the value class in blank.rb's own order and routing to each class's arm;
`string-utils.ts` re-exports it so its long-standing importers keep working.

The three private `isBlank`/`isPresent` copies in actionpack
(`strong-parameters.ts`, `http/url.ts`, `journey/formatter.ts`) — each a
different subset of blank.rb, disagreeing on `Set`, whitespace strings, and `0` —
are deleted in favour of it. To keep strong-parameters' `Parameters` arm,
`Object#blank?`'s `respond_to?(:empty?)` probe is now general: a boolean-valued
`isEmpty` / `empty` reader answers. It is deliberately not invoked when
method-shaped, because trails has async ones (`Relation#isEmpty` runs a query)
and Ruby's `blank?` issues no I/O.

### Verification

`pnpm parity:api:calls` and `pnpm parity:api:calls:args` both green (two rows
deleted, none added); `parity:api:extra` shows no new novel name; `pnpm lint`
and `pnpm typecheck` clean. Tests: full `activesupport` suite (4532),
`activerecord/src/associations` (2147), `strict-loading.test.ts` (54),
`actionpack/{action-controller,action-dispatch}`, and the new
`trailties/src/minitest` — all green.

Closes-story: converge-strict-loading-violation-signature
Closes-story: hash-slice-bang-reachable-under-its-rails-subpath
Closes-story: minitest-backtrace-filter-debug-arm-and-rails-plugin
Closes-story: port-object-blank-to-core-ext-and-retire-private-copies
Closes-story: port-rails-plugin-backtrace-filter-assignment
