### PR TITLE
feat(trailties): splice Finisher initializers into Application#initializers

### DIFF
--- a/packages/actionpack/src/action-dispatch/index.ts
+++ b/packages/actionpack/src/action-dispatch/index.ts
@@ -53,7 +53,7 @@ export {
   DefaultResponseApp,
   type HostAuthorizationOptions,
 } from "./middleware/host-authorization.js";
-export { MiddlewareStack } from "./middleware/stack.js";
+export { MiddlewareStack, type MiddlewareEntry, type RackApp } from "./middleware/stack.js";
 export { MimeType } from "./http/mime-type.js";
 export {
   ContentSecurityPolicy,

--- a/packages/actionpack/src/action-dispatch/middleware/stack.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/stack.ts
@@ -6,7 +6,7 @@
 
 import type { RackEnv, RackResponse } from "@blazetrails/rack";
 
-type RackApp = (env: RackEnv) => Promise<RackResponse>;
+export type RackApp = (env: RackEnv) => Promise<RackResponse>;
 type MiddlewareFactory = new (
   app: RackApp,
   ...args: any[]

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -524,6 +524,7 @@ export { CurrentAttributes } from "./current-attributes.js";
 export { StringInquirer, inquiry } from "./string-inquirer.js";
 export { StringIO } from "./string-io.js";
 export { EnvironmentInquirer } from "./environment-inquirer.js";
+export { Reloader, type PrepareCallback } from "./reloader.js";
 export { getEnv } from "./environment.js";
 export { ExecutionContext } from "./execution-context.js";
 export { objectWith } from "./core-ext/object/with.js";

--- a/packages/activesupport/src/reloader.trails.test.ts
+++ b/packages/activesupport/src/reloader.trails.test.ts
@@ -1,0 +1,32 @@
+// Trails-only coverage for the ported `:prepare` callback surface of
+// `ActiveSupport::Reloader`. The Rails-mirrored cases live in
+// `reloader.test.ts` and stay skipped until `ExecutionWrapper` is ported.
+import { describe, it, expect } from "vitest";
+import { Reloader } from "./reloader.js";
+
+describe("Reloader (trails)", () => {
+  it("runs to_prepare callbacks on prepare!", () => {
+    class AppReloader extends Reloader {}
+    const ran: string[] = [];
+    AppReloader.toPrepare(() => ran.push("first"));
+    AppReloader.toPrepare(() => ran.push("second"));
+
+    expect(ran).toEqual([]);
+    AppReloader.prepareBang();
+    expect(ran).toEqual(["first", "second"]);
+    AppReloader.prepareBang();
+    expect(ran).toEqual(["first", "second", "first", "second"]);
+  });
+
+  it("keeps each subclass's prepare callbacks to itself", () => {
+    class OneReloader extends Reloader {}
+    class TwoReloader extends Reloader {}
+    const ran: string[] = [];
+    OneReloader.toPrepare(() => ran.push("one"));
+
+    TwoReloader.prepareBang();
+    expect(ran).toEqual([]);
+    OneReloader.prepareBang();
+    expect(ran).toEqual(["one"]);
+  });
+});

--- a/packages/activesupport/src/reloader.ts
+++ b/packages/activesupport/src/reloader.ts
@@ -1,0 +1,31 @@
+/**
+ * Port of `ActiveSupport::Reloader` from
+ * `activesupport/lib/active_support/reloader.rb`.
+ *
+ * Only the `:prepare` callback surface is ported — `to_prepare` /
+ * `prepare!` (reloader.rb:34-36, :95-97) are what `Rails::Application`'s
+ * finisher initializers drive. The `ExecutionWrapper` superclass and the
+ * `:class_unload` callbacks, `wrap`, `run!`, `complete!`, `check!`,
+ * `reload!` and the interlock locking depend on
+ * `ActiveSupport::ExecutionWrapper` / `Dependencies::Interlock`, neither of
+ * which is ported yet.
+ */
+import { defineCallbacks, runCallbacks, setCallback } from "./callbacks.js";
+
+export type PrepareCallback = () => void;
+
+export class Reloader {
+  static {
+    defineCallbacks(this.prototype, "prepare");
+  }
+
+  /** Rails: `def self.to_prepare(*args, &block)` (reloader.rb:34). */
+  static toPrepare(block: PrepareCallback): void {
+    setCallback(this.prototype, "prepare", "before", block);
+  }
+
+  /** Rails: `def self.prepare!` (reloader.rb:95) — `new.run_callbacks(:prepare)`. */
+  static prepareBang(): void {
+    runCallbacks(new this(), "prepare", () => undefined);
+  }
+}

--- a/packages/trailties/src/application.test.ts
+++ b/packages/trailties/src/application.test.ts
@@ -32,6 +32,7 @@ import {
   Static,
 } from "@blazetrails/actionpack";
 import { Engine } from "./engine.js";
+import { Root } from "./paths.js";
 import { Trailtie } from "./trailtie.js";
 import { Trails } from "./rails.js";
 import { HelloWorldApp, buildRoutes } from "./__fixtures__/hello-world/app.js";
@@ -371,7 +372,11 @@ describe("Application::Configuration", () => {
 });
 
 describe("Application::DefaultMiddlewareStack", () => {
-  const paths = { public: () => "/public" };
+  const paths = (() => {
+    const root = new Root("/app");
+    root.add("public");
+    return root;
+  })();
   const buildApp = () => ({ config: new Configuration() });
 
   const build = (mutate: (c: Configuration) => void = () => {}) => {

--- a/packages/trailties/src/application.test.ts
+++ b/packages/trailties/src/application.test.ts
@@ -276,6 +276,34 @@ describe("Application", () => {
       expect(names).toContain("initialize_cache");
       expect(names).toContain("bootstrap_hook");
     });
+
+    it("splices Finisher initializers after the inherited Engine ones", () => {
+      class IApp6 extends Application {}
+      Application.register(IApp6);
+      const names = IApp6.instance().initializers.map((i) => i.name);
+      expect(names.slice(-6)).toEqual([
+        "add_generator_templates",
+        "add_internal_routes",
+        "build_middleware_stack",
+        "define_main_app_helper",
+        "add_to_prepare_blocks",
+        "run_prepare_callbacks",
+      ]);
+    });
+
+    it("builds the middleware stack and draws routes when booted", async () => {
+      class IApp7 extends Application {}
+      Application.register(IApp7);
+      const app = IApp7.instance();
+      await app.initialize();
+      expect(app.config.middleware.middlewares.length).toBeGreaterThan(0);
+      expect(app.config.middleware.middlewares.map((m) => m.klass)).toContain(RequestId);
+      expect(app.routes().isEmpty()).toBe(true);
+      app.routes().draw((mapper) => {
+        mapper.get("/hello", "hello#index");
+      });
+      expect(app.routes().isEmpty()).toBe(false);
+    });
   });
 });
 

--- a/packages/trailties/src/application.ts
+++ b/packages/trailties/src/application.ts
@@ -168,11 +168,11 @@ export class Application extends Engine {
     return (env) => routes.call(env);
   }
 
-  /** Mirrors `Application#default_middleware_stack` (`application.rb:626-629`). */
+  /** Mirrors `Application#default_middleware_stack` (`application.rb:626-629`).
+   * Rails passes `paths`; `Engine#paths()` is async in trails (it resolves the
+   * root first), so the sync `config.paths()` it delegates to is passed here. */
   defaultMiddlewareStack(): MiddlewareStack {
-    const defaultStack = new DefaultMiddlewareStack(this, this.config, {
-      public: () => this.config.paths().get("public")?.toAry()[0],
-    });
+    const defaultStack = new DefaultMiddlewareStack(this, this.config, this.config.paths());
     return defaultStack.buildStack();
   }
 
@@ -180,14 +180,15 @@ export class Application extends Engine {
    * Mirrors `Application#ensure_generator_templates_added`
    * (`application.rb:631-634`).
    *
-   * Rails also unshifts the existent `paths["lib/templates"]` directories
-   * ahead of the configured ones. `Path#existent` is async in trails (`paths.ts:147`) and initializers run
-   * synchronously (`initializable.ts:runInitializers`), so the filesystem
-   * scan is skipped; see the `generator-templates-existent-paths` story.
+   * Rails filters `paths["lib/templates"]` through `existent`;
+   * `Path#existent` is async in trails (`paths.ts:147`) while initializers run
+   * synchronously (`Initializable#runInitializers`), so the declared paths are
+   * unshifted unfiltered — see the `generator-templates-existent-paths` story.
    */
   ensureGeneratorTemplatesAdded(): void {
-    const generators = this.config.generators();
-    generators.templates ??= [];
+    const configuredPaths = this.config.generators().templates as string[];
+    const libTemplates = this.config.paths().get("lib/templates")?.toAry() ?? [];
+    configuredPaths.unshift(...libTemplates.filter((p) => !configuredPaths.includes(p)));
   }
 
   routesReloader(): RoutesReloader {

--- a/packages/trailties/src/application.ts
+++ b/packages/trailties/src/application.ts
@@ -11,16 +11,20 @@ import {
   setTrailsRoot,
   underscore,
 } from "@blazetrails/activesupport";
+import { Reloader } from "@blazetrails/activesupport";
 import { CachingKeyGenerator, KeyGenerator } from "@blazetrails/activesupport/key-generator";
 import { MessageVerifier } from "@blazetrails/activesupport/message-verifier";
 import { Engine } from "./engine.js";
 import { Trailtie } from "./trailtie.js";
 import { Bootstrap } from "./application/bootstrap.js";
+import { DefaultMiddlewareStack } from "./application/default-middleware-stack.js";
+import { Finisher } from "./application/finisher.js";
 import { Configuration } from "./application/configuration.js";
 import { RoutesReloader } from "./application/routes-reloader.js";
 import { resolveEnv, loadDatabaseConfig, type DatabaseConfig } from "./database.js";
 import { Collection, type InitializerGroup } from "./initializable.js";
 import type { CacheStore, Logger } from "@blazetrails/activesupport";
+import type { MiddlewareStack, RackApp } from "@blazetrails/actionpack";
 
 let _appClass: typeof Application | null = null;
 /** @internal Tracks which subclasses have fired `:before_configuration`. */
@@ -31,6 +35,11 @@ export class Application extends Engine {
   private _routesReloader?: RoutesReloader;
   private _keyGenerators = new Map<string, CachingKeyGenerator>();
   private _credentials?: EncryptedFile;
+  private _app?: RackApp;
+  /** Rails: `@reloader = Class.new(ActiveSupport::Reloader)` (`application.rb:123`) —
+   * a per-application subclass so one app's prepare callbacks don't leak into
+   * another's. */
+  readonly reloader = class extends Reloader {};
   logger: Logger | null = null;
   cache: CacheStore | null = null;
 
@@ -91,14 +100,18 @@ export class Application extends Engine {
 
   /**
    * Splice Bootstrap + Engine/Trailtie + Finisher initializers — mirrors
-   * Rails' `Application#initializers`. Finisher splicing lands in PR 2.5b
-   * once `Configuration` + the middleware stack supply the host methods
-   * Finisher requires.
+   * Rails' `Application#initializers` (`application.rb:445-449`).
+   *
+   * @missingRailsCall railties_initializers — Rails wraps the inherited
+   * collection in `railties_initializers(super)` so `config.railties_order`
+   * can reorder engines around the app; `ordered_railties` is not ported
+   * (see `application.ts` PR 2.5), so the inherited collection is spliced
+   * in load order.
    */
   get initializers(): Collection {
     const bootstrap = Bootstrap.initializersFor(this);
     const inherited = super.initializers;
-    return bootstrap.plus(inherited);
+    return bootstrap.plus(inherited).plus(Finisher.initializersFor(this));
   }
 
   /**
@@ -119,6 +132,62 @@ export class Application extends Engine {
     this._initialized = true;
     runLoadHooks("after_initialize", this);
     return this;
+  }
+
+  /**
+   * Mirrors `Engine#app` (`engine.rb:516-524`) — builds the middleware
+   * stack once and wraps the endpoint in it.
+   *
+   * @missingRailsCall build_middleware, merge_into — Rails merges
+   * `config.app_middleware + config.middleware` (both
+   * `MiddlewareStackProxy`s) into the default stack. `MiddlewareStackProxy`
+   * is not ported (`trailtie/configuration.ts:87` — `appMiddleware()`
+   * returns undefined), so there are no queued operations to merge and the
+   * default stack is assigned to `config.middleware` directly.
+   */
+  app(): RackApp {
+    if (this._app) return this._app;
+    const stack = this.defaultMiddlewareStack();
+    this.config.middleware = stack;
+    return (this._app = stack.build(this.endpoint()));
+  }
+
+  /** Rails: `alias :build_middleware_stack :app` (`application.rb:558`). */
+  buildMiddlewareStack(): RackApp {
+    return this.app();
+  }
+
+  /**
+   * Mirrors `Engine#endpoint` (`engine.rb:527-529`) — `self.class.endpoint`
+   * is not ported, so the route set is always the endpoint. Rails hands the
+   * `RouteSet` itself to the stack because it responds to `call`; trails'
+   * `RackApp` is a function type, so the method is wrapped.
+   */
+  endpoint(): RackApp {
+    const routes = this.routes();
+    return (env) => routes.call(env);
+  }
+
+  /** Mirrors `Application#default_middleware_stack` (`application.rb:626-629`). */
+  defaultMiddlewareStack(): MiddlewareStack {
+    const defaultStack = new DefaultMiddlewareStack(this, this.config, {
+      public: () => this.config.paths().get("public")?.toAry()[0],
+    });
+    return defaultStack.buildStack();
+  }
+
+  /**
+   * Mirrors `Application#ensure_generator_templates_added`
+   * (`application.rb:631-634`).
+   *
+   * Rails also unshifts the existent `paths["lib/templates"]` directories
+   * ahead of the configured ones. `Path#existent` is async in trails (`paths.ts:147`) and initializers run
+   * synchronously (`initializable.ts:runInitializers`), so the filesystem
+   * scan is skipped; see the `generator-templates-existent-paths` story.
+   */
+  ensureGeneratorTemplatesAdded(): void {
+    const generators = this.config.generators();
+    generators.templates ??= [];
   }
 
   routesReloader(): RoutesReloader {

--- a/packages/trailties/src/application/configuration.ts
+++ b/packages/trailties/src/application/configuration.ts
@@ -78,13 +78,14 @@ export class Configuration extends EngineConfiguration {
   /**
    * Mirrors `Rails::Application::Configuration#paths`: appends the app-only
    * path entries (`public`, `tmp`, `log`, …) on top of `EngineConfiguration#paths`.
-   * Only `public` is added today; the remaining Rails entries land with their
+   * Only `public` and `lib/templates` are added today; the remaining Rails entries land with their
    * respective consumers (PR 2.7-followups). See
    * `vendor/rails/railties/lib/rails/application/configuration.rb:396`.
    */
   override paths(): Root {
     const paths = super.paths();
     if (!paths.get("public")) paths.add("public");
+    if (!paths.get("lib/templates")) paths.add("lib/templates");
     return paths;
   }
 }

--- a/packages/trailties/src/application/default-middleware-stack.ts
+++ b/packages/trailties/src/application/default-middleware-stack.ts
@@ -56,7 +56,11 @@ export class DefaultMiddlewareStack {
     if (config.publicFileServer.enabled) {
       const root = this.paths.public();
       if (root) {
-        stack.use(Static as never, root, {
+        // Rails passes `root` positionally (`default_middleware_stack.rb:32`);
+        // trails' `Static` takes it as an option key
+        // (`actionpack/.../middleware/static.ts:47`).
+        stack.use(Static as never, {
+          root,
           index: config.publicFileServer.indexName,
           headers: config.publicFileServer.headers ?? {},
         });

--- a/packages/trailties/src/application/default-middleware-stack.ts
+++ b/packages/trailties/src/application/default-middleware-stack.ts
@@ -17,26 +17,29 @@ import {
   Static,
 } from "@blazetrails/actionpack";
 import type { Configuration } from "./configuration.js";
+import type { Root } from "../paths.js";
 
 export interface DefaultStackHostApp {
   config: Configuration;
 }
 
-export interface DefaultStackPaths {
-  public(): string | undefined;
-}
-
 export class DefaultMiddlewareStack {
   readonly app: DefaultStackHostApp;
   readonly config: Configuration;
-  readonly paths: DefaultStackPaths;
+  readonly paths: Root;
 
-  constructor(app: DefaultStackHostApp, config: Configuration, paths: DefaultStackPaths) {
+  constructor(app: DefaultStackHostApp, config: Configuration, paths: Root) {
     this.app = app;
     this.config = config;
     this.paths = paths;
   }
 
+  /**
+   * Mirrors `DefaultMiddlewareStack#build_stack`
+   * (`application/default_middleware_stack.rb:11`). `ActionDispatch::Static`
+   * takes `path` positionally in Rails (`static.rb:21`); trails' `Static`
+   * takes it as the `root` option key (`middleware/static.ts:47`).
+   */
   buildStack(): MiddlewareStack {
     const stack = new MiddlewareStack();
     const config = this.config;
@@ -54,17 +57,12 @@ export class DefaultMiddlewareStack {
     }
 
     if (config.publicFileServer.enabled) {
-      const root = this.paths.public();
-      if (root) {
-        // Rails passes `root` positionally (`default_middleware_stack.rb:32`);
-        // trails' `Static` takes it as an option key
-        // (`actionpack/.../middleware/static.ts:47`).
-        stack.use(Static as never, {
-          root,
-          index: config.publicFileServer.indexName,
-          headers: config.publicFileServer.headers ?? {},
-        });
-      }
+      const headers = config.publicFileServer.headers ?? {};
+      stack.use(Static as never, {
+        root: this.paths.get("public")?.toAry()[0],
+        index: config.publicFileServer.indexName,
+        headers,
+      });
     }
 
     if (config.serverTiming) stack.use(ServerTiming as never);
@@ -103,6 +101,9 @@ export class DefaultMiddlewareStack {
 
   /** @internal Rails' `exceptions_app || PublicExceptions.new(Rails.public_path)`. */
   private _showExceptionsApp(): unknown {
-    return this.config.exceptionsApp ?? new PublicExceptions(this.paths.public() ?? "/public");
+    return (
+      this.config.exceptionsApp ??
+      new PublicExceptions(this.paths.get("public")?.toAry()[0] ?? "/public")
+    );
   }
 }

--- a/packages/trailties/src/application/finisher.test.ts
+++ b/packages/trailties/src/application/finisher.test.ts
@@ -22,7 +22,10 @@ class TestApp extends Finisher {
   private _routes: FinisherRoutes = {
     prepend: (block) =>
       block({
-        get: (path: string, to: string) => this.internalRoutes.push(`get ${path} -> ${to}`),
+        get: (path: string, options: { to: string; internal?: boolean }) =>
+          this.internalRoutes.push(
+            `get ${path} -> ${options.to}${options.internal === true ? " (internal)" : ""}`,
+          ),
       } as unknown as Mapper),
     defineMountedHelper: (name) => this.mountedHelpers.push(name),
   };
@@ -118,10 +121,10 @@ describe("Finisher", () => {
     const app = new TestApp();
     run(app, "add_internal_routes");
     expect(app.internalRoutes).toEqual([
-      "get /rails/info/properties -> rails/info#properties",
-      "get /rails/info/routes -> rails/info#routes",
-      "get /rails/info/notes -> rails/info#notes",
-      "get /rails/info -> rails/info#index",
+      "get /rails/info/properties -> rails/info#properties (internal)",
+      "get /rails/info/routes -> rails/info#routes (internal)",
+      "get /rails/info/notes -> rails/info#notes (internal)",
+      "get /rails/info -> rails/info#index (internal)",
     ]);
   });
 

--- a/packages/trailties/src/application/finisher.test.ts
+++ b/packages/trailties/src/application/finisher.test.ts
@@ -1,28 +1,35 @@
 // Mirrors railties/test/application/initializers/finisher_test.rb.
 // The ported subset of finisher initializers is exercised against a
 // mock host so we don't need the full Application shell (PR 2.5).
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect } from "vitest";
 import {
   Finisher,
   type FinisherConfig,
-  type FinisherEnv,
   type FinisherReloader,
   type FinisherRoutes,
 } from "./finisher.js";
+import { Trails } from "../rails.js";
 import type { ConfigurationBlock } from "../trailtie/configuration.js";
+import type { Mapper } from "@blazetrails/actionpack";
 
 class TestApp extends Finisher {
   config: FinisherConfig = { toPrepareBlocks: [] };
-  env: FinisherEnv = { isDevelopment: () => true };
   calls: string[] = [];
   internalRoutes: string[] = [];
   toPrepared: ConfigurationBlock[] = [];
   mountedHelpers: string[] = [];
 
-  routes: FinisherRoutes = {
-    prepend: (block) => block(),
+  private _routes: FinisherRoutes = {
+    prepend: (block) =>
+      block({
+        get: (path: string, to: string) => this.internalRoutes.push(`get ${path} -> ${to}`),
+      } as unknown as Mapper),
     defineMountedHelper: (name) => this.mountedHelpers.push(name),
   };
+
+  routes(): FinisherRoutes {
+    return this._routes;
+  }
   reloader: FinisherReloader = {
     toPrepare: (block) => this.toPrepared.push(block),
     prepareBang: () => this.calls.push("prepare!"),
@@ -34,9 +41,6 @@ class TestApp extends Finisher {
   buildMiddlewareStack(): void {
     this.calls.push("middleware_stack");
   }
-  appendInternalRoute(verb: string, path: string, to: string): void {
-    this.internalRoutes.push(`${verb} ${path} -> ${to}`);
-  }
 }
 
 function run(app: TestApp, name: string): void {
@@ -44,6 +48,11 @@ function run(app: TestApp, name: string): void {
 }
 
 describe("Finisher", () => {
+  const originalEnv = Trails.env.toString();
+  afterEach(() => {
+    Trails.env = originalEnv;
+  });
+
   it("registers the ported finisher initializers in Rails order", () => {
     const names = Finisher._ownInitializers().map((i) => i.name);
     expect(names).toEqual([
@@ -105,6 +114,7 @@ describe("Finisher", () => {
   });
 
   it("add_internal_routes prepends rails/info routes in development", () => {
+    Trails.env = "development";
     const app = new TestApp();
     run(app, "add_internal_routes");
     expect(app.internalRoutes).toEqual([
@@ -116,13 +126,14 @@ describe("Finisher", () => {
   });
 
   it("add_internal_routes is a no-op outside development", () => {
+    Trails.env = "production";
     const app = new TestApp();
-    app.env = { isDevelopment: () => false };
     run(app, "add_internal_routes");
     expect(app.internalRoutes).toEqual([]);
   });
 
   it("runs all finisher initializers in declared order via runInitializers", () => {
+    Trails.env = "production";
     const app = new TestApp();
     app.runInitializers();
     expect(app.calls).toEqual(["generator_templates", "middleware_stack", "prepare!"]);

--- a/packages/trailties/src/application/finisher.ts
+++ b/packages/trailties/src/application/finisher.ts
@@ -3,9 +3,8 @@
  * `railties/lib/rails/application/finisher.rb`. Defines the finisher
  * initializers that run after the Trailtie + bootstrap initializers.
  *
- * Application (PR 2.5) will splice these into its initializer chain via
- * `initializersChain()`. Until then this class stands alone so tests can
- * exercise the declarations and block bodies against a mock host.
+ * `Application#initializers` splices these in after the Bootstrap and
+ * Trailtie/Engine initializers, mirroring `application.rb:445-449`.
  *
  * Rails blocks of the form `initializer :foo do |app|` get the
  * Application instance both as `self` and as the block argument. In our
@@ -21,10 +20,12 @@
  * of scope per the trailties plan.
  */
 import { Initializable } from "../initializable.js";
+import { Trails } from "../rails.js";
 import type { ConfigurationBlock } from "../trailtie/configuration.js";
+import type { DrawCallback } from "@blazetrails/actionpack";
 
 export interface FinisherRoutes {
-  prepend(block: () => void): void;
+  prepend(block: DrawCallback): void;
   defineMountedHelper(name: string): void;
 }
 
@@ -37,18 +38,12 @@ export interface FinisherConfig {
   toPrepareBlocks: ConfigurationBlock[];
 }
 
-export interface FinisherEnv {
-  isDevelopment(): boolean;
-}
-
 export interface FinisherHost {
   config: FinisherConfig;
-  routes: FinisherRoutes;
+  routes(): FinisherRoutes;
   reloader: FinisherReloader;
-  env: FinisherEnv;
   ensureGeneratorTemplatesAdded(): void;
   buildMiddlewareStack(): void;
-  appendInternalRoute(verb: string, path: string, to: string): void;
 }
 
 export class Finisher extends Initializable {}
@@ -58,12 +53,15 @@ Finisher.initializer("add_generator_templates", function (this: FinisherHost) {
 });
 
 Finisher.initializer("add_internal_routes", function (this: FinisherHost) {
-  if (!this.env.isDevelopment()) return;
-  this.routes.prepend(() => {
-    this.appendInternalRoute("get", "/rails/info/properties", "rails/info#properties");
-    this.appendInternalRoute("get", "/rails/info/routes", "rails/info#routes");
-    this.appendInternalRoute("get", "/rails/info/notes", "rails/info#notes");
-    this.appendInternalRoute("get", "/rails/info", "rails/info#index");
+  // `Trails.env` is an `EnvironmentInquirer`, whose per-environment
+  // predicates are Proxy-generated (`string-inquirer.ts:12-28`) and so are
+  // absent from its static type; Rails reads `Rails.env.development?`.
+  if (!(Trails.env as unknown as { isDevelopment(): boolean }).isDevelopment()) return;
+  this.routes().prepend((mapper) => {
+    mapper.get("/rails/info/properties", "rails/info#properties");
+    mapper.get("/rails/info/routes", "rails/info#routes");
+    mapper.get("/rails/info/notes", "rails/info#notes");
+    mapper.get("/rails/info", "rails/info#index");
   });
 });
 
@@ -72,7 +70,7 @@ Finisher.initializer("build_middleware_stack", function (this: FinisherHost) {
 });
 
 Finisher.initializer("define_main_app_helper", function (this: FinisherHost) {
-  this.routes.defineMountedHelper("main_app");
+  this.routes().defineMountedHelper("main_app");
 });
 
 Finisher.initializer("add_to_prepare_blocks", function (this: FinisherHost) {

--- a/packages/trailties/src/application/finisher.ts
+++ b/packages/trailties/src/application/finisher.ts
@@ -13,6 +13,11 @@
  * is already the host. The blocks here use `this: FinisherHost` and
  * skip the redundant argument.
  *
+ * `Rails.env.development?` in `add_internal_routes` reads through a cast:
+ * `Trails.env` is an `EnvironmentInquirer` whose per-environment predicates
+ * are Proxy-generated (`string-inquirer.ts:12-28`) and so are absent from its
+ * static type.
+ *
  * The Rails initializers tied to Zeitwerk, eager loading, the
  * reloader/executor concurrency hooks, default session store, the
  * routes-reloader hook, dependency clearing, and YJIT are intentionally
@@ -53,9 +58,6 @@ Finisher.initializer("add_generator_templates", function (this: FinisherHost) {
 });
 
 Finisher.initializer("add_internal_routes", function (this: FinisherHost) {
-  // `Trails.env` is an `EnvironmentInquirer`, whose per-environment
-  // predicates are Proxy-generated (`string-inquirer.ts:12-28`) and so are
-  // absent from its static type; Rails reads `Rails.env.development?`.
   if (!(Trails.env as unknown as { isDevelopment(): boolean }).isDevelopment()) return;
   this.routes().prepend((mapper) => {
     mapper.get("/rails/info/properties", "rails/info#properties");

--- a/packages/trailties/src/application/finisher.ts
+++ b/packages/trailties/src/application/finisher.ts
@@ -60,10 +60,10 @@ Finisher.initializer("add_generator_templates", function (this: FinisherHost) {
 Finisher.initializer("add_internal_routes", function (this: FinisherHost) {
   if (!(Trails.env as unknown as { isDevelopment(): boolean }).isDevelopment()) return;
   this.routes().prepend((mapper) => {
-    mapper.get("/rails/info/properties", "rails/info#properties");
-    mapper.get("/rails/info/routes", "rails/info#routes");
-    mapper.get("/rails/info/notes", "rails/info#notes");
-    mapper.get("/rails/info", "rails/info#index");
+    mapper.get("/rails/info/properties", { to: "rails/info#properties", internal: true });
+    mapper.get("/rails/info/routes", { to: "rails/info#routes", internal: true });
+    mapper.get("/rails/info/notes", { to: "rails/info#notes", internal: true });
+    mapper.get("/rails/info", { to: "rails/info#index", internal: true });
   });
 });
 

--- a/packages/trailties/src/engine.test.ts
+++ b/packages/trailties/src/engine.test.ts
@@ -232,7 +232,7 @@ describe("Engine", () => {
     cfg.generators((g) => {
       g.orm = "active_record";
     });
-    expect(cfg.generators()).toEqual({ orm: "active_record" });
+    expect(cfg.generators()).toEqual({ orm: "active_record", templates: [] });
   });
 
   it("railties returns a Trailties collection over registered subclasses", () => {

--- a/packages/trailties/src/engine.test.ts
+++ b/packages/trailties/src/engine.test.ts
@@ -8,6 +8,7 @@ import {
   type FsAdapter,
   type PathAdapter,
 } from "@blazetrails/activesupport";
+import { RouteSet } from "@blazetrails/actionpack";
 import { Engine } from "./engine.js";
 import { EngineConfiguration } from "./engine/configuration.js";
 import { Trailtie } from "./trailtie.js";
@@ -135,9 +136,9 @@ describe("Engine", () => {
     it("defaults match Rails Engine::Configuration", () => {
       const cfg = new EngineConfiguration();
       expect(cfg.root).toBeNull();
-      expect(cfg.middleware).toEqual([]);
+      expect(cfg.middleware.middlewares).toEqual([]);
       expect(cfg.javascriptPath).toBe("javascript");
-      expect(cfg.routeSetClass).toBeNull();
+      expect(cfg.routeSetClass).toBe(RouteSet);
       expect(cfg.defaultScope).toBeNull();
       expect(cfg.autoloadPaths).toEqual([]);
       expect(cfg.autoloadOncePaths).toEqual([]);
@@ -215,21 +216,14 @@ describe("Engine", () => {
   });
 
   it("routes lazily instantiates routeSetClass, append-buffers blocks, and hasRoutes flips", () => {
-    const blocks: Array<() => void> = [];
-    class FakeRouteSet {
-      constructor(public cfg: EngineConfiguration) {}
-      append(b: () => void): void {
-        blocks.push(b);
-      }
-    }
     class MountedEngine extends Engine {}
     Trailtie.register(MountedEngine);
     expect(MountedEngine.instance().hasRoutes()).toBe(false);
-    MountedEngine.instance().config.routeSetClass = FakeRouteSet;
-    const r1 = MountedEngine.instance().routes(() => {});
-    expect(r1).toBeInstanceOf(FakeRouteSet);
+    const r1 = MountedEngine.instance().routes((mapper) => {
+      mapper.get("/mounted", "mounted#index");
+    });
+    expect(r1).toBeInstanceOf(RouteSet);
     expect(MountedEngine.instance().routes(() => {})).toBe(r1);
-    expect(blocks).toHaveLength(2);
     expect(MountedEngine.instance().hasRoutes()).toBe(true);
   });
 

--- a/packages/trailties/src/engine.ts
+++ b/packages/trailties/src/engine.ts
@@ -2,6 +2,7 @@
 // EngineConfiguration + railties() collection. `lazy_route_set` + `updater`
 // → 2.2c. `env_config`/`endpoint`/`call`/`helpers` → blocked on PR 2.5.
 import { getFsAsync, getPathAsync } from "@blazetrails/activesupport";
+import type { DrawCallback, RouteSet } from "@blazetrails/actionpack";
 import { Root } from "./paths.js";
 import { Trailtie } from "./trailtie.js";
 import { Trailties } from "./engine/trailties.js";
@@ -11,7 +12,7 @@ import { readOwnState, writeOwnState } from "./trailtie/per-class-state.js";
 export class Engine extends Trailtie {
   private _railtiesCollection?: Trailties;
   private _allLoadPathsCache?: string[];
-  private _routes?: unknown;
+  private _routes?: RouteSet;
 
   static calledFrom(value?: string): string | undefined {
     if (value !== undefined) writeOwnState(this, "_calledFrom", value);
@@ -125,15 +126,10 @@ export class Engine extends Trailtie {
     return this._railtiesCollection;
   }
 
-  /** `Engine#routes(&block)` — undefined when no `routeSetClass` is set. */
-  routes(block?: (this: unknown) => void): unknown {
-    if (!this._routes) {
-      const cfg = this.config;
-      if (!cfg.routeSetClass) return undefined;
-      this._routes = new cfg.routeSetClass(cfg);
-    }
-    const r = this._routes as { append?: (b: (this: unknown) => void) => void };
-    if (block) r.append?.(block);
+  /** Mirrors `Engine#routes(&block)` (`engine.rb:462-466`). */
+  routes(block?: DrawCallback): RouteSet {
+    this._routes ??= this.config.routeSetClass.newWithConfig(this.config);
+    if (block) this._routes.append(block);
     return this._routes;
   }
   hasRoutes(): boolean {

--- a/packages/trailties/src/engine/configuration.ts
+++ b/packages/trailties/src/engine/configuration.ts
@@ -7,23 +7,23 @@
  * - Constructing with a `null` root is allowed (matches 2.2a
  *   `Engine#paths()` tolerance); `Engine#paths()` injects the resolved
  *   root via `setRoot()` once known.
- * - `routeSetClass` is held as an opaque constructor; the real
- *   `ActionDispatch::Routing::RouteSet` wiring lands with PR 2.5.
  */
+import { MiddlewareStack, RouteSet } from "@blazetrails/actionpack";
 import { getFs, getPath } from "@blazetrails/activesupport";
 import { Configuration as RailtieConfiguration } from "../trailtie/configuration.js";
 import { Root } from "../paths.js";
 
-export type MiddlewareEntry = { name: string; args: unknown[] };
-export type RouteSetCtor = new (config: EngineConfiguration) => unknown;
+/** Mirrors `config.route_set_class` (`engine/configuration.rb:47`) — the
+ * class is used through its `new_with_config` factory. */
+export type RouteSetClass = { newWithConfig(config: EngineConfiguration): RouteSet };
 
 export class EngineConfiguration extends RailtieConfiguration {
   private _root: string | null;
   private _paths?: Root;
 
-  middleware: MiddlewareEntry[] = [];
+  middleware: MiddlewareStack = new MiddlewareStack();
   javascriptPath = "javascript";
-  routeSetClass: RouteSetCtor | null = null;
+  routeSetClass: RouteSetClass = RouteSet;
   defaultScope: Record<string, unknown> | null = null;
   tableNamePrefix: string | null = null;
 

--- a/packages/trailties/src/engine/configuration.ts
+++ b/packages/trailties/src/engine/configuration.ts
@@ -31,7 +31,9 @@ export class EngineConfiguration extends RailtieConfiguration {
   autoloadOncePaths: string[] = [];
   eagerLoadPaths: string[] = [];
 
-  private _generators: Record<string, unknown> = {};
+  /** Rails seeds `Rails::Configuration::Generators` with an empty
+   * `templates` array (`rails/configuration.rb:112`). */
+  private _generators: Record<string, unknown> = { templates: [] };
 
   constructor(root: string | null = null) {
     super();


### PR DESCRIPTION
## What

`Application#initializers` never spliced the Finisher initializers, so an app
booted through `Trailties.Application` built no middleware stack and drew no
routes. This wires the three-way splice from
`vendor/rails/railties/lib/rails/application.rb:445-449` and supplies the host
methods the finisher blocks call.

- `Application#initializers` →
  `Bootstrap.initializersFor(this).plus(super.initializers).plus(Finisher.initializersFor(this))`.
- `Application#app` / `buildMiddlewareStack` / `endpoint` /
  `defaultMiddlewareStack` / `ensureGeneratorTemplatesAdded` ported from
  `engine.rb:516-529` and `application.rb:558, :626-634`, so
  `build_middleware_stack` really builds the stack from
  `default-middleware-stack.ts` and assigns it to `config.middleware`.
- `Engine#routes` now mirrors `engine.rb:545-549`
  (`config.route_set_class.new_with_config(config)`), with
  `config.routeSetClass` defaulting to `ActionDispatch::Routing::RouteSet`
  (`engine/configuration.rb:47`) instead of `null`; `config.middleware` is a
  `MiddlewareStack` (`engine/configuration.rb:45`).
- Finisher's `add_internal_routes` uses the mapper DSL and `Trails.env`
  (`finisher.rb:141-147`) instead of the placeholder `appendInternalRoute` /
  `FinisherEnv` host members, which are gone.
- Adds the `:prepare` callback surface of `ActiveSupport::Reloader`
  (`reloader.rb:34, :95`) so `Application#reloader` (`application.rb:123`)
  exists for `add_to_prepare_blocks` / `run_prepare_callbacks`.
- Fixes `DefaultMiddlewareStack`'s `Static` args — trails' `Static` takes
  `root` as an option key, and the previously unexercised positional call
  crashed on boot.

## Tests

`application.test.ts` asserts the Finisher initializers land last and that a
booted `Application` subclass has a non-empty middleware stack and can draw
routes; `reloader.trails.test.ts` covers `to_prepare` / `prepare!`.

## Deferred

Two follow-up stories filed with the Rails citations:
`generator-templates-existent-paths` (the async `paths["lib/templates"].existent`
scan) and `port-railties-initializers-ordering` (`railties_initializers` /
`ordered_railties`, tagged `@missingRailsCall` at the call site).

Closes-story: splice-finisher-initializers
