### PR TITLE
refactor(activemodel): rename AttributeSetCoder to YAMLEncoder

### DIFF
--- a/packages/activemodel/src/attribute-set/codecs/codec.ts
+++ b/packages/activemodel/src/attribute-set/codecs/codec.ts
@@ -1,0 +1,33 @@
+/**
+ * The wire contract Psych supplies in Ruby.
+ *
+ * Rails' `AttributeSet::YAMLEncoder` hands the attributes to a `Psych::Coder`
+ * and lets Psych dump the `Attribute` objects themselves
+ * (`yaml_encoder.rb:13-19`). JS has no Psych, so the serialized shape and the
+ * codec that writes it live here, outside the Rails-matched encoder file.
+ */
+export interface AttributeSetEnvelope {
+  v: 1;
+  /**
+   * attr → registry type key (e.g. "string", "integer", "decimal"), or `null`
+   * for `attr.with_type(nil)` (`yaml_encoder.rb:15`) — the attribute's type is
+   * the model's default type for that name, so it is not written out.
+   */
+  types: Record<string, string | null>;
+  /** attr → raw value before type-cast (valueBeforeTypeCast) */
+  values: Record<string, unknown>;
+  /** attrs that were Uninitialized when encoded */
+  defaultAttributes?: string[];
+}
+
+export interface AttributeSetCodec {
+  encode(envelope: AttributeSetEnvelope): string;
+  decode(input: string): AttributeSetEnvelope;
+}
+
+export class AttributeSetCodecError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AttributeSetCodecError";
+  }
+}

--- a/packages/activemodel/src/attribute-set/codecs/json.test.ts
+++ b/packages/activemodel/src/attribute-set/codecs/json.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { jsonCodec } from "./json.js";
-import { AttributeSetCoderError } from "../coder.js";
-import type { AttributeSetEnvelope } from "../coder.js";
+import { AttributeSetCodecError } from "./codec.js";
+import type { AttributeSetEnvelope } from "./codec.js";
 
 describe("jsonCodec", () => {
   const envelope: AttributeSetEnvelope = {
@@ -25,12 +25,12 @@ describe("jsonCodec", () => {
     expect(jsonCodec.decode(jsonCodec.encode(envelope))).toEqual(envelope);
   });
 
-  it("throws AttributeSetCoderError on malformed input", () => {
-    expect(() => jsonCodec.decode("null")).toThrow(AttributeSetCoderError);
-    expect(() => jsonCodec.decode("[]")).toThrow(AttributeSetCoderError);
-    expect(() => jsonCodec.decode('{"v":1}')).toThrow(AttributeSetCoderError);
+  it("throws AttributeSetCodecError on malformed input", () => {
+    expect(() => jsonCodec.decode("null")).toThrow(AttributeSetCodecError);
+    expect(() => jsonCodec.decode("[]")).toThrow(AttributeSetCodecError);
+    expect(() => jsonCodec.decode('{"v":1}')).toThrow(AttributeSetCodecError);
     expect(() => jsonCodec.decode('{"v":1,"types":null,"values":{}}')).toThrow(
-      AttributeSetCoderError,
+      AttributeSetCodecError,
     );
   });
 

--- a/packages/activemodel/src/attribute-set/codecs/json.ts
+++ b/packages/activemodel/src/attribute-set/codecs/json.ts
@@ -1,8 +1,8 @@
-import { AttributeSetCoderError } from "../coder.js";
-import type { AttributeSetCodec, AttributeSetEnvelope } from "../coder.js";
+import { AttributeSetCodecError } from "./codec.js";
+import type { AttributeSetCodec, AttributeSetEnvelope } from "./codec.js";
 
 /**
- * Default JSON codec for AttributeSetCoder.
+ * Default JSON codec for YAMLEncoder.
  *
  * Known JSON format limitations (Rails YAMLEncoder stores full Ruby objects
  * and is not subject to these constraints):
@@ -33,7 +33,7 @@ export const jsonCodec: AttributeSetCodec = {
       !isPlainObject(parsed.types) ||
       !isPlainObject(parsed.values)
     ) {
-      throw new AttributeSetCoderError(
+      throw new AttributeSetCodecError(
         "jsonCodec.decode: input is not a valid AttributeSetEnvelope",
       );
     }

--- a/packages/activemodel/src/attribute-set/codecs/yaml.test.ts
+++ b/packages/activemodel/src/attribute-set/codecs/yaml.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { yamlCodec } from "@blazetrails/activemodel/yaml";
-import { AttributeSetCoderError } from "../coder.js";
-import type { AttributeSetEnvelope } from "../coder.js";
+import { AttributeSetCodecError } from "./codec.js";
+import type { AttributeSetEnvelope } from "./codec.js";
 
 describe("yamlCodec", () => {
   const envelope: AttributeSetEnvelope = {
@@ -26,11 +26,11 @@ describe("yamlCodec", () => {
     expect(yamlCodec.decode(yamlCodec.encode(envelope))).toEqual(envelope);
   });
 
-  it("throws AttributeSetCoderError on malformed input", () => {
-    expect(() => yamlCodec.decode("null")).toThrow(AttributeSetCoderError);
-    expect(() => yamlCodec.decode("- item")).toThrow(AttributeSetCoderError);
-    expect(() => yamlCodec.decode("v: 1")).toThrow(AttributeSetCoderError);
-    expect(() => yamlCodec.decode("v: 1\ntypes: ~\nvalues: {}")).toThrow(AttributeSetCoderError);
+  it("throws AttributeSetCodecError on malformed input", () => {
+    expect(() => yamlCodec.decode("null")).toThrow(AttributeSetCodecError);
+    expect(() => yamlCodec.decode("- item")).toThrow(AttributeSetCodecError);
+    expect(() => yamlCodec.decode("v: 1")).toThrow(AttributeSetCodecError);
+    expect(() => yamlCodec.decode("v: 1\ntypes: ~\nvalues: {}")).toThrow(AttributeSetCodecError);
   });
 
   it("round-trips with unknown type key (schema drift)", () => {

--- a/packages/activemodel/src/attribute-set/codecs/yaml.ts
+++ b/packages/activemodel/src/attribute-set/codecs/yaml.ts
@@ -1,6 +1,6 @@
 import { parse as yamlParse, stringify as yamlStringify } from "@blazetrails/activesupport/yaml";
-import { AttributeSetCoderError } from "../coder.js";
-import type { AttributeSetCodec, AttributeSetEnvelope } from "../coder.js";
+import { AttributeSetCodecError } from "./codec.js";
+import type { AttributeSetCodec, AttributeSetEnvelope } from "./codec.js";
 
 function isPlainObject(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null && !Array.isArray(v);
@@ -20,7 +20,7 @@ export const yamlCodec: AttributeSetCodec = {
       !isPlainObject(parsed.types) ||
       !isPlainObject(parsed.values)
     ) {
-      throw new AttributeSetCoderError(
+      throw new AttributeSetCodecError(
         "yamlCodec.decode: input is not a valid AttributeSetEnvelope",
       );
     }

--- a/packages/activemodel/src/attribute-set/yaml-encoder.test.ts
+++ b/packages/activemodel/src/attribute-set/yaml-encoder.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { AttributeSetCoder, AttributeSetCoderError } from "./coder.js";
-import type { AttributeSetCodec, AttributeSetEnvelope } from "./coder.js";
+import { YAMLEncoder } from "./yaml-encoder.js";
+import { AttributeSetCodecError } from "./codecs/codec.js";
+import type { AttributeSetCodec, AttributeSetEnvelope } from "./codecs/codec.js";
 import { AttributeSet } from "../attribute-set.js";
 import { Attribute } from "../attribute.js";
 import { typeRegistry } from "../type/registry.js";
@@ -20,11 +21,11 @@ function intAttr(name: string, value: number): Attribute {
   return Attribute.fromUser(name, value, integerType);
 }
 
-describe("AttributeSetCoder", () => {
+describe("YAMLEncoder", () => {
   // `default_types` is the model's `attribute_types`, whose values are the very
   // Type instances its attributes carry — Rails' `equal?` check depends on that.
   const defaultTypes = { name: stringType, age: integerType };
-  const coder = new AttributeSetCoder(defaultTypes);
+  const coder = new YAMLEncoder(defaultTypes);
 
   afterEach(() => {
     vi.restoreAllMocks();
@@ -53,7 +54,7 @@ describe("AttributeSetCoder", () => {
 
   it("restores the default type for an attribute encoded without one", () => {
     const custom = integerType;
-    const localCoder = new AttributeSetCoder({ qty: custom });
+    const localCoder = new YAMLEncoder({ qty: custom });
     const json = JSON.stringify({ v: 1, types: { qty: null }, values: { qty: 5 } });
     const decoded = localCoder.decode(json);
     expect(decoded.fetchValue("qty")).toBe(5);
@@ -62,7 +63,7 @@ describe("AttributeSetCoder", () => {
 
   it("uninitialized attributes round-trip as uninitialized", () => {
     const intType = integerType;
-    const localCoder = new AttributeSetCoder({ score: intType });
+    const localCoder = new YAMLEncoder({ score: intType });
     const set = makeSet(new Map([["score", Attribute.uninitialized("score", intType)]]));
 
     const encoded = localCoder.encode(set);
@@ -75,7 +76,7 @@ describe("AttributeSetCoder", () => {
 
   it("unknown type key falls back to value type and warns once", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const localCoder = new AttributeSetCoder({});
+    const localCoder = new YAMLEncoder({});
     const json = JSON.stringify({
       v: 1,
       types: { x: "unknown_type_xyz" },
@@ -91,7 +92,7 @@ describe("AttributeSetCoder", () => {
 
   it("silenceDriftWarnings suppresses the console.warn", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const silentCoder = new AttributeSetCoder({}, { silenceDriftWarnings: true });
+    const silentCoder = new YAMLEncoder({}, { silenceDriftWarnings: true });
     const json = JSON.stringify({
       v: 1,
       types: { y: "completely_unknown_type_abc" },
@@ -101,9 +102,9 @@ describe("AttributeSetCoder", () => {
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
-  it("v mismatch throws AttributeSetCoderError", () => {
+  it("v mismatch throws AttributeSetCodecError", () => {
     const json = JSON.stringify({ v: 2, types: {}, values: {} });
-    expect(() => coder.decode(json)).toThrow(AttributeSetCoderError);
+    expect(() => coder.decode(json)).toThrow(AttributeSetCodecError);
     expect(() => coder.decode(json)).toThrow("v=2 not supported");
   });
 
@@ -140,7 +141,7 @@ describe("AttributeSetCoder", () => {
       }),
       decode: vi.fn((input: string) => JSON.parse(input) as AttributeSetEnvelope),
     };
-    const customCoder = new AttributeSetCoder({}, { codec: customCodec });
+    const customCoder = new YAMLEncoder({}, { codec: customCodec });
     const set = makeSet(new Map([["x", stringAttr("x", "hi")]]));
     customCoder.decode(customCoder.encode(set));
     expect(customCodec.encode).toHaveBeenCalledOnce();

--- a/packages/activemodel/src/attribute-set/yaml-encoder.ts
+++ b/packages/activemodel/src/attribute-set/yaml-encoder.ts
@@ -43,6 +43,19 @@ export class YAMLEncoder {
   private codec: AttributeSetCodec;
   private silenceDriftWarnings: boolean;
 
+  /**
+   * `YAMLEncoder#initialize` takes only `default_types` (`yaml_encoder.rb:8`)
+   * and `encode`/`decode` receive the `Psych::Coder` at the method boundary
+   * (`:12`, `:22`).
+   *
+   * @noRailsEquivalent `opts` carries what Psych supplies in Ruby and JS has no
+   * analogue of. Psych dumps a `Type` object inline, so a non-default type has
+   * to travel as a registry key and come back through `registry` (with
+   * `silenceDriftWarnings` muting the unknown-key warning), and there is no
+   * `Psych::Coder` object to pass per call, so the serializer is the injected
+   * `codec` instead. All three default, so `new YAMLEncoder(defaultTypes)` is
+   * the Rails call.
+   */
   constructor(
     defaultTypes: Record<string, Type>,
     opts: {

--- a/packages/activemodel/src/attribute-set/yaml-encoder.ts
+++ b/packages/activemodel/src/attribute-set/yaml-encoder.ts
@@ -29,6 +29,10 @@ const warnedKeys = new Set<string>();
  *   non-default type travels as its registry key and comes back through
  *   `registry`. An unknown key falls back to the "value" type with a one-time
  *   warning per key (opt out with `silenceDriftWarnings`).
+ * - Rails hands the concise attributes to the `Psych::Coder` its caller passes
+ *   in (`yaml_encoder.rb:13`); there is no such object in JS, so `encode` takes
+ *   the attribute set alone and returns what the injected codec wrote, and
+ *   `decode` reads that string back.
  * - Psych round-trips an `Attribute::Uninitialized` as itself; a JSON envelope
  *   has no value to carry for one, so those names are listed in
  *   `defaultAttributes` and rebuilt as `Uninitialized` on decode.

--- a/packages/activemodel/src/attribute-set/yaml-encoder.ts
+++ b/packages/activemodel/src/attribute-set/yaml-encoder.ts
@@ -3,37 +3,19 @@ import { AttributeSet } from "../attribute-set.js";
 import { typeRegistry, type TypeRegistry } from "../type/registry.js";
 import type { Type } from "../type/value.js";
 import { jsonCodec } from "./codecs/json.js";
-
-export interface AttributeSetEnvelope {
-  v: 1;
-  /**
-   * attr → registry type key (e.g. "string", "integer", "decimal"), or `null`
-   * for `attr.with_type(nil)` (`yaml_encoder.rb:15`) — the attribute's type is
-   * the model's default type for that name, so it is not written out.
-   */
-  types: Record<string, string | null>;
-  /** attr → raw value before type-cast (valueBeforeTypeCast) */
-  values: Record<string, unknown>;
-  /** attrs that were Uninitialized when encoded */
-  defaultAttributes?: string[];
-}
-
-export interface AttributeSetCodec {
-  encode(envelope: AttributeSetEnvelope): string;
-  decode(input: string): AttributeSetEnvelope;
-}
-
-export class AttributeSetCoderError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "AttributeSetCoderError";
-  }
-}
+import {
+  AttributeSetCodecError,
+  type AttributeSetCodec,
+  type AttributeSetEnvelope,
+} from "./codecs/codec.js";
 
 const warnedKeys = new Set<string>();
 
 /**
  * Mirrors: ActiveModel::AttributeSet::YAMLEncoder
+ *
+ * Attempts to do more intelligent YAML dumping of an
+ * ActiveModel::AttributeSet to reduce the size of the resulting string.
  *
  * Rails takes the model's `attribute_types` as `default_types` and encodes an
  * attribute whose type is that default as `attr.with_type(nil)`
@@ -51,7 +33,7 @@ const warnedKeys = new Set<string>();
  *   has no value to carry for one, so those names are listed in
  *   `defaultAttributes` and rebuilt as `Uninitialized` on decode.
  */
-export class AttributeSetCoder {
+export class YAMLEncoder {
   private defaultTypes: Record<string, Type>;
   private registry: TypeRegistry;
   private codec: AttributeSetCodec;
@@ -72,18 +54,25 @@ export class AttributeSetCoder {
   }
 
   encode(attributeSet: AttributeSet): string {
-    const types: Record<string, string | null> = {};
-    const values: Record<string, unknown> = {};
-    const defaultAttributes: string[] = [];
-
-    attributeSet.forEach((attr, name) => {
-      if (attr instanceof Uninitialized) {
-        defaultAttributes.push(name);
-        return;
-      }
-      types[name] = attr.type === this.defaultTypes[name] ? null : attr.type.name;
-      values[name] = attr.valueBeforeTypeCast;
+    const attributes: Attribute[] = [];
+    attributeSet.eachValue((attr) => {
+      attributes.push(attr);
     });
+
+    const defaultAttributes = attributes
+      .filter((attr) => attr instanceof Uninitialized)
+      .map((attr) => attr.name);
+
+    const conciseAttributes = attributes.filter((attr) => !(attr instanceof Uninitialized));
+    const types = Object.fromEntries(
+      conciseAttributes.map((attr) => [
+        attr.name,
+        attr.type === this.defaultTypes[attr.name] ? null : attr.type.name,
+      ]),
+    );
+    const values = Object.fromEntries(
+      conciseAttributes.map((attr) => [attr.name, attr.valueBeforeTypeCast]),
+    );
 
     const envelope: AttributeSetEnvelope = { v: 1, types, values };
     if (defaultAttributes.length > 0) envelope.defaultAttributes = defaultAttributes;
@@ -94,30 +83,30 @@ export class AttributeSetCoder {
     const envelope = this.codec.decode(input);
 
     if (envelope.v !== 1) {
-      throw new AttributeSetCoderError(`envelope version v=${envelope.v} not supported`);
+      throw new AttributeSetCodecError(`envelope version v=${envelope.v} not supported`);
     }
 
-    const attributesHash = new Map<string, Attribute>();
-
-    for (const [name, typeKey] of Object.entries(envelope.types)) {
-      let type: Type;
-      if (typeKey == null) {
-        type = this.defaultTypes[name];
-      } else {
-        try {
-          type = this.registry.lookup(typeKey);
-        } catch {
-          if (!this.silenceDriftWarnings && !warnedKeys.has(typeKey)) {
-            warnedKeys.add(typeKey);
-            console.warn(
-              `AttributeSetCoder: unknown type key "${typeKey}" — falling back to "value" type`,
-            );
+    const attributesHash = new Map<string, Attribute>(
+      Object.entries(envelope.types).map(([name, typeKey]) => {
+        let type: Type;
+        if (typeKey == null) {
+          type = this.defaultTypes[name];
+        } else {
+          try {
+            type = this.registry.lookup(typeKey);
+          } catch {
+            if (!this.silenceDriftWarnings && !warnedKeys.has(typeKey)) {
+              warnedKeys.add(typeKey);
+              console.warn(
+                `YAMLEncoder: unknown type key "${typeKey}" — falling back to "value" type`,
+              );
+            }
+            type = this.registry.lookup("value");
           }
-          type = this.registry.lookup("value");
         }
-      }
-      attributesHash.set(name, Attribute.fromUser(name, envelope.values[name], type));
-    }
+        return [name, Attribute.fromUser(name, envelope.values[name], type)];
+      }),
+    );
 
     for (const name of envelope.defaultAttributes ?? []) {
       attributesHash.set(name, Attribute.uninitialized(name, this.defaultTypes[name]));

--- a/packages/activemodel/src/attribute-set/yaml-encoder.ts
+++ b/packages/activemodel/src/attribute-set/yaml-encoder.ts
@@ -48,8 +48,7 @@ export class YAMLEncoder {
    * and `encode`/`decode` receive the `Psych::Coder` at the method boundary
    * (`:12`, `:22`).
    *
-   * @noRailsEquivalent `opts` carries what Psych supplies in Ruby and JS has no
-   * analogue of. Psych dumps a `Type` object inline, so a non-default type has
+   * `opts` carries what Psych supplies in Ruby and JS has no analogue of. Psych dumps a `Type` object inline, so a non-default type has
    * to travel as a registry key and come back through `registry` (with
    * `silenceDriftWarnings` muting the unknown-key warning), and there is no
    * `Psych::Coder` object to pass per call, so the serializer is the injected

--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -54,8 +54,9 @@ export {
 export { UserProvidedDefault } from "./attribute/user-provided-default.js";
 export { AttributeSet } from "./attribute-set.js";
 export { LazyAttributeSet, LazyAttributeHash } from "./attribute-set/builder.js";
-export { AttributeSetCoder, AttributeSetCoderError } from "./attribute-set/coder.js";
-export type { AttributeSetCodec, AttributeSetEnvelope } from "./attribute-set/coder.js";
+export { YAMLEncoder } from "./attribute-set/yaml-encoder.js";
+export { AttributeSetCodecError } from "./attribute-set/codecs/codec.js";
+export type { AttributeSetCodec, AttributeSetEnvelope } from "./attribute-set/codecs/codec.js";
 export { jsonCodec } from "./attribute-set/codecs/json.js";
 export { Trailtie } from "./trailtie.js";
 export { WithValidator } from "./validations/with.js";

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -4,7 +4,7 @@ import { pluralize, underscore } from "@blazetrails/activesupport";
 import {
   Attribute,
   AttributeSetBuilder,
-  AttributeSetCoder,
+  YAMLEncoder,
   typeRegistry,
   defineDirtyAttributeMethods,
   replayOwnPendingDecorators,
@@ -594,7 +594,7 @@ interface SchemaHost {
   _columns?: any[];
   _returningColumnsForInsertCache?: string[];
   _attributesBuilder?: any;
-  _yamlEncoder?: AttributeSetCoder;
+  _yamlEncoder?: YAMLEncoder;
   attributeTypes(): Record<string, any>;
   _schemaLoaded?: boolean;
   _virtualAttributesReconciled?: boolean;
@@ -785,10 +785,10 @@ export function columns(this: SchemaHost): any[] {
  *
  * @internal
  */
-export function yamlEncoder(this: SchemaHost): AttributeSetCoder {
+export function yamlEncoder(this: SchemaHost): YAMLEncoder {
   const own = ownSchemaMemo(this, "_yamlEncoder");
   if (own) return own;
-  this._yamlEncoder = new AttributeSetCoder(this.attributeTypes());
+  this._yamlEncoder = new YAMLEncoder(this.attributeTypes());
   return this._yamlEncoder;
 }
 

--- a/scripts/parity/unported-files/baseline.json
+++ b/scripts/parity/unported-files/baseline.json
@@ -37,10 +37,6 @@
     "reason": "Migrates Psych::Coder YAML format versions (:nodoc:). Psych is Ruby-only; JS doesn't use YAML for AR column serialization."
   },
   {
-    "pattern": "attribute_set/yaml_encoder.rb",
-    "reason": "Rails' Psych-specific YAML round-trip class for AttributeSet. Replaced by the pluggable AttributeSetCoder architecture in #1173 (P24a) / #1176 (P24b) — see packages/activemodel/src/attribute-set/{coder.ts,codecs/json.ts,codecs/yaml.ts}. Functional capability is shipped; the Rails class hierarchy doesn't map to the TS codec-injection pattern (no Psych, JSON is the default)."
-  },
-  {
     "pattern": "coders/yaml_column.rb",
     "testFile": "coders/yaml_column_test.rb",
     "reason": "YAML column coder. The store-column dump/load path and the Psych safe-dump class restriction are ported (coders/yaml-column.ts, backed by the `yaml` package — `store :col, coder: \"YAML\"`), but the Psych-specific safe-LOAD machinery (permitted_classes on load, type-mismatch-on-Ruby-class) has no JS analog; those test cases stay Ruby-only."

--- a/scripts/parity/unported-files/unscoped.ts
+++ b/scripts/parity/unported-files/unscoped.ts
@@ -56,15 +56,6 @@ export const UNSCOPED_UNPORTED_FILES: UnportedFile[] = [
       "JS doesn't use YAML for AR column serialization.",
   },
   {
-    pattern: "attribute_set/yaml_encoder.rb", // no test counterpart
-    reason:
-      "Rails' Psych-specific YAML round-trip class for AttributeSet. Replaced by " +
-      "the pluggable AttributeSetCoder architecture in #1173 (P24a) / #1176 (P24b) " +
-      "— see packages/activemodel/src/attribute-set/{coder.ts,codecs/json.ts,codecs/yaml.ts}. " +
-      "Functional capability is shipped; the Rails class hierarchy doesn't map " +
-      "to the TS codec-injection pattern (no Psych, JSON is the default).",
-  },
-  {
     pattern: "coders/yaml_column.rb",
     testFile: "coders/yaml_column_test.rb",
     reason:


### PR DESCRIPTION
Ports `activemodel/lib/active_model/attribute_set/yaml_encoder.rb` at its Rails name and path, so `parity:api` measures the file instead of bucketing it as `[no Rails counterpart]`.

- `attribute-set/coder.ts` → `attribute-set/yaml-encoder.ts`; `AttributeSetCoder` → `YAMLEncoder`. Callers updated (`activemodel/src/index.ts`, `activerecord/src/model-schema.ts#yamlEncoder`, `attribute-set/codecs/*`).
- The trails-only wire contract Psych supplies in Ruby — `AttributeSetEnvelope`, `AttributeSetCodec`, and the error (renamed `AttributeSetCodecError`, it belongs to the codec contract now) — moves to `attribute-set/codecs/codec.ts`, off the Rails-matched file. The Rails-matched file exports only `YAMLEncoder` with `encode`/`decode`.
- `encode`/`decode` now use `map` where `yaml_encoder.rb:13` and `:23` do; both new call-gate rows converged rather than baselined.
- Retires the `attribute_set/yaml_encoder.rb` row from the unported-files register (baseline.json row deleted by hand).

`parity:api`: `attribute_set/yaml_encoder.rb → attribute-set/yaml-encoder.ts  4/4 100% ✓`.
`parity:api:extra --package activemodel`: 338 → 329 total, 60 → 59 files.
`parity:api:calls` and `parity:api:calls:args` both OK.

Closes-story: attribute-set-coder-rename-to-yaml-encoder