### PR TITLE
refactor(activesupport): drop the Logger.prototype predicate loop shadowing the literal getters

### DIFF
--- a/packages/activesupport/src/logger.ts
+++ b/packages/activesupport/src/logger.ts
@@ -349,17 +349,6 @@ export class Logger {
   }
 }
 
-// Add convenience predicate methods (debug?, info?, etc.)
-(["debug", "info", "warn", "error", "fatal"] as LogLevel[]).forEach((name) => {
-  const level = LOG_LEVELS[name];
-  Object.defineProperty(Logger.prototype, `${name}?`, {
-    get() {
-      return this.level <= level;
-    },
-    configurable: true,
-  });
-});
-
 /**
  * TaggedLogging — wraps a Logger to prepend tags to messages.
  * Mirrors ActiveSupport::TaggedLogging.


### PR DESCRIPTION
`packages/activesupport/src/logger.ts` defined each severity predicate twice: the faithful port as class-body getters `debug?`/`info?`/`warn?`/`error?`/`fatal?` (the shape ruby/logger's `lib/logger.rb` has, and the one `vendor/rails/activesupport/lib/active_support/broadcast_logger.rb:167-213` delegates to), and a `forEach` at the bottom of the file redefining the same five names on `Logger.prototype`. The loop's descriptors overwrote the class-body getters at module-eval time, so the getters a reader sees in the class were dead. Rails has no such loop.

Deleted the `forEach`; the five class-body getters stay and are now what every `logger["debug?"]` call reads, on `Logger`, `NullLogger` and any subclass. Nothing in the tree referenced `Logger.prototype` (grep), so nothing depended on the descriptors being own-configurable properties. The separate `Object.defineProperty` loop in `makeTaggedProxy` targets a plain proxy object, not the prototype, and is untouched.

activesupport logger/broadcast/tagged-logging suites pass (289 tests); `parity:api:extra --package activesupport` non-negative (deletion only).

Note: the bundled story `sqlite3-internal-exec-query-delegates-to-raw-execute` is NOT in this PR — it is blocked on PR #6539 (`sqlite3-perform-query-returns-result`), still open. On main `performQuery` still returns the `{rows, affectedRows, insertRowid}` bag and `castResult` rebuilds via `Result.fromRowHashes`, which drops the column set of a zero-row row-returning statement, so converging `internalExecQuery` onto `castResult(rawExecute(...))` today would regress it. Story marked blocked.

Closes-story: drop-logger-prototype-predicate-loop