### PR TITLE
feat(activesupport,parity): port SetupAndTeardown and TestsWithoutAssertions; correct the migration/compatibility reason

### DIFF
--- a/packages/activesupport/src/test-case.ts
+++ b/packages/activesupport/src/test-case.ts
@@ -20,8 +20,26 @@
  * ESM re-export is eager, so this file is deliberately absent from `index.ts`
  * — importing it there would pull vitest into every consumer of the package.
  */
-import { beforeEach } from "vitest";
-import { setTaggedLogger, beforeSetup, taggedLogger } from "./testing/tagged-logging.js";
+import { afterEach, beforeEach, expect } from "vitest";
+import type { TestContext } from "vitest";
+import {
+  setTaggedLogger,
+  beforeSetup as taggedLoggingBeforeSetup,
+  taggedLogger,
+} from "./testing/tagged-logging.js";
+import {
+  failures,
+  prepended as setupAndTeardownPrepended,
+  setup,
+  teardown,
+  beforeSetup as setupAndTeardownBeforeSetup,
+  afterTeardown as setupAndTeardownAfterTeardown,
+} from "./testing/setup-and-teardown.js";
+import {
+  afterTeardown as testsWithoutAssertionsAfterTeardown,
+  type RunningTest,
+} from "./testing/tests-without-assertions.js";
+import { UnexpectedError } from "./testing/assertions.js";
 import {
   assertNot,
   assertRaises,
@@ -40,7 +58,7 @@ import {
   collectDeprecations,
 } from "./testing/deprecation.js";
 import {
-  afterTeardown,
+  afterTeardown as timeHelpersAfterTeardown,
   travel,
   travelTo,
   travelBack,
@@ -51,9 +69,48 @@ import {
 export class TestCase {
   // include ActiveSupport::Testing::TaggedLogging (test_case.rb:144)
   static setTaggedLogger = setTaggedLogger;
-  static beforeSetup = beforeSetup;
   /** @internal */
   static taggedLogger = taggedLogger;
+
+  // prepend ActiveSupport::Testing::SetupAndTeardown (test_case.rb:145)
+  static setup = setup;
+  static teardown = teardown;
+
+  /**
+   * The `before_setup` chain the two `prepend`s produce (test_case.rb:144-145):
+   * `SetupAndTeardown#before_setup` opens with `super`, which reaches
+   * `TaggedLogging#before_setup`, and only then runs the `:setup` callbacks.
+   * `TestsWithoutAssertions` defines no `before_setup`.
+   */
+  static beforeSetup(): void {
+    taggedLoggingBeforeSetup();
+    setupAndTeardownBeforeSetup.call(TestCase);
+  }
+
+  /**
+   * The `after_teardown` chain (test_case.rb:145-146, 151), in ancestor order:
+   * `TestsWithoutAssertions#after_teardown` — prepended last, so it comes
+   * first — opens with `super`, which reaches `SetupAndTeardown#after_teardown`
+   * (the `:teardown` callbacks), whose own trailing `super` reaches
+   * `TimeHelpers#after_teardown`. Its assertion check runs on the way back out,
+   * last.
+   */
+  static afterTeardown(test: RunningTest): void {
+    const recordedBefore = failures.length;
+    setupAndTeardownAfterTeardown.call(TestCase);
+    timeHelpersAfterTeardown();
+    const recorded = failures.splice(recordedBefore);
+    testsWithoutAssertionsAfterTeardown({
+      ...test,
+      // Minitest's `error?` is `failures.any? { UnexpectedError === _1 }`, so a
+      // teardown that raised suppresses the missing-assertion warning.
+      error: test.error || recorded.some((f) => f instanceof UnexpectedError),
+    });
+    // `self.failures` is the list Minitest reports the test on; vitest has no
+    // per-test failure list, so what makes the runner see the failure is the
+    // hook raising it.
+    if (recorded.length > 0) throw recorded[0];
+  }
 
   // include ActiveSupport::Testing::Assertions (test_case.rb:147)
   static assertNot = assertNot;
@@ -83,9 +140,42 @@ export class TestCase {
   static travelBack = travelBack;
   static freezeTime = freezeTime;
   static unfreezeTime = unfreezeTime;
-  static afterTeardown = afterTeardown;
 }
+
+// `prepend` runs `SetupAndTeardown.prepended` (setup_and_teardown.rb:21), which
+// is what defines the `:setup` / `:teardown` callback chains on the receiver.
+setupAndTeardownPrepended(TestCase);
 
 beforeEach(() => {
   TestCase.beforeSetup();
 });
+
+afterEach((context: TestContext) => {
+  TestCase.afterTeardown(_runningTest(context));
+});
+
+/**
+ * The Minitest instance Ruby reads `assertions` / `skipped?` / `error?` /
+ * `name` / `method(name).source_location` off, read from vitest's per-test
+ * context instead.
+ *
+ * @noRailsEquivalent PERMANENT — bridges the runner's task onto the `self` of
+ * `tests_without_assertions.rb`, a `Minitest::Test` that lives in the minitest
+ * gem and so has no file in the mapped Rails source.
+ */
+function _runningTest(context: TestContext): RunningTest {
+  const task = context.task as {
+    name: string;
+    mode?: string;
+    location?: { line?: number };
+    file?: { filepath?: string };
+    result?: { state?: string; errors?: unknown[] };
+  };
+  return {
+    assertions: expect.getState().assertionCalls ?? 0,
+    skipped: task.mode === "skip" || task.mode === "todo",
+    error: task.result?.state === "fail" || (task.result?.errors?.length ?? 0) > 0,
+    name: task.name,
+    sourceLocation: [task.file?.filepath ?? "", task.location?.line ?? 0],
+  };
+}

--- a/packages/activesupport/src/testing/setup-and-teardown.trails.test.ts
+++ b/packages/activesupport/src/testing/setup-and-teardown.trails.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { resetCallbacks } from "../callbacks.js";
+import { Assertion, UnexpectedError } from "./assertions.js";
+import {
+  afterTeardown,
+  beforeSetup,
+  failures,
+  prepended,
+  setup,
+  teardown,
+} from "./setup-and-teardown.js";
+import { afterTeardown as testsWithoutAssertionsAfterTeardown } from "./tests-without-assertions.js";
+import { TestCase } from "../test-case.js";
+
+function testCase(): Record<string, never> {
+  const klass = {} as Record<string, never>;
+  prepended(klass);
+  return klass;
+}
+
+describe("SetupAndTeardown", () => {
+  it("runs setup callbacks before_setup and teardown callbacks after_teardown", () => {
+    const klass = testCase();
+    const ran: string[] = [];
+    setup.call(klass, () => ran.push("setup"));
+    teardown.call(klass, () => ran.push("teardown"));
+
+    beforeSetup.call(klass);
+    expect(ran).toEqual(["setup"]);
+
+    afterTeardown.call(klass);
+    expect(ran).toEqual(["setup", "teardown"]);
+    resetCallbacks(klass, "setup");
+    resetCallbacks(klass, "teardown");
+  });
+
+  it("records a raising teardown callback as a failure instead of propagating", () => {
+    const klass = testCase();
+    const before = failures.length;
+    const raised = new TypeError("boom");
+    teardown.call(klass, () => {
+      throw raised;
+    });
+
+    afterTeardown.call(klass);
+
+    expect(failures.length).toBe(before + 1);
+    const failure = failures[failures.length - 1];
+    expect(failure).toBeInstanceOf(UnexpectedError);
+    expect((failure as UnexpectedError).error).toBe(raised);
+    failures.length = before;
+    resetCallbacks(klass, "teardown");
+  });
+
+  it("records a failed assertion in a teardown callback as itself", () => {
+    const klass = testCase();
+    const before = failures.length;
+    const raised = new Assertion("nope");
+    teardown.call(klass, () => {
+      throw raised;
+    });
+
+    afterTeardown.call(klass);
+
+    expect(failures[failures.length - 1]).toBe(raised);
+    failures.length = before;
+    resetCallbacks(klass, "teardown");
+  });
+});
+
+describe("TestsWithoutAssertions", () => {
+  const running = {
+    assertions: 0,
+    skipped: false,
+    error: false,
+    name: "a test",
+    sourceLocation: ["some_test.ts", 12] as [string, number],
+  };
+
+  it("warns when a test made no assertion", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    testsWithoutAssertionsAfterTeardown({ ...running });
+    const calls = warn.mock.calls.map((c) => c[0]);
+    warn.mockRestore();
+
+    expect(calls).toContain("Test is missing assertions: `a test` some_test.ts:12");
+  });
+
+  it("stays quiet for a test that asserted, was skipped, or errored", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    testsWithoutAssertionsAfterTeardown({ ...running, assertions: 1 });
+    testsWithoutAssertionsAfterTeardown({ ...running, skipped: true });
+    testsWithoutAssertionsAfterTeardown({ ...running, error: true });
+    const calls = warn.mock.calls;
+    warn.mockRestore();
+
+    expect(calls).toEqual([]);
+  });
+});
+
+describe("TestCase after_teardown chain", () => {
+  it("fails the running test when a teardown callback raised, and skips the warning", () => {
+    const raised = new TypeError("boom");
+    teardown.call(TestCase, () => {
+      throw raised;
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(() =>
+        TestCase.afterTeardown({
+          assertions: 0,
+          skipped: false,
+          error: false,
+          name: "a test",
+          sourceLocation: ["some_test.ts", 12],
+        }),
+      ).toThrow(UnexpectedError);
+      expect(warn).not.toHaveBeenCalled();
+      expect(failures).toEqual([]);
+    } finally {
+      warn.mockRestore();
+      resetCallbacks(TestCase, "teardown");
+    }
+  });
+});

--- a/packages/activesupport/src/testing/setup-and-teardown.ts
+++ b/packages/activesupport/src/testing/setup-and-teardown.ts
@@ -1,0 +1,87 @@
+/**
+ * Mirrors: active_support/testing/setup_and_teardown.rb
+ *
+ * Adds support for `setup` and `teardown` callbacks. These callbacks serve as
+ * a replacement to overwriting the `#setup` and `#teardown` methods of your
+ * TestCase.
+ *
+ *     class ExampleTest extends TestCase {
+ *       static {
+ *         this.setup(() => {
+ *           // ...
+ *         });
+ *
+ *         this.teardown(() => {
+ *           // ...
+ *         });
+ *       }
+ *     }
+ *
+ * Ruby `prepend`s this module into `ActiveSupport::TestCase`
+ * (test_case.rb:145), which puts `before_setup` / `after_teardown` ahead of the
+ * included modules' own hooks in the ancestor chain. The trails receiver
+ * expresses the include list as assignments, so that ordering lives in the
+ * hook installation at the bottom of test-case.ts instead.
+ */
+import { defineCallbacks, setCallback, runCallbacks } from "../callbacks.js";
+import type { FilterListEntry } from "../callbacks.js";
+import { Assertion, UnexpectedError } from "./assertions.js";
+
+/**
+ * Mirrors `self.failures` — Minitest keeps the failure list on the test
+ * instance the module is mixed into, which lives for exactly one test. The
+ * ported hooks are free functions with no such receiver, so the list is
+ * module-global here, the same stand-in `testing/tagged_logging.rb`'s
+ * `@tagged_logger` takes.
+ */
+export const failures: (Assertion | UnexpectedError)[] = [];
+
+/**
+ * Mirrors `self.prepended(klass)` (setup_and_teardown.rb:21-25):
+ * `klass.include ActiveSupport::Callbacks` — `defineCallbacks` is that
+ * include's only observable effect here — then `define_callbacks :setup,
+ * :teardown`. Ruby's `klass.extend ClassMethods` is the `setup` / `teardown`
+ * assignment on the receiver.
+ */
+export function prepended(klass: object): void {
+  defineCallbacks(klass, "setup");
+  defineCallbacks(klass, "teardown");
+}
+
+/**
+ * Add a callback, which runs before `TestCase#setup`
+ * (setup_and_teardown.rb:29-31).
+ */
+export function setup(this: object, ...args: FilterListEntry<object>[]): void {
+  setCallback(this, "setup", "before", ...args);
+}
+
+/**
+ * Add a callback, which runs after `TestCase#teardown`
+ * (setup_and_teardown.rb:34-36).
+ */
+export function teardown(this: object, ...args: FilterListEntry<object>[]): void {
+  setCallback(this, "teardown", "after", ...args);
+}
+
+/** Mirrors `before_setup` (setup_and_teardown.rb:39-42). */
+export function beforeSetup(this: object): void {
+  runCallbacks(this, "setup");
+}
+
+/**
+ * Mirrors `after_teardown` (setup_and_teardown.rb:44-53). A teardown callback
+ * that raises is recorded as a failure rather than propagated, so the rest of
+ * the `after_teardown` chain still runs.
+ */
+export function afterTeardown(this: object): void {
+  try {
+    runCallbacks(this, "teardown");
+  } catch (e) {
+    if (e instanceof Assertion) {
+      failures.push(e);
+    } else {
+      failures.push(new UnexpectedError(e as Error));
+    }
+  }
+}

--- a/packages/activesupport/src/testing/tests-without-assertions.ts
+++ b/packages/activesupport/src/testing/tests-without-assertions.ts
@@ -1,0 +1,45 @@
+/**
+ * Mirrors: active_support/testing/tests_without_assertions.rb
+ *
+ * Warns when a test case does not perform any assertions.
+ *
+ * This is helpful in detecting broken tests that do not perform intended
+ * assertions.
+ */
+
+/**
+ * The running test — the Minitest instance Ruby reads `assertions`,
+ * `skipped?`, `error?`, `name` and `method(name).source_location` off. The
+ * ported hook is a free function with no such receiver, so the runner's task
+ * is handed to it instead; test-case.ts builds this from vitest's per-test
+ * context.
+ *
+ * @noRailsEquivalent PERMANENT — a structural stand-in for the `self` of a
+ * `Minitest::Test`, which lives in the minitest gem and so has no file in the
+ * mapped Rails source to match against.
+ */
+export interface RunningTest {
+  assertions: number;
+  skipped: boolean;
+  error: boolean;
+  name: string;
+  sourceLocation: [string, number];
+}
+
+/** Mirrors `after_teardown` (tests_without_assertions.rb:10-17). */
+export function afterTeardown(test: RunningTest): void {
+  if (test.assertions === 0 && !test.skipped && !test.error) {
+    const [file, line] = test.sourceLocation;
+    warn(`Test is missing assertions: \`${test.name}\` ${file}:${line}`);
+  }
+}
+
+/**
+ * Ruby's `Kernel#warn`, which writes to stderr.
+ *
+ * @noRailsEquivalent PERMANENT — a Ruby core method, with no file in the
+ * mapped Rails source to match against.
+ */
+function warn(message: string): void {
+  console.warn(message);
+}

--- a/scripts/parity/unported-files/baseline.json
+++ b/scripts/parity/unported-files/baseline.json
@@ -6,7 +6,7 @@
   },
   {
     "pattern": "migration/compatibility",
-    "reason": "Pre-1.0: legacy Rails version migration compatibility shims."
+    "reason": "Won't-do, by maintainer decision rather than technical limitation: `ActiveRecord::Migration[x.y]` / `Migration::Compatibility::V*` exists so migrations written under an older Rails keep behaving as written, and trails has no older versions. PR #5070 shipped a complete, CI-green `Migration[6.1]` / `Compatibility::V6_1` and was closed unmerged on 2026-07-22 — \"the premise of this pr is not the goal of trails. We have no backwards compatibility necessary since there never were previous versions of trails.\" RFC 0030's story `c1-schema-dumper-migration-version-compat` was closed on the same grounds. The thin registry at packages/activerecord/src/migration/compatibility.ts (version \"1.0\" only) stays; nothing is added to it."
   },
   {
     "pattern": "promise.rb",

--- a/scripts/parity/unported-files/unscoped.ts
+++ b/scripts/parity/unported-files/unscoped.ts
@@ -9,8 +9,21 @@ import type { UnportedFile } from "./types.js";
 
 export const UNSCOPED_UNPORTED_FILES: UnportedFile[] = [
   {
-    pattern: "migration/compatibility", // test excluded by extract-ruby-tests.rb SKIP_PATTERNS (/\/migration\//)
-    reason: "Pre-1.0: legacy Rails version migration compatibility shims.",
+    // Source side only (activerecord/lib/active_record/migration/compatibility.rb).
+    // The test file is excluded by the anchored `testFile` row below, not by any
+    // extract-ruby-tests.rb SKIP_PATTERNS rule.
+    pattern: "migration/compatibility",
+    reason:
+      "Won't-do, by maintainer decision rather than technical limitation: " +
+      "`ActiveRecord::Migration[x.y]` / `Migration::Compatibility::V*` exists so " +
+      "migrations written under an older Rails keep behaving as written, and trails has " +
+      "no older versions. PR #5070 shipped a complete, CI-green `Migration[6.1]` / " +
+      '`Compatibility::V6_1` and was closed unmerged on 2026-07-22 — "the premise of ' +
+      "this pr is not the goal of trails. We have no backwards compatibility necessary " +
+      "since there never were previous versions of trails.\" RFC 0030's story " +
+      "`c1-schema-dumper-migration-version-compat` was closed on the same grounds. The " +
+      "thin registry at packages/activerecord/src/migration/compatibility.ts (version " +
+      '"1.0" only) stays; nothing is added to it.',
   },
   {
     package: "activerecord",


### PR DESCRIPTION
Three stories. (A fourth,
`read-association-scope-off-reflection-not-definition-bag`, was in this PR until
#6512 landed the same convergence — the whole ActiveRecord half of this diff is
gone, rebased away, and the story is marked done against #6512.)

## 1. Port SetupAndTeardown and TestsWithoutAssertions

`testing/setup-and-teardown.ts` and `testing/tests-without-assertions.ts` are
ported under their Rails paths — both now 100% on `parity:api`, from `0/5` and
`0/1` — and carried by the `TestCase` receiver #6510 introduced, at
`test_case.rb:145-146`'s position.

Ruby's two `prepend`s put `before_setup` / `after_teardown` ahead of the
included modules' hooks. The trails receiver expresses the include list as
assignments, so that ordering lives in the composed chains at the bottom of
`test-case.ts`, written out in ancestor order:

- **`beforeSetup`** — `SetupAndTeardown#before_setup` opens with `super`, so
  TaggedLogging's heading runs first, then the `:setup` callbacks.
- **`afterTeardown`** — `TestsWithoutAssertions#after_teardown` (prepended last,
  so first) opens with `super` → `SetupAndTeardown#after_teardown` (the
  `:teardown` callbacks) → its trailing `super` → `TimeHelpers#after_teardown`.
  The missing-assertions check runs on the way back out, last.

`setup_and_teardown.rb:44-53` records a raising teardown callback on
`self.failures` rather than propagating it, so the rest of the chain still runs;
the port keeps that and then re-raises the recorded failure out of the hook,
because `self.failures` is the list Minitest reports the test on and vitest has
no per-test equivalent. Minitest's `error?`
(`failures.any? { UnexpectedError === _1 }`) is fed into the
`TestsWithoutAssertions` check first, so a test whose teardown raised does not
also get a missing-assertion warning.

`RunningTest` is the one piece of invented surface: the `self` of a
`Minitest::Test`, which lives in the minitest gem and has no file in the mapped
Rails source. It is tagged `@noRailsEquivalent PERMANENT` and built from
vitest's per-test context.

## 2. Triage of the non-AR assertion-parity debt

The 5,036 divergences PR #6507 surfaced are now **21 filed stories** under RFC
0105 (`assertion-parity` cluster), one per package or file group, each carrying
its Rails test files with per-file count/kind/value numbers and an est-loc — 9
activesupport, 4 activemodel, 3 arel, and one each for globalid, date, i18n and
did-you-mean. Every measured file is covered exactly once and the per-cluster
totals sum to the seeded mark. `arel`, `globalid` and `did-you-mean` were added
to the RFC's `packages`.

Those story files live in the **`blazetrailsdev/tasks` repo**, not in this diff
— that repo is the source of truth for work tracking (CLAUDE.md: "AR work
tracking lives in the `tasks` repo, not in docs"), and `pnpm tasks new` commits
and pushes each story there directly. They are on `tasks` `main` as the 21
`new: 0105-ar-deps-test-parity-100/assertions-*` commits, alongside the
`rfc 0105 --packages` commit; `pnpm tasks list --rfc 0105-ar-deps-test-parity-100
--cluster assertion-parity` lists them. Nothing about that story is expected to
land in the trails tree.

## 3. migration/compatibility source row

The trailing comment claimed an `extract-ruby-tests.rb` SKIP_PATTERNS rule that
does not exist; it now names what actually excludes the test (the anchored
`testFile` row #6505 added). The reason states the won't-do decision and cites
PR #5070 and RFC 0030's closed `c1-schema-dumper-migration-version-compat`,
matching the test-side row, and is mirrored byte-for-byte into
`unported-files/baseline.json`.

Closes-story: port-setup-and-teardown-and-tests-without-assertions
Closes-story: burn-down-non-ar-assertion-parity-debt
Closes-story: correct-migration-compatibility-source-row-reason
