### PR TITLE
refactor(activerecord): name _enum's value-method locals as Rails does

### DIFF
--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -634,8 +634,8 @@ export function _enum(
   // Rails' `_enum` takes `scopes: true, instance_methods: true` keyword
   // defaults; `scopes: false` suppresses per-value scope generation and
   // `instance_methods: false` suppresses predicate/bang generation.
-  const scopesEnabled = options?.scopes !== false;
-  const instanceMethodsEnabled = options?.instanceMethods !== false;
+  const scopes = options?.scopes !== false;
+  const instanceMethods = options?.instanceMethods !== false;
 
   // Conflict-detection pass, then the generation pass — both ported from the
   // former standalone `defineEnum`, now folded in so `_enum` is the single enum
@@ -680,9 +680,9 @@ export function _enum(
   // `EnumMethods.defineEnumMethods` is the single generator.
   const methodsModule = this._enumMethodsModule();
   for (const [n, value] of Object.entries(mapping)) {
-    const fullName = toCamel(methodName(n));
-    const { predicateName, bangName, notScopeName } = enumMethodNamesFor(fullName);
-    const friendlyName = toCamel(methodName(n).replace(/[^\w\x80-\uffff]+/g, "_"));
+    const valueMethodName = toCamel(methodName(n));
+    const { predicateName, bangName, notScopeName } = enumMethodNamesFor(valueMethodName);
+    const valueMethodAlias = toCamel(methodName(n).replace(/[^\w\x80-\uffff]+/g, "_"));
 
     // Rails feeds both the value method name and its special-char-stripped
     // friendly alias into detect_negative_enum_conditions! (enum.rb:266-279),
@@ -692,10 +692,11 @@ export function _enum(
     // a conflict — the alias sticks to the first label and the second label
     // simply doesn't get one, and its `define_enum_methods` call is skipped
     // with it.
-    valueMethodNames.push(fullName);
-    const aliasIsNew = friendlyName !== fullName && !valueMethodNames.includes(friendlyName);
+    valueMethodNames.push(valueMethodName);
+    const aliasIsNew =
+      valueMethodAlias !== valueMethodName && !valueMethodNames.includes(valueMethodAlias);
     if (aliasIsNew) {
-      valueMethodNames.push(friendlyName);
+      valueMethodNames.push(valueMethodAlias);
     }
 
     // Rails runs `detect_enum_conflict!` for the `?`/`!` methods *only* inside
@@ -704,7 +705,7 @@ export function _enum(
     // opting out of a surface also opts out of its conflict checks — e.g.
     // `instance_methods: false` must not raise on a predicate-name collision it
     // will never generate.
-    if (instanceMethodsEnabled) {
+    if (instanceMethods) {
       // `definedNames` models Rails' `_enum_methods_module`: every
       // `define_enum_methods` call within a single `_enum` defines into that one
       // module, so an intra-enum collision (a later label reusing an earlier
@@ -730,10 +731,10 @@ export function _enum(
       if (enumMethodNames.has(bangName))
         raiseConflictError.call(this, name, bangName, { source: "another enum" });
     }
-    if (scopesEnabled) {
-      if (definedNames.has(fullName))
-        raiseConflictError.call(this, name, fullName, { type: "class" });
-      definedNames.add(fullName);
+    if (scopes) {
+      if (definedNames.has(valueMethodName))
+        raiseConflictError.call(this, name, valueMethodName, { type: "class" });
+      definedNames.add(valueMethodName);
       // The value/`not*` scope names are class methods, so route them through
       // the class-method conflict detector, which consults all three Rails
       // sub-branches (a *dangerous* class method — RESTRICTED_CLASS_METHODS plus
@@ -741,7 +742,7 @@ export function _enum(
       // special-case), each raising with the correct type/source rather than the
       // generic scope error. A scope inherited from a parent enum or a plain
       // user static on the model/an ancestor is NOT a conflict.
-      detectEnumConflictBang.call(this, name, fullName, true);
+      detectEnumConflictBang.call(this, name, valueMethodName, true);
       detectEnumConflictBang.call(this, name, notScopeName, true);
     }
     if (aliasIsNew) {
@@ -749,8 +750,8 @@ export function _enum(
         predicateName: fp,
         bangName: friendlyBang,
         notScopeName: notFriendlyName,
-      } = enumMethodNamesFor(friendlyName);
-      if (instanceMethodsEnabled) {
+      } = enumMethodNamesFor(valueMethodAlias);
+      if (instanceMethods) {
         // Rails defines each friendly alias immediately through
         // `_enum_methods_module`, so `detect_enum_conflict!` catches an
         // already-defined method within the *same* enum (enum.rb:273-275,
@@ -771,8 +772,8 @@ export function _enum(
         if (enumMethodNames.has(friendlyBang))
           raiseConflictError.call(this, name, friendlyBang, { source: "another enum" });
       }
-      if (scopesEnabled) {
-        detectEnumConflictBang.call(this, name, friendlyName, true);
+      if (scopes) {
+        detectEnumConflictBang.call(this, name, valueMethodAlias, true);
         detectEnumConflictBang.call(this, name, notFriendlyName, true);
       }
     }
@@ -782,22 +783,16 @@ export function _enum(
     // `define_enum_methods` calls per value (enum.rb:265-278). This defines the
     // predicate `is{Name}`, the persisting bang `{name}Bang`, the positive
     // scope `{name}`, and the auto negative scope `not{Name}`.
-    methodsModule.defineEnumMethods(name, fullName, value, scopesEnabled, instanceMethodsEnabled);
+    methodsModule.defineEnumMethods(name, valueMethodName, value, scopes, instanceMethods);
     if (aliasIsNew) {
-      methodsModule.defineEnumMethods(
-        name,
-        friendlyName,
-        value,
-        scopesEnabled,
-        instanceMethodsEnabled,
-      );
+      methodsModule.defineEnumMethods(name, valueMethodAlias, value, scopes, instanceMethods);
     }
 
     // Original-form predicate/bang for labels with special chars (spaces,
     // hyphens). Rails: define_method("American Bobtail?"), reachable via
     // bracket notation only.
     const originalName = methodName(n);
-    if (instanceMethodsEnabled && /[^\w\x80-\uffff]/.test(originalName)) {
+    if (instanceMethods && /[^\w\x80-\uffff]/.test(originalName)) {
       const carrier = methodsModule.carrier();
       Object.defineProperty(carrier, `is${originalName}`, {
         value: function (this: Base) {
@@ -821,14 +816,14 @@ export function _enum(
     // `_enum_methods_module`. Only record when the predicate/bang were actually
     // defined (`instance_methods: false` defines neither, so a later enum reusing
     // the name must not conflict).
-    if (instanceMethodsEnabled) {
-      const names = enumMethodNamesFor(fullName);
+    if (instanceMethods) {
+      const names = enumMethodNamesFor(valueMethodName);
       enumMethodNames.add(names.predicateName);
       enumMethodNames.add(names.bangName);
       if (aliasIsNew) {
-        const friendlyNames = enumMethodNamesFor(friendlyName);
-        enumMethodNames.add(friendlyNames.predicateName);
-        enumMethodNames.add(friendlyNames.bangName);
+        const valueMethodAliasNames = enumMethodNamesFor(valueMethodAlias);
+        enumMethodNames.add(valueMethodAliasNames.predicateName);
+        enumMethodNames.add(valueMethodAliasNames.bangName);
       }
     }
   }
@@ -838,7 +833,7 @@ export function _enum(
   // skips the check entirely when scopes are disabled.
   // Mirrors: `detect_negative_enum_conditions!(value_method_names) if scopes`
   // (enum.rb:262), after the generation loop.
-  if (scopesEnabled) {
+  if (scopes) {
     detectNegativeEnumConditionsBang(valueMethodNames);
   }
 


### PR DESCRIPTION
RFC 0096 wave 3, model-core / associations / encryption / tasks slot.

## What this ships

`_enum`'s body locals now carry the Rails identifiers from
`enum.rb:221-262` — `fullName` → `valueMethodName`, `friendlyName` →
`valueMethodAlias`, `scopesEnabled` → `scopes`, `instanceMethodsEnabled` →
`instanceMethods`. That closes both `define_enum_methods` call-argument
`naming` rows. No behavior change, no public surface change.

## The slot was already drained

The story's table was measured on `origin/main` at 059bfe688 (2026-08-12) and
listed **47 rows across 28 files**. Re-measured on 8ee808ff5, activerecord is
down to **59 naming rows repo-wide**, and this slot's share is **18** — sibling
wave-3 PRs (notably the `module-mixin-receiver-this-typed` work) already closed
`store.ts`, `connection-handling.ts`, `autosave-association.ts` (all 5),
`encryption/extended-deterministic-queries.ts` (all 3), `token-for.ts`,
`signed-id.ts`, `scoping/named.ts`, `has-one-association.ts`,
`encryption/encryptable-record.ts`, `model-schema.ts#yamlEncoder`,
`normalization.ts`, `query-logs.ts`, `validations/uniqueness.ts` and
`tasks/mysql-database-tasks.ts`.

So the `>=24` threshold from the recalibration note is no longer reachable in
this slot: **2 of the 18 survivors close by renaming**, and they are the two
shipped here. Every remaining row was read against `vendor/rails` and is a1/a3
or tooling residue, itemised below.

## Rows deliberately left standing

Permanent (classifier `js-reserved-word` / `no-js-equivalent`), one shared
reason at the gate flip — never per-row:

- `associations/belongs-to-polymorphic-association.ts` — Ruby `class` vs
  `ref:constructor`.
- `associations/collection-association.ts` x2 — Ruby `size` vs `length` in
  `raise_record_not_found_exception!`.

Recording artifacts of the settled trails idioms (module-mixin `.call(this)`,
the block idiom) — **not baselineable**, they close when the recorder learns
those shapes:

- `model-schema.ts#columns` — `Object.values(columnsHash.call(this))`; the
  recorder sees `ref:call` where Rails sees `ref:columnsHash`.
- `associations/belongs-to-association.ts#writer` — `block(this.owner)` is the
  trails spelling of `owner.instance_exec(&block)`
  (`belongs_to_association.rb:47`).
- `attribute-methods.ts` — `include(this, this._generatedAttributeMethods)`;
  Rails' `generated_attribute_methods` is a method, trails' is a field.
  Converging needs a public accessor, which is out of scope for a naming PR.
- `migration.ts#migrate` — `this._direction` is the ivar `@direction`
  (`migration.rb:1422`); the `_`-prefixed private-field spelling is repo-wide
  and belongs to a taxonomy class, not to one file.

a1/a3 findings, already filed or filed-worthy:

- `internal-metadata.ts#selectEntry` — trails uses a bare `.eq(key)` where Rails
  wraps in `Arel::Nodes::BindParam.new(key)` (`internal_metadata.rb:154-157`).
  Already tracked by
  `0023-surfaced-deviations/internal-metadata-private-helper-arel-deviations`
  (item 1), which is `ready`.
- `encryption/encrypted-attribute-type.ts#deserialize` — the `decrypted` local
  exists only to feed the trails-only `?? decrypted` fallback that Rails
  (`encrypted_attribute_type.rb:36`) does not have; inlining is a behavior
  change, not a rename.
- `encryption/cipher/aes256-gcm.ts#generateIv` — the arg divergence is the
  already-documented deviation at the call site (`@deterministic` in the IV
  slot, plus the string→Buffer conversion Rails has no counterpart for).
- `enum.ts#serialize` / `isSerializable` — Ruby `mapping.fetch(value, value)`
  has no JS equivalent; the `mapped` local is the expansion.
- `tasks/sqlite-database-tasks.ts` — passes `config.configuration` where Rails
  passes `config`; a3, structural.
- `database-configurations.ts#buildDbConfigFromRawConfig` — Ruby
  `config.symbolize_keys`.
- `middleware/database-selector/resolver/session.ts` — `Temporal.Now.instant()`
  vs `Time.now`.
- `nested-attributes.ts` — Ruby `attributes.except(...)` inlined into `build`.
- `associations/collection-association.ts#delete` — a `Map` delete keyed by
  `recordIdentity`, not a record.

`attribute-methods.ts#generateAliasAttributeMethods` stays with
`naming-burndown-3-arel-activemodel` to keep the file sets disjoint, as the
story asks.

## Gates

- `pnpm parity:api:calls` — OK (no baseline row added, widened or reseeded).
- `pnpm parity:api:calls:args` — OK (242 baselined shape rows, unchanged; no new
  `shape` rows).
- `pnpm typecheck`, `pnpm lint` clean; `enum.test.ts` 101/101.

Closes-story: naming-burndown-3-ar-model-encryption-tasks
