### PR TITLE
feat(parity): derive the AR-closure test manifest, exclude migration compatibility, anchor fixtures.rb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1576,6 +1576,12 @@ jobs:
         # extraction twice. Reseed after convergence with
         # `pnpm parity:test:assertions:reseed`.
         run: pnpm exec tsx scripts/test-compare/lint-assertion-mismatches.ts --no-regen
+      - name: AR-closure test manifest guard
+        # Fails when a file under vendor/rails/activesupport/test/ is neither
+        # derived by R1/R2 nor aliased nor listed out-of-closure, so a vendor
+        # bump cannot land a new Rails test file silently on either side of the
+        # boundary (RFC 0105). Manifest only — it moves no denominator.
+        run: pnpm exec tsx scripts/test-compare/closure-cli.ts --check
       - name: Fixtures comparison
         run: pnpm exec tsx scripts/fixtures-compare/compare.ts --package activerecord --ci
       - name: Models comparison

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "parity:test": "bash scripts/test-compare/run.sh",
     "parity:test:assertions": "pnpm tsx scripts/test-compare/lint-assertion-mismatches.ts",
     "parity:test:assertions:reseed": "pnpm tsx scripts/test-compare/lint-assertion-mismatches.ts --write",
+    "parity:test:closure": "pnpm tsx scripts/test-compare/closure-cli.ts",
     "parity:test:stubs": "pnpm parity:test -- --missing --json && pnpm tsx scripts/test-compare/generate-stubs.ts",
     "parity:fixtures": "pnpm vendor:fetch >/dev/null && pnpm tsx scripts/fixtures-compare/compare.ts",
     "parity:fixtures:models": "pnpm vendor:fetch >/dev/null && pnpm tsx scripts/fixtures-compare/compare.ts --models",

--- a/scripts/parity/unported-files/baseline.json
+++ b/scripts/parity/unported-files/baseline.json
@@ -46,7 +46,7 @@
     "reason": "YAML column coder. The store-column dump/load path and the Psych safe-dump class restriction are ported (coders/yaml-column.ts, backed by the `yaml` package — `store :col, coder: \"YAML\"`), but the Psych-specific safe-LOAD machinery (permitted_classes on load, type-mismatch-on-Ruby-class) has no JS analog; those test cases stay Ruby-only."
   },
   {
-    "pattern": "fixtures.rb",
+    "pattern": "/fixtures.rb",
     "testFile": "/fixtures_test.rb",
     "reason": "Rails-specific YAML fixtures (test/fixtures/*.yml loaded once into the DB with named-row references and ERB preprocessing). The JS/TS ecosystem uses factories or ad-hoc Model.create instead; Trails users won't ship YAML fixtures."
   },

--- a/scripts/parity/unported-files/baseline.json
+++ b/scripts/parity/unported-files/baseline.json
@@ -2,7 +2,7 @@
   {
     "pattern": "i18n_railtie.rb",
     "package": "activesupport",
-    "reason": "Rails boot lifecycle hook that wires I18n into the Railtie/Application init sequence. No JS equivalent \u2014 I18n is configured directly in user code."
+    "reason": "Rails boot lifecycle hook that wires I18n into the Railtie/Application init sequence. No JS equivalent — I18n is configured directly in user code."
   },
   {
     "pattern": "migration/compatibility",
@@ -15,7 +15,7 @@
   {
     "pattern": "future_result.rb",
     "testFile": "relation/load_async_test.rb",
-    "reason": "Thread-pool scheduled query with mutex + EventBuffer bridging Ruby's threaded async. Marked :nodoc: in Rails. Collapses to the Promise returned by the adapter's async exec. Test file fully excluded \u2014 all live test classes exercise FutureResult/scheduled? semantics that don't port to single-threaded JS where `await relation.toArray()` is the async surface."
+    "reason": "Thread-pool scheduled query with mutex + EventBuffer bridging Ruby's threaded async. Marked :nodoc: in Rails. Collapses to the Promise returned by the adapter's async exec. Test file fully excluded — all live test classes exercise FutureResult/scheduled? semantics that don't port to single-threaded JS where `await relation.toArray()` is the async surface."
   },
   {
     "pattern": "asynchronous_queries_tracker.rb",
@@ -38,12 +38,12 @@
   },
   {
     "pattern": "attribute_set/yaml_encoder.rb",
-    "reason": "Rails' Psych-specific YAML round-trip class for AttributeSet. Replaced by the pluggable AttributeSetCoder architecture in #1173 (P24a) / #1176 (P24b) \u2014 see packages/activemodel/src/attribute-set/{coder.ts,codecs/json.ts,codecs/yaml.ts}. Functional capability is shipped; the Rails class hierarchy doesn't map to the TS codec-injection pattern (no Psych, JSON is the default)."
+    "reason": "Rails' Psych-specific YAML round-trip class for AttributeSet. Replaced by the pluggable AttributeSetCoder architecture in #1173 (P24a) / #1176 (P24b) — see packages/activemodel/src/attribute-set/{coder.ts,codecs/json.ts,codecs/yaml.ts}. Functional capability is shipped; the Rails class hierarchy doesn't map to the TS codec-injection pattern (no Psych, JSON is the default)."
   },
   {
     "pattern": "coders/yaml_column.rb",
     "testFile": "coders/yaml_column_test.rb",
-    "reason": "YAML column coder. The store-column dump/load path and the Psych safe-dump class restriction are ported (coders/yaml-column.ts, backed by the `yaml` package \u2014 `store :col, coder: \"YAML\"`), but the Psych-specific safe-LOAD machinery (permitted_classes on load, type-mismatch-on-Ruby-class) has no JS analog; those test cases stay Ruby-only."
+    "reason": "YAML column coder. The store-column dump/load path and the Psych safe-dump class restriction are ported (coders/yaml-column.ts, backed by the `yaml` package — `store :col, coder: \"YAML\"`), but the Psych-specific safe-LOAD machinery (permitted_classes on load, type-mismatch-on-Ruby-class) has no JS analog; those test cases stay Ruby-only."
   },
   {
     "pattern": "/fixtures.rb",
@@ -70,7 +70,7 @@
   },
   {
     "pattern": "dynamic_matchers.rb",
-    "reason": "Ruby `method_missing` magic that synthesizes `find_by_<attr>` / `find_or_*_by_<attr>` at call time. No TS analog \u2014 Proxy-based dispatch can't infer attribute lists at compile time, and `findBy({ ... })` already covers the use case idiomatically. `respond_to_missing?` alone is ported, in dynamic-matchers.ts."
+    "reason": "Ruby `method_missing` magic that synthesizes `find_by_<attr>` / `find_or_*_by_<attr>` at call time. No TS analog — Proxy-based dispatch can't infer attribute lists at compile time, and `findBy({ ... })` already covers the use case idiomatically. `respond_to_missing?` alone is ported, in dynamic-matchers.ts."
   },
   {
     "pattern": "railties/controller_runtime.rb",
@@ -103,7 +103,7 @@
       "active transaction is restored after remote disconnection",
       "dirty transaction cannot be restored after remote disconnection"
     ],
-    "reason": "These tests call the `remote_disconnect` helper, which only supports PostgreSQL and Mysql2/Trilogy \u2014 its `else` branch is `skip(\"remote_disconnect unsupported\")`, so Rails never runs them on SQLite. A genuine remote disconnect cannot be simulated against in-memory SQLite (closing the handle discards the database), which is also why the surrounding suite is gated `unless in_memory_db?`. Trails always uses :memory: SQLite."
+    "reason": "These tests call the `remote_disconnect` helper, which only supports PostgreSQL and Mysql2/Trilogy — its `else` branch is `skip(\"remote_disconnect unsupported\")`, so Rails never runs them on SQLite. A genuine remote disconnect cannot be simulated against in-memory SQLite (closing the handle discards the database), which is also why the surrounding suite is gated `unless in_memory_db?`. Trails always uses :memory: SQLite."
   },
   {
     "testFile": "adapter_test.rb",
@@ -151,7 +151,7 @@
       "compute type on undefined method",
       "compute type argument error"
     ],
-    "reason": "Registers an Object.autoload for a model whose file raises during require, so the exception surfaces from constantize inside compute_type. JS has no autoload/require hook \u2014 a module either resolves at import time or the constant simply doesn't exist."
+    "reason": "Registers an Object.autoload for a model whose file raises during require, so the exception surfaces from constantize inside compute_type. JS has no autoload/require hook — a module either resolves at import time or the constant simply doesn't exist."
   },
   {
     "testFile": "inheritance_test.rb",
@@ -190,7 +190,7 @@
       "swapping shards and roles in a multi threaded environment",
       "swapping granular shards and roles in a multi threaded environment"
     ],
-    "reason": "GVL / Ruby Thread semantics \u2014 concurrent shard-swapping tests cannot translate to single-threaded Node.js."
+    "reason": "GVL / Ruby Thread semantics — concurrent shard-swapping tests cannot translate to single-threaded Node.js."
   },
   {
     "testFile": "connection_pool_test.rb",
@@ -214,7 +214,7 @@
       "pin connection nesting lock",
       "pin connection nesting lock inverse"
     ],
-    "reason": "GVL / Ruby Thread semantics \u2014 concurrent connection tests cannot translate to single-threaded Node.js."
+    "reason": "GVL / Ruby Thread semantics — concurrent connection tests cannot translate to single-threaded Node.js."
   },
   {
     "testFile": "connection_pool_test.rb",
@@ -232,7 +232,7 @@
       "connections are cleared even if inside a non-joinable transaction",
       "cancel asynchronous queries if an exception is raised"
     ],
-    "reason": "GVL / Ruby Thread semantics \u2014 first test pins across threads; second uses FutureResult (thread-based async queries)."
+    "reason": "GVL / Ruby Thread semantics — first test pins across threads; second uses FutureResult (thread-based async queries)."
   },
   {
     "testFile": "query_cache_test.rb",
@@ -244,17 +244,17 @@
       "query cache is cleared for all thread when a connection is shared",
       "threads use the same connection"
     ],
-    "reason": "GVL / Ruby Thread + fork() semantics \u2014 per-thread / cross-process query-cache visibility cannot translate to single-threaded Node.js."
+    "reason": "GVL / Ruby Thread + fork() semantics — per-thread / cross-process query-cache visibility cannot translate to single-threaded Node.js."
   },
   {
     "testFile": "connection_adapters/connection_handlers_multi_db_test.rb",
     "tests": ["multiple connections works in a threaded environment"],
-    "reason": "GVL / Ruby Thread semantics \u2014 concurrent multi-db connection access on shared objects has no single-threaded Node.js equivalent."
+    "reason": "GVL / Ruby Thread semantics — concurrent multi-db connection access on shared objects has no single-threaded Node.js equivalent."
   },
   {
     "testFile": "relations_test.rb",
     "tests": ["where id with delegated ar object", "where relation with delegated ar object"],
-    "reason": "Rails wraps the AR object in Class.new(SimpleDelegator) and where() unwraps it via the delegator protocol (relations_test.rb:835-847). No idiomatic JS analog: a Proxy could forward method_missing, but the bespoke query-builder unwrapping isn't warranted for this niche case. (The find_by sibling at :849 uses SimpleDelegator too, but is currently matched by a plain-object trails test, so it stays counted \u2014 its delegation behavior is untested.)"
+    "reason": "Rails wraps the AR object in Class.new(SimpleDelegator) and where() unwraps it via the delegator protocol (relations_test.rb:835-847). No idiomatic JS analog: a Proxy could forward method_missing, but the bespoke query-builder unwrapping isn't warranted for this niche case. (The find_by sibling at :849 uses SimpleDelegator too, but is currently matched by a plain-object trails test, so it stays counted — its delegation behavior is untested.)"
   },
   {
     "testFile": "associations/has_one_associations_test.rb",
@@ -305,7 +305,7 @@
   {
     "testFile": "tasks/database_tasks_test.rb",
     "tests": ["raises an error when called with protected environment which name is a symbol"],
-    "reason": "Ruby Symbol env names (symbol\u2192string coercion in protected_environments); env names are plain strings in TS."
+    "reason": "Ruby Symbol env names (symbol→string coercion in protected_environments); env names are plain strings in TS."
   },
   {
     "testFile": "scoping/named_scoping_test.rb",
@@ -361,7 +361,7 @@
       "serialized time attribute",
       "supports permitted classes for default column serializer"
     ],
-    "reason": "YAML/Psych column serialization and class-constrained serializers \u2014 Ruby-only format with no Node.js equivalent."
+    "reason": "YAML/Psych column serialization and class-constrained serializers — Ruby-only format with no Node.js equivalent."
   },
   {
     "testFile": "base_test.rb",
@@ -383,7 +383,7 @@
       "generated association methods module name",
       "generated relation methods module name"
     ],
-    "reason": "GVL / Ruby Thread semantics, Marshal binary serialization, Encoding.default_internal, with_env_tz (process-level ENV[\"TZ\"] reload), and Ruby Module#inspect for namespaced generated-method modules \u2014 all Ruby-only with no Node.js equivalent."
+    "reason": "GVL / Ruby Thread semantics, Marshal binary serialization, Encoding.default_internal, with_env_tz (process-level ENV[\"TZ\"] reload), and Ruby Module#inspect for namespaced generated-method modules — all Ruby-only with no Node.js equivalent."
   },
   {
     "testFile": "hstore_test.rb",
@@ -398,17 +398,17 @@
   {
     "testFile": "has_and_belongs_to_many_associations_test.rb",
     "tests": ["marshal dump"],
-    "reason": "Ruby Marshal binary serialization \u2014 no Node.js equivalent."
+    "reason": "Ruby Marshal binary serialization — no Node.js equivalent."
   },
   {
     "testFile": "belongs_to_associations_test.rb",
     "tests": ["belongs to proxy should not respond to private methods"],
-    "reason": "Probes Ruby method visibility: `private_method` must raise NoMethodError on a direct call but succeed via `send` (the via-send sibling IS ported). JS has no runtime-enforced private dispatch \u2014 a method is either callable or absent."
+    "reason": "Probes Ruby method visibility: `private_method` must raise NoMethodError on a direct call but succeed via `send` (the via-send sibling IS ported). JS has no runtime-enforced private dispatch — a method is either callable or absent."
   },
   {
     "testFile": "reaper_test.rb",
     "tests": ["connection pool starts reaper in fork"],
-    "reason": "GVL / Ruby fork() semantics \u2014 process forking has no Node.js equivalent."
+    "reason": "GVL / Ruby fork() semantics — process forking has no Node.js equivalent."
   },
   {
     "testFile": "connection_adapters/connection_handler_test.rb",
@@ -419,7 +419,7 @@
       "retrieve connection pool copies schema cache from ancestor pool",
       "pool from any process for uses most recent spec"
     ],
-    "reason": "Ruby fork() + Marshal \u2014 process forking and binary serialization have no Node.js equivalent."
+    "reason": "Ruby fork() + Marshal — process forking and binary serialization have no Node.js equivalent."
   },
   {
     "testFile": "yaml_serialization_test.rb",
@@ -438,7 +438,7 @@
   {
     "testFile": "/railtie_test.rb",
     "package": "globalid",
-    "reason": "Exercises the `global_id` Railtie initializer through a full `Rails::Application` boot (`@app.initialize!`) under `ActiveSupport::Testing::Isolation` \u2014 GlobalID.app defaulting, `config.global_id.app`/`expires_in` injection, and verifier key derivation from `app.key_generator`. Unlike activemodel/trailties, globalid has not yet ported its railtie to a `Trailtie` (activesupport's `BaseRailtie`); its wiring is a `wire.ts` side-effect plus explicit `setApp`/verifier setters, and there is no `Rails::Application` boot harness for these tests to drive. Porting globalid's railtie to a `Trailtie` would let this file re-enter accounting \u2014 tracked as a follow-up story."
+    "reason": "Exercises the `global_id` Railtie initializer through a full `Rails::Application` boot (`@app.initialize!`) under `ActiveSupport::Testing::Isolation` — GlobalID.app defaulting, `config.global_id.app`/`expires_in` injection, and verifier key derivation from `app.key_generator`. Unlike activemodel/trailties, globalid has not yet ported its railtie to a `Trailtie` (activesupport's `BaseRailtie`); its wiring is a `wire.ts` side-effect plus explicit `setApp`/verifier setters, and there is no `Rails::Application` boot harness for these tests to drive. Porting globalid's railtie to a `Trailtie` would let this file re-enter accounting — tracked as a follow-up story."
   },
   {
     "testFile": "global_locator_test.rb",
@@ -496,7 +496,7 @@
   {
     "package": "did-you-mean",
     "pattern": "formatter.rb",
-    "reason": "Formats `Did you mean? \u2026` suffix for Ruby's Exception#detailed_message integration. JS error stringification is per-error, not via a stdlib hook."
+    "reason": "Formats `Did you mean? …` suffix for Ruby's Exception#detailed_message integration. JS error stringification is per-error, not via a stdlib hook."
   },
   {
     "package": "did-you-mean",
@@ -519,7 +519,7 @@
     "package": "did-you-mean",
     "pattern": "spell_checkers/name_error_checkers/class_name_checker.rb",
     "testFile": "spell_checking/test_class_name_check.rb",
-    "reason": "Suggests constant/class names by walking Module#constants + ancestor scopes. Ruby-only \u2014 JS has no equivalent constant introspection."
+    "reason": "Suggests constant/class names by walking Module#constants + ancestor scopes. Ruby-only — JS has no equivalent constant introspection."
   },
   {
     "package": "did-you-mean",
@@ -553,15 +553,15 @@
   },
   {
     "testFile": "tree_spell/test_change_word.rb",
-    "reason": "tree_spell helper test \u2014 excluded transitively with tree_spell_checker.rb."
+    "reason": "tree_spell helper test — excluded transitively with tree_spell_checker.rb."
   },
   {
     "testFile": "tree_spell/test_explore.rb",
-    "reason": "tree_spell helper test \u2014 excluded transitively with tree_spell_checker.rb."
+    "reason": "tree_spell helper test — excluded transitively with tree_spell_checker.rb."
   },
   {
     "testFile": "tree_spell/test_human_typo.rb",
-    "reason": "tree_spell helper test \u2014 excluded transitively with tree_spell_checker.rb."
+    "reason": "tree_spell helper test — excluded transitively with tree_spell_checker.rb."
   },
   {
     "testFile": "test_ractor_compatibility.rb",
@@ -571,12 +571,12 @@
     "testFile": "verifier_test.rb",
     "className": "VerifierTest",
     "tests": ["generates URL-safe messages"],
-    "reason": "Asserts byte-for-byte equality against a known token produced by Ruby's Marshal serializer wrapped in MessageVerifier. Our globalid Verifier uses JSON serialization (the default for our MessageVerifier), so the encoded payload differs structurally \u2014 the same input produces a different (but equivalent) token. The behavioral guarantee this test cares about (urlsafe encoding, no +/=/ chars) is covered by packages/globalid/src/verifier.test.ts asserting char-class absence rather than exact bytes."
+    "reason": "Asserts byte-for-byte equality against a known token produced by Ruby's Marshal serializer wrapped in MessageVerifier. Our globalid Verifier uses JSON serialization (the default for our MessageVerifier), so the encoded payload differs structurally — the same input produces a different (but equivalent) token. The behavioral guarantee this test cares about (urlsafe encoding, no +/=/ chars) is covered by packages/globalid/src/verifier.test.ts asserting char-class absence rather than exact bytes."
   },
   {
     "testFile": "message_encryptor_test.rb",
     "tests": ["backwards compatibility decrypt previously encrypted messages without metadata"],
-    "reason": "Decrypts a ciphertext minted before message metadata existed (message_encryptor_test.rb:147-154). The plaintext is the Ruby Marshal payload `\\x04\\x08I\"\\x12Ruby on Rails\\x06:\\x06ET` \u2014 an ivar-wrapped Ruby String \u2014 so passing it requires a real Ruby Marshal wire reader. trails has no Ruby Marshal runtime: the `:marshal` serializer in messages/serializer-with-fallback.ts is a trails-native codec behind Rails' `\\x04\\x08` signature, matching the project-wide Marshal exclusion above (marshalling.rb / marshal_serialization_test.rb). Ruby-only wire format."
+    "reason": "Decrypts a ciphertext minted before message metadata existed (message_encryptor_test.rb:147-154). The plaintext is the Ruby Marshal payload `\\x04\\x08I\"\\x12Ruby on Rails\\x06:\\x06ET` — an ivar-wrapped Ruby String — so passing it requires a real Ruby Marshal wire reader. trails has no Ruby Marshal runtime: the `:marshal` serializer in messages/serializer-with-fallback.ts is a trails-native codec behind Rails' `\\x04\\x08` signature, matching the project-wide Marshal exclusion above (marshalling.rb / marshal_serialization_test.rb). Ruby-only wire format."
   },
   {
     "testFile": "associations/extension_test.rb",
@@ -596,7 +596,7 @@
   {
     "testFile": "associations/inverse_associations_test.rb",
     "tests": ["has many and belongs to should find inverse automatically for model in module"],
-    "reason": "Asserts automatic inverse_of detection for namespaced models (Admin::Account / Admin::User). Ruby modules (`::`) have no TypeScript equivalent \u2014 JS class names cannot contain `::`, so the demodulized automatic-inverse scenario isn't representable."
+    "reason": "Asserts automatic inverse_of detection for namespaced models (Admin::Account / Admin::User). Ruby modules (`::`) have no TypeScript equivalent — JS class names cannot contain `::`, so the demodulized automatic-inverse scenario isn't representable."
   },
   {
     "testFile": "associations_test.rb",
@@ -614,7 +614,7 @@
       "yaml loads 5 1 dump",
       "yaml loads 5 1 dump without indexes still queries for indexes"
     ],
-    "reason": "Loads the fixed Rails-5.1-era schema-cache dump asset (test/assets/schema_dump_5_1.yml) and deserializes it via Psych (schema_cache_test.rb:124-142). Note this is NOT covered by our YAML syntax support (the `yaml` package backing coders/yaml-column.ts): the asset is a Psych object graph of `!ruby/object:ActiveRecord::ConnectionAdapters::{SchemaCache,Column,SqlTypeMetadata}` tags with Ruby symbol values and anchors. Loading it requires (a) unsafe-load reconstruction of Ruby class instances from `!ruby/object:` tags \u2014 the same Psych machinery already documented as having no JS analog in the coders/yaml_column.rb and attribute_set/yaml_encoder.rb entries \u2014 and (b) the 5.1\u2192current legacy-format migration handled by legacy_yaml_adapter.rb (itself unported above). Our `yaml` parser yields plain tagged nodes, not SchemaCache instances. The live schema-cache round-trip is exercised by the portable tests in the same file (test_yaml_dump_and_load[_with_gzip], which use our own dump path)."
+    "reason": "Loads the fixed Rails-5.1-era schema-cache dump asset (test/assets/schema_dump_5_1.yml) and deserializes it via Psych (schema_cache_test.rb:124-142). Note this is NOT covered by our YAML syntax support (the `yaml` package backing coders/yaml-column.ts): the asset is a Psych object graph of `!ruby/object:ActiveRecord::ConnectionAdapters::{SchemaCache,Column,SqlTypeMetadata}` tags with Ruby symbol values and anchors. Loading it requires (a) unsafe-load reconstruction of Ruby class instances from `!ruby/object:` tags — the same Psych machinery already documented as having no JS analog in the coders/yaml_column.rb and attribute_set/yaml_encoder.rb entries — and (b) the 5.1→current legacy-format migration handled by legacy_yaml_adapter.rb (itself unported above). Our `yaml` parser yields plain tagged nodes, not SchemaCache instances. The live schema-cache round-trip is exercised by the portable tests in the same file (test_yaml_dump_and_load[_with_gzip], which use our own dump path)."
   },
   {
     "testFile": "prepared_statement_status_test.rb",
@@ -642,7 +642,7 @@
   {
     "testFile": "transactions_test.rb",
     "tests": ["after current transaction commit multidb nested transactions"],
-    "reason": "Requires the ARUnit2Model secondary database connection (multi-database setup). The test asserts afterAllTransactionsCommit fires only after the outermost cross-database transaction commits \u2014 not available in the single-database test environment."
+    "reason": "Requires the ARUnit2Model secondary database connection (multi-database setup). The test asserts afterAllTransactionsCommit fires only after the outermost cross-database transaction commits — not available in the single-database test environment."
   },
   {
     "testFile": "dirty_test.rb",
@@ -656,12 +656,12 @@
       "in place mutation for binary",
       "mutating and then assigning doesn't remove the change"
     ],
-    "reason": "All three mutate a string in place (`catchphrase << \" matey!\"`, `data << \"bar\"` on a serialized binary; dirty_test.rb:668/689/799). JS strings are immutable \u2014 there is no in-place string mutation to detect."
+    "reason": "All three mutate a string in place (`catchphrase << \" matey!\"`, `data << \"bar\"` on a serialized binary; dirty_test.rb:668/689/799). JS strings are immutable — there is no in-place string mutation to detect."
   },
   {
     "testFile": "dirty_test.rb",
     "tests": ["getters with side effects are allowed"],
-    "reason": "The overridden reader persists as a side effect (`update_attribute` inside `def catchphrase`, dirty_test.rb:807) and the assertion relies on that write completing before the reader returns. trails persistence is async; a JS getter cannot await, so the persist would float as an unawaited promise \u2014 no faithful sync equivalent."
+    "reason": "The overridden reader persists as a side effect (`update_attribute` inside `def catchphrase`, dirty_test.rb:807) and the assertion relies on that write completing before the reader returns. trails persistence is async; a JS getter cannot await, so the persist would float as an unawaited promise — no faithful sync equivalent."
   },
   {
     "testFile": "database_selector_test.rb",
@@ -708,101 +708,101 @@
   {
     "pattern": "tools.rb",
     "package": "activerecord-test-support",
-    "reason": "Rails' rake/minitest test-runner plumbing: prepends adapter globbing onto Rails::TestUnit::Runner and invokes it with ARGV. vitest fills that role in trails \u2014 no port intended."
+    "reason": "Rails' rake/minitest test-runner plumbing: prepends adapter globbing onto Rails::TestUnit::Runner and invokes it with ARGV. vitest fills that role in trails — no port intended."
   },
   {
     "pattern": "backend/cache.rb",
     "testFile": "backend/cache_test.rb",
     "package": "i18n",
-    "reason": "Pre-1.0: optional backend mixin \u2014 caches lookups through ActiveSupport::Cache."
+    "reason": "Pre-1.0: optional backend mixin — caches lookups through ActiveSupport::Cache."
   },
   {
     "pattern": "backend/cache_file.rb",
     "testFile": "backend/cache_file_test.rb",
     "package": "i18n",
-    "reason": "Pre-1.0: optional backend mixin \u2014 caches parsed translation files on disk."
+    "reason": "Pre-1.0: optional backend mixin — caches parsed translation files on disk."
   },
   {
     "pattern": "backend/cascade.rb",
     "testFile": "backend/cascade_test.rb",
     "package": "i18n",
-    "reason": "Pre-1.0: optional backend mixin \u2014 cascading key lookup (`foo.bar.baz` \u2192 `foo.baz`)."
+    "reason": "Pre-1.0: optional backend mixin — cascading key lookup (`foo.bar.baz` → `foo.baz`)."
   },
   {
     "pattern": "backend/interpolation_compiler.rb",
     "testFile": "backend/interpolation_compiler_test.rb",
     "package": "i18n",
-    "reason": "Pre-1.0: optional backend mixin \u2014 compiles interpolations into Ruby procs via `eval`/`instance_eval`, which has no trails counterpart."
+    "reason": "Pre-1.0: optional backend mixin — compiles interpolations into Ruby procs via `eval`/`instance_eval`, which has no trails counterpart."
   },
   {
     "pattern": "backend/lazy_loadable.rb",
     "testFile": "backend/lazy_loadable_test.rb",
     "package": "i18n",
-    "reason": "Pre-1.0: optional backend mixin \u2014 defers translation-file loading until first lookup."
+    "reason": "Pre-1.0: optional backend mixin — defers translation-file loading until first lookup."
   },
   {
     "pattern": "backend/memoize.rb",
     "testFile": "backend/memoize_test.rb",
     "package": "i18n",
-    "reason": "Pre-1.0: optional backend mixin \u2014 memoizes lookups per locale."
+    "reason": "Pre-1.0: optional backend mixin — memoizes lookups per locale."
   },
   {
     "pattern": "backend/metadata.rb",
     "testFile": "backend/metadata_test.rb",
     "package": "i18n",
-    "reason": "Pre-1.0: optional backend mixin \u2014 attaches lookup metadata onto the translated String's singleton class. JS strings take no per-instance state."
+    "reason": "Pre-1.0: optional backend mixin — attaches lookup metadata onto the translated String's singleton class. JS strings take no per-instance state."
   },
   {
     "pattern": "backend/pluralization.rb",
     "testFile": "backend/pluralization_test.rb",
     "package": "i18n",
-    "reason": "Pre-1.0: optional backend mixin \u2014 pluralization via per-locale rule procs in the data."
+    "reason": "Pre-1.0: optional backend mixin — pluralization via per-locale rule procs in the data."
   },
   {
     "testFile": "backend/pluralization_fallback_test.rb",
     "package": "i18n",
-    "reason": "Pre-1.0: optional backend mixin \u2014 pluralization via per-locale rule procs in the data. Suite for the deferred `backend/pluralization.rb` composed with Fallbacks."
+    "reason": "Pre-1.0: optional backend mixin — pluralization via per-locale rule procs in the data. Suite for the deferred `backend/pluralization.rb` composed with Fallbacks."
   },
   {
     "testFile": "backend/pluralization_scope_test.rb",
     "package": "i18n",
-    "reason": "Pre-1.0: optional backend mixin \u2014 pluralization via per-locale rule procs in the data. Suite for the deferred `backend/pluralization.rb` looked up under a scope."
+    "reason": "Pre-1.0: optional backend mixin — pluralization via per-locale rule procs in the data. Suite for the deferred `backend/pluralization.rb` looked up under a scope."
   },
   {
     "testFile": "api/all_features_test.rb",
     "package": "i18n",
-    "reason": "Pre-1.0: optional backend mixins \u2014 a Chain of every deferred mixin (Cascade, Memoize, Metadata, Pluralization, Fallbacks) at once."
+    "reason": "Pre-1.0: optional backend mixins — a Chain of every deferred mixin (Cascade, Memoize, Metadata, Pluralization, Fallbacks) at once."
   },
   {
     "testFile": "api/cascade_test.rb",
     "package": "i18n",
-    "reason": "Pre-1.0: optional backend mixin \u2014 cascading key lookup (`foo.bar.baz` \u2192 `foo.baz`)."
+    "reason": "Pre-1.0: optional backend mixin — cascading key lookup (`foo.bar.baz` → `foo.baz`)."
   },
   {
     "testFile": "api/lazy_loadable_test.rb",
     "package": "i18n",
-    "reason": "Pre-1.0: optional backend mixin \u2014 defers translation-file loading until first lookup."
+    "reason": "Pre-1.0: optional backend mixin — defers translation-file loading until first lookup."
   },
   {
     "testFile": "api/memoize_test.rb",
     "package": "i18n",
-    "reason": "Pre-1.0: optional backend mixin \u2014 memoizes lookups per locale."
+    "reason": "Pre-1.0: optional backend mixin — memoizes lookups per locale."
   },
   {
     "testFile": "api/pluralization_test.rb",
     "package": "i18n",
-    "reason": "Pre-1.0: optional backend mixin \u2014 pluralization via per-locale rule procs in the data."
+    "reason": "Pre-1.0: optional backend mixin — pluralization via per-locale rule procs in the data."
   },
   {
     "pattern": "gettext",
     "testFile": "gettext/",
     "package": "i18n",
-    "reason": "Pre-1.0: gettext .po support \u2014 the catalogue parser, the `_`/`n_`/`s_` helpers, and the backend mixin that loads .po files. A Ruby toolchain concern with no trails consumer; Rails' own I18n usage never touches it."
+    "reason": "Pre-1.0: gettext .po support — the catalogue parser, the `_`/`n_`/`s_` helpers, and the backend mixin that loads .po files. A Ruby toolchain concern with no trails consumer; Rails' own I18n usage never touches it."
   },
   {
     "testFile": "gettext_plural_keys_test.rb",
     "package": "i18n",
-    "reason": "Pre-1.0: gettext .po support \u2014 exercises `I18n::Gettext.plural_keys`. Sits at test/i18n/, outside the `gettext/` prefix above."
+    "reason": "Pre-1.0: gettext .po support — exercises `I18n::Gettext.plural_keys`. Sits at test/i18n/, outside the `gettext/` prefix above."
   },
   {
     "pattern": "middleware.rb",
@@ -813,7 +813,7 @@
   {
     "testFile": "i18n_test.rb",
     "tests": ["exposes its VERSION constant"],
-    "reason": "Asserts `I18n::VERSION`, which lives in the `version.rb` excluded above \u2014 trails carries the version in package.json, so there is no constant."
+    "reason": "Asserts `I18n::VERSION`, which lives in the `version.rb` excluded above — trails carries the version in package.json, so there is no constant."
   },
   {
     "testFile": "i18n_test.rb",
@@ -831,22 +831,22 @@
   {
     "pattern": "tests/",
     "package": "i18n",
-    "reason": "`lib/i18n/tests/*` are minitest mixins the gem ships so third-party backends can run its conformance suite. Test-support scaffolding, not library surface \u2014 trails' backend tests are vitest files instead."
+    "reason": "`lib/i18n/tests/*` are minitest mixins the gem ships so third-party backends can run its conformance suite. Test-support scaffolding, not library surface — trails' backend tests are vitest files instead."
   },
   {
     "pattern": "tests.rb",
     "package": "i18n",
-    "reason": "Pre-1.0: the `I18n::Tests` namespace's autoload shim for the `tests/` conformance mixins excluded above \u2014 a file that sits beside the directory the pattern above reaches."
+    "reason": "Pre-1.0: the `I18n::Tests` namespace's autoload shim for the `tests/` conformance mixins excluded above — a file that sits beside the directory the pattern above reaches."
   },
   {
     "testFile": "test_date_ractor.rb",
     "package": "date",
-    "reason": "Ractor is Ruby's actor-based parallelism primitive \u2014 the file exercises `Ractor.make_shareable`/`Ractor.new` round-tripping of a Date across isolated interpreter states. JS is single-threaded and has no analogue, same reason `promise.rb` is excluded above."
+    "reason": "Ractor is Ruby's actor-based parallelism primitive — the file exercises `Ractor.make_shareable`/`Ractor.new` round-tripping of a Date across isolated interpreter states. JS is single-threaded and has no analogue, same reason `promise.rb` is excluded above."
   },
   {
     "testFile": "test_date_marshal.rb",
     "package": "date",
-    "reason": "Ruby's Marshal binary object format \u2014 `Marshal.dump`/`Marshal.load` of a Date, including the frozen-string and instance-variable round trip. Not applicable: JS has no Marshal, and the wire format is Ruby-only."
+    "reason": "Ruby's Marshal binary object format — `Marshal.dump`/`Marshal.load` of a Date, including the frozen-string and instance-variable round trip. Not applicable: JS has no Marshal, and the wire format is Ruby-only."
   },
   {
     "testFile": "test_date_new.rb",

--- a/scripts/parity/unported-files/baseline.json
+++ b/scripts/parity/unported-files/baseline.json
@@ -2,7 +2,7 @@
   {
     "pattern": "i18n_railtie.rb",
     "package": "activesupport",
-    "reason": "Rails boot lifecycle hook that wires I18n into the Railtie/Application init sequence. No JS equivalent — I18n is configured directly in user code."
+    "reason": "Rails boot lifecycle hook that wires I18n into the Railtie/Application init sequence. No JS equivalent \u2014 I18n is configured directly in user code."
   },
   {
     "pattern": "migration/compatibility",
@@ -15,7 +15,7 @@
   {
     "pattern": "future_result.rb",
     "testFile": "relation/load_async_test.rb",
-    "reason": "Thread-pool scheduled query with mutex + EventBuffer bridging Ruby's threaded async. Marked :nodoc: in Rails. Collapses to the Promise returned by the adapter's async exec. Test file fully excluded — all live test classes exercise FutureResult/scheduled? semantics that don't port to single-threaded JS where `await relation.toArray()` is the async surface."
+    "reason": "Thread-pool scheduled query with mutex + EventBuffer bridging Ruby's threaded async. Marked :nodoc: in Rails. Collapses to the Promise returned by the adapter's async exec. Test file fully excluded \u2014 all live test classes exercise FutureResult/scheduled? semantics that don't port to single-threaded JS where `await relation.toArray()` is the async surface."
   },
   {
     "pattern": "asynchronous_queries_tracker.rb",
@@ -38,17 +38,17 @@
   },
   {
     "pattern": "attribute_set/yaml_encoder.rb",
-    "reason": "Rails' Psych-specific YAML round-trip class for AttributeSet. Replaced by the pluggable AttributeSetCoder architecture in #1173 (P24a) / #1176 (P24b) — see packages/activemodel/src/attribute-set/{coder.ts,codecs/json.ts,codecs/yaml.ts}. Functional capability is shipped; the Rails class hierarchy doesn't map to the TS codec-injection pattern (no Psych, JSON is the default)."
+    "reason": "Rails' Psych-specific YAML round-trip class for AttributeSet. Replaced by the pluggable AttributeSetCoder architecture in #1173 (P24a) / #1176 (P24b) \u2014 see packages/activemodel/src/attribute-set/{coder.ts,codecs/json.ts,codecs/yaml.ts}. Functional capability is shipped; the Rails class hierarchy doesn't map to the TS codec-injection pattern (no Psych, JSON is the default)."
   },
   {
     "pattern": "coders/yaml_column.rb",
     "testFile": "coders/yaml_column_test.rb",
-    "reason": "YAML column coder. The store-column dump/load path and the Psych safe-dump class restriction are ported (coders/yaml-column.ts, backed by the `yaml` package — `store :col, coder: \"YAML\"`), but the Psych-specific safe-LOAD machinery (permitted_classes on load, type-mismatch-on-Ruby-class) has no JS analog; those test cases stay Ruby-only."
+    "reason": "YAML column coder. The store-column dump/load path and the Psych safe-dump class restriction are ported (coders/yaml-column.ts, backed by the `yaml` package \u2014 `store :col, coder: \"YAML\"`), but the Psych-specific safe-LOAD machinery (permitted_classes on load, type-mismatch-on-Ruby-class) has no JS analog; those test cases stay Ruby-only."
   },
   {
     "pattern": "/fixtures.rb",
     "testFile": "/fixtures_test.rb",
-    "reason": "Rails-specific YAML fixtures (test/fixtures/*.yml loaded once into the DB with named-row references and ERB preprocessing). The JS/TS ecosystem uses factories or ad-hoc Model.create instead; Trails users won't ship YAML fixtures."
+    "reason": "Rails-specific YAML fixtures (test/fixtures/*.yml loaded once into the DB with named-row references and ERB preprocessing). The JS/TS ecosystem uses factories or ad-hoc Model.create instead; Trails users won't ship YAML fixtures. Anchored: unanchored, this pattern also swallowed test_fixtures.rb, encryption/encrypted_fixtures.rb and activesupport's testing/file_fixtures.rb, which carry (or need) their own rows."
   },
   {
     "pattern": "fixture_set",
@@ -70,7 +70,7 @@
   },
   {
     "pattern": "dynamic_matchers.rb",
-    "reason": "Ruby `method_missing` magic that synthesizes `find_by_<attr>` / `find_or_*_by_<attr>` at call time. No TS analog — Proxy-based dispatch can't infer attribute lists at compile time, and `findBy({ ... })` already covers the use case idiomatically. `respond_to_missing?` alone is ported, in dynamic-matchers.ts."
+    "reason": "Ruby `method_missing` magic that synthesizes `find_by_<attr>` / `find_or_*_by_<attr>` at call time. No TS analog \u2014 Proxy-based dispatch can't infer attribute lists at compile time, and `findBy({ ... })` already covers the use case idiomatically. `respond_to_missing?` alone is ported, in dynamic-matchers.ts."
   },
   {
     "pattern": "railties/controller_runtime.rb",
@@ -103,7 +103,7 @@
       "active transaction is restored after remote disconnection",
       "dirty transaction cannot be restored after remote disconnection"
     ],
-    "reason": "These tests call the `remote_disconnect` helper, which only supports PostgreSQL and Mysql2/Trilogy — its `else` branch is `skip(\"remote_disconnect unsupported\")`, so Rails never runs them on SQLite. A genuine remote disconnect cannot be simulated against in-memory SQLite (closing the handle discards the database), which is also why the surrounding suite is gated `unless in_memory_db?`. Trails always uses :memory: SQLite."
+    "reason": "These tests call the `remote_disconnect` helper, which only supports PostgreSQL and Mysql2/Trilogy \u2014 its `else` branch is `skip(\"remote_disconnect unsupported\")`, so Rails never runs them on SQLite. A genuine remote disconnect cannot be simulated against in-memory SQLite (closing the handle discards the database), which is also why the surrounding suite is gated `unless in_memory_db?`. Trails always uses :memory: SQLite."
   },
   {
     "testFile": "adapter_test.rb",
@@ -151,7 +151,7 @@
       "compute type on undefined method",
       "compute type argument error"
     ],
-    "reason": "Registers an Object.autoload for a model whose file raises during require, so the exception surfaces from constantize inside compute_type. JS has no autoload/require hook — a module either resolves at import time or the constant simply doesn't exist."
+    "reason": "Registers an Object.autoload for a model whose file raises during require, so the exception surfaces from constantize inside compute_type. JS has no autoload/require hook \u2014 a module either resolves at import time or the constant simply doesn't exist."
   },
   {
     "testFile": "inheritance_test.rb",
@@ -190,7 +190,7 @@
       "swapping shards and roles in a multi threaded environment",
       "swapping granular shards and roles in a multi threaded environment"
     ],
-    "reason": "GVL / Ruby Thread semantics — concurrent shard-swapping tests cannot translate to single-threaded Node.js."
+    "reason": "GVL / Ruby Thread semantics \u2014 concurrent shard-swapping tests cannot translate to single-threaded Node.js."
   },
   {
     "testFile": "connection_pool_test.rb",
@@ -214,7 +214,7 @@
       "pin connection nesting lock",
       "pin connection nesting lock inverse"
     ],
-    "reason": "GVL / Ruby Thread semantics — concurrent connection tests cannot translate to single-threaded Node.js."
+    "reason": "GVL / Ruby Thread semantics \u2014 concurrent connection tests cannot translate to single-threaded Node.js."
   },
   {
     "testFile": "connection_pool_test.rb",
@@ -232,7 +232,7 @@
       "connections are cleared even if inside a non-joinable transaction",
       "cancel asynchronous queries if an exception is raised"
     ],
-    "reason": "GVL / Ruby Thread semantics — first test pins across threads; second uses FutureResult (thread-based async queries)."
+    "reason": "GVL / Ruby Thread semantics \u2014 first test pins across threads; second uses FutureResult (thread-based async queries)."
   },
   {
     "testFile": "query_cache_test.rb",
@@ -244,17 +244,17 @@
       "query cache is cleared for all thread when a connection is shared",
       "threads use the same connection"
     ],
-    "reason": "GVL / Ruby Thread + fork() semantics — per-thread / cross-process query-cache visibility cannot translate to single-threaded Node.js."
+    "reason": "GVL / Ruby Thread + fork() semantics \u2014 per-thread / cross-process query-cache visibility cannot translate to single-threaded Node.js."
   },
   {
     "testFile": "connection_adapters/connection_handlers_multi_db_test.rb",
     "tests": ["multiple connections works in a threaded environment"],
-    "reason": "GVL / Ruby Thread semantics — concurrent multi-db connection access on shared objects has no single-threaded Node.js equivalent."
+    "reason": "GVL / Ruby Thread semantics \u2014 concurrent multi-db connection access on shared objects has no single-threaded Node.js equivalent."
   },
   {
     "testFile": "relations_test.rb",
     "tests": ["where id with delegated ar object", "where relation with delegated ar object"],
-    "reason": "Rails wraps the AR object in Class.new(SimpleDelegator) and where() unwraps it via the delegator protocol (relations_test.rb:835-847). No idiomatic JS analog: a Proxy could forward method_missing, but the bespoke query-builder unwrapping isn't warranted for this niche case. (The find_by sibling at :849 uses SimpleDelegator too, but is currently matched by a plain-object trails test, so it stays counted — its delegation behavior is untested.)"
+    "reason": "Rails wraps the AR object in Class.new(SimpleDelegator) and where() unwraps it via the delegator protocol (relations_test.rb:835-847). No idiomatic JS analog: a Proxy could forward method_missing, but the bespoke query-builder unwrapping isn't warranted for this niche case. (The find_by sibling at :849 uses SimpleDelegator too, but is currently matched by a plain-object trails test, so it stays counted \u2014 its delegation behavior is untested.)"
   },
   {
     "testFile": "associations/has_one_associations_test.rb",
@@ -305,7 +305,7 @@
   {
     "testFile": "tasks/database_tasks_test.rb",
     "tests": ["raises an error when called with protected environment which name is a symbol"],
-    "reason": "Ruby Symbol env names (symbol→string coercion in protected_environments); env names are plain strings in TS."
+    "reason": "Ruby Symbol env names (symbol\u2192string coercion in protected_environments); env names are plain strings in TS."
   },
   {
     "testFile": "scoping/named_scoping_test.rb",
@@ -361,7 +361,7 @@
       "serialized time attribute",
       "supports permitted classes for default column serializer"
     ],
-    "reason": "YAML/Psych column serialization and class-constrained serializers — Ruby-only format with no Node.js equivalent."
+    "reason": "YAML/Psych column serialization and class-constrained serializers \u2014 Ruby-only format with no Node.js equivalent."
   },
   {
     "testFile": "base_test.rb",
@@ -383,7 +383,7 @@
       "generated association methods module name",
       "generated relation methods module name"
     ],
-    "reason": "GVL / Ruby Thread semantics, Marshal binary serialization, Encoding.default_internal, with_env_tz (process-level ENV[\"TZ\"] reload), and Ruby Module#inspect for namespaced generated-method modules — all Ruby-only with no Node.js equivalent."
+    "reason": "GVL / Ruby Thread semantics, Marshal binary serialization, Encoding.default_internal, with_env_tz (process-level ENV[\"TZ\"] reload), and Ruby Module#inspect for namespaced generated-method modules \u2014 all Ruby-only with no Node.js equivalent."
   },
   {
     "testFile": "hstore_test.rb",
@@ -398,17 +398,17 @@
   {
     "testFile": "has_and_belongs_to_many_associations_test.rb",
     "tests": ["marshal dump"],
-    "reason": "Ruby Marshal binary serialization — no Node.js equivalent."
+    "reason": "Ruby Marshal binary serialization \u2014 no Node.js equivalent."
   },
   {
     "testFile": "belongs_to_associations_test.rb",
     "tests": ["belongs to proxy should not respond to private methods"],
-    "reason": "Probes Ruby method visibility: `private_method` must raise NoMethodError on a direct call but succeed via `send` (the via-send sibling IS ported). JS has no runtime-enforced private dispatch — a method is either callable or absent."
+    "reason": "Probes Ruby method visibility: `private_method` must raise NoMethodError on a direct call but succeed via `send` (the via-send sibling IS ported). JS has no runtime-enforced private dispatch \u2014 a method is either callable or absent."
   },
   {
     "testFile": "reaper_test.rb",
     "tests": ["connection pool starts reaper in fork"],
-    "reason": "GVL / Ruby fork() semantics — process forking has no Node.js equivalent."
+    "reason": "GVL / Ruby fork() semantics \u2014 process forking has no Node.js equivalent."
   },
   {
     "testFile": "connection_adapters/connection_handler_test.rb",
@@ -419,7 +419,7 @@
       "retrieve connection pool copies schema cache from ancestor pool",
       "pool from any process for uses most recent spec"
     ],
-    "reason": "Ruby fork() + Marshal — process forking and binary serialization have no Node.js equivalent."
+    "reason": "Ruby fork() + Marshal \u2014 process forking and binary serialization have no Node.js equivalent."
   },
   {
     "testFile": "yaml_serialization_test.rb",
@@ -438,7 +438,7 @@
   {
     "testFile": "/railtie_test.rb",
     "package": "globalid",
-    "reason": "Exercises the `global_id` Railtie initializer through a full `Rails::Application` boot (`@app.initialize!`) under `ActiveSupport::Testing::Isolation` — GlobalID.app defaulting, `config.global_id.app`/`expires_in` injection, and verifier key derivation from `app.key_generator`. Unlike activemodel/trailties, globalid has not yet ported its railtie to a `Trailtie` (activesupport's `BaseRailtie`); its wiring is a `wire.ts` side-effect plus explicit `setApp`/verifier setters, and there is no `Rails::Application` boot harness for these tests to drive. Porting globalid's railtie to a `Trailtie` would let this file re-enter accounting — tracked as a follow-up story."
+    "reason": "Exercises the `global_id` Railtie initializer through a full `Rails::Application` boot (`@app.initialize!`) under `ActiveSupport::Testing::Isolation` \u2014 GlobalID.app defaulting, `config.global_id.app`/`expires_in` injection, and verifier key derivation from `app.key_generator`. Unlike activemodel/trailties, globalid has not yet ported its railtie to a `Trailtie` (activesupport's `BaseRailtie`); its wiring is a `wire.ts` side-effect plus explicit `setApp`/verifier setters, and there is no `Rails::Application` boot harness for these tests to drive. Porting globalid's railtie to a `Trailtie` would let this file re-enter accounting \u2014 tracked as a follow-up story."
   },
   {
     "testFile": "global_locator_test.rb",
@@ -496,7 +496,7 @@
   {
     "package": "did-you-mean",
     "pattern": "formatter.rb",
-    "reason": "Formats `Did you mean? …` suffix for Ruby's Exception#detailed_message integration. JS error stringification is per-error, not via a stdlib hook."
+    "reason": "Formats `Did you mean? \u2026` suffix for Ruby's Exception#detailed_message integration. JS error stringification is per-error, not via a stdlib hook."
   },
   {
     "package": "did-you-mean",
@@ -519,7 +519,7 @@
     "package": "did-you-mean",
     "pattern": "spell_checkers/name_error_checkers/class_name_checker.rb",
     "testFile": "spell_checking/test_class_name_check.rb",
-    "reason": "Suggests constant/class names by walking Module#constants + ancestor scopes. Ruby-only — JS has no equivalent constant introspection."
+    "reason": "Suggests constant/class names by walking Module#constants + ancestor scopes. Ruby-only \u2014 JS has no equivalent constant introspection."
   },
   {
     "package": "did-you-mean",
@@ -553,15 +553,15 @@
   },
   {
     "testFile": "tree_spell/test_change_word.rb",
-    "reason": "tree_spell helper test — excluded transitively with tree_spell_checker.rb."
+    "reason": "tree_spell helper test \u2014 excluded transitively with tree_spell_checker.rb."
   },
   {
     "testFile": "tree_spell/test_explore.rb",
-    "reason": "tree_spell helper test — excluded transitively with tree_spell_checker.rb."
+    "reason": "tree_spell helper test \u2014 excluded transitively with tree_spell_checker.rb."
   },
   {
     "testFile": "tree_spell/test_human_typo.rb",
-    "reason": "tree_spell helper test — excluded transitively with tree_spell_checker.rb."
+    "reason": "tree_spell helper test \u2014 excluded transitively with tree_spell_checker.rb."
   },
   {
     "testFile": "test_ractor_compatibility.rb",
@@ -571,12 +571,12 @@
     "testFile": "verifier_test.rb",
     "className": "VerifierTest",
     "tests": ["generates URL-safe messages"],
-    "reason": "Asserts byte-for-byte equality against a known token produced by Ruby's Marshal serializer wrapped in MessageVerifier. Our globalid Verifier uses JSON serialization (the default for our MessageVerifier), so the encoded payload differs structurally — the same input produces a different (but equivalent) token. The behavioral guarantee this test cares about (urlsafe encoding, no +/=/ chars) is covered by packages/globalid/src/verifier.test.ts asserting char-class absence rather than exact bytes."
+    "reason": "Asserts byte-for-byte equality against a known token produced by Ruby's Marshal serializer wrapped in MessageVerifier. Our globalid Verifier uses JSON serialization (the default for our MessageVerifier), so the encoded payload differs structurally \u2014 the same input produces a different (but equivalent) token. The behavioral guarantee this test cares about (urlsafe encoding, no +/=/ chars) is covered by packages/globalid/src/verifier.test.ts asserting char-class absence rather than exact bytes."
   },
   {
     "testFile": "message_encryptor_test.rb",
     "tests": ["backwards compatibility decrypt previously encrypted messages without metadata"],
-    "reason": "Decrypts a ciphertext minted before message metadata existed (message_encryptor_test.rb:147-154). The plaintext is the Ruby Marshal payload `\\x04\\x08I\"\\x12Ruby on Rails\\x06:\\x06ET` — an ivar-wrapped Ruby String — so passing it requires a real Ruby Marshal wire reader. trails has no Ruby Marshal runtime: the `:marshal` serializer in messages/serializer-with-fallback.ts is a trails-native codec behind Rails' `\\x04\\x08` signature, matching the project-wide Marshal exclusion above (marshalling.rb / marshal_serialization_test.rb). Ruby-only wire format."
+    "reason": "Decrypts a ciphertext minted before message metadata existed (message_encryptor_test.rb:147-154). The plaintext is the Ruby Marshal payload `\\x04\\x08I\"\\x12Ruby on Rails\\x06:\\x06ET` \u2014 an ivar-wrapped Ruby String \u2014 so passing it requires a real Ruby Marshal wire reader. trails has no Ruby Marshal runtime: the `:marshal` serializer in messages/serializer-with-fallback.ts is a trails-native codec behind Rails' `\\x04\\x08` signature, matching the project-wide Marshal exclusion above (marshalling.rb / marshal_serialization_test.rb). Ruby-only wire format."
   },
   {
     "testFile": "associations/extension_test.rb",
@@ -596,7 +596,7 @@
   {
     "testFile": "associations/inverse_associations_test.rb",
     "tests": ["has many and belongs to should find inverse automatically for model in module"],
-    "reason": "Asserts automatic inverse_of detection for namespaced models (Admin::Account / Admin::User). Ruby modules (`::`) have no TypeScript equivalent — JS class names cannot contain `::`, so the demodulized automatic-inverse scenario isn't representable."
+    "reason": "Asserts automatic inverse_of detection for namespaced models (Admin::Account / Admin::User). Ruby modules (`::`) have no TypeScript equivalent \u2014 JS class names cannot contain `::`, so the demodulized automatic-inverse scenario isn't representable."
   },
   {
     "testFile": "associations_test.rb",
@@ -614,7 +614,7 @@
       "yaml loads 5 1 dump",
       "yaml loads 5 1 dump without indexes still queries for indexes"
     ],
-    "reason": "Loads the fixed Rails-5.1-era schema-cache dump asset (test/assets/schema_dump_5_1.yml) and deserializes it via Psych (schema_cache_test.rb:124-142). Note this is NOT covered by our YAML syntax support (the `yaml` package backing coders/yaml-column.ts): the asset is a Psych object graph of `!ruby/object:ActiveRecord::ConnectionAdapters::{SchemaCache,Column,SqlTypeMetadata}` tags with Ruby symbol values and anchors. Loading it requires (a) unsafe-load reconstruction of Ruby class instances from `!ruby/object:` tags — the same Psych machinery already documented as having no JS analog in the coders/yaml_column.rb and attribute_set/yaml_encoder.rb entries — and (b) the 5.1→current legacy-format migration handled by legacy_yaml_adapter.rb (itself unported above). Our `yaml` parser yields plain tagged nodes, not SchemaCache instances. The live schema-cache round-trip is exercised by the portable tests in the same file (test_yaml_dump_and_load[_with_gzip], which use our own dump path)."
+    "reason": "Loads the fixed Rails-5.1-era schema-cache dump asset (test/assets/schema_dump_5_1.yml) and deserializes it via Psych (schema_cache_test.rb:124-142). Note this is NOT covered by our YAML syntax support (the `yaml` package backing coders/yaml-column.ts): the asset is a Psych object graph of `!ruby/object:ActiveRecord::ConnectionAdapters::{SchemaCache,Column,SqlTypeMetadata}` tags with Ruby symbol values and anchors. Loading it requires (a) unsafe-load reconstruction of Ruby class instances from `!ruby/object:` tags \u2014 the same Psych machinery already documented as having no JS analog in the coders/yaml_column.rb and attribute_set/yaml_encoder.rb entries \u2014 and (b) the 5.1\u2192current legacy-format migration handled by legacy_yaml_adapter.rb (itself unported above). Our `yaml` parser yields plain tagged nodes, not SchemaCache instances. The live schema-cache round-trip is exercised by the portable tests in the same file (test_yaml_dump_and_load[_with_gzip], which use our own dump path)."
   },
   {
     "testFile": "prepared_statement_status_test.rb",
@@ -642,7 +642,7 @@
   {
     "testFile": "transactions_test.rb",
     "tests": ["after current transaction commit multidb nested transactions"],
-    "reason": "Requires the ARUnit2Model secondary database connection (multi-database setup). The test asserts afterAllTransactionsCommit fires only after the outermost cross-database transaction commits — not available in the single-database test environment."
+    "reason": "Requires the ARUnit2Model secondary database connection (multi-database setup). The test asserts afterAllTransactionsCommit fires only after the outermost cross-database transaction commits \u2014 not available in the single-database test environment."
   },
   {
     "testFile": "dirty_test.rb",
@@ -656,12 +656,12 @@
       "in place mutation for binary",
       "mutating and then assigning doesn't remove the change"
     ],
-    "reason": "All three mutate a string in place (`catchphrase << \" matey!\"`, `data << \"bar\"` on a serialized binary; dirty_test.rb:668/689/799). JS strings are immutable — there is no in-place string mutation to detect."
+    "reason": "All three mutate a string in place (`catchphrase << \" matey!\"`, `data << \"bar\"` on a serialized binary; dirty_test.rb:668/689/799). JS strings are immutable \u2014 there is no in-place string mutation to detect."
   },
   {
     "testFile": "dirty_test.rb",
     "tests": ["getters with side effects are allowed"],
-    "reason": "The overridden reader persists as a side effect (`update_attribute` inside `def catchphrase`, dirty_test.rb:807) and the assertion relies on that write completing before the reader returns. trails persistence is async; a JS getter cannot await, so the persist would float as an unawaited promise — no faithful sync equivalent."
+    "reason": "The overridden reader persists as a side effect (`update_attribute` inside `def catchphrase`, dirty_test.rb:807) and the assertion relies on that write completing before the reader returns. trails persistence is async; a JS getter cannot await, so the persist would float as an unawaited promise \u2014 no faithful sync equivalent."
   },
   {
     "testFile": "database_selector_test.rb",
@@ -708,101 +708,101 @@
   {
     "pattern": "tools.rb",
     "package": "activerecord-test-support",
-    "reason": "Rails' rake/minitest test-runner plumbing: prepends adapter globbing onto Rails::TestUnit::Runner and invokes it with ARGV. vitest fills that role in trails — no port intended."
+    "reason": "Rails' rake/minitest test-runner plumbing: prepends adapter globbing onto Rails::TestUnit::Runner and invokes it with ARGV. vitest fills that role in trails \u2014 no port intended."
   },
   {
     "pattern": "backend/cache.rb",
     "testFile": "backend/cache_test.rb",
     "package": "i18n",
-    "reason": "Pre-1.0: optional backend mixin — caches lookups through ActiveSupport::Cache."
+    "reason": "Pre-1.0: optional backend mixin \u2014 caches lookups through ActiveSupport::Cache."
   },
   {
     "pattern": "backend/cache_file.rb",
     "testFile": "backend/cache_file_test.rb",
     "package": "i18n",
-    "reason": "Pre-1.0: optional backend mixin — caches parsed translation files on disk."
+    "reason": "Pre-1.0: optional backend mixin \u2014 caches parsed translation files on disk."
   },
   {
     "pattern": "backend/cascade.rb",
     "testFile": "backend/cascade_test.rb",
     "package": "i18n",
-    "reason": "Pre-1.0: optional backend mixin — cascading key lookup (`foo.bar.baz` → `foo.baz`)."
+    "reason": "Pre-1.0: optional backend mixin \u2014 cascading key lookup (`foo.bar.baz` \u2192 `foo.baz`)."
   },
   {
     "pattern": "backend/interpolation_compiler.rb",
     "testFile": "backend/interpolation_compiler_test.rb",
     "package": "i18n",
-    "reason": "Pre-1.0: optional backend mixin — compiles interpolations into Ruby procs via `eval`/`instance_eval`, which has no trails counterpart."
+    "reason": "Pre-1.0: optional backend mixin \u2014 compiles interpolations into Ruby procs via `eval`/`instance_eval`, which has no trails counterpart."
   },
   {
     "pattern": "backend/lazy_loadable.rb",
     "testFile": "backend/lazy_loadable_test.rb",
     "package": "i18n",
-    "reason": "Pre-1.0: optional backend mixin — defers translation-file loading until first lookup."
+    "reason": "Pre-1.0: optional backend mixin \u2014 defers translation-file loading until first lookup."
   },
   {
     "pattern": "backend/memoize.rb",
     "testFile": "backend/memoize_test.rb",
     "package": "i18n",
-    "reason": "Pre-1.0: optional backend mixin — memoizes lookups per locale."
+    "reason": "Pre-1.0: optional backend mixin \u2014 memoizes lookups per locale."
   },
   {
     "pattern": "backend/metadata.rb",
     "testFile": "backend/metadata_test.rb",
     "package": "i18n",
-    "reason": "Pre-1.0: optional backend mixin — attaches lookup metadata onto the translated String's singleton class. JS strings take no per-instance state."
+    "reason": "Pre-1.0: optional backend mixin \u2014 attaches lookup metadata onto the translated String's singleton class. JS strings take no per-instance state."
   },
   {
     "pattern": "backend/pluralization.rb",
     "testFile": "backend/pluralization_test.rb",
     "package": "i18n",
-    "reason": "Pre-1.0: optional backend mixin — pluralization via per-locale rule procs in the data."
+    "reason": "Pre-1.0: optional backend mixin \u2014 pluralization via per-locale rule procs in the data."
   },
   {
     "testFile": "backend/pluralization_fallback_test.rb",
     "package": "i18n",
-    "reason": "Pre-1.0: optional backend mixin — pluralization via per-locale rule procs in the data. Suite for the deferred `backend/pluralization.rb` composed with Fallbacks."
+    "reason": "Pre-1.0: optional backend mixin \u2014 pluralization via per-locale rule procs in the data. Suite for the deferred `backend/pluralization.rb` composed with Fallbacks."
   },
   {
     "testFile": "backend/pluralization_scope_test.rb",
     "package": "i18n",
-    "reason": "Pre-1.0: optional backend mixin — pluralization via per-locale rule procs in the data. Suite for the deferred `backend/pluralization.rb` looked up under a scope."
+    "reason": "Pre-1.0: optional backend mixin \u2014 pluralization via per-locale rule procs in the data. Suite for the deferred `backend/pluralization.rb` looked up under a scope."
   },
   {
     "testFile": "api/all_features_test.rb",
     "package": "i18n",
-    "reason": "Pre-1.0: optional backend mixins — a Chain of every deferred mixin (Cascade, Memoize, Metadata, Pluralization, Fallbacks) at once."
+    "reason": "Pre-1.0: optional backend mixins \u2014 a Chain of every deferred mixin (Cascade, Memoize, Metadata, Pluralization, Fallbacks) at once."
   },
   {
     "testFile": "api/cascade_test.rb",
     "package": "i18n",
-    "reason": "Pre-1.0: optional backend mixin — cascading key lookup (`foo.bar.baz` → `foo.baz`)."
+    "reason": "Pre-1.0: optional backend mixin \u2014 cascading key lookup (`foo.bar.baz` \u2192 `foo.baz`)."
   },
   {
     "testFile": "api/lazy_loadable_test.rb",
     "package": "i18n",
-    "reason": "Pre-1.0: optional backend mixin — defers translation-file loading until first lookup."
+    "reason": "Pre-1.0: optional backend mixin \u2014 defers translation-file loading until first lookup."
   },
   {
     "testFile": "api/memoize_test.rb",
     "package": "i18n",
-    "reason": "Pre-1.0: optional backend mixin — memoizes lookups per locale."
+    "reason": "Pre-1.0: optional backend mixin \u2014 memoizes lookups per locale."
   },
   {
     "testFile": "api/pluralization_test.rb",
     "package": "i18n",
-    "reason": "Pre-1.0: optional backend mixin — pluralization via per-locale rule procs in the data."
+    "reason": "Pre-1.0: optional backend mixin \u2014 pluralization via per-locale rule procs in the data."
   },
   {
     "pattern": "gettext",
     "testFile": "gettext/",
     "package": "i18n",
-    "reason": "Pre-1.0: gettext .po support — the catalogue parser, the `_`/`n_`/`s_` helpers, and the backend mixin that loads .po files. A Ruby toolchain concern with no trails consumer; Rails' own I18n usage never touches it."
+    "reason": "Pre-1.0: gettext .po support \u2014 the catalogue parser, the `_`/`n_`/`s_` helpers, and the backend mixin that loads .po files. A Ruby toolchain concern with no trails consumer; Rails' own I18n usage never touches it."
   },
   {
     "testFile": "gettext_plural_keys_test.rb",
     "package": "i18n",
-    "reason": "Pre-1.0: gettext .po support — exercises `I18n::Gettext.plural_keys`. Sits at test/i18n/, outside the `gettext/` prefix above."
+    "reason": "Pre-1.0: gettext .po support \u2014 exercises `I18n::Gettext.plural_keys`. Sits at test/i18n/, outside the `gettext/` prefix above."
   },
   {
     "pattern": "middleware.rb",
@@ -813,7 +813,7 @@
   {
     "testFile": "i18n_test.rb",
     "tests": ["exposes its VERSION constant"],
-    "reason": "Asserts `I18n::VERSION`, which lives in the `version.rb` excluded above — trails carries the version in package.json, so there is no constant."
+    "reason": "Asserts `I18n::VERSION`, which lives in the `version.rb` excluded above \u2014 trails carries the version in package.json, so there is no constant."
   },
   {
     "testFile": "i18n_test.rb",
@@ -831,22 +831,22 @@
   {
     "pattern": "tests/",
     "package": "i18n",
-    "reason": "`lib/i18n/tests/*` are minitest mixins the gem ships so third-party backends can run its conformance suite. Test-support scaffolding, not library surface — trails' backend tests are vitest files instead."
+    "reason": "`lib/i18n/tests/*` are minitest mixins the gem ships so third-party backends can run its conformance suite. Test-support scaffolding, not library surface \u2014 trails' backend tests are vitest files instead."
   },
   {
     "pattern": "tests.rb",
     "package": "i18n",
-    "reason": "Pre-1.0: the `I18n::Tests` namespace's autoload shim for the `tests/` conformance mixins excluded above — a file that sits beside the directory the pattern above reaches."
+    "reason": "Pre-1.0: the `I18n::Tests` namespace's autoload shim for the `tests/` conformance mixins excluded above \u2014 a file that sits beside the directory the pattern above reaches."
   },
   {
     "testFile": "test_date_ractor.rb",
     "package": "date",
-    "reason": "Ractor is Ruby's actor-based parallelism primitive — the file exercises `Ractor.make_shareable`/`Ractor.new` round-tripping of a Date across isolated interpreter states. JS is single-threaded and has no analogue, same reason `promise.rb` is excluded above."
+    "reason": "Ractor is Ruby's actor-based parallelism primitive \u2014 the file exercises `Ractor.make_shareable`/`Ractor.new` round-tripping of a Date across isolated interpreter states. JS is single-threaded and has no analogue, same reason `promise.rb` is excluded above."
   },
   {
     "testFile": "test_date_marshal.rb",
     "package": "date",
-    "reason": "Ruby's Marshal binary object format — `Marshal.dump`/`Marshal.load` of a Date, including the frozen-string and instance-variable round trip. Not applicable: JS has no Marshal, and the wire format is Ruby-only."
+    "reason": "Ruby's Marshal binary object format \u2014 `Marshal.dump`/`Marshal.load` of a Date, including the frozen-string and instance-variable round trip. Not applicable: JS has no Marshal, and the wire format is Ruby-only."
   },
   {
     "testFile": "test_date_new.rb",

--- a/scripts/parity/unported-files/unscoped.ts
+++ b/scripts/parity/unported-files/unscoped.ts
@@ -91,15 +91,15 @@ export const UNSCOPED_UNPORTED_FILES: UnportedFile[] = [
       "test cases stay Ruby-only.",
   },
   {
-    // Anchored: unanchored, this row also swallowed test_fixtures.rb,
-    // encryption/encrypted_fixtures.rb and testing/file_fixtures.rb, which
-    // carry (or need) their own rows.
     pattern: "/fixtures.rb",
     testFile: "/fixtures_test.rb",
     reason:
       "Rails-specific YAML fixtures (test/fixtures/*.yml loaded once into the DB " +
       "with named-row references and ERB preprocessing). The JS/TS ecosystem uses " +
-      "factories or ad-hoc Model.create instead; Trails users won't ship YAML fixtures.",
+      "factories or ad-hoc Model.create instead; Trails users won't ship YAML fixtures. " +
+      "Anchored: unanchored, this pattern also swallowed test_fixtures.rb, " +
+      "encryption/encrypted_fixtures.rb and activesupport's testing/file_fixtures.rb, " +
+      "which carry (or need) their own rows.",
   },
   {
     pattern: "fixture_set",

--- a/scripts/parity/unported-files/unscoped.ts
+++ b/scripts/parity/unported-files/unscoped.ts
@@ -13,6 +13,22 @@ export const UNSCOPED_UNPORTED_FILES: UnportedFile[] = [
     reason: "Pre-1.0: legacy Rails version migration compatibility shims.",
   },
   {
+    package: "activerecord",
+    testFile: "/migration/compatibility_test.rb",
+    reason:
+      "Won't-do, by maintainer decision rather than technical limitation: " +
+      "`ActiveRecord::Migration[x.y]` / `Migration::Compatibility::V*` exists so " +
+      "migrations written under an older Rails keep behaving as written, and trails has " +
+      "no older versions. PR #5070 shipped a complete, CI-green `Migration[6.1]` / " +
+      '`Compatibility::V6_1` and was closed unmerged on 2026-07-22 — "the premise of ' +
+      "this pr is not the goal of trails. We have no backwards compatibility necessary " +
+      "since there never were previous versions of trails.\" RFC 0030's story " +
+      "`c1-schema-dumper-migration-version-compat` was closed on the same grounds. The " +
+      "thin registry at packages/activerecord/src/migration/compatibility.ts (version " +
+      '"1.0" only) stays; nothing is added to it. Source side is already excluded by the ' +
+      "`migration/compatibility` pattern above.",
+  },
+  {
     pattern: "promise.rb",
     reason:
       "Rails Promise wraps a thread-backed FutureResult with a blocking #value. " +
@@ -75,7 +91,10 @@ export const UNSCOPED_UNPORTED_FILES: UnportedFile[] = [
       "test cases stay Ruby-only.",
   },
   {
-    pattern: "fixtures.rb",
+    // Anchored: unanchored, this row also swallowed test_fixtures.rb,
+    // encryption/encrypted_fixtures.rb and testing/file_fixtures.rb, which
+    // carry (or need) their own rows.
+    pattern: "/fixtures.rb",
     testFile: "/fixtures_test.rb",
     reason:
       "Rails-specific YAML fixtures (test/fixtures/*.yml loaded once into the DB " +

--- a/scripts/test-compare/closure-aliases.ts
+++ b/scripts/test-compare/closure-aliases.ts
@@ -1,0 +1,166 @@
+/**
+ * The reviewed edges of the AR-closure test boundary.
+ *
+ * Rules R1 (path) and R2 (directory) in ./manifest.ts are exact and derived.
+ * RFC 0105's derivation had a third rule — match a test stem's *basename*
+ * against a closure file's basename at any path — which is a heuristic and
+ * misfires (it maps `core_ext/pathname/blank_test.rb` onto
+ * `active_support/core_ext/date/blank.rb` on the basename `blank` alone). So
+ * R3 is not shipped: every file it would have caught is listed here by hand
+ * with the closure file it actually covers, and everything else is listed as
+ * out-of-closure. A reviewer settles any file by reading one row, not by
+ * re-running a heuristic.
+ */
+
+export interface ClosureAlias {
+  /** Path under `vendor/rails/activesupport/test/`. */
+  testFile: string;
+  /** The closure file it covers, relative to `activesupport/lib`. */
+  closureFile: string;
+  reason: string;
+}
+
+/** In-closure test files that R1/R2 cannot reach from their own path. */
+export const CLOSURE_ALIASES: ClosureAlias[] = [
+  {
+    testFile: "time_zone_test.rb",
+    closureFile: "active_support/values/time_zone.rb",
+    reason: "TimeZone lives under values/, not at the test's top-level stem.",
+  },
+  {
+    testFile: "core_ext/time_with_zone_test.rb",
+    closureFile: "active_support/time_with_zone.rb",
+    reason: "TimeWithZone is a top-level class; only its test sits under core_ext/.",
+  },
+  {
+    testFile: "share_lock_test.rb",
+    closureFile: "active_support/concurrency/share_lock.rb",
+    reason: "ShareLock lives under concurrency/, reached via dependencies/interlock.",
+  },
+  {
+    testFile: "autoload_test.rb",
+    closureFile: "active_support/dependencies/autoload.rb",
+    reason: "Autoload lives under dependencies/; the test drops the directory.",
+  },
+  {
+    testFile: "transliterate_test.rb",
+    closureFile: "active_support/inflector/transliterate.rb",
+    reason: "Transliterate lives under inflector/; the test drops the directory.",
+  },
+  {
+    testFile: "core_ext/module/attribute_accessor_per_thread_test.rb",
+    closureFile: "active_support/core_ext/module/attribute_accessors_per_thread.rb",
+    reason: "The test singularizes `accessors`, so no stem variant lines up.",
+  },
+  {
+    testFile: "multibyte_proxy_test.rb",
+    closureFile: "active_support/multibyte.rb",
+    reason: "Covers the Multibyte proxy_class hook; the file is multibyte.rb.",
+  },
+];
+
+/**
+ * Activesupport test files deliberately outside the AR closure: nothing under
+ * `activerecord/lib` or `activemodel/lib` requires the file they cover. They
+ * are listed rather than inferred so the guard in ./manifest.ts can tell a
+ * file that was *considered* out from one that is merely new.
+ *
+ * This list removes nothing from any denominator — RFC 0101 owns porting the
+ * out-of-closure surface, and the whole-package activesupport percent still
+ * counts every file here.
+ */
+export const OUT_OF_CLOSURE_TEST_FILES: string[] = [
+  "backtrace_cleaner_test.rb",
+  "benchmark_test.rb",
+  "cache/cache_coder_test.rb",
+  "cache/cache_entry_test.rb",
+  "cache/cache_key_test.rb",
+  "cache/cache_store_logger_test.rb",
+  "cache/cache_store_namespace_test.rb",
+  "cache/cache_store_setting_test.rb",
+  "cache/local_cache_middleware_test.rb",
+  "cache/serializer_with_fallback_test.rb",
+  "cache/stores/file_store_test.rb",
+  "cache/stores/mem_cache_store_test.rb",
+  "cache/stores/memory_store_test.rb",
+  "cache/stores/null_store_test.rb",
+  "cache/stores/redis_cache_store_test.rb",
+  "callback_inheritance_test.rb",
+  "callbacks_test.rb",
+  "clean_logger_test.rb",
+  "configurable_test.rb",
+  "core_ext/benchmark_test.rb",
+  "core_ext/bigdecimal_test.rb",
+  "core_ext/date_and_time_compatibility_test.rb",
+  "core_ext/duration_test.rb",
+  "core_ext/erb_util_test.rb",
+  "core_ext/hash/transform_values_test.rb",
+  "core_ext/kernel/concern_test.rb",
+  "core_ext/kernel_test.rb",
+  "core_ext/load_error_test.rb",
+  "core_ext/module/attribute_aliasing_test.rb",
+  "core_ext/name_error_test.rb",
+  "core_ext/object/json_cherry_pick_test.rb",
+  "core_ext/object/json_gem_encoding_test.rb",
+  "core_ext/object/with_test.rb",
+  "core_ext/pathname/blank_test.rb",
+  "core_ext/pathname/existence_test.rb",
+  "core_ext/regexp_ext_test.rb",
+  "core_ext/secure_random_test.rb",
+  "core_ext/symbol_ext_test.rb",
+  "current_attributes_test.rb",
+  "digest_test.rb",
+  "encrypted_configuration_test.rb",
+  "encrypted_file_test.rb",
+  "error_reporter_test.rb",
+  "evented_file_update_checker_test.rb",
+  "execution_context_test.rb",
+  "executor_test.rb",
+  "file_update_checker_test.rb",
+  "fork_tracker_test.rb",
+  "gzip_test.rb",
+  "isolated_execution_state_test.rb",
+  "key_generator_test.rb",
+  "log_subscriber_test.rb",
+  "message_encryptor_test.rb",
+  "message_encryptors_test.rb",
+  "message_pack/cache_serializer_test.rb",
+  "message_pack/serializer_test.rb",
+  "message_verifier_test.rb",
+  "message_verifiers_test.rb",
+  "messages/message_encryptor_metadata_test.rb",
+  "messages/message_encryptor_rotator_test.rb",
+  "messages/message_verifier_metadata_test.rb",
+  "messages/message_verifier_rotator_test.rb",
+  "messages/rotation_configuration_test.rb",
+  "messages/serializer_with_fallback_test.rb",
+  "multibyte_chars_test.rb",
+  "notifications/evented_notification_test.rb",
+  "number_helper_i18n_test.rb",
+  "option_merger_test.rb",
+  "ordered_hash_test.rb",
+  "reloader_test.rb",
+  "rescuable_test.rb",
+  "safe_buffer_test.rb",
+  "secure_compare_rotator_test.rb",
+  "security_utils_test.rb",
+  "silence_logger_test.rb",
+  "subscriber_test.rb",
+  "tagged_logging_test.rb",
+  "test_case_test.rb",
+  "testing/after_teardown_assertion_test.rb",
+  "testing/after_teardown_test.rb",
+  "testing/constant_lookup_test.rb",
+  "testing/file_fixtures_test.rb",
+  "testing/method_call_assertions_test.rb",
+  "testing/test_without_assertions_test.rb",
+  "time_travel_test.rb",
+  "xml_mini/jdom_engine_test.rb",
+  "xml_mini/libxml_engine_test.rb",
+  "xml_mini/libxmlsax_engine_test.rb",
+  "xml_mini/nokogiri_engine_test.rb",
+  "xml_mini/nokogirisax_engine_test.rb",
+  "xml_mini/rexml_engine_test.rb",
+  "xml_mini/xml_mini_engine_test.rb",
+  "xml_mini_test.rb",
+];

--- a/scripts/test-compare/closure-cli.ts
+++ b/scripts/test-compare/closure-cli.ts
@@ -11,9 +11,13 @@
  * either side of the boundary.
  */
 
+import { execFile } from "node:child_process";
 import { readFile } from "node:fs/promises";
-import { dirname, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { testPathsManifest } from "../../vendor/sources.js";
 
 import { OUT_OF_CLOSURE_TEST_FILES } from "./closure-aliases.js";
 import {
@@ -22,16 +26,29 @@ import {
   tableProblems,
 } from "./closure-manifest.js";
 
-const RAILS_TESTS_JSON = resolve(
-  dirname(fileURLToPath(import.meta.url)),
-  "output/rails-tests.json",
-);
+const DIR = dirname(fileURLToPath(import.meta.url));
+const RAILS_TESTS_JSON = resolve(DIR, "output/rails-tests.json");
 
-/** Rails test counts per activesupport test file, when a compare run left them. */
+const execFileAsync = promisify(execFile);
+
+/**
+ * Rails test counts per activesupport test file. `output/rails-tests.json` is
+ * whatever a previous `parity:test` run left behind; on a fresh checkout there
+ * is none, so the Ruby extractor runs here rather than reporting zeros. A Ruby
+ * or vendor failure propagates — a count is either real or the command fails.
+ */
 async function railsTestCounts(): Promise<Map<string, number>> {
   const counts = new Map<string, number>();
-  const raw = await readFile(RAILS_TESTS_JSON, "utf-8").catch(() => null);
-  if (raw === null) return counts;
+  let raw = await readFile(RAILS_TESTS_JSON, "utf-8").catch(() => null);
+  if (raw === null) {
+    process.stderr.write("==> No output/rails-tests.json; running the Ruby test extractor\n");
+    await execFileAsync("ruby", [join(DIR, "extract-ruby-tests.rb")], {
+      cwd: resolve(DIR, "../.."),
+      env: { ...process.env, TEST_PATHS_JSON: JSON.stringify(testPathsManifest()) },
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    raw = await readFile(RAILS_TESTS_JSON, "utf-8");
+  }
   const manifest = JSON.parse(raw) as {
     packages: Record<string, { files: { file: string; testCases: unknown[] }[] }>;
   };
@@ -64,23 +81,21 @@ async function main(): Promise<void> {
     return;
   }
 
-  const counts = await railsTestCounts();
-  const tests = (files: { testFile: string }[]) =>
-    files.reduce((sum, f) => sum + (counts.get(f.testFile) ?? 0), 0);
-
   if (!check) {
+    const counts = await railsTestCounts();
+    const tests = (files: { testFile: string }[]) =>
+      files.reduce((sum, f) => sum + (counts.get(f.testFile) ?? 0), 0);
+
     for (const verdict of partition.inClosure) {
       process.stdout.write(`  IN  ${(verdict.rule ?? "").padEnd(5)} ${verdict.testFile}\n`);
     }
     for (const verdict of partition.outOfClosure) {
       process.stdout.write(`  OUT       ${verdict.testFile}\n`);
     }
-    const seen =
-      counts.size > 0 ? "" : " (run `pnpm parity:test -- --package activesupport` for test counts)";
     process.stdout.write(
       `\nAR closure: ${partition.closureFiles.length} activesupport lib files\n` +
         `  in closure:  ${partition.inClosure.length} test files, ${tests(partition.inClosure)} Rails tests\n` +
-        `  out:         ${partition.outOfClosure.length} test files, ${tests(partition.outOfClosure)} Rails tests${seen}\n`,
+        `  out:         ${partition.outOfClosure.length} test files, ${tests(partition.outOfClosure)} Rails tests\n`,
     );
   }
 

--- a/scripts/test-compare/closure-cli.ts
+++ b/scripts/test-compare/closure-cli.ts
@@ -1,0 +1,96 @@
+/**
+ * `pnpm parity:test:closure [<test file>] [--check]`
+ *
+ *   pnpm parity:test:closure                      # the full partition + counts
+ *   pnpm parity:test:closure time_zone_test.rb    # in/out for one file
+ *   pnpm parity:test:closure --check              # guard only (CI)
+ *
+ * The guard fails when a file under `vendor/rails/activesupport/test/` is
+ * neither auto-derived (R1/R2) nor aliased nor explicitly listed as
+ * out-of-closure, so a new vendored Rails test file cannot silently land on
+ * either side of the boundary.
+ */
+
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { OUT_OF_CLOSURE_TEST_FILES } from "./closure-aliases.js";
+import {
+  classifyTestFile,
+  partitionActivesupportTests,
+  tableProblems,
+} from "./closure-manifest.js";
+
+const RAILS_TESTS_JSON = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "output/rails-tests.json",
+);
+
+/** Rails test counts per activesupport test file, when a compare run left them. */
+async function railsTestCounts(): Promise<Map<string, number>> {
+  const counts = new Map<string, number>();
+  const raw = await readFile(RAILS_TESTS_JSON, "utf-8").catch(() => null);
+  if (raw === null) return counts;
+  const manifest = JSON.parse(raw) as {
+    packages: Record<string, { files: { file: string; testCases: unknown[] }[] }>;
+  };
+  for (const entry of manifest.packages.activesupport?.files ?? []) {
+    counts.set(entry.file, (counts.get(entry.file) ?? 0) + entry.testCases.length);
+  }
+  return counts;
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const check = args.includes("--check");
+  const target = args.find((arg) => !arg.startsWith("--"));
+
+  const partition = await partitionActivesupportTests();
+  const problems = tableProblems(partition);
+
+  if (target !== undefined) {
+    const verdict = classifyTestFile(target, partition.closureFiles);
+    const listedOut = OUT_OF_CLOSURE_TEST_FILES.includes(target);
+    if (!verdict.inClosure && !listedOut) {
+      process.stdout.write(`${target}: UNCLASSIFIED — not derived, not aliased, not listed out\n`);
+      process.exit(1);
+    }
+    process.stdout.write(
+      verdict.inClosure
+        ? `${target}: IN closure (${verdict.rule}) → ${verdict.closureFile}\n`
+        : `${target}: OUT of closure (listed)\n`,
+    );
+    return;
+  }
+
+  const counts = await railsTestCounts();
+  const tests = (files: { testFile: string }[]) =>
+    files.reduce((sum, f) => sum + (counts.get(f.testFile) ?? 0), 0);
+
+  if (!check) {
+    for (const verdict of partition.inClosure) {
+      process.stdout.write(`  IN  ${(verdict.rule ?? "").padEnd(5)} ${verdict.testFile}\n`);
+    }
+    for (const verdict of partition.outOfClosure) {
+      process.stdout.write(`  OUT       ${verdict.testFile}\n`);
+    }
+    const seen =
+      counts.size > 0 ? "" : " (run `pnpm parity:test -- --package activesupport` for test counts)";
+    process.stdout.write(
+      `\nAR closure: ${partition.closureFiles.length} activesupport lib files\n` +
+        `  in closure:  ${partition.inClosure.length} test files, ${tests(partition.inClosure)} Rails tests\n` +
+        `  out:         ${partition.outOfClosure.length} test files, ${tests(partition.outOfClosure)} Rails tests${seen}\n`,
+    );
+  }
+
+  if (problems.length > 0) {
+    process.stdout.write(`\nAR-closure manifest guard FAILED:\n  ${problems.join("\n  ")}\n`);
+    process.exit(1);
+  }
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(`${String(error)}\n`);
+  process.exit(1);
+});

--- a/scripts/test-compare/closure-manifest.test.ts
+++ b/scripts/test-compare/closure-manifest.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+
+import { CLOSURE_ALIASES, OUT_OF_CLOSURE_TEST_FILES } from "./closure-aliases.js";
+import {
+  classifyTestFile,
+  stemVariants,
+  tableProblems,
+  type ClosurePartition,
+} from "./closure-manifest.js";
+
+// A stand-in closure, spelled the way closureFiles() reports one.
+const FILES = [
+  "active_support/core_ext/numeric.rb",
+  "active_support/core_ext/hash/deep_merge.rb",
+  "active_support/core_ext/hash/keys.rb",
+  "active_support/values/time_zone.rb",
+];
+
+describe("classifyTestFile", () => {
+  it("R1 matches a test path that names a closure file", () => {
+    expect(classifyTestFile("core_ext/numeric_ext_test.rb", FILES)).toEqual({
+      testFile: "core_ext/numeric_ext_test.rb",
+      inClosure: true,
+      rule: "R1",
+      closureFile: "active_support/core_ext/numeric.rb",
+    });
+  });
+
+  it("R2 matches a test path that names a closure directory", () => {
+    expect(classifyTestFile("core_ext/hash_ext_test.rb", FILES)).toEqual({
+      testFile: "core_ext/hash_ext_test.rb",
+      inClosure: true,
+      rule: "R2",
+      closureFile: "active_support/core_ext/hash/deep_merge.rb",
+    });
+  });
+
+  it("an alias row covers a test path R1/R2 cannot reach", () => {
+    expect(classifyTestFile("time_zone_test.rb", FILES)).toEqual({
+      testFile: "time_zone_test.rb",
+      inClosure: true,
+      rule: "alias",
+      closureFile: "active_support/values/time_zone.rb",
+    });
+  });
+
+  it("anything else is out of the closure", () => {
+    expect(classifyTestFile("cache/cache_key_test.rb", FILES)).toEqual({
+      testFile: "cache/cache_key_test.rb",
+      inClosure: false,
+    });
+  });
+
+  it("stemVariants offers the path, its _ext-stripped and pluralized forms", () => {
+    expect(stemVariants("core_ext/numeric_ext_test.rb")).toEqual([
+      "core_ext/numeric_ext",
+      "core_ext/numeric",
+      "core_ext/numeric_exts",
+      "core_ext/numerics",
+    ]);
+  });
+});
+
+function partition(overrides: Partial<ClosurePartition> = {}): ClosurePartition {
+  return {
+    closureFiles: [...FILES, ...CLOSURE_ALIASES.map((alias) => alias.closureFile)],
+    inClosure: [],
+    outOfClosure: [],
+    staleOutOfClosure: [],
+    unclassified: [],
+    ...overrides,
+  };
+}
+
+describe("the AR-closure manifest guard", () => {
+  it("fails on a vendored test file that is neither derived, aliased nor listed", () => {
+    const problems = tableProblems(partition({ unclassified: ["brand_new_test.rb"] }));
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("brand_new_test.rb");
+  });
+
+  it("fails on an out-of-closure entry Rails no longer ships", () => {
+    const problems = tableProblems(partition({ staleOutOfClosure: ["gone_test.rb"] }));
+    expect(problems).toEqual([
+      "gone_test.rb is listed out-of-closure but no longer exists under the Rails test tree.",
+    ]);
+  });
+
+  it("passes on a consistent partition", () => {
+    expect(tableProblems(partition())).toEqual([]);
+  });
+
+  it("no alias is also listed as out-of-closure", () => {
+    for (const alias of CLOSURE_ALIASES) {
+      expect(OUT_OF_CLOSURE_TEST_FILES).not.toContain(alias.testFile);
+    }
+  });
+});

--- a/scripts/test-compare/closure-manifest.ts
+++ b/scripts/test-compare/closure-manifest.ts
@@ -16,7 +16,7 @@
  *             `core_ext/numeric_ext_test.rb` → `core_ext/numeric.rb`
  *   R2 dir  — the same stem names a directory holding at least one closure file.
  *             `core_ext/hash_ext_test.rb` → `core_ext/hash/*`
- *   alias   — CLOSURE_ALIASES in ./aliases.ts, one reviewed reason per row.
+ *   alias   — CLOSURE_ALIASES in ./closure-aliases.ts, one reviewed reason per row.
  *
  * This is a manifest, not an exclusion registry: it removes nothing from any
  * denominator and touches no baseline.
@@ -58,7 +58,7 @@ export interface ClosurePartition {
  * them.
  */
 export function closureFiles(): string[] {
-  return deriveArClosure().files.activesupport.map((file) => `active_support/${file}`);
+  return (deriveArClosure().files.activesupport ?? []).map((file) => `active_support/${file}`);
 }
 
 /**

--- a/scripts/test-compare/closure-manifest.ts
+++ b/scripts/test-compare/closure-manifest.ts
@@ -1,0 +1,163 @@
+/**
+ * The AR-closure activesupport TEST manifest: which Rails activesupport test
+ * files cover the part of activesupport that activerecord + activemodel
+ * actually depend on.
+ *
+ * The *member* closure already exists and is derived at run time by
+ * `scripts/api-compare/ar-closure.ts` (RFC 0098) — a transitive walk of
+ * `require "…"` from `activerecord/lib` + `activemodel/lib`. This module is
+ * the same closure expressed as a test-file boundary, because
+ * `vendor/rails/activesupport/test/` is organized by feature, not by consumer.
+ *
+ * The boundary is two derived rules plus a reviewed table:
+ *
+ *   R1 path — the test path minus `_test.rb` (plus its `_ext`-stripped and
+ *             pluralized variants) names a closure file.
+ *             `core_ext/numeric_ext_test.rb` → `core_ext/numeric.rb`
+ *   R2 dir  — the same stem names a directory holding at least one closure file.
+ *             `core_ext/hash_ext_test.rb` → `core_ext/hash/*`
+ *   alias   — CLOSURE_ALIASES in ./aliases.ts, one reviewed reason per row.
+ *
+ * This is a manifest, not an exclusion registry: it removes nothing from any
+ * denominator and touches no baseline.
+ */
+
+import { readdir } from "node:fs/promises";
+import { join, relative } from "node:path";
+
+import { deriveArClosure } from "../api-compare/ar-closure.js";
+import { testPathsManifest } from "../../vendor/sources.js";
+import { CLOSURE_ALIASES, OUT_OF_CLOSURE_TEST_FILES } from "./closure-aliases.js";
+
+export type ClosureRule = "R1" | "R2" | "alias";
+
+export interface ClosureVerdict {
+  testFile: string;
+  inClosure: boolean;
+  /** Which rule put it in the closure; undefined when it is out. */
+  rule?: ClosureRule;
+  /** The closure file it maps onto, `active_support/…`; undefined when out. */
+  closureFile?: string;
+}
+
+export interface ClosurePartition {
+  /** Closure files as `active_support/….rb`, derived on every run. */
+  closureFiles: string[];
+  inClosure: ClosureVerdict[];
+  outOfClosure: ClosureVerdict[];
+  /** Files listed as out-of-closure that no longer exist under the test tree. */
+  staleOutOfClosure: string[];
+  /** Files that are neither derived, nor aliased, nor explicitly listed out. */
+  unclassified: string[];
+}
+
+/**
+ * The closure as `active_support/….rb` paths. `deriveArClosure` reports them
+ * relative to the package root (`values/time_zone.rb`); the `active_support/`
+ * prefix is how Rails' own `require` lines — and so the alias table — spell
+ * them.
+ */
+export function closureFiles(): string[] {
+  return deriveArClosure().files.activesupport.map((file) => `active_support/${file}`);
+}
+
+/**
+ * The stem variants R1/R2 try: the test path itself, the same path with a
+ * trailing `_ext` stripped (`numeric_ext` → `numeric`), and the pluralized
+ * form of each (`core_ext/hash/key` → `keys`).
+ */
+export function stemVariants(testFile: string): string[] {
+  const stem = testFile.replace(/_test\.rb$/, "");
+  const segments = stem.split("/");
+  const last = segments[segments.length - 1];
+  const variants = new Set<string>([stem]);
+  if (last.endsWith("_ext")) {
+    variants.add([...segments.slice(0, -1), last.slice(0, -"_ext".length)].join("/"));
+  }
+  for (const variant of [...variants]) variants.add(`${variant}s`);
+  return [...variants];
+}
+
+export function classifyTestFile(testFile: string, files: readonly string[]): ClosureVerdict {
+  for (const stem of stemVariants(testFile)) {
+    const path = `active_support/${stem}.rb`;
+    if (files.includes(path)) return { testFile, inClosure: true, rule: "R1", closureFile: path };
+  }
+  for (const stem of stemVariants(testFile)) {
+    const dir = `active_support/${stem}/`;
+    const hit = files.find((file) => file.startsWith(dir));
+    if (hit) return { testFile, inClosure: true, rule: "R2", closureFile: hit };
+  }
+  const alias = CLOSURE_ALIASES.find((entry) => entry.testFile === testFile);
+  if (alias) {
+    return { testFile, inClosure: true, rule: "alias", closureFile: alias.closureFile };
+  }
+  return { testFile, inClosure: false };
+}
+
+async function railsTestFiles(dir: string, root: string): Promise<string[]> {
+  const out: string[] = [];
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...(await railsTestFiles(path, root)));
+    else if (entry.name.endsWith("_test.rb")) out.push(relative(root, path));
+  }
+  return out;
+}
+
+export async function partitionActivesupportTests(): Promise<ClosurePartition> {
+  const files = closureFiles();
+  const root = testPathsManifest().activesupport;
+  const testFiles = (await railsTestFiles(root, root)).sort();
+
+  const inClosure: ClosureVerdict[] = [];
+  const outOfClosure: ClosureVerdict[] = [];
+  const unclassified: string[] = [];
+  for (const testFile of testFiles) {
+    const verdict = classifyTestFile(testFile, files);
+    if (verdict.inClosure) inClosure.push(verdict);
+    else if (OUT_OF_CLOSURE_TEST_FILES.includes(testFile)) outOfClosure.push(verdict);
+    else unclassified.push(testFile);
+  }
+
+  const present = new Set(testFiles);
+  const staleOutOfClosure = OUT_OF_CLOSURE_TEST_FILES.filter((file) => !present.has(file));
+
+  return { closureFiles: files, inClosure, outOfClosure, staleOutOfClosure, unclassified };
+}
+
+/** Contradictions in the checked-in tables themselves. */
+export function tableProblems(partition: ClosurePartition): string[] {
+  const problems: string[] = [];
+  for (const file of partition.unclassified) {
+    problems.push(
+      `${file} is neither derived by R1/R2 nor aliased nor listed out-of-closure. ` +
+        "Add a CLOSURE_ALIASES row (with the closure file it covers) or an " +
+        "OUT_OF_CLOSURE_TEST_FILES entry in scripts/test-compare/closure-aliases.ts.",
+    );
+  }
+  for (const file of partition.staleOutOfClosure) {
+    problems.push(
+      `${file} is listed out-of-closure but no longer exists under the Rails test tree.`,
+    );
+  }
+  for (const alias of CLOSURE_ALIASES) {
+    if (OUT_OF_CLOSURE_TEST_FILES.includes(alias.testFile)) {
+      problems.push(
+        `${alias.testFile} is both aliased into the closure and listed out-of-closure.`,
+      );
+    }
+    if (!partition.closureFiles.includes(alias.closureFile)) {
+      problems.push(
+        `${alias.testFile} aliases ${alias.closureFile}, which is not in the AR closure.`,
+      );
+    }
+  }
+  return problems;
+}


### PR DESCRIPTION
RFC 0105 wave-1 boundary work — three related stories, one PR.

## 1. `derive-ar-closure-test-manifest`

`pnpm parity:test:closure [<test file>] [--check]` answers "is this
activesupport test file inside the AR dependency closure?" mechanically.

The *member* closure already exists and is derived at run time by
`scripts/api-compare/ar-closure.ts` (RFC 0098) — the transitive `require` walk
from `activerecord/lib` + `activemodel/lib`; this reuses it rather than
re-deriving (143 activesupport lib files). The new part is the mapping onto
Rails' feature-organized test tree:

- **R1 path** — the test path minus `_test.rb` (plus `_ext`-stripped and
  pluralized variants) names a closure file.
- **R2 dir** — the same stem names a directory holding a closure file.
- **alias** — `CLOSURE_ALIASES` in `scripts/test-compare/closure-aliases.ts`,
  seven reviewed rows with the closure file each covers. The RFC's third rule
  (basename match) is *not* shipped: it misfires
  (`core_ext/pathname/blank_test.rb` → `core_ext/date/blank.rb`).

Partition, from `pnpm parity:test:closure`:

```
AR closure: 143 activesupport lib files
  in closure:  70 test files, 1798 Rails tests
  out:         93 test files, 1064 Rails tests
```

`--check` is the guard, wired into the `Rails API/Test Comparison` job: it
fails when a file under `vendor/rails/activesupport/test/` is neither derived
nor aliased nor listed in `OUT_OF_CLOSURE_TEST_FILES`, and when the tables
contradict themselves (an alias that is also listed out, an alias naming a
non-closure file, a listed file Rails no longer ships). A vendor bump cannot
land a new Rails test file silently on either side.

This is a manifest, not an exclusion registry: no baseline, no denominator and
no `percent` moves for it.

## 2. `exclude-migration-compatibility-tests-as-wont-do`

One activerecord-scoped, anchored `testFile` row for
`migration/compatibility_test.rb`, citing PR #5070 (a complete, CI-green
`Migration[6.1]` / `Compatibility::V6_1`, closed unmerged 2026-07-22 — "the
premise of this pr is not the goal of trails") and RFC 0030's closed
`c1-schema-dumper-migration-version-compat`. The source side was already
excluded by the existing `migration/compatibility` pattern.

`pnpm parity:test -- --package activerecord`, before → after:

| | before | after |
| --- | ---: | ---: |
| tests | 8232/8407 (97.9%) | **8232/8350 (98.6%)** |
| files | 336/345 | 336/344 |

Denominator −57 exactly, numerator unchanged, no other file's counts move.

## 3. `anchor-fixtures-source-pattern`

`pattern: "fixtures.rb"` → `"/fixtures.rb"`. Unanchored it also matched
`test_fixtures.rb` and `encryption/encrypted_fixtures.rb` (both of which carry
their own rows) and `activesupport/testing/file_fixtures.rb` (which does not).
`baseline.json`'s copy of the row is updated in the same commit, by hand, as
its only-shrink contract requires.

Lifting the shadow makes `activesupport/testing/file_fixtures.rb` visible on
the api-compare source axis. `pnpm parity:api`, before → after:

| | before | after |
| --- | ---: | ---: |
| activesupport | 1517/2000 (75.9%), files 170/199 | 1517/**2011** (75.4%), files 170/**200** |
| overall | 13101/15333, files 883/1051 | 13101/**15344**, files 883/**1052** |

Numerators are unchanged (non-negative); the 11 newly visible members are
`ActiveSupport::Testing::FileFixtures` — reported here rather than re-hidden,
per the story. activerecord is unaffected (`activerecord/fixtures.rb` still
matches the anchored pattern).

**Source-axis sweep** over every `pattern` in `scripts/parity/unported-files/*`
against the vendored lib trees — six rows match more than one file. Five are
deliberate and their reasons already cover every file they match
(`tests/`, `fixture_set`, `adapters/trilogy`, `gettext` are directory-prefix
bulk exclusions; `starts_ends_with.rb` names String *and* Symbol;
`message_pack.rb` names both AR's and AS's; `/version.rb` is already anchored
and intentionally cross-package). One is a genuine shadow and is filed rather
than fixed here, to keep this PR to its story: did-you-mean's `formatter.rb`
swallows `formatters/plain_formatter.rb` and `formatters/verbose_formatter.rb`
→ story `anchor-did-you-mean-formatter-source-pattern` (RFC 0105).

## Tests

`scripts/test-compare/closure-manifest.test.ts` covers R1, R2, an alias hit,
the out-of-closure fall-through, `stemVariants`, and both guard failure modes
(an unclassified vendored file, a stale out-of-closure entry).

Closes-story: derive-ar-closure-test-manifest
Closes-story: exclude-migration-compatibility-tests-as-wont-do
Closes-story: anchor-fixtures-source-pattern
