### PR TITLE
refactor(activerecord,activesupport): virtual_tables returns Rails' pairs, to_fs takes a BigDecimal receiver

### DIFF
--- a/packages/activerecord/src/adapters/sqlite3/virtual-table.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/virtual-table.test.ts
@@ -30,13 +30,10 @@ describeIfSqlite("SQLite3VirtualTableTest", () => {
   it("schema dump", async () => {
     const output = (await SchemaDumper.dump(adapter)).join("\n");
 
-    // Internal FTS5 shadow tables (e.g. searchables_docsize) must not appear
-    expect(output).not.toMatch(/searchables_docsize/);
-    // The virtual table definition must appear
-    expect(output).toContain('createVirtualTable("searchables", "fts5"');
-    expect(output).toContain('"content"');
-    expect(output).toContain('"meta UNINDEXED"');
-    expect(output).toContain("\"tokenize='porter ascii'\"");
+    expect(output).not.toContain("searchables_docsize");
+    expect(output).toContain(
+      `createVirtualTable("searchables", "fts5", ${JSON.stringify(["content", "meta UNINDEXED", "tokenize='porter ascii'"])})`,
+    );
   });
 
   it("schema load", async () => {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1672,19 +1672,22 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     return sqliteVirtualTableExists(this, tableName);
   }
 
+  // Mirrors: ActiveRecord::ConnectionAdapters::SQLite3Adapter::VIRTUAL_TABLE_REGEX
+  static readonly VIRTUAL_TABLE_REGEX = /USING\s+(\w+)\s*\((.+)\)/i;
+
   // Mirrors: ActiveRecord::ConnectionAdapters::SQLite3Adapter#virtual_tables
-  // Returns { tableName => [moduleName, argsString] }
-  async virtualTables(): Promise<Record<string, [string, string]>> {
+  // Returns a list of defined virtual tables, as `[tableName, [moduleName, arguments]]` pairs.
+  async virtualTables(): Promise<Array<[string, [string, string]]>> {
     const query = "SELECT name, sql FROM sqlite_master WHERE sql LIKE 'CREATE VIRTUAL %';";
 
     const rows = (await this.execQuery(query, "SCHEMA")).castValues() as unknown[][];
-    const result: Record<string, [string, string]> = {};
+    const memo: Array<[string, [string, string]]> = [];
     for (const row of rows) {
       const [tableName, sql] = row as [string, string];
-      const m = /USING\s+(\w+)\s*\((.*)\)\s*$/is.exec(sql);
-      if (m) result[tableName] = [m[1], m[2]];
+      const [, moduleName, args] = SQLite3Adapter.VIRTUAL_TABLE_REGEX.exec(sql) ?? [];
+      memo.push([tableName, [moduleName, args]]);
     }
-    return result;
+    return memo;
   }
 
   override async createVirtualTable(

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1678,7 +1678,9 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   /**
    * Returns a list of defined virtual tables, as the
    * `[tableName, [moduleName, arguments]]` pairs Rails' trailing `.to_a`
-   * produces (sqlite3_adapter.rb:296-307).
+   * produces (sqlite3_adapter.rb:296-307). Built through a `Map` because Rails
+   * builds a Hash first (`each_with_object({})`), so a repeated `tableName`
+   * collapses last-write-wins at its first-insertion position.
    *
    * Rails uses `exec_query(query, "SCHEMA")` (sqlite3_adapter.rb:301): the
    * wrapped path — so this dirties — but it still carries the "SCHEMA" name
@@ -1692,13 +1694,13 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     const query = "SELECT name, sql FROM sqlite_master WHERE sql LIKE 'CREATE VIRTUAL %';";
 
     const rows = (await this.execQuery(query, "SCHEMA")).castValues() as unknown[][];
-    const memo: Array<[string, [string, string]]> = [];
+    const memo = new Map<string, [string, string]>();
     for (const row of rows) {
       const [tableName, sql] = row as [string, string];
       const [, moduleName, args] = SQLite3Adapter.VIRTUAL_TABLE_REGEX.exec(sql) ?? [];
-      memo.push([tableName, [moduleName, args]]);
+      memo.set(tableName, [moduleName, args]);
     }
-    return memo;
+    return [...memo];
   }
 
   override async createVirtualTable(

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1672,11 +1672,22 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     return sqliteVirtualTableExists(this, tableName);
   }
 
-  // Mirrors: ActiveRecord::ConnectionAdapters::SQLite3Adapter::VIRTUAL_TABLE_REGEX
+  /** Mirrors: ActiveRecord::ConnectionAdapters::SQLite3Adapter::VIRTUAL_TABLE_REGEX */
   static readonly VIRTUAL_TABLE_REGEX = /USING\s+(\w+)\s*\((.+)\)/i;
 
-  // Mirrors: ActiveRecord::ConnectionAdapters::SQLite3Adapter#virtual_tables
-  // Returns a list of defined virtual tables, as `[tableName, [moduleName, arguments]]` pairs.
+  /**
+   * Returns a list of defined virtual tables, as the
+   * `[tableName, [moduleName, arguments]]` pairs Rails' trailing `.to_a`
+   * produces (sqlite3_adapter.rb:296-307).
+   *
+   * Rails uses `exec_query(query, "SCHEMA")` (sqlite3_adapter.rb:301): the
+   * wrapped path — so this dirties — but it still carries the "SCHEMA" name
+   * for LogSubscriber/ExplainSubscriber filtering. Rails' `arguments` local is
+   * `args` here — `arguments` is not a legal binding name in a strict-mode
+   * module.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::SQLite3Adapter#virtual_tables
+   */
   async virtualTables(): Promise<Array<[string, [string, string]]>> {
     const query = "SELECT name, sql FROM sqlite_master WHERE sql LIKE 'CREATE VIRTUAL %';";
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1682,11 +1682,8 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
    * builds a Hash first (`each_with_object({})`), so a repeated `tableName`
    * collapses last-write-wins at its first-insertion position.
    *
-   * Rails uses `exec_query(query, "SCHEMA")` (sqlite3_adapter.rb:301): the
-   * wrapped path — so this dirties — but it still carries the "SCHEMA" name
-   * for LogSubscriber/ExplainSubscriber filtering. Rails' `arguments` local is
-   * `args` here — `arguments` is not a legal binding name in a strict-mode
-   * module.
+   * Rails' `arguments` local is `args` here — `arguments` is not a legal
+   * binding name in a strict-mode module.
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::SQLite3Adapter#virtual_tables
    */

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-dumper.ts
@@ -28,18 +28,10 @@ export class SchemaDumper extends AbstractSchemaDumper {
     stream.push(
       "  // Note that virtual tables may not work with other database engines. Be careful if changing database.",
     );
-    // Split on commas that are NOT inside single quotes; filter empty segments
-    const splitArgs = (s: string): string[] => {
-      if (s.trim() === "") return [];
-      return s
-        .split(/,(?=(?:[^']*'[^']*')*[^']*$)/)
-        .map((a) => a.trim())
-        .filter((a) => a.length > 0);
-    };
     for (const [tableName, options] of [...virtualTables].sort()) {
       const [moduleName, argumentsStr] = options;
       stream.push(
-        `  await ctx.createVirtualTable(${JSON.stringify(tableName)}, ${JSON.stringify(moduleName)}, ${JSON.stringify(splitArgs(argumentsStr))});`,
+        `  await ctx.createVirtualTable(${JSON.stringify(tableName)}, ${JSON.stringify(moduleName)}, ${JSON.stringify(argumentsStr.split(", "))});`,
       );
     }
   }

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-dumper.ts
@@ -21,9 +21,8 @@ export class SchemaDumper extends AbstractSchemaDumper {
   protected override async virtualTables(stream: string[]): Promise<void> {
     const connection = this._adapter();
     if (!connection || typeof connection.virtualTables !== "function") return;
-    const virtualTables: Record<string, [string, string]> = await connection.virtualTables();
-    const names = Object.keys(virtualTables).sort();
-    if (names.length === 0) return;
+    const virtualTables: Array<[string, [string, string]]> = await connection.virtualTables();
+    if (virtualTables.length === 0) return;
     stream.push("");
     stream.push("  // Virtual tables defined in this database.");
     stream.push(
@@ -37,8 +36,8 @@ export class SchemaDumper extends AbstractSchemaDumper {
         .map((a) => a.trim())
         .filter((a) => a.length > 0);
     };
-    for (const tableName of names) {
-      const [moduleName, argumentsStr] = virtualTables[tableName];
+    for (const [tableName, options] of [...virtualTables].sort()) {
+      const [moduleName, argumentsStr] = options;
       stream.push(
         `  await ctx.createVirtualTable(${JSON.stringify(tableName)}, ${JSON.stringify(moduleName)}, ${JSON.stringify(splitArgs(argumentsStr))});`,
       );

--- a/packages/activesupport/src/core-ext/numeric-ext.test.ts
+++ b/packages/activesupport/src/core-ext/numeric-ext.test.ts
@@ -4,6 +4,7 @@ import { numberToHuman } from "../number-helper.js";
 import { Duration } from "../duration.js";
 import { Numeric } from "./numeric/bytes.js";
 import { NumericWithFormat } from "./numeric/conversions.js";
+import { BigDecimal } from "./big-decimal/conversions.js";
 
 function asDate(instant: Temporal.Instant): Date {
   return new Date(instant.epochMilliseconds);
@@ -391,6 +392,7 @@ describe("NumericExtFormattingTest", () => {
     expect(NumericWithFormat.toFs(1230, ":human")).toBe("1.23 Thousand");
     expect(NumericWithFormat.toFs(Number(1230), ":human")).toBe("1.23 Thousand");
     expect(NumericWithFormat.toFs(100 ** 10, ":human")).toBe("100000 Quadrillion");
+    expect(NumericWithFormat.toFs(new BigDecimal("1000010"), ":human")).toBe("1 Million");
   });
 
   it("to fs with invalid formatter", () => {
@@ -398,6 +400,7 @@ describe("NumericExtFormattingTest", () => {
     expect(NumericWithFormat.toFormattedS(123, ":invalid")).toBe("123");
     expect(NumericWithFormat.toFs(2.5, ":invalid")).toBe("2.5");
     expect(NumericWithFormat.toFs(100 ** 10, ":invalid")).toBe("100000000000000000000");
+    expect(NumericWithFormat.toFs(new BigDecimal("1000010"), ":invalid")).toBe("1000010.0");
   });
 
   it("default to fs", () => {

--- a/packages/activesupport/src/core-ext/numeric/conversions.ts
+++ b/packages/activesupport/src/core-ext/numeric/conversions.ts
@@ -29,7 +29,8 @@ export namespace NumericWithFormat {
    * separates that arm from the format Symbols below. Ruby's trailing
    * `else to_s(format)` arm takes a format that is none of those three types,
    * which this parameter type excludes, so the `when Symbol` fallback to `to_s`
-   * is the last arm here.
+   * is the last arm here. `to_s(format)` dispatches on the receiver:
+   * `BigDecimal#to_s` takes a format string, `Integer#to_s` a base.
    */
   export function toFs(
     self: number | BigDecimal,
@@ -39,8 +40,6 @@ export namespace NumericWithFormat {
     if (format === null) return self.toString();
 
     if (typeof format === "number" || !format.startsWith(":")) {
-      // `to_s(format)` dispatches on the receiver: `BigDecimal#to_s` takes a
-      // format string, `Integer#to_s` a base (conversions.rb:117-118).
       return self instanceof BigDecimal
         ? self.toString(String(format))
         : self.toString(format as number);

--- a/packages/activesupport/src/core-ext/numeric/conversions.ts
+++ b/packages/activesupport/src/core-ext/numeric/conversions.ts
@@ -1,4 +1,5 @@
 import { NumberHelper } from "../../number-helper.js";
+import { BigDecimal } from "../big-decimal/conversions.js";
 
 /**
  * Mirrors: `ActiveSupport::NumericWithFormat`
@@ -31,14 +32,18 @@ export namespace NumericWithFormat {
    * is the last arm here.
    */
   export function toFs(
-    self: number,
+    self: number | BigDecimal,
     format: number | string | null = null,
     options: Record<string, unknown> | null = null,
   ): string {
-    if (format === null) return String(self);
+    if (format === null) return self.toString();
 
     if (typeof format === "number" || !format.startsWith(":")) {
-      return self.toString(format as number);
+      // `to_s(format)` dispatches on the receiver: `BigDecimal#to_s` takes a
+      // format string, `Integer#to_s` a base (conversions.rb:117-118).
+      return self instanceof BigDecimal
+        ? self.toString(String(format))
+        : self.toString(format as number);
     }
 
     switch (format) {
@@ -57,7 +62,7 @@ export namespace NumericWithFormat {
       case ":human_size":
         return NumberHelper.numberToHumanSize(self, options ?? {});
       default:
-        return String(self);
+        return self.toString();
     }
   }
 


### PR DESCRIPTION
## `virtual_tables` returns Rails' array of pairs

`sqlite3_adapter.rb:297-307` accumulates into a Hash keyed by `table_name` and
ends with `.to_a`, so `virtual_tables` returns `[tableName, [moduleName,
arguments]]` pairs. `virtualTables()` returned the intermediate `Record`
instead; it now builds through a `Map` — Ruby Hash semantics, so a repeated name
collapses last-write-wins at its first-insertion position — and returns the
pairs. `VIRTUAL_TABLE_REGEX` is a constant with Rails' exact pattern
(`sqlite3_adapter.rb:294`) rather than an inline `/…\)\s*$/is`.

The one reader, `SQLite3::SchemaDumper#virtualTables`, now mirrors
`sqlite3/schema_dumper.rb:10-19` — `virtual_tables.any?`, then
`virtual_tables.sort.each do |table_name, options|`, and `arguments.split(", ")`
in place of the invented quote-aware splitter (Rails does not handle quoted
commas either). The schema-dump test makes `virtual_table_test.rb:22`'s single
`assert_includes` assertion over the whole emitted argument array.

### Query text

Rebased onto #6567, which landed the `execQuery(query, "SCHEMA").castValues()`
call path and Rails' own `WHERE sql LIKE 'CREATE VIRTUAL %'` query text for this
method. That was the one deviation this PR deferred; it is gone, and the method
now mirrors `sqlite3_adapter.rb:296-306` end to end.

## `NumericWithFormat#toFs` takes a `BigDecimal` receiver

`conversions.rb:148-150` includes the module into `Integer`, `Float` **and**
`BigDecimal`. trails covered the first two (both a JS `number`); `toFs` now also
takes the trails `BigDecimal`. The no-format arm is `self.toString()`, which
already defaults to Ruby's `"F"` form, and the `to_s(format)` arm dispatches on
the receiver the way Ruby does (a `BigDecimal` format string vs an `Integer`
base). The two assertions left out of the ported tests —
`numeric_ext_test.rb:412,421` — join their existing `it(...)` blocks.

## Left out of this bundle

`converge-join-dependency-build-recursive-tree` was claimed with these two and
has been **released back to the queue**, not deferred silently. Converging
`JoinDependency#build` onto Rails' recursive `JoinAssociation` tree is a
state-model rewrite: trails materializes table indices, aliases, columns and the
provisional Arel joins during `build`, and expands a through reflection into a
whole node chain (`_addThroughViaJoinAssociation`), all of which Rails does at
emit time. Making `build(associations, baseKlass)` the pure recursive form means
moving that materialization to a post-pass, which does not fit under the LOC
ceiling alongside these two stories and should not be bolted onto them.

Closes-story: sqlite3-virtual-tables-return-pairs
Closes-story: include-numeric-with-format-into-big-decimal
