### PR TITLE
feat(parity): measure assertion parity for the whole in-scope closure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -267,7 +267,8 @@ takes every future test in that file out of the denominator too.
 
 For an activesupport file, whether it is in the AR closure at all is a separate
 question from whether it is ported: `pnpm parity:test:closure [<test file>]`
-prints in/out (RFC 0105, `derive-ar-closure-test-manifest`). Out-of-closure is
+prints in/out — the command ships with RFC 0105's
+`derive-ar-closure-test-manifest` story. Out-of-closure is
 not a licence to add an `unported-files` row — it changes which denominator the
 file belongs to, not whether the surface exists.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -221,6 +221,56 @@ and exits 0; the arm closes itself the moment the first row lands, and it cannot
 swallow a converged dimension (nothing baselined AND nothing flagged is a real
 green).
 
+### What 100% test compare means
+
+"100% on `parity:test`" is **name parity _and_ assertion parity, with
+`skipped = 0`** — all three, per package. A package whose names all match but
+whose assertion counters are non-zero is not done: the matched tests assert
+something other than what Rails asserts. Since RFC 0105 the assertion counters
+are measured for the whole in-scope closure (`ASSERTION_REPORT_PACKAGES` in
+`scripts/test-compare/compare.ts`), so the number means the same thing for
+activesupport, activemodel, arel, date, i18n, globalid and did-you-mean as it
+does for activerecord; before that widening a 100% claim outside activerecord
+was strictly the weaker claim, because nothing about its assertions was
+measured at all.
+
+Two things that look like a pass and are not:
+
+- **A `pending` / `it.skip` stub.** It counts as matched-and-skipped and
+  subtracts from the implemented total (`compare.ts:1196`, `matched -
+matchedSkipped`), so a file full
+  of stubs cannot reach 100%. Stubs are scaffolding for a port, never its end
+  state.
+- **A whole-file `unported-files` row written because "users won't use this."**
+  The only admissible reason for a new row is that **the trails surface does not
+  exist and is not intended to**. The test is about the surface, not about
+  demand for it.
+
+The two worked examples:
+
+- **Admissible** — `migration/compatibility_test.rb`: `Migration[7.0]` version
+  compatibility is a Rails surface trails deliberately does not ship (PR #5070,
+  closed unmerged). No surface, no denominator.
+- **Not admissible** — the `fixtures.rb` / `fixture_set` / `test_fixtures.rb`
+  rows (`scripts/parity/unported-files/unscoped.ts:77-99`, 172 AR tests), whose
+  reason is that "Trails users won't ship YAML fixtures". The surface exists:
+  `packages/activerecord/src/fixtures.ts` ships, and [CLAUDE.md](CLAUDE.md)
+  names `fixtures({ … })` the canonical test surface. The row went stale and the
+  tests stayed out of the denominator anyway. That is the failure mode this
+  section exists to prevent — the registry grew from 18 entries in May 2026 to
+  ~200 in August (`docs/infrastructure/parity-convergence-forecast.md`, Part 1).
+
+When a _specific_ Rails case is genuinely unportable — it exercises a Ruby-only
+mechanism inside an otherwise ported file — exclude that case with a
+case-level `tests:` entry and a reason, never a whole-file row. A whole-file row
+takes every future test in that file out of the denominator too.
+
+For an activesupport file, whether it is in the AR closure at all is a separate
+question from whether it is ported: `pnpm parity:test:closure [<test file>]`
+prints in/out (RFC 0105, `derive-ar-closure-test-manifest`). Out-of-closure is
+not a licence to add an `unported-files` row — it changes which denominator the
+file belongs to, not whether the surface exists.
+
 ### Assertion-mismatch ratchet
 
 `pnpm parity:test` measures three assertion-level divergences _inside_

--- a/scripts/test-compare/assertion-mismatch-mark.json
+++ b/scripts/test-compare/assertion-mismatch-mark.json
@@ -21,44 +21,44 @@
       "value": 0
     },
     "activemodel": {
-      "assertionCount": 0,
-      "kind": 0,
-      "value": 0
+      "assertionCount": 473,
+      "kind": 707,
+      "value": 96
     },
     "activerecord": {
-      "assertionCount": 1987,
-      "kind": 4069,
-      "value": 54
+      "assertionCount": 1977,
+      "kind": 4066,
+      "value": 49
     },
     "activesupport": {
-      "assertionCount": 0,
-      "kind": 0,
-      "value": 0
+      "assertionCount": 1090,
+      "kind": 1505,
+      "value": 139
     },
     "arel": {
-      "assertionCount": 0,
-      "kind": 0,
-      "value": 0
+      "assertionCount": 180,
+      "kind": 591,
+      "value": 17
     },
     "date": {
-      "assertionCount": 0,
-      "kind": 0,
-      "value": 0
+      "assertionCount": 21,
+      "kind": 31,
+      "value": 1
     },
     "did-you-mean": {
-      "assertionCount": 0,
-      "kind": 0,
+      "assertionCount": 1,
+      "kind": 2,
       "value": 0
     },
     "globalid": {
-      "assertionCount": 0,
-      "kind": 0,
-      "value": 0
+      "assertionCount": 53,
+      "kind": 71,
+      "value": 2
     },
     "i18n": {
-      "assertionCount": 0,
-      "kind": 0,
-      "value": 0
+      "assertionCount": 18,
+      "kind": 32,
+      "value": 6
     },
     "rack": {
       "assertionCount": 0,

--- a/scripts/test-compare/compare.ts
+++ b/scripts/test-compare/compare.ts
@@ -40,8 +40,8 @@
  *                 --gates so the CI log carries the per-test breakdown too.
  *   --assertions  Print the assertion-count-mismatch report — matched,
  *                 implemented tests whose trails port has a different assertion-
- *                 call count than its Rails counterpart. Scoped to activerecord
- *                 for now (see ASSERTION_REPORT_PACKAGES); other packages never
+ *                 call count than its Rails counterpart. Scoped to the in-scope
+ *                 closure (see ASSERTION_REPORT_PACKAGES); other packages never
  *                 contribute the metric. Report-only: no CI gate, no exclude.json.
  *                 Prints per-file counts by default; add --missing for per-test
  *                 `rails N vs trails M` detail. The same section also reports
@@ -73,11 +73,20 @@ import { testPathsManifest } from "../../vendor/sources.js";
 const SCRIPT_DIR = __dirname;
 const OUTPUT_DIR = path.join(SCRIPT_DIR, "output");
 
-// Packages the assertion-count comparison is reported for. Scoped to
-// activerecord for now (RFC follow-up may widen it): both extractors populate
-// `assertionCount` everywhere, but we only surface the mismatch metric (summary
-// tokens, `--assertions` section, JSON) here so it can't leak into other totals.
-const ASSERTION_REPORT_PACKAGES = new Set(["activerecord"]);
+// Packages the assertion-count comparison is reported for: the full in-scope
+// closure of RFC 0105. A 100% name-parity claim for a package outside this set
+// would be a strictly weaker claim than the same number for one inside it,
+// because nothing about its assertions is measured at all.
+const ASSERTION_REPORT_PACKAGES = new Set([
+  "activerecord",
+  "activesupport",
+  "activemodel",
+  "date",
+  "i18n",
+  "arel",
+  "globalid",
+  "did-you-mean",
+]);
 
 export const GATE_ENFORCED_PACKAGES = new Set(["activerecord"]);
 


### PR DESCRIPTION
Widens the assertion-parity report axis from `activerecord` alone to the full
RFC 0105 in-scope closure, seeds the mark at the measured values so the ratchet
is only-shrink from the first run, and writes down what "100% test compare"
means in CONTRIBUTING.md.

## Newly surfaced totals

`ASSERTION_REPORT_PACKAGES` now covers activerecord, activesupport, activemodel,
date, i18n, arel, globalid and did-you-mean. Everything below was already
computed by both extractors and simply never surfaced:

| package | count | kind | value |
| --- | ---: | ---: | ---: |
| activesupport | 1090 | 1505 | 139 |
| activemodel | 473 | 707 | 96 |
| arel | 180 | 591 | 17 |
| globalid | 53 | 71 | 2 |
| date | 21 | 31 | 1 |
| i18n | 18 | 32 | 6 |
| did-you-mean | 1 | 2 | 0 |
| **new total** | **1836** | **2939** | **261** |
| activerecord (unchanged axis, refreshed) | 1977 | 4066 | 49 |

That is **5,036 newly measured divergences** across the three axes — below the
"low thousands" the story budgeted per axis, because the non-AR closure's
density is well under activerecord's. Burning them down is the follow-on work,
not this PR.

Seeding note: the prior mark carried literal `0`s for the unmeasured packages,
and `nextMark` is min-only, so a plain reseed would have clamped every new
package back to 0. Those seven placeholder rows were removed first, then the
mark reseeded from the fresh artifact — activerecord's row went through the
normal min path and moved only downward (1987→1977, 4069→4066, 54→49).
`pnpm parity:test:assertions` is green on the first run. No `percent` moves:
this is a report axis, not a gate axis.

## Docs

New "What 100% test compare means" section in CONTRIBUTING.md: name parity **and**
assertion parity **and** `skipped = 0`; a `pending`/`it.skip` stub is not a pass
(it subtracts at `compare.ts:1196`); the single admissible reason for a new
`unported-files` row is that the trails surface does not exist and is not
intended to. Both worked examples are cited — `migration/compatibility_test.rb`
(admissible, PR #5070) and the `fixtures.rb` rows
(`scripts/parity/unported-files/unscoped.ts:77-99`, 172 AR tests, not
admissible: `packages/activerecord/src/fixtures.ts` ships). Points at
`pnpm parity:test:closure` for the activesupport in/out question.

Closes-story: widen-assertion-report-packages-and-seed-mark
Closes-story: document-the-100-percent-definition-in-contributing
