### PR TITLE
chore(parity): retire 4 stale call-arg baseline rows

### DIFF
--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
@@ -720,30 +720,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
-    "rubyName": "update",
-    "call": "update",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:id",
-      "ref:attributes"
-    ],
-    "reason": "Pre-existing divergence, newly COMPARED (RFC 0099): relation.rb:621 is `update(id = :all, attributes)` and dispatches on the `:all` sentinel, while relation.ts:5791 branches on an omitted/object `id` and forwards a single `updates` hash. Converging the signature is tracked by 0099/converge-weak-receiver-surfaced-call-arg-rows."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "update!",
-    "call": "update!",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:id",
-      "ref:attributes"
-    ],
-    "reason": "Pre-existing divergence, newly COMPARED (RFC 0099): relation.rb:629's `:all` sentinel, as for `update` above. Tracked by 0099/converge-weak-receiver-surfaced-call-arg-rows."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
     "rubyName": "update_all",
     "call": "arel",
     "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."

--- a/scripts/api-compare/call-mismatches-exclude/rack/multipart/parser.json
+++ b/scripts/api-compare/call-mismatches-exclude/rack/multipart/parser.json
@@ -46,18 +46,6 @@
   {
     "package": "rack",
     "tsFile": "multipart/parser.ts",
-    "rubyName": "read_data",
-    "call": "read",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:bufsize",
-      "ref:outbuf"
-    ],
-    "reason": "TS language shortcoming: parser.rb:259 passes `outbuf` to `IO#read` to reuse one mutable String buffer across reads. JS strings are immutable and the port's `io.read(n)` has no such parameter (parser.ts:327), so the argument cannot be spelled."
-  },
-  {
-    "package": "rack",
-    "tsFile": "multipart/parser.ts",
     "rubyName": "result",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/trailties/source-annotation-extractor.json
+++ b/scripts/api-compare/call-mismatches-exclude/trailties/source-annotation-extractor.json
@@ -2,18 +2,6 @@
   {
     "package": "trailties",
     "tsFile": "source-annotation-extractor.ts",
-    "rubyName": "enumerate",
-    "call": "display",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:find",
-      "ref:options"
-    ],
-    "reason": "Pre-existing divergence, newly COMPARED (RFC 0099): Rails passes `display(find(...), options)` while the port passes the results plus a `{ tag }` kwargs bag. Tracked by 0099/converge-weak-receiver-surfaced-call-arg-rows."
-  },
-  {
-    "package": "trailties",
-    "tsFile": "source-annotation-extractor.ts",
     "rubyName": "find_in",
     "call": "call",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
`Rails API/Test Comparison` is red on main @3d5358af: the call-args ratchet reports 4 STALE baseline entries that no longer flag.

#6500 converged the bodies but left the baseline rows behind. The baseline only shrinks, so a stale row reds the gate. This deletes exactly those 4 rows (hand-pruned via `serializeBaseline`, no `--write` reseed):

- activerecord `relation.ts` `update` — `update(ref:id, ref:attributes)`
- activerecord `relation.ts` `update!` — `update!(ref:id, ref:attributes)`
- rack `multipart/parser.ts` `read_data` — `read(ref:bufsize, ref:outbuf)`
- trailties `source-annotation-extractor.ts` `enumerate` — `display(ref:find, ref:options)`

Verified locally after a full `API_COMPARE_FORCE=1 pnpm parity:api --calls` regeneration:
- `pnpm parity:api:calls:args` — OK (244 baselined shape rows)
- `pnpm parity:api:calls` — OK (1649 baselined)

Closes-story: red-3d5358af