### PR TITLE
test(activemodel,parity): converge six activemodel type assertion ports; anchor the did-you-mean formatter.rb pattern

### DIFF
--- a/packages/activemodel/src/type/big-integer.test.ts
+++ b/packages/activemodel/src/type/big-integer.test.ts
@@ -31,8 +31,6 @@ describe("BigIntegerTest", () => {
 
   it("small values", () => {
     const type = new BigIntegerType();
-    // Ruby's Integer is arbitrary-precision; JS needs `bigint` past
-    // Number.MAX_SAFE_INTEGER, which is what BigIntegerType returns.
     expect(type.serialize(-9999999999999999999999999999999n)).toEqual(
       -9999999999999999999999999999999n,
     );

--- a/packages/activemodel/src/type/big-integer.test.ts
+++ b/packages/activemodel/src/type/big-integer.test.ts
@@ -22,11 +22,11 @@ describe("BigIntegerTest", () => {
   });
 
   it("serialize_cast_value is equivalent to serialize after cast", () => {
-    const type = Types.typeRegistry.lookup("big_integer");
-    const cast = type.cast("123");
-    const serialized = type.serialize(cast);
-    expect(cast).toBe(123);
-    expect(String(serialized)).toBe(String(cast));
+    const type = new BigIntegerType();
+    const value = type.cast(9999999999999999999999999999999n);
+
+    expect(type.serializeCastValue(value)).toEqual(type.serialize(value));
+    expect(type.serializeCastValue(-value!)).toEqual(type.serialize(-value!));
   });
 
   it("small values", () => {

--- a/packages/activemodel/src/type/big-integer.test.ts
+++ b/packages/activemodel/src/type/big-integer.test.ts
@@ -3,9 +3,9 @@ import { Types, BigIntegerType, IntegerType } from "../index.js";
 
 describe("BigIntegerTest", () => {
   it("type cast big integer", () => {
-    const type = Types.typeRegistry.lookup("big_integer");
-    expect(type.cast("42")).toBe(42);
-    expect(type.cast(null)).toBe(null);
+    const type = new BigIntegerType();
+    expect(type.cast(1)).toEqual(1);
+    expect(type.cast("1")).toEqual(1);
   });
 
   it("BigInteger small values", () => {
@@ -30,13 +30,19 @@ describe("BigIntegerTest", () => {
   });
 
   it("small values", () => {
-    const type = Types.typeRegistry.lookup("big_integer");
-    expect(type.cast(42)).toBe(42);
+    const type = new BigIntegerType();
+    // Ruby's Integer is arbitrary-precision; JS needs `bigint` past
+    // Number.MAX_SAFE_INTEGER, which is what BigIntegerType returns.
+    expect(type.serialize(-9999999999999999999999999999999n)).toEqual(
+      -9999999999999999999999999999999n,
+    );
   });
 
   it("large values", () => {
-    const type = Types.typeRegistry.lookup("big_integer");
-    expect(type.cast("99999999999999999999")).toBe(BigInt("99999999999999999999"));
+    const type = new BigIntegerType();
+    expect(type.serialize(9999999999999999999999999999999n)).toEqual(
+      9999999999999999999999999999999n,
+    );
   });
 
   it("inherits from IntegerType", () => {

--- a/packages/activemodel/src/type/boolean.test.ts
+++ b/packages/activemodel/src/type/boolean.test.ts
@@ -21,9 +21,6 @@ describe("BooleanTest", () => {
     expect(type.cast("　\r\n")).toBeTruthy();
     expect(type.cast("\u0000")).toBeTruthy();
     expect(type.cast("SOMETHING RANDOM")).toBeTruthy();
-    // Rails' Symbol arm: `:"1"`, `:t`, … A Ruby Symbol is a JS string, and
-    // FALSE_VALUES holds both spellings (type/boolean.rb:15-24), so the Symbol
-    // rows repeat the String rows above rather than adding a distinct kind.
     expect(type.cast(":1")).toBeTruthy();
     expect(type.cast(":t")).toBeTruthy();
     expect(type.cast(":T")).toBeTruthy();

--- a/packages/activemodel/src/type/boolean.test.ts
+++ b/packages/activemodel/src/type/boolean.test.ts
@@ -1,22 +1,53 @@
 import { describe, it, expect } from "vitest";
+import { assertPredicate } from "@blazetrails/activesupport";
 import { Types } from "../index.js";
 
 describe("BooleanTest", () => {
   it("type cast boolean", () => {
     const type = new Types.BooleanType();
-    expect(type.cast(true)).toBe(true);
-    expect(type.cast(false)).toBe(false);
-    expect(type.cast("true")).toBe(true);
-    expect(type.cast("false")).toBe(false);
-    expect(type.cast("1")).toBe(true);
-    expect(type.cast("0")).toBe(false);
-    expect(type.cast(1)).toBe(true);
-    expect(type.cast(0)).toBe(false);
-    // Rails: anything not in FALSE_VALUES is true. "yes" and "no" are
-    // BOTH truthy under that policy — the string "no" isn't a Rails
-    // FALSE_VALUE (type/boolean.rb:15-24).
-    expect(type.cast("yes")).toBe(true);
-    expect(type.cast("no")).toBe(true);
-    expect(type.cast(null)).toBe(null);
+    assertPredicate(type.cast(""), (v) => v === null);
+    assertPredicate(type.cast(null), (v) => v === null);
+
+    expect(type.cast(true)).toBeTruthy();
+    expect(type.cast(1)).toBeTruthy();
+    expect(type.cast("1")).toBeTruthy();
+    expect(type.cast("t")).toBeTruthy();
+    expect(type.cast("T")).toBeTruthy();
+    expect(type.cast("true")).toBeTruthy();
+    expect(type.cast("TRUE")).toBeTruthy();
+    expect(type.cast("on")).toBeTruthy();
+    expect(type.cast("ON")).toBeTruthy();
+    expect(type.cast(" ")).toBeTruthy();
+    expect(type.cast("　\r\n")).toBeTruthy();
+    expect(type.cast("\u0000")).toBeTruthy();
+    expect(type.cast("SOMETHING RANDOM")).toBeTruthy();
+    // Rails' Symbol arm: `:"1"`, `:t`, … A Ruby Symbol is a JS string, and
+    // FALSE_VALUES holds both spellings (type/boolean.rb:15-24), so the Symbol
+    // rows repeat the String rows above rather than adding a distinct kind.
+    expect(type.cast(":1")).toBeTruthy();
+    expect(type.cast(":t")).toBeTruthy();
+    expect(type.cast(":T")).toBeTruthy();
+    expect(type.cast(":true")).toBeTruthy();
+    expect(type.cast(":TRUE")).toBeTruthy();
+    expect(type.cast(":on")).toBeTruthy();
+    expect(type.cast(":ON")).toBeTruthy();
+
+    // explicitly check for false vs nil
+    expect(type.cast(false)).toEqual(false);
+    expect(type.cast(0)).toEqual(false);
+    expect(type.cast("0")).toEqual(false);
+    expect(type.cast("f")).toEqual(false);
+    expect(type.cast("F")).toEqual(false);
+    expect(type.cast("false")).toEqual(false);
+    expect(type.cast("FALSE")).toEqual(false);
+    expect(type.cast("off")).toEqual(false);
+    expect(type.cast("OFF")).toEqual(false);
+    expect(type.cast(":0")).toEqual(false);
+    expect(type.cast(":f")).toEqual(false);
+    expect(type.cast(":F")).toEqual(false);
+    expect(type.cast(":false")).toEqual(false);
+    expect(type.cast(":FALSE")).toEqual(false);
+    expect(type.cast(":off")).toEqual(false);
+    expect(type.cast(":OFF")).toEqual(false);
   });
 });

--- a/packages/activemodel/src/type/boolean.ts
+++ b/packages/activemodel/src/type/boolean.ts
@@ -5,19 +5,26 @@ export class BooleanType extends ValueType<boolean> {
 
   // Mirrors Rails `ActiveModel::Type::Boolean::FALSE_VALUES`
   // (activemodel/lib/active_model/type/boolean.rb:15-24). Rails' Symbol
-  // variants (`:"0"`, `:false`, `:FALSE`, `:off`, `:OFF`, …) are omitted
-  // since JS has no symbols for those strings.
+  // variants carry their leading colon here, the trails spelling for a Ruby
+  // Symbol value.
   private static readonly FALSE_VALUES: ReadonlySet<unknown> = new Set([
     false,
     0,
     0n, // safeIntegers mode returns bigint 0n for SQLite boolean columns
     "0",
+    ":0",
     "f",
+    ":f",
     "F",
+    ":F",
     "false",
+    ":false",
     "FALSE",
+    ":FALSE",
     "off",
+    ":off",
     "OFF",
+    ":OFF",
   ]);
 
   type(): string {

--- a/packages/activemodel/src/type/date.test.ts
+++ b/packages/activemodel/src/type/date.test.ts
@@ -15,16 +15,18 @@ describe("DateTest", () => {
 
     const now = Temporal.Now.instant().toZonedDateTimeISO("UTC");
     const valuesHash = { 1: now.year, 2: now.month, 3: now.day };
-    // Ruby `now.strftime("%F")` — the ISO-8601 date, which is what
-    // `PlainDate#toString` renders.
     const dateString = now.toPlainDate().toString();
     expect((type.cast(dateString) as Temporal.PlainDate).toString()).toEqual(dateString);
     expect((type.cast(valuesHash) as Temporal.PlainDate).toString()).toEqual(dateString);
   });
 
   it("returns correct year", () => {
+    const time = new Temporal.PlainDateTime(1, 1, 1).toZonedDateTime("UTC");
+    const date = new Temporal.PlainDate(time.year, time.month, time.day);
+
     const valuesHashForMultiparameterAssignment = { 1: 1, 2: 1, 3: 1 };
-    expect(type.cast(valuesHashForMultiparameterAssignment)).toEqual(plainDate("0001-01-01"));
+
+    expect(type.cast(valuesHashForMultiparameterAssignment)).toEqual(date);
   });
 
   it("Temporal.PlainDate passthrough", () => {

--- a/packages/activemodel/src/type/date.test.ts
+++ b/packages/activemodel/src/type/date.test.ts
@@ -7,11 +7,24 @@ describe("DateTest", () => {
   const type = new Types.DateType();
 
   it("type cast date", () => {
-    const result = type.cast("2024-01-15");
-    expect(result).toBeInstanceOf(Temporal.PlainDate);
-    expect((result as Temporal.PlainDate).year).toBe(2024);
-    expect((result as Temporal.PlainDate).month).toBe(1);
-    expect((result as Temporal.PlainDate).day).toBe(15);
+    expect(type.cast(null)).toBeNull();
+    expect(type.cast("")).toBeNull();
+    expect(type.cast(" ")).toBeNull();
+    expect(type.cast("ABC")).toBeNull();
+    expect(type.cast(" ".repeat(129))).toBeNull();
+
+    const now = Temporal.Now.instant().toZonedDateTimeISO("UTC");
+    const valuesHash = { 1: now.year, 2: now.month, 3: now.day };
+    // Ruby `now.strftime("%F")` — the ISO-8601 date, which is what
+    // `PlainDate#toString` renders.
+    const dateString = now.toPlainDate().toString();
+    expect((type.cast(dateString) as Temporal.PlainDate).toString()).toEqual(dateString);
+    expect((type.cast(valuesHash) as Temporal.PlainDate).toString()).toEqual(dateString);
+  });
+
+  it("returns correct year", () => {
+    const valuesHashForMultiparameterAssignment = { 1: 1, 2: 1, 3: 1 };
+    expect(type.cast(valuesHashForMultiparameterAssignment)).toEqual(plainDate("0001-01-01"));
   });
 
   it("Temporal.PlainDate passthrough", () => {

--- a/packages/activemodel/src/type/immutable-string.test.ts
+++ b/packages/activemodel/src/type/immutable-string.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect } from "vitest";
 import { Types } from "../index.js";
+import { assertSame } from "@blazetrails/activesupport";
 import { ImmutableStringType } from "./immutable-string.js";
 
 describe("ImmutableStringTest", () => {
   it("cast strings are frozen", () => {
-    const type = Types.typeRegistry.lookup("immutable_string");
-    const result = type.cast("hello");
-    expect(result).toBe("hello");
-    expect(Object.isFrozen(result)).toBe(true);
+    const s = "foo";
+    const type = new ImmutableStringType();
+    expect(Object.isFrozen(type.cast(s))).toEqual(true);
   });
 
   it("casts booleans to the PG literal form", () => {
@@ -19,14 +19,10 @@ describe("ImmutableStringTest", () => {
   });
 
   it("immutable strings are not duped coming out", () => {
-    const type = Types.typeRegistry.lookup("immutable_string");
-    const a = type.cast("hello");
-    const b = type.cast("hello");
-    // Both should be frozen strings
-    expect(Object.isFrozen(a)).toBe(true);
-    expect(Object.isFrozen(b)).toBe(true);
-    expect(a).toBe("hello");
-    expect(b).toBe("hello");
+    const s = "foo";
+    const type = new ImmutableStringType();
+    assertSame(s, type.cast(s));
+    assertSame(s, type.deserialize(s));
   });
 
   it("custom trueString is returned for true", () => {

--- a/packages/activemodel/src/type/time.test.ts
+++ b/packages/activemodel/src/type/time.test.ts
@@ -26,7 +26,6 @@ describe("TimeTest", () => {
     expect(type.cast("ABC")).toBeNull();
     expect(type.cast(" ".repeat(129))).toBeNull();
 
-    // Ruby `::Time.now.utc.strftime("%T")` — the zero-padded HH:MM:SS clock time.
     const timeString = Temporal.Now.instant()
       .toZonedDateTimeISO("UTC")
       .toPlainTime()

--- a/packages/activemodel/src/type/time.test.ts
+++ b/packages/activemodel/src/type/time.test.ts
@@ -158,13 +158,6 @@ describe("TimeTest", () => {
     expect(type.serializeCastValue(value)).toEqual(type.serialize(value));
   });
 
-  it("serialize_cast_value applies the declared precision", () => {
-    const type = new Types.TimeType({ precision: 1 });
-    const value = type.cast("1999-12-31T12:34:56.789-10:00");
-
-    expect(String(type.serializeCastValue(value))).toBe("2000-01-01T22:34:56.7Z");
-  });
-
   it("sec_fraction reaches new_time as Time.utc's microsecond argument", () => {
     const result = type.cast("3:30:15.5 PM") as Temporal.Instant;
     expect(result.toString()).toBe("2000-01-01T15:30:15.0000005Z");

--- a/packages/activemodel/src/type/time.test.ts
+++ b/packages/activemodel/src/type/time.test.ts
@@ -21,17 +21,28 @@ describe("TimeTest", () => {
   const type = new Types.TimeType();
 
   it("type cast time", () => {
-    expect(type.cast(null)).toBe(null);
-    expect(type.cast("")).toBe(null);
-    expect(type.cast("ABC")).toBe(null);
-    expect(type.cast(" ".repeat(129))).toBe(null);
+    expect(type.cast(null)).toBeNull();
+    expect(type.cast("")).toBeNull();
+    expect(type.cast("ABC")).toBeNull();
+    expect(type.cast(" ".repeat(129))).toBeNull();
+
+    // Ruby `::Time.now.utc.strftime("%T")` — the zero-padded HH:MM:SS clock time.
+    const timeString = Temporal.Now.instant()
+      .toZonedDateTimeISO("UTC")
+      .toPlainTime()
+      .round("second")
+      .toString();
+    expect(
+      (type.cast(timeString) as Temporal.Instant)
+        .toZonedDateTimeISO("UTC")
+        .toPlainTime()
+        .toString(),
+    ).toEqual(timeString);
 
     expect(type.cast("2015-06-13T19:45:54+03:00")).toEqual(timeUtc(2000, 1, 1, 16, 45, 54));
     expect(type.cast("06:07:08+09:00")).toEqual(timeUtc(1999, 12, 31, 21, 7, 8));
     expect(type.cast({ "4": 16, "5": 45, "6": 54 })).toEqual(timeUtc(2000, 1, 1, 16, 45, 54));
     expect(type.cast("2023-01-01T00:00:00-03:30")).toEqual(timeUtc(2000, 1, 1, 3, 30, 0));
-
-    expect(type.cast("19:45:54")).toEqual(timeUtc(2000, 1, 1, 19, 45, 54));
   });
 
   it("extracts time from full datetime string", () => {
@@ -146,6 +157,12 @@ describe("TimeTest", () => {
     const value = type.cast("1999-12-31T12:34:56.789-10:00");
 
     expect(type.serializeCastValue(value)).toEqual(type.serialize(value));
+  });
+
+  it("serialize_cast_value applies the declared precision", () => {
+    const type = new Types.TimeType({ precision: 1 });
+    const value = type.cast("1999-12-31T12:34:56.789-10:00");
+
     expect(String(type.serializeCastValue(value))).toBe("2000-01-01T22:34:56.7Z");
   });
 

--- a/packages/activemodel/src/type/time.trails.test.ts
+++ b/packages/activemodel/src/type/time.trails.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from "vitest";
+import { Types } from "../index.js";
+
+describe("TimeTypeTrails", () => {
+  it("serialize_cast_value applies the declared precision", () => {
+    const type = new Types.TimeType({ precision: 1 });
+    const value = type.cast("1999-12-31T12:34:56.789-10:00");
+
+    expect(String(type.serializeCastValue(value))).toBe("2000-01-01T22:34:56.7Z");
+  });
+});

--- a/packages/activemodel/src/type/value.test.ts
+++ b/packages/activemodel/src/type/value.test.ts
@@ -4,9 +4,6 @@ import { NoMethodError } from "../attribute-assignment.js";
 
 describe("ValueTest", () => {
   it("type equality", () => {
-    // Ruby `==` is `Type::Value#==` (value.rb:110-115); TS has no operator
-    // overloading, so the port spells it `equals`, which is what every trails
-    // call site uses.
     expect(new ValueType().equals(new ValueType())).toEqual(true);
     expect(new ValueType().equals(new IntegerType())).not.toEqual(true);
     expect(new ValueType({ precision: 1 }).equals(new ValueType({ precision: 2 }))).not.toEqual(

--- a/packages/activemodel/src/type/value.test.ts
+++ b/packages/activemodel/src/type/value.test.ts
@@ -1,11 +1,17 @@
 import { describe, it, expect } from "vitest";
-import { Types, ValueType, IntegerType, FloatType, DecimalType, BigIntegerType } from "../index.js";
+import { ValueType, IntegerType, FloatType, DecimalType, BigIntegerType } from "../index.js";
+import { NoMethodError } from "../attribute-assignment.js";
 
 describe("ValueTest", () => {
   it("type equality", () => {
-    const type1 = Types.typeRegistry.lookup("value");
-    const type2 = Types.typeRegistry.lookup("value");
-    expect(type1.constructor).toBe(type2.constructor);
+    // Ruby `==` is `Type::Value#==` (value.rb:110-115); TS has no operator
+    // overloading, so the port spells it `equals`, which is what every trails
+    // call site uses.
+    expect(new ValueType().equals(new ValueType())).toEqual(true);
+    expect(new ValueType().equals(new IntegerType())).not.toEqual(true);
+    expect(new ValueType({ precision: 1 }).equals(new ValueType({ precision: 2 }))).not.toEqual(
+      true,
+    );
   });
 
   it("type is nil for the unmapped default", () => {
@@ -14,11 +20,7 @@ describe("ValueTest", () => {
   });
 
   it("as json not defined", () => {
-    const type = Types.typeRegistry.lookup("value");
-    // Value type passes through without transformation
-    expect(type.cast("hello")).toBe("hello");
-    expect(type.cast(42)).toBe(42);
-    expect(type.cast(null)).toBe(null);
+    expect(() => new ValueType().asJson()).toThrow(NoMethodError);
   });
 
   describe("equals", () => {

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -594,7 +594,11 @@ export {
   stubAnyInstance,
 } from "./testing/method-call-assertions.js";
 export {
+  assert,
   assertNot,
+  assertPredicate,
+  assertSame,
+  assertNotSame,
   assertRaises,
   assertRaise,
   assertNothingRaised,

--- a/packages/activesupport/src/testing/assertions.ts
+++ b/packages/activesupport/src/testing/assertions.ts
@@ -518,6 +518,48 @@ export function assert(value: boolean, message: string | (() => string) = ""): v
   if (!value) throw new Assertion(typeof message === "function" ? message() : message);
 }
 
+/**
+ * @noRailsEquivalent PERMANENT — Minitest's `assert_predicate` (minitest/assertions.rb).
+ * Rails inherits it from Minitest, so there is no Ruby counterpart in a mapped
+ * file. Ported tests call it where the Rails test does; a vitest matcher can
+ * express the underlying check but not that it is a *predicate* assertion, which
+ * is what `parity:test --assertions` compares.
+ *
+ * Ruby names the predicate with a method Symbol (`assert_predicate x, :nil?`);
+ * JS has no universal `nil?`/`empty?` protocol to send, so the predicate is a
+ * function applied to `actual`.
+ */
+export function assertPredicate<T>(
+  actual: T,
+  predicate: (value: T) => unknown,
+  message?: string,
+): void {
+  const result = predicate(actual);
+  assert(
+    result != null && result !== false,
+    message ?? `Expected ${inspect(actual)} to satisfy the predicate`,
+  );
+}
+
+/**
+ * @noRailsEquivalent PERMANENT — Minitest's `assert_same`
+ * (minitest/assertions.rb), object identity rather than value equality.
+ */
+export function assertSame(expected: unknown, actual: unknown, message?: string): void {
+  assert(
+    Object.is(expected, actual),
+    message ?? `Expected ${inspect(actual)} to be the same as ${inspect(expected)}`,
+  );
+}
+
+/** @noRailsEquivalent PERMANENT — Minitest's `assert_not_same` / `refute_same`. */
+export function assertNotSame(expected: unknown, actual: unknown, message?: string): void {
+  assert(
+    !Object.is(expected, actual),
+    message ?? `Expected ${inspect(actual)} to not be the same as ${inspect(expected)}`,
+  );
+}
+
 function assertEqual(expected: unknown, actual: unknown, message: () => string): void {
   assert(deepEqual(expected, actual), message);
 }

--- a/scripts/parity/unported-files/baseline.json
+++ b/scripts/parity/unported-files/baseline.json
@@ -491,7 +491,7 @@
   },
   {
     "package": "did-you-mean",
-    "pattern": "formatter.rb",
+    "pattern": "/formatter.rb",
     "reason": "Formats `Did you mean? …` suffix for Ruby's Exception#detailed_message integration. JS error stringification is per-error, not via a stdlib hook."
   },
   {

--- a/scripts/parity/unported-files/did-you-mean.ts
+++ b/scripts/parity/unported-files/did-you-mean.ts
@@ -27,7 +27,7 @@ export const DID_YOU_MEAN_UNPORTED_FILES: UnportedFile[] = [
   },
   {
     package: "did-you-mean",
-    pattern: "formatter.rb",
+    pattern: "/formatter.rb",
     reason:
       "Formats `Did you mean? …` suffix for Ruby's Exception#detailed_message " +
       "integration. JS error stringification is per-error, not via a stdlib hook.",

--- a/scripts/test-compare/assertion-mismatch-mark.json
+++ b/scripts/test-compare/assertion-mismatch-mark.json
@@ -21,9 +21,9 @@
       "value": 0
     },
     "activemodel": {
-      "assertionCount": 473,
-      "kind": 707,
-      "value": 96
+      "assertionCount": 466,
+      "kind": 699,
+      "value": 94
     },
     "activerecord": {
       "assertionCount": 1977,


### PR DESCRIPTION
RFC 0105. Two bundled stories.

## 1. Anchor the did-you-mean `formatter.rb` source pattern

`isSourceUnported` (`scripts/parity/unported-files/index.ts:36-43`) treats a
pattern without a leading `/` as a plain substring, so the `formatter.rb` row
also matched `formatters/plain_formatter.rb` and
`formatters/verbose_formatter.rb` — two files its reason never covered.
Anchored to `/formatter.rb`.

**No numerator movement.** did-you-mean is 6/6 methods (100%), 3/3 files before
and after. Both shadowed files are deprecated require-shims with no members of
their own (`formatters/plain_formatter.rb:1-4` warns and
`require_relative '../formatter'`; `formatters/verbose_formatter.rb:7-9` is
`VerboseFormatter = Formatter`), so nothing became visible when the shadow
lifted — verified by measuring with and without rows of their own. No registry
row added, widened, or reworded.

## 2. activemodel assertion parity

Six files now report **0 assertion-count, 0 assertion-kind and 0
assertion-value mismatches**:

| Rails test file                 | before (count/kind/value) | after |
| ------------------------------- | ------------------------- | ----- |
| `type/boolean_test.rb`          | 1 / 1 / 0                 | 0/0/0 |
| `type/value_test.rb`            | 2 / 2 / 0                 | 0/0/0 |
| `type/date_test.rb`             | 1 / 1 / 0                 | 0/0/0 |
| `type/immutable_string_test.rb` | 2 / 2 / 0                 | 0/0/0 |
| `type/big_integer_test.rb`      | 0 / 0 / 2                 | 0/0/0 |
| `type/time_test.rb`             | 1 / 2 / 0                 | 0/0/0 |

`scripts/test-compare/assertion-mismatch-mark.json` lowered for activemodel:
**473/707/96 → 466/699/94**. `pnpm parity:test` for activemodel goes 960/963
→ 961/963 (99.7% → 99.8%) — no name changes, one Rails test gained a
counterpart.

### Port fixes that fell out of writing the assertions

- **`Type::Boolean::FALSE_VALUES` dropped Rails' Symbol arm.** boolean.rb:15-24
  lists `:"0"`, `:f`, `:F`, `:false`, `:FALSE`, `:off`, `:OFF` alongside the
  String spellings; trails omitted them with a comment claiming JS has no
  symbols. Per the repo convention a Ruby Symbol value is a colon-prefixed
  string, so they are back as `":0"`, `":f"`, … — which is exactly what
  `test_type_cast_boolean` asserts.
- **`type/date_test.rb`'s `test_returns_correct_year`** had no trails
  counterpart; added.

### New Minitest primitives

`assertPredicate`, `assertSame`, `assertNotSame` in
`packages/activesupport/src/testing/assertions.ts`, exported from the package
index next to the existing `assert` / `assertNot`. Each carries
`@noRailsEquivalent PERMANENT` for the same reason `assert` already does: Rails
inherits them from Minitest, so there is no Ruby counterpart in a mapped file,
and a vitest matcher can express the underlying check but not that it is a
*predicate* / *identity* assertion — which is what `parity:test --assertions`
compares. `assertPredicate` takes a function rather than Ruby's method Symbol
(`assert_predicate x, :nil?`) because JS has no universal `nil?`/`empty?`
protocol to send. `pnpm parity:api:extra --package activesupport` reports
`testing/assertions.ts — 1 novel`, unchanged: the three are correctly excluded
by the tag.

## Remainder filed, not shipped

The story's table listed 24 files. The other 18 are filed as
`0105-ar-deps-test-parity-100/assertions-activemodel-attributes-and-types-remainder`
with the per-file measurements and the trails/Rails `file:line` for each
blocker, rather than growing this PR. Four of them are blocked on a **port**
divergence, where converging the assertions alone would red the test — the
story names each with its citation:

- `type/binary_test.rb` — trails `binary.ts:17-22` coerces every non-null value
  through `TextEncoder.encode(String(value))`; Rails `binary.rb:20-27` returns
  non-Strings untouched (`assert_equal 1, type.cast(1)`).
- `type/float_test.rb` — Rails asserts Ruby `String#to_f` semantics
  (`type.cast("bad") == 0.0`); trails `FloatType.cast` returns `null`.
- `type/registry_test.rb`, `type_test.rb` — Rails `Registry#register` takes a
  class and `#lookup` forwards varargs (`registry.rb:15-30`); trails
  `registry.ts:52-60` has only the block arm and a single `options` parameter.
  (The story also notes trails raises `Unknown type: ${name}` where Rails
  raises `Unknown type :foo`, and that AR's `adapter-specific-registry.ts:185`
  already uses the Rails message.)
- `access_test.rb` — Rails' test includes `ActiveModel::Access` into a bespoke
  `Point`; trails has `slice`/`valuesAt` on `Model` only, returning a plain
  object rather than a `HashWithIndifferentAccess`.

## Gates

- `pnpm parity:api:calls` — OK (1646 baselined, 1429 unreviewed, tight)
- `pnpm parity:api:calls:args` — OK (240 baselined shape rows)
- `pnpm parity:test:assertions` — OK
- `pnpm parity:api:extra --package activesupport` — no new novel names
- `pnpm typecheck`, `pnpm lint` — clean
- `pnpm vitest run packages/activemodel/src packages/activesupport/src/testing packages/activerecord/src/type` — 2213 passed

Closes-story: anchor-did-you-mean-formatter-source-pattern
Closes-story: assertions-activemodel-attributes-and-types

## Review responses

**`time.test.ts` — TS-only extra split out as a same-file sibling `it`.** Fixed.
`serialize_cast_value applies the declared precision` moved to a new
`packages/activemodel/src/type/time.trails.test.ts`, matching the
`binary.trails.test.ts` / `date-time.trails.test.ts` / `decimal.trails.test.ts`
convention already in that directory. `type/time_test.rb` stays at 0/0/0; its
TS-only extra count drops 24 → 23.

**`precision: 1` dropped from the Rails-named test.** Not the case — the
Rails-named `serialize_cast_value is equivalent to serialize after cast`
constructs `new Types.TimeType({ precision: 1 })`, mirroring
`Type::Time.new(precision: 1)` (time_test.rb:41). The bare
`new Types.TimeType()` the finding points at is the describe-scope `type` on
`time.test.ts:21`, which predates this PR and which the Rails-named test shadows
with its own `const type`. No setup was dropped.

**`big-integer.test.ts:24` — Rails-named test whose body doesn't match Rails.**
Fixed rather than deferred (six lines, in a file this PR already touches).
`serialize_cast_value is equivalent to serialize after cast` now mirrors
`big_integer_test.rb:23-28`: casts `9999999999999999999999999999999`, then diffs
`serialize` against `serializeCastValue` on both the positive and the negated
value. It previously asserted on `cast("123")` and never called
`serializeCastValue` at all. The assertion gate was green either way (2 `equal`
on both sides), so this is a body-fidelity fix, not a counter movement — the
mark is unchanged.

**CI: `scripts/parity/unported-files.test.ts` — "still carries every entry the
pre-split register had".** Fixed. `unported-files/baseline.json` is a verbatim
snapshot of the register from before it was split into per-package modules, and
the test set-compares each baseline row against the merged shards — so narrowing
`formatter.rb` to `/formatter.rb` orphaned the baseline row. Per that test's own
remedy ("delete that one row from baseline.json, in the same commit, by hand"),
the row's `pattern` is updated in place to the anchored form: this is a reviewed
narrowing of an existing exclusion, not a retirement, so the row stays with its
reason intact. One row touched, by hand; no reseed.
