### PR TITLE
refactor(activesupport): route Date#compare_with_coercion through to_datetime

### DIFF
--- a/packages/activesupport/src/core-ext/date/calculations.ts
+++ b/packages/activesupport/src/core-ext/date/calculations.ts
@@ -13,7 +13,7 @@
  * Mirrors: `class Date` (`core_ext/date/calculations.rb`)
  */
 
-import { Temporal } from "@blazetrails/date";
+import { Temporal, Date as RubyDate } from "@blazetrails/date";
 import { Duration } from "../../duration.js";
 import { IsolatedExecutionState } from "../../isolated-execution-state.js";
 import { TimeWithZone } from "../../time-with-zone.js";
@@ -233,7 +233,10 @@ export function change(
  * and a `TimeWithZone`; trails has no bare-`Time` class to key on. The day is
  * widened by ruby/date's own `to_datetime` (`date_core.c`
  * `d_lite_to_datetime`), which is midnight at offset 0 — `date_ext_test.rb:80`
- * asserts that — not midnight in `Time.zone`.
+ * asserts that — not midnight in `Time.zone`. That method is ported as
+ * `Date#toDatetime` (`packages/date/src/date.ts`), whose receiver is the
+ * ruby/date `Date`, so the `Temporal.PlainDate` this file is keyed on is handed
+ * to it through the `PlainDate` constructor overload.
  */
 export function compareWithCoercion(
   date: Temporal.PlainDate,
@@ -242,14 +245,22 @@ export function compareWithCoercion(
   // boundary: a JS `Date` is one of trails' moment receivers, and this arm is
   // keyed on being one.
   if (other instanceof Date || other instanceof Temporal.Instant || other instanceof TimeWithZone) {
-    const toDatetime = date.toZonedDateTime("UTC").toInstant();
+    const toDatetime = new RubyDate(date).toDatetime();
     const instant =
       other instanceof Temporal.Instant
         ? other
         : other instanceof TimeWithZone
           ? other.utc()
           : Temporal.Instant.fromEpochMilliseconds(other.getTime());
-    return Temporal.Instant.compare(toDatetime, instant);
+    return Temporal.Instant.compare(
+      // A `Date`'s `to_datetime` is always offset 0, which trails spells as the
+      // offsetless `PlainDateTime`; the `ZonedDateTime` arm is unreachable here.
+      (toDatetime instanceof Temporal.ZonedDateTime
+        ? toDatetime
+        : toDatetime.toZonedDateTime("UTC")
+      ).toInstant(),
+      instant,
+    );
   } else {
     return compareWithoutCoercion(date, other);
   }

--- a/packages/activesupport/src/core-ext/date/calculations.ts
+++ b/packages/activesupport/src/core-ext/date/calculations.ts
@@ -236,7 +236,11 @@ export function change(
  * asserts that — not midnight in `Time.zone`. That method is ported as
  * `Date#toDatetime` (`packages/date/src/date.ts`), whose receiver is the
  * ruby/date `Date`, so the `Temporal.PlainDate` this file is keyed on is handed
- * to it through the `PlainDate` constructor overload.
+ * to it through the `PlainDate` constructor overload. Its declared return is the
+ * `PlainDateTime | ZonedDateTime` union `DateTime#toDatetime` can produce; a
+ * `Date` is always offset 0, which trails spells as the offsetless
+ * `PlainDateTime`, so the `ZonedDateTime` arm of the narrow below is unreachable
+ * from here.
  */
 export function compareWithCoercion(
   date: Temporal.PlainDate,
@@ -253,8 +257,6 @@ export function compareWithCoercion(
           ? other.utc()
           : Temporal.Instant.fromEpochMilliseconds(other.getTime());
     return Temporal.Instant.compare(
-      // A `Date`'s `to_datetime` is always offset 0, which trails spells as the
-      // offsetless `PlainDateTime`; the `ZonedDateTime` arm is unreachable here.
       (toDatetime instanceof Temporal.ZonedDateTime
         ? toDatetime
         : toDatetime.toZonedDateTime("UTC")

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/date/calculations.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/date/calculations.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activesupport",
-    "tsFile": "core-ext/date/calculations.ts",
-    "rubyName": "compare_with_coercion",
-    "call": "to_datetime",
-    "reason": "Rails coerces the receiver with `to_datetime` before comparing when the other side is a Time (date/calculations.rb:143); trails compares the temporal values directly. A pre-existing gap, newly visible because `toDatetime` entered the activesupport population; tracked by 0098-activesupport-ar-closure-port/converge-date-time-current-since-to-datetime."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/time-ext.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/time-ext.json
@@ -4,7 +4,7 @@
     "tsFile": "time-ext.ts",
     "rubyName": "current",
     "call": "to_datetime",
-    "reason": "`DateTime.current` is `Time.zone.now.to_datetime` (date_time/calculations.rb:11); trails' `current` returns the Time/TimeWithZone arm only. A pre-existing gap in this body, newly visible because `String#to_datetime` put `toDatetime` in this file's population. Tracked by 0098-activesupport-ar-closure-port/converge-date-time-current-since-to-datetime."
+    "reason": "Homonym across two Ruby receivers: `Time.current` (time/calculations.rb:39-41) has no `to_datetime`, `DateTime.current` (date_time/calculations.rb:10-12) is that same expression plus `.to_datetime`, and trails has one `current()` here serving both — one function cannot return both a Time and a DateTime. Converging it means giving DateTime its own receiver file; tracked by 0098-activesupport-ar-closure-port/split-date-time-current-onto-its-own-receiver."
   },
   {
     "package": "activesupport",
@@ -18,7 +18,7 @@
     "tsFile": "time-ext.ts",
     "rubyName": "since",
     "call": "to_datetime",
-    "reason": "Same body-level gap: `DateTime#since` ends in `.to_datetime` (date_time/calculations.rb:87); tracked by the same story."
+    "reason": "`DateTime#since` (date_time/calculations.rb:116-118) is `self + Rational(seconds, 86400)` and makes no such call; the only `to_datetime` under this name is `Time#since`'s `rescue TypeError` arm (time/calculations.rb:227-233), which exists only to deprecate passing a non-numeric and is documented to raise `TypeError` in Rails 8.1. `since(date, seconds: number)` cannot reach it — the same unrepresentable arm as this file's `since` → `warn` row."
   },
   {
     "package": "activesupport",


### PR DESCRIPTION
Converges the one genuinely convergeable member of the three `to_datetime` call-gate rows #6518 surfaced, and corrects the record on the other two.

## `compare_with_coercion` — converged

`Date#compare_with_coercion` (`date/calculations.rb:152-158`) widens the receiver with ruby/date's `to_datetime` before comparing against a Time. trails inlined that widening as `date.toZonedDateTime("UTC").toInstant()` under a local *named* `toDatetime`. It now calls the actual port — `Date#toDatetime` (`packages/date/src/date.ts:7463`, ruby/date `date_core.c` `d_lite_to_datetime`) — handing it the `Temporal.PlainDate` through that class's `PlainDate` constructor overload (`date.ts:5772`). Same value (midnight at offset 0), same name as Rails.

`Date#toDatetime`'s declared return is `PlainDateTime | ZonedDateTime` because `DateTime#toDatetime` can be either; a `Date` is always offset 0, which trails spells as the offsetless `PlainDateTime`, so the `ZonedDateTime` arm is unreachable here and the narrow says so.

The converged row is deleted; its shard (`call-mismatches-exclude/activesupport/core-ext/date/calculations.json`) held nothing else, so the file goes with it. No `call-mismatches-unreviewed` mark existed for it, so no `tighten` was needed.

## `since` and `current` — the rows were miscited, not deferred

Neither converges, and #6518's reason strings described them wrongly. Both are rewritten to state the actual class:

- **`since`** cited `date_time/calculations.rb:87` — that range is `DateTime#advance`. `DateTime#since` (116-118) is `self + Rational(seconds, 86400)` and makes no `to_datetime` call at all. The only `to_datetime` under this name is `Time#since`'s `rescue TypeError` arm (`time/calculations.rb:227-233`), which exists solely to deprecate passing a non-numeric and is documented to raise `TypeError` in Rails 8.1. `since(date, seconds: number)` cannot reach it — the same unrepresentable arm this file already baselines for that body's `warn` call, in the row immediately below.
- **`current`** is a homonym across two receivers: `Time.current` (`time/calculations.rb:39-41`) has no `to_datetime`; `DateTime.current` (`date_time/calculations.rb:10-12`) is that same expression plus `.to_datetime`; trails has one `current()` in `time-ext.ts` serving both, and one function cannot return both a Time and a DateTime. Converging it means giving DateTime its own receiver file (there is a `core-ext/date/` but no `core-ext/date-time/`), which is a different and larger change — filed as `0098-activesupport-ar-closure-port/split-date-time-current-onto-its-own-receiver` with the citations above.

## Drive-by: a stale row reds the ratchet on main

`class-attribute.json`'s `class_attribute` → `redefine` row no longer flags — #6520 converged that body and did not retire its baseline entry. `pnpm parity:api:calls` is red on `origin/main` without this one-line deletion.

## Verification

- `pnpm parity:api:calls` — OK (1660 baselined, 326 marks all tight)
- `pnpm parity:api:calls:args` — OK (242 baselined shape rows)
- `pnpm parity:api:extra --package activesupport` — no new surface (nothing exported was added)
- `pnpm typecheck` clean; `date-ext.test.ts` + `date-ext.trails.test.ts` 61 passed

Closes-story: converge-date-time-current-since-to-datetime