### PR TITLE
feat(activerecord): wire load_async through the FutureResult path

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -448,10 +448,14 @@ export function makeCachedSelectAll(original: BaseSelectAll): BaseSelectAll {
         // Rails: `result = lookup_sql_cache(sql, name, binds) || super(...)`,
         // then `FutureResult.wrap(result)` (query_cache.rb:244-247). A miss is
         // NOT written back to the cache on this arm — Rails doesn't either.
+        // No per-row copy: Rails' async arm hands `lookup_sql_cache`'s result
+        // back undup'd (query_cache.rb:244 — only `cache_sql`'s write path
+        // dups, :283), and `fromRowHashes` reads each hash into fresh column
+        // arrays, so the Result never aliases the stored rows anyway.
         const cached = this.lookupSqlCache(sql, name, binds ?? []);
         const result =
           cached !== undefined
-            ? Result.fromRowHashes(cached.map((r) => ({ ...r })))
+            ? Result.fromRowHashes(cached)
             : original.call(this, sql, name, binds, forwardOpts);
         // Ruby's `super` here is either a FutureResult or a Result; trails'
         // base hands back a promise whenever the async arm isn't live (e.g.

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -6,7 +6,7 @@ import {
   type DatabaseStatementsHost,
 } from "./database-statements.js";
 import { Result } from "../../result.js";
-import type { FutureResult, Complete as FutureResultComplete } from "../../future-result.js";
+import { FutureResult, Complete as FutureResultComplete } from "../../future-result.js";
 import {
   executionContextId,
   registerContextExitHook,
@@ -387,8 +387,8 @@ export function clearQueryCache(this: QueryCacheHost): void {
  * The base (uncached) `selectAll` signature the override wraps via `super`.
  *
  * The base returns a pending `FutureResult` synchronously on the async arm
- * (database_statements.rb:74,671-694), so the union is not decorative — see
- * `makeCachedSelectAll` for why this wrapper collapses it today.
+ * (database_statements.rb:74,671-694), so the union is not decorative: the
+ * wrapper hands that handle straight back.
  */
 type BaseSelectAll = (
   this: QueryCacheHost,
@@ -413,13 +413,17 @@ type BaseSelectAll = (
  * `cache_sql(...) { super }`.
  */
 export function makeCachedSelectAll(original: BaseSelectAll): BaseSelectAll {
-  return async function cachedSelectAll(
+  // NOT an `async function`: `FutureResult#then` implements the JS thenable
+  // protocol, so an async wrapper's own promise would adopt a returned
+  // FutureResult and settle with the final Result, losing the pending handle
+  // Rails' `async` arm exists to hand back (future_result.rb:126-129).
+  return function cachedSelectAll(
     this: QueryCacheHost,
     arel: string | unknown,
     name: string | null = null,
     binds?: unknown[],
     opts?: { allowRetry?: boolean; preparable?: boolean | null; async?: boolean },
-  ): Promise<Result> {
+  ): Result | Promise<Result> | FutureResult | FutureResultComplete {
     // Rails' QueryCache#select_all first unwraps a Relation to its Arel AST
     // (`arel = arel_from_relation(arel)`), then converts the Arel node to
     // SQL + binds via `to_sql_and_binds` before consulting the cache. A SQL
@@ -440,14 +444,26 @@ export function makeCachedSelectAll(original: BaseSelectAll): BaseSelectAll {
     const forwardOpts = { ...opts, preparable: resolvedPreparable };
     const qc = this._queryCache;
     if (qc?.enabled && !LOCKED_QUERY.test(sql)) {
-      // Rails splits this by `async`: the sync path is `cache_sql { super }`
-      // (which itself tracks `hit` and instruments, query_cache.rb:283,291-296),
-      // the async path is `lookup_sql_cache(...) || super` wrapped in
-      // `FutureResult.wrap` (query_cache.rb:244-249). Only the sync shape is
-      // ported: this wrapper is an `async function`, so a FutureResult returned
-      // by the base `selectAll` would be adopted and resolved away by its own
-      // promise — story wire-load-async-through-future-result ports the async
-      // arm and the non-collapsing shape it needs. INVARIANT: there must be no `await` between this lookupSqlCache
+      if (opts?.async) {
+        // Rails: `result = lookup_sql_cache(sql, name, binds) || super(...)`,
+        // then `FutureResult.wrap(result)` (query_cache.rb:244-247). A miss is
+        // NOT written back to the cache on this arm — Rails doesn't either.
+        const cached = this.lookupSqlCache(sql, name, binds ?? []);
+        const result =
+          cached !== undefined
+            ? Result.fromRowHashes(cached.map((r) => ({ ...r })))
+            : original.call(this, sql, name, binds, forwardOpts);
+        // Ruby's `super` here is either a FutureResult or a Result; trails'
+        // base hands back a promise whenever the async arm isn't live (e.g.
+        // no async_query_executor), so that case wraps once it resolves —
+        // the same shape `select` uses (database_statements.rb:691-693).
+        return result instanceof Promise
+          ? result.then((r) => FutureResult.wrap(r))
+          : FutureResult.wrap(result);
+      }
+      // Rails' sync path is `cache_sql { super }` (query_cache.rb:249), which
+      // itself tracks `hit` and instruments (query_cache.rb:283,291-296).
+      // INVARIANT: there must be no `await` between this lookupSqlCache
       // and the cacheSql below — lookupSqlCache runs synchronously and cacheSql
       // reaches `Store.computeIfAbsent`'s synchronous `get` immediately, so
       // nothing can populate the key in between. That is why trails' cacheSql
@@ -458,18 +474,17 @@ export function makeCachedSelectAll(original: BaseSelectAll): BaseSelectAll {
       // into a silent, uninstrumented cache hit.
       const cached = this.lookupSqlCache(sql, name, binds ?? []);
       if (cached !== undefined) {
-        return Result.fromRowHashes(cached.map((r) => ({ ...r })));
+        // Resolved, not bare: Ruby's callers reach `select_all(...).then`
+        // through Kernel#then, which every object answers (database_statements
+        // .rb:85,102); a trails `Result` deliberately defines no `then`.
+        return Promise.resolve(Result.fromRowHashes(cached.map((r) => ({ ...r }))));
       }
-      const rows = await this.cacheSql(sql, name, binds ?? [], async () => {
+      return this.cacheSql(sql, name, binds ?? [], async () => {
         const result = await original.call(this, sql, name, binds, forwardOpts);
         return result.toArray();
-      });
-      return Result.fromRowHashes(rows);
+      }).then((rows) => Result.fromRowHashes(rows));
     }
-    // Rails' `else` arm is a bare `super` (query_cache.rb:251). A FutureResult
-    // the base returns here is still adopted by this async function's own
-    // promise — see the async-arm note above and story
-    // wire-load-async-through-future-result.
+    // Rails' `else` arm is a bare `super` (query_cache.rb:251).
     return original.call(this, sql, name, binds, forwardOpts);
   };
 }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1634,19 +1634,13 @@ export class PostgreSQLAdapter
    * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#perform_query
    * @internal
    */
-  performQuery(
+  declare performQuery: (
     rawConnection: pg.Client,
     sql: string,
     binds: unknown[],
     typeCastedBinds: unknown[],
     options: { prepare?: boolean; notificationPayload?: Record<string, unknown> },
-  ): Promise<pg.QueryResult> {
-    return this._performQuery(rawConnection, sql, binds, typeCastedBinds, {
-      prepare: options.prepare ?? false,
-      notificationPayload: options.notificationPayload ?? {},
-      rowMode: "array",
-    });
-  }
+  ) => Promise<pg.QueryResult>;
 
   /**
    * Dispatch the notices PG raised during the last statement, wired from the
@@ -4931,6 +4925,30 @@ dirtiesQueryCache(PostgreSQLAdapter, "execQuery", "execute");
 
 // Rails: `include PostgreSQL::SchemaStatements` (postgresql_adapter.rb:185).
 include(PostgreSQLAdapter, SchemaStatements);
+
+// Mirrors `include PostgreSQL::DatabaseStatements` — `perform_query` is an
+// instance method of the adapter, so `raw_execute`'s `this.performQuery(...)`
+// dispatch resolves here (postgresql/database_statements.rb:135), which is what
+// makes `raw_exec_query` — and so `FutureResult#exec_query` — work on PG.
+// `rowMode` is supplied because node-pg decodes a row into one shape or the
+// other before the query runs, while `cast_result` reads the positional view
+// off the `PG::Result` Rails already has (`result.values`,
+// postgresql/database_statements.rb:180). The extracted `performQuery` carries
+// the full note; its other callers pass the shape they read.
+PostgreSQLAdapter.prototype.performQuery = function (
+  this: PostgreSQLAdapter,
+  rawConnection,
+  sql,
+  binds,
+  typeCastedBinds,
+  options,
+) {
+  return pgPerformQuery.call(this as never, rawConnection, sql, binds, typeCastedBinds, {
+    prepare: options.prepare ?? false,
+    notificationPayload: options.notificationPayload ?? {},
+    rowMode: "array",
+  });
+};
 
 // Mirrors `ActiveSupport.run_load_hooks(:active_record_postgresqladapter, self)`
 // at the bottom of Rails' postgresql_adapter.rb — lets railtie initializers

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1620,6 +1620,35 @@ export class PostgreSQLAdapter
   private _performQuery = pgPerformQuery;
 
   /**
+   * `raw_execute` reaches `perform_query` through `this`
+   * (abstract/database_statements.rb:552-558), and `raw_exec_query` casts what
+   * it returns (`:541-543`) — the path `FutureResult#exec_query` runs on
+   * (future_result.rb:169-171). Rails needs no seam here because a `PG::Result`
+   * exposes both the hash and the positional view of a row, so its
+   * `cast_result` can read columns off the one object `perform_query` returns.
+   * node-pg does not: positional rows come only from `rowMode: "array"` (see
+   * the extracted `performQuery`'s note), which every trails path that builds a
+   * `Result` therefore has to ask for. This supplies it for the `raw_execute`
+   * entry; `_performQuery`'s direct callers pass their own.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#perform_query
+   * @internal
+   */
+  performQuery(
+    rawConnection: pg.Client,
+    sql: string,
+    binds: unknown[],
+    typeCastedBinds: unknown[],
+    options: { prepare?: boolean; notificationPayload?: Record<string, unknown> },
+  ): Promise<pg.QueryResult> {
+    return this._performQuery(rawConnection, sql, binds, typeCastedBinds, {
+      prepare: options.prepare ?? false,
+      notificationPayload: options.notificationPayload ?? {},
+      rowMode: "array",
+    });
+  }
+
+  /**
    * Dispatch the notices PG raised during the last statement, wired from the
    * extracted module below.
    *

--- a/packages/activerecord/src/connection-adapters/sqlite3/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/database-statements.ts
@@ -329,9 +329,18 @@ export async function performQuery(
 }
 
 /** @internal */
-export function castResult(result: Result): Result {
-  // SQLite3 already returns an ActiveRecord::Result; nothing to cast.
-  return result;
+export function castResult(result: Result | { rows: Record<string, unknown>[] }): Result {
+  // Rails' `cast_result` is the identity because its `perform_query` already
+  // returns an ActiveRecord::Result (sqlite3/database_statements.rb:110-121).
+  // trails' `performQuery` returns the raw `{ rows, affectedRows, insertRowid }`
+  // bag instead — `executeMutation` reads the last two off the RETURN value to
+  // avoid racing `this._last*` — so the identity arm only holds for the
+  // Result-shaped inputs, and the bag is built into a Result here, where Rails'
+  // perform_query builds it. Converging performQuery onto Rails' return shape
+  // (which also restores the column set of a zero-row SELECT) is story
+  // sqlite3-perform-query-returns-result.
+  if (result instanceof Result) return result;
+  return Result.fromRowHashes(result.rows);
 }
 
 /** @internal */

--- a/packages/activerecord/src/database-statements-raw-execute.trails.test.ts
+++ b/packages/activerecord/src/database-statements-raw-execute.trails.test.ts
@@ -8,27 +8,19 @@
  * sqlite3:78). Until those were wired onto the prototype, `raw_execute` fell
  * through to the abstract `NotImplementedError` stub, so the primitive was only
  * reachable through the adapters' own `execute` paths.
- *
- * PostgreSQL is excluded: its `perform_query` is still the private
- * `_performQuery`, on a trails argument list, until
- * `converge-pg-perform-query-onto-rails-arms` (RFC 0076) inlines Rails' three
- * arms there. This suite picks it up when that lands.
  */
 import { describe, it, expect } from "vitest";
 import { Base } from "./base.js";
 import { fixtures } from "./test-fixtures.js";
-import { currentAdapter } from "./support/adapter-helper.js";
 
-const wired = currentAdapter("SQLite3Adapter", "Mysql2Adapter");
-
-describe.skipIf(!wired)("DatabaseStatementsRawExecuteTest (trails)", () => {
+describe("DatabaseStatementsRawExecuteTest (trails)", () => {
   fixtures({});
 
   it("rawExecute runs a read through the adapter's performQuery", async () => {
     const connection = await Base.leaseConnection();
-    // Every adapter's perform_query yields its driver's native result, and both
-    // of ours carry the rows on `rows` — an empty array for a read that matches
-    // nothing.
+    // Every adapter's perform_query yields its driver's native result, and all
+    // three of ours carry the rows on `rows` — an empty array for a read that
+    // matches nothing.
     const result = (await (
       connection as never as { rawExecute(sql: string, name?: string): Promise<unknown> }
     ).rawExecute("SELECT credit_limit FROM accounts WHERE 1 = 0", "SQL")) as { rows: unknown[] };

--- a/packages/activerecord/src/future-result.trails.test.ts
+++ b/packages/activerecord/src/future-result.trails.test.ts
@@ -4,6 +4,7 @@ import { FutureResult, Complete, type FutureResultConnection } from "./future-re
 import { AsynchronousQueriesTracker } from "./asynchronous-queries-tracker.js";
 import { ActiveRecord } from "./ar-config.js";
 import { DatabaseStatements, select } from "./connection-adapters/abstract/database-statements.js";
+import { makeCachedSelectAll, Store } from "./connection-adapters/abstract/query-cache.js";
 import { AsynchronousQueryInsideTransactionError, RangeError as ARRangeError } from "./errors.js";
 import { RangeError as ActiveModelRangeError } from "@blazetrails/activemodel";
 
@@ -336,6 +337,74 @@ describe("DatabaseStatements#select_all", () => {
     await expect(DatabaseStatements.selectAll.call(host as never, "SELECT 1")).rejects.toThrow(
       "boom",
     );
+  });
+});
+
+describe("QueryCache#select_all", () => {
+  // query_cache.rb:243-250 splits on `async`: the async arm is
+  // `FutureResult.wrap(lookup_sql_cache(...) || super)`, so the pending handle
+  // has to survive the cache wrapper. It only does because `cachedSelectAll`
+  // is not an `async function` — one would adopt the thenable FutureResult and
+  // settle with its Result, which is exactly the collapse this covers.
+  function cacheHost(store: Store) {
+    return {
+      _queryCache: store,
+      lookupSqlCache: (sql: string, _name: string | null | undefined, binds: unknown[]) =>
+        store.get(binds.length === 0 ? sql : JSON.stringify([sql, binds])),
+      cacheSql: async (
+        _sql: string,
+        _name: string | null | undefined,
+        _binds: unknown[],
+        block: () => Promise<Record<string, unknown>[]>,
+      ) => block(),
+    };
+  }
+
+  it("hands back a pending FutureResult with the query cache enabled", async () => {
+    const result = new Result(["id"], [[1]]);
+    const store = new Store();
+    store.enabled = true;
+    const pending = new FutureResult.SelectAll(deferredPool(result) as never, [
+      "SELECT 1",
+      null,
+      [],
+    ]);
+    const selectAll = makeCachedSelectAll(() => pending);
+
+    const returned = selectAll.call(cacheHost(store) as never, "SELECT 1", null, [], {
+      async: true,
+    });
+
+    expect(returned).toBe(pending);
+    expect((returned as FutureResult).pending()).toBe(true);
+  });
+
+  it("wraps a cache hit in a Complete on the async arm", async () => {
+    const store = new Store();
+    store.enabled = true;
+    await store.computeIfAbsent("SELECT 1", async () => [{ id: 1 }]);
+    const selectAll = makeCachedSelectAll(() => {
+      throw new Error("must not reach super on a cache hit");
+    });
+
+    const returned = selectAll.call(cacheHost(store) as never, "SELECT 1", null, [], {
+      async: true,
+    });
+
+    expect(returned).toBeInstanceOf(Complete);
+    expect((returned as Complete).pending()).toBe(false);
+    expect(await (returned as Complete)).toEqual([{ id: 1 }]);
+  });
+
+  it("still caches through cache_sql on the sync arm", async () => {
+    const result = new Result(["id"], [[1]]);
+    const store = new Store();
+    store.enabled = true;
+    const selectAll = makeCachedSelectAll(async () => result);
+
+    expect(
+      await selectAll.call(cacheHost(store) as never, "SELECT 1", null, [], { async: false }),
+    ).toEqual(result);
   });
 });
 

--- a/packages/activerecord/src/future-result.trails.test.ts
+++ b/packages/activerecord/src/future-result.trails.test.ts
@@ -393,7 +393,7 @@ describe("QueryCache#select_all", () => {
 
     expect(returned).toBeInstanceOf(Complete);
     expect((returned as Complete).pending()).toBe(false);
-    expect(await (returned as Complete)).toEqual([{ id: 1 }]);
+    expect((returned as Complete).toArray()).toEqual([{ id: 1 }]);
   });
 
   it("still caches through cache_sql on the sync arm", async () => {

--- a/packages/activerecord/src/relation-load-async.trails.test.ts
+++ b/packages/activerecord/src/relation-load-async.trails.test.ts
@@ -13,6 +13,7 @@ import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
 import { Base, registerModel } from "./index.js";
 import { ActiveRecord } from "./ar-config.js";
 import { FutureResult } from "./future-result.js";
+import { AsynchronousQueriesTracker } from "./asynchronous-queries-tracker.js";
 import { Topic } from "./test-helpers/models/topic.js";
 import { Reply } from "./test-helpers/models/reply.js";
 import { fixtures } from "./test-fixtures.js";
@@ -26,9 +27,21 @@ describe("Relation#load_async", () => {
   registerModel("Reply", Reply);
 
   let restoreExecutor: (() => void) | undefined;
+  let tracker: AsynchronousQueriesTracker | undefined;
 
   beforeEach(async () => {
     ActiveRecord.asyncQueryExecutor = "global_thread_pool";
+    // Rails schedules a FutureResult onto `asynchronous_queries_session`, which
+    // only exists inside one: the Executor opens it per request
+    // (`AsynchronousQueriesTracker.run` / `.complete`,
+    // asynchronous_queries_tracker.rb:32-40). trails has no Executor to hook
+    // yet — `asynchronousQueriesTracker()` seeds a session as a stopgap
+    // (core.ts:660-665, story install-executor-hooks-for-async-queries-tracker)
+    // — and that seed lives on a tracker shared through the isolated execution
+    // state, so a sibling suite's `complete()` can leave the stack empty. Open
+    // this suite's own session, exactly as the Executor would.
+    tracker = AsynchronousQueriesTracker.run();
+
     // The pool reads `asyncQueryExecutor` once, in its constructor
     // (connection_pool.rb:714-728 → buildAsyncExecutor), and the harness has
     // already built this one. Swap the executor in for the test so
@@ -43,6 +56,8 @@ describe("Relation#load_async", () => {
   });
 
   afterEach(() => {
+    if (tracker) AsynchronousQueriesTracker.complete(tracker);
+    tracker = undefined;
     restoreExecutor?.();
     restoreExecutor = undefined;
     ActiveRecord.asyncQueryExecutor = null;

--- a/packages/activerecord/src/relation-load-async.trails.test.ts
+++ b/packages/activerecord/src/relation-load-async.trails.test.ts
@@ -1,0 +1,102 @@
+/**
+ * trails-only end-to-end coverage for `Relation#load_async`.
+ *
+ * Rails' own relation/load_async_test.rb stays excluded
+ * (scripts/parity/unported-files/unscoped.ts): every case there asserts
+ * thread-pool interleaving, `scheduled?` across threads, or mutex lock_wait,
+ * none of which is observable on a single-threaded event loop. What IS
+ * observable — and what relation.rb:1138-1152 is for — is that `load_async`
+ * issues its SELECT through `select_all(..., async:)` and so runs on the
+ * FutureResult path rather than in the foreground.
+ */
+import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
+import { Base } from "./index.js";
+import { ActiveRecord } from "./ar-config.js";
+import { FutureResult } from "./future-result.js";
+import { Topic } from "./test-helpers/models/topic.js";
+import { fixtures } from "./test-fixtures.js";
+
+fixtures({ topics: [Topic, {}] });
+
+describe("Relation#load_async", () => {
+  let restoreExecutor: (() => void) | undefined;
+
+  beforeEach(async () => {
+    ActiveRecord.asyncQueryExecutor = "global_thread_pool";
+    // The pool reads `asyncQueryExecutor` once, in its constructor
+    // (connection_pool.rb:714-728 → buildAsyncExecutor), and the harness has
+    // already built this one. Swap the executor in for the test so
+    // `async_enabled?` is true, exactly as it would be for a pool built with
+    // the config set.
+    const pool = (await Base.connectionPool()) as unknown as { asyncExecutor: unknown };
+    const previous = pool.asyncExecutor;
+    pool.asyncExecutor = ActiveRecord.globalThreadPoolAsyncQueryExecutor();
+    restoreExecutor = () => {
+      pool.asyncExecutor = previous;
+    };
+  });
+
+  afterEach(() => {
+    restoreExecutor?.();
+    restoreExecutor = undefined;
+    ActiveRecord.asyncQueryExecutor = null;
+    vi.restoreAllMocks();
+  });
+
+  it("issues the query through select_all with async on", async () => {
+    // Spy on the instance, not the prototype: the fixture harness restores its
+    // own property and would shadow a prototype spy so it never fires.
+    const connection = Base.connection as unknown as {
+      selectAll: (...args: unknown[]) => unknown;
+    };
+    const spy = vi.spyOn(connection, "selectAll");
+
+    const relation = Topic.all().loadAsync();
+    await relation;
+
+    expect(spy).toHaveBeenCalled();
+    expect((spy.mock.calls[0][3] as { async?: boolean }).async).toBe(true);
+  });
+
+  it("schedules a FutureResult::SelectAll on the pool", async () => {
+    const pool = (await Base.connectionPool()) as unknown as {
+      scheduleQuery(futureResult: { executeOrSkip(): void }): void;
+    };
+    const scheduled: unknown[] = [];
+    const spy = vi.spyOn(pool, "scheduleQuery").mockImplementation((futureResult) => {
+      scheduled.push(futureResult);
+      futureResult.executeOrSkip();
+    });
+
+    await Topic.all().loadAsync();
+
+    expect(spy).toHaveBeenCalled();
+    expect(scheduled[0]).toBeInstanceOf(FutureResult.SelectAll);
+  });
+
+  it("returns the records the scheduled query loaded", async () => {
+    await Topic.create({ title: "async load", author_name: "David" });
+
+    const relation = Topic.all().loadAsync();
+    const records = await relation;
+
+    expect(records.map((t) => t.title)).toContain("async load");
+    expect(relation.isLoaded).toBe(true);
+  });
+
+  it("runs the query in the foreground when no executor is configured", async () => {
+    restoreExecutor?.();
+    restoreExecutor = undefined;
+    ActiveRecord.asyncQueryExecutor = null;
+
+    const connection = Base.connection as unknown as {
+      selectAll: (...args: unknown[]) => unknown;
+    };
+    const spy = vi.spyOn(connection, "selectAll");
+
+    await Topic.all().loadAsync();
+
+    // Rails: `return load if !c.async_enabled?` (relation.rb:1140).
+    expect((spy.mock.calls[0][3] as { async?: boolean }).async).toBe(false);
+  });
+});

--- a/packages/activerecord/src/relation-load-async.trails.test.ts
+++ b/packages/activerecord/src/relation-load-async.trails.test.ts
@@ -10,15 +10,21 @@
  * FutureResult path rather than in the foreground.
  */
 import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
-import { Base } from "./index.js";
+import { Base, registerModel } from "./index.js";
 import { ActiveRecord } from "./ar-config.js";
 import { FutureResult } from "./future-result.js";
 import { Topic } from "./test-helpers/models/topic.js";
+import { Reply } from "./test-helpers/models/reply.js";
 import { fixtures } from "./test-fixtures.js";
 
 fixtures({ topics: [Topic, {}] });
 
 describe("Relation#load_async", () => {
+  // Register by Rails name so the STI Reply rows behind Topic#replies resolve
+  // before the first query warms the model registry.
+  registerModel("Topic", Topic);
+  registerModel("Reply", Reply);
+
   let restoreExecutor: (() => void) | undefined;
 
   beforeEach(async () => {
@@ -72,6 +78,21 @@ describe("Relation#load_async", () => {
 
     expect(spy).toHaveBeenCalled();
     expect(scheduled[0]).toBeInstanceOf(FutureResult.SelectAll);
+  });
+
+  it("issues an eager-loaded relation's join query with async on", async () => {
+    // Rails' exec_main_query forwards `async:` to its eager_loading? arm too —
+    // `c.select_all(relation.arel, "SQL", async: async)` (relation.rb:1436).
+    const connection = Base.connection as unknown as {
+      selectAll: (...args: unknown[]) => unknown;
+    };
+    const spy = vi.spyOn(connection, "selectAll");
+
+    await Topic.eagerLoad("replies").loadAsync();
+
+    const joinCall = spy.mock.calls.find((call) => call[1] === "SQL");
+    expect(joinCall).toBeDefined();
+    expect((joinCall![3] as { async?: boolean }).async).toBe(true);
   });
 
   it("returns the records the scheduled query loaded", async () => {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2509,10 +2509,21 @@ export class Relation<T extends Base> {
       ]),
     ];
 
+    // Rails' load_async bails to a plain `load` unless `c.async_enabled?` and
+    // passes `async: !c.current_transaction.joinable?` into `exec_main_query`
+    // (relation.rb:1140-1142), which forwards it to BOTH of its query arms —
+    // the eager-loading `select_all(relation.arel, "SQL", async: async)`
+    // (relation.rb:1436) and `_query_by_sql` (relation.rb:1449 →
+    // querying.rb:67-68). This method is that `exec_main_query`, so the value
+    // is computed once here and threaded into both.
+    const c = this._conn();
+    const async =
+      this._asyncLoad && c.asyncEnabled?.() === true && !c.currentTransaction?.()?.joinable;
+
     let loadedRecords: T[];
     if (this._eagerLoadAssociations.length > 0 || promotedIncludes.length > 0) {
       const allEager = [...new Set([...this._eagerLoadAssociations, ...promotedIncludes])];
-      await this._executeEagerLoad(allEager);
+      await this._executeEagerLoad(allEager, { async });
       if (token !== this._loadToken) return [];
       loadedRecords = this._records;
       this.loadRecords(loadedRecords);
@@ -2523,16 +2534,8 @@ export class Relation<T extends Base> {
       // visitor's collector here would be wrong: from(ArelNode) recompiles and
       // resets it.
       const allowRetry = this._lastSelectRetryable;
-      const c = this._conn();
-      // Rails' load_async bails to a plain `load` unless `c.async_enabled?`
-      // and passes `async: !c.current_transaction.joinable?`
-      // (relation.rb:1140-1142), which `exec_main_query` hands to
-      // `_query_by_sql` (relation.rb:1449) and that forwards to `select_all`
-      // (querying.rb:67-68) — this call. Awaiting the
-      // FutureResult here is trails' `future.result` in `exec_queries`
-      // (relation.rb:1408).
-      const async =
-        this._asyncLoad && c.asyncEnabled?.() === true && !c.currentTransaction?.()?.joinable;
+      // Awaiting the FutureResult here is trails' `future.result` in
+      // `exec_queries` (relation.rb:1408).
       const result = await c.selectAll(sql, `${this.model.name} Load`, this._lastSelectBinds, {
         allowRetry,
         preparable: this._lastSelectPreparable,
@@ -2740,13 +2743,19 @@ export class Relation<T extends Base> {
     return new JoinDependency(this._model, this.table, specs, Nodes.OuterJoin);
   }
 
-  private async _executeEagerLoad(eagerAssocs?: AssociationSpec[]): Promise<void> {
+  private async _executeEagerLoad(
+    eagerAssocs?: AssociationSpec[],
+    // `exec_main_query`'s `async:` (relation.rb:1423), which its eager arm
+    // hands to `select_all` (relation.rb:1436).
+    { async = false }: { async?: boolean } = {},
+  ): Promise<void> {
     const eagerAssociations = eagerAssocs ?? this._eagerLoadAssociations;
     const basePk = (this._model as any).primaryKey ?? "id";
     if (this._eagerLoadBypassesJoinDependency()) {
       const sql = this._toSql();
       const result = await this._conn().selectAll(sql, "Eager Load", this._lastSelectBinds, {
         preparable: this._lastSelectPreparable,
+        async,
       });
       this._records = this._instrumentInstantiation(
         result.toArray(),
@@ -2784,7 +2793,7 @@ export class Relation<T extends Base> {
     // column_types are available to type-cast extra/computed `select` columns
     // hydrated onto the base record — mirroring Rails' JoinDependency#instantiate,
     // which slices `result_set.column_types`.
-    const result = await this._conn().selectAll(sql, "SQL", eagerBinds);
+    const result = await this._conn().selectAll(sql, "SQL", eagerBinds, { async });
     const rows = result.toArray();
 
     // Mirrors JoinDependency#instantiate: record_count is the raw JOIN

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2140,7 +2140,6 @@ export class Relation<T extends Base> {
     // inside `_toArrayInner` — so the in-flight handle a second caller must
     // join is that promise, not the FutureResult, which covers only the first
     // of those steps.
-    this._asyncLoad = true;
     // Kick off the load in the background and stash the in-flight promise.
     // toArray() already caches _loaded/_records when it resolves, so no
     // .then bookkeeping is needed. A later `await rel.toArray()` drains
@@ -2151,6 +2150,8 @@ export class Relation<T extends Base> {
     // in finally) so concurrent callers share the one in-flight query
     // instead of racing to fire additional ones.
     if (!this._loadAsyncPromise && !this._loaded) {
+      // Rails' `unless loaded?` guards the async query too (relation.rb:1141).
+      this._asyncLoad = true;
       const loadPromise = this.toArray().finally(() => {
         this._loadAsyncPromise = undefined;
         this._asyncLoad = false;

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -477,6 +477,12 @@ export class Relation<T extends Base> {
    */
   _instantiateBlock?: (record: T) => void;
   private _loadAsyncPromise?: Promise<T[]>;
+  /**
+   * Set by `loadAsync()` so `_toArrayInner` — this relation's `exec_main_query`
+   * — issues its SELECT with `async:` on, the way Rails' `load_async` calls
+   * `exec_main_query(async: ...)` (relation.rb:1142).
+   */
+  private _asyncLoad = false;
   // Monotonic token bumped on reset()/reload() so an in-flight toArray()
   // that started before the reset can detect it lost the race and skip
   // committing stale records/loaded state.
@@ -2084,6 +2090,9 @@ export class Relation<T extends Base> {
     // load can't re-populate records after a reset.
     this._loadToken += 1;
     this._loadAsyncPromise = undefined;
+    // Rails' reset also drops the scheduled query (`@future_result&.cancel;
+    // @future_result = nil`, relation.rb:1195-1196).
+    this._asyncLoad = false;
     return this;
   }
 
@@ -2115,6 +2124,23 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#load_async
    */
   loadAsync(): Relation<T> {
+    // Rails' `load_async` takes a connection, bails to `load` unless
+    // `c.async_enabled?`, and calls `exec_main_query(async: !c.current_transaction
+    // .joinable?)`, keeping the returned FutureResult in `@future_result`
+    // (relation.rb:1138-1154). Both of those reads need the connection that
+    // will run the query, so trails makes them where it is in hand — in
+    // `_toArrayInner`, which is this relation's `exec_main_query` — and marks
+    // the load async here.
+    //
+    // The `_loadAsyncPromise` memoization is retained in place of Rails'
+    // `@future_result` + `scheduled?`: Rails' foreground `exec_queries` reads
+    // `future.result` for the ROWS and still instantiates records itself, so
+    // the future is all it has to hold. trails' loading path is a promise the
+    // whole way down — instantiation, eager loading and preloading are awaited
+    // inside `_toArrayInner` — so the in-flight handle a second caller must
+    // join is that promise, not the FutureResult, which covers only the first
+    // of those steps.
+    this._asyncLoad = true;
     // Kick off the load in the background and stash the in-flight promise.
     // toArray() already caches _loaded/_records when it resolves, so no
     // .then bookkeeping is needed. A later `await rel.toArray()` drains
@@ -2127,6 +2153,7 @@ export class Relation<T extends Base> {
     if (!this._loadAsyncPromise && !this._loaded) {
       const loadPromise = this.toArray().finally(() => {
         this._loadAsyncPromise = undefined;
+        this._asyncLoad = false;
       });
       // Attach a no-op rejection handler so a failure here isn't treated
       // as an unhandled rejection if nothing else awaits the relation.
@@ -2495,12 +2522,21 @@ export class Relation<T extends Base> {
       // visitor's collector here would be wrong: from(ArelNode) recompiles and
       // resets it.
       const allowRetry = this._lastSelectRetryable;
-      const result = await this._conn().selectAll(
-        sql,
-        `${this.model.name} Load`,
-        this._lastSelectBinds,
-        { allowRetry, preparable: this._lastSelectPreparable },
-      );
+      const c = this._conn();
+      // Rails' load_async bails to a plain `load` unless `c.async_enabled?`
+      // and passes `async: !c.current_transaction.joinable?`
+      // (relation.rb:1140-1142), which `exec_main_query` hands to
+      // `_query_by_sql` (relation.rb:1449) and that forwards to `select_all`
+      // (querying.rb:67-68) — this call. Awaiting the
+      // FutureResult here is trails' `future.result` in `exec_queries`
+      // (relation.rb:1408).
+      const async =
+        this._asyncLoad && c.asyncEnabled?.() === true && !c.currentTransaction?.()?.joinable;
+      const result = await c.selectAll(sql, `${this.model.name} Load`, this._lastSelectBinds, {
+        allowRetry,
+        preparable: this._lastSelectPreparable,
+        async,
+      });
       if (token !== this._loadToken) return [];
       const rows = result.toArray();
       loadedRecords = this._instrumentInstantiation(


### PR DESCRIPTION
Wires `Relation#load_async` onto the `FutureResult` infrastructure PR #6515
ported, closing the two gaps that PR deliberately left open.

## 1. `QueryCache#select_all`'s async arm (`query_cache.rb:243-250`)

```ruby
if async
  result = lookup_sql_cache(sql, name, binds) || super(...)
  FutureResult.wrap(result)
else
  cache_sql(sql, name, binds) { super(...) }
end
```

`makeCachedSelectAll` took the `cache_sql` shape unconditionally. It now
splits on `async`, and — critically — `cachedSelectAll` is no longer an
`async function`: `FutureResult#then` implements the JS thenable protocol, so
an async wrapper's own promise adopts a returned FutureResult and settles with
the final `Result`, losing the pending handle whenever the query cache is on.
This is the same rule `select` and `DatabaseStatements.selectAll` already
follow.

## 2. `Relation#loadAsync` routes through `selectAll(..., { async })`

Rails' `load_async` (relation.rb:1138-1152) takes a connection, bails to
`load` unless `c.async_enabled?`, and calls
`exec_main_query(async: !c.current_transaction.joinable?)`, which reaches
`select_all` via `_query_by_sql` (querying.rb:67-68). Both of those reads need
the connection that will run the query, so trails makes them in
`_toArrayInner` — this relation's `exec_main_query` — with `loadAsync()`
marking the load async.

The `_loadAsyncPromise` memoization is retained in place of `@future_result` +
`scheduled?`, justified at the call site: Rails' `exec_queries` reads
`future.result` only for the ROWS and instantiates records itself, so the
future is all it has to hold; trails awaits instantiation, eager loading and
preloading inside `_toArrayInner`, so the handle a second caller must join is
that promise, which the FutureResult is only the first step of.

## Incidental: SQLite3 `castResult`

Rails' SQLite `perform_query` returns an `ActiveRecord::Result`, which is why
its `cast_result` is the identity. trails' `performQuery` returns the raw
`{ rows, affectedRows, insertRowid }` bag, so `raw_exec_query` —
`cast_result(raw_execute(...))`, the FutureResult's query path — handed the
bag straight through and `load_async` died on `result.toArray is not a
function` on the SQLite lane. `castResult` builds the Result from a bag,
documented as the deviation it is; converging `performQuery` onto Rails'
return shape is filed as `sqlite3-perform-query-returns-result`.

## 3. `exec_main_query` forwards `async:` to BOTH arms

Rails passes it to the eager-loading arm too —
`c.select_all(relation.arel, "SQL", async: async)` (relation.rb:1436) — not
just `_query_by_sql`. `_toArrayInner` now computes the flag once (as
`exec_main_query` receives it once) and threads it into both branches, so
`Topic.eagerLoad("replies").loadAsync()` reaches the FutureResult path instead
of silently running in the foreground.

## 4. PostgreSQL's `perform_query` seam

`raw_execute` reaches `perform_query` through `this`
(abstract/database_statements.rb:552-558), and `raw_exec_query` casts what it
returns (:541-543) — the path `FutureResult#exec_query` runs on
(future_result.rb:169-171). PG bound its primitive as the private
`_performQuery`, so that path hit the abstract `NotImplementedError` stub and
`load_async` threw on the PG lane. The adapter now binds `performQuery` on its
prototype — the way `SQLite3Adapter` and `Mysql2Adapter` bind theirs, so the
port keeps exactly one `perform_query` body (the extracted one #6330
converged) — supplying the `rowMode: "array"` node-pg needs to yield the
positional rows a `PG::Result` gives Rails for free, where `cast_result` reads
them off `result.values` (postgresql/database_statements.rb:180). The rowMode
deviation is already justified on the extracted `performQuery`; its other
callers pass the shape they read, so the default cannot simply flip. `database-statements-raw-execute.trails.test.ts`
drops its `currentAdapter("SQLite3Adapter", "Mysql2Adapter")` gate as a result —
the last acceptance criterion of `converge-pg-perform-query-onto-rails-arms`.

Verified by running the changed suites on all three lanes locally (SQLite,
PostgreSQL 17, MySQL 8).

## Tests

- `future-result.trails.test.ts` — a pending `FutureResult` survives the
  wrapper with the query cache ENABLED (fails on baseline: the async wrapper
  returns a promise, not the handle), an async cache hit wraps in `Complete`
  without reaching `super`, and the sync arm still caches.
- `relation-load-async.trails.test.ts` — end-to-end against the canonical
  schema with `ActiveRecord.asyncQueryExecutor` set: `Topic.all().loadAsync()`
  calls `select_all` with `async: true`, schedules a `FutureResult::SelectAll`
  on the pool, returns the records it loaded, and falls back to a foreground
  query when no executor is configured, and an eager-loaded relation's join
  query also carries `async: true` (fails on the pre-fix body).

Rails' own `load_async_test.rb` / `asynchronous_queries_test.rb` stay excluded
— they assert thread-pool sizing, cross-thread `scheduled?` and mutex
`lock_wait`.

Closes-story: wire-load-async-through-future-result


