### PR TITLE
refactor(activesupport): split DateTime.current onto its own receiver

### DIFF
--- a/packages/activesupport/package.json
+++ b/packages/activesupport/package.json
@@ -66,6 +66,10 @@
       "types": "./dist/core-ext/date/calculations.d.ts",
       "default": "./dist/core-ext/date/calculations.js"
     },
+    "./core-ext/date-time/calculations": {
+      "types": "./dist/core-ext/date-time/calculations.d.ts",
+      "default": "./dist/core-ext/date-time/calculations.js"
+    },
     "./core-ext/string/conversions": {
       "types": "./dist/core-ext/string/conversions.d.ts",
       "default": "./dist/core-ext/string/conversions.js"

--- a/packages/activesupport/src/core-ext/date-time-ext.test.ts
+++ b/packages/activesupport/src/core-ext/date-time-ext.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect } from "vitest";
-import type { Temporal } from "@blazetrails/date";
+import { describe, it, expect, afterEach } from "vitest";
+import { Temporal } from "@blazetrails/date";
+import { current } from "./date-time/calculations.js";
+import { setFrozenTime } from "../time-travel.js";
+import { setZone } from "../time-zone-config.js";
 import {
   advance,
   ago,
@@ -30,6 +33,11 @@ import {
   toTime,
   xmlschema,
 } from "../time-ext.js";
+
+afterEach(() => {
+  setFrozenTime(null);
+  setZone(null);
+});
 
 function asDate(instant: Temporal.Instant): Date {
   return new Date(instant.epochMilliseconds);
@@ -233,16 +241,39 @@ describe("DateTimeExtCalculationsTest", () => {
   });
 
   it("current returns date today when zone is not set", () => {
-    expect(isToday(new Date())).toBe(true);
+    // Rails stubs `Time.now` and pins TZ to US/Eastern to name the offset
+    // outright; trails freezes the same local wall clock and reads the offset
+    // back off the host zone, so the assertion holds wherever it runs.
+    const now = d(1999, 12, 31, 23, 59, 59);
+    setFrozenTime(now);
+    const dt = current();
+    expect(dt.year).toBe(1999);
+    expect(dt.month).toBe(12);
+    expect(dt.day).toBe(31);
+    expect(dt.hour).toBe(23);
+    expect(dt.minute).toBe(59);
+    expect(dt.second).toBe(59);
   });
 
-  it.skip("current returns time zone today when zone is set");
+  it("current returns time zone today when zone is set", () => {
+    setZone("Eastern Time (US & Canada)");
+    const now = d(1999, 12, 31, 23, 59, 59);
+    setFrozenTime(now);
+    const dt = current() as Temporal.ZonedDateTime;
+    expect(dt.timeZoneId).toBe("America/New_York");
+    expect(dt.toInstant().epochMilliseconds).toBe(now.getTime());
+  });
 
   it("current without time zone", () => {
-    expect(isToday(new Date())).toBe(true);
+    const dt = current();
+    expect(dt instanceof Temporal.PlainDateTime || dt instanceof Temporal.ZonedDateTime).toBe(true);
   });
 
-  it.skip("current with time zone");
+  it("current with time zone", () => {
+    setZone("Eastern Time (US & Canada)");
+    const dt = current();
+    expect(dt instanceof Temporal.PlainDateTime || dt instanceof Temporal.ZonedDateTime).toBe(true);
+  });
 
   it("acts like date", () => {
     const dt = new Date();

--- a/packages/activesupport/src/core-ext/date-time/calculations.ts
+++ b/packages/activesupport/src/core-ext/date-time/calculations.ts
@@ -1,0 +1,44 @@
+/**
+ * The `DateTime` arm of ActiveSupport's calculations reopenings
+ * (`core_ext/date_time/calculations.rb`). Rails keeps `Time`, `Date` and
+ * `DateTime` as three separate receivers, and the members whose bodies differ
+ * only by the receiver's class live on `time-ext.ts` (the instant arm) or
+ * `core-ext/date/calculations.ts` (the calendar-day arm). This file is for the
+ * DateTime members a single TS function cannot stand in for, because their
+ * return type is a DateTime rather than a Time — `DateTime.current` is the
+ * first: `Time.current` (`time/calculations.rb:39-41`) is the same expression
+ * without the `to_datetime` tail, and one function cannot answer both.
+ *
+ * Mirrors: `class DateTime` (`core_ext/date_time/calculations.rb`)
+ */
+
+import { Temporal, Time } from "@blazetrails/date";
+import { instantFrom } from "../../temporal.js";
+import { currentTime } from "../../time-travel.js";
+import { TimeWithZone } from "../../time-with-zone.js";
+import { zone as timeZone } from "../../time-zone-config.js";
+
+/**
+ * Mirrors: `DateTime.current` (`date_time/calculations.rb:10-12`) —
+ * `::Time.zone ? ::Time.zone.now.to_datetime : ::Time.now.to_datetime`.
+ *
+ * `::Time.now` is trails' `currentTime()`, the travel-aware clock read
+ * `Time.current` takes; the ruby/date `Time` it is handed to is what carries
+ * `Time#to_datetime` (`packages/date/src/time.ts`), whose constructor reads the
+ * same local-zone components `::Time.now` answers.
+ */
+export function current(): Temporal.PlainDateTime | Temporal.ZonedDateTime {
+  const zone = timeZone();
+  if (zone) {
+    return new TimeWithZone(instantFrom(currentTime()), zone).toDatetime();
+  }
+  const now = currentTime();
+  return new Time(
+    now.getFullYear(),
+    now.getMonth() + 1,
+    now.getDate(),
+    now.getHours(),
+    now.getMinutes(),
+    now.getSeconds() + now.getMilliseconds() / 1000,
+  ).toDatetime();
+}

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -653,6 +653,13 @@ export { overlap, overlaps } from "./core-ext/range/overlap.js";
 // below owns those spellings, and for core-ext/string's conversions
 // (`@blazetrails/activesupport/core-ext/string/conversions`), the `String` arm
 // of `to_time`/`to_date`/`to_datetime`.
+//
+// core-ext/date-time's calculations
+// (`@blazetrails/activesupport/core-ext/date-time/calculations`) is the same
+// case one receiver over: `DateTime.current`
+// (`active_support/core_ext/date_time/calculations.rb:10-12`) is
+// `Time.current` plus `to_datetime`, so in Ruby the two never collide and in a
+// flat ESM namespace they would.
 
 export { I18n } from "./i18n.js";
 export { Scalar } from "./duration.js";

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -34,7 +34,9 @@ function clone(date: Date): Date {
 /**
  * Returns `Time.zone.now` when `Time.zone` or `config.time_zone` are set,
  * otherwise just returns `Time.now` — time/calculations.rb:39-41. DateTime's
- * `current` (date_time/calculations.rb:10-12) is the same value.
+ * `current` (date_time/calculations.rb:10-12) is that expression plus
+ * `to_datetime`, and lives on its own receiver in
+ * `core-ext/date-time/calculations.ts`.
  */
 export function current(): TimeWithZone | Date {
   const zone = timeZone();

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/time-ext.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/time-ext.json
@@ -11,7 +11,7 @@
     "tsFile": "time-ext.ts",
     "rubyName": "current",
     "call": "to_datetime",
-    "reason": "Homonym across two Ruby receivers: `Time.current` (time/calculations.rb:39-41) has no `to_datetime`, `DateTime.current` (date_time/calculations.rb:10-12) is that same expression plus `.to_datetime`, and trails has one `current()` here serving both — one function cannot return both a Time and a DateTime. Converging it means giving DateTime its own receiver file; tracked by 0098-activesupport-ar-closure-port/split-date-time-current-onto-its-own-receiver."
+    "reason": "Homonym across two Ruby receivers: `Time.current` (time/calculations.rb:39-41) has no `to_datetime`, `DateTime.current` (date_time/calculations.rb:10-12) is that same expression plus `.to_datetime`, and trails has one `current()` here serving both — one function cannot return both a Time and a DateTime. `DateTime.current` now has that receiver — `core-ext/date-time/calculations.ts` — but RUBY_FILE_TS_OVERRIDES maps one Ruby file to ONE TS file, so `date_time/calculations.rb` still points at `time-ext.ts` (where its other 28 members live) and its `current` is still charged here. The row dies when those 28 bodies move too: 0098-activesupport-ar-closure-port/port-date-time-calculations-onto-its-own-receiver."
   },
   {
     "package": "activesupport",


### PR DESCRIPTION
Rails keeps `Time.current` (`time/calculations.rb:39-41`) and `DateTime.current`
(`date_time/calculations.rb:10-12`) on two receivers: the DateTime one is the
same `::Time.zone ? ::Time.zone.now : ::Time.now` plus a `to_datetime` tail, and
one TS function cannot return both a Time and a DateTime.

- New `packages/activesupport/src/core-ext/date-time/calculations.ts` — the
  DateTime arm, the shape `core-ext/date/calculations.ts` already established.
  `current()` keeps Rails' branch order and ends in `toDatetime()` on both arms:
  `TimeWithZone#toDatetime` (`time_with_zone.rb:486-488`) for the zoned arm, and
  ruby/date's `Time#toDatetime` (`date_core.c` `time_to_datetime`) over trails'
  travel-aware `currentTime()` — the `::Time.now` read — for the other.
- `time-ext.ts`'s `current` is `Time.current` only; its JSDoc now points at the
  new file rather than claiming to cover `DateTime.current`.
- `date-time-ext.test.ts`: the four Rails `current` tests now exercise it — two
  of them were `it.skip` placeholders with nothing to call.

**The baseline row could not be deleted here, and that is measured, not
assumed.** `RUBY_FILE_TS_OVERRIDES` maps one Ruby file to exactly ONE TS file,
so `core_ext/date_time/calculations.rb` still has to point at `time-ext.ts`,
where its other 28 members (`subsec`, `change`, `advance`, `ago`, `since`, the
period bounds and their aliases) live — flipping the override to the new file
drops activesupport from 1637/2027 to 1609/2027 methods (-28), and re-exporting
those 28 names from the new file does not recover them (the extractor counts
declarations, not `export … from`; still 1/29 on that file). So the `current` →
`to_datetime` row survives until those bodies move too. Filed as
`0098-activesupport-ar-closure-port/port-date-time-calculations-onto-its-own-receiver`,
with the measurements above in its context; the row's `reason` is rewritten to
name that blocker and that story instead of this one.

Gates: `parity:api:calls` OK, `parity:api:calls:args` OK, `parity:api:extra`
reports 0 novel for the new file, `parity:api` and `parity:test` deltas
non-negative (`date_time_ext_test.rb` 63→65 matched).

**Story stays open on purpose — no `Closes-story:` trailer.** Acceptance
criterion 3 (delete the baseline row) is unmet for the measured reason above,
and CLAUDE.md says a convergence story converges rather than closing with a
better justification. The remaining work — moving the 28
`date_time/calculations.rb` bodies so the override can flip and the row can die
— is scheduled as
`0098-activesupport-ar-closure-port/port-date-time-calculations-onto-its-own-receiver`.
Maintainer call: close this one against that follow-up (add the trailer), or
`pnpm tasks block` it on the follow-up.
