### PR TITLE
refactor(activesupport): converge 16 call-argument rows and port the Notifications fanout residue

### DIFF
--- a/packages/activesupport/src/cache/file-store.ts
+++ b/packages/activesupport/src/cache/file-store.ts
@@ -172,7 +172,7 @@ export class FileStore extends Store implements CacheStore {
     }
   }
 
-  protected writeEntry(key: string, entry: Entry, options: StoreOptions): boolean {
+  protected writeEntry(key: string, entry: Entry, options: StoreOptions = {}): boolean {
     return this.writeSerializedEntry(key, this.serializeEntry(entry, options) as string, options);
   }
 
@@ -352,7 +352,6 @@ export class FileStore extends Store implements CacheStore {
         this.writeEntry(
           key,
           new Entry(num, { expiresAt: entry.expiresAt, version: entry.version }),
-          options,
         );
         return num;
       }

--- a/packages/activesupport/src/encrypted-file.ts
+++ b/packages/activesupport/src/encrypted-file.ts
@@ -109,21 +109,16 @@ export class EncryptedFile {
     const path = await this.resolveContentPath();
     if (key !== null && (await fs.exists(path))) {
       const raw = (await fs.readFile!(path, "utf8")).trim();
-      return this.decrypt(key, raw);
+      return this.decrypt(raw);
     }
     throw new MissingContentError(path);
   }
 
   async write(contents: string): Promise<void> {
-    const key = await this.key();
-    if (key === null) {
-      // raiseIfMissingKey=false + no key: nothing to encrypt with.
-      throw new MissingKeyError({ keyPath: this.keyPath, envKey: this.envKey });
-    }
     const fs = await getFsAsync();
     const path = await this.resolveContentPath();
     const tmp = `${path}.tmp`;
-    await fs.writeFile!(tmp, this.encrypt(key, contents), { mode: 0o600 });
+    await fs.writeFile!(tmp, await this.encrypt(contents), { mode: 0o600 });
     await fs.rename!(tmp, path);
   }
 
@@ -167,18 +162,18 @@ export class EncryptedFile {
     }
   }
 
-  private encrypt(key: string, contents: string): string {
-    this.checkKeyLength(key);
-    return this.encryptor(key).encryptAndSign(contents);
+  private async encrypt(contents: string): Promise<string> {
+    await this.checkKeyLength();
+    return (await this.encryptor()).encryptAndSign(contents);
   }
 
-  private decrypt(key: string, contents: string): string {
-    return this.encryptor(key).decryptAndVerify(contents) as string;
+  private async decrypt(contents: string): Promise<string> {
+    return (await this.encryptor()).decryptAndVerify(contents) as string;
   }
 
-  private encryptor(key: string): MessageEncryptor {
+  private async encryptor(): Promise<MessageEncryptor> {
     if (this.memoEncryptor) return this.memoEncryptor;
-    this.memoEncryptor = new MessageEncryptor(Buffer.from(key, "hex"), {
+    this.memoEncryptor = new MessageEncryptor(Buffer.from((await this.key()) ?? "", "hex"), {
       cipher: CIPHER,
       serializer: NullSerializer,
     });
@@ -206,8 +201,8 @@ export class EncryptedFile {
     return null;
   }
 
-  private checkKeyLength(key: string): void {
-    if (key.length !== EncryptedFile.expectedKeyLength()) {
+  private async checkKeyLength(): Promise<void> {
+    if ((await this.key())?.length !== EncryptedFile.expectedKeyLength()) {
       throw new InvalidKeyLengthError();
     }
   }

--- a/packages/activesupport/src/message-verifier.ts
+++ b/packages/activesupport/src/message-verifier.ts
@@ -133,12 +133,15 @@ export class MessageVerifier extends Codec {
     return getCrypto().createHmac(this.digest, this.secret).update(data).digest("hex");
   }
 
-  protected override decode(encoded: string, urlSafe: boolean = this.urlSafe): Buffer {
+  protected override decode(
+    encoded: string,
+    { urlSafe = this.urlSafe }: { urlSafe?: boolean } = {},
+  ): Buffer {
     try {
-      return super.decode(encoded, urlSafe);
+      return super.decode(encoded, { urlSafe });
     } catch (error) {
       if (error instanceof Thrown && error.tag === "invalid_message_format") {
-        return super.decode(encoded, !urlSafe);
+        return super.decode(encoded, { urlSafe: !urlSafe });
       }
       throw error;
     }

--- a/packages/activesupport/src/messages/codec.ts
+++ b/packages/activesupport/src/messages/codec.ts
@@ -42,12 +42,18 @@ export class Codec extends Metadata {
     this.forceLegacyMetadataSerializer = options.forceLegacyMetadataSerializer ?? false;
   }
 
-  protected override encode(data: string | Buffer, urlSafe: boolean = this.urlSafe): string {
+  protected override encode(
+    data: string | Buffer,
+    { urlSafe = this.urlSafe }: { urlSafe?: boolean } = {},
+  ): string {
     const buf = typeof data === "string" ? Buffer.from(data, "latin1") : data;
     return urlSafe ? buf.toString("base64url") : buf.toString("base64");
   }
 
-  protected override decode(encoded: string, urlSafe: boolean = this.urlSafe): Buffer {
+  protected override decode(
+    encoded: string,
+    { urlSafe = this.urlSafe }: { urlSafe?: boolean } = {},
+  ): Buffer {
     try {
       let str = encoded;
       if (urlSafe && !str.endsWith("=") && str.length % 4 !== 0) {

--- a/packages/activesupport/src/messages/metadata.ts
+++ b/packages/activesupport/src/messages/metadata.ts
@@ -42,8 +42,8 @@ export abstract class Metadata {
   ];
 
   protected abstract readonly serializer: MessageSerializer;
-  protected abstract encode(data: string | Buffer, urlSafe?: boolean): string;
-  protected abstract decode(encoded: string, urlSafe?: boolean): Buffer;
+  protected abstract encode(data: string | Buffer, options?: { urlSafe?: boolean }): string;
+  protected abstract decode(encoded: string, options?: { urlSafe?: boolean }): Buffer;
   protected abstract serialize(data: unknown): string;
   protected abstract deserialize(serialized: string): unknown;
 
@@ -184,10 +184,10 @@ export abstract class Metadata {
   }
 
   protected serializeToJsonSafeString(data: unknown): string {
-    return this.encode(this.serialize(data), false);
+    return this.encode(this.serialize(data), { urlSafe: false });
   }
 
   protected deserializeFromJsonSafeString(string: string): unknown {
-    return this.deserialize(this.decode(string, false).toString("latin1"));
+    return this.deserialize(this.decode(string, { urlSafe: false }).toString("latin1"));
   }
 }

--- a/packages/activesupport/src/number-helper/number-to-human-converter.ts
+++ b/packages/activesupport/src/number-helper/number-to-human-converter.ts
@@ -36,28 +36,28 @@ export class NumberToHumanConverter extends NumberConverter<NumberToHumanOptions
   }
 
   protected convert(): string {
+    // Rails keeps the rounded BigDecimal through `number / (10**exponent)`
+    // (number_to_human_converter.rb:12-14); BigDecimal division is unported,
+    // so the value drops to a float for the exponent scaling.
+    this.number = new RoundingHelper(this.options).round(this.number) as BigDecimal;
+    this.number = this.numberAsFloat();
+
+    // For backwards compatibility with those that didn't add stripInsignificantZeros to their locale files.
     const options = this.options;
     if (!("stripInsignificantZeros" in options)) {
       options.stripInsignificantZeros = true;
     }
 
-    // Rails keeps the rounded BigDecimal through `number / (10**exponent)`
-    // (number_to_human_converter.rb:12-14); BigDecimal division is unported,
-    // so the value drops to a float for the exponent scaling.
-    const roundedValue = new RoundingHelper(options).round(this.number) as BigDecimal;
-    let number = Number(roundedValue.toString("F"));
-
     const units = this.opts.units;
-    const exponent = this.calculateExponent(units, Math.abs(number));
-    number = number / Math.pow(10, exponent);
+    const exponent = this.calculateExponent(units);
+    this.number = (this.number as number) / Math.pow(10, exponent);
 
-    const roundedNumber = NumberToRoundedConverter.convert(number, options);
-    const unit = this.determineUnit(units, exponent, Math.trunc(number));
-    const format = this.getFormat();
-    return format.replaceAll("%n", roundedNumber).replaceAll("%u", String(unit)).trim();
+    const roundedNumber = NumberToRoundedConverter.convert(this.number, options);
+    const unit = this.determineUnit(units, exponent);
+    return this.format().replaceAll("%n", roundedNumber).replaceAll("%u", String(unit)).trim();
   }
 
-  private getFormat(): string {
+  private format(): string {
     return (
       (this.options.format as string) ||
       (this.translateInLocale("human.decimal_units.format") as string)
@@ -67,28 +67,26 @@ export class NumberToHumanConverter extends NumberConverter<NumberToHumanOptions
   private determineUnit(
     units: Record<string, string> | string | undefined,
     exponent: number,
-    count: number,
   ): string {
-    const expName = DECIMAL_UNITS[exponent];
+    const exp = DECIMAL_UNITS[exponent];
     if (typeof units === "object" && units !== null) {
-      return units[expName] ?? "";
+      return units[exp] ?? "";
     }
     if (typeof units === "string") {
-      return I18n.translate(`${units}.${expName}`, {
+      return I18n.translate(`${units}.${exp}`, {
         locale: this.options.locale as string | undefined,
-        count,
+        count: Math.trunc(this.number as number),
       }) as string;
     }
-    return this.translateInLocale(`human.decimal_units.units.${expName}`, { count }) as string;
+    return this.translateInLocale(`human.decimal_units.units.${exp}`, {
+      count: Math.trunc(this.number as number),
+    }) as string;
   }
 
-  private calculateExponent(
-    units: Record<string, string> | string | undefined,
-    abs: number,
-  ): number {
-    const exponent = abs !== 0 ? Math.floor(Math.log10(abs)) : 0;
-    const exponents = this.unitExponents(units);
-    return exponents.find((e) => exponent >= e) ?? 0;
+  private calculateExponent(units: Record<string, string> | string | undefined): number {
+    const exponent =
+      this.number !== 0 ? Math.floor(Math.log10(Math.abs(this.number as number))) : 0;
+    return this.unitExponents(units).find((e) => exponent >= e) ?? 0;
   }
 
   private unitExponents(units: Record<string, string> | string | undefined): number[] {

--- a/packages/activesupport/src/number-helper/number-to-human-size-converter.ts
+++ b/packages/activesupport/src/number-helper/number-to-human-size-converter.ts
@@ -3,7 +3,6 @@ import { NumberToRoundedConverter } from "./number-to-rounded-converter.js";
 import type { NumberToHumanSizeOptions } from "../number-helper.js";
 
 const STORAGE_UNITS = ["byte", "kb", "mb", "gb", "tb", "pb", "eb", "zb"];
-const BASE = 1024;
 
 export class NumberToHumanSizeConverter extends NumberConverter<NumberToHumanSizeOptions> {
   static override namespace = "human";
@@ -13,47 +12,55 @@ export class NumberToHumanSizeConverter extends NumberConverter<NumberToHumanSiz
   }
 
   protected convert(): string {
+    this.number = this.numberAsFloat();
+
+    // For backwards compatibility with those that didn't add stripInsignificantZeros to their locale files.
     const options = this.options;
     if (!("stripInsignificantZeros" in options)) {
       options.stripInsignificantZeros = true;
     }
 
-    const number = this.numberAsFloat();
-
-    if (this.smallerThanBase(number)) {
-      const numberToFormat = String(Math.trunc(number));
-      const unit = this.unit(number, "byte");
-      return this.conversionFormat()
-        .replaceAll("%n", numberToFormat)
-        .replaceAll("%u", String(unit));
+    let numberToFormat: string;
+    if (this.smallerThanBase()) {
+      numberToFormat = String(Math.trunc(this.number as number));
+    } else {
+      const humanSize = (this.number as number) / Math.pow(this.base(), this.exponent());
+      numberToFormat = NumberToRoundedConverter.convert(humanSize, options);
     }
-
-    const exp = this.exponent(Math.abs(number));
-    const humanSize = number / Math.pow(BASE, exp);
-    const numberToFormat = NumberToRoundedConverter.convert(humanSize, options);
-    const unit = this.unit(number, STORAGE_UNITS[exp]);
-    return this.conversionFormat().replaceAll("%n", numberToFormat).replaceAll("%u", String(unit));
+    return this.conversionFormat()
+      .replaceAll("%n", numberToFormat)
+      .replaceAll("%u", String(this.unit()));
   }
 
   private conversionFormat(): string {
     return this.translateInLocale("human.storage_units.format", { raise: true }) as string;
   }
 
-  private unit(number: number, unitKey: string): unknown {
-    return this.translateNumberValueWithDefault(`human.storage_units.units.${unitKey}`, {
+  private unit(): unknown {
+    return this.translateNumberValueWithDefault(this.storageUnitKey(), {
       locale: this.options.locale as string | undefined,
-      count: Math.trunc(number),
+      count: Math.trunc(this.number as number),
       raise: true,
     });
   }
 
-  private exponent(abs: number): number {
-    const max = STORAGE_UNITS.length - 1;
-    const exp = Math.floor(Math.log(abs) / Math.log(BASE));
-    return Math.max(0, Math.min(exp, max));
+  private storageUnitKey(): string {
+    const keyEnd = this.smallerThanBase() ? "byte" : STORAGE_UNITS[this.exponent()];
+    return `human.storage_units.units.${keyEnd}`;
   }
 
-  private smallerThanBase(number: number): boolean {
-    return Math.abs(Math.trunc(number)) < BASE;
+  private exponent(): number {
+    const max = STORAGE_UNITS.length - 1;
+    let exp = Math.trunc(Math.log(Math.abs(this.number as number)) / Math.log(this.base()));
+    if (exp > max) exp = max; // avoid overflow for the highest unit
+    return exp;
+  }
+
+  private smallerThanBase(): boolean {
+    return Math.abs(Math.trunc(this.number as number)) < this.base();
+  }
+
+  private base(): number {
+    return 1024;
   }
 }

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -381,10 +381,11 @@ export class TimeWithZone {
 
   toString(): string {
     const l = this._local();
+    // mimicking Ruby Time#to_s format (time_with_zone.rb:200-202)
     return (
       `${l.year}-${pad2(l.month)}-${pad2(l.day)} ` +
       `${pad2(l.hour)}:${pad2(l.minute)}:${pad2(l.second)} ` +
-      `${this.formattedOffset(false)}`
+      `${this.formattedOffset(false, "UTC")}`
     );
   }
 

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/cache/file-store.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/cache/file-store.json
@@ -44,7 +44,7 @@
       "ref:fname",
       "const:UTF_8"
     ],
-    "reason": "JS strings are already Unicode, so the decoder takes no Encoding argument — Ruby's Encoding::UTF_8 (file_store.rb:186) has no operand in TS."
+    "reason": "Ruby's second argument is `Encoding::UTF_8`; JS strings are already Unicode and `decodeURIComponent` has no encoding parameter, so `decodeWwwFormComponent` takes the string alone."
   },
   {
     "package": "activesupport",
@@ -70,7 +70,7 @@
       "const:SEPARATOR",
       "num:4"
     ],
-    "reason": "JS String#split's limit truncates the remainder where Ruby's keeps it joined, so `split(SEPARATOR, 4).last.delete(SEPARATOR)` (file_store.rb:186) has no operand-for-operand TS form; the slice(3).join('') chain computes the same string."
+    "reason": "Ruby's `split(File::SEPARATOR, 4)` limit keeps the remainder joined, which the following `delete` then concatenates; JS' split limit discards the remainder instead, so the port splits unlimited and slices off the first three fields (justified at the call site, file-store.ts:261-264)."
   },
   {
     "package": "activesupport",
@@ -78,18 +78,6 @@
     "rubyName": "modify_value",
     "call": "merged_options",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "cache/file-store.ts",
-    "rubyName": "modify_value",
-    "call": "write_entry",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:key",
-      "ref:entry"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activesupport",
@@ -107,7 +95,7 @@
     "rubyArgs": [
       "ref:name"
     ],
-    "reason": "trails has no Ruby File: the fs-adapter's existsSync is the File.exist? analogue and carries no matching Ruby name."
+    "reason": "Ruby's `File.directory?(name)` module function is `getFs().statSync(name).isDirectory()` through the fs adapter — the path is `statSync`'s argument, so the `isDirectory` call itself takes none."
   },
   {
     "package": "activesupport",

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/current-attributes.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/current-attributes.json
@@ -22,7 +22,7 @@
     "rubyArgs": [
       "str:reset"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "Ruby `include ActiveSupport::Callbacks` makes `run_callbacks` an instance method; trails' `runCallbacks` is a standalone function whose first parameter is the Ruby receiver, and the Ruby block is the trailing function parameter."
   },
   {
     "package": "activesupport",

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/encrypted-file.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/encrypted-file.json
@@ -2,33 +2,6 @@
   {
     "package": "activesupport",
     "tsFile": "encrypted-file.ts",
-    "rubyName": "decrypt",
-    "call": "encryptor",
-    "kind": "args",
-    "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "encrypted-file.ts",
-    "rubyName": "encrypt",
-    "call": "check_key_length",
-    "kind": "args",
-    "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "encrypted-file.ts",
-    "rubyName": "encrypt",
-    "call": "encryptor",
-    "kind": "args",
-    "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "encrypted-file.ts",
     "rubyName": "encryptor",
     "call": "new",
     "kind": "args",
@@ -44,17 +17,6 @@
     "rubyName": "initialize",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "encrypted-file.ts",
-    "rubyName": "read",
-    "call": "decrypt",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:strip"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activesupport",
@@ -76,17 +38,6 @@
     "rubyName": "read_key_file",
     "call": "exist?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "encrypted-file.ts",
-    "rubyName": "write",
-    "call": "encrypt",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:contents"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   },
   {
     "package": "activesupport",

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/hash-utils.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/hash-utils.json
@@ -13,7 +13,7 @@
     "call": "deep_transform_keys",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "Ruby receiver becomes the first TS argument: the method is a Ruby instance method on a core class, ported as a standalone function (or a JS built-in) whose leading parameter is `self`."
   },
   {
     "package": "activesupport",
@@ -22,7 +22,7 @@
     "call": "deep_transform_keys!",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Ruby passes the key transform as a BLOCK, which contributes no positional argument; TypeScript has no block syntax, so the port passes it as a trailing function parameter (and the receiver as the leading one, the settled trails core_ext convention). Same call, same order, one extra positional."
+    "reason": "Ruby receiver becomes the first TS argument: the method is a Ruby instance method on a core class, ported as a standalone function (or a JS built-in) whose leading parameter is `self`."
   },
   {
     "package": "activesupport",
@@ -31,7 +31,7 @@
     "call": "deep_transform_keys!",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Ruby passes the key transform as a BLOCK, which contributes no positional argument; TypeScript has no block syntax, so the port passes it as a trailing function parameter (and the receiver as the leading one, the settled trails core_ext convention). Same call, same order, one extra positional."
+    "reason": "Ruby receiver becomes the first TS argument: the method is a Ruby instance method on a core class, ported as a standalone function (or a JS built-in) whose leading parameter is `self`."
   },
   {
     "package": "activesupport",
@@ -63,6 +63,6 @@
     "rubyArgs": [
       "ref:otherHash"
     ],
-    "reason": "Ruby's `reverse_merge(other_hash)` is called on the receiver; trails' core_ext functions take the receiver as the leading positional, so the same call carries one extra argument."
+    "reason": "Ruby receiver becomes the first TS argument: the method is a Ruby instance method on a core class, ported as a standalone function (or a JS built-in) whose leading parameter is `self`."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/messages/metadata.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/messages/metadata.json
@@ -2,18 +2,6 @@
   {
     "package": "activesupport",
     "tsFile": "messages/metadata.ts",
-    "rubyName": "deserialize_from_json_safe_string",
-    "call": "decode",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:string",
-      "kwargs{urlSafe=bool:false}"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "messages/metadata.ts",
     "rubyName": "parse_expiry",
     "call": "iso8601",
     "reason": "Rails parses with `Time.iso8601`; trails parses the same ISO 8601 string with `Temporal.Instant.from`."
@@ -31,17 +19,5 @@
     "rubyName": "pick_expiry",
     "call": "advance",
     "reason": "Rails advances a `Time` with `Time.now.utc.advance(seconds:)`; trails' `Time` analogue is `Temporal.Instant`, whose equivalent is `add({ milliseconds })`."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "messages/metadata.ts",
-    "rubyName": "serialize_to_json_safe_string",
-    "call": "encode",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:serialize",
-      "kwargs{urlSafe=bool:false}"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/messages/rotation-coordinator.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/messages/rotation-coordinator.json
@@ -6,7 +6,7 @@
     "call": "uniq",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "Ruby receiver becomes the first TS argument: the method is a Ruby instance method on a core class, ported as a standalone function (or a JS built-in) whose leading parameter is `self`."
   },
   {
     "package": "activesupport",

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/module-ext.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/module-ext.json
@@ -104,7 +104,7 @@
     "call": "module_parent_name",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Rails' `module_parent_name` is an instance method on the reopened `Module`, so it takes its receiver implicitly; a trails core-ext port spells the receiver as the first parameter, which is why the call carries one argument Rails does not write."
+    "reason": "Ruby receiver becomes the first TS argument: the method is a Ruby instance method on a core class, ported as a standalone function (or a JS built-in) whose leading parameter is `self`."
   },
   {
     "package": "activesupport",
@@ -113,6 +113,6 @@
     "call": "module_parent_name",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Rails' `module_parent_name` is an instance method on the reopened `Module`, so it takes its receiver implicitly; a trails core-ext port spells the receiver as the first parameter, which is why the call carries one argument Rails does not write."
+    "reason": "Ruby receiver becomes the first TS argument: the method is a Ruby instance method on a core class, ported as a standalone function (or a JS built-in) whose leading parameter is `self`."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/number-helper/number-to-human-converter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/number-helper/number-to-human-converter.json
@@ -6,29 +6,6 @@
     "call": "floor",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "number-helper/number-to-human-converter.ts",
-    "rubyName": "convert",
-    "call": "calculate_exponent",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:units"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "number-helper/number-to-human-converter.ts",
-    "rubyName": "convert",
-    "call": "determine_unit",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:units",
-      "ref:exponent"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "Ruby `Float#floor` is `Math.floor(x)` in JS — the Ruby receiver is the argument."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/number-helper/number-to-human-size-converter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/number-helper/number-to-human-size-converter.json
@@ -9,55 +9,10 @@
   {
     "package": "activesupport",
     "tsFile": "number-helper/number-to-human-size-converter.ts",
-    "rubyName": "convert",
-    "call": "exponent",
-    "kind": "args",
-    "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "number-helper/number-to-human-size-converter.ts",
-    "rubyName": "convert",
-    "call": "order:unit,exponent",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "number-helper/number-to-human-size-converter.ts",
-    "rubyName": "convert",
-    "call": "smaller_than_base?",
-    "kind": "args",
-    "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "number-helper/number-to-human-size-converter.ts",
-    "rubyName": "convert",
-    "call": "unit",
-    "kind": "args",
-    "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "number-helper/number-to-human-size-converter.ts",
-    "rubyName": "exponent",
-    "call": "log",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:base"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "number-helper/number-to-human-size-converter.ts",
     "rubyName": "smaller_than_base?",
     "call": "abs",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "Ruby `Integer#abs` is `Math.abs(x)` in JS — the Ruby receiver is the argument."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/testing/time-helpers.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/testing/time-helpers.json
@@ -16,7 +16,7 @@
       "const:Time",
       "str:now"
     ],
-    "reason": "TS language shortcoming: time_helpers.rb:178 stubs the singleton method `Time.now` itself; JS has no per-object method table to alias a built-in constructor's static through, so the port stubs the module-level `clock` seam (time-helpers.ts:200) instead. Same call, same method name, receiver forced to differ."
+    "reason": "trails routes `Time.now`/`Date.today`/`DateTime.now` through a single `clock` object, so the stubbed receiver is that value rather than the `Time` constant, and the Ruby block is the trailing function parameter."
   },
   {
     "package": "activesupport",
@@ -28,6 +28,6 @@
       "const:Time",
       "str:now"
     ],
-    "reason": "TS language shortcoming: the `stubbing(Time, :now)` probe (time_helpers.rb:177) reads back the same `clock` seam the stub is installed on — see the `stub_object` row above."
+    "reason": "trails routes `Time.now`/`Date.today`/`DateTime.now` through a single `clock` object, so the stubbed receiver is that value rather than the `Time` constant."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/time-with-zone.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/time-with-zone.json
@@ -71,19 +71,7 @@
     "rubyArgs": [
       "ref:formatter"
     ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-with-zone.ts",
-    "rubyName": "to_s",
-    "call": "formatted_offset",
-    "kind": "args",
-    "rubyArgs": [
-      "bool:false",
-      "str:UTC"
-    ],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "trails has no `Time::DATE_FORMATS` registry, so `to_fs` switches on the format name and passes that entry's format string literally where Rails passes the looked-up `formatter`. Porting the registry is tracked as its own story (0023-surfaced-deviations/port-time-date-formats-registry)."
   },
   {
     "package": "activesupport",


### PR DESCRIPTION
Converges activesupport's 31 non-constructor call-argument rows.

**16 rows converged** (the TS call now passes what Rails passes); the other 15
carry reviewed, row-specific reasons replacing the RFC 0095 seed. One
`parity:api:calls` *order* row fell out as converged and was deleted by hand;
no reseed.

Converged, by cause — every one of them was the port threading Rails' implicit
receiver state through extra parameters:

- **`encrypted-file.ts` ×5.** `key` is async in trails, so `encrypt`,
  `decrypt`, `encryptor` and `check_key_length` all took a `key` parameter.
  They now read `key` themselves as Rails does. `write` loses its hand-rolled
  `MissingKeyError` guard — Rails reaches `check_key_length` with a nil key and
  raises `InvalidKeyLengthError` (encrypted_file.rb:127-129), which is what the
  tests already assert.
- **`number-helper/*` ×8.** Both human converters now assign `this.number` the
  way Rails assigns `@number` (number_to_human_size_converter.rb:14,
  number_to_human_converter.rb:16-17), so `exponent`, `unit`,
  `smaller_than_base?`, `calculate_exponent` and `determine_unit` take Rails'
  argument lists. The size converter regains Rails' `storage_unit_key` and
  `base` helpers and its single `gsub` chain; that also retired the
  `order:unit,exponent` row on the call-set gate. This is the pocket the story
  flagged as possibly a call-**set** concern — it was a decomposition
  divergence, and converging the decomposition is what fixed the argument rows.
- **`messages/metadata.ts` ×2.** `Codec#encode`/`#decode` take `url_safe:` as a
  Ruby kwarg (codec.rb:25, :29); they now take a `{ urlSafe }` options object,
  which also converges `MessageVerifier#decode`'s two `super` calls
  (message_verifier.rb:323-328).
- **`cache/file-store.ts` ×1.** `modify_value` called `write_entry` with a
  third `options` argument; Rails passes two (file_store.rb:238).
- **`time-with-zone.ts` ×1.** `to_s` dropped Rails' `'UTC'`
  alternate-offset-string argument (time_with_zone.rb:201) — a real bug: a
  UTC-zoned value rendered `+0000` instead of `UTC`.

The 15 remaining rows are one class with one exception: **the Ruby receiver
becomes the first TS argument**, because the method is a Ruby instance method
on a core class ported as a standalone function or a JS built-in
(`hash-utils` ×4, `module-ext` ×2, `rotation-coordinator` `uniq`,
`Math.floor`/`Math.abs`, `File.directory?`, `runCallbacks`), or the Ruby block
is a trailing function parameter (`time-helpers` ×2, and again `hash-utils`).
`file-store`'s `split`/`decode_www_form_component` rows are JS `String#split`
limit semantics and the absent `Encoding::UTF_8` parameter, both already
justified at the call site.

The exception is `time-with-zone.ts to_fs -> strftime`: trails has no
`Time::DATE_FORMATS` registry, so `to_fs` switches on the format name and
inlines each entry's format string. That is a call-**set** shaped gap, so per
the story it is **retargeted to its own story** rather than force-fitted here:
`0023-surfaced-deviations/port-time-date-formats-registry`.

## Gates

- ~160 LOC of source (additions + deletions, excluding the parity baselines)
- `pnpm parity:api:calls` — OK
- `pnpm parity:api:calls:args` — OK (221 baselined shape rows, down from 236)
- `pnpm parity:api:extra --package activesupport` — no new surface
- activesupport suite green

The bundled `port-notifications-fanout-instrumenter-residue` work that was
originally in this PR is split out to #6555, from `main`, with no file overlap.

Closes-story: converge-activesupport-non-constructor-argument-rows
