### PR TITLE
fix(activesupport): spell disallowed_warnings' :all as a Symbol and port the Symbol rule arm

### DIFF
--- a/packages/activesupport/src/deprecation.test.ts
+++ b/packages/activesupport/src/deprecation.test.ts
@@ -447,8 +447,6 @@ describe("DeprecationTest", () => {
   });
 
   it("disallowed_warnings can match using a substring as a symbol", () => {
-    // A Ruby Symbol value is a colon-prefixed string in trails;
-    // `deprecation_disallowed?` compares with `rule.to_s`, i.e. without the colon.
     dep.disallowedWarnings = [":fubar"];
 
     expect(() => dep.warn("using fubar is deprecated")).toThrow(/fubar/);

--- a/packages/activesupport/src/deprecation.test.ts
+++ b/packages/activesupport/src/deprecation.test.ts
@@ -202,12 +202,12 @@ describe("DeprecationTest", () => {
   });
 
   it("disallowed_warnings matches all warnings when set to :all", () => {
-    dep.disallowedWarnings = "all";
+    dep.disallowedWarnings = ":all";
     expect(() => dep.warn("using fubar is deprecated")).toThrow(/fubar/);
   });
 
   it("different behaviors for allowed and disallowed warnings", () => {
-    dep.disallowedWarnings = "all";
+    dep.disallowedWarnings = ":all";
     dep.behavior = () => expect.unreachable("the allowed behavior must not run");
 
     expect(() => dep.warn("using fubar is deprecated")).toThrow(/fubar/);
@@ -222,17 +222,17 @@ describe("DeprecationTest", () => {
   });
 
   it("allow", () => {
-    dep.disallowedWarnings = "all";
+    dep.disallowedWarnings = ":all";
 
     expect(() => dep.warn()).toThrow(DeprecationException);
 
-    dep.allow("all", {}, () => {
+    dep.allow(":all", {}, () => {
       expect(() => dep.warn()).not.toThrow();
     });
   });
 
   it("allow only allows matching warnings using a substring", () => {
-    dep.disallowedWarnings = "all";
+    dep.disallowedWarnings = ":all";
 
     dep.allow(["foo bar", "baz qux"], {}, () => {
       expect(() => dep.warn("foo bar")).not.toThrow();
@@ -242,7 +242,7 @@ describe("DeprecationTest", () => {
   });
 
   it("allow only allows matching warnings using a regexp", () => {
-    dep.disallowedWarnings = "all";
+    dep.disallowedWarnings = ":all";
 
     dep.allow([/(foo|baz) (bar|qux)/], {}, () => {
       expect(() => dep.warn("foo bar")).not.toThrow();
@@ -252,9 +252,9 @@ describe("DeprecationTest", () => {
   });
 
   it("allow only affects its block", () => {
-    dep.disallowedWarnings = "all";
+    dep.disallowedWarnings = ":all";
 
-    dep.allow("all", {}, () => {
+    dep.allow(":all", {}, () => {
       expect(() => dep.warn()).not.toThrow();
     });
 
@@ -262,7 +262,7 @@ describe("DeprecationTest", () => {
   });
 
   it("allow with :if option", () => {
-    dep.disallowedWarnings = "all";
+    dep.disallowedWarnings = ":all";
 
     dep.allow(["fubar"], { if: true }, () => {
       expect(() => dep.warn("fubar")).not.toThrow();
@@ -274,7 +274,7 @@ describe("DeprecationTest", () => {
   });
 
   it("allow with :if option as a proc", () => {
-    dep.disallowedWarnings = "all";
+    dep.disallowedWarnings = ":all";
 
     dep.allow(["fubar"], { if: () => true }, () => {
       expect(() => dep.warn("fubar")).not.toThrow();
@@ -286,9 +286,9 @@ describe("DeprecationTest", () => {
   });
 
   it("allow with the default warning message", () => {
-    dep.disallowedWarnings = "all";
+    dep.disallowedWarnings = ":all";
 
-    dep.allow("all", {}, () => {
+    dep.allow(":all", {}, () => {
       expect(() => dep.warn()).not.toThrow();
     });
 
@@ -327,7 +327,7 @@ describe("DeprecationTest", () => {
   });
 
   it("disallowed_warnings with the default warning message", () => {
-    dep.disallowedWarnings = "all";
+    dep.disallowedWarnings = ":all";
     expect(() => dep.warn()).toThrow(DeprecationException);
 
     dep.disallowedWarnings = ["fubar"];
@@ -447,18 +447,19 @@ describe("DeprecationTest", () => {
   });
 
   it("disallowed_warnings can match using a substring as a symbol", () => {
-    // In JS, symbols don't match strings, so use string equivalent
-    dep.disallowedWarnings = ["old"];
-    dep.disallowedBehavior = "raise";
-    expect(() => dep.warn("old API")).toThrow(DeprecationException);
+    // A Ruby Symbol value is a colon-prefixed string in trails;
+    // `deprecation_disallowed?` compares with `rule.to_s`, i.e. without the colon.
+    dep.disallowedWarnings = [":fubar"];
+
+    expect(() => dep.warn("using fubar is deprecated")).toThrow(/fubar/);
   });
 
   it("allow only allows matching warnings using a substring as a symbol", () => {
-    dep.disallowedWarnings = "all";
+    dep.disallowedWarnings = ":all";
 
     // A Ruby Symbol value is a colon-prefixed string in trails; `explicitly_allowed?`
     // compares with `rule.to_s`, i.e. without the colon.
-    dep.allow(["foo bar", "baz qux"], {}, () => {
+    dep.allow([":foo bar", ":baz qux"], {}, () => {
       expect(() => dep.warn("foo bar")).not.toThrow();
       expect(() => dep.warn("baz qux")).not.toThrow();
       expect(() => dep.warn("fubar")).toThrow(/fubar/);
@@ -469,9 +470,9 @@ describe("DeprecationTest", () => {
     // JS has one thread of execution, so the "other thread still disallowed"
     // half of the Rails case has no analogue; what remains is that the
     // allowance ends with its block.
-    dep.disallowedWarnings = "all";
+    dep.disallowedWarnings = ":all";
 
-    dep.allow("all", {}, () => {
+    dep.allow(":all", {}, () => {
       expect(() => dep.warn()).not.toThrow();
     });
 

--- a/packages/activesupport/src/deprecation.ts
+++ b/packages/activesupport/src/deprecation.ts
@@ -229,7 +229,7 @@ export class Deprecation {
   debug = false;
   /**
    * Rails: `disallowed_warnings` (deprecation/disallowed.rb:22), which is an
-   * array of substrings/Regexps, or the scalar `:all`.
+   * array of substrings/Symbols/Regexps, or the scalar `:all`.
    */
   disallowedWarnings: AllowMatcher[] | ":all" = [];
 

--- a/packages/activesupport/src/deprecation.ts
+++ b/packages/activesupport/src/deprecation.ts
@@ -150,6 +150,12 @@ function arityOfCallable(callable: Function): number {
   return callable.length;
 }
 
+/**
+ * A single disallowed/allowed warning rule: Rails' `String`, `Symbol`, or
+ * `Regexp` (deprecation/disallowed.rb:6-8). A Symbol rule keeps its leading
+ * colon per the trails Symbol convention — `:foo` is `":foo"` — and matches on
+ * `rule.to_s`, i.e. the name without the colon.
+ */
 type AllowMatcher = string | RegExp;
 
 /**
@@ -225,14 +231,14 @@ export class Deprecation {
    * Rails: `disallowed_warnings` (deprecation/disallowed.rb:22), which is an
    * array of substrings/Regexps, or the scalar `:all`.
    */
-  disallowedWarnings: AllowMatcher[] | "all" = [];
+  disallowedWarnings: AllowMatcher[] | ":all" = [];
 
   // Rails: `@silence_counter = Concurrent::ThreadLocalVar.new(0)` (deprecation.rb:78).
   private _silenceCounter = 0;
   // Rails: `@explicitly_allowed_warnings = Concurrent::ThreadLocalVar.new(nil)`
   // (deprecation.rb:77); JS is single-threaded, so the bound value is a plain
   // field saved and restored around the block, as `ThreadLocalVar#bind` does.
-  private _explicitlyAllowedWarnings: AllowMatcher[] | "all" | null = null;
+  private _explicitlyAllowedWarnings: AllowMatcher[] | ":all" | null = null;
 
   /**
    * Returns the current behavior or if one isn't set, defaults to `:stderr`.
@@ -393,11 +399,13 @@ export class Deprecation {
   /** Mirrors: deprecation/disallowed.rb:25-36. */
   private isDeprecationDisallowed(message?: string): boolean {
     if (this.isExplicitlyAllowed(message)) return false;
-    if (this.disallowedWarnings === "all") return true;
+    if (this.disallowedWarnings === ":all") return true;
     return (
       message != null &&
       this.disallowedWarnings.some((rule) =>
-        rule instanceof RegExp ? rule.test(message) : message.includes(rule),
+        rule instanceof RegExp
+          ? rule.test(message)
+          : message.includes(rule.startsWith(":") ? rule.slice(1) : rule),
       )
     );
   }
@@ -406,11 +414,13 @@ export class Deprecation {
   private isExplicitlyAllowed(message?: string): boolean {
     const allowances = this._explicitlyAllowedWarnings;
     if (allowances == null) return false;
-    if (allowances === "all") return true;
+    if (allowances === ":all") return true;
     return (
       message != null &&
       wrap(allowances).some((rule) =>
-        rule instanceof RegExp ? rule.test(message) : message.includes(rule),
+        rule instanceof RegExp
+          ? rule.test(message)
+          : message.includes(rule.startsWith(":") ? rule.slice(1) : rule),
       )
     );
   }
@@ -442,7 +452,7 @@ export class Deprecation {
    * truthy/falsy value or something callable; falsy yields without allowing.
    */
   allow<T>(
-    allowedWarnings: AllowMatcher[] | "all" = "all",
+    allowedWarnings: AllowMatcher[] | ":all" = ":all",
     options: { if?: unknown } = {},
     block: () => T,
   ): T {

--- a/packages/activesupport/src/deprecation/deprecators.test.ts
+++ b/packages/activesupport/src/deprecation/deprecators.test.ts
@@ -86,8 +86,8 @@ describe("DeprecationTest", () => {
   });
 
   it("#disallowed_warnings= applies to each deprecator", () => {
-    deprecators.setDisallowedWarnings(["all"]);
-    deprecators.each((deprecator) => expect(deprecator.disallowedWarnings).toEqual(["all"]));
+    deprecators.setDisallowedWarnings(":all");
+    deprecators.each((deprecator) => expect(deprecator.disallowedWarnings).toEqual(":all"));
   });
 
   it("#silence silences each deprecator", () => {

--- a/packages/trailties/src/trailties/active-support.ts
+++ b/packages/trailties/src/trailties/active-support.ts
@@ -58,7 +58,7 @@ export interface ActiveSupportConfig {
   reportDeprecations?: boolean;
   deprecation?: BehaviorSetting;
   disallowedDeprecation?: DisallowedBehaviorSetting;
-  disallowedDeprecationWarnings?: (string | RegExp | "all")[];
+  disallowedDeprecationWarnings?: Deprecation["disallowedWarnings"];
 }
 
 /**


### PR DESCRIPTION
Rails' `disallowed_warnings` accepts **either** an array of String / Symbol /
Regexp rules **or** the scalar Symbol `:all`
(`activesupport/lib/active_support/deprecation/disallowed.rb:6-23`). trails
spelled the scalar `"all"`, which is indistinguishable from a legitimate rule
string `"all"`, and `deprecation_disallowed?`'s `case rule` dropped the
`Symbol` arm (`disallowed.rb:31-32`).

Per the trails Symbol convention (CLAUDE.md), a Ruby Symbol value is a
colon-prefixed string:

- the scalar is `":all"` — `disallowedWarnings: AllowMatcher[] | ":all"`, and
  the same for `@explicitly_allowed_warnings` and `allow`'s `:all` default
  (`reporting.rb:89`);
- a Symbol rule keeps its colon (`":fubar"`) and matches on `rule.to_s`, i.e.
  the name without the colon — `disallowed.rb:31-32` and `:44-45`.

Branch order in both bodies already mirrored Rails (`explicitly_allowed?`
guard, scalar early return, then the `any?` loop); this fills in the Symbol arm
and the scalar's spelling.

Tests: `deprecators.test.ts`'s `#disallowed_warnings= applies to each
deprecator` now sets the scalar as `deprecators_test.rb:66-69` does, and
`disallowed_warnings can match using a substring as a symbol` /
`allow only allows matching warnings using a substring as a symbol` use the
Symbol spelling instead of the string workaround
(`deprecation_test.rb:625-631`, `:694-702`).

Closes-story: deprecation-disallowed-warnings-scalar-all-arm
