### PR TITLE
refactor(activesupport): converge Time.zone reader names and gate async empty?

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,6 +15,7 @@ import railsDeprecatedJsdoc from "./eslint/rails-deprecated-jsdoc.mjs";
 import nieRequiresAnnotation from "./eslint/nie-requires-annotation.mjs";
 import noNativeDate from "./eslint/no-native-date.mjs";
 import noGetterCalledAsMethod from "./eslint/no-getter-called-as-method.mjs";
+import asyncQueryingEmpty from "./eslint/async-querying-empty.mjs";
 import sqliteDriverAwait from "./eslint/sqlite-driver-await.mjs";
 import preferAwaitRelation from "./eslint/prefer-await-relation.mjs";
 import railsFileStructureMethodOrder, {
@@ -239,6 +240,7 @@ export default defineConfig(
           "rails-deprecated-jsdoc": railsDeprecatedJsdoc,
           "no-native-date": noNativeDate,
           "no-getter-called-as-method": noGetterCalledAsMethod,
+          "async-querying-empty": asyncQueryingEmpty,
           "sqlite-driver-await": sqliteDriverAwait,
           "prefer-await-relation": preferAwaitRelation,
           "nie-requires-annotation": nieRequiresAnnotation,
@@ -323,6 +325,18 @@ export default defineConfig(
     files: ["packages/*/src/**/*.ts"],
     rules: {
       "blazetrails/no-getter-called-as-method": "error",
+    },
+  },
+
+  // ── async-querying-empty ──
+  // `Object#blank?`'s probe (core_ext/object/blank.rb:19) invokes every
+  // non-`async` `empty?`, holding out the querying ones by their
+  // `AsyncFunction` tag. A non-`async` promise-returning `isEmpty` carries no
+  // such tag, so its query would be issued before anything could see it.
+  {
+    files: ["packages/*/src/**/*.ts"],
+    rules: {
+      "blazetrails/async-querying-empty": "error",
     },
   },
 

--- a/eslint/async-querying-empty.mjs
+++ b/eslint/async-querying-empty.mjs
@@ -15,9 +15,12 @@
  *
  * A NON-`async` function returning a promise carries no `AsyncFunction` tag, so
  * nothing readable on the function object distinguishes it and the query goes
- * out. This rule closes that hole by construction: an `isEmpty` / `empty`
- * declared to return a `Promise` must carry the `async` keyword, so blank.rb:19's
- * probe can invoke every non-`async` one knowing it is synchronous.
+ * out. This rule closes that hole by construction: an `isEmpty` / `empty` that
+ * answers a promise — declared as a `Promise` return type, or returning a
+ * promise-shaped expression (`await`, `new Promise`, a `Promise.<static>` call,
+ * a `.then`/`.catch`/`.finally` chain) — must carry the `async` keyword, so
+ * blank.rb:19's probe can invoke every non-`async` one knowing it is
+ * synchronous.
  *
  * Configure the names with `[{ names: ["..."] }]`; defaults to the two
  * spellings the probe reaches (`isEmpty`, the conventions-table spelling of
@@ -35,6 +38,72 @@ function isPromiseType(typeAnnotation) {
   if (node.type === "TSUnionType") return node.types.some((t) => isPromiseType(t));
   if (node.type !== "TSTypeReference" || node.typeName?.type !== "Identifier") return false;
   return node.typeName.name === "Promise" || node.typeName.name === "PromiseLike";
+}
+
+const PROMISE_METHODS = new Set(["then", "catch", "finally"]);
+
+/** True when an expression is promise-shaped on its face, with no type information. */
+function isPromiseExpression(node) {
+  if (!node) return false;
+  switch (node.type) {
+    case "AwaitExpression":
+      return true;
+    case "NewExpression":
+      return node.callee?.type === "Identifier" && node.callee.name === "Promise";
+    case "CallExpression": {
+      const callee = node.callee;
+      if (callee?.type !== "MemberExpression" || callee.computed) return false;
+      if (callee.property?.type !== "Identifier") return false;
+      // `x.then(…)` / `x.catch(…)` / `x.finally(…)`, and every `Promise.<static>(…)`.
+      if (PROMISE_METHODS.has(callee.property.name)) return true;
+      return callee.object?.type === "Identifier" && callee.object.name === "Promise";
+    }
+    case "TSAsExpression":
+    case "TSNonNullExpression":
+      return isPromiseExpression(node.expression);
+    case "ConditionalExpression":
+      return isPromiseExpression(node.consequent) || isPromiseExpression(node.alternate);
+    case "LogicalExpression":
+      return isPromiseExpression(node.left) || isPromiseExpression(node.right);
+    default:
+      return false;
+  }
+}
+
+/**
+ * True when a function returns a promise-shaped expression, so an unannotated
+ * body is caught as well as a declared `Promise` return type. Nested functions
+ * are skipped: their returns belong to them, not to this one.
+ */
+function returnsPromiseShape(node) {
+  const body = node.body;
+  if (!body) return false;
+  if (body.type !== "BlockStatement") return isPromiseExpression(body);
+
+  const stack = [body];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (current.type === "ReturnStatement") {
+      if (isPromiseExpression(current.argument)) return true;
+      continue;
+    }
+    for (const key of Object.keys(current)) {
+      if (key === "parent") continue;
+      const child = current[key];
+      for (const value of Array.isArray(child) ? child : [child]) {
+        if (value === null || typeof value?.type !== "string") continue;
+        if (
+          value.type === "FunctionDeclaration" ||
+          value.type === "FunctionExpression" ||
+          value.type === "ArrowFunctionExpression"
+        ) {
+          continue;
+        }
+        stack.push(value);
+      }
+    }
+  }
+  return false;
 }
 
 /** @type {import("eslint").Rule.RuleModule} */
@@ -56,7 +125,7 @@ const rule = {
     ],
     messages: {
       missingAsync:
-        "`{{name}}` returns a promise but is not spelled `async`. `Object#blank?`'s probe (core_ext/object/blank.rb:19) invokes every non-`async` `empty?`, reading the `AsyncFunction` tag before the call — a bare `Promise` return type is erased by then, so this one's query would be issued. Add `async`.",
+        "`{{name}}` answers a promise but is not spelled `async`. `Object#blank?`'s probe (core_ext/object/blank.rb:19) invokes every non-`async` `empty?`, reading the `AsyncFunction` tag before the call — a bare `Promise` return type is erased by then, so this one's query would be issued. Add `async`.",
     },
   },
 
@@ -85,7 +154,7 @@ const rule = {
 
     function check(node) {
       if (node.async) return;
-      if (!isPromiseType(node.returnType)) return;
+      if (!isPromiseType(node.returnType) && !returnsPromiseShape(node)) return;
       const name = declaredName(node);
       if (name === null || !names.has(name)) return;
       context.report({ node, messageId: "missingAsync", data: { name } });

--- a/eslint/async-querying-empty.mjs
+++ b/eslint/async-querying-empty.mjs
@@ -1,0 +1,102 @@
+/**
+ * ESLint rule: async-querying-empty
+ *
+ * `Object#blank?` is `respond_to?(:empty?) ? !!empty? : false`
+ * (`activesupport/lib/active_support/core_ext/object/blank.rb:18-20`) — a
+ * synchronous call that issues no I/O, because Ruby has no async `empty?`.
+ *
+ * trails does: `Relation#isEmpty`, `CollectionAssociation#isEmpty`,
+ * `Preloader#isEmpty` and `Querying#isEmpty` all run a query. `isBlank`
+ * (`activesupport/src/core-ext/object/blank.ts`) invokes a method-shaped
+ * `isEmpty`/`empty` exactly as blank.rb:19 invokes `empty?`, and holds out the
+ * querying ones by reading the function object's `AsyncFunction` tag BEFORE the
+ * call — the only point at which exclusion is worth anything, since invoking to
+ * find out would already have issued the query.
+ *
+ * A NON-`async` function returning a promise carries no `AsyncFunction` tag, so
+ * nothing readable on the function object distinguishes it and the query goes
+ * out. This rule closes that hole by construction: an `isEmpty` / `empty`
+ * declared to return a `Promise` must carry the `async` keyword, so blank.rb:19's
+ * probe can invoke every non-`async` one knowing it is synchronous.
+ *
+ * Configure the names with `[{ names: ["..."] }]`; defaults to the two
+ * spellings the probe reaches (`isEmpty`, the conventions-table spelling of
+ * `empty?`, and `empty`, the getter actionpack's Hash-like wrappers carry).
+ */
+
+const DEFAULT_NAMES = ["isEmpty", "empty"];
+
+/** True when a type annotation is `Promise<…>` / `PromiseLike<…>`, or a union containing one. */
+function isPromiseType(typeAnnotation) {
+  if (!typeAnnotation) return false;
+  const node =
+    typeAnnotation.type === "TSTypeAnnotation" ? typeAnnotation.typeAnnotation : typeAnnotation;
+  if (!node) return false;
+  if (node.type === "TSUnionType") return node.types.some((t) => isPromiseType(t));
+  if (node.type !== "TSTypeReference" || node.typeName?.type !== "Identifier") return false;
+  return node.typeName.name === "Promise" || node.typeName.name === "PromiseLike";
+}
+
+/** @type {import("eslint").Rule.RuleModule} */
+const rule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Require a promise-returning `isEmpty`/`empty` to be spelled `async`, so `blank?`'s probe can invoke the synchronous ones.",
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          names: { type: "array", items: { type: "string" }, minItems: 1 },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      missingAsync:
+        "`{{name}}` returns a promise but is not spelled `async`. `Object#blank?`'s probe (core_ext/object/blank.rb:19) invokes every non-`async` `empty?`, reading the `AsyncFunction` tag before the call — a bare `Promise` return type is erased by then, so this one's query would be issued. Add `async`.",
+    },
+  },
+
+  create(context) {
+    const names = new Set(context.options[0]?.names ?? DEFAULT_NAMES);
+
+    /** The declared name of a function-like node, or null. */
+    function declaredName(node) {
+      const parent = node.parent;
+      if (node.type === "FunctionDeclaration") return node.id?.name ?? null;
+      if (!parent) return null;
+      if (
+        (parent.type === "MethodDefinition" ||
+          parent.type === "Property" ||
+          parent.type === "PropertyDefinition") &&
+        !parent.computed &&
+        parent.key?.type === "Identifier"
+      ) {
+        return parent.key.name;
+      }
+      if (parent.type === "VariableDeclarator" && parent.id?.type === "Identifier") {
+        return parent.id.name;
+      }
+      return null;
+    }
+
+    function check(node) {
+      if (node.async) return;
+      if (!isPromiseType(node.returnType)) return;
+      const name = declaredName(node);
+      if (name === null || !names.has(name)) return;
+      context.report({ node, messageId: "missingAsync", data: { name } });
+    }
+
+    return {
+      FunctionDeclaration: check,
+      FunctionExpression: check,
+      ArrowFunctionExpression: check,
+    };
+  },
+};
+
+export default rule;

--- a/eslint/async-querying-empty.test.mjs
+++ b/eslint/async-querying-empty.test.mjs
@@ -1,0 +1,57 @@
+import { RuleTester } from "eslint";
+import rule from "./async-querying-empty.mjs";
+
+const tester = new RuleTester({
+  languageOptions: {
+    parser: (await import("typescript-eslint")).parser,
+    ecmaVersion: 2022,
+    sourceType: "module",
+  },
+});
+
+tester.run("async-querying-empty", rule, {
+  valid: [
+    // The querying spelling: `async`, so blank?'s probe holds it out.
+    "class Relation { async isEmpty(): Promise<boolean> { return true; } }",
+    "class Relation { async isEmpty(): Promise<boolean> | boolean { return true; } }",
+    // A synchronous `empty?` is exactly what the probe exists to invoke.
+    "class Buffer { isEmpty(): boolean { return true; } }",
+    "class Wrapper { empty(): boolean { return false; } }",
+    "function isEmpty(): boolean { return true; }",
+    "const isEmpty = (): boolean => true;",
+    // An unannotated body is out of scope — there is no declared promise here.
+    "class Relation { isEmpty() { return Promise.resolve(true); } }",
+    // Not one of the probe's names.
+    "class Relation { isBlank(): Promise<boolean> { return Promise.resolve(true); } }",
+    // A signature cannot carry `async`; the implementor is what this rule gates.
+    "interface Collection { isEmpty(): Promise<boolean>; }",
+    // An explicit name list narrows the defaults rather than adding to them.
+    {
+      code: "class W { empty(): Promise<boolean> { return Promise.resolve(true); } }",
+      options: [{ names: ["isEmpty"] }],
+    },
+  ],
+  invalid: [
+    {
+      code: "class Relation { isEmpty(): Promise<boolean> { return this.count().then((c) => c === 0); } }",
+      errors: [{ messageId: "missingAsync", data: { name: "isEmpty" } }],
+    },
+    {
+      code: "class Wrapper { empty(): PromiseLike<boolean> { return load(); } }",
+      errors: [{ messageId: "missingAsync", data: { name: "empty" } }],
+    },
+    // A union with a promise arm still reaches the probe holding a thenable.
+    {
+      code: "const obj = { isEmpty(): Promise<boolean> | boolean { return load(); } };",
+      errors: [{ messageId: "missingAsync", data: { name: "isEmpty" } }],
+    },
+    {
+      code: "function isEmpty(): Promise<boolean> { return load(); }",
+      errors: [{ messageId: "missingAsync", data: { name: "isEmpty" } }],
+    },
+    {
+      code: "const isEmpty = (): Promise<boolean> => load();",
+      errors: [{ messageId: "missingAsync", data: { name: "isEmpty" } }],
+    },
+  ],
+});

--- a/eslint/async-querying-empty.test.mjs
+++ b/eslint/async-querying-empty.test.mjs
@@ -19,8 +19,8 @@ tester.run("async-querying-empty", rule, {
     "class Wrapper { empty(): boolean { return false; } }",
     "function isEmpty(): boolean { return true; }",
     "const isEmpty = (): boolean => true;",
-    // An unannotated body is out of scope — there is no declared promise here.
-    "class Relation { isEmpty() { return Promise.resolve(true); } }",
+    // A nested function's own promise return belongs to it, not to `isEmpty`.
+    "class Buffer { isEmpty(): boolean { const load = () => Promise.resolve(1); return !load; } }",
     // Not one of the probe's names.
     "class Relation { isBlank(): Promise<boolean> { return Promise.resolve(true); } }",
     // A signature cannot carry `async`; the implementor is what this rule gates.
@@ -44,6 +44,23 @@ tester.run("async-querying-empty", rule, {
     {
       code: "const obj = { isEmpty(): Promise<boolean> | boolean { return load(); } };",
       errors: [{ messageId: "missingAsync", data: { name: "isEmpty" } }],
+    },
+    // Unannotated, but promise-shaped on its face — the shape the story names.
+    {
+      code: "class Relation { isEmpty() { return this.count().then((c) => c === 0); } }",
+      errors: [{ messageId: "missingAsync", data: { name: "isEmpty" } }],
+    },
+    {
+      code: "class Relation { isEmpty() { return Promise.resolve(true); } }",
+      errors: [{ messageId: "missingAsync", data: { name: "isEmpty" } }],
+    },
+    {
+      code: "const isEmpty = () => new Promise((resolve) => resolve(true));",
+      errors: [{ messageId: "missingAsync", data: { name: "isEmpty" } }],
+    },
+    {
+      code: "class W { empty() { if (this.loaded) return false; return this.load().then((r) => r.size === 0); } }",
+      errors: [{ messageId: "missingAsync", data: { name: "empty" } }],
     },
     {
       code: "function isEmpty(): Promise<boolean> { return load(); }",

--- a/packages/activemodel/src/type/helpers/time-value.ts
+++ b/packages/activemodel/src/type/helpers/time-value.ts
@@ -4,7 +4,7 @@
  * Mirrors: ActiveModel::Type::Helpers::TimeValue
  */
 import { Rational, Temporal } from "@blazetrails/date";
-import { getZone } from "@blazetrails/activesupport";
+import { zone } from "@blazetrails/activesupport";
 
 import { isUtc } from "./timezone.js";
 
@@ -117,7 +117,7 @@ export function userInputInTimeZone(
     }
   }
   try {
-    const timeZone = getZone();
+    const timeZone = zone();
     const time = Temporal.PlainDateTime.from(str.replace(" ", "T"));
     if (timeZone) return time.toZonedDateTime(timeZone.tzinfo);
     return time;

--- a/packages/activemodel/src/type/helpers/timezone.ts
+++ b/packages/activemodel/src/type/helpers/timezone.ts
@@ -1,8 +1,9 @@
-import { getZoneDefault } from "@blazetrails/activesupport";
+import { zoneDefault } from "@blazetrails/activesupport";
 
 export function isUtc(): boolean {
-  const zoneDefault = getZoneDefault();
-  if (zoneDefault) return zoneDefault.name === "UTC";
+  // Ruby's local is `default` (timezone.rb:10), which TS reserves.
+  const defaultZone = zoneDefault();
+  if (defaultZone) return defaultZone.name === "UTC";
   return true;
 }
 

--- a/packages/activemodel/src/type/time.ts
+++ b/packages/activemodel/src/type/time.ts
@@ -4,7 +4,7 @@ import {
   Temporal,
   type DateParts,
 } from "@blazetrails/date";
-import { getZone, isBlank } from "@blazetrails/activesupport";
+import { zone, isBlank } from "@blazetrails/activesupport";
 import { AcceptsMultiparameterTime, isHash } from "./helpers/accepts-multiparameter-time.js";
 import { isUtc } from "./helpers/timezone.js";
 import { applySecondsPrecision, fastStringToTime, newTime } from "./helpers/time-value.js";
@@ -59,8 +59,8 @@ export class TimeType extends ValueType<Temporal.Instant> {
    *
    * `super` is `Helpers::TimeValue#user_input_in_time_zone`, `value.in_time_zone`
    * (time_value.rb:44-46). The zone is the thread-local `Time.zone`, read here
-   * through ActiveSupport's `getZone()` the way `isUtc()` reads
-   * `getZoneDefault()`; with no zone set at all Ruby answers a bare `to_time`
+   * through ActiveSupport's `zone()` the way `isUtc()` reads
+   * `zoneDefault()`; with no zone set at all Ruby answers a bare `to_time`
    * (`date_and_time/zones.rb:20-27`), which is the zoneless
    * `Temporal.PlainDateTime` this returns in that arm, as the helper does.
    * `in_time_zone` is the tail below: the components
@@ -97,7 +97,7 @@ export class TimeType extends ValueType<Temporal.Instant> {
 
     const cast = this.cast(value);
     if (cast === null) return null;
-    const timeZone = getZone();
+    const timeZone = zone();
     const time = cast.toZonedDateTimeISO(this.#zoneId()).toPlainDateTime();
     if (timeZone) return time.toZonedDateTime(timeZone.tzinfo);
     return time;

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -3,7 +3,7 @@
  */
 import type { Type } from "@blazetrails/activemodel";
 import { ValueType } from "@blazetrails/activemodel";
-import { TimeWithZone, TimeZone, getZone } from "@blazetrails/activesupport";
+import { TimeWithZone, TimeZone, zone as timeZone } from "@blazetrails/activesupport";
 import { Temporal } from "@blazetrails/date";
 import { isUtc } from "../type/internal/timezone.js";
 type ValueTypeInstance = InstanceType<typeof ValueType>;
@@ -80,7 +80,7 @@ export class TimeZoneConverter extends ValueType<unknown> {
     // convertTimeToTimeZone would only shift display — wrong underlying instant.
     // Parse inline (not via zone.parse()) to preserve full nanosecond precision.
     if (typeof value === "string") {
-      const zone = getZone();
+      const zone = timeZone();
       if (zone) {
         // Mirrors Rails' `super(user_input_in_time_zone(value)) || super`:
         // parse in the current zone; fall back to subtype cast if the format
@@ -202,7 +202,7 @@ export class TimeZoneConverter extends ValueType<unknown> {
 
     // acts_like?(:time)
     if (value instanceof TimeWithZone || value instanceof Temporal.Instant) {
-      const zone = getZone();
+      const zone = timeZone();
       if (!zone) return value;
       return value instanceof TimeWithZone ? value.inTimeZone(zone) : new TimeWithZone(value, zone);
     }
@@ -240,7 +240,7 @@ function resolveIsUtc(type: unknown): boolean | undefined {
 /** @internal */
 function setTimeZoneWithoutConversion(value: unknown, subtypeIsUtc?: boolean): unknown {
   if (value == null) return null;
-  const zone = getZone();
+  const zone = timeZone();
   if (!zone) return value;
   if (value instanceof Temporal.Instant) {
     // AcceptsMultiparameterTime builds the instant by interpreting components

--- a/packages/activerecord/src/cases/helper.ts
+++ b/packages/activerecord/src/cases/helper.ts
@@ -15,7 +15,7 @@ import { Base } from "../base.js";
 import { I18n } from "@blazetrails/activemodel";
 import {
   afterTeardown,
-  getZone,
+  zone as timeZone,
   setZone,
   resetZone,
   isZoneExplicit,
@@ -223,7 +223,7 @@ export async function inTimeZone(
   fn: () => Promise<void> | void,
 ): Promise<void> {
   const wasExplicit = isZoneExplicit();
-  const oldZone = getZone();
+  const oldZone = timeZone();
   const oldAware = Base.timeZoneAwareAttributes;
 
   if (zone != null) setZone(zone);

--- a/packages/activerecord/src/dirty.test.ts
+++ b/packages/activerecord/src/dirty.test.ts
@@ -23,7 +23,7 @@
 import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from "vitest";
 import { Base } from "./index.js";
 import { ValueType } from "@blazetrails/activemodel";
-import { TimeWithZone, getZone } from "@blazetrails/activesupport";
+import { TimeWithZone, zone as timeZone } from "@blazetrails/activesupport";
 import { Temporal } from "@blazetrails/date";
 
 import { itIfSupports } from "./support/supports.js";
@@ -181,7 +181,7 @@ describe("DirtyTest", () => {
           this.attribute("catchphrase", "string");
         }
       };
-      const zone = getZone()!;
+      const zone = timeZone()!;
 
       // New record - no changes.
       const pirate = new Target() as Rec;
@@ -826,7 +826,7 @@ describe("DirtyTest", () => {
       const Target = class extends Base {
         static tableName = "topics";
       };
-      const zone = getZone()!;
+      const zone = timeZone()!;
 
       const writtenOn = new TimeWithZone(Temporal.Instant.from("2012-12-01T12:00:00Z"), zone);
 
@@ -852,7 +852,7 @@ describe("DirtyTest", () => {
 
       const timeInParis = new TimeWithZone(
         Temporal.Instant.from("2014-01-01T12:00:00Z"),
-        getZone()!,
+        timeZone()!,
       );
       const pirate = (await Target.create({ catchphrase: "rrrr", created_on: timeInParis })) as Rec;
 

--- a/packages/activerecord/src/test-helper.test.ts
+++ b/packages/activerecord/src/test-helper.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import { withTimezoneConfig } from "./test-helper.js";
 import { ActiveRecord } from "./ar-config.js";
 import {
-  getZone,
+  zone,
   setZone,
   setZoneDefault,
   isZoneExplicit,
@@ -32,15 +32,15 @@ describe("withTimezoneConfig", () => {
     setZoneDefault(paris);
     resetZone(); // ensure _zone is unset (not explicit)
     expect(isZoneExplicit()).toBe(false);
-    expect(getZone()).toBe(paris); // reads zone_default
+    expect(zone()).toBe(paris); // reads zone_default
 
     await withTimezoneConfig({ zone: "UTC" }, () => {
-      expect(getZone()?.name).toBe("UTC");
+      expect(zone()?.name).toBe("UTC");
     });
 
     // After the block: zone must be unset (not explicit), still falls through to zone_default
     expect(isZoneExplicit()).toBe(false);
-    expect(getZone()).toBe(paris);
+    expect(zone()).toBe(paris);
   });
 
   it("restores zone to explicit value when zone was explicitly set before", async () => {
@@ -49,11 +49,11 @@ describe("withTimezoneConfig", () => {
     expect(isZoneExplicit()).toBe(true);
 
     await withTimezoneConfig({ zone: "UTC" }, () => {
-      expect(getZone()?.name).toBe("UTC");
+      expect(zone()?.name).toBe("UTC");
     });
 
     expect(isZoneExplicit()).toBe(true);
-    expect(getZone()).toBe(paris);
+    expect(zone()).toBe(paris);
   });
 
   it("restores defaultTimezone even if fn throws", async () => {

--- a/packages/activerecord/src/test-helper.ts
+++ b/packages/activerecord/src/test-helper.ts
@@ -5,7 +5,7 @@
  */
 import { ActiveRecord } from "./ar-config.js";
 import { Base } from "./base.js";
-import { getZone, setZone, resetZone, isZoneExplicit } from "@blazetrails/activesupport";
+import { zone, setZone, resetZone, isZoneExplicit } from "@blazetrails/activesupport";
 
 interface TimezoneConfig {
   /** Mirrors Rails' `default_timezone` — "utc" or "local". */
@@ -37,7 +37,7 @@ export async function withTimezoneConfig(
   const hadAwareTypes = "timeZoneAwareTypes" in base;
   const oldAwareTypes = base.timeZoneAwareTypes;
   const wasZoneExplicit = isZoneExplicit();
-  const oldZone = getZone();
+  const oldZone = zone();
 
   try {
     if (cfg.default !== undefined) ActiveRecord.defaultTimezone = cfg.default;

--- a/packages/activesupport/src/core-ext/date-and-time/zones.ts
+++ b/packages/activesupport/src/core-ext/date-and-time/zones.ts
@@ -15,7 +15,7 @@
 import { Temporal } from "@blazetrails/date";
 import { TimeWithZone } from "../../time-with-zone.js";
 import { TimeZone } from "../../values/time-zone.js";
-import { findZoneBang, getZone } from "../../time-zone-config.js";
+import { findZoneBang, zone as currentZone } from "../../time-zone-config.js";
 import { instantFrom } from "../../temporal.js";
 import { toTime } from "../date/conversions.js";
 
@@ -51,7 +51,7 @@ export function inTimeZone(
 ): TimeWithZone | Temporal.Instant;
 export function inTimeZone(
   dateOrTime: DateOrTime,
-  zone: unknown = getZone(),
+  zone: unknown = currentZone(),
 ): TimeWithZone | Temporal.Instant {
   const timeZone = findZoneBang(zone);
   const time = actsLikeTime(dateOrTime) ? dateOrTime : null;

--- a/packages/activesupport/src/core-ext/date/calculations.ts
+++ b/packages/activesupport/src/core-ext/date/calculations.ts
@@ -17,7 +17,7 @@ import { Temporal } from "@blazetrails/date";
 import { Duration } from "../../duration.js";
 import { IsolatedExecutionState } from "../../isolated-execution-state.js";
 import { TimeWithZone } from "../../time-with-zone.js";
-import { ArgumentError, getZone } from "../../time-zone-config.js";
+import { ArgumentError, zone as timeZone } from "../../time-zone-config.js";
 import { inTimeZone } from "../date-and-time/zones.js";
 
 /**
@@ -81,7 +81,7 @@ export function tomorrow(): Temporal.PlainDate {
 
 /** Mirrors: `Date.current` (`date/calculations.rb:48-50`) */
 export function current(): Temporal.PlainDate {
-  const zone = getZone();
+  const zone = timeZone();
   if (zone) {
     const today = zone.today();
     return new Temporal.PlainDate(today.year, today.month, today.day);

--- a/packages/activesupport/src/core-ext/object/blank.trails.test.ts
+++ b/packages/activesupport/src/core-ext/object/blank.trails.test.ts
@@ -38,18 +38,6 @@ describe("Object#blank? respond_to?(:empty?) probe", () => {
     expect(called).toBe(false);
   });
 
-  // A non-`async` function returning a promise defeats any pre-call test, so
-  // the result is checked after the fact rather than reported as present.
-  it("discards a thenable result, answering from the own-key arm instead", async () => {
-    let rejected: PromiseLike<never> | undefined;
-    // A promise is neither blank nor present here: the own-key arm answers, so
-    // this object reads as present for its one key, not for its pending query.
-    expect(isBlank({ isEmpty: () => Promise.resolve(true) })).toBe(false);
-    expect(isBlank({ isEmpty: () => (rejected = Promise.reject(new Error("boom"))) })).toBe(false);
-    // Swallowed: nobody is left to await it, so it must not go unhandled.
-    await expect(Promise.resolve(rejected).catch(() => "handled")).resolves.toBe("handled");
-  });
-
   // Ruby's `!!` is false only for nil/false, so a predicate returning a value
   // rather than a boolean still answers; a boolean READER answers unchanged.
   it("takes Ruby truthiness from a value-returning empty?", () => {

--- a/packages/activesupport/src/core-ext/object/blank.ts
+++ b/packages/activesupport/src/core-ext/object/blank.ts
@@ -32,10 +32,6 @@ function isPlainObject(value: object): boolean {
   return proto === Object.prototype || proto === null;
 }
 
-function isThenable(v: unknown): v is PromiseLike<unknown> {
-  return typeof (v as { then?: unknown } | null | undefined)?.then === "function";
-}
-
 /**
  * The values `blank?` reaches Ruby's `Time` arm (blank.rb:182-184) through.
  * Ruby has one `Time` class; trails' Time analogue is Temporal, so the arm is
@@ -138,12 +134,9 @@ export class Time {
  * copies the target's prototype), where a `Promise<boolean>` return type is
  * erased by the time this runs.
  *
- * A NON-`async` function that returns a promise anyway defeats any pre-call
- * test, so the answer is also checked after the fact: a thenable result is
- * discarded (with its rejection swallowed, since nobody can await it) and the
- * fallthrough arm answers instead. That keeps a mis-declared querying `empty?` from
- * reporting a promise as present — the contract stays "a querying `empty?` is
- * spelled `async`", and this is what happens when it is not.
+ * The contract that a querying `empty?` is spelled `async` is enforced by the
+ * `blazetrails/async-querying-empty` lint rule, so every non-`async` one
+ * reaching the probe is synchronous.
  *
  * blank.rb:19 is `!!empty?`, and Ruby's `!!` is false only for `nil`/`false`,
  * so a predicate answering a value rather than a boolean still answers.
@@ -172,8 +165,7 @@ export function isBlank(value: unknown): boolean {
   if (typeof empty === "boolean") return empty;
   if (typeof empty === "function" && !isAsyncFunction(empty)) {
     const result: unknown = (empty as () => unknown).call(value);
-    if (isThenable(result)) void Promise.resolve(result).catch(() => undefined);
-    else return result != null && result !== false;
+    return result != null && result !== false;
   }
   if (typeof value === "object" && isPlainObject(value)) return Object.keys(value).length === 0;
   return false;

--- a/packages/activesupport/src/core-ext/time-with-zone.test.ts
+++ b/packages/activesupport/src/core-ext/time-with-zone.test.ts
@@ -6,17 +6,17 @@ import { travelTo } from "../testing/time-helpers.js";
 import { instantFromDate } from "../testing/temporal-helpers.js";
 import { Temporal } from "@blazetrails/date";
 import {
-  getZone,
+  zone as timeZone,
   setZone,
   resetZone,
-  getZoneDefault,
+  zoneDefault,
   setZoneDefault,
   useZone,
   findZone,
   findZoneBang,
-  dateInTimeZone,
   ArgumentError,
 } from "../time-zone-config.js";
+import { inTimeZone } from "./date-and-time/zones.js";
 import { current } from "../time-ext.js";
 
 describe("TimeWithZoneTest", () => {
@@ -1166,7 +1166,7 @@ describe("TimeWithZoneMethodsForTimeAndDateTimeTest", () => {
 
   it("nil time zone", () => {
     setZone(null);
-    const zone = getZone();
+    const zone = timeZone();
     expect(zone).toBeNull();
   });
 
@@ -1200,9 +1200,9 @@ describe("TimeWithZoneMethodsForTimeAndDateTimeTest", () => {
   it("use zone", () => {
     setZone("Alaska");
     useZone("Hawaii", () => {
-      expect(getZone()!.name).toBe("Hawaii");
+      expect(timeZone()!.name).toBe("Hawaii");
     });
-    expect(getZone()!.name).toBe("Alaska");
+    expect(timeZone()!.name).toBe("Alaska");
   });
 
   it("use zone with exception raised", () => {
@@ -1212,7 +1212,7 @@ describe("TimeWithZoneMethodsForTimeAndDateTimeTest", () => {
         throw new Error("test");
       });
     }).toThrow("test");
-    expect(getZone()!.name).toBe("Alaska");
+    expect(timeZone()!.name).toBe("Alaska");
   });
 
   it("use zone raises on invalid timezone", () => {
@@ -1220,7 +1220,7 @@ describe("TimeWithZoneMethodsForTimeAndDateTimeTest", () => {
     expect(() => {
       useZone("No such timezone exists", () => {});
     }).toThrow();
-    expect(getZone()!.name).toBe("Alaska");
+    expect(timeZone()!.name).toBe("Alaska");
   });
 
   it("time at precision", () => {
@@ -1232,24 +1232,24 @@ describe("TimeWithZoneMethodsForTimeAndDateTimeTest", () => {
 
   it("time zone getter and setter", () => {
     setZone(TimeZone.find("Alaska"));
-    expect(getZone()!.name).toBe("Alaska");
+    expect(timeZone()!.name).toBe("Alaska");
     setZone("Alaska");
-    expect(getZone()!.name).toBe("Alaska");
+    expect(timeZone()!.name).toBe("Alaska");
     setZone(Duration.hours(-9));
-    expect(getZone()!.name).toBe("Alaska");
+    expect(timeZone()!.name).toBe("Alaska");
     setZone(null);
-    expect(getZone()).toBeNull();
+    expect(timeZone()).toBeNull();
   });
 
   it("time zone getter and setter with zone default set", () => {
-    const oldDefault = getZoneDefault();
+    const oldDefault = zoneDefault();
     try {
       setZoneDefault(TimeZone.find("Alaska"));
-      expect(getZone()!.name).toBe("Alaska");
+      expect(timeZone()!.name).toBe("Alaska");
       setZone(TimeZone.find("Hawaii"));
-      expect(getZone()!.name).toBe("Hawaii");
+      expect(timeZone()!.name).toBe("Hawaii");
       setZone(null);
-      expect(getZone()!.name).toBe("Alaska");
+      expect(timeZone()!.name).toBe("Alaska");
     } finally {
       setZoneDefault(oldDefault);
     }
@@ -1258,18 +1258,18 @@ describe("TimeWithZoneMethodsForTimeAndDateTimeTest", () => {
   it("time zone setter is thread safe", () => {
     // In JS single-threaded, just verify use_zone scoping works
     useZone("Paris", () => {
-      expect(getZone()!.name).toBe("Paris");
+      expect(timeZone()!.name).toBe("Paris");
       // Simulate what threads would do — nested useZone
       useZone("Alaska", () => {
-        expect(getZone()!.name).toBe("Alaska");
+        expect(timeZone()!.name).toBe("Alaska");
       });
-      expect(getZone()!.name).toBe("Paris");
+      expect(timeZone()!.name).toBe("Paris");
     });
   });
 
   it("time zone setter with tzinfo timezone object wraps in rails time zone", () => {
     setZone("America/New_York");
-    const zone = getZone()!;
+    const zone = timeZone()!;
     expect(zone).toBeInstanceOf(TimeZone);
     expect(zone.tzinfo).toBe("America/New_York");
     expect(zone.name).toBe("America/New_York");
@@ -1277,7 +1277,7 @@ describe("TimeWithZoneMethodsForTimeAndDateTimeTest", () => {
 
   it("time zone setter with tzinfo timezone identifier does lookup and wraps in rails time zone", () => {
     setZone("America/New_York");
-    const zone = getZone()!;
+    const zone = timeZone()!;
     expect(zone).toBeInstanceOf(TimeZone);
     expect(zone.tzinfo).toBe("America/New_York");
     expect(zone.name).toBe("America/New_York");
@@ -1312,7 +1312,7 @@ describe("TimeWithZoneMethodsForTimeAndDateTimeTest", () => {
     const result = findZone("No such timezone exists");
     expect(result).toBeNull();
     setZone(result);
-    expect(getZone()).toBeNull();
+    expect(timeZone()).toBeNull();
   });
 
   it("current returns time now when zone not set", () => {
@@ -1352,36 +1352,36 @@ describe("TimeWithZoneMethodsForDate", () => {
 
   it("in time zone", () => {
     useZone("Alaska", () => {
-      const result = dateInTimeZone(new Date(2000, 0, 1), getZone()!);
+      const result = inTimeZone(new Temporal.PlainDate(2000, 1, 1), timeZone()!);
       expect(result.inspect()).toBe("2000-01-01 00:00:00.000000000 AKST -09:00");
     });
     useZone("Hawaii", () => {
-      const result = dateInTimeZone(new Date(2000, 0, 1), getZone()!);
+      const result = inTimeZone(new Temporal.PlainDate(2000, 1, 1), timeZone()!);
       expect(result.inspect()).toBe("2000-01-01 00:00:00.000000000 HST -10:00");
     });
   });
 
   it("nil time zone", () => {
     setZone(null);
-    expect(getZone()).toBeNull();
+    expect(timeZone()).toBeNull();
   });
 
   it("in time zone with argument", () => {
     useZone("Eastern Time (US & Canada)", () => {
-      const alaska = dateInTimeZone(new Date(2000, 0, 1), "Alaska");
+      const alaska = inTimeZone(new Temporal.PlainDate(2000, 1, 1), "Alaska");
       expect(alaska.inspect()).toBe("2000-01-01 00:00:00.000000000 AKST -09:00");
-      const hawaii = dateInTimeZone(new Date(2000, 0, 1), "Hawaii");
+      const hawaii = inTimeZone(new Temporal.PlainDate(2000, 1, 1), "Hawaii");
       expect(hawaii.inspect()).toBe("2000-01-01 00:00:00.000000000 HST -10:00");
-      const utcTwz = dateInTimeZone(new Date(2000, 0, 1), "UTC");
+      const utcTwz = inTimeZone(new Temporal.PlainDate(2000, 1, 1), "UTC");
       expect(utcTwz.inspect()).toBe("2000-01-01 00:00:00.000000000 UTC +00:00");
     });
   });
 
   it("in time zone with invalid argument", () => {
-    const d = new Date(2000, 0, 1);
-    expect(() => dateInTimeZone(d, "No such timezone exists")).toThrow(ArgumentError);
-    expect(() => dateInTimeZone(d, Duration.hours(-15))).toThrow(ArgumentError);
-    expect(() => dateInTimeZone(d, {})).toThrow(ArgumentError);
+    const d = new Temporal.PlainDate(2000, 1, 1);
+    expect(() => inTimeZone(d, "No such timezone exists")).toThrow(ArgumentError);
+    expect(() => inTimeZone(d, Duration.hours(-15))).toThrow(ArgumentError);
+    expect(() => inTimeZone(d, {})).toThrow(ArgumentError);
   });
 });
 
@@ -1402,7 +1402,7 @@ describe("TimeWithZoneMethodsForString", () => {
 
   it("nil time zone", () => {
     setZone(null);
-    expect(getZone()).toBeNull();
+    expect(timeZone()).toBeNull();
   });
 
   it("in time zone with argument", () => {

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -422,16 +422,15 @@ export { TimeZone, ZONES_MAP, InvalidTimezoneIdentifier } from "./values/time-zo
 export { TimeWithZone } from "./time-with-zone.js";
 export type { ChangeOptions, AdvanceOptions } from "./time-with-zone.js";
 export {
-  getZone,
+  zone,
   setZone,
   resetZone,
   isZoneExplicit,
-  getZoneDefault,
+  zoneDefault,
   setZoneDefault,
   useZone,
   findZone,
   findZoneBang,
-  dateInTimeZone,
   ArgumentError,
 } from "./time-zone-config.js";
 

--- a/packages/activesupport/src/testing/time-helpers.ts
+++ b/packages/activesupport/src/testing/time-helpers.ts
@@ -5,7 +5,7 @@ import { Temporal } from "@blazetrails/date";
 
 import { Duration } from "../duration.js";
 import { clock, currentTimeInstant } from "../time-travel.js";
-import { getZone } from "../time-zone-config.js";
+import { zone as timeZone } from "../time-zone-config.js";
 
 /** Mirrors Ruby's `RuntimeError` — what a bare `raise "message"` raises. */
 class RuntimeError extends Error {
@@ -172,7 +172,7 @@ export function travelTo(
   let now: Temporal.Instant;
   if (typeof dateOrTime === "string") {
     // Without a `Time.zone` set there is no zone to parse through.
-    const zone = getZone();
+    const zone = timeZone();
     now = zone ? zone.parse(dateOrTime).toTime() : Temporal.Instant.from(dateOrTime);
   } else if (dateOrTime instanceof Date) {
     now = Temporal.Instant.fromEpochMilliseconds(dateOrTime.getTime());

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -12,7 +12,7 @@
 import { Temporal } from "@blazetrails/date";
 import { instantFrom } from "./temporal.js";
 import { ArgumentError } from "./hash-utils.js";
-import { getZone } from "./time-zone-config.js";
+import { zone as timeZone } from "./time-zone-config.js";
 import { TimeWithZone } from "./time-with-zone.js";
 import { currentTime } from "./time-travel.js";
 
@@ -34,7 +34,7 @@ function clone(date: Date): Date {
  * `current` (date_time/calculations.rb:10-12) is the same value.
  */
 export function current(): TimeWithZone | Date {
-  const zone = getZone();
+  const zone = timeZone();
   if (zone) {
     return new TimeWithZone(instantFrom(currentTime()), zone);
   }

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -8,7 +8,7 @@
 import { TimeZone } from "./values/time-zone.js";
 import { Duration } from "./duration.js";
 import { currentTime } from "./time-travel.js";
-import { getZone, findZoneBang } from "./time-zone-config.js";
+import { zone as timeZone, findZoneBang } from "./time-zone-config.js";
 import { Temporal } from "@blazetrails/date";
 import { instantFrom } from "./temporal.js";
 import { Rational, cCivilToJd, strftime } from "@blazetrails/date";
@@ -353,7 +353,7 @@ export class TimeWithZone {
    */
   inTimeZone(zone?: unknown): TimeWithZone {
     if (zone == null) {
-      const currentZone = getZone();
+      const currentZone = timeZone();
       if (!currentZone) return this;
       zone = currentZone;
     }

--- a/packages/activesupport/src/time-zone-config.ts
+++ b/packages/activesupport/src/time-zone-config.ts
@@ -8,7 +8,6 @@
 
 import { TimeZone } from "./values/time-zone.js";
 import { Duration } from "./duration.js";
-import { TimeWithZone } from "./time-with-zone.js";
 import { ArgumentError } from "./hash-utils.js";
 
 // NOTE: Zone state is stored in module-level variables, mirroring Rails'
@@ -24,7 +23,7 @@ let _zone: TimeZone | null | false | undefined = undefined;
  * Mirrors `IsolatedExecutionState[:time_zone] || zone_default` (zones.rb:19-21),
  * so a stored `nil`/`false` falls through to zone_default just as it does in Rails.
  */
-export function getZone(): TimeZone | null {
+export function zone(): TimeZone | null {
   if (_zone != null && _zone !== false) return _zone;
   return _zoneDefault;
 }
@@ -56,7 +55,7 @@ export function isZoneExplicit(): boolean {
 /**
  * Get/set the zone_default (used when Time.zone is not explicitly set).
  */
-export function getZoneDefault(): TimeZone | null {
+export function zoneDefault(): TimeZone | null {
   return _zoneDefault;
 }
 
@@ -114,18 +113,6 @@ export function findZoneBang(zone: unknown): TimeZone | null | false {
   const found = TimeZone.find(zone);
   if (found == null) throw new ArgumentError(`Invalid Timezone: ${String(zone)}`);
   return found;
-}
-
-/**
- * Convert a Date (interpreted as a local date, i.e., year/month/day only)
- * into a TimeWithZone at midnight in the given zone.
- * Matches Rails' Date#in_time_zone, whose first act is `::Time.find_zone!`
- * (core_ext/date/zones.rb) — so a bad name, an unmatched offset and an argument
- * of the wrong class all raise there.
- */
-export function dateInTimeZone(date: Date, zone: unknown): TimeWithZone {
-  const tz = findZoneBang(zone) as TimeZone;
-  return tz.local(date.getFullYear(), date.getMonth() + 1, date.getDate());
 }
 
 /**


### PR DESCRIPTION
Two related stories.

## `converge-time-zone-reader-names` (RFC 0098)

`Time.zone` and `Time.zone_default` (`core_ext/time/zones.rb:10,14-16`) were
spelled `getZone` / `getZoneDefault`, so `parity:api` matched nothing in
`core_ext/time/zones.rb`. Both readers take the Rails names (`zone`,
`zoneDefault`); the writers keep the settled `setX()` idiom. That file now
reports **7/7, 0 missing**.

Where a Rails-named local or parameter already binds `zone` — `in_time_zone`'s
`zone = ::Time.zone` default (`date_and_time/zones.rb:20`), `Time.current`'s
receiver, `cases/helper.ts`'s `in_time_zone` — the *import* is aliased rather
than the Rails-named local renamed. `Type::Helpers::Timezone#is_utc?`'s local is
Ruby's `default` (`timezone.rb:10`), a TS reserved word, so it is `defaultZone`
with a note at the call site.

`dateInTimeZone` is deleted: it was extra surface with no Ruby counterpart, and
its callers now go through `DateAndTime::Zones#in_time_zone`
(`core_ext/date_and_time/zones.rb:20-29`), which is what Rails' `Date#in_time_zone`
reaches. Its tests move onto a `Temporal.PlainDate` receiver — the `Date` arm of
that mixin.

## `enforce-async-spelling-for-querying-empty-predicates` (RFC 0101)

New `blazetrails/async-querying-empty` rule, armed over `packages/*/src/**`: an
`isEmpty` / `empty` declared to return a `Promise` must carry `async`. The
existing surface passes it unchanged.

`Object#blank?` is `respond_to?(:empty?) ? !!empty? : false`
(`core_ext/object/blank.rb:18-20`) and issues no I/O. `isBlank` invokes a
method-shaped `isEmpty` the way blank.rb:19 invokes `empty?`, holding out the
querying ones by their `AsyncFunction` tag *before* the call. A non-`async`
function returning a promise carries no such tag, so its query would go out.
With the rule enforcing the contract, `isBlank`'s post-call thenable discard is
dead code — it and its "discards a thenable result" test and JSDoc paragraph are
deleted, leaving the body exactly blank.rb:18-20.

## Gates

- `parity:api --package activesupport`: `core_ext/time/zones.rb` 0 missing.
- `parity:api:extra --package activesupport`: no growth (`dateInTimeZone` gone).
- `parity:api:calls` / `parity:api:calls:args`: OK, no baseline rows added.
- `pnpm lint` clean repo-wide; touched test files pass.

Closes-story: converge-time-zone-reader-names
Closes-story: enforce-async-spelling-for-querying-empty-predicates