### PR TITLE
feat(trailties): generate an app that subclasses Trailties.Application

### DIFF
--- a/packages/trailties/src/generators/__snapshots__/app-generator.test.ts.snap
+++ b/packages/trailties/src/generators/__snapshots__/app-generator.test.ts.snap
@@ -48,26 +48,30 @@ exports[`AppGenerator > snapshots emitted TypeScript sources > channel.ts 1`] = 
 `;
 
 exports[`AppGenerator > snapshots emitted TypeScript sources > config.ts 1`] = `
-"import { app } from "./src/config/application.js";
+"// This file is used by Rack-based servers to start the application.
+import { Trails } from "@blazetrails/trailties";
 
-export default app;
+import "./src/config/environment.js";
+
+export default Trails.application;
 "
 `;
 
 exports[`AppGenerator > snapshots emitted TypeScript sources > config/application.ts 1`] = `
-"import { ActiveRecord } from "@blazetrails/activerecord";
-import { ActiveSupport } from "@blazetrails/activesupport";
-import databaseConfig from "./database.js";
-import { drawRoutes } from "./routes.js";
+"import { Application } from "@blazetrails/trailties";
 
-export const app = {
-  name: "my-app",
-  config: {
-    database: databaseConfig,
-    // config
-  },
-  routes: drawRoutes,
-};
+export class MyApp extends Application {
+  // Configuration for the application, engines, and trailties goes here.
+  //
+  // These settings can be overridden in specific environments using the files
+  // in src/config/environments, which are processed later.
+  //
+  // config.timeZone = "Central Time (US & Canada)";
+  // config.eagerLoadPaths.push("extras");
+  // config
+}
+
+Application.register(MyApp);
 "
 `;
 
@@ -103,12 +107,15 @@ export default {
 `;
 
 exports[`AppGenerator > snapshots emitted TypeScript sources > config/routes.ts 1`] = `
-"// Define your application routes here.
-// Example:
-//   router.resources("posts");
-//   router.get("/", "home#index");
+"import type { Mapper } from "@blazetrails/actionpack";
 
-export function drawRoutes(router: any): void {
+export function drawRoutes(mapper: Mapper): void {
+  // Define your application routes here.
+  // Example:
+  //   mapper.get("/posts", { to: "posts#index" });
+
+  // Defines the root path route ("/")
+  // mapper.root("posts#index");
   // routes
 }
 "

--- a/packages/trailties/src/generators/app-generator.test.ts
+++ b/packages/trailties/src/generators/app-generator.test.ts
@@ -270,10 +270,36 @@ describe("AppGenerator", () => {
     expect(readme).toContain("my-app");
 
     const appConfig = fs.readFileSync(appPath("src/config/application.ts"), "utf-8");
-    expect(appConfig).toContain("my-app");
+    expect(appConfig).toContain("MyApp");
 
     const layout = fs.readFileSync(appPath("src/app/views/layouts/application.html.tse"), "utf-8");
     expect(layout).toContain("my-app");
+  });
+
+  it("generates an application class that subclasses Application", async () => {
+    await makeGen().run();
+
+    const appConfig = fs.readFileSync(appPath("src/config/application.ts"), "utf-8");
+    expect(appConfig).toContain(`import { Application } from "@blazetrails/trailties";`);
+    expect(appConfig).toContain("export class MyApp extends Application {");
+    expect(appConfig).toContain("Application.register(MyApp);");
+
+    const environment = fs.readFileSync(appPath("src/config/environment.ts"), "utf-8");
+    expect(environment).toContain(`import "./application.js";`);
+    expect(environment).toContain("await Trails.initialize()");
+
+    const configRu = fs.readFileSync(appPath("config.ts"), "utf-8");
+    expect(configRu).toContain(`import "./src/config/environment.js";`);
+    expect(configRu).toContain("export default Trails.application;");
+  });
+
+  it("types drawRoutes against Mapper", async () => {
+    await makeGen().run();
+
+    const routes = fs.readFileSync(appPath("src/config/routes.ts"), "utf-8");
+    expect(routes).toContain(`import type { Mapper } from "@blazetrails/actionpack";`);
+    expect(routes).toContain("export function drawRoutes(mapper: Mapper): void {");
+    expect(routes).not.toContain(": any");
   });
 
   it("snapshots emitted TypeScript sources", async () => {

--- a/packages/trailties/src/generators/app-generator.test.ts
+++ b/packages/trailties/src/generators/app-generator.test.ts
@@ -293,6 +293,18 @@ describe("AppGenerator", () => {
     expect(configRu).toContain("export default Trails.application;");
   });
 
+  it("invalid application name raises an error", async () => {
+    const gen = new AppGenerator({
+      cwd: tmpDir,
+      output: (m) => lines.push(m),
+      appPath: "43-things",
+      database: "sqlite",
+    });
+    await expect(gen.run()).rejects.toThrow(
+      "Invalid application name 43-things. Please give a name which does not start with numbers.",
+    );
+  });
+
   it("invalid application name is fixed", async () => {
     const gen = new AppGenerator({
       cwd: tmpDir,

--- a/packages/trailties/src/generators/app-generator.test.ts
+++ b/packages/trailties/src/generators/app-generator.test.ts
@@ -293,6 +293,20 @@ describe("AppGenerator", () => {
     expect(configRu).toContain("export default Trails.application;");
   });
 
+  it("invalid application name is fixed", async () => {
+    const gen = new AppGenerator({
+      cwd: tmpDir,
+      output: (m) => lines.push(m),
+      appPath: "things-43",
+      database: "sqlite",
+    });
+    await gen.run();
+    const read = (...segs: string[]) =>
+      fs.readFileSync(path.join(tmpDir, "things-43", ...segs), "utf-8");
+    expect(read("src/config/environment.ts")).toMatch(/Trails\.initialize\(\)/);
+    expect(read("src/config/application.ts")).toMatch(/^export class Things43 /m);
+  });
+
   it("types drawRoutes against Mapper", async () => {
     await makeGen().run();
 

--- a/packages/trailties/src/generators/app-generator.ts
+++ b/packages/trailties/src/generators/app-generator.ts
@@ -1,3 +1,4 @@
+import { camelize } from "@blazetrails/activesupport";
 import { ref, tsClass, tsField, tsModule, tsRaw } from "../template-builder/index.js";
 import { AppBase, type AppBaseOptions } from "./app-base.js";
 import { GeneratorError } from "./generated-attribute.js";
@@ -51,6 +52,18 @@ export class AppGenerator extends AppBase {
         `Unknown SQLite driver '${this.sqliteDriver}'. Valid options: ${VALID_SQLITE_DRIVERS.join(", ")}`,
       );
     }
+  }
+
+  /**
+   * Rails' `Rails::Generators::AppName#app_const_base`
+   * (`railties/lib/rails/generators/app_name.rb:18`):
+   * `app_name.gsub(/\W/, "_").squeeze("_").camelize`. Rails names the app
+   * constant `<%= app_const_base %>::Application`; TypeScript has no module
+   * nesting, so the generated class is `app_const_base` itself — which is
+   * what `Application#name` dasherizes back into the Rails app name.
+   */
+  private appConstBase(name: string): string {
+    return camelize(name.replace(/\W/g, "_").replace(/_+/g, "_"));
   }
 
   private pmInstall(): string {
@@ -247,9 +260,12 @@ This application was generated with [trails](https://github.com/blazetrailsdev/b
 
     this.createFile(
       "config.ts",
-      `import { app } from "./src/config/application.js";
+      `// This file is used by Rack-based servers to start the application.
+import { Trails } from "@blazetrails/trailties";
 
-export default app;
+import "./src/config/environment.js";
+
+export default Trails.application;
 `,
     );
 
@@ -330,38 +346,45 @@ execSync("trails server", { stdio: "inherit" });
   private createConfigFiles(name: string): void {
     this.createFile(
       "src/config/application.ts",
-      `import { ActiveRecord } from "@blazetrails/activerecord";
-import { ActiveSupport } from "@blazetrails/activesupport";
-import databaseConfig from "./database.js";
-import { drawRoutes } from "./routes.js";
+      `import { Application } from "@blazetrails/trailties";
 
-export const app = {
-  name: "${name}",
-  config: {
-    database: databaseConfig,
-    // config
-  },
-  routes: drawRoutes,
-};
+export class ${this.appConstBase(name)} extends Application {
+  // Configuration for the application, engines, and trailties goes here.
+  //
+  // These settings can be overridden in specific environments using the files
+  // in src/config/environments, which are processed later.
+  //
+  // config.timeZone = "Central Time (US & Canada)";
+  // config.eagerLoadPaths.push("extras");
+  // config
+}
+
+Application.register(${this.appConstBase(name)});
 `,
     );
 
     this.createFile(
       "src/config/environment.ts",
-      `import { app } from "./application.js";
+      `// Load the trails application.
+import { Trails } from "@blazetrails/trailties";
+import "./application.js";
 
-export default app;
+// Initialize the trails application.
+export default await Trails.initialize();
 `,
     );
 
     this.createFile(
       "src/config/routes.ts",
-      `// Define your application routes here.
-// Example:
-//   router.resources("posts");
-//   router.get("/", "home#index");
+      `import type { Mapper } from "@blazetrails/actionpack";
 
-export function drawRoutes(router: any): void {
+export function drawRoutes(mapper: Mapper): void {
+  // Define your application routes here.
+  // Example:
+  //   mapper.get("/posts", { to: "posts#index" });
+
+  // Defines the root path route ("/")
+  // mapper.root("posts#index");
   // routes
 }
 `,

--- a/packages/trailties/src/generators/app-generator.ts
+++ b/packages/trailties/src/generators/app-generator.ts
@@ -1,8 +1,11 @@
-import { camelize } from "@blazetrails/activesupport";
+import { camelize, parameterize, underscore } from "@blazetrails/activesupport";
 import { ref, tsClass, tsField, tsModule, tsRaw } from "../template-builder/index.js";
 import { AppBase, type AppBaseOptions } from "./app-base.js";
 import { GeneratorError } from "./generated-attribute.js";
 import { type DatabaseName } from "./database.js";
+
+// Rails' `Rails::Generators::AppName::RESERVED_NAMES` (`app_name.rb:6`).
+const RESERVED_NAMES = ["application", "destroy", "plugin", "runner", "test"];
 
 // CLI-friendly DB aliases — `trails new -d sqlite|postgres|mysql` maps
 // onto the canonical Rails `DatabaseName`. MariaDB is exposed via the
@@ -54,16 +57,48 @@ export class AppGenerator extends AppBase {
     }
   }
 
-  /**
-   * Rails' `Rails::Generators::AppName#app_const_base`
-   * (`railties/lib/rails/generators/app_name.rb:18`):
-   * `app_name.gsub(/\W/, "_").squeeze("_").camelize`. Rails names the app
-   * constant `<%= app_const_base %>::Application`; TypeScript has no module
-   * nesting, so the generated class is `app_const_base` itself — which is
-   * what `Application#name` dasherizes back into the Rails app name.
-   */
-  private appConstBase(name: string): string {
-    return camelize(name.replace(/\W/g, "_").replace(/_+/g, "_"));
+  /** Rails' `AppName#original_app_name` (`app_name.rb:12`). Trails has no
+   * `--name` option, so the `options[:name]` arm has nothing to read. */
+  private originalAppName(): string {
+    return this.path.basename(this.destinationRoot);
+  }
+
+  /** Rails' `AppName#app_name` (`app_name.rb:9`):
+   * `original_app_name.parameterize(preserve_case: true).underscore`. */
+  private appName(): string {
+    return underscore(parameterize(this.originalAppName(), { preserveCase: true }));
+  }
+
+  /** Rails' `AppName#app_const_base` (`app_name.rb:18`):
+   * `app_name.gsub(/\W/, "_").squeeze("_").camelize`. */
+  private appConstBase(): string {
+    return camelize(this.appName().replace(/\W/g, "_").replace(/_+/g, "_"));
+  }
+
+  /** Rails' `AppName#app_const` (`app_name.rb:22`) is
+   * `"#{app_const_base}::Application"`. TypeScript has no module nesting, so
+   * the generated class is `app_const_base` itself — which is what
+   * `Application#name` dasherizes back into the Rails app name. */
+  private appConst(): string {
+    return this.appConstBase();
+  }
+
+  /** Rails' `AppName#valid_const?` (`app_name.rb:26`), called from
+   * `AppBase#create_root` (`app_base.rb:258`). The third Rails arm,
+   * `Object.const_defined?(app_const_base)`, has no counterpart: JavaScript
+   * has no global constant table to probe. */
+  private isValidConst(): void {
+    if (/^\d/.test(this.appConst())) {
+      throw new GeneratorError(
+        `Invalid application name ${this.originalAppName()}. Please give a name which does not start with numbers.`,
+      );
+    } else if (RESERVED_NAMES.includes(this.originalAppName())) {
+      throw new GeneratorError(
+        `Invalid application name ${this.originalAppName()}. Please give a ` +
+          `name which does not match one of the reserved trails ` +
+          `words: ${RESERVED_NAMES.join(", ")}`,
+      );
+    }
   }
 
   private pmInstall(): string {
@@ -79,6 +114,7 @@ export class AppGenerator extends AppBase {
   }
 
   async run(): Promise<string[]> {
+    this.isValidConst();
     const name = this.path.basename(this.appPath);
 
     this.output(`Creating new trails application: ${name}`);
@@ -348,7 +384,7 @@ execSync("trails server", { stdio: "inherit" });
       "src/config/application.ts",
       `import { Application } from "@blazetrails/trailties";
 
-export class ${this.appConstBase(name)} extends Application {
+export class ${this.appConstBase()} extends Application {
   // Configuration for the application, engines, and trailties goes here.
   //
   // These settings can be overridden in specific environments using the files
@@ -359,14 +395,15 @@ export class ${this.appConstBase(name)} extends Application {
   // config
 }
 
-Application.register(${this.appConstBase(name)});
+Application.register(${this.appConstBase()});
 `,
     );
 
     this.createFile(
       "src/config/environment.ts",
-      `// Load the trails application.
-import { Trails } from "@blazetrails/trailties";
+      `import { Trails } from "@blazetrails/trailties";
+
+// Load the trails application.
 import "./application.js";
 
 // Initialize the trails application.


### PR DESCRIPTION
Ports Rails's `config/application.rb.tt`, `config/environment.rb.tt` and `config.ru.tt` into the `trails new` templates.

Before, `trails new` emitted a plain object literal with two unused imports:

```ts
import { ActiveRecord } from "@blazetrails/activerecord";
import { ActiveSupport } from "@blazetrails/activesupport";
export const app = { name: "twitter-app", ... };
```

Now:

- `src/config/application.ts` declares `export class <AppConstBase> extends Application` and calls `Application.register(...)`. The class name follows Rails' `Rails::Generators::AppName#app_const_base` (`railties/lib/rails/generators/app_name.rb:18`): `app_name.gsub(/\W/, "_").squeeze("_").camelize`. TypeScript has no module nesting, so the class is `app_const_base` itself rather than `<Base>::Application` — which is exactly what `Application#name` dasherizes back into the Rails app name.
- `src/config/environment.ts` mirrors `environment.rb.tt`: load the application, then `Trails.initialize()`.
- root `config.ts` mirrors `config.ru.tt`: `require_relative "config/environment"` + `run Rails.application` → an `import` plus `export default Trails.application`.
- `src/config/routes.ts` types `drawRoutes(mapper: Mapper)` against `@blazetrails/actionpack`, not `any`, matching the `__fixtures__/boot-app` shape the routes reloader loads.
- No unused imports remain in the generated tree. The `// config` and `// routes` markers the `environment()` / `route()` generator actions splice into are preserved.

Tests: two new generator tests assert the emitted app subclasses `Application` and that `drawRoutes` is `Mapper`-typed; the emitted-source snapshots are updated.

Closes-story: generate-app-subclassing-application

### Deliberate omissions from `application.rb.tt`

- `require_relative "boot"` — `trails new` generates no `config/boot.ts` (no Bundler analogue).
- `config.load_defaults <version>` — `Configuration#loadDefaults` is not ported yet (`application/configuration.ts:1-4`), so emitting it would generate a non-booting app.
- `config.autoload_lib(ignore:)` and `config.generators.system_tests` — same, no ported counterpart.

The `// config` / `// routes` markers stay where the templates had them so the `environment()` and `route()` generator actions (`generators/trails-actions.ts:94,105`) still splice.


- `config.ru.tt:6`'s `Rails.application.load_server` — `Application#loadServer` is not ported (Rails uses it to load `config/server.rb`; trails' dev server is configured through `src/config/puma.ts` and `commands/server.ts`). Omitted deliberately; nothing to call.

### Review pass 1

- `appConstBase` now runs the whole Rails chain: `originalAppName` → `appName` (`parameterize(preserveCase: true)` + `underscore`, `app_name.rb:9`) → `appConstBase` (`app_name.rb:18`) → `appConst` (`app_name.rb:22`, flattened since TS has no module nesting).
- Ported `valid_const?` (`app_name.rb:26`) as `isValidConst()`, called from `run()` where Rails calls it in `create_root` (`app_base.rb:258`), plus `RESERVED_NAMES` (`app_name.rb:6`). The third Rails arm — `Object.const_defined?(app_const_base)` — has no counterpart: JavaScript has no global constant table to probe. Rails'"'"' sibling test `test_invalid_application_name_raises_an_error` is ported alongside `test_invalid_application_name_is_fixed`.
- Moved the `// Load the trails application.` comment in the generated `environment.ts` onto the `./application.js` side-effect import it describes.
