### PR TITLE
feat(activesupport): port the minitest reporter surface

### DIFF
--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -618,7 +618,16 @@ export {
   UNTRACKED,
   BacktraceFilter,
   Minitest,
+  Skip,
+  UnexpectedWarning,
+  AbstractReporter,
+  Reporter,
+  ProgressReporter,
+  StatisticsReporter,
+  SummaryReporter,
+  CompositeReporter,
 } from "./testing/assertions.js";
+export type { IO, Options, Reportable } from "./testing/assertions.js";
 export { beforeSetup, setTaggedLogger } from "./testing/tagged-logging.js";
 export { currentTime } from "./time-travel.js";
 export { currentTimeInstant } from "./time-travel.js";

--- a/packages/activesupport/src/testing/assertions.ts
+++ b/packages/activesupport/src/testing/assertions.ts
@@ -23,7 +23,7 @@
  */
 import { indexWith } from "../enumerable-utils.js";
 
-import { cwd, env } from "../process-adapter.js";
+import { cwd, env, stdout } from "../process-adapter.js";
 import { _testCaseIdentity, taggedLogger } from "./tagged-logging.js";
 
 /**
@@ -36,6 +36,21 @@ import { _testCaseIdentity, taggedLogger } from "./tagged-logging.js";
  */
 export class Assertion extends Error {
   override name = "Assertion";
+}
+
+/**
+ * Mirrors `Minitest::Skip` (minitest.rb:1050-1054) — the assertion raised when
+ * skipping a run, and the class {@link StatisticsReporter#report} counts the
+ * skips of a run by.
+ *
+ * @noRailsEquivalent PERMANENT — minitest's, not Rails'; see {@link Assertion}.
+ */
+export class Skip extends Assertion {
+  override name = "Skip";
+
+  get resultLabel(): string {
+    return "Skipped";
+  }
 }
 
 /**
@@ -69,6 +84,20 @@ export class UnexpectedError extends Assertion {
 
   get resultLabel(): string {
     return "Error";
+  }
+}
+
+/**
+ * Mirrors `Minitest::UnexpectedWarning` (minitest.rb:1098-1102) — the assertion
+ * raised on a warning under `-Werror`.
+ *
+ * @noRailsEquivalent PERMANENT — minitest's, not Rails'; see {@link Assertion}.
+ */
+export class UnexpectedWarning extends Assertion {
+  override name = "UnexpectedWarning";
+
+  get resultLabel(): string {
+    return "Warning";
   }
 }
 
@@ -152,6 +181,8 @@ export class BacktraceFilter {
 export const Minitest: {
   backtraceFilter: { filter(bt: string[] | null): string[] };
   filterBacktrace(bt: string[] | null): string[];
+  reporter: CompositeReporter | null;
+  clockTime(): number;
 } = {
   backtraceFilter: new BacktraceFilter(),
 
@@ -159,6 +190,25 @@ export const Minitest: {
     let result = Minitest.backtraceFilter.filter(bt);
     if (result.length === 0 && bt) result = [...bt];
     return result;
+  },
+
+  /**
+   * Mirrors the `cattr_accessor :reporter` (minitest.rb:51), which
+   * `Minitest.run` sets to the run's `CompositeReporter` around
+   * `init_plugins` and nils out again (minitest.rb:277-282) — hence the
+   * nullable seat rather than an eagerly-built composite.
+   */
+  reporter: null,
+
+  /**
+   * Mirrors `Minitest.clock_time` (minitest.rb:1214-1222): the monotonic clock
+   * where one exists, `Time.now` otherwise. `performance.now()` is JS'
+   * monotonic clock and reads in milliseconds, so it is divided to the seconds
+   * both Ruby arms return.
+   */
+  clockTime(): number {
+    if (typeof performance !== "undefined") return performance.now() / 1000;
+    return Date.now() / 1000;
   },
 };
 
@@ -594,4 +644,371 @@ function inspect(value: unknown): string {
   if (typeof value === "string") return JSON.stringify(value);
   if (value === null || value === undefined) return "nil";
   return String(value);
+}
+
+/**
+ * The subset of Ruby's `IO` a reporter talks to (minitest.rb:733-747 types the
+ * seat as `$stdout`): `print`, `puts`, `flush`, and the `sync` flag
+ * `SummaryReporter#start` flips (minitest.rb:911-912).
+ *
+ * @noRailsEquivalent PERMANENT — Ruby's `IO`, from core, not from a Rails file
+ * the comparator maps; declared here so the reporters below can name the
+ * receiver Ruby leaves duck-typed. See {@link Assertion}.
+ */
+export interface IO {
+  print(str: string): void;
+  puts(str?: string): void;
+  flush?(): void;
+  sync?: boolean;
+}
+
+/**
+ * Ruby's `StringIO`, which {@link SummaryReporter#toString} renders into
+ * (minitest.rb:948).
+ */
+class StringIO implements IO {
+  string = "";
+
+  print(str: string): void {
+    this.string += str;
+  }
+
+  puts(str = ""): void {
+    this.string += str.endsWith("\n") ? str : `${str}\n`;
+  }
+}
+
+/** Ruby's `$stdout`, the `io` every reporter defaults to (minitest.rb:743). */
+const $stdout: IO = {
+  print(str: string): void {
+    stdout.write(str);
+  },
+  puts(str = ""): void {
+    stdout.write(str.endsWith("\n") ? str : `${str}\n`);
+  },
+  flush(): void {},
+  sync: true,
+};
+
+/**
+ * The options hash minitest builds in `Minitest.process_args`
+ * (minitest.rb:143-236) and hands every reporter. Ruby's keys are Symbols; the
+ * `:show_skips` / `:Werror` spellings camelCase per docs/ruby-ts-conventions.md
+ * (`Werror` is already a single token).
+ *
+ * @noRailsEquivalent PERMANENT — a type for minitest's untyped options hash;
+ * see {@link Assertion}.
+ */
+export interface Options {
+  io?: IO;
+  args?: string;
+  verbose?: boolean;
+  quiet?: boolean;
+  showSkips?: boolean;
+  skip?: string[];
+  Werror?: boolean;
+  profile?: number;
+  [key: string]: unknown;
+}
+
+/**
+ * The `Minitest::Reportable` surface (minitest.rb:579-628) a reporter receives:
+ * `Minitest::Test` and `Minitest::Result` both mix it in. trails runs its tests
+ * under vitest, which owns the run lifecycle, so the runnable half of the gem
+ * is not ported — this is the shape a reporter reads off whatever the runner
+ * records.
+ *
+ * @noRailsEquivalent PERMANENT — minitest's, not Rails'; see {@link Assertion}.
+ */
+export interface Reportable {
+  name: string;
+  assertions: number;
+  time: number;
+  failure: Assertion | null;
+  passed(): boolean;
+  skipped(): boolean;
+  resultCode(): string;
+  toString(): string;
+}
+
+/**
+ * Mirrors `Minitest::AbstractReporter` (minitest.rb:687-731) — the API a
+ * reporter overrides. Ruby's `@mutex` guards a parallel run; JS has no threads,
+ * so {@link AbstractReporter#synchronize} just calls the block.
+ *
+ * @noRailsEquivalent PERMANENT — minitest's, not Rails'; see {@link Assertion}.
+ */
+export class AbstractReporter {
+  /** Starts reporting on the run. */
+  start(): void {}
+
+  /** About to start running a test. */
+  prerecord(_klass: { name: string }, _name: string): void {}
+
+  /** Output and record the result of the test. */
+  record(_result: Reportable): void {}
+
+  /** Outputs the summary of the run. */
+  report(): void {}
+
+  /** Did this run pass? */
+  passed(): boolean {
+    return true;
+  }
+
+  synchronize<T>(block: () => T): T {
+    return block();
+  }
+}
+
+/**
+ * Mirrors `Minitest::Reporter` (minitest.rb:733-751).
+ *
+ * @noRailsEquivalent PERMANENT — minitest's, not Rails'; see {@link Assertion}.
+ */
+export class Reporter extends AbstractReporter {
+  /** The IO used to report. */
+  io: IO;
+
+  /** Command-line options for this run. */
+  options: Options;
+
+  constructor(io: IO = $stdout, options: Options = {}) {
+    super();
+    this.io = io;
+    this.options = options;
+  }
+}
+
+/**
+ * Mirrors `Minitest::ProgressReporter` (minitest.rb:759-771) — the reporter
+ * that prints the "dots" during the run, and the one
+ * `Minitest.plugin_rails_init` swaps for `Rails::TestUnitReporter`
+ * (rails_plugin.rb:129-131).
+ *
+ * @noRailsEquivalent PERMANENT — minitest's, not Rails'; see {@link Assertion}.
+ */
+export class ProgressReporter extends Reporter {
+  override prerecord(klass: { name: string }, name: string): void {
+    if (this.options.verbose !== true) return;
+
+    this.io.print(`${klass.name}#${name} = `);
+    this.io.flush?.();
+  }
+
+  override record(result: Reportable): void {
+    if (this.options.verbose === true) this.io.print(`${result.time.toFixed(2)} s = `);
+    this.io.print(result.resultCode());
+    if (this.options.verbose === true) this.io.puts();
+  }
+}
+
+/**
+ * Mirrors `Minitest::StatisticsReporter` (minitest.rb:795-878) — gathers
+ * statistics about a test run, does no IO of its own.
+ *
+ * @noRailsEquivalent PERMANENT — minitest's, not Rails'; see {@link Assertion}.
+ */
+export class StatisticsReporter extends Reporter {
+  /** Total number of assertions. */
+  assertions = 0;
+
+  /** Total number of test cases. */
+  count = 0;
+
+  /** Test cases that failed or were skipped. */
+  results: Reportable[] = [];
+
+  /** Time the test run started. */
+  startTime: number | null = null;
+
+  /** Test run time. */
+  totalTime: number | null = null;
+
+  /** Total number of tests that failed. */
+  failures: number | null = null;
+
+  /** Total number of tests that erred. */
+  errors: number | null = null;
+
+  /** Total number of tests that warned. */
+  warnings: number | null = null;
+
+  /** Total number of tests that were skipped. */
+  skips: number | null = null;
+
+  override passed(): boolean {
+    return this.results.every((r) => r.skipped());
+  }
+
+  override start(): void {
+    this.startTime = Minitest.clockTime();
+  }
+
+  override record(result: Reportable): void {
+    this.count += 1;
+    this.assertions += result.assertions;
+
+    if (!result.passed() || result.skipped()) this.results.push(result);
+  }
+
+  /** Report on the tracked statistics. */
+  override report(): void {
+    const aggregate = new Map<unknown, Reportable[]>();
+    for (const r of this.results) {
+      const klass = r.failure?.constructor;
+      const bucket = aggregate.get(klass);
+      if (bucket) bucket.push(r);
+      else aggregate.set(klass, [r]);
+    }
+
+    this.totalTime = Minitest.clockTime() - (this.startTime as number);
+    this.failures = (aggregate.get(Assertion) ?? []).length;
+    this.errors = (aggregate.get(UnexpectedError) ?? []).length;
+    this.warnings = (aggregate.get(UnexpectedWarning) ?? []).length;
+    this.skips = (aggregate.get(Skip) ?? []).length;
+  }
+}
+
+/**
+ * Mirrors `Minitest::SummaryReporter` (minitest.rb:897-967) — prints the
+ * header, summary, and failure details at the end of the run, and the reporter
+ * `Minitest.plugin_rails_init` swaps for `SuppressedSummaryReporter`
+ * (rails_plugin.rb:126-128).
+ *
+ * @noRailsEquivalent PERMANENT — minitest's, not Rails'; see {@link Assertion}.
+ */
+export class SummaryReporter extends StatisticsReporter {
+  sync: boolean | null = null;
+  oldSync: boolean | null = null;
+
+  override start(): void {
+    super.start();
+
+    this.io.puts(`Run options: ${String(this.options.args ?? "")}`);
+    this.io.puts();
+    this.io.puts("# Running:");
+    this.io.puts();
+
+    this.sync = "sync" in this.io;
+    if (this.sync) {
+      this.oldSync = this.io.sync ?? null;
+      this.io.sync = true;
+    }
+  }
+
+  override report(): void {
+    super.report();
+
+    this.io.sync = this.oldSync ?? undefined;
+
+    if (this.options.verbose !== true) this.io.puts();
+    this.io.puts();
+    this.io.puts(this.statistics());
+    this.aggregatedResults(this.io);
+    this.io.puts(this.summary());
+  }
+
+  statistics(): string {
+    const totalTime = this.totalTime as number;
+    return (
+      `Finished in ${totalTime.toFixed(6)}s, ` +
+      `${(this.count / totalTime).toFixed(4)} runs/s, ` +
+      `${(this.assertions / totalTime).toFixed(4)} assertions/s.`
+    );
+  }
+
+  aggregatedResults(io: IO): IO {
+    let filteredResults = [...this.results];
+    if (this.options.verbose !== true && this.options.showSkips !== true)
+      filteredResults = filteredResults.filter((r) => !r.skipped());
+
+    const skip = this.options.skip ?? [];
+
+    filteredResults.forEach((result, i) => {
+      if (skip.includes(result.resultCode())) return;
+
+      io.puts(`\n${String(i + 1).padStart(3, " ")}) ${String(result)}`);
+    });
+    io.puts();
+    return io;
+  }
+
+  override toString(): string {
+    return (this.aggregatedResults(new StringIO()) as StringIO).string;
+  }
+
+  summary(): string {
+    const extra: string[] = [];
+
+    if (this.options.Werror === true) extra.push(`, ${this.warnings} warnings`);
+
+    if (
+      this.options.verbose !== true &&
+      this.options.showSkips !== true &&
+      env.MT_NO_SKIP_MSG == null &&
+      this.results.some((r) => r.skipped())
+    )
+      extra.push("\n\nYou have skipped tests. Run with --verbose for details.");
+
+    return (
+      `${this.count} runs, ${this.assertions} assertions, ${this.failures} failures, ` +
+      `${this.errors} errors, ${this.skips} skips${extra.join("")}`
+    );
+  }
+}
+
+/**
+ * Mirrors `Minitest::CompositeReporter` (minitest.rb:969-1024) — dispatch to
+ * multiple reporters as one. This is the receiver
+ * `Minitest.plugin_rails_init` rejects from and appends to
+ * (rails_plugin.rb:122-135).
+ *
+ * @noRailsEquivalent PERMANENT — minitest's, not Rails'; see {@link Assertion}.
+ */
+export class CompositeReporter extends AbstractReporter {
+  /** The list of reporters to dispatch to. */
+  reporters: AbstractReporter[];
+
+  constructor(...reporters: AbstractReporter[]) {
+    super();
+    this.reporters = reporters;
+  }
+
+  get io(): IO {
+    return (this.reporters[0] as Reporter).io;
+  }
+
+  /**
+   * Mirrors `Minitest::CompositeReporter#<<` (minitest.rb:988-990). TypeScript
+   * has no `<<` to overload, so the operator keeps its Ruby name spelled out —
+   * `Array#<<` is `push` on both sides of the port.
+   */
+  push(reporter: AbstractReporter): void {
+    this.reporters.push(reporter);
+  }
+
+  override passed(): boolean {
+    return this.reporters.every((r) => r.passed());
+  }
+
+  override start(): void {
+    this.reporters.forEach((r) => r.start());
+  }
+
+  override prerecord(klass: { name: string }, name: string): void {
+    this.reporters.forEach((reporter) => {
+      reporter.prerecord(klass, name);
+    });
+  }
+
+  override record(result: Reportable): void {
+    this.reporters.forEach((reporter) => {
+      reporter.record(result);
+    });
+  }
+
+  override report(): void {
+    this.reporters.forEach((r) => r.report());
+  }
 }

--- a/packages/activesupport/src/testing/assertions.ts
+++ b/packages/activesupport/src/testing/assertions.ts
@@ -944,10 +944,10 @@ export class SummaryReporter extends StatisticsReporter {
     if (this.options.Werror === true) extra.push(`, ${this.warnings} warnings`);
 
     if (
+      this.results.some((r) => r.skipped()) &&
       this.options.verbose !== true &&
       this.options.showSkips !== true &&
-      env.MT_NO_SKIP_MSG == null &&
-      this.results.some((r) => r.skipped())
+      env.MT_NO_SKIP_MSG == null
     )
       extra.push("\n\nYou have skipped tests. Run with --verbose for details.");
 
@@ -996,6 +996,13 @@ export class CompositeReporter extends AbstractReporter {
     this.reporters.forEach((r) => r.start());
   }
 
+  /**
+   * Mirrors `Minitest::CompositeReporter#prerecord` (minitest.rb:1000-1005).
+   * Ruby guards each dispatch with `if reporter.respond_to? :prerecord` — its
+   * own `# TODO: remove conditional for minitest 6` — which a
+   * {@link AbstractReporter}-typed element cannot fail, so the guard has no
+   * arm to port.
+   */
   override prerecord(klass: { name: string }, name: string): void {
     this.reporters.forEach((reporter) => {
       reporter.prerecord(klass, name);

--- a/packages/activesupport/src/testing/assertions.ts
+++ b/packages/activesupport/src/testing/assertions.ts
@@ -39,7 +39,7 @@ export class Assertion extends Error {
 }
 
 /**
- * Mirrors `Minitest::Skip` (minitest.rb:1050-1054) — the assertion raised when
+ * Mirrors `Minitest::Skip` (minitest.rb:1065-1069) — the assertion raised when
  * skipping a run, and the class {@link StatisticsReporter#report} counts the
  * skips of a run by.
  *
@@ -88,7 +88,7 @@ export class UnexpectedError extends Assertion {
 }
 
 /**
- * Mirrors `Minitest::UnexpectedWarning` (minitest.rb:1098-1102) — the assertion
+ * Mirrors `Minitest::UnexpectedWarning` (minitest.rb:1113-1117) — the assertion
  * raised on a warning under `-Werror`.
  *
  * @noRailsEquivalent PERMANENT — minitest's, not Rails'; see {@link Assertion}.
@@ -195,13 +195,13 @@ export const Minitest: {
   /**
    * Mirrors the `cattr_accessor :reporter` (minitest.rb:51), which
    * `Minitest.run` sets to the run's `CompositeReporter` around
-   * `init_plugins` and nils out again (minitest.rb:277-282) — hence the
+   * `init_plugins` and nils out again (minitest.rb:290-296) — hence the
    * nullable seat rather than an eagerly-built composite.
    */
   reporter: null,
 
   /**
-   * Mirrors `Minitest.clock_time` (minitest.rb:1214-1222): the monotonic clock
+   * Mirrors `Minitest.clock_time` (minitest.rb:1229-1238): the monotonic clock
    * where one exists, `Time.now` otherwise. `performance.now()` is JS'
    * monotonic clock and reads in milliseconds, so it is divided to the seconds
    * both Ruby arms return.
@@ -647,9 +647,9 @@ function inspect(value: unknown): string {
 }
 
 /**
- * The subset of Ruby's `IO` a reporter talks to (minitest.rb:733-747 types the
+ * The subset of Ruby's `IO` a reporter talks to (minitest.rb:748-764 types the
  * seat as `$stdout`): `print`, `puts`, `flush`, and the `sync` flag
- * `SummaryReporter#start` flips (minitest.rb:911-912).
+ * `SummaryReporter#start` flips (minitest.rb:924-925).
  *
  * @noRailsEquivalent PERMANENT — Ruby's `IO`, from core, not from a Rails file
  * the comparator maps; declared here so the reporters below can name the
@@ -664,7 +664,7 @@ export interface IO {
 
 /**
  * Ruby's `StringIO`, which {@link SummaryReporter#toString} renders into
- * (minitest.rb:948).
+ * (minitest.rb:962).
  */
 class StringIO implements IO {
   string = "";
@@ -678,7 +678,26 @@ class StringIO implements IO {
   }
 }
 
-/** Ruby's `$stdout`, the `io` every reporter defaults to (minitest.rb:743). */
+/**
+ * Ruby's `io.respond_to? :"sync="` (minitest.rb:924) — asks for the SETTER, not
+ * for a readable `sync`, so an IO exposing a read-only `sync` answers false and
+ * keeps {@link SummaryReporter#start} from assigning to it. JS has no
+ * `respond_to?`, and `"sync" in io` would answer true for that read-only case,
+ * so the property descriptor is what carries the question.
+ */
+function respondToSyncWriter(io: IO): boolean {
+  for (
+    let obj: object | null = io;
+    obj !== null;
+    obj = Object.getPrototypeOf(obj) as object | null
+  ) {
+    const descriptor = Object.getOwnPropertyDescriptor(obj, "sync");
+    if (descriptor) return descriptor.set !== undefined || descriptor.writable === true;
+  }
+  return false;
+}
+
+/** Ruby's `$stdout`, the `io` every reporter defaults to (minitest.rb:759). */
 const $stdout: IO = {
   print(str: string): void {
     stdout.write(str);
@@ -692,7 +711,7 @@ const $stdout: IO = {
 
 /**
  * The options hash minitest builds in `Minitest.process_args`
- * (minitest.rb:143-236) and hands every reporter. Ruby's keys are Symbols; the
+ * (minitest.rb:142-259) and hands every reporter. Ruby's keys are Symbols; the
  * `:show_skips` / `:Werror` spellings camelCase per docs/ruby-ts-conventions.md
  * (`Werror` is already a single token).
  *
@@ -712,7 +731,7 @@ export interface Options {
 }
 
 /**
- * The `Minitest::Reportable` surface (minitest.rb:579-628) a reporter receives:
+ * The `Minitest::Reportable` surface (minitest.rb:596-642) a reporter receives:
  * `Minitest::Test` and `Minitest::Result` both mix it in. trails runs its tests
  * under vitest, which owns the run lifecycle, so the runnable half of the gem
  * is not ported — this is the shape a reporter reads off whatever the runner
@@ -732,7 +751,7 @@ export interface Reportable {
 }
 
 /**
- * Mirrors `Minitest::AbstractReporter` (minitest.rb:687-731) — the API a
+ * Mirrors `Minitest::AbstractReporter` (minitest.rb:702-746) — the API a
  * reporter overrides. Ruby's `@mutex` guards a parallel run; JS has no threads,
  * so {@link AbstractReporter#synchronize} just calls the block.
  *
@@ -762,7 +781,7 @@ export class AbstractReporter {
 }
 
 /**
- * Mirrors `Minitest::Reporter` (minitest.rb:733-751).
+ * Mirrors `Minitest::Reporter` (minitest.rb:748-764).
  *
  * @noRailsEquivalent PERMANENT — minitest's, not Rails'; see {@link Assertion}.
  */
@@ -781,7 +800,7 @@ export class Reporter extends AbstractReporter {
 }
 
 /**
- * Mirrors `Minitest::ProgressReporter` (minitest.rb:759-771) — the reporter
+ * Mirrors `Minitest::ProgressReporter` (minitest.rb:774-787) — the reporter
  * that prints the "dots" during the run, and the one
  * `Minitest.plugin_rails_init` swaps for `Rails::TestUnitReporter`
  * (rails_plugin.rb:129-131).
@@ -804,7 +823,7 @@ export class ProgressReporter extends Reporter {
 }
 
 /**
- * Mirrors `Minitest::StatisticsReporter` (minitest.rb:795-878) — gathers
+ * Mirrors `Minitest::StatisticsReporter` (minitest.rb:810-901) — gathers
  * statistics about a test run, does no IO of its own.
  *
  * @noRailsEquivalent PERMANENT — minitest's, not Rails'; see {@link Assertion}.
@@ -871,7 +890,7 @@ export class StatisticsReporter extends Reporter {
 }
 
 /**
- * Mirrors `Minitest::SummaryReporter` (minitest.rb:897-967) — prints the
+ * Mirrors `Minitest::SummaryReporter` (minitest.rb:912-979) — prints the
  * header, summary, and failure details at the end of the run, and the reporter
  * `Minitest.plugin_rails_init` swaps for `SuppressedSummaryReporter`
  * (rails_plugin.rb:126-128).
@@ -890,7 +909,7 @@ export class SummaryReporter extends StatisticsReporter {
     this.io.puts("# Running:");
     this.io.puts();
 
-    this.sync = "sync" in this.io;
+    this.sync = respondToSyncWriter(this.io);
     if (this.sync) {
       this.oldSync = this.io.sync ?? null;
       this.io.sync = true;
@@ -959,7 +978,7 @@ export class SummaryReporter extends StatisticsReporter {
 }
 
 /**
- * Mirrors `Minitest::CompositeReporter` (minitest.rb:969-1024) — dispatch to
+ * Mirrors `Minitest::CompositeReporter` (minitest.rb:984-1030) — dispatch to
  * multiple reporters as one. This is the receiver
  * `Minitest.plugin_rails_init` rejects from and appends to
  * (rails_plugin.rb:122-135).
@@ -980,7 +999,7 @@ export class CompositeReporter extends AbstractReporter {
   }
 
   /**
-   * Mirrors `Minitest::CompositeReporter#<<` (minitest.rb:988-990). TypeScript
+   * Mirrors `Minitest::CompositeReporter#<<` (minitest.rb:1002-1004). TypeScript
    * has no `<<` to overload, so the operator keeps its Ruby name spelled out —
    * `Array#<<` is `push` on both sides of the port.
    */
@@ -997,7 +1016,7 @@ export class CompositeReporter extends AbstractReporter {
   }
 
   /**
-   * Mirrors `Minitest::CompositeReporter#prerecord` (minitest.rb:1000-1005).
+   * Mirrors `Minitest::CompositeReporter#prerecord` (minitest.rb:1014-1019).
    * Ruby guards each dispatch with `if reporter.respond_to? :prerecord` — its
    * own `# TODO: remove conditional for minitest 6` — which a
    * {@link AbstractReporter}-typed element cannot fail, so the guard has no

--- a/packages/activesupport/src/testing/minitest-reporter.trails.test.ts
+++ b/packages/activesupport/src/testing/minitest-reporter.trails.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  Assertion,
+  CompositeReporter,
+  IO,
+  Minitest,
+  ProgressReporter,
+  Reportable,
+  Skip,
+  StatisticsReporter,
+  SummaryReporter,
+  UnexpectedError,
+  UnexpectedWarning,
+} from "./assertions.js";
+
+/**
+ * trails-only: the minitest gem's own reporter tests
+ * (`test/minitest/test_minitest_reporter.rb`) are not enrolled in
+ * `parity:test`, which scans vendored Rails, so these cover the ported surface
+ * under trails names.
+ */
+class FakeIO implements IO {
+  string = "";
+  sync = false;
+
+  print(str: string): void {
+    this.string += str;
+  }
+
+  puts(str = ""): void {
+    this.string += str.endsWith("\n") ? str : `${str}\n`;
+  }
+}
+
+function result(overrides: Partial<Reportable> = {}): Reportable {
+  const failure = overrides.failure ?? null;
+  return {
+    name: "test_ok",
+    assertions: 1,
+    time: 0.5,
+    failure,
+    passed: () => failure === null,
+    skipped: () => failure instanceof Skip,
+    resultCode: () => (failure === null ? "." : "F"),
+    toString: () => "FakeResult#test_ok",
+    ...overrides,
+  };
+}
+
+describe("Minitest reporters", () => {
+  it("CompositeReporter dispatches to its reporters", () => {
+    const io = new FakeIO();
+    const progress = new ProgressReporter(io);
+    const reporter = new CompositeReporter(progress);
+    const stats = new StatisticsReporter(io);
+
+    reporter.push(stats);
+    expect(reporter.reporters).toEqual([progress, stats]);
+    expect(reporter.io).toBe(io);
+
+    reporter.start();
+    reporter.record(result());
+    reporter.report();
+
+    expect(io.string).toBe(".");
+    expect(stats.count).toBe(1);
+    expect(reporter.passed()).toBe(true);
+  });
+
+  it("ProgressReporter prints the class and time when verbose", () => {
+    const io = new FakeIO();
+    const reporter = new ProgressReporter(io, { verbose: true });
+
+    reporter.prerecord({ name: "FakeTest" }, "test_ok");
+    reporter.record(result());
+
+    expect(io.string).toBe("FakeTest#test_ok = 0.50 s = .\n");
+  });
+
+  it("StatisticsReporter counts failures, errors, warnings and skips by class", () => {
+    const reporter = new StatisticsReporter(new FakeIO());
+
+    reporter.start();
+    reporter.record(result());
+    reporter.record(result({ failure: new Assertion("boom") }));
+    reporter.record(result({ failure: new UnexpectedError(new Error("boom")) }));
+    reporter.record(result({ failure: new UnexpectedWarning("boom") }));
+    reporter.record(result({ failure: new Skip("later") }));
+    reporter.report();
+
+    expect(reporter.count).toBe(5);
+    expect(reporter.assertions).toBe(5);
+    expect(reporter.results.length).toBe(4);
+    expect([reporter.failures, reporter.errors, reporter.warnings, reporter.skips]).toEqual([
+      1, 1, 1, 1,
+    ]);
+    expect(reporter.passed()).toBe(false);
+    expect(reporter.totalTime).not.toBeNull();
+  });
+
+  it("SummaryReporter reports the header, the failures and the summary", () => {
+    const io = new FakeIO();
+    const reporter = new SummaryReporter(io, { args: "--seed 42" });
+
+    reporter.start();
+    expect(io.string).toBe("Run options: --seed 42\n\n# Running:\n\n");
+    expect(io.sync).toBe(true);
+
+    reporter.record(result({ failure: new Assertion("boom") }));
+    reporter.report();
+
+    expect(io.string).toContain("1 runs, 1 assertions, 1 failures, 0 errors, 0 skips");
+    expect(io.string).toContain("  1) FakeResult#test_ok");
+    expect(reporter.statistics()).toMatch(/^Finished in \d+\.\d{6}s, /);
+  });
+
+  it("SummaryReporter#toString renders the aggregated results alone", () => {
+    const reporter = new SummaryReporter(new FakeIO());
+
+    reporter.record(result({ failure: new Assertion("boom") }));
+    expect(String(reporter)).toBe("\n  1) FakeResult#test_ok\n\n");
+  });
+
+  it("Minitest.reporter is an unset CompositeReporter seat", () => {
+    expect(Minitest.reporter).toBeNull();
+
+    const reporter = new CompositeReporter();
+    Minitest.reporter = reporter;
+    try {
+      expect(Minitest.reporter.reporters).toEqual([]);
+    } finally {
+      Minitest.reporter = null;
+    }
+  });
+
+  it("Minitest.clockTime returns monotonic seconds", () => {
+    const before = Minitest.clockTime();
+    expect(typeof before).toBe("number");
+    expect(Minitest.clockTime()).toBeGreaterThanOrEqual(before);
+  });
+});

--- a/packages/activesupport/src/testing/minitest-reporter.trails.test.ts
+++ b/packages/activesupport/src/testing/minitest-reporter.trails.test.ts
@@ -115,6 +115,23 @@ describe("Minitest reporters", () => {
     expect(reporter.statistics()).toMatch(/^Finished in \d+\.\d{6}s, /);
   });
 
+  it("SummaryReporter leaves a read-only sync alone", () => {
+    const io: IO = {
+      print() {},
+      puts() {},
+      get sync() {
+        return true;
+      },
+    };
+    const reporter = new SummaryReporter(io);
+
+    reporter.start();
+
+    expect(reporter.sync).toBe(false);
+    expect(reporter.oldSync).toBeNull();
+    expect(io.sync).toBe(true);
+  });
+
   it("SummaryReporter#toString renders the aggregated results alone", () => {
     const reporter = new SummaryReporter(new FakeIO());
 

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/class-attribute.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/class-attribute.json
@@ -12,12 +12,5 @@
     "rubyName": "class_attribute",
     "call": "first",
     "reason": "Part of the same omission — `first` is only there to pick the `caller_locations(1, 1)` frame."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "class-attribute.ts",
-    "rubyName": "class_attribute",
-    "call": "redefine",
-    "reason": "trails' `classAttribute` writes the default straight into its own attribute store instead of routing through `ActiveSupport::ClassAttribute.redefine` (class/attribute.rb:97). A pre-existing divergence in this body, surfaced (not introduced) by bucketing `core_ext/class/attribute.rb` on class-attribute.ts; converging the whole body is 0098-activesupport-ar-closure-port/converge-class-attribute-to-rails-shape."
   }
 ]


### PR DESCRIPTION
Ports the minitest gem's reporter stack — the receiver the three reporter swaps at `railties/lib/minitest/rails_plugin.rb:122-135` operate on, and the thing `port-rails-plugin-reporter-blocks` is blocked behind.

Everything lands in `packages/activesupport/src/testing/assertions.ts`, next to the minitest ports already there (`Assertion`, `UnexpectedError`, `BacktraceFilter`, the `Minitest` module seat), each with the same `@noRailsEquivalent PERMANENT` reason: the minitest gem has no vendored Rails file for the comparator to map onto.

- `AbstractReporter` (minitest.rb:687-731) — Ruby's `@mutex` guards a parallel run; JS has no threads, so `synchronize` calls the block.
- `Reporter` (:733-751), `ProgressReporter` (:759-771), `StatisticsReporter` (:795-878), `SummaryReporter` (:897-967), `CompositeReporter` (:969-1024). `<<` is `push` — an operator with no parity counterpart per docs/ruby-ts-conventions.md:61, and `Array#<<` is `push` on both sides.
- `Minitest.reporter` (the `cattr_accessor` at minitest.rb:51) — nullable, because `Minitest.run` sets it around `init_plugins` and nils it again (:277-282) — and `Minitest.clockTime` (:1214-1222), whose two arms port to `performance.now()` and `Date.now()`.
- `Skip` (:1050-1054) and `UnexpectedWarning` (:1098-1102), the failure classes `StatisticsReporter#report` aggregates by.
- `IO` / `Options` / `Reportable` — type-only shapes for the receivers Ruby leaves duck-typed (`$stdout`, the `process_args` hash, `Minitest::Reportable`). trails runs under vitest, which owns the run lifecycle, so the runnable half of the gem is not ported; `Reportable` is what a reporter reads off whatever the runner records.

Remaining ordering, filed as follow-ups rather than stacked here:

- `port-minitest-rails-plugin-reporter-subclasses` — `SuppressedSummaryReporter` (rails_plugin.rb:21-26) and `ProfileReporter` (:28-65).
- `port-rails-test-unit-reporter` — `Rails::TestUnitReporter` (`rails/test_unit/reporter.rb`).

Drive-by: deletes the `class-attribute.ts` / `redefine` call-mismatch baseline row, which #6520 converged without retiring — it reds `parity:api:calls` on `main` today.

No `node:*`, no `process.*` (`$stdout` goes through `process-adapter`).

Closes-story: port-minitest-reporter-surface