### PR TITLE
refactor(activerecord,activesupport): except/only through relation_with values.except/slice, port Object#inspect

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1,5 +1,5 @@
 import { Temporal } from "@blazetrails/date";
-import { except, hexdigest, Notifications } from "@blazetrails/activesupport";
+import { except, hexdigest, Notifications, slice } from "@blazetrails/activesupport";
 import {
   Table,
   SelectManager,
@@ -53,7 +53,6 @@ export { Range };
 import {
   WhereChain,
   QueryMethodBangs,
-  EXCEPT_ONLY_KEYS,
   argumentError,
   assertModifiableBang as _assertModifiableBang,
   checkIfMethodHasArgumentsBang as _checkIfMethodHasArgumentsBang,
@@ -1412,11 +1411,7 @@ export class Relation<T extends Base> {
    * (the complement of `values.slice`).
    */
   only(...onlies: Array<ExceptSkip>): Relation<T> {
-    const rel = this._clone();
-    for (const key of EXCEPT_ONLY_KEYS) {
-      if (!onlies.includes(key)) this._resetExceptValue(rel, key);
-    }
-    return rel;
+    return this.relationWith(slice(this.values(), ...onlies));
   }
 
   /**
@@ -1448,66 +1443,7 @@ export class Relation<T extends Base> {
    * other relation.
    */
   except(...skips: Array<ExceptSkip>): Relation<T> {
-    const rel = this._clone();
-    for (const skip of skips) {
-      this._resetExceptValue(rel, skip);
-    }
-    return rel;
-  }
-
-  /**
-   * Reset a single `Relation::VALUE_METHODS` value key to its default on `rel`,
-   * with no `unscope_values` merge-replay side effect. Shared by `except`
-   * (reset the named keys) and `only` (reset the complement).
-   *
-   * @internal
-   */
-  private _resetExceptValue(rel: Relation<T>, key: ExceptSkip): void {
-    switch (key) {
-      // Value keys that have no `unscope` equivalent (they are not in
-      // VALID_UNSCOPING_VALUES) but are part of Rails' `Relation::VALUE_METHODS`.
-      case "distinct":
-        rel._isDistinct = false;
-        break;
-      case "strictLoading":
-        // `:strict_loading` is a SINGLE_VALUE_METHOD (default `nil`); deleting
-        // the key reads back as unset, distinct from an explicit `false`.
-        rel._isStrictLoading = undefined;
-        break;
-      case "references":
-        // `:references` is a single Rails value key; trails splits its local
-        // representation into the values list and the manual-vs-derived
-        // marker, so both must be cleared together.
-        rel._referencesValues = [];
-        rel._manualReferences = [];
-        break;
-      case "extending":
-        rel._extending = [];
-        break;
-      case "unscope":
-        rel._unscopeValues = [];
-        break;
-      case "reordering":
-        // `values.except(:reordering)` deletes the key → unset (`nil`).
-        rel._reordering = undefined;
-        break;
-      case "skipQueryCache":
-        rel._skipQueryCache = undefined;
-        break;
-      case "reverseOrder":
-        // `:reverse_order` is in VALUE_METHODS, so `values.except`/`values.slice`
-        // touch it; but trails (like the pinned Rails' `reverse_order!`) flips
-        // order eagerly and leaves `_reverseOrderValue` vestigial-nil, so this
-        // reset is a faithful no-op — the flipped order lives in `_orderClauses`
-        // (the `order` key).
-        rel._reverseOrderValue = undefined;
-        break;
-      default:
-        // Rails' `values` slice/except silently ignores unknown keys;
-        // resetValueForScope's switch no-ops on any non-UnscopeType string.
-        _qm.resetValueForScope(rel as any, key as UnscopeType);
-        break;
-    }
+    return this.relationWith(except(this.values(), ...skips));
   }
 
   /**
@@ -6355,6 +6291,7 @@ export class Relation<T extends Base> {
       group: [...this._groupColumns],
       order: [...this._orderClauses],
       joins: [...this._joinClauses],
+      leftOuterJoins: [...this._leftOuterJoinsValues],
       where: this._whereClause.clone(),
       having: this._havingClause.clone(),
       limit: this._limitValue,
@@ -6364,7 +6301,10 @@ export class Relation<T extends Base> {
       distinct: this._isDistinct,
       strictLoading: this._isStrictLoading,
       from: this._fromClause,
-      annotations: [...this._annotations],
+      reordering: this._reordering,
+      reverseOrder: this._reverseOrderValue,
+      skipQueryCache: this._skipQueryCache,
+      annotate: [...this._annotations],
       optimizerHints: [...this._optimizerHints],
       references: [...this._referencesValues],
       extending: [...this._extending],
@@ -7362,7 +7302,7 @@ export class Relation<T extends Base> {
   }
 
   /** @internal */
-  private relationWith(values: Partial<Relation<T>>): Relation<T> {
+  private relationWith(values: Record<string, unknown>): Relation<T> {
     return _sm.relationWith(this as any, values as any);
   }
 }

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -230,6 +230,7 @@ interface QueryMethodsHost {
   _ctes: Array<{ name: string; expression: Nodes.Node; recursive: boolean }>;
   _skipPreloading: boolean;
   _skipQueryCache: boolean | undefined;
+  _reverseOrderValue: boolean | undefined;
   _model: typeof import("../base.js").Base;
   model: QueryMethodsHost["_model"];
   /** Rails `attr_reader :table` (relation.rb:71) — the relation's own Arel table. */
@@ -722,11 +723,15 @@ export type ExceptSkip = ExceptKey | (string & {});
  * Reset a single value-key to its default, with no merge-replay side effect.
  *
  * Shared by `unscope!` (which additionally records the key in
- * `_unscopeValues` so a later merge re-applies the reset) and
- * `SpawnMethods#except` (which removes the value only, mirroring Rails'
- * `relation_with values.except(*skips)` — no `unscope_values` directive).
+ * `_unscopeValues` so a later merge re-applies the reset) and by `setValues`
+ * (the write half of the `@values` hash, which `relation_with` replaces
+ * wholesale): a `Relation::VALUE_METHODS` key that is absent from the hash
+ * reads back as its default, which here means resetting the field(s) that back
+ * it. `unscope!` validates against `VALID_UNSCOPING_VALUES` first, so the arms
+ * below that key has no `unscope` equivalent are reachable only from
+ * `setValues`.
  */
-export function resetValueForScope(host: QueryMethodsHost, scope: UnscopeType): void {
+export function resetValueForScope(host: QueryMethodsHost, scope: ExceptKey): void {
   switch (scope) {
     case "where":
       host._whereClause = WhereClause.empty();
@@ -791,6 +796,150 @@ export function resetValueForScope(host: QueryMethodsHost, scope: UnscopeType): 
       break;
     case "with":
       host._ctes = [];
+      break;
+    case "distinct":
+      host._isDistinct = false;
+      break;
+    case "strictLoading":
+      // `:strict_loading` is a SINGLE_VALUE_METHOD (default `nil`); deleting
+      // the key reads back as unset, distinct from an explicit `false`.
+      host._isStrictLoading = undefined;
+      break;
+    case "references":
+      // `:references` is a single Rails value key; trails splits its local
+      // representation into the values list and the manual-vs-derived marker,
+      // so both must be cleared together.
+      host._referencesValues = [];
+      host._manualReferences = [];
+      break;
+    case "extending":
+      host._extending = [];
+      break;
+    case "unscope":
+      host._unscopeValues = [];
+      break;
+    case "reordering":
+      host._reordering = undefined;
+      break;
+    case "skipQueryCache":
+      host._skipQueryCache = undefined;
+      break;
+    case "reverseOrder":
+      // `:reverse_order` is in VALUE_METHODS, so `values.except`/`values.slice`
+      // touch it; but trails (like the pinned Rails' `reverse_order!`) flips
+      // order eagerly and leaves `_reverseOrderValue` vestigial-nil, so this
+      // reset is a faithful no-op — the flipped order lives in `_orderClauses`
+      // (the `order` key).
+      host._reverseOrderValue = undefined;
+      break;
+  }
+}
+
+/**
+ * The write half of the `@values` hash: assign each `Relation::VALUE_METHODS`
+ * key present in `values`, and reset the ones that are absent.
+ *
+ * Ruby's `relation_with` replaces `@values` wholesale
+ * (`spawn_methods.rb:71-74`), so a key `values.except`/`values.slice` deleted
+ * simply reads back as its default. trails keeps the values in typed fields
+ * rather than a hash, so the wholesale replacement is spelled as a per-key
+ * assign-or-reset over the same key set — the TypeScript counterpart of the
+ * `VALUE_METHODS.each`-generated writers (`query_methods.rb:162-172`).
+ *
+ * @internal
+ */
+export function setValues(host: QueryMethodsHost, values: Record<string, unknown>): void {
+  for (const key of EXCEPT_ONLY_KEYS) {
+    if (!(key in values)) {
+      resetValueForScope(host, key);
+      continue;
+    }
+    setValueForScope(host, key, values[key]);
+  }
+}
+
+function setValueForScope(host: QueryMethodsHost, scope: ExceptKey, value: any): void {
+  switch (scope) {
+    case "where":
+      host._whereClause = value;
+      break;
+    case "having":
+      host._havingClause = value;
+      break;
+    case "from":
+      host._fromClause = value;
+      break;
+    case "order":
+      host._orderClauses = value;
+      break;
+    case "limit":
+      host._limitValue = value;
+      break;
+    case "offset":
+      host._offsetValue = value;
+      break;
+    case "group":
+      host._groupColumns = value;
+      break;
+    case "select":
+      host._selectColumns = value;
+      break;
+    case "lock":
+      host._lockValue = value;
+      break;
+    case "readonly":
+      host._isReadonly = value;
+      break;
+    case "joins":
+      host._joinClauses = value;
+      break;
+    case "leftOuterJoins":
+      host._leftOuterJoinsValues = value;
+      break;
+    case "includes":
+      host._includesAssociations = value;
+      break;
+    case "preload":
+      host._preloadAssociations = value;
+      break;
+    case "eagerLoad":
+      host._eagerLoadAssociations = value;
+      break;
+    case "createWith":
+      host._createWithAttrs = value;
+      break;
+    case "optimizerHints":
+      host._optimizerHints = value;
+      break;
+    case "annotate":
+      host._annotations = value;
+      break;
+    case "with":
+      host._ctes = value;
+      break;
+    case "distinct":
+      host._isDistinct = value;
+      break;
+    case "strictLoading":
+      host._isStrictLoading = value;
+      break;
+    case "references":
+      host._referencesValues = value;
+      break;
+    case "extending":
+      host._extending = value;
+      break;
+    case "unscope":
+      host._unscopeValues = value;
+      break;
+    case "reordering":
+      host._reordering = value;
+      break;
+    case "skipQueryCache":
+      host._skipQueryCache = value;
+      break;
+    case "reverseOrder":
+      host._reverseOrderValue = value;
       break;
   }
 }

--- a/packages/activerecord/src/relation/spawn-methods.ts
+++ b/packages/activerecord/src/relation/spawn-methods.ts
@@ -5,7 +5,7 @@
  */
 
 import { Merger, HashMerger } from "./merger.js";
-import { argumentError } from "./query-methods.js";
+import { argumentError, setValues } from "./query-methods.js";
 
 interface SpawnRelation<T = unknown> {
   _clone(): T;
@@ -109,11 +109,20 @@ export const SpawnMethods = {
   mergeBang,
 } as const;
 
-/** @internal */
-export function relationWith<T extends SpawnRelation<T>>(self: T, values: Partial<T>): T {
-  const result = self._clone();
-  for (const [key, val] of Object.entries(values as Record<string, unknown>)) {
-    (result as any)[key] = val;
-  }
+/**
+ * Mirrors: ActiveRecord::SpawnMethods#relation_with (spawn_methods.rb:71-74) —
+ * `result = spawn; result.instance_variable_set(:@values, values); result`.
+ * trails holds the values in typed fields instead of a `@values` hash, so the
+ * ivar replacement is spelled as `setValues`, which assigns the keys the hash
+ * carries and resets the ones it dropped.
+ *
+ * @internal
+ */
+export function relationWith<T extends SpawnRelation<T>>(
+  self: T,
+  values: Record<string, unknown>,
+): T {
+  const result = (self as any).spawn();
+  setValues(result, values);
   return result;
 }

--- a/packages/activerecord/src/relation/value-accessor-semantics.test.ts
+++ b/packages/activerecord/src/relation/value-accessor-semantics.test.ts
@@ -13,6 +13,7 @@ import "../index.js";
 import { fixtures } from "../test-fixtures.js";
 import { Post } from "../test-helpers/models/post.js";
 import type { Relation } from "../relation.js";
+import { EXCEPT_ONLY_KEYS } from "./query-methods.js";
 
 fixtures([]);
 /** The split join-storage and group fields the reader semantics build on. */
@@ -110,5 +111,13 @@ describe("Relation value accessor Rails semantics", () => {
   it("select_values returns the shared frozen empty array when unset", () => {
     expect(relation().selectValues).toBe(relation().selectValues);
     expect(relation().selectValues).toEqual([]);
+  });
+
+  it("values() covers exactly the Relation::VALUE_METHODS key set", () => {
+    // `except`/`only` round-trip through `values()` and `setValues`
+    // (spawn_methods.rb:59-68), so a VALUE_METHODS key present in
+    // EXCEPT_ONLY_KEYS but absent from `values()` would reset that field on
+    // every call, named or not, and an extra key would never be resettable.
+    expect(new Set(Object.keys(Post.all().values()))).toEqual(new Set(EXCEPT_ONLY_KEYS));
   });
 });

--- a/packages/activesupport/src/array-utils.trails.test.ts
+++ b/packages/activesupport/src/array-utils.trails.test.ts
@@ -43,8 +43,10 @@ describe("ToFsTest (trails)", () => {
   // Rails' own suite only covers the `:db` arm (core_ext/array/conversions_test.rb
   // `test_to_fs_db`). The default arm is `Array#to_s`, which is `Array#inspect`
   // and recurses; the expectation is MRI's own `[1, [2, "a"], {b: 3}, nil].to_s`.
+  // A Ruby Symbol key is a colon-prefixed string in trails (CLAUDE.md), which is
+  // what makes it render as `:b` rather than as the quoted string key `"b"`.
   it("default format inspects nested arrays and hashes", () => {
-    expect(toFs([1, [2, "a"], { b: 3 }, null])).toBe('[1, [2, "a"], {:b=>3}, nil]');
+    expect(toFs([1, [2, "a"], { ":b": 3 }, null])).toBe('[1, [2, "a"], {:b=>3}, nil]');
   });
 
   it("default format is the empty brackets for an empty array", () => {

--- a/packages/activesupport/src/array-utils.ts
+++ b/packages/activesupport/src/array-utils.ts
@@ -5,6 +5,7 @@
 import { assertValidKeys } from "./hash-utils.js";
 import { I18n } from "./i18n.js";
 import { camelize } from "./inflector.js";
+import { toS } from "./core-ext/object/inspect.js";
 
 /**
  * Wraps a value in an array. `null`/`undefined` → `[]`, arrays pass through,
@@ -170,33 +171,6 @@ export function extractBang<T>(array: T[], predicate?: (item: T) => boolean): T[
     }
   }
   return extracted;
-}
-
-/**
- * Ruby `Array#to_s`, which is `inspect` — the element list in brackets, each
- * element inspected. `Array#to_fs`'s `else` arm is the receiver's own `to_s`,
- * and a JS array's `toString` is the comma-joined form instead, so the Ruby
- * one is spelled out here.
- */
-function toS(self: unknown[]): string {
-  return `[${self.map(inspect).join(", ")}]`;
-}
-
-/**
- * Ruby `Object#inspect`, which `Array#to_s` calls on each element and which
- * recurses through nested Arrays and Hashes. JS has no `inspect`: `String(x)`
- * is `to_s`, which for a nested Array is the comma-joined form and for a
- * plain object is `[object Object]`.
- */
-function inspect(value: unknown): string {
-  if (value == null) return "nil";
-  if (typeof value === "string") return JSON.stringify(value);
-  if (Array.isArray(value)) return toS(value);
-  if (typeof value === "object") {
-    const entries = Object.entries(value as Record<string, unknown>);
-    return `{${entries.map(([k, v]) => `:${k}=>${inspect(v)}`).join(", ")}}`;
-  }
-  return String(value);
 }
 
 /**

--- a/packages/activesupport/src/core-ext/object/inspect.trails.test.ts
+++ b/packages/activesupport/src/core-ext/object/inspect.trails.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { inspect, toS } from "./inspect.js";
+
+// Every expectation below is the output of the quoted `ruby -e` on MRI 3.3.
+describe("Object#inspect", () => {
+  it("renders nested arrays, hashes, nil, strings and numbers as MRI does", () => {
+    // ruby -e 'p [1, [2, "a"], {b: 3}, nil].to_s' => "[1, [2, \"a\"], {:b=>3}, nil]"
+    expect(inspect([1, [2, "a"], { ":b": 3 }, null])).toBe('[1, [2, "a"], {:b=>3}, nil]');
+    // ruby -e 'p({"a"=>[1,nil]}.to_s)' => "{\"a\"=>[1, nil]}"
+    expect(inspect({ a: [1, null] })).toBe('{"a"=>[1, nil]}');
+    // ruby -e 'p ["x", :y, 2.5, true].to_s' => "[\"x\", :y, 2.5, true]"
+    expect(inspect(["x", ":y", 2.5, true])).toBe('["x", :y, 2.5, true]');
+  });
+
+  it("renders empty collections and nil", () => {
+    // ruby -e 'p [].inspect, ({}).inspect, nil.inspect' => "[]", "{}", "nil"
+    expect(inspect([])).toBe("[]");
+    expect(inspect({})).toBe("{}");
+    expect(inspect(null)).toBe("nil");
+    expect(inspect(undefined)).toBe("nil");
+  });
+
+  it("escapes a quote inside a string", () => {
+    // ruby -e 'p "q\"u".inspect' => "\"q\\\"u\""
+    expect(inspect('q"u')).toBe('"q\\"u"');
+  });
+});
+
+describe("Object#to_s", () => {
+  it("is inspect for Array and Hash and the value's own to_s otherwise", () => {
+    // ruby -e 'p 3.to_s, nil.to_s, "hi".to_s, [{"a"=>1}].to_s'
+    expect(toS(3)).toBe("3");
+    expect(toS(null)).toBe("");
+    expect(toS("hi")).toBe("hi");
+    expect(toS([{ a: 1 }])).toBe('[{"a"=>1}]');
+  });
+});

--- a/packages/activesupport/src/core-ext/object/inspect.ts
+++ b/packages/activesupport/src/core-ext/object/inspect.ts
@@ -53,7 +53,7 @@ export function inspect(value: unknown): string {
  * other value — a String above all, which `to_s` returns unquoted — is its own
  * `to_s`.
  *
- * @noRailsEquivalent Ruby core, not Rails: `Object#to_s` is defined in object.c,
+ * @noRailsEquivalent PERMANENT — Ruby core, not Rails: `Object#to_s` is defined in object.c,
  * so no `.rb` in the vendored corpus declares it. JS `String(x)` is not the same
  * function — it gives the comma-joined form for a nested Array and
  * `[object Object]` for a Hash — so the Ruby one is spelled out here rather than

--- a/packages/activesupport/src/core-ext/object/inspect.ts
+++ b/packages/activesupport/src/core-ext/object/inspect.ts
@@ -34,6 +34,11 @@ const SYMBOL_RE = /^:[A-Za-z_][A-Za-z0-9_]*[?!=]?$/;
 /**
  * Ruby `Object#inspect` — `[1, [2, "a"], {:b=>3}, nil]` for
  * `[1, [2, "a"], {b: 3}, nil]`, verified against MRI 3.3.
+ *
+ * The default arm is `to_s`, not Ruby's `#<Foo:0x… @a=1>`: reproducing that
+ * needs an object id JS does not expose. Both callers hand this plain data
+ * structures only, so the arm is unreached today — a caller that does pass a
+ * class instance gets its `to_s`.
  */
 export function inspect(value: unknown): string {
   // Ruby `nil.inspect` is "nil"; `undefined` is trails' other spelling of nil.

--- a/packages/activesupport/src/core-ext/object/inspect.ts
+++ b/packages/activesupport/src/core-ext/object/inspect.ts
@@ -1,0 +1,68 @@
+/**
+ * Ruby's `Object#inspect` / `Object#to_s`, which trails has no other way to
+ * spell: JS `String(x)` is `to_s` for a JS value, which for a nested Array is
+ * the comma-joined form and for a plain object is `[object Object]`.
+ *
+ * These are core Ruby, not Rails, but every body that needs them lives in
+ * ActiveSupport, and this file sits next to `blank.ts` — the same place the
+ * `Object#blank?` dispatch went — so the next caller finds one implementation
+ * rather than writing a third private copy.
+ *
+ * Ruby dispatches per class; TypeScript cannot reopen `Array`/`Hash`, so the
+ * arms are a switch on the value class here, in the order Ruby's own overrides
+ * matter: `Array#inspect`, `Hash#inspect`, `String#inspect`, `NilClass#inspect`
+ * and `Object#inspect` (which is `to_s` for everything else).
+ */
+
+/**
+ * A JS object literal is trails' Ruby `Hash`; a class instance is a plain Ruby
+ * object, which renders through its own `to_s` rather than as a brace-wrapped
+ * pair list. Mirrors the same distinction `blank.ts` draws.
+ */
+function isPlainObject(value: object): boolean {
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+/**
+ * A Ruby Symbol is a JS string carrying its leading colon (see CLAUDE.md), and
+ * `:b.inspect` is `":b"` — the colon is already the rendering, so the string is
+ * emitted bare rather than quoted.
+ */
+const SYMBOL_RE = /^:[A-Za-z_][A-Za-z0-9_]*[?!=]?$/;
+
+/**
+ * Ruby `Object#inspect` — `[1, [2, "a"], {:b=>3}, nil]` for
+ * `[1, [2, "a"], {b: 3}, nil]`, verified against MRI 3.3.
+ */
+export function inspect(value: unknown): string {
+  // Ruby `nil.inspect` is "nil"; `undefined` is trails' other spelling of nil.
+  if (value == null) return "nil";
+  if (typeof value === "string") return SYMBOL_RE.test(value) ? value : JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(inspect).join(", ")}]`;
+  if (typeof value === "object" && isPlainObject(value)) {
+    const entries = Object.entries(value as Record<string, unknown>);
+    return `{${entries.map(([k, v]) => `${inspect(k)}=>${inspect(v)}`).join(", ")}}`;
+  }
+  return String(value);
+}
+
+/**
+ * Ruby `Object#to_s`. `Array#to_s` and `Hash#to_s` are aliases of `inspect`
+ * (array.c / hash.c), so those two classes render through `inspect`; every
+ * other value — a String above all, which `to_s` returns unquoted — is its own
+ * `to_s`.
+ *
+ * @noRailsEquivalent Ruby core, not Rails: `Object#to_s` is defined in object.c,
+ * so no `.rb` in the vendored corpus declares it. JS `String(x)` is not the same
+ * function — it gives the comma-joined form for a nested Array and
+ * `[object Object]` for a Hash — so the Ruby one is spelled out here rather than
+ * re-derived privately by each caller.
+ */
+export function toS(value: unknown): string {
+  // Ruby `nil.to_s` is the empty string, not `String(null)`'s "null".
+  if (value == null) return "";
+  if (Array.isArray(value)) return inspect(value);
+  if (value !== null && typeof value === "object" && isPlainObject(value)) return inspect(value);
+  return String(value);
+}

--- a/packages/activesupport/src/xml-mini.ts
+++ b/packages/activesupport/src/xml-mini.ts
@@ -6,6 +6,7 @@ import { StringIO } from "./string-io.js";
 import { Temporal, Date as RubyDate, DateTime } from "@blazetrails/date";
 import { Duration } from "./duration.js";
 import { ArgumentError } from "./hash-utils.js";
+import { toS } from "./core-ext/object/inspect.js";
 import * as XmlMini_REXML from "./xml-mini/rexml.js";
 
 /**
@@ -254,22 +255,6 @@ function toF(value: unknown): number {
 function toD(value: string): BigDecimal {
   const match = /^\s*[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?/.exec(value);
   return new BigDecimal(match ? match[0].trim() : "0");
-}
-
-/**
- * Ruby `Object#to_s`, for the shapes `PARSING["string"]` is asked to render:
- * an Array is `"[]"`-bracketed and a Hash `"{}"`-braced, where JS `String()`
- * gives `""` and `"[object Object]"`.
- */
-function toS(value: unknown): string {
-  if (Array.isArray(value)) return `[${value.map((v) => toS(v)).join(", ")}]`;
-  // boundary: a JS `Date` is one of the values a document can carry, and it
-  // renders through `String()` rather than as a Hash.
-  if (value !== null && typeof value === "object" && !(value instanceof Date)) {
-    const entries = Object.entries(value as Record<string, unknown>);
-    return `{${entries.map(([k, v]) => `${k} => ${toS(v)}`).join(", ")}}`;
-  }
-  return String(value);
 }
 
 /**

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
@@ -93,13 +93,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
-    "rubyName": "except",
-    "call": "relation_with",
-    "reason": "Verified per-site (RFC 0106): `relation_with values.except(*skips)` (spawn_methods.rb:59-61) writes a whole `@values` hash back onto a spawned clone. trails keeps query state in typed fields, not a `@values` hash — `values()` is a read-only snapshot with no writable counterpart — so the clone is reset key by key via `_resetExceptValue`, which is the same per-key erasure."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
     "rubyName": "exec_explain",
     "call": "render_bind",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -166,20 +159,6 @@
     "rubyName": "instantiate_records",
     "call": "instantiate",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "only",
-    "call": "relation_with",
-    "reason": "Verified per-site (RFC 0106): `relation_with values.slice(*onlies)` (spawn_methods.rb:66-68) writes a whole `@values` hash back onto a spawned clone; trails' relation state lives in typed fields with no writable `@values`, so the clone resets the complement of `onlies` via `_resetExceptValue`."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "only",
-    "call": "slice",
-    "reason": "Verified per-site (RFC 0106): `values.slice(*onlies)` (spawn_methods.rb:67) selects hash keys; with no `@values` hash to slice, trails iterates `EXCEPT_ONLY_KEYS` and resets every key not in `onlies` — the complement of the same selection."
   },
   {
     "package": "activerecord",


### PR DESCRIPTION
Bundle of two RFC 0106 / RFC 0101 convergence stories.

## `except`/`only` go through `relation_with values.except/slice`

`spawn_methods.rb:59-73` writes both as one-liners over `relation_with`, which
replaces `@values` wholesale. trails instead cloned and reset key by key through
a trails-only `_resetExceptValue`, which is what kept three `kind: "set"` rows
alive in `call-mismatches-exclude/activerecord/relation.json`.

The projection is now bidirectional:

- `Relation#values()` covers the full `Relation::VALUE_METHODS` key set — it
  gained `leftOuterJoins`, `reordering`, `reverseOrder` and `skipQueryCache`, and
  the `annotate` key is spelled as Rails spells it (was `annotations`).
- `setValues` (query-methods.ts) is the write half: it assigns each key the hash
  carries and resets the ones it dropped, which is how a TS field set spells
  `instance_variable_set(:@values, values)`. The eight reset arms that have no
  `unscope` equivalent moved onto `resetValueForScope`, so there is one reset
  switch for value keys rather than two.
- `relationWith` is now `spawn` + `setValues`, matching `spawn_methods.rb:71-74`
  (it spawned a `_clone()` before, so the `already_in_scope?` arm now applies).
- `except`/`only` are the two Rails one-liners; `_resetExceptValue` is gone.

The three baseline rows are deleted by hand via `serializeBaseline`; no reseed,
and no tighten was needed (their marks were already tight).

## `Object#inspect` ported once; the private `to_s` copies retired

`xml-mini.ts` and `array-utils.ts` each carried a private `toS`/`inspect` that
disagreed on nil rendering and hash-key form, and xml-mini's rendered a Hash as
`{k => v}` where MRI gives `{"k"=>1}`. Both now use one port in
`core-ext/object/inspect.ts` — `inspect` plus `to_s` (an alias of `inspect` for
Array and Hash only, which is what both call sites actually invoke).

Rendering is asserted against MRI 3.3 output quoted in the test. A Ruby Symbol
key is a colon-prefixed string per CLAUDE.md, so `{ ":b": 3 }` renders `{:b=>3}`
and a genuine string key renders `{"b"=>3}` — the `array-utils.trails.test.ts`
input was updated to the Symbol spelling accordingly (test name unchanged).

## Verification

`pnpm typecheck`, `pnpm lint`, `pnpm parity:api:calls`, `pnpm parity:api:calls:args`
green; relations, querying, merging, mutation, scoping, preloader, xml-mini,
array-utils and value-accessor-semantics suites pass locally on SQLite.

Closes-story: except-only-go-through-relation-with-values
Closes-story: port-object-inspect-and-retire-private-to-s-copies
