### PR TITLE
feat(activesupport,activerecord): port testing modules, split blank?'s object arm, drop the scope option shim

### DIFF
--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -2485,8 +2485,9 @@ describe("AssociationsTest", () => {
       title: "wrongShard",
     });
     const rel = hasManyScope(post, "freshChildren", {
-      className: "ShardedBlogPost",
-      as: "parent",
+      type: "hasMany",
+      name: "freshChildren",
+      options: { className: "ShardedBlogPost", as: "parent" },
     });
     const rows: Base[] = await rel!.toArray();
     expect(rows.map((r) => (r as any).title)).toEqual(["match"]);

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -105,7 +105,6 @@ export interface AssociationOptions {
   counterCache?: boolean | string;
   touch?: boolean | string | string[];
   autosave?: boolean;
-  scope?: (rel: any, owner?: any) => any;
   validate?: boolean;
   required?: boolean;
   optional?: boolean;
@@ -163,6 +162,13 @@ export interface AssociationDefinition {
   type: "belongsTo" | "hasOne" | "hasMany" | "hasAndBelongsToMany";
   name: string;
   options: AssociationOptions & { joinTable?: string };
+  /**
+   * Rails' `MacroReflection#scope` — the macro's second POSITIONAL argument
+   * (`associations/builder/association.rb:48-49`, `associations.rb:1871`).
+   * Rails keeps it on the reflection and never in the options hash, which
+   * `assert_valid_keys` would reject (`association.rb:21,70`).
+   */
+  scope?: ((...args: any[]) => any) | null;
   /**
    * Rails' `MacroReflection#macro`. Present on the rich reflection an
    * `Association` resolves off the owner's class in its constructor
@@ -1118,7 +1124,7 @@ export function _builtAssociationScope(
  *
  * `scope.eager_loading?` is not a distinct check: on the singular load path the
  * scope's eager-loading can only come from a reflection/macro scope lambda
- * (subsumed by `reflection.has_scope?` / `options.scope`) or a target default
+ * (subsumed by `reflection.has_scope?` / the definition's scope) or a target default
  * scope carrying `includes` (subsumed by the `klass.scope_attributes?` arm
  * below), so the remaining arms cover it.
  *
@@ -1136,7 +1142,7 @@ export function _skipSingularStatementCache(
   // `reflection.has_scope?` — a caller-supplied `scope:` lambda (or the
   // reflection's own macro-time scope) is instance-dependent (it receives the
   // owner), so the compiled SQL can't be shared.
-  if (options.scope) return true;
+  if (reflection.scope) return true;
   const refl = reflection as {
     hasScope?(): boolean;
     sourceReflection?: { activeRecord?: { defaultScopes?: unknown[] } } | null;
@@ -1285,7 +1291,6 @@ export function ownerHasUnresolvedThroughKey(
 async function _buildDisableJoinsScopeRelation(
   record: Base,
   reflection: ReflectionLike | null | undefined,
-  options?: AssociationOptions,
 ): Promise<{ rel: unknown } | null> {
   if (!reflection || ownerHasUnresolvedThroughKey(record, reflection)) return null;
   // Lazy-import to avoid an eager cycle: DJAS imports
@@ -1296,16 +1301,14 @@ async function _buildDisableJoinsScopeRelation(
   // DJAS.scope() now returns a sync deferred-chain Relation — the
   // async chain walk runs on first toArray(). No more Promise<{relation}>
   // boxing to unwrap.
-  let rel: unknown = DisableJoinsAssociationScope.create().scope({
+  const rel: unknown = DisableJoinsAssociationScope.create().scope({
     owner: record,
     reflection: reflection as never,
     klass,
   });
-  // Apply caller-supplied `options.scope` when it differs from the
-  // reflection's own scope — same rule the JOIN-based loaders use.
-  // Skipping when equal avoids double-application since DJAS already
-  // consumed the reflection's scope via constraints.
-  rel = applyAssociationScope(rel as never, options?.scope, record, reflection.scope);
+  // DJAS has already consumed `reflection.scope` through its constraints, so
+  // there is nothing left to apply — the scope reaches the reflection
+  // positionally and lives nowhere else (association.rb:48-49).
   return { rel };
 }
 
@@ -1315,7 +1318,7 @@ export async function _loadThroughViaDisableJoinsScope(
   reflection: ReflectionLike | null | undefined,
   options?: AssociationOptions,
 ): Promise<Base[]> {
-  const built = await _buildDisableJoinsScopeRelation(record, reflection, options);
+  const built = await _buildDisableJoinsScopeRelation(record, reflection);
   if (built == null) return [];
   return (built.rel as { toArray: () => Promise<Base[]> }).toArray();
 }
@@ -1338,7 +1341,7 @@ export async function _loadSingularThroughViaDisableJoinsScope(
   reflection: ReflectionLike | null | undefined,
   options?: AssociationOptions,
 ): Promise<Base | null> {
-  const built = await _buildDisableJoinsScopeRelation(record, reflection, options);
+  const built = await _buildDisableJoinsScopeRelation(record, reflection);
   if (built == null) return null;
   return (built.rel as { first: () => Promise<Base | null> }).first();
 }
@@ -1564,9 +1567,10 @@ export function _inlinePolymorphicKeys(
 export async function countHasMany(
   record: Base,
   assocName: string,
-  options: AssociationOptions,
+  assocDef: AssociationDefinition,
 ): Promise<number> {
   const { scope } = await import("./associations/has-many-association.js");
+  const options = assocDef.options;
   if (options.through) {
     // COUNT(*) over the JOIN — matching Rails' scope.count(:all) — instead of
     // materializing rows just to read their length. Temporarily disable strict
@@ -1581,7 +1585,7 @@ export async function countHasMany(
       if (!throughRegistered) {
         throw _hmtNotFound(ctor, assocName, options.through);
       }
-      const rel = scope(record, assocName, options);
+      const rel = scope(record, assocName, assocDef);
       if (!rel) return 0;
       // counter_cache.rb:57 `object.send(counter_association).count(:all)`: the
       // `:all` keeps a `select` declared on the association off the COUNT.
@@ -1597,7 +1601,7 @@ export async function countHasMany(
       record._strictLoadingBypassCount--;
     }
   }
-  const rel = scope(record, assocName, options);
+  const rel = scope(record, assocName, assocDef);
   if (!rel) return 0;
   // counter_cache.rb:57 `object.send(counter_association).count(:all)`.
   const result = await rel.count("all");

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -163,10 +163,16 @@ export interface AssociationDefinition {
   name: string;
   options: AssociationOptions & { joinTable?: string };
   /**
-   * Rails' `MacroReflection#scope` — the macro's second POSITIONAL argument
-   * (`associations/builder/association.rb:48-49`, `associations.rb:1871`).
-   * Rails keeps it on the reflection and never in the options hash, which
-   * `assert_valid_keys` would reject (`association.rb:21,70`).
+   * Rails' `MacroReflection#scope` (`attr_reader :scope`, reflection.rb:376),
+   * assigned from the macro's second POSITIONAL argument beside — never
+   * inside — the options hash: `initialize(name, scope, options,
+   * active_record)` sets `@scope` and `@options` separately
+   * (reflection.rb:388-392), which is the object
+   * `Reflection.create(macro, name, scope, options, model)`
+   * (`associations/builder/association.rb:48-49`) and
+   * `HasAndBelongsToManyReflection.new(name, scope, options, ...)`
+   * (`associations.rb:1871`) build. A scope inside `options` is what
+   * `assert_valid_keys` rejects (`association.rb:21,70`).
    */
   scope?: ((...args: any[]) => any) | null;
   /**

--- a/packages/activerecord/src/associations/association-scope.test.ts
+++ b/packages/activerecord/src/associations/association-scope.test.ts
@@ -319,16 +319,19 @@ describe("AssociationScope", () => {
 
       static {
         this.attribute("id", "integer");
-        this.hasMany("zero_arity_posts", {
-          className: "ZeroArityPost",
-          foreignKey: "zero_arity_author_id",
+        this.hasMany(
+          "zero_arity_posts",
           // The function's .length is 0, so the loader must use scopeFor's
           // 0-arity branch (this=relation). If we passed it as a 1-arg
           // function, `where` would not exist on the empty arg.
-          scope: function (this: any) {
+          function (this: any) {
             return this.where({ active: true });
           },
-        });
+          {
+            className: "ZeroArityPost",
+            foreignKey: "zero_arity_author_id",
+          },
+        );
       }
     }
     class ZeroArityPost extends Base {

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -1015,7 +1015,7 @@ export class Association {
     // Rails: reflection.has_scope? || scope.eager_loading? ||
     //        klass.scope_attributes? || reflection.source_reflection.active_record.default_scopes.any?
     const refl = this.reflection as any;
-    const hasReflScope = !!(refl.hasScope?.() ?? refl.options?.scope);
+    const hasReflScope = !!(refl.hasScope?.() ?? refl.scope);
     const eagerLoading = !!scope?.eagerLoading?.();
     const scopeAttrs = !!(this.klass as any)?.hasScopeAttributes?.();
     const sourceDefaultScopes = !!refl.sourceReflection?.()?.activeRecord?.defaultScopes?.length;

--- a/packages/activerecord/src/associations/builder/association.trails.test.ts
+++ b/packages/activerecord/src/associations/builder/association.trails.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { Association } from "./association.js";
+import { Author } from "../../test-helpers/models/author.js";
+
+// `Builder::Association::VALID_OPTIONS`
+// (associations/builder/association.rb:20-22) does not carry `:scope`: a scope
+// only ever reaches an association as the second POSITIONAL argument
+// (associations.rb:1302), and `create_reflection` hands the options hash
+// straight to `assert_valid_keys` (association.rb:43,70).
+describe("Builder::Association VALID_OPTIONS", () => {
+  it("does not accept a scope in the options hash", () => {
+    expect(Association.VALID_OPTIONS).not.toContain("scope");
+    expect(() => {
+      (Author as unknown as { hasMany(name: string, options: object): void }).hasMany(
+        "scoped_posts",
+        { scope: (rel: unknown) => rel },
+      );
+    }).toThrow(/^Unknown key: :scope\. Valid keys are: /);
+  });
+});

--- a/packages/activerecord/src/associations/builder/association.ts
+++ b/packages/activerecord/src/associations/builder/association.ts
@@ -6,7 +6,7 @@
  */
 
 import { ArgumentError } from "@blazetrails/activemodel";
-import { throwAbort } from "@blazetrails/activesupport";
+import { assertValidKeys, throwAbort } from "@blazetrails/activesupport";
 import { ConfigurationError, RecordNotDestroyed } from "../../errors.js";
 import * as Reflection from "../../reflection.js";
 import { beforeDestroy } from "../../callbacks.js";
@@ -72,7 +72,6 @@ export class Association {
     "inverseOf",
     "strictLoading",
     "queryConstraints",
-    "scope",
   ];
 
   static build(
@@ -121,13 +120,6 @@ export class Association {
     }
 
     this.validateOptions(options);
-
-    // Extract scope from options if passed there (e.g., Associations.hasMany(name, { scope: fn }))
-    if (!scope && typeof options.scope === "function") {
-      scope = options.scope as (...args: any[]) => any;
-      const { scope: _, ...rest } = options;
-      options = rest;
-    }
 
     const extension = this.defineExtensions(model, name);
     if (extension) {
@@ -185,14 +177,7 @@ export class Association {
   }
 
   static validateOptions(options: Record<string, unknown>): void {
-    const valid = new Set(this.validOptions(options));
-    for (const key of Object.keys(options)) {
-      if (!valid.has(key)) {
-        throw new Error(
-          `Unknown key: :${key}. Valid keys are: ${[...valid].map((k) => `:${k}`).join(", ")}`,
-        );
-      }
-    }
+    assertValidKeys(options, this.validOptions(options));
   }
 
   static defineExtensions(_model: any, _name: string): any {

--- a/packages/activerecord/src/associations/builder/association.ts
+++ b/packages/activerecord/src/associations/builder/association.ts
@@ -68,7 +68,6 @@ export class Association {
     "foreignKey",
     "dependent",
     "validate",
-    "autosave",
     "inverseOf",
     "strictLoading",
     "queryConstraints",
@@ -139,12 +138,11 @@ export class Association {
     const reflection = Reflection.create(macro as any, name, scope, options, model);
 
     this._ensureOwnAssociations(model);
-    const assocOptions: Record<string, unknown> = { ...options };
-    if (scope) assocOptions.scope = scope;
     model._associations.push({
       type: macro,
       name,
-      options: assocOptions,
+      scope,
+      options: { ...options },
     });
 
     Reflection.addReflection(model, name, reflection as any);

--- a/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
+++ b/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
@@ -329,17 +329,11 @@ export class HasAndBelongsToMany {
         habtmOptions[k] = options[k];
       }
     }
-    // Rails passes `scope` as the second positional to
-    // `HasAndBelongsToManyReflection.new` (associations.rb:1871). It is
-    // captured as a positional reflection arg below, but kept on the options
-    // bag too for the through-routing loaders, which read it from there.
     const positionalScope = typeof scope === "function" ? scope : null;
-    if (positionalScope) {
-      habtmOptions.scope = positionalScope;
-    }
     model._associations.push({
       type: "hasAndBelongsToMany",
       name,
+      scope: positionalScope,
       options: habtmOptions,
     });
     // Register before/after_add/remove class properties for Rails parity —
@@ -353,12 +347,11 @@ export class HasAndBelongsToMany {
     // the HasAndBelongsToManyReflection in a ThroughReflection — mirrors
     // Rails' `Builder::HasAndBelongsToMany`, which builds an internal
     // has_many :through and registers the HABTM as a through reflection.
-    const { scope: _scope, ...habtmReflectionOptions } = habtmOptions;
     const habtmReflection = Reflection.create(
       "hasAndBelongsToMany" as any,
       name,
       positionalScope,
-      habtmReflectionOptions,
+      habtmOptions,
       model,
     );
     Reflection.addReflection(model, name, habtmReflection as any);

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -603,7 +603,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // `findTarget` runs, and what `countHasMany()` counts) so CP
     // gets identical semantics: the relation starts from
     // `targetModel.all()` (default scope applied), is scope-proxied
-    // (so `options.scope` callbacks can call named scopes / generated
+    // (so the definition's scope callbacks can call named scopes / generated
     // methods on it), and composite-PK mismatches throw
     // `CompositePrimaryKeyMismatchError`. State is then copied onto
     // `this` so the inherited Relation methods observe the same scope.
@@ -648,7 +648,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       // Build via the `scope()` seam so CP's inherited Relation
       // state matches `scope()` / direct Relation callers: default
       // scope from `targetModel.all()` is applied, the relation is
-      // scope-proxied (so `options.scope` can call named scopes /
+      // scope-proxied (so the definition's scope can call named scopes /
       // generated methods on it), and composite-PK validation runs.
       // Then `_copyStateFrom` onto `this`. Missing owner PK →
       // `_isNone = true` (Rails' NullRelation fallback).
@@ -661,7 +661,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       // surface eagerly — they are not part of Rails' lazy-FK contract.
       let seedRel: Relation<T> | null;
       try {
-        seedRel = hasManyScope(record, assocName, assocDef.options) as Relation<T> | null;
+        seedRel = hasManyScope(record, assocName, assocDef) as Relation<T> | null;
       } catch (err) {
         if (err instanceof ArgumentError) {
           this._deferredFkError = err;
@@ -2854,7 +2854,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // that fallback, where the composite guards remain as a loud backstop.
     const refl = this.reflection as any;
     if (_routeThroughViaAssociationScope(this._record, refl, this._assocDef.options)) {
-      const joinRel = hasManyScope(this._record, this._assocName, this._assocDef.options);
+      const joinRel = hasManyScope(this._record, this._assocName, this._assocDef);
       return joinRel ?? (this.model as any).all().none(); // null FK → empty, as below
     }
     // Below is the single-column IN-subquery fallback, reached only for shapes
@@ -2951,7 +2951,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       const inNode = targetArelTable.get(targetPkCol).in(throughSubquery);
 
       let rel = (targetModel as any).all().where(inNode);
-      if (this._assocDef.options.scope) rel = this._assocDef.options.scope(rel);
+      if (this._assocDef.scope) rel = this._assocDef.scope(rel);
       return rel;
     } else {
       const sourceAsName = sourceRefl?.options?.as;
@@ -2964,7 +2964,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
         // single-column IN-subquery can't express the tuple match, so route
         // through the JOIN-based AssociationScope, which builds the composite ON
         // clause. Falls back to a null scope only when the owner FK is absent.
-        const joinRel = hasManyScope(this._record, this._assocName, this._assocDef.options);
+        const joinRel = hasManyScope(this._record, this._assocName, this._assocDef);
         return joinRel ?? (targetModel as any).all().none();
       }
       // When the source reflection specifies a primaryKey option (e.g.
@@ -2992,7 +2992,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       if (sourceAsName) {
         rel = rel.where({ [`${underscore(sourceAsName)}_type`]: throughClassName });
       }
-      if (this._assocDef.options.scope) rel = this._assocDef.options.scope(rel);
+      if (this._assocDef.scope) rel = this._assocDef.scope(rel);
       return rel;
     }
   }

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -1,5 +1,5 @@
 import type { Base } from "../base.js";
-import type { AssociationDefinition, AssociationOptions } from "../associations.js";
+import type { AssociationDefinition } from "../associations.js";
 import {
   _builtAssociationScope,
   _canRouteThroughViaDisableJoinsAssociationScope,
@@ -191,7 +191,7 @@ export class HasManyAssociation extends CollectionAssociation {
       const records = await findTarget(
         this.owner,
         this.reflection.name,
-        this.reflection.options,
+        this.reflection,
         this._queryExecutor,
         this.isViolatesStrictLoading(),
       );
@@ -563,10 +563,11 @@ export function setIntersection(a: Base[], b: Base[]): Base[] {
 async function findTarget(
   record: Base,
   assocName: string,
-  options: AssociationOptions,
+  assocDef: AssociationDefinition,
   queryExecutor?: () => Promise<Base[]>,
   violatesStrictLoading = false,
 ): Promise<Base[]> {
+  const options = assocDef.options;
   if (options.through) {
     validateThroughReflection(record.constructor as typeof Base, assocName);
   }
@@ -639,6 +640,7 @@ async function findTarget(
       const through = _buildAssociationInstance.call(record, {
         name: assocName,
         type: "hasMany",
+        scope: assocDef.scope,
         options,
       }) as unknown as { loadHasManyThrough(): Promise<Base[]> };
       return through.loadHasManyThrough();
@@ -656,7 +658,7 @@ async function findTarget(
     );
   }
 
-  const rel = scope(record, assocName, options);
+  const rel = scope(record, assocName, assocDef);
   if (rel === null) return [];
 
   // Set inverse_of on each loaded child. Resolve via the reflection so
@@ -694,7 +696,12 @@ async function findTarget(
  *
  * @internal
  */
-export function scope(record: Base, assocName: string, options: AssociationOptions): any | null {
+export function scope(
+  record: Base,
+  assocName: string,
+  assocDef: AssociationDefinition,
+): any | null {
+  const options = assocDef.options;
   const ctor = record.constructor as typeof Base;
   const className = options.className ?? camelize(singularize(assocName));
   const primaryKey = options.primaryKey ?? ctor.primaryKey;
@@ -769,14 +776,14 @@ export function scope(record: Base, assocName: string, options: AssociationOptio
     // be merged with `klass.scope_for_association` — otherwise default_scope
     // / scope extensions silently disappear. AssociationScope.scope
     // already merges `reflection.scope` (macro-time lambda) via scopeFor;
-    // skip re-applying `options.scope` ONLY when it's that exact same
+    // skip re-applying the definition's scope ONLY when it's that exact same
     // function. Callers like `loadHasManyThrough` synthesize a NEW
-    // `options.scope` (wrapping with `sourceType` filtering) — those
+    // scope (wrapping with `sourceType` filtering) — those
     // must still run.
     const built = _builtAssociationScope(record, assocName, reflection, targetModel);
     const baseRelation = _scopeForAssociation(targetModel);
     rel = baseRelation.merge(built);
-    rel = applyAssociationScope(rel, options.scope, record, reflection.scope);
+    rel = applyAssociationScope(rel, assocDef.scope, record, reflection.scope);
   } else {
     // Inline fallback: no reflection (lower-level test helpers).
     if (Array.isArray(foreignKey)) {
@@ -818,7 +825,7 @@ export function scope(record: Base, assocName: string, options: AssociationOptio
         [foreignKey]: record._readAttribute(ownerKey as string),
       });
     }
-    rel = applyAssociationScope(rel, options.scope, record);
+    rel = applyAssociationScope(rel, assocDef.scope, record);
   }
   return rel;
 }

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -1,5 +1,5 @@
 import type { Base } from "../base.js";
-import type { AssociationDefinition, AssociationOptions } from "../associations.js";
+import type { AssociationDefinition } from "../associations.js";
 import { association, _buildAssociationInstance } from "./instance-methods.js";
 import { HasManyAssociation } from "./has-many-association.js";
 import {
@@ -113,7 +113,7 @@ export class HasManyThroughAssociation extends HasManyAssociation {
    * @internal
    */
   protected loadHasManyThrough(): Promise<Base[]> {
-    return loadHasManyThrough(this.owner, this.reflection.name, this.reflection.options);
+    return loadHasManyThrough(this.owner, this.reflection.name, this.reflection);
   }
 
   /**
@@ -1145,12 +1145,13 @@ function targetReflectionHasAssociatedRecord(
 function findHasManyTarget(
   record: Base,
   assocName: string,
-  options: AssociationOptions,
+  assocDef: Pick<AssociationDefinition, "options" | "scope">,
 ): Promise<Base[]> {
   const assoc = _buildAssociationInstance.call(record, {
     name: assocName,
     type: "hasMany",
-    options,
+    scope: assocDef.scope,
+    options: assocDef.options,
   });
   return (assoc as unknown as { findTarget(): Promise<Base[]> }).findTarget();
 }
@@ -1162,8 +1163,9 @@ function findHasManyTarget(
 async function loadHasManyThrough(
   record: Base,
   assocName: string,
-  options: AssociationOptions,
+  assocDef: AssociationDefinition,
 ): Promise<Base[]> {
+  const options = assocDef.options;
   const ctor = record.constructor as typeof Base;
   const associations: AssociationDefinition[] = ctor._associations ?? [];
   const throughAssoc = associations.find((a) => a.name === options.through);
@@ -1195,18 +1197,22 @@ async function loadHasManyThrough(
     ) {
       const resolvedSourceName = sourceAssoc?.name ?? sourceName;
       const sourceTypeCol = `${underscore(resolvedSourceName)}_type`;
-      const originalScope = throughAssoc.options.scope;
-      const augmentedOptions = {
-        ...throughAssoc.options,
+      const originalScope = throughAssoc.scope;
+      // `Reflection.create(macro, name, scope, options, model)` keeps the scope
+      // beside the options hash rather than in it (association.rb:48-49), so the
+      // synthesised `sourceType` scope replaces the definition's own without
+      // touching its options.
+      const augmentedDefinition = {
+        options: throughAssoc.options,
         scope: (rel: any) => {
           let r = rel.where({ [sourceTypeCol]: options.sourceType });
           if (originalScope) r = originalScope(r);
           return r;
         },
       };
-      throughRecords = await findHasManyTarget(record, throughAssoc.name, augmentedOptions);
+      throughRecords = await findHasManyTarget(record, throughAssoc.name, augmentedDefinition);
     } else {
-      throughRecords = await findHasManyTarget(record, throughAssoc.name, throughAssoc.options);
+      throughRecords = await findHasManyTarget(record, throughAssoc.name, throughAssoc);
     }
   } else if (throughAssoc.type === "hasOne") {
     const one = (await association.call(record, throughAssoc.name).loadTarget()) as Base | null;
@@ -1228,22 +1234,22 @@ async function loadHasManyThrough(
       .filter((v) => v !== null && v !== undefined);
     if (targetIds.length === 0) return [];
     let rel = targetModel.all().where({ [targetModel.primaryKey as string]: targetIds });
-    rel = applyAssociationScope(rel, options.scope, record);
+    rel = applyAssociationScope(rel, assocDef.scope, record);
     return rel.toArray();
   } else if (sourceAssoc?.options?.through) {
     const results: Base[] = [];
     for (const tr of throughRecords) {
-      const sub = await findHasManyTarget(tr, sourceAssoc.name, sourceAssoc.options);
+      const sub = await findHasManyTarget(tr, sourceAssoc.name, sourceAssoc);
       results.push(...sub);
     }
-    if (!options.scope) return results;
+    if (!assocDef.scope) return results;
     const ids = results
       .map((r) => r._readAttribute(targetModel.primaryKey as string))
       .filter((v) => v !== null && v !== undefined);
     if (ids.length === 0) return [];
     const rel = applyAssociationScope(
       targetModel.all().where({ [targetModel.primaryKey as string]: ids }),
-      options.scope,
+      assocDef.scope,
       record,
     );
     return rel.toArray();
@@ -1259,7 +1265,7 @@ async function loadHasManyThrough(
     const whereConditions: Record<string, unknown> = { [sourceFk as string]: throughIds };
     if (sourceAsName) whereConditions[`${underscore(sourceAsName)}_type`] = throughClassName;
     let rel = targetModel.all().where(whereConditions);
-    rel = applyAssociationScope(rel, options.scope, record);
+    rel = applyAssociationScope(rel, assocDef.scope, record);
     return rel.toArray();
   }
 }

--- a/packages/activerecord/src/associations/singular-association.ts
+++ b/packages/activerecord/src/associations/singular-association.ts
@@ -388,7 +388,7 @@ export class SingularAssociation extends Association {
         const built = _builtAssociationScope(owner, assocName, reflection, targetModel);
         const baseRelation = _scopeForAssociation(targetModel);
         let rel = baseRelation.merge(built);
-        rel = applyAssociationScope(rel, options.scope, owner, reflection.scope);
+        rel = applyAssociationScope(rel, this.reflection.scope, owner, reflection.scope);
         // Rails returns the array and calls `Array#first` — no ORDER BY in SQL.
         // `take` (unordered LIMIT 1) matches; `first` would route through
         // `ordered_relation` and add one. See has_one_associations_test

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -171,6 +171,28 @@ export function validOptions(): string[] {
   return ["autosave"];
 }
 
+/**
+ * `AutosaveAssociation`'s `included do` block
+ * (autosave_association.rb:153-155): `Associations::Builder::Association
+ * .extensions << AssociationBuilderExtension`, the registration that puts
+ * `:autosave` in `valid_options` (autosave_association.rb:148) — Rails' base
+ * `VALID_OPTIONS` deliberately does not list it (association.rb:21). Called
+ * from `base.ts` beside `include(Base, AutosaveAssociation)`, since importing
+ * the builder here closes a module cycle through `reflection.ts`.
+ * @internal
+ */
+export function _registerAssociationBuilderExtension(extensions: ExtensionList): void {
+  extensions.push({ build, validOptions });
+}
+
+/** The `Builder::Association.extensions` array the block above pushes onto. */
+interface ExtensionList {
+  push(extension: {
+    build(model: typeof Base, reflection: { options: Record<string, unknown> }): void;
+    validOptions(): string[];
+  }): void;
+}
+
 // Post-commit flush for association instances that still queue a deferred
 // `_pendingReplace`. Collection associations no longer participate: their
 // persisted-owner assignment throws (`CollectionPersistedAssignmentError`) and

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -84,7 +84,9 @@ import {
   flushPendingReplaces,
   computePrimaryKey as _computePrimaryKey,
   _ensureNoDuplicateErrors as _autosaveEnsureNoDuplicateErrors,
+  _registerAssociationBuilderExtension,
 } from "./autosave-association.js";
+import { Association as AssociationBuilder } from "./associations/builder/association.js";
 import {
   isValid as validationsIsValid,
   defaultValidationContext,
@@ -4678,6 +4680,7 @@ include(Base, TouchLater.InstanceMethods);
 };
 include(Base, _AttributeAssignment.InstanceMethods);
 include(Base, AutosaveAssociation);
+_registerAssociationBuilderExtension(AssociationBuilder.extensions);
 // AutosaveAssociation#reload resets marked-for-destruction / destroyed-by-
 // association state, then calls super. Capture the inherited reload (Persistence)
 // at wire time and slot it BELOW Aggregations' lazy wrap, so the MRO is

--- a/packages/activerecord/src/counter-cache.ts
+++ b/packages/activerecord/src/counter-cache.ts
@@ -186,7 +186,7 @@ export async function resetCounters(
     ) as any;
     const counterName = reflection.counterCacheColumn();
 
-    const count = await countHasMany(object, countReflection.name, countReflection.options);
+    const count = await countHasMany(object, countReflection.name, countReflection);
     // Ruby's `!=` is type-coercing across Integer/Bignum; in TS the stored
     // attribute of a big_integer column is a bigint and needs an explicit widen.
     const countWas = (object as any).readAttribute?.(counterName) ?? (object as any)[counterName];

--- a/packages/activerecord/src/delegated-type-scope.test.ts
+++ b/packages/activerecord/src/delegated-type-scope.test.ts
@@ -4,7 +4,7 @@ import { delegatedType } from "./index.js";
 
 // Rails' `delegated_type(role, types:, **options)` forwards `options[:scope]`
 // as the polymorphic belongs_to scope proc. trails' belongsTo takes the scope
-// via `options.scope`, so it must reach the generated reflection.
+// as the belongs_to's positional scope, so it must reach the generated reflection.
 describe("delegatedType :scope option", () => {
   it("forwards the scope proc to the generated belongsTo reflection", () => {
     const scope = (rel: any) => rel.order("created_at");

--- a/packages/activerecord/src/delegated-type.ts
+++ b/packages/activerecord/src/delegated-type.ts
@@ -71,11 +71,15 @@ export function delegatedType(
   const primaryKey = options.primaryKey ?? "id";
   const config = { ...options, foreignKey, foreignType, primaryKey };
 
-  // Rails: belongs_to role, options.delete(:scope), **options.merge(polymorphic: true)
-  // — the `:scope` proc becomes the belongs_to scope; the rest are options.
-  // trails' belongsTo takes the scope as `options.scope`, so forward it there.
-  const { types: _types, ...assocOptions } = options as DelegatedTypeOptions & { types?: unknown };
-  (modelClass as any).belongsTo(role, {
+  // `belongs_to role, options.delete(:scope), **options.merge(polymorphic: true)`
+  // (delegated_type.rb:232) — the `:scope` proc is the belongs_to's positional
+  // scope, and `delete` takes it out of the options hash before the merge.
+  const {
+    types: _types,
+    scope,
+    ...assocOptions
+  } = options as DelegatedTypeOptions & { types?: unknown; scope?: (...args: any[]) => any };
+  (modelClass as any).belongsTo(role, scope ?? null, {
     ...assocOptions,
     polymorphic: true,
     foreignKey,

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1637,7 +1637,7 @@ export class Relation<T extends Base> {
    * @internal
    */
   private _appendAssociationScope(predicates: Nodes.Node[], assocDef: any, targetModel: any): void {
-    const scope = assocDef.options.scope;
+    const scope = assocDef.scope;
     if (typeof scope !== "function") return;
     const baseRel = targetModel._allForPreload();
     const scopeRel = invokeScopeLambda(scope, baseRel, undefined as unknown as Base) || baseRel;

--- a/packages/activerecord/src/test-helpers/find-collection-target.ts
+++ b/packages/activerecord/src/test-helpers/find-collection-target.ts
@@ -1,5 +1,5 @@
 import type { Base } from "../base.js";
-import type { AssociationOptions } from "../associations.js";
+import type { AssociationDefinition, AssociationOptions } from "../associations.js";
 import { _buildAssociationInstance } from "../associations/instance-methods.js";
 
 /**
@@ -19,21 +19,30 @@ import { _buildAssociationInstance } from "../associations/instance-methods.js";
  *
  * `scope` is positional ahead of `options`, as on the macros it stands in for
  * (`has_many(name, scope = nil, **options)`, `associations.rb:1302`), and is
- * folded into the holder's options the same way `Builder::Association.build`
- * folds it into the reflection's (`builder/association.ts:151`) — which is what
- * a caller forwarding a whole `reflection.options` is already passing.
+ * kept beside the options the same way `Builder::Association.createReflection`
+ * keeps it beside the reflection's (`association.rb:48-49`) — the options hash
+ * never carries it, so a caller forwarding a whole `reflection.options` passes
+ * options only.
  */
+type AssociationScopeLambda = NonNullable<AssociationDefinition["scope"]>;
+
 export async function findCollectionTarget(
   record: Base,
   name: string,
-  scope: NonNullable<AssociationOptions["scope"]> | AssociationOptions | null = {},
+  scope: AssociationScopeLambda | AssociationOptions | null = {},
   options: AssociationOptions = {},
 ): Promise<Base[]> {
+  let positionalScope: AssociationScopeLambda | null = null;
   if (typeof scope === "function") {
-    options = { ...options, scope };
+    positionalScope = scope;
   } else if (scope !== null) {
     options = scope;
   }
-  const assoc = _buildAssociationInstance.call(record, { name, type: "hasMany", options });
+  const assoc = _buildAssociationInstance.call(record, {
+    name,
+    type: "hasMany",
+    scope: positionalScope,
+    options,
+  });
   return (assoc as unknown as { findTarget(): Promise<Base[]> }).findTarget();
 }

--- a/packages/activesupport/src/core-ext/object/blank.trails.test.ts
+++ b/packages/activesupport/src/core-ext/object/blank.trails.test.ts
@@ -22,7 +22,7 @@ describe("Object#blank? respond_to?(:empty?) probe", () => {
   // Invoking to find out is not an option — the query would already have been
   // issued — so the AsyncFunction is recognised before the call, bound or not
   // (`Function.prototype.bind` copies the target's prototype).
-  it("never invokes an async isEmpty, bound or not, falling back to the own-key arm", () => {
+  it("never invokes an async isEmpty, bound or not, falling back to !self", () => {
     let called = false;
     class Relation {
       async isEmpty(): Promise<boolean> {
@@ -31,9 +31,9 @@ describe("Object#blank? respond_to?(:empty?) probe", () => {
       }
     }
     const relation = new Relation();
-    // Both fall through to the own-key arm: a bare instance carries no own key
-    // (its method is on the prototype), the literal carries one.
-    expect(isBlank(relation)).toBe(true);
+    // Both fall through past the probe: the instance reaches `!self`
+    // (blank.rb:18-20), the literal is a Hash and carries one key.
+    expect(isBlank(relation)).toBe(false);
     expect(isBlank({ isEmpty: relation.isEmpty.bind(relation) })).toBe(false);
     expect(called).toBe(false);
   });
@@ -57,5 +57,36 @@ describe("Object#blank? respond_to?(:empty?) probe", () => {
     expect(isBlank({ isEmpty: () => null })).toBe(false);
     expect(isBlank({ isEmpty: true })).toBe(true);
     expect(isBlank({ empty: false })).toBe(false);
+  });
+});
+
+// blank.rb has two arms behind one TS switch: `Hash#blank?` is
+// `alias_method :blank?, :empty?` (blank.rb:111), and `Object#blank?` is
+// `!self` (blank.rb:18-20) — always `false`, since only nil/false are falsy.
+// A JS object literal is the Ruby Hash; every other object is the Ruby Object.
+describe("Object#blank? vs Hash#blank?", () => {
+  it("counts own keys for a Hash, per blank.rb:111", () => {
+    expect(isBlank({})).toBe(true);
+    expect(isBlank({ a: 1 })).toBe(false);
+    expect(isBlank(Object.create(null) as object)).toBe(true);
+  });
+
+  // Ruby keeps no own keys for a getter, so `Object.keys` reporting `0` says
+  // nothing about the receiver — Ruby's answer is `false` either way.
+  it("answers false for a class instance with no own keys, per blank.rb:18-20", () => {
+    class Config {
+      get name(): string {
+        return "trails";
+      }
+    }
+    expect(isBlank(new Config())).toBe(false);
+
+    class Slots {
+      readonly #value = 1;
+      value(): number {
+        return this.#value;
+      }
+    }
+    expect(isBlank(new Slots())).toBe(false);
   });
 });

--- a/packages/activesupport/src/core-ext/object/blank.ts
+++ b/packages/activesupport/src/core-ext/object/blank.ts
@@ -22,6 +22,16 @@ function isAsyncFunction(fn: object): boolean {
   return Object.prototype.toString.call(fn) === "[object AsyncFunction]";
 }
 
+/**
+ * A JS object literal is trails' Ruby `Hash`, and only it reaches blank.rb:111's
+ * `alias_method :blank?, :empty?`. A class instance is a plain Ruby object, whose
+ * `blank?` is `!self` (blank.rb:18-20) — never an own-key count.
+ */
+function isPlainObject(value: object): boolean {
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
 function isThenable(v: unknown): v is PromiseLike<unknown> {
   return typeof (v as { then?: unknown } | null | undefined)?.then === "function";
 }
@@ -32,9 +42,8 @@ function isThenable(v: unknown): v is PromiseLike<unknown> {
  * typed on the whole family plus `TimeWithZone` — the same widening
  * `core-ext/object/json.ts` applies to `Time#as_json`. `Temporal.PlainDate` /
  * `PlainDateTime` stand for Ruby's `Date` / `DateTime`, which blank.rb does not
- * reopen; they are `false` in Ruby through `Object#blank?`, which the object
- * arm below cannot reproduce because it is trails' `Hash` arm and reports a
- * slot-only Temporal value as empty.
+ * reopen; they are `false` in Ruby through `Object#blank?`, which the fallthrough
+ * arm below now answers for them anyway.
  */
 type TimeValue =
   | Date
@@ -132,7 +141,7 @@ export class Time {
  * A NON-`async` function that returns a promise anyway defeats any pre-call
  * test, so the answer is also checked after the fact: a thenable result is
  * discarded (with its rejection swallowed, since nobody can await it) and the
- * own-key arm answers instead. That keeps a mis-declared querying `empty?` from
+ * fallthrough arm answers instead. That keeps a mis-declared querying `empty?` from
  * reporting a promise as present — the contract stays "a querying `empty?` is
  * spelled `async`", and this is what happens when it is not.
  *
@@ -166,7 +175,7 @@ export function isBlank(value: unknown): boolean {
     if (isThenable(result)) void Promise.resolve(result).catch(() => undefined);
     else return result != null && result !== false;
   }
-  if (typeof value === "object") return Object.keys(value).length === 0;
+  if (typeof value === "object" && isPlainObject(value)) return Object.keys(value).length === 0;
   return false;
 }
 

--- a/packages/activesupport/src/test-case.test.ts
+++ b/packages/activesupport/src/test-case.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest";
+import { NameError } from "./core-ext/name-error.js";
+import { stubConst } from "./testing/constant-stubbing.js";
 
 function mbLength(str: string): number {
   return [...str].length;
@@ -628,43 +630,63 @@ describe("TestOrderTest", () => {
   });
 });
 
+class ConstStubbable {
+  static CONSTANT = 1;
+}
+
+class SubclassOfConstStubbable extends ConstStubbable {}
+
 describe("TestConstStubbing", () => {
   it("stubbing a constant temporarily replaces it with a new value", () => {
-    // In JS, we can temporarily override object properties
-    const container: any = { CONSTANT: "original" };
-    const original = container.CONSTANT;
-    container.CONSTANT = "stubbed";
-    expect(container.CONSTANT).toBe("stubbed");
-    container.CONSTANT = original;
-    expect(container.CONSTANT).toBe("original");
+    stubConst(ConstStubbable as never, "CONSTANT", 2, () => {
+      expect(ConstStubbable.CONSTANT).toBe(2);
+    });
+
+    expect(ConstStubbable.CONSTANT).toBe(1);
   });
 
   it("stubbed constant still reset even if exception is raised", () => {
-    const container: any = { CONSTANT: "original" };
-    const original = container.CONSTANT;
-    try {
-      container.CONSTANT = "stubbed";
-      throw new Error("test");
-    } catch {
-      // Reset always
-    } finally {
-      container.CONSTANT = original;
-    }
-    expect(container.CONSTANT).toBe("original");
+    expect(() => {
+      stubConst(ConstStubbable as never, "CONSTANT", 2, () => {
+        expect(ConstStubbable.CONSTANT).toBe(2);
+        throw new Error("Exception");
+      });
+    }).toThrow("Exception");
+
+    expect(ConstStubbable.CONSTANT).toBe(1);
   });
 
   it("stubbing a constant that does not exist in the receiver raises NameError", () => {
-    // In JS, accessing undefined property is safe (returns undefined), not an error
-    const obj: any = {};
-    expect(obj.NONEXISTENT).toBeUndefined();
+    expect(() => {
+      stubConst(ConstStubbable as never, "NOT_A_CONSTANT", 1, () => {});
+    }).toThrow(NameError);
+
+    // `const_get(constant, false)` does not look up the ancestors, so the
+    // constant the SUBCLASS inherits is not one it defines.
+    expect(() => {
+      stubConst(SubclassOfConstStubbable as never, "CONSTANT", 1, () => {});
+    }).toThrow(NameError);
   });
 
   it("stubbing a constant that does not exist can be done with `exists: false`", () => {
-    const container: any = {};
-    container.NEW_CONST = "value";
-    expect(container.NEW_CONST).toBe("value");
-    delete container.NEW_CONST;
-    expect(container.NEW_CONST).toBeUndefined();
+    stubConst(
+      ConstStubbable as never,
+      "NOT_A_CONSTANT",
+      1,
+      () => {
+        expect((ConstStubbable as { NOT_A_CONSTANT?: number }).NOT_A_CONSTANT).toBe(1);
+      },
+      { exists: false },
+    );
+
+    // Ruby raises NameError for an undefined constant; JS reads `undefined`.
+    expect((ConstStubbable as { NOT_A_CONSTANT?: number }).NOT_A_CONSTANT).toBeUndefined();
+
+    // Ruby's `Object`, the namespace `ConstStubbable` itself is defined in.
+    const namespace = { ConstStubbable } as unknown as Record<string, unknown>;
+    expect(() => {
+      stubConst(namespace, "ConstStubbable", 1, () => {}, { exists: false });
+    }).toThrow(NameError);
   });
 });
 

--- a/packages/activesupport/src/test-case.ts
+++ b/packages/activesupport/src/test-case.ts
@@ -32,6 +32,8 @@ import {
   assertChanges,
   assertNoChanges,
 } from "./testing/assertions.js";
+import { assertErrorReported, assertNoErrorReported } from "./testing/error-reporter-assertions.js";
+import { stubConst } from "./testing/constant-stubbing.js";
 import {
   assertDeprecated,
   assertNotDeprecated,
@@ -63,10 +65,17 @@ export class TestCase {
   static assertChanges = assertChanges;
   static assertNoChanges = assertNoChanges;
 
+  // include ActiveSupport::Testing::ErrorReporterAssertions (test_case.rb:148)
+  static assertErrorReported = assertErrorReported;
+  static assertNoErrorReported = assertNoErrorReported;
+
   // include ActiveSupport::Testing::Deprecation (test_case.rb:149)
   static assertDeprecated = assertDeprecated;
   static assertNotDeprecated = assertNotDeprecated;
   static collectDeprecations = collectDeprecations;
+
+  // include ActiveSupport::Testing::ConstantStubbing (test_case.rb:150)
+  static stubConst = stubConst;
 
   // include ActiveSupport::Testing::TimeHelpers (test_case.rb:151)
   static travel = travel;

--- a/packages/activesupport/src/testing/assertions.ts
+++ b/packages/activesupport/src/testing/assertions.ts
@@ -26,8 +26,15 @@ import { indexWith } from "../enumerable-utils.js";
 import { cwd, env } from "../process-adapter.js";
 import { _testCaseIdentity, taggedLogger } from "./tagged-logging.js";
 
-/** Mirrors `Minitest::Assertion` — the error a failed assertion raises. */
-class Assertion extends Error {
+/**
+ * Mirrors `Minitest::Assertion` — the error a failed assertion raises.
+ *
+ * @noRailsEquivalent PERMANENT — minitest's, not Rails': Rails raises it
+ * (assertions.rb, error_reporter_assertions.rb:45) but the class is defined in
+ * the minitest gem, which has no vendored Rails file for the comparator to map
+ * onto. Exported so `testing/error-reporter-assertions.ts` raises the same one.
+ */
+export class Assertion extends Error {
   override name = "Assertion";
 }
 
@@ -448,7 +455,7 @@ export async function assertNoChanges<T>(
 }
 
 /** @internal */
-async function _assertNothingRaisedOrWarn<T>(
+export async function _assertNothingRaisedOrWarn<T>(
   assertion: string,
   block?: () => T | Promise<T>,
 ): Promise<T | undefined> {

--- a/packages/activesupport/src/testing/constant-stubbing.ts
+++ b/packages/activesupport/src/testing/constant-stubbing.ts
@@ -1,0 +1,66 @@
+/**
+ * Mirrors: active_support/testing/constant_stubbing.rb
+ *
+ * A Ruby constant under a module is a property of an object here, so
+ * `const_get`/`const_set`/`remove_const` are the property reads, writes and
+ * deletes below, against the same `mod` receiver Rails takes.
+ */
+import { NameError } from "../core-ext/name-error.js";
+
+/**
+ * Changes the value of a constant for the duration of a block. Example:
+ *
+ *   // World.List.Import.LARGE_IMPORT_THRESHOLD === 5000
+ *   stubConst(World.List.Import, "LARGE_IMPORT_THRESHOLD", 1, () => {
+ *     assertEqual(1, World.List.Import.LARGE_IMPORT_THRESHOLD);
+ *   });
+ *
+ *   assertEqual(5000, World.List.Import.LARGE_IMPORT_THRESHOLD);
+ *
+ * Using this method rather than forcing
+ * `World.List.Import.LARGE_IMPORT_THRESHOLD = 5000` prevents warnings from
+ * being thrown, and ensures that the old value is returned after the test has
+ * completed.
+ *
+ * If the constant doesn't already exist, but you need it set for the duration
+ * of the block you can do so by passing `exists: false`.
+ *
+ *   stubConst(object, "SOME_CONST", 1, () => {
+ *     assertEqual(1, object.SOME_CONST);
+ *   }, { exists: false });
+ */
+export function stubConst<T>(
+  mod: Record<string, unknown>,
+  constant: string,
+  newValue: unknown,
+  block: () => T,
+  { exists = true }: { exists?: boolean } = {},
+): T {
+  if (exists) {
+    // `mod.const_get(constant, false)` — `false` is `inherit`, so an
+    // inherited constant is NOT found and Ruby raises NameError.
+    if (!Object.prototype.hasOwnProperty.call(mod, constant)) {
+      throw new NameError(`uninitialized constant ${constant}`, constant);
+    }
+    const oldValue = mod[constant];
+    try {
+      delete mod[constant];
+      mod[constant] = newValue;
+      return block();
+    } finally {
+      delete mod[constant];
+      mod[constant] = oldValue;
+    }
+  } else {
+    if (constant in mod) {
+      throw new NameError(`already defined constant ${constant} in ${String(mod.name ?? "")}`);
+    }
+
+    try {
+      mod[constant] = newValue;
+      return block();
+    } finally {
+      delete mod[constant];
+    }
+  }
+}

--- a/packages/activesupport/src/testing/error-reporter-assertions.trails.test.ts
+++ b/packages/activesupport/src/testing/error-reporter-assertions.trails.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { ActiveSupport } from "../index.js";
+import { assertErrorReported, assertNoErrorReported } from "./error-reporter-assertions.js";
+
+class IOError extends Error {}
+
+// `ErrorReporterAssertions` has no Rails test file of its own — Rails exercises
+// it through the suites that use it (deprecation_test.rb, cache_store_behavior)
+// — so its own coverage lives here.
+describe("ActiveSupport::Testing::ErrorReporterAssertions", () => {
+  it("returns the matching report", async () => {
+    const report = await assertErrorReported(IOError, () => {
+      ActiveSupport.errorReporter.report(new IOError("Oops"), { context: { section: "admin" } });
+    });
+    expect(report?.error.message).toBe("Oops");
+    expect(report?.context.section).toBe("admin");
+    expect(report?.isHandled()).toBe(true);
+  });
+
+  it("fails when no error is reported", async () => {
+    await expect(assertErrorReported(IOError, () => {})).rejects.toThrow(
+      "Expected a IOError to be reported, but there were no errors reported.",
+    );
+  });
+
+  it("fails when no reported error matches", async () => {
+    await expect(
+      assertErrorReported(IOError, () => {
+        ActiveSupport.errorReporter.report(new RangeError("nope"));
+      }),
+    ).rejects.toThrow(/none of the 1 reported errors matched/);
+  });
+
+  it("passes when nothing is reported", async () => {
+    await expect(assertNoErrorReported(() => {})).resolves.toBeUndefined();
+  });
+
+  it("fails when something is reported", async () => {
+    await expect(
+      assertNoErrorReported(() => {
+        ActiveSupport.errorReporter.report(new IOError("Oops"));
+      }),
+    ).rejects.toThrow(/to be empty\?/);
+  });
+
+  // Each `record` stacks its own recorder, so an inner assertion does not
+  // swallow the reports an outer one is watching for.
+  it("records nested blocks independently", async () => {
+    const outer = await assertErrorReported(Error, async () => {
+      await assertErrorReported(IOError, () => {
+        ActiveSupport.errorReporter.report(new IOError("inner"));
+      });
+    });
+    expect(outer?.error.message).toBe("inner");
+  });
+});

--- a/packages/activesupport/src/testing/error-reporter-assertions.ts
+++ b/packages/activesupport/src/testing/error-reporter-assertions.ts
@@ -59,8 +59,7 @@ export const ErrorCollector = {
       await block();
       return reports;
     } finally {
-      const at = recorders.findIndex((r) => reports === r);
-      if (at !== -1) recorders.splice(at, 1);
+      deleteIf(recorders, (r) => reports === r);
     }
   },
 
@@ -88,6 +87,13 @@ export const ErrorCollector = {
  *
  * @internal
  */
+function deleteIf<T>(array: T[], predicate: (element: T) => boolean): void {
+  for (let i = array.length - 1; i >= 0; i--) {
+    if (predicate(array[i])) array.splice(i, 1);
+  }
+}
+
+/** @internal */
 function subscribe(): void {
   if (ErrorCollector.subscribed) return;
 
@@ -130,6 +136,11 @@ export async function assertNoErrorReported(block: () => unknown): Promise<void>
  *
  *   const report = await assertErrorReported(IOError, () => { ... });
  *   assertEqual("Oops", report.error.message);
+ *
+ * Ruby's block is a separate `&block` parameter and is not optional; TypeScript
+ * cannot declare a required parameter after `error_class`'s default, so the
+ * block carries one too. Rails' `self.assertions += 1` on the matching arm is
+ * Minitest's assertion counter, for which trails has no receiver.
  */
 export async function assertErrorReported(
   errorClass: abstract new (...args: any[]) => Error = Error,

--- a/packages/activesupport/src/testing/error-reporter-assertions.ts
+++ b/packages/activesupport/src/testing/error-reporter-assertions.ts
@@ -1,0 +1,158 @@
+/**
+ * Mirrors: active_support/testing/error_reporter_assertions.rb
+ *
+ * The `ErrorCollector` subscribes itself to `ActiveSupport.errorReporter` once
+ * and stacks a recorder array per `record` call, so nested assertions each see
+ * the reports raised inside their own block.
+ */
+import { ActiveSupport } from "../index.js";
+import { IsolatedExecutionState } from "../isolated-execution-state.js";
+import type { ErrorContext, ErrorSeverity } from "../error-reporter.js";
+import { assert, Assertion, _assertNothingRaisedOrWarn } from "./assertions.js";
+
+const RECORDERS = "active_support_error_reporter_assertions";
+
+/**
+ * `Report = Struct.new(..., keyword_init: true)` plus its
+ * `alias_method :handled?, :handled` reopening
+ * (error_reporter_assertions.rb:10-13).
+ * @internal
+ */
+export class Report {
+  error: Error;
+  handled: boolean;
+  severity: ErrorSeverity;
+  context: ErrorContext;
+  source: string;
+
+  constructor(kwargs: {
+    error: Error;
+    handled: boolean;
+    severity: ErrorSeverity;
+    context: ErrorContext;
+    source: string;
+  }) {
+    this.error = kwargs.error;
+    this.handled = kwargs.handled;
+    this.severity = kwargs.severity;
+    this.context = kwargs.context;
+    this.source = kwargs.source;
+  }
+
+  isHandled(): boolean {
+    return this.handled;
+  }
+}
+
+/** @internal */
+export const ErrorCollector = {
+  subscribed: false,
+
+  async record(block: () => unknown): Promise<Report[]> {
+    subscribe();
+    const recorders =
+      IsolatedExecutionState.get<Report[][]>(RECORDERS) ??
+      IsolatedExecutionState.set(RECORDERS, [] as Report[][]);
+    const reports: Report[] = [];
+    recorders.push(reports);
+    try {
+      await block();
+      return reports;
+    } finally {
+      const at = recorders.findIndex((r) => reports === r);
+      if (at !== -1) recorders.splice(at, 1);
+    }
+  },
+
+  report(
+    error: Error,
+    kwargs: {
+      handled: boolean;
+      severity: ErrorSeverity;
+      context: ErrorContext;
+      source: string;
+    },
+  ): boolean {
+    const report = new Report({ error, ...kwargs });
+    IsolatedExecutionState.get<Report[][]>(RECORDERS)?.forEach((reports) => {
+      reports.push(report);
+    });
+    return true;
+  },
+};
+
+/**
+ * `@mutex.synchronize` (error_reporter_assertions.rb:39) guards a race a
+ * single-threaded JS runtime cannot have: nothing can interleave between the
+ * `@subscribed` read and the write below.
+ *
+ * @internal
+ */
+function subscribe(): void {
+  if (ErrorCollector.subscribed) return;
+
+  if (ActiveSupport.errorReporter) {
+    ActiveSupport.errorReporter.subscribe(ErrorCollector);
+    ErrorCollector.subscribed = true;
+  } else {
+    throw new Assertion("No error reporter is configured");
+  }
+}
+
+/**
+ * Assertion that the block should not cause an exception to be reported
+ * to `Rails.error`.
+ *
+ * Passes if evaluated code in the yielded block reports no exception.
+ *
+ *   assertNoErrorReported(() => {
+ *     performService({ param: "no_exception" });
+ *   });
+ */
+export async function assertNoErrorReported(block: () => unknown): Promise<void> {
+  const reports = await ErrorCollector.record(() =>
+    _assertNothingRaisedOrWarn("assert_no_error_reported", block),
+  );
+  // Minitest's `assert_predicate(reports, :empty?)`, with its message.
+  assert(
+    reports.length === 0,
+    () => `Expected [${reports.map((r) => r.error.constructor.name).join(", ")}] to be empty?`,
+  );
+}
+
+/**
+ * Assertion that the block should cause at least one exception to be reported
+ * to `Rails.error`.
+ *
+ * Passes if the evaluated code in the yielded block reports a matching
+ * exception. To test further details about the reported exception, use the
+ * return value:
+ *
+ *   const report = await assertErrorReported(IOError, () => { ... });
+ *   assertEqual("Oops", report.error.message);
+ */
+export async function assertErrorReported(
+  errorClass: abstract new (...args: any[]) => Error = Error,
+  block: () => unknown = () => undefined,
+): Promise<Report | undefined> {
+  const reports = await ErrorCollector.record(() =>
+    _assertNothingRaisedOrWarn("assert_error_reported", block),
+  );
+
+  let report: Report | undefined;
+  if (reports.length === 0) {
+    assert(
+      false,
+      `Expected a ${errorClass.name} to be reported, but there were no errors reported.`,
+    );
+  } else if ((report = reports.find((r) => r.error instanceof errorClass))) {
+    return report;
+  } else {
+    const message =
+      `Expected a ${errorClass.name} to be reported, but none of the ` +
+      `${reports.length} reported errors matched:  \n` +
+      `${reports.map((r) => r.error.constructor.name).join("\n  ")}`;
+    assert(false, message);
+  }
+  return undefined;
+}

--- a/scripts/parity/pipeline/fixtures/ar-152/models.ts
+++ b/scripts/parity/pipeline/fixtures/ar-152/models.ts
@@ -4,9 +4,8 @@ export class Author extends Base {
   static {
     this.tableName = "authors";
     this.hasMany("books");
-    this.hasMany("publishedBooks", {
+    this.hasMany("publishedBooks", (rel: Relation<any>) => rel.where({ status: "published" }), {
       className: "Book",
-      scope: (rel: Relation<any>) => rel.where({ status: "published" }),
     });
     registerModel(this);
   }


### PR DESCRIPTION
Bundle of three convergence stories.

## 1. Drop the `Builder::Association` options-bag scope shim

`Builder::Association::VALID_OPTIONS` (`associations/builder/association.rb:20-22`)
does not carry `:scope` — a scope only ever arrives as the second positional
(`associations.rb:1302`), and `create_reflection` hands the options hash to
`assert_valid_keys` (`association.rb:43,70`). trails carried an extra `"scope"`
entry plus a `createReflection` lift that pulled it back out; both are gone, so
`hasMany("x", { scope: fn })` now raises Rails' `ArgumentError: Unknown key: :scope`.
`validateOptions` also routes through `assertValidKeys` rather than
re-implementing the message inline — same string, Rails' call.

`VALID_OPTIONS` also drops `"autosave"`: Rails does not list it either — it
arrives through `Association.extensions.flat_map(&:valid_options)`
(`association.rb:65-66`) from `AutosaveAssociation::AssociationBuilderExtension`
(`autosave_association.rb:143-155`). trails already had that extension module in
`autosave-association.ts` but never registered it; it is now registered from
`base.ts` beside `include(Base, AutosaveAssociation)`, which is where Ruby's
`included do` block runs. (Registering it from `autosave-association.ts` itself
closes a module cycle through `reflection.ts`.)

The scope no longer lives in the options hash anywhere. trails'
`AssociationDefinition` — the lightweight reflection the loaders read — now
carries `scope` beside `options`, exactly the separation
`Reflection.create(macro, name, scope, options, model)` (`association.rb:48-49`)
and `HasAndBelongsToManyReflection.new(name, scope, options, ...)`
(`associations.rb:1871`) have, and every reader moved with it: `collection-proxy.ts`,
`relation.ts`, `singular-association.ts`, `has-many-association.ts`,
`has-many-through-association.ts`, `association.ts`, `counter-cache.ts`. The
loader helpers that took an options hash now take the definition. The
`sourceType` through-routing wrapper (`has-many-through-association.ts`)
synthesises a definition with a replacement scope rather than an options hash
with one.

### Why the scope lives on the definition, beside the options

Rails keeps the scope on the reflection, as a sibling of the options hash —
`MacroReflection#initialize(name, scope, options, active_record)` assigns
`@scope` and `@options` separately (`reflection.rb:388-392`) and exposes both as
readers (`attr_reader :scope`, `reflection.rb:376`; `attr_reader :options`,
`:382`). `Reflection.create(macro, name, scope, options, model)`
(`association.rb:48-49`) is the call that builds exactly that object, and
`HasAndBelongsToManyReflection.new(name, scope, options, ...)`
(`associations.rb:1871`) the HABTM equivalent. The separation Rails enforces is
scope-vs-options-hash, not scope-vs-reflection: a scope inside the options hash
is what `assert_valid_keys` rejects (`association.rb:21,70`), and that is what
this PR removes.

trails' `AssociationDefinition` IS that reflection object, not a second bag
beside it: it is what `Association#reflection` holds (`association.rb:32` →
`associations/association.ts:33`, `readonly reflection: AssociationDefinition`),
it is what the loaders read as `this.reflection`, and its existing fields are
each documented against a Rails reflection reader — `MacroReflection#macro`,
`AssociationReflection#foreign_key`, `AssociationReflection#association_primary_key`,
`AbstractReflection#klass`. Giving it `scope` mirrors `attr_reader :scope` on the
same class that owns those; putting the scope anywhere else would be the
deviation.

`delegatedType` forwards its `:scope` positionally too, matching
`belongs_to role, options.delete(:scope), **options.merge(polymorphic: true)`
(`delegated_type.rb:232`).

The one remaining bag-spelling caller (`association-scope.test.ts`) moved to the
positional, finishing what #6509 started.

## 2. Port `ErrorReporterAssertions` and `ConstantStubbing`

Both modules `test_case.rb` includes had no port to name. Added under their
Rails paths with Rails' names and control flow:

- `testing/error-reporter-assertions.ts` — `ErrorCollector` (`record` / `report`
  / private `subscribe`), the `Report` struct with its `handled?` alias, and
  `assertErrorReported` / `assertNoErrorReported`. Blocks may be async in trails,
  so `record` awaits, matching the rest of `testing/assertions.ts`.
- `testing/constant-stubbing.ts` — `stubConst`, both the `exists: true` and
  `exists: false` arms, including `const_get(constant, false)`'s NameError for a
  merely-inherited constant.

`test-case.ts` includes both at Rails' positions (`test_case.rb:148`, `:150`).
`test-case.test.ts`'s `TestConstStubbing` tests now exercise `stubConst` instead
of standing in for it with inline property juggling.

## 3. `blank?`'s fallthrough arm is the Hash arm, not the Object arm

`core_ext/object/blank.rb:18-20` is `respond_to?(:empty?) ? !!empty? : !self`, so
an object that does not answer `empty?` is **never** blank. Ruby's Hash arm
(`alias_method :blank?, :empty?`, blank.rb:111) is a separate reopening. trails
collapsed the two into one own-key count, so every getter-only or slot-only class
instance answered backwards (#6508 patched one family of this via the `Time` arm).
Split back into two: a plain object (prototype `Object.prototype` or `null`) is
the Hash and keeps the own-key count; everything else is `false`.

Closes-story: drop-builder-association-scope-option-shim
Closes-story: read-association-scope-off-reflection-not-definition-bag
Closes-story: port-error-reporter-assertions-and-constant-stubbing
Closes-story: blank-object-arm-is-hash-arm-for-class-instances
