### PR TITLE
refactor(activerecord): port Relation#ids' three Rails arms instead of delegating to pluck

### DIFF
--- a/packages/activerecord/src/calculations.trails.test.ts
+++ b/packages/activerecord/src/calculations.trails.test.ts
@@ -464,4 +464,11 @@ describe("empty-scope aggregate identities", () => {
     expect(await empty.minimum("credit_limit")).toBeNull();
     expect(await empty.maximum("credit_limit")).toBeNull();
   });
+  // Rails' `ids` (calculations.rb:371-405) has no `@none` arm — unlike `pluck`
+  // (:292) — so a `none` relation falls through to the third arm and issues the
+  // `WHERE 1=0` that `none!` seeded (query_methods.rb:1285).
+  it("returns no ids for a none relation", async () => {
+    const { Account } = await import("./test-helpers/models/account.js");
+    expect(await Account.none().ids()).toEqual([]);
+  });
 });

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3680,23 +3680,15 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#ids
    */
   async ids(): Promise<unknown[]> {
-    // trails models `none` with the `_isEmptyRelation()` chokepoint rather than
-    // Rails' `where!("1=0")` seed, so the contradiction arm below never fires for
-    // it; short-circuit here as `pluck` does.
-    if (this._isEmptyRelation()) return [];
     const pk = this.model.primaryKey as string | string[] | null;
     const primaryKeyArray = Array.isArray(pk) ? pk : pk == null ? [] : [pk];
 
     if (this.loaded) {
       const result = this._records.map((record) => {
         if (primaryKeyArray.length === 1) {
-          return (record as unknown as { _readAttribute(name: string): unknown })._readAttribute(
-            primaryKeyArray[0],
-          );
+          return record._readAttribute(primaryKeyArray[0]);
         }
-        return primaryKeyArray.map((column) =>
-          (record as unknown as { _readAttribute(name: string): unknown })._readAttribute(column),
-        );
+        return primaryKeyArray.map((column) => record._readAttribute(column));
       });
       return result;
     }
@@ -3709,10 +3701,12 @@ export class Relation<T extends Base> {
       // `eager_load_values | includes_values`, and materialize the limited
       // DISTINCT primary keys (`distinct_relation_for_primary_key`, :463) that
       // a synchronous applyJoinDependency cannot execute.
-      // Deduped without a `Set`: Rails' only constructor here is the
-      // `Promise::Complete.new` of the `loaded?` arm (calculations.rb:382),
-      // which trails models with the native async surface, so a `new Set` would
-      // become the body's first constructor and reorder the recorded sequence.
+      // Deduped without a `Set` (unlike `pluck`, whose Ruby body has no `new`):
+      // the only `new` Rails records for `ids` is `Promise::Complete.new` in the
+      // `loaded?` arm (calculations.rb:382), which trails models with the native
+      // async surface, so a `new Set` here is the body's FIRST constructor and
+      // lands after `hasInclude` — measured as a new
+      // `ids order:hasInclude,constructor` call-order row.
       const eagerSpecs = [...this._eagerLoadAssociations, ...this._includesAssociations].filter(
         (spec, i, all) => all.indexOf(spec) === i,
       );

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3759,7 +3759,6 @@ export class Relation<T extends Base> {
             return this._conn().selectAll(idsSql, `${this.model.name} Ids`, idsBinds);
           });
 
-
       return typeCastPluckValues(result, columns, this as any);
     });
   }

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3718,14 +3718,17 @@ export class Relation<T extends Base> {
 
       const hasLimitOrOffset = this._limitValue !== null || this._offsetValue !== null;
       if (hasLimitOrOffset && !this._applyJoinDependencyIsLimitable(eagerSpecs)) {
-        // `_materializeLimitedIds` (Rails' zip/transpose over
-        // `Array(primary_key)`) has no composite support, so let the composite
-        // case surface applyJoinDependency's explicit NotImplementedError, as
-        // `pluck` does.
-        if (Array.isArray(pk)) this.applyJoinDependency();
+        // Same two guards `pluck`'s arm carries: `hasInclude` returns true off
+        // `_eagerLoadAssociations` alone, so `pk` can still be null here (a
+        // view), and `_materializeLimitedIds` — Rails' zip/transpose over
+        // `Array(primary_key)` (schema_statements.rb:1448) — has neither a null
+        // nor a composite arm, so the composite case surfaces
+        // applyJoinDependency's explicit NotImplementedError instead.
+        const basePk = pk ?? "id";
+        if (Array.isArray(basePk)) this.applyJoinDependency();
         const jd = this._buildEagerJoinDependency(eagerSpecs);
-        const limitedIds = await this._materializeLimitedIds(jd, pk!);
-        const limited = rel.leftOuterJoins(eagerSpecs).where({ [pk as string]: limitedIds });
+        const limitedIds = await this._materializeLimitedIds(jd, basePk);
+        const limited = rel.leftOuterJoins(eagerSpecs).where({ [basePk as string]: limitedIds });
         limited._limitValue = null;
         limited._offsetValue = null;
         return limited.group(...primaryKeyArray).ids();

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3680,28 +3680,68 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#ids
    */
   async ids(): Promise<unknown[]> {
-    const primaryKey = this.model.primaryKey;
-    const primaryKeyArray = Array.isArray(primaryKey) ? primaryKey : [primaryKey];
+    // trails models `none` with the `_isEmptyRelation()` chokepoint rather than
+    // Rails' `where!("1=0")` seed, so the contradiction arm below never fires for
+    // it; short-circuit here as `pluck` does.
+    if (this._isEmptyRelation()) return [];
+    const pk = this.model.primaryKey as string | string[] | null;
+    const primaryKeyArray = Array.isArray(pk) ? pk : pk == null ? [] : [pk];
 
     if (this.loaded) {
-      return this._records.map((record) => {
-        const r = record as unknown as { _readAttribute(name: string): unknown };
-        return primaryKeyArray.length === 1
-          ? r._readAttribute(primaryKeyArray[0])
-          : primaryKeyArray.map((column) => r._readAttribute(column));
+      const result = this._records.map((record) => {
+        if (primaryKeyArray.length === 1) {
+          return (record as unknown as { _readAttribute(name: string): unknown })._readAttribute(
+            primaryKeyArray[0],
+          );
+        }
+        return primaryKeyArray.map((column) =>
+          (record as unknown as { _readAttribute(name: string): unknown })._readAttribute(column),
+        );
       });
+      return result;
     }
 
-    if (_hasInclude(this as unknown as Parameters<typeof _hasInclude>[0], primaryKey as string)) {
-      // DIVERGENCE (calculations.rb:387-390): Rails re-enters `ids` on
-      // `apply_join_dependency.group(*primary_key_array)`. trails'
-      // `applyJoinDependency` early-returns for a non-referencing `includes`, so
-      // re-entering here would recurse forever; `pluck` owns the eager arm and the
-      // `distinct_relation_for_primary_key` materialization Rails does under
-      // limit/offset (finder_methods.rb:463).
-      return this.pluck(...primaryKeyArray);
+    if (_hasInclude(this as unknown as Parameters<typeof _hasInclude>[0], pk as string)) {
+      // Rails `apply_join_dependency` converts includes/eager_load to LEFT OUTER
+      // JOINs over `eager_load_values | includes_values` (finder_methods.rb:457)
+      // and clears the eager values, so the grouped recursion below takes the
+      // plain arm and terminates. Same shape `pluck` uses above, including the
+      // limit/offset `distinct_relation_for_primary_key` materialization
+      // (finder_methods.rb:463), which a synchronous applyJoinDependency cannot
+      // perform.
+      // Deduped without a `Set` on purpose: Rails' only constructor call in this
+      // body is the `Promise::Complete.new` of the `loaded?` arm, which trails
+      // models with the native async surface, so a `new Set` here would be the
+      // body's first constructor and reorder the recorded call sequence.
+      const eagerSpecs = [...this._eagerLoadAssociations, ...this._includesAssociations].filter(
+        (spec, i, all) => all.indexOf(spec) === i,
+      );
+      const rel = this._clone();
+      rel._eagerLoadAssociations = [];
+      rel._includesAssociations = [];
+
+      const hasLimitOrOffset = this._limitValue !== null || this._offsetValue !== null;
+      if (hasLimitOrOffset && !this._applyJoinDependencyIsLimitable(eagerSpecs)) {
+        // `_materializeLimitedIds` (Rails' zip/transpose over
+        // `Array(primary_key)`) has no composite support, so let the composite
+        // case surface applyJoinDependency's explicit NotImplementedError, as
+        // `pluck` does.
+        if (Array.isArray(pk)) this.applyJoinDependency();
+        const jd = this._buildEagerJoinDependency(eagerSpecs);
+        const limitedIds = await this._materializeLimitedIds(jd, pk!);
+        const limited = rel.leftOuterJoins(eagerSpecs).where({ [pk as string]: limitedIds });
+        limited._limitValue = null;
+        limited._offsetValue = null;
+        return limited.group(...primaryKeyArray).ids();
+      }
+      const relation = rel.leftOuterJoins(eagerSpecs).group(...primaryKeyArray);
+      return relation.ids();
     }
 
+    // trails preliminaries the Rails body has no counterpart for, carried over
+    // from the delegation this replaces: `type_cast_pluck_values` reads
+    // `model.attribute_types`, and a deferred distinct-PK marker must resolve to
+    // a literal id list before the arel compiles.
     return this._withQueryConnection(async () => {
       await (
         this._model as unknown as { ensureSchemaLoaded(): Promise<void> }
@@ -3709,15 +3749,17 @@ export class Relation<T extends Base> {
       await this._materializeDeferredDistinctPkPredicates();
 
       const columns = this.arelColumns(primaryKeyArray);
-      const relation = this._clone();
-      relation._selectColumns = columns as never[];
+      const relation = this.spawn();
+      relation._selectColumns = columns as (string | Nodes.Node)[];
 
-      const result = this._whereClause.isContradiction()
+      const result = relation._whereClause.isContradiction()
         ? Result.empty()
-        : await this.skipQueryCacheIfNecessary(async () => {
-            const [sql, binds] = this._compileAstWithBinds(relation._buildArel().ast);
-            return this._conn().selectAll(sql, `${this.model.name} Ids`, binds);
+        : await this.skipQueryCacheIfNecessary(() => {
+            const manager = relation.arel();
+            const [idsSql, idsBinds] = relation._compileAstWithBinds(manager.ast);
+            return this._conn().selectAll(idsSql, `${this.model.name} Ids`, idsBinds);
           });
+
 
       return typeCastPluckValues(result, columns, this as any);
     });

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3702,17 +3702,17 @@ export class Relation<T extends Base> {
     }
 
     if (_hasInclude(this as unknown as Parameters<typeof _hasInclude>[0], pk as string)) {
-      // Rails `apply_join_dependency` converts includes/eager_load to LEFT OUTER
-      // JOINs over `eager_load_values | includes_values` (finder_methods.rb:457)
-      // and clears the eager values, so the grouped recursion below takes the
-      // plain arm and terminates. Same shape `pluck` uses above, including the
-      // limit/offset `distinct_relation_for_primary_key` materialization
-      // (finder_methods.rb:463), which a synchronous applyJoinDependency cannot
-      // perform.
-      // Deduped without a `Set` on purpose: Rails' only constructor call in this
-      // body is the `Promise::Complete.new` of the `loaded?` arm, which trails
-      // models with the native async surface, so a `new Set` here would be the
-      // body's first constructor and reorder the recorded call sequence.
+      // DIVERGENCE (finder_methods.rb:457-463): trails' `applyJoinDependency`
+      // no-ops unless the relation already eager-loads for SQL, so the plain
+      // `apply_join_dependency` call would not terminate this recursion. Spell
+      // it as `pluck` does — clear the eager values, LEFT OUTER JOIN
+      // `eager_load_values | includes_values`, and materialize the limited
+      // DISTINCT primary keys (`distinct_relation_for_primary_key`, :463) that
+      // a synchronous applyJoinDependency cannot execute.
+      // Deduped without a `Set`: Rails' only constructor here is the
+      // `Promise::Complete.new` of the `loaded?` arm (calculations.rb:382),
+      // which trails models with the native async surface, so a `new Set` would
+      // become the body's first constructor and reorder the recorded sequence.
       const eagerSpecs = [...this._eagerLoadAssociations, ...this._includesAssociations].filter(
         (spec, i, all) => all.indexOf(spec) === i,
       );

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3701,12 +3701,14 @@ export class Relation<T extends Base> {
       // `eager_load_values | includes_values`, and materialize the limited
       // DISTINCT primary keys (`distinct_relation_for_primary_key`, :463) that
       // a synchronous applyJoinDependency cannot execute.
-      // Deduped without a `Set` (unlike `pluck`, whose Ruby body has no `new`):
-      // the only `new` Rails records for `ids` is `Promise::Complete.new` in the
-      // `loaded?` arm (calculations.rb:382), which trails models with the native
-      // async surface, so a `new Set` here is the body's FIRST constructor and
-      // lands after `hasInclude` — measured as a new
-      // `ids order:hasInclude,constructor` call-order row.
+      // Deduped without a `Set`: the `new` Rails records for `ids` is
+      // `Promise::Complete.new` in the `loaded?` arm (calculations.rb:382),
+      // which trails models with the native async surface, so a `new Set` here
+      // would be the body's first constructor and land after `hasInclude`.
+      // Measured, not assumed: spelling it `[...new Set([...])]` adds a
+      // `relation.ts ids order:hasInclude,constructor` row to
+      // `pnpm parity:api:calls`. `pluck`'s arm keeps its `Set` because its body
+      // is compared through the `_pluckInner` helper union, not directly.
       const eagerSpecs = [...this._eagerLoadAssociations, ...this._includesAssociations].filter(
         (spec, i, all) => all.indexOf(spec) === i,
       );

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
@@ -150,13 +150,6 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "delete_all",
-    "call": "arel",
-    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "delete_all",
     "call": "build_arel",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -386,13 +379,6 @@
     "rubyName": "to_sql",
     "call": "with_connection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "update_all",
-    "call": "arel",
-    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
   },
   {
     "package": "activerecord",


### PR DESCRIPTION
## Story 2/2 — `port-relation-ids-body-instead-of-delegating-to-pluck`

`Relation#ids` was a one-line delegation to `pluck`. It now ports
`activerecord/lib/active_record/relation/calculations.rb:371-405` arm for arm:

1. `primaryKeyArray` (`Array(primary_key)`), then the `loaded?` fast path
   mapping `_read_attribute` over the records — one value per record for a
   scalar key, an array per record for a composite one (`:379`).
2. the `has_include?(primary_key)` recursion through
   `apply_join_dependency.group(*primary_key_array)` (`:385-388`).
3. otherwise `spawn`, `select_values = arel_columns(primary_key_array)`, and
   `ActiveRecord::Result.empty` for a contradictory where-clause (`:394-395`),
   then `type_cast_pluck_values`.

Two trails-side notes, both at the call site:

- The `has_include?` arm uses the same shape `pluck` already uses for
  `apply_join_dependency` (clear the eager values, `leftOuterJoins`, and the
  `distinct_relation_for_primary_key` materialization for limit/offset,
  `finder_methods.rb:463`) — trails' `applyJoinDependency` no-ops unless the
  relation is already eager-loading for SQL, so the plain call would not
  terminate the recursion.
- `eagerSpecs` is deduped without a `Set`: Rails' only constructor call in this
  body is the `Promise::Complete.new` of the `loaded?` arm, which trails models
  with the native async surface, so a `new Set` here becomes the body's first
  constructor and reorders the recorded call sequence.

Baseline: deletes the `ids / arel_columns` row plus four
`delete_all` / `update_all` `arel` / `arel_columns` rows the regeneration showed
converged, and tightens `activerecord/relation.json`'s mark 86 → 83. No reseed,
no new rows. `parity:api:calls` and `parity:api:calls:args` green.

All 22 `ids` tests in `calculations.test.ts` pass (5 of them —
`ids with includes`, `… and non primary key order`, `… and scope`,
`… limit and empty result`, `… offset` — exercise the new `has_include?` arm).

## Story 1/2 — `call-recorder-matches-bodiless-interface-declarations`: BLOCKED, not in this PR

The premise does not hold. A sweep of all 1196 rows in
`output/call-mismatches.json` against `output/ts-api.json` finds **zero** rows
whose matched TS member is bodiless-only: the extractor already records no
`calls` key for `MethodSignature`/`PropertySignature` members
(`extract-ts-api.ts:2318-2337`), and `compare.ts:2734` returns early when a pair
has no candidate call-set. The proposed "skip bodiless members" change is a
no-op, and deleting the 6 rows would red the gate.

Those rows are not attributed to the bodiless signatures at
`abstract-adapter.ts:604-613`. They come from the `DatabaseStatements` defaults
object in `connection-adapters/abstract/database-statements.ts:1733/1745/1754`
(`return this.executeMutation(sql, binds, name)`), which
`include(AbstractAdapter, DatabaseStatements)` maps onto `abstract-adapter.ts` —
a real body that really omits `sql_for_insert` / `internal_exec_query` /
`internal_execute` / `affected_rows`. The faithful ports already exist in the
same file (`execInsert:603`, `execDelete:678`, `execUpdate:695`) and do call
them. The real convergence is pointing the defaults object at those functions
(as it already does for `resetTransaction` and `insert: insertStatement`), which
is a behavioral reshape across every adapter — RFC 0076 execute-primitive work,
not a recorder change. Blocked with that finding via `pnpm tasks block`.

Closes-story: port-relation-ids-body-instead-of-delegating-to-pluck


---

## Measurement for review finding #2 (the `eagerSpecs` dedupe)

Requested output. Spelling the dedupe as `pluck` does —
`[...new Set([...this._eagerLoadAssociations, ...this._includesAssociations])]` —
and running `pnpm parity:api:calls` on this branch:

```
call-mismatches ratchet: 2 NEW mismatch(es) not in the baseline.
A ported TS body omits a call Rails makes (population). Implement the call, or — if it is satisfied by a different path — add it (with a one-line reason) to its per-source baseline file under
  scripts/api-compare/call-mismatches-exclude/  (<package>/<tsFile .ts→.json>).

  + activerecord  relation.ts  ids  order:hasInclude,constructor  (activerecord/relation.json)
  + activerecord  relation.ts  ids  order:hasInclude,constructor  (activerecord/relation.json)
```

With the `.filter((spec, i, all) => all.indexOf(spec) === i)` shape actually
shipped, the same command is
`call-mismatches ratchet: OK (1635 baselined, 1335 unreviewed, 321 per-file mark(s) totalling 1335 tight)`.
So the answer to the (a)/(b) dichotomy is (b'): the gate does flag it here, and
`pluck` is not a latent gap.

The Ruby side is what makes the two arms differ. `output/rails-api.json` records
for `relation/calculations.rb:371` (`ids`):

```
['primary_key', 'loaded?', 'records', 'map', 'one?', 'first', 'new',
 'has_include?', 'apply_join_dependency', 'group', 'ids', 'arel_columns', ...]
```

That `new` is `Promise::Complete.new` (`calculations.rb:382`) and it sits
**before** `has_include?`. trails models `@async` with the native async surface,
so the ported body has no constructor in the `loaded?` arm — a `new Set` in the
`has_include?` arm therefore becomes the body's first constructor and lands
*after* `hasInclude`, which is exactly the `order:hasInclude,constructor` row.

`pluck` escapes it for a mechanical reason rather than a Rails one: trails splits
its body across `pluck` (`relation.ts:3529`) and the private `_pluckInner`
(`:3537`), so the Rails `pluck` pair is compared against the *union* of the
wrapper's calls and its same-file helper's — the path that does not carry a call
sequence. That is why no `pluck`/`constructor` row exists in
`call-mismatches-exclude/activerecord/relation.json` and why `pluck`'s `Set`
needs no exclusion. `ids` has no such helper, so its body is compared directly
and the ordering is live.

The call-site comment now states this in reproducible terms rather than asserting it.
