### PR TITLE
fix(parity): drop the converged class_attribute redefine baseline row

### DIFF
--- a/scripts/api-compare/call-mismatches-exclude/activesupport/class-attribute.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/class-attribute.json
@@ -12,12 +12,5 @@
     "rubyName": "class_attribute",
     "call": "first",
     "reason": "Part of the same omission — `first` is only there to pick the `caller_locations(1, 1)` frame."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "class-attribute.ts",
-    "rubyName": "class_attribute",
-    "call": "redefine",
-    "reason": "trails' `classAttribute` writes the default straight into its own attribute store instead of routing through `ActiveSupport::ClassAttribute.redefine` (class/attribute.rb:97). A pre-existing divergence in this body, surfaced (not introduced) by bucketing `core_ext/class/attribute.rb` on class-attribute.ts; converging the whole body is 0098-activesupport-ar-closure-port/converge-class-attribute-to-rails-shape."
   }
 ]

--- a/scripts/parity/write-json-manifest.test.ts
+++ b/scripts/parity/write-json-manifest.test.ts
@@ -18,9 +18,13 @@ function tmpManifest(): string {
   return path.join(dir, "manifest.json");
 }
 
+// Same --ignore-path bypass the helper spawns with: these manifests live in an
+// os.tmpdir() scratch dir, i.e. outside the repo root prettier runs from, and a
+// path prettier considers ignored is reported as formatted with exit 0 — so
+// without the bypass every check here returns true regardless of the bytes.
 function prettierCheck(file: string): boolean {
   try {
-    execFileSync(PRETTIER_BIN, ["--check", file], { stdio: "pipe" });
+    execFileSync(PRETTIER_BIN, ["--ignore-path", "/dev/null", "--check", file], { stdio: "pipe" });
     return true;
   } catch {
     return false;


### PR DESCRIPTION
Two reds on main @1770f467.

**1. `Rails API/Test Comparison`** — the call-mismatches ratchet reports

```
call-mismatches ratchet: 1 STALE baseline entr(ies) that no longer flag.
  - activesupport  class-attribute.ts  class_attribute  redefine
```

#6520 converged `classAttribute` onto `class_attribute`'s shape (it now routes through `ClassAttribute.redefine`, `class/attribute.rb:97`) but left the baseline row behind. The baseline is only-shrink, so the stale row fails the gate. Removes that one row by hand (no reseed). `pnpm parity:api:calls` and `pnpm parity:api:calls:args` are green, and a `--write` reseed produces no further diff.

**2. `Unit Tests`** — `scripts/parity/write-json-manifest.test.ts > repairs a file an older stringify-based emitter already churned` fails at `expect(prettierCheck(out)).toBe(false)`. Reproduces on main at the same commit, independent of change 1.

The test's `prettierCheck` spawns a bare `prettier --check <file>`, while the manifests it checks live in an `os.tmpdir()` scratch dir — outside the repo root prettier runs from. Prettier reports an ignored path as formatted with **exit 0** (the same silent no-op the helper documents at `write-json-manifest.ts:42-48`), so `prettierCheck` was returning `true` for every input regardless of its bytes; the `toBe(false)` assertion is simply the one that notices. The fix gives the test the same `--ignore-path /dev/null` bypass the helper already spawns with, which also makes the four `toBe(true)` assertions meaningful instead of vacuous. All 14 tests pass.

Closes-story: red-1770f467