### PR TITLE
refactor(activesupport): converge classAttribute to class_attribute's shape

### DIFF
--- a/packages/activesupport/src/class-attribute.test.ts
+++ b/packages/activesupport/src/class-attribute.test.ts
@@ -95,6 +95,20 @@ describe("classAttribute", () => {
     expect(instance.isActive).toBe(true);
   });
 
+  it("defines several attributes at once", () => {
+    class Model {}
+    classAttribute(Model, "one", "two", { default: 1 });
+
+    expect((Model as any).one).toBe(1);
+    expect((Model as any).two).toBe(1);
+  });
+
+  it("raises a TypeError on a name that is neither a symbol nor a string", () => {
+    expect(() => classAttribute(class {}, 1 as unknown as string)).toThrow(
+      new TypeError("1 is not a symbol nor a string"),
+    );
+  });
+
   it("predicate reflects current value", () => {
     class Model {}
     classAttribute(Model, "active", {

--- a/packages/activesupport/src/class-attribute.ts
+++ b/packages/activesupport/src/class-attribute.ts
@@ -6,120 +6,126 @@
  */
 
 export interface ClassAttributeOptions {
-  instanceWriter?: boolean;
+  instanceAccessor?: boolean;
   instanceReader?: boolean;
+  instanceWriter?: boolean;
   instancePredicate?: boolean;
   default?: unknown;
 }
 
-const CLASS_ATTRS = Symbol("classAttributes");
-
-interface AttrStore {
-  values: Map<string, unknown>;
-}
-
-function getStore(target: any): AttrStore {
-  if (!Object.prototype.hasOwnProperty.call(target, CLASS_ATTRS)) {
-    target[CLASS_ATTRS] = { values: new Map() };
-  }
-  return target[CLASS_ATTRS];
+function inspect(value: unknown): string {
+  if (typeof value === "string") return JSON.stringify(value);
+  return String(value);
 }
 
 /**
- * Define a class-level attribute that is inherited by subclasses.
- * Reads walk the prototype chain; writes are local to the class/instance.
+ * A Ruby class's singleton class holds its class methods; in JS those live on
+ * the constructor itself, and the constructor's prototype chain gives the same
+ * inheritance, so `owner.singleton_class` is the owner.
  */
 export namespace ClassAttribute {
-  export function redefine(
-    owner: any,
-    _name: string,
-    namespacedName: string,
-    value: unknown,
-  ): void {
-    const store = getStore(owner);
-    store.values.set(namespacedName, value);
+  export function redefine(owner: any, name: string, namespacedName: string, value: unknown): void {
+    // Rails' `if owner.singleton_class?` arm has no JS counterpart: there is no
+    // singleton class to reopen, and no attached object to test for a Module.
+    redefineMethod(owner, namespacedName, true, () => value);
+
+    redefineMethod(owner, `${namespacedName}=`, true, function (this: any, newValue: unknown) {
+      if (owner === this) {
+        value = newValue;
+      } else {
+        ClassAttribute.redefine(this, name, namespacedName, newValue);
+      }
+    });
   }
 
   export function redefineMethod(
     owner: any,
     name: string,
     isPrivate: boolean,
-    fn: () => unknown,
+    fn: (...args: any[]) => unknown,
   ): void {
-    Object.defineProperty(owner.prototype ?? owner, name, {
-      get: fn,
+    // A zero-arg Ruby reader is a JS getter and a Ruby `name=` writer is a JS
+    // setter; both are `define_method` on the Ruby side. Ruby's two methods are
+    // one JS property, so the writer keeps whatever reader is already there.
+    const isWriter = name.endsWith("=");
+    const key = isWriter ? name.slice(0, -1) : name;
+    const existing = isWriter ? Object.getOwnPropertyDescriptor(owner, key) : undefined;
+    Object.defineProperty(owner, key, {
+      get: isWriter ? existing?.get : (fn as () => unknown),
+      set: isWriter ? (fn as (value: unknown) => void) : undefined,
       configurable: true,
       enumerable: !isPrivate,
     });
   }
 }
 
-export function classAttribute(
-  klass: any,
-  name: string,
-  options: ClassAttributeOptions = {},
-): void {
+/**
+ * Define a class-level attribute that is inherited by subclasses.
+ * Reads walk the constructor chain; writes are local to the class/instance.
+ */
+export function classAttribute(klass: any, ...attrs: (string | ClassAttributeOptions)[]): void {
+  const last = attrs[attrs.length - 1];
+  const options: ClassAttributeOptions =
+    typeof last === "object" && last !== null ? (attrs.pop() as ClassAttributeOptions) : {};
   const {
-    instanceWriter = true,
-    instanceReader = true,
-    instancePredicate = false,
+    instanceAccessor = true,
+    instanceReader = instanceAccessor,
+    instanceWriter = instanceAccessor,
+    instancePredicate = true,
     default: defaultValue,
   } = options;
 
-  // Set default value on the class
-  if (defaultValue !== undefined) {
-    getStore(klass).values.set(name, defaultValue);
-  }
+  for (const name of attrs as string[]) {
+    if (typeof name !== "string") {
+      // Ruby's core TypeError, exactly as attribute.rb:91 raises it — there is
+      // no Rails error class to port here.
+      // eslint-disable-next-line blazetrails/rails-error-parity
+      throw new TypeError(`${inspect(name)} is not a symbol nor a string`);
+    }
 
-  // Class-level getter/setter
-  Object.defineProperty(klass, name, {
-    get() {
-      // Walk prototype chain for inherited values
-      let current = this;
-      while (current) {
-        const store = current[CLASS_ATTRS] as AttrStore | undefined;
-        if (store?.values.has(name)) {
-          return store.values.get(name);
-        }
-        current = Object.getPrototypeOf(current);
-      }
-      return undefined;
-    },
-    set(value: unknown) {
-      getStore(this).values.set(name, value);
-    },
-    configurable: true,
-  });
+    const namespacedName = `__class_attr_${name}`;
+    ClassAttribute.redefine(klass, name, namespacedName, defaultValue);
 
-  // Instance-level reader
-  if (instanceReader) {
-    Object.defineProperty(klass.prototype, name, {
-      get() {
-        // Check instance-level override first
-        const instanceStore = this[CLASS_ATTRS] as AttrStore | undefined;
-        if (instanceStore?.values.has(name)) {
-          return instanceStore.values.get(name);
-        }
-        // Fall back to class-level value
-        return this.constructor[name];
+    Object.defineProperty(klass, name, {
+      configurable: true,
+      enumerable: false,
+      get(this: any) {
+        return this[namespacedName];
       },
-      set: instanceWriter
-        ? function (this: any, value: unknown) {
-            getStore(this).values.set(name, value);
+      set(this: any, value: unknown) {
+        this[namespacedName] = value;
+      },
+    });
+
+    if (instanceReader || instanceWriter) {
+      const descriptor: PropertyDescriptor = { configurable: true, enumerable: false };
+      if (instanceReader) {
+        descriptor.get = function (this: any) {
+          if (Object.prototype.hasOwnProperty.call(this, `@${name}`)) {
+            return this[`@${name}`];
+          } else {
+            return this.constructor[name];
           }
-        : undefined,
-      configurable: true,
-    });
-  }
+        };
+      }
+      if (instanceWriter) {
+        descriptor.set = function (this: any, value: unknown) {
+          this[`@${name}`] = value;
+        };
+      }
+      Object.defineProperty(klass.prototype, name, descriptor);
+    }
 
-  // Instance predicate (name + "?"-like, we use `isName` in TS)
-  if (instancePredicate) {
-    const predicateName = `is${name.charAt(0).toUpperCase()}${name.slice(1)}`;
-    Object.defineProperty(klass.prototype, predicateName, {
-      get() {
+    if (instancePredicate) {
+      const predicateName = `is${name.charAt(0).toUpperCase()}${name.slice(1)}`;
+      ClassAttribute.redefineMethod(klass, predicateName, false, function (this: any) {
         return !!this[name];
-      },
-      configurable: true,
-    });
+      });
+      if (instanceReader) {
+        ClassAttribute.redefineMethod(klass.prototype, predicateName, false, function (this: any) {
+          return !!this[name];
+        });
+      }
+    }
   }
 }

--- a/packages/activesupport/src/core-ext/class/attribute.test.ts
+++ b/packages/activesupport/src/core-ext/class/attribute.test.ts
@@ -35,16 +35,20 @@ describe("ClassAttributeTest", () => {
     Klass.setting = 2;
     expect(Klass.setting).toBe(2);
     expect(Sub.setting).toBe(1);
+
+    expect(class extends Sub {}.setting).toBe(1);
+    expect(class extends Klass {}.setting).toBe(2);
   });
 
   it("predicate method", () => {
-    expect(!!Klass.setting).toBe(false);
+    expect(Klass.isSetting).toBe(false);
     Klass.setting = 1;
-    expect(!!Klass.setting).toBe(true);
+    expect(Klass.isSetting).toBe(true);
   });
 
   it("instance reader delegates to class", () => {
     expect(new Klass().setting).toBeUndefined();
+
     Klass.setting = 1;
     expect(new Klass().setting).toBe(1);
   });
@@ -58,12 +62,10 @@ describe("ClassAttributeTest", () => {
   });
 
   it("instance predicate", () => {
-    const Cls = class {};
-    classAttribute(Cls, "active", { instancePredicate: true });
-    const object = new (Cls as any)();
-    expect(object.isActive).toBe(false);
-    object.active = 1;
-    expect(object.isActive).toBe(true);
+    const object = new Klass();
+    expect(object.isSetting).toBe(false);
+    object.setting = 1;
+    expect(object.isSetting).toBe(true);
   });
 
   it("disabling instance writer", () => {
@@ -72,31 +74,40 @@ describe("ClassAttributeTest", () => {
     const object = new (Cls as any)();
     expect(() => {
       object.setting = "boom";
-    }).toThrow();
+    }).toThrow(TypeError);
+    expect(
+      Object.getOwnPropertyDescriptor(Object.getPrototypeOf(object), "setting")?.set,
+    ).toBeUndefined();
   });
 
   it("disabling instance reader", () => {
     const Cls = class {};
     classAttribute(Cls, "setting", { instanceReader: false });
     const object = new (Cls as any)();
-    expect(Object.getOwnPropertyDescriptor(Cls.prototype, "setting")).toBeUndefined();
+    expect(object.setting).toBeUndefined();
+    expect(
+      Object.getOwnPropertyDescriptor(Object.getPrototypeOf(object), "setting")?.get,
+    ).toBeUndefined();
+    expect(object.isSetting).toBeUndefined();
+    expect(Object.getPrototypeOf(object)).not.toHaveProperty("isSetting");
   });
 
   it("disabling both instance writer and reader", () => {
     const Cls = class {};
-    classAttribute(Cls, "setting", { instanceReader: false, instanceWriter: false });
+    classAttribute(Cls, "setting", { instanceAccessor: false });
     const object = new (Cls as any)();
-    expect(Object.getOwnPropertyDescriptor(Cls.prototype, "setting")).toBeUndefined();
+    expect(object.setting).toBeUndefined();
+    expect(Object.getPrototypeOf(object)).not.toHaveProperty("setting");
+    expect(object.isSetting).toBeUndefined();
+    expect(Object.getPrototypeOf(object)).not.toHaveProperty("isSetting");
   });
 
   it("disabling instance predicate", () => {
-    const WithPred = class {};
-    classAttribute(WithPred, "setting", { instancePredicate: true });
-    expect(Object.getOwnPropertyDescriptor(WithPred.prototype, "isSetting")).toBeDefined();
-
-    const Without = class {};
-    classAttribute(Without, "setting", { instancePredicate: false });
-    expect(Object.getOwnPropertyDescriptor(Without.prototype, "isSetting")).toBeUndefined();
+    const Cls = class {};
+    classAttribute(Cls, "setting", { instancePredicate: false });
+    const object = new (Cls as any)();
+    expect(object.isSetting).toBeUndefined();
+    expect(Object.getPrototypeOf(object)).not.toHaveProperty("isSetting");
   });
 
   it.skip("works well with singleton classes");
@@ -104,8 +115,8 @@ describe("ClassAttributeTest", () => {
   it.skip("works well with module singleton classes");
 
   it("setter returns set value", () => {
-    Klass.setting = 1;
-    expect(Klass.setting).toBe(1);
+    const val = (Klass.setting = 1);
+    expect(val).toBe(1);
   });
 
   it("works when overriding private methods from an ancestor", () => {
@@ -115,11 +126,16 @@ describe("ClassAttributeTest", () => {
 
     const instance = new Klass();
     expect(instance.system).toBe(1);
+    expect(new Klass().isSystem).toBe(true);
     instance.system = 2;
     expect(instance.system).toBe(2);
   });
 
   it.skip("allow to prepend accessors");
 
-  it.skip("can check if value is set on a sub class");
+  it("can check if value is set on a sub class", () => {
+    expect(Object.prototype.hasOwnProperty.call(Sub, "__class_attr_setting")).toBe(false);
+    Sub.setting = true;
+    expect(Object.prototype.hasOwnProperty.call(Sub, "__class_attr_setting")).toBe(true);
+  });
 });


### PR DESCRIPTION
Converges `classAttribute` onto `class_attribute`'s shape
(`vendor/rails/activesupport/lib/active_support/core_ext/class/attribute.rb:86-137`).

- **Varargs + kwargs.** `classAttribute(klass, ...attrs, options?)` mirrors
  `class_attribute(*attrs, instance_accessor: true, instance_reader:
  instance_accessor, instance_writer: instance_accessor, instance_predicate:
  true, default: nil)` — including `instance_accessor` (new; it was missing)
  and `instance_predicate` defaulting to **true**, not `false`. The trailing
  options object is the settled trails idiom for Ruby varargs + kwargs
  (`module-ext.ts:109`, `mattrAccessor`).
- **TypeError** on a name that is neither a Symbol nor a String, with Rails'
  message (attribute.rb:90-92). It is Ruby's core `TypeError`, so the raise
  carries a scoped `rails-error-parity` disable with the same reasoning
  `xml-mini.ts:209` gives.
- **`__class_attr_` namespaced storage** and the default written through
  `ActiveSupport::ClassAttribute.redefine` (attribute.rb:97,
  `class_attribute.rb:7-24`), replacing the bespoke `CLASS_ATTRS` symbol-keyed
  store. Inheritance and per-subclass override now come from `redefine`'s own
  `owner.equal?(self)` recursion rather than a hand-rolled chain walk, so
  "can check if value is set on a sub class" is now a real test instead of a
  skip.
- **Class-level predicate** (`silence_redefinition_of_method def name?; !!self.name; end`)
  was missing entirely; the instance one is now gated on `instance_reader`, as
  Rails gates it.
- Instance reader/writer follow Rails' `defined?(@name)` / `attr_writer :name`
  split, keyed off an `@name` own property.

`ClassAttribute.redefineMethod` collapses Ruby's separate `name` / `name=`
methods onto one JS accessor property (a writer keeps the reader already
defined on the same key) — JS has no other spelling for a Ruby writer.

Tests: `core-ext/class/attribute.test.ts` now carries every test name from
`vendor/rails/activesupport/test/core_ext/class/attribute_test.rb` verbatim,
with the four singleton-class / `prepend` cases still `it.skip` (no JS
counterpart). The trails-only extras (multi-attr varargs, the TypeError) live
in `class-attribute.test.ts`.

Not done here, and why: the story's remaining two criteria — deleting the
`redefine` row from
`scripts/api-compare/call-mismatches-exclude/activesupport/class-attribute.json`
and tightening its high-water mark — depend on the
`core_ext/class/attribute.rb` → `class-attribute.ts` `RUBY_FILE_TS_OVERRIDES`
row, which is still unmerged in #6518. Neither the row nor the exclude file
exists on `main`, so there is nothing to delete yet; both gates
(`parity:api:calls`, `parity:api:calls:args`) are green here. Whichever of the
two lands second should drop that `redefine` row.

`parity:api:extra` reports `instanceAccessor` as one more novel name in
`ClassAttributeOptions`, alongside the three option keys already there — they
are Rails' kwarg names, which `api:extra` counts as interface properties.

Closes-story: converge-class-attribute-to-rails-shape
