### PR TITLE
refactor(activerecord): pass association scopes positionally in canonical models

### DIFF
--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -1494,11 +1494,14 @@ describe("WithAnnotationsTest", () => {
         foreignKey: "parrot_id",
       });
       this.hasAndBelongsToMany("parrots", { className: "Parrot", foreignKey: "pirate_id" });
-      this.hasAndBelongsToMany("parrotsWithAnnotation", {
-        scope: (q: any) => q.annotate("that are very colorful"),
-        className: "Parrot",
-        foreignKey: "pirate_id",
-      });
+      this.hasAndBelongsToMany(
+        "parrotsWithAnnotation",
+        (q: any) => q.annotate("that are very colorful"),
+        {
+          className: "Parrot",
+          foreignKey: "pirate_id",
+        },
+      );
       this.hasOne("ship", { className: "Ship", foreignKey: "pirate_id" });
       this.hasOne("shipWithAnnotation", {
         scope: (q: any) => q.annotate("that is a rocket"),

--- a/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
+++ b/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
@@ -349,16 +349,6 @@ export class HasAndBelongsToMany {
     for (const callbackName of ["beforeAdd", "afterAdd", "beforeRemove", "afterRemove"] as const) {
       CollectionAssociationBuilder.defineCallback(model, callbackName, name, habtmOptions);
     }
-    // Pull `scope:` off the options bag and forward it as the dedicated
-    // scope arg on the reflection. Mirrors Rails' Builder::Association,
-    // which captures `scope` as a positional arg to `has_and_belongs_to_many`
-    // rather than treating it as a generic option. The through-routing loaders
-    // already check `options.scope` — keeping it there too means callers who
-    // don't go through reflection still see it.
-    const habtmScope =
-      typeof habtmOptions.scope === "function"
-        ? (habtmOptions.scope as (...args: any[]) => any)
-        : null;
     // Keep `through:` in the options passed to Reflection.create so it wraps
     // the HasAndBelongsToManyReflection in a ThroughReflection — mirrors
     // Rails' `Builder::HasAndBelongsToMany`, which builds an internal
@@ -367,7 +357,7 @@ export class HasAndBelongsToMany {
     const habtmReflection = Reflection.create(
       "hasAndBelongsToMany" as any,
       name,
-      habtmScope,
+      positionalScope,
       habtmReflectionOptions,
       model,
     );

--- a/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
+++ b/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
@@ -334,8 +334,8 @@ export class HasAndBelongsToMany {
     // captured as a positional reflection arg below, but kept on the options
     // bag too for the through-routing loaders, which read it from there.
     const positionalScope = typeof scope === "function" ? scope : null;
-    if (positionalScope || typeof options.scope === "function") {
-      habtmOptions.scope = positionalScope ?? options.scope;
+    if (positionalScope) {
+      habtmOptions.scope = positionalScope;
     }
     model._associations.push({
       type: "hasAndBelongsToMany",

--- a/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
@@ -122,8 +122,7 @@ class DeveloperWithExtendOption extends Developer {
 class ProjectUnscopingDavidDefaultScope extends Base {
   static {
     this.tableName = "projects";
-    this.hasAndBelongsToMany("developers", {
-      scope: (q: any) => q.unscope({ where: "name" }),
+    this.hasAndBelongsToMany("developers", (q: any) => q.unscope({ where: "name" }), {
       className: "LazyBlockDeveloperCalledDavid",
       joinTable: "developers_projects",
       foreignKey: "project_id",

--- a/packages/activerecord/src/test-helpers/models/author.ts
+++ b/packages/activerecord/src/test-helpers/models/author.ts
@@ -209,52 +209,46 @@ export class Author extends Base {
     this.hasMany("serializedPosts");
     this.hasOne("post");
     this.hasMany("verySpecialComments", { through: "posts" });
-    this.hasMany("postsWithComments", {
-      scope: (q: any) => q.includes("comments"),
-      className: "Post",
-    });
-    this.hasMany("popularGroupedPosts", {
-      scope: (q: any) =>
+    this.hasMany("postsWithComments", (q: any) => q.includes("comments"), { className: "Post" });
+    this.hasMany(
+      "popularGroupedPosts",
+      (q: any) =>
         q
           .includes("comments")
           .group("type")
           .having("SUM(legacy_comments_count) > 1")
           .select("type"),
+      { className: "Post" },
+    );
+    this.hasMany(
+      "postsWithCommentsSortedByCommentId",
+      (q: any) => q.includes("comments").order("comments.id"),
+      { className: "Post" },
+    );
+    this.hasMany("postsSortedById", (q: any) => q.order("id"), { className: "Post" });
+    this.hasMany("postsSortedByIdLimited", (q: any) => q.order("posts.id").limit(1), {
       className: "Post",
     });
-    this.hasMany("postsWithCommentsSortedByCommentId", {
-      scope: (q: any) => q.includes("comments").order("comments.id"),
+    this.hasMany("postsWithCategories", (q: any) => q.includes("categories"), {
       className: "Post",
     });
-    this.hasMany("postsSortedById", {
-      scope: (q: any) => q.order("id"),
-      className: "Post",
-    });
-    this.hasMany("postsSortedByIdLimited", {
-      scope: (q: any) => q.order("posts.id").limit(1),
-      className: "Post",
-    });
-    this.hasMany("postsWithCategories", {
-      scope: (q: any) => q.includes("categories"),
-      className: "Post",
-    });
-    this.hasMany("postsWithCommentsAndCategories", {
-      scope: (q: any) => q.includes("comments", "categories").order("posts.id"),
-      className: "Post",
-    });
+    this.hasMany(
+      "postsWithCommentsAndCategories",
+      (q: any) => q.includes("comments", "categories").order("posts.id"),
+      { className: "Post" },
+    );
     this.hasMany("postsWithSpecialCategorizations", { className: "PostWithSpecialCategorization" });
-    this.hasOne("postAboutThinking", {
-      scope: (q: any) => q.where("posts.title like '%thinking%'"),
+    this.hasOne("postAboutThinking", (q: any) => q.where("posts.title like '%thinking%'"), {
       className: "Post",
     });
-    this.hasOne("postAboutThinkingWithLastComment", {
-      scope: (q: any) => q.where("posts.title like '%thinking%'").includes("lastComment"),
-      className: "Post",
-    });
+    this.hasOne(
+      "postAboutThinkingWithLastComment",
+      (q: any) => q.where("posts.title like '%thinking%'").includes("lastComment"),
+      { className: "Post" },
+    );
 
     this.hasMany("comments", { through: "posts" });
-    this.hasMany("commentsWithOrder", {
-      scope: (q: any) => q.orderedByPostId(),
+    this.hasMany("commentsWithOrder", (q: any) => q.orderedByPostId(), {
       through: "posts",
       source: "comments",
     });
@@ -287,14 +281,12 @@ export class Author extends Base {
       sourceType: "Member",
       disableJoins: true,
     });
-    this.hasMany("orderedMembers", {
-      scope: (q: any) => q.order({ id: "desc" }),
+    this.hasMany("orderedMembers", (q: any) => q.order({ id: "desc" }), {
       through: "commentsWithOrder",
       source: "origin",
       sourceType: "Member",
     });
-    this.hasMany("noJoinsOrderedMembers", {
-      scope: (q: any) => q.order({ id: "desc" }),
+    this.hasMany("noJoinsOrderedMembers", (q: any) => q.order({ id: "desc" }), {
       through: "commentsWithOrder",
       source: "origin",
       sourceType: "Member",
@@ -302,8 +294,7 @@ export class Author extends Base {
     });
 
     this.hasMany("ratings", { through: "comments" });
-    this.hasMany("goodRatings", {
-      scope: (q: any) => q.where("ratings.value > 5").order({ id: "asc" }),
+    this.hasMany("goodRatings", (q: any) => q.where("ratings.value > 5").order({ id: "asc" }), {
       through: "comments",
       source: "ratings",
     });
@@ -312,86 +303,76 @@ export class Author extends Base {
       disableJoins: true,
       source: "ratings",
     });
-    this.hasMany("noJoinsGoodRatings", {
-      scope: (q: any) => q.where("ratings.value > 5").order({ id: "asc" }),
-      through: "comments",
-      source: "ratings",
-      disableJoins: true,
-    });
+    this.hasMany(
+      "noJoinsGoodRatings",
+      (q: any) => q.where("ratings.value > 5").order({ id: "asc" }),
+      { through: "comments", source: "ratings", disableJoins: true },
+    );
 
     this.hasMany("commentsContainingTheLetterE", { through: "posts", source: "comments" });
-    this.hasMany("commentsWithOrderAndConditions", {
-      scope: (q: any) => q.order("comments.body").where("comments.body like 'Thank%'"),
-      through: "posts",
-      source: "comments",
-    });
-    this.hasMany("commentsWithInclude", {
-      scope: (q: any) => q.includes("post").where({ posts: { type: "Post" } }),
-      through: "posts",
-      source: "comments",
-    });
-    this.hasMany("commentsForFirstAuthor", {
-      scope: (q: any) => q.forFirstAuthor(),
+    this.hasMany(
+      "commentsWithOrderAndConditions",
+      (q: any) => q.order("comments.body").where("comments.body like 'Thank%'"),
+      { through: "posts", source: "comments" },
+    );
+    this.hasMany(
+      "commentsWithInclude",
+      (q: any) => q.includes("post").where({ posts: { type: "Post" } }),
+      { through: "posts", source: "comments" },
+    );
+    this.hasMany("commentsForFirstAuthor", (q: any) => q.forFirstAuthor(), {
       through: "posts",
       source: "comments",
     });
 
     this.hasMany("firstPosts");
-    this.hasMany("commentsOnFirstPosts", {
-      scope: (q: any) => q.order("posts.id desc, comments.id asc"),
+    this.hasMany("commentsOnFirstPosts", (q: any) => q.order("posts.id desc, comments.id asc"), {
       through: "firstPosts",
       source: "comments",
     });
     this.hasOne("firstPost");
-    this.hasOne("commentOnFirstPost", {
-      scope: (q: any) => q.order("posts.id desc, comments.id asc"),
+    this.hasOne("commentOnFirstPost", (q: any) => q.order("posts.id desc, comments.id asc"), {
       through: "firstPost",
       source: "comments",
     });
 
-    this.hasMany("thinkingPosts", {
-      scope: (q: any) => q.where({ title: "So I was thinking" }),
+    this.hasMany("thinkingPosts", (q: any) => q.where({ title: "So I was thinking" }), {
       // Rails: dependent: :delete_all — not yet supported, using "delete" as closest equivalent
       dependent: "delete",
       className: "Post",
     });
-    this.hasMany("welcomePosts", {
-      scope: (q: any) => q.where({ title: "Welcome to the weblog" }),
+    this.hasMany("welcomePosts", (q: any) => q.where({ title: "Welcome to the weblog" }), {
       className: "Post",
     });
-    this.hasMany("welcomePostsWithOneComment", {
-      scope: (q: any) => q.where({ title: "Welcome to the weblog" }).where({ comments_count: 1 }),
-      className: "Post",
-    });
-    this.hasMany("welcomePostsWithComments", {
-      scope: (q: any) =>
-        q.where({ title: "Welcome to the weblog" }).where("legacy_comments_count > 0"),
-      className: "Post",
-    });
+    this.hasMany(
+      "welcomePostsWithOneComment",
+      (q: any) => q.where({ title: "Welcome to the weblog" }).where({ comments_count: 1 }),
+      { className: "Post" },
+    );
+    this.hasMany(
+      "welcomePostsWithComments",
+      (q: any) => q.where({ title: "Welcome to the weblog" }).where("legacy_comments_count > 0"),
+      { className: "Post" },
+    );
 
-    this.hasMany("commentsDesc", {
-      scope: (q: any) => q.order("comments.id DESC"),
+    this.hasMany("commentsDesc", (q: any) => q.order("comments.id DESC"), {
       through: "postsSortedById",
       source: "comments",
     });
-    this.hasMany("unorderedComments", {
-      scope: (q: any) => q.unscope("order").distinct(),
+    this.hasMany("unorderedComments", (q: any) => q.unscope("order").distinct(), {
       through: "postsSortedByIdLimited",
       source: "comments",
     });
     this.hasMany("funkyComments", { through: "posts", source: "comments" });
-    this.hasMany("orderedUniqComments", {
-      scope: (q: any) => q.distinct().order("comments.id"),
+    this.hasMany("orderedUniqComments", (q: any) => q.distinct().order("comments.id"), {
       through: "posts",
       source: "comments",
     });
-    this.hasMany("orderedUniqCommentsDesc", {
-      scope: (q: any) => q.distinct().order("comments.id DESC"),
+    this.hasMany("orderedUniqCommentsDesc", (q: any) => q.distinct().order("comments.id DESC"), {
       through: "posts",
       source: "comments",
     });
-    this.hasMany("readonlyComments", {
-      scope: (q: any) => q.readonly(),
+    this.hasMany("readonlyComments", (q: any) => q.readonly(), {
       through: "posts",
       source: "comments",
     });
@@ -403,33 +384,29 @@ export class Author extends Base {
     this.hasMany("stiPosts", { className: "StiPost" });
     this.hasMany("stiPostComments", { through: "stiPosts", source: "comments" });
 
-    this.hasMany("specialNonexistentPosts", {
-      scope: (q: any) => q.where("posts.body = 'nonexistent'"),
+    this.hasMany("specialNonexistentPosts", (q: any) => q.where("posts.body = 'nonexistent'"), {
       className: "SpecialPost",
     });
-    this.hasMany("specialNonexistentPostComments", {
-      scope: (q: any) => q.where({ "comments.post_id": 0 }),
+    this.hasMany("specialNonexistentPostComments", (q: any) => q.where({ "comments.post_id": 0 }), {
       through: "specialNonexistentPosts",
       source: "comments",
     });
     this.hasMany("nonexistentComments", { through: "posts" });
 
-    this.hasMany("helloPosts", {
-      scope: (q: any) => q.where("posts.body = 'hello'"),
-      className: "Post",
-    });
+    this.hasMany("helloPosts", (q: any) => q.where("posts.body = 'hello'"), { className: "Post" });
     this.hasMany("helloPostComments", { through: "helloPosts", source: "comments" });
-    this.hasMany("postsWithNoComments", {
-      scope: (q: any) => q.where({ "comments.id": null }).includes("comments"),
-      className: "Post",
-    });
-    this.hasMany("postsWithNoComments_2", {
-      scope: (q: any) => q.leftJoins("comments").where({ "comments.id": null }),
-      className: "Post",
-    });
+    this.hasMany(
+      "postsWithNoComments",
+      (q: any) => q.where({ "comments.id": null }).includes("comments"),
+      { className: "Post" },
+    );
+    this.hasMany(
+      "postsWithNoComments_2",
+      (q: any) => q.leftJoins("comments").where({ "comments.id": null }),
+      { className: "Post" },
+    );
 
-    this.hasMany("helloPostsWithHashConditions", {
-      scope: (q: any) => q.where({ body: "hello" }),
+    this.hasMany("helloPostsWithHashConditions", (q: any) => q.where({ body: "hello" }), {
       className: "Post",
     });
     this.hasMany("helloPostCommentsWithHashConditions", {
@@ -494,33 +471,32 @@ export class Author extends Base {
     this.hasMany("specialCategories", { through: "specialCategorizations", source: "category" });
     this.hasOne("specialCategory", { through: "specialCategorizations", source: "category" });
 
-    this.hasMany("generalCategorizations", {
-      scope: (q: any) => q.joins("category").where({ "categories.name": "General" }),
-      className: "Categorization",
-    });
+    this.hasMany(
+      "generalCategorizations",
+      (q: any) => q.joins("category").where({ "categories.name": "General" }),
+      { className: "Categorization" },
+    );
     this.hasMany("generalPosts", { through: "generalCategorizations", source: "post" });
 
-    this.hasMany("specialCategoriesWithConditions", {
-      scope: (q: any) => q.where({ categorizations: { special: true } }),
-      through: "categorizations",
-      source: "category",
-    });
-    this.hasMany("nonspecialCategoriesWithConditions", {
-      scope: (q: any) => q.where({ categorizations: { special: false } }),
-      through: "categorizations",
-      source: "category",
-    });
+    this.hasMany(
+      "specialCategoriesWithConditions",
+      (q: any) => q.where({ categorizations: { special: true } }),
+      { through: "categorizations", source: "category" },
+    );
+    this.hasMany(
+      "nonspecialCategoriesWithConditions",
+      (q: any) => q.where({ categorizations: { special: false } }),
+      { through: "categorizations", source: "category" },
+    );
 
-    this.hasMany("categoriesLikeGeneral", {
-      scope: (q: any) => q.where({ name: "General" }),
+    this.hasMany("categoriesLikeGeneral", (q: any) => q.where({ name: "General" }), {
       through: "categorizations",
       source: "category",
       className: "Category",
     });
 
     this.hasMany("categorizedPosts", { through: "categorizations", source: "post" });
-    this.hasMany("uniqueCategorizedPosts", {
-      scope: (q: any) => q.distinct(),
+    this.hasMany("uniqueCategorizedPosts", (q: any) => q.distinct(), {
       through: "categorizations",
       source: "post",
     });
@@ -528,10 +504,7 @@ export class Author extends Base {
     this.hasMany("nothings", { through: "kateggorizatons", className: "Category" });
 
     this.hasMany("authorFavorites");
-    this.hasMany("favoriteAuthors", {
-      scope: (q: any) => q.order("name"),
-      through: "authorFavorites",
-    });
+    this.hasMany("favoriteAuthors", (q: any) => q.order("name"), { through: "authorFavorites" });
 
     this.hasMany("taggings", { through: "posts", source: "taggings" });
     this.hasMany("taggings_2", { through: "posts", source: "tagging" });
@@ -540,18 +513,15 @@ export class Author extends Base {
     this.hasMany("postCategories", { through: "posts", source: "categories" });
     this.hasMany("taggingTags", { through: "taggings", source: "tag" });
 
-    this.hasMany("similarPosts", {
-      scope: (q: any) => q.distinct(),
+    this.hasMany("similarPosts", (q: any) => q.distinct(), {
       through: "tags",
       source: "taggedPosts",
     });
-    this.hasMany("orderedPosts", {
-      scope: (q: any) => q.distinct(),
+    this.hasMany("orderedPosts", (q: any) => q.distinct(), {
       through: "orderedTags",
       source: "taggedPosts",
     });
-    this.hasMany("distinctTags", {
-      scope: (q: any) => q.select("DISTINCT tags.*").order("tags.name"),
+    this.hasMany("distinctTags", (q: any) => q.select("DISTINCT tags.*").order("tags.name"), {
       through: "posts",
       source: "tags",
     });
@@ -565,30 +535,26 @@ export class Author extends Base {
       sourceType: "BestHardback",
     });
     this.hasMany("publishedBooks", { className: "PublishedBook" });
-    this.hasMany("unpublishedBooks", {
-      scope: (q: any) => q.where({ status: ["proposed", "written"] }),
+    this.hasMany("unpublishedBooks", (q: any) => q.where({ status: ["proposed", "written"] }), {
       className: "Book",
     });
-    this.hasOne("unreadListing", {
-      scope: (q: any) => q.unread(),
+    this.hasOne("unreadListing", (q: any) => q.unread(), {
       className: "Book",
       foreignKey: "last_read",
     });
-    this.hasOne("readingListing", {
-      scope: (q: any) => q.reading(),
+    this.hasOne("readingListing", (q: any) => q.reading(), {
       className: "Book",
       foreignKey: "last_read",
     });
     this.hasMany("subscriptions", { through: "books" });
-    this.hasMany("subscribers", {
-      scope: (q: any) => q.order("subscribers.nick"),
+    this.hasMany("subscribers", (q: any) => q.order("subscribers.nick"), {
       through: "subscriptions",
     });
-    this.hasMany("distinctSubscribers", {
-      scope: (q: any) => q.select("DISTINCT subscribers.*").order("subscribers.nick"),
-      through: "subscriptions",
-      source: "subscriber",
-    });
+    this.hasMany(
+      "distinctSubscribers",
+      (q: any) => q.select("DISTINCT subscribers.*").order("subscribers.nick"),
+      { through: "subscriptions", source: "subscriber" },
+    );
 
     this.hasOne("essay", { primaryKey: "name", as: "writer" });
     this.hasOne("essayCategory", { through: "essay", source: "category" });
@@ -612,17 +578,18 @@ export class Author extends Base {
 
     this.hasMany("categoryPostComments", { through: "categories", source: "postComments" });
 
-    this.hasMany("miscPosts", {
-      scope: (q: any) => q.where({ posts: { title: ["misc post by bob", "misc post by mary"] } }),
-      className: "Post",
-    });
+    this.hasMany(
+      "miscPosts",
+      (q: any) => q.where({ posts: { title: ["misc post by bob", "misc post by mary"] } }),
+      { className: "Post" },
+    );
     this.hasMany("miscPostFirstBlueTags", { through: "miscPosts", source: "firstBlueTags" });
 
-    this.hasMany("miscPostFirstBlueTags_2", {
-      scope: (q: any) => q.where({ posts: { title: ["misc post by bob", "misc post by mary"] } }),
-      through: "posts",
-      source: "firstBlueTags_2",
-    });
+    this.hasMany(
+      "miscPostFirstBlueTags_2",
+      (q: any) => q.where({ posts: { title: ["misc post by bob", "misc post by mary"] } }),
+      { through: "posts", source: "firstBlueTags_2" },
+    );
 
     this.hasMany("postsWithDefaultInclude", { className: "PostWithDefaultInclude" });
     this.hasMany("commentsOnPostsWithDefaultInclude", {
@@ -630,42 +597,42 @@ export class Author extends Base {
       source: "comments",
     });
 
-    this.hasMany("postsWithSignature", {
-      scope: (q: any, record: any) =>
+    this.hasMany(
+      "postsWithSignature",
+      (q: any, record: any) =>
         q.where(q.model.arelTable.get("title").matches(`%by ${record.name.toLowerCase()}%`)),
-      className: "Post",
-    });
-    this.hasMany("postsMentioningAuthor", {
-      scope: (q: any, record: any) =>
+      { className: "Post" },
+    );
+    this.hasMany(
+      "postsMentioningAuthor",
+      (q: any, record: any) =>
         q.where(q.model.arelTable.get("body").matches(`%${record?.name?.toLowerCase() ?? ""}%`)),
-      className: "Post",
-    });
+      { className: "Post" },
+    );
     this.hasMany("commentsOnPostsMentioningAuthor", {
       through: "postsMentioningAuthor",
       source: "comments",
     });
-    this.hasMany("commentsMentioningAuthor", {
-      scope: (q: any, record: any) =>
+    this.hasMany(
+      "commentsMentioningAuthor",
+      (q: any, record: any) =>
         q.where(q.model.arelTable.get("body").matches(`%${record.name.toLowerCase()}%`)),
-      through: "posts",
-      source: "comments",
-    });
+      { through: "posts", source: "comments" },
+    );
 
-    this.hasOne("recentPost", { scope: (q: any) => q.order({ id: "desc" }), className: "Post" });
+    this.hasOne("recentPost", (q: any) => q.order({ id: "desc" }), { className: "Post" });
     this.hasOne("recentResponse", { through: "recentPost", source: "comments" });
 
-    this.hasMany("postsWithExtension", { scope: (q: any) => q.order("title"), className: "Post" });
-    this.hasMany("postsWithExtensionAndInstance", {
-      scope: (q: any, _record: any) => q.order("title"),
+    this.hasMany("postsWithExtension", (q: any) => q.order("title"), { className: "Post" });
+    this.hasMany("postsWithExtensionAndInstance", (q: any, _record: any) => q.order("title"), {
       className: "Post",
     });
 
-    this.hasMany("topPosts", { scope: (q: any) => q.order({ id: "asc" }), className: "Post" });
-    this.hasMany("otherTopPosts", { scope: (q: any) => q.order({ id: "asc" }), className: "Post" });
+    this.hasMany("topPosts", (q: any) => q.order({ id: "asc" }), { className: "Post" });
+    this.hasMany("otherTopPosts", (q: any) => q.order({ id: "asc" }), { className: "Post" });
 
     this.hasMany("topics", { primaryKey: "name", foreignKey: "author_name" });
-    this.hasMany("topicsWithoutType", {
-      scope: (q: any) => q.select("id", "title", "author_name"),
+    this.hasMany("topicsWithoutType", (q: any) => q.select("id", "title", "author_name"), {
       className: "Topic",
       primaryKey: "name",
       foreignKey: "author_name",

--- a/packages/activerecord/src/test-helpers/models/car.ts
+++ b/packages/activerecord/src/test-helpers/models/car.ts
@@ -47,32 +47,16 @@ export class Car extends Base {
   static {
     this.belongsTo("person", { counterCache: true });
     this.hasMany("bulbs");
-    this.hasMany("allBulbs", {
-      scope: (q: any) => q.unscope({ where: "name" }),
+    this.hasMany("allBulbs", (q: any) => q.unscope({ where: "name" }), { className: "Bulb" });
+    this.hasMany("allBulbs2", (q: any) => q.unscope("where"), { className: "Bulb" });
+    this.hasMany("otherBulbs", (q: any) => q.unscope({ where: "name" }).where({ name: "other" }), {
       className: "Bulb",
     });
-    this.hasMany("allBulbs2", {
-      scope: (q: any) => q.unscope("where"),
-      className: "Bulb",
-    });
-    this.hasMany("otherBulbs", {
-      scope: (q: any) => q.unscope({ where: "name" }).where({ name: "other" }),
-      className: "Bulb",
-    });
-    this.hasMany("oldBulbs", {
-      scope: (q: any) => q.rewhere({ name: "old" }),
-      className: "Bulb",
-    });
+    this.hasMany("oldBulbs", (q: any) => q.rewhere({ name: "old" }), { className: "Bulb" });
     this.hasMany("funkyBulbs", { className: "FunkyBulb", dependent: "destroy" });
     this.hasMany("failedBulbs", { className: "FailedBulb", dependent: "destroy" });
-    this.hasMany("fooBulbs", {
-      scope: (q: any) => q.where({ name: "foo" }),
-      className: "Bulb",
-    });
-    this.hasMany("awesomeBulbs", {
-      scope: (q: any) => q.awesome(),
-      className: "Bulb",
-    });
+    this.hasMany("fooBulbs", (q: any) => q.where({ name: "foo" }), { className: "Bulb" });
+    this.hasMany("awesomeBulbs", (q: any) => q.awesome(), { className: "Bulb" });
 
     this.hasOne("bulb");
 

--- a/packages/activerecord/src/test-helpers/models/category.ts
+++ b/packages/activerecord/src/test-helpers/models/category.ts
@@ -36,46 +36,42 @@ export class Category extends Base {
     this.hasAndBelongsToMany("posts");
     this.hasAndBelongsToMany("specialPosts", { className: "Post" });
     this.hasAndBelongsToMany("otherPosts", { className: "Post" });
-    this.hasAndBelongsToMany("postsWithAuthorsSortedByAuthorId", {
-      scope: (q: any) => q.includes("authors").order("authors.id"),
-      className: "Post",
-    });
-    this.hasAndBelongsToMany("selectTestingPosts", {
-      scope: (q: any) => q.select("posts.*, 1 as correctness_marker"),
-      className: "Post",
-      foreignKey: "category_id",
-      associationForeignKey: "post_id",
-    });
-    this.hasAndBelongsToMany("postWithConditions", {
-      scope: (q: any) => q.where({ title: "Yet Another Testing Title" }),
-      className: "Post",
-    });
-    this.hasAndBelongsToMany("postsGroupedByTitle", {
-      scope: (q: any) => q.group("title").select("title"),
+    this.hasAndBelongsToMany(
+      "postsWithAuthorsSortedByAuthorId",
+      (q: any) => q.includes("authors").order("authors.id"),
+      { className: "Post" },
+    );
+    this.hasAndBelongsToMany(
+      "selectTestingPosts",
+      (q: any) => q.select("posts.*, 1 as correctness_marker"),
+      { className: "Post", foreignKey: "category_id", associationForeignKey: "post_id" },
+    );
+    this.hasAndBelongsToMany(
+      "postWithConditions",
+      (q: any) => q.where({ title: "Yet Another Testing Title" }),
+      { className: "Post" },
+    );
+    this.hasAndBelongsToMany("postsGroupedByTitle", (q: any) => q.group("title").select("title"), {
       className: "Post",
     });
     this.hasMany("categorizations");
     this.hasMany("specialCategorizations");
     this.hasMany("postComments", { through: "posts", source: "comments" });
-    this.hasMany("orderedPostComments", {
-      scope: (q: any) => q.order({ id: "desc" }),
+    this.hasMany("orderedPostComments", (q: any) => q.order({ id: "desc" }), {
       through: "posts",
       source: "comments",
     });
     this.hasMany("authors", { through: "categorizations" });
-    this.hasMany("authorsWithSelect", {
-      scope: (q: any) => q.select("authors.*, categorizations.post_id"),
+    this.hasMany("authorsWithSelect", (q: any) => q.select("authors.*, categorizations.post_id"), {
       through: "categorizations",
       source: "author",
     });
     this.hasMany("essays", { primaryKey: "name" });
-    this.hasMany("humanWritersOfTypedEssays", {
-      scope: (q: any) => q.where({ essays: { type: "TypedEssay" } }),
-      through: "essays",
-      source: "writer",
-      sourceType: "Human",
-      primaryKey: "name",
-    });
+    this.hasMany(
+      "humanWritersOfTypedEssays",
+      (q: any) => q.where({ essays: { type: "TypedEssay" } }),
+      { through: "essays", source: "writer", sourceType: "Human", primaryKey: "name" },
+    );
     this.scope("general", (q: any) => q.where({ name: "General" }));
   }
 

--- a/packages/activerecord/src/test-helpers/models/club.ts
+++ b/packages/activerecord/src/test-helpers/models/club.ts
@@ -39,15 +39,13 @@ export class Club extends Base {
     });
     this.belongsTo("category");
 
-    this.hasMany("favorites", {
-      scope: (q: any) => q.where({ memberships: { favorite: true } }),
+    this.hasMany("favorites", (q: any) => q.where({ memberships: { favorite: true } }), {
       through: "memberships",
       source: "member",
     });
 
     this.hasMany("customMemberships", { className: "Membership" });
-    this.hasMany("customFavorites", {
-      scope: (q: any) => q.where({ memberships: { favorite: true } }),
+    this.hasMany("customFavorites", (q: any) => q.where({ memberships: { favorite: true } }), {
       through: "customMemberships",
       source: "member",
     });

--- a/packages/activerecord/src/test-helpers/models/college.ts
+++ b/packages/activerecord/src/test-helpers/models/college.ts
@@ -4,9 +4,6 @@ import { ARUnit2Model } from "./arunit2-model.js";
 export class College extends ARUnit2Model {
   static {
     this.hasMany("courses");
-    this.hasMany("students", {
-      scope: (q: any) => q.where({ active: true }),
-      dependent: "destroy",
-    });
+    this.hasMany("students", (q: any) => q.where({ active: true }), { dependent: "destroy" });
   }
 }

--- a/packages/activerecord/src/test-helpers/models/company-in-module.ts
+++ b/packages/activerecord/src/test-helpers/models/company-in-module.ts
@@ -32,23 +32,19 @@ export class MyAppBusinessFirm extends MyAppBusinessCompany {
   static {
     // foreignKey explicit throughout: JS class name MyAppBusinessFirm would derive
     // my_app_business_firm_id, but Rails demodulizes MyApplication::Business::Firm → firm_id.
-    this.hasMany("clients", {
-      scope: (q: any) => q.order("id"),
+    this.hasMany("clients", (q: any) => q.order("id"), {
       foreignKey: "firm_id",
       dependent: "destroy",
     });
-    this.hasMany("clientsSortedDesc", {
-      scope: (q: any) => q.order("id DESC"),
+    this.hasMany("clientsSortedDesc", (q: any) => q.order("id DESC"), {
       className: "Client",
       foreignKey: "firm_id",
     });
-    this.hasMany("clientsOfFirm", {
-      scope: (q: any) => q.order("id"),
+    this.hasMany("clientsOfFirm", (q: any) => q.order("id"), {
       foreignKey: "client_of",
       className: "Client",
     });
-    this.hasMany("clientsLikeMs", {
-      scope: (q: any) => q.where("name = 'Microsoft'").order("id"),
+    this.hasMany("clientsLikeMs", (q: any) => q.where("name = 'Microsoft'").order("id"), {
       className: "Client",
       foreignKey: "firm_id",
     });

--- a/packages/activerecord/src/test-helpers/models/company.ts
+++ b/packages/activerecord/src/test-helpers/models/company.ts
@@ -64,9 +64,9 @@ export class Company extends AbstractCompany {
     this.hasOne("dummyAccount", { foreignKey: "firm_id", className: "Account" });
     this.hasMany("contracts");
     this.hasMany("developers", { through: "contracts" });
-    this.hasMany("specialContracts", {
-      scope: (q: any) => q.includes("specialDeveloper").whereNot({ "developers.id": null }),
-    });
+    this.hasMany("specialContracts", (q: any) =>
+      q.includes("specialDeveloper").whereNot({ "developers.id": null }),
+    );
     this.hasMany("specialDevelopers", { through: "specialContracts" });
     this.hasMany("comments", { foreignKey: "company" });
 
@@ -181,57 +181,48 @@ export class Firm extends Company {
   static {
     this.toParam("name");
 
-    this.hasMany("clients", {
-      scope: (q: any) => q.order("id"),
+    this.hasMany("clients", (q: any) => q.order("id"), {
       dependent: "destroy",
       beforeRemove: (owner: any, record: any) => (owner as Firm).logBeforeRemove(record),
       afterRemove: (owner: any, record: any) => (owner as Firm).logAfterRemove(record),
     });
     this.hasMany("unsortedClients", { className: "Client" });
     this.hasMany("unsortedClientsWithSymbol", { className: "Client" });
-    this.hasMany("clientsSortedDesc", {
-      scope: (q: any) => q.order("id DESC"),
-      className: "Client",
-    });
-    this.hasMany("clientsOfFirm", {
-      scope: (q: any) => q.order("id"),
+    this.hasMany("clientsSortedDesc", (q: any) => q.order("id DESC"), { className: "Client" });
+    this.hasMany("clientsOfFirm", (q: any) => q.order("id"), {
       className: "Client",
       inverseOf: "firm",
     });
-    this.hasMany("clientsOrderedByName", {
-      scope: (q: any) => q.order("name"),
-      className: "Client",
-    });
+    this.hasMany("clientsOrderedByName", (q: any) => q.order("name"), { className: "Client" });
     this.hasMany("unvalidatedClientsOfFirm", {
       foreignKey: "client_of",
       className: "Client",
       validate: false,
     });
-    this.hasMany("dependentClientsOfFirm", {
-      scope: (q: any) => q.order("id"),
+    this.hasMany("dependentClientsOfFirm", (q: any) => q.order("id"), {
       foreignKey: "client_of",
       className: "Client",
       dependent: "destroy",
     });
-    this.hasMany("exclusivelyDependentClientsOfFirm", {
-      scope: (q: any) => q.order("id"),
+    this.hasMany("exclusivelyDependentClientsOfFirm", (q: any) => q.order("id"), {
       foreignKey: "client_of",
       className: "Client",
       dependent: "delete",
     });
-    this.hasMany("limitedClients", { scope: (q: any) => q.limit(1), className: "Client" });
-    this.hasMany("clientsWithInterpolatedConditions", {
-      scope: (q: any, firm: any) => q.where(`rating > ${firm.rating}`),
+    this.hasMany("limitedClients", (q: any) => q.limit(1), { className: "Client" });
+    this.hasMany(
+      "clientsWithInterpolatedConditions",
+      (q: any, firm: any) => q.where(`rating > ${firm.rating}`),
+      { className: "Client" },
+    );
+    this.hasMany("clientsLikeMs", (q: any) => q.where("name = 'Microsoft'").order("id"), {
       className: "Client",
     });
-    this.hasMany("clientsLikeMs", {
-      scope: (q: any) => q.where("name = 'Microsoft'").order("id"),
-      className: "Client",
-    });
-    this.hasMany("clientsLikeMsWithHashConditions", {
-      scope: (q: any) => q.where({ name: "Microsoft" }).order("id"),
-      className: "Client",
-    });
+    this.hasMany(
+      "clientsLikeMsWithHashConditions",
+      (q: any) => q.where({ name: "Microsoft" }).order("id"),
+      { className: "Client" },
+    );
     this.hasMany("plainClients", { className: "Client" });
     this.hasMany("clientsUsingPrimaryKey", {
       className: "Client",
@@ -244,12 +235,10 @@ export class Firm extends Company {
       foreignKey: "firm_name",
       dependent: "delete",
     });
-    this.hasMany("clientsGroupedByFirmId", {
-      scope: (q: any) => q.group("firm_id").select("firm_id"),
+    this.hasMany("clientsGroupedByFirmId", (q: any) => q.group("firm_id").select("firm_id"), {
       className: "Client",
     });
-    this.hasMany("clientsGroupedByName", {
-      scope: (q: any) => q.group("name").select("name"),
+    this.hasMany("clientsGroupedByName", (q: any) => q.group("name").select("name"), {
       className: "Client",
     });
 
@@ -259,18 +248,15 @@ export class Firm extends Company {
       className: "Account",
       validate: false,
     });
-    this.hasOne("accountWithSelect", {
-      scope: (q: any) => q.select("id, firm_id"),
+    this.hasOne("accountWithSelect", (q: any) => q.select("id, firm_id"), {
       foreignKey: "firm_id",
       className: "Account",
     });
-    this.hasOne("readonlyAccount", {
-      scope: (q: any) => q.readonly(),
+    this.hasOne("readonlyAccount", (q: any) => q.readonly(), {
       foreignKey: "firm_id",
       className: "Account",
     });
-    this.hasOne("accountUsingPrimaryKey", {
-      scope: (q: any) => q.order("id"),
+    this.hasOne("accountUsingPrimaryKey", (q: any) => q.order("id"), {
       primaryKey: "firm_id",
       className: "Account",
     });
@@ -291,8 +277,7 @@ export class Firm extends Company {
 
     this.hasOne("client", { foreignKey: "client_of" });
 
-    this.hasOne("accountLimit500WithHashConditions", {
-      scope: (q: any) => q.where({ credit_limit: 500 }),
+    this.hasOne("accountLimit500WithHashConditions", (q: any) => q.where({ credit_limit: 500 }), {
       foreignKey: "firm_id",
       className: "Account",
     });
@@ -309,13 +294,11 @@ export class Firm extends Company {
       autosave: false,
     });
 
-    this.hasMany("associationWithReferences", {
-      scope: (q: any) => q.references("foo"),
+    this.hasMany("associationWithReferences", (q: any) => q.references("foo"), {
       className: "Client",
     });
 
-    this.hasMany("developersWithSelect", {
-      scope: (q: any) => q.select("id, name, first_name"),
+    this.hasMany("developersWithSelect", (q: any) => q.select("id, name, first_name"), {
       className: "Developer",
     });
 
@@ -345,8 +328,7 @@ export class DependentFirm extends Company {
     ((name: "company") => Promise<Company | null>);
 
   static {
-    this.hasOne("account", {
-      scope: (q: any) => q.order("id"),
+    this.hasOne("account", (q: any) => q.order("id"), {
       foreignKey: "firm_id",
       dependent: "nullify",
     });
@@ -362,13 +344,11 @@ export class RestrictedWithExceptionFirm extends Company {
     ((name: "dummyAccount") => Promise<Account | null>);
 
   static {
-    this.hasOne("account", {
-      scope: (q: any) => q.order("id"),
+    this.hasOne("account", (q: any) => q.order("id"), {
       foreignKey: "firm_id",
       dependent: "restrictWithException",
     });
-    this.hasMany("companies", {
-      scope: (q: any) => q.order("id"),
+    this.hasMany("companies", (q: any) => q.order("id"), {
       foreignKey: "client_of",
       dependent: "restrictWithException",
     });
@@ -382,13 +362,11 @@ export class RestrictedWithErrorFirm extends Company {
     ((name: "dummyAccount") => Promise<Account | null>);
 
   static {
-    this.hasOne("account", {
-      scope: (q: any) => q.order("id"),
+    this.hasOne("account", (q: any) => q.order("id"), {
       foreignKey: "firm_id",
       dependent: "restrictWithError",
     });
-    this.hasMany("companies", {
-      scope: (q: any) => q.order("id"),
+    this.hasMany("companies", (q: any) => q.order("id"), {
       foreignKey: "client_of",
       dependent: "restrictWithError",
     });
@@ -452,14 +430,12 @@ export class Client extends Company {
   static {
     this.belongsTo("firm", { foreignKey: "client_of", inverseOf: "client" });
     this.belongsTo("firmWithBasicId", { className: "Firm", foreignKey: "firm_id" });
-    this.belongsTo("firmWithSelect", {
-      scope: (q: any) => q.select("id"),
+    this.belongsTo("firmWithSelect", (q: any) => q.select("id"), {
       className: "Firm",
       foreignKey: "firm_id",
     });
     this.belongsTo("firmWithOtherName", { className: "Firm", foreignKey: "client_of" });
-    this.belongsTo("firmWithCondition", {
-      scope: (q: any) => q.where("1 = ?", 1),
+    this.belongsTo("firmWithCondition", (q: any) => q.where("1 = ?", 1), {
       className: "Firm",
       foreignKey: "client_of",
     });
@@ -473,13 +449,11 @@ export class Client extends Company {
       primaryKey: "name",
       foreignKey: "firm_name",
     });
-    this.belongsTo("readonlyFirm", {
-      scope: (q: any) => q.readonly(),
+    this.belongsTo("readonlyFirm", (q: any) => q.readonly(), {
       className: "Firm",
       foreignKey: "firm_id",
     });
-    this.belongsTo("bobFirm", {
-      scope: (q: any) => q.where({ name: "Bob" }),
+    this.belongsTo("bobFirm", (q: any) => q.where({ name: "Bob" }), {
       className: "Firm",
       foreignKey: "client_of",
     });
@@ -545,24 +519,21 @@ export class ExclusivelyDependentFirm extends Company {
 
   static {
     this.hasOne("account", { foreignKey: "firm_id", dependent: "delete" });
-    this.hasMany("dependentSanitizedConditionalClientsOfFirm", {
-      scope: (q: any) => q.order("id").where("name = 'BigShot Inc.'"),
-      foreignKey: "client_of",
-      className: "Client",
-      dependent: "delete",
-    });
-    this.hasMany("dependentHashConditionalClientsOfFirm", {
-      scope: (q: any) => q.order("id").where({ name: "BigShot Inc." }),
-      foreignKey: "client_of",
-      className: "Client",
-      dependent: "delete",
-    });
-    this.hasMany("dependentConditionalClientsOfFirm", {
-      scope: (q: any) => q.order("id").where("name = ?", "BigShot Inc."),
-      foreignKey: "client_of",
-      className: "Client",
-      dependent: "delete",
-    });
+    this.hasMany(
+      "dependentSanitizedConditionalClientsOfFirm",
+      (q: any) => q.order("id").where("name = 'BigShot Inc.'"),
+      { foreignKey: "client_of", className: "Client", dependent: "delete" },
+    );
+    this.hasMany(
+      "dependentHashConditionalClientsOfFirm",
+      (q: any) => q.order("id").where({ name: "BigShot Inc." }),
+      { foreignKey: "client_of", className: "Client", dependent: "delete" },
+    );
+    this.hasMany(
+      "dependentConditionalClientsOfFirm",
+      (q: any) => q.order("id").where("name = ?", "BigShot Inc."),
+      { foreignKey: "client_of", className: "Client", dependent: "delete" },
+    );
   }
 }
 

--- a/packages/activerecord/src/test-helpers/models/developer.ts
+++ b/packages/activerecord/src/test-helpers/models/developer.ts
@@ -167,9 +167,9 @@ export class Developer extends Base {
     this.hasMany("contracts");
     this.hasMany("firms", { through: "contracts", source: "firm" });
     // Rails: `has_many :comments, ->(developer) { where(body: "I'm #{developer.name}") }`
-    this.hasMany("comments", {
-      scope: (q: any, developer: any) => q.where({ body: `I'm ${developer.name}` }),
-    });
+    this.hasMany("comments", (q: any, developer: any) =>
+      q.where({ body: `I'm ${developer.name}` }),
+    );
     this.hasMany("ratings", { through: "comments" });
 
     this.hasOne("ship", { dependent: "nullify" });
@@ -331,8 +331,7 @@ export class DeveloperFilteredOnJoins extends Base {
 
   static {
     this.tableName = "developers";
-    this.hasAndBelongsToMany("projects", {
-      scope: (q: any) => q.order("projects.id"),
+    this.hasAndBelongsToMany("projects", (q: any) => q.order("projects.id"), {
       foreignKey: "developer_id",
       joinTable: "developers_projects",
     });
@@ -473,8 +472,7 @@ export class EagerDeveloperWithDefaultScope extends Base {
 
   static {
     this.tableName = "developers";
-    this.hasAndBelongsToMany("projects", {
-      scope: (q: any) => q.order("projects.id"),
+    this.hasAndBelongsToMany("projects", (q: any) => q.order("projects.id"), {
       foreignKey: "developer_id",
       joinTable: "developers_projects",
     });
@@ -487,8 +485,7 @@ export class EagerDeveloperWithClassMethodDefaultScope extends Base {
 
   static {
     this.tableName = "developers";
-    this.hasAndBelongsToMany("projects", {
-      scope: (q: any) => q.order("projects.id"),
+    this.hasAndBelongsToMany("projects", (q: any) => q.order("projects.id"), {
       foreignKey: "developer_id",
       joinTable: "developers_projects",
     });
@@ -506,8 +503,7 @@ export class EagerDeveloperWithLambdaDefaultScope extends Base {
 
   static {
     this.tableName = "developers";
-    this.hasAndBelongsToMany("projects", {
-      scope: (q: any) => q.order("projects.id"),
+    this.hasAndBelongsToMany("projects", (q: any) => q.order("projects.id"), {
       foreignKey: "developer_id",
       joinTable: "developers_projects",
     });
@@ -520,8 +516,7 @@ export class EagerDeveloperWithBlockDefaultScope extends Base {
 
   static {
     this.tableName = "developers";
-    this.hasAndBelongsToMany("projects", {
-      scope: (q: any) => q.order("projects.id"),
+    this.hasAndBelongsToMany("projects", (q: any) => q.order("projects.id"), {
       foreignKey: "developer_id",
       joinTable: "developers_projects",
     });
@@ -534,8 +529,7 @@ export class EagerDeveloperWithCallableDefaultScope extends Base {
 
   static {
     this.tableName = "developers";
-    this.hasAndBelongsToMany("projects", {
-      scope: (q: any) => q.order("projects.id"),
+    this.hasAndBelongsToMany("projects", (q: any) => q.order("projects.id"), {
       foreignKey: "developer_id",
       joinTable: "developers_projects",
     });

--- a/packages/activerecord/src/test-helpers/models/family.ts
+++ b/packages/activerecord/src/test-helpers/models/family.ts
@@ -9,7 +9,7 @@ export class Family extends Base {
   declare members: AssociationProxy<Member>;
 
   static {
-    this.hasMany("familyTrees", { scope: (q: any) => q.where({ token: null }) });
+    this.hasMany("familyTrees", (q: any) => q.where({ token: null }));
     this.hasMany("members", { through: "familyTrees" });
   }
 }

--- a/packages/activerecord/src/test-helpers/models/liquid.ts
+++ b/packages/activerecord/src/test-helpers/models/liquid.ts
@@ -9,6 +9,6 @@ export class Liquid extends Base {
   static _tableName = "liquid";
 
   static {
-    this.hasMany("molecules", { scope: (q: any) => q.distinct() });
+    this.hasMany("molecules", (q: any) => q.distinct());
   }
 }

--- a/packages/activerecord/src/test-helpers/models/member.ts
+++ b/packages/activerecord/src/test-helpers/models/member.ts
@@ -84,16 +84,15 @@ export class Member extends Base {
       disableJoins: true,
     });
     this.hasOne("selectedClub", { through: "selectedMembership", source: "club" });
-    this.hasOne("favoriteClub", {
-      scope: (q: any) => q.where("memberships.favorite = ?", true),
+    this.hasOne("favoriteClub", (q: any) => q.where("memberships.favorite = ?", true), {
       through: "membership",
       source: "club",
     });
-    this.hasOne("hairyClub", {
-      scope: (q: any) => q.where({ clubs: { name: "Moustache and Eyebrow Fancier Club" } }),
-      through: "membership",
-      source: "club",
-    });
+    this.hasOne(
+      "hairyClub",
+      (q: any) => q.where({ clubs: { name: "Moustache and Eyebrow Fancier Club" } }),
+      { through: "membership", source: "club" },
+    );
     this.hasOne("sponsor", { as: "sponsorable" });
     this.hasOne("sponsorClub", { through: "sponsor" });
     this.hasOne("memberDetail", { inverseOf: false });
@@ -118,15 +117,13 @@ export class Member extends Base {
     });
 
     this.hasOne("clubCategory", { through: "club", source: "category" });
-    this.hasOne("generalClub", {
-      scope: (q: any) => q.general(),
+    this.hasOne("generalClub", (q: any) => q.general(), {
       through: "currentMembership",
       source: "club",
     });
 
     this.hasMany("superMemberships");
-    this.hasMany("favoriteMemberships", {
-      scope: (q: any) => q.where({ favorite: true }),
+    this.hasMany("favoriteMemberships", (q: any) => q.where({ favorite: true }), {
       className: "Membership",
     });
     this.hasMany("clubs", { through: "favoriteMemberships" });

--- a/packages/activerecord/src/test-helpers/models/membership.ts
+++ b/packages/activerecord/src/test-helpers/models/membership.ts
@@ -88,7 +88,7 @@ export class SuperMembership extends Membership {
   static {
     registerModel(SuperMembership);
     registerSubclass(SuperMembership);
-    this.belongsTo("member", { scope: (q: any) => q.order("members.id DESC") });
+    this.belongsTo("member", (q: any) => q.order("members.id DESC"));
     this.belongsTo("club");
   }
 }

--- a/packages/activerecord/src/test-helpers/models/owner.ts
+++ b/packages/activerecord/src/test-helpers/models/owner.ts
@@ -25,7 +25,7 @@ export class Owner extends Base {
 
   static {
     this._primaryKey = "owner_id";
-    this.hasMany("pets", { scope: (q: any) => q.order("pets.name desc") });
+    this.hasMany("pets", (q: any) => q.order("pets.name desc"));
     this.hasMany("toys", { through: "pets" });
     this.hasMany("persons", { through: "pets" });
     this.belongsTo("lastPet", { className: "Pet" });

--- a/packages/activerecord/src/test-helpers/models/person.ts
+++ b/packages/activerecord/src/test-helpers/models/person.ts
@@ -79,11 +79,11 @@ export class Person extends Base {
 
     this.hasMany("posts", { through: "readers" });
     this.hasMany("securePosts", { through: "secureReaders" });
-    this.hasMany("postsWithNoComments", {
-      scope: (q: any) => q.includes("comments").where("comments.id is null").references("comments"),
-      through: "readers",
-      source: "post",
-    });
+    this.hasMany(
+      "postsWithNoComments",
+      (q: any) => q.includes("comments").where("comments.id is null").references("comments"),
+      { through: "readers", source: "post" },
+    );
 
     this.hasMany("friendships", { foreignKey: "friend_id" });
     this.hasMany("friendsToo", { foreignKey: "friend_id", className: "Friendship" });
@@ -91,21 +91,19 @@ export class Person extends Base {
 
     this.hasMany("references");
     this.hasMany("badReferences");
-    this.hasMany("fixedBadReferences", {
-      scope: (q: any) => q.where({ favorite: true }),
+    this.hasMany("fixedBadReferences", (q: any) => q.where({ favorite: true }), {
       className: "BadReference",
     });
-    this.hasOne("favoriteReference", {
-      scope: (q: any) => q.where({ favorite: true }),
+    this.hasOne("favoriteReference", (q: any) => q.where({ favorite: true }), {
       className: "Reference",
     });
     this.hasOne("favoriteReferenceJob", { through: "favoriteReference", source: "job" });
-    this.hasMany("postsWithCommentsSortedByCommentId", {
-      scope: (q: any) => q.includes("comments").order("comments.id"),
-      through: "readers",
-      source: "post",
-    });
-    this.hasMany("firstPosts", { scope: (q: any) => q.where({ id: [1, 2] }), through: "readers" });
+    this.hasMany(
+      "postsWithCommentsSortedByCommentId",
+      (q: any) => q.includes("comments").order("comments.id"),
+      { through: "readers", source: "post" },
+    );
+    this.hasMany("firstPosts", (q: any) => q.where({ id: [1, 2] }), { through: "readers" });
 
     this.hasMany("jobs", { through: "references" });
     this.hasMany("jobsWithDependentDestroy", {

--- a/packages/activerecord/src/test-helpers/models/pirate.ts
+++ b/packages/activerecord/src/test-helpers/models/pirate.ts
@@ -72,10 +72,7 @@ export class Pirate extends Base {
 
     this.belongsTo("parrot", { validate: true });
     this.belongsTo("nonValidatedParrot", { className: "Parrot" });
-    this.hasAndBelongsToMany("parrots", {
-      scope: (q: any) => q.order("parrots.id ASC"),
-      validate: true,
-    });
+    this.hasAndBelongsToMany("parrots", (q: any) => q.order("parrots.id ASC"), { validate: true });
     this.hasAndBelongsToMany("nonValidatedParrots", { className: "Parrot" });
     this.hasAndBelongsToMany("parrotsWithMethodCallbacks", {
       className: "Parrot",
@@ -100,7 +97,7 @@ export class Pirate extends Base {
     this.hasOne("ship");
     this.hasOne("updateOnlyShip", { className: "Ship" });
     this.hasOne("nonValidatedShip", { className: "Ship" });
-    this.hasMany("birds", { scope: (q: any) => q.order("birds.id ASC") });
+    this.hasMany("birds", (q: any) => q.order("birds.id ASC"));
     this.hasMany("birdsWithMethodCallbacks", {
       className: "Bird",
       beforeAdd: (p: any, b: any) => p.logBeforeAdd(b),
@@ -117,8 +114,7 @@ export class Pirate extends Base {
     });
     this.hasMany("birdsWithRejectAllBlank", { className: "Bird" });
 
-    this.hasOne("fooBulb", {
-      scope: (q: any) => q.where({ name: "foo" }),
+    this.hasOne("fooBulb", (q: any) => q.where({ name: "foo" }), {
       foreignKey: "car_id",
       className: "Bulb",
     });

--- a/packages/activerecord/src/test-helpers/models/post.ts
+++ b/packages/activerecord/src/test-helpers/models/post.ts
@@ -239,28 +239,23 @@ export class Post extends Base {
     );
 
     this.belongsTo("author");
-    this.belongsTo("readonlyAuthor", {
-      scope: (q: any) => q.readonly(),
+    this.belongsTo("readonlyAuthor", (q: any) => q.readonly(), {
       className: "Author",
       foreignKey: "author_id",
     });
-    this.belongsTo("authorWithPosts", {
-      scope: (q: any) => q.includes("posts"),
+    this.belongsTo("authorWithPosts", (q: any) => q.includes("posts"), {
       className: "Author",
       foreignKey: "author_id",
     });
-    this.belongsTo("authorWithAddress", {
-      scope: (q: any) => q.includes("authorAddress"),
+    this.belongsTo("authorWithAddress", (q: any) => q.includes("authorAddress"), {
       className: "Author",
       foreignKey: "author_id",
     });
-    this.belongsTo("authorWithSelect", {
-      scope: (q: any) => q.select("id"),
+    this.belongsTo("authorWithSelect", (q: any) => q.select("id"), {
       className: "Author",
       foreignKey: "author_id",
     });
-    this.belongsTo("authorWithTheLetterA", {
-      scope: (q: any) => q.where("name LIKE '%a%'"),
+    this.belongsTo("authorWithTheLetterA", (q: any) => q.where("name LIKE '%a%'"), {
       className: "Author",
       foreignKey: "author_id",
     });
@@ -274,14 +269,8 @@ export class Post extends Base {
       configurable: false,
       enumerable: false,
     });
-    this.hasOne("firstComment", {
-      scope: (q: any) => q.order("id ASC"),
-      className: "Comment",
-    });
-    this.hasOne("lastComment", {
-      scope: (q: any) => q.order("id desc"),
-      className: "Comment",
-    });
+    this.hasOne("firstComment", (q: any) => q.order("id ASC"), { className: "Comment" });
+    this.hasOne("lastComment", (q: any) => q.order("id desc"), { className: "Comment" });
 
     this.hasMany("comments", {
       // Rails: `has_many :comments do ... end` — the inline extension block on
@@ -312,8 +301,7 @@ export class Post extends Base {
       className: "Comment",
       foreignKey: "post_id",
     });
-    this.hasMany("commentsWithExtending", {
-      scope: (q: any) => q.extending(Post.namedExtension),
+    this.hasMany("commentsWithExtending", (q: any) => q.extending(Post.namedExtension), {
       className: "Comment",
       foreignKey: "post_id",
     });
@@ -337,29 +325,30 @@ export class Post extends Base {
     });
 
     this.hasOne("verySpecialComment");
-    this.hasOne("verySpecialCommentWithPost", {
-      scope: (q: any) => q.includes("post"),
+    this.hasOne("verySpecialCommentWithPost", (q: any) => q.includes("post"), {
       className: "VerySpecialComment",
     });
-    this.hasOne("verySpecialCommentWithPostWithJoins", {
-      scope: (q: any) => q.joins("post").order("posts.id"),
-      className: "VerySpecialComment",
-    });
-    this.hasOne("verySpecialCommentWithStringJoins", {
-      scope: (q: any) =>
+    this.hasOne(
+      "verySpecialCommentWithPostWithJoins",
+      (q: any) => q.joins("post").order("posts.id"),
+      { className: "VerySpecialComment" },
+    );
+    this.hasOne(
+      "verySpecialCommentWithStringJoins",
+      (q: any) =>
         q.joins("JOIN posts AS p1 ON comments.post_id = p1.id").whereNot({ p1: { id: 999999 } }),
-      className: "VerySpecialComment",
-    });
+      { className: "VerySpecialComment" },
+    );
     // trails-authored: a through chain whose intermediate (`through`) reflection
     // scope contributes a raw-string `joins(...)`. Exercises the through-path
     // analogue of `verySpecialCommentWithStringJoins` — the string-join source
     // must attach to the intermediate chain step, not be dropped.
-    this.hasMany("commentsWithStringJoins", {
-      scope: (q: any) =>
+    this.hasMany(
+      "commentsWithStringJoins",
+      (q: any) =>
         q.joins("JOIN posts AS p2 ON comments.post_id = p2.id").whereNot({ p2: { id: 999999 } }),
-      className: "Comment",
-      foreignKey: "post_id",
-    });
+      { className: "Comment", foreignKey: "post_id" },
+    );
     this.hasMany("ratingsViaStringJoinComments", {
       through: "commentsWithStringJoins",
       source: "ratings",
@@ -377,8 +366,7 @@ export class Post extends Base {
 
     this.hasMany("categoryPosts", { className: "CategoryPost" });
     this.hasMany("scategories", { through: "categoryPosts", source: "category" });
-    this.hasMany("hmtSpecialCategories", {
-      scope: (q: any) => q.whereNot({ name: null }),
+    this.hasMany("hmtSpecialCategories", (q: any) => q.whereNot({ name: null }), {
       through: "categoryPosts",
       source: "category",
       className: "SpecialCategory",
@@ -390,8 +378,7 @@ export class Post extends Base {
     });
 
     this.hasMany("essays", { through: "categories" });
-    this.hasMany("authorsOfEssaysNamedBob", {
-      scope: (q: any) => q.where({ name: "Bob" }),
+    this.hasMany("authorsOfEssaysNamedBob", (q: any) => q.where({ name: "Bob" }), {
       through: "essays",
       source: "writer",
       sourceType: "Author",
@@ -445,8 +432,7 @@ export class Post extends Base {
       counterCache: "tags_with_nullify_count",
     });
 
-    this.hasMany("miscTags", {
-      scope: (q: any) => q.where({ tags: { name: "Misc" } }),
+    this.hasMany("miscTags", (q: any) => q.where({ tags: { name: "Misc" } }), {
       through: "taggings",
       source: "tag",
     });
@@ -456,24 +442,20 @@ export class Post extends Base {
     this.hasMany("tagsWithPrimaryKey", { through: "taggings", source: "tagWithPrimaryKey" });
     this.hasOne("tagging", { as: "taggable" });
 
-    this.hasMany("firstTaggings", {
-      scope: (q: any) => q.where({ taggings: { comment: "first" } }),
+    this.hasMany("firstTaggings", (q: any) => q.where({ taggings: { comment: "first" } }), {
       as: "taggable",
       className: "Tagging",
     });
-    this.hasMany("firstBlueTags", {
-      scope: (q: any) => q.where({ tags: { name: "Blue" } }),
+    this.hasMany("firstBlueTags", (q: any) => q.where({ tags: { name: "Blue" } }), {
       through: "firstTaggings",
       source: "tag",
     });
-    this.hasMany("firstBlueTags_2", {
-      scope: (q: any) => q.where({ taggings: { comment: "first" } }),
+    this.hasMany("firstBlueTags_2", (q: any) => q.where({ taggings: { comment: "first" } }), {
       through: "taggings",
       source: "blueTag",
     });
 
-    this.hasMany("invalidTaggings", {
-      scope: (q: any) => q.where("taggings.id < 0"),
+    this.hasMany("invalidTaggings", (q: any) => q.where("taggings.id < 0"), {
       as: "taggable",
       className: "Tagging",
     });
@@ -521,10 +503,7 @@ export class Post extends Base {
 
     this.hasMany("readers");
     this.hasMany("secureReaders");
-    this.hasMany("readersWithPerson", {
-      scope: (q: any) => q.includes("person"),
-      className: "Reader",
-    });
+    this.hasMany("readersWithPerson", (q: any) => q.includes("person"), { className: "Reader" });
     this.hasMany("people", { through: "readers" });
     this.hasMany("singlePeople", { through: "readers" });
     this.hasMany("peopleWithCallbacks", {
@@ -543,20 +522,15 @@ export class Post extends Base {
         Post.log("removed", "after", reader.first_name);
       },
     });
-    this.hasMany("skimmers", {
-      scope: (q: any) => q.where({ skimmer: true }),
-      className: "Reader",
-    });
+    this.hasMany("skimmers", (q: any) => q.where({ skimmer: true }), { className: "Reader" });
     this.hasMany("impatientPeople", { through: "skimmers", source: "person" });
 
     this.hasMany("lazyReaders");
-    this.hasMany("lazyReadersSkimmersOrNot", {
-      scope: (q: any) => q.where({ skimmer: [true, false] }),
+    this.hasMany("lazyReadersSkimmersOrNot", (q: any) => q.where({ skimmer: [true, false] }), {
       className: "LazyReader",
     });
     this.hasMany("lazyPeople", { through: "lazyReaders", source: "person" });
-    this.hasMany("lazyReadersUnscopeSkimmers", {
-      scope: (q: any) => q.skimmersOrNot(),
+    this.hasMany("lazyReadersUnscopeSkimmers", (q: any) => q.skimmersOrNot(), {
       className: "LazyReader",
     });
     this.hasMany("lazyPeopleUnscopeSkimmers", {
@@ -763,8 +737,7 @@ export class TaggedPost extends Post {
     ((name: "mainImage") => Promise<Image | null>);
 
   static {
-    this.hasMany("taggings", {
-      scope: (q: any) => q.rewhere({ taggable_type: "TaggedPost" }),
+    this.hasMany("taggings", (q: any) => q.rewhere({ taggable_type: "TaggedPost" }), {
       as: "taggable",
     });
     this.hasMany("tags", { through: "taggings" });

--- a/packages/activerecord/src/test-helpers/models/project.ts
+++ b/packages/activerecord/src/test-helpers/models/project.ts
@@ -37,28 +37,28 @@ export class Project extends Base {
     this.hasAndBelongsToMany("developers", (q: any) =>
       q.distinct().order("developers.name desc, developers.id desc"),
     );
-    this.hasAndBelongsToMany("readonlyDevelopers", {
-      scope: (q: any) => q.readonly(),
+    this.hasAndBelongsToMany("readonlyDevelopers", (q: any) => q.readonly(), {
       className: "Developer",
     });
-    this.hasAndBelongsToMany("nonUniqueDevelopers", {
-      scope: (q: any) => q.order("developers.name desc, developers.id desc"),
+    this.hasAndBelongsToMany(
+      "nonUniqueDevelopers",
+      (q: any) => q.order("developers.name desc, developers.id desc"),
+      { className: "Developer" },
+    );
+    this.hasAndBelongsToMany("limitedDevelopers", (q: any) => q.limit(1), {
       className: "Developer",
     });
-    this.hasAndBelongsToMany("limitedDevelopers", {
-      scope: (q: any) => q.limit(1),
-      className: "Developer",
-    });
-    this.hasAndBelongsToMany("developersNamedDavid", {
-      scope: (q: any) => q.where("name = 'David'").distinct(),
-      className: "Developer",
-    });
-    this.hasAndBelongsToMany("developersNamedDavidWithHashConditions", {
-      scope: (q: any) => q.where({ name: "David" }).distinct(),
-      className: "Developer",
-    });
-    this.hasAndBelongsToMany("salariedDevelopers", {
-      scope: (q: any) => q.where("salary > 0"),
+    this.hasAndBelongsToMany(
+      "developersNamedDavid",
+      (q: any) => q.where("name = 'David'").distinct(),
+      { className: "Developer" },
+    );
+    this.hasAndBelongsToMany(
+      "developersNamedDavidWithHashConditions",
+      (q: any) => q.where({ name: "David" }).distinct(),
+      { className: "Developer" },
+    );
+    this.hasAndBelongsToMany("salariedDevelopers", (q: any) => q.where("salary > 0"), {
       className: "Developer",
     });
     this.hasAndBelongsToMany("developersWithCallbacks", {
@@ -83,11 +83,12 @@ export class Project extends Base {
           prev;
       }
     }
-    this.hasAndBelongsToMany("wellPaidSalaryGroups", {
-      scope: (q: any) =>
+    this.hasAndBelongsToMany(
+      "wellPaidSalaryGroups",
+      (q: any) =>
         q.group("developers.salary").having("SUM(salary) > 10000").select("SUM(salary) as salary"),
-      className: "Developer",
-    });
+      { className: "Developer" },
+    );
     this.belongsTo("firm");
     this.hasOne("leadDeveloper", { through: "firm", inverseOf: "contractedProjects" });
     this.hasOne("leadDeveloperDisableJoins", {

--- a/packages/activerecord/src/test-helpers/models/rating.ts
+++ b/packages/activerecord/src/test-helpers/models/rating.ts
@@ -16,16 +16,16 @@ export class Rating extends Base {
   static {
     this.belongsTo("comment");
     this.hasMany("taggings", { as: "taggable" });
-    this.hasMany("taggingsWithoutTag", {
-      scope: (q: any) => q.leftJoins("tag").where({ "tags.id": [null, 0] }),
-      as: "taggable",
-      className: "Tagging",
-    });
-    this.hasMany("taggingsWithNoTag", {
-      scope: (q: any) =>
+    this.hasMany(
+      "taggingsWithoutTag",
+      (q: any) => q.leftJoins("tag").where({ "tags.id": [null, 0] }),
+      { as: "taggable", className: "Tagging" },
+    );
+    this.hasMany(
+      "taggingsWithNoTag",
+      (q: any) =>
         q.joins("LEFT OUTER JOIN tags ON tags.id = taggings.tag_id").where({ "tags.id": null }),
-      as: "taggable",
-      className: "Tagging",
-    });
+      { as: "taggable", className: "Tagging" },
+    );
   }
 }

--- a/packages/activerecord/src/test-helpers/models/reader.ts
+++ b/packages/activerecord/src/test-helpers/models/reader.ts
@@ -28,7 +28,7 @@ export class Reader extends Base {
       foreignKey: "person_id",
       inverseOf: "reader",
     });
-    this.belongsTo("firstPost", { scope: (q: any) => q.where({ id: [2, 3] }) });
+    this.belongsTo("firstPost", (q: any) => q.where({ id: [2, 3] }));
   }
 }
 

--- a/packages/activerecord/src/test-helpers/models/sponsor.ts
+++ b/packages/activerecord/src/test-helpers/models/sponsor.ts
@@ -28,8 +28,7 @@ export class Sponsor extends Base {
       foreignType: "sponsorable_type",
       foreignKey: "sponsorable_id",
     });
-    this.belongsTo("sponsorableWithConditions", {
-      scope: (q: any) => q.where({ name: "Ernie" }),
+    this.belongsTo("sponsorableWithConditions", (q: any) => q.where({ name: "Ernie" }), {
       polymorphic: true,
       foreignType: "sponsorable_type",
       foreignKey: "sponsorable_id",

--- a/packages/activerecord/src/test-helpers/models/subscription.ts
+++ b/packages/activerecord/src/test-helpers/models/subscription.ts
@@ -15,9 +15,9 @@ export class Subscription extends Base {
 
   static {
     this.belongsTo("subscriber", { counterCache: "books_count" });
-    this.belongsTo("book", {
-      scope: (q: ReturnType<(typeof Base)["all"]>) => q.where({ author_visibility: 0 }),
-    });
+    this.belongsTo("book", (q: ReturnType<(typeof Base)["all"]>) =>
+      q.where({ author_visibility: 0 }),
+    );
     this.validatesPresenceOf("subscriber_id", "book_id");
   }
 }

--- a/packages/activerecord/src/test-helpers/models/tag.ts
+++ b/packages/activerecord/src/test-helpers/models/tag.ts
@@ -24,7 +24,7 @@ export class Tag extends Base {
     // Defined inline in join_model_test.rb's
     // test_has_many_polymorphic_associations_merges_through_scope; carried on the
     // canonical model so the test needn't mutate the shared class at runtime.
-    this.hasMany("nullTaggings", { scope: (q: any) => q.none(), className: "Tagging" });
+    this.hasMany("nullTaggings", (q: any) => q.none(), { className: "Tagging" });
     this.hasMany("nullTaggedPosts", {
       through: "nullTaggings",
       source: "taggable",
@@ -40,8 +40,7 @@ export class OrderedTag extends Tag {
 
   static {
     this._tableName = "tags";
-    this.hasMany("orderedTaggings", {
-      scope: (q: any) => q.order("taggings.id DESC"),
+    this.hasMany("orderedTaggings", (q: any) => q.order("taggings.id DESC"), {
       foreignKey: "tag_id",
       className: "Tagging",
     });

--- a/packages/activerecord/src/test-helpers/models/tagging.ts
+++ b/packages/activerecord/src/test-helpers/models/tagging.ts
@@ -30,12 +30,11 @@ export class Tagging extends Base {
   declare taggable: Base | null;
 
   static {
-    this.belongsTo("tag", { scope: (q: any) => q.includes("tagging") });
+    this.belongsTo("tag", (q: any) => q.includes("tagging"));
     this.belongsTo("superTag", { className: "Tag", foreignKey: "super_tag_id" });
     this.belongsTo("invalidTag", { className: "Tag", foreignKey: "tag_id" });
     this.belongsTo("orderedTag", { className: "OrderedTag", foreignKey: "tag_id" });
-    this.belongsTo("blueTag", {
-      scope: (q: any) => q.where({ tags: { name: "Blue" } }),
+    this.belongsTo("blueTag", (q: any) => q.where({ tags: { name: "Blue" } }), {
       className: "Tag",
       foreignKey: "tag_id",
     });

--- a/packages/activerecord/src/test-helpers/models/user.ts
+++ b/packages/activerecord/src/test-helpers/models/user.ts
@@ -39,10 +39,7 @@ export class User extends Base {
 
     this.hasOne("room");
     this.hasOne("ownedRoom", { className: "Room", foreignKey: "owner_id" });
-    this.hasOne("familyTree", {
-      scope: (q: any) => q.where({ token: null }),
-      foreignKey: "member_id",
-    });
+    this.hasOne("familyTree", (q: any) => q.where({ token: null }), { foreignKey: "member_id" });
     this.hasOne("family", { through: "familyTree" });
     this.hasMany("familyMembers", { through: "family", source: "members" });
 


### PR DESCRIPTION
## What

Rails writes every scoped association in `test/models/*.rb` as a positional
lambda — `has_many :nonexistent_comments, -> { where "comments.id < 0" }, class_name: "Comment"`
(`vendor/rails/activerecord/test/models/post.rb:120`). The canonical trails
models still passed the scope in the options bag (`{ scope: (q) => … }`), a
trails spelling with no Rails counterpart, in ~174 declarations across 26 model
files. #6375 converted two of them; this sweeps the rest so the two spellings no
longer coexist in the same tree.

All four macros already accept the positional (`associations.rb:1302, 1870`).

## Verification against Rails

Every converted declaration was cross-checked against the `->` lambda on the
corresponding `vendor/rails/activerecord/test/models/*.rb` line. The one
declaration with no model-file counterpart, `Tag.nullTaggings`, matches
`Tag.has_many :null_taggings, -> { none }, class_name: :Tagging` defined inline
at `join_model_test.rb:376`. No trails-invented scope was found, so nothing had
to be dropped or filed (acceptance criterion 2).

## Builder narrowing

With no caller left feeding the bag, `Builder::HasAndBelongsToMany` reads the
scope from the positional only (`positionalScope ?? options.scope` →
`positionalScope`). `habtmOptions.scope` still carries it onward for the
through-routing loaders, unchanged.

## Size

This is a single mechanical sweep — one transformation applied uniformly — which
is why it sits above the usual LOC ceiling. The bundled story
`port-active-support-test-case-receiver` was released back to the queue rather
than stacked on top of this; at ~400 LOC it would have pushed the PR past 1200.

## Checks

- `pnpm typecheck`, `pnpm lint` clean
- `pnpm parity:api:calls` OK, `pnpm parity:api:calls:args` OK (no new rows)
- `pnpm vitest run src/associations.test.ts src/associations/` — 99 files, 2147 passed
- `pnpm vitest run src/relation src/scoping src/nested-attributes.test.ts` — 61 files, 1577 passed

Closes-story: models-scope-positional-sweep