### PR TITLE
fix(parity): don't walk a same-file constructor in the call-set closure

### DIFF
--- a/scripts/api-compare/call-mismatches-exclude/actionview/renderer/abstract-renderer.json
+++ b/scripts/api-compare/call-mismatches-exclude/actionview/renderer/abstract-renderer.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "actionview",
+    "tsFile": "renderer/abstract-renderer.ts",
+    "rubyName": "local_variable",
+    "call": "basename",
+    "reason": "Rails' local_variable takes the base via `File.basename(path)` (actionview/lib/action_view/renderer/abstract_renderer.rb:48); trails splits on `/` inline instead of calling the ported `basename`. Unmasked by the RFC 0025 same-file-closure fix, not introduced by it."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/cache/entry.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/cache/entry.json
@@ -2,6 +2,13 @@
   {
     "package": "activesupport",
     "tsFile": "cache/entry.ts",
+    "rubyName": "compressed",
+    "call": "compressed?",
+    "reason": "Rails' Entry#compressed short-circuits on its own `compressed?` predicate (activesupport/lib/active_support/cache/entry.rb:77); trails' port tests the `_compressed` field inline instead of calling the ported predicate. Unmasked by the RFC 0025 same-file-closure fix, not introduced by it."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "cache/entry.ts",
     "rubyName": "dup_value!",
     "call": "compressed?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/duration.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/duration.json
@@ -16,6 +16,13 @@
   {
     "package": "activesupport",
     "tsFile": "duration.ts",
+    "rubyName": "build",
+    "call": "include?",
+    "reason": "Rails' Duration.build sets `variable` via `VARIABLE_PARTS.include?(part)` (activesupport/lib/active_support/duration.rb:206); trails' port derives it without the ported `include`/`includes` call. Unmasked by the RFC 0025 same-file-closure fix, not introduced by it."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "duration.ts",
     "rubyName": "iso8601",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/hash-with-indifferent-access.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/hash-with-indifferent-access.json
@@ -2,6 +2,13 @@
   {
     "package": "activesupport",
     "tsFile": "hash-with-indifferent-access.ts",
+    "rubyName": "merge",
+    "call": "update",
+    "reason": "Rails' HashWithIndifferentAccess#merge is `dup.update(*hashes, &block)` (activesupport/lib/active_support/hash_with_indifferent_access.rb:274); trails' merge copies entries inline instead of delegating to the ported `update`. Unmasked by the RFC 0025 same-file-closure fix, not introduced by it."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "hash-with-indifferent-access.ts",
     "rubyName": "replace",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -369,6 +369,31 @@ describe("significantMissingCalls", () => {
       expect(reachedSameFileMethods("a", ["b"], (n) => cycle.get(n))).toEqual(new Set(["b", "c"]));
     });
 
+    it("does not walk into a same-file `constructor` a `new X()` recorded", () => {
+      // `new Requested({...})` in LookupContext#detailArgsForAny records the
+      // call as `constructor`, and every class in the file declares one — so
+      // resolving it credits the body with an unrelated constructor's calls,
+      // and editing that constructor changes a byte-identical body's missing
+      // set (RFC 0025 extractor-missing-set-perturbed-by-unrelated-edits).
+      const sameFile = new Map<string, string[]>([
+        ["constructor", ["initializeDetails", "buildViewPaths", "detailsKey"]],
+        ["detailsKey", ["detailsCacheKey"]],
+      ]);
+      const own = new Set(["_detailArgsForAny", "_detailsCache", "constructor"]);
+      const calls = (n: string) => sameFile.get(n);
+      expect(reachedSameFileMethods("detailArgsForAny", own, calls)).toEqual(new Set());
+      const tsCalls = effectiveTsCalls("detailArgsForAny", own, () => undefined, calls);
+      const missing = significantMissingCalls(
+        "detail_args_for_any",
+        ["details_cache_key"],
+        tsCalls,
+        () => true,
+        (rc) => (rc === "details_cache_key" ? ["detailsCacheKey"] : null),
+        new Set(["details_cache_key"]),
+      );
+      expect(missing).toEqual(["details_cache_key → detailsCacheKey"]);
+    });
+
     it("still flags a call no helper in the chain makes", () => {
       const own = new Set(file.get("indexes"));
       const tsCalls = effectiveTsCalls("indexes", own, () => undefined, sameFileCalls);

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -370,11 +370,6 @@ describe("significantMissingCalls", () => {
     });
 
     it("does not walk into a same-file `constructor` a `new X()` recorded", () => {
-      // `new Requested({...})` in LookupContext#detailArgsForAny records the
-      // call as `constructor`, and every class in the file declares one — so
-      // resolving it credits the body with an unrelated constructor's calls,
-      // and editing that constructor changes a byte-identical body's missing
-      // set (RFC 0025 extractor-missing-set-perturbed-by-unrelated-edits).
       const sameFile = new Map<string, string[]>([
         ["constructor", ["initializeDetails", "buildViewPaths", "detailsKey"]],
         ["detailsKey", ["detailsCacheKey"]],

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -684,13 +684,31 @@ export function isDelegatingWrapper(tsName: string, tsCalls: Set<string>): boole
 export const SAME_FILE_CLOSURE_DEPTH = 3;
 
 /**
+ * Call names the extractor synthesizes from a syntactic form instead of reading
+ * them off a named callee, so a same-file member carrying the name is NOT what
+ * the body called and must not be walked into.
+ *
+ * `new Requested({...})` records the call as `constructor` — the name every
+ * class in the file declares, whichever class was constructed. Resolving it in
+ * the same-file closure unions an unrelated constructor's call-set (and, three
+ * hops out, everything that constructor reaches) into this body's effective
+ * calls, so editing that constructor changes THIS body's `missing` set with its
+ * own body byte-identical: `lookup_context.rb`'s `detail_args_for_any` stopped
+ * flagging `details_cache_key` because `LookupContext`'s constructor was edited
+ * to reach `detailsKey` (RFC 0025
+ * `extractor-missing-set-perturbed-by-unrelated-edits`).
+ */
+const SYNTHETIC_CALL_NAMES: ReadonlySet<string> = new Set(["constructor"]);
+
+/**
  * The same-file methods a TS body reaches transitively, up to `depth` hops.
  *
  * `sameFileCalls` resolves a method name to its call-set ONLY when that method
  * is defined in the same TS file as the body under comparison — that scoping is
  * what makes the closure sound (unlike the package-wide `delegateCalls` map,
  * which an unrelated same-named method can satisfy). `tsName` seeds the visited
- * set, so self-recursion and longer cycles terminate.
+ * set, so self-recursion and longer cycles terminate. Names in
+ * SYNTHETIC_CALL_NAMES are never resolved or expanded.
  */
 export function reachedSameFileMethods(
   tsName: string,
@@ -704,6 +722,7 @@ export function reachedSameFileMethods(
   for (let hop = 0; hop < depth && frontier.length > 0; hop++) {
     const next: string[] = [];
     for (const name of frontier) {
+      if (SYNTHETIC_CALL_NAMES.has(name)) continue;
       if (visited.has(name)) continue;
       visited.add(name);
       const calls = sameFileCalls(name);


### PR DESCRIPTION
The call-set extractor's verdict for one method changed when *other* methods in
the same file were edited, making a baseline row go stale without anything
converging.

## Cause

`new Requested({...})` is extracted as a call named `constructor` — the name
every class in a file declares, whichever class was actually constructed. The
same-file closure (`reachedSameFileMethods`) resolves call names against the
file, so it walked into an unrelated constructor and unioned its call-set (and,
three hops out, everything that constructor reaches) into the body's effective
calls.

That is exactly the reported case: `LookupContext#detailArgsForAny` calls
`new Requested(...)` → `constructor` → `LookupContext`'s constructor → … →
`detailsKey` → `detailsCacheKey`, so PR 6470's edit to the constructor
silenced `details_cache_key → detailsCacheKey` on a byte-identical body.

Reproduced locally on `main`: adding a single `this.detailsKey()` line to
`LookupContext`'s constructor drops that entry from `detail_args_for_any`'s
`missing` set; with this fix the entry survives the same perturbation.

## Fix

`SYNTHETIC_CALL_NAMES` — call names the extractor synthesizes from a syntactic
form rather than reading off a named callee — are neither resolved nor expanded
by the closure. `constructor` is the one member.

## Unmasked rows

The old behaviour was discharging four real, pre-existing omissions through an
unrelated constructor. They are baselined with Rails `file:line` citations and
a convergence story
(`0025-fidelity-verification-tooling/converge-constructor-closure-unmasked-call-omissions`):
`cache/entry.ts compressed` (`compressed?`), `duration.ts build` (`include?`),
`hash-with-indifferent-access.ts merge` (`update`), and
`renderer/abstract-renderer.ts local_variable` (`basename`).

`pnpm parity:api:calls` and `pnpm parity:api:calls:args` are green.

Closes-story: extractor-missing-set-perturbed-by-unrelated-edits
