### PR TITLE
feat(activesupport,parity): DeprecationException, after_teardown/without-assertions test enrollment, class-attribute row retirement

### DIFF
--- a/packages/activesupport/src/deprecation.test.ts
+++ b/packages/activesupport/src/deprecation.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ActiveSupport } from "./index.js";
-import { Deprecation, DeprecationError, deprecator, type CallerLocation } from "./deprecation.js";
+import {
+  Deprecation,
+  DeprecationException,
+  deprecator,
+  type CallerLocation,
+} from "./deprecation.js";
 import { ErrorReporter } from "./error-reporter.js";
 import { ErrorSubscriber } from "./error-reporter/test-helper.js";
 import { Logger } from "./logger.js";
@@ -39,7 +44,7 @@ describe("DeprecationTest", () => {
 
   it(":raise behavior", () => {
     dep.behavior = "raise";
-    expect(() => dep.warn("old API")).toThrow(DeprecationError);
+    expect(() => dep.warn("old API")).toThrow(DeprecationException);
     expect(() => dep.warn("old API")).toThrow("old API");
   });
 
@@ -187,13 +192,13 @@ describe("DeprecationTest", () => {
   it("disallowed_warnings can match using a substring", () => {
     dep.disallowedWarnings = ["old"];
     dep.disallowedBehavior = "raise";
-    expect(() => dep.warn("using old API")).toThrow(DeprecationError);
+    expect(() => dep.warn("using old API")).toThrow(DeprecationException);
   });
 
   it("disallowed_warnings can match using a regexp", () => {
     dep.disallowedWarnings = [/old.*/];
     dep.disallowedBehavior = "raise";
-    expect(() => dep.warn("old API is gone")).toThrow(DeprecationError);
+    expect(() => dep.warn("old API is gone")).toThrow(DeprecationException);
   });
 
   it("disallowed_warnings matches all warnings when set to :all", () => {
@@ -219,7 +224,7 @@ describe("DeprecationTest", () => {
   it("allow", () => {
     dep.disallowedWarnings = "all";
 
-    expect(() => dep.warn()).toThrow(DeprecationError);
+    expect(() => dep.warn()).toThrow(DeprecationException);
 
     dep.allow("all", {}, () => {
       expect(() => dep.warn()).not.toThrow();
@@ -253,7 +258,7 @@ describe("DeprecationTest", () => {
       expect(() => dep.warn()).not.toThrow();
     });
 
-    expect(() => dep.warn()).toThrow(DeprecationError);
+    expect(() => dep.warn()).toThrow(DeprecationException);
   });
 
   it("allow with :if option", () => {
@@ -288,7 +293,7 @@ describe("DeprecationTest", () => {
     });
 
     dep.allow(["fubar"], {}, () => {
-      expect(() => dep.warn()).toThrow(DeprecationError);
+      expect(() => dep.warn()).toThrow(DeprecationException);
     });
   });
 
@@ -323,7 +328,7 @@ describe("DeprecationTest", () => {
 
   it("disallowed_warnings with the default warning message", () => {
     dep.disallowedWarnings = "all";
-    expect(() => dep.warn()).toThrow(DeprecationError);
+    expect(() => dep.warn()).toThrow(DeprecationException);
 
     dep.disallowedWarnings = ["fubar"];
     expect(() => dep.warn()).not.toThrow();
@@ -445,7 +450,7 @@ describe("DeprecationTest", () => {
     // In JS, symbols don't match strings, so use string equivalent
     dep.disallowedWarnings = ["old"];
     dep.disallowedBehavior = "raise";
-    expect(() => dep.warn("old API")).toThrow(DeprecationError);
+    expect(() => dep.warn("old API")).toThrow(DeprecationException);
   });
 
   it("allow only allows matching warnings using a substring as a symbol", () => {
@@ -470,7 +475,7 @@ describe("DeprecationTest", () => {
       expect(() => dep.warn()).not.toThrow();
     });
 
-    expect(() => dep.warn()).toThrow(DeprecationError);
+    expect(() => dep.warn()).toThrow(DeprecationException);
   });
 
   // A `Thread::Backtrace::Location` stand-in — see CallerLocation.
@@ -505,13 +510,13 @@ describe("DeprecationTest", () => {
   it("assert_deprecated", () => {
     // assert_deprecated is a testing helper; verify warn triggers the behavior
     dep.behavior = "raise";
-    expect(() => dep.warn("deprecated!")).toThrow(DeprecationError);
+    expect(() => dep.warn("deprecated!")).toThrow(DeprecationException);
   });
 
   it("assert_deprecated requires a deprecator", () => {
     const customDep = new Deprecation();
     customDep.behavior = "raise";
-    expect(() => customDep.warn("x")).toThrow(DeprecationError);
+    expect(() => customDep.warn("x")).toThrow(DeprecationException);
   });
 
   it("assert_not_deprecated", () => {
@@ -701,7 +706,7 @@ describe("DeprecationTest", () => {
       ActiveSupport.errorReporter = previousReporter;
     }
     const [error, handled, severity, source] = subscriber.events[0];
-    expect(error).toBeInstanceOf(DeprecationError);
+    expect(error).toBeInstanceOf(DeprecationException);
     expect(handled).toBe(true);
     expect(severity).toBe("warning");
     expect(source).toBe("application");
@@ -754,7 +759,7 @@ describe("DeprecationTest", () => {
   it("deprecate_constant", () => {
     // Not directly supported; verify deprecation system works
     dep.behavior = "raise";
-    expect(() => dep.warn("constant deprecated")).toThrow(DeprecationError);
+    expect(() => dep.warn("constant deprecated")).toThrow(DeprecationException);
   });
 
   it("deprecate_constant when rescuing a deprecated error", () => {
@@ -763,7 +768,7 @@ describe("DeprecationTest", () => {
     try {
       dep.warn("constant deprecated");
     } catch (e) {
-      caught = e instanceof DeprecationError;
+      caught = e instanceof DeprecationException;
     }
     expect(caught).toBe(true);
   });
@@ -771,7 +776,7 @@ describe("DeprecationTest", () => {
   it("deprecate_constant requires a deprecator", () => {
     const customDep = new Deprecation();
     customDep.behavior = "raise";
-    expect(() => customDep.warn("x")).toThrow(DeprecationError);
+    expect(() => customDep.warn("x")).toThrow(DeprecationException);
   });
 
   it("assert_deprecated raises when no deprecation warning", () => {
@@ -782,6 +787,6 @@ describe("DeprecationTest", () => {
 
   it("assert_not_deprecated raises when some deprecation warning", () => {
     dep.behavior = "raise";
-    expect(() => dep.warn("unexpected deprecation")).toThrow(DeprecationError);
+    expect(() => dep.warn("unexpected deprecation")).toThrow(DeprecationException);
   });
 });

--- a/packages/activesupport/src/deprecation.ts
+++ b/packages/activesupport/src/deprecation.ts
@@ -17,6 +17,13 @@ export type DeprecationBehaviorCallable = (
   deprecator: Deprecation,
 ) => void;
 
+/**
+ * Raised when ActiveSupport::Deprecation::Behavior#behavior is set with
+ * `:raise`. You would set `:raise`, as a behavior to raise errors and
+ * proactively report exceptions from deprecations.
+ *
+ * Mirrors: `ActiveSupport::DeprecationException` (deprecation/behaviors.rb:8).
+ */
 export class DeprecationException extends Error {
   constructor(message: string) {
     super(message);

--- a/packages/activesupport/src/deprecation.ts
+++ b/packages/activesupport/src/deprecation.ts
@@ -17,10 +17,10 @@ export type DeprecationBehaviorCallable = (
   deprecator: Deprecation,
 ) => void;
 
-export class DeprecationError extends Error {
+export class DeprecationException extends Error {
   constructor(message: string) {
     super(message);
-    this.name = "DeprecationError";
+    this.name = "DeprecationException";
   }
 }
 
@@ -44,7 +44,7 @@ export const DEFAULT_BEHAVIORS: ReadonlyMap<DeprecationBehavior, DeprecationBeha
     [
       "raise",
       (message, callstack) => {
-        const e = new DeprecationError(message);
+        const e = new DeprecationException(message);
         e.stack = callstack.map((l) => String(l)).join("\n");
         throw e;
       },
@@ -87,7 +87,7 @@ export const DEFAULT_BEHAVIORS: ReadonlyMap<DeprecationBehavior, DeprecationBeha
     [
       "report",
       (message, callstack) => {
-        const error = new DeprecationError(message);
+        const error = new DeprecationException(message);
         error.stack = callstack.map((l) => String(l)).join("\n");
         currentErrorReporter.report(error);
       },

--- a/packages/activesupport/src/hwia-module-string.test.ts
+++ b/packages/activesupport/src/hwia-module-string.test.ts
@@ -12,7 +12,7 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { HashWithIndifferentAccess } from "./hash-with-indifferent-access.js";
-import { Deprecation, DeprecationError, deprecator } from "./deprecation.js";
+import { Deprecation, DeprecationException, deprecator } from "./deprecation.js";
 import {
   delegate,
   mattrAccessor,
@@ -71,7 +71,7 @@ describe("DeprecationTest", () => {
 
   it(":raise behavior", () => {
     dep.behavior = "raise";
-    expect(() => dep.warn("old API")).toThrow(DeprecationError);
+    expect(() => dep.warn("old API")).toThrow(DeprecationException);
     expect(() => dep.warn("old API")).toThrow("old API");
   });
 

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -400,7 +400,7 @@ export { NullStore } from "./cache/null-store.js";
 // FileStore uses getFs()/getPath() adapters but is kept as a subpath import for tree-shaking
 export type { CacheOptions, CacheStore } from "./cache/index.js";
 
-export { Deprecation, DeprecationError, DEFAULT_BEHAVIORS, deprecator } from "./deprecation.js";
+export { Deprecation, DeprecationException, DEFAULT_BEHAVIORS, deprecator } from "./deprecation.js";
 export type {
   DeprecationBehavior,
   DeprecationBehaviorCallable,

--- a/packages/activesupport/src/testing/after-teardown-assertion.test.ts
+++ b/packages/activesupport/src/testing/after-teardown-assertion.test.ts
@@ -1,5 +1,49 @@
-import { describe, it } from "vitest";
+/**
+ * Mirrors: activesupport/test/testing/after_teardown_assertion_test.rb
+ *
+ * The `Minitest::Assertion` arm of `setup_and_teardown.rb:44-53`'s rescue:
+ * Rails' teardown block calls `flunk`, which raises `Minitest::Assertion`, and
+ * that is recorded on `failures` as itself rather than wrapped. trails has no
+ * `flunk`, so the block raises the `Assertion` it would have raised.
+ */
+import { describe, expect, it } from "vitest";
+
+import { resetCallbacks } from "../callbacks.js";
+import { Assertion } from "./assertions.js";
+import { afterTeardown, failures, prepended, teardown } from "./setup-and-teardown.js";
 
 describe("AfterTeardownAssertionTest", () => {
-  it.skip("teardown raise but all after teardown method are called");
+  it("teardown raise but all after teardown method are called", () => {
+    const klass = {};
+    prepended(klass);
+    let witness = false;
+
+    const flunked = new Assertion(
+      "Test raises a Minitest::Assertion error, all after_teardown should still get called",
+    );
+    teardown.call(klass, () => {
+      throw flunked;
+    });
+
+    /**
+     * Mirrors `AfterTeardownAssertionTest::OtherAfterTeardown#after_teardown`
+     * (after_teardown_assertion_test.rb:6-10).
+     */
+    const otherAfterTeardown = () => {
+      afterTeardown.call(klass);
+      witness = true;
+    };
+
+    try {
+      expect(failures.length).toBe(0);
+      otherAfterTeardown();
+      expect(failures.length).toBe(1);
+      expect(failures[0]).toBe(flunked);
+
+      expect(witness).toBe(true);
+    } finally {
+      failures.length = 0;
+      resetCallbacks(klass, "teardown");
+    }
+  });
 });

--- a/packages/activesupport/src/testing/after-teardown-assertion.test.ts
+++ b/packages/activesupport/src/testing/after-teardown-assertion.test.ts
@@ -4,7 +4,9 @@
  * The `Minitest::Assertion` arm of `setup_and_teardown.rb:44-53`'s rescue:
  * Rails' teardown block calls `flunk`, which raises `Minitest::Assertion`, and
  * that is recorded on `failures` as itself rather than wrapped. trails has no
- * `flunk`, so the block raises the `Assertion` it would have raised.
+ * `flunk`, so the block raises the `Assertion` it would have raised, and
+ * `otherAfterTeardown` is `AfterTeardownAssertionTest::OtherAfterTeardown#after_teardown`
+ * (after_teardown_assertion_test.rb:6-10).
  */
 import { describe, expect, it } from "vitest";
 
@@ -25,10 +27,6 @@ describe("AfterTeardownAssertionTest", () => {
       throw flunked;
     });
 
-    /**
-     * Mirrors `AfterTeardownAssertionTest::OtherAfterTeardown#after_teardown`
-     * (after_teardown_assertion_test.rb:6-10).
-     */
     const otherAfterTeardown = () => {
       afterTeardown.call(klass);
       witness = true;

--- a/packages/activesupport/src/testing/after-teardown.test.ts
+++ b/packages/activesupport/src/testing/after-teardown.test.ts
@@ -25,7 +25,6 @@ describe("AfterTeardownTest", () => {
       throw new MyError("Test raises an error, all after_teardown should still get called");
     });
 
-    /** Mirrors `OtherAfterTeardown#after_teardown` (after_teardown_test.rb:5-9). */
     const otherAfterTeardown = () => {
       afterTeardown.call(klass);
       witness = true;

--- a/packages/activesupport/src/testing/after-teardown.test.ts
+++ b/packages/activesupport/src/testing/after-teardown.test.ts
@@ -1,5 +1,47 @@
-import { describe, it } from "vitest";
+/**
+ * Mirrors: activesupport/test/testing/after_teardown_test.rb
+ *
+ * Rails drives this through a `Minitest::Test` subclass whose `after_teardown`
+ * asserts the failure count moved 0 -> 1 around `super` and that the other
+ * `after_teardown` in the chain still ran. trails has no Minitest runner, so
+ * the chain is spelled out: the mixed-in `afterTeardown` calls the ported one
+ * and then records its witness, exactly as `OtherAfterTeardown` does.
+ */
+import { describe, expect, it } from "vitest";
+
+import { resetCallbacks } from "../callbacks.js";
+import { UnexpectedError } from "./assertions.js";
+import { afterTeardown, failures, prepended, teardown } from "./setup-and-teardown.js";
+
+class MyError extends Error {}
 
 describe("AfterTeardownTest", () => {
-  it.skip("teardown raise but all after teardown method are called");
+  it("teardown raise but all after teardown method are called", () => {
+    const klass = {};
+    prepended(klass);
+    let witness = false;
+
+    teardown.call(klass, () => {
+      throw new MyError("Test raises an error, all after_teardown should still get called");
+    });
+
+    /** Mirrors `OtherAfterTeardown#after_teardown` (after_teardown_test.rb:5-9). */
+    const otherAfterTeardown = () => {
+      afterTeardown.call(klass);
+      witness = true;
+    };
+
+    try {
+      expect(failures.length).toBe(0);
+      otherAfterTeardown();
+      expect(failures.length).toBe(1);
+      expect(failures[0]).toBeInstanceOf(UnexpectedError);
+      expect((failures[0] as UnexpectedError).error).toBeInstanceOf(MyError);
+
+      expect(witness).toBe(true);
+    } finally {
+      failures.length = 0;
+      resetCallbacks(klass, "teardown");
+    }
+  });
 });

--- a/packages/activesupport/src/testing/test-without-assertions.test.ts
+++ b/packages/activesupport/src/testing/test-without-assertions.test.ts
@@ -1,3 +1,32 @@
-import { it } from "vitest";
+/**
+ * Mirrors: activesupport/test/testing/test_without_assertions_test.rb
+ *
+ * Rails' `test_without_assertions` is an empty test whose surrounding
+ * `AfterTeardown` captures stderr around `super` and matches the warning
+ * `tests_without_assertions.rb:10-17` writes. trails' hook takes the running
+ * test rather than reading it off `self`, so the assertion-free test is the
+ * `RunningTest` handed to it, and the warning is captured off `console.warn`.
+ */
+import { expect, it, vi } from "vitest";
 
-it.skip("without assertions");
+import { afterTeardown } from "./tests-without-assertions.js";
+
+it("without assertions", () => {
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  try {
+    afterTeardown({
+      assertions: 0,
+      skipped: false,
+      error: false,
+      name: "test_without_assertions",
+      sourceLocation: ["packages/activesupport/src/testing/test_without_assertions_test.ts", 9],
+    });
+
+    const err = warn.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(err).toMatch(
+      /Test is missing assertions: `test_without_assertions` .+test_without_assertions_test\.ts:\d+/,
+    );
+  } finally {
+    warn.mockRestore();
+  }
+});


### PR DESCRIPTION
Bundle of three RFC 0098 stories.

1. `ActiveSupport::Deprecation`'s `:raise` behavior raises `DeprecationException` (`activesupport/lib/active_support/deprecation/behaviors.rb:8`, raised at `:15`). Renames trails' `DeprecationError` to that name across `deprecation.ts`, `index.ts` and both asserting test files; no alias left behind.

2. Enrolls the three PERMANENT-SKIP test stubs against the modules PR #6516 ported, Rails test names verbatim:
   - `testing/after-teardown.test.ts` — `after_teardown_test.rb`, the non-assertion arm of `setup_and_teardown.rb:44-53`'s rescue.
   - `testing/after-teardown-assertion.test.ts` — `after_teardown_assertion_test.rb`, the `Minitest::Assertion` arm.
   - `testing/test-without-assertions.test.ts` — `test_without_assertions_test.rb`, `tests_without_assertions.rb:10-17`.
   `pnpm parity:test --package activesupport` scores all three ✓; the assertion-mismatch ratchet is unchanged (`OK`).

3. (Landed on main as #6523 while this PR was open — the row is gone from `main`, so it no longer appears in this diff.) Retires the now-stale `redefine` call-mismatch row in `scripts/api-compare/call-mismatches-exclude/activesupport/class-attribute.json` — PR #6520 converged `classAttribute` onto `ClassAttribute.redefine` and PR #6518 put the file back in the population. Deleted by hand via `serializeBaseline`; the `caller_locations`/`first` rows stay (the shared generated-method-location omission). No stale high-water mark resulted, and `pnpm parity:api:calls` / `parity:api:calls:args` are green.

Closes-story: deprecation-raise-behavior-raises-deprecationexception
Closes-story: port-testing-after-teardown-and-without-assertions-cases
Closes-story: retire-class-attribute-redefine-baseline-row
