### PR TITLE
refactor(activerecord): SQLite3 inherits internalExecQuery; narrow bigints in performQuery

### DIFF
--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.bigint-narrowing.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.bigint-narrowing.trails.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { SQLite3Adapter } from "./sqlite3-adapter.js";
+import { BetterSQLite3Adapter } from "./better-sqlite3-adapter.js";
+
+// `readBigInts` is statement-wide, so a SELECT touching one BIGINT column also
+// widens every INTEGER column of the same row. The narrowing that undoes that
+// spill lives in the single `performQuery` reader arm, which every read path
+// funnels through — `execQuery`/`internalExecQuery`, `execute`, `rawExecute`,
+// and the `loadAsync` FutureResult path. Before, only `internalExecQuery`
+// narrowed, so the same SELECT answered `number` one way and `bigint` the other.
+describe("SQLite3Adapter bigint narrowing", () => {
+  let adapter: SQLite3Adapter;
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "trails-sqlite-bignarrow-"));
+    adapter = new BetterSQLite3Adapter(path.join(tmpDir, "db.sqlite3"));
+    await adapter.executeMutation(
+      "CREATE TABLE widgets (id INTEGER PRIMARY KEY, wide BIGINT, narrow INTEGER)",
+    );
+    await adapter.executeMutation("INSERT INTO widgets (id, wide, narrow) VALUES (1, 7, 2)");
+  });
+
+  afterEach(async () => {
+    await adapter.dropTable("widgets", { ifExists: true });
+    await adapter.close();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("narrows spilled bigints identically through execQuery and execute", async () => {
+    const sql = "SELECT id, wide, narrow FROM widgets";
+    const viaExecQuery = (await adapter.execQuery(sql)).toArray()[0];
+    const viaExecute = (await adapter.execute(sql))[0];
+
+    expect(typeof viaExecQuery.narrow).toBe("number");
+    expect(typeof viaExecute.narrow).toBe("number");
+    expect(typeof viaExecQuery.id).toBe("number");
+    expect(typeof viaExecute.id).toBe("number");
+    // The bigint-declared column keeps the wide value on both paths.
+    expect(typeof viaExecQuery.wide).toBe("bigint");
+    expect(typeof viaExecute.wide).toBe("bigint");
+    expect(viaExecute).toEqual(viaExecQuery);
+  });
+
+  it("narrows spilled bigints through rawExecute", async () => {
+    const result = (await adapter.rawExecute("SELECT id, wide, narrow FROM widgets")) as {
+      toArray(): Record<string, unknown>[];
+    };
+    const row = result.toArray()[0];
+    expect(typeof row.id).toBe("number");
+    expect(typeof row.narrow).toBe("number");
+  });
+});

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -883,7 +883,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   /**
    * Rails' SQLite3Adapter has no `exec_query` override: `exec_query` lives on
    * the abstract DatabaseStatements and funnels into `internal_exec_query`. We
-   * mirror that by delegating to our `internalExecQuery`.
+   * mirror that by delegating to `internalExecQuery`.
    */
   override async execQuery(
     sql: string,

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -79,7 +79,6 @@ import {
   executeBatch as sqliteExecuteBatch,
   castResult as sqliteCastResult,
   affectedRows as sqliteAffectedRows,
-  acquireStatementLock,
   performQuery as sqlitePerformQuery,
 } from "./sqlite3/database-statements.js";
 import { Result } from "../result.js";
@@ -621,7 +620,11 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   // at the row boundary so only bigint-declared columns keep the wide value, and
   // only where the value still fits a JS number (above that, a bigint is the
   // faithful reading and the alternative is silent precision loss).
-  private _narrowSpilledBigInts(stmt: SqliteStatement, rows: Record<string, unknown>[]): void {
+  // Non-private (underscore-public) so the extracted `performQuery` in
+  // sqlite3/database-statements.ts can reach it through PerformQueryHost —
+  // it is the one reader arm, so every path (`execQuery`, `execute`,
+  // `rawExecute`, `loadAsync`) narrows identically.
+  _narrowSpilledBigInts(stmt: SqliteStatement, rows: Record<string, unknown>[]): void {
     const wide = new Set(
       stmt
         .columns()
@@ -891,72 +894,11 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     return this.internalExecQuery(sql, name, binds, options);
   }
 
-  /**
-   * Run a query and return an ActiveRecord::Result.
-   *
-   * Mirrors Rails' SQLite3Adapter#perform_query (then `cast_result`): a
-   * non-row-returning statement (INSERT/UPDATE/DELETE/DDL) yields an empty
-   * Result, while a row-returning statement reports its column set from the
-   * prepared statement even when it matches no rows — `Result.fromRowHashes`
-   * drops the columns on a zero-row result. Like Rails' `perform_query`, the
-   * statement is pooled only on the `prepare` branch; otherwise a fresh
-   * statement is used.
-   */
-  override async internalExecQuery(
-    sql: string,
-    name: string | null = "SQL",
-    binds: unknown[] = [],
-    options: { prepare?: boolean; allowRetry?: boolean } = {},
-  ): Promise<Result> {
-    const processed = this.preprocessQuery(sql);
-    await this.materializeTransactions();
-    const driverBinds = (binds ?? []).map(_driverBind, this) as SqliteBinds;
-    // Rails' SQLite `perform_query` pools the statement only when `prepare` is
-    // true (`@statements[sql] ||= ...`) and otherwise prepares a fresh one. The
-    // `exec_query` keyword defaults to `false` (database_statements.rb), so we
-    // default to a fresh statement and pool only on an explicit `prepare: true`;
-    // the preparable decision lives upstream, not here.
-    const prepare = options.prepare ?? false;
-    return this.log(
-      processed,
-      name,
-      binds ?? [],
-      this.typeCastedBinds(binds ?? []) ?? [],
-      false,
-      async (payload) => {
-        try {
-          const stmt = await (prepare
-            ? this._cachedStatement(processed)
-            : this._freshStatement(processed));
-          let result: Result;
-          const release = await acquireStatementLock(this);
-          try {
-            if (!stmt.reader) {
-              await stmt.run(driverBinds);
-              result = Result.empty();
-            } else {
-              const rows = (await stmt.all(driverBinds)) as Record<string, unknown>[];
-              this._narrowSpilledBigInts(stmt, rows);
-              payload.row_count = rows.length;
-              result =
-                rows.length > 0
-                  ? Result.fromRowHashes(rows)
-                  : new Result(
-                      stmt.columns().map((c) => c.name),
-                      [],
-                    );
-            }
-          } finally {
-            release();
-          }
-          return this.castResult(result);
-        } catch (e: any) {
-          const translated = this._translateException(e, processed, binds);
-          throw translated;
-        }
-      },
-    );
-  }
+  // Rails' SQLite3Adapter has no `internal_exec_query` override: the abstract
+  // `cast_result(internal_execute(...))`
+  // (abstract/database_statements.rb:546-548) funnels the whole read path
+  // through the one `perform_query` (sqlite3/database_statements.rb:78-113),
+  // so we inherit it too.
 
   // Mirrors: SQLite3::DatabaseStatements#begin_db_transaction
   async beginDbTransaction(): Promise<void> {

--- a/packages/activerecord/src/connection-adapters/sqlite3/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/database-statements.ts
@@ -110,6 +110,7 @@ interface InternalBeginTransactionHost {
 interface PerformQueryHost {
   _cachedStatement(sql: string): Promise<SqliteStatement>;
   _freshStatement(sql: string): Promise<SqliteStatement>;
+  _narrowSpilledBigInts(stmt: SqliteStatement, rows: Record<string, unknown>[]): void;
   verifiedBang(): void;
   _statementLock: Promise<void> | null;
   _lastAffectedRows: number;
@@ -308,6 +309,7 @@ export async function performQuery(
       // the columns come off the statement, not off the rows, so a SELECT that
       // matches nothing still reports them.
       const rows = (await stmt.all(typeCastedBinds)) as Record<string, unknown>[];
+      this._narrowSpilledBigInts(stmt, rows);
       result =
         rows.length > 0
           ? Result.fromRowHashes(rows)


### PR DESCRIPTION
Rails' `SQLite3Adapter` has no `internal_exec_query` override — the abstract
`cast_result(internal_execute(...))`
(`abstract/database_statements.rb:546-548`) funnels the whole read path
through the one `perform_query` (`sqlite3/database_statements.rb:78-113`).

trails' override re-prepared the statement, re-took the statement lock and
rebuilt the `Result`: a second copy of the branch `performQuery` already has.
#6539 removed the reason it existed (`performQuery` now returns an
`ActiveRecord::Result` built from `stmt.columns()`, and `castResult` is the
identity again), so the override is deleted and SQLite inherits the abstract
one.

The duplication was also carrying a live behavioural asymmetry surfaced in
review of #6539: only `internalExecQuery` called `_narrowSpilledBigInts`, so
a statement-wide `readBigInts` spill onto INTEGER columns was narrowed
through `execQuery` and not through `execute` / `rawExecute` / the `loadAsync`
`FutureResult` path. The narrowing is real (better-sqlite3's `readBigInts` is
statement-wide; Ruby has a single Integer and MRI's raw values carry no
width), so it moves to the one `performQuery` reader arm rather than being
dropped — every path now narrows identically.

`sqlite3-adapter.bigint-narrowing.trails.test.ts` covers the asymmetry
directly and fails on the baseline (`bigint` where `number` is expected via
`execute`/`rawExecute`).

One behaviour change rides along and is intended: the deleted override never
called `dirtyCurrentTransaction()`, while the inherited path exits through
`rawExecute`'s `finally`, which does. That matches Rails, where
`with_raw_connection` always dirties on exit when `materialize_transactions`
is true (`abstract_adapter.rb:1046`) — the override was the divergent side.

`parity:api:calls` OK (1684 baselined), `parity:api:calls:args` OK (239
shape rows) — no rows added.

Closes-story: sqlite3-internal-exec-query-delegates-to-raw-execute
