### PR TITLE
fix(parity): cluster the remaining RFC 0096 naming rows and fix the camelCased no-js-equivalent lookup

### DIFF
--- a/scripts/api-compare/naming-taxonomy.test.ts
+++ b/scripts/api-compare/naming-taxonomy.test.ts
@@ -22,6 +22,17 @@ describe("classifyPair", () => {
     expect(classifyPair("size", "n")).toBe("burndown");
   });
 
+  // The recorder camelCases a plain Ruby `ref:` identifier, so a multi-word
+  // key only ever reaches here in its camel spelling (abstract-adapter.ts's
+  // `object_id` records as `objectId`) — matching snake_case alone missed the
+  // whole `to_*` family and read four permanent rows as burndown work.
+  it("names a Ruby construct under the camelCased spelling the recorder gives it", () => {
+    expect(classifyPair("objectId", "this")).toBe("no-js-equivalent");
+    expect(classifyPair("toI", "parseInt")).toBe("no-js-equivalent");
+    expect(classifyPair("toS", "toString")).toBe("no-js-equivalent");
+    expect(classifyPair("toS", "fetchValue")).toBe("burndown");
+  });
+
   it("names what the conventions table itself produces", () => {
     expect(classifyPair("primary_class?", "primaryClassQ")).toBe("conventions-rename");
     expect(classifyPair("@callbacks", "_callbacks")).toBe("conventions-rename");

--- a/scripts/api-compare/naming-taxonomy.ts
+++ b/scripts/api-compare/naming-taxonomy.ts
@@ -124,6 +124,17 @@ export const NO_JS_EQUIVALENT: Record<string, string[]> = {
   to_s: ["toString", "String"],
 };
 
+/**
+ * {@link NO_JS_EQUIVALENT} keyed by the camelCased Ruby name as well. The
+ * recorder camelCases a Ruby `ref:` argument that is a plain identifier
+ * (`object_id` reaches the artifact as `objectId`, `to_i` as `toI`) while
+ * leaving a `?`/`!` one alone, so a snake_case-only lookup silently never fires
+ * for the multi-word keys — `object_id`, `to_f`, `to_i`, `to_s`.
+ */
+const NO_JS_EQUIVALENT_BY_CAMEL = new Map(
+  Object.entries(NO_JS_EQUIVALENT).map(([rubyRef, tsRefs]) => [snakeToCamel(rubyRef), tsRefs]),
+);
+
 /** The bare identifier behind a recorded `ref:` argument, or undefined. */
 export function refName(arg: string): string | undefined {
   return arg.startsWith("ref:") ? arg.slice("ref:".length) : undefined;
@@ -176,9 +187,10 @@ export function classifyPair(
 ): NamingClass {
   if (rubyRef === "self" || rubyRef === "this") return "module-mixin-receiver";
   if (JS_RESERVED_WORDS.has(rubyRef)) return "js-reserved-word";
-  if (Object.hasOwn(NO_JS_EQUIVALENT, rubyRef) && NO_JS_EQUIVALENT[rubyRef].includes(tsRef)) {
-    return "no-js-equivalent";
-  }
+  const noJsEquivalent = Object.hasOwn(NO_JS_EQUIVALENT, rubyRef)
+    ? NO_JS_EQUIVALENT[rubyRef]
+    : NO_JS_EQUIVALENT_BY_CAMEL.get(rubyRef);
+  if (noJsEquivalent?.includes(tsRef)) return "no-js-equivalent";
   if (!rubyRef.startsWith("@") && tsRef === `_${snakeToCamel(rubyRef)}`) return "ivar-underscore";
   if (tsRef === "call" && isThisTypedFunction(rubyRef, thisTypedFunctions)) {
     return "module-mixin-call";


### PR DESCRIPTION
Wave 4 of RFC 0096: assign every remaining in-scope `naming` call-argument row
to a cluster, so `naming-gate-flip`'s precondition is checkable rather than a
judgement call.

## Measurement

Fresh, from a full `pnpm build`, then `API_COMPARE_FORCE=1 pnpm parity:api --calls`
and `pnpm parity:api:calls:args:report` (2026-08-14): **539 rows across 220
files**, of which **293 are `naming`**. Restricted to this RFC's scope
(`activerecord` and its dependencies — activesupport, activemodel, arel, i18n,
globalid, did-you-mean), **108 naming rows survive across 73 files**, matching
the story's measurement.

After the taxonomy fix below the in-scope split is:

| | Rows |
| --- | --- |
| Permanent classes (no rename can close them) | **37** |
| Burndown (convergeable, never baselined) | **71** |
| Total | **108** |

Permanent breakdown: `no-js-equivalent` 15, `ivar-underscore` 12,
`js-reserved-word` 4, `module-mixin-call` 4, `conventions-rename` 1,
`block-idiom` 1.

## The `x -> x` triage

Triaged first, as the story asked. They are **not** misclassified: the `x -> x`
in the story's table is the *enclosing method* name against the *called* name
(`arel/visitors/to-sql.ts#quoteTableName` calling `quote_table_name`,
`time-with-zone.ts#dst` calling `dst?`, `globalid/locator.ts#unscoped` calling
`unscoped`). Each of those rows has a genuine differing identifier pair in its
arguments (`name -> toS`, `period -> toInstant`, `modelClass -> block`), so
they are real burndown rows and stay in the clusters.

A different misclassification did surface, and is fixed here rather than in any
port: the recorder camelCases a plain Ruby `ref:` identifier (`object_id`
records as `objectId`, `to_i` as `toI`) while leaving a `?`/`!` one alone, so
`NO_JS_EQUIVALENT`'s multi-word keys — `object_id`, `to_f`, `to_i`, `to_s` —
never matched and their rows read as burndown. `classifyPair` now also looks the
table up under the camelCased key. That moves 3 in-scope rows
(`abstract-adapter.ts#unpreparedStatement` ×2, `activemodel/type/date.ts#fastStringToDate`)
from burndown to permanent without touching a ported body — 34 permanent → 37,
74 burndown → 71.

## The clusters (71 rows, filed as 7 stories)

| Story | Rows |
| --- | --- |
| `wave-4-naming-ar-adapters` (PostgreSQL adapter + OID types) | 11 |
| `wave-4-naming-ar-relation` (relation, scoping, statement-cache) | 11 |
| `wave-4-naming-ar-model` (model, encryption, tasks, middleware) | 12 |
| `wave-4-naming-activesupport` | 10 |
| `wave-4-naming-activemodel` | 7 |
| `wave-4-naming-arel-i18n-tail` (arel, i18n, globalid, did-you-mean) | 13 |
| `wave-4-naming-mixin-receiver-rewire` (all `module-mixin-receiver` rows) | 7 |

Each story body carries its own row list — file, method, call, and the differing
identifiers — so no re-derivation is needed to claim one. The
`module-mixin-receiver` rows are clustered separately because they converge by
rewiring to the `this`-typed mixin idiom, not by renaming a parameter.

`naming-gate-flip`'s `deps` now name all seven plus this story, so the flip
becomes green exactly when the burndown reaches zero and the permanent classes
are all that remain. 37 + 71 = 108, the measured total.

No baseline is added, widened or reseeded; `naming` stays report-only until the
flip.

Closes-story: wave-4-cluster-remaining-naming-rows
