### PR TITLE
fix(activesupport): blank?'s Time arm covers trails' Temporal times

### DIFF
--- a/packages/activesupport/src/core-ext/object/blank.test.ts
+++ b/packages/activesupport/src/core-ext/object/blank.test.ts
@@ -6,7 +6,7 @@ import { isBlank, isPresent, presence, TimeWithZone, TimeZone } from "../../inde
 // trails analogue is the whole Temporal family plus `TimeWithZone`.
 const NOW = new Temporal.Instant(1_700_000_000_000_000_000n);
 const TIMES = [
-  new Date(),
+  new Date(NOW.epochMilliseconds),
   new TimeWithZone(NOW, TimeZone.create("UTC")),
   NOW,
   NOW.toZonedDateTimeISO("UTC"),

--- a/packages/activesupport/src/core-ext/object/blank.test.ts
+++ b/packages/activesupport/src/core-ext/object/blank.test.ts
@@ -1,5 +1,19 @@
 import { describe, expect, it } from "vitest";
-import { isBlank, isPresent, presence } from "../../index.js";
+import { Temporal } from "@blazetrails/date";
+import { isBlank, isPresent, presence, TimeWithZone, TimeZone } from "../../index.js";
+
+// blank_test.rb's NOT list carries `Time.now`; Ruby has one Time class, so the
+// trails analogue is the whole Temporal family plus `TimeWithZone`.
+const NOW = new Temporal.Instant(1_700_000_000_000_000_000n);
+const TIMES = [
+  new Date(),
+  new TimeWithZone(NOW, TimeZone.create("UTC")),
+  NOW,
+  NOW.toZonedDateTimeISO("UTC"),
+  Temporal.PlainDate.from("2026-08-13"),
+  Temporal.PlainDateTime.from("2026-08-13T12:00:00"),
+  Temporal.PlainTime.from("12:00:00"),
+];
 
 describe("BlankTest", () => {
   it("blank", () => {
@@ -13,6 +27,7 @@ describe("BlankTest", () => {
     expect(isBlank(0)).toBe(false);
     expect(isBlank("hello")).toBe(false);
     expect(isBlank([1])).toBe(false);
+    for (const v of TIMES) expect(isBlank(v)).toBe(false);
   });
 
   it("blank with bundled string encodings", () => {
@@ -26,6 +41,7 @@ describe("BlankTest", () => {
     expect(isPresent(42)).toBe(true);
     expect(isPresent(null)).toBe(false);
     expect(isPresent("")).toBe(false);
+    for (const v of TIMES) expect(isPresent(v)).toBe(true);
   });
 
   it("presence", () => {
@@ -33,5 +49,6 @@ describe("BlankTest", () => {
     expect(presence("")).toBeUndefined();
     expect(presence(null)).toBeUndefined();
     expect(presence(42)).toBe(42);
+    for (const v of TIMES) expect(presence(v)).toBe(v);
   });
 });

--- a/packages/activesupport/src/core-ext/object/blank.ts
+++ b/packages/activesupport/src/core-ext/object/blank.ts
@@ -13,6 +13,9 @@
  * blank.rb:167-169) are one expression each, applied inline at the switch.
  */
 
+import { Temporal } from "@blazetrails/date";
+import { TimeWithZone } from "../../time-with-zone.js";
+
 const BLANK_RE = /^\s*$/;
 
 function isAsyncFunction(fn: object): boolean {
@@ -22,6 +25,25 @@ function isAsyncFunction(fn: object): boolean {
 function isThenable(v: unknown): v is PromiseLike<unknown> {
   return typeof (v as { then?: unknown } | null | undefined)?.then === "function";
 }
+
+/**
+ * The values `blank?` reaches Ruby's `Time` arm (blank.rb:182-184) through.
+ * Ruby has one `Time` class; trails' Time analogue is Temporal, so the arm is
+ * typed on the whole family plus `TimeWithZone` — the same widening
+ * `core-ext/object/json.ts` applies to `Time#as_json`. `Temporal.PlainDate` /
+ * `PlainDateTime` stand for Ruby's `Date` / `DateTime`, which blank.rb does not
+ * reopen; they are `false` in Ruby through `Object#blank?`, which the object
+ * arm below cannot reproduce because it is trails' `Hash` arm and reports a
+ * slot-only Temporal value as empty.
+ */
+type TimeValue =
+  | Date
+  | TimeWithZone
+  | Temporal.Instant
+  | Temporal.ZonedDateTime
+  | Temporal.PlainDate
+  | Temporal.PlainDateTime
+  | Temporal.PlainTime;
 
 export class NilClass {
   static isBlank(_value: null | undefined): true {
@@ -72,10 +94,10 @@ export class String {
 }
 
 export class Time {
-  static isBlank(_value: Date): false {
+  static isBlank(_value: TimeValue): false {
     return false;
   }
-  static isPresent(_value: Date): true {
+  static isPresent(_value: TimeValue): true {
     return true;
   }
 }
@@ -85,9 +107,9 @@ export class Time {
  * overrides, dispatched on the value class in blank.rb's own order: `NilClass`
  * (:56), `FalseClass` (:69), `TrueClass` (:82), `Array` (:96), `Hash` (:111),
  * `Symbol` (:120), `String` (:145-153), `Numeric` (:167-169), `Time`
- * (:182-184). `Array`, `Hash` and `Numeric` get no class of their own here:
- * their arms are `alias_method :blank?, :empty?` and a bare `false`, applied at
- * the switch.
+ * (:182-184, over the whole {@link TimeValue} family). `Array`, `Hash` and
+ * `Numeric` get no class of their own here: their arms are
+ * `alias_method :blank?, :empty?` and a bare `false`, applied at the switch.
  *
  * A Ruby Symbol is a JS string, so the `Symbol` arm is reached only by a
  * genuine JS `symbol`; the string spelling falls through to `String`.
@@ -125,8 +147,17 @@ export function isBlank(value: unknown): boolean {
   if (typeof value === "symbol") return Symbol.isBlank(value);
   if (typeof value === "string") return String.isBlank(value);
   if (typeof value === "number" || typeof value === "bigint") return false;
-  // boundary: the `Time` arm is typed on the JS `Date` this dispatches to.
-  if (value instanceof Date) return Time.isBlank(value);
+  // boundary: a JS `Date` is one of the `TimeValue`s this arm answers for.
+  if (
+    value instanceof Date ||
+    value instanceof TimeWithZone ||
+    value instanceof Temporal.Instant ||
+    value instanceof Temporal.ZonedDateTime ||
+    value instanceof Temporal.PlainDate ||
+    value instanceof Temporal.PlainDateTime ||
+    value instanceof Temporal.PlainTime
+  )
+    return Time.isBlank(value);
   if (value instanceof Set || value instanceof Map) return value.size === 0;
   const empty = (value as { isEmpty?: unknown }).isEmpty ?? (value as { empty?: unknown }).empty;
   if (typeof empty === "boolean") return empty;


### PR DESCRIPTION
`vendor/rails/activesupport/lib/active_support/core_ext/object/blank.rb:182-184`
reopens `Time` so no Time is ever blank:

```ruby
class Time # :nodoc:
  def blank?
    false
  end
end
```

`core-ext/object/blank.ts` routed only `value instanceof Date` to that arm, so
trails' actual Time analogues — `Temporal.Instant` / `ZonedDateTime` /
`PlainDate` / `PlainDateTime` / `PlainTime`, and `TimeWithZone`
(`time-with-zone.ts:91`) — fell through to the object arm, where
`Object.keys(value).length === 0` (trails' `Hash` arm) reported them BLANK.
Temporal values keep their state in internal slots, so `Object.keys` on one is
genuinely `0` — verified. `TimeWithZone` was non-blank only by accident, off
its two own fields.

The `Time` arm is now typed on that whole family, the same widening
`core-ext/object/json.ts` already applies to `Time#as_json`
(`json.ts:220`, `:241`, `:256`). `Temporal.PlainDate` / `PlainDateTime` stand
for Ruby's `Date` / `DateTime`, which blank.rb does not reopen — they are
`false` in Ruby through `Object#blank?`, which trails' object arm cannot
reproduce because it doubles as the `Hash` arm.

`blank_test.rb:20`'s `NOT` list carries `Time.now`; the port's `blank` /
`present` / `presence` tests now carry the trails analogues of it. No test
names changed.

## Not in this PR

The other two bundled stories are blocked, both on unported prerequisites
rather than on anything in this diff:

- **`drop-builder-association-scope-option-shim`** — blocked on
  `test-files-scope-positional-sweep` (ready, unclaimed), exactly as the story
  file already stated. Dropping `"scope"` from
  `Builder::Association.VALID_OPTIONS` (`association.rb:20-22`) makes
  `assertValidKeys` raise `Unknown key: :scope` for the **71** options-bag
  `scope:` declarations still live across 24 AR test files
  (`grep -rn 'scope: (' packages/activerecord/src --include=*.ts | grep -v test-helpers/models`).
  PR #6502 swept only `test-helpers/models`.
- **`port-rails-plugin-reporter-blocks`** — `rails_plugin.rb:122-135` operates
  on `Minitest.reporter` (a `CompositeReporter`) and names `SummaryReporter`,
  `ProgressReporter`, `SuppressedSummaryReporter` (:21-26), `ProfileReporter`
  (:28-65) and `Rails::TestUnitReporter`
  (`rails/test_unit/reporter.rb`, 121 lines). None exist in trails. Porting
  that stack is far past the story's 220 LOC and strictly ordered, so it is
  filed as `port-minitest-reporter-surface` (RFC 0098) and this story is
  blocked on it.

Both carry the finding in `pnpm tasks block`, so neither closes here.

## Gates

- `pnpm parity:api:calls` — OK (1649 baselined), `pnpm parity:api:calls:args` — OK (241 shape rows). No rows added.
- `pnpm parity:api:extra --package activesupport` — `blank.ts` 0 novel.
- `pnpm typecheck` clean; built-`dist` node import of both `blank.js` and
  `time-with-zone.js` as entry modules confirms the new import closes no cycle.
- `blank.test.ts` green (4/4).

Closes-story: blank-time-arm-covers-temporal
