### PR TITLE
fix(activerecord): SQLite3 performQuery returns an ActiveRecord::Result

### DIFF
--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-perform-query.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-perform-query.trails.test.ts
@@ -14,6 +14,7 @@ import { Base } from "../../base.js";
 import { SQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "../../connection-adapters/better-sqlite3-adapter.js";
 import { ReadOnlyError } from "../../errors.js";
+import { Result } from "../../result.js";
 import { acquireStatementLock } from "../../connection-adapters/sqlite3/database-statements.js";
 
 let adapter: SQLite3Adapter;
@@ -41,6 +42,28 @@ describeIfSqlite("SQLite3AdapterPerformQueryTest (trails)", () => {
   it("execute still returns rows for a row-returning statement", async () => {
     await adapter.executeMutation(`INSERT INTO "pq" ("nick") VALUES ('a')`);
     await expect(adapter.execute(`SELECT "nick" FROM "pq"`)).resolves.toEqual([{ nick: "a" }]);
+  });
+
+  it("rawExecute returns an ActiveRecord::Result carrying the statement's columns", async () => {
+    // `ActiveRecord::Result.new(stmt.columns, stmt.to_a)`
+    // (sqlite3/database_statements.rb:93) sources the columns from the
+    // statement, so a SELECT matching no rows still reports them — which is
+    // what makes cast_result (`:117-121`) the identity.
+    const empty = (await adapter.rawExecute(`SELECT "id", "nick" FROM "pq"`, "SQL")) as Result;
+    expect(empty).toBeInstanceOf(Result);
+    expect(empty.columns).toEqual(["id", "nick"]);
+    expect(empty.rows).toEqual([]);
+
+    // A non-row-returning statement takes `stmt.step; ActiveRecord::Result.empty`.
+    const written = (await adapter.rawExecute(
+      `INSERT INTO "pq" ("nick") VALUES ('a')`,
+      "SQL",
+    )) as Result;
+    expect(written.columns).toEqual([]);
+    expect(written.rows).toEqual([]);
+
+    const loaded = (await adapter.rawExecute(`SELECT "nick" FROM "pq"`, "SQL")) as Result;
+    expect(loaded.toArray()).toEqual([{ nick: "a" }]);
   });
 
   it("affectedRows reports the rows changed by the last write", async () => {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -525,7 +525,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
                 prepare: this.preparedStatements,
                 notificationPayload: payload,
               })
-            ).rows;
+            ).toArray();
           } catch (e: any) {
             const translated = this._translateException(e, sql, binds);
             throw translated;
@@ -679,16 +679,18 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
         false,
         async (payload) => {
           try {
-            // Use the values RETURNED by performQuery, not this._last* — those
-            // fields are shared and a concurrent write can overwrite them before
-            // this post-await continuation reads them (the Promise.all insert race).
-            const { affectedRows, insertRowid } = await this.performQuery(
-              this.driver,
-              sql,
-              binds,
-              driverBinds,
-              { prepare: this.preparedStatements, notificationPayload: payload },
-            );
+            // performQuery fills this in the same synchronous turn it writes
+            // `this._last*`; reading those shared fields back here instead
+            // would race, since a concurrent write's performQuery can overwrite
+            // them before this post-await continuation runs (the Promise.all
+            // insert race). See the `counters` note on performQuery.
+            const counters = { affectedRows: 0, insertRowid: 0 as number | bigint };
+            await this.performQuery(this.driver, sql, binds, driverBinds, {
+              prepare: this.preparedStatements,
+              notificationPayload: payload,
+              counters,
+            });
+            const { affectedRows, insertRowid } = counters;
             // perform_query reports the returned-row count (0 for a write); this
             // path has always reported affected rows, and subscribers rely on it.
             payload.row_count = affectedRows;

--- a/packages/activerecord/src/connection-adapters/sqlite3/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/database-statements.ts
@@ -235,15 +235,13 @@ export function acquireStatementLock(host: {
  * promise-returning, multi-driver) rather than better-sqlite3's native sync
  * API, so it is reachable from the adapter.
  *
- * Two deviations, both forced by that driver abstraction and by the
- * `execute`/`executeMutation` split (justified once at the `executeMutation`
- * declaration in abstract-adapter.ts):
+ * Like Rails (`:85-107`) it returns an `ActiveRecord::Result` — built from the
+ * statement's own columns, so a row-returning statement reports its column set
+ * even when it matches no rows — which is why `castResult` below is the
+ * identity, as it is in Rails (`:113-121`).
  *
- * - Rails returns an `ActiveRecord::Result` (`:82-107`); this returns the rows
- *   plus the two counters, because `executeMutation` needs the affected-row
- *   count and insert rowid as RETURNED locals — reading them back off the
- *   shared fields after its own await re-opens the concurrent-write race.
- *   `castResult` is the identity here either way, as it is in Rails (`:113`).
+ * One deviation, forced by that driver abstraction:
+ *
  * - Rails' unprepared arm guards `stmt.bind_params` with
  *   `unless binds.nil? || binds.empty?` (`:96-98`); binds reach this driver as
  *   a call argument rather than a separate `bind_params` round-trip, so an
@@ -263,13 +261,19 @@ export async function performQuery(
     prepare?: boolean;
     notificationPayload?: Record<string, unknown>;
     batch?: boolean;
+    // Out-parameter, filled in the same synchronous turn as
+    // `this._last*` below. Rails reads `@last_affected_rows` back through
+    // `affected_rows(result)` on the strength of `with_raw_connection`'s
+    // `@lock`, which one Ruby thread holds across the whole call; a JS caller
+    // resumes a microtask later, by which time an interleaving write's
+    // `perform_query` may already have overwritten the shared fields. Callers
+    // that need the counters (only `executeMutation` — itself the deviation
+    // justified at the `AbstractAdapter` declaration) pass this and read it
+    // instead. It carries no Rails behaviour of its own.
+    counters?: { affectedRows: number; insertRowid: number | bigint };
   } = {},
-): Promise<{
-  rows: Record<string, unknown>[];
-  affectedRows: number;
-  insertRowid: number | bigint;
-}> {
-  const { prepare = false, notificationPayload, batch = false } = options;
+): Promise<Result> {
+  const { prepare = false, notificationPayload, batch = false, counters } = options;
   // The lock is taken BEFORE the statement is prepared: Rails' `@lock` is held
   // by `with_raw_connection` (abstract/database_statements.rb:552-559) around
   // the whole of `perform_query`, preparation included, and `disconnect!` takes
@@ -283,7 +287,7 @@ export async function performQuery(
   const acquired = acquireStatementLock(this);
   const release = typeof acquired === "function" ? acquired : await acquired;
   let stmt: SqliteStatement | null = null;
-  let rows: Record<string, unknown>[];
+  let result: Result;
   let affectedRows: number;
   let insertRowid: number | bigint;
   try {
@@ -298,12 +302,23 @@ export async function performQuery(
         : await this._freshStatement(sql);
     if (stmt === null) {
       await rawConnection.exec(sql);
-      rows = [];
+      result = Result.empty();
     } else if (stmt.reader) {
-      rows = (await stmt.all(typeCastedBinds)) as Record<string, unknown>[];
+      // `ActiveRecord::Result.new(stmt.columns, stmt.to_a)` (`:93`, `:104`) —
+      // the columns come off the statement, not off the rows, so a SELECT that
+      // matches nothing still reports them.
+      const rows = (await stmt.all(typeCastedBinds)) as Record<string, unknown>[];
+      result =
+        rows.length > 0
+          ? Result.fromRowHashes(rows)
+          : new Result(
+              stmt.columns().map((c) => c.name),
+              [],
+            );
     } else {
+      // `stmt.step; ActiveRecord::Result.empty` (`:90-92`, `:101-103`).
       await stmt.run(typeCastedBinds);
-      rows = [];
+      result = Result.empty();
     }
     affectedRows = await rawConnection.changes();
     insertRowid = await rawConnection.lastInsertRowId();
@@ -314,33 +329,26 @@ export async function performQuery(
     // arm is the pool's to close. `finalize` is the driver's `close`.
     if (!prepare && stmt !== null) await stmt.finalize?.();
   }
-  // Persist for the affected_rows() port / public accessor. The RETURNED
-  // locals — not these fields — are what executeMutation uses for its return
-  // value: reading `this._lastInsertRowid` back after the caller's await
-  // would race, since a concurrent write's performQuery can overwrite it
-  // between this assignment and that read.
+  // `@last_affected_rows = raw_connection.changes` (`:108`). The insert rowid
+  // has no Rails field; it backs `executeMutation`'s INSERT return value.
   this._lastAffectedRows = affectedRows;
   this._lastInsertRowid = insertRowid;
+  if (counters) {
+    counters.affectedRows = affectedRows;
+    counters.insertRowid = insertRowid;
+  }
   // Rails' perform_query: `verified!` after @last_affected_rows, success
   // path only — a successful round-trip proves the connection is live.
   this.verifiedBang();
-  if (notificationPayload) notificationPayload.row_count = rows.length;
-  return { rows, affectedRows, insertRowid };
+  if (notificationPayload) notificationPayload.row_count = result.length;
+  return result;
 }
 
 /** @internal */
-export function castResult(result: Result | { rows: Record<string, unknown>[] }): Result {
-  // Rails' `cast_result` is the identity because its `perform_query` already
-  // returns an ActiveRecord::Result (sqlite3/database_statements.rb:110-121).
-  // trails' `performQuery` returns the raw `{ rows, affectedRows, insertRowid }`
-  // bag instead — `executeMutation` reads the last two off the RETURN value to
-  // avoid racing `this._last*` — so the identity arm only holds for the
-  // Result-shaped inputs, and the bag is built into a Result here, where Rails'
-  // perform_query builds it. Converging performQuery onto Rails' return shape
-  // (which also restores the column set of a zero-row SELECT) is story
-  // sqlite3-perform-query-returns-result.
-  if (result instanceof Result) return result;
-  return Result.fromRowHashes(result.rows);
+export function castResult(result: Result): Result {
+  // Given that SQLite3 doesn't really a Result type, raw_execute already return
+  // an ActiveRecord::Result and we have nothing to cast here.
+  return result;
 }
 
 /** @internal */

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/sqlite3/database-statements.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/sqlite3/database-statements.json
@@ -30,13 +30,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3/database-statements.ts",
-    "rubyName": "perform_query",
-    "call": "empty",
-    "reason": "Pre-existing divergence, newly SURFACED (not introduced) by story call-args-ar-select-all-empty-async-row: `Result.empty` gained Rails' `async:` kwarg (result.rb:94-100), which flips `isPortedWithArgs(\"empty\")` true, so compare.ts gate 2 stops suppressing every `empty`/`empty?` call whose TS spelling is a zero-arg reader. The TS bodies are unchanged."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3/database-statements.ts",
     "rubyName": "reset_isolation_level",
     "call": "internal_execute",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Rails' SQLite3 `perform_query` returns an `ActiveRecord::Result` built from the
statement's own columns and rows
(`activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb:85-107`),
which is precisely why its `cast_result` is the identity (`:117-121`).

trails' `performQuery` returned a raw `{ rows, affectedRows, insertRowid }` bag,
so `castResult` had to build a `Result` from it — a documented deviation that
also lost the column set of a zero-row row-returning statement, where Rails
keeps `stmt.columns`.

## What changed

- `performQuery` returns a `Result`: `Result.empty()` on the batch and
  non-row-returning arms (`stmt.step; ActiveRecord::Result.empty`, `:90-92`,
  `:101-103`), and the statement's columns + rows on the reader arm
  (`ActiveRecord::Result.new(stmt.columns, stmt.to_a)`, `:93`, `:104`) — so a
  SELECT matching nothing still reports its columns.
- `notification_payload[:row_count] = result&.length` now reads off the Result,
  as Rails does (`:111`).
- `castResult` is the identity again, with Rails' own comment; the
  `wire-load-async-through-future-result` deviation note is deleted, along with
  its `call-mismatches-exclude` row (`perform_query` / `empty`), which the
  ratchet reported stale once converged.
- `executeMutation` still gets its affected-row count and insert rowid without
  re-reading the shared `this._last*` fields across an await. It passes a
  `counters` out-parameter that `performQuery` fills in the same synchronous
  turn it writes those fields, so the `Promise.all` insert race (PR #4893) stays
  closed. Rails needs no such channel: `with_raw_connection`'s `@lock` is held
  by one Ruby thread across the whole call, so `affected_rows(result)` can read
  `@last_affected_rows` back safely; a JS caller resumes a microtask later.
- `execute` takes `.toArray()` (Ruby `to_a`) where it took `.rows`.

## Verification

- New trails coverage in `sqlite3-adapter-perform-query.trails.test.ts`: a
  zero-row SELECT through `rawExecute` comes back as a `Result` carrying its
  columns; a write comes back as `Result.empty`.
- `relation-load-async.trails.test.ts` — the `FutureResult` path that first
  surfaced the divergence — still round-trips on the SQLite lane.
- `pnpm parity:api:calls` / `parity:api:calls:args` green (one baseline row
  removed, `--write` reseed confirms it as the only diff); `parity:api:extra`
  adds no novel public name.
- 1599 tests across `persistence/`, `relation/`, `adapters/sqlite3/` and
  `connection-adapters/` pass locally.

Closes-story: sqlite3-perform-query-returns-result