### PR TITLE
refactor(activerecord): pass association scopes positionally in test files

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/uuid.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/uuid.test.ts
@@ -978,10 +978,9 @@ describeIfPg("PostgreSQLAdapter", () => {
           this.attribute("id", "uuid");
           // Rails: has_many :uuid_posts, -> { order("title DESC") } — the
           // ordering scope exercises the delegate-cache path the test name calls out.
-          this.hasMany("uuidPosts", {
+          this.hasMany("uuidPosts", (rel: any) => rel.order("title DESC"), {
             className: "UuidPostDj",
             foreignKey: "uuid_forum_id",
-            scope: (rel: any) => rel.order("title DESC"),
           });
           this.hasMany("uuidComments", {
             className: "UuidCommentDj",

--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -1488,8 +1488,7 @@ describe("WithAnnotationsTest", () => {
     static {
       this.tableName = "pirates";
       this.belongsTo("parrot", { className: "Parrot", foreignKey: "parrot_id" });
-      this.belongsTo("parrotWithAnnotation", {
-        scope: (q: any) => q.annotate("that tells jokes"),
+      this.belongsTo("parrotWithAnnotation", (q: any) => q.annotate("that tells jokes"), {
         className: "Parrot",
         foreignKey: "parrot_id",
       });
@@ -1503,21 +1502,18 @@ describe("WithAnnotationsTest", () => {
         },
       );
       this.hasOne("ship", { className: "Ship", foreignKey: "pirate_id" });
-      this.hasOne("shipWithAnnotation", {
-        scope: (q: any) => q.annotate("that is a rocket"),
+      this.hasOne("shipWithAnnotation", (q: any) => q.annotate("that is a rocket"), {
         className: "Ship",
         foreignKey: "pirate_id",
       });
       this.hasMany("birds", { className: "Bird", foreignKey: "pirate_id" });
-      this.hasMany("birdsWithAnnotation", {
-        scope: (q: any) => q.annotate("that are also parrots"),
+      this.hasMany("birdsWithAnnotation", (q: any) => q.annotate("that are also parrots"), {
         className: "Bird",
         foreignKey: "pirate_id",
       });
       this.hasMany("treasures", { as: "looter" });
       this.hasMany("treasureEstimates", { through: "treasures", source: "priceEstimates" });
-      this.hasMany("treasureEstimatesWithAnnotation", {
-        scope: (q: any) => q.annotate("yarrr"),
+      this.hasMany("treasureEstimatesWithAnnotation", (q: any) => q.annotate("yarrr"), {
         through: "treasures",
         source: "priceEstimates",
       });

--- a/packages/activerecord/src/associations/association-scope.test.ts
+++ b/packages/activerecord/src/associations/association-scope.test.ts
@@ -296,11 +296,15 @@ describe("AssociationScope", () => {
     // scope (which is null here). Loader must still apply it. No reader form:
     // the caller-supplied `options.scope` IS the subject, and the generated
     // `author.posts` accessor can only pass the reflection's own options.
-    const results = await findTarget(author, "posts", {
-      className: "Post",
-      foreignKey: "author_id",
-      scope: (rel: any) => rel.where({ title: "published" }),
-    });
+    const results = await findTarget(
+      author,
+      "posts",
+      (rel: any) => rel.where({ title: "published" }),
+      {
+        className: "Post",
+        foreignKey: "author_id",
+      },
+    );
     expect(results).toHaveLength(1);
     expect((results[0] as any).title).toBe("published");
   });

--- a/packages/activerecord/src/associations/association-scope.test.ts
+++ b/packages/activerecord/src/associations/association-scope.test.ts
@@ -163,14 +163,18 @@ describe("AssociationScope", () => {
     }
     registerModel(CountAuthor);
     registerModel(CountPost);
-    Associations.hasMany.call(CountAuthor, "count_posts", {
-      className: "CountPost",
-      foreignKey: "count_author_id",
-      scope: (rel: any) => {
+    Associations.hasMany.call(
+      CountAuthor,
+      "count_posts",
+      (rel: any) => {
         calls++;
         return rel.where({ published: true });
       },
-    });
+      {
+        className: "CountPost",
+        foreignKey: "count_author_id",
+      },
+    );
 
     const author = new CountAuthor({ id: 5 });
     const reflection = (CountAuthor as any)._reflectOnAssociation("count_posts");
@@ -627,12 +631,11 @@ describe("AssociationScope", () => {
 
       static {
         this.attribute("id", "integer");
-        this.hasMany("cc_memberships", {
+        // Scope on the through reflection — chain.reverse_each must pick
+        // it up when AssociationScope walks the chain for cc_tags.
+        this.hasMany("cc_memberships", (rel: any) => rel.where({ active: true }), {
           className: "CcMembership",
           foreignKey: "cc_author_id",
-          // Scope on the through reflection — chain.reverse_each must pick
-          // it up when AssociationScope walks the chain for cc_tags.
-          scope: (rel: any) => rel.where({ active: true }),
         });
         this.hasMany("cc_tags", {
           className: "CcTag",

--- a/packages/activerecord/src/associations/collection-proxy-count.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy-count.test.ts
@@ -156,11 +156,15 @@ describe("CollectionProxy#count — non-through fast path", () => {
     // `!group_values.empty?` branch — load + count rows, not a scalar
     // COUNT(*). The `.select("title")` pairs with the GROUP BY so the loaded
     // SELECT is valid SQL (PostgreSQL rejects `SELECT *` under GROUP BY).
-    Associations.hasMany.call(CpcAuthor, "cpcPostsByTitle", {
-      className: "CpcPost",
-      foreignKey: "author_id",
-      scope: (rel: any) => rel.group("title").select("title"),
-    });
+    Associations.hasMany.call(
+      CpcAuthor,
+      "cpcPostsByTitle",
+      (rel: any) => rel.group("title").select("title"),
+      {
+        className: "CpcPost",
+        foreignKey: "author_id",
+      },
+    );
     const author = await CpcAuthor.create({ name: "g" });
     await CpcPost.create({ author_id: author.id, title: "X", body: "b1" });
     await CpcPost.create({ author_id: author.id, title: "X", body: "b2" });
@@ -173,10 +177,9 @@ describe("CollectionProxy#count — non-through fast path", () => {
   });
 
   it("size() with DISTINCT ignores the unsaved-records shortcut and counts via SQL", async () => {
-    Associations.hasMany.call(CpcAuthor, "cpcPostsDistinct", {
+    Associations.hasMany.call(CpcAuthor, "cpcPostsDistinct", (rel: any) => rel.distinct(), {
       className: "CpcPost",
       foreignKey: "author_id",
-      scope: (rel: any) => rel.distinct(),
     });
     const author = await CpcAuthor.create({ name: "d" });
     await CpcPost.create({ author_id: author.id, title: "p1", body: "b1" });
@@ -234,10 +237,9 @@ describe("CollectionProxy#count — non-through fast path", () => {
     // ActiveRecord::Core#== (class + present primary key), not object identity.
     // A re-fetched instance (same id, different object) must dedup in place
     // rather than appending a duplicate to the loaded target.
-    Associations.hasMany.call(CpcAuthor, "cpcPostsDedup", {
+    Associations.hasMany.call(CpcAuthor, "cpcPostsDedup", (rel: any) => rel.distinct(), {
       className: "CpcPost",
       foreignKey: "author_id",
-      scope: (rel: any) => rel.distinct(),
     });
     const author = await CpcAuthor.create({ name: "dedup" });
     const post = await CpcPost.create({ author_id: author.id, title: "p1", body: "b1" });
@@ -298,10 +300,9 @@ describe("CollectionProxy#count — non-through fast path", () => {
   it("count_records clamps the result to the association scope's limit_value", async () => {
     // Mirrors `[association_scope.limit_value, count].compact.min`: a scoped
     // limit caps the reported size even when the DB holds more rows.
-    Associations.hasMany.call(CpcAuthor, "cpcPostsLimited", {
+    Associations.hasMany.call(CpcAuthor, "cpcPostsLimited", (rel: any) => rel.limit(2), {
       className: "CpcPost",
       foreignKey: "author_id",
-      scope: (rel: any) => rel.limit(2),
     });
     const author = await CpcAuthor.create({ name: "limited" });
     await CpcPost.create({ author_id: author.id, title: "p1", body: "b1" });

--- a/packages/activerecord/src/associations/disable-joins-association-scope.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.test.ts
@@ -63,10 +63,9 @@ describe("DisableJoinsAssociationScope", () => {
       source: "djsComments",
       disableJoins: true,
     });
-    Associations.hasMany.call(DjsAuthor, "djsPostsOrdered", {
+    Associations.hasMany.call(DjsAuthor, "djsPostsOrdered", (rel: any) => rel.order("title"), {
       className: "DjsPost",
       foreignKey: "djs_author_id",
-      scope: (rel: any) => rel.order("title"),
     });
     Associations.hasMany.call(DjsAuthor, "djsCommentsViaOrderedPosts", {
       className: "DjsComment",

--- a/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
@@ -134,10 +134,9 @@ describe("DJAS — composite key support", () => {
   });
 
   it("composite-key + ordered upstream: skips DJAR wrap (records load via composite-key WHERE, no in-list reorder)", async () => {
-    Associations.hasMany.call(CkShop, "ckOrdersOrdered", {
+    Associations.hasMany.call(CkShop, "ckOrdersOrdered", (rel: any) => rel.order("name"), {
       className: "CkOrder",
       foreignKey: "shop_id",
-      scope: (rel: any) => rel.order("name"),
     });
     Associations.hasMany.call(CkShop, "ckLineItemsOrdered", {
       className: "CkLineItem",
@@ -312,10 +311,9 @@ describe("DJAS — composite key support", () => {
   });
 
   it("composite-key + ordered upstream + empty through: preserves none() instead of full table scan", async () => {
-    Associations.hasMany.call(CkShop, "ckOrdersOrdered2", {
+    Associations.hasMany.call(CkShop, "ckOrdersOrdered2", (rel: any) => rel.order("name"), {
       className: "CkOrder",
       foreignKey: "shop_id",
-      scope: (rel: any) => rel.order("name"),
     });
     Associations.hasMany.call(CkShop, "ckLineItemsEmpty", {
       className: "CkLineItem",

--- a/packages/activerecord/src/associations/disable-joins-nested-through.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-nested-through.test.ts
@@ -153,10 +153,9 @@ describe("DJAS routing widening — nested-through", () => {
   });
 
   it("nested-through + ordered intermediate: DJAR wrap reorders final records by chain-intermediate sequence", async () => {
-    Associations.hasMany.call(NtPost, "ntCommentsOrdered", {
+    Associations.hasMany.call(NtPost, "ntCommentsOrdered", (rel: any) => rel.order("body"), {
       className: "NtComment",
       foreignKey: "nt_post_id",
-      scope: (rel: any) => rel.order("body"),
     });
     Associations.hasMany.call(NtAuthor, "ntCommentsOrd", {
       className: "NtComment",

--- a/packages/activerecord/src/associations/eager.test.ts
+++ b/packages/activerecord/src/associations/eager.test.ts
@@ -871,10 +871,9 @@ describe("EagerAssociationTest", () => {
       static tableName = "authors";
       static {
         this.hasOne("post", { className: "PostWithDefaultScope", foreignKey: "author_id" });
-        this.hasOne("reorderedPost", {
+        this.hasOne("reorderedPost", (q: any) => q.reorder({ title: "desc" }), {
           className: "PostWithDefaultScope",
           foreignKey: "author_id",
-          scope: (q: any) => q.reorder({ title: "desc" }),
         });
       }
     }

--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -3101,11 +3101,10 @@ describe("HasManyAssociationsTest", () => {
       static {
         this._tableName = "companies";
         this.attribute("name", "string");
-        this.hasMany("conditionalClients", {
+        this.hasMany("conditionalClients", (rel: any) => rel.where({ name: "BigShot Inc." }), {
           className: "DcClient",
           foreignKey: "firm_id",
           dependent: "destroy",
-          scope: (rel: any) => rel.where({ name: "BigShot Inc." }),
         });
       }
     }
@@ -3143,11 +3142,10 @@ describe("HasManyAssociationsTest", () => {
       static {
         this._tableName = "companies";
         this.attribute("name", "string");
-        this.hasMany("conditionalClients", {
+        this.hasMany("conditionalClients", (rel: any) => rel.where({ name: "BigShot Inc." }), {
           className: "DsClient",
           foreignKey: "firm_id",
           dependent: "destroy",
-          scope: (rel: any) => rel.where({ name: "BigShot Inc." }),
         });
       }
     }
@@ -3177,11 +3175,10 @@ describe("HasManyAssociationsTest", () => {
       static {
         this._tableName = "companies";
         this.attribute("name", "string");
-        this.hasMany("conditionalClients", {
+        this.hasMany("conditionalClients", (rel: any) => rel.where({ name: "BigShot Inc." }), {
           className: "DhClient",
           foreignKey: "firm_id",
           dependent: "destroy",
-          scope: (rel: any) => rel.where({ name: "BigShot Inc." }),
         });
       }
     }
@@ -4055,11 +4052,10 @@ describe("HasManyAssociationsTest", () => {
           className: "HcPost",
           foreignKey: "author_id",
         });
-        this.hasMany("helloPostComments", {
+        this.hasMany("helloPostComments", (rel: any) => rel.where({ body: "hello" }), {
           className: "HcComment",
           through: "hcPosts",
           source: "hcComments",
-          scope: (rel: any) => rel.where({ body: "hello" }),
         });
       }
     }

--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -3125,11 +3125,15 @@ describe("HasManyAssociationsTest", () => {
     await DcClient.create({ firm_id: firm.id, name: "BigShot Inc." });
     await DcClient.create({ firm_id: firm.id, name: "SmallTime Inc." });
     expect((await DcClient.where({ firm_id: firm.id })).length).toBe(2);
-    const scoped = await findHasManyTarget(firm, "conditionalClients", {
-      className: "DcClient",
-      foreignKey: "firm_id",
-      scope: (rel: any) => rel.where({ name: "BigShot Inc." }),
-    });
+    const scoped = await findHasManyTarget(
+      firm,
+      "conditionalClients",
+      (rel: any) => rel.where({ name: "BigShot Inc." }),
+      {
+        className: "DcClient",
+        foreignKey: "firm_id",
+      },
+    );
     expect(scoped.length).toBe(1);
     await firm.destroy();
     expect((await DcClient.where({ firm_id: firm.id })).length).toBe(1);
@@ -4098,12 +4102,16 @@ describe("HasManyAssociationsTest", () => {
     await HcComment.create({ post_id: post.id, body: "hello" });
     await HcComment.create({ post_id: post.id, body: "goodbye" });
 
-    const comments = await findHasManyTarget(author, "helloPostComments", {
-      className: "HcComment",
-      through: "hcPosts",
-      source: "hcComments",
-      scope: (rel: any) => rel.where({ body: "hello" }),
-    });
+    const comments = await findHasManyTarget(
+      author,
+      "helloPostComments",
+      (rel: any) => rel.where({ body: "hello" }),
+      {
+        className: "HcComment",
+        through: "hcPosts",
+        source: "hcComments",
+      },
+    );
     expect(comments.length).toBe(1);
     expect(comments[0].body).toBe("hello");
   });

--- a/packages/activerecord/src/associations/has-many-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-through-associations.test.ts
@@ -338,8 +338,7 @@ describe("HasManyThroughAssociationsTest", () => {
       static {
         this._tableName = "people";
         this.hasMany("readers", { foreignKey: "person_id" });
-        this.hasMany("posts", {
-          scope: (q: any) => q.order("posts.id DESC"),
+        this.hasMany("posts", (q: any) => q.order("posts.id DESC"), {
           through: "readers",
           className: "Post",
         });
@@ -2175,8 +2174,7 @@ describe("HasManyThroughAssociationsTest", () => {
   });
 
   it("has many through with scope that should not be fully merged", async () => {
-    Club.hasMany("distinctMemberships", {
-      scope: (q: any) => q.distinct(),
+    Club.hasMany("distinctMemberships", (q: any) => q.distinct(), {
       className: "Membership",
     });
     Club.hasMany("specialFavorites", {

--- a/packages/activerecord/src/associations/join-model.test.ts
+++ b/packages/activerecord/src/associations/join-model.test.ts
@@ -91,9 +91,8 @@ class PostWithHasOneNullify extends Base {
 class WelcomeOnlyTagging extends Base {
   static {
     this._tableName = "taggings";
-    this.belongsTo("taggable", {
+    this.belongsTo("taggable", (q: any) => q.where({ posts: { title: "Welcome to the weblog" } }), {
       polymorphic: true,
-      scope: (q: any) => q.where({ posts: { title: "Welcome to the weblog" } }),
     });
   }
 }

--- a/packages/activerecord/src/associations/preloader/through-association-hasmany-raw-join-scope.test.ts
+++ b/packages/activerecord/src/associations/preloader/through-association-hasmany-raw-join-scope.test.ts
@@ -52,20 +52,27 @@ type JoinWhere = {
   where: (sql: string) => JoinWhere;
 };
 type HasManyHost = {
-  hasMany: (name: string, options: Record<string, unknown>) => void;
+  hasMany: (
+    name: string,
+    scope: (rel: JoinWhere) => JoinWhere,
+    options: Record<string, unknown>,
+  ) => void;
 };
 
 // A has_many-through mirroring `clubs` (Member → favoriteMemberships → club) but
 // whose scope reaches `categories` via a RAW string join instead of a symbol
 // association — the case real Rails raises on for has_many-through too.
-(Member as unknown as HasManyHost).hasMany("rawClubs", {
-  through: "favoriteMemberships",
-  source: "club",
-  scope: (rel: JoinWhere) =>
+(Member as unknown as HasManyHost).hasMany(
+  "rawClubs",
+  (rel: JoinWhere) =>
     rel
       .joins("INNER JOIN categories ON categories.id = clubs.category_id")
       .where("categories.name = 'General'"),
-});
+  {
+    through: "favoriteMemberships",
+    source: "club",
+  },
+);
 
 describe("Preloader::ThroughAssociation#through_scope has_many raw-join handling", () => {
   const { members } = fixtures(["memberTypes", "members", "clubs", "memberships", "categories"]);

--- a/packages/activerecord/src/associations/preloader/through-association-nested-join-scope.test.ts
+++ b/packages/activerecord/src/associations/preloader/through-association-nested-join-scope.test.ts
@@ -44,10 +44,18 @@ type NestedRel = {
   where: (spec: Record<string, unknown>) => NestedRel;
 };
 type HasOneHost = {
-  hasOne: (name: string, options: Record<string, unknown>) => void;
+  hasOne: (
+    name: string,
+    scope: (rel: NestedRel) => NestedRel,
+    options: Record<string, unknown>,
+  ) => void;
 };
 type HasManyHost = {
-  hasMany: (name: string, options: Record<string, unknown>) => void;
+  hasMany: (
+    name: string,
+    scope: (rel: NestedRel) => NestedRel,
+    options: Record<string, unknown>,
+  ) => void;
 };
 
 // A has_one-through mirroring `general_club` (Member → current_membership →
@@ -55,40 +63,49 @@ type HasManyHost = {
 // source klass Club (club → category → categorizations) — and predicates on it.
 // `categorizations.author_id = 1` (david) matches category `general`, so
 // groucho's through row (boring_club, category general) survives.
-(Member as unknown as HasOneHost).hasOne("davidCategorizedClub", {
-  through: "currentMembership",
-  source: "club",
-  scope: (rel: NestedRel) =>
+(Member as unknown as HasOneHost).hasOne(
+  "davidCategorizedClub",
+  (rel: NestedRel) =>
     rel.leftJoins({ category: "categorizations" }).where({ categorizations: { author_id: 1 } }),
-});
+  {
+    through: "currentMembership",
+    source: "club",
+  },
+);
 
 // Same shape but reaching the deeper table via `.includes` instead of
 // `.leftJoins`. Rails' through_scope nests the scope's `values[:includes]` under
 // the source reflection (`includes!(source => includes)`), so `.includes` and
 // `.leftJoins` both realize the deeper join on the through query. Pins that a
 // has_one-through honors an explicit `.includes` in its scope.
-(Member as unknown as HasOneHost).hasOne("davidIncludedCategorizedClub", {
-  through: "currentMembership",
-  source: "club",
-  scope: (rel: NestedRel) =>
+(Member as unknown as HasOneHost).hasOne(
+  "davidIncludedCategorizedClub",
+  (rel: NestedRel) =>
     (rel as unknown as { includes: (s: Record<string, unknown>) => NestedRel })
       .includes({ category: "categorizations" })
       .where({ categorizations: { author_id: 1 } }),
-});
+  {
+    through: "currentMembership",
+    source: "club",
+  },
+);
 
 // A has_MANY-through whose scope carries a `.includes` reaching a belongs_to
 // association (`category` on Club) plus a predicate on it. A belongs_to join is
 // 1:1, so it does NOT fan the through rows out and IS nested onto the through
 // query even for a collection target — the predicate must resolve there, not
 // leak onto the source query where `categories` is unjoined.
-(Member as unknown as HasManyHost).hasMany("generalClubs", {
-  through: "favoriteMemberships",
-  source: "club",
-  scope: (rel: NestedRel) =>
+(Member as unknown as HasManyHost).hasMany(
+  "generalClubs",
+  (rel: NestedRel) =>
     (rel as unknown as { includes: (s: string) => NestedRel })
       .includes("category")
       .where({ categories: { name: "General" } }),
-});
+  {
+    through: "favoriteMemberships",
+    source: "club",
+  },
+);
 
 // A has_MANY-through whose scope includes a two-level nested path
 // (`categorizations`, a has_many via club → category → categorizations) AND
@@ -98,14 +115,17 @@ type HasManyHost = {
 // middle records out. The join and its `categorizations.author_id` predicate
 // are realized on the through query, resolving there instead of leaking onto
 // the source stage.
-(Member as unknown as HasManyHost).hasMany("categorizedClubs", {
-  through: "favoriteMemberships",
-  source: "club",
-  scope: (rel: NestedRel) =>
+(Member as unknown as HasManyHost).hasMany(
+  "categorizedClubs",
+  (rel: NestedRel) =>
     (rel as unknown as { includes: (s: Record<string, unknown>) => NestedRel })
       .includes({ category: "categorizations" })
       .where({ categorizations: { author_id: 1 } }),
-});
+  {
+    through: "favoriteMemberships",
+    source: "club",
+  },
+);
 
 describe("Preloader::ThroughAssociation#through_scope multi-level nested join carry", () => {
   const { members, clubs } = fixtures([

--- a/packages/activerecord/src/associations/preloader/through-association-nested-raw-join-scope.test.ts
+++ b/packages/activerecord/src/associations/preloader/through-association-nested-raw-join-scope.test.ts
@@ -45,68 +45,90 @@ type JoinWhere = {
   where: (sql: string) => JoinWhere;
 };
 type HasManyHost = {
-  hasMany: (name: string, options: Record<string, unknown>) => void;
+  hasMany: (
+    name: string,
+    scope: (rel: JoinWhere) => JoinWhere,
+    options: Record<string, unknown>,
+  ) => void;
 };
 type HasOneHost = {
-  hasOne: (name: string, options: Record<string, unknown>) => void;
+  hasOne: (
+    name: string,
+    scope: (rel: JoinWhere) => JoinWhere,
+    options: Record<string, unknown>,
+  ) => void;
 };
 
 // Nested through (source `members` on Club is itself a has_many-through, so this
 // takes the "twoStep"/nested branch) whose OUTER scope reaches `categories` via
 // a RAW string join + a `.where`. The flattened where_clause is non-empty, so
 // Rails raises ConfigurationError at the through-scope build.
-(Member as unknown as HasManyHost).hasMany("rawMembersOfClub", {
-  through: "club",
-  source: "members",
-  scope: (rel: JoinWhere) =>
+(Member as unknown as HasManyHost).hasMany(
+  "rawMembersOfClub",
+  (rel: JoinWhere) =>
     rel
       .joins("INNER JOIN categories ON categories.id = memberships.club_id")
       .where("categories.name = 'General'"),
-});
+  {
+    through: "club",
+    source: "members",
+  },
+);
 
 // Same nested branch, but the raw join is declared on the SUB-CHAIN only: Club's
 // own has_many-through `rawMembers` carries `.joins(...).where(...)`, and the
 // outer `membersViaRawClub` sources through it with a raw-join-free `.where`.
 // Rails still raises at the OUTER build because the flattened `values[:joins]`
 // includes the sub-chain's raw join and the flattened where_clause is non-empty.
-(Club as unknown as HasManyHost).hasMany("rawMembers", {
-  through: "memberships",
-  source: "member",
-  scope: (rel: JoinWhere) =>
+(Club as unknown as HasManyHost).hasMany(
+  "rawMembers",
+  (rel: JoinWhere) =>
     rel
       .joins("INNER JOIN categories ON categories.id = members.id")
       .where("categories.name = 'General'"),
-});
-(Member as unknown as HasManyHost).hasMany("membersViaRawClub", {
-  through: "club",
-  source: "rawMembers",
-  scope: (rel: JoinWhere) => rel.where("clubs.name IS NOT NULL"),
-});
+  {
+    through: "memberships",
+    source: "member",
+  },
+);
+(Member as unknown as HasManyHost).hasMany(
+  "membersViaRawClub",
+  (rel: JoinWhere) => rel.where("clubs.name IS NOT NULL"),
+  {
+    through: "club",
+    source: "rawMembers",
+  },
+);
 
 // Nested through whose OWN scope carries a raw join but NO `.where` anywhere in
 // the chain. The flattened where_clause is empty, so Rails skips the whole
 // `elsif` branch (through_association.rb:117) and NOTHING raises — the raw join
 // is never nested. Pins that the raise is gated on the where_clause, not on the
 // mere presence of a raw join.
-(Member as unknown as HasManyHost).hasMany("noWhereRawMembersOfClub", {
-  through: "club",
-  source: "members",
-  scope: (rel: JoinWhere) =>
-    rel.joins("INNER JOIN categories ON categories.id = memberships.club_id"),
-});
+(Member as unknown as HasManyHost).hasMany(
+  "noWhereRawMembersOfClub",
+  (rel: JoinWhere) => rel.joins("INNER JOIN categories ON categories.id = memberships.club_id"),
+  {
+    through: "club",
+    source: "members",
+  },
+);
 
 // Nested through (through reflection `club` is itself a has_one-through, so
 // `reflectionScope` is the flattened chain scope) whose has_ONE target's own
 // scope reaches `categorizations` via a RAW join + `.where`. Exercises the
 // "join" branch's flattened raw-join handling for a has_one nested through.
-(Member as unknown as HasOneHost).hasOne("rawCategoryOfClub", {
-  through: "club",
-  source: "category",
-  scope: (rel: JoinWhere) =>
+(Member as unknown as HasOneHost).hasOne(
+  "rawCategoryOfClub",
+  (rel: JoinWhere) =>
     rel
       .joins("INNER JOIN categorizations ON categorizations.category_id = categories.id")
       .where("categorizations.author_id = 1"),
-});
+  {
+    through: "club",
+    source: "category",
+  },
+);
 
 describe("Preloader::ThroughAssociation#through_scope nested raw-join handling", () => {
   const { members } = fixtures(["memberTypes", "members", "clubs", "memberships", "categories"]);

--- a/packages/activerecord/src/associations/preloader/through-association-raw-join-scope.test.ts
+++ b/packages/activerecord/src/associations/preloader/through-association-raw-join-scope.test.ts
@@ -52,20 +52,27 @@ type JoinWhere = {
   where: (sql: string) => JoinWhere;
 };
 type HasOneHost = {
-  hasOne: (name: string, options: Record<string, unknown>) => void;
+  hasOne: (
+    name: string,
+    scope: (rel: JoinWhere) => JoinWhere,
+    options: Record<string, unknown>,
+  ) => void;
 };
 
 // A has_one-through mirroring `general_club` (Member → current_membership →
 // club) but whose scope reaches `categories` via a RAW string join instead of
 // `left_joins(:category)` — the case real Rails raises on.
-(Member as unknown as HasOneHost).hasOne("rawGeneralClub", {
-  through: "currentMembership",
-  source: "club",
-  scope: (rel: JoinWhere) =>
+(Member as unknown as HasOneHost).hasOne(
+  "rawGeneralClub",
+  (rel: JoinWhere) =>
     rel
       .joins("INNER JOIN categories ON categories.id = clubs.category_id")
       .where("categories.name = 'General'"),
-});
+  {
+    through: "currentMembership",
+    source: "club",
+  },
+);
 
 describe("Preloader::ThroughAssociation#through_scope raw-join handling", () => {
   const { members } = fixtures(["memberTypes", "members", "clubs", "memberships", "categories"]);

--- a/packages/activerecord/src/associations/through-association-scope-composite-pk.trails.test.ts
+++ b/packages/activerecord/src/associations/through-association-scope-composite-pk.trails.test.ts
@@ -36,12 +36,15 @@ registerModel([CpkOrder, CpkOrderTag, CpkTag]);
 // preload stage (which never joins `cpk_order_tags`), the through-table column
 // would raise `no such column`. `order_1` is tagged both `Loyal customer` and
 // `Digital product`; the source-table half narrows the result to the latter.
-CpkOrder.hasMany("tagsWithMixedCondition", {
-  className: "CpkTag",
-  through: "orderTags",
-  source: "tag",
-  scope: (rel) => rel.where("cpk_order_tags.order_id > 0 AND cpk_tags.name = 'Digital product'"),
-});
+CpkOrder.hasMany(
+  "tagsWithMixedCondition",
+  (rel) => rel.where("cpk_order_tags.order_id > 0 AND cpk_tags.name = 'Digital product'"),
+  {
+    className: "CpkTag",
+    through: "orderTags",
+    source: "tag",
+  },
+);
 
 interface ThroughScopeProbe {
   throughScope(): { toSql(): string };

--- a/packages/activerecord/src/associations/through-association-scope.test.ts
+++ b/packages/activerecord/src/associations/through-association-scope.test.ts
@@ -37,20 +37,22 @@ registerModel(Tagging);
 // (through_association.rb:115-116), then passes the full built scope to
 // `source_preloaders` — so the source-table predicate must be kept at the
 // source stage, not emptied.
-(Tag as any).hasMany("welcomeTaggedPosts", {
-  through: "taggings",
-  source: "taggable",
-  sourceType: "Post",
-  scope: (rel: any) => rel.where("posts.title = 'Welcome to the weblog'"),
-});
+(Tag as any).hasMany(
+  "welcomeTaggedPosts",
+  (rel: any) => rel.where("posts.title = 'Welcome to the weblog'"),
+  {
+    through: "taggings",
+    source: "taggable",
+    sourceType: "Post",
+  },
+);
 
 // Add a scope-annotated through association to Author for this test suite.
 // Author → posts → comments, but with an SQL annotation on the scope.
-(Author as any).hasMany("annotatedComments", {
+(Author as any).hasMany("annotatedComments", (rel: any) => rel.annotate("preload-through"), {
   className: "Comment",
   through: "posts",
   source: "comments",
-  scope: (rel: any) => rel.annotate("preload-through"),
 });
 
 // A source-table (`comments.`) condition on a has_many-through (collection
@@ -59,45 +61,57 @@ registerModel(Tagging);
 // the source via a JOIN whose JoinDependency dedups the middle records by PK — so
 // the source condition IS carried onto the through query (with the source JOIN)
 // rather than deferred to the source-preloader stage.
-(Author as any).hasMany("commentsWithSourceCondition", {
-  className: "Comment",
-  through: "posts",
-  source: "comments",
-  scope: (rel: any) => rel.where("comments.body = 'first comment'"),
-});
+(Author as any).hasMany(
+  "commentsWithSourceCondition",
+  (rel: any) => rel.where("comments.body = 'first comment'"),
+  {
+    className: "Comment",
+    through: "posts",
+    source: "comments",
+  },
+);
 
 // A through-table (`posts.title`) condition expressed as a hash so its Arel
 // attribute is precisely detected. For a collection-source two-step, the
 // through-table predicate is copied onto the through query to constrain which
 // intermediate rows are selected.
-(Author as any).hasMany("commentsWithThroughCondition", {
-  className: "Comment",
-  through: "posts",
-  source: "comments",
-  scope: (rel: any) => rel.where({ posts: { title: "Welcome to the weblog" } }),
-});
+(Author as any).hasMany(
+  "commentsWithThroughCondition",
+  (rel: any) => rel.where({ posts: { title: "Welcome to the weblog" } }),
+  {
+    className: "Comment",
+    through: "posts",
+    source: "comments",
+  },
+);
 
 // Same, but the through-table condition is RAW SQL. Rails' `through_scope`
 // assigns the full `reflection_scope.where_clause` before the source join, so a
 // raw through-table predicate must be copied onto the through query too (not
 // left on the source query, where `posts` is not joined — an invalid predicate).
-(Author as any).hasMany("commentsWithRawThroughCondition", {
-  className: "Comment",
-  through: "posts",
-  source: "comments",
-  scope: (rel: any) => rel.where("posts.title = 'Welcome to the weblog'"),
-});
+(Author as any).hasMany(
+  "commentsWithRawThroughCondition",
+  (rel: any) => rel.where("posts.title = 'Welcome to the weblog'"),
+  {
+    className: "Comment",
+    through: "posts",
+    source: "comments",
+  },
+);
 
 // A MIXED predicate referencing both the through table (`posts`) and the source
 // table (`comments`) in one node. Rails copies the full where_clause and JOINs
 // the source, so both `posts` and `comments` are available on the through query
 // and the whole predicate resolves there in one query.
-(Author as any).hasMany("commentsWithMixedCondition", {
-  className: "Comment",
-  through: "posts",
-  source: "comments",
-  scope: (rel: any) => rel.where("posts.title = 'Welcome to the weblog' OR comments.body = 'x'"),
-});
+(Author as any).hasMany(
+  "commentsWithMixedCondition",
+  (rel: any) => rel.where("posts.title = 'Welcome to the weblog' OR comments.body = 'x'"),
+  {
+    className: "Comment",
+    through: "posts",
+    source: "comments",
+  },
+);
 
 describe("Preloader::ThroughAssociation#through_scope", () => {
   const { authors, posts, tags } = fixtures([

--- a/packages/activerecord/src/counter-cache.test.ts
+++ b/packages/activerecord/src/counter-cache.test.ts
@@ -66,8 +66,7 @@ for (const model of [
 export class SpecialTopic extends Topic {
   static {
     this.hasMany("specialReplies", { className: "SpecialReply", foreignKey: "parent_id" });
-    this.hasMany("lightweightSpecialReplies", {
-      scope: (q: any) => q.select("topics.id", "topics.title"),
+    this.hasMany("lightweightSpecialReplies", (q: any) => q.select("topics.id", "topics.title"), {
       className: "SpecialReply",
       foreignKey: "parent_id",
     });

--- a/packages/activerecord/src/relation/predicate-builder.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.test.ts
@@ -97,11 +97,14 @@ describe("PredicateBuilderTest", () => {
     // the canonical Reply (Rails leaks the association; we keep it scoped).
     class RegexpReply extends Reply {
       static {
-        this.belongsTo("regexp_topic", {
-          className: "Topic",
-          foreignKey: "parent_id",
-          scope: (rel: any) => rel.where({ title: new RegexFilter("rails") }),
-        });
+        this.belongsTo(
+          "regexp_topic",
+          (rel: any) => rel.where({ title: new RegexFilter("rails") }),
+          {
+            className: "Topic",
+            foreignKey: "parent_id",
+          },
+        );
       }
     }
     registerModel("RegexpReply", RegexpReply);

--- a/packages/activerecord/src/test-helpers/find-collection-target.ts
+++ b/packages/activerecord/src/test-helpers/find-collection-target.ts
@@ -16,12 +16,24 @@ import { _buildAssociationInstance } from "../associations/instance-methods.js";
  * would otherwise repeat the same cast. `async` so `check_validity!` — run when
  * the holder is built, as in `Association#initialize` (`association.rb:41-45`) —
  * surfaces as a rejection like every other load failure.
+ *
+ * `scope` is positional ahead of `options`, as on the macros it stands in for
+ * (`has_many(name, scope = nil, **options)`, `associations.rb:1302`), and is
+ * folded into the holder's options the same way `Builder::Association.build`
+ * folds it into the reflection's (`builder/association.ts:151`) — which is what
+ * a caller forwarding a whole `reflection.options` is already passing.
  */
 export async function findCollectionTarget(
   record: Base,
   name: string,
+  scope: NonNullable<AssociationOptions["scope"]> | AssociationOptions | null = {},
   options: AssociationOptions = {},
 ): Promise<Base[]> {
+  if (typeof scope === "function") {
+    options = { ...options, scope };
+  } else if (scope !== null) {
+    options = scope;
+  }
   const assoc = _buildAssociationInstance.call(record, { name, type: "hasMany", options });
   return (assoc as unknown as { findTarget(): Promise<Base[]> }).findTarget();
 }


### PR DESCRIPTION
Sweeps the remaining options-bag `scope:` association declarations in AR test files onto Rails' positional lambda (`associations.rb:1302,1870`), finishing what #6502 did for the canonical models: 46 sites across 19 test files, covering `hasMany` / `hasOne` / `belongsTo`.

Also updates the four local `HasManyHost` / `HasOneHost` structural types in the preloader through-scope tests to the positional signature.

Three `scope:` bags remain and are deliberately unchanged: `findCollectionTarget(record, name, options)` calls in `association-scope.test.ts` and `has-many-associations.test.ts`. That helper builds an association holder directly from an internal options set (`_buildAssociationInstance`) rather than going through a macro, so its bag is the post-builder representation, not the macro surface `drop-builder-association-scope-option-shim` is gated on.

Verification:
- `pnpm typecheck` green.
- 18 touched suites green (1123 passed, 3 skipped); `adapters/postgresql/uuid.test.ts` left to CI.
- `pnpm parity:api:calls:args` OK, no new rows.

Closes-story: test-files-scope-positional-sweep