### PR TITLE
fix(date,activesupport,trailties): exact usec positional, StringIO-backed nokogiri parse, executor seam coverage

### DIFF
--- a/packages/activesupport/src/core-ext/string-ext.test.ts
+++ b/packages/activesupport/src/core-ext/string-ext.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { toDate, toDatetime, toTime } from "./string/conversions.js";
-import { ArgumentError, Rational, Temporal, Time } from "@blazetrails/date";
+import { ArgumentError, Temporal, Time } from "@blazetrails/date";
 import { at, from, to, first, last, indent, exclude } from "../string-utils.js";
 import {
   registerConstantizeFixtures,
@@ -134,14 +134,11 @@ describe("StringConversionsTest", () => {
         epochNs(Time.utc(2005, 2, 27, 23, 50)),
       );
       expect(epochNs(toTime("2005-02-27 23:50"))).toBe(epochNs(Time.mktime(2005, 2, 27, 23, 50)));
-      // Rails passes the microsecond as `Time.utc`'s seventh positional; trails'
-      // folds it into `sec` as a float there, which loses the last nanosecond,
-      // so the exact `Rational` MRI holds is spelled out instead.
       expect(epochNs(toTime("2005-02-27T23:50:19.275038", "utc"))).toBe(
-        epochNs(Time.utc(2005, 2, 27, 23, 50, new Rational(19275038, 1000000))),
+        epochNs(Time.utc(2005, 2, 27, 23, 50, 19, 275038)),
       );
       expect(epochNs(toTime("2005-02-27T23:50:19.275038"))).toBe(
-        epochNs(Time.mktime(2005, 2, 27, 23, 50, new Rational(19275038, 1000000))),
+        epochNs(Time.mktime(2005, 2, 27, 23, 50, 19, 275038)),
       );
       expect(epochNs(toTime("2039-02-27 23:50", "utc"))).toBe(
         epochNs(Time.utc(2039, 2, 27, 23, 50)),

--- a/packages/activesupport/src/xml-mini.ts
+++ b/packages/activesupport/src/xml-mini.ts
@@ -51,7 +51,7 @@ export const FileLike = {
  * dynamic import — see `xml-mini/nokogirisax.ts:55` and `xml-mini/nokogiri.ts:99`.
  */
 export interface XmlMiniBackend {
-  parse(data: string | Blob | null | undefined): Promise<Record<string, unknown>>;
+  parse(data: string | StringIO | null | undefined): Promise<Record<string, unknown>>;
 }
 
 /** The name of a backend, or the backend module itself. */
@@ -305,7 +305,9 @@ let _backend: XmlMiniBackend | null | undefined;
  * every backend's `parse` is (see {@link XmlMiniBackend}); the delegation itself
  * still forwards straight to the selected backend.
  */
-export function parse(data: string | Blob | null | undefined): Promise<Record<string, unknown>> {
+export function parse(
+  data: string | StringIO | null | undefined,
+): Promise<Record<string, unknown>> {
   return backend()!.parse(data);
 }
 

--- a/packages/activesupport/src/xml-mini/nokogiri.ts
+++ b/packages/activesupport/src/xml-mini/nokogiri.ts
@@ -1,3 +1,5 @@
+import { StringIO } from "../string-io.js";
+
 const CONTENT_ROOT = "__content__";
 
 function isModuleNotFound(e: unknown, pkg: string): boolean {
@@ -97,28 +99,27 @@ function nodeToHash(node: XmlNode): XmlHash {
 }
 
 /**
- * Mirrors: ActiveSupport::XmlMini_Nokogiri#parse (nokogiri.rb:19-31) — `Blob`
- * is the platform's in-memory readable byte container, so it stands in for the
- * `StringIO` Rails wraps a non-readable `data` in (the same stand-in
- * `XmlMini._parse_file` makes), and `instanceof Blob` for `respond_to?(:read)`.
- * Reading the blob out is the `eof?` test: an empty read is Ruby's `eof?`.
+ * Mirrors: ActiveSupport::XmlMini_Nokogiri#parse (nokogiri.rb:19-31) —
+ * `StringIO` is the shim for Ruby's stdlib `StringIO`, and `instanceof
+ * StringIO` stands in for `respond_to?(:read)`.
  */
-export async function parse(data: string | Blob | null | undefined): Promise<XmlHash> {
-  if (!(data instanceof Blob)) {
-    data = new Blob([data ?? ""]);
+export async function parse(data: string | StringIO | null | undefined): Promise<XmlHash> {
+  if (!(data instanceof StringIO)) {
+    data = new StringIO(data ?? "");
   }
 
-  const text = await data.text();
-  if (text.length === 0) return {};
-
-  const { parseXml } = await loadNokogiri();
-  const doc = parseXml(text);
-  try {
-    if (doc.errors.length > 0) {
-      throw new Error(doc.errors[0].message);
+  if (data.isEof()) {
+    return {};
+  } else {
+    const { parseXml } = await loadNokogiri();
+    const doc = parseXml(data.read() ?? "");
+    try {
+      if (doc.errors.length > 0) {
+        throw new Error(doc.errors[0].message);
+      }
+      return { [doc.root.name]: nodeToHash(doc.root) };
+    } finally {
+      doc.dispose();
     }
-    return { [doc.root.name]: nodeToHash(doc.root) };
-  } finally {
-    doc.dispose();
   }
 }

--- a/packages/activesupport/src/xml-mini/nokogirisax-readable.trails.test.ts
+++ b/packages/activesupport/src/xml-mini/nokogirisax-readable.trails.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { parse } from "./nokogirisax.js";
 import { parse as parseDom } from "./nokogiri.js";
+import { StringIO } from "../string-io.js";
 
 // trails-only coverage for the readable-IO and `eof?` arms of
 // `XmlMini_NokogiriSAX#parse` (nokogirisax.rb:69-80) and
@@ -9,12 +10,12 @@ import { parse as parseDom } from "./nokogiri.js";
 describe("NokogiriSAX parse readable input", () => {
   it("parses a readable input", async () => {
     const xml = '<products><book type="novel"><title>Dune</title></book></products>';
-    expect(await parse(new Blob([xml]))).toEqual(await parse(xml));
-    expect(await parseDom(new Blob([xml]))).toEqual(await parseDom(xml));
+    expect(await parse(new StringIO(xml))).toEqual(await parse(xml));
+    expect(await parseDom(new StringIO(xml))).toEqual(await parseDom(xml));
   });
 
   it("returns an empty hash for a readable input at eof", async () => {
-    expect(await parse(new Blob([]))).toEqual({});
-    expect(await parseDom(new Blob([]))).toEqual({});
+    expect(await parse(new StringIO(""))).toEqual({});
+    expect(await parseDom(new StringIO(""))).toEqual({});
   });
 });

--- a/packages/activesupport/src/xml-mini/nokogirisax.ts
+++ b/packages/activesupport/src/xml-mini/nokogirisax.ts
@@ -1,4 +1,5 @@
 import { isBlank } from "../string-utils.js";
+import { StringIO } from "../string-io.js";
 
 function isModuleNotFound(e: unknown, pkg: string): boolean {
   if (!(e instanceof Error)) return false;
@@ -141,23 +142,22 @@ export function setDocumentClass(klass: new () => HashBuilder): void {
 
 /**
  * Mirrors: ActiveSupport::XmlMini_NokogiriSAX#parse (nokogirisax.rb:69-80) —
- * `Blob` is the platform's in-memory readable byte container, so it stands in
- * for the `StringIO` Rails wraps a non-readable `data` in (the same stand-in
- * `XmlMini._parse_file` makes), and `instanceof Blob` for `respond_to?(:read)`.
- * Reading the blob out is the `eof?` test: an empty read is Ruby's `eof?`.
+ * `StringIO` is the shim for Ruby's stdlib `StringIO`, and `instanceof
+ * StringIO` stands in for `respond_to?(:read)`.
  */
-export async function parse(data: string | Blob | null | undefined): Promise<XmlHash> {
-  if (!(data instanceof Blob)) {
-    data = new Blob([data ?? ""]);
+export async function parse(data: string | StringIO | null | undefined): Promise<XmlHash> {
+  if (!(data instanceof StringIO)) {
+    data = new StringIO(data ?? "");
   }
 
-  const text = await data.text();
-  if (text.length === 0) return {};
+  if (data.isEof()) {
+    return {};
+  } else {
+    const { SAX } = await loadNokogiri();
 
-  const { SAX } = await loadNokogiri();
-
-  const document = new (documentClass())();
-  const parser = new SAX.Parser(document);
-  parser.parse(text);
-  return document.hash;
+    const document = new (documentClass())();
+    const parser = new SAX.Parser(document);
+    parser.parse(data.read() ?? "");
+    return document.hash;
+  }
 }

--- a/packages/date/src/time.trails.test.ts
+++ b/packages/date/src/time.trails.test.ts
@@ -132,6 +132,18 @@ describe("Time", () => {
     );
   });
 
+  it("a usec positional truncates sec to a whole second, as MRI's does", () => {
+    // ruby 3.3.11:
+    //   Time.utc(2008, 3, 1, 6, 0, 0.3, 5).nsec                #=> 5000
+    //   Time.utc(2008, 3, 1, 6, 0, 0.3, 0.5).nsec              #=> 500
+    //   Time.utc(2008, 3, 1, 6, 0, Rational(1, 3), 0).nsec     #=> 0
+    //   Time.utc(2008, 3, 1, 6, 0, 0.3).nsec                   #=> 299999999
+    expect(Time.utc(2008, 3, 1, 6, 0, 0.3, 5).nsec).toBe(5000);
+    expect(Time.utc(2008, 3, 1, 6, 0, 0.3, 0.5).nsec).toBe(500);
+    expect(Time.utc(2008, 3, 1, 6, 0, new Rational(1, 3), 0).nsec).toBe(0);
+    expect(Time.utc(2008, 3, 1, 6, 0, 0.3).nsec).toBe(299999999);
+  });
+
   it("Time.new takes a Rational second, as MRI's does", () => {
     // ruby 3.3.11:
     //   Time.new(2008, 3, 1, 6, 0, Rational(1, 3)).nsec           #=> 333333333

--- a/packages/date/src/time.trails.test.ts
+++ b/packages/date/src/time.trails.test.ts
@@ -120,6 +120,18 @@ describe("Time", () => {
     expect(Time.utc(2008, 3, 1, 6, 0, 7.456789).nsec).toBe(456788999);
   });
 
+  it("the usec positional is exact, matching the Rational spelling", () => {
+    // ruby 3.3.11:
+    //   Time.utc(2005, 2, 27, 23, 50, 19, 275038).nsec  #=> 275038000
+    expect(Time.utc(2005, 2, 27, 23, 50, 19, 275038).toTime().epochNanoseconds).toBe(
+      Time.utc(2005, 2, 27, 23, 50, new Rational(19275038, 1000000)).toTime().epochNanoseconds,
+    );
+    expect(Time.utc(2005, 2, 27, 23, 50, 19, 275038).nsec).toBe(275038000);
+    expect(Time.mktime(2005, 2, 27, 23, 50, 19, 275038).toTime().epochNanoseconds).toBe(
+      Time.mktime(2005, 2, 27, 23, 50, new Rational(19275038, 1000000)).toTime().epochNanoseconds,
+    );
+  });
+
   it("Time.new takes a Rational second, as MRI's does", () => {
     // ruby 3.3.11:
     //   Time.new(2008, 3, 1, 6, 0, Rational(1, 3)).nsec           #=> 333333333

--- a/packages/date/src/time.ts
+++ b/packages/date/src/time.ts
@@ -268,7 +268,14 @@ export class Time {
       day,
       hour,
       min,
-      sec instanceof Rational ? sec.add(new Rational(usec, 1_000_000)) : sec + usec / 1_000_000,
+      sec instanceof Rational
+        ? sec.add(new Rational(usec, 1_000_000))
+        : Number.isInteger(sec)
+          ? // MRI keeps the sub-second as a Rational (`time.c`, `time_new_timew`),
+            // so an integer `sec` never touches a double and the last nanosecond
+            // of `usec` survives.
+            new Rational(sec, 1).add(new Rational(usec, 1_000_000))
+          : sec + usec / 1_000_000,
       "UTC",
     );
   }
@@ -293,7 +300,14 @@ export class Time {
       day,
       hour,
       min,
-      sec instanceof Rational ? sec.add(new Rational(usec, 1_000_000)) : sec + usec / 1_000_000,
+      sec instanceof Rational
+        ? sec.add(new Rational(usec, 1_000_000))
+        : Number.isInteger(sec)
+          ? // MRI keeps the sub-second as a Rational (`time.c`, `time_new_timew`),
+            // so an integer `sec` never touches a double and the last nanosecond
+            // of `usec` survives.
+            new Rational(sec, 1).add(new Rational(usec, 1_000_000))
+          : sec + usec / 1_000_000,
     );
   }
 

--- a/packages/date/src/time.ts
+++ b/packages/date/src/time.ts
@@ -251,7 +251,11 @@ export class Time {
   /**
    * Ruby `Time.utc(year, month, day, hour = 0, min = 0, sec = 0, usec = 0)`.
    * MRI's seventh positional is the microsecond, not a zone — `Time.utc` names
-   * its zone in the method — so it folds into `sec` here.
+   * its zone in the method — so it folds into `sec` here. MRI holds the
+   * sub-second as a `Rational` (`time.c`, `time_s_mkutc` -> `time_new_timew`),
+   * so the fold goes through `Rational` rather than a double, and passing
+   * `usec` truncates `sec` to a whole second exactly as MRI's does:
+   * `Time.utc(2008, 3, 1, 6, 0, 0.3, 5).nsec` is `5000`.
    */
   static utc(
     year: number,
@@ -260,7 +264,7 @@ export class Time {
     hour = 0,
     min = 0,
     sec: number | Rational = 0,
-    usec = 0,
+    usec?: number,
   ): Time {
     return new Time(
       year,
@@ -268,14 +272,11 @@ export class Time {
       day,
       hour,
       min,
-      sec instanceof Rational
-        ? sec.add(new Rational(usec, 1_000_000))
-        : Number.isInteger(sec)
-          ? // MRI keeps the sub-second as a Rational (`time.c`, `time_new_timew`),
-            // so an integer `sec` never touches a double and the last nanosecond
-            // of `usec` survives.
-            new Rational(sec, 1).add(new Rational(usec, 1_000_000))
-          : sec + usec / 1_000_000,
+      usec === undefined
+        ? sec
+        : new Rational(sec instanceof Rational ? sec.toI() : Math.trunc(sec), 1).add(
+            new Rational(Math.round(usec * 1_000), 1_000_000_000),
+          ),
       "UTC",
     );
   }
@@ -283,7 +284,8 @@ export class Time {
   /**
    * Ruby `Time.mktime(year, month, day, hour = 0, min = 0, sec = 0, usec = 0)`,
    * the `Time.local` alias, which builds in the LOCAL zone. As with
-   * {@link Time.utc}, the seventh positional is the microsecond.
+   * {@link Time.utc}, the seventh positional is the microsecond, and passing it
+   * truncates `sec` to a whole second.
    */
   static mktime(
     year: number,
@@ -292,7 +294,7 @@ export class Time {
     hour = 0,
     min = 0,
     sec: number | Rational = 0,
-    usec = 0,
+    usec?: number,
   ): Time {
     return new Time(
       year,
@@ -300,14 +302,11 @@ export class Time {
       day,
       hour,
       min,
-      sec instanceof Rational
-        ? sec.add(new Rational(usec, 1_000_000))
-        : Number.isInteger(sec)
-          ? // MRI keeps the sub-second as a Rational (`time.c`, `time_new_timew`),
-            // so an integer `sec` never touches a double and the last nanosecond
-            // of `usec` survives.
-            new Rational(sec, 1).add(new Rational(usec, 1_000_000))
-          : sec + usec / 1_000_000,
+      usec === undefined
+        ? sec
+        : new Rational(sec instanceof Rational ? sec.toI() : Math.trunc(sec), 1).add(
+            new Rational(Math.round(usec * 1_000), 1_000_000_000),
+          ),
     );
   }
 

--- a/packages/trailties/src/application/executor-seam.trails.test.ts
+++ b/packages/trailties/src/application/executor-seam.trails.test.ts
@@ -4,11 +4,14 @@
 // (`default_middleware_stack.rb:49`). Rails covers the two halves separately
 // (`dispatch/executor_test.rb`, `asynchronous_queries_test.rb`); the wiring
 // between them has no single Rails counterpart.
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
 import { Executor as ActionDispatchExecutor } from "@blazetrails/actionpack";
 import type { RackEnv, RackResponse } from "@blazetrails/rack";
 import { Base, Trailtie } from "@blazetrails/activerecord";
 import { Application } from "../application.js";
+import { Configuration } from "./configuration.js";
+import { DefaultMiddlewareStack } from "./default-middleware-stack.js";
+import { Root } from "../paths.js";
 
 const SESSION_ERROR = "Can't perform asynchronous queries without a query session";
 
@@ -22,8 +25,13 @@ describe("ActionDispatch::Executor around a request (trails)", () => {
   class TestApplication extends Application {}
   let app: TestApplication;
 
-  beforeEach(async () => {
+  // The initializers register the executor hooks on `ActiveSupport::Executor`
+  // itself, so running them per-test would stack a second copy of every hook.
+  beforeAll(() => {
     Trailtie.runInitializers();
+  });
+
+  beforeEach(async () => {
     app = new TestApplication();
     await Base.establishConnection({ adapter: "sqlite3", database: ":memory:" });
   });
@@ -52,6 +60,55 @@ describe("ActionDispatch::Executor around a request (trails)", () => {
     // (`executor.rb:23`), so the session outlives `call` and dies with the body.
     expect(Base.asynchronousQueriesSession().active()).toBe(true);
     (body as unknown as { close(): void }).close();
+    expect(() => Base.asynchronousQueriesSession()).toThrow(SESSION_ERROR);
+  });
+
+  it("enables the query cache for the request body and clears it on close", async () => {
+    const pool = Base.connectionPool();
+    expect(pool.queryCacheEnabled).toBe(false);
+
+    let enabledInRequest: boolean | null = null;
+    const middleware = new ActionDispatchExecutor(async () => {
+      const connection = await Base.leaseConnection();
+      await connection.selectAll("SELECT 1 AS one", null, []);
+      enabledInRequest = Base.connectionPool().queryCacheEnabled;
+      return [200, {}, []] as unknown as RackResponse;
+    }, app.executor);
+
+    const [, , body] = await middleware.call({} as RackEnv);
+    expect(enabledInRequest).toBe(true);
+
+    (body as unknown as { close(): void }).close();
+    expect(Base.connectionPool().queryCacheEnabled).toBe(false);
+    expect(Base.connectionPool().queryCache.empty).toBe(true);
+  });
+
+  it("opens the session through the built default middleware stack", async () => {
+    const paths = new Root("/app");
+    paths.add("public");
+    const config = new Configuration();
+    config.publicFileServer.enabled = false;
+    const stack = new DefaultMiddlewareStack(
+      { config, executor: app.executor, reloader: app.reloader },
+      config,
+      paths,
+    ).buildStack();
+
+    let rows: unknown[] | null = null;
+    const stackApp = stack.build(async () => {
+      rows = await selectOneAsync();
+      return [200, {}, []] as unknown as RackResponse;
+    });
+
+    const [status, , stackBody] = await stackApp({
+      REQUEST_METHOD: "GET",
+      PATH_INFO: "/",
+    } as unknown as RackEnv);
+
+    expect(status).toBe(200);
+    expect(rows).toEqual([{ one: 1 }]);
+
+    (stackBody as unknown as { close(): void }).close();
     expect(() => Base.asynchronousQueriesSession()).toThrow(SESSION_ERROR);
   });
 


### PR DESCRIPTION
Three bundled stories.

**`Time.utc`/`Time.mktime` usec positional** (`packages/date/src/time.ts`) — MRI keeps the sub-second as a `Rational` (`time.c`, `time_s_mkutc` → `time_new_timew`), so the seventh positional now folds into `sec` through `Rational` instead of `sec + usec / 1_000_000`, which lost the last nanosecond. Verified against ruby 3.3.11, which also truncates `sec` to a whole second whenever `usec` is passed (`Time.utc(2008, 3, 1, 6, 0, 0.3, 5).nsec #=> 5000`), so the port distinguishes an absent `usec` from `0`. `string-ext.test.ts`'s `"string to time"` is restored to Rails' literal `Time.utc(2005, 2, 27, 23, 50, 19, 275038)` / `Time.mktime(...)` calls.

**Nokogiri backends' `parse`** — both `xml-mini/nokogiri.ts` (`nokogiri.rb:19-31`) and `xml-mini/nokogirisax.ts` (`nokogirisax.rb:69-80`) now wrap a non-readable `data` in the `StringIO` shim and branch on its `eof?`, rather than wrapping a `Blob` and reading it out in full. `XmlMiniBackend.parse` / `XmlMini.parse` name the shim.

**Executor seam** (`application/executor-seam.trails.test.ts`) — adds a request driven through the built `DefaultMiddlewareStack` (session open in the body, finalized on body close) and a query-cache case asserting `QueryCache.run` / `complete` run through the real executor: enabled inside the body, disabled and cleared on close. The initializers moved to `beforeAll`, since they register hooks on `ActiveSupport::Executor` itself.

Closes-story: executor-seam-end-to-end-request-coverage
Closes-story: converge-nokogiri-parse-onto-the-stringio-shim
Closes-story: time-utc-usec-positional-loses-a-nanosecond
