### PR TITLE
feat(activesupport,activerecord): port ExecutionWrapper/Executor and install the async-queries tracker's executor hooks

### DIFF
--- a/packages/activerecord/src/asynchronous-queries-tracker.ts
+++ b/packages/activerecord/src/asynchronous-queries-tracker.ts
@@ -1,3 +1,4 @@
+import { Executor } from "@blazetrails/activesupport";
 import { ActiveRecordError } from "./errors.js";
 import { asynchronousQueriesTracker } from "./core.js";
 
@@ -22,6 +23,10 @@ export class AsynchronousQueriesTracker {
 
   constructor() {
     this.#stack = [];
+  }
+
+  static installExecutorHooks(executor: typeof Executor = Executor): void {
+    executor.registerHook(this);
   }
 
   static run(): AsynchronousQueriesTracker {

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -6,7 +6,7 @@
 
 import { NoMethodError } from "@blazetrails/activemodel";
 import { ActiveRecord, AsyncExecutor } from "../../ar-config.js";
-import { synchronize, type MonitorMixin } from "@blazetrails/activesupport";
+import { Executor, synchronize, type MonitorMixin } from "@blazetrails/activesupport";
 import { adapterNameFromConfig } from "../abstract-adapter.js";
 import type { AbstractAdapter as DatabaseAdapter } from "../abstract-adapter.js";
 import type { DatabaseConfig } from "../../database-configurations/database-config.js";
@@ -680,10 +680,10 @@ export class ConnectionPool implements ReapablePool {
 
   // --- Install executor hooks ---
 
-  static installExecutorHooks(executor?: {
-    registerHook(hooks: typeof ExecutorHooks): void;
-  }): void {
-    executor?.registerHook(ExecutorHooks);
+  static installExecutorHooks(
+    executor: { registerHook(hooks: typeof ExecutorHooks): void } = Executor,
+  ): void {
+    executor.registerHook(ExecutorHooks);
   }
 
   // --- Lease management ---

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -655,16 +655,7 @@ export function connectionClassForSelf(this: CoreHost): CoreHost {
 export function asynchronousQueriesTracker(): AsynchronousQueriesTracker {
   return IsolatedExecutionState.fetch<AsynchronousQueriesTracker>(
     ASYNCHRONOUS_QUERIES_TRACKER_KEY,
-    () => {
-      const tracker = new AsynchronousQueriesTracker();
-      // Rails returns the bare tracker and lets the ActiveSupport::Executor hook
-      // (`AsynchronousQueriesTracker.run`, asynchronous_queries_tracker.rb:32-40)
-      // push the session. trails has no Executor to register with, so nothing
-      // would ever open one — story
-      // install-executor-hooks-for-async-queries-tracker retires this line.
-      tracker.startSession();
-      return tracker;
-    },
+    () => new AsynchronousQueriesTracker(),
   );
 }
 

--- a/packages/activerecord/src/future-result.trails.test.ts
+++ b/packages/activerecord/src/future-result.trails.test.ts
@@ -147,11 +147,6 @@ describe("AsynchronousQueriesTracker", () => {
 });
 
 describe("DatabaseStatements#select", () => {
-  // The async arm reads `Base.asynchronous_queries_session`, which only exists
-  // inside an execution — Rails' railtie installs the tracker's hooks on
-  // `ActiveSupport::Executor` (railtie.rb) and every request runs inside one.
-  // `run!`/`complete!` rather than `wrap` because the bodies below are async and
-  // `wrap`'s ensure would finalize the session before they resolve.
   class TestExecutor extends Executor {}
   AsynchronousQueriesTracker.installExecutorHooks(TestExecutor);
 

--- a/packages/activerecord/src/future-result.trails.test.ts
+++ b/packages/activerecord/src/future-result.trails.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Result } from "./result.js";
 import { FutureResult, Complete, type FutureResultConnection } from "./future-result.js";
 import { AsynchronousQueriesTracker } from "./asynchronous-queries-tracker.js";
@@ -6,6 +6,7 @@ import { ActiveRecord } from "./ar-config.js";
 import { DatabaseStatements, select } from "./connection-adapters/abstract/database-statements.js";
 import { AsynchronousQueryInsideTransactionError, RangeError as ARRangeError } from "./errors.js";
 import { RangeError as ActiveModelRangeError } from "@blazetrails/activemodel";
+import { Executor, type CompletableExecution } from "@blazetrails/activesupport";
 
 // Rails' own load_async_test.rb / asynchronous_queries_test.rb stay excluded
 // (scripts/parity/unported-files/unscoped.ts): every live test class there
@@ -146,7 +147,22 @@ describe("AsynchronousQueriesTracker", () => {
 });
 
 describe("DatabaseStatements#select", () => {
+  // The async arm reads `Base.asynchronous_queries_session`, which only exists
+  // inside an execution — Rails' railtie installs the tracker's hooks on
+  // `ActiveSupport::Executor` (railtie.rb) and every request runs inside one.
+  // `run!`/`complete!` rather than `wrap` because the bodies below are async and
+  // `wrap`'s ensure would finalize the session before they resolve.
+  class TestExecutor extends Executor {}
+  AsynchronousQueriesTracker.installExecutorHooks(TestExecutor);
+
+  let execution: CompletableExecution;
+
+  beforeEach(() => {
+    execution = TestExecutor.runBang();
+  });
+
   afterEach(() => {
+    execution.completeBang();
     ActiveRecord.asyncQueryExecutor = null;
   });
 

--- a/packages/activerecord/src/query-cache.ts
+++ b/packages/activerecord/src/query-cache.ts
@@ -11,6 +11,7 @@
 
 // Import under the qualified TS name so the public surface doesn't leak the
 // generic `Store` symbol into the generated `.d.ts`.
+import { Executor } from "@blazetrails/activesupport";
 import { Store as QueryCacheStore } from "./connection-adapters/abstract/query-cache.js";
 import type { Base } from "./base.js";
 
@@ -91,17 +92,16 @@ export class QueryCache {
    * Mirrors: ActiveRecord::QueryCache.install_executor_hooks
    */
   static installExecutorHooks(
-    executor?: {
+    executor: {
       registerHook(hook: {
         run(): (QueryCacheRunTarget & QueryCacheCompleteTarget)[];
         complete(pools: QueryCacheCompleteTarget[]): void;
       }): void;
-    },
+    } = Executor,
     targets:
       | (QueryCacheRunTarget & QueryCacheCompleteTarget)[]
       | (() => (QueryCacheRunTarget & QueryCacheCompleteTarget)[]) = [],
   ): void {
-    if (!executor) return;
     const resolve = typeof targets === "function" ? targets : () => targets;
 
     // Mirrors Rails' ExecutorHooks module with static run/complete. Rails'

--- a/packages/activerecord/src/trailtie.test.ts
+++ b/packages/activerecord/src/trailtie.test.ts
@@ -11,6 +11,8 @@ import { installExtendedQueriesIfConfigured } from "./encryption/install.js";
 import { UniquenessValidator } from "./validations.js";
 import { deprecator } from "./deprecator.js";
 import { ActiveRecord } from "./ar-config.js";
+import { Executor } from "@blazetrails/activesupport";
+import { asynchronousQueriesTracker } from "./core.js";
 
 const { deprecators } = BaseRailtie;
 
@@ -173,6 +175,22 @@ describe("RailtieTest", () => {
     runLoadHooks("active_record", Base);
 
     expect(ExtendedDeterministicUniquenessValidator.installed).toBe(false);
+  });
+
+  it("runInitializers installs the executor hooks that open an async query session", () => {
+    Trailtie.runInitializers();
+
+    expect(() => asynchronousQueriesTracker().currentSession).toThrow(
+      "Can't perform asynchronous queries without a query session",
+    );
+
+    Executor.wrap(() => {
+      expect(asynchronousQueriesTracker().currentSession.active()).toBe(true);
+    });
+
+    expect(() => asynchronousQueriesTracker().currentSession).toThrow(
+      "Can't perform asynchronous queries without a query session",
+    );
   });
 
   it("load_defaults: partial_inserts is true without any version load", () => {

--- a/packages/activerecord/src/trailtie.ts
+++ b/packages/activerecord/src/trailtie.ts
@@ -229,16 +229,6 @@ export class Trailtie extends BaseRailtie {
       }
     });
 
-    this.initializer("active_record.set_executor_hooks", () => {
-      QueryCache.installExecutorHooks(Executor, () => {
-        const pools: ConnectionPool[] = [];
-        Base.connectionHandler.eachConnectionPool((pool) => pools.push(pool));
-        return pools;
-      });
-      AsynchronousQueriesTracker.installExecutorHooks();
-      ConnectionPool.installExecutorHooks(Executor);
-    });
-
     this.initializer("active_record.set_configs", () => {
       // Rails' `active_record.set_configs` initializer copies each
       // `config.active_record.x` entry into the matching `ActiveRecord.x=`
@@ -252,6 +242,16 @@ export class Trailtie extends BaseRailtie {
       ActiveRecord.belongsToRequiredValidatesForeignKey = cfg.belongsToRequiredValidatesForeignKey;
       ActiveRecord.generateSecureTokenOn = cfg.generateSecureTokenOn;
       ActiveRecord.queues = cfg.queues;
+    });
+
+    this.initializer("active_record.set_executor_hooks", () => {
+      QueryCache.installExecutorHooks(Executor, () => {
+        const pools: ConnectionPool[] = [];
+        Base.connectionHandler.eachConnectionPool((pool) => pools.push(pool));
+        return pools;
+      });
+      AsynchronousQueriesTracker.installExecutorHooks();
+      ConnectionPool.installExecutorHooks();
     });
 
     this.initializer("active_record_encryption.configuration", () => {

--- a/packages/activerecord/src/trailtie.ts
+++ b/packages/activerecord/src/trailtie.ts
@@ -16,7 +16,7 @@
  *
  * Unported targets (rake tasks, console/runner hooks, migration_error
  * middleware insertion, set_configs setter-dispatch loop, set_reloader_hooks,
- * set_executor_hooks, watchable_files, log_runtime subscriber,
+ * watchable_files, log_runtime subscriber,
  * clear_active_connections, set_filter_attributes,
  * set_signed_id_verifier_secret, logger, backtrace_cleaner) are intentionally
  * left out for now — they each depend on either an Application-instance
@@ -24,8 +24,16 @@
  * supply) or on Trails-level infrastructure that has not yet been ported.
  * See docs/trailties-plan.md PR 2.7 follow-ups.
  */
-import { onLoad, Railtie as BaseRailtie, registerRailtie } from "@blazetrails/activesupport";
+import {
+  Executor,
+  onLoad,
+  Railtie as BaseRailtie,
+  registerRailtie,
+} from "@blazetrails/activesupport";
+import { AsynchronousQueriesTracker } from "./asynchronous-queries-tracker.js";
 import { Base } from "./base.js";
+import { ConnectionPool } from "./connection-adapters/abstract/connection-pool.js";
+import { QueryCache } from "./query-cache.js";
 import { Configurable as EncryptionConfigurable } from "./encryption/configurable.js";
 import { installExtendedQueriesIfConfigured } from "./encryption/install.js";
 import { SchemaReflection } from "./connection-adapters/schema-cache.js";
@@ -219,6 +227,16 @@ export class Trailtie extends BaseRailtie {
       if (cfg.postgresqlAdapterDecodeDates) {
         onLoad("active_record_postgresqladapter", { once: true }, setPostgresqlDecodeDates);
       }
+    });
+
+    this.initializer("active_record.set_executor_hooks", () => {
+      QueryCache.installExecutorHooks(Executor, () => {
+        const pools: ConnectionPool[] = [];
+        Base.connectionHandler.eachConnectionPool((pool) => pools.push(pool));
+        return pools;
+      });
+      AsynchronousQueriesTracker.installExecutorHooks();
+      ConnectionPool.installExecutorHooks(Executor);
     });
 
     this.initializer("active_record.set_configs", () => {

--- a/packages/activesupport/src/execution-wrapper.ts
+++ b/packages/activesupport/src/execution-wrapper.ts
@@ -26,6 +26,12 @@ export interface CompletableExecution {
 }
 
 export class ExecutionWrapper {
+  /** Mirrors Ruby's nested `ExecutionWrapper::RunHook`. */
+  static RunHook: typeof RunHook;
+
+  /** Mirrors Ruby's nested `ExecutionWrapper::CompleteHook`. */
+  static CompleteHook: typeof CompleteHook;
+
   /** Mirrors: `Null = Object.new` / `def Null.complete!` (execution_wrapper.rb:9-11). */
   static Null: CompletableExecution = {
     completeBang(): void {},
@@ -37,8 +43,9 @@ export class ExecutionWrapper {
   }
 
   /**
-   * `@active_key ||= :"active_execution_wrapper_#{object_id}"` keys the store
-   * per class; a fresh Symbol is the TS spelling of an object-id-derived key.
+   * Backs {@link ExecutionWrapper.activeKey}. Ruby memoizes
+   * `:"active_execution_wrapper_#{object_id}"` per class; a fresh Symbol is the
+   * TS spelling of an object-id-derived key.
    */
   static _activeKey?: symbol;
 
@@ -79,11 +86,13 @@ export class ExecutionWrapper {
    * after the work has been performed.
    *
    * Where possible, prefer +wrap+.
+   *
+   * Ruby's `IsolatedExecutionState.delete` returns the deleted value; trails'
+   * returns a boolean, so the `reset:` arm reads the lost instance before
+   * deleting it rather than in one call.
    */
   static runBang({ reset = false }: { reset?: boolean } = {}): CompletableExecution {
     if (reset) {
-      // Ruby's `Hash#delete` returns the deleted value; trails' returns a
-      // boolean, so the read has to precede the delete.
       const lostInstance = IsolatedExecutionState.get<CompletableExecution>(this.activeKey());
       IsolatedExecutionState.delete(this.activeKey());
       lostInstance?.completeBang();
@@ -102,7 +111,12 @@ export class ExecutionWrapper {
     return instance;
   }
 
-  /** Perform the work in the supplied block as an execution. */
+  /**
+   * Perform the work in the supplied block as an execution.
+   *
+   * Ruby takes `source:` as a keyword and the work as a trailing block; TS has
+   * no block argument, so the block leads and the keywords follow it.
+   */
   static wrap<T>(block: () => T, { source = "application.active_support" } = {}): T {
     if (this.active()) return block();
 
@@ -182,7 +196,7 @@ export class ExecutionWrapper {
 
 /** Mirrors: `RunHook = Struct.new(:hook)` (execution_wrapper.rb:25-30). */
 export class RunHook {
-  /** Lets an instance satisfy {@link CallbackObject}, the ObjectCall filter shape. */
+  /** Lets an instance satisfy `CallbackObject`, the ObjectCall filter shape. */
   [key: string]: unknown;
 
   constructor(readonly hook: ExecutionHook) {}
@@ -195,7 +209,7 @@ export class RunHook {
 
 /** Mirrors: `CompleteHook = Struct.new(:hook)` (execution_wrapper.rb:32-39). */
 export class CompleteHook {
-  /** Lets an instance satisfy {@link CallbackObject}, the ObjectCall filter shape. */
+  /** Lets an instance satisfy `CallbackObject`, the ObjectCall filter shape. */
   [key: string]: unknown;
 
   constructor(readonly hook: ExecutionHook) {}
@@ -211,3 +225,6 @@ export class CompleteHook {
     this.before(target);
   }
 }
+
+ExecutionWrapper.RunHook = RunHook;
+ExecutionWrapper.CompleteHook = CompleteHook;

--- a/packages/activesupport/src/execution-wrapper.ts
+++ b/packages/activesupport/src/execution-wrapper.ts
@@ -1,0 +1,213 @@
+/**
+ * Port of `ActiveSupport::ExecutionWrapper`
+ * (activesupport/lib/active_support/execution_wrapper.rb).
+ *
+ * @internal
+ */
+
+import { currentErrorReporter } from "./error-reporter.js";
+import type { ErrorReporter } from "./error-reporter.js";
+import { defineCallbacks, runCallbacks, setCallback } from "./callbacks.js";
+import type { FilterListEntry } from "./callbacks.js";
+import { IsolatedExecutionState } from "./isolated-execution-state.js";
+
+/**
+ * The `run`/`complete` pair `register_hook` threads state between
+ * (execution_wrapper.rb:41-48). `complete` is handed whatever `run` returned.
+ */
+export interface ExecutionHook {
+  run(): unknown;
+  complete(state: unknown): void;
+}
+
+/** What `run!` returns: either an instance or {@link ExecutionWrapper.Null}. */
+export interface CompletableExecution {
+  completeBang(): void;
+}
+
+export class ExecutionWrapper {
+  /** Mirrors: `Null = Object.new` / `def Null.complete!` (execution_wrapper.rb:9-11). */
+  static Null: CompletableExecution = {
+    completeBang(): void {},
+  };
+
+  static {
+    defineCallbacks(this.prototype, "run");
+    defineCallbacks(this.prototype, "complete");
+  }
+
+  /**
+   * `@active_key ||= :"active_execution_wrapper_#{object_id}"` keys the store
+   * per class; a fresh Symbol is the TS spelling of an object-id-derived key.
+   */
+  static _activeKey?: symbol;
+
+  #_hookState?: Map<ExecutionHook, unknown>;
+
+  static toRun(...args: FilterListEntry[]): void {
+    setCallback(this.prototype, "run", ...args);
+  }
+
+  static toComplete(...args: FilterListEntry[]): void {
+    setCallback(this.prototype, "complete", ...args);
+  }
+
+  /**
+   * Register an object to be invoked during both the +run+ and
+   * +complete+ steps.
+   *
+   * +hook.complete+ will be passed the value returned from +hook.run+,
+   * and will only be invoked if +run+ has previously been called.
+   * (Mostly, this means it won't be invoked if an exception occurs in
+   * a preceding +to_run+ block; all ordinary +to_complete+ blocks are
+   * invoked in that situation.)
+   */
+  static registerHook(hook: ExecutionHook, { outer = false }: { outer?: boolean } = {}): void {
+    if (outer) {
+      this.toRun(new RunHook(hook), { prepend: true });
+      this.toComplete("after", new CompleteHook(hook));
+    } else {
+      this.toRun(new RunHook(hook));
+      this.toComplete(new CompleteHook(hook));
+    }
+  }
+
+  /**
+   * Run this execution.
+   *
+   * Returns an instance, whose +complete!+ method *must* be invoked
+   * after the work has been performed.
+   *
+   * Where possible, prefer +wrap+.
+   */
+  static runBang({ reset = false }: { reset?: boolean } = {}): CompletableExecution {
+    if (reset) {
+      // Ruby's `Hash#delete` returns the deleted value; trails' returns a
+      // boolean, so the read has to precede the delete.
+      const lostInstance = IsolatedExecutionState.get<CompletableExecution>(this.activeKey());
+      IsolatedExecutionState.delete(this.activeKey());
+      lostInstance?.completeBang();
+    } else {
+      if (this.active()) return this.Null;
+    }
+
+    const instance = new this();
+    let success = null;
+    try {
+      instance.runBang();
+      success = true;
+    } finally {
+      if (success == null) instance.completeBang();
+    }
+    return instance;
+  }
+
+  /** Perform the work in the supplied block as an execution. */
+  static wrap<T>(block: () => T, { source = "application.active_support" } = {}): T {
+    if (this.active()) return block();
+
+    const instance = this.runBang();
+    try {
+      return block();
+    } catch (error) {
+      this.errorReporter().report(error as Error, { handled: false, source });
+      throw error;
+    } finally {
+      instance.completeBang();
+    }
+  }
+
+  static perform<T>(block: () => T): T {
+    const instance = new this();
+    instance.run();
+    try {
+      return block();
+    } finally {
+      instance.complete();
+    }
+  }
+
+  static errorReporter(): ErrorReporter {
+    return currentErrorReporter;
+  }
+
+  static activeKey(): symbol {
+    if (!Object.prototype.hasOwnProperty.call(this, "_activeKey")) {
+      this._activeKey = Symbol("active_execution_wrapper");
+    }
+    return this._activeKey as symbol;
+  }
+
+  static active(): boolean {
+    return IsolatedExecutionState.has(this.activeKey());
+  }
+
+  runBang(): void {
+    const klass = this.constructor as typeof ExecutionWrapper;
+    IsolatedExecutionState.set(klass.activeKey(), this);
+    this.run();
+  }
+
+  run(): void {
+    runCallbacks(this, "run");
+  }
+
+  /**
+   * Complete this in-flight execution. This method *must* be called
+   * exactly once on the result of any call to +run!+.
+   *
+   * Where possible, prefer +wrap+.
+   */
+  completeBang(): void {
+    try {
+      this.complete();
+    } finally {
+      IsolatedExecutionState.delete((this.constructor as typeof ExecutionWrapper).activeKey());
+    }
+  }
+
+  complete(): void {
+    runCallbacks(this, "complete");
+  }
+
+  /**
+   * Ruby private; reached from the hooks below via `target.send(:hook_state)`.
+   *
+   * @internal
+   */
+  hookState(): Map<ExecutionHook, unknown> {
+    return (this.#_hookState ??= new Map());
+  }
+}
+
+/** Mirrors: `RunHook = Struct.new(:hook)` (execution_wrapper.rb:25-30). */
+export class RunHook {
+  /** Lets an instance satisfy {@link CallbackObject}, the ObjectCall filter shape. */
+  [key: string]: unknown;
+
+  constructor(readonly hook: ExecutionHook) {}
+
+  before(target: ExecutionWrapper): void {
+    const hookState = target.hookState();
+    hookState.set(this.hook, this.hook.run());
+  }
+}
+
+/** Mirrors: `CompleteHook = Struct.new(:hook)` (execution_wrapper.rb:32-39). */
+export class CompleteHook {
+  /** Lets an instance satisfy {@link CallbackObject}, the ObjectCall filter shape. */
+  [key: string]: unknown;
+
+  constructor(readonly hook: ExecutionHook) {}
+
+  before(target: ExecutionWrapper): void {
+    const hookState = target.hookState();
+    if (hookState.has(this.hook)) {
+      this.hook.complete(hookState.get(this.hook));
+    }
+  }
+
+  after(target: ExecutionWrapper): void {
+    this.before(target);
+  }
+}

--- a/packages/activesupport/src/executor.test.ts
+++ b/packages/activesupport/src/executor.test.ts
@@ -1,164 +1,265 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
+import { Executor } from "./executor.js";
+import { ActiveSupport } from "./index.js";
+import { ErrorReporter } from "./error-reporter.js";
+
+class DummyError extends Error {}
+
+class ErrorSubscriber {
+  readonly events: unknown[][] = [];
+
+  report(
+    error: Error,
+    {
+      handled,
+      severity,
+      source,
+      context,
+    }: { handled: boolean; severity: string; source: string; context: object },
+  ): void {
+    this.events.push([error, handled, severity, source, context]);
+  }
+}
 
 describe("ExecutorTest", () => {
-  // Simple Executor implementation for testing
-  class Executor {
-    private hooks: Array<{ run: () => unknown; complete?: (state: unknown) => void }> = [];
+  let executor: typeof Executor;
 
-    register(hook: { run: () => unknown; complete?: (state: unknown) => void }) {
-      this.hooks.push(hook);
-    }
-
-    wrap<T>(fn: () => T): T {
-      const states = this.hooks.map((h) => h.run());
-      try {
-        return fn();
-      } finally {
-        this.hooks.forEach((h, i) => h.complete?.(states[i]));
-      }
-    }
-  }
+  beforeEach(() => {
+    executor = class extends Executor {};
+  });
 
   it("wrap report errors", () => {
-    const executor = new Executor();
-    const errors: Error[] = [];
-    executor.register({
-      run: () => null,
-      complete: () => {},
-    });
-    expect(() =>
-      executor.wrap(() => {
-        throw new Error("test error");
-      }),
-    ).toThrow("test error");
+    const previousReporter = ActiveSupport.errorReporter;
+    ActiveSupport.errorReporter = new ErrorReporter();
+    try {
+      const subscriber = new ErrorSubscriber();
+      executor.errorReporter().subscribe(subscriber);
+      let error = new DummyError("Oops");
+      expect(() =>
+        executor.wrap(() => {
+          throw error;
+        }),
+      ).toThrow(DummyError);
+      expect(subscriber.events[subscriber.events.length - 1]).toEqual([
+        error,
+        false,
+        "error",
+        "application.active_support",
+        {},
+      ]);
+
+      error = new DummyError("Oops");
+      expect(() =>
+        executor.wrap(
+          () => {
+            throw error;
+          },
+          { source: "custom" },
+        ),
+      ).toThrow(DummyError);
+      expect(subscriber.events[subscriber.events.length - 1]).toEqual([
+        error,
+        false,
+        "error",
+        "custom",
+        {},
+      ]);
+    } finally {
+      ActiveSupport.errorReporter = previousReporter;
+    }
   });
 
   it("wrap invokes callbacks", () => {
-    const executor = new Executor();
-    const log: string[] = [];
-    executor.register({
-      run: () => {
-        log.push("run");
-      },
-      complete: () => {
-        log.push("complete");
-      },
+    const called: string[] = [];
+    executor.toRun(() => called.push("run"));
+    executor.toComplete(() => called.push("complete"));
+
+    executor.wrap(() => {
+      called.push("body");
     });
-    executor.wrap(() => {});
-    expect(log).toEqual(["run", "complete"]);
+
+    expect(called).toEqual(["run", "body", "complete"]);
   });
 
   it("callbacks share state", () => {
-    const executor = new Executor();
-    let shared = 0;
-    executor.register({
-      run: () => {
-        shared = 1;
-        return shared;
-      },
-      complete: (state) => {
-        shared = (state as number) + 1;
-      },
-    });
+    let result = false;
+    executor.toRun((target: object) => ((target as { foo?: boolean }).foo = true));
+    executor.toComplete((target: object) => (result = (target as { foo?: boolean }).foo === true));
+
     executor.wrap(() => {});
-    expect(shared).toBe(2);
+
+    expect(result).toBe(true);
   });
 
   it("separated calls invoke callbacks", () => {
-    const executor = new Executor();
-    const calls: string[] = [];
-    executor.register({ run: () => calls.push("run"), complete: () => calls.push("complete") });
-    executor.wrap(() => {});
-    executor.wrap(() => {});
-    expect(calls).toEqual(["run", "complete", "run", "complete"]);
+    const called: string[] = [];
+    executor.toRun(() => called.push("run"));
+    executor.toComplete(() => called.push("complete"));
+
+    const state = executor.runBang();
+    called.push("body");
+    state.completeBang();
+
+    expect(called).toEqual(["run", "body", "complete"]);
   });
 
   it("exceptions unwind", () => {
-    const executor = new Executor();
-    const log: string[] = [];
-    executor.register({ run: () => log.push("start"), complete: () => log.push("end") });
-    expect(() =>
-      executor.wrap(() => {
-        throw new Error("boom");
-      }),
-    ).toThrow();
-    expect(log).toEqual(["start", "end"]);
+    const called: string[] = [];
+    executor.toRun(() => called.push("run_1"));
+    executor.toRun(() => {
+      throw new DummyError();
+    });
+    executor.toRun(() => called.push("run_2"));
+    executor.toComplete(() => called.push("complete"));
+
+    expect(() => executor.wrap(() => called.push("body"))).toThrow(DummyError);
+
+    expect(called).toEqual(["run_1", "complete"]);
   });
 
   it("avoids double wrapping", () => {
-    const executor = new Executor();
-    let count = 0;
-    executor.register({ run: () => count++, complete: () => {} });
-    executor.wrap(() => {});
-    expect(count).toBe(1);
+    const called: string[] = [];
+    executor.toRun(() => called.push("run"));
+    executor.toComplete(() => called.push("complete"));
+
+    executor.wrap(() => {
+      called.push("early");
+      executor.wrap(() => {
+        called.push("body");
+      });
+      called.push("late");
+    });
+
+    expect(called).toEqual(["run", "early", "body", "late", "complete"]);
   });
 
   it("hooks carry state", () => {
-    const executor = new Executor();
-    const states: unknown[] = [];
-    executor.register({
-      run: () => ({ value: 42 }),
-      complete: (state) => states.push(state),
-    });
+    let suppliedState: unknown = "none";
+
+    const hook = {
+      run: () => "some_state",
+      complete: (state: unknown) => {
+        suppliedState = state;
+      },
+    };
+
+    executor.registerHook(hook);
+
     executor.wrap(() => {});
-    expect(states[0]).toEqual({ value: 42 });
+
+    expect(suppliedState).toBe("some_state");
   });
 
   it("nil state is sufficient", () => {
-    const executor = new Executor();
-    executor.register({ run: () => null, complete: () => {} });
-    expect(() => executor.wrap(() => {})).not.toThrow();
+    let suppliedState: unknown = "none";
+
+    const hook = {
+      run: () => null,
+      complete: (state: unknown) => {
+        suppliedState = state;
+      },
+    };
+
+    executor.registerHook(hook);
+
+    executor.wrap(() => {});
+
+    expect(suppliedState).toBeNull();
   });
 
   it("exception skips uninvoked hook", () => {
-    const executor = new Executor();
-    let completed = false;
-    executor.register({
-      run: () => {
-        throw new Error("hook failed");
+    let suppliedState: unknown = "none";
+
+    const hook = {
+      run: () => "some_state",
+      complete: (state: unknown) => {
+        suppliedState = state;
       },
-      complete: () => {
-        completed = true;
-      },
+    };
+
+    executor.toRun(() => {
+      throw new DummyError();
     });
-    expect(() => executor.wrap(() => {})).toThrow();
-    expect(completed).toBe(false);
+    executor.registerHook(hook);
+
+    expect(() => executor.wrap(() => {})).toThrow(DummyError);
+
+    expect(suppliedState).toBe("none");
   });
 
   it("exception unwinds invoked hook", () => {
-    const executor = new Executor();
-    let completedA = false;
-    executor.register({
-      run: () => {},
-      complete: () => {
-        completedA = true;
+    let suppliedState: unknown = "none";
+
+    const hook = {
+      run: () => "some_state",
+      complete: (state: unknown) => {
+        suppliedState = state;
       },
+    };
+
+    executor.registerHook(hook);
+    executor.toRun(() => {
+      throw new DummyError();
     });
-    expect(() =>
-      executor.wrap(() => {
-        throw new Error("work failed");
-      }),
-    ).toThrow();
-    expect(completedA).toBe(true);
+
+    expect(() => executor.wrap(() => {})).toThrow(DummyError);
+
+    expect(suppliedState).toBe("some_state");
   });
 
   it("hook insertion order", () => {
-    const executor = new Executor();
-    const log: string[] = [];
-    executor.register({ run: () => log.push("A"), complete: () => {} });
-    executor.register({ run: () => log.push("B"), complete: () => {} });
+    const invoked: string[] = [];
+    const suppliedState: unknown[] = [];
+
+    class HookClass {
+      constructor(readonly letter: string) {}
+
+      run(): string {
+        invoked.push(`run_${this.letter}`);
+        return `state_${this.letter}`;
+      }
+
+      complete(state: unknown): void {
+        invoked.push(`complete_${this.letter}`);
+        suppliedState.push(state);
+      }
+    }
+
+    executor.registerHook(new HookClass("a"));
+    executor.registerHook(new HookClass("b"));
+    executor.registerHook(new HookClass("c"), { outer: true });
+    executor.registerHook(new HookClass("d"));
+
     executor.wrap(() => {});
-    expect(log).toEqual(["A", "B"]);
+
+    expect(invoked).toEqual([
+      "run_c",
+      "run_a",
+      "run_b",
+      "run_d",
+      "complete_a",
+      "complete_b",
+      "complete_d",
+      "complete_c",
+    ]);
+    expect(suppliedState).toEqual(["state_a", "state_b", "state_d", "state_c"]);
   });
 
   it("separate classes can wrap", () => {
-    const e1 = new Executor();
-    const e2 = new Executor();
-    const log: string[] = [];
-    e1.register({ run: () => log.push("e1"), complete: () => {} });
-    e2.register({ run: () => log.push("e2"), complete: () => {} });
-    e1.wrap(() => {});
-    e2.wrap(() => {});
-    expect(log).toEqual(["e1", "e2"]);
+    const otherExecutor = class extends Executor {};
+
+    const called: string[] = [];
+    executor.toRun(() => called.push("run"));
+    executor.toComplete(() => called.push("complete"));
+    otherExecutor.toRun(() => called.push("other_run"));
+    otherExecutor.toComplete(() => called.push("other_complete"));
+
+    executor.wrap(() => {
+      otherExecutor.wrap(() => {
+        called.push("body");
+      });
+    });
+
+    expect(called).toEqual(["run", "other_run", "body", "other_complete", "complete"]);
   });
 });

--- a/packages/activesupport/src/executor.ts
+++ b/packages/activesupport/src/executor.ts
@@ -1,0 +1,9 @@
+/**
+ * Port of `ActiveSupport::Executor` (activesupport/lib/active_support/executor.rb).
+ *
+ * @internal
+ */
+
+import { ExecutionWrapper } from "./execution-wrapper.js";
+
+export class Executor extends ExecutionWrapper {}

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -535,6 +535,14 @@ export { EnvironmentInquirer } from "./environment-inquirer.js";
 export { Reloader, type PrepareCallback } from "./reloader.js";
 export { getEnv } from "./environment.js";
 export { ExecutionContext } from "./execution-context.js";
+export {
+  ExecutionWrapper,
+  RunHook,
+  CompleteHook,
+  type ExecutionHook,
+  type CompletableExecution,
+} from "./execution-wrapper.js";
+export { Executor } from "./executor.js";
 export { objectWith } from "./core-ext/object/with.js";
 export { withOptions } from "./core-ext/object/with-options.js";
 export { OptionMerger } from "./option-merger.js";

--- a/packages/activesupport/src/reloader.ts
+++ b/packages/activesupport/src/reloader.ts
@@ -4,11 +4,10 @@
  *
  * Only the `:prepare` callback surface is ported — `to_prepare` /
  * `prepare!` (reloader.rb:34-36, :95-97) are what `Rails::Application`'s
- * finisher initializers drive. The `ExecutionWrapper` superclass and the
- * `:class_unload` callbacks, `wrap`, `run!`, `complete!`, `check!`,
- * `reload!` and the interlock locking depend on
- * `ActiveSupport::ExecutionWrapper` / `Dependencies::Interlock`, neither of
- * which is ported yet.
+ * finisher initializers drive. The `:class_unload` callbacks, `wrap`, `run!`,
+ * `complete!`, `check!`, `reload!` and the interlock locking are still
+ * unported; `ActiveSupport::ExecutionWrapper` now is, so extending it is
+ * tracked by `converge-reloader-onto-execution-wrapper`.
  */
 import { defineCallbacks, runCallbacks, setCallback } from "./callbacks.js";
 

--- a/scripts/parity/unported-files/activesupport.ts
+++ b/scripts/parity/unported-files/activesupport.ts
@@ -130,12 +130,6 @@ export const ACTIVESUPPORT_UNPORTED_FILES: UnportedFile[] = [
       "outside the AR/AM require closure; deferred until an actionpack/railties port needs it.",
   },
   {
-    pattern: "execution_wrapper.rb",
-    package: "activesupport",
-    reason:
-      "outside the AR/AM require closure; deferred until an actionpack/railties port needs it.",
-  },
-  {
     pattern: "/file_update_checker.rb",
     testFile: "/file_update_checker_test.rb",
     package: "activesupport",


### PR DESCRIPTION
Ports `ActiveSupport::ExecutionWrapper` and `ActiveSupport::Executor`, then
ports `AsynchronousQueriesTracker.install_executor_hooks` on top of them and
retires the session-priming deviation PR #6515 left in `core.ts`.

## What landed

- **`packages/activesupport/src/execution-wrapper.ts`** — port of
  `activesupport/lib/active_support/execution_wrapper.rb`: `Null`, `to_run`,
  `to_complete`, the nested `RunHook` / `CompleteHook`,
  `register_hook(hook, outer:)`, `run!(reset:)`, `wrap(source:)`, `perform`,
  `error_reporter`, `active_key`, `active?`, instance
  `run!` / `run` / `complete!` / `complete`, and the private `hook_state`. The
  `:run` / `:complete` chains are trails' `defineCallbacks` / `setCallback` /
  `runCallbacks`, and the hooks are ordinary callback objects, exactly as Rails
  compiles the `RunHook`/`CompleteHook` Structs. `parity:api --missing` reports
  the file at 15/16 — the one unmatched name is the Callbacks-generated
  `__callbacks` accessor — and its `unported-files` entry is removed.
- **`packages/activesupport/src/executor.ts`** — `class Executor extends
  ExecutionWrapper {}` (executor.rb:5-7).
- **`AsynchronousQueriesTracker.installExecutorHooks`**
  (`asynchronous_queries_tracker.rb:32-34`) — `executor.registerHook(this)`,
  defaulting to `ActiveSupport::Executor`. `pnpm parity:api --package
  activerecord --missing` now reports `asynchronous_queries_tracker.rb` at
  **7/7**.
- **`core.ts`** — the `asynchronousQueriesTracker` initializer returns a bare
  `new AsynchronousQueriesTracker()` as Rails does (`core.rb:145-148`). The
  `startSession()` call #6515 added because there was no executor to register
  with is gone; the run hook pushes the session now.
- **`executor.test.ts`** — was a local stub `Executor` class asserting against
  itself. It now drives the ported `Executor`, so all 12 of Rails'
  `executor_test.rb` tests (names unchanged) actually exercise the port —
  including `hook insertion order`, which pins the `outer: true`
  prepend / `:after` ordering.
- **`future-result.trails.test.ts`** — the `DatabaseStatements#select` describe
  installs the tracker's hooks on a local `Executor` subclass and brackets each
  test with `run!` / `complete!`, which is where the async `select` arm's
  session comes from at runtime (Rails' railtie installs the same hooks on
  `ActiveSupport::Executor`). `run!` / `complete!` rather than `wrap` because
  those bodies are async and `wrap`'s ensure would finalize the session before
  they resolve.

## Deviations

Two, both language-forced and cited in JSDoc at the definition:

- `wrap(block, { source })` — Ruby takes `source:` as a keyword and the work as
  a trailing block; TS has no block argument, so the block leads.
- `run!(reset: true)` reads the lost instance before deleting it. Ruby's
  `IsolatedExecutionState.delete` returns the deleted value; trails' returns a
  boolean.

`active_key`'s `object_id`-derived Symbol becomes a per-class `Symbol()`, and
Ruby-private `hook_state` stays visible because TS has no `send`.

## Follow-up

`ActiveSupport::Reloader` is `Reloader < ExecutionWrapper` (reloader.rb:8) but
trails' `Reloader` is a bare class porting only the `:prepare` chain. Its file
comment blamed the unported superclass, which is no longer true — the comment
is corrected and the convergence is filed as
`converge-reloader-onto-execution-wrapper` (RFC 0099) rather than widened into
this PR.

## Review round 1

**"Nothing installs the executor hooks outside tests"** — fixed, in the half that
was actually missing, and justified in the half that is Rails' own behaviour.

*Fixed:* `active_record.set_executor_hooks` (`railtie.rb:288-292`) is now ported
into `trailtie.ts`, calling `QueryCache`, `AsynchronousQueriesTracker` and
`ConnectionAdapters::ConnectionPool`'s `installExecutorHooks` in Rails' order.
That initializer was on trailtie.ts's "unported targets" list *because*
`ActiveSupport::Executor` did not exist; this PR is what unblocks it, so it
belongs here rather than in a follow-up. `trailtie.test.ts` gains a test that
boots the initializers and asserts a real `Executor.wrap` opens and finalizes a
session on `Base.asynchronousQueriesTracker` — it fails on the baseline with the
`AsynchronousQueriesTracker.installExecutorHooks()` line removed.

*Not a regression:* the remaining half — something calling `Executor.wrap` /
`run!` around each unit of work — is `ActionDispatch::Executor` (actionpack) and
ActiveJob's wrapping, neither of which trails has ported. Rails behaves
identically without them: `core.rb:145-148` builds a bare tracker, and
`current_session` (`asynchronous_queries_tracker.rb:44`) raises `Can't perform
asynchronous queries without a query session` for any standalone ActiveRecord
user who calls `load_async` outside an execution. Priming a session in
`asynchronousQueriesTracker` is precisely the deviation AC3 asks this PR to
retire, so restoring it to paper over the missing framework layer would close
the story by re-introducing what it exists to remove. Filed as
`port-executor-wrapping-around-a-unit-of-work` (RFC 0099), whose AC3 explicitly
forbids that regression as the escape hatch.

One deviation surfaced while wiring the initializer and is filed, not
propagated further: trails' `QueryCache.installExecutorHooks(executor?, targets)`
diverges from `query_cache.rb:51-53`'s `(executor = ActiveSupport::Executor)`
(and its `run` takes the pool list rather than reading
`connection_handler.each_connection_pool` as `query_cache.rb:37-42` does), which
is why that one line has to build the pool list by hand where the other two are
Rails' bare calls. Converging it is
`converge-query-cache-install-executor-hooks-signature` (RFC 0099).

## Review round 2

**Initializer ordering** — fixed. `active_record.set_executor_hooks` now sits
after `active_record.set_configs` and before
`active_record_encryption.configuration`, which is Rails' relative order among
the initializers trails has ported (`railtie.rb`: `set_configs` 207,
`set_executor_hooks` 288, encryption config 336); `initialize_database`,
`log_runtime` and `set_reloader_hooks` are the unported gaps in between.

**Bare calls (non-blocking note)** — taken, and it exposed a real divergence
rather than a style choice. Two of the three could not be called bare because
trails' installers had no default: `ConnectionPool.installExecutorHooks` took
`executor?` and *silently no-oped* on a bare call (`executor?.registerHook`),
and `QueryCache.installExecutorHooks` did the same via an `if (!executor)
return` guard. Rails defaults both to `ActiveSupport::Executor`
(`connection_pool.rb:212`, `query_cache.rb:51`), so both now default to
`Executor` and drop the guard, and the trailtie calls are bare:

```ts
AsynchronousQueriesTracker.installExecutorHooks();
ConnectionPool.installExecutorHooks();
```

`QueryCache`'s call still passes `Executor` explicitly, only because its
divergent second `targets` parameter is positional — the argument cannot be
omitted while the pools resolver is supplied. That disappears with
`converge-query-cache-install-executor-hooks-signature`, which now also carries
the default-argument half.

## Verification

- `packages/activesupport/src/executor.test.ts` — 12/12
- `packages/activerecord/src/future-result.trails.test.ts` — 25/25
- plus `callbacks.test.ts`, `reloader.test.ts`, `reloader.trails.test.ts`,
  `asynchronous-queries.test.ts`, `query-cache.trails.test.ts`
- `pnpm typecheck`, `pnpm lint`, `pnpm parity:api:calls`,
  `pnpm parity:api:calls:args`, `pnpm parity:test:assertions` — all green;
  `parity:api:extra` reports 0 novel names for `execution-wrapper.ts`
- `parity:test`: `executor_test.rb` → `executor.test.ts` 12/12 ✓, no assertion
  mismatches

Closes-story: install-executor-hooks-for-async-queries-tracker


