### PR TITLE
refactor(activerecord,rack,trailties): converge three call-argument divergences

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -5788,9 +5788,15 @@ export class Relation<T extends Base> {
    *
    * Mirrors: ActiveRecord::Relation#update
    */
-  async update(id: unknown = ":all", attributes?: Record<string, unknown>): Promise<T | T[]> {
-    if (attributes === undefined && id !== ":all") {
-      attributes = (id ?? {}) as Record<string, unknown>;
+  update(attributes: Record<string, unknown>): Promise<T[]>;
+  update(id: ":all", attributes: Record<string, unknown>): Promise<T[]>;
+  update(id: unknown, attributes: Record<string, unknown>): Promise<T>;
+  async update(id?: unknown, attributes?: Record<string, unknown>): Promise<T | T[]> {
+    if (arguments.length === 0) {
+      throw new ArgumentError("wrong number of arguments (given 0, expected 1..2)");
+    }
+    if (arguments.length === 1) {
+      attributes = id as Record<string, unknown>;
       id = ":all";
     }
     if (id === ":all") {
@@ -5809,9 +5815,15 @@ export class Relation<T extends Base> {
    *
    * Mirrors: ActiveRecord::Relation#update!
    */
-  async updateBang(id: unknown = ":all", attributes?: Record<string, unknown>): Promise<T | T[]> {
-    if (attributes === undefined && id !== ":all") {
-      attributes = (id ?? {}) as Record<string, unknown>;
+  updateBang(attributes: Record<string, unknown>): Promise<T[]>;
+  updateBang(id: ":all", attributes: Record<string, unknown>): Promise<T[]>;
+  updateBang(id: unknown, attributes: Record<string, unknown>): Promise<T>;
+  async updateBang(id?: unknown, attributes?: Record<string, unknown>): Promise<T | T[]> {
+    if (arguments.length === 0) {
+      throw new ArgumentError("wrong number of arguments (given 0, expected 1..2)");
+    }
+    if (arguments.length === 1) {
+      attributes = id as Record<string, unknown>;
       id = ":all";
     }
     if (id === ":all") {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -5788,17 +5788,22 @@ export class Relation<T extends Base> {
    *
    * Mirrors: ActiveRecord::Relation#update
    */
-  async update(id?: unknown, attrs?: Record<string, unknown>): Promise<T | T[]> {
-    if (id === undefined || (typeof id === "object" && id !== null && attrs === undefined)) {
-      // update(attrs) form — update all matching records
-      const updates = (id ?? {}) as Record<string, unknown>;
+  async update(id: unknown = ":all", attributes?: Record<string, unknown>): Promise<T | T[]> {
+    // Ruby's `update(id = :all, attributes)` fills the trailing required arg
+    // first, so a one-argument call is `update(attributes)` with id == :all.
+    if (attributes === undefined) {
+      attributes = (id ?? {}) as Record<string, unknown>;
+      id = ":all";
+    }
+    if (id === ":all") {
       const records = await this.toArray();
       for (const record of records) {
-        await record.update(updates);
+        await record.update(attributes);
       }
       return records;
+    } else {
+      return (await this.model.update(id, attributes)) as T;
     }
-    return (await this.model.update(id, attrs ?? {})) as T;
   }
 
   /**
@@ -5806,16 +5811,20 @@ export class Relation<T extends Base> {
    *
    * Mirrors: ActiveRecord::Relation#update!
    */
-  async updateBang(id?: unknown, attrs?: Record<string, unknown>): Promise<T | T[]> {
-    if (id === undefined || (typeof id === "object" && id !== null && attrs === undefined)) {
-      const updates = (id ?? {}) as Record<string, unknown>;
+  async updateBang(id: unknown = ":all", attributes?: Record<string, unknown>): Promise<T | T[]> {
+    if (attributes === undefined) {
+      attributes = (id ?? {}) as Record<string, unknown>;
+      id = ":all";
+    }
+    if (id === ":all") {
       const records = await this.toArray();
       for (const record of records) {
-        await record.updateBang(updates);
+        await record.updateBang(attributes);
       }
       return records;
+    } else {
+      return (await this.model.updateBang(id, attributes)) as T;
     }
-    return (await this.model.updateBang(id, attrs ?? {})) as T;
   }
 
   /**

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -5789,20 +5789,18 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#update
    */
   async update(id: unknown = ":all", attributes?: Record<string, unknown>): Promise<T | T[]> {
-    // Ruby's `update(id = :all, attributes)` fills the trailing required arg
-    // first, so a one-argument call is `update(attributes)` with id == :all.
-    if (attributes === undefined) {
+    if (attributes === undefined && id !== ":all") {
       attributes = (id ?? {}) as Record<string, unknown>;
       id = ":all";
     }
     if (id === ":all") {
       const records = await this.toArray();
       for (const record of records) {
-        await record.update(attributes);
+        await record.update(attributes!);
       }
       return records;
     } else {
-      return (await this.model.update(id, attributes)) as T;
+      return (await this.model.update(id, attributes!)) as T;
     }
   }
 
@@ -5812,18 +5810,18 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#update!
    */
   async updateBang(id: unknown = ":all", attributes?: Record<string, unknown>): Promise<T | T[]> {
-    if (attributes === undefined) {
+    if (attributes === undefined && id !== ":all") {
       attributes = (id ?? {}) as Record<string, unknown>;
       id = ":all";
     }
     if (id === ":all") {
       const records = await this.toArray();
       for (const record of records) {
-        await record.updateBang(attributes);
+        await record.updateBang(attributes!);
       }
       return records;
     } else {
-      return (await this.model.updateBang(id, attributes)) as T;
+      return (await this.model.updateBang(id, attributes!)) as T;
     }
   }
 

--- a/packages/rack/src/multipart/parser.test.ts
+++ b/packages/rack/src/multipart/parser.test.ts
@@ -3,6 +3,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { fileURLToPath } from "node:url";
 import {
+  BoundedIO,
   Parser,
   BoundaryTooLongError,
   EmptyContentError,
@@ -142,6 +143,20 @@ describe("Rack::Multipart::Parser", () => {
     } finally {
       setMultipartFileLimit(prev);
     }
+  });
+
+  it("bounds the read by content length in bytes", () => {
+    let calls = 0;
+    const io = {
+      read: (_size: number) => {
+        calls++;
+        return "\u00e9";
+      },
+    };
+    const bounded = new BoundedIO(io, 2);
+    expect(bounded.read(10)).toBe("\u00e9");
+    expect(bounded.read(10)).toBeNull();
+    expect(calls).toBe(1);
   });
 
   it("reaches a multipart total limit", () => {

--- a/packages/rack/src/multipart/parser.ts
+++ b/packages/rack/src/multipart/parser.ts
@@ -67,7 +67,7 @@ export class BoundedIO {
 
     const str = left < size ? this.io.read(left, outbuf) : this.io.read(size, outbuf);
     if (str) {
-      this.cursor += str.length;
+      this.cursor += new TextEncoder().encode(str).length;
     } else {
       throw new EmptyContentError("bad content body");
     }

--- a/packages/rack/src/multipart/parser.ts
+++ b/packages/rack/src/multipart/parser.ts
@@ -55,15 +55,17 @@ Object.freeze(EMPTY);
 export class BoundedIO {
   private cursor = 0;
   constructor(
-    private io: { read(n: number): string | null },
+    private io: { read(n: number, outbuf?: string): string | null },
     private contentLength: number,
   ) {}
 
   /** @internal */
-  read(size: number, _outbuf?: string): string | null {
+  read(size: number, outbuf?: string): string | null {
     if (this.cursor >= this.contentLength) return null;
+
     const left = this.contentLength - this.cursor;
-    const str = this.io.read(left < size ? left : size);
+
+    const str = left < size ? this.io.read(left, outbuf) : this.io.read(size, outbuf);
     if (str) {
       this.cursor += str.length;
     } else {
@@ -294,8 +296,9 @@ export class Parser {
     this.headRe = new RegExp(`(.*?${EOL})${EOL}`, "s");
   }
 
-  parse(io: { read(n: number): string | null }) {
-    this.readData(io);
+  parse(io: { read(n: number, outbuf?: string): string | null }) {
+    const outbuf = "";
+    this.readData(io, outbuf);
     while (true) {
       let s: void | "want_read";
       if (this.state === "FAST_FORWARD") s = this.handleFastForward();
@@ -303,7 +306,7 @@ export class Parser {
       else if (this.state === "MIME_HEAD") s = this.handleMimeHead();
       else if (this.state === "MIME_BODY") s = this.handleMimeBody();
       else return;
-      if (s === "want_read") this.readData(io);
+      if (s === "want_read") this.readData(io, outbuf);
     }
   }
 
@@ -323,10 +326,13 @@ export class Parser {
     return (m ? m[1] : str).replace(/\\(.)/g, "$1");
   }
 
-  /** @internal */ private readData(io: { read(n: number): string | null }) {
-    const c = io.read(this.bufsize);
-    this.handleEmptyContentBang(c);
-    this.sb.concat(c!);
+  /** @internal */ private readData(
+    io: { read(n: number, outbuf?: string): string | null },
+    outbuf: string,
+  ) {
+    const content = io.read(this.bufsize, outbuf);
+    this.handleEmptyContentBang(content);
+    this.sb.concat(content!);
   }
 
   /** @internal */ private handleFastForward(): void | "want_read" {

--- a/packages/trailties/src/source-annotation-extractor.ts
+++ b/packages/trailties/src/source-annotation-extractor.ts
@@ -59,11 +59,13 @@ registerDefaults();
 export class SourceAnnotationExtractor {
   static async enumerate(
     tag: string | null = null,
-    options: { dirs?: readonly string[]; tag?: boolean } = {},
+    options: AnnotationOptions & { dirs?: readonly string[] } = {},
   ): Promise<string> {
-    const extractor = new SourceAnnotationExtractor(tag ?? tags.join("|"));
-    const results = await extractor.find(options.dirs ?? directories);
-    return extractor.display(results, { tag: options.tag });
+    tag ??= tags.join("|");
+    const extractor = new SourceAnnotationExtractor(tag);
+    const dirs = options.dirs ?? directories;
+    delete options.dirs;
+    return extractor.display(await extractor.find(dirs), options);
   }
 
   constructor(public readonly tag: string) {}


### PR DESCRIPTION
Converges the call-argument divergences listed in
`converge-weak-receiver-surfaced-call-arg-rows` (RFC 0099).

The prerequisite gate PR (`call-args-weak-receiver-sites-excluded-from-population`)
never landed, so none of the seven baseline rows exist in `main` — there was
nothing to delete under `scripts/api-compare/call-mismatches-exclude/`. The
underlying divergences are real either way, so this PR converges the bodies.

## Converged

- **`Relation#update` / `#update!`** (`activerecord/lib/active_record/relation.rb:621,629`).
  Rails' signature is `update(id = :all, attributes)`: the trailing required arg
  is filled first, so a one-argument call means `id == :all`. The port branched
  on `id === undefined` / "first arg is an object", and passed `updates` /
  `attrs ?? {}`. Now it mirrors the Ruby — the `":all"` sentinel (a Ruby Symbol
  is a colon-prefixed string), Rails' `attributes` parameter name, and
  `record.update(attributes)` / `model.update(id, attributes)` at the call sites.
  `attributes` stays required: overloads reject a zero-arg call at the type
  surface, and the body raises `ArgumentError("wrong number of arguments (given
  0, expected 1..2)")` — MRI's own message for `def update(id = :all,
  attributes)`, verified with `ruby -e`. One-arg calls bind the trailing
  required arg first, exactly as Ruby does (so `update(":all")` means
  `attributes == ":all"`, which MRI also accepts without raising).
- **`Multipart::Parser#read_data`** (`rack/lib/rack/multipart/parser.rb:258`).
  Rails is `read_data(io, outbuf)` calling `io.read(@bufsize, outbuf)`; the port
  dropped `outbuf` entirely. `parse` now builds `outbuf` (parser.rb:218) and
  passes it at both call sites (218, 236), and `BoundedIO#read` forwards it
  through both arms instead of collapsing them (parser.rb:55-63). Local `c` is
  Rails' `content`. `BoundedIO#read` also advances `@cursor` by `str.bytesize`
  (parser.rb:67), not JS string length — `contentLength` is byte-based, so a
  non-ASCII body previously let the bounded reader run past the declared
  length. Covered by a regression test that fails on the baseline.
- **`SourceAnnotationExtractor.enumerate`**
  (`railties/lib/rails/source_annotation_extractor.rb:145`). Rails does
  `dirs = options.delete(:dirs) || ...` then
  `extractor.display(extractor.find(dirs), options)` — the whole options hash is
  forwarded. The port reconstructed `{ tag: options.tag }`, silently dropping
  every other key.

## Not converged here

Both are now tracked by RFC 0099's
`weak-receiver-rows-residual-mixin-call-pairing`, filed with the full
disposition and the `file:line` citations below, so nothing disappears from the
story state when this PR closes its parent.

- **`actiondispatch http/request.ts` → `strategy.call(raw_post)`** is a pairing
  artifact, not a divergence: the real site in
  `action-dispatch/http/parameters.ts` already passes `this.rawPost`
  (`parameters.rb:95`). The row paired Rails' `strategy.call` against the
  `Function.prototype.call` of the settled Ruby-`include` mixin idiom in
  `request.ts`'s delegating wrapper. Nothing to change.
- **The two `activesupport testing/time-helpers.ts` rows** (`stub_object` /
  `stubbing` receiving `clock` where Rails passes `Time`) are exactly the
  deviation already owned by RFC 0098's ready story
  `time-helpers-stub-date-and-datetime-clock`, and are documented as such on
  the `clock` holder's `@noRailsEquivalent CONVERGEABLE` tag in
  `time-travel.ts`. Converging them means routing the trails clock through
  `@blazetrails/date`'s `Time.now` / `Date.today` / `DateTime.now`, which is
  that story's whole scope.

## Verification

`pnpm parity:api:calls` and `pnpm parity:api:calls:args` both green
(`call-mismatches ratchet: OK`, `call-args ratchet: OK (255 baselined shape rows)`).
`relation`, `relations`, `persistence`, rack `multipart`, and trailties
`source-annotation-extractor` suites pass.

Closes-story: converge-weak-receiver-surfaced-call-arg-rows
