### PR TITLE
fix(trailties): drop stale story pointer from minitest plugin receipts

### DIFF
--- a/packages/trailties/src/minitest/rails-plugin.ts
+++ b/packages/trailties/src/minitest/rails-plugin.ts
@@ -16,8 +16,7 @@ import { Trails } from "../rails.js";
  * outside the trailties libPath the API comparator scans
  * (`railties/lib/rails`, vendor/sources.ts:128), so it cannot be matched —
  * the same reason `Minitest::BacktraceFilter` carries one in
- * `activesupport/src/testing/assertions.ts`. Tracked by
- * `widen-trailties-libpath-to-cover-lib-minitest`.
+ * `activesupport/src/testing/assertions.ts`.
  */
 export class BacktraceFilterWithFallback {
   private preferred: { filter(backtrace: string[]): string[] };
@@ -51,8 +50,7 @@ export class BacktraceFilterWithFallback {
  *
  * @noRailsEquivalent CONVERGEABLE — comparator gap, not a deviation. Ports
  * `Minitest.plugin_rails_init`, which the comparator cannot see for the libPath
- * reason on {@link BacktraceFilterWithFallback}; same story,
- * `widen-trailties-libpath-to-cover-lib-minitest`.
+ * reason on {@link BacktraceFilterWithFallback}.
  */
 export function pluginRailsInit(options: { fullBacktrace?: boolean }): void {
   if (env.RAILS_ENV == null && env.RAILS_MINITEST_PLUGIN == null) return;


### PR DESCRIPTION
Unit Tests went red on main @9fe1b049 in `scripts/stale-story-references.test.ts`:

```
"packages/trailties/src/minitest/rails-plugin.ts:9 widen-trailties-libpath-to-cover-lib-minitest"
```

`widen-trailties-libpath-to-cover-lib-minitest` was closed (reason: "No mini test") after the two `@noRailsEquivalent` receipts in `rails-plugin.ts` were written to cite it, so the citations became stale and the gate fired. The receipts themselves still stand — `railties/lib/minitest/` genuinely sits outside the trailties `libPath` the comparator scans (`vendor/sources.ts:128`), which is what the tag documents — so only the dead `Tracked by <slug>` pointers are removed; the gap explanation stays verbatim.

Widening `libPath` is not a red-CI fix: it is a single directory string consumed as a path throughout `scripts/api-compare/`, and pointing it at `railties/lib` would pull the whole of railties into the population.

`pnpm vitest run scripts/stale-story-references.test.ts` — 17 passed.

Closes-story: red-9fe1b049
