### PR TITLE
refactor(activerecord): thread Rails' async kwarg through the select family

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -571,16 +571,27 @@ export interface AbstractAdapter {
     arel: string | unknown,
     name?: string | null,
     binds?: unknown[],
-    opts?: { allowRetry?: boolean; preparable?: boolean | null },
+    opts?: { allowRetry?: boolean; preparable?: boolean | null; async?: boolean },
   ): Promise<Result>;
   selectOne(
     arel: unknown,
     name?: string | null,
     binds?: unknown[],
+    opts?: { async?: boolean },
   ): Promise<Record<string, unknown> | undefined>;
-  selectValue(arel: unknown, name?: string | null, binds?: unknown[]): Promise<unknown>;
+  selectValue(
+    arel: unknown,
+    name?: string | null,
+    binds?: unknown[],
+    opts?: { async?: boolean },
+  ): Promise<unknown>;
   selectValues(arel: unknown, name?: string | null, binds?: unknown[]): Promise<unknown[]>;
-  selectRows(arel: unknown, name?: string | null, binds?: unknown[]): Promise<unknown[][]>;
+  selectRows(
+    arel: unknown,
+    name?: string | null,
+    binds?: unknown[],
+    opts?: { async?: boolean },
+  ): Promise<unknown[][]>;
   queryValue(sql: string, name?: string | null, binds?: unknown[]): Promise<unknown>;
   queryValues(sql: string, name?: string | null, binds?: unknown[]): Promise<unknown[]>;
   execQuery(

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements-select-async.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements-select-async.trails.test.ts
@@ -1,0 +1,68 @@
+/**
+ * trails-only regression coverage for the `async:` kwarg on the select family.
+ *
+ * Rails' select_one/select_value/select_rows forward `async:` down to
+ * select_all (database_statements.rb:85, :90, :102), which is what turns a
+ * `load_async` relation into a FutureResult. trails previously dropped the
+ * kwarg at every one of those call sites, so a caller asking for an async
+ * select reached select_all with no record of having asked. Rails' own
+ * coverage lives in relation/load_async_test.rb, which is fully excluded
+ * (scripts/parity/unported-files/unscoped.ts) because it asserts
+ * FutureResult/scheduled? semantics — the forwarding itself still needs a home.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { Base } from "../../index.js";
+import type { AbstractAdapter } from "../abstract-adapter.js";
+import { fixtures } from "../../test-fixtures.js";
+
+describe("DatabaseStatements select async kwarg", () => {
+  fixtures({});
+
+  function conn(): AbstractAdapter {
+    return Base.connection as unknown as AbstractAdapter;
+  }
+
+  // Spy on the instance, not the prototype: the fixture harness restores its
+  // own property and would shadow a prototype spy so it never fires.
+  const spySelectAll = () => vi.spyOn(conn(), "selectAll");
+
+  it("select_one forwards async to select_all", async () => {
+    const spy = spySelectAll();
+    try {
+      await conn().selectOne("SELECT 1 AS one", "SQL", [], { async: true });
+      expect(spy.mock.calls[0][3]).toEqual({ async: true });
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("select_rows forwards async to select_all", async () => {
+    const spy = spySelectAll();
+    try {
+      await conn().selectRows("SELECT 1 AS one", "SQL", [], { async: true });
+      expect(spy.mock.calls[0][3]).toEqual({ async: true });
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("select_value forwards async to select_rows", async () => {
+    const spy = vi.spyOn(conn(), "selectRows");
+    try {
+      await conn().selectValue("SELECT 1 AS one", "SQL", [], { async: true });
+      expect(spy.mock.calls[0][3]).toEqual({ async: true });
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("defaults async to false", async () => {
+    const spy = spySelectAll();
+    try {
+      await conn().selectOne("SELECT 1 AS one");
+      expect(spy.mock.calls[0][3]).toEqual({ async: false });
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements-select-async.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements-select-async.trails.test.ts
@@ -10,7 +10,7 @@
  * (scripts/parity/unported-files/unscoped.ts) because it asserts
  * FutureResult/scheduled? semantics — the forwarding itself still needs a home.
  */
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { Base } from "../../index.js";
 import type { AbstractAdapter } from "../abstract-adapter.js";
 import { fixtures } from "../../test-fixtures.js";
@@ -26,43 +26,31 @@ describe("DatabaseStatements select async kwarg", () => {
   // own property and would shadow a prototype spy so it never fires.
   const spySelectAll = () => vi.spyOn(conn(), "selectAll");
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("select_one forwards async to select_all", async () => {
     const spy = spySelectAll();
-    try {
-      await conn().selectOne("SELECT 1 AS one", "SQL", [], { async: true });
-      expect(spy.mock.calls[0][3]).toEqual({ async: true });
-    } finally {
-      spy.mockRestore();
-    }
+    await conn().selectOne("SELECT 1 AS one", "SQL", [], { async: true });
+    expect(spy.mock.calls[0][3]).toEqual({ async: true });
   });
 
   it("select_rows forwards async to select_all", async () => {
     const spy = spySelectAll();
-    try {
-      await conn().selectRows("SELECT 1 AS one", "SQL", [], { async: true });
-      expect(spy.mock.calls[0][3]).toEqual({ async: true });
-    } finally {
-      spy.mockRestore();
-    }
+    await conn().selectRows("SELECT 1 AS one", "SQL", [], { async: true });
+    expect(spy.mock.calls[0][3]).toEqual({ async: true });
   });
 
   it("select_value forwards async to select_rows", async () => {
     const spy = vi.spyOn(conn(), "selectRows");
-    try {
-      await conn().selectValue("SELECT 1 AS one", "SQL", [], { async: true });
-      expect(spy.mock.calls[0][3]).toEqual({ async: true });
-    } finally {
-      spy.mockRestore();
-    }
+    await conn().selectValue("SELECT 1 AS one", "SQL", [], { async: true });
+    expect(spy.mock.calls[0][3]).toEqual({ async: true });
   });
 
   it("defaults async to false", async () => {
     const spy = spySelectAll();
-    try {
-      await conn().selectOne("SELECT 1 AS one");
-      expect(spy.mock.calls[0][3]).toEqual({ async: false });
-    } finally {
-      spy.mockRestore();
-    }
+    await conn().selectOne("SELECT 1 AS one");
+    expect(spy.mock.calls[0][3]).toEqual({ async: false });
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -1583,14 +1583,11 @@ export const DatabaseStatements = {
     // is correct for every shape that carries binds.
     const preparable = compiledPreparable ?? (binds != null && binds.length > 0);
     const prepare = !!((this as { preparedStatements?: boolean }).preparedStatements && preparable);
-    // Rails passes `async: async && FutureResult::SelectAll` down into `select`
-    // (database_statements.rb:74), which schedules the query on the async
-    // executor and hands back a FutureResult the caller resolves later. Every
-    // trails select already returns a Promise, so the `async` kwarg the select
-    // family forwards here collapses into that Promise — see the future_result.rb
-    // entry in scripts/parity/unported-files/unscoped.ts. It is accepted and
-    // threaded so the forwarding call sites match Rails' argument lists; the
-    // scheduling half lands with the load_async port.
+    // Rails passes `async: async && FutureResult::SelectAll` into `select`
+    // (database_statements.rb:74) so the caller gets a FutureResult to resolve
+    // later; a trails select already returns that Promise, which is what the
+    // forwarded `async` collapses to here (future_result.rb is permanently
+    // unported — scripts/parity/unported-files/unscoped.ts:21).
     try {
       // Rails' select_all runs `internal_exec_query` (the private work method),
       // NOT the public `exec_query` — the latter is wrapped by

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -105,7 +105,7 @@ export interface DatabaseStatementsHost {
     sql: string,
     name?: string | null,
     binds?: unknown[],
-    opts?: { allowRetry?: boolean; preparable?: boolean | null },
+    opts?: { allowRetry?: boolean; preparable?: boolean | null; async?: boolean },
   ): Promise<Result>;
   /** @internal */
   internalExecute?(
@@ -402,7 +402,12 @@ export function cacheableQuery(
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#select_all
  */
-export function selectAll(sql: string, _name?: string | null, _binds?: unknown[]): Promise<Result> {
+export function selectAll(
+  sql: string,
+  _name?: string | null,
+  _binds?: unknown[],
+  _opts?: { allowRetry?: boolean; preparable?: boolean | null; async?: boolean },
+): Promise<Result> {
   throw new Error("selectAll must be implemented by adapter subclass");
 }
 
@@ -416,9 +421,10 @@ export async function selectOne(
   sql: string,
   name: string | null = null,
   binds?: unknown[],
+  { async = false }: { async?: boolean } = {},
 ): Promise<Record<string, unknown> | undefined> {
   const doSelect = (this as DatabaseStatementsHost)?.selectAll ?? selectAll;
-  const result = await doSelect(sql, name, binds);
+  const result = await doSelect(sql, name, binds, { async });
   return result.first();
 }
 
@@ -432,8 +438,11 @@ export function selectValue(
   sql: string,
   name: string | null = null,
   binds?: unknown[],
+  { async = false }: { async?: boolean } = {},
 ): Promise<unknown> {
-  return selectRows.call(this, sql, name, binds).then((rows) => singleValueFromRows(rows));
+  return selectRows
+    .call(this, sql, name, binds, { async })
+    .then((rows) => singleValueFromRows(rows));
 }
 
 /**
@@ -460,9 +469,10 @@ export async function selectRows(
   sql: string,
   name: string | null = null,
   binds?: unknown[],
+  { async = false }: { async?: boolean } = {},
 ): Promise<unknown[][]> {
   const doSelect = (this as DatabaseStatementsHost)?.selectAll ?? selectAll;
-  const result = await doSelect(sql, name, binds);
+  const result = await doSelect(sql, name, binds, { async });
   return result.rows;
 }
 
@@ -1464,9 +1474,14 @@ interface DatabaseStatementsDefaultsHost {
     arel: unknown,
     name?: string | null,
     binds?: unknown[],
-    opts?: { allowRetry?: boolean; preparable?: boolean | null },
+    opts?: { allowRetry?: boolean; preparable?: boolean | null; async?: boolean },
   ): Promise<Result>;
-  selectRows(arel: unknown, name?: string | null, binds?: unknown[]): Promise<unknown[][]>;
+  selectRows(
+    arel: unknown,
+    name?: string | null,
+    binds?: unknown[],
+    opts?: { async?: boolean },
+  ): Promise<unknown[][]>;
   execQuery(
     sql: string,
     name?: string | null,
@@ -1542,7 +1557,7 @@ export const DatabaseStatements = {
     arel: unknown,
     name: string | null = null,
     binds?: unknown[],
-    opts?: { allowRetry?: boolean; preparable?: boolean | null },
+    opts?: { allowRetry?: boolean; preparable?: boolean | null; async?: boolean },
   ): Promise<Result> {
     // Rails: `arel = arel_from_relation(arel)` then `sql, binds, preparable,
     // allow_retry = to_sql_and_binds(...)` (database_statements.rb:69-71) — a
@@ -1568,6 +1583,14 @@ export const DatabaseStatements = {
     // is correct for every shape that carries binds.
     const preparable = compiledPreparable ?? (binds != null && binds.length > 0);
     const prepare = !!((this as { preparedStatements?: boolean }).preparedStatements && preparable);
+    // Rails passes `async: async && FutureResult::SelectAll` down into `select`
+    // (database_statements.rb:74), which schedules the query on the async
+    // executor and hands back a FutureResult the caller resolves later. Every
+    // trails select already returns a Promise, so the `async` kwarg the select
+    // family forwards here collapses into that Promise — see the future_result.rb
+    // entry in scripts/parity/unported-files/unscoped.ts. It is accepted and
+    // threaded so the forwarding call sites match Rails' argument lists; the
+    // scheduling half lands with the load_async port.
     try {
       // Rails' select_all runs `internal_exec_query` (the private work method),
       // NOT the public `exec_query` — the latter is wrapped by
@@ -1595,8 +1618,9 @@ export const DatabaseStatements = {
     arel: unknown,
     name: string | null = null,
     binds?: unknown[],
+    { async = false }: { async?: boolean } = {},
   ): Promise<Record<string, unknown> | undefined> {
-    return (await this.selectAll(arel, name, binds)).first();
+    return (await this.selectAll(arel, name, binds, { async })).first();
   },
 
   async selectValue(
@@ -1604,8 +1628,9 @@ export const DatabaseStatements = {
     arel: unknown,
     name: string | null = null,
     binds?: unknown[],
+    { async = false }: { async?: boolean } = {},
   ): Promise<unknown> {
-    const rows = await this.selectRows(arel, name, binds);
+    const rows = await this.selectRows(arel, name, binds, { async });
     return rows.length > 0 ? rows[0][0] : undefined;
   },
 
@@ -1624,8 +1649,9 @@ export const DatabaseStatements = {
     arel: unknown,
     name: string | null = null,
     binds?: unknown[],
+    { async = false }: { async?: boolean } = {},
   ): Promise<unknown[][]> {
-    return (await this.selectAll(arel, name, binds)).rows;
+    return (await this.selectAll(arel, name, binds, { async })).rows;
   },
 
   async execQuery(

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -388,7 +388,7 @@ type BaseSelectAll = (
   arel: string | unknown,
   name?: string | null,
   binds?: unknown[],
-  opts?: { allowRetry?: boolean; preparable?: boolean | null },
+  opts?: { allowRetry?: boolean; preparable?: boolean | null; async?: boolean },
 ) => Promise<Result>;
 
 /**
@@ -411,7 +411,7 @@ export function makeCachedSelectAll(original: BaseSelectAll): BaseSelectAll {
     arel: string | unknown,
     name: string | null = null,
     binds?: unknown[],
-    opts?: { allowRetry?: boolean; preparable?: boolean | null },
+    opts?: { allowRetry?: boolean; preparable?: boolean | null; async?: boolean },
   ): Promise<Result> {
     // Rails' QueryCache#select_all first unwraps a Relation to its Arel AST
     // (`arel = arel_from_relation(arel)`), then converts the Arel node to

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-adapter.json
@@ -125,48 +125,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-adapter.ts",
-    "rubyName": "select_one",
-    "call": "select_all",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:arel",
-      "ref:name",
-      "ref:binds",
-      "kwargs{async=ref:async}"
-    ],
-    "reason": "database_statements.rb:85 forwards `async:` into `select_all`, which turns it into `FutureResult::SelectAll` (:75). FutureResult and the load_async infrastructure are deliberately unported (database-statements.ts:2099-2112), so the kwarg would forward into nothing — story call-args-ar-select-async-kwarg."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-adapter.ts",
-    "rubyName": "select_rows",
-    "call": "select_all",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:arel",
-      "ref:name",
-      "ref:binds",
-      "kwargs{async=ref:async}"
-    ],
-    "reason": "database_statements.rb:102 forwards `async:` into `select_all`, which turns it into `FutureResult::SelectAll` (:75). FutureResult and the load_async infrastructure are deliberately unported (database-statements.ts:2099-2112), so the kwarg would forward into nothing — story call-args-ar-select-async-kwarg."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-adapter.ts",
-    "rubyName": "select_value",
-    "call": "select_rows",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:arel",
-      "ref:name",
-      "ref:binds",
-      "kwargs{async=ref:async}"
-    ],
-    "reason": "database_statements.rb:90 forwards `async:` into `select_rows` → `select_all` → `FutureResult::SelectAll` (:75). FutureResult and the load_async infrastructure are deliberately unported (database-statements.ts:2099-2112), so the kwarg would forward into nothing — story call-args-ar-select-async-kwarg."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-adapter.ts",
     "rubyName": "select_value",
     "call": "single_value_from_rows",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
## Scope (read first)

Story `call-args-ar-select-async-kwarg` was **blocked** for the reason both review
comments raise: its criteria 1 and 3 require porting `FutureResult` / `load_async`
and wiring `AsynchronousQueryInsideTransactionError`, and `future_result.rb`,
`promise.rb`, and `asynchronous_queries_tracker.rb` are **permanently excluded** in
`scripts/parity/unported-files/unscoped.ts:16-35` — a standing, reviewed decision
that Ruby's Mutex / thread-pool / `Concurrent::*` primitives collapse into the
native Promise every trails select already returns.

The maintainer then directed the narrower change this PR ships: thread the kwarg,
retire the three forwarding rows, leave the infrastructure alone. **This PR is
deliberately partial and does not close the story** — it stays open and stamped for
the rest.

## What

`select_one` / `select_value` / `select_rows` now take Rails' `async:` kwarg with
Rails' default (`false`) and forward it exactly as Rails does:

- `select_one` → `select_all(arel, name, binds, async: async)` — `database_statements.rb:85`
- `select_value` → `select_rows(arel, name, binds, async: async)` — `:90`
- `select_rows` → `select_all(arel, name, binds, async: async)` — `:102`

`select_all` accepts the kwarg on its options object. Three converged
`kind: "args"` baseline rows on `connection-adapters/abstract-adapter.ts` deleted by
hand (only-shrink, no `--write`).

## Review comment 1 — `FutureResult` / `load_async` / the transaction guard

Correct, and out of scope by the directive above. Rails' `select_all` passes
`async && FutureResult::SelectAll` into `select` (`database_statements.rb:74`), and
`select` raises inside a joinable transaction, then schedules or executes the
FutureResult (`:671-699`), gated on `async_enabled?` → `pool.async_executor`
(`abstract_adapter.rb:562`). None of that has a trails home while `future_result.rb`
is unported, and wiring the guard alone would be dead code that fakes the feature —
which is exactly what the note at `database-statements.ts:2124` records. That note
stays. Landing it is the reopened story's job, not this PR's.

## Review comment 2 — the surviving `Result.empty(async: async)` row

Cannot converge here. Rails' `Result.empty(async:)` is a two-arm dispatch on a
constant that does not exist in trails:

```ruby
def self.empty(async: false)  # result.rb:94-100
  async ? EMPTY_ASYNC : EMPTY
end
EMPTY_ASYNC = FutureResult.wrap(EMPTY).freeze  # result.rb:247
```

Giving `Result.empty` an `async` kwarg with only one arm to return would be a stub,
not a convergence, so criterion 4 is **partially** met (3 of 4 rows) and the row keeps
its reason. That reason cites this story, which is the second reason the story stays
open: closing it would red the stale-refs check.

## Verification

- `pnpm parity:api:calls` → OK · `pnpm parity:api:calls:args` → OK (275 rows; the 3 retired)
- `pnpm parity:api:arity` → OK · `pnpm parity:api:extra --package activerecord` unchanged (params only, no new public names)
- There is no `api:calls:wide` — RFC 0084 folded that ratchet into `parity:api:calls`.
- `pnpm typecheck`, `pnpm lint --fix` clean; `adapter.test.ts`, `query-cache.test.ts` green
