### PR TITLE
refactor(activemodel,activesupport): Rails branch structure in date cast_value, per-test failures list

### DIFF
--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -40,22 +40,21 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
    *     fast_string_to_time(value) || fallback_string_to_time(value)
    *   end
    *
-   * A JS `Date`, a `Temporal.ZonedDateTime` and a `Temporal.PlainDateTime` are
-   * this platform's spellings of Ruby's `::Time`, which Rails hands straight to
+   * A JS `Date` and a `Temporal.PlainDateTime` are this platform's spellings
+   * of Ruby's `::Time`, which Rails hands straight to
    * `apply_seconds_precision` — but that reads `nsec` off the receiver and
    * trails' cast result is the `Temporal.Instant` that carries it, so they are
-   * anchored to one first. The zone-less `PlainDateTime` is anchored on the
-   * `is_utc?` branch `new_time` puts a zone-less value on
-   * (time_value.rb:57-62). Everything else — `DateInfinity` /
-   * `DateNegativeInfinity` included — reaches `apply_seconds_precision`, which
-   * answers a receiver with no `nsec` unchanged (time_value.rb:24-25).
+   * anchored to one first, the zone-less `PlainDateTime` on the `is_utc?`
+   * branch `new_time` puts a zone-less value on (time_value.rb:57-62).
+   * Everything else — `DateInfinity` / `DateNegativeInfinity` included —
+   * reaches `apply_seconds_precision`, which answers a receiver with no `nsec`
+   * unchanged (time_value.rb:24-25).
    *
    * @internal Rails-private helper.
    */
   protected castValue(value: unknown): DateTimeCastResult | null {
     // boundary: a JS Date assigned to a datetime attribute is Ruby's ::Time.
     if (value instanceof Date) value = Temporal.Instant.fromEpochMilliseconds(value.getTime());
-    if (value instanceof Temporal.ZonedDateTime) value = value.toInstant();
     if (value instanceof Temporal.PlainDateTime) {
       value = value.toZonedDateTime(this.isUtc ? "UTC" : Temporal.Now.timeZoneId()).toInstant();
     }
@@ -207,9 +206,11 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
     return isHash(value);
   }
 
-  // Mirrors Helpers::TimeValue#apply_seconds_precision (time_value.rb:24-34):
-  // `return value unless precision && value.respond_to?(:nsec)` — Instant is
-  // the receiver carrying nanoseconds here, everything else passes through.
+  /**
+   * Mirrors: Helpers::TimeValue#apply_seconds_precision (time_value.rb:24-34).
+   * `return value unless precision && value.respond_to?(:nsec)` — `Instant` is
+   * the receiver carrying nanoseconds here; everything else passes through.
+   */
   private applySecondsPrecision<T>(value: T): T {
     if (
       this.precision == null ||

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -6,8 +6,6 @@ import {
   type DateParts,
 } from "@blazetrails/date";
 import {
-  DateInfinity,
-  DateNegativeInfinity,
   type DateInfinity as DateInfinityType,
   type DateNegativeInfinity as DateNegativeInfinityType,
 } from "./internal/sentinels.js";
@@ -32,18 +30,40 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
     return this.name;
   }
 
-  /** @internal Rails-private helper. */
+  /**
+   * Mirrors: ActiveModel::Type::DateTime#cast_value (date_time.rb:54-59).
+   *
+   *   def cast_value(value)
+   *     return apply_seconds_precision(value) unless value.is_a?(::String)
+   *     return if value.empty?
+   *
+   *     fast_string_to_time(value) || fallback_string_to_time(value)
+   *   end
+   *
+   * A JS `Date`, a `Temporal.ZonedDateTime` and a `Temporal.PlainDateTime` are
+   * this platform's spellings of Ruby's `::Time`, which Rails hands straight to
+   * `apply_seconds_precision` — but that reads `nsec` off the receiver and
+   * trails' cast result is the `Temporal.Instant` that carries it, so they are
+   * anchored to one first. The zone-less `PlainDateTime` is anchored on the
+   * `is_utc?` branch `new_time` puts a zone-less value on
+   * (time_value.rb:57-62). Everything else — `DateInfinity` /
+   * `DateNegativeInfinity` included — reaches `apply_seconds_precision`, which
+   * answers a receiver with no `nsec` unchanged (time_value.rb:24-25).
+   *
+   * @internal Rails-private helper.
+   */
   protected castValue(value: unknown): DateTimeCastResult | null {
-    if (value === DateInfinity) return DateInfinity;
-    if (value === DateNegativeInfinity) return DateNegativeInfinity;
-    if (value instanceof Temporal.Instant) return this.applySecondsPrecision(value);
-    // boundary: JS Date assigned to a datetime attribute (e.g. aircraft.manufactured_at = new Date())
-    if (value instanceof Date) {
-      return this.applySecondsPrecision(Temporal.Instant.fromEpochMilliseconds(value.getTime()));
+    // boundary: a JS Date assigned to a datetime attribute is Ruby's ::Time.
+    if (value instanceof Date) value = Temporal.Instant.fromEpochMilliseconds(value.getTime());
+    if (value instanceof Temporal.ZonedDateTime) value = value.toInstant();
+    if (value instanceof Temporal.PlainDateTime) {
+      value = value.toZonedDateTime(this.isUtc ? "UTC" : Temporal.Now.timeZoneId()).toInstant();
     }
-    const str = String(value).trim();
-    if (str === "") return null;
-    return this.fastStringToTime(str) ?? this.fallbackStringToTime(str);
+    if (typeof value !== "string")
+      return this.applySecondsPrecision(value) as DateTimeCastResult | null;
+    if (value === "") return null;
+
+    return this.fastStringToTime(value) ?? this.fallbackStringToTime(value);
   }
 
   /**
@@ -187,12 +207,16 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
     return isHash(value);
   }
 
-  private applySecondsPrecision(value: Temporal.Instant): Temporal.Instant {
+  // Mirrors Helpers::TimeValue#apply_seconds_precision (time_value.rb:24-34):
+  // `return value unless precision && value.respond_to?(:nsec)` — Instant is
+  // the receiver carrying nanoseconds here, everything else passes through.
+  private applySecondsPrecision<T>(value: T): T {
     if (
       this.precision == null ||
       !Number.isInteger(this.precision) ||
       this.precision < 0 ||
-      this.precision > 9
+      this.precision > 9 ||
+      !(value instanceof Temporal.Instant)
     )
       return value;
     const mod = 10n ** BigInt(9 - this.precision);
@@ -200,7 +224,7 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
     if (subsec < 0n) subsec += 1_000_000_000n;
     const roundedOff = subsec % mod;
     if (roundedOff === 0n) return value;
-    return Temporal.Instant.fromEpochNanoseconds(value.epochNanoseconds - roundedOff);
+    return Temporal.Instant.fromEpochNanoseconds(value.epochNanoseconds - roundedOff) as T;
   }
 
   override isChanged(oldValue: unknown, newValue: unknown, _raw?: unknown): boolean {
@@ -243,7 +267,6 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
 
   // Mirrors ActiveModel::Type::Helpers::TimeValue#serialize_cast_value (apply_seconds_precision).
   serializeCastValue(value: DateTimeCastResult | null): DateTimeCastResult | null {
-    if (value === null || value === DateInfinity || value === DateNegativeInfinity) return value;
-    return this.applySecondsPrecision(value as Temporal.Instant);
+    return this.applySecondsPrecision(value);
   }
 }

--- a/packages/activemodel/src/type/date.ts
+++ b/packages/activemodel/src/type/date.ts
@@ -31,28 +31,56 @@ export class DateType extends ValueType<DateCastResult> {
     return JSON.stringify(cast.toString());
   }
 
-  /** @internal Rails-private helper. */
+  /**
+   * Mirrors: ActiveModel::Type::Date#cast_value (date.rb:39-48).
+   *
+   *   def cast_value(value)
+   *     if value.is_a?(::String)
+   *       return if value.empty?
+   *       fast_string_to_date(value) || fallback_string_to_date(value)
+   *     elsif value.respond_to?(:to_date)
+   *       value.to_date
+   *     else
+   *       value
+   *     end
+   *   end
+   *
+   * The `to_date` arm is spelled out per receiver, since TS has no
+   * `respond_to?`: `Temporal.PlainDate` is already a `::Date` (`to_date` is
+   * identity), `Temporal.PlainDateTime` and a JS `Date` are the platform's
+   * `Time`, whose `to_date` drops the time-of-day. The Hash arm stands in for
+   * `AcceptsMultiparameterTime::InstanceMethods#cast`, which Rails runs before
+   * `cast_value` and trails' `DateType` has no `cast` override for.
+   * `DateInfinity` / `DateNegativeInfinity` are `Float::INFINITY`, which
+   * answers no `to_date` and so falls through the `else` arm untouched, as in
+   * Rails.
+   *
+   * @internal Rails-private helper.
+   */
   protected castValue(value: unknown): DateCastResult | null {
-    if (value === DateInfinity) return DateInfinity;
-    if (value === DateNegativeInfinity) return DateNegativeInfinity;
-    if (value instanceof Temporal.PlainDate) return value;
-    // Accept PlainDateTime from multiparameter assignment — extract the date part.
-    if (value instanceof Temporal.PlainDateTime) return value.toPlainDate();
-    // Mirrors AcceptsMultiparameterTime::InstanceMethods#cast's Hash branch.
-    if (isHash(value)) return this.valueFromMultiparameterAssignment(value);
-    // boundary: cast accepts Date input from legacy callers / custom types
-    // and bridges into Temporal.PlainDate via the UTC calendar components.
-    if (value instanceof Date) {
+    if (typeof value === "string") {
+      if (value === "") return null;
+      return this.fastStringToDate(value) ?? this.fallbackStringToDate(value);
+    } else if (isHash(value)) {
+      return this.valueFromMultiparameterAssignment(value);
+    } else if (value instanceof Temporal.PlainDate) {
+      return value;
+    } else if (value instanceof Temporal.PlainDateTime) {
+      return value.toPlainDate();
+      // boundary: a JS Date assigned to a date attribute is Ruby's ::Time,
+      // whose `to_date` drops the time of day.
+    } else if (value instanceof Date) {
+      // An invalid JS Date has no calendar components to hand ::Date.new, so
+      // it lands where new_date's `rescue nil` would (date.rb:68).
       if (Number.isNaN(value.getTime())) return null;
       return Temporal.PlainDate.from({
         year: value.getUTCFullYear(),
         month: value.getUTCMonth() + 1,
         day: value.getUTCDate(),
       });
+    } else {
+      return value as DateCastResult;
     }
-    const str = String(value).trim();
-    if (str === "") return null;
-    return this.fastStringToDate(str) ?? this.fallbackStringToDate(str);
   }
 
   /**

--- a/packages/activemodel/src/type/date.ts
+++ b/packages/activemodel/src/type/date.ts
@@ -47,10 +47,11 @@ export class DateType extends ValueType<DateCastResult> {
    *
    * The `to_date` arm is spelled out per receiver, since TS has no
    * `respond_to?`: `Temporal.PlainDate` is already a `::Date` (`to_date` is
-   * identity), `Temporal.PlainDateTime` and a JS `Date` are the platform's
-   * `Time`, whose `to_date` drops the time-of-day. The Hash arm stands in for
-   * `AcceptsMultiparameterTime::InstanceMethods#cast`, which Rails runs before
-   * `cast_value` and trails' `DateType` has no `cast` override for.
+   * identity), while `Temporal.PlainDateTime` and a JS `Date` are the
+   * platform's `::Time`, whose `to_date` drops the time of day. An invalid JS
+   * `Date` has no calendar components to hand `::Date.new`, so it lands where
+   * `new_date`'s `rescue nil` puts it (date.rb:68).
+   *
    * `DateInfinity` / `DateNegativeInfinity` are `Float::INFINITY`, which
    * answers no `to_date` and so falls through the `else` arm untouched, as in
    * Rails.
@@ -61,17 +62,12 @@ export class DateType extends ValueType<DateCastResult> {
     if (typeof value === "string") {
       if (value === "") return null;
       return this.fastStringToDate(value) ?? this.fallbackStringToDate(value);
-    } else if (isHash(value)) {
-      return this.valueFromMultiparameterAssignment(value);
     } else if (value instanceof Temporal.PlainDate) {
       return value;
     } else if (value instanceof Temporal.PlainDateTime) {
       return value.toPlainDate();
-      // boundary: a JS Date assigned to a date attribute is Ruby's ::Time,
-      // whose `to_date` drops the time of day.
+      // boundary: a JS Date assigned to a date attribute is Ruby's ::Time.
     } else if (value instanceof Date) {
-      // An invalid JS Date has no calendar components to hand ::Date.new, so
-      // it lands where new_date's `rescue nil` would (date.rb:68).
       if (Number.isNaN(value.getTime())) return null;
       return Temporal.PlainDate.from({
         year: value.getUTCFullYear(),
@@ -192,6 +188,19 @@ export class DateType extends ValueType<DateCastResult> {
     // within-range overflow like Time.local (Nov 31 → Dec 1).
     const time = new AcceptsMultiparameterTime(this).cast(values) as Temporal.PlainDate | null;
     return time && this.newDate(time.year, time.month, time.day);
+  }
+
+  /**
+   * Mirrors: AcceptsMultiparameterTime::InstanceMethods#cast
+   * (accepts_multiparameter_time.rb:16-22). The nil guard stays in
+   * `Value#cast` (value.rb:53-55), which is `super`.
+   */
+  override cast(value: unknown): DateCastResult | null {
+    if (isHash(value)) {
+      return this.valueFromMultiparameterAssignment(value);
+    } else {
+      return super.cast(value);
+    }
   }
 
   /**

--- a/packages/activerecord/src/relation/query-attribute.ts
+++ b/packages/activerecord/src/relation/query-attribute.ts
@@ -47,7 +47,16 @@ export class QueryAttribute extends Attribute {
     super(name, value, ensureType(type));
   }
 
+  /**
+   * `query_attribute.rb:22-24` is `def type_cast(value) = value` — a
+   * QueryAttribute never puts its raw value through the type. Trails casts
+   * here instead, which is why the `Substitute` arm has to be spelled out: a
+   * StatementCache placeholder stands in for a value not supplied yet, and
+   * Rails' own constructor names it as the one value it will not route through
+   * the type (query_attribute.rb:13-14). `nil?` below carries the same guard.
+   */
   typeCast(value: unknown): unknown {
+    if (value instanceof Substitute) return value;
     return this.type.cast(value);
   }
 

--- a/packages/activesupport/src/test-case.ts
+++ b/packages/activesupport/src/test-case.ts
@@ -28,7 +28,6 @@ import {
   taggedLogger,
 } from "./testing/tagged-logging.js";
 import {
-  failures,
   prepended as setupAndTeardownPrepended,
   setup,
   teardown,
@@ -96,20 +95,18 @@ export class TestCase {
    * last.
    */
   static afterTeardown(test: RunningTest): void {
-    const recordedBefore = failures.length;
-    setupAndTeardownAfterTeardown.call(TestCase);
+    setupAndTeardownAfterTeardown.call(TestCase, test);
     timeHelpersAfterTeardown();
-    const recorded = failures.splice(recordedBefore);
     testsWithoutAssertionsAfterTeardown({
       ...test,
       // Minitest's `error?` is `failures.any? { UnexpectedError === _1 }`, so a
       // teardown that raised suppresses the missing-assertion warning.
-      error: test.error || recorded.some((f) => f instanceof UnexpectedError),
+      error: test.error || test.failures.some((f) => f instanceof UnexpectedError),
     });
     // `self.failures` is the list Minitest reports the test on; vitest has no
     // per-test failure list, so what makes the runner see the failure is the
     // hook raising it.
-    if (recorded.length > 0) throw recorded[0];
+    if (test.failures.length > 0) throw test.failures[0];
   }
 
   // include ActiveSupport::Testing::Assertions (test_case.rb:147)
@@ -177,5 +174,7 @@ function _runningTest(context: TestContext): RunningTest {
     error: task.result?.state === "fail" || (task.result?.errors?.length ?? 0) > 0,
     name: task.name,
     sourceLocation: [task.file?.filepath ?? "", task.location?.line ?? 0],
+    // `Minitest::Runnable#initialize` starts every test on an empty list.
+    failures: [],
   };
 }

--- a/packages/activesupport/src/test-case.ts
+++ b/packages/activesupport/src/test-case.ts
@@ -174,7 +174,6 @@ function _runningTest(context: TestContext): RunningTest {
     error: task.result?.state === "fail" || (task.result?.errors?.length ?? 0) > 0,
     name: task.name,
     sourceLocation: [task.file?.filepath ?? "", task.location?.line ?? 0],
-    // `Minitest::Runnable#initialize` starts every test on an empty list.
     failures: [],
   };
 }

--- a/packages/activesupport/src/testing/after-teardown-assertion.test.ts
+++ b/packages/activesupport/src/testing/after-teardown-assertion.test.ts
@@ -12,12 +12,15 @@ import { describe, expect, it } from "vitest";
 
 import { resetCallbacks } from "../callbacks.js";
 import { Assertion } from "./assertions.js";
-import { afterTeardown, failures, prepended, teardown } from "./setup-and-teardown.js";
+import { afterTeardown, prepended, teardown } from "./setup-and-teardown.js";
+import type { RunningTest } from "./tests-without-assertions.js";
 
 describe("AfterTeardownAssertionTest", () => {
   it("teardown raise but all after teardown method are called", () => {
     const klass = {};
     prepended(klass);
+    // The `self` Ruby's `self.failures` resolves against — one list per test.
+    const test: Pick<RunningTest, "failures"> = { failures: [] };
     let witness = false;
 
     const flunked = new Assertion(
@@ -28,19 +31,18 @@ describe("AfterTeardownAssertionTest", () => {
     });
 
     const otherAfterTeardown = () => {
-      afterTeardown.call(klass);
+      afterTeardown.call(klass, test);
       witness = true;
     };
 
     try {
-      expect(failures.length).toBe(0);
+      expect(test.failures.length).toBe(0);
       otherAfterTeardown();
-      expect(failures.length).toBe(1);
-      expect(failures[0]).toBe(flunked);
+      expect(test.failures.length).toBe(1);
+      expect(test.failures[0]).toBe(flunked);
 
       expect(witness).toBe(true);
     } finally {
-      failures.length = 0;
       resetCallbacks(klass, "teardown");
     }
   });

--- a/packages/activesupport/src/testing/after-teardown-assertion.test.ts
+++ b/packages/activesupport/src/testing/after-teardown-assertion.test.ts
@@ -19,7 +19,6 @@ describe("AfterTeardownAssertionTest", () => {
   it("teardown raise but all after teardown method are called", () => {
     const klass = {};
     prepended(klass);
-    // The `self` Ruby's `self.failures` resolves against — one list per test.
     const test: Pick<RunningTest, "failures"> = { failures: [] };
     let witness = false;
 

--- a/packages/activesupport/src/testing/after-teardown.test.ts
+++ b/packages/activesupport/src/testing/after-teardown.test.ts
@@ -20,7 +20,6 @@ describe("AfterTeardownTest", () => {
   it("teardown raise but all after teardown method are called", () => {
     const klass = {};
     prepended(klass);
-    // The `self` Ruby's `self.failures` resolves against — one list per test.
     const test: Pick<RunningTest, "failures"> = { failures: [] };
     let witness = false;
 

--- a/packages/activesupport/src/testing/after-teardown.test.ts
+++ b/packages/activesupport/src/testing/after-teardown.test.ts
@@ -11,7 +11,8 @@ import { describe, expect, it } from "vitest";
 
 import { resetCallbacks } from "../callbacks.js";
 import { UnexpectedError } from "./assertions.js";
-import { afterTeardown, failures, prepended, teardown } from "./setup-and-teardown.js";
+import { afterTeardown, prepended, teardown } from "./setup-and-teardown.js";
+import type { RunningTest } from "./tests-without-assertions.js";
 
 class MyError extends Error {}
 
@@ -19,6 +20,8 @@ describe("AfterTeardownTest", () => {
   it("teardown raise but all after teardown method are called", () => {
     const klass = {};
     prepended(klass);
+    // The `self` Ruby's `self.failures` resolves against — one list per test.
+    const test: Pick<RunningTest, "failures"> = { failures: [] };
     let witness = false;
 
     teardown.call(klass, () => {
@@ -26,20 +29,19 @@ describe("AfterTeardownTest", () => {
     });
 
     const otherAfterTeardown = () => {
-      afterTeardown.call(klass);
+      afterTeardown.call(klass, test);
       witness = true;
     };
 
     try {
-      expect(failures.length).toBe(0);
+      expect(test.failures.length).toBe(0);
       otherAfterTeardown();
-      expect(failures.length).toBe(1);
-      expect(failures[0]).toBeInstanceOf(UnexpectedError);
-      expect((failures[0] as UnexpectedError).error).toBeInstanceOf(MyError);
+      expect(test.failures.length).toBe(1);
+      expect(test.failures[0]).toBeInstanceOf(UnexpectedError);
+      expect((test.failures[0] as UnexpectedError).error).toBeInstanceOf(MyError);
 
       expect(witness).toBe(true);
     } finally {
-      failures.length = 0;
       resetCallbacks(klass, "teardown");
     }
   });

--- a/packages/activesupport/src/testing/setup-and-teardown.trails.test.ts
+++ b/packages/activesupport/src/testing/setup-and-teardown.trails.test.ts
@@ -2,21 +2,22 @@ import { describe, expect, it, vi } from "vitest";
 
 import { resetCallbacks } from "../callbacks.js";
 import { Assertion, UnexpectedError } from "./assertions.js";
+import { afterTeardown, beforeSetup, prepended, setup, teardown } from "./setup-and-teardown.js";
 import {
-  afterTeardown,
-  beforeSetup,
-  failures,
-  prepended,
-  setup,
-  teardown,
-} from "./setup-and-teardown.js";
-import { afterTeardown as testsWithoutAssertionsAfterTeardown } from "./tests-without-assertions.js";
+  afterTeardown as testsWithoutAssertionsAfterTeardown,
+  type RunningTest,
+} from "./tests-without-assertions.js";
 import { TestCase } from "../test-case.js";
 
 function testCase(): Record<string, never> {
   const klass = {} as Record<string, never>;
   prepended(klass);
   return klass;
+}
+
+/** The `self` Ruby's `self.failures` resolves against — one list per test. */
+function runningTest(): Pick<RunningTest, "failures"> {
+  return { failures: [] };
 }
 
 describe("SetupAndTeardown", () => {
@@ -29,7 +30,7 @@ describe("SetupAndTeardown", () => {
     beforeSetup.call(klass);
     expect(ran).toEqual(["setup"]);
 
-    afterTeardown.call(klass);
+    afterTeardown.call(klass, runningTest());
     expect(ran).toEqual(["setup", "teardown"]);
     resetCallbacks(klass, "setup");
     resetCallbacks(klass, "teardown");
@@ -37,34 +38,32 @@ describe("SetupAndTeardown", () => {
 
   it("records a raising teardown callback as a failure instead of propagating", () => {
     const klass = testCase();
-    const before = failures.length;
+    const test = runningTest();
     const raised = new TypeError("boom");
     teardown.call(klass, () => {
       throw raised;
     });
 
-    afterTeardown.call(klass);
+    afterTeardown.call(klass, test);
 
-    expect(failures.length).toBe(before + 1);
-    const failure = failures[failures.length - 1];
+    expect(test.failures.length).toBe(1);
+    const failure = test.failures[0];
     expect(failure).toBeInstanceOf(UnexpectedError);
     expect((failure as UnexpectedError).error).toBe(raised);
-    failures.length = before;
     resetCallbacks(klass, "teardown");
   });
 
   it("records a failed assertion in a teardown callback as itself", () => {
     const klass = testCase();
-    const before = failures.length;
+    const test = runningTest();
     const raised = new Assertion("nope");
     teardown.call(klass, () => {
       throw raised;
     });
 
-    afterTeardown.call(klass);
+    afterTeardown.call(klass, test);
 
-    expect(failures[failures.length - 1]).toBe(raised);
-    failures.length = before;
+    expect(test.failures[0]).toBe(raised);
     resetCallbacks(klass, "teardown");
   });
 });
@@ -76,6 +75,7 @@ describe("TestsWithoutAssertions", () => {
     error: false,
     name: "a test",
     sourceLocation: ["some_test.ts", 12] as [string, number],
+    failures: [],
   };
 
   it("warns when a test made no assertion", () => {
@@ -114,10 +114,10 @@ describe("TestCase after_teardown chain", () => {
           error: false,
           name: "a test",
           sourceLocation: ["some_test.ts", 12],
+          failures: [],
         }),
       ).toThrow(UnexpectedError);
       expect(warn).not.toHaveBeenCalled();
-      expect(failures).toEqual([]);
     } finally {
       warn.mockRestore();
       resetCallbacks(TestCase, "teardown");

--- a/packages/activesupport/src/testing/setup-and-teardown.ts
+++ b/packages/activesupport/src/testing/setup-and-teardown.ts
@@ -26,15 +26,7 @@
 import { defineCallbacks, setCallback, runCallbacks } from "../callbacks.js";
 import type { FilterListEntry } from "../callbacks.js";
 import { Assertion, UnexpectedError } from "./assertions.js";
-
-/**
- * Mirrors `self.failures` — Minitest keeps the failure list on the test
- * instance the module is mixed into, which lives for exactly one test. The
- * ported hooks are free functions with no such receiver, so the list is
- * module-global here, the same stand-in `testing/tagged_logging.rb`'s
- * `@tagged_logger` takes.
- */
-export const failures: (Assertion | UnexpectedError)[] = [];
+import type { RunningTest } from "./tests-without-assertions.js";
 
 /**
  * Mirrors `self.prepended(klass)` (setup_and_teardown.rb:21-25):
@@ -73,15 +65,25 @@ export function beforeSetup(this: object): void {
  * Mirrors `after_teardown` (setup_and_teardown.rb:44-53). A teardown callback
  * that raises is recorded as a failure rather than propagated, so the rest of
  * the `after_teardown` chain still runs.
+ *
+ * Ruby's `self` is one object: the Minitest instance both `run_callbacks` and
+ * `self.failures` (setup_and_teardown.rb:48,50) resolve against. Trails splits
+ * it — the callback chains live on the receiver `prepended()` installed them
+ * on, so the per-test half of that `self`, the `RunningTest` whose `failures`
+ * list lives for exactly one test, is taken as an argument.
+ *
+ * Ruby's `rescue => e` arm reads first, but `Minitest::Assertion` descends
+ * from `Exception`, not `StandardError`, so it is the second arm that takes
+ * it — which is the order the `instanceof` check spells out.
  */
-export function afterTeardown(this: object): void {
+export function afterTeardown(this: object, test: Pick<RunningTest, "failures">): void {
   try {
     runCallbacks(this, "teardown");
   } catch (e) {
     if (e instanceof Assertion) {
-      failures.push(e);
+      test.failures.push(e);
     } else {
-      failures.push(new UnexpectedError(e as Error));
+      test.failures.push(new UnexpectedError(e as Error));
     }
   }
 }

--- a/packages/activesupport/src/testing/test-without-assertions.test.ts
+++ b/packages/activesupport/src/testing/test-without-assertions.test.ts
@@ -20,6 +20,7 @@ it("without assertions", () => {
       error: false,
       name: "test_without_assertions",
       sourceLocation: ["packages/activesupport/src/testing/test_without_assertions_test.ts", 9],
+      failures: [],
     });
 
     const err = warn.mock.calls.map((c) => String(c[0])).join("\n");

--- a/packages/activesupport/src/testing/tests-without-assertions.ts
+++ b/packages/activesupport/src/testing/tests-without-assertions.ts
@@ -6,13 +6,15 @@
  * This is helpful in detecting broken tests that do not perform intended
  * assertions.
  */
+import type { Assertion, UnexpectedError } from "./assertions.js";
 
 /**
  * The running test — the Minitest instance Ruby reads `assertions`,
- * `skipped?`, `error?`, `name` and `method(name).source_location` off. The
- * ported hook is a free function with no such receiver, so the runner's task
- * is handed to it instead; test-case.ts builds this from vitest's per-test
- * context.
+ * `skipped?`, `error?`, `name`, `method(name).source_location` and
+ * `failures` off. The ported hooks are free functions with no such receiver,
+ * so the runner's task is handed to them instead; test-case.ts builds this
+ * from vitest's per-test context, once per test, which is the lifetime
+ * `Minitest::Runnable#failures` has.
  *
  * @noRailsEquivalent PERMANENT — a structural stand-in for the `self` of a
  * `Minitest::Test`, which lives in the minitest gem and so has no file in the
@@ -24,6 +26,7 @@ export interface RunningTest {
   error: boolean;
   name: string;
   sourceLocation: [string, number];
+  failures: (Assertion | UnexpectedError)[];
 }
 
 /** Mirrors `after_teardown` (tests_without_assertions.rb:10-17). */


### PR DESCRIPTION
Two convergences, one per bundled story.

## `Date` / `DateTime` `cast_value` branch structure

`type/date.rb:39-48` and `type/date_time.rb:54-59` branch on the value's type.
The port instead ended both bodies with `String(value).trim()`, which coerced
every non-Temporal input through a string where Rails' `else` arm returns it
untouched, and trimmed where Rails does not — `" "` is `empty?`-false in Ruby
and reaches `fast_string_to_date`, while trails answered `null`.

Both bodies now carry Rails' arms. The Temporal / JS-`Date` boundary arms trails
needs on top are justified at the call site against the Rails line they stand in
for: they are the receivers Ruby's `to_date` / `::Time` arms take, anchored to
the `Temporal.PlainDate` / `Temporal.Instant` the cast result is. `DateTime`'s
`applySecondsPrecision` takes the pass-through guard Rails has
(`time_value.rb:24-25`), so the non-String arm can hand it anything — including
the `Float::INFINITY` sentinels, which now fall through exactly as in Rails
rather than needing their own leading branches.

`Date`'s Hash arm moves out of `cast_value` into a `cast` override, mirroring
`AcceptsMultiparameterTime::InstanceMethods#cast` the way `DateTimeType`
already does, so `cast_value` carries only the three arms Rails gives it.

One downstream fix comes with it. `QueryAttribute#type_cast` is a no-op in
Rails (`query_attribute.rb:22-24`), so a `StatementCache::Substitute` bind
never reaches a type; trails casts there instead, and the faithful `else` arm
sent a `Substitute` into a `normalizes` normalizer, reddening
`normalized-attribute.test.ts > finds record by normalized value`. The guard
added is the one Rails' own constructor justifies (`query_attribute.rb:13-14`,
"we don't need to serialize StatementCache::Substitute"), and it sits next to
the identical guard `nil?` already carries. The general convergence to Rails'
no-op is filed as
`0023-surfaced-deviations/converge-query-attribute-type-cast-to-rails-no-op`
— it was measured on this branch and reds three `relation/query-attribute.test.ts`
expectations that need resolving against their Rails counterparts first.

`pnpm parity:api:calls:args:report` no longer carries the 4 `naming` rows
(2 per file) these bodies stood behind; no new `shape` rows.

## `SetupAndTeardown`'s failures list

`setup_and_teardown.rb:44-53` pushes a raising teardown callback onto
`self.failures` — the Minitest instance's own list, alive for exactly one test.
The port held it in a module global, so the list leaked across test files in a
worker and every test exercising `afterTeardown` had to reset it in a `finally`.

`failures` now lives on `RunningTest`, the per-test half of that `self` that
`tests_without_assertions.rb`'s hook is already handed, and `afterTeardown`
takes it. The three `failures.length = 0` cleanups are gone, and `test-case.ts`
no longer has to splice a window out of a shared list to know what this test
recorded. Both rescue arms are unchanged in behaviour.

Closes-story: date-cast-value-rails-branch-structure
Closes-story: converge-setup-and-teardown-failures-off-module-global
