### PR TITLE
refactor(activerecord): reach async-query session/tracker through Base at call sites

### DIFF
--- a/packages/activerecord/src/asynchronous-queries-tracker.ts
+++ b/packages/activerecord/src/asynchronous-queries-tracker.ts
@@ -1,6 +1,19 @@
 import { Executor } from "@blazetrails/activesupport";
 import { ActiveRecordError } from "./errors.js";
-import { asynchronousQueriesTracker } from "./core.js";
+import type { Base } from "./base.js";
+
+/** @internal Set by `base.ts` at the bottom of its own module body — see the note there. */
+let _base: typeof Base | undefined;
+
+/** @internal */
+export function _registerBase(base: typeof Base): void {
+  _base = base;
+}
+
+function baseClass(): typeof Base {
+  if (!_base) throw new ActiveRecordError("ActiveRecord::Base has not finished loading");
+  return _base;
+}
 
 /**
  * Tracks the async-query sessions opened around a unit of work.
@@ -30,7 +43,7 @@ export class AsynchronousQueriesTracker {
   }
 
   static run(): AsynchronousQueriesTracker {
-    const tracker = asynchronousQueriesTracker();
+    const tracker = baseClass().asynchronousQueriesTracker();
     tracker.startSession();
     return tracker;
   }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -56,6 +56,8 @@ import { _registerBase as _registerBaseWithSchemaMigration } from "./schema-migr
 import { _registerBase as _registerBaseWithInternalMetadata } from "./internal-metadata.js";
 import { _registerBase as _registerBaseWithSchemaDumper } from "./schema-dumper.js";
 import { _registerBase as _registerBaseWithNamedScoping } from "./scoping/named.js";
+import { _registerBase as _registerBaseWithAsynchronousQueriesTracker } from "./asynchronous-queries-tracker.js";
+import { _registerBase as _registerBaseWithDatabaseStatements } from "./connection-adapters/abstract/database-statements.js";
 import {
   discriminateClassForRecord,
   stiName,
@@ -5007,3 +5009,5 @@ _registerBaseWithInternalMetadata(Base);
 _registerBaseWithSchemaDumper(Base);
 _registerBaseWithNamedScoping(Base);
 _registerBaseWithConnectionHandler(Base);
+_registerBaseWithAsynchronousQueriesTracker(Base);
+_registerBaseWithDatabaseStatements(Base);

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -22,6 +22,7 @@ import {
   NotImplementedError,
   RangeError as ARRangeError,
   AsynchronousQueryInsideTransactionError,
+  ActiveRecordError,
 } from "../../errors.js";
 
 import type { Quoting } from "./quoting.js";
@@ -35,7 +36,20 @@ import {
   type FutureResultPool,
   type FutureResultConnection,
 } from "../../future-result.js";
-import { asynchronousQueriesSession } from "../../core.js";
+import type { Base } from "../../base.js";
+
+/** @internal Set by `base.ts` at the bottom of its own module body — see the note there. */
+let _base: typeof Base | undefined;
+
+/** @internal */
+export function _registerBase(base: typeof Base): void {
+  _base = base;
+}
+
+function baseClass(): typeof Base {
+  if (!_base) throw new ActiveRecordError("ActiveRecord::Base has not finished loading");
+  return _base;
+}
 import { isWriteQuerySql } from "../sql-classification.js";
 import { ActiveRecord } from "../../ar-config.js";
 
@@ -2197,7 +2211,7 @@ export function select(
       { prepare: options?.prepare },
     );
     if (this.supportsConcurrentConnections?.() && !currentTransactionJoinable(this)) {
-      futureResult.scheduleBang(asynchronousQueriesSession());
+      futureResult.scheduleBang(baseClass().asynchronousQueriesSession());
       return futureResult;
     } else {
       // Ruby's `execute!` is an ordinary blocking call, so by the time this

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -37,6 +37,8 @@ import {
   type FutureResultConnection,
 } from "../../future-result.js";
 import type { Base } from "../../base.js";
+import { isWriteQuerySql } from "../sql-classification.js";
+import { ActiveRecord } from "../../ar-config.js";
 
 /** @internal Set by `base.ts` at the bottom of its own module body — see the note there. */
 let _base: typeof Base | undefined;
@@ -50,8 +52,6 @@ function baseClass(): typeof Base {
   if (!_base) throw new ActiveRecordError("ActiveRecord::Base has not finished loading");
   return _base;
 }
-import { isWriteQuerySql } from "../sql-classification.js";
-import { ActiveRecord } from "../../ar-config.js";
 
 /**
  * A single entry in `Relation#explain`'s options list. Either a bare


### PR DESCRIPTION
Rails reaches the async-query session through `ActiveRecord::Base`:
`database_statements.rb:687` (`future_result.schedule!(ActiveRecord::Base.asynchronous_queries_session)`)
and `asynchronous_queries_tracker.rb:37` (`ActiveRecord::Base.asynchronous_queries_tracker.tap(&:start_session)`).
They are singleton methods on `Base` because `Core`'s `included do` block defines
them (`core.rb:141-148`).

#6532 added `Base.asynchronousQueriesSession()` / `Base.asynchronousQueriesTracker()`
but left the call sites on the `core.ts` free functions. This converges them:

- `connection-adapters/abstract/database-statements.ts` now calls
  `Base.asynchronousQueriesSession()`.
- `AsynchronousQueriesTracker.run` now calls `Base.asynchronousQueriesTracker()`.

Both reach `Base` through the existing call-time `_registerBase` slot (as
`schema-migration.ts` / `query-cache.ts` do), so no load-time import edge into
`base.ts` is added — `scripts/test-deps/base-import-cycle.test.ts` stays green,
along with `future-result.trails.test.ts`, `trailtie.test.ts`,
`relation-load-async.trails.test.ts` and `executor-seam.trails.test.ts`.
`parity:api:calls` and `parity:api:calls:args` are green.

Closes-story: converge-async-query-session-callers-onto-base